### PR TITLE
Add associated-token-account support to spl-token-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3365,6 +3365,7 @@ dependencies = [
  "solana-logger",
  "solana-remote-wallet",
  "solana-sdk",
+ "spl-associated-token-account",
  "spl-token 2.0.8",
 ]
 

--- a/associated-token-account/program/program-id.md
+++ b/associated-token-account/program/program-id.md
@@ -1,1 +1,1 @@
-3medvrcM8s3UnkoYqqV3RAURii1ysuT5oD7t8nmfgJmj
+5vXnHJkHwqo9UJ3L8WM6YnW4TmhujV4AKs1mS9DpsFAG

--- a/associated-token-account/program/src/lib.rs
+++ b/associated-token-account/program/src/lib.rs
@@ -14,7 +14,7 @@ use solana_program::{
     sysvar,
 };
 
-solana_program::declare_id!("3medvrcM8s3UnkoYqqV3RAURii1ysuT5oD7t8nmfgJmj");
+solana_program::declare_id!("5vXnHJkHwqo9UJ3L8WM6YnW4TmhujV4AKs1mS9DpsFAG");
 
 pub(crate) fn get_associated_token_address_and_bump_seed(
     wallet_address: &Pubkey,

--- a/associated-token-account/program/src/lib.rs
+++ b/associated-token-account/program/src/lib.rs
@@ -46,7 +46,7 @@ pub fn get_associated_token_address(
 ///   0. `[writeable,signer]` Funding account (must be a system account)
 ///   1. `[writeable]` Associated token account address to be created
 ///   2. `[]` Wallet address for the new associated token account
-///   3. `[]` The token mint for new associated token account
+///   3. `[]` The token mint for the new associated token account
 ///   4. `[]` System program
 ///   4. `[]` SPL Token program
 ///   5. `[]` Rent sysvar

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -21,6 +21,7 @@ solana-logger = "1.4.4"
 solana-remote-wallet = "1.4.4"
 solana-sdk = "1.4.4"
 spl-token = { version = "2.0", path="../program", features = [ "no-entrypoint" ] }
+spl-associated-token-account = { path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
 
 [[bin]]
 name = "spl-token"


### PR DESCRIPTION
The following commands feature additional behaviour:
* `spl-token create-account <token>` without an explicit account will now create the associated token account
* `spl-token transfer` now accepts the user wallet address as the recipient, which will transfer to their associated token account.   The `--fund-recipient` flag may also be specified to fund their associated token account

Also adds a new `spl-token gc` command.  This will consolidate token balances into the associated token account, and then close the ancillary token accounts.  Frozen accounts and accounts with another close authority are skipped.