### PR TITLE
Standardize failure case ordering

### DIFF
--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -2086,7 +2086,7 @@ mod tests {
             ) = accounts.setup_token_accounts(
                 &user_key,
                 &withdrawer_key,
-                initial_a,
+                withdraw_amount,
                 initial_b,
                 withdraw_amount,
             );


### PR DESCRIPTION
While relevant failure cases vary from instruction to instruction, there are some that are consistent across many. It makes code easier to understand and test if these consistent failure cases are checked in the same order across instructions.

Here is the general order implemented:
1. Frozen
2. Account type is wrong in some way (native vs. non-native, authority type not applicable)
3. Insufficient funds
4. Mint mismatch
5. Decimal mismatch
6. Delegated checks

Fixes #500 

- [x] Rebase on #507 

