### PR TITLE
Fix token-swap tests

### DIFF
--- a/bpf-sdk-install.sh
+++ b/bpf-sdk-install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-channel=${1:-v1.3.1}
+channel=${1:-v1.3.6}
 installDir="$(dirname "$0")"/bin
 cacheDir=~/.cache/solana-bpf-sdk/"$channel"
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -51,12 +51,7 @@ for Xargo_toml in $(git ls-files -- '*/Xargo.toml'); do
 
   _ ./do.sh build "$program_dir"
 
-  if [[ $program_dir =~ token-swap/* ]]; then
-    # TODO: Remove once "Undefined symbols for architecture x86_64: _sol_create_program_address" is resolved
-    _ echo "SKIPPED token-swap test due to: Undefined symbols for architecture x86_64: _sol_create_program_address"
-  else
-    _ ./do.sh test "$program_dir"
-  fi
+  _ ./do.sh test "$program_dir"
 done
 
 
@@ -87,13 +82,12 @@ js_token_swap() {
   # TODO: Restore flow
   # time npm run flow || exit $?
 
-  # TODO: Uncomment once https://github.com/solana-labs/solana/issues/11465 is resolved
-  # npm run cluster:localnet || exit $?
-  # npm run localnet:down
-  # npm run localnet:update || exit $?
-  # npm run localnet:up || exit $?
-  # npm run start || exit $?
-  # npm run localnet:down
+  npm run cluster:localnet || exit $?
+  npm run localnet:down
+  npm run localnet:update || exit $?
+  npm run localnet:up || exit $?
+  npm run start || exit $?
+  npm run localnet:down
 }
 _ js_token_swap
 

--- a/do.sh
+++ b/do.sh
@@ -146,7 +146,7 @@ perform_action() {
         (
             cd "$projectDir"
             echo "test $projectDir"
-            cargo test $features ${@:3}
+            cargo test ${@:3}
         )
         ;;
     update)

--- a/token-swap/program/src/instruction.rs
+++ b/token-swap/program/src/instruction.rs
@@ -40,10 +40,10 @@ pub enum SwapInstruction {
     ///   0. `[]` Token-swap
     ///   1. `[]` $authority
     ///   2. `[writable]` token_(A|B) SOURCE Account, amount is transferable by $authority,
-    ///   4. `[writable]` token_(A|B) Base Account to swap INTO.  Must be the SOURCE token.
-    ///   5. `[writable]` token_(A|B) Base Account to swap FROM.  Must be the DEST token.
-    ///   6. `[writable]` token_(A|B) DEST Account assigned to USER as the owner.
-    ///   7. '[]` Token program id
+    ///   3. `[writable]` token_(A|B) Base Account to swap INTO.  Must be the SOURCE token.
+    ///   4. `[writable]` token_(A|B) Base Account to swap FROM.  Must be the DEST token.
+    ///   5. `[writable]` token_(A|B) DEST Account assigned to USER as the owner.
+    ///   6. '[]` Token program id
     ///   userdata: SOURCE amount to transfer, output to DEST is based on the exchange rate
     Swap(u64),
 
@@ -52,13 +52,13 @@ pub enum SwapInstruction {
     ///
     ///   0. `[]` Token-swap
     ///   1. `[]` $authority
-    ///   2. `[writable]` token_a $authority can transfer amount,
-    ///   4. `[writable]` token_b $authority can transfer amount,
-    ///   6. `[writable]` token_a Base Account to deposit into.
-    ///   7. `[writable]` token_b Base Account to deposit into.
-    ///   8. `[writable]` Pool MINT account, $authority is the owner.
-    ///   9. `[writable]` Pool Account to deposit the generated tokens, user is the owner.
-    ///   10. '[]` Token program id
+    ///   2. `[writable]` token_a $authority can transfer amount from, user is the owner
+    ///   3. `[writable]` token_b $authority can transfer amount from, user is the owner
+    ///   4. `[writable]` token_a Base Account to deposit into, $authority is the owner
+    ///   5. `[writable]` token_b Base Account to deposit into, $authority is the owner
+    ///   6. `[writable]` Pool MINT account, $authority is the owner.
+    ///   7. `[writable]` Pool Account to deposit the generated tokens, user is the owner.
+    ///   8. '[]` Token program id
     ///   userdata: token_a amount to transfer.  token_b amount is set by the current exchange rate.
     Deposit(u64),
 
@@ -67,11 +67,11 @@ pub enum SwapInstruction {
     ///   0. `[]` Token-swap
     ///   1. `[]` $authority
     ///   2. `[writable]` SOURCE Pool account, amount is transferable by $authority.
-    ///   5. `[writable]` token_a Account to withdraw FROM.
-    ///   6. `[writable]` token_b Account to withdraw FROM.
-    ///   7. `[writable]` token_a user Account.
-    ///   8. `[writable]` token_b user Account.
-    ///   9. '[]` Token program id
+    ///   3. `[writable]` token_a Account to withdraw FROM.
+    ///   4. `[writable]` token_b Account to withdraw FROM.
+    ///   5. `[writable]` token_a user Account.
+    ///   6. `[writable]` token_b user Account.
+    ///   7. '[]` Token program id
     ///   userdata: SOURCE amount of pool tokens to transfer. User receives an output based on the
     ///   percentage of the pool tokens that are returned.
     Withdraw(u64),

--- a/utils/test-client/Cargo.toml
+++ b/utils/test-client/Cargo.toml
@@ -12,4 +12,3 @@ solana-sdk = "1.3.6"
 spl-memo = { path = "../../memo/program" }
 spl-token = { path = "../../token/program" }
 spl-token-swap = { path = "../../token-swap/program" }
-


### PR DESCRIPTION
**Problem**

Token-swap tests currently do not pass, even with the linking
issue resolved on `create_program_address`, failing with key errors
since there are incorrect hard-coded program ids.

**Solution**

To fix this, some more conditional compilation is done to create valid
program ids for token and token-swap, followed by properly adding
the program as a signer on its addresses, mimicking what happens in the
real runtime's syscalls.

Note: In order to get valid `Keypair`s as they are used by the BPF
loader, the `program` feature is removed from the test build, since it
requires `sdk::signature::Keypair`, which is not allowed for
`feature = program`.  I considered adding the ed25519-dalek library as
a dev dependency, but it seemed better to use the same code as the sdk.
Let me know if there's a better way to generate these while also
maintaining `feature = program`.