### PR TITLE
Back to no-entrypoint feature name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,19 +684,6 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
-dependencies = [
- "byteorder",
- "digest 0.8.1",
- "rand_core",
- "subtle 2.2.3",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "2.1.0"
 source = "git+https://github.com/garious/curve25519-dalek?rev=60efef3553d6bf3d7f3b09b5f97acd54d72529ff#60efef3553d6bf3d7f3b09b5f97acd54d72529ff"
 dependencies = [
  "borsh",
@@ -704,6 +691,19 @@ dependencies = [
  "digest 0.8.1",
  "rand_core",
  "serde",
+ "subtle 2.2.3",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
+dependencies = [
+ "byteorder",
+ "digest 0.8.1",
+ "rand_core",
  "subtle 2.2.3",
  "zeroize",
 ]

--- a/associated-token-account/program/Cargo.toml
+++ b/associated-token-account/program/Cargo.toml
@@ -8,11 +8,11 @@ license = "Apache-2.0"
 edition = "2018"
 
 [features]
-exclude_entrypoint = []
+no-entrypoint = []
 
 [dependencies]
 solana-program = "1.4.4"
-spl-token = { path = "../../token/program", features = ["exclude_entrypoint"] }
+spl-token = { path = "../../token/program", features = ["no-entrypoint"] }
 
 [dev-dependencies]
 solana-program-test = "1.4.4"

--- a/associated-token-account/program/src/entrypoint.rs
+++ b/associated-token-account/program/src/entrypoint.rs
@@ -1,6 +1,6 @@
 //! Program entrypoint
 
-#![cfg(all(target_arch = "bpf", not(feature = "exclude_entrypoint")))]
+#![cfg(all(target_arch = "bpf", not(feature = "no-entrypoint")))]
 
 use solana_program::{
     account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,

--- a/memo/program/Cargo.toml
+++ b/memo/program/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [features]
-exclude_entrypoint = []
+no-entrypoint = []
 
 [dependencies]
 solana-program = "1.4.4"

--- a/memo/program/src/lib.rs
+++ b/memo/program/src/lib.rs
@@ -2,7 +2,7 @@
 
 //! A simple program that accepts a string of encoded characters and verifies that it parses. Currently handles UTF-8.
 
-#[cfg(not(feature = "exclude_entrypoint"))]
+#[cfg(not(feature = "no-entrypoint"))]
 mod entrypoint;
 
 // Export current sdk types for downstream users building with a different sdk version

--- a/stake-pool/cli/Cargo.toml
+++ b/stake-pool/cli/Cargo.toml
@@ -17,8 +17,8 @@ solana-cli-config = "1.4.4"
 solana-client = "1.4.4"
 solana-logger = "1.4.4"
 solana-sdk = "1.4.4"
-spl-stake-pool = { version = "0.1.0", path="../program", features = [ "exclude_entrypoint" ] }
-spl-token = { path="../../token/program" }
+spl-stake-pool = { path="../program", features = [ "no-entrypoint" ] }
+spl-token = { path="../../token/program", features = [ "no-entrypoint" ]  }
 
 [[bin]]
 name = "spl-stake-pool"

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [features]
-exclude_entrypoint = []
+no-entrypoint = []
 
 [dependencies]
 arrayref = "0.3.6"
@@ -18,7 +18,7 @@ num_enum = "0.5.1"
 serde = "1.0.117"
 serde_derive = "1.0.103"
 solana-program = "1.4.4"
-spl-token = { path = "../../token/program", features = [ "exclude_entrypoint" ] }
+spl-token = { path = "../../token/program", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/stake-pool/program/src/lib.rs
+++ b/stake-pool/program/src/lib.rs
@@ -8,7 +8,7 @@ pub mod processor;
 pub mod stake;
 pub mod state;
 
-#[cfg(not(feature = "exclude_entrypoint"))]
+#[cfg(not(feature = "no-entrypoint"))]
 pub mod entrypoint;
 
 // Export current sdk types for downstream users building with a different sdk version

--- a/themis/client_ristretto/Cargo.toml
+++ b/themis/client_ristretto/Cargo.toml
@@ -18,7 +18,7 @@ futures = "0.3"
 solana-banks-client = "1.4.4"
 solana-cli-config = "1.4.4"
 solana-sdk = "1.4.4"
-spl-themis-ristretto = { version = "0.1.0", path = "../program_ristretto", features = ["exclude_entrypoint"] }
+spl-themis-ristretto = { version = "0.1.0", path = "../program_ristretto", features = ["no-entrypoint"] }
 tarpc = { version = "0.22.0", features = ["full"] }
 tokio = "0.3"
 url = "2.1"

--- a/themis/program_ristretto/Cargo.toml
+++ b/themis/program_ristretto/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [features]
-exclude_entrypoint = []
+no-entrypoint = []
 default = ["elgamal_ristretto/program"]
 
 [dependencies]

--- a/themis/program_ristretto/src/lib.rs
+++ b/themis/program_ristretto/src/lib.rs
@@ -6,7 +6,7 @@ pub mod instruction;
 pub mod processor;
 pub mod state;
 
-#[cfg(not(feature = "exclude_entrypoint"))]
+#[cfg(not(feature = "no-entrypoint"))]
 pub mod entrypoint;
 
 // Export current sdk types for downstream users building with a different sdk version

--- a/token-lending/program/Cargo.toml
+++ b/token-lending/program/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [features]
-exclude_entrypoint = []
+no-entrypoint = []
 
 [dependencies]
 arrayref = "0.3.6"

--- a/token-lending/program/src/lib.rs
+++ b/token-lending/program/src/lib.rs
@@ -7,7 +7,7 @@ pub mod instruction;
 pub mod processor;
 pub mod state;
 
-#[cfg(not(feature = "exclude_entrypoint"))]
+#[cfg(not(feature = "no-entrypoint"))]
 pub mod entrypoint;
 
 // Export current sdk types for downstream users building with a different sdk version

--- a/token-swap/program/Cargo.toml
+++ b/token-swap/program/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [features]
-exclude_entrypoint = []
+no-entrypoint = []
 production = []
 
 [dependencies]
@@ -16,7 +16,7 @@ arrayref = "0.3.6"
 num-derive = "0.3"
 num-traits = "0.2"
 solana-program = "1.4.4"
-spl-token = { path = "../../token/program", features = [ "exclude_entrypoint" ] }
+spl-token = { path = "../../token/program", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/token-swap/program/src/lib.rs
+++ b/token-swap/program/src/lib.rs
@@ -9,7 +9,7 @@ pub mod instruction;
 pub mod processor;
 pub mod state;
 
-#[cfg(not(feature = "exclude_entrypoint"))]
+#[cfg(not(feature = "no-entrypoint"))]
 mod entrypoint;
 
 // Export current sdk types for downstream users building with a different sdk version

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -20,7 +20,7 @@ solana-client = "1.4.4"
 solana-logger = "1.4.4"
 solana-remote-wallet = "1.4.4"
 solana-sdk = "1.4.4"
-spl-token = { version = "2.0", path="../program", features = [ "exclude_entrypoint" ] }
+spl-token = { version = "2.0", path="../program", features = [ "no-entrypoint" ] }
 
 [[bin]]
 name = "spl-token"

--- a/token/perf-monitor/Cargo.toml
+++ b/token/perf-monitor/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dev-dependencies]
 rand = { version = "0.7.0"}
-spl-token = { path = "../program", features = [ "exclude_entrypoint" ] }
+spl-token = { path = "../program", features = [ "no-entrypoint" ] }
 solana-runtime = "1.4.4"
 solana-sdk = "1.4.4"
 solana-bpf-loader-program = "1.4.4"

--- a/token/program-v3/Cargo.toml
+++ b/token/program-v3/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 exclude = ["js/**"]
 
 [features]
-exclude_entrypoint = []
+no-entrypoint = []
 
 [dependencies]
 arrayref = "0.3.6"

--- a/token/program-v3/src/lib.rs
+++ b/token/program-v3/src/lib.rs
@@ -9,7 +9,7 @@ pub mod native_mint;
 pub mod processor;
 pub mod state;
 
-#[cfg(not(feature = "exclude_entrypoint"))]
+#[cfg(not(feature = "no-entrypoint"))]
 pub mod entrypoint;
 
 // Export current sdk types for downstream users building with a different sdk version

--- a/token/program/Cargo.toml
+++ b/token/program/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 exclude = ["js/**"]
 
 [features]
-exclude_entrypoint = []
+no-entrypoint = []
 
 [dependencies]
 arrayref = "0.3.6"

--- a/token/program/src/lib.rs
+++ b/token/program/src/lib.rs
@@ -9,7 +9,7 @@ pub mod native_mint;
 pub mod processor;
 pub mod state;
 
-#[cfg(not(feature = "exclude_entrypoint"))]
+#[cfg(not(feature = "no-entrypoint"))]
 mod entrypoint;
 
 // Export current sdk types for downstream users building with a different sdk version

--- a/utils/test-client/Cargo.toml
+++ b/utils/test-client/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dependencies]
 solana-sdk = "1.4.4"
-spl-memo = { path = "../../memo/program", features = [ "exclude_entrypoint" ] }
-spl-token = { path = "../../token/program", features = [ "exclude_entrypoint" ] }
-spl-token-swap = { path = "../../token-swap/program", features = [ "exclude_entrypoint" ] }
-spl-token-v3 = { path = "../../token/program-v3", features = [ "exclude_entrypoint" ] }
+spl-memo = { path = "../../memo/program", features = [ "no-entrypoint" ] }
+spl-token = { path = "../../token/program", features = [ "no-entrypoint" ] }
+spl-token-swap = { path = "../../token-swap/program", features = [ "no-entrypoint" ] }
+spl-token-v3 = { path = "../../token/program-v3", features = [ "no-entrypoint" ] }


### PR DESCRIPTION
Downstream clients are using `no-entrypoint`, no need to make them change when upgrading to a newer crate