### PR TITLE
Allow destination or mint to be mint_authority in MintTo and MintTo2

### DIFF
--- a/token/program-v3/src/processor.rs
+++ b/token/program-v3/src/processor.rs
@@ -2525,6 +2525,104 @@ mod tests {
     }
 
     #[test]
+    fn test_mint_to_dups() {
+        let program_id = pubkey_rand();
+        let account1_key = pubkey_rand();
+        let mut account1_account = SolanaAccount::new(
+            account_minimum_balance(),
+            Account::get_packed_len(),
+            &program_id,
+        );
+        let account1_info: AccountInfo = (&account1_key, true, &mut account1_account).into();
+        let owner_key = pubkey_rand();
+        let mut owner_account = SolanaAccount::default();
+        let owner_info: AccountInfo = (&owner_key, true, &mut owner_account).into();
+        let mint_key = pubkey_rand();
+        let mut mint_account =
+            SolanaAccount::new(mint_minimum_balance(), Mint::get_packed_len(), &program_id);
+        let mint_info: AccountInfo = (&mint_key, true, &mut mint_account).into();
+        let rent_key = rent::id();
+        let mut rent_sysvar = rent_sysvar();
+        let rent_info: AccountInfo = (&rent_key, false, &mut rent_sysvar).into();
+
+        // create mint
+        do_process_instruction_dups(
+            initialize_mint(&program_id, &mint_key, &mint_key, None, 2).unwrap(),
+            vec![mint_info.clone(), rent_info.clone()],
+        )
+        .unwrap();
+
+        // create account
+        do_process_instruction_dups(
+            initialize_account(&program_id, &account1_key, &mint_key, &owner_key).unwrap(),
+            vec![
+                account1_info.clone(),
+                mint_info.clone(),
+                owner_info.clone(),
+                rent_info.clone(),
+            ],
+        )
+        .unwrap();
+
+        // mint_to when mint_authority is self
+        do_process_instruction_dups(
+            mint_to(&program_id, &mint_key, &account1_key, &mint_key, &[], 42).unwrap(),
+            vec![mint_info.clone(), account1_info.clone(), mint_info.clone()],
+        )
+        .unwrap();
+
+        // mint_to2 when mint_authority is self
+        do_process_instruction_dups(
+            mint_to2(&program_id, &mint_key, &account1_key, &mint_key, &[], 42, 2).unwrap(),
+            vec![mint_info.clone(), account1_info.clone(), mint_info.clone()],
+        )
+        .unwrap();
+
+        // mint_to when mint_authority is account owner
+        Mint::unpack_unchecked_mut(&mut mint_info.data.borrow_mut(), &mut |mint: &mut Mint| {
+            mint.mint_authority = COption::Some(account1_key);
+            Ok(())
+        })
+        .unwrap();
+        do_process_instruction_dups(
+            mint_to(
+                &program_id,
+                &mint_key,
+                &account1_key,
+                &account1_key,
+                &[],
+                42,
+            )
+            .unwrap(),
+            vec![
+                mint_info.clone(),
+                account1_info.clone(),
+                account1_info.clone(),
+            ],
+        )
+        .unwrap();
+
+        // mint_to2 when mint_authority is account owner
+        do_process_instruction_dups(
+            mint_to(
+                &program_id,
+                &mint_key,
+                &account1_key,
+                &account1_key,
+                &[],
+                42,
+            )
+            .unwrap(),
+            vec![
+                mint_info.clone(),
+                account1_info.clone(),
+                account1_info.clone(),
+            ],
+        )
+        .unwrap();
+    }
+
+    #[test]
     fn test_mint_to() {
         let program_id = pubkey_rand();
         let account_key = pubkey_rand();


### PR DESCRIPTION
As in the transfer instruction (cc #433 ), if the mint authority is either the Mint itself or the destination Account, a MintTo or MintTo2 instruction panics trying to double mutably borrow.

Add tests and re-order process_mint_to to fix