### PR TITLE
lending: Flash Loan fixes

### DIFF
--- a/token-lending/program/src/error.rs
+++ b/token-lending/program/src/error.rs
@@ -153,9 +153,13 @@ pub enum LendingError {
     /// Oracle config is invalid
     #[error("Input oracle config is invalid")]
     InvalidOracleConfig,
+    /// Expected a different flash loan receiver program
+    #[error("Input flash loan receiver program account is not valid")]
+    InvalidFlashLoanReceiverProgram,
     /// Not enough liquidity after flash loan
     #[error("Not enough liquidity after flash loan")]
     NotEnoughLiquidityAfterFlashLoan,
+    // 45
 }
 
 impl From<LendingError> for ProgramError {

--- a/token-lending/program/src/instruction.rs
+++ b/token-lending/program/src/instruction.rs
@@ -281,15 +281,15 @@ pub enum LendingInstruction {
     ///   1. `[writable]` Destination liquidity token account.
     ///                     Minted by reserve liquidity mint.
     ///   2. `[writable]` Reserve account.
-    ///   3. `[]` Lending market account.
-    ///   4. `[]` Derived lending market authority.
-    ///   5. `[]` Flash loan receiver program account.
-    ///             Must implement an instruction that has tag of 0 and a signature of `(repay_amount: u64)`
-    ///             This instruction must return the amount to the source liquidity account.
-    ///   6. `[]` Token program id.
-    ///   7. `[writable]` Flash loan fee receiver account.
+    ///   3. `[writable]` Flash loan fee receiver account.
     ///                     Must match the reserve liquidity fee receiver.
-    ///   8. `[writable]` Host fee receiver.
+    ///   4. `[writable]` Host fee receiver.
+    ///   5. `[]` Lending market account.
+    ///   6. `[]` Derived lending market authority.
+    ///   7. `[]` Token program id.
+    ///   8. `[]` Flash loan receiver program id.
+    ///             Must implement an instruction that has tag of 0 and a signature of `(amount: u64)`
+    ///             This instruction must return the amount to the source liquidity account.
     ///   .. `[any]` Additional accounts expected by the receiving program's `ReceiveFlashLoan` instruction.
     ///
     ///   The flash loan receiver program that is to be invoked should contain an instruction with
@@ -303,7 +303,7 @@ pub enum LendingInstruction {
     ///   2. `[]` Token program id
     ///   .. `[any]` Additional accounts provided to the lending program's `FlashLoan` instruction above.
     ///   ReceiveFlashLoan {
-    ///       // Amount that is loaned to the receiver program
+    ///       // Amount that must be repaid by the receiver program
     ///       amount: u64
     ///   }
     FlashLoan {
@@ -943,28 +943,31 @@ pub fn liquidate_obligation(
 pub fn flash_loan(
     program_id: Pubkey,
     amount: u64,
-    reserve_liquidity_pubkey: Pubkey,
+    source_liquidity_pubkey: Pubkey,
     destination_liquidity_pubkey: Pubkey,
     reserve_pubkey: Pubkey,
-    lending_market_pubkey: Pubkey,
-    derived_lending_market_authority_pubkey: Pubkey,
-    flash_loan_receiver_pubkey: Pubkey,
-    flash_loan_fee_receiver_pubkey: Pubkey,
+    reserve_liquidity_fee_receiver_pubkey: Pubkey,
     host_fee_receiver_pubkey: Pubkey,
-    flash_loan_receiver_program_account_meta: Vec<AccountMeta>,
+    lending_market_pubkey: Pubkey,
+    flash_loan_receiver_program_id: Pubkey,
+    flash_loan_receiver_program_accounts: Vec<AccountMeta>,
 ) -> Instruction {
+    let (lending_market_authority_pubkey, _bump_seed) = Pubkey::find_program_address(
+        &[&lending_market_pubkey.to_bytes()[..PUBKEY_BYTES]],
+        &program_id,
+    );
     let mut accounts = vec![
-        AccountMeta::new(reserve_liquidity_pubkey, false),
+        AccountMeta::new(source_liquidity_pubkey, false),
         AccountMeta::new(destination_liquidity_pubkey, false),
-        AccountMeta::new_readonly(reserve_pubkey, false),
-        AccountMeta::new_readonly(lending_market_pubkey, false),
-        AccountMeta::new_readonly(derived_lending_market_authority_pubkey, false),
-        AccountMeta::new_readonly(flash_loan_receiver_pubkey, false),
-        AccountMeta::new(flash_loan_fee_receiver_pubkey, false),
+        AccountMeta::new(reserve_pubkey, false),
+        AccountMeta::new(reserve_liquidity_fee_receiver_pubkey, false),
         AccountMeta::new(host_fee_receiver_pubkey, false),
+        AccountMeta::new_readonly(lending_market_pubkey, false),
+        AccountMeta::new_readonly(lending_market_authority_pubkey, false),
         AccountMeta::new_readonly(spl_token::id(), false),
+        AccountMeta::new_readonly(flash_loan_receiver_program_id, false),
     ];
-    accounts.extend(flash_loan_receiver_program_account_meta);
+    accounts.extend(flash_loan_receiver_program_accounts);
     Instruction {
         program_id,
         accounts,

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -1550,6 +1550,10 @@ fn process_flash_loan(
     if lending_market_info.owner != program_id {
         return Err(LendingError::InvalidAccountOwner.into());
     }
+    if &lending_market.token_program_id != token_program_id.key {
+        msg!("Lending market token program does not match the token program provided");
+        return Err(LendingError::InvalidTokenProgram.into());
+    }
 
     let authority_signer_seeds = &[
         lending_market_info.key.as_ref(),

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -1546,6 +1546,11 @@ fn process_flash_loan(
     let token_program_id = next_account_info(account_info_iter)?;
     let flash_loan_receiver_program_id = next_account_info(account_info_iter)?;
 
+    if program_id == flash_loan_receiver_program_id.key {
+        msg!("Lending program cannot be used as the flash loan receiver program provided");
+        return Err(LendingError::InvalidFlashLoanReceiverProgram.into());
+    }
+
     let lending_market = LendingMarket::unpack(&lending_market_info.data.borrow())?;
     if lending_market_info.owner != program_id {
         return Err(LendingError::InvalidAccountOwner.into());
@@ -1636,6 +1641,7 @@ fn process_flash_loan(
     })?;
 
     const RECEIVE_FLASH_LOAN_INSTRUCTION_DATA_SIZE: usize = 9;
+    // @FIXME: don't use 0 to indicate a flash loan receiver instruction https://git.io/JGzz9
     const RECEIVE_FLASH_LOAN_INSTRUCTION_TAG: u8 = 0u8;
 
     let mut data = Vec::with_capacity(RECEIVE_FLASH_LOAN_INSTRUCTION_DATA_SIZE);

--- a/token-lending/program/src/state/reserve.rs
+++ b/token-lending/program/src/state/reserve.rs
@@ -624,6 +624,7 @@ pub struct ReserveFees {
     /// 0.00001% (Aave borrow fee) = 100_000_000_000
     pub borrow_fee_wad: u64,
     /// Fee for flash loan, expressed as a Wad.
+    /// 0.3% (Aave flash loan fee) = 3_000_000_000_000_000
     pub flash_loan_fee_wad: u64,
     /// Amount of fee going to host account, if provided in liquidate and repay
     pub host_fee_percentage: u8,

--- a/token-lending/program/src/state/reserve.rs
+++ b/token-lending/program/src/state/reserve.rs
@@ -1138,6 +1138,7 @@ mod test {
             host_fee_percentage in 0..=100u8,
             borrow_amount in 3..=u64::MAX, // start at 3 to ensure calculation success
                                            // 0, 1, and 2 are covered in the minimum tests
+                                           // @FIXME: ^ no longer true
         ) {
             let fees = ReserveFees {
                 borrow_fee_wad,

--- a/token-lending/program/tests/borrow_obligation_liquidity.rs
+++ b/token-lending/program/tests/borrow_obligation_liquidity.rs
@@ -126,7 +126,6 @@ async fn test_borrow_quote_currency() {
             FeeCalculation::Exclusive,
         )
         .unwrap();
-
     assert_eq!(total_fee, FEE_AMOUNT);
     assert_eq!(host_fee, HOST_FEE_AMOUNT);
 

--- a/token-lending/program/tests/flash_loan.rs
+++ b/token-lending/program/tests/flash_loan.rs
@@ -24,7 +24,7 @@ async fn test_success() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(41_000);
+    test.set_bpf_compute_max_units(50_000);
 
     const FLASH_LOAN_AMOUNT: u64 = 1_000 * FRACTIONAL_TO_USDC;
     const FEE_AMOUNT: u64 = 3_000_000;

--- a/token-lending/program/tests/flash_loan.rs
+++ b/token-lending/program/tests/flash_loan.rs
@@ -5,16 +5,17 @@ mod helpers;
 use helpers::*;
 use solana_program::instruction::AccountMeta;
 use solana_program_test::*;
-use solana_sdk::signature::Signer;
-use solana_sdk::transaction::{Transaction, TransactionError};
-use solana_sdk::{pubkey::Pubkey, signature::Keypair};
+use solana_sdk::{
+    pubkey::Pubkey,
+    signature::{Keypair, Signer},
+    transaction::{Transaction, TransactionError},
+};
 use spl_token::solana_program::instruction::InstructionError;
-use spl_token_lending::error::LendingError;
-use spl_token_lending::instruction::flash_loan;
-use spl_token_lending::math::Decimal;
-use spl_token_lending::processor::process_instruction;
-
-const INITIAL_RESERVE_LIQUIDITY: u64 = 1_000_000;
+use spl_token_lending::{
+    error::LendingError,
+    instruction::flash_loan,
+    processor::process_instruction
+};
 
 #[tokio::test]
 async fn test_success() {
@@ -25,131 +26,11 @@ async fn test_success() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(118_000);
+    test.set_bpf_compute_max_units(41_000);
 
-    let receiver_program_account = Keypair::new();
-    let receiver_program_id = receiver_program_account.pubkey();
-    test.add_program(
-        "flash_loan_receiver",
-        receiver_program_id.clone(),
-        processor!(helpers::flash_loan_receiver::process_instruction),
-    );
-
-    let user_accounts_owner = Keypair::new();
-    let usdc_mint = add_usdc_mint(&mut test);
-    let lending_market = add_lending_market(&mut test, usdc_mint.pubkey);
-
-    let reserve_config = TEST_RESERVE_CONFIG;
-    let flash_loan_amount = 1_000_000u64;
-    let (flash_loan_fee, host_fee) = TEST_RESERVE_CONFIG
-        .fees
-        .calculate_flash_loan_fees(Decimal::from(flash_loan_amount))
-        .unwrap();
-
-    let usdc_reserve = add_reserve(
-        &mut test,
-        &lending_market,
-        &user_accounts_owner,
-        AddReserveArgs {
-            liquidity_amount: INITIAL_RESERVE_LIQUIDITY,
-            liquidity_mint_pubkey: usdc_mint.pubkey,
-            liquidity_mint_decimals: usdc_mint.decimals,
-            config: reserve_config,
-            user_liquidity_amount: flash_loan_fee,
-            ..AddReserveArgs::default()
-        },
-    );
-
-    let (receiver_authority_pubkey, _) =
-        Pubkey::find_program_address(&[b"flashloan"], &receiver_program_id);
-    let program_owned_token_account = add_account_for_program(
-        &mut test,
-        &receiver_authority_pubkey,
-        flash_loan_fee,
-        &usdc_mint.pubkey,
-    );
-
-    let (mut banks_client, payer, recent_blockhash) = test.start().await;
-
-    let before_flash_loan_reserve_liquidity_token_balance =
-        get_token_balance(&mut banks_client, usdc_reserve.liquidity_supply_pubkey).await;
-    assert_eq!(
-        before_flash_loan_reserve_liquidity_token_balance,
-        INITIAL_RESERVE_LIQUIDITY
-    );
-
-    let before_flash_loan_reserve = usdc_reserve.get_state(&mut banks_client).await;
-    assert_eq!(
-        before_flash_loan_reserve.liquidity.available_amount,
-        INITIAL_RESERVE_LIQUIDITY
-    );
-
-    let before_flash_loan_token_balance =
-        get_token_balance(&mut banks_client, program_owned_token_account).await;
-    // There should be enough token at the beginning to pay back the flash loan fee.
-    assert_eq!(before_flash_loan_token_balance, flash_loan_fee);
-
-    let mut transaction = Transaction::new_with_payer(
-        &[flash_loan(
-            spl_token_lending::id(),
-            flash_loan_amount,
-            usdc_reserve.liquidity_supply_pubkey,
-            program_owned_token_account,
-            usdc_reserve.pubkey,
-            lending_market.pubkey,
-            lending_market.authority,
-            receiver_program_id.clone(),
-            usdc_reserve.liquidity_fee_receiver_pubkey,
-            usdc_reserve.liquidity_host_pubkey,
-            vec![AccountMeta::new_readonly(
-                receiver_authority_pubkey.clone(),
-                false,
-            )],
-        )],
-        Some(&payer.pubkey()),
-    );
-
-    transaction.sign(&[&payer], recent_blockhash);
-    assert!(banks_client.process_transaction(transaction).await.is_ok());
-
-    let after_flash_loan_reserve_liquidity_token_balance =
-        get_token_balance(&mut banks_client, usdc_reserve.liquidity_supply_pubkey).await;
-    assert_eq!(
-        after_flash_loan_reserve_liquidity_token_balance,
-        INITIAL_RESERVE_LIQUIDITY
-    );
-
-    let after_flash_loan_reserve = usdc_reserve.get_state(&mut banks_client).await;
-    assert_eq!(
-        after_flash_loan_reserve.liquidity.available_amount,
-        INITIAL_RESERVE_LIQUIDITY
-    );
-
-    let after_flash_loan_token_balance =
-        get_token_balance(&mut banks_client, program_owned_token_account).await;
-    assert_eq!(after_flash_loan_token_balance, 0);
-    let fee_balance = get_token_balance(
-        &mut banks_client,
-        usdc_reserve.liquidity_fee_receiver_pubkey,
-    )
-    .await;
-    assert_eq!(fee_balance, flash_loan_fee - host_fee);
-
-    let host_fee_balance =
-        get_token_balance(&mut banks_client, usdc_reserve.liquidity_host_pubkey).await;
-    assert_eq!(host_fee_balance, host_fee);
-}
-
-#[tokio::test]
-async fn test_failure() {
-    let mut test = ProgramTest::new(
-        "spl_token_lending",
-        spl_token_lending::id(),
-        processor!(process_instruction),
-    );
-
-    // limit to track compute unit increase
-    test.set_bpf_compute_max_units(118_000);
+    const FLASH_LOAN_AMOUNT: u64 = 1_000 * FRACTIONAL_TO_USDC;
+    const FEE_AMOUNT: u64 = 3_000_000;
+    const HOST_FEE_AMOUNT: u64 = 600_000;
 
     let receiver_program_account = Keypair::new();
     let receiver_program_id = receiver_program_account.pubkey();
@@ -164,55 +45,164 @@ async fn test_failure() {
     let lending_market = add_lending_market(&mut test, usdc_mint.pubkey);
 
     let mut reserve_config = TEST_RESERVE_CONFIG;
-    reserve_config.loan_to_value_ratio = 80;
-    let flash_loan_amount = 1_000_000u64;
-    let (flash_loan_fee, _host_fee) = TEST_RESERVE_CONFIG
-        .fees
-        .calculate_flash_loan_fees(Decimal::from(flash_loan_amount))
-        .unwrap();
+    reserve_config.fees.flash_loan_fee_wad = 3_000_000_000_000_000;
 
-    let usdc_reserve = add_reserve(
+    let usdc_test_reserve = add_reserve(
         &mut test,
         &lending_market,
         &user_accounts_owner,
         AddReserveArgs {
-            liquidity_amount: INITIAL_RESERVE_LIQUIDITY,
+            liquidity_amount: FLASH_LOAN_AMOUNT,
             liquidity_mint_pubkey: usdc_mint.pubkey,
             liquidity_mint_decimals: usdc_mint.decimals,
             config: reserve_config,
-            user_liquidity_amount: flash_loan_fee,
             ..AddReserveArgs::default()
         },
     );
+
     let (receiver_authority_pubkey, _) =
         Pubkey::find_program_address(&[b"flashloan"], &receiver_program_id);
     let program_owned_token_account = add_account_for_program(
         &mut test,
         &receiver_authority_pubkey,
-        // Provide Insufficient fund to exercise the flash loan returned fund check.
-        flash_loan_fee - 1,
+        FEE_AMOUNT,
         &usdc_mint.pubkey,
     );
 
     let (mut banks_client, payer, recent_blockhash) = test.start().await;
 
-    let before_flash_loan_token_balance =
+    let initial_liquidity_supply =
+        get_token_balance(&mut banks_client, usdc_test_reserve.liquidity_supply_pubkey).await;
+    assert_eq!(initial_liquidity_supply, FLASH_LOAN_AMOUNT);
+
+    let usdc_reserve = usdc_test_reserve.get_state(&mut banks_client).await;
+    let initial_available_amount = usdc_reserve.liquidity.available_amount;
+    assert_eq!(initial_available_amount, FLASH_LOAN_AMOUNT);
+
+    let initial_token_balance =
         get_token_balance(&mut banks_client, program_owned_token_account).await;
-    // There should be not enough token at the beginning.
-    assert_eq!(before_flash_loan_token_balance, flash_loan_fee - 1);
+    assert_eq!(initial_token_balance, FEE_AMOUNT);
 
     let mut transaction = Transaction::new_with_payer(
         &[flash_loan(
             spl_token_lending::id(),
-            flash_loan_amount,
-            usdc_reserve.liquidity_supply_pubkey,
+            FLASH_LOAN_AMOUNT,
+            usdc_test_reserve.liquidity_supply_pubkey,
             program_owned_token_account,
-            usdc_reserve.pubkey,
+            usdc_test_reserve.pubkey,
+            usdc_test_reserve.liquidity_fee_receiver_pubkey,
+            usdc_test_reserve.liquidity_host_pubkey,
             lending_market.pubkey,
-            lending_market.authority,
             receiver_program_id.clone(),
-            usdc_reserve.liquidity_fee_receiver_pubkey,
-            usdc_reserve.liquidity_host_pubkey,
+            vec![AccountMeta::new_readonly(
+                receiver_authority_pubkey.clone(),
+                false,
+            )],
+        )],
+        Some(&payer.pubkey()),
+    );
+
+    transaction.sign(&[&payer], recent_blockhash);
+    assert!(banks_client.process_transaction(transaction).await.is_ok());
+
+    let usdc_reserve = usdc_test_reserve.get_state(&mut banks_client).await;
+    assert_eq!(
+        usdc_reserve.liquidity.available_amount,
+        initial_available_amount
+    );
+
+    let (total_fee, host_fee) = usdc_reserve
+        .config
+        .fees
+        .calculate_flash_loan_fees(FLASH_LOAN_AMOUNT.into())
+        .unwrap();
+    assert_eq!(total_fee, FEE_AMOUNT);
+    assert_eq!(host_fee, HOST_FEE_AMOUNT);
+
+    let liquidity_supply =
+        get_token_balance(&mut banks_client, usdc_test_reserve.liquidity_supply_pubkey).await;
+    assert_eq!(liquidity_supply, initial_liquidity_supply);
+
+    let token_balance = get_token_balance(&mut banks_client, program_owned_token_account).await;
+    assert_eq!(token_balance, initial_token_balance - FEE_AMOUNT);
+
+    let fee_balance = get_token_balance(
+        &mut banks_client,
+        usdc_test_reserve.liquidity_fee_receiver_pubkey,
+    )
+    .await;
+    assert_eq!(fee_balance, FEE_AMOUNT - HOST_FEE_AMOUNT);
+
+    let host_fee_balance =
+        get_token_balance(&mut banks_client, usdc_test_reserve.liquidity_host_pubkey).await;
+    assert_eq!(host_fee_balance, HOST_FEE_AMOUNT);
+}
+
+#[tokio::test]
+async fn test_failure() {
+    let mut test = ProgramTest::new(
+        "spl_token_lending",
+        spl_token_lending::id(),
+        processor!(process_instruction),
+    );
+
+    const FLASH_LOAN_AMOUNT: u64 = 1_000 * FRACTIONAL_TO_USDC;
+    const FEE_AMOUNT: u64 = 3_000_000;
+
+    let flash_loan_receiver_program_keypair = Keypair::new();
+    let flash_loan_receiver_program_id = flash_loan_receiver_program_keypair.pubkey();
+    test.add_program(
+        "flash_loan_receiver",
+        flash_loan_receiver_program_id.clone(),
+        processor!(helpers::flash_loan_receiver::process_instruction),
+    );
+
+    let user_accounts_owner = Keypair::new();
+    let usdc_mint = add_usdc_mint(&mut test);
+    let lending_market = add_lending_market(&mut test, usdc_mint.pubkey);
+
+    let mut reserve_config = TEST_RESERVE_CONFIG;
+    reserve_config.fees.flash_loan_fee_wad = 3_000_000_000_000_000;
+
+    let usdc_test_reserve = add_reserve(
+        &mut test,
+        &lending_market,
+        &user_accounts_owner,
+        AddReserveArgs {
+            liquidity_amount: FLASH_LOAN_AMOUNT,
+            liquidity_mint_pubkey: usdc_mint.pubkey,
+            liquidity_mint_decimals: usdc_mint.decimals,
+            config: reserve_config,
+            ..AddReserveArgs::default()
+        },
+    );
+
+    let (receiver_authority_pubkey, _) =
+        Pubkey::find_program_address(&[b"flashloan"], &flash_loan_receiver_program_id);
+    let program_owned_token_account = add_account_for_program(
+        &mut test,
+        &receiver_authority_pubkey,
+        FEE_AMOUNT - 1,
+        &usdc_mint.pubkey,
+    );
+
+    let (mut banks_client, payer, recent_blockhash) = test.start().await;
+
+    let initial_token_balance =
+        get_token_balance(&mut banks_client, program_owned_token_account).await;
+    assert_eq!(initial_token_balance, FEE_AMOUNT - 1);
+
+    let mut transaction = Transaction::new_with_payer(
+        &[flash_loan(
+            spl_token_lending::id(),
+            FLASH_LOAN_AMOUNT,
+            usdc_test_reserve.liquidity_supply_pubkey,
+            program_owned_token_account,
+            usdc_test_reserve.pubkey,
+            usdc_test_reserve.liquidity_fee_receiver_pubkey,
+            usdc_test_reserve.liquidity_host_pubkey,
+            lending_market.pubkey,
+            flash_loan_receiver_program_id.clone(),
             vec![AccountMeta::new_readonly(
                 receiver_authority_pubkey.clone(),
                 false,

--- a/token-lending/program/tests/flash_loan.rs
+++ b/token-lending/program/tests/flash_loan.rs
@@ -12,9 +12,7 @@ use solana_sdk::{
 };
 use spl_token::solana_program::instruction::InstructionError;
 use spl_token_lending::{
-    error::LendingError,
-    instruction::flash_loan,
-    processor::process_instruction
+    error::LendingError, instruction::flash_loan, processor::process_instruction,
 };
 
 #[tokio::test]

--- a/token-lending/program/tests/helpers/mod.rs
+++ b/token-lending/program/tests/helpers/mod.rs
@@ -52,10 +52,10 @@ pub const TEST_RESERVE_CONFIG: ReserveConfig = ReserveConfig {
     optimal_borrow_rate: 4,
     max_borrow_rate: 30,
     fees: ReserveFees {
-        borrow_fee_wad: 100_000_000_000,
         /// 0.00001% (Aave borrow fee)
-        flash_loan_fee_wad: 3_000_000_000_000_000,
+        borrow_fee_wad: 100_000_000_000,
         /// 0.3% (Aave flash loan fee)
+        flash_loan_fee_wad: 3_000_000_000_000_000,
         host_fee_percentage: 20,
     },
 };


### PR DESCRIPTION
This PR

- Makes the reserve account writable and persists the borrow and repay so the flash loan receiver program has a consistent view of the state.
- Reorganizes the accounts expected by the FlashLoan instruction so that the writable accounts come first, the reserve accounts come in order, and the flash loan receiver program ID and variadic accounts come last.
- Renames some things for consistency with the other instructions.
- Improves related tests.