### PR TITLE
Add tag to C enum variants

### DIFF
--- a/token/build.rs
+++ b/token/build.rs
@@ -27,6 +27,10 @@ fn main() {
         tab_width: 4,
         cpp_compat: true,
         pragma_once: true,
+        enumeration: cbindgen::EnumConfig {
+            prefix_with_name: true,
+            ..cbindgen::EnumConfig::default()
+        },
         export: cbindgen::ExportConfig {
             prefix: Some("Token_".to_string()),
             include: vec![

--- a/token/inc/token.h
+++ b/token/inc/token.h
@@ -42,7 +42,7 @@ typedef enum Token_TokenInstruction_Tag {
      *                      present then further minting is supported.
      *
      */
-    InitializeMint,
+    Token_TokenInstruction_InitializeMint,
     /**
      * Initializes a new account to hold tokens.  If this account is associated with the native mint
      * then the token balance of the initialized account will be equal to the amount of SOL in the account.
@@ -57,7 +57,7 @@ typedef enum Token_TokenInstruction_Tag {
      *   1. `[]` The mint this account will be associated with.
      *   2. `[]` The new account's owner/multisignature.
      */
-    InitializeAccount,
+    Token_TokenInstruction_InitializeAccount,
     /**
      * Initializes a multisignature account with N provided signers.
      *
@@ -74,7 +74,7 @@ typedef enum Token_TokenInstruction_Tag {
      *   0. `[writable]` The multisignature account to initialize.
      *   1. ..1+N. `[]` The signer accounts, must equal to N where 1 <= N <= 11.
      */
-    InitializeMultisig,
+    Token_TokenInstruction_InitializeMultisig,
     /**
      * Transfers tokens from one account to another either directly or via a delegate.  If this
      * account is associated with the native mint then equal amounts of SOL and Tokens will be
@@ -93,7 +93,7 @@ typedef enum Token_TokenInstruction_Tag {
      *   2. '[]' The source account's multisignature owner/delegate.
      *   3. ..3+M '[signer]' M signer accounts.
      */
-    Transfer,
+    Token_TokenInstruction_Transfer,
     /**
      * Approves a delegate.  A delegate is given the authority over
      * tokens on behalf of the source account's owner.
@@ -110,7 +110,7 @@ typedef enum Token_TokenInstruction_Tag {
      *   2. '[]' The source account's multisignature owner.
      *   3. ..3+M '[signer]' M signer accounts
      */
-    Approve,
+    Token_TokenInstruction_Approve,
     /**
      * Revokes the delegate's authority.
      *
@@ -125,7 +125,7 @@ typedef enum Token_TokenInstruction_Tag {
      *   1. '[]' The source account's multisignature owner.
      *   2. ..2+M '[signer]' M signer accounts
      */
-    Revoke,
+    Token_TokenInstruction_Revoke,
     /**
      * Sets a new owner of a mint or account.
      *
@@ -142,7 +142,7 @@ typedef enum Token_TokenInstruction_Tag {
      *   2. `[]` The mint's or account's multisignature owner.
      *   3. ..3+M '[signer]' M signer accounts
      */
-    SetOwner,
+    Token_TokenInstruction_SetOwner,
     /**
      * Mints new tokens to an account.  The native mint does not support minting.
      *
@@ -159,7 +159,7 @@ typedef enum Token_TokenInstruction_Tag {
      *   2. `[]` The mint's multisignature owner.
      *   3. ..3+M '[signer]' M signer accounts.
      */
-    MintTo,
+    Token_TokenInstruction_MintTo,
     /**
      * Burns tokens by removing them from an account.  `Burn` does not support accounts
      * associated with the native mint, use `CloseAccount` instead.
@@ -175,7 +175,7 @@ typedef enum Token_TokenInstruction_Tag {
      *   1. `[]` The account's multisignature owner/delegate.
      *   2. ..2+M '[signer]' M signer accounts.
      */
-    Burn,
+    Token_TokenInstruction_Burn,
     /**
      * Close an account by transferring all its SOL to the destination account.
      * Non-native accounts may only be closed if its token amount is zero.
@@ -193,10 +193,10 @@ typedef enum Token_TokenInstruction_Tag {
      *   2. `[]` The account's multisignature owner.
      *   3. ..3+M '[signer]' M signer accounts.
      */
-    CloseAccount,
+    Token_TokenInstruction_CloseAccount,
 } Token_TokenInstruction_Tag;
 
-typedef struct Token_InitializeMint_Body {
+typedef struct Token_TokenInstruction_Token_InitializeMint_Body {
     /**
      * Initial amount of tokens to mint.
      */
@@ -205,52 +205,52 @@ typedef struct Token_InitializeMint_Body {
      * Number of base 10 digits to the right of the decimal place.
      */
     uint8_t decimals;
-} Token_InitializeMint_Body;
+} Token_TokenInstruction_Token_InitializeMint_Body;
 
-typedef struct Token_InitializeMultisig_Body {
+typedef struct Token_TokenInstruction_Token_InitializeMultisig_Body {
     /**
      * The number of signers (M) required to validate this multisignature account.
      */
     uint8_t m;
-} Token_InitializeMultisig_Body;
+} Token_TokenInstruction_Token_InitializeMultisig_Body;
 
-typedef struct Token_Transfer_Body {
+typedef struct Token_TokenInstruction_Token_Transfer_Body {
     /**
      * The amount of tokens to transfer.
      */
     uint64_t amount;
-} Token_Transfer_Body;
+} Token_TokenInstruction_Token_Transfer_Body;
 
-typedef struct Token_Approve_Body {
+typedef struct Token_TokenInstruction_Token_Approve_Body {
     /**
      * The amount of tokens the delegate is approved for.
      */
     uint64_t amount;
-} Token_Approve_Body;
+} Token_TokenInstruction_Token_Approve_Body;
 
-typedef struct Token_MintTo_Body {
+typedef struct Token_TokenInstruction_Token_MintTo_Body {
     /**
      * The amount of new tokens to mint.
      */
     uint64_t amount;
-} Token_MintTo_Body;
+} Token_TokenInstruction_Token_MintTo_Body;
 
-typedef struct Token_Burn_Body {
+typedef struct Token_TokenInstruction_Token_Burn_Body {
     /**
      * The amount of tokens to burn.
      */
     uint64_t amount;
-} Token_Burn_Body;
+} Token_TokenInstruction_Token_Burn_Body;
 
 typedef struct Token_TokenInstruction {
     Token_TokenInstruction_Tag tag;
     union {
-        Token_InitializeMint_Body initialize_mint;
-        Token_InitializeMultisig_Body initialize_multisig;
-        Token_Transfer_Body transfer;
-        Token_Approve_Body approve;
-        Token_MintTo_Body mint_to;
-        Token_Burn_Body burn;
+        Token_TokenInstruction_Token_InitializeMint_Body initialize_mint;
+        Token_TokenInstruction_Token_InitializeMultisig_Body initialize_multisig;
+        Token_TokenInstruction_Token_Transfer_Body transfer;
+        Token_TokenInstruction_Token_Approve_Body approve;
+        Token_TokenInstruction_Token_MintTo_Body mint_to;
+        Token_TokenInstruction_Token_Burn_Body burn;
     };
 } Token_TokenInstruction;
 
@@ -263,21 +263,21 @@ typedef enum Token_COption_Pubkey_Tag {
     /**
      * No value
      */
-    None_Pubkey,
+    Token_COption_Pubkey_None_Pubkey,
     /**
      * Some value `T`
      */
-    Some_Pubkey,
+    Token_COption_Pubkey_Some_Pubkey,
 } Token_COption_Pubkey_Tag;
 
-typedef struct Token_Some_Body_Pubkey {
+typedef struct Token_COption_Pubkey_Token_Some_Body_Pubkey {
     Token_Pubkey _0;
-} Token_Some_Body_Pubkey;
+} Token_COption_Pubkey_Token_Some_Body_Pubkey;
 
 typedef struct Token_COption_Pubkey {
     Token_COption_Pubkey_Tag tag;
     union {
-        Token_Some_Body_Pubkey some;
+        Token_COption_Pubkey_Token_Some_Body_Pubkey some;
     };
 } Token_COption_Pubkey;
 


### PR DESCRIPTION
Autogenerated C enum variants may conflict with other programs, tag them with the enum name.