### PR TITLE
token: Fully check self-transfers

### DIFF
--- a/token/program/src/processor.rs
+++ b/token/program/src/processor.rs
@@ -786,7 +786,9 @@ impl PrintProgramError for TokenError {
 mod tests {
     use super::*;
     use crate::instruction::*;
-    use solana_program::{clock::Epoch, instruction::Instruction, sysvar::rent};
+    use solana_program::{
+        account_info::IntoAccountInfo, clock::Epoch, instruction::Instruction, sysvar::rent,
+    };
     use solana_sdk::account::{
         create_account, create_is_signer_account_infos, Account as SolanaAccount,
     };
@@ -1680,41 +1682,6 @@ mod tests {
         )
         .unwrap();
 
-        // transfer to self
-        {
-            let instruction = transfer(
-                &program_id,
-                &account_key,
-                &account_key,
-                &owner_key,
-                &[],
-                500,
-            )
-            .unwrap();
-            let account_account_info = AccountInfo::from((
-                &instruction.accounts[0].pubkey,
-                instruction.accounts[0].is_signer,
-                &mut account_account,
-            ));
-            let owner_account_info = AccountInfo::from((
-                &instruction.accounts[2].pubkey,
-                instruction.accounts[2].is_signer,
-                &mut owner_account,
-            ));
-            Processor::process(
-                &instruction.program_id,
-                &[
-                    account_account_info.clone(),
-                    account_account_info,
-                    owner_account_info,
-                ],
-                &instruction.data,
-            )
-            .unwrap()
-        }
-        let account = Account::unpack_unchecked(&account_account.data).unwrap();
-        assert_eq!(account.amount, 1000);
-
         // insufficient funds
         assert_eq!(
             Err(TokenError::InsufficientFunds.into()),
@@ -1845,6 +1812,536 @@ mod tests {
                 ],
             )
         );
+    }
+
+    #[test]
+    fn test_self_transfer() {
+        let program_id = Pubkey::new_unique();
+        let account_key = Pubkey::new_unique();
+        let mut account_account = SolanaAccount::new(
+            account_minimum_balance(),
+            Account::get_packed_len(),
+            &program_id,
+        );
+        let account2_key = Pubkey::new_unique();
+        let mut account2_account = SolanaAccount::new(
+            account_minimum_balance(),
+            Account::get_packed_len(),
+            &program_id,
+        );
+        let account3_key = Pubkey::new_unique();
+        let mut account3_account = SolanaAccount::new(
+            account_minimum_balance(),
+            Account::get_packed_len(),
+            &program_id,
+        );
+        let delegate_key = Pubkey::new_unique();
+        let mut delegate_account = SolanaAccount::default();
+        let owner_key = Pubkey::new_unique();
+        let mut owner_account = SolanaAccount::default();
+        let owner2_key = Pubkey::new_unique();
+        let mut owner2_account = SolanaAccount::default();
+        let mint_key = Pubkey::new_unique();
+        let mut mint_account =
+            SolanaAccount::new(mint_minimum_balance(), Mint::get_packed_len(), &program_id);
+        let mut rent_sysvar = rent_sysvar();
+
+        // create mint
+        do_process_instruction(
+            initialize_mint(&program_id, &mint_key, &owner_key, None, 2).unwrap(),
+            vec![&mut mint_account, &mut rent_sysvar],
+        )
+        .unwrap();
+
+        // create account
+        do_process_instruction(
+            initialize_account(&program_id, &account_key, &mint_key, &owner_key).unwrap(),
+            vec![
+                &mut account_account,
+                &mut mint_account,
+                &mut owner_account,
+                &mut rent_sysvar,
+            ],
+        )
+        .unwrap();
+
+        // create another account
+        do_process_instruction(
+            initialize_account(&program_id, &account2_key, &mint_key, &owner_key).unwrap(),
+            vec![
+                &mut account2_account,
+                &mut mint_account,
+                &mut owner_account,
+                &mut rent_sysvar,
+            ],
+        )
+        .unwrap();
+
+        // create another account
+        do_process_instruction(
+            initialize_account(&program_id, &account3_key, &mint_key, &owner_key).unwrap(),
+            vec![
+                &mut account3_account,
+                &mut mint_account,
+                &mut owner_account,
+                &mut rent_sysvar,
+            ],
+        )
+        .unwrap();
+
+        // mint to account
+        do_process_instruction(
+            mint_to(&program_id, &mint_key, &account_key, &owner_key, &[], 1000).unwrap(),
+            vec![&mut mint_account, &mut account_account, &mut owner_account],
+        )
+        .unwrap();
+
+        let account_info = (&account_key, false, &mut account_account).into_account_info();
+        let account3_info = (&account3_key, false, &mut account3_account).into_account_info();
+        let delegate_info = (&delegate_key, true, &mut delegate_account).into_account_info();
+        let owner_info = (&owner_key, true, &mut owner_account).into_account_info();
+        let owner2_info = (&owner2_key, true, &mut owner2_account).into_account_info();
+        let mint_info = (&mint_key, false, &mut mint_account).into_account_info();
+
+        // transfer
+        let instruction = transfer(
+            &program_id,
+            &account_info.key,
+            &account_info.key,
+            &owner_info.key,
+            &[],
+            1000,
+        )
+        .unwrap();
+        assert_eq!(
+            Ok(()),
+            Processor::process(
+                &instruction.program_id,
+                &[
+                    account_info.clone(),
+                    account_info.clone(),
+                    owner_info.clone(),
+                ],
+                &instruction.data,
+            )
+        );
+        // no balance change...
+        let account = Account::unpack_unchecked(&account_info.try_borrow_data().unwrap()).unwrap();
+        assert_eq!(account.amount, 1000);
+
+        // transfer checked
+        let instruction = transfer_checked(
+            &program_id,
+            &account_info.key,
+            &mint_info.key,
+            &account_info.key,
+            &owner_info.key,
+            &[],
+            1000,
+            2,
+        )
+        .unwrap();
+        assert_eq!(
+            Ok(()),
+            Processor::process(
+                &instruction.program_id,
+                &[
+                    account_info.clone(),
+                    mint_info.clone(),
+                    account_info.clone(),
+                    owner_info.clone(),
+                ],
+                &instruction.data,
+            )
+        );
+        // no balance change...
+        let account = Account::unpack_unchecked(&account_info.try_borrow_data().unwrap()).unwrap();
+        assert_eq!(account.amount, 1000);
+
+        // missing signer
+        let mut owner_no_sign_info = owner_info.clone();
+        let mut instruction = transfer(
+            &program_id,
+            &account_info.key,
+            &account_info.key,
+            &owner_no_sign_info.key,
+            &[],
+            1000,
+        )
+        .unwrap();
+        instruction.accounts[2].is_signer = false;
+        owner_no_sign_info.is_signer = false;
+        assert_eq!(
+            Err(ProgramError::MissingRequiredSignature),
+            Processor::process(
+                &instruction.program_id,
+                &[
+                    account_info.clone(),
+                    account_info.clone(),
+                    owner_no_sign_info.clone(),
+                ],
+                &instruction.data,
+            )
+        );
+
+        // missing signer checked
+        let mut instruction = transfer_checked(
+            &program_id,
+            &account_info.key,
+            &mint_info.key,
+            &account_info.key,
+            &owner_no_sign_info.key,
+            &[],
+            1000,
+            2,
+        )
+        .unwrap();
+        instruction.accounts[3].is_signer = false;
+        assert_eq!(
+            Err(ProgramError::MissingRequiredSignature),
+            Processor::process(
+                &instruction.program_id,
+                &[
+                    account_info.clone(),
+                    mint_info.clone(),
+                    account_info.clone(),
+                    owner_no_sign_info,
+                ],
+                &instruction.data,
+            )
+        );
+
+        // missing owner
+        let instruction = transfer(
+            &program_id,
+            &account_info.key,
+            &account_info.key,
+            &owner2_info.key,
+            &[],
+            1000,
+        )
+        .unwrap();
+        assert_eq!(
+            Err(TokenError::OwnerMismatch.into()),
+            Processor::process(
+                &instruction.program_id,
+                &[
+                    account_info.clone(),
+                    account_info.clone(),
+                    owner2_info.clone(),
+                ],
+                &instruction.data,
+            )
+        );
+
+        // missing owner checked
+        let instruction = transfer_checked(
+            &program_id,
+            &account_info.key,
+            &mint_info.key,
+            &account_info.key,
+            &owner2_info.key,
+            &[],
+            1000,
+            2,
+        )
+        .unwrap();
+        assert_eq!(
+            Err(TokenError::OwnerMismatch.into()),
+            Processor::process(
+                &instruction.program_id,
+                &[
+                    account_info.clone(),
+                    mint_info.clone(),
+                    account_info.clone(),
+                    owner2_info.clone(),
+                ],
+                &instruction.data,
+            )
+        );
+
+        // insufficient funds
+        let instruction = transfer(
+            &program_id,
+            &account_info.key,
+            &account_info.key,
+            &owner_info.key,
+            &[],
+            1001,
+        )
+        .unwrap();
+        assert_eq!(
+            Err(TokenError::InsufficientFunds.into()),
+            Processor::process(
+                &instruction.program_id,
+                &[
+                    account_info.clone(),
+                    account_info.clone(),
+                    owner_info.clone(),
+                ],
+                &instruction.data,
+            )
+        );
+
+        // insufficient funds checked
+        let instruction = transfer_checked(
+            &program_id,
+            &account_info.key,
+            &mint_info.key,
+            &account_info.key,
+            &owner_info.key,
+            &[],
+            1001,
+            2,
+        )
+        .unwrap();
+        assert_eq!(
+            Err(TokenError::InsufficientFunds.into()),
+            Processor::process(
+                &instruction.program_id,
+                &[
+                    account_info.clone(),
+                    mint_info.clone(),
+                    account_info.clone(),
+                    owner_info.clone(),
+                ],
+                &instruction.data,
+            )
+        );
+
+        // incorrect decimals
+        let instruction = transfer_checked(
+            &program_id,
+            &account_info.key,
+            &mint_info.key,
+            &account_info.key,
+            &owner_info.key,
+            &[],
+            1,
+            10, // <-- incorrect decimals
+        )
+        .unwrap();
+        assert_eq!(
+            Err(TokenError::MintDecimalsMismatch.into()),
+            Processor::process(
+                &instruction.program_id,
+                &[
+                    account_info.clone(),
+                    mint_info.clone(),
+                    account_info.clone(),
+                    owner_info.clone(),
+                ],
+                &instruction.data,
+            )
+        );
+
+        // incorrect mint
+        let instruction = transfer_checked(
+            &program_id,
+            &account_info.key,
+            &account3_info.key, // <-- incorrect mint
+            &account_info.key,
+            &owner_info.key,
+            &[],
+            1,
+            2,
+        )
+        .unwrap();
+        assert_eq!(
+            Err(TokenError::MintMismatch.into()),
+            Processor::process(
+                &instruction.program_id,
+                &[
+                    account_info.clone(),
+                    account3_info.clone(), // <-- incorrect mint
+                    account_info.clone(),
+                    owner_info.clone(),
+                ],
+                &instruction.data,
+            )
+        );
+
+        // approve delegate
+        let instruction = approve(
+            &program_id,
+            &account_info.key,
+            &delegate_info.key,
+            &owner_info.key,
+            &[],
+            100,
+        )
+        .unwrap();
+        Processor::process(
+            &instruction.program_id,
+            &[
+                account_info.clone(),
+                delegate_info.clone(),
+                owner_info.clone(),
+            ],
+            &instruction.data,
+        )
+        .unwrap();
+
+        // delegate transfer
+        let instruction = transfer(
+            &program_id,
+            &account_info.key,
+            &account_info.key,
+            &delegate_info.key,
+            &[],
+            100,
+        )
+        .unwrap();
+        assert_eq!(
+            Ok(()),
+            Processor::process(
+                &instruction.program_id,
+                &[
+                    account_info.clone(),
+                    account_info.clone(),
+                    delegate_info.clone(),
+                ],
+                &instruction.data,
+            )
+        );
+        // no balance change...
+        let account = Account::unpack_unchecked(&account_info.try_borrow_data().unwrap()).unwrap();
+        assert_eq!(account.amount, 1000);
+        assert_eq!(account.delegated_amount, 100);
+
+        // delegate transfer checked
+        let instruction = transfer_checked(
+            &program_id,
+            &account_info.key,
+            &mint_info.key,
+            &account_info.key,
+            &delegate_info.key,
+            &[],
+            100,
+            2,
+        )
+        .unwrap();
+        assert_eq!(
+            Ok(()),
+            Processor::process(
+                &instruction.program_id,
+                &[
+                    account_info.clone(),
+                    mint_info.clone(),
+                    account_info.clone(),
+                    delegate_info.clone(),
+                ],
+                &instruction.data,
+            )
+        );
+        // no balance change...
+        let account = Account::unpack_unchecked(&account_info.try_borrow_data().unwrap()).unwrap();
+        assert_eq!(account.amount, 1000);
+        assert_eq!(account.delegated_amount, 100);
+
+        // delegate insufficient funds
+        let instruction = transfer(
+            &program_id,
+            &account_info.key,
+            &account_info.key,
+            &delegate_info.key,
+            &[],
+            101,
+        )
+        .unwrap();
+        assert_eq!(
+            Err(TokenError::InsufficientFunds.into()),
+            Processor::process(
+                &instruction.program_id,
+                &[
+                    account_info.clone(),
+                    account_info.clone(),
+                    delegate_info.clone(),
+                ],
+                &instruction.data,
+            )
+        );
+
+        // delegate insufficient funds checked
+        let instruction = transfer_checked(
+            &program_id,
+            &account_info.key,
+            &mint_info.key,
+            &account_info.key,
+            &delegate_info.key,
+            &[],
+            101,
+            2,
+        )
+        .unwrap();
+        assert_eq!(
+            Err(TokenError::InsufficientFunds.into()),
+            Processor::process(
+                &instruction.program_id,
+                &[
+                    account_info.clone(),
+                    mint_info.clone(),
+                    account_info.clone(),
+                    delegate_info.clone(),
+                ],
+                &instruction.data,
+            )
+        );
+
+        // owner transfer with delegate assigned
+        let instruction = transfer(
+            &program_id,
+            &account_info.key,
+            &account_info.key,
+            &owner_info.key,
+            &[],
+            1000,
+        )
+        .unwrap();
+        assert_eq!(
+            Ok(()),
+            Processor::process(
+                &instruction.program_id,
+                &[
+                    account_info.clone(),
+                    account_info.clone(),
+                    owner_info.clone(),
+                ],
+                &instruction.data,
+            )
+        );
+        // no balance change...
+        let account = Account::unpack_unchecked(&account_info.try_borrow_data().unwrap()).unwrap();
+        assert_eq!(account.amount, 1000);
+
+        // owner transfer with delegate assigned checked
+        let instruction = transfer_checked(
+            &program_id,
+            &account_info.key,
+            &mint_info.key,
+            &account_info.key,
+            &owner_info.key,
+            &[],
+            1000,
+            2,
+        )
+        .unwrap();
+        assert_eq!(
+            Ok(()),
+            Processor::process(
+                &instruction.program_id,
+                &[
+                    account_info.clone(),
+                    mint_info.clone(),
+                    account_info.clone(),
+                    owner_info.clone(),
+                ],
+                &instruction.data,
+            )
+        );
+        // no balance change...
+        let account = Account::unpack_unchecked(&account_info.try_borrow_data().unwrap()).unwrap();
+        assert_eq!(account.amount, 1000);
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

SPL Token self-transfers are special-cased such that they always succeed despite bypassing many checks.  This could mislead other programs or apps which make assumptions based on the success of a transfer.

#### Changes

~Since most of the benefits of the special-case were to avoid deserializing accounts and those deserializations are necessary to perform the checks we'd like to reinstate, simply remove the special-case and treat self-transfers as normal transfers~

So that only works if you delete too many tests :sweat_smile: 

Problem being that even though the account refs are the same, we deser into separate buffers, so the token `amount` manipulations don't cancel each other out and the add-store overwrites the subtract-store.  Instead, move the self-transfer special case to just before the `amount` manipulations occur and add a comment.

fixes: #722