### PR TITLE
stake-pool: Add depositor key on init, required on deposit

### DIFF
--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -28,7 +28,8 @@ use {
     spl_stake_pool::{
         self,
         borsh::get_instance_packed_len,
-        find_transient_stake_program_address, find_stake_program_address, find_withdraw_authority_program_address,
+        find_stake_program_address, find_transient_stake_program_address,
+        find_withdraw_authority_program_address,
         stake_program::{self, StakeState},
         state::{Fee, StakePool, ValidatorList},
         MAX_VALIDATORS_TO_UPDATE,

--- a/stake-pool/program/src/instruction.rs
+++ b/stake-pool/program/src/instruction.rs
@@ -4,7 +4,8 @@
 
 use {
     crate::{
-        find_deposit_authority_program_address, find_stake_program_address, find_transient_stake_program_address, stake_program, state::Fee,
+        find_deposit_authority_program_address, find_stake_program_address,
+        find_transient_stake_program_address, stake_program, state::Fee,
     },
     borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
     solana_program::{
@@ -33,10 +34,8 @@ pub enum StakePoolInstruction {
     ///   8. `[]` Rent sysvar
     ///   9. `[]` Token program id
     ///  10. `[]` (Optional) Deposit authority that must sign all deposits.
-    ///      Defaults to a program address:
-    ///      ```ignore
-    ///      spl_stake_pool::find_deposit_authority_program_address(program_id, stake_pool_address)
-    ///      ```
+    ///      Defaults to the program address generated using
+    ///      `find_deposit_authority_program_address`, making deposits permissionless.
     Initialize {
         /// Fee assessed as percentage of perceived rewards
         #[allow(dead_code)] // but it's not

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -231,7 +231,8 @@ impl Processor {
         let authority_signature_seeds = [&me_bytes[..32], authority_type, &[bump_seed]];
         let signers = &[&authority_signature_seeds[..]];
 
-        let merge_instruction = stake_program::merge(destination_account.key, source_account.key, authority.key);
+        let merge_instruction =
+            stake_program::merge(destination_account.key, source_account.key, authority.key);
 
         invoke_signed(
             &merge_instruction,

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -4,6 +4,7 @@ use {
     crate::{
         borsh::try_from_slice_unchecked,
         error::StakePoolError,
+        find_deposit_authority_program_address,
         instruction::StakePoolInstruction,
         minimum_reserve_lamports, minimum_stake_lamports, stake_program,
         state::{AccountType, Fee, StakePool, ValidatorList, ValidatorStakeInfo},
@@ -203,10 +204,14 @@ impl Processor {
         let authority_signature_seeds = [&me_bytes[..32], authority_type, &[bump_seed]];
         let signers = &[&authority_signature_seeds[..]];
 
-        let ix =
+        let split_instruction =
             stake_program::split_only(stake_account.key, authority.key, amount, split_stake.key);
 
-        invoke_signed(&ix, &[stake_account, split_stake, authority], signers)
+        invoke_signed(
+            &split_instruction,
+            &[stake_account, split_stake, authority],
+            signers,
+        )
     }
 
     /// Issue a stake_merge instruction.
@@ -226,10 +231,10 @@ impl Processor {
         let authority_signature_seeds = [&me_bytes[..32], authority_type, &[bump_seed]];
         let signers = &[&authority_signature_seeds[..]];
 
-        let ix = stake_program::merge(destination_account.key, source_account.key, authority.key);
+        let merge_instruction = stake_program::merge(destination_account.key, source_account.key, authority.key);
 
         invoke_signed(
-            &ix,
+            &merge_instruction,
             &[
                 destination_account,
                 source_account,
@@ -242,16 +247,53 @@ impl Processor {
         )
     }
 
-    /// Issue a stake_set_manager instruction.
-    #[allow(clippy::too_many_arguments)]
+    /// Issue stake_program::authorize instructions to update both authorities
     fn stake_authorize<'a>(
+        stake_account: AccountInfo<'a>,
+        authority: AccountInfo<'a>,
+        new_staker: &Pubkey,
+        clock: AccountInfo<'a>,
+        stake_program_info: AccountInfo<'a>,
+    ) -> Result<(), ProgramError> {
+        let authorize_instruction = stake_program::authorize(
+            stake_account.key,
+            authority.key,
+            new_staker,
+            stake_program::StakeAuthorize::Staker,
+        );
+
+        invoke(
+            &authorize_instruction,
+            &[
+                stake_account.clone(),
+                clock.clone(),
+                authority.clone(),
+                stake_program_info.clone(),
+            ],
+        )?;
+
+        let authorize_instruction = stake_program::authorize(
+            stake_account.key,
+            authority.key,
+            new_staker,
+            stake_program::StakeAuthorize::Withdrawer,
+        );
+
+        invoke(
+            &authorize_instruction,
+            &[stake_account, clock, authority, stake_program_info],
+        )
+    }
+
+    /// Issue stake_program::authorize instructions to update both authorities
+    #[allow(clippy::too_many_arguments)]
+    fn stake_authorize_signed<'a>(
         stake_pool: &Pubkey,
         stake_account: AccountInfo<'a>,
         authority: AccountInfo<'a>,
         authority_type: &[u8],
         bump_seed: u8,
         new_staker: &Pubkey,
-        staker_auth: stake_program::StakeAuthorize,
         clock: AccountInfo<'a>,
         stake_program_info: AccountInfo<'a>,
     ) -> Result<(), ProgramError> {
@@ -259,11 +301,32 @@ impl Processor {
         let authority_signature_seeds = [&me_bytes[..32], authority_type, &[bump_seed]];
         let signers = &[&authority_signature_seeds[..]];
 
-        let ix =
-            stake_program::authorize(stake_account.key, authority.key, new_staker, staker_auth);
+        let authorize_instruction = stake_program::authorize(
+            stake_account.key,
+            authority.key,
+            new_staker,
+            stake_program::StakeAuthorize::Staker,
+        );
 
         invoke_signed(
-            &ix,
+            &authorize_instruction,
+            &[
+                stake_account.clone(),
+                clock.clone(),
+                authority.clone(),
+                stake_program_info.clone(),
+            ],
+            signers,
+        )?;
+
+        let authorize_instruction = stake_program::authorize(
+            stake_account.key,
+            authority.key,
+            new_staker,
+            stake_program::StakeAuthorize::Withdrawer,
+        );
+        invoke_signed(
+            &authorize_instruction,
             &[stake_account, clock, authority, stake_program_info],
             signers,
         )
@@ -414,8 +477,16 @@ impl Processor {
             return Err(StakePoolError::WrongAccountMint.into());
         }
 
-        let (_, deposit_bump_seed) =
-            crate::find_deposit_authority_program_address(program_id, stake_pool_info.key);
+        let deposit_authority = match next_account_info(account_info_iter) {
+            Ok(deposit_authority_info) => {
+                if !deposit_authority_info.is_signer {
+                    return Err(StakePoolError::SignatureMissing.into());
+                } else {
+                    *deposit_authority_info.key
+                }
+            }
+            Err(_) => find_deposit_authority_program_address(program_id, stake_pool_info.key).0,
+        };
         let (withdraw_authority_key, withdraw_bump_seed) =
             crate::find_withdraw_authority_program_address(program_id, stake_pool_info.key);
 
@@ -475,7 +546,7 @@ impl Processor {
         stake_pool.manager = *manager_info.key;
         stake_pool.staker = *staker_info.key;
         stake_pool.reserve_stake = *reserve_stake_info.key;
-        stake_pool.deposit_bump_seed = deposit_bump_seed;
+        stake_pool.deposit_authority = deposit_authority;
         stake_pool.withdraw_bump_seed = withdraw_bump_seed;
         stake_pool.validator_list = *validator_list_info.key;
         stake_pool.pool_mint = *pool_mint_info.key;
@@ -594,8 +665,7 @@ impl Processor {
         let account_info_iter = &mut accounts.iter();
         let stake_pool_info = next_account_info(account_info_iter)?;
         let staker_info = next_account_info(account_info_iter)?;
-        let deposit_info = next_account_info(account_info_iter)?;
-        let withdraw_info = next_account_info(account_info_iter)?;
+        let withdraw_authority_info = next_account_info(account_info_iter)?;
         let validator_list_info = next_account_info(account_info_iter)?;
         let stake_account_info = next_account_info(account_info_iter)?;
         let clock_info = next_account_info(account_info_iter)?;
@@ -614,8 +684,11 @@ impl Processor {
             return Err(StakePoolError::InvalidState.into());
         }
 
-        stake_pool.check_authority_withdraw(withdraw_info.key, program_id, stake_pool_info.key)?;
-        stake_pool.check_authority_deposit(deposit_info.key, program_id, stake_pool_info.key)?;
+        stake_pool.check_authority_withdraw(
+            withdraw_authority_info.key,
+            program_id,
+            stake_pool_info.key,
+        )?;
 
         stake_pool.check_staker(staker_info)?;
 
@@ -645,6 +718,11 @@ impl Processor {
             &vote_account_address,
         )?;
 
+        if meta.lockup != stake_program::Lockup::default() {
+            msg!("Invalid lockup exists on validator stake account");
+            return Err(StakePoolError::WrongStakeState.into());
+        }
+
         if validator_list.contains(&vote_account_address) {
             return Err(StakePoolError::ValidatorAlreadyAdded.into());
         }
@@ -665,22 +743,13 @@ impl Processor {
         //Self::check_stake_activation(stake_account_info, clock, stake_history)?;
 
         // Update Withdrawer and Staker authority to the program withdraw authority
-        for authority in &[
-            stake_program::StakeAuthorize::Withdrawer,
-            stake_program::StakeAuthorize::Staker,
-        ] {
-            Self::stake_authorize(
-                stake_pool_info.key,
-                stake_account_info.clone(),
-                deposit_info.clone(),
-                AUTHORITY_DEPOSIT,
-                stake_pool.deposit_bump_seed,
-                withdraw_info.key,
-                *authority,
-                clock_info.clone(),
-                stake_program_info.clone(),
-            )?;
-        }
+        Self::stake_authorize(
+            stake_account_info.clone(),
+            staker_info.clone(),
+            withdraw_authority_info.key,
+            clock_info.clone(),
+            stake_program_info.clone(),
+        )?;
 
         validator_list.validators.push(ValidatorStakeInfo {
             vote_account_address,
@@ -700,7 +769,7 @@ impl Processor {
         let account_info_iter = &mut accounts.iter();
         let stake_pool_info = next_account_info(account_info_iter)?;
         let staker_info = next_account_info(account_info_iter)?;
-        let withdraw_info = next_account_info(account_info_iter)?;
+        let withdraw_authority_info = next_account_info(account_info_iter)?;
         let new_stake_authority_info = next_account_info(account_info_iter)?;
         let validator_list_info = next_account_info(account_info_iter)?;
         let stake_account_info = next_account_info(account_info_iter)?;
@@ -717,7 +786,11 @@ impl Processor {
             return Err(StakePoolError::InvalidState.into());
         }
 
-        stake_pool.check_authority_withdraw(withdraw_info.key, program_id, stake_pool_info.key)?;
+        stake_pool.check_authority_withdraw(
+            withdraw_authority_info.key,
+            program_id,
+            stake_pool_info.key,
+        )?;
         stake_pool.check_staker(staker_info)?;
 
         if stake_pool.last_update_epoch < clock.epoch {
@@ -772,22 +845,16 @@ impl Processor {
             return Err(StakePoolError::StakeLamportsNotEqualToMinimum.into());
         }
 
-        for authority in &[
-            stake_program::StakeAuthorize::Withdrawer,
-            stake_program::StakeAuthorize::Staker,
-        ] {
-            Self::stake_authorize(
-                stake_pool_info.key,
-                stake_account_info.clone(),
-                withdraw_info.clone(),
-                AUTHORITY_WITHDRAW,
-                stake_pool.withdraw_bump_seed,
-                new_stake_authority_info.key,
-                *authority,
-                clock_info.clone(),
-                stake_program_info.clone(),
-            )?;
-        }
+        Self::stake_authorize_signed(
+            stake_pool_info.key,
+            stake_account_info.clone(),
+            withdraw_authority_info.clone(),
+            AUTHORITY_WITHDRAW,
+            stake_pool.withdraw_bump_seed,
+            new_stake_authority_info.key,
+            clock_info.clone(),
+            stake_program_info.clone(),
+        )?;
 
         validator_list
             .validators
@@ -1381,8 +1448,8 @@ impl Processor {
         let account_info_iter = &mut accounts.iter();
         let stake_pool_info = next_account_info(account_info_iter)?;
         let validator_list_info = next_account_info(account_info_iter)?;
-        let deposit_info = next_account_info(account_info_iter)?;
-        let withdraw_info = next_account_info(account_info_iter)?;
+        let deposit_authority_info = next_account_info(account_info_iter)?;
+        let withdraw_authority_info = next_account_info(account_info_iter)?;
         let stake_info = next_account_info(account_info_iter)?;
         let validator_stake_account_info = next_account_info(account_info_iter)?;
         let dest_user_info = next_account_info(account_info_iter)?;
@@ -1405,8 +1472,12 @@ impl Processor {
 
         //Self::check_stake_activation(stake_info, clock, stake_history)?;
 
-        stake_pool.check_authority_withdraw(withdraw_info.key, program_id, stake_pool_info.key)?;
-        stake_pool.check_authority_deposit(deposit_info.key, program_id, stake_pool_info.key)?;
+        stake_pool.check_authority_withdraw(
+            withdraw_authority_info.key,
+            program_id,
+            stake_pool_info.key,
+        )?;
+        stake_pool.check_deposit_authority(deposit_authority_info.key)?;
         stake_pool.check_mint(pool_mint_info)?;
 
         if stake_pool.token_program_id != *token_program_info.key {
@@ -1450,34 +1521,33 @@ impl Processor {
             validator_stake_account_info.lamports()
         );
 
-        Self::stake_authorize(
-            stake_pool_info.key,
-            stake_info.clone(),
-            deposit_info.clone(),
-            AUTHORITY_DEPOSIT,
-            stake_pool.deposit_bump_seed,
-            withdraw_info.key,
-            stake_program::StakeAuthorize::Withdrawer,
-            clock_info.clone(),
-            stake_program_info.clone(),
-        )?;
-
-        Self::stake_authorize(
-            stake_pool_info.key,
-            stake_info.clone(),
-            deposit_info.clone(),
-            AUTHORITY_DEPOSIT,
-            stake_pool.deposit_bump_seed,
-            withdraw_info.key,
-            stake_program::StakeAuthorize::Staker,
-            clock_info.clone(),
-            stake_program_info.clone(),
-        )?;
+        let (deposit_authority_program_address, deposit_bump_seed) =
+            find_deposit_authority_program_address(program_id, stake_pool_info.key);
+        if *deposit_authority_info.key == deposit_authority_program_address {
+            Self::stake_authorize_signed(
+                stake_pool_info.key,
+                stake_info.clone(),
+                deposit_authority_info.clone(),
+                AUTHORITY_DEPOSIT,
+                deposit_bump_seed,
+                withdraw_authority_info.key,
+                clock_info.clone(),
+                stake_program_info.clone(),
+            )?;
+        } else {
+            Self::stake_authorize(
+                stake_info.clone(),
+                deposit_authority_info.clone(),
+                withdraw_authority_info.key,
+                clock_info.clone(),
+                stake_program_info.clone(),
+            )?;
+        }
 
         Self::stake_merge(
             stake_pool_info.key,
             stake_info.clone(),
-            withdraw_info.clone(),
+            withdraw_authority_info.clone(),
             AUTHORITY_WITHDRAW,
             stake_pool.withdraw_bump_seed,
             validator_stake_account_info.clone(),
@@ -1491,7 +1561,7 @@ impl Processor {
             token_program_info.clone(),
             pool_mint_info.clone(),
             dest_user_info.clone(),
-            withdraw_info.clone(),
+            withdraw_authority_info.clone(),
             AUTHORITY_WITHDRAW,
             stake_pool.withdraw_bump_seed,
             new_pool_tokens,
@@ -1529,7 +1599,7 @@ impl Processor {
         let account_info_iter = &mut accounts.iter();
         let stake_pool_info = next_account_info(account_info_iter)?;
         let validator_list_info = next_account_info(account_info_iter)?;
-        let withdraw_info = next_account_info(account_info_iter)?;
+        let withdraw_authority_info = next_account_info(account_info_iter)?;
         let stake_split_from = next_account_info(account_info_iter)?;
         let stake_split_to = next_account_info(account_info_iter)?;
         let user_stake_authority = next_account_info(account_info_iter)?;
@@ -1549,8 +1619,12 @@ impl Processor {
             return Err(StakePoolError::InvalidState.into());
         }
 
-        stake_pool.check_authority_withdraw(withdraw_info.key, program_id, stake_pool_info.key)?;
         stake_pool.check_mint(pool_mint_info)?;
+        stake_pool.check_authority_withdraw(
+            withdraw_authority_info.key,
+            program_id,
+            stake_pool_info.key,
+        )?;
 
         if stake_pool.token_program_id != *token_program_info.key {
             return Err(ProgramError::IncorrectProgramId);
@@ -1600,7 +1674,7 @@ impl Processor {
             token_program_info.clone(),
             burn_from_info.clone(),
             pool_mint_info.clone(),
-            withdraw_info.clone(),
+            withdraw_authority_info.clone(),
             AUTHORITY_WITHDRAW,
             stake_pool.withdraw_bump_seed,
             pool_tokens,
@@ -1609,33 +1683,20 @@ impl Processor {
         Self::stake_split(
             stake_pool_info.key,
             stake_split_from.clone(),
-            withdraw_info.clone(),
+            withdraw_authority_info.clone(),
             AUTHORITY_WITHDRAW,
             stake_pool.withdraw_bump_seed,
             withdraw_lamports,
             stake_split_to.clone(),
         )?;
 
-        Self::stake_authorize(
+        Self::stake_authorize_signed(
             stake_pool_info.key,
             stake_split_to.clone(),
-            withdraw_info.clone(),
+            withdraw_authority_info.clone(),
             AUTHORITY_WITHDRAW,
             stake_pool.withdraw_bump_seed,
             user_stake_authority.key,
-            stake_program::StakeAuthorize::Withdrawer,
-            clock_info.clone(),
-            stake_program_info.clone(),
-        )?;
-
-        Self::stake_authorize(
-            stake_pool_info.key,
-            stake_split_to.clone(),
-            withdraw_info.clone(),
-            AUTHORITY_WITHDRAW,
-            stake_pool.withdraw_bump_seed,
-            user_stake_authority.key,
-            stake_program::StakeAuthorize::Staker,
             clock_info.clone(),
             stake_program_info.clone(),
         )?;

--- a/stake-pool/program/tests/decrease.rs
+++ b/stake-pool/program/tests/decrease.rs
@@ -233,10 +233,7 @@ async fn fail_with_unknown_validator() {
         decrease_lamports,
     ) = setup().await;
 
-    let unknown_stake = ValidatorStakeAccount::new_with_target_authority(
-        &stake_pool_accounts.deposit_authority,
-        &stake_pool_accounts.stake_pool.pubkey(),
-    );
+    let unknown_stake = ValidatorStakeAccount::new(&stake_pool_accounts.stake_pool.pubkey());
     unknown_stake
         .create_and_delegate(
             &mut banks_client,

--- a/stake-pool/program/tests/deposit.rs
+++ b/stake-pool/program/tests/deposit.rs
@@ -639,7 +639,7 @@ async fn success_with_deposit_authority() {
     let deposit_authority = Keypair::new();
     let stake_pool_accounts = StakePoolAccounts::new_with_deposit_authority(deposit_authority);
     stake_pool_accounts
-        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash)
+        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash, 1)
         .await
         .unwrap();
 
@@ -673,6 +673,7 @@ async fn success_with_deposit_authority() {
         &mut banks_client,
         &payer,
         &recent_blockhash,
+        &validator_stake_account.validator,
         &validator_stake_account.vote,
     )
     .await;
@@ -719,7 +720,7 @@ async fn fail_without_deposit_authority_signature() {
     let deposit_authority = Keypair::new();
     let mut stake_pool_accounts = StakePoolAccounts::new_with_deposit_authority(deposit_authority);
     stake_pool_accounts
-        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash)
+        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash, 1)
         .await
         .unwrap();
 
@@ -745,6 +746,7 @@ async fn fail_without_deposit_authority_signature() {
         &user_stake,
         &authorized,
         &lockup,
+        TEST_STAKE_AMOUNT,
     )
     .await;
 
@@ -752,6 +754,7 @@ async fn fail_without_deposit_authority_signature() {
         &mut banks_client,
         &payer,
         &recent_blockhash,
+        &validator_stake_account.validator,
         &validator_stake_account.vote,
     )
     .await;

--- a/stake-pool/program/tests/deposit.rs
+++ b/stake-pool/program/tests/deposit.rs
@@ -306,15 +306,13 @@ async fn test_stake_pool_deposit_with_wrong_token_program_id() {
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.validator_list.pubkey(),
-            &stake_pool_accounts.deposit_authority,
             &stake_pool_accounts.withdraw_authority,
             &user_stake.pubkey(),
+            &user.pubkey(),
             &validator_stake_account.stake_account,
             &user_pool_account.pubkey(),
             &stake_pool_accounts.pool_mint.pubkey(),
             &wrong_token_program.pubkey(),
-            &user.pubkey(),
-            false,
         ),
         Some(&payer.pubkey()),
     );
@@ -480,76 +478,6 @@ async fn test_stake_pool_deposit_to_unknown_validator() {
         _ => {
             panic!("Wrong error occurs while try to make a deposit with unknown validator account")
         }
-    }
-}
-
-#[tokio::test]
-async fn test_stake_pool_deposit_with_wrong_deposit_authority() {
-    let (
-        mut banks_client,
-        payer,
-        recent_blockhash,
-        mut stake_pool_accounts,
-        validator_stake_account,
-    ) = setup().await;
-
-    let user = Keypair::new();
-    // make stake account
-    let user_stake = Keypair::new();
-    let lockup = stake_program::Lockup::default();
-    let authorized = stake_program::Authorized {
-        staker: user.pubkey(),
-        withdrawer: user.pubkey(),
-    };
-    create_independent_stake_account(
-        &mut banks_client,
-        &payer,
-        &recent_blockhash,
-        &user_stake,
-        &authorized,
-        &lockup,
-        TEST_STAKE_AMOUNT,
-    )
-    .await;
-
-    // make pool token account
-    let user_pool_account = Keypair::new();
-    create_token_account(
-        &mut banks_client,
-        &payer,
-        &recent_blockhash,
-        &user_pool_account,
-        &stake_pool_accounts.pool_mint.pubkey(),
-        &user.pubkey(),
-    )
-    .await
-    .unwrap();
-
-    stake_pool_accounts.deposit_authority = Keypair::new().pubkey();
-
-    let transaction_error = stake_pool_accounts
-        .deposit_stake(
-            &mut banks_client,
-            &payer,
-            &recent_blockhash,
-            &user_stake.pubkey(),
-            &user_pool_account.pubkey(),
-            &validator_stake_account.stake_account,
-            &user,
-        )
-        .await
-        .err()
-        .unwrap();
-
-    match transaction_error {
-        TransportError::TransactionError(TransactionError::InstructionError(
-            _,
-            InstructionError::Custom(error_index),
-        )) => {
-            let program_error = error::StakePoolError::InvalidProgramAddress as u32;
-            assert_eq!(error_index, program_error);
-        }
-        _ => panic!("Wrong error occurs while try to make a deposit with wrong deposit authority"),
     }
 }
 

--- a/stake-pool/program/tests/deposit.rs
+++ b/stake-pool/program/tests/deposit.rs
@@ -102,28 +102,6 @@ async fn test_stake_pool_deposit() {
     )
     .await;
 
-    // Change authority to the stake pool's deposit
-    authorize_stake_account(
-        &mut banks_client,
-        &payer,
-        &recent_blockhash,
-        &user_stake.pubkey(),
-        &stake_authority,
-        &stake_pool_accounts.deposit_authority,
-        stake_program::StakeAuthorize::Withdrawer,
-    )
-    .await;
-    authorize_stake_account(
-        &mut banks_client,
-        &payer,
-        &recent_blockhash,
-        &user_stake.pubkey(),
-        &stake_authority,
-        &stake_pool_accounts.deposit_authority,
-        stake_program::StakeAuthorize::Staker,
-    )
-    .await;
-
     // make pool token account
     let user_pool_account = Keypair::new();
     create_token_account(
@@ -163,6 +141,7 @@ async fn test_stake_pool_deposit() {
             &user_stake.pubkey(),
             &user_pool_account.pubkey(),
             &validator_stake_account.stake_account,
+            &stake_authority,
         )
         .await
         .unwrap();
@@ -293,8 +272,8 @@ async fn test_stake_pool_deposit_with_wrong_token_program_id() {
     let user_stake = Keypair::new();
     let lockup = stake_program::Lockup::default();
     let authorized = stake_program::Authorized {
-        staker: stake_pool_accounts.deposit_authority,
-        withdrawer: stake_pool_accounts.deposit_authority,
+        staker: user.pubkey(),
+        withdrawer: user.pubkey(),
     };
     create_independent_stake_account(
         &mut banks_client,
@@ -323,7 +302,7 @@ async fn test_stake_pool_deposit_with_wrong_token_program_id() {
     let wrong_token_program = Keypair::new();
 
     let mut transaction = Transaction::new_with_payer(
-        &[instruction::deposit(
+        &instruction::deposit(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.validator_list.pubkey(),
@@ -334,11 +313,12 @@ async fn test_stake_pool_deposit_with_wrong_token_program_id() {
             &user_pool_account.pubkey(),
             &stake_pool_accounts.pool_mint.pubkey(),
             &wrong_token_program.pubkey(),
-        )
-        .unwrap()],
+            &user.pubkey(),
+            false,
+        ),
         Some(&payer.pubkey()),
     );
-    transaction.sign(&[&payer], recent_blockhash);
+    transaction.sign(&[&payer, &user], recent_blockhash);
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
@@ -368,8 +348,8 @@ async fn test_stake_pool_deposit_with_wrong_validator_list_account() {
     let user_stake = Keypair::new();
     let lockup = stake_program::Lockup::default();
     let authorized = stake_program::Authorized {
-        staker: stake_pool_accounts.deposit_authority,
-        withdrawer: stake_pool_accounts.deposit_authority,
+        staker: user.pubkey(),
+        withdrawer: user.pubkey(),
     };
     create_independent_stake_account(
         &mut banks_client,
@@ -406,6 +386,7 @@ async fn test_stake_pool_deposit_with_wrong_validator_list_account() {
             &user_stake.pubkey(),
             &user_pool_account.pubkey(),
             &validator_stake_account.stake_account,
+            &user,
         )
         .await
         .err()
@@ -432,10 +413,8 @@ async fn test_stake_pool_deposit_to_unknown_validator() {
         .await
         .unwrap();
 
-    let validator_stake_account = ValidatorStakeAccount::new_with_target_authority(
-        &stake_pool_accounts.deposit_authority,
-        &stake_pool_accounts.stake_pool.pubkey(),
-    );
+    let validator_stake_account =
+        ValidatorStakeAccount::new(&stake_pool_accounts.stake_pool.pubkey());
     validator_stake_account
         .create_and_delegate(
             &mut banks_client,
@@ -462,8 +441,8 @@ async fn test_stake_pool_deposit_to_unknown_validator() {
     let user_stake = Keypair::new();
     let lockup = stake_program::Lockup::default();
     let authorized = stake_program::Authorized {
-        staker: stake_pool_accounts.deposit_authority,
-        withdrawer: stake_pool_accounts.deposit_authority,
+        staker: user.pubkey(),
+        withdrawer: user.pubkey(),
     };
     create_independent_stake_account(
         &mut banks_client,
@@ -484,6 +463,7 @@ async fn test_stake_pool_deposit_to_unknown_validator() {
             &user_stake.pubkey(),
             &user_pool_account.pubkey(),
             &validator_stake_account.stake_account,
+            &user,
         )
         .await
         .err()
@@ -518,8 +498,8 @@ async fn test_stake_pool_deposit_with_wrong_deposit_authority() {
     let user_stake = Keypair::new();
     let lockup = stake_program::Lockup::default();
     let authorized = stake_program::Authorized {
-        staker: stake_pool_accounts.deposit_authority,
-        withdrawer: stake_pool_accounts.deposit_authority,
+        staker: user.pubkey(),
+        withdrawer: user.pubkey(),
     };
     create_independent_stake_account(
         &mut banks_client,
@@ -555,6 +535,7 @@ async fn test_stake_pool_deposit_with_wrong_deposit_authority() {
             &user_stake.pubkey(),
             &user_pool_account.pubkey(),
             &validator_stake_account.stake_account,
+            &user,
         )
         .await
         .err()
@@ -587,8 +568,8 @@ async fn test_stake_pool_deposit_with_wrong_withdraw_authority() {
     let user_stake = Keypair::new();
     let lockup = stake_program::Lockup::default();
     let authorized = stake_program::Authorized {
-        staker: stake_pool_accounts.deposit_authority,
-        withdrawer: stake_pool_accounts.deposit_authority,
+        staker: user.pubkey(),
+        withdrawer: user.pubkey(),
     };
     create_independent_stake_account(
         &mut banks_client,
@@ -624,6 +605,7 @@ async fn test_stake_pool_deposit_with_wrong_withdraw_authority() {
             &user_stake.pubkey(),
             &user_pool_account.pubkey(),
             &validator_stake_account.stake_account,
+            &user,
         )
         .await
         .err()
@@ -642,75 +624,17 @@ async fn test_stake_pool_deposit_with_wrong_withdraw_authority() {
 }
 
 #[tokio::test]
-async fn test_stake_pool_deposit_with_wrong_set_deposit_authority() {
-    let (mut banks_client, payer, recent_blockhash, stake_pool_accounts, validator_stake_account) =
-        setup().await;
-
-    let user = Keypair::new();
-    // make stake account
-    let user_stake = Keypair::new();
-    let lockup = stake_program::Lockup::default();
-    let authorized = stake_program::Authorized {
-        staker: Keypair::new().pubkey(),
-        withdrawer: stake_pool_accounts.deposit_authority,
-    };
-    create_independent_stake_account(
-        &mut banks_client,
-        &payer,
-        &recent_blockhash,
-        &user_stake,
-        &authorized,
-        &lockup,
-        TEST_STAKE_AMOUNT,
-    )
-    .await;
-    // make pool token account
-    let user_pool_account = Keypair::new();
-    create_token_account(
-        &mut banks_client,
-        &payer,
-        &recent_blockhash,
-        &user_pool_account,
-        &stake_pool_accounts.pool_mint.pubkey(),
-        &user.pubkey(),
-    )
-    .await
-    .unwrap();
-
-    let transaction_error = stake_pool_accounts
-        .deposit_stake(
-            &mut banks_client,
-            &payer,
-            &recent_blockhash,
-            &user_stake.pubkey(),
-            &user_pool_account.pubkey(),
-            &validator_stake_account.stake_account,
-        )
-        .await
-        .err()
-        .unwrap();
-
-    match transaction_error {
-        TransportError::TransactionError(TransactionError::InstructionError(_, error)) => {
-            assert_eq!(error, InstructionError::MissingRequiredSignature);
-        }
-        _ => {
-            panic!("Wrong error occurs while try to make deposit with wrong set deposit authority")
-        }
-    }
-}
-
-#[tokio::test]
 async fn test_stake_pool_deposit_with_wrong_mint_for_receiver_acc() {
     let (mut banks_client, payer, recent_blockhash, stake_pool_accounts, validator_stake_account) =
         setup().await;
 
     // make stake account
+    let user = Keypair::new();
     let user_stake = Keypair::new();
     let lockup = stake_program::Lockup::default();
     let authorized = stake_program::Authorized {
-        staker: stake_pool_accounts.deposit_authority,
-        withdrawer: stake_pool_accounts.deposit_authority,
+        staker: user.pubkey(),
+        withdrawer: user.pubkey(),
     };
     create_independent_stake_account(
         &mut banks_client,
@@ -757,6 +681,7 @@ async fn test_stake_pool_deposit_with_wrong_mint_for_receiver_acc() {
             &user_stake.pubkey(),
             &outside_pool_fee_acc.pubkey(),
             &validator_stake_account.stake_account,
+            &user,
         )
         .await
         .err()
@@ -779,3 +704,177 @@ async fn test_deposit_with_uninitialized_validator_list() {} // TODO
 
 #[tokio::test]
 async fn test_deposit_with_out_of_dated_pool_balances() {} // TODO
+
+#[tokio::test]
+async fn success_with_deposit_authority() {
+    let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
+    let deposit_authority = Keypair::new();
+    let stake_pool_accounts = StakePoolAccounts::new_with_deposit_authority(deposit_authority);
+    stake_pool_accounts
+        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash)
+        .await
+        .unwrap();
+
+    let validator_stake_account = simple_add_validator_to_pool(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        &stake_pool_accounts,
+    )
+    .await;
+
+    let user = Keypair::new();
+    let user_stake = Keypair::new();
+    let lockup = stake_program::Lockup::default();
+    let authorized = stake_program::Authorized {
+        staker: user.pubkey(),
+        withdrawer: user.pubkey(),
+    };
+    let _stake_lamports = create_independent_stake_account(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        &user_stake,
+        &authorized,
+        &lockup,
+        TEST_STAKE_AMOUNT,
+    )
+    .await;
+
+    create_vote(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        &validator_stake_account.vote,
+    )
+    .await;
+    delegate_stake_account(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        &user_stake.pubkey(),
+        &user,
+        &validator_stake_account.vote.pubkey(),
+    )
+    .await;
+
+    // make pool token account
+    let user_pool_account = Keypair::new();
+    create_token_account(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        &user_pool_account,
+        &stake_pool_accounts.pool_mint.pubkey(),
+        &user.pubkey(),
+    )
+    .await
+    .unwrap();
+
+    stake_pool_accounts
+        .deposit_stake(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            &user_stake.pubkey(),
+            &user_pool_account.pubkey(),
+            &validator_stake_account.stake_account,
+            &user,
+        )
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn fail_without_deposit_authority_signature() {
+    let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
+    let deposit_authority = Keypair::new();
+    let mut stake_pool_accounts = StakePoolAccounts::new_with_deposit_authority(deposit_authority);
+    stake_pool_accounts
+        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash)
+        .await
+        .unwrap();
+
+    let validator_stake_account = simple_add_validator_to_pool(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        &stake_pool_accounts,
+    )
+    .await;
+
+    let user = Keypair::new();
+    let user_stake = Keypair::new();
+    let lockup = stake_program::Lockup::default();
+    let authorized = stake_program::Authorized {
+        staker: user.pubkey(),
+        withdrawer: user.pubkey(),
+    };
+    let _stake_lamports = create_independent_stake_account(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        &user_stake,
+        &authorized,
+        &lockup,
+    )
+    .await;
+
+    create_vote(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        &validator_stake_account.vote,
+    )
+    .await;
+    delegate_stake_account(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        &user_stake.pubkey(),
+        &user,
+        &validator_stake_account.vote.pubkey(),
+    )
+    .await;
+
+    // make pool token account
+    let user_pool_account = Keypair::new();
+    create_token_account(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        &user_pool_account,
+        &stake_pool_accounts.pool_mint.pubkey(),
+        &user.pubkey(),
+    )
+    .await
+    .unwrap();
+
+    let wrong_depositor = Keypair::new();
+    stake_pool_accounts.deposit_authority = wrong_depositor.pubkey();
+    stake_pool_accounts.deposit_authority_keypair = Some(wrong_depositor);
+
+    let error = stake_pool_accounts
+        .deposit_stake(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            &user_stake.pubkey(),
+            &user_pool_account.pubkey(),
+            &validator_stake_account.stake_account,
+            &user,
+        )
+        .await
+        .unwrap_err()
+        .unwrap();
+
+    match error {
+        TransactionError::InstructionError(_, InstructionError::Custom(error_index)) => {
+            assert_eq!(
+                error_index,
+                error::StakePoolError::InvalidProgramAddress as u32
+            );
+        }
+        _ => panic!("Wrong error occurs while try to make a deposit with wrong stake program ID"),
+    }
+}

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -597,6 +597,7 @@ impl StakePoolAccounts {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn deposit_stake(
         &self,
         banks_client: &mut BanksClient,
@@ -975,26 +976,6 @@ impl DepositStakeAccount {
         recent_blockhash: &Hash,
         stake_pool_accounts: &StakePoolAccounts,
     ) {
-        authorize_stake_account(
-            banks_client,
-            payer,
-            recent_blockhash,
-            &self.stake.pubkey(),
-            &self.authority,
-            &stake_pool_accounts.deposit_authority,
-            stake_program::StakeAuthorize::Staker,
-        )
-        .await;
-        authorize_stake_account(
-            banks_client,
-            &payer,
-            &recent_blockhash,
-            &self.stake.pubkey(),
-            &self.authority,
-            &stake_pool_accounts.deposit_authority,
-            stake_program::StakeAuthorize::Withdrawer,
-        )
-        .await;
         // make pool token account
         create_token_account(
             banks_client,
@@ -1015,6 +996,7 @@ impl DepositStakeAccount {
                 &self.stake.pubkey(),
                 &self.pool_account.pubkey(),
                 &self.validator_stake_account,
+                &self.authority,
             )
             .await
             .unwrap();
@@ -1057,26 +1039,6 @@ pub async fn simple_deposit(
         &vote_account,
     )
     .await;
-    authorize_stake_account(
-        banks_client,
-        payer,
-        recent_blockhash,
-        &stake.pubkey(),
-        &authority,
-        &stake_pool_accounts.deposit_authority,
-        stake_program::StakeAuthorize::Staker,
-    )
-    .await;
-    authorize_stake_account(
-        banks_client,
-        &payer,
-        &recent_blockhash,
-        &stake.pubkey(),
-        &authority,
-        &stake_pool_accounts.deposit_authority,
-        stake_program::StakeAuthorize::Withdrawer,
-    )
-    .await;
     // make pool token account
     let pool_account = Keypair::new();
     create_token_account(
@@ -1099,7 +1061,7 @@ pub async fn simple_deposit(
             &stake.pubkey(),
             &pool_account.pubkey(),
             &validator_stake_account,
-            &user,
+            &authority,
         )
         .await
         .unwrap();

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -210,6 +210,7 @@ pub async fn create_stake_pool(
     pool_token_account: &Pubkey,
     manager: &Keypair,
     staker: &Pubkey,
+    deposit_authority: &Option<Keypair>,
     fee: &state::Fee,
     max_validators: u32,
 ) -> Result<(), TransportError> {
@@ -245,6 +246,7 @@ pub async fn create_stake_pool(
                 pool_mint,
                 pool_token_account,
                 &spl_token::id(),
+                deposit_authority.as_ref().map(|k| k.pubkey()),
                 *fee,
                 max_validators,
             )
@@ -252,10 +254,11 @@ pub async fn create_stake_pool(
         ],
         Some(&payer.pubkey()),
     );
-    transaction.sign(
-        &[payer, stake_pool, validator_list, manager],
-        *recent_blockhash,
-    );
+    let mut signers = vec![payer, stake_pool, validator_list, manager];
+    if let Some(deposit_authority) = deposit_authority.as_ref() {
+        signers.push(deposit_authority);
+    }
+    transaction.sign(&signers, *recent_blockhash);
     banks_client.process_transaction(transaction).await?;
     Ok(())
 }
@@ -424,14 +427,13 @@ pub async fn authorize_stake_account(
 pub struct ValidatorStakeAccount {
     pub stake_account: Pubkey,
     pub transient_stake_account: Pubkey,
-    pub target_authority: Pubkey,
     pub vote: Keypair,
     pub validator: Keypair,
     pub stake_pool: Pubkey,
 }
 
 impl ValidatorStakeAccount {
-    pub fn new_with_target_authority(authority: &Pubkey, stake_pool: &Pubkey) -> Self {
+    pub fn new(stake_pool: &Pubkey) -> Self {
         let validator = Keypair::new();
         let vote = Keypair::new();
         let (stake_account, _) = find_stake_program_address(&id(), &vote.pubkey(), stake_pool);
@@ -440,7 +442,6 @@ impl ValidatorStakeAccount {
         ValidatorStakeAccount {
             stake_account,
             transient_stake_account,
-            target_authority: *authority,
             vote,
             validator,
             stake_pool: *stake_pool,
@@ -473,28 +474,6 @@ impl ValidatorStakeAccount {
             &self.vote.pubkey(),
         )
         .await;
-
-        authorize_stake_account(
-            &mut banks_client,
-            &payer,
-            &recent_blockhash,
-            &self.stake_account,
-            &staker,
-            &self.target_authority,
-            stake_program::StakeAuthorize::Staker,
-        )
-        .await;
-
-        authorize_stake_account(
-            &mut banks_client,
-            &payer,
-            &recent_blockhash,
-            &self.stake_account,
-            &staker,
-            &self.target_authority,
-            stake_program::StakeAuthorize::Withdrawer,
-        )
-        .await;
     }
 }
 
@@ -508,6 +487,7 @@ pub struct StakePoolAccounts {
     pub staker: Keypair,
     pub withdraw_authority: Pubkey,
     pub deposit_authority: Pubkey,
+    pub deposit_authority_keypair: Option<Keypair>,
     pub fee: state::Fee,
     pub max_validators: u32,
 }
@@ -541,12 +521,20 @@ impl StakePoolAccounts {
             staker,
             withdraw_authority,
             deposit_authority,
+            deposit_authority_keypair: None,
             fee: state::Fee {
                 numerator: 1,
                 denominator: 100,
             },
             max_validators: MAX_TEST_VALIDATORS,
         }
+    }
+
+    pub fn new_with_deposit_authority(deposit_authority: Keypair) -> Self {
+        let mut stake_pool_accounts = Self::new();
+        stake_pool_accounts.deposit_authority = deposit_authority.pubkey();
+        stake_pool_accounts.deposit_authority_keypair = Some(deposit_authority);
+        stake_pool_accounts
     }
 
     pub fn calculate_fee(&self, amount: u64) -> u64 {
@@ -601,6 +589,7 @@ impl StakePoolAccounts {
             &self.pool_fee_account.pubkey(),
             &self.manager,
             &self.staker.pubkey(),
+            &self.deposit_authority_keypair,
             &self.fee,
             self.max_validators,
         )
@@ -616,9 +605,18 @@ impl StakePoolAccounts {
         stake: &Pubkey,
         pool_account: &Pubkey,
         validator_stake_account: &Pubkey,
+        current_staker: &Keypair,
     ) -> Result<(), TransportError> {
+        let mut signers = vec![payer, current_staker];
+        let deposit_authority_must_sign =
+            if let Some(deposit_authority) = self.deposit_authority_keypair.as_ref() {
+                signers.push(deposit_authority);
+                true
+            } else {
+                false
+            };
         let transaction = Transaction::new_signed_with_payer(
-            &[instruction::deposit(
+            &instruction::deposit(
                 &id(),
                 &self.stake_pool.pubkey(),
                 &self.validator_list.pubkey(),
@@ -629,10 +627,11 @@ impl StakePoolAccounts {
                 pool_account,
                 &self.pool_mint.pubkey(),
                 &spl_token::id(),
-            )
-            .unwrap()],
+                &current_staker.pubkey(),
+                deposit_authority_must_sign,
+            ),
             Some(&payer.pubkey()),
-            &[payer],
+            &signers,
             *recent_blockhash,
         );
         banks_client.process_transaction(transaction).await?;
@@ -771,7 +770,6 @@ impl StakePoolAccounts {
                 &id(),
                 &self.stake_pool.pubkey(),
                 &self.staker.pubkey(),
-                &self.deposit_authority,
                 &self.withdraw_authority,
                 &self.validator_list.pubkey(),
                 stake,
@@ -874,10 +872,7 @@ pub async fn simple_add_validator_to_pool(
     recent_blockhash: &Hash,
     stake_pool_accounts: &StakePoolAccounts,
 ) -> ValidatorStakeAccount {
-    let validator_stake = ValidatorStakeAccount::new_with_target_authority(
-        &stake_pool_accounts.deposit_authority,
-        &stake_pool_accounts.stake_pool.pubkey(),
-    );
+    let validator_stake = ValidatorStakeAccount::new(&stake_pool_accounts.stake_pool.pubkey());
     validator_stake
         .create_and_delegate(
             banks_client,
@@ -1094,6 +1089,7 @@ pub async fn simple_deposit(
             &stake.pubkey(),
             &pool_account.pubkey(),
             &validator_stake_account,
+            &user,
         )
         .await
         .unwrap();

--- a/stake-pool/program/tests/increase.rs
+++ b/stake-pool/program/tests/increase.rs
@@ -233,10 +233,7 @@ async fn fail_with_unknown_validator() {
         reserve_lamports,
     ) = setup().await;
 
-    let unknown_stake = ValidatorStakeAccount::new_with_target_authority(
-        &stake_pool_accounts.deposit_authority,
-        &stake_pool_accounts.stake_pool.pubkey(),
-    );
+    let unknown_stake = ValidatorStakeAccount::new(&stake_pool_accounts.stake_pool.pubkey());
     unknown_stake
         .create_and_delegate(
             &mut banks_client,

--- a/stake-pool/program/tests/initialize.rs
+++ b/stake-pool/program/tests/initialize.rs
@@ -3,7 +3,7 @@
 mod helpers;
 
 use {
-    borsh::BorshSerialize,
+    borsh::{BorshDeserialize, BorshSerialize},
     helpers::*,
     solana_program::{
         borsh::get_packed_len,
@@ -226,6 +226,7 @@ async fn fail_with_wrong_max_validators() {
                 &stake_pool_accounts.pool_mint.pubkey(),
                 &stake_pool_accounts.pool_fee_account.pubkey(),
                 &spl_token::id(),
+                None,
                 stake_pool_accounts.fee,
                 stake_pool_accounts.max_validators,
             )
@@ -296,6 +297,7 @@ async fn fail_with_wrong_mint_authority() {
         &stake_pool_accounts.pool_fee_account.pubkey(),
         &stake_pool_accounts.manager,
         &stake_pool_accounts.staker.pubkey(),
+        &None,
         &stake_pool_accounts.fee,
         stake_pool_accounts.max_validators,
     )
@@ -384,6 +386,7 @@ async fn fail_with_wrong_token_program_id() {
                 &stake_pool_accounts.pool_mint.pubkey(),
                 &stake_pool_accounts.pool_fee_account.pubkey(),
                 &wrong_token_program.pubkey(),
+                None,
                 stake_pool_accounts.fee,
                 stake_pool_accounts.max_validators,
             )
@@ -460,6 +463,7 @@ async fn fail_with_wrong_fee_account() {
         &stake_pool_accounts.pool_fee_account.pubkey(),
         &stake_pool_accounts.manager,
         &stake_pool_accounts.staker.pubkey(),
+        &None,
         &stake_pool_accounts.fee,
         stake_pool_accounts.max_validators,
     )
@@ -547,6 +551,7 @@ async fn fail_with_not_rent_exempt_pool() {
                 &stake_pool_accounts.pool_mint.pubkey(),
                 &stake_pool_accounts.pool_fee_account.pubkey(),
                 &spl_token::id(),
+                None,
                 stake_pool_accounts.fee,
                 stake_pool_accounts.max_validators,
             )
@@ -621,6 +626,7 @@ async fn fail_with_not_rent_exempt_validator_list() {
                 &stake_pool_accounts.pool_mint.pubkey(),
                 &stake_pool_accounts.pool_fee_account.pubkey(),
                 &spl_token::id(),
+                None,
                 stake_pool_accounts.fee,
                 stake_pool_accounts.max_validators,
             )
@@ -793,6 +799,7 @@ async fn fail_with_pre_minted_pool_tokens() {
         &stake_pool_accounts.pool_fee_account.pubkey(),
         &stake_pool_accounts.manager,
         &stake_pool_accounts.staker.pubkey(),
+        &None,
         &stake_pool_accounts.fee,
         stake_pool_accounts.max_validators,
     )
@@ -1007,4 +1014,24 @@ async fn fail_with_bad_reserve() {
             )
         );
     }
+}
+
+#[tokio::test]
+async fn success_with_required_deposit_authority() {
+    let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
+    let deposit_authority = Keypair::new();
+    let stake_pool_accounts = StakePoolAccounts::new_with_deposit_authority(deposit_authority);
+    stake_pool_accounts
+        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash)
+        .await
+        .unwrap();
+
+    // Stake pool now exists
+    let stake_pool_account =
+        get_account(&mut banks_client, &stake_pool_accounts.stake_pool.pubkey()).await;
+    let stake_pool = state::StakePool::try_from_slice(stake_pool_account.data.as_slice()).unwrap();
+    assert_eq!(
+        stake_pool.deposit_authority,
+        stake_pool_accounts.deposit_authority
+    );
 }

--- a/stake-pool/program/tests/initialize.rs
+++ b/stake-pool/program/tests/initialize.rs
@@ -860,6 +860,7 @@ async fn fail_with_bad_reserve() {
             &stake_pool_accounts.pool_fee_account.pubkey(),
             &stake_pool_accounts.manager,
             &stake_pool_accounts.staker.pubkey(),
+            &None,
             &stake_pool_accounts.fee,
             stake_pool_accounts.max_validators,
         )
@@ -904,6 +905,7 @@ async fn fail_with_bad_reserve() {
             &stake_pool_accounts.pool_fee_account.pubkey(),
             &stake_pool_accounts.manager,
             &stake_pool_accounts.staker.pubkey(),
+            &None,
             &stake_pool_accounts.fee,
             stake_pool_accounts.max_validators,
         )
@@ -951,6 +953,7 @@ async fn fail_with_bad_reserve() {
             &stake_pool_accounts.pool_fee_account.pubkey(),
             &stake_pool_accounts.manager,
             &stake_pool_accounts.staker.pubkey(),
+            &None,
             &stake_pool_accounts.fee,
             stake_pool_accounts.max_validators,
         )
@@ -998,6 +1001,7 @@ async fn fail_with_bad_reserve() {
             &stake_pool_accounts.pool_fee_account.pubkey(),
             &stake_pool_accounts.manager,
             &stake_pool_accounts.staker.pubkey(),
+            &None,
             &stake_pool_accounts.fee,
             stake_pool_accounts.max_validators,
         )
@@ -1022,7 +1026,7 @@ async fn success_with_required_deposit_authority() {
     let deposit_authority = Keypair::new();
     let stake_pool_accounts = StakePoolAccounts::new_with_deposit_authority(deposit_authority);
     stake_pool_accounts
-        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash)
+        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash, 1)
         .await
         .unwrap();
 

--- a/stake-pool/program/tests/update_validator_list_balance.rs
+++ b/stake-pool/program/tests/update_validator_list_balance.rs
@@ -43,10 +43,7 @@ async fn setup(
     let mut stake_accounts: Vec<ValidatorStakeAccount> = vec![];
     let mut deposit_accounts: Vec<DepositStakeAccount> = vec![];
     for _ in 0..num_validators {
-        let stake_account = ValidatorStakeAccount::new_with_target_authority(
-            &stake_pool_accounts.deposit_authority,
-            &stake_pool_accounts.stake_pool.pubkey(),
-        );
+        let stake_account = ValidatorStakeAccount::new(&stake_pool_accounts.stake_pool.pubkey());
         stake_account
             .create_and_delegate(
                 &mut context.banks_client,

--- a/stake-pool/program/tests/vsa_add.rs
+++ b/stake-pool/program/tests/vsa_add.rs
@@ -38,10 +38,7 @@ async fn setup() -> (
         .await
         .unwrap();
 
-    let user_stake = ValidatorStakeAccount::new_with_target_authority(
-        &stake_pool_accounts.deposit_authority,
-        &stake_pool_accounts.stake_pool.pubkey(),
-    );
+    let user_stake = ValidatorStakeAccount::new(&stake_pool_accounts.stake_pool.pubkey());
     user_stake
         .create_and_delegate(
             &mut banks_client,
@@ -126,7 +123,6 @@ async fn fail_with_wrong_validator_list_account() {
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.staker.pubkey(),
-            &stake_pool_accounts.deposit_authority,
             &stake_pool_accounts.withdraw_authority,
             &wrong_validator_list.pubkey(),
             &user_stake.stake_account,
@@ -162,10 +158,7 @@ async fn fail_too_little_stake() {
         .await
         .unwrap();
 
-    let user_stake = ValidatorStakeAccount::new_with_target_authority(
-        &stake_pool_accounts.deposit_authority,
-        &stake_pool_accounts.stake_pool.pubkey(),
-    );
+    let user_stake = ValidatorStakeAccount::new(&stake_pool_accounts.stake_pool.pubkey());
     create_vote(
         &mut banks_client,
         &payer,
@@ -203,28 +196,6 @@ async fn fail_too_little_stake() {
 
     banks_client.process_transaction(transaction).await.unwrap();
 
-    authorize_stake_account(
-        &mut banks_client,
-        &payer,
-        &recent_blockhash,
-        &user_stake.stake_account,
-        &stake_pool_accounts.staker,
-        &user_stake.target_authority,
-        stake_program::StakeAuthorize::Staker,
-    )
-    .await;
-
-    authorize_stake_account(
-        &mut banks_client,
-        &payer,
-        &recent_blockhash,
-        &user_stake.stake_account,
-        &stake_pool_accounts.staker,
-        &user_stake.target_authority,
-        stake_program::StakeAuthorize::Withdrawer,
-    )
-    .await;
-
     let error = stake_pool_accounts
         .add_validator_to_pool(
             &mut banks_client,
@@ -253,10 +224,7 @@ async fn fail_too_much_stake() {
         .await
         .unwrap();
 
-    let user_stake = ValidatorStakeAccount::new_with_target_authority(
-        &stake_pool_accounts.deposit_authority,
-        &stake_pool_accounts.stake_pool.pubkey(),
-    );
+    let user_stake = ValidatorStakeAccount::new(&stake_pool_accounts.stake_pool.pubkey());
     user_stake
         .create_and_delegate(
             &mut banks_client,
@@ -344,7 +312,6 @@ async fn fail_wrong_staker() {
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &malicious.pubkey(),
-            &stake_pool_accounts.deposit_authority,
             &stake_pool_accounts.withdraw_authority,
             &stake_pool_accounts.validator_list.pubkey(),
             &user_stake.stake_account,
@@ -379,7 +346,6 @@ async fn fail_without_signature() {
     let accounts = vec![
         AccountMeta::new(stake_pool_accounts.stake_pool.pubkey(), false),
         AccountMeta::new_readonly(stake_pool_accounts.staker.pubkey(), false),
-        AccountMeta::new_readonly(stake_pool_accounts.deposit_authority, false),
         AccountMeta::new_readonly(stake_pool_accounts.withdraw_authority, false),
         AccountMeta::new(stake_pool_accounts.validator_list.pubkey(), false),
         AccountMeta::new(user_stake.stake_account, false),
@@ -425,7 +391,6 @@ async fn fail_with_wrong_stake_program_id() {
     let accounts = vec![
         AccountMeta::new(stake_pool_accounts.stake_pool.pubkey(), false),
         AccountMeta::new_readonly(stake_pool_accounts.staker.pubkey(), true),
-        AccountMeta::new_readonly(stake_pool_accounts.deposit_authority, false),
         AccountMeta::new_readonly(stake_pool_accounts.withdraw_authority, false),
         AccountMeta::new(stake_pool_accounts.validator_list.pubkey(), false),
         AccountMeta::new(user_stake.stake_account, false),
@@ -468,10 +433,7 @@ async fn fail_add_too_many_validator_stake_accounts() {
         .await
         .unwrap();
 
-    let user_stake = ValidatorStakeAccount::new_with_target_authority(
-        &stake_pool_accounts.deposit_authority,
-        &stake_pool_accounts.stake_pool.pubkey(),
-    );
+    let user_stake = ValidatorStakeAccount::new(&stake_pool_accounts.stake_pool.pubkey());
     user_stake
         .create_and_delegate(
             &mut banks_client,
@@ -491,10 +453,7 @@ async fn fail_add_too_many_validator_stake_accounts() {
         .await;
     assert!(error.is_none());
 
-    let user_stake = ValidatorStakeAccount::new_with_target_authority(
-        &stake_pool_accounts.deposit_authority,
-        &stake_pool_accounts.stake_pool.pubkey(),
-    );
+    let user_stake = ValidatorStakeAccount::new(&stake_pool_accounts.stake_pool.pubkey());
     user_stake
         .create_and_delegate(
             &mut banks_client,

--- a/stake-pool/program/tests/vsa_remove.rs
+++ b/stake-pool/program/tests/vsa_remove.rs
@@ -38,10 +38,7 @@ async fn setup() -> (
         .await
         .unwrap();
 
-    let user_stake = ValidatorStakeAccount::new_with_target_authority(
-        &stake_pool_accounts.deposit_authority,
-        &stake_pool_accounts.stake_pool.pubkey(),
-    );
+    let user_stake = ValidatorStakeAccount::new(&stake_pool_accounts.stake_pool.pubkey());
     user_stake
         .create_and_delegate(
             &mut banks_client,

--- a/stake-pool/program/tests/withdraw.rs
+++ b/stake-pool/program/tests/withdraw.rs
@@ -403,10 +403,8 @@ async fn fail_with_unknown_validator() {
         .await
         .unwrap();
 
-    let validator_stake_account = ValidatorStakeAccount::new_with_target_authority(
-        &stake_pool_accounts.deposit_authority,
-        &stake_pool_accounts.stake_pool.pubkey(),
-    );
+    let validator_stake_account =
+        ValidatorStakeAccount::new(&stake_pool_accounts.stake_pool.pubkey());
     validator_stake_account
         .create_and_delegate(
             &mut banks_client,
@@ -416,10 +414,7 @@ async fn fail_with_unknown_validator() {
         )
         .await;
 
-    let user_stake = ValidatorStakeAccount::new_with_target_authority(
-        &stake_pool_accounts.deposit_authority,
-        &stake_pool_accounts.stake_pool.pubkey(),
-    );
+    let user_stake = ValidatorStakeAccount::new(&stake_pool_accounts.stake_pool.pubkey());
     user_stake
         .create_and_delegate(
             &mut banks_client,


### PR DESCRIPTION
Some stake pools need to be private, and not allow outside depositors.

Enhance the existing deposit authority in the stake pool be configurable
on initialization, and then require its signature on deposit.

The existing deposit authority is a program address, making deposits
permissionless. This allows a pool creator to set their own deposit_authority on
initialization. In a great turn of events, almost everything else works
the same way!

Here's the current workflow for deposit, where the user calls
stake_program::authorize and stake_pool::deposit in the same
transaction:

* stake_program::authorize assigns staker and withdraw authority to the
  stake pool deposit authority
* stake_pool::deposit
    - uses the deposit authority to assign authority on the deposited
  stake account to the stake pool withdraw authority
    - uses the withdraw authority to merge the deposited stake into the validator stake

The deposit authority must "sign" the transaction in order to reassign
authority to the withdraw authority. Currently, as a program address, it
can just do that. With this change, if the deposit authority is set
during initialization, then that deposit authority must sign the
instruction.

There's also a little update for ease-of-use to always do the
stake_program::authorize in the same transaction as stake_pool::deposit.
This way, in case someone tries to deposit into a forbidden stake pool, the
whole transaction will bail and their stake will stay as theirs.

Fixes #1502 