### PR TITLE
Reinstate Mint supply

### DIFF
--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -89,13 +89,20 @@ impl State {
         token_program_id: &Pubkey,
         swap: &Pubkey,
         burn_account: &Pubkey,
+        mint: &Pubkey,
         authority: &Pubkey,
         amount: u64,
     ) -> Result<(), ProgramError> {
         let swap_bytes = swap.to_bytes();
         let signers = &[&[&swap_bytes[..32]][..]];
-        let ix =
-            spl_token::instruction::burn(token_program_id, burn_account, authority, &[], amount)?;
+        let ix = spl_token::instruction::burn(
+            token_program_id,
+            burn_account,
+            mint,
+            authority,
+            &[],
+            amount,
+        )?;
         invoke_signed(&ix, accounts, signers)
     }
 
@@ -414,6 +421,7 @@ impl State {
             token_program_info.key,
             swap_info.key,
             source_info.key,
+            &token_swap.pool_mint,
             authority_info.key,
             amount,
         )?;

--- a/token/program/inc/token.h
+++ b/token/program/inc/token.h
@@ -152,8 +152,8 @@ typedef enum Token_TokenInstruction_Tag {
      * Accounts expected by this instruction:
      *
      *   0. `[writable]` The multisignature account to initialize.
-     *   2. `[]` Rent sysvar
-     *   3. ..2+N. `[]` The signer accounts, must equal to N where 1 <= N <= 11.
+     *   1. `[]` Rent sysvar
+     *   2. ..2+N. `[]` The signer accounts, must equal to N where 1 <= N <= 11.
      */
     Token_TokenInstruction_InitializeMultisig,
     /**
@@ -219,7 +219,7 @@ typedef enum Token_TokenInstruction_Tag {
      *   * Multisignature authority
      *   0. `[writable]` The mint or account to change the authority of.
      *   1. `[]` The mint's or account's multisignature authority.
-     *   3. ..3+M '[signer]' M signer accounts
+     *   2. ..2+M '[signer]' M signer accounts
      */
     Token_TokenInstruction_SetAuthority,
     /**
@@ -247,12 +247,14 @@ typedef enum Token_TokenInstruction_Tag {
      *
      *   * Single owner/delegate
      *   0. `[writable]` The account to burn from.
-     *   1. `[signer]` The account's owner/delegate.
+     *   1. '[writable]' The token mint.
+     *   2. `[signer]` The account's owner/delegate.
      *
      *   * Multisignature owner/delegate
      *   0. `[writable]` The account to burn from.
-     *   1. `[]` The account's multisignature owner/delegate.
-     *   2. ..2+M '[signer]' M signer accounts.
+     *   1. '[writable]' The token mint.
+     *   2. `[]` The account's multisignature owner/delegate.
+     *   3. ..3+M '[signer]' M signer accounts.
      */
     Token_TokenInstruction_Burn,
     /**
@@ -393,6 +395,10 @@ typedef struct Token_Mint {
      * further tokens may be minted.
      */
     Token_COption_Pubkey mint_authority;
+    /**
+     * Total supply of tokens.
+     */
+    uint64_t supply;
     /**
      * Number of base 10 digits to the right of the decimal place.
      */

--- a/token/program/src/instruction.rs
+++ b/token/program/src/instruction.rs
@@ -64,8 +64,8 @@ pub enum TokenInstruction {
     /// Accounts expected by this instruction:
     ///
     ///   0. `[writable]` The multisignature account to initialize.
-    ///   2. `[]` Rent sysvar
-    ///   3. ..2+N. `[]` The signer accounts, must equal to N where 1 <= N <= 11.
+    ///   1. `[]` Rent sysvar
+    ///   2. ..2+N. `[]` The signer accounts, must equal to N where 1 <= N <= 11.
     InitializeMultisig {
         /// The number of signers (M) required to validate this multisignature account.
         m: u8,
@@ -133,7 +133,7 @@ pub enum TokenInstruction {
     ///   * Multisignature authority
     ///   0. `[writable]` The mint or account to change the authority of.
     ///   1. `[]` The mint's or account's multisignature authority.
-    ///   3. ..3+M '[signer]' M signer accounts
+    ///   2. ..2+M '[signer]' M signer accounts
     SetAuthority {
         /// The type of authority to update.
         authority_type: AuthorityType,
@@ -165,12 +165,14 @@ pub enum TokenInstruction {
     ///
     ///   * Single owner/delegate
     ///   0. `[writable]` The account to burn from.
-    ///   1. `[signer]` The account's owner/delegate.
+    ///   1. '[writable]' The token mint.
+    ///   2. `[signer]` The account's owner/delegate.
     ///
     ///   * Multisignature owner/delegate
     ///   0. `[writable]` The account to burn from.
-    ///   1. `[]` The account's multisignature owner/delegate.
-    ///   2. ..2+M '[signer]' M signer accounts.
+    ///   1. '[writable]' The token mint.
+    ///   2. `[]` The account's multisignature owner/delegate.
+    ///   3. ..3+M '[signer]' M signer accounts.
     Burn {
         /// The amount of tokens to burn.
         amount: u64,
@@ -696,14 +698,16 @@ pub fn mint_to(
 pub fn burn(
     token_program_id: &Pubkey,
     account_pubkey: &Pubkey,
+    mint_pubkey: &Pubkey,
     authority_pubkey: &Pubkey,
     signer_pubkeys: &[&Pubkey],
     amount: u64,
 ) -> Result<Instruction, ProgramError> {
     let data = TokenInstruction::Burn { amount }.pack()?;
 
-    let mut accounts = Vec::with_capacity(2 + signer_pubkeys.len());
+    let mut accounts = Vec::with_capacity(3 + signer_pubkeys.len());
     accounts.push(AccountMeta::new(*account_pubkey, false));
+    accounts.push(AccountMeta::new(*mint_pubkey, false));
     accounts.push(AccountMeta::new_readonly(
         *authority_pubkey,
         signer_pubkeys.is_empty(),

--- a/token/program/src/state.rs
+++ b/token/program/src/state.rs
@@ -12,6 +12,8 @@ pub struct Mint {
     /// mint creation. If no mint authority is present then the mint has a fixed supply and no
     /// further tokens may be minted.
     pub mint_authority: COption<Pubkey>,
+    /// Total supply of tokens.
+    pub supply: u64,
     /// Number of base 10 digits to the right of the decimal place.
     pub decimals: u8,
     /// Is `true` if this structure has been initialized


### PR DESCRIPTION
Reinstate the `supply` field to the `Mint` state, and adjust on MintTo and Burn instructions. Reinstate passing the mint account into Burn instructions.

Also cleaned up a couple account ordered lists in docs

Fixes #328 