### PR TITLE
Add airdrop help to token docs

### DIFF
--- a/docs/src/token.md
+++ b/docs/src/token.md
@@ -83,6 +83,15 @@ Hardware Wallet URL (See [URL spec](https://docs.solana.com/wallet-guide/hardwar
 solana config set --keypair usb://ledger/
 ```
 
+#### Airdrop SOL
+
+Creating tokens and accounts requires SOL for account rent deposits and
+transaction fees. If the cluster you are targeting offers a faucet, you can get
+a little SOL for testing:
+```
+solana airdrop 1
+```
+
 ### Example: Creating your own fungible token
 
 ```sh


### PR DESCRIPTION
`spl.solana.com/token` may be a user's entrypoint to solana; if they are following the token examples target devnet or testnet, they may not know how to get some SOL to execute the commands successfully.

Fixes https://github.com/solana-labs/solana/issues/16837