### PR TITLE
Restore generated token.h check

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -42,7 +42,7 @@ _ "memo_test" ./do.sh test memo
 )
 
 # Check generated C headers
-#_ "diff token.h" git diff --exit-code token/program/inc/token.h
+_ "diff_token.h" git diff --exit-code token/program/inc/token.h
 _ "cc_token.sh" cc token/program/inc/token.h -o target/token.gch
 
 _ "diff_token-swap.h" git diff --exit-code token-swap/program/inc/token-swap.h

--- a/token/program/build.rs
+++ b/token/program/build.rs
@@ -47,6 +47,7 @@ fn main() {
                 "Account".to_string(),
                 "Multisig".to_string(),
             ],
+            exclude: vec!["DECIMALS".to_string()],
             ..cbindgen::ExportConfig::default()
         },
         parse: cbindgen::ParseConfig {

--- a/token/program/inc/token.h
+++ b/token/program/inc/token.h
@@ -43,7 +43,7 @@ typedef enum Token_TokenInstruction_Tag {
      *   1.
      *      * If supply is non-zero: `[writable]` The account to hold all the newly minted tokens.
      *      * If supply is zero: `[]` The owner/multisignature of the mint.
-     *   2. `[]`  (optional) The owner/multisignature of the mint if supply is non-zero, if
+     *   2. `[]` (optional) The owner/multisignature of the mint if supply is non-zero, if
      *                      present then further minting is supported.
      *
      */

--- a/token/program/inc/token.h
+++ b/token/program/inc/token.h
@@ -12,11 +12,6 @@
 #define TOKEN_PATCH_VERSION 7
 
 /**
- * There are 10^9 lamports in one SOL
- */
-#define Token_DECIMALS 9
-
-/**
  * Maximum number of multisignature signers (max N)
  */
 #define Token_MAX_SIGNERS 11

--- a/token/program/src/instruction.rs
+++ b/token/program/src/instruction.rs
@@ -29,7 +29,7 @@ pub enum TokenInstruction {
     ///   1.
     ///      * If supply is non-zero: `[writable]` The account to hold all the newly minted tokens.
     ///      * If supply is zero: `[]` The owner/multisignature of the mint.
-    ///   2. `[]`  (optional) The owner/multisignature of the mint if supply is non-zero, if
+    ///   2. `[]` (optional) The owner/multisignature of the mint if supply is non-zero, if
     ///                      present then further minting is supported.
     ///
     InitializeMint {


### PR DESCRIPTION
Exclude `Token_DECIMALS` and extra white space to work around weird cbindgen non-determinism

Fixes #262