### PR TITLE
stake-pool: Rework create validator stake account

### DIFF
--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -278,13 +278,10 @@ fn command_vsa_create(config: &Config, pool: &Pubkey, vote_account: &Pubkey) -> 
             create_validator_stake_account(
                 &spl_stake_pool::id(),
                 &pool,
+                &config.owner.pubkey(),
                 &config.fee_payer.pubkey(),
                 &stake_account,
                 &vote_account,
-                &config.owner.pubkey(),
-                &config.owner.pubkey(),
-                &solana_program::system_program::id(),
-                &stake_program_id(),
             )?,
         ],
         Some(&config.fee_payer.pubkey()),
@@ -292,7 +289,10 @@ fn command_vsa_create(config: &Config, pool: &Pubkey, vote_account: &Pubkey) -> 
 
     let (recent_blockhash, fee_calculator) = config.rpc_client.get_recent_blockhash()?;
     check_fee_payer_balance(config, fee_calculator.calculate_fee(&transaction.message()))?;
-    transaction.sign(&[config.fee_payer.as_ref()], recent_blockhash);
+    transaction.sign(
+        &[config.fee_payer.as_ref(), config.owner.as_ref()],
+        recent_blockhash,
+    );
     send_transaction(&config, transaction)?;
     Ok(())
 }
@@ -378,7 +378,6 @@ fn command_vsa_add(
             &token_receiver,
             &pool_data.pool_mint,
             &spl_token::id(),
-            &stake_program_id(),
         )?,
     ]);
 
@@ -469,7 +468,6 @@ fn command_vsa_remove(
                 &withdraw_from,
                 &pool_data.pool_mint,
                 &spl_token::id(),
-                &stake_program_id(),
             )?,
         ],
         Some(&config.fee_payer.pubkey()),
@@ -646,7 +644,6 @@ fn command_deposit(
             &pool_data.owner_fee_account,
             &pool_data.pool_mint,
             &spl_token::id(),
-            &stake_program_id(),
         )?,
     ]);
 
@@ -984,7 +981,6 @@ fn command_withdraw(
             &withdraw_from,
             &pool_data.pool_mint,
             &spl_token::id(),
-            &stake_program_id(),
             withdraw_stake.pool_amount,
         )?);
     }
@@ -1163,7 +1159,7 @@ fn main() {
                     .help("Max number of validators included in the stake pool"),
             )
         )
