### PR TITLE
token: Extension state packing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3980,6 +3980,7 @@ name = "spl-token-2022"
 version = "0.1.0"
 dependencies = [
  "arrayref",
+ "bytemuck",
  "num-derive",
  "num-traits",
  "num_enum",

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -14,6 +14,7 @@ test-bpf = []
 
 [dependencies]
 arrayref = "0.3.6"
+bytemuck = { version = "1.7.2", features = ["derive"] }
 num-derive = "0.3"
 num-traits = "0.2"
 num_enum = "0.5.4"

--- a/token/program-2022/src/extension.rs
+++ b/token/program-2022/src/extension.rs
@@ -124,7 +124,7 @@ fn type_and_tlv_indices<S: BaseState>(rest_input: &[u8]) -> Result<(usize, usize
 pub struct StateWithExtensions<'data, S: BaseState> {
     /// Unpacked base data
     pub base: S,
-    /// Unpacked base data
+    /// Unpacked account type
     pub account_type: AccountType,
     /// Slice of data containing all TLV data, deserialized on demand
     tlv_data: &'data [u8],
@@ -340,7 +340,7 @@ pub fn get_account_len(extension_types: &[ExtensionType]) -> usize {
         })
         .sum();
     let total_extension_size = if extension_size == Multisig::LEN {
-        extension_size + 1
+        extension_size.saturating_add(size_of::<ExtensionType>())
     } else {
         extension_size
     };

--- a/token/program-2022/src/extension.rs
+++ b/token/program-2022/src/extension.rs
@@ -258,10 +258,9 @@ impl<'data, S: BaseState> StateWithExtensionsMut<'data, S> {
 
     /// Write the account type into the buffer, done during the base
     /// state initialization
-    /// Noop if no extensions are present
+    /// Noops if there is no room for an extension in the account, needed for
+    /// pure base mints / accounts.
     pub fn init_account_type(&mut self) {
-        // TODO maybe we can do this on `pack_base`, but that means writing this
-        // every time there's a change to the base mint / account.
         if !self.account_type.is_empty() {
             self.account_type[0] = S::ACCOUNT_TYPE.into();
         }

--- a/token/program-2022/src/extension.rs
+++ b/token/program-2022/src/extension.rs
@@ -1,6 +1,185 @@
 //! Extensions available to token mints and accounts
 
-use solana_program::{clock::Epoch, program_option::COption, pubkey::Pubkey};
+use {
+    crate::state::{pack_coption_key, unpack_coption_key, Account, Mint, Multisig},
+    arrayref::{array_mut_ref, array_ref},
+    solana_program::{
+        clock::Epoch,
+        program_error::ProgramError,
+        program_option::COption,
+        program_pack::{IsInitialized, Pack, Sealed},
+        pubkey::Pubkey,
+    },
+    std::convert::{TryFrom, TryInto},
+};
+
+const TYPE_LEN: usize = 1;
+const LENGTH_LEN: usize = 4;
+
+// TODO probably need an immutable version of this for clients
+/// Encapsulates base state data (mint or account) with possible extensions
+#[derive(Debug, PartialEq)]
+pub struct BaseStateWithExtensions<'data, S: BaseState> {
+    /// Unpacked base data
+    pub base: S,
+    /// Raw base data
+    pub base_data: &'data mut [u8],
+    /// Slice of data containing all TLV data, deserialized on demand
+    pub tlv_data: &'data mut [u8],
+}
+impl<'data, S: BaseState + Pack + IsInitialized> BaseStateWithExtensions<'data, S> {
+    /// Unpack the base state portion of the buffer, leaving the extension data as
+    /// a serialized slice.
+    pub fn unpack(input: &'data mut [u8]) -> Result<Self, ProgramError> {
+        let input_len = input.len();
+        if input_len == Multisig::LEN {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        let (base_data, rest) = input.split_at_mut(S::LEN);
+        let base = S::unpack(base_data)?;
+        if input_len == S::LEN {
+            Ok(Self {
+                base,
+                base_data,
+                tlv_data: rest, // empty slice
+            })
+        } else {
+            let tlv_start_index = Account::LEN.saturating_sub(S::LEN);
+            let account_type: AccountType = rest[tlv_start_index].try_into()?;
+            if account_type != S::ACCOUNT_TYPE {
+                return Err(ProgramError::InvalidAccountData);
+            }
+            Ok(Self {
+                base,
+                base_data,
+                tlv_data: &mut rest[tlv_start_index..],
+            })
+        }
+    }
+
+    /// Unpack the base state portion of the buffer without checking for initialization,
+    /// leaving the extension data as a serialized slice.
+    ///
+    /// The base state of the struct may be totally unusable.
+    pub fn unpack_unchecked(input: &'data mut [u8]) -> Result<Self, ProgramError> {
+        let input_len = input.len();
+        if input_len == Multisig::LEN {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        let (base_data, rest) = input.split_at_mut(S::LEN);
+        let base = S::unpack_unchecked(base_data)?;
+        let tlv_data = if input_len == S::LEN {
+            rest // empty slice
+        } else {
+            let tlv_start_index = Account::LEN.saturating_sub(S::LEN);
+            &mut rest[tlv_start_index..]
+        };
+        Ok(Self {
+            base,
+            base_data,
+            tlv_data,
+        })
+    }
+
+    /// Unpack a portion of the TLV data as the desired type
+    pub fn unpack_extension<V: Pack + Extension>(&self) -> Result<V, ProgramError> {
+        // TODO: this might not be necessary, but may save some footguns?
+        if V::ACCOUNT_TYPE != S::ACCOUNT_TYPE {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        let mut start_index = 1; // start one byte in to skip the account type
+        while start_index < self.tlv_data.len() {
+            let length_start_index = start_index.saturating_add(TYPE_LEN);
+            let length_end_index = length_start_index.saturating_add(LENGTH_LEN);
+
+            let extension_type: ExtensionType = self.tlv_data[start_index].try_into()?;
+            if extension_type == ExtensionType::Uninitialized {
+                start_index = length_start_index;
+            } else {
+                let length = u32::from_le_bytes(
+                    self.tlv_data[length_start_index..length_end_index]
+                        .try_into()
+                        .unwrap(),
+                ) as usize;
+                let value_start_index = length_end_index;
+                let value_end_index = value_start_index.saturating_add(length);
+                if extension_type == V::TYPE {
+                    return V::unpack_unchecked(&self.tlv_data[value_start_index..value_end_index]);
+                } else {
+                    start_index = value_end_index;
+                }
+            };
+        }
+        Err(ProgramError::InvalidAccountData)
+    }
+
+    /// Packs base state data into the base data portion
+    pub fn pack_base(&mut self, new_base: S) {
+        self.base = new_base;
+        S::pack_into_slice(&self.base, self.base_data);
+    }
+
+    /// Packs the extension data into an open slot if not already found in the
+    /// data buffer, otherwise overwrites itself
+    pub fn pack_extension<V: Pack + Extension>(
+        &mut self,
+        extension: V,
+    ) -> Result<(), ProgramError> {
+        // TODO: this might not be necessary, but may save some footguns?
+        if V::ACCOUNT_TYPE != S::ACCOUNT_TYPE {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        let mut start_index = 1; // start one byte in for the account type
+        while start_index < self.tlv_data.len() {
+            let length_start_index = start_index.saturating_add(TYPE_LEN);
+            let length_end_index = length_start_index.saturating_add(LENGTH_LEN);
+
+            let value_start_index = length_end_index;
+            let extension_type: ExtensionType = self.tlv_data[start_index].try_into()?;
+            if extension_type == ExtensionType::Uninitialized {
+                // Got to an uninitialized spot, write here
+                self.tlv_data[start_index] = V::TYPE as u8;
+                let length = &mut self.tlv_data[length_start_index..length_end_index];
+
+                // maybe this becomes smarter later for dynamically sized extensions
+                length.copy_from_slice(&(V::LEN as u32).to_le_bytes());
+
+                let value_end_index = value_start_index.saturating_add(V::LEN);
+                return Pack::pack(
+                    extension,
+                    &mut self.tlv_data[value_start_index..value_end_index],
+                );
+            } else {
+                let length = u32::from_le_bytes(
+                    self.tlv_data[length_start_index..length_end_index]
+                        .try_into()
+                        .unwrap(),
+                ) as usize;
+                let value_end_index = value_start_index.saturating_add(length);
+                if extension_type == V::TYPE {
+                    return Pack::pack(
+                        extension,
+                        &mut self.tlv_data[value_start_index..value_end_index],
+                    );
+                } else {
+                    start_index = value_end_index;
+                }
+            }
+        }
+        Err(ProgramError::AccountDataTooSmall)
+    }
+
+    /// Write the account type into the buffer, done during the base
+    /// state initialization
+    /// Noop if no extensions are present
+    pub fn pack_account_type(&mut self) {
+        // TODO maybe we can do this on `pack_base`, but that means writing this
+        // every time there's a change to the base mint / account.
+        if !self.tlv_data.is_empty() {
+            self.tlv_data[0] = S::ACCOUNT_TYPE as u8;
+        }
+    }
+}
 
 /// Different kinds of accounts. Note that `Mint`, `Account`, and `Multisig` types
 /// are determined exclusively by the size of the account, and are not included in
@@ -22,13 +201,25 @@ impl Default for AccountType {
         Self::Uninitialized
     }
 }
+impl TryFrom<u8> for AccountType {
+    type Error = ProgramError;
+
+    fn try_from(account_type: u8) -> Result<Self, Self::Error> {
+        match account_type {
+            0 => Ok(AccountType::Uninitialized),
+            1 => Ok(AccountType::Mint),
+            2 => Ok(AccountType::Account),
+            _ => Err(ProgramError::InvalidAccountData),
+        }
+    }
+}
 
 /// Extensions that can be applied to mints or accounts.  Mint extensions must only be
 /// applied to mint accounts, and account extensions must only be applied to token holding
 /// accounts.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub enum Extension {
+pub enum ExtensionType {
     /// Used as padding if the account size would otherwise be 355, same as a multisig
     Uninitialized,
     /// Includes a transfer fee and accompanying authorities to withdraw and set the fee
@@ -38,30 +229,104 @@ pub enum Extension {
     /// Includes an optional mint close authority
     MintCloseAuthority,
 }
+impl TryFrom<u8> for ExtensionType {
+    type Error = ProgramError;
 
-/// Type-Length-Value Entry, used to encapsulate all extensions contained within an account
-#[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct TlvEntry<V> {
-    /// Extension type encoded in the rest of the entry
-    pub extension: Extension,
-    /// Length of the entry, in bytes
-    pub length: u32,
-    /// Deserialized value
-    pub value: V,
+    fn try_from(extension_type: u8) -> Result<Self, Self::Error> {
+        match extension_type {
+            0 => Ok(ExtensionType::Uninitialized),
+            1 => Ok(ExtensionType::MintTransferFee),
+            2 => Ok(ExtensionType::AccountTransferFee),
+            3 => Ok(ExtensionType::MintCloseAuthority),
+            _ => Err(ProgramError::InvalidAccountData),
+        }
+    }
+}
+impl ExtensionType {
+    /// Get the data length of the type associated with the enum
+    pub fn get_associated_type_len(&self) -> usize {
+        match self {
+            ExtensionType::Uninitialized => 0,
+            ExtensionType::MintTransferFee => MintTransferFee::LEN,
+            ExtensionType::AccountTransferFee => AccountTransferFee::LEN,
+            ExtensionType::MintCloseAuthority => MintCloseAuthority::LEN,
+        }
+    }
+}
+
+/// Get the required account data length for the given ExtensionTypes
+pub fn get_account_len(extension_types: &[ExtensionType]) -> usize {
+    let extension_size: usize = extension_types
+        .iter()
+        .map(|e| {
+            e.get_associated_type_len()
+                .saturating_add(TYPE_LEN)
+                .saturating_add(LENGTH_LEN)
+        })
+        .sum();
+    let total_extension_size = if extension_size == Multisig::LEN {
+        extension_size + 1
+    } else {
+        extension_size
+    };
+    total_extension_size
+        .saturating_add(Account::LEN)
+        .saturating_add(1) // for account type
+}
+
+/// Trait for base states, specifying the associated enum
+pub trait BaseState {
+    /// Associated extension type enum, checked at the start of TLV entries
+    const ACCOUNT_TYPE: AccountType;
+}
+impl BaseState for Account {
+    const ACCOUNT_TYPE: AccountType = AccountType::Account;
+}
+impl BaseState for Mint {
+    const ACCOUNT_TYPE: AccountType = AccountType::Mint;
+}
+
+/// Trait to be implemented by all extension states, specifying which extension
+/// and account type they are associated with
+pub trait Extension {
+    /// Associated extension type enum, checked at the start of TLV entries
+    const TYPE: ExtensionType;
+    /// Associated account type enum, checked for compatibility when reading or
+    /// writing extensions into the buffer
+    const ACCOUNT_TYPE: AccountType;
 }
 
 /// Close authority extension data for mints.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct MintCloseAuthority {
     /// Optional authority to close the mint
     pub close_authority: COption<Pubkey>,
 }
+impl Sealed for MintCloseAuthority {}
+impl Pack for MintCloseAuthority {
+    const LEN: usize = 36;
+    fn unpack_from_slice(src: &[u8]) -> Result<Self, ProgramError> {
+        let src = array_ref![src, 0, 36];
+        let close_authority = unpack_coption_key(src)?;
+        Ok(MintCloseAuthority { close_authority })
+    }
+    fn pack_into_slice(&self, dst: &mut [u8]) {
+        let dst = array_mut_ref![dst, 0, 36];
+        let &MintCloseAuthority {
+            ref close_authority,
+        } = self;
+        pack_coption_key(close_authority, dst);
+    }
+}
+impl Extension for MintCloseAuthority {
+    const TYPE: ExtensionType = ExtensionType::MintCloseAuthority;
+    const ACCOUNT_TYPE: AccountType = AccountType::Mint;
+}
 
 /// Transfer fee information
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct TransferFee {
     /// First epoch where the transfer fee takes effect
     pub epoch: Epoch,
@@ -74,7 +339,7 @@ pub struct TransferFee {
 
 /// Transfer fee extension data for mints.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct MintTransferFee {
     /// Optional authority to set the fee
     pub transfer_fee_config_authority: COption<Pubkey>,
@@ -87,11 +352,143 @@ pub struct MintTransferFee {
     /// Newer transfer fee, used if the current epoch >= new_transfer_fee.epoch
     pub newer_transfer_fee: TransferFee,
 }
+impl Sealed for MintTransferFee {}
+impl Pack for MintTransferFee {
+    const LEN: usize = 36 + 36 + 8 + 18 + 18;
+    fn unpack_from_slice(_src: &[u8]) -> Result<Self, ProgramError> {
+        unimplemented!();
+    }
+    fn pack_into_slice(&self, _dst: &mut [u8]) {
+        unimplemented!();
+    }
+}
+impl Extension for MintTransferFee {
+    const TYPE: ExtensionType = ExtensionType::MintTransferFee;
+    const ACCOUNT_TYPE: AccountType = AccountType::Mint;
+}
 
 /// Transfer fee extension data for accounts.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct AccountTransferFee {
     /// Amount withheld during transfers, to be harvested to the mint
     pub withheld_amount: u64,
+}
+impl Sealed for AccountTransferFee {}
+impl Pack for AccountTransferFee {
+    const LEN: usize = 8;
+    fn unpack_from_slice(_src: &[u8]) -> Result<Self, ProgramError> {
+        unimplemented!();
+    }
+    fn pack_into_slice(&self, _dst: &mut [u8]) {
+        unimplemented!();
+    }
+}
+impl Extension for AccountTransferFee {
+    const TYPE: ExtensionType = ExtensionType::AccountTransferFee;
+    const ACCOUNT_TYPE: AccountType = AccountType::Account;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::state::test::{TEST_MINT, TEST_MINT_SLICE};
+
+    #[test]
+    fn mint_close_authority_pack_unpack() {
+        let check = MintCloseAuthority {
+            close_authority: COption::Some(Pubkey::new(&[1; 32])),
+        };
+        let mut packed = vec![0; MintCloseAuthority::get_packed_len()];
+        Pack::pack(check.clone(), &mut packed).unwrap();
+        let mut expect = vec![1, 0, 0, 0];
+        expect.extend_from_slice(&[1; 32]);
+        assert_eq!(packed, expect);
+        let unpacked = MintCloseAuthority::unpack_from_slice(&packed).unwrap();
+        assert_eq!(unpacked, check);
+    }
+
+    #[test]
+    fn mint_with_extensions_pack_unpack() {
+        let mint_size = get_account_len(&[ExtensionType::MintCloseAuthority]);
+        let mut buffer = vec![0; mint_size];
+
+        // fail unpack
+        assert_eq!(
+            BaseStateWithExtensions::<Mint>::unpack(&mut buffer),
+            Err(ProgramError::UninitializedAccount),
+        );
+
+        let mut state = BaseStateWithExtensions::<Mint>::unpack_unchecked(&mut buffer).unwrap();
+        // fail pack account extension, since this is a mint!
+        assert_eq!(
+            state.pack_extension(AccountTransferFee { withheld_amount: 0 }),
+            Err(ProgramError::InvalidAccountData),
+        );
+
+        // success write extension
+        let extension = MintCloseAuthority {
+            close_authority: COption::Some(Pubkey::new(&[1; 32])),
+        };
+        state.pack_extension(extension.clone()).unwrap();
+
+        // fail unpack again, still no base data
+        assert_eq!(
+            BaseStateWithExtensions::<Mint>::unpack(&mut buffer.clone()),
+            Err(ProgramError::UninitializedAccount),
+        );
+
+        // write base mint
+        let mut state = BaseStateWithExtensions::<Mint>::unpack_unchecked(&mut buffer).unwrap();
+        let base = TEST_MINT;
+        state.pack_base(base);
+        assert_eq!(state.base, base);
+        state.pack_account_type();
+
+        // check raw buffer
+        let mut expect = TEST_MINT_SLICE.to_vec();
+        expect.extend_from_slice(&[0; Account::LEN - Mint::LEN]); // padding
+        expect.push(AccountType::Mint as u8);
+        expect.push(ExtensionType::MintCloseAuthority as u8);
+        expect.extend_from_slice(&(MintCloseAuthority::LEN as u32).to_le_bytes());
+        expect.extend_from_slice(&[1, 0, 0, 0]);
+        expect.extend_from_slice(&[1; 32]);
+        assert_eq!(expect, buffer);
+
+        // check unpacking
+        let mut state = BaseStateWithExtensions::<Mint>::unpack(&mut buffer).unwrap();
+        assert_eq!(state.base, base);
+        let unpacked_extension = state.unpack_extension::<MintCloseAuthority>().unwrap();
+        assert_eq!(unpacked_extension, extension);
+
+        // update base
+        let mut new_base = TEST_MINT;
+        new_base.supply += 100;
+        state.pack_base(new_base);
+        assert_eq!(state.base, new_base);
+
+        // update extension
+        let new_extension = MintCloseAuthority {
+            close_authority: COption::Some(Pubkey::new(&[2; 32])),
+        };
+        state.pack_extension(new_extension.clone()).unwrap();
+
+        // fail writing an additional extension
+        assert_eq!(
+            state.pack_extension(MintTransferFee::default()),
+            Err(ProgramError::AccountDataTooSmall)
+        );
+
+        // check updates are propagated
+        let state = BaseStateWithExtensions::<Mint>::unpack(&mut buffer).unwrap();
+        assert_eq!(state.base, new_base);
+        let unpacked_extension = state.unpack_extension::<MintCloseAuthority>().unwrap();
+        assert_eq!(unpacked_extension, new_extension);
+
+        // fail unpack as an account
+        assert_eq!(
+            BaseStateWithExtensions::<Account>::unpack(&mut buffer),
+            Err(ProgramError::InvalidAccountData),
+        );
+    }
 }

--- a/token/program-2022/src/lib.rs
+++ b/token/program-2022/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(missing_docs)]
-#![cfg_attr(not(test), forbid(unsafe_code))]
+#![cfg_attr(not(test), deny(unsafe_code))]
 
 //! An ERC20-like Token program for the Solana blockchain
 
@@ -7,6 +7,7 @@ pub mod error;
 pub mod extension;
 pub mod instruction;
 pub mod native_mint;
+pub mod pod;
 pub mod processor;
 pub mod state;
 

--- a/token/program-2022/src/lib.rs
+++ b/token/program-2022/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(missing_docs)]
-#![cfg_attr(not(test), deny(unsafe_code))]
+#![cfg_attr(not(test), forbid(unsafe_code))]
 
 //! An ERC20-like Token program for the Solana blockchain
 

--- a/token/program-2022/src/pod.rs
+++ b/token/program-2022/src/pod.rs
@@ -100,7 +100,7 @@ pub fn pod_from_bytes<T: Pod>(bytes: &[u8]) -> Result<&T, ProgramError> {
 /// Maybe convert a slice into a `Pod` (zero copy)
 ///
 /// Returns `None` if the slice is empty, but `Err` if all other lengths but `get_packed_len()`
-/// This function exists primary because `Option<T>` is not a `Pod`.
+/// This function exists primarily because `Option<T>` is not a `Pod`.
 pub fn pod_maybe_from_bytes<T: Pod>(bytes: &[u8]) -> Result<Option<&T>, ProgramError> {
     if bytes.is_empty() {
         Ok(None)

--- a/token/program-2022/src/pod.rs
+++ b/token/program-2022/src/pod.rs
@@ -1,0 +1,178 @@
+//! Solana program utilities for Plain Old Data types
+use {
+    bytemuck::{Pod, Zeroable},
+    solana_program::{program_error::ProgramError, pubkey::Pubkey},
+};
+
+// TODO Generic `PodOption` is tricky, since we need to be sure that it'll
+// always take up the same amount of space.  A few ideas, since all of these are
+// pubkeys at the moment:
+//
+//#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+//#[repr(transparent)]
+//struct NonZeroPubkey(Pubkey);
+//impl NonZeroPubkey {
+//    fn new(pubkey: Pubkey) -> Option<Self> {
+//        if pubkey == Pubkey::default() {
+//            None
+//        else {
+//            Some(Self(pubkey))
+//        }
+//    }
+//}
+//type OptionNonZeroPubkey = Option<NonZeroPubkey>;
+//#[allow(unsafe_code)]
+//unsafe impl Pod for Option<NonZeroPubkey> {}
+//#[allow(unsafe_code)]
+//unsafe impl Zeroable for Option<NonZeroPubkey> {}
+// fails because you can't impl a foreign trait on a foreign type, option
+
+// Looks just like a pubkey and works like a Pod.
+// Might be confusing?
+//
+// 2.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+#[repr(C)]
+struct PodOptionPubkey {
+    option: u8,
+    pubkey: Pubkey,
+}
+// Doesn't work like an enum though
+//
+// 3.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(C, u8)]
+enum PodOption<T: Pod> {
+    None,
+    Some(T),
+}
+#[allow(unsafe_code)]
+unsafe impl<T: Pod> Pod for PodOption<T> {}
+#[allow(unsafe_code)]
+unsafe impl<T: Pod> Zeroable for PodOption<T> {}
+// This maintains the size, may be unclear to use.  We'll also have to reimplement
+// all of the Option helpers, same as COption has to.
+//
+// I'm leaning towards number 3, and eventually adding the support to COption.
+
+/// The standard `bool` is not a `Pod`, define a replacement that is
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+#[repr(transparent)]
+pub struct PodBool(u8);
+impl From<bool> for PodBool {
+    fn from(b: bool) -> Self {
+        Self(if b { 1 } else { 0 })
+    }
+}
+impl From<&PodBool> for bool {
+    fn from(b: &PodBool) -> Self {
+        b.0 != 0
+    }
+}
+
+/// The standard `u16` can cause alignment issues when placed in a `Pod`, define a replacement that
+/// is usable in all `Pod`s
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+#[repr(transparent)]
+pub struct PodU16([u8; 2]);
+impl From<u16> for PodU16 {
+    fn from(n: u16) -> Self {
+        Self(n.to_le_bytes())
+    }
+}
+impl From<PodU16> for u16 {
+    fn from(pod: PodU16) -> Self {
+        Self::from_le_bytes(pod.0)
+    }
+}
+
+/// The standard `u64` can cause alignment issues when placed in a `Pod`, define a replacement that
+/// is usable in all `Pod`s
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+#[repr(transparent)]
+pub struct PodU64([u8; 8]);
+impl From<u64> for PodU64 {
+    fn from(n: u64) -> Self {
+        Self(n.to_le_bytes())
+    }
+}
+impl From<PodU64> for u64 {
+    fn from(pod: PodU64) -> Self {
+        Self::from_le_bytes(pod.0)
+    }
+}
+
+/// On-chain size of a `Pod` type
+pub fn pod_get_packed_len<T: Pod>() -> usize {
+    std::mem::size_of::<T>()
+}
+
+/// Convert a `Pod` into a slice (zero copy)
+pub fn pod_bytes_of<T: Pod>(t: &T) -> &[u8] {
+    bytemuck::bytes_of(t)
+}
+
+/// Convert a slice into a `Pod` (zero copy)
+pub fn pod_from_bytes<T: Pod>(bytes: &[u8]) -> Result<&T, ProgramError> {
+    bytemuck::try_from_bytes(bytes).map_err(|_| ProgramError::InvalidArgument)
+}
+
+/// Maybe convert a slice into a `Pod` (zero copy)
+///
+/// Returns `None` if the slice is empty, but `Err` if all other lengths but `get_packed_len()`
+/// This function exists primary because `Option<T>` is not a `Pod`.
+pub fn pod_maybe_from_bytes<T: Pod>(bytes: &[u8]) -> Result<Option<&T>, ProgramError> {
+    if bytes.is_empty() {
+        Ok(None)
+    } else {
+        bytemuck::try_from_bytes(bytes)
+            .map(Some)
+            .map_err(|_| ProgramError::InvalidArgument)
+    }
+}
+
+/// Convert a slice into a mutable `Pod` (zero copy)
+pub fn pod_from_bytes_mut<T: Pod>(bytes: &mut [u8]) -> Result<&mut T, ProgramError> {
+    bytemuck::try_from_bytes_mut(bytes).map_err(|_| ProgramError::InvalidArgument)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pod_bool() {
+        assert!(pod_from_bytes::<PodBool>(&[]).is_err());
+        assert!(pod_from_bytes::<PodBool>(&[0, 0]).is_err());
+
+        for i in 0..=u8::MAX {
+            assert_eq!(i != 0, bool::from(pod_from_bytes::<PodBool>(&[i]).unwrap()));
+        }
+    }
+
+    #[test]
+    fn test_pod_u64() {
+        assert!(pod_from_bytes::<PodU64>(&[]).is_err());
+        assert_eq!(
+            1u64,
+            u64::from(*pod_from_bytes::<PodU64>(&[1, 0, 0, 0, 0, 0, 0, 0]).unwrap())
+        );
+    }
+
+    #[test]
+    fn test_pod_option() {
+        assert!(pod_from_bytes::<PodOption<Pubkey>>(&[]).is_err());
+        assert_eq!(
+            PodOption::Some(Pubkey::new_from_array([1; 32])),
+            *pod_from_bytes::<PodOption<Pubkey>>(&[1; 33]).unwrap()
+        );
+        assert_eq!(
+            PodOption::None,
+            *pod_from_bytes::<PodOption<Pubkey>>(&[0; 33]).unwrap()
+        );
+        assert!(pod_from_bytes::<PodOption<Pubkey>>(&[0; 32]).is_err());
+        assert!(pod_from_bytes::<PodOption<Pubkey>>(&[1; 32]).is_err());
+        assert!(pod_from_bytes::<PodOption<Pubkey>>(&[0; 34]).is_err());
+        assert!(pod_from_bytes::<PodOption<Pubkey>>(&[1; 34]).is_err());
+    }
+}

--- a/token/program-2022/src/state.rs
+++ b/token/program-2022/src/state.rs
@@ -288,19 +288,26 @@ fn unpack_coption_u64(src: &[u8; 12]) -> Result<COption<u64>, ProgramError> {
 }
 
 #[cfg(test)]
-mod test {
+pub(crate) mod test {
     use super::*;
+
+    pub const TEST_MINT: Mint = Mint {
+        mint_authority: COption::Some(Pubkey::new_from_array([1; 32])),
+        supply: 42,
+        decimals: 7,
+        is_initialized: true,
+        freeze_authority: COption::Some(Pubkey::new_from_array([2; 32])),
+    };
+    pub const TEST_MINT_SLICE: &[u8] = &[
+        1, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 42, 0, 0, 0, 0, 0, 0, 0, 7, 1, 1, 0, 0, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+    ];
 
     #[test]
     fn test_pack_unpack() {
         // Mint
-        let check = Mint {
-            mint_authority: COption::Some(Pubkey::new(&[1; 32])),
-            supply: 42,
-            decimals: 7,
-            is_initialized: true,
-            freeze_authority: COption::Some(Pubkey::new(&[2; 32])),
-        };
+        let check = TEST_MINT;
         let mut packed = vec![0; Mint::get_packed_len() + 1];
         assert_eq!(
             Err(ProgramError::InvalidAccountData),
@@ -313,12 +320,7 @@ mod test {
         );
         let mut packed = vec![0; Mint::get_packed_len()];
         Mint::pack(check, &mut packed).unwrap();
-        let expect = vec![
-            1, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-            1, 1, 1, 1, 1, 1, 1, 42, 0, 0, 0, 0, 0, 0, 0, 7, 1, 1, 0, 0, 0, 2, 2, 2, 2, 2, 2, 2, 2,
-            2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-        ];
-        assert_eq!(packed, expect);
+        assert_eq!(packed, TEST_MINT_SLICE);
         let unpacked = Mint::unpack(&packed).unwrap();
         assert_eq!(unpacked, check);
 

--- a/token/program-2022/src/state.rs
+++ b/token/program-2022/src/state.rs
@@ -304,6 +304,25 @@ pub(crate) mod test {
         2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
     ];
 
+    pub const TEST_ACCOUNT: Account = Account {
+        mint: Pubkey::new_from_array([1; 32]),
+        owner: Pubkey::new_from_array([2; 32]),
+        amount: 3,
+        delegate: COption::Some(Pubkey::new_from_array([4; 32])),
+        state: AccountState::Frozen,
+        is_native: COption::Some(5),
+        delegated_amount: 6,
+        close_authority: COption::Some(Pubkey::new_from_array([7; 32])),
+    };
+    pub const TEST_ACCOUNT_SLICE: &[u8] = &[
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 3, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 2, 1, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0,
+        0, 6, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+        7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+    ];
+
     #[test]
     fn test_pack_unpack() {
         // Mint
@@ -325,16 +344,7 @@ pub(crate) mod test {
         assert_eq!(unpacked, check);
 
         // Account
-        let check = Account {
-            mint: Pubkey::new(&[1; 32]),
-            owner: Pubkey::new(&[2; 32]),
-            amount: 3,
-            delegate: COption::Some(Pubkey::new(&[4; 32])),
-            state: AccountState::Frozen,
-            is_native: COption::Some(5),
-            delegated_amount: 6,
-            close_authority: COption::Some(Pubkey::new(&[7; 32])),
-        };
+        let check = TEST_ACCOUNT;
         let mut packed = vec![0; Account::get_packed_len() + 1];
         assert_eq!(
             Err(ProgramError::InvalidAccountData),
@@ -347,14 +357,7 @@ pub(crate) mod test {
         );
         let mut packed = vec![0; Account::get_packed_len()];
         Account::pack(check, &mut packed).unwrap();
-        let expect = vec![
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-            1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-            2, 2, 2, 2, 2, 2, 3, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-            4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 2, 1, 0, 0, 0, 5, 0, 0,
-            0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
-            7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
-        ];
+        let expect = TEST_ACCOUNT_SLICE;
         assert_eq!(packed, expect);
         let unpacked = Account::unpack(&packed).unwrap();
         assert_eq!(unpacked, check);


### PR DESCRIPTION
#### Problem

Extensions need to be read / written in a way that's simple for the program processor and clients.

#### Solution

Implement a `Pack`-like interface for the TLV entries using bytemuck and Pod types for extensions.