### PR TITLE
Fix token-js CI tests

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -68,13 +68,13 @@ js_token() {
   time npm run flow || exit $?
   tsc module.d.ts || exit $?
 
-  # TODO: Uncomment when resolving https://github.com/solana-labs/solana-program-library/issues/332
-  # npm run cluster:localnet || exit $?
-  # npm run localnet:down
-  # npm run localnet:update || exit $?
-  # npm run localnet:up || exit $?
-  # time npm run start || exit $?
-  # npm run localnet:down
+  npm run cluster:localnet || exit $?
+  npm run localnet:down
+  npm run localnet:update || exit $?
+  npm run localnet:up || exit $?
+  time npm run start || exit $?
+  time PROGRAM_VERSION=2.0.3 npm run start || exit $?
+  npm run localnet:down
 }
 _ js_token
 

--- a/token/js/cli/token-test.js
+++ b/token/js/cli/token-test.js
@@ -71,11 +71,21 @@ async function loadProgram(
   const from = await newAccountWithLamports(connection, balanceNeeded);
   const program_account = new Account();
   console.log('Loading program:', path);
-  await BpfLoader.load(connection, from, program_account, data, 1);
+  await BpfLoader.load(connection, from, program_account, data, 2);
   return program_account.publicKey;
 }
 
 async function GetPrograms(connection: Connection): Promise<PublicKey> {
+  const programVersion = process.env.PROGRAM_VERSION;
+  if (programVersion) {
+    switch (programVersion) {
+      case '2.0.3':
+        return new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
+      default:
+        throw new Error('Unknown program version');
+    }
+  }
+
   const store = new Store();
   let tokenProgramId = null;
   try {


### PR DESCRIPTION
Fixes: https://github.com/solana-labs/solana-program-library/issues/332
Fixes: https://github.com/solana-labs/solana-program-library/issues/370

#### Problem
- Now that spl-token is deployed in the wild, we need to make sure that the JS bindings are always tested against it to prevent incompatible changes
- solana-sdk v1.3.6 requires bpf loader 2

#### Changes
- Allow running token-js tests against token keg
- Use bpf loader 2 for program loading from source

