### PR TITLE
lending: remove unnecessary PDA

### DIFF
--- a/token-lending/js/src/instructions/depositObligationCollateral.ts
+++ b/token-lending/js/src/instructions/depositObligationCollateral.ts
@@ -19,7 +19,6 @@ export const depositObligationCollateralInstruction = (
     depositReserve: PublicKey,
     obligation: PublicKey,
     lendingMarket: PublicKey,
-    lendingMarketAuthority: PublicKey,
     obligationOwner: PublicKey,
     transferAuthority: PublicKey
 ): TransactionInstruction => {
@@ -38,7 +37,6 @@ export const depositObligationCollateralInstruction = (
         { pubkey: depositReserve, isSigner: false, isWritable: false },
         { pubkey: obligation, isSigner: false, isWritable: true },
         { pubkey: lendingMarket, isSigner: false, isWritable: false },
-        { pubkey: lendingMarketAuthority, isSigner: false, isWritable: false },
         { pubkey: obligationOwner, isSigner: true, isWritable: false },
         { pubkey: transferAuthority, isSigner: true, isWritable: false },
         { pubkey: SYSVAR_CLOCK_PUBKEY, isSigner: false, isWritable: false },

--- a/token-lending/program/src/instruction.rs
+++ b/token-lending/program/src/instruction.rs
@@ -168,11 +168,10 @@ pub enum LendingInstruction {
     ///   2. `[]` Deposit reserve account - refreshed.
     ///   3. `[writable]` Obligation account.
     ///   4. `[]` Lending market account.
-    ///   5. `[]` Derived lending market authority.
-    ///   6. `[signer]` Obligation owner.
-    ///   7. `[signer]` User transfer authority ($authority).
-    ///   8. `[]` Clock sysvar.
-    ///   9. `[]` Token program id.
+    ///   5. `[signer]` Obligation owner.
+    ///   6. `[signer]` User transfer authority ($authority).
+    ///   7. `[]` Clock sysvar.
+    ///   8. `[]` Token program id.
     DepositObligationCollateral {
         /// Amount of collateral tokens to deposit
         collateral_amount: u64,
@@ -789,10 +788,6 @@ pub fn deposit_obligation_collateral(
     obligation_owner_pubkey: Pubkey,
     user_transfer_authority_pubkey: Pubkey,
 ) -> Instruction {
-    let (lending_market_authority_pubkey, _bump_seed) = Pubkey::find_program_address(
-        &[&lending_market_pubkey.to_bytes()[..PUBKEY_BYTES]],
-        &program_id,
-    );
     Instruction {
         program_id,
         accounts: vec![
@@ -801,7 +796,6 @@ pub fn deposit_obligation_collateral(
             AccountMeta::new_readonly(deposit_reserve_pubkey, false),
             AccountMeta::new(obligation_pubkey, false),
             AccountMeta::new_readonly(lending_market_pubkey, false),
-            AccountMeta::new_readonly(lending_market_authority_pubkey, false),
             AccountMeta::new_readonly(obligation_owner_pubkey, true),
             AccountMeta::new_readonly(user_transfer_authority_pubkey, true),
             AccountMeta::new_readonly(sysvar::clock::id(), false),

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -817,7 +817,6 @@ fn process_deposit_obligation_collateral(
     let deposit_reserve_info = next_account_info(account_info_iter)?;
     let obligation_info = next_account_info(account_info_iter)?;
     let lending_market_info = next_account_info(account_info_iter)?;
-    let lending_market_authority_info = next_account_info(account_info_iter)?;
     let obligation_owner_info = next_account_info(account_info_iter)?;
     let user_transfer_authority_info = next_account_info(account_info_iter)?;
     let clock = &Clock::from_account_info(next_account_info(account_info_iter)?)?;
@@ -877,19 +876,6 @@ fn process_deposit_obligation_collateral(
     if !obligation_owner_info.is_signer {
         msg!("Obligation owner provided must be a signer");
         return Err(LendingError::InvalidSigner.into());
-    }
-
-    let authority_signer_seeds = &[
-        lending_market_info.key.as_ref(),
-        &[lending_market.bump_seed],
-    ];
-    let lending_market_authority_pubkey =
-        Pubkey::create_program_address(authority_signer_seeds, program_id)?;
-    if &lending_market_authority_pubkey != lending_market_authority_info.key {
-        msg!(
-            "Derived lending market authority does not match the lending market authority provided"
-        );
-        return Err(LendingError::InvalidMarketAuthority.into());
     }
 
     obligation


### PR DESCRIPTION
The `DepositObligationCollateral` instruction has a derived lending market authority that isn't needed for validation or for token transfers. This removes the account from the instruction and JS client.