### PR TITLE
Remove supply from Token

### DIFF
--- a/token-swap/inc/token-swap.h
+++ b/token-swap/inc/token-swap.h
@@ -73,7 +73,6 @@ typedef enum TokenSwap_SwapInstruction_Tag {
      *   0. `[]` Token-swap
      *   1. `[]` $authority
      *   2. `[writable]` SOURCE Pool account, amount is transferable by $authority.
-     *   4. `[writable]` Pool MINT account, $authority is the owner.
      *   5. `[writable]` token_a Account to withdraw FROM.
      *   6. `[writable]` token_b Account to withdraw FROM.
      *   7. `[writable]` token_a user Account.

--- a/token-swap/js/cli/token-swap-test.js
+++ b/token-swap/js/cli/token-swap-test.js
@@ -244,7 +244,6 @@ export async function withdraw(): Promise<void> {
   await tokenSwap.withdraw(
     authority,
     tokenAccountPool,
-    tokenPool.publicKey,
     tokenAccountA,
     tokenAccountB,
     userAccountA,

--- a/token-swap/js/client/token-swap.js
+++ b/token-swap/js/client/token-swap.js
@@ -453,7 +453,6 @@ export class TokenSwap {
   async withdraw(
     authority: PublicKey,
     sourcePoolAccount: PublicKey,
-    poolToken: PublicKey,
     fromA: PublicKey,
     fromB: PublicKey,
     userAccountA: PublicKey,
@@ -468,7 +467,6 @@ export class TokenSwap {
         this.withdrawInstruction(
           authority,
           sourcePoolAccount,
-          poolToken,
           fromA,
           fromB,
           userAccountA,
@@ -483,7 +481,6 @@ export class TokenSwap {
   withdrawInstruction(
     authority: PublicKey,
     sourcePoolAccount: PublicKey,
-    poolToken: PublicKey,
     fromA: PublicKey,
     fromB: PublicKey,
     userAccountA: PublicKey,
@@ -509,7 +506,6 @@ export class TokenSwap {
       {pubkey: this.tokenSwap, isSigner: false, isWritable: false},
       {pubkey: authority, isSigner: false, isWritable: false},
       {pubkey: sourcePoolAccount, isSigner: false, isWritable: true},
-      {pubkey: poolToken, isSigner: false, isWritable: true},
       {pubkey: fromA, isSigner: false, isWritable: true},
       {pubkey: fromB, isSigner: false, isWritable: true},
       {pubkey: userAccountA, isSigner: false, isWritable: true},

--- a/token/inc/token.h
+++ b/token/inc/token.h
@@ -18,20 +18,6 @@
 #define Token_MIN_SIGNERS 1
 
 /**
- * Specifies the financial specifics of a token.
- */
-typedef struct Token_TokenInfo {
-    /**
-     * Total supply of tokens.
-     */
-    uint64_t supply;
-    /**
-     * Number of base 10 digits to the right of the decimal place in the total supply.
-     */
-    uint64_t decimals;
-} Token_TokenInfo;
-
-/**
  * Instructions supported by the token program.
  */
 typedef enum Token_TokenInstruction_Tag {
@@ -186,9 +172,13 @@ typedef enum Token_TokenInstruction_Tag {
 
 typedef struct Token_InitializeMint_Body {
     /**
-     * The financial specifics of the token.
+     * Initial amount of tokens to mint.
      */
-    Token_TokenInfo info;
+    uint64_t amount;
+    /**
+     * Number of base 10 digits to the right of the decimal place.
+     */
+    uint8_t decimals;
 } Token_InitializeMint_Body;
 
 typedef struct Token_InitializeMultisig_Body {
@@ -272,15 +262,15 @@ typedef struct Token_COption_Pubkey {
  */
 typedef struct Token_Token {
     /**
-     * Token details.
-     */
-    Token_TokenInfo info;
-    /**
      * Optional owner, used to mint new tokens.  The owner may only
      * be provided during mint creation.  If no owner is present then the mint
      * has a fixed supply and no further tokens may be minted.
      */
     Token_COption_Pubkey owner;
+    /**
+     * Number of base 10 digits to the right of the decimal place.
+     */
+    uint8_t decimals;
 } Token_Token;
 
 /**

--- a/token/js/cli/token-test.js
+++ b/token/js/cli/token-test.js
@@ -120,7 +120,6 @@ export async function createMint(): Promise<void> {
   );
 
   const mintInfo = await testToken.getMintInfo();
-  assert(mintInfo.supply.toNumber() == 10000);
   assert(mintInfo.decimals == 2);
   assert(mintInfo.owner == null);
 
@@ -264,7 +263,6 @@ export async function mintTo(): Promise<void> {
 
   {
     const mintInfo = await testMintableToken.getMintInfo();
-    assert(mintInfo.supply.toNumber() == 10000);
     assert(mintInfo.decimals == 2);
     if (mintInfo.owner === null) {
       throw new Error('owner should not be null');
@@ -285,7 +283,6 @@ export async function mintTo(): Promise<void> {
 
   {
     const mintInfo = await testMintableToken.getMintInfo();
-    assert(mintInfo.supply.toNumber() == 10042);
     assert(mintInfo.decimals == 2);
     if (mintInfo.owner === null) {
       throw new Error('owner should not be null');
@@ -303,16 +300,12 @@ export async function mintTo(): Promise<void> {
 }
 
 export async function burn(): Promise<void> {
-  let mintInfo = await testToken.getMintInfo();
-  const supply = mintInfo.supply.toNumber();
   let accountInfo = await testToken.getAccountInfo(testAccount);
   const amount = accountInfo.amount.toNumber();
 
   await testToken.burn(testAccount, testAccountOwner, [], 1);
   await sleep(500);
 
-  mintInfo = await testToken.getMintInfo();
-  assert(mintInfo.supply.toNumber() == supply - 1);
   accountInfo = await testToken.getAccountInfo(testAccount);
   assert(accountInfo.amount.toNumber() == amount - 1);
 }


### PR DESCRIPTION
- Tracking total supply may be misinterpreted and lead to confusion If accounts are removed due to rent delinquency.
- Removing supply reduces a required key in the `Burn` instruction