### PR TITLE
Add Anchor.toml for source verification

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -1,0 +1,11 @@
+anchor_version = "0.13.2"
+
+[workspace]
+members = ["governance/program"]
+
+[provider]
+cluster = "mainnet"
+wallet = "~/.config/solana/id.json"
+
+[programs.mainnet]
+spl_governance = "GoVEr6xcF9QGrRFJC4kt9wiCdNqZzrG7KWdrm7viDnpa"


### PR DESCRIPTION
As requested by @SebastianBor.

Adds an Anchor.toml so that the governance program can be built and verified via the Anchor CLI. Both the write-buffer and the program can be verified.

Usage:

* [Install](https://project-serum.github.io/anchor/getting-started/installation.html#install-anchor) anchor-cli v0.13.2 or later.
* Build: `anchor build -p spl_governance --verifiable` in the root workspace directory.
* Deploy: `solana program write-buffer target/verifiable/spl_governance.so`
* Verify: `anchor verify -p spl_governance <program-id>`