-        .subcommand(SubCommand::with_name("create-validator-stake").about("Create a new stake account to use with the pool")
+        .subcommand(SubCommand::with_name("create-validator-stake").about("Create a new stake account to use with the pool. Must be signed by the pool owner.")
             .arg(
                 Arg::with_name("pool")
                     .index(1)

--- a/stake-pool/program/src/stake.rs
+++ b/stake-pool/program/src/stake.rs
@@ -13,6 +13,10 @@ use std::str::FromStr;
 solana_program::declare_id!("Stake11111111111111111111111111111111111111");
 
 const STAKE_CONFIG: &str = "StakeConfig11111111111111111111111111111111";
+/// Id for stake config account
+pub fn config_id() -> Pubkey {
+    Pubkey::from_str(STAKE_CONFIG).unwrap()
+}
 
 /// FIXME copied from solana stake program
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
@@ -489,8 +493,18 @@ pub fn delegate_stake(
         AccountMeta::new_readonly(*vote_pubkey, false),
         AccountMeta::new_readonly(sysvar::clock::id(), false),
         AccountMeta::new_readonly(sysvar::stake_history::id(), false),
-        AccountMeta::new_readonly(Pubkey::from_str(STAKE_CONFIG).unwrap(), false),
+        AccountMeta::new_readonly(config_id(), false),
         AccountMeta::new_readonly(*authorized_pubkey, true),
     ];
     Instruction::new_with_bincode(id(), &StakeInstruction::DelegateStake, account_metas)
+}
+
+/// FIXME copied from stake program
+pub fn deactivate_stake(stake_pubkey: &Pubkey, authorized_pubkey: &Pubkey) -> Instruction {
+    let account_metas = vec![
+        AccountMeta::new(*stake_pubkey, false),
+        AccountMeta::new_readonly(sysvar::clock::id(), false),
+        AccountMeta::new_readonly(*authorized_pubkey, true),
+    ];
+    Instruction::new_with_bincode(id(), &StakeInstruction::Deactivate, account_metas)
 }

--- a/stake-pool/program/tests/vsa_add.rs
+++ b/stake-pool/program/tests/vsa_add.rs
@@ -8,12 +8,12 @@ use {
     helpers::*,
     solana_program::{
         hash::Hash,
-        instruction::{AccountMeta, Instruction},
+        instruction::{AccountMeta, Instruction, InstructionError},
+        pubkey::Pubkey,
         sysvar,
     },
     solana_program_test::*,
     solana_sdk::{
-        instruction::InstructionError,
         signature::{Keypair, Signer},
         transaction::{Transaction, TransactionError},
         transport::TransportError,
@@ -43,7 +43,12 @@ async fn setup() -> (
         &stake_pool_accounts.stake_pool.pubkey(),
     );
     user_stake
-        .create_and_delegate(&mut banks_client, &payer, &recent_blockhash)
+        .create_and_delegate(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            &stake_pool_accounts.owner,
+        )
         .await;
 
     // make pool token account
@@ -170,7 +175,6 @@ async fn test_add_validator_to_pool_with_wrong_token_program_id() {
             &user_pool_account.pubkey(),
             &stake_pool_accounts.pool_mint.pubkey(),
             &stake::id(),
-            &stake::id(),
         )
         .unwrap()],
         Some(&payer.pubkey()),
@@ -215,7 +219,6 @@ async fn test_add_validator_to_pool_with_wrong_pool_mint_account() {
             &user_pool_account.pubkey(),
             &wrong_pool_mint.pubkey(),
             &spl_token::id(),
-            &stake::id(),
         )
         .unwrap()],
         Some(&payer.pubkey()),
@@ -264,7 +267,6 @@ async fn test_add_validator_to_pool_with_wrong_validator_list_account() {
             &user_pool_account.pubkey(),
             &stake_pool_accounts.pool_mint.pubkey(),
             &spl_token::id(),
-            &stake::id(),
         )
         .unwrap()],
         Some(&payer.pubkey()),
@@ -359,7 +361,6 @@ async fn test_not_owner_try_to_add_validator_to_pool() {
             &user_pool_account.pubkey(),
             &stake_pool_accounts.pool_mint.pubkey(),
             &spl_token::id(),
-            &stake::id(),
         )
         .unwrap()],
         Some(&payer.pubkey()),
@@ -437,69 +438,6 @@ async fn test_not_owner_try_to_add_validator_to_pool_without_signature() {
 }
 
 #[tokio::test]
