### PR TITLE
Feature Proposal program

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "examples/rust/logging",
   "examples/rust/sysvar",
   "examples/rust/transfer-lamports",
+  "feature-proposal/program",
   "memo/program",
   "shared-memory/program",
   "stake-pool/cli",

--- a/feature-proposal/program/Cargo.toml
+++ b/feature-proposal/program/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "spl-feature-proposal"
+version = "1.0.0-pre1"
+description = "Solana Program Library Feature Proposal Program"
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+repository = "https://github.com/solana-labs/solana-program-library"
+license = "Apache-2.0"
+edition = "2018"
+
+[features]
+no-entrypoint = []
+test-bpf = []
+
+[dependencies]
+borsh = "0.7.1"
+borsh-derive = "0.7.1"
+solana-program = "1.4.5"
+spl-token = { version = "3.0", path = "../../token/program", features = ["no-entrypoint"] }
+
+
+[dev-dependencies]
+futures = "0.3"
+solana-program-test = "1.4.5"
+solana-sdk = "1.4.5"
+tokio = { version = "0.3", features = ["macros"]}
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/feature-proposal/program/Xargo.toml
+++ b/feature-proposal/program/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/feature-proposal/program/program-id.md
+++ b/feature-proposal/program/program-id.md
@@ -1,0 +1,1 @@
+badkenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8kn

--- a/feature-proposal/program/run-tests.sh
+++ b/feature-proposal/program/run-tests.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -ex
+cd "$(dirname "$0")"
+cargo fmt -- --check
+cargo clippy
+cargo build
+cargo build-bpf
+
+if [[ $1 = -v ]]; then
+  export RUST_LOG=solana=debug
+fi
+
+cargo test
+cargo test-bpf

--- a/feature-proposal/program/src/borsh_utils.rs
+++ b/feature-proposal/program/src/borsh_utils.rs
@@ -1,0 +1,55 @@
+//! Borsh utils
+use borsh::schema::{BorshSchema, Declaration, Definition, Fields};
+use std::collections::HashMap;
+
+/// Get packed length for the given BorchSchema Declaration
+fn get_declaration_packed_len(
+    declaration: &str,
+    definitions: &HashMap<Declaration, Definition>,
+) -> usize {
+    match definitions.get(declaration) {
+        Some(Definition::Array { length, elements }) => {
+            *length as usize * get_declaration_packed_len(elements, definitions)
+        }
+        Some(Definition::Enum { variants }) => {
+            1 + variants
+                .iter()
+                .map(|(_, declaration)| get_declaration_packed_len(declaration, definitions))
+                .max()
+                .unwrap_or(0)
+        }
+        Some(Definition::Struct { fields }) => match fields {
+            Fields::NamedFields(named_fields) => named_fields
+                .iter()
+                .map(|(_, declaration)| get_declaration_packed_len(declaration, definitions))
+                .sum(),
+            Fields::UnnamedFields(declarations) => declarations
+                .iter()
+                .map(|declaration| get_declaration_packed_len(declaration, definitions))
+                .sum(),
+            Fields::Empty => 0,
+        },
+        Some(Definition::Sequence {
+            elements: _elements,
+        }) => panic!("Missing support for Definition::Sequence"),
+        Some(Definition::Tuple { elements }) => elements
+            .iter()
+            .map(|element| get_declaration_packed_len(element, definitions))
+            .sum(),
+        None => match declaration {
+            "u8" | "i8" => 1,
+            "u16" | "i16" => 2,
+            "u32" | "i32" => 2,
+            "u64" | "i64" => 8,
+            "u128" | "i128" => 16,
+            "nil" => 0,
+            _ => panic!("Missing primitive type: {}", declaration),
+        },
+    }
+}
+
+/// Get the worst-case packed length for the given BorshSchema
+pub fn get_packed_len<S: BorshSchema>() -> usize {
+    let schema_container = S::schema_container();
+    get_declaration_packed_len(&schema_container.declaration, &schema_container.definitions)
+}

--- a/feature-proposal/program/src/entrypoint.rs
+++ b/feature-proposal/program/src/entrypoint.rs
@@ -1,0 +1,16 @@
+//! Program entrypoint
+
+#![cfg(all(target_arch = "bpf", not(feature = "no-entrypoint")))]
+
+use solana_program::{
+    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
+};
+
+entrypoint!(process_instruction);
+fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    crate::processor::process_instruction(program_id, accounts, instruction_data)
+}

