### PR TITLE
stake-pool: Address a few points post-liquid staking

### DIFF
--- a/stake-pool/program/src/instruction.rs
+++ b/stake-pool/program/src/instruction.rs
@@ -28,14 +28,14 @@ pub enum PreferredValidatorType {
     Withdraw,
 }
 
-/// Defines which validator vote account is set during the
-/// `SetPreferredValidator` instruction
+/// Defines which deposit authority to update in the `SetDepositAuthority`
+/// instruction
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize, BorshSchema)]
 pub enum DepositType {
-    /// Set preferred validator for deposits
+    /// Sets the stake deposit authority
     Stake,
-    /// Set preferred validator for withdraws
+    /// Sets the SOL deposit authority
     Sol,
 }
 
@@ -1132,66 +1132,6 @@ pub fn set_fee(
     }
 }
 
-/// Creates a 'set fee' instruction for setting the epoch fee
-pub fn set_epoch_fee(
-    program_id: &Pubkey,
-    stake_pool: &Pubkey,
-    manager: &Pubkey,
-    fee: Fee,
-) -> Instruction {
-    set_fee(program_id, stake_pool, manager, FeeType::Epoch(fee))
-}
-
-/// Creates a 'set fee' instruction for setting withdrawal fee
-pub fn set_withdrawal_fee(
-    program_id: &Pubkey,
-    stake_pool: &Pubkey,
-    manager: &Pubkey,
-    fee: Fee,
-) -> Instruction {
-    set_fee(program_id, stake_pool, manager, FeeType::Withdrawal(fee))
-}
-
-/// Creates a 'set fee' instruction for setting SOL deposit fee
-pub fn set_sol_deposit_fee(
-    program_id: &Pubkey,
-    stake_pool: &Pubkey,
-    manager: &Pubkey,
-    fee: Fee,
-) -> Instruction {
-    set_fee(program_id, stake_pool, manager, FeeType::SolDeposit(fee))
-}
-
-/// Creates a 'set fee' instruction for setting stake deposit fee
-pub fn set_stake_deposit_fee(
-    program_id: &Pubkey,
-    stake_pool: &Pubkey,
-    manager: &Pubkey,
-    fee: Fee,
-) -> Instruction {
-    set_fee(program_id, stake_pool, manager, FeeType::StakeDeposit(fee))
-}
-
-/// Creates a 'set fee' instruction for setting SOL referral fee
-pub fn set_sol_referral_fee(
-    program_id: &Pubkey,
-    stake_pool: &Pubkey,
-    manager: &Pubkey,
-    fee: u8,
-) -> Instruction {
-    set_fee(program_id, stake_pool, manager, FeeType::SolReferral(fee))
-}
-
-/// Creates a 'set fee' instruction for setting stake referral fee
-pub fn set_stake_referral_fee(
-    program_id: &Pubkey,
-    stake_pool: &Pubkey,
-    manager: &Pubkey,
-    fee: u8,
-) -> Instruction {
-    set_fee(program_id, stake_pool, manager, FeeType::StakeReferral(fee))
-}
-
 /// Creates a 'set staker' instruction.
 pub fn set_staker(
     program_id: &Pubkey,
@@ -1211,13 +1151,13 @@ pub fn set_staker(
     }
 }
 
