### PR TITLE
Remove bpf-sdk handling from token package.json

### DIFF
--- a/ci/token.sh
+++ b/ci/token.sh
@@ -15,7 +15,6 @@ set -e
     cd "$(dirname "$0")/../token/js"
 
     npm install
-    npm run build:program
     npm run cluster:devnet
     npm run start
 )

--- a/token/js/package.json
+++ b/token/js/package.json
@@ -14,11 +14,6 @@
     "flow": "flow",
     "flow:watch": "watch 'flow' . --wait=1 --ignoreDirectoryPattern=/doc/",
     "lint:watch": "watch 'npm run lint:fix' . --wait=1",
-    "bpf-sdk:update": "mkdir -p ../../bin && solana-bpf-sdk-install ../../bin && npm run clean:program",
-    "build:program": "../../do.sh build token",
-    "clean:program": "../../do.sh clean token",
-    "test:program": "../../do.sh test token",
-    "bench:program": "npm run build:program",
     "cluster:localnet": "rm -f .env",
     "cluster:devnet": "cp cluster-devnet.env .env",
     "cluster:testnet": "cp cluster-testnet.env .env",
@@ -27,9 +22,7 @@
     "localnet:up": "set -x; solana-localnet down; set -e; solana-localnet up",
     "localnet:down": "solana-localnet down",
     "localnet:logs": "solana-localnet logs -f",
-    "pretty": "prettier --write '{,src/**/}*.js'",
-    "postinstall": "npm run bpf-sdk:update && cd .. && cargo update --manifest-path=Cargo.toml",
-    "test": "npm run build:program && npm run flow"
+    "pretty": "prettier --write '{,src/**/}*.js'"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Web3.js used to be the only way to pull the bpf-sdk, and build a program. Now that we have generic scripting for that in this repo, we can remove the overloading from package.json and the duplicate build from token CI