### PR TITLE
token-swap: Add fuzz check for pool token value

### DIFF
--- a/token-swap/js/cli/token-swap-test.js
+++ b/token-swap/js/cli/token-swap-test.js
@@ -63,9 +63,9 @@ let currentFeeAmount = 0;
 // Swap instruction constants
 // Because there is no withdraw fee in the production version, these numbers
 // need to get slightly tweaked in the two cases.
-const SWAP_AMOUNT_IN = 99999;
+const SWAP_AMOUNT_IN = 100000;
 const SWAP_AMOUNT_OUT = SWAP_PROGRAM_OWNER_FEE_ADDRESS ? 90661 : 90674;
-const SWAP_FEE = SWAP_PROGRAM_OWNER_FEE_ADDRESS ? 21820 : 21823;
+const SWAP_FEE = SWAP_PROGRAM_OWNER_FEE_ADDRESS ? 22272 : 22276;
 const HOST_SWAP_FEE = SWAP_PROGRAM_OWNER_FEE_ADDRESS
   ? Math.floor((SWAP_FEE * HOST_FEE_NUMERATOR) / HOST_FEE_DENOMINATOR)
   : 0;
@@ -292,13 +292,11 @@ export async function depositAllTokenTypes(): Promise<void> {
   const supply = poolMintInfo.supply.toNumber();
   const swapTokenA = await mintA.getAccountInfo(tokenAccountA);
   const tokenA = Math.floor(
-    (swapTokenA.amount.toNumber() * POOL_TOKEN_AMOUNT) /
-      (supply + POOL_TOKEN_AMOUNT),
+    (swapTokenA.amount.toNumber() * POOL_TOKEN_AMOUNT) / supply,
   );
   const swapTokenB = await mintB.getAccountInfo(tokenAccountB);
   const tokenB = Math.floor(
-    (swapTokenB.amount.toNumber() * POOL_TOKEN_AMOUNT) /
-      (supply + POOL_TOKEN_AMOUNT),
+    (swapTokenB.amount.toNumber() * POOL_TOKEN_AMOUNT) / supply,
   );
 
   console.log('Creating depositor token a account');
@@ -350,10 +348,10 @@ export async function withdrawAllTokenTypes(): Promise<void> {
     );
   }
   const poolTokenAmount = POOL_TOKEN_AMOUNT - feeAmount;
