### PR TITLE
stake-pool: Assess fee as a percentage of rewards

### DIFF
--- a/docs/src/stake-pool.md
+++ b/docs/src/stake-pool.md
@@ -54,8 +54,8 @@ active, the stake pool manager adds it to the stake pool.
 At this point, users can participate with deposits. They must delegate a stake
 account to the one of the validators in the stake pool. Once it's active, the
 user can deposit their stake into the pool in exchange for SPL staking derivatives
-representing their fractional ownership in pool. A percentage of the user's
-deposit goes to the pool manager as a fee.
+representing their fractional ownership in pool. A percentage of the rewards
+earned by the pool goes to the pool manager as a fee.
 
 Over time, as the stake pool accrues staking rewards, the user's fractional
 ownership will be worth more than their initial deposit. Whenever the user chooses,
@@ -153,9 +153,9 @@ The identifier for the SPL token for staking derivatives is
 over the mint.
 
 The pool creator's fee account identifier is
-`3xvXPfQi2SaTkqPV9A7BQwh4GyTe2ZPasfoaCBCnTAJ5`. When users deposit warmed up
-stake accounts into the stake pool, the program will transfer 3% of their
-contribution into this account in the form of SPL token staking derivatives.
+`3xvXPfQi2SaTkqPV9A7BQwh4GyTe2ZPasfoaCBCnTAJ5`. Every epoch, as stake accounts
+in the stake pool earn rewards, the program will mint SPL token staking derivatives
+equal to 3% of the gains on that epoch into this account.
 
 #### Create a validator stake account
 

--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -561,7 +561,6 @@ fn command_deposit(
             &stake,
             &validator_stake_account,
             &token_receiver,
-            &stake_pool.manager_fee_account,
             &stake_pool.pool_mint,
             &spl_token::id(),
         )?,
@@ -689,10 +688,16 @@ fn command_update(config: &Config, stake_pool_address: &Pubkey) -> CommandResult
         )?);
     }
 
+    let (withdraw_authority, _) =
+        find_withdraw_authority_program_address(&spl_stake_pool::id(), &stake_pool_address);
+
     instructions.push(spl_stake_pool::instruction::update_stake_pool_balance(
         &spl_stake_pool::id(),
         stake_pool_address,
         &stake_pool.validator_list,
+        &withdraw_authority,
+        &stake_pool.manager_fee_account,
+        &stake_pool.pool_mint,
     )?);
 
     // TODO: A faster solution would be to send all the `update_validator_list_balance` instructions concurrently