-/// Creates a 'set sol deposit authority' instruction.
+/// Creates a 'set deposit authority' instruction.
 pub fn set_deposit_authority(
     program_id: &Pubkey,
     stake_pool: &Pubkey,
     manager: &Pubkey,
     new_sol_deposit_authority: Option<&Pubkey>,
-    for_stake_deposit: bool,
+    deposit_type: DepositType,
 ) -> Instruction {
     let mut accounts = vec![
         AccountMeta::new(*stake_pool, false),
@@ -1229,59 +1169,7 @@ pub fn set_deposit_authority(
     Instruction {
         program_id: *program_id,
         accounts,
-        data: if for_stake_deposit {
-            StakePoolInstruction::SetDepositAuthority(DepositType::Stake)
-                .try_to_vec()
-                .unwrap()
-        } else {
-            StakePoolInstruction::SetDepositAuthority(DepositType::Sol)
-                .try_to_vec()
-                .unwrap()
-        },
-    }
-}
-
-/// Creates a 'set stake deposit authority' instruction.
-pub fn set_stake_deposit_authority(
-    program_id: &Pubkey,
-    stake_pool: &Pubkey,
-    manager: &Pubkey,
-    new_stake_deposit_authority: Option<&Pubkey>,
-) -> Instruction {
-    let mut accounts = vec![
-        AccountMeta::new(*stake_pool, false),
-        AccountMeta::new_readonly(*manager, true),
-    ];
-    if let Some(auth) = new_stake_deposit_authority {
-        accounts.push(AccountMeta::new_readonly(*auth, false))
-    }
-    Instruction {
-        program_id: *program_id,
-        accounts,
-        data: StakePoolInstruction::SetDepositAuthority(DepositType::Stake)
-            .try_to_vec()
-            .unwrap(),
-    }
-}
-
-/// Creates a 'set stake deposit authority' instruction.
-pub fn set_sol_deposit_authority(
-    program_id: &Pubkey,
-    stake_pool: &Pubkey,
-    manager: &Pubkey,
-    new_stake_deposit_authority: Option<&Pubkey>,
-) -> Instruction {
-    let mut accounts = vec![
-        AccountMeta::new(*stake_pool, false),
-        AccountMeta::new_readonly(*manager, true),
-    ];
-    if let Some(auth) = new_stake_deposit_authority {
-        accounts.push(AccountMeta::new_readonly(*auth, false))
-    }
-    Instruction {
-        program_id: *program_id,
-        accounts,
-        data: StakePoolInstruction::SetDepositAuthority(DepositType::Sol)
+        data: StakePoolInstruction::SetDepositAuthority(deposit_type)
             .try_to_vec()
             .unwrap(),
     }

--- a/stake-pool/program/src/state.rs
+++ b/stake-pool/program/src/state.rs
@@ -295,9 +295,10 @@ impl StakePool {
     #[inline]
     pub(crate) fn check_sol_deposit_authority(
         &self,
-        sol_deposit_authority: &AccountInfo,
+        maybe_sol_deposit_authority: Result<&AccountInfo, ProgramError>,
     ) -> Result<(), ProgramError> {
         if let Some(auth) = self.sol_deposit_authority {
+            let sol_deposit_authority = maybe_sol_deposit_authority?;
             if auth != *sol_deposit_authority.key {
                 return Err(StakePoolError::InvalidSolDepositAuthority.into());
             }

--- a/stake-pool/program/tests/deposit_sol.rs
+++ b/stake-pool/program/tests/deposit_sol.rs
@@ -14,7 +14,11 @@ use {
         transaction::TransactionError,
         transport::TransportError,
     },
-    spl_stake_pool::{error, id, instruction, state},
+    spl_stake_pool::{
+        error, id,
+        instruction::{self, DepositType},
+        state,
+    },
     spl_token::error as token_error,
 };
 
@@ -48,17 +52,17 @@ async fn setup() -> (ProgramTestContext, StakePoolAccounts, Keypair, Pubkey) {
     .unwrap();
     let mut transaction = Transaction::new_with_payer(
         &[
-            instruction::set_sol_deposit_fee(
+            instruction::set_fee(
                 &id(),
                 &stake_pool_accounts.stake_pool.pubkey(),
                 &stake_pool_accounts.manager.pubkey(),
-                stake_pool_accounts.deposit_fee,
+                state::FeeType::SolDeposit(stake_pool_accounts.deposit_fee),
             ),
-            instruction::set_sol_referral_fee(
+            instruction::set_fee(
                 &id(),
                 &stake_pool_accounts.stake_pool.pubkey(),
                 &stake_pool_accounts.manager.pubkey(),
-                stake_pool_accounts.referral_fee,
+                state::FeeType::SolReferral(stake_pool_accounts.referral_fee),
             ),
         ],
         Some(&context.payer.pubkey()),
@@ -318,7 +322,7 @@ async fn success_with_sol_deposit_authority() {
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.manager.pubkey(),
             Some(&sol_deposit_authority.pubkey()),
-            false,
+            DepositType::Sol,
         )],
         Some(&payer.pubkey()),
     );
@@ -369,7 +373,7 @@ async fn fail_without_sol_deposit_authority_signature() {
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.manager.pubkey(),
             Some(&sol_deposit_authority.pubkey()),
-            false,
+            DepositType::Sol,
         )],
         Some(&payer.pubkey()),
     );

--- a/stake-pool/program/tests/set_deposit_authority.rs
+++ b/stake-pool/program/tests/set_deposit_authority.rs
@@ -15,7 +15,11 @@ use {
         instruction::InstructionError, signature::Keypair, signature::Signer,
         transaction::Transaction, transaction::TransactionError, transport::TransportError,
     },
-    spl_stake_pool::{error, find_deposit_authority_program_address, id, instruction, state},
+    spl_stake_pool::{
+        error, find_deposit_authority_program_address, id,
+        instruction::{self, DepositType},
+        state,
+    },
 };
 
 async fn setup() -> (BanksClient, Keypair, Hash, StakePoolAccounts, Keypair) {
@@ -53,7 +57,7 @@ async fn success_set_stake_deposit_authority() {
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.manager.pubkey(),
             Some(&new_stake_deposit_authority.pubkey()),
-            true,
+            DepositType::Stake,
         )],
         Some(&payer.pubkey()),
     );
@@ -86,7 +90,7 @@ async fn success_set_stake_deposit_authority_to_none() {
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.manager.pubkey(),
             Some(&new_stake_deposit_authority.pubkey()),
-            true,
+            DepositType::Stake,
         )],
         Some(&payer.pubkey()),
     );
@@ -108,7 +112,7 @@ async fn success_set_stake_deposit_authority_to_none() {
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.manager.pubkey(),
             None,
-            true,
+            DepositType::Stake,
         )],
         Some(&payer.pubkey()),
     );
