### PR TITLE
stake-pool: Use `matches!` to allow for fix in underlying error

### DIFF
--- a/stake-pool/program/tests/vsa_remove.rs
+++ b/stake-pool/program/tests/vsa_remove.rs
@@ -316,13 +316,10 @@ async fn fail_double_remove() {
         .unwrap()
         .unwrap();
 
-    assert_eq!(
+    assert!(matches!(
         error,
-        TransactionError::InstructionError(
-            1,
-            InstructionError::BorshIoError("Unkown".to_string()), // sic
-        )
-    );
+        TransactionError::InstructionError(1, InstructionError::BorshIoError(_),)
+    ));
 }
 
 #[tokio::test]


### PR DESCRIPTION
#### Problem

`Unkown` is not how you spell `Unknown`, but a stake pool test relies on that misspelling, making it impossible to update the spelling in the monorepo.

#### Solution

use a `matches!` check in the test instead