### PR TITLE
stake-pool: skip manager fee if invalid account, check new manager fee owned by `spl_token`

### DIFF
--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -2180,7 +2180,7 @@ impl Processor {
         // To prevent a faulty manager fee account from preventing withdrawals
         // if the token program does not own the account, or if the account is not initialized
         let pool_tokens_fee = if stake_pool.manager_fee_account == *burn_from_pool_info.key
-            || !stake_pool.check_manager_fee_info(manager_fee_info).is_ok()
+            || stake_pool.check_manager_fee_info(manager_fee_info).is_err()
         {
             0
         } else {

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -33,7 +33,7 @@ use {
         system_instruction, system_program,
         sysvar::Sysvar,
     },
-    spl_token::state::{Account, AccountState, Mint},
+    spl_token::state::Mint,
 };
 
 /// Deserialize the stake state from AccountInfo
@@ -2174,8 +2174,7 @@ impl Processor {
         // To prevent a faulty manager fee account from preventing withdrawals
         // if the token program does not own the account, or if the account is not initialized
         let pool_tokens_fee = if stake_pool.manager_fee_account == *burn_from_pool_info.key
-            || check_account_owner(manager_fee_info, &stake_pool.token_program_id).is_err()
-            || Account::unpack(&manager_fee_info.data.borrow())?.state != AccountState::Initialized
+            || !stake_pool.check_manager_fee_info(manager_fee_info).is_ok()
         {
             0
         } else {

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -2364,6 +2364,7 @@ impl Processor {
 
         check_account_owner(stake_pool_info, program_id)?;
         let mut stake_pool = try_from_slice_unchecked::<StakePool>(&stake_pool_info.data.borrow())?;
+        check_account_owner(new_manager_fee_info, &stake_pool.token_program_id)?;
         if !stake_pool.is_valid() {
             return Err(StakePoolError::InvalidState.into());
         }

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -160,6 +160,54 @@ pub async fn create_token_account(
     Ok(())
 }
 
+pub async fn close_token_account(
+    banks_client: &mut BanksClient,
+    payer: &Keypair,
+    recent_blockhash: &Hash,
+    account: &Pubkey,
+    lamports_destination: &Pubkey,
+    manager: &Keypair,
+) -> Result<(), TransportError> {
+    let mut transaction = Transaction::new_with_payer(
+        &[spl_token::instruction::close_account(
+            &spl_token::id(),
+            &account,
+            &lamports_destination,
+            &manager.pubkey(),
+            &[],
+        )
+        .unwrap()],
+        Some(&payer.pubkey()),
+    );
+    transaction.sign(&[payer, manager], *recent_blockhash);
+    banks_client.process_transaction(transaction).await?;
+    Ok(())
+}
+
+pub async fn freeze_token_account(
+    banks_client: &mut BanksClient,
+    payer: &Keypair,
+    recent_blockhash: &Hash,
+    account: &Pubkey,
+    pool_mint: &Pubkey,
+    manager: &Keypair,
+) -> Result<(), TransportError> {
+    let mut transaction = Transaction::new_with_payer(
+        &[spl_token::instruction::freeze_account(
+            &spl_token::id(),
+            &account,
+            pool_mint,
+            &manager.pubkey(),
+            &[],
+        )
+        .unwrap()],
+        Some(&payer.pubkey()),
+    );
+    transaction.sign(&[payer, manager], *recent_blockhash);
+    banks_client.process_transaction(transaction).await?;
+    Ok(())
+}
+
 pub async fn mint_tokens(
     banks_client: &mut BanksClient,
     payer: &Keypair,


### PR DESCRIPTION
Fixes: https://github.com/solana-labs/solana-program-library/issues/2261 https://github.com/solana-labs/solana-program-library/issues/2264