### PR TITLE
token: Add close_authority and re-enable CloseAccount for non-native Accounts

### DIFF
--- a/token/program2/inc/token2.h
+++ b/token/program2/inc/token2.h
@@ -68,6 +68,10 @@ enum Token_AuthorityType
      * Holder of a given token account
      */
     Token_AuthorityType_AccountHolder,
+    /**
+     * Authority to close a token account
+     */
+    Token_AuthorityType_CloseAccount,
 };
 #ifndef __cplusplus
 typedef uint8_t Token_AuthorityType;
@@ -439,6 +443,10 @@ typedef struct Token_Account {
      * The amount delegated
      */
     uint64_t delegated_amount;
+    /**
+     * Optional authority to close the account.
+     */
+    Token_COption_Pubkey close_authority;
 } Token_Account;
 
 /**

--- a/token/program2/src/error.rs
+++ b/token/program2/src/error.rs
@@ -37,9 +37,9 @@ pub enum TokenError {
     /// Instruction does not support native tokens
     #[error("Instruction does not support native tokens")]
     NativeNotSupported,
-    /// Instruction does not support non-native tokens
-    #[error("Instruction does not support non-native tokens")]
-    NonNativeNotSupported,
+    /// Non-native account can only be closed if its balance is zero
+    #[error("Non-native account can only be closed if its balance is zero")]
+    NonNativeHasBalance,
     /// Invalid instruction
     #[error("Invalid instruction")]
     InvalidInstruction,

--- a/token/program2/src/instruction.rs
+++ b/token/program2/src/instruction.rs
@@ -451,6 +451,8 @@ pub enum AuthorityType {
     FreezeAccount,
     /// Holder of a given token account
     AccountHolder,
+    /// Authority to close a token account
+    CloseAccount,
 }
 
 impl AuthorityType {
@@ -459,6 +461,7 @@ impl AuthorityType {
             AuthorityType::MintTokens => 0,
             AuthorityType::FreezeAccount => 1,
             AuthorityType::AccountHolder => 2,
+            AuthorityType::CloseAccount => 3,
         }
     }
 
@@ -467,6 +470,7 @@ impl AuthorityType {
             0 => Ok(AuthorityType::MintTokens),
             1 => Ok(AuthorityType::FreezeAccount),
             2 => Ok(AuthorityType::AccountHolder),
+            3 => Ok(AuthorityType::CloseAccount),
             _ => Err(TokenError::InvalidInstruction.into()),
         }
     }

--- a/token/program2/src/state.rs
+++ b/token/program2/src/state.rs
@@ -44,6 +44,8 @@ pub struct Account {
     pub is_native: bool,
     /// The amount delegated
     pub delegated_amount: u64,
+    /// Optional authority to close the account.
+    pub close_authority: COption<Pubkey>,
 }
 impl Account {
     /// Checks if account is frozen


### PR DESCRIPTION
There are cases when the SOL required for rent at the creation of an SPL token account will be subsidized by a 3rd party, opening the door for a financial attack where users request token accounts from the subsidizer only to immediately close them in order to drain SOL from the subsidizer.

Our previous solution to this attack was to disable CloseAccount for non-native accounts, locking that SOL forever.

This PR re-enables CloseAccount for non-native accounts, and adds an Account::close_authority, enabling a 3rd party as above to reclaim their SOL when an account has 0 token balance.

Also adds a couple clarifying comments to the mint section of process_set_authority

Closes #302 
Reverts #127 