### PR TITLE
Disable multisig in JS client

### DIFF
--- a/token/js/cli/main.js
+++ b/token/js/cli/main.js
@@ -15,7 +15,7 @@ import {
   setAuthority,
   mintTo,
   mintTo2,
-  multisig,
+  //multisig,
   burn,
   burn2,
   freezeThawAccount,
@@ -52,8 +52,8 @@ async function main() {
   await freezeThawAccount();
   console.log('Run test: closeAccount');
   await closeAccount();
-  console.log('Run test: multisig');
-  await multisig();
+  //console.log('Run test: multisig');
+  //await multisig();
   console.log('Run test: nativeToken');
   await nativeToken();
   console.log('Success\n');

--- a/token/js/cli/token-test.js
+++ b/token/js/cli/token-test.js
@@ -13,7 +13,7 @@ import semver from 'semver';
 import {Token, NATIVE_MINT} from '../client/token';
 import {url} from '../url';
 import {newAccountWithLamports} from '../client/util/new-account-with-lamports';
-import {sleep} from '../client/util/sleep';
+//import {sleep} from '../client/util/sleep';
 import {Store} from '../client/util/store';
 
 // Loaded token program's program id
@@ -455,6 +455,13 @@ export async function closeAccount(): Promise<void> {
   assert(destAccountInfo.amount.toNumber() === remaining);
 }
 
+/*
+ SPL Token v2's multisignature validation is compromised and should not
+ be used.  Validation will erroneously pass a single valid signer signs m times.
+ For more information:
+    https://github.com/solana-labs/solana-program-library/issues/477*
+*/
+/*
 export async function multisig(): Promise<void> {
   const m = 2;
   const n = 5;
@@ -524,6 +531,7 @@ export async function multisig(): Promise<void> {
     assert(accountInfo.owner.equals(newOwner));
   }
 }
+*/
 
 export async function nativeToken(): Promise<void> {
   const connection = await getConnection();

--- a/token/js/client/token.js
+++ b/token/js/client/token.js
@@ -520,6 +520,13 @@ export class Token {
    * @param signers Full set of signers
    * @return Public key of the new multisig account
    */
+  /*
+   SPL Token v2's multisignature validation is compromised and should not
+   be used.  Validation will erroneously pass a single valid signer signs m times.
+   For more information:
+      https://github.com/solana-labs/solana-program-library/issues/477*
+  */
+  /*
   async createMultisig(
     m: number,
     signers: Array<PublicKey>,
@@ -578,6 +585,7 @@ export class Token {
 
     return multisigAccount.publicKey;
   }
+  */
 
   /**
    * Retrieve mint information

--- a/token/js/module.d.ts
+++ b/token/js/module.d.ts
@@ -75,7 +75,7 @@ declare module '@solana/spl-token' {
         payer: Account,
         amount: number,
     ): Promise<PublicKey>;
-    createMultisig(m: number, signers: Array<PublicKey>): Promise<PublicKey>;
+    //createMultisig(m: number, signers: Array<PublicKey>): Promise<PublicKey>;
     getMintInfo(): Promise<MintInfo>;
     getAccountInfo(account: PublicKey): Promise<AccountInfo>;
     getMultisigInfo(multisig: PublicKey): Promise<MultisigInfo>;

--- a/token/js/module.flow.js
+++ b/token/js/module.flow.js
@@ -76,7 +76,7 @@ declare module '@solana/spl-token' {
       payer: Account,
       amount: number,
     ): Promise<PublicKey>;
-    createMultisig(m: number, signers: Array<PublicKey>): Promise<PublicKey>;
+    //createMultisig(m: number, signers: Array<PublicKey>): Promise<PublicKey>;
     getMintInfo(): Promise<MintInfo>;
     getAccountInfo(account: PublicKey): Promise<AccountInfo>;
     getMultisigInfo(multisig: PublicKey): Promise<MultisigInfo>;


### PR DESCRIPTION
This PR is just an initial rough sketch.   It would be nice to keep multisig support in JS when using the v3 program, but we definitely shouldn't advertise multisig support for the v2 program.