--- a/feature-proposal/program/src/instruction.rs
+++ b/feature-proposal/program/src/instruction.rs
@@ -1,0 +1,216 @@
+//! Program instructions
+
+use crate::{state::AcceptanceCriteria, *};
+use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use solana_program::{
+    info,
+    instruction::{AccountMeta, Instruction},
+    program_error::ProgramError,
+    program_pack::{Pack, Sealed},
+    pubkey::Pubkey,
+    sysvar,
+};
+
+/// Instructions supported by the Feature Proposal program
+#[derive(Clone, Debug, BorshSerialize, BorshDeserialize, BorshSchema, PartialEq)]
+pub enum FeatureProposalInstruction {
+    /// Propose a new feature.
+    ///
+    /// This instruction will create a variety of accounts to support the feature proposal, all
+    /// funded by account 0:
+    /// * A new token mint with a supply of `tokens_to_mint`, owned by the program and never
+    ///   modified again
+    /// * A new "delivery" token account that holds the total supply, owned by account 0.
+    /// * A new "acceptance" token account that holds 0 tokens, owned by the program.  Tokens
+    ///   transfers to this address are irrevocable and permanent.
+    /// * A new feature id account that has been funded and allocated (as described in
+    ///  `solana_program::feature`)
+    ///
+    /// On successful execution of the instruction, the feature proposer is expected to distribute
+    /// the tokens in the delivery token account out to all participating parties.
+    ///
+    /// Based on the provided acceptance criteria, if `AcceptanceCriteria::tokens_required`
+    /// tokens are transferred into the acceptance token account before
+    /// `AcceptanceCriteria::deadline` then the proposal is eligible to be accepted.
+    ///
+    /// The `FeatureProposalInstruction::Tally` instruction must be executed, by any party, to
+    /// complete the feature acceptance process.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    /// 0. `[writeable,signer]` Funding account (must be a system account)
+    /// 1. `[writeable,signer]` Unallocated feature proposal account to create
+    /// 2. `[writeable]` Token mint address from `get_mint_address`
+    /// 3. `[writeable]` Delivery token account address from `get_delivery_token_address`
+    /// 4. `[writeable]` Acceptance token account address from `get_acceptance_token_address`
+    /// 5. `[writeable]` Feature id account address from `get_feature_id_address`
+    /// 6. `[]` System program
+    /// 7. `[]` SPL Token program
+    /// 8. `[]` Rent sysvar
+    ///
+    Propose {
+        /// Total number of tokens to mint for this proposal
+        #[allow(dead_code)] // not dead code..
+        tokens_to_mint: u64,
+
+        /// Criteria for how this proposal may be activated
+        #[allow(dead_code)] // not dead code..
+        acceptance_criteria: AcceptanceCriteria,
+    },
+
+    /// `Tally` is a permission-less instruction to check the acceptance criteria for the feature
+    /// proposal, which may result in:
+    /// * No action
+    /// * Feature proposal acceptance
+    /// * Feature proposal expiration
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    /// 0. `[writeable]` Feature proposal account
+    /// 1. `[]` Acceptance token account address from `get_acceptance_token_address`
+    /// 2. `[writeable]` Derived feature id account address from `get_feature_id_address`
+    /// 3. `[]` System program
+    /// 4. `[]` Clock sysvar
+    Tally,
+}
+
+impl Sealed for FeatureProposalInstruction {}
+impl Pack for FeatureProposalInstruction {
+    const LEN: usize = 26; // see `test_get_packed_len()` for justification of "18"
+
+    fn pack_into_slice(&self, dst: &mut [u8]) {
+        let data = self.pack_into_vec();
+        dst[..data.len()].copy_from_slice(&data);
+    }
+
+    fn unpack_from_slice(src: &[u8]) -> Result<Self, ProgramError> {
+        let mut mut_src: &[u8] = src;
+        Self::deserialize(&mut mut_src).map_err(|err| {
+            info!(&format!(
+                "Error: failed to deserialize feature proposal instruction: {}",
+                err
+            ));
+            ProgramError::InvalidInstructionData
+        })
+    }
+}
+
+impl FeatureProposalInstruction {
+    fn pack_into_vec(&self) -> Vec<u8> {
+        self.try_to_vec().expect("try_to_vec")
+    }
+}
+
+/// Create a `FeatureProposalInstruction::Propose` instruction
+pub fn propose(
+    funding_address: &Pubkey,
+    feature_proposal_address: &Pubkey,
+    tokens_to_mint: u64,
+    acceptance_criteria: AcceptanceCriteria,
+) -> Instruction {
+    let mint_address = get_mint_address(feature_proposal_address);
+    let delivery_token_address = get_delivery_token_address(feature_proposal_address);
+    let acceptance_token_address = get_acceptance_token_address(feature_proposal_address);
+    let feature_id_address = get_feature_id_address(feature_proposal_address);
+
+    Instruction {
+        program_id: id(),
+        accounts: vec![
+            AccountMeta::new(*funding_address, true),
+            AccountMeta::new(*feature_proposal_address, true),
+            AccountMeta::new(mint_address, false),
+            AccountMeta::new(delivery_token_address, false),
+            AccountMeta::new(acceptance_token_address, false),
+            AccountMeta::new(feature_id_address, false),
+            AccountMeta::new_readonly(solana_program::system_program::id(), false),
+            AccountMeta::new_readonly(spl_token::id(), false),
+            AccountMeta::new_readonly(sysvar::rent::id(), false),
+        ],
+        data: FeatureProposalInstruction::Propose {
+            tokens_to_mint,
+            acceptance_criteria,
+        }
+        .pack_into_vec(),
+    }
+}
+
+/// Create a `FeatureProposalInstruction::Tally` instruction
+pub fn tally(feature_proposal_address: &Pubkey) -> Instruction {
+    let acceptance_token_address = get_acceptance_token_address(feature_proposal_address);
+    let feature_id_address = get_feature_id_address(feature_proposal_address);
+
+    Instruction {
+        program_id: id(),
+        accounts: vec![
+            AccountMeta::new(*feature_proposal_address, false),
+            AccountMeta::new_readonly(acceptance_token_address, false),
+            AccountMeta::new(feature_id_address, false),
+            AccountMeta::new_readonly(solana_program::system_program::id(), false),
+            AccountMeta::new_readonly(sysvar::clock::id(), false),
+        ],
+        data: FeatureProposalInstruction::Tally.pack_into_vec(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::borsh_utils;
+
+    #[test]
+    fn test_get_packed_len() {
+        assert_eq!(
+            FeatureProposalInstruction::get_packed_len(),
+            borsh_utils::get_packed_len::<FeatureProposalInstruction>()
+        )
+    }
+
+    #[test]
+    fn test_serialize_bytes() {
+        assert_eq!(
+            FeatureProposalInstruction::Tally.try_to_vec().unwrap(),
+            vec![1]
+        );
+
+        assert_eq!(
+            FeatureProposalInstruction::Propose {
+                tokens_to_mint: 42,
+                acceptance_criteria: AcceptanceCriteria {
+                    tokens_required: 0xdeadbeefdeadbeef,
+                    deadline: None,
+                }
+            }
+            .try_to_vec()
+            .unwrap(),
+            vec![0, 42, 0, 0, 0, 0, 0, 0, 0, 239, 190, 173, 222, 239, 190, 173, 222, 0]
+        );
+    }
+
+    #[test]
+    fn test_serialize_large_slice() {
+        let mut dst = vec![0xff; 4];
+        FeatureProposalInstruction::Tally.pack_into_slice(&mut dst);
+
+        // Extra bytes (0xff) ignored
+        assert_eq!(dst, vec![1, 0xff, 0xff, 0xff]);
+    }
+
+    #[test]
+    fn state_deserialize_invalid() {
+        assert_eq!(
+            FeatureProposalInstruction::unpack_from_slice(&[1]),
+            Ok(FeatureProposalInstruction::Tally),
+        );
+
+        // Extra bytes (0xff) ignored...
+        assert_eq!(
+            FeatureProposalInstruction::unpack_from_slice(&[1, 0xff, 0xff, 0xff]),
+            Ok(FeatureProposalInstruction::Tally),
+        );
+
+        assert_eq!(
+            FeatureProposalInstruction::unpack_from_slice(&[2]),
+            Err(ProgramError::InvalidInstructionData),
+        );
+    }
+}

--- a/feature-proposal/program/src/lib.rs
+++ b/feature-proposal/program/src/lib.rs
@@ -1,0 +1,63 @@
+//! Feature Proposal program
+#![deny(missing_docs)]
+#![forbid(unsafe_code)]
+
+pub mod borsh_utils;
+mod entrypoint;
+pub mod instruction;
+pub mod processor;
+pub mod state;
+
+// Export current SDK types for downstream users building with a different SDK version
+pub use solana_program;
+use solana_program::{program_pack::Pack, pubkey::Pubkey};
+
+solana_program::declare_id!("badkenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8kn"); // TODO: Update Id
+
+pub(crate) fn get_mint_address_with_seed(feature_proposal_address: &Pubkey) -> (Pubkey, u8) {
+    Pubkey::find_program_address(&[&feature_proposal_address.to_bytes(), br"mint"], &id())
+}
+
+pub(crate) fn get_delivery_token_address_with_seed(
+    feature_proposal_address: &Pubkey,
+) -> (Pubkey, u8) {
+    Pubkey::find_program_address(&[&feature_proposal_address.to_bytes(), br"delivery"], &id())
+}
+
+pub(crate) fn get_acceptance_token_address_with_seed(
+    feature_proposal_address: &Pubkey,
+) -> (Pubkey, u8) {
+    Pubkey::find_program_address(
+        &[&feature_proposal_address.to_bytes(), br"acceptance"],
+        &id(),
+    )
+}
+
+pub(crate) fn get_feature_id_address_with_seed(feature_proposal_address: &Pubkey) -> (Pubkey, u8) {
+    Pubkey::find_program_address(
+        &[&feature_proposal_address.to_bytes(), br"feature-id"],
+        &id(),
+    )
+}
+
+/// Derive the SPL Token mint address associated with a feature proposal
+pub fn get_mint_address(feature_proposal_address: &Pubkey) -> Pubkey {
+    get_mint_address_with_seed(feature_proposal_address).0
+}
+
+/// Derive the SPL Token token address associated with a feature proposal that receives the initial
+/// minted tokens
+pub fn get_delivery_token_address(feature_proposal_address: &Pubkey) -> Pubkey {
+    get_delivery_token_address_with_seed(feature_proposal_address).0
+}
+
+/// Derive the SPL Token token address associated with a feature proposal that users send their
+/// tokens to accept the proposal
+pub fn get_acceptance_token_address(feature_proposal_address: &Pubkey) -> Pubkey {
+    get_acceptance_token_address_with_seed(feature_proposal_address).0
+}
+
+/// Derive the feature id address associated with the feature proposal
+pub fn get_feature_id_address(feature_proposal_address: &Pubkey) -> Pubkey {
+    get_feature_id_address_with_seed(feature_proposal_address).0
+}

--- a/feature-proposal/program/src/processor.rs
+++ b/feature-proposal/program/src/processor.rs
@@ -1,0 +1,340 @@
+//! Program state processor
+
+use crate::{instruction::*, state::*, *};
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    clock::Clock,
+    entrypoint::ProgramResult,
+    feature::{self, Feature},
+    info,
+    program::{invoke, invoke_signed},
+    program_error::ProgramError,
+    pubkey::Pubkey,
+    rent::Rent,
+    system_instruction,
+    sysvar::Sysvar,
+};
+
+/// Instruction processor
+pub fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    input: &[u8],
+) -> ProgramResult {
+    let instruction = FeatureProposalInstruction::unpack_from_slice(input)?;
+    let account_info_iter = &mut accounts.iter();
+
+    match instruction {
+        FeatureProposalInstruction::Propose {
+            tokens_to_mint,
+            acceptance_criteria,
+        } => {
+            info!("FeatureProposalInstruction::Propose");
+
+            let funder_info = next_account_info(account_info_iter)?;
+            let feature_proposal_info = next_account_info(account_info_iter)?;
+            let mint_info = next_account_info(account_info_iter)?;
+            let delivery_token_info = next_account_info(account_info_iter)?;
+            let acceptance_token_info = next_account_info(account_info_iter)?;
+            let feature_id_info = next_account_info(account_info_iter)?;
+            let system_program_info = next_account_info(account_info_iter)?;
+            let spl_token_program_info = next_account_info(account_info_iter)?;
+            let rent_sysvar_info = next_account_info(account_info_iter)?;
+            let rent = &Rent::from_account_info(rent_sysvar_info)?;
+
+            let (mint_address, mint_bump_seed) =
+                get_mint_address_with_seed(feature_proposal_info.key);
+            if mint_address != *mint_info.key {
+                info!("Error: mint address derivation mismatch");
+                return Err(ProgramError::InvalidArgument);
+            }
+
+            let (delivery_token_address, delivery_token_bump_seed) =
+                get_delivery_token_address_with_seed(feature_proposal_info.key);
+            if delivery_token_address != *delivery_token_info.key {
+                info!("Error: delivery token address derivation mismatch");
+                return Err(ProgramError::InvalidArgument);
+            }
+
+            let (acceptance_token_address, acceptance_token_bump_seed) =
+                get_acceptance_token_address_with_seed(feature_proposal_info.key);
+            if acceptance_token_address != *acceptance_token_info.key {
+                info!("Error: acceptance token address derivation mismatch");
+                return Err(ProgramError::InvalidArgument);
+            }
+
+            let (feature_id_address, feature_id_bump_seed) =
+                get_feature_id_address_with_seed(feature_proposal_info.key);
+            if feature_id_address != *feature_id_info.key {
+                info!("Error: feature-id address derivation mismatch");
+                return Err(ProgramError::InvalidArgument);
+            }
+
+            let mint_signer_seeds: &[&[_]] = &[
+                &feature_proposal_info.key.to_bytes(),
+                br"mint",
+                &[mint_bump_seed],
+            ];
+
+            let delivery_token_signer_seeds: &[&[_]] = &[
+                &feature_proposal_info.key.to_bytes(),
+                br"delivery",
+                &[delivery_token_bump_seed],
+            ];
+
+            let acceptance_token_signer_seeds: &[&[_]] = &[
+                &feature_proposal_info.key.to_bytes(),
+                br"acceptance",
+                &[acceptance_token_bump_seed],
+            ];
+
+            let feature_id_signer_seeds: &[&[_]] = &[
+                &feature_proposal_info.key.to_bytes(),
+                br"feature-id",
+                &[feature_id_bump_seed],
+            ];
+
+            info!("Creating feature proposal account");
+            invoke(
+                &system_instruction::create_account(
+                    funder_info.key,
+                    feature_proposal_info.key,
+                    1.max(rent.minimum_balance(FeatureProposal::get_packed_len())),
+                    FeatureProposal::get_packed_len() as u64,
+                    program_id,
+                ),
+                &[
+                    funder_info.clone(),
+                    feature_proposal_info.clone(),
+                    system_program_info.clone(),
+                ],
+            )?;
+            FeatureProposal::Pending(acceptance_criteria)
+                .pack_into_slice(&mut feature_proposal_info.data.borrow_mut());
+
+            info!("Creating mint");
+            invoke_signed(
+                &system_instruction::create_account(
+                    funder_info.key,
+                    mint_info.key,
+                    1.max(rent.minimum_balance(spl_token::state::Mint::get_packed_len())),
+                    spl_token::state::Mint::get_packed_len() as u64,
+                    &spl_token::id(),
+                ),
+                &[
+                    funder_info.clone(),
+                    mint_info.clone(),
+                    system_program_info.clone(),
+                ],
+                &[&mint_signer_seeds],
+            )?;
+
+            info!("Initializing mint");
+            invoke(
+                &spl_token::instruction::initialize_mint(
+                    &spl_token::id(),
+                    mint_info.key,
+                    mint_info.key,
+                    None,
+                    spl_token::native_mint::DECIMALS,
+                )?,
+                &[
+                    mint_info.clone(),
+                    spl_token_program_info.clone(),
+                    rent_sysvar_info.clone(),
+                ],
+            )?;
+
+            info!("Creating delivery token account");
+            invoke_signed(
+                &system_instruction::create_account(
+                    funder_info.key,
+                    delivery_token_info.key,
+                    1.max(rent.minimum_balance(spl_token::state::Account::get_packed_len())),
+                    spl_token::state::Account::get_packed_len() as u64,
+                    &spl_token::id(),
+                ),
+                &[
+                    funder_info.clone(),
+                    delivery_token_info.clone(),
+                    system_program_info.clone(),
+                ],
+                &[&delivery_token_signer_seeds],
+            )?;
+
+            info!("Initializing delivery token account");
+            invoke(
+                &spl_token::instruction::initialize_account(
+                    &spl_token::id(),
+                    delivery_token_info.key,
+                    mint_info.key,
+                    feature_proposal_info.key,
+                )?,
+                &[
+                    delivery_token_info.clone(),
+                    spl_token_program_info.clone(),
+                    rent_sysvar_info.clone(),
+                    feature_proposal_info.clone(),
+                    mint_info.clone(),
+                ],
+            )?;
+
+            info!("Creating acceptance token account");
+            invoke_signed(
+                &system_instruction::create_account(
+                    funder_info.key,
+                    acceptance_token_info.key,
+                    1.max(rent.minimum_balance(spl_token::state::Account::get_packed_len())),
+                    spl_token::state::Account::get_packed_len() as u64,
+                    &spl_token::id(),
+                ),
+                &[
+                    funder_info.clone(),
+                    acceptance_token_info.clone(),
+                    system_program_info.clone(),
+                ],
+                &[&acceptance_token_signer_seeds],
+            )?;
+
+            info!("Initializing acceptance token account");
+            invoke(
+                &spl_token::instruction::initialize_account(
+                    &spl_token::id(),
+                    acceptance_token_info.key,
+                    mint_info.key,
+                    feature_proposal_info.key,
+                )?,
+                &[
+                    acceptance_token_info.clone(),
+                    spl_token_program_info.clone(),
+                    rent_sysvar_info.clone(),
+                    feature_proposal_info.clone(),
+                    mint_info.clone(),
+                ],
+            )?;
+
+            // Mint `tokens_to_mint` tokens into `delivery_token_account` owned by
+            // `feature_proposal`
+            info!(&format!("Minting {} tokens", tokens_to_mint));
+            invoke_signed(
+                &spl_token::instruction::mint_to(
+                    &spl_token::id(),
+                    mint_info.key,
+                    delivery_token_info.key,
+                    mint_info.key,
+                    &[],
+                    tokens_to_mint,
+                )?,
+                &[
+                    mint_info.clone(),
+                    delivery_token_info.clone(),
+                    spl_token_program_info.clone(),
+                ],
+                &[&mint_signer_seeds],
+            )?;
+
+            // Fully fund the feature id account so the `Tally` instruction will not require any
+            // lamports from the caller
+            info!("Funding feature id account");
+            invoke(
+                &system_instruction::transfer(
+                    funder_info.key,
+                    feature_id_info.key,
+                    1.max(rent.minimum_balance(Feature::size_of())),
+                ),
+                &[
+                    funder_info.clone(),
+                    feature_id_info.clone(),
+                    system_program_info.clone(),
+                ],
+            )?;
+
+            info!("Allocating feature id account");
+            invoke_signed(
+                &system_instruction::allocate(feature_id_info.key, Feature::size_of() as u64),
+                &[feature_id_info.clone(), system_program_info.clone()],
+                &[&feature_id_signer_seeds],
+            )?;
+        }
+
+        FeatureProposalInstruction::Tally => {
+            info!("FeatureProposalInstruction::Tally");
+
+            let feature_proposal_info = next_account_info(account_info_iter)?;
+            let feature_proposal_state =
+                FeatureProposal::unpack_from_slice(&feature_proposal_info.data.borrow())?;
+
+            match feature_proposal_state {
+                FeatureProposal::Pending(acceptance_criteria) => {
+                    let acceptance_token_info = next_account_info(account_info_iter)?;
+                    let feature_id_info = next_account_info(account_info_iter)?;
+                    let system_program_info = next_account_info(account_info_iter)?;
+                    let clock_sysvar_info = next_account_info(account_info_iter)?;
+                    let clock = &Clock::from_account_info(clock_sysvar_info)?;
+
+                    // Re-derive the acceptance token and feature id program addresses to confirm
+                    // the caller provided the correct addresses
+                    let acceptance_token_address =
+                        get_acceptance_token_address(feature_proposal_info.key);
+                    if acceptance_token_address != *acceptance_token_info.key {
+                        info!("Error: acceptance token address derivation mismatch");
+                        return Err(ProgramError::InvalidArgument);
+                    }
+
+                    let (feature_id_address, feature_id_bump_seed) =
+                        get_feature_id_address_with_seed(feature_proposal_info.key);
+                    if feature_id_address != *feature_id_info.key {
+                        info!("Error: feature-id address derivation mismatch");
+                        return Err(ProgramError::InvalidArgument);
+                    }
+
+                    let feature_id_signer_seeds: &[&[_]] = &[
+                        &feature_proposal_info.key.to_bytes(),
+                        br"feature-id",
+                        &[feature_id_bump_seed],
+                    ];
+
+                    if let Some(deadline) = acceptance_criteria.deadline {
+                        if clock.unix_timestamp >= deadline {
+                            info!("Feature proposal expired");
+                            FeatureProposal::Expired
+                                .pack_into_slice(&mut feature_proposal_info.data.borrow_mut());
+                            return Ok(());
+                        }
+                    }
+                    info!("Unpacking acceptance token account");
+                    let acceptance_token =
+                        spl_token::state::Account::unpack(&acceptance_token_info.data.borrow())?;
+
+                    info!(&format!(
+                            "Feature proposal has received {} tokens, and {} tokens required for acceptance",
+                            acceptance_token.amount, acceptance_criteria.tokens_required
+                        ));
+                    if acceptance_token.amount < acceptance_criteria.tokens_required {
+                        info!("Activation threshold has not been reached");
+                        return Ok(());
+                    }
+
+                    info!("Assigning feature id account");
+                    invoke_signed(
+                        &system_instruction::assign(feature_id_info.key, &feature::id()),
+                        &[feature_id_info.clone(), system_program_info.clone()],
+                        &[&feature_id_signer_seeds],
+                    )?;
+
+                    info!("Feature proposal accepted");
+                    FeatureProposal::Accepted {
+                        tokens_upon_acceptance: acceptance_token.amount,
+                    }
+                    .pack_into_slice(&mut feature_proposal_info.data.borrow_mut());
+                }
+                _ => {
+                    info!("Error: feature proposal account not in the pending state");
+                    return Err(ProgramError::InvalidAccountData);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/feature-proposal/program/src/state.rs
+++ b/feature-proposal/program/src/state.rs
@@ -1,0 +1,125 @@
+//! Program state
+use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use solana_program::{
+    clock::UnixTimestamp,
+    info,
+    program_error::ProgramError,
+    program_pack::{Pack, Sealed},
+};
+
+/// Criteria for accepting a feature proposal
+#[derive(Clone, Debug, BorshSerialize, BorshDeserialize, BorshSchema, PartialEq)]
+pub struct AcceptanceCriteria {
+    /// The balance of the feature proposal's token account must be greater than this amount, and
+    /// tallied before the deadline for the feature to be accepted.
+    pub tokens_required: u64,
+
+    /// If the required tokens are not tallied by this deadline then the proposal will expire.
+    /// `None` if the proposal should never expire.
+    pub deadline: Option<UnixTimestamp>,
+}
+
+/// Contents of a Feature Proposal account
+#[derive(Clone, Debug, BorshSerialize, BorshDeserialize, BorshSchema, PartialEq)]
+pub enum FeatureProposal {
+    /// Default account state after creating it
+    Uninitialized,
+    /// Feature proposal is now pending
+    Pending(AcceptanceCriteria),
+    /// Feature proposal was accepted and the feature is now active
+    Accepted {
+        /// The balance of the feature proposal's token account at the time of activation.
+        #[allow(dead_code)] // not dead code..
+        tokens_upon_acceptance: u64,
+    },
+    /// Feature proposal was not accepted before the deadline
+    Expired,
+}
+impl Sealed for FeatureProposal {}
+
+impl Pack for FeatureProposal {
+    const LEN: usize = 18; // see `test_get_packed_len()` for justification of "18"
+
+    fn pack_into_slice(&self, dst: &mut [u8]) {
+        let data = self.try_to_vec().unwrap();
+        dst[..data.len()].copy_from_slice(&data);
+    }
+
+    fn unpack_from_slice(src: &[u8]) -> Result<Self, ProgramError> {
+        let mut mut_src: &[u8] = src;
+        Self::deserialize(&mut mut_src).map_err(|err| {
+            info!(&format!(
+                "Error: failed to deserialize feature proposal account: {}",
+                err
+            ));
+            ProgramError::InvalidAccountData
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::borsh_utils;
+
+    #[test]
+    fn test_get_packed_len() {
+        assert_eq!(
+            FeatureProposal::get_packed_len(),
+            borsh_utils::get_packed_len::<FeatureProposal>()
+        );
+    }
+
+    #[test]
+    fn test_serialize_bytes() {
+        assert_eq!(FeatureProposal::Expired.try_to_vec().unwrap(), vec![3]);
+
+        assert_eq!(
+            FeatureProposal::Pending(AcceptanceCriteria {
+                tokens_required: 0xdeadbeefdeadbeef,
+                deadline: None,
+            })
+            .try_to_vec()
+            .unwrap(),
+            vec![1, 239, 190, 173, 222, 239, 190, 173, 222, 0],
+        );
+
+        assert_eq!(
+            FeatureProposal::Pending(AcceptanceCriteria {
+                tokens_required: 0,
+                deadline: Some(-1),
+            })
+            .try_to_vec()
+            .unwrap(),
+            vec![1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 255, 255, 255, 255, 255, 255, 255, 255],
+        );
+    }
+
+    #[test]
+    fn test_serialize_large_slice() {
+        let mut dst = vec![0xff; 4];
+        FeatureProposal::Expired.pack_into_slice(&mut dst);
+
+        // Extra bytes (0xff) ignored
+        assert_eq!(dst, vec![3, 0xff, 0xff, 0xff]);
+    }
+
+    #[test]
+    fn state_deserialize_invalid() {
+        assert_eq!(
+            FeatureProposal::unpack_from_slice(&[3]),
+            Ok(FeatureProposal::Expired),
+        );
+
+        // Extra bytes (0xff) ignored...
+        assert_eq!(
+            FeatureProposal::unpack_from_slice(&[3, 0xff, 0xff, 0xff]),
+            Ok(FeatureProposal::Expired),
+        );
+
+        assert_eq!(
+            FeatureProposal::unpack_from_slice(&[4]),
+            Err(ProgramError::InvalidAccountData),
+        );
+    }
+}

--- a/feature-proposal/program/tests/functional.rs
+++ b/feature-proposal/program/tests/functional.rs
@@ -1,0 +1,169 @@
+// Mark this test as BPF-only due to current `ProgramTest` limitations when CPIing into the system program
+#![cfg(feature = "test-bpf")]
+
+use futures::{Future, FutureExt};
+use solana_program::{
+    feature::{self, Feature},
+    program_pack::Pack,
+    pubkey::Pubkey,
+    system_program,
+};
+use solana_program_test::*;
+use solana_sdk::{
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
+use spl_feature_proposal::{instruction::*, state::*, *};
+use std::io;
+
+fn program_test() -> ProgramTest {
+    let mut pc = ProgramTest::new(
+        "spl_feature_proposal",
+        id(),
+        processor!(processor::process_instruction),
+    );
+
+    // Add SPL Token program
+    pc.add_program(
+        "spl_token",
+        spl_token::id(),
+        processor!(spl_token::processor::Processor::process),
+    );
+
+    pc
+}
+
+fn get_account<T: Pack>(
+    banks_client: &mut BanksClient,
+    address: Pubkey,
+) -> impl Future<Output = std::io::Result<T>> + '_ {
+    banks_client.get_account(address).map(|result| {
+        let account =
+            result?.ok_or_else(|| io::Error::new(io::ErrorKind::Other, "account not found"))?;
+
+        T::unpack_from_slice(&account.data)
+            .ok()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Failed to deserialize account"))
+    })
+}
+
+#[tokio::test]
+async fn test_basic() {
+    let feature_proposal = Keypair::new();
+
+    let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
+
+    let feature_id_address = get_feature_id_address(&feature_proposal.pubkey());
+
+    // Create a new feature proposal
+    let mut transaction = Transaction::new_with_payer(
+        &[propose(
+            &payer.pubkey(),
+            &feature_proposal.pubkey(),
+            42,
+            AcceptanceCriteria {
+                tokens_required: 42,
+                deadline: None,
+            },
+        )],
+        Some(&payer.pubkey()),
+    );
+    transaction.sign(&[&payer, &feature_proposal], recent_blockhash);
+    banks_client.process_transaction(transaction).await.unwrap();
+
+    // Confirm feature id account is now funded and allocated, but not assigned
+    let feature_id_acccount = banks_client
+        .get_account(feature_id_address)
+        .await
+        .expect("success")
+        .expect("some account");
+    assert_eq!(feature_id_acccount.owner, system_program::id());
+    assert_eq!(feature_id_acccount.data.len(), Feature::size_of());
+
+    // Tally #1: Does nothing because the acceptance criteria has not been met
+    let mut transaction =
+        Transaction::new_with_payer(&[tally(&feature_proposal.pubkey())], Some(&payer.pubkey()));
+    transaction.sign(&[&payer], recent_blockhash);
+    banks_client.process_transaction(transaction).await.unwrap();
+
+    // Confirm feature id account is not yet assigned
+    let feature_id_acccount = banks_client
+        .get_account(feature_id_address)
+        .await
+        .expect("success")
+        .expect("some account");
+    assert_eq!(feature_id_acccount.owner, system_program::id());
+
+    let feature_proposal_acccount = banks_client
+        .get_account(feature_proposal.pubkey())
+        .await
+        .expect("success")
+        .expect("some account");
+    let feature_proposal_acccount =
+        spl_feature_proposal::state::FeatureProposal::unpack_from_slice(
+            &feature_proposal_acccount.data,
+        )
+        .expect("unpack success");
+    assert!(matches!(
+        feature_proposal_acccount,
+        FeatureProposal::Pending(AcceptanceCriteria {
+            tokens_required: 42,
+            deadline: None,
+        })
+    ));
+    assert!(matches!(
+        get_account::<FeatureProposal>(&mut banks_client, feature_proposal.pubkey()).await,
+        Ok(FeatureProposal::Pending(_))
+    ));
+
+    // Transfer tokens to the acceptance account
+    let delivery_token_address = get_delivery_token_address(&feature_proposal.pubkey());
+    let acceptance_token_address = get_acceptance_token_address(&feature_proposal.pubkey());
+
+    let mut transaction = Transaction::new_with_payer(
+        &[spl_token::instruction::transfer(
+            &spl_token::id(),
+            &delivery_token_address,
+            &acceptance_token_address,
+            &feature_proposal.pubkey(),
+            &[],
+            42,
+        )
+        .unwrap()],
+        Some(&payer.pubkey()),
+    );
+    transaction.sign(&[&payer, &feature_proposal], recent_blockhash);
+    banks_client.process_transaction(transaction).await.unwrap();
+
+    // Fetch a new blockhash to avoid the second Tally transaction having the same signature as the
+    // first Tally transaction
+    let recent_blockhash = banks_client
+        .get_new_blockhash(&recent_blockhash)
+        .await
+        .unwrap()
+        .0;
+
+    // Tally #2: the acceptance criteria is now met
+    let mut transaction =
+        Transaction::new_with_payer(&[tally(&feature_proposal.pubkey())], Some(&payer.pubkey()));
+    transaction.sign(&[&payer], recent_blockhash);
+    banks_client.process_transaction(transaction).await.unwrap();
+
+    // Confirm feature id account is now assigned
+    let feature_id_acccount = banks_client
+        .get_account(feature_id_address)
+        .await
+        .expect("success")
+        .expect("some account");
+    assert_eq!(feature_id_acccount.owner, feature::id());
+
+    // Confirm feature proposal account state
+    assert!(matches!(
+        get_account::<FeatureProposal>(&mut banks_client, feature_proposal.pubkey()).await,
+        Ok(FeatureProposal::Accepted {
+            tokens_upon_acceptance: 42
+        })
+    ));
+}
+
+// TODO: more tests....


### PR DESCRIPTION
The Feature Proposal program will allow for Solana runtime features to be activated based on community vote.  The feature proposer is responsible for:
* Submitting the code for the feature itself into the Solana code base, and gating the feature by a feature id
* Once all validators have updated to a version of the software with the new feature, submitting a transaction to initiate the on-chain voting.
* Distributing the SPL Tokens that will be used to vote for the feature using `solana-tokens` (fyi @CriesofCarrots)
* Informing the community that a vote is active, and sharing the SPL Token activation address that used to denote "yes".

Community members then use `spl-token transfer` to vote for the feature activation (or another SPL Token-enabled wallet of their choosing).

Finally the permissionless `Tally` instruction is invoked by anybody to confirm the vote count and affect the runtime feature activation.

TODO:
* [ ] Documentation
* [ ] Comprehensive unit tests
* [ ] CLI integration