### PR TITLE
stake-pool-cli: Support new features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3837,6 +3837,7 @@ dependencies = [
  "solana-logger",
  "solana-program",
  "solana-sdk",
+ "spl-associated-token-account 1.0.2",
  "spl-stake-pool",
  "spl-token 3.1.0",
 ]

--- a/stake-pool/cli/Cargo.toml
+++ b/stake-pool/cli/Cargo.toml
@@ -19,6 +19,7 @@ solana-client = "1.6.6"
 solana-logger = "1.6.6"
 solana-sdk = "1.6.6"
 solana-program = "1.6.6"
+spl-associated-token-account = { path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
 spl-stake-pool = { path="../program", features = [ "no-entrypoint" ] }
 spl-token = { path="../../token/program", features = [ "no-entrypoint" ]  }
 bs58 = "0.4.0"


### PR DESCRIPTION
While going back through the docs, I ended up doing a lot of stake
pool CLI items, and also adding support for new program features:

* Deposit / withdraw command: Use associated token account by default
* Create command: Allow passing the stake pool and mint keypair (useful
  for testing)
* Create command: Split the transaction for pool creation (required to get under the
  transaction size limit)
* Add / remove validator command: take a validator vote account rather than stake
  account, which makes integration from outside tools a lot simpler
* Update command: add a `--force` flag to force the update
* Update command: add a `--no-merge` flag to not merge while updating
  (useful to allow the pool to work, even if the transient stake
  accounts are unmergeable)
* Withdraw: Add `--use-reserve` flag to withdraw from reserve
* Withdraw: Add `--vote-account` arg to specify which validator to
  withdraw from

Sorry that this is all one PR, it sort of evolved that way as I was doing the docs.  If it's too confusing, however, I can split it up.

Fixes #1292 Fixes #1495 