### PR TITLE
Check for close and freeze authorities in token-swap

### DIFF
--- a/token-swap/program/src/error.rs
+++ b/token-swap/program/src/error.rs
@@ -58,6 +58,12 @@ pub enum SwapError {
     /// Swap instruction exceeds desired slippage limit
     #[error("Swap instruction exceeds desired slippage limit")]
     ExceededSlippage,
+    /// The provided token account has a close authority.
+    #[error("Token account has a close authority")]
+    InvalidCloseAuthority,
+    /// The pool token mint has a freeze authority.
+    #[error("Pool token mint has a freeze authority")]
+    InvalidFreezeAuthority,
 }
 impl From<SwapError> for ProgramError {
     fn from(e: SwapError) -> Self {


### PR DESCRIPTION
#### Problem
- Swap pool mints can have a freeze authority which can be used to freeze liquidity provider's pool tokens to lock in liquidity
- Swap pool liquidity token accounts can have a close authority. If the token accounts reach zero tokens, they can be closed and deleted and replaced with new accounts which aren't restricted by the normal initialization instruction.

#### Changes
- Prohibit token accounts from having a close authority
- Prohibit mint accounts from having a freeze authority