### PR TITLE
Enable rustls-tls-native-roots for spl-token CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1424,6 +1424,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes 1.0.1",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "idna"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2549,18 +2562,22 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
  "log",
  "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
+ "rustls-native-certs",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "url",
  "wasm-bindgen",
@@ -2633,6 +2650,18 @@ dependencies = [
  "ring",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+dependencies = [
+ "openssl-probe",
+ "rustls",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -3996,6 +4025,7 @@ dependencies = [
  "clap",
  "console 0.14.1",
  "indicatif 0.16.2",
+ "reqwest",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4370,6 +4400,16 @@ dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.9",
  "syn 1.0.81",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -27,6 +27,7 @@ solana-transaction-status = "=1.8.1"
 spl-token = { version = "3.2", path="../program", features = [ "no-entrypoint" ] }
 spl-associated-token-account = { version = "1.0", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
 spl-memo = { version = "3.0.1", path="../../memo/program", features = ["no-entrypoint"] }
+reqwest = { version = "0.11", features = ["rustls-tls-native-roots"] }
 
 [[bin]]
 name = "spl-token"


### PR DESCRIPTION
Fixes #2665 .

This is just a quick fix that got `spl-token` to work behind my http proxy with a custom cert.

Let me know if you've got any feedback or if we should do this for all the CLIs, etc.