### PR TITLE
Governance: Create token governance

### DIFF
--- a/governance/README.md
+++ b/governance/README.md
@@ -6,7 +6,7 @@ a voting population to vote on disbursement of access or funds collectively.
 
 ## Architecture
 
-### Accounts diagram
+### Accounts diagram (Program Governance use case)
 
 ![Accounts diagram](./resources/governance-accounts.jpg)
 
@@ -31,6 +31,20 @@ The governance program validates at creation time of the Governance account that
 taken under governance signed the transaction. Optionally `CreateProgramGovernance` instruction can also transfer `upgrade_authority`
 of the governed program to the Governance PDA at the creation time of the Governance account.
 
+### Mint Governance account
+
+Mint governance account allows to setup a governance over a Mint account.
+The Governance program validates at creation time the current mint authority sing the transaction to
+create the governance and optionally can transfer the authority to the Governance account.
+Once setup the Mint Governance allows to create Proposals to execute mint instructions for the governed Mint.
+
+### Token Governance account
+
+Token governance account allows to setup a governance over a Token account.
+The Governance program validates at creation time the current owner sing the transaction to
+create the governance and optionally can transfer the owner to the Governance account.
+Once setup the Token Governance allows to create Proposals to execute transfer instructions from the governed token account.
+
 ### How does the authority work?
 
 Governance can handle arbitrary executions of code, but it's real power lies in the power to upgrade programs.
@@ -41,6 +55,10 @@ Normally, this is the developer who created and deployed the program, and this c
 the new program data and overwriting of the existing Program account's data with it is handled in the background for you
 by the Solana program deploy cli command.
 However, in order for Governance to be useful, Governance now needs this authority.
+
+In similar fashion for Mint and Token governances the relevant authorities to mint and transfer tokens
+are transferer to the Governance account which allows to create and vote on Proposals which can then execute
+mint and transfer instructions for the governed accounts.
 
 ### Proposal accounts
 

--- a/governance/README.md
+++ b/governance/README.md
@@ -33,17 +33,17 @@ of the governed program to the Governance PDA at the creation time of the Govern
 
 ### Mint Governance account
 
-Mint governance account allows to setup a governance over a Mint account.
-The Governance program validates at creation time the current mint authority sign the transaction to
+A mint governance account allows a mint authority to setup governance over an SPL Mint account.
+The Governance program validates at creation time that the current mint authority signed the transaction to
 create the governance and optionally can transfer the authority to the Governance account.
-Once setup the Mint Governance allows to create Proposals to execute mint instructions for the governed Mint.
+Once setup the Mint Governance allows governance participants to create Proposals which execute mint instructions for the governed Mint.
 
 ### Token Governance account
 
-Token governance account allows to setup a governance over a Token account.
+A token governance account allows a token account owner to setup governance over an SPL Token account.
 The Governance program validates at creation time the current owner sign the transaction to
 create the governance and optionally can transfer the owner to the Governance account.
-Once setup the Token Governance allows to create Proposals to execute transfer instructions from the governed token account.
+Once setup the Token Governance allows participants to create Proposals to execute transfer instructions from the governed token account.
 
 ### How does the authority work?
 
@@ -57,7 +57,7 @@ by the Solana program deploy cli command.
 However, in order for Governance to be useful, Governance now needs this authority.
 
 In similar fashion for Mint and Token governances the relevant authorities to mint and transfer tokens
-are transferer to the Governance account. It in turns allows to create and vote on Proposals which can then execute
+are transferred to the Governance account. It in turn allows participants to create and vote on Proposals which can then execute
 mint and transfer instructions for the governed accounts.
 
 ### Proposal accounts

--- a/governance/README.md
+++ b/governance/README.md
@@ -34,14 +34,14 @@ of the governed program to the Governance PDA at the creation time of the Govern
 ### Mint Governance account
 
 Mint governance account allows to setup a governance over a Mint account.
