### PR TITLE
stake-pool-cli: Update minimum balance to be correct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3807,7 +3807,6 @@ dependencies = [
  "borsh",
  "bs58 0.4.0",
  "clap",
- "lazy_static",
  "serde_json",
  "solana-account-decoder",
  "solana-clap-utils",

--- a/stake-pool/cli/Cargo.toml
+++ b/stake-pool/cli/Cargo.toml
@@ -25,7 +25,6 @@ spl-stake-pool = { version = "0.5", path="../program", features = [ "no-entrypoi
 spl-token = { version = "3.2", path="../../token/program", features = [ "no-entrypoint" ]  }
 bs58 = "0.4.0"
 bincode = "1.3.1"
-lazy_static = "1.4.0"
 
 [[bin]]
 name = "spl-stake-pool"


### PR DESCRIPTION
#### Problem

There's a new minimum balance for stake pool accounts, but the CLI used its own hard-coded value, so it was out of step with the program, causing strange failures.

#### Solution

Corporate software engineering 101: Hardcode values in one place only!