### PR TITLE
stake-pool: Don't assess withdrawal fee from fee account

### DIFF
--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -1963,9 +1963,13 @@ impl Processor {
             return Err(StakePoolError::InvalidState.into());
         }
 
-        let pool_tokens_fee = stake_pool
-            .calc_pool_tokens_withdrawal_fee(pool_tokens)
-            .ok_or(StakePoolError::CalculationFailure)?;
+        let pool_tokens_fee = if stake_pool.manager_fee_account == *burn_from_info.key {
+            0
+        } else {
+            stake_pool
+                .calc_pool_tokens_withdrawal_fee(pool_tokens)
+                .ok_or(StakePoolError::CalculationFailure)?
+        };
         let pool_tokens_burnt = pool_tokens
             .checked_sub(pool_tokens_fee)
             .ok_or(StakePoolError::CalculationFailure)?;

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -99,6 +99,32 @@ pub async fn transfer(
     banks_client.process_transaction(transaction).await.unwrap();
 }
 
+pub async fn transfer_spl_tokens(
+    banks_client: &mut BanksClient,
+    payer: &Keypair,
+    recent_blockhash: &Hash,
+    source: &Pubkey,
+    destination: &Pubkey,
+    authority: &Keypair,
+    amount: u64,
+) {
+    let transaction = Transaction::new_signed_with_payer(
+        &[spl_token::instruction::transfer(
+            &spl_token::id(),
+            source,
+            destination,
+            &authority.pubkey(),
+            &[],
+            amount,
+        )
+        .unwrap()],
+        Some(&payer.pubkey()),
+        &[payer, authority],
+        *recent_blockhash,
+    );
+    banks_client.process_transaction(transaction).await.unwrap();
+}
+
 pub async fn create_token_account(
     banks_client: &mut BanksClient,
     payer: &Keypair,


### PR DESCRIPTION
#### Problem

If a stake pool has a withdraw fee, even the fee account will be assessed a fee, making it very annoying for the manager to get SOL out of the pool.

#### Solution

Don't assess the withdrawal fee for the fee account.

cc @jon-chuang what do you think?