### PR TITLE
Remove skip-no-mangle entirely

### DIFF
--- a/memo/program/Cargo.toml
+++ b/memo/program/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 
 [features]
 no-entrypoint = []
-skip-no-mangle = []
 program = ["solana-sdk/program"]
 default = ["solana-sdk/default"]
 

--- a/themis/client_bn/Cargo.toml
+++ b/themis/client_bn/Cargo.toml
@@ -11,7 +11,6 @@ exclude = ["js/**"]
 
 [features]
 no-entrypoint = []
-skip-no-mangle = []
 program = ["solana-sdk/program"]
 default = ["solana-sdk/default"]
 

--- a/themis/client_ristretto/Cargo.toml
+++ b/themis/client_ristretto/Cargo.toml
@@ -11,7 +11,6 @@ exclude = ["js/**"]
 
 [features]
 no-entrypoint = []
-skip-no-mangle = []
 program = ["solana-sdk/program"]
 default = ["solana-sdk/default"]
 

--- a/themis/program_bn/Cargo.toml
+++ b/themis/program_bn/Cargo.toml
@@ -13,7 +13,6 @@ exclude = ["js/**"]
 
 [features]
 no-entrypoint = []
-skip-no-mangle = []
 program = ["solana-sdk/program"]
 default = ["solana-sdk/default"]
 

--- a/themis/program_ristretto/Cargo.toml
+++ b/themis/program_ristretto/Cargo.toml
@@ -13,7 +13,6 @@ exclude = ["js/**"]
 
 [features]
 no-entrypoint = []
-skip-no-mangle = []
 program = ["solana-sdk/program"]
 default = ["solana-sdk/default"]
 

--- a/token-swap/program/Cargo.toml
+++ b/token-swap/program/Cargo.toml
@@ -13,7 +13,6 @@ exclude = ["js/**"]
 
 [features]
 no-entrypoint = []
-skip-no-mangle = []
 program = ["solana-sdk/program", "spl-token/program", "spl-token/no-entrypoint"]
 default = ["solana-sdk/default", "spl-token/default"]
 

--- a/token/program-v3/Cargo.toml
+++ b/token/program-v3/Cargo.toml
@@ -13,7 +13,6 @@ exclude = ["js/**"]
 
 [features]
 no-entrypoint = []
-skip-no-mangle = []
 program = ["solana-sdk/program"]
 default = ["solana-sdk/default"]
 

--- a/token/program/Cargo.toml
+++ b/token/program/Cargo.toml
@@ -13,7 +13,6 @@ exclude = ["js/**"]
 
 [features]
 no-entrypoint = []
-skip-no-mangle = []
 program = ["solana-sdk/program"]
 default = ["solana-sdk/default"]
 


### PR DESCRIPTION
Programs now use other features to decide if the program's entrypoint should be pulled in or not.  Remove it entirely. 