### PR TITLE
token-js: Add test for disabling mint authority

### DIFF
--- a/token/js/cli/main.js
+++ b/token/js/cli/main.js
@@ -9,6 +9,7 @@ import {
   createMint,
   createAccount,
   createAssociatedAccount,
+  disableMintAuthority,
   transfer,
   transferChecked,
   transferCheckedAssociated,
@@ -67,6 +68,8 @@ async function main() {
   await multisig();
   console.log('Run test: nativeToken');
   await nativeToken();
+  console.log('Run test: disable mint authority');
+  await disableMintAuthority();
   console.log('Success\n');
 }
 

--- a/token/js/cli/token-test.js
+++ b/token/js/cli/token-test.js
@@ -428,6 +428,16 @@ export async function setAuthority(): Promise<void> {
   );
 }
 
+export async function disableMintAuthority(): Promise<void> {
+  await testToken.setAuthority(
+    testToken.publicKey,
+    null,
+    'MintTokens',
+    testMintAuthority,
+    [],
+  );
+}
+
 export async function burn(): Promise<void> {
   let accountInfo = await testToken.getAccountInfo(testAccount);
   const amount = accountInfo.amount.toNumber();


### PR DESCRIPTION
#### Problem

There's no JS test disabling a mint authority in the token program, so it might not seem possible.

#### Solution

Add a test, as a start.