### PR TITLE
token-js: Use `flow check-contents` to not trip on others' issues

### DIFF
--- a/token-lending/program/tests/init_lending_market.rs
+++ b/token-lending/program/tests/init_lending_market.rs
@@ -23,7 +23,7 @@ async fn test_success() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(15_000);
+    test.set_bpf_compute_max_units(20_000);
 
     let (mut banks_client, payer, _recent_blockhash) = test.start().await;
 

--- a/token/js/package-lock.json
+++ b/token/js/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.5",
-        "@solana/web3.js": "^1.12.0",
+        "@solana/web3.js": "^1.21.0",
         "bn.js": "^5.1.0",
         "buffer": "6.0.3",
         "buffer-layout": "^1.2.0",

--- a/token/js/package.json
+++ b/token/js/package.json
@@ -39,7 +39,7 @@
     "start-with-test-validator": "start-server-and-test 'solana-test-validator --reset --quiet' http://localhost:8899/health start",
     "lint": "npm run pretty && eslint .",
     "lint:fix": "npm run pretty:fix && eslint . --fix",
-    "flow": "flow",
+    "flow": "flow check-contents < module.flow.js",
     "flow:watch": "watch 'flow' . --wait=1 --ignoreDirectoryPattern=/doc/",
     "lint:watch": "watch 'npm run lint:fix' . --wait=1",
     "build:program": "rm -f client/util/store/config.json; cargo build-bpf --manifest-path ../program/Cargo.toml",
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.10.5",
-    "@solana/web3.js": "^1.12.0",
+    "@solana/web3.js": "^1.21.0",
     "bn.js": "^5.1.0",
     "buffer": "6.0.3",
     "buffer-layout": "^1.2.0",


### PR DESCRIPTION
#### Problem

The token js CI is tripping up on flow, due to issues in upstream projects.

#### Solution

Use `flow check-contents` to restrict the checks to just token.

And also, bump the compute budget on failing lending test.