### PR TITLE
Pack instructions and state more efficiently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2281,6 +2281,7 @@ dependencies = [
 name = "spl-token-swap"
 version = "0.1.0"
 dependencies = [
+ "arrayref",
  "num-derive",
  "num-traits",
  "rand",

--- a/token-swap/js/client/token-swap.js
+++ b/token-swap/js/client/token-swap.js
@@ -97,7 +97,7 @@ type TokenSwapInfo = {|
  * @private
  */
 const TokenSwapLayout = BufferLayout.struct([
-  BufferLayout.u8('is_initialized'),
+  BufferLayout.u8('isInitialized'),
   BufferLayout.u8('nonce'),
   Layout.publicKey('tokenAccountA'),
   Layout.publicKey('tokenAccountB'),
@@ -270,7 +270,7 @@ export class TokenSwap {
 
     const data = Buffer.from(accountInfo.data);
     const tokenSwapInfo = TokenSwapLayout.decode(data);
-    if (!tokenSwapInfo.is_initialized) {
+    if (!tokenSwapInfo.isInitialized) {
       throw new Error(`Invalid token swap state`);
     }
     // already properly filled in

--- a/token-swap/js/client/token-swap.js
+++ b/token-swap/js/client/token-swap.js
@@ -97,15 +97,13 @@ type TokenSwapInfo = {|
  * @private
  */
 const TokenSwapLayout = BufferLayout.struct([
-  BufferLayout.u8('state'),
+  BufferLayout.u8('is_initialized'),
   BufferLayout.u8('nonce'),
   Layout.publicKey('tokenAccountA'),
   Layout.publicKey('tokenAccountB'),
   Layout.publicKey('tokenPool'),
-  BufferLayout.blob(7, 'padding'),
-  Layout.uint64('feesDenominator'),
   Layout.uint64('feesNumerator'),
-  BufferLayout.blob(7, 'padding'),
+  Layout.uint64('feesDenominator'),
 ]);
 
 /**
@@ -226,7 +224,6 @@ export class TokenSwap {
       BufferLayout.nu64('feeNumerator'),
       BufferLayout.nu64('feeDenominator'),
       BufferLayout.u8('nonce'),
-      BufferLayout.blob(14, 'padding'),
     ]);
     let data = Buffer.alloc(1024);
     {
@@ -273,7 +270,7 @@ export class TokenSwap {
 
     const data = Buffer.from(accountInfo.data);
     const tokenSwapInfo = TokenSwapLayout.decode(data);
-    if (tokenSwapInfo.state !== 1) {
+    if (!tokenSwapInfo.is_initialized) {
       throw new Error(`Invalid token swap state`);
     }
     // already properly filled in

--- a/token-swap/program/Cargo.toml
+++ b/token-swap/program/Cargo.toml
@@ -18,6 +18,7 @@ program = ["solana-sdk/program", "spl-token/program", "spl-token/no-entrypoint"]
 default = ["solana-sdk/default", "spl-token/default"]
 
 [dependencies]
+arrayref = "0.3.6"
 num-derive = "0.3"
 num-traits = "0.2"
 remove_dir_all = "=0.5.0"

--- a/token-swap/program/src/entrypoint.rs
+++ b/token-swap/program/src/entrypoint.rs
@@ -3,7 +3,7 @@
 #![cfg(feature = "program")]
 #![cfg(not(feature = "no-entrypoint"))]
 
-use crate::{error::Error, processor::Processor};
+use crate::{error::SwapError, processor::Processor};
 use solana_sdk::{
     account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,
     program_error::PrintProgramError, pubkey::Pubkey,
@@ -17,7 +17,7 @@ fn process_instruction<'a>(
 ) -> ProgramResult {
     if let Err(error) = Processor::process(program_id, accounts, instruction_data) {
         // catch the error so we can print it
-        error.print::<Error>();
+        error.print::<SwapError>();
         return Err(error);
     }
     Ok(())

--- a/token-swap/program/src/error.rs
+++ b/token-swap/program/src/error.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 
 /// Errors that may be returned by the TokenSwap program.
 #[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]
-pub enum Error {
+pub enum SwapError {
     /// The account cannot be initialized because it is already being used.
     #[error("AlreadyInUse")]
     AlreadyInUse,
@@ -40,13 +40,16 @@ pub enum Error {
     /// The calculation failed.
     #[error("CalculationFailure")]
     CalculationFailure,
+    /// Invalid instruction number passed in
+    #[error("Invalid instruction")]
+    InvalidInstruction,
 }
-impl From<Error> for ProgramError {
-    fn from(e: Error) -> Self {
+impl From<SwapError> for ProgramError {
+    fn from(e: SwapError) -> Self {
         ProgramError::Custom(e as u32)
     }
 }
-impl<T> DecodeError<T> for Error {
+impl<T> DecodeError<T> for SwapError {
     fn type_of() -> &'static str {
         "Swap Error"
     }

--- a/token-swap/program/src/instruction.rs
+++ b/token-swap/program/src/instruction.rs
@@ -84,7 +84,7 @@ pub enum SwapInstruction {
 }
 
 impl SwapInstruction {
-    /// Unpacks a byte buffer into an [SwapInstruction](enum.SwapInstruction.html).
+    /// Unpacks a byte buffer into a [SwapInstruction](enum.SwapInstruction.html).
     pub fn unpack(input: &[u8]) -> Result<Self, ProgramError> {
         let (&tag, rest) = input.split_first().ok_or(SwapError::InvalidInstruction)?;
         Ok(match tag {
@@ -125,7 +125,7 @@ impl SwapInstruction {
         }
     }
 
-    /// Serializes an [SwapInstruction](enum.SwapInstruction.html) into a byte buffer.
+    /// Packs a [SwapInstruction](enum.SwapInstruction.html) into a byte buffer.
     pub fn pack(&self) -> Vec<u8> {
         let mut buf = Vec::with_capacity(size_of::<Self>());
         match *self {
@@ -321,17 +321,14 @@ mod tests {
             nonce,
         };
         let packed = check.pack();
-        println!("{:?}", packed);
-        let unpacked = SwapInstruction::unpack(&packed).unwrap();
-        assert_eq!(check, unpacked);
-
-        let mut data = vec![];
-        data.push(0 as u8);
-        data.extend_from_slice(&fee_numerator.to_le_bytes());
-        data.extend_from_slice(&fee_denominator.to_le_bytes());
-        data.push(nonce);
-        let unpacked = SwapInstruction::unpack(&data).unwrap();
-        assert_eq!(check, unpacked);
+        let mut expect = vec![];
+        expect.push(0 as u8);
+        expect.extend_from_slice(&fee_numerator.to_le_bytes());
+        expect.extend_from_slice(&fee_denominator.to_le_bytes());
+        expect.push(nonce);
+        assert_eq!(packed, expect);
+        let unpacked = SwapInstruction::unpack(&expect).unwrap();
+        assert_eq!(unpacked, check);
 
         let amount = 2;
         let check = SwapInstruction::Swap { amount };

--- a/token-swap/program/src/instruction.rs
+++ b/token-swap/program/src/instruction.rs
@@ -2,34 +2,14 @@
 
 #![allow(clippy::too_many_arguments)]
 
+use crate::error::SwapError;
 use solana_sdk::{
     instruction::{AccountMeta, Instruction},
     program_error::ProgramError,
     pubkey::Pubkey,
 };
+use std::convert::TryInto;
 use std::mem::size_of;
-
-/// fee rate as a ratio
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
-pub struct Fee {
-    /// denominator of the fee ratio
-    pub denominator: u64,
-    /// numerator of the fee ratio
-    pub numerator: u64,
-}
-
-/// Swap initialization data
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
-pub struct InitializationData {
-    /// swap pool fee numerator
-    pub fee_numerator: u64,
-    /// swap pool fee denominator
-    pub fee_denominator: u64,
-    /// nonce used to create valid program address
-    pub nonce: u8,
-}
 
 /// Instructions supported by the SwapInfo program.
 #[repr(C)]
@@ -44,8 +24,14 @@ pub enum SwapInstruction {
     ///   4. `[writable]` pool Token. Must be empty, owned by $authority.
     ///   5. `[writable]` Pool Account to deposit the generated tokens, user is the owner.
     ///   6. '[]` Token program id
-    ///   userdata: nonce for program address, fee rate as a ratio (numerator and denominator separate)
-    Initialize(InitializationData),
+    Initialize {
+        /// swap pool fee numerator
+        fee_numerator: u64,
+        /// swap pool fee denominator
+        fee_denominator: u64,
+        /// nonce used to create valid program address
+        nonce: u8,
+    },
 
     ///   Swap the tokens in the pool.
     ///
@@ -56,8 +42,10 @@ pub enum SwapInstruction {
     ///   4. `[writable]` token_(A|B) Base Account to swap FROM.  Must be the DESTINATION token.
     ///   5. `[writable]` token_(A|B) DESTINATION Account assigned to USER as the owner.
     ///   6. '[]` Token program id
-    ///   userdata: SOURCE amount to transfer, output to DESTINATION is based on the exchange rate
-    Swap(u64),
+    Swap {
+        /// SOURCE amount to transfer, output to DESTINATION is based on the exchange rate
+        amount: u64,
+    },
 
     ///   Deposit some tokens into the pool.  The output is a "pool" token representing ownership
     ///   into the pool. Inputs are converted to the current ratio.
@@ -71,8 +59,11 @@ pub enum SwapInstruction {
     ///   6. `[writable]` Pool MINT account, $authority is the owner.
     ///   7. `[writable]` Pool Account to deposit the generated tokens, user is the owner.
     ///   8. '[]` Token program id
-    ///   userdata: token_a amount to transfer.  token_b amount is set by the current exchange rate.
-    Deposit(u64),
+    Deposit {
+        /// Pool token amount to transfer. token_a and token_b amount are set by
+        /// the current exchange rate and size of the pool
+        amount: u64,
+    },
 
     ///   Withdraw the token from the pool at the current ratio.
     ///
@@ -85,69 +76,83 @@ pub enum SwapInstruction {
     ///   6. `[writable]` token_a user Account to credit.
     ///   7. `[writable]` token_b user Account to credit.
     ///   8. '[]` Token program id
-    ///   userdata: SOURCE amount of pool tokens to transfer. User receives an output based on the
-    ///   percentage of the pool tokens that are returned.
-    Withdraw(u64),
+    Withdraw {
+        /// Amount of pool tokens to burn. User receives an output of token a
+        /// and b based on the percentage of the pool tokens that are returned.
+        amount: u64,
+    },
 }
 
 impl SwapInstruction {
-    /// Deserializes a byte buffer into an [SwapInstruction](enum.SwapInstruction.html).
-    pub fn deserialize(input: &[u8]) -> Result<Self, ProgramError> {
-        if input.len() < size_of::<u8>() {
-            return Err(ProgramError::InvalidAccountData);
-        }
-        Ok(match input[0] {
+    /// Unpacks a byte buffer into an [SwapInstruction](enum.SwapInstruction.html).
+    pub fn unpack(input: &[u8]) -> Result<Self, ProgramError> {
+        let (&tag, rest) = input.split_first().ok_or(SwapError::InvalidInstruction)?;
+        Ok(match tag {
             0 => {
-                let init_data: &InitializationData = unpack(input)?;
-                Self::Initialize(*init_data)
+                let (fee_numerator, rest) = Self::unpack_u64(rest)?;
+                let (fee_denominator, rest) = Self::unpack_u64(rest)?;
+                let (&nonce, _rest) = rest.split_first().ok_or(SwapError::InvalidInstruction)?;
+                Self::Initialize {
+                    fee_numerator,
+                    fee_denominator,
+                    nonce,
+                }
             }
-            1 => {
-                let fee: &u64 = unpack(input)?;
-                Self::Swap(*fee)
+            1 | 2 | 3 => {
+                let (amount, _rest) = Self::unpack_u64(rest)?;
+                match tag {
+                    1 => Self::Swap { amount },
+                    2 => Self::Deposit { amount },
+                    3 => Self::Withdraw { amount },
+                    _ => unreachable!(),
+                }
             }
-            2 => {
-                let fee: &u64 = unpack(input)?;
-                Self::Deposit(*fee)
-            }
-            3 => {
-                let fee: &u64 = unpack(input)?;
-                Self::Withdraw(*fee)
-            }
-            _ => return Err(ProgramError::InvalidAccountData),
+            _ => return Err(SwapError::InvalidInstruction.into()),
         })
     }
 
+    fn unpack_u64(input: &[u8]) -> Result<(u64, &[u8]), ProgramError> {
+        if input.len() >= 8 {
+            let (amount, rest) = input.split_at(8);
+            let amount = amount
+                .get(..8)
+                .and_then(|slice| slice.try_into().ok())
+                .map(u64::from_le_bytes)
+                .ok_or(SwapError::InvalidInstruction)?;
+            Ok((amount, rest))
+        } else {
+            Err(SwapError::InvalidInstruction.into())
+        }
+    }
+
     /// Serializes an [SwapInstruction](enum.SwapInstruction.html) into a byte buffer.
-    /// TODO Pack things better than standard memory layout.
-    pub fn serialize(&self) -> Result<Vec<u8>, ProgramError> {
-        let mut output = vec![0u8; size_of::<SwapInstruction>()];
-        match self {
-            Self::Initialize(init_data) => {
-                output[0] = 0;
-                #[allow(clippy::cast_ptr_alignment)]
-                let value = unsafe { &mut *(&mut output[1] as *mut u8 as *mut InitializationData) };
-                *value = *init_data;
+    pub fn pack(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(size_of::<Self>());
+        match *self {
+            Self::Initialize {
+                fee_numerator,
+                fee_denominator,
+                nonce,
+            } => {
+                buf.push(0);
+                buf.extend_from_slice(&fee_numerator.to_le_bytes());
+                buf.extend_from_slice(&fee_denominator.to_le_bytes());
+                buf.push(nonce);
             }
-            Self::Swap(amount) => {
-                output[0] = 1;
-                #[allow(clippy::cast_ptr_alignment)]
-                let value = unsafe { &mut *(&mut output[1] as *mut u8 as *mut u64) };
-                *value = *amount;
+            Self::Swap { amount } => {
+                buf.push(1);
+                buf.extend_from_slice(&amount.to_le_bytes());
             }
-            Self::Deposit(amount) => {
-                output[0] = 2;
-                #[allow(clippy::cast_ptr_alignment)]
-                let value = unsafe { &mut *(&mut output[1] as *mut u8 as *mut u64) };
-                *value = *amount;
+            Self::Deposit { amount } => {
+                buf.push(2);
+                buf.extend_from_slice(&amount.to_le_bytes());
             }
-            Self::Withdraw(amount) => {
-                output[0] = 3;
-                #[allow(clippy::cast_ptr_alignment)]
-                let value = unsafe { &mut *(&mut output[1] as *mut u8 as *mut u64) };
-                *value = *amount;
+            Self::Withdraw { amount } => {
+                buf.push(3);
+                buf.extend_from_slice(&amount.to_le_bytes());
             }
         }
-        Ok(output)
+        buf
     }
 }
 
@@ -162,14 +167,15 @@ pub fn initialize(
     pool_pubkey: &Pubkey,
     destination_pubkey: &Pubkey,
     nonce: u8,
-    fee: Fee,
+    fee_numerator: u64,
+    fee_denominator: u64,
 ) -> Result<Instruction, ProgramError> {
-    let init_data = InitializationData {
-        fee_numerator: fee.numerator,
-        fee_denominator: fee.denominator,
+    let init_data = SwapInstruction::Initialize {
+        fee_numerator,
+        fee_denominator,
         nonce,
     };
-    let data = SwapInstruction::Initialize(init_data).serialize()?;
+    let data = init_data.pack();
 
     let accounts = vec![
         AccountMeta::new(*swap_pubkey, true),
@@ -202,7 +208,7 @@ pub fn deposit(
     destination_pubkey: &Pubkey,
     amount: u64,
 ) -> Result<Instruction, ProgramError> {
-    let data = SwapInstruction::Deposit(amount).serialize()?;
+    let data = SwapInstruction::Deposit { amount }.pack();
 
     let accounts = vec![
         AccountMeta::new(*swap_pubkey, false),
@@ -237,7 +243,7 @@ pub fn withdraw(
     destination_token_b_pubkey: &Pubkey,
     amount: u64,
 ) -> Result<Instruction, ProgramError> {
-    let data = SwapInstruction::Withdraw(amount).serialize()?;
+    let data = SwapInstruction::Withdraw { amount }.pack();
 
     let accounts = vec![
         AccountMeta::new(*swap_pubkey, false),
@@ -270,7 +276,7 @@ pub fn swap(
     destination_pubkey: &Pubkey,
     amount: u64,
 ) -> Result<Instruction, ProgramError> {
-    let data = SwapInstruction::Swap(amount).serialize()?;
+    let data = SwapInstruction::Swap { amount }.pack();
 
     let accounts = vec![
         AccountMeta::new(*swap_pubkey, false),
@@ -305,29 +311,53 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_instruction_deserialization() {
+    fn test_instruction_packing() {
         let fee_numerator: u64 = 1;
         let fee_denominator: u64 = 4;
         let nonce: u8 = 255;
-        let check = SwapInstruction::Initialize(InitializationData {
+        let check = SwapInstruction::Initialize {
             fee_numerator,
             fee_denominator,
             nonce,
-        });
-        let packed = check.serialize().unwrap();
-        let unpacked = SwapInstruction::deserialize(&packed).unwrap();
+        };
+        let packed = check.pack();
+        println!("{:?}", packed);
+        let unpacked = SwapInstruction::unpack(&packed).unwrap();
         assert_eq!(check, unpacked);
 
         let mut data = vec![];
         data.push(0 as u8);
-        data.push(fee_numerator as u8);
-        data.extend_from_slice(&[0u8; 7]); // padding
-        data.push(fee_denominator as u8);
-        data.extend_from_slice(&[0u8; 7]); // padding
+        data.extend_from_slice(&fee_numerator.to_le_bytes());
+        data.extend_from_slice(&fee_denominator.to_le_bytes());
         data.push(nonce);
-        data.extend_from_slice(&[0u8; 14]); // padding
-        data.extend_from_slice(&[0u8; 7]); // padding
-        let unpacked = SwapInstruction::deserialize(&data).unwrap();
+        let unpacked = SwapInstruction::unpack(&data).unwrap();
         assert_eq!(check, unpacked);
+
+        let amount = 2;
+        let check = SwapInstruction::Swap { amount };
+        let packed = check.pack();
+        let mut expect = vec![1, 2];
+        expect.extend_from_slice(&[0u8; 7]);
+        assert_eq!(packed, expect);
+        let unpacked = SwapInstruction::unpack(&expect).unwrap();
+        assert_eq!(unpacked, check);
+
+        let amount = 5;
+        let check = SwapInstruction::Deposit { amount };
+        let packed = check.pack();
+        let mut expect = vec![2, 5];
+        expect.extend_from_slice(&[0u8; 7]);
+        assert_eq!(packed, expect);
+        let unpacked = SwapInstruction::unpack(&expect).unwrap();
+        assert_eq!(unpacked, check);
+
+        let amount: u64 = 1212438012089;
+        let check = SwapInstruction::Withdraw { amount };
+        let packed = check.pack();
+        let mut expect = vec![3];
+        expect.extend_from_slice(&amount.to_le_bytes());
+        assert_eq!(packed, expect);
+        let unpacked = SwapInstruction::unpack(&expect).unwrap();
+        assert_eq!(unpacked, check);
     }
 }

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -3,9 +3,9 @@
 #![cfg(feature = "program")]
 
 use crate::{
-    error::Error,
-    instruction::{Fee, SwapInstruction},
-    state::{Invariant, State, SwapInfo},
+    error::SwapError,
+    instruction::SwapInstruction,
+    state::{Invariant, SwapInfo},
 };
 use num_traits::FromPrimitive;
 #[cfg(not(target_arch = "bpf"))]
@@ -34,19 +34,23 @@ const TOKEN_PROGRAM_ID: Pubkey = Pubkey::new_from_array([1u8; 32]);
 pub struct Processor {}
 impl Processor {
     /// Deserializes a spl_token `Account`.
-    pub fn token_account_deserialize(data: &[u8]) -> Result<spl_token::state::Account, Error> {
-        spl_token::state::Account::unpack(data).map_err(|_| Error::ExpectedAccount)
+    pub fn token_account_deserialize(data: &[u8]) -> Result<spl_token::state::Account, SwapError> {
+        spl_token::state::Account::unpack(data).map_err(|_| SwapError::ExpectedAccount)
     }
 
     /// Deserializes a spl_token `Mint`.
-    pub fn mint_deserialize(data: &[u8]) -> Result<spl_token::state::Mint, Error> {
-        spl_token::state::Mint::unpack(data).map_err(|_| Error::ExpectedAccount)
+    pub fn mint_deserialize(data: &[u8]) -> Result<spl_token::state::Mint, SwapError> {
+        spl_token::state::Mint::unpack(data).map_err(|_| SwapError::ExpectedAccount)
     }
 
     /// Calculates the authority id by generating a program address.
-    pub fn authority_id(program_id: &Pubkey, my_info: &Pubkey, nonce: u8) -> Result<Pubkey, Error> {
+    pub fn authority_id(
+        program_id: &Pubkey,
+        my_info: &Pubkey,
+        nonce: u8,
+    ) -> Result<Pubkey, SwapError> {
         Pubkey::create_program_address(&[&my_info.to_bytes()[..32], &[nonce]], program_id)
-            .or(Err(Error::InvalidProgramAddress))
+            .or(Err(SwapError::InvalidProgramAddress))
     }
 
     /// Issue a spl_token `Burn` instruction.
@@ -136,7 +140,8 @@ impl Processor {
     pub fn process_initialize(
         program_id: &Pubkey,
         nonce: u8,
-        fee: Fee,
+        fee_numerator: u64,
+        fee_denominator: u64,
         accounts: &[AccountInfo],
     ) -> ProgramResult {
         let account_info_iter = &mut accounts.iter();
@@ -148,36 +153,37 @@ impl Processor {
         let user_destination_info = next_account_info(account_info_iter)?;
         let token_program_info = next_account_info(account_info_iter)?;
 
-        if State::Unallocated != State::deserialize(&swap_info.data.borrow())? {
-            return Err(Error::AlreadyInUse.into());
+        let token_swap = SwapInfo::unpack(&swap_info.data.borrow())?;
+        if token_swap.is_initialized {
+            return Err(SwapError::AlreadyInUse.into());
         }
 
         if *authority_info.key != Self::authority_id(program_id, swap_info.key, nonce)? {
-            return Err(Error::InvalidProgramAddress.into());
+            return Err(SwapError::InvalidProgramAddress.into());
         }
         let token_a = Self::token_account_deserialize(&token_a_info.data.borrow())?;
         let token_b = Self::token_account_deserialize(&token_b_info.data.borrow())?;
         let pool_mint = Self::mint_deserialize(&pool_info.data.borrow())?;
         if *authority_info.key != token_a.owner {
-            return Err(Error::InvalidOwner.into());
+            return Err(SwapError::InvalidOwner.into());
         }
         if *authority_info.key != token_b.owner {
-            return Err(Error::InvalidOwner.into());
+            return Err(SwapError::InvalidOwner.into());
         }
         if spl_token::option::COption::Some(*authority_info.key) != pool_mint.mint_authority {
-            return Err(Error::InvalidOwner.into());
+            return Err(SwapError::InvalidOwner.into());
         }
         if token_b.amount == 0 {
-            return Err(Error::InvalidSupply.into());
+            return Err(SwapError::InvalidSupply.into());
         }
         if token_a.amount == 0 {
-            return Err(Error::InvalidSupply.into());
+            return Err(SwapError::InvalidSupply.into());
         }
         if token_a.delegate.is_some() {
-            return Err(Error::InvalidDelegate.into());
+            return Err(SwapError::InvalidDelegate.into());
         }
         if token_b.delegate.is_some() {
-            return Err(Error::InvalidDelegate.into());
+            return Err(SwapError::InvalidDelegate.into());
         }
 
         // liquidity is measured in terms of token_a's value since both sides of
@@ -193,14 +199,17 @@ impl Processor {
             amount,
         )?;
 
-        let obj = State::Init(SwapInfo {
+        let obj = SwapInfo {
+            is_initialized: true,
             nonce,
             token_a: *token_a_info.key,
             token_b: *token_b_info.key,
             pool_mint: *pool_info.key,
-            fee,
-        });
-        obj.serialize(&mut swap_info.data.borrow_mut())
+            fee_numerator,
+            fee_denominator,
+        };
+        obj.pack(&mut swap_info.data.borrow_mut());
+        Ok(())
     }
 
     /// Processes an [Swap](enum.Instruction.html).
@@ -218,23 +227,26 @@ impl Processor {
         let destination_info = next_account_info(account_info_iter)?;
         let token_program_info = next_account_info(account_info_iter)?;
 
-        let token_swap = State::deserialize(&swap_info.data.borrow())?.token_swap()?;
+        let token_swap = SwapInfo::unpack(&swap_info.data.borrow())?;
+        if !token_swap.is_initialized {
+            return Err(SwapError::AlreadyInUse.into());
+        }
 
         if *authority_info.key != Self::authority_id(program_id, swap_info.key, token_swap.nonce)? {
-            return Err(Error::InvalidProgramAddress.into());
+            return Err(SwapError::InvalidProgramAddress.into());
         }
         if !(*swap_source_info.key == token_swap.token_a
             || *swap_source_info.key == token_swap.token_b)
         {
-            return Err(Error::InvalidInput.into());
+            return Err(SwapError::InvalidInput.into());
         }
         if !(*swap_destination_info.key == token_swap.token_a
             || *swap_destination_info.key == token_swap.token_b)
         {
-            return Err(Error::InvalidOutput.into());
+            return Err(SwapError::InvalidOutput.into());
         }
         if *swap_source_info.key == *swap_destination_info.key {
-            return Err(Error::InvalidInput.into());
+            return Err(SwapError::InvalidInput.into());
         }
         let source_account = Self::token_account_deserialize(&swap_source_info.data.borrow())?;
         let dest_account = Self::token_account_deserialize(&swap_destination_info.data.borrow())?;
@@ -243,20 +255,22 @@ impl Processor {
             let mut invariant = Invariant {
                 token_a: source_account.amount,
                 token_b: dest_account.amount,
-                fee: token_swap.fee,
+                fee_numerator: token_swap.fee_numerator,
+                fee_denominator: token_swap.fee_denominator,
             };
             invariant
                 .swap_a_to_b(amount)
-                .ok_or(Error::CalculationFailure)?
+                .ok_or(SwapError::CalculationFailure)?
         } else {
             let mut invariant = Invariant {
                 token_a: dest_account.amount,
                 token_b: source_account.amount,
-                fee: token_swap.fee,
+                fee_numerator: token_swap.fee_numerator,
+                fee_denominator: token_swap.fee_denominator,
             };
             invariant
                 .swap_b_to_a(amount)
-                .ok_or(Error::CalculationFailure)?
+                .ok_or(SwapError::CalculationFailure)?
         };
         Self::token_transfer(
             swap_info.key,
@@ -296,18 +310,21 @@ impl Processor {
         let dest_info = next_account_info(account_info_iter)?;
         let token_program_info = next_account_info(account_info_iter)?;
 
-        let token_swap = State::deserialize(&swap_info.data.borrow())?.token_swap()?;
+        let token_swap = SwapInfo::unpack(&swap_info.data.borrow())?;
+        if !token_swap.is_initialized {
+            return Err(SwapError::AlreadyInUse.into());
+        }
         if *authority_info.key != Self::authority_id(program_id, swap_info.key, token_swap.nonce)? {
-            return Err(Error::InvalidProgramAddress.into());
+            return Err(SwapError::InvalidProgramAddress.into());
         }
         if *token_a_info.key != token_swap.token_a {
-            return Err(Error::InvalidInput.into());
+            return Err(SwapError::InvalidInput.into());
         }
         if *token_b_info.key != token_swap.token_b {
-            return Err(Error::InvalidInput.into());
+            return Err(SwapError::InvalidInput.into());
         }
         if *pool_info.key != token_swap.pool_mint {
-            return Err(Error::InvalidInput.into());
+            return Err(SwapError::InvalidInput.into());
         }
         let token_a = Self::token_account_deserialize(&token_a_info.data.borrow())?;
         let token_b = Self::token_account_deserialize(&token_b_info.data.borrow())?;
@@ -315,11 +332,12 @@ impl Processor {
         let invariant = Invariant {
             token_a: token_a.amount,
             token_b: token_b.amount,
-            fee: token_swap.fee,
+            fee_numerator: token_swap.fee_numerator,
+            fee_denominator: token_swap.fee_denominator,
         };
         let b_amount = invariant
             .exchange_rate(a_amount)
-            .ok_or(Error::CalculationFailure)?;
+            .ok_or(SwapError::CalculationFailure)?;
 
         // liquidity is measured in terms of token_a's value
         // since both sides of the pool are equal
@@ -373,15 +391,18 @@ impl Processor {
         let dest_token_b_info = next_account_info(account_info_iter)?;
         let token_program_info = next_account_info(account_info_iter)?;
 
-        let token_swap = State::deserialize(&swap_info.data.borrow())?.token_swap()?;
+        let token_swap = SwapInfo::unpack(&swap_info.data.borrow())?;
+        if !token_swap.is_initialized {
+            return Err(SwapError::AlreadyInUse.into());
+        }
         if *authority_info.key != Self::authority_id(program_id, swap_info.key, token_swap.nonce)? {
-            return Err(Error::InvalidProgramAddress.into());
+            return Err(SwapError::InvalidProgramAddress.into());
         }
         if *token_a_info.key != token_swap.token_a {
-            return Err(Error::InvalidInput.into());
+            return Err(SwapError::InvalidInput.into());
         }
         if *token_b_info.key != token_swap.token_b {
-            return Err(Error::InvalidInput.into());
+            return Err(SwapError::InvalidInput.into());
         }
 
         let token_a = Self::token_account_deserialize(&token_a_info.data.borrow())?;
@@ -390,13 +411,14 @@ impl Processor {
         let invariant = Invariant {
             token_a: token_a.amount,
             token_b: token_b.amount,
-            fee: token_swap.fee,
+            fee_numerator: token_swap.fee_numerator,
+            fee_denominator: token_swap.fee_denominator,
         };
 
         let a_amount = amount;
         let b_amount = invariant
             .exchange_rate(a_amount)
-            .ok_or(Error::CalculationFailure)?;
+            .ok_or(SwapError::CalculationFailure)?;
 
         Self::token_transfer(
             swap_info.key,
@@ -430,25 +452,31 @@ impl Processor {
 
     /// Processes an [Instruction](enum.Instruction.html).
     pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> ProgramResult {
-        let instruction = SwapInstruction::deserialize(input)?;
+        let instruction = SwapInstruction::unpack(input)?;
         match instruction {
-            SwapInstruction::Initialize(init_data) => {
+            SwapInstruction::Initialize {
+                fee_numerator,
+                fee_denominator,
+                nonce,
+            } => {
                 info!("Instruction: Init");
-                let fee = Fee {
-                    numerator: init_data.fee_numerator,
-                    denominator: init_data.fee_denominator,
-                };
-                Self::process_initialize(program_id, init_data.nonce, fee, accounts)
+                Self::process_initialize(
+                    program_id,
+                    nonce,
+                    fee_numerator,
+                    fee_denominator,
+                    accounts,
+                )
             }
-            SwapInstruction::Swap(amount) => {
+            SwapInstruction::Swap { amount } => {
                 info!("Instruction: Swap");
                 Self::process_swap(program_id, amount, accounts)
             }
-            SwapInstruction::Deposit(amount) => {
+            SwapInstruction::Deposit { amount } => {
                 info!("Instruction: Deposit");
                 Self::process_deposit(program_id, amount, accounts)
             }
-            SwapInstruction::Withdraw(amount) => {
+            SwapInstruction::Withdraw { amount } => {
                 info!("Instruction: Withdraw");
                 Self::process_withdraw(program_id, amount, accounts)
             }
@@ -492,23 +520,24 @@ pub fn invoke_signed<'a>(
     )
 }
 
-impl PrintProgramError for Error {
+impl PrintProgramError for SwapError {
     fn print<E>(&self)
     where
         E: 'static + std::error::Error + DecodeError<E> + PrintProgramError + FromPrimitive,
     {
         match self {
-            Error::AlreadyInUse => info!("Error: AlreadyInUse"),
-            Error::InvalidProgramAddress => info!("Error: InvalidProgramAddress"),
-            Error::InvalidOwner => info!("Error: InvalidOwner"),
-            Error::ExpectedToken => info!("Error: ExpectedToken"),
-            Error::ExpectedAccount => info!("Error: ExpectedAccount"),
-            Error::InvalidSupply => info!("Error: InvalidSupply"),
-            Error::InvalidDelegate => info!("Error: InvalidDelegate"),
-            Error::InvalidState => info!("Error: InvalidState"),
-            Error::InvalidInput => info!("Error: InvalidInput"),
-            Error::InvalidOutput => info!("Error: InvalidOutput"),
-            Error::CalculationFailure => info!("Error: CalculationFailure"),
+            SwapError::AlreadyInUse => info!("Error: AlreadyInUse"),
+            SwapError::InvalidProgramAddress => info!("Error: InvalidProgramAddress"),
+            SwapError::InvalidOwner => info!("Error: InvalidOwner"),
+            SwapError::ExpectedToken => info!("Error: ExpectedToken"),
+            SwapError::ExpectedAccount => info!("Error: ExpectedAccount"),
+            SwapError::InvalidSupply => info!("Error: InvalidSupply"),
+            SwapError::InvalidDelegate => info!("Error: InvalidDelegate"),
+            SwapError::InvalidState => info!("Error: InvalidState"),
+            SwapError::InvalidInput => info!("Error: InvalidInput"),
+            SwapError::InvalidOutput => info!("Error: InvalidOutput"),
+            SwapError::CalculationFailure => info!("Error: CalculationFailure"),
+            SwapError::InvalidInstruction => info!("Error: InvalidInstruction"),
         }
     }
 }
@@ -683,13 +712,13 @@ mod tests {
     }
 
     fn initialize_swap<'a>(
-        numerator: u64,
-        denominator: u64,
+        fee_numerator: u64,
+        fee_denominator: u64,
         token_a_amount: u64,
         token_b_amount: u64,
     ) -> SwapAccountInfo {
         let swap_key = pubkey_rand();
-        let mut swap_account = Account::new(0, size_of::<State>(), &SWAP_PROGRAM_ID);
+        let mut swap_account = Account::new(0, size_of::<SwapInfo>(), &SWAP_PROGRAM_ID);
         let (authority_key, nonce) =
             Pubkey::find_program_address(&[&swap_key.to_bytes()[..]], &SWAP_PROGRAM_ID);
 
@@ -732,10 +761,8 @@ mod tests {
                 &pool_mint_key,
                 &pool_token_key,
                 nonce,
-                Fee {
-                    denominator,
-                    numerator,
-                },
+                fee_numerator,
+                fee_denominator,
             )
             .unwrap(),
             vec![
@@ -770,25 +797,24 @@ mod tests {
 
     #[test]
     fn test_initialize() {
-        let numerator = 1;
-        let denominator = 2;
+        let fee_numerator = 1;
+        let fee_denominator = 2;
         let token_a_amount = 1000;
         let token_b_amount = 2000;
-        let swap_accounts = initialize_swap(numerator, denominator, token_a_amount, token_b_amount);
-        let state = State::deserialize(&swap_accounts.swap_account.data).unwrap();
-        match state {
-            State::Init(swap_info) => {
-                assert_eq!(swap_info.nonce, swap_accounts.nonce);
-                assert_eq!(swap_info.token_a, swap_accounts.token_a_key);
-                assert_eq!(swap_info.token_b, swap_accounts.token_b_key);
-                assert_eq!(swap_info.pool_mint, swap_accounts.pool_mint_key);
-                assert_eq!(swap_info.fee.denominator, denominator);
-                assert_eq!(swap_info.fee.numerator, numerator);
-            }
-            _ => {
-                panic!("Incorrect state");
-            }
-        }
+        let swap_accounts = initialize_swap(
+            fee_numerator,
+            fee_denominator,
+            token_a_amount,
+            token_b_amount,
+        );
+        let swap_info = SwapInfo::unpack(&swap_accounts.swap_account.data).unwrap();
+        assert_eq!(swap_info.is_initialized, true);
+        assert_eq!(swap_info.nonce, swap_accounts.nonce);
+        assert_eq!(swap_info.token_a, swap_accounts.token_a_key);
+        assert_eq!(swap_info.token_b, swap_accounts.token_b_key);
+        assert_eq!(swap_info.pool_mint, swap_accounts.pool_mint_key);
+        assert_eq!(swap_info.fee_denominator, fee_denominator);
+        assert_eq!(swap_info.fee_numerator, fee_numerator);
         let token_a =
             Processor::token_account_deserialize(&swap_accounts.token_a_account.data).unwrap();
         assert_eq!(token_a.amount, token_a_amount);
@@ -803,11 +829,16 @@ mod tests {
 
     #[test]
     fn test_deposit() {
-        let numerator = 1;
-        let denominator = 2;
+        let fee_numerator = 1;
+        let fee_denominator = 2;
         let token_a_amount = 1000;
         let token_b_amount = 8000;
-        let mut accounts = initialize_swap(numerator, denominator, token_a_amount, token_b_amount);
+        let mut accounts = initialize_swap(
+            fee_numerator,
+            fee_denominator,
+            token_a_amount,
+            token_b_amount,
+        );
         let seeds = [&accounts.swap_key.to_bytes()[..32], &[accounts.nonce]];
         let authority_key = Pubkey::create_program_address(&seeds, &SWAP_PROGRAM_ID).unwrap();
         let deposit_a = token_a_amount / 10;
@@ -886,11 +917,16 @@ mod tests {
 
     #[test]
     fn test_withdraw() {
-        let numerator = 1;
-        let denominator = 2;
+        let fee_numerator = 1;
+        let fee_denominator = 2;
         let token_a_amount = 1000;
         let token_b_amount = 2000;
-        let mut accounts = initialize_swap(numerator, denominator, token_a_amount, token_b_amount);
+        let mut accounts = initialize_swap(
+            fee_numerator,
+            fee_denominator,
+            token_a_amount,
+            token_b_amount,
+        );
         let seeds = [&accounts.swap_key.to_bytes()[..32], &[accounts.nonce]];
         let authority_key = Pubkey::create_program_address(&seeds, &SWAP_PROGRAM_ID).unwrap();
         let initial_a = token_a_amount / 10;
@@ -958,11 +994,16 @@ mod tests {
 
     #[test]
     fn test_swap() {
-        let numerator = 1;
-        let denominator = 10;
+        let fee_numerator = 1;
+        let fee_denominator = 10;
         let token_a_amount = 1000;
         let token_b_amount = 5000;
-        let mut accounts = initialize_swap(numerator, denominator, token_a_amount, token_b_amount);
+        let mut accounts = initialize_swap(
+            fee_numerator,
+            fee_denominator,
+            token_a_amount,
+            token_b_amount,
+        );
         let seeds = [&accounts.swap_key.to_bytes()[..32], &[accounts.nonce]];
         let authority_key = Pubkey::create_program_address(&seeds, &SWAP_PROGRAM_ID).unwrap();
 
@@ -1013,10 +1054,8 @@ mod tests {
             a_to_b_amount,
             token_a_amount,
             token_b_amount,
-            &Fee {
-                numerator,
-                denominator,
-            },
+            fee_numerator,
+            fee_denominator,
         )
         .unwrap();
 
@@ -1068,10 +1107,8 @@ mod tests {
             b_to_a_amount,
             token_b_amount,
             token_a_amount,
-            &Fee {
-                numerator,
-                denominator,
-            },
+            fee_numerator,
+            fee_denominator,
         )
         .unwrap();
 

--- a/token-swap/program/src/state.rs
+++ b/token-swap/program/src/state.rs
@@ -1,16 +1,14 @@
 //! State transition types
 
-use crate::{
-    error::Error,
-    instruction::{unpack, Fee},
-};
-use solana_sdk::{entrypoint::ProgramResult, program_error::ProgramError, pubkey::Pubkey};
-use std::mem::size_of;
+use arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs};
+use solana_sdk::{program_error::ProgramError, pubkey::Pubkey};
 
-/// Initialized program details.
+/// Program states.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct SwapInfo {
+    /// Initialized state.
+    pub is_initialized: bool,
     /// Nonce used in program address.
     /// The program address is created deterministically with the nonce,
     /// swap program id, and swap account pubkey.  This program address has
@@ -25,63 +23,51 @@ pub struct SwapInfo {
     /// Pool tokens are issued when A or B tokens are deposited.
     /// Pool tokens can be withdrawn back to the original A or B token.
     pub pool_mint: Pubkey,
-    /// Fee applied to the input token amount prior to output calculation.
-    pub fee: Fee,
+    /// Numerator of fee applied to the input token amount prior to output calculation.
+    pub fee_numerator: u64,
+    /// Denominator of fee applied to the input token amount prior to output calculation.
+    pub fee_denominator: u64,
 }
 
-/// Program states.
-#[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum State {
-    /// Unallocated state, may be initialized into another state.
-    Unallocated,
-    /// Initialized state.
-    Init(SwapInfo),
-}
+impl SwapInfo {
+    /// Helper function to get the more efficient packed size of the struct
+    const fn get_packed_len() -> usize {
+        114
+    }
 
-impl State {
-    /// Deserializes a byte buffer into a [State](struct.State.html).
-    pub fn deserialize(input: &[u8]) -> Result<Self, ProgramError> {
-        if input.len() < size_of::<u8>() {
-            return Err(ProgramError::InvalidAccountData);
-        }
-        Ok(match input[0] {
-            0 => Self::Unallocated,
-            1 => {
-                let swap: &SwapInfo = unpack(input)?;
-                Self::Init(*swap)
-            }
-            _ => return Err(ProgramError::InvalidAccountData),
+    /// Deserializes a byte buffer into a [SwapInfo](struct.SwapInfo.html).
+    pub fn unpack(input: &[u8]) -> Result<Self, ProgramError> {
+        let input = array_ref![input, 0, SwapInfo::get_packed_len()];
+        #[allow(clippy::ptr_offset_with_cast)]
+        let (is_initialized, nonce, token_a, token_b, pool_mint, fee_numerator, fee_denominator) =
+            array_refs![input, 1, 1, 32, 32, 32, 8, 8];
+        Ok(Self {
+            is_initialized: match is_initialized {
+                [0] => false,
+                [1] => true,
+                _ => return Err(ProgramError::InvalidAccountData),
+            },
+            nonce: nonce[0],
+            token_a: Pubkey::new_from_array(*token_a),
+            token_b: Pubkey::new_from_array(*token_b),
+            pool_mint: Pubkey::new_from_array(*pool_mint),
+            fee_numerator: u64::from_le_bytes(*fee_numerator),
+            fee_denominator: u64::from_le_bytes(*fee_denominator),
         })
     }
 
-    /// Serializes [State](struct.State.html) into a byte buffer.
-    pub fn serialize(&self, output: &mut [u8]) -> ProgramResult {
-        if output.len() < size_of::<u8>() {
-            return Err(ProgramError::InvalidAccountData);
-        }
-        match self {
-            Self::Unallocated => output[0] = 0,
-            Self::Init(swap) => {
-                if output.len() < size_of::<u8>() + size_of::<SwapInfo>() {
-                    return Err(ProgramError::InvalidAccountData);
-                }
-                output[0] = 1;
-                #[allow(clippy::cast_ptr_alignment)]
-                let value = unsafe { &mut *(&mut output[1] as *mut u8 as *mut SwapInfo) };
-                *value = *swap;
-            }
-        }
-        Ok(())
-    }
-
-    /// Gets the `SwapInfo` from `State`
-    pub fn token_swap(&self) -> Result<SwapInfo, ProgramError> {
-        if let State::Init(swap) = &self {
-            Ok(*swap)
-        } else {
-            Err(Error::InvalidState.into())
-        }
+    /// Serializes [SwapInfo](struct.SwapInfo.html) into a byte buffer.
+    pub fn pack(&self, output: &mut [u8]) {
+        let output = array_mut_ref![output, 0, SwapInfo::get_packed_len()];
+        let (is_initialized, nonce, token_a, token_b, pool_mint, fee_numerator, fee_denominator) =
+            mut_array_refs![output, 1, 1, 32, 32, 32, 8, 8];
+        is_initialized[0] = self.is_initialized as u8;
+        nonce[0] = self.nonce;
+        token_a.copy_from_slice(self.token_a.as_ref());
+        token_b.copy_from_slice(self.token_b.as_ref());
+        pool_mint.copy_from_slice(self.pool_mint.as_ref());
+        *fee_numerator = self.fee_numerator.to_le_bytes();
+        *fee_denominator = self.fee_denominator.to_le_bytes();
     }
 }
 
@@ -102,15 +88,16 @@ impl SwapResult {
         source: u64,
         source_amount: u64,
         dest_amount: u64,
-        fee: &Fee,
+        fee_numerator: u64,
+        fee_denominator: u64,
     ) -> Option<SwapResult> {
         let invariant = source_amount.checked_mul(dest_amount)?;
         let new_source = source_amount.checked_add(source)?;
         let new_destination = invariant.checked_div(new_source)?;
         let remove = dest_amount.checked_sub(new_destination)?;
         let fee = remove
-            .checked_mul(fee.numerator)?
-            .checked_div(fee.denominator)?;
+            .checked_mul(fee_numerator)?
+            .checked_div(fee_denominator)?;
         let new_destination = new_destination.checked_add(fee)?;
         let amount_swapped = remove.checked_sub(fee)?;
         Some(SwapResult {
@@ -127,14 +114,22 @@ pub struct Invariant {
     pub token_a: u64,
     /// Token B
     pub token_b: u64,
-    /// Fee
-    pub fee: Fee,
+    /// Fee numerator
+    pub fee_numerator: u64,
+    /// Fee denominator
+    pub fee_denominator: u64,
 }
 
 impl Invariant {
     /// Swap token a to b
     pub fn swap_a_to_b(&mut self, token_a: u64) -> Option<u64> {
-        let result = SwapResult::swap_to(token_a, self.token_a, self.token_b, &self.fee)?;
+        let result = SwapResult::swap_to(
+            token_a,
+            self.token_a,
+            self.token_b,
+            self.fee_numerator,
+            self.fee_denominator,
+        )?;
         self.token_a = result.new_source;
         self.token_b = result.new_destination;
         Some(result.amount_swapped)
@@ -142,7 +137,13 @@ impl Invariant {
 
     /// Swap token b to a
     pub fn swap_b_to_a(&mut self, token_b: u64) -> Option<u64> {
-        let result = SwapResult::swap_to(token_b, self.token_b, self.token_a, &self.fee)?;
+        let result = SwapResult::swap_to(
+            token_b,
+            self.token_b,
+            self.token_a,
+            self.fee_numerator,
+            self.fee_denominator,
+        )?;
         self.token_b = result.new_source;
         self.token_a = result.new_destination;
         Some(result.amount_swapped)
@@ -157,10 +158,9 @@ impl Invariant {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::mem::size_of;
 
     #[test]
-    fn test_state_swap_info_deserialization() {
+    fn test_swap_info_packing() {
         let nonce = 255;
         let token_a_raw = [1u8; 32];
         let token_b_raw = [2u8; 32];
@@ -168,38 +168,35 @@ mod tests {
         let token_a = Pubkey::new_from_array(token_a_raw);
         let token_b = Pubkey::new_from_array(token_b_raw);
         let pool_mint = Pubkey::new_from_array(pool_mint_raw);
-        let numerator = 1;
-        let denominator = 4;
-        let fee = Fee {
-            numerator,
-            denominator,
-        };
-        let state = State::Init(SwapInfo {
+        let fee_numerator = 1;
+        let fee_denominator = 4;
+        let is_initialized = true;
+        let swap_info = SwapInfo {
+            is_initialized,
             nonce,
             token_a,
             token_b,
             pool_mint,
-            fee,
-        });
+            fee_numerator,
+            fee_denominator,
+        };
 
-        let mut data = [0u8; size_of::<State>()];
-        state.serialize(&mut data).unwrap();
-        let deserialized = State::deserialize(&data).unwrap();
-        assert_eq!(state, deserialized);
+        let mut packed = [0u8; SwapInfo::get_packed_len()];
+        swap_info.pack(&mut packed);
+        let unpacked = SwapInfo::unpack(&packed).unwrap();
+        assert_eq!(swap_info, unpacked);
 
-        let mut data = vec![];
-        data.push(1 as u8);
-        data.push(nonce);
-        data.extend_from_slice(&token_a_raw);
-        data.extend_from_slice(&token_b_raw);
-        data.extend_from_slice(&pool_mint_raw);
-        data.extend_from_slice(&[0u8; 7]); // padding
-        data.push(denominator as u8);
-        data.extend_from_slice(&[0u8; 7]); // padding
-        data.push(numerator as u8);
-        data.extend_from_slice(&[0u8; 7]); // padding
-        data.extend_from_slice(&[0u8; 7]); // padding
-        let deserialized = State::deserialize(&data).unwrap();
-        assert_eq!(state, deserialized);
+        let mut packed = vec![];
+        packed.push(1 as u8);
+        packed.push(nonce);
+        packed.extend_from_slice(&token_a_raw);
+        packed.extend_from_slice(&token_b_raw);
+        packed.extend_from_slice(&pool_mint_raw);
+        packed.push(fee_numerator as u8);
+        packed.extend_from_slice(&[0u8; 7]); // padding
+        packed.push(fee_denominator as u8);
+        packed.extend_from_slice(&[0u8; 7]); // padding
+        let unpacked = SwapInfo::unpack(&packed).unwrap();
+        assert_eq!(swap_info, unpacked);
     }
 }

--- a/token-swap/program/src/state.rs
+++ b/token-swap/program/src/state.rs
@@ -1,5 +1,6 @@
 //! State transition types
 
+use crate::error::SwapError;
 use arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs};
 use solana_sdk::{program_error::ProgramError, pubkey::Pubkey};
 
@@ -35,8 +36,19 @@ impl SwapInfo {
         114
     }
 
-    /// Deserializes a byte buffer into a [SwapInfo](struct.SwapInfo.html).
+    /// Unpacks a byte buffer into a [SwapInfo](struct.SwapInfo.html) and checks
+    /// that it is initialized.
     pub fn unpack(input: &[u8]) -> Result<Self, ProgramError> {
+        let value = Self::unpack_unchecked(input)?;
+        if value.is_initialized {
+            Ok(value)
+        } else {
+            Err(SwapError::InvalidState.into())
+        }
+    }
+
+    /// Unpacks a byte buffer into a [SwapInfo](struct.SwapInfo.html).
+    pub fn unpack_unchecked(input: &[u8]) -> Result<Self, ProgramError> {
         let input = array_ref![input, 0, SwapInfo::get_packed_len()];
         #[allow(clippy::ptr_offset_with_cast)]
         let (is_initialized, nonce, token_a, token_b, pool_mint, fee_numerator, fee_denominator) =
@@ -56,7 +68,7 @@ impl SwapInfo {
         })
     }
 
-    /// Serializes [SwapInfo](struct.SwapInfo.html) into a byte buffer.
+    /// Packs [SwapInfo](struct.SwapInfo.html) into a byte buffer.
     pub fn pack(&self, output: &mut [u8]) {
         let output = array_mut_ref![output, 0, SwapInfo::get_packed_len()];
         let (is_initialized, nonce, token_a, token_b, pool_mint, fee_numerator, fee_denominator) =
@@ -198,5 +210,12 @@ mod tests {
         packed.extend_from_slice(&[0u8; 7]); // padding
         let unpacked = SwapInfo::unpack(&packed).unwrap();
         assert_eq!(swap_info, unpacked);
+
+        let packed = [0u8; SwapInfo::get_packed_len()];
+        let swap_info: SwapInfo = Default::default();
+        let unpack_unchecked = SwapInfo::unpack_unchecked(&packed).unwrap();
+        assert_eq!(unpack_unchecked, swap_info);
+        let err = SwapInfo::unpack(&packed).unwrap_err();
+        assert_eq!(err, SwapError::InvalidState.into());
     }
 }


### PR DESCRIPTION
* SwapInfo and SwapInstruction are more memory-efficient, following the
  example from SPL Token
* Remove unnecessary helper structs to make instructions clearer
* Error -> SwapError
* Update JS tests to reflect the change