### PR TITLE
stake-pool-cli: Add next fees in verbose mode, fix mapping

### DIFF
--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -1579,6 +1579,9 @@ fn command_set_manager(
     new_manager: &Option<Keypair>,
     new_fee_receiver: &Option<Pubkey>,
 ) -> CommandResult {
+    if !config.no_update {
+        command_update(config, stake_pool_address, false, false)?;
+    }
     let stake_pool = get_stake_pool(&config.rpc_client, stake_pool_address)?;
 
     // If new accounts are missing in the arguments use the old ones
@@ -1626,6 +1629,9 @@ fn command_set_staker(
     stake_pool_address: &Pubkey,
     new_staker: &Pubkey,
 ) -> CommandResult {
+    if !config.no_update {
+        command_update(config, stake_pool_address, false, false)?;
+    }
     let mut signers = vec![config.fee_payer.as_ref(), config.manager.as_ref()];
     unique_signers!(signers);
     let transaction = checked_transaction_with_signers(
@@ -1648,6 +1654,9 @@ fn command_set_funding_authority(
     new_authority: Option<Pubkey>,
     funding_type: FundingType,
 ) -> CommandResult {
+    if !config.no_update {
+        command_update(config, stake_pool_address, false, false)?;
+    }
     let mut signers = vec![config.fee_payer.as_ref(), config.manager.as_ref()];
     unique_signers!(signers);
     let transaction = checked_transaction_with_signers(
@@ -1670,6 +1679,9 @@ fn command_set_fee(
     stake_pool_address: &Pubkey,
     new_fee: FeeType,
 ) -> CommandResult {
+    if !config.no_update {
+        command_update(config, stake_pool_address, false, false)?;
+    }
     let mut signers = vec![config.fee_payer.as_ref(), config.manager.as_ref()];
     unique_signers!(signers);
     let transaction = checked_transaction_with_signers(

--- a/stake-pool/cli/src/output.rs
+++ b/stake-pool/cli/src/output.rs
@@ -119,16 +119,33 @@ impl VerboseDisplay for CliStakePool {
             }
         }
         writeln!(w, "Epoch Fee: {} of epoch rewards", &self.epoch_fee)?;
+        if let Some(next_epoch_fee) = &self.next_epoch_fee {
+            writeln!(w, "Next Epoch Fee: {} of epoch rewards", next_epoch_fee)?;
+        }
         writeln!(
             w,
             "Stake Withdrawal Fee: {} of withdrawal amount",
             &self.stake_withdrawal_fee
         )?;
+        if let Some(next_stake_withdrawal_fee) = &self.next_stake_withdrawal_fee {
+            writeln!(
+                w,
+                "Next Stake Withdrawal Fee: {} of withdrawal amount",
+                next_stake_withdrawal_fee
+            )?;
+        }
         writeln!(
             w,
             "SOL Withdrawal Fee: {} of withdrawal amount",
             &self.sol_withdrawal_fee
         )?;
+        if let Some(next_sol_withdrawal_fee) = &self.next_sol_withdrawal_fee {
+            writeln!(
+                w,
+                "Next SOL Withdrawal Fee: {} of withdrawal amount",
+                next_sol_withdrawal_fee
+            )?;
+        }
         writeln!(
             w,
             "Stake Deposit Fee: {} of deposit amount",
@@ -462,7 +479,7 @@ impl From<(Pubkey, StakePool, ValidatorList, Pubkey)> for CliStakePool {
             stake_deposit_fee: CliStakePoolFee::from(stake_pool.stake_deposit_fee),
             stake_withdrawal_fee: CliStakePoolFee::from(stake_pool.stake_withdrawal_fee),
             next_stake_withdrawal_fee: stake_pool
-                .next_sol_withdrawal_fee
+                .next_stake_withdrawal_fee
                 .map(CliStakePoolFee::from),
             stake_referral_fee: stake_pool.stake_referral_fee,
             sol_deposit_authority: stake_pool.sol_deposit_authority.map(|x| x.to_string()),


### PR DESCRIPTION
#### Problem

Next epoch's fees aren't displayed through the CLI, even in verbose mode, and the next stake withdrawal fee is improperly mapped.  This was discovered by the JPool team while modifying fees, thanks @AlexanderRay !

#### Solution

Fix the mapping, and print out next epoch's fees too.