### PR TITLE
token-swap: Constant price curve

### DIFF
--- a/token-swap/program/src/curve/constant_price.rs
+++ b/token-swap/program/src/curve/constant_price.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     curve::calculator::{
-        CurveCalculator, DynPack, SwapWithoutFeesResult, TradeDirection, TradingTokenResult,
+        map_zero_to_none, CurveCalculator, DynPack, SwapWithoutFeesResult, TradeDirection, TradingTokenResult,
     },
     error::SwapError,
 };
@@ -10,10 +10,14 @@ use solana_program::{
     program_error::ProgramError,
     program_pack::{IsInitialized, Pack, Sealed},
 };
+use arrayref::{array_mut_ref, array_ref};
 
 /// ConstantPriceCurve struct implementing CurveCalculator
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct ConstantPriceCurve;
+pub struct ConstantPriceCurve {
+    /// Amount of token A required to get 1 token B
+    pub token_b_price: u64,
+}
 
 impl CurveCalculator for ConstantPriceCurve {
     /// Constant price curve always returns 1:1
@@ -22,11 +26,32 @@ impl CurveCalculator for ConstantPriceCurve {
         source_amount: u128,
         _swap_source_amount: u128,
         _swap_destination_amount: u128,
-        _trade_direction: TradeDirection,
+        trade_direction: TradeDirection,
     ) -> Option<SwapWithoutFeesResult> {
+        let token_b_price = self.token_b_price as u128;
+
+        let (source_amount_swapped, destination_amount_swapped) = match trade_direction {
+            TradeDirection::BtoA => (source_amount, source_amount.checked_mul(token_b_price)?),
+            TradeDirection::AtoB => {
+                let destination_amount_swapped = source_amount.checked_div(token_b_price)?;
+                let mut source_amount_swapped = source_amount;
+
+                // if there is a remainder from buying token B, floor
+                // token_a_amount provided to avoid taking too many tokens, but
+                // don't recalculate the fees
+                let remainder = source_amount_swapped.checked_rem(token_b_price)?;
+                if remainder > 0 {
+                    source_amount_swapped = source_amount.checked_sub(remainder)?;
+                }
+
+                (source_amount_swapped, destination_amount_swapped)
+            }
+        };
+        let source_amount_swapped = map_zero_to_none(source_amount_swapped)?;
+        let destination_amount_swapped = map_zero_to_none(destination_amount_swapped)?;
         Some(SwapWithoutFeesResult {
-            source_amount_swapped: source_amount,
-            destination_amount_swapped: source_amount,
+            source_amount_swapped,
+            destination_amount_swapped,
         })
     }
 
@@ -68,16 +93,17 @@ impl CurveCalculator for ConstantPriceCurve {
     /// by the price of token B.
     fn trading_tokens_to_pool_tokens(
         &self,
-        token_a_amount: u128,
+        source_amount: u128,
         swap_token_a_amount: u128,
-        token_b_amount: u128,
         swap_token_b_amount: u128,
         pool_supply: u128,
+        trade_direction: TradeDirection,
     ) -> Option<u128> {
         let token_b_price = self.token_b_price as u128;
-        let given_value = token_b_amount
-            .checked_mul(token_b_price)?
-            .checked_add(token_a_amount)?;
+        let given_value = match trade_direction {
+            TradeDirection::AtoB => source_amount,
+            TradeDirection::BtoA => source_amount.checked_mul(token_b_price)?,
+        };
         let total_value = swap_token_b_amount
             .checked_mul(token_b_price)?
             .checked_add(swap_token_a_amount)?;
@@ -87,7 +113,11 @@ impl CurveCalculator for ConstantPriceCurve {
     }
 
     fn validate(&self) -> Result<(), SwapError> {
-        Ok(())
+        if self.token_b_price == 0 {
+            Err(SwapError::InvalidCurve)
+        } else {
+            Ok(())
+        }
     }
 
     fn validate_supply(&self, token_a_amount: u64, _token_b_amount: u64) -> Result<(), SwapError> {
@@ -106,18 +136,24 @@ impl IsInitialized for ConstantPriceCurve {
 }
 impl Sealed for ConstantPriceCurve {}
 impl Pack for ConstantPriceCurve {
-    const LEN: usize = 0;
+    const LEN: usize = 8;
     fn pack_into_slice(&self, output: &mut [u8]) {
         (self as &dyn DynPack).pack_into_slice(output);
     }
 
-    fn unpack_from_slice(_input: &[u8]) -> Result<ConstantPriceCurve, ProgramError> {
-        Ok(Self {})
+    fn unpack_from_slice(input: &[u8]) -> Result<ConstantPriceCurve, ProgramError> {
+        let token_b_price = array_ref![input, 0, 8];
+        Ok(Self {
+            token_b_price: u64::from_le_bytes(*token_b_price),
+        })
     }
 }
 
 impl DynPack for ConstantPriceCurve {
-    fn pack_into_slice(&self, _output: &mut [u8]) {}
+    fn pack_into_slice(&self, output: &mut [u8]) {
+        let token_b_price = array_mut_ref![output, 0, 8];
+        *token_b_price = self.token_b_price.to_le_bytes();
+    }
 }
 
 #[cfg(test)]
@@ -129,7 +165,10 @@ mod tests {
         let swap_source_amount: u128 = 0;
         let swap_destination_amount: u128 = 0;
         let source_amount: u128 = 100;
-        let curve = ConstantPriceCurve {};
+        let token_b_price = 1;
+        let curve = ConstantPriceCurve {
+            token_b_price,
+        };
 
         let expected_result = SwapWithoutFeesResult {
             source_amount_swapped: source_amount,
@@ -159,16 +198,28 @@ mod tests {
 
     #[test]
     fn pack_flat_curve() {
-        let curve = ConstantPriceCurve {};
+        let token_b_price = 1_251_258;
+        let curve = ConstantPriceCurve {
+            token_b_price,
+        };
 
         let mut packed = [0u8; ConstantPriceCurve::LEN];
         Pack::pack_into_slice(&curve, &mut packed[..]);
         let unpacked = ConstantPriceCurve::unpack(&packed).unwrap();
         assert_eq!(curve, unpacked);
 
-        let packed = vec![];
+        let mut packed = vec![];
+        packed.extend_from_slice(&token_b_price.to_le_bytes());
         let unpacked = ConstantPriceCurve::unpack(&packed).unwrap();
         assert_eq!(curve, unpacked);
+    }
+
+    fn almost_equal(a: u128, b: u128) {
+        if a >= b {
+            assert!(a - b <= 1);
+        } else {
+            assert!(b - a <= 1);
+        }
     }
 
     fn check_pool_token_conversion(token_b_price: u128, swap_token_a_amount: u128, swap_token_b_amount: u128, token_b_amount: u128) {
@@ -177,25 +228,34 @@ mod tests {
             token_b_price: token_b_price as u64,
         };
         let pool_supply = curve.new_pool_supply();
-        let pool_tokens = curve
+        let pool_tokens_from_a = curve
             .trading_tokens_to_pool_tokens(
                 token_a_amount,
                 swap_token_a_amount,
-                token_b_amount,
                 swap_token_b_amount,
                 pool_supply,
+                TradeDirection::AtoB,
+            )
+            .unwrap();
+        let pool_tokens_from_b = curve
+            .trading_tokens_to_pool_tokens(
+                token_b_amount,
+                swap_token_a_amount,
+                swap_token_b_amount,
+                pool_supply,
+                TradeDirection::BtoA,
             )
             .unwrap();
         let results = curve
             .pool_tokens_to_trading_tokens(
-                pool_tokens,
+                pool_tokens_from_a + pool_tokens_from_b,
                 pool_supply,
                 swap_token_a_amount,
                 swap_token_b_amount,
             )
             .unwrap();
-        assert!(results.token_a_amount <= token_a_amount); // as long as we don't create more value, we're good
-        assert_eq!(results.token_b_amount, token_b_amount);
+        almost_equal(results.token_a_amount / token_b_price, token_a_amount / token_b_price); // takes care of truncation issues
+        almost_equal(results.token_b_amount, token_b_amount);
     }
 
     #[test]
@@ -221,5 +281,68 @@ mod tests {
                 *token_b_amount
             );
         }
+    }
+
+    #[test]
+    fn swap_calculation_large_price() {
+        let token_b_price = 1123513u128;
+        let curve = ConstantPriceCurve {
+            token_b_price: token_b_price as u64,
+        };
+        let token_b_amount = 500u128;
+        let token_a_amount = token_b_amount * token_b_price;
+        let bad_result = curve.swap_without_fees(
+            token_b_price - 1u128,
+            token_a_amount,
+            token_b_amount,
+            TradeDirection::AtoB,
+        );
+        assert!(bad_result.is_none());
+        let bad_result =
+            curve.swap_without_fees(1u128, token_a_amount, token_b_amount, TradeDirection::AtoB);
+        assert!(bad_result.is_none());
+        let result = curve
+            .swap_without_fees(
+                token_b_price,
+                token_a_amount,
+                token_b_amount,
+                TradeDirection::AtoB,
+            )
+            .unwrap();
+        assert_eq!(result.source_amount_swapped, token_b_price);
+        assert_eq!(result.destination_amount_swapped, 1u128);
+    }
+
+    #[test]
+    fn swap_calculation_max_min() {
+        let token_b_price = u64::MAX as u128;
+        let curve = ConstantPriceCurve {
+            token_b_price: token_b_price as u64,
+        };
+        let token_b_amount = 1u128;
+        let token_a_amount = token_b_price;
+        let bad_result = curve.swap_without_fees(
+            token_b_price - 1u128,
+            token_a_amount,
+            token_b_amount,
+            TradeDirection::AtoB,
+        );
+        assert!(bad_result.is_none());
+        let bad_result =
+            curve.swap_without_fees(1u128, token_a_amount, token_b_amount, TradeDirection::AtoB);
+        assert!(bad_result.is_none());
+        let bad_result =
+            curve.swap_without_fees(0u128, token_a_amount, token_b_amount, TradeDirection::AtoB);
+        assert!(bad_result.is_none());
+        let result = curve
+            .swap_without_fees(
+                token_b_price,
+                token_a_amount,
+                token_b_amount,
+                TradeDirection::AtoB,
+            )
+            .unwrap();
+        assert_eq!(result.source_amount_swapped, token_b_price);
+        assert_eq!(result.destination_amount_swapped, 1u128);
     }
 }

--- a/token-swap/program/src/curve/constant_price.rs
+++ b/token-swap/program/src/curve/constant_price.rs
@@ -2,15 +2,16 @@
 
 use crate::{
     curve::calculator::{
-        map_zero_to_none, CurveCalculator, DynPack, SwapWithoutFeesResult, TradeDirection, TradingTokenResult,
+        map_zero_to_none, CurveCalculator, DynPack, SwapWithoutFeesResult, TradeDirection,
+        TradingTokenResult,
     },
     error::SwapError,
 };
+use arrayref::{array_mut_ref, array_ref};
 use solana_program::{
     program_error::ProgramError,
     program_pack::{IsInitialized, Pack, Sealed},
 };
-use arrayref::{array_mut_ref, array_ref};
 
 /// ConstantPriceCurve struct implementing CurveCalculator
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -166,9 +167,7 @@ mod tests {
         let swap_destination_amount: u128 = 0;
         let source_amount: u128 = 100;
         let token_b_price = 1;
-        let curve = ConstantPriceCurve {
-            token_b_price,
-        };
+        let curve = ConstantPriceCurve { token_b_price };
 
         let expected_result = SwapWithoutFeesResult {
             source_amount_swapped: source_amount,
@@ -199,9 +198,7 @@ mod tests {
     #[test]
     fn pack_flat_curve() {
         let token_b_price = 1_251_258;
-        let curve = ConstantPriceCurve {
-            token_b_price,
-        };
+        let curve = ConstantPriceCurve { token_b_price };
 
         let mut packed = [0u8; ConstantPriceCurve::LEN];
         Pack::pack_into_slice(&curve, &mut packed[..]);
@@ -222,7 +219,12 @@ mod tests {
         }
     }
 
-    fn check_pool_token_conversion(token_b_price: u128, swap_token_a_amount: u128, swap_token_b_amount: u128, token_b_amount: u128) {
+    fn check_pool_token_conversion(
+        token_b_price: u128,
+        swap_token_a_amount: u128,
+        swap_token_b_amount: u128,
+        token_b_amount: u128,
+    ) {
         let token_a_amount = token_b_amount * token_b_price;
         let curve = ConstantPriceCurve {
             token_b_price: token_b_price as u64,
@@ -254,7 +256,10 @@ mod tests {
                 swap_token_b_amount,
             )
             .unwrap();
-        almost_equal(results.token_a_amount / token_b_price, token_a_amount / token_b_price); // takes care of truncation issues
+        almost_equal(
+            results.token_a_amount / token_b_price,
+            token_a_amount / token_b_price,
+        ); // takes care of truncation issues
         almost_equal(results.token_b_amount, token_b_amount);
     }
 
@@ -267,18 +272,14 @@ mod tests {
             (1_000_251, 0, 1_288, 1),
             (1_000_000_000_000, 212, 10_000, 1),
         ];
-        for (
-            token_b_price,
-            swap_token_a_amount,
-            swap_token_b_amount,
-            token_b_amount
-        ) in tests.iter()
+        for (token_b_price, swap_token_a_amount, swap_token_b_amount, token_b_amount) in
+            tests.iter()
         {
             check_pool_token_conversion(
                 *token_b_price,
                 *swap_token_a_amount,
                 *swap_token_b_amount,
-                *token_b_amount
+                *token_b_amount,
             );
         }
     }

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -2048,9 +2048,7 @@ mod tests {
             let token_b_price = 10_000;
             let swap_curve = SwapCurve {
                 curve_type: CurveType::ConstantPrice,
-                calculator: Box::new(ConstantPriceCurve {
-                    token_b_price,
-                }),
+                calculator: Box::new(ConstantPriceCurve { token_b_price }),
             };
             let mut accounts =
                 SwapAccountInfo::new(&user_key, fees, swap_curve, token_a_amount, token_b_amount);

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -2008,8 +2008,9 @@ mod tests {
         // create valid swap
         accounts.initialize_swap().unwrap();
 
-        // create valid flat swap
+        // create invalid flat swap
         {
+            let token_b_price = 0;
             let fees = Fees {
                 trade_fee_numerator,
                 trade_fee_denominator,
@@ -2022,7 +2023,34 @@ mod tests {
             };
             let swap_curve = SwapCurve {
                 curve_type: CurveType::ConstantPrice,
-                calculator: Box::new(ConstantPriceCurve {}),
+                calculator: Box::new(ConstantPriceCurve { token_b_price }),
+            };
+            let mut accounts =
+                SwapAccountInfo::new(&user_key, fees, swap_curve, token_a_amount, token_b_amount);
+            assert_eq!(
+                Err(SwapError::InvalidCurve.into()),
+                accounts.initialize_swap()
+            );
+        }
+
+        // create valid flat swap
+        {
+            let fees = Fees {
+                trade_fee_numerator,
+                trade_fee_denominator,
+                owner_trade_fee_numerator,
+                owner_trade_fee_denominator,
+                owner_withdraw_fee_numerator,
+                owner_withdraw_fee_denominator,
+                host_fee_numerator,
+                host_fee_denominator,
+            };
+            let token_b_price = 10_000;
+            let swap_curve = SwapCurve {
+                curve_type: CurveType::ConstantPrice,
+                calculator: Box::new(ConstantPriceCurve {
+                    token_b_price,
+                }),
             };
             let mut accounts =
                 SwapAccountInfo::new(&user_key, fees, swap_curve, token_a_amount, token_b_amount);
@@ -3937,10 +3965,11 @@ mod tests {
             token_a_amount,
             token_b_amount,
         );
+        let token_b_price = 1;
         check_valid_swap_curve(
             fees.clone(),
             CurveType::ConstantPrice,
-            Box::new(ConstantPriceCurve {}),
+            Box::new(ConstantPriceCurve { token_b_price }),
             token_a_amount,
             token_b_amount,
         );
@@ -3985,12 +4014,13 @@ mod tests {
             token_a_amount,
             token_b_amount,
         );
+        let token_b_price = 10_000;
         check_valid_swap_curve(
             fees.clone(),
             CurveType::ConstantPrice,
-            Box::new(ConstantPriceCurve {}),
+            Box::new(ConstantPriceCurve { token_b_price }),
             token_a_amount,
-            token_b_amount,
+            token_b_amount / token_b_price,
         );
         let token_b_offset = 1;
         check_valid_swap_curve(


### PR DESCRIPTION
The constant price is a flat line, where the amount of token A required to buy 1 token B is fixed on init.  This makes the value function for the pool very simple:
`value = token_a_amount + token_b_amount * token_b_price`, so single deposit calculations are done with respect to that number.

~~Note that this depends on #934 , so the only substantial changes are in `constant_price.rs` and some more tests in `processor.rs`.~~
The PR has been rebased for easier reading.