### PR TITLE
token-2022: Add transfer fee types and instructions

### DIFF
--- a/token/program-2022/src/extension.rs
+++ b/token/program-2022/src/extension.rs
@@ -1,0 +1,71 @@
+use solana_program::{clock::Epoch, program_option::COption, pubkey::Pubkey};
+
+/// Extensions that can be applied to mints or accounts.  Mint extensions must only be
+/// applied to mint accounts, and account extensions must only be applied to token holding
+/// accounts.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Extension {
+    /// Used as padding if the account size would otherwise be 355, same as a multisig
+    Uninitialized,
+    /// Includes a transfer fee and accompanying authorities to withdraw and set the fee
+    MintTransferFee,
+    /// Includes withheld transfer fees
+    AccountTransferFee,
+    /// Includes an optional mint close authority
+    MintCloseAuthority,
+}
+
+/// Type-Length-Value Entry, used to encapsulate all extensions contained within an account
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct TlvEntry<V> {
+    pub extension: Extension,
+    pub length: u32,
+    pub value: V,
+}
+
+/// Close authority extension data for mints.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct MintCloseAuthority {
+    /// Optional authority to close the mint
+    pub close_authority: COption<Pubkey>,
+}
+
+/// Transfer fee information
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct TransferFee {
+    /// First epoch where the transfer fee takes effect
+    pub epoch: Epoch,
+    /// Amount of transfer collected as fees, expressed as basis points of the
+    /// transfer amount, ie. increments of 0.01%
+    pub transfer_fee_basis_points: u16,
+    /// Maximum fee assessed on transfers, expressed as an amount of tokens
+    pub maximum_fee: u64,
+}
+
+/// Transfer fee extension data for mints.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct MintTransferFee {
+    /// Optional authority to set the fee
+    pub transfer_fee_config_authority: COption<Pubkey>,
+    /// Withdraw from mint instructions must be signed by this key
+    pub withheld_withdraw_authority: COption<Pubkey>,
+    /// Withheld transfer fee tokens that have been moved to the mint for withdrawal
+    pub withheld_amount: u64,
+    /// Older transfer fee, used if the current epoch < new_transfer_fee.epoch
+    pub older_transfer_fee: TransferFee,
+    /// Newer transfer fee, used if the current epoch >= new_transfer_fee.epoch
+    pub newer_transfer_fee: TransferFee,
+}
+
+/// Transfer fee extension data for accounts.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct AccountTransferFee {
+    /// Amount withheld during transfers, to be harvested to the mint
+    pub withheld_amount: u64,
+}

--- a/token/program-2022/src/extension.rs
+++ b/token/program-2022/src/extension.rs
@@ -1,4 +1,27 @@
+//! Extensions available to token mints and accounts
+
 use solana_program::{clock::Epoch, program_option::COption, pubkey::Pubkey};
+
+/// Different kinds of accounts. Note that `Mint`, `Account`, and `Multisig` types
+/// are determined exclusively by the size of the account, and are not included in
+/// the account data. `AccountType` is only included if extensions have been
+/// initialized.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum AccountType {
+    /// Marker for 0 data
+    Uninitialized,
+    /// Mint account with additional extensions
+    Mint,
+    /// Token holding account with additional extensions
+    Account,
+}
+
+impl Default for AccountType {
+    fn default() -> Self {
+        Self::Uninitialized
+    }
+}
 
 /// Extensions that can be applied to mints or accounts.  Mint extensions must only be
 /// applied to mint accounts, and account extensions must only be applied to token holding
