### PR TITLE
stake-pool: Add ability to remove a validator that has deactivating transient stake

### DIFF
--- a/stake-pool/program/src/instruction.rs
+++ b/stake-pool/program/src/instruction.rs
@@ -519,7 +519,7 @@ pub fn update_stake_pool_balance(
     let accounts = vec![
         AccountMeta::new(*stake_pool, false),
         AccountMeta::new_readonly(*withdraw_authority, false),
-        AccountMeta::new_readonly(*validator_list_storage, false),
+        AccountMeta::new(*validator_list_storage, false),
         AccountMeta::new_readonly(*reserve_stake, false),
         AccountMeta::new(*manager_fee_account, false),
         AccountMeta::new(*stake_pool_mint, false),

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -7,7 +7,7 @@ use {
         find_deposit_authority_program_address,
         instruction::StakePoolInstruction,
         minimum_reserve_lamports, minimum_stake_lamports, stake_program,
-        state::{AccountType, Fee, StakePool, ValidatorList, ValidatorStakeInfo},
+        state::{AccountType, Fee, StakeStatus, StakePool, ValidatorList, ValidatorStakeInfo},
         AUTHORITY_DEPOSIT, AUTHORITY_WITHDRAW, MINIMUM_ACTIVE_STAKE, TRANSIENT_STAKE_SEED,
     },
     borsh::{BorshDeserialize, BorshSerialize},
@@ -15,7 +15,7 @@ use {
     solana_program::{
         account_info::next_account_info,
         account_info::AccountInfo,
-        clock::Clock,
+        clock::{Clock, Epoch},
         decode_error::DecodeError,
         entrypoint::ProgramResult,
         msg,
@@ -747,6 +747,7 @@ impl Processor {
         )?;
 
         validator_list.validators.push(ValidatorStakeInfo {
+            status: StakeStatus::Active,
             vote_account_address,
             stake_lamports: stake_lamports.saturating_sub(minimum_lamport_amount),
             last_update_epoch: clock.epoch,
@@ -814,20 +815,16 @@ impl Processor {
             transient_stake_account_info.key,
             &vote_account_address,
         )?;
-        // check that the transient stake account doesn't exist
-        if get_stake_state(transient_stake_account_info).is_ok() {
+
+        let maybe_validator_list_entry = validator_list.find_mut(&vote_account_address);
+        if maybe_validator_list_entry.is_none() {
             msg!(
-                "Transient stake {} exists, can't remove stake {} on validator {}",
-                transient_stake_account_info.key,
-                stake_account_info.key,
+                "Vote account {} not found in stake pool",
                 vote_account_address
             );
-            return Err(StakePoolError::WrongStakeState.into());
-        }
-
-        if !validator_list.contains(&vote_account_address) {
             return Err(StakePoolError::ValidatorNotFound.into());
         }
+        let mut validator_list_entry = maybe_validator_list_entry.unwrap();
 
         let stake_lamports = **stake_account_info.lamports.borrow();
         let required_lamports = minimum_stake_lamports(&meta);
@@ -840,6 +837,24 @@ impl Processor {
             return Err(StakePoolError::StakeLamportsNotEqualToMinimum.into());
         }
 
+        // check that the transient stake account doesn't exist
+        let new_status = if let Ok((_meta, stake)) = get_stake_state(transient_stake_account_info) {
+            if stake.delegation.deactivation_epoch == Epoch::MAX {
+                msg!(
+                    "Transient stake {} activating, can't remove stake {} on validator {}",
+                    transient_stake_account_info.key,
+                    stake_account_info.key,
+                    vote_account_address
+                );
+                return Err(StakePoolError::WrongStakeState.into());
+            } else {
+                // stake is deactivating, mark the entry as such
+                StakeStatus::DeactivatingTransient
+            }
+        } else {
+            StakeStatus::ReadyForRemoval
+        };
+
         Self::stake_authorize_signed(
             stake_pool_info.key,
             stake_account_info.clone(),
@@ -851,9 +866,14 @@ impl Processor {
             stake_program_info.clone(),
         )?;
 
-        validator_list
-            .validators
-            .retain(|item| item.vote_account_address != vote_account_address);
+        match new_status {
+            StakeStatus::DeactivatingTransient => validator_list_entry.status = new_status,
+            StakeStatus::ReadyForRemoval =>
+                validator_list
+                    .validators
+                    .retain(|item| item.vote_account_address != vote_account_address),
+            _ => unreachable!(),
+        }
         validator_list.serialize(&mut *validator_list_info.data.borrow_mut())?;
 
         Ok(())
@@ -1507,6 +1527,11 @@ impl Processor {
             .find_mut(&vote_account_address)
             .ok_or(StakePoolError::ValidatorNotFound)?;
 
+        if validator_list_item.status != StakeStatus::Active {
+            msg!("Validator is marked for removal and no longer accepting deposits");
+            return Err(StakePoolError::ValidatorNotFound)?;
+        }
+
         let stake_lamports = **stake_info.lamports.borrow();
         let new_pool_tokens = stake_pool
             .calc_pool_tokens_for_deposit(stake_lamports)
@@ -1638,6 +1663,24 @@ impl Processor {
             try_from_slice_unchecked::<ValidatorList>(&validator_list_info.data.borrow())?;
         if !validator_list.is_valid() {
             return Err(StakePoolError::InvalidState.into());
+        }
+
+        let (meta, stake) = get_stake_state(stake_split_from)?;
+        let vote_account_address = stake.delegation.voter_pubkey;
+        check_validator_stake_address(
+            program_id,
+            stake_pool_info.key,
+            stake_split_from.key,
+            &vote_account_address,
+        )?;
+
+        let validator_list_item = validator_list
+            .find_mut(&vote_account_address)
+            .ok_or(StakePoolError::ValidatorNotFound)?;
+
+        if validator_list_item.status != StakeStatus::Active {
+            msg!("Validator is marked for removal and no longer allowing withdrawals");
+            return Err(StakePoolError::ValidatorNotFound)?;
         }
 
         let withdraw_lamports = stake_pool

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -1327,15 +1327,19 @@ impl Processor {
             //  * any other state / not a stake -> error state, but account for transient stake
             match validator_stake_state {
                 Some(stake_program::StakeState::Stake(meta, _)) => {
-                    stake_lamports += validator_stake_info
-                        .lamports()
-                        .saturating_sub(minimum_stake_lamports(&meta));
+                    if validator_stake_record.status == StakeStatus::Active {
+                        stake_lamports += validator_stake_info
+                            .lamports()
+                            .saturating_sub(minimum_stake_lamports(&meta));
+                    } else {
+                        msg!("Validator stake account no longer part of the pool, ignoring");
+                    }
                 }
                 Some(stake_program::StakeState::Initialized(_))
                 | Some(stake_program::StakeState::Uninitialized)
                 | Some(stake_program::StakeState::RewardsPool)
                 | None => {
-                    msg!("Validator stake account no longer part of the pool, not considering");
+                    msg!("Validator stake account no longer part of the pool, ignoring");
                 }
             }
 

--- a/stake-pool/program/tests/decrease.rs
+++ b/stake-pool/program/tests/decrease.rs
@@ -49,7 +49,8 @@ async fn setup() -> (
         &validator_stake_account,
         100_000_000,
     )
-    .await;
+    .await
+    .unwrap();
 
     let lamports = deposit_info.stake_lamports / 2;
 

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -1010,7 +1010,7 @@ pub async fn simple_deposit(
     stake_pool_accounts: &StakePoolAccounts,
     validator_stake_account: &ValidatorStakeAccount,
     stake_lamports: u64,
-) -> DepositStakeAccount {
+) -> Option<DepositStakeAccount> {
     let authority = Keypair::new();
     // make stake account
     let stake = Keypair::new();
@@ -1064,11 +1064,11 @@ pub async fn simple_deposit(
             &authority,
         )
         .await
-        .unwrap();
+        .ok()?;
 
     let pool_tokens = get_token_balance(banks_client, &pool_account.pubkey()).await;
 
-    DepositStakeAccount {
+    Some(DepositStakeAccount {
         authority,
         stake,
         pool_account,
@@ -1076,7 +1076,7 @@ pub async fn simple_deposit(
         pool_tokens,
         vote_account,
         validator_stake_account,
-    }
+    })
 }
 
 pub async fn get_validator_list_sum(

--- a/stake-pool/program/tests/increase.rs
+++ b/stake-pool/program/tests/increase.rs
@@ -54,7 +54,8 @@ async fn setup() -> (
         &validator_stake_account,
         5_000_000,
     )
-    .await;
+    .await
+    .unwrap();
 
     (
         banks_client,

--- a/stake-pool/program/tests/update_stake_pool_balance.rs
+++ b/stake-pool/program/tests/update_stake_pool_balance.rs
@@ -51,7 +51,8 @@ async fn setup() -> (
             &validator_stake_account,
             TEST_STAKE_AMOUNT,
         )
-        .await;
+        .await
+        .unwrap();
 
         stake_accounts.push(validator_stake_account);
     }

--- a/stake-pool/program/tests/vsa_add.rs
+++ b/stake-pool/program/tests/vsa_add.rs
@@ -86,6 +86,7 @@ async fn success() {
             account_type: state::AccountType::ValidatorList,
             max_validators: stake_pool_accounts.max_validators,
             validators: vec![state::ValidatorStakeInfo {
+                status: state::StakeStatus::Active,
                 vote_account_address: user_stake.vote.pubkey(),
                 last_update_epoch: 0,
                 stake_lamports: 0,

--- a/stake-pool/program/tests/withdraw.rs
+++ b/stake-pool/program/tests/withdraw.rs
@@ -57,7 +57,8 @@ async fn setup() -> (
         &validator_stake_account,
         TEST_STAKE_AMOUNT,
     )
-    .await;
+    .await
+    .unwrap();
 
     let tokens_to_burn = deposit_info.pool_tokens / 4;
 
@@ -607,7 +608,8 @@ async fn fail_without_token_approval() {
         &validator_stake_account,
         TEST_STAKE_AMOUNT,
     )
-    .await;
+    .await
+    .unwrap();
 
     let tokens_to_burn = deposit_info.pool_tokens / 4;
 
@@ -675,7 +677,8 @@ async fn fail_with_low_delegation() {
         &validator_stake_account,
         TEST_STAKE_AMOUNT,
     )
-    .await;
+    .await
+    .unwrap();
 
     let tokens_to_burn = deposit_info.pool_tokens / 4;
 

--- a/stake-pool/program/tests/withdraw.rs
+++ b/stake-pool/program/tests/withdraw.rs
@@ -822,7 +822,8 @@ async fn success_with_reserve() {
         &validator_stake,
         deposit_lamports,
     )
-    .await;
+    .await
+    .unwrap();
 
     // decrease some stake
     let error = stake_pool_accounts


### PR DESCRIPTION
#### Problem

When removing a validator from the pool, the validator stake account must have the minimum lamports in the account, and no transient stake is allowed either.  This effectively makes it impossible to remove a validator from the stake pool.  Here's the situation:

* the staker wants to remove validator X from the pool, it currently has 10 SOL
* the staker decreases a validator's stake by 9 SOL, leaving it with the minimum of 1 SOL
* the stake pool creates the transient stake account and deactivates it
* staker tries to remove the validator account, but it's not possible because there's a transient stake
* staker waits one epoch, updates the pool, the transient stake is merged, thinks they're good to go
* staker tries to remove validator X, but the operation fails because the stake account earned rewards and now has 1.0000xxxx SOL
* staker decreases the validator's stake....
* groundhog day

#### Solution

Change the accounting to add a status flag, which allows for removing a validator with a transient stake.  This flag can be:

* `Active`: all good, normal
* `DeactivatingTransient`: removed, but the transient stake is deactivating
* `ReadyForRemoval`: removed, and the transient stake has been merged.  We don't remove right away during `UpdateValidatorListBalance` to not upset the iteration from CLI and other tools

Like any extra accounting, this can cause issues for missed situations before the removal finalizes.  Thankfully, since the transient stake is in place, increase / decrease will automatically fail, so we only need to prevent deposit / withdraw.  Add validator will also fail for now, since there's still an entry for that validator.

Little note: the `#[ignore]` test passes against 1.6.2, but if it's committed as is, it'll break the downstream projects from the monorepo.  Once the newest 1.6 is released with the fix, then we can add those back in.