-  const tokenA = Math.floor(
+  const tokenA = Math.ceil(
     (swapTokenA.amount.toNumber() * poolTokenAmount) / supply,
   );
-  const tokenB = Math.floor(
+  const tokenB = Math.ceil(
     (swapTokenB.amount.toNumber() * poolTokenAmount) / supply,
   );
 
@@ -498,7 +496,9 @@ export async function swap(): Promise<void> {
     SWAP_AMOUNT_IN,
     SWAP_AMOUNT_OUT,
   );
+
   await sleep(500);
+
   let info;
   info = await mintA.getAccountInfo(userAccountA);
   assert(info.amount.toNumber() == 0);

--- a/token-swap/program/fuzz/src/instructions.rs
+++ b/token-swap/program/fuzz/src/instructions.rs
@@ -167,12 +167,15 @@ fn run_fuzz_instructions(fuzz_instructions: Vec<FuzzInstruction>) {
         .iter()
         .map(|&x| get_token_balance(x))
         .sum::<u64>() as u128;
-    let pool_token_amount = pool_tokens + pool_accounts.values().map(get_token_balance).sum::<u64>() as u128;
+    let pool_token_amount =
+        pool_tokens + pool_accounts.values().map(get_token_balance).sum::<u64>() as u128;
     let swap_token_a_amount = get_token_balance(&token_swap.token_a_account) as u128;
     let swap_token_b_amount = get_token_balance(&token_swap.token_b_account) as u128;
 
-    let lost_a_value = initial_swap_token_a_amount * pool_token_amount > swap_token_a_amount * initial_pool_token_amount;
-    let lost_b_value = initial_swap_token_b_amount * pool_token_amount > swap_token_b_amount * initial_pool_token_amount;
+    let lost_a_value = initial_swap_token_a_amount * pool_token_amount
+        > swap_token_a_amount * initial_pool_token_amount;
+    let lost_b_value = initial_swap_token_b_amount * pool_token_amount
+        > swap_token_b_amount * initial_pool_token_amount;
     assert!(!(lost_a_value && lost_b_value));
 
     // check total token a and b amounts

--- a/token-swap/program/fuzz/src/instructions.rs
+++ b/token-swap/program/fuzz/src/instructions.rs
@@ -142,10 +142,10 @@ fn run_fuzz_instructions(fuzz_instructions: Vec<FuzzInstruction>) {
         .iter()
         .map(|&x| get_token_balance(x))
         .sum::<u64>() as u128;
-    let initial_shares =
+    let initial_pool_token_amount =
         pool_shares + pool_accounts.values().map(get_token_balance).sum::<u64>() as u128;
-    let initial_basket_a = get_token_balance(&token_swap.token_a_account) as u128;
-    let initial_basket_b = get_token_balance(&token_swap.token_b_account) as u128;
+    let initial_swap_token_a_amount = get_token_balance(&token_swap.token_a_account) as u128;
+    let initial_swap_token_b_amount = get_token_balance(&token_swap.token_b_account) as u128;
 
     // to ensure that we never create or remove base tokens
     let before_total_token_a =
@@ -167,12 +167,14 @@ fn run_fuzz_instructions(fuzz_instructions: Vec<FuzzInstruction>) {
         .iter()
         .map(|&x| get_token_balance(x))
         .sum::<u64>() as u128;
-    let shares = pool_shares + pool_accounts.values().map(get_token_balance).sum::<u64>() as u128;
-    let basket_a = get_token_balance(&token_swap.token_a_account) as u128;
-    let basket_b = get_token_balance(&token_swap.token_b_account) as u128;
+    let pool_token_amount = pool_shares + pool_accounts.values().map(get_token_balance).sum::<u64>() as u128;
+    let swap_token_a_amount = get_token_balance(&token_swap.token_a_account) as u128;
+    let swap_token_b_amount = get_token_balance(&token_swap.token_b_account) as u128;
 
-    let lost_a_per_share = initial_basket_a * shares > basket_a * initial_shares;
-    let lost_b_per_share = initial_basket_b * shares > basket_b * initial_shares;
+    println!("{} {} {}", initial_swap_token_a_amount, initial_swap_token_b_amount, initial_pool_token_amount);
+    println!("{} {} {}", swap_token_a_amount, swap_token_b_amount, pool_token_amount);
+    let lost_a_per_share = initial_swap_token_a_amount * pool_token_amount > swap_token_a_amount * initial_pool_token_amount;
+    let lost_b_per_share = initial_swap_token_b_amount * pool_token_amount > swap_token_b_amount * initial_pool_token_amount;
     assert!(!(lost_a_per_share && lost_b_per_share));
 
     // check total token a and b amounts

--- a/token-swap/program/src/curve/calculator.rs
+++ b/token-swap/program/src/curve/calculator.rs
@@ -1,6 +1,6 @@
 //! Swap calculations
 
-use crate::{curve::math::PreciseNumber, error::SwapError};
+use crate::{curve::math::{ceiling_division, PreciseNumber}, error::SwapError};
 use std::fmt::Debug;
 
 /// Initial amount of pool tokens for swap contract, hard-coded to something
@@ -56,9 +56,9 @@ pub struct SwapWithoutFeesResult {
 /// Encodes results of depositing both sides at once
 #[derive(Debug, PartialEq)]
 pub struct TradingTokenResult {
-    /// Amount of token
+    /// Amount of token A
     pub token_a_amount: u128,
-    /// Amount of destination token swapped
+    /// Amount of token B
     pub token_b_amount: u128,
 }
 
@@ -99,12 +99,16 @@ pub trait CurveCalculator: Debug + DynPack {
         swap_token_a_amount: u128,
         swap_token_b_amount: u128,
     ) -> Option<TradingTokenResult> {
-        let token_a_amount = pool_tokens
-            .checked_mul(swap_token_a_amount)?
-            .checked_div(pool_token_supply)?;
-        let token_b_amount = pool_tokens
-            .checked_mul(swap_token_b_amount)?
-            .checked_div(pool_token_supply)?;
+        let (token_a_amount, _) =
+            ceiling_division(
+                pool_tokens.checked_mul(swap_token_a_amount)?,
+                pool_token_supply
+            )?;
+        let (token_b_amount, _) =
+            ceiling_division(
+                pool_tokens.checked_mul(swap_token_b_amount)?,
+                pool_token_supply
+            )?;
         Some(TradingTokenResult {
             token_a_amount,
             token_b_amount,

--- a/token-swap/program/src/curve/calculator.rs
+++ b/token-swap/program/src/curve/calculator.rs
@@ -1,6 +1,9 @@
 //! Swap calculations
 
-use crate::{curve::math::{ceiling_division, PreciseNumber}, error::SwapError};
+use crate::{
+    curve::math::{ceiling_division, PreciseNumber},
+    error::SwapError,
+};
 use std::fmt::Debug;
 
 /// Initial amount of pool tokens for swap contract, hard-coded to something
@@ -99,16 +102,14 @@ pub trait CurveCalculator: Debug + DynPack {
         swap_token_a_amount: u128,
         swap_token_b_amount: u128,
     ) -> Option<TradingTokenResult> {
-        let (token_a_amount, _) =
-            ceiling_division(
-                pool_tokens.checked_mul(swap_token_a_amount)?,
-                pool_token_supply
-            )?;
-        let (token_b_amount, _) =
-            ceiling_division(
-                pool_tokens.checked_mul(swap_token_b_amount)?,
-                pool_token_supply
-            )?;
+        let (token_a_amount, _) = ceiling_division(
+            pool_tokens.checked_mul(swap_token_a_amount)?,
+            pool_token_supply,
+        )?;
+        let (token_b_amount, _) = ceiling_division(
+            pool_tokens.checked_mul(swap_token_b_amount)?,
+            pool_token_supply,
+        )?;
         Some(TradingTokenResult {
             token_a_amount,
             token_b_amount,

--- a/token-swap/program/src/curve/constant_product.rs
+++ b/token-swap/program/src/curve/constant_product.rs
@@ -117,9 +117,9 @@ mod tests {
 
     #[test]
     fn trading_token_conversion() {
-        check_pool_token_rate(2, 49, 5, 10, 1, 24);
-        check_pool_token_rate(100, 202, 5, 101, 4, 10);
-        check_pool_token_rate(5, 501, 2, 10, 1, 100);
+        check_pool_token_rate(2, 49, 5, 10, 1, 25);
+        check_pool_token_rate(100, 202, 5, 101, 5, 10);
+        check_pool_token_rate(5, 501, 2, 10, 1, 101);
     }
 
     #[test]

--- a/token-swap/program/src/curve/constant_product.rs
+++ b/token-swap/program/src/curve/constant_product.rs
@@ -9,6 +9,7 @@ use crate::{
     curve::calculator::{
         map_zero_to_none, CurveCalculator, DynPack, SwapWithoutFeesResult, TradeDirection,
     },
+    curve::math::ceiling_division,
     error::SwapError,
 };
 
@@ -28,22 +29,8 @@ pub fn swap(
 ) -> Option<SwapWithoutFeesResult> {
     let invariant = swap_source_amount.checked_mul(swap_destination_amount)?;
 
-    let mut new_swap_source_amount = swap_source_amount.checked_add(source_amount)?;
-    let mut new_swap_destination_amount = invariant.checked_div(new_swap_source_amount)?;
-
-    // Ceiling the destination amount if there's any remainder, which will
-    // almost always be the case.
-    let remainder = invariant.checked_rem(new_swap_source_amount)?;
-    if remainder > 0 {
-        new_swap_destination_amount = new_swap_destination_amount.checked_add(1)?;
-        // now calculate the minimum amount of source token needed to get
-        // the destination amount to avoid taking too much from users
-        new_swap_source_amount = invariant.checked_div(new_swap_destination_amount)?;
-        let remainder = invariant.checked_rem(new_swap_destination_amount)?;
-        if remainder > 0 {
-            new_swap_source_amount = new_swap_source_amount.checked_add(1)?;
-        }
-    }
+    let new_swap_source_amount = swap_source_amount.checked_add(source_amount)?;
+    let (new_swap_destination_amount, new_swap_source_amount) = ceiling_division(invariant, new_swap_source_amount)?;
 
     let source_amount_swapped = new_swap_source_amount.checked_sub(swap_source_amount)?;
     let destination_amount_swapped =

--- a/token-swap/program/src/curve/constant_product.rs
+++ b/token-swap/program/src/curve/constant_product.rs
@@ -30,7 +30,8 @@ pub fn swap(
     let invariant = swap_source_amount.checked_mul(swap_destination_amount)?;
 
     let new_swap_source_amount = swap_source_amount.checked_add(source_amount)?;
-    let (new_swap_destination_amount, new_swap_source_amount) = ceiling_division(invariant, new_swap_source_amount)?;
+    let (new_swap_destination_amount, new_swap_source_amount) =
+        ceiling_division(invariant, new_swap_source_amount)?;
 
     let source_amount_swapped = new_swap_source_amount.checked_sub(swap_source_amount)?;
     let destination_amount_swapped =

--- a/token-swap/program/src/curve/math.rs
+++ b/token-swap/program/src/curve/math.rs
@@ -49,13 +49,19 @@ impl U256 {
 /// calculation.
 ///
 /// For example, 400 / 32 = 12, with a remainder cutting off 0.5 of amount.
-/// If we ceiling the quotient to 13, then we say 400 / 32 = 13, which
-/// also cuts off value.  We calculate the other way around and again check
-/// for a remainder: 400 / 13 = 30, with a remainder of 0.77, and we ceiling
-/// that value again.  This gives us a final calculation of 400 / 31 = 13, which
-/// provides a ceiling calculation without cutting off more value than needed.
+/// If we simply ceiling the quotient to 13, then we're saying 400 / 32 = 13, which
+/// also cuts off value.  To improve this result, we calculate the other way
+/// around and again check for a remainder: 400 / 13 = 30, with a remainder of
+/// 0.77, and we ceiling that value again.  This gives us a final calculation
+/// of 400 / 31 = 13, which provides a ceiling calculation without cutting off
+/// more value than needed.
+///
+/// This calculation fails if the divisor is larger than the dividend, to avoid
+/// having a result like: 1 / 1000 = 1.
 pub fn ceiling_division(dividend: u128, mut divisor: u128) -> Option<(u128, u128)> {
     let mut quotient = dividend.checked_div(divisor)?;
+    // Avoid dividing a small number by a big one and returning 1, and instead
+    // fail.
     if quotient == 0 {
         return None;
     }

--- a/token-swap/program/src/curve/math.rs
+++ b/token-swap/program/src/curve/math.rs
@@ -56,6 +56,9 @@ impl U256 {
 /// provides a ceiling calculation without cutting off more value than needed.
 pub fn ceiling_division(dividend: u128, mut divisor: u128) -> Option<(u128, u128)> {
     let mut quotient = dividend.checked_div(divisor)?;
+    if quotient == 0 {
+        return None;
+    }
 
     // Ceiling the destination amount if there's any remainder, which will
     // almost always be the case.

--- a/token-swap/program/src/curve/math.rs
+++ b/token-swap/program/src/curve/math.rs
@@ -40,6 +40,39 @@ impl U256 {
     }
 }
 
+/// Perform a division that does not truncate value from either side, returning
+/// the (quotient, divisor) as a tuple
+///
+/// When dividing integers, we are often left with a remainder, which can
+/// cause information to be lost.  By checking for a remainder, adjusting
+/// the quotient, and recalculating the divisor, this provides the most fair
+/// calculation.
+///
+/// For example, 400 / 32 = 12, with a remainder cutting off 0.5 of amount.
+/// If we ceiling the quotient to 13, then we say 400 / 32 = 13, which
+/// also cuts off value.  We calculate the other way around and again check
+/// for a remainder: 400 / 13 = 30, with a remainder of 0.77, and we ceiling
+/// that value again.  This gives us a final calculation of 400 / 31 = 13, which
+/// provides a ceiling calculation without cutting off more value than needed.
+pub fn ceiling_division(dividend: u128, mut divisor: u128) -> Option<(u128, u128)> {
+    let mut quotient = dividend.checked_div(divisor)?;
+
+    // Ceiling the destination amount if there's any remainder, which will
+    // almost always be the case.
+    let remainder = dividend.checked_rem(divisor)?;
+    if remainder > 0 {
+        quotient = quotient.checked_add(1)?;
+        // calculate the minimum amount needed to get the dividend amount to
+        // avoid truncating too much
+        divisor = dividend.checked_div(quotient)?;
+        let remainder = dividend.checked_rem(quotient)?;
+        if remainder > 0 {
+            divisor = divisor.checked_add(1)?;
+        }
+    }
+    Some((quotient, divisor))
+}
+
 /// The representation of the number one as a precise number as 10^12
 pub const ONE: u128 = 1_000_000_000_000;
 

--- a/token-swap/program/src/curve/stable.rs
+++ b/token-swap/program/src/curve/stable.rs
@@ -203,9 +203,9 @@ mod tests {
 
     #[test]
     fn trading_token_conversion() {
-        check_pool_token_rate(2, 49, 5, 10, 1, 24);
-        check_pool_token_rate(100, 202, 5, 101, 4, 10);
-        check_pool_token_rate(5, 501, 2, 10, 1, 100);
+        check_pool_token_rate(2, 49, 5, 10, 1, 25);
+        check_pool_token_rate(100, 202, 5, 101, 5, 10);
+        check_pool_token_rate(5, 501, 2, 10, 1, 101);
     }
 
     #[test]

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -522,16 +522,13 @@ impl Processor {
         let pool_mint = Self::unpack_mint(pool_mint_info, &token_swap.token_program_id)?;
         let pool_token_amount = to_u128(pool_token_amount)?;
         let pool_mint_supply = to_u128(pool_mint.supply)?;
-        let new_pool_mint_supply = pool_mint_supply
-            .checked_add(pool_token_amount)
-            .ok_or(SwapError::CalculationFailure)?;
 
         let calculator = token_swap.swap_curve.calculator;
 
         let results = calculator
             .pool_tokens_to_trading_tokens(
                 pool_token_amount,
-                new_pool_mint_supply,
+                pool_mint_supply,
                 to_u128(token_a.amount)?,
                 to_u128(token_b.amount)?,
             )
@@ -550,6 +547,8 @@ impl Processor {
         if token_b_amount == 0 {
             return Err(SwapError::ZeroTradingTokens.into());
         }
+
+        let pool_token_amount = to_u64(pool_token_amount)?;
 
         Self::token_transfer(
             swap_info.key,
@@ -576,7 +575,7 @@ impl Processor {
             dest_info.clone(),
             authority_info.clone(),
             token_swap.nonce,
-            to_u64(pool_token_amount)?,
+            pool_token_amount,
         )?;
 
         Ok(())
@@ -2826,10 +2825,10 @@ mod tests {
             SwapAccountInfo::new(&user_key, fees, swap_curve, token_a_amount, token_b_amount);
 
         // depositing 10% of the current pool amount means that our share will
-        // be 1 / 11 of the final pool amount
+        // be 1 / 10 of the final pool amount
         let pool_amount = INITIAL_SWAP_POOL_AMOUNT / 10;
-        let deposit_a = token_a_amount / 11;
-        let deposit_b = token_b_amount / 11;
+        let deposit_a = token_a_amount / 10;
+        let deposit_b = token_b_amount / 10;
 
         // swap not initialized
         {
@@ -3270,7 +3269,7 @@ mod tests {
                     &mut pool_account,
                     1,
                     deposit_a,
-                    deposit_b / 10,
+                    deposit_b,
                 )
             );
         }

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -2824,8 +2824,8 @@ mod tests {
         let mut accounts =
             SwapAccountInfo::new(&user_key, fees, swap_curve, token_a_amount, token_b_amount);
 
-        // depositing 10% of the current pool amount means that our share will
-        // be 1 / 10 of the final pool amount
+        // depositing 10% of the current pool amount in token A and B means
+        // that our pool tokens will be worth 1 / 10 of the current pool amount
         let pool_amount = INITIAL_SWAP_POOL_AMOUNT / 10;
         let deposit_a = token_a_amount / 10;
         let deposit_b = token_b_amount / 10;


### PR DESCRIPTION
This adds an extra check in the instruction fuzzer, where we calculate the total value of pool tokens before and after the instructions.  Their relative value should never decrease, ie. `A_total_start / P_total_start <= A_total_end / P_total_end` should always hold.  This also showed that the deposit math was incorrect, and we should *not* be adding the amount coming in on a deposit.  See https://balancer.finance/whitepaper/#all-asset-deposit-withdrawal for the applicable formula.