### PR TITLE
Build Token on SDK 1.3.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,7 +1900,7 @@ dependencies = [
  "solana-sdk",
  "solana-stake-program",
  "solana-vote-program",
- "spl-token 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token 2.0.3",
  "thiserror",
 ]
 
@@ -2172,7 +2172,7 @@ dependencies = [
  "solana-stake-program",
  "solana-vote-program",
  "spl-memo 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token 2.0.3",
  "thiserror",
 ]
 
@@ -2236,20 +2236,6 @@ dependencies = [
 [[package]]
 name = "spl-token"
 version = "2.0.3"
-dependencies = [
- "arrayref",
- "num-derive",
- "num-traits",
- "num_enum",
- "rand",
- "remove_dir_all",
- "solana-sdk",
- "thiserror",
-]
-
-[[package]]
-name = "spl-token"
-version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "813ab51fcfeabfc60157e6556b96cf005bab55321508053ade8c9f9bcfe5ce0b"
 dependencies = [
@@ -2257,6 +2243,20 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
+ "remove_dir_all",
+ "solana-sdk",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-token"
+version = "2.0.4"
+dependencies = [
+ "arrayref",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "rand",
  "remove_dir_all",
  "solana-sdk",
  "thiserror",
@@ -2274,7 +2274,7 @@ dependencies = [
  "solana-client",
  "solana-logger",
  "solana-sdk",
- "spl-token 2.0.3",
+ "spl-token 2.0.4",
 ]
 
 [[package]]
@@ -2286,7 +2286,7 @@ dependencies = [
  "rand",
  "remove_dir_all",
  "solana-sdk",
- "spl-token 2.0.3",
+ "spl-token 2.0.4",
  "thiserror",
 ]
 
@@ -2390,7 +2390,7 @@ version = "0.1.0"
 dependencies = [
  "solana-sdk",
  "spl-memo 1.0.7",
- "spl-token 2.0.3",
+ "spl-token 2.0.4",
  "spl-token-swap",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1883,9 +1883,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.3.6"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91f518ae83fc6a598d4b7c445f7ad5bf5598edcaaab1bf5e80373df25ede3a1"
+checksum = "6228310c1f7b351009269c5fff88f2a4d42ad67a32711d05c88c9b03de2cd2e2"
 dependencies = [
  "Inflector",
  "base64 0.12.3",
@@ -1906,9 +1906,9 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "1.3.6"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494a3e161dfe9725f09397d70c5066e33fa5fc40e6c6b1591a6706b623125782"
+checksum = "3db743173681e14e9d738d72f73422bbd8a3d102a1ab6505d95dc5cb2b10c1c6"
 dependencies = [
  "chrono",
  "clap",
@@ -1922,9 +1922,9 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "1.3.6"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a24428aa4955f6098348e8036e12bb3fb8cff48ee5e7f3df48643f0097e83cd3"
+checksum = "5d31c646d710ea89900631e6223c5b0cb8f6342596bad77bf40c8b7f4824a899"
 dependencies = [
  "dirs",
  "lazy_static",
@@ -1936,9 +1936,9 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "1.3.6"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86bd0d34126b7e7388af21ce33d8f1bac4b969b8b838087b5c73325c6a11fb70"
+checksum = "f96248d0cd588f3cd6107592321f8e2340458a161683d7e902015c6e97d30d08"
 dependencies = [
  "bincode",
  "bs58",
@@ -1962,9 +1962,9 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "1.3.6"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec64652208d94f37af552f4e6daeb21e5f9ea90eb9974f2460c58649016f877d"
+checksum = "8df068c0006cdcdf6ed872ec63ef4c51e5d708bbaeb3ec70cde6d0b569dc421e"
 dependencies = [
  "bincode",
  "chrono",
@@ -1976,9 +1976,9 @@ dependencies = [
 
 [[package]]
 name = "solana-crate-features"
-version = "1.3.6"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6b16bf7e62e3224211eb3b1470515cc5ce601f99ce19e4f7f88c72049acaeb"
+checksum = "712d2b279d16841614420192c6022e57e832bee72368a0749e138c64ef042440"
 dependencies = [
  "backtrace",
  "bytes 0.4.12",
@@ -2001,9 +2001,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.3.6"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72eff2774a9c7231d41117a4e2f40d54cd03bf790620850d5435aecdcec59e4"
+checksum = "8f183d10b392f11419729323725a29ca702bd33efab0e7bc410adeb3ca6d0d9f"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -2012,9 +2012,9 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "1.3.6"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5e9d0ce8febe92c38328a3ac94ff0b4deedadfb2413f15c3a8def74e9e351"
+checksum = "30eb6d547c6b5bbf9ca00237728fc3440fd6cb4e7622efa3ca21aa7f8d16f8fa"
 dependencies = [
  "env_logger",
  "gethostname",
@@ -2026,9 +2026,9 @@ dependencies = [
 
 [[package]]
 name = "solana-net-utils"
-version = "1.3.6"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31282737c9e02c36b463d77028ddaf879554a9caf6ca8d14a23ead5b00f7d837"
+checksum = "470d91656269f0ea9dddcf25fbe2843a370fe8bfe10f6a6f978f722617fb745e"
 dependencies = [
  "bincode",
  "bytes 0.4.12",
@@ -2049,9 +2049,9 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "1.3.6"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cd0418a735377adcd7027300317066059063fc916a6cea38a288d46d5fa0e6"
+checksum = "f6b1bc8db11994bf273dc152ef1ad7a4e055839adf0762475cab0ad3f275de17"
 dependencies = [
  "base32",
  "console",
@@ -2069,9 +2069,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.3.6"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6b24d9b6caf7de0d9e14018d8c7cfa7a3d6c8163a36bff49e6587675802497c"
+checksum = "b5c847e86f75d823d080a754819047a260be88e44f61a01e1fbb5437919eb1dd"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -2108,9 +2108,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.3.6"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ff99e30d2b61bc6739f575c8c3f40beca6daf7d00eacddbbe3857bbb4fc987d"
+checksum = "90bfce7167a4277ab047386d4700067fa19bfb3a936f33bd203ca11ecc3eff5a"
 dependencies = [
  "bs58",
  "proc-macro2 1.0.19",
@@ -2121,9 +2121,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro-frozen-abi"
-version = "1.3.6"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cd58f524c7134fe5aa0f8ca4479c51c57c53213ae2feba0fb18abd78902d53d"
+checksum = "039555fb905974e0e6d6549a8b4769aff26af403d9aa3ba9218b6cc527cea89e"
 dependencies = [
  "lazy_static",
  "proc-macro2 1.0.19",
@@ -2134,9 +2134,9 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "1.3.6"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f8f7ee75e6bdb70f9e300f60785c66ae1b7f95d44146aca9ea7e055fb11a3a7"
+checksum = "a968f635f374261b8a557b452ac0f8348e456b6be472433dd526e1f7fda401b9"
 dependencies = [
  "bincode",
  "log",
@@ -2155,9 +2155,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.3.6"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f034bb9ba4218f28f7be130010718a3b8fe6c0856b52dc887a153cf8ed6ae970"
+checksum = "8657738bf9d18b46defb3d27783268bf58b68a70f9dc0d5bc6bea8dfffd07d7c"
 dependencies = [
  "Inflector",
  "base64 0.12.3",
@@ -2178,9 +2178,9 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "1.3.6"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2ae34df71bb85e9f569f92588ad73016da7b37a1dcdd53ed4d9cf2e67a01f7"
+checksum = "0480f28d25ac925f921808c269e6fa43d02de843ba0d44bdfc1b7ae77c37e3cb"
 dependencies = [
  "log",
  "rustc_version",
@@ -2193,9 +2193,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "1.3.6"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8940877a7f41bff1389d7c8d502f49f0a29d443f24df2f53bdc69cbcfc50fd1c"
+checksum = "ad75e79c1454fce32d5b81362fb2ee5b990c544ad65ad9a7013b983b688d0508"
 dependencies = [
  "bincode",
  "log",

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -76,7 +76,7 @@ js_token() {
   npm run localnet:update || exit $?
   npm run localnet:up || exit $?
   time npm run start || exit $?
-  time PROGRAM_VERSION=2.0.3 npm run start || exit $?
+  time PROGRAM_VERSION=2.0.4 npm run start || exit $?
   npm run localnet:down
 }
 _ js_token

--- a/docs/src/token.md
+++ b/docs/src/token.md
@@ -24,7 +24,7 @@ The Token Program's source is available on
 
 The on-chain Token Program is written in Rust and available on crates.io as
 [spl-token](https://docs.rs/spl-token). The program's [instruction interface
-documentation](https://docs.rs/spl-token/2.0.3/spl_token/instruction/enum.TokenInstruction.html)
+documentation](https://docs.rs/spl-token/2.0.4/spl_token/instruction/enum.TokenInstruction.html)
 can also be found there.
 
 Auto-generated C bindings are also available for the on-chain Token Program and

--- a/memo/program/Cargo.toml
+++ b/memo/program/Cargo.toml
@@ -17,7 +17,7 @@ program = ["solana-sdk/program"]
 default = ["solana-sdk/default"]
 
 [dependencies]
-solana-sdk = { version = "1.3.6", default-features = false, optional = true }
+solana-sdk = { version = "1.3.8", default-features = false, optional = true }
 
 [lib]
 name = "spl_memo"

--- a/token-swap/js/package.json
+++ b/token-swap/js/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/solana-labs/solana-program-library"
   },
-  "testnetDefaultChannel": "v1.3.6",
+  "testnetDefaultChannel": "v1.3.8",
   "scripts": {
     "start": "babel-node --ignore node_modules cli/main.js",
     "lint": "npm run pretty && eslint .",

--- a/token-swap/program/Cargo.toml
+++ b/token-swap/program/Cargo.toml
@@ -21,7 +21,7 @@ default = ["solana-sdk/default", "spl-token/default"]
 num-derive = "0.3"
 num-traits = "0.2"
 remove_dir_all = "=0.5.0"
-solana-sdk = { version = "1.3.6", default-features = false, optional = true }
+solana-sdk = { version = "1.3.8", default-features = false, optional = true }
 spl-token = { path = "../../token/program", default-features = false, optional = true }
 thiserror = "1.0"
 

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -257,9 +257,7 @@ impl State {
             token_b: from_token.amount,
             fee: token_swap.fee,
         };
-        let output = invariant
-            .swap(amount)
-            .ok_or_else(|| Error::CalculationFailure)?;
+        let output = invariant.swap(amount).ok_or(Error::CalculationFailure)?;
         Self::token_transfer(
             accounts,
             token_program_info.key,
@@ -320,7 +318,7 @@ impl State {
         };
         let b_amount = invariant
             .exchange_rate(a_amount)
-            .ok_or_else(|| Error::CalculationFailure)?;
+            .ok_or(Error::CalculationFailure)?;
 
         // liquidity is measured in terms of token_a's value
         // since both sides of the pool are equal
@@ -396,7 +394,7 @@ impl State {
         let a_amount = amount;
         let b_amount = invariant
             .exchange_rate(a_amount)
-            .ok_or_else(|| Error::CalculationFailure)?;
+            .ok_or(Error::CalculationFailure)?;
 
         Self::token_transfer(
             accounts,

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -11,12 +11,12 @@ version = "2.0.0"
 [dependencies]
 clap = "2.33.3"
 serde_json = "1.0.57"
-solana-account-decoder = { version = "1.3.6" }
-solana-clap-utils = { version = "1.3.6"}
-solana-cli-config = { version = "1.3.6" }
-solana-client = { version = "1.3.6" }
-solana-logger = { version = "1.3.6" }
-solana-sdk = { version = "1.3.6" }
+solana-account-decoder = { version = "1.3.8" }
+solana-clap-utils = { version = "1.3.8"}
+solana-cli-config = { version = "1.3.8" }
+solana-client = { version = "1.3.8" }
+solana-logger = { version = "1.3.8" }
+solana-sdk = { version = "1.3.8" }
 spl-token = { version = "2.0", path="../program" }
 
 [[bin]]

--- a/token/js/cli/token-test.js
+++ b/token/js/cli/token-test.js
@@ -79,7 +79,7 @@ async function GetPrograms(connection: Connection): Promise<PublicKey> {
   const programVersion = process.env.PROGRAM_VERSION;
   if (programVersion) {
     switch (programVersion) {
-      case '2.0.3':
+      case '2.0.4':
         return new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
       default:
         throw new Error('Unknown program version');

--- a/token/js/package.json
+++ b/token/js/package.json
@@ -22,7 +22,7 @@
     "/lib",
     "/module.flow.js"
   ],
-  "testnetDefaultChannel": "v1.3.6",
+  "testnetDefaultChannel": "v1.3.8",
   "scripts": {
     "build": "rollup -c",
     "start": "babel-node cli/main.js",

--- a/token/perf-monitor/Cargo.lock
+++ b/token/perf-monitor/Cargo.lock
@@ -31,6 +31,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
+name = "arrayvec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+
+[[package]]
 name = "ascii"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,6 +106,21 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "blake3"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce4f9586c9a3151c4b49b19e82ba163dd073614dd057e53c969e1a4db5b52720"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "crypto-mac 0.8.0",
+ "digest 0.9.0",
+]
 
 [[package]]
 name = "block-buffer"
@@ -242,6 +263,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
 name = "crc32fast"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,13 +345,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array 0.14.4",
+ "subtle 2.2.3",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
 dependencies = [
  "byteorder",
- "digest",
+ "digest 0.8.1",
  "rand_core",
  "subtle 2.2.3",
  "zeroize",
@@ -348,6 +385,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
  "generic-array 0.12.3",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -688,8 +734,8 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
 dependencies = [
- "crypto-mac",
- "digest",
+ "crypto-mac 0.7.0",
+ "digest 0.8.1",
 ]
 
 [[package]]
@@ -1162,7 +1208,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "006c038a43a45995a9670da19e67600114740e8511d4333bf97a56e66a7542d9"
 dependencies = [
  "byteorder",
- "crypto-mac",
+ "crypto-mac 0.7.0",
 ]
 
 [[package]]
@@ -1598,7 +1644,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
 dependencies = [
  "block-buffer",
- "digest",
+ "digest 0.8.1",
  "fake-simd",
  "opaque-debug",
 ]
@@ -1644,9 +1690,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "1.3.7"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f531149f17ca53ab61f7a9c8567e16c704e93679d8994407b49a8f86c15405"
+checksum = "fb6190c2badfa6f222e7c3fc4dfe4d979ddd306a2e9bc59471bcd70c435a112b"
 dependencies = [
  "bincode",
  "byteorder",
@@ -1660,9 +1706,9 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "1.3.7"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320b90d65ac28ce238eef7ca8d0da33c1eca4748ff7114a474b84859ee7efe4d"
+checksum = "8df068c0006cdcdf6ed872ec63ef4c51e5d708bbaeb3ec70cde6d0b569dc421e"
 dependencies = [
  "bincode",
  "chrono",
@@ -1674,9 +1720,9 @@ dependencies = [
 
 [[package]]
 name = "solana-crate-features"
-version = "1.3.7"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cbeaeba25dc40611642eed90105bff7ba086afdc6b768f11455cfee06d817c0"
+checksum = "712d2b279d16841614420192c6022e57e832bee72368a0749e138c64ef042440"
 dependencies = [
  "backtrace",
  "bytes 0.4.12",
@@ -1699,9 +1745,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.3.7"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b252863bd79835e60654f7639bb6050983f9b2b3c89d607a8a0f4b23bfb7d97"
+checksum = "8f183d10b392f11419729323725a29ca702bd33efab0e7bc410adeb3ca6d0d9f"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -1710,9 +1756,9 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.3.7"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710b78e7d567df061a1a56396329c9db0c897538ebfd9e8a339bef547f448458"
+checksum = "308980f5bdc3f3edb77aa12b7a423800696e39f5ab2435d5d13e2320491a9bfc"
 dependencies = [
  "jemalloc-ctl",
  "jemallocator",
@@ -1723,9 +1769,9 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "1.3.7"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "123417e835ab3f19049b1fca06f545864c5bcca55f7be64151472f0e6fb56dca"
+checksum = "30eb6d547c6b5bbf9ca00237728fc3440fd6cb4e7622efa3ca21aa7f8d16f8fa"
 dependencies = [
  "env_logger",
  "gethostname",
@@ -1737,9 +1783,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.3.7"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a8252624138b2d0a6e570e894ab295d50354c5a9a247ae0fd0537399fc5708"
+checksum = "874e21b4c10603d1f8efdb7b2b51f14dc84553dfe46a32403ee949fc7aaf362e"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -1747,11 +1793,12 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "1.3.7"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a570f1a4f142a6bf9f624a1a13088d6646381f0a77aeabc8928b0fcdc1c326"
+checksum = "098e3283359a65a195e7d2766faf33e32416481400146d989ad10e888048038e"
 dependencies = [
  "bincode",
+ "blake3",
  "bv",
  "byteorder",
  "bzip2",
@@ -1793,9 +1840,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.3.7"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec6a3588b346638f2de74da18dbc15f831d7fa31cef9eef6d2de07cbdec75abc"
+checksum = "b5c847e86f75d823d080a754819047a260be88e44f61a01e1fbb5437919eb1dd"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -1832,9 +1879,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.3.7"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "968f0066cac1303d9f3036b71b912bdea73e44e6cffdd8eb7d0bdbf59c5ec1b6"
+checksum = "90bfce7167a4277ab047386d4700067fa19bfb3a936f33bd203ca11ecc3eff5a"
 dependencies = [
  "bs58",
  "proc-macro2 1.0.19",
@@ -1845,9 +1892,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro-frozen-abi"
-version = "1.3.7"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0f77c76cdfc5964046cc0ff46a1920e55863e081631416f865a66eae8570f4"
+checksum = "039555fb905974e0e6d6549a8b4769aff26af403d9aa3ba9218b6cc527cea89e"
 dependencies = [
  "lazy_static",
  "proc-macro2 1.0.19",
@@ -1858,9 +1905,9 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "1.3.7"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a40222d5b1f3f44436b862c0ba598269f797f09d50307ed41e7ce32275095eef"
+checksum = "a968f635f374261b8a557b452ac0f8348e456b6be472433dd526e1f7fda401b9"
 dependencies = [
  "bincode",
  "log",
@@ -1879,9 +1926,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "1.3.7"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9d563af28d7118ca84ac2a8792fcc1633d6e1193cd5c982518fa8a4a876f5d6"
+checksum = "ad75e79c1454fce32d5b81362fb2ee5b990c544ad65ad9a7013b983b688d0508"
 dependencies = [
  "bincode",
  "log",
@@ -1923,7 +1970,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spl-token"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "arrayref",
  "num-derive",

--- a/token/perf-monitor/Cargo.toml
+++ b/token/perf-monitor/Cargo.toml
@@ -10,6 +10,6 @@ edition = "2018"
 [dev-dependencies]
 rand = { version = "0.7.0"}
 spl-token = { path = "../program" }
-solana-sdk = { version = "1.3.6" }
-solana-bpf-loader-program = { version = "1.3.6" }
+solana-sdk = { version = "1.3.8" }
+solana-bpf-loader-program = { version = "1.3.8" }
 solana_rbpf = "=0.1.30"

--- a/token/program/Cargo.toml
+++ b/token/program/Cargo.toml
@@ -21,7 +21,7 @@ default = ["solana-sdk/default"]
 num-derive = "0.3"
 num-traits = "0.2"
 remove_dir_all = "=0.5.0"
-solana-sdk = { version = "1.3.6", default-features = false, optional = true }
+solana-sdk = { version = "1.3.8", default-features = false, optional = true }
 thiserror = "1.0"
 arrayref = "0.3.6"
 num_enum = "0.5.1"

--- a/token/program/Cargo.toml
+++ b/token/program/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "spl-token"
-version = "2.0.3"
+version = "2.0.4"
 description = "Solana Program Library Token"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token/program/src/native_mint.rs
+++ b/token/program/src/native_mint.rs
@@ -14,7 +14,7 @@ mod tests {
     #[test]
     fn test_decimals() {
         assert!(
-            lamports_to_sol(42) - crate::amount_to_ui_amount(42, DECIMALS).abs() < f64::EPSILON
+            (lamports_to_sol(42) - crate::amount_to_ui_amount(42, DECIMALS)).abs() < f64::EPSILON
         );
         assert_eq!(
             sol_to_lamports(42.),

--- a/utils/test-client/Cargo.toml
+++ b/utils/test-client/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 # Used to ensure that SPL programs are buildable by external clients
 
 [dependencies]
-solana-sdk = "1.3.6"
+solana-sdk = "1.3.8"
 spl-memo = { path = "../../memo/program" }
 spl-token = { path = "../../token/program" }
 spl-token-swap = { path = "../../token-swap/program" }


### PR DESCRIPTION
I need to link Ledger app tests against SDK 1.3.8 _and the SPL Token program.  So Token needs to upgrade, too!