### PR TITLE
stake-pool: Add rebalancing instruction interface

### DIFF
--- a/stake-pool/program/src/instruction.rs
+++ b/stake-pool/program/src/instruction.rs
@@ -104,7 +104,7 @@ pub enum StakePoolInstruction {
     /// some amount of stake, up to the total activated stake, from the canonical
     /// validator stake account, into its "transient" stake account, defined by:
     ///
-    /// ```
+    /// ```ignore
     /// Pubkey::find_program_address(
     ///     &[&stake_account_address.to_bytes()[..32],], program_id,
     /// )

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -1097,6 +1097,22 @@ impl Processor {
                 msg!("Instruction: RemoveValidatorFromPool");
                 Self::process_remove_validator_from_pool(program_id, accounts)
             }
+            StakePoolInstruction::SplitIntoTransient(_amount) => {
+                msg!("Instruction: SplitIntoTransient");
+                Ok(())
+            }
+            StakePoolInstruction::TransferTransientStake(_amount) => {
+                msg!("Instruction: TransferTransientStake");
+                Ok(())
+            }
+            StakePoolInstruction::DelegateTransientStake => {
+                msg!("Instruction: DelegateTransientStake");
+                Ok(())
+            }
+            StakePoolInstruction::MergeTransientStake => {
+                msg!("Instruction: MergeTransientStake");
+                Ok(())
+            }
             StakePoolInstruction::UpdateValidatorListBalance => {
                 msg!("Instruction: UpdateValidatorListBalance");
                 Self::process_update_validator_list_balance(program_id, accounts)

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -1097,12 +1097,12 @@ impl Processor {
                 msg!("Instruction: RemoveValidatorFromPool");
                 Self::process_remove_validator_from_pool(program_id, accounts)
             }
-            StakePoolInstruction::ValidatorToReserve(_amount) => {
-                msg!("Instruction: SplitIntoTransient");
+            StakePoolInstruction::DecreaseValidatorStake(_amount) => {
+                msg!("Instruction: DecreaseValidatorStake");
                 Ok(())
             }
-            StakePoolInstruction::ReserveToValidator(_amount) => {
-                msg!("Instruction: TransferTransientStake");
+            StakePoolInstruction::IncreaseValidatorStake(_amount) => {
+                msg!("Instruction: IncreaseValidatorStake");
                 Ok(())
             }
             StakePoolInstruction::UpdateValidatorListBalance => {

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -1097,20 +1097,12 @@ impl Processor {
                 msg!("Instruction: RemoveValidatorFromPool");
                 Self::process_remove_validator_from_pool(program_id, accounts)
             }
-            StakePoolInstruction::SplitIntoTransient(_amount) => {
+            StakePoolInstruction::ValidatorToReserve(_amount) => {
                 msg!("Instruction: SplitIntoTransient");
                 Ok(())
             }
-            StakePoolInstruction::TransferTransientStake(_amount) => {
+            StakePoolInstruction::ReserveToValidator(_amount) => {
                 msg!("Instruction: TransferTransientStake");
-                Ok(())
-            }
-            StakePoolInstruction::DelegateTransientStake => {
-                msg!("Instruction: DelegateTransientStake");
-                Ok(())
-            }
-            StakePoolInstruction::MergeTransientStake => {
-                msg!("Instruction: MergeTransientStake");
                 Ok(())
             }
             StakePoolInstruction::UpdateValidatorListBalance => {

--- a/stake-pool/program/src/state.rs
+++ b/stake-pool/program/src/state.rs
@@ -50,6 +50,9 @@ pub struct StakePool {
     /// Validator stake list storage account
     pub validator_list: Pubkey,
 
+    /// Reserve stake account, holds deactivated stake
+    pub reserve_stake: Pubkey,
+
     /// Pool Mint
     pub pool_mint: Pubkey,
 


### PR DESCRIPTION
This can get the discussion going about the interface for the new rebalancing instructions.  I may be missing some sysvars or builtin programs, which will come out in implementation and testing.

Some open questions:
* PDA derivation for transient stake accounts: I'm not wedded to the solution of just using the stake account, and just opted for the simplest thing
* Accounting gets more complicated.  In order to properly keep track of the amount of stake under management, we need to also update the balances in transient accounts.  This proposes sending in pairs of accounts (canonical and transient) during `UpdateValidatorListBalance`.
* This adds a funder for transient stake accounts, but if we make sure that all movements are for `stake_account_rent_exemption + 1` lamport, then we can have all of the transient stake accounts self-funded (unless I'm forgetting how splitting works).

Let me know what you think and how this will work for stake-o-matic!  I'll prefer to merge this once it's ok and then implement bit by bit.