### PR TITLE
stake-pool: Rework add / remove validator to not use pool tokens

### DIFF
--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -268,7 +268,6 @@ fn command_vsa_add(
     config: &Config,
     stake_pool_address: &Pubkey,
     stake: &Pubkey,
-    token_receiver: &Option<Pubkey>,
 ) -> CommandResult {
     if config.rpc_client.get_stake_activation(*stake, None)?.state != StakeActivationState::Active {
         return Err("Stake account is not active.".into());
@@ -280,25 +279,8 @@ fn command_vsa_add(
 
     let stake_pool = get_stake_pool(&config.rpc_client, stake_pool_address)?;
 
-    let mut total_rent_free_balances: u64 = 0;
-
-    let token_receiver_account = Keypair::new();
-
     let mut instructions: Vec<Instruction> = vec![];
     let mut signers = vec![config.fee_payer.as_ref(), config.staker.as_ref()];
-
-    // Create token account if not specified
-    let token_receiver = unwrap_create_token_account(
-        &config,
-        &token_receiver,
-        &token_receiver_account,
-        &stake_pool.pool_mint,
-        &mut instructions,
-        |balance| {
-            signers.push(&token_receiver_account);
-            total_rent_free_balances += balance;
-        },
-    )?;
 
     // Calculate Deposit and Withdraw stake pool authorities
     let pool_deposit_authority =
@@ -331,9 +313,6 @@ fn command_vsa_add(
             &pool_withdraw_authority,
             &stake_pool.validator_list,
             &stake,
-            &token_receiver,
-            &stake_pool.pool_mint,
-            &spl_token::id(),
         )?,
     ]);
 
@@ -343,7 +322,7 @@ fn command_vsa_add(
     let (recent_blockhash, fee_calculator) = config.rpc_client.get_recent_blockhash()?;
     check_fee_payer_balance(
         config,
-        total_rent_free_balances + fee_calculator.calculate_fee(&transaction.message()),
+        fee_calculator.calculate_fee(&transaction.message()),
     )?;
     unique_signers!(signers);
     transaction.sign(&signers, recent_blockhash);
@@ -355,7 +334,6 @@ fn command_vsa_remove(
     config: &Config,
     stake_pool_address: &Pubkey,
     stake: &Pubkey,
-    withdraw_from: &Pubkey,
     new_authority: &Option<Pubkey>,
 ) -> CommandResult {
     if !config.no_update {
@@ -369,35 +347,8 @@ fn command_vsa_remove(
     let staker_pubkey = config.staker.pubkey();
     let new_authority = new_authority.as_ref().unwrap_or(&staker_pubkey);
 
-    // Calculate amount of tokens to withdraw
-    let stake_account = config.rpc_client.get_account(&stake)?;
-    let tokens_to_withdraw = stake_pool
-        .calc_pool_tokens_for_withdraw(stake_account.lamports)
-        .unwrap();
-
-    // Check balance and mint
-    let token_account =
-        get_token_account(&config.rpc_client, &withdraw_from, &stake_pool.pool_mint)?;
-
-    if token_account.amount < tokens_to_withdraw {
-        let pool_mint = get_token_mint(&config.rpc_client, &stake_pool.pool_mint)?;
-        return Err(format!(
-            "Not enough balance to burn to remove validator stake account from the pool. {} pool tokens needed.",
-            spl_token::amount_to_ui_amount(tokens_to_withdraw, pool_mint.decimals)
-        ).into());
-    }
-
     let mut transaction = Transaction::new_with_payer(
         &[
-            // Approve spending token
-            spl_token::instruction::approve(
-                &spl_token::id(),
-                &withdraw_from,
-                &pool_withdraw_authority,
-                &config.token_owner.pubkey(),
-                &[],
-                tokens_to_withdraw,
-            )?,
             // Create new validator stake account address
             spl_stake_pool::instruction::remove_validator_from_pool(
                 &spl_stake_pool::id(),
@@ -407,9 +358,6 @@ fn command_vsa_remove(
                 &new_authority,
                 &stake_pool.validator_list,
                 &stake,
-                &withdraw_from,
-                &stake_pool.pool_mint,
-                &spl_token::id(),
             )?,
         ],
         Some(&config.fee_payer.pubkey()),
@@ -589,7 +537,7 @@ fn command_list(config: &Config, stake_pool_address: &Pubkey) -> CommandResult {
     for validator in validator_list.validators {
         println!(
             "Validator Vote Account: {}\tBalance: {}\tLast Update Epoch: {}{}",
-            validator.vote_account,
+            validator.voter_pubkey,
             Sol(validator.stake_lamports),
             validator.last_update_epoch,
             if validator.last_update_epoch != epoch_info.epoch {
@@ -669,7 +617,7 @@ fn command_update(config: &Config, stake_pool_address: &Pubkey) -> CommandResult
             } else {
                 let (stake_account, _) = find_stake_program_address(
                     &spl_stake_pool::id(),
-                    &item.vote_account,
+                    &item.voter_pubkey,
                     &stake_pool_address,
                 );
                 Some(stake_account)
@@ -1439,24 +1387,20 @@ fn main() {
         ("add-validator", Some(arg_matches)) => {
             let stake_pool_address = pubkey_of(arg_matches, "pool").unwrap();
             let stake_account = pubkey_of(arg_matches, "stake_account").unwrap();
-            let token_receiver: Option<Pubkey> = pubkey_of(arg_matches, "token_receiver");
             command_vsa_add(
                 &config,
                 &stake_pool_address,
                 &stake_account,
-                &token_receiver,
             )
         }
         ("remove-validator", Some(arg_matches)) => {
             let stake_pool_address = pubkey_of(arg_matches, "pool").unwrap();
             let stake_account = pubkey_of(arg_matches, "stake_account").unwrap();
-            let withdraw_from = pubkey_of(arg_matches, "withdraw_from").unwrap();
             let new_authority: Option<Pubkey> = pubkey_of(arg_matches, "new_authority");
             command_vsa_remove(
                 &config,
                 &stake_pool_address,
                 &stake_account,
-                &withdraw_from,
                 &new_authority,
             )
         }

--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -264,11 +264,7 @@ fn command_vsa_create(
     Ok(())
 }
 
-fn command_vsa_add(
-    config: &Config,
-    stake_pool_address: &Pubkey,
-    stake: &Pubkey,
-) -> CommandResult {
+fn command_vsa_add(config: &Config, stake_pool_address: &Pubkey, stake: &Pubkey) -> CommandResult {
     if config.rpc_client.get_stake_activation(*stake, None)?.state != StakeActivationState::Active {
         return Err("Stake account is not active.".into());
     }
@@ -320,10 +316,7 @@ fn command_vsa_add(
         Transaction::new_with_payer(&instructions, Some(&config.fee_payer.pubkey()));
 
     let (recent_blockhash, fee_calculator) = config.rpc_client.get_recent_blockhash()?;
-    check_fee_payer_balance(
-        config,
-        fee_calculator.calculate_fee(&transaction.message()),
-    )?;
+    check_fee_payer_balance(config, fee_calculator.calculate_fee(&transaction.message()))?;
     unique_signers!(signers);
     transaction.sign(&signers, recent_blockhash);
     send_transaction(&config, transaction)?;
@@ -1387,22 +1380,13 @@ fn main() {
         ("add-validator", Some(arg_matches)) => {
             let stake_pool_address = pubkey_of(arg_matches, "pool").unwrap();
             let stake_account = pubkey_of(arg_matches, "stake_account").unwrap();
-            command_vsa_add(
-                &config,
-                &stake_pool_address,
-                &stake_account,
-            )
+            command_vsa_add(&config, &stake_pool_address, &stake_account)
         }
         ("remove-validator", Some(arg_matches)) => {
             let stake_pool_address = pubkey_of(arg_matches, "pool").unwrap();
             let stake_account = pubkey_of(arg_matches, "stake_account").unwrap();
             let new_authority: Option<Pubkey> = pubkey_of(arg_matches, "new_authority");
-            command_vsa_remove(
-                &config,
-                &stake_pool_address,
-                &stake_account,
-                &new_authority,
-            )
+            command_vsa_remove(&config, &stake_pool_address, &stake_account, &new_authority)
         }
         ("deposit", Some(arg_matches)) => {
             let stake_pool_address = pubkey_of(arg_matches, "pool").unwrap();

--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -530,7 +530,7 @@ fn command_list(config: &Config, stake_pool_address: &Pubkey) -> CommandResult {
     for validator in validator_list.validators {
         println!(
             "Validator Vote Account: {}\tBalance: {}\tLast Update Epoch: {}{}",
-            validator.voter_pubkey,
+            validator.vote_account_address,
             Sol(validator.stake_lamports),
             validator.last_update_epoch,
             if validator.last_update_epoch != epoch_info.epoch {
@@ -610,7 +610,7 @@ fn command_update(config: &Config, stake_pool_address: &Pubkey) -> CommandResult
             } else {
                 let (stake_account, _) = find_stake_program_address(
                     &spl_stake_pool::id(),
-                    &item.voter_pubkey,
+                    &item.vote_account_address,
                     &stake_pool_address,
                 );
                 Some(stake_account)

--- a/stake-pool/program/src/error.rs
+++ b/stake-pool/program/src/error.rs
@@ -85,6 +85,9 @@ pub enum StakePoolError {
     /// Pool token supply is not zero on initialization
     #[error("NonZeroPoolTokenSupply")]
     NonZeroPoolTokenSupply,
+    /// The lamports in the validator stake account is not equal to the minimum
+    #[error("StakeLamportsNotEqualToMinimum")]
+    StakeLamportsNotEqualToMinimum,
 }
 impl From<StakePoolError> for ProgramError {
     fn from(e: StakePoolError) -> Self {

--- a/stake-pool/program/src/lib.rs
+++ b/stake-pool/program/src/lib.rs
@@ -14,13 +14,27 @@ pub mod entrypoint;
 
 // Export current sdk types for downstream users building with a different sdk version
 pub use solana_program;
-use solana_program::pubkey::Pubkey;
+use {
+    crate::stake_program::Meta,
+    solana_program::{native_token::LAMPORTS_PER_SOL, pubkey::Pubkey},
+};
 
 /// Seed for deposit authority seed
 const AUTHORITY_DEPOSIT: &[u8] = b"deposit";
 
 /// Seed for withdraw authority seed
 const AUTHORITY_WITHDRAW: &[u8] = b"withdraw";
+
+/// Minimum amount of staked SOL required in a validator stake account to allow
+/// for merges without a mismatch on credits observed
+pub const MINIMUM_ACTIVE_STAKE: u64 = LAMPORTS_PER_SOL;
+
+/// Get the stake amount under consideration when calculating pool token
+/// conversions
+pub fn minimum_stake_lamports(meta: &Meta) -> u64 {
+    meta.rent_exempt_reserve
+        .saturating_add(MINIMUM_ACTIVE_STAKE)
+}
 
 /// Generates the deposit authority program address for the stake pool
 pub fn find_deposit_authority_program_address(

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -19,7 +19,6 @@ use {
         decode_error::DecodeError,
         entrypoint::ProgramResult,
         msg,
-        native_token::LAMPORTS_PER_SOL,
         program::{invoke, invoke_signed},
         program_error::PrintProgramError,
         program_error::ProgramError,
@@ -32,8 +31,6 @@ use {
     },
     spl_token::state::Mint,
 };
-
-const MAXIMUM_ACTIVE_STAKE: u64 = LAMPORTS_PER_SOL / 1_000;
 
 /// Deserialize the stake state from AccountInfo
 fn get_stake_state(
@@ -503,9 +500,12 @@ impl Processor {
         // Check amount of lamports
         let stake_lamports = **stake_account_info.lamports.borrow();
         let minimum_lamport_amount = minimum_stake_lamports(&meta);
-        let maximum_lamport_amount = minimum_lamport_amount.saturating_add(MAXIMUM_ACTIVE_STAKE);
-        if stake_lamports < minimum_lamport_amount || stake_lamports > maximum_lamport_amount {
-            msg!("Error: attempting to add stake with {} lamports, must have between {} and {} lamports", stake_lamports, minimum_lamport_amount, maximum_lamport_amount);
+        if stake_lamports != minimum_lamport_amount {
+            msg!(
+                "Error: attempting to add stake with {} lamports, must have {} lamports",
+                stake_lamports,
+                minimum_lamport_amount
+            );
             return Err(StakePoolError::StakeLamportsNotEqualToMinimum.into());
         }
 

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -734,8 +734,6 @@ impl Processor {
                 .ok_or(StakePoolError::CalculationFailure)?;
         }
 
-        stake_pool.total_stake_lamports = total_stake_lamports;
-
         let reward_lamports = total_stake_lamports.saturating_sub(previous_lamports);
         let fee = stake_pool
             .calc_fee_amount(reward_lamports)
@@ -758,6 +756,7 @@ impl Processor {
                 .checked_add(fee)
                 .ok_or(StakePoolError::CalculationFailure)?;
         }
+        stake_pool.total_stake_lamports = total_stake_lamports;
         stake_pool.last_update_epoch = clock.epoch;
         stake_pool.serialize(&mut *stake_pool_info.data.borrow_mut())?;
 

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -488,15 +488,15 @@ impl Processor {
         }
 
         let (meta, stake) = get_stake_state(stake_account_info)?;
-        let voter_pubkey = stake.delegation.voter_pubkey;
+        let vote_account_address = stake.delegation.voter_pubkey;
         check_validator_stake_address(
             program_id,
             stake_pool_info.key,
             stake_account_info.key,
-            &voter_pubkey,
+            &vote_account_address,
         )?;
 
-        if validator_list.contains(&voter_pubkey) {
+        if validator_list.contains(&vote_account_address) {
             return Err(StakePoolError::ValidatorAlreadyAdded.into());
         }
 
@@ -531,7 +531,7 @@ impl Processor {
         }
 
         validator_list.validators.push(ValidatorStakeInfo {
-            voter_pubkey,
+            vote_account_address,
             stake_lamports: stake_lamports.saturating_sub(minimum_lamport_amount),
             last_update_epoch: clock.epoch,
         });
@@ -586,15 +586,15 @@ impl Processor {
         }
 
         let (meta, stake) = get_stake_state(stake_account_info)?;
-        let voter_pubkey = stake.delegation.voter_pubkey;
+        let vote_account_address = stake.delegation.voter_pubkey;
         check_validator_stake_address(
             program_id,
             stake_pool_info.key,
             stake_account_info.key,
-            &voter_pubkey,
+            &vote_account_address,
         )?;
 
-        if !validator_list.contains(&voter_pubkey) {
+        if !validator_list.contains(&vote_account_address) {
             return Err(StakePoolError::ValidatorNotFound.into());
         }
 
@@ -628,7 +628,7 @@ impl Processor {
 
         validator_list
             .validators
-            .retain(|item| item.voter_pubkey != voter_pubkey);
+            .retain(|item| item.vote_account_address != vote_account_address);
         validator_list.serialize(&mut *validator_list_info.data.borrow_mut())?;
 
         Ok(())
@@ -666,7 +666,7 @@ impl Processor {
             for (validator_stake_account, (meta, stake)) in
                 validator_stake_accounts.iter().zip(stake_states.iter())
             {
-                if validator_stake_record.voter_pubkey != stake.delegation.voter_pubkey {
+                if validator_stake_record.vote_account_address != stake.delegation.voter_pubkey {
                     continue;
                 }
                 validator_stake_record.last_update_epoch = clock.epoch;
@@ -846,16 +846,16 @@ impl Processor {
         }
 
         let (meta, stake) = get_stake_state(validator_stake_account_info)?;
-        let voter_pubkey = stake.delegation.voter_pubkey;
+        let vote_account_address = stake.delegation.voter_pubkey;
         check_validator_stake_address(
             program_id,
             stake_pool_info.key,
             validator_stake_account_info.key,
-            &voter_pubkey,
+            &vote_account_address,
         )?;
 
         let validator_list_item = validator_list
-            .find_mut(&voter_pubkey)
+            .find_mut(&vote_account_address)
             .ok_or(StakePoolError::ValidatorNotFound)?;
 
         let stake_lamports = **stake_info.lamports.borrow();
@@ -981,16 +981,16 @@ impl Processor {
         }
 
         let (meta, stake) = get_stake_state(stake_split_from)?;
-        let voter_pubkey = stake.delegation.voter_pubkey;
+        let vote_account_address = stake.delegation.voter_pubkey;
         check_validator_stake_address(
             program_id,
             stake_pool_info.key,
             stake_split_from.key,
-            &voter_pubkey,
+            &vote_account_address,
         )?;
 
         let validator_list_item = validator_list
-            .find_mut(&voter_pubkey)
+            .find_mut(&vote_account_address)
             .ok_or(StakePoolError::ValidatorNotFound)?;
 
         let withdraw_lamports = stake_pool

--- a/stake-pool/program/src/stake_program.rs
+++ b/stake-pool/program/src/stake_program.rs
@@ -200,6 +200,14 @@ impl StakeState {
             _ => None,
         }
     }
+    /// Get meta
+    pub fn meta(&self) -> Option<&Meta> {
+        match self {
+            StakeState::Initialized(meta) => Some(meta),
+            StakeState::Stake(meta, _) => Some(meta),
+            _ => None,
+        }
+    }
 }
 
 /// FIXME copied from the stake program

--- a/stake-pool/program/src/state.rs
+++ b/stake-pool/program/src/state.rs
@@ -79,7 +79,7 @@ pub struct StakePool {
 impl StakePool {
     /// calculate the pool tokens that should be minted for a deposit of `stake_lamports`
     pub fn calc_pool_tokens_for_deposit(&self, stake_lamports: u64) -> Option<u64> {
-        if self.total_stake_lamports == 0 {
+        if self.total_stake_lamports == 0 || self.pool_token_supply == 0 {
             return Some(stake_lamports);
         }
         u64::try_from(
@@ -236,7 +236,7 @@ pub struct ValidatorList {
 #[derive(Clone, Copy, Debug, Default, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct ValidatorStakeInfo {
     /// Validator vote account address
-    pub vote_account: Pubkey,
+    pub voter_pubkey: Pubkey,
 
     /// Amount of stake delegated to this validator
     /// Note that if `last_update_epoch` does not match the current epoch then this field may not
@@ -264,23 +264,23 @@ impl ValidatorList {
     }
 
     /// Check if contains validator with particular pubkey
-    pub fn contains(&self, vote_account: &Pubkey) -> bool {
+    pub fn contains(&self, voter_pubkey: &Pubkey) -> bool {
         self.validators
             .iter()
-            .any(|x| x.vote_account == *vote_account)
+            .any(|x| x.voter_pubkey == *voter_pubkey)
     }
 
     /// Check if contains validator with particular pubkey
-    pub fn find_mut(&mut self, vote_account: &Pubkey) -> Option<&mut ValidatorStakeInfo> {
+    pub fn find_mut(&mut self, voter_pubkey: &Pubkey) -> Option<&mut ValidatorStakeInfo> {
         self.validators
             .iter_mut()
-            .find(|x| x.vote_account == *vote_account)
+            .find(|x| x.voter_pubkey == *voter_pubkey)
     }
     /// Check if contains validator with particular pubkey
-    pub fn find(&self, vote_account: &Pubkey) -> Option<&ValidatorStakeInfo> {
+    pub fn find(&self, voter_pubkey: &Pubkey) -> Option<&ValidatorStakeInfo> {
         self.validators
             .iter()
-            .find(|x| x.vote_account == *vote_account)
+            .find(|x| x.voter_pubkey == *voter_pubkey)
     }
 
     /// Check if validator stake list is actually initialized as a validator stake list
@@ -337,17 +337,17 @@ mod test {
             max_validators,
             validators: vec![
                 ValidatorStakeInfo {
-                    vote_account: Pubkey::new_from_array([1; 32]),
+                    voter_pubkey: Pubkey::new_from_array([1; 32]),
                     stake_lamports: 123456789,
                     last_update_epoch: 987654321,
                 },
                 ValidatorStakeInfo {
-                    vote_account: Pubkey::new_from_array([2; 32]),
+                    voter_pubkey: Pubkey::new_from_array([2; 32]),
                     stake_lamports: 998877665544,
                     last_update_epoch: 11223445566,
                 },
                 ValidatorStakeInfo {
-                    vote_account: Pubkey::new_from_array([3; 32]),
+                    voter_pubkey: Pubkey::new_from_array([3; 32]),
                     stake_lamports: 0,
                     last_update_epoch: 999999999999999,
                 },

--- a/stake-pool/program/src/state.rs
+++ b/stake-pool/program/src/state.rs
@@ -236,7 +236,7 @@ pub struct ValidatorList {
 #[derive(Clone, Copy, Debug, Default, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct ValidatorStakeInfo {
     /// Validator vote account address
-    pub voter_pubkey: Pubkey,
+    pub vote_account_address: Pubkey,
 
     /// Amount of stake delegated to this validator
     /// Note that if `last_update_epoch` does not match the current epoch then this field may not
@@ -264,23 +264,23 @@ impl ValidatorList {
     }
 
     /// Check if contains validator with particular pubkey
-    pub fn contains(&self, voter_pubkey: &Pubkey) -> bool {
+    pub fn contains(&self, vote_account_address: &Pubkey) -> bool {
         self.validators
             .iter()
-            .any(|x| x.voter_pubkey == *voter_pubkey)
+            .any(|x| x.vote_account_address == *vote_account_address)
     }
 
     /// Check if contains validator with particular pubkey
-    pub fn find_mut(&mut self, voter_pubkey: &Pubkey) -> Option<&mut ValidatorStakeInfo> {
+    pub fn find_mut(&mut self, vote_account_address: &Pubkey) -> Option<&mut ValidatorStakeInfo> {
         self.validators
             .iter_mut()
-            .find(|x| x.voter_pubkey == *voter_pubkey)
+            .find(|x| x.vote_account_address == *vote_account_address)
     }
     /// Check if contains validator with particular pubkey
-    pub fn find(&self, voter_pubkey: &Pubkey) -> Option<&ValidatorStakeInfo> {
+    pub fn find(&self, vote_account_address: &Pubkey) -> Option<&ValidatorStakeInfo> {
         self.validators
             .iter()
-            .find(|x| x.voter_pubkey == *voter_pubkey)
+            .find(|x| x.vote_account_address == *vote_account_address)
     }
 
     /// Check if validator stake list is actually initialized as a validator stake list
@@ -337,17 +337,17 @@ mod test {
             max_validators,
             validators: vec![
                 ValidatorStakeInfo {
-                    voter_pubkey: Pubkey::new_from_array([1; 32]),
+                    vote_account_address: Pubkey::new_from_array([1; 32]),
                     stake_lamports: 123456789,
                     last_update_epoch: 987654321,
                 },
                 ValidatorStakeInfo {
-                    voter_pubkey: Pubkey::new_from_array([2; 32]),
+                    vote_account_address: Pubkey::new_from_array([2; 32]),
                     stake_lamports: 998877665544,
                     last_update_epoch: 11223445566,
                 },
                 ValidatorStakeInfo {
-                    voter_pubkey: Pubkey::new_from_array([3; 32]),
+                    vote_account_address: Pubkey::new_from_array([3; 32]),
                     stake_lamports: 0,
                     last_update_epoch: 999999999999999,
                 },

--- a/stake-pool/program/tests/update_validator_list_balance.rs
+++ b/stake-pool/program/tests/update_validator_list_balance.rs
@@ -3,9 +3,8 @@
 mod helpers;
 
 use {
-    crate::helpers::TEST_STAKE_AMOUNT,
     helpers::*,
-    solana_program::{native_token, pubkey::Pubkey},
+    solana_program::pubkey::Pubkey,
     solana_program_test::*,
     solana_sdk::signature::Signer,
     spl_stake_pool::stake_program,
@@ -67,6 +66,7 @@ async fn success() {
         .await;
     }
 
+<<<<<<< HEAD
     // Update epoch
     context.warp_to_slot(50_000).unwrap();
 
@@ -84,18 +84,33 @@ async fn success() {
         .await;
 
     // Check balance updated
+||||||| parent of d5547a3 (Rework remove)
+    let rent = banks_client.get_rent().await.unwrap();
+    let stake_rent = rent.minimum_balance(std::mem::size_of::<stake_program::StakeState>())
+        + native_token::sol_to_lamports(1.0);
+
+    // Check current balance in the list
+=======
+    // Check current balance in the list
+>>>>>>> d5547a3 (Rework remove)
     assert_eq!(
         get_validator_list_sum(
             &mut context.banks_client,
             &stake_pool_accounts.validator_list.pubkey()
         )
         .await,
+<<<<<<< HEAD
         STAKE_ACCOUNTS * (stake_rent + TEST_STAKE_AMOUNT + EXTRA_STAKE_AMOUNT)
+||||||| parent of d5547a3 (Rework remove)
+        STAKE_ACCOUNTS * (stake_rent + TEST_STAKE_AMOUNT)
+=======
+        0
+>>>>>>> d5547a3 (Rework remove)
     );
 }
 
 #[tokio::test]
-async fn test_update_validator_list_balance_with_uninitialized_validator_list() {} // TODO
+async fn fail_with_uninitialized_validator_list() {} // TODO
 
 #[tokio::test]
-async fn test_update_validator_list_balance_with_wrong_stake_state() {} // TODO
+async fn fail_with_wrong_stake_state() {} // TODO

--- a/stake-pool/program/tests/update_validator_list_balance.rs
+++ b/stake-pool/program/tests/update_validator_list_balance.rs
@@ -3,11 +3,8 @@
 mod helpers;
 
 use {
-    helpers::*,
-    solana_program::pubkey::Pubkey,
-    solana_program_test::*,
+    helpers::*, solana_program::pubkey::Pubkey, solana_program_test::*,
     solana_sdk::signature::Signer,
-    spl_stake_pool::stake_program,
 };
 
 #[tokio::test]
@@ -38,10 +35,6 @@ async fn success() {
         );
     }
 
-    let rent = context.banks_client.get_rent().await.unwrap();
-    let stake_rent = rent.minimum_balance(std::mem::size_of::<stake_program::StakeState>())
-        + native_token::sol_to_lamports(1.0);
-
     // Check current balance in the list
     assert_eq!(
         get_validator_list_sum(
@@ -49,7 +42,7 @@ async fn success() {
             &stake_pool_accounts.validator_list.pubkey()
         )
         .await,
-        STAKE_ACCOUNTS * (stake_rent + TEST_STAKE_AMOUNT)
+        0,
     );
 
     // Add extra funds, simulating rewards
@@ -66,7 +59,6 @@ async fn success() {
         .await;
     }
 
-<<<<<<< HEAD
     // Update epoch
     context.warp_to_slot(50_000).unwrap();
 
@@ -84,28 +76,13 @@ async fn success() {
         .await;
 
     // Check balance updated
-||||||| parent of d5547a3 (Rework remove)
-    let rent = banks_client.get_rent().await.unwrap();
-    let stake_rent = rent.minimum_balance(std::mem::size_of::<stake_program::StakeState>())
-        + native_token::sol_to_lamports(1.0);
-
-    // Check current balance in the list
-=======
-    // Check current balance in the list
->>>>>>> d5547a3 (Rework remove)
     assert_eq!(
         get_validator_list_sum(
             &mut context.banks_client,
             &stake_pool_accounts.validator_list.pubkey()
         )
         .await,
-<<<<<<< HEAD
-        STAKE_ACCOUNTS * (stake_rent + TEST_STAKE_AMOUNT + EXTRA_STAKE_AMOUNT)
-||||||| parent of d5547a3 (Rework remove)
-        STAKE_ACCOUNTS * (stake_rent + TEST_STAKE_AMOUNT)
-=======
-        0
->>>>>>> d5547a3 (Rework remove)
+        STAKE_ACCOUNTS * EXTRA_STAKE_AMOUNT
     );
 }
 

--- a/stake-pool/program/tests/vsa_add.rs
+++ b/stake-pool/program/tests/vsa_add.rs
@@ -270,7 +270,7 @@ async fn fail_too_much_stake() {
         &payer,
         &recent_blockhash,
         &user_stake.stake_account,
-        1_000_001,
+        1,
     )
     .await;
 

--- a/stake-pool/program/tests/vsa_add.rs
+++ b/stake-pool/program/tests/vsa_add.rs
@@ -89,7 +89,7 @@ async fn success() {
             account_type: state::AccountType::ValidatorList,
             max_validators: stake_pool_accounts.max_validators,
             validators: vec![state::ValidatorStakeInfo {
-                voter_pubkey: user_stake.vote.pubkey(),
+                vote_account_address: user_stake.vote.pubkey(),
                 last_update_epoch: 0,
                 stake_lamports: 0,
             }]

--- a/stake-pool/program/tests/vsa_remove.rs
+++ b/stake-pool/program/tests/vsa_remove.rs
@@ -19,7 +19,8 @@ use {
         transport::TransportError,
     },
     spl_stake_pool::{
-        borsh::try_from_slice_unchecked, error::StakePoolError, id, instruction, stake_program, state,
+        borsh::try_from_slice_unchecked, error::StakePoolError, id, instruction, stake_program,
+        state,
     },
 };
 
@@ -211,7 +212,8 @@ async fn fail_not_at_minimum() {
         &recent_blockhash,
         &user_stake.stake_account,
         1_000_001,
-    ).await;
+    )
+    .await;
 
     let new_authority = Pubkey::new_unique();
     let error = stake_pool_accounts
@@ -227,7 +229,10 @@ async fn fail_not_at_minimum() {
         .unwrap();
     assert_eq!(
         error,
-        TransactionError::InstructionError(0, InstructionError::Custom(StakePoolError::StakeLamportsNotEqualToMinimum as u32)),
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(StakePoolError::StakeLamportsNotEqualToMinimum as u32)
+        ),
     );
 }
 

--- a/stake-pool/program/tests/withdraw.rs
+++ b/stake-pool/program/tests/withdraw.rs
@@ -19,8 +19,8 @@ use {
         transport::TransportError,
     },
     spl_stake_pool::{
-        borsh::try_from_slice_unchecked, error::StakePoolError, id, instruction, minimum_stake_lamports,
-        stake_program, state,
+        borsh::try_from_slice_unchecked, error::StakePoolError, id, instruction,
+        minimum_stake_lamports, stake_program, state,
     },
     spl_token::error::TokenError,
 };
@@ -785,6 +785,9 @@ async fn fail_overdraw_validator() {
         .unwrap();
     assert_eq!(
         error,
-        TransactionError::InstructionError(0, InstructionError::Custom(StakePoolError::StakeLamportsNotEqualToMinimum as u32)),
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(StakePoolError::StakeLamportsNotEqualToMinimum as u32)
+        ),
     );
 }


### PR DESCRIPTION
#### Problem

Adding and removing validators from the pool involves pool tokens, which mixes the staker and manager roles.  The staker should not have to handle any pool tokens to do their work.

#### Solution

* Remove pool tokens from add to pool and remove validator from pool
* Set a required minimum for validator stake accounts (1 SOL + rent exemption)
* Make sure that on add validator / remove validator / withdraw we are respecting that limit
* Update book-keeping to not count the minimum amount

Fixes #1501 