### PR TITLE
Fix lint check in CI

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -62,7 +62,7 @@ cargo test --manifest-path=token/perf-monitor/Cargo.toml -- --nocapture
 js_token() {
   cd token/js
   time npm install || exit $?
-  time npm run lint || exit $?
+  time npm run lint:check || exit $?
   time npm run flow || exit $?
   tsc module.d.ts || exit $?
 
@@ -80,7 +80,7 @@ _ js_token
 js_token_swap() {
   cd token-swap/js
   time npm install || exit $?
-  time npm run lint || exit $?
+  time npm run lint:check || exit $?
   time npm run flow || exit $?
   tsc module.d.ts || exit $?
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -62,7 +62,7 @@ cargo test --manifest-path=token/perf-monitor/Cargo.toml -- --nocapture
 js_token() {
   cd token/js
   time npm install || exit $?
-  time npm run lint:check || exit $?
+  time npm run lint || exit $?
   time npm run flow || exit $?
   tsc module.d.ts || exit $?
 
@@ -80,7 +80,7 @@ _ js_token
 js_token_swap() {
   cd token-swap/js
   time npm install || exit $?
-  time npm run lint:check || exit $?
+  time npm run lint || exit $?
   time npm run flow || exit $?
   tsc module.d.ts || exit $?
 

--- a/token-swap/js/client/layout.js
+++ b/token-swap/js/client/layout.js
@@ -19,7 +19,7 @@ export const uint64 = (property: string = 'uint64'): Object => {
 /**
  * Layout for a Rust String type
  */
-export const rustString = (property: string = 'string') => {
+export const rustString = (property: string = 'string'): Object => {
   const rsl = BufferLayout.struct(
     [
       BufferLayout.u32('length'),

--- a/token-swap/js/client/token-swap.js
+++ b/token-swap/js/client/token-swap.js
@@ -5,11 +5,17 @@
 import assert from 'assert';
 import BN from 'bn.js';
 import * as BufferLayout from 'buffer-layout';
-import type { Connection, TransactionSignature } from '@solana/web3.js';
-import { Account, PublicKey, SystemProgram, Transaction, TransactionInstruction, } from '@solana/web3.js';
+import type {Connection, TransactionSignature} from '@solana/web3.js';
+import {
+  Account,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  TransactionInstruction,
+} from '@solana/web3.js';
 
 import * as Layout from './layout';
-import { sendAndConfirmTransaction } from './util/send-and-confirm-transaction';
+import {sendAndConfirmTransaction} from './util/send-and-confirm-transaction';
 
 /**
  * Some amount of tokens
@@ -18,7 +24,7 @@ export class Numberu64 extends BN {
   /**
    * Convert to Buffer representation
    */
-  toBuffer(): Buffer {
+  toBuffer(): typeof Buffer {
     const a = super.toArray().reverse();
     const b = Buffer.from(a);
     if (b.length === 8) {
@@ -34,7 +40,7 @@ export class Numberu64 extends BN {
   /**
    * Construct a Numberu64 from Buffer representation
    */
-  static fromBuffer(buffer: Buffer): Numberu64 {
+  static fromBuffer(buffer: typeof Buffer): Numberu64 {
     assert(buffer.length === 8, `Invalid buffer length: ${buffer.length}`);
     return new BN(
       [...buffer]
@@ -89,15 +95,17 @@ type TokenSwapInfo = {|
 /**
  * @private
  */
-export const TokenSwapLayout = BufferLayout.struct([
-  BufferLayout.u8('isInitialized'),
-  BufferLayout.u8('nonce'),
-  Layout.publicKey('tokenAccountA'),
-  Layout.publicKey('tokenAccountB'),
-  Layout.publicKey('tokenPool'),
-  Layout.uint64('feesNumerator'),
-  Layout.uint64('feesDenominator'),
-]);
+export const TokenSwapLayout: typeof BufferLayout.Structure = BufferLayout.struct(
+  [
+    BufferLayout.u8('isInitialized'),
+    BufferLayout.u8('nonce'),
+    Layout.publicKey('tokenAccountA'),
+    Layout.publicKey('tokenAccountB'),
+    Layout.publicKey('tokenPool'),
+    Layout.uint64('feesNumerator'),
+    Layout.uint64('feesDenominator'),
+  ],
+);
 
 /**
  * An ERC20-like Token
@@ -153,7 +161,6 @@ export class TokenSwap {
     );
   }
 
-
   static createInitSwapInstruction(
     tokenSwapAccount: Account,
     authority: PublicKey,
@@ -165,16 +172,16 @@ export class TokenSwap {
     tokenProgramId: PublicKey,
     swapProgramId: PublicKey,
     feeNumerator: number,
-    feeDenominator: number
-  ):TransactionInstruction {
+    feeDenominator: number,
+  ): TransactionInstruction {
     const keys = [
-      { pubkey: tokenSwapAccount.publicKey, isSigner: false, isWritable: true },
-      { pubkey: authority, isSigner: false, isWritable: false },
-      { pubkey: tokenAccountA, isSigner: false, isWritable: false },
-      { pubkey: tokenAccountB, isSigner: false, isWritable: false },
-      { pubkey: tokenPool, isSigner: false, isWritable: true },
-      { pubkey: tokenAccountPool, isSigner: false, isWritable: true },
-      { pubkey: tokenProgramId, isSigner: false, isWritable: false },
+      {pubkey: tokenSwapAccount.publicKey, isSigner: false, isWritable: true},
+      {pubkey: authority, isSigner: false, isWritable: false},
+      {pubkey: tokenAccountA, isSigner: false, isWritable: false},
+      {pubkey: tokenAccountB, isSigner: false, isWritable: false},
+      {pubkey: tokenPool, isSigner: false, isWritable: true},
+      {pubkey: tokenAccountPool, isSigner: false, isWritable: true},
+      {pubkey: tokenProgramId, isSigner: false, isWritable: false},
     ];
     const commandDataLayout = BufferLayout.struct([
       BufferLayout.u8('instruction'),
@@ -257,7 +264,19 @@ export class TokenSwap {
       }),
     );
 
-    const instruction = TokenSwap.createInitSwapInstruction(tokenSwapAccount, authority, nonce, tokenAccountA, tokenAccountB, tokenPool, tokenAccountPool, tokenProgramId, swapProgramId, feeNumerator, feeDenominator);
+    const instruction = TokenSwap.createInitSwapInstruction(
+      tokenSwapAccount,
+      authority,
+      nonce,
+      tokenAccountA,
+      tokenAccountB,
+      tokenPool,
+      tokenAccountPool,
+      tokenProgramId,
+      swapProgramId,
+      feeNumerator,
+      feeDenominator,
+    );
 
     transaction.add(instruction);
     await sendAndConfirmTransaction(
@@ -270,7 +289,6 @@ export class TokenSwap {
 
     return tokenSwap;
   }
-
 
   /**
    * Retrieve tokenSwap information

--- a/token-swap/js/client/util/store.js
+++ b/token-swap/js/client/util/store.js
@@ -9,18 +9,20 @@ import fs from 'mz/fs';
 import mkdirp from 'mkdirp-promise';
 
 export class Store {
-  dir = path.join(__dirname, 'store');
+  static getDir(): string {
+    return path.join(__dirname, 'store');
+  }
 
   async load(uri: string): Promise<Object> {
-    const filename = path.join(this.dir, uri);
+    const filename = path.join(Store.getDir(), uri);
     const data = await fs.readFile(filename, 'utf8');
     const config = JSON.parse(data);
     return config;
   }
 
   async save(uri: string, config: Object): Promise<void> {
-    await mkdirp(this.dir);
-    const filename = path.join(this.dir, uri);
+    await mkdirp(Store.getDir());
+    const filename = path.join(Store.getDir(), uri);
     await fs.writeFile(filename, JSON.stringify(config), 'utf8');
   }
 }

--- a/token-swap/js/module.d.ts
+++ b/token-swap/js/module.d.ts
@@ -1,7 +1,13 @@
 declare module '@solana/spl-token-swap' {
-  import { Buffer } from 'buffer';
-  import { Layout } from 'buffer-layout';
-  import { PublicKey, TransactionInstruction, TransactionSignature, Connection, Account } from "@solana/web3.js";
+  import {Buffer} from 'buffer';
+  import {Layout} from 'buffer-layout';
+  import {
+    PublicKey,
+    TransactionInstruction,
+    TransactionSignature,
+    Connection,
+    Account,
+  } from '@solana/web3.js';
   import BN from 'bn.js';
 
   // === client/token-swap.js ===
@@ -11,19 +17,24 @@ declare module '@solana/spl-token-swap' {
   }
 
   export type TokenSwapInfo = {
-    nonce: number,
-    tokenAccountA: PublicKey,
-    tokenAccountB: PublicKey,
-    tokenPool: PublicKey,
-    feesNumerator: Numberu64,
-    feesDenominator: Numberu64,
-    feeRatio: number,
+    nonce: number;
+    tokenAccountA: PublicKey;
+    tokenAccountB: PublicKey;
+    tokenPool: PublicKey;
+    feesNumerator: Numberu64;
+    feesDenominator: Numberu64;
+    feeRatio: number;
   };
 
   export const TokenSwapLayout: Layout;
 
   export class TokenSwap {
-    constructor(connection: Connection, tokenSwap: PublicKey, programId: PublicKey, payer: Account);
+    constructor(
+      connection: Connection,
+      tokenSwap: PublicKey,
+      programId: PublicKey,
+      payer: Account,
+    );
 
     static getMinBalanceRentForExemptTokenSwap(
       connection: Connection,
@@ -40,7 +51,7 @@ declare module '@solana/spl-token-swap' {
       tokenProgramId: PublicKey,
       swapProgramId: PublicKey,
       feeNumerator: number,
-      feeDenominator: number
+      feeDenominator: number,
     ): TransactionInstruction;
 
     static createTokenSwap(
@@ -57,9 +68,9 @@ declare module '@solana/spl-token-swap' {
       feeNumerator: number,
       feeDenominator: number,
       swapProgramId: PublicKey,
-    ): Promise<TokenSwap>
+    ): Promise<TokenSwap>;
 
-    getInfo(): Promise<TokenSwapInfo>
+    getInfo(): Promise<TokenSwapInfo>;
     swap(
       authority: PublicKey,
       source: PublicKey,
@@ -68,7 +79,7 @@ declare module '@solana/spl-token-swap' {
       destination: PublicKey,
       tokenProgramId: PublicKey,
       amount: number | Numberu64,
-    ): Promise<TransactionSignature>
+    ): Promise<TransactionSignature>;
 
     static swapInstruction(
       tokenSwap: PublicKey,
@@ -80,7 +91,7 @@ declare module '@solana/spl-token-swap' {
       swapProgramId: PublicKey,
       tokenProgramId: PublicKey,
       amount: number | Numberu64,
-    ): TransactionInstruction
+    ): TransactionInstruction;
 
     deposit(
       authority: PublicKey,
@@ -92,7 +103,7 @@ declare module '@solana/spl-token-swap' {
       poolAccount: PublicKey,
       tokenProgramId: PublicKey,
       amount: number | Numberu64,
-    ): Promise<TransactionSignature>
+    ): Promise<TransactionSignature>;
 
     static depositInstruction(
       tokenSwap: PublicKey,
@@ -106,7 +117,7 @@ declare module '@solana/spl-token-swap' {
       swapProgramId: PublicKey,
       tokenProgramId: PublicKey,
       amount: number | Numberu64,
-    ): TransactionInstruction
+    ): TransactionInstruction;
 
     withdraw(
       authority: PublicKey,
@@ -118,7 +129,7 @@ declare module '@solana/spl-token-swap' {
       userAccountB: PublicKey,
       tokenProgramId: PublicKey,
       amount: number | Numberu64,
-    ): Promise<TransactionSignature>
+    ): Promise<TransactionSignature>;
 
     static withdrawInstruction(
       tokenSwap: PublicKey,
@@ -132,6 +143,6 @@ declare module '@solana/spl-token-swap' {
       swapProgramId: PublicKey,
       tokenProgramId: PublicKey,
       amount: number | Numberu64,
-    ): TransactionInstruction
+    ): TransactionInstruction;
   }
 }

--- a/token-swap/js/module.flow.js
+++ b/token-swap/js/module.flow.js
@@ -47,7 +47,7 @@ declare module '@solana/spl-token-swap' {
       tokenAccountPool: PublicKey,
       tokenProgramId: PublicKey,
       feeNumerator: number,
-      feeDenominator: number
+      feeDenominator: number,
     ): TransactionInstruction;
 
     static createTokenSwap(

--- a/token-swap/js/package-lock.json
+++ b/token-swap/js/package-lock.json
@@ -3734,9 +3734,9 @@
       "dev": true
     },
     "flow-bin": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.131.0.tgz",
-      "integrity": "sha512-fZmoIBcDrtLhy/NNMxwJysSYzMr1ksRcAOMi3AHSoYXfcuQqTvhGJx+wqjlIOqIwz8RRYm8J4V4JrSJbIKP+Xg==",
+      "version": "0.134.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.134.0.tgz",
+      "integrity": "sha512-j5aCugO3jmwDsUKc+7KReArgnL6aVjHLo6DlozKhxKYN+TaP8BY+mintPSISjSQtKZFJyvoNAc1oXA79X5WjIA==",
       "dev": true
     },
     "flow-typed": {

--- a/token-swap/js/package.json
+++ b/token-swap/js/package.json
@@ -27,6 +27,7 @@
     "build": "rollup -c",
     "start": "babel-node --ignore node_modules cli/main.js",
     "lint": "npm run pretty && eslint .",
+    "lint:check": "npm run pretty:check && eslint .",
     "lint:fix": "npm run lint -- --fix",
     "flow": "flow",
     "flow:watch": "watch 'flow' . --wait=1 --ignoreDirectoryPattern=/doc/",
@@ -40,7 +41,8 @@
     "localnet:up": "rm client/util/store/config.json; set -x; solana-localnet down; set -e; solana-localnet up",
     "localnet:down": "solana-localnet down",
     "localnet:logs": "solana-localnet logs -f",
-    "pretty": "prettier --write '{,cli*/**/}*.js'"
+    "pretty": "prettier --write '{,cli*/**/}*.[jt]s'",
+    "pretty:check": "prettier --check '{,cli*/**/}*.[jt]s'"
   },
   "keywords": [],
   "dependencies": {
@@ -65,7 +67,7 @@
     "babel-eslint": "^10.1.0",
     "eslint": "^7.9.0",
     "eslint-plugin-import": "^2.22.0",
-    "flow-bin": "0.131.0",
+    "flow-bin": "0.134.0",
     "flow-typed": "^3.2.0",
     "mz": "^2.7.0",
     "prettier": "^2.1.2",

--- a/token-swap/js/package.json
+++ b/token-swap/js/package.json
@@ -27,8 +27,7 @@
     "build": "rollup -c",
     "start": "babel-node --ignore node_modules cli/main.js",
     "lint": "npm run pretty && eslint .",
-    "lint:check": "npm run pretty:check && eslint .",
-    "lint:fix": "npm run lint -- --fix",
+    "lint:fix": "npm run pretty:fix && eslint . --fix",
     "flow": "flow",
     "flow:watch": "watch 'flow' . --wait=1 --ignoreDirectoryPattern=/doc/",
     "lint:watch": "watch 'npm run lint:fix' . --wait=1",
@@ -41,8 +40,8 @@
     "localnet:up": "rm client/util/store/config.json; set -x; solana-localnet down; set -e; solana-localnet up",
     "localnet:down": "solana-localnet down",
     "localnet:logs": "solana-localnet logs -f",
-    "pretty": "prettier --write '{,cli*/**/}*.[jt]s'",
-    "pretty:check": "prettier --check '{,cli*/**/}*.[jt]s'"
+    "pretty": "prettier --check '{,cli*/**/}*.[jt]s'",
+    "pretty:fix": "prettier --write '{,cli*/**/}*.[jt]s'"
   },
   "keywords": [],
   "dependencies": {

--- a/token/js/client/layout.js
+++ b/token/js/client/layout.js
@@ -19,7 +19,7 @@ export const uint64 = (property: string = 'uint64'): Object => {
 /**
  * Layout for a Rust String type
  */
-export const rustString = (property: string = 'string') => {
+export const rustString = (property: string = 'string'): Object => {
   const rsl = BufferLayout.struct(
     [
       BufferLayout.u32('length'),

--- a/token/js/client/token.js
+++ b/token/js/client/token.js
@@ -13,7 +13,11 @@ import {
   TransactionInstruction,
   SYSVAR_RENT_PUBKEY,
 } from '@solana/web3.js';
-import type {Connection, Commitment, TransactionSignature} from '@solana/web3.js';
+import type {
+  Connection,
+  Commitment,
+  TransactionSignature,
+} from '@solana/web3.js';
 
 import * as Layout from './layout';
 import {sendAndConfirmTransaction} from './util/send-and-confirm-transaction';
@@ -25,7 +29,7 @@ export class u64 extends BN {
   /**
    * Convert to Buffer representation
    */
-  toBuffer(): Buffer {
+  toBuffer(): typeof Buffer {
     const a = super.toArray().reverse();
     const b = Buffer.from(a);
     if (b.length === 8) {
@@ -41,7 +45,7 @@ export class u64 extends BN {
   /**
    * Construct a u64 from Buffer representation
    */
-  static fromBuffer(buffer: Buffer): u64 {
+  static fromBuffer(buffer: typeof Buffer): u64 {
     assert(buffer.length === 8, `Invalid buffer length: ${buffer.length}`);
     return new BN(
       [...buffer]
@@ -71,7 +75,7 @@ const AuthorityTypeCodes = {
 };
 
 // The address of the special mint for wrapped native token.
-export const NATIVE_MINT = new PublicKey(
+export const NATIVE_MINT: PublicKey = new PublicKey(
   'So11111111111111111111111111111111111111112',
 );
 
@@ -107,7 +111,7 @@ type MintInfo = {|
   freezeAuthority: null | PublicKey,
 |};
 
-export const MintLayout = BufferLayout.struct([
+export const MintLayout: typeof BufferLayout.Structure = BufferLayout.struct([
   BufferLayout.u32('mintAuthorityOption'),
   Layout.publicKey('mintAuthority'),
   Layout.uint64('supply'),
@@ -177,19 +181,21 @@ type AccountInfo = {|
 /**
  * @private
  */
-export const AccountLayout = BufferLayout.struct([
-  Layout.publicKey('mint'),
-  Layout.publicKey('owner'),
-  Layout.uint64('amount'),
-  BufferLayout.u32('delegateOption'),
-  Layout.publicKey('delegate'),
-  BufferLayout.u8('state'),
-  BufferLayout.u32('isNativeOption'),
-  Layout.uint64('isNative'),
-  Layout.uint64('delegatedAmount'),
-  BufferLayout.u32('closeAuthorityOption'),
-  Layout.publicKey('closeAuthority'),
-]);
+export const AccountLayout: typeof BufferLayout.Structure = BufferLayout.struct(
+  [
+    Layout.publicKey('mint'),
+    Layout.publicKey('owner'),
+    Layout.uint64('amount'),
+    BufferLayout.u32('delegateOption'),
+    Layout.publicKey('delegate'),
+    BufferLayout.u8('state'),
+    BufferLayout.u32('isNativeOption'),
+    Layout.uint64('isNative'),
+    Layout.uint64('delegatedAmount'),
+    BufferLayout.u32('closeAuthorityOption'),
+    Layout.publicKey('closeAuthority'),
+  ],
+);
 
 /**
  * Information about an multisig
@@ -619,7 +625,10 @@ export class Token {
    *
    * @param account Public key of the account
    */
-  async getAccountInfo(account: PublicKey, commitment?: Commitment): Promise<AccountInfo> {
+  async getAccountInfo(
+    account: PublicKey,
+    commitment?: Commitment,
+  ): Promise<AccountInfo> {
     const info = await this.connection.getAccountInfo(account, commitment);
     if (info === null) {
       throw new Error('Failed to find account');

--- a/token/js/client/util/store.js
+++ b/token/js/client/util/store.js
@@ -9,18 +9,20 @@ import fs from 'mz/fs';
 import mkdirp from 'mkdirp-promise';
 
 export class Store {
-  dir = path.join(__dirname, 'store');
+  static getDir(): string {
+    return path.join(__dirname, 'store');
+  }
 
   async load(uri: string): Promise<Object> {
-    const filename = path.join(this.dir, uri);
+    const filename = path.join(Store.getDir(), uri);
     const data = await fs.readFile(filename, 'utf8');
     const config = JSON.parse(data);
     return config;
   }
 
   async save(uri: string, config: Object): Promise<void> {
-    await mkdirp(this.dir);
-    const filename = path.join(this.dir, uri);
+    await mkdirp(Store.getDir());
+    const filename = path.join(Store.getDir(), uri);
     await fs.writeFile(filename, JSON.stringify(config), 'utf8');
   }
 }

--- a/token/js/module.d.ts
+++ b/token/js/module.d.ts
@@ -1,7 +1,13 @@
 declare module '@solana/spl-token' {
-  import { Buffer } from 'buffer';
-  import { Layout } from 'buffer-layout';
-  import { PublicKey, TransactionInstruction, TransactionSignature, Connection, Account } from '@solana/web3.js';
+  import {Buffer} from 'buffer';
+  import {Layout} from 'buffer-layout';
+  import {
+    PublicKey,
+    TransactionInstruction,
+    TransactionSignature,
+    Connection,
+    Account,
+  } from '@solana/web3.js';
   import BN from 'bn.js';
 
   // === client/token.js ===
@@ -10,49 +16,49 @@ declare module '@solana/spl-token' {
     static fromBuffer(buffer: Buffer): u64;
   }
   export type AuthorityType =
-  | 'MintTokens'
-  | 'FreezeAccount'
-  | 'AccountOwner'
-  | 'CloseAccount';
+    | 'MintTokens'
+    | 'FreezeAccount'
+    | 'AccountOwner'
+    | 'CloseAccount';
 
   export const NATIVE_MINT: PublicKey;
   export const MintLayout: Layout;
   export type MintInfo = {
-    mintAuthority: null | PublicKey,
-    supply: u64,
-    decimals: number,
-    isInitialized: boolean,
-    freezeAuthority: null | PublicKey,
+    mintAuthority: null | PublicKey;
+    supply: u64;
+    decimals: number;
+    isInitialized: boolean;
+    freezeAuthority: null | PublicKey;
   };
 
   export const AccountLayout: Layout;
   export type AccountInfo = {
-    mint: PublicKey,
-    owner: PublicKey,
-    amount: u64,
-    delegate: null | PublicKey,
-    delegatedAmount: u64,
-    isInitialized: boolean,
-    isFrozen: boolean,
-    isNative: boolean,
-    rentExemptReserve: null | u64,
-    closeAuthority: null | PublicKey,
+    mint: PublicKey;
+    owner: PublicKey;
+    amount: u64;
+    delegate: null | PublicKey;
+    delegatedAmount: u64;
+    isInitialized: boolean;
+    isFrozen: boolean;
+    isNative: boolean;
+    rentExemptReserve: null | u64;
+    closeAuthority: null | PublicKey;
   };
   export type MultisigInfo = {
-    m: number,
-    n: number,
-    initialized: boolean,
-    signer1: PublicKey,
-    signer2: PublicKey,
-    signer3: PublicKey,
-    signer4: PublicKey,
-    signer5: PublicKey,
-    signer6: PublicKey,
-    signer7: PublicKey,
-    signer8: PublicKey,
-    signer9: PublicKey,
-    signer10: PublicKey,
-    signer11: PublicKey,
+    m: number;
+    n: number;
+    initialized: boolean;
+    signer1: PublicKey;
+    signer2: PublicKey;
+    signer3: PublicKey;
+    signer4: PublicKey;
+    signer5: PublicKey;
+    signer6: PublicKey;
+    signer7: PublicKey;
+    signer8: PublicKey;
+    signer9: PublicKey;
+    signer10: PublicKey;
+    signer11: PublicKey;
   };
   export class Token {
     constructor(
@@ -72,11 +78,11 @@ declare module '@solana/spl-token' {
     static getAccount(connection: Connection): Promise<Account>;
     createAccount(owner: PublicKey): Promise<PublicKey>;
     static createWrappedNativeAccount(
-        connection: Connection,
-        programId: PublicKey,
-        owner: PublicKey,
-        payer: Account,
-        amount: number,
+      connection: Connection,
+      programId: PublicKey,
+      owner: PublicKey,
+      payer: Account,
+      amount: number,
     ): Promise<PublicKey>;
     createMultisig(m: number, signers: Array<PublicKey>): Promise<PublicKey>;
     getMintInfo(): Promise<MintInfo>;

--- a/token/js/package-lock.json
+++ b/token/js/package-lock.json
@@ -4138,9 +4138,9 @@
       "dev": true
     },
     "flow-bin": {
-      "version": "0.131.0",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.131.0.tgz",
-      "integrity": "sha512-fZmoIBcDrtLhy/NNMxwJysSYzMr1ksRcAOMi3AHSoYXfcuQqTvhGJx+wqjlIOqIwz8RRYm8J4V4JrSJbIKP+Xg==",
+      "version": "0.134.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.134.0.tgz",
+      "integrity": "sha512-j5aCugO3jmwDsUKc+7KReArgnL6aVjHLo6DlozKhxKYN+TaP8BY+mintPSISjSQtKZFJyvoNAc1oXA79X5WjIA==",
       "dev": true
     },
     "flow-typed": {

--- a/token/js/package.json
+++ b/token/js/package.json
@@ -27,8 +27,7 @@
     "build": "rollup -c",
     "start": "babel-node cli/main.js",
     "lint": "npm run pretty && eslint .",
-    "lint:check": "npm run pretty:check && eslint .",
-    "lint:fix": "npm run lint -- --fix",
+    "lint:fix": "npm run pretty:fix && eslint . --fix",
     "flow": "flow",
     "flow:watch": "watch 'flow' . --wait=1 --ignoreDirectoryPattern=/doc/",
     "lint:watch": "watch 'npm run lint:fix' . --wait=1",
@@ -41,8 +40,8 @@
     "localnet:up": "rm client/util/store/config.json; set -x; solana-localnet down; set -e; solana-localnet up",
     "localnet:down": "solana-localnet down",
     "localnet:logs": "solana-localnet logs -f",
-    "pretty": "prettier --write '{,cli*/**/}*.[jt]s'",
-    "pretty:check": "prettier --check '{,cli*/**/}*.[jt]s'"
+    "pretty": "prettier --check '{,cli*/**/}*.[jt]s'",
+    "pretty:fix": "prettier --write '{,cli*/**/}*.[jt]s'"
   },
   "dependencies": {
     "@babel/runtime": "^7.10.5",

--- a/token/js/package.json
+++ b/token/js/package.json
@@ -27,6 +27,7 @@
     "build": "rollup -c",
     "start": "babel-node cli/main.js",
     "lint": "npm run pretty && eslint .",
+    "lint:check": "npm run pretty:check && eslint .",
     "lint:fix": "npm run lint -- --fix",
     "flow": "flow",
     "flow:watch": "watch 'flow' . --wait=1 --ignoreDirectoryPattern=/doc/",
@@ -40,7 +41,8 @@
     "localnet:up": "rm client/util/store/config.json; set -x; solana-localnet down; set -e; solana-localnet up",
     "localnet:down": "solana-localnet down",
     "localnet:logs": "solana-localnet logs -f",
-    "pretty": "prettier --write '{,cli*/**/}*.js'"
+    "pretty": "prettier --write '{,cli*/**/}*.[jt]s'",
+    "pretty:check": "prettier --check '{,cli*/**/}*.[jt]s'"
   },
   "dependencies": {
     "@babel/runtime": "^7.10.5",
@@ -63,7 +65,7 @@
     "babel-eslint": "^10.1.0",
     "eslint": "^7.4.0",
     "eslint-plugin-import": "^2.22.0",
-    "flow-bin": "0.131.0",
+    "flow-bin": "0.134.0",
     "flow-typed": "^3.2.0",
     "mz": "^2.7.0",
     "prettier": "^2.0.5",


### PR DESCRIPTION
* `npm run lint` now checks that code is properly formatted, instead of
  running the formatter
* Add extra commands to run the linting, include ts definitions file
* Update flow-bin, fix type errors that came up