### PR TITLE
fix stake-pool: preferred validator can be set to validator not part of the pool

### DIFF
--- a/stake-pool/program/src/error.rs
+++ b/stake-pool/program/src/error.rs
@@ -116,6 +116,9 @@ pub enum StakePoolError {
     /// Provided sol deposit authority does not match the program's
     #[error("InvalidSolDepositAuthority")]
     InvalidSolDepositAuthority,
+    /// Provided preferred validator is invalid
+    #[error("InvalidPreferredValidator")]
+    InvalidPreferredValidator,
 }
 impl From<StakePoolError> for ProgramError {
     fn from(e: StakePoolError) -> Self {

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -1315,9 +1315,17 @@ impl Processor {
                 vote_account_address.as_ref(),
                 ValidatorStakeInfo::memcmp_pubkey,
             );
-            if maybe_validator_stake_info.is_none() {
-                msg!("Validator for {} not present in the stake pool, cannot set as preferred deposit account");
-                return Err(StakePoolError::ValidatorNotFound.into());
+            match maybe_validator_stake_info {
+                Some(vsi) => {
+                    if vsi.status == StakeStatus::ReadyForRemoval {
+                        msg!("Validator for {:?} about to be removed, cannot set as preferred deposit account", validator_type);
+                        return Err(StakePoolError::InvalidPreferredValidator.into());
+                    }
+                }
+                None => {
+                    msg!("Validator for {:?} not present in the stake pool, cannot set as preferred deposit account", validator_type);
+                    return Err(StakePoolError::ValidatorNotFound.into());
+                }
             }
         }
 
@@ -2611,6 +2619,7 @@ impl PrintProgramError for StakePoolError {
             StakePoolError::DepositTooSmall => msg!("Error: Not enough lamports provided for deposit to result in one pool token"),
             StakePoolError::InvalidStakeDepositAuthority => msg!("Error: Provided stake deposit authority does not match the program's"),
             StakePoolError::InvalidSolDepositAuthority => msg!("Error: Provided sol deposit authority does not match the program's"),
+            StakePoolError::InvalidPreferredValidator => msg!("Error: Provided preferred validator is invalid"),
         }
     }
 }

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -1317,7 +1317,7 @@ impl Processor {
             );
             match maybe_validator_stake_info {
                 Some(vsi) => {
-                    if vsi.status == StakeStatus::ReadyForRemoval {
+                    if vsi.status != StakeStatus::Active {
                         msg!("Validator for {:?} about to be removed, cannot set as preferred deposit account", validator_type);
                         return Err(StakePoolError::InvalidPreferredValidator.into());
                     }

--- a/stake-pool/program/tests/set_preferred.rs
+++ b/stake-pool/program/tests/set_preferred.rs
@@ -250,6 +250,6 @@ async fn fail_ready_for_removal() {
             let program_error = error::StakePoolError::InvalidPreferredValidator as u32;
             assert_eq!(error_index, program_error);
         }
-        _ => panic!("Wrong error occurs while malicious try to set manager"),
+        _ => panic!("Wrong error occurs while trying to set ReadyForRemoval validator"),
     }
 }

--- a/stake-pool/program/tests/set_preferred.rs
+++ b/stake-pool/program/tests/set_preferred.rs
@@ -14,7 +14,7 @@ use {
         transaction::{Transaction, TransactionError},
     },
     spl_stake_pool::{
-        error, id,
+        error, find_transient_stake_program_address, id,
         instruction::{self, PreferredValidatorType},
         state::StakePool,
     },
@@ -202,6 +202,52 @@ async fn fail_not_present_validator() {
     match error {
         TransactionError::InstructionError(_, InstructionError::Custom(error_index)) => {
             let program_error = error::StakePoolError::ValidatorNotFound as u32;
+            assert_eq!(error_index, program_error);
+        }
+        _ => panic!("Wrong error occurs while malicious try to set manager"),
+    }
+}
+
+#[tokio::test]
+async fn fail_ready_for_removal() {
+    let (mut banks_client, payer, recent_blockhash, stake_pool_accounts, validator_stake_account) =
+        setup().await;
+    let validator_vote_address = validator_stake_account.vote.pubkey();
+
+    // Mark validator as ready for removal
+    let (transient_stake_address, _) = find_transient_stake_program_address(
+        &id(),
+        &validator_vote_address,
+        &stake_pool_accounts.stake_pool.pubkey(),
+    );
+    let new_authority = Pubkey::new_unique();
+    let remove_err = stake_pool_accounts
+        .remove_validator_from_pool(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            &new_authority,
+            &validator_stake_account.stake_account,
+            &transient_stake_address,
+        )
+        .await;
+    assert!(remove_err.is_none());
+
+    let error = stake_pool_accounts
+        .set_preferred_validator(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            PreferredValidatorType::Withdraw,
+            Some(validator_vote_address),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+    match error {
+        TransactionError::InstructionError(_, InstructionError::Custom(error_index)) => {
+            let program_error = error::StakePoolError::InvalidPreferredValidator as u32;
             assert_eq!(error_index, program_error);
         }
         _ => panic!("Wrong error occurs while malicious try to set manager"),


### PR DESCRIPTION
closes #2262

- denies setting validator to validators with status `ReadyForRemoval`
- add test for this in `set_preferred`

@jon-chuang