### PR TITLE
stake-pool-cli: Add small optimizations for updating faster

### DIFF
--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -27,6 +27,7 @@ use {
         commitment_config::CommitmentConfig,
         native_token::{self, Sol},
         signature::{Keypair, Signer},
+        signers::Signers,
         system_instruction,
         transaction::Transaction,
     },
@@ -112,15 +113,16 @@ fn send_transaction(
     Ok(())
 }
 
-fn transaction_with_payer_as_only_signer(
+fn transaction_with_signers<T: Signers>(
     config: &Config,
     instructions: &[Instruction],
+    signers: &T,
 ) -> Result<Transaction, Error> {
     let (recent_blockhash, fee_calculator) = config.rpc_client.get_recent_blockhash()?;
     let transaction = Transaction::new_signed_with_payer(
         instructions,
         Some(&config.fee_payer.pubkey()),
-        &[config.fee_payer.as_ref()],
+        signers,
         recent_blockhash,
     );
 
@@ -315,8 +317,8 @@ fn command_vsa_create(
     vote_account: &Pubkey,
 ) -> CommandResult {
     println!("Creating stake account on {}", vote_account);
-
-    let mut transaction = Transaction::new_with_payer(
+    let transaction = transaction_with_signers(
+        config,
         &[
             // Create new validator stake account address
             spl_stake_pool::instruction::create_validator_stake_account_with_vote(
@@ -327,15 +329,8 @@ fn command_vsa_create(
                 vote_account,
             ),
         ],
-        Some(&config.fee_payer.pubkey()),
-    );
-
-    let (recent_blockhash, fee_calculator) = config.rpc_client.get_recent_blockhash()?;
-    check_fee_payer_balance(config, fee_calculator.calculate_fee(transaction.message()))?;
-    transaction.sign(
         &[config.fee_payer.as_ref(), config.staker.as_ref()],
-        recent_blockhash,
-    );
+    )?;
     send_transaction(config, transaction)?;
     Ok(())
 }
@@ -375,21 +370,21 @@ fn command_vsa_add(
         command_update(config, stake_pool_address, false, false)?;
     }
 
-    let instruction = spl_stake_pool::instruction::add_validator_to_pool_with_vote(
-        &spl_stake_pool::id(),
-        &stake_pool,
-        stake_pool_address,
-        vote_account,
-    );
-
-    let mut transaction =
-        Transaction::new_with_payer(&[instruction], Some(&config.fee_payer.pubkey()));
-
-    let (recent_blockhash, fee_calculator) = config.rpc_client.get_recent_blockhash()?;
-    check_fee_payer_balance(config, fee_calculator.calculate_fee(transaction.message()))?;
     let mut signers = vec![config.fee_payer.as_ref(), config.staker.as_ref()];
     unique_signers!(signers);
-    transaction.sign(&signers, recent_blockhash);
+    let transaction = transaction_with_signers(
+        config,
+        &[
+            spl_stake_pool::instruction::add_validator_to_pool_with_vote(
+                &spl_stake_pool::id(),
+                &stake_pool,
+                stake_pool_address,
+                vote_account,
+            ),
+        ],
+        &signers,
+    )?;
+
     send_transaction(config, transaction)?;
     Ok(())
 }
@@ -409,7 +404,10 @@ fn command_vsa_remove(
     let staker_pubkey = config.staker.pubkey();
     let new_authority = new_authority.as_ref().unwrap_or(&staker_pubkey);
 
-    let mut transaction = Transaction::new_with_payer(
+    let mut signers = vec![config.fee_payer.as_ref(), config.staker.as_ref()];
+    unique_signers!(signers);
+    let transaction = transaction_with_signers(
+        config,
         &[
             // Create new validator stake account address
             spl_stake_pool::instruction::remove_validator_from_pool_with_vote(
@@ -420,15 +418,8 @@ fn command_vsa_remove(
                 new_authority,
             ),
         ],
-        Some(&config.fee_payer.pubkey()),
-    );
-
-    let (recent_blockhash, fee_calculator) = config.rpc_client.get_recent_blockhash()?;
-    check_fee_payer_balance(config, fee_calculator.calculate_fee(transaction.message()))?;
-    transaction.sign(
-        &[config.fee_payer.as_ref(), config.staker.as_ref()],
-        recent_blockhash,
-    );
+        &signers,
+    )?;
     send_transaction(config, transaction)?;
     Ok(())
 }
@@ -445,23 +436,22 @@ fn command_increase_validator_stake(
     }
 
     let stake_pool = get_stake_pool(&config.rpc_client, stake_pool_address)?;
-    let instruction = spl_stake_pool::instruction::increase_validator_stake_with_vote(
-        &spl_stake_pool::id(),
-        &stake_pool,
-        stake_pool_address,
-        vote_account,
-        lamports,
-    );
 
-    let mut transaction =
-        Transaction::new_with_payer(&[instruction], Some(&config.fee_payer.pubkey()));
-
-    let (recent_blockhash, fee_calculator) = config.rpc_client.get_recent_blockhash()?;
-    check_fee_payer_balance(config, fee_calculator.calculate_fee(transaction.message()))?;
-    transaction.sign(
-        &[config.fee_payer.as_ref(), config.staker.as_ref()],
-        recent_blockhash,
-    );
+    let mut signers = vec![config.fee_payer.as_ref(), config.staker.as_ref()];
+    unique_signers!(signers);
+    let transaction = transaction_with_signers(
+        config,
+        &[
+            spl_stake_pool::instruction::increase_validator_stake_with_vote(
+                &spl_stake_pool::id(),
+                &stake_pool,
+                stake_pool_address,
+                vote_account,
+                lamports,
+            ),
+        ],
+        &signers,
+    )?;
     send_transaction(config, transaction)?;
     Ok(())
 }
@@ -478,23 +468,22 @@ fn command_decrease_validator_stake(
     }
 
     let stake_pool = get_stake_pool(&config.rpc_client, stake_pool_address)?;
-    let instruction = spl_stake_pool::instruction::decrease_validator_stake_with_vote(
-        &spl_stake_pool::id(),
-        &stake_pool,
-        stake_pool_address,
-        vote_account,
-        lamports,
-    );
 
-    let mut transaction =
-        Transaction::new_with_payer(&[instruction], Some(&config.fee_payer.pubkey()));
-
-    let (recent_blockhash, fee_calculator) = config.rpc_client.get_recent_blockhash()?;
-    check_fee_payer_balance(config, fee_calculator.calculate_fee(transaction.message()))?;
-    transaction.sign(
-        &[config.fee_payer.as_ref(), config.staker.as_ref()],
-        recent_blockhash,
-    );
+    let mut signers = vec![config.fee_payer.as_ref(), config.staker.as_ref()];
+    unique_signers!(signers);
+    let transaction = transaction_with_signers(
+        config,
+        &[
+            spl_stake_pool::instruction::decrease_validator_stake_with_vote(
+                &spl_stake_pool::id(),
+                &stake_pool,
+                stake_pool_address,
+                vote_account,
+                lamports,
+            ),
+        ],
+        &signers,
+    )?;
     send_transaction(config, transaction)?;
     Ok(())
 }
@@ -506,7 +495,10 @@ fn command_set_preferred_validator(
     vote_address: Option<Pubkey>,
 ) -> CommandResult {
     let stake_pool = get_stake_pool(&config.rpc_client, stake_pool_address)?;
-    let mut transaction = Transaction::new_with_payer(
+    let mut signers = vec![config.fee_payer.as_ref(), config.staker.as_ref()];
+    unique_signers!(signers);
+    let transaction = transaction_with_signers(
+        config,
         &[spl_stake_pool::instruction::set_preferred_validator(
             &spl_stake_pool::id(),
             stake_pool_address,
@@ -515,14 +507,8 @@ fn command_set_preferred_validator(
             preferred_type,
             vote_address,
         )],
-        Some(&config.fee_payer.pubkey()),
-    );
-
-    let (recent_blockhash, fee_calculator) = config.rpc_client.get_recent_blockhash()?;
-    check_fee_payer_balance(config, fee_calculator.calculate_fee(transaction.message()))?;
-    let mut signers = vec![config.fee_payer.as_ref(), config.staker.as_ref()];
-    unique_signers!(signers);
-    transaction.sign(&signers, recent_blockhash);
+        &signers,
+    )?;
     send_transaction(config, transaction)?;
     Ok(())
 }
@@ -783,15 +769,21 @@ fn command_update(
         let last_instruction = update_list_instructions.split_off(update_list_instructions_len - 1);
         // send the first ones without waiting
         for instruction in update_list_instructions {
-            let transaction = transaction_with_payer_as_only_signer(config, &[instruction])?;
+            let transaction =
+                transaction_with_signers(config, &[instruction], &[config.fee_payer.as_ref()])?;
             send_transaction_no_wait(config, transaction)?;
         }
 
         // wait on the last one
-        let transaction = transaction_with_payer_as_only_signer(config, &last_instruction)?;
+        let transaction =
+            transaction_with_signers(config, &last_instruction, &[config.fee_payer.as_ref()])?;
         send_transaction(config, transaction)?;
     }
-    let transaction = transaction_with_payer_as_only_signer(config, &[update_balance_instruction])?;
+    let transaction = transaction_with_signers(
+        config,
+        &[update_balance_instruction],
+        &[config.fee_payer.as_ref()],
+    )?;
     send_transaction(config, transaction)?;
 
     Ok(())
@@ -1062,7 +1054,10 @@ fn command_set_manager(
         }
     };
 
-    let mut transaction = Transaction::new_with_payer(
+    let mut signers = vec![config.fee_payer.as_ref(), config.manager.as_ref()];
+    unique_signers!(signers);
+    let transaction = transaction_with_signers(
+        config,
         &[spl_stake_pool::instruction::set_manager(
             &spl_stake_pool::id(),
             stake_pool_address,
@@ -1070,14 +1065,8 @@ fn command_set_manager(
             &new_manager,
             &new_fee_receiver,
         )],
-        Some(&config.fee_payer.pubkey()),
-    );
-
-    let (recent_blockhash, fee_calculator) = config.rpc_client.get_recent_blockhash()?;
-    check_fee_payer_balance(config, fee_calculator.calculate_fee(transaction.message()))?;
-    let mut signers = vec![config.fee_payer.as_ref(), config.manager.as_ref()];
-    unique_signers!(signers);
-    transaction.sign(&signers, recent_blockhash);
+        &signers,
+    )?;
     send_transaction(config, transaction)?;
     Ok(())
 }
@@ -1087,41 +1076,35 @@ fn command_set_staker(
     stake_pool_address: &Pubkey,
     new_staker: &Pubkey,
 ) -> CommandResult {
-    let mut transaction = Transaction::new_with_payer(
+    let mut signers = vec![config.fee_payer.as_ref(), config.manager.as_ref()];
+    unique_signers!(signers);
+    let transaction = transaction_with_signers(
+        config,
         &[spl_stake_pool::instruction::set_staker(
             &spl_stake_pool::id(),
             stake_pool_address,
             &config.manager.pubkey(),
             new_staker,
         )],
-        Some(&config.fee_payer.pubkey()),
-    );
-
-    let (recent_blockhash, fee_calculator) = config.rpc_client.get_recent_blockhash()?;
-    check_fee_payer_balance(config, fee_calculator.calculate_fee(transaction.message()))?;
-    let mut signers = vec![config.fee_payer.as_ref(), config.manager.as_ref()];
-    unique_signers!(signers);
-    transaction.sign(&signers, recent_blockhash);
+        &signers,
+    )?;
     send_transaction(config, transaction)?;
     Ok(())
 }
 
 fn command_set_fee(config: &Config, stake_pool_address: &Pubkey, new_fee: Fee) -> CommandResult {
-    let mut transaction = Transaction::new_with_payer(
+    let mut signers = vec![config.fee_payer.as_ref(), config.manager.as_ref()];
+    unique_signers!(signers);
+    let transaction = transaction_with_signers(
+        config,
         &[spl_stake_pool::instruction::set_fee(
             &spl_stake_pool::id(),
             stake_pool_address,
             &config.manager.pubkey(),
             new_fee,
         )],
-        Some(&config.fee_payer.pubkey()),
-    );
-
-    let (recent_blockhash, fee_calculator) = config.rpc_client.get_recent_blockhash()?;
-    check_fee_payer_balance(config, fee_calculator.calculate_fee(transaction.message()))?;
-    let mut signers = vec![config.fee_payer.as_ref(), config.manager.as_ref()];
-    unique_signers!(signers);
-    transaction.sign(&signers, recent_blockhash);
+        &signers,
+    )?;
     send_transaction(config, transaction)?;
     Ok(())
 }

--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -113,7 +113,7 @@ fn send_transaction(
     Ok(())
 }
 
-fn transaction_with_signers<T: Signers>(
+fn checked_transaction_with_signers<T: Signers>(
     config: &Config,
     instructions: &[Instruction],
     signers: &T,
@@ -317,7 +317,7 @@ fn command_vsa_create(
     vote_account: &Pubkey,
 ) -> CommandResult {
     println!("Creating stake account on {}", vote_account);
-    let transaction = transaction_with_signers(
+    let transaction = checked_transaction_with_signers(
         config,
         &[
             // Create new validator stake account address
@@ -372,7 +372,7 @@ fn command_vsa_add(
 
     let mut signers = vec![config.fee_payer.as_ref(), config.staker.as_ref()];
     unique_signers!(signers);
-    let transaction = transaction_with_signers(
+    let transaction = checked_transaction_with_signers(
         config,
         &[
             spl_stake_pool::instruction::add_validator_to_pool_with_vote(
@@ -406,7 +406,7 @@ fn command_vsa_remove(
 
     let mut signers = vec![config.fee_payer.as_ref(), config.staker.as_ref()];
     unique_signers!(signers);
-    let transaction = transaction_with_signers(
+    let transaction = checked_transaction_with_signers(
         config,
         &[
             // Create new validator stake account address
@@ -439,7 +439,7 @@ fn command_increase_validator_stake(
 
     let mut signers = vec![config.fee_payer.as_ref(), config.staker.as_ref()];
     unique_signers!(signers);
-    let transaction = transaction_with_signers(
+    let transaction = checked_transaction_with_signers(
         config,
         &[
             spl_stake_pool::instruction::increase_validator_stake_with_vote(
@@ -471,7 +471,7 @@ fn command_decrease_validator_stake(
 
     let mut signers = vec![config.fee_payer.as_ref(), config.staker.as_ref()];
     unique_signers!(signers);
-    let transaction = transaction_with_signers(
+    let transaction = checked_transaction_with_signers(
         config,
         &[
             spl_stake_pool::instruction::decrease_validator_stake_with_vote(
@@ -497,7 +497,7 @@ fn command_set_preferred_validator(
     let stake_pool = get_stake_pool(&config.rpc_client, stake_pool_address)?;
     let mut signers = vec![config.fee_payer.as_ref(), config.staker.as_ref()];
     unique_signers!(signers);
-    let transaction = transaction_with_signers(
+    let transaction = checked_transaction_with_signers(
         config,
         &[spl_stake_pool::instruction::set_preferred_validator(
             &spl_stake_pool::id(),
@@ -769,17 +769,23 @@ fn command_update(
         let last_instruction = update_list_instructions.split_off(update_list_instructions_len - 1);
         // send the first ones without waiting
         for instruction in update_list_instructions {
-            let transaction =
-                transaction_with_signers(config, &[instruction], &[config.fee_payer.as_ref()])?;
+            let transaction = checked_transaction_with_signers(
+                config,
+                &[instruction],
+                &[config.fee_payer.as_ref()],
+            )?;
             send_transaction_no_wait(config, transaction)?;
         }
 
         // wait on the last one
-        let transaction =
-            transaction_with_signers(config, &last_instruction, &[config.fee_payer.as_ref()])?;
+        let transaction = checked_transaction_with_signers(
+            config,
+            &last_instruction,
+            &[config.fee_payer.as_ref()],
+        )?;
         send_transaction(config, transaction)?;
     }
-    let transaction = transaction_with_signers(
+    let transaction = checked_transaction_with_signers(
         config,
         &[update_balance_instruction],
         &[config.fee_payer.as_ref()],
@@ -1056,7 +1062,7 @@ fn command_set_manager(
 
     let mut signers = vec![config.fee_payer.as_ref(), config.manager.as_ref()];
     unique_signers!(signers);
-    let transaction = transaction_with_signers(
+    let transaction = checked_transaction_with_signers(
         config,
         &[spl_stake_pool::instruction::set_manager(
             &spl_stake_pool::id(),
@@ -1078,7 +1084,7 @@ fn command_set_staker(
 ) -> CommandResult {
     let mut signers = vec![config.fee_payer.as_ref(), config.manager.as_ref()];
     unique_signers!(signers);
-    let transaction = transaction_with_signers(
+    let transaction = checked_transaction_with_signers(
         config,
         &[spl_stake_pool::instruction::set_staker(
             &spl_stake_pool::id(),
@@ -1095,7 +1101,7 @@ fn command_set_staker(
 fn command_set_fee(config: &Config, stake_pool_address: &Pubkey, new_fee: Fee) -> CommandResult {
     let mut signers = vec![config.fee_payer.as_ref(), config.manager.as_ref()];
     unique_signers!(signers);
-    let transaction = transaction_with_signers(
+    let transaction = checked_transaction_with_signers(
         config,
         &[spl_stake_pool::instruction::set_fee(
             &spl_stake_pool::id(),

--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -90,9 +90,7 @@ fn send_transaction_no_wait(
         let result = config.rpc_client.simulate_transaction(&transaction)?;
         println!("Simulate result: {:?}", result);
     } else {
-        let signature = config
-            .rpc_client
-            .send_transaction(&transaction)?;
+        let signature = config.rpc_client.send_transaction(&transaction)?;
         println!("Signature: {}", signature);
     }
     Ok(())
@@ -691,8 +689,14 @@ fn command_list(config: &Config, stake_pool_address: &Pubkey) -> CommandResult {
         "Total Pool Tokens: {}",
         spl_token::amount_to_ui_amount(stake_pool.pool_token_supply, pool_mint.decimals)
     );
-    println!("Total number of validators: {}", validator_list.validators.len());
-    println!("Max number of validators: {}", validator_list.max_validators);
+    println!(
+        "Total number of validators: {}",
+        validator_list.validators.len()
+    );
+    println!(
+        "Max number of validators: {}",
+        validator_list.max_validators
+    );
 
     if config.verbose {
         println!();
@@ -749,17 +753,19 @@ fn command_update(
 
     let validator_list = get_validator_list(&config.rpc_client, &stake_pool.validator_list)?;
 
-    let (mut update_list_instructions, update_balance_instruction) = spl_stake_pool::instruction::update_stake_pool(
-        &spl_stake_pool::id(),
-        &stake_pool,
-        &validator_list,
-        stake_pool_address,
-        no_merge,
-    );
+    let (mut update_list_instructions, update_balance_instruction) =
+        spl_stake_pool::instruction::update_stake_pool(
+            &spl_stake_pool::id(),
+            &stake_pool,
+            &validator_list,
+            stake_pool_address,
+            no_merge,
+        );
 
     let update_list_instructions_len = update_list_instructions.len();
     if update_list_instructions_len > 0 {
-        let mut last_instruction = update_list_instructions.split_off(update_list_instructions_len - 1);
+        let mut last_instruction =
+            update_list_instructions.split_off(update_list_instructions_len - 1);
         // send the first ones without waiting
         for instruction in update_list_instructions {
             let mut transaction =
@@ -772,8 +778,10 @@ fn command_update(
         }
 
         // wait on the last one
-        let mut transaction =
-            Transaction::new_with_payer(&[last_instruction.pop().unwrap()], Some(&config.fee_payer.pubkey()));
+        let mut transaction = Transaction::new_with_payer(
+            &[last_instruction.pop().unwrap()],
+            Some(&config.fee_payer.pubkey()),
+        );
 
         let (recent_blockhash, fee_calculator) = config.rpc_client.get_recent_blockhash()?;
         check_fee_payer_balance(config, fee_calculator.calculate_fee(transaction.message()))?;
@@ -781,8 +789,10 @@ fn command_update(
         send_transaction(config, transaction)?;
     }
 
-    let mut transaction =
-        Transaction::new_with_payer(&[update_balance_instruction], Some(&config.fee_payer.pubkey()));
+    let mut transaction = Transaction::new_with_payer(
+        &[update_balance_instruction],
+        Some(&config.fee_payer.pubkey()),
+    );
 
     let (recent_blockhash, fee_calculator) = config.rpc_client.get_recent_blockhash()?;
     check_fee_payer_balance(config, fee_calculator.calculate_fee(transaction.message()))?;

--- a/stake-pool/program/src/lib.rs
+++ b/stake-pool/program/src/lib.rs
@@ -33,7 +33,7 @@ pub const MINIMUM_ACTIVE_STAKE: u64 = LAMPORTS_PER_SOL;
 
 /// Maximum amount of validator stake accounts to update per
 /// `UpdateValidatorListBalance` instruction, based on compute limits
-pub const MAX_VALIDATORS_TO_UPDATE: usize = 9;
+pub const MAX_VALIDATORS_TO_UPDATE: usize = 5;
 
 /// Get the stake amount under consideration when calculating pool token
 /// conversions


### PR DESCRIPTION
#### Problem

When testing locally with 32-slot epochs, on bigger pools, it would take longer than an epoch to just update.

#### Solution

Split up the updating instructions to process all of them at the same time, and also reduce the number of accounts updated at once to avoid using up the whole compute budget.  This allows us to work with stake pools of roughly 200 validators.