### PR TITLE
Expose layouts and instruction creation function

### DIFF
--- a/token-swap/js/module.d.ts
+++ b/token-swap/js/module.d.ts
@@ -1,5 +1,6 @@
 declare module '@solana/spl-token-swap' {
   import { Buffer } from 'buffer';
+  import { Layout } from 'buffer-layout';
   import { PublicKey, TransactionInstruction, TransactionSignature, Connection, Account } from "@solana/web3.js";
   import BN from 'bn.js';
 
@@ -19,12 +20,28 @@ declare module '@solana/spl-token-swap' {
     feeRatio: number,
   };
 
+  export const TokenSwapLayout: Layout;
+
   export class TokenSwap {
     constructor(connection: Connection, tokenSwap: PublicKey, programId: PublicKey, payer: Account);
 
     static getMinBalanceRentForExemptTokenSwap(
       connection: Connection,
     ): Promise<number>;
+
+    static createInitSwapInstruction(
+      tokenSwapAccount: Account,
+      authority: PublicKey,
+      nonce: number,
+      tokenAccountA: PublicKey,
+      tokenAccountB: PublicKey,
+      tokenPool: PublicKey,
+      tokenAccountPool: PublicKey,
+      tokenProgramId: PublicKey,
+      swapProgramId: PublicKey,
+      feeNumerator: number,
+      feeDenominator: number
+    ): TransactionInstruction;
 
     static createTokenSwap(
       connection: Connection,
@@ -39,7 +56,7 @@ declare module '@solana/spl-token-swap' {
       nonce: number,
       feeNumerator: number,
       feeDenominator: number,
-      programId: PublicKey,
+      swapProgramId: PublicKey,
     ): Promise<TokenSwap>
 
     getInfo(): Promise<TokenSwapInfo>

--- a/token-swap/js/module.flow.js
+++ b/token-swap/js/module.flow.js
@@ -22,6 +22,8 @@ declare module '@solana/spl-token-swap' {
     feeRatio: number,
   |};
 
+  declare export var TokenSwapLayout: Layout;
+
   declare export class TokenSwap {
     constructor(
       connection: Connection,
@@ -33,6 +35,20 @@ declare module '@solana/spl-token-swap' {
     static getMinBalanceRentForExemptTokenSwap(
       connection: Connection,
     ): Promise<number>;
+
+    static createInitSwapInstruction(
+      programId: PublicKey,
+      tokenSwapAccount: Account,
+      authority: PublicKey,
+      nonce: number,
+      tokenAccountA: PublicKey,
+      tokenAccountB: PublicKey,
+      tokenPool: PublicKey,
+      tokenAccountPool: PublicKey,
+      tokenProgramId: PublicKey,
+      feeNumerator: number,
+      feeDenominator: number
+    ): TransactionInstruction;
 
     static createTokenSwap(
       connection: Connection,

--- a/token/js/client/token.js
+++ b/token/js/client/token.js
@@ -13,7 +13,7 @@ import {
   TransactionInstruction,
   SYSVAR_RENT_PUBKEY,
 } from '@solana/web3.js';
-import type {Connection, TransactionSignature} from '@solana/web3.js';
+import type {Connection, Commitment, TransactionSignature} from '@solana/web3.js';
 
 import * as Layout from './layout';
 import {sendAndConfirmTransaction} from './util/send-and-confirm-transaction';
@@ -107,7 +107,7 @@ type MintInfo = {|
   freezeAuthority: null | PublicKey,
 |};
 
-const MintLayout = BufferLayout.struct([
+export const MintLayout = BufferLayout.struct([
   BufferLayout.u32('mintAuthorityOption'),
   Layout.publicKey('mintAuthority'),
   Layout.uint64('supply'),
@@ -177,7 +177,7 @@ type AccountInfo = {|
 /**
  * @private
  */
-const AccountLayout = BufferLayout.struct([
+export const AccountLayout = BufferLayout.struct([
   Layout.publicKey('mint'),
   Layout.publicKey('owner'),
   Layout.uint64('amount'),
@@ -619,8 +619,8 @@ export class Token {
    *
    * @param account Public key of the account
    */
-  async getAccountInfo(account: PublicKey): Promise<AccountInfo> {
-    const info = await this.connection.getAccountInfo(account);
+  async getAccountInfo(account: PublicKey, commitment?: Commitment): Promise<AccountInfo> {
+    const info = await this.connection.getAccountInfo(account, commitment);
     if (info === null) {
       throw new Error('Failed to find account');
     }

--- a/token/js/module.d.ts
+++ b/token/js/module.d.ts
@@ -1,6 +1,7 @@
 declare module '@solana/spl-token' {
   import { Buffer } from 'buffer';
-  import { PublicKey, TransactionInstruction, TransactionSignature, Connection, Account } from "@solana/web3.js";
+  import { Layout } from 'buffer-layout';
+  import { PublicKey, TransactionInstruction, TransactionSignature, Connection, Account } from '@solana/web3.js';
   import BN from 'bn.js';
 
   // === client/token.js ===
@@ -15,7 +16,7 @@ declare module '@solana/spl-token' {
   | 'CloseAccount';
 
   export const NATIVE_MINT: PublicKey;
-
+  export const MintLayout: Layout;
   export type MintInfo = {
     mintAuthority: null | PublicKey,
     supply: u64,
@@ -23,6 +24,8 @@ declare module '@solana/spl-token' {
     isInitialized: boolean,
     freezeAuthority: null | PublicKey,
   };
+
+  export const AccountLayout: Layout;
   export type AccountInfo = {
     mint: PublicKey,
     owner: PublicKey,

--- a/token/js/module.flow.js
+++ b/token/js/module.flow.js
@@ -6,7 +6,6 @@
  */
 
 declare module '@solana/spl-token' {
-  // === client/token.js ===
   declare export class u64 extends BN {
     toBuffer(): Buffer;
     static fromBuffer(buffer: Buffer): u64;
@@ -17,6 +16,7 @@ declare module '@solana/spl-token' {
     | 'AccountOwner'
     | 'CloseAccount';
   declare export var NATIVE_MINT: PublicKey;
+  declare export var MintLayout: Layout;
   declare export type MintInfo = {|
     mintAuthority: null | PublicKey,
     supply: u64,
@@ -24,6 +24,7 @@ declare module '@solana/spl-token' {
     isInitialized: boolean,
     freezeAuthority: null | PublicKey,
   |};
+  declare export var AccountLayout: Layout;
   declare export type AccountInfo = {|
     mint: PublicKey,
     owner: PublicKey,


### PR DESCRIPTION
Expose Layouts and instruction creation functions to allow more flexible use of the Token and TokenSwap clients.

This PR does two things:

- expose the Mint, Account and TokenSwap layouts, so that you can TransactionInstructions to create system program accounts for each of them. The alternative is using the client functions, which send a transaction immediately and therefore require passing an account (with secret key).
- expose a static function to create a TransactionInstruction that initialises the token swap, again to avoid having to pass an account..