### PR TITLE
ATA: Avoid hard coding spl_token id

### DIFF
--- a/associated-token-account/program/src/processor.rs
+++ b/associated-token-account/program/src/processor.rs
@@ -78,7 +78,7 @@ pub fn process_create_associated_token_account(
         funder_info,
         &rent,
         spl_token::state::Account::LEN,
-        &spl_token::id(),
+        spl_token_program_id,
         system_program_info,
         associated_token_account_info,
         associated_token_account_signer_seeds,


### PR DESCRIPTION
The latest ATA release, v1.0.3, is not affected.  Introduced by #2325