### PR TITLE
Fix 'all' parameter in do.sh

### DIFF
--- a/do.sh
+++ b/do.sh
@@ -178,7 +178,7 @@ fi
 if [[ $2 == "all" ]]; then
     # Perform operation on all projects
     for project in */program*; do
-        if [[ -f "$project"Cargo.toml ]]; then
+        if [[ -f "$project"/Cargo.toml ]]; then
             perform_action "$1" "${project%/}" ${@:3}
         else
             continue


### PR DESCRIPTION
Fix an issue in do.sh where the 'all' argument didn't work, e.g. for `do.sh build all`