### PR TITLE
Add subscription support

### DIFF
--- a/token/src/instruction.rs
+++ b/token/src/instruction.rs
@@ -107,6 +107,9 @@ pub enum TokenInstruction {
     Approve {
         /// The amount of tokens the delegate is approved for.
         amount: u64,
+        /// If non-zero then subscribe the delegate to be re-approved the same `amount`
+        /// every `slots_until_renewal`
+        slots_until_renewal: u64,
     },
     /// Revokes the delegate's authority.
     ///


### PR DESCRIPTION
Adds support for delegate subscriptions which is the ability for the owner to auto-approve the same amount periodically.  The period is set by the owner as the number of slots between re-approvals.

Fixes: #119 