### PR TITLE
Use ristretto_mul builtin to stay below BPF instruction limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.49"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e450b8da92aa6f274e7c6437692f9f2ce6d701fb73bacfcf87897b3f89a4c20e"
+checksum = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
 dependencies = [
  "jobserver",
  "num_cpus",
@@ -709,7 +709,7 @@ dependencies = [
 [[package]]
 name = "elgamal_ristretto"
 version = "0.2.4"
-source = "git+https://github.com/garious/elgamal?rev=260763fb67c34debe3915b39d95b6e7b3e1461d0#260763fb67c34debe3915b39d95b6e7b3e1461d0"
+source = "git+https://github.com/garious/elgamal?rev=6c5ad5b32160e78be080b74eb7a1867dd65aec6c#6c5ad5b32160e78be080b74eb7a1867dd65aec6c"
 dependencies = [
  "bincode",
  "borsh",
@@ -718,6 +718,7 @@ dependencies = [
  "rand_core",
  "serde",
  "sha2 0.8.2",
+ "solana-sdk 1.4.0",
  "zkp",
 ]
 
@@ -2317,7 +2318,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-config-program",
- "solana-sdk",
+ "solana-sdk 1.3.14",
  "solana-stake-program",
  "solana-vote-program",
  "spl-token 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2334,7 +2335,7 @@ dependencies = [
  "clap",
  "rpassword",
  "solana-remote-wallet",
- "solana-sdk",
+ "solana-sdk 1.3.14",
  "thiserror",
  "tiny-bip39",
  "url",
@@ -2371,7 +2372,7 @@ dependencies = [
  "solana-account-decoder",
  "solana-clap-utils",
  "solana-client",
- "solana-sdk",
+ "solana-sdk 1.3.14",
  "solana-stake-program",
  "solana-transaction-status",
  "solana-vote-program",
@@ -2397,7 +2398,7 @@ dependencies = [
  "solana-account-decoder",
  "solana-clap-utils",
  "solana-net-utils",
- "solana-sdk",
+ "solana-sdk 1.3.14",
  "solana-transaction-status",
  "solana-vote-program",
  "thiserror",
@@ -2416,7 +2417,7 @@ dependencies = [
  "log",
  "serde",
  "serde_derive",
- "solana-sdk",
+ "solana-sdk 1.3.14",
 ]
 
 [[package]]
@@ -2424,6 +2425,30 @@ name = "solana-crate-features"
 version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cc2deb783d0f6954d1a244cab9a7a20416c075b86918c5aa6a1be3caa795e32"
+dependencies = [
+ "backtrace",
+ "bytes 0.4.12",
+ "cc",
+ "curve25519-dalek 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519-dalek",
+ "either",
+ "failure",
+ "lazy_static",
+ "libc",
+ "rand_chacha",
+ "regex-syntax",
+ "reqwest",
+ "serde",
+ "syn 0.15.44",
+ "syn 1.0.41",
+ "tokio 0.1.22",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "solana-crate-features"
+version = "1.4.0"
+source = "git+https://github.com/solana-labs/solana?rev=dd7fae4afb898dee5b5147c8ee8d6f6d712363d1#dd7fae4afb898dee5b5147c8ee8d6f6d712363d1"
 dependencies = [
  "backtrace",
  "bytes 0.4.12",
@@ -2456,6 +2481,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-logger"
+version = "1.4.0"
+source = "git+https://github.com/solana-labs/solana?rev=dd7fae4afb898dee5b5147c8ee8d6f6d712363d1#dd7fae4afb898dee5b5147c8ee8d6f6d712363d1"
+dependencies = [
+ "env_logger",
+ "lazy_static",
+ "log",
+]
+
+[[package]]
 name = "solana-measure"
 version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2465,7 +2500,7 @@ dependencies = [
  "jemallocator",
  "log",
  "solana-metrics",
- "solana-sdk",
+ "solana-sdk 1.3.14",
 ]
 
 [[package]]
@@ -2479,7 +2514,7 @@ dependencies = [
  "lazy_static",
  "log",
  "reqwest",
- "solana-sdk",
+ "solana-sdk 1.3.14",
 ]
 
 [[package]]
@@ -2498,7 +2533,7 @@ dependencies = [
  "serde_derive",
  "socket2",
  "solana-clap-utils",
- "solana-logger",
+ "solana-logger 1.3.15",
  "solana-version",
  "tokio 0.1.22",
  "tokio-codec",
@@ -2530,7 +2565,7 @@ dependencies = [
  "num-traits",
  "parking_lot 0.10.2",
  "semver",
- "solana-sdk",
+ "solana-sdk 1.3.14",
  "thiserror",
  "url",
 ]
@@ -2567,12 +2602,12 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-config-program",
- "solana-logger",
+ "solana-logger 1.3.15",
  "solana-measure",
  "solana-metrics",
  "solana-rayon-threadlimit",
- "solana-sdk",
- "solana-sdk-macro-frozen-abi",
+ "solana-sdk 1.3.14",
+ "solana-sdk-macro-frozen-abi 1.3.14",
  "solana-secp256k1-program",
  "solana-stake-program",
  "solana-vote-program",
@@ -2618,10 +2653,51 @@ dependencies = [
  "serde_json",
  "sha2 0.8.2",
  "sha3",
- "solana-crate-features",
- "solana-logger",
- "solana-sdk-macro",
- "solana-sdk-macro-frozen-abi",
+ "solana-crate-features 1.3.14",
+ "solana-logger 1.3.15",
+ "solana-sdk-macro 1.3.14",
+ "solana-sdk-macro-frozen-abi 1.3.14",
+ "thiserror",
+]
+
+[[package]]
+name = "solana-sdk"
+version = "1.4.0"
+source = "git+https://github.com/solana-labs/solana?rev=dd7fae4afb898dee5b5147c8ee8d6f6d712363d1#dd7fae4afb898dee5b5147c8ee8d6f6d712363d1"
+dependencies = [
+ "assert_matches",
+ "bincode",
+ "bs58",
+ "bv",
+ "byteorder",
+ "chrono",
+ "curve25519-dalek 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.9.0",
+ "ed25519-dalek",
+ "generic-array 0.14.3",
+ "hex",
+ "hmac",
+ "itertools",
+ "libsecp256k1",
+ "log",
+ "memmap",
+ "num-derive",
+ "num-traits",
+ "pbkdf2",
+ "rand",
+ "rand_chacha",
+ "rustc_version",
+ "rustversion",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "serde_json",
+ "sha2 0.8.2",
+ "sha3",
+ "solana-crate-features 1.4.0",
+ "solana-logger 1.4.0",
+ "solana-sdk-macro 1.4.0",
+ "solana-sdk-macro-frozen-abi 1.4.0",
  "thiserror",
 ]
 
@@ -2630,6 +2706,18 @@ name = "solana-sdk-macro"
 version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2678edfd446d5396fd5f8957bf3da820b8b8b780113ea4c5918a33059aecb7fd"
+dependencies = [
+ "bs58",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "rustversion",
+ "syn 1.0.41",
+]
+
+[[package]]
+name = "solana-sdk-macro"
+version = "1.4.0"
+source = "git+https://github.com/solana-labs/solana?rev=dd7fae4afb898dee5b5147c8ee8d6f6d712363d1#dd7fae4afb898dee5b5147c8ee8d6f6d712363d1"
 dependencies = [
  "bs58",
  "proc-macro2 1.0.19",
@@ -2652,6 +2740,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-sdk-macro-frozen-abi"
+version = "1.4.0"
+source = "git+https://github.com/solana-labs/solana?rev=dd7fae4afb898dee5b5147c8ee8d6f6d712363d1#dd7fae4afb898dee5b5147c8ee8d6f6d712363d1"
+dependencies = [
+ "lazy_static",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "rustc_version",
+ "syn 1.0.41",
+]
+
+[[package]]
 name = "solana-secp256k1-program"
 version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2662,8 +2762,8 @@ dependencies = [
  "libsecp256k1",
  "rand",
  "sha3",
- "solana-logger",
- "solana-sdk",
+ "solana-logger 1.3.15",
+ "solana-sdk 1.3.14",
 ]
 
 [[package]]
@@ -2681,8 +2781,8 @@ dependencies = [
  "serde_derive",
  "solana-config-program",
  "solana-metrics",
- "solana-sdk",
- "solana-sdk-macro-frozen-abi",
+ "solana-sdk 1.3.14",
+ "solana-sdk-macro-frozen-abi 1.3.14",
  "solana-vote-program",
  "thiserror",
 ]
@@ -2702,7 +2802,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-account-decoder",
- "solana-sdk",
+ "solana-sdk 1.3.14",
  "solana-stake-program",
  "solana-vote-program",
  "spl-memo 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2720,10 +2820,10 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_derive",
- "solana-logger",
+ "solana-logger 1.3.15",
  "solana-runtime",
- "solana-sdk",
- "solana-sdk-macro-frozen-abi",
+ "solana-sdk 1.3.14",
+ "solana-sdk-macro-frozen-abi 1.3.14",
 ]
 
 [[package]]
@@ -2739,10 +2839,10 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_derive",
- "solana-logger",
+ "solana-logger 1.3.15",
  "solana-metrics",
- "solana-sdk",
- "solana-sdk-macro-frozen-abi",
+ "solana-sdk 1.3.14",
+ "solana-sdk-macro-frozen-abi 1.3.14",
  "thiserror",
 ]
 
@@ -2756,7 +2856,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 name = "spl-memo"
 version = "1.0.7"
 dependencies = [
- "solana-sdk",
+ "solana-sdk 1.3.14",
 ]
 
 [[package]]
@@ -2765,7 +2865,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b303bab17e0c696de6d7550ba6f05a5a6dbf5c5d1597e68a4592899072e1c07a"
 dependencies = [
- "solana-sdk",
+ "solana-sdk 1.3.14",
 ]
 
 [[package]]
@@ -2780,7 +2880,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "rand",
- "solana-sdk",
+ "solana-sdk 1.3.14",
  "thiserror",
 ]
 
@@ -2796,7 +2896,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "rand",
- "solana-sdk",
+ "solana-sdk 1.4.0",
  "thiserror",
 ]
 
@@ -2810,7 +2910,7 @@ dependencies = [
  "num_enum",
  "rand",
  "remove_dir_all",
- "solana-sdk",
+ "solana-sdk 1.3.14",
  "thiserror",
 ]
 
@@ -2825,7 +2925,7 @@ dependencies = [
  "num-traits",
  "num_enum",
  "remove_dir_all",
- "solana-sdk",
+ "solana-sdk 1.3.14",
  "thiserror",
 ]
 
@@ -2841,8 +2941,8 @@ dependencies = [
  "solana-cli-config",
  "solana-cli-output",
  "solana-client",
- "solana-logger",
- "solana-sdk",
+ "solana-logger 1.3.15",
+ "solana-sdk 1.3.14",
  "spl-token 2.0.6",
 ]
 
@@ -2868,7 +2968,7 @@ dependencies = [
  "num-traits",
  "rand",
  "remove_dir_all",
- "solana-sdk",
+ "solana-sdk 1.3.14",
  "spl-token 2.0.6",
  "thiserror",
 ]
@@ -2883,7 +2983,7 @@ dependencies = [
  "num_enum",
  "rand",
  "remove_dir_all",
- "solana-sdk",
+ "solana-sdk 1.3.14",
  "thiserror",
 ]
 
@@ -3003,7 +3103,7 @@ dependencies = [
 name = "test-client"
 version = "0.1.0"
 dependencies = [
- "solana-sdk",
+ "solana-sdk 1.3.14",
  "spl-memo 1.0.7",
  "spl-token 2.0.6",
  "spl-token-swap",

--- a/themis/client_ristretto/Cargo.toml
+++ b/themis/client_ristretto/Cargo.toml
@@ -18,11 +18,11 @@ default = ["solana-sdk/default"]
 bincode = "1.3"
 borsh = "0.7.1"
 curve25519-dalek = {git = "https://github.com/garious/curve25519-dalek", rev = "60efef3553d6bf3d7f3b09b5f97acd54d72529ff", default-features = false, features = ["borsh"]}
-elgamal_ristretto = { git = "https://github.com/garious/elgamal", rev = "260763fb67c34debe3915b39d95b6e7b3e1461d0" }
+elgamal_ristretto = { git = "https://github.com/garious/elgamal", rev = "6c5ad5b32160e78be080b74eb7a1867dd65aec6c", default-features = false }
 futures = "0.3"
-solana-banks-client = "1.3.14"
-solana-cli-config = "1.3.14"
-solana-sdk = "1.3.14"
+solana-banks-client = { git = "https://github.com/solana-labs/solana", rev = "dd7fae4afb898dee5b5147c8ee8d6f6d712363d1" }
+solana-cli-config = { git = "https://github.com/solana-labs/solana", rev = "dd7fae4afb898dee5b5147c8ee8d6f6d712363d1" }
+solana-sdk = { git = "https://github.com/solana-labs/solana", rev = "dd7fae4afb898dee5b5147c8ee8d6f6d712363d1" }
 spl-themis-ristretto = { version = "0.1.0", path = "../program_ristretto" }
 tarpc = { version = "0.21.1", features = ["full"] }
 tokio = "0.2"
@@ -30,10 +30,10 @@ url = "2.1"
 
 [dev-dependencies]
 separator = "0.4.1"
-solana-banks-server = "1.3.14"
-solana-bpf-loader-program = "1.3.14"
+solana-banks-server = { git = "https://github.com/solana-labs/solana", rev = "dd7fae4afb898dee5b5147c8ee8d6f6d712363d1" }
+solana-bpf-loader-program = { git = "https://github.com/solana-labs/solana", rev = "dd7fae4afb898dee5b5147c8ee8d6f6d712363d1" }
 solana_rbpf = "=0.1.31"
-solana-runtime = "1.3.14"
+solana-runtime = { git = "https://github.com/solana-labs/solana", rev = "dd7fae4afb898dee5b5147c8ee8d6f6d712363d1" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/themis/client_ristretto/Cargo.toml
+++ b/themis/client_ristretto/Cargo.toml
@@ -32,6 +32,7 @@ url = "2.1"
 separator = "0.4.1"
 solana-banks-server = { git = "https://github.com/solana-labs/solana", rev = "dd7fae4afb898dee5b5147c8ee8d6f6d712363d1" }
 solana-bpf-loader-program = { git = "https://github.com/solana-labs/solana", rev = "dd7fae4afb898dee5b5147c8ee8d6f6d712363d1" }
+solana-core = { git = "https://github.com/solana-labs/solana", rev = "dd7fae4afb898dee5b5147c8ee8d6f6d712363d1" }
 solana_rbpf = "=0.1.31"
 solana-runtime = { git = "https://github.com/solana-labs/solana", rev = "dd7fae4afb898dee5b5147c8ee8d6f6d712363d1" }
 

--- a/themis/client_ristretto/examples/tps.rs
+++ b/themis/client_ristretto/examples/tps.rs
@@ -25,6 +25,7 @@ fn main() {
         let sender_keypair = read_keypair_file(&config.keypair_path).unwrap();
         test_e2e(
             &mut banks_client,
+            &spl_themis_ristretto::id(),
             sender_keypair,
             policies,
             1_000,

--- a/themis/client_ristretto/tests/assert_instruction_count.rs
+++ b/themis/client_ristretto/tests/assert_instruction_count.rs
@@ -261,10 +261,10 @@ fn assert_instruction_count() {
     let proof_decryption_count =
         run_program(&program_id, &parameter_accounts[..], &instruction_data).unwrap();
 
-    const BASELINE_NEW_POLICIES_COUNT: u64 = 80_000; // last known 75,796 @ 128, 4,675 @ 2
-    const BASELINE_INITIALIZE_USER_COUNT: u64 = 22_000; // last known 19,868
-    const BASELINE_CALCULATE_AGGREGATE_COUNT: u64 = 15_000_000; // last known 13,061,884
-    const BASELINE_PROOF_DECRYPTION_COUNT: u64 = 60_000_000; // last known 13,167,140
+    const BASELINE_NEW_POLICIES_COUNT: u64 = 80_000; // last known 3,354
+    const BASELINE_INITIALIZE_USER_COUNT: u64 = 22_000; // last known 19,746
+    const BASELINE_CALCULATE_AGGREGATE_COUNT: u64 = 200_000; // last known 87,220
+    const BASELINE_PROOF_DECRYPTION_COUNT: u64 = 200_000; // last known 105,368
 
     println!("BPF instructions executed");
     println!(
@@ -297,12 +297,28 @@ fn assert_instruction_count() {
 
 // Mock InvokeContext
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct MockInvokeContext {
     pub key: Pubkey,
     pub logger: MockLogger,
     pub compute_meter: MockComputeMeter,
+    compute_budget: ComputeBudget,
 }
+
+impl Default for MockInvokeContext {
+    fn default() -> Self {
+        Self {
+            key: Pubkey::default(),
+            logger: MockLogger::default(),
+            compute_meter: MockComputeMeter::default(),
+            compute_budget: ComputeBudget {
+                max_invoke_depth: 10,
+                ..ComputeBudget::default()
+            },
+        }
+    }
+}
+
 impl InvokeContext for MockInvokeContext {
     fn push(&mut self, _key: &Pubkey) -> Result<(), InstructionError> {
         Ok(())
@@ -325,14 +341,11 @@ impl InvokeContext for MockInvokeContext {
     fn get_logger(&self) -> Rc<RefCell<dyn Logger>> {
         Rc::new(RefCell::new(self.logger.clone()))
     }
-    fn is_cross_program_supported(&self) -> bool {
-        true
-    }
-    fn get_compute_budget(&self) -> ComputeBudget {
-        ComputeBudget {
-            max_invoke_depth: 10,
-            ..ComputeBudget::default()
-        }
+    //fn is_cross_program_supported(&self) -> bool {
+    //    true
+    //}
+    fn get_compute_budget(&self) -> &ComputeBudget {
+        &self.compute_budget
     }
     fn get_compute_meter(&self) -> Rc<RefCell<dyn ComputeMeter>> {
         Rc::new(RefCell::new(self.compute_meter.clone()))
@@ -343,6 +356,9 @@ impl InvokeContext for MockInvokeContext {
     }
     fn record_instruction(&self, _: &solana_sdk::instruction::Instruction) {
         todo!()
+    }
+    fn is_feature_active(&self, _: &solana_sdk::pubkey::Pubkey) -> bool {
+        true
     }
 }
 

--- a/themis/client_ristretto/tests/assert_instruction_count.rs
+++ b/themis/client_ristretto/tests/assert_instruction_count.rs
@@ -194,7 +194,7 @@ fn assert_instruction_count() {
         Policies {
             is_initialized: true,
             num_scalars: num_scalars as u8,
-            scalars: scalars.clone(),
+            scalars,
         }
         .try_to_vec()
         .unwrap()

--- a/themis/client_ristretto/tests/e2e.rs
+++ b/themis/client_ristretto/tests/e2e.rs
@@ -1,0 +1,216 @@
+use solana_banks_client::{start_tcp_client, BanksClient, BanksClientExt};
+use solana_core::test_validator::{TestValidator, TestValidatorOptions};
+use solana_sdk::{
+    bpf_loader,
+    commitment_config::CommitmentLevel,
+    loader_instruction,
+    message::Message,
+    native_token::sol_to_lamports,
+    pubkey::Pubkey,
+    signature::{Keypair, Signer},
+    system_instruction,
+    transaction::Transaction,
+    transport,
+};
+use spl_themis_ristretto_client::test_e2e;
+use std::{
+    fs::{remove_dir_all, File},
+    io::Read,
+    path::PathBuf,
+};
+use tokio::runtime::Runtime;
+
+const DATA_CHUNK_SIZE: usize = 229; // Keep program chunks under PACKET_DATA_SIZE
+
+fn load_program(name: &str) -> Vec<u8> {
+    let mut path = PathBuf::new();
+    path.push("../../target/bpfel-unknown-unknown/release");
+    path.push(name);
+    path.set_extension("so");
+    let mut file = File::open(path).unwrap();
+
+    let mut program = Vec::new();
+    file.read_to_end(&mut program).unwrap();
+    program
+}
+
+// TODO: Add this to BanksClient
+async fn process_transactions_with_commitment(
+    client: &mut BanksClient,
+    transactions: Vec<Transaction>,
+    commitment: CommitmentLevel,
+) -> transport::Result<()> {
+    let mut clients: Vec<_> = transactions.iter().map(|_| client.clone()).collect();
+    let futures = clients
+        .iter_mut()
+        .zip(transactions)
+        .map(|(client, transaction)| {
+            client.process_transaction_with_commitment(transaction, commitment)
+        });
+    let statuses = futures::future::join_all(futures).await;
+    statuses.into_iter().collect() // Convert Vec<Result<_, _>> to Result<Vec<_>>
+}
+
+async fn create_program_account_with_commitment(
+    client: &mut BanksClient,
+    loader_id: &Pubkey,
+    funder_keypair: &Keypair,
+    program_keypair: &Keypair,
+    program_len: usize,
+    commitment: CommitmentLevel,
+) -> transport::Result<()> {
+    let minimum_balance = 0.01; // TODO: Can we calcualte this from get_fees() and program_len?
+    let ix = system_instruction::create_account(
+        &funder_keypair.pubkey(),
+        &program_keypair.pubkey(),
+        sol_to_lamports(minimum_balance),
+        program_len as u64,
+        loader_id,
+    );
+    let message = Message::new(&[ix], Some(&funder_keypair.pubkey()));
+    let recent_blockhash = client.get_recent_blockhash().await?;
+    let transaction = Transaction::new(
+        &[funder_keypair, program_keypair],
+        message,
+        recent_blockhash,
+    );
+    client
+        .process_transaction_with_commitment(transaction, commitment)
+        .await
+}
+
+async fn write_program_with_commitment(
+    client: &mut BanksClient,
+    loader_id: &Pubkey,
+    funder_keypair: &Keypair,
+    program_keypair: &Keypair,
+    program: Vec<u8>,
+    commitment: CommitmentLevel,
+) -> transport::Result<()> {
+    let recent_blockhash = client.get_recent_blockhash().await?;
+    let transactions: Vec<_> = program
+        .chunks(DATA_CHUNK_SIZE)
+        .enumerate()
+        .map(|(i, chunk)| {
+            let instruction = loader_instruction::write(
+                &program_keypair.pubkey(),
+                loader_id,
+                (i * DATA_CHUNK_SIZE) as u32,
+                chunk.to_vec(),
+            );
+            let message = Message::new(&[instruction], Some(&funder_keypair.pubkey()));
+            Transaction::new(
+                &[funder_keypair, program_keypair],
+                message,
+                recent_blockhash,
+            )
+        })
+        .collect();
+    process_transactions_with_commitment(client, transactions, commitment).await
+}
+
+async fn finalize_program_with_commitment(
+    client: &mut BanksClient,
+    loader_id: &Pubkey,
+    funder_keypair: &Keypair,
+    program_keypair: &Keypair,
+    commitment: CommitmentLevel,
+) -> transport::Result<()> {
+    let ix = loader_instruction::finalize(&program_keypair.pubkey(), &loader_id);
+    let message = Message::new(&[ix], Some(&funder_keypair.pubkey()));
+    let recent_blockhash = client.get_recent_blockhash().await?;
+    let transaction = Transaction::new(
+        &[funder_keypair, program_keypair],
+        message,
+        recent_blockhash,
+    );
+    client
+        .process_transaction_with_commitment(transaction, commitment)
+        .await
+}
+
+// TODO: Add this to BanksClient
+async fn deploy_program_with_commitment(
+    client: &mut BanksClient,
+    loader_id: &Pubkey,
+    funder_keypair: &Keypair,
+    program_keypair: &Keypair,
+    program: Vec<u8>,
+    commitment: CommitmentLevel,
+) -> transport::Result<()> {
+    create_program_account_with_commitment(
+        client,
+        loader_id,
+        funder_keypair,
+        program_keypair,
+        program.len(),
+        commitment,
+    )
+    .await?;
+    write_program_with_commitment(
+        client,
+        loader_id,
+        funder_keypair,
+        program_keypair,
+        program,
+        commitment,
+    )
+    .await?;
+    finalize_program_with_commitment(
+        client,
+        loader_id,
+        funder_keypair,
+        program_keypair,
+        commitment,
+    )
+    .await?;
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn test_validator_e2e() {
+    let TestValidator {
+        server,
+        leader_data,
+        alice,
+        ledger_path,
+        ..
+    } = TestValidator::run_with_options(TestValidatorOptions {
+        mint_lamports: sol_to_lamports(10.0),
+        ..TestValidatorOptions::default()
+    });
+
+    let program = load_program("spl_themis_ristretto");
+
+    Runtime::new().unwrap().block_on(async {
+        let mut banks_client = start_tcp_client(leader_data.rpc_banks).await.unwrap();
+        let program_keypair = Keypair::new();
+        deploy_program_with_commitment(
+            &mut banks_client,
+            &bpf_loader::id(),
+            &alice,
+            &program_keypair,
+            program,
+            CommitmentLevel::Recent,
+        )
+        .await
+        .unwrap();
+
+        let policies = vec![1u64.into(), 2u64.into()];
+        test_e2e(
+            &mut banks_client,
+            &program_keypair.pubkey(),
+            alice,
+            policies,
+            10,
+            3u64.into(),
+        )
+        .await
+        .unwrap();
+    });
+
+    // Explicit cleanup, otherwise "pure virtual method called" crash in Docker
+    server.close().unwrap();
+    remove_dir_all(ledger_path).unwrap();
+}

--- a/themis/program_ristretto/Cargo.toml
+++ b/themis/program_ristretto/Cargo.toml
@@ -13,19 +13,19 @@ exclude = ["js/**"]
 
 [features]
 no-entrypoint = []
-program = ["solana-sdk/program"]
-default = ["solana-sdk/default"]
+program = ["solana-sdk/program", "elgamal_ristretto/program"]
+default = ["solana-sdk/default", "elgamal_ristretto/default"]
 
 [dependencies]
 bincode = "1.3"
 borsh = "0.7.1"
 curve25519-dalek = { git = "https://github.com/garious/curve25519-dalek", rev = "60efef3553d6bf3d7f3b09b5f97acd54d72529ff", features = ["borsh"] }
-elgamal_ristretto = { git = "https://github.com/garious/elgamal", rev = "260763fb67c34debe3915b39d95b6e7b3e1461d0" }
+elgamal_ristretto = { git = "https://github.com/garious/elgamal", rev = "6c5ad5b32160e78be080b74eb7a1867dd65aec6c", default-features = false }
 getrandom = { version = "0.1.15", features = ["dummy"] }
 num-derive = "0.3"
 num-traits = "0.2"
 rand = "0.7.0"
-solana-sdk = { version = "1.3.14", default-features = false, optional = true }
+solana-sdk = { git = "https://github.com/solana-labs/solana", rev = "dd7fae4afb898dee5b5147c8ee8d6f6d712363d1", default-features = false, optional = true }
 thiserror = "1.0"
 
 [lib]

--- a/themis/program_ristretto/src/instruction.rs
+++ b/themis/program_ristretto/src/instruction.rs
@@ -111,13 +111,17 @@ impl ThemisInstruction {
 }
 
 /// Return an `InitializeUserAccount` instruction.
-fn initialize_user_account(user_pubkey: &Pubkey, public_key: PublicKey) -> Instruction {
+fn initialize_user_account(
+    program_id: &Pubkey,
+    user_pubkey: &Pubkey,
+    public_key: PublicKey,
+) -> Instruction {
     let data = ThemisInstruction::InitializeUserAccount { public_key };
 
     let accounts = vec![AccountMeta::new(*user_pubkey, false)];
 
     Instruction {
-        program_id: crate::id(),
+        program_id: *program_id,
         accounts,
         data: data.serialize().unwrap(),
     }
@@ -125,6 +129,7 @@ fn initialize_user_account(user_pubkey: &Pubkey, public_key: PublicKey) -> Instr
 
 /// Return two instructions that create and initialize a user account.
 pub fn create_user_account(
+    program_id: &Pubkey,
     from: &Pubkey,
     user_pubkey: &Pubkey,
     lamports: u64,
@@ -132,17 +137,21 @@ pub fn create_user_account(
 ) -> Vec<Instruction> {
     let space = User::default().try_to_vec().unwrap().len() as u64;
     vec![
-        system_instruction::create_account(from, user_pubkey, lamports, space, &crate::id()),
-        initialize_user_account(user_pubkey, public_key),
+        system_instruction::create_account(from, user_pubkey, lamports, space, program_id),
+        initialize_user_account(program_id, user_pubkey, public_key),
     ]
 }
 
 /// Return an `InitializePoliciesAccount` instruction.
-fn initialize_policies_account(policies_pubkey: &Pubkey, num_scalars: u8) -> Instruction {
+fn initialize_policies_account(
+    program_id: &Pubkey,
+    policies_pubkey: &Pubkey,
+    num_scalars: u8,
+) -> Instruction {
     let data = ThemisInstruction::InitializePoliciesAccount { num_scalars };
     let accounts = vec![AccountMeta::new(*policies_pubkey, false)];
     Instruction {
-        program_id: crate::id(),
+        program_id: *program_id,
         accounts,
         data: data.serialize().unwrap(),
     }
@@ -150,6 +159,7 @@ fn initialize_policies_account(policies_pubkey: &Pubkey, num_scalars: u8) -> Ins
 
 /// Return two instructions that create and initialize a policies account.
 pub fn create_policies_account(
+    program_id: &Pubkey,
     from: &Pubkey,
     policies_pubkey: &Pubkey,
     lamports: u64,
@@ -157,17 +167,21 @@ pub fn create_policies_account(
 ) -> Vec<Instruction> {
     let space = Policies::new(num_scalars).try_to_vec().unwrap().len() as u64;
     vec![
-        system_instruction::create_account(from, policies_pubkey, lamports, space, &crate::id()),
-        initialize_policies_account(policies_pubkey, num_scalars),
+        system_instruction::create_account(from, policies_pubkey, lamports, space, program_id),
+        initialize_policies_account(program_id, policies_pubkey, num_scalars),
     ]
 }
 
 /// Return an `InitializePoliciesAccount` instruction.
-pub fn store_policies(policies_pubkey: &Pubkey, scalars: Vec<(u8, Scalar)>) -> Instruction {
+pub fn store_policies(
+    program_id: &Pubkey,
+    policies_pubkey: &Pubkey,
+    scalars: Vec<(u8, Scalar)>,
+) -> Instruction {
     let data = ThemisInstruction::StorePolicies { scalars };
     let accounts = vec![AccountMeta::new(*policies_pubkey, true)];
     Instruction {
-        program_id: crate::id(),
+        program_id: *program_id,
         accounts,
         data: data.serialize().unwrap(),
     }
@@ -175,6 +189,7 @@ pub fn store_policies(policies_pubkey: &Pubkey, scalars: Vec<(u8, Scalar)>) -> I
 
 /// Return a `SubmitInteractions` instruction.
 pub fn submit_interactions(
+    program_id: &Pubkey,
     user_pubkey: &Pubkey,
     policies_pubkey: &Pubkey,
     encrypted_interactions: Vec<(u8, (RistrettoPoint, RistrettoPoint))>,
@@ -187,7 +202,7 @@ pub fn submit_interactions(
         AccountMeta::new_readonly(*policies_pubkey, false),
     ];
     Instruction {
-        program_id: crate::id(),
+        program_id: *program_id,
         accounts,
         data: data.serialize().unwrap(),
     }
@@ -195,6 +210,7 @@ pub fn submit_interactions(
 
 /// Return a `SubmitProofDecryption` instruction.
 pub fn submit_proof_decryption(
+    program_id: &Pubkey,
     user_pubkey: &Pubkey,
     plaintext: RistrettoPoint,
     announcement_g: RistrettoPoint,
@@ -208,7 +224,7 @@ pub fn submit_proof_decryption(
     };
     let accounts = vec![AccountMeta::new(*user_pubkey, true)];
     Instruction {
-        program_id: crate::id(),
+        program_id: *program_id,
         accounts,
         data: data.serialize().unwrap(),
     }
@@ -216,6 +232,7 @@ pub fn submit_proof_decryption(
 
 /// Return a `RequestPayment` instruction.
 pub fn request_payment(
+    program_id: &Pubkey,
     user_pubkey: &Pubkey,
     encrypted_aggregate: (RistrettoPoint, RistrettoPoint),
     decrypted_aggregate: RistrettoPoint,
@@ -228,7 +245,7 @@ pub fn request_payment(
     };
     let accounts = vec![AccountMeta::new(*user_pubkey, true)];
     Instruction {
-        program_id: crate::id(),
+        program_id: *program_id,
         accounts,
         data: data.serialize().unwrap(),
     }

--- a/themis/program_ristretto/src/state.rs
+++ b/themis/program_ristretto/src/state.rs
@@ -5,7 +5,9 @@ use curve25519_dalek::{
     constants::RISTRETTO_BASEPOINT_POINT, ristretto::RistrettoPoint, scalar::Scalar,
     traits::Identity,
 };
-use elgamal_ristretto::{ciphertext::Ciphertext, private::SecretKey, public::PublicKey};
+use elgamal_ristretto::{
+    ciphertext::Ciphertext, multiply::ristretto_mul, private::SecretKey, public::PublicKey,
+};
 use rand::thread_rng;
 use solana_sdk::program_error::ProgramError;
 
@@ -73,8 +75,8 @@ fn inner_product(
     scalars: &[Scalar],
 ) -> Points {
     for &(i, (x, y)) in ciphertexts {
-        aggregate_x = x * scalars[i as usize] + aggregate_x;
-        aggregate_y = y * scalars[i as usize] + aggregate_y;
+        aggregate_x = ristretto_mul(&x, &scalars[i as usize]).unwrap() + aggregate_x;
+        aggregate_y = ristretto_mul(&y, &scalars[i as usize]).unwrap() + aggregate_y;
     }
 
     (aggregate_x, aggregate_y)


### PR DESCRIPTION
#### Problem

CalculateAggregate and SubmitProofDecryption operations exceed the BPF instruction limit

#### Proposed changes

Use the new `ristretto_mul` and Sha256 builtins to stay below the BPF instruction limit.

All operations will now stay below the limit in the forthcoming 1.4 testnet:

```
BPF instructions executed
  InitializePolicies(2): 3,354 (80000)
  InitializeUserAccount: 19,746 (22000)
  CalculateAggregate:    87,220 (200000)
  SubmitProofDecryption: 105,372 (200000)
```