### PR TITLE
Governance: SetGovernanceConfig instruction

### DIFF
--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -79,9 +79,9 @@ pub enum GovernanceError {
     #[error("Invalid GoverningTokenOwner for VoteRecord")]
     InvalidGoverningTokenOwnerForVoteRecord,
 
-    /// Invalid Governance config
-    #[error("Invalid Governance config")]
-    InvalidGovernanceConfig,
+    /// Invalid Governance config: Vote threshold percentage out of range"
+    #[error("Invalid Governance config: Vote threshold percentage out of range")]
+    InvalidVoteThresholdPercentage,
 
     /// Proposal for the given Governance, Governing Token Mint and index already exists
     #[error("Proposal for the given Governance, Governing Token Mint and index already exists")]
@@ -271,6 +271,18 @@ pub enum GovernanceError {
     /// Proposal cool off time is not supported
     #[error("Proposal cool off time is not supported")]
     ProposalCoolOffTimeNotSupported,
+
+    /// Governance PDA must sign
+    #[error("Governance PDA must sign")]
+    GovernancePdaMustSign,
+
+    /// Invalid config realm for Governance
+    #[error("Invalid config realm for Governance")]
+    InvalidConfigRealmForGovernance,
+
+    /// Invalid config governed account for Governance
+    #[error("Invalid config governed account for Governance")]
+    InvalidConfigGovernedAccountForGovernance,
 }
 
 impl PrintProgramError for GovernanceError {

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -335,6 +335,16 @@ pub enum GovernanceInstruction {
         /// However the instruction would validate the current token owner signed the transaction nonetheless
         transfer_token_owner: bool,
     },
+
+    /// Sets GovernanceConfig for a Governance
+    ///
+    ///   0. `[]` Realm account the Governance account belongs to    
+    ///   1. `[writable, signer]` The Governance account the config is for
+    SetGovernanceConfig {
+        #[allow(dead_code)]
+        /// New governance config
+        config: GovernanceConfig,
+    },
 }
 
 /// Creates CreateRealm instruction
@@ -985,6 +995,29 @@ pub fn execute_instruction(
     accounts.extend_from_slice(instruction_accounts);
 
     let instruction = GovernanceInstruction::ExecuteInstruction {};
+
+    Instruction {
+        program_id: *program_id,
+        accounts,
+        data: instruction.try_to_vec().unwrap(),
+    }
+}
+
+/// Creates SetGovernanceConfig instruction
+pub fn set_governance_config(
+    program_id: &Pubkey,
+    // Args
+    config: GovernanceConfig,
+) -> Instruction {
+    let account_governance_address =
+        get_account_governance_address(program_id, &config.realm, &config.governed_account);
+
+    let accounts = vec![
+        AccountMeta::new_readonly(config.realm, false),
+        AccountMeta::new(account_governance_address, true),
+    ];
+
+    let instruction = GovernanceInstruction::SetGovernanceConfig { config };
 
     Instruction {
         program_id: *program_id,

--- a/governance/program/src/processor/mod.rs
+++ b/governance/program/src/processor/mod.rs
@@ -16,6 +16,7 @@ mod process_insert_instruction;
 mod process_relinquish_vote;
 mod process_remove_instruction;
 mod process_remove_signatory;
+mod process_set_governance_config;
 mod process_set_governance_delegate;
 mod process_sign_off_proposal;
 mod process_withdraw_governing_tokens;
@@ -39,6 +40,7 @@ use process_insert_instruction::*;
 use process_relinquish_vote::*;
 use process_remove_instruction::*;
 use process_remove_signatory::*;
+use process_set_governance_config::*;
 use process_set_governance_delegate::*;
 use process_sign_off_proposal::*;
 use process_withdraw_governing_tokens::*;
@@ -153,6 +155,10 @@ pub fn process_instruction(
         }
         GovernanceInstruction::ExecuteInstruction {} => {
             process_execute_instruction(program_id, accounts)
+        }
+
+        GovernanceInstruction::SetGovernanceConfig { config } => {
+            process_set_governance_config(program_id, accounts, config)
         }
     }
 }

--- a/governance/program/src/processor/process_set_governance_config.rs
+++ b/governance/program/src/processor/process_set_governance_config.rs
@@ -1,0 +1,41 @@
+//! Program state processor
+
+use borsh::BorshSerialize;
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    entrypoint::ProgramResult,
+    pubkey::Pubkey,
+};
+
+use crate::{
+    error::GovernanceError,
+    state::governance::{
+        assert_is_valid_governance_config, get_governance_data_for_config, GovernanceConfig,
+    },
+};
+
+/// Processes SetGovernanceConfig instruction
+pub fn process_set_governance_config(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    config: GovernanceConfig,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    let realm_info = next_account_info(account_info_iter)?; // 0
+    let governance_info = next_account_info(account_info_iter)?; // 1
+
+    // Only governance PDA via a proposal can authorize change to its own config
+    if !governance_info.is_signer {
+        return Err(GovernanceError::GovernancePdaMustSign.into());
+    }
+
+    assert_is_valid_governance_config(program_id, &config, realm_info)?;
+
+    let mut governance_data = get_governance_data_for_config(program_id, governance_info, &config)?;
+    governance_data.config = config;
+
+    governance_data.serialize(&mut *governance_info.data.borrow_mut())?;
+
+    Ok(())
+}

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -125,7 +125,7 @@ pub fn get_governance_data_for_config(
         return Err(GovernanceError::InvalidConfigGovernedAccountForGovernance.into());
     }
 
