### PR TITLE
spl-feature-proposal: output raw spl-token amounts in csv

### DIFF
--- a/feature-proposal/cli/Cargo.toml
+++ b/feature-proposal/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-feature-proposal-cli"
-version = "1.0.0"
+version = "1.1.0"
 description = "SPL Feature Proposal Command-line Utility"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/feature-proposal/cli/src/main.rs
+++ b/feature-proposal/cli/src/main.rs
@@ -307,14 +307,7 @@ fn process_propose(
         let mut file = File::create(&distribution_file)?;
         file.write_all(b"recipient,amount\n")?;
         for (node_address, activated_stake) in distribution {
-            file.write_all(
-                format!(
-                    "{},{}\n",
-                    node_address,
-                    spl_feature_proposal::amount_to_ui_amount(activated_stake)
-                )
-                .as_bytes(),
-            )?;
+            file.write_all(format!("{},{}\n", node_address, activated_stake).as_bytes())?;
         }
     }
 


### PR DESCRIPTION
Once https://github.com/solana-labs/solana/pull/13815 lands, `solana-tokens` will expect spl-token distribution CSVs to use raw amounts (no decimal).
Update `feature-proposal` CSV-generation code accordingly.