### PR TITLE
Governance: Flag payer account as writable on instructions creators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3743,7 +3743,7 @@ dependencies = [
 
 [[package]]
 name = "spl-governance"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "arrayref",
  "assert_matches",
@@ -3783,7 +3783,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-governance 2.1.2",
+ "spl-governance 2.1.3",
  "spl-governance-test-sdk",
  "spl-governance-tools",
  "spl-token 3.2.0",
@@ -3841,7 +3841,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-governance 2.1.2",
+ "spl-governance 2.1.3",
  "spl-governance-test-sdk",
  "spl-governance-tools",
  "spl-token 3.2.0",

--- a/governance/program/Cargo.toml
+++ b/governance/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-governance"
-version = "2.1.2"
+version = "2.1.3"
 description = "Solana Program Library Governance Program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -224,7 +224,7 @@ pub enum GovernanceInstruction {
     ///   4. `[writable]` ProposalInstruction account. PDA seeds: ['governance',proposal,index]
     ///   5. `[signer]` Payer
     ///   6. `[]` System program
-    ///   7. `[]` Clock sysvar
+    ///   7. `[]` Rent sysvar
     InsertInstruction {
         #[allow(dead_code)]
         /// Instruction index to be inserted at.
@@ -465,7 +465,7 @@ pub fn create_realm(
         AccountMeta::new_readonly(*realm_authority, false),
         AccountMeta::new_readonly(*community_token_mint, false),
         AccountMeta::new(community_token_holding_address, false),
-        AccountMeta::new_readonly(*payer, true),
+        AccountMeta::new(*payer, true),
         AccountMeta::new_readonly(system_program::id(), false),
         AccountMeta::new_readonly(spl_token::id(), false),
         AccountMeta::new_readonly(sysvar::rent::id(), false),
@@ -544,7 +544,7 @@ pub fn deposit_governing_tokens(
         AccountMeta::new_readonly(*governing_token_owner, true),
         AccountMeta::new_readonly(*governing_token_transfer_authority, true),
         AccountMeta::new(token_owner_record_address, false),
-        AccountMeta::new_readonly(*payer, true),
+        AccountMeta::new(*payer, true),
         AccountMeta::new_readonly(system_program::id(), false),
         AccountMeta::new_readonly(spl_token::id(), false),
         AccountMeta::new_readonly(sysvar::rent::id(), false),
@@ -653,7 +653,7 @@ pub fn create_account_governance(
         AccountMeta::new(account_governance_address, false),
         AccountMeta::new_readonly(*governed_account, false),
         AccountMeta::new_readonly(*token_owner_record, false),
-        AccountMeta::new_readonly(*payer, true),
+        AccountMeta::new(*payer, true),
         AccountMeta::new_readonly(system_program::id(), false),
         AccountMeta::new_readonly(sysvar::rent::id(), false),
         AccountMeta::new_readonly(*governance_authority, true),
@@ -697,7 +697,7 @@ pub fn create_program_governance(
         AccountMeta::new(governed_program_data_address, false),
         AccountMeta::new_readonly(*governed_program_upgrade_authority, true),
         AccountMeta::new_readonly(*token_owner_record, false),
-        AccountMeta::new_readonly(*payer, true),
+        AccountMeta::new(*payer, true),
         AccountMeta::new_readonly(bpf_loader_upgradeable::id(), false),
         AccountMeta::new_readonly(system_program::id(), false),
         AccountMeta::new_readonly(sysvar::rent::id(), false),
@@ -742,7 +742,7 @@ pub fn create_mint_governance(
         AccountMeta::new(*governed_mint, false),
         AccountMeta::new_readonly(*governed_mint_authority, true),
         AccountMeta::new_readonly(*token_owner_record, false),
-        AccountMeta::new_readonly(*payer, true),
+        AccountMeta::new(*payer, true),
         AccountMeta::new_readonly(spl_token::id(), false),
         AccountMeta::new_readonly(system_program::id(), false),
         AccountMeta::new_readonly(sysvar::rent::id(), false),
@@ -787,7 +787,7 @@ pub fn create_token_governance(
         AccountMeta::new(*governed_token, false),
         AccountMeta::new_readonly(*governed_token_owner, true),
         AccountMeta::new_readonly(*token_owner_record, false),
-        AccountMeta::new_readonly(*payer, true),
+        AccountMeta::new(*payer, true),
         AccountMeta::new_readonly(spl_token::id(), false),
         AccountMeta::new_readonly(system_program::id(), false),
         AccountMeta::new_readonly(sysvar::rent::id(), false),
@@ -838,7 +838,7 @@ pub fn create_proposal(
         AccountMeta::new(*governance, false),
         AccountMeta::new(*proposal_owner_record, false),
         AccountMeta::new_readonly(*governance_authority, true),
-        AccountMeta::new_readonly(*payer, true),
+        AccountMeta::new(*payer, true),
         AccountMeta::new_readonly(system_program::id(), false),
         AccountMeta::new_readonly(sysvar::rent::id(), false),
         AccountMeta::new_readonly(sysvar::clock::id(), false),
@@ -877,7 +877,7 @@ pub fn add_signatory(
         AccountMeta::new_readonly(*token_owner_record, false),
         AccountMeta::new_readonly(*governance_authority, true),
         AccountMeta::new(signatory_record_address, false),
-        AccountMeta::new_readonly(*payer, true),
+        AccountMeta::new(*payer, true),
         AccountMeta::new_readonly(system_program::id(), false),
         AccountMeta::new_readonly(sysvar::rent::id(), false),
     ];
@@ -978,7 +978,7 @@ pub fn cast_vote(
         AccountMeta::new_readonly(*governance_authority, true),
         AccountMeta::new(vote_record_address, false),
         AccountMeta::new_readonly(*governing_token_mint, false),
-        AccountMeta::new_readonly(*payer, true),
+        AccountMeta::new(*payer, true),
         AccountMeta::new_readonly(system_program::id(), false),
         AccountMeta::new_readonly(sysvar::rent::id(), false),
         AccountMeta::new_readonly(sysvar::clock::id(), false),
@@ -1108,7 +1108,7 @@ pub fn insert_instruction(
         AccountMeta::new_readonly(*token_owner_record, false),
         AccountMeta::new_readonly(*governance_authority, true),
         AccountMeta::new(proposal_instruction_address, false),
-        AccountMeta::new_readonly(*payer, true),
+        AccountMeta::new(*payer, true),
         AccountMeta::new_readonly(system_program::id(), false),
         AccountMeta::new_readonly(sysvar::rent::id(), false),
     ];
@@ -1352,7 +1352,7 @@ pub fn create_token_owner_record(
         AccountMeta::new_readonly(*governing_token_owner, false),
         AccountMeta::new(token_owner_record_address, false),
         AccountMeta::new_readonly(*governing_token_mint, false),
-        AccountMeta::new_readonly(*payer, true),
+        AccountMeta::new(*payer, true),
         AccountMeta::new_readonly(system_program::id(), false),
     ];
 


### PR DESCRIPTION
#### Summary 

Payer account needs to be flagged as writable on instruction metadata 