### PR TITLE
Adds "solana-version" to "patch.crates-io.sh"

### DIFF
--- a/patch.crates-io.sh
+++ b/patch.crates-io.sh
@@ -53,6 +53,7 @@ solana-runtime = { path = "$solana_dir/runtime" }
 solana-sdk = { path = "$solana_dir/sdk" }
 solana-stake-program = { path = "$solana_dir/programs/stake" }
 solana-transaction-status = { path = "$solana_dir/transaction-status" }
+solana-version = { path = "$solana_dir/version" }
 solana-vote-program = { path = "$solana_dir/programs/vote" }
 PATCH
   fi


### PR DESCRIPTION
To fix broken "downstream-projects" CI step in the mono repo after #2576 was merged.