### PR TITLE
swap: Avoid fuzz 1 token withdrawal errors by using fee account

### DIFF
--- a/token-swap/program/fuzz/src/instructions.rs
+++ b/token-swap/program/fuzz/src/instructions.rs
@@ -1,5 +1,5 @@
 use spl_token_swap_fuzz::{
-    native_account_data::NativeAccountData, native_token::get_token_balance,
+    native_account_data::NativeAccountData, native_token::{get_token_balance, transfer},
     native_token_swap::NativeTokenSwap,
 };
 
@@ -231,27 +231,24 @@ fn run_fuzz_instructions(fuzz_instructions: Vec<FuzzInstruction>) {
         + get_token_balance(&token_swap.token_b_account);
     assert_eq!(before_total_token_b, after_total_token_b);
 
-    // final check to make sure that withdrawing everything works
-    let mut withdrawn_token_a_account = token_swap.create_token_a_account(0);
-    let mut withdrawn_token_b_account = token_swap.create_token_b_account(0);
+    // Final check to make sure that withdrawing everything works
+    //
+    // First, transfer all pool tokens to the fee account to avoid withdrawal
+    // fees and a potential crash when withdrawing just 1 pool token.
+    let mut fee_account = token_swap.pool_fee_account.clone();
     for mut pool_account in pool_accounts.values_mut() {
-        token_swap
-            .withdraw_all(
-                &mut pool_account,
-                &mut withdrawn_token_a_account,
-                &mut withdrawn_token_b_account,
-            )
-            .unwrap();
+        let pool_token_amount = get_token_balance(&pool_account);
+        if pool_token_amount > 0 {
+            transfer(&mut pool_account, &mut fee_account, pool_token_amount);
+        }
     }
     let mut pool_account = token_swap.pool_token_account.clone();
-    token_swap
-        .withdraw_all(
-            &mut pool_account,
-            &mut withdrawn_token_a_account,
-            &mut withdrawn_token_b_account,
-        )
-        .unwrap();
-    let mut fee_account = token_swap.pool_fee_account.clone();
+    let pool_token_amount = get_token_balance(&pool_account);
+    transfer(&mut pool_account, &mut fee_account, pool_token_amount);
+
+    // Withdraw everything once again
+    let mut withdrawn_token_a_account = token_swap.create_token_a_account(0);
+    let mut withdrawn_token_b_account = token_swap.create_token_b_account(0);
     token_swap
         .withdraw_all(
             &mut fee_account,

--- a/token-swap/program/fuzz/src/instructions.rs
+++ b/token-swap/program/fuzz/src/instructions.rs
@@ -1,5 +1,6 @@
 use spl_token_swap_fuzz::{
-    native_account_data::NativeAccountData, native_token::{get_token_balance, transfer},
+    native_account_data::NativeAccountData,
+    native_token::{get_token_balance, transfer},
     native_token_swap::NativeTokenSwap,
 };
 

--- a/token-swap/program/fuzz/src/native_token.rs
+++ b/token-swap/program/fuzz/src/native_token.rs
@@ -40,7 +40,11 @@ pub fn get_token_balance(account_data: &NativeAccountData) -> u64 {
     account.amount
 }
 
-pub fn transfer(from_account: &mut NativeAccountData, to_account: &mut NativeAccountData, amount: u64) {
+pub fn transfer(
+    from_account: &mut NativeAccountData,
+    to_account: &mut NativeAccountData,
+    amount: u64,
+) {
     let mut from = TokenAccount::unpack(&from_account.data).unwrap();
     let mut to = TokenAccount::unpack(&to_account.data).unwrap();
     assert_eq!(from.mint, to.mint);

--- a/token-swap/program/fuzz/src/native_token.rs
+++ b/token-swap/program/fuzz/src/native_token.rs
@@ -39,3 +39,13 @@ pub fn get_token_balance(account_data: &NativeAccountData) -> u64 {
     let account = TokenAccount::unpack(&account_data.data).unwrap();
     account.amount
 }
+
+pub fn transfer(from_account: &mut NativeAccountData, to_account: &mut NativeAccountData, amount: u64) {
+    let mut from = TokenAccount::unpack(&from_account.data).unwrap();
+    let mut to = TokenAccount::unpack(&to_account.data).unwrap();
+    assert_eq!(from.mint, to.mint);
+    from.amount -= amount;
+    to.amount += amount;
+    TokenAccount::pack(from, &mut from_account.data[..]).unwrap();
+    TokenAccount::pack(to, &mut from_account.data[..]).unwrap();
+}

--- a/token-swap/program/fuzz/src/native_token_swap.rs
+++ b/token-swap/program/fuzz/src/native_token_swap.rs
@@ -272,7 +272,7 @@ impl NativeTokenSwap {
         token_a_account: &mut NativeAccountData,
         token_b_account: &mut NativeAccountData,
         pool_account: &mut NativeAccountData,
-        mut instruction: DepositAllTokenTypes,
+        instruction: DepositAllTokenTypes,
     ) -> ProgramResult {
         let mut user_transfer_account = NativeAccountData::new(0, system_program::id());
         user_transfer_account.is_signer = true;
@@ -312,12 +312,6 @@ impl NativeTokenSwap {
         )
         .unwrap();
 
-        // special logic: if we only deposit 1 pool token, we can't withdraw it
-        // because we incur a withdrawal fee, so we hack it to not be 1
-        if instruction.pool_token_amount == 1 {
-            instruction.pool_token_amount = 2;
-        }
-
         let deposit_instruction = instruction::deposit_all_token_types(
             &spl_token_swap::id(),
             &spl_token::id(),
@@ -356,16 +350,10 @@ impl NativeTokenSwap {
         pool_account: &mut NativeAccountData,
         token_a_account: &mut NativeAccountData,
         token_b_account: &mut NativeAccountData,
-        mut instruction: WithdrawAllTokenTypes,
+        instruction: WithdrawAllTokenTypes,
     ) -> ProgramResult {
         let mut user_transfer_account = NativeAccountData::new(0, system_program::id());
         user_transfer_account.is_signer = true;
-        let pool_token_amount = native_token::get_token_balance(&pool_account);
-        // special logic to avoid withdrawing down to 1 pool token, which
-        // eventually causes an error on withdrawing all
-        if pool_token_amount.saturating_sub(instruction.pool_token_amount) == 1 {
-            instruction.pool_token_amount = pool_token_amount;
-        }
         do_process_instruction(
             approve(
                 &self.token_program_account.key,
@@ -423,7 +411,7 @@ impl NativeTokenSwap {
         &mut self,
         source_token_account: &mut NativeAccountData,
         pool_account: &mut NativeAccountData,
-        mut instruction: DepositSingleTokenTypeExactAmountIn,
+        instruction: DepositSingleTokenTypeExactAmountIn,
     ) -> ProgramResult {
         let mut user_transfer_account = NativeAccountData::new(0, system_program::id());
         user_transfer_account.is_signer = true;
@@ -444,12 +432,6 @@ impl NativeTokenSwap {
             ],
         )
         .unwrap();
-
-        // special logic: if we only deposit 1 pool token, we can't withdraw it
-        // because we incur a withdrawal fee, so we hack it to not be 1
-        if instruction.minimum_pool_token_amount < 2 {
-            instruction.minimum_pool_token_amount = 2;
-        }
 
         let deposit_instruction = instruction::deposit_single_token_type_exact_amount_in(
             &spl_token_swap::id(),
@@ -486,16 +468,10 @@ impl NativeTokenSwap {
         &mut self,
         pool_account: &mut NativeAccountData,
         destination_token_account: &mut NativeAccountData,
-        mut instruction: WithdrawSingleTokenTypeExactAmountOut,
+        instruction: WithdrawSingleTokenTypeExactAmountOut,
     ) -> ProgramResult {
         let mut user_transfer_account = NativeAccountData::new(0, system_program::id());
         user_transfer_account.is_signer = true;
-        let pool_token_amount = native_token::get_token_balance(&pool_account);
-        // special logic to avoid withdrawing down to 1 pool token, which
-        // eventually causes an error on withdrawing all
-        if pool_token_amount.saturating_sub(instruction.maximum_pool_token_amount) == 1 {
-            instruction.maximum_pool_token_amount = pool_token_amount;
-        }
         do_process_instruction(
             approve(
                 &self.token_program_account.key,


### PR DESCRIPTION
There are sporadic crashes on the nightly fuzzing because of the new "withdraw single token type" instruction.  In the fuzzing environment, the curve has a withdraw fee, which means we must provide a minimum of 2 pool tokens to the withdraw instruction, 1 for the fee, and 1 to withdraw token A / B.  There are checks in the other instructions to avoid getting down to 1 pool token, but "withdraw single token type" doesn't allow us to specify exactly how many pool tokens to withdraw, meaning that we can eventually have a situation where we have 1 pool token, causing a crash on the end calculation.  To get around that, this introduces a change to transfer all pool tokens to the fee account before the final withdrawal.  The fee account is not charged a withdrawal fee, so this makes the end calculation more stable.