### PR TITLE
stake-pool: Update versions for crate deployment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3822,7 +3822,7 @@ dependencies = [
 
 [[package]]
 name = "spl-stake-pool-cli"
-version = "2.0.1"
+version = "0.1.0"
 dependencies = [
  "bincode",
  "borsh 0.8.2",

--- a/stake-pool/cli/Cargo.toml
+++ b/stake-pool/cli/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://spl.solana.com/stake-pool"
 license = "Apache-2.0"
 name = "spl-stake-pool-cli"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "2.0.1"
+version = "0.1.0"
 
 [dependencies]
 borsh = "0.8"
@@ -19,9 +19,9 @@ solana-client = "1.6.6"
 solana-logger = "1.6.6"
 solana-sdk = "1.6.6"
 solana-program = "1.6.6"
-spl-associated-token-account = { path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
-spl-stake-pool = { path="../program", features = [ "no-entrypoint" ] }
-spl-token = { path="../../token/program", features = [ "no-entrypoint" ]  }
+spl-associated-token-account = { version = "1.0", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
+spl-stake-pool = { version = "0.1", path="../program", features = [ "no-entrypoint" ] }
+spl-token = { version = "3.1", path="../../token/program", features = [ "no-entrypoint" ]  }
 bs58 = "0.4.0"
 bincode = "1.3.1"
 lazy_static = "1.4.0"

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -20,8 +20,8 @@ num_enum = "0.5.1"
 serde = "1.0.121"
 serde_derive = "1.0.103"
 solana-program = "1.6.6"
-spl-math = { path = "../../libraries/math", features = [ "no-entrypoint" ] }
-spl-token = { path = "../../token/program", features = [ "no-entrypoint" ] }
+spl-math = { version = "0.1", path = "../../libraries/math", features = [ "no-entrypoint" ] }
+spl-token = { version = "3.1", path = "../../token/program", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 bincode = "1.3.1"
 


### PR DESCRIPTION
It's time to release the stake pool crates! But they need versions on the SPL dependencies, so add those versions, and update the stake pool cli version to 0.1.0, which was probably just copied from the token cli.