### PR TITLE
stake-pool-docs: Add published audits from Quantstamp, Neodyme, and Kudelski

### DIFF
--- a/docs/src/stake-pool.md
+++ b/docs/src/stake-pool.md
@@ -198,6 +198,23 @@ The Stake Pool Program's source is available on
 For information about the types and instructions, the Stake Pool Rust docs are
 available at [docs.rs](https://docs.rs/spl-stake-pool/0.5.0/spl_stake_pool/).
 
+## Security Audits
+
+Multiple security firms have audited the stake pool program to ensure total
+safety of funds. The audit reports are available for reading, presented in descending
+chronological order, and the commit hash that each was reviewed at:
+
+* Quantstamp
+    - Initial review commit hash [`99914c9`](https://github.com/solana-labs/solana-program-library/tree/99914c9fc7246b22ef04416586ab1722c89576de)
+    - Re-review commit hash [`3b48fa0`](https://github.com/solana-labs/solana-program-library/tree/3b48fa09d38d1b66ffb4fef186b606f1bc4fdb31)
+    - Final report https://solana.com/SolanaQuantstampStakePoolAudit.pdf
+* Neodyme
+    - Review commit hash [`0a85a9a`](https://github.com/solana-labs/solana-program-library/tree/0a85a9a533795b6338ea144e433893c6c0056210)
+    - Report https://solana.com/SolanaNeodymeStakePoolAudit.pdf
+* Kudelski
+    - Review commit hash [`3dd6767`](https://github.com/solana-labs/solana-program-library/tree/3dd67672974f92d3b648bb50ee74f4747a5f8973)
+    - Report https://solana.com/SolanaKudelskiStakePoolAudit.pdf
+
 ## Command-line Utility
 
 The following explains the instructions available in the Stake Pool Program along

--- a/stake-pool/README.md
+++ b/stake-pool/README.md
@@ -1,12 +1,7 @@
 # stake-pool program
 
-A work-in-progress program for pooling together SOL to be staked by an off-chain
-agent running SoM (Stake-o-Matic).
-
-Each SoM needs at least one pool.  Users deposit stakes into the SoM pool
-and receives a pool token minus the fee.  The SoM redistributes the stakes
-across the network and tries to maximize censorship resistance and rewards.
-
 Full documentation is available at https://spl.solana.com/stake-pool
+
+The command-line interface tool is available in the `./cli` directory.
 
 Javascript bindings are available in the `./js` directory.


### PR DESCRIPTION
#### Problem

People want to read the stake pool audits, but they're not published anywhere.

#### Solution

Start by publishing them on the stake pool docs!