### PR TITLE
stake-pool: Update pool token supply on update, in case of burns

### DIFF
--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -1621,6 +1621,10 @@ impl Processor {
         }
         stake_pool.total_stake_lamports = total_stake_lamports;
         stake_pool.last_update_epoch = clock.epoch;
+
+        let pool_mint = Mint::unpack_from_slice(&pool_mint_info.data.borrow())?;
+        stake_pool.pool_token_supply = pool_mint.supply;
+
         stake_pool.serialize(&mut *stake_pool_info.data.borrow_mut())?;
 
         Ok(())


### PR DESCRIPTION
#### Problem

People can burn pool tokens on their own, but the pool doesn't take those into account when figuring the fair value of pool tokens.

#### Solution

During the update phase, also update the pool token supply.