### PR TITLE
math: Add f64 powf and powi

### DIFF
--- a/libraries/math/src/instruction.rs
+++ b/libraries/math/src/instruction.rs
@@ -97,6 +97,16 @@ pub enum MathInstruction {
         argument: f32,
     },
 
+    /// Pow two float values
+    ///
+    /// No accounts required for this instruction
+    F64Pow {
+        /// The base
+        base: f64,
+        /// The exponent
+        exponent: f64,
+    },
+
     /// Don't do anything for comparison
     ///
     /// No accounts required for this instruction
@@ -214,6 +224,17 @@ pub fn f32_normal_cdf(argument: f32) -> Instruction {
         program_id: id(),
         accounts: vec![],
         data: MathInstruction::F32NormalCDF { argument }
+            .try_to_vec()
+            .unwrap(),
+    }
+}
+
+/// Create F64Pow instruction
+pub fn f64_pow(base: f64, exponent: f64) -> Instruction {
+    Instruction {
+        program_id: id(),
+        accounts: vec![],
+        data: MathInstruction::F64Pow { base, exponent }
             .try_to_vec()
             .unwrap(),
     }

--- a/libraries/math/src/processor.rs
+++ b/libraries/math/src/processor.rs
@@ -148,7 +148,10 @@ pub fn process_instruction(
         MathInstruction::F64Pow { base, exponent } => {
             msg!("Calculating f64 Pow");
             sol_log_compute_units();
-            let _result = base.powi(5);
+            let result = base.powi(exponent as i32);
+            sol_log_compute_units();
+            msg!("{}", result as u64);
+            sol_log_compute_units();
             let result = base.powf(exponent);
             sol_log_compute_units();
             msg!("{}", result as u64);

--- a/libraries/math/src/processor.rs
+++ b/libraries/math/src/processor.rs
@@ -145,6 +145,15 @@ pub fn process_instruction(
             msg!("{}", result as u64);
             Ok(())
         }
+        MathInstruction::F64Pow { base, exponent } => {
+            msg!("Calculating f64 Pow");
+            sol_log_compute_units();
+            let _result = base.powi(5);
+            let result = base.powf(exponent);
+            sol_log_compute_units();
+            msg!("{}", result as u64);
+            Ok(())
+        }
         MathInstruction::Noop => {
             msg!("Do nothing");
             msg!("{}", 0_u64);

--- a/libraries/math/tests/instruction_count.rs
+++ b/libraries/math/tests/instruction_count.rs
@@ -195,6 +195,22 @@ async fn test_f32_normal_cdf() {
 }
 
 #[tokio::test]
+async fn test_f64_pow() {
+    let mut pc = ProgramTest::new("spl_math", id(), processor!(process_instruction));
+
+    pc.set_compute_max_units(30_000);
+
+    let (mut banks_client, payer, recent_blockhash) = pc.start().await;
+
+    let mut transaction = Transaction::new_with_payer(
+        &[instruction::f64_pow(50_f64, 10.5_f64)],
+        Some(&payer.pubkey()),
+    );
+    transaction.sign(&[&payer], recent_blockhash);
+    banks_client.process_transaction(transaction).await.unwrap();
+}
+
+#[tokio::test]
 async fn test_noop() {
     let mut pc = ProgramTest::new("spl_math", id(), processor!(process_instruction));
 


### PR DESCRIPTION
#### Problem

`powf` finally works in bpf!

#### Solution

To make sure it keeps working, here's a test calling `powi` and `powf` on floats