### PR TITLE
spl-token-cli: Remove global owner argument

### DIFF
--- a/token/cli/src/config.rs
+++ b/token/cli/src/config.rs
@@ -1,0 +1,132 @@
+use clap::ArgMatches;
+use solana_clap_utils::{
+    input_parsers::pubkey_of_signer,
+    keypair::{pubkey_from_path, signer_from_path},
+};
+use solana_client::{blockhash_query::BlockhashQuery, rpc_client::RpcClient};
+use solana_remote_wallet::remote_wallet::RemoteWalletManager;
+use solana_sdk::{pubkey::Pubkey, signature::Signer};
+use spl_associated_token_account::*;
+use std::{process::exit, sync::Arc};
+
+pub(crate) struct Config<'a> {
+    pub(crate) rpc_client: RpcClient,
+    pub(crate) verbose: bool,
+    pub(crate) fee_payer: Pubkey,
+    pub(crate) default_keypair_path: String,
+    pub(crate) nonce_account: Option<Pubkey>,
+    pub(crate) nonce_authority: Option<Pubkey>,
+    pub(crate) blockhash_query: BlockhashQuery,
+    pub(crate) sign_only: bool,
+    pub(crate) multisigner_pubkeys: Vec<&'a Pubkey>,
+}
+
+impl<'a> Config<'a> {
+    // Check if an explicit token account address was provided, otherwise
+    // return the associated token address for the default address.
+    pub(crate) fn associated_token_address_or_override(
+        &self,
+        arg_matches: &ArgMatches,
+        override_name: &str,
+        wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    ) -> Pubkey {
+        if let Some(address) = pubkey_of_signer(arg_matches, override_name, wallet_manager).unwrap()
+        {
+            return address;
+        }
+
+        let token = pubkey_of_signer(arg_matches, "token", wallet_manager)
+            .unwrap()
+            .unwrap();
+        let owner = self
+            .default_signer(arg_matches, wallet_manager)
+            .unwrap_or_else(|e| {
+                eprintln!("error: {}", e);
+                exit(1);
+            })
+            .pubkey();
+        get_associated_token_address(&owner, &token)
+    }
+
+    // Checks if an explicit address was provided, otherwise return the default address.
+    pub(crate) fn pubkey_or_default(
+        &self,
+        arg_matches: &ArgMatches,
+        address_name: &str,
+        wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    ) -> Pubkey {
+        if address_name != "owner" {
+            if let Some(address) =
+                pubkey_of_signer(arg_matches, address_name, wallet_manager).unwrap()
+            {
+                return address;
+            }
+        }
+
+        return self
+            .default_address(arg_matches, wallet_manager)
+            .unwrap_or_else(|e| {
+                eprintln!("error: {}", e);
+                exit(1);
+            });
+    }
+
+    // Checks if an explicit signer was provided, otherwise return the default signer.
+    pub(crate) fn signer_or_default(
+        &self,
+        arg_matches: &ArgMatches,
+        authority_name: &str,
+        wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    ) -> (Box<dyn Signer>, Pubkey) {
+        let mut load_authority = move || {
+            if authority_name != "owner" {
+                if let Some(keypair_path) = arg_matches.value_of(authority_name) {
+                    return signer_from_path(
+                        &arg_matches,
+                        keypair_path,
+                        authority_name,
+                        wallet_manager,
+                    );
+                }
+            }
+
+            self.default_signer(arg_matches, wallet_manager)
+        };
+
+        let authority = load_authority().unwrap_or_else(|e| {
+            eprintln!("error: {}", e);
+            exit(1);
+        });
+
+        let authority_address = authority.pubkey();
+        (authority, authority_address)
+    }
+
+    fn default_address(
+        &self,
+        matches: &ArgMatches,
+        wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    ) -> Result<Pubkey, Box<dyn std::error::Error>> {
+        // for backwards compatibility, check owner before cli config default
+        if let Some(address) = pubkey_of_signer(matches, "owner", wallet_manager).unwrap() {
+            return Ok(address);
+        }
+
+        let path = &self.default_keypair_path;
+        pubkey_from_path(matches, path, "default", wallet_manager)
+    }
+
+    fn default_signer(
+        &self,
+        matches: &ArgMatches,
+        wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+    ) -> Result<Box<dyn Signer>, Box<dyn std::error::Error>> {
+        // for backwards compatibility, check owner before cli config default
+        if let Some(owner_path) = matches.value_of("owner") {
+            return signer_from_path(&matches, owner_path, "owner", wallet_manager);
+        }
+
+        let path = &self.default_keypair_path;
+        signer_from_path(matches, path, "default", wallet_manager)
+    }
+}

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -9,12 +9,12 @@ use solana_account_decoder::{
 };
 use solana_clap_utils::{
     fee_payer::fee_payer_arg,
-    input_parsers::{pubkey_of_signer, pubkeys_of_multiple_signers, signer_of, value_of},
+    input_parsers::{pubkey_of_signer, pubkeys_of_multiple_signers, value_of},
     input_validators::{
         is_amount, is_amount_or_all, is_parsable, is_url_or_moniker, is_valid_pubkey,
         is_valid_signer, normalize_to_url_if_moniker,
     },
-    keypair::{signer_from_path, DefaultSigner, SignerFromPathConfig},
+    keypair::{signer_from_path, CliSignerInfo},
     nonce::*,
     offline::{self, *},
     ArgConstant,
@@ -45,10 +45,25 @@ use spl_token::{
 };
 use std::{collections::HashMap, process::exit, str::FromStr, sync::Arc};
 
+mod config;
+use config::Config;
+
 mod sort;
 use sort::sort_and_parse_token_accounts;
 
 static WARNING: Emoji = Emoji("⚠️", "!");
+
+pub const OWNER_ADDRESS_ARG: ArgConstant<'static> = ArgConstant {
+    name: "owner",
+    long: "owner",
+    help: "Address of the token's owner. Defaults to the client keypair address.",
+};
+
+pub const OWNER_KEYPAIR_ARG: ArgConstant<'static> = ArgConstant {
+    name: "owner",
+    long: "owner",
+    help: "Keypair of the token's owner. Defaults to the client keypair.",
+};
 
 pub const MINT_ADDRESS_ARG: ArgConstant<'static> = ArgConstant {
     name: "mint_address",
@@ -73,6 +88,24 @@ pub const MULTISIG_SIGNER_ARG: ArgConstant<'static> = ArgConstant {
     long: "multisig-signer",
     help: "Member signer of a multisig account",
 };
+
+pub fn owner_address_arg<'a, 'b>() -> Arg<'a, 'b> {
+    Arg::with_name(OWNER_ADDRESS_ARG.name)
+        .long(OWNER_ADDRESS_ARG.long)
+        .takes_value(true)
+        .value_name("OWNER_ADDRESS")
+        .validator(is_valid_pubkey)
+        .help(OWNER_ADDRESS_ARG.help)
+}
+
+pub fn owner_keypair_arg<'a, 'b>() -> Arg<'a, 'b> {
+    Arg::with_name(OWNER_KEYPAIR_ARG.name)
+        .long(OWNER_KEYPAIR_ARG.long)
+        .takes_value(true)
+        .value_name("OWNER_KEYPAIR")
+        .validator(is_valid_signer)
+        .help(OWNER_KEYPAIR_ARG.help)
+}
 
 pub fn mint_address_arg<'a, 'b>() -> Arg<'a, 'b> {
     Arg::with_name(MINT_ADDRESS_ARG.name)
@@ -145,26 +178,29 @@ fn is_multisig_minimum_signers(string: String) -> Result<(), String> {
     }
 }
 
