### PR TITLE
lending: Store bump_seed in lending market to cut compute cost

### DIFF
--- a/token-lending/js/client/index.ts
+++ b/token-lending/js/client/index.ts
@@ -25,9 +25,10 @@ const TOKEN_PROGRAM_ID = new PublicKey(
 export const LendingMarketLayout: typeof BufferLayout.Structure = BufferLayout.struct(
   [
     BufferLayout.u8("version"),
+    BufferLayout.u8("bumpSeed"),
     Layout.publicKey("quoteTokenMint"),
     Layout.publicKey("tokenProgramId"),
-    BufferLayout.blob(63, "padding"),
+    BufferLayout.blob(62, "padding"),
   ]
 );
 

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -186,8 +186,12 @@ fn process_init_reserve(
         COption::None
     };
 
-    let (lending_market_authority_pubkey, bump_seed) =
-        Pubkey::find_program_address(&[lending_market_info.key.as_ref()], program_id);
+    let authority_signer_seeds = &[
+        lending_market_info.key.as_ref(),
+        &[lending_market.bump_seed],
+    ];
+    let lending_market_authority_pubkey =
+        Pubkey::create_program_address(authority_signer_seeds, program_id)?;
     if lending_market_authority_info.key != &lending_market_authority_pubkey {
         return Err(LendingError::InvalidMarketAuthority.into());
     }
@@ -233,7 +237,6 @@ fn process_init_reserve(
         token_program: token_program_id.clone(),
     })?;
 
