### PR TITLE
stake-pool: Mint extra reserve lamports as pool tokens on init

### DIFF
--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -314,6 +314,7 @@ fn command_create_pool(
                 &stake_pool_keypair.pubkey(),
                 &config.manager.pubkey(),
                 &config.staker.pubkey(),
+                &withdraw_authority,
                 &validator_list_keypair.pubkey(),
                 &reserve_keypair.pubkey(),
                 &mint_keypair.pubkey(),

--- a/stake-pool/program/src/instruction.rs
+++ b/stake-pool/program/src/instruction.rs
@@ -49,13 +49,14 @@ pub enum StakePoolInstruction {
     ///   0. `[w]` New StakePool to create.
     ///   1. `[s]` Manager
     ///   2. `[]` Staker
-    ///   3. `[w]` Uninitialized validator stake list storage account
-    ///   4. `[]` Reserve stake account must be initialized, have zero balance,
+    ///   3. `[]` Stake pool withdraw authority
+    ///   4. `[w]` Uninitialized validator stake list storage account
+    ///   5. `[]` Reserve stake account must be initialized, have zero balance,
     ///       and staker / withdrawer authority set to pool withdraw authority.
-    ///   5. `[]` Pool token mint. Must have zero supply, owned by withdraw authority.
-    ///   6. `[]` Pool account to deposit the generated fee for manager.
-    ///   7. `[]` Token program id
-    ///   8. `[]` (Optional) Deposit authority that must sign all deposits.
+    ///   6. `[]` Pool token mint. Must have zero supply, owned by withdraw authority.
+    ///   7. `[]` Pool account to deposit the generated fee for manager.
+    ///   8. `[]` Token program id
+    ///   9. `[]` (Optional) Deposit authority that must sign all deposits.
     ///      Defaults to the program address generated using
     ///      `find_deposit_authority_program_address`, making deposits permissionless.
     Initialize {
@@ -380,6 +381,7 @@ pub fn initialize(
     stake_pool: &Pubkey,
     manager: &Pubkey,
     staker: &Pubkey,
+    stake_pool_withdraw_authority: &Pubkey,
     validator_list: &Pubkey,
     reserve_stake: &Pubkey,
     pool_mint: &Pubkey,
@@ -404,10 +406,11 @@ pub fn initialize(
         AccountMeta::new(*stake_pool, false),
         AccountMeta::new_readonly(*manager, true),
         AccountMeta::new_readonly(*staker, false),
+        AccountMeta::new_readonly(*stake_pool_withdraw_authority, false),
         AccountMeta::new(*validator_list, false),
         AccountMeta::new_readonly(*reserve_stake, false),
-        AccountMeta::new_readonly(*pool_mint, false),
-        AccountMeta::new_readonly(*manager_pool_account, false),
+        AccountMeta::new(*pool_mint, false),
+        AccountMeta::new(*manager_pool_account, false),
         AccountMeta::new_readonly(*token_program_id, false),
     ];
     if let Some(deposit_authority) = deposit_authority {

--- a/stake-pool/py/stake_pool/actions.py
+++ b/stake-pool/py/stake_pool/actions.py
@@ -63,6 +63,8 @@ async def create(client: AsyncClient, manager: Keypair,
     await client.send_transaction(
         txn, manager, stake_pool, validator_list, opts=TxOpts(skip_confirmation=False, preflight_commitment=Confirmed))
 
+    (withdraw_authority, seed) = find_withdraw_authority_program_address(
+        STAKE_POOL_PROGRAM_ID, stake_pool.public_key)
     txn = Transaction()
     txn.add(
         sp.initialize(
@@ -71,6 +73,7 @@ async def create(client: AsyncClient, manager: Keypair,
                 stake_pool=stake_pool.public_key,
                 manager=manager.public_key,
                 staker=manager.public_key,
+                withdraw_authority=withdraw_authority,
                 validator_list=validator_list.public_key,
                 reserve_stake=reserve_stake,
                 pool_mint=pool_mint,

--- a/stake-pool/py/stake_pool/instructions.py
+++ b/stake-pool/py/stake_pool/instructions.py
@@ -49,14 +49,16 @@ class InitializeParams(NamedTuple):
     """[s] Manager for new stake pool."""
     staker: PublicKey
     """[] Staker for the new stake pool."""
+    withdraw_authority: PublicKey
+    """[] Withdraw authority for the new stake pool."""
     validator_list: PublicKey
     """[w] Uninitialized validator list account for the new stake pool."""
     reserve_stake: PublicKey
     """[] Reserve stake account."""
     pool_mint: PublicKey
-    """[] Pool token mint account."""
+    """[w] Pool token mint account."""
     manager_fee_account: PublicKey
-    """[] Manager's fee account"""
+    """[w] Manager's fee account"""
     token_program_id: PublicKey
     """[] SPL Token program id."""
 
@@ -535,10 +537,11 @@ def initialize(params: InitializeParams) -> TransactionInstruction:
         AccountMeta(pubkey=params.stake_pool, is_signer=False, is_writable=True),
         AccountMeta(pubkey=params.manager, is_signer=True, is_writable=False),
         AccountMeta(pubkey=params.staker, is_signer=False, is_writable=False),
+        AccountMeta(pubkey=params.withdraw_authority, is_signer=False, is_writable=False),
         AccountMeta(pubkey=params.validator_list, is_signer=False, is_writable=True),
         AccountMeta(pubkey=params.reserve_stake, is_signer=False, is_writable=False),
-        AccountMeta(pubkey=params.pool_mint, is_signer=False, is_writable=False),
-        AccountMeta(pubkey=params.manager_fee_account, is_signer=False, is_writable=False),
+        AccountMeta(pubkey=params.pool_mint, is_signer=False, is_writable=True),
+        AccountMeta(pubkey=params.manager_fee_account, is_signer=False, is_writable=True),
         AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
     ]
     if params.deposit_authority:

--- a/stake-pool/py/tests/conftest.py
+++ b/stake-pool/py/tests/conftest.py
@@ -113,6 +113,9 @@ class Waiter:
         resp = await async_client.get_epoch_info(commitment=Confirmed)
         if resp['result']['slotsInEpoch'] - resp['result']['slotIndex'] < 10:
             await Waiter.wait_for_next_epoch(async_client)
+            return True
+        else:
+            return False
 
 
 @pytest.fixture

--- a/stake-pool/py/tests/conftest.py
+++ b/stake-pool/py/tests/conftest.py
@@ -111,7 +111,7 @@ class Waiter:
     @staticmethod
     async def wait_for_next_epoch_if_soon(async_client: AsyncClient):
         resp = await async_client.get_epoch_info(commitment=Confirmed)
-        if resp['result']['slotsInEpoch'] - resp['result']['slotIndex'] < 10:
+        if resp['result']['slotsInEpoch'] - resp['result']['slotIndex'] < NUM_SLOTS_PER_EPOCH // 2:
             await Waiter.wait_for_next_epoch(async_client)
             return True
         else:

--- a/stake-pool/py/tests/test_deposit_withdraw_stake.py
+++ b/stake-pool/py/tests/test_deposit_withdraw_stake.py
@@ -1,6 +1,5 @@
 import asyncio
 import pytest
-from typing import Tuple
 from solana.rpc.async_api import AsyncClient
 from solana.rpc.commitment import Confirmed
 from solana.keypair import Keypair
@@ -16,11 +15,11 @@ from stake_pool.state import StakePool
 async def prepare_stake(
     async_client: AsyncClient, payer: Keypair, stake_pool_address: PublicKey,
     validator: PublicKey, token_account: PublicKey, stake_amount: int
-) -> Tuple[PublicKey, PublicKey]:
+) -> PublicKey:
     stake = Keypair()
     await create_stake(async_client, payer, stake, payer.public_key, stake_amount)
     await delegate_stake(async_client, payer, payer, stake.public_key, validator)
-    return (stake.public_key, validator)
+    return stake.public_key
 
 
 @pytest.mark.asyncio
@@ -33,22 +32,19 @@ async def test_deposit_withdraw_stake(async_client, validators, payer, stake_poo
 
     resp = await async_client.get_minimum_balance_for_rent_exemption(STAKE_LEN)
     stake_rent_exemption = resp['result']
-    await waiter.wait_for_next_epoch_if_soon(async_client)
-    await update_stake_pool(async_client, payer, stake_pool_address)
+    waited = await waiter.wait_for_next_epoch_if_soon(async_client)
+    if waited:
+        await update_stake_pool(async_client, payer, stake_pool_address)
 
     stake_amount = 1_000_000
-    futures = [
-        prepare_stake(async_client, payer, stake_pool_address, validator, token_account, stake_amount)
-        for validator in validators
-    ]
-    stakes = await asyncio.gather(*futures)
+    stakes = []
+    for validator in validators:
+        stake = await prepare_stake(async_client, payer, stake_pool_address, validator, token_account, stake_amount)
+        stakes.append(stake)
     await waiter.wait_for_next_epoch(async_client)
     await update_stake_pool(async_client, payer, stake_pool_address)
-    futures = [
-        deposit_stake(async_client, payer, stake_pool_address, validator, stake, token_account)
-        for (stake, validator) in stakes
-    ]
-    stakes = await asyncio.gather(*futures)
+    for (stake, validator) in zip(stakes, validators):
+        await deposit_stake(async_client, payer, stake_pool_address, validator, stake, token_account)
 
     pool_token_balance = await async_client.get_token_account_balance(token_account, Confirmed)
     pool_token_balance = pool_token_balance['result']['value']['amount']

--- a/stake-pool/py/tests/test_deposit_withdraw_stake.py
+++ b/stake-pool/py/tests/test_deposit_withdraw_stake.py
@@ -1,25 +1,12 @@
-import asyncio
 import pytest
-from solana.rpc.async_api import AsyncClient
 from solana.rpc.commitment import Confirmed
 from solana.keypair import Keypair
-from solana.publickey import PublicKey
 from spl.token.instructions import get_associated_token_address
 
 from stake.actions import create_stake, delegate_stake
 from stake.constants import STAKE_LEN
 from stake_pool.actions import deposit_stake, withdraw_stake, update_stake_pool
 from stake_pool.state import StakePool
-
-
-async def prepare_stake(
-    async_client: AsyncClient, payer: Keypair, stake_pool_address: PublicKey,
-    validator: PublicKey, token_account: PublicKey, stake_amount: int
-) -> PublicKey:
-    stake = Keypair()
-    await create_stake(async_client, payer, stake, payer.public_key, stake_amount)
-    await delegate_stake(async_client, payer, payer, stake.public_key, validator)
-    return stake.public_key
 
 
 @pytest.mark.asyncio
@@ -36,29 +23,26 @@ async def test_deposit_withdraw_stake(async_client, validators, payer, stake_poo
     if waited:
         await update_stake_pool(async_client, payer, stake_pool_address)
 
+    validator = next(iter(validators))
     stake_amount = 1_000_000
-    stakes = []
-    for validator in validators:
-        stake = await prepare_stake(async_client, payer, stake_pool_address, validator, token_account, stake_amount)
-        stakes.append(stake)
+    stake = Keypair()
+    await create_stake(async_client, payer, stake, payer.public_key, stake_amount)
+    stake = stake.public_key
+    await delegate_stake(async_client, payer, payer, stake, validator)
     await waiter.wait_for_next_epoch(async_client)
     await update_stake_pool(async_client, payer, stake_pool_address)
-    for (stake, validator) in zip(stakes, validators):
-        await deposit_stake(async_client, payer, stake_pool_address, validator, stake, token_account)
+    await deposit_stake(async_client, payer, stake_pool_address, validator, stake, token_account)
 
     pool_token_balance = await async_client.get_token_account_balance(token_account, Confirmed)
     pool_token_balance = pool_token_balance['result']['value']['amount']
-    assert pool_token_balance == str((stake_amount + stake_rent_exemption) * len(validators))
+    assert pool_token_balance == str(stake_amount + stake_rent_exemption)
 
-    futures = []
-    for validator in validators:
-        destination_stake = Keypair()
-        futures.append(withdraw_stake(
-            async_client, payer, payer, destination_stake, stake_pool_address, validator,
-            payer.public_key, token_account, stake_amount
-        ))
-    await asyncio.gather(*futures)
+    destination_stake = Keypair()
+    await withdraw_stake(
+        async_client, payer, payer, destination_stake, stake_pool_address, validator,
+        payer.public_key, token_account, stake_amount
+    )
 
     pool_token_balance = await async_client.get_token_account_balance(token_account, Confirmed)
     pool_token_balance = pool_token_balance['result']['value']['amount']
-    assert pool_token_balance == str(stake_rent_exemption * len(validators))
+    assert pool_token_balance == str(stake_rent_exemption)


### PR DESCRIPTION
#### Problem

If a pool creator puts too many lamports in the reserve account on creation, those are essentially lost.  This behavior is unclear.

#### Solution

Credit the additional reserve lamports as pool tokens on init.

Big thanks to @soteria-bc / Soteria for reporting this issue!