### PR TITLE
Stake pool interface fixes

### DIFF
--- a/stake-pool/program/src/instruction.rs
+++ b/stake-pool/program/src/instruction.rs
@@ -179,10 +179,10 @@ pub fn initialize(
     let data = init_data.serialize()?;
     let accounts = vec![
         AccountMeta::new(*stake_pool, true),
-        AccountMeta::new(*owner, false),
-        AccountMeta::new(*pool_mint, false),
-        AccountMeta::new(*owner_pool_account, false),
-        AccountMeta::new(*token_program_id, false),
+        AccountMeta::new_readonly(*owner, false),
+        AccountMeta::new_readonly(*pool_mint, false),
+        AccountMeta::new_readonly(*owner_pool_account, false),
+        AccountMeta::new_readonly(*token_program_id, false),
     ];
     Ok(Instruction {
         program_id: *program_id,
@@ -207,13 +207,13 @@ pub fn deposit(
     let data = args.serialize()?;
     let accounts = vec![
         AccountMeta::new(*stake_pool, false),
-        AccountMeta::new(*stake_pool_deposit, false),
-        AccountMeta::new(*stake_pool_withdraw, false),
+        AccountMeta::new_readonly(*stake_pool_deposit, false),
+        AccountMeta::new_readonly(*stake_pool_withdraw, false),
         AccountMeta::new(*stake_to_join, false),
         AccountMeta::new(*pool_tokens_to, false),
         AccountMeta::new(*pool_fee_to, false),
         AccountMeta::new(*pool_mint, false),
-        AccountMeta::new(*token_program_id, false),
+        AccountMeta::new_readonly(*token_program_id, false),
     ];
     Ok(Instruction {
         program_id: *program_id,
@@ -239,13 +239,13 @@ pub fn withdraw(
     let data = args.serialize()?;
     let accounts = vec![
         AccountMeta::new(*stake_pool, false),
-        AccountMeta::new(*stake_pool_withdraw, false),
+        AccountMeta::new_readonly(*stake_pool_withdraw, false),
         AccountMeta::new(*stake_to_split, false),
         AccountMeta::new(*stake_to_receive, false),
-        AccountMeta::new(*user_withdrawer, false),
+        AccountMeta::new_readonly(*user_withdrawer, false),
         AccountMeta::new(*burn_from, true),
         AccountMeta::new(*pool_mint, false),
-        AccountMeta::new(*token_program_id, false),
+        AccountMeta::new_readonly(*token_program_id, false),
     ];
     Ok(Instruction {
         program_id: *program_id,
@@ -270,12 +270,12 @@ pub fn claim(
     let data = args.serialize()?;
     let accounts = vec![
         AccountMeta::new(*stake_pool, false),
-        AccountMeta::new(*stake_pool_withdraw, false),
+        AccountMeta::new_readonly(*stake_pool_withdraw, false),
         AccountMeta::new(*stake_to_claim, false),
-        AccountMeta::new(*user_withdrawer, false),
+        AccountMeta::new_readonly(*user_withdrawer, false),
         AccountMeta::new(*burn_from, true),
         AccountMeta::new(*pool_mint, false),
-        AccountMeta::new(*token_program_id, false),
+        AccountMeta::new_readonly(*token_program_id, false),
     ];
     Ok(Instruction {
         program_id: *program_id,
@@ -297,10 +297,10 @@ pub fn set_staking_authority(
     let data = args.serialize()?;
     let accounts = vec![
         AccountMeta::new(*stake_pool, false),
-        AccountMeta::new(*stake_pool_owner, true),
-        AccountMeta::new(*stake_pool_withdraw, false),
+        AccountMeta::new_readonly(*stake_pool_owner, true),
+        AccountMeta::new_readonly(*stake_pool_withdraw, false),
         AccountMeta::new(*stake_account_to_update, false),
-        AccountMeta::new(*stake_account_new_authority, false),
+        AccountMeta::new_readonly(*stake_account_new_authority, false),
     ];
     Ok(Instruction {
         program_id: *program_id,
@@ -321,9 +321,9 @@ pub fn set_owner(
     let data = args.serialize()?;
     let accounts = vec![
         AccountMeta::new(*stake_pool, false),
-        AccountMeta::new(*stake_pool_owner, true),
-        AccountMeta::new(*stake_pool_new_owner, false),
-        AccountMeta::new(*stake_pool_new_fee_receiver, false),
+        AccountMeta::new_readonly(*stake_pool_owner, true),
+        AccountMeta::new_readonly(*stake_pool_new_owner, false),
+        AccountMeta::new_readonly(*stake_pool_new_fee_receiver, false),
     ];
     Ok(Instruction {
         program_id: *program_id,

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -275,8 +275,8 @@ impl Processor {
             pool_mint_info.clone(),
             dest_user_info.clone(),
             withdraw_info.clone(),
-            Self::AUTHORITY_DEPOSIT,
-            stake_pool.deposit_bump_seed,
+            Self::AUTHORITY_WITHDRAW,
+            stake_pool.withdraw_bump_seed,
             user_amount,
         )?;
         let fee_amount = <u64>::try_from(fee_amount).or(Err(Error::CalculationFailure))?;

--- a/stake-pool/program/src/state.rs
+++ b/stake-pool/program/src/state.rs
@@ -78,7 +78,8 @@ impl State {
         Ok(match input[0] {
             0 => State::Unallocated,
             1 => {
-                let swap: &StakePool = unpack(&input[1..])?;
+                // We send whole input here, because unpack skips the first byte
+                let swap: &StakePool = unpack(&input)?;
                 State::Init(*swap)
             }
             _ => return Err(ProgramError::InvalidAccountData),


### PR DESCRIPTION
Fixed several issues we found while working on CLI and unit tests:

- Read-only interface accounts added as read-only
- Fixed mint authority on deposit
- Fixed stake pool state deserializing