### PR TITLE
stake-pool: Set fee

### DIFF
--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -1487,8 +1487,8 @@ fn main() {
             let numerator = value_t_or_exit!(arg_matches, "fee_numerator", u64);
             let denominator = value_t_or_exit!(arg_matches, "fee_denominator", u64);
             let new_fee = Fee {
-                numerator,
                 denominator,
+                numerator,
             };
             command_set_fee(&config, &stake_pool_address, new_fee)
         }

--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -31,7 +31,7 @@ use {
         find_deposit_authority_program_address, find_stake_program_address,
         find_withdraw_authority_program_address,
         stake_program::{self, StakeAuthorize, StakeState},
-        state::{StakePool, ValidatorList},
+        state::{Fee, StakePool, ValidatorList},
     },
     std::process::exit,
 };
@@ -96,7 +96,7 @@ fn send_transaction(
 
 fn command_create_pool(
     config: &Config,
-    fee: spl_stake_pool::instruction::Fee,
+    fee: Fee,
     max_validators: u32,
 ) -> CommandResult {
     let mint_account = Keypair::new();
@@ -921,6 +921,30 @@ fn command_set_staker(
     Ok(())
 }
 
+fn command_set_fee(
+    config: &Config,
+    stake_pool_address: &Pubkey,
+    new_fee: Fee,
+) -> CommandResult {
+    let mut transaction = Transaction::new_with_payer(
+        &[spl_stake_pool::instruction::set_fee(
+            &spl_stake_pool::id(),
+            &stake_pool_address,
+            &config.manager.pubkey(),
+            new_fee,
+        )],
+        Some(&config.fee_payer.pubkey()),
+    );
+
+    let (recent_blockhash, fee_calculator) = config.rpc_client.get_recent_blockhash()?;
+    check_fee_payer_balance(config, fee_calculator.calculate_fee(&transaction.message()))?;
+    let mut signers = vec![config.fee_payer.as_ref(), config.manager.as_ref()];
+    unique_signers!(signers);
+    transaction.sign(&signers, recent_blockhash);
+    send_transaction(&config, transaction)?;
+    Ok(())
+}
+
 fn main() {
     solana_logger::setup_with_default("solana=info");
 
@@ -1290,6 +1314,36 @@ fn main() {
                     .help("Public key for the new stake pool staker."),
             )
         )
+        .subcommand(SubCommand::with_name("set-fee")
+            .about("Change the fee assessed by the stake pool. Must be signed by the manager.")
+            .arg(
+                Arg::with_name("pool")
+                    .index(1)
+                    .validator(is_pubkey)
+                    .value_name("POOL_ADDRESS")
+                    .takes_value(true)
+                    .required(true)
+                    .help("Stake pool address."),
+            )
+            .arg(
+                Arg::with_name("fee_numerator")
+                    .index(2)
+                    .validator(is_parsable::<u64>)
+                    .value_name("NUMERATOR")
+                    .takes_value(true)
+                    .required(true)
+                    .help("Fee numerator, fee amount is numerator divided by denominator."),
+            )
+            .arg(
+                Arg::with_name("fee_denominator")
+                    .index(3)
+                    .validator(is_parsable::<u64>)
+                    .value_name("DENOMINATOR")
+                    .takes_value(true)
+                    .required(true)
+                    .help("Fee denominator, fee amount is numerator divided by denominator."),
+            )
+        )
         .get_matches();
 
     let mut wallet_manager = None;
@@ -1365,7 +1419,7 @@ fn main() {
             let max_validators = value_t_or_exit!(arg_matches, "max_validators", u32);
             command_create_pool(
                 &config,
-                spl_stake_pool::instruction::Fee {
+                Fee {
                     denominator,
                     numerator,
                 },
@@ -1435,6 +1489,16 @@ fn main() {
             let stake_pool_address = pubkey_of(arg_matches, "pool").unwrap();
             let new_staker = pubkey_of(arg_matches, "new_staker").unwrap();
             command_set_staker(&config, &stake_pool_address, &new_staker)
+        }
+        ("set-fee", Some(arg_matches)) => {
+            let stake_pool_address = pubkey_of(arg_matches, "pool").unwrap();
+            let numerator = value_t_or_exit!(arg_matches, "fee_numerator", u64);
+            let denominator = value_t_or_exit!(arg_matches, "fee_denominator", u64);
+            let new_fee = Fee {
+                numerator,
+                denominator,
+            };
+            command_set_fee(&config, &stake_pool_address, new_fee)
         }
         _ => unreachable!(),
     }

--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -94,11 +94,7 @@ fn send_transaction(
     Ok(())
 }
 
-fn command_create_pool(
-    config: &Config,
-    fee: Fee,
-    max_validators: u32,
-) -> CommandResult {
+fn command_create_pool(config: &Config, fee: Fee, max_validators: u32) -> CommandResult {
     let mint_account = Keypair::new();
     println!("Creating mint {}", mint_account.pubkey());
 
@@ -921,11 +917,7 @@ fn command_set_staker(
     Ok(())
 }
 
-fn command_set_fee(
-    config: &Config,
-    stake_pool_address: &Pubkey,
-    new_fee: Fee,
-) -> CommandResult {
+fn command_set_fee(config: &Config, stake_pool_address: &Pubkey, new_fee: Fee) -> CommandResult {
     let mut transaction = Transaction::new_with_payer(
         &[spl_stake_pool::instruction::set_fee(
             &spl_stake_pool::id(),

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -7,7 +7,7 @@ use {
         instruction::StakePoolInstruction,
         minimum_stake_lamports, stake_program,
         state::{AccountType, Fee, StakePool, ValidatorList, ValidatorStakeInfo},
-        AUTHORITY_DEPOSIT, AUTHORITY_WITHDRAW, MINIMUM_ACTIVE_STAKE
+        AUTHORITY_DEPOSIT, AUTHORITY_WITHDRAW, MINIMUM_ACTIVE_STAKE,
     },
     bincode::deserialize,
     borsh::{BorshDeserialize, BorshSerialize},

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -1117,7 +1117,11 @@ impl Processor {
 
         // Numerator should be smaller than or equal to denominator (fee <= 1)
         if fee.numerator > fee.denominator {
-            msg!("Fee greater than 100%, numerator {}, denominator {}", fee.numerator, fee.denominator);
+            msg!(
+                "Fee greater than 100%, numerator {}, denominator {}",
+                fee.numerator,
+                fee.denominator
+            );
             return Err(StakePoolError::FeeTooHigh.into());
         }
 

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -4,10 +4,10 @@ use {
     crate::{
         borsh::try_from_slice_unchecked,
         error::StakePoolError,
-        instruction::{Fee, StakePoolInstruction},
+        instruction::StakePoolInstruction,
         minimum_stake_lamports, stake_program,
-        state::{AccountType, StakePool, ValidatorList, ValidatorStakeInfo},
-        AUTHORITY_DEPOSIT, AUTHORITY_WITHDRAW, MINIMUM_ACTIVE_STAKE,
+        state::{AccountType, Fee, StakePool, ValidatorList, ValidatorStakeInfo},
+        AUTHORITY_DEPOSIT, AUTHORITY_WITHDRAW, MINIMUM_ACTIVE_STAKE
     },
     bincode::deserialize,
     borsh::{BorshDeserialize, BorshSerialize},
@@ -1096,6 +1096,36 @@ impl Processor {
         Ok(())
     }
 
+    /// Processes [SetFee](enum.Instruction.html).
+    fn process_set_fee(_program_id: &Pubkey, accounts: &[AccountInfo], fee: Fee) -> ProgramResult {
+        let account_info_iter = &mut accounts.iter();
+        let stake_pool_info = next_account_info(account_info_iter)?;
+        let manager_info = next_account_info(account_info_iter)?;
+        let clock_info = next_account_info(account_info_iter)?;
+        let clock = &Clock::from_account_info(clock_info)?;
+
+        let mut stake_pool = StakePool::try_from_slice(&stake_pool_info.data.borrow())?;
+        if !stake_pool.is_valid() {
+            return Err(StakePoolError::InvalidState.into());
+        }
+
+        stake_pool.check_manager(manager_info)?;
+
+        if stake_pool.last_update_epoch < clock.epoch {
+            return Err(StakePoolError::StakeListAndPoolOutOfDate.into());
+        }
+
+        // Numerator should be smaller than or equal to denominator (fee <= 1)
+        if fee.numerator > fee.denominator {
+            msg!("Fee greater than 100%, numerator {}, denominator {}", fee.numerator, fee.denominator);
+            return Err(StakePoolError::FeeTooHigh.into());
+        }
+
+        stake_pool.fee = fee;
+        stake_pool.serialize(&mut *stake_pool_info.data.borrow_mut())?;
+        Ok(())
+    }
+
     /// Processes [SetManager](enum.Instruction.html).
     fn process_set_staker(_program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
         let account_info_iter = &mut accounts.iter();
@@ -1168,6 +1198,10 @@ impl Processor {
             StakePoolInstruction::SetManager => {
                 msg!("Instruction: SetManager");
                 Self::process_set_manager(program_id, accounts)
+            }
+            StakePoolInstruction::SetFee { fee } => {
+                msg!("Instruction: SetFee");
+                Self::process_set_fee(program_id, accounts, fee)
             }
             StakePoolInstruction::SetStaker => {
                 msg!("Instruction: SetStaker");

--- a/stake-pool/program/src/state.rs
+++ b/stake-pool/program/src/state.rs
@@ -1,7 +1,7 @@
 //! State transition types
 
 use {
-    crate::{error::StakePoolError, instruction::Fee},
+    crate::error::StakePoolError,
     borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
     solana_program::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey},
     spl_math::checked_ceil_div::CheckedCeilDiv,
@@ -292,6 +292,17 @@ impl ValidatorList {
     pub fn is_uninitialized(&self) -> bool {
         self.account_type == AccountType::Uninitialized
     }
+}
+
+/// Fee rate as a ratio, minted on `UpdateStakePoolBalance` as a proportion of
+/// the rewards
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, BorshSerialize, BorshDeserialize, BorshSchema)]
+pub struct Fee {
+    /// denominator of the fee ratio
+    pub denominator: u64,
+    /// numerator of the fee ratio
+    pub numerator: u64,
 }
 
 #[cfg(test)]

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -204,7 +204,7 @@ pub async fn create_stake_pool(
     pool_token_account: &Pubkey,
     manager: &Keypair,
     staker: &Pubkey,
-    fee: &instruction::Fee,
+    fee: &state::Fee,
     max_validators: u32,
 ) -> Result<(), TransportError> {
     let rent = banks_client.get_rent().await.unwrap();
@@ -471,7 +471,7 @@ pub struct StakePoolAccounts {
     pub staker: Keypair,
     pub withdraw_authority: Pubkey,
     pub deposit_authority: Pubkey,
-    pub fee: instruction::Fee,
+    pub fee: state::Fee,
     pub max_validators: u32,
 }
 
@@ -502,7 +502,7 @@ impl StakePoolAccounts {
             staker,
             withdraw_authority,
             deposit_authority,
-            fee: instruction::Fee {
+            fee: state::Fee {
                 numerator: 1,
                 denominator: 100,
             },

--- a/stake-pool/program/tests/initialize.rs
+++ b/stake-pool/program/tests/initialize.rs
@@ -142,7 +142,7 @@ async fn fail_initialize_with_already_initialized_validator_list() {
 async fn fail_initialize_with_high_fee() {
     let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
     let mut stake_pool_accounts = StakePoolAccounts::new();
-    stake_pool_accounts.fee = instruction::Fee {
+    stake_pool_accounts.fee = state::Fee {
         numerator: 100001,
         denominator: 100000,
     };

--- a/stake-pool/program/tests/set_fee.rs
+++ b/stake-pool/program/tests/set_fee.rs
@@ -1,0 +1,70 @@
+#![cfg(feature = "test-bpf")]
+
+mod helpers;
+
+use {
+    borsh::{BorshDeserialize, BorshSerialize},
+    helpers::*,
+    solana_program::{
+        hash::Hash,
+        instruction::{AccountMeta, Instruction},
+    },
+    solana_program_test::*,
+    solana_sdk::{
+        instruction::InstructionError, signature::Keypair, signature::Signer,
+        transaction::Transaction, transaction::TransactionError, transport::TransportError,
+    },
+    spl_stake_pool::{error, id, instruction, state::{Fee, StakePool}},
+};
+
+async fn setup() -> (BanksClient, Keypair, Hash, StakePoolAccounts) {
+    let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
+    let stake_pool_accounts = StakePoolAccounts::new();
+    stake_pool_accounts
+        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash)
+        .await
+        .unwrap();
+
+    (
+        banks_client,
+        payer,
+        recent_blockhash,
+        stake_pool_accounts,
+    )
+}
+
+#[tokio::test]
+async fn success() {
+    let (mut banks_client, payer, recent_blockhash, stake_pool_accounts) = setup().await;
+
+    let new_fee = Fee { numerator: 10, denominator: 100 };
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction::set_fee(
+            &id(),
+            &stake_pool_accounts.stake_pool.pubkey(),
+            &stake_pool_accounts.manager.pubkey(),
+            new_fee.clone(),
+        )],
+        Some(&payer.pubkey()),
+        &[&payer, &stake_pool_accounts.manager],
+        recent_blockhash
+    );
+    banks_client.process_transaction(transaction).await.unwrap();
+
+    let stake_pool = get_account(&mut banks_client, &stake_pool_accounts.stake_pool.pubkey()).await;
+    let stake_pool = StakePool::try_from_slice(&stake_pool.data.as_slice()).unwrap();
+
+    assert_eq!(stake_pool.fee, new_fee);
+}
+
+#[tokio::test]
+async fn fail_wrong_manager() {
+}
+
+#[tokio::test]
+async fn fail_bad_fee() {
+}
+
+#[tokio::test]
+async fn fail_not_updated() {
+}

--- a/stake-pool/program/tests/set_fee.rs
+++ b/stake-pool/program/tests/set_fee.rs
@@ -3,41 +3,45 @@
 mod helpers;
 
 use {
-    borsh::{BorshDeserialize, BorshSerialize},
+    borsh::BorshDeserialize,
     helpers::*,
-    solana_program::{
-        hash::Hash,
-        instruction::{AccountMeta, Instruction},
-    },
+    solana_program::hash::Hash,
     solana_program_test::*,
     solana_sdk::{
         instruction::InstructionError, signature::Keypair, signature::Signer,
-        transaction::Transaction, transaction::TransactionError, transport::TransportError,
+        transaction::Transaction, transaction::TransactionError,
     },
-    spl_stake_pool::{error, id, instruction, state::{Fee, StakePool}},
+    spl_stake_pool::{
+        error, id, instruction,
+        state::{Fee, StakePool},
+    },
 };
 
-async fn setup() -> (BanksClient, Keypair, Hash, StakePoolAccounts) {
+async fn setup() -> (BanksClient, Keypair, Hash, StakePoolAccounts, Fee) {
     let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
     let stake_pool_accounts = StakePoolAccounts::new();
     stake_pool_accounts
         .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash)
         .await
         .unwrap();
+    let new_fee = Fee {
+        numerator: 10,
+        denominator: 10,
+    };
 
     (
         banks_client,
         payer,
         recent_blockhash,
         stake_pool_accounts,
+        new_fee,
     )
 }
 
 #[tokio::test]
 async fn success() {
-    let (mut banks_client, payer, recent_blockhash, stake_pool_accounts) = setup().await;
+    let (mut banks_client, payer, recent_blockhash, stake_pool_accounts, new_fee) = setup().await;
 
-    let new_fee = Fee { numerator: 10, denominator: 100 };
     let transaction = Transaction::new_signed_with_payer(
         &[instruction::set_fee(
             &id(),
@@ -47,7 +51,7 @@ async fn success() {
         )],
         Some(&payer.pubkey()),
         &[&payer, &stake_pool_accounts.manager],
-        recent_blockhash
+        recent_blockhash,
     );
     banks_client.process_transaction(transaction).await.unwrap();
 
@@ -59,12 +63,115 @@ async fn success() {
 
 #[tokio::test]
 async fn fail_wrong_manager() {
+    let (mut banks_client, payer, recent_blockhash, stake_pool_accounts, new_fee) = setup().await;
+
+    let wrong_manager = Keypair::new();
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction::set_fee(
+            &id(),
+            &stake_pool_accounts.stake_pool.pubkey(),
+            &wrong_manager.pubkey(),
+            new_fee,
+        )],
+        Some(&payer.pubkey()),
+        &[&payer, &wrong_manager],
+        recent_blockhash,
+    );
+    let error = banks_client
+        .process_transaction(transaction)
+        .await
+        .err()
+        .unwrap()
+        .unwrap();
+
+    match error {
+        TransactionError::InstructionError(_, InstructionError::Custom(error_index)) => {
+            let program_error = error::StakePoolError::WrongManager as u32;
+            assert_eq!(error_index, program_error);
+        }
+        _ => panic!("Wrong error occurs while malicious try to set manager"),
+    }
 }
 
 #[tokio::test]
 async fn fail_bad_fee() {
+    let (mut banks_client, payer, recent_blockhash, stake_pool_accounts, _new_fee) = setup().await;
+
+    let new_fee = Fee {
+        numerator: 11,
+        denominator: 10,
+    };
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction::set_fee(
+            &id(),
+            &stake_pool_accounts.stake_pool.pubkey(),
+            &stake_pool_accounts.manager.pubkey(),
+            new_fee,
+        )],
+        Some(&payer.pubkey()),
+        &[&payer, &stake_pool_accounts.manager],
+        recent_blockhash,
+    );
+    let error = banks_client
+        .process_transaction(transaction)
+        .await
+        .err()
+        .unwrap()
+        .unwrap();
+
+    match error {
+        TransactionError::InstructionError(_, InstructionError::Custom(error_index)) => {
+            let program_error = error::StakePoolError::FeeTooHigh as u32;
+            assert_eq!(error_index, program_error);
+        }
+        _ => panic!("Wrong error occurs while malicious try to set manager"),
+    }
 }
 
 #[tokio::test]
 async fn fail_not_updated() {
+    let mut context = program_test().start_with_context().await;
+    let stake_pool_accounts = StakePoolAccounts::new();
+    stake_pool_accounts
+        .initialize_stake_pool(
+            &mut context.banks_client,
+            &context.payer,
+            &context.last_blockhash,
+        )
+        .await
+        .unwrap();
+    let new_fee = Fee {
+        numerator: 10,
+        denominator: 100,
+    };
+
+    // move forward so an update is required
+    context.warp_to_slot(50_000).unwrap();
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction::set_fee(
+            &id(),
+            &stake_pool_accounts.stake_pool.pubkey(),
+            &stake_pool_accounts.manager.pubkey(),
+            new_fee,
+        )],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &stake_pool_accounts.manager],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .err()
+        .unwrap()
+        .unwrap();
+
+    match error {
+        TransactionError::InstructionError(_, InstructionError::Custom(error_index)) => {
+            let program_error = error::StakePoolError::StakeListAndPoolOutOfDate as u32;
+            assert_eq!(error_index, program_error);
+        }
+        _ => panic!("Wrong error occurs while malicious try to set manager"),
+    }
 }


### PR DESCRIPTION
#### Problem

The manager has no option to update the fee assessed by the stake pool.

#### Solution

Align things with the native vote program, and allow the manager to update the fee!  This does not allow the fee to be changed if the pool hasn't been updated in the current epoch.

While adding the documentation for the new set fee command, I noticed a bit of the documentation was out of date, and rearranged that for the new manager / staker split.

I'll take care of the confirmation step for #1418 in another PR.