### PR TITLE
stake-pool-cli: Add validator list argument to create

### DIFF
--- a/docs/src/stake-pool.md
+++ b/docs/src/stake-pool.md
@@ -297,6 +297,18 @@ This account holds onto additional stake used when rebalancing between validator
 For a stake pool with 1000 validators, the cost to create a stake pool is less
 than 0.5 SOL.
 
+The `create-pool` command allows setting all of the accounts and keypairs to
+pre-generated values, including:
+
+* stake pool, through the `--pool-keypair` flag
+* validator list, through the `--validator-list-keypair` flag
+* pool token mint, through the `--mint-keypair` flag
+* pool reserve stake account, through the `--reserve-keypair` flag
+
+Otherwise, these will all default to newly-generated keypairs.
+
+You can always check out the available options by running `spl-stake-pool create-pool -h`.
+
 ### Create a restricted stake pool
 
 If a manager would like to restrict deposits (stake and SOL) to one key in

--- a/stake-pool/cli/scripts/setup-stake-pool.sh
+++ b/stake-pool/cli/scripts/setup-stake-pool.sh
@@ -71,9 +71,11 @@ build_stake_pool_cli
 
 echo "Creating pool"
 stake_pool_keyfile=$keys_dir/stake-pool.json
+validator_list_keyfile=$keys_dir/validator-list.json
 mint_keyfile=$keys_dir/mint.json
 reserve_keyfile=$keys_dir/reserve.json
 create_keypair $stake_pool_keyfile
+create_keypair $validator_list_keyfile
 create_keypair $mint_keyfile
 create_keypair $reserve_keyfile
 
@@ -83,6 +85,7 @@ $spl_stake_pool \
   create-pool \
   "${command_args[@]}" \
   --pool-keypair "$stake_pool_keyfile" \
+  --validator-list-keypair "$validator_list_keyfile" \
   --mint-keypair "$mint_keyfile" \
   --reserve-keypair "$reserve_keyfile"
 


### PR DESCRIPTION
#### Problem

People want to know more about the validator list, but there isn't too much info provided.

#### Solution

* Include the validator list as an optional parameter to pool creation
* Print out the address during creation
* Always print out the address during `list`
* Add docs about it