### PR TITLE
token: Check mint on InitializeAccount

### DIFF
--- a/token/program/inc/token.h
+++ b/token/program/inc/token.h
@@ -123,8 +123,10 @@ typedef enum Token_TokenInstruction_Tag {
      */
     Token_TokenInstruction_InitializeMint,
     /**
-     * Initializes a new account to hold tokens.  If this account is associated with the native mint
-     * then the token balance of the initialized account will be equal to the amount of SOL in the account.
+     * Initializes a new account to hold tokens.  If this account is associated with the native
+     * mint then the token balance of the initialized account will be equal to the amount of SOL
+     * in the account. If this account is associated with another mint, that mint must be
+     * initialized before this command can succeed.
      *
      * The `InitializeAccount` instruction requires no signers and MUST be included within
      * the same Transaction as the system program's `CreateInstruction` that creates the account

--- a/token/program/src/error.rs
+++ b/token/program/src/error.rs
@@ -13,6 +13,9 @@ pub enum TokenError {
     /// Insufficient funds for the operation requested.
     #[error("Insufficient funds")]
     InsufficientFunds,
+    /// Invalid Mint.
+    #[error("Invalid Mint")]
+    InvalidMint,
     /// Account not associated with this Mint.
     #[error("Account not associated with this Mint")]
     MintMismatch,

--- a/token/program/src/instruction.rs
+++ b/token/program/src/instruction.rs
@@ -37,8 +37,10 @@ pub enum TokenInstruction {
         /// The freeze authority/multisignature of the mint.
         freeze_authority: COption<Pubkey>,
     },
-    /// Initializes a new account to hold tokens.  If this account is associated with the native mint
-    /// then the token balance of the initialized account will be equal to the amount of SOL in the account.
+    /// Initializes a new account to hold tokens.  If this account is associated with the native
+    /// mint then the token balance of the initialized account will be equal to the amount of SOL
+    /// in the account. If this account is associated with another mint, that mint must be
+    /// initialized before this command can succeed.
     ///
     /// The `InitializeAccount` instruction requires no signers and MUST be included within
     /// the same Transaction as the system program's `CreateInstruction` that creates the account


### PR DESCRIPTION
Tokens can be created with invalid mints. These token accounts are useless because without a valid mint, they can never hold a token balance.

- Add check for Mint validity in process_initialize_account

Fixes #303 