### PR TITLE
token-swap: Remove tokenSwapAccount as signer

### DIFF
--- a/token-swap/js/client/token-swap.js
+++ b/token-swap/js/client/token-swap.js
@@ -211,7 +211,7 @@ export class TokenSwap {
     );
 
     let keys = [
-      {pubkey: tokenSwapAccount.publicKey, isSigner: true, isWritable: true},
+      {pubkey: tokenSwapAccount.publicKey, isSigner: false, isWritable: true},
       {pubkey: authority, isSigner: false, isWritable: false},
       {pubkey: tokenAccountA, isSigner: false, isWritable: false},
       {pubkey: tokenAccountB, isSigner: false, isWritable: false},
@@ -248,7 +248,6 @@ export class TokenSwap {
       connection,
       transaction,
       payer,
-      tokenSwapAccount
     );
 
     return tokenSwap;


### PR DESCRIPTION
**Problem**

We unnecessarily set `tokenSwapAccount` as a signer of the initialize transaction, and it's not required.  Please correct me if I've misunderstood how this should work!

**Solution**

Remove the parameter.