### PR TITLE
stake-pool: Split transient stake account creation

### DIFF
--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -132,6 +132,30 @@ fn check_account_owner(
     }
 }
 
+/// Create a transient stake account without transferring lamports
+fn create_transient_stake_account<'a>(
+    transient_stake_account_info: AccountInfo<'a>,
+    transient_stake_account_signer_seeds: &[&[u8]],
+    system_program_info: AccountInfo<'a>,
+) -> Result<(), ProgramError> {
+    invoke_signed(
+        &system_instruction::allocate(
+            transient_stake_account_info.key,
+            std::mem::size_of::<stake_program::StakeState>() as u64,
+        ),
+        &[
+            transient_stake_account_info.clone(),
+            system_program_info.clone(),
+        ],
+        &[&transient_stake_account_signer_seeds],
+    )?;
+    invoke_signed(
+        &system_instruction::assign(transient_stake_account_info.key, &stake_program::id()),
+        &[transient_stake_account_info, system_program_info],
+        &[&transient_stake_account_signer_seeds],
+    )
+}
+
 /// Program state handler.
 pub struct Processor {}
 impl Processor {
@@ -966,17 +990,10 @@ impl Processor {
             return Err(ProgramError::AccountNotRentExempt);
         }
 
-        // create transient stake account
-        invoke_signed(
-            &system_instruction::create_account(
-                &transient_stake_account_info.key, // doesn't matter since no lamports are transferred
-                &transient_stake_account_info.key,
-                0,
-                std::mem::size_of::<stake_program::StakeState>() as u64,
-                &stake_program::id(),
-            ),
-            &[transient_stake_account_info.clone()],
-            &[&transient_stake_account_signer_seeds],
+        create_transient_stake_account(
+            transient_stake_account_info.clone(),
+            &transient_stake_account_signer_seeds,
+            system_program_info.clone(),
         )?;
 
         // split into transient stake account
@@ -1120,17 +1137,10 @@ impl Processor {
             return Err(ProgramError::InsufficientFunds);
         }
 
-        // create transient stake account
-        invoke_signed(
-            &system_instruction::create_account(
-                &transient_stake_account_info.key, // doesn't matter since no lamports are transferred
-                &transient_stake_account_info.key,
-                0,
-                std::mem::size_of::<stake_program::StakeState>() as u64,
-                &stake_program::id(),
-            ),
-            &[transient_stake_account_info.clone()],
-            &[&transient_stake_account_signer_seeds],
+        create_transient_stake_account(
+            transient_stake_account_info.clone(),
+            &transient_stake_account_signer_seeds,
+            system_program_info.clone(),
         )?;
 
         // split into transient stake account


### PR DESCRIPTION
#### Problem

The runtime was updated in 1.7 to not allow 0-lamport account creation, creating an issue reported at https://github.com/solana-labs/solana-program-library/pull/1617#issuecomment-864482976

Stake pools still leans on 0-lamport account creation for transient stake accounts.

#### Solution

Don't do `create_account` with 0 lamports when working with transient stake accounts, and instead separate out allocate + assign.

cc @keemy