### PR TITLE
token-swap: Fix zero fee calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,13 +684,12 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "2.1.0"
-source = "git+https://github.com/garious/curve25519-dalek?rev=60efef3553d6bf3d7f3b09b5f97acd54d72529ff#60efef3553d6bf3d7f3b09b5f97acd54d72529ff"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
 dependencies = [
- "borsh",
  "byteorder",
  "digest 0.8.1",
  "rand_core",
- "serde",
  "subtle 2.2.3",
  "zeroize",
 ]
@@ -698,12 +697,13 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
+source = "git+https://github.com/garious/curve25519-dalek?rev=60efef3553d6bf3d7f3b09b5f97acd54d72529ff#60efef3553d6bf3d7f3b09b5f97acd54d72529ff"
 dependencies = [
+ "borsh",
  "byteorder",
  "digest 0.8.1",
  "rand_core",
+ "serde",
  "subtle 2.2.3",
  "zeroize",
 ]

--- a/token-swap/program/src/curve/calculator.rs
+++ b/token-swap/program/src/curve/calculator.rs
@@ -14,7 +14,7 @@ pub fn calculate_fee(
     fee_numerator: u128,
     fee_denominator: u128,
 ) -> Option<u128> {
-    if fee_numerator == 0 {
+    if fee_numerator == 0 || token_amount == 0 {
         Some(0)
     } else {
         let fee = token_amount

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -3642,6 +3642,25 @@ mod tests {
                 host_fee_denominator,
             }),
         );
+        let owner_trade_fee_numerator = 0;
+        let owner_trade_fee_denominator = 0;
+        let owner_withdraw_fee_numerator = 0;
+        let owner_withdraw_fee_denominator = 0;
+        let host_fee_numerator = 0;
+        let host_fee_denominator = 0;
+        check_valid_swap_curve(
+            CurveType::ConstantProduct,
+            Box::new(ConstantProductCurve {
+                trade_fee_numerator,
+                trade_fee_denominator,
+                owner_trade_fee_numerator,
+                owner_trade_fee_denominator,
+                owner_withdraw_fee_numerator,
+                owner_withdraw_fee_denominator,
+                host_fee_numerator,
+                host_fee_denominator,
+            }),
+        );
     }
 
     #[test]


### PR DESCRIPTION
If a swap has a trading fee and a zero owner fee, when calculating the owner
fee to pool token conversion, the simulated trading fee will be non-zero
because we floor the trading fee to 1 token.  If the input to trading
fee calculation is 0, then we will try to do `0 - 1` on an unsigned int,
which causes an underflow error.  The fix is to simply return a 0 fee
for a 0 input.