### PR TITLE
CI: skip build/test suite when changes only affect docs

### DIFF
--- a/.github/workflows/pull-request-docs.yml
+++ b/.github/workflows/pull-request-docs.yml
@@ -1,0 +1,16 @@
+name: Docs Pull Request
+
+on:
+  pull_request:
+    paths:
+    - 'docs/**'
+  push:
+    branches: [master]
+    paths:
+    - 'docs/**'
+
+jobs:
+  all_github_action_checks:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Done"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,8 +2,12 @@ name: Pull Request
 
 on:
   pull_request:
+    paths-ignore:
+    - 'docs/**'
   push:
     branches: [master]
+    paths-ignore:
+    - 'docs/**'
 
 jobs:
   all_github_action_checks:


### PR DESCRIPTION
CI runs on this repo are pretty long, and lengthening as more programs are added. No reason to wait all that time to just update the SPL docs.