### PR TITLE
adding a dep i needed when building on Ubuntu 20.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Full documentation is available at https://spl.solana.com
 
 1. Install the latest Rust stable from https://rustup.rs/
 2. Install Solana v1.4.7 or later from https://docs.solana.com/cli/install-solana-cli-tools
+3. Install the `libudev` development package for your distribution (`libudev-dev` on Debian-derived distros, `libudev-devel` on Redhat-derived).
 
 ### Build
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Full documentation is available at https://spl.solana.com
 ### Environment Setup
 
 1. Install the latest Rust stable from https://rustup.rs/
-2. Install Solana v1.4.7 or later from https://docs.solana.com/cli/install-solana-cli-tools
+2. Install Solana v1.6.1 or later from https://docs.solana.com/cli/install-solana-cli-tools
 3. Install the `libudev` development package for your distribution (`libudev-dev` on Debian-derived distros, `libudev-devel` on Redhat-derived).
 
 ### Build


### PR DESCRIPTION
when building for the first time:
```
error: failed to run custom build command for `hidapi v1.2.5`

Caused by:
  process didn't exit successfully: `solana-program-library/target/debug/build/hidapi-81175f45ee69e1c2/build-script-build` (exit code: 101)
  --- stdout
  cargo:rerun-if-env-changed=LIBUDEV_NO_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG
  cargo:rerun-if-env-changed=LIBUDEV_STATIC
  cargo:rerun-if-env-changed=LIBUDEV_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_STATIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR

  --- stderr
  thread 'main' panicked at 'Unable to find libudev: Failure { command: "\"pkg-config\" \"--libs\" \"--cflags\" \"libudev\"", output: Output { status: ExitStatus(ExitStatus(256)), stdout: "", stderr: "Package libudev was not found in the pkg-config search path.\nPerhaps you should add the directory containing `libudev.pc\'\nto the PKG_CONFIG_PATH environment variable\nNo package \'libudev\' found\n" } }', ~/.cargo/registry/src/github.com-1ecc6299db9ec823/hidapi-1.2.5/build.rs:53:54
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
error: build failed
```