### PR TITLE
Help package version resolution by removing exact matches

### DIFF
--- a/stake-pool/cli/Cargo.toml
+++ b/stake-pool/cli/Cargo.toml
@@ -12,17 +12,17 @@ version = "0.4.0"
 borsh = "0.9"
 clap = "2.33.3"
 serde_json = "1.0.67"
-solana-account-decoder = "=1.7.11"
-solana-clap-utils = "=1.7.11"
-solana-cli-config = "=1.7.11"
-solana-client = "=1.7.11"
-solana-logger = "=1.7.11"
-solana-program = "=1.7.11"
-solana-remote-wallet = "=1.7.11"
-solana-sdk = "=1.7.11"
-spl-associated-token-account = { version = "1.0", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
-spl-stake-pool = { version = "0.4", path="../program", features = [ "no-entrypoint" ] }
-spl-token = { version = "3.2", path="../../token/program", features = [ "no-entrypoint" ]  }
+solana-account-decoder = "1.7.11"
+solana-clap-utils = "1.7.11"
+solana-cli-config = "1.7.11"
+solana-client = "1.7.11"
+solana-logger = "1.7.11"
+solana-program = "1.7.11"
+solana-remote-wallet = "1.7.11"
+solana-sdk = "1.7.11"
+spl-associated-token-account = { version = "1.0", path = "../../associated-token-account/program", features = [ "no-entrypoint" ] }
+spl-stake-pool = { version = "0.4", path = "../program", features = [ "no-entrypoint" ] }
+spl-token = { version = "3.2", path = "../../token/program", features = [ "no-entrypoint" ]  }
 bs58 = "0.4.0"
 bincode = "1.3.1"
 lazy_static = "1.4.0"


### PR DESCRIPTION
This fixes a possible future problem similar to #2344 in spl-stake-pool-cli v0.4.0. That issue has a separate fix https://github.com/vkomenda/solana-program-library/commit/3926496e52b1b63c73996cfa09893af44ff987f8 which amounts to removing the exact version match of solana libs in Cargo.toml, allowing the version constraint solver find appropriate matches. A similar patch is applied here to the latest version.