### PR TITLE
lending: fix slots per year calculation

### DIFF
--- a/token-lending/program/src/state/mod.rs
+++ b/token-lending/program/src/state/mod.rs
@@ -31,7 +31,7 @@ pub const UNINITIALIZED_VERSION: u8 = 0;
 
 /// Number of slots per year
 pub const SLOTS_PER_YEAR: u64 =
-    DEFAULT_TICKS_PER_SECOND / DEFAULT_TICKS_PER_SLOT * SECONDS_PER_DAY * 365;
+    DEFAULT_TICKS_PER_SECOND * SECONDS_PER_DAY * 365 / DEFAULT_TICKS_PER_SLOT;
 
 // Helpers
 fn pack_decimal(decimal: Decimal, dst: &mut [u8; 16]) {


### PR DESCRIPTION
The current calculation of slots per year for interest loses precision by performing division before multiplication.