### PR TITLE
update token/js/readme.md

### DIFF
--- a/token/js/README.md
+++ b/token/js/README.md
@@ -8,7 +8,7 @@ The Token JavaScript library comprises:
 
 ## Getting Started
 
-First, make sure you've already deployed the associate-token-account by going into `associated-token-account/pogram` and running:
+First, make sure you've already deployed the associate-token-account by going into `associated-token-account/program` and running:
 
 ```bash
 $ cargo build-bpf

--- a/token/js/README.md
+++ b/token/js/README.md
@@ -8,7 +8,13 @@ The Token JavaScript library comprises:
 
 ## Getting Started
 
-First fetch the npm dependencies, including `@solana/web3.js`, by running:
+First, make sure you've already deployed the associate-token-account by going into `associated-token-account/pogram` and running:
+
+```bash
+$ cargo build-bpf
+```
+
+Once that's complete, come back to the `token/program/js` folder and install the npm dependencies, including `@solana/web3.js`, by running:
 ```bash
 $ npm install
 ```

--- a/token/js/README.md
+++ b/token/js/README.md
@@ -8,7 +8,7 @@ The Token JavaScript library comprises:
 
 ## Getting Started
 
-First, make sure you've already deployed the associate-token-account by going into `associated-token-account/program` and running:
+First, make sure you've already deployed the associated-token-account program by going into `associated-token-account/program` and running:
 
 ```bash
 $ cargo build-bpf


### PR DESCRIPTION
### The issue

The current readme instructions result in the following error because they leave that you first have to build the associate-token-account program:

```
Run test: loadTokenProgram
Connection to cluster established: http://localhost:8899 { 'feature-set': 1140394761, 'solana-core': '1.7.11' }
Checking pre-loaded Token programs failed, will load new programs:
{
  err: [Error: ENOENT: no such file or directory, open '/solana-program-library/token/js/cli/store/store/config.json'] {
    errno: -2,
    code: 'ENOENT',
    syscall: 'open',
    path: '/solana-program-library/token/js/cli/store/store/config.json'
  }
}
Loading program: ../../target/deploy/spl_token.so
[Error: ENOENT: no such file or directory, open '../../target/deploy/spl_associated_token_account.so'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '../../target/deploy/spl_associated_token_account.so'
}
```

### The fix

This PR updates the readme to point out that one must first build the associated-token-account program before being able to run the token js client.