### PR TITLE
fuzz: Dump error file as hex instead of using cat

### DIFF
--- a/ci/fuzz.sh
+++ b/ci/fuzz.sh
@@ -32,8 +32,10 @@ exit_status=0
 for crash_file in ./hfuzz_workspace/"$fuzz_target"/*.fuzz; do
   # Check if the glob gets expanded to existing files.
   if [[ -e "$crash_file" ]]; then
-    echo ".fuzz file $crash_file found, meaning some error occurred, try to reproduce locall with the contents of the file:"
-    cat "$crash_file"
+    echo ".fuzz file $crash_file found, some error occurred, try to reproduce"
+    echo "locally with the hexdump of fuzz file.  Use \"xxd -r\" on this to"
+    echo "reconstruct the binary input file"
+    od -t x1 "$crash_file"
     exit_status=1
   fi
 done

--- a/ci/fuzz.sh
+++ b/ci/fuzz.sh
@@ -22,8 +22,6 @@ if [[ -z $2 ]]; then
   usage "No runtime provided"
 fi
 
-set -x
-
 HFUZZ_RUN_ARGS="--run_time $run_time --exit_upon_crash" cargo hfuzz run $fuzz_target
 
 # Until https://github.com/rust-fuzz/honggfuzz-rs/issues/16 is resolved,
@@ -32,10 +30,15 @@ exit_status=0
 for crash_file in ./hfuzz_workspace/"$fuzz_target"/*.fuzz; do
   # Check if the glob gets expanded to existing files.
   if [[ -e "$crash_file" ]]; then
-    echo ".fuzz file $crash_file found, some error occurred, try to reproduce"
-    echo "locally with the hexdump of fuzz file.  Use \"xxd -r\" on this to"
-    echo "reconstruct the binary input file"
+    echo "Error: .fuzz file $crash_file found, reproduce locally with the hexdump:"
     od -t x1 "$crash_file"
+    crash_file_base=$(basename $crash_file)
+    hex_output_filename=hex_"$crash_file_base"
+    echo "Copy / paste this output into a normal file (e.g. $hex_output_filename)"
+    echo "Reconstruct the binary file using:"
+    echo "xxd -r $hex_output_filename > $crash_file_base"
+    echo "To reproduce the problem, run:"
+    echo "cargo hfuzz run-debug $fuzz_target $crash_file_base"
     exit_status=1
   fi
 done


### PR DESCRIPTION
If there's a fuzz failure, the contents of the file are printed using `cat`, which isn't useful for binary files.  Instead, use `od -t x1` to get a hex output that's easy to use with `xxd -r` to reconstruct the binary file.  That way we can reliably reproduce the fuzz failure locally.  There are now more instructions included in the script as well.