### PR TITLE
spl-token-cli: support ATA in close, balance, and account-info

### DIFF
--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -1776,7 +1776,7 @@ fn main() {
                         .validator(is_valid_pubkey)
                         .value_name("TOKEN_ACCOUNT_ADDRESS")
                         .takes_value(true)
-                        .required_unless("token")
+                        .conflicts_with("token")
                         .help("Specify the token account to close \
                             [default: owner's associated token account]"),
                 )
@@ -1802,7 +1802,7 @@ fn main() {
                         .value_name("TOKEN_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .long("address")
-                        .required_unless("token")
+                        .conflicts_with("token")
                         .help("Specify the token account to query \
                             [default: owner's associated token account]"),
                 ),
@@ -1863,7 +1863,7 @@ fn main() {
                         .value_name("TOKEN_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .long("address")
-                        .required_unless("token")
+                        .conflicts_with("token")
                         .help("Specify the token account to query"),
                 ),
         )


### PR DESCRIPTION
Various spl-token cli subcommands require account addresses be passed in. This is inconsistent with the general emphasis on ATA, and the standard of one ATA per main wallet address per mint.

This PR updates close, balance, and account-info to expect a mint address and use the ATA by default. Closing or querying a specific account is still available using the `--address` parameter.

Also adds an `Aux` tag to account infos of non-ATAs