### PR TITLE
swap associated token account addr for token addr

### DIFF
--- a/docs/src/token.md
+++ b/docs/src/token.md
@@ -273,7 +273,7 @@ Now the `7KqpRwzkkeweW5jQoETyLzhvs9rcCj9dVQ1MnzudirsM` account holds the
 one and only `559u4Tdr9umKwft3yHMsnAxohhzkFnUBPAFtibwuZD9z` token:
 
 ```
-$ spl-token account-info 7KqpRwzkkeweW5jQoETyLzhvs9rcCj9dVQ1MnzudirsM
+$ spl-token account-info 559u4Tdr9umKwft3yHMsnAxohhzkFnUBPAFtibwuZD9z
 
 Address: 7KqpRwzkkeweW5jQoETyLzhvs9rcCj9dVQ1MnzudirsM
 Balance: 1


### PR DESCRIPTION
As the cli prompt indicates the argument should be the token address

```bash
$ spl-token account-info
error: The following required arguments were not provided:
    <TOKEN_ADDRESS>

USAGE:
    spl-token account-info <TOKEN_ADDRESS> --config <PATH>
```

In this case `7KqpRwzkkeweW5jQoETyLzhvs9rcCj9dVQ1MnzudirsM` is the associated token address and `559u4Tdr9umKwft3yHMsnAxohhzkFnUBPAFtibwuZD9z` is the token's address. 

Therefore the argument has been replaced to use the token rather than the associated account