@@ -141,7 +145,7 @@ async fn fail_stake_wrong_manager() {
             &stake_pool_accounts.stake_pool.pubkey(),
             &new_stake_deposit_authority.pubkey(),
             Some(&new_stake_deposit_authority.pubkey()),
-            true,
+            DepositType::Stake,
         )],
         Some(&payer.pubkey()),
     );
@@ -220,7 +224,7 @@ async fn success_set_sol_deposit_authority() {
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.manager.pubkey(),
             Some(&new_sol_deposit_authority.pubkey()),
-            false,
+            DepositType::Sol,
         )],
         Some(&payer.pubkey()),
     );
@@ -248,7 +252,7 @@ async fn success_set_sol_deposit_authority_to_none() {
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.manager.pubkey(),
             Some(&new_sol_deposit_authority.pubkey()),
-            false,
+            DepositType::Sol,
         )],
         Some(&payer.pubkey()),
     );
@@ -270,7 +274,7 @@ async fn success_set_sol_deposit_authority_to_none() {
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.manager.pubkey(),
             None,
-            false,
+            DepositType::Sol,
         )],
         Some(&payer.pubkey()),
     );
@@ -295,7 +299,7 @@ async fn fail_sol_wrong_manager() {
             &stake_pool_accounts.stake_pool.pubkey(),
             &new_sol_deposit_authority.pubkey(),
             Some(&new_sol_deposit_authority.pubkey()),
-            false,
+            DepositType::Sol,
         )],
         Some(&payer.pubkey()),
     );

--- a/stake-pool/program/tests/set_deposit_fee.rs
+++ b/stake-pool/program/tests/set_deposit_fee.rs
@@ -11,7 +11,11 @@ use {
         signature::{Keypair, Signer},
         transaction::{Transaction, TransactionError},
     },
