### PR TITLE
token-swap: Add proptest for deposit draining

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,19 +724,6 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
-dependencies = [
- "byteorder",
- "digest 0.8.1",
- "rand_core",
- "subtle 2.2.3",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "2.1.0"
 source = "git+https://github.com/garious/curve25519-dalek?rev=60efef3553d6bf3d7f3b09b5f97acd54d72529ff#60efef3553d6bf3d7f3b09b5f97acd54d72529ff"
 dependencies = [
  "borsh",
@@ -744,6 +731,19 @@ dependencies = [
  "digest 0.8.1",
  "rand_core",
  "serde",
+ "subtle 2.2.3",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
+dependencies = [
+ "byteorder",
+ "digest 0.8.1",
+ "rand_core",
  "subtle 2.2.3",
  "zeroize",
 ]

--- a/token-swap/program/src/curve/constant_price.rs
+++ b/token-swap/program/src/curve/constant_price.rs
@@ -142,10 +142,15 @@ impl CurveCalculator for ConstantPriceCurve {
         swap_token_a_amount: u128,
         swap_token_b_amount: u128,
     ) -> Option<u128> {
-        let swap_token_b_amount = swap_token_b_amount.checked_mul(self.token_b_price as u128)?;
-        swap_token_a_amount
-            .checked_add(swap_token_b_amount)?
-            .checked_div(2)
+        let swap_token_b_value = swap_token_b_amount.checked_mul(self.token_b_price as u128)?;
+        // special logic in case we're close to the limits, avoid overflowing u128
+        if swap_token_b_value.saturating_sub(u64::MAX.into()) > (u128::MAX.saturating_sub(u64::MAX.into())) {
+            swap_token_b_value.checked_div(2)?.checked_add(swap_token_a_amount.checked_div(2)?)
+        } else {
+            swap_token_a_amount
+                .checked_add(swap_token_b_value)?
+                .checked_div(2)
+        }
     }
 }
 

--- a/token-swap/program/src/curve/constant_price.rs
+++ b/token-swap/program/src/curve/constant_price.rs
@@ -68,21 +68,13 @@ impl CurveCalculator for ConstantPriceCurve {
         swap_token_a_amount: u128,
         swap_token_b_amount: u128,
     ) -> Option<TradingTokenResult> {
-        // Split the pool tokens in half, send half as token A, half as token B
-        let token_a_pool_tokens = pool_tokens.checked_div(2)?;
-        let token_b_pool_tokens = pool_tokens.checked_sub(token_a_pool_tokens)?;
-
         let token_b_price = self.token_b_price as u128;
-        let total_value = swap_token_b_amount
-            .checked_mul(token_b_price)?
-            .checked_add(swap_token_a_amount)?;
+        let total_value = self.normalized_value(swap_token_a_amount, swap_token_b_amount)?;
 
-        let (token_a_amount, _) = ceiling_division(
-            token_a_pool_tokens.checked_mul(total_value)?,
-            pool_token_supply,
-        )?;
+        let (token_a_amount, _) =
+            ceiling_division(pool_tokens.checked_mul(total_value)?, pool_token_supply)?;
         let (token_b_amount, _) = ceiling_division(
-            token_b_pool_tokens
+            pool_tokens
                 .checked_mul(total_value)?
                 .checked_div(token_b_price)?,
             pool_token_supply,
@@ -142,13 +134,18 @@ impl CurveCalculator for ConstantPriceCurve {
     /// Note that since most other curves use a multiplicative invariant, ie.
     /// `token_a * token_b`, whereas this one uses an addition,
     /// ie. `token_a + token_b`.
+    ///
+    /// At the end, we divide by 2 to normalize the value between the two token
+    /// types.
     fn normalized_value(
         &self,
         swap_token_a_amount: u128,
         swap_token_b_amount: u128,
     ) -> Option<u128> {
         let swap_token_b_amount = swap_token_b_amount.checked_mul(self.token_b_price as u128)?;
-        swap_token_a_amount.checked_add(swap_token_b_amount)
+        swap_token_a_amount
+            .checked_add(swap_token_b_amount)?
+            .checked_div(2)
     }
 }
 
@@ -419,6 +416,57 @@ mod tests {
                 swap_destination_amount,
                 TradeDirection::BtoA
             );
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn curve_value_does_not_decrease_from_deposit(
+            pool_token_amount in 2..u64::MAX, // minimum 2 to splitting on deposit
+            pool_token_supply in INITIAL_SWAP_POOL_AMOUNT..u64::MAX as u128,
+            swap_token_a_amount in 1..u64::MAX,
+            swap_token_b_amount in 1..u32::MAX, // kept small to avoid proptest rejections
+            token_b_price in 1..u32::MAX, // kept small to avoid proptest rejections
+        ) {
+            let curve = ConstantPriceCurve { token_b_price: token_b_price as u64 };
+            let pool_token_amount = pool_token_amount as u128;
+            let pool_token_supply = pool_token_supply as u128;
+            let swap_token_a_amount = swap_token_a_amount as u128;
+            let swap_token_b_amount = swap_token_b_amount as u128;
+            let token_b_price = token_b_price as u128;
+
+            let value = curve.normalized_value(swap_token_a_amount, swap_token_b_amount).unwrap();
+
+            // Make sure we trade at least one of each token
+            prop_assume!(pool_token_amount * value >= 2 * token_b_price * pool_token_supply);
+            let deposit_result = curve
+                .pool_tokens_to_trading_tokens(
+                    pool_token_amount,
+                    pool_token_supply,
+                    swap_token_a_amount,
+                    swap_token_b_amount,
+                )
+                .unwrap();
+            let new_swap_token_a_amount = swap_token_a_amount + deposit_result.token_a_amount;
+            let new_swap_token_b_amount = swap_token_b_amount + deposit_result.token_b_amount;
+            let new_pool_token_supply = pool_token_supply + pool_token_amount;
+
+            let new_value = curve.normalized_value(new_swap_token_a_amount, new_swap_token_b_amount).unwrap();
+
+            // the following inequality must hold:
+            // new_value / new_pool_token_supply >= value / pool_token_supply
+            // which reduces to:
+            // new_value * pool_token_supply >= value * new_pool_token_supply
+
+            // These numbers can be just slightly above u64 after the deposit, which
+            // means that their multiplication can be just above the range of u128.
+            // For ease of testing, we bump these up to U256.
+            let pool_token_supply = U256::from(pool_token_supply);
+            let new_pool_token_supply = U256::from(new_pool_token_supply);
+            let value = U256::from(value);
+            let new_value = U256::from(new_value);
+
+            assert!(new_value * pool_token_supply >= value * new_pool_token_supply);
         }
     }
 }

--- a/token-swap/program/src/curve/constant_price.rs
+++ b/token-swap/program/src/curve/constant_price.rs
@@ -144,8 +144,8 @@ impl CurveCalculator for ConstantPriceCurve {
     ) -> Option<u128> {
         let swap_token_b_value = swap_token_b_amount.checked_mul(self.token_b_price as u128)?;
         // special logic in case we're close to the limits, avoid overflowing u128
-        if swap_token_b_value.saturating_sub(u64::MAX.into())
-            > (u128::MAX.saturating_sub(u64::MAX.into()))
+        if swap_token_b_value.saturating_sub(std::u64::MAX.into())
+            > (std::u128::MAX.saturating_sub(std::u64::MAX.into()))
         {
             swap_token_b_value
                 .checked_div(2)?

--- a/token-swap/program/src/curve/constant_price.rs
+++ b/token-swap/program/src/curve/constant_price.rs
@@ -144,8 +144,12 @@ impl CurveCalculator for ConstantPriceCurve {
     ) -> Option<u128> {
         let swap_token_b_value = swap_token_b_amount.checked_mul(self.token_b_price as u128)?;
         // special logic in case we're close to the limits, avoid overflowing u128
-        if swap_token_b_value.saturating_sub(u64::MAX.into()) > (u128::MAX.saturating_sub(u64::MAX.into())) {
-            swap_token_b_value.checked_div(2)?.checked_add(swap_token_a_amount.checked_div(2)?)
+        if swap_token_b_value.saturating_sub(u64::MAX.into())
+            > (u128::MAX.saturating_sub(u64::MAX.into()))
+        {
+            swap_token_b_value
+                .checked_div(2)?
+                .checked_add(swap_token_a_amount.checked_div(2)?)
         } else {
             swap_token_a_amount
                 .checked_add(swap_token_b_value)?

--- a/token-swap/program/src/curve/constant_product.rs
+++ b/token-swap/program/src/curve/constant_product.rs
@@ -88,7 +88,7 @@ mod tests {
     use crate::curve::calculator::{
         test::{
             check_curve_value_from_swap, check_pool_token_conversion,
-            CONVERSION_BASIS_POINTS_GUARANTEE,
+            check_pool_value_from_deposit, CONVERSION_BASIS_POINTS_GUARANTEE,
         },
         INITIAL_SWAP_POOL_AMOUNT,
     };
@@ -260,6 +260,33 @@ mod tests {
                 swap_source_amount as u128,
                 swap_destination_amount as u128,
                 TradeDirection::AtoB
+            );
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn curve_value_does_not_decrease_from_deposit(
+            pool_token_amount in 1..u64::MAX,
+            pool_token_supply in 1..u64::MAX,
+            swap_token_a_amount in 1..u64::MAX,
+            swap_token_b_amount in 1..u64::MAX,
+        ) {
+            let pool_token_amount = pool_token_amount as u128;
+            let pool_token_supply = pool_token_supply as u128;
+            let swap_token_a_amount = swap_token_a_amount as u128;
+            let swap_token_b_amount = swap_token_b_amount as u128;
+            // Make sure we will get at least one trading token out for each
+            // side, otherwise the calculation fails
+            prop_assume!(pool_token_amount * swap_token_a_amount / pool_token_supply >= 1);
+            prop_assume!(pool_token_amount * swap_token_b_amount / pool_token_supply >= 1);
+            let curve = ConstantProductCurve {};
+            check_pool_value_from_deposit(
+                &curve,
+                pool_token_amount,
+                pool_token_supply,
+                swap_token_a_amount,
+                swap_token_b_amount,
             );
         }
     }


### PR DESCRIPTION
This adds a specific proptest to make sure that no deposit drains value from the pool.  While creating these tests, I noticed that the constant price curve was not performing its conversions totally correctly.  The true normalized value for an additive curve (one in which the value is derived as `x * token_a + y * token_b`) needs to have a division by 2 at the end, similar to how the constant product curve normalized value needs to be `sqrt`'ed.