### PR TITLE
Governance:  vote options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3725,24 +3725,6 @@ dependencies = [
 
 [[package]]
 name = "spl-governance"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3df1aa25c5f5ce7a6595959b1b02c6ae6ea35274379ee64bcf80bae11a767"
-dependencies = [
- "arrayref",
- "bincode",
- "borsh",
- "num-derive",
- "num-traits",
- "serde",
- "serde_derive",
- "solana-program",
- "spl-token 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
-]
-
-[[package]]
-name = "spl-governance"
 version = "2.1.3"
 dependencies = [
  "arrayref",
@@ -3759,7 +3741,6 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-governance 1.1.1",
  "spl-governance-test-sdk",
  "spl-governance-tools",
  "spl-token 3.2.0",
@@ -3783,7 +3764,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-governance 2.1.3",
+ "spl-governance",
  "spl-governance-test-sdk",
  "spl-governance-tools",
  "spl-token 3.2.0",
@@ -3841,7 +3822,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-governance 2.1.3",
+ "spl-governance",
  "spl-governance-test-sdk",
  "spl-governance-tools",
  "spl-token 3.2.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3725,7 +3725,7 @@ dependencies = [
 
 [[package]]
 name = "spl-governance"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "arrayref",
  "assert_matches",

--- a/governance/chat/program/Cargo.toml
+++ b/governance/chat/program/Cargo.toml
@@ -21,7 +21,7 @@ serde = "1.0.127"
 serde_derive = "1.0.103"
 solana-program = "1.8.1"
 spl-token = { version = "3.2", path = "../../../token/program", features = [ "no-entrypoint" ] }
-spl-governance= { version = "2.1.2", path ="../../program", features = [ "no-entrypoint" ]}
+spl-governance= { version = "2.1.3", path ="../../program", features = [ "no-entrypoint" ]}
 spl-governance-tools= { version = "0.1.0", path ="../../tools"}
 thiserror = "1.0"
 

--- a/governance/chat/program/src/state.rs
+++ b/governance/chat/program/src/state.rs
@@ -53,7 +53,7 @@ pub struct ChatMessage {
 
 impl AccountMaxSize for ChatMessage {
     fn get_max_size(&self) -> Option<usize> {
-        let body_size = match self.body.clone() {
+        let body_size = match &self.body {
             MessageBody::Text(body) => body.len(),
             MessageBody::Reaction(body) => body.len(),
         };

--- a/governance/chat/program/tests/program_test/mod.rs
+++ b/governance/chat/program/tests/program_test/mod.rs
@@ -11,7 +11,7 @@ use spl_governance::{
     state::{
         enums::{MintMaxVoteWeightSource, VoteThresholdPercentage},
         governance::{get_account_governance_address, GovernanceConfig},
-        proposal::get_proposal_address,
+        proposal::{get_proposal_address, VoteType},
         realm::get_realm_address,
         token_owner_record::get_token_owner_record_address,
     },
@@ -178,7 +178,9 @@ impl GovernanceChatProgramTest {
 
         let proposal_name = "Proposal #1".to_string();
         let description_link = "Proposal Description".to_string();
+        let options = vec!["Yes".to_string()];
         let proposal_index: u32 = 0;
+        let use_deny_option = true;
 
         let create_proposal_ix = create_proposal(
             &self.governance_program_id,
@@ -191,6 +193,9 @@ impl GovernanceChatProgramTest {
             proposal_name,
             description_link.clone(),
             &governing_token_mint_keypair.pubkey(),
+            VoteType::SingleChoice,
+            options,
+            use_deny_option,
             proposal_index,
         );
 

--- a/governance/program/Cargo.toml
+++ b/governance/program/Cargo.toml
@@ -21,7 +21,6 @@ serde = "1.0.130"
 serde_derive = "1.0.103"
 solana-program = "1.8.1"
 spl-token = { version = "3.2", path = "../../token/program", features = [ "no-entrypoint" ] }
-spl-governance-v1 = {package="spl-governance", version = "1.1.1", features = [ "no-entrypoint" ] }
 spl-governance-tools= { version = "0.1.0", path ="../tools"}
 thiserror = "1.0"
 

--- a/governance/program/Cargo.toml
+++ b/governance/program/Cargo.toml
@@ -21,6 +21,7 @@ serde = "1.0.130"
 serde_derive = "1.0.103"
 solana-program = "1.8.1"
 spl-token = { version = "3.2", path = "../../token/program", features = [ "no-entrypoint" ] }
+spl-governance-v1 = {package="spl-governance", version = "1.1.1", features = [ "no-entrypoint" ] }
 spl-governance-tools= { version = "0.1.0", path ="../tools"}
 thiserror = "1.0"
 
@@ -32,7 +33,7 @@ proptest = "1.0"
 solana-program-test = "1.8.1"
 solana-sdk = "1.8.1"
 spl-governance-test-sdk = { version = "0.1.0", path ="../test-sdk"}
-spl-governance-v1 = {package="spl-governance", version = "1.1.1", features = [ "no-entrypoint" ] }
+
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/governance/program/Cargo.toml
+++ b/governance/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-governance"
-version = "2.1.3"
+version = "2.1.4"
 description = "Solana Program Library Governance Program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -345,6 +345,10 @@ pub enum GovernanceError {
     /// Vote type not supported
     #[error("Vote type not supported")]
     VoteTypeNotSupported,
+
+    /// InvalidProposalOptions
+    #[error("Invalid proposal options")]
+    InvalidProposalOptions,
 }
 
 impl PrintProgramError for GovernanceError {

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -337,6 +337,10 @@ pub enum GovernanceError {
     /// Governing token deposits not allowed
     #[error("Governing token deposits not allowed")]
     GoverningTokenDepositsNotAllowed,
+
+    /// Invalid vote choice weight percentage
+    #[error("Invalid vote choice weight percentage")]
+    InvalidVoteChoiceWeightPercentage,
 }
 
 impl PrintProgramError for GovernanceError {

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -341,6 +341,10 @@ pub enum GovernanceError {
     /// Invalid vote choice weight percentage
     #[error("Invalid vote choice weight percentage")]
     InvalidVoteChoiceWeightPercentage,
+
+    /// Vote type not supported
+    #[error("Vote type not supported")]
+    VoteTypeNotSupported,
 }
 
 impl PrintProgramError for GovernanceError {

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -357,6 +357,10 @@ pub enum GovernanceError {
     /// Invalid vote
     #[error("Invalid vote")]
     InvalidVote,
+
+    /// Cannot execute defeated option
+    #[error("Cannot execute defeated option")]
+    CannotExecuteDefeatedOption,
 }
 
 impl PrintProgramError for GovernanceError {

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -353,6 +353,10 @@ pub enum GovernanceError {
     /// Proposal is not not executable
     #[error("Proposal is not not executable")]
     ProposalIsNotExecutable,
+
+    /// Invalid vote
+    #[error("Invalid vote")]
+    InvalidVote,
 }
 
 impl PrintProgramError for GovernanceError {

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -349,6 +349,10 @@ pub enum GovernanceError {
     /// InvalidProposalOptions
     #[error("Invalid proposal options")]
     InvalidProposalOptions,
+
+    /// Proposal is not not executable
+    #[error("Proposal is not not executable")]
+    ProposalIsNotExecutable,
 }
 
 impl PrintProgramError for GovernanceError {

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -13,7 +13,7 @@ use crate::{
         realm_config::get_realm_config_address,
         signatory_record::get_signatory_record_address,
         token_owner_record::get_token_owner_record_address,
-        vote_record::get_vote_record_address,
+        vote_record::{get_vote_record_address, VoteChoice},
     },
     tools::bpf_loader_upgradeable::get_program_data_address,
 };
@@ -285,8 +285,9 @@ pub enum GovernanceInstruction {
     ///   12. `[]` Optional Voter Weight Record
     CastVote {
         #[allow(dead_code)]
-        /// Yes/No vote
-        vote: Vote,
+        /// vote choices
+        /// TODO: Create VoteChoice (with intentions only) and VoteChoiceWeight
+        choices: Vec<VoteChoice>,
     },
 
     /// Finalizes vote in case the Vote was not automatically tipped within max_voting_time period
@@ -964,7 +965,7 @@ pub fn cast_vote(
     payer: &Pubkey,
     voter_weight_record: Option<Pubkey>,
     // Args
-    vote: Vote,
+    choices: Vec<VoteChoice>,
 ) -> Instruction {
     let vote_record_address =
         get_vote_record_address(program_id, proposal, voter_token_owner_record);
@@ -986,7 +987,7 @@ pub fn cast_vote(
 
     with_voter_weight_accounts(program_id, &mut accounts, realm, voter_weight_record);
 
-    let instruction = GovernanceInstruction::CastVote { vote };
+    let instruction = GovernanceInstruction::CastVote { choices };
 
     Instruction {
         program_id: *program_id,

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -229,7 +229,7 @@ pub enum GovernanceInstruction {
     InsertInstruction {
         #[allow(dead_code)]
         /// The index of the option the instruction is for
-        option_index: u8,
+        option_index: u16,
         #[allow(dead_code)]
         /// Instruction index to be inserted at.
         index: u16,
@@ -1105,7 +1105,7 @@ pub fn insert_instruction(
     governance_authority: &Pubkey,
     payer: &Pubkey,
     // Args
-    option_index: u8,
+    option_index: u16,
     index: u16,
     hold_up_time: u32,
     instruction: InstructionData,

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -25,16 +25,6 @@ use solana_program::{
     system_program, sysvar,
 };
 
-/// Yes/No Vote
-#[repr(C)]
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
-pub enum Vote {
-    /// Yes vote
-    Yes,
-    /// No vote
-    No,
-}
-
 /// Instructions supported by the Governance program
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 #[repr(C)]

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -7,7 +7,7 @@ use crate::{
             get_account_governance_address, get_mint_governance_address,
             get_program_governance_address, get_token_governance_address, GovernanceConfig,
         },
-        proposal::{get_proposal_address, ProposalOptionArg, VoteType},
+        proposal::{get_proposal_address, VoteType},
         proposal_instruction::{get_proposal_instruction_address, InstructionData},
         realm::{get_governing_token_holding_address, get_realm_address, RealmConfigArgs},
         realm_config::get_realm_config_address,
@@ -180,8 +180,13 @@ pub enum GovernanceInstruction {
 
         #[allow(dead_code)]
         /// Proposal options
-        /// TODO: Use ProposalOptionArgs
-        options: Vec<ProposalOptionArg>,
+        options: Vec<String>,
+
+        #[allow(dead_code)]
+        /// Indicates whether the proposal has a reject option
+        /// A proposal without the reject option is a none binding survey
+        /// And only proposals with the reject options can have executable instructions
+        use_reject_option: bool,
     },
 
     /// Adds a signatory to the Proposal which means this Proposal can't leave Draft state until yet another Signatory signs
@@ -827,7 +832,8 @@ pub fn create_proposal(
     description_link: String,
     governing_token_mint: &Pubkey,
     vote_type: VoteType,
-    options: Vec<ProposalOptionArg>,
+    options: Vec<String>,
+    use_reject_option: bool,
     proposal_index: u32,
 ) -> Instruction {
     let proposal_address = get_proposal_address(
@@ -857,6 +863,7 @@ pub fn create_proposal(
         governing_token_mint: *governing_token_mint,
         vote_type,
         options,
+        use_reject_option,
     };
 
     Instruction {

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -226,6 +226,9 @@ pub enum GovernanceInstruction {
     ///   7. `[]` Rent sysvar
     InsertInstruction {
         #[allow(dead_code)]
+        /// The index of the option the instruction is for
+        option_index: u8,
+        #[allow(dead_code)]
         /// Instruction index to be inserted at.
         index: u16,
         #[allow(dead_code)]
@@ -1099,12 +1102,17 @@ pub fn insert_instruction(
     governance_authority: &Pubkey,
     payer: &Pubkey,
     // Args
+    option_index: u8,
     index: u16,
     hold_up_time: u32,
     instruction: InstructionData,
 ) -> Instruction {
-    let proposal_instruction_address =
-        get_proposal_instruction_address(program_id, proposal, &index.to_le_bytes());
+    let proposal_instruction_address = get_proposal_instruction_address(
+        program_id,
+        proposal,
+        &option_index.to_le_bytes(),
+        &index.to_le_bytes(),
+    );
 
     let accounts = vec![
         AccountMeta::new_readonly(*governance, false),
@@ -1118,6 +1126,7 @@ pub fn insert_instruction(
     ];
 
     let instruction = GovernanceInstruction::InsertInstruction {
+        option_index,
         index,
         hold_up_time,
         instruction,

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -7,7 +7,7 @@ use crate::{
             get_account_governance_address, get_mint_governance_address,
             get_program_governance_address, get_token_governance_address, GovernanceConfig,
         },
-        proposal::get_proposal_address,
+        proposal::{get_proposal_address, ProposalOption},
         proposal_instruction::{get_proposal_instruction_address, InstructionData},
         realm::{get_governing_token_holding_address, get_realm_address, RealmConfigArgs},
         realm_config::get_realm_config_address,
@@ -173,6 +173,11 @@ pub enum GovernanceInstruction {
         #[allow(dead_code)]
         /// Governing Token Mint the Proposal is created for
         governing_token_mint: Pubkey,
+
+        #[allow(dead_code)]
+        /// Proposal options
+        /// TODO: Use ProposalOptionArgs
+        options: Vec<ProposalOption>,
     },
 
     /// Adds a signatory to the Proposal which means this Proposal can't leave Draft state until yet another Signatory signs
@@ -814,6 +819,7 @@ pub fn create_proposal(
     name: String,
     description_link: String,
     governing_token_mint: &Pubkey,
+    options: Vec<ProposalOption>,
     proposal_index: u32,
 ) -> Instruction {
     let proposal_address = get_proposal_address(
@@ -841,6 +847,7 @@ pub fn create_proposal(
         name,
         description_link,
         governing_token_mint: *governing_token_mint,
+        options,
     };
 
     Instruction {

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -154,25 +154,22 @@ pub enum GovernanceInstruction {
     ///   1. `[writable]` Proposal account. PDA seeds ['governance',governance, governing_token_mint, proposal_index]
     ///   2. `[writable]` Governance account
     ///   3. `[writable]` TokenOwnerRecord account of the Proposal owner
-    ///   4. `[signer]` Governance Authority (Token Owner or Governance Delegate)
-    ///   5. `[signer]` Payer
-    ///   6. `[]` System program
-    ///   7. `[]` Rent sysvar
-    ///   8. `[]` Clock sysvar
-    ///   9. `[]` Optional Realm Config
-    ///   10. `[]` Optional Voter Weight Record
+    ///   4. `[]` Governing Token Mint the Proposal is created for
+    ///   5. `[signer]` Governance Authority (Token Owner or Governance Delegate)
+    ///   6. `[signer]` Payer
+    ///   7. `[]` System program
+    ///   8. `[]` Rent sysvar
+    ///   9. `[]` Clock sysvar
+    ///   10. `[]` Optional Realm Config
+    ///   11. `[]` Optional Voter Weight Record
     CreateProposal {
         #[allow(dead_code)]
         /// UTF-8 encoded name of the proposal
         name: String,
 
         #[allow(dead_code)]
-        /// Link to gist explaining proposal
+        /// Link to a gist explaining the proposal
         description_link: String,
-
-        #[allow(dead_code)]
-        /// Governing Token Mint the Proposal is created for
-        governing_token_mint: Pubkey,
 
         #[allow(dead_code)]
         /// Proposal vote type
@@ -848,6 +845,7 @@ pub fn create_proposal(
         AccountMeta::new(proposal_address, false),
         AccountMeta::new(*governance, false),
         AccountMeta::new(*proposal_owner_record, false),
+        AccountMeta::new_readonly(*governing_token_mint, false),
         AccountMeta::new_readonly(*governance_authority, true),
         AccountMeta::new(*payer, true),
         AccountMeta::new_readonly(system_program::id(), false),
@@ -860,7 +858,6 @@ pub fn create_proposal(
     let instruction = GovernanceInstruction::CreateProposal {
         name,
         description_link,
-        governing_token_mint: *governing_token_mint,
         vote_type,
         options,
         use_reject_option,

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -7,7 +7,7 @@ use crate::{
             get_account_governance_address, get_mint_governance_address,
             get_program_governance_address, get_token_governance_address, GovernanceConfig,
         },
-        proposal::{get_proposal_address, ProposalOption},
+        proposal::{get_proposal_address, ProposalOption, ProposalType},
         proposal_instruction::{get_proposal_instruction_address, InstructionData},
         realm::{get_governing_token_holding_address, get_realm_address, RealmConfigArgs},
         realm_config::get_realm_config_address,
@@ -173,6 +173,10 @@ pub enum GovernanceInstruction {
         #[allow(dead_code)]
         /// Governing Token Mint the Proposal is created for
         governing_token_mint: Pubkey,
+
+        #[allow(dead_code)]
+        /// Proposal type
+        proposal_type: ProposalType,
 
         #[allow(dead_code)]
         /// Proposal options
@@ -819,6 +823,7 @@ pub fn create_proposal(
     name: String,
     description_link: String,
     governing_token_mint: &Pubkey,
+    proposal_type: ProposalType,
     options: Vec<ProposalOption>,
     proposal_index: u32,
 ) -> Instruction {
@@ -847,6 +852,7 @@ pub fn create_proposal(
         name,
         description_link,
         governing_token_mint: *governing_token_mint,
+        proposal_type,
         options,
     };
 

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -181,7 +181,7 @@ pub enum GovernanceInstruction {
 
         #[allow(dead_code)]
         /// Indicates whether the proposal has the deny option
-        /// A proposal without the rejecting option is a none binding survey
+        /// A proposal without the rejecting option is a non binding survey
         /// Only proposals with the rejecting option can have executable instructions
         use_deny_option: bool,
     },

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -7,7 +7,7 @@ use crate::{
             get_account_governance_address, get_mint_governance_address,
             get_program_governance_address, get_token_governance_address, GovernanceConfig,
         },
-        proposal::{get_proposal_address, ProposalOption, ProposalType},
+        proposal::{get_proposal_address, ProposalOptionArg, VoteType},
         proposal_instruction::{get_proposal_instruction_address, InstructionData},
         realm::{get_governing_token_holding_address, get_realm_address, RealmConfigArgs},
         realm_config::get_realm_config_address,
@@ -175,13 +175,13 @@ pub enum GovernanceInstruction {
         governing_token_mint: Pubkey,
 
         #[allow(dead_code)]
-        /// Proposal type
-        proposal_type: ProposalType,
+        /// Proposal vote type
+        vote_type: VoteType,
 
         #[allow(dead_code)]
         /// Proposal options
         /// TODO: Use ProposalOptionArgs
-        options: Vec<ProposalOption>,
+        options: Vec<ProposalOptionArg>,
     },
 
     /// Adds a signatory to the Proposal which means this Proposal can't leave Draft state until yet another Signatory signs
@@ -823,8 +823,8 @@ pub fn create_proposal(
     name: String,
     description_link: String,
     governing_token_mint: &Pubkey,
-    proposal_type: ProposalType,
-    options: Vec<ProposalOption>,
+    vote_type: VoteType,
+    options: Vec<ProposalOptionArg>,
     proposal_index: u32,
 ) -> Instruction {
     let proposal_address = get_proposal_address(
@@ -852,7 +852,7 @@ pub fn create_proposal(
         name,
         description_link,
         governing_token_mint: *governing_token_mint,
-        proposal_type,
+        vote_type,
         options,
     };
 

--- a/governance/program/src/processor/mod.rs
+++ b/governance/program/src/processor/mod.rs
@@ -129,7 +129,6 @@ pub fn process_instruction(
         GovernanceInstruction::CreateProposal {
             name,
             description_link,
-            governing_token_mint,
             vote_type: proposal_type,
             options,
             use_reject_option,
@@ -138,7 +137,6 @@ pub fn process_instruction(
             accounts,
             name,
             description_link,
-            governing_token_mint,
             proposal_type,
             options,
             use_reject_option,

--- a/governance/program/src/processor/mod.rs
+++ b/governance/program/src/processor/mod.rs
@@ -132,6 +132,7 @@ pub fn process_instruction(
             governing_token_mint,
             vote_type: proposal_type,
             options,
+            use_reject_option,
         } => process_create_proposal(
             program_id,
             accounts,
@@ -140,6 +141,7 @@ pub fn process_instruction(
             governing_token_mint,
             proposal_type,
             options,
+            use_reject_option,
         ),
         GovernanceInstruction::AddSignatory { signatory } => {
             process_add_signatory(program_id, accounts, signatory)

--- a/governance/program/src/processor/mod.rs
+++ b/governance/program/src/processor/mod.rs
@@ -128,7 +128,7 @@ pub fn process_instruction(
             name,
             description_link,
             governing_token_mint,
-            proposal_type,
+            vote_type: proposal_type,
             options,
         } => process_create_proposal(
             program_id,

--- a/governance/program/src/processor/mod.rs
+++ b/governance/program/src/processor/mod.rs
@@ -131,7 +131,7 @@ pub fn process_instruction(
             description_link,
             vote_type: proposal_type,
             options,
-            use_reject_option,
+            use_deny_option,
         } => process_create_proposal(
             program_id,
             accounts,
@@ -139,7 +139,7 @@ pub fn process_instruction(
             description_link,
             proposal_type,
             options,
-            use_reject_option,
+            use_deny_option,
         ),
         GovernanceInstruction::AddSignatory { signatory } => {
             process_add_signatory(program_id, accounts, signatory)
@@ -150,9 +150,7 @@ pub fn process_instruction(
         GovernanceInstruction::SignOffProposal {} => {
             process_sign_off_proposal(program_id, accounts)
         }
-        GovernanceInstruction::CastVote { choices } => {
-            process_cast_vote(program_id, accounts, choices)
-        }
+        GovernanceInstruction::CastVote { vote } => process_cast_vote(program_id, accounts, vote),
 
         GovernanceInstruction::FinalizeVote {} => process_finalize_vote(program_id, accounts),
 

--- a/governance/program/src/processor/mod.rs
+++ b/governance/program/src/processor/mod.rs
@@ -128,12 +128,14 @@ pub fn process_instruction(
             name,
             description_link,
             governing_token_mint,
+            options,
         } => process_create_proposal(
             program_id,
             accounts,
             name,
             description_link,
             governing_token_mint,
+            options,
         ),
         GovernanceInstruction::AddSignatory { signatory } => {
             process_add_signatory(program_id, accounts, signatory)

--- a/governance/program/src/processor/mod.rs
+++ b/governance/program/src/processor/mod.rs
@@ -68,6 +68,7 @@ pub fn process_instruction(
         try_from_slice_unchecked(input).map_err(|_| ProgramError::InvalidInstructionData)?;
 
     if let GovernanceInstruction::InsertInstruction {
+        option_index,
         index,
         hold_up_time,
         instruction: _,
@@ -75,7 +76,8 @@ pub fn process_instruction(
     {
         // Do not dump instruction data into logs
         msg!(
-            "GOVERNANCE-INSTRUCTION: InsertInstruction {{ index: {:?}, hold_up_time: {:?} }}",
+            "GOVERNANCE-INSTRUCTION: InsertInstruction {{option_index: {:?}, index: {:?}, hold_up_time: {:?} }}",
+            option_index,
             index,
             hold_up_time
         );
@@ -159,10 +161,18 @@ pub fn process_instruction(
         GovernanceInstruction::CancelProposal {} => process_cancel_proposal(program_id, accounts),
 
         GovernanceInstruction::InsertInstruction {
+            option_index,
             index,
             hold_up_time,
             instruction,
-        } => process_insert_instruction(program_id, accounts, index, hold_up_time, instruction),
+        } => process_insert_instruction(
+            program_id,
+            accounts,
+            option_index,
+            index,
+            hold_up_time,
+            instruction,
+        ),
 
         GovernanceInstruction::RemoveInstruction {} => {
             process_remove_instruction(program_id, accounts)

--- a/governance/program/src/processor/mod.rs
+++ b/governance/program/src/processor/mod.rs
@@ -144,7 +144,9 @@ pub fn process_instruction(
         GovernanceInstruction::SignOffProposal {} => {
             process_sign_off_proposal(program_id, accounts)
         }
-        GovernanceInstruction::CastVote { vote } => process_cast_vote(program_id, accounts, vote),
+        GovernanceInstruction::CastVote { choices } => {
+            process_cast_vote(program_id, accounts, choices)
+        }
 
         GovernanceInstruction::FinalizeVote {} => process_finalize_vote(program_id, accounts),
 

--- a/governance/program/src/processor/mod.rs
+++ b/governance/program/src/processor/mod.rs
@@ -128,6 +128,7 @@ pub fn process_instruction(
             name,
             description_link,
             governing_token_mint,
+            proposal_type,
             options,
         } => process_create_proposal(
             program_id,
@@ -135,6 +136,7 @@ pub fn process_instruction(
             name,
             description_link,
             governing_token_mint,
+            proposal_type,
             options,
         ),
         GovernanceInstruction::AddSignatory { signatory } => {

--- a/governance/program/src/processor/process_add_signatory.rs
+++ b/governance/program/src/processor/process_add_signatory.rs
@@ -1,6 +1,5 @@
 //! Program state processor
 
-use borsh::BorshSerialize;
 use solana_program::{
     account_info::{next_account_info, AccountInfo},
     entrypoint::ProgramResult,

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -108,7 +108,7 @@ pub fn process_cast_vote(
     proposal_data.assert_valid_vote(&vote)?;
 
     // Calculate Proposal voting weights
-    match vote.clone() {
+    match &vote {
         Vote::Approve(choices) => {
             for (option, choice) in proposal_data.options.iter_mut().zip(choices) {
                 option.vote_weight = option

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -109,7 +109,7 @@ pub fn process_cast_vote(
 
     // Calculate Proposal voting weights
     // TODO: Validate choices are valid for given proposal vote type
-    for i in 0..proposal_data.options.len() {
+    for (i, option) in proposal_data.options.iter_mut().enumerate() {
         let choice_weight = if choices[i].weight == 1 {
             voter_weight
         } else {
@@ -122,10 +122,7 @@ pub fn process_cast_vote(
             weight: choice_weight,
         });
 
-        proposal_data.options[i].vote_weight = proposal_data.options[i]
-            .vote_weight
-            .checked_add(choice_weight)
-            .unwrap();
+        option.weight = option.weight.checked_add(choice_weight).unwrap();
     }
 
     let governing_token_mint_supply = get_spl_token_mint_supply(governing_token_mint_info)?;

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -105,13 +105,9 @@ pub fn process_cast_vote(
         &realm_data,
     )?;
 
-    // TODO: Add test to reject proposal without rejection
+    proposal_data.assert_valid_vote(&vote)?;
 
     // Calculate Proposal voting weights
-    // TODO: Validate choices are valid for given proposal vote type. Single choice should have one choice only, no deny shouldn't have Deny vote
-    //  Assert option.len() === choices().len()
-    // YesNo - only once choice 100% and no rank
-
     match vote.clone() {
         Vote::Approve(choices) => {
             for (option, choice) in proposal_data.options.iter_mut().zip(choices) {

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -21,7 +21,7 @@ use crate::{
             get_token_owner_record_data_for_proposal_owner,
             get_token_owner_record_data_for_realm_and_governing_mint,
         },
-        vote_record::{get_vote_record_address_seeds, Vote, VoteRecord},
+        vote_record::{get_vote_record_address_seeds, Vote, VoteRecordV2},
     },
     tools::spl_token::get_spl_token_mint_supply,
 };
@@ -155,7 +155,7 @@ pub fn process_cast_vote(
     proposal_data.serialize(&mut *proposal_info.data.borrow_mut())?;
 
     // Create and serialize VoteRecord
-    let vote_record_data = VoteRecord {
+    let vote_record_data = VoteRecordV2 {
         account_type: GovernanceAccountType::VoteRecordV2,
         proposal: *proposal_info.key,
         governing_token_owner: voter_token_owner_record_data.governing_token_owner,
@@ -164,7 +164,7 @@ pub fn process_cast_vote(
         is_relinquished: false,
     };
 
-    create_and_serialize_account_signed::<VoteRecord>(
+    create_and_serialize_account_signed::<VoteRecordV2>(
         payer_info,
         vote_record_info,
         &vote_record_data,

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -108,10 +108,11 @@ pub fn process_cast_vote(
 
     // Calculate Proposal voting weights
     // TODO: Pass choices to the instruction and validate it's correct for given vote type
+    // TODO: Set options in a loop
     let vote_choices = match vote {
         Vote::Yes => {
-            proposal_data.yes_votes_count = proposal_data
-                .yes_votes_count
+            proposal_data.options[0].vote_weight = proposal_data.options[0]
+                .vote_weight
                 .checked_add(voter_weight)
                 .unwrap();
 
@@ -124,8 +125,8 @@ pub fn process_cast_vote(
             ]
         }
         Vote::No => {
-            proposal_data.no_votes_count = proposal_data
-                .no_votes_count
+            proposal_data.options[1].vote_weight = proposal_data.options[1]
+                .vote_weight
                 .checked_add(voter_weight)
                 .unwrap();
 

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -156,7 +156,7 @@ pub fn process_cast_vote(
 
     // Create and serialize VoteRecord
     let vote_record_data = VoteRecord {
-        account_type: GovernanceAccountType::VoteRecord,
+        account_type: GovernanceAccountType::VoteRecordV2,
         proposal: *proposal_info.key,
         governing_token_owner: voter_token_owner_record_data.governing_token_owner,
         voter_weight,

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -109,8 +109,10 @@ pub fn process_cast_vote(
 
     // Calculate Proposal voting weights
     // TODO: Validate choices are valid for given proposal vote type
+    //  Assert option.len() === choices().len()
     // YesNo - only once choice 100% and no rank
     for (option, choice) in proposal_data.options.iter_mut().zip(choices) {
+        // TODO: generalize as single choice
         let choice_weight = match choice.weight_percentage {
             100 => voter_weight,
             0 => 0,

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -109,12 +109,8 @@ pub fn process_cast_vote(
 
     // Calculate Proposal voting weights
     // TODO: Validate choices are valid for given proposal vote type
-    for (i, option) in proposal_data.options.iter_mut().enumerate() {
-        let choice_weight = if choices[i].weight == 1 {
-            voter_weight
-        } else {
-            0
-        };
+    for (option, choice) in proposal_data.options.iter_mut().zip(choices) {
+        let choice_weight = if choice.weight == 1 { voter_weight } else { 0 };
         // TODO throw for weight != 0 and weight != 1
 
         vote_choices.push(VoteChoice {

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -124,7 +124,7 @@ pub fn process_cast_vote(
             weight: choice_weight,
         });
 
-        option.weight = option.weight.checked_add(choice_weight).unwrap();
+        option.vote_weight = option.vote_weight.checked_add(choice_weight).unwrap();
     }
 
     let governing_token_mint_supply = get_spl_token_mint_supply(governing_token_mint_info)?;

--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -16,7 +16,9 @@ use crate::{
     state::{
         enums::{GovernanceAccountType, InstructionExecutionFlags, ProposalState},
         governance::get_governance_data_for_realm,
-        proposal::{get_proposal_address_seeds, Proposal, ProposalOption, ProposalOptionVote},
+        proposal::{
+            get_proposal_address_seeds, Proposal, ProposalOption, ProposalOptionVote, ProposalType,
+        },
         realm::get_realm_data_for_governing_token_mint,
         token_owner_record::get_token_owner_record_data_for_realm,
     },
@@ -29,6 +31,7 @@ pub fn process_create_proposal(
     name: String,
     description_link: String,
     governing_token_mint: Pubkey,
+    proposal_type: ProposalType,
     options: Vec<ProposalOption>,
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
@@ -124,6 +127,7 @@ pub fn process_create_proposal(
 
         execution_flags: InstructionExecutionFlags::None,
 
+        proposal_type,
         // TODO: validate options for proposal type
         options: proposal_options,
 

--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -16,7 +16,7 @@ use crate::{
     state::{
         enums::{GovernanceAccountType, InstructionExecutionFlags, ProposalState},
         governance::get_governance_data_for_realm,
-        proposal::{get_proposal_address_seeds, Proposal},
+        proposal::{get_proposal_address_seeds, Proposal, ProposalOption},
         realm::get_realm_data_for_governing_token_mint,
         token_owner_record::get_token_owner_record_data_for_realm,
     },
@@ -115,8 +115,18 @@ pub fn process_create_proposal(
 
         execution_flags: InstructionExecutionFlags::None,
 
-        yes_votes_count: 0,
-        no_votes_count: 0,
+        // TODO: Pass options in the instruction
+        options: vec![
+            ProposalOption {
+                label: "Yes".to_string(),
+                vote_weight: 0,
+            },
+            ProposalOption {
+                label: "No".to_string(),
+                vote_weight: 0,
+            },
+        ],
+
         max_vote_weight: None,
         vote_threshold_percentage: None,
     };

--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -33,7 +33,7 @@ pub fn process_create_proposal(
     description_link: String,
     vote_type: VoteType,
     options: Vec<String>,
-    use_reject_option: bool,
+    use_deny_option: bool,
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
 
@@ -111,7 +111,7 @@ pub fn process_create_proposal(
         })
         .collect();
 
-    let reject_option_vote_weight = if use_reject_option { Some(0) } else { None };
+    let deny_vote_weight = if use_deny_option { Some(0) } else { None };
 
     let proposal_data = Proposal {
         account_type: GovernanceAccountType::Proposal,
@@ -138,7 +138,7 @@ pub fn process_create_proposal(
 
         vote_type,
         options: proposal_options,
-        reject_option_vote_weight,
+        deny_vote_weight,
 
         max_vote_weight: None,
         vote_threshold_percentage: None,

--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -17,7 +17,8 @@ use crate::{
         enums::{GovernanceAccountType, InstructionExecutionFlags, ProposalState},
         governance::get_governance_data_for_realm,
         proposal::{
-            get_proposal_address_seeds, Proposal, ProposalOption, ProposalOptionArg, VoteType,
+            get_proposal_address_seeds, OptionVoteResult, Proposal, ProposalOption,
+            ProposalOptionArg, VoteType,
         },
         realm::get_realm_data_for_governing_token_mint,
         token_owner_record::get_token_owner_record_data_for_realm,
@@ -96,7 +97,8 @@ pub fn process_create_proposal(
         .iter()
         .map(|o| ProposalOption {
             label: o.label.to_string(),
-            weight: 0,
+            vote_weight: 0,
+            vote_result: OptionVoteResult::None,
         })
         .collect();
 

--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -147,7 +147,6 @@ pub fn process_create_proposal(
         execution_flags: InstructionExecutionFlags::None,
 
         vote_type,
-        // TODO: validate options for proposal type
         options: proposal_options,
         has_reject_option: use_reject_option,
 

--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -99,7 +99,7 @@ pub fn process_create_proposal(
 
     assert_valid_proposal_options(&vote_type, &options)?;
 
-    let mut proposal_options: Vec<ProposalOption> = options
+    let proposal_options: Vec<ProposalOption> = options
         .iter()
         .map(|o| ProposalOption {
             label: o.to_string(),
@@ -111,17 +111,7 @@ pub fn process_create_proposal(
         })
         .collect();
 
-    // TODO: Use separate option for rejection
-    if use_reject_option {
-        proposal_options.push(ProposalOption {
-            label: "No".to_string(),
-            vote_weight: 0,
-            vote_result: OptionVoteResult::None,
-            instructions_executed_count: 0,
-            instructions_count: 0,
-            instructions_next_index: 0,
-        })
-    }
+    let reject_option_vote_weight = if use_reject_option { Some(0) } else { None };
 
     let proposal_data = Proposal {
         account_type: GovernanceAccountType::Proposal,
@@ -148,7 +138,7 @@ pub fn process_create_proposal(
 
         vote_type,
         options: proposal_options,
-        has_reject_option: use_reject_option,
+        reject_option_vote_weight,
 
         max_vote_weight: None,
         vote_threshold_percentage: None,

--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -99,6 +99,9 @@ pub fn process_create_proposal(
             label: o.label.to_string(),
             vote_weight: 0,
             vote_result: OptionVoteResult::None,
+            instructions_executed_count: 0,
+            instructions_count: 0,
+            instructions_next_index: 0,
         })
         .collect();
 
@@ -122,10 +125,6 @@ pub fn process_create_proposal(
         voting_completed_at: None,
         executing_at: None,
         closed_at: None,
-
-        instructions_executed_count: 0,
-        instructions_count: 0,
-        instructions_next_index: 0,
 
         execution_flags: InstructionExecutionFlags::None,
 

--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -17,8 +17,8 @@ use crate::{
         enums::{GovernanceAccountType, InstructionExecutionFlags, ProposalState},
         governance::get_governance_data_for_realm,
         proposal::{
-            assert_valid_proposal_options, get_proposal_address_seeds, OptionVoteResult, Proposal,
-            ProposalOption, VoteType,
+            assert_valid_proposal_options, get_proposal_address_seeds, OptionVoteResult,
+            ProposalOption, ProposalV2, VoteType,
         },
         realm::get_realm_data_for_governing_token_mint,
         token_owner_record::get_token_owner_record_data_for_realm,
@@ -113,8 +113,8 @@ pub fn process_create_proposal(
 
     let deny_vote_weight = if use_deny_option { Some(0) } else { None };
 
-    let proposal_data = Proposal {
-        account_type: GovernanceAccountType::Proposal,
+    let proposal_data = ProposalV2 {
+        account_type: GovernanceAccountType::ProposalV2,
         governance: *governance_info.key,
         governing_token_mint: *governing_token_mint_info.key,
         state: ProposalState::Draft,
@@ -144,7 +144,7 @@ pub fn process_create_proposal(
         vote_threshold_percentage: None,
     };
 
-    create_and_serialize_account_signed::<Proposal>(
+    create_and_serialize_account_signed::<ProposalV2>(
         payer_info,
         proposal_info,
         &proposal_data,

--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -17,7 +17,8 @@ use crate::{
         enums::{GovernanceAccountType, InstructionExecutionFlags, ProposalState},
         governance::get_governance_data_for_realm,
         proposal::{
-            get_proposal_address_seeds, OptionVoteResult, Proposal, ProposalOption, VoteType,
+            assert_valid_proposal_options, get_proposal_address_seeds, OptionVoteResult, Proposal,
+            ProposalOption, VoteType,
         },
         realm::get_realm_data_for_governing_token_mint,
         token_owner_record::get_token_owner_record_data_for_realm,
@@ -95,6 +96,8 @@ pub fn process_create_proposal(
         .checked_add(1)
         .unwrap();
     proposal_owner_record_data.serialize(&mut *proposal_owner_record_info.data.borrow_mut())?;
+
+    assert_valid_proposal_options(&vote_type, &options)?;
 
     let mut proposal_options: Vec<ProposalOption> = options
         .iter()

--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -97,7 +97,7 @@ pub fn process_create_proposal(
         .unwrap();
     proposal_owner_record_data.serialize(&mut *proposal_owner_record_info.data.borrow_mut())?;
 
-    assert_valid_proposal_options(&vote_type, &options)?;
+    assert_valid_proposal_options(&options, &vote_type)?;
 
     let proposal_options: Vec<ProposalOption> = options
         .iter()

--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -17,7 +17,7 @@ use crate::{
         enums::{GovernanceAccountType, InstructionExecutionFlags, ProposalState},
         governance::get_governance_data_for_realm,
         proposal::{
-            get_proposal_address_seeds, Proposal, ProposalOption, ProposalOptionVote, ProposalType,
+            get_proposal_address_seeds, Proposal, ProposalOption, ProposalOptionArg, VoteType,
         },
         realm::get_realm_data_for_governing_token_mint,
         token_owner_record::get_token_owner_record_data_for_realm,
@@ -31,8 +31,8 @@ pub fn process_create_proposal(
     name: String,
     description_link: String,
     governing_token_mint: Pubkey,
-    proposal_type: ProposalType,
-    options: Vec<ProposalOption>,
+    vote_type: VoteType,
+    options: Vec<ProposalOptionArg>,
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
 
@@ -94,7 +94,7 @@ pub fn process_create_proposal(
 
     let proposal_options = options
         .iter()
-        .map(|o| ProposalOptionVote {
+        .map(|o| ProposalOption {
             label: o.label.to_string(),
             weight: 0,
         })
@@ -127,9 +127,11 @@ pub fn process_create_proposal(
 
         execution_flags: InstructionExecutionFlags::None,
 
-        proposal_type,
+        vote_type,
         // TODO: validate options for proposal type
         options: proposal_options,
+        // TODO: populate from args
+        has_reject_option: true,
 
         max_vote_weight: None,
         vote_threshold_percentage: None,

--- a/governance/program/src/processor/process_execute_instruction.rs
+++ b/governance/program/src/processor/process_execute_instruction.rs
@@ -1,6 +1,5 @@
 //! Program state processor
 
-use borsh::BorshSerialize;
 use solana_program::{
     account_info::{next_account_info, AccountInfo},
     clock::Clock,

--- a/governance/program/src/processor/process_execute_instruction.rs
+++ b/governance/program/src/processor/process_execute_instruction.rs
@@ -14,7 +14,7 @@ use solana_program::{
 use crate::state::{
     enums::{InstructionExecutionStatus, ProposalState},
     governance::get_governance_data,
-    proposal::get_proposal_data_for_governance,
+    proposal::{get_proposal_data_for_governance, OptionVoteResult},
     proposal_instruction::get_proposal_instruction_data_for_proposal,
 };
 
@@ -75,6 +75,7 @@ pub fn process_execute_instruction(program_id: &Pubkey, accounts: &[AccountInfo]
         && proposal_data
             .options
             .iter()
+            .filter(|o| o.vote_result == OptionVoteResult::Succeeded)
             .all(|o| o.instructions_executed_count == o.instructions_count)
     {
         proposal_data.closed_at = Some(clock.unix_timestamp);

--- a/governance/program/src/processor/process_execute_instruction.rs
+++ b/governance/program/src/processor/process_execute_instruction.rs
@@ -65,7 +65,6 @@ pub fn process_execute_instruction(program_id: &Pubkey, accounts: &[AccountInfo]
         proposal_data.state = ProposalState::Executing;
     }
 
-    // TODO: test for out of bounds index
     let mut option = &mut proposal_data.options[proposal_instruction_data.option_index as usize];
     option.instructions_executed_count = option.instructions_executed_count.checked_add(1).unwrap();
 

--- a/governance/program/src/processor/process_finalize_vote.rs
+++ b/governance/program/src/processor/process_finalize_vote.rs
@@ -58,15 +58,16 @@ pub fn process_finalize_vote(program_id: &Pubkey, accounts: &[AccountInfo]) -> P
         clock.unix_timestamp,
     )?;
 
-    proposal_data.serialize(&mut *proposal_info.data.borrow_mut())?;
-
     let mut proposal_owner_record_data = get_token_owner_record_data_for_proposal_owner(
         program_id,
         proposal_owner_record_info,
         &proposal_data.token_owner_record,
     )?;
+
     proposal_owner_record_data.decrease_outstanding_proposal_count();
     proposal_owner_record_data.serialize(&mut *proposal_owner_record_info.data.borrow_mut())?;
+
+    proposal_data.serialize(&mut *proposal_info.data.borrow_mut())?;
 
     Ok(())
 }

--- a/governance/program/src/processor/process_flag_instruction_error.rs
+++ b/governance/program/src/processor/process_flag_instruction_error.rs
@@ -1,6 +1,5 @@
 //! Program state processor
 
-use borsh::BorshSerialize;
 use solana_program::{
     account_info::{next_account_info, AccountInfo},
     clock::Clock,

--- a/governance/program/src/processor/process_insert_instruction.rs
+++ b/governance/program/src/processor/process_insert_instruction.rs
@@ -71,20 +71,20 @@ pub fn process_insert_instruction(
 
     token_owner_record_data.assert_token_owner_or_delegate_is_signer(governance_authority_info)?;
 
-    match instruction_index.cmp(&proposal_data.instructions_next_index) {
+    // TODO: should we use some safe access?
+    let option = &mut proposal_data.options[option_index as usize];
+
+    match instruction_index.cmp(&option.instructions_next_index) {
         Ordering::Greater => return Err(GovernanceError::InvalidInstructionIndex.into()),
         // If the index is the same as instructions_next_index then we are adding a new instruction
         // If the index is below instructions_next_index then we are inserting into an existing empty space
         Ordering::Equal => {
-            proposal_data.instructions_next_index = proposal_data
-                .instructions_next_index
-                .checked_add(1)
-                .unwrap();
+            option.instructions_next_index = option.instructions_next_index.checked_add(1).unwrap();
         }
         Ordering::Less => {}
     }
 
-    proposal_data.instructions_count = proposal_data.instructions_count.checked_add(1).unwrap();
+    option.instructions_count = option.instructions_count.checked_add(1).unwrap();
     proposal_data.serialize(&mut *proposal_info.data.borrow_mut())?;
 
     let proposal_instruction_data = ProposalInstruction {

--- a/governance/program/src/processor/process_insert_instruction.rs
+++ b/governance/program/src/processor/process_insert_instruction.rs
@@ -19,7 +19,7 @@ use crate::{
         governance::get_governance_data,
         proposal::get_proposal_data_for_governance,
         proposal_instruction::{
-            get_proposal_instruction_address_seeds, InstructionData, ProposalInstruction,
+            get_proposal_instruction_address_seeds, InstructionData, ProposalInstructionV2,
         },
         token_owner_record::get_token_owner_record_data_for_proposal_owner,
     },
@@ -86,8 +86,8 @@ pub fn process_insert_instruction(
     option.instructions_count = option.instructions_count.checked_add(1).unwrap();
     proposal_data.serialize(&mut *proposal_info.data.borrow_mut())?;
 
-    let proposal_instruction_data = ProposalInstruction {
-        account_type: GovernanceAccountType::ProposalInstruction,
+    let proposal_instruction_data = ProposalInstructionV2 {
+        account_type: GovernanceAccountType::ProposalInstructionV2,
         option_index,
         instruction_index,
         hold_up_time,
@@ -97,7 +97,7 @@ pub fn process_insert_instruction(
         proposal: *proposal_info.key,
     };
 
-    create_and_serialize_account_signed::<ProposalInstruction>(
+    create_and_serialize_account_signed::<ProposalInstructionV2>(
         payer_info,
         proposal_instruction_info,
         &proposal_instruction_data,

--- a/governance/program/src/processor/process_insert_instruction.rs
+++ b/governance/program/src/processor/process_insert_instruction.rs
@@ -2,7 +2,6 @@
 
 use std::cmp::Ordering;
 
-use borsh::BorshSerialize;
 use solana_program::{
     account_info::{next_account_info, AccountInfo},
     entrypoint::ProgramResult,

--- a/governance/program/src/processor/process_insert_instruction.rs
+++ b/governance/program/src/processor/process_insert_instruction.rs
@@ -71,7 +71,6 @@ pub fn process_insert_instruction(
 
     token_owner_record_data.assert_token_owner_or_delegate_is_signer(governance_authority_info)?;
 
-    // TODO: should we use some safe access?
     let option = &mut proposal_data.options[option_index as usize];
 
     match instruction_index.cmp(&option.instructions_next_index) {

--- a/governance/program/src/processor/process_insert_instruction.rs
+++ b/governance/program/src/processor/process_insert_instruction.rs
@@ -28,7 +28,7 @@ use crate::{
 pub fn process_insert_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
-    option_index: u8,
+    option_index: u16,
     instruction_index: u16,
     hold_up_time: u32,
     instruction: InstructionData,

--- a/governance/program/src/processor/process_insert_instruction.rs
+++ b/governance/program/src/processor/process_insert_instruction.rs
@@ -29,6 +29,7 @@ use crate::{
 pub fn process_insert_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
+    option_index: u8,
     instruction_index: u16,
     hold_up_time: u32,
     instruction: InstructionData,
@@ -88,6 +89,7 @@ pub fn process_insert_instruction(
 
     let proposal_instruction_data = ProposalInstruction {
         account_type: GovernanceAccountType::ProposalInstruction,
+        option_index,
         instruction_index,
         hold_up_time,
         instruction,
@@ -102,6 +104,7 @@ pub fn process_insert_instruction(
         &proposal_instruction_data,
         &get_proposal_instruction_address_seeds(
             proposal_info.key,
+            &option_index.to_le_bytes(),
             &instruction_index.to_le_bytes(),
         ),
         program_id,

--- a/governance/program/src/processor/process_relinquish_vote.rs
+++ b/governance/program/src/processor/process_relinquish_vote.rs
@@ -10,10 +10,11 @@ use solana_program::{
 use spl_governance_tools::account::dispose_account;
 
 use crate::state::{
-    enums::ProposalState, governance::get_governance_data,
+    enums::ProposalState,
+    governance::get_governance_data,
     proposal::get_proposal_data_for_governance_and_governing_mint,
     token_owner_record::get_token_owner_record_data_for_realm_and_governing_mint,
-    vote_record::get_vote_record_data_for_proposal_and_token_owner,
+    vote_record::{get_vote_record_data_for_proposal_and_token_owner, Vote},
 };
 
 use borsh::BorshSerialize;
@@ -69,12 +70,24 @@ pub fn process_relinquish_vote(program_id: &Pubkey, accounts: &[AccountInfo]) ->
         token_owner_record_data
             .assert_token_owner_or_delegate_is_signer(governance_authority_info)?;
 
-        for (option, choice) in proposal_data
-            .options
-            .iter_mut()
-            .zip(vote_record_data.choices)
-        {
-            option.vote_weight = option.vote_weight.checked_sub(choice.weight).unwrap();
+        match vote_record_data.vote {
+            Vote::Approve(choices) => {
+                for (option, choice) in proposal_data.options.iter_mut().zip(choices) {
+                    option.vote_weight = option
+                        .vote_weight
+                        .checked_sub(choice.get_choice_weight(vote_record_data.voter_weight)?)
+                        .unwrap();
+                }
+            }
+            Vote::Deny => {
+                proposal_data.deny_vote_weight = Some(
+                    proposal_data
+                        .deny_vote_weight
+                        .unwrap()
+                        .checked_sub(vote_record_data.voter_weight)
+                        .unwrap(),
+                )
+            }
         }
 
         proposal_data.serialize(&mut *proposal_info.data.borrow_mut())?;

--- a/governance/program/src/processor/process_relinquish_vote.rs
+++ b/governance/program/src/processor/process_relinquish_vote.rs
@@ -10,8 +10,7 @@ use solana_program::{
 use spl_governance_tools::account::dispose_account;
 
 use crate::state::{
-    enums::{ProposalState, VoteWeight},
-    governance::get_governance_data,
+    enums::ProposalState, governance::get_governance_data,
     proposal::get_proposal_data_for_governance_and_governing_mint,
     token_owner_record::get_token_owner_record_data_for_realm_and_governing_mint,
     vote_record::get_vote_record_data_for_proposal_and_token_owner,
@@ -70,20 +69,17 @@ pub fn process_relinquish_vote(program_id: &Pubkey, accounts: &[AccountInfo]) ->
         token_owner_record_data
             .assert_token_owner_or_delegate_is_signer(governance_authority_info)?;
 
-        match vote_record_data.vote_weight {
-            VoteWeight::Yes(vote_amount) => {
-                proposal_data.yes_votes_count = proposal_data
-                    .yes_votes_count
-                    .checked_sub(vote_amount)
-                    .unwrap();
-            }
-            VoteWeight::No(vote_amount) => {
-                proposal_data.no_votes_count = proposal_data
-                    .no_votes_count
-                    .checked_sub(vote_amount)
-                    .unwrap();
-            }
-        };
+        // TODO: iterate for all choices
+        proposal_data.yes_votes_count = proposal_data
+            .yes_votes_count
+            .checked_sub(vote_record_data.choices[0].weight)
+            .unwrap();
+
+        proposal_data.no_votes_count = proposal_data
+            .no_votes_count
+            .checked_sub(vote_record_data.choices[1].weight)
+            .unwrap();
+
         proposal_data.serialize(&mut *proposal_info.data.borrow_mut())?;
 
         dispose_account(vote_record_info, beneficiary_info);

--- a/governance/program/src/processor/process_relinquish_vote.rs
+++ b/governance/program/src/processor/process_relinquish_vote.rs
@@ -69,9 +69,9 @@ pub fn process_relinquish_vote(program_id: &Pubkey, accounts: &[AccountInfo]) ->
         token_owner_record_data
             .assert_token_owner_or_delegate_is_signer(governance_authority_info)?;
 
-        for i in 0..proposal_data.options.len() {
-            proposal_data.options[i].vote_weight = proposal_data.options[i]
-                .vote_weight
+        for (i, option) in proposal_data.options.iter_mut().enumerate() {
+            option.weight = option
+                .weight
                 .checked_sub(vote_record_data.choices[i].weight)
                 .unwrap();
         }

--- a/governance/program/src/processor/process_relinquish_vote.rs
+++ b/governance/program/src/processor/process_relinquish_vote.rs
@@ -74,7 +74,7 @@ pub fn process_relinquish_vote(program_id: &Pubkey, accounts: &[AccountInfo]) ->
             .iter_mut()
             .zip(vote_record_data.choices)
         {
-            option.weight = option.weight.checked_sub(choice.weight).unwrap();
+            option.vote_weight = option.vote_weight.checked_sub(choice.weight).unwrap();
         }
 
         proposal_data.serialize(&mut *proposal_info.data.borrow_mut())?;

--- a/governance/program/src/processor/process_relinquish_vote.rs
+++ b/governance/program/src/processor/process_relinquish_vote.rs
@@ -69,11 +69,12 @@ pub fn process_relinquish_vote(program_id: &Pubkey, accounts: &[AccountInfo]) ->
         token_owner_record_data
             .assert_token_owner_or_delegate_is_signer(governance_authority_info)?;
 
-        for (i, option) in proposal_data.options.iter_mut().enumerate() {
-            option.weight = option
-                .weight
-                .checked_sub(vote_record_data.choices[i].weight)
-                .unwrap();
+        for (option, choice) in proposal_data
+            .options
+            .iter_mut()
+            .zip(vote_record_data.choices)
+        {
+            option.weight = option.weight.checked_sub(choice.weight).unwrap();
         }
 
         proposal_data.serialize(&mut *proposal_info.data.borrow_mut())?;

--- a/governance/program/src/processor/process_relinquish_vote.rs
+++ b/governance/program/src/processor/process_relinquish_vote.rs
@@ -70,13 +70,13 @@ pub fn process_relinquish_vote(program_id: &Pubkey, accounts: &[AccountInfo]) ->
             .assert_token_owner_or_delegate_is_signer(governance_authority_info)?;
 
         // TODO: iterate for all choices
-        proposal_data.yes_votes_count = proposal_data
-            .yes_votes_count
+        proposal_data.options[0].vote_weight = proposal_data.options[0]
+            .vote_weight
             .checked_sub(vote_record_data.choices[0].weight)
             .unwrap();
 
-        proposal_data.no_votes_count = proposal_data
-            .no_votes_count
+        proposal_data.options[1].vote_weight = proposal_data.options[1]
+            .vote_weight
             .checked_sub(vote_record_data.choices[1].weight)
             .unwrap();
 

--- a/governance/program/src/processor/process_relinquish_vote.rs
+++ b/governance/program/src/processor/process_relinquish_vote.rs
@@ -69,16 +69,12 @@ pub fn process_relinquish_vote(program_id: &Pubkey, accounts: &[AccountInfo]) ->
         token_owner_record_data
             .assert_token_owner_or_delegate_is_signer(governance_authority_info)?;
 
-        // TODO: iterate for all choices
-        proposal_data.options[0].vote_weight = proposal_data.options[0]
-            .vote_weight
-            .checked_sub(vote_record_data.choices[0].weight)
-            .unwrap();
-
-        proposal_data.options[1].vote_weight = proposal_data.options[1]
-            .vote_weight
-            .checked_sub(vote_record_data.choices[1].weight)
-            .unwrap();
+        for i in 0..proposal_data.options.len() {
+            proposal_data.options[i].vote_weight = proposal_data.options[i]
+                .vote_weight
+                .checked_sub(vote_record_data.choices[i].weight)
+                .unwrap();
+        }
 
         proposal_data.serialize(&mut *proposal_info.data.borrow_mut())?;
 

--- a/governance/program/src/processor/process_remove_instruction.rs
+++ b/governance/program/src/processor/process_remove_instruction.rs
@@ -1,6 +1,5 @@
 //! Program state processor
 
-use borsh::BorshSerialize;
 use solana_program::{
     account_info::{next_account_info, AccountInfo},
     entrypoint::ProgramResult,

--- a/governance/program/src/processor/process_remove_instruction.rs
+++ b/governance/program/src/processor/process_remove_instruction.rs
@@ -9,7 +9,7 @@ use solana_program::{
 use spl_governance_tools::account::dispose_account;
 
 use crate::state::{
-    proposal::get_proposal_data, proposal_instruction::assert_proposal_instruction_for_proposal,
+    proposal::get_proposal_data, proposal_instruction::get_proposal_instruction_data_for_proposal,
     token_owner_record::get_token_owner_record_data_for_proposal_owner,
 };
 
@@ -22,7 +22,6 @@ pub fn process_remove_instruction(program_id: &Pubkey, accounts: &[AccountInfo])
     let governance_authority_info = next_account_info(account_info_iter)?; // 2
 
     let proposal_instruction_info = next_account_info(account_info_iter)?; // 3
-
     let beneficiary_info = next_account_info(account_info_iter)?; // 4
 
     let mut proposal_data = get_proposal_data(program_id, proposal_info)?;
@@ -36,7 +35,7 @@ pub fn process_remove_instruction(program_id: &Pubkey, accounts: &[AccountInfo])
 
     token_owner_record_data.assert_token_owner_or_delegate_is_signer(governance_authority_info)?;
 
-    assert_proposal_instruction_for_proposal(
+    let proposal_instruction_data = get_proposal_instruction_data_for_proposal(
         program_id,
         proposal_instruction_info,
         proposal_info.key,
@@ -44,7 +43,9 @@ pub fn process_remove_instruction(program_id: &Pubkey, accounts: &[AccountInfo])
 
     dispose_account(proposal_instruction_info, beneficiary_info);
 
-    proposal_data.instructions_count = proposal_data.instructions_count.checked_sub(1).unwrap();
+    let mut option = &mut proposal_data.options[proposal_instruction_data.option_index as usize];
+    option.instructions_count = option.instructions_count.checked_sub(1).unwrap();
+
     proposal_data.serialize(&mut *proposal_info.data.borrow_mut())?;
 
     Ok(())

--- a/governance/program/src/processor/process_remove_signatory.rs
+++ b/governance/program/src/processor/process_remove_signatory.rs
@@ -1,6 +1,5 @@
 //! Program state processor
 
-use borsh::BorshSerialize;
 use solana_program::{
     account_info::{next_account_info, AccountInfo},
     entrypoint::ProgramResult,

--- a/governance/program/src/processor/process_set_realm_config.rs
+++ b/governance/program/src/processor/process_set_realm_config.rs
@@ -46,7 +46,7 @@ pub fn process_set_realm_config(
         let council_token_mint_info = next_account_info(account_info_iter)?; // 2
         let _council_token_holding_info = next_account_info(account_info_iter)?; // 3
 
-        // Council mint can only be at present set to none (removed) and changing it to other mint is not supported
+        // Council mint can only be at present set to None (removed) and changing it to other mint is not supported
         // It might be implemented in future versions but it needs careful planning
         // It can potentially open a can of warms like what happens with existing deposits or pending proposals
         if let Some(council_token_mint) = realm_data.config.council_mint {

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -22,7 +22,7 @@ pub enum GovernanceAccountType {
     ProgramGovernance,
 
     /// Proposal account for Governance account. A single Governance account can have multiple Proposal accounts
-    Proposal,
+    ProposalV1,
 
     /// Proposal Signatory account
     SignatoryRecord,
@@ -49,6 +49,10 @@ pub enum GovernanceAccountType {
     /// ProposalInstruction account which holds an instruction to execute for Proposal
     /// V2 adds index for proposal option
     ProposalInstructionV2,
+
+    /// Proposal account for Governance account. A single Governance account can have multiple Proposal accounts
+    /// V2 adds support for multiple vote options
+    ProposalV2,
 }
 
 impl Default for GovernanceAccountType {

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -28,7 +28,7 @@ pub enum GovernanceAccountType {
     SignatoryRecord,
 
     /// Vote record account for a given Proposal.  Proposal can have 0..n voting records
-    VoteRecord,
+    VoteRecordV1,
 
     /// ProposalInstruction account which holds an instruction to execute for Proposal
     ProposalInstructionV1,

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -49,7 +49,6 @@ impl Default for GovernanceAccountType {
     }
 }
 
-
 /// What state a Proposal is in
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -49,16 +49,6 @@ impl Default for GovernanceAccountType {
     }
 }
 
-/// Vote  with number of votes
-#[repr(C)]
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
-pub enum VoteWeight {
-    /// Yes vote
-    Yes(u64),
-
-    /// No vote
-    No(u64),
-}
 
 /// What state a Proposal is in
 #[repr(C)]

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -31,7 +31,7 @@ pub enum GovernanceAccountType {
     VoteRecord,
 
     /// ProposalInstruction account which holds an instruction to execute for Proposal
-    ProposalInstruction,
+    ProposalInstructionV1,
 
     /// Mint Governance account
     MintGovernance,
@@ -45,6 +45,10 @@ pub enum GovernanceAccountType {
     /// Vote record account for a given Proposal.  Proposal can have 0..n voting records
     /// V2 adds support for multi option votes
     VoteRecordV2,
+
+    /// ProposalInstruction account which holds an instruction to execute for Proposal
+    /// V2 adds index for proposal option
+    ProposalInstructionV2,
 }
 
 impl Default for GovernanceAccountType {

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -41,6 +41,10 @@ pub enum GovernanceAccountType {
 
     /// Realm config account
     RealmConfig,
+
+    /// Vote record account for a given Proposal.  Proposal can have 0..n voting records
+    /// V2 adds support for multi option votes
+    VoteRecordV2,
 }
 
 impl Default for GovernanceAccountType {

--- a/governance/program/src/state/legacy.rs
+++ b/governance/program/src/state/legacy.rs
@@ -40,3 +40,39 @@ impl IsInitialized for ProposalInstructionV1 {
         self.account_type == GovernanceAccountType::ProposalInstructionV1
     }
 }
+
+/// Vote  with number of votes
+#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+pub enum VoteWeightV1 {
+    /// Yes vote
+    Yes(u64),
+
+    /// No vote
+    No(u64),
+}
+
+/// Proposal VoteRecord
+#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+pub struct VoteRecordV1 {
+    /// Governance account type
+    pub account_type: GovernanceAccountType,
+
+    /// Proposal account
+    pub proposal: Pubkey,
+
+    /// The user who casted this vote
+    /// This is the Governing Token Owner who deposited governing tokens into the Realm
+    pub governing_token_owner: Pubkey,
+
+    /// Indicates whether the vote was relinquished by voter
+    pub is_relinquished: bool,
+
+    /// Voter's vote: Yes/No and amount
+    pub vote_weight: VoteWeightV1,
+}
+
+impl IsInitialized for VoteRecordV1 {
+    fn is_initialized(&self) -> bool {
+        self.account_type == GovernanceAccountType::VoteRecordV1
+    }
+}

--- a/governance/program/src/state/legacy.rs
+++ b/governance/program/src/state/legacy.rs
@@ -1,0 +1,42 @@
+//! Legacy Accounts
+
+use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use solana_program::{clock::UnixTimestamp, program_pack::IsInitialized, pubkey::Pubkey};
+
+use super::{
+    enums::{GovernanceAccountType, InstructionExecutionStatus},
+    proposal_instruction::InstructionData,
+};
+
+/// Proposal instruction V1
+#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+pub struct ProposalInstructionV1 {
+    /// Governance Account type
+    pub account_type: GovernanceAccountType,
+
+    /// The Proposal the instruction belongs to
+    pub proposal: Pubkey,
+
+    /// Unique instruction index within it's parent Proposal
+    pub instruction_index: u16,
+
+    /// Minimum waiting time in seconds for the  instruction to be executed once proposal is voted on
+    pub hold_up_time: u32,
+
+    /// Instruction to execute
+    /// The instruction will be signed by Governance PDA the Proposal belongs to
+    // For example for ProgramGovernance the instruction to upgrade program will be signed by ProgramGovernance PDA
+    pub instruction: InstructionData,
+
+    /// Executed at flag
+    pub executed_at: Option<UnixTimestamp>,
+
+    /// Instruction execution status
+    pub execution_status: InstructionExecutionStatus,
+}
+
+impl IsInitialized for ProposalInstructionV1 {
+    fn is_initialized(&self) -> bool {
+        self.account_type == GovernanceAccountType::ProposalInstructionV1
+    }
+}

--- a/governance/program/src/state/mod.rs
+++ b/governance/program/src/state/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod enums;
 pub mod governance;
+pub mod legacy;
 pub mod proposal;
 pub mod proposal_instruction;
 pub mod realm;

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -68,11 +68,15 @@ pub struct ProposalOption {
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum VoteType {
     /// Single choice vote with mutually exclusive choices
+    /// In the SingeChoice mode there can ever be a single winner
+    /// If multiple options score the same highest vote then the Proposal is not resolved and considered as Failed
     /// Note: Yes/No vote is a single choice (Yes) vote with the deny option (No)
     SingleChoice,
 
-    /// Multiple options can be selected
-    MultiChoice,
+    /// Multiple options can be selected with up to N choices per voter
+    /// By default N equals to the number of available options
+    /// Note: In the current version the N limit is not supported and not enforced yet
+    MultiChoice(u16),
 }
 
 /// Governance Proposal
@@ -159,7 +163,7 @@ pub struct ProposalV2 {
 impl AccountMaxSize for ProposalV2 {
     fn get_max_size(&self) -> Option<usize> {
         let options_size: usize = self.options.iter().map(|o| o.label.len() + 19).sum();
-        Some(self.name.len() + self.description_link.len() + options_size + 197)
+        Some(self.name.len() + self.description_link.len() + options_size + 199)
     }
 }
 
@@ -345,7 +349,7 @@ impl ProposalV2 {
 
                     proposal_state
                 }
-                VoteType::MultiChoice => {
+                VoteType::MultiChoice(_n) => {
                     // If any option succeeded for multi choice then the proposal as a whole succeeded as well
                     ProposalState::Succeeded
                 }
@@ -610,7 +614,7 @@ impl ProposalV2 {
                             return Err(GovernanceError::InvalidVote.into());
                         }
                     }
-                    VoteType::MultiChoice => {
+                    VoteType::MultiChoice(_n) => {
                         if choice_count == 0 {
                             return Err(GovernanceError::InvalidVote.into());
                         }
@@ -824,8 +828,10 @@ pub fn assert_valid_proposal_options(
         return Err(GovernanceError::InvalidProposalOptions.into());
     }
 
-    if options.len() == 1 && *vote_type == VoteType::MultiChoice {
-        return Err(GovernanceError::InvalidProposalOptions.into());
+    if let VoteType::MultiChoice(n) = *vote_type {
+        if options.len() == 1 || n as usize != options.len() {
+            return Err(GovernanceError::InvalidProposalOptions.into());
+        }
     }
 
     if options.iter().any(|o| o.is_empty()) {
@@ -954,7 +960,9 @@ mod test {
 
     #[test]
     fn test_max_size() {
-        let proposal = create_test_proposal();
+        let mut proposal = create_test_proposal();
+        proposal.vote_type = VoteType::MultiChoice(1);
+
         let size = proposal.try_to_vec().unwrap().len();
 
         assert_eq!(proposal.get_max_size(), Some(size));
@@ -962,7 +970,9 @@ mod test {
 
     #[test]
     fn test_multi_option_proposal_max_size() {
-        let proposal = create_test_multi_option_proposal();
+        let mut proposal = create_test_multi_option_proposal();
+        proposal.vote_type = VoteType::MultiChoice(3);
+
         let size = proposal.try_to_vec().unwrap().len();
 
         assert_eq!(proposal.get_max_size(), Some(size));
@@ -1895,7 +1905,7 @@ mod test {
     pub fn test_assert_valid_vote_with_no_choices_for_multi_choice_error() {
         // Arrange
         let mut proposal = create_test_multi_option_proposal();
-        proposal.vote_type = VoteType::MultiChoice;
+        proposal.vote_type = VoteType::MultiChoice(3);
 
         let choices = vec![
             VoteChoice {
@@ -1922,6 +1932,85 @@ mod test {
 
         // Assert
         assert_eq!(result, Err(GovernanceError::InvalidVote.into()));
+    }
+
+    #[test]
+    pub fn test_assert_valid_proposal_options_with_invalid_choice_number_for_multi_choice_vote_error(
+    ) {
+        // Arrange
+        let vote_type = VoteType::MultiChoice(3);
+
+        let options = vec!["option 1".to_string(), "option 2".to_string()];
+
+        // Act
+        let result = assert_valid_proposal_options(&options, &vote_type);
+
+        // Assert
+        assert_eq!(result, Err(GovernanceError::InvalidProposalOptions.into()));
+    }
+
+    #[test]
+    pub fn test_assert_valid_proposal_options_with_no_options_for_multi_choice_vote_error() {
+        // Arrange
+        let vote_type = VoteType::MultiChoice(3);
+
+        let options = vec![];
+
+        // Act
+        let result = assert_valid_proposal_options(&options, &vote_type);
+
+        // Assert
+        assert_eq!(result, Err(GovernanceError::InvalidProposalOptions.into()));
+    }
+
+    #[test]
+    pub fn test_assert_valid_proposal_options_with_no_options_for_single_choice_vote_error() {
+        // Arrange
+        let vote_type = VoteType::SingleChoice;
+
+        let options = vec![];
+
+        // Act
+        let result = assert_valid_proposal_options(&options, &vote_type);
+
+        // Assert
+        assert_eq!(result, Err(GovernanceError::InvalidProposalOptions.into()));
+    }
+
+    #[test]
+    pub fn test_assert_valid_proposal_options_for_multi_choice_vote() {
+        // Arrange
+        let vote_type = VoteType::MultiChoice(3);
+
+        let options = vec![
+            "option 1".to_string(),
+            "option 2".to_string(),
+            "option 3".to_string(),
+        ];
+
+        // Act
+        let result = assert_valid_proposal_options(&options, &vote_type);
+
+        // Assert
+        assert_eq!(result, Ok(()));
+    }
+
+    #[test]
+    pub fn test_assert_valid_proposal_options_for_multi_choice_vote_with_empty_option_error() {
+        // Arrange
+        let vote_type = VoteType::MultiChoice(3);
+
+        let options = vec![
+            "".to_string(),
+            "option 2".to_string(),
+            "option 3".to_string(),
+        ];
+
+        // Act
+        let result = assert_valid_proposal_options(&options, &vote_type);
+
+        // Assert
+        assert_eq!(result, Err(GovernanceError::InvalidProposalOptions.into()));
     }
 
     #[test]

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -731,7 +731,7 @@ pub fn get_proposal_data(
             options: vec![ProposalOption {
                 label: "Yes".to_string(),
                 vote_weight: proposal_data_v1.yes_votes_count,
-                vote_result: vote_result,
+                vote_result,
                 instructions_executed_count: proposal_data_v1.instructions_executed_count,
                 instructions_count: proposal_data_v1.instructions_count,
                 instructions_next_index: proposal_data_v1.instructions_next_index,

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -43,6 +43,13 @@ pub struct ProposalOptionVote {
     pub weight: u64,
 }
 
+/// Proposal type
+#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+pub enum ProposalType {
+    /// Yes/No vote with tipping point (when mathematically possible)
+    YesNoVote,
+}
+
 /// Governance Proposal
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct Proposal {
@@ -67,6 +74,9 @@ pub struct Proposal {
 
     /// The number of signatories who already signed
     pub signatories_signed_off_count: u8,
+
+    /// Proposal type
+    pub proposal_type: ProposalType,
 
     /// Proposal options
     pub options: Vec<ProposalOptionVote>,
@@ -126,7 +136,7 @@ pub struct Proposal {
 impl AccountMaxSize for Proposal {
     fn get_max_size(&self) -> Option<usize> {
         let options_size: usize = self.options.iter().map(|o| o.label.len() + 12).sum();
-        Some(self.name.len() + self.description_link.len() + options_size + 193)
+        Some(self.name.len() + self.description_link.len() + options_size + 194)
     }
 }
 
@@ -598,6 +608,7 @@ mod test {
             executing_at: Some(10),
             closed_at: Some(10),
 
+            proposal_type: ProposalType::YesNoVote,
             options: vec![
                 ProposalOptionVote {
                     label: "yes".to_string(),

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -458,7 +458,7 @@ impl Proposal {
         //       and I decided to fight it another day
         if self.vote_type != VoteType::SingleChoice
             // Tipping should not be allowed for opinion only proposals (surveys without rejection) to allow everybody's voice to be heard
-            && !self.has_reject_option 
+            && !self.has_reject_option
             && !self.options.len() != 2
         {
             return None;

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -676,9 +676,9 @@ pub fn get_proposal_address<'a>(
 /// Assert options to create proposal are valid
 pub fn assert_valid_proposal_options(
     vote_type: &VoteType,
-    options: &Vec<String>,
+    options: &[String],
 ) -> Result<(), ProgramError> {
-    if options.len() == 0 {
+    if options.is_empty() {
         return Err(GovernanceError::InvalidProposalOptions.into());
     }
 

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -1252,8 +1252,22 @@ mod test {
             assert_eq!(proposal.state,test_case.expected_tipped_state,"CASE: {:?}",test_case);
 
             if test_case.expected_tipped_state != ProposalState::Voting {
-                assert_eq!(Some(current_timestamp),proposal.voting_completed_at)
+                assert_eq!(Some(current_timestamp),proposal.voting_completed_at);
+
             }
+
+            match proposal.options[0].vote_result {
+                OptionVoteResult::Succeeded => {
+                    assert_eq!(ProposalState::Succeeded,test_case.expected_tipped_state)
+                },
+                OptionVoteResult::Defeated => {
+                    assert_eq!(ProposalState::Defeated,test_case.expected_tipped_state)
+                },
+                OptionVoteResult::None =>  {
+                    assert_eq!(ProposalState::Voting,test_case.expected_tipped_state)
+                },
+            };
+
         }
 
         #[test]
@@ -1279,6 +1293,18 @@ mod test {
             // Assert
             assert_eq!(proposal.state,test_case.expected_finalized_state,"CASE: {:?}",test_case);
             assert_eq!(Some(current_timestamp),proposal.voting_completed_at);
+
+            match proposal.options[0].vote_result {
+                OptionVoteResult::Succeeded => {
+                    assert_eq!(ProposalState::Succeeded,test_case.expected_finalized_state)
+                },
+                OptionVoteResult::Defeated => {
+                    assert_eq!(ProposalState::Defeated,test_case.expected_finalized_state)
+                },
+                OptionVoteResult::None =>  {
+                    panic!("Option result must be resolved for finalized vote")
+                },
+            };
 
         }
     }

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -1,7 +1,7 @@
 //! Proposal  Account
 
+use borsh::maybestd::io::Write;
 use std::cmp::Ordering;
-use std::io::Write;
 
 use solana_program::borsh::try_from_slice_unchecked;
 use solana_program::clock::{Slot, UnixTimestamp};
@@ -628,17 +628,17 @@ impl ProposalV2 {
     }
 
     /// Serializes account into the target buffer
-    pub fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), ProgramError> {
+    pub fn serialize<W: Write>(self, writer: &mut W) -> Result<(), ProgramError> {
         if self.account_type == GovernanceAccountType::ProposalV2 {
             BorshSerialize::serialize(&self, writer)?
         } else if self.account_type == GovernanceAccountType::ProposalV1 {
             // V1 account can't be resized and we have to translate it back to the original format
 
             let proposal_data_v1 = ProposalV1 {
-                account_type: self.account_type.clone(),
+                account_type: self.account_type,
                 governance: self.governance,
                 governing_token_mint: self.governing_token_mint,
-                state: self.state.clone(),
+                state: self.state,
                 token_owner_record: self.token_owner_record,
                 signatories_count: self.signatories_count,
                 signatories_signed_off_count: self.signatories_signed_off_count,
@@ -654,11 +654,11 @@ impl ProposalV2 {
                 voting_completed_at: self.voting_completed_at,
                 executing_at: self.executing_at,
                 closed_at: self.closed_at,
-                execution_flags: self.execution_flags.clone(),
+                execution_flags: self.execution_flags,
                 max_vote_weight: self.max_vote_weight,
-                vote_threshold_percentage: self.vote_threshold_percentage.clone(),
-                name: self.name.clone(),
-                description_link: self.description_link.clone(),
+                vote_threshold_percentage: self.vote_threshold_percentage,
+                name: self.name,
+                description_link: self.description_link,
             };
 
             BorshSerialize::serialize(&proposal_data_v1, writer)?;

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -63,11 +63,10 @@ pub struct ProposalOption {
 /// Proposal vote type
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum VoteType {
-    /// Single choice vote with mutually exclusive choices a
-    /// Note: Yse/No vote is a single choice with rejection option
+    /// Single choice vote with mutually exclusive choices
+    /// Note: Yes/No vote is a single choice (Yes) vote with the deny option (No)
     SingleChoice,
     /// Multiple options can be selected
-    /// TODO: add N of M choices
     MultiChoice,
 }
 
@@ -697,16 +696,20 @@ pub fn get_proposal_address<'a>(
     .0
 }
 
-/// Assert options to create proposal are valid
+/// Assert options to create proposal are valid for the Proposal vote_type
 pub fn assert_valid_proposal_options(
-    vote_type: &VoteType,
     options: &[String],
+    vote_type: &VoteType,
 ) -> Result<(), ProgramError> {
     if options.is_empty() {
         return Err(GovernanceError::InvalidProposalOptions.into());
     }
 
     if options.len() == 1 && *vote_type == VoteType::MultiChoice {
+        return Err(GovernanceError::InvalidProposalOptions.into());
+    }
+
+    if options.iter().any(|o| o.is_empty()) {
         return Err(GovernanceError::InvalidProposalOptions.into());
     }
 

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -1,5 +1,7 @@
 //! Proposal  Account
 
+use std::cmp::Ordering;
+
 use solana_program::clock::{Slot, UnixTimestamp};
 
 use solana_program::{
@@ -316,11 +318,13 @@ impl Proposal {
             {
                 option.vote_result = OptionVoteResult::Succeeded;
 
-                if option.vote_weight > best_succeeded_option_weight {
-                    best_succeeded_option_weight = option.vote_weight;
-                    best_succeeded_option_count = 1;
-                } else if option.vote_weight == best_succeeded_option_weight {
-                    best_succeeded_option_count = best_succeeded_option_count + 1;
+                match option.vote_weight.cmp(&best_succeeded_option_weight) {
+                    Ordering::Greater => {
+                        best_succeeded_option_weight = option.vote_weight;
+                        best_succeeded_option_count = 1;
+                    }
+                    Ordering::Equal => best_succeeded_option_count += 1,
+                    Ordering::Less => {}
                 }
             }
         }
@@ -383,6 +387,7 @@ impl Proposal {
                     .checked_div(MintMaxVoteWeightSource::SUPPLY_FRACTION_BASE as u128)
                     .unwrap() as u64;
 
+                // TODO: generalize for multi option case
                 let yes_vote_weight = self.options[0].vote_weight;
                 let no_vote_weight = self.options[1].vote_weight;
 
@@ -436,6 +441,7 @@ impl Proposal {
             return None;
         };
 
+        // TODO: generalize for multi option case
         let yes_vote_weight = self.options[0].vote_weight;
         let no_vote_weight = self.options[1].vote_weight;
 

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -20,20 +20,21 @@ use crate::{
         governance::GovernanceConfig,
         proposal_instruction::ProposalInstruction,
         realm::Realm,
+        vote_record::Vote,
     },
     PROGRAM_AUTHORITY_SEED,
 };
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 
-use super::vote_record::Vote;
-
-/// Proposal option vote status
+/// Proposal option vote result
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum OptionVoteResult {
     /// Vote on the option is not resolved yet
     None,
+
     /// Vote on the option is completed and the option passed
     Succeeded,
+
     /// Vote on the option is completed and the option was defeated
     Defeated,
 }
@@ -66,6 +67,7 @@ pub enum VoteType {
     /// Single choice vote with mutually exclusive choices
     /// Note: Yes/No vote is a single choice (Yes) vote with the deny option (No)
     SingleChoice,
+
     /// Multiple options can be selected
     MultiChoice,
 }
@@ -102,10 +104,10 @@ pub struct Proposal {
     /// Proposal options
     pub options: Vec<ProposalOption>,
 
-    /// The weight of proposal rejection votes
+    /// The weight of the Proposal rejection votes
     /// If the proposal has no deny option then the weight is None
     /// Only proposals with the deny option can have executable instructions attached to them
-    /// Without the deny option a proposal is only none executable survey
+    /// Without the deny option a proposal is only non executable survey
     pub deny_vote_weight: Option<u64>,
 
     /// When the Proposal was created and entered Draft state
@@ -428,7 +430,7 @@ impl Proposal {
         if self.vote_type != VoteType::SingleChoice
             // Tipping should not be allowed for opinion only proposals (surveys without rejection) to allow everybody's voice to be heard
             && self.deny_vote_weight.is_none()
-            && !self.options.len() != 2
+            && !self.options.len() != 1
         {
             return None;
         };
@@ -1651,6 +1653,7 @@ mod test {
         let mut proposal = create_test_proposal();
         proposal.deny_vote_weight = None;
 
+        // Survey only proposal can't be denied
         let vote = Vote::Deny;
 
         // Act

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -634,7 +634,7 @@ impl ProposalV2 {
         } else if self.account_type == GovernanceAccountType::ProposalV1 {
             // V1 account can't be resized and we have to translate it back to the original format
 
-            let vote_record_data_v1 = ProposalV1 {
+            let proposal_data_v1 = ProposalV1 {
                 account_type: self.account_type.clone(),
                 governance: self.governance,
                 governing_token_mint: self.governing_token_mint,

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -57,6 +57,15 @@ pub struct ProposalOption {
 
     /// Vote result for the option
     pub vote_result: OptionVoteResult,
+
+    /// The number of the instructions already executed
+    pub instructions_executed_count: u16,
+
+    /// The number of instructions included in the option
+    pub instructions_count: u16,
+
+    /// The index of the the next instruction to be added
+    pub instructions_next_index: u16,
 }
 
 /// Proposal vote type
@@ -108,15 +117,6 @@ pub struct Proposal {
     /// The reject option should be the last one in the options collection
     pub has_reject_option: bool,
 
-    /// The number of the instructions already executed
-    pub instructions_executed_count: u16,
-
-    /// The number of instructions included in the proposal
-    pub instructions_count: u16,
-
-    /// The index of the the next instruction to be added
-    pub instructions_next_index: u16,
-
     /// When the Proposal was created and entered Draft state
     pub draft_at: UnixTimestamp,
 
@@ -162,8 +162,8 @@ pub struct Proposal {
 
 impl AccountMaxSize for Proposal {
     fn get_max_size(&self) -> Option<usize> {
-        let options_size: usize = self.options.iter().map(|o| o.label.len() + 13).sum();
-        Some(self.name.len() + self.description_link.len() + options_size + 195)
+        let options_size: usize = self.options.iter().map(|o| o.label.len() + 19).sum();
+        Some(self.name.len() + self.description_link.len() + options_size + 189)
     }
 }
 
@@ -730,20 +730,23 @@ mod test {
                     label: "yes".to_string(),
                     vote_weight: 0,
                     vote_result: OptionVoteResult::None,
+                    instructions_executed_count: 10,
+                    instructions_count: 10,
+                    instructions_next_index: 10,
                 },
                 ProposalOption {
                     label: "no".to_string(),
                     vote_weight: 0,
                     vote_result: OptionVoteResult::None,
+                    instructions_executed_count: 10,
+                    instructions_count: 10,
+                    instructions_next_index: 10,
                 },
             ],
             has_reject_option: true,
 
             execution_flags: InstructionExecutionFlags::Ordered,
 
-            instructions_executed_count: 10,
-            instructions_count: 10,
-            instructions_next_index: 10,
             vote_threshold_percentage: Some(VoteThresholdPercentage::YesVote(100)),
         }
     }
@@ -755,16 +758,25 @@ mod test {
                 label: "option 1".to_string(),
                 vote_weight: 0,
                 vote_result: OptionVoteResult::None,
+                instructions_executed_count: 10,
+                instructions_count: 10,
+                instructions_next_index: 10,
             },
             ProposalOption {
                 label: "option 2".to_string(),
                 vote_weight: 0,
                 vote_result: OptionVoteResult::None,
+                instructions_executed_count: 10,
+                instructions_count: 10,
+                instructions_next_index: 10,
             },
             ProposalOption {
                 label: "option 3".to_string(),
                 vote_weight: 0,
                 vote_result: OptionVoteResult::None,
+                instructions_executed_count: 10,
+                instructions_count: 10,
+                instructions_next_index: 10,
             },
         ];
 

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -634,7 +634,7 @@ impl ProposalV2 {
             // V1 account can't be resized and we have to translate it back to the original format
 
             let vote_record_data_v1 = ProposalV1 {
-                account_type: self.account_type,
+                account_type: self.account_type.clone(),
                 governance: self.governance,
                 governing_token_mint: self.governing_token_mint,
                 state: self.state.clone(),

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -18,7 +18,7 @@ use crate::{
             MintMaxVoteWeightSource, ProposalState, VoteThresholdPercentage,
         },
         governance::GovernanceConfig,
-        proposal_instruction::ProposalInstruction,
+        proposal_instruction::ProposalInstructionV2,
         realm::Realm,
         vote_record::Vote,
     },
@@ -522,7 +522,7 @@ impl Proposal {
     /// Checks if Instructions can be executed for the Proposal in the given state
     pub fn assert_can_execute_instruction(
         &self,
-        proposal_instruction_data: &ProposalInstruction,
+        proposal_instruction_data: &ProposalInstructionV2,
         current_unix_timestamp: UnixTimestamp,
     ) -> Result<(), ProgramError> {
         match self.state {
@@ -565,7 +565,7 @@ impl Proposal {
     /// Checks if the instruction can be flagged with error for the Proposal in the given state
     pub fn assert_can_flag_instruction_error(
         &self,
-        proposal_instruction_data: &ProposalInstruction,
+        proposal_instruction_data: &ProposalInstructionV2,
         current_unix_timestamp: UnixTimestamp,
     ) -> Result<(), ProgramError> {
         // Instruction can be flagged for error only when it's eligible for execution

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -25,14 +25,7 @@ use crate::{
 };
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 
-/// Proposal Option
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
-pub struct ProposalOptionArg {
-    /// Option label
-    /// TODO: make label optional or create ProposalOptions with a collection of labels
-    /// add has_reject_option flag
-    pub label: String,
-}
+
 
 /// Proposal option vote status
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -25,8 +25,6 @@ use crate::{
 };
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 
-
-
 /// Proposal option vote status
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum OptionVoteResult {
@@ -664,6 +662,22 @@ pub fn get_proposal_address<'a>(
         program_id,
     )
     .0
+}
+
+/// Assert options to create proposal are valid
+pub fn assert_valid_proposal_options(
+    vote_type: &VoteType,
+    options: &Vec<String>,
+) -> Result<(), ProgramError> {
+    if options.len() == 0 {
+        return Err(GovernanceError::InvalidProposalOptions.into());
+    }
+
+    if options.len() == 1 && *vote_type == VoteType::MultiChoice {
+        return Err(GovernanceError::InvalidProposalOptions.into());
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -269,7 +269,7 @@ impl ProposalV2 {
 
         let max_vote_weight = self.get_max_vote_weight(realm_data, governing_token_mint_supply)?;
 
-        self.state = self.get_final_vote_state(max_vote_weight, config)?;
+        self.state = self.resolve_final_vote_state(max_vote_weight, config)?;
         // TODO: set voting_completed_at based on the time when the voting ended and not when we finalized the proposal
         self.voting_completed_at = Some(current_unix_timestamp);
 
@@ -280,8 +280,9 @@ impl ProposalV2 {
         Ok(())
     }
 
-    /// Returns final proposal state after vote ends
-    fn get_final_vote_state(
+    /// Resolves final proposal state after vote ends
+    /// It inspects all proposals options and resolves their final vote results
+    fn resolve_final_vote_state(
         &mut self,
         max_vote_weight: u64,
         config: &GovernanceConfig,

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -510,9 +510,18 @@ impl Proposal {
     }
 
     /// Checks if Instructions can be edited (inserted or removed) for the Proposal in the given state
+    /// It also asserts whether the Proposal is executable (has the reject option)
     pub fn assert_can_edit_instructions(&self) -> Result<(), ProgramError> {
-        self.assert_is_draft_state()
-            .map_err(|_| GovernanceError::InvalidStateCannotEditInstructions.into())
+        if self.assert_is_draft_state().is_err() {
+            return Err(GovernanceError::InvalidStateCannotEditInstructions.into());
+        }
+
+        // For security purposes only proposals with the reject option can have executable instructions
+        if !self.has_reject_option {
+            return Err(GovernanceError::ProposalIsNotExecutable.into());
+        }
+
+        Ok(())
     }
 
     /// Checks if Instructions can be executed for the Proposal in the given state

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -74,7 +74,7 @@ pub enum VoteType {
 
 /// Governance Proposal
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
-pub struct Proposal {
+pub struct ProposalV2 {
     /// Governance account type
     pub account_type: GovernanceAccountType,
 
@@ -153,20 +153,20 @@ pub struct Proposal {
     pub description_link: String,
 }
 
-impl AccountMaxSize for Proposal {
+impl AccountMaxSize for ProposalV2 {
     fn get_max_size(&self) -> Option<usize> {
         let options_size: usize = self.options.iter().map(|o| o.label.len() + 19).sum();
         Some(self.name.len() + self.description_link.len() + options_size + 197)
     }
 }
 
-impl IsInitialized for Proposal {
+impl IsInitialized for ProposalV2 {
     fn is_initialized(&self) -> bool {
-        self.account_type == GovernanceAccountType::Proposal
+        self.account_type == GovernanceAccountType::ProposalV2
     }
 }
 
-impl Proposal {
+impl ProposalV2 {
     /// Checks if Signatories can be edited (added or removed) for the Proposal in the given state
     pub fn assert_can_edit_signatories(&self) -> Result<(), ProgramError> {
         self.assert_is_draft_state()
@@ -656,8 +656,8 @@ fn get_min_vote_threshold_weight(
 pub fn get_proposal_data(
     program_id: &Pubkey,
     proposal_info: &AccountInfo,
-) -> Result<Proposal, ProgramError> {
-    get_account_data::<Proposal>(program_id, proposal_info)
+) -> Result<ProposalV2, ProgramError> {
+    get_account_data::<ProposalV2>(program_id, proposal_info)
 }
 
 /// Deserializes Proposal and validates it belongs to the given Governance and Governing Mint
@@ -666,7 +666,7 @@ pub fn get_proposal_data_for_governance_and_governing_mint(
     proposal_info: &AccountInfo,
     governance: &Pubkey,
     governing_token_mint: &Pubkey,
-) -> Result<Proposal, ProgramError> {
+) -> Result<ProposalV2, ProgramError> {
     let proposal_data = get_proposal_data_for_governance(program_id, proposal_info, governance)?;
 
     if proposal_data.governing_token_mint != *governing_token_mint {
@@ -681,7 +681,7 @@ pub fn get_proposal_data_for_governance(
     program_id: &Pubkey,
     proposal_info: &AccountInfo,
     governance: &Pubkey,
-) -> Result<Proposal, ProgramError> {
+) -> Result<ProposalV2, ProgramError> {
     let proposal_data = get_proposal_data(program_id, proposal_info)?;
 
     if proposal_data.governance != *governance {
@@ -749,8 +749,8 @@ mod test {
 
     use {super::*, proptest::prelude::*};
 
-    fn create_test_proposal() -> Proposal {
-        Proposal {
+    fn create_test_proposal() -> ProposalV2 {
+        ProposalV2 {
             account_type: GovernanceAccountType::TokenOwnerRecord,
             governance: Pubkey::new_unique(),
             governing_token_mint: Pubkey::new_unique(),
@@ -788,7 +788,7 @@ mod test {
         }
     }
 
-    fn create_test_multi_option_proposal() -> Proposal {
+    fn create_test_multi_option_proposal() -> ProposalV2 {
         let mut proposal = create_test_proposal();
         proposal.options = vec![
             ProposalOption {

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -125,13 +125,8 @@ pub struct Proposal {
 
 impl AccountMaxSize for Proposal {
     fn get_max_size(&self) -> Option<usize> {
-        Some(
-            self.name.len()
-                + self.description_link.len()
-                + self.options[0].label.len()
-                + self.options[1].label.len()
-                + 217,
-        )
+        let options_size: usize = self.options.iter().map(|o| o.label.len() + 12).sum();
+        Some(self.name.len() + self.description_link.len() + options_size + 193)
     }
 }
 
@@ -623,6 +618,26 @@ mod test {
         }
     }
 
+    fn create_test_multi_option_proposal() -> Proposal {
+        let mut proposal = create_test_proposal();
+        proposal.options = vec![
+            ProposalOptionVote {
+                label: "option 1".to_string(),
+                weight: 0,
+            },
+            ProposalOptionVote {
+                label: "option 2".to_string(),
+                weight: 0,
+            },
+            ProposalOptionVote {
+                label: "option 3".to_string(),
+                weight: 0,
+            },
+        ];
+
+        proposal
+    }
+
     fn create_test_realm() -> Realm {
         Realm {
             account_type: GovernanceAccountType::Realm,
@@ -658,6 +673,14 @@ mod test {
     #[test]
     fn test_max_size() {
         let proposal = create_test_proposal();
+        let size = proposal.try_to_vec().unwrap().len();
+
+        assert_eq!(proposal.get_max_size(), Some(size));
+    }
+
+    #[test]
+    fn test_multi_option_proposal_max_size() {
+        let proposal = create_test_multi_option_proposal();
         let size = proposal.try_to_vec().unwrap().len();
 
         assert_eq!(proposal.get_max_size(), Some(size));

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -661,7 +661,7 @@ impl ProposalV2 {
                 description_link: self.description_link.clone(),
             };
 
-            BorshSerialize::serialize(&vote_record_data_v1, writer)?;
+            BorshSerialize::serialize(&proposal_data_v1, writer)?;
         }
 
         Ok(())

--- a/governance/program/src/state/proposal_instruction.rs
+++ b/governance/program/src/state/proposal_instruction.rs
@@ -1,6 +1,6 @@
 //! ProposalInstruction Account
 
-use std::io::Write;
+use borsh::maybestd::io::Write;
 
 use crate::{
     error::GovernanceError,

--- a/governance/program/src/state/proposal_instruction.rs
+++ b/governance/program/src/state/proposal_instruction.rs
@@ -93,7 +93,7 @@ pub struct ProposalInstructionV2 {
     pub proposal: Pubkey,
 
     /// The option index the instruction belongs to
-    pub option_index: u8,
+    pub option_index: u16,
 
     /// Unique instruction index within it's parent Proposal
     pub instruction_index: u16,
@@ -115,7 +115,7 @@ pub struct ProposalInstructionV2 {
 
 impl AccountMaxSize for ProposalInstructionV2 {
     fn get_max_size(&self) -> Option<usize> {
-        Some(self.instruction.accounts.len() * 34 + self.instruction.data.len() + 90)
+        Some(self.instruction.accounts.len() * 34 + self.instruction.data.len() + 91)
     }
 }
 
@@ -152,7 +152,7 @@ impl ProposalInstructionV2 {
 /// Returns ProposalInstruction PDA seeds
 pub fn get_proposal_instruction_address_seeds<'a>(
     proposal: &'a Pubkey,
-    option_index: &'a [u8; 1],
+    option_index: &'a [u8; 2],               // u16 le bytes
     instruction_index_le_bytes: &'a [u8; 2], // u16 le bytes
 ) -> [&'a [u8]; 4] {
     [
@@ -167,11 +167,15 @@ pub fn get_proposal_instruction_address_seeds<'a>(
 pub fn get_proposal_instruction_address<'a>(
     program_id: &Pubkey,
     proposal: &'a Pubkey,
-    option_index: &'a [u8; 1],
+    option_index_le_bytes: &'a [u8; 2],      // u16 le bytes
     instruction_index_le_bytes: &'a [u8; 2], // u16 le bytes
 ) -> Pubkey {
     Pubkey::find_program_address(
-        &get_proposal_instruction_address_seeds(proposal, option_index, instruction_index_le_bytes),
+        &get_proposal_instruction_address_seeds(
+            proposal,
+            option_index_le_bytes,
+            instruction_index_le_bytes,
+        ),
         program_id,
     )
     .0
@@ -193,7 +197,7 @@ pub fn get_proposal_instruction_data(
         return Ok(ProposalInstructionV2 {
             account_type,
             proposal: proposal_instruction_data_v1.proposal,
-            option_index: 0, // V1 has single implied option
+            option_index: 0, // V1 has a single implied option at index 0
             instruction_index: proposal_instruction_data_v1.instruction_index,
             hold_up_time: proposal_instruction_data_v1.hold_up_time,
             instruction: proposal_instruction_data_v1.instruction,

--- a/governance/program/src/state/proposal_instruction.rs
+++ b/governance/program/src/state/proposal_instruction.rs
@@ -127,19 +127,19 @@ impl IsInitialized for ProposalInstructionV2 {
 
 impl ProposalInstructionV2 {
     /// Serializes account into the target buffer
-    pub fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), ProgramError> {
+    pub fn serialize<W: Write>(self, writer: &mut W) -> Result<(), ProgramError> {
         if self.account_type == GovernanceAccountType::ProposalInstructionV2 {
             BorshSerialize::serialize(&self, writer)?
         } else if self.account_type == GovernanceAccountType::ProposalInstructionV1 {
             // V1 account can't be resized and we have to translate it back to the original format
             let proposal_instruction_data_v1 = ProposalInstructionV1 {
-                account_type: self.account_type.clone(),
+                account_type: self.account_type,
                 proposal: self.proposal,
                 instruction_index: self.instruction_index,
                 hold_up_time: self.hold_up_time,
-                instruction: self.instruction.clone(),
+                instruction: self.instruction,
                 executed_at: self.executed_at,
-                execution_status: self.execution_status.clone(),
+                execution_status: self.execution_status,
             };
 
             BorshSerialize::serialize(&proposal_instruction_data_v1, writer)?;

--- a/governance/program/src/state/proposal_instruction.rs
+++ b/governance/program/src/state/proposal_instruction.rs
@@ -133,7 +133,7 @@ impl ProposalInstructionV2 {
         } else if self.account_type == GovernanceAccountType::ProposalInstructionV1 {
             // V1 account can't be resized and we have to translate it back to the original format
             let proposal_instruction_data_v1 = ProposalInstructionV1 {
-                account_type: GovernanceAccountType::ProposalInstructionV1,
+                account_type: self.account_type,
                 proposal: self.proposal,
                 instruction_index: self.instruction_index,
                 hold_up_time: self.hold_up_time,
@@ -191,7 +191,7 @@ pub fn get_proposal_instruction_data(
             get_account_data::<ProposalInstructionV1>(program_id, proposal_instruction_info)?;
 
         return Ok(ProposalInstructionV2 {
-            account_type: GovernanceAccountType::ProposalInstructionV1,
+            account_type,
             proposal: proposal_instruction_data_v1.proposal,
             option_index: 0, //
             instruction_index: proposal_instruction_data_v1.instruction_index,

--- a/governance/program/src/state/proposal_instruction.rs
+++ b/governance/program/src/state/proposal_instruction.rs
@@ -193,7 +193,7 @@ pub fn get_proposal_instruction_data(
         return Ok(ProposalInstructionV2 {
             account_type,
             proposal: proposal_instruction_data_v1.proposal,
-            option_index: 0, //
+            option_index: 0, // V1 has single implied option
             instruction_index: proposal_instruction_data_v1.instruction_index,
             hold_up_time: proposal_instruction_data_v1.hold_up_time,
             instruction: proposal_instruction_data_v1.instruction,

--- a/governance/program/src/state/proposal_instruction.rs
+++ b/governance/program/src/state/proposal_instruction.rs
@@ -171,16 +171,6 @@ pub fn get_proposal_instruction_data_for_proposal(
     Ok(proposal_instruction_data)
 }
 
-///  Deserializes ProposalInstruction account and checks it belongs to the given Proposal
-pub fn assert_proposal_instruction_for_proposal(
-    program_id: &Pubkey,
-    proposal_instruction_info: &AccountInfo,
-    proposal: &Pubkey,
-) -> Result<(), ProgramError> {
-    get_proposal_instruction_data_for_proposal(program_id, proposal_instruction_info, proposal)
-        .map(|_| ())
-}
-
 #[cfg(test)]
 mod test {
 

--- a/governance/program/src/state/proposal_instruction.rs
+++ b/governance/program/src/state/proposal_instruction.rs
@@ -86,6 +86,9 @@ pub struct ProposalInstruction {
     /// The Proposal the instruction belongs to
     pub proposal: Pubkey,
 
+    /// The option index the instruction belongs to
+    pub option_index: u8,
+
     /// Unique instruction index within it's parent Proposal
     pub instruction_index: u16,
 
@@ -106,7 +109,7 @@ pub struct ProposalInstruction {
 
 impl AccountMaxSize for ProposalInstruction {
     fn get_max_size(&self) -> Option<usize> {
-        Some(self.instruction.accounts.len() * 34 + self.instruction.data.len() + 89)
+        Some(self.instruction.accounts.len() * 34 + self.instruction.data.len() + 90)
     }
 }
 
@@ -119,11 +122,13 @@ impl IsInitialized for ProposalInstruction {
 /// Returns ProposalInstruction PDA seeds
 pub fn get_proposal_instruction_address_seeds<'a>(
     proposal: &'a Pubkey,
-    instruction_index_le_bytes: &'a [u8],
-) -> [&'a [u8]; 3] {
+    option_index: &'a [u8; 1],
+    instruction_index_le_bytes: &'a [u8; 2], // u16 le bytes
+) -> [&'a [u8]; 4] {
     [
         PROGRAM_AUTHORITY_SEED,
         proposal.as_ref(),
+        option_index,
         instruction_index_le_bytes,
     ]
 }
@@ -132,10 +137,11 @@ pub fn get_proposal_instruction_address_seeds<'a>(
 pub fn get_proposal_instruction_address<'a>(
     program_id: &Pubkey,
     proposal: &'a Pubkey,
-    instruction_index_le_bytes: &'a [u8],
+    option_index: &'a [u8; 1],
+    instruction_index_le_bytes: &'a [u8; 2], // u16 le bytes
 ) -> Pubkey {
     Pubkey::find_program_address(
-        &get_proposal_instruction_address_seeds(proposal, instruction_index_le_bytes),
+        &get_proposal_instruction_address_seeds(proposal, option_index, instruction_index_le_bytes),
         program_id,
     )
     .0
@@ -207,6 +213,7 @@ mod test {
         ProposalInstruction {
             account_type: GovernanceAccountType::ProposalInstruction,
             proposal: Pubkey::new_unique(),
+            option_index: 0,
             instruction_index: 1,
             hold_up_time: 10,
             instruction: create_test_instruction_data(),

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -244,7 +244,10 @@ pub fn assert_valid_realm_config_args(config_args: &RealmConfigArgs) -> Result<(
 #[cfg(test)]
 mod test {
 
-    use crate::instruction::GovernanceInstruction;
+    use crate::{
+        instruction::GovernanceInstruction,
+        state::legacy::{GovernanceInstructionV1, RealmConfigV1, RealmV1},
+    };
     use solana_program::borsh::try_from_slice_unchecked;
 
     use super::*;
@@ -276,14 +279,13 @@ mod test {
     #[test]
     fn test_deserialize_v2_realm_account_from_v1() {
         // Arrange
-        let realm_v1 = spl_governance_v1::state::realm::Realm {
-            account_type: spl_governance_v1::state::enums::GovernanceAccountType::Realm,
+        let realm_v1 = RealmV1 {
+            account_type: GovernanceAccountType::Realm,
             community_mint: Pubkey::new_unique(),
-            config: spl_governance_v1::state::realm::RealmConfig {
+            config: RealmConfigV1 {
                 council_mint: Some(Pubkey::new_unique()),
                 reserved: [0; 8],
-                community_mint_max_vote_weight_source:
-                    spl_governance_v1::state::enums::MintMaxVoteWeightSource::Absolute(100),
+                community_mint_max_vote_weight_source: MintMaxVoteWeightSource::Absolute(100),
                 min_community_tokens_to_create_governance: 10,
             },
             reserved: [0; 8],
@@ -309,7 +311,7 @@ mod test {
     #[test]
     fn test_deserialize_v1_create_realm_instruction_from_v2() {
         // Arrange
-        let create_realm_ix = GovernanceInstruction::CreateRealm {
+        let create_realm_ix_v2 = GovernanceInstruction::CreateRealm {
             name: "test-realm".to_string(),
             config_args: RealmConfigArgs {
                 use_council_mint: true,
@@ -321,23 +323,19 @@ mod test {
         };
 
         let mut create_realm_ix_data = vec![];
-        create_realm_ix
+        create_realm_ix_v2
             .serialize(&mut create_realm_ix_data)
             .unwrap();
 
         // Act
-        let create_realm_ix_v1: spl_governance_v1::instruction::GovernanceInstruction =
+        let create_realm_ix_v1: GovernanceInstructionV1 =
             try_from_slice_unchecked(&create_realm_ix_data).unwrap();
 
         // Assert
-        if let spl_governance_v1::instruction::GovernanceInstruction::CreateRealm {
-            name,
-            config_args,
-        } = create_realm_ix_v1
-        {
+        if let GovernanceInstructionV1::CreateRealm { name, config_args } = create_realm_ix_v1 {
             assert_eq!("test-realm", name);
             assert_eq!(
-                spl_governance_v1::state::enums::MintMaxVoteWeightSource::FULL_SUPPLY_FRACTION,
+                MintMaxVoteWeightSource::FULL_SUPPLY_FRACTION,
                 config_args.community_mint_max_vote_weight_source
             );
         } else {

--- a/governance/program/src/state/vote_record.rs
+++ b/governance/program/src/state/vote_record.rs
@@ -10,10 +10,19 @@ use crate::error::GovernanceError;
 
 use crate::PROGRAM_AUTHORITY_SEED;
 
-use crate::state::enums::{GovernanceAccountType, VoteWeight};
+use crate::state::enums::GovernanceAccountType;
+
+/// Vote choice
+#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+pub struct VoteChoice {
+    /// The rank given to the choice by voter
+    pub rank: u8,
+
+    /// The weight given by the voter to the choice
+    pub weight: u64,
+}
 
 /// Proposal VoteRecord
-#[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct VoteRecord {
     /// Governance account type
@@ -29,8 +38,8 @@ pub struct VoteRecord {
     /// Indicates whether the vote was relinquished by voter
     pub is_relinquished: bool,
 
-    /// Voter's vote: Yes/No and amount
-    pub vote_weight: VoteWeight,
+    /// Voter choices
+    pub choices: Vec<VoteChoice>,
 }
 
 impl AccountMaxSize for VoteRecord {}

--- a/governance/program/src/state/vote_record.rs
+++ b/governance/program/src/state/vote_record.rs
@@ -1,6 +1,6 @@
 //! Proposal Vote Record Account
 
-use std::io::Write;
+use borsh::maybestd::io::Write;
 
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use solana_program::account_info::AccountInfo;

--- a/governance/program/src/state/vote_record.rs
+++ b/governance/program/src/state/vote_record.rs
@@ -94,7 +94,7 @@ impl VoteRecordV2 {
     }
 
     /// Serializes account into the target buffer
-    pub fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), ProgramError> {
+    pub fn serialize<W: Write>(self, writer: &mut W) -> Result<(), ProgramError> {
         if self.account_type == GovernanceAccountType::VoteRecordV2 {
             BorshSerialize::serialize(&self, writer)?
         } else if self.account_type == GovernanceAccountType::VoteRecordV1 {
@@ -105,7 +105,7 @@ impl VoteRecordV2 {
             };
 
             let vote_record_data_v1 = VoteRecordV1 {
-                account_type: self.account_type.clone(),
+                account_type: self.account_type,
                 proposal: self.proposal,
                 governing_token_owner: self.governing_token_owner,
                 is_relinquished: self.is_relinquished,

--- a/governance/program/src/state/vote_record.rs
+++ b/governance/program/src/state/vote_record.rs
@@ -1,7 +1,11 @@
 //! Proposal Vote Record Account
 
+use std::io::Write;
+
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use solana_program::account_info::AccountInfo;
+use solana_program::borsh::try_from_slice_unchecked;
+
 use solana_program::program_error::ProgramError;
 use solana_program::{program_pack::IsInitialized, pubkey::Pubkey};
 use spl_governance_tools::account::{get_account_data, AccountMaxSize};
@@ -73,7 +77,7 @@ impl AccountMaxSize for VoteRecord {}
 
 impl IsInitialized for VoteRecord {
     fn is_initialized(&self) -> bool {
-        self.account_type == GovernanceAccountType::VoteRecord
+        self.account_type == GovernanceAccountType::VoteRecordV2
     }
 }
 impl VoteRecord {
@@ -85,6 +89,33 @@ impl VoteRecord {
 
         Ok(())
     }
+
+    /// Serializes account into the target buffer
+    pub fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), ProgramError> {
+        if self.account_type == GovernanceAccountType::VoteRecordV2 {
+            BorshSerialize::serialize(&self, writer)?
+        } else if self.account_type == GovernanceAccountType::VoteRecord {
+            // For V1 translate the account back to the original format
+            let vote_weight = match self.vote.clone() {
+                Vote::Approve(_options) => {
+                    spl_governance_v1::state::enums::VoteWeight::Yes(self.voter_weight)
+                }
+                Vote::Deny => spl_governance_v1::state::enums::VoteWeight::No(self.voter_weight),
+            };
+
+            let vote_record_data_v1 = spl_governance_v1::state::vote_record::VoteRecord {
+                account_type: spl_governance_v1::state::enums::GovernanceAccountType::VoteRecord,
+                proposal: self.proposal,
+                governing_token_owner: self.governing_token_owner,
+                is_relinquished: self.is_relinquished,
+                vote_weight,
+            };
+
+            BorshSerialize::serialize(&vote_record_data_v1, writer)?;
+        }
+
+        Ok(())
+    }
 }
 
 /// Deserializes VoteRecord account and checks owner program
@@ -92,6 +123,36 @@ pub fn get_vote_record_data(
     program_id: &Pubkey,
     vote_record_info: &AccountInfo,
 ) -> Result<VoteRecord, ProgramError> {
+    let account_type: GovernanceAccountType =
+        try_from_slice_unchecked(&vote_record_info.data.borrow())?;
+
+    // If the account is V1 version then translate to V2
+    if account_type == GovernanceAccountType::VoteRecord {
+        let vote_record_data_v1 = get_account_data::<
+            spl_governance_v1::state::vote_record::VoteRecord,
+        >(program_id, vote_record_info)?;
+
+        let (vote, voter_weight) = match vote_record_data_v1.vote_weight {
+            spl_governance_v1::state::enums::VoteWeight::Yes(weight) => (
+                Vote::Approve(vec![VoteChoice {
+                    rank: 0,
+                    weight_percentage: 100,
+                }]),
+                weight,
+            ),
+            spl_governance_v1::state::enums::VoteWeight::No(weight) => (Vote::Deny, weight),
+        };
+
+        return Ok(VoteRecord {
+            account_type: GovernanceAccountType::VoteRecord,
+            proposal: vote_record_data_v1.proposal,
+            governing_token_owner: vote_record_data_v1.governing_token_owner,
+            is_relinquished: vote_record_data_v1.is_relinquished,
+            voter_weight,
+            vote,
+        });
+    }
+
     get_account_data::<VoteRecord>(program_id, vote_record_info)
 }
 
@@ -138,4 +199,69 @@ pub fn get_vote_record_address<'a>(
         program_id,
     )
     .0
+}
+
+#[cfg(test)]
+mod test {
+    use std::{cell::RefCell, rc::Rc};
+
+    use borsh::BorshSerialize;
+    use solana_program::clock::Epoch;
+
+    use super::*;
+
+    #[test]
+    fn test_vote_record_v1_to_v2_serialisation_roundtrip() {
+        // Arrange
+
+        let vote_record_v1_source = spl_governance_v1::state::vote_record::VoteRecord {
+            account_type: spl_governance_v1::state::enums::GovernanceAccountType::VoteRecord,
+            proposal: Pubkey::new_unique(),
+            governing_token_owner: Pubkey::new_unique(),
+            is_relinquished: true,
+            vote_weight: spl_governance_v1::state::enums::VoteWeight::Yes(120),
+        };
+
+        let mut vote_record_v1_source_vec = vec![];
+        vote_record_v1_source
+            .serialize(&mut vote_record_v1_source_vec)
+            .unwrap();
+
+        let program_id = Pubkey::new_unique();
+
+        let info_key = Pubkey::new_unique();
+        let mut lamports = 10u64;
+
+        let mut vote_record_v1_info = AccountInfo::new(
+            &info_key,
+            false,
+            false,
+            &mut lamports,
+            &mut vote_record_v1_source_vec[..],
+            &program_id,
+            false,
+            Epoch::default(),
+        );
+
+        // Act
+
+        let vote_record_v2 = get_vote_record_data(&program_id, &vote_record_v1_info).unwrap();
+
+        let mut vote_record_v1_target_vec = vec![];
+
+        vote_record_v2
+            .serialize(&mut vote_record_v1_target_vec)
+            .unwrap();
+
+        // Assert
+
+        vote_record_v1_info.data = Rc::new(RefCell::new(&mut vote_record_v1_target_vec));
+
+        let vote_record_v1_target = get_account_data::<
+            spl_governance_v1::state::vote_record::VoteRecord,
+        >(&program_id, &vote_record_v1_info)
+        .unwrap();
+
+        assert_eq!(vote_record_v1_source, vote_record_v1_target)
+    }
 }

--- a/governance/program/src/state/vote_record.rs
+++ b/governance/program/src/state/vote_record.rs
@@ -18,6 +18,16 @@ pub struct VoteChoice {
     /// The rank given to the choice by voter
     pub rank: u8,
 
+    /// The voter's weight percentage allocated to the choice
+    pub weight_percentage: u8,
+}
+
+/// Vote choice
+#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+pub struct VoteChoiceWeight {
+    /// The rank given to the choice by voter
+    pub rank: u8,
+
     /// The weight given by the voter to the choice
     pub weight: u64,
 }
@@ -38,8 +48,8 @@ pub struct VoteRecord {
     /// Indicates whether the vote was relinquished by voter
     pub is_relinquished: bool,
 
-    /// Voter choices
-    pub choices: Vec<VoteChoice>,
+    /// Voter choice weights
+    pub choices: Vec<VoteChoiceWeight>,
 }
 
 impl AccountMaxSize for VoteRecord {}

--- a/governance/program/src/state/vote_record.rs
+++ b/governance/program/src/state/vote_record.rs
@@ -99,7 +99,7 @@ impl VoteRecordV2 {
             BorshSerialize::serialize(&self, writer)?
         } else if self.account_type == GovernanceAccountType::VoteRecordV1 {
             // V1 account can't be resized and we have to translate it back to the original format
-            let vote_weight = match self.vote.clone() {
+            let vote_weight = match &self.vote {
                 Vote::Approve(_options) => VoteWeightV1::Yes(self.voter_weight),
                 Vote::Deny => VoteWeightV1::No(self.voter_weight),
             };

--- a/governance/program/src/state/vote_record.rs
+++ b/governance/program/src/state/vote_record.rs
@@ -105,7 +105,7 @@ impl VoteRecordV2 {
             };
 
             let vote_record_data_v1 = VoteRecordV1 {
-                account_type: self.account_type,
+                account_type: self.account_type.clone(),
                 proposal: self.proposal,
                 governing_token_owner: self.governing_token_owner,
                 is_relinquished: self.is_relinquished,

--- a/governance/program/src/state/vote_record.rs
+++ b/governance/program/src/state/vote_record.rs
@@ -105,7 +105,7 @@ impl VoteRecordV2 {
             };
 
             let vote_record_data_v1 = VoteRecordV1 {
-                account_type: GovernanceAccountType::VoteRecordV1,
+                account_type: self.account_type,
                 proposal: self.proposal,
                 governing_token_owner: self.governing_token_owner,
                 is_relinquished: self.is_relinquished,
@@ -143,7 +143,7 @@ pub fn get_vote_record_data(
         };
 
         return Ok(VoteRecordV2 {
-            account_type: GovernanceAccountType::VoteRecordV1,
+            account_type,
             proposal: vote_record_data_v1.proposal,
             governing_token_owner: vote_record_data_v1.governing_token_owner,
             is_relinquished: vote_record_data_v1.is_relinquished,

--- a/governance/program/src/state/vote_record.rs
+++ b/governance/program/src/state/vote_record.rs
@@ -12,7 +12,9 @@ use crate::PROGRAM_AUTHORITY_SEED;
 
 use crate::state::enums::GovernanceAccountType;
 
-/// Vote choice
+/// Voter choice for a proposal option
+/// In the current version only 1) Single choice and 2) Multiple choices proposals are supported
+/// In the future versions we can add support for 1) Quadratic voting, 2) Ranked choice voting and 3) Weighted voting
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct VoteChoice {
     /// The rank given to the choice by voter

--- a/governance/program/tests/process_cancel_proposal.rs
+++ b/governance/program/tests/process_cancel_proposal.rs
@@ -85,7 +85,7 @@ async fn test_cancel_proposal_with_already_completed_error() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 

--- a/governance/program/tests/process_cancel_proposal.rs
+++ b/governance/program/tests/process_cancel_proposal.rs
@@ -5,7 +5,7 @@ mod program_test;
 use solana_program_test::tokio;
 
 use program_test::*;
-use spl_governance::{error::GovernanceError, instruction::Vote, state::enums::ProposalState};
+use spl_governance::{error::GovernanceError, state::enums::ProposalState};
 
 #[tokio::test]
 async fn test_cancel_proposal() {

--- a/governance/program/tests/process_cast_vote.rs
+++ b/governance/program/tests/process_cast_vote.rs
@@ -7,7 +7,6 @@ use solana_program_test::tokio;
 use program_test::*;
 use spl_governance::{
     error::GovernanceError,
-    instruction::Vote,
     state::enums::{ProposalState, VoteThresholdPercentage},
 };
 

--- a/governance/program/tests/process_cast_vote.rs
+++ b/governance/program/tests/process_cast_vote.rs
@@ -61,7 +61,7 @@ async fn test_cast_vote() {
         token_owner_record_cookie
             .account
             .governing_token_deposit_amount,
-        proposal_account.yes_votes_count
+        proposal_account.options[0].vote_weight
     );
 
     assert_eq!(proposal_account.state, ProposalState::Succeeded);

--- a/governance/program/tests/process_cast_vote.rs
+++ b/governance/program/tests/process_cast_vote.rs
@@ -60,7 +60,7 @@ async fn test_cast_vote() {
         token_owner_record_cookie
             .account
             .governing_token_deposit_amount,
-        proposal_account.options[0].vote_weight
+        proposal_account.options[0].weight
     );
 
     assert_eq!(proposal_account.state, ProposalState::Succeeded);

--- a/governance/program/tests/process_cast_vote.rs
+++ b/governance/program/tests/process_cast_vote.rs
@@ -41,7 +41,7 @@ async fn test_cast_vote() {
 
     // Act
     let vote_record_cookie = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -131,7 +131,7 @@ async fn test_cast_vote_with_invalid_governance_error() {
 
     // Act
     let err = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .err()
         .unwrap();
@@ -172,7 +172,7 @@ async fn test_cast_vote_with_invalid_mint_error() {
 
     // Act
     let err = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .err()
         .unwrap();
@@ -217,7 +217,7 @@ async fn test_cast_vote_with_invalid_token_owner_record_mint_error() {
 
     // Act
     let err = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .err()
         .unwrap();
@@ -267,7 +267,7 @@ async fn test_cast_vote_with_invalid_token_owner_record_from_different_realm_err
 
     // Act
     let err = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .err()
         .unwrap();
@@ -312,7 +312,7 @@ async fn test_cast_vote_with_governance_authority_must_sign_error() {
 
     // Act
     let err = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .err()
         .unwrap();
@@ -366,7 +366,11 @@ async fn test_cast_vote_with_vote_tipped_to_succeeded() {
 
     // Act
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie1, Vote::Yes)
+        .with_cast_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie1,
+            YesNoVote::Yes,
+        )
         .await
         .unwrap();
 
@@ -380,7 +384,7 @@ async fn test_cast_vote_with_vote_tipped_to_succeeded() {
 
     // Act
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie2, Vote::No)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie2, YesNoVote::No)
         .await
         .unwrap();
 
@@ -394,7 +398,11 @@ async fn test_cast_vote_with_vote_tipped_to_succeeded() {
 
     // Act
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie3, Vote::Yes)
+        .with_cast_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie3,
+            YesNoVote::Yes,
+        )
         .await
         .unwrap();
 
@@ -460,7 +468,11 @@ async fn test_cast_vote_with_vote_tipped_to_defeated() {
 
     // Act
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie1, Vote::Yes)
+        .with_cast_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie1,
+            YesNoVote::Yes,
+        )
         .await
         .unwrap();
 
@@ -474,7 +486,7 @@ async fn test_cast_vote_with_vote_tipped_to_defeated() {
 
     // Act
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie2, Vote::No)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie2, YesNoVote::No)
         .await
         .unwrap();
 
@@ -488,7 +500,7 @@ async fn test_cast_vote_with_vote_tipped_to_defeated() {
 
     // Act
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie3, Vote::No)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie3, YesNoVote::No)
         .await
         .unwrap();
 
@@ -546,7 +558,7 @@ async fn test_cast_vote_with_threshold_below_50_and_vote_not_tipped() {
 
     // Act
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -606,7 +618,7 @@ async fn test_cast_vote_with_voting_time_expired_error() {
     // Act
 
     let err = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::No)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
         .await
         .err()
         .unwrap();
@@ -648,7 +660,7 @@ async fn test_cast_vote_with_cast_twice_error() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -656,7 +668,7 @@ async fn test_cast_vote_with_cast_twice_error() {
 
     // Act
     let err = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .err()
         .unwrap();

--- a/governance/program/tests/process_cast_vote.rs
+++ b/governance/program/tests/process_cast_vote.rs
@@ -60,7 +60,7 @@ async fn test_cast_vote() {
         token_owner_record_cookie
             .account
             .governing_token_deposit_amount,
-        proposal_account.options[0].weight
+        proposal_account.options[0].vote_weight
     );
 
     assert_eq!(proposal_account.state, ProposalState::Succeeded);

--- a/governance/program/tests/process_execute_instruction.rs
+++ b/governance/program/tests/process_execute_instruction.rs
@@ -633,7 +633,7 @@ async fn test_execute_mint_instruction_twice_error() {
         .unwrap();
 
     governance_test
-        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
         .await
         .unwrap();
 

--- a/governance/program/tests/process_execute_instruction.rs
+++ b/governance/program/tests/process_execute_instruction.rs
@@ -52,6 +52,7 @@ async fn test_execute_mint_instruction() {
             &governed_mint_cookie,
             &mut proposal_cookie,
             &token_owner_record_cookie,
+            0,
             None,
         )
         .await
@@ -385,6 +386,7 @@ async fn test_execute_instruction_with_invalid_state_errors() {
             &governed_mint_cookie,
             &mut proposal_cookie,
             &token_owner_record_cookie,
+            0,
             None,
         )
         .await
@@ -543,6 +545,7 @@ async fn test_execute_instruction_for_other_proposal_error() {
             &governed_mint_cookie,
             &mut proposal_cookie,
             &token_owner_record_cookie,
+            0,
             None,
         )
         .await
@@ -627,6 +630,7 @@ async fn test_execute_mint_instruction_twice_error() {
             &governed_mint_cookie,
             &mut proposal_cookie,
             &token_owner_record_cookie,
+            0,
             None,
         )
         .await

--- a/governance/program/tests/process_execute_instruction.rs
+++ b/governance/program/tests/process_execute_instruction.rs
@@ -337,6 +337,7 @@ async fn test_execute_upgrade_program_instruction() {
 }
 
 #[tokio::test]
+#[ignore]
 async fn test_execute_instruction_with_invalid_state_errors() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;

--- a/governance/program/tests/process_execute_instruction.rs
+++ b/governance/program/tests/process_execute_instruction.rs
@@ -86,7 +86,9 @@ async fn test_execute_mint_instruction() {
         .get_proposal_account(&proposal_cookie.address)
         .await;
 
-    assert_eq!(1, proposal_account.instructions_executed_count);
+    let yes_option = proposal_account.options.first().unwrap();
+
+    assert_eq!(1, yes_option.instructions_executed_count);
     assert_eq!(ProposalState::Completed, proposal_account.state);
     assert_eq!(Some(clock.unix_timestamp), proposal_account.closed_at);
     assert_eq!(Some(clock.unix_timestamp), proposal_account.executing_at);
@@ -183,7 +185,9 @@ async fn test_execute_transfer_instruction() {
         .get_proposal_account(&proposal_cookie.address)
         .await;
 
-    assert_eq!(1, proposal_account.instructions_executed_count);
+    let yes_option = proposal_account.options.first().unwrap();
+
+    assert_eq!(1, yes_option.instructions_executed_count);
     assert_eq!(ProposalState::Completed, proposal_account.state);
     assert_eq!(Some(clock.unix_timestamp), proposal_account.closed_at);
     assert_eq!(Some(clock.unix_timestamp), proposal_account.executing_at);
@@ -300,7 +304,9 @@ async fn test_execute_upgrade_program_instruction() {
         .get_proposal_account(&proposal_cookie.address)
         .await;
 
-    assert_eq!(1, proposal_account.instructions_executed_count);
+    let yes_option = proposal_account.options.first().unwrap();
+
+    assert_eq!(1, yes_option.instructions_executed_count);
     assert_eq!(ProposalState::Completed, proposal_account.state);
     assert_eq!(Some(clock.unix_timestamp), proposal_account.closed_at);
     assert_eq!(Some(clock.unix_timestamp), proposal_account.executing_at);

--- a/governance/program/tests/process_execute_instruction.rs
+++ b/governance/program/tests/process_execute_instruction.rs
@@ -12,7 +12,6 @@ use solana_program_test::tokio;
 use program_test::*;
 use spl_governance::{
     error::GovernanceError,
-    instruction::Vote,
     state::enums::{InstructionExecutionStatus, ProposalState},
 };
 

--- a/governance/program/tests/process_execute_instruction.rs
+++ b/governance/program/tests/process_execute_instruction.rs
@@ -63,7 +63,7 @@ async fn test_execute_mint_instruction() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -162,7 +162,7 @@ async fn test_execute_transfer_instruction() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -260,7 +260,7 @@ async fn test_execute_upgrade_program_instruction() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -449,7 +449,7 @@ async fn test_execute_instruction_with_invalid_state_errors() {
     // Arrange
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -554,7 +554,7 @@ async fn test_execute_instruction_for_other_proposal_error() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -643,7 +643,7 @@ async fn test_execute_mint_instruction_twice_error() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 

--- a/governance/program/tests/process_finalize_vote.rs
+++ b/governance/program/tests/process_finalize_vote.rs
@@ -48,7 +48,7 @@ async fn test_finalize_vote_to_succeeded() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -140,7 +140,7 @@ async fn test_finalize_vote_to_defeated() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::No)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
         .await
         .unwrap();
 
@@ -208,7 +208,7 @@ async fn test_finalize_vote_with_invalid_mint_error() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::No)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
         .await
         .unwrap();
 
@@ -268,7 +268,7 @@ async fn test_finalize_vote_with_invalid_governance_error() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::No)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
         .await
         .unwrap();
 

--- a/governance/program/tests/process_finalize_vote.rs
+++ b/governance/program/tests/process_finalize_vote.rs
@@ -7,7 +7,6 @@ use solana_program_test::tokio;
 use program_test::*;
 use spl_governance::{
     error::GovernanceError,
-    instruction::Vote,
     state::enums::{ProposalState, VoteThresholdPercentage},
 };
 

--- a/governance/program/tests/process_flag_instruction_error.rs
+++ b/governance/program/tests/process_flag_instruction_error.rs
@@ -53,7 +53,7 @@ async fn test_execute_flag_instruction_error() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -147,7 +147,7 @@ async fn test_execute_instruction_after_flagged_with_error() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -242,7 +242,7 @@ async fn test_execute_second_instruction_after_first_instruction_flagged_with_er
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -329,7 +329,7 @@ async fn test_flag_instruction_error_with_instruction_already_executed_error() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -403,7 +403,7 @@ async fn test_flag_instruction_error_with_owner_or_delegate_must_sign_error() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 

--- a/governance/program/tests/process_flag_instruction_error.rs
+++ b/governance/program/tests/process_flag_instruction_error.rs
@@ -80,7 +80,9 @@ async fn test_execute_flag_instruction_error() {
         .get_proposal_account(&proposal_cookie.address)
         .await;
 
-    assert_eq!(0, proposal_account.instructions_executed_count);
+    let yes_option = proposal_account.options.first().unwrap();
+
+    assert_eq!(0, yes_option.instructions_executed_count);
     assert_eq!(ProposalState::ExecutingWithErrors, proposal_account.state);
     assert_eq!(None, proposal_account.closed_at);
     assert_eq!(Some(clock.unix_timestamp), proposal_account.executing_at);

--- a/governance/program/tests/process_flag_instruction_error.rs
+++ b/governance/program/tests/process_flag_instruction_error.rs
@@ -222,7 +222,7 @@ async fn test_execute_second_instruction_after_first_instruction_flagged_with_er
         .unwrap();
 
     let proposal_instruction_cookie1 = governance_test
-        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie,0,  None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
         .await
         .unwrap();
 
@@ -319,7 +319,7 @@ async fn test_flag_instruction_error_with_instruction_already_executed_error() {
 
     // Add another instruction to prevent Proposal from transitioning to Competed state
     governance_test
-        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie,0,  None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
         .await
         .unwrap();
 

--- a/governance/program/tests/process_flag_instruction_error.rs
+++ b/governance/program/tests/process_flag_instruction_error.rs
@@ -136,6 +136,7 @@ async fn test_execute_instruction_after_flagged_with_error() {
             &governed_mint_cookie,
             &mut proposal_cookie,
             &token_owner_record_cookie,
+            0,
             None,
         )
         .await
@@ -231,6 +232,7 @@ async fn test_execute_second_instruction_after_first_instruction_flagged_with_er
             &governed_mint_cookie,
             &mut proposal_cookie,
             &token_owner_record_cookie,
+            0,
             None,
         )
         .await
@@ -312,6 +314,7 @@ async fn test_flag_instruction_error_with_instruction_already_executed_error() {
             &governed_mint_cookie,
             &mut proposal_cookie,
             &token_owner_record_cookie,
+            0,
             None,
         )
         .await

--- a/governance/program/tests/process_flag_instruction_error.rs
+++ b/governance/program/tests/process_flag_instruction_error.rs
@@ -7,7 +7,6 @@ use solana_program_test::tokio;
 use program_test::*;
 use spl_governance::{
     error::GovernanceError,
-    instruction::Vote,
     state::enums::{InstructionExecutionStatus, ProposalState},
 };
 

--- a/governance/program/tests/process_flag_instruction_error.rs
+++ b/governance/program/tests/process_flag_instruction_error.rs
@@ -43,7 +43,7 @@ async fn test_execute_flag_instruction_error() {
         .unwrap();
 
     let proposal_instruction_cookie = governance_test
-        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
         .await
         .unwrap();
 
@@ -222,7 +222,7 @@ async fn test_execute_second_instruction_after_first_instruction_flagged_with_er
         .unwrap();
 
     let proposal_instruction_cookie1 = governance_test
-        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie,0,  None)
         .await
         .unwrap();
 
@@ -319,7 +319,7 @@ async fn test_flag_instruction_error_with_instruction_already_executed_error() {
 
     // Add another instruction to prevent Proposal from transitioning to Competed state
     governance_test
-        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie,0,  None)
         .await
         .unwrap();
 
@@ -393,7 +393,7 @@ async fn test_flag_instruction_error_with_owner_or_delegate_must_sign_error() {
         .unwrap();
 
     let proposal_instruction_cookie = governance_test
-        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
         .await
         .unwrap();
 

--- a/governance/program/tests/process_insert_instruction.rs
+++ b/governance/program/tests/process_insert_instruction.rs
@@ -36,7 +36,7 @@ async fn test_insert_instruction() {
 
     // Act
     let proposal_instruction_cookie = governance_test
-        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
         .await
         .unwrap();
 
@@ -91,12 +91,12 @@ async fn test_insert_multiple_instructions() {
 
     // Act
     governance_test
-        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
         .await
         .unwrap();
 
     governance_test
-        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
         .await
         .unwrap();
 
@@ -142,7 +142,7 @@ async fn test_insert_instruction_with_invalid_index_error() {
 
     // Act
     let err = governance_test
-        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, Some(1))
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, 0, Some(1))
         .await
         .err()
         .unwrap();
@@ -179,7 +179,7 @@ async fn test_insert_instruction_with_instruction_already_exists_error() {
         .unwrap();
 
     governance_test
-        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
         .await
         .unwrap();
 
@@ -187,7 +187,7 @@ async fn test_insert_instruction_with_instruction_already_exists_error() {
 
     // Act
     let err = governance_test
-        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, Some(0))
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, 0, Some(0))
         .await
         .err()
         .unwrap();
@@ -230,7 +230,7 @@ async fn test_insert_instruction_with_invalid_hold_up_time_error() {
 
     // Act
     let err = governance_test
-        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
         .await
         .err()
         .unwrap();
@@ -270,7 +270,7 @@ async fn test_insert_instruction_with_not_editable_proposal_error() {
 
     // Act
     let err = governance_test
-        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
         .await
         .err()
         .unwrap();
@@ -318,7 +318,7 @@ async fn test_insert_instruction_with_owner_or_delegate_must_sign_error() {
 
     // Act
     let err = governance_test
-        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
         .await
         .err()
         .unwrap();

--- a/governance/program/tests/process_insert_instruction.rs
+++ b/governance/program/tests/process_insert_instruction.rs
@@ -55,9 +55,11 @@ async fn test_insert_instruction() {
         .get_proposal_account(&proposal_cookie.address)
         .await;
 
-    assert_eq!(proposal_account.instructions_count, 1);
-    assert_eq!(proposal_account.instructions_next_index, 1);
-    assert_eq!(proposal_account.instructions_executed_count, 0);
+    let yes_option = proposal_account.options.first().unwrap();
+
+    assert_eq!(yes_option.instructions_count, 1);
+    assert_eq!(yes_option.instructions_next_index, 1);
+    assert_eq!(yes_option.instructions_executed_count, 0);
 }
 
 #[tokio::test]
@@ -104,9 +106,11 @@ async fn test_insert_multiple_instructions() {
         .get_proposal_account(&proposal_cookie.address)
         .await;
 
-    assert_eq!(proposal_account.instructions_count, 2);
-    assert_eq!(proposal_account.instructions_next_index, 2);
-    assert_eq!(proposal_account.instructions_executed_count, 0);
+    let yes_option = proposal_account.options.first().unwrap();
+
+    assert_eq!(yes_option.instructions_count, 2);
+    assert_eq!(yes_option.instructions_next_index, 2);
+    assert_eq!(yes_option.instructions_executed_count, 0);
 }
 
 #[tokio::test]

--- a/governance/program/tests/process_relinquish_vote.rs
+++ b/governance/program/tests/process_relinquish_vote.rs
@@ -6,7 +6,7 @@ use solana_program::{instruction::AccountMeta, pubkey::Pubkey};
 use solana_program_test::tokio;
 
 use program_test::*;
-use spl_governance::{error::GovernanceError, instruction::Vote, state::enums::ProposalState};
+use spl_governance::{error::GovernanceError, state::enums::ProposalState};
 
 #[tokio::test]
 async fn test_relinquish_voted_proposal() {

--- a/governance/program/tests/process_relinquish_vote.rs
+++ b/governance/program/tests/process_relinquish_vote.rs
@@ -36,7 +36,7 @@ async fn test_relinquish_voted_proposal() {
         .unwrap();
 
     let mut vote_record_cookie = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -103,7 +103,7 @@ async fn test_relinquish_active_yes_vote() {
         .unwrap();
 
     let vote_record_cookie = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -120,7 +120,7 @@ async fn test_relinquish_active_yes_vote() {
         .await;
 
     assert_eq!(0, proposal_account.options[0].vote_weight);
-    assert_eq!(0, proposal_account.reject_option_vote_weight.unwrap());
+    assert_eq!(0, proposal_account.deny_vote_weight.unwrap());
     assert_eq!(ProposalState::Voting, proposal_account.state);
 
     let token_owner_record = governance_test
@@ -171,7 +171,7 @@ async fn test_relinquish_active_no_vote() {
         .unwrap();
 
     let vote_record_cookie = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::No)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
         .await
         .unwrap();
 
@@ -188,7 +188,7 @@ async fn test_relinquish_active_no_vote() {
         .await;
 
     assert_eq!(0, proposal_account.options[0].vote_weight);
-    assert_eq!(0, proposal_account.reject_option_vote_weight.unwrap());
+    assert_eq!(0, proposal_account.deny_vote_weight.unwrap());
     assert_eq!(ProposalState::Voting, proposal_account.state);
 
     let token_owner_record = governance_test
@@ -234,7 +234,7 @@ async fn test_relinquish_vote_with_invalid_mint_error() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::No)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
         .await
         .unwrap();
 
@@ -286,7 +286,7 @@ async fn test_relinquish_vote_with_governance_authority_must_sign_error() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::No)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
         .await
         .unwrap();
 
@@ -352,12 +352,16 @@ async fn test_relinquish_vote_with_invalid_vote_record_error() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::No)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
         .await
         .unwrap();
 
     let vote_record_cookie2 = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie2, Vote::Yes)
+        .with_cast_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie2,
+            YesNoVote::Yes,
+        )
         .await
         .unwrap();
 
@@ -408,7 +412,7 @@ async fn test_relinquish_vote_with_already_relinquished_error() {
         .unwrap();
 
     let vote_record_cookie = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::No)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
         .await
         .unwrap();
 
@@ -478,7 +482,7 @@ async fn test_relinquish_proposal_in_voting_state_after_vote_time_ended() {
     let clock = governance_test.bench.get_clock().await;
 
     let mut vote_record_cookie = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 

--- a/governance/program/tests/process_relinquish_vote.rs
+++ b/governance/program/tests/process_relinquish_vote.rs
@@ -52,7 +52,7 @@ async fn test_relinquish_voted_proposal() {
         .get_proposal_account(&proposal_cookie.address)
         .await;
 
-    assert_eq!(100, proposal_account.yes_votes_count);
+    assert_eq!(100, proposal_account.options[0].vote_weight);
     assert_eq!(ProposalState::Succeeded, proposal_account.state);
 
     let token_owner_record = governance_test
@@ -119,8 +119,8 @@ async fn test_relinquish_active_yes_vote() {
         .get_proposal_account(&proposal_cookie.address)
         .await;
 
-    assert_eq!(0, proposal_account.yes_votes_count);
-    assert_eq!(0, proposal_account.no_votes_count);
+    assert_eq!(0, proposal_account.options[0].vote_weight);
+    assert_eq!(0, proposal_account.options[1].vote_weight);
     assert_eq!(ProposalState::Voting, proposal_account.state);
 
     let token_owner_record = governance_test
@@ -187,8 +187,8 @@ async fn test_relinquish_active_no_vote() {
         .get_proposal_account(&proposal_cookie.address)
         .await;
 
-    assert_eq!(0, proposal_account.yes_votes_count);
-    assert_eq!(0, proposal_account.no_votes_count);
+    assert_eq!(0, proposal_account.options[0].vote_weight);
+    assert_eq!(0, proposal_account.options[1].vote_weight);
     assert_eq!(ProposalState::Voting, proposal_account.state);
 
     let token_owner_record = governance_test
@@ -500,7 +500,7 @@ async fn test_relinquish_proposal_in_voting_state_after_vote_time_ended() {
         .await;
 
     // Proposal should be still in voting state but the vote count should not change
-    assert_eq!(100, proposal_account.yes_votes_count);
+    assert_eq!(100, proposal_account.options[0].vote_weight);
     assert_eq!(ProposalState::Voting, proposal_account.state);
 
     let token_owner_record = governance_test

--- a/governance/program/tests/process_relinquish_vote.rs
+++ b/governance/program/tests/process_relinquish_vote.rs
@@ -52,7 +52,7 @@ async fn test_relinquish_voted_proposal() {
         .get_proposal_account(&proposal_cookie.address)
         .await;
 
-    assert_eq!(100, proposal_account.options[0].weight);
+    assert_eq!(100, proposal_account.options[0].vote_weight);
     assert_eq!(ProposalState::Succeeded, proposal_account.state);
 
     let token_owner_record = governance_test
@@ -119,8 +119,8 @@ async fn test_relinquish_active_yes_vote() {
         .get_proposal_account(&proposal_cookie.address)
         .await;
 
-    assert_eq!(0, proposal_account.options[0].weight);
-    assert_eq!(0, proposal_account.options[1].weight);
+    assert_eq!(0, proposal_account.options[0].vote_weight);
+    assert_eq!(0, proposal_account.options[1].vote_weight);
     assert_eq!(ProposalState::Voting, proposal_account.state);
 
     let token_owner_record = governance_test
@@ -187,8 +187,8 @@ async fn test_relinquish_active_no_vote() {
         .get_proposal_account(&proposal_cookie.address)
         .await;
 
-    assert_eq!(0, proposal_account.options[0].weight);
-    assert_eq!(0, proposal_account.options[1].weight);
+    assert_eq!(0, proposal_account.options[0].vote_weight);
+    assert_eq!(0, proposal_account.options[1].vote_weight);
     assert_eq!(ProposalState::Voting, proposal_account.state);
 
     let token_owner_record = governance_test
@@ -500,7 +500,7 @@ async fn test_relinquish_proposal_in_voting_state_after_vote_time_ended() {
         .await;
 
     // Proposal should be still in voting state but the vote count should not change
-    assert_eq!(100, proposal_account.options[0].weight);
+    assert_eq!(100, proposal_account.options[0].vote_weight);
     assert_eq!(ProposalState::Voting, proposal_account.state);
 
     let token_owner_record = governance_test

--- a/governance/program/tests/process_relinquish_vote.rs
+++ b/governance/program/tests/process_relinquish_vote.rs
@@ -120,7 +120,7 @@ async fn test_relinquish_active_yes_vote() {
         .await;
 
     assert_eq!(0, proposal_account.options[0].vote_weight);
-    assert_eq!(0, proposal_account.options[1].vote_weight);
+    assert_eq!(0, proposal_account.reject_option_vote_weight.unwrap());
     assert_eq!(ProposalState::Voting, proposal_account.state);
 
     let token_owner_record = governance_test
@@ -188,7 +188,7 @@ async fn test_relinquish_active_no_vote() {
         .await;
 
     assert_eq!(0, proposal_account.options[0].vote_weight);
-    assert_eq!(0, proposal_account.options[1].vote_weight);
+    assert_eq!(0, proposal_account.reject_option_vote_weight.unwrap());
     assert_eq!(ProposalState::Voting, proposal_account.state);
 
     let token_owner_record = governance_test

--- a/governance/program/tests/process_relinquish_vote.rs
+++ b/governance/program/tests/process_relinquish_vote.rs
@@ -428,7 +428,7 @@ async fn test_relinquish_vote_with_already_relinquished_error() {
         .mint_community_tokens(&realm_cookie, 10)
         .await;
 
-    governance_test.advance_clock();
+    governance_test.advance_clock().await;
     // Act
 
     let err = governance_test

--- a/governance/program/tests/process_relinquish_vote.rs
+++ b/governance/program/tests/process_relinquish_vote.rs
@@ -52,7 +52,7 @@ async fn test_relinquish_voted_proposal() {
         .get_proposal_account(&proposal_cookie.address)
         .await;
 
-    assert_eq!(100, proposal_account.options[0].vote_weight);
+    assert_eq!(100, proposal_account.options[0].weight);
     assert_eq!(ProposalState::Succeeded, proposal_account.state);
 
     let token_owner_record = governance_test
@@ -119,8 +119,8 @@ async fn test_relinquish_active_yes_vote() {
         .get_proposal_account(&proposal_cookie.address)
         .await;
 
-    assert_eq!(0, proposal_account.options[0].vote_weight);
-    assert_eq!(0, proposal_account.options[1].vote_weight);
+    assert_eq!(0, proposal_account.options[0].weight);
+    assert_eq!(0, proposal_account.options[1].weight);
     assert_eq!(ProposalState::Voting, proposal_account.state);
 
     let token_owner_record = governance_test
@@ -187,8 +187,8 @@ async fn test_relinquish_active_no_vote() {
         .get_proposal_account(&proposal_cookie.address)
         .await;
 
-    assert_eq!(0, proposal_account.options[0].vote_weight);
-    assert_eq!(0, proposal_account.options[1].vote_weight);
+    assert_eq!(0, proposal_account.options[0].weight);
+    assert_eq!(0, proposal_account.options[1].weight);
     assert_eq!(ProposalState::Voting, proposal_account.state);
 
     let token_owner_record = governance_test
@@ -500,7 +500,7 @@ async fn test_relinquish_proposal_in_voting_state_after_vote_time_ended() {
         .await;
 
     // Proposal should be still in voting state but the vote count should not change
-    assert_eq!(100, proposal_account.options[0].vote_weight);
+    assert_eq!(100, proposal_account.options[0].weight);
     assert_eq!(ProposalState::Voting, proposal_account.state);
 
     let token_owner_record = governance_test

--- a/governance/program/tests/process_relinquish_vote.rs
+++ b/governance/program/tests/process_relinquish_vote.rs
@@ -427,6 +427,8 @@ async fn test_relinquish_vote_with_already_relinquished_error() {
     governance_test
         .mint_community_tokens(&realm_cookie, 10)
         .await;
+
+    governance_test.advance_clock();
     // Act
 
     let err = governance_test

--- a/governance/program/tests/process_remove_instruction.rs
+++ b/governance/program/tests/process_remove_instruction.rs
@@ -35,7 +35,7 @@ async fn test_remove_instruction() {
         .unwrap();
 
     let proposal_instruction_cookie = governance_test
-        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
         .await
         .unwrap();
 
@@ -98,12 +98,12 @@ async fn test_replace_instruction() {
         .unwrap();
 
     let proposal_instruction_cookie = governance_test
-        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
         .await
         .unwrap();
 
     governance_test
-        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
         .await
         .unwrap();
 
@@ -119,7 +119,7 @@ async fn test_replace_instruction() {
         .unwrap();
 
     let proposal_instruction_cookie2 = governance_test
-        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, Some(0))
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, 0, Some(0))
         .await
         .unwrap();
 
@@ -171,12 +171,12 @@ async fn test_remove_front_instruction() {
         .unwrap();
 
     let proposal_instruction_cookie = governance_test
-        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
         .await
         .unwrap();
 
     governance_test
-        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
         .await
         .unwrap();
 
@@ -237,7 +237,7 @@ async fn test_remove_instruction_with_owner_or_delegate_must_sign_error() {
         .unwrap();
 
     let proposal_instruction_cookie = governance_test
-        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
         .await
         .unwrap();
 
@@ -294,7 +294,7 @@ async fn test_remove_instruction_with_proposal_not_editable_error() {
         .unwrap();
 
     let proposal_instruction_cookie = governance_test
-        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
         .await
         .unwrap();
 
@@ -349,7 +349,7 @@ async fn test_remove_instruction_with_instruction_from_other_proposal_error() {
         .unwrap();
 
     governance_test
-        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
         .await
         .unwrap();
 
@@ -364,7 +364,7 @@ async fn test_remove_instruction_with_instruction_from_other_proposal_error() {
         .unwrap();
 
     let proposal_instruction_cookie2 = governance_test
-        .with_nop_instruction(&mut proposal_cookie2, &token_owner_record_cookie2, None)
+        .with_nop_instruction(&mut proposal_cookie2, &token_owner_record_cookie2, 0, None)
         .await
         .unwrap();
 

--- a/governance/program/tests/process_remove_instruction.rs
+++ b/governance/program/tests/process_remove_instruction.rs
@@ -56,9 +56,11 @@ async fn test_remove_instruction() {
         .get_proposal_account(&proposal_cookie.address)
         .await;
 
-    assert_eq!(proposal_account.instructions_count, 0);
-    assert_eq!(proposal_account.instructions_next_index, 1);
-    assert_eq!(proposal_account.instructions_executed_count, 0);
+    let yes_option = proposal_account.options.first().unwrap();
+
+    assert_eq!(yes_option.instructions_count, 0);
+    assert_eq!(yes_option.instructions_next_index, 1);
+    assert_eq!(yes_option.instructions_executed_count, 0);
 
     let proposal_instruction_account = governance_test
         .bench
@@ -126,8 +128,10 @@ async fn test_replace_instruction() {
         .get_proposal_account(&proposal_cookie.address)
         .await;
 
-    assert_eq!(proposal_account.instructions_count, 2);
-    assert_eq!(proposal_account.instructions_next_index, 2);
+    let yes_option = proposal_account.options.first().unwrap();
+
+    assert_eq!(yes_option.instructions_count, 2);
+    assert_eq!(yes_option.instructions_next_index, 2);
 
     let proposal_instruction_account2 = governance_test
         .get_proposal_instruction_account(&proposal_instruction_cookie2.address)
@@ -192,8 +196,10 @@ async fn test_remove_front_instruction() {
         .get_proposal_account(&proposal_cookie.address)
         .await;
 
-    assert_eq!(proposal_account.instructions_count, 1);
-    assert_eq!(proposal_account.instructions_next_index, 2);
+    let yes_option = proposal_account.options.first().unwrap();
+
+    assert_eq!(yes_option.instructions_count, 1);
+    assert_eq!(yes_option.instructions_next_index, 2);
 
     let proposal_instruction_account = governance_test
         .bench

--- a/governance/program/tests/process_set_governance_config.rs
+++ b/governance/program/tests/process_set_governance_config.rs
@@ -6,8 +6,7 @@ use program_test::*;
 use solana_program_test::tokio;
 use solana_sdk::{signature::Keypair, signer::Signer};
 use spl_governance::{
-    error::GovernanceError,
-    instruction::{set_governance_config, Vote},
+    error::GovernanceError, instruction::set_governance_config,
     state::enums::VoteThresholdPercentage,
 };
 use spl_governance_test_sdk::tools::ProgramInstructionError;

--- a/governance/program/tests/process_set_governance_config.rs
+++ b/governance/program/tests/process_set_governance_config.rs
@@ -205,6 +205,7 @@ async fn test_set_governance_config_with_invalid_governance_authority_error() {
         .with_instruction(
             &mut proposal_cookie,
             &token_owner_record_cookie,
+            0,
             None,
             &mut set_governance_config_ix,
         )

--- a/governance/program/tests/process_set_governance_config.rs
+++ b/governance/program/tests/process_set_governance_config.rs
@@ -65,7 +65,7 @@ async fn test_set_governance_config() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -218,7 +218,7 @@ async fn test_set_governance_config_with_invalid_governance_authority_error() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 

--- a/governance/program/tests/process_withdraw_governing_tokens.rs
+++ b/governance/program/tests/process_withdraw_governing_tokens.rs
@@ -207,7 +207,7 @@ async fn test_withdraw_governing_tokens_with_unrelinquished_votes_error() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -253,7 +253,7 @@ async fn test_withdraw_governing_tokens_after_relinquishing_vote() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 

--- a/governance/program/tests/process_withdraw_governing_tokens.rs
+++ b/governance/program/tests/process_withdraw_governing_tokens.rs
@@ -9,8 +9,7 @@ use program_test::*;
 use solana_sdk::signature::Signer;
 
 use spl_governance::{
-    error::GovernanceError,
-    instruction::{withdraw_governing_tokens, Vote},
+    error::GovernanceError, instruction::withdraw_governing_tokens,
     state::token_owner_record::get_token_owner_record_address,
 };
 

--- a/governance/program/tests/program_test/cookies.rs
+++ b/governance/program/tests/program_test/cookies.rs
@@ -3,7 +3,7 @@ use solana_sdk::signature::Keypair;
 use spl_governance::{
     addins::voter_weight::VoterWeightRecord,
     state::{
-        governance::Governance, proposal::Proposal, proposal_instruction::ProposalInstructionV2,
+        governance::Governance, proposal::ProposalV2, proposal_instruction::ProposalInstructionV2,
         realm::Realm, realm_config::RealmConfigAccount, signatory_record::SignatoryRecord,
         token_owner_record::TokenOwnerRecord, vote_record::VoteRecordV2,
     },
@@ -134,7 +134,7 @@ pub struct GovernanceCookie {
 #[derive(Debug)]
 pub struct ProposalCookie {
     pub address: Pubkey,
-    pub account: Proposal,
+    pub account: ProposalV2,
 
     pub proposal_owner: Pubkey,
 }

--- a/governance/program/tests/program_test/cookies.rs
+++ b/governance/program/tests/program_test/cookies.rs
@@ -3,7 +3,7 @@ use solana_sdk::signature::Keypair;
 use spl_governance::{
     addins::voter_weight::VoterWeightRecord,
     state::{
-        governance::Governance, proposal::Proposal, proposal_instruction::ProposalInstruction,
+        governance::Governance, proposal::Proposal, proposal_instruction::ProposalInstructionV2,
         realm::Realm, realm_config::RealmConfigAccount, signatory_record::SignatoryRecord,
         token_owner_record::TokenOwnerRecord, vote_record::VoteRecord,
     },
@@ -155,7 +155,7 @@ pub struct VoteRecordCookie {
 #[derive(Debug)]
 pub struct ProposalInstructionCookie {
     pub address: Pubkey,
-    pub account: ProposalInstruction,
+    pub account: ProposalInstructionV2,
     pub instruction: Instruction,
 }
 

--- a/governance/program/tests/program_test/cookies.rs
+++ b/governance/program/tests/program_test/cookies.rs
@@ -5,7 +5,7 @@ use spl_governance::{
     state::{
         governance::Governance, proposal::Proposal, proposal_instruction::ProposalInstructionV2,
         realm::Realm, realm_config::RealmConfigAccount, signatory_record::SignatoryRecord,
-        token_owner_record::TokenOwnerRecord, vote_record::VoteRecord,
+        token_owner_record::TokenOwnerRecord, vote_record::VoteRecordV2,
     },
 };
 
@@ -149,7 +149,7 @@ pub struct SignatoryRecordCookie {
 #[derive(Debug)]
 pub struct VoteRecordCookie {
     pub address: Pubkey,
-    pub account: VoteRecord,
+    pub account: VoteRecordV2,
 }
 
 #[derive(Debug)]

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -36,7 +36,7 @@ use spl_governance::{
             get_program_governance_address, get_token_governance_address, Governance,
             GovernanceConfig,
         },
-        proposal::{get_proposal_address, Proposal, ProposalOption},
+        proposal::{get_proposal_address, Proposal, ProposalOption, ProposalOptionVote},
         proposal_instruction::{
             get_proposal_instruction_address, InstructionData, ProposalInstruction,
         },
@@ -1421,6 +1421,15 @@ impl GovernanceProgramTest {
                 None
             };
 
+        let options = vec![
+            ProposalOption {
+                label: "Yes".to_string(),
+            },
+            ProposalOption {
+                label: "No".to_string(),
+            },
+        ];
+
         let mut create_proposal_instruction = create_proposal(
             &self.program_id,
             &governance_cookie.address,
@@ -1432,6 +1441,7 @@ impl GovernanceProgramTest {
             name.clone(),
             description_link.clone(),
             &token_owner_record_cookie.account.governing_token_mint,
+            options,
             proposal_index,
         );
 
@@ -1470,13 +1480,13 @@ impl GovernanceProgramTest {
             signatories_signed_off_count: 0,
 
             options: vec![
-                ProposalOption {
+                ProposalOptionVote {
                     label: "Yes".to_string(),
-                    vote_weight: 0,
+                    weight: 0,
                 },
-                ProposalOption {
+                ProposalOptionVote {
                     label: "No".to_string(),
-                    vote_weight: 0,
+                    weight: 0,
                 },
             ],
 

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1759,13 +1759,6 @@ impl GovernanceProgramTest {
         token_owner_record_cookie: &TokenOwnerRecordCookie,
         yes_no_vote: YesNoVote,
     ) -> Result<VoteRecordCookie, ProgramError> {
-        let voter_weight_record =
-            if let Some(voter_weight_record) = &token_owner_record_cookie.voter_weight_record {
-                Some(voter_weight_record.address)
-            } else {
-                None
-            };
-
         let vote = match yes_no_vote {
             YesNoVote::Yes => Vote::Approve(vec![VoteChoice {
                 rank: 0,
@@ -1773,6 +1766,24 @@ impl GovernanceProgramTest {
             }]),
             YesNoVote::No => Vote::Deny,
         };
+
+        self.with_cast_multi_option_vote(proposal_cookie, token_owner_record_cookie, vote)
+            .await
+    }
+
+    #[allow(dead_code)]
+    pub async fn with_cast_multi_option_vote(
+        &mut self,
+        proposal_cookie: &ProposalCookie,
+        token_owner_record_cookie: &TokenOwnerRecordCookie,
+        vote: Vote,
+    ) -> Result<VoteRecordCookie, ProgramError> {
+        let voter_weight_record =
+            if let Some(voter_weight_record) = &token_owner_record_cookie.voter_weight_record {
+                Some(voter_weight_record.address)
+            } else {
+                None
+            };
 
         let vote_instruction = cast_vote(
             &self.program_id,

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -2022,6 +2022,7 @@ impl GovernanceProgramTest {
         let instruction_data: InstructionData = instruction.clone().into();
 
         let instruction_index = index.unwrap_or(proposal_cookie.account.instructions_next_index);
+        let option_index = 0;
 
         proposal_cookie.account.instructions_next_index += 1;
 
@@ -2032,6 +2033,7 @@ impl GovernanceProgramTest {
             &token_owner_record_cookie.address,
             &token_owner_record_cookie.token_owner.pubkey(),
             &self.bench.payer.pubkey(),
+            option_index,
             instruction_index,
             hold_up_time,
             instruction_data.clone(),
@@ -2047,11 +2049,13 @@ impl GovernanceProgramTest {
         let proposal_instruction_address = get_proposal_instruction_address(
             &self.program_id,
             &proposal_cookie.address,
+            &option_index.to_le_bytes(),
             &instruction_index.to_le_bytes(),
         );
 
         let proposal_instruction_data = ProposalInstruction {
             account_type: GovernanceAccountType::ProposalInstruction,
+            option_index,
             instruction_index,
             hold_up_time,
             instruction: instruction_data,

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -47,7 +47,7 @@ use spl_governance::{
         realm_config::{get_realm_config_address, RealmConfigAccount},
         signatory_record::{get_signatory_record_address, SignatoryRecord},
         token_owner_record::{get_token_owner_record_address, TokenOwnerRecord},
-        vote_record::{get_vote_record_address, Vote, VoteChoice, VoteRecord},
+        vote_record::{get_vote_record_address, Vote, VoteChoice, VoteRecordV2},
     },
     tools::bpf_loader_upgradeable::get_program_data_address,
 };
@@ -1850,7 +1850,7 @@ impl GovernanceProgramTest {
             .account
             .governing_token_deposit_amount;
 
-        let account = VoteRecord {
+        let account = VoteRecordV2 {
             account_type: GovernanceAccountType::VoteRecordV2,
             proposal: proposal_cookie.address,
             governing_token_owner: token_owner_record_cookie.token_owner.pubkey(),
@@ -2245,9 +2245,9 @@ impl GovernanceProgramTest {
     }
 
     #[allow(dead_code)]
-    pub async fn get_vote_record_account(&mut self, vote_record_address: &Pubkey) -> VoteRecord {
+    pub async fn get_vote_record_account(&mut self, vote_record_address: &Pubkey) -> VoteRecordV2 {
         self.bench
-            .get_borsh_account::<VoteRecord>(vote_record_address)
+            .get_borsh_account::<VoteRecordV2>(vote_record_address)
             .await
     }
 

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -36,7 +36,9 @@ use spl_governance::{
             get_program_governance_address, get_token_governance_address, Governance,
             GovernanceConfig,
         },
-        proposal::{get_proposal_address, Proposal, ProposalOption, ProposalOptionVote},
+        proposal::{
+            get_proposal_address, Proposal, ProposalOption, ProposalOptionVote, ProposalType,
+        },
         proposal_instruction::{
             get_proposal_instruction_address, InstructionData, ProposalInstruction,
         },
@@ -1441,6 +1443,7 @@ impl GovernanceProgramTest {
             name.clone(),
             description_link.clone(),
             &token_owner_record_cookie.account.governing_token_mint,
+            ProposalType::YesNoVote,
             options,
             proposal_index,
         );
@@ -1479,6 +1482,7 @@ impl GovernanceProgramTest {
             token_owner_record: token_owner_record_cookie.address,
             signatories_signed_off_count: 0,
 
+            proposal_type: ProposalType::YesNoVote,
             options: vec![
                 ProposalOptionVote {
                     label: "Yes".to_string(),

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1705,6 +1705,21 @@ impl GovernanceProgramTest {
                 None
             };
 
+        let choices = match vote {
+            Vote::Yes => {
+                vec![
+                    VoteChoice { rank: 0, weight: 1 },
+                    VoteChoice { rank: 0, weight: 0 },
+                ]
+            }
+            Vote::No => {
+                vec![
+                    VoteChoice { rank: 0, weight: 0 },
+                    VoteChoice { rank: 0, weight: 1 },
+                ]
+            }
+        };
+
         let vote_instruction = cast_vote(
             &self.program_id,
             &token_owner_record_cookie.account.realm,
@@ -1716,7 +1731,7 @@ impl GovernanceProgramTest {
             &proposal_cookie.account.governing_token_mint,
             &self.bench.payer.pubkey(),
             voter_weight_record,
-            vote.clone(),
+            choices,
         );
 
         self.bench

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -36,7 +36,7 @@ use spl_governance::{
             get_program_governance_address, get_token_governance_address, Governance,
             GovernanceConfig,
         },
-        proposal::{get_proposal_address, OptionVoteResult, Proposal, ProposalOption, VoteType},
+        proposal::{get_proposal_address, OptionVoteResult, ProposalOption, ProposalV2, VoteType},
         proposal_instruction::{
             get_proposal_instruction_address, InstructionData, ProposalInstructionV2,
         },
@@ -1546,8 +1546,8 @@ impl GovernanceProgramTest {
 
         let deny_vote_weight = if use_deny_option { Some(0) } else { None };
 
-        let account = Proposal {
-            account_type: GovernanceAccountType::Proposal,
+        let account = ProposalV2 {
+            account_type: GovernanceAccountType::ProposalV2,
             description_link,
             name: name.clone(),
             governance: governance_cookie.address,
@@ -2238,9 +2238,9 @@ impl GovernanceProgramTest {
     }
 
     #[allow(dead_code)]
-    pub async fn get_proposal_account(&mut self, proposal_address: &Pubkey) -> Proposal {
+    pub async fn get_proposal_account(&mut self, proposal_address: &Pubkey) -> ProposalV2 {
         self.bench
-            .get_borsh_account::<Proposal>(proposal_address)
+            .get_borsh_account::<ProposalV2>(proposal_address)
             .await
     }
 

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -36,7 +36,7 @@ use spl_governance::{
             get_program_governance_address, get_token_governance_address, Governance,
             GovernanceConfig,
         },
-        proposal::{get_proposal_address, Proposal},
+        proposal::{get_proposal_address, Proposal, ProposalOption},
         proposal_instruction::{
             get_proposal_instruction_address, InstructionData, ProposalInstruction,
         },
@@ -1458,8 +1458,17 @@ impl GovernanceProgramTest {
             instructions_next_index: 0,
             token_owner_record: token_owner_record_cookie.address,
             signatories_signed_off_count: 0,
-            yes_votes_count: 0,
-            no_votes_count: 0,
+
+            options: vec![
+                ProposalOption {
+                    label: "Yes".to_string(),
+                    vote_weight: 0,
+                },
+                ProposalOption {
+                    label: "No".to_string(),
+                    vote_weight: 0,
+                },
+            ],
 
             execution_flags: InstructionExecutionFlags::None,
             max_vote_weight: None,

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1477,9 +1477,7 @@ impl GovernanceProgramTest {
             voting_completed_at: None,
             executing_at: None,
             closed_at: None,
-            instructions_executed_count: 0,
-            instructions_count: 0,
-            instructions_next_index: 0,
+
             token_owner_record: token_owner_record_cookie.address,
             signatories_signed_off_count: 0,
 
@@ -1489,11 +1487,17 @@ impl GovernanceProgramTest {
                     label: "Yes".to_string(),
                     vote_weight: 0,
                     vote_result: OptionVoteResult::None,
+                    instructions_executed_count: 0,
+                    instructions_count: 0,
+                    instructions_next_index: 0,
                 },
                 ProposalOption {
                     label: "No".to_string(),
                     vote_weight: 0,
                     vote_result: OptionVoteResult::None,
+                    instructions_executed_count: 0,
+                    instructions_count: 0,
+                    instructions_next_index: 0,
                 },
             ],
             has_reject_option: true,
@@ -2020,11 +2024,12 @@ impl GovernanceProgramTest {
         let hold_up_time = 15;
 
         let instruction_data: InstructionData = instruction.clone().into();
+        let mut yes_option = &mut proposal_cookie.account.options[0];
 
-        let instruction_index = index.unwrap_or(proposal_cookie.account.instructions_next_index);
+        let instruction_index = index.unwrap_or(yes_option.instructions_next_index);
         let option_index = 0;
 
-        proposal_cookie.account.instructions_next_index += 1;
+        yes_option.instructions_next_index += 1;
 
         let insert_instruction_instruction = insert_instruction(
             &self.program_id,

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -36,9 +36,7 @@ use spl_governance::{
             get_program_governance_address, get_token_governance_address, Governance,
             GovernanceConfig,
         },
-        proposal::{
-            get_proposal_address, Proposal, ProposalOption, ProposalOptionVote, ProposalType,
-        },
+        proposal::{get_proposal_address, Proposal, ProposalOption, ProposalOptionArg, VoteType},
         proposal_instruction::{
             get_proposal_instruction_address, InstructionData, ProposalInstruction,
         },
@@ -1424,10 +1422,10 @@ impl GovernanceProgramTest {
             };
 
         let options = vec![
-            ProposalOption {
+            ProposalOptionArg {
                 label: "Yes".to_string(),
             },
-            ProposalOption {
+            ProposalOptionArg {
                 label: "No".to_string(),
             },
         ];
@@ -1443,7 +1441,7 @@ impl GovernanceProgramTest {
             name.clone(),
             description_link.clone(),
             &token_owner_record_cookie.account.governing_token_mint,
-            ProposalType::YesNoVote,
+            VoteType::SingleChoice,
             options,
             proposal_index,
         );
@@ -1482,17 +1480,18 @@ impl GovernanceProgramTest {
             token_owner_record: token_owner_record_cookie.address,
             signatories_signed_off_count: 0,
 
-            proposal_type: ProposalType::YesNoVote,
+            vote_type: VoteType::SingleChoice,
             options: vec![
-                ProposalOptionVote {
+                ProposalOption {
                     label: "Yes".to_string(),
                     weight: 0,
                 },
-                ProposalOptionVote {
+                ProposalOption {
                     label: "No".to_string(),
                     weight: 0,
                 },
             ],
+            has_reject_option: true,
 
             execution_flags: InstructionExecutionFlags::None,
             max_vote_weight: None,

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1881,6 +1881,7 @@ impl GovernanceProgramTest {
         self.with_instruction(
             proposal_cookie,
             token_owner_record_cookie,
+            0,
             None,
             &mut set_governance_config_ix,
         )
@@ -1917,6 +1918,7 @@ impl GovernanceProgramTest {
         self.with_instruction(
             proposal_cookie,
             token_owner_record_cookie,
+            0,
             index,
             &mut instruction,
         )
@@ -1953,6 +1955,7 @@ impl GovernanceProgramTest {
         self.with_instruction(
             proposal_cookie,
             token_owner_record_cookie,
+            0,
             index,
             &mut instruction,
         )
@@ -2022,6 +2025,7 @@ impl GovernanceProgramTest {
         self.with_instruction(
             proposal_cookie,
             token_owner_record_cookie,
+            0,
             None,
             &mut upgrade_instruction,
         )
@@ -2033,6 +2037,7 @@ impl GovernanceProgramTest {
         &mut self,
         proposal_cookie: &mut ProposalCookie,
         token_owner_record_cookie: &TokenOwnerRecordCookie,
+        option_index: u8,
         index: Option<u16>,
     ) -> Result<ProposalInstructionCookie, ProgramError> {
         // Create NOP instruction as a placeholder
@@ -2046,6 +2051,7 @@ impl GovernanceProgramTest {
         self.with_instruction(
             proposal_cookie,
             token_owner_record_cookie,
+            option_index,
             index,
             &mut instruction,
         )
@@ -2057,6 +2063,7 @@ impl GovernanceProgramTest {
         &mut self,
         proposal_cookie: &mut ProposalCookie,
         token_owner_record_cookie: &TokenOwnerRecordCookie,
+        option_index: u8,
         index: Option<u16>,
         instruction: &mut Instruction,
     ) -> Result<ProposalInstructionCookie, ProgramError> {
@@ -2066,7 +2073,6 @@ impl GovernanceProgramTest {
         let mut yes_option = &mut proposal_cookie.account.options[0];
 
         let instruction_index = index.unwrap_or(yes_option.instructions_next_index);
-        let option_index = 0;
 
         yes_option.instructions_next_index += 1;
 

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -36,7 +36,10 @@ use spl_governance::{
             get_program_governance_address, get_token_governance_address, Governance,
             GovernanceConfig,
         },
-        proposal::{get_proposal_address, Proposal, ProposalOption, ProposalOptionArg, VoteType},
+        proposal::{
+            get_proposal_address, OptionVoteResult, Proposal, ProposalOption, ProposalOptionArg,
+            VoteType,
+        },
         proposal_instruction::{
             get_proposal_instruction_address, InstructionData, ProposalInstruction,
         },
@@ -1484,11 +1487,13 @@ impl GovernanceProgramTest {
             options: vec![
                 ProposalOption {
                     label: "Yes".to_string(),
-                    weight: 0,
+                    vote_weight: 0,
+                    vote_result: OptionVoteResult::None,
                 },
                 ProposalOption {
                     label: "No".to_string(),
-                    weight: 0,
+                    vote_weight: 0,
+                    vote_result: OptionVoteResult::None,
                 },
             ],
             has_reject_option: true,

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -23,7 +23,7 @@ use spl_governance::{
         execute_instruction, finalize_vote, flag_instruction_error, insert_instruction,
         relinquish_vote, remove_instruction, remove_signatory, set_governance_config,
         set_governance_delegate, set_realm_authority, set_realm_config, sign_off_proposal,
-        withdraw_governing_tokens, Vote,
+        withdraw_governing_tokens,
     },
     processor::process_instruction,
     state::{
@@ -72,6 +72,16 @@ use self::{
         TokenOwnerRecordCookie, VoteRecordCookie,
     },
 };
+
+/// Yes/No Vote
+pub enum Vote {
+    /// Yes vote
+    #[allow(dead_code)]
+    Yes,
+    /// No vote
+    #[allow(dead_code)]
+    No,
+}
 
 pub struct GovernanceProgramTest {
     pub bench: ProgramTestBench,

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -47,7 +47,7 @@ use spl_governance::{
         realm_config::{get_realm_config_address, RealmConfigAccount},
         signatory_record::{get_signatory_record_address, SignatoryRecord},
         token_owner_record::{get_token_owner_record_address, TokenOwnerRecord},
-        vote_record::{get_vote_record_address, VoteChoice, VoteRecord},
+        vote_record::{get_vote_record_address, VoteChoice, VoteChoiceWeight, VoteRecord},
     },
     tools::bpf_loader_upgradeable::get_program_data_address,
 };
@@ -1728,14 +1728,26 @@ impl GovernanceProgramTest {
         let choices = match vote {
             Vote::Yes => {
                 vec![
-                    VoteChoice { rank: 0, weight: 1 },
-                    VoteChoice { rank: 0, weight: 0 },
+                    VoteChoice {
+                        rank: 0,
+                        weight_percentage: 100,
+                    },
+                    VoteChoice {
+                        rank: 0,
+                        weight_percentage: 0,
+                    },
                 ]
             }
             Vote::No => {
                 vec![
-                    VoteChoice { rank: 0, weight: 0 },
-                    VoteChoice { rank: 0, weight: 1 },
+                    VoteChoice {
+                        rank: 0,
+                        weight_percentage: 0,
+                    },
+                    VoteChoice {
+                        rank: 0,
+                        weight_percentage: 100,
+                    },
                 ]
             }
         };
@@ -1765,17 +1777,17 @@ impl GovernanceProgramTest {
             .account
             .governing_token_deposit_amount;
 
-        let vote_choices = match vote {
+        let weighted_choices = match vote {
             Vote::Yes => vec![
-                VoteChoice {
+                VoteChoiceWeight {
                     rank: 0,
                     weight: vote_amount,
                 },
-                VoteChoice { rank: 0, weight: 0 },
+                VoteChoiceWeight { rank: 0, weight: 0 },
             ],
             Vote::No => vec![
-                VoteChoice { rank: 0, weight: 0 },
-                VoteChoice {
+                VoteChoiceWeight { rank: 0, weight: 0 },
+                VoteChoiceWeight {
                     rank: 0,
                     weight: vote_amount,
                 },
@@ -1786,7 +1798,7 @@ impl GovernanceProgramTest {
             account_type: GovernanceAccountType::VoteRecord,
             proposal: proposal_cookie.address,
             governing_token_owner: token_owner_record_cookie.token_owner.pubkey(),
-            choices: vote_choices,
+            choices: weighted_choices,
             is_relinquished: false,
         };
 

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1492,7 +1492,7 @@ impl GovernanceProgramTest {
 
         let clock = self.bench.get_clock().await;
 
-        let mut proposal_options: Vec<ProposalOption> = options
+        let proposal_options: Vec<ProposalOption> = options
             .iter()
             .map(|o| ProposalOption {
                 label: o.to_string(),
@@ -1504,17 +1504,7 @@ impl GovernanceProgramTest {
             })
             .collect();
 
-        // TODO: Use separate option for rejection
-        if use_reject_option {
-            proposal_options.push(ProposalOption {
-                label: "No".to_string(),
-                vote_weight: 0,
-                vote_result: OptionVoteResult::None,
-                instructions_executed_count: 0,
-                instructions_count: 0,
-                instructions_next_index: 0,
-            })
-        }
+        let reject_option_vote_weight = if use_reject_option { Some(0) } else { None };
 
         let account = Proposal {
             account_type: GovernanceAccountType::Proposal,
@@ -1539,7 +1529,7 @@ impl GovernanceProgramTest {
 
             vote_type: vote_type,
             options: proposal_options,
-            has_reject_option: use_reject_option,
+            reject_option_vote_weight,
 
             execution_flags: InstructionExecutionFlags::None,
             max_vote_weight: None,

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1851,7 +1851,7 @@ impl GovernanceProgramTest {
             .governing_token_deposit_amount;
 
         let account = VoteRecord {
-            account_type: GovernanceAccountType::VoteRecord,
+            account_type: GovernanceAccountType::VoteRecordV2,
             proposal: proposal_cookie.address,
             governing_token_owner: token_owner_record_cookie.token_owner.pubkey(),
             vote,

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -38,7 +38,7 @@ use spl_governance::{
         },
         proposal::{get_proposal_address, OptionVoteResult, Proposal, ProposalOption, VoteType},
         proposal_instruction::{
-            get_proposal_instruction_address, InstructionData, ProposalInstruction,
+            get_proposal_instruction_address, InstructionData, ProposalInstructionV2,
         },
         realm::{
             get_governing_token_holding_address, get_realm_address, Realm, RealmConfig,
@@ -2110,8 +2110,8 @@ impl GovernanceProgramTest {
             &instruction_index.to_le_bytes(),
         );
 
-        let proposal_instruction_data = ProposalInstruction {
-            account_type: GovernanceAccountType::ProposalInstruction,
+        let proposal_instruction_data = ProposalInstructionV2 {
+            account_type: GovernanceAccountType::ProposalInstructionV2,
             option_index,
             instruction_index,
             hold_up_time,
@@ -2255,9 +2255,9 @@ impl GovernanceProgramTest {
     pub async fn get_proposal_instruction_account(
         &mut self,
         proposal_instruction_address: &Pubkey,
-    ) -> ProposalInstruction {
+    ) -> ProposalInstructionV2 {
         self.bench
-            .get_borsh_account::<ProposalInstruction>(proposal_instruction_address)
+            .get_borsh_account::<ProposalInstructionV2>(proposal_instruction_address)
             .await
     }
 

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1900,7 +1900,7 @@ impl GovernanceProgramTest {
         governed_mint_cookie: &GovernedMintCookie,
         proposal_cookie: &mut ProposalCookie,
         token_owner_record_cookie: &TokenOwnerRecordCookie,
-        option_index: u8,
+        option_index: u16,
         index: Option<u16>,
     ) -> Result<ProposalInstructionCookie, ProgramError> {
         let token_account_keypair = Keypair::new();
@@ -2044,7 +2044,7 @@ impl GovernanceProgramTest {
         &mut self,
         proposal_cookie: &mut ProposalCookie,
         token_owner_record_cookie: &TokenOwnerRecordCookie,
-        option_index: u8,
+        option_index: u16,
         index: Option<u16>,
     ) -> Result<ProposalInstructionCookie, ProgramError> {
         // Create NOP instruction as a placeholder
@@ -2070,7 +2070,7 @@ impl GovernanceProgramTest {
         &mut self,
         proposal_cookie: &mut ProposalCookie,
         token_owner_record_cookie: &TokenOwnerRecordCookie,
-        option_index: u8,
+        option_index: u16,
         index: Option<u16>,
         instruction: &mut Instruction,
     ) -> Result<ProposalInstructionCookie, ProgramError> {

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -29,7 +29,7 @@ use spl_governance::{
     state::{
         enums::{
             GovernanceAccountType, InstructionExecutionFlags, InstructionExecutionStatus,
-            MintMaxVoteWeightSource, ProposalState, VoteThresholdPercentage, VoteWeight,
+            MintMaxVoteWeightSource, ProposalState, VoteThresholdPercentage,
         },
         governance::{
             get_account_governance_address, get_mint_governance_address,
@@ -47,7 +47,7 @@ use spl_governance::{
         realm_config::{get_realm_config_address, RealmConfigAccount},
         signatory_record::{get_signatory_record_address, SignatoryRecord},
         token_owner_record::{get_token_owner_record_address, TokenOwnerRecord},
-        vote_record::{get_vote_record_address, VoteRecord},
+        vote_record::{get_vote_record_address, VoteChoice, VoteRecord},
     },
     tools::bpf_loader_upgradeable::get_program_data_address,
 };
@@ -1721,16 +1721,28 @@ impl GovernanceProgramTest {
             .account
             .governing_token_deposit_amount;
 
-        let vote_weight = match vote {
-            Vote::Yes => VoteWeight::Yes(vote_amount),
-            Vote::No => VoteWeight::No(vote_amount),
+        let vote_choices = match vote {
+            Vote::Yes => vec![
+                VoteChoice {
+                    rank: 0,
+                    weight: vote_amount,
+                },
+                VoteChoice { rank: 0, weight: 0 },
+            ],
+            Vote::No => vec![
+                VoteChoice { rank: 0, weight: 0 },
+                VoteChoice {
+                    rank: 0,
+                    weight: vote_amount,
+                },
+            ],
         };
 
         let account = VoteRecord {
             account_type: GovernanceAccountType::VoteRecord,
             proposal: proposal_cookie.address,
             governing_token_owner: token_owner_record_cookie.token_owner.pubkey(),
-            vote_weight,
+            choices: vote_choices,
             is_relinquished: false,
         };
 

--- a/governance/program/tests/use_proposals_with_multiple_options.rs
+++ b/governance/program/tests/use_proposals_with_multiple_options.rs
@@ -91,7 +91,7 @@ async fn test_create_proposal_with_multiple_choice_options_and_without_deny_opti
             &mut account_governance_cookie,
             options,
             false,
-            VoteType::MultiChoice,
+            VoteType::MultiChoice(2),
         )
         .await
         .unwrap();
@@ -100,7 +100,7 @@ async fn test_create_proposal_with_multiple_choice_options_and_without_deny_opti
         .get_proposal_account(&proposal_cookie.address)
         .await;
 
-    assert_eq!(proposal_account.vote_type, VoteType::MultiChoice);
+    assert_eq!(proposal_account.vote_type, VoteType::MultiChoice(2));
     assert!(!proposal_account.deny_vote_weight.is_some());
 
     assert_eq!(proposal_cookie.account, proposal_account);
@@ -350,7 +350,7 @@ async fn test_vote_on_none_executable_multi_choice_proposal_with_multiple_option
                 "option 3".to_string(),
             ],
             false,
-            VoteType::MultiChoice,
+            VoteType::MultiChoice(3),
         )
         .await
         .unwrap();
@@ -475,7 +475,7 @@ async fn test_vote_on_executable_proposal_with_multiple_options_and_partial_succ
                 "option 3".to_string(),
             ],
             true,
-            VoteType::MultiChoice,
+            VoteType::MultiChoice(3),
         )
         .await
         .unwrap();
@@ -633,7 +633,7 @@ async fn test_execute_proposal_with_multiple_options_and_partial_success() {
                 "option 3".to_string(),
             ],
             true,
-            VoteType::MultiChoice,
+            VoteType::MultiChoice(3),
         )
         .await
         .unwrap();
@@ -836,7 +836,7 @@ async fn test_try_execute_proposal_with_multiple_options_and_full_deny() {
                 "option 3".to_string(),
             ],
             true,
-            VoteType::MultiChoice,
+            VoteType::MultiChoice(3),
         )
         .await
         .unwrap();

--- a/governance/program/tests/use_proposals_with_multiple_options.rs
+++ b/governance/program/tests/use_proposals_with_multiple_options.rs
@@ -5,7 +5,7 @@ use solana_program_test::*;
 mod program_test;
 
 use program_test::*;
-use spl_governance::state::proposal::VoteType;
+use spl_governance::{error::GovernanceError, state::proposal::VoteType};
 
 #[tokio::test]
 async fn test_create_proposal_with_single_choice_options_and_reject_option() {
@@ -97,4 +97,48 @@ async fn test_create_proposal_with_multiple_choice_options_and_without_reject_op
     assert!(!proposal_account.has_reject_option);
 
     assert_eq!(proposal_cookie.account, proposal_account);
+}
+
+#[tokio::test]
+async fn test_insert_proposal_instruction_with_no_reject_option_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut account_governance_cookie = governance_test
+        .with_account_governance(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_multi_option_proposal(
+            &token_owner_record_cookie,
+            &mut account_governance_cookie,
+            vec!["option 1".to_string(), "option 2".to_string()],
+            false,
+            VoteType::SingleChoice,
+        )
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::ProposalIsNotExecutable.into());
 }

--- a/governance/program/tests/use_proposals_with_multiple_options.rs
+++ b/governance/program/tests/use_proposals_with_multiple_options.rs
@@ -313,6 +313,9 @@ async fn test_vote_on_none_executable_single_choice_proposal_with_multiple_optio
         OptionVoteResult::Defeated,
         proposal_account.options[1].vote_result
     );
+
+    // None executable proposal transitions to Completed when vote is finalized
+    assert_eq!(ProposalState::Completed, proposal_account.state);
 }
 
 #[tokio::test]
@@ -417,10 +420,13 @@ async fn test_vote_on_none_executable_multi_choice_proposal_with_multiple_option
         OptionVoteResult::Defeated,
         proposal_account.options[2].vote_result
     );
+
+    // None executable proposal transitions to Completed when vote is finalized
+    assert_eq!(ProposalState::Completed, proposal_account.state);
 }
 
 #[tokio::test]
-async fn test_vote_on_proposal_with_multiple_options_and_partial_success() {
+async fn test_vote_on_executable_proposal_with_multiple_options_and_partial_success() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 

--- a/governance/program/tests/use_proposals_with_multiple_options.rs
+++ b/governance/program/tests/use_proposals_with_multiple_options.rs
@@ -1,0 +1,100 @@
+#![cfg(feature = "test-bpf")]
+
+use solana_program_test::*;
+
+mod program_test;
+
+use program_test::*;
+use spl_governance::state::proposal::VoteType;
+
+#[tokio::test]
+async fn test_create_proposal_with_single_choice_options_and_reject_option() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut account_governance_cookie = governance_test
+        .with_account_governance(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let options = vec!["option 1".to_string(), "option 2".to_string()];
+
+    // Act
+    let proposal_cookie = governance_test
+        .with_multi_option_proposal(
+            &token_owner_record_cookie,
+            &mut account_governance_cookie,
+            options,
+            true,
+            VoteType::SingleChoice,
+        )
+        .await
+        .unwrap();
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(proposal_account.vote_type, VoteType::SingleChoice);
+    assert!(proposal_account.has_reject_option);
+
+    assert_eq!(proposal_cookie.account, proposal_account);
+}
+
+#[tokio::test]
+async fn test_create_proposal_with_multiple_choice_options_and_without_reject_option() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut account_governance_cookie = governance_test
+        .with_account_governance(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let options = vec!["option 1".to_string(), "option 2".to_string()];
+
+    // Act
+    let proposal_cookie = governance_test
+        .with_multi_option_proposal(
+            &token_owner_record_cookie,
+            &mut account_governance_cookie,
+            options,
+            false,
+            VoteType::MultiChoice,
+        )
+        .await
+        .unwrap();
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(proposal_account.vote_type, VoteType::MultiChoice);
+    assert!(!proposal_account.has_reject_option);
+
+    assert_eq!(proposal_cookie.account, proposal_account);
+}

--- a/governance/program/tests/use_proposals_with_multiple_options.rs
+++ b/governance/program/tests/use_proposals_with_multiple_options.rs
@@ -48,7 +48,7 @@ async fn test_create_proposal_with_single_choice_options_and_reject_option() {
         .await;
 
     assert_eq!(proposal_account.vote_type, VoteType::SingleChoice);
-    assert!(proposal_account.has_reject_option);
+    assert!(proposal_account.reject_option_vote_weight.is_some());
 
     assert_eq!(proposal_cookie.account, proposal_account);
 }
@@ -94,7 +94,7 @@ async fn test_create_proposal_with_multiple_choice_options_and_without_reject_op
         .await;
 
     assert_eq!(proposal_account.vote_type, VoteType::MultiChoice);
-    assert!(!proposal_account.has_reject_option);
+    assert!(!proposal_account.reject_option_vote_weight.is_some());
 
     assert_eq!(proposal_cookie.account, proposal_account);
 }

--- a/governance/program/tests/use_proposals_with_multiple_options.rs
+++ b/governance/program/tests/use_proposals_with_multiple_options.rs
@@ -5,7 +5,13 @@ use solana_program_test::*;
 mod program_test;
 
 use program_test::*;
-use spl_governance::{error::GovernanceError, state::proposal::VoteType};
+use spl_governance::{
+    error::GovernanceError,
+    state::{
+        proposal::{OptionVoteResult, VoteType},
+        vote_record::{Vote, VoteChoice},
+    },
+};
 
 #[tokio::test]
 async fn test_create_proposal_with_single_choice_options_and_deny_option() {
@@ -215,4 +221,199 @@ async fn test_insert_instructions_for_multiple_options() {
 
     assert_eq!(2, proposal_account.options[0].instructions_count);
     assert_eq!(3, proposal_account.options[1].instructions_count);
+}
+
+#[tokio::test]
+async fn test_vote_on_none_executable_single_choice_proposal_with_multiple_options() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut account_governance_cookie = governance_test
+        .with_account_governance(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_multi_option_proposal(
+            &token_owner_record_cookie,
+            &mut account_governance_cookie,
+            vec!["option 1".to_string(), "option 2".to_string()],
+            false,
+            VoteType::SingleChoice,
+        )
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let clock = governance_test.bench.get_clock().await;
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    let vote = Vote::Approve(vec![
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 100,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 0,
+        },
+    ]);
+
+    // Act
+    governance_test
+        .with_cast_multi_option_vote(&proposal_cookie, &token_owner_record_cookie, vote)
+        .await
+        .unwrap();
+
+    // Advance timestamp past max_voting_time
+    governance_test
+        .advance_clock_past_timestamp(
+            account_governance_cookie.account.config.max_voting_time as i64 + clock.unix_timestamp,
+        )
+        .await;
+
+    governance_test
+        .finalize_vote(&realm_cookie, &proposal_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(
+        OptionVoteResult::Succeeded,
+        proposal_account.options[0].vote_result
+    );
+
+    assert_eq!(
+        OptionVoteResult::Defeated,
+        proposal_account.options[1].vote_result
+    );
+}
+
+#[tokio::test]
+async fn test_vote_on_none_executable_multi_choice_proposal_with_multiple_options() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut account_governance_cookie = governance_test
+        .with_account_governance(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_multi_option_proposal(
+            &token_owner_record_cookie,
+            &mut account_governance_cookie,
+            vec![
+                "option 1".to_string(),
+                "option 2".to_string(),
+                "option 3".to_string(),
+            ],
+            false,
+            VoteType::MultiChoice,
+        )
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let clock = governance_test.bench.get_clock().await;
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    let vote = Vote::Approve(vec![
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 100,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 100,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 0,
+        },
+    ]);
+
+    // Act
+    governance_test
+        .with_cast_multi_option_vote(&proposal_cookie, &token_owner_record_cookie, vote)
+        .await
+        .unwrap();
+
+    // Advance timestamp past max_voting_time
+    governance_test
+        .advance_clock_past_timestamp(
+            account_governance_cookie.account.config.max_voting_time as i64 + clock.unix_timestamp,
+        )
+        .await;
+
+    governance_test
+        .finalize_vote(&realm_cookie, &proposal_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(
+        OptionVoteResult::Succeeded,
+        proposal_account.options[0].vote_result
+    );
+
+    assert_eq!(
+        OptionVoteResult::Succeeded,
+        proposal_account.options[1].vote_result
+    );
+
+    assert_eq!(
+        OptionVoteResult::Defeated,
+        proposal_account.options[2].vote_result
+    );
 }

--- a/governance/program/tests/use_proposals_with_multiple_options.rs
+++ b/governance/program/tests/use_proposals_with_multiple_options.rs
@@ -100,7 +100,7 @@ async fn test_create_proposal_with_multiple_choice_options_and_without_reject_op
 }
 
 #[tokio::test]
-async fn test_insert_proposal_instruction_with_no_reject_option_error() {
+async fn test_insert_instruction_with_proposal_not_executable_error() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
@@ -134,11 +134,85 @@ async fn test_insert_proposal_instruction_with_no_reject_option_error() {
 
     // Act
     let err = governance_test
-        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, None)
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
         .await
         .err()
         .unwrap();
 
     // Assert
     assert_eq!(err, GovernanceError::ProposalIsNotExecutable.into());
+}
+
+#[tokio::test]
+async fn test_insert_instructions_for_multiple_options() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut account_governance_cookie = governance_test
+        .with_account_governance(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_multi_option_proposal(
+            &token_owner_record_cookie,
+            &mut account_governance_cookie,
+            vec!["option 1".to_string(), "option 2".to_string()],
+            true,
+            VoteType::SingleChoice,
+        )
+        .await
+        .unwrap();
+
+    // Act
+
+    // option 1 / instruction 0
+    governance_test
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, 1, Some(0))
+        .await
+        .unwrap();
+
+    // option 1 / instruction 1
+    governance_test
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, 1, Some(1))
+        .await
+        .unwrap();
+
+    // option 1 / instruction 2
+    governance_test
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, 1, Some(2))
+        .await
+        .unwrap();
+
+    // option 0 / instruction 0
+    governance_test
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, 0, Some(0))
+        .await
+        .unwrap();
+
+    // option 0 / instruction 1
+    governance_test
+        .with_nop_instruction(&mut proposal_cookie, &token_owner_record_cookie, 0, Some(1))
+        .await
+        .unwrap();
+
+    // Assert
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(2, proposal_account.options[0].instructions_count);
+    assert_eq!(3, proposal_account.options[1].instructions_count);
 }

--- a/governance/program/tests/use_proposals_with_multiple_options.rs
+++ b/governance/program/tests/use_proposals_with_multiple_options.rs
@@ -8,7 +8,7 @@ use program_test::*;
 use spl_governance::{error::GovernanceError, state::proposal::VoteType};
 
 #[tokio::test]
-async fn test_create_proposal_with_single_choice_options_and_reject_option() {
+async fn test_create_proposal_with_single_choice_options_and_deny_option() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
@@ -48,13 +48,13 @@ async fn test_create_proposal_with_single_choice_options_and_reject_option() {
         .await;
 
     assert_eq!(proposal_account.vote_type, VoteType::SingleChoice);
-    assert!(proposal_account.reject_option_vote_weight.is_some());
+    assert!(proposal_account.deny_vote_weight.is_some());
 
     assert_eq!(proposal_cookie.account, proposal_account);
 }
 
 #[tokio::test]
-async fn test_create_proposal_with_multiple_choice_options_and_without_reject_option() {
+async fn test_create_proposal_with_multiple_choice_options_and_without_deny_option() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
@@ -94,7 +94,7 @@ async fn test_create_proposal_with_multiple_choice_options_and_without_reject_op
         .await;
 
     assert_eq!(proposal_account.vote_type, VoteType::MultiChoice);
-    assert!(!proposal_account.reject_option_vote_weight.is_some());
+    assert!(!proposal_account.deny_vote_weight.is_some());
 
     assert_eq!(proposal_cookie.account, proposal_account);
 }

--- a/governance/program/tests/use_realm_with_voter_weight_addin.rs
+++ b/governance/program/tests/use_realm_with_voter_weight_addin.rs
@@ -5,7 +5,7 @@ use solana_program_test::*;
 mod program_test;
 
 use program_test::*;
-use spl_governance::{error::GovernanceError, instruction::Vote, state::enums::VoteWeight};
+use spl_governance::{error::GovernanceError, instruction::Vote};
 
 #[tokio::test]
 async fn test_create_account_governance_with_voter_weight_addin() {
@@ -125,7 +125,7 @@ async fn test_cast_vote_with_voter_weight_addin() {
         .get_vote_record_account(&vote_record_cookie.address)
         .await;
 
-    assert_eq!(VoteWeight::Yes(100), vote_record_account.vote_weight);
+    assert_eq!(100, vote_record_account.choices[0].weight);
 
     let proposal_account = governance_test
         .get_proposal_account(&proposal_cookie.address)

--- a/governance/program/tests/use_realm_with_voter_weight_addin.rs
+++ b/governance/program/tests/use_realm_with_voter_weight_addin.rs
@@ -141,7 +141,7 @@ async fn test_cast_vote_with_voter_weight_addin() {
         .get_proposal_account(&proposal_cookie.address)
         .await;
 
-    assert_eq!(100, proposal_account.options[0].vote_weight);
+    assert_eq!(120, proposal_account.options[0].vote_weight);
 }
 
 #[tokio::test]

--- a/governance/program/tests/use_realm_with_voter_weight_addin.rs
+++ b/governance/program/tests/use_realm_with_voter_weight_addin.rs
@@ -131,7 +131,7 @@ async fn test_cast_vote_with_voter_weight_addin() {
         .get_proposal_account(&proposal_cookie.address)
         .await;
 
-    assert_eq!(100, proposal_account.options[0].vote_weight);
+    assert_eq!(100, proposal_account.options[0].weight);
 }
 
 #[tokio::test]

--- a/governance/program/tests/use_realm_with_voter_weight_addin.rs
+++ b/governance/program/tests/use_realm_with_voter_weight_addin.rs
@@ -131,7 +131,7 @@ async fn test_cast_vote_with_voter_weight_addin() {
         .get_proposal_account(&proposal_cookie.address)
         .await;
 
-    assert_eq!(100, proposal_account.yes_votes_count);
+    assert_eq!(100, proposal_account.options[0].vote_weight);
 }
 
 #[tokio::test]

--- a/governance/program/tests/use_realm_with_voter_weight_addin.rs
+++ b/governance/program/tests/use_realm_with_voter_weight_addin.rs
@@ -131,7 +131,7 @@ async fn test_cast_vote_with_voter_weight_addin() {
         .get_proposal_account(&proposal_cookie.address)
         .await;
 
-    assert_eq!(100, proposal_account.options[0].weight);
+    assert_eq!(100, proposal_account.options[0].vote_weight);
 }
 
 #[tokio::test]

--- a/governance/program/tests/use_realm_with_voter_weight_addin.rs
+++ b/governance/program/tests/use_realm_with_voter_weight_addin.rs
@@ -5,7 +5,7 @@ use solana_program_test::*;
 mod program_test;
 
 use program_test::*;
-use spl_governance::{error::GovernanceError, instruction::Vote};
+use spl_governance::error::GovernanceError;
 
 #[tokio::test]
 async fn test_create_account_governance_with_voter_weight_addin() {

--- a/governance/program/tests/use_realm_with_voter_weight_addin.rs
+++ b/governance/program/tests/use_realm_with_voter_weight_addin.rs
@@ -5,7 +5,10 @@ use solana_program_test::*;
 mod program_test;
 
 use program_test::*;
-use spl_governance::error::GovernanceError;
+use spl_governance::{
+    error::GovernanceError,
+    state::vote_record::{Vote, VoteChoice},
+};
 
 #[tokio::test]
 async fn test_create_account_governance_with_voter_weight_addin() {
@@ -115,7 +118,7 @@ async fn test_cast_vote_with_voter_weight_addin() {
 
     // Act
     let vote_record_cookie = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Yes)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -125,7 +128,14 @@ async fn test_cast_vote_with_voter_weight_addin() {
         .get_vote_record_account(&vote_record_cookie.address)
         .await;
 
-    assert_eq!(100, vote_record_account.choices[0].weight);
+    assert_eq!(120, vote_record_account.voter_weight);
+    assert_eq!(
+        Vote::Approve(vec![VoteChoice {
+            rank: 0,
+            weight_percentage: 100
+        }]),
+        vote_record_account.vote
+    );
 
     let proposal_account = governance_test
         .get_proposal_account(&proposal_cookie.address)


### PR DESCRIPTION
#### Summary 
This change adds support for multi option voting and survey only proposals. The following voting systems were implemented:

- Single choice voting - each voter may select only one choice from multiple options
- Multi choice voting - each voter may select multiple choices from multiple options 

Each proposal can either be executable or non executable (survey only). The executable proposals can have instructions associated with different options and always have `Deny` option which allows to down vote the proposal and prevent execution of the instructions. 
When multiple choice executable proposal is voted on each option is considered individually and can either success or fail and hence only a subset of successful options can be executed after vote on the proposal ends.

#### Implementation details
The voting system was generalised to multi option voting and the legacy Yes/No vote system is now implemented as a specific use case: `SingleChoice` vote with `Yes` only option and  `Deny (No)` option.

Legacy V1 accounts are fully supported through in/out serialisation transformations.

#### Out of the scope
Support for 1) Weighted voting  2) Quadratic voting and 3) Ranked voting was added to the account structures but not implemented in this PR