-    spl_stake_pool::{error, id, instruction, state::Fee, state::StakePool},
+    spl_stake_pool::{
+        error, id, instruction,
+        state::StakePool,
+        state::{Fee, FeeType},
+    },
 };
 
 async fn setup(fee: Option<Fee>) -> (ProgramTestContext, StakePoolAccounts, Fee) {
@@ -42,11 +46,11 @@ async fn success_stake() {
     let (mut context, stake_pool_accounts, new_deposit_fee) = setup(None).await;
 
     let transaction = Transaction::new_signed_with_payer(
-        &[instruction::set_stake_deposit_fee(
+        &[instruction::set_fee(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.manager.pubkey(),
-            new_deposit_fee,
+            FeeType::StakeDeposit(new_deposit_fee),
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, &stake_pool_accounts.manager],
@@ -80,11 +84,11 @@ async fn success_stake_increase_fee_from_0() {
     };
 
     let transaction = Transaction::new_signed_with_payer(
-        &[instruction::set_stake_deposit_fee(
+        &[instruction::set_fee(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.manager.pubkey(),
-            new_deposit_fee,
+            FeeType::StakeDeposit(new_deposit_fee),
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, &stake_pool_accounts.manager],
@@ -111,11 +115,11 @@ async fn fail_stake_wrong_manager() {
 
     let wrong_manager = Keypair::new();
     let transaction = Transaction::new_signed_with_payer(
-        &[instruction::set_stake_deposit_fee(
+        &[instruction::set_fee(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &wrong_manager.pubkey(),
-            new_deposit_fee,
+            FeeType::StakeDeposit(new_deposit_fee),
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, &wrong_manager],
@@ -147,11 +151,11 @@ async fn fail_stake_high_deposit_fee() {
         denominator: 100000,
     };
     let transaction = Transaction::new_signed_with_payer(
-        &[instruction::set_stake_deposit_fee(
+        &[instruction::set_fee(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.manager.pubkey(),
-            new_deposit_fee,
+            FeeType::StakeDeposit(new_deposit_fee),
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, &stake_pool_accounts.manager],
@@ -179,11 +183,11 @@ async fn success_sol() {
     let (mut context, stake_pool_accounts, new_deposit_fee) = setup(None).await;
 
     let transaction = Transaction::new_signed_with_payer(
-        &[instruction::set_sol_deposit_fee(
+        &[instruction::set_fee(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.manager.pubkey(),
-            new_deposit_fee,
+            FeeType::SolDeposit(new_deposit_fee),
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, &stake_pool_accounts.manager],
@@ -210,11 +214,11 @@ async fn fail_sol_wrong_manager() {
 
     let wrong_manager = Keypair::new();
     let transaction = Transaction::new_signed_with_payer(
-        &[instruction::set_sol_deposit_fee(
+        &[instruction::set_fee(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &wrong_manager.pubkey(),
-            new_deposit_fee,
+            FeeType::SolDeposit(new_deposit_fee),
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, &wrong_manager],
@@ -246,11 +250,11 @@ async fn fail_sol_high_deposit_fee() {
         denominator: 100000,
     };
     let transaction = Transaction::new_signed_with_payer(
-        &[instruction::set_sol_deposit_fee(
+        &[instruction::set_fee(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.manager.pubkey(),
-            new_deposit_fee,
+            FeeType::SolDeposit(new_deposit_fee),
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, &stake_pool_accounts.manager],

--- a/stake-pool/program/tests/set_fee.rs
+++ b/stake-pool/program/tests/set_fee.rs
@@ -13,7 +13,7 @@ use {
     },
     spl_stake_pool::{
         error, id, instruction,
-        state::{Fee, StakePool},
+        state::{Fee, FeeType, StakePool},
     },
 };
 
@@ -50,11 +50,11 @@ async fn success() {
     let old_fee = stake_pool.fee;
 
     let transaction = Transaction::new_signed_with_payer(
-        &[instruction::set_epoch_fee(
+        &[instruction::set_fee(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.manager.pubkey(),
-            new_fee,
+            FeeType::Epoch(new_fee),
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, &stake_pool_accounts.manager],
@@ -108,11 +108,11 @@ async fn fail_wrong_manager() {
 
     let wrong_manager = Keypair::new();
     let transaction = Transaction::new_signed_with_payer(
-        &[instruction::set_epoch_fee(
+        &[instruction::set_fee(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &wrong_manager.pubkey(),
-            new_fee,
+            FeeType::Epoch(new_fee),
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, &wrong_manager],
@@ -144,11 +144,11 @@ async fn fail_high_fee() {
         denominator: 10,
     };
     let transaction = Transaction::new_signed_with_payer(
-        &[instruction::set_epoch_fee(
+        &[instruction::set_fee(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.manager.pubkey(),
-            new_fee,
+            FeeType::Epoch(new_fee),
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, &stake_pool_accounts.manager],
@@ -193,11 +193,11 @@ async fn fail_not_updated() {
     context.warp_to_slot(50_000).unwrap();
 
     let transaction = Transaction::new_signed_with_payer(
-        &[instruction::set_epoch_fee(
+        &[instruction::set_fee(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.manager.pubkey(),
-            new_fee,
+            FeeType::Epoch(new_fee),
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, &stake_pool_accounts.manager],

--- a/stake-pool/program/tests/set_referral_fee.rs
+++ b/stake-pool/program/tests/set_referral_fee.rs
@@ -11,7 +11,10 @@ use {
         signature::{Keypair, Signer},
         transaction::{Transaction, TransactionError},
     },
-    spl_stake_pool::{error, id, instruction, state::StakePool},
+    spl_stake_pool::{
+        error, id, instruction,
+        state::{FeeType, StakePool},
+    },
 };
 
 async fn setup(fee: Option<u8>) -> (ProgramTestContext, StakePoolAccounts, u8) {
@@ -39,11 +42,11 @@ async fn success_stake() {
     let (mut context, stake_pool_accounts, new_referral_fee) = setup(None).await;
 
     let transaction = Transaction::new_signed_with_payer(
-        &[instruction::set_stake_referral_fee(
+        &[instruction::set_fee(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.manager.pubkey(),
-            new_referral_fee,
+            FeeType::StakeReferral(new_referral_fee),
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, &stake_pool_accounts.manager],
@@ -70,11 +73,11 @@ async fn success_stake_increase_fee_from_0() {
     let new_referral_fee = 30u8;
 
     let transaction = Transaction::new_signed_with_payer(
-        &[instruction::set_stake_referral_fee(
+        &[instruction::set_fee(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.manager.pubkey(),
-            new_referral_fee,
+            FeeType::StakeReferral(new_referral_fee),
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, &stake_pool_accounts.manager],
@@ -101,11 +104,11 @@ async fn fail_stake_wrong_manager() {
 
     let wrong_manager = Keypair::new();
     let transaction = Transaction::new_signed_with_payer(
-        &[instruction::set_stake_referral_fee(
+        &[instruction::set_fee(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &wrong_manager.pubkey(),
-            new_referral_fee,
+            FeeType::StakeReferral(new_referral_fee),
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, &wrong_manager],
@@ -134,11 +137,11 @@ async fn fail_stake_high_referral_fee() {
 
     let new_referral_fee = 110u8;
     let transaction = Transaction::new_signed_with_payer(
-        &[instruction::set_stake_referral_fee(
+        &[instruction::set_fee(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.manager.pubkey(),
-            new_referral_fee,
+            FeeType::StakeReferral(new_referral_fee),
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, &stake_pool_accounts.manager],
@@ -166,11 +169,11 @@ async fn success_sol() {
     let (mut context, stake_pool_accounts, new_referral_fee) = setup(None).await;
 
     let transaction = Transaction::new_signed_with_payer(
-        &[instruction::set_sol_referral_fee(
+        &[instruction::set_fee(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.manager.pubkey(),
-            new_referral_fee,
+            FeeType::SolReferral(new_referral_fee),
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, &stake_pool_accounts.manager],
@@ -197,11 +200,11 @@ async fn fail_sol_wrong_manager() {
 
     let wrong_manager = Keypair::new();
     let transaction = Transaction::new_signed_with_payer(
-        &[instruction::set_sol_referral_fee(
+        &[instruction::set_fee(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &wrong_manager.pubkey(),
-            new_referral_fee,
+            FeeType::SolReferral(new_referral_fee),
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, &wrong_manager],
@@ -230,11 +233,11 @@ async fn fail_sol_high_referral_fee() {
 
     let new_referral_fee = 110u8;
     let transaction = Transaction::new_signed_with_payer(
-        &[instruction::set_sol_referral_fee(
+        &[instruction::set_fee(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.manager.pubkey(),
-            new_referral_fee,
+            FeeType::SolReferral(new_referral_fee),
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, &stake_pool_accounts.manager],

--- a/stake-pool/program/tests/set_withdrawal_fee.rs
+++ b/stake-pool/program/tests/set_withdrawal_fee.rs
@@ -13,7 +13,7 @@ use {
     },
     spl_stake_pool::{
         error, id, instruction,
-        state::{Fee, StakePool},
+        state::{Fee, FeeType, StakePool},
     },
 };
 
@@ -53,11 +53,11 @@ async fn success() {
     let old_withdrawal_fee = stake_pool.withdrawal_fee;
 
     let transaction = Transaction::new_signed_with_payer(
-        &[instruction::set_withdrawal_fee(
+        &[instruction::set_fee(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.manager.pubkey(),
-            new_withdrawal_fee,
+            FeeType::Withdrawal(new_withdrawal_fee),
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, &stake_pool_accounts.manager],
@@ -126,11 +126,11 @@ async fn success_increase_fee_from_0() {
     let old_withdrawal_fee = stake_pool.withdrawal_fee;
 
     let transaction = Transaction::new_signed_with_payer(
-        &[instruction::set_withdrawal_fee(
+        &[instruction::set_fee(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.manager.pubkey(),
-            new_withdrawal_fee,
+            FeeType::Withdrawal(new_withdrawal_fee),
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, &stake_pool_accounts.manager],
@@ -184,11 +184,11 @@ async fn fail_wrong_manager() {
 
     let wrong_manager = Keypair::new();
     let transaction = Transaction::new_signed_with_payer(
-        &[instruction::set_withdrawal_fee(
+        &[instruction::set_fee(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &wrong_manager.pubkey(),
-            new_withdrawal_fee,
+            FeeType::Withdrawal(new_withdrawal_fee),
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, &wrong_manager],
@@ -220,11 +220,11 @@ async fn fail_high_withdrawal_fee() {
         denominator: 10,
     };
     let transaction = Transaction::new_signed_with_payer(
-        &[instruction::set_withdrawal_fee(
+        &[instruction::set_fee(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.manager.pubkey(),
-            new_withdrawal_fee,
+            FeeType::Withdrawal(new_withdrawal_fee),
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, &stake_pool_accounts.manager],
@@ -255,11 +255,11 @@ async fn fail_high_withdrawal_fee_increase() {
         denominator: 10_000,
     };
     let transaction = Transaction::new_signed_with_payer(
-        &[instruction::set_withdrawal_fee(
+        &[instruction::set_fee(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.manager.pubkey(),
-            new_withdrawal_fee,
+            FeeType::Withdrawal(new_withdrawal_fee),
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, &stake_pool_accounts.manager],
@@ -294,11 +294,11 @@ async fn fail_high_withdrawal_fee_increase_from_0() {
         denominator: 10_000,
     };
     let transaction = Transaction::new_signed_with_payer(
-        &[instruction::set_withdrawal_fee(
+        &[instruction::set_fee(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.manager.pubkey(),
-            new_withdrawal_fee,
+            FeeType::Withdrawal(new_withdrawal_fee),
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, &stake_pool_accounts.manager],
@@ -343,11 +343,11 @@ async fn fail_not_updated() {
     context.warp_to_slot(50_000).unwrap();
 
     let transaction = Transaction::new_signed_with_payer(
-        &[instruction::set_withdrawal_fee(
+        &[instruction::set_fee(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.manager.pubkey(),
-            new_withdrawal_fee,
+            FeeType::Withdrawal(new_withdrawal_fee),
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, &stake_pool_accounts.manager],


### PR DESCRIPTION
A few cleanup bits from the great work done in #2141

Program:
* fix checking sol deposit auth <-- this one's important
* add 0 pool token check for user, so that they don't deposit into the pool and get nothing back!
* avoid using `+` in favor of `saturating_add` for one check in particular (which may even be optimized away by the compiler)
* remove unused instruction creators

CLI:
* unify `set-sol-deposit-authority` and `set-stake-deposit-authority` into `set-deposit-authority`
* unify `set-sol-referral-fee`and `set-stake-referral-fee` into `set-referral-fee`

cc @jon-chuang @billythedummy 