### PR TITLE
stake-pool: Reduce minimum stake per validator to 0.001 SOL

### DIFF
--- a/stake-pool/program/src/lib.rs
+++ b/stake-pool/program/src/lib.rs
@@ -30,7 +30,7 @@ const TRANSIENT_STAKE_SEED_PREFIX: &[u8] = b"transient";
 
 /// Minimum amount of staked SOL required in a validator stake account to allow
 /// for merges without a mismatch on credits observed
-pub const MINIMUM_ACTIVE_STAKE: u64 = LAMPORTS_PER_SOL / 100;
+pub const MINIMUM_ACTIVE_STAKE: u64 = LAMPORTS_PER_SOL / 1_000;
 
 /// Maximum amount of validator stake accounts to update per
 /// `UpdateValidatorListBalance` instruction, based on compute limits

--- a/stake-pool/program/src/lib.rs
+++ b/stake-pool/program/src/lib.rs
@@ -30,7 +30,7 @@ const TRANSIENT_STAKE_SEED_PREFIX: &[u8] = b"transient";
 
 /// Minimum amount of staked SOL required in a validator stake account to allow
 /// for merges without a mismatch on credits observed
-pub const MINIMUM_ACTIVE_STAKE: u64 = LAMPORTS_PER_SOL;
+pub const MINIMUM_ACTIVE_STAKE: u64 = LAMPORTS_PER_SOL / 100;
 
 /// Maximum amount of validator stake accounts to update per
 /// `UpdateValidatorListBalance` instruction, based on compute limits

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -749,7 +749,7 @@ impl Processor {
             &[bump_seed],
         ];
 
-        // Fund the stake account with 1 SOL + rent-exempt balance
+        // Fund the stake account with the minimum + rent-exempt balance
         let required_lamports = MINIMUM_ACTIVE_STAKE
             + rent.minimum_balance(std::mem::size_of::<stake_program::StakeState>());
 

--- a/stake-pool/program/tests/increase.rs
+++ b/stake-pool/program/tests/increase.rs
@@ -12,7 +12,8 @@ use {
         transaction::{Transaction, TransactionError},
     },
     spl_stake_pool::{
-        error::StakePoolError, find_transient_stake_program_address, id, instruction, stake_program,
+        error::StakePoolError, find_transient_stake_program_address, id, instruction,
+        stake_program, MINIMUM_ACTIVE_STAKE,
     },
 };
 
@@ -345,9 +346,6 @@ async fn fail_with_small_lamport_amount() {
         _reserve_lamports,
     ) = setup().await;
 
-    let rent = banks_client.get_rent().await.unwrap();
-    let stake_rent = rent.minimum_balance(std::mem::size_of::<stake_program::StakeState>());
-
     let error = stake_pool_accounts
         .increase_validator_stake(
             &mut banks_client,
@@ -355,7 +353,7 @@ async fn fail_with_small_lamport_amount() {
             &recent_blockhash,
             &validator_stake.transient_stake_account,
             &validator_stake.vote.pubkey(),
-            stake_rent,
+            MINIMUM_ACTIVE_STAKE - 1,
             validator_stake.transient_stake_seed,
         )
         .await


### PR DESCRIPTION
#### Problem

It's expensive to commit 1 SOL + rent exemption for each validator to add to the pool, creating a high barrier for potential pool operators.

#### Solution

Even in the worst case of a poorly performing validator with a 1% commission, ~0.001 SOL will earn rewards, so let's bring this number down to 0.001 SOL!