### PR TITLE
bugfix: fix getAssociatedTokenAddress can't used by pda

### DIFF
--- a/token/js/client/token.js
+++ b/token/js/client/token.js
@@ -2239,8 +2239,9 @@ export class Token {
     programId: PublicKey,
     mint: PublicKey,
     owner: PublicKey,
+    allowOwnerOffCurve: boolean = false,
   ): Promise<PublicKey> {
-    if (!PublicKey.isOnCurve(owner.toBuffer())) {
+    if (!allowOwnerOffCurve && !PublicKey.isOnCurve(owner.toBuffer())) {
       throw new Error(`Owner cannot sign: ${owner.toString()}`);
     }
     return (

--- a/token/js/test/token.test.js
+++ b/token/js/test/token.test.js
@@ -52,6 +52,16 @@ describe('Token', () => {
       new PublicKey('7o36UsWR1JQLpZ9PE2gn9L4SQ69CNNiWAXd4Jt7rqz9Z'),
       associatedPublicKey,
     )).to.be.rejectedWith(`Owner cannot sign: ${associatedPublicKey.toString()}`);
+    const associatedPublicKey2 = await Token.getAssociatedTokenAddress(
+      ASSOCIATED_TOKEN_PROGRAM_ID,
+      TOKEN_PROGRAM_ID,
+      new PublicKey('7o36UsWR1JQLpZ9PE2gn9L4SQ69CNNiWAXd4Jt7rqz9Z'),
+      associatedPublicKey,
+      true,
+    )
+    expect(associatedPublicKey2.toString()).to.eql(
+      new PublicKey('F3DmXZFqkfEWFA7MN2vDPs813GeEWPaT6nLk4PSGuWJd').toString(),
+    );
   });
 
   it('createAssociatedTokenAccount', () => {

--- a/token/js/test/token.test.js
+++ b/token/js/test/token.test.js
@@ -58,7 +58,7 @@ describe('Token', () => {
       new PublicKey('7o36UsWR1JQLpZ9PE2gn9L4SQ69CNNiWAXd4Jt7rqz9Z'),
       associatedPublicKey,
       true,
-    )
+    );
     expect(associatedPublicKey2.toString()).to.eql(
       new PublicKey('F3DmXZFqkfEWFA7MN2vDPs813GeEWPaT6nLk4PSGuWJd').toString(),
     );


### PR DESCRIPTION
`getAssociatedTokenAddress` will throw an error If I want to create an ada for a pda.
I don't think it should be blocked here and in fact I can sign the owner by program.