### PR TITLE
chore(token): add createTransferCheckedInstruction to flow-typed

### DIFF
--- a/token/js/module.flow.js
+++ b/token/js/module.flow.js
@@ -252,6 +252,16 @@ declare module '@solana/spl-token' {
       authority: PublicKey,
       multiSigners: Array<Signer>,
     ): TransactionInstruction;
+    static createTransferCheckedInstruction(
+      programId: PublicKey,
+      source: PublicKey,
+      mint: PublicKey,
+      destination: PublicKey,
+      owner: PublicKey,
+      multiSigners: Array<Signer>,
+      amount: number | u64,
+      decimals: number,
+    ): TransactionInstruction;
     static createBurnCheckedInstruction(
       programId: PublicKey,
       mint: PublicKey,


### PR DESCRIPTION
This PR intention is to add the `createTransferCheckedInstruction` static method from the Token class in the flow-typed definitions for users still using it.