-async fn test_add_validator_to_pool_when_stake_acc_not_in_stake_state() {
-    let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
-    let stake_pool_accounts = StakePoolAccounts::new();
-    stake_pool_accounts
-        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash)
-        .await
-        .unwrap();
-
-    let user = Keypair::new();
-
-    let user_stake = ValidatorStakeAccount::new_with_target_authority(
-        &stake_pool_accounts.deposit_authority,
-        &stake_pool_accounts.stake_pool.pubkey(),
-    );
-    let user_stake_authority = Keypair::new();
-    create_validator_stake_account(
-        &mut banks_client,
-        &payer,
-        &recent_blockhash,
-        &user_stake.stake_pool,
-        &user_stake.stake_account,
-        &user_stake.vote.pubkey(),
-        &user_stake_authority.pubkey(),
-        &user_stake.target_authority,
-    )
-    .await;
-
-    let user_pool_account = Keypair::new();
-    create_token_account(
-        &mut banks_client,
-        &payer,
-        &recent_blockhash,
-        &user_pool_account,
-        &stake_pool_accounts.pool_mint.pubkey(),
-        &user.pubkey(),
-    )
-    .await
-    .unwrap();
-
-    let transaction_error = stake_pool_accounts
-        .add_validator_to_pool(
-            &mut banks_client,
-            &payer,
-            &recent_blockhash,
-            &user_stake.stake_account,
-            &user_pool_account.pubkey(),
-        )
-        .await
-        .unwrap();
-
-    match transaction_error {
-        TransportError::TransactionError(TransactionError::InstructionError(
-            _,
-            InstructionError::Custom(error_index),
-        )) => {
-            let program_error = error::StakePoolError::WrongStakeState as u32;
-            assert_eq!(error_index, program_error);
-        }
-        _ => panic!("Wrong error occurs while try to add validator stake account when it isn't in stake state"),
-    }
-}
-
-#[tokio::test]
 async fn test_add_validator_to_pool_with_wrong_stake_program_id() {
     let (
         mut banks_client,
@@ -510,25 +448,30 @@ async fn test_add_validator_to_pool_with_wrong_stake_program_id() {
         user_pool_account,
     ) = setup().await;
 
-    let wrong_stake_program = Keypair::new();
+    let wrong_stake_program = Pubkey::new_unique();
 
-    let mut transaction = Transaction::new_with_payer(
-        &[instruction::add_validator_to_pool(
-            &id(),
-            &stake_pool_accounts.stake_pool.pubkey(),
-            &stake_pool_accounts.owner.pubkey(),
-            &stake_pool_accounts.deposit_authority,
-            &stake_pool_accounts.withdraw_authority,
-            &stake_pool_accounts.validator_list.pubkey(),
-            &user_stake.stake_account,
-            &user_pool_account.pubkey(),
-            &stake_pool_accounts.pool_mint.pubkey(),
-            &spl_token::id(),
-            &wrong_stake_program.pubkey(),
-        )
-        .unwrap()],
-        Some(&payer.pubkey()),
-    );
+    let accounts = vec![
+        AccountMeta::new(stake_pool_accounts.stake_pool.pubkey(), false),
+        AccountMeta::new_readonly(stake_pool_accounts.owner.pubkey(), true),
+        AccountMeta::new_readonly(stake_pool_accounts.deposit_authority, false),
+        AccountMeta::new_readonly(stake_pool_accounts.withdraw_authority, false),
+        AccountMeta::new(stake_pool_accounts.validator_list.pubkey(), false),
+        AccountMeta::new(user_stake.stake_account, false),
+        AccountMeta::new(user_pool_account.pubkey(), false),
+        AccountMeta::new(stake_pool_accounts.pool_mint.pubkey(), false),
+        AccountMeta::new_readonly(sysvar::clock::id(), false),
+        AccountMeta::new_readonly(sysvar::stake_history::id(), false),
+        AccountMeta::new_readonly(spl_token::id(), false),
+        AccountMeta::new_readonly(wrong_stake_program, false),
+    ];
+    let instruction = Instruction {
+        program_id: id(),
+        accounts,
+        data: instruction::StakePoolInstruction::AddValidatorToPool
+            .try_to_vec()
+            .unwrap(),
+    };
+    let mut transaction = Transaction::new_with_payer(&[instruction], Some(&payer.pubkey()));
     transaction.sign(&[&payer, &stake_pool_accounts.owner], recent_blockhash);
     let transaction_error = banks_client
         .process_transaction(transaction)
@@ -563,7 +506,12 @@ async fn test_add_too_many_validator_stake_accounts() {
         &stake_pool_accounts.stake_pool.pubkey(),
     );
     user_stake
-        .create_and_delegate(&mut banks_client, &payer, &recent_blockhash)
+        .create_and_delegate(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            &stake_pool_accounts.owner,
+        )
         .await;
 
     // make pool token account
@@ -595,7 +543,12 @@ async fn test_add_too_many_validator_stake_accounts() {
         &stake_pool_accounts.stake_pool.pubkey(),
     );
     user_stake
-        .create_and_delegate(&mut banks_client, &payer, &recent_blockhash)
+        .create_and_delegate(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            &stake_pool_accounts.owner,
+        )
         .await;
     let error = stake_pool_accounts
         .add_validator_to_pool(

--- a/stake-pool/program/tests/vsa_create.rs
+++ b/stake-pool/program/tests/vsa_create.rs
@@ -2,22 +2,76 @@
 
 mod helpers;
 
-use crate::solana_program::pubkey::Pubkey;
-use helpers::*;
-
-use bincode::deserialize;
-use solana_program_test::*;
-use solana_sdk::{
-    instruction::InstructionError,
-    signature::{Keypair, Signer},
-    transaction::Transaction,
-    transaction::TransactionError,
-    transport::TransportError,
+use {
+    bincode::deserialize,
+    borsh::BorshSerialize,
+    helpers::*,
+    solana_program::{
+        instruction::{AccountMeta, Instruction, InstructionError},
+        pubkey::Pubkey,
+        system_program, sysvar,
+    },
+    solana_program_test::*,
+    solana_sdk::{
+        signature::{Keypair, Signer},
+        transaction::Transaction,
+        transaction::TransactionError,
+        transport::TransportError,
+    },
+    spl_stake_pool::{error, id, instruction, processor, stake},
 };
-use spl_stake_pool::*;
 
 #[tokio::test]
-async fn test_create_validator_stake_account() {
+async fn success_create_validator_stake_account() {
+    let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
+    let stake_pool_accounts = StakePoolAccounts::new();
+    stake_pool_accounts
+        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash)
+        .await
+        .unwrap();
+
+    let validator = Keypair::new();
+    create_vote(&mut banks_client, &payer, &recent_blockhash, &validator).await;
+
+    let (stake_account, _) = processor::Processor::find_stake_address_for_validator(
+        &id(),
+        &validator.pubkey(),
+        &stake_pool_accounts.stake_pool.pubkey(),
+    );
+
+    let mut transaction = Transaction::new_with_payer(
+        &[instruction::create_validator_stake_account(
+            &id(),
+            &stake_pool_accounts.stake_pool.pubkey(),
+            &stake_pool_accounts.owner.pubkey(),
+            &payer.pubkey(),
+            &stake_account,
+            &validator.pubkey(),
+        )
+        .unwrap()],
+        Some(&payer.pubkey()),
+    );
+    transaction.sign(&[&payer, &stake_pool_accounts.owner], recent_blockhash);
+    banks_client.process_transaction(transaction).await.unwrap();
+
+    // Check authorities
+    let stake = get_account(&mut banks_client, &stake_account).await;
+    let stake_state = deserialize::<stake::StakeState>(&stake.data).unwrap();
+    match stake_state {
+        stake::StakeState::Stake(meta, stake) => {
+            assert_eq!(&meta.authorized.staker, &stake_pool_accounts.owner.pubkey());
+            assert_eq!(
+                &meta.authorized.withdrawer,
+                &stake_pool_accounts.owner.pubkey()
+            );
+            assert_eq!(stake.delegation.voter_pubkey, validator.pubkey());
+        }
+        _ => panic!(),
+    }
+}
+
+#[tokio::test]
+async fn fail_create_validator_stake_account_on_non_vote_account() {
     let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
     let stake_pool_accounts = StakePoolAccounts::new();
     stake_pool_accounts
@@ -26,8 +80,6 @@ async fn test_create_validator_stake_account() {
         .unwrap();
 
     let validator = Pubkey::new_unique();
-    let user_stake_authority = Keypair::new();
-    let user_withdraw_authority = Keypair::new();
 
     let (stake_account, _) = processor::Processor::find_stake_address_for_validator(
         &id(),
@@ -39,37 +91,30 @@ async fn test_create_validator_stake_account() {
         &[instruction::create_validator_stake_account(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
+            &stake_pool_accounts.owner.pubkey(),
             &payer.pubkey(),
             &stake_account,
             &validator,
-            &user_stake_authority.pubkey(),
-            &user_withdraw_authority.pubkey(),
-            &solana_program::system_program::id(),
-            &stake::id(),
         )
         .unwrap()],
         Some(&payer.pubkey()),
     );
-    transaction.sign(&[&payer], recent_blockhash);
-    banks_client.process_transaction(transaction).await.unwrap();
+    transaction.sign(&[&payer, &stake_pool_accounts.owner], recent_blockhash);
+    let transaction_error = banks_client
+        .process_transaction(transaction)
+        .await
+        .err()
+        .unwrap()
+        .unwrap();
 
-    // Check authorities
-    let stake = get_account(&mut banks_client, &stake_account).await;
-    let stake_state = deserialize::<stake::StakeState>(&stake.data).unwrap();
-    match stake_state {
-        stake::StakeState::Initialized(meta) => {
-            assert_eq!(&meta.authorized.staker, &user_stake_authority.pubkey());
-            assert_eq!(
-                &meta.authorized.withdrawer,
-                &user_withdraw_authority.pubkey()
-            );
-        }
-        _ => panic!(),
-    }
+    assert_eq!(
+        transaction_error,
+        TransactionError::InstructionError(0, InstructionError::IncorrectProgramId,)
+    );
 }
 
 #[tokio::test]
-async fn test_create_validator_stake_account_with_incorrect_address() {
+async fn fail_create_validator_stake_account_with_wrong_system_program() {
     let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
     let stake_pool_accounts = StakePoolAccounts::new();
     stake_pool_accounts
@@ -78,26 +123,127 @@ async fn test_create_validator_stake_account_with_incorrect_address() {
         .unwrap();
 
     let validator = Pubkey::new_unique();
-    let user_stake_authority = Keypair::new();
-    let user_withdraw_authority = Keypair::new();
+
+    let (stake_account, _) = processor::Processor::find_stake_address_for_validator(
+        &id(),
+        &validator,
+        &stake_pool_accounts.stake_pool.pubkey(),
+    );
+    let wrong_system_program = Pubkey::new_unique();
+    let accounts = vec![
+        AccountMeta::new_readonly(stake_pool_accounts.stake_pool.pubkey(), false),
+        AccountMeta::new_readonly(stake_pool_accounts.owner.pubkey(), true),
+        AccountMeta::new(payer.pubkey(), true),
+        AccountMeta::new(stake_account, false),
+        AccountMeta::new_readonly(validator, false),
+        AccountMeta::new_readonly(sysvar::rent::id(), false),
+        AccountMeta::new_readonly(sysvar::clock::id(), false),
+        AccountMeta::new_readonly(sysvar::stake_history::id(), false),
+        AccountMeta::new_readonly(stake::config_id(), false),
+        AccountMeta::new_readonly(wrong_system_program, false),
+        AccountMeta::new_readonly(stake::id(), false),
+    ];
+    let instruction = Instruction {
+        program_id: id(),
+        accounts,
+        data: instruction::StakePoolInstruction::CreateValidatorStakeAccount
+            .try_to_vec()
+            .unwrap(),
+    };
+
+    let mut transaction = Transaction::new_with_payer(&[instruction], Some(&payer.pubkey()));
+    transaction.sign(&[&payer, &stake_pool_accounts.owner], recent_blockhash);
+    let transaction_error = banks_client
+        .process_transaction(transaction)
+        .await
+        .err()
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        transaction_error,
+        TransactionError::InstructionError(0, InstructionError::IncorrectProgramId,)
+    );
+}
+
+#[tokio::test]
+async fn fail_create_validator_stake_account_with_wrong_stake_program() {
+    let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
+    let stake_pool_accounts = StakePoolAccounts::new();
+    stake_pool_accounts
+        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash)
+        .await
+        .unwrap();
+
+    let validator = Pubkey::new_unique();
+
+    let (stake_account, _) = processor::Processor::find_stake_address_for_validator(
+        &id(),
+        &validator,
+        &stake_pool_accounts.stake_pool.pubkey(),
+    );
+    let wrong_stake_program = Pubkey::new_unique();
+    let accounts = vec![
+        AccountMeta::new_readonly(stake_pool_accounts.stake_pool.pubkey(), false),
+        AccountMeta::new_readonly(stake_pool_accounts.owner.pubkey(), true),
+        AccountMeta::new(payer.pubkey(), true),
+        AccountMeta::new(stake_account, false),
+        AccountMeta::new_readonly(validator, false),
+        AccountMeta::new_readonly(sysvar::rent::id(), false),
+        AccountMeta::new_readonly(sysvar::clock::id(), false),
+        AccountMeta::new_readonly(sysvar::stake_history::id(), false),
+        AccountMeta::new_readonly(stake::config_id(), false),
+        AccountMeta::new_readonly(system_program::id(), false),
+        AccountMeta::new_readonly(wrong_stake_program, false),
+    ];
+    let instruction = Instruction {
+        program_id: id(),
+        accounts,
+        data: instruction::StakePoolInstruction::CreateValidatorStakeAccount
+            .try_to_vec()
+            .unwrap(),
+    };
+
+    let mut transaction = Transaction::new_with_payer(&[instruction], Some(&payer.pubkey()));
+    transaction.sign(&[&payer, &stake_pool_accounts.owner], recent_blockhash);
+    let transaction_error = banks_client
+        .process_transaction(transaction)
+        .await
+        .err()
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        transaction_error,
+        TransactionError::InstructionError(0, InstructionError::IncorrectProgramId,)
+    );
+}
+
+#[tokio::test]
+async fn fail_create_validator_stake_account_with_incorrect_address() {
+    let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
+    let stake_pool_accounts = StakePoolAccounts::new();
+    stake_pool_accounts
+        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash)
+        .await
+        .unwrap();
+
+    let validator = Pubkey::new_unique();
     let stake_account = Keypair::new();
 
     let mut transaction = Transaction::new_with_payer(
         &[instruction::create_validator_stake_account(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
+            &stake_pool_accounts.owner.pubkey(),
             &payer.pubkey(),
             &stake_account.pubkey(),
             &validator,
-            &user_stake_authority.pubkey(),
-            &user_withdraw_authority.pubkey(),
-            &solana_program::system_program::id(),
-            &stake::id(),
         )
         .unwrap()],
         Some(&payer.pubkey()),
     );
-    transaction.sign(&[&payer], recent_blockhash);
+    transaction.sign(&[&payer, &stake_pool_accounts.owner], recent_blockhash);
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
@@ -114,112 +260,6 @@ async fn test_create_validator_stake_account_with_incorrect_address() {
         }
         _ => panic!(
             "Wrong error occurs while try to create validator stake account with incorrect address"
-        ),
-    }
-}
-
-#[tokio::test]
-async fn test_create_validator_stake_account_with_wrong_system_program() {
-    let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
-    let stake_pool_accounts = StakePoolAccounts::new();
-    stake_pool_accounts
-        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash)
-        .await
-        .unwrap();
-
-    let validator = Pubkey::new_unique();
-    let user_stake_authority = Keypair::new();
-    let user_withdraw_authority = Keypair::new();
-
-    let (stake_account, _) = processor::Processor::find_stake_address_for_validator(
-        &id(),
-        &validator,
-        &stake_pool_accounts.stake_pool.pubkey(),
-    );
-
-    let wrong_system_program = Keypair::new();
-
-    let mut transaction = Transaction::new_with_payer(
-        &[instruction::create_validator_stake_account(
-            &id(),
-            &stake_pool_accounts.stake_pool.pubkey(),
-            &payer.pubkey(),
-            &stake_account,
-            &validator,
-            &user_stake_authority.pubkey(),
-            &user_withdraw_authority.pubkey(),
-            &wrong_system_program.pubkey(),
-            &stake::id(),
-        )
-        .unwrap()],
-        Some(&payer.pubkey()),
-    );
-    transaction.sign(&[&payer], recent_blockhash);
-    let transaction_error = banks_client
-        .process_transaction(transaction)
-        .await
-        .err()
-        .unwrap();
-
-    match transaction_error {
-        TransportError::TransactionError(TransactionError::InstructionError(_, error)) => {
-            assert_eq!(error, InstructionError::IncorrectProgramId);
-        }
-        _ => panic!(
-            "Wrong error occurs while try to create validator stake account with wrong token program ID"
-        ),
-    }
-}
-
-#[tokio::test]
-async fn test_create_validator_stake_account_with_wrong_stake_program() {
-    let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
-    let stake_pool_accounts = StakePoolAccounts::new();
-    stake_pool_accounts
-        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash)
-        .await
-        .unwrap();
-
-    let validator = Pubkey::new_unique();
-    let user_stake_authority = Keypair::new();
-    let user_withdraw_authority = Keypair::new();
-
-    let (stake_account, _) = processor::Processor::find_stake_address_for_validator(
-        &id(),
-        &validator,
-        &stake_pool_accounts.stake_pool.pubkey(),
-    );
-
-    let wrong_stake_program = Keypair::new();
-
-    let mut transaction = Transaction::new_with_payer(
-        &[instruction::create_validator_stake_account(
-            &id(),
-            &stake_pool_accounts.stake_pool.pubkey(),
-            &payer.pubkey(),
-            &stake_account,
-            &validator,
-            &user_stake_authority.pubkey(),
-            &user_withdraw_authority.pubkey(),
-            &solana_program::system_program::id(),
-            &wrong_stake_program.pubkey(),
-        )
-        .unwrap()],
-        Some(&payer.pubkey()),
-    );
-    transaction.sign(&[&payer], recent_blockhash);
-    let transaction_error = banks_client
-        .process_transaction(transaction)
-        .await
-        .err()
-        .unwrap();
-
-    match transaction_error {
-        TransportError::TransactionError(TransactionError::InstructionError(_, error)) => {
-            assert_eq!(error, InstructionError::IncorrectProgramId);
-        }
-        _ => panic!(
-            "Wrong error occurs while try to create validator stake account with wrong stake program ID"
         ),
     }
 }

--- a/stake-pool/program/tests/vsa_remove.rs
+++ b/stake-pool/program/tests/vsa_remove.rs
@@ -8,13 +8,12 @@ use {
     helpers::*,
     solana_program::{
         hash::Hash,
-        instruction::{AccountMeta, Instruction},
+        instruction::{AccountMeta, Instruction, InstructionError},
         pubkey::Pubkey,
         sysvar,
     },
     solana_program_test::*,
     solana_sdk::{
-        instruction::InstructionError,
         signature::{Keypair, Signer},
         transaction::{Transaction, TransactionError},
         transport::TransportError,
@@ -45,7 +44,12 @@ async fn setup() -> (
         &stake_pool_accounts.stake_pool.pubkey(),
     );
     user_stake
-        .create_and_delegate(&mut banks_client, &payer, &recent_blockhash)
+        .create_and_delegate(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            &stake_pool_accounts.owner,
+        )
         .await;
 
     // make pool token account
@@ -165,26 +169,31 @@ async fn test_remove_validator_from_pool_with_wrong_stake_program_id() {
         _,
     ) = setup().await;
 
-    let wrong_stake_program = Keypair::new();
+    let wrong_stake_program = Pubkey::new_unique();
 
     let new_authority = Pubkey::new_unique();
-    let mut transaction = Transaction::new_with_payer(
-        &[instruction::remove_validator_from_pool(
-            &id(),
-            &stake_pool_accounts.stake_pool.pubkey(),
-            &stake_pool_accounts.owner.pubkey(),
-            &stake_pool_accounts.withdraw_authority,
-            &new_authority,
-            &stake_pool_accounts.validator_list.pubkey(),
-            &user_stake.stake_account,
-            &user_pool_account.pubkey(),
-            &stake_pool_accounts.pool_mint.pubkey(),
-            &spl_token::id(),
-            &wrong_stake_program.pubkey(),
-        )
-        .unwrap()],
-        Some(&payer.pubkey()),
-    );
+    let accounts = vec![
+        AccountMeta::new(stake_pool_accounts.stake_pool.pubkey(), false),
+        AccountMeta::new_readonly(stake_pool_accounts.owner.pubkey(), true),
+        AccountMeta::new_readonly(stake_pool_accounts.withdraw_authority, false),
+        AccountMeta::new_readonly(new_authority, false),
+        AccountMeta::new(stake_pool_accounts.validator_list.pubkey(), false),
+        AccountMeta::new(user_stake.stake_account, false),
+        AccountMeta::new(user_pool_account.pubkey(), false),
+        AccountMeta::new(stake_pool_accounts.pool_mint.pubkey(), false),
+        AccountMeta::new_readonly(sysvar::clock::id(), false),
+        AccountMeta::new_readonly(spl_token::id(), false),
+        AccountMeta::new_readonly(wrong_stake_program, false),
+    ];
+    let instruction = Instruction {
+        program_id: id(),
+        accounts,
+        data: instruction::StakePoolInstruction::RemoveValidatorFromPool
+            .try_to_vec()
+            .unwrap(),
+    };
+
+    let mut transaction = Transaction::new_with_payer(&[instruction], Some(&payer.pubkey()));
     transaction.sign(&[&payer, &stake_pool_accounts.owner], recent_blockhash);
     let transaction_error = banks_client
         .process_transaction(transaction)
@@ -230,7 +239,6 @@ async fn test_remove_validator_from_pool_with_wrong_token_program_id() {
             &user_pool_account.pubkey(),
             &stake_pool_accounts.pool_mint.pubkey(),
             &wrong_token_program.pubkey(),
-            &stake::id(),
         )
         .unwrap()],
         Some(&payer.pubkey()),
@@ -277,7 +285,6 @@ async fn test_remove_validator_from_pool_with_wrong_pool_mint_account() {
             &user_pool_account.pubkey(),
             &wrong_pool_mint.pubkey(),
             &spl_token::id(),
-            &stake::id(),
         )
         .unwrap()],
         Some(&payer.pubkey()),
@@ -328,7 +335,6 @@ async fn test_remove_validator_from_pool_with_wrong_validator_list_account() {
             &user_pool_account.pubkey(),
             &stake_pool_accounts.pool_mint.pubkey(),
             &spl_token::id(),
-            &stake::id(),
         )
         .unwrap()],
         Some(&payer.pubkey()),
