### PR TITLE
CI: attempt to fix early merging with one rule and lots of "and" clauses

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -15,10 +15,11 @@ pull_request_rules:
           - community
   - name: automatic merge (squash) on CI success
     conditions:
-      - check-success=Travis CI - Pull Request
-      - check-success=all_github_action_checks
-      - "#status-failure=0"
-      - "#status-neutral=0"
+      - and:
+          check-success=Travis CI - Pull Request
+          check-success=all_github_action_checks
+          "#status-failure=0"
+          "#status-neutral=0"
       - label=automerge
       - author≠@dont-squash-my-commits
     actions:
@@ -27,10 +28,11 @@ pull_request_rules:
   # Join the dont-squash-my-commits group if you won't like your commits squashed
   - name: automatic merge (rebase) on CI success
     conditions:
-      - check-success=Travis CI - Pull Request
-      - check-success=all_github_action_checks
-      - "#status-failure=0"
-      - "#status-neutral=0"
+      - and:
+          check-success=Travis CI - Pull Request
+          check-success=all_github_action_checks
+          "#status-failure=0"
+          "#status-neutral=0"
       - label=automerge
       - author=@dont-squash-my-commits
     actions:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -16,10 +16,10 @@ pull_request_rules:
   - name: automatic merge (squash) on CI success
     conditions:
       - and:
-          check-success=Travis CI - Pull Request
-          check-success=all_github_action_checks
-          "#status-failure=0"
-          "#status-neutral=0"
+        - check-success=Travis CI - Pull Request
+        - check-success=all_github_action_checks
+        - "#status-failure=0"
+        - "#status-neutral=0"
       - label=automerge
       - author≠@dont-squash-my-commits
     actions:
@@ -29,10 +29,10 @@ pull_request_rules:
   - name: automatic merge (rebase) on CI success
     conditions:
       - and:
-          check-success=Travis CI - Pull Request
-          check-success=all_github_action_checks
-          "#status-failure=0"
-          "#status-neutral=0"
+        - check-success=Travis CI - Pull Request
+        - check-success=all_github_action_checks
+        - "#status-failure=0"
+        - "#status-neutral=0"
       - label=automerge
       - author=@dont-squash-my-commits
     actions:


### PR DESCRIPTION
CI is still being wonky with mergify, so let's try to create one rule with lots of and clauses, and hope that it will only tick when "all" are correct all at once, and thus avoiding early merging.