### PR TITLE
fix grcov dependency checking

### DIFF
--- a/coverage.sh
+++ b/coverage.sh
@@ -11,7 +11,7 @@ if ! which grcov; then
   exit 1
 fi
 
-if [[ ! "$(grcov --version)" =~ "0.6.1" ]] && [[ ! "$(grcov --version)" =~ "0."[7-9] ]]; then
+if [[ ! "$(grcov --version)" =~ 0.[678].[0124] ]]; then
   echo Error: Required grcov version not installed
   exit 1
 fi

--- a/coverage.sh
+++ b/coverage.sh
@@ -11,7 +11,7 @@ if ! which grcov; then
   exit 1
 fi
 
-if [[ ! "$(grcov --version)" =~ "0.6.1" ]]; then
+if [[ ! "$(grcov --version)" =~ "0.6.1" ]] && [[ ! "$(grcov --version)" =~ "0."[7-9] ]]; then
   echo Error: Required grcov version not installed
   exit 1
 fi


### PR DESCRIPTION
Hi,

I have grcov in version 0.8.4 and current version check causes problem here when running coverage.sh

This change fixes version check for me, but in the future this check should be redesigned.

Best regards,
Michal