### PR TITLE
Remove target from cache

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -101,7 +101,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
+            # target # Removed due to build dependency caching conflicts
           key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE}}
 
       - uses: actions/cache@v2


### PR DESCRIPTION
PRs that do not change the dependency hash run into this error on CI build:
`error[E0460]: found possibly newer version of crate `std` which `solana_program` depends on`
https://github.com/solana-labs/solana-program-library/pull/1157/checks?check_run_id=1829061379

Use a big hammer for now, and remove `target` from the cache