### PR TITLE
stake-pool: Add merging transient stakes in update

### DIFF
--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -32,6 +32,7 @@ use {
         find_transient_stake_program_address, find_withdraw_authority_program_address,
         stake_program::{self, StakeAuthorize, StakeState},
         state::{Fee, StakePool, ValidatorList},
+        MAX_VALIDATORS_TO_UPDATE,
     },
     std::process::exit,
 };
@@ -51,7 +52,6 @@ type Error = Box<dyn std::error::Error>;
 type CommandResult = Result<(), Error>;
 
 const STAKE_STATE_LEN: usize = 200;
-const MAX_ACCOUNTS_TO_UPDATE: usize = 10;
 lazy_static! {
     static ref MIN_STAKE_BALANCE: u64 = native_token::sol_to_lamports(1.0);
 }
@@ -653,7 +653,7 @@ fn command_update(config: &Config, stake_pool_address: &Pubkey) -> CommandResult
 
     let mut instructions: Vec<Instruction> = vec![];
     let mut start_index = 0;
-    for accounts_chunk in accounts_to_update.chunks(MAX_ACCOUNTS_TO_UPDATE) {
+    for accounts_chunk in accounts_to_update.chunks(MAX_VALIDATORS_TO_UPDATE) {
         instructions.push(spl_stake_pool::instruction::update_validator_list_balance(
             &spl_stake_pool::id(),
             stake_pool_address,
@@ -664,7 +664,7 @@ fn command_update(config: &Config, stake_pool_address: &Pubkey) -> CommandResult
             start_index,
             false,
         ));
-        start_index += MAX_ACCOUNTS_TO_UPDATE as u32;
+        start_index += MAX_VALIDATORS_TO_UPDATE as u32;
     }
 
     instructions.push(spl_stake_pool::instruction::update_stake_pool_balance(

--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -29,7 +29,7 @@ use {
         self,
         borsh::get_instance_packed_len,
         find_deposit_authority_program_address, find_stake_program_address,
-        find_withdraw_authority_program_address,
+        find_transient_stake_program_address, find_withdraw_authority_program_address,
         stake_program::{self, StakeAuthorize, StakeState},
         state::{Fee, StakePool, ValidatorList},
     },
@@ -347,7 +347,7 @@ fn command_vsa_add(config: &Config, stake_pool_address: &Pubkey, stake: &Pubkey)
 fn command_vsa_remove(
     config: &Config,
     stake_pool_address: &Pubkey,
-    stake: &Pubkey,
+    vote_account: &Pubkey,
     new_authority: &Option<Pubkey>,
 ) -> CommandResult {
     if !config.no_update {
@@ -357,6 +357,13 @@ fn command_vsa_remove(
     let stake_pool = get_stake_pool(&config.rpc_client, stake_pool_address)?;
     let pool_withdraw_authority =
         find_withdraw_authority_program_address(&spl_stake_pool::id(), stake_pool_address).0;
+    let (validator_stake_account, _) =
+        find_stake_program_address(&spl_stake_pool::id(), &vote_account, stake_pool_address);
+    let (transient_stake_account, _) = find_transient_stake_program_address(
+        &spl_stake_pool::id(),
+        &vote_account,
+        stake_pool_address,
+    );
 
     let staker_pubkey = config.staker.pubkey();
     let new_authority = new_authority.as_ref().unwrap_or(&staker_pubkey);
@@ -371,7 +378,8 @@ fn command_vsa_remove(
                 &pool_withdraw_authority,
                 &new_authority,
                 &stake_pool.validator_list,
-                &stake,
+                &validator_stake_account,
+                &transient_stake_account,
             )?,
         ],
         Some(&config.fee_payer.pubkey()),
@@ -1135,15 +1143,6 @@ fn main() {
                     .required(true)
                     .help("Stake account to add to the pool"),
             )
-            .arg(
-                Arg::with_name("token_receiver")
-                    .long("token-receiver")
-                    .validator(is_pubkey)
-                    .value_name("ADDRESS")
-                    .takes_value(true)
-                    .help("Account to receive pool token. Must be initialized account of the stake pool token. \
-                          Defaults to the new pool token account."),
-            )
         )
         .subcommand(SubCommand::with_name("remove-validator")
             .about("Remove validator account from the stake pool. Must be signed by the pool staker.")
@@ -1157,23 +1156,13 @@ fn main() {
                     .help("Stake pool address"),
             )
             .arg(
-                Arg::with_name("stake_account")
+                Arg::with_name("vote_account")
                     .index(2)
                     .validator(is_pubkey)
-                    .value_name("STAKE_ACCOUNT_ADDRESS")
+                    .value_name("VOTE_ACCOUNT_ADDRESS")
                     .takes_value(true)
                     .required(true)
-                    .help("Stake account to remove from the pool"),
-            )
-            .arg(
-                Arg::with_name("withdraw_from")
-                    .long("withdraw-from")
-                    .validator(is_pubkey)
-                    .value_name("ADDRESS")
-                    .takes_value(true)
-                    .required(true)
-                    .help("Token account to withdraw pool token from. \
-                          Must have enough tokens for the full stake address balance."),
+                    .help("Vote account for the validator to remove from the pool"),
             )
             .arg(
                 Arg::with_name("new_authority")
@@ -1455,9 +1444,9 @@ fn main() {
         }
         ("remove-validator", Some(arg_matches)) => {
             let stake_pool_address = pubkey_of(arg_matches, "pool").unwrap();
-            let stake_account = pubkey_of(arg_matches, "stake_account").unwrap();
+            let vote_account = pubkey_of(arg_matches, "vote_account").unwrap();
             let new_authority: Option<Pubkey> = pubkey_of(arg_matches, "new_authority");
-            command_vsa_remove(&config, &stake_pool_address, &stake_account, &new_authority)
+            command_vsa_remove(&config, &stake_pool_address, &vote_account, &new_authority)
         }
         ("deposit", Some(arg_matches)) => {
             let stake_pool_address = pubkey_of(arg_matches, "pool").unwrap();

--- a/stake-pool/program/src/instruction.rs
+++ b/stake-pool/program/src/instruction.rs
@@ -88,8 +88,9 @@ pub enum StakePoolInstruction {
     ///   3. `[]` New withdraw/staker authority to set in the stake account
     ///   4. `[w]` Validator stake list storage account
     ///   5. `[w]` Stake account to remove from the pool
-    ///   8. '[]' Sysvar clock
-    ///  10. `[]` Stake program id,
+    ///   6. `[]` Transient stake account, to check that that we're not trying to activate
+    ///   7. '[]' Sysvar clock
+    ///   8. `[]` Stake program id,
     RemoveValidatorFromPool,
 
     /// (Staker only) Decrease active stake on a validator, eventually moving it to the reserve
@@ -347,6 +348,7 @@ pub fn remove_validator_from_pool(
     new_stake_authority: &Pubkey,
     validator_list: &Pubkey,
     stake_account: &Pubkey,
+    transient_stake_account: &Pubkey,
 ) -> Result<Instruction, ProgramError> {
     let accounts = vec![
         AccountMeta::new(*stake_pool, false),
@@ -355,6 +357,7 @@ pub fn remove_validator_from_pool(
         AccountMeta::new_readonly(*new_stake_authority, false),
         AccountMeta::new(*validator_list, false),
         AccountMeta::new(*stake_account, false),
+        AccountMeta::new_readonly(*transient_stake_account, false),
         AccountMeta::new_readonly(sysvar::clock::id(), false),
         AccountMeta::new_readonly(stake_program::id(), false),
     ];

--- a/stake-pool/program/src/instruction.rs
+++ b/stake-pool/program/src/instruction.rs
@@ -3,7 +3,9 @@
 #![allow(clippy::too_many_arguments)]
 
 use {
-    crate::{stake_program, state::Fee},
+    crate::{
+        find_stake_program_address, find_transient_stake_program_address, stake_program, state::Fee,
+    },
     borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
     solana_program::{
         instruction::{AccountMeta, Instruction},
@@ -133,7 +135,7 @@ pub enum StakePoolInstruction {
     ///  0. `[]` Stake pool
     ///  1. `[s]` Stake pool staker
     ///  2. `[]` Stake pool withdraw authority
-    ///  3. `[]` Validator list
+    ///  3. `[w]` Validator list
     ///  4. `[w]` Stake pool reserve stake
     ///  5. `[w]` Transient stake account
     ///  6. `[]` Validator vote account to delegate to
@@ -150,26 +152,36 @@ pub enum StakePoolInstruction {
     ///
     ///  While going through the pairs of validator and transient stake accounts,
     ///  if the transient stake is inactive, it is merged into the reserve stake
-    ///  account.  If the transient stake is active and has matching credits
+    ///  account. If the transient stake is active and has matching credits
     ///  observed, it is merged into the canonical validator stake account. In
     ///  all other states, nothing is done, and the balance is simply added to
     ///  the canonical stake account balance.
     ///
     ///  0. `[]` Stake pool
-    ///  1. `[w]` Validator stake list storage account
-    ///  2. `[w]` Reserve stake account
-    ///  3. `[]` Stake pool withdraw authority
-    ///  4. `[]` Sysvar clock account
-    ///  5. `[]` Stake program
-    ///  6. ..6+N ` [] N pairs of validator and transient stake accounts
-    UpdateValidatorListBalance,
+    ///  1. `[]` Stake pool withdraw authority
+    ///  2. `[w]` Validator stake list storage account
+    ///  3. `[w]` Reserve stake account
+    ///  4. `[]` Sysvar clock
+    ///  5. `[]` Sysvar stake history
+    ///  6. `[]` Stake program
+    ///  7. ..7+N ` [] N pairs of validator and transient stake accounts
+    UpdateValidatorListBalance {
+        /// Index to start updating on the validator list
+        #[allow(dead_code)] // but it's not
+        start_index: u32,
+        /// If true, don't try merging transient stake accounts into the reserve or
+        /// validator stake account.  Useful for testing or if a particular stake
+        /// account is in a bad state, but we still want to update
+        #[allow(dead_code)] // but it's not
+        no_merge: bool,
+    },
 
     ///   Updates total pool balance based on balances in the reserve and validator list
     ///
     ///   0. `[w]` Stake pool
-    ///   1. `[]` Validator stake list storage account
-    ///   2. `[]` Reserve stake account
-    ///   3. `[]` Stake pool withdraw authority
+    ///   1. `[]` Stake pool withdraw authority
+    ///   2. `[]` Validator stake list storage account
+    ///   3. `[]` Reserve stake account
     ///   4. `[w]` Account to receive pool fee tokens
     ///   5. `[w]` Pool mint account
     ///   6. `[]` Sysvar clock account
@@ -416,7 +428,7 @@ pub fn increase_validator_stake(
         AccountMeta::new_readonly(*stake_pool, false),
         AccountMeta::new_readonly(*staker, true),
         AccountMeta::new_readonly(*stake_pool_withdraw_authority, false),
-        AccountMeta::new_readonly(*validator_list, false),
+        AccountMeta::new(*validator_list, false),
         AccountMeta::new(*reserve_stake, false),
         AccountMeta::new(*transient_stake, false),
         AccountMeta::new_readonly(*validator, false),
@@ -437,45 +449,80 @@ pub fn increase_validator_stake(
 /// Creates `UpdateValidatorListBalance` instruction (update validator stake account balances)
 pub fn update_validator_list_balance(
     program_id: &Pubkey,
-    validator_list_storage: &Pubkey,
-    validator_list: &[Pubkey],
-) -> Result<Instruction, ProgramError> {
-    let mut accounts: Vec<AccountMeta> = validator_list
-        .iter()
-        .map(|pubkey| AccountMeta::new_readonly(*pubkey, false))
-        .collect();
-    accounts.insert(0, AccountMeta::new(*validator_list_storage, false));
-    accounts.insert(1, AccountMeta::new_readonly(sysvar::clock::id(), false));
-    Ok(Instruction {
+    stake_pool: &Pubkey,
+    stake_pool_withdraw_authority: &Pubkey,
+    validator_list: &Pubkey,
+    reserve_stake: &Pubkey,
+    validator_vote_accounts: &[Pubkey],
+    start_index: u32,
+    no_merge: bool,
+) -> Instruction {
+    let mut accounts = vec![
+        AccountMeta::new_readonly(*stake_pool, false),
+        AccountMeta::new_readonly(*stake_pool_withdraw_authority, false),
+        AccountMeta::new(*validator_list, false),
+        AccountMeta::new(*reserve_stake, false),
+        AccountMeta::new_readonly(sysvar::clock::id(), false),
+        AccountMeta::new_readonly(sysvar::stake_history::id(), false),
+        AccountMeta::new_readonly(stake_program::id(), false),
+    ];
+    accounts.append(
+        &mut validator_vote_accounts
+            .iter()
+            .flat_map(|vote_account_address| {
+                let (validator_stake_account, _) =
+                    find_stake_program_address(program_id, vote_account_address, stake_pool);
+                let (transient_stake_account, _) = find_transient_stake_program_address(
+                    program_id,
+                    vote_account_address,
+                    stake_pool,
+                );
+                vec![
+                    AccountMeta::new(validator_stake_account, false),
+                    AccountMeta::new(transient_stake_account, false),
+                ]
+            })
+            .collect::<Vec<AccountMeta>>(),
+    );
+    Instruction {
         program_id: *program_id,
         accounts,
-        data: StakePoolInstruction::UpdateValidatorListBalance.try_to_vec()?,
-    })
+        data: StakePoolInstruction::UpdateValidatorListBalance {
+            start_index,
+            no_merge,
+        }
+        .try_to_vec()
+        .unwrap(),
+    }
 }
 
 /// Creates `UpdateStakePoolBalance` instruction (pool balance from the stake account list balances)
 pub fn update_stake_pool_balance(
     program_id: &Pubkey,
     stake_pool: &Pubkey,
-    validator_list_storage: &Pubkey,
     withdraw_authority: &Pubkey,
+    validator_list_storage: &Pubkey,
+    reserve_stake: &Pubkey,
     manager_fee_account: &Pubkey,
     stake_pool_mint: &Pubkey,
-) -> Result<Instruction, ProgramError> {
+) -> Instruction {
     let accounts = vec![
         AccountMeta::new(*stake_pool, false),
-        AccountMeta::new(*validator_list_storage, false),
         AccountMeta::new_readonly(*withdraw_authority, false),
+        AccountMeta::new_readonly(*validator_list_storage, false),
+        AccountMeta::new_readonly(*reserve_stake, false),
         AccountMeta::new(*manager_fee_account, false),
         AccountMeta::new(*stake_pool_mint, false),
         AccountMeta::new_readonly(sysvar::clock::id(), false),
         AccountMeta::new_readonly(spl_token::id(), false),
     ];
-    Ok(Instruction {
+    Instruction {
         program_id: *program_id,
         accounts,
-        data: StakePoolInstruction::UpdateStakePoolBalance.try_to_vec()?,
-    })
+        data: StakePoolInstruction::UpdateStakePoolBalance
+            .try_to_vec()
+            .unwrap(),
+    }
 }
 
 /// Creates a 'Deposit' instruction.

--- a/stake-pool/program/src/lib.rs
+++ b/stake-pool/program/src/lib.rs
@@ -39,6 +39,12 @@ pub fn minimum_stake_lamports(meta: &Meta) -> u64 {
         .saturating_add(MINIMUM_ACTIVE_STAKE)
 }
 
+/// Get the stake amount under consideration when calculating pool token
+/// conversions
+pub fn minimum_reserve_lamports(meta: &Meta) -> u64 {
+    meta.rent_exempt_reserve.saturating_add(1)
+}
+
 /// Generates the deposit authority program address for the stake pool
 pub fn find_deposit_authority_program_address(
     program_id: &Pubkey,

--- a/stake-pool/program/src/lib.rs
+++ b/stake-pool/program/src/lib.rs
@@ -32,6 +32,10 @@ const TRANSIENT_STAKE_SEED: &[u8] = b"transient";
 /// for merges without a mismatch on credits observed
 pub const MINIMUM_ACTIVE_STAKE: u64 = LAMPORTS_PER_SOL;
 
+/// Maximum amount of validator stake accounts to update per
+/// `UpdateValidatorListBalance` instruction, based on compute limits
+pub const MAX_VALIDATORS_TO_UPDATE: usize = 12;
+
 /// Get the stake amount under consideration when calculating pool token
 /// conversions
 pub fn minimum_stake_lamports(meta: &Meta) -> u64 {

--- a/stake-pool/program/src/lib.rs
+++ b/stake-pool/program/src/lib.rs
@@ -34,7 +34,7 @@ pub const MINIMUM_ACTIVE_STAKE: u64 = LAMPORTS_PER_SOL;
 
 /// Maximum amount of validator stake accounts to update per
 /// `UpdateValidatorListBalance` instruction, based on compute limits
-pub const MAX_VALIDATORS_TO_UPDATE: usize = 12;
+pub const MAX_VALIDATORS_TO_UPDATE: usize = 10;
 
 /// Get the stake amount under consideration when calculating pool token
 /// conversions

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -746,17 +746,15 @@ impl Processor {
             transient_stake_account_info.key,
             &vote_account_address,
         )?;
-        // check that the transient stake account isn't activating
-        if let Ok((_, transient_stake)) = get_stake_state(transient_stake_account_info) {
-            if transient_stake.delegation.activation_epoch == clock.epoch {
-                msg!(
-                    "Transient stake {} is activating, can't remove stake {} on validator {}",
-                    transient_stake_account_info.key,
-                    stake_account_info.key,
-                    vote_account_address
-                );
-                return Err(StakePoolError::WrongStakeState.into());
-            }
+        // check that the transient stake account doesn't exist
+        if get_stake_state(transient_stake_account_info).is_ok() {
+            msg!(
+                "Transient stake {} exists, can't remove stake {} on validator {}",
+                transient_stake_account_info.key,
+                stake_account_info.key,
+                vote_account_address
+            );
+            return Err(StakePoolError::WrongStakeState.into());
         }
 
         if !validator_list.contains(&vote_account_address) {

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -1126,20 +1126,24 @@ impl Processor {
             // chunks_exact means that we always get 2 elements, making this safe
             let validator_stake_info = validator_stakes.first().unwrap();
             let transient_stake_info = validator_stakes.last().unwrap();
-            if let Err(_) = check_validator_stake_address(
+            if check_validator_stake_address(
                 program_id,
                 stake_pool_info.key,
                 validator_stake_info.key,
                 &validator_stake_record.vote_account_address,
-            ) {
+            )
+            .is_err()
+            {
                 continue;
             };
-            if let Err(_) = check_transient_stake_address(
+            if check_transient_stake_address(
                 program_id,
                 stake_pool_info.key,
                 transient_stake_info.key,
                 &validator_stake_record.vote_account_address,
-            ) {
+            )
+            .is_err()
+            {
                 continue;
             };
             // Possible merge situations for transient stake
@@ -1201,8 +1205,8 @@ impl Processor {
                         if let Some(stake_program::StakeState::Stake(_, validator_stake)) =
                             validator_stake_state
                         {
-                            if let Ok(_) =
-                                stake_program::active_stakes_can_merge(&stake, &validator_stake)
+                            if stake_program::active_stakes_can_merge(&stake, &validator_stake)
+                                .is_ok()
                             {
                                 Self::stake_merge(
                                     stake_pool_info.key,

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -5,11 +5,10 @@ use {
         borsh::try_from_slice_unchecked,
         error::StakePoolError,
         instruction::StakePoolInstruction,
-        minimum_stake_lamports, stake_program,
+        minimum_reserve_lamports, minimum_stake_lamports, stake_program,
         state::{AccountType, Fee, StakePool, ValidatorList, ValidatorStakeInfo},
         AUTHORITY_DEPOSIT, AUTHORITY_WITHDRAW, MINIMUM_ACTIVE_STAKE, TRANSIENT_STAKE_SEED,
     },
-    bincode::deserialize,
     borsh::{BorshDeserialize, BorshSerialize},
     num_traits::FromPrimitive,
     solana_program::{
@@ -36,8 +35,8 @@ use {
 fn get_stake_state(
     stake_account_info: &AccountInfo,
 ) -> Result<(stake_program::Meta, stake_program::Stake), ProgramError> {
-    let stake_state: stake_program::StakeState =
-        deserialize(&stake_account_info.data.borrow()).or(Err(ProgramError::InvalidAccountData))?;
+    let stake_state =
+        try_from_slice_unchecked::<stake_program::StakeState>(&stake_account_info.data.borrow())?;
     match stake_state {
         stake_program::StakeState::Stake(meta, stake) => Ok((meta, stake)),
         _ => Err(StakePoolError::WrongStakeState.into()),
@@ -214,11 +213,11 @@ impl Processor {
     #[allow(clippy::too_many_arguments)]
     fn stake_merge<'a>(
         stake_pool: &Pubkey,
-        stake_account: AccountInfo<'a>,
+        source_account: AccountInfo<'a>,
         authority: AccountInfo<'a>,
         authority_type: &[u8],
         bump_seed: u8,
-        merge_with: AccountInfo<'a>,
+        destination_account: AccountInfo<'a>,
         clock: AccountInfo<'a>,
         stake_history: AccountInfo<'a>,
         stake_program_info: AccountInfo<'a>,
@@ -227,13 +226,13 @@ impl Processor {
         let authority_signature_seeds = [&me_bytes[..32], authority_type, &[bump_seed]];
         let signers = &[&authority_signature_seeds[..]];
 
-        let ix = stake_program::merge(merge_with.key, stake_account.key, authority.key);
+        let ix = stake_program::merge(destination_account.key, source_account.key, authority.key);
 
         invoke_signed(
             &ix,
             &[
-                merge_with,
-                stake_account,
+                destination_account,
+                source_account,
                 clock,
                 stake_history,
                 authority,
@@ -434,9 +433,11 @@ impl Processor {
             msg!("Reserve stake account not owned by stake program");
             return Err(ProgramError::IncorrectProgramId);
         }
-        let stake_state: stake_program::StakeState = deserialize(&reserve_stake_info.data.borrow())
-            .or(Err(ProgramError::InvalidAccountData))?;
-        if let stake_program::StakeState::Initialized(meta) = stake_state {
+        let stake_state = try_from_slice_unchecked::<stake_program::StakeState>(
+            &reserve_stake_info.data.borrow(),
+        )?;
+        let total_stake_lamports = if let stake_program::StakeState::Initialized(meta) = stake_state
+        {
             if meta.lockup != stake_program::Lockup::default() {
                 msg!("Reserve stake account has some lockup");
                 return Err(StakePoolError::WrongStakeState.into());
@@ -459,10 +460,14 @@ impl Processor {
                 );
                 return Err(StakePoolError::WrongStakeState.into());
             }
+            reserve_stake_info
+                .lamports()
+                .checked_sub(minimum_reserve_lamports(&meta))
+                .ok_or(StakePoolError::CalculationFailure)?
         } else {
             msg!("Reserve stake account not in intialized state");
             return Err(StakePoolError::WrongStakeState.into());
-        }
+        };
 
         validator_list.serialize(&mut *validator_list_info.data.borrow_mut())?;
 
@@ -478,6 +483,7 @@ impl Processor {
         stake_pool.token_program_id = *token_program_info.key;
         stake_pool.last_update_epoch = clock.epoch;
         stake_pool.fee = fee;
+        stake_pool.total_stake_lamports = total_stake_lamports;
 
         stake_pool
             .serialize(&mut *stake_pool_info.data.borrow_mut())
@@ -594,8 +600,8 @@ impl Processor {
         let stake_account_info = next_account_info(account_info_iter)?;
         let clock_info = next_account_info(account_info_iter)?;
         let clock = &Clock::from_account_info(clock_info)?;
-        let stake_history_info = next_account_info(account_info_iter)?;
-        let stake_history = &StakeHistory::from_account_info(stake_history_info)?;
+        let _stake_history_info = next_account_info(account_info_iter)?;
+        //let stake_history = &StakeHistory::from_account_info(stake_history_info)?;
         let stake_program_info = next_account_info(account_info_iter)?;
 
         check_stake_program(stake_program_info.key)?;
@@ -656,7 +662,7 @@ impl Processor {
         }
 
         // Check if stake is warmed up
-        Self::check_stake_activation(stake_account_info, clock, stake_history)?;
+        //Self::check_stake_activation(stake_account_info, clock, stake_history)?;
 
         // Update Withdrawer and Staker authority to the program withdraw authority
         for authority in &[
@@ -965,7 +971,7 @@ impl Processor {
 
         stake_pool.check_validator_list(validator_list_info)?;
 
-        let validator_list =
+        let mut validator_list =
             try_from_slice_unchecked::<ValidatorList>(&validator_list_info.data.borrow())?;
         if !validator_list.is_valid() {
             return Err(StakePoolError::InvalidState.into());
@@ -988,13 +994,15 @@ impl Processor {
             &[transient_stake_bump_seed],
         ];
 
-        if !validator_list.contains(&validator_vote_account_info.key) {
+        let maybe_validator_list_entry = validator_list.find_mut(&vote_account_address);
+        if maybe_validator_list_entry.is_none() {
             msg!(
                 "Vote account {} not found in stake pool",
                 vote_account_address
             );
             return Err(StakePoolError::ValidatorNotFound.into());
         }
+        let mut validator_list_entry = maybe_validator_list_entry.unwrap();
 
         let stake_rent = rent.minimum_balance(std::mem::size_of::<stake_program::StakeState>());
         if lamports <= stake_rent {
@@ -1004,6 +1012,22 @@ impl Processor {
                 lamports
             );
             return Err(ProgramError::AccountNotRentExempt);
+        }
+
+        if reserve_stake_account_info
+            .lamports()
+            .saturating_sub(lamports)
+            <= stake_rent
+        {
+            let max_split_amount = reserve_stake_account_info
+                .lamports()
+                .saturating_sub(stake_rent);
+            msg!(
+                "Reserve stake does not have enough lamports for increase, must be less than {}, {} requested",
+                max_split_amount,
+                lamports
+            );
+            return Err(ProgramError::InsufficientFunds);
         }
 
         // create transient stake account
@@ -1043,19 +1067,45 @@ impl Processor {
             stake_pool.withdraw_bump_seed,
         )?;
 
+        validator_list_entry.stake_lamports = validator_list_entry
+            .stake_lamports
+            .checked_add(lamports)
+            .ok_or(StakePoolError::CalculationFailure)?;
+        validator_list.serialize(&mut *validator_list_info.data.borrow_mut())?;
+
         Ok(())
     }
 
     /// Processes `UpdateValidatorListBalance` instruction.
     fn process_update_validator_list_balance(
-        _program_id: &Pubkey,
+        program_id: &Pubkey,
         accounts: &[AccountInfo],
+        start_index: u32,
+        no_merge: bool,
     ) -> ProgramResult {
         let account_info_iter = &mut accounts.iter();
+        let stake_pool_info = next_account_info(account_info_iter)?;
+        let withdraw_authority_info = next_account_info(account_info_iter)?;
         let validator_list_info = next_account_info(account_info_iter)?;
+        let reserve_stake_info = next_account_info(account_info_iter)?;
         let clock_info = next_account_info(account_info_iter)?;
         let clock = &Clock::from_account_info(clock_info)?;
+        let stake_history_info = next_account_info(account_info_iter)?;
+        let stake_program_info = next_account_info(account_info_iter)?;
         let validator_stake_accounts = account_info_iter.as_slice();
+
+        let stake_pool = StakePool::try_from_slice(&stake_pool_info.data.borrow())?;
+        if stake_pool_info.owner != program_id {
+            msg!(
+                "Stake pool is owned by the wrong program, expected {}, received {}",
+                program_id,
+                stake_pool_info.owner
+            );
+            return Err(ProgramError::IncorrectProgramId);
+        }
+        if !stake_pool.is_valid() {
+            return Err(StakePoolError::InvalidState.into());
+        }
 
         let mut validator_list =
             try_from_slice_unchecked::<ValidatorList>(&validator_list_info.data.borrow())?;
@@ -1063,31 +1113,143 @@ impl Processor {
             return Err(StakePoolError::InvalidState.into());
         }
 
-        let stake_states: Vec<(stake_program::Meta, stake_program::Stake)> =
-            validator_stake_accounts
-                .iter()
-                .filter_map(|stake| get_stake_state(stake).ok())
-                .collect();
-
         let mut changes = false;
-        // Do a brute iteration through the list, optimize if necessary
-        for validator_stake_record in &mut validator_list.validators {
+        let validator_iter = &mut validator_list
+            .validators
+            .iter_mut()
+            .skip(start_index as usize)
+            .zip(validator_stake_accounts.chunks_exact(2));
+        for (validator_stake_record, validator_stakes) in validator_iter {
             if validator_stake_record.last_update_epoch >= clock.epoch {
                 continue;
             }
-            for (validator_stake_account, (meta, stake)) in
-                validator_stake_accounts.iter().zip(stake_states.iter())
-            {
-                if validator_stake_record.vote_account_address != stake.delegation.voter_pubkey {
-                    continue;
+            // chunks_exact means that we always get 2 elements, making this safe
+            let validator_stake_info = validator_stakes.first().unwrap();
+            let transient_stake_info = validator_stakes.last().unwrap();
+            if let Err(_) = check_validator_stake_address(
+                program_id,
+                stake_pool_info.key,
+                validator_stake_info.key,
+                &validator_stake_record.vote_account_address,
+            ) {
+                continue;
+            };
+            if let Err(_) = check_transient_stake_address(
+                program_id,
+                stake_pool_info.key,
+                transient_stake_info.key,
+                &validator_stake_record.vote_account_address,
+            ) {
+                continue;
+            };
+            // Possible merge situations for transient stake
+            //  * active -> merge into validator stake
+            //  * activating -> nothing, just account its stakes
+            //  * deactivating -> nothing, just account its stakes
+            //  * inactive -> merge into reserve stake
+            //  * not a stake -> ignore totally
+            //
+            // Status for validator stake
+            //  * active -> do everything
+            //  * any other state / not a stake -> error state, but account for transient stake
+            let mut stake_lamports = 0;
+            let validator_stake_state = try_from_slice_unchecked::<stake_program::StakeState>(
+                &validator_stake_info.data.borrow(),
+            )
+            .ok();
+            let transient_stake_state = try_from_slice_unchecked::<stake_program::StakeState>(
+                &transient_stake_info.data.borrow(),
+            )
+            .ok();
+
+            match transient_stake_state {
+                Some(stake_program::StakeState::Initialized(_meta)) => {
+                    if no_merge {
+                        stake_lamports += transient_stake_info.lamports();
+                    } else {
+                        // merge into reserve
+                        Self::stake_merge(
+                            stake_pool_info.key,
+                            transient_stake_info.clone(),
+                            withdraw_authority_info.clone(),
+                            AUTHORITY_WITHDRAW,
+                            stake_pool.withdraw_bump_seed,
+                            reserve_stake_info.clone(),
+                            clock_info.clone(),
+                            stake_history_info.clone(),
+                            stake_program_info.clone(),
+                        )?;
+                    }
                 }
-                validator_stake_record.last_update_epoch = clock.epoch;
-                validator_stake_record.stake_lamports = validator_stake_account
-                    .lamports
-                    .borrow()
-                    .saturating_sub(minimum_stake_lamports(&meta));
-                changes = true;
+                Some(stake_program::StakeState::Stake(_, stake)) => {
+                    if no_merge {
+                        stake_lamports += transient_stake_info.lamports();
+                    } else if stake.delegation.deactivation_epoch < clock.epoch {
+                        // deactivated, merge into reserve
+                        Self::stake_merge(
+                            stake_pool_info.key,
+                            transient_stake_info.clone(),
+                            withdraw_authority_info.clone(),
+                            AUTHORITY_WITHDRAW,
+                            stake_pool.withdraw_bump_seed,
+                            reserve_stake_info.clone(),
+                            clock_info.clone(),
+                            stake_history_info.clone(),
+                            stake_program_info.clone(),
+                        )?;
+                    } else if stake.delegation.activation_epoch < clock.epoch {
+                        if let Some(stake_program::StakeState::Stake(_, validator_stake)) =
+                            validator_stake_state
+                        {
+                            if let Ok(_) =
+                                stake_program::active_stakes_can_merge(&stake, &validator_stake)
+                            {
+                                Self::stake_merge(
+                                    stake_pool_info.key,
+                                    transient_stake_info.clone(),
+                                    withdraw_authority_info.clone(),
+                                    AUTHORITY_WITHDRAW,
+                                    stake_pool.withdraw_bump_seed,
+                                    validator_stake_info.clone(),
+                                    clock_info.clone(),
+                                    stake_history_info.clone(),
+                                    stake_program_info.clone(),
+                                )?;
+                            } else {
+                                msg!("Stake activating or just active, not ready to merge");
+                                stake_lamports += transient_stake_info.lamports();
+                            }
+                        } else {
+                            msg!("Transient stake is activating or active, but validator stake is not, need to add the validator stake account on {} back into the stake pool", stake.delegation.voter_pubkey);
+                            stake_lamports += transient_stake_info.lamports();
+                        }
+                    } else {
+                        msg!("Transient stake not ready to be merged anywhere");
+                        stake_lamports += transient_stake_info.lamports();
+                    }
+                }
+                None
+                | Some(stake_program::StakeState::Uninitialized)
+                | Some(stake_program::StakeState::RewardsPool) => {} // do nothing
             }
+
+            match validator_stake_state {
+                Some(stake_program::StakeState::Stake(meta, _)) => {
+                    stake_lamports += validator_stake_info
+                        .lamports()
+                        .saturating_sub(minimum_stake_lamports(&meta));
+                }
+                Some(stake_program::StakeState::Initialized(_))
+                | Some(stake_program::StakeState::Uninitialized)
+                | Some(stake_program::StakeState::RewardsPool)
+                | None => {
+                    msg!("Validator stake account no longer part of the pool, not considering");
+                }
+            }
+
+            validator_stake_record.last_update_epoch = clock.epoch;
+            validator_stake_record.stake_lamports = stake_lamports;
+            changes = true;
         }
 
         if changes {
@@ -1104,8 +1266,9 @@ impl Processor {
     ) -> ProgramResult {
         let account_info_iter = &mut accounts.iter();
         let stake_pool_info = next_account_info(account_info_iter)?;
-        let validator_list_info = next_account_info(account_info_iter)?;
         let withdraw_info = next_account_info(account_info_iter)?;
+        let validator_list_info = next_account_info(account_info_iter)?;
+        let reserve_stake_info = next_account_info(account_info_iter)?;
         let manager_fee_info = next_account_info(account_info_iter)?;
         let pool_mint_info = next_account_info(account_info_iter)?;
         let clock_info = next_account_info(account_info_iter)?;
@@ -1136,7 +1299,19 @@ impl Processor {
         }
 
         let previous_lamports = stake_pool.total_stake_lamports;
-        let mut total_stake_lamports: u64 = 0;
+        let reserve_stake = try_from_slice_unchecked::<stake_program::StakeState>(
+            &reserve_stake_info.data.borrow(),
+        )?;
+        let mut total_stake_lamports =
+            if let stake_program::StakeState::Initialized(meta) = reserve_stake {
+                reserve_stake_info
+                    .lamports()
+                    .checked_sub(minimum_reserve_lamports(&meta))
+                    .ok_or(StakePoolError::CalculationFailure)?
+            } else {
+                msg!("Reserve stake account in unknown state, aborting");
+                return Err(StakePoolError::WrongStakeState.into());
+            };
         for validator_stake_record in validator_list.validators {
             if validator_stake_record.last_update_epoch < clock.epoch {
                 return Err(StakePoolError::StakeListOutOfDate.into());
@@ -1177,31 +1352,27 @@ impl Processor {
 
     /// Check stake activation status
     #[allow(clippy::unnecessary_wraps)]
-    fn check_stake_activation(
-        _stake_info: &AccountInfo,
-        _clock: &Clock,
-        _stake_history: &StakeHistory,
+    fn _check_stake_activation(
+        stake_info: &AccountInfo,
+        clock: &Clock,
+        stake_history: &StakeHistory,
     ) -> ProgramResult {
-        // TODO: remove conditional compilation when time travel in tests is possible
-        //#[cfg(not(feature = "test-bpf"))]
-        // This check is commented to make tests run without special command line arguments
-        /*{
-            let stake_acc_state: stake_program::StakeState =
-                deserialize(&stake_info.data.borrow()).unwrap();
-            let delegation = stake_acc_state.delegation();
-            if let Some(delegation) = delegation {
-                let target_epoch = clock.epoch;
-                let history = Some(stake_history);
-                let fix_stake_deactivate = true;
-                let (effective, activating, deactivating) = delegation
-                    .stake_activating_and_deactivating(target_epoch, history, fix_stake_deactivate);
-                if activating != 0 || deactivating != 0 || effective == 0 {
-                    return Err(StakePoolError::UserStakeNotActive.into());
-                }
-            } else {
-                return Err(StakePoolError::WrongStakeState.into());
+        let stake_acc_state =
+            try_from_slice_unchecked::<stake_program::StakeState>(&stake_info.data.borrow())
+                .unwrap();
+        let delegation = stake_acc_state.delegation();
+        if let Some(delegation) = delegation {
+            let target_epoch = clock.epoch;
+            let history = Some(stake_history);
+            let fix_stake_deactivate = true;
+            let (effective, activating, deactivating) = delegation
+                .stake_activating_and_deactivating(target_epoch, history, fix_stake_deactivate);
+            if activating != 0 || deactivating != 0 || effective == 0 {
+                return Err(StakePoolError::UserStakeNotActive.into());
             }
-        }*/
+        } else {
+            return Err(StakePoolError::WrongStakeState.into());
+        }
         Ok(())
     }
 
@@ -1219,7 +1390,7 @@ impl Processor {
         let clock_info = next_account_info(account_info_iter)?;
         let clock = &Clock::from_account_info(clock_info)?;
         let stake_history_info = next_account_info(account_info_iter)?;
-        let stake_history = &StakeHistory::from_account_info(stake_history_info)?;
+        //let stake_history = &StakeHistory::from_account_info(stake_history_info)?;
         let token_program_info = next_account_info(account_info_iter)?;
         let stake_program_info = next_account_info(account_info_iter)?;
 
@@ -1232,7 +1403,7 @@ impl Processor {
             return Err(StakePoolError::InvalidState.into());
         }
 
-        Self::check_stake_activation(stake_info, clock, stake_history)?;
+        //Self::check_stake_activation(stake_info, clock, stake_history)?;
 
         stake_pool.check_authority_withdraw(withdraw_info.key, program_id, stake_pool_info.key)?;
         stake_pool.check_authority_deposit(deposit_info.key, program_id, stake_pool_info.key)?;
@@ -1273,6 +1444,11 @@ impl Processor {
         let new_pool_tokens = stake_pool
             .calc_pool_tokens_for_deposit(stake_lamports)
             .ok_or(StakePoolError::CalculationFailure)?;
+
+        msg!(
+            "lamports pre merge {}",
+            validator_stake_account_info.lamports()
+        );
 
         Self::stake_authorize(
             stake_pool_info.key,
@@ -1331,9 +1507,12 @@ impl Processor {
             .ok_or(StakePoolError::CalculationFailure)?;
         stake_pool.serialize(&mut *stake_pool_info.data.borrow_mut())?;
 
+        msg!(
+            "lamports post merge {}",
+            validator_stake_account_info.lamports()
+        );
         validator_list_item.stake_lamports = validator_stake_account_info
-            .lamports
-            .borrow()
+            .lamports()
             .checked_sub(minimum_stake_lamports(&meta))
             .ok_or(StakePoolError::CalculationFailure)?;
         validator_list.serialize(&mut *validator_list_info.data.borrow_mut())?;
@@ -1572,7 +1751,7 @@ impl Processor {
                 fee,
                 max_validators,
             } => {
-                msg!("Instruction: Init");
+                msg!("Instruction: Initialize stake pool");
                 Self::process_initialize(program_id, accounts, fee, max_validators)
             }
             StakePoolInstruction::CreateValidatorStakeAccount => {
@@ -1595,9 +1774,17 @@ impl Processor {
                 msg!("Instruction: IncreaseValidatorStake");
                 Self::process_increase_validator_stake(program_id, accounts, amount)
             }
-            StakePoolInstruction::UpdateValidatorListBalance => {
+            StakePoolInstruction::UpdateValidatorListBalance {
+                start_index,
+                no_merge,
+            } => {
                 msg!("Instruction: UpdateValidatorListBalance");
-                Self::process_update_validator_list_balance(program_id, accounts)
+                Self::process_update_validator_list_balance(
+                    program_id,
+                    accounts,
+                    start_index,
+                    no_merge,
+                )
             }
             StakePoolInstruction::UpdateStakePoolBalance => {
                 msg!("Instruction: UpdateStakePoolBalance");

--- a/stake-pool/program/src/stake_program.rs
+++ b/stake-pool/program/src/stake_program.rs
@@ -1,7 +1,10 @@
 //! FIXME copied from the solana stake program
 
 use {
-    borsh::{maybestd::io::{Result as IoResult, Error as IoError, ErrorKind as IoErrorKind}, BorshSerialize, BorshDeserialize, BorshSchema},
+    borsh::{
+        maybestd::io::{Error as IoError, ErrorKind as IoErrorKind, Result as IoResult},
+        BorshDeserialize, BorshSchema, BorshSerialize,
+    },
     serde_derive::{Deserialize, Serialize},
     solana_program::{
         clock::{Epoch, UnixTimestamp},
@@ -138,12 +141,12 @@ impl BorshDeserialize for StakeState {
             1 => {
                 let meta: Meta = BorshDeserialize::deserialize(buf)?;
                 Ok(StakeState::Initialized(meta))
-            },
+            }
             2 => {
                 let meta: Meta = BorshDeserialize::deserialize(buf)?;
                 let stake: Stake = BorshDeserialize::deserialize(buf)?;
                 Ok(StakeState::Stake(meta, stake))
-            },
+            }
             3 => Ok(StakeState::RewardsPool),
             _ => Err(IoError::new(IoErrorKind::InvalidData, "Invalid enum value")),
         }
@@ -151,7 +154,18 @@ impl BorshDeserialize for StakeState {
 }
 
 /// FIXME copied from the stake program
-#[derive(BorshSerialize, BorshDeserialize, BorshSchema, Default, Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
+#[derive(
+    BorshSerialize,
+    BorshDeserialize,
+    BorshSchema,
+    Default,
+    Debug,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Clone,
+    Copy,
+)]
 pub struct Meta {
     /// FIXME copied from the stake program
     pub rent_exempt_reserve: u64,
@@ -162,7 +176,18 @@ pub struct Meta {
 }
 
 /// FIXME copied from the stake program
-#[derive(BorshSerialize, BorshDeserialize, BorshSchema, Debug, Default, Serialize, Deserialize, PartialEq, Clone, Copy)]
+#[derive(
+    BorshSerialize,
+    BorshDeserialize,
+    BorshSchema,
+    Debug,
+    Default,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Clone,
+    Copy,
+)]
 pub struct Stake {
     /// FIXME copied from the stake program
     pub delegation: Delegation,
@@ -171,7 +196,18 @@ pub struct Stake {
 }
 
 /// FIXME copied from the stake program
-#[derive(BorshSerialize, BorshDeserialize, BorshSchema, Debug, Default, Serialize, Deserialize, PartialEq, Clone, Copy)]
+#[derive(
+    BorshSerialize,
+    BorshDeserialize,
+    BorshSchema,
+    Debug,
+    Default,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Clone,
+    Copy,
+)]
 pub struct Delegation {
     /// to whom the stake is delegated
     pub voter_pubkey: Pubkey,
@@ -186,7 +222,17 @@ pub struct Delegation {
 }
 
 /// FIXME copied from the stake program
-#[derive(BorshSerialize, BorshDeserialize, BorshSchema, Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
+#[derive(
+    BorshSerialize,
+    BorshDeserialize,
+    BorshSchema,
+    Debug,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Clone,
+    Copy,
+)]
 pub enum StakeAuthorize {
     /// FIXME copied from the stake program
     Staker,
@@ -194,7 +240,18 @@ pub enum StakeAuthorize {
     Withdrawer,
 }
 /// FIXME copied from the stake program
-#[derive(BorshSerialize, BorshDeserialize, BorshSchema, Default, Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
+#[derive(
+    BorshSerialize,
+    BorshDeserialize,
+    BorshSchema,
+    Default,
+    Debug,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Clone,
+    Copy,
+)]
 pub struct Authorized {
     /// FIXME copied from the stake program
     pub staker: Pubkey,
@@ -203,7 +260,18 @@ pub struct Authorized {
 }
 
 /// FIXME copied from the stake program
-#[derive(BorshSerialize, BorshDeserialize, BorshSchema, Default, Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
+#[derive(
+    BorshSerialize,
+    BorshDeserialize,
+    BorshSchema,
+    Default,
+    Debug,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Clone,
+    Copy,
+)]
 pub struct Lockup {
     /// UnixTimestamp at which this stake will allow withdrawal, unless the
     ///   transaction is signed by the custodian
@@ -435,7 +503,7 @@ impl Delegation {
 /// from a CPI error.
 pub fn active_delegations_can_merge(
     stake: &Delegation,
-    source: &Delegation
+    source: &Delegation,
 ) -> Result<(), ProgramError> {
     if stake.voter_pubkey != source.voter_pubkey {
         msg!("Unable to merge due to voter mismatch");
@@ -454,10 +522,7 @@ pub fn active_delegations_can_merge(
 /// FIXME copied from stake program
 /// Checks if two active stakes are mergeable, required since we cannot recover
 /// from a CPI error.
-pub fn active_stakes_can_merge(
-    stake: &Stake,
-    source: &Stake,
-) -> Result<(), ProgramError> {
+pub fn active_stakes_can_merge(stake: &Stake, source: &Stake) -> Result<(), ProgramError> {
     active_delegations_can_merge(&stake.delegation, &source.delegation)?;
 
     if stake.credits_observed == source.credits_observed {
@@ -582,11 +647,7 @@ pub fn deactivate_stake(stake_pubkey: &Pubkey, authorized_pubkey: &Pubkey) -> In
 
 #[cfg(test)]
 mod test {
-    use {
-        super::*,
-        crate::borsh::try_from_slice_unchecked,
-        bincode::serialize,
-    };
+    use {super::*, crate::borsh::try_from_slice_unchecked, bincode::serialize};
 
     fn check_borsh_deserialization(stake: StakeState) {
         let serialized = serialize(&stake).unwrap();
@@ -606,7 +667,8 @@ mod test {
             },
             lockup: Lockup::default(),
         }));
-        check_borsh_deserialization(StakeState::Stake(Meta {
+        check_borsh_deserialization(StakeState::Stake(
+            Meta {
                 rent_exempt_reserve: 1,
                 authorized: Authorized {
                     staker: Pubkey::new_unique(),
@@ -623,13 +685,23 @@ mod test {
                     warmup_cooldown_rate: f64::MAX,
                 },
                 credits_observed: 1,
-            }
+            },
         ));
     }
 
     #[test]
     fn borsh_deserialization_live_data() {
-        let data = [1, 0, 0, 0, 128, 213, 34, 0, 0, 0, 0, 0, 133, 0, 79, 231, 141, 29, 73, 61, 232, 35, 119, 124, 168, 12, 120, 216, 195, 29, 12, 166, 139, 28, 36, 182, 186, 154, 246, 149, 224, 109, 52, 100, 133, 0, 79, 231, 141, 29, 73, 61, 232, 35, 119, 124, 168, 12, 120, 216, 195, 29, 12, 166, 139, 28, 36, 182, 186, 154, 246, 149, 224, 109, 52, 100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let data = [
+            1, 0, 0, 0, 128, 213, 34, 0, 0, 0, 0, 0, 133, 0, 79, 231, 141, 29, 73, 61, 232, 35,
+            119, 124, 168, 12, 120, 216, 195, 29, 12, 166, 139, 28, 36, 182, 186, 154, 246, 149,
+            224, 109, 52, 100, 133, 0, 79, 231, 141, 29, 73, 61, 232, 35, 119, 124, 168, 12, 120,
+            216, 195, 29, 12, 166, 139, 28, 36, 182, 186, 154, 246, 149, 224, 109, 52, 100, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0,
+        ];
         let _deserialized = try_from_slice_unchecked::<StakeState>(&data).unwrap();
     }
 }

--- a/stake-pool/program/src/stake_program.rs
+++ b/stake-pool/program/src/stake_program.rs
@@ -1,14 +1,19 @@
 //! FIXME copied from the solana stake program
 
-use serde_derive::{Deserialize, Serialize};
-use solana_program::{
-    clock::{Epoch, UnixTimestamp},
-    instruction::{AccountMeta, Instruction},
-    pubkey::Pubkey,
-    stake_history::StakeHistory,
-    system_instruction, sysvar,
+use {
+    borsh::{maybestd::io::{Result as IoResult, Error as IoError, ErrorKind as IoErrorKind}, BorshSerialize, BorshDeserialize, BorshSchema},
+    serde_derive::{Deserialize, Serialize},
+    solana_program::{
+        clock::{Epoch, UnixTimestamp},
+        instruction::{AccountMeta, Instruction},
+        msg,
+        program_error::ProgramError,
+        pubkey::Pubkey,
+        stake_history::StakeHistory,
+        system_instruction, sysvar,
+    },
+    std::str::FromStr,
 };
-use std::str::FromStr;
 
 solana_program::declare_id!("Stake11111111111111111111111111111111111111");
 
@@ -125,8 +130,28 @@ pub enum StakeState {
     RewardsPool,
 }
 
+impl BorshDeserialize for StakeState {
+    fn deserialize(buf: &mut &[u8]) -> IoResult<Self> {
+        let u: u32 = BorshDeserialize::deserialize(buf)?;
+        match u {
+            0 => Ok(StakeState::Uninitialized),
+            1 => {
+                let meta: Meta = BorshDeserialize::deserialize(buf)?;
+                Ok(StakeState::Initialized(meta))
+            },
+            2 => {
+                let meta: Meta = BorshDeserialize::deserialize(buf)?;
+                let stake: Stake = BorshDeserialize::deserialize(buf)?;
+                Ok(StakeState::Stake(meta, stake))
+            },
+            3 => Ok(StakeState::RewardsPool),
+            _ => Err(IoError::new(IoErrorKind::InvalidData, "Invalid enum value")),
+        }
+    }
+}
+
 /// FIXME copied from the stake program
-#[derive(Default, Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
+#[derive(BorshSerialize, BorshDeserialize, BorshSchema, Default, Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
 pub struct Meta {
     /// FIXME copied from the stake program
     pub rent_exempt_reserve: u64,
@@ -137,7 +162,7 @@ pub struct Meta {
 }
 
 /// FIXME copied from the stake program
-#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Clone, Copy)]
+#[derive(BorshSerialize, BorshDeserialize, BorshSchema, Debug, Default, Serialize, Deserialize, PartialEq, Clone, Copy)]
 pub struct Stake {
     /// FIXME copied from the stake program
     pub delegation: Delegation,
@@ -146,7 +171,7 @@ pub struct Stake {
 }
 
 /// FIXME copied from the stake program
-#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Clone, Copy)]
+#[derive(BorshSerialize, BorshDeserialize, BorshSchema, Debug, Default, Serialize, Deserialize, PartialEq, Clone, Copy)]
 pub struct Delegation {
     /// to whom the stake is delegated
     pub voter_pubkey: Pubkey,
@@ -161,7 +186,7 @@ pub struct Delegation {
 }
 
 /// FIXME copied from the stake program
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
+#[derive(BorshSerialize, BorshDeserialize, BorshSchema, Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
 pub enum StakeAuthorize {
     /// FIXME copied from the stake program
     Staker,
@@ -169,7 +194,7 @@ pub enum StakeAuthorize {
     Withdrawer,
 }
 /// FIXME copied from the stake program
-#[derive(Default, Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
+#[derive(BorshSerialize, BorshDeserialize, BorshSchema, Default, Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
 pub struct Authorized {
     /// FIXME copied from the stake program
     pub staker: Pubkey,
@@ -178,7 +203,7 @@ pub struct Authorized {
 }
 
 /// FIXME copied from the stake program
-#[derive(Default, Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
+#[derive(BorshSerialize, BorshDeserialize, BorshSchema, Default, Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
 pub struct Lockup {
     /// UnixTimestamp at which this stake will allow withdrawal, unless the
     ///   transaction is signed by the custodian
@@ -405,6 +430,44 @@ impl Delegation {
     }
 }
 
+/// FIXME copied from stake program
+/// Checks if two active delegations are mergeable, required since we cannot recover
+/// from a CPI error.
+pub fn active_delegations_can_merge(
+    stake: &Delegation,
+    source: &Delegation
+) -> Result<(), ProgramError> {
+    if stake.voter_pubkey != source.voter_pubkey {
+        msg!("Unable to merge due to voter mismatch");
+        Err(ProgramError::InvalidAccountData)
+    } else if (stake.warmup_cooldown_rate - source.warmup_cooldown_rate).abs() < f64::EPSILON
+        && stake.deactivation_epoch == Epoch::MAX
+        && source.deactivation_epoch == Epoch::MAX
+    {
+        Ok(())
+    } else {
+        msg!("Unable to merge due to stake deactivation");
+        Err(ProgramError::InvalidAccountData)
+    }
+}
+
+/// FIXME copied from stake program
+/// Checks if two active stakes are mergeable, required since we cannot recover
+/// from a CPI error.
+pub fn active_stakes_can_merge(
+    stake: &Stake,
+    source: &Stake,
+) -> Result<(), ProgramError> {
+    active_delegations_can_merge(&stake.delegation, &source.delegation)?;
+
+    if stake.credits_observed == source.credits_observed {
+        Ok(())
+    } else {
+        msg!("Unable to merge due to credits observed mismatch");
+        Err(ProgramError::InvalidAccountData)
+    }
+}
+
 /// FIXME copied from the stake program
 pub fn split_only(
     stake_pubkey: &Pubkey,
@@ -515,4 +578,58 @@ pub fn deactivate_stake(stake_pubkey: &Pubkey, authorized_pubkey: &Pubkey) -> In
         AccountMeta::new_readonly(*authorized_pubkey, true),
     ];
     Instruction::new_with_bincode(id(), &StakeInstruction::Deactivate, account_metas)
+}
+
+#[cfg(test)]
+mod test {
+    use {
+        super::*,
+        crate::borsh::try_from_slice_unchecked,
+        bincode::serialize,
+    };
+
+    fn check_borsh_deserialization(stake: StakeState) {
+        let serialized = serialize(&stake).unwrap();
+        let deserialized = StakeState::try_from_slice(&serialized).unwrap();
+        assert_eq!(stake, deserialized);
+    }
+
+    #[test]
+    fn bincode_vs_borsh() {
+        check_borsh_deserialization(StakeState::Uninitialized);
+        check_borsh_deserialization(StakeState::RewardsPool);
+        check_borsh_deserialization(StakeState::Initialized(Meta {
+            rent_exempt_reserve: u64::MAX,
+            authorized: Authorized {
+                staker: Pubkey::new_unique(),
+                withdrawer: Pubkey::new_unique(),
+            },
+            lockup: Lockup::default(),
+        }));
+        check_borsh_deserialization(StakeState::Stake(Meta {
+                rent_exempt_reserve: 1,
+                authorized: Authorized {
+                    staker: Pubkey::new_unique(),
+                    withdrawer: Pubkey::new_unique(),
+                },
+                lockup: Lockup::default(),
+            },
+            Stake {
+                delegation: Delegation {
+                    voter_pubkey: Pubkey::new_unique(),
+                    stake: u64::MAX,
+                    activation_epoch: Epoch::MAX,
+                    deactivation_epoch: Epoch::MAX,
+                    warmup_cooldown_rate: f64::MAX,
+                },
+                credits_observed: 1,
+            }
+        ));
+    }
+
+    #[test]
+    fn borsh_deserialization_live_data() {
+        let data = [1, 0, 0, 0, 128, 213, 34, 0, 0, 0, 0, 0, 133, 0, 79, 231, 141, 29, 73, 61, 232, 35, 119, 124, 168, 12, 120, 216, 195, 29, 12, 166, 139, 28, 36, 182, 186, 154, 246, 149, 224, 109, 52, 100, 133, 0, 79, 231, 141, 29, 73, 61, 232, 35, 119, 124, 168, 12, 120, 216, 195, 29, 12, 166, 139, 28, 36, 182, 186, 154, 246, 149, 224, 109, 52, 100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let _deserialized = try_from_slice_unchecked::<StakeState>(&data).unwrap();
+    }
 }

--- a/stake-pool/program/tests/decrease.rs
+++ b/stake-pool/program/tests/decrease.rs
@@ -23,7 +23,7 @@ async fn setup() -> (
     Hash,
     StakePoolAccounts,
     ValidatorStakeAccount,
-    DepositInfo,
+    DepositStakeAccount,
     u64,
 ) {
     let (mut banks_client, payer, recent_blockhash) = program_test().start().await;

--- a/stake-pool/program/tests/deposit.rs
+++ b/stake-pool/program/tests/deposit.rs
@@ -88,6 +88,7 @@ async fn test_stake_pool_deposit() {
         &mut banks_client,
         &payer,
         &recent_blockhash,
+        &validator_stake_account.validator,
         &validator_stake_account.vote,
     )
     .await;

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -270,14 +270,13 @@ pub async fn create_vote(
     let rent = banks_client.get_rent().await.unwrap();
     let rent_voter = rent.minimum_balance(VoteState::size_of());
 
-    let mut instructions = vec![];
-    instructions.push(system_instruction::create_account(
+    let mut instructions = vec![system_instruction::create_account(
         &payer.pubkey(),
         &validator.pubkey(),
         42,
         0,
         &system_program::id(),
-    ));
+    )];
     instructions.append(&mut vote_instruction::create_account(
         &payer.pubkey(),
         &vote.pubkey(),

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -719,8 +719,9 @@ impl StakePoolAccounts {
         banks_client: &mut BanksClient,
         payer: &Keypair,
         recent_blockhash: &Hash,
-        stake: &Pubkey,
         new_authority: &Pubkey,
+        validator_stake: &Pubkey,
+        transient_stake: &Pubkey,
     ) -> Option<TransportError> {
         let transaction = Transaction::new_signed_with_payer(
             &[instruction::remove_validator_from_pool(
@@ -730,7 +731,8 @@ impl StakePoolAccounts {
                 &self.withdraw_authority,
                 &new_authority,
                 &self.validator_list.pubkey(),
-                stake,
+                validator_stake,
+                transient_stake,
             )
             .unwrap()],
             Some(&payer.pubkey()),

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -3,6 +3,7 @@
 use {
     solana_program::{
         borsh::get_packed_len, hash::Hash, program_pack::Pack, pubkey::Pubkey, system_instruction,
+        system_program,
     },
     solana_program_test::*,
     solana_sdk::{
@@ -11,7 +12,10 @@ use {
         transaction::Transaction,
         transport::TransportError,
     },
-    solana_vote_program::{self, vote_state::VoteState},
+    solana_vote_program::{
+        self, vote_instruction,
+        vote_state::{VoteInit, VoteState},
+    },
     spl_stake_pool::{
         borsh::{get_instance_packed_len, try_from_slice_unchecked},
         find_stake_program_address, find_transient_stake_program_address, id, instruction,
@@ -19,7 +23,7 @@ use {
     },
 };
 
-pub const TEST_STAKE_AMOUNT: u64 = 1_000_000;
+pub const TEST_STAKE_AMOUNT: u64 = 100_000_000;
 pub const MAX_TEST_VALIDATORS: u32 = 10_000;
 
 pub fn program_test() -> ProgramTest {
@@ -260,22 +264,37 @@ pub async fn create_vote(
     banks_client: &mut BanksClient,
     payer: &Keypair,
     recent_blockhash: &Hash,
+    validator: &Keypair,
     vote: &Keypair,
 ) {
     let rent = banks_client.get_rent().await.unwrap();
     let rent_voter = rent.minimum_balance(VoteState::size_of());
 
-    let mut transaction = Transaction::new_with_payer(
-        &[system_instruction::create_account(
-            &payer.pubkey(),
-            &vote.pubkey(),
-            rent_voter,
-            VoteState::size_of() as u64,
-            &solana_vote_program::id(),
-        )],
+    let mut instructions = vec![];
+    instructions.push(system_instruction::create_account(
+        &payer.pubkey(),
+        &validator.pubkey(),
+        42,
+        0,
+        &system_program::id(),
+    ));
+    instructions.append(&mut vote_instruction::create_account(
+        &payer.pubkey(),
+        &vote.pubkey(),
+        &VoteInit {
+            node_pubkey: validator.pubkey(),
+            authorized_voter: validator.pubkey(),
+            ..VoteInit::default()
+        },
+        rent_voter,
+    ));
+
+    let transaction = Transaction::new_signed_with_payer(
+        &instructions,
         Some(&payer.pubkey()),
+        &[validator, vote, payer],
+        *recent_blockhash,
     );
-    transaction.sign(&[&vote, payer], *recent_blockhash);
     banks_client.process_transaction(transaction).await.unwrap();
 }
 
@@ -408,20 +427,23 @@ pub struct ValidatorStakeAccount {
     pub transient_stake_account: Pubkey,
     pub target_authority: Pubkey,
     pub vote: Keypair,
+    pub validator: Keypair,
     pub stake_pool: Pubkey,
 }
 
 impl ValidatorStakeAccount {
     pub fn new_with_target_authority(authority: &Pubkey, stake_pool: &Pubkey) -> Self {
         let validator = Keypair::new();
-        let (stake_account, _) = find_stake_program_address(&id(), &validator.pubkey(), stake_pool);
+        let vote = Keypair::new();
+        let (stake_account, _) = find_stake_program_address(&id(), &vote.pubkey(), stake_pool);
         let (transient_stake_account, _) =
-            find_transient_stake_program_address(&id(), &validator.pubkey(), stake_pool);
+            find_transient_stake_program_address(&id(), &vote.pubkey(), stake_pool);
         ValidatorStakeAccount {
             stake_account,
             transient_stake_account,
             target_authority: *authority,
-            vote: validator,
+            vote,
+            validator,
             stake_pool: *stake_pool,
         }
     }
@@ -433,7 +455,14 @@ impl ValidatorStakeAccount {
         recent_blockhash: &Hash,
         staker: &Keypair,
     ) {
-        create_vote(&mut banks_client, &payer, &recent_blockhash, &self.vote).await;
+        create_vote(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            &self.validator,
+            &self.vote,
+        )
+        .await;
 
         create_validator_stake_account(
             &mut banks_client,
@@ -650,15 +679,20 @@ impl StakePoolAccounts {
         banks_client: &mut BanksClient,
         payer: &Keypair,
         recent_blockhash: &Hash,
-        validator_list: &[Pubkey],
+        validator_vote_accounts: &[Pubkey],
+        no_merge: bool,
     ) -> Option<TransportError> {
         let transaction = Transaction::new_signed_with_payer(
             &[instruction::update_validator_list_balance(
                 &id(),
+                &self.stake_pool.pubkey(),
+                &self.withdraw_authority,
                 &self.validator_list.pubkey(),
-                validator_list,
-            )
-            .unwrap()],
+                &self.reserve_stake.pubkey(),
+                validator_vote_accounts,
+                0,
+                no_merge,
+            )],
             Some(&payer.pubkey()),
             &[payer],
             *recent_blockhash,
@@ -676,12 +710,49 @@ impl StakePoolAccounts {
             &[instruction::update_stake_pool_balance(
                 &id(),
                 &self.stake_pool.pubkey(),
-                &self.validator_list.pubkey(),
                 &self.withdraw_authority,
+                &self.validator_list.pubkey(),
+                &self.reserve_stake.pubkey(),
                 &self.pool_fee_account.pubkey(),
                 &self.pool_mint.pubkey(),
-            )
-            .unwrap()],
+            )],
+            Some(&payer.pubkey()),
+            &[payer],
+            *recent_blockhash,
+        );
+        banks_client.process_transaction(transaction).await.err()
+    }
+
+    pub async fn update_all(
+        &self,
+        banks_client: &mut BanksClient,
+        payer: &Keypair,
+        recent_blockhash: &Hash,
+        validator_vote_accounts: &[Pubkey],
+        no_merge: bool,
+    ) -> Option<TransportError> {
+        let transaction = Transaction::new_signed_with_payer(
+            &[
+                instruction::update_validator_list_balance(
+                    &id(),
+                    &self.stake_pool.pubkey(),
+                    &self.withdraw_authority,
+                    &self.validator_list.pubkey(),
+                    &self.reserve_stake.pubkey(),
+                    validator_vote_accounts,
+                    0,
+                    no_merge,
+                ),
+                instruction::update_stake_pool_balance(
+                    &id(),
+                    &self.stake_pool.pubkey(),
+                    &self.withdraw_authority,
+                    &self.validator_list.pubkey(),
+                    &self.reserve_stake.pubkey(),
+                    &self.pool_fee_account.pubkey(),
+                    &self.pool_mint.pubkey(),
+                ),
+            ],
             Some(&payer.pubkey()),
             &[payer],
             *recent_blockhash,
@@ -806,11 +877,11 @@ pub async fn simple_add_validator_to_pool(
     recent_blockhash: &Hash,
     stake_pool_accounts: &StakePoolAccounts,
 ) -> ValidatorStakeAccount {
-    let user_stake = ValidatorStakeAccount::new_with_target_authority(
+    let validator_stake = ValidatorStakeAccount::new_with_target_authority(
         &stake_pool_accounts.deposit_authority,
         &stake_pool_accounts.stake_pool.pubkey(),
     );
-    user_stake
+    validator_stake
         .create_and_delegate(
             banks_client,
             &payer,
@@ -824,20 +895,128 @@ pub async fn simple_add_validator_to_pool(
             banks_client,
             &payer,
             &recent_blockhash,
-            &user_stake.stake_account,
+            &validator_stake.stake_account,
         )
         .await;
     assert!(error.is_none());
 
-    user_stake
+    validator_stake
 }
 
 #[derive(Debug)]
-pub struct DepositInfo {
-    pub user: Keypair,
-    pub user_pool_account: Pubkey,
+pub struct DepositStakeAccount {
+    pub authority: Keypair,
+    pub stake: Keypair,
+    pub pool_account: Keypair,
     pub stake_lamports: u64,
     pub pool_tokens: u64,
+    pub vote_account: Pubkey,
+    pub validator_stake_account: Pubkey,
+}
+
+impl DepositStakeAccount {
+    pub fn new_with_vote(
+        vote_account: Pubkey,
+        validator_stake_account: Pubkey,
+        stake_lamports: u64,
+    ) -> Self {
+        let authority = Keypair::new();
+        let stake = Keypair::new();
+        let pool_account = Keypair::new();
+        Self {
+            authority,
+            stake,
+            pool_account,
+            vote_account,
+            validator_stake_account,
+            stake_lamports,
+            pool_tokens: 0,
+        }
+    }
+
+    pub async fn create_and_delegate(
+        &self,
+        banks_client: &mut BanksClient,
+        payer: &Keypair,
+        recent_blockhash: &Hash,
+    ) {
+        let lockup = stake_program::Lockup::default();
+        let authorized = stake_program::Authorized {
+            staker: self.authority.pubkey(),
+            withdrawer: self.authority.pubkey(),
+        };
+        create_independent_stake_account(
+            banks_client,
+            payer,
+            recent_blockhash,
+            &self.stake,
+            &authorized,
+            &lockup,
+            self.stake_lamports,
+        )
+        .await;
+        delegate_stake_account(
+            banks_client,
+            payer,
+            recent_blockhash,
+            &self.stake.pubkey(),
+            &self.authority,
+            &self.vote_account,
+        )
+        .await;
+    }
+
+    pub async fn deposit(
+        &self,
+        banks_client: &mut BanksClient,
+        payer: &Keypair,
+        recent_blockhash: &Hash,
+        stake_pool_accounts: &StakePoolAccounts,
+    ) {
+        authorize_stake_account(
+            banks_client,
+            payer,
+            recent_blockhash,
+            &self.stake.pubkey(),
+            &self.authority,
+            &stake_pool_accounts.deposit_authority,
+            stake_program::StakeAuthorize::Staker,
+        )
+        .await;
+        authorize_stake_account(
+            banks_client,
+            &payer,
+            &recent_blockhash,
+            &self.stake.pubkey(),
+            &self.authority,
+            &stake_pool_accounts.deposit_authority,
+            stake_program::StakeAuthorize::Withdrawer,
+        )
+        .await;
+        // make pool token account
+        create_token_account(
+            banks_client,
+            payer,
+            recent_blockhash,
+            &self.pool_account,
+            &stake_pool_accounts.pool_mint.pubkey(),
+            &self.authority.pubkey(),
+        )
+        .await
+        .unwrap();
+
+        stake_pool_accounts
+            .deposit_stake(
+                banks_client,
+                payer,
+                recent_blockhash,
+                &self.stake.pubkey(),
+                &self.pool_account.pubkey(),
+                &self.validator_stake_account,
+            )
+            .await
+            .unwrap();
+    }
 }
 
 pub async fn simple_deposit(
@@ -847,76 +1026,118 @@ pub async fn simple_deposit(
     stake_pool_accounts: &StakePoolAccounts,
     validator_stake_account: &ValidatorStakeAccount,
     stake_lamports: u64,
-) -> DepositInfo {
-    let user = Keypair::new();
+) -> DepositStakeAccount {
+    let authority = Keypair::new();
     // make stake account
-    let user_stake = Keypair::new();
+    let stake = Keypair::new();
     let lockup = stake_program::Lockup::default();
     let authorized = stake_program::Authorized {
-        staker: stake_pool_accounts.deposit_authority,
-        withdrawer: stake_pool_accounts.deposit_authority,
+        staker: authority.pubkey(),
+        withdrawer: authority.pubkey(),
     };
     create_independent_stake_account(
         banks_client,
         payer,
         recent_blockhash,
-        &user_stake,
+        &stake,
         &authorized,
         &lockup,
         stake_lamports,
     )
     .await;
+    let vote_account = validator_stake_account.vote.pubkey();
+    delegate_stake_account(
+        banks_client,
+        payer,
+        recent_blockhash,
+        &stake.pubkey(),
+        &authority,
+        &vote_account,
+    )
+    .await;
+    authorize_stake_account(
+        banks_client,
+        payer,
+        recent_blockhash,
+        &stake.pubkey(),
+        &authority,
+        &stake_pool_accounts.deposit_authority,
+        stake_program::StakeAuthorize::Staker,
+    )
+    .await;
+    authorize_stake_account(
+        banks_client,
+        &payer,
+        &recent_blockhash,
+        &stake.pubkey(),
+        &authority,
+        &stake_pool_accounts.deposit_authority,
+        stake_program::StakeAuthorize::Withdrawer,
+    )
+    .await;
     // make pool token account
-    let user_pool_account = Keypair::new();
+    let pool_account = Keypair::new();
     create_token_account(
         banks_client,
         payer,
         recent_blockhash,
-        &user_pool_account,
+        &pool_account,
         &stake_pool_accounts.pool_mint.pubkey(),
-        &user.pubkey(),
+        &authority.pubkey(),
     )
     .await
     .unwrap();
 
+    let validator_stake_account = validator_stake_account.stake_account;
     stake_pool_accounts
         .deposit_stake(
             banks_client,
             payer,
             recent_blockhash,
-            &user_stake.pubkey(),
-            &user_pool_account.pubkey(),
-            &validator_stake_account.stake_account,
+            &stake.pubkey(),
+            &pool_account.pubkey(),
+            &validator_stake_account,
         )
         .await
         .unwrap();
 
-    let user_pool_account = user_pool_account.pubkey();
-    let pool_tokens = get_token_balance(banks_client, &user_pool_account).await;
+    let pool_tokens = get_token_balance(banks_client, &pool_account.pubkey()).await;
 
-    DepositInfo {
-        user,
-        user_pool_account,
+    DepositStakeAccount {
+        authority,
+        stake,
+        pool_account,
         stake_lamports,
         pool_tokens,
+        vote_account,
+        validator_stake_account,
     }
 }
 
 pub async fn get_validator_list_sum(
     banks_client: &mut BanksClient,
-    validator_list_key: &Pubkey,
+    reserve_stake: &Pubkey,
+    validator_list: &Pubkey,
 ) -> u64 {
     let validator_list = banks_client
-        .get_account(*validator_list_key)
+        .get_account(*validator_list)
         .await
         .unwrap()
         .unwrap();
     let validator_list =
         try_from_slice_unchecked::<state::ValidatorList>(validator_list.data.as_slice()).unwrap();
+    let reserve_stake = banks_client
+        .get_account(*reserve_stake)
+        .await
+        .unwrap()
+        .unwrap();
 
-    validator_list
+    let validator_sum: u64 = validator_list
         .validators
         .iter()
         .map(|info| info.stake_lamports)
-        .sum()
+        .sum();
+    let rent = banks_client.get_rent().await.unwrap();
+    let rent = rent.minimum_balance(std::mem::size_of::<stake_program::StakeState>());
+    validator_sum + reserve_stake.lamports - rent - 1
 }

--- a/stake-pool/program/tests/update_stake_pool_balance.rs
+++ b/stake-pool/program/tests/update_stake_pool_balance.rs
@@ -63,13 +63,17 @@ async fn setup() -> (
 async fn success() {
     let (mut context, stake_pool_accounts, stake_accounts) = setup().await;
 
-    let before_balance = get_validator_list_sum(
+    let pre_balance = get_validator_list_sum(
         &mut context.banks_client,
+        &stake_pool_accounts.reserve_stake.pubkey(),
         &stake_pool_accounts.validator_list.pubkey(),
     )
     .await;
+    let stake_pool = get_account(&mut context.banks_client, &stake_pool_accounts.stake_pool.pubkey()).await;
+    let stake_pool = StakePool::try_from_slice(&stake_pool.data.as_slice()).unwrap();
+    assert_eq!(pre_balance, stake_pool.total_stake_lamports);
 
-    let before_token_supply = get_token_supply(
+    let pre_token_supply = get_token_supply(
         &mut context.banks_client,
         &stake_pool_accounts.pool_mint.pubkey(),
     )
@@ -102,33 +106,30 @@ async fn success() {
 
     // Update list and pool
     let error = stake_pool_accounts
-        .update_validator_list_balance(
+        .update_all(
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
             stake_accounts
                 .iter()
-                .map(|v| v.stake_account)
+                .map(|v| v.vote.pubkey())
                 .collect::<Vec<Pubkey>>()
                 .as_slice(),
-        )
-        .await;
-    assert!(error.is_none());
-    let error = stake_pool_accounts
-        .update_stake_pool_balance(
-            &mut context.banks_client,
-            &context.payer,
-            &context.last_blockhash,
+            false,
         )
         .await;
     assert!(error.is_none());
 
     // Check fee
-    let after_balance = get_validator_list_sum(
+    let post_balance = get_validator_list_sum(
         &mut context.banks_client,
+        &stake_pool_accounts.reserve_stake.pubkey(),
         &stake_pool_accounts.validator_list.pubkey(),
     )
     .await;
+    let stake_pool = get_account(&mut context.banks_client, &stake_pool_accounts.stake_pool.pubkey()).await;
+    let stake_pool = StakePool::try_from_slice(&stake_pool.data.as_slice()).unwrap();
+    assert_eq!(post_balance, stake_pool.total_stake_lamports);
 
     let actual_fee = get_token_balance(
         &mut context.banks_client,
@@ -147,7 +148,7 @@ async fn success() {
     )
     .await;
     let stake_pool = StakePool::try_from_slice(&stake_pool_info.data).unwrap();
-    let expected_fee = (after_balance - before_balance) * before_token_supply / before_balance
+    let expected_fee = (post_balance - pre_balance) * pre_token_supply / pre_balance
         * stake_pool.fee.numerator
         / stake_pool.fee.denominator;
     assert_eq!(actual_fee, expected_fee);

--- a/stake-pool/program/tests/update_stake_pool_balance.rs
+++ b/stake-pool/program/tests/update_stake_pool_balance.rs
@@ -69,7 +69,11 @@ async fn success() {
         &stake_pool_accounts.validator_list.pubkey(),
     )
     .await;
-    let stake_pool = get_account(&mut context.banks_client, &stake_pool_accounts.stake_pool.pubkey()).await;
+    let stake_pool = get_account(
+        &mut context.banks_client,
+        &stake_pool_accounts.stake_pool.pubkey(),
+    )
+    .await;
     let stake_pool = StakePool::try_from_slice(&stake_pool.data.as_slice()).unwrap();
     assert_eq!(pre_balance, stake_pool.total_stake_lamports);
 
@@ -127,7 +131,11 @@ async fn success() {
         &stake_pool_accounts.validator_list.pubkey(),
     )
     .await;
-    let stake_pool = get_account(&mut context.banks_client, &stake_pool_accounts.stake_pool.pubkey()).await;
+    let stake_pool = get_account(
+        &mut context.banks_client,
+        &stake_pool_accounts.stake_pool.pubkey(),
+    )
+    .await;
     let stake_pool = StakePool::try_from_slice(&stake_pool.data.as_slice()).unwrap();
     assert_eq!(post_balance, stake_pool.total_stake_lamports);
 

--- a/stake-pool/program/tests/update_validator_list_balance.rs
+++ b/stake-pool/program/tests/update_validator_list_balance.rs
@@ -3,88 +3,413 @@
 mod helpers;
 
 use {
+    borsh::BorshDeserialize,
     helpers::*, solana_program::pubkey::Pubkey, solana_program_test::*,
-    solana_sdk::signature::Signer,
+    solana_sdk::signature::Signer, spl_stake_pool::{MINIMUM_ACTIVE_STAKE, state::StakePool, stake_program},
 };
 
-#[tokio::test]
-async fn success() {
+const STAKE_ACCOUNTS: u64 = 5;
+
+async fn setup() -> (
+    ProgramTestContext,
+    StakePoolAccounts,
+    Vec<ValidatorStakeAccount>,
+    u64,
+    u64,
+) {
     let mut context = program_test().start_with_context().await;
+    let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
+    let slots_per_epoch = context.genesis_config().epoch_schedule.slots_per_epoch;
+    context.warp_to_slot(first_normal_slot).unwrap();
+
     let stake_pool_accounts = StakePoolAccounts::new();
     stake_pool_accounts
         .initialize_stake_pool(
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            1,
+            TEST_STAKE_AMOUNT + 1,
         )
         .await
         .unwrap();
 
-    // Add several accounts
+    // Add several accounts with some stake
     let mut stake_accounts: Vec<ValidatorStakeAccount> = vec![];
-    const STAKE_ACCOUNTS: u64 = 3;
+    let mut deposit_accounts: Vec<DepositStakeAccount> = vec![];
     for _ in 0..STAKE_ACCOUNTS {
-        stake_accounts.push(
-            simple_add_validator_to_pool(
+        let stake_account = ValidatorStakeAccount::new_with_target_authority(
+            &stake_pool_accounts.deposit_authority,
+            &stake_pool_accounts.stake_pool.pubkey(),
+        );
+        stake_account
+            .create_and_delegate(
                 &mut context.banks_client,
                 &context.payer,
                 &context.last_blockhash,
-                &stake_pool_accounts,
+                &stake_pool_accounts.staker,
             )
-            .await,
-        );
+            .await;
+
+        let deposit_account = DepositStakeAccount::new_with_vote(stake_account.vote.pubkey(), stake_account.stake_account, TEST_STAKE_AMOUNT);
+        deposit_account.create_and_delegate(&mut context.banks_client, &context.payer, &context.last_blockhash).await;
+
+        stake_accounts.push(stake_account);
+        deposit_accounts.push(deposit_account);
     }
 
-    // Check current balance in the list
-    assert_eq!(
-        get_validator_list_sum(
-            &mut context.banks_client,
-            &stake_pool_accounts.validator_list.pubkey()
-        )
-        .await,
-        0,
-    );
-
-    // Add extra funds, simulating rewards
-    const EXTRA_STAKE_AMOUNT: u64 = 1_000_000;
-
-    for stake_account in &stake_accounts {
-        transfer(
-            &mut context.banks_client,
-            &context.payer,
-            &context.last_blockhash,
-            &stake_account.stake_account,
-            EXTRA_STAKE_AMOUNT,
-        )
-        .await;
+    // Warp forward so the stakes properly activate, and deposit
+    // TODO This is *bad* -- program-test needs to have some more active stake
+    // so we can warm up faster than this. Also, we need to do each of these
+    // warps by hand to get fully active stakes.
+    for i in 2..100 {
+        context.warp_to_slot(first_normal_slot + i * slots_per_epoch).unwrap();
     }
-
-    // Update epoch
-    context.warp_to_slot(50_000).unwrap();
-
     stake_pool_accounts
-        .update_validator_list_balance(
+        .update_all(
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
             stake_accounts
                 .iter()
-                .map(|v| v.stake_account)
+                .map(|v| v.vote.pubkey())
                 .collect::<Vec<Pubkey>>()
                 .as_slice(),
+            false,
         )
         .await;
 
-    // Check balance updated
+    for stake_account in &stake_accounts {
+        let error = stake_pool_accounts
+            .add_validator_to_pool(
+                &mut context.banks_client,
+                &context.payer,
+                &context.last_blockhash,
+                &stake_account.stake_account,
+            )
+            .await;
+        assert!(error.is_none());
+    }
+
+    for deposit_account in &deposit_accounts {
+        deposit_account.deposit(
+            &mut context.banks_client,
+            &context.payer,
+            &context.last_blockhash,
+            &stake_pool_accounts,
+        )
+        .await;
+    }
+
+    // Warp forward one epoch so the stakes activate, and update
+    context.warp_to_slot(first_normal_slot + 100 * slots_per_epoch + 1).unwrap();
+
+    stake_pool_accounts
+        .update_all(
+            &mut context.banks_client,
+            &context.payer,
+            &context.last_blockhash,
+            stake_accounts
+                .iter()
+                .map(|v| v.vote.pubkey())
+                .collect::<Vec<Pubkey>>()
+                .as_slice(),
+            false,
+        )
+        .await;
+
+    (
+        context,
+        stake_pool_accounts,
+        stake_accounts,
+        TEST_STAKE_AMOUNT,
+        100
+    )
+}
+
+#[tokio::test]
+async fn success() {
+    let (mut context, stake_pool_accounts, stake_accounts, _, start_epoch) = setup().await;
+
+    // Check current balance in the list
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let stake_rent = rent.minimum_balance(std::mem::size_of::<stake_program::StakeState>());
+    // initially, have all of the deposits plus their rent, and the reserve stake
+    let initial_lamports = (TEST_STAKE_AMOUNT + stake_rent) * STAKE_ACCOUNTS + TEST_STAKE_AMOUNT;
     assert_eq!(
         get_validator_list_sum(
             &mut context.banks_client,
+            &stake_pool_accounts.reserve_stake.pubkey(),
             &stake_pool_accounts.validator_list.pubkey()
         )
         .await,
-        STAKE_ACCOUNTS * EXTRA_STAKE_AMOUNT
+        initial_lamports,
     );
+
+    // Simulate rewards
+    for stake_account in &stake_accounts {
+        context.increment_vote_account_credits(&stake_account.vote.pubkey(), 100);
+    }
+
+    // Warp one more epoch so the rewards are paid out
+    let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
+    let slots_per_epoch = context.genesis_config().epoch_schedule.slots_per_epoch;
+    context.warp_to_slot(first_normal_slot + (start_epoch + 1) * slots_per_epoch).unwrap();
+
+    stake_pool_accounts
+        .update_all(
+            &mut context.banks_client,
+            &context.payer,
+            &context.last_blockhash,
+            stake_accounts
+                .iter()
+                .map(|v| v.vote.pubkey())
+                .collect::<Vec<Pubkey>>()
+                .as_slice(),
+            false,
+        )
+        .await;
+    let new_lamports = get_validator_list_sum(
+            &mut context.banks_client,
+            &stake_pool_accounts.reserve_stake.pubkey(),
+            &stake_pool_accounts.validator_list.pubkey()
+        )
+        .await;
+    assert!(new_lamports > initial_lamports);
+
+    let stake_pool_info = get_account(
+        &mut context.banks_client,
+        &stake_pool_accounts.stake_pool.pubkey(),
+    )
+    .await;
+    let stake_pool = StakePool::try_from_slice(&stake_pool_info.data).unwrap();
+    assert_eq!(new_lamports, stake_pool.total_stake_lamports);
+}
+
+#[tokio::test]
+async fn merge_into_reserve() {
+    let (mut context, stake_pool_accounts, stake_accounts, lamports, start_epoch) = setup().await;
+
+    let pre_lamports = get_validator_list_sum(
+            &mut context.banks_client,
+            &stake_pool_accounts.reserve_stake.pubkey(),
+            &stake_pool_accounts.validator_list.pubkey()
+        )
+        .await;
+
+    let reserve_stake = context.banks_client
+        .get_account(stake_pool_accounts.reserve_stake.pubkey())
+        .await
+        .unwrap()
+        .unwrap();
+    let pre_reserve_lamports = reserve_stake.lamports;
+
+    // Decrease from all validators
+    for stake_account in &stake_accounts {
+        let error = stake_pool_accounts
+            .decrease_validator_stake(
+                &mut context.banks_client,
+                &context.payer,
+                &context.last_blockhash,
+                &stake_account.stake_account,
+                &stake_account.transient_stake_account,
+                lamports,
+            )
+            .await;
+        assert!(error.is_none());
+    }
+
+    // Update, should not change, no merges yet
+    stake_pool_accounts
+        .update_all(
+            &mut context.banks_client,
+            &context.payer,
+            &context.last_blockhash,
+            stake_accounts
+                .iter()
+                .map(|v| v.vote.pubkey())
+                .collect::<Vec<Pubkey>>()
+                .as_slice(),
+            false,
+        )
+        .await;
+
+    let expected_lamports = get_validator_list_sum(
+            &mut context.banks_client,
+            &stake_pool_accounts.reserve_stake.pubkey(),
+            &stake_pool_accounts.validator_list.pubkey()
+        )
+        .await;
+    assert_eq!(pre_lamports, expected_lamports);
+
+    let stake_pool_info = get_account(
+        &mut context.banks_client,
+        &stake_pool_accounts.stake_pool.pubkey(),
+    )
+    .await;
+    let stake_pool = StakePool::try_from_slice(&stake_pool_info.data).unwrap();
+    assert_eq!(expected_lamports, stake_pool.total_stake_lamports);
+
+    // Warp one more epoch so the stakes deactivate
+    let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
+    let slots_per_epoch = context.genesis_config().epoch_schedule.slots_per_epoch;
+    context.warp_to_slot(first_normal_slot + (start_epoch + 1) * slots_per_epoch).unwrap();
+
+    stake_pool_accounts
+        .update_all(
+            &mut context.banks_client,
+            &context.payer,
+            &context.last_blockhash,
+            stake_accounts
+                .iter()
+                .map(|v| v.vote.pubkey())
+                .collect::<Vec<Pubkey>>()
+                .as_slice(),
+            false,
+        )
+        .await;
+    let expected_lamports = get_validator_list_sum(
+            &mut context.banks_client,
+            &stake_pool_accounts.reserve_stake.pubkey(),
+            &stake_pool_accounts.validator_list.pubkey()
+        )
+        .await;
+    assert_eq!(pre_lamports, expected_lamports);
+
+    let reserve_stake = context.banks_client
+        .get_account(stake_pool_accounts.reserve_stake.pubkey())
+        .await
+        .unwrap()
+        .unwrap();
+    let post_reserve_lamports = reserve_stake.lamports;
+    assert!(post_reserve_lamports > pre_reserve_lamports);
+
+    let stake_pool_info = get_account(
+        &mut context.banks_client,
+        &stake_pool_accounts.stake_pool.pubkey(),
+    )
+    .await;
+    let stake_pool = StakePool::try_from_slice(&stake_pool_info.data).unwrap();
+    assert_eq!(expected_lamports, stake_pool.total_stake_lamports);
+}
+
+#[tokio::test]
+async fn merge_into_validator_stake() {
+    let (mut context, stake_pool_accounts, stake_accounts, lamports, start_epoch) = setup().await;
+
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let pre_lamports = get_validator_list_sum(
+            &mut context.banks_client,
+            &stake_pool_accounts.reserve_stake.pubkey(),
+            &stake_pool_accounts.validator_list.pubkey()
+        )
+        .await;
+
+    // Increase stake to all validators
+    for stake_account in &stake_accounts {
+        let error = stake_pool_accounts
+            .increase_validator_stake(
+                &mut context.banks_client,
+                &context.payer,
+                &context.last_blockhash,
+                &stake_account.transient_stake_account,
+                &stake_account.vote.pubkey(),
+                lamports / stake_accounts.len() as u64,
+            )
+            .await;
+        assert!(error.is_none());
+    }
+
+    // Warp just a little bit to get a new blockhash and update again
+    let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
+    let slots_per_epoch = context.genesis_config().epoch_schedule.slots_per_epoch;
+    context.warp_to_slot(first_normal_slot + start_epoch * slots_per_epoch + 10).unwrap();
+
+    // Update, should not change, no merges yet
+    let error = stake_pool_accounts
+        .update_all(
+            &mut context.banks_client,
+            &context.payer,
+            &context.last_blockhash,
+            stake_accounts
+                .iter()
+                .map(|v| v.vote.pubkey())
+                .collect::<Vec<Pubkey>>()
+                .as_slice(),
+            false,
+        )
+        .await;
+    assert!(error.is_none());
+
+    let expected_lamports = get_validator_list_sum(
+            &mut context.banks_client,
+            &stake_pool_accounts.reserve_stake.pubkey(),
+            &stake_pool_accounts.validator_list.pubkey()
+        )
+        .await;
+    assert_eq!(pre_lamports, expected_lamports);
+    let stake_pool_info = get_account(
+        &mut context.banks_client,
+        &stake_pool_accounts.stake_pool.pubkey(),
+    )
+    .await;
+    let stake_pool = StakePool::try_from_slice(&stake_pool_info.data).unwrap();
+    assert_eq!(expected_lamports, stake_pool.total_stake_lamports);
+
+    let stake_pool_info = get_account(
+        &mut context.banks_client,
+        &stake_pool_accounts.stake_pool.pubkey(),
+    )
+    .await;
+    let stake_pool = StakePool::try_from_slice(&stake_pool_info.data).unwrap();
+    assert_eq!(expected_lamports, stake_pool.total_stake_lamports);
+
+    // Warp one more epoch so the stakes activate, ready to merge
+    context.warp_to_slot(first_normal_slot + (start_epoch + 1) * slots_per_epoch).unwrap();
+
+    let error = stake_pool_accounts
+        .update_all(
+            &mut context.banks_client,
+            &context.payer,
+            &context.last_blockhash,
+            stake_accounts
+                .iter()
+                .map(|v| v.vote.pubkey())
+                .collect::<Vec<Pubkey>>()
+                .as_slice(),
+            false,
+        )
+        .await;
+    assert!(error.is_none());
+    let current_lamports = get_validator_list_sum(
+            &mut context.banks_client,
+            &stake_pool_accounts.reserve_stake.pubkey(),
+            &stake_pool_accounts.validator_list.pubkey()
+        )
+        .await;
+    let stake_pool_info = get_account(
+        &mut context.banks_client,
+        &stake_pool_accounts.stake_pool.pubkey(),
+    )
+    .await;
+    let stake_pool = StakePool::try_from_slice(&stake_pool_info.data).unwrap();
+    assert_eq!(current_lamports, stake_pool.total_stake_lamports);
+
+    // Check that transient accounts are gone
+    for stake_account in &stake_accounts {
+        assert!(context.banks_client.get_account(stake_account.transient_stake_account).await.unwrap().is_none());
+    }
+
+    // Check validator stake accounts have the expected balance now:
+    // validator stake account minimum + deposited lamports + 2 rents + increased lamports
+    let expected_lamports = MINIMUM_ACTIVE_STAKE + lamports + lamports / stake_accounts.len() as u64 + 2 * rent.minimum_balance(std::mem::size_of::<stake_program::StakeState>());
+    for stake_account in &stake_accounts {
+        let validator_stake = get_account(
+            &mut context.banks_client,
+            &stake_account.stake_account,
+        )
+        .await;
+        assert_eq!(validator_stake.lamports, expected_lamports);
+    }
 }
 
 #[tokio::test]

--- a/stake-pool/program/tests/vsa_add.rs
+++ b/stake-pool/program/tests/vsa_add.rs
@@ -170,6 +170,7 @@ async fn fail_too_little_stake() {
         &mut banks_client,
         &payer,
         &recent_blockhash,
+        &user_stake.validator,
         &user_stake.vote,
     )
     .await;

--- a/stake-pool/program/tests/vsa_create.rs
+++ b/stake-pool/program/tests/vsa_create.rs
@@ -31,11 +31,12 @@ async fn success_create_validator_stake_account() {
         .unwrap();
 
     let validator = Keypair::new();
-    create_vote(&mut banks_client, &payer, &recent_blockhash, &validator).await;
+    let vote = Keypair::new();
+    create_vote(&mut banks_client, &payer, &recent_blockhash, &validator, &vote).await;
 
     let (stake_account, _) = find_stake_program_address(
         &id(),
-        &validator.pubkey(),
+        &vote.pubkey(),
         &stake_pool_accounts.stake_pool.pubkey(),
     );
 
@@ -46,7 +47,7 @@ async fn success_create_validator_stake_account() {
             &stake_pool_accounts.staker.pubkey(),
             &payer.pubkey(),
             &stake_account,
-            &validator.pubkey(),
+            &vote.pubkey(),
         )
         .unwrap()],
         Some(&payer.pubkey()),
@@ -67,7 +68,7 @@ async fn success_create_validator_stake_account() {
                 &meta.authorized.withdrawer,
                 &stake_pool_accounts.staker.pubkey()
             );
-            assert_eq!(stake.delegation.voter_pubkey, validator.pubkey());
+            assert_eq!(stake.delegation.voter_pubkey, vote.pubkey());
         }
         _ => panic!(),
     }

--- a/stake-pool/program/tests/vsa_create.rs
+++ b/stake-pool/program/tests/vsa_create.rs
@@ -32,7 +32,14 @@ async fn success_create_validator_stake_account() {
 
     let validator = Keypair::new();
     let vote = Keypair::new();
-    create_vote(&mut banks_client, &payer, &recent_blockhash, &validator, &vote).await;
+    create_vote(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        &validator,
+        &vote,
+    )
+    .await;
 
     let (stake_account, _) = find_stake_program_address(
         &id(),

--- a/stake-pool/program/tests/withdraw.rs
+++ b/stake-pool/program/tests/withdraw.rs
@@ -31,7 +31,7 @@ async fn setup() -> (
     Hash,
     StakePoolAccounts,
     ValidatorStakeAccount,
-    DepositInfo,
+    DepositStakeAccount,
     u64,
 ) {
     let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
@@ -66,8 +66,8 @@ async fn setup() -> (
         &mut banks_client,
         &payer,
         &recent_blockhash,
-        &deposit_info.user_pool_account,
-        &deposit_info.user,
+        &deposit_info.pool_account.pubkey(),
+        &deposit_info.authority,
         &stake_pool_accounts.withdraw_authority,
         tokens_to_burn,
     )
@@ -126,7 +126,7 @@ async fn success() {
 
     // Save user token balance
     let user_token_balance_before =
-        get_token_balance(&mut banks_client, &deposit_info.user_pool_account).await;
+        get_token_balance(&mut banks_client, &deposit_info.pool_account.pubkey()).await;
 
     let new_authority = Pubkey::new_unique();
     let error = stake_pool_accounts
@@ -135,7 +135,7 @@ async fn success() {
             &payer,
             &recent_blockhash,
             &user_stake_recipient.pubkey(),
-            &deposit_info.user_pool_account,
+            &deposit_info.pool_account.pubkey(),
             &validator_stake_account.stake_account,
             &new_authority,
             tokens_to_burn,
@@ -173,7 +173,7 @@ async fn success() {
 
     // Check tokens burned
     let user_token_balance =
-        get_token_balance(&mut banks_client, &deposit_info.user_pool_account).await;
+        get_token_balance(&mut banks_client, &deposit_info.pool_account.pubkey()).await;
     assert_eq!(
         user_token_balance,
         user_token_balance_before - tokens_to_burn
@@ -224,7 +224,7 @@ async fn fail_with_wrong_stake_program() {
         AccountMeta::new(validator_stake_account.stake_account, false),
         AccountMeta::new(user_stake_recipient.pubkey(), false),
         AccountMeta::new_readonly(new_authority, false),
-        AccountMeta::new(deposit_info.user_pool_account, false),
+        AccountMeta::new(deposit_info.pool_account.pubkey(), false),
         AccountMeta::new(stake_pool_accounts.pool_mint.pubkey(), false),
         AccountMeta::new_readonly(sysvar::clock::id(), false),
         AccountMeta::new_readonly(spl_token::id(), false),
@@ -278,7 +278,7 @@ async fn fail_with_wrong_withdraw_authority() {
             &payer,
             &recent_blockhash,
             &user_stake_recipient.pubkey(),
-            &deposit_info.user_pool_account,
+            &deposit_info.pool_account.pubkey(),
             &validator_stake_account.stake_account,
             &new_authority,
             tokens_to_burn,
@@ -325,7 +325,7 @@ async fn fail_with_wrong_token_program_id() {
             &validator_stake_account.stake_account,
             &user_stake_recipient.pubkey(),
             &new_authority,
-            &deposit_info.user_pool_account,
+            &deposit_info.pool_account.pubkey(),
             &stake_pool_accounts.pool_mint.pubkey(),
             &wrong_token_program.pubkey(),
             tokens_to_burn,
@@ -372,7 +372,7 @@ async fn fail_with_wrong_validator_list() {
             &payer,
             &recent_blockhash,
             &user_stake_recipient.pubkey(),
-            &deposit_info.user_pool_account,
+            &deposit_info.pool_account.pubkey(),
             &validator_stake_account.stake_account,
             &new_authority,
             tokens_to_burn,
@@ -550,7 +550,7 @@ async fn fail_double_withdraw_to_the_same_account() {
             &payer,
             &recent_blockhash,
             &user_stake_recipient.pubkey(),
-            &deposit_info.user_pool_account,
+            &deposit_info.pool_account.pubkey(),
             &validator_stake_account.stake_account,
             &new_authority,
             tokens_to_burn,
@@ -565,8 +565,8 @@ async fn fail_double_withdraw_to_the_same_account() {
         &mut banks_client,
         &payer,
         &latest_blockhash,
-        &deposit_info.user_pool_account,
-        &deposit_info.user,
+        &deposit_info.pool_account.pubkey(),
+        &deposit_info.authority,
         &stake_pool_accounts.withdraw_authority,
         tokens_to_burn,
     )
@@ -578,7 +578,7 @@ async fn fail_double_withdraw_to_the_same_account() {
             &payer,
             &latest_blockhash,
             &user_stake_recipient.pubkey(),
-            &deposit_info.user_pool_account,
+            &deposit_info.pool_account.pubkey(),
             &validator_stake_account.stake_account,
             &new_authority,
             tokens_to_burn,
@@ -640,7 +640,7 @@ async fn fail_without_token_approval() {
             &payer,
             &recent_blockhash,
             &user_stake_recipient.pubkey(),
-            &deposit_info.user_pool_account,
+            &deposit_info.pool_account.pubkey(),
             &validator_stake_account.stake_account,
             &new_authority,
             tokens_to_burn,
@@ -696,8 +696,8 @@ async fn fail_with_low_delegation() {
         &mut banks_client,
         &payer,
         &recent_blockhash,
-        &deposit_info.user_pool_account,
-        &deposit_info.user,
+        &deposit_info.pool_account.pubkey(),
+        &deposit_info.authority,
         &stake_pool_accounts.withdraw_authority,
         1,
     )
@@ -720,7 +720,7 @@ async fn fail_with_low_delegation() {
             &payer,
             &recent_blockhash,
             &user_stake_recipient.pubkey(),
-            &deposit_info.user_pool_account,
+            &deposit_info.pool_account.pubkey(),
             &validator_stake_account.stake_account,
             &new_authority,
             tokens_to_burn,
@@ -779,7 +779,7 @@ async fn fail_overdraw_validator() {
             &payer,
             &recent_blockhash,
             &user_stake_recipient.pubkey(),
-            &deposit_info.user_pool_account,
+            &deposit_info.pool_account.pubkey(),
             &validator_stake_account.stake_account,
             &new_authority,
             tokens_to_burn,


### PR DESCRIPTION
#### Problem

Transient stakes need to merged into their associated validator stake account or reserve stake.

#### Solution

Add merging logic!  Also:

* use Borsh to deserialize stakes, which allows us to merge up to 12 stakes per `Update` instruction
* add an index parameter for processing many at once, eliminating the brute force logic
* add a `no_merge` parameter, which allows to just update without performing merges.  Useful in case a merge just isn't working
* check for the transient stake while removing a validator from the pool
* fixup accounting

Fixes #1499 Fixes #1567 