### PR TITLE
stake-pool: Bump version for 0.2 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3877,7 +3877,7 @@ dependencies = [
 
 [[package]]
 name = "spl-stake-pool"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arrayref",
  "bincode",

--- a/stake-pool/cli/Cargo.toml
+++ b/stake-pool/cli/Cargo.toml
@@ -20,7 +20,7 @@ solana-logger = "1.6.7"
 solana-sdk = "1.6.7"
 solana-program = "1.6.7"
 spl-associated-token-account = { version = "1.0", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
-spl-stake-pool = { version = "0.1", path="../program", features = [ "no-entrypoint" ] }
+spl-stake-pool = { version = "0.2", path="../program", features = [ "no-entrypoint" ] }
 spl-token = { version = "3.1", path="../../token/program", features = [ "no-entrypoint" ]  }
 bs58 = "0.4.0"
 bincode = "1.3.1"

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-stake-pool"
-version = "0.1.0"
+version = "0.2.0"
 description = "Solana Program Library Stake Pool"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"


### PR DESCRIPTION
Stake-o-matic will need the newer crates, so bump the CLI / program crate versions