### PR TITLE
token3: Added Revoke2 instruction [WIP DO NOT MERGE]

### DIFF
--- a/token/program/src/instruction.rs
+++ b/token/program/src/instruction.rs
@@ -409,7 +409,7 @@ pub enum TokenInstruction {
         /// The freeze authority/multisignature of the mint.
         freeze_authority: COption<Pubkey>,
     },
-    /// Like Revoke, but allows the delegate to revoke itself 
+    /// Like Revoke, but allows the delegate to revoke itself
     ///
     /// Accounts expected by this instruction:
     ///

--- a/token/program/src/processor.rs
+++ b/token/program/src/processor.rs
@@ -6231,8 +6231,7 @@ mod tests {
 
         // initialize non-native account
         do_process_instruction(
-            initialize_account(&program_id, &token_account_key, &mint_key, &owner_key)
-                .unwrap(),
+            initialize_account(&program_id, &token_account_key, &mint_key, &owner_key).unwrap(),
             vec![
                 &mut token_account,
                 &mut mint_account,
@@ -6242,29 +6241,35 @@ mod tests {
         )
         .unwrap();
 
-        // delegate account 
+        // delegate account
         assert_eq!(
             Ok(()),
             do_process_instruction(
-                approve(&program_id, &token_account_key, &delegate_key, &owner_key, &[], 1).unwrap(),
-                vec![&mut token_account, &mut delegate_account, &mut owner_account],
+                approve(
+                    &program_id,
+                    &token_account_key,
+                    &delegate_key,
+                    &owner_key,
+                    &[],
+                    1
+                )
+                .unwrap(),
+                vec![
+                    &mut token_account,
+                    &mut delegate_account,
+                    &mut owner_account
+                ],
             )
         );
 
         let account = Account::unpack_unchecked(&token_account.data).unwrap();
-        // check delegate 
-        assert_eq!(
-            account.delegate,
-            COption::Some(delegate_key)
-        );
+        // check delegate
+        assert_eq!(account.delegate, COption::Some(delegate_key));
 
-        // check delegate 
-        assert_eq!(
-            account.delegated_amount,
-            1, 
-        );
+        // check delegate
+        assert_eq!(account.delegated_amount, 1,);
 
-        // revoke account with random account (will fail) 
+        // revoke account with random account (will fail)
         assert_eq!(
             Err(TokenError::OwnerMismatch.into()),
             do_process_instruction(
@@ -6284,40 +6289,40 @@ mod tests {
 
         let account = Account::unpack_unchecked(&token_account.data).unwrap();
 
-        // check delegate 
-        assert_eq!(
-            account.delegate,
-            COption::None
-        );
+        // check delegate
+        assert_eq!(account.delegate, COption::None);
 
-        // check delegate 
-        assert_eq!(
-            account.delegated_amount,
-            0, 
-        );
+        // check delegate
+        assert_eq!(account.delegated_amount, 0,);
 
-        // delegate account 
+        // delegate account
         assert_eq!(
             Ok(()),
             do_process_instruction(
-                approve(&program_id, &token_account_key, &delegate_key, &owner_key, &[], 1).unwrap(),
-                vec![&mut token_account, &mut delegate_account, &mut owner_account],
+                approve(
+                    &program_id,
+                    &token_account_key,
+                    &delegate_key,
+                    &owner_key,
+                    &[],
+                    1
+                )
+                .unwrap(),
+                vec![
+                    &mut token_account,
+                    &mut delegate_account,
+                    &mut owner_account
+                ],
             )
         );
 
         let account = Account::unpack_unchecked(&token_account.data).unwrap();
-        // check delegate 
-        assert_eq!(
-            account.delegate,
-            COption::Some(delegate_key)
-        );
+        // check delegate
+        assert_eq!(account.delegate, COption::Some(delegate_key));
 
-        // check delegate 
-        assert_eq!(
-            account.delegated_amount,
-            1, 
-        );
-        
+        // check delegate
+        assert_eq!(account.delegated_amount, 1,);
+
         // try revoking account with delegate with Revoke, should fail because the delegate cannot revoke
         assert_eq!(
             Err(TokenError::OwnerMismatch.into()),
@@ -6338,17 +6343,10 @@ mod tests {
 
         let account = Account::unpack_unchecked(&token_account.data).unwrap();
 
-        // check delegate 
-        assert_eq!(
-            account.delegate,
-            COption::None
-        );
+        // check delegate
+        assert_eq!(account.delegate, COption::None);
 
-        // check delegate 
-        assert_eq!(
-            account.delegated_amount,
-            0, 
-        );
-
+        // check delegate
+        assert_eq!(account.delegated_amount, 0,);
     }
 }


### PR DESCRIPTION
### Problem

Currently, the base wallet MUST sign into order to revoke the authority of a delegate. This introduces poor UX for situations where you might want to delegate authority for a 1 time transfer/burn

### Solution

Allow the delegate to revoke itself. If the delegate is in a PDA, the program owning the delegate can make a CPI to `Revoke2` after the responsibility of the delegate has been completed. This is better UX for the base wallet as they can be confident that the delegation is self closing.


### Caveats

I know that pushing changes to the Token Program is Very Hard. 

*This is only to start a conversation.*

Because of this, I really don't expect this to get merged in any time soon. I did add in a test (tests mean nothing IMO) and I created a new instruction to prevent collisions with existing programs using `Revoke` (even though I am confident that those programs will not break).

The other design consideration is the case in which you do not want to allow the delegate to be able to revoke itself. This is notably unhandled by this change, and I think you might have to set a flag for this specific case (I wonder if you can use the COption bits for this).