### PR TITLE
stake-pool-cli: Integrate user feedback

### DIFF
--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -164,12 +164,6 @@ fn command_create_pool(
     let mint_keypair = mint_keypair.unwrap_or_else(Keypair::new);
     println!("Creating mint {}", mint_keypair.pubkey());
 
-    let pool_fee_account = Keypair::new();
-    println!(
-        "Creating pool fee collection account {}",
-        pool_fee_account.pubkey()
-    );
-
     let stake_pool_keypair = stake_pool_keypair.unwrap_or_else(Keypair::new);
 
     let validator_list = Keypair::new();
@@ -192,7 +186,7 @@ fn command_create_pool(
     let validator_list_balance = config
         .rpc_client
         .get_minimum_balance_for_rent_exemption(validator_list_size)?;
-    let total_rent_free_balances = reserve_stake_balance
+    let mut total_rent_free_balances = reserve_stake_balance
         + mint_account_balance
         + pool_fee_account_balance
         + stake_pool_account_lamports
@@ -210,58 +204,52 @@ fn command_create_pool(
         println!("Stake pool withdraw authority {}", withdraw_authority);
     }
 
-    let mut setup_transaction = Transaction::new_with_payer(
-        &[
-            // Account for the stake pool reserve
-            system_instruction::create_account(
-                &config.fee_payer.pubkey(),
-                &reserve_keypair.pubkey(),
-                reserve_stake_balance,
-                STAKE_STATE_LEN as u64,
-                &stake_program::id(),
-            ),
-            stake_program::initialize(
-                &reserve_keypair.pubkey(),
-                &stake_program::Authorized {
-                    staker: withdraw_authority,
-                    withdrawer: withdraw_authority,
-                },
-                &stake_program::Lockup::default(),
-            ),
-            // Account for the stake pool mint
-            system_instruction::create_account(
-                &config.fee_payer.pubkey(),
-                &mint_keypair.pubkey(),
-                mint_account_balance,
-                spl_token::state::Mint::LEN as u64,
-                &spl_token::id(),
-            ),
-            // Account for the pool fee accumulation
-            system_instruction::create_account(
-                &config.fee_payer.pubkey(),
-                &pool_fee_account.pubkey(),
-                pool_fee_account_balance,
-                spl_token::state::Account::LEN as u64,
-                &spl_token::id(),
-            ),
-            // Initialize pool token mint account
-            spl_token::instruction::initialize_mint(
-                &spl_token::id(),
-                &mint_keypair.pubkey(),
-                &withdraw_authority,
-                None,
-                default_decimals,
-            )?,
-            // Initialize fee receiver account
-            spl_token::instruction::initialize_account(
-                &spl_token::id(),
-                &pool_fee_account.pubkey(),
-                &mint_keypair.pubkey(),
-                &config.manager.pubkey(),
-            )?,
-        ],
-        Some(&config.fee_payer.pubkey()),
+    let mut instructions = vec![
+        // Account for the stake pool reserve
+        system_instruction::create_account(
+            &config.fee_payer.pubkey(),
+            &reserve_keypair.pubkey(),
+            reserve_stake_balance,
+            STAKE_STATE_LEN as u64,
+            &stake_program::id(),
+        ),
+        stake_program::initialize(
+            &reserve_keypair.pubkey(),
+            &stake_program::Authorized {
+                staker: withdraw_authority,
+                withdrawer: withdraw_authority,
+            },
+            &stake_program::Lockup::default(),
+        ),
+        // Account for the stake pool mint
+        system_instruction::create_account(
+            &config.fee_payer.pubkey(),
+            &mint_keypair.pubkey(),
+            mint_account_balance,
+            spl_token::state::Mint::LEN as u64,
+            &spl_token::id(),
+        ),
+        // Initialize pool token mint account
+        spl_token::instruction::initialize_mint(
+            &spl_token::id(),
+            &mint_keypair.pubkey(),
+            &withdraw_authority,
+            None,
+            default_decimals,
+        )?,
+    ];
+
+    let pool_fee_account = add_associated_token_account(
+        config,
+        &mint_keypair.pubkey(),
+        &config.manager.pubkey(),
+        &mut instructions,
+        &mut total_rent_free_balances,
     );
+    println!("Creating pool fee collection account {}", pool_fee_account);
+
+    let mut setup_transaction =
+        Transaction::new_with_payer(&instructions, Some(&config.fee_payer.pubkey()));
 
     let mut initialize_transaction = Transaction::new_with_payer(
         &[
@@ -290,7 +278,7 @@ fn command_create_pool(
                 &validator_list.pubkey(),
                 &reserve_keypair.pubkey(),
                 &mint_keypair.pubkey(),
-                &pool_fee_account.pubkey(),
+                &pool_fee_account,
                 &spl_token::id(),
                 deposit_authority,
                 fee,
@@ -307,12 +295,7 @@ fn command_create_pool(
             + fee_calculator.calculate_fee(setup_transaction.message())
             + fee_calculator.calculate_fee(initialize_transaction.message()),
     )?;
-    let mut setup_signers = vec![
-        config.fee_payer.as_ref(),
-        &mint_keypair,
-        &pool_fee_account,
-        &reserve_keypair,
-    ];
+    let mut setup_signers = vec![config.fee_payer.as_ref(), &mint_keypair, &reserve_keypair];
     unique_signers!(setup_signers);
     setup_transaction.sign(&setup_signers, recent_blockhash);
     send_transaction(config, setup_transaction)?;
@@ -552,13 +535,14 @@ fn command_set_preferred_validator(
 fn add_associated_token_account(
     config: &Config,
     mint: &Pubkey,
+    owner: &Pubkey,
     instructions: &mut Vec<Instruction>,
     rent_free_balances: &mut u64,
 ) -> Pubkey {
     // Account for tokens not specified, creating one
-    let account = get_associated_token_address(&config.fee_payer.pubkey(), mint);
+    let account = get_associated_token_address(owner, mint);
     if get_token_account(&config.rpc_client, &account, mint).is_err() {
-        println!("Creating associated token account {} to receive stake pool tokens of mint {}, owned by {}", account, mint, config.fee_payer.pubkey());
+        println!("Creating associated token account {} to receive stake pool tokens of mint {}, owned by {}", account, mint, owner);
 
         let min_account_balance = config
             .rpc_client
@@ -567,13 +551,13 @@ fn add_associated_token_account(
 
         instructions.push(create_associated_token_account(
             &config.fee_payer.pubkey(),
-            &config.fee_payer.pubkey(),
+            owner,
             mint,
         ));
 
         *rent_free_balances += min_account_balance;
     } else {
-        println!("Using existing associated token account {} to receive stake pool tokens of mint {}, owned by {}", account, mint, config.fee_payer.pubkey());
+        println!("Using existing associated token account {} to receive stake pool tokens of mint {}, owned by {}", account, mint, owner);
     }
 
     account
@@ -628,6 +612,7 @@ fn command_deposit(
     let token_receiver = token_receiver.unwrap_or(add_associated_token_account(
         config,
         &stake_pool.pool_mint,
+        &config.token_owner.pubkey(),
         &mut instructions,
         &mut total_rent_free_balances,
     ));
@@ -697,12 +682,27 @@ fn command_list(config: &Config, stake_pool_address: &Pubkey) -> CommandResult {
     let validator_list = get_validator_list(&config.rpc_client, &stake_pool.validator_list)?;
     let pool_mint = get_token_mint(&config.rpc_client, &stake_pool.pool_mint)?;
     let epoch_info = config.rpc_client.get_epoch_info()?;
+    let pool_withdraw_authority =
+        find_withdraw_authority_program_address(&spl_stake_pool::id(), stake_pool_address).0;
+
+    println!("Stake Pool: {}", stake_pool_address);
+    println!("Validator List: {}", stake_pool.validator_list);
+    println!("Manager: {}", stake_pool.manager);
+    println!("Staker: {}", stake_pool.staker);
+    println!("Depositor: {}", stake_pool.deposit_authority);
+    println!("Withdraw Authority: {}", pool_withdraw_authority);
+    println!("Pool Token Mint: {}", stake_pool.pool_mint);
+    println!("Fee Account: {}", stake_pool.manager_fee_account);
 
     let reserve_stake = config.rpc_client.get_account(&stake_pool.reserve_stake)?;
+    let minimum_reserve_stake_balance = config
+        .rpc_client
+        .get_minimum_balance_for_rent_exemption(STAKE_STATE_LEN)?
+        + 1;
     println!(
-        "Reserve Account: {}\tBalance: {}",
+        "Reserve Account: {}\tAvailable Balance: {}",
         stake_pool.reserve_stake,
-        Sol(reserve_stake.lamports),
+        Sol(reserve_stake.lamports - minimum_reserve_stake_balance),
     );
 
     for validator in &validator_list.validators {
@@ -744,9 +744,6 @@ fn command_list(config: &Config, stake_pool_address: &Pubkey) -> CommandResult {
     if config.verbose {
         println!();
 
-        let pool_withdraw_authority =
-            find_withdraw_authority_program_address(&spl_stake_pool::id(), stake_pool_address).0;
-
         let accounts =
             get_stake_accounts_by_withdraw_authority(&config.rpc_client, &pool_withdraw_authority)?;
         if accounts.is_empty() {
@@ -759,7 +756,7 @@ fn command_list(config: &Config, stake_pool_address: &Pubkey) -> CommandResult {
             println!(
                 "Stake Account: {}\tVote Account: {}\t{}",
                 pubkey,
-                stake_state.delegation().expect("delegation").voter_pubkey,
+                stake_state.delegation().map(|x| x.voter_pubkey.to_string()).unwrap_or("undelegated".to_owned()),
                 Sol(stake_lamports)
             );
         }
@@ -920,7 +917,7 @@ fn command_withdraw(
         find_withdraw_authority_program_address(&spl_stake_pool::id(), stake_pool_address).0;
 
     let pool_token_account = pool_token_account.unwrap_or(get_associated_token_address(
-        &config.fee_payer.pubkey(),
+        &config.token_owner.pubkey(),
         &stake_pool.pool_mint,
     ));
     let token_account = get_token_account(


### PR DESCRIPTION
#### Problem

We had some user feedback, issues with identifying information about the pool, including accounts used / required, and the pool fee account.

#### Solution

* Add more output for `list` command, `-v` gives more info
* Default to the manager's associated token account when creating a pool

New output for list:
```
Stake Pool: tppRnkEWouTxXoLVXDPMJ6V5rTYWYaQ7qWsJ3E6YfkA
Pool Token Mint: tpmg27ULGHUnCFVaDhiTrPErCh7kg9JGcN2jVTkhpcN
Fee: none
Reserve Account: tprLWb21rTvUTX7CSTNgfxz2jgwooNayoN1ken2F7H4    Available Balance: ◎22000.000000000
Vote Account: AYHQTpjHsCEaSboz2vL5tUKiP8t4a2khgLp3TASXVvP8      Balance: ◎0.000000000   Last Update Epoch: 210
Total Pool Stake: ◎22000.000000000
Total Pool Tokens: 22000
Current Number of Validators: 1
Max Number of Validators: 4000
```

New output for list -v:
```
Stake Pool Info
===============
Stake Pool: tppRnkEWouTxXoLVXDPMJ6V5rTYWYaQ7qWsJ3E6YfkA
Validator List: BxXUNLs1nayKRKkPkdemLEzgAiRk39o2ubQnLHuKmNRz
Manager: tpsLEGaJcaMoz2L3XxoUvWeyBCFNajdNpWPyRi5PaY6
Staker: tpsLEGaJcaMoz2L3XxoUvWeyBCFNajdNpWPyRi5PaY6
Depositor: tpsLEGaJcaMoz2L3XxoUvWeyBCFNajdNpWPyRi5PaY6
Withdraw Authority: 8jUkVNYwjEARDEERm6YTU97RQvgKwnCKsgGBDCRxAsch
Pool Token Mint: tpmg27ULGHUnCFVaDhiTrPErCh7kg9JGcN2jVTkhpcN
Fee Account: FjmB7MUPUspruS6WE3aNYGYFxtFPgVm4ZyfL46MZDLMx
Fee: none

Stake Accounts
--------------
Reserve Account: tprLWb21rTvUTX7CSTNgfxz2jgwooNayoN1ken2F7H4    Available Balance: ◎22000.000000000
Vote Account: AYHQTpjHsCEaSboz2vL5tUKiP8t4a2khgLp3TASXVvP8      Stake Account: 8nkEYC8JvPLxHfbcknQ5W9f1rxyb67uaorFp3Zr1eq3N        Active Balance: ◎0.000000000    Transient Stake Account: 5RgJVJjoiXcg98PoD7WTFGekn5nqMTCi1xVw6639QH9P      Transient Balance: ◎0.000000000 Last Update Epoch: 210

Total Pool Stake: ◎22000.000000000
Total Pool Tokens: 22000
Current Number of Validators: 1
Max Number of Validators: 4000
```