### PR TITLE
stake-pool: Add comment to validator stake info field

### DIFF
--- a/stake-pool/program/src/state.rs
+++ b/stake-pool/program/src/state.rs
@@ -532,12 +532,16 @@ impl Default for StakeStatus {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct ValidatorStakeInfo {
-    /// Amount of active stake delegated to this validator
+    /// Amount of active stake delegated to this validator, minus the minimum
+    /// required stake amount of rent-exemption + `crate::MINIMUM_ACTIVE_STAKE`
+    /// (currently 0.001 SOL).
+    ///
     /// Note that if `last_update_epoch` does not match the current epoch then
     /// this field may not be accurate
     pub active_stake_lamports: u64,
 
     /// Amount of transient stake delegated to this validator
+    ///
     /// Note that if `last_update_epoch` does not match the current epoch then
     /// this field may not be accurate
     pub transient_stake_lamports: u64,


### PR DESCRIPTION
#### Problem

`active_stake_lamports` isn't clear that it doesn't include `MINIMUM_ACTIVE_STAKE`, since there's no comment or info about it.

#### Solution

Add a comment on the field.