-    let authority_signer_seeds = &[lending_market_info.key.as_ref(), &[bump_seed]];
     spl_token_transfer(TokenTransferParams {
         source: source_liquidity_info.clone(),
         destination: reserve_liquidity_supply_info.clone(),
@@ -331,13 +334,16 @@ fn process_deposit(
     let collateral_amount = reserve.deposit_liquidity(liquidity_amount);
     Reserve::pack(reserve, &mut reserve_info.data.borrow_mut())?;
 
-    let (lending_market_authority_pubkey, bump_seed) =
-        Pubkey::find_program_address(&[lending_market_info.key.as_ref()], program_id);
+    let authority_signer_seeds = &[
+        lending_market_info.key.as_ref(),
+        &[lending_market.bump_seed],
+    ];
+    let lending_market_authority_pubkey =
+        Pubkey::create_program_address(authority_signer_seeds, program_id)?;
     if lending_market_authority_info.key != &lending_market_authority_pubkey {
         return Err(LendingError::InvalidMarketAuthority.into());
     }
 
-    let authority_signer_seeds = &[lending_market_info.key.as_ref(), &[bump_seed]];
     spl_token_transfer(TokenTransferParams {
         source: source_liquidity_info.clone(),
         destination: reserve_liquidity_supply_info.clone(),
@@ -417,12 +423,15 @@ fn process_withdraw(
     let liquidity_withdraw_amount = reserve.redeem_collateral(collateral_amount)?;
     Reserve::pack(reserve, &mut reserve_info.data.borrow_mut())?;
 
-    let (lending_market_authority_pubkey, bump_seed) =
-        Pubkey::find_program_address(&[lending_market_info.key.as_ref()], program_id);
+    let authority_signer_seeds = &[
+        lending_market_info.key.as_ref(),
+        &[lending_market.bump_seed],
+    ];
+    let lending_market_authority_pubkey =
+        Pubkey::create_program_address(authority_signer_seeds, program_id)?;
     if lending_market_authority_info.key != &lending_market_authority_pubkey {
         return Err(LendingError::InvalidMarketAuthority.into());
     }
-    let authority_signer_seeds = &[lending_market_info.key.as_ref(), &[bump_seed]];
 
     spl_token_transfer(TokenTransferParams {
         source: reserve_liquidity_supply_info.clone(),
@@ -578,7 +587,6 @@ fn process_borrow(
 
     borrow_reserve.state.add_borrow(borrow_amount)?;
 
-    let lending_market_key = deposit_reserve.lending_market;
     let obligation_mint_decimals = deposit_reserve.liquidity_mint_decimals;
 
     Reserve::pack(deposit_reserve, &mut deposit_reserve_info.data.borrow_mut())?;
@@ -618,12 +626,15 @@ fn process_borrow(
         Obligation::pack(new_obligation, &mut obligation_info.data.borrow_mut())?;
     }
 
-    let (lending_market_authority_pubkey, bump_seed) =
-        Pubkey::find_program_address(&[lending_market_key.as_ref()], program_id);
+    let authority_signer_seeds = &[
+        lending_market_info.key.as_ref(),
+        &[lending_market.bump_seed],
+    ];
+    let lending_market_authority_pubkey =
+        Pubkey::create_program_address(authority_signer_seeds, program_id)?;
     if lending_market_authority_info.key != &lending_market_authority_pubkey {
         return Err(LendingError::InvalidMarketAuthority.into());
     }
-    let authority_signer_seeds = &[lending_market_key.as_ref(), &[bump_seed]];
 
     // deposit collateral
     spl_token_transfer(TokenTransferParams {
@@ -843,12 +854,15 @@ fn process_repay(
     obligation.deposited_collateral_tokens -= collateral_withdraw_amount;
     Obligation::pack(obligation, &mut obligation_info.data.borrow_mut())?;
 
-    let (lending_market_authority_pubkey, bump_seed) =
-        Pubkey::find_program_address(&[lending_market_info.key.as_ref()], program_id);
+    let authority_signer_seeds = &[
+        lending_market_info.key.as_ref(),
+        &[lending_market.bump_seed],
+    ];
+    let lending_market_authority_pubkey =
+        Pubkey::create_program_address(authority_signer_seeds, program_id)?;
     if lending_market_authority_info.key != &lending_market_authority_pubkey {
         return Err(LendingError::InvalidMarketAuthority.into());
     }
-    let authority_signer_seeds = &[lending_market_info.key.as_ref(), &[bump_seed]];
 
     // deposit repaid liquidity
     spl_token_transfer(TokenTransferParams {
@@ -1057,12 +1071,15 @@ fn process_liquidate(
     obligation.deposited_collateral_tokens -= collateral_withdraw_amount;
     Obligation::pack(obligation, &mut obligation_info.data.borrow_mut())?;
 
-    let (lending_market_authority_pubkey, bump_seed) =
-        Pubkey::find_program_address(&[lending_market_info.key.as_ref()], program_id);
+    let authority_signer_seeds = &[
+        lending_market_info.key.as_ref(),
+        &[lending_market.bump_seed],
+    ];
+    let lending_market_authority_pubkey =
+        Pubkey::create_program_address(authority_signer_seeds, program_id)?;
     if lending_market_authority_info.key != &lending_market_authority_pubkey {
         return Err(LendingError::InvalidMarketAuthority.into());
     }
-    let authority_signer_seeds = &[lending_market_info.key.as_ref(), &[bump_seed]];
 
     // deposit repaid liquidity
     spl_token_transfer(TokenTransferParams {

--- a/token-lending/program/src/state.rs
+++ b/token-lending/program/src/state.rs
@@ -34,6 +34,8 @@ pub const SLOTS_PER_YEAR: u64 =
 pub struct LendingMarket {
     /// Version of lending market
     pub version: u8,
+    /// Bump seed for derived authority address
+    pub bump_seed: u8,
     /// Quote currency token mint
     pub quote_token_mint: Pubkey,
     /// Token program id
@@ -507,12 +509,14 @@ impl Pack for LendingMarket {
     fn unpack_from_slice(input: &[u8]) -> Result<Self, ProgramError> {
         let input = array_ref![input, 0, LENDING_MARKET_LEN];
         #[allow(clippy::ptr_offset_with_cast)]
-        let (version, quote_token_mint, token_program_id, _padding) =
-            array_refs![input, 1, 32, 32, 63];
+        let (version, bump_seed, quote_token_mint, token_program_id, _padding) =
+            array_refs![input, 1, 1, 32, 32, 62];
         let version = u8::from_le_bytes(*version);
+        let bump_seed = u8::from_le_bytes(*bump_seed);
         match version {
             PROGRAM_VERSION | UNINITIALIZED_VERSION => Ok(Self {
                 version,
+                bump_seed,
                 quote_token_mint: Pubkey::new_from_array(*quote_token_mint),
                 token_program_id: Pubkey::new_from_array(*token_program_id),
             }),
@@ -523,9 +527,10 @@ impl Pack for LendingMarket {
     fn pack_into_slice(&self, output: &mut [u8]) {
         let output = array_mut_ref![output, 0, LENDING_MARKET_LEN];
         #[allow(clippy::ptr_offset_with_cast)]
-        let (version, quote_token_mint, token_program_id, _padding) =
-            mut_array_refs![output, 1, 32, 32, 63];
+        let (version, bump_seed, quote_token_mint, token_program_id, _padding) =
+            mut_array_refs![output, 1, 1, 32, 32, 62];
         *version = self.version.to_le_bytes();
+        *bump_seed = self.bump_seed.to_le_bytes();
         quote_token_mint.copy_from_slice(self.quote_token_mint.as_ref());
         token_program_id.copy_from_slice(self.token_program_id.as_ref());
     }

--- a/token-lending/program/tests/borrow.rs
+++ b/token-lending/program/tests/borrow.rs
@@ -35,7 +35,7 @@ async fn test_borrow_quote_currency() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(186_000);
+    test.set_bpf_compute_max_units(188_000);
 
     let user_accounts_owner = Keypair::new();
     let sol_usdc_dex_market = TestDexMarket::setup(&mut test, TestDexMarketPair::SOL_USDC);
@@ -176,7 +176,7 @@ async fn test_borrow_base_currency() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(186_000);
+    test.set_bpf_compute_max_units(188_000);
 
     let user_accounts_owner = Keypair::new();
     let sol_usdc_dex_market = TestDexMarket::setup(&mut test, TestDexMarketPair::SOL_USDC);

--- a/token-lending/program/tests/borrow.rs
+++ b/token-lending/program/tests/borrow.rs
@@ -35,7 +35,7 @@ async fn test_borrow_quote_currency() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(190_000);
+    test.set_bpf_compute_max_units(186_000);
 
     let user_accounts_owner = Keypair::new();
     let sol_usdc_dex_market = TestDexMarket::setup(&mut test, TestDexMarketPair::SOL_USDC);
@@ -176,7 +176,7 @@ async fn test_borrow_base_currency() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(190_000);
+    test.set_bpf_compute_max_units(186_000);
 
     let user_accounts_owner = Keypair::new();
     let sol_usdc_dex_market = TestDexMarket::setup(&mut test, TestDexMarketPair::SOL_USDC);

--- a/token-lending/program/tests/deposit.rs
+++ b/token-lending/program/tests/deposit.rs
@@ -18,7 +18,7 @@ async fn test_success() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(62_000);
+    test.set_bpf_compute_max_units(58_000);
 
     let user_accounts_owner = Keypair::new();
     let usdc_mint = add_usdc_mint(&mut test);

--- a/token-lending/program/tests/deposit.rs
+++ b/token-lending/program/tests/deposit.rs
@@ -18,7 +18,7 @@ async fn test_success() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(58_000);
+    test.set_bpf_compute_max_units(60_000);
 
     let user_accounts_owner = Keypair::new();
     let usdc_mint = add_usdc_mint(&mut test);

--- a/token-lending/program/tests/helpers/mod.rs
+++ b/token-lending/program/tests/helpers/mod.rs
@@ -117,19 +117,19 @@ impl AddPacked for ProgramTest {
 
 pub fn add_lending_market(test: &mut ProgramTest, quote_token_mint: Pubkey) -> TestLendingMarket {
     let keypair = Keypair::new();
+    let pubkey = keypair.pubkey();
+    let (authority, bump_seed) =
+        Pubkey::find_program_address(&[pubkey.as_ref()], &spl_token_lending::id());
+
     test.add_packable_account(
-        keypair.pubkey(),
+        pubkey,
         u32::MAX as u64,
         &LendingMarket {
             version: PROGRAM_VERSION,
+            bump_seed,
             quote_token_mint,
             token_program_id: spl_token::id(),
         },
-        &spl_token_lending::id(),
-    );
-
-    let (authority, _bump_seed) = Pubkey::find_program_address(
-        &[&keypair.pubkey().to_bytes()[..32]],
         &spl_token_lending::id(),
     );
 

--- a/token-lending/program/tests/liquidate.rs
+++ b/token-lending/program/tests/liquidate.rs
@@ -26,7 +26,7 @@ async fn test_success() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(160_000);
+    test.set_bpf_compute_max_units(152_000);
 
     // set loan values to about 90% of collateral value so that it gets liquidated
     const USDC_LOAN: u64 = 2 * FRACTIONAL_TO_USDC;

--- a/token-lending/program/tests/liquidate.rs
+++ b/token-lending/program/tests/liquidate.rs
@@ -26,7 +26,7 @@ async fn test_success() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(152_000);
+    test.set_bpf_compute_max_units(154_000);
 
     // set loan values to about 90% of collateral value so that it gets liquidated
     const USDC_LOAN: u64 = 2 * FRACTIONAL_TO_USDC;

--- a/token-lending/program/tests/repay.rs
+++ b/token-lending/program/tests/repay.rs
@@ -37,7 +37,7 @@ async fn test_success() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(77_000);
+    test.set_bpf_compute_max_units(79_000);
 
     const OBLIGATION_LOAN: u64 = 1;
     const OBLIGATION_COLLATERAL: u64 = 500;

--- a/token-lending/program/tests/repay.rs
+++ b/token-lending/program/tests/repay.rs
@@ -37,7 +37,7 @@ async fn test_success() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(80_000);
+    test.set_bpf_compute_max_units(77_000);
 
     const OBLIGATION_LOAN: u64 = 1;
     const OBLIGATION_COLLATERAL: u64 = 500;

--- a/token-lending/program/tests/withdraw.rs
+++ b/token-lending/program/tests/withdraw.rs
@@ -28,7 +28,7 @@ async fn test_success() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(60_000);
+    test.set_bpf_compute_max_units(62_000);
 
     let user_accounts_owner = Keypair::new();
     let usdc_mint = add_usdc_mint(&mut test);

--- a/token-lending/program/tests/withdraw.rs
+++ b/token-lending/program/tests/withdraw.rs
@@ -28,7 +28,7 @@ async fn test_success() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(62_000);
+    test.set_bpf_compute_max_units(60_000);
 
     let user_accounts_owner = Keypair::new();
     let usdc_mint = add_usdc_mint(&mut test);


### PR DESCRIPTION
#### Problem
Finding the bump seed for a derived address can take a variable number of iterations which each cost 1500 compute units leading to varied compute costs for lending instructions.

#### Changes
- Store bump seed in lending market state to avoid having to recompute it
- Lower compute unit clamps in tests