### PR TITLE
stake-pool: Add new fee fields for liquid staking and arbitrage prevention

### DIFF
--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -613,6 +613,9 @@ impl Processor {
         stake_pool.next_epoch_fee = None;
         stake_pool.preferred_deposit_validator_vote_address = None;
         stake_pool.preferred_withdraw_validator_vote_address = None;
+        stake_pool.deposit_fee = Fee::default();
+        stake_pool.withdrawal_fee = Fee::default();
+        stake_pool.next_withdrawal_fee = None;
 
         stake_pool
             .serialize(&mut *stake_pool_info.data.borrow_mut())

--- a/stake-pool/program/src/state.rs
+++ b/stake-pool/program/src/state.rs
@@ -8,6 +8,7 @@ use {
     solana_program::{
         account_info::AccountInfo,
         borsh::get_instance_packed_len,
+        clock::Epoch,
         msg,
         program_error::ProgramError,
         program_memory::sol_memcmp,
@@ -103,6 +104,15 @@ pub struct StakePool {
 
     /// Preferred withdraw validator vote account pubkey
     pub preferred_withdraw_validator_vote_address: Option<Pubkey>,
+
+    /// Fee assessed on deposits
+    pub deposit_fee: Fee,
+
+    /// Fee assessed on withdrawals
+    pub withdrawal_fee: Fee,
+
+    /// Future withdrawal fee, to be set at the given epoch
+    pub next_withdrawal_fee: Option<(Epoch, Fee)>,
 }
 impl StakePool {
     /// calculate the pool tokens that should be minted for a deposit of `stake_lamports`

--- a/stake-pool/program/tests/huge_pool.rs
+++ b/stake-pool/program/tests/huge_pool.rs
@@ -26,7 +26,7 @@ use {
         find_withdraw_authority_program_address, id,
         instruction::{self, PreferredValidatorType},
         stake_program,
-        state::{AccountType, StakePool, StakeStatus, ValidatorList, ValidatorStakeInfo},
+        state::{AccountType, Fee, StakePool, StakeStatus, ValidatorList, ValidatorStakeInfo},
         MAX_VALIDATORS_TO_UPDATE, MINIMUM_ACTIVE_STAKE,
     },
     spl_token::state::{Account as SplAccount, AccountState as SplAccountState, Mint},
@@ -78,6 +78,9 @@ async fn setup(
         next_epoch_fee: None,
         preferred_deposit_validator_vote_address: None,
         preferred_withdraw_validator_vote_address: None,
+        deposit_fee: Fee::default(),
+        withdrawal_fee: Fee::default(),
+        next_withdrawal_fee: None,
     };
 
     let mut validator_list = ValidatorList::new(max_validators);


### PR DESCRIPTION
In order to launch their stake pool, @lieuzhenghong and co. would like to be able to assess a fee for liquid deposits (for a fair price), and on withdrawals (to prevent arbitrage).

They will do the work to integrate the fees, but this at least adds the new fields to avoid backwards compatibility issues whenever their work is ready.

Let me know how it looks!