### PR TITLE
Bail on build script error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,19 +567,6 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
-dependencies = [
- "byteorder",
- "digest 0.8.1",
- "rand_core",
- "subtle 2.2.3",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "2.1.0"
 source = "git+https://github.com/garious/curve25519-dalek?rev=60efef3553d6bf3d7f3b09b5f97acd54d72529ff#60efef3553d6bf3d7f3b09b5f97acd54d72529ff"
 dependencies = [
  "borsh",
@@ -587,6 +574,19 @@ dependencies = [
  "digest 0.8.1",
  "rand_core",
  "serde",
+ "subtle 2.2.3",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
+dependencies = [
+ "byteorder",
+ "digest 0.8.1",
+ "rand_core",
  "subtle 2.2.3",
  "zeroize",
 ]

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -41,6 +41,7 @@ _ cargo +nightly clippy --workspace --all-targets -- --deny=warnings
 _ cargo build
 _ cargo run --manifest-path=utils/test-client/Cargo.toml
 
+_ cargo test --manifest-path=token/perf-monitor/Cargo.toml -- --nocapture
 
 #  # Check generated C headers
 #  _ cargo run --manifest-path=utils/cgen/Cargo.toml

--- a/token/perf-monitor/build.rs
+++ b/token/perf-monitor/build.rs
@@ -2,11 +2,11 @@ use std::{fs::canonicalize, process::Command};
 
 fn main() {
     println!("cargo:warning=(not a warning) Building SPL Token shared object");
-    Command::new(canonicalize("../../do.sh").unwrap())
+    assert!(Command::new(canonicalize("../../do.sh").unwrap())
         .current_dir("../..")
         .arg("build")
         .arg("token/program")
         .status()
         .expect("Failed to build token program")
-        .success();
+        .success());
 }


### PR DESCRIPTION
Reports of failures building the shared objects from within a build script.  Unable to reproduce myself and CI has been covering this up since it builds the shared objects first and independently.

Build the test upfront and assert if the build script fails.

Reported in: #646