### PR TITLE
Allow GC to close empty associated accounts

### DIFF
--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -2140,7 +2140,7 @@ fn main() {
                 .arg(owner_keypair_arg())
                 .arg(
                     Arg::with_name("del_associated_accounts")
-                    .long("del_associated_accounts")
+                    .long("close-empty-associated-accounts")
                     .value_name("DEL_ASSOCIATED_ACCOUNTS")
                     .takes_value(false)
                     .help("set to true if all empty associated accounts should be deleted")

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -1309,8 +1309,13 @@ fn command_gc(config: &Config, owner: Pubkey, close_empty_associated_accounts: b
 
             let mut account_instructions = vec![];
 
-            // Transfer the account balance into the associated token account
-            if amount > 0 {
+            
+            if amount > 0 && address == associated_token_account {
+                // Sanity check!
+                // we shouldn't ever be here, but if we are here, abort!
+                continue;
+            } else if amount > 0 {
+                // Transfer the account balance into the associated token account
                 account_instructions.push(transfer_checked(
                     &spl_token::id(),
                     &address,

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -1214,7 +1214,11 @@ fn command_multisig(config: &Config, address: Pubkey) -> CommandResult {
     Ok(None)
 }
 
-fn command_gc(config: &Config, owner: Pubkey, close_empty_associated_accounts: bool) -> CommandResult {
+fn command_gc(
+    config: &Config,
+    owner: Pubkey,
+    close_empty_associated_accounts: bool,
+) -> CommandResult {
     println_display(config, "Fetching token accounts".to_string());
     let accounts = config
         .rpc_client
@@ -1295,11 +1299,18 @@ fn command_gc(config: &Config, owner: Pubkey, close_empty_associated_accounts: b
         }
 
         for (address, (amount, decimals, frozen, close_authority)) in accounts {
-            match (address == associated_token_account, close_empty_associated_accounts, total_balance > 0) {
+            match (
+                address == associated_token_account,
+                close_empty_associated_accounts,
+                total_balance > 0,
+            ) {
                 (true, _, true) => continue, // don't ever close associated token account with amount
                 (true, false, _) => continue, // don't close associated token account if close_empty_associated_accounts isn't set
-                (true, true, false) => println_display(config, format!("Closing Account {}", associated_token_account)),
-                _ => {},
+                (true, true, false) => println_display(
+                    config,
+                    format!("Closing Account {}", associated_token_account),
+                ),
+                _ => {}
             }
 
             if frozen {
@@ -1309,7 +1320,6 @@ fn command_gc(config: &Config, owner: Pubkey, close_empty_associated_accounts: b
 
             let mut account_instructions = vec![];
 
-            
             if amount > 0 && address == associated_token_account {
                 // Sanity check!
                 // we shouldn't ever be here, but if we are here, abort!
@@ -2623,7 +2633,8 @@ fn main() {
                 _ => {}
             }
 
-            let close_empty_associated_accounts = matches.is_present("close_empty_associated_accounts");
+            let close_empty_associated_accounts =
+                matches.is_present("close_empty_associated_accounts");
 
             let (owner_signer, owner_address) =
                 config.signer_or_default(arg_matches, "owner", &mut wallet_manager);

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -1295,7 +1295,7 @@ fn command_gc(config: &Config, owner: Pubkey, close_empty_associated_accounts: b
         }
 
         for (address, (amount, decimals, frozen, close_authority)) in accounts {
-            match (address == associated_token_account, close_empty_associated_accounts, amount > 0) {
+            match (address == associated_token_account, close_empty_associated_accounts, total_balance > 0) {
                 (true, _, true) => continue, // don't ever close associated token account with amount
                 (true, false, _) => continue, // don't close associated token account if close_empty_associated_accounts isn't set
                 (true, true, false) => println_display(config, format!("Closing Account {}", associated_token_account)),

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -1320,11 +1320,11 @@ fn command_gc(
 
             let mut account_instructions = vec![];
 
-            if amount > 0 && address == associated_token_account {
-                // Sanity check!
-                // we shouldn't ever be here, but if we are here, abort!
-                continue;
-            } else if amount > 0 {
+            // Sanity check!
+            // we shouldn't ever be here, but if we are here, abort!
+            assert!(amount == 0 || address != associated_token_account);
+
+            if amount > 0 {
                 // Transfer the account balance into the associated token account
                 account_instructions.push(transfer_checked(
                     &spl_token::id(),


### PR DESCRIPTION
Empty associated accounts will only be closed in case the new flag del_associated_accounts is set. Otherwise behaviour is as before.
This can be used tto reclaim SOL that was sent to the associated accounts e.g. for rent exemption

Useage:
spl-token gc --del_associated_accounts