### PR TITLE
stake-pool: Add lockup support

### DIFF
--- a/stake-pool/program/src/error.rs
+++ b/stake-pool/program/src/error.rs
@@ -96,6 +96,9 @@ pub enum StakePoolError {
     /// The provided withdraw stake account is not the preferred deposit vote account
     #[error("IncorrectWithdrawVoteAddress")]
     IncorrectWithdrawVoteAddress,
+    /// The lockup on the provided stake does not match the pool lockup
+    #[error("IncorrectLockup")]
+    IncorrectLockup,
 }
 impl From<StakePoolError> for ProgramError {
     fn from(e: StakePoolError) -> Self {

--- a/stake-pool/program/src/instruction.rs
+++ b/stake-pool/program/src/instruction.rs
@@ -97,6 +97,7 @@ pub enum StakePoolInstruction {
     ///   5. `[]` Clock sysvar
     ///   6. '[]' Sysvar stake history account
     ///   7. `[]` Stake program
+    ///   8. `[s]` (Optional) Lockup custodian, if stake pool has a lockup
     AddValidatorToPool,
 
     ///   (Staker only) Removes validator from the pool
@@ -113,6 +114,7 @@ pub enum StakePoolInstruction {
     ///   6. `[]` Transient stake account, to check that that we're not trying to activate
     ///   7. '[]' Sysvar clock
     ///   8. `[]` Stake program id,
+    ///   9. `[s]` (Optional) Lockup custodian, if stake pool has a lockup
     RemoveValidatorFromPool,
 
     /// (Staker only) Decrease active stake on a validator, eventually moving it to the reserve
@@ -245,6 +247,7 @@ pub enum StakePoolInstruction {
     ///   10. '[]' Sysvar stake history account
     ///   11. `[]` Pool token program id,
     ///   12. `[]` Stake program id,
+    ///   13. `[s]` (Optional) Lockup custodian, if stake pool has a lockup
     Deposit,
 
     ///   Withdraw the token from the pool at the current ratio.
@@ -269,6 +272,7 @@ pub enum StakePoolInstruction {
     ///   9. `[]` Sysvar clock account (required)
     ///  10. `[]` Pool token program id
     ///  11. `[]` Stake program id,
+    ///  12. `[s]` (Optional) Lockup custodian, if stake pool has a lockup
     ///  userdata: amount of pool tokens to withdraw
     Withdraw(u64),
 

--- a/stake-pool/program/tests/update_validator_list_balance.rs
+++ b/stake-pool/program/tests/update_validator_list_balance.rs
@@ -60,6 +60,7 @@ async fn setup(
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
+            &stake_pool_accounts.lockup,
         )
         .await;
 
@@ -87,6 +88,7 @@ async fn setup(
                 &mut context.banks_client,
                 &context.payer,
                 &context.last_blockhash,
+                &stake_pool_accounts.lockup,
             )
             .await;
 

--- a/stake-pool/program/tests/vsa_create.rs
+++ b/stake-pool/program/tests/vsa_create.rs
@@ -266,13 +266,13 @@ async fn fail_with_incorrect_address() {
 #[tokio::test]
 async fn success_with_lockup() {
     let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
-    let deposit_authority = Keypair::new();
+    let custodian = Keypair::new();
     let lockup = stake_program::Lockup {
-        custodian: deposit_authority.pubkey(),
+        custodian: custodian.pubkey(),
         epoch: 100,
         unix_timestamp: 100_000_000,
     };
-    let stake_pool_accounts = StakePoolAccounts::new_with_lockup(lockup, deposit_authority);
+    let stake_pool_accounts = StakePoolAccounts::new_with_lockup(lockup, custodian);
     stake_pool_accounts
         .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash, 1)
         .await


### PR DESCRIPTION
#### Problem

Stake pools don't support lockups.

#### Solution

Add lockup support!  The main idea is to add the lockup inside of the stake pool itself and then add the custodian as an optional signer for the required instructions.  Since the custodian needs to sign any changes of the stake account withdraw authority, that means we need to add the custodian to:
* add validator to pool
* remove validator from pool
* deposit
* withdraw

This also adds CLI support, mimicking how the main solana CLI does lockups