-struct Config<'a> {
-    rpc_client: RpcClient,
-    verbose: bool,
-    owner: Pubkey,
-    fee_payer: Pubkey,
-    default_signer: DefaultSigner,
-    nonce_account: Option<Pubkey>,
-    nonce_authority: Option<Pubkey>,
-    blockhash_query: BlockhashQuery,
-    sign_only: bool,
-    multisigner_pubkeys: Vec<&'a Pubkey>,
-}
-
 type Error = Box<dyn std::error::Error>;
 type CommandResult = Result<Option<(u64, Vec<Vec<Instruction>>)>, Error>;
 
-fn new_throwaway_signer() -> (Option<Box<dyn Signer>>, Option<Pubkey>) {
+fn new_throwaway_signer() -> (Box<dyn Signer>, Pubkey) {
     let keypair = Keypair::new();
     let pubkey = keypair.pubkey();
-    (Some(Box::new(keypair) as Box<dyn Signer>), Some(pubkey))
+    (Box::new(keypair) as Box<dyn Signer>, pubkey)
+}
+
+fn get_signer(
+    matches: &ArgMatches<'_>,
+    keypair_name: &str,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+) -> Option<(Box<dyn Signer>, Pubkey)> {
+    matches.value_of(keypair_name).map(|path| {
+        let signer =
+            signer_from_path(matches, path, keypair_name, wallet_manager).unwrap_or_else(|e| {
+                eprintln!("error: {}", e);
+                exit(1);
+            });
+        let signer_pubkey = signer.pubkey();
+        (signer, signer_pubkey)
+    })
 }
 
 fn check_fee_payer_balance(config: &Config, required_balance: u64) -> Result<(), Error> {
@@ -182,12 +218,16 @@ fn check_fee_payer_balance(config: &Config, required_balance: u64) -> Result<(),
     }
 }
 
