### PR TITLE
Governance: Create mint governance

### DIFF
--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -180,6 +180,18 @@ pub enum GovernanceError {
     #[error("Proposal does not belong to given Governing Mint")]
     InvalidGoverningMintForProposal,
 
+    /// Current mint authority must sign transaction
+    #[error("Current mint authority must sign transaction")]
+    MintAuthorityMustSign,
+
+    /// Invalid mint authority
+    #[error("Invalid mint authority")]
+    InvalidMintAuthority,
+
+    /// Mint has no authority
+    #[error("Mint has no authority")]
+    MintHasNoAuthority,
+
     /// ---- SPL Token Tools Errors ----
 
     /// Invalid Token account owner

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -218,6 +218,10 @@ pub enum GovernanceError {
     #[error("Token Mint account is not initialized")]
     SplTokenMintNotInitialized,
 
+    /// Token Mint account doesn't exist
+    #[error("Token Mint account doesn't exist")]
+    SplTokenMintDoesNotExist,
+
     /// ---- Bpf Upgradable Loader Tools Errors ----
 
     /// Invalid ProgramData account Address

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -168,6 +168,10 @@ pub enum GovernanceError {
     #[error("Invalid account owner")]
     InvalidAccountOwner,
 
+    /// Account doesn't exist
+    #[error("Account doesn't exist")]
+    AccountDoesNotExist,
+
     /// Invalid Account type
     #[error("Invalid Account type")]
     InvalidAccountType,
@@ -205,6 +209,10 @@ pub enum GovernanceError {
     /// Token Account is not initialized
     #[error("Token Account is not initialized")]
     SplTokenAccountNotInitialized,
+
+    /// Token Account doesn't exist
+    #[error("Token Account doesn't exist")]
+    SplTokenAccountDoesNotExist,
 
     /// Token account data is invalid
     #[error("Token account data is invalid")]

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -3,7 +3,8 @@
 use crate::{
     state::{
         governance::{
-            get_account_governance_address, get_program_governance_address, GovernanceConfig,
+            get_account_governance_address, get_mint_governance_address,
+            get_program_governance_address, GovernanceConfig,
         },
         proposal::get_proposal_address,
         proposal_instruction::{get_proposal_instruction_address, InstructionData},
@@ -126,10 +127,32 @@ pub enum GovernanceInstruction {
         config: GovernanceConfig,
 
         #[allow(dead_code)]
-        /// Indicate whether Program's upgrade_authority should be transferred to the Governance PDA
+        /// Indicates whether Program's upgrade_authority should be transferred to the Governance PDA
         /// If it's set to false then it can be done at a later time
         /// However the instruction would validate the current upgrade_authority signed the transaction nonetheless
         transfer_upgrade_authority: bool,
+    },
+
+    /// Creates Mint Governance account which governs a mint
+    ///
+    ///   0. `[]` Realm account the created Governance belongs to    
+    ///   1. `[writable]` Mint Governance account. PDA seeds: ['mint-governance', realm, governed_mint]
+    ///   2. `[writable]` Mint governed by this Governance account
+    ///   3. `[signer]` Current Mint Authority
+    ///   4. `[signer]` Payer
+    ///   5. `[]` SPL Token program
+    ///   6. `[]` System program
+    ///   7. `[]` Sysvar Rent
+    CreateMintGovernance {
+        /// Governance config
+        #[allow(dead_code)]
+        config: GovernanceConfig,
+
+        #[allow(dead_code)]
+        /// Indicates whether Mint's authority should be transferred to the Governance PDA
+        /// If it's set to false then it can be done at a later time
+        /// However the instruction would validate the current mint authority signed the transaction nonetheless
+        transfer_mint_authority: bool,
     },
 
     /// Creates Proposal account for Instructions that will be executed at various slots in the future
@@ -505,6 +528,42 @@ pub fn create_program_governance(
     let instruction = GovernanceInstruction::CreateProgramGovernance {
         config,
         transfer_upgrade_authority,
+    };
+
+    Instruction {
+        program_id: *program_id,
+        accounts,
+        data: instruction.try_to_vec().unwrap(),
+    }
+}
+
+/// Creates CreateMintGovernance instruction
+pub fn create_mint_governance(
+    program_id: &Pubkey,
+    // Accounts
+    governed_mint_authority: &Pubkey,
+    payer: &Pubkey,
+    // Args
+    config: GovernanceConfig,
+    transfer_mint_authority: bool,
+) -> Instruction {
+    let mint_governance_address =
+        get_mint_governance_address(program_id, &config.realm, &config.governed_account);
+
+    let accounts = vec![
+        AccountMeta::new_readonly(config.realm, false),
+        AccountMeta::new(mint_governance_address, false),
+        AccountMeta::new(config.governed_account, false),
+        AccountMeta::new_readonly(*governed_mint_authority, true),
+        AccountMeta::new_readonly(*payer, true),
+        AccountMeta::new_readonly(spl_token::id(), false),
+        AccountMeta::new_readonly(system_program::id(), false),
+        AccountMeta::new_readonly(sysvar::rent::id(), false),
+    ];
+
+    let instruction = GovernanceInstruction::CreateMintGovernance {
+        config,
+        transfer_mint_authority,
     };
 
     Instruction {

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -133,28 +133,6 @@ pub enum GovernanceInstruction {
         transfer_upgrade_authority: bool,
     },
 
-    /// Creates Mint Governance account which governs a mint
-    ///
-    ///   0. `[]` Realm account the created Governance belongs to    
-    ///   1. `[writable]` Mint Governance account. PDA seeds: ['mint-governance', realm, governed_mint]
-    ///   2. `[writable]` Mint governed by this Governance account
-    ///   3. `[signer]` Current Mint Authority
-    ///   4. `[signer]` Payer
-    ///   5. `[]` SPL Token program
-    ///   6. `[]` System program
-    ///   7. `[]` Sysvar Rent
-    CreateMintGovernance {
-        /// Governance config
-        #[allow(dead_code)]
-        config: GovernanceConfig,
-
-        #[allow(dead_code)]
-        /// Indicates whether Mint's authority should be transferred to the Governance PDA
-        /// If it's set to false then it can be done at a later time
-        /// However the instruction would validate the current mint authority signed the transaction nonetheless
-        transfer_mint_authority: bool,
-    },
-
     /// Creates Proposal account for Instructions that will be executed at various slots in the future
     ///
     ///   0. `[writable]` Proposal account. PDA seeds ['governance',governance, governing_token_mint, proposal_index]
@@ -313,6 +291,28 @@ pub enum GovernanceInstruction {
     ///   2. `[]` Clock sysvar
     ///   3+ Any extra accounts that are part of the instruction, in order
     ExecuteInstruction,
+
+    /// Creates Mint Governance account which governs a mint
+    ///
+    ///   0. `[]` Realm account the created Governance belongs to    
+    ///   1. `[writable]` Mint Governance account. PDA seeds: ['mint-governance', realm, governed_mint]
+    ///   2. `[writable]` Mint governed by this Governance account
+    ///   3. `[signer]` Current Mint Authority
+    ///   4. `[signer]` Payer
+    ///   5. `[]` SPL Token program
+    ///   6. `[]` System program
+    ///   7. `[]` Sysvar Rent
+    CreateMintGovernance {
+        #[allow(dead_code)]
+        /// Governance config
+        config: GovernanceConfig,
+
+        #[allow(dead_code)]
+        /// Indicates whether Mint's authority should be transferred to the Governance PDA
+        /// If it's set to false then it can be done at a later time
+        /// However the instruction would validate the current mint authority signed the transaction nonetheless
+        transfer_mint_authority: bool,
+    },
 }
 
 /// Creates CreateRealm instruction

--- a/governance/program/src/processor/mod.rs
+++ b/governance/program/src/processor/mod.rs
@@ -4,6 +4,7 @@ mod process_add_signatory;
 mod process_cancel_proposal;
 mod process_cast_vote;
 mod process_create_account_governance;
+mod process_create_mint_governance;
 mod process_create_program_governance;
 mod process_create_proposal;
 mod process_create_realm;
@@ -25,6 +26,7 @@ use process_add_signatory::*;
 use process_cancel_proposal::*;
 use process_cast_vote::*;
 use process_create_account_governance::*;
+use process_create_mint_governance::*;
 use process_create_program_governance::*;
 use process_create_proposal::*;
 use process_create_realm::*;
@@ -95,6 +97,11 @@ pub fn process_instruction(
             config,
             transfer_upgrade_authority,
         ),
+
+        GovernanceInstruction::CreateMintGovernance {
+            config,
+            transfer_mint_authority,
+        } => process_create_mint_governance(program_id, accounts, config, transfer_mint_authority),
 
         GovernanceInstruction::CreateAccountGovernance { config } => {
             process_create_account_governance(program_id, accounts, config)

--- a/governance/program/src/processor/process_create_mint_governance.rs
+++ b/governance/program/src/processor/process_create_mint_governance.rs
@@ -44,7 +44,7 @@ pub fn process_create_mint_governance(
     let rent_sysvar_info = next_account_info(account_info_iter)?; // 7
     let rent = &Rent::from_account_info(rent_sysvar_info)?;
 
-    assert_is_valid_governance_config(program_id, &config, &realm_info)?;
+    assert_is_valid_governance_config(program_id, &config, realm_info)?;
 
     let mint_governance_data = Governance {
         account_type: GovernanceAccountType::MintGovernance,
@@ -54,7 +54,7 @@ pub fn process_create_mint_governance(
 
     create_and_serialize_account_signed::<Governance>(
         payer_info,
-        &mint_governance_info,
+        mint_governance_info,
         &mint_governance_data,
         &get_mint_governance_address_seeds(&config.realm, &config.governed_account),
         program_id,
@@ -71,8 +71,8 @@ pub fn process_create_mint_governance(
         )?;
     } else {
         assert_spl_token_mint_authority_is_signer(
-            &governed_mint_info,
-            &governed_mint_authority_info,
+            governed_mint_info,
+            governed_mint_authority_info,
         )?;
     }
 

--- a/governance/program/src/processor/process_create_mint_governance.rs
+++ b/governance/program/src/processor/process_create_mint_governance.rs
@@ -1,0 +1,80 @@
+//! Program state processor
+
+use crate::{
+    state::{
+        enums::GovernanceAccountType,
+        governance::{
+            assert_is_valid_governance_config, get_mint_governance_address_seeds, Governance,
+            GovernanceConfig,
+        },
+    },
+    tools::{
+        account::create_and_serialize_account_signed,
+        spl_token::{assert_spl_token_mint_authority_is_signer, set_spl_token_mint_authority},
+    },
+};
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    entrypoint::ProgramResult,
+    pubkey::Pubkey,
+    rent::Rent,
+    sysvar::Sysvar,
+};
+
+/// Processes CreateMintGovernance instruction
+pub fn process_create_mint_governance(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    config: GovernanceConfig,
+    transfer_mint_authority: bool,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    let realm_info = next_account_info(account_info_iter)?; // 0
+    let mint_governance_info = next_account_info(account_info_iter)?; // 1
+
+    let governed_mint_info = next_account_info(account_info_iter)?; // 2
+    let governed_mint_authority_info = next_account_info(account_info_iter)?; // 3
+
+    let payer_info = next_account_info(account_info_iter)?; // 4
+    let spl_token_info = next_account_info(account_info_iter)?; // 5
+
+    let system_info = next_account_info(account_info_iter)?; // 6
+
+    let rent_sysvar_info = next_account_info(account_info_iter)?; // 7
+    let rent = &Rent::from_account_info(rent_sysvar_info)?;
+
+    assert_is_valid_governance_config(program_id, &config, &realm_info)?;
+
+    let mint_governance_data = Governance {
+        account_type: GovernanceAccountType::MintGovernance,
+        config: config.clone(),
+        proposals_count: 0,
+    };
+
+    create_and_serialize_account_signed::<Governance>(
+        payer_info,
+        &mint_governance_info,
+        &mint_governance_data,
+        &get_mint_governance_address_seeds(&config.realm, &config.governed_account),
+        program_id,
+        system_info,
+        rent,
+    )?;
+
+    if transfer_mint_authority {
+        set_spl_token_mint_authority(
+            governed_mint_info,
+            governed_mint_authority_info,
+            mint_governance_info.key,
+            spl_token_info,
+        )?;
+    } else {
+        assert_spl_token_mint_authority_is_signer(
+            &governed_mint_info,
+            &governed_mint_authority_info,
+        )?;
+    }
+
+    Ok(())
+}

--- a/governance/program/src/processor/process_create_program_governance.rs
+++ b/governance/program/src/processor/process_create_program_governance.rs
@@ -47,7 +47,7 @@ pub fn process_create_program_governance(
     let rent_sysvar_info = next_account_info(account_info_iter)?; // 6
     let rent = &Rent::from_account_info(rent_sysvar_info)?;
 
-    assert_is_valid_governance_config(program_id, &config, &realm_info)?;
+    assert_is_valid_governance_config(program_id, &config, realm_info)?;
 
     let program_governance_data = Governance {
         account_type: GovernanceAccountType::ProgramGovernance,
@@ -57,7 +57,7 @@ pub fn process_create_program_governance(
 
     create_and_serialize_account_signed::<Governance>(
         payer_info,
-        &program_governance_info,
+        program_governance_info,
         &program_governance_data,
         &get_program_governance_address_seeds(&config.realm, &config.governed_account),
         program_id,
@@ -76,8 +76,8 @@ pub fn process_create_program_governance(
     } else {
         assert_program_upgrade_authority_is_signer(
             &config.governed_account,
-            &governed_program_data_info,
-            &governed_program_upgrade_authority_info,
+            governed_program_data_info,
+            governed_program_upgrade_authority_info,
         )?;
     }
 

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -21,6 +21,9 @@ pub enum GovernanceAccountType {
     /// Program Governance account
     ProgramGovernance,
 
+    /// Mint Governance account
+    MintGovernance,
+
     /// Proposal account for Governance account. A single Governance account can have multiple Proposal accounts
     Proposal,
 

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -21,9 +21,6 @@ pub enum GovernanceAccountType {
     /// Program Governance account
     ProgramGovernance,
 
-    /// Mint Governance account
-    MintGovernance,
-
     /// Proposal account for Governance account. A single Governance account can have multiple Proposal accounts
     Proposal,
 
@@ -35,6 +32,9 @@ pub enum GovernanceAccountType {
 
     /// ProposalInstruction account which holds an instruction to execute for Proposal
     ProposalInstruction,
+
+    /// Mint Governance account
+    MintGovernance,
 }
 
 impl Default for GovernanceAccountType {

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -58,6 +58,7 @@ impl IsInitialized for Governance {
     fn is_initialized(&self) -> bool {
         self.account_type == GovernanceAccountType::AccountGovernance
             || self.account_type == GovernanceAccountType::ProgramGovernance
+            || self.account_type == GovernanceAccountType::MintGovernance
     }
 }
 
@@ -73,6 +74,9 @@ impl Governance {
                 &self.config.realm,
                 &self.config.governed_account,
             ),
+            GovernanceAccountType::MintGovernance => {
+                get_mint_governance_address_seeds(&self.config.realm, &self.config.governed_account)
+            }
             _ => return Err(GovernanceError::InvalidAccountType.into()),
         };
 
@@ -110,6 +114,29 @@ pub fn get_program_governance_address<'a>(
 ) -> Pubkey {
     Pubkey::find_program_address(
         &get_program_governance_address_seeds(realm, governed_program),
+        program_id,
+    )
+    .0
+}
+
+/// Returns MintGovernance PDA seeds
+pub fn get_mint_governance_address_seeds<'a>(
+    realm: &'a Pubkey,
+    governed_mint: &'a Pubkey,
+) -> [&'a [u8]; 3] {
+    // 'mint-governance' prefix ensures uniqueness of the PDA
+    // Note: Only the current mint authority can create an account with this PDA using CreateMintGovernance instruction
+    [b"mint-governance", &realm.as_ref(), &governed_mint.as_ref()]
+}
+
+/// Returns MintGovernance PDA address
+pub fn get_mint_governance_address<'a>(
+    program_id: &Pubkey,
+    realm: &'a Pubkey,
+    governed_mint: &'a Pubkey,
+) -> Pubkey {
+    Pubkey::find_program_address(
+        &get_mint_governance_address_seeds(realm, governed_mint),
         program_id,
     )
     .0

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -101,8 +101,8 @@ pub fn get_program_governance_address_seeds<'a>(
     // Note: Only the current program upgrade authority can create an account with this PDA using CreateProgramGovernance instruction
     [
         b"program-governance",
-        &realm.as_ref(),
-        &governed_program.as_ref(),
+        realm.as_ref(),
+        governed_program.as_ref(),
     ]
 }
 
@@ -126,7 +126,7 @@ pub fn get_mint_governance_address_seeds<'a>(
 ) -> [&'a [u8]; 3] {
     // 'mint-governance' prefix ensures uniqueness of the PDA
     // Note: Only the current mint authority can create an account with this PDA using CreateMintGovernance instruction
-    [b"mint-governance", &realm.as_ref(), &governed_mint.as_ref()]
+    [b"mint-governance", realm.as_ref(), governed_mint.as_ref()]
 }
 
 /// Returns MintGovernance PDA address
@@ -149,8 +149,8 @@ pub fn get_account_governance_address_seeds<'a>(
 ) -> [&'a [u8]; 3] {
     [
         b"account-governance",
-        &realm.as_ref(),
-        &governed_account.as_ref(),
+        realm.as_ref(),
+        governed_account.as_ref(),
     ]
 }
 

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -378,7 +378,7 @@ pub fn get_proposal_address_seeds<'a>(
         PROGRAM_AUTHORITY_SEED,
         governance.as_ref(),
         governing_token_mint.as_ref(),
-        &proposal_index_le_bytes,
+        proposal_index_le_bytes,
     ]
 }
 

--- a/governance/program/src/state/proposal_instruction.rs
+++ b/governance/program/src/state/proposal_instruction.rs
@@ -118,7 +118,7 @@ pub fn get_proposal_instruction_address_seeds<'a>(
     [
         PROGRAM_AUTHORITY_SEED,
         proposal.as_ref(),
-        &instruction_index_le_bytes,
+        instruction_index_le_bytes,
     ]
 }
 

--- a/governance/program/src/tools/account.rs
+++ b/governance/program/src/tools/account.rs
@@ -103,7 +103,8 @@ pub fn get_account_data<T: BorshDeserialize + IsInitialized>(
     }
 }
 
-/// Asserts the given account is not empty, owned given program and of the expected type
+/// Asserts the given account is not empty, owned by the given program and of the expected type
+/// Note: The function assumes the account type T is stored as the first element in the account data
 pub fn assert_is_valid_account<T: BorshDeserialize + PartialEq>(
     account_info: &AccountInfo,
     expected_account_type: T,

--- a/governance/program/src/tools/account.rs
+++ b/governance/program/src/tools/account.rs
@@ -89,7 +89,7 @@ pub fn get_account_data<T: BorshDeserialize + IsInitialized>(
     owner_program_id: &Pubkey,
 ) -> Result<T, ProgramError> {
     if account_info.data_is_empty() {
-        return Err(ProgramError::UninitializedAccount);
+        return Err(GovernanceError::AccountDoesNotExist.into());
     }
     if account_info.owner != owner_program_id {
         return Err(GovernanceError::InvalidAccountOwner.into());
@@ -115,7 +115,7 @@ pub fn assert_is_valid_account<T: BorshDeserialize + PartialEq>(
     }
 
     if account_info.data_is_empty() {
-        return Err(ProgramError::UninitializedAccount);
+        return Err(GovernanceError::AccountDoesNotExist.into());
     }
 
     let account_type: T = try_from_slice_unchecked(&account_info.data.borrow())?;

--- a/governance/program/src/tools/mod.rs
+++ b/governance/program/src/tools/mod.rs
@@ -5,3 +5,5 @@ pub mod account;
 pub mod spl_token;
 
 pub mod bpf_loader_upgradeable;
+
+pub mod pack;

--- a/governance/program/src/tools/pack.rs
+++ b/governance/program/src/tools/pack.rs
@@ -1,0 +1,14 @@
+//! General purpose packing utility functions
+
+use arrayref::array_refs;
+use solana_program::{program_error::ProgramError, program_option::COption, pubkey::Pubkey};
+
+/// Unpacks COption from a slice
+pub fn unpack_coption_pubkey(src: &[u8; 36]) -> Result<COption<Pubkey>, ProgramError> {
+    let (tag, body) = array_refs![src, 4, 32];
+    match *tag {
+        [0, 0, 0, 0] => Ok(COption::None),
+        [1, 0, 0, 0] => Ok(COption::Some(Pubkey::new_from_array(*body))),
+        _ => Err(ProgramError::InvalidAccountData),
+    }
+}

--- a/governance/program/src/tools/spl_token.rs
+++ b/governance/program/src/tools/spl_token.rs
@@ -281,7 +281,7 @@ pub fn assert_spl_token_mint_authority_is_signer(
     mint_info: &AccountInfo,
     mint_authority_info: &AccountInfo,
 ) -> Result<(), ProgramError> {
-    let mint_authority = get_spl_token_mint_authority(&mint_info)?;
+    let mint_authority = get_spl_token_mint_authority(mint_info)?;
 
     if mint_authority.is_none() {
         return Err(GovernanceError::MintHasNoAuthority.into());

--- a/governance/program/tests/process_create_mint_governance.rs
+++ b/governance/program/tests/process_create_mint_governance.rs
@@ -1,0 +1,172 @@
+#![cfg(feature = "test-bpf")]
+mod program_test;
+
+use solana_program_test::*;
+
+use program_test::*;
+use solana_sdk::{signature::Keypair, signer::Signer};
+use spl_governance::error::GovernanceError;
+use spl_token::error::TokenError;
+
+#[tokio::test]
+async fn test_create_mint_governance() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_mint_cookie = governance_test.with_governed_mint().await;
+
+    // Act
+    let mint_governance_cookie = governance_test
+        .with_mint_governance(&realm_cookie, &governed_mint_cookie)
+        .await
+        .unwrap();
+
+    // // Assert
+    let mint_governance_account = governance_test
+        .get_governance_account(&mint_governance_cookie.address)
+        .await;
+
+    assert_eq!(mint_governance_cookie.account, mint_governance_account);
+
+    let mint_account = governance_test
+        .get_mint_account(&governed_mint_cookie.address)
+        .await;
+
+    assert_eq!(
+        mint_governance_cookie.address,
+        mint_account.mint_authority.unwrap()
+    );
+}
+
+#[tokio::test]
+async fn test_create_mint_governance_without_transferring_mint_authority() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let mut governed_mint_cookie = governance_test.with_governed_mint().await;
+
+    governed_mint_cookie.transfer_mint_authority = false;
+    // Act
+    let mint_governance_cookie = governance_test
+        .with_mint_governance(&realm_cookie, &governed_mint_cookie)
+        .await
+        .unwrap();
+
+    // // Assert
+    let mint_governance_account = governance_test
+        .get_governance_account(&mint_governance_cookie.address)
+        .await;
+
+    assert_eq!(mint_governance_cookie.account, mint_governance_account);
+
+    let mint_account = governance_test
+        .get_mint_account(&governed_mint_cookie.address)
+        .await;
+
+    assert_eq!(
+        governed_mint_cookie.mint_authority.pubkey(),
+        mint_account.mint_authority.unwrap()
+    );
+}
+
+#[tokio::test]
+async fn test_create_mint_governance_without_transferring_mint_authority_with_invalid_authority_error(
+) {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let mut governed_mint_cookie = governance_test.with_governed_mint().await;
+
+    governed_mint_cookie.transfer_mint_authority = false;
+    governed_mint_cookie.mint_authority = Keypair::new();
+
+    // Act
+    let err = governance_test
+        .with_mint_governance(&realm_cookie, &governed_mint_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::InvalidMintAuthority.into());
+}
+
+#[tokio::test]
+async fn test_create_mint_governance_without_transferring_mint_authority_with_authority_not_signed_error(
+) {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let mut governed_mint_cookie = governance_test.with_governed_mint().await;
+
+    governed_mint_cookie.transfer_mint_authority = false;
+
+    // Act
+    let err = governance_test
+        .with_mint_governance_using_instruction(
+            &realm_cookie,
+            &governed_mint_cookie,
+            |i| {
+                i.accounts[3].is_signer = false; // governed_mint_authority
+            },
+            Some(&[]),
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::MintAuthorityMustSign.into());
+}
+
+#[tokio::test]
+async fn test_create_mint_governance_with_invalid_mint_authority_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let mut governed_mint_cookie = governance_test.with_governed_mint().await;
+
+    governed_mint_cookie.mint_authority = Keypair::new();
+
+    // Act
+    let err = governance_test
+        .with_mint_governance(&realm_cookie, &governed_mint_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, TokenError::OwnerMismatch.into());
+}
+
+#[tokio::test]
+async fn test_create_mint_governance_with_invalid_realm_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+    let governed_mint_cookie = governance_test.with_governed_mint().await;
+
+    let mint_governance_cookie = governance_test
+        .with_mint_governance(&realm_cookie, &governed_mint_cookie)
+        .await
+        .unwrap();
+
+    // try to use Governance account other than Realm as realm
+    realm_cookie.address = mint_governance_cookie.address;
+
+    // Act
+    let err = governance_test
+        .with_mint_governance(&realm_cookie, &governed_mint_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::InvalidAccountType.into());
+}

--- a/governance/program/tests/process_create_mint_governance.rs
+++ b/governance/program/tests/process_create_mint_governance.rs
@@ -14,7 +14,7 @@ async fn test_create_mint_governance() {
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
     let realm_cookie = governance_test.with_realm().await;
-    let governed_mint_cookie = governance_test.with_governed_mint().await;
+    let mut governed_mint_cookie = governance_test.with_governed_mint().await;
 
     // Act
     let mint_governance_cookie = governance_test

--- a/governance/program/tests/process_create_mint_governance.rs
+++ b/governance/program/tests/process_create_mint_governance.rs
@@ -14,7 +14,7 @@ async fn test_create_mint_governance() {
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
     let realm_cookie = governance_test.with_realm().await;
-    let mut governed_mint_cookie = governance_test.with_governed_mint().await;
+    let governed_mint_cookie = governance_test.with_governed_mint().await;
 
     // Act
     let mint_governance_cookie = governance_test

--- a/governance/program/tests/process_execute_instruction.rs
+++ b/governance/program/tests/process_execute_instruction.rs
@@ -18,10 +18,10 @@ async fn test_execute_mint_instruction() {
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
     let realm_cookie = governance_test.with_realm().await;
-    let governed_account_cookie = governance_test.with_governed_account().await;
+    let governed_mint_cookie = governance_test.with_governed_mint().await;
 
-    let mut account_governance_cookie = governance_test
-        .with_account_governance(&realm_cookie, &governed_account_cookie)
+    let mut mint_governance_cookie = governance_test
+        .with_mint_governance(&realm_cookie, &governed_mint_cookie)
         .await
         .unwrap();
 
@@ -30,7 +30,7 @@ async fn test_execute_mint_instruction() {
         .await;
 
     let mut proposal_cookie = governance_test
-        .with_proposal(&token_owner_record_cookie, &mut account_governance_cookie)
+        .with_proposal(&token_owner_record_cookie, &mut mint_governance_cookie)
         .await
         .unwrap();
 
@@ -40,7 +40,12 @@ async fn test_execute_mint_instruction() {
         .unwrap();
 
     let proposal_instruction_cookie = governance_test
-        .with_mint_tokens_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_mint_tokens_instruction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            None,
+        )
         .await
         .unwrap();
 
@@ -219,10 +224,10 @@ async fn test_execute_instruction_with_invalid_state_errors() {
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
     let realm_cookie = governance_test.with_realm().await;
-    let governed_account_cookie = governance_test.with_governed_account().await;
+    let governed_mint_cookie = governance_test.with_governed_mint().await;
 
-    let mut account_governance_cookie = governance_test
-        .with_account_governance(&realm_cookie, &governed_account_cookie)
+    let mut mint_governance_cookie = governance_test
+        .with_mint_governance(&realm_cookie, &governed_mint_cookie)
         .await
         .unwrap();
 
@@ -231,7 +236,7 @@ async fn test_execute_instruction_with_invalid_state_errors() {
         .await;
 
     let mut proposal_cookie = governance_test
-        .with_proposal(&token_owner_record_cookie, &mut account_governance_cookie)
+        .with_proposal(&token_owner_record_cookie, &mut mint_governance_cookie)
         .await
         .unwrap();
 
@@ -246,7 +251,12 @@ async fn test_execute_instruction_with_invalid_state_errors() {
         .unwrap();
 
     let proposal_instruction_cookie = governance_test
-        .with_mint_tokens_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_mint_tokens_instruction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            None,
+        )
         .await
         .unwrap();
 
@@ -378,10 +388,10 @@ async fn test_execute_instruction_for_other_proposal_error() {
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
     let realm_cookie = governance_test.with_realm().await;
-    let governed_account_cookie = governance_test.with_governed_account().await;
+    let governed_mint_cookie = governance_test.with_governed_mint().await;
 
-    let mut account_governance_cookie = governance_test
-        .with_account_governance(&realm_cookie, &governed_account_cookie)
+    let mut mint_governance_cookie = governance_test
+        .with_mint_governance(&realm_cookie, &governed_mint_cookie)
         .await
         .unwrap();
 
@@ -390,7 +400,7 @@ async fn test_execute_instruction_for_other_proposal_error() {
         .await;
 
     let mut proposal_cookie = governance_test
-        .with_proposal(&token_owner_record_cookie, &mut account_governance_cookie)
+        .with_proposal(&token_owner_record_cookie, &mut mint_governance_cookie)
         .await
         .unwrap();
 
@@ -400,7 +410,12 @@ async fn test_execute_instruction_for_other_proposal_error() {
         .unwrap();
 
     let proposal_instruction_cookie = governance_test
-        .with_mint_tokens_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_mint_tokens_instruction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            None,
+        )
         .await
         .unwrap();
 
@@ -423,7 +438,7 @@ async fn test_execute_instruction_for_other_proposal_error() {
         .unwrap();
 
     let proposal_cookie2 = governance_test
-        .with_proposal(&token_owner_record_cookie, &mut account_governance_cookie)
+        .with_proposal(&token_owner_record_cookie, &mut mint_governance_cookie)
         .await
         .unwrap();
 
@@ -447,10 +462,10 @@ async fn test_execute_mint_instruction_twice_error() {
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
     let realm_cookie = governance_test.with_realm().await;
-    let governed_account_cookie = governance_test.with_governed_account().await;
+    let governed_mint_cookie = governance_test.with_governed_mint().await;
 
-    let mut account_governance_cookie = governance_test
-        .with_account_governance(&realm_cookie, &governed_account_cookie)
+    let mut mint_governance_cookie = governance_test
+        .with_mint_governance(&realm_cookie, &governed_mint_cookie)
         .await
         .unwrap();
 
@@ -459,7 +474,7 @@ async fn test_execute_mint_instruction_twice_error() {
         .await;
 
     let mut proposal_cookie = governance_test
-        .with_proposal(&token_owner_record_cookie, &mut account_governance_cookie)
+        .with_proposal(&token_owner_record_cookie, &mut mint_governance_cookie)
         .await
         .unwrap();
 
@@ -469,7 +484,12 @@ async fn test_execute_mint_instruction_twice_error() {
         .unwrap();
 
     let proposal_instruction_cookie = governance_test
-        .with_mint_tokens_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_mint_tokens_instruction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            None,
+        )
         .await
         .unwrap();
 

--- a/governance/program/tests/program_test/cookies.rs
+++ b/governance/program/tests/program_test/cookies.rs
@@ -62,6 +62,13 @@ pub struct GovernedProgramCookie {
 }
 
 #[derive(Debug)]
+pub struct GovernedMintCookie {
+    pub address: Pubkey,
+    pub mint_authority: Keypair,
+    pub transfer_mint_authority: bool,
+}
+
+#[derive(Debug)]
 pub struct GovernedAccountCookie {
     pub address: Pubkey,
 }

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -25,17 +25,17 @@ use solana_sdk::{
 use spl_governance::{
     instruction::{
         add_signatory, cancel_proposal, cast_vote, create_account_governance,
-        create_program_governance, create_proposal, create_realm, deposit_governing_tokens,
-        execute_instruction, finalize_vote, insert_instruction, relinquish_vote,
-        remove_instruction, remove_signatory, set_governance_delegate, sign_off_proposal,
-        withdraw_governing_tokens, Vote,
+        create_mint_governance, create_program_governance, create_proposal, create_realm,
+        deposit_governing_tokens, execute_instruction, finalize_vote, insert_instruction,
+        relinquish_vote, remove_instruction, remove_signatory, set_governance_delegate,
+        sign_off_proposal, withdraw_governing_tokens, Vote,
     },
     processor::process_instruction,
     state::{
         enums::{GovernanceAccountType, ProposalState, VoteWeight},
         governance::{
-            get_account_governance_address, get_program_governance_address, Governance,
-            GovernanceConfig,
+            get_account_governance_address, get_mint_governance_address,
+            get_program_governance_address, Governance, GovernanceConfig,
         },
         proposal::{get_proposal_address, Proposal},
         proposal_instruction::{
@@ -54,8 +54,9 @@ use crate::program_test::{cookies::SignatoryRecordCookie, tools::clone_keypair};
 
 use self::{
     cookies::{
-        GovernanceCookie, GovernedAccountCookie, GovernedProgramCookie, ProposalCookie,
-        ProposalInstructionCookie, RealmCookie, TokeOwnerRecordCookie, VoteRecordCookie,
+        GovernanceCookie, GovernedAccountCookie, GovernedMintCookie, GovernedProgramCookie,
+        ProposalCookie, ProposalInstructionCookie, RealmCookie, TokeOwnerRecordCookie,
+        VoteRecordCookie,
     },
     tools::NopOverride,
 };
@@ -581,6 +582,21 @@ impl GovernanceProgramTest {
         }
     }
 
+    #[allow(dead_code)]
+    pub async fn with_governed_mint(&mut self) -> GovernedMintCookie {
+        let mint_keypair = Keypair::new();
+        let mint_authority = Keypair::new();
+
+        self.create_mint(&mint_keypair, &mint_authority.pubkey())
+            .await;
+
+        GovernedMintCookie {
+            address: mint_keypair.pubkey(),
+            mint_authority: mint_authority,
+            transfer_mint_authority: true,
+        }
+    }
+
     pub fn get_default_governance_config(
         &mut self,
         realm_cookie: &RealmCookie,
@@ -775,6 +791,73 @@ impl GovernanceProgramTest {
 
         Ok(GovernanceCookie {
             address: program_governance_address,
+            account,
+            next_proposal_index: 0,
+        })
+    }
+
+    #[allow(dead_code)]
+    pub async fn with_mint_governance(
+        &mut self,
+        realm_cookie: &RealmCookie,
+        governed_mint_cookie: &GovernedMintCookie,
+    ) -> Result<GovernanceCookie, ProgramError> {
+        self.with_mint_governance_using_instruction(
+            realm_cookie,
+            governed_mint_cookie,
+            NopOverride,
+            None,
+        )
+        .await
+    }
+
+    #[allow(dead_code)]
+    pub async fn with_mint_governance_using_instruction<F: Fn(&mut Instruction)>(
+        &mut self,
+        realm_cookie: &RealmCookie,
+        governed_mint_cookie: &GovernedMintCookie,
+        instruction_override: F,
+        signers_override: Option<&[&Keypair]>,
+    ) -> Result<GovernanceCookie, ProgramError> {
+        let config = GovernanceConfig {
+            realm: realm_cookie.address,
+            governed_account: governed_mint_cookie.address,
+            min_tokens_to_create_proposal: 5,
+            min_instruction_hold_up_time: 10,
+            max_voting_time: 100,
+            yes_vote_threshold_percentage: 60,
+        };
+
+        let mut create_mint_governance_instruction = create_mint_governance(
+            &self.program_id,
+            &governed_mint_cookie.mint_authority.pubkey(),
+            &self.context.payer.pubkey(),
+            config.clone(),
+            governed_mint_cookie.transfer_mint_authority,
+        );
+
+        instruction_override(&mut create_mint_governance_instruction);
+
+        let default_signers = &[&governed_mint_cookie.mint_authority];
+        let singers = signers_override.unwrap_or(default_signers);
+
+        self.process_transaction(&[create_mint_governance_instruction], Some(singers))
+            .await?;
+
+        let account = Governance {
+            account_type: GovernanceAccountType::MintGovernance,
+            config,
+            proposals_count: 0,
+        };
+
+        let mint_governance_address = get_mint_governance_address(
+            &self.program_id,
+            &realm_cookie.address,
+            &governed_mint_cookie.address,
+        );
+
+        Ok(GovernanceCookie {
+            address: mint_governance_address,
             account,
             next_proposal_index: 0,
         })
@@ -1118,30 +1201,22 @@ impl GovernanceProgramTest {
     #[allow(dead_code)]
     pub async fn with_mint_tokens_instruction(
         &mut self,
+        governed_mint_cookie: &GovernedMintCookie,
         proposal_cookie: &mut ProposalCookie,
         token_owner_record_cookie: &TokeOwnerRecordCookie,
         index: Option<u16>,
     ) -> Result<ProposalInstructionCookie, ProgramError> {
-        let token_mint_keypair = Keypair::new();
-
-        // Create mint with minting authority granted to Proposal Governance
-        // Note the actual governed_account in the Governance account is irrelevant in this scenario because we don't support CreateMintGovernance instruction yet
-        // Once implemented CreateMintGovernance should take over mint_authority (or ensure the current authority signed the transaction)
-        // as it is done with CreateProgramGovernance and upgrade_authority
-        self.create_mint(&token_mint_keypair, &proposal_cookie.account.governance)
-            .await;
-
         let token_account_keypair = Keypair::new();
         self.create_empty_token_account(
             &token_account_keypair,
-            &token_mint_keypair.pubkey(),
+            &governed_mint_cookie.address,
             &self.context.payer.pubkey(),
         )
         .await;
 
         let mut instruction = spl_token::instruction::mint_to(
             &spl_token::id(),
-            &token_mint_keypair.pubkey(),
+            &governed_mint_cookie.address,
             &token_account_keypair.pubkey(),
             &proposal_cookie.account.governance,
             &[],
@@ -1373,11 +1448,8 @@ impl GovernanceProgramTest {
     }
 
     #[allow(dead_code)]
-    pub async fn get_governance_account(
-        &mut self,
-        program_governance_address: &Pubkey,
-    ) -> Governance {
-        self.get_borsh_account::<Governance>(program_governance_address)
+    pub async fn get_governance_account(&mut self, governance_address: &Pubkey) -> Governance {
+        self.get_borsh_account::<Governance>(governance_address)
             .await
     }
 
@@ -1460,6 +1532,11 @@ impl GovernanceProgramTest {
 
     #[allow(dead_code)]
     pub async fn get_token_account(&mut self, address: &Pubkey) -> spl_token::state::Account {
+        self.get_packed_account(address).await
+    }
+
+    #[allow(dead_code)]
+    pub async fn get_mint_account(&mut self, address: &Pubkey) -> spl_token::state::Mint {
         self.get_packed_account(address).await
     }
 


### PR DESCRIPTION
#### Implemented instructions:

- `CreateMintGovernance` - It works in similar way to `CreateProgramGovernance` by allowing to create a concrete `Governance` account of `MintGovernance` type.  

  In addition to creating the concrete account type the instruction verifies the current mint authority signed the transaction and optionally transfers the authority to the newly created `Governance` account PDA.

   The account PDA is unique and can only be created using `CreateMintGovernance` instruction ensuring only the current mint authority can create it.



  