### PR TITLE
Update token js bindings

### DIFF
--- a/docs/src/token.md
+++ b/docs/src/token.md
@@ -188,7 +188,7 @@ The owner of the source Account must be present as a signer in the `Transfer`
 instruction.
 
 An Account's owner may transfer ownership of an account to another using the
-`SetOwner` instruction.
+`SetAuthority` instruction.
 
 It's important to note that the `InitializeAccount` instruction does not require
 the Solana account being initialized also be a signer. The `InitializeAccount`

--- a/token/js/cli/main.js
+++ b/token/js/cli/main.js
@@ -12,11 +12,11 @@ import {
   approveRevoke,
   invalidApprove,
   failOnApproveOverspend,
-  setOwner,
+  setAuthority,
   mintTo,
   multisig,
   burn,
-  failOnCloseAccount,
+  closeAccount,
   nativeToken,
 } from './token-test';
 
@@ -27,6 +27,8 @@ async function main() {
   await createMint();
   console.log('Run test: createAccount');
   await createAccount();
+  console.log('Run test: mintTo');
+  await mintTo();
   console.log('Run test: transfer');
   await transfer();
   console.log('Run test: approveRevoke');
@@ -35,16 +37,14 @@ async function main() {
   await invalidApprove();
   console.log('Run test: failOnApproveOverspend');
   await failOnApproveOverspend();
-  console.log('Run test: setOwner');
-  await setOwner();
-  console.log('Run test: mintTo');
-  await mintTo();
-  console.log('Run test: multisig');
-  await multisig();
+  console.log('Run test: setAuthority');
+  await setAuthority();
   console.log('Run test: burn');
   await burn();
-  console.log('Run test: failOnCloseAccount');
-  await failOnCloseAccount();
+  console.log('Run test: closeAccount');
+  await closeAccount();
+  console.log('Run test: multisig');
+  await multisig();
   console.log('Run test: nativeToken');
   await nativeToken();
   console.log('Success\n');

--- a/token/js/module.flow.js
+++ b/token/js/module.flow.js
@@ -11,10 +11,17 @@ declare module '@solana/spl-token' {
     toBuffer(): Buffer;
     static fromBuffer(buffer: Buffer): u64;
   }
+  declare export type AuthorityType =
+    | 'MintTokens'
+    | 'FreezeAccount'
+    | 'AccountOwner'
+    | 'CloseAccount';
   declare export type MintInfo = {|
-    owner: null | PublicKey,
+    mintAuthority: null | PublicKey,
+    supply: u64,
     decimals: number,
-    initialized: boolean,
+    isInitialized: boolean,
+    freezeAuthority: null | PublicKey,
   |};
   declare export type AccountInfo = {|
     mint: PublicKey,
@@ -23,7 +30,10 @@ declare module '@solana/spl-token' {
     delegate: null | PublicKey,
     delegatedAmount: u64,
     isInitialized: boolean,
+    isFrozen: boolean,
     isNative: boolean,
+    rentExemptReserve: null | u64,
+    closeAuthority: null | PublicKey,
   |};
   declare export type MultisigInfo = {|
     m: number,
@@ -41,7 +51,6 @@ declare module '@solana/spl-token' {
     signer10: PublicKey,
     signer11: PublicKey,
   |};
-  declare export type TokenAndPublicKey = [Token, PublicKey];
   declare export class Token {
     constructor(
       connection: Connection,
@@ -52,13 +61,11 @@ declare module '@solana/spl-token' {
     static createMint(
       connection: Connection,
       payer: Account,
-      mintOwner: PublicKey,
-      accountOwner: PublicKey,
-      supply: u64,
+      mintAuthority: PublicKey,
+      freezeAuthority: PublicKey | null,
       decimals: number,
       programId: PublicKey,
-      is_owned: boolean,
-    ): Promise<TokenAndPublicKey>;
+    ): Promise<Token>;
     static getAccount(connection: Connection): Promise<Account>;
     createAccount(owner: PublicKey): Promise<PublicKey>;
     createMultisig(m: number, signers: Array<PublicKey>): Promise<PublicKey>;
@@ -68,7 +75,7 @@ declare module '@solana/spl-token' {
     transfer(
       source: PublicKey,
       destination: PublicKey,
-      authority: Account | PublicKey,
+      owner: Account | PublicKey,
       multiSigners: Array<Account>,
       amount: number | u64,
     ): Promise<TransactionSignature>;
@@ -84,10 +91,11 @@ declare module '@solana/spl-token' {
       owner: Account | PublicKey,
       multiSigners: Array<Account>,
     ): Promise<void>;
-    setOwner(
-      owned: PublicKey,
-      newOwner: PublicKey,
-      owner: Account | PublicKey,
+    setAuthority(
+      account: PublicKey,
+      newAuthority: PublicKey | null,
+      authorityType: AuthorityType,
+      currentAuthority: Account | PublicKey,
       multiSigners: Array<Account>,
     ): Promise<void>;
     mintTo(
@@ -98,21 +106,34 @@ declare module '@solana/spl-token' {
     ): Promise<void>;
     burn(
       account: PublicKey,
-      authority: Account | PublicKey,
+      owner: Account | PublicKey,
       multiSigners: Array<Account>,
       amount: number,
     ): Promise<void>;
     closeAccount(
       account: PublicKey,
       dest: PublicKey,
-      owner: Account | PublicKey,
+      authority: Account | PublicKey,
       multiSigners: Array<Account>,
     ): Promise<void>;
+    static createInitMintInstruction(
+      programId: PublicKey,
+      mint: PublicKey,
+      decimals: number,
+      mintAuthority: PublicKey,
+      freezeAuthority: PublicKey | null,
+    ): TransactionInstruction;
+    static createInitAccountInstruction(
+      programId: PublicKey,
+      mint: PublicKey,
+      account: PublicKey,
+      owner: PublicKey,
+    ): TransactionInstruction;
     static createTransferInstruction(
       programId: PublicKey,
       source: PublicKey,
       destination: PublicKey,
-      authority: Account | PublicKey,
+      owner: PublicKey,
       multiSigners: Array<Account>,
       amount: number | u64,
     ): TransactionInstruction;
@@ -120,35 +141,36 @@ declare module '@solana/spl-token' {
       programId: PublicKey,
       account: PublicKey,
       delegate: PublicKey,
-      owner: Account | PublicKey,
+      owner: PublicKey,
       multiSigners: Array<Account>,
       amount: number | u64,
     ): TransactionInstruction;
     static createRevokeInstruction(
       programId: PublicKey,
       account: PublicKey,
-      owner: Account | PublicKey,
+      owner: PublicKey,
       multiSigners: Array<Account>,
     ): TransactionInstruction;
-    static createSetOwnerInstruction(
+    static createSetAuthorityInstruction(
       programId: PublicKey,
-      owned: PublicKey,
-      newOwner: PublicKey,
-      owner: Account | PublicKey,
+      account: PublicKey,
+      newAuthority: PublicKey | null,
+      authority: PublicKey,
       multiSigners: Array<Account>,
     ): TransactionInstruction;
     static createMintToInstruction(
       programId: PublicKey,
       mint: PublicKey,
       dest: PublicKey,
-      authority: Account | PublicKey,
+      authority: PublicKey,
       multiSigners: Array<Account>,
       amount: number,
     ): TransactionInstruction;
     static createBurnInstruction(
       programId: PublicKey,
+      mint: PublicKey,
       account: PublicKey,
-      authority: Account | PublicKey,
+      owner: PublicKey,
       multiSigners: Array<Account>,
       amount: number,
     ): TransactionInstruction;
@@ -156,8 +178,8 @@ declare module '@solana/spl-token' {
       programId: PublicKey,
       account: PublicKey,
       dest: PublicKey,
-      owner: Account | PublicKey,
+      authority: PublicKey,
       multiSigners: Array<Account>,
-    ): TransactionInstructio;
+    ): TransactionInstruction;
   }
 }


### PR DESCRIPTION
#### Changes
- Update mint / account state and layout
- Rename setOwner to setAuthority
- Update mint creation to no longer require initial account and supply
- Add static methods for initializing mints and accounts
- Fix bug where `Token` methods called static methods with `PublicKey` when `Account` was expected (for non multisig accounts)