### PR TITLE
stake-pool: Force pools to only use the SPL token program

### DIFF
--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -565,6 +565,15 @@ impl Processor {
             return Err(StakePoolError::FeeTooHigh.into());
         }
 
+        if *token_program_info.key != spl_token::id() {
+            msg!(
+                "Only the SPL token program is currently supported, expected {}, received {}",
+                spl_token::id(),
+                *token_program_info.key
+            );
+            return Err(ProgramError::IncorrectProgramId);
+        }
+
         if manager_fee_info.owner != token_program_info.key {
             return Err(ProgramError::IncorrectProgramId);
         }


### PR DESCRIPTION
#### Problem

Stake pools have a `token_program_id` field, theoretically allowing the stake pool manager to set their own token program.  In practice, this isn't even usable because the spl_token instruction creators force the program id to be `spl_token::id()`.

#### Solution

Let's avoid a footgun, and just force the token program to be `spl_token::id()`