### PR TITLE
Breakup stake-pool update test transactions

### DIFF
--- a/stake-pool/program/tests/huge_pool.rs
+++ b/stake-pool/program/tests/huge_pool.rs
@@ -324,6 +324,20 @@ async fn update() {
                 0,
                 /* no_merge = */ false,
             ),
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .err();
+    assert!(error.is_none());
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[
             instruction::update_stake_pool_balance(
                 &id(),
                 &stake_pool_accounts.stake_pool.pubkey(),
@@ -333,6 +347,20 @@ async fn update() {
                 &stake_pool_accounts.pool_fee_account.pubkey(),
                 &stake_pool_accounts.pool_mint.pubkey(),
             ),
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .err();
+    assert!(error.is_none());
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[
             instruction::cleanup_removed_validator_entries(
                 &id(),
                 &stake_pool_accounts.stake_pool.pubkey(),

--- a/stake-pool/program/tests/huge_pool.rs
+++ b/stake-pool/program/tests/huge_pool.rs
@@ -313,18 +313,16 @@ async fn update() {
         setup(HUGE_POOL_SIZE, HUGE_POOL_SIZE, STAKE_AMOUNT).await;
 
     let transaction = Transaction::new_signed_with_payer(
-        &[
-            instruction::update_validator_list_balance(
-                &id(),
-                &stake_pool_accounts.stake_pool.pubkey(),
-                &stake_pool_accounts.withdraw_authority,
-                &stake_pool_accounts.validator_list.pubkey(),
-                &stake_pool_accounts.reserve_stake.pubkey(),
-                &vote_account_pubkeys[0..MAX_VALIDATORS_TO_UPDATE],
-                0,
-                /* no_merge = */ false,
-            ),
-        ],
+        &[instruction::update_validator_list_balance(
+            &id(),
+            &stake_pool_accounts.stake_pool.pubkey(),
+            &stake_pool_accounts.withdraw_authority,
+            &stake_pool_accounts.validator_list.pubkey(),
+            &stake_pool_accounts.reserve_stake.pubkey(),
+            &vote_account_pubkeys[0..MAX_VALIDATORS_TO_UPDATE],
+            0,
+            /* no_merge = */ false,
+        )],
         Some(&context.payer.pubkey()),
         &[&context.payer],
         context.last_blockhash,
@@ -337,17 +335,15 @@ async fn update() {
     assert!(error.is_none());
 
     let transaction = Transaction::new_signed_with_payer(
-        &[
-            instruction::update_stake_pool_balance(
-                &id(),
-                &stake_pool_accounts.stake_pool.pubkey(),
-                &stake_pool_accounts.withdraw_authority,
-                &stake_pool_accounts.validator_list.pubkey(),
-                &stake_pool_accounts.reserve_stake.pubkey(),
-                &stake_pool_accounts.pool_fee_account.pubkey(),
-                &stake_pool_accounts.pool_mint.pubkey(),
-            ),
-        ],
+        &[instruction::update_stake_pool_balance(
+            &id(),
+            &stake_pool_accounts.stake_pool.pubkey(),
+            &stake_pool_accounts.withdraw_authority,
+            &stake_pool_accounts.validator_list.pubkey(),
+            &stake_pool_accounts.reserve_stake.pubkey(),
+            &stake_pool_accounts.pool_fee_account.pubkey(),
+            &stake_pool_accounts.pool_mint.pubkey(),
+        )],
         Some(&context.payer.pubkey()),
         &[&context.payer],
         context.last_blockhash,
@@ -360,13 +356,11 @@ async fn update() {
     assert!(error.is_none());
 
     let transaction = Transaction::new_signed_with_payer(
-        &[
-            instruction::cleanup_removed_validator_entries(
-                &id(),
-                &stake_pool_accounts.stake_pool.pubkey(),
-                &stake_pool_accounts.validator_list.pubkey(),
-            ),
-        ],
+        &[instruction::cleanup_removed_validator_entries(
+            &id(),
+            &stake_pool_accounts.stake_pool.pubkey(),
+            &stake_pool_accounts.validator_list.pubkey(),
+        )],
         Some(&context.payer.pubkey()),
         &[&context.payer],
         context.last_blockhash,


### PR DESCRIPTION
Stake-pool's `huge_test` includes the test `update` that attempts to process a very large transaction that fails the new compute budget tx-wide limit.  The test's transaction is not a practical use case and was done because it was easy to throw all the instructions into one transaction.  Break the test's transaction into multiple.