### PR TITLE
Remove NFT "authorize mint --disable" step to ensure Metaplex compat.

### DIFF
--- a/docs/src/token.md
+++ b/docs/src/token.md
@@ -263,15 +263,6 @@ Minting 1 tokens
 Signature: 2Kzg6ZArQRCRvcoKSiievYy3sfPqGV91Whnz6SeimhJQXKBTYQf3E54tWg3zPpYLbcDexxyTxnj4QF69ucswfdY
 ```
 
-and disable future minting:
-```console
-$ spl-token authorize 559u4Tdr9umKwft3yHMsnAxohhzkFnUBPAFtibwuZD9z mint --disable
-Updating 559u4Tdr9umKwft3yHMsnAxohhzkFnUBPAFtibwuZD9z
-  Current mint authority: vines1vzrYbzLMRdu58ou5XTby4qAqVRLmqo36NKPTg
-  New mint authority: disabled
-Signature: 5QpykLzZsceoKcVRRFow9QCdae4Dp2zQAcjebyEWoezPFg2Np73gHKWQicHG1mqRdXu3yiZbrft3Q8JmqNRNqhwU
-```
-
 Now the `7KqpRwzkkeweW5jQoETyLzhvs9rcCj9dVQ1MnzudirsM` account holds the
 one and only `559u4Tdr9umKwft3yHMsnAxohhzkFnUBPAFtibwuZD9z` token:
 


### PR DESCRIPTION
If this step is being carried out, the mint will never be able to have Metaplex metadata attached to it, as Metaplex requires the mint authority to be set to the account submitting the metadata.