### PR TITLE
Relax solana-sdk version requirement

### DIFF
--- a/.travis/install-program-deps.sh
+++ b/.travis/install-program-deps.sh
@@ -12,6 +12,7 @@ sudo apt-get install -y clang-7 --allow-unauthenticated
 sudo apt-get install -y openssl --allow-unauthenticated
 sudo apt-get install -y libssl-dev --allow-unauthenticated
 sudo apt-get install -y libssl1.1 --allow-unauthenticated
+sudo apt-get install -y libudev-dev
 clang-7 --version
 nvm install node
 npm install -g typescript

--- a/ci/client/Cargo.lock
+++ b/ci/client/Cargo.lock
@@ -226,15 +226,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clear_on_drop"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9cc5db465b294c3fa986d5bbb0f3017cd850bff6dd6c52f9ccff8b4d21b7b08"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,16 +321,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
-name = "ed25519-dalek"
-version = "1.0.0-pre.3"
+name = "ed25519"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978710b352437433c97b2bff193f2fb1dfd58a093f863dd95e225a19baa599a2"
+checksum = "bf038a7b6fd7ef78ad3348b63f3a17550877b0e28f8d68bcc94894d1412158bc"
 dependencies = [
- "clear_on_drop",
+ "serde",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "1.0.0-pre.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a8a37f4e8b35af971e6db5e3897e7a6344caa3f92f6544f88125a1f5f0035a"
+dependencies = [
  "curve25519-dalek",
+ "ed25519",
  "rand",
  "serde",
  "sha2",
+ "zeroize",
 ]
 
 [[package]]
@@ -1359,6 +1361,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
+
+[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,9 +1395,9 @@ dependencies = [
 
 [[package]]
 name = "solana-crate-features"
-version = "1.2.15"
+version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a7c8c63c914172560a4b77398fd71ff0a10f4bf5aad73934abfb5a4f6594f7"
+checksum = "610ba71932d0bf4abf88eabb081ee43fa1ee6bb5137c4fa6776ea9dd8630ca5c"
 dependencies = [
  "backtrace",
  "bytes 0.4.12",
@@ -1412,9 +1420,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.2.15"
+version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d09a703cfdb8a9d391084df724e00b0bdaeb79040ce830f6da9a111f7f4218e8"
+checksum = "bc703cb2807e9d713f70df32ac8c3a7a9c8af437dd0d468b1b77cfd8e8b4cbc8"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -1423,9 +1431,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.2.13"
+version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae779f912f1cbe2fe91df656ecc5ccdda9dd3378c0934f4390b7ba33501b3dc"
+checksum = "a556c1b456609b760ff47b933912f27563ea8a9a1692864cbc1014c02f5b981e"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -1460,9 +1468,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.2.15"
+version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219054744d6e13b7587d4433bc94e720d25b39617a9987488ba1cea8995ea61"
+checksum = "38bc386020de692562a29c0696a71c14a3d94455a9a785a97c7b254c38d6a2c8"
 dependencies = [
  "bs58",
  "proc-macro2 1.0.19",
@@ -1479,14 +1487,14 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spl-memo"
-version = "1.0.4"
+version = "1.0.7"
 dependencies = [
  "solana-sdk",
 ]
 
 [[package]]
 name = "spl-token"
-version = "1.0.3"
+version = "1.0.6"
 dependencies = [
  "cbindgen",
  "num-derive",
@@ -2181,3 +2189,18 @@ name = "zeroize"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
+dependencies = [
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.36",
+ "synstructure",
+]

--- a/ci/client/Cargo.toml
+++ b/ci/client/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # Used to ensure that SPL programs are buildable by external clients
 
 [dependencies]
-solana-sdk = "1.2"
+solana-sdk = "1.2.17"
 spl-memo = { path = "../../memo" }
 spl-token = { path = "../../token" }
 spl-token-swap = { path = "../../token-swap" }

--- a/memo/Cargo.lock
+++ b/memo/Cargo.lock
@@ -162,14 +162,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clear_on_drop"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cc 1.0.49 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,15 +248,25 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "ed25519-dalek"
-version = "1.0.0-pre.3"
+name = "ed25519"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "clear_on_drop 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.112 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signature 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "1.0.0-pre.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
  "curve25519-dalek 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.112 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1161,6 +1163,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1186,14 +1193,14 @@ dependencies = [
 
 [[package]]
 name = "solana-crate-features"
-version = "1.2.15"
+version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.49 (registry+https://github.com/rust-lang/crates.io-index)",
  "curve25519-dalek 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ed25519-dalek 1.0.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519-dalek 1.0.0-pre.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1210,7 +1217,7 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.2.15"
+version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1220,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.2.13"
+version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1229,7 +1236,7 @@ dependencies = [
  "bv 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "ed25519-dalek 1.0.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519-dalek 1.0.0-pre.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.14.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1248,15 +1255,15 @@ dependencies = [
  "serde_derive 1.0.112 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-crate-features 1.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 1.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk-macro 1.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-crate-features 1.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-logger 1.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk-macro 1.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.2.13"
+version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bs58 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1273,9 +1280,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "spl-memo"
-version = "1.0.4"
+version = "1.0.7"
 dependencies = [
- "solana-sdk 1.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1824,6 +1831,20 @@ dependencies = [
 name = "zeroize"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "zeroize_derive 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [metadata]
 "checksum addr2line 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1b6a2d3371669ab3ca9797670853d61402b03d0b4b9ebf33d677dfa720203072"
@@ -1848,7 +1869,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cc 1.0.49 (registry+https://github.com/rust-lang/crates.io-index)" = "e450b8da92aa6f274e7c6437692f9f2ce6d701fb73bacfcf87897b3f89a4c20e"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chrono 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "c74d84029116787153e02106bf53e66828452a4b325cc8652b788b5967c0a0b6"
-"checksum clear_on_drop 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c9cc5db465b294c3fa986d5bbb0f3017cd850bff6dd6c52f9ccff8b4d21b7b08"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
 "checksum crossbeam-epoch 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
@@ -1858,7 +1878,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum curve25519-dalek 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum dtoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
-"checksum ed25519-dalek 1.0.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)" = "978710b352437433c97b2bff193f2fb1dfd58a093f863dd95e225a19baa599a2"
+"checksum ed25519 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bf038a7b6fd7ef78ad3348b63f3a17550877b0e28f8d68bcc94894d1412158bc"
+"checksum ed25519-dalek 1.0.0-pre.4 (registry+https://github.com/rust-lang/crates.io-index)" = "21a8a37f4e8b35af971e6db5e3897e7a6344caa3f92f6544f88125a1f5f0035a"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum encoding_rs 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "e8ac63f94732332f44fe654443c46f6375d1939684c17b0afb6cb56b0456e171"
 "checksum env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
@@ -1964,13 +1985,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)" = "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c"
 "checksum serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 "checksum sha2 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
+"checksum signature 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
 "checksum socket2 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)" = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
-"checksum solana-crate-features 1.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "b3a7c8c63c914172560a4b77398fd71ff0a10f4bf5aad73934abfb5a4f6594f7"
-"checksum solana-logger 1.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "d09a703cfdb8a9d391084df724e00b0bdaeb79040ce830f6da9a111f7f4218e8"
-"checksum solana-sdk 1.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "cae779f912f1cbe2fe91df656ecc5ccdda9dd3378c0934f4390b7ba33501b3dc"
-"checksum solana-sdk-macro 1.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "8924af69f2685287988a530014c3268d78d6ce3fe4a1a61f87537c545afa8427"
+"checksum solana-crate-features 1.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "610ba71932d0bf4abf88eabb081ee43fa1ee6bb5137c4fa6776ea9dd8630ca5c"
+"checksum solana-logger 1.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "bc703cb2807e9d713f70df32ac8c3a7a9c8af437dd0d468b1b77cfd8e8b4cbc8"
+"checksum solana-sdk 1.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "a556c1b456609b760ff47b933912f27563ea8a9a1692864cbc1014c02f5b981e"
+"checksum solana-sdk-macro 1.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "38bc386020de692562a29c0696a71c14a3d94455a9a785a97c7b254c38d6a2c8"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
@@ -2032,3 +2054,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum winreg 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
+"checksum zeroize_derive 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"

--- a/memo/Cargo.toml
+++ b/memo/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "spl-memo"
-version = "1.0.4"
+version = "1.0.7"
 description = "Solana Program Library Memo"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -17,7 +17,7 @@ program = ["solana-sdk/program"]
 default = ["solana-sdk/default"]
 
 [dependencies]
-solana-sdk = { version = "=1.2.13", default-features = false, optional = true }
+solana-sdk = { version = "1.2.17", default-features = false, optional = true }
 
 [lib]
 name = "spl_memo"

--- a/token-swap/Cargo.lock
+++ b/token-swap/Cargo.lock
@@ -226,15 +226,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clear_on_drop"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9cc5db465b294c3fa986d5bbb0f3017cd850bff6dd6c52f9ccff8b4d21b7b08"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,16 +321,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
-name = "ed25519-dalek"
-version = "1.0.0-pre.3"
+name = "ed25519"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978710b352437433c97b2bff193f2fb1dfd58a093f863dd95e225a19baa599a2"
+checksum = "bf038a7b6fd7ef78ad3348b63f3a17550877b0e28f8d68bcc94894d1412158bc"
 dependencies = [
- "clear_on_drop",
+ "serde",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "1.0.0-pre.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a8a37f4e8b35af971e6db5e3897e7a6344caa3f92f6544f88125a1f5f0035a"
+dependencies = [
  "curve25519-dalek",
+ "ed25519",
  "rand",
  "serde",
  "sha2",
+ "zeroize",
 ]
 
 [[package]]
@@ -1359,6 +1361,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
+
+[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,9 +1395,9 @@ dependencies = [
 
 [[package]]
 name = "solana-crate-features"
-version = "1.2.15"
+version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a7c8c63c914172560a4b77398fd71ff0a10f4bf5aad73934abfb5a4f6594f7"
+checksum = "610ba71932d0bf4abf88eabb081ee43fa1ee6bb5137c4fa6776ea9dd8630ca5c"
 dependencies = [
  "backtrace",
  "bytes 0.4.12",
@@ -1412,9 +1420,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.2.15"
+version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d09a703cfdb8a9d391084df724e00b0bdaeb79040ce830f6da9a111f7f4218e8"
+checksum = "bc703cb2807e9d713f70df32ac8c3a7a9c8af437dd0d468b1b77cfd8e8b4cbc8"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -1423,9 +1431,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.2.13"
+version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae779f912f1cbe2fe91df656ecc5ccdda9dd3378c0934f4390b7ba33501b3dc"
+checksum = "a556c1b456609b760ff47b933912f27563ea8a9a1692864cbc1014c02f5b981e"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -1460,9 +1468,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.2.13"
+version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8924af69f2685287988a530014c3268d78d6ce3fe4a1a61f87537c545afa8427"
+checksum = "38bc386020de692562a29c0696a71c14a3d94455a9a785a97c7b254c38d6a2c8"
 dependencies = [
  "bs58",
  "proc-macro2 1.0.18",
@@ -1479,7 +1487,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spl-token"
-version = "1.0.3"
+version = "1.0.6"
 dependencies = [
  "cbindgen",
  "num-derive",
@@ -2165,3 +2173,18 @@ name = "zeroize"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
+dependencies = [
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.33",
+ "synstructure",
+]

--- a/token-swap/Cargo.toml
+++ b/token-swap/Cargo.toml
@@ -21,7 +21,7 @@ default = ["solana-sdk/default", "spl-token/default"]
 num-derive = "0.3"
 num-traits = "0.2"
 remove_dir_all = "=0.5.0"
-solana-sdk = { version = "=1.2.13", default-features = false, optional = true }
+solana-sdk = { version = "1.2.17", default-features = false, optional = true }
 spl-token = { path = "../token", default-features = false, optional = true }
 thiserror = "1.0"
 

--- a/token-swap/js/cli/token-swap-test.js
+++ b/token-swap/js/cli/token-swap-test.js
@@ -111,7 +111,7 @@ export async function createTokenSwap(): Promise<void> {
   owner = await newAccountWithLamports(connection, 100000000000 /* wag */);
   const tokenSwapAccount = new Account();
   authority = await PublicKey.createProgramAddress(
-    [tokenSwapAccount.publicKey.toString().substring(0, 32)],
+    [tokenSwapAccount.publicKey.toBuffer()],
     tokenSwapProgramId
   );
 

--- a/token-swap/js/package-lock.json
+++ b/token-swap/js/package-lock.json
@@ -4032,8 +4032,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",

--- a/token-swap/js/package.json
+++ b/token-swap/js/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/solana-labs/solana-program-library"
   },
-  "testnetDefaultChannel": "v1.2.12",
+  "testnetDefaultChannel": "v1.2.17",
   "scripts": {
     "start": "babel-node --ignore node_modules cli/main.js",
     "lint": "npm run pretty && eslint .",

--- a/token-swap/src/processor.rs
+++ b/token-swap/src/processor.rs
@@ -80,7 +80,7 @@ impl State {
 
     /// Calculates the authority id by generating a program address.
     pub fn authority_id(program_id: &Pubkey, my_info: &Pubkey) -> Result<Pubkey, Error> {
-        Pubkey::create_program_address(&[&my_info.to_string()[..32]], program_id)
+        Pubkey::create_program_address(&[&my_info.to_bytes()[..32]], program_id)
             .or(Err(Error::InvalidProgramAddress))
     }
     /// Issue a spl_token `Burn` instruction.
@@ -92,8 +92,8 @@ impl State {
         authority: &Pubkey,
         amount: u64,
     ) -> Result<(), ProgramError> {
-        let swap_string = swap.to_string();
-        let signers = &[&[&swap_string[..32]][..]];
+        let swap_bytes = swap.to_bytes();
+        let signers = &[&[&swap_bytes[..32]][..]];
         let ix =
             spl_token::instruction::burn(token_program_id, burn_account, authority, &[], amount)?;
         invoke_signed(&ix, accounts, signers)
@@ -109,8 +109,8 @@ impl State {
         authority: &Pubkey,
         amount: u64,
     ) -> Result<(), ProgramError> {
-        let swap_string = swap.to_string();
-        let signers = &[&[&swap_string[..32]][..]];
+        let swap_bytes = swap.to_bytes();
+        let signers = &[&[&swap_bytes[..32]][..]];
         let ix = spl_token::instruction::mint_to(
             token_program_id,
             mint,
@@ -132,8 +132,8 @@ impl State {
         authority: &Pubkey,
         amount: u64,
     ) -> Result<(), ProgramError> {
-        let swap_string = swap.to_string();
-        let signers = &[&[&swap_string[..32]][..]];
+        let swap_bytes = swap.to_bytes();
+        let signers = &[&[&swap_bytes[..32]][..]];
         let ix = spl_token::instruction::transfer(
             token_program_id,
             source,
@@ -452,7 +452,7 @@ const SWAP_PROGRAM_ID: Pubkey = Pubkey::new_from_array([2u8; 32]);
 pub fn invoke_signed<'a>(
     instruction: &Instruction,
     account_infos: &[AccountInfo<'a>],
-    signers_seeds: &[&[&str]],
+    signers_seeds: &[&[&[u8]]],
 ) -> ProgramResult {
     let mut new_account_infos = vec![];
     for meta in instruction.accounts.iter() {

--- a/token/Cargo.lock
+++ b/token/Cargo.lock
@@ -226,15 +226,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clear_on_drop"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9cc5db465b294c3fa986d5bbb0f3017cd850bff6dd6c52f9ccff8b4d21b7b08"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,16 +321,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
-name = "ed25519-dalek"
-version = "1.0.0-pre.3"
+name = "ed25519"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978710b352437433c97b2bff193f2fb1dfd58a093f863dd95e225a19baa599a2"
+checksum = "bf038a7b6fd7ef78ad3348b63f3a17550877b0e28f8d68bcc94894d1412158bc"
 dependencies = [
- "clear_on_drop",
+ "serde",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "1.0.0-pre.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a8a37f4e8b35af971e6db5e3897e7a6344caa3f92f6544f88125a1f5f0035a"
+dependencies = [
  "curve25519-dalek",
+ "ed25519",
  "rand",
  "serde",
  "sha2",
+ "zeroize",
 ]
 
 [[package]]
@@ -1359,6 +1361,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
+
+[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,9 +1395,9 @@ dependencies = [
 
 [[package]]
 name = "solana-crate-features"
-version = "1.2.15"
+version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a7c8c63c914172560a4b77398fd71ff0a10f4bf5aad73934abfb5a4f6594f7"
+checksum = "610ba71932d0bf4abf88eabb081ee43fa1ee6bb5137c4fa6776ea9dd8630ca5c"
 dependencies = [
  "backtrace",
  "bytes 0.4.12",
@@ -1412,9 +1420,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.2.15"
+version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d09a703cfdb8a9d391084df724e00b0bdaeb79040ce830f6da9a111f7f4218e8"
+checksum = "bc703cb2807e9d713f70df32ac8c3a7a9c8af437dd0d468b1b77cfd8e8b4cbc8"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -1423,9 +1431,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.2.13"
+version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae779f912f1cbe2fe91df656ecc5ccdda9dd3378c0934f4390b7ba33501b3dc"
+checksum = "a556c1b456609b760ff47b933912f27563ea8a9a1692864cbc1014c02f5b981e"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -1460,9 +1468,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.2.13"
+version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8924af69f2685287988a530014c3268d78d6ce3fe4a1a61f87537c545afa8427"
+checksum = "38bc386020de692562a29c0696a71c14a3d94455a9a785a97c7b254c38d6a2c8"
 dependencies = [
  "bs58",
  "proc-macro2 1.0.18",
@@ -1479,7 +1487,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spl-token"
-version = "1.0.3"
+version = "1.0.6"
 dependencies = [
  "cbindgen",
  "num-derive",
@@ -2152,3 +2160,18 @@ name = "zeroize"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
+dependencies = [
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.31",
+ "synstructure",
+]

--- a/token/Cargo.toml
+++ b/token/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "spl-token"
-version = "1.0.3"
+version = "1.0.6"
 description = "Solana Program Library Token"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -21,7 +21,7 @@ default = ["solana-sdk/default"]
 num-derive = "0.3"
 num-traits = "0.2"
 remove_dir_all = "=0.5.0"
-solana-sdk = { version = "=1.2.13", default-features = false, optional = true }
+solana-sdk = { version = "1.2.17", default-features = false, optional = true }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/token/inc/token.h
+++ b/token/inc/token.h
@@ -9,7 +9,7 @@
 
 #define TOKEN_MAJOR_VERSION 1
 #define TOKEN_MINOR_VERSION 0
-#define TOKEN_PATCH_VERSION 3
+#define TOKEN_PATCH_VERSION 6
 
 /**
  * Maximum number of multisignature signers (max N)

--- a/token/js/package.json
+++ b/token/js/package.json
@@ -22,7 +22,7 @@
     "/lib",
     "/module.flow.js"
   ],
-  "testnetDefaultChannel": "v1.2.12",
+  "testnetDefaultChannel": "v1.2.17",
   "scripts": {
     "build": "rollup -c",
     "start": "babel-node cli/main.js",


### PR DESCRIPTION
Fixing solana-sdk at 1.2.13 breaks crates.io publishing from the monorepo, `cargo publish` does not permit multiple version fo solana-sdk to exist.  Instead allow the version of solana-sdk to float upwards to match the monorepo's current version