### PR TITLE
CI: Add status-failure and status-pending check to be sure that all steps are run

### DIFF
--- a/.github/workflows/pull-request-token.yml
+++ b/.github/workflows/pull-request-token.yml
@@ -12,6 +12,14 @@ on:
     - 'token/**'
 
 jobs:
+  all_github_action_checks:
+    runs-on: ubuntu-latest
+    needs:
+      - cargo-test-bpf
+      - js-test
+    steps:
+      - run: echo "Done"
+
   cargo-test-bpf:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pull-request-token.yml
+++ b/.github/workflows/pull-request-token.yml
@@ -12,14 +12,6 @@ on:
     - 'token/**'
 
 jobs:
-  all_github_action_checks:
-    runs-on: ubuntu-latest
-    needs:
-      - cargo-test-bpf
-      - js-test
-    steps:
-      - run: echo "Done"
-
   cargo-test-bpf:
     runs-on: ubuntu-latest
     steps:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -18,7 +18,7 @@ pull_request_rules:
       - check-success=Travis CI - Pull Request
       - check-success=all_github_action_checks
       - "#status-failure=0"
-      - "#status-pending=0"
+      - "#status-neutral=0"
       - label=automerge
       - author≠@dont-squash-my-commits
     actions:
@@ -30,7 +30,7 @@ pull_request_rules:
       - check-success=Travis CI - Pull Request
       - check-success=all_github_action_checks
       - "#status-failure=0"
-      - "#status-pending=0"
+      - "#status-neutral=0"
       - label=automerge
       - author=@dont-squash-my-commits
     actions:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -17,6 +17,8 @@ pull_request_rules:
     conditions:
       - check-success=Travis CI - Pull Request
       - check-success=all_github_action_checks
+      - "#status-failure=0"
+      - "#status-pending=0"
       - label=automerge
       - author≠@dont-squash-my-commits
     actions:
@@ -27,6 +29,8 @@ pull_request_rules:
     conditions:
       - check-success=Travis CI - Pull Request
       - check-success=all_github_action_checks
+      - "#status-failure=0"
+      - "#status-pending=0"
       - label=automerge
       - author=@dont-squash-my-commits
     actions:

--- a/token/js/cli/token-test.js
+++ b/token/js/cli/token-test.js
@@ -365,7 +365,6 @@ export async function failOnApproveOverspend(): Promise<void> {
   const delegate = Keypair.generate();
 
   await testToken.transfer(testAccount, account1, testAccountOwner, [], 10);
-
   await testToken.approve(account1, delegate.publicKey, owner, [], 2);
 
   let account1Info = await testToken.getAccountInfo(account1);


### PR DESCRIPTION
Trying again for #1965

#### Problem

Automerge may be broken due to the split of GitHub Actions workflows -- once all_github_action_checks passes on the main pull-request.yml workflow, it may merge before finishing the program specific workflow.

#### Solution

This may not work, so the idea is to add more status-checks to mergify *along with* the normal all_github_actions check, and just change some whitespace to trigger it. If automerge waits for everything, then we're all good! If not, back to the drawing board.