-The Governance program validates at creation time the current mint authority sing the transaction to
+The Governance program validates at creation time the current mint authority sign the transaction to
 create the governance and optionally can transfer the authority to the Governance account.
 Once setup the Mint Governance allows to create Proposals to execute mint instructions for the governed Mint.
 
 ### Token Governance account
 
 Token governance account allows to setup a governance over a Token account.
-The Governance program validates at creation time the current owner sing the transaction to
+The Governance program validates at creation time the current owner sign the transaction to
 create the governance and optionally can transfer the owner to the Governance account.
 Once setup the Token Governance allows to create Proposals to execute transfer instructions from the governed token account.
 
@@ -57,7 +57,7 @@ by the Solana program deploy cli command.
 However, in order for Governance to be useful, Governance now needs this authority.
 
 In similar fashion for Mint and Token governances the relevant authorities to mint and transfer tokens
-are transferer to the Governance account which allows to create and vote on Proposals which can then execute
+are transferer to the Governance account. It in turns allows to create and vote on Proposals which can then execute
 mint and transfer instructions for the governed accounts.
 
 ### Proposal accounts

--- a/governance/README.md
+++ b/governance/README.md
@@ -36,14 +36,16 @@ of the governed program to the Governance PDA at the creation time of the Govern
 A mint governance account allows a mint authority to setup governance over an SPL Mint account.
 The Governance program validates at creation time that the current mint authority signed the transaction to
 create the governance and optionally can transfer the authority to the Governance account.
-Once setup the Mint Governance allows governance participants to create Proposals which execute mint instructions for the governed Mint.
+Once setup the Mint Governance allows governance participants to create Proposals which execute mint instructions for
+the governed Mint.
 
 ### Token Governance account
 
 A token governance account allows a token account owner to setup governance over an SPL Token account.
-The Governance program validates at creation time the current owner sign the transaction to
+The Governance program validates at creation time the current owner signed the transaction to
 create the governance and optionally can transfer the owner to the Governance account.
-Once setup the Token Governance allows participants to create Proposals to execute transfer instructions from the governed token account.
+Once setup the Token Governance allows participants to create Proposals to execute transfer instructions
+from the governed token account.
 
 ### How does the authority work?
 
@@ -57,7 +59,8 @@ by the Solana program deploy cli command.
 However, in order for Governance to be useful, Governance now needs this authority.
 
 In similar fashion for Mint and Token governances the relevant authorities to mint and transfer tokens
