### PR TITLE
lending: validate pyth price trading status

### DIFF
--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -1775,6 +1775,11 @@ fn get_pyth_price(pyth_price_info: &AccountInfo, clock: &Clock) -> Result<Decima
         return Err(LendingError::InvalidOracleConfig.into());
     }
 
+    if pyth_price.agg.status != pyth::PriceStatus::Trading {
+        msg!("Oracle price status is invalid");
+        return Err(LendingError::InvalidOracleConfig.into());
+    }
+
     let slots_elapsed = clock
         .slot
         .checked_sub(pyth_price.valid_slot)

--- a/token-lending/program/src/pyth.rs
+++ b/token-lending/program/src/pyth.rs
@@ -20,7 +20,7 @@ pub struct AccKey {
     pub val: [u8; 32],
 }
 
-#[derive(Copy, Clone)]
+#[derive(PartialEq, Copy, Clone)]
 #[repr(C)]
 pub enum AccountType {
     Unknown,
@@ -29,7 +29,7 @@ pub enum AccountType {
     Price,
 }
 
-#[derive(Copy, Clone)]
+#[derive(PartialEq, Copy, Clone)]
 #[repr(C)]
 pub enum PriceStatus {
     Unknown,
@@ -38,7 +38,7 @@ pub enum PriceStatus {
     Auction,
 }
 
-#[derive(Copy, Clone)]
+#[derive(PartialEq, Copy, Clone)]
 #[repr(C)]
 pub enum CorpAction {
     NoCorpAct,


### PR DESCRIPTION
Pyth's [best practices guide](https://docs.pyth.network/consumers/best-practices) encourages checking the price's status to make sure it's valid.