### PR TITLE
spl-memo: Add back v1 program ID as `spl_memo::v1::id()`

### DIFF
--- a/memo/program/src/lib.rs
+++ b/memo/program/src/lib.rs
@@ -13,6 +13,11 @@ use solana_program::{
     pubkey::Pubkey,
 };
 
+/// Legacy symbols from Memo v1
+pub mod v1 {
+    solana_program::declare_id!("Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo");
+}
+
 solana_program::declare_id!("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr");
 
 /// Build a memo instruction, possibly signed


### PR DESCRIPTION
#### Program

Memo's old program ID is still handy to have around

#### Solution

Add it back under `mod v1`