### PR TITLE
stake-pool: Add helper instruction creators for stake pool integration

### DIFF
--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -1072,6 +1072,11 @@ impl Processor {
         }
         let mut validator_list_entry = maybe_validator_list_entry.unwrap();
 
+        if validator_list_entry.status != StakeStatus::Active {
+            msg!("Validator is marked for removal and no longer allows increases");
+            return Err(StakePoolError::ValidatorNotFound.into());
+        }
+
         let stake_rent = rent.minimum_balance(std::mem::size_of::<stake_program::StakeState>());
         let minimum_lamports = MINIMUM_ACTIVE_STAKE + stake_rent;
         if lamports < minimum_lamports {

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -250,8 +250,7 @@ pub async fn create_stake_pool(
                 deposit_authority.as_ref().map(|k| k.pubkey()),
                 *fee,
                 max_validators,
-            )
-            .unwrap(),
+            ),
         ],
         Some(&payer.pubkey()),
     );
@@ -374,8 +373,7 @@ pub async fn create_validator_stake_account(
             &payer.pubkey(),
             &stake_account,
             &validator,
-        )
-        .unwrap()],
+        )],
         Some(&payer.pubkey()),
         &[payer, staker],
         *recent_blockhash,
@@ -677,8 +675,7 @@ impl StakePoolAccounts {
                 &self.pool_mint.pubkey(),
                 &spl_token::id(),
                 amount,
-            )
-            .unwrap()],
+            )],
             Some(&payer.pubkey()),
             &[payer, user_transfer_authority],
             *recent_blockhash,
@@ -787,8 +784,7 @@ impl StakePoolAccounts {
                 &self.withdraw_authority,
                 &self.validator_list.pubkey(),
                 stake,
-            )
-            .unwrap()],
+            )],
             Some(&payer.pubkey()),
             &[payer, &self.staker],
             *recent_blockhash,
@@ -815,8 +811,7 @@ impl StakePoolAccounts {
                 &self.validator_list.pubkey(),
                 validator_stake,
                 transient_stake,
-            )
-            .unwrap()],
+            )],
             Some(&payer.pubkey()),
             &[payer, &self.staker],
             *recent_blockhash,

--- a/stake-pool/program/tests/initialize.rs
+++ b/stake-pool/program/tests/initialize.rs
@@ -229,8 +229,7 @@ async fn fail_with_wrong_max_validators() {
                 None,
                 stake_pool_accounts.fee,
                 stake_pool_accounts.max_validators,
-            )
-            .unwrap(),
+            ),
         ],
         Some(&payer.pubkey()),
     );
@@ -389,8 +388,7 @@ async fn fail_with_wrong_token_program_id() {
                 None,
                 stake_pool_accounts.fee,
                 stake_pool_accounts.max_validators,
-            )
-            .unwrap(),
+            ),
         ],
         Some(&payer.pubkey()),
     );
@@ -554,8 +552,7 @@ async fn fail_with_not_rent_exempt_pool() {
                 None,
                 stake_pool_accounts.fee,
                 stake_pool_accounts.max_validators,
-            )
-            .unwrap(),
+            ),
         ],
         Some(&payer.pubkey()),
     );
@@ -629,8 +626,7 @@ async fn fail_with_not_rent_exempt_validator_list() {
                 None,
                 stake_pool_accounts.fee,
                 stake_pool_accounts.max_validators,
-            )
-            .unwrap(),
+            ),
         ],
         Some(&payer.pubkey()),
     );

--- a/stake-pool/program/tests/set_manager.rs
+++ b/stake-pool/program/tests/set_manager.rs
@@ -67,8 +67,7 @@ async fn test_set_manager() {
             &stake_pool_accounts.manager.pubkey(),
             &new_manager.pubkey(),
             &new_pool_fee.pubkey(),
-        )
-        .unwrap()],
+        )],
         Some(&payer.pubkey()),
     );
     transaction.sign(&[&payer, &stake_pool_accounts.manager], recent_blockhash);
@@ -92,8 +91,7 @@ async fn test_set_manager_by_malicious() {
             &new_manager.pubkey(),
             &new_manager.pubkey(),
             &new_pool_fee.pubkey(),
-        )
-        .unwrap()],
+        )],
         Some(&payer.pubkey()),
     );
     transaction.sign(&[&payer, &new_manager], recent_blockhash);
@@ -196,8 +194,7 @@ async fn test_set_manager_with_wrong_mint_for_pool_fee_acc() {
             &stake_pool_accounts.manager.pubkey(),
             &new_manager.pubkey(),
             &new_pool_fee.pubkey(),
-        )
-        .unwrap()],
+        )],
         Some(&payer.pubkey()),
     );
     transaction.sign(&[&payer, &stake_pool_accounts.manager], recent_blockhash);

--- a/stake-pool/program/tests/set_staker.rs
+++ b/stake-pool/program/tests/set_staker.rs
@@ -47,8 +47,7 @@ async fn success_set_staker_as_manager() {
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.manager.pubkey(),
             &new_staker.pubkey(),
-        )
-        .unwrap()],
+        )],
         Some(&payer.pubkey()),
     );
     transaction.sign(&[&payer, &stake_pool_accounts.manager], recent_blockhash);
