### PR TITLE
token-swap: Add proptests for decreasing curve value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 ./package-lock.json
 hfuzz_target
 hfuzz_workspace
+proptest-regressions

--- a/token-swap/program/src/curve/calculator.rs
+++ b/token-swap/program/src/curve/calculator.rs
@@ -290,6 +290,15 @@ pub mod test {
         assert!(difference <= epsilon);
     }
 
+    /// Test function checking that a swap never reduces the overall value of
+    /// the pool.
+    ///
+    /// Since curve calculations use unsigned integers, there is potential for
+    /// truncation at some point, meaning a potential for value to be lost in
+    /// either direction if too much is given to the swapper.
+    ///
+    /// This test guarantees that the relative change in value will be at most
+    /// 1 normalized token, and that the value will never decrease from a trade.
     pub fn check_curve_value_from_swap(
         curve: &dyn CurveCalculator,
         source_token_amount: u128,

--- a/token-swap/program/src/curve/constant_price.rs
+++ b/token-swap/program/src/curve/constant_price.rs
@@ -133,17 +133,19 @@ impl CurveCalculator for ConstantPriceCurve {
         Ok(())
     }
 
-    /// The total value of the constant price curve adds the total value of the
-    /// token B side to the token A side.
+    /// The total normalized value of the constant price curve adds the total
+    /// value of the token B side to the token A side.
     ///
     /// Note that since most other curves use a multiplicative invariant, ie.
-    /// token_a * token_b, whereas this one uses an addition,
-    /// ie. token_a + token_b, the dimensionality of this curve is different from
-    /// the others, and cannot be directly compared to other curves.
-    fn total_value(&self, swap_token_a_amount: u128, swap_token_b_amount: u128) -> Option<U256> {
-        let swap_token_b_amount =
-            U256::from(swap_token_b_amount).checked_mul(U256::from(self.token_b_price))?;
-        U256::from(swap_token_a_amount).checked_add(swap_token_b_amount)
+    /// `token_a * token_b`, whereas this one uses an addition,
+    /// ie. `token_a + token_b`.
+    fn normalized_value(
+        &self,
+        swap_token_a_amount: u128,
+        swap_token_b_amount: u128,
+    ) -> Option<u128> {
+        let swap_token_b_amount = swap_token_b_amount.checked_mul(self.token_b_price as u128)?;
+        swap_token_a_amount.checked_add(swap_token_b_amount)
     }
 }
 
@@ -179,7 +181,10 @@ impl DynPack for ConstantPriceCurve {
 mod tests {
     use super::*;
     use crate::curve::calculator::{
-        test::{check_pool_token_conversion, check_curve_value_from_swap, CONVERSION_BASIS_POINTS_GUARANTEE},
+        test::{
+            check_curve_value_from_swap, check_pool_token_conversion,
+            CONVERSION_BASIS_POINTS_GUARANTEE,
+        },
         INITIAL_SWAP_POOL_AMOUNT,
     };
     use proptest::prelude::*;
@@ -389,18 +394,20 @@ mod tests {
     proptest! {
         #[test]
         fn curve_value_does_not_decrease_from_swap_b_to_a(
-            source_token_amount in 1..u64::MAX,
+            source_token_amount in 1..u32::MAX, // kept small to avoid proptest rejections
             swap_source_amount in 1..u64::MAX,
-            swap_destination_amount in 1..u128::MAX, // bumped up to avoid global rejects
-            token_b_price in 1..u64::MAX,
+            swap_destination_amount in 1..u64::MAX,
+            token_b_price in 1..u32::MAX, // kept small to avoid proptest rejections
         ) {
             // The constant price curve needs to have enough destination amount
             // on the other side to complete the swap
-            let curve = ConstantPriceCurve { token_b_price };
+            let curve = ConstantPriceCurve { token_b_price: token_b_price as u64 };
             let token_b_price = token_b_price as u128;
             let source_token_amount = source_token_amount as u128;
             let swap_destination_amount = swap_destination_amount as u128;
             let swap_source_amount = swap_source_amount as u128;
+            // The constant price curve needs to have enough destination amount
+            // on the other side to complete the swap
             prop_assume!(token_b_price * source_token_amount <= swap_destination_amount);
             check_curve_value_from_swap(
                 &curve,

--- a/token-swap/program/src/curve/constant_product.rs
+++ b/token-swap/program/src/curve/constant_product.rs
@@ -98,7 +98,7 @@ impl DynPack for ConstantProductCurve {
 mod tests {
     use super::*;
     use crate::curve::calculator::{
-        test::{check_pool_token_conversion, CONVERSION_BASIS_POINTS_GUARANTEE},
+        test::{check_curve_value_from_swap, check_pool_token_conversion, CONVERSION_BASIS_POINTS_GUARANTEE},
         INITIAL_SWAP_POOL_AMOUNT,
     };
     use proptest::prelude::*;
@@ -251,6 +251,24 @@ mod tests {
                 TradeDirection::BtoA,
                 pool_supply,
                 CONVERSION_BASIS_POINTS_GUARANTEE,
+            );
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn curve_value_does_not_decrease_from_swap(
+            source_token_amount in 1..u64::MAX,
+            swap_source_amount in 1..u64::MAX,
+            swap_destination_amount in 1..u64::MAX,
+        ) {
+            let curve = ConstantProductCurve {};
+            check_curve_value_from_swap(
+                &curve,
+                source_token_amount as u128,
+                swap_source_amount as u128,
+                swap_destination_amount as u128,
+                TradeDirection::AtoB
             );
         }
     }

--- a/token-swap/program/src/curve/constant_product.rs
+++ b/token-swap/program/src/curve/constant_product.rs
@@ -98,7 +98,10 @@ impl DynPack for ConstantProductCurve {
 mod tests {
     use super::*;
     use crate::curve::calculator::{
-        test::{check_curve_value_from_swap, check_pool_token_conversion, CONVERSION_BASIS_POINTS_GUARANTEE},
+        test::{
+            check_curve_value_from_swap, check_pool_token_conversion,
+            CONVERSION_BASIS_POINTS_GUARANTEE,
+        },
         INITIAL_SWAP_POOL_AMOUNT,
     };
     use proptest::prelude::*;

--- a/token-swap/program/src/curve/math.rs
+++ b/token-swap/program/src/curve/math.rs
@@ -379,9 +379,7 @@ impl PreciseNumber {
     /// Based on testing around the limits, this base is the smallest value that
     /// provides an epsilon of 11 digits
     fn maximum_sqrt_base() -> Self {
-        Self {
-            value: U256::from(std::u128::MAX),
-        }
+        Self::new(std::u128::MAX).unwrap()
     }
 
     /// Approximate the square root using Newton's method.  Based on testing,


### PR DESCRIPTION
This set of proptests checks that a swap never takes value out of the liquidity pools, and re-uses the successful swap conditions developed for #950.

In order to check that value has not been lost, this also adds a simple `total_value` function to the calculator, which defaults to the constant product invariant.  The offset and constant price curves have different ways of figuring out the total value.

Note that the total value result is meant to be unique to each curve type, and not to be used for comparing against other curves.

Also, I tried implementing this for `StableCurve`, but the tests failed.  It seems we need to do some more work to properly support it first.