-are transferred to the Governance account. It in turn allows participants to create and vote on Proposals which can then execute
+are transferred to the Governance account. It in turn allows participants to create and vote on Proposals
+which can then execute
 mint and transfer instructions for the governed accounts.
 
 ### Proposal accounts

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -251,6 +251,14 @@ pub enum GovernanceError {
     /// Given program is not upgradable
     #[error("Given program is not upgradable")]
     ProgramNotUpgradable,
+
+    /// Invalid token owner
+    #[error("Invalid token owner")]
+    InvalidTokenOwner,
+
+    /// Current token owner must sign transaction
+    #[error("Current token owner must sign transaction")]
+    TokenOwnerMustSign,
 }
 
 impl PrintProgramError for GovernanceError {

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -4,7 +4,7 @@ use crate::{
     state::{
         governance::{
             get_account_governance_address, get_mint_governance_address,
-            get_program_governance_address, GovernanceConfig,
+            get_program_governance_address, get_token_governance_address, GovernanceConfig,
         },
         proposal::get_proposal_address,
         proposal_instruction::{get_proposal_instruction_address, InstructionData},
@@ -313,6 +313,28 @@ pub enum GovernanceInstruction {
         /// However the instruction would validate the current mint authority signed the transaction nonetheless
         transfer_mint_authority: bool,
     },
+
+    /// Creates Token Governance account which governs a token account
+    ///
+    ///   0. `[]` Realm account the created Governance belongs to    
+    ///   1. `[writable]` Token Governance account. PDA seeds: ['token-governance', realm, governed_token]
+    ///   2. `[writable]` Token account governed by this Governance account
+    ///   3. `[signer]` Current Token account owner
+    ///   4. `[signer]` Payer
+    ///   5. `[]` SPL Token program
+    ///   6. `[]` System program
+    ///   7. `[]` Sysvar Rent
+    CreateTokenGovernance {
+        #[allow(dead_code)]
+        /// Governance config
+        config: GovernanceConfig,
+
+        #[allow(dead_code)]
+        /// Indicates whether token owner should be transferred to the Governance PDA
+        /// If it's set to false then it can be done at a later time
+        /// However the instruction would validate the current token owner signed the transaction nonetheless
+        transfer_token_owner: bool,
+    },
 }
 
 /// Creates CreateRealm instruction
@@ -564,6 +586,42 @@ pub fn create_mint_governance(
     let instruction = GovernanceInstruction::CreateMintGovernance {
         config,
         transfer_mint_authority,
+    };
+
+    Instruction {
+        program_id: *program_id,
+        accounts,
+        data: instruction.try_to_vec().unwrap(),
+    }
+}
+
+/// Creates CreateTokenGovernance instruction
+pub fn create_token_governance(
+    program_id: &Pubkey,
+    // Accounts
+    governed_token_owner: &Pubkey,
+    payer: &Pubkey,
+    // Args
+    config: GovernanceConfig,
+    transfer_token_owner: bool,
+) -> Instruction {
+    let token_governance_address =
+        get_token_governance_address(program_id, &config.realm, &config.governed_account);
+
+    let accounts = vec![
+        AccountMeta::new_readonly(config.realm, false),
+        AccountMeta::new(token_governance_address, false),
+        AccountMeta::new(config.governed_account, false),
+        AccountMeta::new_readonly(*governed_token_owner, true),
+        AccountMeta::new_readonly(*payer, true),
+        AccountMeta::new_readonly(spl_token::id(), false),
+        AccountMeta::new_readonly(system_program::id(), false),
+        AccountMeta::new_readonly(sysvar::rent::id(), false),
+    ];
+
+    let instruction = GovernanceInstruction::CreateTokenGovernance {
+        config,
+        transfer_token_owner,
     };
 
     Instruction {

--- a/governance/program/src/processor/mod.rs
+++ b/governance/program/src/processor/mod.rs
@@ -8,6 +8,7 @@ mod process_create_mint_governance;
 mod process_create_program_governance;
 mod process_create_proposal;
 mod process_create_realm;
+mod process_create_token_governance;
 mod process_deposit_governing_tokens;
 mod process_execute_instruction;
 mod process_finalize_vote;
@@ -30,6 +31,7 @@ use process_create_mint_governance::*;
 use process_create_program_governance::*;
 use process_create_proposal::*;
 use process_create_realm::*;
+use process_create_token_governance::*;
 use process_deposit_governing_tokens::*;
 use process_execute_instruction::*;
 use process_finalize_vote::*;
@@ -102,6 +104,11 @@ pub fn process_instruction(
             config,
             transfer_mint_authority,
         } => process_create_mint_governance(program_id, accounts, config, transfer_mint_authority),
+
+        GovernanceInstruction::CreateTokenGovernance {
+            config,
+            transfer_token_owner,
+        } => process_create_token_governance(program_id, accounts, config, transfer_token_owner),
 
         GovernanceInstruction::CreateAccountGovernance { config } => {
             process_create_account_governance(program_id, accounts, config)

--- a/governance/program/src/processor/process_create_token_governance.rs
+++ b/governance/program/src/processor/process_create_token_governance.rs
@@ -1,0 +1,77 @@
+//! Program state processor
+
+use crate::{
+    state::{
+        enums::GovernanceAccountType,
+        governance::{
+            assert_is_valid_governance_config, get_token_governance_address_seeds, Governance,
+            GovernanceConfig,
+        },
+    },
+    tools::{
+        account::create_and_serialize_account_signed,
+        spl_token::{assert_spl_token_owner_is_signer, set_spl_token_owner},
+    },
+};
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    entrypoint::ProgramResult,
+    pubkey::Pubkey,
+    rent::Rent,
+    sysvar::Sysvar,
+};
+
+/// Processes CreateTokenGovernance instruction
+pub fn process_create_token_governance(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    config: GovernanceConfig,
+    transfer_token_owner: bool,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    let realm_info = next_account_info(account_info_iter)?; // 0
+    let token_governance_info = next_account_info(account_info_iter)?; // 1
+
+    let governed_token_info = next_account_info(account_info_iter)?; // 2
+    let governed_token_owner_info = next_account_info(account_info_iter)?; // 3
+
+    let payer_info = next_account_info(account_info_iter)?; // 4
+    let spl_token_info = next_account_info(account_info_iter)?; // 5
+
+    let system_info = next_account_info(account_info_iter)?; // 6
+
+    let rent_sysvar_info = next_account_info(account_info_iter)?; // 7
+    let rent = &Rent::from_account_info(rent_sysvar_info)?;
+
+    assert_is_valid_governance_config(program_id, &config, realm_info)?;
+
+    let token_governance_data = Governance {
+        account_type: GovernanceAccountType::TokenGovernance,
+        config: config.clone(),
+        proposals_count: 0,
+    };
+
+    create_and_serialize_account_signed::<Governance>(
+        payer_info,
+        token_governance_info,
+        &token_governance_data,
+        &get_token_governance_address_seeds(&config.realm, &config.governed_account),
+        program_id,
+        system_info,
+        rent,
+    )?;
+
+    if transfer_token_owner {
+        set_spl_token_owner(
+            governed_token_info,
+            governed_token_owner_info,
+            token_governance_info.key,
+            spl_token_info,
+        )?;
+    } else {
+        assert_spl_token_owner_is_signer(governed_token_info, governed_token_owner_info)?;
+    }
+
+    Ok(())
+}

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -35,6 +35,9 @@ pub enum GovernanceAccountType {
 
     /// Mint Governance account
     MintGovernance,
+
+    /// Token Governance account
+    TokenGovernance,
 }
 
 impl Default for GovernanceAccountType {

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -59,6 +59,7 @@ impl IsInitialized for Governance {
         self.account_type == GovernanceAccountType::AccountGovernance
             || self.account_type == GovernanceAccountType::ProgramGovernance
             || self.account_type == GovernanceAccountType::MintGovernance
+            || self.account_type == GovernanceAccountType::TokenGovernance
     }
 }
 
@@ -77,6 +78,10 @@ impl Governance {
             GovernanceAccountType::MintGovernance => {
                 get_mint_governance_address_seeds(&self.config.realm, &self.config.governed_account)
             }
+            GovernanceAccountType::TokenGovernance => get_token_governance_address_seeds(
+                &self.config.realm,
+                &self.config.governed_account,
+            ),
             _ => return Err(GovernanceError::InvalidAccountType.into()),
         };
 
@@ -137,6 +142,29 @@ pub fn get_mint_governance_address<'a>(
 ) -> Pubkey {
     Pubkey::find_program_address(
         &get_mint_governance_address_seeds(realm, governed_mint),
+        program_id,
+    )
+    .0
+}
+
+/// Returns TokenGovernance PDA seeds
+pub fn get_token_governance_address_seeds<'a>(
+    realm: &'a Pubkey,
+    governed_token: &'a Pubkey,
+) -> [&'a [u8]; 3] {
+    // 'token-governance' prefix ensures uniqueness of the PDA
+    // Note: Only the current token account owner can create an account with this PDA using CreateTokenGovernance instruction
+    [b"token-governance", realm.as_ref(), governed_token.as_ref()]
+}
+
+/// Returns TokenGovernance PDA address
+pub fn get_token_governance_address<'a>(
+    program_id: &Pubkey,
+    realm: &'a Pubkey,
+    governed_token: &'a Pubkey,
+) -> Pubkey {
+    Pubkey::find_program_address(
+        &get_token_governance_address_seeds(realm, governed_token),
         program_id,
     )
     .0

--- a/governance/program/tests/process_create_token_governance.rs
+++ b/governance/program/tests/process_create_token_governance.rs
@@ -1,0 +1,170 @@
+#![cfg(feature = "test-bpf")]
+mod program_test;
+
+use solana_program_test::*;
+
+use program_test::*;
+use solana_sdk::{signature::Keypair, signer::Signer};
+use spl_governance::error::GovernanceError;
+use spl_token::error::TokenError;
+
+#[tokio::test]
+async fn test_create_token_governance() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_token_cookie = governance_test.with_governed_token().await;
+
+    // Act
+    let token_governance_cookie = governance_test
+        .with_token_governance(&realm_cookie, &governed_token_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let token_governance_account = governance_test
+        .get_governance_account(&token_governance_cookie.address)
+        .await;
+
+    assert_eq!(token_governance_cookie.account, token_governance_account);
+
+    let token_account = governance_test
+        .get_token_account(&governed_token_cookie.address)
+        .await;
+
+    assert_eq!(token_governance_cookie.address, token_account.owner);
+}
+
+#[tokio::test]
+async fn test_create_token_governance_without_transferring_token_owner() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let mut governed_token_cookie = governance_test.with_governed_token().await;
+
+    governed_token_cookie.transfer_token_owner = false;
+
+    // Act
+    let token_governance_cookie = governance_test
+        .with_token_governance(&realm_cookie, &governed_token_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let token_governance_account = governance_test
+        .get_governance_account(&token_governance_cookie.address)
+        .await;
+
+    assert_eq!(token_governance_cookie.account, token_governance_account);
+
+    let token_account = governance_test
+        .get_token_account(&governed_token_cookie.address)
+        .await;
+
+    assert_eq!(
+        governed_token_cookie.token_owner.pubkey(),
+        token_account.owner
+    );
+}
+
+#[tokio::test]
+async fn test_create_token_governance_without_transferring_token_owner_with_invalid_token_owner_error(
+) {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let mut governed_token_cookie = governance_test.with_governed_token().await;
+
+    governed_token_cookie.transfer_token_owner = false;
+    governed_token_cookie.token_owner = Keypair::new();
+
+    // Act
+    let err = governance_test
+        .with_token_governance(&realm_cookie, &governed_token_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::InvalidTokenOwner.into());
+}
+
+#[tokio::test]
+async fn test_create_token_governance_without_transferring_token_owner_with_owner_not_signed_error()
+{
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let mut governed_token_cookie = governance_test.with_governed_token().await;
+
+    governed_token_cookie.transfer_token_owner = false;
+
+    // Act
+    let err = governance_test
+        .with_token_governance_using_instruction(
+            &realm_cookie,
+            &governed_token_cookie,
+            |i| {
+                i.accounts[3].is_signer = false; // governed_token_owner
+            },
+            Some(&[]),
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::TokenOwnerMustSign.into());
+}
+
+#[tokio::test]
+async fn test_create_token_governance_with_invalid_token_owner_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let mut governed_token_cookie = governance_test.with_governed_token().await;
+
+    governed_token_cookie.token_owner = Keypair::new();
+
+    // Act
+    let err = governance_test
+        .with_token_governance(&realm_cookie, &governed_token_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, TokenError::OwnerMismatch.into());
+}
+
+#[tokio::test]
+async fn test_create_token_governance_with_invalid_realm_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+    let governed_token_cookie = governance_test.with_governed_token().await;
+
+    let token_governance_cookie = governance_test
+        .with_token_governance(&realm_cookie, &governed_token_cookie)
+        .await
+        .unwrap();
+
+    // try to use Governance account other than Realm as realm
+    realm_cookie.address = token_governance_cookie.address;
+
+    // Act
+    let err = governance_test
+        .with_token_governance(&realm_cookie, &governed_token_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::InvalidAccountType.into());
+}

