### PR TITLE
Version solana-sdk-bpf-test and spl-memo for crates.io

### DIFF
--- a/memo/Cargo.toml
+++ b/memo/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "spl-memo"
-version = "1.0.0"
+version = "1.0.1"
 description = "Solana Program Library Memo"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 solana-sdk = { version = "1.2.4", default-features = false, features=["program"] }
-solana-sdk-bpf-test = { path = "../bin/bpf-sdk/rust/test", default-features = false }
+solana-sdk-bpf-test = { version = "1.2.4", default-features = false }
 
 [lib]
 name = "spl_memo"


### PR DESCRIPTION
Cargo.toml changes to enable `cargo publish`

@mvines @jackcmay While the program itself hasn't changed, do you think I should go all the way and change the program id and republish to the clusters, since this is a version number change?