@@ -71,8 +70,7 @@ async fn success_set_staker_as_staker() {
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.staker.pubkey(),
             &new_staker.pubkey(),
-        )
-        .unwrap()],
+        )],
         Some(&payer.pubkey()),
     );
     transaction.sign(&[&payer, &stake_pool_accounts.staker], recent_blockhash);
@@ -89,8 +87,7 @@ async fn success_set_staker_as_staker() {
             &stake_pool_accounts.stake_pool.pubkey(),
             &new_staker.pubkey(),
             &stake_pool_accounts.staker.pubkey(),
-        )
-        .unwrap()],
+        )],
         Some(&payer.pubkey()),
     );
     transaction.sign(&[&payer, &new_staker], recent_blockhash);
@@ -113,8 +110,7 @@ async fn fail_wrong_manager() {
             &stake_pool_accounts.stake_pool.pubkey(),
             &new_staker.pubkey(),
             &new_staker.pubkey(),
-        )
-        .unwrap()],
+        )],
         Some(&payer.pubkey()),
     );
     transaction.sign(&[&payer, &new_staker], recent_blockhash);

--- a/stake-pool/program/tests/vsa_add.rs
+++ b/stake-pool/program/tests/vsa_add.rs
@@ -127,8 +127,7 @@ async fn fail_with_wrong_validator_list_account() {
             &stake_pool_accounts.withdraw_authority,
             &wrong_validator_list.pubkey(),
             &user_stake.stake_account,
-        )
-        .unwrap()],
+        )],
         Some(&payer.pubkey()),
     );
     transaction.sign(&[&payer, &stake_pool_accounts.staker], recent_blockhash);
@@ -316,8 +315,7 @@ async fn fail_wrong_staker() {
             &stake_pool_accounts.withdraw_authority,
             &stake_pool_accounts.validator_list.pubkey(),
             &user_stake.stake_account,
-        )
-        .unwrap()],
+        )],
         Some(&payer.pubkey()),
     );
     transaction.sign(&[&payer, &malicious], recent_blockhash);

--- a/stake-pool/program/tests/vsa_create.rs
+++ b/stake-pool/program/tests/vsa_create.rs
@@ -55,8 +55,7 @@ async fn success_create_validator_stake_account() {
             &payer.pubkey(),
             &stake_account,
             &vote.pubkey(),
-        )
-        .unwrap()],
+        )],
         Some(&payer.pubkey()),
     );
     transaction.sign(&[&payer, &stake_pool_accounts.staker], recent_blockhash);
@@ -103,8 +102,7 @@ async fn fail_create_validator_stake_account_on_non_vote_account() {
             &payer.pubkey(),
             &stake_account,
             &validator,
-        )
-        .unwrap()],
+        )],
         Some(&payer.pubkey()),
     );
     transaction.sign(&[&payer, &stake_pool_accounts.staker], recent_blockhash);
@@ -241,8 +239,7 @@ async fn fail_create_validator_stake_account_with_incorrect_address() {
             &payer.pubkey(),
             &stake_account.pubkey(),
             &validator,
-        )
-        .unwrap()],
+        )],
         Some(&payer.pubkey()),
     );
     transaction.sign(&[&payer, &stake_pool_accounts.staker], recent_blockhash);

--- a/stake-pool/program/tests/vsa_remove.rs
+++ b/stake-pool/program/tests/vsa_remove.rs
@@ -178,8 +178,7 @@ async fn fail_with_wrong_validator_list_account() {
             &wrong_validator_list.pubkey(),
             &validator_stake.stake_account,
             &validator_stake.transient_stake_account,
-        )
-        .unwrap()],
+        )],
         Some(&payer.pubkey()),
     );
     transaction.sign(&[&payer, &stake_pool_accounts.staker], recent_blockhash);
@@ -301,8 +300,7 @@ async fn fail_wrong_staker() {
             &stake_pool_accounts.validator_list.pubkey(),
             &validator_stake.stake_account,
             &validator_stake.transient_stake_account,
-        )
-        .unwrap()],
+        )],
         Some(&payer.pubkey()),
     );
     transaction.sign(&[&payer, &malicious], recent_blockhash);

--- a/stake-pool/program/tests/withdraw.rs
+++ b/stake-pool/program/tests/withdraw.rs
@@ -345,8 +345,7 @@ async fn fail_with_wrong_token_program_id() {
             &stake_pool_accounts.pool_mint.pubkey(),
             &wrong_token_program.pubkey(),
             tokens_to_burn,
-        )
-        .unwrap()],
+        )],
         Some(&payer.pubkey()),
         &[&payer, &user_transfer_authority],
         recent_blockhash,


### PR DESCRIPTION
#### Problem

The functions to create instructions on the stake pool are a little cumbersome, since they often require also passing in the correct validator / transient stake account.

#### Solution

Create a set of functions that take the stake pool and validator vote account address for easier use by clients.  These all came up while implementing the stake-o-matic with stake pools, so I imagine they'll be useful for other integrations.