### PR TITLE
Reimplement `spl-stake-pool list` command to use the StakePool/ValidatorList as the primary source of information

### DIFF
--- a/stake-pool/cli/src/client.rs
+++ b/stake-pool/cli/src/client.rs
@@ -18,17 +18,17 @@ use {
 
 type Error = Box<dyn std::error::Error>;
 
-pub(crate) fn get_stake_pool(
+pub fn get_stake_pool(
     rpc_client: &RpcClient,
-    pool_address: &Pubkey,
+    stake_pool_address: &Pubkey,
 ) -> Result<StakePool, Error> {
-    let account_data = rpc_client.get_account_data(pool_address)?;
+    let account_data = rpc_client.get_account_data(stake_pool_address)?;
     let stake_pool = StakePool::try_from_slice(account_data.as_slice())
-        .map_err(|err| format!("Invalid stake pool {}: {}", pool_address, err))?;
+        .map_err(|err| format!("Invalid stake pool {}: {}", stake_pool_address, err))?;
     Ok(stake_pool)
 }
 
-pub(crate) fn get_validator_list(
+pub fn get_validator_list(
     rpc_client: &RpcClient,
     validator_list_address: &Pubkey,
 ) -> Result<ValidatorList, Error> {
@@ -38,7 +38,7 @@ pub(crate) fn get_validator_list(
     Ok(validator_list)
 }
 
-pub(crate) fn get_token_account(
+pub fn get_token_account(
     rpc_client: &RpcClient,
     token_account_address: &Pubkey,
     expected_token_mint: &Pubkey,
@@ -58,7 +58,7 @@ pub(crate) fn get_token_account(
     }
 }
 
-pub(crate) fn get_token_mint(
+pub fn get_token_mint(
     rpc_client: &RpcClient,
     token_mint_address: &Pubkey,
 ) -> Result<spl_token::state::Mint, Error> {

--- a/stake-pool/program/tests/deposit.rs
+++ b/stake-pool/program/tests/deposit.rs
@@ -177,12 +177,12 @@ async fn test_stake_pool_deposit() {
     let stake_pool = get_account(&mut banks_client, &stake_pool_accounts.stake_pool.pubkey()).await;
     let stake_pool = state::StakePool::try_from_slice(&stake_pool.data.as_slice()).unwrap();
     assert_eq!(
-        stake_pool.stake_total,
-        stake_pool_before.stake_total + stake_lamports
+        stake_pool.total_stake_lamports,
+        stake_pool_before.total_stake_lamports + stake_lamports
     );
     assert_eq!(
-        stake_pool.pool_total,
-        stake_pool_before.pool_total + tokens_issued
+        stake_pool.pool_token_supply,
+        stake_pool_before.pool_token_supply + tokens_issued
     );
 
     // Check minted tokens
@@ -208,8 +208,8 @@ async fn test_stake_pool_deposit() {
         .find(&validator_stake_account.vote.pubkey())
         .unwrap();
     assert_eq!(
-        validator_stake_item.balance,
-        validator_stake_item_before.balance + stake_lamports
+        validator_stake_item.stake_lamports,
+        validator_stake_item_before.stake_lamports + stake_lamports
     );
 
     // Check validator stake account actual SOL balance
@@ -217,7 +217,7 @@ async fn test_stake_pool_deposit() {
         get_account(&mut banks_client, &validator_stake_account.stake_account).await;
     assert_eq!(
         validator_stake_account.lamports,
-        validator_stake_item.balance
+        validator_stake_item.stake_lamports
     );
 }
 

--- a/stake-pool/program/tests/update_validator_list_balance.rs
+++ b/stake-pool/program/tests/update_validator_list_balance.rs
@@ -23,7 +23,7 @@ async fn get_list_sum(banks_client: &mut BanksClient, validator_list_key: &Pubke
     validator_list
         .validators
         .iter()
-        .map(|info| info.balance)
+        .map(|info| info.stake_lamports)
         .sum()
 }
 

--- a/stake-pool/program/tests/vsa_add.rs
+++ b/stake-pool/program/tests/vsa_add.rs
@@ -98,14 +98,14 @@ async fn test_add_validator_to_pool() {
         .await;
     assert!(error.is_none());
 
-    let stake_account_balance = banks_client
+    let stake_lamports = banks_client
         .get_account(user_stake.stake_account)
         .await
         .unwrap()
         .unwrap()
         .lamports;
-    let deposit_tokens = stake_account_balance; // For now 1:1 math
-                                                // Check token account balance
+    let deposit_tokens = stake_lamports; // For now 1:1 math
+                                         // Check token account balance
     let token_balance = get_token_balance(&mut banks_client, &user_pool_account.pubkey()).await;
     assert_eq!(token_balance, deposit_tokens);
     let pool_fee_token_balance = get_token_balance(
@@ -131,7 +131,7 @@ async fn test_add_validator_to_pool() {
             validators: vec![state::ValidatorStakeInfo {
                 vote_account: user_stake.vote.pubkey(),
                 last_update_epoch: 0,
-                balance: stake_account_balance,
+                stake_lamports,
             }]
         }
     );

--- a/stake-pool/program/tests/withdraw.rs
+++ b/stake-pool/program/tests/withdraw.rs
@@ -144,12 +144,12 @@ async fn test_stake_pool_withdraw() {
     let stake_pool = get_account(&mut banks_client, &stake_pool_accounts.stake_pool.pubkey()).await;
     let stake_pool = state::StakePool::try_from_slice(&stake_pool.data.as_slice()).unwrap();
     assert_eq!(
-        stake_pool.stake_total,
-        stake_pool_before.stake_total - tokens_to_burn
+        stake_pool.total_stake_lamports,
+        stake_pool_before.total_stake_lamports - tokens_to_burn
     );
     assert_eq!(
-        stake_pool.pool_total,
-        stake_pool_before.pool_total - tokens_to_burn
+        stake_pool.pool_token_supply,
+        stake_pool_before.pool_token_supply - tokens_to_burn
     );
 
     // Check validator stake list storage
@@ -164,8 +164,8 @@ async fn test_stake_pool_withdraw() {
         .find(&validator_stake_account.vote.pubkey())
         .unwrap();
     assert_eq!(
-        validator_stake_item.balance,
-        validator_stake_item_before.balance - tokens_to_burn
+        validator_stake_item.stake_lamports,
+        validator_stake_item_before.stake_lamports - tokens_to_burn
     );
 
     // Check tokens burned
@@ -181,7 +181,7 @@ async fn test_stake_pool_withdraw() {
         get_account(&mut banks_client, &validator_stake_account.stake_account).await;
     assert_eq!(
         validator_stake_account.lamports,
-        validator_stake_item.balance
+        validator_stake_item.stake_lamports
     );
 
     // Check user recipient stake account balance


### PR DESCRIPTION
`spl-stake-pool list -v` then displays information about each actual stake account.

Oh yeah, rename a bunch of variables too.  I guess I'm not quite done scent marking this part of the code base yet...