### PR TITLE
Update rust stable to 1.49 (and add token swap program id)

### DIFF
--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -18,7 +18,7 @@
 if [[ -n $RUST_STABLE_VERSION ]]; then
   stable_version="$RUST_STABLE_VERSION"
 else
-  stable_version=1.48.0
+  stable_version=1.49.0
 fi
 
 if [[ -n $RUST_NIGHTLY_VERSION ]]; then

--- a/token-swap/program/program-id.md
+++ b/token-swap/program/program-id.md
@@ -1,0 +1,1 @@
+SwaPpA9LAaLfeLi3a68M4DjnLqgtticKg6CnyNwgAC8

--- a/token-swap/program/src/lib.rs
+++ b/token-swap/program/src/lib.rs
@@ -15,4 +15,4 @@ mod entrypoint;
 // Export current sdk types for downstream users building with a different sdk version
 pub use solana_program;
 
-solana_program::declare_id!("TokenSwap1111111111111111111111111111111111");
+solana_program::declare_id!("SwaPpA9LAaLfeLi3a68M4DjnLqgtticKg6CnyNwgAC8");


### PR DESCRIPTION
Since token swap has finally been released to a stable address, it's time to add it to the repo for other people to build against.