### PR TITLE
stake-pool: Add preferred deposit / withdraw validator accounts

### DIFF
--- a/stake-pool/program/src/error.rs
+++ b/stake-pool/program/src/error.rs
@@ -88,6 +88,14 @@ pub enum StakePoolError {
     /// The lamports in the validator stake account is not equal to the minimum
     #[error("StakeLamportsNotEqualToMinimum")]
     StakeLamportsNotEqualToMinimum,
+    /// The provided deposit stake account is not delegated to the preferred deposit vote account
+    #[error("IncorrectDepositVoteAddress")]
+    IncorrectDepositVoteAddress,
+
+    // 25.
+    /// The provided withdraw stake account is not the preferred deposit vote account
+    #[error("IncorrectWithdrawVoteAddress")]
+    IncorrectWithdrawVoteAddress,
 }
 impl From<StakePoolError> for ProgramError {
     fn from(e: StakePoolError) -> Self {

--- a/stake-pool/program/src/instruction.rs
+++ b/stake-pool/program/src/instruction.rs
@@ -18,6 +18,17 @@ use {
     },
 };
 
+/// Defines which validator vote account is set during the
+/// `SetPreferredValidator` instruction
+#[repr(C)]
+#[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize, BorshSchema)]
+pub enum PreferredValidatorType {
+    /// Set preferred validator for deposits
+    Deposit,
+    /// Set preferred validator for withdraws
+    Withdraw,
+}
+
 /// Instructions supported by the StakePool program.
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize, BorshSchema)]
@@ -153,6 +164,28 @@ pub enum StakePoolInstruction {
     /// 12. `[]` Stake program
     ///  userdata: amount of lamports to split into the transient stake account
     IncreaseValidatorStake(u64),
+
+    /// (Staker only) Set the preferred deposit or withdraw stake account for the
+    /// stake pool
+    ///
+    /// In order to avoid users abusing the stake pool as a free conversion
+    /// between SOL staked on different validators, the staker can force all
+    /// deposits and/or withdraws to go to one chosen account, or unset that account.
+    ///
+    /// 0. `[]` Stake pool
+    /// 1. `[s]` Stake pool staker
+    /// 2. `[w]` Validator list
+    ///
+    /// Fails if the validator is not part of the stake pool.
+    SetPreferredValidator {
+        /// Affected operation (deposit or withdraw)
+        #[allow(dead_code)] // but it's not
+        validator_type: PreferredValidatorType,
+        /// Validator vote account that deposits or withdraws must go through,
+        /// unset with None
+        #[allow(dead_code)] // but it's not
+        validator_vote_address: Option<Pubkey>,
+    },
 
     ///  Updates balances of validator and transient stake accounts in the pool
     ///
@@ -462,6 +495,29 @@ pub fn increase_validator_stake(
         data: StakePoolInstruction::IncreaseValidatorStake(lamports)
             .try_to_vec()
             .unwrap(),
+    }
+}
+
+/// Creates `SetPreferredDepositValidator` instruction
+pub fn set_preferred_validator(
+    program_id: &Pubkey,
+    stake_pool_address: &Pubkey,
+    staker: &Pubkey,
+    validator_list_address: &Pubkey,
+    validator_type: PreferredValidatorType,
+    validator_vote_address: Option<Pubkey>,
+) -> Instruction {
+    Instruction {
+        program_id: *program_id,
+        accounts: vec![
+            AccountMeta::new_readonly(*stake_pool_address, false),
+            AccountMeta::new_readonly(*staker, true),
+            AccountMeta::new(*validator_list_address, false),
+        ],
+        data: StakePoolInstruction::SetPreferredValidator {
+            validator_type,
+            validator_vote_address,
+        }.try_to_vec().unwrap()
     }
 }
 

