### PR TITLE
Fix #1739: ThawAccount incorrectly logged as FreezeAccount in token program

### DIFF
--- a/token/program/src/processor.rs
+++ b/token/program/src/processor.rs
@@ -702,7 +702,7 @@ impl Processor {
                 Self::process_toggle_freeze_account(program_id, accounts, true)
             }
             TokenInstruction::ThawAccount => {
-                msg!("Instruction: FreezeAccount");
+                msg!("Instruction: ThawAccount");
                 Self::process_toggle_freeze_account(program_id, accounts, false)
             }
             TokenInstruction::TransferChecked { amount, decimals } => {


### PR DESCRIPTION
Resolves #1739.

Please close if it's actually intentional.