### PR TITLE
stake-pool: Split from validator stake account during removal

### DIFF
--- a/stake-pool/program/src/instruction.rs
+++ b/stake-pool/program/src/instruction.rs
@@ -127,8 +127,9 @@ pub enum StakePoolInstruction {
     ///   4. `[w]` Validator stake list storage account
     ///   5. `[w]` Stake account to remove from the pool
     ///   6. `[]` Transient stake account, to check that that we're not trying to activate
-    ///   7. '[]' Sysvar clock
-    ///   8. `[]` Stake program id,
+    ///   7. `[w]` Destination stake account, to receive the minimum SOL from the validator stake account. Must be
+    ///   8. `[]` Sysvar clock
+    ///   9. `[]` Stake program id,
     RemoveValidatorFromPool,
 
     /// (Staker only) Decrease active stake on a validator, eventually moving it to the reserve
@@ -483,6 +484,7 @@ pub fn remove_validator_from_pool(
     validator_list: &Pubkey,
     stake_account: &Pubkey,
     transient_stake_account: &Pubkey,
+    destination_stake_account: &Pubkey,
 ) -> Instruction {
     let accounts = vec![
         AccountMeta::new(*stake_pool, false),
@@ -492,6 +494,7 @@ pub fn remove_validator_from_pool(
         AccountMeta::new(*validator_list, false),
         AccountMeta::new(*stake_account, false),
         AccountMeta::new_readonly(*transient_stake_account, false),
+        AccountMeta::new(*destination_stake_account, false),
         AccountMeta::new_readonly(sysvar::clock::id(), false),
         AccountMeta::new_readonly(stake_program::id(), false),
     ];
@@ -658,6 +661,7 @@ pub fn remove_validator_from_pool_with_vote(
     vote_account_address: &Pubkey,
     new_stake_account_authority: &Pubkey,
     transient_stake_seed: u64,
+    destination_stake_address: &Pubkey,
 ) -> Instruction {
     let pool_withdraw_authority =
         find_withdraw_authority_program_address(program_id, stake_pool_address).0;
@@ -678,6 +682,7 @@ pub fn remove_validator_from_pool_with_vote(
         &stake_pool.validator_list,
         &stake_account_address,
         &transient_stake_account,
+        destination_stake_address,
     )
 }
 

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -886,6 +886,7 @@ impl Processor {
         let validator_list_info = next_account_info(account_info_iter)?;
         let stake_account_info = next_account_info(account_info_iter)?;
         let transient_stake_account_info = next_account_info(account_info_iter)?;
+        let destination_stake_account_info = next_account_info(account_info_iter)?;
         let clock_info = next_account_info(account_info_iter)?;
         let clock = &Clock::from_account_info(clock_info)?;
         let stake_program_info = next_account_info(account_info_iter)?;
@@ -994,9 +995,20 @@ impl Processor {
             StakeStatus::ReadyForRemoval
         };
 
-        Self::stake_authorize_signed(
+        // split whole thing into destination stake account
+        Self::stake_split(
             stake_pool_info.key,
             stake_account_info.clone(),
+            withdraw_authority_info.clone(),
+            AUTHORITY_WITHDRAW,
+            stake_pool.stake_withdraw_bump_seed,
+            stake_account_info.lamports(),
+            destination_stake_account_info.clone(),
+        )?;
+
+        Self::stake_authorize_signed(
+            stake_pool_info.key,
+            destination_stake_account_info.clone(),
             withdraw_authority_info.clone(),
             AUTHORITY_WITHDRAW,
             stake_pool.stake_withdraw_bump_seed,

--- a/stake-pool/program/tests/huge_pool.rs
+++ b/stake-pool/program/tests/huge_pool.rs
@@ -404,6 +404,7 @@ async fn remove_validator_from_pool() {
     );
 
     let new_authority = Pubkey::new_unique();
+    let destination_stake = Keypair::new();
     let error = stake_pool_accounts
         .remove_validator_from_pool(
             &mut context.banks_client,
@@ -412,6 +413,7 @@ async fn remove_validator_from_pool() {
             &new_authority,
             &stake_address,
             &transient_stake_address,
+            &destination_stake,
         )
         .await;
     assert!(error.is_none());
@@ -431,6 +433,7 @@ async fn remove_validator_from_pool() {
     );
 
     let new_authority = Pubkey::new_unique();
+    let destination_stake = Keypair::new();
     let error = stake_pool_accounts
         .remove_validator_from_pool(
             &mut context.banks_client,
@@ -439,6 +442,7 @@ async fn remove_validator_from_pool() {
             &new_authority,
             &stake_address,
             &transient_stake_address,
+            &destination_stake,
         )
         .await;
     assert!(error.is_none());
@@ -455,6 +459,7 @@ async fn remove_validator_from_pool() {
     );
 
     let new_authority = Pubkey::new_unique();
+    let destination_stake = Keypair::new();
     let error = stake_pool_accounts
         .remove_validator_from_pool(
             &mut context.banks_client,
@@ -463,6 +468,7 @@ async fn remove_validator_from_pool() {
             &new_authority,
             &stake_address,
             &transient_stake_address,
+            &destination_stake,
         )
         .await;
     assert!(error.is_none());

--- a/stake-pool/program/tests/set_preferred.rs
+++ b/stake-pool/program/tests/set_preferred.rs
@@ -223,6 +223,7 @@ async fn fail_ready_for_removal() {
         transient_stake_seed,
     );
     let new_authority = Pubkey::new_unique();
+    let destination_stake = Keypair::new();
     let remove_err = stake_pool_accounts
         .remove_validator_from_pool(
             &mut banks_client,
@@ -231,6 +232,7 @@ async fn fail_ready_for_removal() {
             &new_authority,
             &validator_stake_account.stake_account,
             &transient_stake_address,
+            &destination_stake,
         )
         .await;
     assert!(remove_err.is_none());

--- a/stake-pool/program/tests/update_validator_list_balance.rs
+++ b/stake-pool/program/tests/update_validator_list_balance.rs
@@ -6,7 +6,11 @@ use {
     helpers::*,
     solana_program::{borsh::try_from_slice_unchecked, program_pack::Pack, pubkey::Pubkey},
     solana_program_test::*,
-    solana_sdk::{signature::Signer, system_instruction, transaction::Transaction},
+    solana_sdk::{
+        signature::{Keypair, Signer},
+        system_instruction,
+        transaction::Transaction,
+    },
     spl_stake_pool::{
         find_transient_stake_program_address, id, instruction, stake_program,
         state::{StakePool, StakeStatus, ValidatorList},
@@ -462,6 +466,7 @@ async fn merge_transient_stake_after_remove() {
     let stake_rent = rent.minimum_balance(std::mem::size_of::<stake_program::StakeState>());
     let deactivated_lamports = lamports;
     let new_authority = Pubkey::new_unique();
+    let destination_stake = Keypair::new();
     // Decrease and remove all validators
     for stake_account in &stake_accounts {
         let error = stake_pool_accounts
@@ -484,6 +489,7 @@ async fn merge_transient_stake_after_remove() {
                 &new_authority,
                 &stake_account.stake_account,
                 &stake_account.transient_stake_account,
+                &destination_stake,
             )
             .await;
         assert!(error.is_none());


### PR DESCRIPTION
#### Problem

If the stake pool gives over the validator stake account to the staker,
they may keep it and make it impossible to re-add that validator in the
future.

#### Solution

Split the whole amount into a new stake account on removal.