### PR TITLE
rework fees to be u32

### DIFF
--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -1813,8 +1813,8 @@ fn main() {
     let _ = match matches.subcommand() {
         ("create-pool", Some(arg_matches)) => {
             let deposit_authority = pubkey_of(arg_matches, "deposit_authority");
-            let numerator = value_t_or_exit!(arg_matches, "fee_numerator", u64);
-            let denominator = value_t_or_exit!(arg_matches, "fee_denominator", u64);
+            let numerator = value_t_or_exit!(arg_matches, "fee_numerator", u32);
+            let denominator = value_t_or_exit!(arg_matches, "fee_denominator", u32);
             let max_validators = value_t_or_exit!(arg_matches, "max_validators", u32);
             let pool_keypair = keypair_of(arg_matches, "pool_keypair");
             let mint_keypair = keypair_of(arg_matches, "mint_keypair");
@@ -1934,8 +1934,8 @@ fn main() {
         }
         ("set-fee", Some(arg_matches)) => {
             let stake_pool_address = pubkey_of(arg_matches, "pool").unwrap();
-            let numerator = value_t_or_exit!(arg_matches, "fee_numerator", u64);
-            let denominator = value_t_or_exit!(arg_matches, "fee_denominator", u64);
+            let numerator = value_t_or_exit!(arg_matches, "fee_numerator", u32);
+            let denominator = value_t_or_exit!(arg_matches, "fee_denominator", u32);
             let new_fee = Fee {
                 denominator,
                 numerator,

--- a/stake-pool/program/src/state.rs
+++ b/stake-pool/program/src/state.rs
@@ -529,9 +529,9 @@ impl ValidatorListHeader {
 #[derive(Clone, Copy, Debug, Default, PartialEq, BorshSerialize, BorshDeserialize, BorshSchema)]
 pub struct Fee {
     /// denominator of the fee ratio
-    pub denominator: u64,
+    pub denominator: u32,
     /// numerator of the fee ratio
-    pub numerator: u64,
+    pub numerator: u32,
 }
 
 #[cfg(test)]
@@ -706,8 +706,8 @@ mod test {
         fn fee()(denominator in 1..=u16::MAX)(
             denominator in Just(denominator),
             numerator in 0..=denominator,
-        ) -> (u64, u64) {
-            (numerator as u64, denominator as u64)
+        ) -> (u32, u32) {
+            (numerator as u32, denominator as u32)
         }
     }
 

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -566,7 +566,7 @@ impl StakePoolAccounts {
     }
 
     pub fn calculate_fee(&self, amount: u64) -> u64 {
-        amount * self.fee.numerator / self.fee.denominator
+        amount * self.fee.numerator as u64 / self.fee.denominator as u64
     }
 
     pub async fn initialize_stake_pool(

--- a/stake-pool/program/tests/update_stake_pool_balance.rs
+++ b/stake-pool/program/tests/update_stake_pool_balance.rs
@@ -146,8 +146,8 @@ async fn success() {
     .await;
     assert_eq!(pool_token_supply - pre_token_supply, actual_fee);
 
-    let expected_fee_lamports =
-        (post_balance - pre_balance) * stake_pool.fee.numerator as u64 / stake_pool.fee.denominator as u64;
+    let expected_fee_lamports = (post_balance - pre_balance) * stake_pool.fee.numerator as u64
+        / stake_pool.fee.denominator as u64;
     let actual_fee_lamports = stake_pool.calc_pool_tokens_for_deposit(actual_fee).unwrap();
     assert_eq!(actual_fee_lamports, expected_fee_lamports);
 

--- a/stake-pool/program/tests/update_stake_pool_balance.rs
+++ b/stake-pool/program/tests/update_stake_pool_balance.rs
@@ -147,7 +147,7 @@ async fn success() {
     assert_eq!(pool_token_supply - pre_token_supply, actual_fee);
 
     let expected_fee_lamports =
-        (post_balance - pre_balance) * stake_pool.fee.numerator / stake_pool.fee.denominator;
+        (post_balance - pre_balance) * stake_pool.fee.numerator as u64 / stake_pool.fee.denominator as u64;
     let actual_fee_lamports = stake_pool.calc_pool_tokens_for_deposit(actual_fee).unwrap();
     assert_eq!(actual_fee_lamports, expected_fee_lamports);
 


### PR DESCRIPTION
The restriction makes arithmetic easier to handle

Fees don't really need more than 6, let alone 9 digits of precision

Discussion: https://github.com/solana-labs/solana-program-library/pull/2107#discussion_r672628739