### PR TITLE
Update tests to prepare for `BanksClientError`

### DIFF
--- a/governance/test-sdk/src/lib.rs
+++ b/governance/test-sdk/src/lib.rs
@@ -72,11 +72,12 @@ impl ProgramTestBench {
 
         transaction.sign(&all_signers, recent_blockhash);
 
+        #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
         self.context
             .banks_client
             .process_transaction(transaction)
             .await
-            .map_err(map_transaction_error)?;
+            .map_err(|e| map_transaction_error(e.into()))?;
 
         Ok(())
     }

--- a/name-service/program/tests/functional.rs
+++ b/name-service/program/tests/functional.rs
@@ -201,5 +201,9 @@ pub async fn sign_send_instruction(
         payer_signers.push(s);
     }
     transaction.partial_sign(&payer_signers, ctx.last_blockhash);
-    ctx.banks_client.process_transaction(transaction).await
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
+    ctx.banks_client
+        .process_transaction(transaction)
+        .await
+        .map_err(|e| e.into())
 }

--- a/record/program/tests/functional.rs
+++ b/record/program/tests/functional.rs
@@ -13,7 +13,6 @@ use {
     solana_sdk::{
         signature::{Keypair, Signer},
         transaction::{Transaction, TransactionError},
-        transport,
     },
     spl_record::{
         error::RecordError,

--- a/record/program/tests/functional.rs
+++ b/record/program/tests/functional.rs
@@ -32,7 +32,7 @@ async fn initialize_storage_account(
     authority: &Keypair,
     account: &Keypair,
     data: Data,
-) -> transport::Result<()> {
+) {
     let transaction = Transaction::new_signed_with_payer(
         &[
             system_instruction::create_account(
@@ -54,7 +54,11 @@ async fn initialize_storage_account(
         &[&context.payer, account, authority],
         context.last_blockhash,
     );
-    context.banks_client.process_transaction(transaction).await
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -66,9 +70,7 @@ async fn initialize_success() {
     let data = Data {
         bytes: [111u8; Data::DATA_SIZE],
     };
-    initialize_storage_account(&mut context, &authority, &account, data.clone())
-        .await
-        .unwrap();
+    initialize_storage_account(&mut context, &authority, &account, data.clone()).await;
     let account_data = context
         .banks_client
         .get_account_data_with_borsh::<RecordData>(account.pubkey())
@@ -131,9 +133,7 @@ async fn initialize_twice_fail() {
     let data = Data {
         bytes: [111u8; Data::DATA_SIZE],
     };
-    initialize_storage_account(&mut context, &authority, &account, data)
-        .await
-        .unwrap();
+    initialize_storage_account(&mut context, &authority, &account, data).await;
     let transaction = Transaction::new_signed_with_payer(
         &[instruction::initialize(
             &account.pubkey(),
@@ -163,9 +163,7 @@ async fn write_success() {
     let data = Data {
         bytes: [222u8; Data::DATA_SIZE],
     };
-    initialize_storage_account(&mut context, &authority, &account, data)
-        .await
-        .unwrap();
+    initialize_storage_account(&mut context, &authority, &account, data).await;
 
     let new_data = Data {
         bytes: [200u8; Data::DATA_SIZE],
@@ -206,9 +204,7 @@ async fn write_fail_wrong_authority() {
     let data = Data {
         bytes: [222u8; Data::DATA_SIZE],
     };
-    initialize_storage_account(&mut context, &authority, &account, data)
-        .await
-        .unwrap();
+    initialize_storage_account(&mut context, &authority, &account, data).await;
 
     let new_data = Data {
         bytes: [200u8; Data::DATA_SIZE],
@@ -248,9 +244,7 @@ async fn write_fail_unsigned() {
     let data = Data {
         bytes: [222u8; Data::DATA_SIZE],
     };
-    initialize_storage_account(&mut context, &authority, &account, data)
-        .await
-        .unwrap();
+    initialize_storage_account(&mut context, &authority, &account, data).await;
 
     let data = Data {
         bytes: [200u8; Data::DATA_SIZE],
@@ -290,9 +284,7 @@ async fn close_account_success() {
     let data = Data {
         bytes: [222u8; Data::DATA_SIZE],
     };
-    initialize_storage_account(&mut context, &authority, &account, data)
-        .await
-        .unwrap();
+    initialize_storage_account(&mut context, &authority, &account, data).await;
     let recipient = Pubkey::new_unique();
 
     let transaction = Transaction::new_signed_with_payer(
@@ -332,9 +324,7 @@ async fn close_account_fail_wrong_authority() {
     let data = Data {
         bytes: [222u8; Data::DATA_SIZE],
     };
-    initialize_storage_account(&mut context, &authority, &account, data)
-        .await
-        .unwrap();
+    initialize_storage_account(&mut context, &authority, &account, data).await;
 
     let wrong_authority = Keypair::new();
     let transaction = Transaction::new_signed_with_payer(
@@ -374,9 +364,7 @@ async fn close_account_fail_unsigned() {
     let data = Data {
         bytes: [222u8; Data::DATA_SIZE],
     };
-    initialize_storage_account(&mut context, &authority, &account, data)
-        .await
-        .unwrap();
+    initialize_storage_account(&mut context, &authority, &account, data).await;
 
     let transaction = Transaction::new_signed_with_payer(
         &[Instruction::new_with_borsh(
@@ -412,9 +400,7 @@ async fn set_authority_success() {
     let data = Data {
         bytes: [222u8; Data::DATA_SIZE],
     };
-    initialize_storage_account(&mut context, &authority, &account, data)
-        .await
-        .unwrap();
+    initialize_storage_account(&mut context, &authority, &account, data).await;
     let new_authority = Keypair::new();
 
     let transaction = Transaction::new_signed_with_payer(
@@ -479,9 +465,7 @@ async fn set_authority_fail_wrong_authority() {
     let data = Data {
         bytes: [222u8; Data::DATA_SIZE],
     };
-    initialize_storage_account(&mut context, &authority, &account, data)
-        .await
-        .unwrap();
+    initialize_storage_account(&mut context, &authority, &account, data).await;
 
     let wrong_authority = Keypair::new();
     let transaction = Transaction::new_signed_with_payer(
@@ -521,9 +505,7 @@ async fn set_authority_fail_unsigned() {
     let data = Data {
         bytes: [222u8; Data::DATA_SIZE],
     };
-    initialize_storage_account(&mut context, &authority, &account, data)
-        .await
-        .unwrap();
+    initialize_storage_account(&mut context, &authority, &account, data).await;
 
     let transaction = Transaction::new_signed_with_payer(
         &[Instruction::new_with_borsh(

--- a/stake-pool/program/tests/deposit.rs
+++ b/stake-pool/program/tests/deposit.rs
@@ -503,12 +503,14 @@ async fn fail_with_wrong_stake_program_id() {
     let mut transaction =
         Transaction::new_with_payer(&[instruction], Some(&context.payer.pubkey()));
     transaction.sign(&[&context.payer], context.last_blockhash);
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = context
         .banks_client
         .process_transaction(transaction)
         .await
         .err()
-        .unwrap();
+        .unwrap()
+        .into();
 
     match transaction_error {
         TransportError::TransactionError(TransactionError::InstructionError(_, error)) => {
@@ -551,12 +553,14 @@ async fn fail_with_wrong_token_program_id() {
         Some(&context.payer.pubkey()),
     );
     transaction.sign(&[&context.payer, &user], context.last_blockhash);
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = context
         .banks_client
         .process_transaction(transaction)
         .await
         .err()
-        .unwrap();
+        .unwrap()
+        .into();
 
     match transaction_error {
         TransportError::TransactionError(TransactionError::InstructionError(_, error)) => {

--- a/stake-pool/program/tests/deposit_sol.rs
+++ b/stake-pool/program/tests/deposit_sol.rs
@@ -154,12 +154,14 @@ async fn fail_with_wrong_token_program_id() {
         Some(&context.payer.pubkey()),
     );
     transaction.sign(&[&context.payer], context.last_blockhash);
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = context
         .banks_client
         .process_transaction(transaction)
         .await
         .err()
-        .unwrap();
+        .unwrap()
+        .into();
 
     match transaction_error {
         TransportError::TransactionError(TransactionError::InstructionError(_, error)) => {

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -79,8 +79,11 @@ pub async fn create_mint(
         Some(&payer.pubkey()),
     );
     transaction.sign(&[payer, pool_mint], *recent_blockhash);
-    banks_client.process_transaction(transaction).await?;
-    Ok(())
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
+    banks_client
+        .process_transaction(transaction)
+        .await
+        .map_err(|e| e.into())
 }
 
 pub async fn transfer(
@@ -160,8 +163,11 @@ pub async fn create_token_account(
         Some(&payer.pubkey()),
     );
     transaction.sign(&[payer, account], *recent_blockhash);
-    banks_client.process_transaction(transaction).await?;
-    Ok(())
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
+    banks_client
+        .process_transaction(transaction)
+        .await
+        .map_err(|e| e.into())
 }
 
 pub async fn close_token_account(
@@ -184,8 +190,11 @@ pub async fn close_token_account(
         Some(&payer.pubkey()),
     );
     transaction.sign(&[payer, manager], *recent_blockhash);
-    banks_client.process_transaction(transaction).await?;
-    Ok(())
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
+    banks_client
+        .process_transaction(transaction)
+        .await
+        .map_err(|e| e.into())
 }
 
 pub async fn freeze_token_account(
@@ -208,8 +217,11 @@ pub async fn freeze_token_account(
         Some(&payer.pubkey()),
     );
     transaction.sign(&[payer, manager], *recent_blockhash);
-    banks_client.process_transaction(transaction).await?;
-    Ok(())
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
+    banks_client
+        .process_transaction(transaction)
+        .await
+        .map_err(|e| e.into())
 }
 
 pub async fn mint_tokens(
@@ -235,8 +247,11 @@ pub async fn mint_tokens(
         &[payer, mint_authority],
         *recent_blockhash,
     );
-    banks_client.process_transaction(transaction).await?;
-    Ok(())
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
+    banks_client
+        .process_transaction(transaction)
+        .await
+        .map_err(|e| e.into())
 }
 
 pub async fn burn_tokens(
@@ -262,8 +277,11 @@ pub async fn burn_tokens(
         &[payer, authority],
         *recent_blockhash,
     );
-    banks_client.process_transaction(transaction).await?;
-    Ok(())
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
+    banks_client
+        .process_transaction(transaction)
+        .await
+        .map_err(|e| e.into())
 }
 
 pub async fn get_token_balance(banks_client: &mut BanksClient, token: &Pubkey) -> u64 {
@@ -388,8 +406,11 @@ pub async fn create_stake_pool(
         signers.push(stake_deposit_authority);
     }
     transaction.sign(&signers, *recent_blockhash);
-    banks_client.process_transaction(transaction).await?;
-    Ok(())
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
+    banks_client
+        .process_transaction(transaction)
+        .await
+        .map_err(|e| e.into())
 }
 
 pub async fn create_vote(
@@ -839,7 +860,12 @@ impl StakePoolAccounts {
             &signers,
             *recent_blockhash,
         );
-        banks_client.process_transaction(transaction).await.err()
+        #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
+        banks_client
+            .process_transaction(transaction)
+            .await
+            .map_err(|e| e.into())
+            .err()
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -890,7 +916,12 @@ impl StakePoolAccounts {
             &signers,
             *recent_blockhash,
         );
-        banks_client.process_transaction(transaction).await.err()
+        #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
+        banks_client
+            .process_transaction(transaction)
+            .await
+            .map_err(|e| e.into())
+            .err()
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -926,7 +957,12 @@ impl StakePoolAccounts {
             &[payer, user_transfer_authority],
             *recent_blockhash,
         );
-        banks_client.process_transaction(transaction).await.err()
+        #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
+        banks_client
+            .process_transaction(transaction)
+            .await
+            .map_err(|e| e.into())
+            .err()
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -978,7 +1014,12 @@ impl StakePoolAccounts {
             &signers,
             *recent_blockhash,
         );
-        banks_client.process_transaction(transaction).await.err()
+        #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
+        banks_client
+            .process_transaction(transaction)
+            .await
+            .map_err(|e| e.into())
+            .err()
     }
 
     pub async fn get_validator_list(&self, banks_client: &mut BanksClient) -> ValidatorList {
@@ -1011,7 +1052,12 @@ impl StakePoolAccounts {
             &[payer],
             *recent_blockhash,
         );
-        banks_client.process_transaction(transaction).await.err()
+        #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
+        banks_client
+            .process_transaction(transaction)
+            .await
+            .map_err(|e| e.into())
+            .err()
     }
 
     pub async fn update_stake_pool_balance(
@@ -1035,7 +1081,12 @@ impl StakePoolAccounts {
             &[payer],
             *recent_blockhash,
         );
-        banks_client.process_transaction(transaction).await.err()
+        #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
+        banks_client
+            .process_transaction(transaction)
+            .await
+            .map_err(|e| e.into())
+            .err()
     }
 
     pub async fn cleanup_removed_validator_entries(
@@ -1054,7 +1105,12 @@ impl StakePoolAccounts {
             &[payer],
             *recent_blockhash,
         );
-        banks_client.process_transaction(transaction).await.err()
+        #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
+        banks_client
+            .process_transaction(transaction)
+            .await
+            .map_err(|e| e.into())
+            .err()
     }
 
     pub async fn update_all(
@@ -1099,7 +1155,12 @@ impl StakePoolAccounts {
             &[payer],
             *recent_blockhash,
         );
-        banks_client.process_transaction(transaction).await.err()
+        #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
+        banks_client
+            .process_transaction(transaction)
+            .await
+            .map_err(|e| e.into())
+            .err()
     }
 
     pub async fn add_validator_to_pool(
@@ -1125,7 +1186,12 @@ impl StakePoolAccounts {
             &[payer, &self.staker],
             *recent_blockhash,
         );
-        banks_client.process_transaction(transaction).await.err()
+        #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
+        banks_client
+            .process_transaction(transaction)
+            .await
+            .map_err(|e| e.into())
+            .err()
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1164,7 +1230,12 @@ impl StakePoolAccounts {
             &[payer, &self.staker, destination_stake],
             *recent_blockhash,
         );
-        banks_client.process_transaction(transaction).await.err()
+        #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
+        banks_client
+            .process_transaction(transaction)
+            .await
+            .map_err(|e| e.into())
+            .err()
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1194,7 +1265,12 @@ impl StakePoolAccounts {
             &[payer, &self.staker],
             *recent_blockhash,
         );
-        banks_client.process_transaction(transaction).await.err()
+        #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
+        banks_client
+            .process_transaction(transaction)
+            .await
+            .map_err(|e| e.into())
+            .err()
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1225,7 +1301,12 @@ impl StakePoolAccounts {
             &[payer, &self.staker],
             *recent_blockhash,
         );
-        banks_client.process_transaction(transaction).await.err()
+        #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
+        banks_client
+            .process_transaction(transaction)
+            .await
+            .map_err(|e| e.into())
+            .err()
     }
 
     pub async fn set_preferred_validator(
@@ -1249,7 +1330,12 @@ impl StakePoolAccounts {
             &[payer, &self.staker],
             *recent_blockhash,
         );
-        banks_client.process_transaction(transaction).await.err()
+        #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
+        banks_client
+            .process_transaction(transaction)
+            .await
+            .map_err(|e| e.into())
+            .err()
     }
 }
 

--- a/stake-pool/program/tests/initialize.rs
+++ b/stake-pool/program/tests/initialize.rs
@@ -271,11 +271,13 @@ async fn fail_with_wrong_max_validators() {
         ],
         recent_blockhash,
     );
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
         .err()
-        .unwrap();
+        .unwrap()
+        .into();
 
     match transaction_error {
         TransportError::TransactionError(TransactionError::InstructionError(
@@ -522,11 +524,13 @@ async fn fail_with_wrong_token_program_id() {
         ],
         recent_blockhash,
     );
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
         .err()
-        .unwrap();
+        .unwrap()
+        .into();
 
     match transaction_error {
         TransportError::TransactionError(TransactionError::InstructionError(_, error)) => {
@@ -625,11 +629,13 @@ async fn fail_with_fee_owned_by_wrong_token_program_id() {
         ],
         recent_blockhash,
     );
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
         .err()
-        .unwrap();
+        .unwrap()
+        .into();
 
     match transaction_error {
         TransportError::TransactionError(TransactionError::InstructionError(_, error)) => {
@@ -966,11 +972,13 @@ async fn fail_without_manager_signature() {
         ],
         recent_blockhash,
     );
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
         .err()
-        .unwrap();
+        .unwrap()
+        .into();
 
     match transaction_error {
         TransportError::TransactionError(TransactionError::InstructionError(

--- a/stake-pool/program/tests/set_funding_authority.rs
+++ b/stake-pool/program/tests/set_funding_authority.rs
@@ -104,11 +104,13 @@ async fn fail_wrong_manager() {
         Some(&payer.pubkey()),
     );
     transaction.sign(&[&payer, &new_authority], recent_blockhash);
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
         .err()
-        .unwrap();
+        .unwrap()
+        .into();
 
     match transaction_error {
         TransportError::TransactionError(TransactionError::InstructionError(
@@ -143,11 +145,13 @@ async fn fail_without_signature() {
 
     let mut transaction = Transaction::new_with_payer(&[instruction], Some(&payer.pubkey()));
     transaction.sign(&[&payer], recent_blockhash);
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
         .err()
-        .unwrap();
+        .unwrap()
+        .into();
 
     match transaction_error {
         TransportError::TransactionError(TransactionError::InstructionError(

--- a/stake-pool/program/tests/set_manager.rs
+++ b/stake-pool/program/tests/set_manager.rs
@@ -100,11 +100,13 @@ async fn test_set_manager_by_malicious() {
         Some(&payer.pubkey()),
     );
     transaction.sign(&[&payer, &new_manager], recent_blockhash);
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
         .err()
-        .unwrap();
+        .unwrap()
+        .into();
 
     match transaction_error {
         TransportError::TransactionError(TransactionError::InstructionError(
@@ -140,11 +142,13 @@ async fn test_set_manager_without_existing_signature() {
 
     let mut transaction = Transaction::new_with_payer(&[instruction], Some(&payer.pubkey()));
     transaction.sign(&[&payer, &new_manager], recent_blockhash);
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
         .err()
-        .unwrap();
+        .unwrap()
+        .into();
 
     match transaction_error {
         TransportError::TransactionError(TransactionError::InstructionError(
@@ -182,11 +186,13 @@ async fn test_set_manager_without_new_signature() {
 
     let mut transaction = Transaction::new_with_payer(&[instruction], Some(&payer.pubkey()));
     transaction.sign(&[&payer, &stake_pool_accounts.manager], recent_blockhash);
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
         .err()
-        .unwrap();
+        .unwrap()
+        .into();
 
     match transaction_error {
         TransportError::TransactionError(TransactionError::InstructionError(
@@ -250,11 +256,13 @@ async fn test_set_manager_with_wrong_mint_for_pool_fee_acc() {
         &[&payer, &stake_pool_accounts.manager, &new_manager],
         recent_blockhash,
     );
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
         .err()
-        .unwrap();
+        .unwrap()
+        .into();
 
     match transaction_error {
         TransportError::TransactionError(TransactionError::InstructionError(

--- a/stake-pool/program/tests/set_staker.rs
+++ b/stake-pool/program/tests/set_staker.rs
@@ -118,11 +118,13 @@ async fn fail_wrong_manager() {
         Some(&payer.pubkey()),
     );
     transaction.sign(&[&payer, &new_staker], recent_blockhash);
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
         .err()
-        .unwrap();
+        .unwrap()
+        .into();
 
     match transaction_error {
         TransportError::TransactionError(TransactionError::InstructionError(
@@ -157,11 +159,13 @@ async fn fail_set_staker_without_signature() {
 
     let mut transaction = Transaction::new_with_payer(&[instruction], Some(&payer.pubkey()));
     transaction.sign(&[&payer], recent_blockhash);
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
         .err()
-        .unwrap();
+        .unwrap()
+        .into();
 
     match transaction_error {
         TransportError::TransactionError(TransactionError::InstructionError(

--- a/stake-pool/program/tests/vsa_add.rs
+++ b/stake-pool/program/tests/vsa_add.rs
@@ -137,11 +137,13 @@ async fn fail_with_wrong_validator_list_account() {
         Some(&payer.pubkey()),
     );
     transaction.sign(&[&payer, &stake_pool_accounts.staker], recent_blockhash);
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
         .err()
-        .unwrap();
+        .unwrap()
+        .into();
 
     match transaction_error {
         TransportError::TransactionError(TransactionError::InstructionError(
@@ -216,11 +218,13 @@ async fn fail_wrong_staker() {
         Some(&payer.pubkey()),
     );
     transaction.sign(&[&payer, &malicious], recent_blockhash);
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
         .err()
-        .unwrap();
+        .unwrap()
+        .into();
 
     match transaction_error {
         TransportError::TransactionError(TransactionError::InstructionError(
@@ -264,11 +268,13 @@ async fn fail_without_signature() {
 
     let mut transaction = Transaction::new_with_payer(&[instruction], Some(&payer.pubkey()));
     transaction.sign(&[&payer], recent_blockhash);
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
         .err()
-        .unwrap();
+        .unwrap()
+        .into();
 
     match transaction_error {
         TransportError::TransactionError(TransactionError::InstructionError(
@@ -312,11 +318,13 @@ async fn fail_with_wrong_stake_program_id() {
     };
     let mut transaction = Transaction::new_with_payer(&[instruction], Some(&payer.pubkey()));
     transaction.sign(&[&payer, &stake_pool_accounts.staker], recent_blockhash);
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
         .err()
-        .unwrap();
+        .unwrap()
+        .into();
 
     match transaction_error {
         TransportError::TransactionError(TransactionError::InstructionError(_, error)) => {
@@ -359,11 +367,13 @@ async fn fail_with_wrong_system_program_id() {
     };
     let mut transaction = Transaction::new_with_payer(&[instruction], Some(&payer.pubkey()));
     transaction.sign(&[&payer, &stake_pool_accounts.staker], recent_blockhash);
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
         .err()
-        .unwrap();
+        .unwrap()
+        .into();
 
     match transaction_error {
         TransportError::TransactionError(TransactionError::InstructionError(_, error)) => {

--- a/stake-pool/program/tests/vsa_remove.rs
+++ b/stake-pool/program/tests/vsa_remove.rs
@@ -173,12 +173,14 @@ async fn fail_with_wrong_stake_program_id() {
         &[&context.payer, &stake_pool_accounts.staker],
         context.last_blockhash,
     );
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = context
         .banks_client
         .process_transaction(transaction)
         .await
         .err()
-        .unwrap();
+        .unwrap()
+        .into();
 
     match transaction_error {
         TransportError::TransactionError(TransactionError::InstructionError(
@@ -216,12 +218,14 @@ async fn fail_with_wrong_validator_list_account() {
         &[&context.payer, &stake_pool_accounts.staker],
         context.last_blockhash,
     );
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = context
         .banks_client
         .process_transaction(transaction)
         .await
         .err()
-        .unwrap();
+        .unwrap()
+        .into();
 
     match transaction_error {
         TransportError::TransactionError(TransactionError::InstructionError(
@@ -343,12 +347,14 @@ async fn fail_wrong_staker() {
         Some(&context.payer.pubkey()),
     );
     transaction.sign(&[&context.payer, &malicious], context.last_blockhash);
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = context
         .banks_client
         .process_transaction(transaction)
         .await
         .err()
-        .unwrap();
+        .unwrap()
+        .into();
 
     match transaction_error {
         TransportError::TransactionError(TransactionError::InstructionError(
@@ -395,12 +401,14 @@ async fn fail_no_signature() {
         &[&context.payer],
         context.last_blockhash,
     );
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = context
         .banks_client
         .process_transaction(transaction)
         .await
         .err()
-        .unwrap();
+        .unwrap()
+        .into();
 
     match transaction_error {
         TransportError::TransactionError(TransactionError::InstructionError(

--- a/stake-pool/program/tests/withdraw.rs
+++ b/stake-pool/program/tests/withdraw.rs
@@ -358,11 +358,13 @@ async fn fail_with_wrong_stake_program() {
         &[&payer, &user_transfer_authority],
         recent_blockhash,
     );
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
         .err()
-        .unwrap();
+        .unwrap()
+        .into();
 
     match transaction_error {
         TransportError::TransactionError(TransactionError::InstructionError(_, error)) => {
@@ -453,11 +455,13 @@ async fn fail_with_wrong_token_program_id() {
         &[&payer, &user_transfer_authority],
         recent_blockhash,
     );
+    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
         .err()
-        .unwrap();
+        .unwrap()
+        .into();
 
     match transaction_error {
         TransportError::TransactionError(TransactionError::InstructionError(_, error)) => {


### PR DESCRIPTION
#### Problem

Soon, `BanksClient` will only return `BanksClientError`, but many tests in SPL rely on `TransportError` being returned.

#### Solution

Be sneaky, and add a currently unnecessary `into()` conversion, which will be necessary when the return type changes.  This way, we never break downstream builds.