### PR TITLE
Governance: future proofing for v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3720,7 +3720,7 @@ dependencies = [
 
 [[package]]
 name = "spl-governance"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "arrayref",
  "assert_matches",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3720,7 +3720,7 @@ dependencies = [
 
 [[package]]
 name = "spl-governance"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrayref",
  "assert_matches",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3724,6 +3724,7 @@ version = "0.1.0"
 dependencies = [
  "arrayref",
  "assert_matches",
+ "base64 0.13.0",
  "bincode",
  "borsh",
  "num-derive",

--- a/governance/program/Cargo.toml
+++ b/governance/program/Cargo.toml
@@ -25,6 +25,7 @@ thiserror = "1.0"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
+base64 = "0.13"
 proptest = "1.0"
 solana-program-test = "1.7.4"
 solana-sdk = "1.7.4"

--- a/governance/program/Cargo.toml
+++ b/governance/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-governance"
-version = "1.0.0"
+version = "1.0.1"
 description = "Solana Program Library Governance Program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/governance/program/Cargo.toml
+++ b/governance/program/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spl-governance"
-version = "0.1.0"
-description = "Solana Program Library Governance"
+version = "1.0.0"
+description = "Solana Program Library Governance Program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
@@ -20,7 +20,7 @@ num-traits = "0.2"
 serde = "1.0.126"
 serde_derive = "1.0.103"
 solana-program = "1.7.4"
-spl-token = { path = "../../token/program", features = [ "no-entrypoint" ] }
+spl-token = { version = "3.1.1", path = "../../token/program", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 pub enum GovernanceError {
     /// Invalid instruction passed to program
     #[error("Invalid instruction passed to program")]
-    InvalidInstruction = 500,
+    InvalidInstruction = 500, // Start Governance custom errors from 500 to avoid conflicts with programs invoked via CPI
 
     /// Realm with the given name and governing mints already exists
     #[error("Realm with the given name and governing mints already exists")]

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 pub enum GovernanceError {
     /// Invalid instruction passed to program
     #[error("Invalid instruction passed to program")]
-    InvalidInstruction,
+    InvalidInstruction = 500,
 
     /// Realm with the given name and governing mints already exists
     #[error("Realm with the given name and governing mints already exists")]

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -267,6 +267,10 @@ pub enum GovernanceError {
     /// Given VoteWeightSource is not supported
     #[error("Given VoteWeightSource is not supported")]
     VoteWeightSourceNotSupported,
+
+    /// Proposal cool off time is not supported
+    #[error("Proposal cool off time is not supported")]
+    ProposalCoolOffTimeNotSupported,
 }
 
 impl PrintProgramError for GovernanceError {

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -259,6 +259,10 @@ pub enum GovernanceError {
     /// Current token owner must sign transaction
     #[error("Current token owner must sign transaction")]
     TokenOwnerMustSign,
+
+    /// Given VoteThresholdPercentageType is not supported
+    #[error("Given VoteThresholdPercentageType is not supported")]
+    VoteThresholdPercentageTypeNotSupported,
 }
 
 impl PrintProgramError for GovernanceError {

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -263,6 +263,10 @@ pub enum GovernanceError {
     /// Given VoteThresholdPercentageType is not supported
     #[error("Given VoteThresholdPercentageType is not supported")]
     VoteThresholdPercentageTypeNotSupported,
+
+    /// Given VoteWeightSource is not supported
+    #[error("Given VoteWeightSource is not supported")]
+    VoteWeightSourceNotSupported,
 }
 
 impl PrintProgramError for GovernanceError {

--- a/governance/program/src/processor/process_create_account_governance.rs
+++ b/governance/program/src/processor/process_create_account_governance.rs
@@ -40,6 +40,7 @@ pub fn process_create_account_governance(
         account_type: GovernanceAccountType::AccountGovernance,
         config: config.clone(),
         proposals_count: 0,
+        reserved: 0,
     };
 
     create_and_serialize_account_signed::<Governance>(

--- a/governance/program/src/processor/process_create_account_governance.rs
+++ b/governance/program/src/processor/process_create_account_governance.rs
@@ -40,7 +40,7 @@ pub fn process_create_account_governance(
         account_type: GovernanceAccountType::AccountGovernance,
         config: config.clone(),
         proposals_count: 0,
-        reserved: 0,
+        reserved: [0; 8],
     };
 
     create_and_serialize_account_signed::<Governance>(

--- a/governance/program/src/processor/process_create_mint_governance.rs
+++ b/governance/program/src/processor/process_create_mint_governance.rs
@@ -50,6 +50,7 @@ pub fn process_create_mint_governance(
         account_type: GovernanceAccountType::MintGovernance,
         config: config.clone(),
         proposals_count: 0,
+        reserved: 0,
     };
 
     create_and_serialize_account_signed::<Governance>(

--- a/governance/program/src/processor/process_create_mint_governance.rs
+++ b/governance/program/src/processor/process_create_mint_governance.rs
@@ -50,7 +50,7 @@ pub fn process_create_mint_governance(
         account_type: GovernanceAccountType::MintGovernance,
         config: config.clone(),
         proposals_count: 0,
-        reserved: 0,
+        reserved: [0; 8],
     };
 
     create_and_serialize_account_signed::<Governance>(

--- a/governance/program/src/processor/process_create_program_governance.rs
+++ b/governance/program/src/processor/process_create_program_governance.rs
@@ -53,7 +53,7 @@ pub fn process_create_program_governance(
         account_type: GovernanceAccountType::ProgramGovernance,
         config: config.clone(),
         proposals_count: 0,
-        reserved: 0,
+        reserved: [0; 8],
     };
 
     create_and_serialize_account_signed::<Governance>(

--- a/governance/program/src/processor/process_create_program_governance.rs
+++ b/governance/program/src/processor/process_create_program_governance.rs
@@ -53,6 +53,7 @@ pub fn process_create_program_governance(
         account_type: GovernanceAccountType::ProgramGovernance,
         config: config.clone(),
         proposals_count: 0,
+        reserved: 0,
     };
 
     create_and_serialize_account_signed::<Governance>(

--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -13,7 +13,7 @@ use solana_program::{
 use crate::{
     error::GovernanceError,
     state::{
-        enums::{GovernanceAccountType, ProposalState},
+        enums::{GovernanceAccountType, InstructionExecutionFlags, ProposalState},
         governance::get_governance_data,
         proposal::{get_proposal_address_seeds, Proposal},
         token_owner_record::get_token_owner_record_data_for_realm_and_governing_mint,
@@ -93,7 +93,7 @@ pub fn process_create_proposal(
         instructions_count: 0,
         instructions_next_index: 0,
 
-        execution_flags: None,
+        execution_flags: InstructionExecutionFlags::None,
 
         yes_votes_count: 0,
         no_votes_count: 0,

--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -93,6 +93,8 @@ pub fn process_create_proposal(
         instructions_count: 0,
         instructions_next_index: 0,
 
+        execution_flags: None,
+
         yes_votes_count: 0,
         no_votes_count: 0,
     };

--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -84,6 +84,7 @@ pub fn process_create_proposal(
         draft_at: clock.unix_timestamp,
         signing_off_at: None,
         voting_at: None,
+        voting_at_slot: None,
         voting_completed_at: None,
         executing_at: None,
         closed_at: None,

--- a/governance/program/src/processor/process_create_realm.rs
+++ b/governance/program/src/processor/process_create_realm.rs
@@ -83,7 +83,7 @@ pub fn process_create_realm(
         community_mint: *governance_token_mint_info.key,
         council_mint: council_token_mint_address,
         name: name.clone(),
-        reserved: 0,
+        reserved: [0; 8],
     };
 
     create_and_serialize_account_signed::<Realm>(

--- a/governance/program/src/processor/process_create_realm.rs
+++ b/governance/program/src/processor/process_create_realm.rs
@@ -83,6 +83,7 @@ pub fn process_create_realm(
         community_mint: *governance_token_mint_info.key,
         council_mint: council_token_mint_address,
         name: name.clone(),
+        reserved: 0,
     };
 
     create_and_serialize_account_signed::<Realm>(

--- a/governance/program/src/processor/process_create_token_governance.rs
+++ b/governance/program/src/processor/process_create_token_governance.rs
@@ -50,7 +50,7 @@ pub fn process_create_token_governance(
         account_type: GovernanceAccountType::TokenGovernance,
         config: config.clone(),
         proposals_count: 0,
-        reserved: 0,
+        reserved: [0; 8],
     };
 
     create_and_serialize_account_signed::<Governance>(

--- a/governance/program/src/processor/process_create_token_governance.rs
+++ b/governance/program/src/processor/process_create_token_governance.rs
@@ -50,6 +50,7 @@ pub fn process_create_token_governance(
         account_type: GovernanceAccountType::TokenGovernance,
         config: config.clone(),
         proposals_count: 0,
+        reserved: 0,
     };
 
     create_and_serialize_account_signed::<Governance>(

--- a/governance/program/src/processor/process_deposit_governing_tokens.rs
+++ b/governance/program/src/processor/process_deposit_governing_tokens.rs
@@ -87,6 +87,7 @@ pub fn process_deposit_governing_tokens(
             governance_delegate: None,
             unrelinquished_votes_count: 0,
             total_votes_count: 0,
+            reserved: 0,
         };
 
         create_and_serialize_account_signed(

--- a/governance/program/src/processor/process_deposit_governing_tokens.rs
+++ b/governance/program/src/processor/process_deposit_governing_tokens.rs
@@ -87,7 +87,7 @@ pub fn process_deposit_governing_tokens(
             governance_delegate: None,
             unrelinquished_votes_count: 0,
             total_votes_count: 0,
-            reserved: 0,
+            reserved: [0; 8],
         };
 
         create_and_serialize_account_signed(

--- a/governance/program/src/processor/process_execute_instruction.rs
+++ b/governance/program/src/processor/process_execute_instruction.rs
@@ -80,7 +80,7 @@ pub fn process_execute_instruction(program_id: &Pubkey, accounts: &[AccountInfo]
     proposal_data.serialize(&mut *proposal_info.data.borrow_mut())?;
 
     proposal_instruction_data.executed_at = Some(clock.unix_timestamp);
-    proposal_instruction_data.execution_status = Some(InstructionExecutionStatus::Success);
+    proposal_instruction_data.execution_status = InstructionExecutionStatus::Success;
     proposal_instruction_data.serialize(&mut *proposal_instruction_info.data.borrow_mut())?;
 
     Ok(())

--- a/governance/program/src/processor/process_execute_instruction.rs
+++ b/governance/program/src/processor/process_execute_instruction.rs
@@ -12,7 +12,8 @@ use solana_program::{
 };
 
 use crate::state::{
-    enums::ProposalState, governance::get_governance_data,
+    enums::{InstructionExecutionStatus, ProposalState},
+    governance::get_governance_data,
     proposal::get_proposal_data_for_governance,
     proposal_instruction::get_proposal_instruction_data_for_proposal,
 };
@@ -79,6 +80,7 @@ pub fn process_execute_instruction(program_id: &Pubkey, accounts: &[AccountInfo]
     proposal_data.serialize(&mut *proposal_info.data.borrow_mut())?;
 
     proposal_instruction_data.executed_at = Some(clock.unix_timestamp);
+    proposal_instruction_data.execution_status = Some(InstructionExecutionStatus::Success);
     proposal_instruction_data.serialize(&mut *proposal_instruction_info.data.borrow_mut())?;
 
     Ok(())

--- a/governance/program/src/processor/process_insert_instruction.rs
+++ b/governance/program/src/processor/process_insert_instruction.rs
@@ -29,7 +29,7 @@ use crate::{
 pub fn process_insert_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
-    index: u16,
+    instruction_index: u16,
     hold_up_time: u32,
     instruction: InstructionData,
 ) -> ProgramResult {
@@ -70,7 +70,7 @@ pub fn process_insert_instruction(
 
     token_owner_record_data.assert_token_owner_or_delegate_is_signer(governance_authority_info)?;
 
-    match index.cmp(&proposal_data.instructions_next_index) {
+    match instruction_index.cmp(&proposal_data.instructions_next_index) {
         Ordering::Greater => return Err(GovernanceError::InvalidInstructionIndex.into()),
         // If the index is the same as instructions_next_index then we are adding a new instruction
         // If the index is below instructions_next_index then we are inserting into an existing empty space
@@ -88,6 +88,7 @@ pub fn process_insert_instruction(
 
     let proposal_instruction_data = ProposalInstruction {
         account_type: GovernanceAccountType::ProposalInstruction,
+        instruction_index,
         hold_up_time,
         instruction,
         executed_at: None,
@@ -99,7 +100,10 @@ pub fn process_insert_instruction(
         payer_info,
         proposal_instruction_info,
         &proposal_instruction_data,
-        &get_proposal_instruction_address_seeds(proposal_info.key, &index.to_le_bytes()),
+        &get_proposal_instruction_address_seeds(
+            proposal_info.key,
+            &instruction_index.to_le_bytes(),
+        ),
         program_id,
         system_info,
         rent,

--- a/governance/program/src/processor/process_insert_instruction.rs
+++ b/governance/program/src/processor/process_insert_instruction.rs
@@ -14,7 +14,7 @@ use solana_program::{
 use crate::{
     error::GovernanceError,
     state::{
-        enums::GovernanceAccountType,
+        enums::{GovernanceAccountType, InstructionExecutionStatus},
         governance::get_governance_data,
         proposal::get_proposal_data_for_governance,
         proposal_instruction::{
@@ -92,7 +92,7 @@ pub fn process_insert_instruction(
         hold_up_time,
         instruction,
         executed_at: None,
-        execution_status: None,
+        execution_status: InstructionExecutionStatus::None,
         proposal: *proposal_info.key,
     };
 

--- a/governance/program/src/processor/process_insert_instruction.rs
+++ b/governance/program/src/processor/process_insert_instruction.rs
@@ -91,6 +91,7 @@ pub fn process_insert_instruction(
         hold_up_time,
         instruction,
         executed_at: None,
+        execution_status: None,
         proposal: *proposal_info.key,
     };
 

--- a/governance/program/src/processor/process_sign_off_proposal.rs
+++ b/governance/program/src/processor/process_sign_off_proposal.rs
@@ -53,6 +53,7 @@ pub fn process_sign_off_proposal(program_id: &Pubkey, accounts: &[AccountInfo]) 
     // If all Signatories signed off we can start voting
     if proposal_data.signatories_signed_off_count == proposal_data.signatories_count {
         proposal_data.voting_at = Some(clock.unix_timestamp);
+        proposal_data.voting_at_slot = Some(clock.slot);
         proposal_data.state = ProposalState::Voting;
     }
 

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -92,3 +92,20 @@ impl Default for ProposalState {
         ProposalState::Draft
     }
 }
+
+/// The type of the vote threshold percentage used to resolve a vote on a Proposal
+#[repr(C)]
+#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+pub enum VoteThresholdPercentageType {
+    /// Voting threshold of Yes votes in % required to tip the vote
+    /// It's the percentage of tokens out of the entire pool of governance tokens eligible to vote
+    /// Note: If the threshold is below or equal to 50% then an even split of votes ex: 50:50 or 40:40 is always resolved as Defeated
+    /// In other words +1 vote tie breaker is always required to have a successful vote
+    YesVote,
+
+    /// The minimum number of votes in % out of the entire pool of governance tokens eligible to vote
+    /// which must be cast for the vote to be valid
+    /// Once the quorum is achieved a simple majority (50%+1) of Yes votes is required for the vote to succeed
+    /// Note: Quorum is not implemented in V1
+    Quorum,
+}

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -106,7 +106,7 @@ pub enum VoteThresholdPercentageType {
     /// The minimum number of votes in % out of the entire pool of governance tokens eligible to vote
     /// which must be cast for the vote to be valid
     /// Once the quorum is achieved a simple majority (50%+1) of Yes votes is required for the vote to succeed
-    /// Note: Quorum is not implemented in V1
+    /// Note: Quorum is not implemented in the current version
     Quorum,
 }
 
@@ -117,7 +117,7 @@ pub enum VoteWeightSource {
     /// Governing token deposits into the Realm are used as voter weights
     Deposit,
     /// Governing token account snapshots as of the time a proposal entered voting state are used as voter weights
-    /// Note: Snapshot source is not supported in V1
+    /// Note: Snapshot source is not supported in the current version
     /// Support for account snapshots are required in solana and/or arweave as a prerequisite
     Snapshot,
 }
@@ -140,12 +140,12 @@ pub enum InstructionExecutionStatus {
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum InstructionExecutionFlags {
     /// Instructions are executed in a specific order
-    /// Note: Ordered execution is not supported in V1
+    /// Note: Ordered execution is not supported in the current version
     /// The implementation requires another account type to track deleted instructions
     Ordered,
 
     /// Multiple instructions can be executed as a single transaction
-    /// Note: Transactions are not supported in V1
+    /// Note: Transactions are not supported in the current version
     /// The implementation requires another account type to group instructions within a transaction
     UseTransaction,
 }

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -96,18 +96,18 @@ impl Default for ProposalState {
 /// The type of the vote threshold percentage used to resolve a vote on a Proposal
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
-pub enum VoteThresholdPercentageType {
+pub enum VoteThresholdPercentage {
     /// Voting threshold of Yes votes in % required to tip the vote
     /// It's the percentage of tokens out of the entire pool of governance tokens eligible to vote
     /// Note: If the threshold is below or equal to 50% then an even split of votes ex: 50:50 or 40:40 is always resolved as Defeated
-    /// In other words +1 vote tie breaker is always required to have a successful vote
-    YesVote,
+    /// In other words a '+1 vote' tie breaker is always required to have a successful vote
+    YesVote(u8),
 
     /// The minimum number of votes in % out of the entire pool of governance tokens eligible to vote
     /// which must be cast for the vote to be valid
     /// Once the quorum is achieved a simple majority (50%+1) of Yes votes is required for the vote to succeed
     /// Note: Quorum is not implemented in the current version
-    Quorum,
+    Quorum(u8),
 }
 
 /// The source of voter weights used to vote on proposals

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -134,3 +134,18 @@ pub enum InstructionExecutionStatus {
     /// We either have to make it possible to change that behavior or add an instruction to manually set the status
     Error,
 }
+
+/// Instruction execution flags defining how instructions are executed for a Proposal
+#[repr(C)]
+#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+pub enum InstructionExecutionFlags {
+    /// Instructions are executed in a specific order
+    /// Note: Ordered execution is not supported in V1
+    /// The implementation requires another account type to track deleted instructions
+    Ordered,
+
+    /// Multiple instructions can be executed as a single transaction
+    /// Note: Transactions are not supported in V1
+    /// The implementation requires another account type to group instructions within a transaction
+    UseTransaction,
+}

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -126,6 +126,9 @@ pub enum VoteWeightSource {
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum InstructionExecutionStatus {
+    /// Instruction was not executed yet
+    None,
+
     /// Instruction was executed successfully
     Success,
 

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -121,3 +121,16 @@ pub enum VoteWeightSource {
     /// Support for account snapshots are required in solana and/or arweave as a prerequisite
     Snapshot,
 }
+
+/// The status of instruction execution
+#[repr(C)]
+#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+pub enum InstructionExecutionStatus {
+    /// Instruction was executed successfully
+    Success,
+
+    /// Instruction execution failed
+    /// Note: Error status is not supported yet because when CPI call fails it always terminates parent instruction
+    /// We either have to make it possible to change that behavior or add an instruction to manually set the status
+    Error,
+}

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -142,6 +142,10 @@ pub enum InstructionExecutionStatus {
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum InstructionExecutionFlags {
+    /// No execution flags are specified
+    /// Instructions can be executed individually, in any order, as soon as they hold_up time expires
+    None,
+
     /// Instructions are executed in a specific order
     /// Note: Ordered execution is not supported in the current version
     /// The implementation requires another account type to track deleted instructions

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -109,3 +109,15 @@ pub enum VoteThresholdPercentageType {
     /// Note: Quorum is not implemented in V1
     Quorum,
 }
+
+/// The source of voter weights used to vote on proposals
+#[repr(C)]
+#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+pub enum VoteWeightSource {
+    /// Governing token deposits into the Realm are used as voter weights
+    Deposit,
+    /// Governing token account snapshots as of the time a proposal entered voting state are used as voter weights
+    /// Note: Snapshot source is not supported in V1
+    /// Support for account snapshots are required in solana and/or arweave as a prerequisite
+    Snapshot,
+}

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -25,6 +25,7 @@ pub struct GovernanceConfig {
     pub governed_account: Pubkey,
 
     /// The type of the vote threshold used for voting
+    /// Note: In the current version only YesVote threshold is supported
     pub vote_threshold_percentage_type: VoteThresholdPercentageType,
 
     /// The vote threshold value of the type defined by vote_threshold_percentage_type
@@ -42,6 +43,11 @@ pub struct GovernanceConfig {
     /// The source of vote weight for voters
     /// Note: In the current version only token deposits are accepted as vote weight
     pub vote_weight_source: VoteWeightSource,
+
+    /// The time period within which a Proposal can be still cancelled after being voted on
+    /// Once cool off time expires Proposal can't be cancelled any longer and becomes a law
+    /// Note: This field is not implemented in the current version
+    pub proposal_cool_off_time: u32,
 }
 
 /// Governance Account

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -61,7 +61,7 @@ pub struct Governance {
     pub config: GovernanceConfig,
 
     /// Reserved space for future versions
-    pub reserved: u64,
+    pub reserved: [u8; 8],
 
     /// Running count of proposals
     pub proposals_count: u32,

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -44,7 +44,7 @@ pub struct GovernanceConfig {
     /// Note: In the current version only token deposits are accepted as vote weight
     pub vote_weight_source: VoteWeightSource,
 
-    /// The time period within which a Proposal can be still cancelled after being voted on
+    /// The time period in seconds within which a Proposal can be still cancelled after being voted on
     /// Once cool off time expires Proposal can't be cancelled any longer and becomes a law
     /// Note: This field is not implemented in the current version
     pub proposal_cool_off_time: u32,
@@ -59,6 +59,9 @@ pub struct Governance {
 
     /// Governance config
     pub config: GovernanceConfig,
+
+    /// Reserved space for future versions
+    pub reserved: u64,
 
     /// Running count of proposals
     pub proposals_count: u32,

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -236,5 +236,9 @@ pub fn assert_is_valid_governance_config(
         return Err(GovernanceError::VoteWeightSourceNotSupported.into());
     }
 
+    if governance_config.proposal_cool_off_time > 0 {
+        return Err(GovernanceError::ProposalCoolOffTimeNotSupported.into());
+    }
+
     Ok(())
 }

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -221,7 +221,7 @@ pub fn assert_is_valid_governance_config(
 
     match governance_config.vote_threshold_percentage {
         VoteThresholdPercentage::YesVote(yes_vote_threshold_percentage) => {
-            if yes_vote_threshold_percentage < 1 || yes_vote_threshold_percentage > 100 {
+            if !(1..=100).contains(&yes_vote_threshold_percentage) {
                 return Err(GovernanceError::InvalidGovernanceConfig.into());
             }
         }

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -31,7 +31,7 @@ pub struct GovernanceConfig {
     pub vote_threshold_percentage: u8,
 
     /// Minimum number of tokens a governance token owner must possess to be able to create a proposal
-    pub min_tokens_to_create_proposal: u16,
+    pub min_tokens_to_create_proposal: u64,
 
     /// Minimum waiting time in seconds for an instruction to be executed after proposal is voted on
     pub min_instruction_hold_up_time: u32,

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -3,7 +3,7 @@
 use crate::{
     error::GovernanceError,
     state::{
-        enums::{GovernanceAccountType, VoteThresholdPercentageType, VoteWeightSource},
+        enums::{GovernanceAccountType, VoteThresholdPercentage, VoteWeightSource},
         realm::assert_is_valid_realm,
     },
     tools::account::{get_account_data, AccountMaxSize},
@@ -26,10 +26,7 @@ pub struct GovernanceConfig {
 
     /// The type of the vote threshold used for voting
     /// Note: In the current version only YesVote threshold is supported
-    pub vote_threshold_percentage_type: VoteThresholdPercentageType,
-
-    /// The vote threshold value of the type defined by vote_threshold_percentage_type
-    pub vote_threshold_percentage: u8,
+    pub vote_threshold_percentage: VoteThresholdPercentage,
 
     /// Minimum number of tokens a governance token owner must possess to be able to create a proposal
     pub min_tokens_to_create_proposal: u64,
@@ -222,14 +219,15 @@ pub fn assert_is_valid_governance_config(
 
     assert_is_valid_realm(program_id, realm_info)?;
 
-    if governance_config.vote_threshold_percentage < 1
-        || governance_config.vote_threshold_percentage > 100
-    {
-        return Err(GovernanceError::InvalidGovernanceConfig.into());
-    }
-
-    if governance_config.vote_threshold_percentage_type != VoteThresholdPercentageType::YesVote {
-        return Err(GovernanceError::VoteThresholdPercentageTypeNotSupported.into());
+    match governance_config.vote_threshold_percentage {
+        VoteThresholdPercentage::YesVote(yes_vote_threshold_percentage) => {
+            if yes_vote_threshold_percentage < 1 || yes_vote_threshold_percentage > 100 {
+                return Err(GovernanceError::InvalidGovernanceConfig.into());
+            }
+        }
+        _ => {
+            return Err(GovernanceError::VoteThresholdPercentageTypeNotSupported.into());
+        }
     }
 
     if governance_config.vote_weight_source != VoteWeightSource::Deposit {

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -200,7 +200,7 @@ impl Proposal {
         config: &GovernanceConfig,
     ) -> ProposalState {
         let yes_vote_threshold_count =
-            get_vote_threshold_count(config.yes_vote_threshold_percentage, governing_token_supply);
+            get_vote_threshold_count(config.vote_threshold_percentage, governing_token_supply);
 
         // Yes vote must be equal or above the required yes_vote_threshold_percentage and higher than No vote
         // The same number of Yes and No votes is a tie and resolved as Defeated
@@ -244,7 +244,7 @@ impl Proposal {
         }
 
         let yes_vote_threshold_count =
-            get_vote_threshold_count(config.yes_vote_threshold_percentage, governing_token_supply);
+            get_vote_threshold_count(config.vote_threshold_percentage, governing_token_supply);
 
         if self.yes_votes_count >= yes_vote_threshold_count
             && self.yes_votes_count > (governing_token_supply - self.yes_votes_count)
@@ -399,6 +399,7 @@ pub fn get_proposal_address<'a>(
 
 #[cfg(test)]
 mod test {
+    use crate::state::enums::VoteThresholdPercentageType;
 
     use {super::*, proptest::prelude::*};
 
@@ -433,10 +434,11 @@ mod test {
         GovernanceConfig {
             realm: Pubkey::new_unique(),
             governed_account: Pubkey::new_unique(),
-            yes_vote_threshold_percentage: 60,
+            vote_threshold_percentage: 60,
             min_tokens_to_create_proposal: 5,
             min_instruction_hold_up_time: 10,
             max_voting_time: 5,
+            vote_threshold_percentage_type: VoteThresholdPercentageType::YesVote,
         }
     }
 
@@ -812,7 +814,7 @@ mod test {
             proposal.state = ProposalState::Voting;
 
             let mut governance_config = create_test_governance_config();
-            governance_config.yes_vote_threshold_percentage = test_case.vote_threshold_percentage;
+            governance_config.vote_threshold_percentage = test_case.vote_threshold_percentage;
 
             let current_timestamp = 15_i64;
 
@@ -836,7 +838,7 @@ mod test {
             proposal.state = ProposalState::Voting;
 
             let mut governance_config = create_test_governance_config();
-            governance_config.yes_vote_threshold_percentage = test_case.vote_threshold_percentage;
+            governance_config.vote_threshold_percentage = test_case.vote_threshold_percentage;
 
             let current_timestamp = 16_i64;
 
@@ -878,7 +880,7 @@ mod test {
 
 
             let mut governance_config = create_test_governance_config();
-            governance_config.yes_vote_threshold_percentage = yes_vote_threshold_percentage;
+            governance_config.vote_threshold_percentage = yes_vote_threshold_percentage;
 
             let current_timestamp = 15_i64;
 
@@ -914,7 +916,7 @@ mod test {
 
 
             let mut governance_config = create_test_governance_config();
-            governance_config.yes_vote_threshold_percentage = yes_vote_threshold_percentage;
+            governance_config.vote_threshold_percentage = yes_vote_threshold_percentage;
 
             let current_timestamp = 16_i64;
 

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -6,17 +6,17 @@ use solana_program::{
     pubkey::Pubkey,
 };
 
-use crate::tools::account::get_account_data;
-use crate::{error::GovernanceError, tools::account::AccountMaxSize, PROGRAM_AUTHORITY_SEED};
-
-use crate::state::enums::{GovernanceAccountType, ProposalState};
+use crate::{
+    error::GovernanceError,
+    state::{
+        enums::{GovernanceAccountType, InstructionExecutionFlags, ProposalState},
+        governance::GovernanceConfig,
+        proposal_instruction::ProposalInstruction,
+    },
+    tools::account::{get_account_data, AccountMaxSize},
+    PROGRAM_AUTHORITY_SEED,
+};
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-
-use crate::state::governance::GovernanceConfig;
-
-use crate::state::proposal_instruction::ProposalInstruction;
-
-use super::enums::InstructionExecutionFlags;
 
 /// Governance Proposal
 #[repr(C)]

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -1,6 +1,6 @@
 //! Proposal  Account
 
-use solana_program::clock::UnixTimestamp;
+use solana_program::clock::{Slot, UnixTimestamp};
 use solana_program::{
     account_info::AccountInfo, program_error::ProgramError, program_pack::IsInitialized,
     pubkey::Pubkey,
@@ -63,8 +63,12 @@ pub struct Proposal {
     /// When Signatories started signing off the Proposal
     pub signing_off_at: Option<UnixTimestamp>,
 
-    /// When the Proposal began voting
+    /// When the Proposal began voting as UnixTimestamp
     pub voting_at: Option<UnixTimestamp>,
+
+    /// When the Proposal began voting as Slot
+    /// Note: The slot is not currently used but the exact slot is going to be required to support snapshot based vote weights
+    pub voting_at_slot: Option<Slot>,
 
     /// When the Proposal ended voting and entered either Succeeded or Defeated
     pub voting_completed_at: Option<UnixTimestamp>,
@@ -84,7 +88,7 @@ pub struct Proposal {
 
 impl AccountMaxSize for Proposal {
     fn get_max_size(&self) -> Option<usize> {
-        Some(self.name.len() + self.description_link.len() + 183)
+        Some(self.name.len() + self.description_link.len() + 192)
     }
 }
 
@@ -399,7 +403,7 @@ pub fn get_proposal_address<'a>(
 
 #[cfg(test)]
 mod test {
-    use crate::state::enums::VoteThresholdPercentageType;
+    use crate::state::enums::{VoteThresholdPercentageType, VoteWeightSource};
 
     use {super::*, proptest::prelude::*};
 
@@ -416,7 +420,10 @@ mod test {
             name: "This is my name".to_string(),
             draft_at: 10,
             signing_off_at: Some(10),
+
             voting_at: Some(10),
+            voting_at_slot: Some(500),
+
             voting_completed_at: Some(10),
             executing_at: Some(10),
             closed_at: Some(10),
@@ -439,6 +446,7 @@ mod test {
             min_instruction_hold_up_time: 10,
             max_voting_time: 5,
             vote_threshold_percentage_type: VoteThresholdPercentageType::YesVote,
+            vote_weight_source: VoteWeightSource::Deposit,
         }
     }
 

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -455,6 +455,7 @@ mod test {
             max_voting_time: 5,
             vote_threshold_percentage_type: VoteThresholdPercentageType::YesVote,
             vote_weight_source: VoteWeightSource::Deposit,
+            proposal_cool_off_time: 0,
         }
     }
 

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -86,7 +86,7 @@ pub struct Proposal {
 
     /// Instruction execution flag for ordered and transactional instructions
     /// Note: This field is not used in the current version
-    pub execution_flags: Option<InstructionExecutionFlags>,
+    pub execution_flags: InstructionExecutionFlags,
 
     /// Proposal name
     pub name: String,
@@ -97,7 +97,7 @@ pub struct Proposal {
 
 impl AccountMaxSize for Proposal {
     fn get_max_size(&self) -> Option<usize> {
-        Some(self.name.len() + self.description_link.len() + 194)
+        Some(self.name.len() + self.description_link.len() + 193)
     }
 }
 
@@ -454,7 +454,7 @@ mod test {
             yes_votes_count: 0,
             no_votes_count: 0,
 
-            execution_flags: Some(InstructionExecutionFlags::Ordered),
+            execution_flags: InstructionExecutionFlags::Ordered,
 
             instructions_executed_count: 10,
             instructions_count: 10,

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -82,7 +82,7 @@ pub struct Proposal {
     pub closed_at: Option<UnixTimestamp>,
 
     /// Instruction execution flag for ordered and transactional instructions
-    /// Note: This field is not used in V1
+    /// Note: This field is not used in the current version
     pub execution_flags: Option<InstructionExecutionFlags>,
 
     /// Proposal name

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -42,17 +42,20 @@ pub struct Proposal {
     /// The number of signatories who already signed
     pub signatories_signed_off_count: u8,
 
-    /// Link to proposal's description
-    pub description_link: String,
-
-    /// Proposal name
-    pub name: String,
-
     /// The number of Yes votes
     pub yes_votes_count: u64,
 
     /// The number of No votes
     pub no_votes_count: u64,
+
+    /// The number of the instructions already executed
+    pub instructions_executed_count: u16,
+
+    /// The number of instructions included in the proposal
+    pub instructions_count: u16,
+
+    /// The index of the the next instruction to be added
+    pub instructions_next_index: u16,
 
     /// When the Proposal was created and entered Draft state
     pub draft_at: UnixTimestamp,
@@ -72,14 +75,11 @@ pub struct Proposal {
     /// When the Proposal entered final state Completed or Cancelled and was closed
     pub closed_at: Option<UnixTimestamp>,
 
-    /// The number of the instructions already executed
-    pub instructions_executed_count: u16,
+    /// Proposal name
+    pub name: String,
 
-    /// The number of instructions included in the proposal
-    pub instructions_count: u16,
-
-    /// The index of the the next instruction to be added
-    pub instructions_next_index: u16,
+    /// Link to proposal's description
+    pub description_link: String,
 }
 
 impl AccountMaxSize for Proposal {

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -16,6 +16,8 @@ use crate::state::governance::GovernanceConfig;
 
 use crate::state::proposal_instruction::ProposalInstruction;
 
+use super::enums::InstructionExecutionFlags;
+
 /// Governance Proposal
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
@@ -79,6 +81,10 @@ pub struct Proposal {
     /// When the Proposal entered final state Completed or Cancelled and was closed
     pub closed_at: Option<UnixTimestamp>,
 
+    /// Instruction execution flag for ordered and transactional instructions
+    /// Note: This field is not used in V1
+    pub execution_flags: Option<InstructionExecutionFlags>,
+
     /// Proposal name
     pub name: String,
 
@@ -88,7 +94,7 @@ pub struct Proposal {
 
 impl AccountMaxSize for Proposal {
     fn get_max_size(&self) -> Option<usize> {
-        Some(self.name.len() + self.description_link.len() + 192)
+        Some(self.name.len() + self.description_link.len() + 194)
     }
 }
 
@@ -430,6 +436,8 @@ mod test {
 
             yes_votes_count: 0,
             no_votes_count: 0,
+
+            execution_flags: Some(InstructionExecutionFlags::Ordered),
 
             instructions_executed_count: 10,
             instructions_count: 10,

--- a/governance/program/src/state/proposal_instruction.rs
+++ b/governance/program/src/state/proposal_instruction.rs
@@ -88,6 +88,9 @@ pub struct ProposalInstruction {
     /// The Proposal the instruction belongs to
     pub proposal: Pubkey,
 
+    /// Unique instruction index within it's parent Proposal
+    pub instruction_index: u16,
+
     /// Minimum waiting time in seconds for the  instruction to be executed once proposal is voted on
     pub hold_up_time: u32,
 
@@ -106,7 +109,7 @@ pub struct ProposalInstruction {
 
 impl AccountMaxSize for ProposalInstruction {
     fn get_max_size(&self) -> Option<usize> {
-        Some(self.instruction.accounts.len() * 34 + self.instruction.data.len() + 88)
+        Some(self.instruction.accounts.len() * 34 + self.instruction.data.len() + 90)
     }
 }
 
@@ -207,6 +210,7 @@ mod test {
         ProposalInstruction {
             account_type: GovernanceAccountType::ProposalInstruction,
             proposal: Pubkey::new_unique(),
+            instruction_index: 1,
             hold_up_time: 10,
             instruction: create_test_instruction_data(),
             executed_at: Some(100),

--- a/governance/program/src/state/proposal_instruction.rs
+++ b/governance/program/src/state/proposal_instruction.rs
@@ -172,6 +172,10 @@ pub fn assert_proposal_instruction_for_proposal(
 #[cfg(test)]
 mod test {
 
+    use std::str::FromStr;
+
+    use solana_program::bpf_loader_upgradeable;
+
     use super::*;
 
     fn create_test_account_meta_data() -> AccountMetaData {
@@ -232,5 +236,35 @@ mod test {
 
         // Act, Assert
         assert_eq!(proposal_instruction.get_max_size(), Some(size));
+    }
+
+    #[test]
+    fn test_upgrade_instruction_serialization() {
+        // Arrange
+        let program_address =
+            Pubkey::from_str("Hita5Lun87S4MADAF4vGoWEgFm5DyuVqxoWzzqYxS3AD").unwrap();
+        let buffer_address =
+            Pubkey::from_str("5XqXkgJGAUwrUHBkxbKpYMGqsRoQLfyqRbYUEkjNY6hL").unwrap();
+        let governance = Pubkey::from_str("FqSReK9R8QxvFZgdrAwGT3gsYp1ZGfiFjS8xrzyyadn3").unwrap();
+
+        let upgrade_instruction = bpf_loader_upgradeable::upgrade(
+            &program_address,
+            &buffer_address,
+            &governance,
+            &governance,
+        );
+
+        // Act
+        let instruction_data: InstructionData = upgrade_instruction.clone().into();
+        let mut instruciton_bytes = vec![];
+        instruction_data.serialize(&mut instruciton_bytes).unwrap();
+
+        println!("base64: {}", base64::encode(instruciton_bytes.clone()));
+
+        // Assert
+        let instruction =
+            Instruction::from(&InstructionData::deserialize(&mut &instruciton_bytes[..]).unwrap());
+
+        assert_eq!(upgrade_instruction, instruction);
     }
 }

--- a/governance/program/src/state/proposal_instruction.rs
+++ b/governance/program/src/state/proposal_instruction.rs
@@ -102,12 +102,12 @@ pub struct ProposalInstruction {
 
     /// Instruction execution status
     /// Note: The field is not used in the current version
-    pub execution_status: Option<InstructionExecutionStatus>,
+    pub execution_status: InstructionExecutionStatus,
 }
 
 impl AccountMaxSize for ProposalInstruction {
     fn get_max_size(&self) -> Option<usize> {
-        Some(self.instruction.accounts.len() * 34 + self.instruction.data.len() + 90)
+        Some(self.instruction.accounts.len() * 34 + self.instruction.data.len() + 89)
     }
 }
 
@@ -212,7 +212,7 @@ mod test {
             hold_up_time: 10,
             instruction: create_test_instruction_data(),
             executed_at: Some(100),
-            execution_status: Some(InstructionExecutionStatus::Success),
+            execution_status: InstructionExecutionStatus::Success,
         }
     }
 

--- a/governance/program/src/state/proposal_instruction.rs
+++ b/governance/program/src/state/proposal_instruction.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     error::GovernanceError,
-    state::enums::GovernanceAccountType,
+    state::enums::{GovernanceAccountType, InstructionExecutionStatus},
     tools::account::{get_account_data, AccountMaxSize},
     PROGRAM_AUTHORITY_SEED,
 };
@@ -15,8 +15,6 @@ use solana_program::{
     program_pack::IsInitialized,
     pubkey::Pubkey,
 };
-
-use super::enums::InstructionExecutionStatus;
 
 /// InstructionData wrapper. It can be removed once Borsh serialization for Instruction is supported in the SDK
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]

--- a/governance/program/src/state/proposal_instruction.rs
+++ b/governance/program/src/state/proposal_instruction.rs
@@ -16,6 +16,8 @@ use solana_program::{
     pubkey::Pubkey,
 };
 
+use super::enums::InstructionExecutionStatus;
+
 /// InstructionData wrapper. It can be removed once Borsh serialization for Instruction is supported in the SDK
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 #[repr(C)]
@@ -96,11 +98,15 @@ pub struct ProposalInstruction {
 
     /// Executed at flag
     pub executed_at: Option<UnixTimestamp>,
+
+    /// Instruction execution status
+    /// Note: The field is not used in V1
+    pub execution_status: Option<InstructionExecutionStatus>,
 }
 
 impl AccountMaxSize for ProposalInstruction {
     fn get_max_size(&self) -> Option<usize> {
-        Some(self.instruction.accounts.len() * 34 + self.instruction.data.len() + 86)
+        Some(self.instruction.accounts.len() * 34 + self.instruction.data.len() + 88)
     }
 }
 
@@ -204,6 +210,7 @@ mod test {
             hold_up_time: 10,
             instruction: create_test_instruction_data(),
             executed_at: Some(100),
+            execution_status: Some(InstructionExecutionStatus::Success),
         }
     }
 

--- a/governance/program/src/state/proposal_instruction.rs
+++ b/governance/program/src/state/proposal_instruction.rs
@@ -256,15 +256,18 @@ mod test {
 
         // Act
         let instruction_data: InstructionData = upgrade_instruction.clone().into();
-        let mut instruciton_bytes = vec![];
-        instruction_data.serialize(&mut instruciton_bytes).unwrap();
+        let mut instruction_bytes = vec![];
+        instruction_data.serialize(&mut instruction_bytes).unwrap();
 
-        println!("base64: {}", base64::encode(instruciton_bytes.clone()));
+        // base64 encoded message is accepted as the input in the UI
+        let base64 = base64::encode(instruction_bytes.clone());
 
         // Assert
         let instruction =
-            Instruction::from(&InstructionData::deserialize(&mut &instruciton_bytes[..]).unwrap());
+            Instruction::from(&InstructionData::deserialize(&mut &instruction_bytes[..]).unwrap());
 
         assert_eq!(upgrade_instruction, instruction);
+
+        assert_eq!(base64,"Aqj2kU6IobDiEBU+92OuKwDCuT0WwSTSwFN6EASAAAAHAAAAchkHXTU9jF+rKpILT6dzsVyNI9NsQy9cab+GGvdwNn0AAfh2HVruy2YibpgcQUmJf5att5YdPXSv1k2pRAKAfpSWAAFDVQuXWos2urmegSPblI813GlTm7CJ/8rv+9yzNE3yfwAB3Gw+apCyfrRNqJ6f1160Htkx+uYZT6FIILQ3WzNA4KwAAQan1RcZLFxRIYzJTD1K8X9Y2u4Im6H9ROPb2YoAAAAAAAAGp9UXGMd0yShWY5hpHV62i164o5tLbVxzVVshAAAAAAAA3Gw+apCyfrRNqJ6f1160Htkx+uYZT6FIILQ3WzNA4KwBAAQAAAADAAAA");
     }
 }

--- a/governance/program/src/state/proposal_instruction.rs
+++ b/governance/program/src/state/proposal_instruction.rs
@@ -103,7 +103,7 @@ pub struct ProposalInstruction {
     pub executed_at: Option<UnixTimestamp>,
 
     /// Instruction execution status
-    /// Note: The field is not used in V1
+    /// Note: The field is not used in the current version
     pub execution_status: Option<InstructionExecutionStatus>,
 }
 

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -25,6 +25,9 @@ pub struct Realm {
     /// Community mint
     pub community_mint: Pubkey,
 
+    /// Reserved space for future versions
+    pub reserved: u64,
+
     /// Council mint
     pub council_mint: Option<Pubkey>,
 

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -26,7 +26,7 @@ pub struct Realm {
     pub community_mint: Pubkey,
 
     /// Reserved space for future versions
-    pub reserved: u64,
+    pub reserved: [u8; 8],
 
     /// Council mint
     pub council_mint: Option<Pubkey>,

--- a/governance/program/src/state/signatory_record.rs
+++ b/governance/program/src/state/signatory_record.rs
@@ -20,10 +20,13 @@ use crate::state::enums::GovernanceAccountType;
 pub struct SignatoryRecord {
     /// Governance account type
     pub account_type: GovernanceAccountType,
+
     /// Proposal the signatory is assigned for
     pub proposal: Pubkey,
+
     /// The account of the signatory who can sign off the proposal
     pub signatory: Pubkey,
+
     /// Indicates whether the signatory signed off the proposal
     pub signed_off: bool,
 }

--- a/governance/program/src/state/token_owner_record.rs
+++ b/governance/program/src/state/token_owner_record.rs
@@ -36,10 +36,6 @@ pub struct TokenOwnerRecord {
     /// This amount is the voter weight used when voting on proposals
     pub governing_token_deposit_amount: u64,
 
-    /// A single account that is allowed to operate governance with the deposited governing tokens
-    /// It can be delegated to by the governing_token_owner or current governance_delegate
-    pub governance_delegate: Option<Pubkey>,
-
     /// The number of votes cast by TokenOwner but not relinquished yet
     /// Every time a vote is cast this number is increased and it's always decreased when relinquishing a vote regardless of the vote state
     pub unrelinquished_votes_count: u32,
@@ -47,6 +43,10 @@ pub struct TokenOwnerRecord {
     /// The total number of votes cast by the TokenOwner
     /// If TokenOwner withdraws vote while voting is still in progress total_votes_count is decreased  and the vote doesn't count towards the total
     pub total_votes_count: u32,
+
+    /// A single account that is allowed to operate governance with the deposited governing tokens
+    /// It can be delegated to by the governing_token_owner or current governance_delegate
+    pub governance_delegate: Option<Pubkey>,
 }
 
 impl AccountMaxSize for TokenOwnerRecord {

--- a/governance/program/src/state/token_owner_record.rs
+++ b/governance/program/src/state/token_owner_record.rs
@@ -44,6 +44,9 @@ pub struct TokenOwnerRecord {
     /// If TokenOwner withdraws vote while voting is still in progress total_votes_count is decreased  and the vote doesn't count towards the total
     pub total_votes_count: u32,
 
+    /// Reserved space for future versions
+    pub reserved: u64,
+
     /// A single account that is allowed to operate governance with the deposited governing tokens
     /// It can be delegated to by the governing_token_owner or current governance_delegate
     pub governance_delegate: Option<Pubkey>,
@@ -51,7 +54,7 @@ pub struct TokenOwnerRecord {
 
 impl AccountMaxSize for TokenOwnerRecord {
     fn get_max_size(&self) -> Option<usize> {
-        Some(146)
+        Some(154)
     }
 }
 
@@ -185,6 +188,7 @@ mod test {
             governance_delegate: Some(Pubkey::new_unique()),
             unrelinquished_votes_count: 1,
             total_votes_count: 1,
+            reserved: 0,
         };
 
         let size = get_packed_len::<TokenOwnerRecord>();

--- a/governance/program/src/state/token_owner_record.rs
+++ b/governance/program/src/state/token_owner_record.rs
@@ -45,7 +45,7 @@ pub struct TokenOwnerRecord {
     pub total_votes_count: u32,
 
     /// Reserved space for future versions
-    pub reserved: u64,
+    pub reserved: [u8; 8],
 
     /// A single account that is allowed to operate governance with the deposited governing tokens
     /// It can be delegated to by the governing_token_owner or current governance_delegate
@@ -188,7 +188,7 @@ mod test {
             governance_delegate: Some(Pubkey::new_unique()),
             unrelinquished_votes_count: 1,
             total_votes_count: 1,
-            reserved: 0,
+            reserved: [0; 8],
         };
 
         let size = get_packed_len::<TokenOwnerRecord>();

--- a/governance/program/tests/process_cast_vote.rs
+++ b/governance/program/tests/process_cast_vote.rs
@@ -5,7 +5,11 @@ mod program_test;
 use solana_program_test::tokio;
 
 use program_test::*;
-use spl_governance::{error::GovernanceError, instruction::Vote, state::enums::ProposalState};
+use spl_governance::{
+    error::GovernanceError,
+    instruction::Vote,
+    state::enums::{ProposalState, VoteThresholdPercentage},
+};
 
 #[tokio::test]
 async fn test_cast_vote() {
@@ -440,7 +444,7 @@ async fn test_cast_vote_with_threshold_below_50_and_vote_not_tipped() {
     let mut governance_config =
         governance_test.get_default_governance_config(&realm_cookie, &governed_account_cookie);
 
-    governance_config.vote_threshold_percentage = 40;
+    governance_config.vote_threshold_percentage = VoteThresholdPercentage::YesVote(40);
 
     let mut account_governance_cookie = governance_test
         .with_account_governance_using_config(

--- a/governance/program/tests/process_cast_vote.rs
+++ b/governance/program/tests/process_cast_vote.rs
@@ -440,7 +440,7 @@ async fn test_cast_vote_with_threshold_below_50_and_vote_not_tipped() {
     let mut governance_config =
         governance_test.get_default_governance_config(&realm_cookie, &governed_account_cookie);
 
-    governance_config.yes_vote_threshold_percentage = 40;
+    governance_config.vote_threshold_percentage = 40;
 
     let mut account_governance_cookie = governance_test
         .with_account_governance_using_config(

--- a/governance/program/tests/process_create_account_governance.rs
+++ b/governance/program/tests/process_create_account_governance.rs
@@ -4,7 +4,7 @@ mod program_test;
 use solana_program_test::*;
 
 use program_test::*;
-use spl_governance::error::GovernanceError;
+use spl_governance::{error::GovernanceError, state::enums::VoteThresholdPercentage};
 
 #[tokio::test]
 async fn test_create_account_governance() {
@@ -69,7 +69,7 @@ async fn test_create_account_governance_with_invalid_config_error() {
     // Arrange
     let mut config =
         governance_test.get_default_governance_config(&realm_cookie, &governed_account_cookie);
-    config.vote_threshold_percentage = 0; // below 1% threshold
+    config.vote_threshold_percentage = VoteThresholdPercentage::YesVote(0); // below 1% threshold
 
     // Act
     let err = governance_test
@@ -85,7 +85,7 @@ async fn test_create_account_governance_with_invalid_config_error() {
     // Arrange
     let mut config =
         governance_test.get_default_governance_config(&realm_cookie, &governed_account_cookie);
-    config.vote_threshold_percentage = 101; // Above 100% threshold
+    config.vote_threshold_percentage = VoteThresholdPercentage::YesVote(101); // Above 100% threshold
 
     // Act
     let err = governance_test

--- a/governance/program/tests/process_create_account_governance.rs
+++ b/governance/program/tests/process_create_account_governance.rs
@@ -4,7 +4,10 @@ mod program_test;
 use solana_program_test::*;
 
 use program_test::*;
-use spl_governance::{error::GovernanceError, state::governance::GovernanceConfig};
+use spl_governance::{
+    error::GovernanceError,
+    state::{enums::VoteThresholdPercentageType, governance::GovernanceConfig},
+};
 
 #[tokio::test]
 async fn test_create_account_governance() {
@@ -70,10 +73,11 @@ async fn test_create_account_governance_with_invalid_config_error() {
     let config = GovernanceConfig {
         realm: realm_cookie.address,
         governed_account: governed_account_cookie.address,
-        yes_vote_threshold_percentage: 0, // below 1% threshold
+        vote_threshold_percentage: 0, // below 1% threshold
         min_tokens_to_create_proposal: 1,
         min_instruction_hold_up_time: 1,
         max_voting_time: 1,
+        vote_threshold_percentage_type: VoteThresholdPercentageType::YesVote,
     };
 
     // Act
@@ -91,10 +95,11 @@ async fn test_create_account_governance_with_invalid_config_error() {
     let config = GovernanceConfig {
         realm: realm_cookie.address,
         governed_account: governed_account_cookie.address,
-        yes_vote_threshold_percentage: 101, // Above 100% threshold
+        vote_threshold_percentage: 101, // Above 100% threshold
         min_tokens_to_create_proposal: 1,
         min_instruction_hold_up_time: 1,
         max_voting_time: 1,
+        vote_threshold_percentage_type: VoteThresholdPercentageType::YesVote,
     };
 
     // Act

--- a/governance/program/tests/process_create_account_governance.rs
+++ b/governance/program/tests/process_create_account_governance.rs
@@ -4,10 +4,7 @@ mod program_test;
 use solana_program_test::*;
 
 use program_test::*;
-use spl_governance::{
-    error::GovernanceError,
-    state::{enums::VoteThresholdPercentageType, governance::GovernanceConfig},
-};
+use spl_governance::error::GovernanceError;
 
 #[tokio::test]
 async fn test_create_account_governance() {
@@ -69,16 +66,10 @@ async fn test_create_account_governance_with_invalid_config_error() {
     let realm_cookie = governance_test.with_realm().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    // Arrange below 1% threshold
-    let config = GovernanceConfig {
-        realm: realm_cookie.address,
-        governed_account: governed_account_cookie.address,
-        vote_threshold_percentage: 0, // below 1% threshold
-        min_tokens_to_create_proposal: 1,
-        min_instruction_hold_up_time: 1,
-        max_voting_time: 1,
-        vote_threshold_percentage_type: VoteThresholdPercentageType::YesVote,
-    };
+    // Arrange
+    let mut config =
+        governance_test.get_default_governance_config(&realm_cookie, &governed_account_cookie);
+    config.vote_threshold_percentage = 0; // below 1% threshold
 
     // Act
     let err = governance_test
@@ -91,16 +82,10 @@ async fn test_create_account_governance_with_invalid_config_error() {
 
     assert_eq!(err, GovernanceError::InvalidGovernanceConfig.into());
 
-    // Arrange  above 100% threshold
-    let config = GovernanceConfig {
-        realm: realm_cookie.address,
-        governed_account: governed_account_cookie.address,
-        vote_threshold_percentage: 101, // Above 100% threshold
-        min_tokens_to_create_proposal: 1,
-        min_instruction_hold_up_time: 1,
-        max_voting_time: 1,
-        vote_threshold_percentage_type: VoteThresholdPercentageType::YesVote,
-    };
+    // Arrange
+    let mut config =
+        governance_test.get_default_governance_config(&realm_cookie, &governed_account_cookie);
+    config.vote_threshold_percentage = 101; // Above 100% threshold
 
     // Act
     let err = governance_test

--- a/governance/program/tests/process_execute_instruction.rs
+++ b/governance/program/tests/process_execute_instruction.rs
@@ -10,7 +10,11 @@ use solana_program::{
 use solana_program_test::tokio;
 
 use program_test::*;
-use spl_governance::{error::GovernanceError, instruction::Vote, state::enums::ProposalState};
+use spl_governance::{
+    error::GovernanceError,
+    instruction::Vote,
+    state::enums::{InstructionExecutionStatus, ProposalState},
+};
 
 #[tokio::test]
 async fn test_execute_mint_instruction() {
@@ -90,6 +94,11 @@ async fn test_execute_mint_instruction() {
     assert_eq!(
         Some(clock.unix_timestamp),
         proposal_instruction_account.executed_at
+    );
+
+    assert_eq!(
+        Some(InstructionExecutionStatus::Success),
+        proposal_instruction_account.execution_status
     );
 
     let instruction_token_account = governance_test
@@ -177,6 +186,11 @@ async fn test_execute_transfer_instruction() {
     assert_eq!(
         Some(clock.unix_timestamp),
         proposal_instruction_account.executed_at
+    );
+
+    assert_eq!(
+        Some(InstructionExecutionStatus::Success),
+        proposal_instruction_account.execution_status
     );
 
     let instruction_token_account = governance_test
@@ -283,6 +297,11 @@ async fn test_execute_upgrade_program_instruction() {
     assert_eq!(
         Some(clock.unix_timestamp),
         proposal_instruction_account.executed_at
+    );
+
+    assert_eq!(
+        Some(InstructionExecutionStatus::Success),
+        proposal_instruction_account.execution_status
     );
 
     // Assert we can invoke the governed program after upgrade

--- a/governance/program/tests/process_execute_instruction.rs
+++ b/governance/program/tests/process_execute_instruction.rs
@@ -97,7 +97,7 @@ async fn test_execute_mint_instruction() {
     );
 
     assert_eq!(
-        Some(InstructionExecutionStatus::Success),
+        InstructionExecutionStatus::Success,
         proposal_instruction_account.execution_status
     );
 
@@ -189,7 +189,7 @@ async fn test_execute_transfer_instruction() {
     );
 
     assert_eq!(
-        Some(InstructionExecutionStatus::Success),
+        InstructionExecutionStatus::Success,
         proposal_instruction_account.execution_status
     );
 
@@ -300,7 +300,7 @@ async fn test_execute_upgrade_program_instruction() {
     );
 
     assert_eq!(
-        Some(InstructionExecutionStatus::Success),
+        InstructionExecutionStatus::Success,
         proposal_instruction_account.execution_status
     );
 

--- a/governance/program/tests/process_finalize_vote.rs
+++ b/governance/program/tests/process_finalize_vote.rs
@@ -6,7 +6,11 @@ use solana_program::pubkey::Pubkey;
 use solana_program_test::tokio;
 
 use program_test::*;
-use spl_governance::{error::GovernanceError, instruction::Vote, state::enums::ProposalState};
+use spl_governance::{
+    error::GovernanceError,
+    instruction::Vote,
+    state::enums::{ProposalState, VoteThresholdPercentage},
+};
 
 #[tokio::test]
 async fn test_finalize_vote_to_succeeded() {
@@ -19,7 +23,7 @@ async fn test_finalize_vote_to_succeeded() {
     let mut governance_config =
         governance_test.get_default_governance_config(&realm_cookie, &governed_account_cookie);
 
-    governance_config.vote_threshold_percentage = 40;
+    governance_config.vote_threshold_percentage = VoteThresholdPercentage::YesVote(40);
 
     let mut account_governance_cookie = governance_test
         .with_account_governance_using_config(

--- a/governance/program/tests/process_finalize_vote.rs
+++ b/governance/program/tests/process_finalize_vote.rs
@@ -19,7 +19,7 @@ async fn test_finalize_vote_to_succeeded() {
     let mut governance_config =
         governance_test.get_default_governance_config(&realm_cookie, &governed_account_cookie);
 
-    governance_config.yes_vote_threshold_percentage = 40;
+    governance_config.vote_threshold_percentage = 40;
 
     let mut account_governance_cookie = governance_test
         .with_account_governance_using_config(

--- a/governance/program/tests/process_sign_off_proposal.rs
+++ b/governance/program/tests/process_sign_off_proposal.rs
@@ -52,6 +52,7 @@ async fn test_sign_off_proposal() {
     assert_eq!(ProposalState::Voting, proposal_account.state);
     assert_eq!(Some(clock.unix_timestamp), proposal_account.signing_off_at);
     assert_eq!(Some(clock.unix_timestamp), proposal_account.voting_at);
+    assert_eq!(Some(clock.slot), proposal_account.voting_at_slot);
 
     let signatory_record_account = governance_test
         .get_signatory_record_account(&signatory_record_cookie.address)

--- a/governance/program/tests/process_withdraw_governing_tokens.rs
+++ b/governance/program/tests/process_withdraw_governing_tokens.rs
@@ -9,7 +9,8 @@ use program_test::*;
 use solana_sdk::signature::Signer;
 
 use spl_governance::{
-    error::GovernanceError, instruction::withdraw_governing_tokens,
+    error::GovernanceError,
+    instruction::{withdraw_governing_tokens, Vote},
     state::token_owner_record::get_token_owner_record_address,
 };
 
@@ -169,5 +170,95 @@ async fn test_withdraw_community_tokens_with_token_owner_record_address_mismatch
     assert_eq!(
         err,
         GovernanceError::InvalidTokenOwnerRecordAccountAddress.into()
+    );
+}
+
+#[tokio::test]
+async fn test_withdraw_governing_tokens_with_unrelinquished_votes_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let mut account_governance_cookie = governance_test
+        .with_account_governance(&realm_cookie, &governed_account_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await;
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut account_governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .withdraw_community_tokens(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::AllVotesMustBeRelinquishedToWithdrawGoverningTokens.into()
+    );
+}
+
+#[tokio::test]
+async fn test_withdraw_governing_tokens_after_relinquishing_vote() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let mut account_governance_cookie = governance_test
+        .with_account_governance(&realm_cookie, &governed_account_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await;
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut account_governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .await
+        .unwrap();
+
+    governance_test
+        .relinquish_vote(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .withdraw_community_tokens(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let source_account = governance_test
+        .get_token_account(&token_owner_record_cookie.token_source)
+        .await;
+
+    assert_eq!(
+        token_owner_record_cookie.token_source_amount,
+        source_account.amount
     );
 }

--- a/governance/program/tests/program_test/cookies.rs
+++ b/governance/program/tests/program_test/cookies.rs
@@ -8,6 +8,10 @@ use spl_governance::state::{
 
 use crate::tools::clone_keypair;
 
+pub trait AccountCookie {
+    fn get_address(&self) -> Pubkey;
+}
+
 #[derive(Debug)]
 pub struct RealmCookie {
     pub address: Pubkey,
@@ -61,11 +65,23 @@ pub struct GovernedProgramCookie {
     pub transfer_upgrade_authority: bool,
 }
 
+impl AccountCookie for GovernedProgramCookie {
+    fn get_address(&self) -> Pubkey {
+        self.address
+    }
+}
+
 #[derive(Debug)]
 pub struct GovernedMintCookie {
     pub address: Pubkey,
     pub mint_authority: Keypair,
     pub transfer_mint_authority: bool,
+}
+
+impl AccountCookie for GovernedMintCookie {
+    fn get_address(&self) -> Pubkey {
+        self.address
+    }
 }
 
 #[derive(Debug)]
@@ -76,9 +92,21 @@ pub struct GovernedTokenCookie {
     pub token_mint: Pubkey,
 }
 
+impl AccountCookie for GovernedTokenCookie {
+    fn get_address(&self) -> Pubkey {
+        self.address
+    }
+}
+
 #[derive(Debug)]
 pub struct GovernedAccountCookie {
     pub address: Pubkey,
+}
+
+impl AccountCookie for GovernedAccountCookie {
+    fn get_address(&self) -> Pubkey {
+        self.address
+    }
 }
 
 #[derive(Debug)]

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -180,6 +180,7 @@ impl GovernanceProgramTest {
             community_mint: community_token_mint_keypair.pubkey(),
             council_mint: Some(council_token_mint_keypair.pubkey()),
             name,
+            reserved: 0,
         };
 
         RealmCookie {
@@ -219,6 +220,7 @@ impl GovernanceProgramTest {
             community_mint: realm_cookie.account.community_mint,
             council_mint: Some(council_mint),
             name,
+            reserved: 0,
         };
 
         let community_token_holding_address = get_governing_token_holding_address(
@@ -377,6 +379,7 @@ impl GovernanceProgramTest {
             governance_delegate: None,
             unrelinquished_votes_count: 0,
             total_votes_count: 0,
+            reserved: 0,
         };
 
         let governance_delegate = Keypair::from_base58_string(&token_owner.to_base58_string());
@@ -679,6 +682,7 @@ impl GovernanceProgramTest {
             account_type: GovernanceAccountType::AccountGovernance,
             config: governance_config.clone(),
             proposals_count: 0,
+            reserved: 0,
         };
 
         self.process_transaction(&[create_account_governance_instruction], None)
@@ -813,6 +817,7 @@ impl GovernanceProgramTest {
             account_type: GovernanceAccountType::ProgramGovernance,
             config,
             proposals_count: 0,
+            reserved: 0,
         };
 
         let program_governance_address = get_program_governance_address(
@@ -873,6 +878,7 @@ impl GovernanceProgramTest {
             account_type: GovernanceAccountType::MintGovernance,
             config,
             proposals_count: 0,
+            reserved: 0,
         };
 
         let mint_governance_address = get_mint_governance_address(
@@ -933,6 +939,7 @@ impl GovernanceProgramTest {
             account_type: GovernanceAccountType::TokenGovernance,
             config,
             proposals_count: 0,
+            reserved: 0,
         };
 
         let token_governance_address = get_token_governance_address(

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -33,7 +33,7 @@ use spl_governance::{
     },
     processor::process_instruction,
     state::{
-        enums::{GovernanceAccountType, ProposalState, VoteThresholdPercentageType, VoteWeight},
+        enums::{GovernanceAccountType, ProposalState, VoteThresholdPercentage, VoteWeight},
         governance::{
             get_account_governance_address, get_mint_governance_address,
             get_program_governance_address, get_token_governance_address, Governance,
@@ -644,11 +644,11 @@ impl GovernanceProgramTest {
         GovernanceConfig {
             realm: realm_cookie.address,
             governed_account: governed_account_cookie.get_address(),
-            vote_threshold_percentage: 60,
+
             min_tokens_to_create_proposal: 5,
             min_instruction_hold_up_time: 10,
             max_voting_time: 10,
-            vote_threshold_percentage_type: VoteThresholdPercentageType::YesVote,
+            vote_threshold_percentage: VoteThresholdPercentage::YesVote(60),
             vote_weight_source: spl_governance::state::enums::VoteWeightSource::Deposit,
             proposal_cool_off_time: 0,
         }

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1044,6 +1044,8 @@ impl GovernanceProgramTest {
             signatories_signed_off_count: 0,
             yes_votes_count: 0,
             no_votes_count: 0,
+
+            execution_flags: None,
         };
 
         let proposal_address = get_proposal_address(
@@ -1457,7 +1459,7 @@ impl GovernanceProgramTest {
 
         let instruction_data: InstructionData = instruction.clone().into();
 
-        let index = index.unwrap_or(proposal_cookie.account.instructions_next_index);
+        let instruction_index = index.unwrap_or(proposal_cookie.account.instructions_next_index);
 
         proposal_cookie.account.instructions_next_index =
             proposal_cookie.account.instructions_next_index + 1;
@@ -1469,7 +1471,7 @@ impl GovernanceProgramTest {
             &token_owner_record_cookie.address,
             &token_owner_record_cookie.token_owner.pubkey(),
             &self.context.payer.pubkey(),
-            index,
+            instruction_index,
             hold_up_time,
             instruction_data.clone(),
         );
@@ -1483,11 +1485,12 @@ impl GovernanceProgramTest {
         let proposal_instruction_address = get_proposal_instruction_address(
             &self.program_id,
             &proposal_cookie.address,
-            &index.to_le_bytes(),
+            &instruction_index.to_le_bytes(),
         );
 
         let proposal_instruction_data = ProposalInstruction {
             account_type: GovernanceAccountType::ProposalInstruction,
+            instruction_index,
             hold_up_time,
             instruction: instruction_data,
             executed_at: None,

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -180,7 +180,7 @@ impl GovernanceProgramTest {
             community_mint: community_token_mint_keypair.pubkey(),
             council_mint: Some(council_token_mint_keypair.pubkey()),
             name,
-            reserved: 0,
+            reserved: [0; 8],
         };
 
         RealmCookie {
@@ -220,7 +220,7 @@ impl GovernanceProgramTest {
             community_mint: realm_cookie.account.community_mint,
             council_mint: Some(council_mint),
             name,
-            reserved: 0,
+            reserved: [0; 8],
         };
 
         let community_token_holding_address = get_governing_token_holding_address(
@@ -379,7 +379,7 @@ impl GovernanceProgramTest {
             governance_delegate: None,
             unrelinquished_votes_count: 0,
             total_votes_count: 0,
-            reserved: 0,
+            reserved: [0; 8],
         };
 
         let governance_delegate = Keypair::from_base58_string(&token_owner.to_base58_string());
@@ -682,7 +682,7 @@ impl GovernanceProgramTest {
             account_type: GovernanceAccountType::AccountGovernance,
             config: governance_config.clone(),
             proposals_count: 0,
-            reserved: 0,
+            reserved: [0; 8],
         };
 
         self.process_transaction(&[create_account_governance_instruction], None)
@@ -817,7 +817,7 @@ impl GovernanceProgramTest {
             account_type: GovernanceAccountType::ProgramGovernance,
             config,
             proposals_count: 0,
-            reserved: 0,
+            reserved: [0; 8],
         };
 
         let program_governance_address = get_program_governance_address(
@@ -878,7 +878,7 @@ impl GovernanceProgramTest {
             account_type: GovernanceAccountType::MintGovernance,
             config,
             proposals_count: 0,
-            reserved: 0,
+            reserved: [0; 8],
         };
 
         let mint_governance_address = get_mint_governance_address(
@@ -939,7 +939,7 @@ impl GovernanceProgramTest {
             account_type: GovernanceAccountType::TokenGovernance,
             config,
             proposals_count: 0,
-            reserved: 0,
+            reserved: [0; 8],
         };
 
         let token_governance_address = get_token_governance_address(

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1491,6 +1491,7 @@ impl GovernanceProgramTest {
             hold_up_time,
             instruction: instruction_data,
             executed_at: None,
+            execution_status: None,
             proposal: proposal_cookie.address,
         };
 

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -33,7 +33,10 @@ use spl_governance::{
     },
     processor::process_instruction,
     state::{
-        enums::{GovernanceAccountType, ProposalState, VoteThresholdPercentage, VoteWeight},
+        enums::{
+            GovernanceAccountType, InstructionExecutionStatus, ProposalState,
+            VoteThresholdPercentage, VoteWeight,
+        },
         governance::{
             get_account_governance_address, get_mint_governance_address,
             get_program_governance_address, get_token_governance_address, Governance,
@@ -1502,7 +1505,7 @@ impl GovernanceProgramTest {
             hold_up_time,
             instruction: instruction_data,
             executed_at: None,
-            execution_status: None,
+            execution_status: InstructionExecutionStatus::None,
             proposal: proposal_cookie.address,
         };
 

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -647,6 +647,7 @@ impl GovernanceProgramTest {
             max_voting_time: 10,
             vote_threshold_percentage_type: VoteThresholdPercentageType::YesVote,
             vote_weight_source: spl_governance::state::enums::VoteWeightSource::Deposit,
+            proposal_cool_off_time: 0,
         }
     }
 

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -33,7 +33,7 @@ use spl_governance::{
     },
     processor::process_instruction,
     state::{
-        enums::{GovernanceAccountType, ProposalState, VoteWeight},
+        enums::{GovernanceAccountType, ProposalState, VoteThresholdPercentageType, VoteWeight},
         governance::{
             get_account_governance_address, get_mint_governance_address,
             get_program_governance_address, get_token_governance_address, Governance,
@@ -641,10 +641,11 @@ impl GovernanceProgramTest {
         GovernanceConfig {
             realm: realm_cookie.address,
             governed_account: governed_account_cookie.address,
-            yes_vote_threshold_percentage: 60,
+            vote_threshold_percentage: 60,
             min_tokens_to_create_proposal: 5,
             min_instruction_hold_up_time: 10,
             max_voting_time: 10,
+            vote_threshold_percentage_type: VoteThresholdPercentageType::YesVote,
         }
     }
 
@@ -794,7 +795,8 @@ impl GovernanceProgramTest {
             min_tokens_to_create_proposal: 5,
             min_instruction_hold_up_time: 10,
             max_voting_time: 100,
-            yes_vote_threshold_percentage: 60,
+            vote_threshold_percentage: 60,
+            vote_threshold_percentage_type: VoteThresholdPercentageType::YesVote,
         };
 
         let mut create_program_governance_instruction = create_program_governance(
@@ -861,7 +863,8 @@ impl GovernanceProgramTest {
             min_tokens_to_create_proposal: 5,
             min_instruction_hold_up_time: 10,
             max_voting_time: 100,
-            yes_vote_threshold_percentage: 60,
+            vote_threshold_percentage: 60,
+            vote_threshold_percentage_type: VoteThresholdPercentageType::YesVote,
         };
 
         let mut create_mint_governance_instruction = create_mint_governance(
@@ -928,7 +931,8 @@ impl GovernanceProgramTest {
             min_tokens_to_create_proposal: 5,
             min_instruction_hold_up_time: 10,
             max_voting_time: 100,
-            yes_vote_threshold_percentage: 60,
+            vote_threshold_percentage: 60,
+            vote_threshold_percentage_type: VoteThresholdPercentageType::YesVote,
         };
 
         let mut create_token_governance_instruction = create_token_governance(

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -34,8 +34,8 @@ use spl_governance::{
     processor::process_instruction,
     state::{
         enums::{
-            GovernanceAccountType, InstructionExecutionStatus, ProposalState,
-            VoteThresholdPercentage, VoteWeight,
+            GovernanceAccountType, InstructionExecutionFlags, InstructionExecutionStatus,
+            ProposalState, VoteThresholdPercentage, VoteWeight,
         },
         governance::{
             get_account_governance_address, get_mint_governance_address,
@@ -1056,7 +1056,7 @@ impl GovernanceProgramTest {
             yes_votes_count: 0,
             no_votes_count: 0,
 
-            execution_flags: None,
+            execution_flags: InstructionExecutionFlags::None,
         };
 
         let proposal_address = get_proposal_address(


### PR DESCRIPTION
#### Summary 
The PR contains a set of changes which aim to future proof `Governance` program accounts for future versions


1. `VoteThresholdPercentageType` - vote threshold percentage type to support quorum based votes in future versions.

2. `VoteWeightSource` - vote weight source to support account snapshot based voter weights in future versions. With snapshots it'll be possible to vote without depositing governing tokens. 
3. `InstructionExecutionStatus` - status to support failed instructions in future versions and prevent Proposals permanently staying in `Succeeded` or `Executing` state.
4. `InstructionExecutionFlags` - execution flags to support ordered and transactional instructions in future versions.
5. `proposal_cool_off_time`- time period to allow proposal cancellation after voting. 
3. Move all fields with dynamic size to the end of an account layout to support search on all fixed fields
4. Add reserved padding space to permanent accounts. The permanent accounts like `Realm` or `Governance` once created would stay as is forever and hence will be the most difficult to change in the future. 
5. Add missing tests for withdrawals and serialization

 