### PR TITLE
Pin cbindgen harder

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,3 +36,5 @@ updates:
   labels:
     - "automerge"
   open-pull-requests-limit: 3
+  ignore:
+    - dependency-name: "cbindgen"


### PR DESCRIPTION
#### Problem

While the `cbindgen` crate version is pinned in `Cargo.toml`, dependabot happily bumps it as new releases come out.  Since these updates don't regenerate the C bindings, cosmetic changes silently creep in.

#### Solution

Add `cbindgen` to dependabot ignore