### PR TITLE
Standardise amount datatypes in token client

### DIFF
--- a/token/js/client/token.js
+++ b/token/js/client/token.js
@@ -893,7 +893,7 @@ export class Token {
     dest: PublicKey,
     authority: any,
     multiSigners: Array<Account>,
-    amount: number,
+    amount: number | u64,
   ): Promise<void> {
     let ownerPublicKey;
     let signers;
@@ -934,7 +934,7 @@ export class Token {
     account: PublicKey,
     owner: any,
     multiSigners: Array<Account>,
-    amount: number,
+    amount: number | u64,
   ): Promise<void> {
     let ownerPublicKey;
     let signers;
@@ -1187,7 +1187,7 @@ export class Token {
     dest: PublicKey,
     authority: any,
     multiSigners: Array<Account>,
-    amount: number,
+    amount: number | u64,
     decimals: number,
   ): Promise<void> {
     let ownerPublicKey;
@@ -1231,7 +1231,7 @@ export class Token {
     account: PublicKey,
     owner: any,
     multiSigners: Array<Account>,
-    amount: number,
+    amount: number | u64,
     decimals: number,
   ): Promise<void> {
     let ownerPublicKey;
@@ -1583,7 +1583,7 @@ export class Token {
     dest: PublicKey,
     authority: PublicKey,
     multiSigners: Array<Account>,
-    amount: number,
+    amount: number | u64,
   ): TransactionInstruction {
     const dataLayout = BufferLayout.struct([
       BufferLayout.u8('instruction'),
@@ -1643,7 +1643,7 @@ export class Token {
     account: PublicKey,
     owner: PublicKey,
     multiSigners: Array<Account>,
-    amount: number,
+    amount: number | u64,
   ): TransactionInstruction {
     const dataLayout = BufferLayout.struct([
       BufferLayout.u8('instruction'),
@@ -1980,7 +1980,7 @@ export class Token {
     dest: PublicKey,
     authority: PublicKey,
     multiSigners: Array<Account>,
-    amount: number,
+    amount: number | u64,
     decimals: number,
   ): TransactionInstruction {
     const dataLayout = BufferLayout.struct([
@@ -2043,7 +2043,7 @@ export class Token {
     account: PublicKey,
     owner: PublicKey,
     multiSigners: Array<Account>,
-    amount: number,
+    amount: number | u64,
     decimals: number,
   ): TransactionInstruction {
     const dataLayout = BufferLayout.struct([

--- a/token/js/module.d.ts
+++ b/token/js/module.d.ts
@@ -118,13 +118,13 @@ declare module '@solana/spl-token' {
       dest: PublicKey,
       authority: Account | PublicKey,
       multiSigners: Array<Account>,
-      amount: number,
+      amount: number | u64,
     ): Promise<void>;
     burn(
       account: PublicKey,
       owner: Account | PublicKey,
       multiSigners: Array<Account>,
-      amount: number,
+      amount: number | u64,
     ): Promise<void>;
     closeAccount(
       account: PublicKey,
@@ -180,7 +180,7 @@ declare module '@solana/spl-token' {
       dest: PublicKey,
       authority: PublicKey,
       multiSigners: Array<Account>,
-      amount: number,
+      amount: number | u64,
     ): TransactionInstruction;
     static createBurnInstruction(
       programId: PublicKey,
@@ -188,7 +188,7 @@ declare module '@solana/spl-token' {
       account: PublicKey,
       owner: PublicKey,
       multiSigners: Array<Account>,
-      amount: number,
+      amount: number | u64,
     ): TransactionInstruction;
     static createCloseAccountInstruction(
       programId: PublicKey,

--- a/token/js/module.flow.js
+++ b/token/js/module.flow.js
@@ -111,13 +111,13 @@ declare module '@solana/spl-token' {
       dest: PublicKey,
       authority: Account | PublicKey,
       multiSigners: Array<Account>,
-      amount: number,
+      amount: number | u64,
     ): Promise<void>;
     burn(
       account: PublicKey,
       owner: Account | PublicKey,
       multiSigners: Array<Account>,
-      amount: number,
+      amount: number | u64,
     ): Promise<void>;
     closeAccount(
       account: PublicKey,
@@ -173,7 +173,7 @@ declare module '@solana/spl-token' {
       dest: PublicKey,
       authority: PublicKey,
       multiSigners: Array<Account>,
-      amount: number,
+      amount: number | u64,
     ): TransactionInstruction;
     static createBurnInstruction(
       programId: PublicKey,
@@ -181,7 +181,7 @@ declare module '@solana/spl-token' {
       account: PublicKey,
       owner: PublicKey,
       multiSigners: Array<Account>,
-      amount: number,
+      amount: number | u64,
     ): TransactionInstruction;
     static createCloseAccountInstruction(
       programId: PublicKey,


### PR DESCRIPTION
Standardise datatypes of amount parameters to accept u64s across the board in the token program JS client.