### PR TITLE
Governance: Use option for proposal VoteThresholdPercentage

### DIFF
--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -13,10 +13,7 @@ use solana_program::{
 use crate::{
     error::GovernanceError,
     state::{
-        enums::{
-            GovernanceAccountType, InstructionExecutionFlags, ProposalState,
-            VoteThresholdPercentage,
-        },
+        enums::{GovernanceAccountType, InstructionExecutionFlags, ProposalState},
         governance::get_governance_data_for_realm,
         proposal::{get_proposal_address_seeds, Proposal},
         realm::get_realm_data_for_governing_token_mint,
@@ -100,7 +97,7 @@ pub fn process_create_proposal(
         yes_votes_count: 0,
         no_votes_count: 0,
         governing_token_mint_vote_supply: None,
-        vote_threshold_percentage: VoteThresholdPercentage::None,
+        vote_threshold_percentage: None,
     };
 
     create_and_serialize_account_signed::<Proposal>(

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -102,9 +102,6 @@ impl Default for ProposalState {
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum VoteThresholdPercentage {
-    /// Vote threshold not set
-    None,
-
     /// Voting threshold of Yes votes in % required to tip the vote
     /// It's the percentage of tokens out of the entire pool of governance tokens eligible to vote
     /// Note: If the threshold is below or equal to 50% then an even split of votes ex: 50:50 or 40:40 is always resolved as Defeated

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -96,7 +96,7 @@ pub struct Proposal {
     /// The vote threshold percentage at the time Proposal was decided
     /// It's used to show correct vote results for historical proposals in cases when the threshold
     /// was changed for governance config after vote was completed.
-    pub vote_threshold_percentage: VoteThresholdPercentage,
+    pub vote_threshold_percentage: Option<VoteThresholdPercentage>,
 
     /// Proposal name
     pub name: String,
@@ -107,7 +107,7 @@ pub struct Proposal {
 
 impl AccountMaxSize for Proposal {
     fn get_max_size(&self) -> Option<usize> {
-        Some(self.name.len() + self.description_link.len() + 204)
+        Some(self.name.len() + self.description_link.len() + 205)
     }
 }
 
@@ -217,7 +217,7 @@ impl Proposal {
 
         // Capture vote params to correctly display historical results
         self.governing_token_mint_vote_supply = Some(governing_token_mint_supply);
-        self.vote_threshold_percentage = config.vote_threshold_percentage.clone();
+        self.vote_threshold_percentage = Some(config.vote_threshold_percentage.clone());
 
         Ok(())
     }
@@ -259,7 +259,7 @@ impl Proposal {
 
             // Capture vote params to correctly display historical results
             self.governing_token_mint_vote_supply = Some(governing_token_mint_supply);
-            self.vote_threshold_percentage = config.vote_threshold_percentage.clone();
+            self.vote_threshold_percentage = Some(config.vote_threshold_percentage.clone());
         }
     }
 
@@ -500,7 +500,7 @@ mod test {
             instructions_executed_count: 10,
             instructions_count: 10,
             instructions_next_index: 10,
-            vote_threshold_percentage: VoteThresholdPercentage::YesVote(100),
+            vote_threshold_percentage: Some(VoteThresholdPercentage::YesVote(100)),
         }
     }
 

--- a/governance/program/tests/process_cast_vote.rs
+++ b/governance/program/tests/process_cast_vote.rs
@@ -67,10 +67,12 @@ async fn test_cast_vote() {
 
     assert_eq!(Some(100), proposal_account.governing_token_mint_vote_supply);
     assert_eq!(
-        account_governance_cookie
-            .account
-            .config
-            .vote_threshold_percentage,
+        Some(
+            account_governance_cookie
+                .account
+                .config
+                .vote_threshold_percentage
+        ),
         proposal_account.vote_threshold_percentage
     );
 

--- a/governance/program/tests/process_finalize_vote.rs
+++ b/governance/program/tests/process_finalize_vote.rs
@@ -91,10 +91,12 @@ async fn test_finalize_vote_to_succeeded() {
     assert_eq!(Some(210), proposal_account.governing_token_mint_vote_supply);
 
     assert_eq!(
-        account_governance_cookie
-            .account
-            .config
-            .vote_threshold_percentage,
+        Some(
+            account_governance_cookie
+                .account
+                .config
+                .vote_threshold_percentage
+        ),
         proposal_account.vote_threshold_percentage
     );
 }

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1133,7 +1133,7 @@ impl GovernanceProgramTest {
 
             execution_flags: InstructionExecutionFlags::None,
             governing_token_mint_vote_supply: None,
-            vote_threshold_percentage: VoteThresholdPercentage::None,
+            vote_threshold_percentage: None,
         };
 
         let proposal_address = get_proposal_address(


### PR DESCRIPTION
#### Summary

Use Option for storing `vote_threshold_percentage` on proposal instead of None enum value. 
The change is necessary because 
- There is no native `None` value for `VoteThresholdPercentage` enum
- It broke backward compatibility with existing test `Governances` 