### PR TITLE
Ensure only docs files are modified when triggering all-checks success

### DIFF
--- a/.github/workflows/pull-request-docs.yml
+++ b/.github/workflows/pull-request-docs.yml
@@ -10,7 +10,34 @@ on:
     - 'docs/**'
 
 jobs:
+  check_non_docs:
+    outputs:
+      run_all_github_action_checks: ${{ steps.check_files.outputs.run_all_github_action_checks }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      - name: check modified files
+        id: check_files
+        run: |
+          echo "========== check paths of modified files =========="
+          echo "::set-output name=run_all_github_action_checks::true"
+          git diff --name-only HEAD^ HEAD > files.txt
+          while IFS= read -r file
+          do
+            if [[ $file != docs/** ]]; then
+              echo "Found modified non-'docs' file(s)"
+              echo "::set-output name=run_all_github_action_checks::false"
+              break
+            fi
+          done < files.txt
+
   all_github_action_checks:
     runs-on: ubuntu-latest
+    needs: check_non_docs
+    if: needs.check_non_docs.outputs.run_all_github_action_checks == 'true'
     steps:
       - run: echo "Done"


### PR DESCRIPTION
If a PR has docs changes in additional to other code changes, Mergify may merge it before the full CI suite completes.