### PR TITLE
- fix "attempt to subtract with overflow" issue

### DIFF
--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -1104,9 +1104,14 @@ fn prepare_withdraw_accounts(
         if lamports <= min_balance {
             continue;
         }
-        let available_for_withdrawal = stake_pool
-            .calc_lamports_withdraw_amount(lamports - *MIN_STAKE_BALANCE)
-            .unwrap();
+
+        let available_for_withdrawal: u64 = if lamports > *MIN_STAKE_BALANCE
+        {
+            stake_pool
+                .calc_lamports_withdraw_amount(lamports - *MIN_STAKE_BALANCE)
+                .unwrap()
+        } else { 0 };
+
         let pool_amount = u64::min(available_for_withdrawal, remaining_amount);
 
         // Those accounts will be withdrawn completely with `claim` instruction
@@ -1187,9 +1192,14 @@ fn command_withdraw(
             stake_pool_address,
         );
         let stake_account = config.rpc_client.get_account(&stake_account_address)?;
-        let available_for_withdrawal = stake_pool
-            .calc_lamports_withdraw_amount(stake_account.lamports - *MIN_STAKE_BALANCE)
-            .unwrap();
+
+        let available_for_withdrawal: u64 = if stake_account.lamports > *MIN_STAKE_BALANCE
+        {
+            stake_pool
+                .calc_lamports_withdraw_amount(stake_account.lamports - *MIN_STAKE_BALANCE)
+                .unwrap()
+        } else { 0 };
+
         if available_for_withdrawal < pool_amount {
             return Err(format!(
                 "Not enough lamports available for withdrawal from {}, {} asked, {} available",

--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -1106,8 +1106,8 @@ fn prepare_withdraw_accounts(
         }
 
         let available_for_withdrawal = stake_pool
-                .calc_lamports_withdraw_amount(lamports.saturating_sub(*MIN_STAKE_BALANCE))
-                .unwrap();
+            .calc_lamports_withdraw_amount(lamports.saturating_sub(*MIN_STAKE_BALANCE))
+            .unwrap();
 
         let pool_amount = u64::min(available_for_withdrawal, remaining_amount);
 
@@ -1191,8 +1191,10 @@ fn command_withdraw(
         let stake_account = config.rpc_client.get_account(&stake_account_address)?;
 
         let available_for_withdrawal = stake_pool
-                .calc_lamports_withdraw_amount(stake_account.lamports.saturating_sub(*MIN_STAKE_BALANCE))
-                .unwrap();
+            .calc_lamports_withdraw_amount(
+                stake_account.lamports.saturating_sub(*MIN_STAKE_BALANCE),
+            )
+            .unwrap();
 
         if available_for_withdrawal < pool_amount {
             return Err(format!(

--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -1190,12 +1190,9 @@ fn command_withdraw(
         );
         let stake_account = config.rpc_client.get_account(&stake_account_address)?;
 
-        let available_for_withdrawal: u64 = if stake_account.lamports > *MIN_STAKE_BALANCE
-        {
-            stake_pool
-                .calc_lamports_withdraw_amount(stake_account.lamports - *MIN_STAKE_BALANCE)
-                .unwrap()
-        } else { 0 };
+        let available_for_withdrawal = stake_pool
+                .calc_lamports_withdraw_amount(stake_account.lamports.saturating_sub(*MIN_STAKE_BALANCE))
+                .unwrap();
 
         if available_for_withdrawal < pool_amount {
             return Err(format!(

--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -1105,12 +1105,9 @@ fn prepare_withdraw_accounts(
             continue;
         }
 
-        let available_for_withdrawal: u64 = if lamports > *MIN_STAKE_BALANCE
-        {
-            stake_pool
-                .calc_lamports_withdraw_amount(lamports - *MIN_STAKE_BALANCE)
-                .unwrap()
-        } else { 0 };
+        let available_for_withdrawal = stake_pool
+                .calc_lamports_withdraw_amount(lamports.saturating_sub(*MIN_STAKE_BALANCE))
+                .unwrap();
 
         let pool_amount = u64::min(available_for_withdrawal, remaining_amount);
 


### PR DESCRIPTION
@joncinque 

if the active stake balance is lower than MIN_STAKE_BALANCE, then we get an "attempt to subtract with overflow" exception

````
spl-stake-pool withdraw-stake --verbose --vote-account F7LN71sYZGLB6WpDmNT6LP25z7a3HezLStDM1y1JJfdf 5mJ3EhrQ1ZBwDW7AFodQaEzBSw1wG89mvTpAnc81bngK 0.01 --config /Users/alexanderray/Documents/Development/mfactory/customers/solana/projects/stake-pool/playground/config-with-delegator-wallet.yaml
Signature: 5PMzHKbZAHTMTZFHS1dRjLpbHhsnMh3Bxg3RuRBf8fMqK9QGNB12ANWEJR6FrVTV1DQ3nyyfNaZuxbxKvwi5Jqk9
Signature: 2s33p7hRyA2ta34iEngcxGoGJtrL5oiGaHmBR2CP81yCNczDEg7gZweeQZpYBsrdN3HYRQksyse1KF7LwoWMzHP3
thread 'main' panicked at 'attempt to subtract with overflow', stake-pool/cli/src/main.rs:1191:44
````