@@ -18,10 +41,13 @@ pub enum Extension {
 
 /// Type-Length-Value Entry, used to encapsulate all extensions contained within an account
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TlvEntry<V> {
+    /// Extension type encoded in the rest of the entry
     pub extension: Extension,
+    /// Length of the entry, in bytes
     pub length: u32,
+    /// Deserialized value
     pub value: V,
 }
 

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -29,7 +29,7 @@ pub enum TokenInstruction {
     /// Otherwise another party can acquire ownership of the uninitialized
     /// account.
     ///
-    /// Any mixins must be initialized before this instruction.
+    /// Any extensions must be initialized before this instruction.
     ///
     /// Accounts expected by this instruction:
     ///
@@ -56,7 +56,7 @@ pub enum TokenInstruction {
     /// Otherwise another party can acquire ownership of the uninitialized
     /// account.
     ///
-    /// All required mixins will be initialized at the same time.
+    /// All required extensions will be initialized at the same time.
     ///
     /// Accounts expected by this instruction:
     ///
@@ -97,8 +97,8 @@ pub enum TokenInstruction {
     /// amounts of SOL and Tokens will be transferred to the destination
     /// account.
     ///
-    /// If the accounts contain `AccountTransferFeeMixin`s, this will fail.  Mints with
-    /// the `MintTransferFeeMixin` are required in order to assess the fee.
+    /// If the accounts contain `AccountTransferFeeExtension`s, this will fail.  Mints with
+    /// the `MintTransferFeeExtension` are required in order to assess the fee.
     ///
     /// Accounts expected by this instruction:
     ///
@@ -207,10 +207,10 @@ pub enum TokenInstruction {
     /// Close an account by transferring all its SOL to the destination account.
     /// Non-native accounts may only be closed if its token amount is zero.
     ///
-    /// Accounts with the `AccountTransferFeeMixin` may only be closed if the withheld
+    /// Accounts with the `AccountTransferFeeExtension` may only be closed if the withheld
     /// amount is zero.
     ///
-    /// Mints may be closed if they have the `MintCloseAuthority` mixin and their token
+    /// Mints may be closed if they have the `MintCloseAuthority` extension and their token
     /// supply is zero
     ///
     /// Accounts expected by this instruction:
@@ -267,7 +267,7 @@ pub enum TokenInstruction {
     /// decimals value is checked by the caller.  This may be useful when
     /// creating transactions offline or within a hardware wallet.
     ///
-    /// If the accounts contain `AccountTransferFeeMixin`s, the fee is withheld in the
+    /// If the accounts contain `AccountTransferFeeExtension`s, the fee is withheld in the
     /// destination account.
     ///
     /// Accounts expected by this instruction:
@@ -373,7 +373,7 @@ pub enum TokenInstruction {
     /// Cross Program Invocation from an instruction that does not need the owner's
     /// `AccountInfo` otherwise.
     ///
-    /// All required mixins will be initialized at the same time.
+    /// All required extensions will be initialized at the same time.
     ///
     /// Accounts expected by this instruction:
     ///
@@ -396,7 +396,7 @@ pub enum TokenInstruction {
     SyncNative,
     /// Like InitializeAccount2, but does not require the Rent sysvar to be provided
     ///
-    /// All required mixins will be initialized at the same time.
+    /// All required extensions will be initialized at the same time.
     ///
     /// Accounts expected by this instruction:
     ///
@@ -420,7 +420,7 @@ pub enum TokenInstruction {
     },
     /// Like InitializeMint, but does not require the Rent sysvar to be provided
     ///
-    /// Any mixins must be initialized before this instruction.
+    /// Any extensions must be initialized before this instruction.
     ///
     /// Accounts expected by this instruction:
     ///
@@ -444,14 +444,14 @@ pub enum TokenInstruction {
     ///
     ///   0. `[]` The mint to calculate for
     GetAccountDataSize,
-    /// Initialize the close account mixin on a new mint.
+    /// Initialize the close account authority on a new mint.
     ///
     /// Fails if the mint has already been initialized, so must be called before
     /// `InitializeMint`.
     ///
     /// The mint must have exactly enough space allocated for the base mint (82
     /// bytes), plus 83 bytes of padding, 1 byte reserved for the account type,
-    /// then space required for the mixin.
+    /// then space required for the extension.
     ///
     /// Accounts expected by this instruction:
     ///
@@ -459,14 +459,14 @@ pub enum TokenInstruction {
     InitializeMintCloseAuthority {
         close_authority: COption<Pubkey>,
     },
-    /// Initialize the transfer fee mixin on a new mint.
+    /// Initialize the transfer fee on a new mint.
     ///
     /// Fails if the mint has already been initialized, so must be called before
     /// `InitializeMint`.
     ///
     /// The mint must have exactly enough space allocated for the base mint (82
     /// bytes), plus 83 bytes of padding, 1 byte reserved for the account type,
-    /// then space required for the mixin.
+    /// then space required for the extension.
     ///
     /// Accounts expected by this instruction:
     ///
@@ -487,9 +487,9 @@ pub enum TokenInstruction {
     /// Accounts expected by this instruction:
     ///
     ///   * Single owner/delegate
-    ///   0. `[writable]` The source account. Must include the `AccountTransferFeeMixin`.
-    ///   1. `[]` The token mint. Must include the `AccountMintFeeMixin`.
-    ///   2. `[writable]` The destination account. Must include the `AccountTransferFeeMixin`.
+    ///   0. `[writable]` The source account. Must include the `AccountTransferFeeExtension`.
+    ///   1. `[]` The token mint. Must include the `AccountMintFeeExtension`.
+    ///   2. `[writable]` The destination account. Must include the `AccountTransferFeeExtension`.
     ///   3. `[signer]` The source account's owner/delegate.
     ///
     ///   * Multisignature owner/delegate
@@ -507,14 +507,14 @@ pub enum TokenInstruction {
         /// the transfer_fee_basis_points and maximum_fee of the mint.
         fee: u64,
     },
-    /// Transfer all withheld tokens to a fee account. Signed by the mint's
+    /// Transfer all withheld tokens to an account. Signed by the mint's
     /// fee withdraw authority.
     ///
     /// Accounts expected by this instruction:
     ///
     ///   * Single owner/delegate
-    ///   0. `[writable]` The token mint. Must include the `MintTransferFeeMixin`.
-    ///   1. `[writable]` The fee receiver account. Must include the `AccountTransferFeeMixin`.
+    ///   0. `[writable]` The token mint. Must include the `MintTransferFeeExtension`.
+    ///   1. `[writable]` The fee receiver account. Must include the `AccountTransferFeeExtension`.
     ///      associated with the provided mint.
     ///   2. `[signer]` The mint's `fee_withdraw_authority`
     ///
@@ -523,18 +523,20 @@ pub enum TokenInstruction {
     ///   1. `[writable]` The destination account.
     ///   2. `[]` The mint's `fee_withdraw_authority`'s multisignature owner/delegate.
     ///   3. ..3+M `[signer]` M signer accounts.
-    HarvestFeeFromMint,
+    HarvestWithheldTokensFromMint,
     /// Permissionless instruction to transfer all withheld tokens to the mint.
     ///
     /// Succeeds for frozen accounts.
+    ///
+    /// Accounts provided should include the `AccountTransferFeeExtension`. If not,
+    /// the account is skipped.
     ///
     /// Accounts expected by this instruction:
     ///
     ///   0. `[writable]` The mint.
     ///   1. ..1+N `[writable]` The source accounts to harvest from.
-    ///      Must include the `AccountTransferFeeMixin`.
-    HarvestFeeToMint,
-    /// Set transfer fee. Only supported for mints that include the `MintTransferFeeMixin`.
+    HarvestWithheldTokensToMint,
+    /// Set transfer fee. Only supported for mints that include the `MintTransferFeeExtension`.
     ///
     /// Accounts expected by this instruction:
     ///
@@ -818,10 +820,10 @@ pub enum AuthorityType {
     AccountOwner,
     /// Authority to close a token account
     CloseAccount,
-    /// Authority to set the fee
-    FeeConfig,
-    /// Authority to withdraw fees from accounts and mint
-    FeeWithdraw,
+    /// Authority to set the transfer fee
+    TransferFeeConfig,
+    /// Authority to withdraw withheld tokens from a mint
+    WithheldWithdraw,
 }
 
 impl AuthorityType {

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -56,7 +56,7 @@ pub enum TokenInstruction {
     /// Otherwise another party can acquire ownership of the uninitialized
     /// account.
     ///
-    /// Any mixins must be initialized before this instruction.
+    /// All required mixins will be initialized at the same time.
     ///
     /// Accounts expected by this instruction:
     ///
@@ -209,6 +209,9 @@ pub enum TokenInstruction {
     ///
     /// Accounts with the `AccountTransferFeeMixin` may only be closed if the withheld
     /// amount is zero.
+    ///
+    /// Mints may be closed if they have the `MintCloseAuthority` mixin and their token
+    /// supply is zero
     ///
     /// Accounts expected by this instruction:
     ///
@@ -370,7 +373,7 @@ pub enum TokenInstruction {
     /// Cross Program Invocation from an instruction that does not need the owner's
     /// `AccountInfo` otherwise.
     ///
-    /// Any mixins must be initialized before this instruction.
+    /// All required mixins will be initialized at the same time.
     ///
     /// Accounts expected by this instruction:
     ///
@@ -393,7 +396,7 @@ pub enum TokenInstruction {
     SyncNative,
     /// Like InitializeAccount2, but does not require the Rent sysvar to be provided
     ///
-    /// Any mixins must be initialized before this instruction.
+    /// All required mixins will be initialized at the same time.
     ///
     /// Accounts expected by this instruction:
     ///
@@ -440,21 +443,7 @@ pub enum TokenInstruction {
     /// Accounts expected by this instruction:
     ///
     ///   0. `[]` The mint to calculate for
-    GetAccountLength,
-    /// Initializes the empty mixin on a new account.
-    ///
-    /// The account must have a size 356, which requires it to use this mixin.
-    /// The size of 356 comes from the size of a multisig (355) plus 1 byte of
-    /// padding.
-    ///
-    /// Fails if the account has already been initialized, so must be called before
-    /// `InitializeAccount`. The account must have enough data allocated for all
-    /// mixins included in the mint.
-    ///
-    /// Accounts expected by this instruction:
-    ///
-    ///   0. `[writable]`  The account to initialize.
-    InitializeEmptyMixin,
+    GetAccountDataSize,
     /// Initialize the close account mixin on a new mint.
     ///
     /// Fails if the mint has already been initialized, so must be called before
@@ -467,7 +456,9 @@ pub enum TokenInstruction {
     /// Accounts expected by this instruction:
     ///
     ///   0. `[writable]` The mint to initialize.
-    InitializeMintCloseMixin,
+    InitializeMintCloseAuthority {
+        close_authority: COption<Pubkey>,
+    },
     /// Initialize the transfer fee mixin on a new mint.
     ///
     /// Fails if the mint has already been initialized, so must be called before
@@ -480,7 +471,7 @@ pub enum TokenInstruction {
     /// Accounts expected by this instruction:
     ///
     ///   0. `[writable]` The mint to initialize.
-    InitializeMintTransferFeeMixin {
+    InitializeMintTransferFee {
         /// Pubkey that may update the fees
         fee_config_authority: COption<Pubkey>,
         /// Harvest instructions must be signed by this key
@@ -491,17 +482,6 @@ pub enum TokenInstruction {
         /// Maximum fee assessed on transfers
         maximum_fee: u64,
     },
-    /// Initializes the transfer fee mixin on a new account.
-    ///
-    /// Fails if the account has already been initialized, so must be called before
-    /// `InitializeAccount`. The account must have enough data allocated for all
-    /// mixins included in the mint.
-    ///
-    /// Accounts expected by this instruction:
-    ///
-    ///   0. `[writable]`  The account to initialize.
-    ///   1. `[]` The mint this account will be associated with.
-    InitializeAccountTransferFeeMixin,
     /// Transfer, providing expected mint information and fees
     ///
     /// Accounts expected by this instruction:

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -467,7 +467,7 @@ pub enum TokenInstruction {
         /// Pubkey that may update the fees
         fee_config_authority: COption<Pubkey>,
         /// Withdraw instructions must be signed by this key
-        fee_withdraw_authority: COption<Pubkey>,
+        withdraw_withheld_authority: COption<Pubkey>,
         /// Amount of transfer collected as fees, expressed as basis points of the
         /// transfer amount
         transfer_fee_basis_points: u16,
@@ -499,8 +499,8 @@ pub enum TokenInstruction {
         /// the transfer_fee_basis_points and maximum_fee of the mint.
         fee: u64,
     },
-    /// Transfer all withheld tokens to an account. Signed by the mint's
-    /// fee withdraw authority.
+    /// Transfer all withheld tokens in the mint to an account. Signed by the mint's
+    /// withdraw withheld tokens authority.
     ///
     /// Accounts expected by this instruction:
     ///
@@ -508,14 +508,33 @@ pub enum TokenInstruction {
     ///   0. `[writable]` The token mint. Must include the `MintTransferFee` extension.
     ///   1. `[writable]` The fee receiver account. Must include the `AccountTransferFee` extension
     ///      associated with the provided mint.
-    ///   2. `[signer]` The mint's `fee_withdraw_authority`
+    ///   2. `[signer]` The mint's `withdraw_withheld_authority`.
     ///
     ///   * Multisignature owner/delegate
     ///   0. `[writable]` The token mint.
     ///   1. `[writable]` The destination account.
-    ///   2. `[]` The mint's `fee_withdraw_authority`'s multisignature owner/delegate.
+    ///   2. `[]` The mint's `withdraw_withheld_authority`'s multisignature owner/delegate.
     ///   3. ..3+M `[signer]` M signer accounts.
     WithdrawWithheldTokensFromMint,
+    /// Transfer all withheld tokens to an account. Signed by the mint's
+    /// withdraw withheld tokens authority.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   * Single owner/delegate
+    ///   0. `[]` The token mint. Must include the `MintTransferFee` extension.
+    ///   1. `[writable]` The fee receiver account. Must include the `AccountTransferFee`
+    ///      extension and be associated with the provided mint.
+    ///   2. `[signer]` The mint's `withdraw_withheld_authority`.
+    ///   3. ..3+N `[writable]` The source accounts to withdraw from.
+    ///
+    ///   * Multisignature owner/delegate
+    ///   0. `[]` The token mint.
+    ///   1. `[writable]` The destination account.
+    ///   2. `[]` The mint's `withdraw_withheld_authority`'s multisignature owner/delegate.
+    ///   3. ..3+M `[signer]` M signer accounts.
+    ///   3+M+1. ..3+M+N `[writable]` The source accounts to withdraw from.
+    WithdrawWithheldTokensFromAccounts,
     /// Permissionless instruction to transfer all withheld tokens to the mint.
     ///
     /// Succeeds for frozen accounts.

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -439,8 +439,10 @@ pub enum TokenInstruction {
         mint_authority: Pubkey,
         /// The freeze authority/multisignature of the mint.
         freeze_authority: COption<Pubkey>,
-        /// Pubkey that must own any provided fee account
-        fee_account_owner: Pubkey,
+        /// Pubkey that may update the fees
+        fee_config_authority: COption<Pubkey>,
+        /// Harvest instructions must be signed by this key
+        fee_withdraw_authority: COption<Pubkey>,
         /// Amount of transfer collected as fees, expressed as basis points of the
         /// transfer amount
         transfer_fee_basis_points: u16,
@@ -480,11 +482,9 @@ pub enum TokenInstruction {
         amount: u64,
         /// Expected number of base 10 digits to the right of the decimal place.
         decimals: u8,
-        /// Amount of transfer collected as fees, expressed as basis points of the
-        /// transfer amount
-        transfer_fee_basis_points: u16,
-        /// Maximum fee assessed on transfers
-        maximum_fee: u64,
+        /// Expected fee assessed on this transfer, calculated off-chain based on
+        /// the transfer_fee_basis_points and maximum_fee of the mint.
+        fee: u64,
     },
     /// Transfer all withheld tokens to a fee account. Signed by the mint's
     /// fee withdraw authority.
@@ -498,14 +498,14 @@ pub enum TokenInstruction {
     ///   1. `[writable]` The fee receiver account. Must be a PaymentAccount
     ///      associated with the provided PaymentMint.
     ///   2. `[signer]` The mint's `fee_withdraw_authority`
-    ///   3. ..3+N `[writable]` The source accounts to harvest from. Must be PaymentAccounts.
+    ///   3. ..3+N `[writable]` (Optional) The source accounts to harvest from. Must be PaymentAccounts.
     ///
     ///   * Multisignature owner/delegate
     ///   0. `[writable]` The token mint. Must be a PaymentMint.
     ///   1. `[writable]` The destination account.
     ///   2. `[]` The source or destination account's multisignature owner/delegate.
     ///   3. ..3+M `[signer]` M signer accounts.
-    ///   3+M+1. ..3+M+N`[writable]` The source accounts to harvest from. Must be PaymentAccounts.
+    ///   3+M+1. ..3+M+N`[writable]` (Optional) The source accounts to harvest from. Must be PaymentAccounts.
     HarvestFee,
     /// Close an account by transferring all its SOL to the destination account.
     ///

--- a/token/program-2022/src/lib.rs
+++ b/token/program-2022/src/lib.rs
@@ -4,6 +4,7 @@
 //! An ERC20-like Token program for the Solana blockchain
 
 pub mod error;
+pub mod extension;
 pub mod instruction;
 pub mod native_mint;
 pub mod processor;

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -767,6 +767,7 @@ impl Processor {
                 msg!("Instruction: InitializeMultisig2");
                 Self::process_initialize_multisig2(accounts, m)
             }
+            #[allow(deprecated)]
             TokenInstruction::Transfer { amount } => {
                 msg!("Instruction: Transfer");
                 Self::process_transfer(program_id, accounts, amount, None)
@@ -825,6 +826,30 @@ impl Processor {
             TokenInstruction::SyncNative => {
                 msg!("Instruction: SyncNative");
                 Self::process_sync_native(program_id, accounts)
+            }
+            TokenInstruction::GetAccountDataSize => {
+                unimplemented!();
+            }
+            TokenInstruction::InitializeMintCloseAuthority { .. } => {
+                unimplemented!();
+            }
+            TokenInstruction::InitializeMintTransferFee { .. } => {
+                unimplemented!();
+            }
+            TokenInstruction::TransferCheckedWithFee { .. } => {
+                unimplemented!();
+            }
+            TokenInstruction::WithdrawWithheldTokensFromMint => {
+                unimplemented!();
+            }
+            TokenInstruction::WithdrawWithheldTokensFromAccounts => {
+                unimplemented!();
+            }
+            TokenInstruction::HarvestWithheldTokensToMint => {
+                unimplemented!();
+            }
+            TokenInstruction::SetTransferFee { .. } => {
+                unimplemented!();
             }
         }
     }
@@ -1028,111 +1053,6 @@ mod tests {
         assert_ne!(Account::get_packed_len(), 0);
         assert_ne!(Account::get_packed_len(), Multisig::get_packed_len());
         assert_ne!(Multisig::get_packed_len(), 0);
-    }
-
-    #[test]
-    fn test_pack_unpack() {
-        // Mint
-        let check = Mint {
-            mint_authority: COption::Some(Pubkey::new(&[1; 32])),
-            supply: 42,
-            decimals: 7,
-            is_initialized: true,
-            freeze_authority: COption::Some(Pubkey::new(&[2; 32])),
-        };
-        let mut packed = vec![0; Mint::get_packed_len() + 1];
-        assert_eq!(
-            Err(ProgramError::InvalidAccountData),
-            Mint::pack(check, &mut packed)
-        );
-        let mut packed = vec![0; Mint::get_packed_len() - 1];
-        assert_eq!(
-            Err(ProgramError::InvalidAccountData),
-            Mint::pack(check, &mut packed)
-        );
-        let mut packed = vec![0; Mint::get_packed_len()];
-        Mint::pack(check, &mut packed).unwrap();
-        let expect = vec![
-            1, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-            1, 1, 1, 1, 1, 1, 1, 42, 0, 0, 0, 0, 0, 0, 0, 7, 1, 1, 0, 0, 0, 2, 2, 2, 2, 2, 2, 2, 2,
-            2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-        ];
-        assert_eq!(packed, expect);
-        let unpacked = Mint::unpack(&packed).unwrap();
-        assert_eq!(unpacked, check);
-
-        // Account
-        let check = Account {
-            mint: Pubkey::new(&[1; 32]),
-            owner: Pubkey::new(&[2; 32]),
-            amount: 3,
-            delegate: COption::Some(Pubkey::new(&[4; 32])),
-            state: AccountState::Frozen,
-            is_native: COption::Some(5),
-            delegated_amount: 6,
-            close_authority: COption::Some(Pubkey::new(&[7; 32])),
-        };
-        let mut packed = vec![0; Account::get_packed_len() + 1];
-        assert_eq!(
-            Err(ProgramError::InvalidAccountData),
-            Account::pack(check, &mut packed)
-        );
-        let mut packed = vec![0; Account::get_packed_len() - 1];
-        assert_eq!(
-            Err(ProgramError::InvalidAccountData),
-            Account::pack(check, &mut packed)
-        );
-        let mut packed = vec![0; Account::get_packed_len()];
-        Account::pack(check, &mut packed).unwrap();
-        let expect = vec![
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-            1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-            2, 2, 2, 2, 2, 2, 3, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-            4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 2, 1, 0, 0, 0, 5, 0, 0,
-            0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
-            7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
-        ];
-        assert_eq!(packed, expect);
-        let unpacked = Account::unpack(&packed).unwrap();
-        assert_eq!(unpacked, check);
-
-        // Multisig
-        let check = Multisig {
-            m: 1,
-            n: 2,
-            is_initialized: true,
-            signers: [Pubkey::new(&[3; 32]); MAX_SIGNERS],
-        };
-        let mut packed = vec![0; Multisig::get_packed_len() + 1];
-        assert_eq!(
-            Err(ProgramError::InvalidAccountData),
-            Multisig::pack(check, &mut packed)
-        );
-        let mut packed = vec![0; Multisig::get_packed_len() - 1];
-        assert_eq!(
-            Err(ProgramError::InvalidAccountData),
-            Multisig::pack(check, &mut packed)
-        );
-        let mut packed = vec![0; Multisig::get_packed_len()];
-        Multisig::pack(check, &mut packed).unwrap();
-        let expect = vec![
-            1, 2, 1, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-            3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-            3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-            3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-            3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-            3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-            3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-            3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-            3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-            3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-            3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-            3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-            3, 3, 3, 3, 3, 3, 3,
-        ];
-        assert_eq!(packed, expect);
-        let unpacked = Multisig::unpack(&packed).unwrap();
-        assert_eq!(unpacked, check);
     }
 
     #[test]
@@ -1395,6 +1315,7 @@ mod tests {
 
         // source-owner transfer
         do_process_instruction_dups(
+            #[allow(deprecated)]
             transfer(
                 &program_id,
                 &account1_key,
@@ -1443,6 +1364,7 @@ mod tests {
         Account::pack(account, &mut account1_info.data.borrow_mut()).unwrap();
 
         do_process_instruction_dups(
+            #[allow(deprecated)]
             transfer(
                 &program_id,
                 &account1_key,
@@ -1502,6 +1424,7 @@ mod tests {
         account1_info.is_signer = false;
         account2_info.is_signer = true;
         do_process_instruction_dups(
+            #[allow(deprecated)]
             transfer(
                 &program_id,
                 &account3_key,
@@ -1571,6 +1494,7 @@ mod tests {
 
         // source-multisig-signer transfer
         do_process_instruction_dups(
+            #[allow(deprecated)]
             transfer(
                 &program_id,
                 &account4_key,
@@ -1718,6 +1642,7 @@ mod tests {
         .unwrap();
 
         // missing signer
+        #[allow(deprecated)]
         let mut instruction = transfer(
             &program_id,
             &account_key,
@@ -1744,6 +1669,7 @@ mod tests {
         assert_eq!(
             Err(TokenError::MintMismatch.into()),
             do_process_instruction(
+                #[allow(deprecated)]
                 transfer(
                     &program_id,
                     &account_key,
@@ -1765,6 +1691,7 @@ mod tests {
         assert_eq!(
             Err(TokenError::OwnerMismatch.into()),
             do_process_instruction(
+                #[allow(deprecated)]
                 transfer(
                     &program_id,
                     &account_key,
@@ -1784,6 +1711,7 @@ mod tests {
 
         // transfer
         do_process_instruction(
+            #[allow(deprecated)]
             transfer(
                 &program_id,
                 &account_key,
@@ -1805,6 +1733,7 @@ mod tests {
         assert_eq!(
             Err(TokenError::InsufficientFunds.into()),
             do_process_instruction(
+                #[allow(deprecated)]
                 transfer(&program_id, &account_key, &account2_key, &owner_key, &[], 1).unwrap(),
                 vec![
                     &mut account_account,
@@ -1816,6 +1745,7 @@ mod tests {
 
         // transfer half back
         do_process_instruction(
+            #[allow(deprecated)]
             transfer(
                 &program_id,
                 &account2_key,
@@ -1906,6 +1836,7 @@ mod tests {
         assert_eq!(
             Err(TokenError::InsufficientFunds.into()),
             do_process_instruction(
+                #[allow(deprecated)]
                 transfer(&program_id, &account2_key, &account_key, &owner_key, &[], 1).unwrap(),
                 vec![
                     &mut account2_account,
@@ -1936,6 +1867,7 @@ mod tests {
 
         // transfer via delegate
         do_process_instruction(
+            #[allow(deprecated)]
             transfer(
                 &program_id,
                 &account_key,
@@ -1957,6 +1889,7 @@ mod tests {
         assert_eq!(
             Err(TokenError::OwnerMismatch.into()),
             do_process_instruction(
+                #[allow(deprecated)]
                 transfer(
                     &program_id,
                     &account_key,
@@ -1976,6 +1909,7 @@ mod tests {
 
         // transfer rest
         do_process_instruction(
+            #[allow(deprecated)]
             transfer(
                 &program_id,
                 &account_key,
@@ -2016,6 +1950,7 @@ mod tests {
         assert_eq!(
             Err(TokenError::InsufficientFunds.into()),
             do_process_instruction(
+                #[allow(deprecated)]
                 transfer(
                     &program_id,
                     &account_key,
@@ -2124,6 +2059,7 @@ mod tests {
         let mint_info = (&mint_key, false, &mut mint_account).into_account_info();
 
         // transfer
+        #[allow(deprecated)]
         let instruction = transfer(
             &program_id,
             account_info.key,
@@ -2180,6 +2116,7 @@ mod tests {
 
         // missing signer
         let mut owner_no_sign_info = owner_info.clone();
+        #[allow(deprecated)]
         let mut instruction = transfer(
             &program_id,
             account_info.key,
@@ -2232,6 +2169,7 @@ mod tests {
         );
 
         // missing owner
+        #[allow(deprecated)]
         let instruction = transfer(
             &program_id,
             account_info.key,
@@ -2281,6 +2219,7 @@ mod tests {
         );
 
         // insufficient funds
+        #[allow(deprecated)]
         let instruction = transfer(
             &program_id,
             account_info.key,
@@ -2403,6 +2342,7 @@ mod tests {
         .unwrap();
 
         // delegate transfer
+        #[allow(deprecated)]
         let instruction = transfer(
             &program_id,
             account_info.key,
@@ -2460,6 +2400,7 @@ mod tests {
         assert_eq!(account.delegated_amount, 100);
 
         // delegate insufficient funds
+        #[allow(deprecated)]
         let instruction = transfer(
             &program_id,
             account_info.key,
@@ -2509,6 +2450,7 @@ mod tests {
         );
 
         // owner transfer with delegate assigned
+        #[allow(deprecated)]
         let instruction = transfer(
             &program_id,
             account_info.key,
@@ -4370,7 +4312,7 @@ mod tests {
                 vec![
                     &mut multisig_account,
                     &mut rent_sysvar,
-                    &mut account_info_iter.next().unwrap(),
+                    account_info_iter.next().unwrap(),
                 ],
             )
         );
@@ -4385,7 +4327,7 @@ mod tests {
             vec![
                 &mut multisig_account,
                 &mut rent_sysvar,
-                &mut account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
             ],
         )
         .unwrap();
@@ -4394,10 +4336,7 @@ mod tests {
         let account_info_iter = &mut signer_accounts.iter_mut();
         do_process_instruction(
             initialize_multisig2(&program_id, &multisig_key, &[&signer_keys[0]], 1).unwrap(),
-            vec![
-                &mut multisig_account2,
-                &mut account_info_iter.next().unwrap(),
-            ],
+            vec![&mut multisig_account2, account_info_iter.next().unwrap()],
         )
         .unwrap();
 
@@ -4414,17 +4353,17 @@ mod tests {
             vec![
                 &mut multisig_delegate_account,
                 &mut rent_sysvar,
-                &mut account_info_iter.next().unwrap(),
-                &mut account_info_iter.next().unwrap(),
-                &mut account_info_iter.next().unwrap(),
-                &mut account_info_iter.next().unwrap(),
-                &mut account_info_iter.next().unwrap(),
-                &mut account_info_iter.next().unwrap(),
-                &mut account_info_iter.next().unwrap(),
-                &mut account_info_iter.next().unwrap(),
-                &mut account_info_iter.next().unwrap(),
-                &mut account_info_iter.next().unwrap(),
-                &mut account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
             ],
         )
         .unwrap();
@@ -4482,7 +4421,7 @@ mod tests {
                 &mut mint_account,
                 &mut account,
                 &mut multisig_account,
-                &mut account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
             ],
         )
         .unwrap();
@@ -4503,7 +4442,7 @@ mod tests {
                 &mut account,
                 &mut multisig_delegate_account,
                 &mut multisig_account,
-                &mut account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
             ],
         )
         .unwrap();
@@ -4511,6 +4450,7 @@ mod tests {
         // transfer
         let account_info_iter = &mut signer_accounts.iter_mut();
         do_process_instruction(
+            #[allow(deprecated)]
             transfer(
                 &program_id,
                 &account_key,
@@ -4524,7 +4464,7 @@ mod tests {
                 &mut account,
                 &mut account2_account,
                 &mut multisig_account,
-                &mut account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
             ],
         )
         .unwrap();
@@ -4532,6 +4472,7 @@ mod tests {
         // transfer via delegate
         let account_info_iter = &mut signer_accounts.iter_mut();
         do_process_instruction(
+            #[allow(deprecated)]
             transfer(
                 &program_id,
                 &account_key,
@@ -4545,17 +4486,17 @@ mod tests {
                 &mut account,
                 &mut account2_account,
                 &mut multisig_delegate_account,
-                &mut account_info_iter.next().unwrap(),
-                &mut account_info_iter.next().unwrap(),
-                &mut account_info_iter.next().unwrap(),
-                &mut account_info_iter.next().unwrap(),
-                &mut account_info_iter.next().unwrap(),
-                &mut account_info_iter.next().unwrap(),
-                &mut account_info_iter.next().unwrap(),
-                &mut account_info_iter.next().unwrap(),
-                &mut account_info_iter.next().unwrap(),
-                &mut account_info_iter.next().unwrap(),
-                &mut account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
             ],
         )
         .unwrap();
@@ -4576,7 +4517,7 @@ mod tests {
                 &mut mint_account,
                 &mut account2_account,
                 &mut multisig_account,
-                &mut account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
             ],
         )
         .unwrap();
@@ -4597,7 +4538,7 @@ mod tests {
                 &mut account,
                 &mut mint_account,
                 &mut multisig_account,
-                &mut account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
             ],
         )
         .unwrap();
@@ -4618,17 +4559,17 @@ mod tests {
                 &mut account,
                 &mut mint_account,
                 &mut multisig_delegate_account,
-                &mut account_info_iter.next().unwrap(),
-                &mut account_info_iter.next().unwrap(),
-                &mut account_info_iter.next().unwrap(),
-                &mut account_info_iter.next().unwrap(),
-                &mut account_info_iter.next().unwrap(),
-                &mut account_info_iter.next().unwrap(),
-                &mut account_info_iter.next().unwrap(),
-                &mut account_info_iter.next().unwrap(),
-                &mut account_info_iter.next().unwrap(),
-                &mut account_info_iter.next().unwrap(),
-                &mut account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
             ],
         )
         .unwrap();
@@ -4680,7 +4621,7 @@ mod tests {
                 &mut mint2_account,
                 &mut account3_account,
                 &mut multisig_account,
-                &mut account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
             ],
         )
         .unwrap();
@@ -4698,7 +4639,7 @@ mod tests {
                 &mut account3_account,
                 &mut mint2_account,
                 &mut multisig_account,
-                &mut account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
             ],
         )
         .unwrap();
@@ -4718,7 +4659,7 @@ mod tests {
             vec![
                 &mut mint_account,
                 &mut multisig_account,
-                &mut account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
             ],
         )
         .unwrap();
@@ -4738,7 +4679,7 @@ mod tests {
             vec![
                 &mut account,
                 &mut multisig_account,
-                &mut account_info_iter.next().unwrap(),
+                account_info_iter.next().unwrap(),
             ],
         )
         .unwrap();
@@ -5338,6 +5279,7 @@ mod tests {
         assert_eq!(
             Err(TokenError::InsufficientFunds.into()),
             do_process_instruction(
+                #[allow(deprecated)]
                 transfer(
                     &program_id,
                     &account_key,
@@ -5357,6 +5299,7 @@ mod tests {
 
         // transfer between native accounts
         do_process_instruction(
+            #[allow(deprecated)]
             transfer(
                 &program_id,
                 &account_key,
@@ -5594,6 +5537,7 @@ mod tests {
         assert_eq!(
             Err(TokenError::Overflow.into()),
             do_process_instruction(
+                #[allow(deprecated)]
                 transfer(
                     &program_id,
                     &account2_key,
@@ -5679,6 +5623,7 @@ mod tests {
         assert_eq!(
             Err(TokenError::AccountFrozen.into()),
             do_process_instruction(
+                #[allow(deprecated)]
                 transfer(
                     &program_id,
                     &account_key,
@@ -5705,6 +5650,7 @@ mod tests {
         assert_eq!(
             Err(TokenError::AccountFrozen.into()),
             do_process_instruction(
+                #[allow(deprecated)]
                 transfer(
                     &program_id,
                     &account_key,

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -826,7 +826,7 @@ impl Processor {
                 msg!("Instruction: SyncNative");
                 Self::process_sync_native(program_id, accounts)
             }
-            TokenInstruction::InitializeMintWithTransferFee {
+            TokenInstruction::InitializePaymentMint {
                 decimals: _,
                 mint_authority: _,
                 freeze_authority: _,
@@ -836,16 +836,21 @@ impl Processor {
             } => {
                 panic!();
             }
-            TokenInstruction::TransferWithFee {
+            TokenInstruction::InitializePaymentAccount { owner: _ } => {
+                panic!();
+            }
+            TokenInstruction::TransferCheckedWithFee {
                 amount: _,
                 decimals: _,
+                transfer_fee_basis_points: _,
+                maximum_fee: _,
             } => {
                 panic!();
             }
-            TokenInstruction::TransferWithheld {
-                amount: _,
-                decimals: _,
-            } => {
+            TokenInstruction::HarvestFee => {
+                panic!();
+            }
+            TokenInstruction::ClosePaymentAccount => {
                 panic!();
             }
             TokenInstruction::SetTransferFee {

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -826,6 +826,34 @@ impl Processor {
                 msg!("Instruction: SyncNative");
                 Self::process_sync_native(program_id, accounts)
             }
+            TokenInstruction::InitializeMintWithTransferFee {
+                decimals: _,
+                mint_authority: _,
+                freeze_authority: _,
+                fee_account_owner: _,
+                transfer_fee_basis_points: _,
+                maximum_fee: _,
+            } => {
+                panic!();
+            }
+            TokenInstruction::TransferWithFee {
+                amount: _,
+                decimals: _,
+            } => {
+                panic!();
+            }
+            TokenInstruction::TransferWithheld {
+                amount: _,
+                decimals: _,
+            } => {
+                panic!();
+            }
+            TokenInstruction::SetTransferFee {
+                transfer_fee_basis_points: _,
+                maximum_fee: _,
+            } => {
+                panic!();
+            }
         }
     }
 

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -826,39 +826,6 @@ impl Processor {
                 msg!("Instruction: SyncNative");
                 Self::process_sync_native(program_id, accounts)
             }
-            TokenInstruction::InitializePaymentMint {
-                decimals: _,
-                mint_authority: _,
-                freeze_authority: _,
-                fee_account_owner: _,
-                transfer_fee_basis_points: _,
-                maximum_fee: _,
-            } => {
-                panic!();
-            }
-            TokenInstruction::InitializePaymentAccount { owner: _ } => {
-                panic!();
-            }
-            TokenInstruction::TransferCheckedWithFee {
-                amount: _,
-                decimals: _,
-                transfer_fee_basis_points: _,
-                maximum_fee: _,
-            } => {
-                panic!();
-            }
-            TokenInstruction::HarvestFee => {
-                panic!();
-            }
-            TokenInstruction::ClosePaymentAccount => {
-                panic!();
-            }
-            TokenInstruction::SetTransferFee {
-                transfer_fee_basis_points: _,
-                maximum_fee: _,
-            } => {
-                panic!();
-            }
         }
     }
 

--- a/token/program-2022/src/state.rs
+++ b/token/program-2022/src/state.rs
@@ -4,33 +4,11 @@ use crate::instruction::MAX_SIGNERS;
 use arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs};
 use num_enum::TryFromPrimitive;
 use solana_program::{
-    clock::Epoch,
     program_error::ProgramError,
     program_option::COption,
     program_pack::{IsInitialized, Pack, Sealed},
     pubkey::Pubkey,
 };
-
-/// Different kinds of accounts. Note that `Mint`, `Account`, and `Multisig` types
-/// are determined exclusively by the size of the account, and are not included in
-/// the account data. `AccountType` is only included if extensions have been
-/// initialized.
-#[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum AccountType {
-    /// Marker for 0 data
-    Uninitialized,
-    /// Mint account with additional extensions
-    Mint,
-    /// Token holding account with additional extensions
-    Account,
-}
-
-impl Default for AccountType {
-    fn default() -> Self {
-        Self::Uninitialized
-    }
-}
 
 /// Mint data.
 #[repr(C)]
@@ -268,7 +246,7 @@ impl Pack for Multisig {
 }
 
 // Helpers
-fn pack_coption_key(src: &COption<Pubkey>, dst: &mut [u8; 36]) {
+pub(crate) fn pack_coption_key(src: &COption<Pubkey>, dst: &mut [u8; 36]) {
     let (tag, body) = mut_array_refs![dst, 4, 32];
     match src {
         COption::Some(key) => {
@@ -280,7 +258,7 @@ fn pack_coption_key(src: &COption<Pubkey>, dst: &mut [u8; 36]) {
         }
     }
 }
-fn unpack_coption_key(src: &[u8; 36]) -> Result<COption<Pubkey>, ProgramError> {
+pub(crate) fn unpack_coption_key(src: &[u8; 36]) -> Result<COption<Pubkey>, ProgramError> {
     let (tag, body) = array_refs![src, 4, 32];
     match *tag {
         [0, 0, 0, 0] => Ok(COption::None),
@@ -306,5 +284,115 @@ fn unpack_coption_u64(src: &[u8; 12]) -> Result<COption<u64>, ProgramError> {
         [0, 0, 0, 0] => Ok(COption::None),
         [1, 0, 0, 0] => Ok(COption::Some(u64::from_le_bytes(*body))),
         _ => Err(ProgramError::InvalidAccountData),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_pack_unpack() {
+        // Mint
+        let check = Mint {
+            mint_authority: COption::Some(Pubkey::new(&[1; 32])),
+            supply: 42,
+            decimals: 7,
+            is_initialized: true,
+            freeze_authority: COption::Some(Pubkey::new(&[2; 32])),
+        };
+        let mut packed = vec![0; Mint::get_packed_len() + 1];
+        assert_eq!(
+            Err(ProgramError::InvalidAccountData),
+            Mint::pack(check, &mut packed)
+        );
+        let mut packed = vec![0; Mint::get_packed_len() - 1];
+        assert_eq!(
+            Err(ProgramError::InvalidAccountData),
+            Mint::pack(check, &mut packed)
+        );
+        let mut packed = vec![0; Mint::get_packed_len()];
+        Mint::pack(check, &mut packed).unwrap();
+        let expect = vec![
+            1, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 42, 0, 0, 0, 0, 0, 0, 0, 7, 1, 1, 0, 0, 0, 2, 2, 2, 2, 2, 2, 2, 2,
+            2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        ];
+        assert_eq!(packed, expect);
+        let unpacked = Mint::unpack(&packed).unwrap();
+        assert_eq!(unpacked, check);
+
+        // Account
+        let check = Account {
+            mint: Pubkey::new(&[1; 32]),
+            owner: Pubkey::new(&[2; 32]),
+            amount: 3,
+            delegate: COption::Some(Pubkey::new(&[4; 32])),
+            state: AccountState::Frozen,
+            is_native: COption::Some(5),
+            delegated_amount: 6,
+            close_authority: COption::Some(Pubkey::new(&[7; 32])),
+        };
+        let mut packed = vec![0; Account::get_packed_len() + 1];
+        assert_eq!(
+            Err(ProgramError::InvalidAccountData),
+            Account::pack(check, &mut packed)
+        );
+        let mut packed = vec![0; Account::get_packed_len() - 1];
+        assert_eq!(
+            Err(ProgramError::InvalidAccountData),
+            Account::pack(check, &mut packed)
+        );
+        let mut packed = vec![0; Account::get_packed_len()];
+        Account::pack(check, &mut packed).unwrap();
+        let expect = vec![
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+            2, 2, 2, 2, 2, 2, 3, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+            4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 2, 1, 0, 0, 0, 5, 0, 0,
+            0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+            7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+        ];
+        assert_eq!(packed, expect);
+        let unpacked = Account::unpack(&packed).unwrap();
+        assert_eq!(unpacked, check);
+
+        // Multisig
+        let check = Multisig {
+            m: 1,
+            n: 2,
+            is_initialized: true,
+            signers: [Pubkey::new(&[3; 32]); MAX_SIGNERS],
+        };
+        let mut packed = vec![0; Multisig::get_packed_len() + 1];
+        assert_eq!(
+            Err(ProgramError::InvalidAccountData),
+            Multisig::pack(check, &mut packed)
+        );
+        let mut packed = vec![0; Multisig::get_packed_len() - 1];
+        assert_eq!(
+            Err(ProgramError::InvalidAccountData),
+            Multisig::pack(check, &mut packed)
+        );
+        let mut packed = vec![0; Multisig::get_packed_len()];
+        Multisig::pack(check, &mut packed).unwrap();
+        let expect = vec![
+            1, 2, 1, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+            3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+            3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+            3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+            3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+            3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+            3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+            3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+            3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+            3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+            3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+            3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+            3, 3, 3, 3, 3, 3, 3,
+        ];
+        assert_eq!(packed, expect);
+        let unpacked = Multisig::unpack(&packed).unwrap();
+        assert_eq!(unpacked, check);
     }
 }

--- a/token/program-2022/src/state.rs
+++ b/token/program-2022/src/state.rs
@@ -10,6 +10,29 @@ use solana_program::{
     pubkey::Pubkey,
 };
 
+/// Different kinds of accounts. Note that `Mint` and `Account` types are determined
+/// exclusively by the size of the account, and are not included in the account data.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum AccountType {
+    /// Nothing, uninitialized
+    Uninitialized,
+    /// Base mint
+    Mint,
+    /// Base token account
+    Account,
+    /// Mints that assess a transfer fee
+    MintWithTransferFee,
+    /// Accounts that require transfer fees
+    AccountWithTransferFee,
+}
+
+impl Default for AccountType {
+    fn default() -> Self {
+        Self::Uninitialized
+    }
+}
+
 /// Mint data.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
@@ -78,6 +101,55 @@ impl Pack for Mint {
         is_initialized_dst[0] = is_initialized as u8;
         pack_coption_key(freeze_authority, freeze_authority_dst);
     }
+}
+
+/// MintWithTransferFee data.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct MintWithTransferFee {
+    /// Base mint data, done as composition
+    pub base_mint: Mint,
+
+    /// ALL NEW DATA MUST START FROM HERE
+    /// account type, always set to "MintWithTransferFee"
+    pub account_type: AccountType,
+    /// Any provided fee account must be owned by this key. If set to `None`, then
+    /// this mint behaves like a normal `Mint`.
+    pub fee_account_owner: COption<Pubkey>,
+    /// Amount of transfer collected as fees, expressed as basis points of the
+    /// transfer amount, ie.  increments of 0.01%
+    pub transfer_fee_basis_points: u16,
+    /// Maximum fee assessed on transfers, expressed as an amount of tokens
+    pub maximum_fee: u64,
+}
+
+/// `UberMint` contains all of the possible data in any Mint, to be used instead
+/// of `Mint` in programs.  Instead of using `Mint::unpack`, use
+/// `UberMint::unpack`, and the unpack works for any Mint type, filling in
+/// the appropriate type.
+/// When writing data back to the buffer, `UberMint::pack` respects the type contained,
+/// and errors if unusable fields have been populated or changed.  For example,
+/// if the fee is set on a normal Mint, it will error.
+///
+/// Name TBD. Other options: MetaMint, AllMint, OverMint, MegaMint.
+/// OR we rename Mint to BaseMint, and then call this Mint.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct UberMint {
+    /// Base mint data, done as composition
+    pub base_mint: Mint,
+
+    /// Account type, can be either Mint or MintWithTransferFee
+    pub account_type: AccountType,
+    /// Fee account must be owned by this key. If set to `None`, then this mint
+    /// behaves like a normal `Mint`.
+    pub fee_account_owner: COption<Pubkey>,
+    /// Amount of transfer collected as fees, expressed as basis points of the
+    /// transfer amount, ie.  increments of 0.01%
+    pub transfer_fee_basis_points: u16,
+    /// Maximum fee assessed on transfers, expressed
+    pub maximum_fee: u64,
+    // ADD ANY NEW MINT FIELDS HERE
 }
 
 /// Account data.
@@ -189,6 +261,34 @@ impl Default for AccountState {
     fn default() -> Self {
         AccountState::Uninitialized
     }
+}
+
+/// AccountWithTransferFee data.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct AccountWithTransferFee {
+    /// All base account data, done through composition
+    pub base_account: Account,
+
+    /// ALL NEW DATA STARTS HERE
+    /// Account type, must always be AccountType::AccountWithTransferFee
+    pub account_type: AccountType,
+    /// Amount withheld during transfers, to be claimed by the fee recipient
+    pub withheld_amount: u64,
+}
+
+/// See the discussion at `UberMint` about the concept of this type.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct UberAccount {
+    /// All base account data, done through composition
+    pub base_account: Account,
+
+    /// Account type, can be either Account or AccountWithTransferFee
+    pub account_type: AccountType,
+    /// Amount withheld during transfers, to be claimed by the fee recipient
+    pub withheld_amount: u64,
+    // ADD ANY NEW ACCOUNT FIELDS HERE
 }
 
 /// Multisignature data.

--- a/token/program-2022/src/state.rs
+++ b/token/program-2022/src/state.rs
@@ -13,7 +13,7 @@ use solana_program::{
 
 /// Different kinds of accounts. Note that `Mint`, `Account`, and `Multisig` types
 /// are determined exclusively by the size of the account, and are not included in
-/// the account data. These `AccountType`s are only included if extensions have been
+/// the account data. `AccountType` is only included if extensions have been
 /// initialized.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -30,22 +30,6 @@ impl Default for AccountType {
     fn default() -> Self {
         Self::Uninitialized
     }
-}
-
-/// Extensions that can be applied to mints or accounts.  Mint extensions must only be
-/// applied to mint accounts, and account extensions must only be applied to holding
-/// accounts.
-#[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum Extension {
-    /// Used as padding if the account size would otherwise be 355, same as a multisig
-    Uninitialized,
-    /// Includes a transfer fee and accompanying authorities to harvest and set the fee
-    MintTransferFee,
-    /// Includes withheld transfer fees
-    AccountTransferFee,
-    /// Includes an optional mint close authority
-    MintCloseAuthority,
 }
 
 /// Mint data.
@@ -116,52 +100,6 @@ impl Pack for Mint {
         is_initialized_dst[0] = is_initialized as u8;
         pack_coption_key(freeze_authority, freeze_authority_dst);
     }
-}
-
-/// Type-Length-Value Entry, used to encapsulate all extensions contained within an account
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
-pub struct TlvEntry<V> {
-    pub extension: Extension,
-    pub length: u32,
-    pub value: V,
-}
-
-/// Close authority extension data for mints.
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
-pub struct MintCloseAuthorityExtension {
-    /// Optional authority to close the mint
-    pub close_authority: COption<Pubkey>,
-}
-
-/// Transfer fee information
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
-pub struct TransferFee {
-    /// First epoch where the transfer fee takes effect
-    pub epoch: Epoch,
-    /// Amount of transfer collected as fees, expressed as basis points of the
-    /// transfer amount, ie.  increments of 0.01%
-    pub transfer_fee_basis_points: u16,
-    /// Maximum fee assessed on transfers, expressed as an amount of tokens
-    pub maximum_fee: u64,
-}
-
-/// Transfer fee extension data for mints.
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
-pub struct MintTransferFeeExtension {
-    /// Optional authority to set the fee
-    pub transfer_fee_config_authority: COption<Pubkey>,
-    /// Harvest from mint instructions must be signed by this key
-    pub withheld_withdraw_authority: COption<Pubkey>,
-    /// Withheld transfer fee tokens that have been moved to the mint for withdrawal
-    pub withheld_amount: u64,
-    /// Older transfer fee, used if the current epoch < new_transfer_fee.epoch
-    pub older_transfer_fee: TransferFee,
-    /// Newer transfer fee, used if the current epoch >= new_transfer_fee.epoch
-    pub newer_transfer_fee: TransferFee,
 }
 
 /// Account data.
@@ -273,14 +211,6 @@ impl Default for AccountState {
     fn default() -> Self {
         AccountState::Uninitialized
     }
-}
-
-/// Transfer fee extension data for accounts.
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
-pub struct AccountTransferFeeExtension {
-    /// Amount withheld during transfers, to be harvested by the fee withdraw authority
-    pub withheld_amount: u64,
 }
 
 /// Multisignature data.

--- a/token/program-2022/src/state.rs
+++ b/token/program-2022/src/state.rs
@@ -21,16 +21,32 @@ pub enum AccountType {
     Mint,
     /// Base token account
     Account,
-    /// Mints with payment system features
-    PaymentMint,
-    /// Accounts with payment system features
-    PaymentAccount,
 }
 
 impl Default for AccountType {
     fn default() -> Self {
         Self::Uninitialized
     }
+}
+
+/// Mixins that can be applied to a mint
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum MintMixin {
+    /// Reserved as 0, or for padding
+    None,
+    /// Includes a transfer fee and accompanying authorities to harvest and set the fee
+    TransferFee,
+}
+
+/// Mixins that can be applied to an account
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum AccountMixin {
+    /// Reserved as 0, or for padding
+    None,
+    /// Includes withheld transfer fees
+    TransferFee,
 }
 
 /// Mint data.
@@ -103,16 +119,12 @@ impl Pack for Mint {
     }
 }
 
-/// PaymentMint data.
+/// Transfer fee mixin data for mints.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
-pub struct PaymentMint {
-    /// Base mint data, done as composition
-    pub base_mint: Mint,
-
-    /// ALL NEW DATA MUST START FROM HERE
-    /// account type, always set to "PaymentMint"
-    pub account_type: AccountType,
+pub struct MintTransferFeeMixin {
+    /// mixin type, always set to "TransferFee"
+    pub mixin_type: MintMixin,
     /// Optional authority to set the fee
     pub fee_config_authority: COption<Pubkey>,
     /// Any harvest instruction must be signed by this key. If set to `None`, then
@@ -238,16 +250,12 @@ impl Default for AccountState {
     }
 }
 
-/// PaymentAccount data.
+/// Transfer fee mixin data for accounts.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
-pub struct PaymentAccount {
-    /// All base account data, done through composition
-    pub base_account: Account,
-
-    /// ALL NEW DATA STARTS HERE
-    /// Account type, must always be AccountType::PaymentAccount
-    pub account_type: AccountType,
+pub struct AccountTransferFeeMixin {
+    /// mixin type, always set to "TransferFee"
+    pub mixin_type: AccountMixin,
     /// Amount withheld during transfers, to be harvested by the fee withdraw authority
     pub withheld_amount: u64,
 }

--- a/token/program-2022/tests/action.rs
+++ b/token/program-2022/tests/action.rs
@@ -98,6 +98,7 @@ pub async fn mint_to(
     Ok(())
 }
 
+#[allow(deprecated)]
 pub async fn transfer(
     banks_client: &mut BanksClient,
     payer: &Keypair,

--- a/token/program-2022/tests/assert_instruction_count.rs
+++ b/token/program-2022/tests/assert_instruction_count.rs
@@ -59,7 +59,7 @@ async fn initialize_mint() {
 
 #[tokio::test]
 async fn initialize_account() {
-    let mut pt = ProgramTest::new("spl_token", id(), processor!(Processor::process));
+    let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
     pt.set_bpf_compute_max_units(4_000); // last known 3284
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
@@ -111,7 +111,7 @@ async fn initialize_account() {
 
 #[tokio::test]
 async fn mint_to() {
-    let mut pt = ProgramTest::new("spl_token", id(), processor!(Processor::process));
+    let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
     pt.set_bpf_compute_max_units(4_000); // last known 2668
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
@@ -160,7 +160,7 @@ async fn mint_to() {
 
 #[tokio::test]
 async fn transfer() {
-    let mut pt = ProgramTest::new("spl_token", id(), processor!(Processor::process));
+    let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
     pt.set_bpf_compute_max_units(4_000); // last known 2972
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
@@ -228,7 +228,7 @@ async fn transfer() {
 
 #[tokio::test]
 async fn burn() {
-    let mut pt = ProgramTest::new("spl_token", id(), processor!(Processor::process));
+    let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
     pt.set_bpf_compute_max_units(4_000); // last known 2655
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 


### PR DESCRIPTION
#### Problem

It isn't possible to assess fees on token transfers.

#### Solution

Add new account types for Mints / Accounts with transfer fees, along with an over-type to handle any type, see `UberMint` for more info.

Add instructions for initializing mints with transfer fees, setting fees, transferring tokens, and transferring withheld tokens.