### PR TITLE
stake-pool: Ensure zero pool token supply on init

### DIFF
--- a/stake-pool/program/src/error.rs
+++ b/stake-pool/program/src/error.rs
@@ -82,6 +82,9 @@ pub enum StakePoolError {
     /// Wrong pool staker account.
     #[error("WrongStaker")]
     WrongStaker,
+    /// Pool token supply is not zero on initialization
+    #[error("NonZeroPoolTokenSupply")]
+    NonZeroPoolTokenSupply,
 }
 impl From<StakePoolError> for ProgramError {
     fn from(e: StakePoolError) -> Self {

--- a/stake-pool/program/src/instruction.rs
+++ b/stake-pool/program/src/instruction.rs
@@ -33,7 +33,7 @@ pub enum StakePoolInstruction {
     ///   1. `[s]` Manager
     ///   2. `[]` Staker
     ///   3. `[w]` Uninitialized validator stake list storage account
-    ///   4. `[]` Pool token mint. Must be non zero, owned by withdraw authority.
+    ///   4. `[]` Pool token mint. Must have zero supply, owned by withdraw authority.
     ///   5. `[]` Pool account to deposit the generated fee for manager.
     ///   6. `[]` Clock sysvar
     ///   7. `[]` Rent sysvar

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -281,7 +281,7 @@ impl Processor {
         }
 
         if manager_fee_info.owner != token_program_info.key {
-            return Err(StakePoolError::InvalidFeeAccount.into());
+            return Err(ProgramError::IncorrectProgramId);
         }
 
         if pool_mint_info.owner != token_program_info.key {
@@ -300,6 +300,10 @@ impl Processor {
             crate::find_withdraw_authority_program_address(program_id, stake_pool_info.key);
 
         let pool_mint = Mint::unpack_from_slice(&pool_mint_info.data.borrow())?;
+
+        if pool_mint.supply != 0 {
+            return Err(StakePoolError::NonZeroPoolTokenSupply.into());
+        }
 
         if !pool_mint.mint_authority.contains(&withdraw_authority_key) {
             return Err(StakePoolError::WrongMintingAuthority.into());
@@ -1155,6 +1159,7 @@ impl PrintProgramError for StakePoolError {
             StakePoolError::WrongMintingAuthority => msg!("Error: Wrong minting authority set for mint pool account"),
             StakePoolError::UnexpectedValidatorListAccountSize=> msg!("Error: The size of the given validator stake list does match the expected amount"),
             StakePoolError::WrongStaker=> msg!("Error: Wrong pool staker account"),
+            StakePoolError::NonZeroPoolTokenSupply => msg!("Error: Pool token supply is not zero on initialization"),
         }
     }
 }

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -126,6 +126,33 @@ pub async fn create_token_account(
     Ok(())
 }
 
+pub async fn mint_tokens(
+    banks_client: &mut BanksClient,
+    payer: &Keypair,
+    recent_blockhash: &Hash,
+    mint: &Pubkey,
+    account: &Pubkey,
+    mint_authority: &Keypair,
+    amount: u64,
+) -> Result<(), TransportError> {
+    let transaction = Transaction::new_signed_with_payer(
+        &[spl_token::instruction::mint_to(
+            &spl_token::id(),
+            mint,
+            account,
+            &mint_authority.pubkey(),
+            &[],
+            amount,
+        )
+        .unwrap()],
+        Some(&payer.pubkey()),
+        &[payer, mint_authority],
+        *recent_blockhash,
+    );
+    banks_client.process_transaction(transaction).await?;
+    Ok(())
+}
+
 pub async fn get_token_balance(banks_client: &mut BanksClient, token: &Pubkey) -> u64 {
     let token_account = banks_client
         .get_account(token.clone())


### PR DESCRIPTION
#### Problem

The stake pool init does not check the supply on the pool token mint, so someone could mint a bunch of tokens to themselves, then reuse that mint for a stake pool.

#### Solution

Add a supply check and test