### PR TITLE
token-swap: Bump crate version to 2.1.0 for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3946,7 +3946,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-swap"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "arbitrary",
  "arrayref",

--- a/token-swap/program/Cargo.toml
+++ b/token-swap/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-swap"
-version = "2.0.0"
+version = "2.1.0"
 description = "Solana Program Library Token Swap"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"


### PR DESCRIPTION
The token swap 2.0.0 crates were published against Solana SDK 1.5, so this version will be built against 1.6.