### PR TITLE
spl-token-cli: Add bench subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3792,6 +3792,8 @@ dependencies = [
 name = "spl-token-cli"
 version = "2.0.14"
 dependencies = [
+ "chrono",
+ "chrono-humanize",
  "clap",
  "console 0.14.1",
  "serde",
@@ -3805,6 +3807,7 @@ dependencies = [
  "solana-logger",
  "solana-remote-wallet",
  "solana-sdk",
+ "solana-transaction-status",
  "spl-associated-token-account 1.0.3",
  "spl-memo 3.0.1",
  "spl-token 3.2.0",

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -10,6 +10,8 @@ version = "2.0.14"
 
 [dependencies]
 clap = "2.33.3"
+chrono = "0.4"
+chrono-humanize = "0.2.1"
 console = "0.14.0"
 serde = "1.0.130"
 serde_derive = "1.0.103"
@@ -22,6 +24,7 @@ solana-client = "=1.7.11"
 solana-logger = "=1.7.11"
 solana-remote-wallet = "=1.7.11"
 solana-sdk = "=1.7.11"
+solana-transaction-status = "=1.7.11"
 spl-token = { version = "3.2", path="../program", features = [ "no-entrypoint" ] }
 spl-associated-token-account = { version = "1.0", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
 spl-memo = { version = "3.0.1", path="../../memo/program", features = ["no-entrypoint"] }

--- a/token/cli/src/bench.rs
+++ b/token/cli/src/bench.rs
@@ -1,0 +1,480 @@
+/// The `bench` subcommand
+use {
+    crate::{
+        config::Config, owner_address_arg,
+        rpc_client_utils::send_and_confirm_messages_with_spinner, Error,
+    },
+    chrono_humanize::{Accuracy, HumanTime, Tense},
+    clap::{value_t_or_exit, App, AppSettings, Arg, ArgMatches, SubCommand},
+    solana_clap_utils::{
+        input_parsers::pubkey_of_signer,
+        input_validators::{is_amount, is_parsable, is_valid_pubkey},
+    },
+    solana_client::rpc_client::RpcClient,
+    solana_remote_wallet::remote_wallet::RemoteWalletManager,
+    solana_sdk::{
+        message::Message, native_token::Sol, program_pack::Pack, pubkey::Pubkey, signature::Signer,
+        system_instruction,
+    },
+    spl_associated_token_account::*,
+    std::{sync::Arc, time::Instant},
+};
+
+pub(crate) trait BenchSubCommand {
+    fn bench_subcommand(self) -> Self;
+}
+
+impl BenchSubCommand for App<'_, '_> {
+    fn bench_subcommand(self) -> Self {
+        self.subcommand(
+            SubCommand::with_name("bench")
+                .about("Token benchmarking facilities")
+                .setting(AppSettings::InferSubcommands)
+                .setting(AppSettings::SubcommandRequiredElseHelp)
+                .subcommand(
+                    SubCommand::with_name("create-accounts")
+                        .about("Create multiple token accounts for benchmarking")
+                        .arg(
+                            Arg::with_name("token")
+                                .validator(is_valid_pubkey)
+                                .value_name("TOKEN_ADDRESS")
+                                .takes_value(true)
+                                .index(1)
+                                .required(true)
+                                .help("The token that the accounts will hold"),
+                        )
+                        .arg(
+                            Arg::with_name("n")
+                                .validator(is_parsable::<usize>)
+                                .value_name("N")
+                                .takes_value(true)
+                                .index(2)
+                                .required(true)
+                                .help("The number of accounts to create"),
+                        )
+                        .arg(owner_address_arg()),
+                )
+                .subcommand(
+                    SubCommand::with_name("close-accounts")
+                        .about("Close multiple token accounts used for benchmarking")
+                        .arg(
+                            Arg::with_name("token")
+                                .validator(is_valid_pubkey)
+                                .value_name("TOKEN_ADDRESS")
+                                .takes_value(true)
+                                .index(1)
+                                .required(true)
+                                .help("The token that the accounts held"),
+                        )
+                        .arg(
+                            Arg::with_name("n")
+                                .validator(is_parsable::<usize>)
+                                .value_name("N")
+                                .takes_value(true)
+                                .index(2)
+                                .required(true)
+                                .help("The number of accounts to close"),
+                        )
+                        .arg(owner_address_arg()),
+                )
+                .subcommand(
+                    SubCommand::with_name("deposit-into")
+                        .about("Deposit tokens into multiple accounts")
+                        .arg(
+                            Arg::with_name("token")
+                                .validator(is_valid_pubkey)
+                                .value_name("TOKEN_ADDRESS")
+                                .takes_value(true)
+                                .index(1)
+                                .required(true)
+                                .help("The token that the accounts will hold"),
+                        )
+                        .arg(
+                            Arg::with_name("n")
+                                .validator(is_parsable::<usize>)
+                                .value_name("N")
+                                .takes_value(true)
+                                .index(2)
+                                .required(true)
+                                .help("The number of accounts to deposit into"),
+                        )
+                        .arg(
+                            Arg::with_name("amount")
+                                .validator(is_amount)
+                                .value_name("TOKEN_AMOUNT")
+                                .takes_value(true)
+                                .index(3)
+                                .required(true)
+                                .help("Amount to deposit into each account, in tokens"),
+                        )
+                        .arg(
+                            Arg::with_name("from")
+                                .long("from")
+                                .validator(is_valid_pubkey)
+                                .value_name("SOURCE_TOKEN_ACCOUNT_ADDRESS")
+                                .takes_value(true)
+                                .help("The source token account address [default: associated token account for --owner]")
+                        )
+                        .arg(owner_address_arg()),
+                )
+                .subcommand(
+                    SubCommand::with_name("withdraw-from")
+                        .about("Withdraw tokens from multiple accounts")
+                        .arg(
+                            Arg::with_name("token")
+                                .validator(is_valid_pubkey)
+                                .value_name("TOKEN_ADDRESS")
+                                .takes_value(true)
+                                .index(1)
+                                .required(true)
+                                .help("The token that the accounts hold"),
+                        )
+                        .arg(
+                            Arg::with_name("n")
+                                .validator(is_parsable::<usize>)
+                                .value_name("N")
+                                .takes_value(true)
+                                .index(2)
+                                .required(true)
+                                .help("The number of accounts to withdraw from"),
+                        )
+                        .arg(
+                            Arg::with_name("amount")
+                                .validator(is_amount)
+                                .value_name("TOKEN_AMOUNT")
+                                .takes_value(true)
+                                .index(3)
+                                .required(true)
+                                .help("Amount to withdraw from each account, in tokens"),
+                        )
+                        .arg(
+                            Arg::with_name("to")
+                                .long("to")
+                                .validator(is_valid_pubkey)
+                                .value_name("RECIPIENT_TOKEN_ACCOUNT_ADDRESS")
+                                .takes_value(true)
+                                .help("The recipient token account address [default: associated token account for --owner]")
+                        )
+                        .arg(owner_address_arg()),
+                ),
+        )
+    }
+}
+
+pub(crate) fn bench_process_command(
+    matches: &ArgMatches<'_>,
+    config: &Config,
+    mut signers: Vec<Box<dyn Signer>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+) -> Result<(), Error> {
+    assert!(!config.sign_only);
+
+    match matches.subcommand() {
+        ("create-accounts", Some(arg_matches)) => {
+            let token = pubkey_of_signer(arg_matches, "token", wallet_manager)
+                .unwrap()
+                .unwrap();
+            let n = value_t_or_exit!(arg_matches, "n", usize);
+
+            let (owner_signer, owner) =
+                config.signer_or_default(arg_matches, "owner", wallet_manager);
+            signers.push(owner_signer);
+
+            command_create_accounts(config, signers, &token, n, &owner)?;
+        }
+        ("close-accounts", Some(arg_matches)) => {
+            let token = pubkey_of_signer(arg_matches, "token", wallet_manager)
+                .unwrap()
+                .unwrap();
+            let n = value_t_or_exit!(arg_matches, "n", usize);
+            let (owner_signer, owner) =
+                config.signer_or_default(arg_matches, "owner", wallet_manager);
+            signers.push(owner_signer);
+
+            command_close_accounts(config, signers, &token, n, &owner)?;
+        }
+        ("deposit-into", Some(arg_matches)) => {
+            let token = pubkey_of_signer(arg_matches, "token", wallet_manager)
+                .unwrap()
+                .unwrap();
+            let n = value_t_or_exit!(arg_matches, "n", usize);
+            let ui_amount = value_t_or_exit!(arg_matches, "amount", f64);
+            let (owner_signer, owner) =
+                config.signer_or_default(arg_matches, "owner", wallet_manager);
+            signers.push(owner_signer);
+            let from = pubkey_of_signer(arg_matches, "from", wallet_manager)
+                .unwrap()
+                .unwrap_or_else(|| get_associated_token_address(&owner, &token));
+
+            command_deposit_into_or_withdraw_from(
+                config, signers, &token, n, &owner, ui_amount, &from, true,
+            )?;
+        }
+        ("withdraw-from", Some(arg_matches)) => {
+            let token = pubkey_of_signer(arg_matches, "token", wallet_manager)
+                .unwrap()
+                .unwrap();
+            let n = value_t_or_exit!(arg_matches, "n", usize);
+            let ui_amount = value_t_or_exit!(arg_matches, "amount", f64);
+            let (owner_signer, owner) =
+                config.signer_or_default(arg_matches, "owner", wallet_manager);
+            signers.push(owner_signer);
+            let to = pubkey_of_signer(arg_matches, "to", wallet_manager)
+                .unwrap()
+                .unwrap_or_else(|| get_associated_token_address(&owner, &token));
+
+            command_deposit_into_or_withdraw_from(
+                config, signers, &token, n, &owner, ui_amount, &to, false,
+            )?;
+        }
+        _ => unreachable!(),
+    }
+
+    Ok(())
+}
+
+fn get_token_address_with_seed(token: &Pubkey, owner: &Pubkey, i: usize) -> (Pubkey, String) {
+    let seed = format!("{}{}", i, token)[..31].to_string();
+    (
+        Pubkey::create_with_seed(owner, &seed, &spl_token::id()).unwrap(),
+        seed,
+    )
+}
+
+fn get_token_addresses_with_seed(
+    token: &Pubkey,
+    owner: &Pubkey,
+    n: usize,
+) -> Vec<(Pubkey, String)> {
+    (0..n)
+        .map(|i| get_token_address_with_seed(token, owner, i))
+        .collect()
+}
+
+/*
+fn get_token_addresses(token: &Pubkey, owner: &Pubkey, n: usize) -> Vec<Pubkey> {
+    get_token_addresses_with_seed(token, owner, n)
+        .iter()
+        .map(|x| x.0)
+        .collect()
+}
+*/
+
+fn is_valid_token(rpc_client: &RpcClient, token: &Pubkey) -> Result<(), Error> {
+    let mint_account_data = rpc_client
+        .get_account_data(token)
+        .map_err(|err| format!("Token mint {} does not exist: {}", token, err))?;
+
+    spl_token::state::Mint::unpack(&mint_account_data)
+        .map(|_| ())
+        .map_err(|err| format!("Invalid token mint {}: {}", token, err).into())
+}
+
+fn command_create_accounts(
+    config: &Config,
+    signers: Vec<Box<dyn Signer>>,
+    token: &Pubkey,
+    n: usize,
+    owner: &Pubkey,
+) -> Result<(), Error> {
+    let rpc_client = &config.rpc_client;
+
+    println!("Scanning accounts...");
+    is_valid_token(rpc_client, token)?;
+
+    let minimum_balance_for_rent_exemption = rpc_client
+        .get_minimum_balance_for_rent_exemption(spl_token::state::Account::get_packed_len())?;
+
+    let mut lamports_required = 0;
+
+    let token_addresses_with_seed = get_token_addresses_with_seed(token, owner, n);
+    let mut messages = vec![];
+    for address_chunk in token_addresses_with_seed.chunks(100) {
+        let accounts_chunk = rpc_client
+            .get_multiple_accounts(&address_chunk.iter().map(|x| x.0).collect::<Vec<_>>())?;
+
+        for (account, (address, seed)) in accounts_chunk.iter().zip(address_chunk) {
+            if account.is_none() {
+                lamports_required += minimum_balance_for_rent_exemption;
+                messages.push(Message::new(
+                    &[
+                        system_instruction::create_account_with_seed(
+                            &config.fee_payer,
+                            address,
+                            owner,
+                            seed,
+                            minimum_balance_for_rent_exemption,
+                            spl_token::state::Account::get_packed_len() as u64,
+                            &spl_token::id(),
+                        ),
+                        spl_token::instruction::initialize_account(
+                            &spl_token::id(),
+                            address,
+                            token,
+                            owner,
+                        )?,
+                    ],
+                    Some(&config.fee_payer),
+                ));
+            }
+        }
+    }
+
+    send_messages(config, &messages, lamports_required, signers)
+}
+
+fn command_close_accounts(
+    config: &Config,
+    signers: Vec<Box<dyn Signer>>,
+    token: &Pubkey,
+    n: usize,
+    owner: &Pubkey,
+) -> Result<(), Error> {
+    let rpc_client = &config.rpc_client;
+
+    println!("Scanning accounts...");
+    is_valid_token(rpc_client, token)?;
+
+    let token_addresses_with_seed = get_token_addresses_with_seed(token, owner, n);
+    let mut messages = vec![];
+    for address_chunk in token_addresses_with_seed.chunks(100) {
+        let accounts_chunk = rpc_client
+            .get_multiple_accounts(&address_chunk.iter().map(|x| x.0).collect::<Vec<_>>())?;
+
+        for (account, (address, _seed)) in accounts_chunk.iter().zip(address_chunk) {
+            if let Some(account) = account {
+                match spl_token::state::Account::unpack(&account.data) {
+                    Ok(token_account) => {
+                        if token_account.amount != 0 {
+                            eprintln!(
+                                "Token account {} holds a balance; unable to close it",
+                                address,
+                            );
+                        } else {
+                            messages.push(Message::new(
+                                &[spl_token::instruction::close_account(
+                                    &spl_token::id(),
+                                    address,
+                                    owner,
+                                    owner,
+                                    &[],
+                                )?],
+                                Some(&config.fee_payer),
+                            ));
+                        }
+                    }
+                    Err(err) => {
+                        eprintln!("Invalid token account {}: {}", address, err)
+                    }
+                }
+            }
+        }
+    }
+
+    send_messages(config, &messages, 0, signers)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn command_deposit_into_or_withdraw_from(
+    config: &Config,
+    signers: Vec<Box<dyn Signer>>,
+    token: &Pubkey,
+    n: usize,
+    owner: &Pubkey,
+    ui_amount: f64,
+    from_or_to: &Pubkey,
+    deposit_into: bool,
+) -> Result<(), Error> {
+    let rpc_client = &config.rpc_client;
+
+    println!("Scanning accounts...");
+    is_valid_token(rpc_client, token)?;
+
+    let (mint_pubkey, decimals) = crate::resolve_mint_info(config, from_or_to, Some(*token), None)?;
+    if mint_pubkey != *token {
+        return Err(format!("Source account {} is not a {} token", from_or_to, token).into());
+    }
+    let amount = spl_token::ui_amount_to_amount(ui_amount, decimals);
+
+    let token_addresses_with_seed = get_token_addresses_with_seed(token, owner, n);
+    let mut messages = vec![];
+    for address_chunk in token_addresses_with_seed.chunks(100) {
+        let accounts_chunk = rpc_client
+            .get_multiple_accounts(&address_chunk.iter().map(|x| x.0).collect::<Vec<_>>())?;
+
+        for (account, (address, _seed)) in accounts_chunk.iter().zip(address_chunk) {
+            if account.is_some() {
+                messages.push(Message::new(
+                    &[spl_token::instruction::transfer_checked(
+                        &spl_token::id(),
+                        if deposit_into { from_or_to } else { address },
+                        token,
+                        if deposit_into { address } else { from_or_to },
+                        owner,
+                        &[],
+                        amount,
+                        decimals,
+                    )?],
+                    Some(&config.fee_payer),
+                ));
+            } else {
+                eprintln!("Token account does not exist: {}", address)
+            }
+        }
+    }
+
+    send_messages(config, &messages, 0, signers)
+}
+
+fn send_messages(
+    config: &Config,
+    messages: &[Message],
+    mut lamports_required: u64,
+    signers: Vec<Box<dyn Signer>>,
+) -> Result<(), Error> {
+    if messages.is_empty() {
+        println!("Nothing to do");
+        return Ok(());
+    }
+
+    let (_blockhash, fee_calculator, _last_valid_block_height) = config
+        .rpc_client
+        .get_recent_blockhash_with_commitment(config.rpc_client.commitment())?
+        .value;
+
+    lamports_required += messages
+        .iter()
+        .map(|message| fee_calculator.calculate_fee(message))
+        .sum::<u64>();
+
+    println!(
+        "Sending {:?} messages for ~{}",
+        messages.len(),
+        Sol(lamports_required)
+    );
+
+    crate::check_fee_payer_balance(config, lamports_required)?;
+
+    let start = Instant::now();
+    let transaction_errors = send_and_confirm_messages_with_spinner(
+        config.rpc_client.clone(),
+        &config.websocket_url,
+        messages,
+        &signers,
+    )?;
+
+    for (i, transaction_error) in transaction_errors.into_iter().enumerate() {
+        if let Some(transaction_error) = transaction_error {
+            println!("Message {} failed with {:?}", i, transaction_error);
+        }
+    }
+    let elapsed = Instant::now().duration_since(start);
+    println!(
+        "Elapsed time: {}",
+        HumanTime::from(chrono::Duration::from_std(elapsed).unwrap())
+            .to_text_en(Accuracy::Precise, Tense::Present)
+    );
+    let tps = messages.len() as f64 / elapsed.as_secs_f64();
+    println!("Average TPS: {:.2}", tps);
+    Ok(())
+}

--- a/token/cli/src/config.rs
+++ b/token/cli/src/config.rs
@@ -11,7 +11,8 @@ use spl_associated_token_account::*;
 use std::{process::exit, sync::Arc};
 
 pub(crate) struct Config<'a> {
-    pub(crate) rpc_client: RpcClient,
+    pub(crate) rpc_client: Arc<RpcClient>,
+    pub(crate) websocket_url: String,
     pub(crate) output_format: OutputFormat,
     pub(crate) fee_payer: Pubkey,
     pub(crate) default_keypair_path: String,

--- a/token/cli/src/rpc_client_utils.rs
+++ b/token/cli/src/rpc_client_utils.rs
@@ -1,0 +1,165 @@
+// TODO: In v1.8 timeframe delete this module and use `send_and_confirm_messages_with_spinner()`
+//       from the Solana monorepo
+use {
+    solana_cli_output::display::new_spinner_progress_bar,
+    solana_client::{
+        rpc_client::RpcClient,
+        rpc_config::RpcSendTransactionConfig,
+        rpc_request::MAX_GET_SIGNATURE_STATUSES_QUERY_ITEMS,
+        rpc_response::Fees,
+        tpu_client::{TpuClient, TpuClientConfig},
+    },
+    solana_sdk::{
+        message::Message,
+        signers::Signers,
+        transaction::{Transaction, TransactionError},
+    },
+    solana_transaction_status::TransactionConfirmationStatus,
+    std::{collections::HashMap, error, sync::Arc, thread::sleep, time::Duration},
+};
+
+pub fn send_and_confirm_messages_with_spinner<T: Signers>(
+    rpc_client: Arc<RpcClient>,
+    websocket_url: &str,
+    messages: &[Message],
+    signers: &T,
+) -> Result<Vec<Option<TransactionError>>, Box<dyn error::Error>> {
+    let commitment = rpc_client.commitment();
+    let progress_bar = new_spinner_progress_bar();
+    let mut send_retries = 5;
+    let send_transaction_interval = Duration::from_millis(10); /* ~100 TPS */
+
+    let Fees {
+        blockhash,
+        fee_calculator: _,
+        mut last_valid_block_height,
+    } = rpc_client.get_fees()?;
+
+    let mut transactions = vec![];
+    let mut transaction_errors = vec![None; messages.len()];
+    for (i, message) in messages.iter().enumerate() {
+        let mut transaction = Transaction::new_unsigned(message.clone());
+        transaction.try_sign(signers, blockhash)?;
+        transactions.push((i, transaction));
+    }
+
+    progress_bar.set_message("Finding leader nodes...");
+    let tpu_client = TpuClient::new(
+        rpc_client.clone(),
+        websocket_url,
+        TpuClientConfig::default(),
+    )?;
+    loop {
+        // Send all transactions
+        let mut pending_transactions = HashMap::new();
+        let num_transactions = transactions.len();
+        for (i, transaction) in transactions {
+            if !tpu_client.send_transaction(&transaction) {
+                let _result = rpc_client
+                    .send_transaction_with_config(
+                        &transaction,
+                        RpcSendTransactionConfig {
+                            preflight_commitment: Some(commitment.commitment),
+                            ..RpcSendTransactionConfig::default()
+                        },
+                    )
+                    .ok();
+            }
+            pending_transactions.insert(transaction.signatures[0], (i, transaction));
+            progress_bar.set_message(&format!(
+                "[{}/{}] Transactions sent",
+                pending_transactions.len(),
+                num_transactions
+            ));
+
+            sleep(send_transaction_interval);
+        }
+
+        // Collect statuses for all the transactions, drop those that are confirmed
+        loop {
+            let mut block_height = 0;
+            let pending_signatures = pending_transactions.keys().cloned().collect::<Vec<_>>();
+            for pending_signatures_chunk in
+                pending_signatures.chunks(MAX_GET_SIGNATURE_STATUSES_QUERY_ITEMS)
+            {
+                if let Ok(result) = rpc_client.get_signature_statuses(pending_signatures_chunk) {
+                    let statuses = result.value;
+                    for (signature, status) in
+                        pending_signatures_chunk.iter().zip(statuses.into_iter())
+                    {
+                        if let Some(status) = status {
+                            if let Some(confirmation_status) = &status.confirmation_status {
+                                if *confirmation_status != TransactionConfirmationStatus::Processed
+                                {
+                                    if let Some((i, _)) = pending_transactions.remove(signature) {
+                                        transaction_errors[i] = status.err;
+                                    }
+                                }
+                            } else if status.confirmations.is_none()
+                                || status.confirmations.unwrap() > 1
+                            {
+                                if let Some((i, _)) = pending_transactions.remove(signature) {
+                                    transaction_errors[i] = status.err;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                block_height = rpc_client.get_block_height()?;
+                progress_bar.set_message(&format!(
+                    "[{}/{}] Transactions confirmed. Retrying in {} blocks",
+                    num_transactions - pending_transactions.len(),
+                    num_transactions,
+                    last_valid_block_height.saturating_sub(block_height)
+                ));
+            }
+
+            if pending_transactions.is_empty() {
+                return Ok(transaction_errors);
+            }
+
+            if block_height > last_valid_block_height {
+                break;
+            }
+
+            for (_i, transaction) in pending_transactions.values() {
+                if !tpu_client.send_transaction(transaction) {
+                    let _result = rpc_client
+                        .send_transaction_with_config(
+                            transaction,
+                            RpcSendTransactionConfig {
+                                preflight_commitment: Some(commitment.commitment),
+                                ..RpcSendTransactionConfig::default()
+                            },
+                        )
+                        .ok();
+                }
+            }
+
+            if cfg!(not(test)) {
+                // Retry twice a second
+                sleep(Duration::from_millis(500));
+            }
+        }
+
+        if send_retries == 0 {
+            return Err("Transactions failed".into());
+        }
+        send_retries -= 1;
+
+        // Re-sign any failed transactions with a new blockhash and retry
+        let Fees {
+            blockhash,
+            fee_calculator: _,
+            last_valid_block_height: new_last_valid_block_height,
+        } = rpc_client.get_fees()?;
+
+        last_valid_block_height = new_last_valid_block_height;
+        transactions = vec![];
+        for (_, (i, mut transaction)) in pending_transactions.into_iter() {
+            transaction.try_sign(signers, blockhash)?;
+            transactions.push((i, transaction));
+        }
+    }
+}


### PR DESCRIPTION
Add a `spl-token bench` subcommand with some basic token benchmarking facilities.

```
SUBCOMMANDS:
    close-accounts     Close multiple token accounts used for benchmarking
    create-accounts    Create multiple token accounts for benchmarking
    deposit-into       Deposit tokens into multiple accounts
    withdraw-from      Withdraw tokens from multiple accounts
```