### PR TITLE
Use deprecated bpf loader

### DIFF
--- a/token-swap/js/cli/token-swap-test.js
+++ b/token-swap/js/cli/token-swap-test.js
@@ -71,7 +71,7 @@ async function loadProgram(connection: Connection, path: string): Promise<Public
   const from = await newAccountWithLamports(connection, balanceNeeded);
   const program_account = new Account();
   console.log('Loading program:', path);
-  await BpfLoader.load(connection, from, program_account, data);
+  await BpfLoader.load(connection, from, program_account, data, 1);
   return program_account.publicKey;
 }
 

--- a/token-swap/js/package-lock.json
+++ b/token-swap/js/package-lock.json
@@ -1630,9 +1630,9 @@
       "dev": true
     },
     "@solana/web3.js": {
-      "version": "0.71.1",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-0.71.1.tgz",
-      "integrity": "sha512-LV8fwCIyL1n4OfaRTDCznjXxpPn4506YNESMU19BfERQl8IwQDWI6OKdWImpPpUQUEtGceaXbw9bPGtSMlqXJA==",
+      "version": "0.71.6",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-0.71.6.tgz",
+      "integrity": "sha512-mVCqVSEsBacL0xHHwuciHg8qJmFF7Yao9ItASLokYvUYfgwocNS0urnCytOqAFwfE27JRXLHOMOPq6mLbX/2Kg==",
       "requires": {
         "@babel/runtime": "^7.3.1",
         "bn.js": "^5.0.0",
@@ -1718,9 +1718,9 @@
       }
     },
     "@types/lodash": {
-      "version": "4.14.159",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.159.tgz",
-      "integrity": "sha512-gF7A72f7WQN33DpqOWw9geApQPh4M3PxluMtaHxWHXEGSN12/WbcEk/eNSqWNQcQhF66VSZ06vCF94CrHwXJDg=="
+      "version": "4.14.160",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.160.tgz",
+      "integrity": "sha512-aP03BShJoO+WVndoVj/WNcB/YBPt+CIU1mvaao2GRAHy2yg4pT/XS4XnVHEQBjPJGycWf/9seKEO9vopTJGkvA=="
     },
     "@types/node": {
       "version": "12.12.53",
@@ -4135,21 +4135,33 @@
       "optional": true
     },
     "jayson": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/jayson/-/jayson-3.3.3.tgz",
