### PR TITLE
ci: Base `target` cache key on env.RUST_STABLE (version)

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -102,7 +102,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: cargo-build-${{ hashFiles('**/Cargo.lock') }}
+          key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE}}
 
       - uses: actions/cache@v2
         with:


### PR DESCRIPTION
Base CI target cache key on Rust version