### PR TITLE
Bump token-lending test caps

### DIFF
--- a/token-lending/program/tests/borrow_obligation_liquidity.rs
+++ b/token-lending/program/tests/borrow_obligation_liquidity.rs
@@ -28,7 +28,7 @@ async fn test_borrow_usdc_fixed_amount() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(41_000);
+    test.set_bpf_compute_max_units(60_000);
 
     const USDC_TOTAL_BORROW_FRACTIONAL: u64 = 1_000 * FRACTIONAL_TO_USDC;
     const FEE_AMOUNT: u64 = 100;
@@ -175,7 +175,7 @@ async fn test_borrow_sol_max_amount() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(42_000);
+    test.set_bpf_compute_max_units(60_000);
 
     const FEE_AMOUNT: u64 = 5000;
     const HOST_FEE_AMOUNT: u64 = 1000;

--- a/token-lending/program/tests/deposit_reserve_liquidity.rs
+++ b/token-lending/program/tests/deposit_reserve_liquidity.rs
@@ -16,7 +16,7 @@ async fn test_success() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(27_000);
+    test.set_bpf_compute_max_units(30_000);
 
     let user_accounts_owner = Keypair::new();
     let lending_market = add_lending_market(&mut test);

--- a/token-lending/program/tests/liquidate_obligation.rs
+++ b/token-lending/program/tests/liquidate_obligation.rs
@@ -25,7 +25,7 @@ async fn test_success() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(51_000);
+    test.set_bpf_compute_max_units(68_000);
 
     // 100 SOL collateral
     const SOL_DEPOSIT_AMOUNT_LAMPORTS: u64 = 100 * LAMPORTS_TO_SOL * INITIAL_COLLATERAL_RATIO;

--- a/token-lending/program/tests/obligation_end_to_end.rs
+++ b/token-lending/program/tests/obligation_end_to_end.rs
@@ -32,7 +32,7 @@ async fn test_success() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(41_000);
+    test.set_bpf_compute_max_units(170_000);
 
     const FEE_AMOUNT: u64 = 100;
     const HOST_FEE_AMOUNT: u64 = 20;

--- a/token-lending/program/tests/redeem_reserve_collateral.rs
+++ b/token-lending/program/tests/redeem_reserve_collateral.rs
@@ -24,7 +24,7 @@ async fn test_success() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(29_000);
+    test.set_bpf_compute_max_units(40_000);
 
     let user_accounts_owner = Keypair::new();
     let lending_market = add_lending_market(&mut test);

--- a/token-lending/program/tests/refresh_obligation.rs
+++ b/token-lending/program/tests/refresh_obligation.rs
@@ -27,7 +27,7 @@ async fn test_success() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(28_000);
+    test.set_bpf_compute_max_units(45_000);
 
     const SOL_DEPOSIT_AMOUNT: u64 = 100;
     const USDC_BORROW_AMOUNT: u64 = 1_000;

--- a/token-lending/program/tests/refresh_reserve.rs
+++ b/token-lending/program/tests/refresh_reserve.rs
@@ -25,7 +25,7 @@ async fn test_success() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(16_000);
+    test.set_bpf_compute_max_units(30_000);
 
     const SOL_RESERVE_LIQUIDITY_LAMPORTS: u64 = 100 * LAMPORTS_TO_SOL;
     const USDC_RESERVE_LIQUIDITY_FRACTIONAL: u64 = 100 * FRACTIONAL_TO_USDC;

--- a/token-lending/program/tests/repay_obligation_liquidity.rs
+++ b/token-lending/program/tests/repay_obligation_liquidity.rs
@@ -25,7 +25,7 @@ async fn test_success() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(27_000);
+    test.set_bpf_compute_max_units(36_000);
 
     const SOL_DEPOSIT_AMOUNT_LAMPORTS: u64 = 100 * LAMPORTS_TO_SOL * INITIAL_COLLATERAL_RATIO;
     const USDC_BORROW_AMOUNT_FRACTIONAL: u64 = 1_000 * FRACTIONAL_TO_USDC;

--- a/token-lending/program/tests/withdraw_obligation_collateral.rs
+++ b/token-lending/program/tests/withdraw_obligation_collateral.rs
@@ -27,7 +27,7 @@ async fn test_withdraw_fixed_amount() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(33_000);
+    test.set_bpf_compute_max_units(50_000);
 
     const SOL_DEPOSIT_AMOUNT_LAMPORTS: u64 = 200 * LAMPORTS_TO_SOL * INITIAL_COLLATERAL_RATIO;
     const USDC_BORROW_AMOUNT_FRACTIONAL: u64 = 1_000 * FRACTIONAL_TO_USDC;
@@ -154,7 +154,7 @@ async fn test_withdraw_max_amount() {
     );
 
     // limit to track compute unit increase
-    test.set_bpf_compute_max_units(28_000);
+    test.set_bpf_compute_max_units(50_000);
 
     const USDC_DEPOSIT_AMOUNT_FRACTIONAL: u64 =
         1_000 * FRACTIONAL_TO_USDC * INITIAL_COLLATERAL_RATIO;


### PR DESCRIPTION
The Solana compute cap is being applied transaction-wide instead of per instruction.  Bump the test's compute caps to compensate