### PR TITLE
Add revoke instruction

### DIFF
--- a/token/inc/token.h
+++ b/token/inc/token.h
@@ -110,16 +110,31 @@ typedef enum Token_TokenInstruction_Tag {
      *
      *   * Single owner/delegate
      *   0. `[writable]` The source account.
-     *   1. `[]` (optional) The delegate if amount is non-zero.
+     *   1. `[]` The delegate if amount is non-zero.
      *   2. `[signer]` The source account owner/delegate.
      *
      *   * Multisignature owner/delegate
      *   0. `[writable]` The source account.
-     *   1. `[]` (optional) The delegate if amount is non-zero.
+     *   1. `[]` The delegate if amount is non-zero.
      *   2. '[]' The source account's multisignature owner/delegate.
      *   3. ..3+M '[signer]' M signer accounts
      */
     Approve,
+    /**
+     * Revokes a delegate.
+     *
+     * Accounts expected by this instruction:
+     *
+     *   * Single owner/delegate
+     *   0. `[writable]` The source account.
+     *   2. `[signer]` The source account owner/delegate.
+     *
+     *   * Multisignature owner/delegate
+     *   0. `[writable]` The source account.
+     *   2. '[]' The source account's multisignature owner/delegate.
+     *   3. ..3+M '[signer]' M signer accounts
+     */
+    Revoke,
     /**
      * Sets a new owner of a mint or account.
      *

--- a/token/inc/token.h
+++ b/token/inc/token.h
@@ -103,25 +103,23 @@ typedef enum Token_TokenInstruction_Tag {
     Transfer,
     /**
      * Approves a delegate.  A delegate is given the authority over
-     * tokens on behalf of the source account's owner.  If the amount to
-     * delegate is zero then delegation is rescinded
-     *
+     * tokens on behalf of the source account's owner.
      * Accounts expected by this instruction:
      *
      *   * Single owner
      *   0. `[writable]` The source account.
-     *   1. `[]` The delegate if amount is non-zero.
+     *   1. `[]` The delegate.
      *   2. `[signer]` The source account owner.
      *
      *   * Multisignature owner
      *   0. `[writable]` The source account.
-     *   1. `[]` The delegate if amount is non-zero.
+     *   1. `[]` The delegate.
      *   2. '[]' The source account's multisignature owner.
      *   3. ..3+M '[signer]' M signer accounts
      */
     Approve,
     /**
-     * Revokes a delegate.
+     * Revokes the delegate's authority.
      *
      * Accounts expected by this instruction:
      *

--- a/token/inc/token.h
+++ b/token/inc/token.h
@@ -108,15 +108,15 @@ typedef enum Token_TokenInstruction_Tag {
      *
      * Accounts expected by this instruction:
      *
-     *   * Single owner/delegate
+     *   * Single owner
      *   0. `[writable]` The source account.
      *   1. `[]` The delegate if amount is non-zero.
-     *   2. `[signer]` The source account owner/delegate.
+     *   2. `[signer]` The source account owner.
      *
-     *   * Multisignature owner/delegate
+     *   * Multisignature owner
      *   0. `[writable]` The source account.
      *   1. `[]` The delegate if amount is non-zero.
-     *   2. '[]' The source account's multisignature owner/delegate.
+     *   2. '[]' The source account's multisignature owner.
      *   3. ..3+M '[signer]' M signer accounts
      */
     Approve,
@@ -125,13 +125,13 @@ typedef enum Token_TokenInstruction_Tag {
      *
      * Accounts expected by this instruction:
      *
-     *   * Single owner/delegate
+     *   * Single owner
      *   0. `[writable]` The source account.
-     *   2. `[signer]` The source account owner/delegate.
+     *   2. `[signer]` The source account owner.
      *
-     *   * Multisignature owner/delegate
+     *   * Multisignature owner
      *   0. `[writable]` The source account.
-     *   2. '[]' The source account's multisignature owner/delegate.
+     *   2. '[]' The source account's multisignature owner.
      *   3. ..3+M '[signer]' M signer accounts
      */
     Revoke,

--- a/token/js/cli/token-test.js
+++ b/token/js/cli/token-test.js
@@ -175,7 +175,7 @@ export async function approveRevoke(): Promise<void> {
     assert(testAccountInfo.delegate.equals(delegate));
   }
 
-  await testToken.revoke(testAccount, delegate, testAccountOwner, []);
+  await testToken.revoke(testAccount, testAccountOwner, []);
   testAccountInfo = await testToken.getAccountInfo(testAccount);
   assert(testAccountInfo.delegatedAmount.toNumber() == 0);
   if (testAccountInfo.delegate != null) {

--- a/token/src/instruction.rs
+++ b/token/src/instruction.rs
@@ -86,23 +86,22 @@ pub enum TokenInstruction {
     ///   3. ..3+M '[signer]' M signer accounts.
     Transfer(u64),
     /// Approves a delegate.  A delegate is given the authority over
-    /// tokens on behalf of the source account's owner.  If the amount to
-    /// delegate is zero then delegation is rescinded
-    ///
+    /// tokens on behalf of the source account's owner.
+
     /// Accounts expected by this instruction:
     ///
     ///   * Single owner
     ///   0. `[writable]` The source account.
-    ///   1. `[]` The delegate if amount is non-zero.
+    ///   1. `[]` The delegate.
     ///   2. `[signer]` The source account owner.
     ///
     ///   * Multisignature owner
     ///   0. `[writable]` The source account.
-    ///   1. `[]` The delegate if amount is non-zero.
+    ///   1. `[]` The delegate.
     ///   2. '[]' The source account's multisignature owner.
     ///   3. ..3+M '[signer]' M signer accounts
     Approve(u64),
-    /// Revokes a delegate.
+    /// Revokes the delegate's authority.
     ///
     /// Accounts expected by this instruction:
     ///

--- a/token/src/instruction.rs
+++ b/token/src/instruction.rs
@@ -93,15 +93,28 @@ pub enum TokenInstruction {
     ///
     ///   * Single owner/delegate
     ///   0. `[writable]` The source account.
-    ///   1. `[]` (optional) The delegate if amount is non-zero.
+    ///   1. `[]` The delegate if amount is non-zero.
     ///   2. `[signer]` The source account owner/delegate.
     ///
     ///   * Multisignature owner/delegate
     ///   0. `[writable]` The source account.
-    ///   1. `[]` (optional) The delegate if amount is non-zero.
+    ///   1. `[]` The delegate if amount is non-zero.
     ///   2. '[]' The source account's multisignature owner/delegate.
     ///   3. ..3+M '[signer]' M signer accounts
     Approve(u64),
+    /// Revokes a delegate.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   * Single owner/delegate
+    ///   0. `[writable]` The source account.
+    ///   2. `[signer]` The source account owner/delegate.
+    ///
+    ///   * Multisignature owner/delegate
+    ///   0. `[writable]` The source account.
+    ///   2. '[]' The source account's multisignature owner/delegate.
+    ///   3. ..3+M '[signer]' M signer accounts
+    Revoke,
     /// Sets a new owner of a mint or account.
     ///
     /// Accounts expected by this instruction:
@@ -188,8 +201,9 @@ impl TokenInstruction {
                 let amount: &u64 = unsafe { &*(&input[1] as *const u8 as *const u64) };
                 Self::Approve(*amount)
             }
-            5 => Self::SetOwner,
-            6 => {
+            5 => Self::Revoke,
+            6 => Self::SetOwner,
+            7 => {
                 if input.len() < size_of::<u8>() + size_of::<u64>() {
                     return Err(ProgramError::InvalidAccountData);
                 }
@@ -197,7 +211,7 @@ impl TokenInstruction {
                 let amount: &u64 = unsafe { &*(&input[1] as *const u8 as *const u64) };
                 Self::MintTo(*amount)
             }
-            7 => {
+            8 => {
                 if input.len() < size_of::<u8>() + size_of::<u64>() {
                     return Err(ProgramError::InvalidAccountData);
                 }
@@ -238,15 +252,16 @@ impl TokenInstruction {
                 let value = unsafe { &mut *(&mut output[1] as *mut u8 as *mut u64) };
                 *value = *amount;
             }
-            Self::SetOwner => output[0] = 5,
+            Self::Revoke => output[0] = 5,
+            Self::SetOwner => output[0] = 6,
             Self::MintTo(amount) => {
-                output[0] = 6;
+                output[0] = 7;
                 #[allow(clippy::cast_ptr_alignment)]
                 let value = unsafe { &mut *(&mut output[1] as *mut u8 as *mut u64) };
                 *value = *amount;
             }
             Self::Burn(amount) => {
-                output[0] = 7;
+                output[0] = 8;
                 #[allow(clippy::cast_ptr_alignment)]
                 let value = unsafe { &mut *(&mut output[1] as *mut u8 as *mut u64) };
                 *value = *amount;
@@ -383,9 +398,33 @@ pub fn approve(
 
     let mut accounts = Vec::with_capacity(3 + signer_pubkeys.len());
     accounts.push(AccountMeta::new_readonly(*source_pubkey, false));
-    if amount > 0 {
-        accounts.push(AccountMeta::new(*delegate_pubkey, false));
+    accounts.push(AccountMeta::new(*delegate_pubkey, false));
+    accounts.push(AccountMeta::new_readonly(
+        *owner_pubkey,
+        signer_pubkeys.len() == 0,
+    ));
+    for signer_pubkey in signer_pubkeys.iter() {
+        accounts.push(AccountMeta::new(**signer_pubkey, true));
     }
+
+    Ok(Instruction {
+        program_id: *token_program_id,
+        accounts,
+        data,
+    })
+}
+
+/// Creates an `Approve` instruction.
+pub fn revoke(
+    token_program_id: &Pubkey,
+    source_pubkey: &Pubkey,
+    owner_pubkey: &Pubkey,
+    signer_pubkeys: &[&Pubkey],
+) -> Result<Instruction, ProgramError> {
+    let data = TokenInstruction::Revoke.serialize()?;
+
+    let mut accounts = Vec::with_capacity(2 + signer_pubkeys.len());
+    accounts.push(AccountMeta::new_readonly(*source_pubkey, false));
     accounts.push(AccountMeta::new_readonly(
         *owner_pubkey,
         signer_pubkeys.is_empty(),

--- a/token/src/instruction.rs
+++ b/token/src/instruction.rs
@@ -400,7 +400,7 @@ pub fn approve(
     accounts.push(AccountMeta::new(*delegate_pubkey, false));
     accounts.push(AccountMeta::new_readonly(
         *owner_pubkey,
-        signer_pubkeys.len() == 0,
+        signer_pubkeys.is_empty(),
     ));
     for signer_pubkey in signer_pubkeys.iter() {
         accounts.push(AccountMeta::new(**signer_pubkey, true));

--- a/token/src/instruction.rs
+++ b/token/src/instruction.rs
@@ -91,28 +91,28 @@ pub enum TokenInstruction {
     ///
     /// Accounts expected by this instruction:
     ///
-    ///   * Single owner/delegate
+    ///   * Single owner
     ///   0. `[writable]` The source account.
     ///   1. `[]` The delegate if amount is non-zero.
-    ///   2. `[signer]` The source account owner/delegate.
+    ///   2. `[signer]` The source account owner.
     ///
-    ///   * Multisignature owner/delegate
+    ///   * Multisignature owner
     ///   0. `[writable]` The source account.
     ///   1. `[]` The delegate if amount is non-zero.
-    ///   2. '[]' The source account's multisignature owner/delegate.
+    ///   2. '[]' The source account's multisignature owner.
     ///   3. ..3+M '[signer]' M signer accounts
     Approve(u64),
     /// Revokes a delegate.
     ///
     /// Accounts expected by this instruction:
     ///
-    ///   * Single owner/delegate
+    ///   * Single owner
     ///   0. `[writable]` The source account.
-    ///   2. `[signer]` The source account owner/delegate.
+    ///   2. `[signer]` The source account owner.
     ///
-    ///   * Multisignature owner/delegate
+    ///   * Multisignature owner
     ///   0. `[writable]` The source account.
-    ///   2. '[]' The source account's multisignature owner/delegate.
+    ///   2. '[]' The source account's multisignature owner.
     ///   3. ..3+M '[signer]' M signer accounts
     Revoke,
     /// Sets a new owner of a mint or account.


### PR DESCRIPTION
Split the `Approve` instruction into two to avoid the complexity of an optional account