### PR TITLE
Remove initialize signers

### DIFF
--- a/token/inc/token.h
+++ b/token/inc/token.h
@@ -38,9 +38,13 @@ typedef enum Token_TokenInstruction_Tag {
     /**
      * Initializes a new mint and optionally deposits all the newly minted tokens in an account.
      *
+     * The `InitializeWrappedAccount` instruction requires no signers and MUST be included within
+     * the Transaction that creates the uninitialized account with the system program.  Otherwise
+     * another party can acquire ownership of the uninitialized token account.
+     *
      * Accounts expected by this instruction:
      *
-     *   0. `[writable, signer]` The mint to initialize.
+     *   0. `[writable]` The mint to initialize.
      *   1.
      *      * If supply is non-zero: `[writable]` The account to hold all the newly minted tokens.
      *      * If supply is zero: `[]` The owner/multisignature of the mint.
@@ -52,9 +56,13 @@ typedef enum Token_TokenInstruction_Tag {
     /**
      * Initializes a new account to hold tokens.
      *
+     * The `InitializeWrappedAccount` instruction requires no signers and MUST be included within
+     * the Transaction that creates the uninitialized account with the system program.  Otherwise
+     * another party can acquire ownership of the uninitialized token account.
+     *
      * Accounts expected by this instruction:
      *
-     *   0. `[writable, signer]`  The account to initialize.
+     *   0. `[writable]`  The account to initialize.
      *   1. `[]` The mint this account will be associated with.
      *   2. `[]` The new account's owner/multisignature.
      */
@@ -66,9 +74,13 @@ typedef enum Token_TokenInstruction_Tag {
      * token instruction that require an owner/delegate to be present.  The variant field represents the
      * number of signers (M) required to validate this multisignature account.
      *
+     * The `InitializeWrappedAccount` instruction requires no signers and MUST be included within
+     * the Transaction that creates the uninitialized account with the system program.  Otherwise
+     * another party can acquire ownership of the uninitialized token account.
+     *
      * Accounts expected by this instruction:
      *
-     *   0. `[signer, writable]` The multisignature account to initialize.
+     *   0. `[writable]` The multisignature account to initialize.
      *   1. ..1+N. `[]` The signer accounts, must equal to N where 1 <= N <= 11.
      */
     InitializeMultisig,

--- a/token/js/cli/token-test.js
+++ b/token/js/cli/token-test.js
@@ -196,9 +196,6 @@ export async function invalidApprove(): Promise<void> {
 }
 
 export async function failOnApproveOverspend(): Promise<void> {
-  const connection = await getConnection();
-  const balanceNeeded =
-    (await Token.getMinBalanceRentForExemptAccount(connection)) * 3;
   const owner = new Account();
   const account1 = await testToken.createAccount(owner.publicKey);
   const account2 = await testToken.createAccount(owner.publicKey);
@@ -324,10 +321,6 @@ export async function multisig(): Promise<void> {
   const m = 2;
   const n = 5;
 
-  const connection = await getConnection();
-  const balanceNeeded = await Token.getMinBalanceRentForExemptAccount(
-    connection,
-  );
   let signerAccounts = [];
   for (var i = 0; i < n; i++) {
     signerAccounts.push(new Account());

--- a/token/js/client/token.js
+++ b/token/js/client/token.js
@@ -299,7 +299,7 @@ export class Token {
 
     // Create the mint
     let keys = [
-      {pubkey: mintAccount.publicKey, isSigner: true, isWritable: false},
+      {pubkey: mintAccount.publicKey, isSigner: false, isWritable: true},
     ];
     if (supply.toNumber() != 0) {
       keys.push({pubkey: initialAccountPublicKey, isSigner: false, isWritable: true});
@@ -335,7 +335,6 @@ export class Token {
       connection,
       transaction,
       payer,
-      mintAccount,
     );
 
     return [token, initialAccountPublicKey];
@@ -381,7 +380,7 @@ export class Token {
 
     // create the new account
     const keys = [
-      {pubkey: mintAccount.publicKey, isSigner: true, isWritable: true},
+      {pubkey: mintAccount.publicKey, isSigner: false, isWritable: true},
       {pubkey: this.publicKey, isSigner: false, isWritable: false},
       {pubkey: owner, isSigner: false, isWritable: false},
     ];
@@ -404,7 +403,6 @@ export class Token {
       this.connection,
       transaction,
       this.payer,
-      mintAccount,
     );
 
     return mintAccount.publicKey;
@@ -446,7 +444,7 @@ export class Token {
 
     // create the new account
     let keys = [
-      {pubkey: multisigAccount.publicKey, isSigner: true, isWritable: true},
+      {pubkey: multisigAccount.publicKey, isSigner: false, isWritable: true},
     ];
     signers.forEach(signer => keys.push({pubkey: signer, isSigner: false, isWritable: false}));
 
@@ -474,7 +472,6 @@ export class Token {
       this.connection,
       transaction,
       this.payer,
-      multisigAccount,
     );
 
     return multisigAccount.publicKey;

--- a/token/js/client/token.js
+++ b/token/js/client/token.js
@@ -289,13 +289,6 @@ export class Token {
       space: MintLayout.span,
       programId,
     });
-    await sendAndConfirmTransaction(
-      'createAccount',
-      connection,
-      transaction,
-      payer,
-      mintAccount,
-    );
 
     // Create the mint
     let keys = [
@@ -324,17 +317,19 @@ export class Token {
       );
       data = data.slice(0, encodeLength);
     }
-
-    transaction = new Transaction().add({
+    transaction.add({
       keys,
       programId,
       data,
     });
+
+    // Send the two instructions
     await sendAndConfirmTransaction(
-      'InitializeMint',
+      'createAccount and InitializeMint',
       connection,
       transaction,
       payer,
+      mintAccount
     );
 
     return [token, initialAccountPublicKey];
@@ -370,13 +365,6 @@ export class Token {
       space: AccountLayout.span,
       programId: this.programId,
     });
-    await sendAndConfirmTransaction(
-      'createAccount',
-      this.connection,
-      transaction,
-      this.payer,
-      mintAccount,
-    );
 
     // create the new account
     const keys = [
@@ -384,7 +372,6 @@ export class Token {
       {pubkey: this.publicKey, isSigner: false, isWritable: false},
       {pubkey: owner, isSigner: false, isWritable: false},
     ];
-
     const dataLayout = BufferLayout.struct([BufferLayout.u8('instruction')]);
     const data = Buffer.alloc(dataLayout.span);
     dataLayout.encode(
@@ -393,16 +380,19 @@ export class Token {
       },
       data,
     );
-    transaction = new Transaction().add({
+    transaction.add({
       keys,
       programId: this.programId,
       data,
     });
+
+    // Send the two instructions
     await sendAndConfirmTransaction(
-      'InitializeAccount',
+      'createAccount and InitializeAccount',
       this.connection,
       transaction,
       this.payer,
+      mintAccount
     );
 
     return mintAccount.publicKey;
@@ -434,20 +424,12 @@ export class Token {
       space: MultisigLayout.span,
       programId: this.programId,
     });
-    await sendAndConfirmTransaction(
-      'createAccount',
-      this.connection,
-      transaction,
-      this.payer,
-      multisigAccount,
-    );
 
     // create the new account
     let keys = [
       {pubkey: multisigAccount.publicKey, isSigner: false, isWritable: true},
     ];
     signers.forEach(signer => keys.push({pubkey: signer, isSigner: false, isWritable: false}));
-
     const dataLayout = BufferLayout.struct(
       [
         BufferLayout.u8('instruction'),
@@ -462,16 +444,19 @@ export class Token {
       },
       data,
     );
-    transaction = new Transaction().add({
+    transaction.add({
       keys,
       programId: this.programId,
       data,
     });
+
+    // Send the two instructions
     await sendAndConfirmTransaction(
-      'InitializeMultisig',
+      'createAccount and InitializeMultisig',
       this.connection,
       transaction,
       this.payer,
+      multisigAccount
     );
 
     return multisigAccount.publicKey;

--- a/token/src/state.rs
+++ b/token/src/state.rs
@@ -97,10 +97,6 @@ impl State {
         let account_info_iter = &mut accounts.iter();
         let mint_info = next_account_info(account_info_iter)?;
 
-        if !mint_info.is_signer {
-            return Err(ProgramError::MissingRequiredSignature);
-        }
-
         if State::Unallocated != State::deserialize(&mint_info.data.borrow())? {
             return Err(TokenError::AlreadyInUse.into());
         }
@@ -139,10 +135,6 @@ impl State {
         let new_account_info = next_account_info(account_info_iter)?;
         let mint_info = next_account_info(account_info_iter)?;
         let owner_info = next_account_info(account_info_iter)?;
-
-        if !new_account_info.is_signer {
-            return Err(ProgramError::MissingRequiredSignature);
-        }
 
         let mut new_account_data = new_account_info.data.borrow_mut();
         if State::Unallocated != State::deserialize(&new_account_data)? {
@@ -712,18 +704,6 @@ mod tests {
         let mut owner_account = Account::default();
         let mint_key = pubkey_rand();
         let mut mint_account = Account::new(0, size_of::<State>(), &program_id);
-
-        // missing signer
-        let mut instruction =
-            initialize_account(&program_id, &account_key, &mint_key, &owner_key).unwrap();
-        instruction.accounts[0].is_signer = false;
-        assert_eq!(
-            Err(ProgramError::MissingRequiredSignature),
-            do_process_instruction(
-                instruction,
-                vec![&mut account_account, &mut mint_account, &mut owner_account],
-            )
-        );
 
         // create account
         do_process_instruction(


### PR DESCRIPTION
Requiring signers to initialize mint states means these states cannot be initialized with an account obtained with `create_from_seed`.

Removing the requirement that accounts being initialized be signed and added documentation alerting the user that these operations should be done atomically.