### PR TITLE
Fix float measurements

### DIFF
--- a/libraries/math/src/instruction.rs
+++ b/libraries/math/src/instruction.rs
@@ -43,7 +43,16 @@ pub enum MathInstruction {
         /// The multipier
         multiplier: u64,
     },
-    /// Multiply two float valies
+    /// Divide two u64 values
+    ///
+    /// No accounts required for this instruction
+    U64Divide {
+        /// The dividend
+        dividend: u64,
+        /// The divisor
+        divisor: u64,
+    },
+    /// Multiply two float values
     ///
     /// No accounts required for this instruction
     F32Multiply {
@@ -52,7 +61,7 @@ pub enum MathInstruction {
         /// The multipier
         multiplier: f32,
     },
-    /// Divide two float valies
+    /// Divide two float values
     ///
     /// No accounts required for this instruction
     F32Divide {
@@ -111,6 +120,17 @@ pub fn u64_multiply(multiplicand: u64, multiplier: u64) -> Instruction {
         }
         .try_to_vec()
         .unwrap(),
+    }
+}
+
+/// Create PreciseSquareRoot instruction
+pub fn u64_divide(dividend: u64, divisor: u64) -> Instruction {
+    Instruction {
+        program_id: id(),
+        accounts: vec![],
+        data: MathInstruction::U64Divide { dividend, divisor }
+            .try_to_vec()
+            .unwrap(),
     }
 }
 

--- a/libraries/math/src/processor.rs
+++ b/libraries/math/src/processor.rs
@@ -15,6 +15,12 @@ fn u64_multiply(multiplicand: u64, multiplier: u64) -> u64 {
     multiplicand * multiplier
 }
 
+/// u64_divide
+#[inline(never)]
+fn u64_divide(dividend: u64, divisor: u64) -> u64 {
+    dividend / divisor
+}
+
 /// f32_multiply
 #[inline(never)]
 fn f32_multiply(multiplicand: f32, multiplier: f32) -> f32 {
@@ -67,6 +73,14 @@ pub fn process_instruction(
             msg!("Calculating U64 Multiply");
             sol_log_compute_units();
             let result = u64_multiply(multiplicand, multiplier);
+            sol_log_compute_units();
+            msg!("{}", result);
+            Ok(())
+        }
+        MathInstruction::U64Divide { dividend, divisor } => {
+            msg!("Calculating U64 Divide");
+            sol_log_compute_units();
+            let result = u64_divide(dividend, divisor);
             sol_log_compute_units();
             msg!("{}", result);
             Ok(())

--- a/libraries/math/src/processor.rs
+++ b/libraries/math/src/processor.rs
@@ -3,8 +3,29 @@
 use {
     crate::{approximations::sqrt, instruction::MathInstruction, precise_number::PreciseNumber},
     borsh::BorshDeserialize,
-    solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, msg, pubkey::Pubkey},
+    solana_program::{
+        account_info::AccountInfo, entrypoint::ProgramResult, log::sol_log_compute_units, msg,
+        pubkey::Pubkey,
+    },
 };
+
+/// u64_multiply
+#[inline(never)]
+fn u64_multiply(multiplicand: u64, multiplier: u64) -> u64 {
+    multiplicand * multiplier
+}
+
+/// f32_multiply
+#[inline(never)]
+fn f32_multiply(multiplicand: f32, multiplier: f32) -> f32 {
+    multiplicand * multiplier
+}
+
+/// f32_divide
+#[inline(never)]
+fn f32_divide(dividend: f32, divisor: f32) -> f32 {
+    dividend / divisor
+}
 
 /// Instruction processor
 pub fn process_instruction(
@@ -17,19 +38,25 @@ pub fn process_instruction(
         MathInstruction::PreciseSquareRoot { radicand } => {
             msg!("Calculating square root using PreciseNumber");
             let radicand = PreciseNumber::new(radicand as u128).unwrap();
+            sol_log_compute_units();
             let result = radicand.sqrt().unwrap().to_imprecise().unwrap() as u64;
+            sol_log_compute_units();
             msg!("{}", result);
             Ok(())
         }
         MathInstruction::SquareRootU64 { radicand } => {
             msg!("Calculating u64 square root");
+            sol_log_compute_units();
             let result = sqrt(radicand).unwrap();
+            sol_log_compute_units();
             msg!("{}", result);
             Ok(())
         }
         MathInstruction::SquareRootU128 { radicand } => {
             msg!("Calculating u128 square root");
+            sol_log_compute_units();
             let result = sqrt(radicand).unwrap();
+            sol_log_compute_units();
             msg!("{}", result);
             Ok(())
         }
@@ -38,7 +65,9 @@ pub fn process_instruction(
             multiplier,
         } => {
             msg!("Calculating U64 Multiply");
-            let result = multiplicand * multiplier;
+            sol_log_compute_units();
+            let result = u64_multiply(multiplicand, multiplier);
+            sol_log_compute_units();
             msg!("{}", result);
             Ok(())
         }
@@ -47,13 +76,17 @@ pub fn process_instruction(
             multiplier,
         } => {
             msg!("Calculating f32 Multiply");
-            let result = multiplicand * multiplier;
+            sol_log_compute_units();
+            let result = f32_multiply(multiplicand, multiplier);
+            sol_log_compute_units();
             msg!("{}", result as u64);
             Ok(())
         }
         MathInstruction::F32Divide { dividend, divisor } => {
             msg!("Calculating f32 Divide");
-            let result = dividend / divisor;
+            sol_log_compute_units();
+            let result = f32_divide(dividend, divisor);
+            sol_log_compute_units();
             msg!("{}", result as u64);
             Ok(())
         }

--- a/libraries/math/tests/instruction_count.rs
+++ b/libraries/math/tests/instruction_count.rs
@@ -103,6 +103,20 @@ async fn test_u64_multiply() {
 }
 
 #[tokio::test]
+async fn test_u64_divide() {
+    let mut pc = ProgramTest::new("spl_math", id(), processor!(process_instruction));
+
+    pc.set_bpf_compute_max_units(1650);
+
+    let (mut banks_client, payer, recent_blockhash) = pc.start().await;
+
+    let mut transaction =
+        Transaction::new_with_payer(&[instruction::u64_divide(3, 1)], Some(&payer.pubkey()));
+    transaction.sign(&[&payer], recent_blockhash);
+    banks_client.process_transaction(transaction).await.unwrap();
+}
+
+#[tokio::test]
 async fn test_f32_multiply() {
     let mut pc = ProgramTest::new("spl_math", id(), processor!(process_instruction));
 


### PR DESCRIPTION
Due to inlining, it was hard to tell how many instructions the float operations were taking.  Move the float and integer operations out into their own function.

New operation comparison (instructions)
u64 multiply - 8
f32 multiply - 176
f32 divide - 219

