### PR TITLE
Remove cdylib crate type attribute from non programs

### DIFF
--- a/governance/test-sdk/Cargo.toml
+++ b/governance/test-sdk/Cargo.toml
@@ -20,6 +20,3 @@ solana-program-test = "1.7.11"
 solana-sdk = "1.7.11"
 spl-token = { version = "3.2", path = "../../token/program", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
-
-[lib]
-crate-type = ["cdylib", "lib"]


### PR DESCRIPTION
#### Problem
The `cargo-test-bpf` binary looks for the presence of a `cdylib` crate type to determine whether to run tests with the SBF toolchain (https://github.com/solana-labs/solana/blob/7aa5f6b8332516347282d0e36ceb8ae020c02ddb/sdk/cargo-test-bpf/src/main.rs#L192). Crates which are not BPF programs could therefore be built for BPF which doesn't support some dependency crates.

#### Changes
- Removed crate-type from the governance test crate