### PR TITLE
Support json for transfer with --silent

### DIFF
--- a/token/cli/src/config.rs
+++ b/token/cli/src/config.rs
@@ -3,6 +3,7 @@ use solana_clap_utils::{
     input_parsers::pubkey_of_signer,
     keypair::{pubkey_from_path, signer_from_path},
 };
+use solana_cli_output::OutputFormat;
 use solana_client::{blockhash_query::BlockhashQuery, rpc_client::RpcClient};
 use solana_remote_wallet::remote_wallet::RemoteWalletManager;
 use solana_sdk::{pubkey::Pubkey, signature::Signer};
@@ -12,6 +13,7 @@ use std::{process::exit, sync::Arc};
 pub(crate) struct Config<'a> {
     pub(crate) rpc_client: RpcClient,
     pub(crate) verbose: bool,
+    pub(crate) silent: bool,
     pub(crate) fee_payer: Pubkey,
     pub(crate) default_keypair_path: String,
     pub(crate) nonce_account: Option<Pubkey>,
@@ -19,6 +21,7 @@ pub(crate) struct Config<'a> {
     pub(crate) blockhash_query: BlockhashQuery,
     pub(crate) sign_only: bool,
     pub(crate) multisigner_pubkeys: Vec<&'a Pubkey>,
+    pub(crate) output_format: OutputFormat,
 }
 
 impl<'a> Config<'a> {


### PR DESCRIPTION
this is another feature parity thing for `solana transfer` following #1525  :)

the unfortunate twist here is that I had to introduce `--silent` not to pollute stdout for `--output json` while keeping current behavior untouched, this time...

before:

```
$ spl-token -ut transfer --allow-unfunded-recipient So11111111111111111111111111111111111111112 0.1 7DEkZ3z7cWA7DpfBZjR6iCEdc5zkfr8wZi2TNBTkbt6j
Transfer 0.1 tokens
  Sender: Ej1X2wW8ERUH5JXb4PJMcCjzPFx2A7PUpohwA71uJbDk
  Recipient: 7DEkZ3z7cWA7DpfBZjR6iCEdc5zkfr8wZi2TNBTkbt6j
  Recipient associated token account: Ej1X2wW8ERUH5JXb4PJMcCjzPFx2A7PUpohwA71uJbDk
Signature: LrmPTnvYgt1FRfnBujGcVzkHEdeMJHk8JCZiwaJTn4GyqLCqwwBngSKWqhcHNt1HSGBasdQuZoSYtgbqBaHMsyC
```

after:

```
$ spl-token -ut transfer --allow-unfunded-recipient So11111111111111111111111111111111111111112 0.1 7DEkZ3z7cWA7DpfBZjR6iCEdc5zkfr8wZi2TNBTkbt6j --output json --silent
{
  "signature": "4Thq5PbUVsfj4JY3MfodwoDZ3nLdHAGz1JkrHQ59a8s7iJ7GAVpovg34XYV3hb4oqMvTkt4CCEa5rDvwFQjeVEit"
} 
```