### PR TITLE
Re-enable token-swap ci

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -82,17 +82,14 @@ js_token_swap() {
   time npm install || exit $?
   time npm run lint || exit $?
 
-  # TODO: Restore flow
-  # time npm run flow || exit $?
+  time npm run flow || exit $?
 
-  # TODO re-enable after investigating CI issues
-  # https://github.com/solana-labs/solana-program-library/pull/408
-  # npm run cluster:localnet || exit $?
-  # npm run localnet:down
-  # npm run localnet:update || exit $?
-  # npm run localnet:up || exit $?
-  # npm run start || exit $?
-  # npm run localnet:down
+  npm run cluster:localnet || exit $?
+  npm run localnet:down
+  npm run localnet:update || exit $?
+  npm run localnet:up || exit $?
+  npm run start || exit $?
+  npm run localnet:down
 }
 _ js_token_swap
 


### PR DESCRIPTION
Now that all of the token-swap and web3 fixes have landed, we can finally re-enable the token-swap JS tests in CI.

Fixes #305 