### PR TITLE
stake-pool: Add withdraw-sol command + CLI + docs

### DIFF
--- a/stake-pool/cli/scripts/deposit-withdraw.sh
+++ b/stake-pool/cli/scripts/deposit-withdraw.sh
@@ -72,3 +72,5 @@ echo "Depositing stakes into stake pool"
 deposit_stakes $stake_pool_pubkey $validator_list
 echo "Withdrawing stakes from stake pool"
 withdraw_stakes $stake_pool_pubkey $validator_list $half_sol_amount
+echo "Withdrawing sol from stake pool"
+$spl_stake_pool withdraw-sol $stake_pool_pubkey $half_sol_amount

--- a/stake-pool/cli/scripts/setup-stake-pool.sh
+++ b/stake-pool/cli/scripts/setup-stake-pool.sh
@@ -30,7 +30,7 @@ setup_pool () {
   create_keypair $stake_pool_keyfile
   create_keypair $mint_keyfile
 
-  $spl_stake_pool create-pool --fee-numerator 3 --fee-denominator 100 \
+  $spl_stake_pool create-pool --epoch-fee-numerator 3 --epoch-fee-denominator 100 \
     --withdrawal-fee-numerator 5 --withdrawal-fee-denominator 1000 \
     --max-validators $max_validators \
     --pool-keypair $stake_pool_keyfile \

--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -776,7 +776,7 @@ fn command_deposit_sol(
     let pool_withdraw_authority =
         find_withdraw_authority_program_address(&spl_stake_pool::id(), stake_pool_address).0;
 
-    let mut deposit_instructions = if let Some(deposit_authority) = config.depositor.as_ref() {
+    let deposit_instruction = if let Some(deposit_authority) = config.depositor.as_ref() {
         let expected_sol_deposit_authority = stake_pool.sol_deposit_authority.ok_or_else(|| {
             "SOL deposit authority specified in arguments but stake pool has none".to_string()
         })?;
@@ -820,7 +820,7 @@ fn command_deposit_sol(
         )
     };
 
-    instructions.append(&mut deposit_instructions);
+    instructions.push(deposit_instruction);
 
     let mut transaction =
         Transaction::new_with_payer(&instructions, Some(&config.fee_payer.pubkey()));
@@ -1023,6 +1023,10 @@ fn command_update(
     force: bool,
     no_merge: bool,
 ) -> CommandResult {
+    if config.no_update {
+        println!("Update requested, but --no-update flag specified, so doing nothing");
+        return Ok(());
+    }
     let stake_pool = get_stake_pool(&config.rpc_client, stake_pool_address)?;
     let epoch_info = config.rpc_client.get_epoch_info()?;
 

--- a/stake-pool/program/src/error.rs
+++ b/stake-pool/program/src/error.rs
@@ -111,7 +111,7 @@ pub enum StakePoolError {
 
     // 30.
     /// Provided stake deposit authority does not match the program's
-    #[error("FeeIncreaseTooHigh")]
+    #[error("InvalidStakeDepositAuthority")]
     InvalidStakeDepositAuthority,
     /// Provided sol deposit authority does not match the program's
     #[error("InvalidSolDepositAuthority")]
@@ -122,6 +122,14 @@ pub enum StakePoolError {
     /// Provided validator stake account already has a transient stake account in use
     #[error("TransientAccountInUse")]
     TransientAccountInUse,
+    /// Provided sol withdraw authority does not match the program's
+    #[error("InvalidSolWithdrawAuthority")]
+    InvalidSolWithdrawAuthority,
+
+    // 35.
+    /// Too much SOL withdrawn from the stake pool's reserve account
+    #[error("SolWithdrawalTooLarge")]
+    SolWithdrawalTooLarge,
 }
 impl From<StakePoolError> for ProgramError {
     fn from(e: StakePoolError) -> Self {

--- a/stake-pool/program/src/instruction.rs
+++ b/stake-pool/program/src/instruction.rs
@@ -361,7 +361,7 @@ pub enum StakePoolInstruction {
     ///  10. `[]` Stake program account
     ///  11. `[]` Token program id
     ///  12. `[s]` (Optional) Stake pool sol withdraw authority
-    WithdrawSol(u64)
+    WithdrawSol(u64),
 }
 
 /// Creates an 'initialize' instruction.
@@ -1137,8 +1137,8 @@ pub fn withdraw_sol(
 pub fn withdraw_sol_with_authority(
     program_id: &Pubkey,
     stake_pool: &Pubkey,
-    stake_pool_withdraw_authority: &Pubkey,
     sol_withdraw_authority: &Pubkey,
+    stake_pool_withdraw_authority: &Pubkey,
     user_transfer_authority: &Pubkey,
     pool_tokens_from: &Pubkey,
     reserve_stake_account: &Pubkey,

--- a/stake-pool/program/src/instruction.rs
+++ b/stake-pool/program/src/instruction.rs
@@ -28,15 +28,17 @@ pub enum PreferredValidatorType {
     Withdraw,
 }
 
-/// Defines which deposit authority to update in the `SetDepositAuthority`
+/// Defines which authority to update in the `SetFundingAuthority`
 /// instruction
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize, BorshSchema)]
-pub enum DepositType {
+pub enum FundingType {
     /// Sets the stake deposit authority
-    Stake,
+    StakeDeposit,
     /// Sets the SOL deposit authority
-    Sol,
+    SolDeposit,
+    /// Sets the SOL withdraw authority
+    SolWithdraw,
 }
 
 /// Instructions supported by the StakePool program.
@@ -345,8 +347,8 @@ pub enum StakePoolInstruction {
     ///
     ///  0. `[w]` StakePool
     ///  1. `[s]` Manager
-    ///  2. '[]` New sol_deposit_authority pubkey or none
-    SetDepositAuthority(DepositType),
+    ///  2. '[]` New authority pubkey or none
+    SetFundingAuthority(FundingType),
 }
 
 /// Creates an 'initialize' instruction.
@@ -376,7 +378,7 @@ pub fn initialize(
     };
     let data = init_data.try_to_vec().unwrap();
     let mut accounts = vec![
-        AccountMeta::new(*stake_pool, true),
+        AccountMeta::new(*stake_pool, false),
         AccountMeta::new_readonly(*manager, true),
         AccountMeta::new_readonly(*staker, false),
         AccountMeta::new(*validator_list, false),
@@ -1145,13 +1147,13 @@ pub fn set_staker(
     }
 }
 
-/// Creates a 'set deposit authority' instruction.
-pub fn set_deposit_authority(
+/// Creates a 'SetFundingAuthority' instruction.
+pub fn set_funding_authority(
     program_id: &Pubkey,
     stake_pool: &Pubkey,
     manager: &Pubkey,
     new_sol_deposit_authority: Option<&Pubkey>,
-    deposit_type: DepositType,
+    funding_type: FundingType,
 ) -> Instruction {
     let mut accounts = vec![
         AccountMeta::new(*stake_pool, false),
@@ -1163,7 +1165,7 @@ pub fn set_deposit_authority(
     Instruction {
         program_id: *program_id,
         accounts,
-        data: StakePoolInstruction::SetDepositAuthority(deposit_type)
+        data: StakePoolInstruction::SetFundingAuthority(funding_type)
             .try_to_vec()
             .unwrap(),
     }

--- a/stake-pool/program/src/instruction.rs
+++ b/stake-pool/program/src/instruction.rs
@@ -1041,7 +1041,6 @@ pub fn deposit_sol_with_authority(
         AccountMeta::new(*manager_fee_account, false),
         AccountMeta::new(*referrer_pool_tokens_account, false),
         AccountMeta::new(*pool_mint, false),
-        AccountMeta::new_readonly(sysvar::clock::id(), false),
         AccountMeta::new_readonly(system_program::id(), false),
         AccountMeta::new_readonly(*token_program_id, false),
         AccountMeta::new_readonly(*sol_deposit_authority, true),

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -1,11 +1,10 @@
 //! Program state processor
 
-use crate::instruction::DepositType;
 use {
     crate::{
         error::StakePoolError,
         find_deposit_authority_program_address,
-        instruction::{PreferredValidatorType, StakePoolInstruction},
+        instruction::{FundingType, PreferredValidatorType, StakePoolInstruction},
         minimum_reserve_lamports, minimum_stake_lamports, stake_program,
         state::{
             AccountType, Fee, FeeType, StakePool, StakeStatus, ValidatorList, ValidatorListHeader,
@@ -487,10 +486,10 @@ impl Processor {
     fn process_initialize(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
-        fee: Fee,
+        epoch_fee: Fee,
         withdrawal_fee: Fee,
-        stake_deposit_fee: Fee,
-        stake_referral_fee: u8,
+        deposit_fee: Fee,
+        referral_fee: u8,
         max_validators: u32,
     ) -> ProgramResult {
         let account_info_iter = &mut accounts.iter();
@@ -560,10 +559,10 @@ impl Processor {
         }
 
         // Numerator should be smaller than or equal to denominator (fee <= 1)
-        if fee.numerator > fee.denominator
+        if epoch_fee.numerator > epoch_fee.denominator
             || withdrawal_fee.numerator > withdrawal_fee.denominator
-            || stake_deposit_fee.numerator > stake_deposit_fee.denominator
-            || stake_referral_fee > 100u8
+            || deposit_fee.numerator > deposit_fee.denominator
+            || referral_fee > 100u8
         {
             return Err(StakePoolError::FeeTooHigh.into());
         }
@@ -657,15 +656,20 @@ impl Processor {
         stake_pool.token_program_id = *token_program_info.key;
         stake_pool.last_update_epoch = clock.epoch;
         stake_pool.total_stake_lamports = total_stake_lamports;
-        stake_pool.fee = fee;
+        stake_pool.epoch_fee = epoch_fee;
         stake_pool.next_epoch_fee = None;
         stake_pool.preferred_deposit_validator_vote_address = None;
         stake_pool.preferred_withdraw_validator_vote_address = None;
-        stake_pool.stake_deposit_fee = stake_deposit_fee;
-        stake_pool.withdrawal_fee = withdrawal_fee;
-        stake_pool.next_withdrawal_fee = None;
-        stake_pool.stake_referral_fee = stake_referral_fee;
+        stake_pool.stake_deposit_fee = deposit_fee;
+        stake_pool.stake_withdrawal_fee = withdrawal_fee;
+        stake_pool.next_stake_withdrawal_fee = None;
+        stake_pool.stake_referral_fee = referral_fee;
         stake_pool.sol_deposit_authority = None;
+        stake_pool.sol_deposit_fee = deposit_fee;
+        stake_pool.sol_referral_fee = referral_fee;
+        stake_pool.sol_withdraw_authority = None;
+        stake_pool.sol_withdrawal_fee = withdrawal_fee;
+        stake_pool.next_stake_withdrawal_fee = None;
 
         stake_pool
             .serialize(&mut *stake_pool_info.data.borrow_mut())
@@ -1659,13 +1663,17 @@ impl Processor {
         }
 
         if stake_pool.last_update_epoch < clock.epoch {
-            if let Some(next_epoch_fee) = stake_pool.next_epoch_fee {
-                stake_pool.fee = next_epoch_fee;
+            if let Some(fee) = stake_pool.next_epoch_fee {
+                stake_pool.epoch_fee = fee;
                 stake_pool.next_epoch_fee = None;
             }
-            if let Some(next_withdrawal_fee) = stake_pool.next_withdrawal_fee {
-                stake_pool.withdrawal_fee = next_withdrawal_fee;
-                stake_pool.next_withdrawal_fee = None;
+            if let Some(fee) = stake_pool.next_stake_withdrawal_fee {
+                stake_pool.stake_withdrawal_fee = fee;
+                stake_pool.next_stake_withdrawal_fee = None;
+            }
+            if let Some(fee) = stake_pool.next_sol_withdrawal_fee {
+                stake_pool.sol_withdrawal_fee = fee;
+                stake_pool.next_sol_withdrawal_fee = None;
             }
             stake_pool.last_update_epoch = clock.epoch;
         }
@@ -2433,7 +2441,6 @@ impl Processor {
         if !stake_pool.is_valid() {
             return Err(StakePoolError::InvalidState.into());
         }
-
         stake_pool.check_manager(manager_info)?;
 
         if fee.can_only_change_next_epoch() && stake_pool.last_update_epoch < clock.epoch {
@@ -2441,9 +2448,7 @@ impl Processor {
         }
 
         fee.check_too_high()?;
-        fee.check_withdrawal(&stake_pool.withdrawal_fee)?;
-
-        stake_pool.update_fee(&fee);
+        stake_pool.update_fee(&fee)?;
         stake_pool.serialize(&mut *stake_pool_info.data.borrow_mut())?;
         Ok(())
     }
@@ -2471,19 +2476,19 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes [SetStakeDepositAuthority/SetSolDepositAuthority](enum.Instruction.html).
-    fn process_set_deposit_authority(
+    /// Processes [SetFundingAuthority](enum.Instruction.html).
+    fn process_set_funding_authority(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
-        deposit_type: DepositType,
+        funding_type: FundingType,
     ) -> ProgramResult {
         let account_info_iter = &mut accounts.iter();
         let stake_pool_info = next_account_info(account_info_iter)?;
         let manager_info = next_account_info(account_info_iter)?;
 
-        let new_sol_deposit_authority = next_account_info(account_info_iter).ok().map(
-            |new_sol_deposit_authority_account_info| *new_sol_deposit_authority_account_info.key,
-        );
+        let new_authority = next_account_info(account_info_iter)
+            .ok()
+            .map(|new_authority_account_info| *new_authority_account_info.key);
 
         check_account_owner(stake_pool_info, program_id)?;
         let mut stake_pool = try_from_slice_unchecked::<StakePool>(&stake_pool_info.data.borrow())?;
@@ -2491,13 +2496,14 @@ impl Processor {
             return Err(StakePoolError::InvalidState.into());
         }
         stake_pool.check_manager(manager_info)?;
-        match deposit_type {
-            DepositType::Stake => {
-                stake_pool.stake_deposit_authority = new_sol_deposit_authority.unwrap_or(
+        match funding_type {
+            FundingType::StakeDeposit => {
+                stake_pool.stake_deposit_authority = new_authority.unwrap_or(
                     find_deposit_authority_program_address(program_id, stake_pool_info.key).0,
                 );
             }
-            DepositType::Sol => stake_pool.sol_deposit_authority = new_sol_deposit_authority,
+            FundingType::SolDeposit => stake_pool.sol_deposit_authority = new_authority,
+            FundingType::SolWithdraw => stake_pool.sol_withdraw_authority = new_authority,
         }
         stake_pool.serialize(&mut *stake_pool_info.data.borrow_mut())?;
         Ok(())
@@ -2613,9 +2619,9 @@ impl Processor {
                 msg!("Instruction: DepositSol");
                 Self::process_deposit_sol(program_id, accounts, lamports)
             }
-            StakePoolInstruction::SetDepositAuthority(deposit_type) => {
-                msg!("Instruction: SetDepositAuthority");
-                Self::process_set_deposit_authority(program_id, accounts, deposit_type)
+            StakePoolInstruction::SetFundingAuthority(funding_type) => {
+                msg!("Instruction: SetFundingAuthority");
+                Self::process_set_funding_authority(program_id, accounts, funding_type)
             }
         }
     }

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -28,7 +28,6 @@ use {
         program_pack::Pack,
         pubkey::Pubkey,
         rent::Rent,
-        stake_history::StakeHistory,
         system_instruction, system_program,
         sysvar::Sysvar,
     },
@@ -483,6 +482,7 @@ impl Processor {
     }
 
     /// Processes `Initialize` instruction.
+    #[inline(never)] // needed due to stack size violation
     fn process_initialize(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
@@ -675,6 +675,7 @@ impl Processor {
     }
 
     /// Processes `AddValidatorToPool` instruction.
+    #[inline(never)] // needed due to stack size violation
     fn process_add_validator_to_pool(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
@@ -810,6 +811,7 @@ impl Processor {
     }
 
     /// Processes `RemoveValidatorFromPool` instruction.
+    #[inline(never)] // needed due to stack size violation
     fn process_remove_validator_from_pool(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
@@ -967,6 +969,7 @@ impl Processor {
     }
 
     /// Processes `DecreaseValidatorStake` instruction.
+    #[inline(never)] // needed due to stack size violation
     fn process_decrease_validator_stake(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
@@ -1105,6 +1108,7 @@ impl Processor {
     }
 
     /// Processes `IncreaseValidatorStake` instruction.
+    #[inline(never)] // needed due to stack size violation
     fn process_increase_validator_stake(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
@@ -1264,6 +1268,7 @@ impl Processor {
     }
 
     /// Process `SetPreferredValidator` instruction
+    #[inline(never)] // needed due to stack size violation
     fn process_set_preferred_validator(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
@@ -1326,6 +1331,7 @@ impl Processor {
     }
 
     /// Processes `UpdateValidatorListBalance` instruction.
+    #[inline(always)] // needed to maximize number of validators
     fn process_update_validator_list_balance(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
@@ -1566,6 +1572,7 @@ impl Processor {
     }
 
     /// Processes `UpdateStakePoolBalance` instruction.
+    #[inline(always)] // needed to optimize number of validators
     fn process_update_stake_pool_balance(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
@@ -1685,6 +1692,7 @@ impl Processor {
     }
 
     /// Processes the `CleanupRemovedValidatorEntries` instruction
+    #[inline(never)] // needed to avoid stack size violation
     fn process_cleanup_removed_validator_entries(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
@@ -1713,33 +1721,8 @@ impl Processor {
         Ok(())
     }
 
-    /// Check stake activation status
-    #[allow(clippy::unnecessary_wraps)]
-    fn _check_stake_activation(
-        stake_info: &AccountInfo,
-        clock: &Clock,
-        stake_history: &StakeHistory,
-    ) -> ProgramResult {
-        let stake_acc_state =
-            try_from_slice_unchecked::<stake_program::StakeState>(&stake_info.data.borrow())
-                .unwrap();
-        let delegation = stake_acc_state.delegation();
-        if let Some(delegation) = delegation {
-            let target_epoch = clock.epoch;
-            let history = Some(stake_history);
-            let fix_stake_deactivate = true;
-            let (effective, activating, deactivating) = delegation
-                .stake_activating_and_deactivating(target_epoch, history, fix_stake_deactivate);
-            if activating != 0 || deactivating != 0 || effective == 0 {
-                return Err(StakePoolError::UserStakeNotActive.into());
-            }
-        } else {
-            return Err(StakePoolError::WrongStakeState.into());
-        }
-        Ok(())
-    }
-
     /// Processes [DepositStake](enum.Instruction.html).
+    #[inline(never)] // needed to avoid stack size violation
     fn process_deposit_stake(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
         let account_info_iter = &mut accounts.iter();
         let stake_pool_info = next_account_info(account_info_iter)?;
@@ -2007,6 +1990,7 @@ impl Processor {
     }
 
     /// Processes [DepositSol](enum.Instruction.html).
+    #[inline(never)] // needed to avoid stack size violation
     fn process_deposit_sol(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
@@ -2147,6 +2131,7 @@ impl Processor {
     }
 
     /// Processes [WithdrawStake](enum.Instruction.html).
+    #[inline(never)] // needed to avoid stack size violation
     fn process_withdraw_stake(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
@@ -2386,6 +2371,7 @@ impl Processor {
     }
 
     /// Processes [WithdrawSol](enum.Instruction.html).
+    #[inline(never)] // needed to avoid stack size violation
     fn process_withdraw_sol(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
@@ -2522,6 +2508,7 @@ impl Processor {
     }
 
     /// Processes [SetManager](enum.Instruction.html).
+    #[inline(never)] // needed to avoid stack size violation
     fn process_set_manager(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
         let account_info_iter = &mut accounts.iter();
         let stake_pool_info = next_account_info(account_info_iter)?;
@@ -2556,6 +2543,7 @@ impl Processor {
     }
 
     /// Processes [SetFee](enum.Instruction.html).
+    #[inline(never)] // needed to avoid stack size violation
     fn process_set_fee(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
@@ -2584,6 +2572,7 @@ impl Processor {
     }
 
     /// Processes [SetStaker](enum.Instruction.html).
+    #[inline(never)] // needed to avoid stack size violation
     fn process_set_staker(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
         let account_info_iter = &mut accounts.iter();
         let stake_pool_info = next_account_info(account_info_iter)?;
@@ -2607,6 +2596,7 @@ impl Processor {
     }
 
     /// Processes [SetFundingAuthority](enum.Instruction.html).
+    #[inline(never)] // needed to avoid stack size violation
     fn process_set_funding_authority(
         program_id: &Pubkey,
         accounts: &[AccountInfo],

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -2445,7 +2445,9 @@ impl Processor {
             return Err(StakePoolError::WithdrawalTooSmall.into());
         }
 
-        let new_reserve_lamports = reserve_stake_info.lamports().saturating_sub(withdraw_lamports);
+        let new_reserve_lamports = reserve_stake_info
+            .lamports()
+            .saturating_sub(withdraw_lamports);
         let stake_state = try_from_slice_unchecked::<stake_program::StakeState>(
             &reserve_stake_info.data.borrow(),
         )?;

--- a/stake-pool/program/src/state.rs
+++ b/stake-pool/program/src/state.rs
@@ -98,7 +98,7 @@ pub struct StakePool {
     pub lockup: Lockup,
 
     /// Fee taken as a proportion of rewards each epoch
-    pub fee: Fee,
+    pub epoch_fee: Fee,
 
     /// Fee for next epoch
     pub next_epoch_fee: Option<Fee>,
@@ -113,10 +113,10 @@ pub struct StakePool {
     pub stake_deposit_fee: Fee,
 
     /// Fee assessed on withdrawals
-    pub withdrawal_fee: Fee,
+    pub stake_withdrawal_fee: Fee,
 
-    /// Future withdrawal fee, to be set for the following epoch
-    pub next_withdrawal_fee: Option<Fee>,
+    /// Future stake withdrawal fee, to be set for the following epoch
+    pub next_stake_withdrawal_fee: Option<Fee>,
 
     /// Fees paid out to referrers on referred stake deposits.
     /// Expressed as a percentage (0 - 100) of deposit fees.
@@ -125,7 +125,7 @@ pub struct StakePool {
     pub stake_referral_fee: u8,
 
     /// Toggles whether the `DepositSol` instruction requires a signature from
-    /// the `deposit_authority`
+    /// this `sol_deposit_authority`
     pub sol_deposit_authority: Option<Pubkey>,
 
     /// Fee assessed on SOL deposits
@@ -136,6 +136,16 @@ pub struct StakePool {
     /// i.e. `sol_deposit_fee`% of SOL deposited is collected as deposit fees for every deposit
     /// and `sol_referral_fee`% of the collected SOL deposit fees is paid out to the referrer
     pub sol_referral_fee: u8,
+
+    /// Toggles whether the `WithdrawSol` instruction requires a signature from
+    /// the `deposit_authority`
+    pub sol_withdraw_authority: Option<Pubkey>,
+
+    /// Fee assessed on SOL withdrawals
+    pub sol_withdrawal_fee: Fee,
+
+    /// Future SOL withdrawal fee, to be set for the following epoch
+    pub next_sol_withdrawal_fee: Option<Fee>,
 }
 impl StakePool {
     /// calculate the pool tokens that should be minted for a deposit of `stake_lamports`
@@ -171,7 +181,7 @@ impl StakePool {
     /// calculate pool tokens to be deducted as withdrawal fees
     #[inline]
     pub fn calc_pool_tokens_withdrawal_fee(&self, pool_tokens: u64) -> Option<u64> {
-        u64::try_from(self.withdrawal_fee.apply(pool_tokens)?).ok()
+        u64::try_from(self.stake_withdrawal_fee.apply(pool_tokens)?).ok()
     }
 
     /// calculate pool tokens to be deducted as stake deposit fees
@@ -219,7 +229,7 @@ impl StakePool {
         }
         let total_stake_lamports =
             (self.total_stake_lamports as u128).checked_add(reward_lamports as u128)?;
-        let fee_lamports = self.fee.apply(reward_lamports)?;
+        let fee_lamports = self.epoch_fee.apply(reward_lamports)?;
         if total_stake_lamports == fee_lamports || self.pool_token_supply == 0 {
             Some(reward_lamports)
         } else {
@@ -416,15 +426,23 @@ impl StakePool {
     }
 
     /// Updates one of the StakePool's fees.
-    pub fn update_fee(&mut self, fee: &FeeType) {
+    pub fn update_fee(&mut self, fee: &FeeType) -> Result<(), StakePoolError> {
         match fee {
             FeeType::SolReferral(new_fee) => self.sol_referral_fee = *new_fee,
             FeeType::StakeReferral(new_fee) => self.stake_referral_fee = *new_fee,
             FeeType::Epoch(new_fee) => self.next_epoch_fee = Some(*new_fee),
-            FeeType::Withdrawal(new_fee) => self.next_withdrawal_fee = Some(*new_fee),
+            FeeType::StakeWithdrawal(new_fee) => {
+                new_fee.check_withdrawal(&self.stake_withdrawal_fee)?;
+                self.next_stake_withdrawal_fee = Some(*new_fee)
+            }
+            FeeType::SolWithdrawal(new_fee) => {
+                new_fee.check_withdrawal(&self.sol_withdrawal_fee)?;
+                self.next_sol_withdrawal_fee = Some(*new_fee)
+            }
             FeeType::SolDeposit(new_fee) => self.sol_deposit_fee = *new_fee,
             FeeType::StakeDeposit(new_fee) => self.stake_deposit_fee = *new_fee,
-        }
+        };
+        Ok(())
     }
 }
 
@@ -666,6 +684,43 @@ impl Fee {
             .checked_mul(self.numerator as u128)?
             .checked_div(self.denominator as u128)
     }
+
+    /// Withdrawal fees have some additional restrictions,
+    /// this fn checks if those are met, returning an error if not.
+    /// Does nothing and returns Ok if fee type is not withdrawal
+    pub fn check_withdrawal(&self, old_withdrawal_fee: &Fee) -> Result<(), StakePoolError> {
+        // If the previous withdrawal fee was 0, we allow the fee to be set to a
+        // maximum of (WITHDRAWAL_BASELINE_FEE * MAX_WITHDRAWAL_FEE_INCREASE)
+        let (old_num, old_denom) =
+            if old_withdrawal_fee.denominator == 0 || old_withdrawal_fee.numerator == 0 {
+                (
+                    WITHDRAWAL_BASELINE_FEE.numerator,
+                    WITHDRAWAL_BASELINE_FEE.denominator,
+                )
+            } else {
+                (old_withdrawal_fee.numerator, old_withdrawal_fee.denominator)
+            };
+
+        // Check that new_fee / old_fee <= MAX_WITHDRAWAL_FEE_INCREASE
+        // Program fails if provided numerator or denominator is too large, resulting in overflow
+        if (old_num as u128)
+            .checked_mul(self.denominator as u128)
+            .map(|x| x.checked_mul(MAX_WITHDRAWAL_FEE_INCREASE.numerator as u128))
+            .ok_or(StakePoolError::CalculationFailure)?
+            < (self.numerator as u128)
+                .checked_mul(old_denom as u128)
+                .map(|x| x.checked_mul(MAX_WITHDRAWAL_FEE_INCREASE.denominator as u128))
+                .ok_or(StakePoolError::CalculationFailure)?
+        {
+            msg!(
+                "Fee increase exceeds maximum allowed, proposed increase factor ({} / {})",
+                self.numerator * old_denom,
+                old_num * self.denominator,
+            );
+            return Err(StakePoolError::FeeIncreaseTooHigh);
+        }
+        Ok(())
+    }
 }
 
 impl fmt::Display for Fee {
@@ -683,12 +738,14 @@ pub enum FeeType {
     StakeReferral(u8),
     /// Management fee paid per epoch
     Epoch(Fee),
-    /// Withdrawal fee
-    Withdrawal(Fee),
+    /// Stake withdrawal fee
+    StakeWithdrawal(Fee),
     /// Deposit fee for SOL deposits
     SolDeposit(Fee),
     /// Deposit fee for stake deposits
     StakeDeposit(Fee),
+    /// SOL withdrawal fee
+    SolWithdrawal(Fee),
 }
 
 impl FeeType {
@@ -698,7 +755,8 @@ impl FeeType {
             Self::SolReferral(pct) => *pct > 100u8,
             Self::StakeReferral(pct) => *pct > 100u8,
             Self::Epoch(fee) => fee.numerator > fee.denominator,
-            Self::Withdrawal(fee) => fee.numerator > fee.denominator,
+            Self::StakeWithdrawal(fee) => fee.numerator > fee.denominator,
+            Self::SolWithdrawal(fee) => fee.numerator > fee.denominator,
             Self::SolDeposit(fee) => fee.numerator > fee.denominator,
             Self::StakeDeposit(fee) => fee.numerator > fee.denominator,
         };
@@ -709,52 +767,13 @@ impl FeeType {
         Ok(())
     }
 
-    /// Withdrawal fees have some additional restrictions,
-    /// this fn checks if those are met, returning an error if not.
-    /// Does nothing and returns Ok if fee type is not withdrawal
-    pub fn check_withdrawal(&self, old_withdrawal_fee: &Fee) -> Result<(), StakePoolError> {
-        let fee = match self {
-            Self::Withdrawal(fee) => fee,
-            _ => return Ok(()),
-        };
-
-        // If the previous withdrawal fee was 0, we allow the fee to be set to a
-        // maximum of (WITHDRAWAL_BASELINE_FEE * MAX_WITHDRAWAL_FEE_INCREASE)
-        let (old_num, old_denom) =
-            if old_withdrawal_fee.denominator == 0 || old_withdrawal_fee.numerator == 0 {
-                (
-                    WITHDRAWAL_BASELINE_FEE.numerator,
-                    WITHDRAWAL_BASELINE_FEE.denominator,
-                )
-            } else {
-                (old_withdrawal_fee.numerator, old_withdrawal_fee.denominator)
-            };
-
-        // Check that new_fee / old_fee <= MAX_WITHDRAWAL_FEE_INCREASE
-        // Program fails if provided numerator or denominator is too large, resulting in overflow
-        if (old_num as u128)
-            .checked_mul(fee.denominator as u128)
-            .map(|x| x.checked_mul(MAX_WITHDRAWAL_FEE_INCREASE.numerator as u128))
-            .ok_or(StakePoolError::CalculationFailure)?
-            < (fee.numerator as u128)
-                .checked_mul(old_denom as u128)
-                .map(|x| x.checked_mul(MAX_WITHDRAWAL_FEE_INCREASE.denominator as u128))
-                .ok_or(StakePoolError::CalculationFailure)?
-        {
-            msg!(
-                "Fee increase exceeds maximum allowed, proposed increase factor ({} / {})",
-                fee.numerator * old_denom,
-                old_num * fee.denominator,
-            );
-            return Err(StakePoolError::FeeIncreaseTooHigh);
-        }
-        Ok(())
-    }
-
     /// Returns if the contained fee can only be updated earliest on the next epoch
     #[inline]
     pub fn can_only_change_next_epoch(&self) -> bool {
-        matches!(self, Self::Withdrawal(_) | Self::Epoch(_))
+        matches!(
+            self,
+            Self::StakeWithdrawal(_) | Self::SolWithdrawal(_) | Self::Epoch(_)
+        )
     }
 }
 
@@ -953,14 +972,14 @@ mod test {
     #[test]
     fn specific_fee_calculation() {
         // 10% of 10 SOL in rewards should be 1 SOL in fees
-        let fee = Fee {
+        let epoch_fee = Fee {
             numerator: 1,
             denominator: 10,
         };
         let mut stake_pool = StakePool {
             total_stake_lamports: 100 * LAMPORTS_PER_SOL,
             pool_token_supply: 100 * LAMPORTS_PER_SOL,
-            fee,
+            epoch_fee,
             ..StakePool::default()
         };
         let reward_lamports = 10 * LAMPORTS_PER_SOL;
@@ -977,12 +996,12 @@ mod test {
 
     #[test]
     fn zero_withdraw_calculation() {
-        let fee = Fee {
+        let epoch_fee = Fee {
             numerator: 0,
             denominator: 1,
         };
         let stake_pool = StakePool {
-            fee,
+            epoch_fee,
             ..StakePool::default()
         };
         let fee_lamports = stake_pool.calc_lamports_withdraw_amount(0).unwrap();
@@ -993,7 +1012,7 @@ mod test {
     fn divide_by_zero_fee() {
         let stake_pool = StakePool {
             total_stake_lamports: 0,
-            fee: Fee {
+            epoch_fee: Fee {
                 numerator: 1,
                 denominator: 10,
             },
@@ -1010,11 +1029,11 @@ mod test {
             (numerator, denominator) in fee(),
             (total_stake_lamports, reward_lamports) in total_stake_and_rewards(),
         ) {
-            let fee = Fee { denominator, numerator };
+            let epoch_fee = Fee { denominator, numerator };
             let mut stake_pool = StakePool {
                 total_stake_lamports,
                 pool_token_supply: total_stake_lamports,
-                fee,
+                epoch_fee,
                 ..StakePool::default()
             };
             let pool_token_fee = stake_pool.calc_epoch_fee_amount(reward_lamports).unwrap();
@@ -1023,7 +1042,7 @@ mod test {
             stake_pool.pool_token_supply += pool_token_fee;
 
             let fee_lamports = stake_pool.calc_lamports_withdraw_amount(pool_token_fee).unwrap();
-            let max_fee_lamports = u64::try_from((reward_lamports as u128) * (fee.numerator as u128) / (fee.denominator as u128)).unwrap();
+            let max_fee_lamports = u64::try_from((reward_lamports as u128) * (epoch_fee.numerator as u128) / (epoch_fee.denominator as u128)).unwrap();
             assert!(max_fee_lamports >= fee_lamports,
                 "Max possible fee must always be greater than or equal to what is actually withdrawn, max {} actual {}",
                 max_fee_lamports,

--- a/stake-pool/program/src/state.rs
+++ b/stake-pool/program/src/state.rs
@@ -333,6 +333,7 @@ impl StakePool {
         if let Some(auth) = self.sol_deposit_authority {
             let sol_deposit_authority = maybe_sol_deposit_authority?;
             if auth != *sol_deposit_authority.key {
+                msg!("Expected {}, received {}", auth, sol_deposit_authority.key);
                 return Err(StakePoolError::InvalidSolDepositAuthority.into());
             }
             if !sol_deposit_authority.is_signer {

--- a/stake-pool/program/src/state.rs
+++ b/stake-pool/program/src/state.rs
@@ -752,7 +752,11 @@ impl Fee {
 
 impl fmt::Display for Fee {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}/{}", self.numerator, self.denominator)
+        if self.numerator > 0 && self.denominator > 0 {
+            write!(f, "{}/{}", self.numerator, self.denominator)
+        } else {
+            write!(f, "none")
+        }
     }
 }
 

--- a/stake-pool/program/tests/deposit.rs
+++ b/stake-pool/program/tests/deposit.rs
@@ -149,7 +149,7 @@ async fn success() {
     )
     .await;
     let pre_stake_pool =
-        try_from_slice_unchecked::<state::StakePool>(&pre_stake_pool.data.as_slice()).unwrap();
+        try_from_slice_unchecked::<state::StakePool>(pre_stake_pool.data.as_slice()).unwrap();
 
     // Save validator stake account record before depositing
     let validator_list = get_account(
@@ -201,7 +201,7 @@ async fn success() {
     )
     .await;
     let post_stake_pool =
-        try_from_slice_unchecked::<state::StakePool>(&post_stake_pool.data.as_slice()).unwrap();
+        try_from_slice_unchecked::<state::StakePool>(post_stake_pool.data.as_slice()).unwrap();
     assert_eq!(
         post_stake_pool.total_stake_lamports,
         pre_stake_pool.total_stake_lamports + stake_lamports
@@ -244,7 +244,7 @@ async fn success() {
         deserialize::<stake_program::StakeState>(&validator_stake_account.data).unwrap();
     let meta = stake_state.meta().unwrap();
     assert_eq!(
-        validator_stake_account.lamports - minimum_stake_lamports(&meta),
+        validator_stake_account.lamports - minimum_stake_lamports(meta),
         post_validator_stake_item.stake_lamports()
     );
     assert_eq!(post_validator_stake_item.transient_stake_lamports, 0);
@@ -314,7 +314,7 @@ async fn success_with_extra_stake_lamports() {
     )
     .await;
     let pre_stake_pool =
-        try_from_slice_unchecked::<state::StakePool>(&pre_stake_pool.data.as_slice()).unwrap();
+        try_from_slice_unchecked::<state::StakePool>(pre_stake_pool.data.as_slice()).unwrap();
 
     // Save validator stake account record before depositing
     let validator_list = get_account(
@@ -372,7 +372,7 @@ async fn success_with_extra_stake_lamports() {
     .await;
 
     let post_stake_pool =
-        try_from_slice_unchecked::<state::StakePool>(&post_stake_pool.data.as_slice()).unwrap();
+        try_from_slice_unchecked::<state::StakePool>(post_stake_pool.data.as_slice()).unwrap();
     assert_eq!(
         post_stake_pool.total_stake_lamports,
         pre_stake_pool.total_stake_lamports + extra_lamports + stake_lamports
@@ -439,7 +439,7 @@ async fn success_with_extra_stake_lamports() {
         deserialize::<stake_program::StakeState>(&validator_stake_account.data).unwrap();
     let meta = stake_state.meta().unwrap();
     assert_eq!(
-        validator_stake_account.lamports - minimum_stake_lamports(&meta),
+        validator_stake_account.lamports - minimum_stake_lamports(meta),
         post_validator_stake_item.stake_lamports()
     );
     assert_eq!(post_validator_stake_item.transient_stake_lamports, 0);

--- a/stake-pool/program/tests/deposit_sol.rs
+++ b/stake-pool/program/tests/deposit_sol.rs
@@ -165,7 +165,7 @@ async fn fail_with_wrong_token_program_id() {
     let wrong_token_program = Keypair::new();
 
     let mut transaction = Transaction::new_with_payer(
-        &instruction::deposit_sol(
+        &[instruction::deposit_sol(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.withdraw_authority,
@@ -177,7 +177,7 @@ async fn fail_with_wrong_token_program_id() {
             &stake_pool_accounts.pool_mint.pubkey(),
             &wrong_token_program.pubkey(),
             TEST_STAKE_AMOUNT,
-        ),
+        )],
         Some(&context.payer.pubkey()),
     );
     transaction.sign(&[&context.payer], context.last_blockhash);
@@ -427,7 +427,7 @@ async fn success_with_referral_fee() {
         get_token_balance(&mut context.banks_client, &referrer_token_account.pubkey()).await;
 
     let mut transaction = Transaction::new_with_payer(
-        &instruction::deposit_sol(
+        &[instruction::deposit_sol(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.withdraw_authority,
@@ -439,7 +439,7 @@ async fn success_with_referral_fee() {
             &stake_pool_accounts.pool_mint.pubkey(),
             &spl_token::id(),
             TEST_STAKE_AMOUNT,
-        ),
+        )],
         Some(&context.payer.pubkey()),
     );
     transaction.sign(&[&context.payer], context.last_blockhash);
@@ -464,7 +464,7 @@ async fn fail_with_invalid_referrer() {
     let invalid_token_account = Keypair::new();
 
     let mut transaction = Transaction::new_with_payer(
-        &instruction::deposit_sol(
+        &[instruction::deposit_sol(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.withdraw_authority,
@@ -476,7 +476,7 @@ async fn fail_with_invalid_referrer() {
             &stake_pool_accounts.pool_mint.pubkey(),
             &spl_token::id(),
             TEST_STAKE_AMOUNT,
-        ),
+        )],
         Some(&context.payer.pubkey()),
     );
     transaction.sign(&[&context.payer], context.last_blockhash);

--- a/stake-pool/program/tests/deposit_sol.rs
+++ b/stake-pool/program/tests/deposit_sol.rs
@@ -16,7 +16,7 @@ use {
     },
     spl_stake_pool::{
         error, id,
-        instruction::{self, DepositType},
+        instruction::{self, FundingType},
         state,
     },
     spl_token::error as token_error,
@@ -97,7 +97,7 @@ async fn success() {
     )
     .await;
     let pre_stake_pool =
-        try_from_slice_unchecked::<state::StakePool>(&pre_stake_pool.data.as_slice()).unwrap();
+        try_from_slice_unchecked::<state::StakePool>(pre_stake_pool.data.as_slice()).unwrap();
 
     // Save reserve state before depositing
     let pre_reserve_lamports = get_account(
@@ -128,7 +128,7 @@ async fn success() {
     )
     .await;
     let post_stake_pool =
-        try_from_slice_unchecked::<state::StakePool>(&post_stake_pool.data.as_slice()).unwrap();
+        try_from_slice_unchecked::<state::StakePool>(post_stake_pool.data.as_slice()).unwrap();
     assert_eq!(
         post_stake_pool.total_stake_lamports,
         pre_stake_pool.total_stake_lamports + TEST_STAKE_AMOUNT
@@ -317,12 +317,12 @@ async fn success_with_sol_deposit_authority() {
     let sol_deposit_authority = Keypair::new();
 
     let mut transaction = Transaction::new_with_payer(
-        &[instruction::set_deposit_authority(
+        &[instruction::set_funding_authority(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.manager.pubkey(),
             Some(&sol_deposit_authority.pubkey()),
-            DepositType::Sol,
+            FundingType::SolDeposit,
         )],
         Some(&payer.pubkey()),
     );
@@ -368,12 +368,12 @@ async fn fail_without_sol_deposit_authority_signature() {
     .unwrap();
 
     let mut transaction = Transaction::new_with_payer(
-        &[instruction::set_deposit_authority(
+        &[instruction::set_funding_authority(
             &id(),
             &stake_pool_accounts.stake_pool.pubkey(),
             &stake_pool_accounts.manager.pubkey(),
             Some(&sol_deposit_authority.pubkey()),
-            DepositType::Sol,
+            FundingType::SolDeposit,
         )],
         Some(&payer.pubkey()),
     );

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -856,7 +856,7 @@ impl StakePoolAccounts {
         sol_deposit_authority: Option<&Keypair>,
     ) -> Option<TransportError> {
         let mut signers = vec![payer];
-        let instructions = if let Some(sol_deposit_authority) = sol_deposit_authority {
+        let instruction = if let Some(sol_deposit_authority) = sol_deposit_authority {
             signers.push(sol_deposit_authority);
             instruction::deposit_sol_with_authority(
                 &id(),
@@ -888,7 +888,7 @@ impl StakePoolAccounts {
             )
         };
         let transaction = Transaction::new_signed_with_payer(
-            &instructions,
+            &[instruction],
             Some(&payer.pubkey()),
             &signers,
             *recent_blockhash,

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -69,7 +69,7 @@ pub async fn create_mint(
             spl_token::instruction::initialize_mint(
                 &spl_token::id(),
                 &pool_mint.pubkey(),
-                &manager,
+                manager,
                 None,
                 0,
             )
@@ -174,8 +174,8 @@ pub async fn close_token_account(
     let mut transaction = Transaction::new_with_payer(
         &[spl_token::instruction::close_account(
             &spl_token::id(),
-            &account,
-            &lamports_destination,
+            account,
+            lamports_destination,
             &manager.pubkey(),
             &[],
         )
@@ -198,7 +198,7 @@ pub async fn freeze_token_account(
     let mut transaction = Transaction::new_with_payer(
         &[spl_token::instruction::freeze_account(
             &spl_token::id(),
-            &account,
+            account,
             pool_mint,
             &manager.pubkey(),
             &[],
@@ -291,8 +291,8 @@ pub async fn delegate_tokens(
     let transaction = Transaction::new_signed_with_payer(
         &[spl_token::instruction::approve(
             &spl_token::id(),
-            &account,
-            &delegate,
+            account,
+            delegate,
             &manager.pubkey(),
             &[],
             amount,
@@ -318,7 +318,7 @@ pub async fn create_stake_pool(
     manager: &Keypair,
     staker: &Pubkey,
     stake_deposit_authority: &Option<Keypair>,
-    fee: &state::Fee,
+    epoch_fee: &state::Fee,
     withdrawal_fee: &state::Fee,
     deposit_fee: &state::Fee,
     referral_fee: u8,
@@ -359,7 +359,7 @@ pub async fn create_stake_pool(
                 pool_token_account,
                 &spl_token::id(),
                 stake_deposit_authority.as_ref().map(|k| k.pubkey()),
-                *fee,
+                *epoch_fee,
                 *withdrawal_fee,
                 *deposit_fee,
                 referral_fee,
@@ -492,9 +492,9 @@ pub async fn delegate_stake_account(
 ) {
     let mut transaction = Transaction::new_with_payer(
         &[stake_program::delegate_stake(
-            &stake,
+            stake,
             &authorized.pubkey(),
-            &vote,
+            vote,
         )],
         Some(&payer.pubkey()),
     );
@@ -513,9 +513,9 @@ pub async fn authorize_stake_account(
 ) {
     let mut transaction = Transaction::new_with_payer(
         &[stake_program::authorize(
-            &stake,
+            stake,
             &authorized.pubkey(),
-            &new_authorized,
+            new_authorized,
             stake_authorize,
         )],
         Some(&payer.pubkey()),
@@ -609,7 +609,7 @@ pub struct StakePoolAccounts {
     pub withdraw_authority: Pubkey,
     pub stake_deposit_authority: Pubkey,
     pub stake_deposit_authority_keypair: Option<Keypair>,
-    pub fee: state::Fee,
+    pub epoch_fee: state::Fee,
     pub withdrawal_fee: state::Fee,
     pub deposit_fee: state::Fee,
     pub referral_fee: u8,
@@ -648,7 +648,7 @@ impl StakePoolAccounts {
             withdraw_authority,
             stake_deposit_authority,
             stake_deposit_authority_keypair: None,
-            fee: state::Fee {
+            epoch_fee: state::Fee {
                 numerator: 1,
                 denominator: 100,
             },
@@ -678,7 +678,7 @@ impl StakePoolAccounts {
     }
 
     pub fn calculate_fee(&self, amount: u64) -> u64 {
-        amount * self.fee.numerator / self.fee.denominator
+        amount * self.epoch_fee.numerator / self.epoch_fee.denominator
     }
 
     pub fn calculate_withdrawal_fee(&self, pool_tokens: u64) -> u64 {
@@ -710,16 +710,16 @@ impl StakePoolAccounts {
     ) -> Result<(), TransportError> {
         create_mint(
             &mut banks_client,
-            &payer,
-            &recent_blockhash,
+            payer,
+            recent_blockhash,
             &self.pool_mint,
             &self.withdraw_authority,
         )
         .await?;
         create_token_account(
             &mut banks_client,
-            &payer,
-            &recent_blockhash,
+            payer,
+            recent_blockhash,
             &self.pool_fee_account,
             &self.pool_mint.pubkey(),
             &self.manager.pubkey(),
@@ -727,8 +727,8 @@ impl StakePoolAccounts {
         .await?;
         create_independent_stake_account(
             &mut banks_client,
-            &payer,
-            &recent_blockhash,
+            payer,
+            recent_blockhash,
             &self.reserve_stake,
             &stake_program::Authorized {
                 staker: self.withdraw_authority,
@@ -740,8 +740,8 @@ impl StakePoolAccounts {
         .await;
         create_stake_pool(
             &mut banks_client,
-            &payer,
-            &recent_blockhash,
+            payer,
+            recent_blockhash,
             &self.stake_pool,
             &self.validator_list,
             &self.reserve_stake.pubkey(),
@@ -750,7 +750,7 @@ impl StakePoolAccounts {
             &self.manager,
             &self.staker.pubkey(),
             &self.stake_deposit_authority_keypair,
-            &self.fee,
+            &self.epoch_fee,
             &self.withdrawal_fee,
             &self.deposit_fee,
             self.referral_fee,
@@ -831,7 +831,7 @@ impl StakePoolAccounts {
                     &self.reserve_stake.pubkey(),
                     pool_account,
                     &self.pool_fee_account.pubkey(),
-                    &referrer,
+                    referrer,
                     &self.pool_mint.pubkey(),
                     &spl_token::id(),
                 )
@@ -1079,6 +1079,7 @@ impl StakePoolAccounts {
         banks_client.process_transaction(transaction).await.err()
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn remove_validator_from_pool(
         &self,
         banks_client: &mut BanksClient,
@@ -1103,7 +1104,7 @@ impl StakePoolAccounts {
                     &self.stake_pool.pubkey(),
                     &self.staker.pubkey(),
                     &self.withdraw_authority,
-                    &new_authority,
+                    new_authority,
                     &self.validator_list.pubkey(),
                     validator_stake,
                     transient_stake,
@@ -1117,6 +1118,7 @@ impl StakePoolAccounts {
         banks_client.process_transaction(transaction).await.err()
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn decrease_validator_stake(
         &self,
         banks_client: &mut BanksClient,
@@ -1146,6 +1148,7 @@ impl StakePoolAccounts {
         banks_client.process_transaction(transaction).await.err()
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn increase_validator_stake(
         &self,
         banks_client: &mut BanksClient,
@@ -1224,8 +1227,8 @@ pub async fn simple_add_validator_to_pool(
     let error = stake_pool_accounts
         .add_validator_to_pool(
             banks_client,
-            &payer,
-            &recent_blockhash,
+            payer,
+            recent_blockhash,
             &validator_stake.stake_account,
             &validator_stake.vote.pubkey(),
         )

--- a/stake-pool/program/tests/initialize.rs
+++ b/stake-pool/program/tests/initialize.rs
@@ -50,8 +50,8 @@ async fn create_required_accounts(
 
     create_independent_stake_account(
         banks_client,
-        &payer,
-        &recent_blockhash,
+        payer,
+        recent_blockhash,
         &stake_pool_accounts.reserve_stake,
         &stake_program::Authorized {
             staker: stake_pool_accounts.withdraw_authority,
@@ -154,7 +154,7 @@ async fn fail_with_already_initialized_validator_list() {
 async fn fail_with_high_fee() {
     let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
     let mut stake_pool_accounts = StakePoolAccounts::new();
-    stake_pool_accounts.fee = state::Fee {
+    stake_pool_accounts.epoch_fee = state::Fee {
         numerator: 100001,
         denominator: 100000,
     };
@@ -252,7 +252,7 @@ async fn fail_with_wrong_max_validators() {
                 &stake_pool_accounts.pool_fee_account.pubkey(),
                 &spl_token::id(),
                 None,
-                stake_pool_accounts.fee,
+                stake_pool_accounts.epoch_fee,
                 stake_pool_accounts.withdrawal_fee,
                 stake_pool_accounts.deposit_fee,
                 stake_pool_accounts.referral_fee,
@@ -325,7 +325,7 @@ async fn fail_with_wrong_mint_authority() {
         &stake_pool_accounts.manager,
         &stake_pool_accounts.staker.pubkey(),
         &None,
-        &stake_pool_accounts.fee,
+        &stake_pool_accounts.epoch_fee,
         &stake_pool_accounts.withdrawal_fee,
         &stake_pool_accounts.deposit_fee,
         stake_pool_accounts.referral_fee,
@@ -415,7 +415,7 @@ async fn fail_with_freeze_authority() {
         &stake_pool_accounts.manager,
         &stake_pool_accounts.staker.pubkey(),
         &None,
-        &stake_pool_accounts.fee,
+        &stake_pool_accounts.epoch_fee,
         &stake_pool_accounts.withdrawal_fee,
         &stake_pool_accounts.deposit_fee,
         stake_pool_accounts.referral_fee,
@@ -507,7 +507,7 @@ async fn fail_with_wrong_token_program_id() {
                 &stake_pool_accounts.pool_fee_account.pubkey(),
                 &wrong_token_program.pubkey(),
                 None,
-                stake_pool_accounts.fee,
+                stake_pool_accounts.epoch_fee,
                 stake_pool_accounts.withdrawal_fee,
                 stake_pool_accounts.deposit_fee,
                 stake_pool_accounts.referral_fee,
@@ -586,7 +586,7 @@ async fn fail_with_wrong_fee_account() {
         &stake_pool_accounts.manager,
         &stake_pool_accounts.staker.pubkey(),
         &None,
-        &stake_pool_accounts.fee,
+        &stake_pool_accounts.epoch_fee,
         &stake_pool_accounts.withdrawal_fee,
         &stake_pool_accounts.deposit_fee,
         stake_pool_accounts.referral_fee,
@@ -679,7 +679,7 @@ async fn fail_with_not_rent_exempt_pool() {
                 &stake_pool_accounts.pool_fee_account.pubkey(),
                 &spl_token::id(),
                 None,
-                stake_pool_accounts.fee,
+                stake_pool_accounts.epoch_fee,
                 stake_pool_accounts.withdrawal_fee,
                 stake_pool_accounts.deposit_fee,
                 stake_pool_accounts.referral_fee,
@@ -756,7 +756,7 @@ async fn fail_with_not_rent_exempt_validator_list() {
                 &stake_pool_accounts.pool_fee_account.pubkey(),
                 &spl_token::id(),
                 None,
-                stake_pool_accounts.fee,
+                stake_pool_accounts.epoch_fee,
                 stake_pool_accounts.withdrawal_fee,
                 stake_pool_accounts.deposit_fee,
                 stake_pool_accounts.referral_fee,
@@ -810,7 +810,7 @@ async fn fail_without_manager_signature() {
     let rent_validator_list = rent.minimum_balance(validator_list_size);
 
     let init_data = instruction::StakePoolInstruction::Initialize {
-        fee: stake_pool_accounts.fee,
+        fee: stake_pool_accounts.epoch_fee,
         withdrawal_fee: stake_pool_accounts.withdrawal_fee,
         deposit_fee: stake_pool_accounts.deposit_fee,
         referral_fee: stake_pool_accounts.referral_fee,
@@ -934,7 +934,7 @@ async fn fail_with_pre_minted_pool_tokens() {
         &stake_pool_accounts.manager,
         &stake_pool_accounts.staker.pubkey(),
         &None,
-        &stake_pool_accounts.fee,
+        &stake_pool_accounts.epoch_fee,
         &stake_pool_accounts.withdrawal_fee,
         &stake_pool_accounts.deposit_fee,
         stake_pool_accounts.referral_fee,
@@ -1000,7 +1000,7 @@ async fn fail_with_bad_reserve() {
             &stake_pool_accounts.manager,
             &stake_pool_accounts.staker.pubkey(),
             &None,
-            &stake_pool_accounts.fee,
+            &stake_pool_accounts.epoch_fee,
             &stake_pool_accounts.withdrawal_fee,
             &stake_pool_accounts.deposit_fee,
             stake_pool_accounts.referral_fee,
@@ -1050,7 +1050,7 @@ async fn fail_with_bad_reserve() {
             &stake_pool_accounts.manager,
             &stake_pool_accounts.staker.pubkey(),
             &None,
-            &stake_pool_accounts.fee,
+            &stake_pool_accounts.epoch_fee,
             &stake_pool_accounts.withdrawal_fee,
             &stake_pool_accounts.deposit_fee,
             stake_pool_accounts.referral_fee,
@@ -1103,7 +1103,7 @@ async fn fail_with_bad_reserve() {
             &stake_pool_accounts.manager,
             &stake_pool_accounts.staker.pubkey(),
             &None,
-            &stake_pool_accounts.fee,
+            &stake_pool_accounts.epoch_fee,
             &stake_pool_accounts.withdrawal_fee,
             &stake_pool_accounts.deposit_fee,
             stake_pool_accounts.referral_fee,
@@ -1156,7 +1156,7 @@ async fn fail_with_bad_reserve() {
             &stake_pool_accounts.manager,
             &stake_pool_accounts.staker.pubkey(),
             &None,
-            &stake_pool_accounts.fee,
+            &stake_pool_accounts.epoch_fee,
             &stake_pool_accounts.withdrawal_fee,
             &stake_pool_accounts.deposit_fee,
             stake_pool_accounts.referral_fee,

--- a/stake-pool/program/tests/set_deposit_fee.rs
+++ b/stake-pool/program/tests/set_deposit_fee.rs
@@ -67,7 +67,7 @@ async fn success_stake() {
         &stake_pool_accounts.stake_pool.pubkey(),
     )
     .await;
-    let stake_pool = try_from_slice_unchecked::<StakePool>(&stake_pool.data.as_slice()).unwrap();
+    let stake_pool = try_from_slice_unchecked::<StakePool>(stake_pool.data.as_slice()).unwrap();
     assert_eq!(stake_pool.stake_deposit_fee, new_deposit_fee);
 }
 
@@ -105,7 +105,7 @@ async fn success_stake_increase_fee_from_0() {
         &stake_pool_accounts.stake_pool.pubkey(),
     )
     .await;
-    let stake_pool = try_from_slice_unchecked::<StakePool>(&stake_pool.data.as_slice()).unwrap();
+    let stake_pool = try_from_slice_unchecked::<StakePool>(stake_pool.data.as_slice()).unwrap();
     assert_eq!(stake_pool.stake_deposit_fee, new_deposit_fee);
 }
 
@@ -204,7 +204,7 @@ async fn success_sol() {
         &stake_pool_accounts.stake_pool.pubkey(),
     )
     .await;
-    let stake_pool = try_from_slice_unchecked::<StakePool>(&stake_pool.data.as_slice()).unwrap();
+    let stake_pool = try_from_slice_unchecked::<StakePool>(stake_pool.data.as_slice()).unwrap();
     assert_eq!(stake_pool.sol_deposit_fee, new_deposit_fee);
 }
 

--- a/stake-pool/program/tests/set_epoch_fee.rs
+++ b/stake-pool/program/tests/set_epoch_fee.rs
@@ -46,8 +46,8 @@ async fn success() {
         &stake_pool_accounts.stake_pool.pubkey(),
     )
     .await;
-    let stake_pool = try_from_slice_unchecked::<StakePool>(&stake_pool.data.as_slice()).unwrap();
-    let old_fee = stake_pool.fee;
+    let stake_pool = try_from_slice_unchecked::<StakePool>(stake_pool.data.as_slice()).unwrap();
+    let old_fee = stake_pool.epoch_fee;
 
     let transaction = Transaction::new_signed_with_payer(
         &[instruction::set_fee(
@@ -71,9 +71,9 @@ async fn success() {
         &stake_pool_accounts.stake_pool.pubkey(),
     )
     .await;
-    let stake_pool = try_from_slice_unchecked::<StakePool>(&stake_pool.data.as_slice()).unwrap();
+    let stake_pool = try_from_slice_unchecked::<StakePool>(stake_pool.data.as_slice()).unwrap();
 
-    assert_eq!(stake_pool.fee, old_fee);
+    assert_eq!(stake_pool.epoch_fee, old_fee);
     assert_eq!(stake_pool.next_epoch_fee, Some(new_fee));
 
     let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
@@ -97,8 +97,8 @@ async fn success() {
         &stake_pool_accounts.stake_pool.pubkey(),
     )
     .await;
-    let stake_pool = try_from_slice_unchecked::<StakePool>(&stake_pool.data.as_slice()).unwrap();
-    assert_eq!(stake_pool.fee, new_fee);
+    let stake_pool = try_from_slice_unchecked::<StakePool>(stake_pool.data.as_slice()).unwrap();
+    assert_eq!(stake_pool.epoch_fee, new_fee);
     assert_eq!(stake_pool.next_epoch_fee, None);
 }
 

--- a/stake-pool/program/tests/set_manager.rs
+++ b/stake-pool/program/tests/set_manager.rs
@@ -79,7 +79,7 @@ async fn test_set_manager() {
 
     let stake_pool = get_account(&mut banks_client, &stake_pool_accounts.stake_pool.pubkey()).await;
     let stake_pool =
-        try_from_slice_unchecked::<state::StakePool>(&stake_pool.data.as_slice()).unwrap();
+        try_from_slice_unchecked::<state::StakePool>(stake_pool.data.as_slice()).unwrap();
 
     assert_eq!(stake_pool.manager, new_manager.pubkey());
 }

--- a/stake-pool/program/tests/set_preferred.rs
+++ b/stake-pool/program/tests/set_preferred.rs
@@ -69,7 +69,7 @@ async fn success_deposit() {
     assert!(error.is_none());
 
     let stake_pool = get_account(&mut banks_client, &stake_pool_accounts.stake_pool.pubkey()).await;
-    let stake_pool = try_from_slice_unchecked::<StakePool>(&stake_pool.data.as_slice()).unwrap();
+    let stake_pool = try_from_slice_unchecked::<StakePool>(stake_pool.data.as_slice()).unwrap();
 
     assert_eq!(
         stake_pool.preferred_deposit_validator_vote_address,
@@ -97,7 +97,7 @@ async fn success_withdraw() {
     assert!(error.is_none());
 
     let stake_pool = get_account(&mut banks_client, &stake_pool_accounts.stake_pool.pubkey()).await;
-    let stake_pool = try_from_slice_unchecked::<StakePool>(&stake_pool.data.as_slice()).unwrap();
+    let stake_pool = try_from_slice_unchecked::<StakePool>(stake_pool.data.as_slice()).unwrap();
 
     assert_eq!(stake_pool.preferred_deposit_validator_vote_address, None);
     assert_eq!(
@@ -124,7 +124,7 @@ async fn success_unset() {
     assert!(error.is_none());
 
     let stake_pool = get_account(&mut banks_client, &stake_pool_accounts.stake_pool.pubkey()).await;
-    let stake_pool = try_from_slice_unchecked::<StakePool>(&stake_pool.data.as_slice()).unwrap();
+    let stake_pool = try_from_slice_unchecked::<StakePool>(stake_pool.data.as_slice()).unwrap();
 
     assert_eq!(
         stake_pool.preferred_withdraw_validator_vote_address,
@@ -143,7 +143,7 @@ async fn success_unset() {
     assert!(error.is_none());
 
     let stake_pool = get_account(&mut banks_client, &stake_pool_accounts.stake_pool.pubkey()).await;
-    let stake_pool = try_from_slice_unchecked::<StakePool>(&stake_pool.data.as_slice()).unwrap();
+    let stake_pool = try_from_slice_unchecked::<StakePool>(stake_pool.data.as_slice()).unwrap();
 
     assert_eq!(stake_pool.preferred_withdraw_validator_vote_address, None);
 }

--- a/stake-pool/program/tests/set_referral_fee.rs
+++ b/stake-pool/program/tests/set_referral_fee.rs
@@ -63,7 +63,7 @@ async fn success_stake() {
         &stake_pool_accounts.stake_pool.pubkey(),
     )
     .await;
-    let stake_pool = try_from_slice_unchecked::<StakePool>(&stake_pool.data.as_slice()).unwrap();
+    let stake_pool = try_from_slice_unchecked::<StakePool>(stake_pool.data.as_slice()).unwrap();
     assert_eq!(stake_pool.stake_referral_fee, new_referral_fee);
 }
 
@@ -94,7 +94,7 @@ async fn success_stake_increase_fee_from_0() {
         &stake_pool_accounts.stake_pool.pubkey(),
     )
     .await;
-    let stake_pool = try_from_slice_unchecked::<StakePool>(&stake_pool.data.as_slice()).unwrap();
+    let stake_pool = try_from_slice_unchecked::<StakePool>(stake_pool.data.as_slice()).unwrap();
     assert_eq!(stake_pool.stake_referral_fee, new_referral_fee);
 }
 
@@ -190,7 +190,7 @@ async fn success_sol() {
         &stake_pool_accounts.stake_pool.pubkey(),
     )
     .await;
-    let stake_pool = try_from_slice_unchecked::<StakePool>(&stake_pool.data.as_slice()).unwrap();
+    let stake_pool = try_from_slice_unchecked::<StakePool>(stake_pool.data.as_slice()).unwrap();
     assert_eq!(stake_pool.sol_referral_fee, new_referral_fee);
 }
 

--- a/stake-pool/program/tests/set_staker.rs
+++ b/stake-pool/program/tests/set_staker.rs
@@ -56,7 +56,7 @@ async fn success_set_staker_as_manager() {
 
     let stake_pool = get_account(&mut banks_client, &stake_pool_accounts.stake_pool.pubkey()).await;
     let stake_pool =
-        try_from_slice_unchecked::<state::StakePool>(&stake_pool.data.as_slice()).unwrap();
+        try_from_slice_unchecked::<state::StakePool>(stake_pool.data.as_slice()).unwrap();
 
     assert_eq!(stake_pool.staker, new_staker.pubkey());
 }
@@ -80,7 +80,7 @@ async fn success_set_staker_as_staker() {
 
     let stake_pool = get_account(&mut banks_client, &stake_pool_accounts.stake_pool.pubkey()).await;
     let stake_pool =
-        try_from_slice_unchecked::<state::StakePool>(&stake_pool.data.as_slice()).unwrap();
+        try_from_slice_unchecked::<state::StakePool>(stake_pool.data.as_slice()).unwrap();
 
     assert_eq!(stake_pool.staker, new_staker.pubkey());
 
@@ -98,7 +98,7 @@ async fn success_set_staker_as_staker() {
 
     let stake_pool = get_account(&mut banks_client, &stake_pool_accounts.stake_pool.pubkey()).await;
     let stake_pool =
-        try_from_slice_unchecked::<state::StakePool>(&stake_pool.data.as_slice()).unwrap();
+        try_from_slice_unchecked::<state::StakePool>(stake_pool.data.as_slice()).unwrap();
 
     assert_eq!(stake_pool.staker, stake_pool_accounts.staker.pubkey());
 }

--- a/stake-pool/program/tests/update_stake_pool_balance.rs
+++ b/stake-pool/program/tests/update_stake_pool_balance.rs
@@ -82,7 +82,7 @@ async fn success() {
         &stake_pool_accounts.stake_pool.pubkey(),
     )
     .await;
-    let stake_pool = try_from_slice_unchecked::<StakePool>(&stake_pool.data.as_slice()).unwrap();
+    let stake_pool = try_from_slice_unchecked::<StakePool>(stake_pool.data.as_slice()).unwrap();
     assert_eq!(pre_balance, stake_pool.total_stake_lamports);
 
     let pre_token_supply = get_token_supply(
@@ -137,7 +137,7 @@ async fn success() {
         &stake_pool_accounts.stake_pool.pubkey(),
     )
     .await;
-    let stake_pool = try_from_slice_unchecked::<StakePool>(&stake_pool.data.as_slice()).unwrap();
+    let stake_pool = try_from_slice_unchecked::<StakePool>(stake_pool.data.as_slice()).unwrap();
     assert_eq!(post_balance, stake_pool.total_stake_lamports);
 
     let post_fee = get_token_balance(
@@ -153,8 +153,8 @@ async fn success() {
     let actual_fee = post_fee - pre_fee;
     assert_eq!(pool_token_supply - pre_token_supply, actual_fee);
 
-    let expected_fee_lamports =
-        (post_balance - pre_balance) * stake_pool.fee.numerator / stake_pool.fee.denominator;
+    let expected_fee_lamports = (post_balance - pre_balance) * stake_pool.epoch_fee.numerator
+        / stake_pool.epoch_fee.denominator;
     let actual_fee_lamports = stake_pool.calc_pool_tokens_for_deposit(actual_fee).unwrap();
     assert_eq!(actual_fee_lamports, expected_fee_lamports);
 
@@ -179,7 +179,7 @@ async fn success_ignoring_extra_lamports() {
         &stake_pool_accounts.stake_pool.pubkey(),
     )
     .await;
-    let stake_pool = try_from_slice_unchecked::<StakePool>(&stake_pool.data.as_slice()).unwrap();
+    let stake_pool = try_from_slice_unchecked::<StakePool>(stake_pool.data.as_slice()).unwrap();
     assert_eq!(pre_balance, stake_pool.total_stake_lamports);
 
     let pre_token_supply = get_token_supply(

--- a/stake-pool/program/tests/withdraw.rs
+++ b/stake-pool/program/tests/withdraw.rs
@@ -132,7 +132,7 @@ async fn _success(test_type: SuccessTestType) {
     let stake_pool_before =
         get_account(&mut banks_client, &stake_pool_accounts.stake_pool.pubkey()).await;
     let stake_pool_before =
-        try_from_slice_unchecked::<state::StakePool>(&stake_pool_before.data.as_slice()).unwrap();
+        try_from_slice_unchecked::<state::StakePool>(stake_pool_before.data.as_slice()).unwrap();
 
     // Check user recipient stake account balance
     let initial_stake_lamports = get_account(&mut banks_client, &user_stake_recipient.pubkey())
@@ -235,7 +235,7 @@ async fn _success(test_type: SuccessTestType) {
     // Check pool stats
     let stake_pool = get_account(&mut banks_client, &stake_pool_accounts.stake_pool.pubkey()).await;
     let stake_pool =
-        try_from_slice_unchecked::<state::StakePool>(&stake_pool.data.as_slice()).unwrap();
+        try_from_slice_unchecked::<state::StakePool>(stake_pool.data.as_slice()).unwrap();
     // first and only deposit, lamports:pool 1:1
     let tokens_withdrawal_fee = match test_type {
         SuccessTestType::Success => {
@@ -301,7 +301,7 @@ async fn _success(test_type: SuccessTestType) {
         deserialize::<stake_program::StakeState>(&validator_stake_account.data).unwrap();
     let meta = stake_state.meta().unwrap();
     assert_eq!(
-        validator_stake_account.lamports - minimum_stake_lamports(&meta),
+        validator_stake_account.lamports - minimum_stake_lamports(meta),
         validator_stake_item.active_stake_lamports
     );
 

--- a/stake-pool/program/tests/withdraw_sol.rs
+++ b/stake-pool/program/tests/withdraw_sol.rs
@@ -1,0 +1,312 @@
+#![cfg(feature = "test-bpf")]
+
+mod helpers;
+
+use {
+    helpers::*,
+    solana_program::{
+        borsh::try_from_slice_unchecked, instruction::InstructionError, pubkey::Pubkey,
+    },
+    solana_program_test::*,
+    solana_sdk::{
+        signature::{Keypair, Signer},
+        transaction::Transaction,
+        transaction::TransactionError,
+    },
+    spl_stake_pool::{
+        error::StakePoolError,
+        id,
+        instruction::{self, FundingType},
+        stake_program, state,
+    },
+};
+
+async fn setup() -> (ProgramTestContext, StakePoolAccounts, Keypair, Pubkey, u64) {
+    let mut context = program_test().start_with_context().await;
+
+    let stake_pool_accounts = StakePoolAccounts::new();
+    stake_pool_accounts
+        .initialize_stake_pool(
+            &mut context.banks_client,
+            &context.payer,
+            &context.last_blockhash,
+            1,
+        )
+        .await
+        .unwrap();
+
+    let user = Keypair::new();
+
+    // make pool token account for user
+    let pool_token_account = Keypair::new();
+    create_token_account(
+        &mut context.banks_client,
+        &context.payer,
+        &context.last_blockhash,
+        &pool_token_account,
+        &stake_pool_accounts.pool_mint.pubkey(),
+        &user.pubkey(),
+    )
+    .await
+    .unwrap();
+
+    let error = stake_pool_accounts
+        .deposit_sol(
+            &mut context.banks_client,
+            &context.payer,
+            &context.last_blockhash,
+            &pool_token_account.pubkey(),
+            TEST_STAKE_AMOUNT,
+            None,
+        )
+        .await;
+    assert!(error.is_none());
+
+    let tokens_issued =
+        get_token_balance(&mut context.banks_client, &pool_token_account.pubkey()).await;
+
+    (
+        context,
+        stake_pool_accounts,
+        user,
+        pool_token_account.pubkey(),
+        tokens_issued,
+    )
+}
+
+#[tokio::test]
+async fn success() {
+    let (mut context, stake_pool_accounts, user, pool_token_account, pool_tokens) = setup().await;
+
+    // Save stake pool state before withdrawing
+    let pre_stake_pool = get_account(
+        &mut context.banks_client,
+        &stake_pool_accounts.stake_pool.pubkey(),
+    )
+    .await;
+    let pre_stake_pool =
+        try_from_slice_unchecked::<state::StakePool>(pre_stake_pool.data.as_slice()).unwrap();
+
+    // Save reserve state before withdrawing
+    let pre_reserve_lamports = get_account(
+        &mut context.banks_client,
+        &stake_pool_accounts.reserve_stake.pubkey(),
+    )
+    .await
+    .lamports;
+
+    let error = stake_pool_accounts
+        .withdraw_sol(
+            &mut context.banks_client,
+            &context.payer,
+            &context.last_blockhash,
+            &user,
+            &pool_token_account,
+            pool_tokens,
+            None,
+        )
+        .await;
+    assert!(error.is_none());
+
+    // Stake pool should add its balance to the pool balance
+    let post_stake_pool = get_account(
+        &mut context.banks_client,
+        &stake_pool_accounts.stake_pool.pubkey(),
+    )
+    .await;
+    let post_stake_pool =
+        try_from_slice_unchecked::<state::StakePool>(post_stake_pool.data.as_slice()).unwrap();
+    let amount_withdrawn_minus_fee =
+        pool_tokens - stake_pool_accounts.calculate_withdrawal_fee(pool_tokens);
+    assert_eq!(
+        post_stake_pool.total_stake_lamports,
+        pre_stake_pool.total_stake_lamports - amount_withdrawn_minus_fee
+    );
+    assert_eq!(
+        post_stake_pool.pool_token_supply,
+        pre_stake_pool.pool_token_supply - amount_withdrawn_minus_fee
+    );
+
+    // Check minted tokens
+    let user_token_balance =
+        get_token_balance(&mut context.banks_client, &pool_token_account).await;
+    assert_eq!(user_token_balance, 0);
+
+    // Check reserve
+    let post_reserve_lamports = get_account(
+        &mut context.banks_client,
+        &stake_pool_accounts.reserve_stake.pubkey(),
+    )
+    .await
+    .lamports;
+    assert_eq!(
+        post_reserve_lamports,
+        pre_reserve_lamports - amount_withdrawn_minus_fee
+    );
+}
+
+#[tokio::test]
+async fn fail_with_wrong_withdraw_authority() {
+    let (mut context, mut stake_pool_accounts, user, pool_token_account, pool_tokens) =
+        setup().await;
+
+    stake_pool_accounts.withdraw_authority = Pubkey::new_unique();
+
+    let error = stake_pool_accounts
+        .withdraw_sol(
+            &mut context.banks_client,
+            &context.payer,
+            &context.last_blockhash,
+            &user,
+            &pool_token_account,
+            pool_tokens,
+            None,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(StakePoolError::InvalidProgramAddress as u32)
+        )
+    );
+}
+
+#[tokio::test]
+async fn fail_overdraw_reserve() {
+    let (mut context, stake_pool_accounts, user, pool_token_account, _) = setup().await;
+
+    // add a validator and increase stake to drain the reserve
+    let validator_stake = simple_add_validator_to_pool(
+        &mut context.banks_client,
+        &context.payer,
+        &context.last_blockhash,
+        &stake_pool_accounts,
+    )
+    .await;
+
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let stake_rent = rent.minimum_balance(std::mem::size_of::<stake_program::StakeState>());
+    let error = stake_pool_accounts
+        .increase_validator_stake(
+            &mut context.banks_client,
+            &context.payer,
+            &context.last_blockhash,
+            &validator_stake.transient_stake_account,
+            &validator_stake.vote.pubkey(),
+            TEST_STAKE_AMOUNT - stake_rent,
+            validator_stake.transient_stake_seed,
+        )
+        .await;
+    assert!(error.is_none());
+
+    // try to withdraw one lamport, will overdraw
+    let error = stake_pool_accounts
+        .withdraw_sol(
+            &mut context.banks_client,
+            &context.payer,
+            &context.last_blockhash,
+            &user,
+            &pool_token_account,
+            1,
+            None,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(StakePoolError::SolWithdrawalTooLarge as u32)
+        )
+    );
+}
+
+#[tokio::test]
+async fn success_with_sol_withdraw_authority() {
+    let (mut context, stake_pool_accounts, user, pool_token_account, pool_tokens) = setup().await;
+    let sol_withdraw_authority = Keypair::new();
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction::set_funding_authority(
+            &id(),
+            &stake_pool_accounts.stake_pool.pubkey(),
+            &stake_pool_accounts.manager.pubkey(),
+            Some(&sol_withdraw_authority.pubkey()),
+            FundingType::SolWithdraw,
+        )],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &stake_pool_accounts.manager],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+
+    let error = stake_pool_accounts
+        .withdraw_sol(
+            &mut context.banks_client,
+            &context.payer,
+            &context.last_blockhash,
+            &user,
+            &pool_token_account,
+            pool_tokens,
+            Some(&sol_withdraw_authority),
+        )
+        .await;
+    assert!(error.is_none());
+}
+
+#[tokio::test]
+async fn fail_without_sol_withdraw_authority_signature() {
+    let (mut context, stake_pool_accounts, user, pool_token_account, pool_tokens) = setup().await;
+    let sol_withdraw_authority = Keypair::new();
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction::set_funding_authority(
+            &id(),
+            &stake_pool_accounts.stake_pool.pubkey(),
+            &stake_pool_accounts.manager.pubkey(),
+            Some(&sol_withdraw_authority.pubkey()),
+            FundingType::SolWithdraw,
+        )],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &stake_pool_accounts.manager],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+
+    let wrong_withdrawer = Keypair::new();
+    let error = stake_pool_accounts
+        .withdraw_sol(
+            &mut context.banks_client,
+            &context.payer,
+            &context.last_blockhash,
+            &user,
+            &pool_token_account,
+            pool_tokens,
+            Some(&wrong_withdrawer),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(StakePoolError::InvalidSolWithdrawAuthority as u32)
+        )
+    );
+}


### PR DESCRIPTION
#### Problem

People want to withdraw SOL directly from the reserve, but this is currently only permitted if there's nowhere else to withdraw from.  There are many valid usecases for someone to withdraw SOL directly from the reserve, especially for restricted pools that want easier control over all the SOL in the pool.

#### Solution

Add a `withdraw-sol` instruction! The concept is very similar to `deposit-sol`, except in reverse.  Other additions:

* sol withdrawal fee: allow managers to specify a different fee for sol withdrawals.  this makes sense if you want to encourage stake withdraws
* sol withdraw authority: forces sol withdrawals to be signed by a particular key
* add CLI support for withdrawing sol, setting the sol withdrawal fee, and setting the sol withdraw authority
* update the docs for the new instructions
* rename `fee` -> `epoch_fee` for clarity
* force *not* inlining some processor functions because we were blowing the stack size with the addition of the new instruction (who knew?)
* remove the clock and rent accounts wherever they *weren't* needed during CPIs to the stake program

@jon-chuang could you take a look at the program changes in c6f1f34 and 819c76c?
@c3pko could you look at the doc changes in bd14d67 ?