### PR TITLE
Add JS test for creating accounts and swapping in one transaction

### DIFF
--- a/token-swap/js/cli/main.js
+++ b/token-swap/js/cli/main.js
@@ -6,9 +6,9 @@
 
 import {
   loadPrograms,
+  createAccountAndSwapAtomic,
   createTokenSwap,
   swap,
-  swapOneTransaction,
   deposit,
   withdraw,
 } from './token-swap-test';
@@ -19,14 +19,14 @@ async function main() {
   await loadPrograms();
   console.log('Run test: createTokenSwap');
   await createTokenSwap();
-  console.log('Run test: create account, approve, swap all at once');
-  await swapOneTransaction();
   console.log('Run test: deposit');
   await deposit();
   console.log('Run test: withdraw');
   await withdraw();
   console.log('Run test: swap');
   await swap();
+  console.log('Run test: create account, approve, swap all at once');
+  await createAccountAndSwapAtomic();
   console.log('Success\n');
 }
 

--- a/token-swap/js/cli/main.js
+++ b/token-swap/js/cli/main.js
@@ -8,6 +8,7 @@ import {
   loadPrograms,
   createTokenSwap,
   swap,
+  swapOneTransaction,
   deposit,
   withdraw,
 } from './token-swap-test';
@@ -18,6 +19,8 @@ async function main() {
   await loadPrograms();
   console.log('Run test: createTokenSwap');
   await createTokenSwap();
+  console.log('Run test: create account, approve, swap all at once');
+  await swapOneTransaction();
   console.log('Run test: deposit');
   await deposit();
   console.log('Run test: withdraw');

--- a/token-swap/js/cli/token-swap-test.js
+++ b/token-swap/js/cli/token-swap-test.js
@@ -6,11 +6,14 @@ import {
   Connection,
   BpfLoader,
   PublicKey,
+  SystemProgram,
+  Transaction,
   BPF_LOADER_PROGRAM_ID,
 } from '@solana/web3.js';
 
-import {Token} from '../../../token/js/client/token';
+import {AccountLayout, Token} from '../../../token/js/client/token';
 import {TokenSwap, CurveType} from '../client/token-swap';
+import {sendAndConfirmTransaction} from '../client/util/send-and-confirm-transaction';
 import {Store} from '../client/util/store';
 import {newAccountWithLamports} from '../client/util/new-account-with-lamports';
 import {url} from '../url';
@@ -391,6 +394,77 @@ export async function withdraw(): Promise<void> {
   info = await tokenPool.getAccountInfo(feeAccount);
   assert(info.amount.toNumber() == feeAmount);
   currentFeeAmount = feeAmount;
+}
+
+export async function swapOneTransaction(): Promise<void> {
+  console.log('Creating swap token a account');
+  let userAccountA = await mintA.createAccount(owner.publicKey);
+  await mintA.mintTo(userAccountA, owner, [], SWAP_AMOUNT_IN);
+
+  const balanceNeeded = await Token.getMinBalanceRentForExemptAccount(
+    connection,
+  );
+  const newAccount = new Account();
+  const transaction = new Transaction();
+  transaction.add(
+    SystemProgram.createAccount({
+      fromPubkey: mintB.payer.publicKey,
+      newAccountPubkey: newAccount.publicKey,
+      lamports: balanceNeeded,
+      space: AccountLayout.span,
+      programId: mintB.programId,
+    }),
+  );
+
+  transaction.add(
+    Token.createInitAccountInstruction(
+      mintB.programId,
+      mintB.publicKey,
+      newAccount.publicKey,
+      owner.publicKey,
+    ),
+  );
+
+  transaction.add(
+    Token.createApproveInstruction(
+      mintA.programId,
+      userAccountA,
+      authority,
+      owner.publicKey,
+      [owner],
+      SWAP_AMOUNT_IN,
+    )
+  );
+
+  transaction.add(
+    TokenSwap.swapInstruction(
+      this.tokenSwap,
+      this.authority,
+      userAccountA,
+      tokenAccountA,
+      tokenAccountB,
+      newAccount.publicKey,
+      tokenSwap.poolToken,
+      tokenSwap.feeAccount,
+      null,
+      tokenSwap.swapProgramId,
+      tokenSwap.tokenProgramId,
+      SWAP_AMOUNT_IN,
+      SWAP_AMOUNT_OUT,
+    )
+  );
+
+  // Send the instructions
+  console.log('sending big instruction');
+  await sendAndConfirmTransaction(
+    'do a whole lot',
+    connection,
+    transaction,
+    owner,
+    newAccount,
+    mintA.payer,
+    mintB.payer,
+  );
 }
 
 export async function swap(): Promise<void> {

--- a/token-swap/js/cli/token-swap-test.js
+++ b/token-swap/js/cli/token-swap-test.js
@@ -396,7 +396,7 @@ export async function withdraw(): Promise<void> {
   currentFeeAmount = feeAmount;
 }
 
-export async function swapOneTransaction(): Promise<void> {
+export async function createAccountAndSwapAtomic(): Promise<void> {
   console.log('Creating swap token a account');
   let userAccountA = await mintA.createAccount(owner.publicKey);
   await mintA.mintTo(userAccountA, owner, [], SWAP_AMOUNT_IN);
@@ -433,16 +433,16 @@ export async function swapOneTransaction(): Promise<void> {
       owner.publicKey,
       [owner],
       SWAP_AMOUNT_IN,
-    )
+    ),
   );
 
   transaction.add(
     TokenSwap.swapInstruction(
-      this.tokenSwap,
-      this.authority,
+      tokenSwap.tokenSwap,
+      tokenSwap.authority,
       userAccountA,
-      tokenAccountA,
-      tokenAccountB,
+      tokenSwap.tokenAccountA,
+      tokenSwap.tokenAccountB,
       newAccount.publicKey,
       tokenSwap.poolToken,
       tokenSwap.feeAccount,
@@ -450,14 +450,14 @@ export async function swapOneTransaction(): Promise<void> {
       tokenSwap.swapProgramId,
       tokenSwap.tokenProgramId,
       SWAP_AMOUNT_IN,
-      SWAP_AMOUNT_OUT,
-    )
+      0,
+    ),
   );
 
   // Send the instructions
   console.log('sending big instruction');
   await sendAndConfirmTransaction(
-    'do a whole lot',
+    'create account, approve transfer, swap',
     connection,
     transaction,
     owner,

--- a/token-swap/js/cli/token-swap-test.js
+++ b/token-swap/js/cli/token-swap-test.js
@@ -408,7 +408,7 @@ export async function swapOneTransaction(): Promise<void> {
   const transaction = new Transaction();
   transaction.add(
     SystemProgram.createAccount({
-      fromPubkey: mintB.payer.publicKey,
+      fromPubkey: owner.publicKey,
       newAccountPubkey: newAccount.publicKey,
       lamports: balanceNeeded,
       space: AccountLayout.span,
@@ -462,8 +462,6 @@ export async function swapOneTransaction(): Promise<void> {
     transaction,
     owner,
     newAccount,
-    mintA.payer,
-    mintB.payer,
   );
 }
 


### PR DESCRIPTION
This is WIP, but it can showcase how to reduce the number of separate roundtrips required to do many things at once.  It may be worth porting all of the token-swap tests to look like this to speed them considerably.