### PR TITLE
Add Token class properties to spl-token library module declaration files

### DIFF
--- a/token/js/module.d.ts
+++ b/token/js/module.d.ts
@@ -61,6 +61,9 @@ declare module '@solana/spl-token' {
     signer11: PublicKey;
   };
   export class Token {
+    publicKey: PublicKey;
+    programId: PublicKey;
+    payer: Account;
     constructor(
       connection: Connection,
       publicKey: PublicKey,

--- a/token/js/module.flow.js
+++ b/token/js/module.flow.js
@@ -54,6 +54,9 @@ declare module '@solana/spl-token' {
     signer11: PublicKey,
   |};
   declare export class Token {
+    publicKey: PublicKey;
+    programId: PublicKey;
+    payer: Account;
     constructor(
       connection: Connection,
       publicKey: PublicKey,


### PR DESCRIPTION
Add Token class properties to spl-token library module declaration files so downstream users can access them without having to bypass type checking