### PR TITLE
token-swap: Fix bpf build, need to fully reference u128::MAX

### DIFF
--- a/token-swap/program/src/curve/math.rs
+++ b/token-swap/program/src/curve/math.rs
@@ -380,7 +380,7 @@ impl PreciseNumber {
     /// provides an epsilon of 11 digits
     fn maximum_sqrt_base() -> Self {
         Self {
-            value: U256::from(u128::MAX),
+            value: U256::from(std::u128::MAX),
         }
     }
 


### PR DESCRIPTION
The Rust version used to build BPF is a bit older, so it requires a full name for `u128::MAX`.