### PR TITLE
token-swap: Add slippage to swap / withdraw / deposit

### DIFF
--- a/token-swap/js/cli/token-swap-test.js
+++ b/token-swap/js/cli/token-swap-test.js
@@ -37,8 +37,9 @@ let tokenAccountB: PublicKey;
 
 // Initial amount in each swap token
 const BASE_AMOUNT = 1000;
-// Amount passed to instructions
-const USER_AMOUNT = 100;
+// Amount passed to swap instruction
+const SWAP_AMOUNT_IN = 100;
+const SWAP_AMOUNT_OUT = 69;
 // Pool token amount minted on init
 const DEFAULT_POOL_TOKEN_AMOUNT = 1000000000;
 // Pool token amount to withdraw / deposit
@@ -253,6 +254,8 @@ export async function deposit(): Promise<void> {
     newAccountPool,
     tokenProgramId,
     POOL_TOKEN_AMOUNT,
+    tokenA,
+    tokenB,
   );
 
   let info;
@@ -302,6 +305,8 @@ export async function withdraw(): Promise<void> {
     userAccountB,
     tokenProgramId,
     POOL_TOKEN_AMOUNT,
+    tokenA,
+    tokenB,
   );
 
   //const poolMintInfo = await tokenPool.getMintInfo();
@@ -323,8 +328,8 @@ export async function withdraw(): Promise<void> {
 export async function swap(): Promise<void> {
   console.log('Creating swap token a account');
   let userAccountA = await mintA.createAccount(owner.publicKey);
-  await mintA.mintTo(userAccountA, owner, [], USER_AMOUNT);
-  await mintA.approve(userAccountA, authority, owner, [], USER_AMOUNT);
+  await mintA.mintTo(userAccountA, owner, [], SWAP_AMOUNT_IN);
+  await mintA.approve(userAccountA, authority, owner, [], SWAP_AMOUNT_IN);
   console.log('Creating swap token b account');
   let userAccountB = await mintB.createAccount(owner.publicKey);
   const [tokenProgramId] = await GetPrograms(connection);
@@ -337,18 +342,19 @@ export async function swap(): Promise<void> {
     tokenAccountB,
     userAccountB,
     tokenProgramId,
-    USER_AMOUNT,
+    SWAP_AMOUNT_IN,
+    SWAP_AMOUNT_OUT,
   );
   await sleep(500);
   let info;
   info = await mintA.getAccountInfo(userAccountA);
   assert(info.amount.toNumber() == 0);
   info = await mintA.getAccountInfo(tokenAccountA);
-  assert(info.amount.toNumber() == BASE_AMOUNT + USER_AMOUNT);
+  assert(info.amount.toNumber() == BASE_AMOUNT + SWAP_AMOUNT_IN);
   info = await mintB.getAccountInfo(tokenAccountB);
-  assert(info.amount.toNumber() == 931);
+  assert(info.amount.toNumber() == BASE_AMOUNT - SWAP_AMOUNT_OUT);
   info = await mintB.getAccountInfo(userAccountB);
-  assert(info.amount.toNumber() == 69);
+  assert(info.amount.toNumber() == SWAP_AMOUNT_OUT);
   info = await tokenPool.getAccountInfo(tokenAccountPool);
   assert(
     info.amount.toNumber() == DEFAULT_POOL_TOKEN_AMOUNT - POOL_TOKEN_AMOUNT,

--- a/token-swap/js/client/token-swap.js
+++ b/token-swap/js/client/token-swap.js
@@ -345,8 +345,8 @@ export class TokenSwap {
     swapDestination: PublicKey,
     destination: PublicKey,
     tokenProgramId: PublicKey,
-    amount_in: number | Numberu64,
-    minimum_amount_out: number | Numberu64,
+    amountIn: number | Numberu64,
+    minimumAmountOut: number | Numberu64,
   ): Promise<TransactionSignature> {
     return await sendAndConfirmTransaction(
       'swap',
@@ -361,8 +361,8 @@ export class TokenSwap {
           destination,
           this.programId,
           tokenProgramId,
-          amount_in,
-          minimum_amount_out,
+          amountIn,
+          minimumAmountOut,
         ),
       ),
       this.payer,
@@ -378,21 +378,21 @@ export class TokenSwap {
     destination: PublicKey,
     swapProgramId: PublicKey,
     tokenProgramId: PublicKey,
-    amount_in: number | Numberu64,
-    minimum_amount_out: number | Numberu64,
+    amountIn: number | Numberu64,
+    minimumAmountOut: number | Numberu64,
   ): TransactionInstruction {
     const dataLayout = BufferLayout.struct([
       BufferLayout.u8('instruction'),
-      Layout.uint64('amount_in'),
-      Layout.uint64('minimum_amount_out'),
+      Layout.uint64('amountIn'),
+      Layout.uint64('minimumAmountOut'),
     ]);
 
     const data = Buffer.alloc(dataLayout.span);
     dataLayout.encode(
       {
         instruction: 1, // Swap instruction
-        amount_in: new Numberu64(amount_in).toBuffer(),
-        minimum_amount_out: new Numberu64(minimum_amount_out).toBuffer(),
+        amountIn: new Numberu64(amountIn).toBuffer(),
+        minimumAmountOut: new Numberu64(minimumAmountOut).toBuffer(),
       },
       data,
     );
@@ -435,9 +435,9 @@ export class TokenSwap {
     poolToken: PublicKey,
     poolAccount: PublicKey,
     tokenProgramId: PublicKey,
-    pool_token_amount: number | Numberu64,
-    maximum_token_a_amount: number | Numberu64,
-    maximum_token_b_amount: number | Numberu64,
+    poolTokenAmount: number | Numberu64,
+    maximumTokenA: number | Numberu64,
+    maximumTokenB: number | Numberu64,
   ): Promise<TransactionSignature> {
     return await sendAndConfirmTransaction(
       'deposit',
@@ -454,9 +454,9 @@ export class TokenSwap {
           poolAccount,
           this.programId,
           tokenProgramId,
-          pool_token_amount,
-          maximum_token_a_amount,
-          maximum_token_b_amount,
+          poolTokenAmount,
+          maximumTokenA,
+          maximumTokenB,
         ),
       ),
       this.payer,
@@ -474,28 +474,24 @@ export class TokenSwap {
     poolAccount: PublicKey,
     swapProgramId: PublicKey,
     tokenProgramId: PublicKey,
-    pool_token_amount: number | Numberu64,
-    maximum_token_a_amount: number | Numberu64,
-    maximum_token_b_amount: number | Numberu64,
+    poolTokenAmount: number | Numberu64,
+    maximumTokenA: number | Numberu64,
+    maximumTokenB: number | Numberu64,
   ): TransactionInstruction {
     const dataLayout = BufferLayout.struct([
       BufferLayout.u8('instruction'),
-      Layout.uint64('pool_token_amount'),
-      Layout.uint64('maximum_token_a_amount'),
-      Layout.uint64('maximum_token_b_amount'),
+      Layout.uint64('poolTokenAmount'),
+      Layout.uint64('maximumTokenA'),
+      Layout.uint64('maximumTokenB'),
     ]);
 
     const data = Buffer.alloc(dataLayout.span);
     dataLayout.encode(
       {
         instruction: 2, // Deposit instruction
-        pool_token_amount: new Numberu64(pool_token_amount).toBuffer(),
-        maximum_token_a_amount: new Numberu64(
-          maximum_token_a_amount,
-        ).toBuffer(),
-        maximum_token_b_amount: new Numberu64(
-          maximum_token_b_amount,
-        ).toBuffer(),
+        poolTokenAmount: new Numberu64(poolTokenAmount).toBuffer(),
+        maximumTokenA: new Numberu64(maximumTokenA).toBuffer(),
+        maximumTokenB: new Numberu64(maximumTokenB).toBuffer(),
       },
       data,
     );
@@ -540,9 +536,9 @@ export class TokenSwap {
     userAccountA: PublicKey,
     userAccountB: PublicKey,
     tokenProgramId: PublicKey,
-    pool_token_amount: number | Numberu64,
-    minimum_token_a_amount: number | Numberu64,
-    minimum_token_b_amount: number | Numberu64,
+    poolTokenAmount: number | Numberu64,
+    minimumTokenA: number | Numberu64,
+    minimumTokenB: number | Numberu64,
   ): Promise<TransactionSignature> {
     return await sendAndConfirmTransaction(
       'withdraw',
@@ -559,9 +555,9 @@ export class TokenSwap {
           userAccountB,
           this.programId,
           tokenProgramId,
-          pool_token_amount,
-          minimum_token_a_amount,
-          minimum_token_b_amount,
+          poolTokenAmount,
+          minimumTokenA,
+          minimumTokenB,
         ),
       ),
       this.payer,
@@ -579,27 +575,27 @@ export class TokenSwap {
     userAccountB: PublicKey,
     swapProgramId: PublicKey,
     tokenProgramId: PublicKey,
-    pool_token_amount: number | Numberu64,
-    minimum_token_a_amount: number | Numberu64,
-    minimum_token_b_amount: number | Numberu64,
+    poolTokenAmount: number | Numberu64,
+    minimumTokenA: number | Numberu64,
+    minimumTokenB: number | Numberu64,
   ): TransactionInstruction {
     const dataLayout = BufferLayout.struct([
       BufferLayout.u8('instruction'),
-      Layout.uint64('pool_token_amount'),
-      Layout.uint64('minimum_token_a_amount'),
-      Layout.uint64('minimum_token_b_amount'),
+      Layout.uint64('poolTokenAmount'),
+      Layout.uint64('minimumTokenA'),
+      Layout.uint64('minimumTokenB'),
     ]);
 
     const data = Buffer.alloc(dataLayout.span);
     dataLayout.encode(
       {
         instruction: 3, // Withdraw instruction
-        pool_token_amount: new Numberu64(pool_token_amount).toBuffer(),
-        minimum_token_a_amount: new Numberu64(
-          minimum_token_a_amount,
+        poolTokenAmount: new Numberu64(poolTokenAmount).toBuffer(),
+        minimumTokenA: new Numberu64(
+          minimumTokenA,
         ).toBuffer(),
-        minimum_token_b_amount: new Numberu64(
-          minimum_token_b_amount,
+        minimumTokenB: new Numberu64(
+          minimumTokenB,
         ).toBuffer(),
       },
       data,

--- a/token-swap/js/client/token-swap.js
+++ b/token-swap/js/client/token-swap.js
@@ -591,12 +591,8 @@ export class TokenSwap {
       {
         instruction: 3, // Withdraw instruction
         poolTokenAmount: new Numberu64(poolTokenAmount).toBuffer(),
-        minimumTokenA: new Numberu64(
-          minimumTokenA,
-        ).toBuffer(),
-        minimumTokenB: new Numberu64(
-          minimumTokenB,
-        ).toBuffer(),
+        minimumTokenA: new Numberu64(minimumTokenA).toBuffer(),
+        minimumTokenB: new Numberu64(minimumTokenB).toBuffer(),
       },
       data,
     );

--- a/token-swap/js/client/token-swap.js
+++ b/token-swap/js/client/token-swap.js
@@ -345,7 +345,8 @@ export class TokenSwap {
     swapDestination: PublicKey,
     destination: PublicKey,
     tokenProgramId: PublicKey,
-    amount: number | Numberu64,
+    amount_in: number | Numberu64,
+    minimum_amount_out: number | Numberu64,
   ): Promise<TransactionSignature> {
     return await sendAndConfirmTransaction(
       'swap',
@@ -360,7 +361,8 @@ export class TokenSwap {
           destination,
           this.programId,
           tokenProgramId,
-          amount,
+          amount_in,
+          minimum_amount_out,
         ),
       ),
       this.payer,
@@ -376,18 +378,21 @@ export class TokenSwap {
     destination: PublicKey,
     swapProgramId: PublicKey,
     tokenProgramId: PublicKey,
-    amount: number | Numberu64,
+    amount_in: number | Numberu64,
+    minimum_amount_out: number | Numberu64,
   ): TransactionInstruction {
     const dataLayout = BufferLayout.struct([
       BufferLayout.u8('instruction'),
-      Layout.uint64('amount'),
+      Layout.uint64('amount_in'),
+      Layout.uint64('minimum_amount_out'),
     ]);
 
     const data = Buffer.alloc(dataLayout.span);
     dataLayout.encode(
       {
         instruction: 1, // Swap instruction
-        amount: new Numberu64(amount).toBuffer(),
+        amount_in: new Numberu64(amount_in).toBuffer(),
+        minimum_amount_out: new Numberu64(minimum_amount_out).toBuffer(),
       },
       data,
     );
@@ -430,7 +435,9 @@ export class TokenSwap {
     poolToken: PublicKey,
     poolAccount: PublicKey,
     tokenProgramId: PublicKey,
-    amount: number | Numberu64,
+    pool_token_amount: number | Numberu64,
+    maximum_token_a_amount: number | Numberu64,
+    maximum_token_b_amount: number | Numberu64,
   ): Promise<TransactionSignature> {
     return await sendAndConfirmTransaction(
       'deposit',
@@ -447,7 +454,9 @@ export class TokenSwap {
           poolAccount,
           this.programId,
           tokenProgramId,
-          amount,
+          pool_token_amount,
+          maximum_token_a_amount,
+          maximum_token_b_amount,
         ),
       ),
       this.payer,
@@ -465,18 +474,28 @@ export class TokenSwap {
     poolAccount: PublicKey,
     swapProgramId: PublicKey,
     tokenProgramId: PublicKey,
-    amount: number | Numberu64,
+    pool_token_amount: number | Numberu64,
+    maximum_token_a_amount: number | Numberu64,
+    maximum_token_b_amount: number | Numberu64,
   ): TransactionInstruction {
     const dataLayout = BufferLayout.struct([
       BufferLayout.u8('instruction'),
-      Layout.uint64('amount'),
+      Layout.uint64('pool_token_amount'),
+      Layout.uint64('maximum_token_a_amount'),
+      Layout.uint64('maximum_token_b_amount'),
     ]);
 
     const data = Buffer.alloc(dataLayout.span);
     dataLayout.encode(
       {
         instruction: 2, // Deposit instruction
-        amount: new Numberu64(amount).toBuffer(),
+        pool_token_amount: new Numberu64(pool_token_amount).toBuffer(),
+        maximum_token_a_amount: new Numberu64(
+          maximum_token_a_amount,
+        ).toBuffer(),
+        maximum_token_b_amount: new Numberu64(
+          maximum_token_b_amount,
+        ).toBuffer(),
       },
       data,
     );
@@ -521,7 +540,9 @@ export class TokenSwap {
     userAccountA: PublicKey,
     userAccountB: PublicKey,
     tokenProgramId: PublicKey,
-    amount: number | Numberu64,
+    pool_token_amount: number | Numberu64,
+    minimum_token_a_amount: number | Numberu64,
+    minimum_token_b_amount: number | Numberu64,
   ): Promise<TransactionSignature> {
     return await sendAndConfirmTransaction(
       'withdraw',
@@ -538,7 +559,9 @@ export class TokenSwap {
           userAccountB,
           this.programId,
           tokenProgramId,
-          amount,
+          pool_token_amount,
+          minimum_token_a_amount,
+          minimum_token_b_amount,
         ),
       ),
       this.payer,
@@ -556,18 +579,28 @@ export class TokenSwap {
     userAccountB: PublicKey,
     swapProgramId: PublicKey,
     tokenProgramId: PublicKey,
-    amount: number | Numberu64,
+    pool_token_amount: number | Numberu64,
+    minimum_token_a_amount: number | Numberu64,
+    minimum_token_b_amount: number | Numberu64,
   ): TransactionInstruction {
     const dataLayout = BufferLayout.struct([
       BufferLayout.u8('instruction'),
-      Layout.uint64('amount'),
+      Layout.uint64('pool_token_amount'),
+      Layout.uint64('minimum_token_a_amount'),
+      Layout.uint64('minimum_token_b_amount'),
     ]);
 
     const data = Buffer.alloc(dataLayout.span);
     dataLayout.encode(
       {
         instruction: 3, // Withdraw instruction
-        amount: new Numberu64(amount).toBuffer(),
+        pool_token_amount: new Numberu64(pool_token_amount).toBuffer(),
+        minimum_token_a_amount: new Numberu64(
+          minimum_token_a_amount,
+        ).toBuffer(),
+        minimum_token_b_amount: new Numberu64(
+          minimum_token_b_amount,
+        ).toBuffer(),
       },
       data,
     );

--- a/token-swap/js/module.d.ts
+++ b/token-swap/js/module.d.ts
@@ -78,7 +78,8 @@ declare module '@solana/spl-token-swap' {
       swapDestination: PublicKey,
       destination: PublicKey,
       tokenProgramId: PublicKey,
-      amount: number | Numberu64,
+      amount_in: number | Numberu64,
+      minimum_amount_out: number | Numberu64,
     ): Promise<TransactionSignature>;
 
     static swapInstruction(
@@ -90,7 +91,8 @@ declare module '@solana/spl-token-swap' {
       destination: PublicKey,
       swapProgramId: PublicKey,
       tokenProgramId: PublicKey,
-      amount: number | Numberu64,
+      amount_in: number | Numberu64,
+      minimum_amount_out: number | Numberu64,
     ): TransactionInstruction;
 
     deposit(
@@ -102,7 +104,9 @@ declare module '@solana/spl-token-swap' {
       poolToken: PublicKey,
       poolAccount: PublicKey,
       tokenProgramId: PublicKey,
-      amount: number | Numberu64,
+      pool_token_amount: number | Numberu64,
+      maximum_token_a_amount: number | Numberu64,
+      maximum_token_b_amount: number | Numberu64,
     ): Promise<TransactionSignature>;
 
     static depositInstruction(
@@ -116,7 +120,9 @@ declare module '@solana/spl-token-swap' {
       poolAccount: PublicKey,
       swapProgramId: PublicKey,
       tokenProgramId: PublicKey,
-      amount: number | Numberu64,
+      pool_token_amount: number | Numberu64,
+      maximum_token_a_amount: number | Numberu64,
+      maximum_token_b_amount: number | Numberu64,
     ): TransactionInstruction;
 
     withdraw(
@@ -128,7 +134,9 @@ declare module '@solana/spl-token-swap' {
       userAccountA: PublicKey,
       userAccountB: PublicKey,
       tokenProgramId: PublicKey,
-      amount: number | Numberu64,
+      pool_token_amount: number | Numberu64,
+      minimum_token_a_amount: number | Numberu64,
+      minimum_token_b_amount: number | Numberu64,
     ): Promise<TransactionSignature>;
 
     static withdrawInstruction(
@@ -142,7 +150,9 @@ declare module '@solana/spl-token-swap' {
       userAccountB: PublicKey,
       swapProgramId: PublicKey,
       tokenProgramId: PublicKey,
-      amount: number | Numberu64,
+      pool_token_amount: number | Numberu64,
+      minimum_token_a_amount: number | Numberu64,
+      minimum_token_b_amount: number | Numberu64,
     ): TransactionInstruction;
   }
 }

--- a/token-swap/js/module.d.ts
+++ b/token-swap/js/module.d.ts
@@ -71,6 +71,7 @@ declare module '@solana/spl-token-swap' {
     ): Promise<TokenSwap>;
 
     getInfo(): Promise<TokenSwapInfo>;
+
     swap(
       authority: PublicKey,
       source: PublicKey,
@@ -78,8 +79,8 @@ declare module '@solana/spl-token-swap' {
       swapDestination: PublicKey,
       destination: PublicKey,
       tokenProgramId: PublicKey,
-      amount_in: number | Numberu64,
-      minimum_amount_out: number | Numberu64,
+      amountIn: number | Numberu64,
+      minimumAmountOut: number | Numberu64,
     ): Promise<TransactionSignature>;
 
     static swapInstruction(
@@ -91,8 +92,8 @@ declare module '@solana/spl-token-swap' {
       destination: PublicKey,
       swapProgramId: PublicKey,
       tokenProgramId: PublicKey,
-      amount_in: number | Numberu64,
-      minimum_amount_out: number | Numberu64,
+      amountIn: number | Numberu64,
+      minimumAmountOut: number | Numberu64,
     ): TransactionInstruction;
 
     deposit(
@@ -104,9 +105,9 @@ declare module '@solana/spl-token-swap' {
       poolToken: PublicKey,
       poolAccount: PublicKey,
       tokenProgramId: PublicKey,
-      pool_token_amount: number | Numberu64,
-      maximum_token_a_amount: number | Numberu64,
-      maximum_token_b_amount: number | Numberu64,
+      poolTokenAmount: number | Numberu64,
+      maximumTokenA: number | Numberu64,
+      maximumTokenB: number | Numberu64,
     ): Promise<TransactionSignature>;
 
     static depositInstruction(
@@ -120,9 +121,9 @@ declare module '@solana/spl-token-swap' {
       poolAccount: PublicKey,
       swapProgramId: PublicKey,
       tokenProgramId: PublicKey,
-      pool_token_amount: number | Numberu64,
-      maximum_token_a_amount: number | Numberu64,
-      maximum_token_b_amount: number | Numberu64,
+      poolTokenAmount: number | Numberu64,
+      maximumTokenA: number | Numberu64,
+      maximumTokenB: number | Numberu64,
     ): TransactionInstruction;
 
     withdraw(
@@ -134,9 +135,9 @@ declare module '@solana/spl-token-swap' {
       userAccountA: PublicKey,
       userAccountB: PublicKey,
       tokenProgramId: PublicKey,
-      pool_token_amount: number | Numberu64,
-      minimum_token_a_amount: number | Numberu64,
-      minimum_token_b_amount: number | Numberu64,
+      poolTokenAmount: number | Numberu64,
+      minimumTokenA: number | Numberu64,
+      minimumTokenB: number | Numberu64,
     ): Promise<TransactionSignature>;
 
     static withdrawInstruction(
@@ -150,9 +151,9 @@ declare module '@solana/spl-token-swap' {
       userAccountB: PublicKey,
       swapProgramId: PublicKey,
       tokenProgramId: PublicKey,
-      pool_token_amount: number | Numberu64,
-      minimum_token_a_amount: number | Numberu64,
-      minimum_token_b_amount: number | Numberu64,
+      poolTokenAmount: number | Numberu64,
+      minimumTokenA: number | Numberu64,
+      minimumTokenB: number | Numberu64,
     ): TransactionInstruction;
   }
 }

--- a/token-swap/js/module.flow.js
+++ b/token-swap/js/module.flow.js
@@ -75,8 +75,8 @@ declare module '@solana/spl-token-swap' {
       swapDestination: PublicKey,
       destination: PublicKey,
       tokenProgramId: PublicKey,
-      amount_in: number | Numberu64,
-      minimum_amount_out: number | Numberu64,
+      amountIn: number | Numberu64,
+      minimumAmountOut: number | Numberu64,
     ): Promise<TransactionSignature>;
 
     static swapInstruction(
@@ -88,8 +88,8 @@ declare module '@solana/spl-token-swap' {
       destination: PublicKey,
       swapProgramId: PublicKey,
       tokenProgramId: PublicKey,
-      amount_in: number | Numberu64,
-      minimum_amount_out: number | Numberu64,
+      amountIn: number | Numberu64,
+      minimumAmountOut: number | Numberu64,
     ): TransactionInstruction;
 
     deposit(
@@ -101,9 +101,9 @@ declare module '@solana/spl-token-swap' {
       poolToken: PublicKey,
       poolAccount: PublicKey,
       tokenProgramId: PublicKey,
-      pool_token_amount: number | Numberu64,
-      maximum_token_a_amount: number | Numberu64,
-      maximum_token_b_amount: number | Numberu64,
+      poolTokenAmount: number | Numberu64,
+      maximumTokenA: number | Numberu64,
+      maximumTokenB: number | Numberu64,
     ): Promise<TransactionSignature>;
 
     static depositInstruction(
@@ -117,9 +117,9 @@ declare module '@solana/spl-token-swap' {
       poolAccount: PublicKey,
       swapProgramId: PublicKey,
       tokenProgramId: PublicKey,
-      pool_token_amount: number | Numberu64,
-      maximum_token_a_amount: number | Numberu64,
-      maximum_token_b_amount: number | Numberu64,
+      poolTokenAmount: number | Numberu64,
+      maximumTokenA: number | Numberu64,
+      maximumTokenB: number | Numberu64,
     ): TransactionInstruction;
 
     withdraw(
@@ -131,9 +131,9 @@ declare module '@solana/spl-token-swap' {
       userAccountA: PublicKey,
       userAccountB: PublicKey,
       tokenProgramId: PublicKey,
-      pool_token_amount: number | Numberu64,
-      minimum_token_a_amount: number | Numberu64,
-      minimum_token_b_amount: number | Numberu64,
+      poolTokenAmount: number | Numberu64,
+      minimumTokenA: number | Numberu64,
+      minimumTokenB: number | Numberu64,
     ): Promise<TransactionSignature>;
 
     static withdrawInstruction(
@@ -147,9 +147,9 @@ declare module '@solana/spl-token-swap' {
       userAccountB: PublicKey,
       swapProgramId: PublicKey,
       tokenProgramId: PublicKey,
-      pool_token_amount: number | Numberu64,
-      minimum_token_a_amount: number | Numberu64,
-      minimum_token_b_amount: number | Numberu64,
+      poolTokenAmount: number | Numberu64,
+      minimumTokenA: number | Numberu64,
+      minimumTokenB: number | Numberu64,
     ): TransactionInstruction;
   }
 }

--- a/token-swap/js/module.flow.js
+++ b/token-swap/js/module.flow.js
@@ -75,7 +75,8 @@ declare module '@solana/spl-token-swap' {
       swapDestination: PublicKey,
       destination: PublicKey,
       tokenProgramId: PublicKey,
-      amount: number | Numberu64,
+      amount_in: number | Numberu64,
+      minimum_amount_out: number | Numberu64,
     ): Promise<TransactionSignature>;
 
     static swapInstruction(
@@ -87,7 +88,8 @@ declare module '@solana/spl-token-swap' {
       destination: PublicKey,
       swapProgramId: PublicKey,
       tokenProgramId: PublicKey,
-      amount: number | Numberu64,
+      amount_in: number | Numberu64,
+      minimum_amount_out: number | Numberu64,
     ): TransactionInstruction;
 
     deposit(
@@ -99,7 +101,9 @@ declare module '@solana/spl-token-swap' {
       poolToken: PublicKey,
       poolAccount: PublicKey,
       tokenProgramId: PublicKey,
-      amount: number | Numberu64,
+      pool_token_amount: number | Numberu64,
+      maximum_token_a_amount: number | Numberu64,
+      maximum_token_b_amount: number | Numberu64,
     ): Promise<TransactionSignature>;
 
     static depositInstruction(
@@ -113,7 +117,9 @@ declare module '@solana/spl-token-swap' {
       poolAccount: PublicKey,
       swapProgramId: PublicKey,
       tokenProgramId: PublicKey,
-      amount: number | Numberu64,
+      pool_token_amount: number | Numberu64,
+      maximum_token_a_amount: number | Numberu64,
+      maximum_token_b_amount: number | Numberu64,
     ): TransactionInstruction;
 
     withdraw(
@@ -125,7 +131,9 @@ declare module '@solana/spl-token-swap' {
       userAccountA: PublicKey,
       userAccountB: PublicKey,
       tokenProgramId: PublicKey,
-      amount: number | Numberu64,
+      pool_token_amount: number | Numberu64,
+      minimum_token_a_amount: number | Numberu64,
+      minimum_token_b_amount: number | Numberu64,
     ): Promise<TransactionSignature>;
 
     static withdrawInstruction(
@@ -139,7 +147,9 @@ declare module '@solana/spl-token-swap' {
       userAccountB: PublicKey,
       swapProgramId: PublicKey,
       tokenProgramId: PublicKey,
-      amount: number | Numberu64,
+      pool_token_amount: number | Numberu64,
+      minimum_token_a_amount: number | Numberu64,
+      minimum_token_b_amount: number | Numberu64,
     ): TransactionInstruction;
   }
 }

--- a/token-swap/program/src/error.rs
+++ b/token-swap/program/src/error.rs
@@ -55,6 +55,9 @@ pub enum SwapError {
     /// Swap input token accounts have the same mint
     #[error("Swap input token accounts have the same mint")]
     RepeatedMint,
+    /// Swap instruction exceeds desired slippage limit
+    #[error("Swap instruction exceeds desired slippage limit")]
+    ExceededSlippage,
 }
 impl From<SwapError> for ProgramError {
     fn from(e: SwapError) -> Self {


### PR DESCRIPTION
**Problem**

When performing swap, withdraw, or deposit, there's a chance that we'll receive much less than expected due to slippage.

**Solution**

Add minimum / maximum amount parameters for all commands, along with updates to JS bindings.

Fixes #87 and #88