### PR TITLE
stake-pool-cli: Fix update command for empty stake pool list

### DIFF
--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -676,7 +676,7 @@ fn command_update(config: &Config, pool: &Pubkey) -> CommandResult {
         )?);
     }
 
-    if instructions.is_empty() {
+    if instructions.is_empty() && pool_data.last_update_epoch == epoch_info.epoch {
         println!("Stake pool balances are up to date, no update required.");
         Ok(None)
     } else {


### PR DESCRIPTION
When running `spl-stake-pool update` on an empty stake pool with no validator accounts, the command does no work, when it actually needs to update the last epoch on the stake pool.  This adds an additional check for when to do no work.