### PR TITLE
token-cli: support json output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3897,6 +3897,8 @@ version = "2.0.13"
 dependencies = [
  "clap",
  "console 0.14.1",
+ "serde",
+ "serde_derive",
  "serde_json",
  "solana-account-decoder",
  "solana-clap-utils",

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -11,6 +11,8 @@ version = "2.0.13"
 [dependencies]
 clap = "2.33.3"
 console = "0.14.0"
+serde = "1.0.122"
+serde_derive = "1.0.103"
 serde_json = "1.0.62"
 solana-account-decoder = "=1.7.4"
 solana-clap-utils = "=1.7.4"

--- a/token/cli/src/config.rs
+++ b/token/cli/src/config.rs
@@ -12,7 +12,6 @@ use std::{process::exit, sync::Arc};
 
 pub(crate) struct Config<'a> {
     pub(crate) rpc_client: RpcClient,
-    pub(crate) verbose: bool,
     pub(crate) output_format: OutputFormat,
     pub(crate) fee_payer: Pubkey,
     pub(crate) default_keypair_path: String,

--- a/token/cli/src/config.rs
+++ b/token/cli/src/config.rs
@@ -3,6 +3,7 @@ use solana_clap_utils::{
     input_parsers::pubkey_of_signer,
     keypair::{pubkey_from_path, signer_from_path},
 };
+use solana_cli_output::OutputFormat;
 use solana_client::{blockhash_query::BlockhashQuery, rpc_client::RpcClient};
 use solana_remote_wallet::remote_wallet::RemoteWalletManager;
 use solana_sdk::{pubkey::Pubkey, signature::Signer};
@@ -12,6 +13,7 @@ use std::{process::exit, sync::Arc};
 pub(crate) struct Config<'a> {
     pub(crate) rpc_client: RpcClient,
     pub(crate) verbose: bool,
+    pub(crate) output_format: OutputFormat,
     pub(crate) fee_payer: Pubkey,
     pub(crate) default_keypair_path: String,
     pub(crate) nonce_account: Option<Pubkey>,

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -987,7 +987,7 @@ fn command_balance(config: &Config, address: Pubkey) -> CommandResult {
         .get_token_account_balance(&address)
         .map_err(|_| format!("Could not find token account {}", address))?;
 
-    if config.verbose {
+    if config.verbose && config.output_format == OutputFormat::DisplayVerbose {
         println!("ui amount: {}", balance.real_number_string_trimmed());
         println!("decimals: {}", balance.decimals);
         println!("amount: {}", balance.amount);
@@ -1025,7 +1025,7 @@ fn command_accounts(config: &Config, token: Option<Pubkey>, owner: Pubkey) -> Co
     let aux_len = if includes_aux { 10 } else { 0 };
     let mut gc_alert = false;
 
-    if config.verbose {
+    if config.verbose && config.output_format == OutputFormat::DisplayVerbose {
         if token.is_some() {
             println!("{:<44}  {:<2$}", "Account", "Balance", max_len_balance);
             println!("-------------------------------------------------------------");
@@ -1059,7 +1059,7 @@ fn command_accounts(config: &Config, token: Option<Pubkey>, owner: Pubkey) -> Co
             } else {
                 "".to_string()
             };
-            if config.verbose {
+            if config.verbose && config.output_format == OutputFormat::DisplayVerbose {
                 if token.is_some() {
                     println!(
                         "{:<44}  {:<4$}{:<5$}{}",
@@ -2171,6 +2171,11 @@ fn main() {
         bulk_signers.push(signer);
 
         let verbose = matches.is_present("verbose");
+        let output_format = if verbose {
+            OutputFormat::DisplayVerbose
+        } else {
+            OutputFormat::Display
+        };
 
         let nonce_account = pubkey_of_signer(matches, NONCE_ARG.name, &mut wallet_manager)
             .unwrap_or_else(|e| {
@@ -2220,6 +2225,7 @@ fn main() {
         Config {
             rpc_client: RpcClient::new_with_commitment(json_rpc_url, CommitmentConfig::confirmed()),
             verbose,
+            output_format,
             fee_payer,
             default_keypair_path: cli_config.keypair_path,
             nonce_account,

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -2494,6 +2494,15 @@ fn main() {
             command_multisig(&config, address)
         }
         ("gc", Some(arg_matches)) => {
+            match config.output_format {
+                OutputFormat::Json | OutputFormat::JsonCompact => {
+                    eprintln!(
+                        "`spl-token gc` does not support the `--ouput` parameter at this time"
+                    );
+                    exit(1);
+                }
+                _ => {}
+            }
             let (owner_signer, owner_address) =
                 config.signer_or_default(arg_matches, "owner", &mut wallet_manager);
             bulk_signers.push(owner_signer);

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -1098,7 +1098,7 @@ fn command_accounts(config: &Config, token: Option<Pubkey>, owner: Pubkey) -> Co
             } else {
                 "".to_string()
             };
-            let maybe_frozen = if let UiAccountState::Frozen = account.ui_token_account.state {
+            let maybe_frozen = if let UiAccountState::Frozen = account.account.state {
                 format!(" {}  Frozen", WARNING)
             } else {
                 "".to_string()
@@ -1108,10 +1108,7 @@ fn command_accounts(config: &Config, token: Option<Pubkey>, owner: Pubkey) -> Co
                     println!(
                         "{:<44}  {:<4$}{:<5$}{}",
                         account.address,
-                        account
-                            .ui_token_account
-                            .token_amount
-                            .real_number_string_trimmed(),
+                        account.account.token_amount.real_number_string_trimmed(),
                         maybe_aux,
                         maybe_frozen,
                         max_len_balance,
@@ -1120,12 +1117,9 @@ fn command_accounts(config: &Config, token: Option<Pubkey>, owner: Pubkey) -> Co
                 } else {
                     println!(
                         "{:<44}  {:<44}  {:<5$}{:<6$}{}",
-                        account.ui_token_account.mint,
+                        account.account.mint,
                         account.address,
-                        account
-                            .ui_token_account
-                            .token_amount
-                            .real_number_string_trimmed(),
+                        account.account.token_amount.real_number_string_trimmed(),
                         maybe_aux,
                         maybe_frozen,
                         max_len_balance,
@@ -1135,10 +1129,7 @@ fn command_accounts(config: &Config, token: Option<Pubkey>, owner: Pubkey) -> Co
             } else if token.is_some() {
                 println!(
                     "{:<3$}{:<4$}{}",
-                    account
-                        .ui_token_account
-                        .token_amount
-                        .real_number_string_trimmed(),
+                    account.account.token_amount.real_number_string_trimmed(),
                     maybe_aux,
                     maybe_frozen,
                     max_len_balance,
@@ -1147,11 +1138,8 @@ fn command_accounts(config: &Config, token: Option<Pubkey>, owner: Pubkey) -> Co
             } else {
                 println!(
                     "{:<44}  {:<4$}{:<5$}{}",
-                    account.ui_token_account.mint,
-                    account
-                        .ui_token_account
-                        .token_amount
-                        .real_number_string_trimmed(),
+                    account.account.mint,
+                    account.account.token_amount.real_number_string_trimmed(),
                     maybe_aux,
                     maybe_frozen,
                     max_len_balance,

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -1399,6 +1399,15 @@ fn main() {
                 .help("Show additional information"),
         )
         .arg(
+            Arg::with_name("output_format")
+                .long("output")
+                .value_name("FORMAT")
+                .global(true)
+                .takes_value(true)
+                .possible_values(&["json", "json-compact"])
+                .help("Return information in specified output format"),
+        )
+        .arg(
             Arg::with_name("json_rpc_url")
                 .short("u")
                 .long("url")
@@ -2171,11 +2180,18 @@ fn main() {
         bulk_signers.push(signer);
 
         let verbose = matches.is_present("verbose");
-        let output_format = if verbose {
-            OutputFormat::DisplayVerbose
-        } else {
-            OutputFormat::Display
-        };
+        let output_format = matches
+            .value_of("output_format")
+            .map(|value| match value {
+                "json" => OutputFormat::Json,
+                "json-compact" => OutputFormat::JsonCompact,
+                _ => unreachable!(),
+            })
+            .unwrap_or(if verbose {
+                OutputFormat::DisplayVerbose
+            } else {
+                OutputFormat::Display
+            });
 
         let nonce_account = pubkey_of_signer(matches, NONCE_ARG.name, &mut wallet_manager)
             .unwrap_or_else(|e| {

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -2177,7 +2177,6 @@ fn main() {
 
         Config {
             rpc_client: RpcClient::new_with_commitment(json_rpc_url, CommitmentConfig::confirmed()),
-            verbose,
             output_format,
             fee_payer,
             default_keypair_path: cli_config.keypair_path,

--- a/token/cli/src/output.rs
+++ b/token/cli/src/output.rs
@@ -1,0 +1,11 @@
+use crate::config::Config;
+use solana_cli_output::{OutputFormat, QuietDisplay, VerboseDisplay};
+
+pub(crate) fn println_display(config: &Config, message: String) {
+    match config.output_format {
+        OutputFormat::Display | OutputFormat::DisplayVerbose => {
+            println!("{}", message);
+        }
+        _ => {}
+    }
+}

--- a/token/cli/src/output.rs
+++ b/token/cli/src/output.rs
@@ -1,5 +1,8 @@
 use crate::config::Config;
-use solana_cli_output::{OutputFormat, QuietDisplay, VerboseDisplay};
+use serde::{Deserialize, Serialize};
+use solana_account_decoder::parse_token::{UiTokenAccount, UiTokenAmount};
+use solana_cli_output::{display::writeln_name_value, OutputFormat, QuietDisplay, VerboseDisplay};
+use std::fmt;
 
 pub(crate) fn println_display(config: &Config, message: String) {
     match config.output_format {
@@ -7,5 +10,137 @@ pub(crate) fn println_display(config: &Config, message: String) {
             println!("{}", message);
         }
         _ => {}
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CliTokenAmount {
+    #[serde(flatten)]
+    pub(crate) amount: UiTokenAmount,
+}
+
+impl QuietDisplay for CliTokenAmount {}
+impl VerboseDisplay for CliTokenAmount {
+    fn write_str(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+        writeln!(w, "ui amount: {}", self.amount.real_number_string_trimmed())?;
+        writeln!(w, "decimals: {}", self.amount.decimals)?;
+        writeln!(w, "amount: {}", self.amount.amount)
+    }
+}
+
+impl fmt::Display for CliTokenAmount {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "{}", self.amount.real_number_string_trimmed())
+    }
+}
+
+#[derive(Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CliWalletAddress {
+    pub(crate) wallet_address: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) associated_token_address: Option<String>,
+}
+
+impl QuietDisplay for CliWalletAddress {}
+impl VerboseDisplay for CliWalletAddress {}
+
+impl fmt::Display for CliWalletAddress {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "Wallet address: {}", self.wallet_address)?;
+        if let Some(associated_token_address) = &self.associated_token_address {
+            writeln!(f, "Associated token address: {}", associated_token_address)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CliMultisig {
+    pub(crate) address: String,
+    pub(crate) m: u8,
+    pub(crate) n: u8,
+    pub(crate) signers: Vec<String>,
+}
+
+impl QuietDisplay for CliMultisig {}
+impl VerboseDisplay for CliMultisig {}
+
+impl fmt::Display for CliMultisig {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f)?;
+        writeln_name_value(f, "Address:", &self.address)?;
+        writeln_name_value(f, "M/N:", &format!("{}/{}", self.m, self.n))?;
+        writeln_name_value(f, "Signers:", " ")?;
+        let width = if self.n >= 9 { 4 } else { 3 };
+        for i in 0..self.n as usize {
+            let title = format!("{1:>0$}:", width, i + 1);
+            let pubkey = &self.signers[i];
+            writeln_name_value(f, &title, pubkey)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CliTokenAccount {
+    pub(crate) address: String,
+    pub(crate) is_associated: bool,
+    #[serde(flatten)]
+    pub(crate) account: UiTokenAccount,
+}
+
+impl QuietDisplay for CliTokenAccount {}
+impl VerboseDisplay for CliTokenAccount {}
+
+impl fmt::Display for CliTokenAccount {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f)?;
+        if self.is_associated {
+            writeln_name_value(f, "Address:", &self.address)?;
+        } else {
+            writeln_name_value(f, "Address:", &format!("{}  (Aux*)", self.address))?;
+        }
+        writeln_name_value(
+            f,
+            "Balance:",
+            &self.account.token_amount.real_number_string_trimmed(),
+        )?;
+        let mint = format!(
+            "{}{}",
+            self.account.mint,
+            if self.account.is_native {
+                " (native)"
+            } else {
+                ""
+            }
+        );
+        writeln_name_value(f, "Mint:", &mint)?;
+        writeln_name_value(f, "Owner:", &self.account.owner)?;
+        writeln_name_value(f, "State:", &format!("{:?}", self.account.state))?;
+        if let Some(delegate) = &self.account.delegate {
+            writeln!(f, "Delegation:")?;
+            writeln_name_value(f, "  Delegate:", delegate)?;
+            let allowance = self.account.delegated_amount.as_ref().unwrap();
+            writeln_name_value(f, "  Allowance:", &allowance.real_number_string_trimmed())?;
+        } else {
+            writeln_name_value(f, "Delegation:", "")?;
+        }
+        writeln_name_value(
+            f,
+            "Close authority:",
+            self.account
+                .close_authority
+                .as_ref()
+                .unwrap_or(&String::new()),
+        )?;
+        if !self.is_associated {
+            writeln!(f)?;
+            writeln!(f, "* Please run `spl-token gc` to clean up Aux accounts")?;
+        }
+        Ok(())
     }
 }

--- a/token/cli/src/sort.rs
+++ b/token/cli/src/sort.rs
@@ -1,8 +1,5 @@
-use crate::get_associated_token_address;
-use solana_account_decoder::{
-    parse_token::{TokenAccountType, UiTokenAccount},
-    UiAccountData,
-};
+use crate::{get_associated_token_address, output::CliTokenAccount};
+use solana_account_decoder::{parse_token::TokenAccountType, UiAccountData};
 use solana_client::rpc_response::RpcKeyedAccount;
 use solana_sdk::pubkey::Pubkey;
 use std::{
@@ -10,20 +7,14 @@ use std::{
     str::FromStr,
 };
 
-pub type MintAccounts = BTreeMap<String, Vec<ParsedTokenAccount>>;
+pub(crate) type MintAccounts = BTreeMap<String, Vec<CliTokenAccount>>;
 
-pub struct ParsedTokenAccount {
-    pub address: String,
-    pub ui_token_account: UiTokenAccount,
-    pub is_associated: bool,
-}
-
-pub struct UnsupportedAccount {
+pub(crate) struct UnsupportedAccount {
     pub address: String,
     pub err: String,
 }
 
-pub fn sort_and_parse_token_accounts(
+pub(crate) fn sort_and_parse_token_accounts(
     owner: &Pubkey,
     accounts: Vec<RpcKeyedAccount>,
 ) -> (MintAccounts, Vec<UnsupportedAccount>, usize, bool) {
@@ -55,9 +46,9 @@ pub fn sort_and_parse_token_accounts(
                             .real_number_string_trimmed()
                             .len();
                         max_len_balance = max_len_balance.max(len_balance);
-                        let parsed_account = ParsedTokenAccount {
+                        let parsed_account = CliTokenAccount {
                             address,
-                            ui_token_account,
+                            account: ui_token_account,
                             is_associated,
                         };
                         let entry = mint_accounts.entry(mint);

--- a/token/cli/src/sort.rs
+++ b/token/cli/src/sort.rs
@@ -1,4 +1,5 @@
 use crate::{get_associated_token_address, output::CliTokenAccount};
+use serde::{Deserialize, Serialize};
 use solana_account_decoder::{parse_token::TokenAccountType, UiAccountData};
 use solana_client::rpc_response::RpcKeyedAccount;
 use solana_sdk::pubkey::Pubkey;
@@ -9,6 +10,7 @@ use std::{
 
 pub(crate) type MintAccounts = BTreeMap<String, Vec<CliTokenAccount>>;
 
+#[derive(Serialize, Deserialize)]
 pub(crate) struct UnsupportedAccount {
     pub address: String,
     pub err: String,


### PR DESCRIPTION
As more apps integrate SPL tokens alongside SOL, there is demand for `spl-token-cli` json support that parallels `solana-cli`. This PR adds that functionality.

There is one existing weirdness around `spl-token gc`, since that method may submit multiple transactions. Currently, `spl-token gc --output json` prints multiple json Signature objects (or Signer objects, if `--sign-only`), instead of one nice json array of those objects. Implementing this properly requires an upstream change in the form of `solana_cli_output::return_signers_with_config()` that returns `CliSignOnlyData` instead of strings (or a bunch of duplication). That will follow after the upstream work is implemented. In the meantime, this changeset should meet current needs.

Closes #2128
cc @ryoqun 