### PR TITLE
Governance: Realm config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3758,7 +3758,7 @@ dependencies = [
 
 [[package]]
 name = "spl-governance"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "arrayref",
  "assert_matches",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3758,7 +3758,7 @@ dependencies = [
 
 [[package]]
 name = "spl-governance"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "arrayref",
  "assert_matches",

--- a/governance/program/Cargo.toml
+++ b/governance/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-governance"
-version = "1.0.6"
+version = "1.0.7"
 description = "Solana Program Library Governance Program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/governance/program/Cargo.toml
+++ b/governance/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-governance"
-version = "1.0.7"
+version = "1.0.8"
 description = "Solana Program Library Governance Program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -303,6 +303,14 @@ pub enum GovernanceError {
     /// Realm council mint change is not supported
     #[error("Realm council mint change is not supported")]
     RealmCouncilMintChangeIsNotSupported,
+
+    /// Not supported mint max vote weight source
+    #[error("Not supported mint max vote weight source")]
+    MintMaxVoteWeightSourceNotSupported,
+
+    /// Invalid supply fraction
+    #[error("Invalid supply fraction")]
+    InvalidSupplyFraction,
 }
 
 impl PrintProgramError for GovernanceError {

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -299,6 +299,10 @@ pub enum GovernanceError {
     /// Invalid governing token holding account
     #[error("Invalid governing token holding account")]
     InvalidGoverningTokenHoldingAccount,
+
+    /// Realm council mint change is not supported
+    #[error("Realm council mint change is not supported")]
+    RealmCouncilMintChangeIsNotSupported,
 }
 
 impl PrintProgramError for GovernanceError {

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -308,9 +308,9 @@ pub enum GovernanceError {
     #[error("Not supported mint max vote weight source")]
     MintMaxVoteWeightSourceNotSupported,
 
-    /// Invalid supply fraction
-    #[error("Invalid supply fraction")]
-    InvalidSupplyFraction,
+    /// Invalid max vote weight supply fraction
+    #[error("Invalid max vote weight supply fraction")]
+    InvalidMaxVoteWeightSupplyFraction,
 }
 
 impl PrintProgramError for GovernanceError {

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -383,12 +383,12 @@ pub enum GovernanceInstruction {
     /// Sets realm config
     ///   0. `[writable]` Realm account
     ///   1. `[signer]`  Realm authority    
-    ///   3. `[]` Realm custodian - optional    
-    ///   4. `[]` Council Token Mint - optional
+    ///   2. `[]` Realm custodian - optional    
+    ///   3. `[]` Council Token Mint - optional
     ///       Note: In the current version it's only possible to remove council mint (set it to None)
     ///       After setting council to None it won't be possible to withdraw the tokens from the Realm any longer
     ///       If that's required then it must be done before executing this instruction
-    ///   5. `[writable]` Council Token Holding account - optional unless council is used. PDA seeds: ['governance',realm,council_mint]
+    ///   4. `[writable]` Council Token Holding account - optional unless council is used. PDA seeds: ['governance',realm,council_mint]
     ///       The account will be created with the Realm PDA as its owner
     SetRealmConfig {
         #[allow(dead_code)]

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -60,7 +60,7 @@ pub enum GovernanceInstruction {
         name: String,
 
         #[allow(dead_code)]
-        /// Realm     
+        /// Realm config args     
         config_args: RealmConfigArgs,
     },
 

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -385,6 +385,9 @@ pub enum GovernanceInstruction {
     ///   1. `[signer]`  Realm authority    
     ///   3. `[]` Realm custodian - optional    
     ///   4. `[]` Council Token Mint - optional
+    ///       Note: In the current version it's only possible to remove council mint (set it to None)
+    ///       After setting council to None it won't be possible to withdraw the tokens from the  any longer
+    ///       If that's required then it must be done before executing this instruction
     ///   5. `[writable]` Council Token Holding account - optional unless council is used. PDA seeds: ['governance',realm,council_mint]
     ///       The account will be created with the Realm PDA as its owner
     SetRealmConfig {

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -382,6 +382,7 @@ pub enum GovernanceInstruction {
 }
 
 /// Creates CreateRealm instruction
+#[allow(clippy::too_many_arguments)]
 pub fn create_realm(
     program_id: &Pubkey,
     // Accounts

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -1174,7 +1174,7 @@ pub fn set_realm_config(
 
     let use_council_mint = if let Some(council_token_mint) = council_token_mint {
         let council_token_holding_address =
-            get_governing_token_holding_address(program_id, &realm, &council_token_mint);
+            get_governing_token_holding_address(program_id, realm, &council_token_mint);
 
         accounts.push(AccountMeta::new_readonly(council_token_mint, false));
         accounts.push(AccountMeta::new(council_token_holding_address, false));

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -386,7 +386,7 @@ pub enum GovernanceInstruction {
     ///   3. `[]` Realm custodian - optional    
     ///   4. `[]` Council Token Mint - optional
     ///       Note: In the current version it's only possible to remove council mint (set it to None)
-    ///       After setting council to None it won't be possible to withdraw the tokens from the  any longer
+    ///       After setting council to None it won't be possible to withdraw the tokens from the Realm any longer
     ///       If that's required then it must be done before executing this instruction
     ///   5. `[writable]` Council Token Holding account - optional unless council is used. PDA seeds: ['governance',realm,council_mint]
     ///       The account will be created with the Realm PDA as its owner

--- a/governance/program/src/processor/mod.rs
+++ b/governance/program/src/processor/mod.rs
@@ -20,6 +20,7 @@ mod process_remove_signatory;
 mod process_set_governance_config;
 mod process_set_governance_delegate;
 mod process_set_realm_authority;
+mod process_set_realm_config;
 mod process_sign_off_proposal;
 mod process_withdraw_governing_tokens;
 
@@ -46,6 +47,7 @@ use process_remove_signatory::*;
 use process_set_governance_config::*;
 use process_set_governance_delegate::*;
 use process_set_realm_authority::*;
+use process_set_realm_config::*;
 use process_sign_off_proposal::*;
 use process_withdraw_governing_tokens::*;
 
@@ -171,5 +173,8 @@ pub fn process_instruction(
         GovernanceInstruction::SetRealmAuthority {
             new_realm_authority,
         } => process_set_realm_authority(program_id, accounts, new_realm_authority),
+        GovernanceInstruction::SetRealmConfig { config_args } => {
+            process_set_realm_config(program_id, accounts, config_args)
+        }
     }
 }

--- a/governance/program/src/processor/mod.rs
+++ b/governance/program/src/processor/mod.rs
@@ -80,8 +80,8 @@ pub fn process_instruction(
     }
 
     match instruction {
-        GovernanceInstruction::CreateRealm { name } => {
-            process_create_realm(program_id, accounts, name)
+        GovernanceInstruction::CreateRealm { name, config_args } => {
+            process_create_realm(program_id, accounts, name, config_args)
         }
 
         GovernanceInstruction::DepositGoverningTokens {} => {

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -14,8 +14,9 @@ use crate::{
     instruction::Vote,
     state::{
         enums::{GovernanceAccountType, VoteWeight},
-        governance::get_governance_data,
+        governance::get_governance_data_for_realm,
         proposal::get_proposal_data_for_governance_and_governing_mint,
+        realm::get_realm_data_for_governing_token_mint,
         token_owner_record::get_token_owner_record_data_for_realm_and_governing_mint,
         vote_record::{get_vote_record_address_seeds, VoteRecord},
     },
@@ -32,7 +33,7 @@ pub fn process_cast_vote(
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
 
-    let _realm_info = next_account_info(account_info_iter)?; // 0
+    let realm_info = next_account_info(account_info_iter)?; // 0
     let governance_info = next_account_info(account_info_iter)?; // 1
     let proposal_info = next_account_info(account_info_iter)?; // 2
     let token_owner_record_info = next_account_info(account_info_iter)?; // 3
@@ -54,7 +55,13 @@ pub fn process_cast_vote(
         return Err(GovernanceError::VoteAlreadyExists.into());
     }
 
-    let governance_data = get_governance_data(program_id, governance_info)?;
+    let realm_data = get_realm_data_for_governing_token_mint(
+        program_id,
+        realm_info,
+        governing_token_mint_info.key,
+    )?;
+    let governance_data =
+        get_governance_data_for_realm(program_id, governance_info, realm_info.key)?;
 
     let mut proposal_data = get_proposal_data_for_governance_and_governing_mint(
         program_id,
@@ -109,6 +116,7 @@ pub fn process_cast_vote(
     proposal_data.try_tip_vote(
         governing_token_mint_supply,
         &governance_data.config,
+        &realm_data,
         clock.unix_timestamp,
     );
 

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -118,7 +118,7 @@ pub fn process_cast_vote(
         &governance_data.config,
         &realm_data,
         clock.unix_timestamp,
-    );
+    )?;
 
     proposal_data.serialize(&mut *proposal_info.data.borrow_mut())?;
 

--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -96,7 +96,7 @@ pub fn process_create_proposal(
 
         yes_votes_count: 0,
         no_votes_count: 0,
-        governing_token_mint_vote_supply: None,
+        max_vote_weight: None,
         vote_threshold_percentage: None,
     };
 

--- a/governance/program/src/processor/process_create_realm.rs
+++ b/governance/program/src/processor/process_create_realm.rs
@@ -32,13 +32,14 @@ pub fn process_create_realm(
     let account_info_iter = &mut accounts.iter();
 
     let realm_info = next_account_info(account_info_iter)?; // 0
-    let governance_token_mint_info = next_account_info(account_info_iter)?; // 1
-    let governance_token_holding_info = next_account_info(account_info_iter)?; // 2
-    let payer_info = next_account_info(account_info_iter)?; // 3
-    let system_info = next_account_info(account_info_iter)?; // 4
-    let spl_token_info = next_account_info(account_info_iter)?; // 5
+    let realm_authority_info = next_account_info(account_info_iter)?; // 1
+    let governance_token_mint_info = next_account_info(account_info_iter)?; // 2
+    let governance_token_holding_info = next_account_info(account_info_iter)?; // 3
+    let payer_info = next_account_info(account_info_iter)?; // 4
+    let system_info = next_account_info(account_info_iter)?; // 5
+    let spl_token_info = next_account_info(account_info_iter)?; // 6
 
-    let rent_sysvar_info = next_account_info(account_info_iter)?; // 6
+    let rent_sysvar_info = next_account_info(account_info_iter)?; // 7
     let rent = &Rent::from_account_info(rent_sysvar_info)?;
 
     if !realm_info.data_is_empty() {
@@ -80,13 +81,6 @@ pub fn process_create_realm(
         None
     };
 
-    let realm_authority = if config_args.use_authority {
-        let realm_authority_info = next_account_info(account_info_iter)?;
-        Some(*realm_authority_info.key)
-    } else {
-        None
-    };
-
     let realm_custodian = if config_args.use_custodian {
         let realm_custodian_info = next_account_info(account_info_iter)?;
         Some(*realm_custodian_info.key)
@@ -100,7 +94,7 @@ pub fn process_create_realm(
 
         name: name.clone(),
         reserved: [0; 8],
-        authority: realm_authority,
+        authority: Some(*realm_authority_info.key),
         config: RealmConfig {
             council_mint: council_token_mint_address,
             reserved: [0; 8],

--- a/governance/program/src/processor/process_create_realm.rs
+++ b/governance/program/src/processor/process_create_realm.rs
@@ -59,6 +59,13 @@ pub fn process_create_realm(
         rent,
     )?;
 
+    let realm_custodian = if config_args.use_custodian {
+        let realm_custodian_info = next_account_info(account_info_iter)?;
+        Some(*realm_custodian_info.key)
+    } else {
+        None
+    };
+
     let council_token_mint_address = if config_args.use_council_mint {
         let council_token_mint_info = next_account_info(account_info_iter)?;
         let council_token_holding_info = next_account_info(account_info_iter)?;
@@ -77,13 +84,6 @@ pub fn process_create_realm(
         )?;
 
         Some(*council_token_mint_info.key)
-    } else {
-        None
-    };
-
-    let realm_custodian = if config_args.use_custodian {
-        let realm_custodian_info = next_account_info(account_info_iter)?;
-        Some(*realm_custodian_info.key)
     } else {
         None
     };

--- a/governance/program/src/processor/process_create_realm.rs
+++ b/governance/program/src/processor/process_create_realm.rs
@@ -13,8 +13,8 @@ use crate::{
     state::{
         enums::GovernanceAccountType,
         realm::{
-            get_governing_token_holding_address_seeds, get_realm_address_seeds, Realm, RealmConfig,
-            RealmConfigArgs,
+            assert_valid_realm_config_args, get_governing_token_holding_address_seeds,
+            get_realm_address_seeds, Realm, RealmConfig, RealmConfigArgs,
         },
     },
     tools::{
@@ -45,6 +45,8 @@ pub fn process_create_realm(
     if !realm_info.data_is_empty() {
         return Err(GovernanceError::RealmAlreadyExists.into());
     }
+
+    assert_valid_realm_config_args(&config_args)?;
 
     create_spl_token_account_signed(
         payer_info,

--- a/governance/program/src/processor/process_create_realm.rs
+++ b/governance/program/src/processor/process_create_realm.rs
@@ -11,9 +11,10 @@ use solana_program::{
 use crate::{
     error::GovernanceError,
     state::{
-        enums::{GovernanceAccountType, MintMaxVoteWeightSource},
+        enums::GovernanceAccountType,
         realm::{
             get_governing_token_holding_address_seeds, get_realm_address_seeds, Realm, RealmConfig,
+            RealmConfigArgs,
         },
     },
     tools::{
@@ -26,18 +27,18 @@ pub fn process_create_realm(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
     name: String,
+    config_args: RealmConfigArgs,
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
 
     let realm_info = next_account_info(account_info_iter)?; // 0
-    let realm_authority_info = next_account_info(account_info_iter)?; // 1
-    let governance_token_mint_info = next_account_info(account_info_iter)?; // 2
-    let governance_token_holding_info = next_account_info(account_info_iter)?; // 3
-    let payer_info = next_account_info(account_info_iter)?; // 4
-    let system_info = next_account_info(account_info_iter)?; // 5
-    let spl_token_info = next_account_info(account_info_iter)?; // 6
+    let governance_token_mint_info = next_account_info(account_info_iter)?; // 1
+    let governance_token_holding_info = next_account_info(account_info_iter)?; // 2
+    let payer_info = next_account_info(account_info_iter)?; // 3
+    let system_info = next_account_info(account_info_iter)?; // 4
+    let spl_token_info = next_account_info(account_info_iter)?; // 5
 
-    let rent_sysvar_info = next_account_info(account_info_iter)?; // 7
+    let rent_sysvar_info = next_account_info(account_info_iter)?; // 6
     let rent = &Rent::from_account_info(rent_sysvar_info)?;
 
     if !realm_info.data_is_empty() {
@@ -57,11 +58,9 @@ pub fn process_create_realm(
         rent,
     )?;
 
-    let council_token_mint_address = if let Ok(council_token_mint_info) =
-        next_account_info(account_info_iter)
-    // 7
-    {
-        let council_token_holding_info = next_account_info(account_info_iter)?; //8
+    let council_token_mint_address = if config_args.use_council_mint {
+        let council_token_mint_info = next_account_info(account_info_iter)?;
+        let council_token_holding_info = next_account_info(account_info_iter)?;
 
         create_spl_token_account_signed(
             payer_info,
@@ -81,18 +80,33 @@ pub fn process_create_realm(
         None
     };
 
+    let realm_authority = if config_args.use_authority {
+        let realm_authority_info = next_account_info(account_info_iter)?;
+        Some(*realm_authority_info.key)
+    } else {
+        None
+    };
+
+    let realm_custodian = if config_args.use_custodian {
+        let realm_custodian_info = next_account_info(account_info_iter)?;
+        Some(*realm_custodian_info.key)
+    } else {
+        None
+    };
+
     let realm_data = Realm {
         account_type: GovernanceAccountType::Realm,
         community_mint: *governance_token_mint_info.key,
 
         name: name.clone(),
         reserved: [0; 8],
-        authority: Some(*realm_authority_info.key),
+        authority: realm_authority,
         config: RealmConfig {
             council_mint: council_token_mint_address,
             reserved: [0; 8],
-            custodian: Some(*realm_authority_info.key),
-            community_mint_max_vote_weight_source: MintMaxVoteWeightSource::MAX_FRACTION,
+            custodian: realm_custodian,
+            community_mint_max_vote_weight_source: config_args
+                .community_mint_max_vote_weight_source,
         },
     };
 

--- a/governance/program/src/processor/process_create_realm.rs
+++ b/governance/program/src/processor/process_create_realm.rs
@@ -92,7 +92,7 @@ pub fn process_create_realm(
             council_mint: council_token_mint_address,
             reserved: [0; 8],
             custodian: Some(*realm_authority_info.key),
-            community_mint_max_vote_weight_source: MintMaxVoteWeightSource::Percentage(100),
+            community_mint_max_vote_weight_source: MintMaxVoteWeightSource::MAX_FRACTION,
         },
     };
 

--- a/governance/program/src/processor/process_set_realm_config.rs
+++ b/governance/program/src/processor/process_set_realm_config.rs
@@ -1,0 +1,67 @@
+//! Program state processor
+
+use borsh::BorshSerialize;
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    entrypoint::ProgramResult,
+    pubkey::Pubkey,
+};
+
+use crate::{
+    error::GovernanceError,
+    state::realm::{get_realm_data_for_authority, RealmConfigArgs},
+};
+
+/// Processes SetRealmConfig instruction
+pub fn process_set_realm_config(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    config_args: RealmConfigArgs,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    let realm_info = next_account_info(account_info_iter)?; // 0
+    let realm_authority_info = next_account_info(account_info_iter)?; // 1
+
+    let mut realm_data =
+        get_realm_data_for_authority(program_id, realm_info, realm_authority_info.key)?;
+
+    if !realm_authority_info.is_signer {
+        return Err(GovernanceError::RealmAuthorityMustSign.into());
+    }
+
+    let realm_custodian = if config_args.use_custodian {
+        let realm_custodian_info = next_account_info(account_info_iter)?;
+        Some(*realm_custodian_info.key)
+    } else {
+        None
+    };
+
+    if config_args.use_council_mint {
+        let council_token_mint_info = next_account_info(account_info_iter)?;
+
+        // Council mint can only be at present set to none (removed) and changing it to other mint is not supported
+        // It might be implemented in future versions but it needs careful planning
+        // It can potentially open a can of warms like what happens with existing deposits or pending proposals
+        if let Some(council_token_mint) = realm_data.config.council_mint {
+            // Council mint can't be changed to different one
+            if council_token_mint != *council_token_mint_info.key {
+                return Err(GovernanceError::RealmCouncilMintChangeIsNotSupported.into());
+            }
+        } else {
+            // Council mint can't be restored (changed from None)
+            return Err(GovernanceError::RealmCouncilMintChangeIsNotSupported.into());
+        }
+    } else {
+        // Remove council mint from realm
+        realm_data.config.council_mint = None;
+    }
+
+    realm_data.config.custodian = realm_custodian;
+    realm_data.config.community_mint_max_vote_weight_source =
+        config_args.community_mint_max_vote_weight_source;
+
+    realm_data.serialize(&mut *realm_info.data.borrow_mut())?;
+
+    Ok(())
+}

--- a/governance/program/src/processor/process_set_realm_config.rs
+++ b/governance/program/src/processor/process_set_realm_config.rs
@@ -9,7 +9,7 @@ use solana_program::{
 
 use crate::{
     error::GovernanceError,
-    state::realm::{get_realm_data_for_authority, RealmConfigArgs},
+    state::realm::{assert_valid_realm_config_args, get_realm_data_for_authority, RealmConfigArgs},
 };
 
 /// Processes SetRealmConfig instruction
@@ -29,6 +29,8 @@ pub fn process_set_realm_config(
     if !realm_authority_info.is_signer {
         return Err(GovernanceError::RealmAuthorityMustSign.into());
     }
+
+    assert_valid_realm_config_args(&config_args)?;
 
     let realm_custodian = if config_args.use_custodian {
         let realm_custodian_info = next_account_info(account_info_iter)?;

--- a/governance/program/src/processor/process_set_realm_config.rs
+++ b/governance/program/src/processor/process_set_realm_config.rs
@@ -56,6 +56,7 @@ pub fn process_set_realm_config(
         }
     } else {
         // Remove council mint from realm
+        // Note: In the current implementation this also makes it impossible to withdraw council tokens
         realm_data.config.council_mint = None;
     }
 

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -166,10 +166,19 @@ pub enum InstructionExecutionFlags {
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum MintMaxVoteWeightSource {
-    /// Percentage of the governing mint supply is used as max vote weight
-    /// The default is 100% to use all available mint supply for voting
-    Percentage(u8),
+    /// Fraction (10^10 precision) of the governing mint supply is used as max vote weight
+    /// The default is 100% (10^10) to use all available mint supply for voting
+    Fraction(u64),
 
     /// Absolute value, irrelevant of the actual mint supply, is used as max vote weight
     Absolute(u64),
+}
+
+impl MintMaxVoteWeightSource {
+    /// Base for mint supply fraction calculation
+    pub const FRACTION_BASE: u64 = 10_000_000_000;
+
+    /// Max fraction (100%)
+    pub const MAX_FRACTION: MintMaxVoteWeightSource =
+        MintMaxVoteWeightSource::Fraction(MintMaxVoteWeightSource::FRACTION_BASE);
 }

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -168,7 +168,7 @@ pub enum InstructionExecutionFlags {
 pub enum MintMaxVoteWeightSource {
     /// Fraction (10^10 precision) of the governing mint supply is used as max vote weight
     /// The default is 100% (10^10) to use all available mint supply for voting
-    Fraction(u64),
+    SupplyFraction(u64),
 
     /// Absolute value, irrelevant of the actual mint supply, is used as max vote weight
     Absolute(u64),
@@ -176,9 +176,9 @@ pub enum MintMaxVoteWeightSource {
 
 impl MintMaxVoteWeightSource {
     /// Base for mint supply fraction calculation
-    pub const FRACTION_BASE: u64 = 10_000_000_000;
+    pub const SUPPLY_FRACTION_BASE: u64 = 10_000_000_000;
 
-    /// Max fraction (100%)
-    pub const MAX_FRACTION: MintMaxVoteWeightSource =
-        MintMaxVoteWeightSource::Fraction(MintMaxVoteWeightSource::FRACTION_BASE);
+    /// 100% of mint supply
+    pub const FULL_SUPPLY_FRACTION: MintMaxVoteWeightSource =
+        MintMaxVoteWeightSource::SupplyFraction(MintMaxVoteWeightSource::SUPPLY_FRACTION_BASE);
 }

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -162,7 +162,6 @@ pub enum InstructionExecutionFlags {
 
 /// The source of max vote weight used for voting
 /// Values below 100% mint supply can be used when the governing token is fully minted but not distributed yet
-/// Note: This field is not used yet. It's reserved for future versions
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum MintMaxVoteWeightSource {
@@ -171,6 +170,7 @@ pub enum MintMaxVoteWeightSource {
     SupplyFraction(u64),
 
     /// Absolute value, irrelevant of the actual mint supply, is used as max vote weight
+    /// Note: this option is not implemented in the current version
     Absolute(u64),
 }
 

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -21,6 +21,7 @@ use crate::{
 };
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 
+use super::enums::MintMaxVoteWeightSource;
 use super::realm::Realm;
 
 /// Governance Proposal
@@ -90,10 +91,10 @@ pub struct Proposal {
     /// Note: This field is not used in the current version
     pub execution_flags: InstructionExecutionFlags,
 
-    /// The supply of the Governing Token mint at the time Proposal was decided
-    /// It's used to show correct vote results for historical proposals in cases when the mint supply changed
+    /// The max vote weight for the Governing Token mint at the time Proposal was decided
+    /// It's used to show correct vote results for historical proposals in cases when the mint supply or max weight source changed
     /// after vote was completed.
-    pub governing_token_mint_vote_supply: Option<u64>,
+    pub max_vote_weight: Option<u64>,
 
     /// The vote threshold percentage at the time Proposal was decided
     /// It's used to show correct vote results for historical proposals in cases when the threshold
@@ -210,16 +211,18 @@ impl Proposal {
         &mut self,
         governing_token_mint_supply: u64,
         config: &GovernanceConfig,
-        _realm_data: &Realm,
+        realm_data: &Realm,
         current_unix_timestamp: UnixTimestamp,
     ) -> Result<(), ProgramError> {
         self.assert_can_finalize_vote(config, current_unix_timestamp)?;
 
-        self.state = self.get_final_vote_state(governing_token_mint_supply, config);
+        let max_vote_weight = self.get_max_vote_weight(&realm_data, governing_token_mint_supply)?;
+
+        self.state = self.get_final_vote_state(max_vote_weight, config);
         self.voting_completed_at = Some(current_unix_timestamp);
 
         // Capture vote params to correctly display historical results
-        self.governing_token_mint_vote_supply = Some(governing_token_mint_supply);
+        self.max_vote_weight = Some(max_vote_weight);
         self.vote_threshold_percentage = Some(config.vote_threshold_percentage.clone());
 
         Ok(())
@@ -227,11 +230,11 @@ impl Proposal {
 
     fn get_final_vote_state(
         &mut self,
-        governing_token_supply: u64,
+        max_vote_weight: u64,
         config: &GovernanceConfig,
     ) -> ProposalState {
         let yes_vote_threshold_count =
-            get_yes_vote_threshold_count(&config.vote_threshold_percentage, governing_token_supply)
+            get_yes_vote_threshold_count(&config.vote_threshold_percentage, max_vote_weight)
                 .unwrap();
 
         // Yes vote must be equal or above the required yes_vote_threshold_percentage and higher than No vote
@@ -246,27 +249,56 @@ impl Proposal {
         }
     }
 
+    /// Calculates max vote weight for given mint supply and realm config
+    fn get_max_vote_weight(
+        &mut self,
+        realm_data: &Realm,
+        governing_token_mint_supply: u64,
+    ) -> Result<u64, ProgramError> {
+        // max vote weight fraction is only used for community mint
+        if Some(self.governing_token_mint) == realm_data.config.council_mint {
+            return Ok(governing_token_mint_supply);
+        }
+
+        match realm_data.config.community_mint_max_vote_weight_source {
+            MintMaxVoteWeightSource::SupplyFraction(fraction) => {
+                if fraction == MintMaxVoteWeightSource::SUPPLY_FRACTION_BASE {
+                    return Ok(governing_token_mint_supply);
+                }
+
+                let max_vote_weight = (governing_token_mint_supply as u128)
+                    .checked_mul(fraction as u128)
+                    .unwrap()
+                    .checked_div(MintMaxVoteWeightSource::SUPPLY_FRACTION_BASE as u128)
+                    .unwrap() as u64;
+
+                return Ok(max_vote_weight);
+            }
+            _ => return Err(GovernanceError::VoteWeightSourceNotSupported.into()),
+        }
+    }
+
     /// Checks if vote can be tipped and automatically transitioned to Succeeded or Defeated state
     /// If the conditions are met the state is updated accordingly
     pub fn try_tip_vote(
         &mut self,
         governing_token_mint_supply: u64,
         config: &GovernanceConfig,
-        _realm_data: &Realm,
+        realm_data: &Realm,
         current_unix_timestamp: UnixTimestamp,
-    ) {
-        // TODO: check which mint it is and get max supply
+    ) -> Result<(), ProgramError> {
+        let max_vote_weight = self.get_max_vote_weight(&realm_data, governing_token_mint_supply)?;
 
-        if let Some(tipped_state) =
-            self.try_get_tipped_vote_state(governing_token_mint_supply, config)
-        {
+        if let Some(tipped_state) = self.try_get_tipped_vote_state(max_vote_weight, config) {
             self.state = tipped_state;
             self.voting_completed_at = Some(current_unix_timestamp);
 
             // Capture vote params to correctly display historical results
-            self.governing_token_mint_vote_supply = Some(governing_token_mint_supply);
+            self.max_vote_weight = Some(max_vote_weight);
             self.vote_threshold_percentage = Some(config.vote_threshold_percentage.clone());
         }
+
+        Ok(())
     }
 
     /// Checks if vote can be tipped and automatically transitioned to Succeeded or Defeated state
@@ -274,26 +306,26 @@ impl Proposal {
     #[allow(clippy::float_cmp)]
     pub fn try_get_tipped_vote_state(
         &self,
-        governing_token_supply: u64,
+        max_vote_weight: u64,
         config: &GovernanceConfig,
     ) -> Option<ProposalState> {
-        if self.yes_votes_count == governing_token_supply {
+        if self.yes_votes_count == max_vote_weight {
             return Some(ProposalState::Succeeded);
         }
-        if self.no_votes_count == governing_token_supply {
+        if self.no_votes_count == max_vote_weight {
             return Some(ProposalState::Defeated);
         }
 
         let yes_vote_threshold_count =
-            get_yes_vote_threshold_count(&config.vote_threshold_percentage, governing_token_supply)
+            get_yes_vote_threshold_count(&config.vote_threshold_percentage, max_vote_weight)
                 .unwrap();
 
         if self.yes_votes_count >= yes_vote_threshold_count
-            && self.yes_votes_count > (governing_token_supply - self.yes_votes_count)
+            && self.yes_votes_count > (max_vote_weight - self.yes_votes_count)
         {
             return Some(ProposalState::Succeeded);
-        } else if self.no_votes_count > (governing_token_supply - yes_vote_threshold_count)
-            || self.no_votes_count >= (governing_token_supply - self.no_votes_count)
+        } else if self.no_votes_count > (max_vote_weight - yes_vote_threshold_count)
+            || self.no_votes_count >= (max_vote_weight - self.no_votes_count)
         {
             return Some(ProposalState::Defeated);
         }
@@ -379,7 +411,7 @@ impl Proposal {
 /// Converts threshold in percentages to actual vote count
 fn get_yes_vote_threshold_count(
     vote_threshold_percentage: &VoteThresholdPercentage,
-    total_supply: u64,
+    max_vote_weight: u64,
 ) -> Result<u64, ProgramError> {
     let yes_vote_threshold_percentage = match vote_threshold_percentage {
         VoteThresholdPercentage::YesVote(yes_vote_threshold_percentage) => {
@@ -391,7 +423,7 @@ fn get_yes_vote_threshold_count(
     };
 
     let numerator = (yes_vote_threshold_percentage as u128)
-        .checked_mul(total_supply as u128)
+        .checked_mul(max_vote_weight as u128)
         .unwrap();
 
     let mut yes_vote_threshold = numerator.checked_div(100).unwrap();
@@ -484,7 +516,7 @@ mod test {
             account_type: GovernanceAccountType::TokenOwnerRecord,
             governance: Pubkey::new_unique(),
             governing_token_mint: Pubkey::new_unique(),
-            governing_token_mint_vote_supply: Some(10),
+            max_vote_weight: Some(10),
             state: ProposalState::Draft,
             token_owner_record: Pubkey::new_unique(),
             signatories_count: 10,
@@ -925,7 +957,7 @@ mod test {
             let realm = create_test_realm();
 
             // Act
-            proposal.try_tip_vote(test_case.governing_token_supply, &governance_config,&realm,current_timestamp);
+            proposal.try_tip_vote(test_case.governing_token_supply, &governance_config,&realm,current_timestamp).unwrap();
 
             // Assert
             assert_eq!(proposal.state,test_case.expected_tipped_state,"CASE: {:?}",test_case);
@@ -996,7 +1028,7 @@ mod test {
             let realm = create_test_realm();
 
             // Act
-            proposal.try_tip_vote(governing_token_supply, &governance_config,&realm, current_timestamp);
+            proposal.try_tip_vote(governing_token_supply, &governance_config,&realm, current_timestamp).unwrap();
 
             // Assert
             let yes_vote_threshold_count = get_yes_vote_threshold_count(&yes_vote_threshold_percentage,governing_token_supply).unwrap();
@@ -1048,6 +1080,111 @@ mod test {
                 assert_eq!(proposal.state,ProposalState::Defeated);
             }
         }
+    }
+
+    #[test]
+    fn test_try_tip_vote_with_reduced_community_mint_max_max_supply() {
+        // Arrange
+        let mut proposal = create_test_proposal();
+        proposal.yes_votes_count = 60;
+        proposal.no_votes_count = 10;
+        proposal.state = ProposalState::Voting;
+
+        let mut governance_config = create_test_governance_config();
+        governance_config.vote_threshold_percentage = VoteThresholdPercentage::YesVote(60);
+
+        let current_timestamp = 15_i64;
+
+        let community_token_supply = 200;
+
+        let mut realm = create_test_realm();
+        realm.config.community_mint_max_vote_weight_source =
+            MintMaxVoteWeightSource::SupplyFraction(
+                MintMaxVoteWeightSource::SUPPLY_FRACTION_BASE / 2,
+            );
+
+        // Act
+        proposal
+            .try_tip_vote(
+                community_token_supply,
+                &governance_config,
+                &realm,
+                current_timestamp,
+            )
+            .unwrap();
+
+        // Assert
+        assert_eq!(proposal.state, ProposalState::Succeeded);
+    }
+
+    #[test]
+    fn test_try_tip_vote_for_council_vote_with_reduced_community_mint_max_supply() {
+        // Arrange
+        let mut proposal = create_test_proposal();
+        proposal.yes_votes_count = 60;
+        proposal.no_votes_count = 10;
+        proposal.state = ProposalState::Voting;
+
+        let mut governance_config = create_test_governance_config();
+        governance_config.vote_threshold_percentage = VoteThresholdPercentage::YesVote(60);
+
+        let current_timestamp = 15_i64;
+
+        let community_token_supply = 200;
+
+        let mut realm = create_test_realm();
+        realm.config.community_mint_max_vote_weight_source =
+            MintMaxVoteWeightSource::SupplyFraction(
+                MintMaxVoteWeightSource::SUPPLY_FRACTION_BASE / 2,
+            );
+        realm.config.council_mint = Some(proposal.governing_token_mint);
+
+        // Act
+        proposal
+            .try_tip_vote(
+                community_token_supply,
+                &governance_config,
+                &realm,
+                current_timestamp,
+            )
+            .unwrap();
+
+        // Assert
+        assert_eq!(proposal.state, ProposalState::Voting);
+    }
+
+    #[test]
+    fn test_finalize_vote_with_reduced_community_mint_max_max_supply() {
+        // Arrange
+        let mut proposal = create_test_proposal();
+        proposal.yes_votes_count = 60;
+        proposal.no_votes_count = 10;
+        proposal.state = ProposalState::Voting;
+
+        let mut governance_config = create_test_governance_config();
+        governance_config.vote_threshold_percentage = VoteThresholdPercentage::YesVote(60);
+
+        let current_timestamp = 16_i64;
+        let community_token_supply = 200;
+
+        let mut realm = create_test_realm();
+        realm.config.community_mint_max_vote_weight_source =
+            MintMaxVoteWeightSource::SupplyFraction(
+                MintMaxVoteWeightSource::SUPPLY_FRACTION_BASE / 2,
+            );
+
+        // Act
+        proposal
+            .finalize_vote(
+                community_token_supply,
+                &governance_config,
+                &realm,
+                current_timestamp,
+            )
+            .unwrap();
+
+        // Assert
+        assert_eq!(proposal.state, ProposalState::Succeeded);
     }
 
     #[test]

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -216,7 +216,7 @@ impl Proposal {
     ) -> Result<(), ProgramError> {
         self.assert_can_finalize_vote(config, current_unix_timestamp)?;
 
-        let max_vote_weight = self.get_max_vote_weight(&realm_data, governing_token_mint_supply)?;
+        let max_vote_weight = self.get_max_vote_weight(realm_data, governing_token_mint_supply)?;
 
         self.state = self.get_final_vote_state(max_vote_weight, config);
         self.voting_completed_at = Some(current_unix_timestamp);
@@ -272,9 +272,9 @@ impl Proposal {
                     .checked_div(MintMaxVoteWeightSource::SUPPLY_FRACTION_BASE as u128)
                     .unwrap() as u64;
 
-                return Ok(max_vote_weight);
+                Ok(max_vote_weight)
             }
-            _ => return Err(GovernanceError::VoteWeightSourceNotSupported.into()),
+            _ => Err(GovernanceError::VoteWeightSourceNotSupported.into()),
         }
     }
 
@@ -287,7 +287,7 @@ impl Proposal {
         realm_data: &Realm,
         current_unix_timestamp: UnixTimestamp,
     ) -> Result<(), ProgramError> {
-        let max_vote_weight = self.get_max_vote_weight(&realm_data, governing_token_mint_supply)?;
+        let max_vote_weight = self.get_max_vote_weight(realm_data, governing_token_mint_supply)?;
 
         if let Some(tipped_state) = self.try_get_tipped_vote_state(max_vote_weight, config) {
             self.state = tipped_state;

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -12,18 +12,16 @@ use crate::{
     state::{
         enums::{
             GovernanceAccountType, InstructionExecutionFlags, InstructionExecutionStatus,
-            ProposalState, VoteThresholdPercentage,
+            MintMaxVoteWeightSource, ProposalState, VoteThresholdPercentage,
         },
         governance::GovernanceConfig,
         proposal_instruction::ProposalInstruction,
+        realm::Realm,
     },
     tools::account::{get_account_data, AccountMaxSize},
     PROGRAM_AUTHORITY_SEED,
 };
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-
-use super::enums::MintMaxVoteWeightSource;
-use super::realm::Realm;
 
 /// Governance Proposal
 #[repr(C)]

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -25,10 +25,6 @@ pub struct RealmConfigArgs {
     /// If yes then custodian account must also be passed to the instruction  
     pub use_custodian: bool,
 
-    /// Indicates whether authority should be used
-    /// If yes then authority account must also be passed to the instruction
-    pub use_authority: bool,
-
     /// The source used for community mint max vote weight source
     pub community_mint_max_vote_weight_source: MintMaxVoteWeightSource,
 }

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -210,6 +210,20 @@ pub fn get_governing_token_holding_address(
     .0
 }
 
+/// Assert given realm config args are correct
+pub fn assert_valid_realm_config_args(config_args: &RealmConfigArgs) -> Result<(), ProgramError> {
+    match config_args.community_mint_max_vote_weight_source {
+        MintMaxVoteWeightSource::SupplyFraction(fraction) => {
+            if !(1..=MintMaxVoteWeightSource::SUPPLY_FRACTION_BASE).contains(&fraction) {
+                return Err(GovernanceError::InvalidSupplyFraction.into());
+            }
+        }
+        _ => return Err(GovernanceError::MintMaxVoteWeightSourceNotSupported.into()),
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod test {
 

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -208,7 +208,7 @@ pub fn get_governing_token_holding_address(
     .0
 }
 
-/// Assert given realm config args are correct
+/// Asserts given realm config args are correct
 pub fn assert_valid_realm_config_args(config_args: &RealmConfigArgs) -> Result<(), ProgramError> {
     match config_args.community_mint_max_vote_weight_source {
         MintMaxVoteWeightSource::SupplyFraction(fraction) => {

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -13,6 +13,26 @@ use crate::{
     PROGRAM_AUTHORITY_SEED,
 };
 
+/// Realm Config instruction args
+#[repr(C)]
+#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+pub struct RealmConfigArgs {
+    /// Indicates whether council_mint should be used
+    /// If yes then council_mint account must be passed to the instruction
+    pub use_council_mint: bool,
+
+    /// Indicates whether custodian should be used
+    /// If yes then custodian account must be passed to the instruction  
+    pub use_custodian: bool,
+
+    /// Indicates whether authority should be used
+    /// If yes then authority account must be passed to the instruction
+    pub use_authority: bool,
+
+    /// The source used for community mint max vote weight source
+    pub community_mint_max_vote_weight_source: MintMaxVoteWeightSource,
+}
+
 /// Realm Config defining Realm parameters.
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -37,7 +37,6 @@ pub struct RealmConfig {
     pub reserved: [u8; 8],
 
     /// The source used for community mint max vote weight source
-    /// Note: This field is not used yet. It's reserved for future versions
     pub community_mint_max_vote_weight_source: MintMaxVoteWeightSource,
 
     /// Optional council mint
@@ -70,7 +69,6 @@ pub struct Realm {
 
     /// Realm authority. The authority must sign transactions which update the realm config
     /// The authority can be transferer to Realm Governance and hence make the Realm self governed through proposals
-    /// Note: This field is not used yet. It's reserved for future versions
     pub authority: Option<Pubkey>,
 
     /// Governance Realm name

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -17,12 +17,15 @@ use crate::{
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct RealmConfig {
-    /// Optional council mint
-    pub council_mint: Option<Pubkey>,
+    /// Reserved space for future versions
+    pub reserved: [u8; 8],
 
     /// The source used for community mint max vote weight source
     /// Note: This field is not used yet. It's reserved for future versions
     pub community_mint_max_vote_weight_source: MintMaxVoteWeightSource,
+
+    /// Optional council mint
+    pub council_mint: Option<Pubkey>,
 
     /// An authority tasked with none critical and maintenance Realm operations
     /// For example custodian authority is required to add governances to the Realm
@@ -30,9 +33,6 @@ pub struct RealmConfig {
     /// to prevent unrelated entries and noise
     /// Note: This field is not used yet. It's reserved for future versions
     pub custodian: Option<Pubkey>,
-
-    /// Reserved space for future versions
-    pub reserved: [u8; 8],
 }
 
 /// Governance Realm Account

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -215,7 +215,7 @@ pub fn assert_valid_realm_config_args(config_args: &RealmConfigArgs) -> Result<(
     match config_args.community_mint_max_vote_weight_source {
         MintMaxVoteWeightSource::SupplyFraction(fraction) => {
             if !(1..=MintMaxVoteWeightSource::SUPPLY_FRACTION_BASE).contains(&fraction) {
-                return Err(GovernanceError::InvalidSupplyFraction.into());
+                return Err(GovernanceError::InvalidMaxVoteWeightSupplyFraction.into());
             }
         }
         _ => return Err(GovernanceError::MintMaxVoteWeightSourceNotSupported.into()),

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -27,7 +27,7 @@ pub struct RealmConfig {
     /// Optional council mint
     pub council_mint: Option<Pubkey>,
 
-    /// An authority tasked with none critical and maintenance Realm operations
+    /// An authority tasked with non-critical and maintenance Realm operations
     /// For example custodian authority is required to add governances to the Realm
     /// There is no security risk with adding governances to the Realm but it should not be open for everybody
     /// to prevent unrelated entries and noise

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -18,15 +18,15 @@ use crate::{
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct RealmConfigArgs {
     /// Indicates whether council_mint should be used
-    /// If yes then council_mint account must be passed to the instruction
+    /// If yes then council_mint account must also be passed to the instruction
     pub use_council_mint: bool,
 
     /// Indicates whether custodian should be used
-    /// If yes then custodian account must be passed to the instruction  
+    /// If yes then custodian account must also be passed to the instruction  
     pub use_custodian: bool,
 
     /// Indicates whether authority should be used
-    /// If yes then authority account must be passed to the instruction
+    /// If yes then authority account must also be passed to the instruction
     pub use_authority: bool,
 
     /// The source used for community mint max vote weight source

--- a/governance/program/tests/process_cast_vote.rs
+++ b/governance/program/tests/process_cast_vote.rs
@@ -65,7 +65,7 @@ async fn test_cast_vote() {
         Some(clock.unix_timestamp)
     );
 
-    assert_eq!(Some(100), proposal_account.governing_token_mint_vote_supply);
+    assert_eq!(Some(100), proposal_account.max_vote_weight);
     assert_eq!(
         Some(
             account_governance_cookie

--- a/governance/program/tests/process_create_realm.rs
+++ b/governance/program/tests/process_create_realm.rs
@@ -31,7 +31,6 @@ async fn test_create_realm_with_non_default_config() {
     let config_args = RealmConfigArgs {
         use_council_mint: false,
         use_custodian: false,
-        use_authority: false,
         community_mint_max_vote_weight_source: MintMaxVoteWeightSource::Absolute(1000),
     };
 

--- a/governance/program/tests/process_create_realm.rs
+++ b/governance/program/tests/process_create_realm.rs
@@ -31,7 +31,7 @@ async fn test_create_realm_with_non_default_config() {
     let config_args = RealmConfigArgs {
         use_council_mint: false,
         use_custodian: false,
-        community_mint_max_vote_weight_source: MintMaxVoteWeightSource::Absolute(1000),
+        community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(1),
     };
 
     // Act

--- a/governance/program/tests/process_create_realm.rs
+++ b/governance/program/tests/process_create_realm.rs
@@ -24,7 +24,7 @@ async fn test_create_realm() {
 }
 
 #[tokio::test]
-async fn test_create_realm_with_none_default_config() {
+async fn test_create_realm_with_non_default_config() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 

--- a/governance/program/tests/process_create_realm.rs
+++ b/governance/program/tests/process_create_realm.rs
@@ -24,7 +24,7 @@ async fn test_create_realm() {
 }
 
 #[tokio::test]
-async fn test_create_realm_none_default_config() {
+async fn test_create_realm_with_none_default_config() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 

--- a/governance/program/tests/process_create_realm.rs
+++ b/governance/program/tests/process_create_realm.rs
@@ -5,14 +5,40 @@ use solana_program_test::*;
 mod program_test;
 
 use program_test::*;
+use spl_governance::state::{enums::MintMaxVoteWeightSource, realm::RealmConfigArgs};
 
 #[tokio::test]
-async fn test_realm_created() {
+async fn test_create_realm() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
     // Act
     let realm_cookie = governance_test.with_realm().await;
+
+    // Assert
+    let realm_account = governance_test
+        .get_realm_account(&realm_cookie.address)
+        .await;
+
+    assert_eq!(realm_cookie.account, realm_account);
+}
+
+#[tokio::test]
+async fn test_create_realm_none_default_config() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let config_args = RealmConfigArgs {
+        use_council_mint: false,
+        use_custodian: false,
+        use_authority: false,
+        community_mint_max_vote_weight_source: MintMaxVoteWeightSource::Absolute(1000),
+    };
+
+    // Act
+    let realm_cookie = governance_test
+        .with_realm_using_config_args(&config_args)
+        .await;
 
     // Assert
     let realm_account = governance_test

--- a/governance/program/tests/process_finalize_vote.rs
+++ b/governance/program/tests/process_finalize_vote.rs
@@ -87,7 +87,7 @@ async fn test_finalize_vote_to_succeeded() {
         proposal_account.voting_completed_at
     );
 
-    assert_eq!(Some(210), proposal_account.governing_token_mint_vote_supply);
+    assert_eq!(Some(210), proposal_account.max_vote_weight);
 
     assert_eq!(
         Some(

--- a/governance/program/tests/process_finalize_vote.rs
+++ b/governance/program/tests/process_finalize_vote.rs
@@ -2,7 +2,6 @@
 
 mod program_test;
 
-use solana_program::pubkey::Pubkey;
 use solana_program_test::tokio;
 
 use program_test::*;
@@ -203,7 +202,8 @@ async fn test_finalize_vote_with_invalid_mint_error() {
 
     assert_eq!(ProposalState::Voting, proposal_account.state);
 
-    proposal_cookie.account.governing_token_mint = Pubkey::new_unique();
+    proposal_cookie.account.governing_token_mint =
+        realm_cookie.account.config.council_mint.unwrap();
 
     // Act
 

--- a/governance/program/tests/process_set_realm_config.rs
+++ b/governance/program/tests/process_set_realm_config.rs
@@ -1,0 +1,36 @@
+#![cfg(feature = "test-bpf")]
+
+use solana_program_test::*;
+
+mod program_test;
+
+use program_test::*;
+use spl_governance::state::{enums::MintMaxVoteWeightSource, realm::RealmConfigArgs};
+
+#[tokio::test]
+async fn test_set_realm_config() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    let config_args = RealmConfigArgs {
+        use_council_mint: true,
+        use_custodian: true,
+        community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(100),
+    };
+
+    // Act
+
+    governance_test
+        .set_realm_config(&mut realm_cookie, &config_args)
+        .await
+        .unwrap();
+
+    // Assert
+    let realm_account = governance_test
+        .get_realm_account(&realm_cookie.address)
+        .await;
+
+    assert_eq!(realm_cookie.account, realm_account);
+}

--- a/governance/program/tests/process_set_realm_config.rs
+++ b/governance/program/tests/process_set_realm_config.rs
@@ -1,11 +1,15 @@
 #![cfg(feature = "test-bpf")]
 
+use solana_program::pubkey::Pubkey;
 use solana_program_test::*;
 
 mod program_test;
 
 use program_test::*;
-use spl_governance::state::{enums::MintMaxVoteWeightSource, realm::RealmConfigArgs};
+use spl_governance::{
+    error::GovernanceError,
+    state::{enums::MintMaxVoteWeightSource, realm::RealmConfigArgs},
+};
 
 #[tokio::test]
 async fn test_set_realm_config() {
@@ -33,4 +37,221 @@ async fn test_set_realm_config() {
         .await;
 
     assert_eq!(realm_cookie.account, realm_account);
+}
+
+#[tokio::test]
+async fn test_set_realm_config_with_authority_must_sign_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    let config_args = RealmConfigArgs {
+        use_council_mint: true,
+        use_custodian: true,
+        community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(100),
+    };
+
+    // Act
+
+    let err = governance_test
+        .set_realm_config_using_instruction(
+            &mut realm_cookie,
+            &config_args,
+            |i| i.accounts[1].is_signer = false,
+            Some(&[]),
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::RealmAuthorityMustSign.into());
+}
+
+#[tokio::test]
+async fn test_set_realm_config_with_no_authority_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    let config_args = RealmConfigArgs {
+        use_council_mint: true,
+        use_custodian: true,
+        community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(100),
+    };
+
+    governance_test
+        .set_realm_authority(&realm_cookie, &None)
+        .await
+        .unwrap();
+
+    // Act
+
+    let err = governance_test
+        .set_realm_config_using_instruction(
+            &mut realm_cookie,
+            &config_args,
+            |i| i.accounts[1].is_signer = false,
+            Some(&[]),
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::RealmHasNoAuthority.into());
+}
+
+#[tokio::test]
+async fn test_set_realm_config_with_invalid_authority_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    let config_args = RealmConfigArgs {
+        use_council_mint: true,
+        use_custodian: true,
+        community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(100),
+    };
+
+    let realm_cookie2 = governance_test.with_realm().await;
+
+    // Try to use authority from other realm
+    realm_cookie.realm_authority = realm_cookie2.realm_authority;
+
+    // Act
+
+    let err = governance_test
+        .set_realm_config(&mut realm_cookie, &config_args)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::InvalidAuthorityForRealm.into());
+}
+
+#[tokio::test]
+async fn test_set_realm_config_with_remove_custodian() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    let config_args = RealmConfigArgs {
+        use_council_mint: true,
+        use_custodian: false,
+        community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(100),
+    };
+
+    // Act
+    governance_test
+        .set_realm_config(&mut realm_cookie, &config_args)
+        .await
+        .unwrap();
+
+    // Assert
+    let realm_account = governance_test
+        .get_realm_account(&realm_cookie.address)
+        .await;
+
+    assert_eq!(realm_cookie.account, realm_account);
+    assert_eq!(None, realm_account.config.custodian);
+}
+
+#[tokio::test]
+async fn test_set_realm_config_with_remove_council() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    let config_args = RealmConfigArgs {
+        use_council_mint: false,
+        use_custodian: true,
+        community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(100),
+    };
+
+    // Act
+    governance_test
+        .set_realm_config(&mut realm_cookie, &config_args)
+        .await
+        .unwrap();
+
+    // Assert
+    let realm_account = governance_test
+        .get_realm_account(&realm_cookie.address)
+        .await;
+
+    assert_eq!(realm_cookie.account, realm_account);
+    assert_eq!(None, realm_account.config.council_mint);
+}
+
+#[tokio::test]
+async fn test_set_realm_config_with_council_change_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    let config_args = RealmConfigArgs {
+        use_council_mint: true,
+        use_custodian: true,
+        community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(100),
+    };
+
+    // Try to replace council mint
+    realm_cookie.account.config.council_mint = serde::__private::Some(Pubkey::new_unique());
+
+    // Act
+    let err = governance_test
+        .set_realm_config(&mut realm_cookie, &config_args)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::RealmCouncilMintChangeIsNotSupported.into()
+    );
+}
+
+#[tokio::test]
+async fn test_set_realm_config_with_council_restore_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    let mut config_args = RealmConfigArgs {
+        use_council_mint: false,
+        use_custodian: true,
+        community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(100),
+    };
+
+    governance_test
+        .set_realm_config(&mut realm_cookie, &config_args)
+        .await
+        .unwrap();
+
+    // Try to restore council mint after removing it
+    config_args.use_council_mint = true;
+    realm_cookie.account.config.council_mint = serde::__private::Some(Pubkey::new_unique());
+
+    // Act
+    let err = governance_test
+        .set_realm_config(&mut realm_cookie, &config_args)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::RealmCouncilMintChangeIsNotSupported.into()
+    );
 }

--- a/governance/program/tests/program_test/cookies.rs
+++ b/governance/program/tests/program_test/cookies.rs
@@ -26,7 +26,7 @@ pub struct RealmCookie {
 
     pub council_token_holding_account: Option<Pubkey>,
 
-    pub realm_authority: Keypair,
+    pub realm_authority: Option<Keypair>,
 }
 
 #[derive(Debug)]

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -206,8 +206,8 @@ impl GovernanceProgramTest {
             &realm_authority.pubkey(),
             &community_token_mint_keypair.pubkey(),
             &self.context.payer.pubkey(),
-            council_token_mint_pubkey,
             Some(realm_custodian.pubkey()),
+            council_token_mint_pubkey,
             name.clone(),
             config_args.community_mint_max_vote_weight_source.clone(),
         );
@@ -263,8 +263,8 @@ impl GovernanceProgramTest {
             &realm_authority.pubkey(),
             &realm_cookie.account.community_mint,
             &self.context.payer.pubkey(),
-            Some(council_mint),
             Some(realm_custodian.pubkey()),
+            Some(council_mint),
             name.clone(),
             community_mint_max_vote_weight_source,
         );

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -136,7 +136,6 @@ impl GovernanceProgramTest {
     #[allow(dead_code)]
     pub async fn with_realm(&mut self) -> RealmCookie {
         let config_args = RealmConfigArgs {
-            use_authority: true,
             use_council_mint: true,
             use_custodian: true,
             community_mint_max_vote_weight_source: MintMaxVoteWeightSource::FULL_SUPPLY_FRACTION,
@@ -199,21 +198,15 @@ impl GovernanceProgramTest {
             (None, None, None)
         };
 
-        let (realm_authority_pubkey, realm_authority) = if config_args.use_authority {
-            let realm_authority = Keypair::new();
-            (Some(realm_authority.pubkey()), Some(realm_authority))
-        } else {
-            (None, None)
-        };
-
+        let realm_authority = Keypair::new();
         let realm_custodian = Keypair::new();
 
         let create_realm_instruction = create_realm(
             &self.program_id,
+            &realm_authority.pubkey(),
             &community_token_mint_keypair.pubkey(),
             &self.context.payer.pubkey(),
             council_token_mint_pubkey,
-            realm_authority_pubkey,
             Some(realm_custodian.pubkey()),
             name.clone(),
             config_args.community_mint_max_vote_weight_source.clone(),
@@ -229,7 +222,7 @@ impl GovernanceProgramTest {
 
             name,
             reserved: [0; 8],
-            authority: realm_authority_pubkey,
+            authority: Some(realm_authority.pubkey()),
             config: RealmConfig {
                 council_mint: council_token_mint_pubkey,
                 reserved: [0; 8],
@@ -249,7 +242,7 @@ impl GovernanceProgramTest {
 
             council_token_holding_account: council_token_holding_address,
             council_mint_authority: council_token_mint_authority,
-            realm_authority,
+            realm_authority: Some(realm_authority),
         }
     }
 
@@ -267,10 +260,10 @@ impl GovernanceProgramTest {
 
         let create_realm_instruction = create_realm(
             &self.program_id,
+            &realm_authority.pubkey(),
             &realm_cookie.account.community_mint,
             &self.context.payer.pubkey(),
             Some(council_mint),
-            Some(realm_authority.pubkey()),
             Some(realm_custodian.pubkey()),
             name.clone(),
             community_mint_max_vote_weight_source,

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1242,7 +1242,7 @@ impl GovernanceProgramTest {
             no_votes_count: 0,
 
             execution_flags: InstructionExecutionFlags::None,
-            governing_token_mint_vote_supply: None,
+            max_vote_weight: None,
             vote_threshold_percentage: None,
         };
 

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -47,7 +47,10 @@ use spl_governance::{
         proposal_instruction::{
             get_proposal_instruction_address, InstructionData, ProposalInstruction,
         },
-        realm::{get_governing_token_holding_address, get_realm_address, Realm, RealmConfig},
+        realm::{
+            get_governing_token_holding_address, get_realm_address, Realm, RealmConfig,
+            RealmConfigArgs,
+        },
         signatory_record::{get_signatory_record_address, SignatoryRecord},
         token_owner_record::{get_token_owner_record_address, TokenOwnerRecord},
         vote_record::{get_vote_record_address, VoteRecord},
@@ -132,6 +135,21 @@ impl GovernanceProgramTest {
 
     #[allow(dead_code)]
     pub async fn with_realm(&mut self) -> RealmCookie {
+        let config_args = RealmConfigArgs {
+            use_authority: true,
+            use_council_mint: true,
+            use_custodian: true,
+            community_mint_max_vote_weight_source: MintMaxVoteWeightSource::FULL_SUPPLY_FRACTION,
+        };
+
+        self.with_realm_using_config_args(&config_args).await
+    }
+
+    #[allow(dead_code)]
+    pub async fn with_realm_using_config_args(
+        &mut self,
+        config_args: &RealmConfigArgs,
+    ) -> RealmCookie {
         let name = format!("Realm #{}", self.next_realm_id).to_string();
         self.next_realm_id += 1;
 
@@ -152,30 +170,53 @@ impl GovernanceProgramTest {
         )
         .await;
 
-        let council_token_mint_keypair = Keypair::new();
-        let council_token_mint_authority = Keypair::new();
+        let (
+            council_token_mint_pubkey,
+            council_token_holding_address,
+            council_token_mint_authority,
+        ) = if config_args.use_council_mint {
+            let council_token_mint_keypair = Keypair::new();
+            let council_token_mint_authority = Keypair::new();
 
-        let council_token_holding_address = get_governing_token_holding_address(
-            &self.program_id,
-            &realm_address,
-            &council_token_mint_keypair.pubkey(),
-        );
+            let council_token_holding_address = get_governing_token_holding_address(
+                &self.program_id,
+                &realm_address,
+                &council_token_mint_keypair.pubkey(),
+            );
 
-        self.create_mint(
-            &council_token_mint_keypair,
-            &council_token_mint_authority.pubkey(),
-        )
-        .await;
+            self.create_mint(
+                &council_token_mint_keypair,
+                &council_token_mint_authority.pubkey(),
+            )
+            .await;
 
-        let realm_authority = Keypair::new();
+            (
+                Some(council_token_mint_keypair.pubkey()),
+                Some(council_token_holding_address),
+                Some(council_token_mint_authority),
+            )
+        } else {
+            (None, None, None)
+        };
+
+        let (realm_authority_pubkey, realm_authority) = if config_args.use_authority {
+            let realm_authority = Keypair::new();
+            (Some(realm_authority.pubkey()), Some(realm_authority))
+        } else {
+            (None, None)
+        };
+
+        let realm_custodian = Keypair::new();
 
         let create_realm_instruction = create_realm(
             &self.program_id,
-            &realm_authority.pubkey(),
             &community_token_mint_keypair.pubkey(),
             &self.context.payer.pubkey(),
-            Some(council_token_mint_keypair.pubkey()),
+            council_token_mint_pubkey,
+            realm_authority_pubkey,
+            Some(realm_custodian.pubkey()),
             name.clone(),
+            config_args.community_mint_max_vote_weight_source.clone(),
         );
 
         self.process_transaction(&[create_realm_instruction], None)
@@ -188,12 +229,14 @@ impl GovernanceProgramTest {
 
             name,
             reserved: [0; 8],
-            authority: Some(realm_authority.pubkey()),
+            authority: realm_authority_pubkey,
             config: RealmConfig {
-                council_mint: Some(council_token_mint_keypair.pubkey()),
+                council_mint: council_token_mint_pubkey,
                 reserved: [0; 8],
-                custodian: Some(realm_authority.pubkey()),
-                community_mint_max_vote_weight_source: MintMaxVoteWeightSource::MAX_FRACTION,
+                custodian: Some(realm_custodian.pubkey()),
+                community_mint_max_vote_weight_source: config_args
+                    .community_mint_max_vote_weight_source
+                    .clone(),
             },
         };
 
@@ -204,8 +247,8 @@ impl GovernanceProgramTest {
             community_mint_authority: community_token_mint_authority,
             community_token_holding_account: community_token_holding_address,
 
-            council_token_holding_account: Some(council_token_holding_address),
-            council_mint_authority: Some(council_token_mint_authority),
+            council_token_holding_account: council_token_holding_address,
+            council_mint_authority: council_token_mint_authority,
             realm_authority,
         }
     }
@@ -219,14 +262,18 @@ impl GovernanceProgramTest {
         let council_mint = realm_cookie.account.config.council_mint.unwrap();
 
         let realm_authority = Keypair::new();
+        let realm_custodian = Keypair::new();
+        let community_mint_max_vote_weight_source = MintMaxVoteWeightSource::FULL_SUPPLY_FRACTION;
 
         let create_realm_instruction = create_realm(
             &self.program_id,
-            &realm_authority.pubkey(),
             &realm_cookie.account.community_mint,
             &self.context.payer.pubkey(),
             Some(council_mint),
+            Some(realm_authority.pubkey()),
+            Some(realm_custodian.pubkey()),
             name.clone(),
+            community_mint_max_vote_weight_source,
         );
 
         self.process_transaction(&[create_realm_instruction], None)
@@ -244,7 +291,8 @@ impl GovernanceProgramTest {
                 council_mint: Some(council_mint),
                 reserved: [0; 8],
                 custodian: Some(realm_authority.pubkey()),
-                community_mint_max_vote_weight_source: MintMaxVoteWeightSource::MAX_FRACTION,
+                community_mint_max_vote_weight_source:
+                    MintMaxVoteWeightSource::FULL_SUPPLY_FRACTION,
             },
         };
 
@@ -268,7 +316,7 @@ impl GovernanceProgramTest {
             council_mint_authority: Some(clone_keypair(
                 realm_cookie.council_mint_authority.as_ref().unwrap(),
             )),
-            realm_authority,
+            realm_authority: Some(realm_authority),
         }
     }
 
@@ -593,13 +641,13 @@ impl GovernanceProgramTest {
         let mut set_realm_authority_ix = set_realm_authority(
             &self.program_id,
             &realm_cookie.address,
-            &realm_cookie.realm_authority.pubkey(),
+            &realm_cookie.realm_authority.as_ref().unwrap().pubkey(),
             new_realm_authority,
         );
 
         instruction_override(&mut set_realm_authority_ix);
 
-        let default_signers = &[&realm_cookie.realm_authority];
+        let default_signers = &[realm_cookie.realm_authority.as_ref().unwrap()];
         let signers = signers_override.unwrap_or(default_signers);
 
         self.process_transaction(&[set_realm_authority_ix], Some(signers))

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -193,7 +193,7 @@ impl GovernanceProgramTest {
                 council_mint: Some(council_token_mint_keypair.pubkey()),
                 reserved: [0; 8],
                 custodian: Some(realm_authority.pubkey()),
-                community_mint_max_vote_weight_source: MintMaxVoteWeightSource::Percentage(100),
+                community_mint_max_vote_weight_source: MintMaxVoteWeightSource::MAX_FRACTION,
             },
         };
 
@@ -244,7 +244,7 @@ impl GovernanceProgramTest {
                 council_mint: Some(council_mint),
                 reserved: [0; 8],
                 custodian: Some(realm_authority.pubkey()),
-                community_mint_max_vote_weight_source: MintMaxVoteWeightSource::Percentage(100),
+                community_mint_max_vote_weight_source: MintMaxVoteWeightSource::MAX_FRACTION,
             },
         };
 


### PR DESCRIPTION
#### Summary 

- `SetRealmConfig` - instruction sets realm config 
- Pass all realm config parameters to `CreateRealm` instruction
- Change mint max vote weight percentage to fraction with 10^10 precision 
- Apply max vote weight fraction when calculating vote results 

Note: In this version it's not possible to change realm council. It's only possible to remove it which is the most common scenario when after initial realm setup the supervisory role of the council is removed.