### PR TITLE
Eliminate doc warnings

### DIFF
--- a/libraries/math/src/approximations.rs
+++ b/libraries/math/src/approximations.rs
@@ -8,10 +8,12 @@ use {
 /// Calculate square root of the given number
 ///
 /// Code lovingly adapted from the excellent work at:
-/// https://github.com/derekdreery/integer-sqrt-rs
+///
+/// <https://github.com/derekdreery/integer-sqrt-rs>
 ///
 /// The algorithm is based on the implementation in:
-/// https://en.wikipedia.org/wiki/Methods_of_computing_square_roots#Binary_numeral_system_(base_2)
+///
+/// <https://en.wikipedia.org/wiki/Methods_of_computing_square_roots#Binary_numeral_system_(base_2)>
 pub fn sqrt<T: PrimInt + CheckedShl + CheckedShr>(radicand: T) -> Option<T> {
     match radicand.cmp(&T::zero()) {
         Ordering::Less => return None,             // fail for less than 0

--- a/stake-pool/program/src/stake_program.rs
+++ b/stake-pool/program/src/stake_program.rs
@@ -32,8 +32,8 @@ pub enum StakeInstruction {
     /// Initialize a stake with lockup and authorization information
     ///
     /// # Account references
-    ///   0. [WRITE] Uninitialized stake account
-    ///   1. [] Rent sysvar
+    ///   0. `[WRITE]` Uninitialized stake account
+    ///   1. `[]` Rent sysvar
     ///
     /// Authorized carries pubkeys that must sign staker transactions
     ///   and withdrawer transactions.
@@ -43,20 +43,20 @@ pub enum StakeInstruction {
     /// Authorize a key to manage stake or withdrawal
     ///
     /// # Account references
-    ///   0. [WRITE] Stake account to be updated
-    ///   1. [] (reserved for future use) Clock sysvar
-    ///   2. [SIGNER] The stake or withdraw authority
+    ///   0. `[WRITE]` Stake account to be updated
+    ///   1. `[]` (reserved for future use) Clock sysvar
+    ///   2. `[SIGNER]` The stake or withdraw authority
     Authorize(Pubkey, StakeAuthorize),
 
     /// Delegate a stake to a particular vote account
     ///
     /// # Account references
-    ///   0. [WRITE] Initialized stake account to be delegated
-    ///   1. [] Vote account to which this stake will be delegated
-    ///   2. [] Clock sysvar
-    ///   3. [] Stake history sysvar that carries stake warmup/cooldown history
-    ///   4. [] Address of config account that carries stake config
-    ///   5. [SIGNER] Stake authority
+    ///   0. `[WRITE]` Initialized stake account to be delegated
+    ///   1. `[]` Vote account to which this stake will be delegated
+    ///   2. `[]` Clock sysvar
+    ///   3. `[]` Stake history sysvar that carries stake warmup/cooldown history
+    ///   4. `[]` Address of config account that carries stake config
+    ///   5. `[SIGNER]` Stake authority
     ///
     /// The entire balance of the staking account is staked.  DelegateStake
     ///   can be called multiple times, but re-delegation is delayed
@@ -66,20 +66,20 @@ pub enum StakeInstruction {
     /// Split u64 tokens and stake off a stake account into another stake account.
     ///
     /// # Account references
-    ///   0. [WRITE] Stake account to be split; must be in the Initialized or Stake state
-    ///   1. [WRITE] Uninitialized stake account that will take the split-off amount
-    ///   2. [SIGNER] Stake authority
+    ///   0. `[WRITE]` Stake account to be split; must be in the Initialized or Stake state
+    ///   1. `[WRITE]` Uninitialized stake account that will take the split-off amount
+    ///   2. `[SIGNER]` Stake authority
     Split(u64),
 
     /// Withdraw unstaked lamports from the stake account
     ///
     /// # Account references
-    ///   0. [WRITE] Stake account from which to withdraw
-    ///   1. [WRITE] Recipient account
-    ///   2. [] Clock sysvar
-    ///   3. [] Stake history sysvar that carries stake warmup/cooldown history
-    ///   4. [SIGNER] Withdraw authority
-    ///   5. Optional: [SIGNER] Lockup authority, if before lockup expiration
+    ///   0. `[WRITE]` Stake account from which to withdraw
+    ///   1. `[WRITE]` Recipient account
+    ///   2. `[]` Clock sysvar
+    ///   3. `[]` Stake history sysvar that carries stake warmup/cooldown history
+    ///   4. `[SIGNER]` Withdraw authority
+    ///   5. Optional: `[SIGNER]` Lockup authority, if before lockup expiration
     ///
     /// The u64 is the portion of the stake account balance to be withdrawn,
     ///    must be `<= ValidatorStakeAccount.lamports - staked_lamports`.
@@ -88,34 +88,34 @@ pub enum StakeInstruction {
     /// Deactivates the stake in the account
     ///
     /// # Account references
-    ///   0. [WRITE] Delegated stake account
-    ///   1. [] Clock sysvar
-    ///   2. [SIGNER] Stake authority
+    ///   0. `[WRITE]` Delegated stake account
+    ///   1. `[]` Clock sysvar
+    ///   2. `[SIGNER]` Stake authority
     Deactivate,
 
     /// Set stake lockup
     ///
     /// # Account references
-    ///   0. [WRITE] Initialized stake account
-    ///   1. [SIGNER] Lockup authority
+    ///   0. `[WRITE]` Initialized stake account
+    ///   1. `[SIGNER]` Lockup authority
     SetLockup,
 
     /// Merge two stake accounts. Both accounts must be deactivated and have identical lockup and
     /// authority keys.
     ///
     /// # Account references
-    ///   0. [WRITE] Destination stake account for the merge
-    ///   1. [WRITE] Source stake account for to merge.  This account will be drained
-    ///   2. [] Clock sysvar
-    ///   3. [] Stake history sysvar that carries stake warmup/cooldown history
-    ///   4. [SIGNER] Stake authority
+    ///   0. `[WRITE]` Destination stake account for the merge
+    ///   1. `[WRITE]` Source stake account for to merge.  This account will be drained
+    ///   2. `[]` Clock sysvar
+    ///   3. `[]` Stake history sysvar that carries stake warmup/cooldown history
+    ///   4. `[SIGNER]` Stake authority
     Merge,
 
     /// Authorize a key to manage stake or withdrawal with a derived key
     ///
     /// # Account references
-    ///   0. [WRITE] Stake account to be updated
-    ///   1. [SIGNER] Base key of stake or withdraw authority
+    ///   0. `[WRITE]` Stake account to be updated
+    ///   1. `[SIGNER]` Base key of stake or withdraw authority
     AuthorizeWithSeed,
 }
 

--- a/token-swap/program/src/curve/calculator.rs
+++ b/token-swap/program/src/curve/calculator.rs
@@ -119,7 +119,8 @@ pub trait CurveCalculator: Debug + DynPack {
     /// change the spot price of the pool.
     ///
     /// See more background for the calculation at:
-    /// https://balancer.finance/whitepaper/#single-asset-deposit-withdrawal
+    ///
+    /// <https://balancer.finance/whitepaper/#single-asset-deposit-withdrawal>
     fn deposit_single_token_type(
         &self,
         source_amount: u128,
@@ -137,7 +138,8 @@ pub trait CurveCalculator: Debug + DynPack {
     /// of the pool.
     ///
     /// See more background for the calculation at:
-    /// https://balancer.finance/whitepaper/#single-asset-deposit-withdrawal
+    ///
+    /// <https://balancer.finance/whitepaper/#single-asset-deposit-withdrawal>
     fn withdraw_single_token_type_exact_out(
         &self,
         source_amount: u128,

--- a/token-swap/program/src/curve/constant_price.rs
+++ b/token-swap/program/src/curve/constant_price.rs
@@ -18,7 +18,7 @@ use {
 /// Get the amount of pool tokens for the given amount of token A or B.
 ///
 /// The constant product implementation uses the Balancer formulas found at
-/// https://balancer.finance/whitepaper/#single-asset-deposit, specifically
+/// <https://balancer.finance/whitepaper/#single-asset-deposit>, specifically
 /// in the case for 2 tokens, each weighted at 1/2.
 pub fn trading_tokens_to_pool_tokens(
     token_b_price: u64,

--- a/token-swap/program/src/curve/constant_product.rs
+++ b/token-swap/program/src/curve/constant_product.rs
@@ -95,7 +95,7 @@ pub fn pool_tokens_to_trading_tokens(
 /// Get the amount of pool tokens for the deposited amount of token A or B.
 ///
 /// The constant product implementation uses the Balancer formulas found at
-/// https://balancer.finance/whitepaper/#single-asset-deposit, specifically
+/// <https://balancer.finance/whitepaper/#single-asset-deposit>, specifically
 /// in the case for 2 tokens, each weighted at 1/2.
 pub fn deposit_single_token_type(
     source_amount: u128,
@@ -126,7 +126,7 @@ pub fn deposit_single_token_type(
 /// Get the amount of pool tokens for the withdrawn amount of token A or B.
 ///
 /// The constant product implementation uses the Balancer formulas found at
-/// https://balancer.finance/whitepaper/#single-asset-withdrawal, specifically
+/// <https://balancer.finance/whitepaper/#single-asset-withdrawal>, specifically
 /// in the case for 2 tokens, each weighted at 1/2.
 pub fn withdraw_single_token_type_exact_out(
     source_amount: u128,

--- a/token-swap/program/src/curve/stable.rs
+++ b/token-swap/program/src/curve/stable.rs
@@ -158,7 +158,9 @@ impl CurveCalculator for StableCurve {
         })
     }
 
-    /// Re-implementation of `remove_liquidty`: https://github.com/curvefi/curve-contract/blob/80bbe179083c9a7062e4c482b0be3bfb7501f2bd/contracts/pool-templates/base/SwapTemplateBase.vy#L513
+    /// Re-implementation of `remove_liquidty`:
+    ///
+    /// <https://github.com/curvefi/curve-contract/blob/80bbe179083c9a7062e4c482b0be3bfb7501f2bd/contracts/pool-templates/base/SwapTemplateBase.vy#L513>
     fn pool_tokens_to_trading_tokens(
         &self,
         pool_tokens: u128,
@@ -199,7 +201,9 @@ impl CurveCalculator for StableCurve {
     }
 
     /// Get the amount of pool tokens for the given amount of token A or B.
-    /// Re-implementation of `calc_token_amount`: https://github.com/curvefi/curve-contract/blob/80bbe179083c9a7062e4c482b0be3bfb7501f2bd/contracts/pool-templates/base/SwapTemplateBase.vy#L267
+    /// Re-implementation of `calc_token_amount`:
+    ///
+    /// <https://github.com/curvefi/curve-contract/blob/80bbe179083c9a7062e4c482b0be3bfb7501f2bd/contracts/pool-templates/base/SwapTemplateBase.vy#L267>
     fn deposit_single_token_type(
         &self,
         source_amount: u128,


### PR DESCRIPTION
This patch series allows `cargo doc` to run without emitting any warnings. It changes bare URLs to "autolinks", surrounded by angle brackets, and it changes some "account references" lists to put their bracketed requirements (sign/write) in code spans (as with other such lists in this repo) so they won't be interpreted as markdown links.