### PR TITLE
Upgrade web3 to 0.78.0 and sdk to 1.3.13

### DIFF
--- a/bpf-sdk-install.sh
+++ b/bpf-sdk-install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-channel=${1:-v1.3.12}
+channel=${1:-v1.3.13}
 installDir="$(dirname "$0")"/bin
 cacheDir=~/.cache/solana-bpf-sdk/"$channel"
 

--- a/token-swap/js/client/util/send-and-confirm-transaction.js
+++ b/token-swap/js/client/util/send-and-confirm-transaction.js
@@ -15,7 +15,8 @@ export function sendAndConfirmTransaction(
   ...signers: Array<Account>
 ): Promise<TransactionSignature> {
   return realSendAndConfirmTransaction(connection, transaction, signers, {
-    skipPreflight: true,
+    skipPreflight: false,
     commitment: 'recent',
+    preflightCommitment: 'recent',
   });
 }

--- a/token-swap/js/package-lock.json
+++ b/token-swap/js/package-lock.json
@@ -1756,9 +1756,9 @@
       "dev": true
     },
     "@solana/web3.js": {
-      "version": "0.77.0",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-0.77.0.tgz",
-      "integrity": "sha512-qfJTpzrUDfmI7h7gK2ApwqMVrkrU1qyF/AzyDkzhEfdbpZHZQeezDq1oRM2RuoKICuXmmIISHu0ddS7BBMqYjw==",
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-0.78.0.tgz",
+      "integrity": "sha512-A3WQkwCO/cuWwtaPyJy+AX7iyImpmMwpu/S6JZ/YR8f4SHNk0QV7Tu0NcrcSSt/wp4rBp0e3I3Su46+hrjYNFw==",
       "requires": {
         "@babel/runtime": "^7.3.1",
         "bn.js": "^5.0.0",

--- a/token-swap/js/package.json
+++ b/token-swap/js/package.json
@@ -22,7 +22,7 @@
     "/lib",
     "/module.flow.js"
   ],
-  "testnetDefaultChannel": "v1.3.9",
+  "testnetDefaultChannel": "v1.3.13",
   "scripts": {
     "build": "rollup -c",
     "start": "babel-node --ignore node_modules cli/main.js",
@@ -46,7 +46,7 @@
   "keywords": [],
   "dependencies": {
     "@babel/runtime": "^7.11.2",
-    "@solana/web3.js": "^0.77.0",
+    "@solana/web3.js": "^0.78.0",
     "bn.js": "^5.1.3",
     "buffer-layout": "^1.2.0",
     "dotenv": "8.2.0",

--- a/token/js/client/util/send-and-confirm-transaction.js
+++ b/token/js/client/util/send-and-confirm-transaction.js
@@ -15,7 +15,8 @@ export function sendAndConfirmTransaction(
   ...signers: Array<Account>
 ): Promise<TransactionSignature> {
   return realSendAndConfirmTransaction(connection, transaction, signers, {
-    skipPreflight: true,
+    skipPreflight: false,
     commitment: 'recent',
+    preflightCommitment: 'recent',
   });
 }

--- a/token/js/package-lock.json
+++ b/token/js/package-lock.json
@@ -2086,9 +2086,9 @@
       "dev": true
     },
     "@solana/web3.js": {
-      "version": "0.77.0",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-0.77.0.tgz",
-      "integrity": "sha512-qfJTpzrUDfmI7h7gK2ApwqMVrkrU1qyF/AzyDkzhEfdbpZHZQeezDq1oRM2RuoKICuXmmIISHu0ddS7BBMqYjw==",
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-0.78.0.tgz",
+      "integrity": "sha512-A3WQkwCO/cuWwtaPyJy+AX7iyImpmMwpu/S6JZ/YR8f4SHNk0QV7Tu0NcrcSSt/wp4rBp0e3I3Su46+hrjYNFw==",
       "requires": {
         "@babel/runtime": "^7.3.1",
         "bn.js": "^5.0.0",

--- a/token/js/package.json
+++ b/token/js/package.json
@@ -22,7 +22,7 @@
     "/lib",
     "/module.flow.js"
   ],
-  "testnetDefaultChannel": "v1.3.9",
+  "testnetDefaultChannel": "v1.3.13",
   "scripts": {
     "build": "rollup -c",
     "start": "babel-node cli/main.js",
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.10.5",
-    "@solana/web3.js": "^0.77.0",
+    "@solana/web3.js": "^0.78.0",
     "bn.js": "^5.0.0",
     "buffer-layout": "^1.2.0",
     "dotenv": "8.2.0",


### PR DESCRIPTION
Also, update `sendAndConfirmTransaction` to use `preflightCommitment` of `recent`. For the token tests, on my machine, this setup took roughly 18.5 seconds, and with `skipPreflight: true` it was about 21.5 seconds.

The main question: should the commitments move to `singleGossip`?

cc @jstarry for awareness -- thanks for the announcement!