### PR TITLE
stake-pool: Fail initializing if mint has a freeze authority

### DIFF
--- a/stake-pool/program/src/error.rs
+++ b/stake-pool/program/src/error.rs
@@ -96,6 +96,9 @@ pub enum StakePoolError {
     /// The provided withdraw stake account is not the preferred deposit vote account
     #[error("IncorrectWithdrawVoteAddress")]
     IncorrectWithdrawVoteAddress,
+    /// The mint has an invalid freeze authority
+    #[error("InvalidMintFreezeAuthority")]
+    InvalidMintFreezeAuthority,
 }
 impl From<StakePoolError> for ProgramError {
     fn from(e: StakePoolError) -> Self {

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -488,6 +488,10 @@ impl Processor {
             return Err(StakePoolError::WrongMintingAuthority.into());
         }
 
+        if pool_mint.freeze_authority.is_some() {
+            return Err(StakePoolError::InvalidMintFreezeAuthority.into());
+        }
+
         if *reserve_stake_info.owner != stake_program::id() {
             msg!("Reserve stake account not owned by stake program");
             return Err(ProgramError::IncorrectProgramId);
@@ -2099,6 +2103,7 @@ impl PrintProgramError for StakePoolError {
             StakePoolError::StakeLamportsNotEqualToMinimum => msg!("Error: The lamports in the validator stake account is not equal to the minimum"),
             StakePoolError::IncorrectDepositVoteAddress => msg!("Error: The provided deposit stake account is not delegated to the preferred deposit vote account"),
             StakePoolError::IncorrectWithdrawVoteAddress => msg!("Error: The provided withdraw stake account is not the preferred deposit vote account"),
+            StakePoolError::InvalidMintFreezeAuthority => msg!("Error: The mint has an invalid freeze authority"),
         }
     }
 }


### PR DESCRIPTION
#### Problem

It's possible to pass a mint with a freeze authority to a stake pool.

#### Solution

Don't allow it.