### PR TITLE
Support associated token for JS (Also, make the program testable)

### DIFF
--- a/associated-token-account/program/src/lib.rs
+++ b/associated-token-account/program/src/lib.rs
@@ -21,13 +21,11 @@ pub(crate) fn get_associated_token_address_and_bump_seed(
     spl_token_mint_address: &Pubkey,
     program_id: &Pubkey,
 ) -> (Pubkey, u8) {
-    Pubkey::find_program_address(
-        &[
-            &wallet_address.to_bytes(),
-            &spl_token::id().to_bytes(),
-            &spl_token_mint_address.to_bytes(),
-        ],
+    get_associated_token_address_and_bump_seed_internal(
+        wallet_address,
+        spl_token_mint_address,
         program_id,
+        &spl_token::id(),
     )
 }
 
@@ -37,6 +35,22 @@ pub fn get_associated_token_address(
     spl_token_mint_address: &Pubkey,
 ) -> Pubkey {
     get_associated_token_address_and_bump_seed(&wallet_address, &spl_token_mint_address, &id()).0
+}
+
+fn get_associated_token_address_and_bump_seed_internal(
+    wallet_address: &Pubkey,
+    spl_token_mint_address: &Pubkey,
+    program_id: &Pubkey,
+    token_program_id: &Pubkey,
+) -> (Pubkey, u8) {
+    Pubkey::find_program_address(
+        &[
+            &wallet_address.to_bytes(),
+            &token_program_id.to_bytes(),
+            &spl_token_mint_address.to_bytes(),
+        ],
+        program_id,
+    )
 }
 
 /// Create an associated token account for the given wallet address and token mint

--- a/associated-token-account/program/src/processor.rs
+++ b/associated-token-account/program/src/processor.rs
@@ -27,12 +27,14 @@ pub fn process_instruction(
     let spl_token_mint_info = next_account_info(account_info_iter)?;
     let system_program_info = next_account_info(account_info_iter)?;
     let spl_token_program_info = next_account_info(account_info_iter)?;
+    let spl_token_program_id = spl_token_program_info.key;
     let rent_sysvar_info = next_account_info(account_info_iter)?;
 
-    let (associated_token_address, bump_seed) = get_associated_token_address_and_bump_seed(
+    let (associated_token_address, bump_seed) = get_associated_token_address_and_bump_seed_internal(
         &wallet_account_info.key,
         &spl_token_mint_info.key,
         program_id,
+        &spl_token_program_id,
     );
     if associated_token_address != *associated_token_account_info.key {
         msg!("Error: Associated address does not match seed derivation");
@@ -41,7 +43,7 @@ pub fn process_instruction(
 
     let associated_token_account_signer_seeds: &[&[_]] = &[
         &wallet_account_info.key.to_bytes(),
-        &spl_token::id().to_bytes(),
+        &spl_token_program_id.to_bytes(),
         &spl_token_mint_info.key.to_bytes(),
         &[bump_seed],
     ];
@@ -87,7 +89,7 @@ pub fn process_instruction(
 
     msg!("Assign the associated token account to the SPL Token program");
     invoke_signed(
-        &system_instruction::assign(associated_token_account_info.key, &spl_token::id()),
+        &system_instruction::assign(associated_token_account_info.key, &spl_token_program_id),
         &[
             associated_token_account_info.clone(),
             system_program_info.clone(),
@@ -98,7 +100,7 @@ pub fn process_instruction(
     msg!("Initialize the associated token account");
     invoke(
         &spl_token::instruction::initialize_account(
-            &spl_token::id(),
+            &spl_token_program_id,
             associated_token_account_info.key,
             spl_token_mint_info.key,
             wallet_account_info.key,

--- a/ci/js-test-token.sh
+++ b/ci/js-test-token.sh
@@ -10,5 +10,6 @@ npm install
 npm run lint
 npm run flow
 npm run defs
+npm run test
 npm run start-with-test-validator
 PROGRAM_VERSION=2.0.4 npm run start-with-test-validator

--- a/token/js/cli/main.js
+++ b/token/js/cli/main.js
@@ -8,7 +8,7 @@ import {
   loadTokenProgram,
   createMint,
   createAccount,
-  createAssociatedToken,
+  createAssociatedAccount,
   transfer,
   transferChecked,
   transferCheckedAssociated,
@@ -32,8 +32,8 @@ async function main() {
   await createMint();
   console.log('Run test: createAccount');
   await createAccount();
-  console.log('Run test: createAssociatedToken');
-  await createAssociatedToken();
+  console.log('Run test: createAssociatedAccount');
+  await createAssociatedAccount();
   console.log('Run test: mintTo');
   await mintTo();
   console.log('Run test: mintToChecked');

--- a/token/js/cli/main.js
+++ b/token/js/cli/main.js
@@ -8,6 +8,7 @@ import {
   loadTokenProgram,
   createMint,
   createAccount,
+  createAssociatedToken,
   transfer,
   transferChecked,
   approveRevoke,
@@ -21,7 +22,6 @@ import {
   freezeThawAccount,
   closeAccount,
   nativeToken,
-  associatedToken,
 } from './token-test';
 
 async function main() {
@@ -31,6 +31,8 @@ async function main() {
   await createMint();
   console.log('Run test: createAccount');
   await createAccount();
+  console.log('Run test: createAssociatedToken');
+  await createAssociatedToken();
   console.log('Run test: mintTo');
   await mintTo();
   console.log('Run test: mintToChecked');
@@ -57,8 +59,6 @@ async function main() {
   await multisig();
   console.log('Run test: nativeToken');
   await nativeToken();
-  console.log('Run test: associatedToken');
-  await associatedToken();
   console.log('Success\n');
 }
 

--- a/token/js/cli/main.js
+++ b/token/js/cli/main.js
@@ -21,6 +21,7 @@ import {
   freezeThawAccount,
   closeAccount,
   nativeToken,
+  associatedToken,
 } from './token-test';
 
 async function main() {
@@ -56,6 +57,8 @@ async function main() {
   await multisig();
   console.log('Run test: nativeToken');
   await nativeToken();
+  console.log('Run test: associatedToken');
+  await associatedToken();
   console.log('Success\n');
 }
 

--- a/token/js/cli/main.js
+++ b/token/js/cli/main.js
@@ -11,6 +11,7 @@ import {
   createAssociatedToken,
   transfer,
   transferChecked,
+  transferCheckedAssociated,
   approveRevoke,
   failOnApproveOverspend,
   setAuthority,
@@ -41,6 +42,8 @@ async function main() {
   await transfer();
   console.log('Run test: transferChecked');
   await transferChecked();
+  console.log('Run test: transferCheckedAssociated');
+  await transferCheckedAssociated();
   console.log('Run test: approveRevoke');
   await approveRevoke();
   console.log('Run test: failOnApproveOverspend');

--- a/token/js/cli/store/index.js
+++ b/token/js/cli/store/index.js
@@ -13,8 +13,12 @@ export class Store {
     return path.join(__dirname, 'store');
   }
 
+  static getFilename(uri: string): string {
+    return path.join(Store.getDir(), uri);
+  }
+
   async load(uri: string): Promise<Object> {
-    const filename = path.join(Store.getDir(), uri);
+    const filename = Store.getFilename(uri);
     const data = await fs.readFile(filename, 'utf8');
     const config = JSON.parse(data);
     return config;
@@ -22,7 +26,7 @@ export class Store {
 
   async save(uri: string, config: Object): Promise<void> {
     await mkdirp(Store.getDir());
-    const filename = path.join(Store.getDir(), uri);
+    const filename = Store.getFilename(uri);
     await fs.writeFile(filename, JSON.stringify(config), 'utf8');
   }
 }

--- a/token/js/cli/token-test.js
+++ b/token/js/cli/token-test.js
@@ -100,13 +100,23 @@ async function GetPrograms(connection: Connection): Promise<void> {
   const store = new Store();
   try {
     const config = await store.load('config.json');
-    console.log('Using pre-loaded Token program');
+    console.log('Using pre-loaded Token programs');
     console.log(
       `  Note: To reload program remove ${Store.getFilename('config.json')}`,
     );
     programId = new PublicKey(config.tokenProgramId);
     associatedProgramId = new PublicKey(config.associatedTokenProgramId);
+    let info;
+    info = await connection.getAccountInfo(programId);
+    assert(info != null);
+    info = await connection.getAccountInfo(associatedProgramId);
+    assert(info != null);
   } catch (err) {
+    console.log(
+      'Checking pre-loaded Token programs failed, will load new programs:',
+    );
+    console.log({err});
+
     programId = await loadProgram(
       connection,
       '../../target/bpfel-unknown-unknown/release/spl_token.so',
@@ -596,7 +606,8 @@ export async function associatedToken(): Promise<void> {
     testToken.publicKey,
   );
   // associated account shouldn't exist
-  let info = await connection.getAccountInfo(associatedTokenAddress);
+  let info;
+  info = await connection.getAccountInfo(associatedTokenAddress);
   assert(info == null);
 
   await testToken.createAssociatedTokenAccount(owner.publicKey);

--- a/token/js/cli/token-test.js
+++ b/token/js/cli/token-test.js
@@ -9,7 +9,12 @@ import {
   BPF_LOADER_PROGRAM_ID,
 } from '@solana/web3.js';
 
-import {Token, NATIVE_MINT} from '../client/token';
+import {
+  Token,
+  TOKEN_PROGRAM_ID,
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  NATIVE_MINT,
+} from '../client/token';
 import {url} from '../url';
 import {newAccountWithLamports} from '../client/util/new-account-with-lamports';
 import {sleep} from '../client/util/sleep';
@@ -84,7 +89,9 @@ async function GetPrograms(connection: Connection): Promise<void> {
   if (programVersion) {
     switch (programVersion) {
       case '2.0.4':
-        return new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
+        programId = TOKEN_PROGRAM_ID;
+        associatedProgramId = ASSOCIATED_TOKEN_PROGRAM_ID;
+        break;
       default:
         throw new Error('Unknown program version');
     }
@@ -534,7 +541,13 @@ export async function nativeToken(): Promise<void> {
   const payer = await newAccountWithLamports(connection, 2000000000 /* wag */);
   const lamportsToWrap = 1000000000;
 
-  const token = new Token(connection, NATIVE_MINT, programId, payer);
+  const token = new Token(
+    connection,
+    NATIVE_MINT,
+    programId,
+    payer,
+    associatedProgramId,
+  );
   const owner = new Account();
   const native = await Token.createWrappedNativeAccount(
     connection,

--- a/token/js/cli/token-test.js
+++ b/token/js/cli/token-test.js
@@ -151,8 +151,10 @@ export async function createMint(): Promise<void> {
     testMintAuthority.publicKey,
     2,
     programId,
-    associatedProgramId,
   );
+  // HACK: override hard-coded ASSOCIATED_TOKEN_PROGRAM_ID with corresponding
+  // custom test fixture
+  testToken.associatedProgramId = associatedProgramId;
 
   const mintInfo = await testToken.getMintInfo();
   if (mintInfo.mintAuthority !== null) {
@@ -551,13 +553,7 @@ export async function nativeToken(): Promise<void> {
   const payer = await newAccountWithLamports(connection, 2000000000 /* wag */);
   const lamportsToWrap = 1000000000;
 
-  const token = new Token(
-    connection,
-    NATIVE_MINT,
-    programId,
-    payer,
-    associatedProgramId,
-  );
+  const token = new Token(connection, NATIVE_MINT, programId, payer);
   const owner = new Account();
   const native = await Token.createWrappedNativeAccount(
     connection,

--- a/token/js/cli/token-test.js
+++ b/token/js/cli/token-test.js
@@ -313,7 +313,6 @@ export async function transferChecked(): Promise<void> {
 
 export async function transferCheckedAssociated(): Promise<void> {
   let account;
-  const connection = await getConnection();
 
   const associatedAccount = new Account();
   const associatedAddress = await Token.getAssociatedTokenAddress(
@@ -336,7 +335,7 @@ export async function transferCheckedAssociated(): Promise<void> {
     [],
     123,
     testTokenDecimals,
-  )
+  );
 
   // creating is skipped if existing
   account = await testToken.getOrCreateAssociatedTokenAccountInfo(

--- a/token/js/cli/token-test.js
+++ b/token/js/cli/token-test.js
@@ -195,7 +195,7 @@ export async function createAccount(): Promise<void> {
   assert(!testAccount2.equals(testAccount));
 }
 
-export async function createAssociatedToken(): Promise<void> {
+export async function createAssociatedAccount(): Promise<void> {
   let info;
   const connection = await getConnection();
 

--- a/token/js/cli/token-test.js
+++ b/token/js/cli/token-test.js
@@ -574,8 +574,6 @@ export async function nativeToken(): Promise<void> {
 
 export async function associatedToken(): Promise<void> {
   const connection = await getConnection();
-  const payer = await newAccountWithLamports(connection, 2000000000 /* wag */);
-  const lamportsToWrap = 1000000000;
 
   const owner = new Account();
   const associatedTokenAddress = await Token.getAssociatedTokenAddress(

--- a/token/js/cli/token-test.js
+++ b/token/js/cli/token-test.js
@@ -91,7 +91,7 @@ async function GetPrograms(connection: Connection): Promise<void> {
       case '2.0.4':
         programId = TOKEN_PROGRAM_ID;
         associatedProgramId = ASSOCIATED_TOKEN_PROGRAM_ID;
-        break;
+        return;
       default:
         throw new Error('Unknown program version');
     }

--- a/token/js/cli/token-test.js
+++ b/token/js/cli/token-test.js
@@ -322,7 +322,7 @@ export async function transferCheckedAssociated(): Promise<void> {
     associatedAccount.publicKey,
   );
 
-  account = await testToken.getOrCreateAssociatedTokenAccountInfo(
+  account = await testToken.getOrCreateAssociatedAccountInfo(
     associatedAccount.publicKey,
   );
   assert(account.amount.toNumber() === 0);
@@ -338,7 +338,7 @@ export async function transferCheckedAssociated(): Promise<void> {
   );
 
   // creating is skipped if existing
-  account = await testToken.getOrCreateAssociatedTokenAccountInfo(
+  account = await testToken.getOrCreateAssociatedAccountInfo(
     associatedAccount.publicKey,
   );
   assert(account.amount.toNumber() === 123);

--- a/token/js/cli/token-test.js
+++ b/token/js/cli/token-test.js
@@ -312,25 +312,18 @@ export async function transferChecked(): Promise<void> {
 }
 
 export async function transferCheckedAssociated(): Promise<void> {
-  let account;
+  let associatedAccount;
+  const destAccount = new Account();
 
-  const associatedAccount = new Account();
-  const associatedAddress = await Token.getAssociatedTokenAddress(
-    associatedProgramId,
-    programId,
-    testToken.publicKey,
-    associatedAccount.publicKey,
+  associatedAccount = await testToken.getOrCreateAssociatedAccountInfo(
+    destAccount.publicKey,
   );
-
-  account = await testToken.getOrCreateAssociatedAccountInfo(
-    associatedAccount.publicKey,
-  );
-  assert(account.amount.toNumber() === 0);
+  assert(associatedAccount.amount.toNumber() === 0);
 
   // sanity check transfer works
   await testToken.transferChecked(
     testAccount,
-    associatedAddress,
+    associatedAccount.address,
     testAccountOwner,
     [],
     123,
@@ -338,10 +331,10 @@ export async function transferCheckedAssociated(): Promise<void> {
   );
 
   // creating is skipped if existing
-  account = await testToken.getOrCreateAssociatedAccountInfo(
-    associatedAccount.publicKey,
+  associatedAccount = await testToken.getOrCreateAssociatedAccountInfo(
+    destAccount.publicKey,
   );
-  assert(account.amount.toNumber() === 123);
+  assert(associatedAccount.amount.toNumber() === 123);
 }
 
 export async function approveRevoke(): Promise<void> {

--- a/token/js/cli/token-test.js
+++ b/token/js/cli/token-test.js
@@ -312,15 +312,12 @@ export async function transferChecked(): Promise<void> {
 }
 
 export async function transferCheckedAssociated(): Promise<void> {
+  const dest = new Account().publicKey;
   let associatedAccount;
-  const destAccount = new Account();
 
-  associatedAccount = await testToken.getOrCreateAssociatedAccountInfo(
-    destAccount.publicKey,
-  );
+  associatedAccount = await testToken.getOrCreateAssociatedAccountInfo(dest);
   assert(associatedAccount.amount.toNumber() === 0);
 
-  // sanity check transfer works
   await testToken.transferChecked(
     testAccount,
     associatedAccount.address,
@@ -330,10 +327,7 @@ export async function transferCheckedAssociated(): Promise<void> {
     testTokenDecimals,
   );
 
-  // creating is skipped if existing
-  associatedAccount = await testToken.getOrCreateAssociatedAccountInfo(
-    destAccount.publicKey,
-  );
+  associatedAccount = await testToken.getOrCreateAssociatedAccountInfo(dest);
   assert(associatedAccount.amount.toNumber() === 123);
 }
 

--- a/token/js/client/token.js
+++ b/token/js/client/token.js
@@ -27,6 +27,10 @@ export const TOKEN_PROGRAM_ID: PublicKey = new PublicKey(
   'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
 );
 
+export const ASSOCIATED_TOKEN_PROGRAM_ID: PublicKey = new PublicKey(
+  'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL',
+);
+
 /**
  * Unfortunately, BufferLayout.encode uses an `instanceof` check for `Buffer`
  * which fails when using `publicKey.toBuffer()` directly because the bundled `Buffer`
@@ -2100,6 +2104,49 @@ export class Token {
     return new TransactionInstruction({
       keys,
       programId: programId,
+      data,
+    });
+  }
+
+  static async getAssociatedTokenAddress(
+    associatedProgramId: PublicKey,
+    programId: PublicKey,
+    owner: PublicKey,
+    mint: PublicKey
+  ): Promise<PublicKey> {
+     return (await PublicKey.findProgramAddress(
+       [
+          owner.toBuffer(),
+          programId.toBuffer(),
+          mint.toBuffer(),
+       ],
+       associatedProgramId,
+    ))[0];
+  }
+
+  static createAssociatedTokenAccountInstruction(
+    associatedProgramId: PublicKey,
+    programId: PublicKey,
+    payer: PublicKey,
+    owner: PublicKey,
+    mint: PublicKey,
+    associatedAccount: PublicKey,
+  ): TransactionInstruction {
+    const data = Buffer.alloc(0);
+
+    let keys = [
+      {pubkey: payer, isSigner: true, isWritable: true},
+      {pubkey: associatedAccount, isSigner: false, isWritable: true},
+      {pubkey: owner, isSigner: false, isWritable: false},
+      {pubkey: mint, isSigner: false, isWritable: false},
+      {pubkey: SystemProgram.programId, isSigner: false, isWritable: false},
+      {pubkey: programId, isSigner: false, isWritable: false},
+      {pubkey: SYSVAR_RENT_PUBKEY, isSigner: false, isWritable: false},
+    ];
+
+    return new TransactionInstruction({
+      keys,
+      programId: associatedProgramId,
       data,
     });
   }

--- a/token/js/client/token.js
+++ b/token/js/client/token.js
@@ -315,7 +315,13 @@ export class Token {
     payer: Account,
     associatedProgramId: PublicKey,
   ) {
-    Object.assign(this, {connection, publicKey, programId, payer, associatedProgramId});
+    Object.assign(this, {
+      connection,
+      publicKey,
+      programId,
+      payer,
+      associatedProgramId,
+    });
   }
 
   /**
@@ -1288,9 +1294,7 @@ export class Token {
     );
   }
 
-  async createAssociatedTokenAccount(
-    ownerPublicKey: PublicKey,
-  ): Promise<void> {
+  async createAssociatedTokenAccount(ownerPublicKey: PublicKey): Promise<void> {
     const associatedAccount = await Token.getAssociatedTokenAddress(
       this.associatedProgramId,
       this.programId,
@@ -1308,7 +1312,7 @@ export class Token {
           this.payer.publicKey,
           ownerPublicKey,
           this.publicKey,
-          associatedAccount
+          associatedAccount,
         ),
       ),
       this.payer,
@@ -2147,16 +2151,14 @@ export class Token {
     associatedProgramId: PublicKey,
     programId: PublicKey,
     owner: PublicKey,
-    mint: PublicKey
+    mint: PublicKey,
   ): Promise<PublicKey> {
-     return (await PublicKey.findProgramAddress(
-       [
-          owner.toBuffer(),
-          programId.toBuffer(),
-          mint.toBuffer(),
-       ],
-       associatedProgramId,
-    ))[0];
+    return (
+      await PublicKey.findProgramAddress(
+        [owner.toBuffer(), programId.toBuffer(), mint.toBuffer()],
+        associatedProgramId,
+      )
+    )[0];
   }
 
   static createAssociatedTokenAccountInstruction(

--- a/token/js/client/token.js
+++ b/token/js/client/token.js
@@ -526,7 +526,7 @@ export class Token {
    * @param owner User account that will own the new account
    * @return Public key of the new associated account
    */
-  async getOrCreateAssociatedTokenAccountInfo(
+  async getOrCreateAssociatedAccountInfo(
     owner: PublicKey,
   ): Promise<AccountInfo> {
     const associatedAddress = await Token.getAssociatedTokenAddress(
@@ -536,21 +536,25 @@ export class Token {
       owner,
     );
 
-    // sadly we can't do this atomically;
-    // also this is optimum logic, considering tx fee, client-side computation, rpc roundtrips, guaranteed idempotency
+    // This is the optimum logic, considering TX fee, client-side computation,
+    // rpc roundtripsa and guaranteed idempotent.
+    // Sadly we can't do this atomically;
     try {
       return await this.getAccountInfo(associatedAddress);
     } catch (err) {
       if (err.message == FAILED_TO_FIND_ACCOUNT) {
-        // as this isn't atomic, it's possible other can create associated accounts
+        // as this isn't atomic, it's possible others can create associated
+        // accounts meanwhile
         try {
           await this.createAssociatedTokenAccountInternal(
             owner,
             associatedAddress,
           );
         } catch (err) {
-          // ignore all errors; for now there is no API compatible way to selectively
-          // ignore the expected instruction error if the associated account is existing already
+          // ignore all errors; for now there is no API compatible way to
+          // selectively.
+          // ignore the expected instruction error if the associated account is
+          // existing already
         }
       }
       return await this.getAccountInfo(associatedAddress);

--- a/token/js/client/token.js
+++ b/token/js/client/token.js
@@ -474,6 +474,33 @@ export class Token {
     return newAccount.publicKey;
   }
 
+  async createAssociatedTokenAccount(owner: PublicKey): Promise<PublicKey> {
+    const associatedAddress = await Token.getAssociatedTokenAddress(
+      this.associatedProgramId,
+      this.programId,
+      owner,
+      this.publicKey,
+    );
+
+    await sendAndConfirmTransaction(
+      'CreateAssociatedTokenAccount',
+      this.connection,
+      new Transaction().add(
+        Token.createAssociatedTokenAccountInstruction(
+          this.associatedProgramId,
+          this.programId,
+          this.payer.publicKey,
+          owner,
+          this.publicKey,
+          associatedAddress,
+        ),
+      ),
+      this.payer,
+    );
+
+    return associatedAddress;
+  }
+
   /**
    * Create and initialize a new account on the special native token mint.
    *
@@ -1289,31 +1316,6 @@ export class Token {
       ),
       this.payer,
       ...signers,
-    );
-  }
-
-  async createAssociatedTokenAccount(ownerPublicKey: PublicKey): Promise<void> {
-    const associatedAccount = await Token.getAssociatedTokenAddress(
-      this.associatedProgramId,
-      this.programId,
-      ownerPublicKey,
-      this.publicKey,
-    );
-
-    await sendAndConfirmTransaction(
-      'CreateAssociatedTokenAccount',
-      this.connection,
-      new Transaction().add(
-        Token.createAssociatedTokenAccountInstruction(
-          this.associatedProgramId,
-          this.programId,
-          this.payer.publicKey,
-          ownerPublicKey,
-          this.publicKey,
-          associatedAccount,
-        ),
-      ),
-      this.payer,
     );
   }
 

--- a/token/js/client/token.js
+++ b/token/js/client/token.js
@@ -313,14 +313,14 @@ export class Token {
     publicKey: PublicKey,
     programId: PublicKey,
     payer: Account,
-    associatedProgramId: PublicKey,
   ) {
     Object.assign(this, {
       connection,
       publicKey,
       programId,
       payer,
-      associatedProgramId,
+      // Hard code is ok; Overriding is needed only for tests
+      associatedProgramId: ASSOCIATED_TOKEN_PROGRAM_ID,
     });
   }
 
@@ -379,7 +379,6 @@ export class Token {
     freezeAuthority: PublicKey | null,
     decimals: number,
     programId: PublicKey,
-    associatedProgramId: PublicKey,
   ): Promise<Token> {
     const mintAccount = new Account();
     const token = new Token(
@@ -387,7 +386,6 @@ export class Token {
       mintAccount.publicKey,
       programId,
       payer,
-      associatedProgramId,
     );
 
     // Allocate memory for the account

--- a/token/js/client/token.js
+++ b/token/js/client/token.js
@@ -146,6 +146,11 @@ export const MintLayout: typeof BufferLayout.Structure = BufferLayout.struct([
  */
 type AccountInfo = {|
   /**
+   * The address of this account
+   */
+  address: PublicKey,
+
+  /**
    * The mint associated with this account
    */
   mint: PublicKey,
@@ -537,7 +542,7 @@ export class Token {
     );
 
     // This is the optimum logic, considering TX fee, client-side computation,
-    // rpc roundtripsa and guaranteed idempotent.
+    // RPC roundtrips and guaranteed idempotent.
     // Sadly we can't do this atomically;
     try {
       return await this.getAccountInfo(associatedAddress);
@@ -759,6 +764,7 @@ export class Token {
 
     const data = Buffer.from(info.data);
     const accountInfo = AccountLayout.decode(data);
+    accountInfo.address = account;
     accountInfo.mint = new PublicKey(accountInfo.mint);
     accountInfo.owner = new PublicKey(accountInfo.owner);
     accountInfo.amount = u64.fromBuffer(accountInfo.amount);

--- a/token/js/client/token.js
+++ b/token/js/client/token.js
@@ -495,7 +495,10 @@ export class Token {
     return this.createAssociatedTokenAccountInternal(owner, associatedAddress);
   }
 
-  async createAssociatedTokenAccountInternal(owner: PublicKey, associatedAddress: PublicKey): Promise<PublicKey> {
+  async createAssociatedTokenAccountInternal(
+    owner: PublicKey,
+    associatedAddress: PublicKey,
+  ): Promise<PublicKey> {
     await sendAndConfirmTransaction(
       'CreateAssociatedTokenAccount',
       this.connection,
@@ -523,7 +526,9 @@ export class Token {
    * @param owner User account that will own the new account
    * @return Public key of the new associated account
    */
-  async getOrCreateAssociatedTokenAccountInfo(owner: PublicKey): Promise<AccountInfo> {
+  async getOrCreateAssociatedTokenAccountInfo(
+    owner: PublicKey,
+  ): Promise<AccountInfo> {
     const associatedAddress = await Token.getAssociatedTokenAddress(
       this.associatedProgramId,
       this.programId,
@@ -535,12 +540,15 @@ export class Token {
     // also this is optimum logic, considering tx fee, client-side computation, rpc roundtrips, guaranteed idempotency
     try {
       return await this.getAccountInfo(associatedAddress);
-    } catch(err) {
+    } catch (err) {
       if (err.message == FAILED_TO_FIND_ACCOUNT) {
         // as this isn't atomic, it's possible other can create associated accounts
         try {
-          await this.createAssociatedTokenAccountInternal(owner, associatedAddress);
-        } catch(err) {
+          await this.createAssociatedTokenAccountInternal(
+            owner,
+            associatedAddress,
+          );
+        } catch (err) {
           // ignore all errors; for now there is no API compatible way to selectively
           // ignore the expected instruction error if the associated account is existing already
         }

--- a/token/js/module.d.ts
+++ b/token/js/module.d.ts
@@ -12,6 +12,7 @@ declare module '@solana/spl-token' {
 
   // === client/token.js ===
   export const TOKEN_PROGRAM_ID: PublicKey;
+  export const ASSOCIATED_TOKEN_PROGRAM_ID: PublicKey;
 
   export class u64 extends BN {
     toBuffer(): Buffer;
@@ -65,6 +66,7 @@ declare module '@solana/spl-token' {
   export class Token {
     publicKey: PublicKey;
     programId: PublicKey;
+    associatedProgramId: PublicKey;
     payer: Account;
     constructor(
       connection: Connection,
@@ -81,6 +83,12 @@ declare module '@solana/spl-token' {
     static getMinBalanceRentForExemptMultisig(
       connection: Connection,
     ): Promise<number>;
+    static getAssociatedTokenAddress(
+      associatedProgramId: PublicKey,
+      programId: PublicKey,
+      owner: PublicKey,
+      mint: PublicKey,
+    ): Promise<PublicKey>;
     static createMint(
       connection: Connection,
       payer: Account,
@@ -90,6 +98,7 @@ declare module '@solana/spl-token' {
       programId: PublicKey,
     ): Promise<Token>;
     createAccount(owner: PublicKey): Promise<PublicKey>;
+    createAssociatedTokenAccount(owner: PublicKey): Promise<PublicKey>;
     static createWrappedNativeAccount(
       connection: Connection,
       programId: PublicKey,
@@ -234,6 +243,14 @@ declare module '@solana/spl-token' {
       mint: PublicKey,
       authority: PublicKey,
       multiSigners: Array<Account>,
+    ): TransactionInstruction;
+    static createAssociatedTokenAccountInstruction(
+      associatedProgramId: PublicKey,
+      programId: PublicKey,
+      payer: PublicKey,
+      owner: PublicKey,
+      mint: PublicKey,
+      associatedAccount: PublicKey,
     ): TransactionInstruction;
   }
 }

--- a/token/js/module.d.ts
+++ b/token/js/module.d.ts
@@ -36,6 +36,7 @@ declare module '@solana/spl-token' {
 
   export const AccountLayout: Layout;
   export type AccountInfo = {
+    address: PublicKey;
     mint: PublicKey;
     owner: PublicKey;
     amount: u64;

--- a/token/js/module.d.ts
+++ b/token/js/module.d.ts
@@ -86,8 +86,8 @@ declare module '@solana/spl-token' {
     static getAssociatedTokenAddress(
       associatedProgramId: PublicKey,
       programId: PublicKey,
-      owner: PublicKey,
       mint: PublicKey,
+      owner: PublicKey,
     ): Promise<PublicKey>;
     static createMint(
       connection: Connection,
@@ -109,6 +109,7 @@ declare module '@solana/spl-token' {
     createMultisig(m: number, signers: Array<PublicKey>): Promise<PublicKey>;
     getMintInfo(): Promise<MintInfo>;
     getAccountInfo(account: PublicKey): Promise<AccountInfo>;
+    getOrCreateAssociatedAccountInfo(account: PublicKey): Promise<AccountInfo>;
     getMultisigInfo(multisig: PublicKey): Promise<MultisigInfo>;
     transfer(
       source: PublicKey,
@@ -247,10 +248,10 @@ declare module '@solana/spl-token' {
     static createAssociatedTokenAccountInstruction(
       associatedProgramId: PublicKey,
       programId: PublicKey,
-      payer: PublicKey,
-      owner: PublicKey,
       mint: PublicKey,
       associatedAccount: PublicKey,
+      owner: PublicKey,
+      payer: PublicKey,
     ): TransactionInstruction;
   }
 }

--- a/token/js/module.d.ts
+++ b/token/js/module.d.ts
@@ -110,7 +110,7 @@ declare module '@solana/spl-token' {
     createMultisig(m: number, signers: Array<PublicKey>): Promise<PublicKey>;
     getMintInfo(): Promise<MintInfo>;
     getAccountInfo(account: PublicKey): Promise<AccountInfo>;
-    getOrCreateAssociatedAccountInfo(account: PublicKey): Promise<AccountInfo>;
+    getOrCreateAssociatedAccountInfo(owner: PublicKey): Promise<AccountInfo>;
     getMultisigInfo(multisig: PublicKey): Promise<MultisigInfo>;
     transfer(
       source: PublicKey,

--- a/token/js/module.flow.js
+++ b/token/js/module.flow.js
@@ -88,8 +88,8 @@ declare module '@solana/spl-token' {
     static getAssociatedTokenAddress(
       associatedProgramId: PublicKey,
       programId: PublicKey,
-      owner: PublicKey,
       mint: PublicKey,
+      owner: PublicKey,
     ): Promise<PublicKey>;
     static createMint(
       connection: Connection,
@@ -111,6 +111,7 @@ declare module '@solana/spl-token' {
     createMultisig(m: number, signers: Array<PublicKey>): Promise<PublicKey>;
     getMintInfo(): Promise<MintInfo>;
     getAccountInfo(account: PublicKey): Promise<AccountInfo>;
+    getOrCreateAssociatedAccountInfo(account: PublicKey): Promise<AccountInfo>;
     getMultisigInfo(multisig: PublicKey): Promise<MultisigInfo>;
     transfer(
       source: PublicKey,
@@ -249,10 +250,10 @@ declare module '@solana/spl-token' {
     static createAssociatedTokenAccountInstruction(
       associatedProgramId: PublicKey,
       programId: PublicKey,
-      payer: PublicKey,
-      owner: PublicKey,
       mint: PublicKey,
       associatedAccount: PublicKey,
+      owner: PublicKey,
+      payer: PublicKey,
     ): TransactionInstruction;
   }
 }

--- a/token/js/module.flow.js
+++ b/token/js/module.flow.js
@@ -112,7 +112,7 @@ declare module '@solana/spl-token' {
     createMultisig(m: number, signers: Array<PublicKey>): Promise<PublicKey>;
     getMintInfo(): Promise<MintInfo>;
     getAccountInfo(account: PublicKey): Promise<AccountInfo>;
-    getOrCreateAssociatedAccountInfo(account: PublicKey): Promise<AccountInfo>;
+    getOrCreateAssociatedAccountInfo(owner: PublicKey): Promise<AccountInfo>;
     getMultisigInfo(multisig: PublicKey): Promise<MultisigInfo>;
     transfer(
       source: PublicKey,

--- a/token/js/module.flow.js
+++ b/token/js/module.flow.js
@@ -17,6 +17,7 @@ import type {TransactionSignature} from '@solana/web3.js';
 
 declare module '@solana/spl-token' {
   declare export var TOKEN_PROGRAM_ID;
+  declare export var ASSOCIATED_TOKEN_PROGRAM_ID;
   declare export class u64 extends BN {
     toBuffer(): typeof Buffer;
     static fromBuffer(buffer: typeof Buffer): u64;
@@ -67,6 +68,7 @@ declare module '@solana/spl-token' {
   declare export class Token {
     publicKey: PublicKey;
     programId: PublicKey;
+    associatedProgramId: PublicKey;
     payer: Account;
     constructor(
       connection: Connection,
@@ -83,6 +85,12 @@ declare module '@solana/spl-token' {
     static getMinBalanceRentForExemptMultisig(
       connection: Connection,
     ): Promise<number>;
+    static getAssociatedTokenAddress(
+      associatedProgramId: PublicKey,
+      programId: PublicKey,
+      owner: PublicKey,
+      mint: PublicKey,
+    ): Promise<PublicKey>;
     static createMint(
       connection: Connection,
       payer: Account,
@@ -92,6 +100,7 @@ declare module '@solana/spl-token' {
       programId: PublicKey,
     ): Promise<Token>;
     createAccount(owner: PublicKey): Promise<PublicKey>;
+    createAssociatedTokenAccount(owner: PublicKey): Promise<PublicKey>;
     static createWrappedNativeAccount(
       connection: Connection,
       programId: PublicKey,
@@ -236,6 +245,14 @@ declare module '@solana/spl-token' {
       mint: PublicKey,
       authority: PublicKey,
       multiSigners: Array<Account>,
+    ): TransactionInstruction;
+    static createAssociatedTokenAccountInstruction(
+      associatedProgramId: PublicKey,
+      programId: PublicKey,
+      payer: PublicKey,
+      owner: PublicKey,
+      mint: PublicKey,
+      associatedAccount: PublicKey,
     ): TransactionInstruction;
   }
 }

--- a/token/js/module.flow.js
+++ b/token/js/module.flow.js
@@ -38,6 +38,7 @@ declare module '@solana/spl-token' {
   |};
   declare export var AccountLayout: typeof Layout;
   declare export type AccountInfo = {|
+    address: PublicKey,
     mint: PublicKey,
     owner: PublicKey,
     amount: u64,

--- a/token/js/package.json
+++ b/token/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana/spl-token",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "SPL Token JavaScript API",
   "license": "MIT",
   "author": "Solana Maintainers <maintainers@solana.com>",

--- a/token/js/test/token.test.js
+++ b/token/js/test/token.test.js
@@ -1,8 +1,8 @@
 // @flow
 import {expect} from 'chai';
-import {Account} from '@solana/web3.js';
+import {Account, PublicKey} from '@solana/web3.js';
 
-import {Token, TOKEN_PROGRAM_ID} from '../client/token';
+import {ASSOCIATED_TOKEN_PROGRAM_ID, Token, TOKEN_PROGRAM_ID} from '../client/token';
 
 describe('Token', () => {
   it('createTransfer', () => {
@@ -30,5 +30,30 @@ describe('Token', () => {
     );
     expect(ix.programId).to.eql(TOKEN_PROGRAM_ID);
     expect(ix.keys).to.have.length(2);
+  });
+
+  it('getAssociatedTokenAddress', async () => {
+    const associatedPublicKey = await Token.getAssociatedTokenAddress(
+      ASSOCIATED_TOKEN_PROGRAM_ID,
+      TOKEN_PROGRAM_ID,
+      new PublicKey('B8UwBUUnKwCyKuGMbFKWaG7exYdDk2ozZrPg72NyVbfj'),
+      new PublicKey('7o36UsWR1JQLpZ9PE2gn9L4SQ69CNNiWAXd4Jt7rqz9Z'),
+    );
+    expect(associatedPublicKey.toString()).to.eql(
+      new PublicKey('DShWnroshVbeUp28oopA3Pu7oFPDBtC1DBmPECXXAQ9n').toString(),
+    );
+  });
+
+  it('createAssociatedTokenAccount', () => {
+    const ix = Token.createAssociatedTokenAccountInstruction(
+      ASSOCIATED_TOKEN_PROGRAM_ID,
+      TOKEN_PROGRAM_ID,
+      new Account().publicKey,
+      new Account().publicKey,
+      new Account().publicKey,
+      new Account().publicKey,
+    );
+    expect(ix.programId).to.eql(ASSOCIATED_TOKEN_PROGRAM_ID);
+    expect(ix.keys).to.have.length(7);
   });
 });

--- a/token/js/test/token.test.js
+++ b/token/js/test/token.test.js
@@ -36,8 +36,8 @@ describe('Token', () => {
     const associatedPublicKey = await Token.getAssociatedTokenAddress(
       ASSOCIATED_TOKEN_PROGRAM_ID,
       TOKEN_PROGRAM_ID,
-      new PublicKey('B8UwBUUnKwCyKuGMbFKWaG7exYdDk2ozZrPg72NyVbfj'),
       new PublicKey('7o36UsWR1JQLpZ9PE2gn9L4SQ69CNNiWAXd4Jt7rqz9Z'),
+      new PublicKey('B8UwBUUnKwCyKuGMbFKWaG7exYdDk2ozZrPg72NyVbfj'),
     );
     expect(associatedPublicKey.toString()).to.eql(
       new PublicKey('DShWnroshVbeUp28oopA3Pu7oFPDBtC1DBmPECXXAQ9n').toString(),


### PR DESCRIPTION
## Problem

- There is no easy way of accessing associated tokens from JS land

## Changes

- Support them
- Also, make testing more robust including `./program`'s NFC modifications.