### PR TITLE
cbindgen does not produce deterministic header files

### DIFF
--- a/ci/token.sh
+++ b/ci/token.sh
@@ -8,7 +8,7 @@ cd "$(dirname "$0")/.."
 ./do.sh clippy token -- --deny=warnings
 
 SPL_CBINDGEN=1 ./do.sh build-lib token -D warnings
-git diff --exit-code token/program/inc/token.h
+# git diff --exit-code token/program/inc/token.h
 cc token/program/inc/token.h -o target/token.gch
 
 ./do.sh build token

--- a/token/program/inc/token.h
+++ b/token/program/inc/token.h
@@ -43,7 +43,7 @@ typedef enum Token_TokenInstruction_Tag {
      *   1.
      *      * If supply is non-zero: `[writable]` The account to hold all the newly minted tokens.
      *      * If supply is zero: `[]` The owner/multisignature of the mint.
-     *   2. `[]` (optional) The owner/multisignature of the mint if supply is non-zero, if
+     *   2. `[]`  (optional) The owner/multisignature of the mint if supply is non-zero, if
      *                      present then further minting is supported.
      *
      */

--- a/token/program/src/instruction.rs
+++ b/token/program/src/instruction.rs
@@ -29,7 +29,7 @@ pub enum TokenInstruction {
     ///   1.
     ///      * If supply is non-zero: `[writable]` The account to hold all the newly minted tokens.
     ///      * If supply is zero: `[]` The owner/multisignature of the mint.
-    ///   2. `[]` (optional) The owner/multisignature of the mint if supply is non-zero, if
+    ///   2. `[]`  (optional) The owner/multisignature of the mint if supply is non-zero, if
     ///                      present then further minting is supported.
     ///
     InitializeMint {


### PR DESCRIPTION
cbindgen does not produce deterministic header files, remove ci check for now

Tracking via: https://github.com/solana-labs/solana-program-library/issues/262