### PR TITLE
Remove entrypoint bpf cfg check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,19 +690,6 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
-dependencies = [
- "byteorder",
- "digest 0.8.1",
- "rand_core",
- "subtle 2.2.3",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "2.1.0"
 source = "git+https://github.com/garious/curve25519-dalek?rev=60efef3553d6bf3d7f3b09b5f97acd54d72529ff#60efef3553d6bf3d7f3b09b5f97acd54d72529ff"
 dependencies = [
  "borsh",
@@ -710,6 +697,19 @@ dependencies = [
  "digest 0.8.1",
  "rand_core",
  "serde",
+ "subtle 2.2.3",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
+dependencies = [
+ "byteorder",
+ "digest 0.8.1",
+ "rand_core",
  "subtle 2.2.3",
  "zeroize",
 ]
@@ -3322,7 +3322,7 @@ dependencies = [
 
 [[package]]
 name = "spl-feature-proposal"
-version = "1.0.0-pre1"
+version = "1.0.0-pre2"
 dependencies = [
  "borsh",
  "borsh-derive",

--- a/associated-token-account/program/src/entrypoint.rs
+++ b/associated-token-account/program/src/entrypoint.rs
@@ -1,6 +1,6 @@
 //! Program entrypoint
 
-#![cfg(all(target_arch = "bpf", not(feature = "no-entrypoint")))]
+#![cfg(not(feature = "no-entrypoint"))]
 
 use solana_program::{
     account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,

--- a/examples/rust/cross-program-invocation/src/entrypoint.rs
+++ b/examples/rust/cross-program-invocation/src/entrypoint.rs
@@ -1,6 +1,6 @@
 //! Program entrypoint
 
-#![cfg(all(target_arch = "bpf", not(feature = "no-entrypoint")))]
+#![cfg(not(feature = "no-entrypoint"))]
 
 use solana_program::{
     account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,

--- a/examples/rust/custom-heap/src/entrypoint.rs
+++ b/examples/rust/custom-heap/src/entrypoint.rs
@@ -1,6 +1,6 @@
 //! Program entrypoint
 
-#![cfg(all(target_arch = "bpf", not(feature = "no-entrypoint")))]
+#![cfg(not(feature = "no-entrypoint"))]
 
 use solana_program::{
     account_info::AccountInfo,
@@ -40,7 +40,7 @@ unsafe impl std::alloc::GlobalAlloc for BumpAllocator {
     }
 }
 
-#[cfg(not(test))]
+#[cfg(target_arch = "bpf")]
 #[global_allocator]
 static A: BumpAllocator = BumpAllocator;
 

--- a/examples/rust/logging/src/entrypoint.rs
+++ b/examples/rust/logging/src/entrypoint.rs
@@ -1,6 +1,6 @@
 //! Program entrypoint
 
-#![cfg(all(target_arch = "bpf", not(feature = "no-entrypoint")))]
+#![cfg(not(feature = "no-entrypoint"))]
 
 use solana_program::{
     account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,

--- a/examples/rust/sysvar/src/entrypoint.rs
+++ b/examples/rust/sysvar/src/entrypoint.rs
@@ -1,6 +1,6 @@
 //! Program entrypoint
 
-#![cfg(all(target_arch = "bpf", not(feature = "no-entrypoint")))]
+#![cfg(not(feature = "no-entrypoint"))]
 
 use solana_program::{
     account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,

--- a/examples/rust/transfer-lamports/src/entrypoint.rs
+++ b/examples/rust/transfer-lamports/src/entrypoint.rs
@@ -1,6 +1,6 @@
 //! Program entrypoint
 
-#![cfg(all(target_arch = "bpf", not(feature = "no-entrypoint")))]
+#![cfg(not(feature = "no-entrypoint"))]
 
 use solana_program::{
     account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,


### PR DESCRIPTION
BPF cfg check has been moved into the `entrypoint` macro where it belongs, remove the unnecessary checks in the programs.