### PR TITLE
Add capability to freeze token Accounts

### DIFF
--- a/token/program2/inc/token2.h
+++ b/token/program2/inc/token2.h
@@ -22,6 +22,85 @@
 #define Token_MIN_SIGNERS 1
 
 /**
+ * Account state.
+ */
+enum Token_AccountState
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+    /**
+     * Account is not yet initialized
+     */
+    Token_AccountState_Uninitialized,
+    /**
+     * Account is initialized; the account owner and/or delegate may perform permitted operations
+     * on this account
+     */
+    Token_AccountState_Initialized,
+    /**
+     * Account has been frozen by the mint freeze authority. Neither the account owner nor
+     * the delegate are able to perform operations on this account.
+     */
+    Token_AccountState_Frozen,
+};
+#ifndef __cplusplus
+typedef uint8_t Token_AccountState;
+#endif // __cplusplus
+
+/**
+ * Specifies the authority type for SetAuthority instructions
+ */
+enum Token_AuthorityType
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+    /**
+     * Authority to mint new tokens
+     */
+    Token_AuthorityType_MintTokens,
+    /**
+     * Authority to freeze any account associated with the Mint
+     */
+    Token_AuthorityType_FreezeAccount,
+    /**
+     * Holder of a given token account
+     */
+    Token_AuthorityType_AccountHolder,
+};
+#ifndef __cplusplus
+typedef uint8_t Token_AuthorityType;
+#endif // __cplusplus
+
+typedef uint8_t Token_Pubkey[32];
+
+/**
+ * A C representation of Rust's `std::option::Option`
+ */
+typedef enum Token_COption_Pubkey_Tag {
+    /**
+     * No value
+     */
+    Token_COption_Pubkey_None_Pubkey,
+    /**
+     * Some value `T`
+     */
+    Token_COption_Pubkey_Some_Pubkey,
+} Token_COption_Pubkey_Tag;
+
+typedef struct Token_COption_Pubkey_Token_Some_Body_Pubkey {
+    Token_Pubkey _0;
+} Token_COption_Pubkey_Token_Some_Body_Pubkey;
+
+typedef struct Token_COption_Pubkey {
+    Token_COption_Pubkey_Tag tag;
+    union {
+        Token_COption_Pubkey_Token_Some_Body_Pubkey some;
+    };
+} Token_COption_Pubkey;
+
+/**
  * Instructions supported by the token program.
  */
 typedef enum Token_TokenInstruction_Tag {
@@ -35,11 +114,7 @@ typedef enum Token_TokenInstruction_Tag {
      * Accounts expected by this instruction:
      *
      *   0. `[writable]` The mint to initialize.
-     *   1.
-     *      * If supply is non-zero: `[writable]` The account to hold all the newly minted tokens.
-     *      * If supply is zero: `[]` The owner/multisignature of the mint.
-     *   2. `[]` (optional) The owner/multisignature of the mint if supply is non-zero, if
-     *                      present then further minting is supported.
+     *   1. If supply is non-zero: `[writable]` The account to hold all the newly minted tokens.
      *
      */
     Token_TokenInstruction_InitializeMint,
@@ -127,36 +202,36 @@ typedef enum Token_TokenInstruction_Tag {
      */
     Token_TokenInstruction_Revoke,
     /**
-     * Sets a new owner of a mint or account.
+     * Sets a new authority of a mint or account.
      *
      * Accounts expected by this instruction:
      *
-     *   * Single owner
-     *   0. `[writable]` The mint or account to change the owner of.
-     *   1. `[]` The new owner/delegate/multisignature.
-     *   2. `[signer]` The owner of the mint or account.
+     *   * Single authority
+     *   0. `[writable]` The mint or account to change the authority of.
+     *   1. `[]` The new authority/multisignature.
+     *   2. `[signer]` The current authority of the mint or account.
      *
-     *   * Multisignature owner
-     *   0. `[writable]` The mint or account to change the owner of.
-     *   1. `[]` The new owner/delegate/multisignature.
-     *   2. `[]` The mint's or account's multisignature owner.
+     *   * Multisignature authority
+     *   0. `[writable]` The mint or account to change the authority of.
+     *   1. `[]` The new authority/multisignature.
+     *   2. `[]` The mint's or account's multisignature authority.
      *   3. ..3+M '[signer]' M signer accounts
      */
-    Token_TokenInstruction_SetOwner,
+    Token_TokenInstruction_SetAuthority,
     /**
      * Mints new tokens to an account.  The native mint does not support minting.
      *
      * Accounts expected by this instruction:
      *
-     *   * Single owner
+     *   * Single authority
      *   0. `[writable]` The mint.
      *   1. `[writable]` The account to mint tokens to.
-     *   2. `[signer]` The mint's owner.
+     *   2. `[signer]` The mint's mint-tokens authority.
      *
-     *   * Multisignature owner
+     *   * Multisignature authority
      *   0. `[writable]` The mint.
      *   1. `[writable]` The account to mint tokens to.
-     *   2. `[]` The mint's multisignature owner.
+     *   2. `[]` The mint's multisignature mint-tokens authority.
      *   3. ..3+M '[signer]' M signer accounts.
      */
     Token_TokenInstruction_MintTo,
@@ -194,6 +269,24 @@ typedef enum Token_TokenInstruction_Tag {
      *   3. ..3+M '[signer]' M signer accounts.
      */
     Token_TokenInstruction_CloseAccount,
+    /**
+     * Freeze an Initialized account or unfreeze a Frozen account, using the Mint's
+     * freeze_authority (if set).
+     *
+     * Accounts expected by this instruction:
+     *
+     *   * Single owner
+     *   0. `[writable]` The account to freeze.
+     *   1. '[]' The token mint.
+     *   2. `[signer]` The mint freeze authority.
+     *
+     *   * Multisignature owner
+     *   0. `[writable]` The account to freeze.
+     *   1. '[]' The token mint.
+     *   2. `[]` The mint's multisignature freeze authority.
+     *   3. ..3+M '[signer]' M signer accounts.
+     */
+    Token_TokenInstruction_FreezeAccount,
 } Token_TokenInstruction_Tag;
 
 typedef struct Token_TokenInstruction_Token_InitializeMint_Body {
@@ -205,6 +298,15 @@ typedef struct Token_TokenInstruction_Token_InitializeMint_Body {
      * Number of base 10 digits to the right of the decimal place.
      */
     uint8_t decimals;
+    /**
+     * The authority/multisignature to mint tokens, if supply is non-zero. If present,
+     * further minting is supported.
+     */
+    Token_COption_Pubkey mint_authority;
+    /**
+     * The freeze authority/multisignature of the mint.
+     */
+    Token_COption_Pubkey freeze_authority;
 } Token_TokenInstruction_Token_InitializeMint_Body;
 
 typedef struct Token_TokenInstruction_Token_InitializeMultisig_Body {
@@ -228,6 +330,13 @@ typedef struct Token_TokenInstruction_Token_Approve_Body {
     uint64_t amount;
 } Token_TokenInstruction_Token_Approve_Body;
 
+typedef struct Token_TokenInstruction_Token_SetAuthority_Body {
+    /**
+     * The type of authority to update.
+     */
+    Token_AuthorityType authority_type;
+} Token_TokenInstruction_Token_SetAuthority_Body;
+
 typedef struct Token_TokenInstruction_Token_MintTo_Body {
     /**
      * The amount of new tokens to mint.
@@ -242,6 +351,14 @@ typedef struct Token_TokenInstruction_Token_Burn_Body {
     uint64_t amount;
 } Token_TokenInstruction_Token_Burn_Body;
 
+typedef struct Token_TokenInstruction_Token_FreezeAccount_Body {
+    /**
+     * Explicitly: whether to freeze the account if it is Initialized. `false` means to
+     * unfreeze if the account is Frozen.
+     */
+    bool freeze;
+} Token_TokenInstruction_Token_FreezeAccount_Body;
+
 typedef struct Token_TokenInstruction {
     Token_TokenInstruction_Tag tag;
     union {
@@ -249,48 +366,23 @@ typedef struct Token_TokenInstruction {
         Token_TokenInstruction_Token_InitializeMultisig_Body initialize_multisig;
         Token_TokenInstruction_Token_Transfer_Body transfer;
         Token_TokenInstruction_Token_Approve_Body approve;
+        Token_TokenInstruction_Token_SetAuthority_Body set_authority;
         Token_TokenInstruction_Token_MintTo_Body mint_to;
         Token_TokenInstruction_Token_Burn_Body burn;
+        Token_TokenInstruction_Token_FreezeAccount_Body freeze_account;
     };
 } Token_TokenInstruction;
-
-typedef uint8_t Token_Pubkey[32];
-
-/**
- * A C representation of Rust's `std::option::Option`
- */
-typedef enum Token_COption_Pubkey_Tag {
-    /**
-     * No value
-     */
-    Token_COption_Pubkey_None_Pubkey,
-    /**
-     * Some value `T`
-     */
-    Token_COption_Pubkey_Some_Pubkey,
-} Token_COption_Pubkey_Tag;
-
-typedef struct Token_COption_Pubkey_Token_Some_Body_Pubkey {
-    Token_Pubkey _0;
-} Token_COption_Pubkey_Token_Some_Body_Pubkey;
-
-typedef struct Token_COption_Pubkey {
-    Token_COption_Pubkey_Tag tag;
-    union {
-        Token_COption_Pubkey_Token_Some_Body_Pubkey some;
-    };
-} Token_COption_Pubkey;
 
 /**
  * Mint data.
  */
 typedef struct Token_Mint {
     /**
-     * Optional owner, used to mint new tokens.  The owner may only
-     * be provided during mint creation.  If no owner is present then the mint
-     * has a fixed supply and no further tokens may be minted.
+     * Optional authority used to mint new tokens. The mint authority may only be provided during
+     * mint creation. If no mint authority is present then the mint has a fixed supply and no
+     * further tokens may be minted.
      */
-    Token_COption_Pubkey owner;
+    Token_COption_Pubkey mint_authority;
     /**
      * Number of base 10 digits to the right of the decimal place.
      */
@@ -299,6 +391,10 @@ typedef struct Token_Mint {
      * Is `true` if this structure has been initialized
      */
     bool is_initialized;
+    /**
+     * Optional authority to freeze token accounts.
+     */
+    Token_COption_Pubkey freeze_authority;
 } Token_Mint;
 
 /**
@@ -323,9 +419,9 @@ typedef struct Token_Account {
      */
     Token_COption_Pubkey delegate;
     /**
-     * Is `true` if this structure has been initialized
+     * Whether the account has been initialized or frozen
      */
-    bool is_initialized;
+    Token_AccountState is_initialized;
     /**
      * Is this a native token
      */

--- a/token/program2/src/error.rs
+++ b/token/program2/src/error.rs
@@ -55,6 +55,9 @@ pub enum TokenError {
     /// This token mint cannot freeze accounts.
     #[error("This token mint cannot freeze accounts")]
     CannotFreeze,
+    /// Account is frozen; all account operations will fail
+    #[error("Account is frozen")]
+    AccountFrozen,
 }
 impl From<TokenError> for ProgramError {
     fn from(e: TokenError) -> Self {

--- a/token/program2/src/error.rs
+++ b/token/program2/src/error.rs
@@ -46,6 +46,9 @@ pub enum TokenError {
     /// Operation overflowed
     #[error("Operation overflowed")]
     Overflow,
+    /// An owner is required if mint can freeze token accounts.
+    #[error("An owner is required if mint can freeze token accounts")]
+    OwnerRequiredIfCanFreeze,
 }
 impl From<TokenError> for ProgramError {
     fn from(e: TokenError) -> Self {

--- a/token/program2/src/error.rs
+++ b/token/program2/src/error.rs
@@ -43,15 +43,12 @@ pub enum TokenError {
     /// Invalid instruction
     #[error("Invalid instruction")]
     InvalidInstruction,
-    /// State is invalid for request operation.
-    #[error("State is invalid for request operation")]
+    /// State is invalid for requested operation.
+    #[error("State is invalid for requested operation")]
     InvalidState,
     /// Operation overflowed
     #[error("Operation overflowed")]
     Overflow,
-    /// An owner is required if mint can freeze token accounts.
-    #[error("An owner is required if mint can freeze token accounts")]
-    OwnerRequiredIfCanFreeze,
     /// Account does not support specified authority type.
     #[error("Account does not support specified authority type")]
     AuthorityTypeNotSupported,

--- a/token/program2/src/error.rs
+++ b/token/program2/src/error.rs
@@ -43,6 +43,9 @@ pub enum TokenError {
     /// Invalid instruction
     #[error("Invalid instruction")]
     InvalidInstruction,
+    /// State is invalid for request operation.
+    #[error("State is invalid for request operation")]
+    InvalidState,
     /// Operation overflowed
     #[error("Operation overflowed")]
     Overflow,
@@ -54,7 +57,7 @@ pub enum TokenError {
     AuthorityTypeNotSupported,
     /// This token mint cannot freeze accounts.
     #[error("This token mint cannot freeze accounts")]
-    CannotFreeze,
+    MintCannotFreeze,
     /// Account is frozen; all account operations will fail
     #[error("Account is frozen")]
     AccountFrozen,

--- a/token/program2/src/error.rs
+++ b/token/program2/src/error.rs
@@ -49,6 +49,12 @@ pub enum TokenError {
     /// An owner is required if mint can freeze token accounts.
     #[error("An owner is required if mint can freeze token accounts")]
     OwnerRequiredIfCanFreeze,
+    /// Account does not support specified authority type.
+    #[error("Account does not support specified authority type")]
+    AuthorityTypeNotSupported,
+    /// This token mint cannot freeze accounts.
+    #[error("This token mint cannot freeze accounts")]
+    CannotFreeze,
 }
 impl From<TokenError> for ProgramError {
     fn from(e: TokenError) -> Self {

--- a/token/program2/src/instruction.rs
+++ b/token/program2/src/instruction.rs
@@ -206,7 +206,7 @@ pub enum TokenInstruction {
     ///   1. '[]' The token mint.
     ///   2. `[]` The mint's multisignature freeze authority.
     ///   3. ..3+M '[signer]' M signer accounts.
-    ToggleFreeze {
+    FreezeAccount {
         /// Explicitly: whether to freeze the account if it is Initialized. `false` means to
         /// unfreeze if the account is Frozen.
         freeze: bool,
@@ -332,7 +332,7 @@ impl TokenInstruction {
                 }
                 #[allow(clippy::cast_ptr_alignment)]
                 let freeze = unsafe { *(&input[size_of::<u8>()] as *const u8 as *const bool) };
-                Self::ToggleFreeze { freeze }
+                Self::FreezeAccount { freeze }
             }
             _ => return Err(TokenError::InvalidInstruction.into()),
         })
@@ -463,7 +463,7 @@ impl TokenInstruction {
                 output[output_len] = 9;
                 output_len += size_of::<u8>();
             }
-            Self::ToggleFreeze { freeze } => {
+            Self::FreezeAccount { freeze } => {
                 output[output_len] = 10;
                 output_len += size_of::<u8>();
 
@@ -781,8 +781,8 @@ pub fn close_account(
     })
 }
 
-/// Creates a `ToggleFreeze` instruction.
-pub fn toggle_freeze_account(
+/// Creates a `FreezeAccount` instruction.
+pub fn freeze_account(
     token_program_id: &Pubkey,
     account_pubkey: &Pubkey,
     freeze: bool,
@@ -790,7 +790,7 @@ pub fn toggle_freeze_account(
     owner_pubkey: &Pubkey,
     signer_pubkeys: &[&Pubkey],
 ) -> Result<Instruction, ProgramError> {
-    let data = TokenInstruction::ToggleFreeze { freeze }.pack()?;
+    let data = TokenInstruction::FreezeAccount { freeze }.pack()?;
 
     let mut accounts = Vec::with_capacity(3 + signer_pubkeys.len());
     accounts.push(AccountMeta::new(*account_pubkey, false));

--- a/token/program2/src/instruction.rs
+++ b/token/program2/src/instruction.rs
@@ -147,7 +147,7 @@ pub enum TokenInstruction {
     ///   * Single authority
     ///   0. `[writable]` The mint.
     ///   1. `[writable]` The account to mint tokens to.
-    ///   2. `[signer]` The mint's mint-tokens authority.
+    ///   2. `[signer]` The mint's minting authority.
     ///
     ///   * Multisignature authority
     ///   0. `[writable]` The mint.

--- a/token/program2/src/processor.rs
+++ b/token/program2/src/processor.rs
@@ -438,8 +438,8 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes a [ToggleFreeze](enum.TokenInstruction.html) instruction.
-    pub fn process_toggle_freeze_account(
+    /// Processes a [FreezeAccount](enum.TokenInstruction.html) instruction.
+    pub fn process_freeze_account(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
         freeze: bool,
@@ -541,9 +541,9 @@ impl Processor {
                 info!("Instruction: CloseAccount");
                 Self::process_close_account(program_id, accounts)
             }
-            TokenInstruction::ToggleFreeze { freeze } => {
-                info!("Instruction: ToggleFreeze");
-                Self::process_toggle_freeze_account(program_id, accounts, freeze)
+            TokenInstruction::FreezeAccount { freeze } => {
+                info!("Instruction: FreezeAccount");
+                Self::process_freeze_account(program_id, accounts, freeze)
             }
         }
     }
@@ -629,8 +629,8 @@ solana_sdk::program_stubs!();
 mod tests {
     use super::*;
     use crate::instruction::{
-        approve, burn, close_account, initialize_account, initialize_mint, initialize_multisig,
-        mint_to, revoke, set_authority, toggle_freeze_account, transfer, MAX_SIGNERS,
+        approve, burn, close_account, freeze_account, initialize_account, initialize_mint,
+        initialize_multisig, mint_to, revoke, set_authority, transfer, MAX_SIGNERS,
     };
     use solana_sdk::{
         account::Account as SolanaAccount, account_info::create_is_signer_account_infos,
@@ -2251,7 +2251,7 @@ mod tests {
         .unwrap();
         let account_info_iter = &mut signer_accounts.iter_mut();
         do_process_instruction(
-            toggle_freeze_account(
+            freeze_account(
                 &program_id,
                 &account3_key,
                 true,
@@ -2961,7 +2961,7 @@ mod tests {
     }
 
     #[test]
-    fn test_toggle_freeze_account() {
+    fn test_freeze_account() {
         let program_id = pubkey_rand();
         let account_key = pubkey_rand();
         let mut account_account = SolanaAccount::new(0, size_of::<Account>(), &program_id);
@@ -3005,7 +3005,7 @@ mod tests {
         assert_eq!(
             Err(TokenError::MintCannotFreeze.into()),
             do_process_instruction(
-                toggle_freeze_account(&program_id, &account_key, true, &mint_key, &owner_key, &[])
+                freeze_account(&program_id, &account_key, true, &mint_key, &owner_key, &[])
                     .unwrap(),
                 vec![&mut account_account, &mut mint_account, &mut owner_account],
             )
@@ -3017,7 +3017,7 @@ mod tests {
         assert_eq!(
             Err(TokenError::OwnerMismatch.into()),
             do_process_instruction(
-                toggle_freeze_account(&program_id, &account_key, true, &mint_key, &owner2_key, &[])
+                freeze_account(&program_id, &account_key, true, &mint_key, &owner2_key, &[])
                     .unwrap(),
                 vec![&mut account_account, &mut mint_account, &mut owner2_account],
             )
@@ -3027,7 +3027,7 @@ mod tests {
         assert_eq!(
             Err(TokenError::InvalidState.into()),
             do_process_instruction(
-                toggle_freeze_account(
+                freeze_account(
                     &program_id,
                     &account_key,
                     false,
@@ -3042,8 +3042,7 @@ mod tests {
 
         // freeze
         do_process_instruction(
-            toggle_freeze_account(&program_id, &account_key, true, &mint_key, &owner_key, &[])
-                .unwrap(),
+            freeze_account(&program_id, &account_key, true, &mint_key, &owner_key, &[]).unwrap(),
             vec![&mut account_account, &mut mint_account, &mut owner_account],
         )
         .unwrap();
@@ -3054,7 +3053,7 @@ mod tests {
         assert_eq!(
             Err(TokenError::InvalidState.into()),
             do_process_instruction(
-                toggle_freeze_account(&program_id, &account_key, true, &mint_key, &owner2_key, &[])
+                freeze_account(&program_id, &account_key, true, &mint_key, &owner2_key, &[])
                     .unwrap(),
                 vec![&mut account_account, &mut mint_account, &mut owner2_account],
             )
@@ -3062,8 +3061,7 @@ mod tests {
 
         // unfreeze
         do_process_instruction(
-            toggle_freeze_account(&program_id, &account_key, false, &mint_key, &owner_key, &[])
-                .unwrap(),
+            freeze_account(&program_id, &account_key, false, &mint_key, &owner_key, &[]).unwrap(),
             vec![&mut account_account, &mut mint_account, &mut owner_account],
         )
         .unwrap();

--- a/token/program2/src/processor.rs
+++ b/token/program2/src/processor.rs
@@ -464,9 +464,7 @@ impl Processor {
         if mint_info.key != &source_account.mint {
             return Err(TokenError::MintMismatch.into());
         }
-        if freeze && source_account.state != AccountState::Initialized
-            || !freeze && !source_account.is_frozen()
-        {
+        if freeze && source_account.is_frozen() || !freeze && !source_account.is_frozen() {
             return Err(TokenError::InvalidState.into());
         }
 

--- a/token/program2/src/processor.rs
+++ b/token/program2/src/processor.rs
@@ -143,9 +143,7 @@ impl Processor {
         if source_account.mint != dest_account.mint {
             return Err(TokenError::MintMismatch.into());
         }
-        if source_account.is_initialized == AccountState::Frozen
-            || dest_account.is_initialized == AccountState::Frozen
-        {
+        if source_account.is_frozen() || dest_account.is_frozen() {
             return Err(TokenError::AccountFrozen.into());
         }
 
@@ -201,7 +199,7 @@ impl Processor {
         let delegate_info = next_account_info(account_info_iter)?;
         let owner_info = next_account_info(account_info_iter)?;
 
-        if source_account.is_initialized == AccountState::Frozen {
+        if source_account.is_frozen() {
             return Err(TokenError::AccountFrozen.into());
         }
 
@@ -227,7 +225,7 @@ impl Processor {
         let mut source_account: &mut Account = state::unpack(&mut source_data)?;
         let owner_info = next_account_info(account_info_iter)?;
 
-        if source_account.is_initialized == AccountState::Frozen {
+        if source_account.is_frozen() {
             return Err(TokenError::AccountFrozen.into());
         }
 
@@ -262,7 +260,7 @@ impl Processor {
             let mut account_data = account_info.data.borrow_mut();
             let mut account: &mut Account = state::unpack(&mut account_data)?;
 
-            if account.is_initialized == AccountState::Frozen {
+            if account.is_frozen() {
                 return Err(TokenError::AccountFrozen.into());
             }
 
@@ -329,7 +327,7 @@ impl Processor {
         let mut dest_account_data = dest_account_info.data.borrow_mut();
         let mut dest_account: &mut Account = state::unpack(&mut dest_account_data)?;
 
-        if dest_account.is_initialized == AccountState::Frozen {
+        if dest_account.is_frozen() {
             return Err(TokenError::AccountFrozen.into());
         }
 
@@ -384,7 +382,7 @@ impl Processor {
         if source_account.amount < amount {
             return Err(TokenError::InsufficientFunds.into());
         }
-        if source_account.is_initialized == AccountState::Frozen {
+        if source_account.is_frozen() {
             return Err(TokenError::AccountFrozen.into());
         }
 
@@ -467,7 +465,7 @@ impl Processor {
             return Err(TokenError::MintMismatch.into());
         }
         if freeze && source_account.is_initialized != AccountState::Initialized
-            || !freeze && source_account.is_initialized != AccountState::Frozen
+            || !freeze && !source_account.is_frozen()
         {
             return Err(TokenError::InvalidState.into());
         }

--- a/token/program2/src/state.rs
+++ b/token/program2/src/state.rs
@@ -45,6 +45,12 @@ pub struct Account {
     /// The amount delegated
     pub delegated_amount: u64,
 }
+impl Account {
+    /// Checks if account is frozen
+    pub fn is_frozen(&self) -> bool {
+        self.is_initialized == AccountState::Frozen
+    }
+}
 impl IsInitialized for Account {
     fn is_initialized(&self) -> bool {
         self.is_initialized != AccountState::Uninitialized

--- a/token/program2/src/state.rs
+++ b/token/program2/src/state.rs
@@ -16,6 +16,8 @@ pub struct Mint {
     pub decimals: u8,
     /// Is `true` if this structure has been initialized
     pub is_initialized: bool,
+    /// Optional authority to freeze token accounts.
+    pub freeze_authority: COption<Pubkey>,
 }
 impl IsInitialized for Mint {
     fn is_initialized(&self) -> bool {
@@ -36,8 +38,8 @@ pub struct Account {
     /// If `delegate` is `Some` then `delegated_amount` represents
     /// the amount authorized by the delegate
     pub delegate: COption<Pubkey>,
-    /// Is `true` if this structure has been initialized
-    pub is_initialized: bool,
+    /// Whether the account has been initialized or frozen
+    pub is_initialized: AccountState,
     /// Is this a native token
     pub is_native: bool,
     /// The amount delegated
@@ -45,7 +47,27 @@ pub struct Account {
 }
 impl IsInitialized for Account {
     fn is_initialized(&self) -> bool {
-        self.is_initialized
+        self.is_initialized == AccountState::Initialized
+    }
+}
+
+/// Account state.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum AccountState {
+    /// Account is not yet initialized
+    Uninitialized,
+    /// Account is initialized; the account owner and/or delegate may perform permitted operations
+    /// on this account
+    Initialized,
+    /// Account has been frozen by the mint freeze authority. Neither the account owner nor
+    /// the delegate are able to perform operations on this account.
+    Frozen,
+}
+
+impl Default for AccountState {
+    fn default() -> Self {
+        AccountState::Uninitialized
     }
 }
 

--- a/token/program2/src/state.rs
+++ b/token/program2/src/state.rs
@@ -38,8 +38,8 @@ pub struct Account {
     /// If `delegate` is `Some` then `delegated_amount` represents
     /// the amount authorized by the delegate
     pub delegate: COption<Pubkey>,
-    /// Whether the account has been initialized or frozen
-    pub is_initialized: AccountState,
+    /// The account's state
+    pub state: AccountState,
     /// Is this a native token
     pub is_native: bool,
     /// The amount delegated
@@ -48,12 +48,12 @@ pub struct Account {
 impl Account {
     /// Checks if account is frozen
     pub fn is_frozen(&self) -> bool {
-        self.is_initialized == AccountState::Frozen
+        self.state == AccountState::Frozen
     }
 }
 impl IsInitialized for Account {
     fn is_initialized(&self) -> bool {
-        self.is_initialized != AccountState::Uninitialized
+        self.state != AccountState::Uninitialized
     }
 }
 

--- a/token/program2/src/state.rs
+++ b/token/program2/src/state.rs
@@ -8,10 +8,10 @@ use std::mem::size_of;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct Mint {
-    /// Optional owner, used to mint new tokens.  The owner may only
-    /// be provided during mint creation.  If no owner is present then the mint
-    /// has a fixed supply and no further tokens may be minted.
-    pub owner: COption<Pubkey>,
+    /// Optional authority used to mint new tokens. The mint authority may only be provided during
+    /// mint creation. If no mint authority is present then the mint has a fixed supply and no
+    /// further tokens may be minted.
+    pub mint_authority: COption<Pubkey>,
     /// Number of base 10 digits to the right of the decimal place.
     pub decimals: u8,
     /// Is `true` if this structure has been initialized

--- a/token/program2/src/state.rs
+++ b/token/program2/src/state.rs
@@ -47,7 +47,7 @@ pub struct Account {
 }
 impl IsInitialized for Account {
     fn is_initialized(&self) -> bool {
-        self.is_initialized == AccountState::Initialized
+        self.is_initialized != AccountState::Uninitialized
     }
 }
 


### PR DESCRIPTION
An authority may want the ability to "freeze" specific accounts.

Add a new authority to the Mint and a new initialized state variant to Account. The authority is able to toggle that variant for an associated account. Setting the variant to "frozen" disables any changes from being made to the account, ie transfer in or out, approve, revoke, set-authority, burn.

Fixes #229 