### PR TITLE
solana sdk does not need skip-no-mangle

### DIFF
--- a/memo/program/Cargo.toml
+++ b/memo/program/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [features]
 no-entrypoint = []
-skip-no-mangle = ["solana-sdk/skip-no-mangle"]
+skip-no-mangle = []
 program = ["solana-sdk/program"]
 default = ["solana-sdk/default"]
 

--- a/themis/client_bn/Cargo.toml
+++ b/themis/client_bn/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["js/**"]
 
 [features]
 no-entrypoint = []
-skip-no-mangle = ["solana-sdk/skip-no-mangle"]
+skip-no-mangle = []
 program = ["solana-sdk/program"]
 default = ["solana-sdk/default"]
 

--- a/themis/client_ristretto/Cargo.toml
+++ b/themis/client_ristretto/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["js/**"]
 
 [features]
 no-entrypoint = []
-skip-no-mangle = ["solana-sdk/skip-no-mangle"]
+skip-no-mangle = ["]
 program = ["solana-sdk/program"]
 default = ["solana-sdk/default"]
 

--- a/themis/client_ristretto/Cargo.toml
+++ b/themis/client_ristretto/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["js/**"]
 
 [features]
 no-entrypoint = []
-skip-no-mangle = ["]
+skip-no-mangle = []
 program = ["solana-sdk/program"]
 default = ["solana-sdk/default"]
 

--- a/themis/program_bn/Cargo.toml
+++ b/themis/program_bn/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["js/**"]
 
 [features]
 no-entrypoint = []
-skip-no-mangle = ["solana-sdk/skip-no-mangle"]
+skip-no-mangle = []
 program = ["solana-sdk/program"]
 default = ["solana-sdk/default"]
 

--- a/themis/program_ristretto/Cargo.toml
+++ b/themis/program_ristretto/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["js/**"]
 
 [features]
 no-entrypoint = []
-skip-no-mangle = ["solana-sdk/skip-no-mangle"]
+skip-no-mangle = []
 program = ["solana-sdk/program"]
 default = ["solana-sdk/default"]
 

--- a/token-swap/program/Cargo.toml
+++ b/token-swap/program/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["js/**"]
 
 [features]
 no-entrypoint = []
-skip-no-mangle = ["solana-sdk/skip-no-mangle"]
+skip-no-mangle = []
 program = ["solana-sdk/program", "spl-token/program", "spl-token/no-entrypoint"]
 default = ["solana-sdk/default", "spl-token/default"]
 

--- a/token/program-v3/Cargo.toml
+++ b/token/program-v3/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["js/**"]
 
 [features]
 no-entrypoint = []
-skip-no-mangle = ["solana-sdk/skip-no-mangle"]
+skip-no-mangle = []
 program = ["solana-sdk/program"]
 default = ["solana-sdk/default"]
 

--- a/token/program/Cargo.toml
+++ b/token/program/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["js/**"]
 
 [features]
 no-entrypoint = []
-skip-no-mangle = ["solana-sdk/skip-no-mangle"]
+skip-no-mangle = []
 program = ["solana-sdk/program"]
 default = ["solana-sdk/default"]
 


### PR DESCRIPTION
The feature `skip-no-mangle` is used a macro that is defined in the sdk but used in programs.  This means to enable this feature the programs must define it, not the sdk.  Currently, all the programs define this feature but they also require it in the sdk which is not necessary.

These changes remove the `skip-no-mangle` feature dependency on the sdk.