### PR TITLE
token: Add default/program crate features to match solana-sdk

### DIFF
--- a/token/Cargo.toml
+++ b/token/Cargo.toml
@@ -13,12 +13,14 @@ exclude = ["js/**"]
 
 [features]
 skip-no-mangle = ["solana-sdk/skip-no-mangle"]
+program = ["solana-sdk/program"]
+default = ["solana-sdk/default"]
 
 [dependencies]
 num-derive = "0.2"
 num-traits = "0.2"
 remove_dir_all = "=0.5.0"
-solana-sdk = { version = "=1.2.13", default-features = false, features=["program"] }
+solana-sdk = { version = "=1.2.13", default-features = false, optional = true }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/token/Cargo.toml
+++ b/token/Cargo.toml
@@ -14,12 +14,13 @@ exclude = ["js/**"]
 [features]
 skip-no-mangle = ["solana-sdk/skip-no-mangle"]
 program = ["solana-sdk/program"]
-default = ["solana-sdk/default"]
+default = ["solana-sdk/default", "log"]
 
 [dependencies]
 num-derive = "0.2"
 num-traits = "0.2"
 remove_dir_all = "=0.5.0"
+log = { version = "0.4.8", optional = true }
 solana-sdk = { version = "=1.2.13", default-features = false, optional = true }
 thiserror = "1.0"
 

--- a/token/src/error.rs
+++ b/token/src/error.rs
@@ -4,9 +4,12 @@ use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use solana_sdk::{
     decode_error::DecodeError,
-    info,
     program_error::{PrintProgramError, ProgramError},
 };
+#[cfg(feature = "program")]
+use solana_sdk::info;
+#[cfg(not(feature = "program"))]
+use log::info;
 use thiserror::Error;
 
 /// Errors that may be returned by the Token program.

--- a/token/src/state.rs
+++ b/token/src/state.rs
@@ -6,9 +6,13 @@ use crate::{
     option::COption,
 };
 use solana_sdk::{
-    account_info::next_account_info, account_info::AccountInfo, entrypoint::ProgramResult, info,
+    account_info::next_account_info, account_info::AccountInfo, entrypoint::ProgramResult,
     program_error::ProgramError, pubkey::Pubkey,
 };
+#[cfg(feature = "program")]
+use solana_sdk::info;
+#[cfg(not(feature = "program"))]
+use log::info;
 use std::mem::size_of;
 
 /// Mint data.
@@ -549,6 +553,7 @@ pub trait IsInitialized {
 }
 
 // Pull in syscall stubs when building for non-BPF targets
+#[cfg(feature = "program")]
 #[cfg(not(target_arch = "bpf"))]
 solana_sdk::program_stubs!();
 


### PR DESCRIPTION
The spl-token crate is not useful for Rust clients because it forces the "program" feature in solana-sdk, which turns off a variety of things.   We have yet to see this issue in the monorepo by fluke.

#### Simple STR:
1. `cargo init`
2. Add `solana-sdk = "1.2"` and `spl-token = "1.0"` to Cargo.toml
3. `use solana_sdk::signature::Signature;` in `src/main.rs`.   

#### Result:
```
error[E0432]: unresolved import `solana_sdk::signature`
 --> src/main.rs:1:17
  |
1 | use solana_sdk::signature::Signature;
  |                 ^^^^^^^^^ could not find `signature` in `solana_sdk`
```

Depends-on: 