### PR TITLE
Mergify squash commits

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,7 +5,7 @@ pull_request_rules:
       - label=automerge
     actions:
       merge:
-        method: rebase
+        method: squash
   - name: remove automerge label on CI failure
     conditions:
       - status-failure=continuous-integration/travis-ci/pr


### PR DESCRIPTION
Automerge isn't working, because it attempts a rebase commit. "Rebase merges are not allowed on this repository."