### PR TITLE
Stateless offer

### DIFF
--- a/stateless-asks/program/README.md
+++ b/stateless-asks/program/README.md
@@ -1,0 +1,22 @@
+# Stateless Offer
+
+Simple program to make token offers to any bidder that can satisify
+the constraints.
+
+This program is stateless.  It is up to the maker to advertize.  It
+uses the PDA as a one way hash of the offer that the maker wants
+to create.  The maker then only needs to approve their token to the
+PDA address for the taker to receive the items.  The maker doesn't
+need to be online to complete the transaction, but needs to advertize
+the offer over an off-chain.
+
+## Maker
+1. compute the offer PDA
+2. approve the token delegation for the amount to the PDA
+3. publish the offer off-chain
+
+## Taker
+1. Create the offer TX
+2. Submit the TX to the stateless-offer program
+
+To cancel, the maker simply needs to cancel the delegation.

--- a/stateless-asks/program/README.md
+++ b/stateless-asks/program/README.md
@@ -8,7 +8,7 @@ uses the PDA as a one way hash of the offer that the maker wants
 to create.  The maker then only needs to approve their token to the
 PDA address for the taker to receive the items.  The maker doesn't
 need to be online to complete the transaction, but needs to advertize
-the offer over an off-chain.
+the offer off-chain.
 
 ## Maker
 1. compute the offer PDA

--- a/stateless-asks/program/src/instruction.rs
+++ b/stateless-asks/program/src/instruction.rs
@@ -1,0 +1,66 @@
+//! Instruction types
+
+#![allow(clippy::too_many_arguments)]
+use {
+    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
+    solana_program::{
+        instruction::{AccountMeta, Instruction},
+        pubkey::Pubkey,
+        system_program, sysvar,
+    },
+};
+
+/// Instructions supported by the StatelessOffer program.
+#[repr(C)]
+#[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize, BorshSchema)]
+pub enum StatelessOfferInstruction {
+    ///  Accept a StatelessOffer
+    ///
+    AcceptOffer {
+        maker_size: u64,
+        taker_size: u64,
+        bump_seed: u8,
+    },
+}
+
+/// Creates an 'initialize' instruction.
+pub fn accept_offer(
+    program_id: &Pubkey,
+    maker_src_account: &Pubkey,
+    maker_dst_account: &Pubkey,
+    taker_src_account: &Pubkey,
+    taker_dst_account: &Pubkey,
+    auth_maker_account: &Pubkey,
+    auth_taker_account: &Pubkey,
+    authority: &Pubkey,
+    token_program_id: &Pubkey,
+    bump_seed: u8,
+) -> Instruction {
+    let init_data = StatelessOfferInstruction::AcceptOffer {
+        maker_size,
+        taker_size,
+        bump_seed,
+    };
+    let data = init_data.try_to_vec().unwrap();
+    let mut accounts = vec![
+        AccountMeta::new(*program_id, false),
+
+        AccountMeta::new(*maker_src_account, false),
+        AccountMeta::new(*maker_dst_account, false),
+
+
+        AccountMeta::new(*taker_src_account, false),
+        AccountMeta::new(*taker_dst_account, false),
+
+        AccountMeta::new(*auth_maker_account, false),
+        AccountMeta::new(*auth_taker_account, false),
+
+        AccountMeta::new_readonly(*token_program_id, false),
+        AccountMeta::new_readonly(*authority, false),
+    ];
+    Instruction {
+        program_id: *program_id,
+        accounts,
+        data,
+    }
+}

