### PR TITLE
Bump Rust to match monorepo (1.54 and 2021-08-02 nightly)

### DIFF
--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -18,13 +18,13 @@
 if [[ -n $RUST_STABLE_VERSION ]]; then
   stable_version="$RUST_STABLE_VERSION"
 else
-  stable_version=1.53.0
+  stable_version=1.54.0
 fi
 
 if [[ -n $RUST_NIGHTLY_VERSION ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2021-06-09
+  nightly_version=2021-08-02
 fi
 
 


### PR DESCRIPTION
#### Problem

The monorepo master is at Rust version 1.54 and nightly 2021-08-02, so let's match that.  Note that the monorepo v1.7 is still on 1.52.1, but since solana-program-library is already at 1.53, we're best off matching master.

#### Solution

Bump the version in CI.