### PR TITLE
stake-pool: Clarify stake deposit fee

### DIFF
--- a/docs/src/stake-pool.md
+++ b/docs/src/stake-pool.md
@@ -807,6 +807,22 @@ $ spl-token balance BoNneHKDrX9BHjjvSpPfnQyRjsnc9WFH71v8wrgCd7LB
 10.00000000
 ```
 
+#### Note on stake deposit fee
+
+Stake pools have separate fees for stake and SOL, so the total fee from depositing
+a stake account is calculated from the rent-exempt reserve as SOL, and the delegation
+as stake.
+
+For example, if a stake pool has a stake deposit fee of 1%, and a SOL deposit fee
+of 5%, and you deposit a stake account with 10 SOL in stake, and .00228288 SOL
+in rent-exemption, the total fee charged is:
+
+```
+total_fee = stake_delegation * stake_deposit_fee + rent_exemption * sol_deposit_fee
+total_fee = 10 * 1% + .00228288 * 5%
+total_fee = 0.100114144
+```
+
 ### Update
 
 Every epoch, the network pays out rewards to stake accounts managed by the stake

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -1749,8 +1749,6 @@ impl Processor {
             return Err(StakePoolError::InvalidState.into());
         }
 
-        //Self::check_stake_activation(stake_info, clock, stake_history)?;
-
         stake_pool.check_authority_withdraw(
             withdraw_authority_info.key,
             program_id,
@@ -1800,16 +1798,6 @@ impl Processor {
                 return Err(StakePoolError::IncorrectDepositVoteAddress.into());
             }
         }
-
-        let (meta, stake) = get_stake_state(stake_info)?;
-
-        // If the stake account is mergeable (full-activated), `meta.rent_exempt_reserve`
-        // will not be merged into `stake.delegation.stake`
-        let unactivated_stake_rent = if stake.delegation.activation_epoch < clock.epoch {
-            meta.rent_exempt_reserve
-        } else {
-            0
-        };
 
         let mut validator_stake_info = validator_list
             .find_mut::<ValidatorStakeInfo>(
@@ -1864,7 +1852,7 @@ impl Processor {
         let post_all_validator_lamports = validator_stake_account_info.lamports();
         msg!("Stake post merge {}", post_validator_stake.delegation.stake);
 
-        let all_deposit_lamports = post_all_validator_lamports
+        let total_deposit_lamports = post_all_validator_lamports
             .checked_sub(pre_all_validator_lamports)
             .ok_or(StakePoolError::CalculationFailure)?;
         let stake_deposit_lamports = post_validator_stake
@@ -1872,30 +1860,39 @@ impl Processor {
             .stake
             .checked_sub(validator_stake.delegation.stake)
             .ok_or(StakePoolError::CalculationFailure)?;
-        let additional_lamports = all_deposit_lamports
+        let sol_deposit_lamports = total_deposit_lamports
             .checked_sub(stake_deposit_lamports)
             .ok_or(StakePoolError::CalculationFailure)?;
-        let credited_additional_lamports = additional_lamports.min(unactivated_stake_rent);
-        let credited_deposit_lamports =
-            stake_deposit_lamports.saturating_add(credited_additional_lamports);
 
         let new_pool_tokens = stake_pool
-            .calc_pool_tokens_for_deposit(credited_deposit_lamports)
+            .calc_pool_tokens_for_deposit(total_deposit_lamports)
+            .ok_or(StakePoolError::CalculationFailure)?;
+        let new_pool_tokens_from_stake = stake_pool
+            .calc_pool_tokens_for_deposit(stake_deposit_lamports)
+            .ok_or(StakePoolError::CalculationFailure)?;
+        let new_pool_tokens_from_sol = new_pool_tokens
+            .checked_sub(new_pool_tokens_from_stake)
             .ok_or(StakePoolError::CalculationFailure)?;
 
-        let pool_tokens_stake_deposit_fee = stake_pool
-            .calc_pool_tokens_stake_deposit_fee(new_pool_tokens)
+        let stake_deposit_fee = stake_pool
+            .calc_pool_tokens_stake_deposit_fee(new_pool_tokens_from_stake)
+            .ok_or(StakePoolError::CalculationFailure)?;
+        let sol_deposit_fee = stake_pool
+            .calc_pool_tokens_sol_deposit_fee(new_pool_tokens_from_sol)
             .ok_or(StakePoolError::CalculationFailure)?;
 
+        let total_fee = stake_deposit_fee
+            .checked_add(sol_deposit_fee)
+            .ok_or(StakePoolError::CalculationFailure)?;
         let pool_tokens_user = new_pool_tokens
-            .checked_sub(pool_tokens_stake_deposit_fee)
+            .checked_sub(total_fee)
             .ok_or(StakePoolError::CalculationFailure)?;
 
         let pool_tokens_referral_fee = stake_pool
-            .calc_pool_tokens_stake_referral_fee(pool_tokens_stake_deposit_fee)
+            .calc_pool_tokens_stake_referral_fee(total_fee)
             .ok_or(StakePoolError::CalculationFailure)?;
 
-        let pool_tokens_manager_deposit_fee = pool_tokens_stake_deposit_fee
+        let pool_tokens_manager_deposit_fee = total_fee
             .checked_sub(pool_tokens_referral_fee)
             .ok_or(StakePoolError::CalculationFailure)?;
 
@@ -1911,18 +1908,16 @@ impl Processor {
             return Err(StakePoolError::DepositTooSmall.into());
         }
 
-        if pool_tokens_user > 0 {
-            Self::token_mint_to(
-                stake_pool_info.key,
-                token_program_info.clone(),
-                pool_mint_info.clone(),
-                dest_user_pool_info.clone(),
-                withdraw_authority_info.clone(),
-                AUTHORITY_WITHDRAW,
-                stake_pool.stake_withdraw_bump_seed,
-                pool_tokens_user,
-            )?;
-        }
+        Self::token_mint_to(
+            stake_pool_info.key,
+            token_program_info.clone(),
+            pool_mint_info.clone(),
+            dest_user_pool_info.clone(),
+            withdraw_authority_info.clone(),
+            AUTHORITY_WITHDRAW,
+            stake_pool.stake_withdraw_bump_seed,
+            pool_tokens_user,
+        )?;
         if pool_tokens_manager_deposit_fee > 0 {
             Self::token_mint_to(
                 stake_pool_info.key,
@@ -1949,8 +1944,7 @@ impl Processor {
         }
 
         // withdraw additional lamports to the reserve
-
-        if additional_lamports > 0 {
+        if sol_deposit_lamports > 0 {
             Self::stake_withdraw(
                 stake_pool_info.key,
                 validator_stake_account_info.clone(),
@@ -1961,7 +1955,7 @@ impl Processor {
                 clock_info.clone(),
                 stake_history_info.clone(),
                 stake_program_info.clone(),
-                additional_lamports,
+                sol_deposit_lamports,
             )?;
         }
 
@@ -1973,7 +1967,7 @@ impl Processor {
         // transferred directly to the reserve stake account.
         stake_pool.total_lamports = stake_pool
             .total_lamports
-            .checked_add(all_deposit_lamports)
+            .checked_add(total_deposit_lamports)
             .ok_or(StakePoolError::CalculationFailure)?;
         stake_pool.serialize(&mut *stake_pool_info.data.borrow_mut())?;
 

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -685,10 +685,6 @@ impl StakePoolAccounts {
         pool_tokens * self.withdrawal_fee.numerator / self.withdrawal_fee.denominator
     }
 
-    pub fn calculate_deposit_fee(&self, pool_tokens: u64) -> u64 {
-        pool_tokens * self.deposit_fee.numerator / self.deposit_fee.denominator
-    }
-
     pub fn calculate_referral_fee(&self, deposit_fee_collected: u64) -> u64 {
         deposit_fee_collected * self.referral_fee as u64 / 100
     }


### PR DESCRIPTION
#### Problem

Stake deposit fees are confusing.  Currently, the behavior only credits rent-exemption + the stake delegation.  This was done to penalize people who fill their stake account with a lot of undelegated SOL and still want to benefit from potentially lower stake deposit fees.

#### Solution

The above approach was taken before SOL deposits existed, and now that SOL deposits are possible, the clearest and most mathematically sound way to handle a stake deposit is to charge the delegation portion at the stake deposit rate, and everything else at the SOL deposit rate.  The new documentation explains this calculation in more depth.