### PR TITLE
token-swap: Add proptests for single token conversion

### DIFF
--- a/token-swap/program/src/curve/calculator.rs
+++ b/token-swap/program/src/curve/calculator.rs
@@ -112,10 +112,11 @@ pub trait CurveCalculator: Debug + DynPack {
     }
 
     /// Get the amount of pool tokens for the given amount of token A or B.
-    /// This is used to do single-sided deposits or withdrawals, which
-    /// essentially performs a swap followed by a deposit, or a withdrawal
-    /// followed by a swap.  Because a swap is implicitly performed, this will
-    /// change the balance in the pool.
+    ///
+    /// This is used for single-sided deposits or withdrawals and owner trade
+    /// fee calculation. It essentially performs a swap followed by a deposit,
+    /// or a withdrawal followed by a swap.  Because a swap is implicitly
+    /// performed, this will change the spot price of the pool.
     ///
     /// See more background for the calculation at:
     /// https://balancer.finance/whitepaper/#single-asset-deposit
@@ -188,6 +189,7 @@ pub mod test {
         swap_source_amount: u128,
         swap_destination_amount: u128,
         trade_direction: TradeDirection,
+        pool_supply: u128,
         epsilon_in_basis_points: u128,
     ) {
         let amount_to_swap = source_token_amount / 2;
@@ -199,7 +201,6 @@ pub mod test {
                 trade_direction,
             )
             .unwrap();
-        let pool_supply = u64::MAX as u128;
         let opposite_direction = trade_direction.opposite();
         let (swap_token_a_amount, swap_token_b_amount) = match trade_direction {
             TradeDirection::AtoB => (swap_source_amount, swap_destination_amount),

--- a/token-swap/program/src/curve/calculator.rs
+++ b/token-swap/program/src/curve/calculator.rs
@@ -182,7 +182,7 @@ pub mod test {
     /// some point, meaning we can't have perfect equality.
     /// We guarantee that the relative error between depositing one side and
     /// performing a swap plus deposit will be at most some epsilon provided by
-    /// the curve.  Most curves work guarantee accuracy within 0.5%.
+    /// the curve. Most curves guarantee accuracy within 0.5%.
     pub fn check_pool_token_conversion(
         curve: &dyn CurveCalculator,
         source_token_amount: u128,

--- a/token-swap/program/src/curve/calculator.rs
+++ b/token-swap/program/src/curve/calculator.rs
@@ -145,7 +145,7 @@ pub trait CurveCalculator: Debug + DynPack {
     /// Validate that the given curve has no invalid parameters
     fn validate(&self) -> Result<(), SwapError>;
 
-    /// Validate the given supply on inititialization. This is useful for curves
+    /// Validate the given supply on initialization. This is useful for curves
     /// that allow zero supply on one or both sides, since the standard constant
     /// product curve must have a non-zero supply on both sides.
     fn validate_supply(&self, token_a_amount: u64, token_b_amount: u64) -> Result<(), SwapError> {

--- a/token-swap/program/src/curve/calculator.rs
+++ b/token-swap/program/src/curve/calculator.rs
@@ -24,6 +24,7 @@ pub fn map_zero_to_none(x: u128) -> Option<u128> {
 
 /// The direction of a trade, since curves can be specialized to treat each
 /// token differently (by adding offsets or weights)
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum TradeDirection {
@@ -31,6 +32,17 @@ pub enum TradeDirection {
     AtoB,
     /// Input token B, output token A
     BtoA,
+}
+
+impl TradeDirection {
+    /// Given a trade direction, gives the opposite direction of the trade, so
+    /// A to B becomes B to A, and vice versa
+    pub fn opposite(&self) -> TradeDirection {
+        match self {
+            TradeDirection::AtoB => TradeDirection::BtoA,
+            TradeDirection::BtoA => TradeDirection::AtoB,
+        }
+    }
 }
 
 /// Encodes all results of swapping from a source token to a destination token
@@ -100,8 +112,13 @@ pub trait CurveCalculator: Debug + DynPack {
         })
     }
 
-    /// Get the amount of pool tokens for the given amount of token A or B
-    /// See the concept for the calculation at:
+    /// Get the amount of pool tokens for the given amount of token A or B.
+    /// This is used to do single-sided deposits or withdrawals, which
+    /// essentially performs a swap followed by a deposit, or a withdrawal
+    /// followed by a swap.  Because a swap is implicitly performed, this will
+    /// change the balance in the pool.
+    ///
+    /// See more background for the calculation at:
     /// https://balancer.finance/whitepaper/#single-asset-deposit
     fn trading_tokens_to_pool_tokens(
         &self,
@@ -125,11 +142,12 @@ pub trait CurveCalculator: Debug + DynPack {
         pool_supply.checked_mul(&root)?.to_imprecise()
     }
 
-    /// Validate that the given curve has no bad parameters
+    /// Validate that the given curve has no invalid parameters
     fn validate(&self) -> Result<(), SwapError>;
 
-    /// Validate the given supply on init, helpful for curves that do or don't
-    /// allow zero supply on one side
+    /// Validate the given supply on inititialization. This is useful for curves
+    /// that allow zero supply on one or both sides, since the standard constant
+    /// product curve must have a non-zero supply on both sides.
     fn validate_supply(&self, token_a_amount: u64, token_b_amount: u64) -> Result<(), SwapError> {
         if token_a_amount == 0 {
             return Err(SwapError::EmptySupply);
@@ -140,89 +158,108 @@ pub trait CurveCalculator: Debug + DynPack {
         Ok(())
     }
 
-    /// Some curves will function best and prevent attacks if we prevent
-    /// deposits after initialization
+    /// Some curves function best and prevent attacks if we prevent deposits
+    /// after initialization.  For example, the offset curve in `offset.rs`,
+    /// which fakes supply on one side of the swap, allows the swap creator
+    /// to steal value from all other depositors.
     fn allows_deposits(&self) -> bool {
         true
     }
 }
 
-#[cfg(test)]
+/// Test helpers for curves
+#[cfg(any(test, fuzzing))]
 pub mod test {
     use super::*;
 
-    /// Check that two numbers are within 1 of each other
-    fn almost_equal(a: u128, b: u128) {
-        if a >= b {
-            assert!(a - b <= 1);
-        } else {
-            assert!(b - a <= 1);
-        }
-    }
+    /// The epsilon for most curves when performing the conversion test,
+    /// comparing a one-sided deposit to a swap + deposit.
+    pub const CONVERSION_BASIS_POINTS_GUARANTEE: u128 = 50;
 
+    /// Test function to check that depositing token A is the same as swapping
+    /// half for token B and depositing both.
+    /// Since calculations use unsigned integers, there will be truncation at
+    /// some point, meaning we can't have perfect equality.
+    /// We guarantee that the relative error between depositing one side and
+    /// performing a swap plus deposit will be at most some epsilon provided by
+    /// the curve.  Most curves work guarantee accuracy within 0.5%.
     pub fn check_pool_token_conversion(
         curve: &dyn CurveCalculator,
-        swap_token_a_amount: u128,
-        swap_token_b_amount: u128,
-        token_a_amount: u128,
+        source_token_amount: u128,
+        swap_source_amount: u128,
+        swap_destination_amount: u128,
+        trade_direction: TradeDirection,
+        epsilon_in_basis_points: u128,
     ) {
-        // check that depositing token A is the same as swapping for token B
-        // and depositing the result
-        let swap_results = curve
+        let amount_to_swap = source_token_amount / 2;
+        let results = curve
             .swap_without_fees(
-                token_a_amount,
+                amount_to_swap,
+                swap_source_amount,
+                swap_destination_amount,
+                trade_direction,
+            )
+            .unwrap();
+        let pool_supply = u64::MAX as u128;
+        let opposite_direction = trade_direction.opposite();
+        let (swap_token_a_amount, swap_token_b_amount) = match trade_direction {
+            TradeDirection::AtoB => (swap_source_amount, swap_destination_amount),
+            TradeDirection::BtoA => (swap_destination_amount, swap_source_amount),
+        };
+
+        // base amount
+        let pool_tokens_from_one_side = curve
+            .trading_tokens_to_pool_tokens(
+                source_token_amount,
                 swap_token_a_amount,
                 swap_token_b_amount,
-                TradeDirection::AtoB,
-            )
-            .unwrap();
-        let token_a_amount = swap_results.source_amount_swapped;
-        let token_b_amount = swap_results.destination_amount_swapped;
-        let pool_supply = curve.new_pool_supply();
-        let pool_tokens_from_a = curve
-            .trading_tokens_to_pool_tokens(
-                token_a_amount,
-                swap_token_a_amount + token_a_amount,
-                swap_token_b_amount,
                 pool_supply,
-                TradeDirection::AtoB,
-            )
-            .unwrap();
-        let pool_tokens_from_b = curve
-            .trading_tokens_to_pool_tokens(
-                token_b_amount,
-                swap_token_a_amount + token_a_amount,
-                swap_token_b_amount,
-                pool_supply,
-                TradeDirection::BtoA,
-            )
-            .unwrap();
-        let deposit_token_a = curve
-            .pool_tokens_to_trading_tokens(
-                pool_tokens_from_a,
-                pool_supply + pool_tokens_from_a,
-                swap_token_a_amount,
-                swap_token_b_amount,
+                trade_direction,
             )
             .unwrap();
 
-        let deposit_token_b = curve
-            .pool_tokens_to_trading_tokens(
-                pool_tokens_from_b,
-                pool_supply + pool_tokens_from_b,
+        // perform both separately, updating amounts accordingly
+        let (swap_token_a_amount, swap_token_b_amount) = match trade_direction {
+            TradeDirection::AtoB => (
+                swap_source_amount + results.source_amount_swapped,
+                swap_destination_amount - results.destination_amount_swapped,
+            ),
+            TradeDirection::BtoA => (
+                swap_destination_amount - results.destination_amount_swapped,
+                swap_source_amount + results.source_amount_swapped,
+            ),
+        };
+        let pool_tokens_from_source = curve
+            .trading_tokens_to_pool_tokens(
+                source_token_amount - results.source_amount_swapped,
                 swap_token_a_amount,
                 swap_token_b_amount,
+                pool_supply,
+                trade_direction,
+            )
+            .unwrap();
+        let pool_tokens_from_destination = curve
+            .trading_tokens_to_pool_tokens(
+                results.destination_amount_swapped,
+                swap_token_a_amount,
+                swap_token_b_amount,
+                pool_supply + pool_tokens_from_source,
+                opposite_direction,
             )
             .unwrap();
 
-        // They should be within 1 token because truncation
-        almost_equal(
-            deposit_token_b.token_a_amount,
-            deposit_token_a.token_a_amount,
+        let pool_tokens_total_separate = pool_tokens_from_source + pool_tokens_from_destination;
+
+        // slippage due to rounding or truncation errors
+        let epsilon = std::cmp::max(
+            1,
+            pool_tokens_total_separate * epsilon_in_basis_points / 10000,
         );
-        almost_equal(
-            deposit_token_b.token_b_amount,
-            deposit_token_b.token_b_amount,
-        );
+        let difference = if pool_tokens_from_one_side >= pool_tokens_total_separate {
+            pool_tokens_from_one_side - pool_tokens_total_separate
+        } else {
+            pool_tokens_total_separate - pool_tokens_from_one_side
+        };
+        assert!(difference <= epsilon);
     }
 }

--- a/token-swap/program/src/curve/calculator.rs
+++ b/token-swap/program/src/curve/calculator.rs
@@ -24,7 +24,6 @@ pub fn map_zero_to_none(x: u128) -> Option<u128> {
 
 /// The direction of a trade, since curves can be specialized to treat each
 /// token differently (by adding offsets or weights)
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum TradeDirection {

--- a/token-swap/program/src/curve/constant_price.rs
+++ b/token-swap/program/src/curve/constant_price.rs
@@ -318,24 +318,25 @@ mod tests {
         fn pool_token_conversion_b_to_a(
             // in the pool token conversion calcs, we simulate trading half of
             // source_token_amount, so this needs to be at least 2
-            source_token_amount in 2..u64::MAX,
+            source_token_amount in 2..u32::MAX, // kept small to avoid proptest rejections
             swap_source_amount in 1..u64::MAX,
-            swap_destination_amount in 1..u128::MAX, // NOTE: this is bumped up to avoid too many proptest rejections
-            token_b_price in 1..u64::MAX,
+            swap_destination_amount in 1..u64::MAX,
+            token_b_price in 1..u32::MAX, // kept small to avoid proptest rejections
         ) {
             let curve = ConstantPriceCurve {
-                token_b_price,
+                token_b_price: token_b_price as u64,
             };
-            // The constant price curve needs to have enough destination amount
-            // on the other side to complete the swap
             let token_b_price = token_b_price as u128;
             let source_token_amount = source_token_amount as u128;
             let swap_source_amount = swap_source_amount as u128;
-            prop_assume!(token_b_price * source_token_amount <= swap_destination_amount);
+            let swap_destination_amount = swap_destination_amount as u128;
+            // The constant price curve needs to have enough destination amount
+            // on the other side to complete the swap
+            prop_assume!(token_b_price * source_token_amount / 2 <= swap_destination_amount);
 
             // basis points guarantee, much higher than other calcs due to potential
             // truncation from huge token b prices
-            let basis_points_guarantee = 2000;
+            let basis_points_guarantee = 50;
             check_pool_token_conversion(
                 &curve,
                 source_token_amount,

--- a/token-swap/program/src/curve/constant_price.rs
+++ b/token-swap/program/src/curve/constant_price.rs
@@ -165,8 +165,9 @@ impl DynPack for ConstantPriceCurve {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::curve::calculator::test::{
-        check_pool_token_conversion, CONVERSION_BASIS_POINTS_GUARANTEE,
+    use crate::curve::calculator::{
+        test::{check_pool_token_conversion, CONVERSION_BASIS_POINTS_GUARANTEE},
+        INITIAL_SWAP_POOL_AMOUNT,
     };
     use proptest::prelude::*;
 
@@ -291,6 +292,7 @@ mod tests {
             source_token_amount in 2..u64::MAX,
             swap_source_amount in 1..u64::MAX,
             swap_destination_amount in 1..u64::MAX,
+            pool_supply in INITIAL_SWAP_POOL_AMOUNT..u64::MAX as u128,
             token_b_price in 1..u64::MAX,
         ) {
             let traded_source_amount = source_token_amount / 2;
@@ -308,6 +310,7 @@ mod tests {
                 swap_source_amount as u128,
                 swap_destination_amount as u128,
                 TradeDirection::AtoB,
+                pool_supply,
                 CONVERSION_BASIS_POINTS_GUARANTEE,
             );
         }
@@ -321,6 +324,7 @@ mod tests {
             source_token_amount in 2..u32::MAX, // kept small to avoid proptest rejections
             swap_source_amount in 1..u64::MAX,
             swap_destination_amount in 1..u64::MAX,
+            pool_supply in INITIAL_SWAP_POOL_AMOUNT..u64::MAX as u128,
             token_b_price in 1..u32::MAX, // kept small to avoid proptest rejections
         ) {
             let curve = ConstantPriceCurve {
@@ -340,6 +344,7 @@ mod tests {
                 swap_source_amount,
                 swap_destination_amount,
                 TradeDirection::BtoA,
+                pool_supply,
                 CONVERSION_BASIS_POINTS_GUARANTEE,
             );
         }

--- a/token-swap/program/src/curve/constant_price.rs
+++ b/token-swap/program/src/curve/constant_price.rs
@@ -5,6 +5,7 @@ use crate::{
         map_zero_to_none, CurveCalculator, DynPack, SwapWithoutFeesResult, TradeDirection,
         TradingTokenResult,
     },
+    curve::math::U256,
     error::SwapError,
 };
 use arrayref::{array_mut_ref, array_ref};
@@ -38,7 +39,7 @@ impl CurveCalculator for ConstantPriceCurve {
                 let mut source_amount_swapped = source_amount;
 
                 // if there is a remainder from buying token B, floor
-                // token_a_amount provided to avoid taking too many tokens, but
+                // token_a_amount to avoid taking too many tokens, but
                 // don't recalculate the fees
                 let remainder = source_amount_swapped.checked_rem(token_b_price)?;
                 if remainder > 0 {
@@ -100,17 +101,21 @@ impl CurveCalculator for ConstantPriceCurve {
         pool_supply: u128,
         trade_direction: TradeDirection,
     ) -> Option<u128> {
-        let token_b_price = self.token_b_price as u128;
+        let token_b_price = U256::from(self.token_b_price);
         let given_value = match trade_direction {
-            TradeDirection::AtoB => source_amount,
-            TradeDirection::BtoA => source_amount.checked_mul(token_b_price)?,
+            TradeDirection::AtoB => U256::from(source_amount),
+            TradeDirection::BtoA => U256::from(source_amount).checked_mul(token_b_price)?,
         };
-        let total_value = swap_token_b_amount
+        let total_value = U256::from(swap_token_b_amount)
             .checked_mul(token_b_price)?
-            .checked_add(swap_token_a_amount)?;
-        pool_supply
-            .checked_mul(given_value)?
-            .checked_div(total_value)
+            .checked_add(U256::from(swap_token_a_amount))?;
+        let pool_supply = U256::from(pool_supply);
+        Some(
+            pool_supply
+                .checked_mul(given_value)?
+                .checked_div(total_value)?
+                .as_u128(),
+        )
     }
 
     fn validate(&self) -> Result<(), SwapError> {
@@ -160,6 +165,10 @@ impl DynPack for ConstantPriceCurve {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::curve::calculator::test::{
+        check_pool_token_conversion, CONVERSION_BASIS_POINTS_GUARANTEE,
+    };
+    use proptest::prelude::*;
 
     #[test]
     fn swap_calculation_no_price() {
@@ -209,79 +218,6 @@ mod tests {
         packed.extend_from_slice(&token_b_price.to_le_bytes());
         let unpacked = ConstantPriceCurve::unpack(&packed).unwrap();
         assert_eq!(curve, unpacked);
-    }
-
-    fn almost_equal(a: u128, b: u128) {
-        if a >= b {
-            assert!(a - b <= 1);
-        } else {
-            assert!(b - a <= 1);
-        }
-    }
-
-    fn check_pool_token_conversion(
-        token_b_price: u128,
-        swap_token_a_amount: u128,
-        swap_token_b_amount: u128,
-        token_b_amount: u128,
-    ) {
-        let token_a_amount = token_b_amount * token_b_price;
-        let curve = ConstantPriceCurve {
-            token_b_price: token_b_price as u64,
-        };
-        let pool_supply = curve.new_pool_supply();
-        let pool_tokens_from_a = curve
-            .trading_tokens_to_pool_tokens(
-                token_a_amount,
-                swap_token_a_amount,
-                swap_token_b_amount,
-                pool_supply,
-                TradeDirection::AtoB,
-            )
-            .unwrap();
-        let pool_tokens_from_b = curve
-            .trading_tokens_to_pool_tokens(
-                token_b_amount,
-                swap_token_a_amount,
-                swap_token_b_amount,
-                pool_supply,
-                TradeDirection::BtoA,
-            )
-            .unwrap();
-        let results = curve
-            .pool_tokens_to_trading_tokens(
-                pool_tokens_from_a + pool_tokens_from_b,
-                pool_supply,
-                swap_token_a_amount,
-                swap_token_b_amount,
-            )
-            .unwrap();
-        almost_equal(
-            results.token_a_amount / token_b_price,
-            token_a_amount / token_b_price,
-        ); // takes care of truncation issues
-        almost_equal(results.token_b_amount, token_b_amount);
-    }
-
-    #[test]
-    fn pool_token_conversion() {
-        let tests: &[(u128, u128, u128, u128)] = &[
-            (10_000, 1_000_000, 1, 10),
-            (10, 1_000, 100, 1),
-            (1_251, 30, 1_288, 1_225),
-            (1_000_251, 0, 1_288, 1),
-            (1_000_000_000_000, 212, 10_000, 1),
-        ];
-        for (token_b_price, swap_token_a_amount, swap_token_b_amount, token_b_amount) in
-            tests.iter()
-        {
-            check_pool_token_conversion(
-                *token_b_price,
-                *swap_token_a_amount,
-                *swap_token_b_amount,
-                *token_b_amount,
-            );
-        }
     }
 
     #[test]
@@ -345,5 +281,69 @@ mod tests {
             .unwrap();
         assert_eq!(result.source_amount_swapped, token_b_price);
         assert_eq!(result.destination_amount_swapped, 1u128);
+    }
+
+    proptest! {
+        #[test]
+        fn pool_token_conversion_a_to_b(
+            // in the pool token conversion calcs, we simulate trading half of
+            // source_token_amount, so this needs to be at least 2
+            source_token_amount in 2..u64::MAX,
+            swap_source_amount in 1..u64::MAX,
+            swap_destination_amount in 1..u64::MAX,
+            token_b_price in 1..u64::MAX,
+        ) {
+            let traded_source_amount = source_token_amount / 2;
+            // Make sure that the trade yields at least 1 token B
+            prop_assume!(traded_source_amount / token_b_price >= 1);
+            // Make sure there's enough tokens to get back on the other side
+            prop_assume!(traded_source_amount / token_b_price <= swap_destination_amount);
+
+            let curve = ConstantPriceCurve {
+                token_b_price,
+            };
+            check_pool_token_conversion(
+                &curve,
+                source_token_amount as u128,
+                swap_source_amount as u128,
+                swap_destination_amount as u128,
+                TradeDirection::AtoB,
+                CONVERSION_BASIS_POINTS_GUARANTEE,
+            );
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn pool_token_conversion_b_to_a(
+            // in the pool token conversion calcs, we simulate trading half of
+            // source_token_amount, so this needs to be at least 2
+            source_token_amount in 2..u64::MAX,
+            swap_source_amount in 1..u64::MAX,
+            swap_destination_amount in 1..u128::MAX, // NOTE: this is bumped up to avoid too many proptest rejections
+            token_b_price in 1..u64::MAX,
+        ) {
+            let curve = ConstantPriceCurve {
+                token_b_price,
+            };
+            // The constant price curve needs to have enough destination amount
+            // on the other side to complete the swap
+            let token_b_price = token_b_price as u128;
+            let source_token_amount = source_token_amount as u128;
+            let swap_source_amount = swap_source_amount as u128;
+            prop_assume!(token_b_price * source_token_amount <= swap_destination_amount);
+
+            // basis points guarantee, much higher than other calcs due to potential
+            // truncation from huge token b prices
+            let basis_points_guarantee = 2000;
+            check_pool_token_conversion(
+                &curve,
+                source_token_amount,
+                swap_source_amount,
+                swap_destination_amount,
+                TradeDirection::BtoA,
+                basis_points_guarantee,
+            );
+        }
     }
 }

--- a/token-swap/program/src/curve/constant_price.rs
+++ b/token-swap/program/src/curve/constant_price.rs
@@ -334,16 +334,13 @@ mod tests {
             // on the other side to complete the swap
             prop_assume!(token_b_price * source_token_amount / 2 <= swap_destination_amount);
 
-            // basis points guarantee, much higher than other calcs due to potential
-            // truncation from huge token b prices
-            let basis_points_guarantee = 50;
             check_pool_token_conversion(
                 &curve,
                 source_token_amount,
                 swap_source_amount,
                 swap_destination_amount,
                 TradeDirection::BtoA,
-                basis_points_guarantee,
+                CONVERSION_BASIS_POINTS_GUARANTEE,
             );
         }
     }

--- a/token-swap/program/src/curve/constant_product.rs
+++ b/token-swap/program/src/curve/constant_product.rs
@@ -16,7 +16,11 @@ use crate::{
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct ConstantProductCurve;
 
-/// The constant product swap calculation, factored out of its class for reuse
+/// The constant product swap calculation, factored out of its class for reuse.
+///
+/// This is guaranteed to work for all values such that:
+///  - 1 <= swap_source_amount * swap_destination_amount <= u128::MAX
+///  - 1 <= source_amount <= u64::MAX
 pub fn swap(
     source_amount: u128,
     swap_source_amount: u128,
@@ -93,7 +97,11 @@ impl DynPack for ConstantProductCurve {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::curve::calculator::{test::check_pool_token_conversion, INITIAL_SWAP_POOL_AMOUNT};
+    use crate::curve::calculator::{
+        test::{check_pool_token_conversion, CONVERSION_BASIS_POINTS_GUARANTEE},
+        INITIAL_SWAP_POOL_AMOUNT,
+    };
+    use proptest::prelude::*;
 
     #[test]
     fn initial_pool_amount() {
@@ -214,22 +222,32 @@ mod tests {
         }
     }
 
-    #[test]
-    fn pool_token_conversion() {
-        let tests: &[(u128, u128, u128)] = &[
-            (1_000_000, 2400112, 100_000),
-            (1_000, 100, 100),
-            (30, 1_288, 100_000),
-            (1_000, 1_288, 100_000),
-            (212, 10_000, 100_000),
-        ];
-        for (swap_token_a_amount, swap_token_b_amount, token_a_amount) in tests.iter() {
+    proptest! {
+        #[test]
+        fn pool_token_conversion(
+            // in the pool token conversion calcs, we simulate trading half of
+            // source_token_amount, so this needs to be at least 2
+            source_token_amount in 2..u64::MAX,
+            swap_source_amount in 1..u64::MAX,
+            swap_destination_amount in 1..u64::MAX,
+        ) {
             let curve = ConstantProductCurve {};
             check_pool_token_conversion(
                 &curve,
-                *swap_token_a_amount,
-                *swap_token_b_amount,
-                *token_a_amount,
+                source_token_amount as u128,
+                swap_source_amount as u128,
+                swap_destination_amount as u128,
+                TradeDirection::AtoB,
+                CONVERSION_BASIS_POINTS_GUARANTEE,
+            );
+
+            check_pool_token_conversion(
+                &curve,
+                source_token_amount as u128,
+                swap_source_amount as u128,
+                swap_destination_amount as u128,
+                TradeDirection::BtoA,
+                CONVERSION_BASIS_POINTS_GUARANTEE,
             );
         }
     }

--- a/token-swap/program/src/curve/constant_product.rs
+++ b/token-swap/program/src/curve/constant_product.rs
@@ -230,6 +230,7 @@ mod tests {
             source_token_amount in 2..u64::MAX,
             swap_source_amount in 1..u64::MAX,
             swap_destination_amount in 1..u64::MAX,
+            pool_supply in INITIAL_SWAP_POOL_AMOUNT..u64::MAX as u128,
         ) {
             let curve = ConstantProductCurve {};
             check_pool_token_conversion(
@@ -238,6 +239,7 @@ mod tests {
                 swap_source_amount as u128,
                 swap_destination_amount as u128,
                 TradeDirection::AtoB,
+                pool_supply,
                 CONVERSION_BASIS_POINTS_GUARANTEE,
             );
 
@@ -247,6 +249,7 @@ mod tests {
                 swap_source_amount as u128,
                 swap_destination_amount as u128,
                 TradeDirection::BtoA,
+                pool_supply,
                 CONVERSION_BASIS_POINTS_GUARANTEE,
             );
         }

--- a/token-swap/program/src/curve/offset.rs
+++ b/token-swap/program/src/curve/offset.rs
@@ -26,6 +26,11 @@ pub struct OffsetCurve {
 
 impl CurveCalculator for OffsetCurve {
     /// Constant product swap ensures token a * (token b + offset) = constant
+    /// This is guaranteed to work for all values such that:
+    ///  - 1 <= source_amount <= u64::MAX
+    ///  - 1 <= (swap_source_amount * (swap_destination_amount + token_b_offset)) <= u128::MAX
+    /// If the offset and token B are both close to u64::MAX, there can be
+    /// overflow errors with the invariant.
     fn swap_without_fees(
         &self,
         source_amount: u128,
@@ -148,7 +153,10 @@ impl DynPack for OffsetCurve {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::curve::calculator::test::check_pool_token_conversion;
+    use crate::curve::calculator::test::{
+        check_pool_token_conversion, CONVERSION_BASIS_POINTS_GUARANTEE,
+    };
+    use proptest::prelude::*;
 
     #[test]
     fn pack_curve() {
@@ -259,26 +267,72 @@ mod tests {
         assert_eq!(result.destination_amount_swapped, 499);
     }
 
-    #[test]
-    fn pool_token_conversion() {
-        let tests: &[(u64, u128, u128, u128)] = &[
-            (10_000, 1_000_000, 1, 100_000),
-            (10, 1_000, 100, 100),
-            (1_251, 30, 1_288, 100_000),
-            (1_000_251, 1_000, 1_288, 100_000),
-            (1_000_000_000_000, 212, 10_000, 100_000),
-        ];
-        for (token_b_offset, swap_token_a_amount, swap_token_b_amount, token_a_amount) in
-            tests.iter()
-        {
+    proptest! {
+        #[test]
+        fn pool_token_conversion_a_to_b(
+            // in the pool token conversion calcs, we simulate trading half of
+            // source_token_amount, so this needs to be at least 2
+            source_token_amount in 2..u64::MAX,
+            swap_source_amount in 1..u64::MAX,
+            swap_destination_amount in 1..u64::MAX,
+            token_b_offset in 1..u64::MAX,
+        ) {
+            // The invariant needs to fit in a u128, so keep token b side
+            // under u64::MAX.
+            // invariant = swap_source_amount * (swap_destination_amount + token_b_offset)
+            prop_assume!(!swap_destination_amount.overflowing_add(token_b_offset).1);
+
             let curve = OffsetCurve {
-                token_b_offset: *token_b_offset,
+                token_b_offset,
+            };
+            // Additionally, in order for the swap to succeed, we need to make
+            // sure that we don't overdraw on the token B side, ie.
+            // (B + offset) - (B + offset) * A / (A + A_in) <= B
+            // which reduces to
+            // A_in * offset <= A * B
+            let source_token_amount = source_token_amount as u128;
+            let swap_source_amount = swap_source_amount as u128;
+            let swap_destination_amount = swap_destination_amount as u128;
+            let token_b_offset = token_b_offset as u128;
+
+            prop_assume!(
+                (source_token_amount / 2 * token_b_offset) <
+                (swap_source_amount * swap_destination_amount));
+            check_pool_token_conversion(
+                &curve,
+                source_token_amount,
+                swap_source_amount,
+                swap_destination_amount,
+                TradeDirection::AtoB,
+                CONVERSION_BASIS_POINTS_GUARANTEE,
+            );
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn pool_token_conversion_b_to_a(
+            // in the pool token conversion calcs, we simulate trading half of
+            // source_token_amount, so this needs to be at least 2
+            source_token_amount in 2..u64::MAX,
+            swap_source_amount in 1..u64::MAX,
+            swap_destination_amount in 1..u64::MAX,
+            token_b_offset in 1..u64::MAX,
+        ) {
+            // The invariant needs to fit in a u128, so keep token b side
+            // under u64::MAX.
+            // invariant = swap_destination_amount * (swap_source_amount + token_b_offset)
+            prop_assume!(!swap_source_amount.overflowing_add(token_b_offset).1);
+            let curve = OffsetCurve {
+                token_b_offset,
             };
             check_pool_token_conversion(
                 &curve,
-                *swap_token_a_amount,
-                *swap_token_b_amount,
-                *token_a_amount,
+                source_token_amount as u128,
+                swap_source_amount as u128,
+                swap_destination_amount as u128,
+                TradeDirection::BtoA,
+                CONVERSION_BASIS_POINTS_GUARANTEE,
             );
         }
     }


### PR DESCRIPTION
In order to provide more confidence for the new curve math, this adds proptests for each curve to make sure that a one-sided deposit is actually equivalent to a swap and deposit.  For almost all curves and deposit directions, with the exception of B -> A constant price curves with huge prices (which highlights truncation issues), we can guarantee an epsilon of less than 0.5% for one-sided deposit vs swap + deposit.

This also provides more information about what the cases in which a swap or deposit is expected to succeed.