### PR TITLE
Allow for fixed error mappings

### DIFF
--- a/stake-pool/program/tests/initialize.rs
+++ b/stake-pool/program/tests/initialize.rs
@@ -545,18 +545,15 @@ async fn test_initialize_stake_pool_with_not_rent_exempt_pool() {
         ],
         recent_blockhash,
     );
-    assert_eq!(
-        banks_client
-            .process_transaction(transaction)
-            .await
-            .unwrap_err()
-            .unwrap(),
-        TransactionError::InstructionError(
-            2,
-            InstructionError::InvalidError,
-            // should be InstructionError::AccountNotRentExempt, but the mapping
-            // is wrong
-        )
+    let result = banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert!(
+        result == TransactionError::InstructionError(2, InstructionError::InvalidError,)
+            || result
+                == TransactionError::InstructionError(2, InstructionError::AccountNotRentExempt,)
     );
 }
 
@@ -621,18 +618,16 @@ async fn test_initialize_stake_pool_with_not_rent_exempt_validator_list() {
         recent_blockhash,
     );
 
-    assert_eq!(
-        banks_client
-            .process_transaction(transaction)
-            .await
-            .unwrap_err()
-            .unwrap(),
-        TransactionError::InstructionError(
-            2,
-            InstructionError::InvalidError,
-            // should be InstructionError::AccountNotRentExempt, but the mapping
-            // is wrong
-        )
+    let result = banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    assert!(
+        result == TransactionError::InstructionError(2, InstructionError::InvalidError,)
+            || result
+                == TransactionError::InstructionError(2, InstructionError::AccountNotRentExempt,)
     );
 }
 


### PR DESCRIPTION
Stake pool tests fail when the `ProgramError` mappings are fixed because they check for the current but wrong error.  Instead, loosen the test to allow for both the current and wrong error as well as the correct error.