--- a/governance/program/tests/program_test/cookies.rs
+++ b/governance/program/tests/program_test/cookies.rs
@@ -69,6 +69,13 @@ pub struct GovernedMintCookie {
 }
 
 #[derive(Debug)]
+pub struct GovernedTokenCookie {
+    pub address: Pubkey,
+    pub token_owner: Keypair,
+    pub transfer_token_owner: bool,
+}
+
+#[derive(Debug)]
 pub struct GovernedAccountCookie {
     pub address: Pubkey,
 }

--- a/governance/program/tests/program_test/cookies.rs
+++ b/governance/program/tests/program_test/cookies.rs
@@ -73,6 +73,7 @@ pub struct GovernedTokenCookie {
     pub address: Pubkey,
     pub token_owner: Keypair,
     pub transfer_token_owner: bool,
+    pub token_mint: Pubkey,
 }
 
 #[derive(Debug)]

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -26,16 +26,17 @@ use spl_governance::{
     instruction::{
         add_signatory, cancel_proposal, cast_vote, create_account_governance,
         create_mint_governance, create_program_governance, create_proposal, create_realm,
-        deposit_governing_tokens, execute_instruction, finalize_vote, insert_instruction,
-        relinquish_vote, remove_instruction, remove_signatory, set_governance_delegate,
-        sign_off_proposal, withdraw_governing_tokens, Vote,
+        create_token_governance, deposit_governing_tokens, execute_instruction, finalize_vote,
+        insert_instruction, relinquish_vote, remove_instruction, remove_signatory,
+        set_governance_delegate, sign_off_proposal, withdraw_governing_tokens, Vote,
     },
     processor::process_instruction,
     state::{
         enums::{GovernanceAccountType, ProposalState, VoteWeight},
         governance::{
             get_account_governance_address, get_mint_governance_address,
-            get_program_governance_address, Governance, GovernanceConfig,
+            get_program_governance_address, get_token_governance_address, Governance,
+            GovernanceConfig,
         },
         proposal::{get_proposal_address, Proposal},
         proposal_instruction::{
@@ -55,8 +56,8 @@ use crate::program_test::{cookies::SignatoryRecordCookie, tools::clone_keypair};
 use self::{
     cookies::{
         GovernanceCookie, GovernedAccountCookie, GovernedMintCookie, GovernedProgramCookie,
-        ProposalCookie, ProposalInstructionCookie, RealmCookie, TokeOwnerRecordCookie,
-        VoteRecordCookie,
+        GovernedTokenCookie, ProposalCookie, ProposalInstructionCookie, RealmCookie,
+        TokeOwnerRecordCookie, VoteRecordCookie,
     },
     tools::NopOverride,
 };
@@ -597,6 +598,39 @@ impl GovernanceProgramTest {
         }
     }
 
+    #[allow(dead_code)]
+    pub async fn with_governed_token(&mut self) -> GovernedTokenCookie {
+        let mint_keypair = Keypair::new();
+        let mint_authority = Keypair::new();
+
+        self.create_mint(&mint_keypair, &mint_authority.pubkey())
+            .await;
+
+        let token_keypair = Keypair::new();
+        let token_owner = Keypair::new();
+
+        self.create_empty_token_account(
+            &token_keypair,
+            &mint_keypair.pubkey(),
+            &token_owner.pubkey(),
+        )
+        .await;
+
+        self.mint_tokens(
+            &mint_keypair.pubkey(),
+            &mint_authority,
+            &token_keypair.pubkey(),
+            100,
+        )
+        .await;
+
+        GovernedTokenCookie {
+            address: token_keypair.pubkey(),
+            token_owner: token_owner,
+            transfer_token_owner: true,
+        }
+    }
+
     pub fn get_default_governance_config(
         &mut self,
         realm_cookie: &RealmCookie,
@@ -858,6 +892,73 @@ impl GovernanceProgramTest {
 
         Ok(GovernanceCookie {
             address: mint_governance_address,
+            account,
+            next_proposal_index: 0,
+        })
+    }
+
+    #[allow(dead_code)]
+    pub async fn with_token_governance(
+        &mut self,
+        realm_cookie: &RealmCookie,
+        governed_token_cookie: &GovernedTokenCookie,
+    ) -> Result<GovernanceCookie, ProgramError> {
+        self.with_token_governance_using_instruction(
+            realm_cookie,
+            governed_token_cookie,
+            NopOverride,
+            None,
+        )
+        .await
+    }
+
+    #[allow(dead_code)]
+    pub async fn with_token_governance_using_instruction<F: Fn(&mut Instruction)>(
+        &mut self,
+        realm_cookie: &RealmCookie,
+        governed_token_cookie: &GovernedTokenCookie,
+        instruction_override: F,
+        signers_override: Option<&[&Keypair]>,
+    ) -> Result<GovernanceCookie, ProgramError> {
+        let config = GovernanceConfig {
+            realm: realm_cookie.address,
+            governed_account: governed_token_cookie.address,
+            min_tokens_to_create_proposal: 5,
+            min_instruction_hold_up_time: 10,
+            max_voting_time: 100,
+            yes_vote_threshold_percentage: 60,
+        };
+
+        let mut create_token_governance_instruction = create_token_governance(
+            &self.program_id,
+            &governed_token_cookie.token_owner.pubkey(),
+            &self.context.payer.pubkey(),
+            config.clone(),
+            governed_token_cookie.transfer_token_owner,
+        );
+
+        instruction_override(&mut create_token_governance_instruction);
+
+        let default_signers = &[&governed_token_cookie.token_owner];
+        let singers = signers_override.unwrap_or(default_signers);
+
+        self.process_transaction(&[create_token_governance_instruction], Some(singers))
+            .await?;
+
+        let account = Governance {
+            account_type: GovernanceAccountType::TokenGovernance,
+            config,
+            proposals_count: 0,
+        };
+
+        let token_governance_address = get_token_governance_address(
+            &self.program_id,
+            &realm_cookie.address,
+            &governed_token_cookie.address,
+        );
+
+        Ok(GovernanceCookie {
+            address: token_governance_address,
             account,
             next_proposal_index: 0,
         })

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -628,6 +628,7 @@ impl GovernanceProgramTest {
             address: token_keypair.pubkey(),
             token_owner: token_owner,
             transfer_token_owner: true,
+            token_mint: mint_keypair.pubkey(),
         }
     }
 
@@ -1322,6 +1323,41 @@ impl GovernanceProgramTest {
             &proposal_cookie.account.governance,
             &[],
             10,
+        )
+        .unwrap();
+
+        self.with_instruction_impl(
+            proposal_cookie,
+            token_owner_record_cookie,
+            index,
+            &mut instruction,
+        )
+        .await
+    }
+
+    #[allow(dead_code)]
+    pub async fn with_transfer_tokens_instruction(
+        &mut self,
+        governed_token_cookie: &GovernedTokenCookie,
+        proposal_cookie: &mut ProposalCookie,
+        token_owner_record_cookie: &TokeOwnerRecordCookie,
+        index: Option<u16>,
+    ) -> Result<ProposalInstructionCookie, ProgramError> {
+        let token_account_keypair = Keypair::new();
+        self.create_empty_token_account(
+            &token_account_keypair,
+            &governed_token_cookie.token_mint,
+            &self.context.payer.pubkey(),
+        )
+        .await;
+
+        let mut instruction = spl_token::instruction::transfer(
+            &spl_token::id(),
+            &governed_token_cookie.address,
+            &token_account_keypair.pubkey(),
+            &proposal_cookie.account.governance,
+            &[],
+            15,
         )
         .unwrap();
 


### PR DESCRIPTION
#### Implemented instructions:

- `CreateTokenGovernance` - It works in similar way to `CreateMintGovernance` by allowing to create a concrete `Governance` account of `TokenGovernance` type.  

  In addition to creating the concrete account type the instruction verifies the current token account owner signed the transaction and optionally transfers the owner to the newly created `Governance` account PDA.

   The account PDA is unique and can only be created using `CreateTokenGovernance` instruction ensuring only the current token owner can create it.
