### PR TITLE
Keep tokio consistent with solana-program-test

### DIFF
--- a/patch.crates-io.sh
+++ b/patch.crates-io.sh
@@ -26,6 +26,7 @@ cd "$(dirname "$0")"
 
 source "$solana_dir"/scripts/read-cargo-variable.sh
 solana_ver=$(readCargoVariable version "$solana_dir"/sdk/Cargo.toml)
+tokio_ver=$(sed -n "s#^tokio.*version *= *\"\([^\"]*\).*#\1#p" "$solana_dir"/program-test/Cargo.toml)
 
 echo "Patching in $solana_ver from $solana_dir"
 echo
@@ -56,5 +57,4 @@ PATCH
   fi
 done
 
-./update-solana-dependencies.sh "$solana_ver"
-
+./update-solana-dependencies.sh "$solana_ver" "$tokio_ver"

--- a/update-solana-dependencies.sh
+++ b/update-solana-dependencies.sh
@@ -37,6 +37,6 @@ set -x
 for crate in "${crates[@]}"; do
   sed -i -e "s#\(${crate} = \"\).*\(\"\)#\1$solana_ver\2#g" "${tomls[@]}"
 done
-if [[ -z $tokio_ver ]]; then
+if [[ -n $tokio_ver ]]; then
   sed -i -e "s#\(tokio.*version *= *\"\)[^\"]*\(\".*$\)#\1$tokio_ver\2#g" "${tomls[@]}"
 fi

--- a/update-solana-dependencies.sh
+++ b/update-solana-dependencies.sh
@@ -4,6 +4,7 @@
 #
 
 solana_ver=$1
+tokio_ver=$2
 if [[ -z $solana_ver ]]; then
   echo "Usage: $0 <new-solana-version>"
   exit 1
@@ -36,4 +37,6 @@ set -x
 for crate in "${crates[@]}"; do
   sed -i -e "s#\(${crate} = \"\).*\(\"\)#\1$solana_ver\2#g" "${tomls[@]}"
 done
-
+if [[ -z $tokio_ver ]]; then
+  sed -i -e "s#\(tokio.*version *= *\"\)[^\"]*\(\".*$\)#\1$tokio_ver\2#g" "${tomls[@]}"
+fi


### PR DESCRIPTION
We are working on upgrading tokio upstream at solana: https://github.com/solana-labs/solana/pull/15013
Currently, this breaks the downstream-projects CI build, because of conflicts between the solana and SPL tokio versions.
This PR updates the SPL patching script to keep tokio in sync with `solana-program-test`. This will fix solana CI, but also make developing SPL against a local solana monorepo easier.