--- a/stake-pool/program/src/instruction.rs
+++ b/stake-pool/program/src/instruction.rs
@@ -517,7 +517,9 @@ pub fn set_preferred_validator(
         data: StakePoolInstruction::SetPreferredValidator {
             validator_type,
             validator_vote_address,
-        }.try_to_vec().unwrap()
+        }
+        .try_to_vec()
+        .unwrap(),
     }
 }
 

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -5,7 +5,7 @@ use {
         borsh::try_from_slice_unchecked,
         error::StakePoolError,
         find_deposit_authority_program_address,
-        instruction::StakePoolInstruction,
+        instruction::{PreferredValidatorType, StakePoolInstruction},
         minimum_reserve_lamports, minimum_stake_lamports, stake_program,
         state::{AccountType, Fee, StakePool, StakeStatus, ValidatorList, ValidatorStakeInfo},
         AUTHORITY_DEPOSIT, AUTHORITY_WITHDRAW, MINIMUM_ACTIVE_STAKE, TRANSIENT_STAKE_SEED,
@@ -432,6 +432,8 @@ impl Processor {
             return Err(StakePoolError::UnexpectedValidatorListAccountSize.into());
         }
         validator_list.account_type = AccountType::ValidatorList;
+        validator_list.preferred_deposit_validator_vote_address = None;
+        validator_list.preferred_withdraw_validator_vote_address = None;
         validator_list.validators.clear();
         validator_list.max_validators = max_validators;
 
@@ -1150,6 +1152,51 @@ impl Processor {
         Ok(())
     }
 
+    /// Process `SetPreferredValidator` instruction
+    fn process_set_preferred_validator(
+        program_id: &Pubkey,
+        accounts: &[AccountInfo],
+        validator_type: PreferredValidatorType,
+        vote_account_address: Option<Pubkey>,
+    ) -> ProgramResult {
+        let account_info_iter = &mut accounts.iter();
+        let stake_pool_info = next_account_info(account_info_iter)?;
+        let staker_info = next_account_info(account_info_iter)?;
+        let validator_list_info = next_account_info(account_info_iter)?;
+
+        check_account_owner(stake_pool_info, program_id)?;
+        check_account_owner(validator_list_info, program_id)?;
+
+        let stake_pool = StakePool::try_from_slice(&stake_pool_info.data.borrow())?;
+        if !stake_pool.is_valid() {
+            msg!("Expected valid stake pool");
+            return Err(StakePoolError::InvalidState.into());
+        }
+
+        stake_pool.check_staker(staker_info)?;
+        stake_pool.check_validator_list(validator_list_info)?;
+
+        let mut validator_list =
+            try_from_slice_unchecked::<ValidatorList>(&validator_list_info.data.borrow())?;
+        if !validator_list.is_valid() {
+            return Err(StakePoolError::InvalidState.into());
+        }
+
+        if let Some(vote_account_address) = vote_account_address {
+            if !validator_list.contains(&vote_account_address) {
+                msg!("Validator for {} not present in the stake pool, cannot set as preferred deposit account");
+                return Err(StakePoolError::ValidatorNotFound.into());
+            }
+        }
+
+        match validator_type {
+            PreferredValidatorType::Deposit => validator_list.preferred_deposit_validator_vote_address = vote_account_address,
+            PreferredValidatorType::Withdraw => validator_list.preferred_withdraw_validator_vote_address = vote_account_address,
+        };
+        validator_list.serialize(&mut *validator_list_info.data.borrow_mut())?;
+        Ok(())
+    }
+
     /// Processes `UpdateValidatorListBalance` instruction.
     fn process_update_validator_list_balance(
         program_id: &Pubkey,
@@ -1484,7 +1531,6 @@ impl Processor {
         let clock_info = next_account_info(account_info_iter)?;
         let clock = &Clock::from_account_info(clock_info)?;
         let stake_history_info = next_account_info(account_info_iter)?;
-        //let stake_history = &StakeHistory::from_account_info(stake_history_info)?;
         let token_program_info = next_account_info(account_info_iter)?;
         let stake_program_info = next_account_info(account_info_iter)?;
 
@@ -1900,6 +1946,13 @@ impl Processor {
             StakePoolInstruction::IncreaseValidatorStake(amount) => {
                 msg!("Instruction: IncreaseValidatorStake");
                 Self::process_increase_validator_stake(program_id, accounts, amount)
+            }
+            StakePoolInstruction::SetPreferredValidator {
+                validator_type,
+                validator_vote_address,
+            } => {
+                msg!("Instruction: SetPreferredValidator");
+                Self::process_set_preferred_validator(program_id, accounts, validator_type, validator_vote_address)
             }
             StakePoolInstruction::UpdateValidatorListBalance {
                 start_index,

--- a/stake-pool/program/tests/deposit.rs
+++ b/stake-pool/program/tests/deposit.rs
@@ -32,6 +32,10 @@ async fn setup() -> (
     Hash,
     StakePoolAccounts,
     ValidatorStakeAccount,
+    Keypair,
+    Pubkey,
+    Pubkey,
+    u64,
 ) {
     let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
     let stake_pool_accounts = StakePoolAccounts::new();
@@ -40,7 +44,7 @@ async fn setup() -> (
         .await
         .unwrap();
 
-    let validator_stake_account: ValidatorStakeAccount = simple_add_validator_to_pool(
+    let validator_stake_account = simple_add_validator_to_pool(
         &mut banks_client,
         &payer,
         &recent_blockhash,
@@ -48,72 +52,76 @@ async fn setup() -> (
     )
     .await;
 
-    (
-        banks_client,
-        payer,
-        recent_blockhash,
-        stake_pool_accounts,
-        validator_stake_account,
-    )
-}
-
-#[tokio::test]
-async fn test_stake_pool_deposit() {
-    let (mut banks_client, payer, recent_blockhash, stake_pool_accounts, validator_stake_account) =
-        setup().await;
-
     let user = Keypair::new();
     // make stake account
-    let user_stake = Keypair::new();
+    let deposit_stake = Keypair::new();
     let lockup = stake_program::Lockup::default();
 
-    let stake_authority = Keypair::new();
     let authorized = stake_program::Authorized {
-        staker: stake_authority.pubkey(),
-        withdrawer: stake_authority.pubkey(),
+        staker: user.pubkey(),
+        withdrawer: user.pubkey(),
     };
 
     let stake_lamports = create_independent_stake_account(
         &mut banks_client,
         &payer,
         &recent_blockhash,
-        &user_stake,
+        &deposit_stake,
         &authorized,
         &lockup,
         TEST_STAKE_AMOUNT,
     )
     .await;
 
-    create_vote(
-        &mut banks_client,
-        &payer,
-        &recent_blockhash,
-        &validator_stake_account.validator,
-        &validator_stake_account.vote,
-    )
-    .await;
     delegate_stake_account(
         &mut banks_client,
         &payer,
         &recent_blockhash,
-        &user_stake.pubkey(),
-        &stake_authority,
+        &deposit_stake.pubkey(),
+        &user,
         &validator_stake_account.vote.pubkey(),
     )
     .await;
 
     // make pool token account
-    let user_pool_account = Keypair::new();
+    let pool_token_account = Keypair::new();
     create_token_account(
         &mut banks_client,
         &payer,
         &recent_blockhash,
-        &user_pool_account,
+        &pool_token_account,
         &stake_pool_accounts.pool_mint.pubkey(),
         &user.pubkey(),
     )
     .await
     .unwrap();
+
+    (
+        banks_client,
+        payer,
+        recent_blockhash,
+        stake_pool_accounts,
+        validator_stake_account,
+        user,
+        deposit_stake.pubkey(),
+        pool_token_account.pubkey(),
+        stake_lamports,
+    )
+}
+
+#[tokio::test]
+async fn success() {
+    let (
+        mut banks_client,
+        payer,
+        recent_blockhash,
+        stake_pool_accounts,
+        validator_stake_account,
+        user,
+        deposit_stake,
+        pool_token_account,
+        stake_lamports,
+    ) = setup().await;
 
     // Save stake pool state before depositing
     let stake_pool_before =
@@ -133,22 +141,22 @@ async fn test_stake_pool_deposit() {
         .find(&validator_stake_account.vote.pubkey())
         .unwrap();
 
-    stake_pool_accounts
+    let error = stake_pool_accounts
         .deposit_stake(
             &mut banks_client,
             &payer,
             &recent_blockhash,
-            &user_stake.pubkey(),
-            &user_pool_account.pubkey(),
+            &deposit_stake,
+            &pool_token_account,
             &validator_stake_account.stake_account,
-            &stake_authority,
+            &user,
         )
-        .await
-        .unwrap();
+        .await;
+    assert!(error.is_none());
 
     // Original stake account should be drained
     assert!(banks_client
-        .get_account(user_stake.pubkey())
+        .get_account(deposit_stake)
         .await
         .expect("get_account")
         .is_none());
@@ -168,8 +176,7 @@ async fn test_stake_pool_deposit() {
     );
 
     // Check minted tokens
-    let user_token_balance =
-        get_token_balance(&mut banks_client, &user_pool_account.pubkey()).await;
+    let user_token_balance = get_token_balance(&mut banks_client, &pool_token_account).await;
     assert_eq!(user_token_balance, tokens_issued);
 
     // Check balances in validator stake account list storage
@@ -201,26 +208,18 @@ async fn test_stake_pool_deposit() {
 }
 
 #[tokio::test]
-async fn test_stake_pool_deposit_with_wrong_stake_program_id() {
-    let (mut banks_client, payer, recent_blockhash, stake_pool_accounts, validator_stake_account) =
-        setup().await;
-
-    let user = Keypair::new();
-    // make stake account
-    let user_stake = Keypair::new();
-
-    // make pool token account
-    let user_pool_account = Keypair::new();
-    create_token_account(
-        &mut banks_client,
-        &payer,
-        &recent_blockhash,
-        &user_pool_account,
-        &stake_pool_accounts.pool_mint.pubkey(),
-        &user.pubkey(),
-    )
-    .await
-    .unwrap();
+async fn fail_with_wrong_stake_program_id() {
+    let (
+        mut banks_client,
+        payer,
+        recent_blockhash,
+        stake_pool_accounts,
+        validator_stake_account,
+        _user,
+        deposit_stake,
+        pool_token_account,
+        _stake_lamports,
+    ) = setup().await;
 
     let wrong_stake_program = Pubkey::new_unique();
 
@@ -229,9 +228,9 @@ async fn test_stake_pool_deposit_with_wrong_stake_program_id() {
         AccountMeta::new(stake_pool_accounts.validator_list.pubkey(), false),
         AccountMeta::new_readonly(stake_pool_accounts.deposit_authority, false),
         AccountMeta::new_readonly(stake_pool_accounts.withdraw_authority, false),
-        AccountMeta::new(user_stake.pubkey(), false),
+        AccountMeta::new(deposit_stake, false),
         AccountMeta::new(validator_stake_account.stake_account, false),
-        AccountMeta::new(user_pool_account.pubkey(), false),
+        AccountMeta::new(pool_token_account, false),
         AccountMeta::new(stake_pool_accounts.pool_mint.pubkey(), false),
         AccountMeta::new_readonly(sysvar::clock::id(), false),
         AccountMeta::new_readonly(sysvar::stake_history::id(), false),
@@ -263,41 +262,18 @@ async fn test_stake_pool_deposit_with_wrong_stake_program_id() {
 }
 
 #[tokio::test]
-async fn test_stake_pool_deposit_with_wrong_token_program_id() {
-    let (mut banks_client, payer, recent_blockhash, stake_pool_accounts, validator_stake_account) =
-        setup().await;
-
-    let user = Keypair::new();
-    // make stake account
-    let user_stake = Keypair::new();
-    let lockup = stake_program::Lockup::default();
-    let authorized = stake_program::Authorized {
-        staker: user.pubkey(),
-        withdrawer: user.pubkey(),
-    };
-    create_independent_stake_account(
-        &mut banks_client,
-        &payer,
-        &recent_blockhash,
-        &user_stake,
-        &authorized,
-        &lockup,
-        TEST_STAKE_AMOUNT,
-    )
-    .await;
-
-    // make pool token account
-    let user_pool_account = Keypair::new();
-    create_token_account(
-        &mut banks_client,
-        &payer,
-        &recent_blockhash,
-        &user_pool_account,
-        &stake_pool_accounts.pool_mint.pubkey(),
-        &user.pubkey(),
-    )
-    .await
-    .unwrap();
+async fn fail_with_wrong_token_program_id() {
+    let (
+        mut banks_client,
+        payer,
+        recent_blockhash,
+        stake_pool_accounts,
+        validator_stake_account,
+        user,
+        deposit_stake,
+        pool_token_account,
+        _stake_lamports,
+    ) = setup().await;
 
     let wrong_token_program = Keypair::new();
 
@@ -307,10 +283,10 @@ async fn test_stake_pool_deposit_with_wrong_token_program_id() {
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.validator_list.pubkey(),
             &stake_pool_accounts.withdraw_authority,
-            &user_stake.pubkey(),
+            &deposit_stake,
             &user.pubkey(),
             &validator_stake_account.stake_account,
-            &user_pool_account.pubkey(),
+            &pool_token_account,
             &stake_pool_accounts.pool_mint.pubkey(),
             &wrong_token_program.pubkey(),
         ),
@@ -332,46 +308,18 @@ async fn test_stake_pool_deposit_with_wrong_token_program_id() {
 }
 
 #[tokio::test]
-async fn test_stake_pool_deposit_with_wrong_validator_list_account() {
+async fn fail_with_wrong_validator_list_account() {
     let (
         mut banks_client,
         payer,
         recent_blockhash,
         mut stake_pool_accounts,
         validator_stake_account,
+        user,
+        deposit_stake,
+        pool_token_account,
+        _stake_lamports,
     ) = setup().await;
-
-    let user = Keypair::new();
-    // make stake account
-    let user_stake = Keypair::new();
-    let lockup = stake_program::Lockup::default();
-    let authorized = stake_program::Authorized {
-        staker: user.pubkey(),
-        withdrawer: user.pubkey(),
-    };
-    create_independent_stake_account(
-        &mut banks_client,
-        &payer,
-        &recent_blockhash,
-        &user_stake,
-        &authorized,
-        &lockup,
-        TEST_STAKE_AMOUNT,
-    )
-    .await;
-
-    // make pool token account
-    let user_pool_account = Keypair::new();
-    create_token_account(
-        &mut banks_client,
-        &payer,
-        &recent_blockhash,
-        &user_pool_account,
-        &stake_pool_accounts.pool_mint.pubkey(),
-        &user.pubkey(),
-    )
-    .await
-    .unwrap();
 
     let wrong_validator_list = Keypair::new();
     stake_pool_accounts.validator_list = wrong_validator_list;
@@ -381,20 +329,20 @@ async fn test_stake_pool_deposit_with_wrong_validator_list_account() {
             &mut banks_client,
             &payer,
             &recent_blockhash,
-            &user_stake.pubkey(),
-            &user_pool_account.pubkey(),
+            &deposit_stake,
+            &pool_token_account,
             &validator_stake_account.stake_account,
             &user,
         )
         .await
-        .err()
+        .unwrap()
         .unwrap();
 
     match transaction_error {
-        TransportError::TransactionError(TransactionError::InstructionError(
+        TransactionError::InstructionError(
             _,
             InstructionError::Custom(error_index),
-        )) => {
+        ) => {
             let program_error = error::StakePoolError::InvalidValidatorStakeList as u32;
             assert_eq!(error_index, program_error);
         }
@@ -403,7 +351,7 @@ async fn test_stake_pool_deposit_with_wrong_validator_list_account() {
 }
 
 #[tokio::test]
-async fn test_stake_pool_deposit_to_unknown_validator() {
+async fn fail_with_unknown_validator() {
     let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
     let stake_pool_accounts = StakePoolAccounts::new();
     stake_pool_accounts
@@ -464,14 +412,11 @@ async fn test_stake_pool_deposit_to_unknown_validator() {
             &user,
         )
         .await
-        .err()
+        .unwrap()
         .unwrap();
 
     match transaction_error {
-        TransportError::TransactionError(TransactionError::InstructionError(
-            _,
-            InstructionError::Custom(error_index),
-        )) => {
+        TransactionError::InstructionError(_, InstructionError::Custom(error_index)) => {
             let program_error = error::StakePoolError::ValidatorNotFound as u32;
             assert_eq!(error_index, program_error);
         }
@@ -482,68 +427,37 @@ async fn test_stake_pool_deposit_to_unknown_validator() {
 }
 
 #[tokio::test]
-async fn test_stake_pool_deposit_with_wrong_withdraw_authority() {
+async fn fail_with_wrong_withdraw_authority() {
     let (
         mut banks_client,
         payer,
         recent_blockhash,
         mut stake_pool_accounts,
         validator_stake_account,
+        user,
+        deposit_stake,
+        pool_token_account,
+        _stake_lamports,
     ) = setup().await;
 
-    let user = Keypair::new();
-    // make stake account
-    let user_stake = Keypair::new();
-    let lockup = stake_program::Lockup::default();
-    let authorized = stake_program::Authorized {
-        staker: user.pubkey(),
-        withdrawer: user.pubkey(),
-    };
-    create_independent_stake_account(
-        &mut banks_client,
-        &payer,
-        &recent_blockhash,
-        &user_stake,
-        &authorized,
-        &lockup,
-        TEST_STAKE_AMOUNT,
-    )
-    .await;
-
-    // make pool token account
-    let user_pool_account = Keypair::new();
-    create_token_account(
-        &mut banks_client,
-        &payer,
-        &recent_blockhash,
-        &user_pool_account,
-        &stake_pool_accounts.pool_mint.pubkey(),
-        &user.pubkey(),
-    )
-    .await
-    .unwrap();
-
-    stake_pool_accounts.withdraw_authority = Keypair::new().pubkey();
+    stake_pool_accounts.withdraw_authority = Pubkey::new_unique();
 
     let transaction_error = stake_pool_accounts
         .deposit_stake(
             &mut banks_client,
             &payer,
             &recent_blockhash,
-            &user_stake.pubkey(),
-            &user_pool_account.pubkey(),
+            &deposit_stake,
+            &pool_token_account,
             &validator_stake_account.stake_account,
             &user,
         )
         .await
-        .err()
+        .unwrap()
         .unwrap();
 
     match transaction_error {
-        TransportError::TransactionError(TransactionError::InstructionError(
-            _,
-            InstructionError::Custom(error_index),
-        )) => {
+        TransactionError::InstructionError(_, InstructionError::Custom(error_index)) => {
             let program_error = error::StakePoolError::InvalidProgramAddress as u32;
             assert_eq!(error_index, program_error);
         }
@@ -552,28 +466,18 @@ async fn test_stake_pool_deposit_with_wrong_withdraw_authority() {
 }
 
 #[tokio::test]
-async fn test_stake_pool_deposit_with_wrong_mint_for_receiver_acc() {
-    let (mut banks_client, payer, recent_blockhash, stake_pool_accounts, validator_stake_account) =
-        setup().await;
-
-    // make stake account
-    let user = Keypair::new();
-    let user_stake = Keypair::new();
-    let lockup = stake_program::Lockup::default();
-    let authorized = stake_program::Authorized {
-        staker: user.pubkey(),
-        withdrawer: user.pubkey(),
-    };
-    create_independent_stake_account(
-        &mut banks_client,
-        &payer,
-        &recent_blockhash,
-        &user_stake,
-        &authorized,
-        &lockup,
-        TEST_STAKE_AMOUNT,
-    )
-    .await;
+async fn fail_with_wrong_mint_for_receiver_acc() {
+    let (
+        mut banks_client,
+        payer,
+        recent_blockhash,
+        stake_pool_accounts,
+        validator_stake_account,
+        user,
+        deposit_stake,
+        _pool_token_account,
+        _stake_lamports,
+    ) = setup().await;
 
     let outside_mint = Keypair::new();
     let outside_withdraw_auth = Keypair::new();
@@ -606,20 +510,17 @@ async fn test_stake_pool_deposit_with_wrong_mint_for_receiver_acc() {
             &mut banks_client,
             &payer,
             &recent_blockhash,
-            &user_stake.pubkey(),
+            &deposit_stake,
             &outside_pool_fee_acc.pubkey(),
             &validator_stake_account.stake_account,
             &user,
         )
         .await
-        .err()
+        .unwrap()
         .unwrap();
 
     match transaction_error {
-        TransportError::TransactionError(TransactionError::InstructionError(
-            _,
-            InstructionError::Custom(error_index),
-        )) => {
+        TransactionError::InstructionError(_, InstructionError::Custom(error_index)) => {
             let program_error = token_error::TokenError::MintMismatch as u32;
             assert_eq!(error_index, program_error);
         }
@@ -628,10 +529,10 @@ async fn test_stake_pool_deposit_with_wrong_mint_for_receiver_acc() {
 }
 
 #[tokio::test]
-async fn test_deposit_with_uninitialized_validator_list() {} // TODO
+async fn fail_with_uninitialized_validator_list() {} // TODO
 
 #[tokio::test]
-async fn test_deposit_with_out_of_dated_pool_balances() {} // TODO
+async fn fail_with_out_of_dated_pool_balances() {} // TODO
 
 #[tokio::test]
 async fn success_with_deposit_authority() {
@@ -700,7 +601,7 @@ async fn success_with_deposit_authority() {
     .await
     .unwrap();
 
-    stake_pool_accounts
+    let error = stake_pool_accounts
         .deposit_stake(
             &mut banks_client,
             &payer,
@@ -710,8 +611,8 @@ async fn success_with_deposit_authority() {
             &validator_stake_account.stake_account,
             &user,
         )
-        .await
-        .unwrap();
+        .await;
+    assert!(error.is_none());
 }
 
 #[tokio::test]
@@ -796,7 +697,7 @@ async fn fail_without_deposit_authority_signature() {
             &user,
         )
         .await
-        .unwrap_err()
+        .unwrap()
         .unwrap();
 
     match error {
@@ -804,6 +705,100 @@ async fn fail_without_deposit_authority_signature() {
             assert_eq!(
                 error_index,
                 error::StakePoolError::InvalidProgramAddress as u32
+            );
+        }
+        _ => panic!("Wrong error occurs while try to make a deposit with wrong stake program ID"),
+    }
+}
+
+#[tokio::test]
+async fn success_with_preferred_deposit() {
+    let (
+        mut banks_client,
+        payer,
+        recent_blockhash,
+        stake_pool_accounts,
+        validator_stake,
+        user,
+        deposit_stake,
+        pool_token_account,
+        _stake_lamports,
+    ) = setup().await;
+
+    stake_pool_accounts
+        .set_preferred_validator(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            instruction::PreferredValidatorType::Deposit,
+            Some(validator_stake.vote.pubkey()),
+        )
+        .await;
+
+    let error = stake_pool_accounts
+        .deposit_stake(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            &deposit_stake,
+            &pool_token_account,
+            &validator_stake.stake_account,
+            &user,
+        )
+        .await;
+    assert!(error.is_none());
+}
+
+#[tokio::test]
+async fn fail_with_wrong_preferred_deposit() {
+    let (
+        mut banks_client,
+        payer,
+        recent_blockhash,
+        stake_pool_accounts,
+        validator_stake,
+        user,
+        deposit_stake,
+        pool_token_account,
+        _stake_lamports,
+    ) = setup().await;
+
+    let preferred_validator = simple_add_validator_to_pool(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        &stake_pool_accounts,
+    )
+    .await;
+
+    stake_pool_accounts
+        .set_preferred_validator(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            instruction::PreferredValidatorType::Deposit,
+            Some(preferred_validator.vote.pubkey()),
+        )
+        .await;
+
+    let error = stake_pool_accounts
+        .deposit_stake(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            &deposit_stake,
+            &pool_token_account,
+            &validator_stake.stake_account,
+            &user,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    match error {
+        TransactionError::InstructionError(_, InstructionError::Custom(error_index)) => {
+            assert_eq!(
+                error_index,
+                error::StakePoolError::IncorrectDepositVoteAddress as u32
             );
         }
         _ => panic!("Wrong error occurs while try to make a deposit with wrong stake program ID"),

--- a/stake-pool/program/tests/set_fee.rs
+++ b/stake-pool/program/tests/set_fee.rs
@@ -8,7 +8,8 @@ use {
     solana_program::hash::Hash,
     solana_program_test::*,
     solana_sdk::{
-        instruction::InstructionError, signature::{Keypair, Signer},
+        instruction::InstructionError,
+        signature::{Keypair, Signer},
         transaction::{Transaction, TransactionError},
     },
     spl_stake_pool::{

--- a/stake-pool/program/tests/set_fee.rs
+++ b/stake-pool/program/tests/set_fee.rs
@@ -8,8 +8,8 @@ use {
     solana_program::hash::Hash,
     solana_program_test::*,
     solana_sdk::{
-        instruction::InstructionError, signature::Keypair, signature::Signer,
-        transaction::Transaction, transaction::TransactionError,
+        instruction::InstructionError, signature::{Keypair, Signer},
+        transaction::{Transaction, TransactionError},
     },
     spl_stake_pool::{
         error, id, instruction,

--- a/stake-pool/program/tests/set_preferred.rs
+++ b/stake-pool/program/tests/set_preferred.rs
@@ -1,0 +1,211 @@
+#![cfg(feature = "test-bpf")]
+
+mod helpers;
+
+use {
+    helpers::*,
+    solana_program::hash::Hash,
+    solana_program_test::*,
+    solana_sdk::{
+        instruction::InstructionError, pubkey::Pubkey, signature::{Keypair, Signer},
+        transaction::{Transaction, TransactionError},
+    },
+    spl_stake_pool::{
+        borsh::try_from_slice_unchecked, error, id, instruction::{self, PreferredValidatorType},
+        state::ValidatorList,
+    },
+};
+
+async fn setup() -> (BanksClient, Keypair, Hash, StakePoolAccounts, ValidatorStakeAccount) {
+    let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
+    let stake_pool_accounts = StakePoolAccounts::new();
+    stake_pool_accounts
+        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash, 1)
+        .await
+        .unwrap();
+
+    let validator_stake_account = simple_add_validator_to_pool(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        &stake_pool_accounts,
+    )
+    .await;
+
+    (
+        banks_client,
+        payer,
+        recent_blockhash,
+        stake_pool_accounts,
+        validator_stake_account,
+    )
+}
+
+#[tokio::test]
+async fn success_deposit() {
+    let (mut banks_client, payer, recent_blockhash, stake_pool_accounts, validator_stake_account) = setup().await;
+
+    let vote_account_address = validator_stake_account.vote.pubkey();
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction::set_preferred_validator(
+            &id(),
+            &stake_pool_accounts.stake_pool.pubkey(),
+            &stake_pool_accounts.staker.pubkey(),
+            &stake_pool_accounts.validator_list.pubkey(),
+            PreferredValidatorType::Deposit,
+            Some(vote_account_address)
+        )],
+        Some(&payer.pubkey()),
+        &[&payer, &stake_pool_accounts.staker],
+        recent_blockhash,
+    );
+    banks_client.process_transaction(transaction).await.unwrap();
+
+    let validator_list = get_account(&mut banks_client, &stake_pool_accounts.validator_list.pubkey()).await;
+    let validator_list = try_from_slice_unchecked::<ValidatorList>(&validator_list.data.as_slice()).unwrap();
+
+    assert_eq!(validator_list.preferred_deposit_validator_vote_address, Some(vote_account_address));
+    assert_eq!(validator_list.preferred_withdraw_validator_vote_address, None);
+}
+
+#[tokio::test]
+async fn success_withdraw() {
+    let (mut banks_client, payer, recent_blockhash, stake_pool_accounts, validator_stake_account) = setup().await;
+
+    let vote_account_address = validator_stake_account.vote.pubkey();
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction::set_preferred_validator(
+            &id(),
+            &stake_pool_accounts.stake_pool.pubkey(),
+            &stake_pool_accounts.staker.pubkey(),
+            &stake_pool_accounts.validator_list.pubkey(),
+            PreferredValidatorType::Withdraw,
+            Some(vote_account_address)
+        )],
+        Some(&payer.pubkey()),
+        &[&payer, &stake_pool_accounts.staker],
+        recent_blockhash,
+    );
+    banks_client.process_transaction(transaction).await.unwrap();
+
+    let validator_list = get_account(&mut banks_client, &stake_pool_accounts.validator_list.pubkey()).await;
+    let validator_list = try_from_slice_unchecked::<ValidatorList>(&validator_list.data.as_slice()).unwrap();
+
+    assert_eq!(validator_list.preferred_deposit_validator_vote_address, None);
+    assert_eq!(validator_list.preferred_withdraw_validator_vote_address, Some(vote_account_address));
+}
+
+#[tokio::test]
+async fn success_unset() {
+    let (mut banks_client, payer, recent_blockhash, stake_pool_accounts, validator_stake_account) = setup().await;
+
+    let vote_account_address = validator_stake_account.vote.pubkey();
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction::set_preferred_validator(
+            &id(),
+            &stake_pool_accounts.stake_pool.pubkey(),
+            &stake_pool_accounts.staker.pubkey(),
+            &stake_pool_accounts.validator_list.pubkey(),
+            PreferredValidatorType::Withdraw,
+            Some(vote_account_address)
+        )],
+        Some(&payer.pubkey()),
+        &[&payer, &stake_pool_accounts.staker],
+        recent_blockhash,
+    );
+    banks_client.process_transaction(transaction).await.unwrap();
+
+    let validator_list = get_account(&mut banks_client, &stake_pool_accounts.validator_list.pubkey()).await;
+    let validator_list = try_from_slice_unchecked::<ValidatorList>(&validator_list.data.as_slice()).unwrap();
+
+    assert_eq!(validator_list.preferred_withdraw_validator_vote_address, Some(vote_account_address));
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction::set_preferred_validator(
+            &id(),
+            &stake_pool_accounts.stake_pool.pubkey(),
+            &stake_pool_accounts.staker.pubkey(),
+            &stake_pool_accounts.validator_list.pubkey(),
+            PreferredValidatorType::Withdraw,
+            None,
+        )],
+        Some(&payer.pubkey()),
+        &[&payer, &stake_pool_accounts.staker],
+        recent_blockhash,
+    );
+    banks_client.process_transaction(transaction).await.unwrap();
+
+    let validator_list = get_account(&mut banks_client, &stake_pool_accounts.validator_list.pubkey()).await;
+    let validator_list = try_from_slice_unchecked::<ValidatorList>(&validator_list.data.as_slice()).unwrap();
+
+    assert_eq!(validator_list.preferred_withdraw_validator_vote_address, None);
+}
+
+#[tokio::test]
+async fn fail_wrong_staker() {
+    let (mut banks_client, payer, recent_blockhash, stake_pool_accounts, _) = setup().await;
+
+    let wrong_staker = Keypair::new();
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction::set_preferred_validator(
+            &id(),
+            &stake_pool_accounts.stake_pool.pubkey(),
+            &wrong_staker.pubkey(),
+            &stake_pool_accounts.validator_list.pubkey(),
+            PreferredValidatorType::Withdraw,
+            None,
+        )],
+        Some(&payer.pubkey()),
+        &[&payer, &wrong_staker],
+        recent_blockhash,
+    );
+    let error = banks_client
+        .process_transaction(transaction)
+        .await
+        .err()
+        .unwrap()
+        .unwrap();
+
+    match error {
+        TransactionError::InstructionError(_, InstructionError::Custom(error_index)) => {
+            let program_error = error::StakePoolError::WrongStaker as u32;
+            assert_eq!(error_index, program_error);
+        }
+        _ => panic!("Wrong error occurs while malicious try to set manager"),
+    }
+}
+
+#[tokio::test]
+async fn fail_not_present_validator() {
+    let (mut banks_client, payer, recent_blockhash, stake_pool_accounts, _) = setup().await;
+
+    let validator_vote_address = Pubkey::new_unique();
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction::set_preferred_validator(
+            &id(),
+            &stake_pool_accounts.stake_pool.pubkey(),
+            &stake_pool_accounts.staker.pubkey(),
+            &stake_pool_accounts.validator_list.pubkey(),
+            PreferredValidatorType::Withdraw,
+            Some(validator_vote_address),
+        )],
+        Some(&payer.pubkey()),
+        &[&payer, &stake_pool_accounts.staker],
+        recent_blockhash,
+    );
+    let error = banks_client
+        .process_transaction(transaction)
+        .await
+        .err()
+        .unwrap()
+        .unwrap();
+
+    match error {
+        TransactionError::InstructionError(_, InstructionError::Custom(error_index)) => {
+            let program_error = error::StakePoolError::ValidatorNotFound as u32;
+            assert_eq!(error_index, program_error);
+        }
+        _ => panic!("Wrong error occurs while malicious try to set manager"),
+    }
+}

--- a/stake-pool/program/tests/vsa_add.rs
+++ b/stake-pool/program/tests/vsa_add.rs
@@ -84,6 +84,8 @@ async fn success() {
         validator_list,
         state::ValidatorList {
             account_type: state::AccountType::ValidatorList,
+            preferred_deposit_validator_vote_address: None,
+            preferred_withdraw_validator_vote_address: None,
             max_validators: stake_pool_accounts.max_validators,
             validators: vec![state::ValidatorStakeInfo {
                 status: state::StakeStatus::Active,

--- a/stake-pool/program/tests/vsa_remove.rs
+++ b/stake-pool/program/tests/vsa_remove.rs
@@ -97,6 +97,8 @@ async fn success() {
         validator_list,
         state::ValidatorList {
             account_type: state::AccountType::ValidatorList,
+            preferred_deposit_validator_vote_address: None,
+            preferred_withdraw_validator_vote_address: None,
             max_validators: stake_pool_accounts.max_validators,
             validators: vec![]
         }
@@ -520,6 +522,8 @@ async fn success_with_deactivating_transient_stake() {
         try_from_slice_unchecked::<state::ValidatorList>(validator_list.data.as_slice()).unwrap();
     let expected_list = state::ValidatorList {
         account_type: state::AccountType::ValidatorList,
+        preferred_deposit_validator_vote_address: None,
+        preferred_withdraw_validator_vote_address: None,
         max_validators: stake_pool_accounts.max_validators,
         validators: vec![state::ValidatorStakeInfo {
             status: state::StakeStatus::DeactivatingTransient,

--- a/stake-pool/program/tests/vsa_remove.rs
+++ b/stake-pool/program/tests/vsa_remove.rs
@@ -557,6 +557,74 @@ async fn success_with_deactivating_transient_stake() {
 }
 
 #[tokio::test]
+async fn success_resets_preferred_validator() {
+    let (mut banks_client, payer, recent_blockhash, stake_pool_accounts, validator_stake) =
+        setup().await;
+
+    stake_pool_accounts
+        .set_preferred_validator(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            instruction::PreferredValidatorType::Deposit,
+            Some(validator_stake.vote.pubkey()),
+        )
+        .await;
+    stake_pool_accounts
+        .set_preferred_validator(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            instruction::PreferredValidatorType::Withdraw,
+            Some(validator_stake.vote.pubkey()),
+        )
+        .await;
+
+    let new_authority = Pubkey::new_unique();
+    let error = stake_pool_accounts
+        .remove_validator_from_pool(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            &new_authority,
+            &validator_stake.stake_account,
+            &validator_stake.transient_stake_account,
+        )
+        .await;
+    assert!(error.is_none());
+
+    // Check if account was removed from the list of stake accounts
+    let validator_list = get_account(
+        &mut banks_client,
+        &stake_pool_accounts.validator_list.pubkey(),
+    )
+    .await;
+    let validator_list =
+        try_from_slice_unchecked::<state::ValidatorList>(validator_list.data.as_slice()).unwrap();
+    assert_eq!(
+        validator_list,
+        state::ValidatorList {
+            account_type: state::AccountType::ValidatorList,
+            preferred_deposit_validator_vote_address: None,
+            preferred_withdraw_validator_vote_address: None,
+            max_validators: stake_pool_accounts.max_validators,
+            validators: vec![]
+        }
+    );
+
+    // Check of stake account authority has changed
+    let stake = get_account(&mut banks_client, &validator_stake.stake_account).await;
+    let stake_state = deserialize::<stake_program::StakeState>(&stake.data).unwrap();
+    match stake_state {
+        stake_program::StakeState::Stake(meta, _) => {
+            assert_eq!(&meta.authorized.staker, &new_authority);
+            assert_eq!(&meta.authorized.withdrawer, &new_authority);
+        }
+        _ => panic!(),
+    }
+}
+
+#[tokio::test]
 async fn fail_not_updated_stake_pool() {} // TODO
 
 #[tokio::test]


### PR DESCRIPTION
#### Problem

Stake pools can be arbitraged by depositing to one validator and withdrawing from another.

#### Solution

Cover a lot of potential attack vectors, and allow the stake pool staker to restrict deposits and withdrawals to specific validators.  If the preferred deposit validator is set, all deposits must go through it.  If a preferred withdrawer is set, all withdrawals must go through it if it has *any* stake at all.  If it's empty, then normal rules apply.

cc @aeyakovenko 