### PR TITLE
spl-token-cli: use ATA by default in wrap/unwrap commands

### DIFF
--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -688,25 +688,45 @@ fn command_thaw(config: &Config, account: Pubkey, mint_address: Option<Pubkey>) 
     Ok(Some((0, vec![instructions])))
 }
 
-fn command_wrap(config: &Config, sol: f64, account: Pubkey) -> CommandResult {
+fn command_wrap(config: &Config, sol: f64, account: Option<Pubkey>) -> CommandResult {
     let lamports = sol_to_lamports(sol);
-    println!("Wrapping {} SOL into {}", sol, account);
 
-    let instructions = vec![
-        system_instruction::create_account(
-            &config.owner,
-            &account,
-            lamports,
-            Account::LEN as u64,
-            &spl_token::id(),
-        ),
-        initialize_account(
-            &spl_token::id(),
-            &account,
-            &native_mint::id(),
-            &config.owner,
-        )?,
-    ];
+    let instructions = if let Some(account) = account {
+        println!("Wrapping {} SOL into {}", sol, account);
+        vec![
+            system_instruction::create_account(
+                &config.owner,
+                &account,
+                lamports,
+                Account::LEN as u64,
+                &spl_token::id(),
+            ),
+            initialize_account(
+                &spl_token::id(),
+                &account,
+                &native_mint::id(),
+                &config.owner,
+            )?,
+        ]
+    } else {
+        let account = get_associated_token_address(&config.owner, &native_mint::id());
+
+        if let Some(account_data) = config
+            .rpc_client
+            .get_account_with_commitment(&account, config.rpc_client.commitment())?
+            .value
+        {
+            if account_data.owner != system_program::id() {
+                return Err(format!("Error: Account already exists: {}", account).into());
+            }
+        }
+
+        println!("Wrapping {} SOL into {}", sol, account);
+        vec![
+            system_instruction::transfer(&config.owner, &account, lamports),
+            create_associated_token_account(&config.fee_payer, &config.owner, &native_mint::id()),
+        ]
+    };
     if !config.sign_only {
         check_owner_balance(config, lamports)?;
     }
@@ -1577,6 +1597,12 @@ fn main() {
                         .required(true)
                         .help("Amount of SOL to wrap"),
                 )
+                .arg(
+                    Arg::with_name("aux")
+                        .takes_value(false)
+                        .long("aux")
+                        .help("Wrap SOL in an auxillary account instead of associated token account"),
+                )
                 .nonce_args(true)
                 .offline_args(),
         )
@@ -2050,9 +2076,14 @@ fn main() {
         }
         ("wrap", Some(arg_matches)) => {
             let amount = value_t_or_exit!(arg_matches, "amount", f64);
-            let (signer, account) = new_throwaway_signer();
-            let account = account.unwrap();
-            bulk_signers.push(signer);
+            let account = if arg_matches.is_present("aux") {
+                let (signer, account) = new_throwaway_signer();
+                bulk_signers.push(signer);
+                account
+            } else {
+                // No need to add a signer when creating an associated token account
+                None
+            };
             command_wrap(&config, amount, account)
         }
         ("unwrap", Some(arg_matches)) => {


### PR DESCRIPTION
`spl-token wrap` spins up an auxiliary account on each use, which deviates from the general standard of one ATA per main wallet address per mint.
Use ATA by default instead. Additional wrapped SOL accounts are still possible via the `--aux` parameter.