### PR TITLE
Governance: Use separate thresholds to create proposals for council and community tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3730,7 +3730,7 @@ dependencies = [
 
 [[package]]
 name = "spl-governance"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "arrayref",
  "assert_matches",

--- a/governance/program/Cargo.toml
+++ b/governance/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-governance"
-version = "1.0.3"
+version = "1.0.4"
 description = "Solana Program Library Governance Program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -279,6 +279,10 @@ pub enum GovernanceError {
     /// Instruction already flagged with error
     #[error("Instruction already flagged with error")]
     InstructionAlreadyFlaggedWithError,
+
+    /// Invalid Realm for Governance
+    #[error("Invalid Realm for Governance")]
+    InvalidRealmForGovernance,
 }
 
 impl PrintProgramError for GovernanceError {

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -670,7 +670,7 @@ pub fn create_proposal(
     program_id: &Pubkey,
     // Accounts
     governance: &Pubkey,
-    governing_token_owner: &Pubkey,
+    governing_token_owner_record: &Pubkey,
     governance_authority: &Pubkey,
     payer: &Pubkey,
     // Args
@@ -686,18 +686,12 @@ pub fn create_proposal(
         governing_token_mint,
         &proposal_index.to_le_bytes(),
     );
-    let token_owner_record_address = get_token_owner_record_address(
-        program_id,
-        realm,
-        governing_token_mint,
-        governing_token_owner,
-    );
 
     let accounts = vec![
         AccountMeta::new_readonly(*realm, false),
         AccountMeta::new(proposal_address, false),
         AccountMeta::new(*governance, false),
-        AccountMeta::new_readonly(token_owner_record_address, false),
+        AccountMeta::new_readonly(*governing_token_owner_record, false),
         AccountMeta::new_readonly(*governance_authority, true),
         AccountMeta::new_readonly(*payer, true),
         AccountMeta::new_readonly(system_program::id(), false),

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -137,14 +137,15 @@ pub enum GovernanceInstruction {
 
     /// Creates Proposal account for Instructions that will be executed at some point in the future
     ///
-    ///   0. `[writable]` Proposal account. PDA seeds ['governance',governance, governing_token_mint, proposal_index]
-    ///   1. `[writable]` Governance account
-    ///   2. `[]` TokenOwnerRecord account for Proposal owner
-    ///   3. `[signer]` Governance Authority (Token Owner or Governance Delegate)
-    ///   4. `[signer]` Payer
-    ///   5. `[]` System program
-    ///   6. `[]` Rent sysvar
-    ///   7. `[]` Clock sysvar
+    ///   0. `[]` Realm account the created Proposal belongs to
+    ///   1. `[writable]` Proposal account. PDA seeds ['governance',governance, governing_token_mint, proposal_index]
+    ///   2. `[writable]` Governance account
+    ///   3. `[]` TokenOwnerRecord account for Proposal owner
+    ///   4. `[signer]` Governance Authority (Token Owner or Governance Delegate)
+    ///   5. `[signer]` Payer
+    ///   6. `[]` System program
+    ///   7. `[]` Rent sysvar
+    ///   8. `[]` Clock sysvar
     CreateProposal {
         #[allow(dead_code)]
         /// UTF-8 encoded name of the proposal
@@ -693,6 +694,7 @@ pub fn create_proposal(
     );
 
     let accounts = vec![
+        AccountMeta::new_readonly(*realm, false),
         AccountMeta::new(proposal_address, false),
         AccountMeta::new(*governance, false),
         AccountMeta::new_readonly(token_owner_record_address, false),

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -484,7 +484,8 @@ mod test {
 
     fn create_test_governance_config() -> GovernanceConfig {
         GovernanceConfig {
-            min_tokens_to_create_proposal: 5,
+            min_community_tokens_to_create_proposal: 5,
+            min_council_tokens_to_create_proposal: 1,
             min_instruction_hold_up_time: 10,
             max_voting_time: 5,
             vote_threshold_percentage: VoteThresholdPercentage::YesVote(60),

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -77,6 +77,19 @@ pub fn get_realm_data(
     get_account_data::<Realm>(realm_info, program_id)
 }
 
+/// Deserializes Ream account and asserts the given governing_token_mint is either Community or Council mint of the Realm
+pub fn get_realm_data_for_governing_token_mint(
+    program_id: &Pubkey,
+    realm_info: &AccountInfo,
+    governing_token_mint: &Pubkey,
+) -> Result<Realm, ProgramError> {
+    let realm_data = get_realm_data(program_id, realm_info)?;
+
+    realm_data.assert_is_valid_governing_token_mint(governing_token_mint)?;
+
+    Ok(realm_data)
+}
+
 /// Returns Realm PDA seeds
 pub fn get_realm_address_seeds(name: &str) -> [&[u8]; 2] {
     [PROGRAM_AUTHORITY_SEED, name.as_bytes()]

--- a/governance/program/src/state/token_owner_record.rs
+++ b/governance/program/src/state/token_owner_record.rs
@@ -2,11 +2,10 @@
 
 use crate::{
     error::GovernanceError,
+    state::{enums::GovernanceAccountType, governance::GovernanceConfig, realm::Realm},
     tools::account::{get_account_data, AccountMaxSize},
     PROGRAM_AUTHORITY_SEED,
 };
-
-use crate::state::enums::GovernanceAccountType;
 
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use solana_program::{
@@ -84,6 +83,35 @@ impl TokenOwnerRecord {
 
         Err(GovernanceError::GoverningTokenOwnerOrDelegateMustSign.into())
     }
+
+    /// Asserts TokenOwner has enough tokens to be allowed to create proposal
+    pub fn assert_can_create_proposal(
+        &self,
+        realm_data: &Realm,
+        config: &GovernanceConfig,
+    ) -> Result<(), ProgramError> {
+        if realm_data.community_mint == self.governing_token_mint {
+            if self.governing_token_deposit_amount
+                < config.min_community_tokens_to_create_proposal as u64
+            {
+                return Err(GovernanceError::NotEnoughTokensToCreateProposal.into());
+            }
+
+            return Ok(());
+        }
+
+        if realm_data.council_mint == Some(self.governing_token_mint) {
+            if self.governing_token_deposit_amount
+                < config.min_council_tokens_to_create_proposal as u64
+            {
+                return Err(GovernanceError::NotEnoughTokensToCreateProposal.into());
+            }
+
+            return Ok(());
+        }
+
+        return Err(GovernanceError::NotEnoughTokensToCreateProposal.into());
+    }
 }
 
 /// Returns TokenOwnerRecord PDA address
@@ -138,21 +166,33 @@ pub fn get_token_owner_record_data_for_seeds(
     get_token_owner_record_data(program_id, token_owner_record_info)
 }
 
-/// Deserializes TokenOwnerRecord account and checks that its PDA matches the given realm and governing mint
+/// Deserializes TokenOwnerRecord account and asserts it belongs to the given realm
+pub fn get_token_owner_record_data_for_realm(
+    program_id: &Pubkey,
+    token_owner_record_info: &AccountInfo,
+    realm: &Pubkey,
+) -> Result<TokenOwnerRecord, ProgramError> {
+    let token_owner_record_data = get_token_owner_record_data(program_id, token_owner_record_info)?;
+
+    if token_owner_record_data.realm != *realm {
+        return Err(GovernanceError::InvalidRealmForTokenOwnerRecord.into());
+    }
+
+    Ok(token_owner_record_data)
+}
+
+/// Deserializes TokenOwnerRecord account and  asserts it belongs to the given realm and is for the given governing mint
 pub fn get_token_owner_record_data_for_realm_and_governing_mint(
     program_id: &Pubkey,
     token_owner_record_info: &AccountInfo,
     realm: &Pubkey,
     governing_token_mint: &Pubkey,
 ) -> Result<TokenOwnerRecord, ProgramError> {
-    let token_owner_record_data = get_token_owner_record_data(program_id, token_owner_record_info)?;
+    let token_owner_record_data =
+        get_token_owner_record_data_for_realm(program_id, token_owner_record_info, realm)?;
 
     if token_owner_record_data.governing_token_mint != *governing_token_mint {
         return Err(GovernanceError::InvalidGoverningMintForTokenOwnerRecord.into());
-    }
-
-    if token_owner_record_data.realm != *realm {
-        return Err(GovernanceError::InvalidRealmForTokenOwnerRecord.into());
     }
 
     Ok(token_owner_record_data)

--- a/governance/program/src/state/token_owner_record.rs
+++ b/governance/program/src/state/token_owner_record.rs
@@ -90,27 +90,20 @@ impl TokenOwnerRecord {
         realm_data: &Realm,
         config: &GovernanceConfig,
     ) -> Result<(), ProgramError> {
-        if realm_data.community_mint == self.governing_token_mint {
-            if self.governing_token_deposit_amount
-                < config.min_community_tokens_to_create_proposal as u64
-            {
-                return Err(GovernanceError::NotEnoughTokensToCreateProposal.into());
-            }
+        let min_tokens_to_create_proposal =
+            if self.governing_token_mint == realm_data.community_mint {
+                config.min_community_tokens_to_create_proposal
+            } else if Some(self.governing_token_mint) == realm_data.council_mint {
+                config.min_council_tokens_to_create_proposal
+            } else {
+                return Err(GovernanceError::InvalidGoverningTokenMint.into());
+            };
 
-            return Ok(());
+        if self.governing_token_deposit_amount < min_tokens_to_create_proposal {
+            return Err(GovernanceError::NotEnoughTokensToCreateProposal.into());
         }
 
-        if realm_data.council_mint == Some(self.governing_token_mint) {
-            if self.governing_token_deposit_amount
-                < config.min_council_tokens_to_create_proposal as u64
-            {
-                return Err(GovernanceError::NotEnoughTokensToCreateProposal.into());
-            }
-
-            return Ok(());
-        }
-
-        return Err(GovernanceError::NotEnoughTokensToCreateProposal.into());
+        Ok(())
     }
 }
 

--- a/governance/program/tests/process_create_proposal.rs
+++ b/governance/program/tests/process_create_proposal.rs
@@ -193,7 +193,7 @@ async fn test_create_proposal_with_not_enough_tokens_error() {
     let token_amount = account_governance_cookie
         .account
         .config
-        .min_tokens_to_create_proposal as u64
+        .min_community_tokens_to_create_proposal as u64
         - 1;
 
     let token_owner_record_cookie = governance_test
@@ -239,7 +239,7 @@ async fn test_create_proposal_with_invalid_token_owner_record_error() {
             &mut account_governance_cookie,
             |i| {
                 // Set token_owner_record_address for different (Council) mint
-                i.accounts[2] =
+                i.accounts[3] =
                     AccountMeta::new_readonly(council_token_owner_record_cookie.address, false);
             },
         )
@@ -250,6 +250,6 @@ async fn test_create_proposal_with_invalid_token_owner_record_error() {
     // Assert
     assert_eq!(
         err,
-        GovernanceError::InvalidGoverningMintForTokenOwnerRecord.into()
+        GovernanceError::GoverningTokenOwnerOrDelegateMustSign.into()
     );
 }

--- a/governance/program/tests/process_create_proposal.rs
+++ b/governance/program/tests/process_create_proposal.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "test-bpf")]
 
-use solana_program::instruction::AccountMeta;
+use solana_program::{instruction::AccountMeta, pubkey::Pubkey};
 use solana_program_test::*;
 
 mod program_test;
@@ -10,7 +10,7 @@ use solana_sdk::signature::Keypair;
 use spl_governance::error::GovernanceError;
 
 #[tokio::test]
-async fn test_community_proposal_created() {
+async fn test_create_community_proposal() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
@@ -47,7 +47,7 @@ async fn test_community_proposal_created() {
 }
 
 #[tokio::test]
-async fn test_multiple_proposals_created() {
+async fn test_create_multiple_proposals() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
@@ -178,7 +178,7 @@ async fn test_create_proposal_with_governance_delegate_signer() {
 }
 
 #[tokio::test]
-async fn test_create_proposal_with_not_enough_tokens_error() {
+async fn test_create_proposal_with_not_enough_community_tokens_error() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
@@ -190,6 +190,7 @@ async fn test_create_proposal_with_not_enough_tokens_error() {
         .await
         .unwrap();
 
+    // Set token deposit amount below the required threshold
     let token_amount = account_governance_cookie
         .account
         .config
@@ -198,6 +199,41 @@ async fn test_create_proposal_with_not_enough_tokens_error() {
 
     let token_owner_record_cookie = governance_test
         .with_community_token_deposit_amount(&realm_cookie, token_amount)
+        .await;
+
+    // Act
+    let err = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut account_governance_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::NotEnoughTokensToCreateProposal.into());
+}
+
+#[tokio::test]
+async fn test_create_proposal_with_not_enough_council_tokens_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let mut account_governance_cookie = governance_test
+        .with_account_governance(&realm_cookie, &governed_account_cookie)
+        .await
+        .unwrap();
+
+    // Set token deposit amount below the required threshold
+    let token_amount = account_governance_cookie
+        .account
+        .config
+        .min_council_tokens_to_create_proposal as u64
+        - 1;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit_amount(&realm_cookie, token_amount)
         .await;
 
     // Act
@@ -251,5 +287,136 @@ async fn test_create_proposal_with_invalid_token_owner_record_error() {
     assert_eq!(
         err,
         GovernanceError::GoverningTokenOwnerOrDelegateMustSign.into()
+    );
+}
+
+#[tokio::test]
+async fn test_create_proposal_with_invalid_governing_token_mint_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let mut account_governance_cookie = governance_test
+        .with_account_governance(&realm_cookie, &governed_account_cookie)
+        .await
+        .unwrap();
+
+    let mut token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await;
+
+    // Try to use mint which  doesn't belong to the Realm
+    token_owner_record_cookie.account.governing_token_mint = Pubkey::new_unique();
+
+    // Act
+    let err = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut account_governance_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::InvalidGoverningTokenMint.into());
+}
+
+#[tokio::test]
+async fn test_create_community_proposal_using_council_tokens() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let mut account_governance_cookie = governance_test
+        .with_account_governance(&realm_cookie, &governed_account_cookie)
+        .await
+        .unwrap();
+
+    let mut community_token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await;
+
+    let council_token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await;
+
+    // Change the proposal owner to council token owner
+    community_token_owner_record_cookie.address = council_token_owner_record_cookie.address;
+    community_token_owner_record_cookie.token_owner = council_token_owner_record_cookie.token_owner;
+
+    // Act
+    let proposal_cookie = governance_test
+        .with_proposal(
+            &community_token_owner_record_cookie,
+            &mut account_governance_cookie,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(
+        realm_cookie.account.community_mint,
+        proposal_account.governing_token_mint
+    );
+
+    assert_eq!(
+        council_token_owner_record_cookie.address,
+        proposal_account.token_owner_record
+    );
+}
+
+#[tokio::test]
+async fn test_create_council_proposal_using_community_tokens() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let mut account_governance_cookie = governance_test
+        .with_account_governance(&realm_cookie, &governed_account_cookie)
+        .await
+        .unwrap();
+
+    let mut council_token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await;
+
+    let community_token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await;
+
+    // Change the proposal owner to community token owner
+    council_token_owner_record_cookie.address = community_token_owner_record_cookie.address;
+    council_token_owner_record_cookie.token_owner = community_token_owner_record_cookie.token_owner;
+
+    // Act
+    let proposal_cookie = governance_test
+        .with_proposal(
+            &council_token_owner_record_cookie,
+            &mut account_governance_cookie,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(
+        realm_cookie.account.council_mint.unwrap(),
+        proposal_account.governing_token_mint
+    );
+
+    assert_eq!(
+        community_token_owner_record_cookie.address,
+        proposal_account.token_owner_record
     );
 }

--- a/governance/program/tests/process_create_proposal.rs
+++ b/governance/program/tests/process_create_proposal.rs
@@ -248,7 +248,7 @@ async fn test_create_proposal_with_not_enough_council_tokens_error() {
 }
 
 #[tokio::test]
-async fn test_create_proposal_with_invalid_token_owner_record_error() {
+async fn test_create_proposal_with_owner_or_delegate_must_sign_error() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -642,7 +642,8 @@ impl GovernanceProgramTest {
 
     pub fn get_default_governance_config(&mut self) -> GovernanceConfig {
         GovernanceConfig {
-            min_tokens_to_create_proposal: 5,
+            min_community_tokens_to_create_proposal: 5,
+            min_council_tokens_to_create_proposal: 1,
             min_instruction_hold_up_time: 10,
             max_voting_time: 10,
             vote_threshold_percentage: VoteThresholdPercentage::YesVote(60),

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -314,6 +314,21 @@ impl GovernanceProgramTest {
     }
 
     #[allow(dead_code)]
+    pub async fn with_council_token_deposit_amount(
+        &mut self,
+        realm_cookie: &RealmCookie,
+        amount: u64,
+    ) -> TokeOwnerRecordCookie {
+        self.with_initial_governing_token_deposit(
+            &realm_cookie.address,
+            &realm_cookie.account.council_mint.unwrap(),
+            &realm_cookie.council_mint_authority.as_ref().unwrap(),
+            amount,
+        )
+        .await
+    }
+
+    #[allow(dead_code)]
     pub async fn with_council_token_deposit(
         &mut self,
         realm_cookie: &RealmCookie,
@@ -643,7 +658,7 @@ impl GovernanceProgramTest {
     pub fn get_default_governance_config(&mut self) -> GovernanceConfig {
         GovernanceConfig {
             min_community_tokens_to_create_proposal: 5,
-            min_council_tokens_to_create_proposal: 1,
+            min_council_tokens_to_create_proposal: 2,
             min_instruction_hold_up_time: 10,
             max_voting_time: 10,
             vote_threshold_percentage: VoteThresholdPercentage::YesVote(60),
@@ -1022,7 +1037,7 @@ impl GovernanceProgramTest {
         let mut create_proposal_instruction = create_proposal(
             &self.program_id,
             &governance_cookie.address,
-            &token_owner_record_cookie.token_owner.pubkey(),
+            &token_owner_record_cookie.address,
             &governance_authority.pubkey(),
             &self.context.payer.pubkey(),
             &governance_cookie.account.realm,


### PR DESCRIPTION
#### Summary 

- This change introduces `min_council_tokens_to_create_proposal` and `min_community_tokens_to_create_proposal` instead of a single `min_tokens_to_create_proposal` threshold to make it possible to use different thresholds for council and community tokens. A single threshold `min_tokens_to_create_proposal` is not sufficient for scenarios when the `Council` and `Community` mints supplies are significantly different (the most common case) and have different decimal places.

- This change also makes it possible for community token holders to create proposals voted on by the council and council token holders can now create proposals voted on by the community. 
  This restriction existed in previous versions but it was a side effect of the implementation and not by design. 



 