### PR TITLE
stake-pool: Add ability to withdraw from transient stakes

### DIFF
--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -641,7 +641,7 @@ fn command_list(config: &Config, stake_pool_address: &Pubkey) -> CommandResult {
         println!(
             "Validator Vote Account: {}\tBalance: {}\tLast Update Epoch: {}{}",
             validator.vote_account_address,
-            Sol(validator.stake_lamports),
+            Sol(validator.stake_lamports()),
             validator.last_update_epoch,
             if validator.last_update_epoch != epoch_info.epoch {
                 " [UPDATE REQUIRED]"

--- a/stake-pool/program/src/instruction.rs
+++ b/stake-pool/program/src/instruction.rs
@@ -129,8 +129,8 @@ pub enum StakePoolInstruction {
     ///  0. `[]` Stake pool
     ///  1. `[s]` Stake pool staker
     ///  2. `[]` Stake pool withdraw authority
-    ///  3. `[]` Validator list
-    ///  5. `[w]` Canonical stake account to split from
+    ///  3. `[w]` Validator list
+    ///  4. `[w]` Canonical stake account to split from
     ///  5. `[w]` Transient stake account to receive split
     ///  6. `[]` Clock sysvar
     ///  7. `[]` Rent sysvar
@@ -444,7 +444,7 @@ pub fn decrease_validator_stake(
         AccountMeta::new_readonly(*stake_pool, false),
         AccountMeta::new_readonly(*staker, true),
         AccountMeta::new_readonly(*stake_pool_withdraw_authority, false),
-        AccountMeta::new_readonly(*validator_list, false),
+        AccountMeta::new(*validator_list, false),
         AccountMeta::new(*validator_stake, false),
         AccountMeta::new(*transient_stake, false),
         AccountMeta::new_readonly(sysvar::clock::id(), false),

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -736,7 +736,8 @@ impl Processor {
         validator_list.validators.push(ValidatorStakeInfo {
             status: StakeStatus::Active,
             vote_account_address,
-            stake_lamports: stake_lamports.saturating_sub(minimum_lamport_amount),
+            active_stake_lamports: stake_lamports.saturating_sub(minimum_lamport_amount),
+            transient_stake_lamports: 0,
             last_update_epoch: clock.epoch,
         });
         validator_list.serialize(&mut *validator_list_info.data.borrow_mut())?;
@@ -916,7 +917,7 @@ impl Processor {
 
         stake_pool.check_validator_list(validator_list_info)?;
         check_account_owner(validator_list_info, program_id)?;
-        let validator_list =
+        let mut validator_list =
             try_from_slice_unchecked::<ValidatorList>(&validator_list_info.data.borrow())?;
         if !validator_list.is_valid() {
             return Err(StakePoolError::InvalidState.into());
@@ -944,13 +945,15 @@ impl Processor {
             &[transient_stake_bump_seed],
         ];
 
-        if !validator_list.contains(&vote_account_address) {
+        let maybe_validator_list_entry = validator_list.find_mut(&vote_account_address);
+        if maybe_validator_list_entry.is_none() {
             msg!(
                 "Vote account {} not found in stake pool",
                 vote_account_address
             );
             return Err(StakePoolError::ValidatorNotFound.into());
         }
+        let mut validator_list_entry = maybe_validator_list_entry.unwrap();
 
         let stake_rent = rent.minimum_balance(std::mem::size_of::<stake_program::StakeState>());
         if lamports <= stake_rent {
@@ -995,6 +998,13 @@ impl Processor {
             AUTHORITY_WITHDRAW,
             stake_pool.withdraw_bump_seed,
         )?;
+
+        validator_list_entry.active_stake_lamports = validator_list_entry
+            .active_stake_lamports
+            .checked_sub(lamports)
+            .ok_or(StakePoolError::CalculationFailure)?;
+        validator_list_entry.transient_stake_lamports = lamports;
+        validator_list.serialize(&mut *validator_list_info.data.borrow_mut())?;
 
         Ok(())
     }
@@ -1146,10 +1156,7 @@ impl Processor {
             stake_pool.withdraw_bump_seed,
         )?;
 
-        validator_list_entry.stake_lamports = validator_list_entry
-            .stake_lamports
-            .checked_add(lamports)
-            .ok_or(StakePoolError::CalculationFailure)?;
+        validator_list_entry.transient_stake_lamports = lamports;
         validator_list.serialize(&mut *validator_list_info.data.borrow_mut())?;
 
         Ok(())
@@ -1274,7 +1281,8 @@ impl Processor {
                 continue;
             };
 
-            let mut stake_lamports = 0;
+            let mut active_stake_lamports = 0;
+            let mut transient_stake_lamports = 0;
             let validator_stake_state = try_from_slice_unchecked::<stake_program::StakeState>(
                 &validator_stake_info.data.borrow(),
             )
@@ -1293,7 +1301,7 @@ impl Processor {
             match transient_stake_state {
                 Some(stake_program::StakeState::Initialized(_meta)) => {
                     if no_merge {
-                        stake_lamports += transient_stake_info.lamports();
+                        transient_stake_lamports = transient_stake_info.lamports();
                     } else {
                         // merge into reserve
                         Self::stake_merge(
@@ -1316,7 +1324,7 @@ impl Processor {
                 }
                 Some(stake_program::StakeState::Stake(_, stake)) => {
                     if no_merge {
-                        stake_lamports += transient_stake_info.lamports();
+                        transient_stake_lamports = transient_stake_info.lamports();
                     } else if stake.delegation.deactivation_epoch < clock.epoch {
                         // deactivated, merge into reserve
                         Self::stake_merge(
@@ -1355,15 +1363,15 @@ impl Processor {
                                 )?;
                             } else {
                                 msg!("Stake activating or just active, not ready to merge");
-                                stake_lamports += transient_stake_info.lamports();
+                                transient_stake_lamports = transient_stake_info.lamports();
                             }
                         } else {
                             msg!("Transient stake is activating or active, but validator stake is not, need to add the validator stake account on {} back into the stake pool", stake.delegation.voter_pubkey);
-                            stake_lamports += transient_stake_info.lamports();
+                            transient_stake_lamports = transient_stake_info.lamports();
                         }
                     } else {
                         msg!("Transient stake not ready to be merged anywhere");
-                        stake_lamports += transient_stake_info.lamports();
+                        transient_stake_lamports = transient_stake_info.lamports();
                     }
                 }
                 None
@@ -1377,7 +1385,7 @@ impl Processor {
             match validator_stake_state {
                 Some(stake_program::StakeState::Stake(meta, _)) => {
                     if validator_stake_record.status == StakeStatus::Active {
-                        stake_lamports += validator_stake_info
+                        active_stake_lamports = validator_stake_info
                             .lamports()
                             .saturating_sub(minimum_stake_lamports(&meta));
                     } else {
@@ -1393,7 +1401,8 @@ impl Processor {
             }
 
             validator_stake_record.last_update_epoch = clock.epoch;
-            validator_stake_record.stake_lamports = stake_lamports;
+            validator_stake_record.active_stake_lamports = active_stake_lamports;
+            validator_stake_record.transient_stake_lamports = transient_stake_lamports;
             changes = true;
         }
 
@@ -1465,7 +1474,7 @@ impl Processor {
                 return Err(StakePoolError::StakeListOutOfDate.into());
             }
             total_stake_lamports = total_stake_lamports
-                .checked_add(validator_stake_record.stake_lamports)
+                .checked_add(validator_stake_record.stake_lamports())
                 .ok_or(StakePoolError::CalculationFailure)?;
         }
 
@@ -1674,7 +1683,7 @@ impl Processor {
             "lamports post merge {}",
             validator_stake_account_info.lamports()
         );
-        validator_list_item.stake_lamports = validator_stake_account_info
+        validator_list_item.active_stake_lamports = validator_stake_account_info
             .lamports()
             .checked_sub(minimum_stake_lamports(&meta))
             .ok_or(StakePoolError::CalculationFailure)?;
@@ -1738,19 +1747,20 @@ impl Processor {
             .calc_lamports_withdraw_amount(pool_tokens)
             .ok_or(StakePoolError::CalculationFailure)?;
 
+        let mut withdrawing_from_transient_stake_account = false;
         let validator_list_item = if *stake_split_from.key == stake_pool.reserve_stake {
             // check that the validator stake accounts have no withdrawable stake
             if let Some(withdrawable_entry) = validator_list
                 .validators
                 .iter()
-                .find(|&&x| x.stake_lamports != 0)
+                .find(|&&x| x.stake_lamports() != 0)
             {
                 let (validator_stake_address, _) = crate::find_stake_program_address(
                     &program_id,
                     &withdrawable_entry.vote_account_address,
                     stake_pool_info.key,
                 );
-                msg!("Error withdrawing from reserve: validator stake account {} has {} lamports available, please use that first.", validator_stake_address, withdrawable_entry.stake_lamports);
+                msg!("Error withdrawing from reserve: validator stake account {} has {} lamports available, please use that first.", validator_stake_address, withdrawable_entry.stake_lamports());
                 return Err(StakePoolError::StakeLamportsNotEqualToMinimum.into());
             }
 
@@ -1767,12 +1777,6 @@ impl Processor {
         } else {
             let (meta, stake) = get_stake_state(stake_split_from)?;
             let vote_account_address = stake.delegation.voter_pubkey;
-            check_validator_stake_address(
-                program_id,
-                stake_pool_info.key,
-                stake_split_from.key,
-                &vote_account_address,
-            )?;
 
             if let Some(preferred_withdraw_validator) =
                 validator_list.preferred_withdraw_validator_vote_address
@@ -1781,11 +1785,30 @@ impl Processor {
                     .find(&preferred_withdraw_validator)
                     .ok_or(StakePoolError::ValidatorNotFound)?;
                 if preferred_withdraw_validator != vote_account_address
-                    && preferred_validator_info.stake_lamports > 0
+                    && preferred_validator_info.active_stake_lamports > 0
                 {
-                    msg!("Validator vote address {} is preferred for withdrawals, it currently has {} lamports available. Please withdraw those before using other validator stake accounts.", preferred_withdraw_validator, preferred_validator_info.stake_lamports);
+                    msg!("Validator vote address {} is preferred for withdrawals, it currently has {} lamports available. Please withdraw those before using other validator stake accounts.", preferred_withdraw_validator, preferred_validator_info.active_stake_lamports);
                     return Err(StakePoolError::IncorrectWithdrawVoteAddress.into());
                 }
+            }
+
+            // if there's any active stake, we must withdraw from an active
+            // stake account
+            if validator_list.has_active_stake() {
+                check_validator_stake_address(
+                    program_id,
+                    stake_pool_info.key,
+                    stake_split_from.key,
+                    &vote_account_address,
+                )?;
+            } else {
+                check_transient_stake_address(
+                    program_id,
+                    stake_pool_info.key,
+                    stake_split_from.key,
+                    &vote_account_address,
+                )?;
+                withdrawing_from_transient_stake_account = true;
             }
 
             let validator_list_item = validator_list
@@ -1847,10 +1870,17 @@ impl Processor {
         stake_pool.serialize(&mut *stake_pool_info.data.borrow_mut())?;
 
         if let Some(validator_list_item) = validator_list_item {
-            validator_list_item.stake_lamports = validator_list_item
-                .stake_lamports
-                .checked_sub(withdraw_lamports)
-                .ok_or(StakePoolError::CalculationFailure)?;
+            if withdrawing_from_transient_stake_account {
+                validator_list_item.transient_stake_lamports = validator_list_item
+                    .transient_stake_lamports
+                    .checked_sub(withdraw_lamports)
+                    .ok_or(StakePoolError::CalculationFailure)?;
+            } else {
+                validator_list_item.active_stake_lamports = validator_list_item
+                    .active_stake_lamports
+                    .checked_sub(withdraw_lamports)
+                    .ok_or(StakePoolError::CalculationFailure)?;
+            }
             validator_list.serialize(&mut *validator_list_info.data.borrow_mut())?;
         }
 

--- a/stake-pool/program/tests/deposit.rs
+++ b/stake-pool/program/tests/deposit.rs
@@ -191,8 +191,8 @@ async fn success() {
         .find(&validator_stake_account.vote.pubkey())
         .unwrap();
     assert_eq!(
-        validator_stake_item.stake_lamports,
-        validator_stake_item_before.stake_lamports + stake_lamports
+        validator_stake_item.stake_lamports(),
+        validator_stake_item_before.stake_lamports() + stake_lamports
     );
 
     // Check validator stake account actual SOL balance
@@ -203,8 +203,9 @@ async fn success() {
     let meta = stake_state.meta().unwrap();
     assert_eq!(
         validator_stake_account.lamports - minimum_stake_lamports(&meta),
-        validator_stake_item.stake_lamports
+        validator_stake_item.stake_lamports()
     );
+    assert_eq!(validator_stake_item.transient_stake_lamports, 0);
 }
 
 #[tokio::test]

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -1124,7 +1124,7 @@ pub async fn get_validator_list_sum(
     let validator_sum: u64 = validator_list
         .validators
         .iter()
-        .map(|info| info.stake_lamports)
+        .map(|info| info.stake_lamports())
         .sum();
     let rent = banks_client.get_rent().await.unwrap();
     let rent = rent.minimum_balance(std::mem::size_of::<stake_program::StakeState>());

--- a/stake-pool/program/tests/update_validator_list_balance.rs
+++ b/stake-pool/program/tests/update_validator_list_balance.rs
@@ -536,8 +536,9 @@ async fn merge_transient_stake_after_remove() {
         validator_list.validators[0].status,
         StakeStatus::DeactivatingTransient
     );
+    assert_eq!(validator_list.validators[0].active_stake_lamports, 0);
     assert_eq!(
-        validator_list.validators[0].stake_lamports,
+        validator_list.validators[0].transient_stake_lamports,
         deactivated_lamports
     );
 
@@ -569,7 +570,7 @@ async fn merge_transient_stake_after_remove() {
         validator_list.validators[0].status,
         StakeStatus::ReadyForRemoval
     );
-    assert_eq!(validator_list.validators[0].stake_lamports, 0);
+    assert_eq!(validator_list.validators[0].stake_lamports(), 0);
 
     let reserve_stake = context
         .banks_client

--- a/stake-pool/program/tests/vsa_add.rs
+++ b/stake-pool/program/tests/vsa_add.rs
@@ -91,7 +91,8 @@ async fn success() {
                 status: state::StakeStatus::Active,
                 vote_account_address: user_stake.vote.pubkey(),
                 last_update_epoch: 0,
-                stake_lamports: 0,
+                active_stake_lamports: 0,
+                transient_stake_lamports: 0,
             }]
         }
     );

--- a/stake-pool/program/tests/vsa_remove.rs
+++ b/stake-pool/program/tests/vsa_remove.rs
@@ -529,7 +529,8 @@ async fn success_with_deactivating_transient_stake() {
             status: state::StakeStatus::DeactivatingTransient,
             vote_account_address: validator_stake.vote.pubkey(),
             last_update_epoch: 0,
-            stake_lamports: TEST_STAKE_AMOUNT + stake_rent,
+            active_stake_lamports: 0,
+            transient_stake_lamports: TEST_STAKE_AMOUNT + stake_rent,
         }],
     };
     assert_eq!(validator_list, expected_list);


### PR DESCRIPTION
#### Problem

It's possible for a very malicious pool staker to constantly increase /
decrease the stake on validators, making it impossible for people to get
their SOL out.

#### Solution

Split the accounting to know how much of the stake is active and how
much is transient and allow users to withdraw from transient accounts,
but only if there's no more active stake.