### PR TITLE
Use stake pool's declared token ID rather than hard-coded

### DIFF
--- a/stake-pool/program/src/instruction.rs
+++ b/stake-pool/program/src/instruction.rs
@@ -768,6 +768,7 @@ pub fn update_stake_pool_balance(
     reserve_stake: &Pubkey,
     manager_fee_account: &Pubkey,
     stake_pool_mint: &Pubkey,
+    token_program_id: &Pubkey,
 ) -> Instruction {
     let accounts = vec![
         AccountMeta::new(*stake_pool, false),
@@ -777,7 +778,7 @@ pub fn update_stake_pool_balance(
         AccountMeta::new(*manager_fee_account, false),
         AccountMeta::new(*stake_pool_mint, false),
         AccountMeta::new_readonly(sysvar::clock::id(), false),
-        AccountMeta::new_readonly(spl_token::id(), false),
+        AccountMeta::new_readonly(*token_program_id, false),
     ];
     Instruction {
         program_id: *program_id,
@@ -850,6 +851,7 @@ pub fn update_stake_pool(
             &stake_pool.reserve_stake,
             &stake_pool.manager_fee_account,
             &stake_pool.pool_mint,
+            &stake_pool.token_program_id,
         ),
         cleanup_removed_validator_entries(
             program_id,

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -869,6 +869,7 @@ impl StakePoolAccounts {
                 &self.reserve_stake.pubkey(),
                 &self.pool_fee_account.pubkey(),
                 &self.pool_mint.pubkey(),
+                &spl_token::id(),
             )],
             Some(&payer.pubkey()),
             &[payer],
@@ -924,6 +925,7 @@ impl StakePoolAccounts {
                     &self.reserve_stake.pubkey(),
                     &self.pool_fee_account.pubkey(),
                     &self.pool_mint.pubkey(),
+                    &spl_token::id(),
                 ),
                 instruction::cleanup_removed_validator_entries(
                     &id(),

--- a/stake-pool/program/tests/huge_pool.rs
+++ b/stake-pool/program/tests/huge_pool.rs
@@ -350,6 +350,7 @@ async fn update() {
             &stake_pool_accounts.reserve_stake.pubkey(),
             &stake_pool_accounts.pool_fee_account.pubkey(),
             &stake_pool_accounts.pool_mint.pubkey(),
+            &spl_token::id(),
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer],


### PR DESCRIPTION
If a stake pool wants to set up a non `spl_token_program::id` pool, they can do so, but their users will not be minting SPL tokens, (unless via a complex scheme where the alternative token program mints spl tokens in exchange for its tokens):

```rust
// on initialize:
if pool_mint_info.owner != token_program_info.key {
    return Err(ProgramError::IncorrectProgramId);
}
```

In my mind, there is nothing strictly wrong with exposing the extra flexibility of a parametrised token program. It is a little redundant though.

If still wanting to make it hard coded, I don't think this is an urgent issue per se. The current logic works, and is probably correct, and tearing it out could introduce errors, for little benefit.

The purpose of this PR is to use a fully non hard-coded token program id

Fixes:  #2266