### PR TITLE
Token-swap: Add "production mode" hard-coded fee constraints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,19 +626,6 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
-dependencies = [
- "byteorder",
- "digest 0.8.1",
- "rand_core",
- "subtle 2.2.3",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "2.1.0"
 source = "git+https://github.com/garious/curve25519-dalek?rev=60efef3553d6bf3d7f3b09b5f97acd54d72529ff#60efef3553d6bf3d7f3b09b5f97acd54d72529ff"
 dependencies = [
  "borsh",
@@ -646,6 +633,19 @@ dependencies = [
  "digest 0.8.1",
  "rand_core",
  "serde",
+ "subtle 2.2.3",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
+dependencies = [
+ "byteorder",
+ "digest 0.8.1",
+ "rand_core",
  "subtle 2.2.3",
  "zeroize",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,13 +626,12 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "2.1.0"
-source = "git+https://github.com/garious/curve25519-dalek?rev=60efef3553d6bf3d7f3b09b5f97acd54d72529ff#60efef3553d6bf3d7f3b09b5f97acd54d72529ff"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
 dependencies = [
- "borsh",
  "byteorder",
  "digest 0.8.1",
  "rand_core",
- "serde",
  "subtle 2.2.3",
  "zeroize",
 ]
@@ -640,12 +639,13 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
+source = "git+https://github.com/garious/curve25519-dalek?rev=60efef3553d6bf3d7f3b09b5f97acd54d72529ff#60efef3553d6bf3d7f3b09b5f97acd54d72529ff"
 dependencies = [
+ "borsh",
  "byteorder",
  "digest 0.8.1",
  "rand_core",
+ "serde",
  "subtle 2.2.3",
  "zeroize",
 ]

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -95,6 +95,20 @@ js_token_swap() {
 }
 _ js_token_swap
 
+# Test token-swap js bindings with "production" feature
+production_token_swap() {
+  address="SwaPpA9LAaLfeLi3a68M4DjnLqgtticKg6CnyNwgAC8"
+  SWAP_PROGRAM_OWNER_FEE_ADDRESS="$address" cargo build-bpf --manifest-path=token-swap/program/Cargo.toml --dump --features production
+  cd token-swap/js
+  npm run cluster:localnet || exit $?
+  npm run localnet:down
+  npm run localnet:update || exit $?
+  npm run localnet:up || exit $?
+  SWAP_PROGRAM_OWNER_FEE_ADDRESS="$address" npm run start || exit $?
+  npm run localnet:down
+}
+_ production_token_swap
+
 # Test token-lending js bindings
 js_token_lending() {
   cd token-lending/js

--- a/token-swap/js/cli/token-swap-test.js
+++ b/token-swap/js/cli/token-swap-test.js
@@ -36,7 +36,8 @@ let tokenAccountA: PublicKey;
 let tokenAccountB: PublicKey;
 
 // Hard-coded fee address, for testing production mode
-const SWAP_PROGRAM_OWNER_FEE_ADDRESS = process.env.SWAP_PROGRAM_OWNER_FEE_ADDRESS;
+const SWAP_PROGRAM_OWNER_FEE_ADDRESS =
+  process.env.SWAP_PROGRAM_OWNER_FEE_ADDRESS;
 
 // Pool fees
 const TRADING_FEE_NUMERATOR = 25;
@@ -62,7 +63,9 @@ let currentFeeAmount = 0;
 const SWAP_AMOUNT_IN = 100000;
 const SWAP_AMOUNT_OUT = SWAP_PROGRAM_OWNER_FEE_ADDRESS ? 90662 : 90675;
 const SWAP_FEE = SWAP_PROGRAM_OWNER_FEE_ADDRESS ? 22272 : 22276;
-const HOST_SWAP_FEE = SWAP_PROGRAM_OWNER_FEE_ADDRESS ? Math.floor(SWAP_FEE * HOST_FEE_NUMERATOR / HOST_FEE_DENOMINATOR) : 0;
+const HOST_SWAP_FEE = SWAP_PROGRAM_OWNER_FEE_ADDRESS
+  ? Math.floor((SWAP_FEE * HOST_FEE_NUMERATOR) / HOST_FEE_DENOMINATOR)
+  : 0;
 const OWNER_SWAP_FEE = SWAP_FEE - HOST_SWAP_FEE;
 
 // Pool token amount minted on init
@@ -330,10 +333,13 @@ export async function withdraw(): Promise<void> {
   const supply = poolMintInfo.supply.toNumber();
   let swapTokenA = await mintA.getAccountInfo(tokenAccountA);
   let swapTokenB = await mintB.getAccountInfo(tokenAccountB);
-  const feeAmount = OWNER_WITHDRAW_FEE_NUMERATOR === 0 ? 0 : Math.floor(
-    (POOL_TOKEN_AMOUNT * OWNER_WITHDRAW_FEE_NUMERATOR) /
-      OWNER_WITHDRAW_FEE_DENOMINATOR,
-  );
+  const feeAmount =
+    OWNER_WITHDRAW_FEE_NUMERATOR === 0
+      ? 0
+      : Math.floor(
+        (POOL_TOKEN_AMOUNT * OWNER_WITHDRAW_FEE_NUMERATOR) /
+            OWNER_WITHDRAW_FEE_DENOMINATOR,
+      );
   const poolTokenAmount = POOL_TOKEN_AMOUNT - feeAmount;
   const tokenA = Math.floor(
     (swapTokenA.amount.toNumber() * poolTokenAmount) / supply,
@@ -394,7 +400,9 @@ export async function swap(): Promise<void> {
   await mintA.approve(userAccountA, authority, owner, [], SWAP_AMOUNT_IN);
   console.log('Creating swap token b account');
   let userAccountB = await mintB.createAccount(owner.publicKey);
-  let poolAccount = SWAP_PROGRAM_OWNER_FEE_ADDRESS ? await tokenPool.createAccount(owner.publicKey) : null;
+  let poolAccount = SWAP_PROGRAM_OWNER_FEE_ADDRESS
+    ? await tokenPool.createAccount(owner.publicKey)
+    : null;
 
   console.log('Swapping');
   await tokenSwap.swap(

--- a/token-swap/js/cli/token-swap-test.js
+++ b/token-swap/js/cli/token-swap-test.js
@@ -333,13 +333,13 @@ export async function withdraw(): Promise<void> {
   const supply = poolMintInfo.supply.toNumber();
   let swapTokenA = await mintA.getAccountInfo(tokenAccountA);
   let swapTokenB = await mintB.getAccountInfo(tokenAccountB);
-  const feeAmount =
-    OWNER_WITHDRAW_FEE_NUMERATOR === 0
-      ? 0
-      : Math.floor(
-        (POOL_TOKEN_AMOUNT * OWNER_WITHDRAW_FEE_NUMERATOR) /
-            OWNER_WITHDRAW_FEE_DENOMINATOR,
-      );
+  let feeAmount = 0;
+  if (OWNER_WITHDRAW_FEE_NUMERATOR !== 0) {
+    feeAmount = Math.floor(
+      (POOL_TOKEN_AMOUNT * OWNER_WITHDRAW_FEE_NUMERATOR) /
+        OWNER_WITHDRAW_FEE_DENOMINATOR,
+    );
+  }
   const poolTokenAmount = POOL_TOKEN_AMOUNT - feeAmount;
   const tokenA = Math.floor(
     (swapTokenA.amount.toNumber() * poolTokenAmount) / supply,

--- a/token-swap/js/cli/token-swap-test.js
+++ b/token-swap/js/cli/token-swap-test.js
@@ -57,6 +57,11 @@ const OWNER_TRADING_FEE_NUMERATOR = 5;
 const OWNER_TRADING_FEE_DENOMINATOR = 10000;
 const OWNER_WITHDRAW_FEE_NUMERATOR = 1;
 const OWNER_WITHDRAW_FEE_DENOMINATOR = 6;
+// The following fees are required by the hard-coded constraints
+//const OWNER_WITHDRAW_FEE_NUMERATOR = 0;
+//const OWNER_WITHDRAW_FEE_DENOMINATOR = 0;
+const HOST_FEE_NUMERATOR = 20;
+const HOST_FEE_DENOMINATOR = 100;
 
 function assert(condition, message) {
   if (!condition) {
@@ -166,7 +171,7 @@ export async function createTokenSwap(): Promise<void> {
   tokenAccountPool = await tokenPool.createAccount(owner.publicKey);
   feeAccount = await tokenPool.createAccount(owner.publicKey);
   // Also need to test the situation of a fixed fee account owner
-  // feeAccount = await tokenPool.createAccount(owner.publicKey);
+  //feeAccount = await tokenPool.createAccount(new PublicKey('TokenSwap1111111111111111111111111111111111'));
 
   console.log('creating token A');
   mintA = await Token.createMint(
@@ -222,6 +227,8 @@ export async function createTokenSwap(): Promise<void> {
     OWNER_TRADING_FEE_DENOMINATOR,
     OWNER_WITHDRAW_FEE_NUMERATOR,
     OWNER_WITHDRAW_FEE_DENOMINATOR,
+    HOST_FEE_NUMERATOR,
+    HOST_FEE_DENOMINATOR,
   );
 
   console.log('loading token swap');
@@ -261,6 +268,10 @@ export async function createTokenSwap(): Promise<void> {
   assert(
     OWNER_WITHDRAW_FEE_DENOMINATOR ==
       fetchedTokenSwap.ownerWithdrawFeeDenominator.toNumber(),
+  );
+  assert(HOST_FEE_NUMERATOR == fetchedTokenSwap.hostFeeNumerator.toNumber());
+  assert(
+    HOST_FEE_DENOMINATOR == fetchedTokenSwap.hostFeeDenominator.toNumber(),
   );
 }
 

--- a/token-swap/js/client/token-swap.js
+++ b/token-swap/js/client/token-swap.js
@@ -74,7 +74,8 @@ export const TokenSwapLayout: typeof BufferLayout.Structure = BufferLayout.struc
     Layout.uint64('ownerTradeFeeDenominator'),
     Layout.uint64('ownerWithdrawFeeNumerator'),
     Layout.uint64('ownerWithdrawFeeDenominator'),
-    BufferLayout.blob(16, 'padding'),
+    Layout.uint64('hostFeeNumerator'),
+    Layout.uint64('hostFeeDenominator'),
   ],
 );
 
@@ -173,6 +174,16 @@ export class TokenSwap {
   ownerWithdrawFeeDenominator: Numberu64;
 
   /**
+   * Host trading fee numerator
+   */
+  hostFeeNumerator: Numberu64;
+
+  /**
+   * Host trading fee denominator
+   */
+  hostFeeDenominator: Numberu64;
+
+  /**
    * CurveType, current options are:
    */
   curveType: number;
@@ -214,6 +225,8 @@ export class TokenSwap {
     ownerTradeFeeDenominator: Numberu64,
     ownerWithdrawFeeNumerator: Numberu64,
     ownerWithdrawFeeDenominator: Numberu64,
+    hostFeeNumerator: Numberu64,
+    hostFeeDenominator: Numberu64,
     payer: Account,
   ) {
     Object.assign(this, {
@@ -235,6 +248,8 @@ export class TokenSwap {
       ownerTradeFeeDenominator,
       ownerWithdrawFeeNumerator,
       ownerWithdrawFeeDenominator,
+      hostFeeNumerator,
+      hostFeeDenominator,
       payer,
     });
   }
@@ -270,6 +285,8 @@ export class TokenSwap {
     ownerTradeFeeDenominator: number,
     ownerWithdrawFeeNumerator: number,
     ownerWithdrawFeeDenominator: number,
+    hostFeeNumerator: number,
+    hostFeeDenominator: number,
   ): TransactionInstruction {
     const keys = [
       {pubkey: tokenSwapAccount.publicKey, isSigner: false, isWritable: true},
@@ -291,7 +308,8 @@ export class TokenSwap {
       BufferLayout.nu64('ownerTradeFeeDenominator'),
       BufferLayout.nu64('ownerWithdrawFeeNumerator'),
       BufferLayout.nu64('ownerWithdrawFeeDenominator'),
-      BufferLayout.blob(16, 'padding'),
+      BufferLayout.nu64('hostFeeNumerator'),
+      BufferLayout.nu64('hostFeeDenominator'),
     ]);
     let data = Buffer.alloc(1024);
     {
@@ -306,6 +324,8 @@ export class TokenSwap {
           ownerTradeFeeDenominator,
           ownerWithdrawFeeNumerator,
           ownerWithdrawFeeDenominator,
+          hostFeeNumerator,
+          hostFeeDenominator,
         },
         data,
       );
@@ -361,6 +381,12 @@ export class TokenSwap {
     const ownerWithdrawFeeDenominator = Numberu64.fromBuffer(
       tokenSwapData.ownerWithdrawFeeDenominator,
     );
+    const hostFeeNumerator = Numberu64.fromBuffer(
+      tokenSwapData.hostFeeNumerator,
+    );
+    const hostFeeDenominator = Numberu64.fromBuffer(
+      tokenSwapData.hostFeeDenominator,
+    );
     const curveType = tokenSwapData.curveType;
 
     return new TokenSwap(
@@ -382,6 +408,8 @@ export class TokenSwap {
       ownerTradeFeeDenominator,
       ownerWithdrawFeeNumerator,
       ownerWithdrawFeeDenominator,
+      hostFeeNumerator,
+      hostFeeDenominator,
       payer,
     );
   }
@@ -426,6 +454,8 @@ export class TokenSwap {
     ownerTradeFeeDenominator: number,
     ownerWithdrawFeeNumerator: number,
     ownerWithdrawFeeDenominator: number,
+    hostFeeNumerator: number,
+    hostFeeDenominator: number,
   ): Promise<TokenSwap> {
     let transaction;
     const tokenSwap = new TokenSwap(
@@ -447,6 +477,8 @@ export class TokenSwap {
       new Numberu64(ownerTradeFeeDenominator),
       new Numberu64(ownerWithdrawFeeNumerator),
       new Numberu64(ownerWithdrawFeeDenominator),
+      new Numberu64(hostFeeNumerator),
+      new Numberu64(hostFeeDenominator),
       payer,
     );
 
@@ -483,6 +515,8 @@ export class TokenSwap {
       ownerTradeFeeDenominator,
       ownerWithdrawFeeNumerator,
       ownerWithdrawFeeDenominator,
+      hostFeeNumerator,
+      hostFeeDenominator,
     );
 
     transaction.add(instruction);

--- a/token-swap/js/client/token-swap.js
+++ b/token-swap/js/client/token-swap.js
@@ -512,6 +512,7 @@ export class TokenSwap {
     poolSource: PublicKey,
     poolDestination: PublicKey,
     userDestination: PublicKey,
+    hostFeeAccount: ?PublicKey,
     amountIn: number | Numberu64,
     minimumAmountOut: number | Numberu64,
   ): Promise<TransactionSignature> {
@@ -528,6 +529,7 @@ export class TokenSwap {
           userDestination,
           this.poolToken,
           this.feeAccount,
+          hostFeeAccount,
           this.swapProgramId,
           this.tokenProgramId,
           amountIn,
@@ -547,6 +549,7 @@ export class TokenSwap {
     userDestination: PublicKey,
     poolMint: PublicKey,
     feeAccount: PublicKey,
+    hostFeeAccount: ?PublicKey,
     swapProgramId: PublicKey,
     tokenProgramId: PublicKey,
     amountIn: number | Numberu64,
@@ -579,6 +582,9 @@ export class TokenSwap {
       {pubkey: feeAccount, isSigner: false, isWritable: true},
       {pubkey: tokenProgramId, isSigner: false, isWritable: false},
     ];
+    if (hostFeeAccount != null) {
+      keys.push({pubkey: hostFeeAccount, isSigner: false, isWritable: true});
+    }
     return new TransactionInstruction({
       keys,
       programId: swapProgramId,

--- a/token-swap/js/module.d.ts
+++ b/token-swap/js/module.d.ts
@@ -102,6 +102,7 @@ declare module '@solana/spl-token-swap' {
       poolSource: PublicKey,
       poolDestination: PublicKey,
       userDestination: PublicKey,
+      hostFeeAccount: PublicKey | null,
       amountIn: number | Numberu64,
       minimumAmountOut: number | Numberu64,
     ): Promise<TransactionSignature>;
@@ -115,6 +116,7 @@ declare module '@solana/spl-token-swap' {
       userDestination: PublicKey,
       poolMint: PublicKey,
       feeAccount: PublicKey,
+      hostFeeAccount: PublicKey | null,
       swapProgramId: PublicKey,
       tokenProgramId: PublicKey,
       amountIn: number | Numberu64,

--- a/token-swap/js/module.d.ts
+++ b/token-swap/js/module.d.ts
@@ -39,6 +39,8 @@ declare module '@solana/spl-token-swap' {
       ownerTradeFeeDenominator: Numberu64,
       ownerWithdrawFeeNumerator: Numberu64,
       ownerWithdrawFeeDenominator: Numberu64,
+      hostFeeNumerator: Numberu64,
+      hostFeeDenominator: Numberu64,
       payer: Account,
     );
 
@@ -64,6 +66,8 @@ declare module '@solana/spl-token-swap' {
       ownerTradeFeeDenominator: number,
       ownerWithdrawFeeNumerator: number,
       ownerWithdrawFeeDenominator: number,
+      hostFeeNumerator: number,
+      hostFeeDenominator: number,
     ): TransactionInstruction;
 
     static loadTokenSwap(
@@ -94,6 +98,8 @@ declare module '@solana/spl-token-swap' {
       ownerTradeFeeDenominator: number,
       ownerWithdrawFeeNumerator: number,
       ownerWithdrawFeeDenominator: number,
+      hostFeeNumerator: number,
+      hostFeeDenominator: number,
       swapProgramId: PublicKey,
     ): Promise<TokenSwap>;
 

--- a/token-swap/js/module.flow.js
+++ b/token-swap/js/module.flow.js
@@ -99,6 +99,7 @@ declare module '@solana/spl-token-swap' {
       poolSource: PublicKey,
       poolDestination: PublicKey,
       userDestination: PublicKey,
+      hostFeeAccount: ?PublicKey,
       amountIn: number | Numberu64,
       minimumAmountOut: number | Numberu64,
     ): Promise<TransactionSignature>;
@@ -112,6 +113,7 @@ declare module '@solana/spl-token-swap' {
       userDestination: PublicKey,
       poolMint: PublicKey,
       feeAccount: PublicKey,
+      hostFeeAccount: ?PublicKey,
       swapProgramId: PublicKey,
       tokenProgramId: PublicKey,
       amountIn: number | Numberu64,

--- a/token-swap/js/module.flow.js
+++ b/token-swap/js/module.flow.js
@@ -36,6 +36,8 @@ declare module '@solana/spl-token-swap' {
       ownerTradeFeeDenominator: Numberu64,
       ownerWithdrawFeeNumerator: Numberu64,
       ownerWithdrawFeeDenominator: Numberu64,
+      hostFeeNumerator: Numberu64,
+      hostFeeDenominator: Numberu64,
       payer: Account,
     ): TokenSwap;
 
@@ -61,6 +63,8 @@ declare module '@solana/spl-token-swap' {
       ownerTradeFeeDenominator: number,
       ownerWithdrawFeeNumerator: number,
       ownerWithdrawFeeDenominator: number,
+      hostFeeNumerator: number,
+      hostFeeDenominator: number,
     ): TransactionInstruction;
 
     static loadTokenSwap(
@@ -91,6 +95,8 @@ declare module '@solana/spl-token-swap' {
       ownerTradeFeeDenominator: number,
       ownerWithdrawFeeNumerator: number,
       ownerWithdrawFeeDenominator: number,
+      hostFeeNumerator: number,
+      hostFeeDenominator: number,
       programId: PublicKey,
     ): Promise<TokenSwap>;
 

--- a/token-swap/program/Cargo.toml
+++ b/token-swap/program/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 
 [features]
 exclude_entrypoint = []
+production = []
 
 [dependencies]
 arrayref = "0.3.6"

--- a/token-swap/program/src/constraints.rs
+++ b/token-swap/program/src/constraints.rs
@@ -1,0 +1,49 @@
+//! Various constraints as required for production environments
+
+#[cfg(feature = "production")]
+use std::env;
+
+/// Encodes fee constraints, used in multihost environments where the program
+/// may be used by multiple frontends, to ensure that proper fees are being
+/// assessed.
+pub struct FeeConstraints<'a> {
+    /// Owner of the program
+    pub owner_key: &'a str,
+    /// Fee numerator
+    pub trade_fee_numerator: u128,
+    /// Fee denominator
+    pub trade_fee_denominator: u128,
+    /// Owner trade fee numerator
+    pub owner_trade_fee_numerator: u128,
+    /// Owner trade fee denominator
+    pub owner_trade_fee_denominator: u128,
+    /// Host fee numerator (e.g. 20 / 100 for host to receive 20% of owner trade fees)
+    pub host_fee_numerator: u128,
+    /// Host fee denominator
+    pub host_fee_denominator: u128,
+}
+
+#[cfg(feature = "production")]
+const OWNER_KEY: &'static str = env!("SWAP_PROGRAM_OWNER_FEE_ADDRESS");
+
+/// Fee structure defined by program creator in order to enforce certain
+/// fees when others use the program.  Adds checks on pool creation and
+/// swapping to ensure the correct fees and account owners are passed.
+pub const FEE_CONSTRAINTS: Option<FeeConstraints> = {
+    #[cfg(feature = "production")]
+    {
+        Some(FeeConstraints {
+            owner_key: OWNER_KEY,
+            trade_fee_numerator: 25,
+            trade_fee_denominator: 10000,
+            owner_trade_fee_numerator: 5,
+            owner_trade_fee_denominator: 10000,
+            host_fee_numerator: 20,
+            host_fee_denominator: 100,
+        })
+    }
+    #[cfg(not(feature = "production"))]
+    {
+        None
+    }
+};

--- a/token-swap/program/src/constraints.rs
+++ b/token-swap/program/src/constraints.rs
@@ -10,17 +10,17 @@ pub struct FeeConstraints<'a> {
     /// Owner of the program
     pub owner_key: &'a str,
     /// Fee numerator
-    pub trade_fee_numerator: u128,
+    pub trade_fee_numerator: u64,
     /// Fee denominator
-    pub trade_fee_denominator: u128,
+    pub trade_fee_denominator: u64,
     /// Owner trade fee numerator
-    pub owner_trade_fee_numerator: u128,
+    pub owner_trade_fee_numerator: u64,
     /// Owner trade fee denominator
-    pub owner_trade_fee_denominator: u128,
+    pub owner_trade_fee_denominator: u64,
     /// Host fee numerator (e.g. 20 / 100 for host to receive 20% of owner trade fees)
-    pub host_fee_numerator: u128,
+    pub host_fee_numerator: u64,
     /// Host fee denominator
-    pub host_fee_denominator: u128,
+    pub host_fee_denominator: u64,
 }
 
 #[cfg(feature = "production")]

--- a/token-swap/program/src/constraints.rs
+++ b/token-swap/program/src/constraints.rs
@@ -87,8 +87,8 @@ pub const FEE_CONSTRAINTS: Option<FeeConstraints> = {
     {
         Some(FeeConstraints {
             owner_key: OWNER_KEY,
-            valid_constant_product_curves: &VALID_CONSTANT_PRODUCT_CURVES,
-            valid_flat_curves: &VALID_FLAT_CURVES,
+            valid_constant_product_curves: VALID_CONSTANT_PRODUCT_CURVES,
+            valid_flat_curves: VALID_FLAT_CURVES,
         })
     }
     #[cfg(not(feature = "production"))]

--- a/token-swap/program/src/constraints.rs
+++ b/token-swap/program/src/constraints.rs
@@ -1,30 +1,83 @@
 //! Various constraints as required for production environments
 
+use crate::{
+    curve::{SwapCurve, CurveType, ConstantProductCurve, FlatCurve},
+    error::SwapError,
+};
+
+use solana_program::program_error::ProgramError;
+
 #[cfg(feature = "production")]
 use std::env;
 
 /// Encodes fee constraints, used in multihost environments where the program
 /// may be used by multiple frontends, to ensure that proper fees are being
 /// assessed.
+/// Since this struct needs to be created at compile-time, we only have access
+/// to const functions and constructors. Since SwapCurve contains a Box, it
+/// cannot be used, so we have to split the curves based on their types.
 pub struct FeeConstraints<'a> {
     /// Owner of the program
     pub owner_key: &'a str,
-    /// Fee numerator
-    pub trade_fee_numerator: u64,
-    /// Fee denominator
-    pub trade_fee_denominator: u64,
-    /// Owner trade fee numerator
-    pub owner_trade_fee_numerator: u64,
-    /// Owner trade fee denominator
-    pub owner_trade_fee_denominator: u64,
-    /// Host fee numerator (e.g. 20 / 100 for host to receive 20% of owner trade fees)
-    pub host_fee_numerator: u64,
-    /// Host fee denominator
-    pub host_fee_denominator: u64,
+    /// Valid flat curves for the program
+    pub valid_flat_curves: &'a[FlatCurve],
+    /// Valid constant product curves for the program
+    pub valid_constant_product_curves: &'a[ConstantProductCurve],
+}
+
+impl<'a> FeeConstraints<'a> {
+    /// Checks that the provided curve is valid for the given constraints
+    pub fn validate_curve(&self, swap_curve: &SwapCurve) -> Result<(), ProgramError> {
+        let valid_swap_curves: Vec<SwapCurve> = match swap_curve.curve_type {
+            CurveType::Flat =>
+                self.valid_flat_curves.iter()
+                    .map(|x| SwapCurve {
+                        curve_type: swap_curve.curve_type,
+                        calculator: Box::new(x.clone()),
+                    }).collect(),
+            CurveType::ConstantProduct =>
+                self.valid_constant_product_curves.iter()
+                    .map(|x| SwapCurve {
+                        curve_type: swap_curve.curve_type,
+                        calculator: Box::new(x.clone()),
+                    }).collect(),
+        };
+        if valid_swap_curves.iter().any(|x| *x == *swap_curve) {
+            Ok(())
+        } else {
+            return Err(SwapError::InvalidFee.into());
+        }
+    }
 }
 
 #[cfg(feature = "production")]
 const OWNER_KEY: &'static str = env!("SWAP_PROGRAM_OWNER_FEE_ADDRESS");
+#[cfg(feature = "production")]
+const VALID_CONSTANT_PRODUCT_CURVES: &[ConstantProductCurve] = &[
+    ConstantProductCurve {
+        trade_fee_numerator: 25,
+        trade_fee_denominator: 10000,
+        owner_trade_fee_numerator: 5,
+        owner_trade_fee_denominator: 10000,
+        owner_withdraw_fee_numerator: 0,
+        owner_withdraw_fee_denominator: 0,
+        host_fee_numerator: 20,
+        host_fee_denominator: 100,
+    }
+];
+#[cfg(feature = "production")]
+const VALID_FLAT_CURVES: &[FlatCurve] = &[
+    FlatCurve {
+        trade_fee_numerator: 25,
+        trade_fee_denominator: 10000,
+        owner_trade_fee_numerator: 5,
+        owner_trade_fee_denominator: 10000,
+        owner_withdraw_fee_numerator: 0,
+        owner_withdraw_fee_denominator: 0,
+        host_fee_numerator: 20,
+        host_fee_denominator: 100,
+    },
+];
 
 /// Fee structure defined by program creator in order to enforce certain
 /// fees when others use the program.  Adds checks on pool creation and
@@ -34,12 +87,8 @@ pub const FEE_CONSTRAINTS: Option<FeeConstraints> = {
     {
         Some(FeeConstraints {
             owner_key: OWNER_KEY,
-            trade_fee_numerator: 25,
-            trade_fee_denominator: 10000,
-            owner_trade_fee_numerator: 5,
-            owner_trade_fee_denominator: 10000,
-            host_fee_numerator: 20,
-            host_fee_denominator: 100,
+            valid_constant_product_curves: &VALID_CONSTANT_PRODUCT_CURVES,
+            valid_flat_curves: &VALID_FLAT_CURVES,
         })
     }
     #[cfg(not(feature = "production"))]
@@ -47,3 +96,89 @@ pub const FEE_CONSTRAINTS: Option<FeeConstraints> = {
         None
     }
 };
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::curve::{CurveType, ConstantProductCurve};
+
+    #[test]
+    fn validate_fees() {
+        let trade_fee_numerator = 1;
+        let trade_fee_denominator = 4;
+        let owner_trade_fee_numerator = 2;
+        let owner_trade_fee_denominator = 5;
+        let owner_withdraw_fee_numerator = 4;
+        let owner_withdraw_fee_denominator = 10;
+        let host_fee_numerator = 10;
+        let host_fee_denominator = 100;
+        let owner_key = "";
+        let curve_type = CurveType::ConstantProduct;
+        let mut calculator = ConstantProductCurve {
+            trade_fee_numerator,
+            trade_fee_denominator,
+            owner_trade_fee_numerator,
+            owner_trade_fee_denominator,
+            owner_withdraw_fee_numerator,
+            owner_withdraw_fee_denominator,
+            host_fee_numerator,
+            host_fee_denominator,
+        };
+        let swap_curve = SwapCurve {
+            curve_type,
+            calculator: Box::new(calculator.clone()),
+        };
+        let fee_constraints = FeeConstraints {
+            owner_key,
+            valid_constant_product_curves: &[calculator.clone()],
+            valid_flat_curves: &[],
+        };
+
+        fee_constraints.validate_curve(&swap_curve).unwrap();
+
+        calculator.trade_fee_numerator = trade_fee_numerator - 1;
+        let swap_curve = SwapCurve {
+            curve_type,
+            calculator: Box::new(calculator.clone()),
+        };
+        assert_eq!(
+            Err(SwapError::InvalidFee.into()),
+            fee_constraints.validate_curve(&swap_curve),
+        );
+        calculator.trade_fee_numerator = trade_fee_numerator;
+
+        calculator.trade_fee_denominator = trade_fee_denominator - 1;
+        let swap_curve = SwapCurve {
+            curve_type,
+            calculator: Box::new(calculator.clone()),
+        };
+        assert_eq!(
+            Err(SwapError::InvalidFee.into()),
+            fee_constraints.validate_curve(&swap_curve),
+        );
+        calculator.trade_fee_denominator = trade_fee_denominator;
+
+        calculator.owner_trade_fee_numerator = owner_trade_fee_numerator - 1;
+        let swap_curve = SwapCurve {
+            curve_type,
+            calculator: Box::new(calculator.clone()),
+        };
+        assert_eq!(
+            Err(SwapError::InvalidFee.into()),
+            fee_constraints.validate_curve(&swap_curve),
+        );
+        calculator.owner_trade_fee_numerator = owner_trade_fee_numerator;
+
+        calculator.owner_trade_fee_denominator = owner_trade_fee_denominator - 1;
+        let swap_curve = SwapCurve {
+            curve_type,
+            calculator: Box::new(calculator.clone()),
+        };
+        assert_eq!(
+            Err(SwapError::InvalidFee.into()),
+            fee_constraints.validate_curve(&swap_curve),
+        );
+        calculator.owner_trade_fee_denominator = owner_trade_fee_denominator;
+    }
+}

--- a/token-swap/program/src/curve.rs
+++ b/token-swap/program/src/curve.rs
@@ -209,7 +209,12 @@ pub trait CurveCalculator: Debug + DynPack {
     /// Calculate the host fee based on the owner fee, only used in production
     /// situations where a program is hosted by multiple frontends
     fn host_fee(&self, owner_fee: u128, constraints: &FeeConstraints) -> Option<u128> {
-        owner_fee.checked_mul(constraints.host_fee_numerator)?.checked_div(constraints.host_fee_denominator).and_then(map_zero_to_none)
+        let numerator = u128::try_from(constraints.host_fee_numerator).ok()?;
+        let denominator = u128::try_from(constraints.host_fee_denominator).ok()?;
+        owner_fee
+            .checked_mul(numerator)?
+            .checked_div(denominator)
+            .and_then(map_zero_to_none)
     }
 }
 
@@ -315,16 +320,16 @@ impl CurveCalculator for FlatCurve {
 
     /// Validate fees based on constraints
     fn validate_fees(&self, constraints: &FeeConstraints) -> Result<(), ProgramError> {
-        if constraints.trade_fee_numerator != u128::from(self.trade_fee_numerator) {
+        if constraints.trade_fee_numerator != self.trade_fee_numerator {
             return Err(SwapError::InvalidFee.into());
         }
-        if constraints.trade_fee_denominator != u128::from(self.trade_fee_denominator) {
+        if constraints.trade_fee_denominator != self.trade_fee_denominator {
             return Err(SwapError::InvalidFee.into());
         }
-        if constraints.owner_trade_fee_numerator != u128::from(self.owner_trade_fee_numerator) {
+        if constraints.owner_trade_fee_numerator != self.owner_trade_fee_numerator {
             return Err(SwapError::InvalidFee.into());
         }
-        if constraints.owner_trade_fee_denominator != u128::from(self.owner_trade_fee_denominator) {
+        if constraints.owner_trade_fee_denominator != self.owner_trade_fee_denominator {
             return Err(SwapError::InvalidFee.into());
         }
         Ok(())
@@ -459,16 +464,16 @@ impl CurveCalculator for ConstantProductCurve {
 
     /// Validate fees based on constraints
     fn validate_fees(&self, constraints: &FeeConstraints) -> Result<(), ProgramError> {
-        if constraints.trade_fee_numerator != u128::from(self.trade_fee_numerator) {
+        if constraints.trade_fee_numerator != self.trade_fee_numerator {
             return Err(SwapError::InvalidFee.into());
         }
-        if constraints.trade_fee_denominator != u128::from(self.trade_fee_denominator) {
+        if constraints.trade_fee_denominator != self.trade_fee_denominator {
             return Err(SwapError::InvalidFee.into());
         }
-        if constraints.owner_trade_fee_numerator != u128::from(self.owner_trade_fee_numerator) {
+        if constraints.owner_trade_fee_numerator != self.owner_trade_fee_numerator {
             return Err(SwapError::InvalidFee.into());
         }
-        if constraints.owner_trade_fee_denominator != u128::from(self.owner_trade_fee_denominator) {
+        if constraints.owner_trade_fee_denominator != self.owner_trade_fee_denominator {
             return Err(SwapError::InvalidFee.into());
         }
         Ok(())

--- a/token-swap/program/src/curve.rs
+++ b/token-swap/program/src/curve.rs
@@ -315,12 +315,11 @@ impl CurveCalculator for FlatCurve {
     /// Calculate the host fee based on the owner fee, only used in production
     /// situations where a program is hosted by multiple frontends
     fn host_fee(&self, owner_fee: u128) -> Option<u128> {
-        let numerator = u128::try_from(self.host_fee_numerator).ok()?;
-        let denominator = u128::try_from(self.host_fee_denominator).ok()?;
-        owner_fee
-            .checked_mul(numerator)?
-            .checked_div(denominator)
-            .and_then(map_zero_to_none)
+        calculate_fee(
+            owner_fee,
+            u128::try_from(self.host_fee_numerator).ok()?,
+            u128::try_from(self.host_fee_denominator).ok()?,
+        )
     }
 }
 
@@ -465,12 +464,11 @@ impl CurveCalculator for ConstantProductCurve {
     /// Calculate the host fee based on the owner fee, only used in production
     /// situations where a program is hosted by multiple frontends
     fn host_fee(&self, owner_fee: u128) -> Option<u128> {
-        let numerator = u128::try_from(self.host_fee_numerator).ok()?;
-        let denominator = u128::try_from(self.host_fee_denominator).ok()?;
-        owner_fee
-            .checked_mul(numerator)?
-            .checked_div(denominator)
-            .and_then(map_zero_to_none)
+        calculate_fee(
+            owner_fee,
+            u128::try_from(self.host_fee_numerator).ok()?,
+            u128::try_from(self.host_fee_denominator).ok()?,
+        )
     }
 }
 

--- a/token-swap/program/src/curve.rs
+++ b/token-swap/program/src/curve.rs
@@ -5,10 +5,7 @@ use solana_program::{
     program_pack::{IsInitialized, Pack, Sealed},
 };
 
-use crate::{
-    constraints::FeeConstraints,
-    error::SwapError,
-};
+use crate::{constraints::FeeConstraints, error::SwapError};
 
 use arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs};
 use std::convert::{TryFrom, TryInto};
@@ -830,19 +827,31 @@ mod tests {
         curve.validate_fees(&fee_constraints).unwrap();
 
         fee_constraints.trade_fee_numerator = trade_fee_numerator - 1;
-        assert_eq!(Err(SwapError::InvalidFee.into()), curve.validate_fees(&fee_constraints));
+        assert_eq!(
+            Err(SwapError::InvalidFee.into()),
+            curve.validate_fees(&fee_constraints)
+        );
         fee_constraints.trade_fee_numerator = trade_fee_numerator;
 
         fee_constraints.trade_fee_denominator = trade_fee_denominator - 1;
-        assert_eq!(Err(SwapError::InvalidFee.into()), curve.validate_fees(&fee_constraints));
+        assert_eq!(
+            Err(SwapError::InvalidFee.into()),
+            curve.validate_fees(&fee_constraints)
+        );
         fee_constraints.trade_fee_denominator = trade_fee_denominator;
 
         fee_constraints.owner_trade_fee_numerator = owner_trade_fee_numerator - 1;
-        assert_eq!(Err(SwapError::InvalidFee.into()), curve.validate_fees(&fee_constraints));
+        assert_eq!(
+            Err(SwapError::InvalidFee.into()),
+            curve.validate_fees(&fee_constraints)
+        );
         fee_constraints.owner_trade_fee_numerator = owner_trade_fee_numerator;
 
         fee_constraints.owner_trade_fee_denominator = owner_trade_fee_denominator - 1;
-        assert_eq!(Err(SwapError::InvalidFee.into()), curve.validate_fees(&fee_constraints));
+        assert_eq!(
+            Err(SwapError::InvalidFee.into()),
+            curve.validate_fees(&fee_constraints)
+        );
         fee_constraints.owner_trade_fee_denominator = owner_trade_fee_denominator;
     }
 }

--- a/token-swap/program/src/error.rs
+++ b/token-swap/program/src/error.rs
@@ -76,6 +76,9 @@ pub enum SwapError {
     /// ConversionFailure
     #[error("Conversion to u64 failed with an overflow or underflow")]
     ConversionFailure,
+    /// The provided fee does not match the program owner's constraints
+    #[error("The provided fee does not match the program owner's constraints")]
+    InvalidFee,
 }
 impl From<SwapError> for ProgramError {
     fn from(e: SwapError) -> Self {

--- a/token-swap/program/src/instruction.rs
+++ b/token-swap/program/src/instruction.rs
@@ -48,6 +48,7 @@ pub enum SwapInstruction {
     ///   6. `[writable]` Pool token mint, to generate trading fees
     ///   7. `[writable]` Fee account, to receive trading fees
     ///   8. '[]` Token program id
+    ///   9. `[optional, writable]` Host fee account to receive additional trading fees
     Swap {
         /// SOURCE amount to transfer, output to DESTINATION is based on the exchange rate
         amount_in: u64,
@@ -333,6 +334,7 @@ pub fn swap(
     destination_pubkey: &Pubkey,
     pool_mint_pubkey: &Pubkey,
     pool_fee_pubkey: &Pubkey,
+    host_fee_pubkey: Option<&Pubkey>,
     amount_in: u64,
     minimum_amount_out: u64,
 ) -> Result<Instruction, ProgramError> {
@@ -342,7 +344,7 @@ pub fn swap(
     }
     .pack();
 
-    let accounts = vec![
+    let mut accounts = vec![
         AccountMeta::new_readonly(*swap_pubkey, false),
         AccountMeta::new_readonly(*authority_pubkey, false),
         AccountMeta::new(*source_pubkey, false),
@@ -353,6 +355,9 @@ pub fn swap(
         AccountMeta::new(*pool_fee_pubkey, false),
         AccountMeta::new_readonly(*token_program_id, false),
     ];
+    if let Some(host_fee_pubkey) = host_fee_pubkey {
+        accounts.push(AccountMeta::new(*host_fee_pubkey, false));
+    }
 
     Ok(Instruction {
         program_id: *program_id,

--- a/token-swap/program/src/instruction.rs
+++ b/token-swap/program/src/instruction.rs
@@ -391,6 +391,8 @@ mod tests {
         let owner_trade_fee_denominator: u64 = 5;
         let owner_withdraw_fee_numerator: u64 = 1;
         let owner_withdraw_fee_denominator: u64 = 3;
+        let host_fee_numerator: u64 = 5;
+        let host_fee_denominator: u64 = 20;
         let nonce: u8 = 255;
         let curve_type = CurveType::Flat;
         let calculator = Box::new(FlatCurve {
@@ -400,6 +402,8 @@ mod tests {
             owner_trade_fee_denominator,
             owner_withdraw_fee_numerator,
             owner_withdraw_fee_denominator,
+            host_fee_numerator,
+            host_fee_denominator,
         });
         let swap_curve = SwapCurve {
             curve_type,
@@ -417,7 +421,8 @@ mod tests {
         expect.extend_from_slice(&owner_trade_fee_denominator.to_le_bytes());
         expect.extend_from_slice(&owner_withdraw_fee_numerator.to_le_bytes());
         expect.extend_from_slice(&owner_withdraw_fee_denominator.to_le_bytes());
-        expect.extend_from_slice(&[0u8; 16]); // padding
+        expect.extend_from_slice(&host_fee_numerator.to_le_bytes());
+        expect.extend_from_slice(&host_fee_denominator.to_le_bytes());
         assert_eq!(packed, expect);
         let unpacked = SwapInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);

--- a/token-swap/program/src/lib.rs
+++ b/token-swap/program/src/lib.rs
@@ -2,6 +2,7 @@
 
 //! An Uniswap-like program for the Solana blockchain.
 
+pub mod constraints;
 pub mod curve;
 pub mod error;
 pub mod instruction;

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -718,20 +718,10 @@ impl PrintProgramError for SwapError {
             SwapError::FeeCalculationFailure => info!(
                 "Error: The fee calculation failed due to overflow, underflow, or unexpected 0"
             ),
-<<<<<<< HEAD
             SwapError::ConversionFailure => info!("Error: Conversion to or from u64 failed."),
-            SwapError::InvalidFee => info!(
-                "Error: The provided fee does not match the program owner's constraints"
-            ),
-||||||| merged common ancestors
-            SwapError::InvalidFee => info!(
-                "Error: The provided fee does not match the program owner's constraints"
-            ),
-=======
             SwapError::InvalidFee => {
                 info!("Error: The provided fee does not match the program owner's constraints")
             }
->>>>>>> Run cargo fmt + clippy
         }
     }
 }

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -627,12 +627,7 @@ impl Processor {
                 minimum_amount_out,
             } => {
                 info!("Instruction: Swap");
-                Self::process_swap(
-                    program_id,
-                    amount_in,
-                    minimum_amount_out,
-                    accounts,
-                )
+                Self::process_swap(program_id, amount_in, minimum_amount_out, accounts)
             }
             SwapInstruction::Deposit {
                 pool_token_amount,
@@ -3802,8 +3797,12 @@ mod tests {
                 host_fee_denominator,
             }),
         };
-        let mut accounts =
-            SwapAccountInfo::new(&user_key, swap_curve.clone(), token_a_amount, token_b_amount);
+        let mut accounts = SwapAccountInfo::new(
+            &user_key,
+            swap_curve,
+            token_a_amount,
+            token_b_amount,
+        );
 
         let initial_a = token_a_amount / 5;
         let initial_b = token_b_amount / 5;

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -3797,12 +3797,8 @@ mod tests {
                 host_fee_denominator,
             }),
         };
-        let mut accounts = SwapAccountInfo::new(
-            &user_key,
-            swap_curve,
-            token_a_amount,
-            token_b_amount,
-        );
+        let mut accounts =
+            SwapAccountInfo::new(&user_key, swap_curve, token_a_amount, token_b_amount);
 
         let initial_a = token_a_amount / 5;
         let initial_b = token_b_amount / 5;

--- a/token-swap/program/src/state.rs
+++ b/token-swap/program/src/state.rs
@@ -149,6 +149,8 @@ mod tests {
         let owner_trade_fee_denominator = 10;
         let owner_withdraw_fee_numerator = 2;
         let owner_withdraw_fee_denominator = 7;
+        let host_fee_numerator = 5;
+        let host_fee_denominator = 20;
         let calculator = Box::new(FlatCurve {
             trade_fee_numerator,
             trade_fee_denominator,
@@ -156,6 +158,8 @@ mod tests {
             owner_trade_fee_denominator,
             owner_withdraw_fee_numerator,
             owner_withdraw_fee_denominator,
+            host_fee_numerator,
+            host_fee_denominator,
         });
         let swap_curve = SwapCurve {
             curve_type,
@@ -197,7 +201,8 @@ mod tests {
         packed.extend_from_slice(&owner_trade_fee_denominator.to_le_bytes());
         packed.extend_from_slice(&owner_withdraw_fee_numerator.to_le_bytes());
         packed.extend_from_slice(&owner_withdraw_fee_denominator.to_le_bytes());
-        packed.extend_from_slice(&[0u8; 16]); // padding
+        packed.extend_from_slice(&host_fee_numerator.to_le_bytes());
+        packed.extend_from_slice(&host_fee_denominator.to_le_bytes());
         let unpacked = SwapInfo::unpack(&packed).unwrap();
         assert_eq!(swap_info, unpacked);
 


### PR DESCRIPTION
In the dex situation, the token swap program may have multiple frontends interacting with it, but the program creator would like to be the default destination for trading fees, along with enforcing certain fees on its exchange.  This provides a little framework for setting and enforcing these constants, enabled using the "production" feature.

Currently, only the owner key is configured through an environment variable.  I wanted to statically create a Pubkey based on &'static str using a const function, but the only const function for creating is from an array, so I'm not sure if we can go the full way to creating a Pubkey at this point.  We could eventually also include the fee parameters as env variables, but the conversion &'static str -> u64 wasn't clear either.

Additionally, there's an optional "host account" parameter added to the swap instruction.  If provided, the program creator shares some of the trading fee with this host account.

I had some trouble working with and without the constraints in testing, but I was pretty happy with the idea of just factoring out the constraints from the normal `process` function in the end.  Any better ideas are absolutely appreciated!

Note that a JS end-to-end test for production mode still needs to be added for CI.