### PR TITLE
Wrapped SOL support

### DIFF
--- a/token/js/cli/token-test.js
+++ b/token/js/cli/token-test.js
@@ -4,7 +4,7 @@ import fs from 'mz/fs';
 import {Account, Connection, BpfLoader, PublicKey} from '@solana/web3.js';
 import semver from 'semver';
 
-import {Token} from '../client/token';
+import {Token, NATIVE_MINT} from '../client/token';
 import {url} from '../url';
 import {newAccountWithLamports} from '../client/util/new-account-with-lamports';
 import {sleep} from '../client/util/sleep';
@@ -417,18 +417,29 @@ export async function multisig(): Promise<void> {
 export async function nativeToken(): Promise<void> {
   const connection = await getConnection();
 
-  const mintPublicKey = new PublicKey(
-    'So11111111111111111111111111111111111111112',
-  );
+  const mintPublicKey = NATIVE_MINT;
   const payer = await newAccountWithLamports(
     connection,
     100000000000 /* wag */,
   );
+
+  const lamportsToWrap = 50000000000;
+
   const token = new Token(connection, mintPublicKey, programId, payer);
   const owner = new Account();
-  const native = await token.createAccount(owner.publicKey);
+  const native = await Token.createWrappedNativeAccount(
+    connection,
+    programId,
+    owner.publicKey,
+    payer,
+    lamportsToWrap,
+  );
   let accountInfo = await token.getAccountInfo(native);
   assert(accountInfo.isNative);
+
+  // check that the new account has wrapped native tokens.
+  assert(accountInfo.amount.toNumber() === lamportsToWrap);
+
   let balance;
   let info = await connection.getAccountInfo(native);
   if (info != null) {

--- a/token/js/cli/token-test.js
+++ b/token/js/cli/token-test.js
@@ -416,16 +416,15 @@ export async function multisig(): Promise<void> {
 
 export async function nativeToken(): Promise<void> {
   const connection = await getConnection();
-
-  const mintPublicKey = NATIVE_MINT;
+  // this user both pays for the creation of the new token account
+  // and provides the lamports to wrap
   const payer = await newAccountWithLamports(
     connection,
     100000000000 /* wag */,
   );
-
   const lamportsToWrap = 50000000000;
 
-  const token = new Token(connection, mintPublicKey, programId, payer);
+  const token = new Token(connection, NATIVE_MINT, programId, payer);
   const owner = new Account();
   const native = await Token.createWrappedNativeAccount(
     connection,

--- a/token/js/client/token.js
+++ b/token/js/client/token.js
@@ -70,6 +70,11 @@ const AuthorityTypeCodes = {
   CloseAccount: 3,
 };
 
+// The address of the special mint for wrapped native token.
+export const NATIVE_MINT = new PublicKey(
+  'So11111111111111111111111111111111111111112',
+);
+
 /**
  * Information about the mint
  */
@@ -383,7 +388,7 @@ export class Token {
   }
 
   /**
-   * Create and initializes a new account.
+   * Create and initialize a new account.
    *
    * This account may then be used as a `transfer()` or `approve()` destination
    *
@@ -421,6 +426,76 @@ export class Token {
       this.connection,
       transaction,
       this.payer,
+      newAccount,
+    );
+
+    return newAccount.publicKey;
+  }
+
+  /**
+   * Create an initialize a new account on the special native token mint.
+   *
+   * In order to wrap native tokens, the account must have a balance of native tokens
+   * when it is initialized with the token program.
+   *
+   * This function sends lamports to the new account before initializing it.
+   *
+   * @param connection A solana web3 connection
+   * @param programId The token program ID
+   * @param owner The owner of the new token account
+   * @param payer The source of the lamports to initialize, and payer of the initialization fees.
+   * @param amount The amount of lamports to wrap
+   * @return {Promise<PublicKey>} The new token account
+   */
+  static async createWrappedNativeAccount(
+    connection: Connection,
+    programId: PublicKey,
+    owner: PublicKey,
+    payer: Account,
+    amount: number,
+  ): Promise<PublicKey> {
+    // Allocate memory for the account
+    const balanceNeeded = await Token.getMinBalanceRentForExemptAccount(
+      connection,
+    );
+
+    // Create a new account
+    const newAccount = new Account();
+    const transaction = SystemProgram.createAccount({
+      fromPubkey: payer.publicKey,
+      newAccountPubkey: newAccount.publicKey,
+      lamports: balanceNeeded,
+      space: AccountLayout.span,
+      programId,
+    });
+
+    // Send lamports to it (these will be wrapped into native tokens by the token program)
+    transaction.add(
+      SystemProgram.transfer({
+        fromPubkey: payer.publicKey,
+        toPubkey: newAccount.publicKey,
+        lamports: amount,
+      }),
+    );
+
+    // assign the new account to the native token mint.
+    // the account will be initialized with a balance equal to the native token balance.
+    // (i.e. amount)
+    transaction.add(
+      Token.createInitAccountInstruction(
+        programId,
+        NATIVE_MINT,
+        newAccount.publicKey,
+        owner,
+      ),
+    );
+
+    // Send the two instructions
+    await sendAndConfirmTransaction(
+      'createAccount, transfer, and initializeAccount',
+      connection,
+      transaction,
+      payer,
       newAccount,
     );
 

--- a/token/js/module.d.ts
+++ b/token/js/module.d.ts
@@ -13,6 +13,9 @@ declare module '@solana/spl-token' {
   | 'FreezeAccount'
   | 'AccountOwner'
   | 'CloseAccount';
+
+  export const NATIVE_MINT: PublicKey;
+
   export type MintInfo = {
     mintAuthority: null | PublicKey,
     supply: u64,
@@ -65,6 +68,13 @@ declare module '@solana/spl-token' {
     ): Promise<Token>;
     static getAccount(connection: Connection): Promise<Account>;
     createAccount(owner: PublicKey): Promise<PublicKey>;
+    static createWrappedNativeAccount(
+        connection: Connection,
+        programId: PublicKey,
+        owner: PublicKey,
+        payer: Account,
+        amount: number,
+    ): Promise<PublicKey>;
     createMultisig(m: number, signers: Array<PublicKey>): Promise<PublicKey>;
     getMintInfo(): Promise<MintInfo>;
     getAccountInfo(account: PublicKey): Promise<AccountInfo>;

--- a/token/js/module.flow.js
+++ b/token/js/module.flow.js
@@ -16,6 +16,7 @@ declare module '@solana/spl-token' {
     | 'FreezeAccount'
     | 'AccountOwner'
     | 'CloseAccount';
+  declare export var NATIVE_MINT: PublicKey;
   declare export type MintInfo = {|
     mintAuthority: null | PublicKey,
     supply: u64,
@@ -68,6 +69,13 @@ declare module '@solana/spl-token' {
     ): Promise<Token>;
     static getAccount(connection: Connection): Promise<Account>;
     createAccount(owner: PublicKey): Promise<PublicKey>;
+    static createWrappedNativeAccount(
+      connection: Connection,
+      programId: PublicKey,
+      owner: PublicKey,
+      payer: Account,
+      amount: number,
+    ): Promise<PublicKey>;
     createMultisig(m: number, signers: Array<PublicKey>): Promise<PublicKey>;
     getMintInfo(): Promise<MintInfo>;
     getAccountInfo(account: PublicKey): Promise<AccountInfo>;


### PR DESCRIPTION
Add support for wrapped native token account generation in the Token JS client.

Usage:

```
const native = await Token.createWrappedNativeAccount(
    connection,
    programId,
    owner.publicKey,
    payer,
    lamportsToWrap,
  );
const accountInfo = await token.getAccountInfo(native);
assert(accountInfo.isNative);

// check that the new account has wrapped native tokens.
assert(accountInfo.amount.toNumber() === lamportsToWrap);
```

Token.createAccount function performs the systemProgram account creation and token account initialisation steps in one transaction, without first passing lamports to the created account. So the balance is 0 (rent notwithstanding) when initializeAccount is called. This means that, in the native token case, the SOL cannot be wrapped

This function allows you to transfer lamports on creation. The alternative is to create the account, fund it, and then call initialise in separate transactions, or not use the Token JS client at all.

Why is this function static? It can only be run on the "special case" native token mint, not on any token mint, like createAccount can. 

This PR also exposes the NATIVE_MINT constant, referring to this special case mint. 

There is a little duplicated code here between createAccount and createWrappedNativeAccount. I'd be open to refactoring this if this is seen as a problem.