### PR TITLE
lending: Add version and padding to state structs

### DIFF
--- a/token-lending/js/client/index.ts
+++ b/token-lending/js/client/index.ts
@@ -24,9 +24,10 @@ const TOKEN_PROGRAM_ID = new PublicKey(
  */
 export const LendingMarketLayout: typeof BufferLayout.Structure = BufferLayout.struct(
   [
-    BufferLayout.u8("isInitialized"),
+    BufferLayout.u8("version"),
     Layout.publicKey("quoteTokenMint"),
     Layout.publicKey("tokenProgramId"),
+    BufferLayout.blob(63, "padding"),
   ]
 );
 

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -82,7 +82,6 @@ fn process_init_lending_market(_program_id: &Pubkey, accounts: &[AccountInfo]) -
     assert_rent_exempt(rent, lending_market_info)?;
     let mut new_lending_market: LendingMarket = assert_uninitialized(lending_market_info)?;
     new_lending_market.version = PROGRAM_VERSION;
-    new_lending_market.is_initialized = true;
     new_lending_market.quote_token_mint = *quote_token_mint_info.key;
     LendingMarket::pack(
         new_lending_market,

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -5,7 +5,7 @@ use crate::{
     error::LendingError,
     instruction::{BorrowAmountType, LendingInstruction},
     math::{Decimal, Rate, WAD},
-    state::{LendingMarket, Obligation, Reserve, ReserveConfig, ReserveState},
+    state::{LendingMarket, Obligation, Reserve, ReserveConfig, ReserveState, PROGRAM_VERSION},
 };
 use num_traits::FromPrimitive;
 use solana_program::{
@@ -81,6 +81,7 @@ fn process_init_lending_market(_program_id: &Pubkey, accounts: &[AccountInfo]) -
 
     assert_rent_exempt(rent, lending_market_info)?;
     let mut new_lending_market: LendingMarket = assert_uninitialized(lending_market_info)?;
+    new_lending_market.version = PROGRAM_VERSION;
     new_lending_market.is_initialized = true;
     new_lending_market.quote_token_mint = *quote_token_mint_info.key;
     LendingMarket::pack(
@@ -255,6 +256,7 @@ fn process_init_reserve(
 
     Reserve::pack(
         Reserve {
+            version: PROGRAM_VERSION,
             lending_market: *lending_market_info.key,
             liquidity_mint: *reserve_liquidity_mint_info.key,
             liquidity_mint_decimals: liquidity_reserve_mint.decimals,
@@ -553,7 +555,6 @@ fn process_borrow(
     borrow_reserve.accrue_interest(clock.slot);
     deposit_reserve.accrue_interest(clock.slot);
     let cumulative_borrow_rate = borrow_reserve.state.cumulative_borrow_rate_wads;
-    let deposit_reserve_collateral_exchange_rate = deposit_reserve.state.collateral_exchange_rate();
 
     let mut trade_simulator = TradeSimulator::new(
         dex_market_info,
@@ -562,56 +563,12 @@ fn process_borrow(
         &lending_market.quote_token_mint,
     )?;
 
-    let (borrow_amount, mut collateral_deposit_amount) = match amount_type {
-        BorrowAmountType::LiquidityBorrowAmount => {
-            let borrow_amount = amount;
-
-            // Simulate buying `borrow_amount` of borrow reserve underlying tokens
-            //   to determine how much collateral is needed
-            let loan_in_deposit_underlying = trade_simulator.simulate_trade(
-                TradeAction::Buy,
-                Decimal::from(borrow_amount),
-                &borrow_reserve.liquidity_mint,
-                false,
-            )?;
-
-            let loan_in_deposit_collateral = deposit_reserve_collateral_exchange_rate
-                .decimal_liquidity_to_collateral(loan_in_deposit_underlying);
-            let required_deposit_collateral: Decimal = loan_in_deposit_collateral
-                / Rate::from_percent(deposit_reserve.config.loan_to_value_ratio);
-
-            let collateral_deposit_amount = required_deposit_collateral.round_u64();
-            if collateral_deposit_amount == 0 {
-                return Err(LendingError::InvalidAmount.into());
-            }
-
-            (borrow_amount, collateral_deposit_amount)
-        }
-        BorrowAmountType::CollateralDepositAmount => {
-            let collateral_deposit_amount = amount;
-
-            let loan_in_deposit_collateral: Decimal = Decimal::from(collateral_deposit_amount)
-                * Rate::from_percent(deposit_reserve.config.loan_to_value_ratio);
-            let loan_in_deposit_underlying = deposit_reserve_collateral_exchange_rate
-                .decimal_collateral_to_liquidity(loan_in_deposit_collateral);
-
-            // Simulate selling `loan_in_deposit_underlying` amount of deposit reserve underlying
-            //   tokens to determine how much to lend to the user
-            let borrow_amount = trade_simulator.simulate_trade(
-                TradeAction::Sell,
-                loan_in_deposit_underlying,
-                &deposit_reserve.liquidity_mint,
-                false,
-            )?;
-
-            let borrow_amount = borrow_amount.round_u64();
-            if borrow_amount == 0 {
-                return Err(LendingError::InvalidAmount.into());
-            }
-
-            (borrow_amount, collateral_deposit_amount)
-        }
-    };
+    let (borrow_amount, mut collateral_deposit_amount) = trade_simulator.calculate_borrow_amounts(
+        &deposit_reserve,
+        &borrow_reserve,
+        amount_type,
+        amount,
+    )?;
 
     let (mut borrow_fee, host_fee) = deposit_reserve
         .config
@@ -651,6 +608,7 @@ fn process_borrow(
     } else {
         assert_rent_exempt(rent, obligation_info)?;
         let mut new_obligation = obligation;
+        new_obligation.version = PROGRAM_VERSION;
         new_obligation.last_update_slot = clock.slot;
         new_obligation.deposited_collateral_tokens = collateral_deposit_amount;
         new_obligation.collateral_reserve = *deposit_reserve_info.key;

--- a/token-lending/program/src/state.rs
+++ b/token-lending/program/src/state.rs
@@ -394,7 +394,8 @@ impl Pack for Reserve {
             collateral_mint_supply,
             __padding,
         ) = array_refs![
-            input, 1, 8, 32, 32, 1, 32, 32, 32, 32, 36, 1, 1, 1, 1, 1, 1, 1, 8, 1, 16, 16, 8, 8, 300
+            input, 1, 8, 32, 32, 1, 32, 32, 32, 32, 36, 1, 1, 1, 1, 1, 1, 1, 8, 1, 16, 16, 8, 8,
+            300
         ];
         Ok(Self {
             version: u8::from_le_bytes(*version),
@@ -457,7 +458,8 @@ impl Pack for Reserve {
             collateral_mint_supply,
             _padding,
         ) = mut_array_refs![
-            output, 1, 8, 32, 32, 1, 32, 32, 32, 32, 36, 1, 1, 1, 1, 1, 1, 1, 8, 1, 16, 16, 8, 8, 300
+            output, 1, 8, 32, 32, 1, 32, 32, 32, 32, 36, 1, 1, 1, 1, 1, 1, 1, 8, 1, 16, 16, 8, 8,
+            300
         ];
         *version = self.version.to_le_bytes();
         *last_update_slot = self.state.last_update_slot.to_le_bytes();

--- a/token-lending/program/src/state.rs
+++ b/token-lending/program/src/state.rs
@@ -360,9 +360,9 @@ impl IsInitialized for Reserve {
     }
 }
 
-const RESERVE_LEN: usize = 302;
+const RESERVE_LEN: usize = 602;
 impl Pack for Reserve {
-    const LEN: usize = 302;
+    const LEN: usize = 602;
 
     /// Unpacks a byte buffer into a [ReserveInfo](struct.ReserveInfo.html).
     fn unpack_from_slice(input: &[u8]) -> Result<Self, ProgramError> {
@@ -392,8 +392,9 @@ impl Pack for Reserve {
             total_borrows,
             available_liquidity,
             collateral_mint_supply,
+            __padding,
         ) = array_refs![
-            input, 1, 8, 32, 32, 1, 32, 32, 32, 32, 36, 1, 1, 1, 1, 1, 1, 1, 8, 1, 16, 16, 8, 8
+            input, 1, 8, 32, 32, 1, 32, 32, 32, 32, 36, 1, 1, 1, 1, 1, 1, 1, 8, 1, 16, 16, 8, 8, 300
         ];
         Ok(Self {
             version: u8::from_le_bytes(*version),
@@ -454,8 +455,9 @@ impl Pack for Reserve {
             total_borrows,
             available_liquidity,
             collateral_mint_supply,
+            _padding,
         ) = mut_array_refs![
-            output, 1, 8, 32, 32, 1, 32, 32, 32, 32, 36, 1, 1, 1, 1, 1, 1, 1, 8, 1, 16, 16, 8, 8
+            output, 1, 8, 32, 32, 1, 32, 32, 32, 32, 36, 1, 1, 1, 1, 1, 1, 1, 8, 1, 16, 16, 8, 8, 300
         ];
         *version = self.version.to_le_bytes();
         *last_update_slot = self.state.last_update_slot.to_le_bytes();
@@ -493,16 +495,16 @@ impl IsInitialized for LendingMarket {
     }
 }
 
-const LENDING_MARKET_LEN: usize = 66;
+const LENDING_MARKET_LEN: usize = 128;
 impl Pack for LendingMarket {
-    const LEN: usize = 66;
+    const LEN: usize = 128;
 
     /// Unpacks a byte buffer into a [LendingMarketInfo](struct.LendingMarketInfo.html).
     fn unpack_from_slice(input: &[u8]) -> Result<Self, ProgramError> {
         let input = array_ref![input, 0, LENDING_MARKET_LEN];
         #[allow(clippy::ptr_offset_with_cast)]
-        let (version, is_initialized, quote_token_mint, token_program_id) =
-            array_refs![input, 1, 1, 32, 32];
+        let (version, is_initialized, quote_token_mint, token_program_id, _padding) =
+            array_refs![input, 1, 1, 32, 32, 62];
         Ok(Self {
             version: u8::from_le_bytes(*version),
             is_initialized: match is_initialized {
@@ -518,8 +520,8 @@ impl Pack for LendingMarket {
     fn pack_into_slice(&self, output: &mut [u8]) {
         let output = array_mut_ref![output, 0, LENDING_MARKET_LEN];
         #[allow(clippy::ptr_offset_with_cast)]
-        let (version, is_initialized, quote_token_mint, token_program_id) =
-            mut_array_refs![output, 1, 1, 32, 32];
+        let (version, is_initialized, quote_token_mint, token_program_id, _padding) =
+            mut_array_refs![output, 1, 1, 32, 32, 62];
         *version = self.version.to_le_bytes();
         *is_initialized = [self.is_initialized as u8];
         quote_token_mint.copy_from_slice(self.quote_token_mint.as_ref());
@@ -534,9 +536,9 @@ impl IsInitialized for Obligation {
     }
 }
 
-const OBLIGATION_LEN: usize = 145;
+const OBLIGATION_LEN: usize = 273;
 impl Pack for Obligation {
-    const LEN: usize = 145;
+    const LEN: usize = 273;
 
     /// Unpacks a byte buffer into a [ObligationInfo](struct.ObligationInfo.html).
     fn unpack_from_slice(input: &[u8]) -> Result<Self, ProgramError> {
@@ -551,7 +553,8 @@ impl Pack for Obligation {
             borrowed_liquidity_wads,
             borrow_reserve,
             token_mint,
-        ) = array_refs![input, 1, 8, 8, 32, 16, 16, 32, 32];
+            _padding,
+        ) = array_refs![input, 1, 8, 8, 32, 16, 16, 32, 32, 128];
         Ok(Self {
             version: u8::from_le_bytes(*version),
             last_update_slot: u64::from_le_bytes(*last_update_slot),
@@ -575,7 +578,8 @@ impl Pack for Obligation {
             borrowed_liquidity_wads,
             borrow_reserve,
             token_mint,
-        ) = mut_array_refs![output, 1, 8, 8, 32, 16, 16, 32, 32];
+            _padding,
+        ) = mut_array_refs![output, 1, 8, 8, 32, 16, 16, 32, 32, 128];
 
         *version = self.version.to_le_bytes();
         *last_update_slot = self.last_update_slot.to_le_bytes();

--- a/token-lending/program/tests/genesis_accounts.rs
+++ b/token-lending/program/tests/genesis_accounts.rs
@@ -5,7 +5,10 @@ mod helpers;
 use helpers::genesis::GenesisAccounts;
 use helpers::*;
 use solana_sdk::signature::Keypair;
-use spl_token_lending::{instruction::BorrowAmountType, state::INITIAL_COLLATERAL_RATE};
+use spl_token_lending::{
+    instruction::BorrowAmountType,
+    state::{INITIAL_COLLATERAL_RATE, PROGRAM_VERSION},
+};
 
 #[tokio::test]
 async fn test_success() {
@@ -91,7 +94,7 @@ async fn test_success() {
 
     // Verify lending market
     let lending_market_info = lending_market.get_state(&mut banks_client).await;
-    assert_eq!(lending_market_info.is_initialized, true);
+    assert_eq!(lending_market_info.version, PROGRAM_VERSION);
     assert_eq!(lending_market_info.quote_token_mint, usdc_mint.pubkey);
 
     // Verify reserves

--- a/token-lending/program/tests/helpers/mod.rs
+++ b/token-lending/program/tests/helpers/mod.rs
@@ -22,7 +22,7 @@ use spl_token_lending::{
     processor::process_instruction,
     state::{
         LendingMarket, Obligation, Reserve, ReserveConfig, ReserveFees, ReserveState,
-        INITIAL_COLLATERAL_RATE,
+        INITIAL_COLLATERAL_RATE, PROGRAM_VERSION,
     },
 };
 use std::str::FromStr;
@@ -121,6 +121,7 @@ pub fn add_lending_market(test: &mut ProgramTest, quote_token_mint: Pubkey) -> T
         keypair.pubkey(),
         u32::MAX as u64,
         &LendingMarket {
+            version: PROGRAM_VERSION,
             is_initialized: true,
             quote_token_mint,
             token_program_id: spl_token::id(),
@@ -196,6 +197,7 @@ pub fn add_obligation(
         obligation_pubkey,
         u32::MAX as u64,
         &Obligation {
+            version: PROGRAM_VERSION,
             last_update_slot: 1u64.wrapping_sub(slots_elapsed),
             deposited_collateral_tokens: collateral_amount,
             collateral_reserve: collateral_reserve.pubkey,
@@ -340,6 +342,7 @@ pub fn add_reserve(
         reserve_pubkey,
         u32::MAX as u64,
         &Reserve {
+            version: PROGRAM_VERSION,
             lending_market: lending_market.keypair.pubkey(),
             liquidity_mint: liquidity_mint_pubkey,
             liquidity_mint_decimals,

--- a/token-lending/program/tests/helpers/mod.rs
+++ b/token-lending/program/tests/helpers/mod.rs
@@ -122,7 +122,6 @@ pub fn add_lending_market(test: &mut ProgramTest, quote_token_mint: Pubkey) -> T
         u32::MAX as u64,
         &LendingMarket {
             version: PROGRAM_VERSION,
-            is_initialized: true,
             quote_token_mint,
             token_program_id: spl_token::id(),
         },
@@ -999,6 +998,7 @@ impl TestReserve {
     pub async fn validate_state(&self, banks_client: &mut BanksClient) {
         let reserve_state = self.get_state(banks_client).await;
         assert!(reserve_state.state.last_update_slot > 0);
+        assert_eq!(PROGRAM_VERSION, reserve_state.version);
         assert_eq!(self.lending_market, reserve_state.lending_market);
         assert_eq!(self.liquidity_mint, reserve_state.liquidity_mint);
         assert_eq!(self.liquidity_supply, reserve_state.liquidity_supply);

--- a/token-lending/program/tests/init_lending_market.rs
+++ b/token-lending/program/tests/init_lending_market.rs
@@ -10,6 +10,7 @@ use solana_sdk::{
 };
 use spl_token_lending::{
     error::LendingError, instruction::init_lending_market, processor::process_instruction,
+    state::PROGRAM_VERSION,
 };
 
 #[tokio::test]
@@ -25,7 +26,7 @@ async fn test_success() {
 
     let lending_market = TestLendingMarket::init(&mut banks_client, usdc_mint.pubkey, &payer).await;
     let lending_market_info = lending_market.get_state(&mut banks_client).await;
-    assert_eq!(lending_market_info.is_initialized, true);
+    assert_eq!(lending_market_info.version, PROGRAM_VERSION);
     assert_eq!(lending_market_info.quote_token_mint, usdc_mint.pubkey);
 }
 


### PR DESCRIPTION
We haven't been able to discuss the best path for versioning structs just yet, but this is a simple alternative of just adding a version at the start of the struct and padding to be potentially used later.

Once `version` was added to `Obligation`, the build failed because of stack size violations in `process_borrow`, so I refactored the borrow amount calculation into a function on `TradeSimulator`.  I didn't see an obvious place to move the calculation -- I thought about putting it in `state.rs`, but then you pull in the TradeSimulator into state, which didn't seem like the right solution.  We can also implement it on `BorrowAmountType`.

Let me know what you think!