### PR TITLE
stake-pool: Increase lower limit for increase-validator-stake

### DIFF
--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -1003,10 +1003,11 @@ impl Processor {
         let mut validator_list_entry = maybe_validator_list_entry.unwrap();
 
         let stake_rent = rent.minimum_balance(std::mem::size_of::<stake_program::StakeState>());
-        if lamports <= stake_rent {
+        let minimum_lamports = MINIMUM_ACTIVE_STAKE + stake_rent;
+        if lamports < minimum_lamports {
             msg!(
-                "Need more than {} lamports for transient stake to be rent-exempt, {} provided",
-                stake_rent,
+                "Need more than {} lamports for transient stake to be rent-exempt and mergeable, {} provided",
+                minimum_lamports,
                 lamports
             );
             return Err(ProgramError::AccountNotRentExempt);

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -23,7 +23,7 @@ use {
     },
 };
 
-pub const TEST_STAKE_AMOUNT: u64 = 100_000_000;
+pub const TEST_STAKE_AMOUNT: u64 = 1_500_000_000;
 pub const MAX_TEST_VALIDATORS: u32 = 10_000;
 
 pub fn program_test() -> ProgramTest {

--- a/stake-pool/program/tests/increase.rs
+++ b/stake-pool/program/tests/increase.rs
@@ -27,7 +27,7 @@ async fn setup() -> (
 ) {
     let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
     let stake_pool_accounts = StakePoolAccounts::new();
-    let reserve_lamports = 100_000_000;
+    let reserve_lamports = 10_000_000_000;
     stake_pool_accounts
         .initialize_stake_pool(
             &mut banks_client,

--- a/stake-pool/program/tests/update_validator_list_balance.rs
+++ b/stake-pool/program/tests/update_validator_list_balance.rs
@@ -7,7 +7,7 @@ use {
     helpers::*,
     solana_program::pubkey::Pubkey,
     solana_program_test::*,
-    solana_sdk::signature::Signer,
+    solana_sdk::signature::{Keypair, Signer},
     spl_stake_pool::{
         stake_program, state::StakePool, MAX_VALIDATORS_TO_UPDATE, MINIMUM_ACTIVE_STAKE,
     },
@@ -21,6 +21,7 @@ async fn setup(
     Vec<ValidatorStakeAccount>,
     u64,
     u64,
+    u64,
 ) {
     let mut context = program_test().start_with_context().await;
     let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
@@ -28,16 +29,38 @@ async fn setup(
     let mut slot = first_normal_slot;
     context.warp_to_slot(slot).unwrap();
 
+    let reserve_stake_amount = TEST_STAKE_AMOUNT * num_validators as u64;
     let stake_pool_accounts = StakePoolAccounts::new();
     stake_pool_accounts
         .initialize_stake_pool(
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            TEST_STAKE_AMOUNT + 1,
+            reserve_stake_amount + 1,
         )
         .await
         .unwrap();
+
+    // so warmups / cooldowns go faster
+    let validator = Keypair::new();
+    let vote = Keypair::new();
+    create_vote(
+        &mut context.banks_client,
+        &context.payer,
+        &context.last_blockhash,
+        &validator,
+        &vote,
+    )
+    .await;
+    let deposit_account =
+        DepositStakeAccount::new_with_vote(vote.pubkey(), validator.pubkey(), 100_000_000_000);
+    deposit_account
+        .create_and_delegate(
+            &mut context.banks_client,
+            &context.payer,
+            &context.last_blockhash,
+        )
+        .await;
 
     // Add several accounts with some stake
     let mut stake_accounts: Vec<ValidatorStakeAccount> = vec![];
@@ -141,6 +164,7 @@ async fn setup(
         stake_pool_accounts,
         stake_accounts,
         TEST_STAKE_AMOUNT,
+        reserve_stake_amount,
         slot,
     )
 }
@@ -148,15 +172,21 @@ async fn setup(
 #[tokio::test]
 async fn success() {
     let num_validators = 5;
-    let (mut context, stake_pool_accounts, stake_accounts, _, mut slot) =
-        setup(num_validators).await;
+    let (
+        mut context,
+        stake_pool_accounts,
+        stake_accounts,
+        validator_lamports,
+        reserve_lamports,
+        mut slot,
+    ) = setup(num_validators).await;
 
     // Check current balance in the list
     let rent = context.banks_client.get_rent().await.unwrap();
     let stake_rent = rent.minimum_balance(std::mem::size_of::<stake_program::StakeState>());
     // initially, have all of the deposits plus their rent, and the reserve stake
     let initial_lamports =
-        (TEST_STAKE_AMOUNT + stake_rent) * num_validators as u64 + TEST_STAKE_AMOUNT;
+        (validator_lamports + stake_rent) * num_validators as u64 + reserve_lamports;
     assert_eq!(
         get_validator_list_sum(
             &mut context.banks_client,
@@ -209,7 +239,7 @@ async fn success() {
 
 #[tokio::test]
 async fn merge_into_reserve() {
-    let (mut context, stake_pool_accounts, stake_accounts, lamports, mut slot) =
+    let (mut context, stake_pool_accounts, stake_accounts, lamports, _, mut slot) =
         setup(MAX_VALIDATORS_TO_UPDATE).await;
 
     let pre_lamports = get_validator_list_sum(
@@ -319,7 +349,7 @@ async fn merge_into_reserve() {
 
 #[tokio::test]
 async fn merge_into_validator_stake() {
-    let (mut context, stake_pool_accounts, stake_accounts, lamports, mut slot) =
+    let (mut context, stake_pool_accounts, stake_accounts, lamports, reserve_lamports, mut slot) =
         setup(MAX_VALIDATORS_TO_UPDATE).await;
 
     let rent = context.banks_client.get_rent().await.unwrap();
@@ -339,7 +369,7 @@ async fn merge_into_validator_stake() {
                 &context.last_blockhash,
                 &stake_account.transient_stake_account,
                 &stake_account.vote.pubkey(),
-                lamports / stake_accounts.len() as u64,
+                reserve_lamports / stake_accounts.len() as u64,
             )
             .await;
         assert!(error.is_none());
@@ -434,7 +464,7 @@ async fn merge_into_validator_stake() {
     // validator stake account minimum + deposited lamports + 2 rents + increased lamports
     let expected_lamports = MINIMUM_ACTIVE_STAKE
         + lamports
-        + lamports / stake_accounts.len() as u64
+        + reserve_lamports / stake_accounts.len() as u64
         + 2 * rent.minimum_balance(std::mem::size_of::<stake_program::StakeState>());
     for stake_account in &stake_accounts {
         let validator_stake =

--- a/stake-pool/program/tests/vsa_remove.rs
+++ b/stake-pool/program/tests/vsa_remove.rs
@@ -34,7 +34,7 @@ async fn setup() -> (
     let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
     let stake_pool_accounts = StakePoolAccounts::new();
     stake_pool_accounts
-        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash, 10_000_000)
+        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash, 10_000_000_000)
         .await
         .unwrap();
 
@@ -392,7 +392,7 @@ async fn fail_with_activating_transient_stake() {
             &recent_blockhash,
             &user_stake.transient_stake_account,
             &user_stake.vote.pubkey(),
-            5_000_000,
+            2_000_000_000,
         )
         .await;
     assert!(error.is_none());


### PR DESCRIPTION
#### Problem

The current lower limit on increase-validator-stake only covers rent exemption, but that transient stake will not be mergeable once it's active if it's too small.

#### Solution

Increase the limit!  There was a huge annoyance on the testing framework due to low staked amounts, so this also adds a huge stake account that speeds up activation and deactivation.