--- a/stake-pool/program/src/instruction.rs
+++ b/stake-pool/program/src/instruction.rs
@@ -41,7 +41,7 @@ pub enum StakePoolInstruction {
     ///   8. `[]` Rent sysvar
     ///   9. `[]` Token program id
     Initialize {
-        /// Deposit fee assessed
+        /// Fee assessed as percentage of perceived rewards
         #[allow(dead_code)] // but it's not
         fee: Fee,
         /// Maximum expected number of validators
@@ -171,7 +171,11 @@ pub enum StakePoolInstruction {
     ///   0. `[w]` Stake pool
     ///   1. `[]` Validator stake list storage account
     ///   2. `[]` Reserve stake account
-    ///   3. `[]` Sysvar clock account
+    ///   3. `[]` Stake pool withdraw authority
+    ///   4. `[w]` Account to receive pool fee tokens
+    ///   5. `[w]` Pool mint account
+    ///   6. `[]` Sysvar clock account
+    ///   7. `[]` Pool token program
     UpdateStakePoolBalance,
 
     ///   Deposit some stake into the pool.  The output is a "pool" token representing ownership
@@ -184,7 +188,6 @@ pub enum StakePoolInstruction {
     ///   4. `[w]` Stake account to join the pool (withdraw should be set to stake pool deposit)
     ///   5. `[w]` Validator stake account for the stake account to be merged with
     ///   6. `[w]` User account to receive pool tokens
-    ///   7. `[w]` Account to receive pool fee tokens
     ///   8. `[w]` Pool token mint account
     ///   9. '[]' Sysvar clock account (required)
     ///   10. '[]' Sysvar stake history account
@@ -397,11 +400,18 @@ pub fn update_stake_pool_balance(
     program_id: &Pubkey,
     stake_pool: &Pubkey,
     validator_list_storage: &Pubkey,
+    withdraw_authority: &Pubkey,
+    manager_fee_account: &Pubkey,
+    stake_pool_mint: &Pubkey,
 ) -> Result<Instruction, ProgramError> {
     let accounts = vec![
         AccountMeta::new(*stake_pool, false),
         AccountMeta::new(*validator_list_storage, false),
+        AccountMeta::new_readonly(*withdraw_authority, false),
+        AccountMeta::new(*manager_fee_account, false),
+        AccountMeta::new(*stake_pool_mint, false),
         AccountMeta::new_readonly(sysvar::clock::id(), false),
+        AccountMeta::new_readonly(spl_token::id(), false),
     ];
     Ok(Instruction {
         program_id: *program_id,
@@ -420,7 +430,6 @@ pub fn deposit(
     stake_to_join: &Pubkey,
     validator_stake_accont: &Pubkey,
     pool_tokens_to: &Pubkey,
-    pool_fee_to: &Pubkey,
     pool_mint: &Pubkey,
     token_program_id: &Pubkey,
 ) -> Result<Instruction, ProgramError> {
@@ -432,7 +441,6 @@ pub fn deposit(
         AccountMeta::new(*stake_to_join, false),
         AccountMeta::new(*validator_stake_accont, false),
         AccountMeta::new(*pool_tokens_to, false),
-        AccountMeta::new(*pool_fee_to, false),
         AccountMeta::new(*pool_mint, false),
         AccountMeta::new_readonly(sysvar::clock::id(), false),
         AccountMeta::new_readonly(sysvar::stake_history::id(), false),

--- a/stake-pool/program/src/instruction.rs
+++ b/stake-pool/program/src/instruction.rs
@@ -13,7 +13,8 @@ use {
     },
 };
 
-/// Fee rate as a ratio, minted on deposit
+/// Fee rate as a ratio, minted on `UpdateStakePoolBalance` as a proportion of
+/// the rewards
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, BorshSerialize, BorshDeserialize, BorshSchema)]
 pub struct Fee {

--- a/stake-pool/program/src/state.rs
+++ b/stake-pool/program/src/state.rs
@@ -107,10 +107,11 @@ impl StakePool {
         .ok()
     }
     /// calculate the fee in pool tokens that goes to the manager
-    pub fn calc_fee_amount(&self, pool_amount: u64) -> Option<u64> {
+    pub fn calc_fee_amount(&self, reward_lamports: u64) -> Option<u64> {
         if self.fee.denominator == 0 {
             return Some(0);
         }
+        let pool_amount = self.calc_pool_tokens_for_deposit(reward_lamports)?;
         u64::try_from(
             (pool_amount as u128)
                 .checked_mul(self.fee.numerator as u128)?
@@ -172,6 +173,15 @@ impl StakePool {
             crate::AUTHORITY_DEPOSIT,
             self.deposit_bump_seed,
         )
+    }
+
+    /// Check staker validity and signature
+    pub(crate) fn check_mint(&self, mint_info: &AccountInfo) -> Result<(), ProgramError> {
+        if *mint_info.key != self.pool_mint {
+            Err(StakePoolError::WrongPoolMint.into())
+        } else {
+            Ok(())
+        }
     }
 
     /// Check manager validity and signature

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -13,8 +13,8 @@ use {
     },
     solana_vote_program::{self, vote_state::VoteState},
     spl_stake_pool::{
-        borsh::get_instance_packed_len, find_stake_program_address, id, instruction, processor,
-        stake_program, state,
+        borsh::{get_instance_packed_len, try_from_slice_unchecked},
+        find_stake_program_address, id, instruction, processor, stake_program, state,
     },
 };
 
@@ -154,14 +154,17 @@ pub async fn mint_tokens(
 }
 
 pub async fn get_token_balance(banks_client: &mut BanksClient, token: &Pubkey) -> u64 {
-    let token_account = banks_client
-        .get_account(token.clone())
-        .await
-        .unwrap()
-        .unwrap();
+    let token_account = banks_client.get_account(*token).await.unwrap().unwrap();
     let account_info: spl_token::state::Account =
         spl_token::state::Account::unpack_from_slice(token_account.data.as_slice()).unwrap();
     account_info.amount
+}
+
+pub async fn get_token_supply(banks_client: &mut BanksClient, mint: &Pubkey) -> u64 {
+    let mint_account = banks_client.get_account(*mint).await.unwrap().unwrap();
+    let account_info =
+        spl_token::state::Mint::unpack_from_slice(mint_account.data.as_slice()).unwrap();
+    account_info.supply
 }
 
 pub async fn delegate_tokens(
@@ -614,6 +617,27 @@ impl StakePoolAccounts {
         Ok(())
     }
 
+    pub async fn update_validator_list_balance(
+        &self,
+        banks_client: &mut BanksClient,
+        payer: &Keypair,
+        recent_blockhash: &Hash,
+        validator_list: &[Pubkey],
+    ) -> Option<TransportError> {
+        let transaction = Transaction::new_signed_with_payer(
+            &[instruction::update_validator_list_balance(
+                &id(),
+                &self.validator_list.pubkey(),
+                validator_list,
+            )
+            .unwrap()],
+            Some(&payer.pubkey()),
+            &[payer],
+            *recent_blockhash,
+        );
+        banks_client.process_transaction(transaction).await.err()
+    }
+
     pub async fn update_stake_pool_balance(
         &self,
         banks_client: &mut BanksClient,
@@ -805,4 +829,23 @@ pub async fn simple_deposit(
         stake_lamports,
         pool_tokens,
     }
+}
+
+pub async fn get_validator_list_sum(
+    banks_client: &mut BanksClient,
+    validator_list_key: &Pubkey,
+) -> u64 {
+    let validator_list = banks_client
+        .get_account(*validator_list_key)
+        .await
+        .unwrap()
+        .unwrap();
+    let validator_list =
+        try_from_slice_unchecked::<state::ValidatorList>(validator_list.data.as_slice()).unwrap();
+
+    validator_list
+        .validators
+        .iter()
+        .map(|info| info.stake_lamports)
+        .sum()
 }

--- a/stake-pool/program/tests/update_stake_pool_balance.rs
+++ b/stake-pool/program/tests/update_stake_pool_balance.rs
@@ -3,28 +3,138 @@
 mod helpers;
 
 use {
+    borsh::BorshDeserialize,
     helpers::*,
+    solana_program::{instruction::InstructionError, pubkey::Pubkey},
     solana_program_test::*,
     solana_sdk::{
-        instruction::InstructionError, signature::Keypair, transaction::TransactionError,
+        signature::{Keypair, Signer},
+        transaction::TransactionError,
     },
-    spl_stake_pool::*,
+    spl_stake_pool::{error::StakePoolError, state::StakePool},
 };
 
-#[tokio::test]
-async fn success() {
-    let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
+async fn setup() -> (
+    ProgramTestContext,
+    StakePoolAccounts,
+    Vec<ValidatorStakeAccount>,
+) {
+    let mut context = program_test().start_with_context().await;
     let stake_pool_accounts = StakePoolAccounts::new();
     stake_pool_accounts
-        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash)
+        .initialize_stake_pool(
+            &mut context.banks_client,
+            &context.payer,
+            &context.last_blockhash,
+        )
         .await
         .unwrap();
 
+    // Add several accounts
+    let mut stake_accounts: Vec<ValidatorStakeAccount> = vec![];
+    const STAKE_ACCOUNTS: u64 = 3;
+    for _ in 0..STAKE_ACCOUNTS {
+        stake_accounts.push(
+            simple_add_validator_to_pool(
+                &mut context.banks_client,
+                &context.payer,
+                &context.last_blockhash,
+                &stake_pool_accounts,
+            )
+            .await,
+        );
+    }
+
+    (context, stake_pool_accounts, stake_accounts)
+}
+
+#[tokio::test]
+async fn success() {
+    let (mut context, stake_pool_accounts, stake_accounts) = setup().await;
+
     let error = stake_pool_accounts
-        .update_stake_pool_balance(&mut banks_client, &payer, &recent_blockhash)
+        .update_stake_pool_balance(
+            &mut context.banks_client,
+            &context.payer,
+            &context.last_blockhash,
+        )
         .await;
     assert!(error.is_none());
-    // TODO: Waiting for the ability to advance clock (or modify account data) to finish the tests
+
+    // Add extra funds, simulating rewards
+    const EXTRA_STAKE_AMOUNT: u64 = 1_000_000;
+    for stake_account in &stake_accounts {
+        transfer(
+            &mut context.banks_client,
+            &context.payer,
+            &context.last_blockhash,
+            &stake_account.stake_account,
+            EXTRA_STAKE_AMOUNT,
+        )
+        .await;
+    }
+
+    let before_balance = get_validator_list_sum(
+        &mut context.banks_client,
+        &stake_pool_accounts.validator_list.pubkey(),
+    )
+    .await;
+
+    // Update epoch
+    context.warp_to_slot(50_000).unwrap();
+
+    // Update list and pool
+    let error = stake_pool_accounts
+        .update_validator_list_balance(
+            &mut context.banks_client,
+            &context.payer,
+            &context.last_blockhash,
+            stake_accounts
+                .iter()
+                .map(|v| v.stake_account)
+                .collect::<Vec<Pubkey>>()
+                .as_slice(),
+        )
+        .await;
+    assert!(error.is_none());
+    let error = stake_pool_accounts
+        .update_stake_pool_balance(
+            &mut context.banks_client,
+            &context.payer,
+            &context.last_blockhash,
+        )
+        .await;
+    assert!(error.is_none());
+
+    // Check fee
+    let after_balance = get_validator_list_sum(
+        &mut context.banks_client,
+        &stake_pool_accounts.validator_list.pubkey(),
+    )
+    .await;
+
+    let actual_fee = get_token_balance(
+        &mut context.banks_client,
+        &stake_pool_accounts.pool_fee_account.pubkey(),
+    )
+    .await;
+    let pool_token_supply = get_token_supply(
+        &mut context.banks_client,
+        &stake_pool_accounts.pool_mint.pubkey(),
+    )
+    .await;
+
+    let stake_pool_info = get_account(
+        &mut context.banks_client,
+        &stake_pool_accounts.stake_pool.pubkey(),
+    )
+    .await;
+    let stake_pool = StakePool::try_from_slice(&stake_pool_info.data).unwrap();
+    let expected_fee = stake_pool
+        .calc_fee_amount(after_balance - before_balance)
+        .unwrap();
+    assert_eq!(actual_fee, expected_fee);
+    assert_eq!(pool_token_supply, stake_pool.pool_token_supply);
 }
 
 #[tokio::test]
@@ -49,7 +159,7 @@ async fn fail_with_wrong_validator_list() {
             _,
             InstructionError::Custom(error_index),
         ) => {
-            let program_error = error::StakePoolError::InvalidValidatorStakeList as u32;
+            let program_error = StakePoolError::InvalidValidatorStakeList as u32;
             assert_eq!(error_index, program_error);
         }
         _ => panic!("Wrong error occurs while try to update pool balance with wrong validator stake list account"),
@@ -78,7 +188,7 @@ async fn fail_with_wrong_pool_fee_account() {
             _,
             InstructionError::Custom(error_index),
         ) => {
-            let program_error = error::StakePoolError::InvalidFeeAccount as u32;
+            let program_error = StakePoolError::InvalidFeeAccount as u32;
             assert_eq!(error_index, program_error);
         }
         _ => panic!("Wrong error occurs while try to update pool balance with wrong validator stake list account"),

--- a/stake-pool/program/tests/update_stake_pool_balance.rs
+++ b/stake-pool/program/tests/update_stake_pool_balance.rs
@@ -6,14 +6,13 @@ use {
     helpers::*,
     solana_program_test::*,
     solana_sdk::{
-        instruction::InstructionError, signature::Keypair, signature::Signer,
-        transaction::Transaction, transaction::TransactionError, transport::TransportError,
+        instruction::InstructionError, signature::Keypair, transaction::TransactionError,
     },
     spl_stake_pool::*,
 };
 
 #[tokio::test]
-async fn test_update_stake_pool_balance() {
+async fn success() {
     let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
     let stake_pool_accounts = StakePoolAccounts::new();
     stake_pool_accounts
@@ -21,42 +20,65 @@ async fn test_update_stake_pool_balance() {
         .await
         .unwrap();
 
+    let error = stake_pool_accounts
+        .update_stake_pool_balance(&mut banks_client, &payer, &recent_blockhash)
+        .await;
+    assert!(error.is_none());
     // TODO: Waiting for the ability to advance clock (or modify account data) to finish the tests
 }
 
 #[tokio::test]
-async fn test_update_stake_pool_balance_with_wrong_validator_list() {
+async fn fail_with_wrong_validator_list() {
     let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
-    let stake_pool_accounts = StakePoolAccounts::new();
+    let mut stake_pool_accounts = StakePoolAccounts::new();
     stake_pool_accounts
         .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash)
         .await
         .unwrap();
 
-    let wrong_stake_list_storage = Keypair::new();
-    let mut transaction = Transaction::new_with_payer(
-        &[instruction::update_stake_pool_balance(
-            &id(),
-            &stake_pool_accounts.stake_pool.pubkey(),
-            &wrong_stake_list_storage.pubkey(),
-        )
-        .unwrap()],
-        Some(&payer.pubkey()),
-    );
-
-    transaction.sign(&[&payer], recent_blockhash);
-    let transaction_error = banks_client
-        .process_transaction(transaction)
+    let wrong_validator_list = Keypair::new();
+    stake_pool_accounts.validator_list = wrong_validator_list;
+    let error = stake_pool_accounts
+        .update_stake_pool_balance(&mut banks_client, &payer, &recent_blockhash)
         .await
-        .err()
+        .unwrap()
         .unwrap();
 
-    match transaction_error {
-        TransportError::TransactionError(TransactionError::InstructionError(
+    match error {
+        TransactionError::InstructionError(
             _,
             InstructionError::Custom(error_index),
-        )) => {
+        ) => {
             let program_error = error::StakePoolError::InvalidValidatorStakeList as u32;
+            assert_eq!(error_index, program_error);
+        }
+        _ => panic!("Wrong error occurs while try to update pool balance with wrong validator stake list account"),
+    }
+}
+
+#[tokio::test]
+async fn fail_with_wrong_pool_fee_account() {
+    let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
+    let mut stake_pool_accounts = StakePoolAccounts::new();
+    stake_pool_accounts
+        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash)
+        .await
+        .unwrap();
+
+    let wrong_fee_account = Keypair::new();
+    stake_pool_accounts.pool_fee_account = wrong_fee_account;
+    let error = stake_pool_accounts
+        .update_stake_pool_balance(&mut banks_client, &payer, &recent_blockhash)
+        .await
+        .unwrap()
+        .unwrap();
+
+    match error {
+        TransactionError::InstructionError(
+            _,
+            InstructionError::Custom(error_index),
+        ) => {
+            let program_error = error::StakePoolError::InvalidFeeAccount as u32;
             assert_eq!(error_index, program_error);
         }
         _ => panic!("Wrong error occurs while try to update pool balance with wrong validator stake list account"),

--- a/stake-pool/program/tests/update_validator_list_balance.rs
+++ b/stake-pool/program/tests/update_validator_list_balance.rs
@@ -8,31 +8,19 @@ use {
     solana_program::{native_token, pubkey::Pubkey},
     solana_program_test::*,
     solana_sdk::signature::Signer,
-    spl_stake_pool::{borsh::try_from_slice_unchecked, stake_program, state},
+    spl_stake_pool::stake_program,
 };
 
-async fn get_list_sum(banks_client: &mut BanksClient, validator_list_key: &Pubkey) -> u64 {
-    let validator_list = banks_client
-        .get_account(*validator_list_key)
-        .await
-        .expect("get_account")
-        .expect("validator stake list not none");
-    let validator_list =
-        try_from_slice_unchecked::<state::ValidatorList>(validator_list.data.as_slice()).unwrap();
-
-    validator_list
-        .validators
-        .iter()
-        .map(|info| info.stake_lamports)
-        .sum()
-}
-
 #[tokio::test]
-async fn test_update_validator_list_balance() {
-    let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
+async fn success() {
+    let mut context = program_test().start_with_context().await;
     let stake_pool_accounts = StakePoolAccounts::new();
     stake_pool_accounts
-        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash)
+        .initialize_stake_pool(
+            &mut context.banks_client,
+            &context.payer,
+            &context.last_blockhash,
+        )
         .await
         .unwrap();
 
@@ -42,44 +30,68 @@ async fn test_update_validator_list_balance() {
     for _ in 0..STAKE_ACCOUNTS {
         stake_accounts.push(
             simple_add_validator_to_pool(
-                &mut banks_client,
-                &payer,
-                &recent_blockhash,
+                &mut context.banks_client,
+                &context.payer,
+                &context.last_blockhash,
                 &stake_pool_accounts,
             )
             .await,
         );
     }
 
-    // Add stake extra funds
-    const EXTRA_STAKE: u64 = 1_000_000;
-
-    for stake_account in stake_accounts {
-        transfer(
-            &mut banks_client,
-            &payer,
-            &recent_blockhash,
-            &stake_account.stake_account,
-            EXTRA_STAKE,
-        )
-        .await;
-    }
-
-    let rent = banks_client.get_rent().await.unwrap();
+    let rent = context.banks_client.get_rent().await.unwrap();
     let stake_rent = rent.minimum_balance(std::mem::size_of::<stake_program::StakeState>())
         + native_token::sol_to_lamports(1.0);
 
     // Check current balance in the list
     assert_eq!(
-        get_list_sum(
-            &mut banks_client,
+        get_validator_list_sum(
+            &mut context.banks_client,
             &stake_pool_accounts.validator_list.pubkey()
         )
         .await,
         STAKE_ACCOUNTS * (stake_rent + TEST_STAKE_AMOUNT)
     );
 
-    // TODO: Execute update list with updated clock
+    // Add extra funds, simulating rewards
+    const EXTRA_STAKE_AMOUNT: u64 = 1_000_000;
+
+    for stake_account in &stake_accounts {
+        transfer(
+            &mut context.banks_client,
+            &context.payer,
+            &context.last_blockhash,
+            &stake_account.stake_account,
+            EXTRA_STAKE_AMOUNT,
+        )
+        .await;
+    }
+
+    // Update epoch
+    context.warp_to_slot(50_000).unwrap();
+
+    stake_pool_accounts
+        .update_validator_list_balance(
+            &mut context.banks_client,
+            &context.payer,
+            &context.last_blockhash,
+            stake_accounts
+                .iter()
+                .map(|v| v.stake_account)
+                .collect::<Vec<Pubkey>>()
+                .as_slice(),
+        )
+        .await;
+
+    // Check balance updated
+    assert_eq!(
+        get_validator_list_sum(
+            &mut context.banks_client,
+            &stake_pool_accounts.validator_list.pubkey()
+        )
+        .await,
+        STAKE_ACCOUNTS * (stake_rent + TEST_STAKE_AMOUNT + EXTRA_STAKE_AMOUNT)
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fixes #1521 

Instead of minting pool tokens on deposit to the manager, we mint them every epoch as a percentage of rewards perceived.  If there were no rewards or the pool lost value due to slashing, no fee is minted.  

From the associated issue:
> Problem
>
> Taking all of the fee upfront on deposit is a simple model, but unnecessarily punishes users who deposit for a short time. Also, it's totally different from the main staking program's reward model if assessing the commission every epoch.
>
> Solution
>
> Adopt a model similar to regular staking, and have the stake pool fee paid out as pool tokens minted every epoch during "update pool balance". Also, update the documentation to reflect this change.