### PR TITLE
fix stake pool corner divide by 0 case

### DIFF
--- a/stake-pool/program/src/state.rs
+++ b/stake-pool/program/src/state.rs
@@ -136,6 +136,11 @@ impl StakePool {
         if self.fee.denominator == 0 || reward_lamports == 0 {
             return Some(0);
         }
+        // If by chance the reserve account has lamports > 0 even though
+        // total_stake_lamports == 0, we credit it entirely to the manager.
+        if self.total_stake_lamports == 0 || self.pool_token_supply == 0 {
+            return Some(reward_lamports);
+        }
         let total_stake_lamports =
             (self.total_stake_lamports as u128).checked_add(reward_lamports as u128)?;
         let fee_lamports = (reward_lamports as u128)


### PR DESCRIPTION
There is  a bug where you can cause the update function to perpetually fail via a divide by zero error.

This occurs when  rewards > 0, manager_fee = 100% and total_staked_lamports is 0. Which can be triggered when SOL is directly transferred to reserve account before the pool has received any stake, and following which, update is called.

I guess it is a rather benign scenario as no funds will be harmed except the "attacker's". But this stake pool will be rendered useless.

The correct behaviour when `rewards > 0` and `total_staked_lamports = 0 || total_staked_lamports = 0` is to mint all of the tokens to the manager, regardless of the fee. 

This is consistent with what is done in
```rust
pub fn calc_pool_tokens_for_deposit(&self, stake_lamports: u64) -> Option<u64> {
        if self.total_stake_lamports == 0 || self.pool_token_supply == 0 {
            return Some(stake_lamports);
        }
```

You can check that after this change, there is no possibility whatsover of dividing by 0 in the function.