### PR TITLE
stake-pool: cli fix remove-vsa bug

### DIFF
--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -455,6 +455,7 @@ fn command_vsa_remove(
             stake_pool_address,
             vote_account,
             new_authority,
+            validator_stake_info.transient_seed_suffix_start,
             &stake_receiver,
         ),
     );

--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -459,7 +459,7 @@ fn command_vsa_remove(
         ),
     );
     unique_signers!(signers);
-    let transaction = checked_transaction_with_signers(config, instructions, &signers)?;
+    let transaction = checked_transaction_with_signers(config, &instructions, &signers)?;
     send_transaction(config, transaction)?;
     Ok(())
 }

--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -447,23 +447,19 @@ fn command_vsa_remove(
     if let Some(stake_keypair) = stake_keypair.as_ref() {
         signers.push(stake_keypair);
     }
+    instructions.push(
+        // Create new validator stake account address
+        spl_stake_pool::instruction::remove_validator_from_pool_with_vote(
+            &spl_stake_pool::id(),
+            &stake_pool,
+            stake_pool_address,
+            vote_account,
+            new_authority,
+            &stake_receiver,
+        ),
+    );
     unique_signers!(signers);
-    let transaction = checked_transaction_with_signers(
-        config,
-        &[
-            // Create new validator stake account address
-            spl_stake_pool::instruction::remove_validator_from_pool_with_vote(
-                &spl_stake_pool::id(),
-                &stake_pool,
-                stake_pool_address,
-                vote_account,
-                new_authority,
-                validator_stake_info.transient_seed_suffix_start,
-                &stake_receiver,
-            ),
-        ],
-        &signers,
-    )?;
+    let transaction = checked_transaction_with_signers(config, instructions, &signers)?;
     send_transaction(config, transaction)?;
     Ok(())
 }


### PR DESCRIPTION
for the `remove-validator` subcommand, `instructions` vec was being overwritten to a single element vec containing the stake pool instruction. If a new stake account needs to be created, it will throw:

```
thread 'main' panicked at 'Transaction::sign failed with error KeypairPubkeyMismatch', /home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/solana-sdk-1.7.7/src/transaction.rs:258:13
```

since the new stake account's keypair is in signers but the create stake account instruction is not in instructions