### PR TITLE
Token cli: Improve authorize command

### DIFF
--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -378,7 +378,7 @@ fn command_authorize(
     let previous_authority = if let Ok(mint) = Mint::unpack(&target_account.data) {
         match authority_type {
             AuthorityType::AccountOwner | AuthorityType::CloseAccount => Err(format!(
-                "Authority type `{}` not supported for mints",
+                "Authority type `{}` not supported for SPL Token mints",
                 auth_str
             )),
             AuthorityType::MintTokens => Ok(mint.mint_authority),
@@ -393,7 +393,7 @@ fn command_authorize(
                 && Some(config.owner) != new_owner
             {
                 Err(
-                    format!("Error: attmepting to change the `{}` of an associated token account of `--owner`", auth_str)
+                    format!("Error: attempting to change the `{}` of an associated token account of `--owner`", auth_str)
                         .into(),
                 )
             } else {
@@ -403,7 +403,7 @@ fn command_authorize(
 
         match authority_type {
             AuthorityType::MintTokens | AuthorityType::FreezeAccount => Err(format!(
-                "Authority type `{}` not supported for accounts",
+                "Authority type `{}` not supported for SPL Token accounts",
                 auth_str
             )),
             AuthorityType::AccountOwner => {

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -372,6 +372,26 @@ fn command_authorize(
         AuthorityType::AccountOwner => "owner",
         AuthorityType::CloseAccount => "close authority",
     };
+    let target_account = config.rpc_client.get_account(&account)?;
+    if let Ok(_mint) = Mint::unpack(&target_account.data) {
+        match authority_type {
+            AuthorityType::AccountOwner | AuthorityType::CloseAccount => Err(format!(
+                "Authority type `{}` not supported for mints",
+                auth_str
+            )),
+            _ => Ok(()),
+        }
+    } else if let Ok(_token_account) = Account::unpack(&target_account.data) {
+        match authority_type {
+            AuthorityType::MintTokens | AuthorityType::FreezeAccount => Err(format!(
+                "Authority type `{}` not supported for accounts",
+                auth_str
+            )),
+            _ => Ok(()),
+        }
+    } else {
+        Err("Unsupported account data format".to_string())
+    }?;
     println!(
         "Updating {}\n  Current {}: {}\n  New {}: {}",
         account,


### PR DESCRIPTION
Several changes to remove footguns and make failure debugging easier for `spl-token authorize` commands.
- Check target account type (mint vs. account) and return clear error message if authorize is attempting to change an incompatible authority type
- Print the real current authority to make it easier to detect if `--owner` is incorrect authority for operation
- Refuse to change the owner or close authority if the account is an ATA of the `--owner`; hidden `--force` arg overrides

Fixes #791 
Fixes #1431 