### PR TITLE
Single delegate support

### DIFF
--- a/token-swap/inc/token-swap.h
+++ b/token-swap/inc/token-swap.h
@@ -37,8 +37,7 @@ typedef enum TokenSwap_SwapInstruction_Tag {
      *
      *   0. `[]` Token-swap
      *   1. `[]` $authority
-     *   2. `[writable]` token_(A|B) SOURCE delegate Account, amount is transferable by $authority,
-     *   3. `[writable]` token_(A|B) SOURCE Account associated with the delegate
+     *   2. `[writable]` token_(A|B) SOURCE Account, amount is transferable by $authority,
      *   4. `[writable]` token_(A|B) Base Account to swap INTO.  Must be the SOURCE token.
      *   5. `[writable]` token_(A|B) Base Account to swap FROM.  Must be the DEST token.
      *   6. `[writable]` token_(A|B) DEST Account assigned to USER as the owner.
@@ -52,10 +51,8 @@ typedef enum TokenSwap_SwapInstruction_Tag {
      *
      *   0. `[]` Token-swap
      *   1. `[]` $authority
-     *   2. `[writable]` token_a delegate $authority can transfer amount,
-     *   3. `[writable]` token_a account associated with delegate
-     *   4. `[writable]` token_b delegate $authority can transfer amount,
-     *   5. `[writable]` token_b account associated with delegate
+     *   2. `[writable]` token_a $authority can transfer amount,
+     *   4. `[writable]` token_b $authority can transfer amount,
      *   6. `[writable]` token_a Base Account to deposit into.
      *   7. `[writable]` token_b Base Account to deposit into.
      *   8. `[writable]` Pool MINT account, $authority is the owner.
@@ -69,8 +66,7 @@ typedef enum TokenSwap_SwapInstruction_Tag {
      *
      *   0. `[]` Token-swap
      *   1. `[]` $authority
-     *   2. `[writable]` SOURCE Pool delegate, amount is transferable by $authority.
-     *   3. `[writable]` SOURCE Pool account associated with the delegate
+     *   2. `[writable]` SOURCE Pool account, amount is transferable by $authority.
      *   4. `[writable]` Pool MINT account, $authority is the owner.
      *   5. `[writable]` token_a Account to withdraw FROM.
      *   6. `[writable]` token_b Account to withdraw FROM.

--- a/token-swap/js/client/token-swap.js
+++ b/token-swap/js/client/token-swap.js
@@ -277,8 +277,7 @@ export class TokenSwap {
    * Swap the tokens in the pool
    *
    * @param authority Authority
-   * @param delegate Delegate account to transfer from
-   * @param source Source account associated with delegate
+   * @param source Source account
    * @param into Base account to swap into, must be a source token
    * @param from Base account to swap from, must be a destination token
    * @param dest Destination token
@@ -287,7 +286,6 @@ export class TokenSwap {
    */
   async swap(
     authority: PublicKey,
-    delegate: PublicKey,
     source: PublicKey,
     into: PublicKey,
     from: PublicKey,
@@ -301,7 +299,6 @@ export class TokenSwap {
       new Transaction().add(
         this.swapInstruction(
           authority,
-          delegate,
           source,
           into,
           from,
@@ -315,7 +312,6 @@ export class TokenSwap {
   }
   swapInstruction(
     authority: PublicKey,
-    delegate: PublicKey,
     source: PublicKey,
     into: PublicKey,
     from: PublicKey,
@@ -340,7 +336,6 @@ export class TokenSwap {
     const keys = [
       {pubkey: this.tokenSwap, isSigner: false, isWritable: false},
       {pubkey: authority, isSigner: false, isWritable: false},
-      {pubkey: delegate, isSigner: false, isWritable: true},
       {pubkey: source, isSigner: false, isWritable: true},
       {pubkey: into, isSigner: false, isWritable: true},
       {pubkey: from, isSigner: false, isWritable: true},
@@ -359,10 +354,8 @@ export class TokenSwap {
    * Deposit some tokens into the pool
    *
    * @param authority Authority
-   * @param delegateA Delegate account to transfer token A from
-   * @param sourceA Source account associated with delegate account A
-   * @param delegateB Delegate account to transfer token B from
-   * @param sourceB Source account associated with delegate account A
+   * @param sourceA Source account A
+   * @param sourceB Source account B
    * @param intoA Base account A to deposit into
    * @param intoB Base account B to deposit into
    * @param poolToken Pool token
@@ -372,9 +365,7 @@ export class TokenSwap {
    */
   async deposit(
     authority: PublicKey,
-    delegateA: PublicKey,
     sourceA: PublicKey,
-    delegateB: PublicKey,
     sourceB: PublicKey,
     intoA: PublicKey,
     intoB: PublicKey,
@@ -389,9 +380,7 @@ export class TokenSwap {
       new Transaction().add(
         this.depositInstruction(
           authority,
-          delegateA,
           sourceA,
-          delegateB,
           sourceB,
           intoA,
           intoB,
@@ -406,9 +395,7 @@ export class TokenSwap {
   }
   depositInstruction(
     authority: PublicKey,
-    delegateA: PublicKey,
     sourceA: PublicKey,
-    delegateB: PublicKey,
     sourceB: PublicKey,
     intoA: PublicKey,
     intoB: PublicKey,
@@ -434,9 +421,7 @@ export class TokenSwap {
     const keys = [
       {pubkey: this.tokenSwap, isSigner: false, isWritable: false},
       {pubkey: authority, isSigner: false, isWritable: false},
-      {pubkey: delegateA, isSigner: false, isWritable: true},
       {pubkey: sourceA, isSigner: false, isWritable: true},
-      {pubkey: delegateB, isSigner: false, isWritable: true},
       {pubkey: sourceB, isSigner: false, isWritable: true},
       {pubkey: intoA, isSigner: false, isWritable: true},
       {pubkey: intoB, isSigner: false, isWritable: true},
@@ -456,8 +441,7 @@ export class TokenSwap {
    * Withdraw the token from the pool at the current ratio
    *
    * @param authority Authority
-   * @param delegatePoolAccount Delegate pool account
-   * @param sourcePoolAccount Source account associated with delegate
+   * @param sourcePoolAccount Source pool account
    * @param poolToken Pool token
    * @param fromA Base account A to withdraw from
    * @param fromB Base account B to withdraw from
@@ -468,7 +452,6 @@ export class TokenSwap {
    */
   async withdraw(
     authority: PublicKey,
-    delegatePoolAccount: PublicKey,
     sourcePoolAccount: PublicKey,
     poolToken: PublicKey,
     fromA: PublicKey,
@@ -484,7 +467,6 @@ export class TokenSwap {
       new Transaction().add(
         this.withdrawInstruction(
           authority,
-          delegatePoolAccount,
           sourcePoolAccount,
           poolToken,
           fromA,
@@ -500,7 +482,6 @@ export class TokenSwap {
   }
   withdrawInstruction(
     authority: PublicKey,
-    delegatePoolAccount: PublicKey,
     sourcePoolAccount: PublicKey,
     poolToken: PublicKey,
     fromA: PublicKey,
@@ -527,7 +508,6 @@ export class TokenSwap {
     const keys = [
       {pubkey: this.tokenSwap, isSigner: false, isWritable: false},
       {pubkey: authority, isSigner: false, isWritable: false},
-      {pubkey: delegatePoolAccount, isSigner: false, isWritable: true},
       {pubkey: sourcePoolAccount, isSigner: false, isWritable: true},
       {pubkey: poolToken, isSigner: false, isWritable: true},
       {pubkey: fromA, isSigner: false, isWritable: true},

--- a/token/.gitignore
+++ b/token/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .env
+config.json

--- a/token/js/cli/main.js
+++ b/token/js/cli/main.js
@@ -6,7 +6,7 @@
 
 import {
   loadTokenProgram,
-  createToken,
+  createMint,
   createAccount,
   transfer,
   approveRevoke,
@@ -19,9 +19,9 @@ import {
 
 async function main() {
   console.log('Run test: loadTokenProgram');
-  await loadTokenProgram('../target/bpfel-unknown-unknown/release/spl_token.so');
-  console.log('Run test: createToken');
-  await createToken();
+  await loadTokenProgram();
+  console.log('Run test: createMint');
+  await createMint();
   console.log('Run test: createAccount');
   await createAccount();
   console.log('Run test: transfer');

--- a/token/js/client/util/store.js
+++ b/token/js/client/util/store.js
@@ -1,0 +1,26 @@
+/**
+ * Simple file-based datastore
+ *
+ * @flow
+ */
+
+import path from 'path';
+import fs from 'mz/fs';
+import mkdirp from 'mkdirp-promise';
+
+export class Store {
+  dir = path.join(__dirname, 'store');
+
+  async load(uri: string): Promise<Object> {
+    const filename = path.join(this.dir, uri);
+    const data = await fs.readFile(filename, 'utf8');
+    const config = JSON.parse(data);
+    return config;
+  }
+
+  async save(uri: string, config: Object): Promise<void> {
+    await mkdirp(this.dir);
+    const filename = path.join(this.dir, uri);
+    await fs.writeFile(filename, JSON.stringify(config), 'utf8');
+  }
+}

--- a/token/src/error.rs
+++ b/token/src/error.rs
@@ -18,9 +18,6 @@ pub enum TokenError {
     /// Token types of the provided accounts don't match.
     #[error("token mismatch")]
     TokenMismatch,
-    /// A delegate is needed but the account provided is not a delegate.
-    #[error("not a delegate")]
-    NotDelegate,
     /// Owner was not a signing member of the instruction.
     #[error("no owner")]
     NoOwner,
@@ -30,9 +27,6 @@ pub enum TokenError {
     /// The account cannot be initialized because it is already being used.
     #[error("AlreadyInUse")]
     AlreadyInUse,
-    /// Cannot transfer token directly to a delegate account.
-    #[error("Destination is a delegate")]
-    DestinationIsDelegate,
     /// An owner is required if supply is zero.
     #[error("An owner is required if supply is zero")]
     OwnerRequiredIfNoInitialSupply,
@@ -55,11 +49,9 @@ impl PrintProgramError for TokenError {
         match self {
             TokenError::InsufficientFunds => info!("Error: insufficient funds"),
             TokenError::TokenMismatch => info!("Error: token mismatch"),
-            TokenError::NotDelegate => info!("Error: not a delegate"),
             TokenError::NoOwner => info!("Error: no owner"),
             TokenError::FixedSupply => info!("Error: the total supply of this token is fixed"),
             TokenError::AlreadyInUse => info!("Error: account or token already in use"),
-            TokenError::DestinationIsDelegate => info!("Error: Delegate accounts hold tokens"),
             TokenError::OwnerRequiredIfNoInitialSupply => {
                 info!("Error: An owner is required if supply is zero")
             }

--- a/token/src/instruction.rs
+++ b/token/src/instruction.rs
@@ -22,7 +22,7 @@ pub struct TokenInfo {
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub enum TokenInstruction {
-    /// Initializes a new mint and deposits all the newly minted tokens in an account.
+    /// Initializes a new mint and optionally deposits all the newly minted tokens in an account.
     ///
     /// # Accounts expected by this instruction:
     ///
@@ -30,61 +30,58 @@ pub enum TokenInstruction {
     ///   1.
     ///      * If supply is non-zero: `[writable]` Account to hold all the newly minted tokens.
     ///      * If supply is zero: `[]` Owner of the mint.
-    ///   2. Optional: `[]` Owner of the mint if supply is non-zero, if present then the 
-    ///      token allows further minting of tokens.
+    ///   2. Optional: `[]` Owner of the mint if supply is non-zero, if present then further
+    ///      minting is supported.
     InitializeMint(TokenInfo),
-    /// Initializes a new account.  The new account can either hold tokens or be a delegate
-    /// for another account.
+    /// Initializes a new account.
     ///
     /// # Accounts expected by this instruction:
     ///
-    ///   0. `[writable, signer]`  New account being created.
-    ///   1. `[]` Owner of the new account.
-    ///   2. `[]` Token this account will be associated with.
-    ///   3. Optional: `[]` Source account that this account will be a delegate for.
+    ///   0. `[writable, signer]`  New account being initialized.
+    ///   1. `[]` The mint this account will be associated with.
+    ///   2. `[]` Owner of the new account.
     InitializeAccount,
     /// Transfers tokens from one account to another either directly or via a delegate.
     ///
     /// # Accounts expected by this instruction:
     ///
-    ///   0. `[signer]` Owner of the source account.
-    ///   1. `[writable]` Source/Delegate account.
-    ///   2. `[writable]` Destination account.
-    ///   3. Optional: `[writable]` Source account if key 1 is a delegate account.
+    ///   0. `[writable]` The source account.
+    ///   1. `[writable]` The destination account.
+    ///   2. '[signer]' The source's owner or delegate
     Transfer(u64),
-    /// Approves a delegate.  A delegate account is given the authority to transfer
-    /// another accounts tokens without the other account's owner signing the transfer.
+    /// Approves a delegate.  A delegate is given the authority over
+    /// tokens on behalf of the source account's owner.  If the amount to
+    /// delegate is zero then delegation is rescinded
     ///
     /// # Accounts expected by this instruction:
     ///
-    ///   0. `[signer]` Owner of the source account.
-    ///   1. `[]` Source account.
-    ///   2. `[writable]` Delegate account.
+    ///   0. `[writable]` The source account.
+    ///   1. Optional: `[writable]` The delegate if amount is non-zero.
+    ///   2. `[signer]`The source account owner address
     Approve(u64),
-    /// Sets a new owner of a token or account.
+    /// Sets a new owner of a mint or account.
     ///
     /// # Accounts expected by this instruction:
     ///
-    ///   0. `[signer]` Current owner of the token or account.
-    ///   1. `[writable]` token or account to change the owner of.
-    ///   2. `[]` New owner
+    ///   0. `[writable]` The mint or account to change the owner of.
+    ///   1. `[]` The new owner
+    ///   2. `[signer]` The owner of the mint or account.
     SetOwner,
     /// Mints new tokens to an account.
     ///
     /// # Accounts expected by this instruction:
     ///
-    ///   0. `[signer]` Owner of the token.
-    ///   1. `[writable]` Token to mint.
-    ///   2. `[writable]` Account to mint tokens to.
+    ///   1. `[writable]` The mint.
+    ///   2. `[writable]` The account to mint tokens to.
+    ///   0. `[signer]` The owner of the mint.
     MintTo(u64),
     /// Burns tokens by removing them from an account and the total supply.
     ///
     /// # Accounts expected by this instruction:
     ///
-    ///   0. `[signer]` Owner of the account to burn from.
-    ///   1. `[writable]` Account to burn from.
-    ///   2. `[writable]` Token being burned.
-    ///   3. Optional: `[writable]` Source account if key 1 is a delegate account.
+    ///   0. `[writable]` The account to burn from.
+    ///   1. `[writable]` The mint being burned.
+    ///   2. `[signer]` The owner or delegate address of the account to burn from.
     Burn(u64),
 }
 impl TokenInstruction {
@@ -184,14 +181,14 @@ impl TokenInstruction {
 /// Creates a 'InitializeMint' instruction.
 pub fn initialize_mint(
     token_program_id: &Pubkey,
-    token_pubkey: &Pubkey,
+    mint_pubkey: &Pubkey,
     account_pubkey: Option<&Pubkey>,
     owner_pubkey: Option<&Pubkey>,
     token_info: TokenInfo,
 ) -> Result<Instruction, ProgramError> {
     let data = TokenInstruction::InitializeMint(token_info).serialize()?;
 
-    let mut accounts = vec![AccountMeta::new(*token_pubkey, true)];
+    let mut accounts = vec![AccountMeta::new(*mint_pubkey, true)];
     if token_info.supply != 0 {
         match account_pubkey {
             Some(pubkey) => accounts.push(AccountMeta::new(*pubkey, false)),
@@ -220,20 +217,16 @@ pub fn initialize_mint(
 pub fn initialize_account(
     token_program_id: &Pubkey,
     account_pubkey: &Pubkey,
+    mint_pubkey: &Pubkey,
     owner_pubkey: &Pubkey,
-    token_pubkey: &Pubkey,
-    source_pubkey: Option<&Pubkey>,
 ) -> Result<Instruction, ProgramError> {
     let data = TokenInstruction::InitializeAccount.serialize()?;
 
-    let mut accounts = vec![
+    let accounts = vec![
         AccountMeta::new(*account_pubkey, true),
+        AccountMeta::new_readonly(*mint_pubkey, false),
         AccountMeta::new_readonly(*owner_pubkey, false),
-        AccountMeta::new_readonly(*token_pubkey, false),
     ];
-    if let Some(pubkey) = source_pubkey {
-        accounts.push(AccountMeta::new_readonly(*pubkey, false));
-    }
 
     Ok(Instruction {
         program_id: *token_program_id,
@@ -245,22 +238,18 @@ pub fn initialize_account(
 /// Creates a `Transfer` instruction.
 pub fn transfer(
     token_program_id: &Pubkey,
-    owner_pubkey: &Pubkey,
-    account_pubkey: &Pubkey,
+    source_pubkey: &Pubkey,
     destination_pubkey: &Pubkey,
-    source_pubkey: Option<&Pubkey>,
+    authority_pubkey: &Pubkey,
     amount: u64,
 ) -> Result<Instruction, ProgramError> {
     let data = TokenInstruction::Transfer(amount).serialize()?;
 
-    let mut accounts = vec![
-        AccountMeta::new_readonly(*owner_pubkey, true),
-        AccountMeta::new(*account_pubkey, false),
+    let accounts = vec![
+        AccountMeta::new(*source_pubkey, false),
         AccountMeta::new(*destination_pubkey, false),
+        AccountMeta::new_readonly(*authority_pubkey, true),
     ];
-    if let Some(pubkey) = source_pubkey {
-        accounts.push(AccountMeta::new(*pubkey, false));
-    }
 
     Ok(Instruction {
         program_id: *token_program_id,
@@ -272,18 +261,18 @@ pub fn transfer(
 /// Creates an `Approve` instruction.
 pub fn approve(
     token_program_id: &Pubkey,
-    owner_pubkey: &Pubkey,
     source_pubkey: &Pubkey,
     delegate_pubkey: &Pubkey,
+    owner_pubkey: &Pubkey,
     amount: u64,
 ) -> Result<Instruction, ProgramError> {
     let data = TokenInstruction::Approve(amount).serialize()?;
 
-    let accounts = vec![
-        AccountMeta::new_readonly(*owner_pubkey, true),
-        AccountMeta::new_readonly(*source_pubkey, false),
-        AccountMeta::new(*delegate_pubkey, false),
-    ];
+    let mut accounts = vec![AccountMeta::new_readonly(*source_pubkey, false)];
+    if amount > 0 {
+        accounts.push(AccountMeta::new(*delegate_pubkey, false));
+    }
+    accounts.push(AccountMeta::new_readonly(*owner_pubkey, true));
 
     Ok(Instruction {
         program_id: *token_program_id,
@@ -295,16 +284,16 @@ pub fn approve(
 /// Creates an `SetOwner` instruction.
 pub fn set_owner(
     token_program_id: &Pubkey,
-    owner_pubkey: &Pubkey,
-    account_pubkey: &Pubkey,
+    owned_pubkey: &Pubkey,
     new_owner_pubkey: &Pubkey,
+    owner_pubkey: &Pubkey,
 ) -> Result<Instruction, ProgramError> {
     let data = TokenInstruction::SetOwner.serialize()?;
 
     let accounts = vec![
-        AccountMeta::new_readonly(*owner_pubkey, true),
-        AccountMeta::new(*account_pubkey, false),
+        AccountMeta::new(*owned_pubkey, false),
         AccountMeta::new_readonly(*new_owner_pubkey, false),
+        AccountMeta::new_readonly(*owner_pubkey, true),
     ];
 
     Ok(Instruction {
@@ -317,17 +306,17 @@ pub fn set_owner(
 /// Creates an `MintTo` instruction.
 pub fn mint_to(
     token_program_id: &Pubkey,
-    owner_pubkey: &Pubkey,
-    token_pubkey: &Pubkey,
+    mint_pubkey: &Pubkey,
     account_pubkey: &Pubkey,
+    owner_pubkey: &Pubkey,
     amount: u64,
 ) -> Result<Instruction, ProgramError> {
     let data = TokenInstruction::MintTo(amount).serialize()?;
 
     let accounts = vec![
-        AccountMeta::new_readonly(*owner_pubkey, true),
-        AccountMeta::new(*token_pubkey, false),
+        AccountMeta::new(*mint_pubkey, false),
         AccountMeta::new(*account_pubkey, false),
+        AccountMeta::new_readonly(*owner_pubkey, true),
     ];
 
     Ok(Instruction {
@@ -340,22 +329,18 @@ pub fn mint_to(
 /// Creates an `Burn` instruction.
 pub fn burn(
     token_program_id: &Pubkey,
-    owner_pubkey: &Pubkey,
     account_pubkey: &Pubkey,
-    token_pubkey: &Pubkey,
-    source_pubkey: Option<&Pubkey>,
+    mint_pubkey: &Pubkey,
+    authority_pubkey: &Pubkey,
     amount: u64,
 ) -> Result<Instruction, ProgramError> {
     let data = TokenInstruction::Burn(amount).serialize()?;
 
-    let mut accounts = vec![
-        AccountMeta::new_readonly(*owner_pubkey, true),
+    let accounts = vec![
         AccountMeta::new(*account_pubkey, false),
-        AccountMeta::new(*token_pubkey, false),
+        AccountMeta::new(*mint_pubkey, false),
+        AccountMeta::new_readonly(*authority_pubkey, true),
     ];
-    if let Some(pubkey) = source_pubkey {
-        accounts.push(AccountMeta::new(*pubkey, false));
-    }
 
     Ok(Instruction {
         program_id: *token_program_id,


### PR DESCRIPTION
Problem:
The Token program currently supports unlimited delegates associated with a single token account.
Doing so:
- Overly complicates both the interface and implementation of the token program
- Requires each delegate to be its own token account, adding unnecessary steps to the process
- Any instruction that that does delegation must include both the delegate account and the associated source account.  This is especially painful for programs like token-swap where it operates on a number of delegated accounts at the same time

Proposed solution:
Switch the token program to supporting one delegate per token account.

(Removes ~1000 lines of implementation and test code 🎉 )