### PR TITLE
Governance: Move realm and goverend_account from config to direct field

### DIFF
--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -276,10 +276,6 @@ pub enum GovernanceError {
     #[error("Governance PDA must sign")]
     GovernancePdaMustSign,
 
-    /// Invalid config realm for Governance
-    #[error("Invalid config realm for Governance")]
-    InvalidConfigRealmForGovernance,
-
     /// Invalid config governed account for Governance
     #[error("Invalid config governed account for Governance")]
     InvalidConfigGovernedAccountForGovernance,

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -275,10 +275,6 @@ pub enum GovernanceError {
     /// Governance PDA must sign
     #[error("Governance PDA must sign")]
     GovernancePdaMustSign,
-
-    /// Invalid config governed account for Governance
-    #[error("Invalid config governed account for Governance")]
-    InvalidConfigGovernedAccountForGovernance,
 }
 
 impl PrintProgramError for GovernanceError {

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -102,7 +102,7 @@ pub enum GovernanceInstruction {
     ///
     ///   0. `[]` Realm account the created Governance belongs to
     ///   1. `[writable]` Account Governance account. PDA seeds: ['account-governance', realm, governed_account]
-    ///   2. `[]` Account governed by this Governance
+    ///   2. `[]` Account governed by this Governance account
     ///   3. `[signer]` Payer
     ///   4. `[]` System program
     ///   5. `[]` Sysvar Rent

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -508,15 +508,16 @@ pub fn set_governance_delegate(
 pub fn create_account_governance(
     program_id: &Pubkey,
     // Accounts
+    realm: &Pubkey,
     payer: &Pubkey,
     // Args
     config: GovernanceConfig,
 ) -> Instruction {
     let account_governance_address =
-        get_account_governance_address(program_id, &config.realm, &config.governed_account);
+        get_account_governance_address(program_id, realm, &config.governed_account);
 
     let accounts = vec![
-        AccountMeta::new_readonly(config.realm, false),
+        AccountMeta::new_readonly(*realm, false),
         AccountMeta::new(account_governance_address, false),
         AccountMeta::new_readonly(*payer, true),
         AccountMeta::new_readonly(system_program::id(), false),
@@ -536,6 +537,7 @@ pub fn create_account_governance(
 pub fn create_program_governance(
     program_id: &Pubkey,
     // Accounts
+    realm: &Pubkey,
     governed_program_upgrade_authority: &Pubkey,
     payer: &Pubkey,
     // Args
@@ -543,11 +545,11 @@ pub fn create_program_governance(
     transfer_upgrade_authority: bool,
 ) -> Instruction {
     let program_governance_address =
-        get_program_governance_address(program_id, &config.realm, &config.governed_account);
+        get_program_governance_address(program_id, realm, &config.governed_account);
     let governed_program_data_address = get_program_data_address(&config.governed_account);
 
     let accounts = vec![
-        AccountMeta::new_readonly(config.realm, false),
+        AccountMeta::new_readonly(*realm, false),
         AccountMeta::new(program_governance_address, false),
         AccountMeta::new(governed_program_data_address, false),
         AccountMeta::new_readonly(*governed_program_upgrade_authority, true),
@@ -573,6 +575,7 @@ pub fn create_program_governance(
 pub fn create_mint_governance(
     program_id: &Pubkey,
     // Accounts
+    realm: &Pubkey,
     governed_mint_authority: &Pubkey,
     payer: &Pubkey,
     // Args
@@ -580,10 +583,10 @@ pub fn create_mint_governance(
     transfer_mint_authority: bool,
 ) -> Instruction {
     let mint_governance_address =
-        get_mint_governance_address(program_id, &config.realm, &config.governed_account);
+        get_mint_governance_address(program_id, realm, &config.governed_account);
 
     let accounts = vec![
-        AccountMeta::new_readonly(config.realm, false),
+        AccountMeta::new_readonly(*realm, false),
         AccountMeta::new(mint_governance_address, false),
         AccountMeta::new(config.governed_account, false),
         AccountMeta::new_readonly(*governed_mint_authority, true),
@@ -609,6 +612,7 @@ pub fn create_mint_governance(
 pub fn create_token_governance(
     program_id: &Pubkey,
     // Accounts
+    realm: &Pubkey,
     governed_token_owner: &Pubkey,
     payer: &Pubkey,
     // Args
@@ -616,10 +620,10 @@ pub fn create_token_governance(
     transfer_token_owner: bool,
 ) -> Instruction {
     let token_governance_address =
-        get_token_governance_address(program_id, &config.realm, &config.governed_account);
+        get_token_governance_address(program_id, realm, &config.governed_account);
 
     let accounts = vec![
-        AccountMeta::new_readonly(config.realm, false),
+        AccountMeta::new_readonly(*realm, false),
         AccountMeta::new(token_governance_address, false),
         AccountMeta::new(config.governed_account, false),
         AccountMeta::new_readonly(*governed_token_owner, true),
@@ -1006,16 +1010,15 @@ pub fn execute_instruction(
 /// Creates SetGovernanceConfig instruction
 pub fn set_governance_config(
     program_id: &Pubkey,
+    // Accounts
+    realm: &Pubkey,
     // Args
     config: GovernanceConfig,
 ) -> Instruction {
     let account_governance_address =
-        get_account_governance_address(program_id, &config.realm, &config.governed_account);
+        get_account_governance_address(program_id, realm, &config.governed_account);
 
-    let accounts = vec![
-        AccountMeta::new_readonly(config.realm, false),
-        AccountMeta::new(account_governance_address, true),
-    ];
+    let accounts = vec![AccountMeta::new(account_governance_address, true)];
 
     let instruction = GovernanceInstruction::SetGovernanceConfig { config };
 

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -66,7 +66,7 @@ pub fn process_cast_vote(
     let mut token_owner_record_data = get_token_owner_record_data_for_realm_and_governing_mint(
         program_id,
         token_owner_record_info,
-        &governance_data.config.realm,
+        &governance_data.realm,
         governing_token_mint_info.key,
     )?;
     token_owner_record_data.assert_token_owner_or_delegate_is_signer(governance_authority_info)?;

--- a/governance/program/src/processor/process_create_account_governance.rs
+++ b/governance/program/src/processor/process_create_account_governance.rs
@@ -27,11 +27,12 @@ pub fn process_create_account_governance(
     let account_info_iter = &mut accounts.iter();
 
     let realm_info = next_account_info(account_info_iter)?; // 0
-    let account_governance_info = next_account_info(account_info_iter)?; // 0
-    let payer_info = next_account_info(account_info_iter)?; // 1
-    let system_info = next_account_info(account_info_iter)?; // 2
+    let account_governance_info = next_account_info(account_info_iter)?; // 1
+    let governed_account_info = next_account_info(account_info_iter)?; // 2
+    let payer_info = next_account_info(account_info_iter)?; // 3
+    let system_info = next_account_info(account_info_iter)?; // 4
 
-    let rent_sysvar_info = next_account_info(account_info_iter)?; // 3
+    let rent_sysvar_info = next_account_info(account_info_iter)?; // 5
     let rent = &Rent::from_account_info(rent_sysvar_info)?;
 
     assert_valid_create_governance_args(program_id, &config, realm_info)?;
@@ -39,6 +40,7 @@ pub fn process_create_account_governance(
     let account_governance_data = Governance {
         account_type: GovernanceAccountType::AccountGovernance,
         realm: *realm_info.key,
+        governed_account: *governed_account_info.key,
         config: config.clone(),
         proposals_count: 0,
         reserved: [0; 8],
@@ -48,7 +50,7 @@ pub fn process_create_account_governance(
         payer_info,
         account_governance_info,
         &account_governance_data,
-        &get_account_governance_address_seeds(realm_info.key, &config.governed_account),
+        &get_account_governance_address_seeds(realm_info.key, governed_account_info.key),
         program_id,
         system_info,
         rent,

--- a/governance/program/src/processor/process_create_account_governance.rs
+++ b/governance/program/src/processor/process_create_account_governance.rs
@@ -4,7 +4,7 @@ use crate::{
     state::{
         enums::GovernanceAccountType,
         governance::{
-            assert_is_valid_governance_config, get_account_governance_address_seeds, Governance,
+            assert_valid_create_governance_args, get_account_governance_address_seeds, Governance,
             GovernanceConfig,
         },
     },
@@ -34,10 +34,11 @@ pub fn process_create_account_governance(
     let rent_sysvar_info = next_account_info(account_info_iter)?; // 3
     let rent = &Rent::from_account_info(rent_sysvar_info)?;
 
-    assert_is_valid_governance_config(program_id, &config, realm_info)?;
+    assert_valid_create_governance_args(program_id, &config, realm_info)?;
 
     let account_governance_data = Governance {
         account_type: GovernanceAccountType::AccountGovernance,
+        realm: *realm_info.key,
         config: config.clone(),
         proposals_count: 0,
         reserved: [0; 8],
@@ -47,7 +48,7 @@ pub fn process_create_account_governance(
         payer_info,
         account_governance_info,
         &account_governance_data,
-        &get_account_governance_address_seeds(&config.realm, &config.governed_account),
+        &get_account_governance_address_seeds(realm_info.key, &config.governed_account),
         program_id,
         system_info,
         rent,

--- a/governance/program/src/processor/process_create_account_governance.rs
+++ b/governance/program/src/processor/process_create_account_governance.rs
@@ -41,7 +41,7 @@ pub fn process_create_account_governance(
         account_type: GovernanceAccountType::AccountGovernance,
         realm: *realm_info.key,
         governed_account: *governed_account_info.key,
-        config: config.clone(),
+        config,
         proposals_count: 0,
         reserved: [0; 8],
     };

--- a/governance/program/src/processor/process_create_mint_governance.rs
+++ b/governance/program/src/processor/process_create_mint_governance.rs
@@ -50,7 +50,7 @@ pub fn process_create_mint_governance(
         account_type: GovernanceAccountType::MintGovernance,
         realm: *realm_info.key,
         governed_account: *governed_mint_info.key,
-        config: config.clone(),
+        config,
         proposals_count: 0,
         reserved: [0; 8],
     };

--- a/governance/program/src/processor/process_create_mint_governance.rs
+++ b/governance/program/src/processor/process_create_mint_governance.rs
@@ -4,7 +4,7 @@ use crate::{
     state::{
         enums::GovernanceAccountType,
         governance::{
-            assert_is_valid_governance_config, get_mint_governance_address_seeds, Governance,
+            assert_valid_create_governance_args, get_mint_governance_address_seeds, Governance,
             GovernanceConfig,
         },
     },
@@ -44,10 +44,11 @@ pub fn process_create_mint_governance(
     let rent_sysvar_info = next_account_info(account_info_iter)?; // 7
     let rent = &Rent::from_account_info(rent_sysvar_info)?;
 
-    assert_is_valid_governance_config(program_id, &config, realm_info)?;
+    assert_valid_create_governance_args(program_id, &config, realm_info)?;
 
     let mint_governance_data = Governance {
         account_type: GovernanceAccountType::MintGovernance,
+        realm: *realm_info.key,
         config: config.clone(),
         proposals_count: 0,
         reserved: [0; 8],
@@ -57,7 +58,7 @@ pub fn process_create_mint_governance(
         payer_info,
         mint_governance_info,
         &mint_governance_data,
-        &get_mint_governance_address_seeds(&config.realm, &config.governed_account),
+        &get_mint_governance_address_seeds(realm_info.key, &config.governed_account),
         program_id,
         system_info,
         rent,

--- a/governance/program/src/processor/process_create_mint_governance.rs
+++ b/governance/program/src/processor/process_create_mint_governance.rs
@@ -49,6 +49,7 @@ pub fn process_create_mint_governance(
     let mint_governance_data = Governance {
         account_type: GovernanceAccountType::MintGovernance,
         realm: *realm_info.key,
+        governed_account: *governed_mint_info.key,
         config: config.clone(),
         proposals_count: 0,
         reserved: [0; 8],
@@ -58,7 +59,7 @@ pub fn process_create_mint_governance(
         payer_info,
         mint_governance_info,
         &mint_governance_data,
-        &get_mint_governance_address_seeds(realm_info.key, &config.governed_account),
+        &get_mint_governance_address_seeds(realm_info.key, governed_mint_info.key),
         program_id,
         system_info,
         rent,

--- a/governance/program/src/processor/process_create_program_governance.rs
+++ b/governance/program/src/processor/process_create_program_governance.rs
@@ -5,7 +5,7 @@ use crate::{
     state::{
         enums::GovernanceAccountType,
         governance::{
-            assert_is_valid_governance_config, get_program_governance_address_seeds,
+            assert_valid_create_governance_args, get_program_governance_address_seeds,
             GovernanceConfig,
         },
     },
@@ -47,10 +47,11 @@ pub fn process_create_program_governance(
     let rent_sysvar_info = next_account_info(account_info_iter)?; // 6
     let rent = &Rent::from_account_info(rent_sysvar_info)?;
 
-    assert_is_valid_governance_config(program_id, &config, realm_info)?;
+    assert_valid_create_governance_args(program_id, &config, realm_info)?;
 
     let program_governance_data = Governance {
         account_type: GovernanceAccountType::ProgramGovernance,
+        realm: *realm_info.key,
         config: config.clone(),
         proposals_count: 0,
         reserved: [0; 8],
@@ -60,7 +61,7 @@ pub fn process_create_program_governance(
         payer_info,
         program_governance_info,
         &program_governance_data,
-        &get_program_governance_address_seeds(&config.realm, &config.governed_account),
+        &get_program_governance_address_seeds(realm_info.key, &config.governed_account),
         program_id,
         system_info,
         rent,

--- a/governance/program/src/processor/process_create_program_governance.rs
+++ b/governance/program/src/processor/process_create_program_governance.rs
@@ -54,7 +54,7 @@ pub fn process_create_program_governance(
         account_type: GovernanceAccountType::ProgramGovernance,
         realm: *realm_info.key,
         governed_account: *governed_program_info.key,
-        config: config.clone(),
+        config,
         proposals_count: 0,
         reserved: [0; 8],
     };

--- a/governance/program/src/processor/process_create_program_governance.rs
+++ b/governance/program/src/processor/process_create_program_governance.rs
@@ -36,15 +36,16 @@ pub fn process_create_program_governance(
     let realm_info = next_account_info(account_info_iter)?; // 0
     let program_governance_info = next_account_info(account_info_iter)?; // 0
 
-    let governed_program_data_info = next_account_info(account_info_iter)?; // 1
-    let governed_program_upgrade_authority_info = next_account_info(account_info_iter)?; // 2
+    let governed_program_info = next_account_info(account_info_iter)?; // 1
+    let governed_program_data_info = next_account_info(account_info_iter)?; // 2
+    let governed_program_upgrade_authority_info = next_account_info(account_info_iter)?; // 3
 
-    let payer_info = next_account_info(account_info_iter)?; // 3
-    let bpf_upgrade_loader_info = next_account_info(account_info_iter)?; // 4
+    let payer_info = next_account_info(account_info_iter)?; // 4
+    let bpf_upgrade_loader_info = next_account_info(account_info_iter)?; // 5
 
-    let system_info = next_account_info(account_info_iter)?; // 5
+    let system_info = next_account_info(account_info_iter)?; // 6
 
-    let rent_sysvar_info = next_account_info(account_info_iter)?; // 6
+    let rent_sysvar_info = next_account_info(account_info_iter)?; // 7
     let rent = &Rent::from_account_info(rent_sysvar_info)?;
 
     assert_valid_create_governance_args(program_id, &config, realm_info)?;
@@ -52,6 +53,7 @@ pub fn process_create_program_governance(
     let program_governance_data = Governance {
         account_type: GovernanceAccountType::ProgramGovernance,
         realm: *realm_info.key,
+        governed_account: *governed_program_info.key,
         config: config.clone(),
         proposals_count: 0,
         reserved: [0; 8],
@@ -61,7 +63,7 @@ pub fn process_create_program_governance(
         payer_info,
         program_governance_info,
         &program_governance_data,
-        &get_program_governance_address_seeds(realm_info.key, &config.governed_account),
+        &get_program_governance_address_seeds(realm_info.key, governed_program_info.key),
         program_id,
         system_info,
         rent,
@@ -69,7 +71,7 @@ pub fn process_create_program_governance(
 
     if transfer_upgrade_authority {
         set_program_upgrade_authority(
-            &config.governed_account,
+            governed_program_info.key,
             governed_program_data_info,
             governed_program_upgrade_authority_info,
             program_governance_info,
@@ -77,7 +79,7 @@ pub fn process_create_program_governance(
         )?;
     } else {
         assert_program_upgrade_authority_is_signer(
-            &config.governed_account,
+            governed_program_info.key,
             governed_program_data_info,
             governed_program_upgrade_authority_info,
         )?;

--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -55,7 +55,7 @@ pub fn process_create_proposal(
     let token_owner_record_data = get_token_owner_record_data_for_realm_and_governing_mint(
         program_id,
         token_owner_record_info,
-        &governance_data.config.realm,
+        &governance_data.realm,
         &governing_token_mint,
     )?;
 

--- a/governance/program/src/processor/process_create_token_governance.rs
+++ b/governance/program/src/processor/process_create_token_governance.rs
@@ -4,7 +4,7 @@ use crate::{
     state::{
         enums::GovernanceAccountType,
         governance::{
-            assert_is_valid_governance_config, get_token_governance_address_seeds, Governance,
+            assert_valid_create_governance_args, get_token_governance_address_seeds, Governance,
             GovernanceConfig,
         },
     },
@@ -44,10 +44,11 @@ pub fn process_create_token_governance(
     let rent_sysvar_info = next_account_info(account_info_iter)?; // 7
     let rent = &Rent::from_account_info(rent_sysvar_info)?;
 
-    assert_is_valid_governance_config(program_id, &config, realm_info)?;
+    assert_valid_create_governance_args(program_id, &config, realm_info)?;
 
     let token_governance_data = Governance {
         account_type: GovernanceAccountType::TokenGovernance,
+        realm: *realm_info.key,
         config: config.clone(),
         proposals_count: 0,
         reserved: [0; 8],
@@ -57,7 +58,7 @@ pub fn process_create_token_governance(
         payer_info,
         token_governance_info,
         &token_governance_data,
-        &get_token_governance_address_seeds(&config.realm, &config.governed_account),
+        &get_token_governance_address_seeds(realm_info.key, &config.governed_account),
         program_id,
         system_info,
         rent,

--- a/governance/program/src/processor/process_create_token_governance.rs
+++ b/governance/program/src/processor/process_create_token_governance.rs
@@ -49,6 +49,7 @@ pub fn process_create_token_governance(
     let token_governance_data = Governance {
         account_type: GovernanceAccountType::TokenGovernance,
         realm: *realm_info.key,
+        governed_account: *governed_token_info.key,
         config: config.clone(),
         proposals_count: 0,
         reserved: [0; 8],
@@ -58,7 +59,7 @@ pub fn process_create_token_governance(
         payer_info,
         token_governance_info,
         &token_governance_data,
-        &get_token_governance_address_seeds(realm_info.key, &config.governed_account),
+        &get_token_governance_address_seeds(realm_info.key, governed_token_info.key),
         program_id,
         system_info,
         rent,

--- a/governance/program/src/processor/process_create_token_governance.rs
+++ b/governance/program/src/processor/process_create_token_governance.rs
@@ -50,7 +50,7 @@ pub fn process_create_token_governance(
         account_type: GovernanceAccountType::TokenGovernance,
         realm: *realm_info.key,
         governed_account: *governed_token_info.key,
-        config: config.clone(),
+        config,
         proposals_count: 0,
         reserved: [0; 8],
     };

--- a/governance/program/src/processor/process_relinquish_vote.rs
+++ b/governance/program/src/processor/process_relinquish_vote.rs
@@ -42,7 +42,7 @@ pub fn process_relinquish_vote(program_id: &Pubkey, accounts: &[AccountInfo]) ->
     let mut token_owner_record_data = get_token_owner_record_data_for_realm_and_governing_mint(
         program_id,
         token_owner_record_info,
-        &governance_data.config.realm,
+        &governance_data.realm,
         governing_token_mint_info.key,
     )?;
 

--- a/governance/program/src/processor/process_set_governance_config.rs
+++ b/governance/program/src/processor/process_set_governance_config.rs
@@ -22,15 +22,14 @@ pub fn process_set_governance_config(
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
 
-    let realm_info = next_account_info(account_info_iter)?; // 0
-    let governance_info = next_account_info(account_info_iter)?; // 1
+    let governance_info = next_account_info(account_info_iter)?; // 0
 
     // Only governance PDA via a proposal can authorize change to its own config
     if !governance_info.is_signer {
         return Err(GovernanceError::GovernancePdaMustSign.into());
     }
 
-    assert_is_valid_governance_config(program_id, &config, realm_info)?;
+    assert_is_valid_governance_config(&config)?;
 
     let mut governance_data = get_governance_data_for_config(program_id, governance_info, &config)?;
     governance_data.config = config;

--- a/governance/program/src/processor/process_set_governance_config.rs
+++ b/governance/program/src/processor/process_set_governance_config.rs
@@ -9,9 +9,7 @@ use solana_program::{
 
 use crate::{
     error::GovernanceError,
-    state::governance::{
-        assert_is_valid_governance_config, get_governance_data_for_config, GovernanceConfig,
-    },
+    state::governance::{assert_is_valid_governance_config, get_governance_data, GovernanceConfig},
 };
 
 /// Processes SetGovernanceConfig instruction
@@ -31,7 +29,7 @@ pub fn process_set_governance_config(
 
     assert_is_valid_governance_config(&config)?;
 
-    let mut governance_data = get_governance_data_for_config(program_id, governance_info, &config)?;
+    let mut governance_data = get_governance_data(program_id, governance_info)?;
     governance_data.config = config;
 
     governance_data.serialize(&mut *governance_info.data.borrow_mut())?;

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -464,7 +464,6 @@ mod test {
 
     fn create_test_governance_config() -> GovernanceConfig {
         GovernanceConfig {
-            governed_account: Pubkey::new_unique(),
             min_tokens_to_create_proposal: 5,
             min_instruction_hold_up_time: 10,
             max_voting_time: 5,

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -464,7 +464,6 @@ mod test {
 
     fn create_test_governance_config() -> GovernanceConfig {
         GovernanceConfig {
-            realm: Pubkey::new_unique(),
             governed_account: Pubkey::new_unique(),
             min_tokens_to_create_proposal: 5,
             min_instruction_hold_up_time: 10,

--- a/governance/program/tests/process_cast_vote.rs
+++ b/governance/program/tests/process_cast_vote.rs
@@ -441,8 +441,7 @@ async fn test_cast_vote_with_threshold_below_50_and_vote_not_tipped() {
     let realm_cookie = governance_test.with_realm().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let mut governance_config =
-        governance_test.get_default_governance_config(&governed_account_cookie);
+    let mut governance_config = governance_test.get_default_governance_config();
 
     governance_config.vote_threshold_percentage = VoteThresholdPercentage::YesVote(40);
 

--- a/governance/program/tests/process_cast_vote.rs
+++ b/governance/program/tests/process_cast_vote.rs
@@ -442,7 +442,7 @@ async fn test_cast_vote_with_threshold_below_50_and_vote_not_tipped() {
     let governed_account_cookie = governance_test.with_governed_account().await;
 
     let mut governance_config =
-        governance_test.get_default_governance_config(&realm_cookie, &governed_account_cookie);
+        governance_test.get_default_governance_config(&governed_account_cookie);
 
     governance_config.vote_threshold_percentage = VoteThresholdPercentage::YesVote(40);
 

--- a/governance/program/tests/process_create_account_governance.rs
+++ b/governance/program/tests/process_create_account_governance.rs
@@ -67,8 +67,7 @@ async fn test_create_account_governance_with_invalid_config_error() {
     let governed_account_cookie = governance_test.with_governed_account().await;
 
     // Arrange
-    let mut config =
-        governance_test.get_default_governance_config(&realm_cookie, &governed_account_cookie);
+    let mut config = governance_test.get_default_governance_config(&governed_account_cookie);
     config.vote_threshold_percentage = VoteThresholdPercentage::YesVote(0); // below 1% threshold
 
     // Act
@@ -83,8 +82,7 @@ async fn test_create_account_governance_with_invalid_config_error() {
     assert_eq!(err, GovernanceError::InvalidVoteThresholdPercentage.into());
 
     // Arrange
-    let mut config =
-        governance_test.get_default_governance_config(&realm_cookie, &governed_account_cookie);
+    let mut config = governance_test.get_default_governance_config(&governed_account_cookie);
     config.vote_threshold_percentage = VoteThresholdPercentage::YesVote(101); // Above 100% threshold
 
     // Act

--- a/governance/program/tests/process_create_account_governance.rs
+++ b/governance/program/tests/process_create_account_governance.rs
@@ -67,7 +67,7 @@ async fn test_create_account_governance_with_invalid_config_error() {
     let governed_account_cookie = governance_test.with_governed_account().await;
 
     // Arrange
-    let mut config = governance_test.get_default_governance_config(&governed_account_cookie);
+    let mut config = governance_test.get_default_governance_config();
     config.vote_threshold_percentage = VoteThresholdPercentage::YesVote(0); // below 1% threshold
 
     // Act
@@ -82,7 +82,7 @@ async fn test_create_account_governance_with_invalid_config_error() {
     assert_eq!(err, GovernanceError::InvalidVoteThresholdPercentage.into());
 
     // Arrange
-    let mut config = governance_test.get_default_governance_config(&governed_account_cookie);
+    let mut config = governance_test.get_default_governance_config();
     config.vote_threshold_percentage = VoteThresholdPercentage::YesVote(101); // Above 100% threshold
 
     // Act

--- a/governance/program/tests/process_create_program_governance.rs
+++ b/governance/program/tests/process_create_program_governance.rs
@@ -120,7 +120,7 @@ async fn test_create_program_governance_without_transferring_upgrade_authority_w
             &realm_cookie,
             &governed_program_cookie,
             |i| {
-                i.accounts[3].is_signer = false; // governed_program_upgrade_authority
+                i.accounts[4].is_signer = false; // governed_program_upgrade_authority
             },
             Some(&[]),
         )

--- a/governance/program/tests/process_finalize_vote.rs
+++ b/governance/program/tests/process_finalize_vote.rs
@@ -20,8 +20,7 @@ async fn test_finalize_vote_to_succeeded() {
     let realm_cookie = governance_test.with_realm().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let mut governance_config =
-        governance_test.get_default_governance_config(&governed_account_cookie);
+    let mut governance_config = governance_test.get_default_governance_config();
 
     governance_config.vote_threshold_percentage = VoteThresholdPercentage::YesVote(40);
 

--- a/governance/program/tests/process_finalize_vote.rs
+++ b/governance/program/tests/process_finalize_vote.rs
@@ -21,7 +21,7 @@ async fn test_finalize_vote_to_succeeded() {
     let governed_account_cookie = governance_test.with_governed_account().await;
 
     let mut governance_config =
-        governance_test.get_default_governance_config(&realm_cookie, &governed_account_cookie);
+        governance_test.get_default_governance_config(&governed_account_cookie);
 
     governance_config.vote_threshold_percentage = VoteThresholdPercentage::YesVote(40);
 

--- a/governance/program/tests/process_insert_instruction.rs
+++ b/governance/program/tests/process_insert_instruction.rs
@@ -178,8 +178,7 @@ async fn test_insert_instruction_with_invalid_hold_up_time_error() {
     let realm_cookie = governance_test.with_realm().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let mut config =
-        governance_test.get_default_governance_config(&realm_cookie, &governed_account_cookie);
+    let mut config = governance_test.get_default_governance_config(&governed_account_cookie);
 
     config.min_instruction_hold_up_time = 100;
 

--- a/governance/program/tests/process_insert_instruction.rs
+++ b/governance/program/tests/process_insert_instruction.rs
@@ -178,7 +178,7 @@ async fn test_insert_instruction_with_invalid_hold_up_time_error() {
     let realm_cookie = governance_test.with_realm().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let mut config = governance_test.get_default_governance_config(&governed_account_cookie);
+    let mut config = governance_test.get_default_governance_config();
 
     config.min_instruction_hold_up_time = 100;
 
@@ -285,4 +285,53 @@ async fn test_insert_instruction_with_owner_or_delegate_must_sign_error() {
         err,
         GovernanceError::GoverningTokenOwnerOrDelegateMustSign.into()
     );
+}
+
+#[tokio::test]
+async fn test_insert_instruction_with_invalid_governance_for_proposal_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let mut account_governance_cookie = governance_test
+        .with_account_governance(&realm_cookie, &governed_account_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await;
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut account_governance_cookie)
+        .await
+        .unwrap();
+
+    // Try to maliciously use a different governance account to use with the proposal
+    let governed_account_cookie2 = governance_test.with_governed_account().await;
+
+    let account_governance_cookie2 = governance_test
+        .with_account_governance(&realm_cookie, &governed_account_cookie2)
+        .await
+        .unwrap();
+
+    proposal_cookie.account.governance = account_governance_cookie2.address;
+
+    let new_governance_config = governance_test.get_default_governance_config();
+
+    // Act
+    let err = governance_test
+        .with_set_governance_config_instruction(
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            &new_governance_config,
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::InvalidGovernanceForProposal.into());
 }

--- a/governance/program/tests/process_set_governance_config.rs
+++ b/governance/program/tests/process_set_governance_config.rs
@@ -2,13 +2,12 @@
 
 mod program_test;
 
-use borsh::BorshSerialize;
 use program_test::{tools::ProgramInstructionError, *};
 use solana_program_test::tokio;
 use solana_sdk::{signature::Keypair, signer::Signer};
 use spl_governance::{
     error::GovernanceError,
-    instruction::{set_governance_config, GovernanceInstruction, Vote},
+    instruction::{set_governance_config, Vote},
     state::enums::VoteThresholdPercentage,
 };
 
@@ -39,8 +38,7 @@ async fn test_set_governance_config() {
         .await
         .unwrap();
 
-    let mut new_governance_config =
-        governance_test.get_default_governance_config(&governed_account_cookie);
+    let mut new_governance_config = governance_test.get_default_governance_config();
 
     // Change vote_threshold_percentage on the new Governance config
     new_governance_config.vote_threshold_percentage = VoteThresholdPercentage::YesVote(40);
@@ -89,10 +87,8 @@ async fn test_set_governance_config_with_governance_must_sign_error() {
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
     let realm_cookie = governance_test.with_realm().await;
-    let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let new_governance_config =
-        governance_test.get_default_governance_config(&governed_account_cookie);
+    let new_governance_config = governance_test.get_default_governance_config();
 
     let mut set_governance_config_ix = set_governance_config(
         &governance_test.program_id,
@@ -120,10 +116,8 @@ async fn test_set_governance_config_with_fake_governance_signer_error() {
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
     let realm_cookie = governance_test.with_realm().await;
-    let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let new_governance_config =
-        governance_test.get_default_governance_config(&governed_account_cookie);
+    let new_governance_config = governance_test.get_default_governance_config();
 
     let mut set_governance_config_ix = set_governance_config(
         &governance_test.program_id,
@@ -181,90 +175,13 @@ async fn test_set_governance_config_with_invalid_governance_authority_error() {
         .await
         .unwrap();
 
-    let mut new_governance_config =
-        governance_test.get_default_governance_config(&governed_account_cookie);
-    new_governance_config.governed_account =
-        account_governance_cookie2.account.config.governed_account;
-
-    let proposal_instruction_cookie = governance_test
-        .with_set_governance_config_instruction(
-            &mut proposal_cookie,
-            &token_owner_record_cookie,
-            &new_governance_config,
-        )
-        .await
-        .unwrap();
-
-    governance_test
-        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
-        .await
-        .unwrap();
-
-    governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
-        .await
-        .unwrap();
-
-    // Advance timestamp past hold_up_time
-    governance_test
-        .advance_clock_by_min_timespan(proposal_instruction_cookie.account.hold_up_time as u64)
-        .await;
-
-    // Act
-    let err = governance_test
-        .execute_instruction(&proposal_cookie, &proposal_instruction_cookie)
-        .await
-        .err()
-        .unwrap();
-
-    // Assert
-    assert_eq!(err, ProgramInstructionError::PrivilegeEscalation.into());
-}
-
-#[tokio::test]
-async fn test_set_governance_config_with_invalid_config_governed_account_error() {
-    // Arrange
-    let mut governance_test = GovernanceProgramTest::start_new().await;
-
-    let realm_cookie = governance_test.with_realm().await;
-    let governed_account_cookie = governance_test.with_governed_account().await;
-
-    let mut account_governance_cookie = governance_test
-        .with_account_governance(&realm_cookie, &governed_account_cookie)
-        .await
-        .unwrap();
-
-    let token_owner_record_cookie = governance_test
-        .with_community_token_deposit(&realm_cookie)
-        .await;
-
-    let mut proposal_cookie = governance_test
-        .with_proposal(&token_owner_record_cookie, &mut account_governance_cookie)
-        .await
-        .unwrap();
-
-    let signatory_record_cookie = governance_test
-        .with_signatory(&proposal_cookie, &token_owner_record_cookie)
-        .await
-        .unwrap();
-
-    let mut new_governance_config =
-        governance_test.get_default_governance_config(&governed_account_cookie);
+    let new_governance_config = governance_test.get_default_governance_config();
 
     let mut set_governance_config_ix = set_governance_config(
         &governance_test.program_id,
-        &realm_cookie.address,
-        new_governance_config.clone(),
+        &account_governance_cookie2.address,
+        new_governance_config,
     );
-
-    // Try to maliciously change governed account  in the governance config
-    let governed_account_cookie2 = governance_test.with_governed_account().await;
-    new_governance_config.governed_account = governed_account_cookie2.address;
-    set_governance_config_ix.data = (GovernanceInstruction::SetGovernanceConfig {
-        config: new_governance_config,
-    })
-    .try_to_vec()
-    .unwrap();
 
     let proposal_instruction_cookie = governance_test
         .with_instruction(
@@ -299,8 +216,5 @@ async fn test_set_governance_config_with_invalid_config_governed_account_error()
         .unwrap();
 
     // Assert
-    assert_eq!(
-        err,
-        GovernanceError::InvalidConfigGovernedAccountForGovernance.into()
-    );
+    assert_eq!(err, ProgramInstructionError::PrivilegeEscalation.into());
 }

--- a/governance/program/tests/process_set_governance_config.rs
+++ b/governance/program/tests/process_set_governance_config.rs
@@ -40,7 +40,7 @@ async fn test_set_governance_config() {
         .unwrap();
 
     let mut new_governance_config =
-        governance_test.get_default_governance_config(&realm_cookie, &governed_account_cookie);
+        governance_test.get_default_governance_config(&governed_account_cookie);
 
     // Change vote_threshold_percentage on the new Governance config
     new_governance_config.vote_threshold_percentage = VoteThresholdPercentage::YesVote(40);
@@ -92,13 +92,16 @@ async fn test_set_governance_config_with_governance_must_sign_error() {
     let governed_account_cookie = governance_test.with_governed_account().await;
 
     let new_governance_config =
-        governance_test.get_default_governance_config(&realm_cookie, &governed_account_cookie);
+        governance_test.get_default_governance_config(&governed_account_cookie);
 
-    let mut set_governance_config_ix =
-        set_governance_config(&governance_test.program_id, new_governance_config.clone());
+    let mut set_governance_config_ix = set_governance_config(
+        &governance_test.program_id,
+        &realm_cookie.address,
+        new_governance_config.clone(),
+    );
 
     // Remove governance signer from instruction
-    set_governance_config_ix.accounts[1].is_signer = false;
+    set_governance_config_ix.accounts[0].is_signer = false;
 
     // Act
     let err = governance_test
@@ -120,14 +123,17 @@ async fn test_set_governance_config_with_fake_governance_signer_error() {
     let governed_account_cookie = governance_test.with_governed_account().await;
 
     let new_governance_config =
-        governance_test.get_default_governance_config(&realm_cookie, &governed_account_cookie);
+        governance_test.get_default_governance_config(&governed_account_cookie);
 
-    let mut set_governance_config_ix =
-        set_governance_config(&governance_test.program_id, new_governance_config.clone());
+    let mut set_governance_config_ix = set_governance_config(
+        &governance_test.program_id,
+        &realm_cookie.address,
+        new_governance_config.clone(),
+    );
 
     // Set Governance signer to fake account we have authority over and can use to sign the transaction
     let governance_signer = Keypair::new();
-    set_governance_config_ix.accounts[1].pubkey = governance_signer.pubkey();
+    set_governance_config_ix.accounts[0].pubkey = governance_signer.pubkey();
 
     // Act
     let err = governance_test
@@ -176,7 +182,7 @@ async fn test_set_governance_config_with_invalid_governance_authority_error() {
         .unwrap();
 
     let mut new_governance_config =
-        governance_test.get_default_governance_config(&realm_cookie, &governed_account_cookie);
+        governance_test.get_default_governance_config(&governed_account_cookie);
     new_governance_config.governed_account =
         account_governance_cookie2.account.config.governed_account;
 
@@ -216,84 +222,6 @@ async fn test_set_governance_config_with_invalid_governance_authority_error() {
 }
 
 #[tokio::test]
-async fn test_set_governance_config_with_invalid_config_realm_error() {
-    // Arrange
-    let mut governance_test = GovernanceProgramTest::start_new().await;
-
-    let realm_cookie = governance_test.with_realm().await;
-    let governed_account_cookie = governance_test.with_governed_account().await;
-
-    let mut account_governance_cookie = governance_test
-        .with_account_governance(&realm_cookie, &governed_account_cookie)
-        .await
-        .unwrap();
-
-    let token_owner_record_cookie = governance_test
-        .with_community_token_deposit(&realm_cookie)
-        .await;
-
-    let mut proposal_cookie = governance_test
-        .with_proposal(&token_owner_record_cookie, &mut account_governance_cookie)
-        .await
-        .unwrap();
-
-    let signatory_record_cookie = governance_test
-        .with_signatory(&proposal_cookie, &token_owner_record_cookie)
-        .await
-        .unwrap();
-
-    let mut new_governance_config =
-        governance_test.get_default_governance_config(&realm_cookie, &governed_account_cookie);
-
-    let mut set_governance_config_ix =
-        set_governance_config(&governance_test.program_id, new_governance_config.clone());
-
-    // Try to maliciously change realm  in the governance config
-    let realm_cookie2 = governance_test.with_realm().await;
-    new_governance_config.realm = realm_cookie2.address;
-    set_governance_config_ix.data = (GovernanceInstruction::SetGovernanceConfig {
-        config: new_governance_config,
-    })
-    .try_to_vec()
-    .unwrap();
-
-    let proposal_instruction_cookie = governance_test
-        .with_instruction(
-            &mut proposal_cookie,
-            &token_owner_record_cookie,
-            None,
-            &mut set_governance_config_ix,
-        )
-        .await
-        .unwrap();
-
-    governance_test
-        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
-        .await
-        .unwrap();
-
-    governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
-        .await
-        .unwrap();
-
-    // Advance timestamp past hold_up_time
-    governance_test
-        .advance_clock_by_min_timespan(proposal_instruction_cookie.account.hold_up_time as u64)
-        .await;
-
-    // Act
-    let err = governance_test
-        .execute_instruction(&proposal_cookie, &proposal_instruction_cookie)
-        .await
-        .err()
-        .unwrap();
-
-    // Assert
-    assert_eq!(err, GovernanceError::InvalidConfigRealmForGovernance.into());
-}
-
-#[tokio::test]
 async fn test_set_governance_config_with_invalid_config_governed_account_error() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
@@ -321,10 +249,13 @@ async fn test_set_governance_config_with_invalid_config_governed_account_error()
         .unwrap();
 
     let mut new_governance_config =
-        governance_test.get_default_governance_config(&realm_cookie, &governed_account_cookie);
+        governance_test.get_default_governance_config(&governed_account_cookie);
 
-    let mut set_governance_config_ix =
-        set_governance_config(&governance_test.program_id, new_governance_config.clone());
+    let mut set_governance_config_ix = set_governance_config(
+        &governance_test.program_id,
+        &realm_cookie.address,
+        new_governance_config.clone(),
+    );
 
     // Try to maliciously change governed account  in the governance config
     let governed_account_cookie2 = governance_test.with_governed_account().await;


### PR DESCRIPTION
#### Change Summary

This is a maintenance change to improve program quality without any feature changes.

While implementing `SetGovernanceConfig` instruction I realised it was too difficult. I had to add code and tests for attack vectors which shouldn't have even existed. The reason for that was `GovernanceConfig` struct which was being changed but at the same time had immutable data on it: `realm` and `governed_account`. This change moves these fields from `GovernanceConfig` to direct `Governance` account fields and hence protects their immutability without any extra code.
