### PR TITLE
stake-pool: Validator stake account initialized with 1 SOL

### DIFF
--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -443,8 +443,9 @@ impl Processor {
             &[bump_seed],
         ];
 
-        // Fund the associated token account with the minimum balance to be rent exempt
-        let required_lamports = sol_to_lamports(1.0) + rent.minimum_balance(std::mem::size_of::<stake::StakeState>());
+        // Fund the stake account with 1 SOL + rent-exempt balance
+        let required_lamports =
+            sol_to_lamports(1.0) + rent.minimum_balance(std::mem::size_of::<stake::StakeState>());
 
         // Create new stake account
         invoke_signed(

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -16,6 +16,7 @@ use solana_program::{
     decode_error::DecodeError,
     entrypoint::ProgramResult,
     msg,
+    native_token::sol_to_lamports,
     program::{invoke, invoke_signed},
     program_error::PrintProgramError,
     program_error::ProgramError,
@@ -443,7 +444,7 @@ impl Processor {
         ];
 
         // Fund the associated token account with the minimum balance to be rent exempt
-        let required_lamports = 1 + rent.minimum_balance(std::mem::size_of::<stake::StakeState>());
+        let required_lamports = sol_to_lamports(1.0) + rent.minimum_balance(std::mem::size_of::<stake::StakeState>());
 
         // Create new stake account
         invoke_signed(

--- a/stake-pool/program/tests/update_list_balance.rs
+++ b/stake-pool/program/tests/update_list_balance.rs
@@ -2,12 +2,14 @@
 
 mod helpers;
 
-use crate::helpers::TEST_STAKE_AMOUNT;
-use helpers::*;
-use solana_program::pubkey::Pubkey;
-use solana_program_test::BanksClient;
-use solana_sdk::signature::Signer;
-use spl_stake_pool::*;
+use {
+    crate::helpers::TEST_STAKE_AMOUNT,
+    helpers::*,
+    solana_program::{native_token, pubkey::Pubkey},
+    solana_program_test::BanksClient,
+    solana_sdk::signature::Signer,
+    spl_stake_pool::*,
+};
 
 async fn get_list_sum(banks_client: &mut BanksClient, validator_stake_list_key: &Pubkey) -> u64 {
     let validator_stake_list = banks_client
@@ -64,7 +66,8 @@ async fn test_update_list_balance() {
     }
 
     let rent = banks_client.get_rent().await.unwrap();
-    let stake_rent = rent.minimum_balance(std::mem::size_of::<stake::StakeState>()) + 1;
+    let stake_rent = rent.minimum_balance(std::mem::size_of::<stake::StakeState>())
+        + native_token::sol_to_lamports(1.0);
 
     // Check current balance in the list
     assert_eq!(


### PR DESCRIPTION
A validator stake account only has 1 lamport, which means that it will
gain very few rewards per epoch.  Its credits_observed is not
be reset each epoch, which makes it practically impossible to merge
into.  Get around this by instantiating them with more stake.