### PR TITLE
spl-token-cli: Use signer arg utils throughout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce4f9586c9a3151c4b49b19e82ba163dd073614dd057e53c969e1a4db5b52720"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "crypto-mac 0.8.0",
+ "digest 0.9.0",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,6 +240,27 @@ name = "bytes"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+
+[[package]]
+name = "bzip2"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.9+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad3b39a260062fca31f7b0b12f207e8f2590a67d32ec7d59c20484b07ea7285e"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "cbindgen"
@@ -360,6 +396,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
+name = "crc32fast"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,6 +479,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array 0.14.3",
+ "subtle 2.2.3",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,6 +539,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array 0.14.3",
+]
+
+[[package]]
+name = "dir-diff"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2860407d7d7e2e004bb2128510ad9e8d669e76fa005ccf567977b5d71b8b4a0b"
+dependencies = [
+ "walkdir",
 ]
 
 [[package]]
@@ -606,6 +670,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
 
 [[package]]
+name = "filetime"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed85775dcc68644b5c950ac06a2b23768d3bc9390464151aaf27136998dcf9e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "766d0e77a2c1502169d4a93ff3b8c15a71fd946cd0126309752104e5f3c46d94"
+dependencies = [
+ "cfg-if",
+ "crc32fast",
+ "libc",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -625,6 +713,12 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "fs_extra"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -762,6 +856,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
 name = "h2"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,7 +930,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
 dependencies = [
- "crypto-mac",
+ "crypto-mac 0.7.0",
  "digest 0.8.1",
 ]
 
@@ -1000,6 +1100,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
+name = "jemalloc-ctl"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c502a5ff9dd2924f1ed32ba96e3b65735d837b4bfd978d3161b1702e66aca4b7"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+ "paste",
+]
+
+[[package]]
+name = "jemalloc-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1019,9 +1151,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-core"
-version = "14.2.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0747307121ffb9703afd93afbd0fb4f854c38fb873f2c8b90e0e902f27c7b62"
+checksum = "f30b12567a31d48588a65b6cf870081e6ba1d7b2ae353977cb9820d512e69c70"
 dependencies = [
  "futures",
  "log",
@@ -1060,6 +1192,16 @@ name = "libc"
 version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "755456fae044e6fa1ebbbd1b3e902ae19e73097ed4ed87bb79934a867c007bc3"
+
+[[package]]
+name = "libloading"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2443d8f0478b16759158b2f66d525991a05491138bc05814ef52a250148ef4f9"
+dependencies = [
+ "cfg-if",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "libsecp256k1"
@@ -1426,13 +1568,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45ca20c77d80be666aef2b45486da86238fabe33e38306bd3118fe4af33fa880"
+dependencies = [
+ "paste-impl",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "paste-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6"
+dependencies = [
+ "proc-macro-hack",
+]
+
+[[package]]
 name = "pbkdf2"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "006c038a43a45995a9670da19e67600114740e8511d4333bf97a56e66a7542d9"
 dependencies = [
  "byteorder",
- "crypto-mac",
+ "crypto-mac 0.7.0",
 ]
 
 [[package]]
@@ -1784,6 +1945,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1988,9 +2158,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.3.13"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8af0e6f5a51919a90392bc85b1f7e58fbb94da62917481d5de9cbee50e2491bd"
+checksum = "70d996ae8448e50e1f7aa2b205e432bdffa20b8f1b59429ba6d52d716f8d64fd"
 dependencies = [
  "Inflector",
  "base64 0.12.3",
@@ -2011,9 +2181,9 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "1.3.13"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0f1e9601c19998c9adf56cfcc64b895ea00d1951d5bc3fe7912bd6738bfb6a3"
+checksum = "5fb1c7125f213121dcbcafd7d43d23c2fa0b31329e78561688196d3934919089"
 dependencies = [
  "chrono",
  "clap",
@@ -2041,9 +2211,9 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "1.3.13"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed68c386972c9765bd94b472672d83f1f61a8e35e4ead9f0a0bc0f52b1f8923"
+checksum = "4ecb40ed160ed398c94c5892cb0a7f44960d0ab50a377229f0eed84c202b83e9"
 dependencies = [
  "Inflector",
  "chrono",
@@ -2053,6 +2223,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "solana-account-decoder",
  "solana-clap-utils",
  "solana-client",
  "solana-sdk",
@@ -2063,9 +2234,9 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "1.3.13"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "085006b3482ca0f3bc2372be2f8e990f4746bc44a1c0fdb2d75414afe4a3c005"
+checksum = "daf8e2dafadadccb703c8a06b37a00efa0f38a06fa00f973e7653bf73f0b350f"
 dependencies = [
  "bincode",
  "bs58",
@@ -2091,9 +2262,9 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "1.3.13"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6a1bc002fa2c4753cda7592422c8107c1f9199bce10ee2b97b1bd0686c79315"
+checksum = "4a5fe6f27c71ff3248b8663b94bb1fe3c8560c8a14a3a33544dc447bdd662407"
 dependencies = [
  "bincode",
  "chrono",
@@ -2105,9 +2276,9 @@ dependencies = [
 
 [[package]]
 name = "solana-crate-features"
-version = "1.3.13"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "154d1182e191cf2a9cbf8018d012999a6780c36a030c1d6531a490e59f1ec73b"
+checksum = "2cc2deb783d0f6954d1a244cab9a7a20416c075b86918c5aa6a1be3caa795e32"
 dependencies = [
  "backtrace",
  "bytes 0.4.12",
@@ -2140,10 +2311,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-metrics"
-version = "1.3.13"
+name = "solana-measure"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc52d611b4147e306979057be6b311270adeb690584b61efe320b6492fde8c1b"
+checksum = "309e671f9a95cac920ada447b6852bd7e72e0635a1d3dc3bdd7a28668cdc5533"
+dependencies = [
+ "jemalloc-ctl",
+ "jemallocator",
+ "log",
+ "solana-metrics",
+ "solana-sdk",
+]
+
+[[package]]
+name = "solana-metrics"
+version = "1.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421614c84626f5ca2bc21760f8cc77df548791766e35c78e210218e616b92c37"
 dependencies = [
  "env_logger",
  "gethostname",
@@ -2155,9 +2339,9 @@ dependencies = [
 
 [[package]]
 name = "solana-net-utils"
-version = "1.3.13"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "303b2f5bdd4c484897392bf193bb605a5fa5ce63521c56012f87526f018e0a73"
+checksum = "3ac81eb0f46b9fca6cf14023298ef741f77f05105349ebc9689bff869d12006e"
 dependencies = [
  "bincode",
  "bytes 0.4.12",
@@ -2177,10 +2361,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-remote-wallet"
-version = "1.3.13"
+name = "solana-rayon-threadlimit"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd66f8ac141d2a441bf6b8b5fbd258b293c19ea5664a4d92eecd03d55bee2eb"
+checksum = "d02f25437a66002b1ce694143705d79cf79aa46cdda1f8decd12a3de2c90e386"
+dependencies = [
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
+name = "solana-remote-wallet"
+version = "1.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96f41d5e6b31f1b2c394881e36adf0f093baf53c08e3706f42cab09b0cbfb4e6"
 dependencies = [
  "base32",
  "console 0.11.3",
@@ -2197,10 +2391,58 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-sdk"
-version = "1.3.13"
+name = "solana-runtime"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae4af85d3817735d3de7c4a2b22e44e4d8efa0d8af862e3c12d5fe1d1be869a0"
+checksum = "dd7e80c2a751acc9a56c22852cccab6e9334873691f119296cb0fe6bbfae7c46"
+dependencies = [
+ "bincode",
+ "blake3",
+ "bv",
+ "byteorder",
+ "bzip2",
+ "crossbeam-channel",
+ "dir-diff",
+ "flate2",
+ "fnv",
+ "fs_extra",
+ "itertools",
+ "lazy_static",
+ "libc",
+ "libloading",
+ "log",
+ "memmap",
+ "num-derive",
+ "num-traits",
+ "num_cpus",
+ "rand",
+ "rayon",
+ "regex",
+ "rustc_version",
+ "serde",
+ "serde_derive",
+ "solana-config-program",
+ "solana-logger",
+ "solana-measure",
+ "solana-metrics",
+ "solana-rayon-threadlimit",
+ "solana-sdk",
+ "solana-sdk-macro-frozen-abi",
+ "solana-secp256k1-program",
+ "solana-stake-program",
+ "solana-vote-program",
+ "symlink",
+ "tar",
+ "tempfile",
+ "thiserror",
+ "zstd",
+]
+
+[[package]]
+name = "solana-sdk"
+version = "1.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa41a7f3655cb6336562e6c194d7ce5253ebbf21894bf3ef524e5f4e1b1d5e6a"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -2240,9 +2482,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.3.13"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5143a76c61935db475c941f32304851f1486395a427ebf073af4cbaef391888"
+checksum = "2678edfd446d5396fd5f8957bf3da820b8b8b780113ea4c5918a33059aecb7fd"
 dependencies = [
  "bs58",
  "proc-macro2 1.0.19",
@@ -2253,9 +2495,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro-frozen-abi"
-version = "1.3.13"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5c149ff4cab22c883e76e1186a318f7a516d1a58c36f9c2df07f7cfeb467d92"
+checksum = "024f848633a58dc8fdd52ce0491630a4a4c0fa3ed91ab9b9911bcbe5c7d2d4e8"
 dependencies = [
  "lazy_static",
  "proc-macro2 1.0.19",
@@ -2265,10 +2507,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-stake-program"
-version = "1.3.13"
+name = "solana-secp256k1-program"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd9e57ab166a0815152c4a4188e9093d981ef8623c0a7c359520378d086df038"
+checksum = "c5acdcfef86bd2b61839dde6992d12ac1b2765a2a45d050aad38e3f362af7c88"
+dependencies = [
+ "bincode",
+ "digest 0.9.0",
+ "libsecp256k1",
+ "rand",
+ "sha3",
+ "solana-logger",
+ "solana-sdk",
+]
+
+[[package]]
+name = "solana-stake-program"
+version = "1.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1a1b7383fc4758e7d9b63c6d12e5a6d596ecbfc5330805db7533b7e1fa6843"
 dependencies = [
  "bincode",
  "log",
@@ -2287,9 +2544,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.3.13"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de55778b3f791f0aeca4d6b07234cbfc9fecfe74a56f6e0e34d1485c84776a3"
+checksum = "f0f576afd214990e57cad9bb5496f96282b79e71646843ed02f432bcc494a6d4"
 dependencies = [
  "Inflector",
  "base64 0.12.3",
@@ -2310,24 +2567,25 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "1.3.13"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa008770555e1102d00464308c85677fadaffab46914747f02712c222a802387"
+checksum = "165562998bf171bc00e80bbfdca46d3fbe9e57cef92c46e93706f7727a5f2b47"
 dependencies = [
  "log",
  "rustc_version",
  "serde",
  "serde_derive",
  "solana-logger",
+ "solana-runtime",
  "solana-sdk",
  "solana-sdk-macro-frozen-abi",
 ]
 
 [[package]]
 name = "solana-vote-program"
-version = "1.3.13"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb3258db651628b86d5ec0b7f3780b308b0b5491d01c6170ec21ee00652e1d3"
+checksum = "31111ce08a479196243bf5335a173f899960ec5fdc0d937fe3bd42289dfbb656"
 dependencies = [
  "bincode",
  "log",
@@ -2458,6 +2716,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "0.15.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2489,6 +2753,18 @@ dependencies = [
  "quote 1.0.7",
  "syn 1.0.41",
  "unicode-xid 0.2.0",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489997b7557e9a43e192c527face4feacc78bfbe6eed67fd55c4c9e381cba290"
+dependencies = [
+ "filetime",
+ "libc",
+ "redox_syscall",
+ "xattr",
 ]
 
 [[package]]
@@ -3006,6 +3282,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
+name = "walkdir"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+dependencies = [
+ "same-file",
+ "winapi 0.3.9",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3181,6 +3468,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "yaml-rust"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3208,4 +3504,35 @@ dependencies = [
  "quote 1.0.7",
  "syn 1.0.41",
  "synstructure",
+]
+
+[[package]]
+name = "zstd"
+version = "0.5.3+zstd.1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b32eaf771efa709e8308605bbf9319bf485dc1503179ec0469b611937c0cd8"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "2.0.5+zstd.1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfb642e0d27f64729a639c52db457e0ae906e7bc6f5fe8f5c453230400f1055"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "1.4.17+zstd.1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89249644df056b522696b1bb9e7c18c87e8ffa3e2f0dc3b0155875d6498f01b"
+dependencies = [
+ "cc",
+ "glob",
+ "itertools",
+ "libc",
 ]

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -12,13 +12,13 @@ version = "2.0.2"
 clap = "2.33.3"
 console = "0.12.0"
 serde_json = "1.0.57"
-solana-account-decoder = { version = "=1.3.13" }
-solana-clap-utils = { version = "=1.3.13"}
+solana-account-decoder = { version = "=1.3.14" }
+solana-clap-utils = { version = "=1.3.14"}
 solana-cli-config = { version = "=1.3.14" }
-solana-cli-output = { version = "=1.3.13" }
-solana-client = { version = "=1.3.13" }
+solana-cli-output = { version = "=1.3.14" }
+solana-client = { version = "=1.3.14" }
 solana-logger = { version = "=1.3.14" }
-solana-sdk = { version = "=1.3.13" }
+solana-sdk = { version = "=1.3.14" }
 spl-token = { version = "2.0", path="../program" }
 
 [[bin]]

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -121,8 +121,7 @@ fn command_create_token(
     let (recent_blockhash, fee_calculator) = config.rpc_client.get_recent_blockhash()?;
     check_fee_payer_balance(
         config,
-        minimum_balance_for_rent_exemption
-            + fee_calculator.calculate_fee(&transaction.message(), None),
+        minimum_balance_for_rent_exemption + fee_calculator.calculate_fee(&transaction.message()),
     )?;
     let mut signers = vec![config.fee_payer.as_ref(), token.as_ref()];
     unique_signers!(signers);
@@ -163,8 +162,7 @@ fn command_create_account(
     let (recent_blockhash, fee_calculator) = config.rpc_client.get_recent_blockhash()?;
     check_fee_payer_balance(
         config,
-        minimum_balance_for_rent_exemption
-            + fee_calculator.calculate_fee(&transaction.message(), None),
+        minimum_balance_for_rent_exemption + fee_calculator.calculate_fee(&transaction.message()),
     )?;
     let mut signers = vec![config.fee_payer.as_ref(), account.as_ref()];
     unique_signers!(signers);
@@ -208,10 +206,7 @@ fn command_authorize(
     );
 
     let (recent_blockhash, fee_calculator) = config.rpc_client.get_recent_blockhash()?;
-    check_fee_payer_balance(
-        config,
-        fee_calculator.calculate_fee(&transaction.message(), None),
-    )?;
+    check_fee_payer_balance(config, fee_calculator.calculate_fee(&transaction.message()))?;
     let mut signers = vec![config.fee_payer.as_ref(), config.owner.as_ref()];
     unique_signers!(signers);
     transaction.sign(&signers, recent_blockhash);
@@ -252,10 +247,7 @@ fn command_transfer(
     );
 
     let (recent_blockhash, fee_calculator) = config.rpc_client.get_recent_blockhash()?;
-    check_fee_payer_balance(
-        config,
-        fee_calculator.calculate_fee(&transaction.message(), None),
-    )?;
+    check_fee_payer_balance(config, fee_calculator.calculate_fee(&transaction.message()))?;
     let mut signers = vec![config.fee_payer.as_ref(), config.owner.as_ref()];
     unique_signers!(signers);
     transaction.sign(&signers, recent_blockhash);
@@ -287,10 +279,7 @@ fn command_burn(config: &Config, source: Pubkey, ui_amount: f64) -> CommandResul
     );
 
     let (recent_blockhash, fee_calculator) = config.rpc_client.get_recent_blockhash()?;
-    check_fee_payer_balance(
-        config,
-        fee_calculator.calculate_fee(&transaction.message(), None),
-    )?;
+    check_fee_payer_balance(config, fee_calculator.calculate_fee(&transaction.message()))?;
     let mut signers = vec![config.fee_payer.as_ref(), config.owner.as_ref()];
     unique_signers!(signers);
     transaction.sign(&signers, recent_blockhash);
@@ -328,10 +317,7 @@ fn command_mint(
     );
 
     let (recent_blockhash, fee_calculator) = config.rpc_client.get_recent_blockhash()?;
-    check_fee_payer_balance(
-        config,
-        fee_calculator.calculate_fee(&transaction.message(), None),
-    )?;
+    check_fee_payer_balance(config, fee_calculator.calculate_fee(&transaction.message()))?;
     let mut signers = vec![config.fee_payer.as_ref(), config.owner.as_ref()];
     unique_signers!(signers);
     transaction.sign(&signers, recent_blockhash);
@@ -360,10 +346,7 @@ fn command_freeze(config: &Config, account: Pubkey) -> CommandResult {
     );
 
     let (recent_blockhash, fee_calculator) = config.rpc_client.get_recent_blockhash()?;
-    check_fee_payer_balance(
-        config,
-        fee_calculator.calculate_fee(&transaction.message(), None),
-    )?;
+    check_fee_payer_balance(config, fee_calculator.calculate_fee(&transaction.message()))?;
     let mut signers = vec![config.fee_payer.as_ref(), config.owner.as_ref()];
     unique_signers!(signers);
     transaction.sign(&signers, recent_blockhash);
@@ -392,10 +375,7 @@ fn command_thaw(config: &Config, account: Pubkey) -> CommandResult {
     );
 
     let (recent_blockhash, fee_calculator) = config.rpc_client.get_recent_blockhash()?;
-    check_fee_payer_balance(
-        config,
-        fee_calculator.calculate_fee(&transaction.message(), None),
-    )?;
+    check_fee_payer_balance(config, fee_calculator.calculate_fee(&transaction.message()))?;
     let mut signers = vec![config.fee_payer.as_ref(), config.owner.as_ref()];
     unique_signers!(signers);
     transaction.sign(&signers, recent_blockhash);
@@ -428,10 +408,7 @@ fn command_wrap(config: &Config, sol: f64) -> CommandResult {
 
     let (recent_blockhash, fee_calculator) = config.rpc_client.get_recent_blockhash()?;
     check_owner_balance(config, lamports)?;
-    check_fee_payer_balance(
-        config,
-        fee_calculator.calculate_fee(&transaction.message(), None),
-    )?;
+    check_fee_payer_balance(config, fee_calculator.calculate_fee(&transaction.message()))?;
     let mut signers = vec![config.fee_payer.as_ref(), config.owner.as_ref(), &account];
     unique_signers!(signers);
     transaction.sign(&signers, recent_blockhash);
@@ -463,10 +440,7 @@ fn command_unwrap(config: &Config, address: Pubkey) -> CommandResult {
     );
 
     let (recent_blockhash, fee_calculator) = config.rpc_client.get_recent_blockhash()?;
-    check_fee_payer_balance(
-        config,
-        fee_calculator.calculate_fee(&transaction.message(), None),
-    )?;
+    check_fee_payer_balance(config, fee_calculator.calculate_fee(&transaction.message()))?;
     let mut signers = vec![config.fee_payer.as_ref(), config.owner.as_ref()];
     unique_signers!(signers);
     transaction.sign(&signers, recent_blockhash);
@@ -507,10 +481,7 @@ fn command_approve(
     );
 
     let (recent_blockhash, fee_calculator) = config.rpc_client.get_recent_blockhash()?;
-    check_fee_payer_balance(
-        config,
-        fee_calculator.calculate_fee(&transaction.message(), None),
-    )?;
+    check_fee_payer_balance(config, fee_calculator.calculate_fee(&transaction.message()))?;
     let mut signers = vec![config.fee_payer.as_ref(), config.owner.as_ref()];
     unique_signers!(signers);
     transaction.sign(&signers, recent_blockhash);
@@ -545,10 +516,7 @@ fn command_revoke(config: &Config, account: Pubkey) -> CommandResult {
     );
 
     let (recent_blockhash, fee_calculator) = config.rpc_client.get_recent_blockhash()?;
-    check_fee_payer_balance(
-        config,
-        fee_calculator.calculate_fee(&transaction.message(), None),
-    )?;
+    check_fee_payer_balance(config, fee_calculator.calculate_fee(&transaction.message()))?;
     let mut signers = vec![config.fee_payer.as_ref(), config.owner.as_ref()];
     unique_signers!(signers);
     transaction.sign(&signers, recent_blockhash);
@@ -582,10 +550,7 @@ fn command_close(config: &Config, account: Pubkey, destination: Pubkey) -> Comma
     );
 
     let (recent_blockhash, fee_calculator) = config.rpc_client.get_recent_blockhash()?;
-    check_fee_payer_balance(
-        config,
-        fee_calculator.calculate_fee(&transaction.message(), None),
-    )?;
+    check_fee_payer_balance(config, fee_calculator.calculate_fee(&transaction.message()))?;
     let mut signers = vec![config.fee_payer.as_ref(), config.owner.as_ref()];
     unique_signers!(signers);
     transaction.sign(&signers, recent_blockhash);

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -8,8 +8,8 @@ use solana_account_decoder::{
     UiAccountData,
 };
 use solana_clap_utils::{
-    input_parsers::pubkey_of,
-    input_validators::{is_amount, is_keypair, is_pubkey_or_keypair, is_url},
+    input_parsers::pubkey_of_signer,
+    input_validators::{is_amount, is_url, is_valid_pubkey, is_valid_signer},
     keypair::signer_from_path,
 };
 use solana_cli_output::display::println_name_value;
@@ -739,7 +739,7 @@ fn main() {
             Arg::with_name("owner")
                 .long("owner")
                 .value_name("KEYPAIR")
-                .validator(is_keypair)
+                .validator(is_valid_signer)
                 .takes_value(true)
                 .global(true)
                 .help(
@@ -752,7 +752,7 @@ fn main() {
             Arg::with_name("fee_payer")
                 .long("fee-payer")
                 .value_name("KEYPAIR")
-                .validator(is_keypair)
+                .validator(is_valid_signer)
                 .takes_value(true)
                 .global(true)
                 .help(
@@ -777,7 +777,7 @@ fn main() {
                 .arg(
                     Arg::with_name("token_keypair")
                         .value_name("KEYPAIR")
-                        .validator(is_keypair)
+                        .validator(is_valid_signer)
                         .takes_value(true)
                         .index(1)
                         .help(
@@ -800,7 +800,7 @@ fn main() {
                 .about("Create a new token account")
                 .arg(
                     Arg::with_name("token")
-                        .validator(is_pubkey_or_keypair)
+                        .validator(is_valid_pubkey)
                         .value_name("TOKEN_ADDRESS")
                         .takes_value(true)
                         .index(1)
@@ -810,7 +810,7 @@ fn main() {
                 .arg(
                     Arg::with_name("account_keypair")
                         .value_name("KEYPAIR")
-                        .validator(is_keypair)
+                        .validator(is_valid_signer)
                         .takes_value(true)
                         .index(2)
                         .help(
@@ -825,7 +825,7 @@ fn main() {
                 .about("Authorize a new signing keypair to a token or token account")
                 .arg(
                     Arg::with_name("address")
-                        .validator(is_pubkey_or_keypair)
+                        .validator(is_valid_pubkey)
                         .value_name("TOKEN_ADDRESS")
                         .takes_value(true)
                         .index(1)
@@ -845,7 +845,7 @@ fn main() {
                 )
                 .arg(
                     Arg::with_name("new_authority")
-                        .validator(is_pubkey_or_keypair)
+                        .validator(is_valid_pubkey)
                         .value_name("AUTHORITY_ADDRESS")
                         .takes_value(true)
                         .index(3)
@@ -865,7 +865,7 @@ fn main() {
                 .about("Transfer tokens between accounts")
                 .arg(
                     Arg::with_name("sender")
-                        .validator(is_pubkey_or_keypair)
+                        .validator(is_valid_pubkey)
                         .value_name("SENDER_TOKEN_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .index(1)
@@ -883,7 +883,7 @@ fn main() {
                 )
                 .arg(
                     Arg::with_name("recipient")
-                        .validator(is_pubkey_or_keypair)
+                        .validator(is_valid_pubkey)
                         .value_name("RECIPIENT_TOKEN_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .index(3)
@@ -896,7 +896,7 @@ fn main() {
                 .about("Burn tokens from an account")
                 .arg(
                     Arg::with_name("source")
-                        .validator(is_pubkey_or_keypair)
+                        .validator(is_valid_pubkey)
                         .value_name("SOURCE_TOKEN_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .index(1)
@@ -918,7 +918,7 @@ fn main() {
                 .about("Mint new tokens")
                 .arg(
                     Arg::with_name("token")
-                        .validator(is_pubkey_or_keypair)
+                        .validator(is_valid_pubkey)
                         .value_name("TOKEN_ADDRESS")
                         .takes_value(true)
                         .index(1)
@@ -936,7 +936,7 @@ fn main() {
                 )
                 .arg(
                     Arg::with_name("recipient")
-                        .validator(is_pubkey_or_keypair)
+                        .validator(is_valid_pubkey)
                         .value_name("RECIPIENT_TOKEN_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .index(3)
@@ -949,7 +949,7 @@ fn main() {
                 .about("Freeze a token account")
                 .arg(
                     Arg::with_name("account")
-                        .validator(is_pubkey_or_keypair)
+                        .validator(is_valid_pubkey)
                         .value_name("TOKEN_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .index(1)
@@ -962,7 +962,7 @@ fn main() {
                 .about("Thaw a token account")
                 .arg(
                     Arg::with_name("account")
-                        .validator(is_pubkey_or_keypair)
+                        .validator(is_valid_pubkey)
                         .value_name("TOKEN_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .index(1)
@@ -975,7 +975,7 @@ fn main() {
                 .about("Get token account balance")
                 .arg(
                     Arg::with_name("address")
-                        .validator(is_pubkey_or_keypair)
+                        .validator(is_valid_pubkey)
                         .value_name("TOKEN_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .index(1)
@@ -988,7 +988,7 @@ fn main() {
                 .about("Get token supply")
                 .arg(
                     Arg::with_name("address")
-                        .validator(is_pubkey_or_keypair)
+                        .validator(is_valid_pubkey)
                         .value_name("TOKEN_ADDRESS")
                         .takes_value(true)
                         .index(1)
@@ -1001,7 +1001,7 @@ fn main() {
                 .about("List all token accounts by owner")
                 .arg(
                     Arg::with_name("token")
-                        .validator(is_pubkey_or_keypair)
+                        .validator(is_valid_pubkey)
                         .value_name("TOKEN_ADDRESS")
                         .takes_value(true)
                         .index(1)
@@ -1026,7 +1026,7 @@ fn main() {
                 .about("Unwrap a SOL token account")
                 .arg(
                     Arg::with_name("address")
-                        .validator(is_pubkey_or_keypair)
+                        .validator(is_valid_pubkey)
                         .value_name("TOKEN_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .index(1)
@@ -1039,7 +1039,7 @@ fn main() {
                 .about("Query details of an SPL Token account by address")
                 .arg(
                     Arg::with_name("address")
-                    .validator(is_pubkey_or_keypair)
+                    .validator(is_valid_pubkey)
                     .value_name("TOKEN_ACCOUNT_ADDRESS")
                     .takes_value(true)
                     .index(1)
@@ -1052,7 +1052,7 @@ fn main() {
                 .about("Approve a delegate for a token account")
                 .arg(
                     Arg::with_name("account")
-                        .validator(is_pubkey_or_keypair)
+                        .validator(is_valid_pubkey)
                         .value_name("TOKEN_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .index(1)
@@ -1070,7 +1070,7 @@ fn main() {
                 )
                 .arg(
                     Arg::with_name("delegate")
-                        .validator(is_pubkey_or_keypair)
+                        .validator(is_valid_pubkey)
                         .value_name("DELEGATE_TOKEN_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .index(3)
@@ -1083,7 +1083,7 @@ fn main() {
                 .about("Revoke a delegate's authority")
                 .arg(
                     Arg::with_name("account")
-                        .validator(is_pubkey_or_keypair)
+                        .validator(is_valid_pubkey)
                         .value_name("TOKEN_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .index(1)
@@ -1096,7 +1096,7 @@ fn main() {
                 .about("Close a token account")
                 .arg(
                     Arg::with_name("account")
-                        .validator(is_pubkey_or_keypair)
+                        .validator(is_valid_pubkey)
                         .value_name("TOKEN_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .index(1)
@@ -1105,7 +1105,7 @@ fn main() {
                 )
                 .arg(
                     Arg::with_name("destination")
-                        .validator(is_pubkey_or_keypair)
+                        .validator(is_valid_pubkey)
                         .value_name("TOKEN_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .index(2)
@@ -1191,7 +1191,9 @@ fn main() {
             )
         }
         ("create-account", Some(arg_matches)) => {
-            let token = pubkey_of(arg_matches, "token").unwrap();
+            let token = pubkey_of_signer(arg_matches, "token", &mut wallet_manager)
+                .unwrap()
+                .unwrap();
             let account = if arg_matches.is_present("account_keypair") {
                 signer_from_path(
                     &matches,
@@ -1210,7 +1212,9 @@ fn main() {
             command_create_account(&config, token, account)
         }
         ("authorize", Some(arg_matches)) => {
-            let address = pubkey_of(arg_matches, "address").unwrap();
+            let address = pubkey_of_signer(arg_matches, "address", &mut wallet_manager)
+                .unwrap()
+                .unwrap();
             let authority_type = arg_matches.value_of("authority_type").unwrap();
             let authority_type = match authority_type {
                 "mint" => AuthorityType::MintTokens,
@@ -1219,32 +1223,47 @@ fn main() {
                 "close" => AuthorityType::CloseAccount,
                 _ => unreachable!(),
             };
-            let new_authority = pubkey_of(arg_matches, "new_authority");
+            let new_authority =
+                pubkey_of_signer(arg_matches, "new_authority", &mut wallet_manager).unwrap();
             command_authorize(&config, address, authority_type, new_authority)
         }
         ("transfer", Some(arg_matches)) => {
-            let sender = pubkey_of(arg_matches, "sender").unwrap();
+            let sender = pubkey_of_signer(arg_matches, "sender", &mut wallet_manager)
+                .unwrap()
+                .unwrap();
             let amount = value_t_or_exit!(arg_matches, "amount", f64);
-            let recipient = pubkey_of(arg_matches, "recipient").unwrap();
+            let recipient = pubkey_of_signer(arg_matches, "recipient", &mut wallet_manager)
+                .unwrap()
+                .unwrap();
             command_transfer(&config, sender, amount, recipient)
         }
         ("burn", Some(arg_matches)) => {
-            let source = pubkey_of(arg_matches, "source").unwrap();
+            let source = pubkey_of_signer(arg_matches, "source", &mut wallet_manager)
+                .unwrap()
+                .unwrap();
             let amount = value_t_or_exit!(arg_matches, "amount", f64);
             command_burn(&config, source, amount)
         }
         ("mint", Some(arg_matches)) => {
-            let token = pubkey_of(arg_matches, "token").unwrap();
+            let token = pubkey_of_signer(arg_matches, "token", &mut wallet_manager)
+                .unwrap()
+                .unwrap();
             let amount = value_t_or_exit!(arg_matches, "amount", f64);
-            let recipient = pubkey_of(arg_matches, "recipient").unwrap();
+            let recipient = pubkey_of_signer(arg_matches, "recipient", &mut wallet_manager)
+                .unwrap()
+                .unwrap();
             command_mint(&config, token, amount, recipient)
         }
         ("freeze", Some(arg_matches)) => {
-            let account = pubkey_of(arg_matches, "account").unwrap();
+            let account = pubkey_of_signer(arg_matches, "account", &mut wallet_manager)
+                .unwrap()
+                .unwrap();
             command_freeze(&config, account)
         }
         ("thaw", Some(arg_matches)) => {
-            let account = pubkey_of(arg_matches, "account").unwrap();
+            let account = pubkey_of_signer(arg_matches, "account", &mut wallet_manager)
+                .unwrap()
+                .unwrap();
             command_thaw(&config, account)
         }
         ("wrap", Some(arg_matches)) => {
@@ -1252,38 +1271,56 @@ fn main() {
             command_wrap(&config, amount)
         }
         ("unwrap", Some(arg_matches)) => {
-            let address = pubkey_of(arg_matches, "address").unwrap();
+            let address = pubkey_of_signer(arg_matches, "address", &mut wallet_manager)
+                .unwrap()
+                .unwrap();
             command_unwrap(&config, address)
         }
         ("approve", Some(arg_matches)) => {
-            let account = pubkey_of(arg_matches, "account").unwrap();
+            let account = pubkey_of_signer(arg_matches, "account", &mut wallet_manager)
+                .unwrap()
+                .unwrap();
             let amount = value_t_or_exit!(arg_matches, "amount", f64);
-            let delegate = pubkey_of(arg_matches, "delegate").unwrap();
+            let delegate = pubkey_of_signer(arg_matches, "delegate", &mut wallet_manager)
+                .unwrap()
+                .unwrap();
             command_approve(&config, account, amount, delegate)
         }
         ("revoke", Some(arg_matches)) => {
-            let account = pubkey_of(arg_matches, "account").unwrap();
+            let account = pubkey_of_signer(arg_matches, "account", &mut wallet_manager)
+                .unwrap()
+                .unwrap();
             command_revoke(&config, account)
         }
         ("close", Some(arg_matches)) => {
-            let account = pubkey_of(arg_matches, "account").unwrap();
-            let destination = pubkey_of(arg_matches, "destination").unwrap();
+            let account = pubkey_of_signer(arg_matches, "account", &mut wallet_manager)
+                .unwrap()
+                .unwrap();
+            let destination = pubkey_of_signer(arg_matches, "destination", &mut wallet_manager)
+                .unwrap()
+                .unwrap();
             command_close(&config, account, destination)
         }
         ("balance", Some(arg_matches)) => {
-            let address = pubkey_of(arg_matches, "address").unwrap();
+            let address = pubkey_of_signer(arg_matches, "address", &mut wallet_manager)
+                .unwrap()
+                .unwrap();
             command_balance(&config, address)
         }
         ("supply", Some(arg_matches)) => {
-            let address = pubkey_of(arg_matches, "address").unwrap();
+            let address = pubkey_of_signer(arg_matches, "address", &mut wallet_manager)
+                .unwrap()
+                .unwrap();
             command_supply(&config, address)
         }
         ("accounts", Some(arg_matches)) => {
-            let token = pubkey_of(arg_matches, "token");
+            let token = pubkey_of_signer(arg_matches, "token", &mut wallet_manager).unwrap();
             command_accounts(&config, token)
         }
         ("account-info", Some(arg_matches)) => {
-            let address = pubkey_of(arg_matches, "address").unwrap();
+            let address = pubkey_of_signer(arg_matches, "address", &mut wallet_manager)
+                .unwrap()
+                .unwrap();
             command_account(&config, address)
         }
         _ => unreachable!(),

--- a/token/perf-monitor/Cargo.lock
+++ b/token/perf-monitor/Cargo.lock
@@ -128,10 +128,20 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
- "block-padding",
+ "block-padding 0.1.5",
  "byte-tools",
  "byteorder",
  "generic-array 0.12.3",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "block-padding 0.2.1",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -142,6 +152,12 @@ checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
  "byte-tools",
 ]
+
+[[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bs58"
@@ -333,6 +349,12 @@ dependencies = [
  "cfg-if",
  "lazy_static",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-mac"
@@ -739,6 +761,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac-drbg"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6e570451493f10f6581b48cdd530413b63ea9e780f544bfd3bdcaa0d89d1a7b"
+dependencies = [
+ "digest 0.8.1",
+ "generic-array 0.12.3",
+ "hmac",
+]
+
+[[package]]
 name = "http"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,6 +942,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -941,6 +980,22 @@ checksum = "2443d8f0478b16759158b2f66d525991a05491138bc05814ef52a250148ef4f9"
 dependencies = [
  "cfg-if",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "libsecp256k1"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc1e2c808481a63dc6da2074752fdd4336a3c8fcc68b83db6f1fd5224ae7962"
+dependencies = [
+ "arrayref",
+ "crunchy",
+ "digest 0.8.1",
+ "hmac-drbg",
+ "rand",
+ "sha2",
+ "subtle 2.2.3",
+ "typenum",
 ]
 
 [[package]]
@@ -1155,6 +1210,12 @@ name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "parking_lot"
@@ -1643,10 +1704,22 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.7.3",
  "digest 0.8.1",
  "fake-simd",
- "opaque-debug",
+ "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "sha3"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "keccak",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -1690,9 +1763,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "1.3.12"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a61d66b0103b49ec1420f19f0202789f24c3bba6d0efdf1498755c071c523e4"
+checksum = "450c86bce41818155645d5c570bb9e860bc862f3d8241ad268311e4ee21c5b13"
 dependencies = [
  "bincode",
  "byteorder",
@@ -1706,9 +1779,9 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "1.3.12"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96a4875aa76cd477910dc95e6de7dcc276c92cad9a82d473503b2b9e4aeb280"
+checksum = "4a5fe6f27c71ff3248b8663b94bb1fe3c8560c8a14a3a33544dc447bdd662407"
 dependencies = [
  "bincode",
  "chrono",
@@ -1720,9 +1793,9 @@ dependencies = [
 
 [[package]]
 name = "solana-crate-features"
-version = "1.3.12"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb500621867cd1e9297ca989bd754f4bf52772c7ea8cd2cb3616c1c75e9f62d"
+checksum = "2cc2deb783d0f6954d1a244cab9a7a20416c075b86918c5aa6a1be3caa795e32"
 dependencies = [
  "backtrace",
  "bytes 0.4.12",
@@ -1745,9 +1818,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.3.12"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10fa1615c22d1d63230e7aeaf421321c24ea4746e2e4842cc0694adf5916c1b8"
+checksum = "927e5a0509529c1940a684d4aba08fd2e6de3fa67ca4858e57c2eb8846ca2b9d"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -1756,9 +1829,9 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.3.12"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "603e2072559207b71e5c9d6abbbfbbe08785be1328bd1cf4b12d3fd5a563cc57"
+checksum = "309e671f9a95cac920ada447b6852bd7e72e0635a1d3dc3bdd7a28668cdc5533"
 dependencies = [
  "jemalloc-ctl",
  "jemallocator",
@@ -1769,9 +1842,9 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "1.3.12"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384187253d39d3777c543de4c2a8216fb7e353d709711cbfb929a9b227184255"
+checksum = "421614c84626f5ca2bc21760f8cc77df548791766e35c78e210218e616b92c37"
 dependencies = [
  "env_logger",
  "gethostname",
@@ -1783,9 +1856,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.3.12"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74dd54ee484b9536f486f2c692872c27bc55e19d48014199d8311aade27a0efd"
+checksum = "d02f25437a66002b1ce694143705d79cf79aa46cdda1f8decd12a3de2c90e386"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -1793,9 +1866,9 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "1.3.12"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8e6dcb65e3b899bf9f307d28d3303e683193dcedbbadf2199069a3b131a193"
+checksum = "dd7e80c2a751acc9a56c22852cccab6e9334873691f119296cb0fe6bbfae7c46"
 dependencies = [
  "bincode",
  "blake3",
@@ -1829,6 +1902,7 @@ dependencies = [
  "solana-rayon-threadlimit",
  "solana-sdk",
  "solana-sdk-macro-frozen-abi",
+ "solana-secp256k1-program",
  "solana-stake-program",
  "solana-vote-program",
  "symlink",
@@ -1840,9 +1914,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.3.12"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "191c1799a2f43eb2f2a97ff8daaeed3bdeb7bee4a3e746bac4618b4eb8b81df9"
+checksum = "aa41a7f3655cb6336562e6c194d7ce5253ebbf21894bf3ef524e5f4e1b1d5e6a"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -1851,11 +1925,13 @@ dependencies = [
  "byteorder",
  "chrono",
  "curve25519-dalek",
+ "digest 0.9.0",
  "ed25519-dalek",
  "generic-array 0.14.4",
  "hex",
  "hmac",
  "itertools",
+ "libsecp256k1",
  "log",
  "memmap",
  "num-derive",
@@ -1870,6 +1946,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2",
+ "sha3",
  "solana-crate-features",
  "solana-logger",
  "solana-sdk-macro",
@@ -1879,9 +1956,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.3.12"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1c48e7c0d81123734b9074ad03546e89508e2ab12d3aca008184f284b62abc9"
+checksum = "2678edfd446d5396fd5f8957bf3da820b8b8b780113ea4c5918a33059aecb7fd"
 dependencies = [
  "bs58",
  "proc-macro2 1.0.19",
@@ -1892,9 +1969,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro-frozen-abi"
-version = "1.3.12"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64fed6f7a226c02c48b539cae879c0eef9f64be08986b248d8ad4cec4328945"
+checksum = "024f848633a58dc8fdd52ce0491630a4a4c0fa3ed91ab9b9911bcbe5c7d2d4e8"
 dependencies = [
  "lazy_static",
  "proc-macro2 1.0.19",
@@ -1904,10 +1981,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-stake-program"
-version = "1.3.12"
+name = "solana-secp256k1-program"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97894719507af7fbdab9e55291249fba1f6f2e2fa762292f2fc2587c93652e87"
+checksum = "c5acdcfef86bd2b61839dde6992d12ac1b2765a2a45d050aad38e3f362af7c88"
+dependencies = [
+ "bincode",
+ "digest 0.9.0",
+ "libsecp256k1",
+ "rand",
+ "sha3",
+ "solana-logger",
+ "solana-sdk",
+]
+
+[[package]]
+name = "solana-stake-program"
+version = "1.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1a1b7383fc4758e7d9b63c6d12e5a6d596ecbfc5330805db7533b7e1fa6843"
 dependencies = [
  "bincode",
  "log",
@@ -1926,9 +2018,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "1.3.12"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a9673c65787d669eade8322a13ed9d35795d797254f7097ac18b731d82702f"
+checksum = "31111ce08a479196243bf5335a173f899960ec5fdc0d937fe3bd42289dfbb656"
 dependencies = [
  "bincode",
  "log",
@@ -1987,6 +2079,7 @@ version = "0.0.1"
 dependencies = [
  "rand",
  "solana-bpf-loader-program",
+ "solana-runtime",
  "solana-sdk",
  "solana_rbpf",
  "spl-token",

--- a/token/perf-monitor/Cargo.toml
+++ b/token/perf-monitor/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 [dev-dependencies]
 rand = { version = "0.7.0"}
 spl-token = { path = "../program" }
-solana-sdk = { version = "1.3.12" }
-solana-bpf-loader-program = { version = "1.3.12" }
+solana-runtime = { version = "1.3.14" }
+solana-sdk = { version = "1.3.14" }
+solana-bpf-loader-program = { version = "1.3.14" }
 solana_rbpf = "=0.1.31"

--- a/token/perf-monitor/tests/assert_instruction_count.rs
+++ b/token/perf-monitor/tests/assert_instruction_count.rs
@@ -3,14 +3,14 @@ use solana_bpf_loader_program::{
     serialization::{deserialize_parameters, serialize_parameters},
 };
 use solana_rbpf::vm::{EbpfVm, InstructionMeter};
+use solana_runtime::process_instruction::{
+    ComputeBudget, ComputeMeter, Executor, InvokeContext, Logger, ProcessInstruction,
+};
 use solana_sdk::{
     account::{Account as SolanaAccount, KeyedAccount},
     bpf_loader,
     entrypoint::SUCCESS,
-    entrypoint_native::{
-        ComputeBudget, ComputeMeter, Executor, InvokeContext, Logger, ProcessInstruction,
-    },
-    instruction::{CompiledInstruction, InstructionError},
+    instruction::{CompiledInstruction, Instruction, InstructionError},
     message::Message,
     program_option::COption,
     program_pack::Pack,
@@ -214,6 +214,7 @@ impl InvokeContext for MockInvokeContext {
     fn get_executor(&mut self, _pubkey: &Pubkey) -> Option<Arc<dyn Executor>> {
         None
     }
+    fn record_instruction(&self, _instruction: &Instruction) {}
 }
 
 #[derive(Debug, Default, Clone)]

--- a/token/program/Cargo.toml
+++ b/token/program/Cargo.toml
@@ -21,7 +21,7 @@ default = ["solana-sdk/default"]
 num-derive = "0.3"
 num-traits = "0.2"
 remove_dir_all = "=0.5.0"
-solana-sdk = { version = "1.3.12", default-features = false, optional = true }
+solana-sdk = { version = "1.3.14", default-features = false, optional = true }
 thiserror = "1.0"
 arrayref = "0.3.6"
 num_enum = "0.5.1"


### PR DESCRIPTION
#### Problem

`spl-token-cli` mostly uses keypair/pubkey args directly, limiting their expression to file paths and base58 pubkeys

#### Changes

* Switch all args to signer-based utils
* BONUS! Consolidate transaction construction and signing

This is blocked by needing changes at the tip of v1.3.  Last commit will need replaced after the next release