### PR TITLE
stake-pool: Add end-to-end testing using ProgramTest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3347,6 +3347,7 @@ name = "spl-stake-pool"
 version = "0.1.0"
 dependencies = [
  "arrayref",
+ "bincode",
  "num-derive",
  "num-traits",
  "num_enum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,13 +684,12 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "2.1.0"
-source = "git+https://github.com/garious/curve25519-dalek?rev=60efef3553d6bf3d7f3b09b5f97acd54d72529ff#60efef3553d6bf3d7f3b09b5f97acd54d72529ff"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
 dependencies = [
- "borsh",
  "byteorder",
  "digest 0.8.1",
  "rand_core",
- "serde",
  "subtle 2.2.3",
  "zeroize",
 ]
@@ -698,12 +697,13 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
+source = "git+https://github.com/garious/curve25519-dalek?rev=60efef3553d6bf3d7f3b09b5f97acd54d72529ff#60efef3553d6bf3d7f3b09b5f97acd54d72529ff"
 dependencies = [
+ "borsh",
  "byteorder",
  "digest 0.8.1",
  "rand_core",
+ "serde",
  "subtle 2.2.3",
  "zeroize",
 ]
@@ -3354,9 +3354,11 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-program",
+ "solana-program-test",
  "solana-sdk",
  "spl-token 3.0.0",
  "thiserror",
+ "tokio 0.3.3",
 ]
 
 [[package]]

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -22,7 +22,9 @@ spl-token = { path = "../../token/program", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 
 [dev-dependencies]
+solana-program-test = "1.4.7"
 solana-sdk = "1.4.7"
+tokio = { version = "0.3", features = ["macros"]}
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -22,6 +22,7 @@ spl-token = { path = "../../token/program", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 
 [dev-dependencies]
+bincode = "1.3.1"
 solana-program-test = "1.4.7"
 solana-sdk = "1.4.7"
 tokio = { version = "0.3", features = ["macros"]}

--- a/stake-pool/program/src/entrypoint.rs
+++ b/stake-pool/program/src/entrypoint.rs
@@ -1,5 +1,7 @@
 //! Program entrypoint
 
+#![cfg(all(target_arch = "bpf", not(feature = "no-entrypoint")))]
+
 use crate::{error::Error, processor::Processor};
 use solana_program::{
     account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,

--- a/stake-pool/program/tests/functional.rs
+++ b/stake-pool/program/tests/functional.rs
@@ -1,0 +1,136 @@
+#![cfg(feature = "test-bpf")]
+
+use solana_program::{hash::Hash, program_pack::Pack, pubkey::Pubkey, system_instruction};
+use solana_program_test::*;
+use solana_sdk::{
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
+use spl_stake_pool::*;
+
+fn program_test() -> ProgramTest {
+    let mut pc = ProgramTest::new(
+        "spl_stake_pool",
+        id(),
+        processor!(processor::Processor::process),
+    );
+
+    // Add SPL Token program
+    pc.add_program(
+        "spl_token",
+        spl_token::id(),
+        processor!(spl_token::processor::Processor::process),
+    );
+
+    pc
+}
+
+async fn create_mint(banks_client: &mut BanksClient, recent_blockhash: &Hash, payer: &Keypair, pool_mint: &Keypair, owner: &Pubkey) {
+    let rent = banks_client.get_rent().await.unwrap();
+    let mint_rent = rent.minimum_balance(spl_token::state::Mint::LEN);
+
+    let mut transaction = Transaction::new_with_payer(
+        &[system_instruction::create_account(
+            &payer.pubkey(),
+            &pool_mint.pubkey(),
+            mint_rent,
+            spl_token::state::Mint::LEN as u64,
+            &spl_token::id(),
+        ),
+        spl_token::instruction::initialize_mint(
+            &spl_token::id(),
+            &pool_mint.pubkey(),
+            &owner,
+            None,
+            0,
+        ).unwrap()],
+        Some(&payer.pubkey()),
+    );
+    transaction.sign(&[payer, pool_mint], *recent_blockhash);
+    banks_client.process_transaction(transaction).await.unwrap();
+}
+
+async fn create_token_account(banks_client: &mut BanksClient, recent_blockhash: &Hash, payer: &Keypair, account: &Keypair, pool_mint: &Pubkey, owner: &Pubkey) {
+    let rent = banks_client.get_rent().await.unwrap();
+    let account_rent = rent.minimum_balance(spl_token::state::Account::LEN);
+
+    let mut transaction = Transaction::new_with_payer(
+        &[system_instruction::create_account(
+            &payer.pubkey(),
+            &account.pubkey(),
+            account_rent,
+            spl_token::state::Account::LEN as u64,
+            &spl_token::id(),
+        ),
+        spl_token::instruction::initialize_account(
+            &spl_token::id(),
+            &account.pubkey(),
+            pool_mint,
+            owner,
+        ).unwrap()],
+        Some(&payer.pubkey()),
+    );
+    transaction.sign(&[payer, account], *recent_blockhash);
+    banks_client.process_transaction(transaction).await.unwrap();
+}
+
+async fn create_stake_pool(banks_client: &mut BanksClient, recent_blockhash: &Hash, payer: &Keypair, stake_pool: &Keypair, pool_mint: &Pubkey, pool_token_account: &Pubkey, owner: &Pubkey) {
+    let rent = banks_client.get_rent().await.unwrap();
+    let rent = rent.minimum_balance(state::State::LEN);
+    let numerator = 1;
+    let denominator = 100;
+    let fee = instruction::Fee { numerator, denominator };
+    let init_args = instruction::InitArgs { fee };
+
+    let mut transaction = Transaction::new_with_payer(
+        &[system_instruction::create_account(
+            &payer.pubkey(),
+            &stake_pool.pubkey(),
+            rent,
+            state::State::LEN as u64,
+            &id(),
+        ),
+        instruction::initialize(
+            &id(),
+            &stake_pool.pubkey(),
+            owner,
+            pool_mint,
+            pool_token_account,
+            &spl_token::id(),
+            init_args,
+        ).unwrap()],
+        Some(&payer.pubkey()),
+    );
+    transaction.sign(&[payer, stake_pool], *recent_blockhash);
+    banks_client.process_transaction(transaction).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_stake_pool_initialize() {
+    let stake_pool = Keypair::new();
+    let stake_pool_address = &stake_pool.pubkey();
+    let (withdraw_authority, _) = Pubkey::find_program_address(
+        &[&stake_pool_address.to_bytes()[..32], b"withdraw"],
+        &id(),
+    );
+    let pool_mint = Keypair::new();
+    let pool_token_account = Keypair::new();
+    let owner_address = Pubkey::new_unique();
+
+    let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
+    create_mint(&mut banks_client, &recent_blockhash, &payer, &pool_mint, &withdraw_authority).await;
+    create_token_account(&mut banks_client, &recent_blockhash, &payer, &pool_token_account, &pool_mint.pubkey(), &owner_address).await;
+    create_stake_pool(&mut banks_client, &recent_blockhash, &payer, &stake_pool, &pool_mint.pubkey(), &pool_token_account.pubkey(), &owner_address).await;
+
+    // Stake pool now exists
+    let stake_pool = banks_client
+        .get_account(*stake_pool_address)
+        .await
+        .expect("get_account")
+        .expect("stake pool not none");
+    assert_eq!(
+        stake_pool.data.len(),
+        state::State::LEN
+    );
+    assert_eq!(stake_pool.owner, id());
+}

--- a/stake-pool/program/tests/functional.rs
+++ b/stake-pool/program/tests/functional.rs
@@ -8,6 +8,10 @@ use solana_sdk::{
 };
 use spl_stake_pool::*;
 
+use bincode::deserialize;
+
+const TEST_STAKE_AMOUNT: u64 = 100;
+
 fn program_test() -> ProgramTest {
     let mut pc = ProgramTest::new(
         "spl_stake_pool",
@@ -27,8 +31,8 @@ fn program_test() -> ProgramTest {
 
 async fn create_mint(
     banks_client: &mut BanksClient,
-    recent_blockhash: &Hash,
     payer: &Keypair,
+    recent_blockhash: &Hash,
     pool_mint: &Keypair,
     owner: &Pubkey,
 ) {
@@ -61,8 +65,8 @@ async fn create_mint(
 
 async fn create_token_account(
     banks_client: &mut BanksClient,
-    recent_blockhash: &Hash,
     payer: &Keypair,
+    recent_blockhash: &Hash,
     account: &Keypair,
     pool_mint: &Pubkey,
     owner: &Pubkey,
@@ -95,8 +99,8 @@ async fn create_token_account(
 
 async fn create_stake_pool(
     banks_client: &mut BanksClient,
-    recent_blockhash: &Hash,
     payer: &Keypair,
+    recent_blockhash: &Hash,
     stake_pool: &Keypair,
     pool_mint: &Pubkey,
     pool_token_account: &Pubkey,
@@ -138,51 +142,215 @@ async fn create_stake_pool(
     banks_client.process_transaction(transaction).await.unwrap();
 }
 
+async fn create_stake_account(
+    banks_client: &mut BanksClient,
+    payer: &Keypair,
+    recent_blockhash: &Hash,
+    stake: &Keypair,
+    authorized: &stake::Authorized,
+    lockup: &stake::Lockup,
+) {
+    let rent = banks_client.get_rent().await.unwrap();
+    let lamports =
+        rent.minimum_balance(std::mem::size_of::<stake::StakeState>()) + TEST_STAKE_AMOUNT;
+
+    let mut transaction = Transaction::new_with_payer(
+        &stake::create_account(
+            &payer.pubkey(),
+            &stake.pubkey(),
+            authorized,
+            lockup,
+            lamports,
+        ),
+        Some(&payer.pubkey()),
+    );
+    transaction.sign(&[payer, stake], *recent_blockhash);
+    banks_client.process_transaction(transaction).await.unwrap();
+}
+
+struct StakePoolAccounts {
+    pub stake_pool: Keypair,
+    pub pool_mint: Keypair,
+    pub pool_fee_account: Keypair,
+    pub owner: Pubkey,
+    pub withdraw_authority: Pubkey,
+    pub deposit_authority: Pubkey,
+}
+
+impl StakePoolAccounts {
+    pub fn new() -> Self {
+        let stake_pool = Keypair::new();
+        let stake_pool_address = &stake_pool.pubkey();
+        let (withdraw_authority, _) = Pubkey::find_program_address(
+            &[&stake_pool_address.to_bytes()[..32], b"withdraw"],
+            &id(),
+        );
+        let (deposit_authority, _) = Pubkey::find_program_address(
+            &[&stake_pool_address.to_bytes()[..32], b"deposit"],
+            &id(),
+        );
+        let pool_mint = Keypair::new();
+        let pool_fee_account = Keypair::new();
+        let owner = Pubkey::new_unique();
+
+        Self {
+            stake_pool,
+            pool_mint,
+            pool_fee_account,
+            owner,
+            withdraw_authority,
+            deposit_authority,
+        }
+    }
+
+    pub async fn initialize_stake_pool(
+        &self,
+        mut banks_client: &mut BanksClient,
+        payer: &Keypair,
+        recent_blockhash: &Hash,
+    ) {
+        create_mint(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            &self.pool_mint,
+            &self.withdraw_authority,
+        )
+        .await;
+        create_token_account(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            &self.pool_fee_account,
+            &self.pool_mint.pubkey(),
+            &self.owner,
+        )
+        .await;
+        create_stake_pool(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            &self.stake_pool,
+            &self.pool_mint.pubkey(),
+            &self.pool_fee_account.pubkey(),
+            &self.owner,
+        )
+        .await;
+    }
+
+    pub async fn deposit_stake(
+        &self,
+        stake: &Pubkey,
+        pool_account: &Pubkey,
+        banks_client: &mut BanksClient,
+        payer: &Keypair,
+        recent_blockhash: &Hash,
+    ) {
+        let mut transaction = Transaction::new_with_payer(
+            &[instruction::deposit(
+                &id(),
+                &self.stake_pool.pubkey(),
+                &self.deposit_authority,
+                &self.withdraw_authority,
+                stake,
+                pool_account,
+                &self.pool_fee_account.pubkey(),
+                &self.pool_mint.pubkey(),
+                &spl_token::id(),
+                &stake::id(),
+            )
+            .unwrap()],
+            Some(&payer.pubkey()),
+        );
+        transaction.sign(&[payer], *recent_blockhash);
+        banks_client.process_transaction(transaction).await.unwrap();
+    }
+}
+
 #[tokio::test]
 async fn test_stake_pool_initialize() {
-    let stake_pool = Keypair::new();
-    let stake_pool_address = &stake_pool.pubkey();
-    let (withdraw_authority, _) =
-        Pubkey::find_program_address(&[&stake_pool_address.to_bytes()[..32], b"withdraw"], &id());
-    let pool_mint = Keypair::new();
-    let pool_token_account = Keypair::new();
-    let owner_address = Pubkey::new_unique();
-
     let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
-    create_mint(
-        &mut banks_client,
-        &recent_blockhash,
-        &payer,
-        &pool_mint,
-        &withdraw_authority,
-    )
-    .await;
-    create_token_account(
-        &mut banks_client,
-        &recent_blockhash,
-        &payer,
-        &pool_token_account,
-        &pool_mint.pubkey(),
-        &owner_address,
-    )
-    .await;
-    create_stake_pool(
-        &mut banks_client,
-        &recent_blockhash,
-        &payer,
-        &stake_pool,
-        &pool_mint.pubkey(),
-        &pool_token_account.pubkey(),
-        &owner_address,
-    )
-    .await;
+    let stake_pool_accounts = StakePoolAccounts::new();
+    stake_pool_accounts
+        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash)
+        .await;
 
     // Stake pool now exists
     let stake_pool = banks_client
-        .get_account(*stake_pool_address)
+        .get_account(stake_pool_accounts.stake_pool.pubkey())
         .await
         .expect("get_account")
         .expect("stake pool not none");
     assert_eq!(stake_pool.data.len(), state::State::LEN);
     assert_eq!(stake_pool.owner, id());
+}
+
+#[tokio::test]
+async fn test_stake_pool_deposit() {
+    let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
+    let stake_pool_accounts = StakePoolAccounts::new();
+    stake_pool_accounts
+        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash)
+        .await;
+
+    let user = Keypair::new();
+    // make stake account
+    let user_stake = Keypair::new();
+    let lockup = stake::Lockup::default();
+    let authorized = stake::Authorized {
+        staker: stake_pool_accounts.deposit_authority.clone(),
+        withdrawer: stake_pool_accounts.deposit_authority.clone(),
+    };
+    create_stake_account(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        &user_stake,
+        &authorized,
+        &lockup,
+    )
+    .await;
+    // make pool token account
+    let user_pool_account = Keypair::new();
+    create_token_account(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        &user_pool_account,
+        &stake_pool_accounts.pool_mint.pubkey(),
+        &user.pubkey(),
+    )
+    .await;
+    stake_pool_accounts
+        .deposit_stake(
+            &user_stake.pubkey(),
+            &user_pool_account.pubkey(),
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+        )
+        .await;
+
+    let stake = banks_client
+        .get_account(user_stake.pubkey())
+        .await
+        .expect("get_account")
+        .expect("stake not none");
+    assert_eq!(stake.data.len(), std::mem::size_of::<stake::StakeState>());
+    assert_eq!(stake.owner, stake::id());
+
+    let stake_state = deserialize::<stake::StakeState>(&stake.data).unwrap();
+    match stake_state {
+        stake::StakeState::Initialized(meta) => {
+            assert_eq!(
+                &meta.authorized.staker,
+                &stake_pool_accounts.withdraw_authority
+            );
+            assert_eq!(
+                &meta.authorized.withdrawer,
+                &stake_pool_accounts.withdraw_authority
+            );
+        }
+        _ => assert!(false),
+    }
 }

--- a/stake-pool/program/tests/functional.rs
+++ b/stake-pool/program/tests/functional.rs
@@ -25,80 +25,113 @@ fn program_test() -> ProgramTest {
     pc
 }
 
-async fn create_mint(banks_client: &mut BanksClient, recent_blockhash: &Hash, payer: &Keypair, pool_mint: &Keypair, owner: &Pubkey) {
+async fn create_mint(
+    banks_client: &mut BanksClient,
+    recent_blockhash: &Hash,
+    payer: &Keypair,
+    pool_mint: &Keypair,
+    owner: &Pubkey,
+) {
     let rent = banks_client.get_rent().await.unwrap();
     let mint_rent = rent.minimum_balance(spl_token::state::Mint::LEN);
 
     let mut transaction = Transaction::new_with_payer(
-        &[system_instruction::create_account(
-            &payer.pubkey(),
-            &pool_mint.pubkey(),
-            mint_rent,
-            spl_token::state::Mint::LEN as u64,
-            &spl_token::id(),
-        ),
-        spl_token::instruction::initialize_mint(
-            &spl_token::id(),
-            &pool_mint.pubkey(),
-            &owner,
-            None,
-            0,
-        ).unwrap()],
+        &[
+            system_instruction::create_account(
+                &payer.pubkey(),
+                &pool_mint.pubkey(),
+                mint_rent,
+                spl_token::state::Mint::LEN as u64,
+                &spl_token::id(),
+            ),
+            spl_token::instruction::initialize_mint(
+                &spl_token::id(),
+                &pool_mint.pubkey(),
+                &owner,
+                None,
+                0,
+            )
+            .unwrap(),
+        ],
         Some(&payer.pubkey()),
     );
     transaction.sign(&[payer, pool_mint], *recent_blockhash);
     banks_client.process_transaction(transaction).await.unwrap();
 }
 
-async fn create_token_account(banks_client: &mut BanksClient, recent_blockhash: &Hash, payer: &Keypair, account: &Keypair, pool_mint: &Pubkey, owner: &Pubkey) {
+async fn create_token_account(
+    banks_client: &mut BanksClient,
+    recent_blockhash: &Hash,
+    payer: &Keypair,
+    account: &Keypair,
+    pool_mint: &Pubkey,
+    owner: &Pubkey,
+) {
     let rent = banks_client.get_rent().await.unwrap();
     let account_rent = rent.minimum_balance(spl_token::state::Account::LEN);
 
     let mut transaction = Transaction::new_with_payer(
-        &[system_instruction::create_account(
-            &payer.pubkey(),
-            &account.pubkey(),
-            account_rent,
-            spl_token::state::Account::LEN as u64,
-            &spl_token::id(),
-        ),
-        spl_token::instruction::initialize_account(
-            &spl_token::id(),
-            &account.pubkey(),
-            pool_mint,
-            owner,
-        ).unwrap()],
+        &[
+            system_instruction::create_account(
+                &payer.pubkey(),
+                &account.pubkey(),
+                account_rent,
+                spl_token::state::Account::LEN as u64,
+                &spl_token::id(),
+            ),
+            spl_token::instruction::initialize_account(
+                &spl_token::id(),
+                &account.pubkey(),
+                pool_mint,
+                owner,
+            )
+            .unwrap(),
+        ],
         Some(&payer.pubkey()),
     );
     transaction.sign(&[payer, account], *recent_blockhash);
     banks_client.process_transaction(transaction).await.unwrap();
 }
 
-async fn create_stake_pool(banks_client: &mut BanksClient, recent_blockhash: &Hash, payer: &Keypair, stake_pool: &Keypair, pool_mint: &Pubkey, pool_token_account: &Pubkey, owner: &Pubkey) {
+async fn create_stake_pool(
+    banks_client: &mut BanksClient,
+    recent_blockhash: &Hash,
+    payer: &Keypair,
+    stake_pool: &Keypair,
+    pool_mint: &Pubkey,
+    pool_token_account: &Pubkey,
+    owner: &Pubkey,
+) {
     let rent = banks_client.get_rent().await.unwrap();
     let rent = rent.minimum_balance(state::State::LEN);
     let numerator = 1;
     let denominator = 100;
-    let fee = instruction::Fee { numerator, denominator };
+    let fee = instruction::Fee {
+        numerator,
+        denominator,
+    };
     let init_args = instruction::InitArgs { fee };
 
     let mut transaction = Transaction::new_with_payer(
-        &[system_instruction::create_account(
-            &payer.pubkey(),
-            &stake_pool.pubkey(),
-            rent,
-            state::State::LEN as u64,
-            &id(),
-        ),
-        instruction::initialize(
-            &id(),
-            &stake_pool.pubkey(),
-            owner,
-            pool_mint,
-            pool_token_account,
-            &spl_token::id(),
-            init_args,
-        ).unwrap()],
+        &[
+            system_instruction::create_account(
+                &payer.pubkey(),
+                &stake_pool.pubkey(),
+                rent,
+                state::State::LEN as u64,
+                &id(),
+            ),
+            instruction::initialize(
+                &id(),
+                &stake_pool.pubkey(),
+                owner,
+                pool_mint,
+                pool_token_account,
+                &spl_token::id(),
+                init_args,
+            )
+            .unwrap(),
+        ],
         Some(&payer.pubkey()),
     );
     transaction.sign(&[payer, stake_pool], *recent_blockhash);
@@ -109,18 +142,40 @@ async fn create_stake_pool(banks_client: &mut BanksClient, recent_blockhash: &Ha
 async fn test_stake_pool_initialize() {
     let stake_pool = Keypair::new();
     let stake_pool_address = &stake_pool.pubkey();
-    let (withdraw_authority, _) = Pubkey::find_program_address(
-        &[&stake_pool_address.to_bytes()[..32], b"withdraw"],
-        &id(),
-    );
+    let (withdraw_authority, _) =
+        Pubkey::find_program_address(&[&stake_pool_address.to_bytes()[..32], b"withdraw"], &id());
     let pool_mint = Keypair::new();
     let pool_token_account = Keypair::new();
     let owner_address = Pubkey::new_unique();
 
     let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
-    create_mint(&mut banks_client, &recent_blockhash, &payer, &pool_mint, &withdraw_authority).await;
-    create_token_account(&mut banks_client, &recent_blockhash, &payer, &pool_token_account, &pool_mint.pubkey(), &owner_address).await;
-    create_stake_pool(&mut banks_client, &recent_blockhash, &payer, &stake_pool, &pool_mint.pubkey(), &pool_token_account.pubkey(), &owner_address).await;
+    create_mint(
+        &mut banks_client,
+        &recent_blockhash,
+        &payer,
+        &pool_mint,
+        &withdraw_authority,
+    )
+    .await;
+    create_token_account(
+        &mut banks_client,
+        &recent_blockhash,
+        &payer,
+        &pool_token_account,
+        &pool_mint.pubkey(),
+        &owner_address,
+    )
+    .await;
+    create_stake_pool(
+        &mut banks_client,
+        &recent_blockhash,
+        &payer,
+        &stake_pool,
+        &pool_mint.pubkey(),
+        &pool_token_account.pubkey(),
+        &owner_address,
+    )
+    .await;
 
     // Stake pool now exists
     let stake_pool = banks_client
@@ -128,9 +183,6 @@ async fn test_stake_pool_initialize() {
         .await
         .expect("get_account")
         .expect("stake pool not none");
-    assert_eq!(
-        stake_pool.data.len(),
-        state::State::LEN
-    );
+    assert_eq!(stake_pool.data.len(), state::State::LEN);
     assert_eq!(stake_pool.owner, id());
 }

--- a/token/program/Cargo.toml
+++ b/token/program/Cargo.toml
@@ -16,7 +16,7 @@ arrayref = "0.3.6"
 num-derive = "0.3"
 num-traits = "0.2"
 num_enum = "0.5.1"
-solana-program = "1.4.6"
+solana-program = "1.4.7"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/token/program/Cargo.toml
+++ b/token/program/Cargo.toml
@@ -16,7 +16,7 @@ arrayref = "0.3.6"
 num-derive = "0.3"
 num-traits = "0.2"
 num_enum = "0.5.1"
-solana-program = "1.4.7"
+solana-program = "1.4.6"
 thiserror = "1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
stake pool unit tests can only cover the local logic, since it isn't possible to extract the stake program processor like we can with spl_token.  This adds the capability to run tests against the real stake program processor using ProgramTest.