### PR TITLE
Test automerge with `all_github_action_checks` twice

### DIFF
--- a/.github/workflows/pull-request-token.yml
+++ b/.github/workflows/pull-request-token.yml
@@ -12,6 +12,14 @@ on:
     - 'token/**'
 
 jobs:
+  all_github_action_checks:
+    runs-on: ubuntu-latest
+    needs:
+      - cargo-test-bpf
+      - js-test
+    steps:
+      - run: echo "Done"
+
   cargo-test-bpf:
     runs-on: ubuntu-latest
     steps:

--- a/token/js/cli/token-test.js
+++ b/token/js/cli/token-test.js
@@ -365,7 +365,6 @@ export async function failOnApproveOverspend(): Promise<void> {
   const delegate = Keypair.generate();
 
   await testToken.transfer(testAccount, account1, testAccountOwner, [], 10);
-
   await testToken.approve(account1, delegate.publicKey, owner, [], 2);
 
   let account1Info = await testToken.getAccountInfo(account1);


### PR DESCRIPTION
#### Problem

Automerge may be broken due to the split of GitHub Actions workflows -- once `all_github_action_checks` passes on the main `pull-request.yml` workflow, it may merge before finishing the program specific workflow.

#### Solution

This may not work, so the test is to add `all_github_action_checks` to the token workflow and just change some whitespace to trigger it.  If automerge waits for both, then we're all good!  If not, back to the drawing board.