### PR TITLE
token: Add SyncNative instruction (program, CLI, JS)

### DIFF
--- a/token/cli/src/config.rs
+++ b/token/cli/src/config.rs
@@ -30,14 +30,30 @@ impl<'a> Config<'a> {
         override_name: &str,
         wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
     ) -> Pubkey {
+        let token = pubkey_of_signer(arg_matches, "token", wallet_manager).unwrap();
+        self.associated_token_address_for_token_or_override(
+            arg_matches,
+            override_name,
+            wallet_manager,
+            token,
+        )
+    }
+
+    // Check if an explicit token account address was provided, otherwise
+    // return the associated token address for the default address.
+    pub(crate) fn associated_token_address_for_token_or_override(
+        &self,
+        arg_matches: &ArgMatches,
+        override_name: &str,
+        wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+        token: Option<Pubkey>,
+    ) -> Pubkey {
         if let Some(address) = pubkey_of_signer(arg_matches, override_name, wallet_manager).unwrap()
         {
             return address;
         }
 
-        let token = pubkey_of_signer(arg_matches, "token", wallet_manager)
-            .unwrap()
-            .unwrap();
+        let token = token.unwrap();
         let owner = self
             .default_signer(arg_matches, wallet_manager)
             .unwrap_or_else(|e| {

--- a/token/js/client/token.js
+++ b/token/js/client/token.js
@@ -1398,6 +1398,22 @@ export class Token {
   }
 
   /**
+   * Sync amount in native SPL token account to underlying lamports
+   *
+   * @param nativeAccount Account to sync
+   */
+  async syncNative(nativeAccount: PublicKey): Promise<void> {
+    await sendAndConfirmTransaction(
+      'SyncNative',
+      this.connection,
+      new Transaction().add(
+        Token.createSyncNativeInstruction(this.programId, nativeAccount),
+      ),
+      this.payer,
+    );
+  }
+
+  /**
    * Construct an InitializeMint instruction
    *
    * @param programId SPL Token program account
@@ -2223,6 +2239,30 @@ export class Token {
       programId: programId,
       data,
     });
+  }
+
+  /**
+   * Construct a SyncNative instruction
+   *
+   * @param programId SPL Token program account
+   * @param nativeAccount Account to sync lamports from
+   */
+  static createSyncNativeInstruction(
+    programId: PublicKey,
+    nativeAccount: PublicKey,
+  ): TransactionInstruction {
+    const dataLayout = BufferLayout.struct([BufferLayout.u8('instruction')]);
+
+    const data = Buffer.alloc(dataLayout.span);
+    dataLayout.encode(
+      {
+        instruction: 17, // SyncNative instruction
+      },
+      data,
+    );
+
+    let keys = [{pubkey: nativeAccount, isSigner: false, isWritable: true}];
+    return new TransactionInstruction({keys, programId: programId, data});
   }
 
   /**

--- a/token/js/module.flow.js
+++ b/token/js/module.flow.js
@@ -147,6 +147,13 @@ declare module '@solana/spl-token' {
       multiSigners: Array<Signer>,
       amount: number | u64,
     ): Promise<void>;
+    burnChecked(
+      account: PublicKey,
+      owner: any,
+      multiSigners: Array<Signer>,
+      amount: number | u64,
+      decimals: number,
+    ): Promise<void>;
     freezeAccount(
       account: PublicKey,
       authority: any,
@@ -163,6 +170,7 @@ declare module '@solana/spl-token' {
       authority: Signer | PublicKey,
       multiSigners: Array<Signer>,
     ): Promise<void>;
+    syncNative(nativeAccount: PublicKey): Promise<void>;
     static createInitMintInstruction(
       programId: PublicKey,
       mint: PublicKey,
@@ -242,6 +250,19 @@ declare module '@solana/spl-token' {
       mint: PublicKey,
       authority: PublicKey,
       multiSigners: Array<Signer>,
+    ): TransactionInstruction;
+    static createBurnCheckedInstruction(
+      programId: PublicKey,
+      mint: PublicKey,
+      account: PublicKey,
+      owner: PublicKey,
+      multiSigners: Array<Signer>,
+      amount: number | u64,
+      decimals: number,
+    ): TransactionInstruction;
+    static createSyncNativeInstruction(
+      programId: PublicKey,
+      nativeAccount: PublicKey,
     ): TransactionInstruction;
     static createAssociatedTokenAccountInstruction(
       associatedProgramId: PublicKey,

--- a/token/js/test/token.test.js
+++ b/token/js/test/token.test.js
@@ -76,4 +76,13 @@ describe('Token', () => {
     expect(ix.programId).to.eql(ASSOCIATED_TOKEN_PROGRAM_ID);
     expect(ix.keys).to.have.length(7);
   });
+
+  it('syncNative', () => {
+    const ix = Token.createSyncNativeInstruction(
+      TOKEN_PROGRAM_ID,
+      Keypair.generate().publicKey,
+    );
+    expect(ix.programId).to.eql(TOKEN_PROGRAM_ID);
+    expect(ix.keys).to.have.length(1);
+  });
 });

--- a/token/program/src/error.rs
+++ b/token/program/src/error.rs
@@ -7,6 +7,7 @@ use thiserror::Error;
 /// Errors that may be returned by the Token program.
 #[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]
 pub enum TokenError {
+    // 0
     /// Lamport balance below rent-exempt threshold.
     #[error("Lamport balance below rent-exempt threshold")]
     NotRentExempt,
@@ -22,6 +23,8 @@ pub enum TokenError {
     /// Owner does not match.
     #[error("Owner does not match")]
     OwnerMismatch,
+
+    // 5
     /// This token's supply is fixed and new tokens cannot be minted.
     #[error("Fixed supply")]
     FixedSupply,
@@ -37,6 +40,8 @@ pub enum TokenError {
     /// State is uninitialized.
     #[error("State is unititialized")]
     UninitializedState,
+
+    // 10
     /// Instruction does not support native tokens
     #[error("Instruction does not support native tokens")]
     NativeNotSupported,
@@ -52,6 +57,8 @@ pub enum TokenError {
     /// Operation overflowed
     #[error("Operation overflowed")]
     Overflow,
+
+    // 15
     /// Account does not support specified authority type.
     #[error("Account does not support specified authority type")]
     AuthorityTypeNotSupported,
@@ -64,6 +71,9 @@ pub enum TokenError {
     /// Mint decimals mismatch between the client and mint
     #[error("The provided decimals value different from the Mint decimals")]
     MintDecimalsMismatch,
+    /// Instruction does not support non-native tokens
+    #[error("Instruction does not support non-native tokens")]
+    NonNativeNotSupported,
 }
 impl From<TokenError> for ProgramError {
     fn from(e: TokenError) -> Self {

--- a/token/program/src/processor.rs
+++ b/token/program/src/processor.rs
@@ -644,6 +644,36 @@ impl Processor {
         Ok(())
     }
 
+    /// Processes a [SyncNative](enum.TokenInstruction.html) instruction
+    pub fn process_sync_native(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
+        let account_info_iter = &mut accounts.iter();
+        let native_account_info = next_account_info(account_info_iter)?;
+
+        if native_account_info.owner != program_id {
+            return Err(ProgramError::IncorrectProgramId);
+        }
+        let mut native_account = Account::unpack(&native_account_info.data.borrow())?;
+        if native_account.mint != crate::native_mint::id() {
+            return Err(TokenError::NonNativeNotSupported.into());
+        }
+
+        if let COption::Some(rent_exempt_reserve) = native_account.is_native {
+            let new_amount = native_account_info
+                .lamports()
+                .checked_sub(rent_exempt_reserve)
+                .ok_or(TokenError::Overflow)?;
+            if new_amount < native_account.amount {
+                return Err(TokenError::InvalidState.into());
+            }
+            native_account.amount = new_amount;
+        } else {
+            return Err(TokenError::InvalidState.into());
+        }
+
+        Account::pack(native_account, &mut native_account_info.data.borrow_mut())?;
+        Ok(())
+    }
+
     /// Processes an [Instruction](enum.Instruction.html).
     pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> ProgramResult {
         let instruction = TokenInstruction::unpack(input)?;
@@ -724,6 +754,10 @@ impl Processor {
                 msg!("Instruction: BurnChecked");
                 Self::process_burn(program_id, accounts, amount, Some(decimals))
             }
+            TokenInstruction::SyncNative => {
+                msg!("Instruction: SyncNative");
+                Self::process_sync_native(program_id, accounts)
+            }
         }
     }
 
@@ -801,6 +835,9 @@ impl PrintProgramError for TokenError {
             TokenError::AccountFrozen => msg!("Error: Account is frozen"),
             TokenError::MintDecimalsMismatch => {
                 msg!("Error: decimals different from the Mint decimals")
+            }
+            TokenError::NonNativeNotSupported => {
+                msg!("Error: Instruction does not support non-native tokens")
             }
         }
     }
@@ -5774,5 +5811,127 @@ mod tests {
         .unwrap();
 
         assert_eq!(account_account, account2_account);
+    }
+
+    #[test]
+    fn test_sync_native() {
+        let program_id = crate::id();
+        let mint_key = Pubkey::new_unique();
+        let mut mint_account =
+            SolanaAccount::new(mint_minimum_balance(), Mint::get_packed_len(), &program_id);
+        let native_account_key = Pubkey::new_unique();
+        let lamports = 40;
+        let mut native_account = SolanaAccount::new(
+            account_minimum_balance() + lamports,
+            Account::get_packed_len(),
+            &program_id,
+        );
+        let non_native_account_key = Pubkey::new_unique();
+        let mut non_native_account = SolanaAccount::new(
+            account_minimum_balance() + 50,
+            Account::get_packed_len(),
+            &program_id,
+        );
+
+        let owner_key = Pubkey::new_unique();
+        let mut owner_account = SolanaAccount::default();
+        let mut rent_sysvar = rent_sysvar();
+
+        // initialize non-native mint
+        do_process_instruction(
+            initialize_mint(&program_id, &mint_key, &owner_key, None, 2).unwrap(),
+            vec![&mut mint_account, &mut rent_sysvar],
+        )
+        .unwrap();
+
+        // initialize non-native account
+        do_process_instruction(
+            initialize_account(&program_id, &non_native_account_key, &mint_key, &owner_key)
+                .unwrap(),
+            vec![
+                &mut non_native_account,
+                &mut mint_account,
+                &mut owner_account,
+                &mut rent_sysvar,
+            ],
+        )
+        .unwrap();
+
+        let account = Account::unpack_unchecked(&non_native_account.data).unwrap();
+        assert!(!account.is_native());
+        assert_eq!(account.amount, 0);
+
+        // fail sync non-native
+        assert_eq!(
+            Err(TokenError::NonNativeNotSupported.into()),
+            do_process_instruction(
+                sync_native(&program_id, &non_native_account_key,).unwrap(),
+                vec![&mut non_native_account],
+            )
+        );
+
+        // fail sync uninitialized
+        assert_eq!(
+            Err(ProgramError::UninitializedAccount),
+            do_process_instruction(
+                sync_native(&program_id, &native_account_key,).unwrap(),
+                vec![&mut native_account],
+            )
+        );
+
+        // wrap native account
+        do_process_instruction(
+            initialize_account(
+                &program_id,
+                &native_account_key,
+                &crate::native_mint::id(),
+                &owner_key,
+            )
+            .unwrap(),
+            vec![
+                &mut native_account,
+                &mut mint_account,
+                &mut owner_account,
+                &mut rent_sysvar,
+            ],
+        )
+        .unwrap();
+        let account = Account::unpack_unchecked(&native_account.data).unwrap();
+        assert!(account.is_native());
+        assert_eq!(account.amount, lamports);
+
+        // sync, no change
+        do_process_instruction(
+            sync_native(&program_id, &native_account_key).unwrap(),
+            vec![&mut native_account],
+        )
+        .unwrap();
+        let account = Account::unpack_unchecked(&native_account.data).unwrap();
+        assert_eq!(account.amount, lamports);
+
+        // transfer sol
+        let new_lamports = lamports + 50;
+        native_account.lamports = account_minimum_balance() + new_lamports;
+
+        // success sync
+        do_process_instruction(
+            sync_native(&program_id, &native_account_key).unwrap(),
+            vec![&mut native_account],
+        )
+        .unwrap();
+        let account = Account::unpack_unchecked(&native_account.data).unwrap();
+        assert_eq!(account.amount, new_lamports);
+
+        // reduce sol
+        native_account.lamports -= 1;
+
+        // fail sync
+        assert_eq!(
+            Err(TokenError::InvalidState.into()),
+            do_process_instruction(
+                sync_native(&program_id, &native_account_key,).unwrap(),
+                vec![&mut native_account],
+            )
+        );
     }
 }

--- a/token/program/src/processor.rs
+++ b/token/program/src/processor.rs
@@ -653,9 +653,6 @@ impl Processor {
             return Err(ProgramError::IncorrectProgramId);
         }
         let mut native_account = Account::unpack(&native_account_info.data.borrow())?;
-        if native_account.mint != crate::native_mint::id() {
-            return Err(TokenError::NonNativeNotSupported.into());
-        }
 
         if let COption::Some(rent_exempt_reserve) = native_account.is_native {
             let new_amount = native_account_info
@@ -667,7 +664,7 @@ impl Processor {
             }
             native_account.amount = new_amount;
         } else {
-            return Err(TokenError::InvalidState.into());
+            return Err(TokenError::NonNativeNotSupported.into());
         }
 
         Account::pack(native_account, &mut native_account_info.data.borrow_mut())?;


### PR DESCRIPTION
Fixes #2077 

#### Problem

If you `system_instruction::transfer` lamports into a wrapped SOL token account, the wrapped SOL account will not register its new balance.

#### Solution

Add `SyncNative` instruction to update the account's `amount` based on the underlying account's lamports.

cc @armaniferrante 