-    return Ok(governance_data);
+    Ok(governance_data)
 }
 
 /// Returns ProgramGovernance PDA seeds

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -109,6 +109,25 @@ pub fn get_governance_data(
     get_account_data::<Governance>(governance_info, program_id)
 }
 
+/// Deserializes governance account data and validates it's consistent with the given config
+pub fn get_governance_data_for_config(
+    program_id: &Pubkey,
+    governance_info: &AccountInfo,
+    config: &GovernanceConfig,
+) -> Result<Governance, ProgramError> {
+    let governance_data = get_governance_data(program_id, governance_info)?;
+
+    if governance_data.config.realm != config.realm {
+        return Err(GovernanceError::InvalidConfigRealmForGovernance.into());
+    }
+
+    if governance_data.config.governed_account != config.governed_account {
+        return Err(GovernanceError::InvalidConfigGovernedAccountForGovernance.into());
+    }
+
+    return Ok(governance_data);
+}
+
 /// Returns ProgramGovernance PDA seeds
 pub fn get_program_governance_address_seeds<'a>(
     realm: &'a Pubkey,
@@ -214,7 +233,7 @@ pub fn assert_is_valid_governance_config(
     realm_info: &AccountInfo,
 ) -> Result<(), ProgramError> {
     if realm_info.key != &governance_config.realm {
-        return Err(GovernanceError::InvalidGovernanceConfig.into());
+        return Err(GovernanceError::InvalidConfigRealmForGovernance.into());
     }
 
     assert_is_valid_realm(program_id, realm_info)?;
@@ -222,7 +241,7 @@ pub fn assert_is_valid_governance_config(
     match governance_config.vote_threshold_percentage {
         VoteThresholdPercentage::YesVote(yes_vote_threshold_percentage) => {
             if !(1..=100).contains(&yes_vote_threshold_percentage) {
-                return Err(GovernanceError::InvalidGovernanceConfig.into());
+                return Err(GovernanceError::InvalidVoteThresholdPercentage.into());
             }
         }
         _ => {

--- a/governance/program/tests/process_create_account_governance.rs
+++ b/governance/program/tests/process_create_account_governance.rs
@@ -80,7 +80,7 @@ async fn test_create_account_governance_with_invalid_config_error() {
 
     // Assert
 
-    assert_eq!(err, GovernanceError::InvalidGovernanceConfig.into());
+    assert_eq!(err, GovernanceError::InvalidVoteThresholdPercentage.into());
 
     // Arrange
     let mut config =
@@ -96,5 +96,5 @@ async fn test_create_account_governance_with_invalid_config_error() {
 
     // Assert
 
-    assert_eq!(err, GovernanceError::InvalidGovernanceConfig.into());
+    assert_eq!(err, GovernanceError::InvalidVoteThresholdPercentage.into());
 }

--- a/governance/program/tests/process_execute_instruction.rs
+++ b/governance/program/tests/process_execute_instruction.rs
@@ -588,7 +588,7 @@ async fn test_execute_mint_instruction_twice_error() {
         .unwrap();
 
     governance_test
-        .with_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
         .await
         .unwrap();
 

--- a/governance/program/tests/process_insert_instruction.rs
+++ b/governance/program/tests/process_insert_instruction.rs
@@ -31,7 +31,7 @@ async fn test_insert_instruction() {
 
     // Act
     let proposal_instruction_cookie = governance_test
-        .with_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
         .await
         .unwrap();
 
@@ -79,12 +79,12 @@ async fn test_insert_multiple_instructions() {
 
     // Act
     governance_test
-        .with_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
         .await
         .unwrap();
 
     governance_test
-        .with_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
         .await
         .unwrap();
 
@@ -123,7 +123,7 @@ async fn test_insert_instruction_with_invalid_index_error() {
 
     // Act
     let err = governance_test
-        .with_instruction(&mut proposal_cookie, &token_owner_record_cookie, Some(1))
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, Some(1))
         .await
         .err()
         .unwrap();
@@ -133,7 +133,7 @@ async fn test_insert_instruction_with_invalid_index_error() {
 }
 
 #[tokio::test]
-async fn test_insert_instruction_with_instruction_already_exists_error() {
+async fn test_insert_instruction_with_nop_instruction_already_exists_error() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
@@ -155,13 +155,13 @@ async fn test_insert_instruction_with_instruction_already_exists_error() {
         .unwrap();
 
     governance_test
-        .with_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
         .await
         .unwrap();
 
     // Act
     let err = governance_test
-        .with_instruction(&mut proposal_cookie, &token_owner_record_cookie, Some(0))
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, Some(0))
         .await
         .err()
         .unwrap();
@@ -199,7 +199,7 @@ async fn test_insert_instruction_with_invalid_hold_up_time_error() {
 
     // Act
     let err = governance_test
-        .with_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
         .await
         .err()
         .unwrap();
@@ -234,7 +234,7 @@ async fn test_insert_instruction_with_not_editable_proposal_error() {
 
     // Act
     let err = governance_test
-        .with_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
         .await
         .err()
         .unwrap();
@@ -276,7 +276,7 @@ async fn test_insert_instruction_with_owner_or_delegate_must_sign_error() {
 
     // Act
     let err = governance_test
-        .with_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
         .await
         .err()
         .unwrap();

--- a/governance/program/tests/process_insert_instruction.rs
+++ b/governance/program/tests/process_insert_instruction.rs
@@ -133,7 +133,7 @@ async fn test_insert_instruction_with_invalid_index_error() {
 }
 
 #[tokio::test]
-async fn test_insert_instruction_with_nop_instruction_already_exists_error() {
+async fn test_insert_instruction_with_instruction_already_exists_error() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 

--- a/governance/program/tests/process_remove_instruction.rs
+++ b/governance/program/tests/process_remove_instruction.rs
@@ -288,7 +288,7 @@ async fn test_remove_instruction_with_proposal_not_editable_error() {
 }
 
 #[tokio::test]
-async fn test_remove_instruction_with_nop_instruction_from_other_proposal_error() {
+async fn test_remove_instruction_with_instruction_from_other_proposal_error() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 

--- a/governance/program/tests/process_remove_instruction.rs
+++ b/governance/program/tests/process_remove_instruction.rs
@@ -30,7 +30,7 @@ async fn test_remove_instruction() {
         .unwrap();
 
     let proposal_instruction_cookie = governance_test
-        .with_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
         .await
         .unwrap();
 
@@ -85,12 +85,12 @@ async fn test_replace_instruction() {
         .unwrap();
 
     let proposal_instruction_cookie = governance_test
-        .with_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
         .await
         .unwrap();
 
     governance_test
-        .with_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
         .await
         .unwrap();
 
@@ -106,7 +106,7 @@ async fn test_replace_instruction() {
         .unwrap();
 
     let proposal_instruction_cookie2 = governance_test
-        .with_instruction(&mut proposal_cookie, &token_owner_record_cookie, Some(0))
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, Some(0))
         .await
         .unwrap();
 
@@ -151,12 +151,12 @@ async fn test_remove_front_instruction() {
         .unwrap();
 
     let proposal_instruction_cookie = governance_test
-        .with_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
         .await
         .unwrap();
 
     governance_test
-        .with_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
         .await
         .unwrap();
 
@@ -209,7 +209,7 @@ async fn test_remove_instruction_with_owner_or_delegate_must_sign_error() {
         .unwrap();
 
     let proposal_instruction_cookie = governance_test
-        .with_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
         .await
         .unwrap();
 
@@ -260,7 +260,7 @@ async fn test_remove_instruction_with_proposal_not_editable_error() {
         .unwrap();
 
     let proposal_instruction_cookie = governance_test
-        .with_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
         .await
         .unwrap();
 
@@ -288,7 +288,7 @@ async fn test_remove_instruction_with_proposal_not_editable_error() {
 }
 
 #[tokio::test]
-async fn test_remove_instruction_with_instruction_from_other_proposal_error() {
+async fn test_remove_instruction_with_nop_instruction_from_other_proposal_error() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
@@ -310,7 +310,7 @@ async fn test_remove_instruction_with_instruction_from_other_proposal_error() {
         .unwrap();
 
     governance_test
-        .with_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
         .await
         .unwrap();
 
@@ -320,7 +320,7 @@ async fn test_remove_instruction_with_instruction_from_other_proposal_error() {
         .unwrap();
 
     let proposal_instruction_cookie2 = governance_test
-        .with_instruction(&mut proposal_cookie2, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie2, &token_owner_record_cookie, None)
         .await
         .unwrap();
 

--- a/governance/program/tests/process_set_governance_config.rs
+++ b/governance/program/tests/process_set_governance_config.rs
@@ -1,11 +1,12 @@
 mod program_test;
 
+use borsh::BorshSerialize;
 use program_test::{tools::ProgramInstructionError, *};
 use solana_program_test::tokio;
 use solana_sdk::{signature::Keypair, signer::Signer};
 use spl_governance::{
     error::GovernanceError,
-    instruction::{set_governance_config, Vote},
+    instruction::{set_governance_config, GovernanceInstruction, Vote},
 };
 
 #[tokio::test]
@@ -204,4 +205,163 @@ async fn test_set_governance_config_with_invalid_governance_authority_error() {
 
     // Assert
     assert_eq!(err, ProgramInstructionError::PrivilegeEscalation.into());
+}
+
+#[tokio::test]
+async fn test_set_governance_config_with_invalid_config_realm_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let mut account_governance_cookie = governance_test
+        .with_account_governance(&realm_cookie, &governed_account_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await;
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut account_governance_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_config =
+        governance_test.get_default_governance_config(&realm_cookie, &governed_account_cookie);
+
+    let mut set_governance_config_ix =
+        set_governance_config(&governance_test.program_id, governance_config.clone());
+
+    // Try to maliciously change realm  in the governance config
+    let realm_cookie2 = governance_test.with_realm().await;
+    governance_config.realm = realm_cookie2.address;
+    set_governance_config_ix.data = (GovernanceInstruction::SetGovernanceConfig {
+        config: governance_config,
+    })
+    .try_to_vec()
+    .unwrap();
+
+    let proposal_instruction_cookie = governance_test
+        .with_instruction(
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            None,
+            &mut set_governance_config_ix,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .await
+        .unwrap();
+
+    // Advance timestamp past hold_up_time
+    governance_test
+        .advance_clock_by_min_timespan(proposal_instruction_cookie.account.hold_up_time as u64)
+        .await;
+
+    // Act
+    let err = governance_test
+        .execute_instruction(&proposal_cookie, &proposal_instruction_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::InvalidConfigRealmForGovernance.into());
+}
+
+#[tokio::test]
+async fn test_set_governance_config_with_invalid_config_governed_account_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let mut account_governance_cookie = governance_test
+        .with_account_governance(&realm_cookie, &governed_account_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await;
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut account_governance_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_config =
+        governance_test.get_default_governance_config(&realm_cookie, &governed_account_cookie);
+
+    let mut set_governance_config_ix =
+        set_governance_config(&governance_test.program_id, governance_config.clone());
+
+    // Try to maliciously change governed account  in the governance config
+    let governed_account_cookie2 = governance_test.with_governed_account().await;
+    governance_config.governed_account = governed_account_cookie2.address;
+    set_governance_config_ix.data = (GovernanceInstruction::SetGovernanceConfig {
+        config: governance_config,
+    })
+    .try_to_vec()
+    .unwrap();
+
+    let proposal_instruction_cookie = governance_test
+        .with_instruction(
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            None,
+            &mut set_governance_config_ix,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .await
+        .unwrap();
+
+    // Advance timestamp past hold_up_time
+    governance_test
+        .advance_clock_by_min_timespan(proposal_instruction_cookie.account.hold_up_time as u64)
+        .await;
+
+    // Act
+    let err = governance_test
+        .execute_instruction(&proposal_cookie, &proposal_instruction_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::InvalidConfigGovernedAccountForGovernance.into()
+    );
 }

--- a/governance/program/tests/process_set_governance_config.rs
+++ b/governance/program/tests/process_set_governance_config.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "test-bpf")]
+
 mod program_test;
 
 use borsh::BorshSerialize;
@@ -38,6 +40,8 @@ async fn test_set_governance_config() {
 
     let mut governance_config =
         governance_test.get_default_governance_config(&realm_cookie, &governed_account_cookie);
+
+    // Change vote_threshold_percentage on the Governance config
     governance_config.vote_threshold_percentage = 40;
 
     let proposal_instruction_cookie = governance_test
@@ -92,6 +96,7 @@ async fn test_set_governance_config_with_governance_must_sign_error() {
     let mut set_governance_config_ix =
         set_governance_config(&governance_test.program_id, governance_config.clone());
 
+    // Remove governance signer from instruction
     set_governance_config_ix.accounts[1].is_signer = false;
 
     // Act
@@ -119,6 +124,7 @@ async fn test_set_governance_config_with_fake_governance_signer_error() {
     let mut set_governance_config_ix =
         set_governance_config(&governance_test.program_id, governance_config.clone());
 
+    // Set Governance signer to fake account we have authority over and can use to sign the transaction
     let governance_signer = Keypair::new();
     set_governance_config_ix.accounts[1].pubkey = governance_signer.pubkey();
 
@@ -160,7 +166,7 @@ async fn test_set_governance_config_with_invalid_governance_authority_error() {
         .await
         .unwrap();
 
-    // Try to maliciously change governed account in the governance config
+    // Try to maliciously use a different governed account to change the given governance config
     let governed_account_cookie2 = governance_test.with_governed_account().await;
 
     let account_governance_cookie2 = governance_test

--- a/governance/program/tests/process_set_governance_config.rs
+++ b/governance/program/tests/process_set_governance_config.rs
@@ -1,0 +1,74 @@
+mod program_test;
+
+use program_test::*;
+use solana_program_test::tokio;
+use spl_governance::instruction::Vote;
+
+#[tokio::test]
+async fn test_set_governance_config() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let mut account_governance_cookie = governance_test
+        .with_account_governance(&realm_cookie, &governed_account_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await;
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut account_governance_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_config =
+        governance_test.get_default_governance_config(&realm_cookie, &governed_account_cookie);
+    governance_config.vote_threshold_percentage = 40;
+
+    let proposal_instruction_cookie = governance_test
+        .with_set_governance_config_instruction(
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .await
+        .unwrap();
+
+    // Advance timestamp past hold_up_time
+    governance_test
+        .advance_clock_by_min_timespan(proposal_instruction_cookie.account.hold_up_time as u64)
+        .await;
+
+    // Act
+    governance_test
+        .execute_instruction(&proposal_cookie, &proposal_instruction_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let governance_account = governance_test
+        .get_governance_account(&account_governance_cookie.address)
+        .await;
+
+    assert_eq!(governance_config, governance_account.config);
+}

--- a/governance/program/tests/process_set_governance_config.rs
+++ b/governance/program/tests/process_set_governance_config.rs
@@ -1,8 +1,12 @@
 mod program_test;
 
-use program_test::*;
+use program_test::{tools::ProgramInstructionError, *};
 use solana_program_test::tokio;
-use spl_governance::instruction::Vote;
+use solana_sdk::{signature::Keypair, signer::Signer};
+use spl_governance::{
+    error::GovernanceError,
+    instruction::{set_governance_config, Vote},
+};
 
 #[tokio::test]
 async fn test_set_governance_config() {
@@ -71,4 +75,133 @@ async fn test_set_governance_config() {
         .await;
 
     assert_eq!(governance_config, governance_account.config);
+}
+
+#[tokio::test]
+async fn test_set_governance_config_with_governance_must_sign_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let governance_config =
+        governance_test.get_default_governance_config(&realm_cookie, &governed_account_cookie);
+
+    let mut set_governance_config_ix =
+        set_governance_config(&governance_test.program_id, governance_config.clone());
+
+    set_governance_config_ix.accounts[1].is_signer = false;
+
+    // Act
+    let err = governance_test
+        .process_transaction(&[set_governance_config_ix], None)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::GovernancePdaMustSign.into());
+}
+
+#[tokio::test]
+async fn test_set_governance_config_with_fake_governance_signer_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let governance_config =
+        governance_test.get_default_governance_config(&realm_cookie, &governed_account_cookie);
+
+    let mut set_governance_config_ix =
+        set_governance_config(&governance_test.program_id, governance_config.clone());
+
+    let governance_signer = Keypair::new();
+    set_governance_config_ix.accounts[1].pubkey = governance_signer.pubkey();
+
+    // Act
+    let err = governance_test
+        .process_transaction(&[set_governance_config_ix], Some(&[&governance_signer]))
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::AccountDoesNotExist.into());
+}
+
+#[tokio::test]
+async fn test_set_governance_config_with_invalid_governance_authority_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let mut account_governance_cookie = governance_test
+        .with_account_governance(&realm_cookie, &governed_account_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await;
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut account_governance_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Try to maliciously change governed account in the governance config
+    let governed_account_cookie2 = governance_test.with_governed_account().await;
+
+    let account_governance_cookie2 = governance_test
+        .with_account_governance(&realm_cookie, &governed_account_cookie2)
+        .await
+        .unwrap();
+
+    let mut governance_config =
+        governance_test.get_default_governance_config(&realm_cookie, &governed_account_cookie);
+    governance_config.governed_account = account_governance_cookie2.address;
+
+    let proposal_instruction_cookie = governance_test
+        .with_set_governance_config_instruction(
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .await
+        .unwrap();
+
+    // Advance timestamp past hold_up_time
+    governance_test
+        .advance_clock_by_min_timespan(proposal_instruction_cookie.account.hold_up_time as u64)
+        .await;
+
+    // Act
+    let err = governance_test
+        .execute_instruction(&proposal_cookie, &proposal_instruction_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, ProgramInstructionError::PrivilegeEscalation.into());
 }

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1588,9 +1588,7 @@ impl GovernanceProgramTest {
         );
 
         self.process_transaction(&[execute_instruction_instruction], None)
-            .await?;
-
-        Ok(())
+            .await
     }
 
     #[allow(dead_code)]

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -29,7 +29,8 @@ use spl_governance::{
         create_mint_governance, create_program_governance, create_proposal, create_realm,
         create_token_governance, deposit_governing_tokens, execute_instruction, finalize_vote,
         insert_instruction, relinquish_vote, remove_instruction, remove_signatory,
-        set_governance_delegate, sign_off_proposal, withdraw_governing_tokens, Vote,
+        set_governance_config, set_governance_delegate, sign_off_proposal,
+        withdraw_governing_tokens, Vote,
     },
     processor::process_instruction,
     state::{
@@ -1297,6 +1298,24 @@ impl GovernanceProgramTest {
         };
 
         Ok(vote_record_cookie)
+    }
+
+    #[allow(dead_code)]
+    pub async fn with_set_governance_config_instruction(
+        &mut self,
+        proposal_cookie: &mut ProposalCookie,
+        token_owner_record_cookie: &TokeOwnerRecordCookie,
+        governance_config: &GovernanceConfig,
+    ) -> Result<ProposalInstructionCookie, ProgramError> {
+        let mut instruction = set_governance_config(&self.program_id, governance_config.clone());
+
+        self.with_instruction_impl(
+            proposal_cookie,
+            token_owner_record_cookie,
+            None,
+            &mut instruction,
+        )
+        .await
     }
 
     #[allow(dead_code)]

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1309,7 +1309,7 @@ impl GovernanceProgramTest {
     ) -> Result<ProposalInstructionCookie, ProgramError> {
         let mut instruction = set_governance_config(&self.program_id, governance_config.clone());
 
-        self.with_instruction_impl(
+        self.with_instruction(
             proposal_cookie,
             token_owner_record_cookie,
             None,
@@ -1344,7 +1344,7 @@ impl GovernanceProgramTest {
         )
         .unwrap();
 
-        self.with_instruction_impl(
+        self.with_instruction(
             proposal_cookie,
             token_owner_record_cookie,
             index,
@@ -1379,7 +1379,7 @@ impl GovernanceProgramTest {
         )
         .unwrap();
 
-        self.with_instruction_impl(
+        self.with_instruction(
             proposal_cookie,
             token_owner_record_cookie,
             index,
@@ -1446,7 +1446,7 @@ impl GovernanceProgramTest {
             &governance_cookie.address,
         );
 
-        self.with_instruction_impl(
+        self.with_instruction(
             proposal_cookie,
             token_owner_record_cookie,
             None,
@@ -1456,7 +1456,7 @@ impl GovernanceProgramTest {
     }
 
     #[allow(dead_code)]
-    pub async fn with_instruction(
+    pub async fn with_nop_instruction(
         &mut self,
         proposal_cookie: &mut ProposalCookie,
         token_owner_record_cookie: &TokeOwnerRecordCookie,
@@ -1468,7 +1468,7 @@ impl GovernanceProgramTest {
             data: vec![],
         };
 
-        self.with_instruction_impl(
+        self.with_instruction(
             proposal_cookie,
             token_owner_record_cookie,
             index,
@@ -1478,7 +1478,7 @@ impl GovernanceProgramTest {
     }
 
     #[allow(dead_code)]
-    async fn with_instruction_impl(
+    pub async fn with_instruction(
         &mut self,
         proposal_cookie: &mut ProposalCookie,
         token_owner_record_cookie: &TokeOwnerRecordCookie,

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -83,7 +83,7 @@ impl GovernanceProgramTest {
 
         let program_test = ProgramTest::new(
             "spl_governance",
-            program_id.clone(),
+            program_id,
             processor!(process_instruction),
         );
 
@@ -104,7 +104,7 @@ impl GovernanceProgramTest {
         signers: Option<&[&Keypair]>,
     ) -> Result<(), ProgramError> {
         let mut transaction =
-            Transaction::new_with_payer(&instructions, Some(&self.context.payer.pubkey()));
+            Transaction::new_with_payer(instructions, Some(&self.context.payer.pubkey()));
 
         let mut all_signers = vec![&self.context.payer];
 
@@ -133,7 +133,7 @@ impl GovernanceProgramTest {
     #[allow(dead_code)]
     pub async fn with_realm(&mut self) -> RealmCookie {
         let name = format!("Realm #{}", self.next_realm_id).to_string();
-        self.next_realm_id = self.next_realm_id + 1;
+        self.next_realm_id += 1;
 
         let realm_address = get_realm_address(&self.program_id, &name);
 
@@ -202,7 +202,7 @@ impl GovernanceProgramTest {
     #[allow(dead_code)]
     pub async fn with_realm_using_mints(&mut self, realm_cookie: &RealmCookie) -> RealmCookie {
         let name = format!("Realm #{}", self.next_realm_id).to_string();
-        self.next_realm_id = self.next_realm_id + 1;
+        self.next_realm_id += 1;
 
         let realm_address = get_realm_address(&self.program_id, &name);
         let council_mint = realm_cookie.account.council_mint.unwrap();
@@ -245,7 +245,7 @@ impl GovernanceProgramTest {
 
             council_token_holding_account: Some(council_token_holding_address),
             council_mint_authority: Some(clone_keypair(
-                &realm_cookie.council_mint_authority.as_ref().unwrap(),
+                realm_cookie.council_mint_authority.as_ref().unwrap(),
             )),
         }
     }
@@ -306,7 +306,7 @@ impl GovernanceProgramTest {
         self.with_subsequent_governing_token_deposit(
             &realm_cookie.address,
             &realm_cookie.account.council_mint.unwrap(),
-            &realm_cookie.council_mint_authority.as_ref().unwrap(),
+            realm_cookie.council_mint_authority.as_ref().unwrap(),
             token_owner_record_cookie,
             amount,
         )
@@ -321,7 +321,7 @@ impl GovernanceProgramTest {
         self.with_initial_governing_token_deposit(
             &realm_cookie.address,
             &realm_cookie.account.council_mint.unwrap(),
-            &realm_cookie.council_mint_authority.as_ref().unwrap(),
+            realm_cookie.council_mint_authority.as_ref().unwrap(),
             100,
         )
         .await
@@ -370,7 +370,7 @@ impl GovernanceProgramTest {
         let token_owner_record_address = get_token_owner_record_address(
             &self.program_id,
             realm_address,
-            &governing_mint,
+            governing_mint,
             &token_owner.pubkey(),
         );
 
@@ -396,7 +396,7 @@ impl GovernanceProgramTest {
             token_source: token_source.pubkey(),
             token_owner,
             governance_authority: None,
-            governance_delegate: governance_delegate,
+            governance_delegate,
         }
     }
 
@@ -462,7 +462,7 @@ impl GovernanceProgramTest {
         token_owner_record_cookie: &mut TokeOwnerRecordCookie,
     ) {
         self.with_governing_token_governance_delegate(
-            &realm_cookie,
+            realm_cookie,
             &realm_cookie.account.community_mint,
             token_owner_record_cookie,
         )
@@ -476,7 +476,7 @@ impl GovernanceProgramTest {
         token_owner_record_cookie: &mut TokeOwnerRecordCookie,
     ) {
         self.with_governing_token_governance_delegate(
-            &realm_cookie,
+            realm_cookie,
             &realm_cookie.account.council_mint.unwrap(),
             token_owner_record_cookie,
         )
@@ -524,7 +524,7 @@ impl GovernanceProgramTest {
 
         self.process_transaction(
             &[set_governance_delegate_instruction],
-            Some(&[&signing_governance_authority]),
+            Some(&[signing_governance_authority]),
         )
         .await
         .unwrap();
@@ -579,7 +579,7 @@ impl GovernanceProgramTest {
 
         self.process_transaction(
             &[deposit_governing_tokens_instruction],
-            Some(&[&governing_token_owner]),
+            Some(&[governing_token_owner]),
         )
         .await
     }
@@ -601,7 +601,7 @@ impl GovernanceProgramTest {
 
         GovernedMintCookie {
             address: mint_keypair.pubkey(),
-            mint_authority: mint_authority,
+            mint_authority,
             transfer_mint_authority: true,
         }
     }
@@ -634,7 +634,7 @@ impl GovernanceProgramTest {
 
         GovernedTokenCookie {
             address: token_keypair.pubkey(),
-            token_owner: token_owner,
+            token_owner,
             transfer_token_owner: true,
             token_mint: mint_keypair.pubkey(),
         }
@@ -980,11 +980,11 @@ impl GovernanceProgramTest {
         governance_cookie: &mut GovernanceCookie,
     ) -> Result<ProposalCookie, ProgramError> {
         let proposal_cookie = self
-            .with_proposal(&token_owner_record_cookie, governance_cookie)
+            .with_proposal(token_owner_record_cookie, governance_cookie)
             .await?;
 
         let signatory_record_cookie = self
-            .with_signatory(&proposal_cookie, &token_owner_record_cookie)
+            .with_signatory(&proposal_cookie, token_owner_record_cookie)
             .await?;
 
         self.sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
@@ -1001,7 +1001,7 @@ impl GovernanceProgramTest {
         instruction_override: F,
     ) -> Result<ProposalCookie, ProgramError> {
         let proposal_index = governance_cookie.next_proposal_index;
-        governance_cookie.next_proposal_index = governance_cookie.next_proposal_index + 1;
+        governance_cookie.next_proposal_index += 1;
 
         let name = format!("Proposal #{}", proposal_index);
 
@@ -1026,7 +1026,7 @@ impl GovernanceProgramTest {
 
         self.process_transaction(
             &[create_proposal_instruction],
-            Some(&[&governance_authority]),
+            Some(&[governance_authority]),
         )
         .await?;
 
@@ -1113,7 +1113,7 @@ impl GovernanceProgramTest {
         let signatory_record_cookie = SignatoryRecordCookie {
             address: signatory_record_address,
             account: signatory_record_data,
-            signatory: signatory,
+            signatory,
         };
 
         Ok(signatory_record_cookie)
@@ -1307,13 +1307,14 @@ impl GovernanceProgramTest {
         token_owner_record_cookie: &TokeOwnerRecordCookie,
         governance_config: &GovernanceConfig,
     ) -> Result<ProposalInstructionCookie, ProgramError> {
-        let mut instruction = set_governance_config(&self.program_id, governance_config.clone());
+        let mut set_governance_config_ix =
+            set_governance_config(&self.program_id, governance_config.clone());
 
         self.with_instruction(
             proposal_cookie,
             token_owner_record_cookie,
             None,
-            &mut instruction,
+            &mut set_governance_config_ix,
         )
         .await
     }
@@ -1462,6 +1463,8 @@ impl GovernanceProgramTest {
         token_owner_record_cookie: &TokeOwnerRecordCookie,
         index: Option<u16>,
     ) -> Result<ProposalInstructionCookie, ProgramError> {
+        // Create NOP instruction as a placeholder
+        // Note: The actual instruction is irrelevant because we do not execute it in tests
         let mut instruction = Instruction {
             program_id: Pubkey::new_unique(),
             accounts: vec![],
@@ -1491,8 +1494,7 @@ impl GovernanceProgramTest {
 
         let instruction_index = index.unwrap_or(proposal_cookie.account.instructions_next_index);
 
-        proposal_cookie.account.instructions_next_index =
-            proposal_cookie.account.instructions_next_index + 1;
+        proposal_cookie.account.instructions_next_index += 1;
 
         let insert_instruction_instruction = insert_instruction(
             &self.program_id,
@@ -1656,8 +1658,8 @@ impl GovernanceProgramTest {
             .get_account(*address)
             .await
             .unwrap()
-            .map(|a| deserialize::<T>(&a.data.borrow()).unwrap())
-            .expect(format!("GET-TEST-ACCOUNT-ERROR: Account {}", address).as_str())
+            .map(|a| deserialize::<T>(a.data.borrow()).unwrap())
+            .unwrap_or_else(|| panic!("GET-TEST-ACCOUNT-ERROR: Account {}", address))
     }
 
     #[allow(dead_code)]
@@ -1675,7 +1677,7 @@ impl GovernanceProgramTest {
             // Since the exact time is not deterministic keep wrapping by arbitrary 400 slots until we pass the requested timestamp
             self.context.warp_to_slot(clock.slot + n * 400).unwrap();
 
-            n = n + 1;
+            n += 1;
             clock = self.get_clock().await;
         }
     }
@@ -1706,7 +1708,7 @@ impl GovernanceProgramTest {
         self.get_account(address)
             .await
             .map(|a| try_from_slice_unchecked(&a.data).unwrap())
-            .expect(format!("GET-TEST-ACCOUNT-ERROR: Account {} not found", address).as_str())
+            .unwrap_or_else(|| panic!("GET-TEST-ACCOUNT-ERROR: Account {} not found", address))
     }
 
     #[allow(dead_code)]
@@ -1742,14 +1744,14 @@ impl GovernanceProgramTest {
             spl_token::instruction::initialize_mint(
                 &spl_token::id(),
                 &mint_keypair.pubkey(),
-                &mint_authority,
+                mint_authority,
                 None,
                 0,
             )
             .unwrap(),
         ];
 
-        self.process_transaction(&instructions, Some(&[&mint_keypair]))
+        self.process_transaction(&instructions, Some(&[mint_keypair]))
             .await
             .unwrap();
     }
@@ -1774,13 +1776,13 @@ impl GovernanceProgramTest {
             &spl_token::id(),
             &token_account_keypair.pubkey(),
             token_mint,
-            &owner,
+            owner,
         )
         .unwrap();
 
         self.process_transaction(
             &[create_account_instruction, initialize_account_instruction],
-            Some(&[&token_account_keypair]),
+            Some(&[token_account_keypair]),
         )
         .await
         .unwrap();
@@ -1840,7 +1842,7 @@ impl GovernanceProgramTest {
                 mint_instruction,
                 approve_instruction,
             ],
-            Some(&[&token_account_keypair, &token_mint_authority, &owner]),
+            Some(&[token_account_keypair, token_mint_authority, owner]),
         )
         .await
         .unwrap();
@@ -1855,15 +1857,15 @@ impl GovernanceProgramTest {
     ) {
         let mint_instruction = spl_token::instruction::mint_to(
             &spl_token::id(),
-            &token_mint,
-            &token_account,
+            token_mint,
+            token_account,
             &token_mint_authority.pubkey(),
             &[],
             amount,
         )
         .unwrap();
 
-        self.process_transaction(&[mint_instruction], Some(&[&token_mint_authority]))
+        self.process_transaction(&[mint_instruction], Some(&[token_mint_authority]))
             .await
             .unwrap();
     }

--- a/governance/program/tests/program_test/tools.rs
+++ b/governance/program/tests/program_test/tools.rs
@@ -7,7 +7,10 @@ use solana_sdk::{signature::Keypair, transaction::TransactionError, transport::T
 /// Instruction errors not mapped in the sdk
 pub enum ProgramInstructionError {
     /// Incorrect authority provided
-    IncorrectAuthority,
+    IncorrectAuthority = 600,
+
+    /// Cross-program invocation with unauthorized signer or writable account
+    PrivilegeEscalation,
 }
 
 impl From<ProgramInstructionError> for ProgramError {
@@ -28,6 +31,9 @@ pub fn map_transaction_error(transport_error: TransportError) -> ProgramError {
         )) => ProgramError::try_from(instruction_error).unwrap_or_else(|ie| match ie {
             InstructionError::IncorrectAuthority => {
                 ProgramInstructionError::IncorrectAuthority.into()
+            }
+            InstructionError::PrivilegeEscalation => {
+                ProgramInstructionError::PrivilegeEscalation.into()
             }
             _ => panic!("TEST-INSTRUCTION-ERROR {:?}", ie),
         }),


### PR DESCRIPTION
#### Implemented instructions:

- `SetGovernanceConfig` - Instruction allows to update `GovernanceConfig`. The instruction must be signed by `Governance` PDA and hence can only be executed as an instruction of a `Proposal` for the `Governance` the `Proposal` belongs to. It allows self governance and tweaking of the `GovernanceConfig` parameters for a given community. For example it can be used to adjust vote threshold which makes sense for the given community engagement. 