### PR TITLE
Fix `spl-token` CLI offline signing support

### DIFF
--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -303,13 +303,15 @@ fn command_create_account(
         )
     };
 
-    if let Some(account_data) = config
-        .rpc_client
-        .get_account_with_commitment(&account, config.rpc_client.commitment())?
-        .value
-    {
-        if !(account_data.owner == system_program::id() && system_account_ok) {
-            return Err(format!("Error: Account already exists: {}", account).into());
+    if !config.sign_only {
+        if let Some(account_data) = config
+            .rpc_client
+            .get_account_with_commitment(&account, config.rpc_client.commitment())?
+            .value
+        {
+            if !(account_data.owner == system_program::id() && system_account_ok) {
+                return Err(format!("Error: Account already exists: {}", account).into());
+            }
         }
     }
 

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -540,20 +540,20 @@ fn command_transfer(
     let mut recipient_token_account = recipient;
     let mut minimum_balance_for_rent_exemption = 0;
 
-    let recipient_account_owner = config
+    let recipient_is_token_account = config
         .rpc_client
         .get_account_with_commitment(&recipient, config.rpc_client.commitment())?
         .value
-        .map(|account_data| account_data.owner);
+        .map(|account| account.owner == spl_token::id() && account.data.len() == Account::LEN);
 
-    if recipient_account_owner.is_none() && !allow_unfunded_recipient {
+    if recipient_is_token_account.is_none() && !allow_unfunded_recipient {
         return Err("Error: The recipient address is not funded. \
                             Add `--allow-unfunded-recipient` to complete the transfer \
                            "
         .into());
     }
 
-    if Some(spl_token::id()) != recipient_account_owner {
+    if Some(true) != recipient_is_token_account {
         recipient_token_account = get_associated_token_address(&recipient, &mint_pubkey);
         println!(
             "  Recipient associated token account: {}",


### PR DESCRIPTION
#### Problem

A few of `spl-token` CLI's subcommands are still querying RPC in sign-only mode, which breaks offline signing.

#### Summary of  changes

Add `sign_only` gates around RPC calls, with sane defaults in else-clauses where they exist and new CLI args where they don't
Bonus: Fix transfers to ATAs of multisig accounts

Review suggestion: `?w=1`