### PR TITLE
Increase compute max units due to changes in handling of memory ops

### DIFF
--- a/token/program/tests/assert_instruction_count.rs
+++ b/token/program/tests/assert_instruction_count.rs
@@ -22,7 +22,7 @@ const TRANSFER_AMOUNT: u64 = 1_000_000_000_000_000;
 #[tokio::test]
 async fn initialize_mint() {
     let mut pt = ProgramTest::new("spl_token", id(), processor!(Processor::process));
-    pt.set_bpf_compute_max_units(2_500); // last known 2252
+    pt.set_bpf_compute_max_units(5_000); // last known 2252
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner_key = Pubkey::new_unique();
@@ -60,7 +60,7 @@ async fn initialize_mint() {
 #[tokio::test]
 async fn initialize_account() {
     let mut pt = ProgramTest::new("spl_token", id(), processor!(Processor::process));
-    pt.set_bpf_compute_max_units(4_000); // last known 3284
+    pt.set_bpf_compute_max_units(6_000); // last known 3284
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();
@@ -112,7 +112,7 @@ async fn initialize_account() {
 #[tokio::test]
 async fn mint_to() {
     let mut pt = ProgramTest::new("spl_token", id(), processor!(Processor::process));
-    pt.set_bpf_compute_max_units(4_000); // last known 2668
+    pt.set_bpf_compute_max_units(6_000); // last known 2668
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();
@@ -161,7 +161,7 @@ async fn mint_to() {
 #[tokio::test]
 async fn transfer() {
     let mut pt = ProgramTest::new("spl_token", id(), processor!(Processor::process));
-    pt.set_bpf_compute_max_units(4_000); // last known 2972
+    pt.set_bpf_compute_max_units(7_000); // last known 2972
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();
@@ -229,7 +229,7 @@ async fn transfer() {
 #[tokio::test]
 async fn burn() {
     let mut pt = ProgramTest::new("spl_token", id(), processor!(Processor::process));
-    pt.set_bpf_compute_max_units(4_000); // last known 2655
+    pt.set_bpf_compute_max_units(6_000); // last known 2655
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();


### PR DESCRIPTION
bpf-tools v1.21 changed implementation of memory operations, which results in larger instruction numbers for the same operations. This PR adjusts the compute limits in tests affected by the changes in bpf-tools.