--- a/stateless-asks/program/src/processor.rs
+++ b/stateless-asks/program/src/processor.rs
@@ -1,0 +1,146 @@
+//! Program state processor
+
+use crate::instruction::DepositType;
+use {
+    borsh::{BorshDeserialize, BorshSerialize},
+    num_traits::FromPrimitive,
+    solana_program::{
+        account_info::next_account_info,
+        account_info::AccountInfo,
+        borsh::try_from_slice_unchecked,
+        clock::{Clock, Epoch},
+        decode_error::DecodeError,
+        entrypoint::ProgramResult,
+        msg,
+        program::{invoke, invoke_signed},
+        program_error::PrintProgramError,
+        program_error::ProgramError,
+        program_pack::Pack,
+        pubkey::Pubkey,
+        rent::Rent,
+        stake_history::StakeHistory,
+        system_instruction, system_program,
+        sysvar::Sysvar,
+    },
+    spl_token::state::Mint,
+};
+
+/// Program state handler.
+pub struct Processor {}
+impl Processor {
+    /// Issue a spl_token `Transfer` instruction.
+    #[allow(clippy::too_many_arguments)]
+    fn token_transfer<'a>(
+        token_program: AccountInfo<'a>,
+        source: AccountInfo<'a>,
+        destination: AccountInfo<'a>,
+        authority: AccountInfo<'a>,
+        seeds: &[&[u8]],
+        amount: u64,
+    ) -> Result<(), ProgramError> {
+        let ix = spl_token::instruction::transfer(
+            token_program.key,
+            source.key,
+            destination.key,
+            authority.key,
+            &[],
+            amount,
+        )?;
+        invoke_signed(&ix, &[source, destination, authority, token_program], seeds)
+    }
+
+    /// Processes `Initialize` instruction.
+    fn process_accept_offer(
+        program_id: &Pubkey,
+        accounts: &[AccountInfo],
+        maker_size: u64,
+        taker_size: u64,
+        bump_seed: u8,
+    ) -> ProgramResult {
+        let account_info_iter = &mut accounts.iter();
+
+        let maker_src_account = next_account_info(account_info_iter)?;
+        let maker_dst_account = next_account_info(account_info_iter)?;
+
+        let taker_src_account = next_account_info(account_info_iter)?;
+        let taker_dst_account = next_account_info(account_info_iter)?;
+
+        let auth_maker_account = next_account_info(account_info_iter)?;
+        let auth_taker_account = next_account_info(account_info_iter)?;
+
+        let token_program_info = next_account_info(account_info_iter)?;
+
+        let transfer_authority = next_account_info(account_info_iter)?;
+
+        let seeds: &[&[_]] = &[
+            &maker_src_account.key.to_bytes(),
+            &maker_dst_account.key.to_bytes(),
+            &taker_src_mint.key.to_bytes(),
+            maker_size.to_bytes(),
+            taker_size.to_bytes(),
+            &[bump_seed],
+        ];
+        msg!("start");
+        Self::token_transfer(
+            token_program_info.clone(),
+            maker_src_account.clone(),
+            auth_maker_account.clone(),
+            transfer_authority.clone(),
+            maker_size,
+            seeds,
+        )?;
+        msg!("done tx from maker to temp {}", maker_size);
+
+        Self::token_transfer(
+            token_program_info.clone(),
+            auth_maker_account.clone(),
+            taker_dst_account.clone(),
+            transfer_authority.clone(),
+            maker_size,
+            seeds,
+        )?;
+        msg!("done tx from temp to taker {}", maker_size);
+
+        Self::token_transfer(
+            token_program_info.clone(),
+            taker_src_account.clone(),
+            auth_taker_account.clone(),
+            transfer_authority.clone(),
+            taker_size,
+            seeds,
+        )?;
+        msg!("done tx from taker to temp {}", taker_size);
+
+        Self::token_transfer(
+            token_program_info.clone(),
+            auth_taker_account.clone(),
+            taker_dst_account.clone(),
+            transfer_authority.clone(),
+            taker_size,
+            seeds,
+        )?;
+        msg!("done tx from temp to taker {}", taker_size);
+        msg!("done!");
+    }
+
+    /// Processes [Instruction](enum.Instruction.html).
+    pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> ProgramResult {
+        let instruction = StakePoolInstruction::try_from_slice(input)?;
+        match instruction {
+            StalessOfferInstruction::AcceptOffer {
+                maker_size,
+                taker_size,
+                bump_seed,
+            } => {
+                msg!("Instruction: Initialize stake pool");
+                Self::process_accept_offer(
+                    program_id,
+                    accounts,
+                    maker_size,
+                    taker_size,
+                    bump_seed,
+                )
+            }
+        }
+    }
+}

--- a/stateless-asks/program/src/processor.rs
+++ b/stateless-asks/program/src/processor.rs
@@ -125,14 +125,14 @@ impl Processor {
 
     /// Processes [Instruction](enum.Instruction.html).
     pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> ProgramResult {
-        let instruction = StakePoolInstruction::try_from_slice(input)?;
+        let instruction = StatelessOfferInstruction::try_from_slice(input)?;
         match instruction {
-            StalessOfferInstruction::AcceptOffer {
+            StatelessOfferInstruction::AcceptOffer {
                 maker_size,
                 taker_size,
                 bump_seed,
             } => {
-                msg!("Instruction: Initialize stake pool");
+                msg!("Instruction: accept offer");
                 Self::process_accept_offer(
                     program_id,
                     accounts,

--- a/stateless-asks/program/src/processor.rs
+++ b/stateless-asks/program/src/processor.rs
@@ -114,12 +114,12 @@ impl Processor {
         Self::token_transfer(
             token_program_info.clone(),
             auth_taker_account.clone(),
-            taker_dst_account.clone(),
+            maker_dst_account.clone(),
             transfer_authority.clone(),
             taker_size,
             seeds,
         )?;
-        msg!("done tx from temp to taker {}", taker_size);
+        msg!("done tx from temp to maker {}", taker_size);
         msg!("done!");
     }
 


### PR DESCRIPTION
# Problem

There is no simple way to create one-off offers for token transfers

# Solution

Maker uses PDA as a hash of the offer constraints and approves the PDA as a token delegation.  The taker then needs to satisfy the constraints by delegating what the maker is asking for to the PDA, which then does the swap.