### PR TITLE
Add freeze and thaw functionality to spl-token cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2267,6 +2267,7 @@ name = "spl-token-cli"
 version = "2.0.1"
 dependencies = [
  "clap",
+ "console",
  "serde_json",
  "solana-account-decoder",
  "solana-clap-utils",

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -10,6 +10,7 @@ version = "2.0.1"
 
 [dependencies]
 clap = "2.33.3"
+console = "0.11.3"
 serde_json = "1.0.57"
 solana-account-decoder = { version = "1.3.12" }
 solana-clap-utils = { version = "1.3.12"}

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -746,7 +746,7 @@ fn main() {
             SubCommand::with_name("freeze")
                 .about("Freeze a token account")
                 .arg(
-                    Arg::with_name("token")
+                    Arg::with_name("token") // TODO: remove this arg when solana-client v1.3.12+ is published; grab mint from token account state
                         .validator(is_pubkey_or_keypair)
                         .value_name("TOKEN_ADDRESS")
                         .takes_value(true)
@@ -768,7 +768,7 @@ fn main() {
             SubCommand::with_name("thaw")
                 .about("Thaw a token account")
                 .arg(
-                    Arg::with_name("token")
+                    Arg::with_name("token") // TODO: remove this arg when solana-client v1.3.12+ is published; grab mint from token account state
                         .validator(is_pubkey_or_keypair)
                         .value_name("TOKEN_ADDRESS")
                         .takes_value(true)


### PR DESCRIPTION
- Add ability to initialize mint with freeze authority (set to same as mint authority for now; SetAuthority work as part of #502 will allow greater control)
- Add freeze and thaw subcommands to cli app
- Add "frozen" marker to accounts output, when relevant

Fixes #365 
Toward #502 