### PR TITLE
stake-pool: Fixup accounting on increase transient account

### DIFF
--- a/stake-pool/program/src/instruction.rs
+++ b/stake-pool/program/src/instruction.rs
@@ -162,7 +162,11 @@ pub enum StakePoolInstruction {
     /// 10. `[]` Stake Config sysvar
     /// 11. `[]` System program
     /// 12. `[]` Stake program
-    ///  userdata: amount of lamports to split into the transient stake account
+    ///  userdata: amount of lamports to increase on the given validator.
+    ///  The actual amount split into the transient stake account is:
+    ///  `lamports + stake_rent_exemption`
+    ///  The rent-exemption of the stake account is withdrawn back to the reserve
+    ///  after it is merged.
     IncreaseValidatorStake(u64),
 
     /// (Staker only) Set the preferred deposit or withdraw stake account for the

--- a/stake-pool/program/src/lib.rs
+++ b/stake-pool/program/src/lib.rs
@@ -33,7 +33,7 @@ pub const MINIMUM_ACTIVE_STAKE: u64 = LAMPORTS_PER_SOL;
 
 /// Maximum amount of validator stake accounts to update per
 /// `UpdateValidatorListBalance` instruction, based on compute limits
-pub const MAX_VALIDATORS_TO_UPDATE: usize = 10;
+pub const MAX_VALIDATORS_TO_UPDATE: usize = 9;
 
 /// Get the stake amount under consideration when calculating pool token
 /// conversions

--- a/stake-pool/program/tests/increase.rs
+++ b/stake-pool/program/tests/increase.rs
@@ -93,8 +93,8 @@ async fn success() {
     assert!(transient_account.is_none());
 
     let rent = banks_client.get_rent().await.unwrap();
-    let lamports = rent.minimum_balance(std::mem::size_of::<stake_program::StakeState>());
-    let reserve_lamports = reserve_lamports - lamports;
+    let stake_rent = rent.minimum_balance(std::mem::size_of::<stake_program::StakeState>());
+    let increase_amount = reserve_lamports - stake_rent - 1;
     let error = stake_pool_accounts
         .increase_validator_stake(
             &mut banks_client,
@@ -102,7 +102,7 @@ async fn success() {
             &recent_blockhash,
             &validator_stake.transient_stake_account,
             &validator_stake.vote.pubkey(),
-            reserve_lamports,
+            increase_amount,
         )
         .await;
     assert!(error.is_none());
@@ -116,7 +116,7 @@ async fn success() {
     let reserve_stake_state =
         deserialize::<stake_program::StakeState>(&reserve_stake_account.data).unwrap();
     assert_eq!(
-        pre_reserve_stake_account.lamports - reserve_lamports,
+        pre_reserve_stake_account.lamports - increase_amount - stake_rent,
         reserve_stake_account.lamports
     );
     assert!(reserve_stake_state.delegation().is_none());
@@ -126,7 +126,10 @@ async fn success() {
         get_account(&mut banks_client, &validator_stake.transient_stake_account).await;
     let transient_stake_state =
         deserialize::<stake_program::StakeState>(&transient_stake_account.data).unwrap();
-    assert_eq!(transient_stake_account.lamports, reserve_lamports);
+    assert_eq!(
+        transient_stake_account.lamports,
+        increase_amount + stake_rent
+    );
     assert_ne!(
         transient_stake_state.delegation().unwrap().activation_epoch,
         Epoch::MAX
@@ -332,7 +335,7 @@ async fn fail_with_small_lamport_amount() {
     ) = setup().await;
 
     let rent = banks_client.get_rent().await.unwrap();
-    let lamports = rent.minimum_balance(std::mem::size_of::<stake_program::StakeState>());
+    let stake_rent = rent.minimum_balance(std::mem::size_of::<stake_program::StakeState>());
 
     let error = stake_pool_accounts
         .increase_validator_stake(
@@ -341,7 +344,7 @@ async fn fail_with_small_lamport_amount() {
             &recent_blockhash,
             &validator_stake.transient_stake_account,
             &validator_stake.vote.pubkey(),
-            lamports,
+            stake_rent,
         )
         .await
         .unwrap()

--- a/stake-pool/program/tests/update_validator_list_balance.rs
+++ b/stake-pool/program/tests/update_validator_list_balance.rs
@@ -381,14 +381,6 @@ async fn merge_into_validator_stake() {
     let stake_pool = try_from_slice_unchecked::<StakePool>(&stake_pool_info.data).unwrap();
     assert_eq!(expected_lamports, stake_pool.total_stake_lamports);
 
-    let stake_pool_info = get_account(
-        &mut context.banks_client,
-        &stake_pool_accounts.stake_pool.pubkey(),
-    )
-    .await;
-    let stake_pool = try_from_slice_unchecked::<StakePool>(&stake_pool_info.data).unwrap();
-    assert_eq!(expected_lamports, stake_pool.total_stake_lamports);
-
     // Warp one more epoch so the stakes activate, ready to merge
     let slots_per_epoch = context.genesis_config().epoch_schedule.slots_per_epoch;
     slot += slots_per_epoch;


### PR DESCRIPTION
#### Problem

In order to make full use of all lamports in a stake pool, we need to withdraw the rent-exemption lamports from an active stake account after a merge.  Also, fix a bug during the update, where we weren't re-deserializing the validator stake account after the merge.

#### Solution

Do the accounting better!  There's also a little CLI update to also take in a reserve keypair if desired.