-      "integrity": "sha512-0bQ/vNvWyi+fzNoMvRK63m7BGU+PWwaJRVaGgJWZeAL5euOSqJtqzqyCrfiS3Sdw3OrvgKWF5f5N8ut87gxrng==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/jayson/-/jayson-3.3.4.tgz",
+      "integrity": "sha512-p2stl9m1C0vM8mdXM1m8shn0v5ECohD5gEDRzLD6CPv02pxRm1lv0jEz0HX6RvfJ/uO9z9Zzlzti7/uqq+Rh5g==",
       "requires": {
-        "@types/connect": "^3.4.32",
-        "@types/express-serve-static-core": "^4.16.9",
-        "@types/lodash": "^4.14.139",
-        "@types/node": "^12.7.7",
-        "JSONStream": "^1.3.1",
-        "commander": "^2.12.2",
+        "@types/connect": "^3.4.33",
+        "@types/express-serve-static-core": "^4.17.9",
+        "@types/lodash": "^4.14.159",
+        "@types/node": "^12.12.54",
+        "JSONStream": "^1.3.5",
+        "commander": "^2.20.3",
         "es6-promisify": "^5.0.0",
         "eyes": "^0.1.8",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.15",
-        "uuid": "^3.2.1"
+        "lodash": "^4.17.20",
+        "uuid": "^3.4.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.12.54",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.54.tgz",
+          "integrity": "sha512-ge4xZ3vSBornVYlDnk7yZ0gK6ChHf/CHB7Gl1I0Jhah8DDnEQqBzgohYG4FX4p81TNirSETOiSyn+y1r9/IR6w=="
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+        }
       }
     },
     "js-tokens": {
@@ -4318,7 +4330,8 @@
     "lodash": {
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "dev": true
     },
     "lodash.assignin": {
       "version": "4.2.0",

--- a/token-swap/js/package.json
+++ b/token-swap/js/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/solana-labs/solana-program-library"
   },
-  "testnetDefaultChannel": "v1.3.2",
+  "testnetDefaultChannel": "v1.3.4",
   "scripts": {
     "start": "babel-node --ignore node_modules cli/main.js",
     "lint": "npm run pretty && eslint .",
@@ -29,7 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.11.2",
-    "@solana/web3.js": "^0.71.1",
+    "@solana/web3.js": "^0.71.6",
     "bn.js": "^5.0.0",
     "buffer-layout": "^1.2.0",
     "dotenv": "8.2.0",

--- a/token/js/cli/token-test.js
+++ b/token/js/cli/token-test.js
@@ -77,7 +77,7 @@ async function loadProgram(
   const from = await newAccountWithLamports(connection, balanceNeeded);
   const program_account = new Account();
   console.log('Loading program:', path);
-  await BpfLoader.load(connection, from, program_account, data);
+  await BpfLoader.load(connection, from, program_account, data, 1);
   return program_account.publicKey;
 }
 

--- a/token/js/package-lock.json
+++ b/token/js/package-lock.json
@@ -2202,9 +2202,9 @@
       "dev": true
     },
     "@solana/web3.js": {
-      "version": "0.71.1",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-0.71.1.tgz",
-      "integrity": "sha512-LV8fwCIyL1n4OfaRTDCznjXxpPn4506YNESMU19BfERQl8IwQDWI6OKdWImpPpUQUEtGceaXbw9bPGtSMlqXJA==",
+      "version": "0.71.6",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-0.71.6.tgz",
+      "integrity": "sha512-mVCqVSEsBacL0xHHwuciHg8qJmFF7Yao9ItASLokYvUYfgwocNS0urnCytOqAFwfE27JRXLHOMOPq6mLbX/2Kg==",
       "requires": {
         "@babel/runtime": "^7.3.1",
         "bn.js": "^5.0.0",
@@ -2315,9 +2315,9 @@
       }
     },
     "@types/lodash": {
-      "version": "4.14.159",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.159.tgz",
-      "integrity": "sha512-gF7A72f7WQN33DpqOWw9geApQPh4M3PxluMtaHxWHXEGSN12/WbcEk/eNSqWNQcQhF66VSZ06vCF94CrHwXJDg=="
+      "version": "4.14.160",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.160.tgz",
+      "integrity": "sha512-aP03BShJoO+WVndoVj/WNcB/YBPt+CIU1mvaao2GRAHy2yg4pT/XS4XnVHEQBjPJGycWf/9seKEO9vopTJGkvA=="
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -5374,27 +5374,32 @@
       "optional": true
     },
     "jayson": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/jayson/-/jayson-3.3.3.tgz",
-      "integrity": "sha512-0bQ/vNvWyi+fzNoMvRK63m7BGU+PWwaJRVaGgJWZeAL5euOSqJtqzqyCrfiS3Sdw3OrvgKWF5f5N8ut87gxrng==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/jayson/-/jayson-3.3.4.tgz",
+      "integrity": "sha512-p2stl9m1C0vM8mdXM1m8shn0v5ECohD5gEDRzLD6CPv02pxRm1lv0jEz0HX6RvfJ/uO9z9Zzlzti7/uqq+Rh5g==",
       "requires": {
-        "@types/connect": "^3.4.32",
-        "@types/express-serve-static-core": "^4.16.9",
-        "@types/lodash": "^4.14.139",
-        "@types/node": "^12.7.7",
-        "JSONStream": "^1.3.1",
-        "commander": "^2.12.2",
+        "@types/connect": "^3.4.33",
+        "@types/express-serve-static-core": "^4.17.9",
+        "@types/lodash": "^4.14.159",
+        "@types/node": "^12.12.54",
+        "JSONStream": "^1.3.5",
+        "commander": "^2.20.3",
         "es6-promisify": "^5.0.0",
         "eyes": "^0.1.8",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.15",
-        "uuid": "^3.2.1"
+        "lodash": "^4.17.20",
+        "uuid": "^3.4.0"
       },
       "dependencies": {
         "@types/node": {
           "version": "12.12.54",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.54.tgz",
           "integrity": "sha512-ge4xZ3vSBornVYlDnk7yZ0gK6ChHf/CHB7Gl1I0Jhah8DDnEQqBzgohYG4FX4p81TNirSETOiSyn+y1r9/IR6w=="
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
         }
       }
     },
@@ -5557,7 +5562,8 @@
     "lodash": {
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "dev": true
     },
     "lodash.assignin": {
       "version": "4.2.0",

--- a/token/js/package.json
+++ b/token/js/package.json
@@ -22,7 +22,7 @@
     "/lib",
     "/module.flow.js"
   ],
-  "testnetDefaultChannel": "v1.3.2",
+  "testnetDefaultChannel": "v1.3.4",
   "scripts": {
     "build": "rollup -c",
     "start": "babel-node cli/main.js",
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.10.5",
-    "@solana/web3.js": "^0.71.1",
+    "@solana/web3.js": "^0.71.6",
     "bn.js": "^5.0.0",
     "buffer-layout": "^1.2.0",
     "dotenv": "8.2.0",


### PR DESCRIPTION
The latest versions of web3.js default to the new loader but the new loader is not supported on any networks yet.

Change the js tests to use the deprecated loader.  Once the networks are updated then the token and token-swap programs must pull in the latest solana-sdk and remove these changes to switch to the new loader