### PR TITLE
stake-pool: Convert `checked_add` to `saturating_add` to fix downstream build

### DIFF
--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -1396,8 +1396,7 @@ impl Processor {
                 Some(stake_program::StakeState::Stake(meta, stake)) => {
                     let account_stake = meta
                         .rent_exempt_reserve
-                        .checked_add(stake.delegation.stake)
-                        .ok_or(StakePoolError::CalculationFailure)?;
+                        .saturating_add(stake.delegation.stake);
                     if no_merge {
                         transient_stake_lamports = account_stake;
                     } else if stake.delegation.deactivation_epoch < clock.epoch {


### PR DESCRIPTION
#### Problem

The downstream build fails on stake pools with the error: "Program failed to complete: Access violation in stack frame 1 at address 0x200001f50 of size 8 by instruction #13025"

https://buildkite.com/solana-labs/solana/builds/49577#463986f1-6a44-4af0-bf07-ecdf147564c0 for an example build.

#### Solution

Not too sure what's going on with the compiler, but since that instruction had to do with `u64` adds around the update validator balance part, I changed the `checked_add` to `saturating_add`, which seems to keep the memory in-line and avoid the problem during the downstream build.