### PR TITLE
Remove unconditional hidden commitment override for sanity

### DIFF
--- a/token/js/client/util/send-and-confirm-transaction.js
+++ b/token/js/client/util/send-and-confirm-transaction.js
@@ -16,7 +16,5 @@ export function sendAndConfirmTransaction(
 ): Promise<TransactionSignature> {
   return realSendAndConfirmTransaction(connection, transaction, signers, {
     skipPreflight: false,
-    commitment: 'recent',
-    preflightCommitment: 'recent',
   });
 }


### PR DESCRIPTION
Currently, sendTransaction via spl-token is confirmed with `recent`, even if the connection's confirmation is `confirmed` for example.
This means any token transaction async executions could return too early, causing very hard-to-debug issues:

The following harmless-looking code doesn't work _for some time_:

```javascript
        try {
          await this.createAssociatedTokenAccountInternal(     <=  this submits tx and it's confirmed with recent internally
            owner,
            associatedAddress,
          );
        } catch (err) {
          // ignore all errors; for now there is no API compatible way to
          // selectively ignore the expected instruction error if the
          // associated account is existing already.
        }

        // Now this should always succeed
        return await this.getAccountInfo(associatedAddress); <= this is fetched with confirmed internally; could return pre-the-tx state.
```

Also, actually, we're seeing very confusing errors on the wild.

Last and not least, our partners are silently using `recent` for tx confirmation, this is too dangerous imo.

### solution

just use connection's configured commitment value.

I looked around git history maybe https://github.com/solana-labs/solana/issues/12498 is the reason of this? How about doing `recent` for example?

could possibly affecting https://github.com/solana-labs/solana/issues/15705