### PR TITLE
Allow source account to be its own owner in Transfer and Transfer2

### DIFF
--- a/token/program-v3/src/processor.rs
+++ b/token/program-v3/src/processor.rs
@@ -1170,7 +1170,7 @@ mod tests {
                 &account2_key,
                 &account1_key,
                 &[],
-                1000,
+                500,
             )
             .unwrap(),
             vec![
@@ -1179,7 +1179,29 @@ mod tests {
                 account1_info.clone(),
             ],
         )
-        .unwrap()
+        .unwrap();
+
+        // transfer rest with explicit decimals
+        do_process_instruction_dups(
+            transfer2(
+                &program_id,
+                &account1_key,
+                &mint_key,
+                &account2_key,
+                &account1_key,
+                &[],
+                500,
+                2,
+            )
+            .unwrap(),
+            vec![
+                account1_info.clone(),
+                mint_info.clone(),
+                account2_info.clone(),
+                account1_info.clone(),
+            ],
+        )
+        .unwrap();
     }
 
     #[test]

--- a/token/program-v3/src/processor.rs
+++ b/token/program-v3/src/processor.rs
@@ -1162,7 +1162,7 @@ mod tests {
         )
         .unwrap();
 
-        // source is its own grandpa
+        // source-owner transfer
         do_process_instruction_dups(
             transfer(
                 &program_id,
@@ -1181,7 +1181,7 @@ mod tests {
         )
         .unwrap();
 
-        // transfer rest with explicit decimals
+        // source-owner transfer2
         do_process_instruction_dups(
             transfer2(
                 &program_id,

--- a/token/program-v3/src/processor.rs
+++ b/token/program-v3/src/processor.rs
@@ -1202,6 +1202,59 @@ mod tests {
             ],
         )
         .unwrap();
+
+        // source-delegate transfer
+        Account::unpack_unchecked_mut(
+            &mut account1_info.data.borrow_mut(),
+            &mut |account: &mut Account| {
+                account.amount = 1000;
+                account.delegated_amount = 1000;
+                account.delegate = COption::Some(account1_key);
+                account.owner = owner_key;
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        do_process_instruction_dups(
+            transfer(
+                &program_id,
+                &account1_key,
+                &account2_key,
+                &account1_key,
+                &[],
+                500,
+            )
+            .unwrap(),
+            vec![
+                account1_info.clone(),
+                account2_info.clone(),
+                account1_info.clone(),
+            ],
+        )
+        .unwrap();
+
+        // source-delegate transfer2
+        do_process_instruction_dups(
+            transfer2(
+                &program_id,
+                &account1_key,
+                &mint_key,
+                &account2_key,
+                &account1_key,
+                &[],
+                500,
+                2,
+            )
+            .unwrap(),
+            vec![
+                account1_info.clone(),
+                mint_info.clone(),
+                account2_info.clone(),
+                account1_info.clone(),
+            ],
+        )
+        .unwrap();
     }
 
     #[test]


### PR DESCRIPTION
#411 for /program-v3

In the transfer instruction, if the source account owns itself the instruction panics trying to double mutably borrow.

Add test and re-arrange to avoid duplicate borrow

These changes are incomplete: more duplicate key tests should be added and more instructions will probably have to be updated. To follow in separate PRs

Also, since I was in there:
Fixes #427 
