### PR TITLE
Add spl-feature-proposal-cli and documentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3322,7 +3322,7 @@ dependencies = [
 
 [[package]]
 name = "spl-feature-proposal"
-version = "1.0.0-pre2"
+version = "1.0.0-pre3"
 dependencies = [
  "borsh",
  "borsh-derive",
@@ -3332,6 +3332,19 @@ dependencies = [
  "solana-sdk",
  "spl-token 3.0.0",
  "tokio 0.3.3",
+]
+
+[[package]]
+name = "spl-feature-proposal-cli"
+version = "1.0.0"
+dependencies = [
+ "clap",
+ "solana-clap-utils",
+ "solana-cli-config",
+ "solana-client",
+ "solana-logger",
+ "solana-sdk",
+ "spl-feature-proposal",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "examples/rust/sysvar",
   "examples/rust/transfer-lamports",
   "feature-proposal/program",
+  "feature-proposal/cli",
   "memo/program",
   "shared-memory/program",
   "stake-pool/cli",

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -10,6 +10,7 @@ module.exports = {
       "memo",
       "shared-memory",
       "stake-pool",
+      "feature-proposal",
     ],
   },
 };

--- a/docs/src/feature-proposal.md
+++ b/docs/src/feature-proposal.md
@@ -111,7 +111,7 @@ Distribute the proposal tokens to all validators by running:
     $ solana-tokens distribute-spl-tokens --from GK55hNft4TGc3Hg4KzbjEmju8VfaNuXK8jQNDTZKcsNF --input-csv feature-proposal.csv --db-path db.8CyUVvio --fee-payer ~/.config/solana/id.json --owner <FEATURE_PROPOSAL_KEYPAIR>
     $ solana-tokens spl-token-balances --mint ALvA7Lv9jbo8JFhxqnRpjWWuR3aD12uCb5KBJst4uc3d --input-csv feature-proposal.csv
 
-Once the distribution is complete, request validators vote for the proposal by first looking up their token account address:
+Once the distribution is complete, request validators vote for the proposal. To vote, validators should first look up their token account address:
     $ spl-token --owner ~/validator-keypair.json accounts ALvA7Lv9jbo8JFhxqnRpjWWuR3aD12uCb5KBJst4uc3d
 and then submit their vote by running:
     $ spl-token --owner ~/validator-keypair.json transfer <TOKEN_ACCOUNT_ADDRESS> ALL AdqKm3mSJf8AtTWjfpA5ZbJszWQPcwyLA2XkRyLbf3Di

--- a/docs/src/feature-proposal.md
+++ b/docs/src/feature-proposal.md
@@ -99,7 +99,7 @@ This is done by running:
 $ spl-feature-proposal propose feature-proposal.json
 Feature Id: HQ3baDfNU7WKCyWvtMYZmi51YPs7vhSiLn1ESYp3jhiA
 Token Mint Address: ALvA7Lv9jbo8JFhxqnRpjWWuR3aD12uCb5KBJst4uc3d
-Delivery Token Address: GK55hNft4TGc3Hg4KzbjEmju8VfaNuXK8jQNDTZKcsNF
+Distributor Token Address: GK55hNft4TGc3Hg4KzbjEmju8VfaNuXK8jQNDTZKcsNF
 Acceptance Token Address: AdqKm3mSJf8AtTWjfpA5ZbJszWQPcwyLA2XkRyLbf3Di
 Number of validators: 376
 Tokens to be minted: 134575791.53064314

--- a/docs/src/feature-proposal.md
+++ b/docs/src/feature-proposal.md
@@ -1,0 +1,147 @@
+---
+title: Feature Proposal Program
+---
+
+The Feature Proposal Program provides a workflow for activation of Solana
+network features through community vote based on validator stake weight.
+
+Community voting is accomplished using [SPL Tokens](token.md).  Tokens are
+minted that represent the total active stake on the network, and distributed to
+all validators based on their stake.  Validators vote for feature activation by
+transferring their vote tokens to a predetermined address.  Once the vote
+threshold is met the feature is activated.
+
+## Background
+
+The Solana validator software supports runtime feature activation through the
+built-in `Feature` program.  This program ensures that features are activated
+simultaneously across all validators to avoid divergent behavior that would
+cause hard forks or otherwise break consensus.
+
+The
+[feature](https://docs.rs/solana-program/latest/solana_program/feature/index.html)
+and [feature_set](https://docs.rs/solana-sdk/latest/solana_sdk/feature_set/index.html)
+Rust modules are the primitives for this facility, and the `solana feature`
+command-line subcommands allow for easy feature status inspection and feature
+activation.
+
+The `solana feature activate` workflow was designed for use by the core Solana
+developers to allow for low-overhead addition of non-controversial network
+features over time.
+
+The Feature Proposal Program provides an additional mechanism over these runtime
+feature activation primitives to permit feature activation by community vote
+when appropriate.
+
+## Source
+The Feature Proposal Program's source is available on
+[github](https://github.com/solana-labs/solana-program-library)
+
+## Interface
+The Feature Proposal Program is written in Rust and available on [crates.io](https://crates.io/crates/spl-feature-proposal) and [docs.rs](https://docs.rs/spl-feature-proposal).
+
+## Command-line Utility
+The `spl-feature-proposal` command-line utility can be used to manage feature
+proposal.  Once you have [Rust installed](https://rustup.rs/), run:
+```sh
+$ cargo install spl-feature-proposal-cli
+```
+
+Run `spl-feature-proposal --help` for a full description of available commands.
+
+### Configuration
+The `spl-feature-proposal` configuration is shared with the `solana` command-line tool.
+
+## Feature Proposal Life Cycle
+
+This section describes the life cycle of a feature proposal.
+
+### Implement The Feature
+The first step is to conceive of the new feature and realize it in the
+Solana code base, working with the core Solana developers at https://github.com/solana-labs/solana.
+
+During the implementation, a *feature id* will be required to identity the new
+feature in the code base to avoid the new functionality until its activation.
+The *feature id* for a feature proposal is derived by running the following
+commands.
+
+First create a keypair for the proposal:
+```
+$ solana-keygen new --outfile feature-proposal.json --silent --no-passphrase
+Wrote new keypair to feature-proposal.json
+```
+
+Now run the `spl-feature-proposal` program to derive the *feature id*:
+```
+$ spl-feature-proposal address feature-proposal.json
+Feature Id: HQ3baDfNU7WKCyWvtMYZmi51YPs7vhSiLn1ESYp3jhiA
+Token Mint Address: ALvA7Lv9jbo8JFhxqnRpjWWuR3aD12uCb5KBJst4uc3d
+Acceptance Token Address: AdqKm3mSJf8AtTWjfpA5ZbJszWQPcwyLA2XkRyLbf3Di
+```
+which in this case is `HQ3baDfNU7WKCyWvtMYZmi51YPs7vhSiLn1ESYp3jhiA`.
+
+`HQ3baDfNU7WKCyWvtMYZmi51YPs7vhSiLn1ESYp3jhiA` is the identifier that will be
+used in the code base and eventually will be visible in the `solana feature status` command.
+
+Note however that it is not possible to use `solana feature activate` to
+activate this feature, as there is no private key for
+`HQ3baDfNU7WKCyWvtMYZmi51YPs7vhSiLn1ESYp3jhiA`.  Activation of this feature is
+only possible by the Feature Proposal Program.
+
+### Initiate the Feature Proposal
+
+After the feature is implemented and deployed to the Solana cluster,
+the *feature id* will be visible in `solana feature status` and the *feature
+proposer* may initiate the community proposal process.
+
+This is done by running:
+```
+$ spl-feature-proposal propose feature-proposal.json
+Feature Id: HQ3baDfNU7WKCyWvtMYZmi51YPs7vhSiLn1ESYp3jhiA
+Token Mint Address: ALvA7Lv9jbo8JFhxqnRpjWWuR3aD12uCb5KBJst4uc3d
+Delivery Token Address: GK55hNft4TGc3Hg4KzbjEmju8VfaNuXK8jQNDTZKcsNF
+Acceptance Token Address: AdqKm3mSJf8AtTWjfpA5ZbJszWQPcwyLA2XkRyLbf3Di
+Number of validators: 376
+Tokens to be minted: 134575791.53064314
+Tokens required for acceptance: 90165780.3255309 (67%)
+Token distribution file: feature-proposal.csv
+JSON RPC URL: http://api.mainnet-beta.solana.com
+
+Distribute the proposal tokens to all validators by running:
+    $ solana-tokens distribute-spl-tokens --from GK55hNft4TGc3Hg4KzbjEmju8VfaNuXK8jQNDTZKcsNF --input-csv feature-proposal.csv --db-path db.8CyUVvio --fee-payer ~/.config/solana/id.json --owner <FEATURE_PROPOSAL_KEYPAIR>
+    $ solana-tokens spl-token-balances --mint ALvA7Lv9jbo8JFhxqnRpjWWuR3aD12uCb5KBJst4uc3d --input-csv feature-proposal.csv
+
+Once the distribution is complete, request validators vote for the proposal by first looking up their token account address:
+    $ spl-token --owner ~/validator-keypair.json accounts ALvA7Lv9jbo8JFhxqnRpjWWuR3aD12uCb5KBJst4uc3d
+and then submit their vote by running:
+    $ spl-token --owner ~/validator-keypair.json transfer <TOKEN_ACCOUNT_ADDRESS> ALL AdqKm3mSJf8AtTWjfpA5ZbJszWQPcwyLA2XkRyLbf3Di
+
+Periodically the votes must be tallied by running:
+  $ spl-feature-proposal tally 8CyUVvio2oYAP28ZkMBPHq88ikhRgWet6i4NYsCW5Cxa
+Tallying is permissionless and may be run by anybody.
+Once this feature proposal is accepted, the HQ3baDfNU7WKCyWvtMYZmi51YPs7vhSiLn1ESYp3jhiA feature will be activated at the next epoch.
+
+Add --confirm flag to initiate the feature proposal
+```
+
+If the output looks good run the command again with the `--confirm` flag to
+continue, and then follow the remaining steps in the output to distribute the
+vote tokens to all the validators.
+
+**COST:** As a part of token distribution, the *feature proposer* will be
+financing the creation of SPL Token accounts for each of the validators.  A SPL
+Token account requires 0.00203928 SOL at creation, so the cost for initiating a
+feature proposal on a network with 500 validators is approximately 1 SOL.
+
+### Tally the Votes
+
+After advertising to the validators that a feature proposal is pending their
+acceptance, the votes are tallied by running:
+```
+$ spl-feature-proposal tally 8CyUVvio2oYAP28ZkMBPHq88ikhRgWet6i4NYsCW5Cxa
+```
+Anybody may tally the vote.  Once the required number of votes are tallied, the
+feature will be automatically activated at the start of the next epoch.
+
+Upon a successful activation the feature will now show as activated by
+`solana feature status` as well.

--- a/feature-proposal/cli/Cargo.toml
+++ b/feature-proposal/cli/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "spl-feature-proposal-cli"
+version = "1.0.0"
+description = "SPL Feature Proposal Command-line Utility"
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+repository = "https://github.com/solana-labs/solana-program-library"
+license = "Apache-2.0"
+edition = "2018"
+
+[dependencies]
+clap = "2.33.3"
+solana-clap-utils = "1.4.8"
+solana-cli-config = "1.4.8"
+solana-client = "1.4.8"
+solana-logger = "1.4.8"
+solana-sdk = "1.4.8"
+spl-feature-proposal = { version = "1.0.0-pre3", path = "../program", features = ["no-entrypoint"] }
+
+[[bin]]
+name = "spl-feature-proposal"
+path = "src/main.rs"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/feature-proposal/cli/src/main.rs
+++ b/feature-proposal/cli/src/main.rs
@@ -1,0 +1,452 @@
+use {
+    clap::{
+        crate_description, crate_name, crate_version, value_t_or_exit, App, AppSettings, Arg,
+        SubCommand,
+    },
+    solana_clap_utils::{
+        input_parsers::{keypair_of, pubkey_of},
+        input_validators::{is_keypair, is_url, is_valid_percentage, is_valid_pubkey},
+    },
+    solana_client::rpc_client::RpcClient,
+    solana_sdk::{
+        commitment_config::CommitmentConfig,
+        program_pack::Pack,
+        pubkey::Pubkey,
+        signature::{read_keypair_file, Keypair, Signer},
+        transaction::Transaction,
+    },
+    spl_feature_proposal::state::{AcceptanceCriteria, FeatureProposal},
+    std::{fs::File, io::Write},
+};
+
+struct Config {
+    keypair: Keypair,
+    json_rpc_url: String,
+    verbose: bool,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let app_matches = App::new(crate_name!())
+        .about(crate_description!())
+        .version(crate_version!())
+        .setting(AppSettings::SubcommandRequiredElseHelp)
+        .arg({
+            let arg = Arg::with_name("config_file")
+                .short("C")
+                .long("config")
+                .value_name("PATH")
+                .takes_value(true)
+                .global(true)
+                .help("Configuration file to use");
+            if let Some(ref config_file) = *solana_cli_config::CONFIG_FILE {
+                arg.default_value(&config_file)
+            } else {
+                arg
+            }
+        })
+        .arg(
+            Arg::with_name("keypair")
+                .long("keypair")
+                .value_name("KEYPAIR")
+                .validator(is_keypair)
+                .takes_value(true)
+                .global(true)
+                .help("Filepath or URL to a keypair [default: client keypair]"),
+        )
+        .arg(
+            Arg::with_name("verbose")
+                .long("verbose")
+                .short("v")
+                .takes_value(false)
+                .global(true)
+                .help("Show additional information"),
+        )
+        .arg(
+            Arg::with_name("json_rpc_url")
+                .long("url")
+                .value_name("URL")
+                .takes_value(true)
+                .global(true)
+                .validator(is_url)
+                .help("JSON RPC URL for the cluster [default: value from configuration file]"),
+        )
+        .subcommand(
+            SubCommand::with_name("address")
+                .about("Display address information for the feature proposal")
+                .arg(
+                    Arg::with_name("feature_proposal")
+                        .value_name("FEATURE_PROPOSAL_ADDRESS")
+                        .validator(is_valid_pubkey)
+                        .index(1)
+                        .required(true)
+                        .help("The address of the feature proposal"),
+                ),
+        )
+        .subcommand(
+            SubCommand::with_name("propose")
+                .about("Initiate a feature proposal")
+                .arg(
+                    Arg::with_name("feature_proposal")
+                        .value_name("FEATURE_PROPOSAL_KEYPAIR")
+                        .validator(is_keypair)
+                        .index(1)
+                        .required(true)
+                        .help("The keypair of the feature proposal"),
+                )
+                .arg(
+                    Arg::with_name("percent_stake_required")
+                        .long("percent-stake-required")
+                        .value_name("PERCENTAGE")
+                        .validator(is_valid_percentage)
+                        .required(true)
+                        .default_value("67")
+                        .help("Percentage of the active stake required for the proposal to pass"),
+                )
+                .arg(
+                    Arg::with_name("distribution_file")
+                        .long("distribution-file")
+                        .value_name("FILENAME")
+                        .required(true)
+                        .default_value("feature-proposal.csv")
+                        .help("Allocations CSV file for use with solana-tokens"),
+                )
+                .arg(
+                    Arg::with_name("confirm")
+                        .long("confirm")
+                        .help("Confirm that the feature proposal should actually be initiated"),
+                ),
+        )
+        .subcommand(
+            SubCommand::with_name("tally")
+                .about("Tally the current results for a proposed feature")
+                .arg(
+                    Arg::with_name("feature_proposal")
+                        .value_name("FEATURE_PROPOSAL_ADDRESS")
+                        .validator(is_valid_pubkey)
+                        .index(1)
+                        .required(true)
+                        .help("The address of the feature proposal"),
+                ),
+        )
+        .get_matches();
+
+    let (sub_command, sub_matches) = app_matches.subcommand();
+    let matches = sub_matches.unwrap();
+
+    let config = {
+        let cli_config = if let Some(config_file) = matches.value_of("config_file") {
+            solana_cli_config::Config::load(config_file).unwrap_or_default()
+        } else {
+            solana_cli_config::Config::default()
+        };
+
+        Config {
+            json_rpc_url: matches
+                .value_of("json_rpc_url")
+                .unwrap_or(&cli_config.json_rpc_url)
+                .to_string(),
+            keypair: read_keypair_file(
+                matches
+                    .value_of("keypair")
+                    .unwrap_or(&cli_config.keypair_path),
+            )?,
+            verbose: matches.is_present("verbose"),
+        }
+    };
+    solana_logger::setup_with_default("solana=info");
+    let rpc_client = RpcClient::new_with_commitment(
+        config.json_rpc_url.clone(),
+        CommitmentConfig::single_gossip(),
+    );
+
+    match (sub_command, sub_matches) {
+        ("address", Some(arg_matches)) => {
+            let feature_proposal_address = pubkey_of(arg_matches, "feature_proposal").unwrap();
+
+            println!(
+                "Feature Id: {}",
+                spl_feature_proposal::get_feature_id_address(&feature_proposal_address)
+            );
+            println!(
+                "Token Mint Address: {}",
+                spl_feature_proposal::get_mint_address(&feature_proposal_address)
+            );
+            println!(
+                "Acceptance Token Address: {}",
+                spl_feature_proposal::get_acceptance_token_address(&feature_proposal_address)
+            );
+
+            Ok(())
+        }
+        ("propose", Some(arg_matches)) => {
+            let feature_proposal_keypair = keypair_of(arg_matches, "feature_proposal").unwrap();
+            let distribution_file = value_t_or_exit!(arg_matches, "distribution_file", String);
+            let percent_stake_required =
+                value_t_or_exit!(arg_matches, "percent_stake_required", u8);
+            process_propose(
+                &rpc_client,
+                &config,
+                &feature_proposal_keypair,
+                distribution_file,
+                percent_stake_required,
+                arg_matches.is_present("confirm"),
+            )
+        }
+        ("tally", Some(arg_matches)) => {
+            if config.verbose {
+                println!("JSON RPC URL: {}", config.json_rpc_url);
+            }
+
+            let feature_proposal_address = pubkey_of(arg_matches, "feature_proposal").unwrap();
+            process_tally(&rpc_client, &config, &feature_proposal_address)
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn get_feature_proposal(
+    rpc_client: &RpcClient,
+    feature_proposal_address: &Pubkey,
+) -> Result<FeatureProposal, String> {
+    let account = rpc_client
+        .get_multiple_accounts(&[*feature_proposal_address])
+        .map_err(|err| err.to_string())?
+        .into_iter()
+        .next()
+        .unwrap();
+
+    match account {
+        None => Err(format!(
+            "Feature proposal {} does not exist",
+            feature_proposal_address
+        )),
+        Some(account) => FeatureProposal::unpack_from_slice(&account.data).map_err(|err| {
+            format!(
+                "Failed to deserialize feature proposal {}: {}",
+                feature_proposal_address, err
+            )
+        }),
+    }
+}
+
+fn process_propose(
+    rpc_client: &RpcClient,
+    config: &Config,
+    feature_proposal_keypair: &Keypair,
+    distribution_file: String,
+    percent_stake_required: u8,
+    confirm: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let delivery_token_address =
+        spl_feature_proposal::get_delivery_token_address(&feature_proposal_keypair.pubkey());
+    let feature_id_address =
+        spl_feature_proposal::get_feature_id_address(&feature_proposal_keypair.pubkey());
+    let acceptance_token_address =
+        spl_feature_proposal::get_acceptance_token_address(&feature_proposal_keypair.pubkey());
+    let mint_address = spl_feature_proposal::get_mint_address(&feature_proposal_keypair.pubkey());
+
+    println!("Feature Id: {}", feature_id_address);
+    println!("Token Mint Address: {}", mint_address);
+    println!("Delivery Token Address: {}", delivery_token_address,);
+    println!("Acceptance Token Address: {}", acceptance_token_address);
+
+    let vote_accounts = rpc_client.get_vote_accounts()?;
+    let distribution = vote_accounts
+        .current
+        .into_iter()
+        .chain(vote_accounts.delinquent)
+        .map(|vote_account| (vote_account.node_pubkey, vote_account.activated_stake))
+        .collect::<Vec<_>>();
+
+    let tokens_to_mint: u64 = distribution.iter().map(|x| x.1).sum();
+    let tokens_required = tokens_to_mint * percent_stake_required as u64 / 100;
+
+    println!("Number of validators: {}", distribution.len());
+    println!(
+        "Tokens to be minted: {}",
+        spl_feature_proposal::amount_to_ui_amount(tokens_to_mint)
+    );
+    println!(
+        "Tokens required for acceptance: {} ({}%)",
+        spl_feature_proposal::amount_to_ui_amount(tokens_required),
+        percent_stake_required
+    );
+
+    println!("Token distribution file: {}", distribution_file);
+    {
+        let mut file = File::create(&distribution_file)?;
+        file.write_all(b"recipient,amount\n")?;
+        for (node_address, activated_stake) in distribution {
+            file.write_all(
+                format!(
+                    "{},{}\n",
+                    node_address,
+                    spl_feature_proposal::amount_to_ui_amount(activated_stake)
+                )
+                .as_bytes(),
+            )?;
+        }
+    }
+
+    let mut transaction = Transaction::new_with_payer(
+        &[spl_feature_proposal::instruction::propose(
+            &config.keypair.pubkey(),
+            &feature_proposal_keypair.pubkey(),
+            tokens_to_mint,
+            AcceptanceCriteria {
+                tokens_required,
+                deadline: None,
+            },
+        )],
+        Some(&config.keypair.pubkey()),
+    );
+    let blockhash = rpc_client.get_recent_blockhash()?.0;
+    transaction.try_sign(&[&config.keypair, &feature_proposal_keypair], blockhash)?;
+
+    println!("JSON RPC URL: {}", config.json_rpc_url);
+
+    println!();
+    println!("Distribute the proposal tokens to all validators by running:");
+    println!(
+        "    $ solana-tokens distribute-spl-tokens \
+                  --from {} \
+                  --input-csv {} \
+                  --db-path db.{} \
+                  --fee-payer ~/.config/solana/id.json \
+                  --owner <FEATURE_PROPOSAL_KEYPAIR>",
+        delivery_token_address,
+        distribution_file,
+        &feature_proposal_keypair.pubkey().to_string()[..8]
+    );
+    println!(
+        "    $ solana-tokens spl-token-balances \
+                 --mint {} --input-csv {}",
+        mint_address, distribution_file
+    );
+    println!();
+
+    println!(
+        "Once the distribution is complete, request validators vote for \
+        the proposal by first looking up their token account address:"
+    );
+    println!(
+        "    $ spl-token --owner ~/validator-keypair.json accounts {}",
+        mint_address
+    );
+    println!("and then submit their vote by running:");
+    println!(
+        "    $ spl-token --owner ~/validator-keypair.json transfer <TOKEN_ACCOUNT_ADDRESS> ALL {}",
+        acceptance_token_address
+    );
+    println!();
+    println!("Periodically the votes must be tallied by running:");
+    println!(
+        "  $ spl-feature-proposal tally {}",
+        feature_proposal_keypair.pubkey()
+    );
+    println!("Tallying is permissionless and may be run by anybody.");
+    println!("Once this feature proposal is accepted, the {} feature will be activated at the next epoch.", feature_id_address);
+
+    println!();
+    if !confirm {
+        println!("Add --confirm flag to initiate the feature proposal");
+        return Ok(());
+    }
+    rpc_client.send_and_confirm_transaction_with_spinner(&transaction)?;
+
+    println!();
+    println!("Feature proposal created!");
+    Ok(())
+}
+
+fn process_tally(
+    rpc_client: &RpcClient,
+    config: &Config,
+    feature_proposal_address: &Pubkey,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let feature_proposal = get_feature_proposal(rpc_client, feature_proposal_address)?;
+
+    let feature_id_address =
+        spl_feature_proposal::get_feature_id_address(&feature_proposal_address);
+    let acceptance_token_address =
+        spl_feature_proposal::get_acceptance_token_address(&feature_proposal_address);
+
+    println!("Feature Id: {}", feature_id_address);
+    println!("Acceptance Token Address: {}", acceptance_token_address);
+
+    match feature_proposal {
+        FeatureProposal::Uninitialized => {
+            return Err("Feature proposal is uninitialized".into());
+        }
+        FeatureProposal::Pending(acceptance_criteria) => {
+            let acceptance_token_address =
+                spl_feature_proposal::get_acceptance_token_address(feature_proposal_address);
+            let acceptance_token_balance = rpc_client
+                .get_token_account_balance(&acceptance_token_address)?
+                .amount
+                .parse::<u64>()
+                .unwrap_or(0);
+
+            println!();
+            println!(
+                "{} tokens required to accept the proposal",
+                spl_feature_proposal::amount_to_ui_amount(acceptance_criteria.tokens_required)
+            );
+            println!(
+                "{} tokens have been received",
+                spl_feature_proposal::amount_to_ui_amount(acceptance_token_balance)
+            );
+            println!();
+
+            match acceptance_criteria.deadline {
+                None => {
+                    // Don't bother issuing a transaction if it's clear the Tally won't succeed
+                    if acceptance_token_balance < acceptance_criteria.tokens_required {
+                        println!("Feature proposal pending");
+                        return Ok(());
+                    }
+                }
+                Some(deadline) => {
+                    println!("Deadline: {}", deadline); // TODO: format deadline nicely
+                }
+            }
+        }
+        FeatureProposal::Accepted { .. } => {
+            println!("Feature proposal accepted");
+            return Ok(());
+        }
+        FeatureProposal::Expired => {
+            println!("Feature proposal expired");
+            return Ok(());
+        }
+    }
+
+    let mut transaction = Transaction::new_with_payer(
+        &[spl_feature_proposal::instruction::tally(
+            feature_proposal_address,
+        )],
+        Some(&config.keypair.pubkey()),
+    );
+    let blockhash = rpc_client.get_recent_blockhash()?.0;
+    transaction.try_sign(&[&config.keypair], blockhash)?;
+
+    rpc_client.send_and_confirm_transaction_with_spinner(&transaction)?;
+
+    // Check the status of the proposal after the tally completes
+    let feature_proposal = get_feature_proposal(rpc_client, feature_proposal_address)?;
+    match feature_proposal {
+        FeatureProposal::Uninitialized => Err("Feature proposal is uninitialized".into()),
+        FeatureProposal::Pending { .. } => {
+            println!("Feature proposal pending");
+            Ok(())
+        }
+        FeatureProposal::Accepted { .. } => {
+            println!("Feature proposal accepted");
+            Ok(())
+        }
+        FeatureProposal::Expired => {
+            println!("Feature proposal expired");
+            Ok(())
+        }
+    }
+}

--- a/feature-proposal/cli/src/main.rs
+++ b/feature-proposal/cli/src/main.rs
@@ -237,8 +237,8 @@ fn process_propose(
     percent_stake_required: u8,
     confirm: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let delivery_token_address =
-        spl_feature_proposal::get_delivery_token_address(&feature_proposal_keypair.pubkey());
+    let distributor_token_address =
+        spl_feature_proposal::get_distributor_token_address(&feature_proposal_keypair.pubkey());
     let feature_id_address =
         spl_feature_proposal::get_feature_id_address(&feature_proposal_keypair.pubkey());
     let acceptance_token_address =
@@ -247,7 +247,7 @@ fn process_propose(
 
     println!("Feature Id: {}", feature_id_address);
     println!("Token Mint Address: {}", mint_address);
-    println!("Delivery Token Address: {}", delivery_token_address,);
+    println!("Distributor Token Address: {}", distributor_token_address);
     println!("Acceptance Token Address: {}", acceptance_token_address);
 
     let vote_accounts = rpc_client.get_vote_accounts()?;
@@ -314,7 +314,7 @@ fn process_propose(
                   --db-path db.{} \
                   --fee-payer ~/.config/solana/id.json \
                   --owner <FEATURE_PROPOSAL_KEYPAIR>",
-        delivery_token_address,
+        distributor_token_address,
         distribution_file,
         &feature_proposal_keypair.pubkey().to_string()[..8]
     );

--- a/feature-proposal/program/Cargo.toml
+++ b/feature-proposal/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-feature-proposal"
-version = "1.0.0-pre2"
+version = "1.0.0-pre3"
 description = "Solana Program Library Feature Proposal Program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/feature-proposal/program/src/instruction.rs
+++ b/feature-proposal/program/src/instruction.rs
@@ -20,14 +20,14 @@ pub enum FeatureProposalInstruction {
     /// funded by account 0:
     /// * A new token mint with a supply of `tokens_to_mint`, owned by the program and never
     ///   modified again
-    /// * A new "delivery" token account that holds the total supply, owned by account 0.
+    /// * A new "distributor" token account that holds the total supply, owned by account 0.
     /// * A new "acceptance" token account that holds 0 tokens, owned by the program.  Tokens
     ///   transfers to this address are irrevocable and permanent.
     /// * A new feature id account that has been funded and allocated (as described in
     ///  `solana_program::feature`)
     ///
     /// On successful execution of the instruction, the feature proposer is expected to distribute
-    /// the tokens in the delivery token account out to all participating parties.
+    /// the tokens in the distributor token account out to all participating parties.
     ///
     /// Based on the provided acceptance criteria, if `AcceptanceCriteria::tokens_required`
     /// tokens are transferred into the acceptance token account before
@@ -41,7 +41,7 @@ pub enum FeatureProposalInstruction {
     /// 0. `[writeable,signer]` Funding account (must be a system account)
     /// 1. `[writeable,signer]` Unallocated feature proposal account to create
     /// 2. `[writeable]` Token mint address from `get_mint_address`
-    /// 3. `[writeable]` Delivery token account address from `get_delivery_token_address`
+    /// 3. `[writeable]` Distributor token account address from `get_distributor_token_address`
     /// 4. `[writeable]` Acceptance token account address from `get_acceptance_token_address`
     /// 5. `[writeable]` Feature id account address from `get_feature_id_address`
     /// 6. `[]` System program
@@ -109,7 +109,7 @@ pub fn propose(
     acceptance_criteria: AcceptanceCriteria,
 ) -> Instruction {
     let mint_address = get_mint_address(feature_proposal_address);
-    let delivery_token_address = get_delivery_token_address(feature_proposal_address);
+    let distributor_token_address = get_distributor_token_address(feature_proposal_address);
     let acceptance_token_address = get_acceptance_token_address(feature_proposal_address);
     let feature_id_address = get_feature_id_address(feature_proposal_address);
 
@@ -119,7 +119,7 @@ pub fn propose(
             AccountMeta::new(*funding_address, true),
             AccountMeta::new(*feature_proposal_address, true),
             AccountMeta::new(mint_address, false),
-            AccountMeta::new(delivery_token_address, false),
+            AccountMeta::new(distributor_token_address, false),
             AccountMeta::new(acceptance_token_address, false),
             AccountMeta::new(feature_id_address, false),
             AccountMeta::new_readonly(solana_program::system_program::id(), false),

--- a/feature-proposal/program/src/lib.rs
+++ b/feature-proposal/program/src/lib.rs
@@ -18,10 +18,13 @@ pub(crate) fn get_mint_address_with_seed(feature_proposal_address: &Pubkey) -> (
     Pubkey::find_program_address(&[&feature_proposal_address.to_bytes(), br"mint"], &id())
 }
 
-pub(crate) fn get_delivery_token_address_with_seed(
+pub(crate) fn get_distributor_token_address_with_seed(
     feature_proposal_address: &Pubkey,
 ) -> (Pubkey, u8) {
-    Pubkey::find_program_address(&[&feature_proposal_address.to_bytes(), br"delivery"], &id())
+    Pubkey::find_program_address(
+        &[&feature_proposal_address.to_bytes(), br"distributor"],
+        &id(),
+    )
 }
 
 pub(crate) fn get_acceptance_token_address_with_seed(
@@ -47,8 +50,8 @@ pub fn get_mint_address(feature_proposal_address: &Pubkey) -> Pubkey {
 
 /// Derive the SPL Token token address associated with a feature proposal that receives the initial
 /// minted tokens
-pub fn get_delivery_token_address(feature_proposal_address: &Pubkey) -> Pubkey {
-    get_delivery_token_address_with_seed(feature_proposal_address).0
+pub fn get_distributor_token_address(feature_proposal_address: &Pubkey) -> Pubkey {
+    get_distributor_token_address_with_seed(feature_proposal_address).0
 }
 
 /// Derive the SPL Token token address associated with a feature proposal that users send their

--- a/feature-proposal/program/src/lib.rs
+++ b/feature-proposal/program/src/lib.rs
@@ -61,3 +61,14 @@ pub fn get_acceptance_token_address(feature_proposal_address: &Pubkey) -> Pubkey
 pub fn get_feature_id_address(feature_proposal_address: &Pubkey) -> Pubkey {
     get_feature_id_address_with_seed(feature_proposal_address).0
 }
+
+/// Convert the UI representation of a token amount (using the decimals field defined in its mint)
+/// to the raw amount
+pub fn ui_amount_to_amount(ui_amount: f64) -> u64 {
+    (ui_amount * 10_usize.pow(spl_token::native_mint::DECIMALS as u32) as f64) as u64
+}
+
+/// Convert a raw amount to its UI representation (using the decimals field defined in its mint)
+pub fn amount_to_ui_amount(amount: u64) -> f64 {
+    amount as f64 / 10_usize.pow(spl_token::native_mint::DECIMALS as u32) as f64
+}

--- a/feature-proposal/program/src/processor.rs
+++ b/feature-proposal/program/src/processor.rs
@@ -212,6 +212,36 @@ pub fn process_instruction(
                     mint_info.clone(),
                 ],
             )?;
+            invoke(
+                &spl_token::instruction::set_authority(
+                    &spl_token::id(),
+                    acceptance_token_info.key,
+                    Some(&feature_proposal_info.key),
+                    spl_token::instruction::AuthorityType::CloseAccount,
+                    feature_proposal_info.key,
+                    &[],
+                )?,
+                &[
+                    spl_token_program_info.clone(),
+                    acceptance_token_info.clone(),
+                    feature_proposal_info.clone(),
+                ],
+            )?;
+            invoke(
+                &spl_token::instruction::set_authority(
+                    &spl_token::id(),
+                    acceptance_token_info.key,
+                    Some(&program_id),
+                    spl_token::instruction::AuthorityType::AccountOwner,
+                    feature_proposal_info.key,
+                    &[],
+                )?,
+                &[
+                    spl_token_program_info.clone(),
+                    acceptance_token_info.clone(),
+                    feature_proposal_info.clone(),
+                ],
+            )?;
 
             // Mint `tokens_to_mint` tokens into `delivery_token_account` owned by
             // `feature_proposal`

--- a/feature-proposal/program/tests/functional.rs
+++ b/feature-proposal/program/tests/functional.rs
@@ -57,7 +57,7 @@ async fn test_basic() {
 
     let feature_id_address = get_feature_id_address(&feature_proposal.pubkey());
     let mint_address = get_mint_address(&feature_proposal.pubkey());
-    let delivery_token_address = get_delivery_token_address(&feature_proposal.pubkey());
+    let distributor_token_address = get_distributor_token_address(&feature_proposal.pubkey());
     let acceptance_token_address = get_acceptance_token_address(&feature_proposal.pubkey());
 
     // Create a new feature proposal
@@ -94,15 +94,15 @@ async fn test_basic() {
     assert!(mint.freeze_authority.is_none());
     assert_eq!(mint.mint_authority, COption::Some(mint_address));
 
-    // Confirm delivery token account state
-    let delivery_token =
-        get_account_data::<spl_token::state::Account>(&mut banks_client, delivery_token_address)
+    // Confirm distributor token account state
+    let distributor_token =
+        get_account_data::<spl_token::state::Account>(&mut banks_client, distributor_token_address)
             .await
             .unwrap();
-    assert_eq!(delivery_token.amount, 42);
-    assert_eq!(delivery_token.mint, mint_address);
-    assert_eq!(delivery_token.owner, feature_proposal.pubkey());
-    assert!(delivery_token.close_authority.is_none());
+    assert_eq!(distributor_token.amount, 42);
+    assert_eq!(distributor_token.mint, mint_address);
+    assert_eq!(distributor_token.owner, feature_proposal.pubkey());
+    assert!(distributor_token.close_authority.is_none());
 
     // Confirm acceptance token account state
     let acceptance_token =
@@ -140,7 +140,7 @@ async fn test_basic() {
     let mut transaction = Transaction::new_with_payer(
         &[spl_token::instruction::transfer(
             &spl_token::id(),
-            &delivery_token_address,
+            &distributor_token_address,
             &acceptance_token_address,
             &feature_proposal.pubkey(),
             &[],

--- a/feature-proposal/program/tests/functional.rs
+++ b/feature-proposal/program/tests/functional.rs
@@ -34,7 +34,8 @@ fn program_test() -> ProgramTest {
     pc
 }
 
-fn get_account<T: Pack>(
+/// Fetch and unpack account data
+fn get_account_data<T: Pack>(
     banks_client: &mut BanksClient,
     address: Pubkey,
 ) -> impl Future<Output = std::io::Result<T>> + '_ {
@@ -85,7 +86,7 @@ async fn test_basic() {
     assert_eq!(feature_id_acccount.data.len(), Feature::size_of());
 
     // Confirm mint account state
-    let mint = get_account::<spl_token::state::Mint>(&mut banks_client, mint_address)
+    let mint = get_account_data::<spl_token::state::Mint>(&mut banks_client, mint_address)
         .await
         .unwrap();
     assert_eq!(mint.supply, 42);
@@ -95,7 +96,7 @@ async fn test_basic() {
 
     // Confirm delivery token account state
     let delivery_token =
-        get_account::<spl_token::state::Account>(&mut banks_client, delivery_token_address)
+        get_account_data::<spl_token::state::Account>(&mut banks_client, delivery_token_address)
             .await
             .unwrap();
     assert_eq!(delivery_token.amount, 42);
@@ -105,7 +106,7 @@ async fn test_basic() {
 
     // Confirm acceptance token account state
     let acceptance_token =
-        get_account::<spl_token::state::Account>(&mut banks_client, acceptance_token_address)
+        get_account_data::<spl_token::state::Account>(&mut banks_client, acceptance_token_address)
             .await
             .unwrap();
     assert_eq!(acceptance_token.amount, 0);
@@ -131,7 +132,7 @@ async fn test_basic() {
     assert_eq!(feature_id_acccount.owner, system_program::id());
 
     assert!(matches!(
-        get_account::<FeatureProposal>(&mut banks_client, feature_proposal.pubkey()).await,
+        get_account_data::<FeatureProposal>(&mut banks_client, feature_proposal.pubkey()).await,
         Ok(FeatureProposal::Pending(_))
     ));
 
@@ -175,7 +176,7 @@ async fn test_basic() {
 
     // Confirm feature proposal account state
     assert!(matches!(
-        get_account::<FeatureProposal>(&mut banks_client, feature_proposal.pubkey()).await,
+        get_account_data::<FeatureProposal>(&mut banks_client, feature_proposal.pubkey()).await,
         Ok(FeatureProposal::Accepted {
             tokens_upon_acceptance: 42
         })


### PR DESCRIPTION
```
$ spl-feature-proposal --help
spl-feature-proposal-cli 1.0.0
SPL Feature Proposal Command-line Utility

USAGE:
    spl-feature-proposal [FLAGS] [OPTIONS] <SUBCOMMAND>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information
    -v, --verbose    Show additional information

OPTIONS:
    -C, --config <PATH>        Configuration file to use [default: /Users/mvines/.config/solana/cli/config.yml]
        --url <URL>            JSON RPC URL for the cluster [default: value from configuration file]
        --keypair <KEYPAIR>    Filepath or URL to a keypair [default: client keypair]

SUBCOMMANDS:
    address    Display address information for the feature proposal
    help       Prints this message or the help of the given subcommand(s)
    propose    Initiate a feature proposal
    tally      Tally the current results for a proposed feature
```