### PR TITLE
Fix u64.fromBuffer return type to u64

### DIFF
--- a/token-swap/js/client/token-swap.js
+++ b/token-swap/js/client/token-swap.js
@@ -43,7 +43,7 @@ export class Numberu64 extends BN {
    */
   static fromBuffer(buffer: typeof Buffer): Numberu64 {
     assert(buffer.length === 8, `Invalid buffer length: ${buffer.length}`);
-    return new BN(
+    return new Numberu64(
       [...buffer]
         .reverse()
         .map(i => `00${i.toString(16)}`.slice(-2))

--- a/token/js/client/token.js
+++ b/token/js/client/token.js
@@ -51,7 +51,7 @@ export class u64 extends BN {
    */
   static fromBuffer(buffer: typeof Buffer): u64 {
     assert(buffer.length === 8, `Invalid buffer length: ${buffer.length}`);
-    return new BN(
+    return new u64(
       [...buffer]
         .reverse()
         .map(i => `00${i.toString(16)}`.slice(-2))


### PR DESCRIPTION
`fromBuffer` expects the return type to be `u64` or `Numberu64` but returns `BN` instead. This causes errors downstream if a user tries to call `toBuffer`, which only exists on `u64`.