### PR TITLE
WIP ELF Error: Add failing test that calls get_packed_len

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3738,6 +3738,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-example-packed-len"
+version = "1.0.0"
+dependencies = [
+ "borsh 0.8.2",
+ "solana-program",
+ "solana-program-test",
+ "solana-sdk",
+]
+
+[[package]]
 name = "spl-example-sysvar"
 version = "1.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "examples/rust/cross-program-invocation",
   "examples/rust/custom-heap",
   "examples/rust/logging",
+  "examples/rust/packed-len",
   "examples/rust/sysvar",
   "examples/rust/transfer-lamports",
   "feature-proposal/program",

--- a/examples/rust/packed-len/Cargo.toml
+++ b/examples/rust/packed-len/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "spl-example-packed-len"
+version = "1.0.0"
+description = "Solana Program Library Packed Length Example"
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+repository = "https://github.com/solana-labs/solana-program-library"
+license = "Apache-2.0"
+edition = "2018"
+
+[features]
+no-entrypoint = []
+test-bpf = []
+
+[dependencies]
+borsh = "0.8"
+solana-program = "1.6.1"
+
+[dev-dependencies]
+solana-program-test = "1.6.1"
+solana-sdk = "1.6.1"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/examples/rust/packed-len/Xargo.toml
+++ b/examples/rust/packed-len/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/examples/rust/packed-len/src/entrypoint.rs
+++ b/examples/rust/packed-len/src/entrypoint.rs
@@ -1,0 +1,16 @@
+//! Program entrypoint
+
+#![cfg(not(feature = "no-entrypoint"))]
+
+use solana_program::{
+    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
+};
+
+entrypoint!(process_instruction);
+fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    crate::processor::process_instruction(program_id, accounts, instruction_data)
+}

--- a/examples/rust/packed-len/src/lib.rs
+++ b/examples/rust/packed-len/src/lib.rs
@@ -1,0 +1,6 @@
+//! A program demonstrating the transfer of lamports
+#![deny(missing_docs)]
+#![forbid(unsafe_code)]
+
+mod entrypoint;
+pub mod processor;

--- a/examples/rust/packed-len/src/processor.rs
+++ b/examples/rust/packed-len/src/processor.rs
@@ -1,0 +1,29 @@
+//! Program instruction processor
+
+use {
+    solana_program::{
+        account_info::AccountInfo,
+        borsh::get_packed_len,
+        entrypoint::ProgramResult,
+        pubkey::Pubkey,
+    },
+    borsh::BorshSchema,
+};
+
+/// Instruction processor
+pub fn process_instruction(
+    _program_id: &Pubkey,
+    _accounts: &[AccountInfo],
+    _instruction_data: &[u8],
+) -> ProgramResult {
+    // Try to get packed len in BPF
+    let _len = get_packed_len::<MyStruct>();
+
+    Ok(())
+}
+
+#[derive(BorshSchema)]
+struct MyStruct {
+    /// Some data
+    pub field: u8,
+}

--- a/examples/rust/packed-len/tests/functional.rs
+++ b/examples/rust/packed-len/tests/functional.rs
@@ -1,0 +1,31 @@
+#![cfg(feature = "test-bpf")]
+
+use {
+    solana_program::{instruction::Instruction, pubkey::Pubkey},
+    solana_program_test::*,
+    solana_sdk::{signature::Signer, transaction::Transaction},
+    spl_example_packed_len::processor::process_instruction,
+    std::str::FromStr,
+};
+
+#[tokio::test]
+async fn test_packed_len() {
+    let program_id = Pubkey::from_str(&"PackedLen1111111111111111111111111111111111").unwrap();
+    let program_test = ProgramTest::new(
+        "spl_example_packed_len",
+        program_id,
+        processor!(process_instruction),
+    );
+    let (mut banks_client, payer, recent_blockhash) = program_test.start().await;
+
+    let mut transaction = Transaction::new_with_payer(
+        &[Instruction::new_with_bincode(
+            program_id,
+            &(),
+            vec![],
+        )],
+        Some(&payer.pubkey()),
+    );
+    transaction.sign(&[&payer], recent_blockhash);
+    banks_client.process_transaction(transaction).await.unwrap();
+}


### PR DESCRIPTION
Calling `solana_program::get_packed_len()` in a program causes the runtime to error out while loading the ELF.  Before running any code, the runtime fails with:

```
[2021-03-26T12:22:33.756766175Z DEBUG solana_runtime::message_processor] ELF error: Failed to parse ELF file: read-write: bad offset 11139534160
```

I've added a minimal example to reproduce the problem if you run `cargo test-bpf`.