### PR TITLE
token-swap: Assess swap fee on input token

### DIFF
--- a/bpf-sdk-install.sh
+++ b/bpf-sdk-install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-channel=${1:-v1.3.13}
+channel=${1:-v1.3.14}
 installDir="$(dirname "$0")"/bin
 cacheDir=~/.cache/solana-bpf-sdk/"$channel"
 

--- a/memo/program/Cargo.toml
+++ b/memo/program/Cargo.toml
@@ -17,7 +17,7 @@ program = ["solana-sdk/program"]
 default = ["solana-sdk/default"]
 
 [dependencies]
-solana-sdk = { version = "1.3.12", default-features = false, optional = true }
+solana-sdk = { version = "1.3.14", default-features = false, optional = true }
 
 [lib]
 name = "spl_memo"

--- a/token-swap/js/cli/token-swap-test.js
+++ b/token-swap/js/cli/token-swap-test.js
@@ -39,7 +39,7 @@ let tokenAccountB: PublicKey;
 const BASE_AMOUNT = 1000;
 // Amount passed to swap instruction
 const SWAP_AMOUNT_IN = 100;
-const SWAP_AMOUNT_OUT = 69;
+const SWAP_AMOUNT_OUT = 70;
 // Pool token amount minted on init
 const DEFAULT_POOL_TOKEN_AMOUNT = 1000000000;
 // Pool token amount to withdraw / deposit

--- a/token-swap/program/Cargo.toml
+++ b/token-swap/program/Cargo.toml
@@ -22,7 +22,7 @@ arrayref = "0.3.6"
 num-derive = "0.3"
 num-traits = "0.2"
 remove_dir_all = "=0.5.0"
-solana-sdk = { version = "1.3.12", default-features = false, optional = true }
+solana-sdk = { version = "1.3.14", default-features = false, optional = true }
 spl-token = { path = "../../token/program", default-features = false, optional = true }
 thiserror = "1.0"
 

--- a/token-swap/program/src/curve.rs
+++ b/token-swap/program/src/curve.rs
@@ -35,7 +35,7 @@ impl SwapResult {
         let new_source_amount_less_fee = swap_source_amount
             .checked_add(source_amount)?
             .checked_sub(fee)?;
-        let new_destination_amount = invariant.checked_div(new_source_amount)?;
+        let new_destination_amount = invariant.checked_div(new_source_amount_less_fee)?;
         let amount_swapped = swap_destination_amount.checked_sub(new_destination_amount)?;
 
         // actually add the whole amount coming in

--- a/token-swap/program/src/curve.rs
+++ b/token-swap/program/src/curve.rs
@@ -27,14 +27,19 @@ impl SwapResult {
         fee_denominator: u64,
     ) -> Option<SwapResult> {
         let invariant = swap_source_amount.checked_mul(swap_destination_amount)?;
-        let new_source_amount = swap_source_amount.checked_add(source_amount)?;
-        let new_destination_amount = invariant.checked_div(new_source_amount)?;
-        let remove = swap_destination_amount.checked_sub(new_destination_amount)?;
-        let fee = remove
+
+        // assess the fee to calculate the amount swapped
+        let fee = source_amount
             .checked_mul(fee_numerator)?
             .checked_div(fee_denominator)?;
-        let new_destination_amount = new_destination_amount.checked_add(fee)?;
-        let amount_swapped = remove.checked_sub(fee)?;
+        let new_source_amount = swap_source_amount
+            .checked_add(source_amount)?
+            .checked_sub(fee)?;
+        let new_destination_amount = invariant.checked_div(new_source_amount)?;
+        let amount_swapped = swap_destination_amount.checked_sub(new_destination_amount)?;
+
+        // actually add the whole amount coming in
+        let new_source_amount = swap_source_amount.checked_add(source_amount)?;
         Some(SwapResult {
             new_source_amount,
             new_destination_amount,
@@ -161,5 +166,26 @@ mod tests {
         check_pool_token_a_rate(5, 100, 5, 10, Some(2));
         check_pool_token_a_rate(5, u64::MAX, 5, 10, Some(2));
         check_pool_token_a_rate(u64::MAX, u64::MAX, 5, 10, None);
+    }
+
+    #[test]
+    fn swap_calculation() {
+        // calculation on https://github.com/solana-labs/solana-program-library/issues/341
+        let swap_source_amount: u64 = 1000;
+        let swap_destination_amount: u64 = 50000;
+        let fee_numerator: u64 = 1;
+        let fee_denominator: u64 = 100;
+        let source_amount: u64 = 100;
+        let result = SwapResult::swap_to(
+            source_amount,
+            swap_source_amount,
+            swap_destination_amount,
+            fee_numerator,
+            fee_denominator,
+        )
+        .unwrap();
+        assert_eq!(result.new_source_amount, 1100);
+        assert_eq!(result.amount_swapped, 4505);
+        assert_eq!(result.new_destination_amount, 45495);
     }
 }

--- a/token-swap/program/src/curve.rs
+++ b/token-swap/program/src/curve.rs
@@ -32,7 +32,7 @@ impl SwapResult {
         let fee = source_amount
             .checked_mul(fee_numerator)?
             .checked_div(fee_denominator)?;
-        let new_source_amount = swap_source_amount
+        let new_source_amount_less_fee = swap_source_amount
             .checked_add(source_amount)?
             .checked_sub(fee)?;
         let new_destination_amount = invariant.checked_div(new_source_amount)?;

--- a/token-swap/program/src/curve.rs
+++ b/token-swap/program/src/curve.rs
@@ -28,7 +28,7 @@ impl SwapResult {
     ) -> Option<SwapResult> {
         let invariant = swap_source_amount.checked_mul(swap_destination_amount)?;
 
-        // assess the fee to calculate the amount swapped
+        // debit the fee to calculate the amount swapped
         let fee = source_amount
             .checked_mul(fee_numerator)?
             .checked_div(fee_denominator)?;

--- a/token/js/package.json
+++ b/token/js/package.json
@@ -22,7 +22,7 @@
     "/lib",
     "/module.flow.js"
   ],
-  "testnetDefaultChannel": "v1.3.13",
+  "testnetDefaultChannel": "v1.3.14",
   "scripts": {
     "build": "rollup -c",
     "start": "babel-node cli/main.js",

--- a/token/program-v3/Cargo.toml
+++ b/token/program-v3/Cargo.toml
@@ -21,7 +21,7 @@ default = ["solana-sdk/default"]
 num-derive = "0.3"
 num-traits = "0.2"
 remove_dir_all = "=0.5.0"
-solana-sdk = { version = "1.3.12", default-features = false, optional = true }
+solana-sdk = { version = "1.3.14", default-features = false, optional = true }
 thiserror = "1.0"
 arrayref = "0.3.6"
 num_enum = "0.5.1"


### PR DESCRIPTION
**Problem**

In our implementation of fee calculation, we assess the fee entirely on the output token, but Uniswap and Balancer assess on the input. The overall effect on the pool value is the same, but when we withdraw from the pool, the gains from fees are slightly unbalanced.

**Solution**

Update the swap fee calculation to line up with uniswap.  Also, update the SDK version everywhere.

Fixes #341