### PR TITLE
memo: Expand error type to make test less flaky

### DIFF
--- a/memo/program/tests/functional.rs
+++ b/memo/program/tests/functional.rs
@@ -140,14 +140,11 @@ async fn test_memo_compute_limits() {
         .await
         .unwrap_err()
         .unwrap();
-    assert!(
-        err == TransactionError::InstructionError(0, InstructionError::ProgramFailedToComplete)
-            || err
-                == TransactionError::InstructionError(
-                    0,
-                    InstructionError::ComputationalBudgetExceeded
-                )
-    );
+    let failed_to_complete =
+        TransactionError::InstructionError(0, InstructionError::ProgramFailedToComplete);
+    let computational_budget_exceeded =
+        TransactionError::InstructionError(0, InstructionError::ComputationalBudgetExceeded);
+    assert!(err == failed_to_complete || err == computational_budget_exceeded);
 
     let mut memo = vec![];
     for _ in 0..100 {
@@ -168,14 +165,7 @@ async fn test_memo_compute_limits() {
         .await
         .unwrap_err()
         .unwrap();
-    assert!(
-        err == TransactionError::InstructionError(0, InstructionError::ProgramFailedToComplete)
-            || err
-                == TransactionError::InstructionError(
-                    0,
-                    InstructionError::ComputationalBudgetExceeded
-                )
-    );
+    assert!(err == failed_to_complete || err == computational_budget_exceeded);
 
     // Test num signers with 32-byte memo
     let memo = Pubkey::new_unique().to_bytes();
@@ -211,12 +201,5 @@ async fn test_memo_compute_limits() {
         .await
         .unwrap_err()
         .unwrap();
-    assert!(
-        err == TransactionError::InstructionError(0, InstructionError::ProgramFailedToComplete)
-            || err
-                == TransactionError::InstructionError(
-                    0,
-                    InstructionError::ComputationalBudgetExceeded
-                )
-    );
+    assert!(err == failed_to_complete || err == computational_budget_exceeded);
 }

--- a/memo/program/tests/functional.rs
+++ b/memo/program/tests/functional.rs
@@ -135,13 +135,18 @@ async fn test_memo_compute_limits() {
     let mut transaction =
         Transaction::new_with_payer(&[build_memo(&memo[..568], &[])], Some(&payer.pubkey()));
     transaction.sign(&[&payer], recent_blockhash);
-    assert_eq!(
-        banks_client
-            .process_transaction(transaction)
-            .await
-            .unwrap_err()
-            .unwrap(),
-        TransactionError::InstructionError(0, InstructionError::ProgramFailedToComplete)
+    let err = banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert!(
+        err == TransactionError::InstructionError(0, InstructionError::ProgramFailedToComplete)
+            || err
+                == TransactionError::InstructionError(
+                    0,
+                    InstructionError::ComputationalBudgetExceeded
+                )
     );
 
     let mut memo = vec![];
@@ -158,13 +163,18 @@ async fn test_memo_compute_limits() {
     let mut transaction =
         Transaction::new_with_payer(&[build_memo(&memo[..63], &[])], Some(&payer.pubkey()));
     transaction.sign(&[&payer], recent_blockhash);
-    assert_eq!(
-        banks_client
-            .process_transaction(transaction)
-            .await
-            .unwrap_err()
-            .unwrap(),
-        TransactionError::InstructionError(0, InstructionError::ProgramFailedToComplete)
+    let err = banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert!(
+        err == TransactionError::InstructionError(0, InstructionError::ProgramFailedToComplete)
+            || err
+                == TransactionError::InstructionError(
+                    0,
+                    InstructionError::ComputationalBudgetExceeded
+                )
     );
 
     // Test num signers with 32-byte memo
@@ -196,12 +206,17 @@ async fn test_memo_compute_limits() {
         Some(&payer.pubkey()),
     );
     transaction.sign(&signers, recent_blockhash);
-    assert_eq!(
-        banks_client
-            .process_transaction(transaction)
-            .await
-            .unwrap_err()
-            .unwrap(),
-        TransactionError::InstructionError(0, InstructionError::ProgramFailedToComplete)
+    let err = banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert!(
+        err == TransactionError::InstructionError(0, InstructionError::ProgramFailedToComplete)
+            || err
+                == TransactionError::InstructionError(
+                    0,
+                    InstructionError::ComputationalBudgetExceeded
+                )
     );
 }


### PR DESCRIPTION
#### Problem

The memo test randomly fails on CI with two different errors.

#### Solution

Not pretty, but expand to check for both possible errors returned.  At least it will unblock CI!