### PR TITLE
stake-pool: Add reserve stake check on update pool balance

### DIFF
--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -1429,6 +1429,7 @@ impl Processor {
         }
         stake_pool.check_mint(pool_mint_info)?;
         stake_pool.check_authority_withdraw(withdraw_info.key, program_id, stake_pool_info.key)?;
+        stake_pool.check_reserve_stake(reserve_stake_info)?;
         if stake_pool.manager_fee_account != *manager_fee_info.key {
             return Err(StakePoolError::InvalidFeeAccount.into());
         }

--- a/stake-pool/program/tests/update_stake_pool_balance.rs
+++ b/stake-pool/program/tests/update_stake_pool_balance.rs
@@ -224,6 +224,32 @@ async fn fail_with_wrong_pool_fee_account() {
 }
 
 #[tokio::test]
+async fn fail_with_wrong_reserve() {
+    let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
+    let mut stake_pool_accounts = StakePoolAccounts::new();
+    stake_pool_accounts
+        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash, 1)
+        .await
+        .unwrap();
+
+    let wrong_reserve_stake = Keypair::new();
+    stake_pool_accounts.reserve_stake = wrong_reserve_stake;
+    let error = stake_pool_accounts
+        .update_stake_pool_balance(&mut banks_client, &payer, &recent_blockhash)
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(StakePoolError::InvalidProgramAddress as u32),
+        )
+    );
+}
+
+#[tokio::test]
 async fn test_update_stake_pool_balance_with_uninitialized_validator_list() {} // TODO
 
 #[tokio::test]


### PR DESCRIPTION
#### Problem

Update stake pool balance isn't properly checking for the correct reserve stake.

#### Solution

Add the check

Fixes #1861 