### PR TITLE
governance: Remove dependency on ProcessInstructionWithContext

### DIFF
--- a/governance/chat/program/tests/program_test/mod.rs
+++ b/governance/chat/program/tests/program_test/mod.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use solana_program::{program_error::ProgramError, pubkey::Pubkey};
-use solana_program_test::processor;
+use solana_program_test::{processor, ProgramTest};
 
 use solana_sdk::{signature::Keypair, signer::Signer};
 use spl_governance::{
@@ -21,7 +21,7 @@ use spl_governance_chat::{
     processor::process_instruction,
     state::{ChatMessage, GovernanceChatAccountType, MessageBody},
 };
-use spl_governance_test_sdk::{ProgramTestBench, TestBenchProgram};
+use spl_governance_test_sdk::ProgramTestBench;
 
 use crate::program_test::cookies::{ChatMessageCookie, ProposalCookie};
 
@@ -37,23 +37,22 @@ pub struct GovernanceChatProgramTest {
 
 impl GovernanceChatProgramTest {
     pub async fn start_new() -> Self {
+        let mut program_test = ProgramTest::default();
         let program_id = Pubkey::from_str("GovernanceChat11111111111111111111111111111").unwrap();
-
-        let chat_program = TestBenchProgram {
-            program_name: "spl_governance_chat",
-            program_id: program_id,
-            process_instruction: processor!(process_instruction),
-        };
+        program_test.add_program(
+            "spl_governance_chat",
+            program_id,
+            processor!(process_instruction),
+        );
 
         let governance_program_id =
             Pubkey::from_str("Governance111111111111111111111111111111111").unwrap();
-        let governance_program = TestBenchProgram {
-            program_name: "spl_governance",
-            program_id: governance_program_id,
-            process_instruction: processor!(spl_governance::processor::process_instruction),
-        };
-
-        let bench = ProgramTestBench::start_new(&[chat_program, governance_program]).await;
+        program_test.add_program(
+            "spl_governance",
+            governance_program_id,
+            processor!(spl_governance::processor::process_instruction),
+        );
+        let bench = ProgramTestBench::start_new(program_test).await;
 
         Self {
             bench,

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -61,7 +61,7 @@ use crate::program_test::cookies::{
 
 use spl_governance_test_sdk::{
     tools::{clone_keypair, NopOverride},
-    ProgramTestBench, TestBenchProgram,
+    ProgramTestBench,
 };
 
 use self::{
@@ -105,35 +105,29 @@ impl GovernanceProgramTest {
 
     #[allow(dead_code)]
     async fn start_impl(use_voter_weight_addin: bool) -> Self {
-        let mut programs = vec![];
+        let mut program_test = ProgramTest::default();
 
         let program_id = Pubkey::from_str("Governance111111111111111111111111111111111").unwrap();
-
-        let program = TestBenchProgram {
-            program_name: "spl_governance",
+        program_test.add_program(
+            "spl_governance",
             program_id,
-            process_instruction: processor!(process_instruction),
-        };
-
-        programs.push(program);
+            processor!(process_instruction),
+        );
 
         let voter_weight_addin_id = if use_voter_weight_addin {
             let voter_weight_addin_id =
                 Pubkey::from_str("VoterWeight11111111111111111111111111111111").unwrap();
-
-            let vote_weight_addin = TestBenchProgram {
-                program_name: "spl_governance_voter_weight_addin",
-                program_id: voter_weight_addin_id,
-                process_instruction: None,
-            };
-
-            programs.push(vote_weight_addin);
+            program_test.add_program(
+                "spl_governance_voter_weight_addin",
+                voter_weight_addin_id,
+                None,
+            );
             Some(voter_weight_addin_id)
         } else {
             None
         };
 
-        let bench = ProgramTestBench::start_new(&programs).await;
+        let bench = ProgramTestBench::start_new(program_test).await;
 
         Self {
             bench,

--- a/governance/test-sdk/src/lib.rs
+++ b/governance/test-sdk/src/lib.rs
@@ -8,10 +8,7 @@ use solana_program::{
     system_instruction, sysvar,
 };
 use solana_program_test::{ProgramTest, ProgramTestContext};
-use solana_sdk::{
-    account::Account, process_instruction::ProcessInstructionWithContext, signature::Keypair,
-    signer::Signer, transaction::Transaction,
-};
+use solana_sdk::{account::Account, signature::Keypair, signer::Signer, transaction::Transaction};
 
 use bincode::deserialize;
 
@@ -22,14 +19,6 @@ use crate::tools::map_transaction_error;
 pub mod cookies;
 pub mod tools;
 
-/// Specification of a program which is loaded into the test bench
-#[derive(Clone)]
-pub struct TestBenchProgram<'a> {
-    pub program_name: &'a str,
-    pub program_id: Pubkey,
-    pub process_instruction: Option<ProcessInstructionWithContext>,
-}
-
 /// Program's test bench which captures test context, rent and payer and common utility functions
 pub struct ProgramTestBench {
     pub context: ProgramTestContext,
@@ -39,17 +28,9 @@ pub struct ProgramTestBench {
 }
 
 impl ProgramTestBench {
-    pub async fn start_new(programs: &[TestBenchProgram<'_>]) -> Self {
-        let mut program_test = ProgramTest::default();
-
-        for program in programs {
-            program_test.add_program(
-                program.program_name,
-                program.program_id,
-                program.process_instruction,
-            )
-        }
-
+    /// Create new bench given a ProgramTest instance populated with all of the
+    /// desired programs.
+    pub async fn start_new(program_test: ProgramTest) -> Self {
         let mut context = program_test.start_with_context().await;
         let rent = context.banks_client.get_rent().await.unwrap();
 


### PR DESCRIPTION
#### Problem

`solana_sdk::process_instruction` is getting refactored in `solana_program_runtime` in https://github.com/solana-labs/solana/pull/21180, but the governance program explicitly uses parts of `solana_sdk::process_instruction`

#### Solution

Redo the testing bits to remove the dependency, with no change to functionality.

cc @SebastianBor @Lichtso 