### PR TITLE
Binary-oracle: Remove explicit tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,11 +255,11 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5a26c53ddf60281f18e7a29b20db7ba3db82a9d81b9650bfaa02d646f50d364"
+checksum = "09a7111f797cc721407885a323fb071636aee57f750b1a4ddc27397eba168a74"
 dependencies = [
- "borsh-derive 0.8.1",
+ "borsh-derive 0.8.2",
  "hashbrown",
 ]
 
@@ -277,12 +277,12 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b637a47728b78a78cd7f4b85bf06d71ef4221840e059a38f048be2422bf673b2"
+checksum = "307f3740906bac2c118a8122fe22681232b244f1369273e45f1156b45c43d2dd"
 dependencies = [
- "borsh-derive-internal 0.8.1",
- "borsh-schema-derive-internal 0.8.1",
+ "borsh-derive-internal 0.8.2",
+ "borsh-schema-derive-internal 0.8.2",
  "proc-macro-crate",
  "proc-macro2 1.0.24",
  "syn 1.0.64",
@@ -301,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive-internal"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d813fa25eb0bed78c36492cff4415f38c760d6de833d255ba9095bd8ebb7d725"
+checksum = "d2104c73179359431cc98e016998f2f23bc7a05bc53e79741bcba705f30047bc"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.8",
@@ -323,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-schema-derive-internal"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf78ee4a98c8cb9eba1bac3d3e2a1ea3d7673c719ce691e67b5cbafc472d3b7"
+checksum = "ae29eb8418fcd46f723f8691a2ac06857d31179d33d2f2d91eb13967de97c728"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.8",
@@ -3086,8 +3086,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f34d1cb27f796a8e368912642501505c3e182a90671afcbbec54b5f2f81c21c"
 dependencies = [
  "bincode",
- "borsh 0.8.1",
- "borsh-derive 0.8.1",
+ "borsh 0.8.2",
+ "borsh-derive 0.8.2",
  "futures 0.3.12",
  "mio 0.7.7",
  "solana-banks-interface",
@@ -3374,8 +3374,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf65f2831d561cf0390bd89692a0b9a5435e09e59a37e6bc9936f4a3ac8bf2b4"
 dependencies = [
  "bincode",
- "borsh 0.8.1",
- "borsh-derive 0.8.1",
+ "borsh 0.8.2",
+ "borsh-derive 0.8.2",
  "bs58 0.3.1",
  "bv",
  "curve25519-dalek 2.1.2",
@@ -3699,13 +3699,13 @@ name = "spl-binary-oracle-pair"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "arrayref",
+ "borsh 0.8.2",
  "num-derive",
  "num-traits",
- "proptest",
  "solana-program",
+ "solana-program-test",
  "solana-sdk",
- "spl-token 3.0.1",
+ "spl-token 3.1.0",
  "thiserror",
  "uint",
 ]
@@ -3760,7 +3760,7 @@ name = "spl-feature-proposal"
 version = "1.0.0"
 dependencies = [
  "borsh 0.7.2",
- "borsh-derive 0.8.1",
+ "borsh-derive 0.8.2",
  "futures 0.3.12",
  "solana-program",
  "solana-program-test",
@@ -3787,7 +3787,7 @@ name = "spl-math"
 version = "0.1.0"
 dependencies = [
  "borsh 0.7.2",
- "borsh-derive 0.8.1",
+ "borsh-derive 0.8.2",
  "num-derive",
  "num-traits",
  "proptest",
@@ -3829,8 +3829,8 @@ dependencies = [
 name = "spl-record"
 version = "0.1.0"
 dependencies = [
- "borsh 0.8.1",
- "borsh-derive 0.8.1",
+ "borsh 0.8.2",
+ "borsh-derive 0.8.2",
  "num-derive",
  "num-traits",
  "solana-program",

--- a/binary-oracle-pair/program/Cargo.toml
+++ b/binary-oracle-pair/program/Cargo.toml
@@ -13,7 +13,7 @@ test-bpf = []
 [dependencies]
 num-derive = "0.3"
 num-traits = "0.2"
-solana-program = "1.5.14"
+solana-program = "1.6.1"
 spl-token = { version = "3.0", path = "../../token/program", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 uint = "0.8"
@@ -22,8 +22,7 @@ borsh = "0.8.2"
 
 [dev-dependencies]
 solana-program-test = "1.6.1"
-solana-sdk = "1.5.14"
-tokio = { version = "1.3.0", features = ["macros"]}
+solana-sdk = "1.6.1"
 
 [lib]
 crate-type = ["cdylib", "lib"]


### PR DESCRIPTION
Binary-oracle-pair program was merged after https://github.com/solana-labs/solana-program-library/pull/1456, and didn't get those changes. As a result, the program is breaking solana CI downstream-projects build on v1.5

cc @joncinque 