### PR TITLE
Owner doesn't need to sign spl-token initialize transactions

### DIFF
--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -123,11 +123,7 @@ fn command_create_token(
         minimum_balance_for_rent_exemption
             + fee_calculator.calculate_fee(&transaction.message(), None),
     )?;
-    let mut signers = vec![
-        config.fee_payer.as_ref(),
-        config.owner.as_ref(),
-        token.as_ref(),
-    ];
+    let mut signers = vec![config.fee_payer.as_ref(), token.as_ref()];
     unique_signers!(signers);
     transaction.sign(&signers, recent_blockhash);
     Ok(Some(transaction))
@@ -169,11 +165,7 @@ fn command_create_account(
         minimum_balance_for_rent_exemption
             + fee_calculator.calculate_fee(&transaction.message(), None),
     )?;
-    let mut signers = vec![
-        config.fee_payer.as_ref(),
-        account.as_ref(),
-        config.owner.as_ref(),
-    ];
+    let mut signers = vec![config.fee_payer.as_ref(), account.as_ref()];
     unique_signers!(signers);
     transaction.sign(&signers, recent_blockhash);
     Ok(Some(transaction))


### PR DESCRIPTION
CreateAccount+InitializeMint and CreateAccount+InitializeAccount transactions are both being signed by an extra Signer; the owner doesn't need to sign Initialize instructions. Due to `unique_signers`, this wasn't an issue when the owner and fee-payer were always the same. However, now that the `--owner` and `--fee-payer` args work to identify separate Signers, the extra Signer panics the app.

Remove unnecessary owner signer