### PR TITLE
lending: Split interest accrual into new instruction

### DIFF
--- a/token-lending/program/src/error.rs
+++ b/token-lending/program/src/error.rs
@@ -86,6 +86,9 @@ pub enum LendingError {
     /// Borrow amount too small
     #[error("Borrow amount too small")]
     BorrowTooSmall,
+    /// Reserve state stale
+    #[error("Reserve state needs to be updated for the current slot")]
+    ReserveStale,
 
     /// Trade simulation error
     #[error("Trade simulation error")]

--- a/token-lending/program/tests/accrue_interest.rs
+++ b/token-lending/program/tests/accrue_interest.rs
@@ -1,0 +1,108 @@
+#![cfg(feature = "test-bpf")]
+
+mod helpers;
+
+use helpers::*;
+use solana_program_test::*;
+use solana_sdk::{
+    pubkey::Pubkey,
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
+use spl_token_lending::{
+    instruction::accrue_reserve_interest,
+    math::{Decimal, Rate, TryMul},
+    processor::process_instruction,
+    state::SLOTS_PER_YEAR,
+};
+
+const LAMPORTS_TO_SOL: u64 = 1_000_000_000;
+const FRACTIONAL_TO_USDC: u64 = 1_000_000;
+
+const INITIAL_SOL_RESERVE_SUPPLY_LAMPORTS: u64 = 100 * LAMPORTS_TO_SOL;
+const INITIAL_USDC_RESERVE_SUPPLY_FRACTIONAL: u64 = 100 * FRACTIONAL_TO_USDC;
+
+#[tokio::test]
+async fn test_success() {
+    let mut test = ProgramTest::new(
+        "spl_token_lending",
+        spl_token_lending::id(),
+        processor!(process_instruction),
+    );
+
+    // limit to track compute unit increase
+    test.set_bpf_compute_max_units(80_000);
+
+    let user_accounts_owner = Keypair::new();
+    let usdc_mint = add_usdc_mint(&mut test);
+    let lending_market = add_lending_market(&mut test, usdc_mint.pubkey);
+
+    let mut reserve_config = TEST_RESERVE_CONFIG;
+    reserve_config.loan_to_value_ratio = 80;
+
+    // Configure reserve to a fixed borrow rate of 1%
+    const BORROW_RATE: u8 = 1;
+    reserve_config.min_borrow_rate = BORROW_RATE;
+    reserve_config.optimal_borrow_rate = BORROW_RATE;
+    reserve_config.optimal_utilization_rate = 100;
+
+    let usdc_reserve = add_reserve(
+        &mut test,
+        &user_accounts_owner,
+        &lending_market,
+        AddReserveArgs {
+            borrow_amount: 100,
+            liquidity_amount: INITIAL_USDC_RESERVE_SUPPLY_FRACTIONAL,
+            liquidity_mint_decimals: usdc_mint.decimals,
+            liquidity_mint_pubkey: usdc_mint.pubkey,
+            slots_elapsed: SLOTS_PER_YEAR,
+            config: reserve_config,
+            ..AddReserveArgs::default()
+        },
+    );
+
+    let sol_reserve = add_reserve(
+        &mut test,
+        &user_accounts_owner,
+        &lending_market,
+        AddReserveArgs {
+            borrow_amount: 100,
+            liquidity_amount: INITIAL_SOL_RESERVE_SUPPLY_LAMPORTS,
+            liquidity_mint_decimals: 9,
+            liquidity_mint_pubkey: spl_token::native_mint::id(),
+            slots_elapsed: SLOTS_PER_YEAR,
+            config: reserve_config,
+            ..AddReserveArgs::default()
+        },
+    );
+
+    let (mut banks_client, payer, recent_blockhash) = test.start().await;
+    let mut transaction = Transaction::new_with_payer(
+        &[accrue_reserve_interest(
+            spl_token_lending::id(),
+            vec![usdc_reserve.pubkey, sol_reserve.pubkey],
+        )],
+        Some(&payer.pubkey()),
+    );
+
+    transaction.sign(&[&payer], recent_blockhash);
+    assert!(banks_client.process_transaction(transaction).await.is_ok());
+
+    let sol_reserve = sol_reserve.get_state(&mut banks_client).await;
+    let usdc_reserve = usdc_reserve.get_state(&mut banks_client).await;
+
+    let borrow_rate = Rate::from_percent(100u8 + BORROW_RATE);
+    assert!(sol_reserve.cumulative_borrow_rate_wads > borrow_rate.into());
+    assert_eq!(
+        sol_reserve.cumulative_borrow_rate_wads,
+        usdc_reserve.cumulative_borrow_rate_wads
+    );
+    assert!(
+        sol_reserve.liquidity.borrowed_amount_wads
+            > Decimal::from(100u64).try_mul(borrow_rate).unwrap()
+    );
+    assert_eq!(
+        sol_reserve.liquidity.borrowed_amount_wads,
+        usdc_reserve.liquidity.borrowed_amount_wads
+    );
+}

--- a/token-lending/program/tests/deposit.rs
+++ b/token-lending/program/tests/deposit.rs
@@ -5,7 +5,7 @@ mod helpers;
 use helpers::*;
 use solana_program_test::*;
 use solana_sdk::{pubkey::Pubkey, signature::Keypair};
-use spl_token_lending::{processor::process_instruction, state::SLOTS_PER_YEAR};
+use spl_token_lending::processor::process_instruction;
 
 const FRACTIONAL_TO_USDC: u64 = 1_000_000;
 
@@ -18,7 +18,7 @@ async fn test_success() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(65_000);
+    test.set_bpf_compute_max_units(31_000);
 
     let user_accounts_owner = Keypair::new();
     let usdc_mint = add_usdc_mint(&mut test);
@@ -29,7 +29,6 @@ async fn test_success() {
         &user_accounts_owner,
         &lending_market,
         AddReserveArgs {
-            slots_elapsed: SLOTS_PER_YEAR,
             user_liquidity_amount: 100 * FRACTIONAL_TO_USDC,
             liquidity_amount: 10_000 * FRACTIONAL_TO_USDC,
             liquidity_mint_decimals: usdc_mint.decimals,

--- a/token-lending/program/tests/init_obligation.rs
+++ b/token-lending/program/tests/init_obligation.rs
@@ -12,7 +12,7 @@ use solana_sdk::{
 };
 use spl_token_lending::{
     error::LendingError, instruction::init_obligation, math::Decimal,
-    processor::process_instruction, state::SLOTS_PER_YEAR,
+    processor::process_instruction,
 };
 
 #[tokio::test]
@@ -24,7 +24,7 @@ async fn test_success() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(60_000);
+    test.set_bpf_compute_max_units(28_000);
 
     let user_accounts_owner = Keypair::new();
     let sol_usdc_dex_market = TestDexMarket::setup(&mut test, TestDexMarketPair::SOL_USDC);
@@ -36,7 +36,6 @@ async fn test_success() {
         &user_accounts_owner,
         &lending_market,
         AddReserveArgs {
-            slots_elapsed: SLOTS_PER_YEAR,
             liquidity_mint_pubkey: usdc_mint.pubkey,
             liquidity_mint_decimals: usdc_mint.decimals,
             config: TEST_RESERVE_CONFIG,
@@ -84,7 +83,7 @@ async fn test_already_initialized() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(14_000);
+    test.set_bpf_compute_max_units(13_000);
 
     let user_accounts_owner = Keypair::new();
     let sol_usdc_dex_market = TestDexMarket::setup(&mut test, TestDexMarketPair::SOL_USDC);
@@ -96,7 +95,6 @@ async fn test_already_initialized() {
         &user_accounts_owner,
         &lending_market,
         AddReserveArgs {
-            slots_elapsed: SLOTS_PER_YEAR,
             liquidity_mint_pubkey: usdc_mint.pubkey,
             liquidity_mint_decimals: usdc_mint.decimals,
             config: TEST_RESERVE_CONFIG,

--- a/token-lending/program/tests/liquidate.rs
+++ b/token-lending/program/tests/liquidate.rs
@@ -6,9 +6,7 @@ use helpers::*;
 use solana_program_test::*;
 use solana_sdk::{pubkey::Pubkey, signature::Keypair};
 use spl_token_lending::{
-    math::Decimal,
-    processor::process_instruction,
-    state::{INITIAL_COLLATERAL_RATIO, SLOTS_PER_YEAR},
+    math::Decimal, processor::process_instruction, state::INITIAL_COLLATERAL_RATIO,
 };
 
 const LAMPORTS_TO_SOL: u64 = 1_000_000_000;
@@ -26,7 +24,7 @@ async fn test_success() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(163_000);
+    test.set_bpf_compute_max_units(90_000);
 
     // set loan values to about 90% of collateral value so that it gets liquidated
     const USDC_LOAN: u64 = 2 * FRACTIONAL_TO_USDC;
@@ -50,11 +48,11 @@ async fn test_success() {
         &lending_market,
         AddReserveArgs {
             config: reserve_config,
-            slots_elapsed: SLOTS_PER_YEAR,
+            initial_borrow_rate: 1,
             liquidity_amount: INITIAL_USDC_RESERVE_SUPPLY_FRACTIONAL,
             liquidity_mint_pubkey: usdc_mint.pubkey,
             liquidity_mint_decimals: usdc_mint.decimals,
-            borrow_amount: USDC_LOAN,
+            borrow_amount: USDC_LOAN * 101 / 100,
             user_liquidity_amount: USDC_LOAN,
             collateral_amount: SOL_LOAN_USDC_COLLATERAL,
             ..AddReserveArgs::default()
@@ -67,13 +65,13 @@ async fn test_success() {
         &lending_market,
         AddReserveArgs {
             config: reserve_config,
-            slots_elapsed: SLOTS_PER_YEAR,
+            initial_borrow_rate: 1,
             liquidity_amount: INITIAL_SOL_RESERVE_SUPPLY_LAMPORTS,
             liquidity_mint_decimals: 9,
             liquidity_mint_pubkey: spl_token::native_mint::id(),
             dex_market_pubkey: Some(sol_usdc_dex_market.pubkey),
             collateral_amount: USDC_LOAN_SOL_COLLATERAL,
-            borrow_amount: SOL_LOAN,
+            borrow_amount: SOL_LOAN * 101 / 100,
             user_liquidity_amount: SOL_LOAN,
             ..AddReserveArgs::default()
         },

--- a/token-lending/program/tests/repay.rs
+++ b/token-lending/program/tests/repay.rs
@@ -29,7 +29,7 @@ async fn test_success() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(87_000);
+    test.set_bpf_compute_max_units(51_000);
 
     const INITIAL_SOL_RESERVE_SUPPLY_LAMPORTS: u64 = 100 * LAMPORTS_TO_SOL;
     const INITIAL_USDC_RESERVE_SUPPLY_FRACTIONAL: u64 = 100 * FRACTIONAL_TO_USDC;
@@ -49,11 +49,11 @@ async fn test_success() {
         &lending_market,
         AddReserveArgs {
             config: TEST_RESERVE_CONFIG,
-            slots_elapsed: SLOTS_PER_YEAR,
+            initial_borrow_rate: 1,
             liquidity_amount: INITIAL_USDC_RESERVE_SUPPLY_FRACTIONAL,
             liquidity_mint_pubkey: usdc_mint.pubkey,
             liquidity_mint_decimals: usdc_mint.decimals,
-            borrow_amount: OBLIGATION_LOAN,
+            borrow_amount: OBLIGATION_LOAN * 101 / 100,
             user_liquidity_amount: OBLIGATION_LOAN,
             ..AddReserveArgs::default()
         },

--- a/token-lending/program/tests/withdraw.rs
+++ b/token-lending/program/tests/withdraw.rs
@@ -11,13 +11,12 @@ use solana_sdk::{
 };
 use spl_token::instruction::approve;
 use spl_token_lending::{
-    instruction::withdraw_reserve_liquidity,
-    processor::process_instruction,
-    state::{INITIAL_COLLATERAL_RATIO, SLOTS_PER_YEAR},
+    instruction::withdraw_reserve_liquidity, processor::process_instruction,
+    state::INITIAL_COLLATERAL_RATIO,
 };
 
 const FRACTIONAL_TO_USDC: u64 = 1_000_000;
-const INITIAL_USDC_RESERVE_SUPPLY_LAMPORTS: u64 = 10 * FRACTIONAL_TO_USDC;
+const INITIAL_USDC_RESERVE_SUPPLY_FRACTIONAL: u64 = 10 * FRACTIONAL_TO_USDC;
 
 #[tokio::test]
 async fn test_success() {
@@ -28,22 +27,21 @@ async fn test_success() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(66_000);
+    test.set_bpf_compute_max_units(33_000);
 
     let user_accounts_owner = Keypair::new();
     let usdc_mint = add_usdc_mint(&mut test);
     let lending_market = add_lending_market(&mut test, usdc_mint.pubkey);
 
     const WITHDRAW_COLLATERAL_AMOUNT: u64 =
-        INITIAL_COLLATERAL_RATIO * INITIAL_USDC_RESERVE_SUPPLY_LAMPORTS;
+        INITIAL_COLLATERAL_RATIO * INITIAL_USDC_RESERVE_SUPPLY_FRACTIONAL;
 
     let usdc_reserve = add_reserve(
         &mut test,
         &user_accounts_owner,
         &lending_market,
         AddReserveArgs {
-            slots_elapsed: SLOTS_PER_YEAR,
-            liquidity_amount: INITIAL_USDC_RESERVE_SUPPLY_LAMPORTS,
+            liquidity_amount: INITIAL_USDC_RESERVE_SUPPLY_FRACTIONAL,
             liquidity_mint_decimals: usdc_mint.decimals,
             liquidity_mint_pubkey: usdc_mint.pubkey,
             collateral_amount: WITHDRAW_COLLATERAL_AMOUNT,


### PR DESCRIPTION
#### Problem
Most lending instructions require up-to-date knowledge about the current reserve borrow rate which requires compounding the interest over the elapsed slots since the last successful instruction. In the worst case (1 year of interest), this adds about 30k compute units per reserve which severely limits the lending protocol's composability

#### Changes
- Create new "Accrue Interest" instruction that can be passed a list of reserves to compound interest for
- Remove interest accrual from borrow, repay, liquidate, etc and replace with an assertion that the reserve was last updated in the current slot