@@ -444,7 +450,6 @@ async fn test_not_owner_try_to_remove_validator_from_pool() {
             &user_pool_account.pubkey(),
             &stake_pool_accounts.pool_mint.pubkey(),
             &spl_token::id(),
-            &stake::id(),
         )
         .unwrap()],
         Some(&payer.pubkey()),
@@ -520,72 +525,6 @@ async fn test_not_owner_try_to_remove_validator_from_pool_without_signature() {
             assert_eq!(error_index, program_error);
         }
         _ => panic!("Wrong error occurs while malicious try to remove validator stake account without signing transaction"),
-    }
-}
-
-#[tokio::test]
-async fn test_remove_validator_from_pool_when_stake_acc_not_in_stake_state() {
-    let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
-    let stake_pool_accounts = StakePoolAccounts::new();
-    stake_pool_accounts
-        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash)
-        .await
-        .unwrap();
-
-    let user = Keypair::new();
-
-    let user_stake = ValidatorStakeAccount::new_with_target_authority(
-        &stake_pool_accounts.deposit_authority,
-        &stake_pool_accounts.stake_pool.pubkey(),
-    );
-    let user_stake_authority = Keypair::new();
-    create_validator_stake_account(
-        &mut banks_client,
-        &payer,
-        &recent_blockhash,
-        &user_stake.stake_pool,
-        &user_stake.stake_account,
-        &user_stake.vote.pubkey(),
-        &user_stake_authority.pubkey(),
-        &user_stake.target_authority,
-    )
-    .await;
-
-    let user_pool_account = Keypair::new();
-    create_token_account(
-        &mut banks_client,
-        &payer,
-        &recent_blockhash,
-        &user_pool_account,
-        &stake_pool_accounts.pool_mint.pubkey(),
-        &user.pubkey(),
-    )
-    .await
-    .unwrap();
-
-    let new_authority = Pubkey::new_unique();
-
-    let transaction_error = stake_pool_accounts
-        .remove_validator_from_pool(
-            &mut banks_client,
-            &payer,
-            &recent_blockhash,
-            &user_stake.stake_account,
-            &user_pool_account.pubkey(),
-            &new_authority,
-        )
-        .await
-        .unwrap();
-
-    match transaction_error {
-        TransportError::TransactionError(TransactionError::InstructionError(
-            _,
-            InstructionError::Custom(error_index),
-        )) => {
-            let program_error = error::StakePoolError::WrongStakeState as u32;
-            assert_eq!(error_index, program_error);
-        }
-        _ => panic!("Wrong error occurs while try to add validator stake account when it isn't in stake state"),
     }
 }
 


### PR DESCRIPTION
This makes create-validator-stake-account a bit nicer:

* requires owner permission, assigns stake / withdraw authority to the owner
* automatically delegates the stake

Extra updates:

* removes unnecessary accounts as parameters (stake program and system program)
* removes all of the tests that check for a non-delegated validator account (not sure what those were really testing to be honest)

Note that the update to not count the rent-exempt reserve will be done during the `remove-validator` rework for #1501 

Fixes #1276 Fixes #1419 