### PR TITLE
Governance: use runtime program_id

### DIFF
--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -1,7 +1,6 @@
 //! Program instructions
 
 use crate::{
-    id,
     state::{
         governance::{
             get_account_governance_address, get_program_governance_address, GovernanceConfig,
@@ -295,6 +294,7 @@ pub enum GovernanceInstruction {
 
 /// Creates CreateRealm instruction
 pub fn create_realm(
+    program_id: &Pubkey,
     // Accounts
     community_token_mint: &Pubkey,
     payer: &Pubkey,
@@ -302,9 +302,9 @@ pub fn create_realm(
     // Args
     name: String,
 ) -> Instruction {
-    let realm_address = get_realm_address(&name);
+    let realm_address = get_realm_address(program_id, &name);
     let community_token_holding_address =
-        get_governing_token_holding_address(&realm_address, &community_token_mint);
+        get_governing_token_holding_address(program_id, &realm_address, &community_token_mint);
 
     let mut accounts = vec![
         AccountMeta::new(realm_address, false),
@@ -318,7 +318,7 @@ pub fn create_realm(
 
     if let Some(council_token_mint) = council_token_mint {
         let council_token_holding_address =
-            get_governing_token_holding_address(&realm_address, &council_token_mint);
+            get_governing_token_holding_address(program_id, &realm_address, &council_token_mint);
 
         accounts.push(AccountMeta::new_readonly(council_token_mint, false));
         accounts.push(AccountMeta::new(council_token_holding_address, false));
@@ -327,7 +327,7 @@ pub fn create_realm(
     let instruction = GovernanceInstruction::CreateRealm { name };
 
     Instruction {
-        program_id: id(),
+        program_id: *program_id,
         accounts,
         data: instruction.try_to_vec().unwrap(),
     }
@@ -335,6 +335,7 @@ pub fn create_realm(
 
 /// Creates DepositGoverningTokens instruction
 pub fn deposit_governing_tokens(
+    program_id: &Pubkey,
     // Accounts
     realm: &Pubkey,
     governing_token_source: &Pubkey,
@@ -344,11 +345,15 @@ pub fn deposit_governing_tokens(
     // Args
     governing_token_mint: &Pubkey,
 ) -> Instruction {
-    let token_owner_record_address =
-        get_token_owner_record_address(realm, governing_token_mint, governing_token_owner);
+    let token_owner_record_address = get_token_owner_record_address(
+        program_id,
+        realm,
+        governing_token_mint,
+        governing_token_owner,
+    );
 
     let governing_token_holding_address =
-        get_governing_token_holding_address(realm, governing_token_mint);
+        get_governing_token_holding_address(program_id, realm, governing_token_mint);
 
     let accounts = vec![
         AccountMeta::new_readonly(*realm, false),
@@ -366,7 +371,7 @@ pub fn deposit_governing_tokens(
     let instruction = GovernanceInstruction::DepositGoverningTokens {};
 
     Instruction {
-        program_id: id(),
+        program_id: *program_id,
         accounts,
         data: instruction.try_to_vec().unwrap(),
     }
@@ -374,6 +379,7 @@ pub fn deposit_governing_tokens(
 
 /// Creates WithdrawGoverningTokens instruction
 pub fn withdraw_governing_tokens(
+    program_id: &Pubkey,
     // Accounts
     realm: &Pubkey,
     governing_token_destination: &Pubkey,
@@ -381,11 +387,15 @@ pub fn withdraw_governing_tokens(
     // Args
     governing_token_mint: &Pubkey,
 ) -> Instruction {
-    let token_owner_record_address =
-        get_token_owner_record_address(realm, governing_token_mint, governing_token_owner);
+    let token_owner_record_address = get_token_owner_record_address(
+        program_id,
+        realm,
+        governing_token_mint,
+        governing_token_owner,
+    );
 
     let governing_token_holding_address =
-        get_governing_token_holding_address(realm, governing_token_mint);
+        get_governing_token_holding_address(program_id, realm, governing_token_mint);
 
     let accounts = vec![
         AccountMeta::new_readonly(*realm, false),
@@ -399,7 +409,7 @@ pub fn withdraw_governing_tokens(
     let instruction = GovernanceInstruction::WithdrawGoverningTokens {};
 
     Instruction {
-        program_id: id(),
+        program_id: *program_id,
         accounts,
         data: instruction.try_to_vec().unwrap(),
     }
@@ -407,6 +417,7 @@ pub fn withdraw_governing_tokens(
 
 /// Creates SetGovernanceDelegate instruction
 pub fn set_governance_delegate(
+    program_id: &Pubkey,
     // Accounts
     governance_authority: &Pubkey,
     // Args
@@ -415,8 +426,12 @@ pub fn set_governance_delegate(
     governing_token_owner: &Pubkey,
     new_governance_delegate: &Option<Pubkey>,
 ) -> Instruction {
-    let vote_record_address =
-        get_token_owner_record_address(realm, governing_token_mint, governing_token_owner);
+    let vote_record_address = get_token_owner_record_address(
+        program_id,
+        realm,
+        governing_token_mint,
+        governing_token_owner,
+    );
 
     let accounts = vec![
         AccountMeta::new_readonly(*governance_authority, true),
@@ -428,7 +443,7 @@ pub fn set_governance_delegate(
     };
 
     Instruction {
-        program_id: id(),
+        program_id: *program_id,
         accounts,
         data: instruction.try_to_vec().unwrap(),
     }
@@ -436,13 +451,14 @@ pub fn set_governance_delegate(
 
 /// Creates CreateAccountGovernance instruction
 pub fn create_account_governance(
+    program_id: &Pubkey,
     // Accounts
     payer: &Pubkey,
     // Args
     config: GovernanceConfig,
 ) -> Instruction {
     let account_governance_address =
-        get_account_governance_address(&config.realm, &config.governed_account);
+        get_account_governance_address(program_id, &config.realm, &config.governed_account);
 
     let accounts = vec![
         AccountMeta::new_readonly(config.realm, false),
@@ -455,7 +471,7 @@ pub fn create_account_governance(
     let instruction = GovernanceInstruction::CreateAccountGovernance { config };
 
     Instruction {
-        program_id: id(),
+        program_id: *program_id,
         accounts,
         data: instruction.try_to_vec().unwrap(),
     }
@@ -463,6 +479,7 @@ pub fn create_account_governance(
 
 /// Creates CreateProgramGovernance instruction
 pub fn create_program_governance(
+    program_id: &Pubkey,
     // Accounts
     governed_program_upgrade_authority: &Pubkey,
     payer: &Pubkey,
@@ -471,7 +488,7 @@ pub fn create_program_governance(
     transfer_upgrade_authority: bool,
 ) -> Instruction {
     let program_governance_address =
-        get_program_governance_address(&config.realm, &config.governed_account);
+        get_program_governance_address(program_id, &config.realm, &config.governed_account);
     let governed_program_data_address = get_program_data_address(&config.governed_account);
 
     let accounts = vec![
@@ -491,7 +508,7 @@ pub fn create_program_governance(
     };
 
     Instruction {
-        program_id: id(),
+        program_id: *program_id,
         accounts,
         data: instruction.try_to_vec().unwrap(),
     }
@@ -500,6 +517,7 @@ pub fn create_program_governance(
 /// Creates CreateProposal instruction
 #[allow(clippy::too_many_arguments)]
 pub fn create_proposal(
+    program_id: &Pubkey,
     // Accounts
     governance: &Pubkey,
     governing_token_owner: &Pubkey,
@@ -513,12 +531,17 @@ pub fn create_proposal(
     proposal_index: u32,
 ) -> Instruction {
     let proposal_address = get_proposal_address(
+        program_id,
         governance,
         governing_token_mint,
         &proposal_index.to_le_bytes(),
     );
-    let token_owner_record_address =
-        get_token_owner_record_address(realm, governing_token_mint, governing_token_owner);
+    let token_owner_record_address = get_token_owner_record_address(
+        program_id,
+        realm,
+        governing_token_mint,
+        governing_token_owner,
+    );
 
     let accounts = vec![
         AccountMeta::new(proposal_address, false),
@@ -538,7 +561,7 @@ pub fn create_proposal(
     };
 
     Instruction {
-        program_id: id(),
+        program_id: *program_id,
         accounts,
         data: instruction.try_to_vec().unwrap(),
     }
@@ -546,6 +569,7 @@ pub fn create_proposal(
 
 /// Creates AddSignatory instruction
 pub fn add_signatory(
+    program_id: &Pubkey,
     // Accounts
     proposal: &Pubkey,
     token_owner_record: &Pubkey,
@@ -554,7 +578,7 @@ pub fn add_signatory(
     // Args
     signatory: &Pubkey,
 ) -> Instruction {
-    let signatory_record_address = get_signatory_record_address(proposal, signatory);
+    let signatory_record_address = get_signatory_record_address(program_id, proposal, signatory);
 
     let accounts = vec![
         AccountMeta::new(*proposal, false),
@@ -571,7 +595,7 @@ pub fn add_signatory(
     };
 
     Instruction {
-        program_id: id(),
+        program_id: *program_id,
         accounts,
         data: instruction.try_to_vec().unwrap(),
     }
@@ -579,6 +603,7 @@ pub fn add_signatory(
 
 /// Creates RemoveSignatory instruction
 pub fn remove_signatory(
+    program_id: &Pubkey,
     // Accounts
     proposal: &Pubkey,
     token_owner_record: &Pubkey,
@@ -586,7 +611,7 @@ pub fn remove_signatory(
     signatory: &Pubkey,
     beneficiary: &Pubkey,
 ) -> Instruction {
-    let signatory_record_address = get_signatory_record_address(proposal, signatory);
+    let signatory_record_address = get_signatory_record_address(program_id, proposal, signatory);
 
     let accounts = vec![
         AccountMeta::new(*proposal, false),
@@ -601,7 +626,7 @@ pub fn remove_signatory(
     };
 
     Instruction {
-        program_id: id(),
+        program_id: *program_id,
         accounts,
         data: instruction.try_to_vec().unwrap(),
     }
@@ -609,11 +634,12 @@ pub fn remove_signatory(
 
 /// Creates SignOffProposal instruction
 pub fn sign_off_proposal(
+    program_id: &Pubkey,
     // Accounts
     proposal: &Pubkey,
     signatory: &Pubkey,
 ) -> Instruction {
-    let signatory_record_address = get_signatory_record_address(proposal, signatory);
+    let signatory_record_address = get_signatory_record_address(program_id, proposal, signatory);
 
     let accounts = vec![
         AccountMeta::new(*proposal, false),
@@ -625,7 +651,7 @@ pub fn sign_off_proposal(
     let instruction = GovernanceInstruction::SignOffProposal;
 
     Instruction {
-        program_id: id(),
+        program_id: *program_id,
         accounts,
         data: instruction.try_to_vec().unwrap(),
     }
@@ -633,6 +659,7 @@ pub fn sign_off_proposal(
 
 /// Creates CastVote instruction
 pub fn cast_vote(
+    program_id: &Pubkey,
     // Accounts
     governance: &Pubkey,
     proposal: &Pubkey,
@@ -643,7 +670,7 @@ pub fn cast_vote(
     // Args
     vote: Vote,
 ) -> Instruction {
-    let vote_record_address = get_vote_record_address(&proposal, &token_owner_record);
+    let vote_record_address = get_vote_record_address(program_id, &proposal, &token_owner_record);
 
     let accounts = vec![
         AccountMeta::new_readonly(*governance, false),
@@ -661,7 +688,7 @@ pub fn cast_vote(
     let instruction = GovernanceInstruction::CastVote { vote };
 
     Instruction {
-        program_id: id(),
+        program_id: *program_id,
         accounts,
         data: instruction.try_to_vec().unwrap(),
     }
@@ -669,6 +696,7 @@ pub fn cast_vote(
 
 /// Creates FinalizeVote instruction
 pub fn finalize_vote(
+    program_id: &Pubkey,
     // Accounts
     governance: &Pubkey,
     proposal: &Pubkey,
@@ -684,7 +712,7 @@ pub fn finalize_vote(
     let instruction = GovernanceInstruction::FinalizeVote {};
 
     Instruction {
-        program_id: id(),
+        program_id: *program_id,
         accounts,
         data: instruction.try_to_vec().unwrap(),
     }
@@ -692,6 +720,7 @@ pub fn finalize_vote(
 
 /// Creates RelinquishVote instruction
 pub fn relinquish_vote(
+    program_id: &Pubkey,
     // Accounts
     governance: &Pubkey,
     proposal: &Pubkey,
@@ -700,7 +729,7 @@ pub fn relinquish_vote(
     governance_authority: Option<Pubkey>,
     beneficiary: Option<Pubkey>,
 ) -> Instruction {
-    let vote_record_address = get_vote_record_address(&proposal, &token_owner_record);
+    let vote_record_address = get_vote_record_address(program_id, &proposal, &token_owner_record);
 
     let mut accounts = vec![
         AccountMeta::new_readonly(*governance, false),
@@ -718,7 +747,7 @@ pub fn relinquish_vote(
     let instruction = GovernanceInstruction::RelinquishVote {};
 
     Instruction {
-        program_id: id(),
+        program_id: *program_id,
         accounts,
         data: instruction.try_to_vec().unwrap(),
     }
@@ -726,6 +755,7 @@ pub fn relinquish_vote(
 
 /// Creates CancelProposal instruction
 pub fn cancel_proposal(
+    program_id: &Pubkey,
     // Accounts
     proposal: &Pubkey,
     token_owner_record: &Pubkey,
@@ -741,7 +771,7 @@ pub fn cancel_proposal(
     let instruction = GovernanceInstruction::CancelProposal {};
 
     Instruction {
-        program_id: id(),
+        program_id: *program_id,
         accounts,
         data: instruction.try_to_vec().unwrap(),
     }
@@ -750,6 +780,7 @@ pub fn cancel_proposal(
 /// Creates InsertInstruction instruction
 #[allow(clippy::too_many_arguments)]
 pub fn insert_instruction(
+    program_id: &Pubkey,
     // Accounts
     governance: &Pubkey,
     proposal: &Pubkey,
@@ -762,7 +793,7 @@ pub fn insert_instruction(
     instruction: InstructionData,
 ) -> Instruction {
     let proposal_instruction_address =
-        get_proposal_instruction_address(&proposal, &index.to_le_bytes());
+        get_proposal_instruction_address(program_id, &proposal, &index.to_le_bytes());
 
     let accounts = vec![
         AccountMeta::new_readonly(*governance, false),
@@ -782,7 +813,7 @@ pub fn insert_instruction(
     };
 
     Instruction {
-        program_id: id(),
+        program_id: *program_id,
         accounts,
         data: instruction.try_to_vec().unwrap(),
     }
@@ -790,6 +821,7 @@ pub fn insert_instruction(
 
 /// Creates RemoveInstruction instruction
 pub fn remove_instruction(
+    program_id: &Pubkey,
     // Accounts
     proposal: &Pubkey,
     token_owner_record: &Pubkey,
@@ -808,7 +840,7 @@ pub fn remove_instruction(
     let instruction = GovernanceInstruction::RemoveInstruction {};
 
     Instruction {
-        program_id: id(),
+        program_id: *program_id,
         accounts,
         data: instruction.try_to_vec().unwrap(),
     }
@@ -816,6 +848,7 @@ pub fn remove_instruction(
 
 /// Creates ExecuteInstruction instruction
 pub fn execute_instruction(
+    program_id: &Pubkey,
     // Accounts
     governance: &Pubkey,
     proposal: &Pubkey,
@@ -836,7 +869,7 @@ pub fn execute_instruction(
     let instruction = GovernanceInstruction::ExecuteInstruction {};
 
     Instruction {
-        program_id: id(),
+        program_id: *program_id,
         accounts,
         data: instruction.try_to_vec().unwrap(),
     }

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -658,6 +658,7 @@ pub fn sign_off_proposal(
 }
 
 /// Creates CastVote instruction
+#[allow(clippy::too_many_arguments)]
 pub fn cast_vote(
     program_id: &Pubkey,
     // Accounts

--- a/governance/program/src/lib.rs
+++ b/governance/program/src/lib.rs
@@ -11,7 +11,5 @@ pub mod tools;
 // Export current sdk types for downstream users building with a different sdk version
 pub use solana_program;
 
-solana_program::declare_id!("GovernancerdmUu324nahyv33G5poQdLUEZ1nEytDeP");
-
 /// Seed prefix for Governance  PDAs
 pub const PROGRAM_AUTHORITY_SEED: &[u8] = b"governance";

--- a/governance/program/src/processor/mod.rs
+++ b/governance/program/src/processor/mod.rs
@@ -84,7 +84,7 @@ pub fn process_instruction(
 
         GovernanceInstruction::SetGovernanceDelegate {
             new_governance_delegate,
-        } => process_set_governance_delegate(accounts, &new_governance_delegate),
+        } => process_set_governance_delegate(program_id, accounts, &new_governance_delegate),
 
         GovernanceInstruction::CreateProgramGovernance {
             config,

--- a/governance/program/src/processor/process_add_signatory.rs
+++ b/governance/program/src/processor/process_add_signatory.rs
@@ -39,10 +39,11 @@ pub fn process_add_signatory(
     let rent_sysvar_info = next_account_info(account_info_iter)?; // 6
     let rent = &Rent::from_account_info(rent_sysvar_info)?;
 
-    let mut proposal_data = get_proposal_data(proposal_info)?;
+    let mut proposal_data = get_proposal_data(program_id, proposal_info)?;
     proposal_data.assert_can_edit_signatories()?;
 
     let token_owner_record_data = get_token_owner_record_data_for_proposal_owner(
+        program_id,
         token_owner_record_info,
         &proposal_data.token_owner_record,
     )?;

--- a/governance/program/src/processor/process_cancel_proposal.rs
+++ b/governance/program/src/processor/process_cancel_proposal.rs
@@ -15,7 +15,7 @@ use crate::state::{
 };
 
 /// Processes CancelProposal instruction
-pub fn process_cancel_proposal(_program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
+pub fn process_cancel_proposal(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
 
     let proposal_info = next_account_info(account_info_iter)?; // 0
@@ -25,10 +25,11 @@ pub fn process_cancel_proposal(_program_id: &Pubkey, accounts: &[AccountInfo]) -
     let clock_info = next_account_info(account_info_iter)?; // 3
     let clock = Clock::from_account_info(clock_info)?;
 
-    let mut proposal_data = get_proposal_data(proposal_info)?;
+    let mut proposal_data = get_proposal_data(program_id, proposal_info)?;
     proposal_data.assert_can_cancel()?;
 
     let token_owner_record_data = get_token_owner_record_data_for_proposal_owner(
+        program_id,
         token_owner_record_info,
         &proposal_data.token_owner_record,
     )?;

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -53,9 +53,10 @@ pub fn process_cast_vote(
         return Err(GovernanceError::VoteAlreadyExists.into());
     }
 
-    let governance_data = get_governance_data(governance_info)?;
+    let governance_data = get_governance_data(program_id, governance_info)?;
 
     let mut proposal_data = get_proposal_data_for_governance_and_governing_mint(
+        program_id,
         &proposal_info,
         governance_info.key,
         governing_token_mint_info.key,
@@ -63,6 +64,7 @@ pub fn process_cast_vote(
     proposal_data.assert_can_cast_vote(&governance_data.config, clock.slot)?;
 
     let mut token_owner_record_data = get_token_owner_record_data_for_realm_and_governing_mint(
+        program_id,
         &token_owner_record_info,
         &governance_data.config.realm,
         governing_token_mint_info.key,

--- a/governance/program/src/processor/process_create_account_governance.rs
+++ b/governance/program/src/processor/process_create_account_governance.rs
@@ -34,7 +34,7 @@ pub fn process_create_account_governance(
     let rent_sysvar_info = next_account_info(account_info_iter)?; // 3
     let rent = &Rent::from_account_info(rent_sysvar_info)?;
 
-    assert_is_valid_governance_config(&config, realm_info)?;
+    assert_is_valid_governance_config(program_id, &config, realm_info)?;
 
     let account_governance_data = Governance {
         account_type: GovernanceAccountType::AccountGovernance,

--- a/governance/program/src/processor/process_create_program_governance.rs
+++ b/governance/program/src/processor/process_create_program_governance.rs
@@ -47,7 +47,7 @@ pub fn process_create_program_governance(
     let rent_sysvar_info = next_account_info(account_info_iter)?; // 6
     let rent = &Rent::from_account_info(rent_sysvar_info)?;
 
-    assert_is_valid_governance_config(&config, &realm_info)?;
+    assert_is_valid_governance_config(program_id, &config, &realm_info)?;
 
     let program_governance_data = Governance {
         account_type: GovernanceAccountType::ProgramGovernance,

--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -50,9 +50,10 @@ pub fn process_create_proposal(
         return Err(GovernanceError::ProposalAlreadyExists.into());
     }
 
-    let mut governance_data = get_governance_data(governance_info)?;
+    let mut governance_data = get_governance_data(program_id, governance_info)?;
 
     let token_owner_record_data = get_token_owner_record_data_for_realm_and_governing_mint(
+        program_id,
         &token_owner_record_info,
         &governance_data.config.realm,
         &governing_token_mint,

--- a/governance/program/src/processor/process_deposit_governing_tokens.rs
+++ b/governance/program/src/processor/process_deposit_governing_tokens.rs
@@ -47,7 +47,7 @@ pub fn process_deposit_governing_tokens(
     let rent_sysvar_info = next_account_info(account_info_iter)?; // 9
     let rent = &Rent::from_account_info(rent_sysvar_info)?;
 
-    let realm_data = get_realm_data(realm_info)?;
+    let realm_data = get_realm_data(program_id, realm_info)?;
     let governing_token_mint = get_spl_token_mint(governing_token_holding_info)?;
 
     realm_data.assert_is_valid_governing_token_mint(&governing_token_mint)?;
@@ -100,6 +100,7 @@ pub fn process_deposit_governing_tokens(
         )?;
     } else {
         let mut token_owner_record_data = get_token_owner_record_data_for_seeds(
+            program_id,
             token_owner_record_info,
             &token_owner_record_address_seeds,
         )?;

--- a/governance/program/src/processor/process_execute_instruction.rs
+++ b/governance/program/src/processor/process_execute_instruction.rs
@@ -28,12 +28,16 @@ pub fn process_execute_instruction(program_id: &Pubkey, accounts: &[AccountInfo]
     let clock_info = next_account_info(account_info_iter)?; // 3
     let clock = Clock::from_account_info(clock_info)?;
 
-    let governance_data = get_governance_data(governance_info)?;
+    let governance_data = get_governance_data(program_id, governance_info)?;
 
-    let mut proposal_data = get_proposal_data_for_governance(proposal_info, governance_info.key)?;
+    let mut proposal_data =
+        get_proposal_data_for_governance(program_id, proposal_info, governance_info.key)?;
 
-    let mut proposal_instruction_data =
-        get_proposal_instruction_data_for_proposal(proposal_instruction_info, proposal_info.key)?;
+    let mut proposal_instruction_data = get_proposal_instruction_data_for_proposal(
+        program_id,
+        proposal_instruction_info,
+        proposal_info.key,
+    )?;
 
     proposal_data.assert_can_execute_instruction(&proposal_instruction_data, clock.slot)?;
 

--- a/governance/program/src/processor/process_finalize_vote.rs
+++ b/governance/program/src/processor/process_finalize_vote.rs
@@ -19,7 +19,7 @@ use crate::{
 use borsh::BorshSerialize;
 
 /// Processes FinalizeVote instruction
-pub fn process_finalize_vote(_program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
+pub fn process_finalize_vote(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
 
     let governance_info = next_account_info(account_info_iter)?; // 0
@@ -30,9 +30,10 @@ pub fn process_finalize_vote(_program_id: &Pubkey, accounts: &[AccountInfo]) -> 
     let clock_info = next_account_info(account_info_iter)?; // 3
     let clock = Clock::from_account_info(clock_info)?;
 
-    let governance_data = get_governance_data(governance_info)?;
+    let governance_data = get_governance_data(program_id, governance_info)?;
 
     let mut proposal_data = get_proposal_data_for_governance_and_governing_mint(
+        program_id,
         &proposal_info,
         governance_info.key,
         governing_token_mint_info.key,

--- a/governance/program/src/processor/process_insert_instruction.rs
+++ b/governance/program/src/processor/process_insert_instruction.rs
@@ -52,16 +52,18 @@ pub fn process_insert_instruction(
         return Err(GovernanceError::InstructionAlreadyExists.into());
     }
 
-    let governance_data = get_governance_data(governance_info)?;
+    let governance_data = get_governance_data(program_id, governance_info)?;
 
     if hold_up_time < governance_data.config.min_instruction_hold_up_time {
         return Err(GovernanceError::InstructionHoldUpTimeBelowRequiredMin.into());
     }
 
-    let mut proposal_data = get_proposal_data_for_governance(&proposal_info, governance_info.key)?;
+    let mut proposal_data =
+        get_proposal_data_for_governance(program_id, &proposal_info, governance_info.key)?;
     proposal_data.assert_can_edit_instructions()?;
 
     let token_owner_record_data = get_token_owner_record_data_for_proposal_owner(
+        program_id,
         token_owner_record_info,
         &proposal_data.token_owner_record,
     )?;

--- a/governance/program/src/processor/process_relinquish_vote.rs
+++ b/governance/program/src/processor/process_relinquish_vote.rs
@@ -20,7 +20,7 @@ use crate::{
 use borsh::BorshSerialize;
 
 /// Processes RelinquishVote instruction
-pub fn process_relinquish_vote(_program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
+pub fn process_relinquish_vote(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
 
     let governance_info = next_account_info(account_info_iter)?; // 0
@@ -30,21 +30,24 @@ pub fn process_relinquish_vote(_program_id: &Pubkey, accounts: &[AccountInfo]) -
     let vote_record_info = next_account_info(account_info_iter)?; // 3
     let governing_token_mint_info = next_account_info(account_info_iter)?; // 4
 
-    let governance_data = get_governance_data(governance_info)?;
+    let governance_data = get_governance_data(program_id, governance_info)?;
 
     let mut proposal_data = get_proposal_data_for_governance_and_governing_mint(
+        program_id,
         &proposal_info,
         governance_info.key,
         governing_token_mint_info.key,
     )?;
 
     let mut token_owner_record_data = get_token_owner_record_data_for_realm_and_governing_mint(
+        program_id,
         &token_owner_record_info,
         &governance_data.config.realm,
         governing_token_mint_info.key,
     )?;
 
     let mut vote_record_data = get_vote_record_data_for_proposal_and_token_owner(
+        program_id,
         vote_record_info,
         proposal_info.key,
         &token_owner_record_data.governing_token_owner,

--- a/governance/program/src/processor/process_remove_instruction.rs
+++ b/governance/program/src/processor/process_remove_instruction.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 /// Processes RemoveInstruction instruction
-pub fn process_remove_instruction(_program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
+pub fn process_remove_instruction(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
 
     let proposal_info = next_account_info(account_info_iter)?; // 0
@@ -28,17 +28,22 @@ pub fn process_remove_instruction(_program_id: &Pubkey, accounts: &[AccountInfo]
 
     let beneficiary_info = next_account_info(account_info_iter)?; // 4
 
-    let mut proposal_data = get_proposal_data(&proposal_info)?;
+    let mut proposal_data = get_proposal_data(program_id, proposal_info)?;
     proposal_data.assert_can_edit_instructions()?;
 
     let token_owner_record_data = get_token_owner_record_data_for_proposal_owner(
+        program_id,
         token_owner_record_info,
         &proposal_data.token_owner_record,
     )?;
 
     token_owner_record_data.assert_token_owner_or_delegate_is_signer(governance_authority_info)?;
 
-    assert_proposal_instruction_for_proposal(proposal_instruction_info, proposal_info.key)?;
+    assert_proposal_instruction_for_proposal(
+        program_id,
+        proposal_instruction_info,
+        proposal_info.key,
+    )?;
 
     dispose_account(proposal_instruction_info, beneficiary_info);
 

--- a/governance/program/src/processor/process_remove_signatory.rs
+++ b/governance/program/src/processor/process_remove_signatory.rs
@@ -17,7 +17,7 @@ use crate::{
 
 /// Processes RemoveSignatory instruction
 pub fn process_remove_signatory(
-    _program_id: &Pubkey,
+    program_id: &Pubkey,
     accounts: &[AccountInfo],
     signatory: Pubkey,
 ) -> ProgramResult {
@@ -30,18 +30,23 @@ pub fn process_remove_signatory(
     let signatory_record_info = next_account_info(account_info_iter)?; // 3
     let beneficiary_info = next_account_info(account_info_iter)?; // 4
 
-    let mut proposal_data = get_proposal_data(proposal_info)?;
+    let mut proposal_data = get_proposal_data(program_id, proposal_info)?;
     proposal_data.assert_can_edit_signatories()?;
 
     let token_owner_record_data = get_token_owner_record_data_for_proposal_owner(
+        program_id,
         token_owner_record_info,
         &proposal_data.token_owner_record,
     )?;
 
     token_owner_record_data.assert_token_owner_or_delegate_is_signer(governance_authority_info)?;
 
-    let signatory_record_data =
-        get_signatory_record_data_for_seeds(signatory_record_info, proposal_info.key, &signatory)?;
+    let signatory_record_data = get_signatory_record_data_for_seeds(
+        program_id,
+        signatory_record_info,
+        proposal_info.key,
+        &signatory,
+    )?;
     signatory_record_data.assert_can_remove_signatory()?;
 
     proposal_data.signatories_count = proposal_data.signatories_count.checked_sub(1).unwrap();

--- a/governance/program/src/processor/process_set_governance_delegate.rs
+++ b/governance/program/src/processor/process_set_governance_delegate.rs
@@ -11,6 +11,7 @@ use crate::state::token_owner_record::get_token_owner_record_data;
 
 /// Processes SetGovernanceDelegate instruction
 pub fn process_set_governance_delegate(
+    program_id: &Pubkey,
     accounts: &[AccountInfo],
     new_governance_delegate: &Option<Pubkey>,
 ) -> ProgramResult {
@@ -19,7 +20,8 @@ pub fn process_set_governance_delegate(
     let governance_authority_info = next_account_info(account_info_iter)?; // 0
     let token_owner_record_info = next_account_info(account_info_iter)?; // 1
 
-    let mut token_owner_record_data = get_token_owner_record_data(token_owner_record_info)?;
+    let mut token_owner_record_data =
+        get_token_owner_record_data(program_id, token_owner_record_info)?;
 
     token_owner_record_data.assert_token_owner_or_delegate_is_signer(&governance_authority_info)?;
 

--- a/governance/program/src/processor/process_sign_off_proposal.rs
+++ b/governance/program/src/processor/process_sign_off_proposal.rs
@@ -15,7 +15,7 @@ use crate::state::{
 };
 
 /// Processes SignOffProposal instruction
-pub fn process_sign_off_proposal(_program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
+pub fn process_sign_off_proposal(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
 
     let proposal_info = next_account_info(account_info_iter)?; // 0
@@ -26,10 +26,11 @@ pub fn process_sign_off_proposal(_program_id: &Pubkey, accounts: &[AccountInfo])
     let clock_info = next_account_info(account_info_iter)?; // 3
     let clock = Clock::from_account_info(clock_info)?;
 
-    let mut proposal_data = get_proposal_data(proposal_info)?;
+    let mut proposal_data = get_proposal_data(program_id, proposal_info)?;
     proposal_data.assert_can_sign_off()?;
 
     let mut signatory_record_data = get_signatory_record_data_for_seeds(
+        program_id,
         signatory_record_info,
         proposal_info.key,
         signatory_info.key,

--- a/governance/program/src/processor/process_withdraw_governing_tokens.rs
+++ b/governance/program/src/processor/process_withdraw_governing_tokens.rs
@@ -36,7 +36,7 @@ pub fn process_withdraw_governing_tokens(
         return Err(GovernanceError::GoverningTokenOwnerMustSign.into());
     }
 
-    let realm_data = get_realm_data(realm_info)?;
+    let realm_data = get_realm_data(program_id, realm_info)?;
     let governing_token_mint = get_spl_token_mint(governing_token_holding_info)?;
 
     let token_owner_record_address_seeds = get_token_owner_record_address_seeds(
@@ -46,6 +46,7 @@ pub fn process_withdraw_governing_tokens(
     );
 
     let mut token_owner_record_data = get_token_owner_record_data_for_seeds(
+        program_id,
         token_owner_record_info,
         &token_owner_record_address_seeds,
     )?;

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -1,8 +1,8 @@
 //! Governance Account
 
 use crate::{
-    error::GovernanceError, id, state::enums::GovernanceAccountType,
-    tools::account::get_account_data, tools::account::AccountMaxSize,
+    error::GovernanceError, state::enums::GovernanceAccountType, tools::account::get_account_data,
+    tools::account::AccountMaxSize,
 };
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use solana_program::{
@@ -81,8 +81,11 @@ impl Governance {
 }
 
 /// Deserializes account and checks owner program
-pub fn get_governance_data(governance_info: &AccountInfo) -> Result<Governance, ProgramError> {
-    get_account_data::<Governance>(governance_info, &id())
+pub fn get_governance_data(
+    program_id: &Pubkey,
+    governance_info: &AccountInfo,
+) -> Result<Governance, ProgramError> {
+    get_account_data::<Governance>(governance_info, program_id)
 }
 
 /// Returns ProgramGovernance PDA seeds
@@ -101,12 +104,13 @@ pub fn get_program_governance_address_seeds<'a>(
 
 /// Returns ProgramGovernance PDA address
 pub fn get_program_governance_address<'a>(
+    program_id: &Pubkey,
     realm: &'a Pubkey,
     governed_program: &'a Pubkey,
 ) -> Pubkey {
     Pubkey::find_program_address(
         &get_program_governance_address_seeds(realm, governed_program),
-        &id(),
+        program_id,
     )
     .0
 }
@@ -125,18 +129,20 @@ pub fn get_account_governance_address_seeds<'a>(
 
 /// Returns AccountGovernance PDA address
 pub fn get_account_governance_address<'a>(
+    program_id: &Pubkey,
     realm: &'a Pubkey,
     governed_account: &'a Pubkey,
 ) -> Pubkey {
     Pubkey::find_program_address(
         &get_account_governance_address_seeds(realm, governed_account),
-        &id(),
+        program_id,
     )
     .0
 }
 
 /// Validates governance config
 pub fn assert_is_valid_governance_config(
+    program_id: &Pubkey,
     governance_config: &GovernanceConfig,
     realm_info: &AccountInfo,
 ) -> Result<(), ProgramError> {
@@ -144,7 +150,7 @@ pub fn assert_is_valid_governance_config(
         return Err(GovernanceError::InvalidGovernanceConfig.into());
     }
 
-    assert_is_valid_realm(realm_info)?;
+    assert_is_valid_realm(program_id, realm_info)?;
 
     if governance_config.yes_vote_threshold_percentage < 1
         || governance_config.yes_vote_threshold_percentage > 100

--- a/governance/program/src/state/proposal_instruction.rs
+++ b/governance/program/src/state/proposal_instruction.rs
@@ -2,7 +2,6 @@
 
 use crate::{
     error::GovernanceError,
-    id,
     state::enums::GovernanceAccountType,
     tools::account::{get_account_data, AccountMaxSize},
     PROGRAM_AUTHORITY_SEED,
@@ -125,29 +124,33 @@ pub fn get_proposal_instruction_address_seeds<'a>(
 
 /// Returns ProposalInstruction PDA address
 pub fn get_proposal_instruction_address<'a>(
+    program_id: &Pubkey,
     proposal: &'a Pubkey,
     instruction_index_le_bytes: &'a [u8],
 ) -> Pubkey {
     Pubkey::find_program_address(
         &get_proposal_instruction_address_seeds(proposal, &instruction_index_le_bytes),
-        &id(),
+        program_id,
     )
     .0
 }
 
 /// Deserializes ProposalInstruction account and checks owner program
 pub fn get_proposal_instruction_data(
+    program_id: &Pubkey,
     proposal_instruction_info: &AccountInfo,
 ) -> Result<ProposalInstruction, ProgramError> {
-    get_account_data::<ProposalInstruction>(proposal_instruction_info, &id())
+    get_account_data::<ProposalInstruction>(proposal_instruction_info, program_id)
 }
 
 ///  Deserializes and returns ProposalInstruction account and checks it belongs to the given Proposal
 pub fn get_proposal_instruction_data_for_proposal(
+    program_id: &Pubkey,
     proposal_instruction_info: &AccountInfo,
     proposal: &Pubkey,
 ) -> Result<ProposalInstruction, ProgramError> {
-    let proposal_instruction_data = get_proposal_instruction_data(proposal_instruction_info)?;
+    let proposal_instruction_data =
+        get_proposal_instruction_data(program_id, proposal_instruction_info)?;
 
     if proposal_instruction_data.proposal != *proposal {
         return Err(GovernanceError::InvalidProposalForProposalInstruction.into());
@@ -158,10 +161,12 @@ pub fn get_proposal_instruction_data_for_proposal(
 
 ///  Deserializes ProposalInstruction account and checks it belongs to the given Proposal
 pub fn assert_proposal_instruction_for_proposal(
+    program_id: &Pubkey,
     proposal_instruction_info: &AccountInfo,
     proposal: &Pubkey,
 ) -> Result<(), ProgramError> {
-    get_proposal_instruction_data_for_proposal(proposal_instruction_info, proposal).map(|_| ())
+    get_proposal_instruction_data_for_proposal(program_id, proposal_instruction_info, proposal)
+        .map(|_| ())
 }
 
 #[cfg(test)]

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -8,7 +8,6 @@ use solana_program::{
 
 use crate::{
     error::GovernanceError,
-    id,
     tools::account::{assert_is_valid_account, get_account_data, AccountMaxSize},
     PROGRAM_AUTHORITY_SEED,
 };
@@ -60,13 +59,19 @@ impl Realm {
 }
 
 /// Checks whether realm account exists, is initialized and  owned by Governance program
-pub fn assert_is_valid_realm(realm_info: &AccountInfo) -> Result<(), ProgramError> {
-    assert_is_valid_account(realm_info, GovernanceAccountType::Realm, &id())
+pub fn assert_is_valid_realm(
+    program_id: &Pubkey,
+    realm_info: &AccountInfo,
+) -> Result<(), ProgramError> {
+    assert_is_valid_account(realm_info, GovernanceAccountType::Realm, program_id)
 }
 
 /// Deserializes account and checks owner program
-pub fn get_realm_data(realm_info: &AccountInfo) -> Result<Realm, ProgramError> {
-    get_account_data::<Realm>(realm_info, &id())
+pub fn get_realm_data(
+    program_id: &Pubkey,
+    realm_info: &AccountInfo,
+) -> Result<Realm, ProgramError> {
+    get_account_data::<Realm>(realm_info, program_id)
 }
 
 /// Returns Realm PDA seeds
@@ -75,8 +80,8 @@ pub fn get_realm_address_seeds(name: &str) -> [&[u8]; 2] {
 }
 
 /// Returns Realm PDA address
-pub fn get_realm_address(name: &str) -> Pubkey {
-    Pubkey::find_program_address(&get_realm_address_seeds(&name), &id()).0
+pub fn get_realm_address(program_id: &Pubkey, name: &str) -> Pubkey {
+    Pubkey::find_program_address(&get_realm_address_seeds(&name), program_id).0
 }
 
 /// Returns Realm Token Holding PDA seeds
@@ -93,12 +98,13 @@ pub fn get_governing_token_holding_address_seeds<'a>(
 
 /// Returns Realm Token Holding PDA address
 pub fn get_governing_token_holding_address(
+    program_id: &Pubkey,
     realm: &Pubkey,
     governing_token_mint: &Pubkey,
 ) -> Pubkey {
     Pubkey::find_program_address(
         &get_governing_token_holding_address_seeds(realm, governing_token_mint),
-        &id(),
+        program_id,
     )
     .0
 }

--- a/governance/program/src/state/signatory_record.rs
+++ b/governance/program/src/state/signatory_record.rs
@@ -8,7 +8,6 @@ use solana_program::{
 
 use crate::{
     error::GovernanceError,
-    id,
     tools::account::{get_account_data, AccountMaxSize},
     PROGRAM_AUTHORITY_SEED,
 };
@@ -74,35 +73,41 @@ pub fn get_signatory_record_address_seeds<'a>(
 }
 
 /// Returns SignatoryRecord PDA address
-pub fn get_signatory_record_address<'a>(proposal: &'a Pubkey, signatory: &'a Pubkey) -> Pubkey {
+pub fn get_signatory_record_address<'a>(
+    program_id: &Pubkey,
+    proposal: &'a Pubkey,
+    signatory: &'a Pubkey,
+) -> Pubkey {
     Pubkey::find_program_address(
         &get_signatory_record_address_seeds(proposal, signatory),
-        &id(),
+        program_id,
     )
     .0
 }
 
 /// Deserializes SignatoryRecord account and checks owner program
 pub fn get_signatory_record_data(
+    program_id: &Pubkey,
     signatory_record_info: &AccountInfo,
 ) -> Result<SignatoryRecord, ProgramError> {
-    get_account_data::<SignatoryRecord>(signatory_record_info, &id())
+    get_account_data::<SignatoryRecord>(signatory_record_info, program_id)
 }
 
 /// Deserializes SignatoryRecord  and validates its PDA
 pub fn get_signatory_record_data_for_seeds(
+    program_id: &Pubkey,
     signatory_record_info: &AccountInfo,
     proposal: &Pubkey,
     signatory: &Pubkey,
 ) -> Result<SignatoryRecord, ProgramError> {
     let (signatory_record_address, _) = Pubkey::find_program_address(
         &get_signatory_record_address_seeds(proposal, signatory),
-        &id(),
+        program_id,
     );
 
     if signatory_record_address != *signatory_record_info.key {
         return Err(GovernanceError::InvalidSignatoryAddress.into());
     }
 
-    get_signatory_record_data(signatory_record_info)
+    get_signatory_record_data(program_id, signatory_record_info)
 }

--- a/governance/program/src/state/vote_record.rs
+++ b/governance/program/src/state/vote_record.rs
@@ -7,7 +7,7 @@ use solana_program::{program_pack::IsInitialized, pubkey::Pubkey};
 
 use crate::error::GovernanceError;
 use crate::tools::account::get_account_data;
-use crate::{id, tools::account::AccountMaxSize, PROGRAM_AUTHORITY_SEED};
+use crate::{tools::account::AccountMaxSize, PROGRAM_AUTHORITY_SEED};
 
 use crate::state::enums::{GovernanceAccountType, VoteWeight};
 
@@ -51,17 +51,21 @@ impl VoteRecord {
 }
 
 /// Deserializes VoteRecord account and checks owner program
-pub fn get_vote_record_data(vote_record_info: &AccountInfo) -> Result<VoteRecord, ProgramError> {
-    get_account_data::<VoteRecord>(vote_record_info, &id())
+pub fn get_vote_record_data(
+    program_id: &Pubkey,
+    vote_record_info: &AccountInfo,
+) -> Result<VoteRecord, ProgramError> {
+    get_account_data::<VoteRecord>(vote_record_info, program_id)
 }
 
 /// Deserializes VoteRecord and checks it belongs to the provided Proposal and Governing Token Owner
 pub fn get_vote_record_data_for_proposal_and_token_owner(
+    program_id: &Pubkey,
     vote_record_info: &AccountInfo,
     proposal: &Pubkey,
     governing_token_owner: &Pubkey,
 ) -> Result<VoteRecord, ProgramError> {
-    let vote_record_data = get_vote_record_data(vote_record_info)?;
+    let vote_record_data = get_vote_record_data(program_id, vote_record_info)?;
 
     if vote_record_data.proposal != *proposal {
         return Err(GovernanceError::InvalidProposalForVoterRecord.into());
@@ -87,10 +91,14 @@ pub fn get_vote_record_address_seeds<'a>(
 }
 
 /// Returns VoteRecord PDA address
-pub fn get_vote_record_address<'a>(proposal: &'a Pubkey, token_owner_record: &'a Pubkey) -> Pubkey {
+pub fn get_vote_record_address<'a>(
+    program_id: &Pubkey,
+    proposal: &'a Pubkey,
+    token_owner_record: &'a Pubkey,
+) -> Pubkey {
     Pubkey::find_program_address(
         &get_vote_record_address_seeds(proposal, token_owner_record),
-        &id(),
+        program_id,
     )
     .0
 }

--- a/governance/program/tests/process_deposit_governing_tokens.rs
+++ b/governance/program/tests/process_deposit_governing_tokens.rs
@@ -204,6 +204,7 @@ async fn test_deposit_initial_community_tokens_with_owner_must_sign_error() {
         .await;
 
     let mut instruction = deposit_governing_tokens(
+        &governance_test.program_id,
         &realm_cookie.address,
         &token_source.pubkey(),
         &token_owner.pubkey(),
@@ -249,6 +250,7 @@ async fn test_deposit_initial_community_tokens_with_invalid_owner_error() {
         .await;
 
     let instruction = deposit_governing_tokens(
+        &governance_test.program_id,
         &realm_cookie.address,
         &token_source.pubkey(),
         &invalid_owner.pubkey(),

--- a/governance/program/tests/process_set_governance_delegate.rs
+++ b/governance/program/tests/process_set_governance_delegate.rs
@@ -103,6 +103,7 @@ async fn test_set_community_governance_delegate_with_owner_must_sign_error() {
     let hacker_governance_delegate = Keypair::new();
 
     let mut instruction = set_governance_delegate(
+        &governance_test.program_id,
         &token_owner_record_cookie.token_owner.pubkey(),
         &realm_cookie.address,
         &realm_cookie.account.community_mint,

--- a/governance/program/tests/process_withdraw_governing_tokens.rs
+++ b/governance/program/tests/process_withdraw_governing_tokens.rs
@@ -104,6 +104,7 @@ async fn test_withdraw_community_tokens_with_owner_must_sign_error() {
     let hacker_token_destination = Pubkey::new_unique();
 
     let mut instruction = withdraw_governing_tokens(
+        &governance_test.program_id,
         &realm_cookie.address,
         &hacker_token_destination,
         &token_owner_record_cookie.token_owner.pubkey(),
@@ -136,6 +137,7 @@ async fn test_withdraw_community_tokens_with_token_owner_record_address_mismatch
         .await;
 
     let vote_record_address = get_token_owner_record_address(
+        &governance_test.program_id,
         &realm_cookie.address,
         &realm_cookie.account.community_mint,
         &token_owner_record_cookie.token_owner.pubkey(),
@@ -146,6 +148,7 @@ async fn test_withdraw_community_tokens_with_token_owner_record_address_mismatch
         .await;
 
     let mut instruction = withdraw_governing_tokens(
+        &governance_test.program_id,
         &realm_cookie.address,
         &hacker_record_cookie.token_source,
         &hacker_record_cookie.token_owner.pubkey(),

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1,4 +1,4 @@
-use std::borrow::Borrow;
+use std::{borrow::Borrow, str::FromStr};
 
 use borsh::BorshDeserialize;
 use solana_program::{
@@ -67,13 +67,16 @@ pub struct GovernanceProgramTest {
     pub context: ProgramTestContext,
     pub rent: Rent,
     pub next_realm_id: u8,
+    pub program_id: Pubkey,
 }
 
 impl GovernanceProgramTest {
     pub async fn start_new() -> Self {
+        let program_id =  Pubkey::from_str("Governance111111111111111111111111111111111").unwrap();
+
         let program_test = ProgramTest::new(
             "spl_governance",
-            spl_governance::id(),
+            program_id.clone(),
             processor!(process_instruction),
         );
 
@@ -84,6 +87,7 @@ impl GovernanceProgramTest {
             context,
             rent,
             next_realm_id: 0,
+            program_id,
         }
     }
 
@@ -124,12 +128,13 @@ impl GovernanceProgramTest {
         let name = format!("Realm #{}", self.next_realm_id).to_string();
         self.next_realm_id = self.next_realm_id + 1;
 
-        let realm_address = get_realm_address(&name);
+        let realm_address = get_realm_address(&self.program_id, &name);
 
         let community_token_mint_keypair = Keypair::new();
         let community_token_mint_authority = Keypair::new();
 
         let community_token_holding_address = get_governing_token_holding_address(
+            &self.program_id,
             &realm_address,
             &community_token_mint_keypair.pubkey(),
         );
@@ -144,6 +149,7 @@ impl GovernanceProgramTest {
         let council_token_mint_authority = Keypair::new();
 
         let council_token_holding_address = get_governing_token_holding_address(
+            &self.program_id,
             &realm_address,
             &council_token_mint_keypair.pubkey(),
         );
@@ -155,6 +161,7 @@ impl GovernanceProgramTest {
         .await;
 
         let create_realm_instruction = create_realm(
+            &self.program_id,
             &community_token_mint_keypair.pubkey(),
             &self.context.payer.pubkey(),
             Some(council_token_mint_keypair.pubkey()),
@@ -189,10 +196,11 @@ impl GovernanceProgramTest {
         let name = format!("Realm #{}", self.next_realm_id).to_string();
         self.next_realm_id = self.next_realm_id + 1;
 
-        let realm_address = get_realm_address(&name);
+        let realm_address = get_realm_address(&self.program_id, &name);
         let council_mint = realm_cookie.account.council_mint.unwrap();
 
         let create_realm_instruction = create_realm(
+            &self.program_id,
             &realm_cookie.account.community_mint,
             &self.context.payer.pubkey(),
             Some(council_mint),
@@ -211,12 +219,13 @@ impl GovernanceProgramTest {
         };
 
         let community_token_holding_address = get_governing_token_holding_address(
+            &self.program_id,
             &realm_address,
             &realm_cookie.account.community_mint,
         );
 
         let council_token_holding_address =
-            get_governing_token_holding_address(&realm_address, &council_mint);
+            get_governing_token_holding_address(&self.program_id, &realm_address, &council_mint);
 
         RealmCookie {
             address: realm_address,
@@ -333,6 +342,7 @@ impl GovernanceProgramTest {
         .await;
 
         let deposit_governing_tokens_instruction = deposit_governing_tokens(
+            &self.program_id,
             realm_address,
             &token_source.pubkey(),
             &token_owner.pubkey(),
@@ -348,8 +358,12 @@ impl GovernanceProgramTest {
         .await
         .unwrap();
 
-        let token_owner_record_address =
-            get_token_owner_record_address(realm_address, &governing_mint, &token_owner.pubkey());
+        let token_owner_record_address = get_token_owner_record_address(
+            &self.program_id,
+            realm_address,
+            &governing_mint,
+            &token_owner.pubkey(),
+        );
 
         let account = TokenOwnerRecord {
             account_type: GovernanceAccountType::TokenOwnerRecord,
@@ -414,6 +428,7 @@ impl GovernanceProgramTest {
         .await;
 
         let deposit_governing_tokens_instruction = deposit_governing_tokens(
+            &self.program_id,
             realm,
             &token_owner_record_cookie.token_source,
             &token_owner_record_cookie.token_owner.pubkey(),
@@ -489,6 +504,7 @@ impl GovernanceProgramTest {
         new_governance_delegate: &Option<Pubkey>,
     ) {
         let set_governance_delegate_instruction = set_governance_delegate(
+            &self.program_id,
             &signing_governance_authority.pubkey(),
             &realm_cookie.address,
             governing_token_mint,
@@ -544,6 +560,7 @@ impl GovernanceProgramTest {
         governing_token_owner: &Keypair,
     ) -> Result<(), ProgramError> {
         let deposit_governing_tokens_instruction = withdraw_governing_tokens(
+            &self.program_id,
             &realm_cookie.address,
             &token_owner_record_cookie.token_source,
             &governing_token_owner.pubkey(),
@@ -597,8 +614,11 @@ impl GovernanceProgramTest {
         governed_account_cookie: &GovernedAccountCookie,
         governance_config: &GovernanceConfig,
     ) -> Result<GovernanceCookie, ProgramError> {
-        let create_account_governance_instruction =
-            create_account_governance(&self.context.payer.pubkey(), governance_config.clone());
+        let create_account_governance_instruction = create_account_governance(
+            &self.program_id,
+            &self.context.payer.pubkey(),
+            governance_config.clone(),
+        );
 
         let account = Governance {
             account_type: GovernanceAccountType::AccountGovernance,
@@ -609,8 +629,11 @@ impl GovernanceProgramTest {
         self.process_transaction(&[create_account_governance_instruction], None)
             .await?;
 
-        let account_governance_address =
-            get_account_governance_address(&realm_cookie.address, &governed_account_cookie.address);
+        let account_governance_address = get_account_governance_address(
+            &self.program_id,
+            &realm_cookie.address,
+            &governed_account_cookie.address,
+        );
 
         Ok(GovernanceCookie {
             address: account_governance_address,
@@ -723,6 +746,7 @@ impl GovernanceProgramTest {
         };
 
         let mut create_program_governance_instruction = create_program_governance(
+            &self.program_id,
             &governed_program_cookie.upgrade_authority.pubkey(),
             &self.context.payer.pubkey(),
             config.clone(),
@@ -743,8 +767,11 @@ impl GovernanceProgramTest {
             proposals_count: 0,
         };
 
-        let program_governance_address =
-            get_program_governance_address(&realm_cookie.address, &governed_program_cookie.address);
+        let program_governance_address = get_program_governance_address(
+            &self.program_id,
+            &realm_cookie.address,
+            &governed_program_cookie.address,
+        );
 
         Ok(GovernanceCookie {
             address: program_governance_address,
@@ -804,6 +831,7 @@ impl GovernanceProgramTest {
         let governance_authority = token_owner_record_cookie.get_governance_authority();
 
         let mut create_proposal_instruction = create_proposal(
+            &self.program_id,
             &governance_cookie.address,
             &token_owner_record_cookie.token_owner.pubkey(),
             &governance_authority.pubkey(),
@@ -848,6 +876,7 @@ impl GovernanceProgramTest {
         };
 
         let proposal_address = get_proposal_address(
+            &self.program_id,
             &governance_cookie.address,
             &token_owner_record_cookie.account.governing_token_mint,
             &proposal_index.to_le_bytes(),
@@ -869,6 +898,7 @@ impl GovernanceProgramTest {
         let signatory = Keypair::new();
 
         let add_signatory_instruction = add_signatory(
+            &self.program_id,
             &proposal_cookie.address,
             &token_owner_record_cookie.address,
             &token_owner_record_cookie.token_owner.pubkey(),
@@ -882,8 +912,11 @@ impl GovernanceProgramTest {
         )
         .await?;
 
-        let signatory_record_address =
-            get_signatory_record_address(&proposal_cookie.address, &signatory.pubkey());
+        let signatory_record_address = get_signatory_record_address(
+            &self.program_id,
+            &proposal_cookie.address,
+            &signatory.pubkey(),
+        );
 
         let signatory_record_data = SignatoryRecord {
             account_type: GovernanceAccountType::SignatoryRecord,
@@ -909,6 +942,7 @@ impl GovernanceProgramTest {
         signatory_record_cookie: &SignatoryRecordCookie,
     ) -> Result<(), ProgramError> {
         let remove_signatory_instruction = remove_signatory(
+            &self.program_id,
             &proposal_cookie.address,
             &token_owner_record_cookie.address,
             &token_owner_record_cookie.token_owner.pubkey(),
@@ -932,6 +966,7 @@ impl GovernanceProgramTest {
         signatory_record_cookie: &SignatoryRecordCookie,
     ) -> Result<(), ProgramError> {
         let sign_off_proposal_instruction = sign_off_proposal(
+            &self.program_id,
             &proposal_cookie.address,
             &signatory_record_cookie.signatory.pubkey(),
         );
@@ -951,6 +986,7 @@ impl GovernanceProgramTest {
         proposal_cookie: &ProposalCookie,
     ) -> Result<(), ProgramError> {
         let finalize_vote_instruction = finalize_vote(
+            &self.program_id,
             &proposal_cookie.account.governance,
             &proposal_cookie.address,
             &proposal_cookie.account.governing_token_mint,
@@ -984,6 +1020,7 @@ impl GovernanceProgramTest {
         instruction_override: F,
     ) -> Result<(), ProgramError> {
         let mut relinquish_vote_instruction = relinquish_vote(
+            &self.program_id,
             &proposal_cookie.account.governance,
             &proposal_cookie.address,
             &token_owner_record_cookie.address,
@@ -1010,6 +1047,7 @@ impl GovernanceProgramTest {
         token_owner_record_cookie: &TokeOwnerRecordCookie,
     ) -> Result<(), ProgramError> {
         let cancel_proposal_instruction = cancel_proposal(
+            &self.program_id,
             &proposal_cookie.address,
             &token_owner_record_cookie.address,
             &token_owner_record_cookie.token_owner.pubkey(),
@@ -1032,6 +1070,7 @@ impl GovernanceProgramTest {
         vote: Vote,
     ) -> Result<VoteRecordCookie, ProgramError> {
         let vote_instruction = cast_vote(
+            &self.program_id,
             &proposal_cookie.account.governance,
             &proposal_cookie.address,
             &token_owner_record_cookie.address,
@@ -1066,6 +1105,7 @@ impl GovernanceProgramTest {
 
         let vote_record_cookie = VoteRecordCookie {
             address: get_vote_record_address(
+                &self.program_id,
                 &proposal_cookie.address,
                 &token_owner_record_cookie.address,
             ),
@@ -1225,6 +1265,7 @@ impl GovernanceProgramTest {
             proposal_cookie.account.instructions_next_index + 1;
 
         let insert_instruction_instruction = insert_instruction(
+            &self.program_id,
             &proposal_cookie.account.governance,
             &proposal_cookie.address,
             &token_owner_record_cookie.address,
@@ -1241,8 +1282,11 @@ impl GovernanceProgramTest {
         )
         .await?;
 
-        let proposal_instruction_address =
-            get_proposal_instruction_address(&proposal_cookie.address, &index.to_le_bytes());
+        let proposal_instruction_address = get_proposal_instruction_address(
+            &self.program_id,
+            &proposal_cookie.address,
+            &index.to_le_bytes(),
+        );
 
         let proposal_instruction_data = ProposalInstruction {
             account_type: GovernanceAccountType::ProposalInstruction,
@@ -1279,6 +1323,7 @@ impl GovernanceProgramTest {
         proposal_instruction_cookie: &ProposalInstructionCookie,
     ) -> Result<(), ProgramError> {
         let remove_instruction_instruction = remove_instruction(
+            &self.program_id,
             &proposal_cookie.address,
             &token_owner_record_cookie.address,
             &token_owner_record_cookie.token_owner.pubkey(),
@@ -1302,6 +1347,7 @@ impl GovernanceProgramTest {
         proposal_instruction_cookie: &ProposalInstructionCookie,
     ) -> Result<(), ProgramError> {
         let execute_instruction_instruction = execute_instruction(
+            &self.program_id,
             &proposal_cookie.account.governance,
             &proposal_cookie.address,
             &proposal_instruction_cookie.address,

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -72,7 +72,7 @@ pub struct GovernanceProgramTest {
 
 impl GovernanceProgramTest {
     pub async fn start_new() -> Self {
-        let program_id =  Pubkey::from_str("Governance111111111111111111111111111111111").unwrap();
+        let program_id = Pubkey::from_str("Governance111111111111111111111111111111111").unwrap();
 
         let program_test = ProgramTest::new(
             "spl_governance",


### PR DESCRIPTION
### Summary 

Remove static program_id to support runtime clones of the program 

