### PR TITLE
Make twitter constants configurable for easier testing in name service js

### DIFF
--- a/name-service/js/package.json
+++ b/name-service/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana/spl-name-service",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "description": "SPL Name Service JavaScript API",
   "license": "MIT",
   "author": "Solana Maintainers <maintainers@solana.foundation>",

--- a/name-service/js/src/twitter.ts
+++ b/name-service/js/src/twitter.ts
@@ -34,327 +34,7 @@ export const TWITTER_ROOT_PARENT_REGISTRY_KEY = new PublicKey(
   '4YcexoW3r78zz16J2aqmukBLRwGq6rAvWzJpkYAXqebv'
 );
 
-////////////////////////////////////////////////////
-// Bindings
-
-// Signed by the authority, the payer and the verified pubkey
-export async function createVerifiedTwitterRegistry(
-  connection: Connection,
-  twitterHandle: string,
-  verifiedPubkey: PublicKey,
-  space: number, // The space that the user will have to write data into the verified registry
-  payerKey: PublicKey
-): Promise<TransactionInstruction[]> {
-  // Create user facing registry
-  const hashedTwitterHandle = await getHashedName(twitterHandle);
-  const twitterHandleRegistryKey = await getNameAccountKey(
-    hashedTwitterHandle,
-    undefined,
-    TWITTER_ROOT_PARENT_REGISTRY_KEY
-  );
-
-  let instructions = [
-    createInstruction(
-      NAME_PROGRAM_ID,
-      SystemProgram.programId,
-      twitterHandleRegistryKey,
-      verifiedPubkey,
-      payerKey,
-      hashedTwitterHandle,
-      new Numberu64(await connection.getMinimumBalanceForRentExemption(space)),
-      new Numberu32(space),
-      undefined,
-      TWITTER_ROOT_PARENT_REGISTRY_KEY,
-      TWITTER_VERIFICATION_AUTHORITY // Twitter authority acts as owner of the parent for all user-facing registries
-    ),
-  ];
-
-  instructions = instructions.concat(
-    await createReverseTwitterRegistry(
-      connection,
-      twitterHandle,
-      twitterHandleRegistryKey,
-      verifiedPubkey,
-      payerKey
-    )
-  );
-
-  return instructions;
-}
-
-// Overwrite the data that is written in the user facing registry
-// Signed by the verified pubkey
-export async function changeTwitterRegistryData(
-  twitterHandle: string,
-  verifiedPubkey: PublicKey,
-  offset: number, // The offset at which to write the input data into the NameRegistryData
-  input_data: Buffer
-): Promise<TransactionInstruction[]> {
-  const hashedTwitterHandle = await getHashedName(twitterHandle);
-  const twitterHandleRegistryKey = await getNameAccountKey(
-    hashedTwitterHandle,
-    undefined,
-    TWITTER_ROOT_PARENT_REGISTRY_KEY
-  );
-
-  const instructions = [
-    updateInstruction(
-      NAME_PROGRAM_ID,
-      twitterHandleRegistryKey,
-      new Numberu32(offset),
-      input_data,
-      verifiedPubkey
-    ),
-  ];
-
-  return instructions;
-}
-
-// Change the verified pubkey for a given twitter handle
-// Signed by the Authority, the verified pubkey and the payer
-export async function changeVerifiedPubkey(
-  connection: Connection,
-  twitterHandle: string,
-  currentVerifiedPubkey: PublicKey,
-  newVerifiedPubkey: PublicKey,
-  payerKey: PublicKey
-): Promise<TransactionInstruction[]> {
-  const hashedTwitterHandle = await getHashedName(twitterHandle);
-  const twitterHandleRegistryKey = await getNameAccountKey(
-    hashedTwitterHandle,
-    undefined,
-    TWITTER_ROOT_PARENT_REGISTRY_KEY
-  );
-
-  // Transfer the user-facing registry ownership
-  let instructions = [
-    transferInstruction(
-      NAME_PROGRAM_ID,
-      twitterHandleRegistryKey,
-      newVerifiedPubkey,
-      currentVerifiedPubkey,
-      undefined
-    ),
-  ];
-
-  // Delete the current reverse registry
-  const currentHashedVerifiedPubkey = await getHashedName(
-    currentVerifiedPubkey.toString()
-  );
-  const currentReverseRegistryKey = await getNameAccountKey(
-    currentHashedVerifiedPubkey,
-    TWITTER_VERIFICATION_AUTHORITY,
-    undefined
-  );
-  instructions.push(
-    await deleteNameRegistry(
-      connection,
-      currentVerifiedPubkey.toString(),
-      payerKey,
-      TWITTER_VERIFICATION_AUTHORITY,
-      TWITTER_ROOT_PARENT_REGISTRY_KEY
-    )
-  );
-
-  // Create the new reverse registry
-  instructions = instructions.concat(
-    await createReverseTwitterRegistry(
-      connection,
-      twitterHandle,
-      twitterHandleRegistryKey,
-      newVerifiedPubkey,
-      payerKey
-    )
-  );
-
-  return instructions;
-}
-
-// Delete the verified registry for a given twitter handle
-// Signed by the verified pubkey
-export async function deleteTwitterRegistry(
-  twitterHandle: string,
-  verifiedPubkey: PublicKey
-): Promise<TransactionInstruction[]> {
-  const hashedTwitterHandle = await getHashedName(twitterHandle);
-  const twitterHandleRegistryKey = await getNameAccountKey(
-    hashedTwitterHandle,
-    undefined,
-    TWITTER_ROOT_PARENT_REGISTRY_KEY
-  );
-
-  const hashedVerifiedPubkey = await getHashedName(verifiedPubkey.toString());
-  const reverseRegistryKey = await getNameAccountKey(
-    hashedVerifiedPubkey,
-    TWITTER_VERIFICATION_AUTHORITY,
-    TWITTER_ROOT_PARENT_REGISTRY_KEY
-  );
-
-  const instructions = [
-    // Delete the user facing registry
-    deleteInstruction(
-      NAME_PROGRAM_ID,
-      twitterHandleRegistryKey,
-      verifiedPubkey,
-      verifiedPubkey
-    ),
-    // Delete the reverse registry
-    deleteInstruction(
-      NAME_PROGRAM_ID,
-      reverseRegistryKey,
-      verifiedPubkey,
-      verifiedPubkey
-    ),
-  ];
-
-  return instructions;
-}
-
-//////////////////////////////////////////
-// Getter Functions
-
-// Returns the key of the user-facing registry
-export async function getTwitterRegistryKey(
-  twitter_handle: string
-): Promise<PublicKey> {
-  const hashedTwitterHandle = await getHashedName(twitter_handle);
-  return await getNameAccountKey(
-    hashedTwitterHandle,
-    undefined,
-    TWITTER_ROOT_PARENT_REGISTRY_KEY
-  );
-}
-
-export async function getTwitterRegistry(
-  connection: Connection,
-  twitter_handle: string
-): Promise<NameRegistryState> {
-  const hashedTwitterHandle = await getHashedName(twitter_handle);
-  const twitterHandleRegistryKey = await getNameAccountKey(
-    hashedTwitterHandle,
-    undefined,
-    TWITTER_ROOT_PARENT_REGISTRY_KEY
-  );
-  const registry = NameRegistryState.retrieve(
-    connection,
-    twitterHandleRegistryKey
-  );
-  return registry;
-}
-
-export async function getHandleAndRegistryKey(
-  connection: Connection,
-  verifiedPubkey: PublicKey
-): Promise<[string, PublicKey]> {
-  const hashedVerifiedPubkey = await getHashedName(verifiedPubkey.toString());
-  const reverseRegistryKey = await getNameAccountKey(
-    hashedVerifiedPubkey,
-    TWITTER_VERIFICATION_AUTHORITY,
-    TWITTER_ROOT_PARENT_REGISTRY_KEY
-  );
-
-  let reverseRegistryState = await ReverseTwitterRegistryState.retrieve(
-    connection,
-    reverseRegistryKey
-  );
-  return [
-    reverseRegistryState.twitterHandle,
-    new PublicKey(reverseRegistryState.twitterRegistryKey),
-  ];
-}
-
-// Uses the RPC node filtering feature, execution speed may vary
-export async function getTwitterHandleandRegistryKeyViaFilters(
-  connection: Connection,
-  verifiedPubkey: PublicKey
-): Promise<[string, PublicKey]> {
-  const filters = [
-    {
-      memcmp: {
-        offset: 0,
-        bytes: TWITTER_ROOT_PARENT_REGISTRY_KEY.toBase58(),
-      },
-    },
-    {
-      memcmp: {
-        offset: 32,
-        bytes: verifiedPubkey.toBase58(),
-      },
-    },
-    {
-      memcmp: {
-        offset: 64,
-        bytes: TWITTER_VERIFICATION_AUTHORITY.toBase58(),
-      },
-    },
-  ];
-
-  const filteredAccounts = await getFilteredProgramAccounts(
-    connection,
-    NAME_PROGRAM_ID,
-    filters
-  );
-
-  for (const f of filteredAccounts) {
-    if (f.accountInfo.data.length > NameRegistryState.HEADER_LEN + 32) {
-      let data = f.accountInfo.data.slice(NameRegistryState.HEADER_LEN);
-      let state: ReverseTwitterRegistryState = deserialize(
-        ReverseTwitterRegistryState.schema,
-        ReverseTwitterRegistryState,
-        data
-      );
-      return [state.twitterHandle, new PublicKey(state.twitterRegistryKey)];
-    }
-  }
-  throw new Error('Registry not found.');
-}
-
-// Uses the RPC node filtering feature, execution speed may vary
-// Does not give you the handle, but is an alternative to getHandlesAndKeysFromVerifiedPubkey + getTwitterRegistry to get the data
-export async function getTwitterRegistryData(
-  connection: Connection,
-  verifiedPubkey: PublicKey
-): Promise<Buffer> {
-  const filters = [
-    {
-      memcmp: {
-        offset: 0,
-        bytes: TWITTER_ROOT_PARENT_REGISTRY_KEY.toBytes(),
-      },
-    },
-    {
-      memcmp: {
-        offset: 32,
-        bytes: verifiedPubkey.toBytes(),
-      },
-    },
-    {
-      memcmp: {
-        offset: 64,
-        bytes: new PublicKey(Buffer.alloc(32, 0)).toBase58(),
-      },
-    },
-  ];
-
-  const filteredAccounts = await getFilteredProgramAccounts(
-    connection,
-    NAME_PROGRAM_ID,
-    filters
-  );
-
-  if (filteredAccounts.length > 1) {
-    throw new Error('Found more than one registry.');
-  }
-
-  return filteredAccounts[0].accountInfo.data.slice(
-    NameRegistryState.HEADER_LEN
-  );
-}
-
-//////////////////////////////////////////////
-// Utils
-
-export class ReverseTwitterRegistryState {
+class ReverseTwitterRegistryState {
   twitterRegistryKey: Uint8Array;
   twitterHandle: string;
 
@@ -397,51 +77,385 @@ export class ReverseTwitterRegistryState {
   }
 }
 
-export async function createReverseTwitterRegistry(
-  connection: Connection,
-  twitterHandle: string,
-  twitterRegistryKey: PublicKey,
-  verifiedPubkey: PublicKey,
-  payerKey: PublicKey
-): Promise<TransactionInstruction[]> {
-  // Create the reverse lookup registry
-  const hashedVerifiedPubkey = await getHashedName(verifiedPubkey.toString());
-  const reverseRegistryKey = await getNameAccountKey(
-    hashedVerifiedPubkey,
-    TWITTER_VERIFICATION_AUTHORITY,
-    TWITTER_ROOT_PARENT_REGISTRY_KEY
-  );
-  let reverseTwitterRegistryStateBuff = serialize(
-    ReverseTwitterRegistryState.schema,
-    new ReverseTwitterRegistryState({
-      twitterRegistryKey: twitterRegistryKey.toBytes(),
-      twitterHandle,
-    })
-  );
-  return [
-    createInstruction(
-      NAME_PROGRAM_ID,
-      SystemProgram.programId,
-      reverseRegistryKey,
-      verifiedPubkey,
-      payerKey,
-      hashedVerifiedPubkey,
-      new Numberu64(
-        await connection.getMinimumBalanceForRentExemption(
-          reverseTwitterRegistryStateBuff.length
-        )
+export class NameServiceTwitter {
+  twitterVerificationAuthority: PublicKey;
+  twitterRootParentRegistryKey: PublicKey;
+
+  constructor(
+    twitterVerificationAuthority: PublicKey = TWITTER_VERIFICATION_AUTHORITY,
+    twitterRootParentRegistryKey: PublicKey = TWITTER_ROOT_PARENT_REGISTRY_KEY
+  ) {
+    this.twitterVerificationAuthority = twitterVerificationAuthority;
+    this.twitterRootParentRegistryKey = twitterRootParentRegistryKey;
+  }
+
+
+  ////////////////////////////////////////////////////
+  // Bindings
+
+  // Signed by the authority, the payer and the verified pubkey
+  async createVerifiedTwitterRegistry(
+    connection: Connection,
+    twitterHandle: string,
+    verifiedPubkey: PublicKey,
+    space: number, // The space that the user will have to write data into the verified registry
+    payerKey: PublicKey
+  ): Promise<TransactionInstruction[]> {
+    // Create user facing registry
+    const hashedTwitterHandle = await getHashedName(twitterHandle);
+    const twitterHandleRegistryKey = await getNameAccountKey(
+      hashedTwitterHandle,
+      undefined,
+      this.twitterRootParentRegistryKey
+    );
+
+    let instructions = [
+      createInstruction(
+        NAME_PROGRAM_ID,
+        SystemProgram.programId,
+        twitterHandleRegistryKey,
+        verifiedPubkey,
+        payerKey,
+        hashedTwitterHandle,
+        new Numberu64(await connection.getMinimumBalanceForRentExemption(space)),
+        new Numberu32(space),
+        undefined,
+        this.twitterRootParentRegistryKey,
+        this.twitterVerificationAuthority // Twitter authority acts as owner of the parent for all user-facing registries
       ),
-      new Numberu32(reverseTwitterRegistryStateBuff.length),
-      TWITTER_VERIFICATION_AUTHORITY, // Twitter authority acts as class for all reverse-lookup registries
-      TWITTER_ROOT_PARENT_REGISTRY_KEY, // Reverse registries are also children of the root
-      TWITTER_VERIFICATION_AUTHORITY
-    ),
-    updateInstruction(
+    ];
+
+    instructions = instructions.concat(
+      await this.createReverseTwitterRegistry(
+        connection,
+        twitterHandle,
+        twitterHandleRegistryKey,
+        verifiedPubkey,
+        payerKey
+      )
+    );
+
+    return instructions;
+  }
+
+  // Overwrite the data that is written in the user facing registry
+  // Signed by the verified pubkey
+  async changeTwitterRegistryData(
+    twitterHandle: string,
+    verifiedPubkey: PublicKey,
+    offset: number, // The offset at which to write the input data into the NameRegistryData
+    input_data: Buffer
+  ): Promise<TransactionInstruction[]> {
+    const hashedTwitterHandle = await getHashedName(twitterHandle);
+    const twitterHandleRegistryKey = await getNameAccountKey(
+      hashedTwitterHandle,
+      undefined,
+      this.twitterRootParentRegistryKey
+    );
+
+    const instructions = [
+      updateInstruction(
+        NAME_PROGRAM_ID,
+        twitterHandleRegistryKey,
+        new Numberu32(offset),
+        input_data,
+        verifiedPubkey
+      ),
+    ];
+
+    return instructions;
+  }
+
+  // Change the verified pubkey for a given twitter handle
+  // Signed by the Authority, the verified pubkey and the payer
+  async changeVerifiedPubkey(
+    connection: Connection,
+    twitterHandle: string,
+    currentVerifiedPubkey: PublicKey,
+    newVerifiedPubkey: PublicKey,
+    payerKey: PublicKey
+  ): Promise<TransactionInstruction[]> {
+    const hashedTwitterHandle = await getHashedName(twitterHandle);
+    const twitterHandleRegistryKey = await getNameAccountKey(
+      hashedTwitterHandle,
+      undefined,
+      this.twitterRootParentRegistryKey
+    );
+
+    // Transfer the user-facing registry ownership
+    let instructions = [
+      transferInstruction(
+        NAME_PROGRAM_ID,
+        twitterHandleRegistryKey,
+        newVerifiedPubkey,
+        currentVerifiedPubkey,
+        undefined
+      ),
+    ];
+
+    // Delete the current reverse registry
+    const currentHashedVerifiedPubkey = await getHashedName(
+      currentVerifiedPubkey.toString()
+    );
+    const currentReverseRegistryKey = await getNameAccountKey(
+      currentHashedVerifiedPubkey,
+      this.twitterVerificationAuthority,
+      undefined
+    );
+    instructions.push(
+      await deleteNameRegistry(
+        connection,
+        currentVerifiedPubkey.toString(),
+        payerKey,
+        this.twitterVerificationAuthority,
+        this.twitterRootParentRegistryKey
+      )
+    );
+
+    // Create the new reverse registry
+    instructions = instructions.concat(
+      await this.createReverseTwitterRegistry(
+        connection,
+        twitterHandle,
+        twitterHandleRegistryKey,
+        newVerifiedPubkey,
+        payerKey
+      )
+    );
+
+    return instructions;
+  }
+
+  // Delete the verified registry for a given twitter handle
+  // Signed by the verified pubkey
+  async deleteTwitterRegistry(
+    twitterHandle: string,
+    verifiedPubkey: PublicKey
+  ): Promise<TransactionInstruction[]> {
+    const hashedTwitterHandle = await getHashedName(twitterHandle);
+    const twitterHandleRegistryKey = await getNameAccountKey(
+      hashedTwitterHandle,
+      undefined,
+      this.twitterRootParentRegistryKey
+    );
+
+    const hashedVerifiedPubkey = await getHashedName(verifiedPubkey.toString());
+    const reverseRegistryKey = await getNameAccountKey(
+      hashedVerifiedPubkey,
+      this.twitterVerificationAuthority,
+      this.twitterRootParentRegistryKey
+    );
+
+    const instructions = [
+      // Delete the user facing registry
+      deleteInstruction(
+        NAME_PROGRAM_ID,
+        twitterHandleRegistryKey,
+        verifiedPubkey,
+        verifiedPubkey
+      ),
+      // Delete the reverse registry
+      deleteInstruction(
+        NAME_PROGRAM_ID,
+        reverseRegistryKey,
+        verifiedPubkey,
+        verifiedPubkey
+      ),
+    ];
+
+    return instructions;
+  }
+
+  //////////////////////////////////////////
+  // Getter Functions
+
+  // Returns the key of the user-facing registry
+  async getTwitterRegistryKey(
+    twitter_handle: string
+  ): Promise<PublicKey> {
+    const hashedTwitterHandle = await getHashedName(twitter_handle);
+    return await getNameAccountKey(
+      hashedTwitterHandle,
+      undefined,
+      this.twitterRootParentRegistryKey
+    );
+  }
+
+  async getTwitterRegistry(
+    connection: Connection,
+    twitter_handle: string
+  ): Promise<NameRegistryState> {
+    const hashedTwitterHandle = await getHashedName(twitter_handle);
+    const twitterHandleRegistryKey = await getNameAccountKey(
+      hashedTwitterHandle,
+      undefined,
+      this.twitterRootParentRegistryKey
+    );
+    const registry = NameRegistryState.retrieve(
+      connection,
+      twitterHandleRegistryKey
+    );
+    return registry;
+  }
+
+  async getHandleAndRegistryKey(
+    connection: Connection,
+    verifiedPubkey: PublicKey
+  ): Promise<[string, PublicKey]> {
+    const hashedVerifiedPubkey = await getHashedName(verifiedPubkey.toString());
+    const reverseRegistryKey = await getNameAccountKey(
+      hashedVerifiedPubkey,
+      this.twitterVerificationAuthority,
+      this.twitterRootParentRegistryKey
+    );
+
+    let reverseRegistryState = await ReverseTwitterRegistryState.retrieve(
+      connection,
+      reverseRegistryKey
+    );
+    return [
+      reverseRegistryState.twitterHandle,
+      new PublicKey(reverseRegistryState.twitterRegistryKey),
+    ];
+  }
+
+  // Uses the RPC node filtering feature, execution speed may vary
+  async getTwitterHandleandRegistryKeyViaFilters(
+    connection: Connection,
+    verifiedPubkey: PublicKey
+  ): Promise<[string, PublicKey]> {
+    const filters = [
+      {
+        memcmp: {
+          offset: 0,
+          bytes: this.twitterRootParentRegistryKey.toBase58(),
+        },
+      },
+      {
+        memcmp: {
+          offset: 32,
+          bytes: verifiedPubkey.toBase58(),
+        },
+      },
+      {
+        memcmp: {
+          offset: 64,
+          bytes: this.twitterVerificationAuthority.toBase58(),
+        },
+      },
+    ];
+
+    const filteredAccounts = await getFilteredProgramAccounts(
+      connection,
       NAME_PROGRAM_ID,
-      reverseRegistryKey,
-      new Numberu32(0),
-      Buffer.from(reverseTwitterRegistryStateBuff),
-      TWITTER_VERIFICATION_AUTHORITY
-    ),
-  ];
+      filters
+    );
+
+    for (const f of filteredAccounts) {
+      if (f.accountInfo.data.length > NameRegistryState.HEADER_LEN + 32) {
+        let data = f.accountInfo.data.slice(NameRegistryState.HEADER_LEN);
+        let state: ReverseTwitterRegistryState = deserialize(
+          ReverseTwitterRegistryState.schema,
+          ReverseTwitterRegistryState,
+          data
+        );
+        return [state.twitterHandle, new PublicKey(state.twitterRegistryKey)];
+      }
+    }
+    throw new Error('Registry not found.');
+  }
+
+  // Uses the RPC node filtering feature, execution speed may vary
+  // Does not give you the handle, but is an alternative to getHandlesAndKeysFromVerifiedPubkey + getTwitterRegistry to get the data
+  async getTwitterRegistryData(
+    connection: Connection,
+    verifiedPubkey: PublicKey
+  ): Promise<Buffer> {
+    const filters = [
+      {
+        memcmp: {
+          offset: 0,
+          bytes: this.twitterRootParentRegistryKey.toBytes(),
+        },
+      },
+      {
+        memcmp: {
+          offset: 32,
+          bytes: verifiedPubkey.toBytes(),
+        },
+      },
+      {
+        memcmp: {
+          offset: 64,
+          bytes: new PublicKey(Buffer.alloc(32, 0)).toBase58(),
+        },
+      },
+    ];
+
+    const filteredAccounts = await getFilteredProgramAccounts(
+      connection,
+      NAME_PROGRAM_ID,
+      filters
+    );
+
+    if (filteredAccounts.length > 1) {
+      throw new Error('Found more than one registry.');
+    }
+
+    return filteredAccounts[0].accountInfo.data.slice(
+      NameRegistryState.HEADER_LEN
+    );
+  }
+
+  //////////////////////////////////////////////
+  // Utils
+
+  async createReverseTwitterRegistry(
+    connection: Connection,
+    twitterHandle: string,
+    twitterRegistryKey: PublicKey,
+    verifiedPubkey: PublicKey,
+    payerKey: PublicKey
+  ): Promise<TransactionInstruction[]> {
+    // Create the reverse lookup registry
+    const hashedVerifiedPubkey = await getHashedName(verifiedPubkey.toString());
+    const reverseRegistryKey = await getNameAccountKey(
+      hashedVerifiedPubkey,
+      this.twitterVerificationAuthority,
+      this.twitterRootParentRegistryKey
+    );
+    let reverseTwitterRegistryStateBuff = serialize(
+      ReverseTwitterRegistryState.schema,
+      new ReverseTwitterRegistryState({
+        twitterRegistryKey: twitterRegistryKey.toBytes(),
+        twitterHandle,
+      })
+    );
+    return [
+      createInstruction(
+        NAME_PROGRAM_ID,
+        SystemProgram.programId,
+        reverseRegistryKey,
+        verifiedPubkey,
+        payerKey,
+        hashedVerifiedPubkey,
+        new Numberu64(
+          await connection.getMinimumBalanceForRentExemption(
+            reverseTwitterRegistryStateBuff.length
+          )
+        ),
+        new Numberu32(reverseTwitterRegistryStateBuff.length),
+        this.twitterVerificationAuthority, // Twitter authority acts as class for all reverse-lookup registries
+        this.twitterRootParentRegistryKey, // Reverse registries are also children of the root
+        this.twitterVerificationAuthority
+      ),
+      updateInstruction(
+        NAME_PROGRAM_ID,
+        reverseRegistryKey,
+        new Numberu32(0),
+        Buffer.from(reverseTwitterRegistryStateBuff),
+        this.twitterVerificationAuthority
+      ),
+    ];
+  }
 }


### PR DESCRIPTION
The diff here ended up uglier than I expected. All I've done is wrap twitter.ts in a class that takes the constants `TWITTER_ROOT_PARENT_REGISTRY_KEY` and `TWITTER_VERIFICATION_AUTHORITY` in its constructor, defaulting to the pre-configured ones.

This makes it easier to test and experiment with, as you can create different registries that act like the main twitter registry. 

This is part of another PR to update the name service to allow oauth claiming of twitter handles (i.e. you just click login with twitter instead of tweeting). 

I've done a major version bump, as this is going to change the API for any name service consumers.