-fn check_owner_balance(config: &Config, required_balance: u64) -> Result<(), Error> {
-    let balance = config.rpc_client.get_balance(&config.owner)?;
+fn check_wallet_balance(
+    config: &Config,
+    wallet: &Pubkey,
+    required_balance: u64,
+) -> Result<(), Error> {
+    let balance = config.rpc_client.get_balance(wallet)?;
     if balance < required_balance {
         Err(format!(
-            "Owner, {}, has insufficient balance: {} required, {} available",
-            config.owner,
+            "Wallet {}, has insufficient balance: {} required, {} available",
+            wallet,
             lamports_to_sol(required_balance),
             lamports_to_sol(balance)
         )
@@ -221,6 +261,7 @@ fn command_create_token(
     config: &Config,
     decimals: u8,
     token: Pubkey,
+    authority: Pubkey,
     enable_freeze: bool,
     memo: Option<String>,
 ) -> CommandResult {
@@ -233,11 +274,7 @@ fn command_create_token(
     } else {
         0
     };
-    let freeze_authority_pubkey = if enable_freeze {
-        Some(config.owner)
-    } else {
-        None
-    };
+    let freeze_authority_pubkey = if enable_freeze { Some(authority) } else { None };
 
     let mut instructions = vec![
         system_instruction::create_account(
@@ -250,13 +287,13 @@ fn command_create_token(
         initialize_mint(
             &spl_token::id(),
             &token,
-            &config.owner,
+            &authority,
             freeze_authority_pubkey.as_ref(),
             decimals,
         )?,
     ];
     if let Some(text) = memo {
-        instructions.push(spl_memo::build_memo(text.as_bytes(), &[&config.owner]));
+        instructions.push(spl_memo::build_memo(text.as_bytes(), &[&config.fee_payer]));
     }
     Ok(Some((
         minimum_balance_for_rent_exemption,
@@ -267,6 +304,7 @@ fn command_create_token(
 fn command_create_account(
     config: &Config,
     token: Pubkey,
+    owner: Pubkey,
     maybe_account: Option<Pubkey>,
 ) -> CommandResult {
     let minimum_balance_for_rent_exemption = if !config.sign_only {
@@ -290,18 +328,18 @@ fn command_create_account(
                     Account::LEN as u64,
                     &spl_token::id(),
                 ),
-                initialize_account(&spl_token::id(), &account, &token, &config.owner)?,
+                initialize_account(&spl_token::id(), &account, &token, &owner)?,
             ],
         )
     } else {
-        let account = get_associated_token_address(&config.owner, &token);
+        let account = get_associated_token_address(&owner, &token);
         println!("Creating account {}", account);
         (
             account,
             true,
             vec![create_associated_token_account(
                 &config.fee_payer,
-                &config.owner,
+                &owner,
                 &token,
             )],
         )
@@ -371,7 +409,8 @@ fn command_authorize(
     config: &Config,
     account: Pubkey,
     authority_type: AuthorityType,
-    new_owner: Option<Pubkey>,
+    authority: Pubkey,
+    new_authority: Option<Pubkey>,
     force_authorize: bool,
 ) -> CommandResult {
     let auth_str = match authority_type {
@@ -394,15 +433,16 @@ fn command_authorize(
         } else if let Ok(token_account) = Account::unpack(&target_account.data) {
             let check_associated_token_account = || -> Result<(), Error> {
                 let maybe_associated_token_account =
-                    get_associated_token_address(&config.owner, &token_account.mint);
+                    get_associated_token_address(&token_account.owner, &token_account.mint);
                 if account == maybe_associated_token_account
                     && !force_authorize
-                    && Some(config.owner) != new_owner
+                    && Some(authority) != new_authority
                 {
-                    Err(
-                        format!("Error: attempting to change the `{}` of an associated token account of `--owner`", auth_str)
-                            .into(),
+                    Err(format!(
+                        "Error: attempting to change the `{}` of an associated token account",
+                        auth_str
                     )
+                    .into())
                 } else {
                     Ok(())
                 }
@@ -438,7 +478,7 @@ fn command_authorize(
             .map(|pubkey| pubkey.to_string())
             .unwrap_or_else(|| "disabled".to_string()),
         auth_str,
-        new_owner
+        new_authority
             .map(|pubkey| pubkey.to_string())
             .unwrap_or_else(|| "disabled".to_string())
     );
@@ -446,9 +486,9 @@ fn command_authorize(
     let instructions = vec![set_authority(
         &spl_token::id(),
         &account,
-        new_owner.as_ref(),
+        new_authority.as_ref(),
         authority_type,
-        &config.owner,
+        &authority,
         &config.multisigner_pubkeys,
     )?];
     Ok(Some((0, vec![instructions])))
@@ -499,6 +539,7 @@ fn command_transfer(
     ui_amount: Option<f64>,
     recipient: Pubkey,
     sender: Option<Pubkey>,
+    sender_owner: Pubkey,
     allow_unfunded_recipient: bool,
     fund_recipient: bool,
     mint_decimals: Option<u8>,
@@ -507,7 +548,7 @@ fn command_transfer(
     let sender = if let Some(sender) = sender {
         sender
     } else {
-        get_associated_token_address(&config.owner, &token)
+        get_associated_token_address(&sender_owner, &token)
     };
     let (mint_pubkey, decimals) = resolve_mint_info(config, &sender, Some(token), mint_decimals)?;
     let maybe_transfer_balance =
@@ -637,7 +678,7 @@ fn command_transfer(
         &sender,
         &mint_pubkey,
         &recipient_token_account,
-        &config.owner,
+        &sender_owner,
         &config.multisigner_pubkeys,
         transfer_balance,
         decimals,
@@ -651,6 +692,7 @@ fn command_transfer(
 fn command_burn(
     config: &Config,
     source: Pubkey,
+    source_owner: Pubkey,
     ui_amount: f64,
     mint_address: Option<Pubkey>,
     mint_decimals: Option<u8>,
@@ -664,7 +706,7 @@ fn command_burn(
         &spl_token::id(),
         &source,
         &mint_pubkey,
-        &config.owner,
+        &source_owner,
         &config.multisigner_pubkeys,
         amount,
         decimals,
@@ -678,6 +720,7 @@ fn command_mint(
     ui_amount: f64,
     recipient: Pubkey,
     mint_decimals: Option<u8>,
+    mint_authority: Pubkey,
 ) -> CommandResult {
     println!(
         "Minting {} tokens\n  Token: {}\n  Recipient: {}",
@@ -691,7 +734,7 @@ fn command_mint(
         &spl_token::id(),
         &token,
         &recipient,
-        &config.owner,
+        &mint_authority,
         &config.multisigner_pubkeys,
         amount,
         decimals,
@@ -699,7 +742,12 @@ fn command_mint(
     Ok(Some((0, vec![instructions])))
 }
 
-fn command_freeze(config: &Config, account: Pubkey, mint_address: Option<Pubkey>) -> CommandResult {
+fn command_freeze(
+    config: &Config,
+    account: Pubkey,
+    mint_address: Option<Pubkey>,
+    freeze_authority: Pubkey,
+) -> CommandResult {
     let (token, _) = resolve_mint_info(config, &account, mint_address, None)?;
 
     println!("Freezing account: {}\n  Token: {}", account, token);
@@ -708,13 +756,18 @@ fn command_freeze(config: &Config, account: Pubkey, mint_address: Option<Pubkey>
         &spl_token::id(),
         &account,
         &token,
-        &config.owner,
+        &freeze_authority,
         &config.multisigner_pubkeys,
     )?];
     Ok(Some((0, vec![instructions])))
 }
 
-fn command_thaw(config: &Config, account: Pubkey, mint_address: Option<Pubkey>) -> CommandResult {
+fn command_thaw(
+    config: &Config,
+    account: Pubkey,
+    mint_address: Option<Pubkey>,
+    freeze_authority: Pubkey,
+) -> CommandResult {
     let (token, _) = resolve_mint_info(config, &account, mint_address, None)?;
 
     println!("Freezing account: {}\n  Token: {}", account, token);
@@ -723,34 +776,39 @@ fn command_thaw(config: &Config, account: Pubkey, mint_address: Option<Pubkey>) 
         &spl_token::id(),
         &account,
         &token,
-        &config.owner,
+        &freeze_authority,
         &config.multisigner_pubkeys,
     )?];
     Ok(Some((0, vec![instructions])))
 }
 
-fn command_wrap(config: &Config, sol: f64, account: Option<Pubkey>) -> CommandResult {
+fn command_wrap(
+    config: &Config,
+    sol: f64,
+    wallet_address: Pubkey,
+    wrapped_sol_account: Option<Pubkey>,
+) -> CommandResult {
     let lamports = sol_to_lamports(sol);
 
-    let instructions = if let Some(account) = account {
-        println!("Wrapping {} SOL into {}", sol, account);
+    let instructions = if let Some(wrapped_sol_account) = wrapped_sol_account {
+        println!("Wrapping {} SOL into {}", sol, wrapped_sol_account);
         vec![
             system_instruction::create_account(
-                &config.owner,
-                &account,
+                &wallet_address,
+                &wrapped_sol_account,
                 lamports,
                 Account::LEN as u64,
                 &spl_token::id(),
             ),
             initialize_account(
                 &spl_token::id(),
-                &account,
+                &wrapped_sol_account,
                 &native_mint::id(),
-                &config.owner,
+                &wallet_address,
             )?,
         ]
     } else {
-        let account = get_associated_token_address(&config.owner, &native_mint::id());
+        let account = get_associated_token_address(&wallet_address, &native_mint::id());
 
         if !config.sign_only {
             if let Some(account_data) = config
@@ -766,20 +824,24 @@ fn command_wrap(config: &Config, sol: f64, account: Option<Pubkey>) -> CommandRe
 
         println!("Wrapping {} SOL into {}", sol, account);
         vec![
-            system_instruction::transfer(&config.owner, &account, lamports),
-            create_associated_token_account(&config.fee_payer, &config.owner, &native_mint::id()),
+            system_instruction::transfer(&wallet_address, &account, lamports),
+            create_associated_token_account(&config.fee_payer, &wallet_address, &native_mint::id()),
         ]
     };
     if !config.sign_only {
-        check_owner_balance(config, lamports)?;
+        check_wallet_balance(config, &wallet_address, lamports)?;
     }
     Ok(Some((0, vec![instructions])))
 }
 
-fn command_unwrap(config: &Config, address: Option<Pubkey>) -> CommandResult {
+fn command_unwrap(
+    config: &Config,
+    wallet_address: Pubkey,
+    address: Option<Pubkey>,
+) -> CommandResult {
     let use_associated_account = address.is_none();
-    let address =
-        address.unwrap_or_else(|| get_associated_token_address(&config.owner, &native_mint::id()));
+    let address = address
+        .unwrap_or_else(|| get_associated_token_address(&wallet_address, &native_mint::id()));
     println!("Unwrapping {}", address);
     if !config.sign_only {
         let lamports = config.rpc_client.get_balance(&address)?;
@@ -792,13 +854,13 @@ fn command_unwrap(config: &Config, address: Option<Pubkey>) -> CommandResult {
         }
         println!("  Amount: {} SOL", lamports_to_sol(lamports),);
     }
-    println!("  Recipient: {}", &config.owner);
+    println!("  Recipient: {}", &wallet_address);
 
     let instructions = vec![close_account(
         &spl_token::id(),
         &address,
-        &config.owner,
-        &config.owner,
+        &wallet_address,
+        &wallet_address,
         &config.multisigner_pubkeys,
     )?];
     Ok(Some((0, vec![instructions])))
@@ -807,6 +869,7 @@ fn command_unwrap(config: &Config, address: Option<Pubkey>) -> CommandResult {
 fn command_approve(
     config: &Config,
     account: Pubkey,
+    owner: Pubkey,
     ui_amount: f64,
     delegate: Pubkey,
     mint_address: Option<Pubkey>,
@@ -825,7 +888,7 @@ fn command_approve(
         &account,
         &mint_pubkey,
         &delegate,
-        &config.owner,
+        &owner,
         &config.multisigner_pubkeys,
         amount,
         decimals,
@@ -833,7 +896,12 @@ fn command_approve(
     Ok(Some((0, vec![instructions])))
 }
 
-fn command_revoke(config: &Config, account: Pubkey, delegate: Option<Pubkey>) -> CommandResult {
+fn command_revoke(
+    config: &Config,
+    account: Pubkey,
+    owner: Pubkey,
+    delegate: Option<Pubkey>,
+) -> CommandResult {
     let delegate = if !config.sign_only {
         let source_account = config
             .rpc_client
@@ -861,7 +929,7 @@ fn command_revoke(config: &Config, account: Pubkey, delegate: Option<Pubkey>) ->
     let instructions = vec![revoke(
         &spl_token::id(),
         &account,
-        &config.owner,
+        &owner,
         &config.multisigner_pubkeys,
     )?];
     Ok(Some((0, vec![instructions])))
@@ -869,15 +937,10 @@ fn command_revoke(config: &Config, account: Pubkey, delegate: Option<Pubkey>) ->
 
 fn command_close(
     config: &Config,
-    token: Option<Pubkey>,
+    account: Pubkey,
+    close_authority: Pubkey,
     recipient: Pubkey,
-    account: Option<Pubkey>,
 ) -> CommandResult {
-    let account = if let Some(account) = account {
-        account
-    } else {
-        get_associated_token_address(&config.owner, &token.unwrap())
-    };
     if !config.sign_only {
         let source_account = config
             .rpc_client
@@ -908,22 +971,13 @@ fn command_close(
         &spl_token::id(),
         &account,
         &recipient,
-        &config.owner,
+        &close_authority,
         &config.multisigner_pubkeys,
     )?];
     Ok(Some((0, vec![instructions])))
 }
 
-fn command_balance(
-    config: &Config,
-    token: Option<Pubkey>,
-    address: Option<Pubkey>,
-) -> CommandResult {
-    let address = if let Some(address) = address {
-        address
-    } else {
-        get_associated_token_address(&config.owner, &token.unwrap())
-    };
+fn command_balance(config: &Config, address: Pubkey) -> CommandResult {
     let balance = config
         .rpc_client
         .get_token_account_balance(&address)
@@ -946,12 +1000,12 @@ fn command_supply(config: &Config, address: Pubkey) -> CommandResult {
     Ok(None)
 }
 
-fn command_accounts(config: &Config, token: Option<Pubkey>) -> CommandResult {
+fn command_accounts(config: &Config, token: Option<Pubkey>, owner: Pubkey) -> CommandResult {
     if let Some(token) = token {
         validate_mint(config, token)?;
     }
     let accounts = config.rpc_client.get_token_accounts_by_owner(
-        &config.owner,
+        &owner,
         match token {
             Some(token) => TokenAccountsFilter::Mint(token),
             None => TokenAccountsFilter::ProgramId(spl_token::id()),
@@ -959,10 +1013,11 @@ fn command_accounts(config: &Config, token: Option<Pubkey>) -> CommandResult {
     )?;
     if accounts.is_empty() {
         println!("None");
+        return Ok(None);
     }
 
     let (mint_accounts, unsupported_accounts, max_len_balance, includes_aux) =
-        sort_and_parse_token_accounts(&config.owner, accounts);
+        sort_and_parse_token_accounts(&owner, accounts);
     let aux_len = if includes_aux { 10 } else { 0 };
     let mut gc_alert = false;
 
@@ -1070,40 +1125,27 @@ fn command_accounts(config: &Config, token: Option<Pubkey>) -> CommandResult {
     Ok(None)
 }
 
-fn command_address(config: &Config, token: Option<Pubkey>) -> CommandResult {
+fn command_address(config: &Config, token: Option<Pubkey>, owner: Pubkey) -> CommandResult {
     if let Some(token) = token {
         validate_mint(config, token)?;
-        let associated_token_address = get_associated_token_address(&config.owner, &token);
-        println!("Wallet address: {:?}", config.owner);
+        let associated_token_address = get_associated_token_address(&owner, &token);
+        println!("Wallet address: {:?}", owner);
         println!("Associated token address: {:?}", associated_token_address);
     } else {
-        println!("Wallet address: {:?}", config.owner);
+        println!("Wallet address: {:?}", owner);
     }
     Ok(None)
 }
 
-fn command_account_info(
-    config: &Config,
-    token: Option<Pubkey>,
-    address: Option<Pubkey>,
-) -> CommandResult {
-    let mut is_associated = false;
-    let address = if let Some(address) = address {
-        address
-    } else {
-        is_associated = true;
-        get_associated_token_address(&config.owner, &token.unwrap())
-    };
+fn command_account_info(config: &Config, address: Pubkey) -> CommandResult {
     let account = config
         .rpc_client
         .get_token_account(&address)
         .map_err(|_| format!("Could not find token account {}", address))?
         .unwrap();
-    if !is_associated {
-        if let Ok(mint) = Pubkey::from_str(&account.mint) {
-            is_associated = get_associated_token_address(&config.owner, &mint) == address;
-        }
-    }
+    let mint = Pubkey::from_str(&account.mint).unwrap();
+    let owner = Pubkey::from_str(&account.owner).unwrap();
+    let is_associated = get_associated_token_address(&owner, &mint) == address;
     let address_message = if is_associated {
         address.to_string()
     } else {
@@ -1164,12 +1206,11 @@ fn command_multisig(config: &Config, address: Pubkey) -> CommandResult {
     Ok(None)
 }
 
-fn command_gc(config: &Config) -> CommandResult {
+fn command_gc(config: &Config, owner: Pubkey) -> CommandResult {
     println!("Fetching token accounts");
-    let accounts = config.rpc_client.get_token_accounts_by_owner(
-        &config.owner,
-        TokenAccountsFilter::ProgramId(spl_token::id()),
-    )?;
+    let accounts = config
+        .rpc_client
+        .get_token_accounts_by_owner(&owner, TokenAccountsFilter::ProgramId(spl_token::id()))?;
     if accounts.is_empty() {
         println!("Nothing to do");
         return Ok(None);
@@ -1207,11 +1248,10 @@ fn command_gc(config: &Config) -> CommandResult {
                         .parse::<u64>()
                         .unwrap_or_else(|err| panic!("Invalid token amount: {}", err));
 
-                    let close_authority =
-                        ui_token_account.close_authority.map_or(config.owner, |s| {
-                            s.parse::<Pubkey>()
-                                .unwrap_or_else(|err| panic!("Invalid close authority: {}", err))
-                        });
+                    let close_authority = ui_token_account.close_authority.map_or(owner, |s| {
+                        s.parse::<Pubkey>()
+                            .unwrap_or_else(|err| panic!("Invalid close authority: {}", err))
+                    });
 
                     let entry = accounts_by_token.entry(token).or_insert_with(HashMap::new);
                     entry.insert(
@@ -1233,14 +1273,14 @@ fn command_gc(config: &Config) -> CommandResult {
 
     for (token, accounts) in accounts_by_token.into_iter() {
         println!("Processing token: {}", token);
-        let associated_token_account = get_associated_token_address(&config.owner, &token);
+        let associated_token_account = get_associated_token_address(&owner, &token);
         let total_balance: u64 = accounts.values().map(|account| account.0).sum();
 
         if total_balance > 0 && !accounts.contains_key(&associated_token_account) {
             // Create the associated token account
             instructions.push(vec![create_associated_token_account(
                 &config.fee_payer,
-                &config.owner,
+                &owner,
                 &token,
             )]);
             lamports_needed += minimum_balance_for_rent_exemption;
@@ -1266,19 +1306,19 @@ fn command_gc(config: &Config) -> CommandResult {
                     &address,
                     &token,
                     &associated_token_account,
-                    &config.owner,
+                    &owner,
                     &config.multisigner_pubkeys,
                     amount,
                     decimals,
                 )?);
             }
             // Close the account if config.owner is able to
-            if close_authority == config.owner {
+            if close_authority == owner {
                 account_instructions.push(close_account(
                     &spl_token::id(),
                     &address,
-                    &config.owner,
-                    &config.owner,
+                    &owner,
+                    &owner,
                     &config.multisigner_pubkeys,
                 )?);
             }
@@ -1363,33 +1403,11 @@ fn main() {
                     Default from the configuration file."
                 ),
         )
-        .arg(
-            Arg::with_name("owner")
-                .long("owner")
-                .value_name("KEYPAIR")
-                .validator(is_valid_signer)
-                .takes_value(true)
-                .global(true)
-                .help(
-                    "Specify the token owner account. \
-                     This may be a keypair file, the ASK keyword. \
-                     Defaults to the client keypair.",
-                ),
-        )
         .arg(fee_payer_arg().global(true))
         .subcommand(SubCommand::with_name("create-token").about("Create a new token")
                 .arg(
-                    Arg::with_name("decimals")
-                        .long("decimals")
-                        .validator(is_mint_decimals)
-                        .value_name("DECIMALS")
-                        .takes_value(true)
-                        .default_value(&default_decimals)
-                        .help("Number of base 10 digits to the right of the decimal place"),
-                )
-                .arg(
                     Arg::with_name("token_keypair")
-                        .value_name("KEYPAIR")
+                        .value_name("TOKEN_KEYPAIR")
                         .validator(is_valid_signer)
                         .takes_value(true)
                         .index(1)
@@ -1398,6 +1416,27 @@ fn main() {
                              This may be a keypair file or the ASK keyword. \
                              [default: randomly generated keypair]"
                         ),
+                )
+                .arg(
+                    Arg::with_name("mint_authority")
+                        .long("mint-authority")
+                        .alias("owner")
+                        .value_name("ADDRESS")
+                        .validator(is_valid_pubkey)
+                        .takes_value(true)
+                        .help(
+                            "Specify the mint authority address. \
+                             Defaults to the client keypair address."
+                        ),
+                )
+                .arg(
+                    Arg::with_name("decimals")
+                        .long("decimals")
+                        .validator(is_mint_decimals)
+                        .value_name("DECIMALS")
+                        .takes_value(true)
+                        .default_value(&default_decimals)
+                        .help("Number of base 10 digits to the right of the decimal place"),
                 )
                 .arg(
                     Arg::with_name("enable_freeze")
@@ -1430,7 +1469,7 @@ fn main() {
                 )
                 .arg(
                     Arg::with_name("account_keypair")
-                        .value_name("KEYPAIR")
+                        .value_name("ACCOUNT_KEYPAIR")
                         .validator(is_valid_signer)
                         .takes_value(true)
                         .index(2)
@@ -1440,6 +1479,7 @@ fn main() {
                              [default: associated token account for --owner]"
                         ),
                 )
+                .arg(owner_address_arg())
                 .nonce_args(true)
                 .offline_args(),
         )
@@ -1520,6 +1560,18 @@ fn main() {
                         .help("The address of the new authority"),
                 )
                 .arg(
+                    Arg::with_name("authority")
+                        .long("authority")
+                        .alias("owner")
+                        .value_name("KEYPAIR")
+                        .validator(is_valid_signer)
+                        .takes_value(true)
+                        .help(
+                            "Specify the current authority keypair. \
+                             Defaults to the client keypair."
+                        ),
+                )
+                .arg(
                     Arg::with_name("disable")
                         .long("disable")
                         .takes_value(false)
@@ -1576,6 +1628,14 @@ fn main() {
                         .long("from")
                         .help("Specify the sending token account \
                             [default: owner's associated token account]")
+                )
+                .arg(owner_keypair_arg()
+                        .value_name("SENDER_TOKEN_OWNER_KEYPAIR")
+                        .help(
+                            "Specify the owner of the sending token account. \
+                            This may be a keypair file, the ASK keyword. \
+                            Defaults to the client keypair.",
+                        ),
                 )
                 .arg(
                     Arg::with_name("allow_unfunded_recipient")
@@ -1634,6 +1694,14 @@ fn main() {
                         .required(true)
                         .help("Amount to burn, in tokens"),
                 )
+                .arg(owner_keypair_arg()
+                        .value_name("SOURCE_TOKEN_OWNER_KEYPAIR")
+                        .help(
+                            "Specify the source token owner account. \
+                            This may be a keypair file, the ASK keyword. \
+                            Defaults to the client keypair.",
+                        ),
+                )
                 .arg(multisig_signer_arg())
                 .mint_args()
                 .nonce_args(true)
@@ -1668,6 +1736,19 @@ fn main() {
                         .index(3)
                         .help("The token account address of recipient [default: associated token account for --owner]"),
                 )
+                .arg(
+                    Arg::with_name("mint_authority")
+                        .long("mint-authority")
+                        .alias("owner")
+                        .value_name("KEYPAIR")
+                        .validator(is_valid_signer)
+                        .takes_value(true)
+                        .help(
+                            "Specify the mint authority keypair. \
+                             This may be a keypair file or the ASK keyword. \
+                             Defaults to the client keypair."
+                        ),
+                )
                 .arg(mint_decimals_arg())
                 .arg(multisig_signer_arg())
                 .nonce_args(true)
@@ -1684,6 +1765,19 @@ fn main() {
                         .index(1)
                         .required(true)
                         .help("The address of the token account to freeze"),
+                )
+                .arg(
+                    Arg::with_name("freeze_authority")
+                        .long("freeze-authority")
+                        .alias("owner")
+                        .value_name("KEYPAIR")
+                        .validator(is_valid_signer)
+                        .takes_value(true)
+                        .help(
+                            "Specify the freeze authority keypair. \
+                             This may be a keypair file or the ASK keyword. \
+                             Defaults to the client keypair."
+                        ),
                 )
                 .arg(mint_address_arg())
                 .arg(multisig_signer_arg())
@@ -1702,6 +1796,19 @@ fn main() {
                         .required(true)
                         .help("The address of the token account to thaw"),
                 )
+                .arg(
+                    Arg::with_name("freeze_authority")
+                        .long("freeze-authority")
+                        .alias("owner")
+                        .value_name("KEYPAIR")
+                        .validator(is_valid_signer)
+                        .takes_value(true)
+                        .help(
+                            "Specify the freeze authority keypair. \
+                             This may be a keypair file or the ASK keyword. \
+                             Defaults to the client keypair."
+                        ),
+                )
                 .arg(mint_address_arg())
                 .arg(multisig_signer_arg())
                 .nonce_args(true)
@@ -1718,6 +1825,19 @@ fn main() {
                         .index(1)
                         .required(true)
                         .help("Amount of SOL to wrap"),
+                )
+                .arg(
+                    Arg::with_name("wallet_keypair")
+                        .alias("owner")
+                        .value_name("KEYPAIR")
+                        .validator(is_valid_signer)
+                        .takes_value(true)
+                        .help(
+                            "Specify the keypair for the wallet which will have its native SOL wrapped. \
+                             This wallet will be assigned as the owner of the wrapped SOL token account. \
+                             This may be a keypair file or the ASK keyword. \
+                             Defaults to the client keypair."
+                        ),
                 )
                 .arg(
                     Arg::with_name("create_aux_account")
@@ -1739,6 +1859,19 @@ fn main() {
                         .index(1)
                         .help("The address of the auxiliary token account to unwrap \
                             [default: associated token account for --owner]"),
+                )
+                .arg(
+                    Arg::with_name("wallet_keypair")
+                        .alias("owner")
+                        .value_name("KEYPAIR")
+                        .validator(is_valid_signer)
+                        .takes_value(true)
+                        .help(
+                            "Specify the keypair for the wallet which owns the wrapped SOL. \
+                             This wallet will receive the unwrapped SOL. \
+                             This may be a keypair file or the ASK keyword. \
+                             Defaults to the client keypair."
+                        ),
                 )
                 .arg(multisig_signer_arg())
                 .nonce_args(true)
@@ -1774,6 +1907,9 @@ fn main() {
                         .required(true)
                         .help("The token account address of delegate"),
                 )
+                .arg(
+                    owner_keypair_arg()
+                )
                 .arg(multisig_signer_arg())
                 .mint_args()
                 .nonce_args(true)
@@ -1790,6 +1926,8 @@ fn main() {
                         .index(1)
                         .required(true)
                         .help("The address of the token account"),
+                )
+                .arg(owner_keypair_arg()
                 )
                 .arg(delegate_address_arg())
                 .arg(multisig_signer_arg())
@@ -1808,6 +1946,7 @@ fn main() {
                         .required_unless("address")
                         .help("Token to close. To close a specific account, use the `--address` parameter instead"),
                 )
+                .arg(owner_address_arg())
                 .arg(
                     Arg::with_name("recipient")
                         .long("recipient")
@@ -1815,6 +1954,20 @@ fn main() {
                         .value_name("REFUND_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .help("The address of the account to receive remaining SOL [default: --owner]"),
+                )
+                .arg(
+                    Arg::with_name("close_authority")
+                        .long("close-authority")
+                        .alias("owner")
+                        .value_name("KEYPAIR")
+                        .validator(is_valid_signer)
+                        .takes_value(true)
+                        .help(
+                            "Specify the token's close authority if it has one, \
+                            otherwise specify the token's owner keypair. \
+                            This may be a keypair file, the ASK keyword. \
+                            Defaults to the client keypair.",
+                        ),
                 )
                 .arg(
                     Arg::with_name("address")
@@ -1842,6 +1995,7 @@ fn main() {
                         .required_unless("address")
                         .help("Token of associated account. To query a specific account, use the `--address` parameter instead"),
                 )
+                .arg(owner_address_arg().conflicts_with("address"))
                 .arg(
                     Arg::with_name("address")
                         .validator(is_valid_pubkey)
@@ -1876,7 +2030,8 @@ fn main() {
                         .takes_value(true)
                         .index(1)
                         .help("Limit results to the given token. [Default: list accounts for all tokens]"),
-                ),
+                )
+                .arg(owner_address_arg())
         )
         .subcommand(
             SubCommand::with_name("address")
@@ -1888,7 +2043,14 @@ fn main() {
                         .takes_value(true)
                         .long("token")
                         .requires("verbose")
-                        .help("Return the associated token address for the given token. [Default: --owner address]"),
+                        .help("Return the associated token address for the given token. \
+                               [Default: return the client keypair address]")
+                )
+                .arg(
+                    owner_address_arg()
+                        .requires("token")
+                        .help("Return the associated token address for the given owner. \
+                               [Default: return the associated token address for the client keypair]"),
                 ),
         )
         .subcommand(
@@ -1900,8 +2062,18 @@ fn main() {
                         .value_name("TOKEN_ADDRESS")
                         .takes_value(true)
                         .index(1)
+                        .conflicts_with("address")
                         .required_unless("address")
-                        .help("Token of associated account. To query a specific account, use the `--address` parameter instead"),
+                        .help("Token of associated account. \
+                               To query a specific account, use the `--address` parameter instead"),
+                )
+                .arg(
+                    owner_address_arg()
+                        .index(2)
+                        .conflicts_with("address")
+                        .help("Owner of the associated account for the specified token. \
+                               To query a specific account, use the `--address` parameter instead. \
+                               Defaults to the client keypair."),
                 )
                 .arg(
                     Arg::with_name("address")
@@ -1929,11 +2101,12 @@ fn main() {
         .subcommand(
             SubCommand::with_name("gc")
                 .about("Cleanup unnecessary token accounts")
+                .arg(owner_keypair_arg())
         )
         .get_matches();
 
     let mut wallet_manager = None;
-    let mut bulk_signers: Vec<Option<Box<dyn Signer>>> = Vec::new();
+    let mut bulk_signers: Vec<Box<dyn Signer>> = Vec::new();
     let mut multisigner_ids = Vec::new();
 
     let (sub_command, sub_matches) = app_matches.subcommand();
@@ -1951,30 +2124,6 @@ fn main() {
                 .unwrap_or(&cli_config.json_rpc_url),
         );
 
-        let default_signer_arg_name = "owner".to_string();
-        let default_signer_path = matches
-            .value_of(&default_signer_arg_name)
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| cli_config.keypair_path.clone());
-        let default_signer = DefaultSigner {
-            path: default_signer_path,
-            arg_name: default_signer_arg_name,
-        };
-
-        let (owner, signer) = {
-            let config = SignerFromPathConfig {
-                allow_null_signer: true,
-            };
-            let owner = default_signer
-                .signer_from_path_with_config(&matches, &mut wallet_manager, &config)
-                .unwrap_or_else(|e| {
-                    eprintln!("error: {}", e);
-                    exit(1);
-                });
-            (owner.pubkey(), Some(owner))
-        };
-        bulk_signers.push(signer);
-
         let (signer, fee_payer) = signer_from_path(
             &matches,
             matches
@@ -1985,7 +2134,7 @@ fn main() {
         )
         .map(|s| {
             let p = s.pubkey();
-            (Some(s), p)
+            (s, p)
         })
         .unwrap_or_else(|e| {
             eprintln!("error: {}", e);
@@ -2000,23 +2149,29 @@ fn main() {
                 eprintln!("error: {}", e);
                 exit(1);
             });
-        let (signer, nonce_authority) = signer_from_path(
-            &matches,
-            matches
-                .value_of(NONCE_AUTHORITY_ARG.name)
-                .unwrap_or(&cli_config.keypair_path),
-            NONCE_AUTHORITY_ARG.name,
-            &mut wallet_manager,
-        )
-        .map(|s| {
-            let p = s.pubkey();
-            (Some(s), Some(p))
-        })
-        .unwrap_or_else(|e| {
-            eprintln!("error: {}", e);
-            exit(1);
-        });
-        bulk_signers.push(signer);
+        let nonce_authority = if nonce_account.is_some() {
+            let (signer, nonce_authority) = signer_from_path(
+                &matches,
+                matches
+                    .value_of(NONCE_AUTHORITY_ARG.name)
+                    .unwrap_or(&cli_config.keypair_path),
+                NONCE_AUTHORITY_ARG.name,
+                &mut wallet_manager,
+            )
+            .map(|s| {
+                let p = s.pubkey();
+                (s, p)
+            })
+            .unwrap_or_else(|e| {
+                eprintln!("error: {}", e);
+                exit(1);
+            });
+            bulk_signers.push(signer);
+
+            Some(nonce_authority)
+        } else {
+            None
+        };
 
         let blockhash_query = BlockhashQuery::new_from_matches(matches);
         let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
@@ -2029,7 +2184,7 @@ fn main() {
         if let Some(mut multisig_signers) = multisig_signers {
             multisig_signers.sort_by(|(_, lp), (_, rp)| lp.cmp(rp));
             let (signers, pubkeys): (Vec<_>, Vec<_>) = multisig_signers.into_iter().unzip();
-            bulk_signers.extend(signers.into_iter().map(Some));
+            bulk_signers.extend(signers);
             multisigner_ids = pubkeys;
         }
         let multisigner_pubkeys = multisigner_ids.iter().collect::<Vec<_>>();
@@ -2037,9 +2192,8 @@ fn main() {
         Config {
             rpc_client: RpcClient::new_with_commitment(json_rpc_url, CommitmentConfig::confirmed()),
             verbose,
-            owner,
             fee_payer,
-            default_signer,
+            default_keypair_path: cli_config.keypair_path,
             nonce_account,
             nonce_authority,
             blockhash_query,
@@ -2048,35 +2202,25 @@ fn main() {
         }
     };
 
-    if matches.is_present(MULTISIG_SIGNER_ARG.name)
-        && !config.sign_only
-        && get_multisig(&config, &config.owner).is_err()
-    {
-        eprintln!("error: {} is not a multisig account", config.owner);
-        exit(1);
-    }
-
     solana_logger::setup_with_default("solana=info");
 
     let _ = match (sub_command, sub_matches) {
         ("create-token", Some(arg_matches)) => {
             let decimals = value_t_or_exit!(arg_matches, "decimals", u8);
+            let mint_authority =
+                config.pubkey_or_default(arg_matches, "mint_authority", &mut wallet_manager);
             let memo = value_t!(arg_matches, "memo", String).ok();
-            let (signer, token) = if arg_matches.is_present("token_keypair") {
-                signer_of(&arg_matches, "token_keypair", &mut wallet_manager).unwrap_or_else(|e| {
-                    eprintln!("error: {}", e);
-                    exit(1);
-                })
-            } else {
-                new_throwaway_signer()
-            };
-            let token = token.unwrap();
-            bulk_signers.push(signer);
+
+            let (token_signer, token) =
+                get_signer(arg_matches, "token_keypair", &mut wallet_manager)
+                    .unwrap_or_else(new_throwaway_signer);
+            bulk_signers.push(token_signer);
 
             command_create_token(
                 &config,
                 decimals,
                 token,
+                mint_authority,
                 arg_matches.is_present("enable_freeze"),
                 memo,
             )
@@ -2086,22 +2230,16 @@ fn main() {
                 .unwrap()
                 .unwrap();
 
-            let account = if arg_matches.is_present("account_keypair") {
-                let (signer, account) =
-                    signer_of(&arg_matches, "account_keypair", &mut wallet_manager).unwrap_or_else(
-                        |e| {
-                            eprintln!("error: {}", e);
-                            exit(1);
-                        },
-                    );
-                bulk_signers.push(signer);
-                account
-            } else {
-                // No need to add a signer when creating an associated token account
-                None
-            };
+            // No need to add a signer when creating an associated token account
+            let account = get_signer(arg_matches, "account_keypair", &mut wallet_manager).map(
+                |(signer, account)| {
+                    bulk_signers.push(signer);
+                    account
+                },
+            );
 
-            command_create_account(&config, token, account)
+            let owner = config.pubkey_or_default(arg_matches, "owner", &mut wallet_manager);
+            command_create_account(&config, token, owner, account)
         }
         ("create-multisig", Some(arg_matches)) => {
             let minimum_signers = value_of::<u8>(&arg_matches, "minimum_signers").unwrap();
@@ -2120,17 +2258,8 @@ fn main() {
                 exit(1);
             }
 
-            let (signer, account) = if arg_matches.is_present("address_keypair") {
-                signer_of(&arg_matches, "address_keypair", &mut wallet_manager).unwrap_or_else(
-                    |e| {
-                        eprintln!("error: {}", e);
-                        exit(1);
-                    },
-                )
-            } else {
-                new_throwaway_signer()
-            };
-            let account = account.unwrap();
+            let (signer, account) = get_signer(arg_matches, "address_keypair", &mut wallet_manager)
+                .unwrap_or_else(new_throwaway_signer);
             bulk_signers.push(signer);
 
             command_create_multisig(&config, account, minimum_signers, multisig_members)
@@ -2147,6 +2276,11 @@ fn main() {
                 "close" => AuthorityType::CloseAccount,
                 _ => unreachable!(),
             };
+
+            let (authority_signer, authority) =
+                config.signer_or_default(arg_matches, "authority", &mut wallet_manager);
+            bulk_signers.push(authority_signer);
+
             let new_authority =
                 pubkey_of_signer(arg_matches, "new_authority", &mut wallet_manager).unwrap();
             let force_authorize = arg_matches.is_present("force");
@@ -2154,6 +2288,7 @@ fn main() {
                 &config,
                 address,
                 authority_type,
+                authority,
                 new_authority,
                 force_authorize,
             )
@@ -2170,6 +2305,11 @@ fn main() {
                 .unwrap()
                 .unwrap();
             let sender = pubkey_of_signer(arg_matches, "from", &mut wallet_manager).unwrap();
+
+            let (owner_signer, owner) =
+                config.signer_or_default(arg_matches, "owner", &mut wallet_manager);
+            bulk_signers.push(owner_signer);
+
             let mint_decimals = value_of::<u8>(&arg_matches, MINT_DECIMALS_ARG.name);
             let fund_recipient = matches.is_present("fund_recipient");
             let allow_unfunded_recipient = matches.is_present("allow_empty_recipient")
@@ -2183,6 +2323,7 @@ fn main() {
                 amount,
                 recipient,
                 sender,
+                owner,
                 allow_unfunded_recipient,
                 fund_recipient,
                 mint_decimals,
@@ -2193,56 +2334,95 @@ fn main() {
             let source = pubkey_of_signer(arg_matches, "source", &mut wallet_manager)
                 .unwrap()
                 .unwrap();
+
+            let (owner_signer, owner) =
+                config.signer_or_default(arg_matches, "owner", &mut wallet_manager);
+            bulk_signers.push(owner_signer);
+
             let amount = value_t_or_exit!(arg_matches, "amount", f64);
             let mint_address =
                 pubkey_of_signer(arg_matches, MINT_ADDRESS_ARG.name, &mut wallet_manager).unwrap();
             let mint_decimals = value_of::<u8>(&arg_matches, MINT_DECIMALS_ARG.name);
-            command_burn(&config, source, amount, mint_address, mint_decimals)
+            command_burn(&config, source, owner, amount, mint_address, mint_decimals)
         }
         ("mint", Some(arg_matches)) => {
+            let (mint_authority_signer, mint_authority) =
+                config.signer_or_default(arg_matches, "mint_authority", &mut wallet_manager);
+            bulk_signers.push(mint_authority_signer);
+
             let token = pubkey_of_signer(arg_matches, "token", &mut wallet_manager)
                 .unwrap()
                 .unwrap();
             let amount = value_t_or_exit!(arg_matches, "amount", f64);
-            let recipient = pubkey_of_signer(arg_matches, "recipient", &mut wallet_manager)
-                .unwrap()
-                .unwrap_or_else(|| get_associated_token_address(&config.owner, &token));
+            let recipient = config.associated_token_address_or_override(
+                arg_matches,
+                "recipient",
+                &mut wallet_manager,
+            );
             let mint_decimals = value_of::<u8>(&arg_matches, MINT_DECIMALS_ARG.name);
-            command_mint(&config, token, amount, recipient, mint_decimals)
+            command_mint(
+                &config,
+                token,
+                amount,
+                recipient,
+                mint_decimals,
+                mint_authority,
+            )
         }
         ("freeze", Some(arg_matches)) => {
+            let (freeze_authority_signer, freeze_authority) =
+                config.signer_or_default(arg_matches, "freeze_authority", &mut wallet_manager);
+            bulk_signers.push(freeze_authority_signer);
+
             let account = pubkey_of_signer(arg_matches, "account", &mut wallet_manager)
                 .unwrap()
                 .unwrap();
             let mint_address =
                 pubkey_of_signer(arg_matches, MINT_ADDRESS_ARG.name, &mut wallet_manager).unwrap();
-            command_freeze(&config, account, mint_address)
+            command_freeze(&config, account, mint_address, freeze_authority)
         }
         ("thaw", Some(arg_matches)) => {
+            let (freeze_authority_signer, freeze_authority) =
+                config.signer_or_default(arg_matches, "freeze_authority", &mut wallet_manager);
+            bulk_signers.push(freeze_authority_signer);
+
             let account = pubkey_of_signer(arg_matches, "account", &mut wallet_manager)
                 .unwrap()
                 .unwrap();
             let mint_address =
                 pubkey_of_signer(arg_matches, MINT_ADDRESS_ARG.name, &mut wallet_manager).unwrap();
-            command_thaw(&config, account, mint_address)
+            command_thaw(&config, account, mint_address, freeze_authority)
         }
         ("wrap", Some(arg_matches)) => {
             let amount = value_t_or_exit!(arg_matches, "amount", f64);
             let account = if arg_matches.is_present("create_aux_account") {
                 let (signer, account) = new_throwaway_signer();
                 bulk_signers.push(signer);
-                account
+                Some(account)
             } else {
                 // No need to add a signer when creating an associated token account
                 None
             };
-            command_wrap(&config, amount, account)
+
+            let (wallet_signer, wallet_address) =
+                config.signer_or_default(arg_matches, "wallet_keypair", &mut wallet_manager);
+            bulk_signers.push(wallet_signer);
+
+            command_wrap(&config, amount, wallet_address, account)
         }
         ("unwrap", Some(arg_matches)) => {
+            let (wallet_signer, wallet_address) =
+                config.signer_or_default(arg_matches, "wallet_keypair", &mut wallet_manager);
+            bulk_signers.push(wallet_signer);
+
             let address = pubkey_of_signer(arg_matches, "address", &mut wallet_manager).unwrap();
-            command_unwrap(&config, address)
+            command_unwrap(&config, wallet_address, address)
         }
         ("approve", Some(arg_matches)) => {
+            let (owner_signer, owner_address) =
+                config.signer_or_default(arg_matches, "owner", &mut wallet_manager);
+            bulk_signers.push(owner_signer);
+
             let account = pubkey_of_signer(arg_matches, "account", &mut wallet_manager)
                 .unwrap()
                 .unwrap();
@@ -2256,6 +2436,7 @@ fn main() {
             command_approve(
                 &config,
                 account,
+                owner_address,
                 amount,
                 delegate,
                 mint_address,
@@ -2263,26 +2444,38 @@ fn main() {
             )
         }
         ("revoke", Some(arg_matches)) => {
+            let (owner_signer, owner_address) =
+                config.signer_or_default(arg_matches, "owner", &mut wallet_manager);
+            bulk_signers.push(owner_signer);
+
             let account = pubkey_of_signer(arg_matches, "account", &mut wallet_manager)
                 .unwrap()
                 .unwrap();
             let delegate_address =
                 pubkey_of_signer(arg_matches, DELEGATE_ADDRESS_ARG.name, &mut wallet_manager)
                     .unwrap();
-            command_revoke(&config, account, delegate_address)
+            command_revoke(&config, account, owner_address, delegate_address)
         }
         ("close", Some(arg_matches)) => {
-            let token = pubkey_of_signer(arg_matches, "token", &mut wallet_manager).unwrap();
-            let recipient = pubkey_of_signer(arg_matches, "recipient", &mut wallet_manager)
-                .unwrap()
-                .unwrap_or(config.owner);
-            let account = pubkey_of_signer(arg_matches, "address", &mut wallet_manager).unwrap();
-            command_close(&config, token, recipient, account)
+            let (close_authority_signer, close_authority) =
+                config.signer_or_default(arg_matches, "close_authority", &mut wallet_manager);
+            bulk_signers.push(close_authority_signer);
+
+            let address = config.associated_token_address_or_override(
+                arg_matches,
+                "address",
+                &mut wallet_manager,
+            );
+            let recipient = config.pubkey_or_default(arg_matches, "recipient", &mut wallet_manager);
+            command_close(&config, address, close_authority, recipient)
         }
         ("balance", Some(arg_matches)) => {
-            let token = pubkey_of_signer(arg_matches, "token", &mut wallet_manager).unwrap();
-            let address = pubkey_of_signer(arg_matches, "address", &mut wallet_manager).unwrap();
-            command_balance(&config, token, address)
+            let address = config.associated_token_address_or_override(
+                arg_matches,
+                "address",
+                &mut wallet_manager,
+            );
+            command_balance(&config, address)
         }
         ("supply", Some(arg_matches)) => {
             let address = pubkey_of_signer(arg_matches, "address", &mut wallet_manager)
@@ -2292,16 +2485,21 @@ fn main() {
         }
         ("accounts", Some(arg_matches)) => {
             let token = pubkey_of_signer(arg_matches, "token", &mut wallet_manager).unwrap();
-            command_accounts(&config, token)
+            let owner = config.pubkey_or_default(arg_matches, "owner", &mut wallet_manager);
+            command_accounts(&config, token, owner)
         }
         ("address", Some(arg_matches)) => {
             let token = pubkey_of_signer(arg_matches, "token", &mut wallet_manager).unwrap();
-            command_address(&config, token)
+            let owner = config.pubkey_or_default(arg_matches, "owner", &mut wallet_manager);
+            command_address(&config, token, owner)
         }
         ("account-info", Some(arg_matches)) => {
-            let token = pubkey_of_signer(arg_matches, "token", &mut wallet_manager).unwrap();
-            let address = pubkey_of_signer(arg_matches, "address", &mut wallet_manager).unwrap();
-            command_account_info(&config, token, address)
+            let address = config.associated_token_address_or_override(
+                arg_matches,
+                "address",
+                &mut wallet_manager,
+            );
+            command_account_info(&config, address)
         }
         ("multisig-info", Some(arg_matches)) => {
             let address = pubkey_of_signer(arg_matches, "address", &mut wallet_manager)
@@ -2309,19 +2507,21 @@ fn main() {
                 .unwrap();
             command_multisig(&config, address)
         }
-        ("gc", Some(_arg_matches)) => command_gc(&config),
+        ("gc", Some(arg_matches)) => {
+            let (owner_signer, owner_address) =
+                config.signer_or_default(arg_matches, "owner", &mut wallet_manager);
+            bulk_signers.push(owner_signer);
+
+            command_gc(&config, owner_address)
+        }
         _ => unreachable!(),
     }
     .and_then(|transaction_info| {
         if let Some((minimum_balance_for_rent_exemption, instruction_batches)) = transaction_info {
             let fee_payer = Some(&config.fee_payer);
-            let signer_info = config
-                .default_signer
-                .generate_unique_signers(bulk_signers, &matches, &mut wallet_manager)
-                .unwrap_or_else(|e| {
-                    eprintln!("error: {}", e);
-                    exit(1);
-                });
+            let signer_info = CliSignerInfo {
+                signers: bulk_signers,
+            };
 
             for instructions in instruction_batches {
                 let message = if let Some(nonce_account) = config.nonce_account.as_ref() {


### PR DESCRIPTION
Fixes: https://github.com/solana-labs/solana-program-library/issues/548
Fixes: https://github.com/solana-labs/solana-program-library/issues/1856

#### Problem
The `--owner` argument is not needed for every subcommand and in some cases `--owner` does not need to be a signer, but this is not explicit in the current code.

#### Changes
- Removed `owner` as a global argument and re-added it to the subcommands where it's needed. Each subcommand can now specify if it needs `owner` to be a keypair or just an address.
- Added named authority arguments for several subcommands (`mint` now accepts `--mint-authority` for example)
- Kept `--owner` as an alias to the new named authority arguments for backwards compatibility
- Added convenience methods for falling back gracefully to `owner` or the default cli signer when authority is not specified
