### PR TITLE
Governance:  FlagInstructionError instruction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3720,7 +3720,7 @@ dependencies = [
 
 [[package]]
 name = "spl-governance"
-version = "1.0.1"
+version = "1.0.3"
 dependencies = [
  "arrayref",
  "assert_matches",

--- a/governance/program/Cargo.toml
+++ b/governance/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-governance"
-version = "1.0.1"
+version = "1.0.3"
 description = "Solana Program Library Governance Program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -275,6 +275,10 @@ pub enum GovernanceError {
     /// Governance PDA must sign
     #[error("Governance PDA must sign")]
     GovernancePdaMustSign,
+
+    /// Instruction already flagged with error
+    #[error("Instruction already flagged with error")]
+    InstructionAlreadyFlaggedWithError,
 }
 
 impl PrintProgramError for GovernanceError {

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -355,7 +355,7 @@ pub enum GovernanceInstruction {
     ///
     ///   0. `[writable]` Proposal account
     ///   1. `[]` TokenOwnerRecord account for Proposal owner
-    ///   2 `[signer]` Governance Authority (Token Owner or Governance Delegate)    
+    ///   2. `[signer]` Governance Authority (Token Owner or Governance Delegate)    
     ///   3. `[writable]` ProposalInstruction account to flag
     ///   4. `[]` Clock sysvar
     FlagInstructionError,

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -350,6 +350,8 @@ pub enum GovernanceInstruction {
 
     /// Flags an instruction and its parent Proposal with error status
     /// It can be used by Proposal owner in case the instruction is permanently broken and can't be executed
+    /// Note: This instruction is a workaround because currently it's not possible to catch errors from CPI calls
+    ///       and the Governance program has no way to know when instruction failed and flag it automatically
     ///
     ///   0. `[writable]` Proposal account
     ///   1. `[]` TokenOwnerRecord account for Proposal owner

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -347,6 +347,16 @@ pub enum GovernanceInstruction {
         /// New governance config
         config: GovernanceConfig,
     },
+
+    /// Flags an instruction and its parent Proposal with error status
+    /// It can be used by Proposal owner in case the instruction is permanently broken and can't be executed
+    ///
+    ///   0. `[writable]` Proposal account
+    ///   1. `[]` TokenOwnerRecord account for Proposal owner
+    ///   2 `[signer]` Governance Authority (Token Owner or Governance Delegate)    
+    ///   3. `[writable]` ProposalInstruction account to flag
+    ///   4. `[]` Clock sysvar
+    FlagInstructionError,
 }
 
 /// Creates CreateRealm instruction
@@ -1024,6 +1034,32 @@ pub fn set_governance_config(
     let accounts = vec![AccountMeta::new(*governance, true)];
 
     let instruction = GovernanceInstruction::SetGovernanceConfig { config };
+
+    Instruction {
+        program_id: *program_id,
+        accounts,
+        data: instruction.try_to_vec().unwrap(),
+    }
+}
+
+/// Creates FlagInstructionError instruction
+pub fn flag_instruction_error(
+    program_id: &Pubkey,
+    // Accounts
+    proposal: &Pubkey,
+    token_owner_record: &Pubkey,
+    governance_authority: &Pubkey,
+    proposal_instruction: &Pubkey,
+) -> Instruction {
+    let accounts = vec![
+        AccountMeta::new(*proposal, false),
+        AccountMeta::new_readonly(*token_owner_record, false),
+        AccountMeta::new_readonly(*governance_authority, true),
+        AccountMeta::new(*proposal_instruction, false),
+        AccountMeta::new_readonly(sysvar::clock::id(), false),
+    ];
+
+    let instruction = GovernanceInstruction::FlagInstructionError {};
 
     Instruction {
         program_id: *program_id,

--- a/governance/program/src/processor/mod.rs
+++ b/governance/program/src/processor/mod.rs
@@ -12,6 +12,7 @@ mod process_create_token_governance;
 mod process_deposit_governing_tokens;
 mod process_execute_instruction;
 mod process_finalize_vote;
+mod process_flag_instruction_error;
 mod process_insert_instruction;
 mod process_relinquish_vote;
 mod process_remove_instruction;
@@ -36,6 +37,7 @@ use process_create_token_governance::*;
 use process_deposit_governing_tokens::*;
 use process_execute_instruction::*;
 use process_finalize_vote::*;
+use process_flag_instruction_error::*;
 use process_insert_instruction::*;
 use process_relinquish_vote::*;
 use process_remove_instruction::*;
@@ -159,6 +161,10 @@ pub fn process_instruction(
 
         GovernanceInstruction::SetGovernanceConfig { config } => {
             process_set_governance_config(program_id, accounts, config)
+        }
+
+        GovernanceInstruction::FlagInstructionError {} => {
+            process_flag_instruction_error(program_id, accounts)
         }
     }
 }

--- a/governance/program/src/processor/process_execute_instruction.rs
+++ b/governance/program/src/processor/process_execute_instruction.rs
@@ -70,7 +70,10 @@ pub fn process_execute_instruction(program_id: &Pubkey, accounts: &[AccountInfo]
         .checked_add(1)
         .unwrap();
 
-    if proposal_data.state == ProposalState::Executing
+    // Checking for Executing and ExecutingWithErrors states because instruction can still be executed after being flagged with error
+    // The check for instructions_executed_count ensures Proposal can't be transitioned to Completed state from ExecutingWithErrors
+    if (proposal_data.state == ProposalState::Executing
+        || proposal_data.state == ProposalState::ExecutingWithErrors)
         && proposal_data.instructions_executed_count == proposal_data.instructions_count
     {
         proposal_data.closed_at = Some(clock.unix_timestamp);

--- a/governance/program/src/processor/process_flag_instruction_error.rs
+++ b/governance/program/src/processor/process_flag_instruction_error.rs
@@ -1,0 +1,67 @@
+//! Program state processor
+
+use borsh::BorshSerialize;
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    clock::Clock,
+    entrypoint::ProgramResult,
+    pubkey::Pubkey,
+    sysvar::Sysvar,
+};
+
+use crate::state::{
+    enums::{InstructionExecutionStatus, ProposalState},
+    proposal::get_proposal_data,
+    proposal_instruction::get_proposal_instruction_data_for_proposal,
+    token_owner_record::get_token_owner_record_data_for_proposal_owner,
+};
+
+/// Processes FlagInstructionError instruction
+pub fn process_flag_instruction_error(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    let proposal_info = next_account_info(account_info_iter)?; // 0
+    let token_owner_record_info = next_account_info(account_info_iter)?; // 1
+    let governance_authority_info = next_account_info(account_info_iter)?; // 2
+
+    let proposal_instruction_info = next_account_info(account_info_iter)?; // 3
+
+    let clock_info = next_account_info(account_info_iter)?; // 4
+    let clock = Clock::from_account_info(clock_info)?;
+
+    let mut proposal_data = get_proposal_data(program_id, proposal_info)?;
+
+    let mut proposal_instruction_data = get_proposal_instruction_data_for_proposal(
+        program_id,
+        proposal_instruction_info,
+        proposal_info.key,
+    )?;
+
+    proposal_data
+        .assert_can_flag_instruction_error(&proposal_instruction_data, clock.unix_timestamp)?;
+
+    let token_owner_record_data = get_token_owner_record_data_for_proposal_owner(
+        program_id,
+        token_owner_record_info,
+        &proposal_data.token_owner_record,
+    )?;
+
+    token_owner_record_data.assert_token_owner_or_delegate_is_signer(governance_authority_info)?;
+
+    // If this is the first instruction to be executed then set the executing_at timestamp
+    // It indicates when we started executing instructions for the Proposal and the fact we only flag it as error is irrelevant here
+    if proposal_data.state == ProposalState::Succeeded {
+        proposal_data.executing_at = Some(clock.unix_timestamp);
+    }
+
+    proposal_data.state = ProposalState::ExecutingWithErrors;
+    proposal_data.serialize(&mut *proposal_info.data.borrow_mut())?;
+
+    proposal_instruction_data.execution_status = InstructionExecutionStatus::Error;
+    proposal_instruction_data.serialize(&mut *proposal_instruction_info.data.borrow_mut())?;
+
+    Ok(())
+}

--- a/governance/program/src/processor/process_flag_instruction_error.rs
+++ b/governance/program/src/processor/process_flag_instruction_error.rs
@@ -51,7 +51,7 @@ pub fn process_flag_instruction_error(
 
     token_owner_record_data.assert_token_owner_or_delegate_is_signer(governance_authority_info)?;
 
-    // If this is the first instruction to be executed then set the executing_at timestamp
+    // If this is the first instruction to be executed then set executing_at timestamp
     // It indicates when we started executing instructions for the Proposal and the fact we only flag it as error is irrelevant here
     if proposal_data.state == ProposalState::Succeeded {
         proposal_data.executing_at = Some(clock.unix_timestamp);

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -74,7 +74,8 @@ pub enum ProposalState {
     /// Voting ended with success
     Succeeded,
 
-    /// Voting completed and now instructions are being execute. Proposal enter this state when first instruction is executed and leaves when the last instruction is executed
+    /// Voting on Proposal succeeded and now instructions are being executed
+    /// Proposal enter this state when first instruction is executed and leaves when the last instruction is executed
     Executing,
 
     /// Completed
@@ -86,7 +87,8 @@ pub enum ProposalState {
     /// Defeated
     Defeated,
 
-    /// Same as Executing but indicates some instructions faield to execute
+    /// Same as Executing but indicates some instructions failed to execute
+    /// Proposal can't be transitioned from ExecutingWithErrors to Completed state
     ExecutingWithErrors,
 }
 

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -85,6 +85,9 @@ pub enum ProposalState {
 
     /// Defeated
     Defeated,
+
+    /// Same as Executing but indicates some instructions faield to execute
+    ExecutingWithErrors,
 }
 
 impl Default for ProposalState {
@@ -133,8 +136,6 @@ pub enum InstructionExecutionStatus {
     Success,
 
     /// Instruction execution failed
-    /// Note: Error status is not supported yet because when CPI call fails it always terminates parent instruction
-    /// We either have to make it possible to change that behavior or add an instruction to manually set the status
     Error,
 }
 

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -531,6 +531,7 @@ mod test {
             Just(ProposalState::Voting),
             Just(ProposalState::Succeeded),
             Just(ProposalState::Executing),
+            Just(ProposalState::ExecutingWithErrors),
             Just(ProposalState::Completed),
             Just(ProposalState::Cancelled),
             Just(ProposalState::Defeated),
@@ -571,6 +572,7 @@ mod test {
             Just(ProposalState::Voting),
             Just(ProposalState::Succeeded),
             Just(ProposalState::Executing),
+            Just(ProposalState::ExecutingWithErrors),
             Just(ProposalState::Completed),
             Just(ProposalState::Cancelled),
             Just(ProposalState::Defeated),
@@ -616,6 +618,7 @@ mod test {
         prop_oneof![
             Just(ProposalState::Succeeded),
             Just(ProposalState::Executing),
+            Just(ProposalState::ExecutingWithErrors),
             Just(ProposalState::Completed),
             Just(ProposalState::Cancelled),
             Just(ProposalState::Defeated),

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -10,8 +10,8 @@ use crate::{
     error::GovernanceError,
     state::{
         enums::{
-            GovernanceAccountType, InstructionExecutionFlags, ProposalState,
-            VoteThresholdPercentage,
+            GovernanceAccountType, InstructionExecutionFlags, InstructionExecutionStatus,
+            ProposalState, VoteThresholdPercentage,
         },
         governance::GovernanceConfig,
         proposal_instruction::ProposalInstruction,
@@ -119,6 +119,7 @@ impl Proposal {
         match self.state {
             ProposalState::Draft | ProposalState::SigningOff => Ok(()),
             ProposalState::Executing
+            | ProposalState::ExecutingWithErrors
             | ProposalState::Completed
             | ProposalState::Cancelled
             | ProposalState::Voting
@@ -279,6 +280,7 @@ impl Proposal {
         match self.state {
             ProposalState::Draft | ProposalState::SigningOff | ProposalState::Voting => Ok(()),
             ProposalState::Executing
+            | ProposalState::ExecutingWithErrors
             | ProposalState::Completed
             | ProposalState::Cancelled
             | ProposalState::Succeeded
@@ -301,7 +303,9 @@ impl Proposal {
         current_unix_timestamp: UnixTimestamp,
     ) -> Result<(), ProgramError> {
         match self.state {
-            ProposalState::Succeeded | ProposalState::Executing => {}
+            ProposalState::Succeeded
+            | ProposalState::Executing
+            | ProposalState::ExecutingWithErrors => {}
             ProposalState::Draft
             | ProposalState::SigningOff
             | ProposalState::Completed
@@ -324,6 +328,22 @@ impl Proposal {
 
         if proposal_instruction_data.executed_at.is_some() {
             return Err(GovernanceError::InstructionAlreadyExecuted.into());
+        }
+
+        Ok(())
+    }
+
+    /// Checks if the instruction can be flagged with error for the Proposal in the given state
+    pub fn assert_can_flag_instruction_error(
+        &self,
+        proposal_instruction_data: &ProposalInstruction,
+        current_unix_timestamp: UnixTimestamp,
+    ) -> Result<(), ProgramError> {
+        // Instruction can be flagged for error only when it's eligible for execution
+        self.assert_can_execute_instruction(proposal_instruction_data, current_unix_timestamp)?;
+
+        if proposal_instruction_data.execution_status == InstructionExecutionStatus::Error {
+            return Err(GovernanceError::InstructionAlreadyFlaggedWithError.into());
         }
 
         Ok(())

--- a/governance/program/src/state/proposal_instruction.rs
+++ b/governance/program/src/state/proposal_instruction.rs
@@ -101,7 +101,6 @@ pub struct ProposalInstruction {
     pub executed_at: Option<UnixTimestamp>,
 
     /// Instruction execution status
-    /// Note: The field is not used in the current version
     pub execution_status: InstructionExecutionStatus,
 }
 

--- a/governance/program/tests/process_flag_instruction_error.rs
+++ b/governance/program/tests/process_flag_instruction_error.rs
@@ -179,7 +179,7 @@ async fn test_execute_instruction_after_flagged_with_error() {
 }
 
 #[tokio::test]
-async fn test_execute_instruction_after_first_instruction_flagged_with_error() {
+async fn test_execute_second_instruction_after_first_instruction_flagged_with_error() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
@@ -340,7 +340,7 @@ async fn test_flag_instruction_error_with_instruction_already_executed_error() {
 }
 
 #[tokio::test]
-async fn test_flag_instruction_error_with_with_owner_or_delegate_must_sign_error() {
+async fn test_flag_instruction_error_with_owner_or_delegate_must_sign_error() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 

--- a/governance/program/tests/process_flag_instruction_error.rs
+++ b/governance/program/tests/process_flag_instruction_error.rs
@@ -1,0 +1,406 @@
+#![cfg(feature = "test-bpf")]
+
+mod program_test;
+
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    program_error::ProgramError,
+    sysvar::{clock, fees},
+};
+use solana_program_test::tokio;
+
+use program_test::*;
+use spl_governance::{
+    error::GovernanceError,
+    instruction::Vote,
+    state::enums::{InstructionExecutionStatus, ProposalState},
+};
+
+#[tokio::test]
+async fn test_execute_flag_instruction_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let mut account_governance_cookie = governance_test
+        .with_account_governance(&realm_cookie, &governed_account_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await;
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut account_governance_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_instruction_cookie = governance_test
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .await
+        .unwrap();
+
+    // Advance timestamp past hold_up_time
+    governance_test
+        .advance_clock_by_min_timespan(proposal_instruction_cookie.account.hold_up_time as u64)
+        .await;
+
+    let clock = governance_test.get_clock().await;
+
+    // Act
+    governance_test
+        .flag_instruction_error(
+            &proposal_cookie,
+            &token_owner_record_cookie,
+            &proposal_instruction_cookie,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(0, proposal_account.instructions_executed_count);
+    assert_eq!(ProposalState::ExecutingWithErrors, proposal_account.state);
+    assert_eq!(None, proposal_account.closed_at);
+    assert_eq!(Some(clock.unix_timestamp), proposal_account.executing_at);
+
+    let proposal_instruction_account = governance_test
+        .get_proposal_instruction_account(&proposal_instruction_cookie.address)
+        .await;
+
+    assert_eq!(None, proposal_instruction_account.executed_at);
+
+    assert_eq!(
+        InstructionExecutionStatus::Error,
+        proposal_instruction_account.execution_status
+    );
+}
+
+#[tokio::test]
+async fn test_execute_instruction_with_invalid_state_errors() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_mint_cookie = governance_test.with_governed_mint().await;
+
+    let mut mint_governance_cookie = governance_test
+        .with_mint_governance(&realm_cookie, &governed_mint_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await;
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut mint_governance_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie1 = governance_test
+        .with_signatory(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie2 = governance_test
+        .with_signatory(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_instruction_cookie = governance_test
+        .with_mint_tokens_instruction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Act
+
+    let err = governance_test
+        .execute_instruction(&proposal_cookie, &proposal_instruction_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::InvalidStateCannotExecuteInstruction.into()
+    );
+
+    // Arrange
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie1)
+        .await
+        .unwrap();
+
+    // Act
+
+    let err = governance_test
+        .execute_instruction(&proposal_cookie, &proposal_instruction_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::InvalidStateCannotExecuteInstruction.into()
+    );
+
+    // Arrange
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie2)
+        .await
+        .unwrap();
+
+    // Act
+
+    let err = governance_test
+        .execute_instruction(&proposal_cookie, &proposal_instruction_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::InvalidStateCannotExecuteInstruction.into()
+    );
+
+    // Arrange
+
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .await
+        .unwrap();
+
+    governance_test.advance_clock().await;
+
+    // Act
+    let err = governance_test
+        .execute_instruction(&proposal_cookie, &proposal_instruction_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::CannotExecuteInstructionWithinHoldUpTime.into()
+    );
+
+    // Arrange
+    // Advance timestamp past hold_up_time
+    governance_test
+        .advance_clock_by_min_timespan(proposal_instruction_cookie.account.hold_up_time as u64)
+        .await;
+
+    // Act
+    governance_test
+        .execute_instruction(&proposal_cookie, &proposal_instruction_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Completed, proposal_account.state);
+
+    // Arrange
+
+    governance_test.advance_clock().await;
+
+    // Act
+    let err = governance_test
+        .execute_instruction(&proposal_cookie, &proposal_instruction_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::InvalidStateCannotExecuteInstruction.into()
+    );
+}
+
+#[tokio::test]
+async fn test_execute_instruction_for_other_proposal_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_mint_cookie = governance_test.with_governed_mint().await;
+
+    let mut mint_governance_cookie = governance_test
+        .with_mint_governance(&realm_cookie, &governed_mint_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await;
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut mint_governance_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_instruction_cookie = governance_test
+        .with_mint_tokens_instruction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            None,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .await
+        .unwrap();
+
+    // Advance clock past hold_up_time
+
+    governance_test
+        .advance_clock_by_min_timespan(proposal_instruction_cookie.account.hold_up_time as u64)
+        .await;
+
+    let proposal_cookie2 = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut mint_governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .execute_instruction(&proposal_cookie2, &proposal_instruction_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::InvalidProposalForProposalInstruction.into()
+    );
+}
+
+#[tokio::test]
+async fn test_execute_mint_instruction_twice_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_mint_cookie = governance_test.with_governed_mint().await;
+
+    let mut mint_governance_cookie = governance_test
+        .with_mint_governance(&realm_cookie, &governed_mint_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await;
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut mint_governance_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_instruction_cookie = governance_test
+        .with_mint_tokens_instruction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            None,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .await
+        .unwrap();
+
+    // Advance clock past hold_up_time
+
+    governance_test
+        .advance_clock_by_min_timespan(proposal_instruction_cookie.account.hold_up_time as u64)
+        .await;
+
+    governance_test
+        .execute_instruction(&proposal_cookie, &proposal_instruction_cookie)
+        .await
+        .unwrap();
+
+    governance_test.advance_clock().await;
+
+    // Act
+
+    let err = governance_test
+        .execute_instruction(&proposal_cookie, &proposal_instruction_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::InstructionAlreadyExecuted.into());
+}

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -28,8 +28,8 @@ use spl_governance::{
         add_signatory, cancel_proposal, cast_vote, create_account_governance,
         create_mint_governance, create_program_governance, create_proposal, create_realm,
         create_token_governance, deposit_governing_tokens, execute_instruction, finalize_vote,
-        insert_instruction, relinquish_vote, remove_instruction, remove_signatory,
-        set_governance_config, set_governance_delegate, sign_off_proposal,
+        flag_instruction_error, insert_instruction, relinquish_vote, remove_instruction,
+        remove_signatory, set_governance_config, set_governance_delegate, sign_off_proposal,
         withdraw_governing_tokens, Vote,
     },
     processor::process_instruction,
@@ -1602,6 +1602,27 @@ impl GovernanceProgramTest {
         );
 
         self.process_transaction(&[execute_instruction_instruction], None)
+            .await
+    }
+
+    #[allow(dead_code)]
+    pub async fn flag_instruction_error(
+        &mut self,
+        proposal_cookie: &ProposalCookie,
+        token_owner_record_cookie: &TokeOwnerRecordCookie,
+        proposal_instruction_cookie: &ProposalInstructionCookie,
+    ) -> Result<(), ProgramError> {
+        let governance_authority = token_owner_record_cookie.get_governance_authority();
+
+        let flag_instruction_error_ix = flag_instruction_error(
+            &self.program_id,
+            &proposal_cookie.address,
+            &proposal_cookie.account.token_owner_record,
+            &governance_authority.pubkey(),
+            &proposal_instruction_cookie.address,
+        );
+
+        self.process_transaction(&[flag_instruction_error_ix], Some(&[&governance_authority]))
             .await
     }
 


### PR DESCRIPTION
#### Implemented instructions:

- `FlagInstructionError` - instruction allows proposal owner (or delegate) to manually flag `ProposalInstruction` and its parent `Proposal` with execution error status. It's required to prevent ghost proposals which could stay indefinitely in `Succeeded` or `Executing` state when one of their instructions couldn't be executed. 

    The flagged error status is information only and doesn't prevent the instruction to be attempted to be executed again when the error condition changes, for example missing governance authority is granted.

  Ideally we shouldn't need this instruction but currently there is no way to catch errors from CPI calls and the `Governance` program has no way to know an instruction failed and flag it automatically. If such an option is implemented at some point in the future this instruction should be removed.