### PR TITLE
Governance: Capture vote_threshold_percentage on voted on proposal

### DIFF
--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -13,7 +13,10 @@ use solana_program::{
 use crate::{
     error::GovernanceError,
     state::{
-        enums::{GovernanceAccountType, InstructionExecutionFlags, ProposalState},
+        enums::{
+            GovernanceAccountType, InstructionExecutionFlags, ProposalState,
+            VoteThresholdPercentage,
+        },
         governance::get_governance_data_for_realm,
         proposal::{get_proposal_address_seeds, Proposal},
         realm::get_realm_data_for_governing_token_mint,
@@ -97,6 +100,7 @@ pub fn process_create_proposal(
         yes_votes_count: 0,
         no_votes_count: 0,
         governing_token_mint_vote_supply: None,
+        vote_threshold_percentage: VoteThresholdPercentage::None,
     };
 
     create_and_serialize_account_signed::<Proposal>(

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -102,6 +102,9 @@ impl Default for ProposalState {
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum VoteThresholdPercentage {
+    /// Vote threshold not set
+    None,
+
     /// Voting threshold of Yes votes in % required to tip the vote
     /// It's the percentage of tokens out of the entire pool of governance tokens eligible to vote
     /// Note: If the threshold is below or equal to 50% then an even split of votes ex: 50:50 or 40:40 is always resolved as Defeated

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -93,6 +93,11 @@ pub struct Proposal {
     /// after vote was completed.
     pub governing_token_mint_vote_supply: Option<u64>,
 
+    /// The vote threshold percentage at the time Proposal was decided
+    /// It's used to show correct vote results for historical proposals in cases when the threshold
+    /// was changed for governance config after vote was completed.
+    pub vote_threshold_percentage: VoteThresholdPercentage,
+
     /// Proposal name
     pub name: String,
 
@@ -102,7 +107,7 @@ pub struct Proposal {
 
 impl AccountMaxSize for Proposal {
     fn get_max_size(&self) -> Option<usize> {
-        Some(self.name.len() + self.description_link.len() + 202)
+        Some(self.name.len() + self.description_link.len() + 204)
     }
 }
 
@@ -209,7 +214,10 @@ impl Proposal {
 
         self.state = self.get_final_vote_state(governing_token_mint_supply, config);
         self.voting_completed_at = Some(current_unix_timestamp);
+
+        // Capture vote params to correctly display historical results
         self.governing_token_mint_vote_supply = Some(governing_token_mint_supply);
+        self.vote_threshold_percentage = config.vote_threshold_percentage.clone();
 
         Ok(())
     }
@@ -248,7 +256,10 @@ impl Proposal {
         {
             self.state = tipped_state;
             self.voting_completed_at = Some(current_unix_timestamp);
+
+            // Capture vote params to correctly display historical results
             self.governing_token_mint_vote_supply = Some(governing_token_mint_supply);
+            self.vote_threshold_percentage = config.vote_threshold_percentage.clone();
         }
     }
 
@@ -489,6 +500,7 @@ mod test {
             instructions_executed_count: 10,
             instructions_count: 10,
             instructions_next_index: 10,
+            vote_threshold_percentage: VoteThresholdPercentage::YesVote(100),
         }
     }
 

--- a/governance/program/tests/process_cast_vote.rs
+++ b/governance/program/tests/process_cast_vote.rs
@@ -66,6 +66,13 @@ async fn test_cast_vote() {
     );
 
     assert_eq!(Some(100), proposal_account.governing_token_mint_vote_supply);
+    assert_eq!(
+        account_governance_cookie
+            .account
+            .config
+            .vote_threshold_percentage,
+        proposal_account.vote_threshold_percentage
+    );
 
     let token_owner_record = governance_test
         .get_token_owner_record_account(&token_owner_record_cookie.address)

--- a/governance/program/tests/process_finalize_vote.rs
+++ b/governance/program/tests/process_finalize_vote.rs
@@ -89,6 +89,14 @@ async fn test_finalize_vote_to_succeeded() {
     );
 
     assert_eq!(Some(210), proposal_account.governing_token_mint_vote_supply);
+    assert_eq!(Some(100), proposal_account.governing_token_mint_vote_supply);
+    assert_eq!(
+        account_governance_cookie
+            .account
+            .config
+            .vote_threshold_percentage,
+        proposal_account.vote_threshold_percentage
+    );
 }
 
 #[tokio::test]

--- a/governance/program/tests/process_finalize_vote.rs
+++ b/governance/program/tests/process_finalize_vote.rs
@@ -89,7 +89,7 @@ async fn test_finalize_vote_to_succeeded() {
     );
 
     assert_eq!(Some(210), proposal_account.governing_token_mint_vote_supply);
-    assert_eq!(Some(100), proposal_account.governing_token_mint_vote_supply);
+
     assert_eq!(
         account_governance_cookie
             .account

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1133,6 +1133,7 @@ impl GovernanceProgramTest {
 
             execution_flags: InstructionExecutionFlags::None,
             governing_token_mint_vote_supply: None,
+            vote_threshold_percentage: VoteThresholdPercentage::None,
         };
 
         let proposal_address = get_proposal_address(


### PR DESCRIPTION
#### Summary

Capture  `vote_threshold_percentage` on voted on proposal to correctly display historical vote results.
 `vote_threshold_percentage` can be changed over time through governance and hence we have to store the value used to resolve proposal vote.