### PR TITLE
token-swap: Add instructions to deposit / withdraw one token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,13 +724,12 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "2.1.0"
-source = "git+https://github.com/garious/curve25519-dalek?rev=60efef3553d6bf3d7f3b09b5f97acd54d72529ff#60efef3553d6bf3d7f3b09b5f97acd54d72529ff"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
 dependencies = [
- "borsh",
  "byteorder",
  "digest 0.8.1",
  "rand_core",
- "serde",
  "subtle 2.2.3",
  "zeroize",
 ]
@@ -738,12 +737,13 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
+source = "git+https://github.com/garious/curve25519-dalek?rev=60efef3553d6bf3d7f3b09b5f97acd54d72529ff#60efef3553d6bf3d7f3b09b5f97acd54d72529ff"
 dependencies = [
+ "borsh",
  "byteorder",
  "digest 0.8.1",
  "rand_core",
+ "serde",
  "subtle 2.2.3",
  "zeroize",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,19 +724,6 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
-dependencies = [
- "byteorder",
- "digest 0.8.1",
- "rand_core",
- "subtle 2.2.3",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "2.1.0"
 source = "git+https://github.com/garious/curve25519-dalek?rev=60efef3553d6bf3d7f3b09b5f97acd54d72529ff#60efef3553d6bf3d7f3b09b5f97acd54d72529ff"
 dependencies = [
  "borsh",
@@ -744,6 +731,19 @@ dependencies = [
  "digest 0.8.1",
  "rand_core",
  "serde",
+ "subtle 2.2.3",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
+dependencies = [
+ "byteorder",
+ "digest 0.8.1",
+ "rand_core",
  "subtle 2.2.3",
  "zeroize",
 ]

--- a/token-swap/js/cli/main.js
+++ b/token-swap/js/cli/main.js
@@ -9,8 +9,8 @@ import {
   createAccountAndSwapAtomic,
   createTokenSwap,
   swap,
-  deposit,
-  withdraw,
+  depositAllTokenTypes,
+  withdrawAllTokenTypes,
   depositOneExactIn,
   withdrawOneExactOut,
 } from './token-swap-test';
@@ -21,10 +21,10 @@ async function main() {
   await loadPrograms();
   console.log('Run test: createTokenSwap');
   await createTokenSwap();
-  console.log('Run test: deposit');
-  await deposit();
-  console.log('Run test: withdraw');
-  await withdraw();
+  console.log('Run test: deposit all token types');
+  await depositAllTokenTypes();
+  console.log('Run test: withdraw all token types');
+  await withdrawAllTokenTypes();
   console.log('Run test: swap');
   await swap();
   console.log('Run test: create account, approve, swap all at once');

--- a/token-swap/js/cli/main.js
+++ b/token-swap/js/cli/main.js
@@ -29,11 +29,11 @@ async function main() {
   await swap();
   console.log('Run test: create account, approve, swap all at once');
   await createAccountAndSwapAtomic();
-  console.log('Success\n');
   console.log('Run test: deposit one exact amount in');
   await depositOneExactIn();
   console.log('Run test: withrdaw one exact amount out');
   await withdrawOneExactOut();
+  console.log('Success\n');
 }
 
 main()

--- a/token-swap/js/cli/main.js
+++ b/token-swap/js/cli/main.js
@@ -11,8 +11,8 @@ import {
   swap,
   depositAllTokenTypes,
   withdrawAllTokenTypes,
-  depositOneExactIn,
-  withdrawOneExactOut,
+  depositSingleTokenTypeExactAmountIn,
+  withdrawSingleTokenTypeExactAmountOut,
 } from './token-swap-test';
 
 async function main() {
@@ -30,9 +30,9 @@ async function main() {
   console.log('Run test: create account, approve, swap all at once');
   await createAccountAndSwapAtomic();
   console.log('Run test: deposit one exact amount in');
-  await depositOneExactIn();
+  await depositSingleTokenTypeExactAmountIn();
   console.log('Run test: withrdaw one exact amount out');
-  await withdrawOneExactOut();
+  await withdrawSingleTokenTypeExactAmountOut();
   console.log('Success\n');
 }
 

--- a/token-swap/js/cli/main.js
+++ b/token-swap/js/cli/main.js
@@ -11,6 +11,8 @@ import {
   swap,
   deposit,
   withdraw,
+  depositOneExactIn,
+  withdrawOneExactOut,
 } from './token-swap-test';
 
 async function main() {
@@ -28,6 +30,10 @@ async function main() {
   console.log('Run test: create account, approve, swap all at once');
   await createAccountAndSwapAtomic();
   console.log('Success\n');
+  console.log('Run test: deposit one exact amount in');
+  await depositOneExactIn();
+  console.log('Run test: withrdaw one exact amount out');
+  await withdrawOneExactOut();
 }
 
 main()

--- a/token-swap/js/cli/token-swap-test.js
+++ b/token-swap/js/cli/token-swap-test.js
@@ -287,7 +287,7 @@ export async function createTokenSwap(): Promise<void> {
   assert(CURVE_TYPE == fetchedTokenSwap.curveType);
 }
 
-export async function deposit(): Promise<void> {
+export async function depositAllTokenTypes(): Promise<void> {
   const poolMintInfo = await tokenPool.getMintInfo();
   const supply = poolMintInfo.supply.toNumber();
   const swapTokenA = await mintA.getAccountInfo(tokenAccountA);
@@ -313,7 +313,7 @@ export async function deposit(): Promise<void> {
   const newAccountPool = await tokenPool.createAccount(owner.publicKey);
 
   console.log('Depositing into swap');
-  await tokenSwap.deposit(
+  await tokenSwap.depositAllTokenTypes(
     userAccountA,
     userAccountB,
     newAccountPool,
@@ -337,7 +337,7 @@ export async function deposit(): Promise<void> {
   assert(info.amount.toNumber() == POOL_TOKEN_AMOUNT);
 }
 
-export async function withdraw(): Promise<void> {
+export async function withdrawAllTokenTypes(): Promise<void> {
   const poolMintInfo = await tokenPool.getMintInfo();
   const supply = poolMintInfo.supply.toNumber();
   let swapTokenA = await mintA.getAccountInfo(tokenAccountA);
@@ -372,7 +372,7 @@ export async function withdraw(): Promise<void> {
   );
 
   console.log('Withdrawing pool tokens for A and B tokens');
-  await tokenSwap.withdraw(
+  await tokenSwap.withdrawAllTokenTypes(
     userAccountA,
     userAccountB,
     tokenAccountPool,

--- a/token-swap/js/cli/token-swap-test.js
+++ b/token-swap/js/cli/token-swap-test.js
@@ -540,7 +540,7 @@ function tradingTokensToPoolTokens(
   return Math.floor(poolAmount * (root - 1));
 }
 
-export async function depositOneExactIn(): Promise<void> {
+export async function depositSingleTokenTypeExactAmountIn(): Promise<void> {
   // Pool token amount to deposit on one side
   const depositAmount = 10000;
 
@@ -571,7 +571,7 @@ export async function depositOneExactIn(): Promise<void> {
   const newAccountPool = await tokenPool.createAccount(owner.publicKey);
 
   console.log('Depositing token A into swap');
-  await tokenSwap.depositOneExactIn(
+  await tokenSwap.depositSingleTokenTypeExactAmountIn(
     userAccountA,
     newAccountPool,
     depositAmount,
@@ -586,7 +586,7 @@ export async function depositOneExactIn(): Promise<void> {
   currentSwapTokenA += depositAmount;
 
   console.log('Depositing token B into swap');
-  await tokenSwap.depositOneExactIn(
+  await tokenSwap.depositSingleTokenTypeExactAmountIn(
     userAccountB,
     newAccountPool,
     depositAmount,
@@ -602,7 +602,7 @@ export async function depositOneExactIn(): Promise<void> {
   assert(info.amount.toNumber() >= poolTokenA + poolTokenB);
 }
 
-export async function withdrawOneExactOut(): Promise<void> {
+export async function withdrawSingleTokenTypeExactAmountOut(): Promise<void> {
   // Pool token amount to withdraw on one side
   const withdrawAmount = 50000;
   const roundingAmount = 1.0001; // make math a little easier
@@ -652,7 +652,7 @@ export async function withdrawOneExactOut(): Promise<void> {
   );
 
   console.log('Withdrawing token A only');
-  await tokenSwap.withdrawOneExactOut(
+  await tokenSwap.withdrawSingleTokenTypeExactAmountOut(
     userAccountA,
     tokenAccountPool,
     withdrawAmount,
@@ -669,7 +669,7 @@ export async function withdrawOneExactOut(): Promise<void> {
   assert(info.amount.toNumber() >= poolTokenAmount - adjustedPoolTokenA);
 
   console.log('Withdrawing token B only');
-  await tokenSwap.withdrawOneExactOut(
+  await tokenSwap.withdrawSingleTokenTypeExactAmountOut(
     userAccountB,
     tokenAccountPool,
     withdrawAmount,

--- a/token-swap/js/cli/token-swap-test.js
+++ b/token-swap/js/cli/token-swap-test.js
@@ -291,9 +291,15 @@ export async function deposit(): Promise<void> {
   const poolMintInfo = await tokenPool.getMintInfo();
   const supply = poolMintInfo.supply.toNumber();
   const swapTokenA = await mintA.getAccountInfo(tokenAccountA);
-  const tokenA = Math.floor((swapTokenA.amount.toNumber() * POOL_TOKEN_AMOUNT) / (supply + POOL_TOKEN_AMOUNT));
+  const tokenA = Math.floor(
+    (swapTokenA.amount.toNumber() * POOL_TOKEN_AMOUNT) /
+      (supply + POOL_TOKEN_AMOUNT),
+  );
   const swapTokenB = await mintB.getAccountInfo(tokenAccountB);
-  const tokenB = Math.floor((swapTokenB.amount.toNumber() * POOL_TOKEN_AMOUNT) / (supply + POOL_TOKEN_AMOUNT));
+  const tokenB = Math.floor(
+    (swapTokenB.amount.toNumber() * POOL_TOKEN_AMOUNT) /
+      (supply + POOL_TOKEN_AMOUNT),
+  );
 
   console.log('Creating depositor token a account');
   const userAccountA = await mintA.createAccount(owner.publicKey);
@@ -525,9 +531,10 @@ export async function swap(): Promise<void> {
 function tradingTokensToPoolTokens(
   sourceAmount: number,
   swapSourceAmount: number,
-  poolAmount: number): number
-{
-  const tradingFee = (sourceAmount / 2) * (TRADING_FEE_NUMERATOR / TRADING_FEE_DENOMINATOR);
+  poolAmount: number,
+): number {
+  const tradingFee =
+    (sourceAmount / 2) * (TRADING_FEE_NUMERATOR / TRADING_FEE_DENOMINATOR);
   const sourceAmountPostFee = sourceAmount - tradingFee;
   const root = Math.sqrt(sourceAmountPostFee / swapSourceAmount + 1);
   return Math.floor(poolAmount * (root - 1));
@@ -540,9 +547,17 @@ export async function depositOneExactIn(): Promise<void> {
   const poolMintInfo = await tokenPool.getMintInfo();
   const supply = poolMintInfo.supply.toNumber();
   const swapTokenA = await mintA.getAccountInfo(tokenAccountA);
-  const poolTokenA = tradingTokensToPoolTokens(depositAmount, swapTokenA.amount.toNumber(), supply);
+  const poolTokenA = tradingTokensToPoolTokens(
+    depositAmount,
+    swapTokenA.amount.toNumber(),
+    supply,
+  );
   const swapTokenB = await mintB.getAccountInfo(tokenAccountB);
-  const poolTokenB = tradingTokensToPoolTokens(depositAmount, swapTokenB.amount.toNumber(), supply);
+  const poolTokenB = tradingTokensToPoolTokens(
+    depositAmount,
+    swapTokenB.amount.toNumber(),
+    supply,
+  );
 
   console.log('Creating depositor token a account');
   const userAccountA = await mintA.createAccount(owner.publicKey);
@@ -597,18 +612,28 @@ export async function withdrawOneExactOut(): Promise<void> {
 
   const swapTokenA = await mintA.getAccountInfo(tokenAccountA);
   const swapTokenAPost = swapTokenA.amount.toNumber() - withdrawAmount;
-  const poolTokenA = tradingTokensToPoolTokens(withdrawAmount, swapTokenAPost, supply);
+  const poolTokenA = tradingTokensToPoolTokens(
+    withdrawAmount,
+    swapTokenAPost,
+    supply,
+  );
   let adjustedPoolTokenA = poolTokenA * roundingAmount;
   if (OWNER_WITHDRAW_FEE_NUMERATOR !== 0) {
-    adjustedPoolTokenA *=  (1 + OWNER_WITHDRAW_FEE_NUMERATOR / OWNER_WITHDRAW_FEE_DENOMINATOR);
+    adjustedPoolTokenA *=
+      1 + OWNER_WITHDRAW_FEE_NUMERATOR / OWNER_WITHDRAW_FEE_DENOMINATOR;
   }
 
   const swapTokenB = await mintB.getAccountInfo(tokenAccountB);
   const swapTokenBPost = swapTokenB.amount.toNumber() - withdrawAmount;
-  const poolTokenB = tradingTokensToPoolTokens(withdrawAmount, swapTokenBPost, supply);
+  const poolTokenB = tradingTokensToPoolTokens(
+    withdrawAmount,
+    swapTokenBPost,
+    supply,
+  );
   let adjustedPoolTokenB = poolTokenB * roundingAmount;
   if (OWNER_WITHDRAW_FEE_NUMERATOR !== 0) {
-    adjustedPoolTokenB *=  (1 + OWNER_WITHDRAW_FEE_NUMERATOR / OWNER_WITHDRAW_FEE_DENOMINATOR);
+    adjustedPoolTokenB *=
+      1 + OWNER_WITHDRAW_FEE_NUMERATOR / OWNER_WITHDRAW_FEE_DENOMINATOR;
   }
 
   console.log('Creating withdraw token a account');
@@ -657,5 +682,8 @@ export async function withdrawOneExactOut(): Promise<void> {
   assert(info.amount.toNumber() == currentSwapTokenB - withdrawAmount);
   currentSwapTokenB += withdrawAmount;
   info = await tokenPool.getAccountInfo(tokenAccountPool);
-  assert(info.amount.toNumber() >= poolTokenAmount - adjustedPoolTokenA - adjustedPoolTokenB);
+  assert(
+    info.amount.toNumber() >=
+      poolTokenAmount - adjustedPoolTokenA - adjustedPoolTokenB,
+  );
 }

--- a/token-swap/js/client/token-swap.js
+++ b/token-swap/js/client/token-swap.js
@@ -824,17 +824,17 @@ export class TokenSwap {
    * @param sourceTokenAmount The amount of token A or B to deposit
    * @param minimumPoolTokenAmount Minimum amount of pool tokens to mint
    */
-  async depositOneExactIn(
+  async depositSingleTokenTypeExactAmountIn(
     userAccount: PublicKey,
     poolAccount: PublicKey,
     sourceTokenAmount: number | Numberu64,
     minimumPoolTokenAmount: number | Numberu64,
   ): Promise<TransactionSignature> {
     return await sendAndConfirmTransaction(
-      'depositOneExactIn',
+      'depositSingleTokenTypeExactAmountIn',
       this.connection,
       new Transaction().add(
-        TokenSwap.depositOneExactInInstruction(
+        TokenSwap.depositSingleTokenTypeExactAmountInInstruction(
           this.tokenSwap,
           this.authority,
           userAccount,
@@ -852,7 +852,7 @@ export class TokenSwap {
     );
   }
 
-  static depositOneExactInInstruction(
+  static depositSingleTokenTypeExactAmountInInstruction(
     tokenSwap: PublicKey,
     authority: PublicKey,
     source: PublicKey,
@@ -874,7 +874,7 @@ export class TokenSwap {
     const data = Buffer.alloc(dataLayout.span);
     dataLayout.encode(
       {
-        instruction: 4, // DepositOneExactIn instruction
+        instruction: 4, // depositSingleTokenTypeExactAmountIn instruction
         sourceTokenAmount: new Numberu64(sourceTokenAmount).toBuffer(),
         minimumPoolTokenAmount: new Numberu64(
           minimumPoolTokenAmount,
@@ -908,17 +908,17 @@ export class TokenSwap {
    * @param destinationTokenAmount The amount of token A or B to withdraw
    * @param maximumPoolTokenAmount Maximum amount of pool tokens to burn
    */
-  async withdrawOneExactOut(
+  async withdrawSingleTokenTypeExactAmountOut(
     userAccount: PublicKey,
     poolAccount: PublicKey,
     destinationTokenAmount: number | Numberu64,
     maximumPoolTokenAmount: number | Numberu64,
   ): Promise<TransactionSignature> {
     return await sendAndConfirmTransaction(
-      'withdrawOneExactOut',
+      'withdrawSingleTokenTypeExactAmountOut',
       this.connection,
       new Transaction().add(
-        TokenSwap.withdrawOneExactOutInstruction(
+        TokenSwap.withdrawSingleTokenTypeExactAmountOutInstruction(
           this.tokenSwap,
           this.authority,
           this.poolToken,
@@ -937,7 +937,7 @@ export class TokenSwap {
     );
   }
 
-  static withdrawOneExactOutInstruction(
+  static withdrawSingleTokenTypeExactAmountOutInstruction(
     tokenSwap: PublicKey,
     authority: PublicKey,
     poolMint: PublicKey,
@@ -960,7 +960,7 @@ export class TokenSwap {
     const data = Buffer.alloc(dataLayout.span);
     dataLayout.encode(
       {
-        instruction: 5, // WithdrawOneExactOut instruction
+        instruction: 5, // withdrawSingleTokenTypeExactAmountOut instruction
         destinationTokenAmount: new Numberu64(
           destinationTokenAmount,
         ).toBuffer(),

--- a/token-swap/js/client/token-swap.js
+++ b/token-swap/js/client/token-swap.js
@@ -816,4 +816,170 @@ export class TokenSwap {
       data,
     });
   }
+
+  /**
+   * Deposit one side of tokens into the pool
+   * @param userAccount User account to deposit token A or B
+   * @param poolAccount User account to receive pool tokens
+   * @param sourceTokenAmount The amount of token A or B to deposit
+   * @param minimumPoolTokenAmount Minimum amount of pool tokens to mint
+   */
+  async depositOneExactIn(
+    userAccount: PublicKey,
+    poolAccount: PublicKey,
+    sourceTokenAmount: number | Numberu64,
+    minimumPoolTokenAmount: number | Numberu64,
+  ): Promise<TransactionSignature> {
+    return await sendAndConfirmTransaction(
+      'depositOneExactIn',
+      this.connection,
+      new Transaction().add(
+        TokenSwap.depositOneExactInInstruction(
+          this.tokenSwap,
+          this.authority,
+          userAccount,
+          this.tokenAccountA,
+          this.tokenAccountB,
+          this.poolToken,
+          poolAccount,
+          this.swapProgramId,
+          this.tokenProgramId,
+          sourceTokenAmount,
+          minimumPoolTokenAmount,
+        ),
+      ),
+      this.payer,
+    );
+  }
+
+  static depositOneExactInInstruction(
+    tokenSwap: PublicKey,
+    authority: PublicKey,
+    source: PublicKey,
+    intoA: PublicKey,
+    intoB: PublicKey,
+    poolToken: PublicKey,
+    poolAccount: PublicKey,
+    swapProgramId: PublicKey,
+    tokenProgramId: PublicKey,
+    sourceTokenAmount: number | Numberu64,
+    minimumPoolTokenAmount: number | Numberu64,
+  ): TransactionInstruction {
+    const dataLayout = BufferLayout.struct([
+      BufferLayout.u8('instruction'),
+      Layout.uint64('sourceTokenAmount'),
+      Layout.uint64('minimumPoolTokenAmount'),
+    ]);
+
+    const data = Buffer.alloc(dataLayout.span);
+    dataLayout.encode(
+      {
+        instruction: 4, // DepositOneExactIn instruction
+        sourceTokenAmount: new Numberu64(sourceTokenAmount).toBuffer(),
+        minimumPoolTokenAmount: new Numberu64(minimumPoolTokenAmount).toBuffer(),
+      },
+      data,
+    );
+
+    const keys = [
+      {pubkey: tokenSwap, isSigner: false, isWritable: false},
+      {pubkey: authority, isSigner: false, isWritable: false},
+      {pubkey: source, isSigner: false, isWritable: true},
+      {pubkey: intoA, isSigner: false, isWritable: true},
+      {pubkey: intoB, isSigner: false, isWritable: true},
+      {pubkey: poolToken, isSigner: false, isWritable: true},
+      {pubkey: poolAccount, isSigner: false, isWritable: true},
+      {pubkey: tokenProgramId, isSigner: false, isWritable: false},
+    ];
+    return new TransactionInstruction({
+      keys,
+      programId: swapProgramId,
+      data,
+    });
+  }
+
+  /**
+   * Withdraw tokens from the pool
+   *
+   * @param userAccount User account to receive token A or B
+   * @param poolAccount User account to burn pool token
+   * @param destinationTokenAmount The amount of token A or B to withdraw
+   * @param maximumPoolTokenAmount Maximum amount of pool tokens to burn
+   */
+  async withdrawOneExactOut(
+    userAccount: PublicKey,
+    poolAccount: PublicKey,
+    destinationTokenAmount: number | Numberu64,
+    maximumPoolTokenAmount: number | Numberu64,
+  ): Promise<TransactionSignature> {
+    return await sendAndConfirmTransaction(
+      'withdrawOneExactOut',
+      this.connection,
+      new Transaction().add(
+        TokenSwap.withdrawOneExactOutInstruction(
+          this.tokenSwap,
+          this.authority,
+          this.poolToken,
+          this.feeAccount,
+          poolAccount,
+          this.tokenAccountA,
+          this.tokenAccountB,
+          userAccount,
+          this.swapProgramId,
+          this.tokenProgramId,
+          destinationTokenAmount,
+          maximumPoolTokenAmount,
+        ),
+      ),
+      this.payer,
+    );
+  }
+
+  static withdrawOneExactOutInstruction(
+    tokenSwap: PublicKey,
+    authority: PublicKey,
+    poolMint: PublicKey,
+    feeAccount: PublicKey,
+    sourcePoolAccount: PublicKey,
+    fromA: PublicKey,
+    fromB: PublicKey,
+    userAccount: PublicKey,
+    swapProgramId: PublicKey,
+    tokenProgramId: PublicKey,
+    destinationTokenAmount: number | Numberu64,
+    maximumPoolTokenAmount: number | Numberu64,
+  ): TransactionInstruction {
+    const dataLayout = BufferLayout.struct([
+      BufferLayout.u8('instruction'),
+      Layout.uint64('destinationTokenAmount'),
+      Layout.uint64('maximumPoolTokenAmount'),
+    ]);
+
+    const data = Buffer.alloc(dataLayout.span);
+    dataLayout.encode(
+      {
+        instruction: 5, // WithdrawOneExactOut instruction
+        destinationTokenAmount: new Numberu64(destinationTokenAmount).toBuffer(),
+        maximumPoolTokenAmount: new Numberu64(maximumPoolTokenAmount).toBuffer(),
+      },
+      data,
+    );
+
+    const keys = [
+      {pubkey: tokenSwap, isSigner: false, isWritable: false},
+      {pubkey: authority, isSigner: false, isWritable: false},
+      {pubkey: poolMint, isSigner: false, isWritable: true},
+      {pubkey: sourcePoolAccount, isSigner: false, isWritable: true},
+      {pubkey: fromA, isSigner: false, isWritable: true},
+      {pubkey: fromB, isSigner: false, isWritable: true},
+      {pubkey: userAccount, isSigner: false, isWritable: true},
+      {pubkey: feeAccount, isSigner: false, isWritable: true},
+      {pubkey: tokenProgramId, isSigner: false, isWritable: false},
+    ];
+    return new TransactionInstruction({
+      keys,
+      programId: swapProgramId,
+      data,
+    });
+  }
 }

--- a/token-swap/js/client/token-swap.js
+++ b/token-swap/js/client/token-swap.js
@@ -876,7 +876,9 @@ export class TokenSwap {
       {
         instruction: 4, // DepositOneExactIn instruction
         sourceTokenAmount: new Numberu64(sourceTokenAmount).toBuffer(),
-        minimumPoolTokenAmount: new Numberu64(minimumPoolTokenAmount).toBuffer(),
+        minimumPoolTokenAmount: new Numberu64(
+          minimumPoolTokenAmount,
+        ).toBuffer(),
       },
       data,
     );
@@ -959,8 +961,12 @@ export class TokenSwap {
     dataLayout.encode(
       {
         instruction: 5, // WithdrawOneExactOut instruction
-        destinationTokenAmount: new Numberu64(destinationTokenAmount).toBuffer(),
-        maximumPoolTokenAmount: new Numberu64(maximumPoolTokenAmount).toBuffer(),
+        destinationTokenAmount: new Numberu64(
+          destinationTokenAmount,
+        ).toBuffer(),
+        maximumPoolTokenAmount: new Numberu64(
+          maximumPoolTokenAmount,
+        ).toBuffer(),
       },
       data,
     );

--- a/token-swap/js/client/token-swap.js
+++ b/token-swap/js/client/token-swap.js
@@ -638,7 +638,7 @@ export class TokenSwap {
    * @param maximumTokenA The maximum amount of token A to deposit
    * @param maximumTokenB The maximum amount of token B to deposit
    */
-  async deposit(
+  async depositAllTokenTypes(
     userAccountA: PublicKey,
     userAccountB: PublicKey,
     poolAccount: PublicKey,
@@ -647,10 +647,10 @@ export class TokenSwap {
     maximumTokenB: number | Numberu64,
   ): Promise<TransactionSignature> {
     return await sendAndConfirmTransaction(
-      'deposit',
+      'depositAllTokenTypes',
       this.connection,
       new Transaction().add(
-        TokenSwap.depositInstruction(
+        TokenSwap.depositAllTokenTypesInstruction(
           this.tokenSwap,
           this.authority,
           userAccountA,
@@ -670,7 +670,7 @@ export class TokenSwap {
     );
   }
 
-  static depositInstruction(
+  static depositAllTokenTypesInstruction(
     tokenSwap: PublicKey,
     authority: PublicKey,
     sourceA: PublicKey,
@@ -731,7 +731,7 @@ export class TokenSwap {
    * @param minimumTokenA The minimum amount of token A to withdraw
    * @param minimumTokenB The minimum amount of token B to withdraw
    */
-  async withdraw(
+  async withdrawAllTokenTypes(
     userAccountA: PublicKey,
     userAccountB: PublicKey,
     poolAccount: PublicKey,
@@ -743,7 +743,7 @@ export class TokenSwap {
       'withdraw',
       this.connection,
       new Transaction().add(
-        TokenSwap.withdrawInstruction(
+        TokenSwap.withdrawAllTokenTypesInstruction(
           this.tokenSwap,
           this.authority,
           this.poolToken,
@@ -764,7 +764,7 @@ export class TokenSwap {
     );
   }
 
-  static withdrawInstruction(
+  static withdrawAllTokenTypesInstruction(
     tokenSwap: PublicKey,
     authority: PublicKey,
     poolMint: PublicKey,

--- a/token-swap/js/module.d.ts
+++ b/token-swap/js/module.d.ts
@@ -178,5 +178,48 @@ declare module '@solana/spl-token-swap' {
       minimumTokenA: number | Numberu64,
       minimumTokenB: number | Numberu64,
     ): TransactionInstruction;
+
+    depositOneExactIn(
+      userAccount: PublicKey,
+      poolAccount: PublicKey,
+      sourceTokenAmount: number | Numberu64,
+      minimumPoolTokenAmount: number | Numberu64,
+    ): Promise<TransactionSignature>;
+
+    static depositOneExactInInstruction(
+      tokenSwap: PublicKey,
+      authority: PublicKey,
+      source: PublicKey,
+      intoA: PublicKey,
+      intoB: PublicKey,
+      poolToken: PublicKey,
+      poolAccount: PublicKey,
+      swapProgramId: PublicKey,
+      tokenProgramId: PublicKey,
+      sourceTokenAmount: number | Numberu64,
+      minimumPoolTokenAmount: number | Numberu64,
+    ): TransactionInstruction;
+
+    withdrawOneExactOut(
+      userAccount: PublicKey,
+      poolAccount: PublicKey,
+      destinationTokenAmount: number | Numberu64,
+      maximumPoolTokenAmount: number | Numberu64,
+    ): Promise<TransactionSignature>;
+
+    static withdrawOneExactOutInstruction(
+      tokenSwap: PublicKey,
+      authority: PublicKey,
+      poolMint: PublicKey,
+      feeAccount: PublicKey,
+      sourcePoolAccount: PublicKey,
+      fromA: PublicKey,
+      fromB: PublicKey,
+      userAccount: PublicKey,
+      swapProgramId: PublicKey,
+      tokenProgramId: PublicKey,
+      destinationTokenAmount: number | Numberu64,
+      maximumPoolTokenAmount: number | Numberu64,
+    ): TransactionInstruction;
   }
 }

--- a/token-swap/js/module.d.ts
+++ b/token-swap/js/module.d.ts
@@ -129,7 +129,7 @@ declare module '@solana/spl-token-swap' {
       minimumAmountOut: number | Numberu64,
     ): TransactionInstruction;
 
-    deposit(
+    depositAllTokenTypes(
       userAccountA: PublicKey,
       userAccountB: PublicKey,
       poolAccount: PublicKey,
@@ -138,7 +138,7 @@ declare module '@solana/spl-token-swap' {
       maximumTokenB: number | Numberu64,
     ): Promise<TransactionSignature>;
 
-    static depositInstruction(
+    static depositAllTokenTypesInstruction(
       tokenSwap: PublicKey,
       authority: PublicKey,
       sourceA: PublicKey,
@@ -154,7 +154,7 @@ declare module '@solana/spl-token-swap' {
       maximumTokenB: number | Numberu64,
     ): TransactionInstruction;
 
-    withdraw(
+    withdrawAllTokenTypes(
       userAccountA: PublicKey,
       userAccountB: PublicKey,
       poolTokenAmount: number | Numberu64,
@@ -162,7 +162,7 @@ declare module '@solana/spl-token-swap' {
       minimumTokenB: number | Numberu64,
     ): Promise<TransactionSignature>;
 
-    static withdrawInstruction(
+    static withdrawAllTokenTypesInstruction(
       tokenSwap: PublicKey,
       authority: PublicKey,
       poolMint: PublicKey,

--- a/token-swap/js/module.d.ts
+++ b/token-swap/js/module.d.ts
@@ -179,14 +179,14 @@ declare module '@solana/spl-token-swap' {
       minimumTokenB: number | Numberu64,
     ): TransactionInstruction;
 
-    depositOneExactIn(
+    depositSingleTokenTypeExactAmountIn(
       userAccount: PublicKey,
       poolAccount: PublicKey,
       sourceTokenAmount: number | Numberu64,
       minimumPoolTokenAmount: number | Numberu64,
     ): Promise<TransactionSignature>;
 
-    static depositOneExactInInstruction(
+    static depositSingleTokenTypeExactAmountInInstruction(
       tokenSwap: PublicKey,
       authority: PublicKey,
       source: PublicKey,
@@ -200,14 +200,14 @@ declare module '@solana/spl-token-swap' {
       minimumPoolTokenAmount: number | Numberu64,
     ): TransactionInstruction;
 
-    withdrawOneExactOut(
+    withdrawSingleTokenTypeExactAmountOut(
       userAccount: PublicKey,
       poolAccount: PublicKey,
       destinationTokenAmount: number | Numberu64,
       maximumPoolTokenAmount: number | Numberu64,
     ): Promise<TransactionSignature>;
 
-    static withdrawOneExactOutInstruction(
+    static withdrawSingleTokenTypeExactAmountOutInstruction(
       tokenSwap: PublicKey,
       authority: PublicKey,
       poolMint: PublicKey,

--- a/token-swap/js/module.flow.js
+++ b/token-swap/js/module.flow.js
@@ -177,14 +177,14 @@ declare module '@solana/spl-token-swap' {
       minimumTokenB: number | Numberu64,
     ): TransactionInstruction;
 
-    depositOneExactIn(
+    depositSingleTokenTypeExactAmountIn(
       userAccount: PublicKey,
       poolAccount: PublicKey,
       sourceTokenAmount: number | Numberu64,
       minimumPoolTokenAmount: number | Numberu64,
     ): Promise<TransactionSignature>;
 
-    static depositOneExactInInstruction(
+    static depositSingleTokenTypeExactAmountInInstruction(
       tokenSwap: PublicKey,
       authority: PublicKey,
       source: PublicKey,
@@ -198,14 +198,14 @@ declare module '@solana/spl-token-swap' {
       minimumPoolTokenAmount: number | Numberu64,
     ): TransactionInstruction;
 
-    withdrawOneExactOut(
+    withdrawSingleTokenTypeExactAmountOut(
       userAccount: PublicKey,
       poolAccount: PublicKey,
       destinationTokenAmount: number | Numberu64,
       maximumPoolTokenAmount: number | Numberu64,
     ): Promise<TransactionSignature>;
 
-    static withdrawOneExactOutInstruction(
+    static withdrawSingleTokenTypeExactAmountOutInstruction(
       tokenSwap: PublicKey,
       authority: PublicKey,
       poolMint: PublicKey,

--- a/token-swap/js/module.flow.js
+++ b/token-swap/js/module.flow.js
@@ -126,7 +126,7 @@ declare module '@solana/spl-token-swap' {
       minimumAmountOut: number | Numberu64,
     ): TransactionInstruction;
 
-    deposit(
+    depositAllTokenTypes(
       userAccountA: PublicKey,
       userAccountB: PublicKey,
       poolAccount: PublicKey,
@@ -135,7 +135,7 @@ declare module '@solana/spl-token-swap' {
       maximumTokenB: number | Numberu64,
     ): Promise<TransactionSignature>;
 
-    static depositInstruction(
+    static depositAllTokenTypesInstruction(
       tokenSwap: PublicKey,
       authority: PublicKey,
       sourceA: PublicKey,
@@ -151,7 +151,7 @@ declare module '@solana/spl-token-swap' {
       maximumTokenB: number | Numberu64,
     ): TransactionInstruction;
 
-    withdraw(
+    withdrawAllTokenTypes(
       userAccountA: PublicKey,
       userAccountB: PublicKey,
       poolAccount: PublicKey,
@@ -160,7 +160,7 @@ declare module '@solana/spl-token-swap' {
       minimumTokenB: number | Numberu64,
     ): Promise<TransactionSignature>;
 
-    static withdrawInstruction(
+    static withdrawAllTokenTypesInstruction(
       tokenSwap: PublicKey,
       authority: PublicKey,
       poolMint: PublicKey,

--- a/token-swap/js/module.flow.js
+++ b/token-swap/js/module.flow.js
@@ -176,5 +176,48 @@ declare module '@solana/spl-token-swap' {
       minimumTokenA: number | Numberu64,
       minimumTokenB: number | Numberu64,
     ): TransactionInstruction;
+
+    depositOneExactIn(
+      userAccount: PublicKey,
+      poolAccount: PublicKey,
+      sourceTokenAmount: number | Numberu64,
+      minimumPoolTokenAmount: number | Numberu64,
+    ): Promise<TransactionSignature>;
+
+    static depositOneExactInInstruction(
+      tokenSwap: PublicKey,
+      authority: PublicKey,
+      source: PublicKey,
+      intoA: PublicKey,
+      intoB: PublicKey,
+      poolToken: PublicKey,
+      poolAccount: PublicKey,
+      swapProgramId: PublicKey,
+      tokenProgramId: PublicKey,
+      sourceTokenAmount: number | Numberu64,
+      minimumPoolTokenAmount: number | Numberu64,
+    ): TransactionInstruction;
+
+    withdrawOneExactOut(
+      userAccount: PublicKey,
+      poolAccount: PublicKey,
+      destinationTokenAmount: number | Numberu64,
+      maximumPoolTokenAmount: number | Numberu64,
+    ): Promise<TransactionSignature>;
+
+    static withdrawOneExactOutInstruction(
+      tokenSwap: PublicKey,
+      authority: PublicKey,
+      poolMint: PublicKey,
+      feeAccount: PublicKey,
+      sourcePoolAccount: PublicKey,
+      fromA: PublicKey,
+      fromB: PublicKey,
+      userAccount: PublicKey,
+      swapProgramId: PublicKey,
+      tokenProgramId: PublicKey,
+      destinationTokenAmount: number | Numberu64,
+      maximumPoolTokenAmount: number | Numberu64,
+    ): TransactionInstruction;
   }
 }

--- a/token-swap/program/fuzz/src/instructions.rs
+++ b/token-swap/program/fuzz/src/instructions.rs
@@ -10,7 +10,7 @@ use spl_token_swap::{
         fees::Fees,
     },
     error::SwapError,
-    instruction::{Deposit, Swap, Withdraw},
+    instruction::{DepositAllTokenTypes, Swap, Withdraw},
 };
 
 use spl_token::error::TokenError;
@@ -28,11 +28,11 @@ enum FuzzInstruction {
         trade_direction: TradeDirection,
         instruction: Swap,
     },
-    Deposit {
+    DepositAllTokenTypes {
         token_a_id: AccountId,
         token_b_id: AccountId,
         pool_token_id: AccountId,
-        instruction: Deposit,
+        instruction: DepositAllTokenTypes,
     },
     Withdraw {
         token_a_id: AccountId,
@@ -206,7 +206,7 @@ fn run_fuzz_instruction(
                 }
             }
         }
-        FuzzInstruction::Deposit {
+        FuzzInstruction::DepositAllTokenTypes {
             token_a_id,
             token_b_id,
             pool_token_id,
@@ -271,7 +271,7 @@ fn get_total_token_a_amount(fuzz_instructions: &[FuzzInstruction]) -> u64 {
     for fuzz_instruction in fuzz_instructions.iter() {
         match fuzz_instruction {
             FuzzInstruction::Swap { token_a_id, .. } => token_a_ids.insert(token_a_id),
-            FuzzInstruction::Deposit { token_a_id, .. } => token_a_ids.insert(token_a_id),
+            FuzzInstruction::DepositAllTokenTypes { token_a_id, .. } => token_a_ids.insert(token_a_id),
             FuzzInstruction::Withdraw { token_a_id, .. } => token_a_ids.insert(token_a_id),
         };
     }
@@ -283,7 +283,7 @@ fn get_total_token_b_amount(fuzz_instructions: &[FuzzInstruction]) -> u64 {
     for fuzz_instruction in fuzz_instructions.iter() {
         match fuzz_instruction {
             FuzzInstruction::Swap { token_b_id, .. } => token_b_ids.insert(token_b_id),
-            FuzzInstruction::Deposit { token_b_id, .. } => token_b_ids.insert(token_b_id),
+            FuzzInstruction::DepositAllTokenTypes { token_b_id, .. } => token_b_ids.insert(token_b_id),
             FuzzInstruction::Withdraw { token_b_id, .. } => token_b_ids.insert(token_b_id),
         };
     }

--- a/token-swap/program/fuzz/src/instructions.rs
+++ b/token-swap/program/fuzz/src/instructions.rs
@@ -271,8 +271,12 @@ fn get_total_token_a_amount(fuzz_instructions: &[FuzzInstruction]) -> u64 {
     for fuzz_instruction in fuzz_instructions.iter() {
         match fuzz_instruction {
             FuzzInstruction::Swap { token_a_id, .. } => token_a_ids.insert(token_a_id),
-            FuzzInstruction::DepositAllTokenTypes { token_a_id, .. } => token_a_ids.insert(token_a_id),
-            FuzzInstruction::WithdrawAllTokenTypes { token_a_id, .. } => token_a_ids.insert(token_a_id),
+            FuzzInstruction::DepositAllTokenTypes { token_a_id, .. } => {
+                token_a_ids.insert(token_a_id)
+            }
+            FuzzInstruction::WithdrawAllTokenTypes { token_a_id, .. } => {
+                token_a_ids.insert(token_a_id)
+            }
         };
     }
     (token_a_ids.len() as u64) * INITIAL_USER_TOKEN_A_AMOUNT
@@ -283,8 +287,12 @@ fn get_total_token_b_amount(fuzz_instructions: &[FuzzInstruction]) -> u64 {
     for fuzz_instruction in fuzz_instructions.iter() {
         match fuzz_instruction {
             FuzzInstruction::Swap { token_b_id, .. } => token_b_ids.insert(token_b_id),
-            FuzzInstruction::DepositAllTokenTypes { token_b_id, .. } => token_b_ids.insert(token_b_id),
-            FuzzInstruction::WithdrawAllTokenTypes { token_b_id, .. } => token_b_ids.insert(token_b_id),
+            FuzzInstruction::DepositAllTokenTypes { token_b_id, .. } => {
+                token_b_ids.insert(token_b_id)
+            }
+            FuzzInstruction::WithdrawAllTokenTypes { token_b_id, .. } => {
+                token_b_ids.insert(token_b_id)
+            }
         };
     }
     (token_b_ids.len() as u64) * INITIAL_USER_TOKEN_B_AMOUNT

--- a/token-swap/program/fuzz/src/instructions.rs
+++ b/token-swap/program/fuzz/src/instructions.rs
@@ -10,7 +10,7 @@ use spl_token_swap::{
         fees::Fees,
     },
     error::SwapError,
-    instruction::{DepositAllTokenTypes, Swap, Withdraw},
+    instruction::{DepositAllTokenTypes, Swap, WithdrawAllTokenTypes},
 };
 
 use spl_token::error::TokenError;
@@ -34,11 +34,11 @@ enum FuzzInstruction {
         pool_token_id: AccountId,
         instruction: DepositAllTokenTypes,
     },
-    Withdraw {
+    WithdrawAllTokenTypes {
         token_a_id: AccountId,
         token_b_id: AccountId,
         pool_token_id: AccountId,
-        instruction: Withdraw,
+        instruction: WithdrawAllTokenTypes,
     },
 }
 
@@ -228,7 +228,7 @@ fn run_fuzz_instruction(
                 instruction,
             )
         }
-        FuzzInstruction::Withdraw {
+        FuzzInstruction::WithdrawAllTokenTypes {
             token_a_id,
             token_b_id,
             pool_token_id,
@@ -272,7 +272,7 @@ fn get_total_token_a_amount(fuzz_instructions: &[FuzzInstruction]) -> u64 {
         match fuzz_instruction {
             FuzzInstruction::Swap { token_a_id, .. } => token_a_ids.insert(token_a_id),
             FuzzInstruction::DepositAllTokenTypes { token_a_id, .. } => token_a_ids.insert(token_a_id),
-            FuzzInstruction::Withdraw { token_a_id, .. } => token_a_ids.insert(token_a_id),
+            FuzzInstruction::WithdrawAllTokenTypes { token_a_id, .. } => token_a_ids.insert(token_a_id),
         };
     }
     (token_a_ids.len() as u64) * INITIAL_USER_TOKEN_A_AMOUNT
@@ -284,7 +284,7 @@ fn get_total_token_b_amount(fuzz_instructions: &[FuzzInstruction]) -> u64 {
         match fuzz_instruction {
             FuzzInstruction::Swap { token_b_id, .. } => token_b_ids.insert(token_b_id),
             FuzzInstruction::DepositAllTokenTypes { token_b_id, .. } => token_b_ids.insert(token_b_id),
-            FuzzInstruction::Withdraw { token_b_id, .. } => token_b_ids.insert(token_b_id),
+            FuzzInstruction::WithdrawAllTokenTypes { token_b_id, .. } => token_b_ids.insert(token_b_id),
         };
     }
     (token_b_ids.len() as u64) * INITIAL_USER_TOKEN_B_AMOUNT

--- a/token-swap/program/fuzz/src/native_token_swap.rs
+++ b/token-swap/program/fuzz/src/native_token_swap.rs
@@ -6,7 +6,7 @@ use crate::native_token;
 
 use spl_token_swap::{
     curve::{base::SwapCurve, fees::Fees},
-    instruction::{self, DepositAllTokenTypes, Swap, Withdraw},
+    instruction::{self, DepositAllTokenTypes, Swap, WithdrawAllTokenTypes},
     state::SwapInfo,
 };
 
@@ -341,7 +341,7 @@ impl NativeTokenSwap {
         pool_account: &mut NativeAccountData,
         token_a_account: &mut NativeAccountData,
         token_b_account: &mut NativeAccountData,
-        mut instruction: Withdraw,
+        mut instruction: WithdrawAllTokenTypes,
     ) -> ProgramResult {
         let pool_token_amount = native_token::get_token_balance(&pool_account);
         // special logic to avoid withdrawing down to 1 pool token, which
@@ -408,7 +408,7 @@ impl NativeTokenSwap {
     ) -> ProgramResult {
         let pool_token_amount = native_token::get_token_balance(&pool_account);
         if pool_token_amount > 0 {
-            let instruction = Withdraw {
+            let instruction = WithdrawAllTokenTypes {
                 pool_token_amount,
                 minimum_token_a_amount: 0,
                 minimum_token_b_amount: 0,

--- a/token-swap/program/fuzz/src/native_token_swap.rs
+++ b/token-swap/program/fuzz/src/native_token_swap.rs
@@ -6,7 +6,7 @@ use crate::native_token;
 
 use spl_token_swap::{
     curve::{base::SwapCurve, fees::Fees},
-    instruction::{self, Deposit, Swap, Withdraw},
+    instruction::{self, DepositAllTokenTypes, Swap, Withdraw},
     state::SwapInfo,
 };
 
@@ -261,7 +261,7 @@ impl NativeTokenSwap {
         token_a_account: &mut NativeAccountData,
         token_b_account: &mut NativeAccountData,
         pool_account: &mut NativeAccountData,
-        mut instruction: Deposit,
+        mut instruction: DepositAllTokenTypes,
     ) -> ProgramResult {
         do_process_instruction(
             approve(

--- a/token-swap/program/src/instruction.rs
+++ b/token-swap/program/src/instruction.rs
@@ -40,11 +40,11 @@ pub struct Swap {
     pub minimum_amount_out: u64,
 }
 
-/// Deposit instruction data
+/// DepositAllTokenTypes instruction data
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
-pub struct Deposit {
+pub struct DepositAllTokenTypes {
     /// Pool token amount to transfer. token_a and token_b amount are set by
     /// the current exchange rate and size of the pool
     pub pool_token_amount: u64,
@@ -68,7 +68,7 @@ pub struct Withdraw {
     pub minimum_token_b_amount: u64,
 }
 
-/// Deposit one exact in instruction data
+/// Deposit one token type, exact amount in instruction data
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
@@ -124,8 +124,9 @@ pub enum SwapInstruction {
     ///   9. `[optional, writable]` Host fee account to receive additional trading fees
     Swap(Swap),
 
-    ///   Deposit some tokens into the pool.  The output is a "pool" token representing ownership
-    ///   into the pool. Inputs are converted to the current ratio.
+    ///   Deposit both types of tokens into the pool.  The output is a "pool"
+    ///   token representing ownership in the pool. Inputs are converted to
+    ///   the current ratio.
     ///
     ///   0. `[]` Token-swap
     ///   1. `[]` $authority
@@ -136,7 +137,7 @@ pub enum SwapInstruction {
     ///   6. `[writable]` Pool MINT account, $authority is the owner.
     ///   7. `[writable]` Pool Account to deposit the generated tokens, user is the owner.
     ///   8. '[]` Token program id
-    Deposit(Deposit),
+    DepositAllTokenTypes(DepositAllTokenTypes),
 
     ///   Withdraw the token from the pool at the current ratio.
     ///
@@ -152,7 +153,7 @@ pub enum SwapInstruction {
     ///   9. '[]` Token program id
     Withdraw(Withdraw),
 
-    ///   Deposit some tokens into the pool.  The output is a "pool" token
+    ///   DepositAllTokenTypes some tokens into the pool.  The output is a "pool" token
     ///   representing ownership into the pool. Input token is converted at
     ///   the current ratio.
     ///
@@ -212,7 +213,7 @@ impl SwapInstruction {
                 let (pool_token_amount, rest) = Self::unpack_u64(rest)?;
                 let (maximum_token_a_amount, rest) = Self::unpack_u64(rest)?;
                 let (maximum_token_b_amount, _rest) = Self::unpack_u64(rest)?;
-                Self::Deposit(Deposit {
+                Self::DepositAllTokenTypes(DepositAllTokenTypes {
                     pool_token_amount,
                     maximum_token_a_amount,
                     maximum_token_b_amount,
@@ -288,7 +289,7 @@ impl SwapInstruction {
                 buf.extend_from_slice(&amount_in.to_le_bytes());
                 buf.extend_from_slice(&minimum_amount_out.to_le_bytes());
             }
-            Self::Deposit(Deposit {
+            Self::DepositAllTokenTypes(DepositAllTokenTypes {
                 pool_token_amount,
                 maximum_token_a_amount,
                 maximum_token_b_amount,
@@ -381,9 +382,9 @@ pub fn deposit(
     swap_token_b_pubkey: &Pubkey,
     pool_mint_pubkey: &Pubkey,
     destination_pubkey: &Pubkey,
-    instruction: Deposit,
+    instruction: DepositAllTokenTypes,
 ) -> Result<Instruction, ProgramError> {
-    let data = SwapInstruction::Deposit(instruction).pack();
+    let data = SwapInstruction::DepositAllTokenTypes(instruction).pack();
 
     let accounts = vec![
         AccountMeta::new_readonly(*swap_pubkey, false),
@@ -640,7 +641,7 @@ mod tests {
         let pool_token_amount: u64 = 5;
         let maximum_token_a_amount: u64 = 10;
         let maximum_token_b_amount: u64 = 20;
-        let check = SwapInstruction::Deposit(Deposit {
+        let check = SwapInstruction::DepositAllTokenTypes(DepositAllTokenTypes {
             pool_token_amount,
             maximum_token_a_amount,
             maximum_token_b_amount,

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -146,6 +146,7 @@ impl Processor {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn check_accounts(
         token_swap: &SwapInfo,
         program_id: &Pubkey,
@@ -4509,7 +4510,7 @@ mod tests {
             let old_b_account = accounts.token_b_account;
 
             accounts.token_b_key = token_b_key;
-            accounts.token_b_account = token_b_account.clone();
+            accounts.token_b_account = token_b_account;
 
             // wrong swap token b account
             assert_eq!(

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -5,7 +5,7 @@ use crate::{
     curve::{base::SwapCurve, calculator::TradeDirection, fees::Fees},
     error::SwapError,
     instruction::{
-        DepositAllTokenTypes, DepositOneExactIn, Initialize, Swap, SwapInstruction, Withdraw,
+        DepositAllTokenTypes, DepositOneExactIn, Initialize, Swap, SwapInstruction, WithdrawAllTokenTypes,
         WithdrawOneExactOut,
     },
     state::SwapInfo,
@@ -582,7 +582,7 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes an [Withdraw](enum.Instruction.html).
+    /// Processes an [WithdrawAllTokenTypes](enum.Instruction.html).
     pub fn process_withdraw(
         program_id: &Pubkey,
         pool_token_amount: u64,
@@ -817,7 +817,7 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes an [Withdraw](enum.Instruction.html).
+    /// Processes an [WithdrawAllTokenTypes](enum.Instruction.html).
     pub fn process_withdraw_one_exact_out(
         program_id: &Pubkey,
         destination_token_amount: u64,
@@ -1022,12 +1022,12 @@ impl Processor {
                     accounts,
                 )
             }
-            SwapInstruction::Withdraw(Withdraw {
+            SwapInstruction::WithdrawAllTokenTypes(WithdrawAllTokenTypes {
                 pool_token_amount,
                 minimum_token_a_amount,
                 minimum_token_b_amount,
             }) => {
-                msg!("Instruction: Withdraw");
+                msg!("Instruction: WithdrawAllTokenTypes");
                 Self::process_withdraw(
                     program_id,
                     pool_token_amount,
@@ -1613,7 +1613,7 @@ mod tests {
                     &self.token_b_key,
                     &token_a_key,
                     &token_b_key,
-                    Withdraw {
+                    WithdrawAllTokenTypes {
                         pool_token_amount,
                         minimum_token_a_amount,
                         minimum_token_b_amount,
@@ -3728,7 +3728,7 @@ mod tests {
                         &accounts.token_b_key,
                         &token_a_key,
                         &token_b_key,
-                        Withdraw {
+                        WithdrawAllTokenTypes {
                             pool_token_amount: withdraw_amount.try_into().unwrap(),
                             minimum_token_a_amount,
                             minimum_token_b_amount,
@@ -3783,7 +3783,7 @@ mod tests {
                         &accounts.token_b_key,
                         &token_a_key,
                         &token_b_key,
-                        Withdraw {
+                        WithdrawAllTokenTypes {
                             pool_token_amount: withdraw_amount.try_into().unwrap(),
                             minimum_token_a_amount,
                             minimum_token_b_amount,
@@ -6621,7 +6621,7 @@ mod tests {
         let pool_key = accounts.pool_token_key;
         let mut pool_account = accounts.pool_token_account.clone();
 
-        // Withdraw takes all tokens for A and B.
+        // WithdrawAllTokenTypes takes all tokens for A and B.
         // The curve's calculation for token B will say to transfer
         // `token_b_offset + token_b_amount`, but only `token_b_amount` will be
         // moved.

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -5,7 +5,7 @@ use crate::{
     curve::{base::SwapCurve, calculator::TradeDirection, fees::Fees},
     error::SwapError,
     instruction::{
-        Deposit, DepositOneExactIn, Initialize, Swap, SwapInstruction, Withdraw,
+        DepositAllTokenTypes, DepositOneExactIn, Initialize, Swap, SwapInstruction, Withdraw,
         WithdrawOneExactOut,
     },
     state::SwapInfo,
@@ -480,7 +480,7 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes an [Deposit](enum.Instruction.html).
+    /// Processes an [DepositAllTokenTypes](enum.Instruction.html).
     pub fn process_deposit(
         program_id: &Pubkey,
         pool_token_amount: u64,
@@ -1008,12 +1008,12 @@ impl Processor {
                 msg!("Instruction: Swap");
                 Self::process_swap(program_id, amount_in, minimum_amount_out, accounts)
             }
-            SwapInstruction::Deposit(Deposit {
+            SwapInstruction::DepositAllTokenTypes(DepositAllTokenTypes {
                 pool_token_amount,
                 maximum_token_a_amount,
                 maximum_token_b_amount,
             }) => {
-                msg!("Instruction: Deposit");
+                msg!("Instruction: DepositAllTokenTypes");
                 Self::process_deposit(
                     program_id,
                     pool_token_amount,
@@ -1545,7 +1545,7 @@ mod tests {
                     &self.token_b_key,
                     &self.pool_mint_key,
                     &depositor_pool_key,
-                    Deposit {
+                    DepositAllTokenTypes {
                         pool_token_amount,
                         maximum_token_a_amount,
                         maximum_token_b_amount,
@@ -3074,7 +3074,7 @@ mod tests {
                         &accounts.token_b_key,
                         &accounts.pool_mint_key,
                         &pool_key,
-                        Deposit {
+                        DepositAllTokenTypes {
                             pool_token_amount: pool_amount.try_into().unwrap(),
                             maximum_token_a_amount: deposit_a,
                             maximum_token_b_amount: deposit_b,
@@ -3121,7 +3121,7 @@ mod tests {
                         &accounts.token_b_key,
                         &accounts.pool_mint_key,
                         &pool_key,
-                        Deposit {
+                        DepositAllTokenTypes {
                             pool_token_amount: pool_amount.try_into().unwrap(),
                             maximum_token_a_amount: deposit_a,
                             maximum_token_b_amount: deposit_b,

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -5,8 +5,8 @@ use crate::{
     curve::{base::SwapCurve, calculator::TradeDirection, fees::Fees},
     error::SwapError,
     instruction::{
-        DepositAllTokenTypes, DepositOneExactIn, Initialize, Swap, SwapInstruction, WithdrawAllTokenTypes,
-        WithdrawOneExactOut,
+        DepositAllTokenTypes, DepositSingleTokenTypeExactAmountIn, Initialize, Swap,
+        SwapInstruction, WithdrawAllTokenTypes, WithdrawSingleTokenTypeExactAmountOut,
     },
     state::SwapInfo,
 };
@@ -481,7 +481,7 @@ impl Processor {
     }
 
     /// Processes an [DepositAllTokenTypes](enum.Instruction.html).
-    pub fn process_deposit(
+    pub fn process_deposit_all_token_types(
         program_id: &Pubkey,
         pool_token_amount: u64,
         maximum_token_a_amount: u64,
@@ -583,7 +583,7 @@ impl Processor {
     }
 
     /// Processes an [WithdrawAllTokenTypes](enum.Instruction.html).
-    pub fn process_withdraw(
+    pub fn process_withdraw_all_token_types(
         program_id: &Pubkey,
         pool_token_amount: u64,
         minimum_token_a_amount: u64,
@@ -706,8 +706,8 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes DepositOneExactIn
-    pub fn process_deposit_one_exact_in(
+    /// Processes DepositSingleTokenTypeExactAmountIn
+    pub fn process_deposit_single_token_type_exact_amount_in(
         program_id: &Pubkey,
         source_token_amount: u64,
         minimum_pool_token_amount: u64,
@@ -817,8 +817,8 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes an [WithdrawAllTokenTypes](enum.Instruction.html).
-    pub fn process_withdraw_one_exact_out(
+    /// Processes a [WithdrawSingleTokenTypeExactAmountOut](enum.Instruction.html).
+    pub fn process_withdraw_single_token_type_exact_amount_out(
         program_id: &Pubkey,
         destination_token_amount: u64,
         maximum_pool_token_amount: u64,
@@ -1014,7 +1014,7 @@ impl Processor {
                 maximum_token_b_amount,
             }) => {
                 msg!("Instruction: DepositAllTokenTypes");
-                Self::process_deposit(
+                Self::process_deposit_all_token_types(
                     program_id,
                     pool_token_amount,
                     maximum_token_a_amount,
@@ -1028,7 +1028,7 @@ impl Processor {
                 minimum_token_b_amount,
             }) => {
                 msg!("Instruction: WithdrawAllTokenTypes");
-                Self::process_withdraw(
+                Self::process_withdraw_all_token_types(
                     program_id,
                     pool_token_amount,
                     minimum_token_a_amount,
@@ -1036,24 +1036,28 @@ impl Processor {
                     accounts,
                 )
             }
-            SwapInstruction::DepositOneExactIn(DepositOneExactIn {
-                source_token_amount,
-                minimum_pool_token_amount,
-            }) => {
-                msg!("Instruction: DepositOneExactIn");
-                Self::process_deposit_one_exact_in(
+            SwapInstruction::DepositSingleTokenTypeExactAmountIn(
+                DepositSingleTokenTypeExactAmountIn {
+                    source_token_amount,
+                    minimum_pool_token_amount,
+                },
+            ) => {
+                msg!("Instruction: DepositSingleTokenTypeExactAmountIn");
+                Self::process_deposit_single_token_type_exact_amount_in(
                     program_id,
                     source_token_amount,
                     minimum_pool_token_amount,
                     accounts,
                 )
             }
-            SwapInstruction::WithdrawOneExactOut(WithdrawOneExactOut {
-                destination_token_amount,
-                maximum_pool_token_amount,
-            }) => {
-                msg!("Instruction: WithdrawOneExactOut");
-                Self::process_withdraw_one_exact_out(
+            SwapInstruction::WithdrawSingleTokenTypeExactAmountOut(
+                WithdrawSingleTokenTypeExactAmountOut {
+                    destination_token_amount,
+                    maximum_pool_token_amount,
+                },
+            ) => {
+                msg!("Instruction: WithdrawSingleTokenTypeExactAmountOut");
+                Self::process_withdraw_single_token_type_exact_amount_out(
                     program_id,
                     destination_token_amount,
                     maximum_pool_token_amount,
@@ -1675,7 +1679,7 @@ mod tests {
                     &self.token_b_key,
                     &self.pool_mint_key,
                     &deposit_pool_key,
-                    DepositOneExactIn {
+                    DepositSingleTokenTypeExactAmountIn {
                         source_token_amount,
                         minimum_pool_token_amount,
                     },
@@ -1736,7 +1740,7 @@ mod tests {
                     &self.token_a_key,
                     &self.token_b_key,
                     &destination_key,
-                    WithdrawOneExactOut {
+                    WithdrawSingleTokenTypeExactAmountOut {
                         destination_token_amount,
                         maximum_pool_token_amount,
                     },
@@ -4408,7 +4412,7 @@ mod tests {
                         &accounts.token_b_key,
                         &accounts.pool_mint_key,
                         &pool_key,
-                        DepositOneExactIn {
+                        DepositSingleTokenTypeExactAmountIn {
                             source_token_amount: deposit_a,
                             minimum_pool_token_amount: pool_amount,
                         },
@@ -4452,7 +4456,7 @@ mod tests {
                         &accounts.token_b_key,
                         &accounts.pool_mint_key,
                         &pool_key,
-                        DepositOneExactIn {
+                        DepositSingleTokenTypeExactAmountIn {
                             source_token_amount: deposit_a,
                             minimum_pool_token_amount: pool_amount,
                         },
@@ -4970,7 +4974,7 @@ mod tests {
                         &accounts.token_a_key,
                         &accounts.token_b_key,
                         &token_a_key,
-                        WithdrawOneExactOut {
+                        WithdrawSingleTokenTypeExactAmountOut {
                             destination_token_amount: destination_a_amount,
                             maximum_pool_token_amount,
                         }
@@ -5022,7 +5026,7 @@ mod tests {
                         &accounts.token_a_key,
                         &accounts.token_b_key,
                         &token_a_key,
-                        WithdrawOneExactOut {
+                        WithdrawSingleTokenTypeExactAmountOut {
                             destination_token_amount: destination_a_amount,
                             maximum_pool_token_amount,
                         }

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -4,7 +4,7 @@ use crate::constraints::{SwapConstraints, SWAP_CONSTRAINTS};
 use crate::{
     curve::{base::SwapCurve, calculator::TradeDirection, fees::Fees},
     error::SwapError,
-    instruction::{Deposit, Initialize, Swap, SwapInstruction, Withdraw},
+    instruction::{Initialize, Swap, SwapInstruction, Deposit, DepositOneExactIn, Withdraw, WithdrawOneExactOut},
     state::SwapInfo,
 };
 use num_traits::FromPrimitive;
@@ -141,6 +141,55 @@ impl Processor {
             &[source, destination, authority, token_program],
             signers,
         )
+    }
+
+    fn check_accounts(
+        token_swap: &SwapInfo,
+        program_id: &Pubkey,
+        swap_account_info: &AccountInfo,
+        authority_info: &AccountInfo,
+        token_a_info: &AccountInfo,
+        token_b_info: &AccountInfo,
+        pool_mint_info: &AccountInfo,
+        token_program_info: &AccountInfo,
+        user_token_a_info: Option<&AccountInfo>,
+        user_token_b_info: Option<&AccountInfo>,
+        pool_fee_account_info: Option<&AccountInfo>,
+    ) -> ProgramResult {
+        if swap_account_info.owner != program_id {
+            return Err(ProgramError::IncorrectProgramId);
+        }
+        if *authority_info.key != Self::authority_id(program_id, swap_account_info.key, token_swap.nonce)? {
+            return Err(SwapError::InvalidProgramAddress.into());
+        }
+        if *token_a_info.key != token_swap.token_a {
+            return Err(SwapError::IncorrectSwapAccount.into());
+        }
+        if *token_b_info.key != token_swap.token_b {
+            return Err(SwapError::IncorrectSwapAccount.into());
+        }
+        if *pool_mint_info.key != token_swap.pool_mint {
+            return Err(SwapError::IncorrectPoolMint.into());
+        }
+        if *token_program_info.key != token_swap.token_program_id {
+            return Err(SwapError::IncorrectTokenProgramId.into());
+        }
+        if let Some(user_token_a_info) = user_token_a_info {
+            if token_a_info.key == user_token_a_info.key {
+                return Err(SwapError::InvalidInput.into());
+            }
+        }
+        if let Some(user_token_b_info) = user_token_b_info {
+            if token_b_info.key == user_token_b_info.key {
+                return Err(SwapError::InvalidInput.into());
+            }
+        }
+        if let Some(pool_fee_account_info) = pool_fee_account_info {
+            if *pool_fee_account_info.key != token_swap.pool_fee_account {
+                return Err(SwapError::IncorrectFeeAccount.into());
+            }
+        }
+        Ok(())
     }
 
     /// Processes an [Initialize](enum.Instruction.html).
@@ -444,34 +493,23 @@ impl Processor {
         let dest_info = next_account_info(account_info_iter)?;
         let token_program_info = next_account_info(account_info_iter)?;
 
-        if swap_info.owner != program_id {
-            return Err(ProgramError::IncorrectProgramId);
-        }
         let token_swap = SwapInfo::unpack(&swap_info.data.borrow())?;
         if !token_swap.swap_curve.calculator.allows_deposits() {
             return Err(SwapError::UnsupportedCurveOperation.into());
         }
-        if *authority_info.key != Self::authority_id(program_id, swap_info.key, token_swap.nonce)? {
-            return Err(SwapError::InvalidProgramAddress.into());
-        }
-        if *token_a_info.key != token_swap.token_a {
-            return Err(SwapError::IncorrectSwapAccount.into());
-        }
-        if *token_b_info.key != token_swap.token_b {
-            return Err(SwapError::IncorrectSwapAccount.into());
-        }
-        if *pool_mint_info.key != token_swap.pool_mint {
-            return Err(SwapError::IncorrectPoolMint.into());
-        }
-        if token_a_info.key == source_a_info.key {
-            return Err(SwapError::InvalidInput.into());
-        }
-        if token_b_info.key == source_b_info.key {
-            return Err(SwapError::InvalidInput.into());
-        }
-        if *token_program_info.key != token_swap.token_program_id {
-            return Err(SwapError::IncorrectTokenProgramId.into());
-        }
+        Self::check_accounts(
+            &token_swap,
+            program_id,
+            swap_info,
+            authority_info,
+            token_a_info,
+            token_b_info,
+            pool_mint_info,
+            token_program_info,
+            Some(source_a_info),
+            Some(source_b_info),
+            None
+        )?;
 
         let token_a = Self::unpack_token_account(token_a_info, &token_swap.token_program_id)?;
         let token_b = Self::unpack_token_account(token_b_info, &token_swap.token_program_id)?;
@@ -558,34 +596,20 @@ impl Processor {
         let pool_fee_account_info = next_account_info(account_info_iter)?;
         let token_program_info = next_account_info(account_info_iter)?;
 
-        if swap_info.owner != program_id {
-            return Err(ProgramError::IncorrectProgramId);
-        }
         let token_swap = SwapInfo::unpack(&swap_info.data.borrow())?;
-        if *authority_info.key != Self::authority_id(program_id, swap_info.key, token_swap.nonce)? {
-            return Err(SwapError::InvalidProgramAddress.into());
-        }
-        if *token_a_info.key != token_swap.token_a {
-            return Err(SwapError::IncorrectSwapAccount.into());
-        }
-        if *token_b_info.key != token_swap.token_b {
-            return Err(SwapError::IncorrectSwapAccount.into());
-        }
-        if *pool_mint_info.key != token_swap.pool_mint {
-            return Err(SwapError::IncorrectPoolMint.into());
-        }
-        if *pool_fee_account_info.key != token_swap.pool_fee_account {
-            return Err(SwapError::IncorrectFeeAccount.into());
-        }
-        if token_a_info.key == dest_token_a_info.key {
-            return Err(SwapError::InvalidInput.into());
-        }
-        if token_b_info.key == dest_token_b_info.key {
-            return Err(SwapError::InvalidInput.into());
-        }
-        if *token_program_info.key != token_swap.token_program_id {
-            return Err(SwapError::IncorrectTokenProgramId.into());
-        }
+        Self::check_accounts(
+            &token_swap,
+            program_id,
+            swap_info,
+            authority_info,
+            token_a_info,
+            token_b_info,
+            pool_mint_info,
+            token_program_info,
+            Some(dest_token_a_info),
+            Some(dest_token_b_info),
+            Some(pool_fee_account_info),
+        )?;
 
         let token_a = Self::unpack_token_account(token_a_info, &token_swap.token_program_id)?;
         let token_b = Self::unpack_token_account(token_b_info, &token_swap.token_program_id)?;
@@ -676,6 +700,265 @@ impl Processor {
         Ok(())
     }
 
+    /// Processes DepositOneExactIn
+    pub fn process_deposit_one_exact_in(
+        program_id: &Pubkey,
+        source_token_amount: u64,
+        minimum_pool_token_amount: u64,
+        accounts: &[AccountInfo],
+    ) -> ProgramResult {
+        let account_info_iter = &mut accounts.iter();
+        let swap_info = next_account_info(account_info_iter)?;
+        let authority_info = next_account_info(account_info_iter)?;
+        let source_info = next_account_info(account_info_iter)?;
+        let swap_token_a_info = next_account_info(account_info_iter)?;
+        let swap_token_b_info = next_account_info(account_info_iter)?;
+        let pool_mint_info = next_account_info(account_info_iter)?;
+        let destination_info = next_account_info(account_info_iter)?;
+        let token_program_info = next_account_info(account_info_iter)?;
+
+        let token_swap = SwapInfo::unpack(&swap_info.data.borrow())?;
+        let source_account = Self::unpack_token_account(source_info, &token_swap.token_program_id)?;
+        let swap_token_a =
+            Self::unpack_token_account(swap_token_a_info, &token_swap.token_program_id)?;
+        let swap_token_b =
+            Self::unpack_token_account(swap_token_b_info, &token_swap.token_program_id)?;
+
+        let trade_direction = if source_account.mint == swap_token_a.mint {
+            TradeDirection::AtoB
+        } else if source_account.mint == swap_token_b.mint {
+            TradeDirection::BtoA
+        } else {
+            return Err(SwapError::IncorrectSwapAccount.into());
+        };
+
+        let (source_a_info, source_b_info) = match trade_direction {
+            TradeDirection::AtoB => (Some(source_info), None),
+            TradeDirection::BtoA => (None, Some(source_info)),
+        };
+
+        Self::check_accounts(
+            &token_swap,
+            program_id,
+            swap_info,
+            authority_info,
+            swap_token_a_info,
+            swap_token_b_info,
+            pool_mint_info,
+            token_program_info,
+            source_a_info,
+            source_b_info,
+            None
+        )?;
+
+        let pool_mint = Self::unpack_mint(pool_mint_info, &token_swap.token_program_id)?;
+        let pool_mint_supply = to_u128(pool_mint.supply)?;
+
+        let pool_token_amount = token_swap
+            .swap_curve
+            .trading_tokens_to_pool_tokens(
+                to_u128(source_token_amount)?,
+                to_u128(swap_token_a.amount)?,
+                to_u128(swap_token_b.amount)?,
+                pool_mint_supply,
+                trade_direction,
+                &token_swap.fees,
+            )
+            .ok_or(SwapError::ZeroTradingTokens)?;
+
+        let pool_token_amount = to_u64(pool_token_amount)?;
+        if pool_token_amount < minimum_pool_token_amount {
+            return Err(SwapError::ExceededSlippage.into());
+        }
+        if pool_token_amount == 0 {
+            return Err(SwapError::ZeroTradingTokens.into());
+        }
+
+        match trade_direction {
+            TradeDirection::AtoB => {
+                Self::token_transfer(
+                    swap_info.key,
+                    token_program_info.clone(),
+                    source_info.clone(),
+                    swap_token_a_info.clone(),
+                    authority_info.clone(),
+                    token_swap.nonce,
+                    source_token_amount,
+                )?;
+            },
+            TradeDirection::BtoA => {
+                Self::token_transfer(
+                    swap_info.key,
+                    token_program_info.clone(),
+                    source_info.clone(),
+                    swap_token_b_info.clone(),
+                    authority_info.clone(),
+                    token_swap.nonce,
+                    source_token_amount,
+                )?;
+            }
+        }
+        Self::token_mint_to(
+            swap_info.key,
+            token_program_info.clone(),
+            pool_mint_info.clone(),
+            destination_info.clone(),
+            authority_info.clone(),
+            token_swap.nonce,
+            pool_token_amount,
+        )?;
+
+        Ok(())
+    }
+
+    /// Processes an [Withdraw](enum.Instruction.html).
+    pub fn process_withdraw_one_exact_out(
+        program_id: &Pubkey,
+        destination_token_amount: u64,
+        maximum_pool_token_amount: u64,
+        accounts: &[AccountInfo],
+    ) -> ProgramResult {
+        let account_info_iter = &mut accounts.iter();
+        let swap_info = next_account_info(account_info_iter)?;
+        let authority_info = next_account_info(account_info_iter)?;
+        let pool_mint_info = next_account_info(account_info_iter)?;
+        let source_info = next_account_info(account_info_iter)?;
+        let swap_token_a_info = next_account_info(account_info_iter)?;
+        let swap_token_b_info = next_account_info(account_info_iter)?;
+        let destination_info = next_account_info(account_info_iter)?;
+        let pool_fee_account_info = next_account_info(account_info_iter)?;
+        let token_program_info = next_account_info(account_info_iter)?;
+
+        let token_swap = SwapInfo::unpack(&swap_info.data.borrow())?;
+        let destination_account = Self::unpack_token_account(destination_info, &token_swap.token_program_id)?;
+        let swap_token_a =
+            Self::unpack_token_account(swap_token_a_info, &token_swap.token_program_id)?;
+        let swap_token_b =
+            Self::unpack_token_account(swap_token_b_info, &token_swap.token_program_id)?;
+
+        let trade_direction = if destination_account.mint == swap_token_a.mint {
+            TradeDirection::AtoB
+        } else if destination_account.mint == swap_token_b.mint {
+            TradeDirection::BtoA
+        } else {
+            return Err(SwapError::IncorrectSwapAccount.into());
+        };
+
+        let (destination_a_info, destination_b_info) = match trade_direction {
+            TradeDirection::AtoB => (Some(destination_info), None),
+            TradeDirection::BtoA => (None, Some(destination_info)),
+        };
+        Self::check_accounts(
+            &token_swap,
+            program_id,
+            swap_info,
+            authority_info,
+            swap_token_a_info,
+            swap_token_b_info,
+            pool_mint_info,
+            token_program_info,
+            destination_a_info,
+            destination_b_info,
+            Some(pool_fee_account_info),
+        )?;
+
+        let pool_mint = Self::unpack_mint(pool_mint_info, &token_swap.token_program_id)?;
+        let pool_mint_supply = to_u128(pool_mint.supply)?;
+        let (swap_token_a_amount, swap_token_b_amount) = match trade_direction {
+            TradeDirection::AtoB => (
+                to_u128(swap_token_a.amount
+                    .checked_sub(destination_token_amount)
+                    .ok_or(SwapError::CalculationFailure)?)?,
+                to_u128(swap_token_b.amount)?
+            ),
+            TradeDirection::BtoA => (
+                to_u128(swap_token_a.amount)?,
+                to_u128(swap_token_b.amount
+                    .checked_sub(destination_token_amount)
+                    .ok_or(SwapError::CalculationFailure)?)?,
+            )
+        };
+
+        let burn_pool_token_amount = token_swap
+            .swap_curve
+            .trading_tokens_to_pool_tokens(
+                to_u128(destination_token_amount)?,
+                swap_token_a_amount,
+                swap_token_b_amount,
+                pool_mint_supply,
+                trade_direction,
+                &token_swap.fees,
+            )
+            .ok_or(SwapError::ZeroTradingTokens)?;
+
+        let withdraw_fee: u128 = if *pool_fee_account_info.key == *source_info.key {
+            // withdrawing from the fee account, don't assess withdraw fee
+            0
+        } else {
+            token_swap
+                .fees
+                .owner_withdraw_fee(burn_pool_token_amount)
+                .ok_or(SwapError::FeeCalculationFailure)?
+        };
+        let pool_token_amount = burn_pool_token_amount
+            .checked_add(withdraw_fee)
+            .ok_or(SwapError::CalculationFailure)?;
+
+        if to_u64(pool_token_amount)? > maximum_pool_token_amount {
+            return Err(SwapError::ExceededSlippage.into());
+        }
+        if pool_token_amount == 0 {
+            return Err(SwapError::ZeroTradingTokens.into());
+        }
+
+        match trade_direction {
+            TradeDirection::AtoB => {
+                Self::token_transfer(
+                    swap_info.key,
+                    token_program_info.clone(),
+                    swap_token_a_info.clone(),
+                    destination_info.clone(),
+                    authority_info.clone(),
+                    token_swap.nonce,
+                    destination_token_amount,
+                )?;
+            },
+            TradeDirection::BtoA => {
+                Self::token_transfer(
+                    swap_info.key,
+                    token_program_info.clone(),
+                    swap_token_b_info.clone(),
+                    destination_info.clone(),
+                    authority_info.clone(),
+                    token_swap.nonce,
+                    destination_token_amount,
+                )?;
+            }
+        }
+
+        if withdraw_fee > 0 {
+            Self::token_transfer(
+                swap_info.key,
+                token_program_info.clone(),
+                source_info.clone(),
+                pool_fee_account_info.clone(),
+                authority_info.clone(),
+                token_swap.nonce,
+                to_u64(withdraw_fee)?,
+            )?;
+        }
+        Self::token_burn(
+            swap_info.key,
+            token_program_info.clone(),
+            source_info.clone(),
+            pool_mint_info.clone(),
+            authority_info.clone(),
+            token_swap.nonce,
+            to_u64(burn_pool_token_amount)?,
+        )?;
+        Ok(())
+    }
+
     /// Processes an [Instruction](enum.Instruction.html).
     pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> ProgramResult {
         Self::process_with_constraints(program_id, accounts, input, &SWAP_CONSTRAINTS)
@@ -737,6 +1020,30 @@ impl Processor {
                     pool_token_amount,
                     minimum_token_a_amount,
                     minimum_token_b_amount,
+                    accounts,
+                )
+            }
+            SwapInstruction::DepositOneExactIn(DepositOneExactIn {
+                source_token_amount,
+                minimum_pool_token_amount,
+            }) => {
+                msg!("Instruction: DepositOneExactIn");
+                Self::process_deposit_one_exact_in(
+                    program_id,
+                    source_token_amount,
+                    minimum_pool_token_amount,
+                    accounts,
+                )
+            }
+            SwapInstruction::WithdrawOneExactOut(WithdrawOneExactOut {
+                destination_token_amount,
+                maximum_pool_token_amount,
+            }) => {
+                msg!("Instruction: WithdrawOneExactOut");
+                Self::process_withdraw_one_exact_out(
+                    program_id,
+                    destination_token_amount,
+                    maximum_pool_token_amount,
                     accounts,
                 )
             }
@@ -829,7 +1136,7 @@ mod tests {
             base::CurveType, constant_price::ConstantPriceCurve,
             constant_product::ConstantProductCurve, offset::OffsetCurve,
         },
-        instruction::{deposit, initialize, swap, withdraw},
+        instruction::{deposit, initialize, swap, withdraw, deposit_one_exact_in, withdraw_one_exact_out},
     };
     use solana_program::{instruction::Instruction, program_stubs, rent::Rent};
     use solana_sdk::account::{create_account, create_is_signer_account_infos, Account};
@@ -1307,6 +1614,127 @@ mod tests {
                     &mut self.token_b_account,
                     &mut token_a_account,
                     &mut token_b_account,
+                    &mut self.pool_fee_account,
+                    &mut Account::default(),
+                ],
+            )
+        }
+
+        #[allow(clippy::too_many_arguments)]
+        pub fn deposit_one_exact_in(
+            &mut self,
+            depositor_key: &Pubkey,
+            deposit_account_key: &Pubkey,
+            mut deposit_token_account: &mut Account,
+            deposit_pool_key: &Pubkey,
+            mut deposit_pool_account: &mut Account,
+            source_token_amount: u64,
+            minimum_pool_token_amount: u64,
+        ) -> ProgramResult {
+            do_process_instruction(
+                approve(
+                    &TOKEN_PROGRAM_ID,
+                    &deposit_account_key,
+                    &self.authority_key,
+                    &depositor_key,
+                    &[],
+                    source_token_amount,
+                )
+                .unwrap(),
+                vec![
+                    &mut deposit_token_account,
+                    &mut Account::default(),
+                    &mut Account::default(),
+                ],
+            )
+            .unwrap();
+
+            do_process_instruction(
+                deposit_one_exact_in(
+                    &SWAP_PROGRAM_ID,
+                    &TOKEN_PROGRAM_ID,
+                    &self.swap_key,
+                    &self.authority_key,
+                    &deposit_account_key,
+                    &self.token_a_key,
+                    &self.token_b_key,
+                    &self.pool_mint_key,
+                    &deposit_pool_key,
+                    DepositOneExactIn {
+                        source_token_amount,
+                        minimum_pool_token_amount,
+                    },
+                )
+                .unwrap(),
+                vec![
+                    &mut self.swap_account,
+                    &mut Account::default(),
+                    &mut deposit_token_account,
+                    &mut self.token_a_account,
+                    &mut self.token_b_account,
+                    &mut self.pool_mint_account,
+                    &mut deposit_pool_account,
+                    &mut Account::default(),
+                ],
+            )
+        }
+
+        #[allow(clippy::too_many_arguments)]
+        pub fn withdraw_one_exact_out(
+            &mut self,
+            user_key: &Pubkey,
+            pool_key: &Pubkey,
+            mut pool_account: &mut Account,
+            destination_key: &Pubkey,
+            mut destination_account: &mut Account,
+            destination_token_amount: u64,
+            maximum_pool_token_amount: u64,
+        ) -> ProgramResult {
+            // approve swap program to take out pool tokens
+            do_process_instruction(
+                approve(
+                    &TOKEN_PROGRAM_ID,
+                    &pool_key,
+                    &self.authority_key,
+                    &user_key,
+                    &[],
+                    maximum_pool_token_amount,
+                )
+                .unwrap(),
+                vec![
+                    &mut pool_account,
+                    &mut Account::default(),
+                    &mut Account::default(),
+                ],
+            )
+            .unwrap();
+
+            do_process_instruction(
+                withdraw_one_exact_out(
+                    &SWAP_PROGRAM_ID,
+                    &TOKEN_PROGRAM_ID,
+                    &self.swap_key,
+                    &self.authority_key,
+                    &self.pool_mint_key,
+                    &self.pool_fee_key,
+                    &pool_key,
+                    &self.token_a_key,
+                    &self.token_b_key,
+                    &destination_key,
+                    WithdrawOneExactOut {
+                        destination_token_amount,
+                        maximum_pool_token_amount,
+                    },
+                )
+                .unwrap(),
+                vec![
+                    &mut self.swap_account,
+                    &mut Account::default(),
+                    &mut self.pool_mint_account,
+                    &mut pool_account,
+                    &mut self.token_a_account,
+                    &mut self.token_b_account,
+                    &mut destination_account,
                     &mut self.pool_fee_account,
                     &mut Account::default(),
                 ],
@@ -3747,6 +4175,1178 @@ mod tests {
             assert_eq!(
                 token_b.amount,
                 TryInto::<u64>::try_into(results.token_b_amount).unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn test_deposit_one_exact_in() {
+        let user_key = Pubkey::new_unique();
+        let depositor_key = Pubkey::new_unique();
+        let trade_fee_numerator = 1;
+        let trade_fee_denominator = 2;
+        let owner_trade_fee_numerator = 1;
+        let owner_trade_fee_denominator = 10;
+        let owner_withdraw_fee_numerator = 1;
+        let owner_withdraw_fee_denominator = 5;
+        let host_fee_numerator = 20;
+        let host_fee_denominator = 100;
+
+        let fees = Fees {
+            trade_fee_numerator,
+            trade_fee_denominator,
+            owner_trade_fee_numerator,
+            owner_trade_fee_denominator,
+            owner_withdraw_fee_numerator,
+            owner_withdraw_fee_denominator,
+            host_fee_numerator,
+            host_fee_denominator,
+        };
+
+        let token_a_amount = 1000;
+        let token_b_amount = 9000;
+        let curve_type = CurveType::ConstantProduct;
+        let swap_curve = SwapCurve {
+            curve_type,
+            calculator: Box::new(ConstantProductCurve {}),
+        };
+
+        let mut accounts =
+            SwapAccountInfo::new(&user_key, fees, swap_curve, token_a_amount, token_b_amount);
+
+        let deposit_a = token_a_amount / 10;
+        let deposit_b = token_b_amount / 10;
+        let pool_amount = to_u64(INITIAL_SWAP_POOL_AMOUNT / 100).unwrap();
+
+        // swap not initialized
+        {
+            let (
+                token_a_key,
+                mut token_a_account,
+                _token_b_key,
+                _token_b_account,
+                pool_key,
+                mut pool_account,
+            ) = accounts.setup_token_accounts(&user_key, &depositor_key, deposit_a, deposit_b, 0);
+            assert_eq!(
+                Err(ProgramError::UninitializedAccount),
+                accounts.deposit_one_exact_in(
+                    &depositor_key,
+                    &token_a_key,
+                    &mut token_a_account,
+                    &pool_key,
+                    &mut pool_account,
+                    deposit_a,
+                    pool_amount,
+                )
+            );
+        }
+
+        accounts.initialize_swap().unwrap();
+
+        // wrong owner for swap account
+        {
+            let (
+                token_a_key,
+                mut token_a_account,
+                _token_b_key,
+                _token_b_account,
+                pool_key,
+                mut pool_account,
+            ) = accounts.setup_token_accounts(&user_key, &depositor_key, deposit_a, deposit_b, 0);
+            let old_swap_account = accounts.swap_account;
+            let mut wrong_swap_account = old_swap_account.clone();
+            wrong_swap_account.owner = TOKEN_PROGRAM_ID;
+            accounts.swap_account = wrong_swap_account;
+            assert_eq!(
+                Err(ProgramError::IncorrectProgramId),
+                accounts.deposit_one_exact_in(
+                    &depositor_key,
+                    &token_a_key,
+                    &mut token_a_account,
+                    &pool_key,
+                    &mut pool_account,
+                    deposit_a,
+                    pool_amount,
+                )
+            );
+            accounts.swap_account = old_swap_account;
+        }
+
+        // wrong nonce for authority_key
+        {
+            let (
+                token_a_key,
+                mut token_a_account,
+                _token_b_key,
+                _token_b_account,
+                pool_key,
+                mut pool_account,
+            ) = accounts.setup_token_accounts(&user_key, &depositor_key, deposit_a, deposit_b, 0);
+            let old_authority = accounts.authority_key;
+            let (bad_authority_key, _nonce) = Pubkey::find_program_address(
+                &[&accounts.swap_key.to_bytes()[..]],
+                &TOKEN_PROGRAM_ID,
+            );
+            accounts.authority_key = bad_authority_key;
+            assert_eq!(
+                Err(SwapError::InvalidProgramAddress.into()),
+                accounts.deposit_one_exact_in(
+                    &depositor_key,
+                    &token_a_key,
+                    &mut token_a_account,
+                    &pool_key,
+                    &mut pool_account,
+                    deposit_a,
+                    pool_amount,
+                )
+            );
+            accounts.authority_key = old_authority;
+        }
+
+        // not enough token A / B
+        {
+            let (
+                token_a_key,
+                mut token_a_account,
+                token_b_key,
+                mut token_b_account,
+                pool_key,
+                mut pool_account,
+            ) = accounts.setup_token_accounts(
+                &user_key,
+                &depositor_key,
+                deposit_a / 2,
+                deposit_b / 2,
+                0,
+            );
+            assert_eq!(
+                Err(TokenError::InsufficientFunds.into()),
+                accounts.deposit_one_exact_in(
+                    &depositor_key,
+                    &token_a_key,
+                    &mut token_a_account,
+                    &pool_key,
+                    &mut pool_account,
+                    deposit_a,
+                    0,
+                )
+            );
+            assert_eq!(
+                Err(TokenError::InsufficientFunds.into()),
+                accounts.deposit_one_exact_in(
+                    &depositor_key,
+                    &token_b_key,
+                    &mut token_b_account,
+                    &pool_key,
+                    &mut pool_account,
+                    deposit_b,
+                    0,
+                )
+            );
+        }
+
+        // wrong pool token account
+        {
+            let (
+                token_a_key,
+                mut token_a_account,
+                token_b_key,
+                mut token_b_account,
+                _pool_key,
+                mut _pool_account,
+            ) = accounts.setup_token_accounts(&user_key, &depositor_key, deposit_a, deposit_b, 0);
+            assert_eq!(
+                Err(TokenError::MintMismatch.into()),
+                accounts.deposit_one_exact_in(
+                    &depositor_key,
+                    &token_a_key,
+                    &mut token_a_account,
+                    &token_b_key,
+                    &mut token_b_account,
+                    deposit_a,
+                    pool_amount,
+                )
+            );
+        }
+
+        // no approval
+        {
+            let (
+                token_a_key,
+                mut token_a_account,
+                _token_b_key,
+                _token_b_account,
+                pool_key,
+                mut pool_account,
+            ) = accounts.setup_token_accounts(&user_key, &depositor_key, deposit_a, deposit_b, 0);
+            assert_eq!(
+                Err(TokenError::OwnerMismatch.into()),
+                do_process_instruction(
+                    deposit_one_exact_in(
+                        &SWAP_PROGRAM_ID,
+                        &TOKEN_PROGRAM_ID,
+                        &accounts.swap_key,
+                        &accounts.authority_key,
+                        &token_a_key,
+                        &accounts.token_a_key,
+                        &accounts.token_b_key,
+                        &accounts.pool_mint_key,
+                        &pool_key,
+                        DepositOneExactIn {
+                            source_token_amount: deposit_a,
+                            minimum_pool_token_amount: pool_amount,
+                        },
+                    )
+                    .unwrap(),
+                    vec![
+                        &mut accounts.swap_account,
+                        &mut Account::default(),
+                        &mut token_a_account,
+                        &mut accounts.token_a_account,
+                        &mut accounts.token_b_account,
+                        &mut accounts.pool_mint_account,
+                        &mut pool_account,
+                        &mut Account::default(),
+                    ],
+                )
+            );
+        }
+
+        // wrong token program id
+        {
+            let (
+                token_a_key,
+                mut token_a_account,
+                _token_b_key,
+                _token_b_account,
+                pool_key,
+                mut pool_account,
+            ) = accounts.setup_token_accounts(&user_key, &depositor_key, deposit_a, deposit_b, 0);
+            let wrong_key = Pubkey::new_unique();
+            assert_eq!(
+                Err(SwapError::IncorrectTokenProgramId.into()),
+                do_process_instruction(
+                    deposit_one_exact_in(
+                        &SWAP_PROGRAM_ID,
+                        &wrong_key,
+                        &accounts.swap_key,
+                        &accounts.authority_key,
+                        &token_a_key,
+                        &accounts.token_a_key,
+                        &accounts.token_b_key,
+                        &accounts.pool_mint_key,
+                        &pool_key,
+                        DepositOneExactIn {
+                            source_token_amount: deposit_a,
+                            minimum_pool_token_amount: pool_amount,
+                        },
+                    )
+                    .unwrap(),
+                    vec![
+                        &mut accounts.swap_account,
+                        &mut Account::default(),
+                        &mut token_a_account,
+                        &mut accounts.token_a_account,
+                        &mut accounts.token_b_account,
+                        &mut accounts.pool_mint_account,
+                        &mut pool_account,
+                        &mut Account::default(),
+                    ],
+                )
+            );
+        }
+
+        // wrong swap token accounts
+        {
+            let (
+                token_a_key,
+                mut token_a_account,
+                token_b_key,
+                token_b_account,
+                pool_key,
+                mut pool_account,
+            ) = accounts.setup_token_accounts(&user_key, &depositor_key, deposit_a, deposit_b, 0);
+
+            let old_a_key = accounts.token_a_key;
+            let old_a_account = accounts.token_a_account;
+
+            accounts.token_a_key = token_a_key;
+            accounts.token_a_account = token_a_account.clone();
+
+            // wrong swap token a account
+            assert_eq!(
+                Err(SwapError::IncorrectSwapAccount.into()),
+                accounts.deposit_one_exact_in(
+                    &depositor_key,
+                    &token_a_key,
+                    &mut token_a_account,
+                    &pool_key,
+                    &mut pool_account,
+                    deposit_a,
+                    pool_amount,
+                )
+            );
+
+            accounts.token_a_key = old_a_key;
+            accounts.token_a_account = old_a_account;
+
+            let old_b_key = accounts.token_b_key;
+            let old_b_account = accounts.token_b_account;
+
+            accounts.token_b_key = token_b_key;
+            accounts.token_b_account = token_b_account.clone();
+
+            // wrong swap token b account
+            assert_eq!(
+                Err(SwapError::IncorrectSwapAccount.into()),
+                accounts.deposit_one_exact_in(
+                    &depositor_key,
+                    &token_a_key,
+                    &mut token_a_account,
+                    &pool_key,
+                    &mut pool_account,
+                    deposit_a,
+                    pool_amount,
+                )
+            );
+
+            accounts.token_b_key = old_b_key;
+            accounts.token_b_account = old_b_account;
+        }
+
+        // wrong mint
+        {
+            let (
+                token_a_key,
+                mut token_a_account,
+                _token_b_key,
+                _token_b_account,
+                pool_key,
+                mut pool_account,
+            ) = accounts.setup_token_accounts(&user_key, &depositor_key, deposit_a, deposit_b, 0);
+            let (pool_mint_key, pool_mint_account) =
+                create_mint(&TOKEN_PROGRAM_ID, &accounts.authority_key, None);
+            let old_pool_key = accounts.pool_mint_key;
+            let old_pool_account = accounts.pool_mint_account;
+            accounts.pool_mint_key = pool_mint_key;
+            accounts.pool_mint_account = pool_mint_account;
+
+            assert_eq!(
+                Err(SwapError::IncorrectPoolMint.into()),
+                accounts.deposit_one_exact_in(
+                    &depositor_key,
+                    &token_a_key,
+                    &mut token_a_account,
+                    &pool_key,
+                    &mut pool_account,
+                    deposit_a,
+                    pool_amount,
+                )
+            );
+
+            accounts.pool_mint_key = old_pool_key;
+            accounts.pool_mint_account = old_pool_account;
+        }
+
+        // slippage exceeded
+        {
+            let (
+                token_a_key,
+                mut token_a_account,
+                token_b_key,
+                mut token_b_account,
+                pool_key,
+                mut pool_account,
+            ) = accounts.setup_token_accounts(&user_key, &depositor_key, deposit_a, deposit_b, 0);
+            // minimum pool amount too high
+            assert_eq!(
+                Err(SwapError::ExceededSlippage.into()),
+                accounts.deposit_one_exact_in(
+                    &depositor_key,
+                    &token_a_key,
+                    &mut token_a_account,
+                    &pool_key,
+                    &mut pool_account,
+                    deposit_a / 10,
+                    pool_amount,
+                )
+            );
+            // minimum pool amount too high
+            assert_eq!(
+                Err(SwapError::ExceededSlippage.into()),
+                accounts.deposit_one_exact_in(
+                    &depositor_key,
+                    &token_b_key,
+                    &mut token_b_account,
+                    &pool_key,
+                    &mut pool_account,
+                    deposit_b / 10,
+                    pool_amount,
+                )
+            );
+        }
+
+        // invalid input: can't use swap pool tokens as source
+        {
+            let (
+                _token_a_key,
+                _token_a_account,
+                _token_b_key,
+                _token_b_account,
+                pool_key,
+                mut pool_account,
+            ) = accounts.setup_token_accounts(&user_key, &depositor_key, deposit_a, deposit_b, 0);
+            let swap_token_a_key = accounts.token_a_key;
+            let mut swap_token_a_account = accounts.get_token_account(&swap_token_a_key).clone();
+            let swap_token_b_key = accounts.token_b_key;
+            let mut swap_token_b_account = accounts.get_token_account(&swap_token_b_key).clone();
+            let authority_key = accounts.authority_key;
+            assert_eq!(
+                Err(SwapError::InvalidInput.into()),
+                accounts.deposit_one_exact_in(
+                    &authority_key,
+                    &swap_token_a_key,
+                    &mut swap_token_a_account,
+                    &pool_key,
+                    &mut pool_account,
+                    deposit_a,
+                    pool_amount,
+                )
+            );
+            assert_eq!(
+                Err(SwapError::InvalidInput.into()),
+                accounts.deposit_one_exact_in(
+                    &authority_key,
+                    &swap_token_b_key,
+                    &mut swap_token_b_account,
+                    &pool_key,
+                    &mut pool_account,
+                    deposit_b,
+                    pool_amount,
+                )
+            );
+        }
+
+        // correctly deposit
+        {
+            let (
+                token_a_key,
+                mut token_a_account,
+                token_b_key,
+                mut token_b_account,
+                pool_key,
+                mut pool_account,
+            ) = accounts.setup_token_accounts(&user_key, &depositor_key, deposit_a, deposit_b, 0);
+            accounts
+                .deposit_one_exact_in(
+                    &depositor_key,
+                    &token_a_key,
+                    &mut token_a_account,
+                    &pool_key,
+                    &mut pool_account,
+                    deposit_a,
+                    pool_amount,
+                )
+                .unwrap();
+
+            let swap_token_a =
+                spl_token::state::Account::unpack(&accounts.token_a_account.data).unwrap();
+            assert_eq!(swap_token_a.amount, deposit_a + token_a_amount);
+
+            let token_a = spl_token::state::Account::unpack(&token_a_account.data).unwrap();
+            assert_eq!(token_a.amount, 0);
+
+            accounts
+                .deposit_one_exact_in(
+                    &depositor_key,
+                    &token_b_key,
+                    &mut token_b_account,
+                    &pool_key,
+                    &mut pool_account,
+                    deposit_b,
+                    pool_amount,
+                )
+                .unwrap();
+            let swap_token_b =
+                spl_token::state::Account::unpack(&accounts.token_b_account.data).unwrap();
+            assert_eq!(swap_token_b.amount, deposit_b + token_b_amount);
+
+            let token_b = spl_token::state::Account::unpack(&token_b_account.data).unwrap();
+            assert_eq!(token_b.amount, 0);
+
+            let pool_account = spl_token::state::Account::unpack(&pool_account.data).unwrap();
+            let swap_pool_account =
+                spl_token::state::Account::unpack(&accounts.pool_token_account.data).unwrap();
+            let pool_mint =
+                spl_token::state::Mint::unpack(&accounts.pool_mint_account.data).unwrap();
+            assert_eq!(
+                pool_mint.supply,
+                pool_account.amount + swap_pool_account.amount
+            );
+        }
+    }
+
+    #[test]
+    fn test_withdraw_one_exact_out() {
+        let user_key = Pubkey::new_unique();
+        let trade_fee_numerator = 1;
+        let trade_fee_denominator = 2;
+        let owner_trade_fee_numerator = 1;
+        let owner_trade_fee_denominator = 10;
+        let owner_withdraw_fee_numerator = 1;
+        let owner_withdraw_fee_denominator = 5;
+        let host_fee_numerator = 7;
+        let host_fee_denominator = 100;
+
+        let fees = Fees {
+            trade_fee_numerator,
+            trade_fee_denominator,
+            owner_trade_fee_numerator,
+            owner_trade_fee_denominator,
+            owner_withdraw_fee_numerator,
+            owner_withdraw_fee_denominator,
+            host_fee_numerator,
+            host_fee_denominator,
+        };
+
+        let token_a_amount = 100_000;
+        let token_b_amount = 200_000;
+        let curve_type = CurveType::ConstantProduct;
+        let swap_curve = SwapCurve {
+            curve_type,
+            calculator: Box::new(ConstantProductCurve {}),
+        };
+
+        let withdrawer_key = Pubkey::new_unique();
+        let initial_a = token_a_amount / 10;
+        let initial_b = token_b_amount / 10;
+        let initial_pool = swap_curve.calculator.new_pool_supply() / 10;
+        let maximum_pool_token_amount = to_u64(initial_pool / 4).unwrap();
+        let destination_a_amount = initial_a / 40;
+        let destination_b_amount = initial_b / 40;
+
+        let mut accounts =
+            SwapAccountInfo::new(&user_key, fees, swap_curve, token_a_amount, token_b_amount);
+
+        // swap not initialized
+        {
+            let (
+                token_a_key,
+                mut token_a_account,
+                _token_b_key,
+                _token_b_account,
+                pool_key,
+                mut pool_account,
+            ) = accounts.setup_token_accounts(&user_key, &withdrawer_key, initial_a, initial_b, 0);
+            assert_eq!(
+                Err(ProgramError::UninitializedAccount),
+                accounts.withdraw_one_exact_out(
+                    &withdrawer_key,
+                    &pool_key,
+                    &mut pool_account,
+                    &token_a_key,
+                    &mut token_a_account,
+                    destination_a_amount,
+                    maximum_pool_token_amount,
+                )
+            );
+        }
+
+        accounts.initialize_swap().unwrap();
+
+        // wrong owner for swap account
+        {
+            let (
+                token_a_key,
+                mut token_a_account,
+                _token_b_key,
+                _token_b_account,
+                pool_key,
+                mut pool_account,
+            ) = accounts.setup_token_accounts(&user_key, &withdrawer_key, initial_a, initial_b, 0);
+            let old_swap_account = accounts.swap_account;
+            let mut wrong_swap_account = old_swap_account.clone();
+            wrong_swap_account.owner = TOKEN_PROGRAM_ID;
+            accounts.swap_account = wrong_swap_account;
+            assert_eq!(
+                Err(ProgramError::IncorrectProgramId),
+                accounts.withdraw_one_exact_out(
+                    &withdrawer_key,
+                    &pool_key,
+                    &mut pool_account,
+                    &token_a_key,
+                    &mut token_a_account,
+                    destination_a_amount,
+                    maximum_pool_token_amount,
+                )
+            );
+            accounts.swap_account = old_swap_account;
+        }
+
+        // wrong nonce for authority_key
+        {
+            let (
+                _token_a_key,
+                _token_a_account,
+                token_b_key,
+                mut token_b_account,
+                pool_key,
+                mut pool_account,
+            ) = accounts.setup_token_accounts(&user_key, &withdrawer_key, initial_a, initial_b, 0);
+            let old_authority = accounts.authority_key;
+            let (bad_authority_key, _nonce) = Pubkey::find_program_address(
+                &[&accounts.swap_key.to_bytes()[..]],
+                &TOKEN_PROGRAM_ID,
+            );
+            accounts.authority_key = bad_authority_key;
+            assert_eq!(
+                Err(SwapError::InvalidProgramAddress.into()),
+                accounts.withdraw_one_exact_out(
+                    &withdrawer_key,
+                    &pool_key,
+                    &mut pool_account,
+                    &token_b_key,
+                    &mut token_b_account,
+                    destination_b_amount,
+                    maximum_pool_token_amount,
+                )
+            );
+            accounts.authority_key = old_authority;
+        }
+
+        // not enough pool tokens
+        {
+            let (
+                _token_a_key,
+                _token_a_account,
+                token_b_key,
+                mut token_b_account,
+                pool_key,
+                mut pool_account,
+            ) = accounts.setup_token_accounts(
+                &user_key,
+                &withdrawer_key,
+                initial_a,
+                initial_b,
+                maximum_pool_token_amount / 1000,
+            );
+            assert_eq!(
+                Err(TokenError::InsufficientFunds.into()),
+                accounts.withdraw_one_exact_out(
+                    &withdrawer_key,
+                    &pool_key,
+                    &mut pool_account,
+                    &token_b_key,
+                    &mut token_b_account,
+                    destination_b_amount,
+                    maximum_pool_token_amount,
+                )
+            );
+        }
+
+        // wrong pool token account
+        {
+            let (
+                token_a_key,
+                mut token_a_account,
+                token_b_key,
+                mut token_b_account,
+                _pool_key,
+                _pool_account,
+            ) = accounts.setup_token_accounts(
+                &user_key,
+                &withdrawer_key,
+                maximum_pool_token_amount,
+                initial_b,
+                maximum_pool_token_amount,
+            );
+            assert_eq!(
+                Err(TokenError::MintMismatch.into()),
+                accounts.withdraw_one_exact_out(
+                    &withdrawer_key,
+                    &token_a_key,
+                    &mut token_a_account,
+                    &token_b_key,
+                    &mut token_b_account,
+                    destination_b_amount,
+                    maximum_pool_token_amount,
+                )
+            );
+        }
+
+        // wrong pool fee account
+        {
+            let (
+                token_a_key,
+                mut token_a_account,
+                _token_b_key,
+                _token_b_account,
+                wrong_pool_key,
+                wrong_pool_account,
+            ) = accounts.setup_token_accounts(
+                &user_key,
+                &withdrawer_key,
+                initial_a,
+                initial_b,
+                maximum_pool_token_amount,
+            );
+            let (
+                _token_a_key,
+                _token_a_account,
+                _token_b_key,
+                _token_b_account,
+                pool_key,
+                mut pool_account,
+            ) = accounts.setup_token_accounts(
+                &user_key,
+                &withdrawer_key,
+                initial_a,
+                initial_b,
+                maximum_pool_token_amount,
+            );
+            let old_pool_fee_account = accounts.pool_fee_account;
+            let old_pool_fee_key = accounts.pool_fee_key;
+            accounts.pool_fee_account = wrong_pool_account;
+            accounts.pool_fee_key = wrong_pool_key;
+            assert_eq!(
+                Err(SwapError::IncorrectFeeAccount.into()),
+                accounts.withdraw_one_exact_out(
+                    &withdrawer_key,
+                    &pool_key,
+                    &mut pool_account,
+                    &token_a_key,
+                    &mut token_a_account,
+                    destination_a_amount,
+                    maximum_pool_token_amount,
+                )
+            );
+            accounts.pool_fee_account = old_pool_fee_account;
+            accounts.pool_fee_key = old_pool_fee_key;
+        }
+
+        // no approval
+        {
+            let (
+                token_a_key,
+                mut token_a_account,
+                _token_b_key,
+                _token_b_account,
+                pool_key,
+                mut pool_account,
+            ) = accounts.setup_token_accounts(
+                &user_key,
+                &withdrawer_key,
+                0,
+                0,
+                maximum_pool_token_amount,
+            );
+            assert_eq!(
+                Err(TokenError::OwnerMismatch.into()),
+                do_process_instruction(
+                    withdraw_one_exact_out(
+                        &SWAP_PROGRAM_ID,
+                        &TOKEN_PROGRAM_ID,
+                        &accounts.swap_key,
+                        &accounts.authority_key,
+                        &accounts.pool_mint_key,
+                        &accounts.pool_fee_key,
+                        &pool_key,
+                        &accounts.token_a_key,
+                        &accounts.token_b_key,
+                        &token_a_key,
+                        WithdrawOneExactOut {
+                            destination_token_amount: destination_a_amount,
+                            maximum_pool_token_amount,
+                        }
+                    )
+                    .unwrap(),
+                    vec![
+                        &mut accounts.swap_account,
+                        &mut Account::default(),
+                        &mut accounts.pool_mint_account,
+                        &mut pool_account,
+                        &mut accounts.token_a_account,
+                        &mut accounts.token_b_account,
+                        &mut token_a_account,
+                        &mut accounts.pool_fee_account,
+                        &mut Account::default(),
+                    ],
+                )
+            );
+        }
+
+        // wrong token program id
+        {
+            let (
+                token_a_key,
+                mut token_a_account,
+                _token_b_key,
+                _token_b_account,
+                pool_key,
+                mut pool_account,
+            ) = accounts.setup_token_accounts(
+                &user_key,
+                &withdrawer_key,
+                initial_a,
+                initial_b,
+                maximum_pool_token_amount,
+            );
+            let wrong_key = Pubkey::new_unique();
+            assert_eq!(
+                Err(SwapError::IncorrectTokenProgramId.into()),
+                do_process_instruction(
+                    withdraw_one_exact_out(
+                        &SWAP_PROGRAM_ID,
+                        &wrong_key,
+                        &accounts.swap_key,
+                        &accounts.authority_key,
+                        &accounts.pool_mint_key,
+                        &accounts.pool_fee_key,
+                        &pool_key,
+                        &accounts.token_a_key,
+                        &accounts.token_b_key,
+                        &token_a_key,
+                        WithdrawOneExactOut {
+                            destination_token_amount: destination_a_amount,
+                            maximum_pool_token_amount,
+                        }
+                    )
+                    .unwrap(),
+                    vec![
+                        &mut accounts.swap_account,
+                        &mut Account::default(),
+                        &mut accounts.pool_mint_account,
+                        &mut pool_account,
+                        &mut accounts.token_a_account,
+                        &mut accounts.token_b_account,
+                        &mut token_a_account,
+                        &mut accounts.pool_fee_account,
+                        &mut Account::default(),
+                    ],
+                )
+            );
+        }
+
+        // wrong swap token accounts
+        {
+            let (
+                token_a_key,
+                mut token_a_account,
+                token_b_key,
+                mut token_b_account,
+                pool_key,
+                mut pool_account,
+            ) = accounts.setup_token_accounts(
+                &user_key,
+                &withdrawer_key,
+                initial_a,
+                initial_b,
+                initial_pool.try_into().unwrap(),
+            );
+
+            let old_a_key = accounts.token_a_key;
+            let old_a_account = accounts.token_a_account;
+
+            accounts.token_a_key = token_a_key;
+            accounts.token_a_account = token_a_account.clone();
+
+            // wrong swap token a account
+            assert_eq!(
+                Err(SwapError::IncorrectSwapAccount.into()),
+                accounts.withdraw_one_exact_out(
+                    &withdrawer_key,
+                    &pool_key,
+                    &mut pool_account,
+                    &token_a_key,
+                    &mut token_a_account,
+                    destination_a_amount,
+                    maximum_pool_token_amount,
+                )
+            );
+
+            accounts.token_a_key = old_a_key;
+            accounts.token_a_account = old_a_account;
+
+            let old_b_key = accounts.token_b_key;
+            let old_b_account = accounts.token_b_account;
+
+            accounts.token_b_key = token_b_key;
+            accounts.token_b_account = token_b_account.clone();
+
+            // wrong swap token b account
+            assert_eq!(
+                Err(SwapError::IncorrectSwapAccount.into()),
+                accounts.withdraw_one_exact_out(
+                    &withdrawer_key,
+                    &pool_key,
+                    &mut pool_account,
+                    &token_b_key,
+                    &mut token_b_account,
+                    destination_b_amount,
+                    maximum_pool_token_amount,
+                )
+            );
+
+            accounts.token_b_key = old_b_key;
+            accounts.token_b_account = old_b_account;
+        }
+
+        // wrong mint
+        {
+            let (
+                token_a_key,
+                mut token_a_account,
+                _token_b_key,
+                _token_b_account,
+                pool_key,
+                mut pool_account,
+            ) = accounts.setup_token_accounts(
+                &user_key,
+                &withdrawer_key,
+                initial_a,
+                initial_b,
+                initial_pool.try_into().unwrap(),
+            );
+            let (pool_mint_key, pool_mint_account) =
+                create_mint(&TOKEN_PROGRAM_ID, &accounts.authority_key, None);
+            let old_pool_key = accounts.pool_mint_key;
+            let old_pool_account = accounts.pool_mint_account;
+            accounts.pool_mint_key = pool_mint_key;
+            accounts.pool_mint_account = pool_mint_account;
+
+            assert_eq!(
+                Err(SwapError::IncorrectPoolMint.into()),
+                accounts.withdraw_one_exact_out(
+                    &withdrawer_key,
+                    &pool_key,
+                    &mut pool_account,
+                    &token_a_key,
+                    &mut token_a_account,
+                    destination_a_amount,
+                    maximum_pool_token_amount,
+                )
+            );
+
+            accounts.pool_mint_key = old_pool_key;
+            accounts.pool_mint_account = old_pool_account;
+        }
+
+        // slippage exceeded
+        {
+            let (
+                token_a_key,
+                mut token_a_account,
+                token_b_key,
+                mut token_b_account,
+                pool_key,
+                mut pool_account,
+            ) = accounts.setup_token_accounts(
+                &user_key,
+                &withdrawer_key,
+                initial_a,
+                initial_b,
+                maximum_pool_token_amount,
+            );
+
+            // maximum pool token amount too low
+            assert_eq!(
+                Err(SwapError::ExceededSlippage.into()),
+                accounts.withdraw_one_exact_out(
+                    &withdrawer_key,
+                    &pool_key,
+                    &mut pool_account,
+                    &token_a_key,
+                    &mut token_a_account,
+                    destination_a_amount,
+                    maximum_pool_token_amount / 1000,
+                )
+            );
+            assert_eq!(
+                Err(SwapError::ExceededSlippage.into()),
+                accounts.withdraw_one_exact_out(
+                    &withdrawer_key,
+                    &pool_key,
+                    &mut pool_account,
+                    &token_b_key,
+                    &mut token_b_account,
+                    destination_b_amount,
+                    maximum_pool_token_amount / 1000,
+                )
+            );
+        }
+
+        // invalid input: can't use swap pool tokens as destination
+        {
+            let (
+                _token_a_key,
+                _token_a_account,
+                _token_b_key,
+                _token_b_account,
+                pool_key,
+                mut pool_account,
+            ) = accounts.setup_token_accounts(
+                &user_key,
+                &withdrawer_key,
+                initial_a,
+                initial_b,
+                maximum_pool_token_amount,
+            );
+            let swap_token_a_key = accounts.token_a_key;
+            let mut swap_token_a_account = accounts.get_token_account(&swap_token_a_key).clone();
+            assert_eq!(
+                Err(SwapError::InvalidInput.into()),
+                accounts.withdraw_one_exact_out(
+                    &withdrawer_key,
+                    &pool_key,
+                    &mut pool_account,
+                    &swap_token_a_key,
+                    &mut swap_token_a_account,
+                    destination_a_amount,
+                    maximum_pool_token_amount,
+                )
+            );
+            let swap_token_b_key = accounts.token_b_key;
+            let mut swap_token_b_account = accounts.get_token_account(&swap_token_b_key).clone();
+            assert_eq!(
+                Err(SwapError::InvalidInput.into()),
+                accounts.withdraw_one_exact_out(
+                    &withdrawer_key,
+                    &pool_key,
+                    &mut pool_account,
+                    &swap_token_b_key,
+                    &mut swap_token_b_account,
+                    destination_b_amount,
+                    maximum_pool_token_amount,
+                )
+            );
+        }
+
+        // correct withdrawal
+        {
+            let (
+                token_a_key,
+                mut token_a_account,
+                _token_b_key,
+                _token_b_account,
+                pool_key,
+                mut pool_account,
+            ) = accounts.setup_token_accounts(
+                &user_key,
+                &withdrawer_key,
+                initial_a,
+                initial_b,
+                initial_pool.try_into().unwrap(),
+            );
+
+            let swap_token_a =
+                spl_token::state::Account::unpack(&accounts.token_a_account.data).unwrap();
+            let swap_token_b =
+                spl_token::state::Account::unpack(&accounts.token_b_account.data).unwrap();
+            let pool_mint =
+                spl_token::state::Mint::unpack(&accounts.pool_mint_account.data).unwrap();
+
+            let pool_token_amount = accounts
+                .swap_curve
+                .trading_tokens_to_pool_tokens(
+                    destination_a_amount.try_into().unwrap(),
+                    (swap_token_a.amount - destination_a_amount).try_into().unwrap(),
+                    swap_token_b.amount.try_into().unwrap(),
+                    pool_mint.supply.try_into().unwrap(),
+                    TradeDirection::AtoB,
+                    &accounts.fees,
+                )
+                .unwrap();
+            let withdraw_fee = accounts.fees.owner_withdraw_fee(pool_token_amount).unwrap();
+
+            accounts
+                .withdraw_one_exact_out(
+                    &withdrawer_key,
+                    &pool_key,
+                    &mut pool_account,
+                    &token_a_key,
+                    &mut token_a_account,
+                    destination_a_amount,
+                    maximum_pool_token_amount,
+                )
+                .unwrap();
+
+            let swap_token_a =
+                spl_token::state::Account::unpack(&accounts.token_a_account.data).unwrap();
+
+            assert_eq!(
+                swap_token_a.amount,
+                token_a_amount - destination_a_amount
+            );
+            let token_a = spl_token::state::Account::unpack(&token_a_account.data).unwrap();
+            assert_eq!(
+                token_a.amount,
+                initial_a + destination_a_amount
+            );
+
+            let pool_account = spl_token::state::Account::unpack(&pool_account.data).unwrap();
+            assert_eq!(
+                pool_account.amount,
+                to_u64(initial_pool - pool_token_amount - withdraw_fee).unwrap()
+            );
+            let fee_account =
+                spl_token::state::Account::unpack(&accounts.pool_fee_account.data).unwrap();
+            assert_eq!(
+                fee_account.amount,
+                to_u64(withdraw_fee).unwrap()
+            );
+        }
+
+        // correct withdrawal from fee account
+        {
+            let (
+                token_a_key,
+                mut token_a_account,
+                _token_b_key,
+                _token_b_account,
+                _pool_key,
+                _pool_account,
+            ) = accounts.setup_token_accounts(
+                &user_key,
+                &withdrawer_key,
+                initial_a,
+                initial_b,
+                0,
+            );
+
+            let fee_a_amount = 2;
+            let pool_fee_key = accounts.pool_fee_key;
+            let mut pool_fee_account = accounts.pool_fee_account.clone();
+            let fee_account = spl_token::state::Account::unpack(&pool_fee_account.data).unwrap();
+            let pool_fee_amount = fee_account.amount;
+
+            let swap_token_a =
+                spl_token::state::Account::unpack(&accounts.token_a_account.data).unwrap();
+
+            let token_a_amount = swap_token_a.amount;
+            accounts
+                .withdraw_one_exact_out(
+                    &user_key,
+                    &pool_fee_key,
+                    &mut pool_fee_account,
+                    &token_a_key,
+                    &mut token_a_account,
+                    fee_a_amount,
+                    pool_fee_amount,
+                )
+                .unwrap();
+
+            let swap_token_a =
+                spl_token::state::Account::unpack(&accounts.token_a_account.data).unwrap();
+
+            assert_eq!(
+                swap_token_a.amount,
+                token_a_amount - fee_a_amount
+            );
+            let token_a = spl_token::state::Account::unpack(&token_a_account.data).unwrap();
+            assert_eq!(
+                token_a.amount,
+                initial_a + fee_a_amount
             );
         }
     }


### PR DESCRIPTION
In order to properly support the new curves, we need the ability to deposit or withdraw just one side of the token swap.  This uses the interface added in #934.

Since the math part is covered in other PRs, this focuses on the interface into processor.rs, and the tests closely mirror the logic to test the normal `withdraw` and `deposit` instructions.