### PR TITLE
Fix account size comparisons

### DIFF
--- a/token/program/src/pack.rs
+++ b/token/program/src/pack.rs
@@ -21,6 +21,11 @@ pub trait Pack: Sealed {
     #[doc(hidden)]
     fn unpack_from_slice(src: &[u8]) -> Result<Self, ProgramError>;
 
+    /// Get the packed length
+    fn get_packed_len() -> usize {
+        Self::LEN
+    }
+
     /// Unpack from slice and check if initialized
     fn unpack(input: &[u8]) -> Result<Self, ProgramError>
     where
@@ -36,8 +41,7 @@ pub trait Pack: Sealed {
 
     /// Unpack from slice without checking if initialized
     fn unpack_unchecked(input: &[u8]) -> Result<Self, ProgramError> {
-        if input.len() < Self::LEN {
-            println!("ilen {:?} tlen {:?}", input.len(), Self::LEN);
+        if input.len() != Self::LEN {
             return Err(ProgramError::InvalidAccountData);
         }
         Ok(Self::unpack_from_slice(input)?)
@@ -72,8 +76,7 @@ pub trait Pack: Sealed {
 
     /// Pack into slice
     fn pack(src: Self, dst: &mut [u8]) -> Result<(), ProgramError> {
-        if dst.len() < Self::LEN {
-            println!("dlen {:?} tlen {:?}", dst.len(), Self::LEN);
+        if dst.len() != Self::LEN {
             return Err(ProgramError::InvalidAccountData);
         }
         src.pack_into_slice(dst);

--- a/token/program/src/state.rs
+++ b/token/program/src/state.rs
@@ -10,9 +10,6 @@ use num_enum::TryFromPrimitive;
 use solana_sdk::{program_error::ProgramError, pubkey::Pubkey};
 
 impl Sealed for Option<Pubkey> {}
-impl Sealed for Mint {}
-impl Sealed for Account {}
-impl Sealed for Multisig {}
 
 /// Mint data.
 #[repr(C)]
@@ -31,6 +28,7 @@ pub struct Mint {
     /// Optional authority to freeze token accounts.
     pub freeze_authority: COption<Pubkey>,
 }
+impl Sealed for Mint {}
 impl IsInitialized for Mint {
     fn is_initialized(&self) -> bool {
         self.is_initialized
@@ -117,6 +115,7 @@ impl Account {
         self.is_native.is_some()
     }
 }
+impl Sealed for Account {}
 impl IsInitialized for Account {
     fn is_initialized(&self) -> bool {
         self.state != AccountState::Uninitialized
@@ -206,6 +205,7 @@ pub struct Multisig {
     /// Signer public keys
     pub signers: [Pubkey; MAX_SIGNERS],
 }
+impl Sealed for Multisig {}
 impl IsInitialized for Multisig {
     fn is_initialized(&self) -> bool {
         self.is_initialized


### PR DESCRIPTION
Tests were using the same mechanism to allocate account sizes as the token was using to check them, this covered up that fact that pack was not enforcing the account sizes correctly.

For correct count sizes and add tests