### PR TITLE
Governance: Program metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3725,7 +3725,7 @@ dependencies = [
 
 [[package]]
 name = "spl-governance"
-version = "2.1.4"
+version = "2.1.5"
 dependencies = [
  "arrayref",
  "assert_matches",

--- a/governance/program/Cargo.toml
+++ b/governance/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-governance"
-version = "2.1.4"
+version = "2.1.5"
 description = "Solana Program Library Governance Program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/governance/program/src/addins/voter_weight.rs
+++ b/governance/program/src/addins/voter_weight.rs
@@ -63,7 +63,7 @@ impl VoterWeightRecord {
     /// Asserts the VoterWeightRecord hasn't expired
     pub fn assert_is_up_to_date(&self) -> Result<(), ProgramError> {
         if let Some(voter_weight_expiry) = self.voter_weight_expiry {
-            let slot = Clock::get().unwrap().slot;
+            let slot = Clock::get()?.slot;
 
             if slot > voter_weight_expiry {
                 return Err(GovernanceError::VoterWeightRecordExpired.into());

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -7,6 +7,7 @@ use crate::{
             get_account_governance_address, get_mint_governance_address,
             get_program_governance_address, get_token_governance_address, GovernanceConfig,
         },
+        program_metadata::get_program_metadata_address,
         proposal::{get_proposal_address, VoteType},
         proposal_instruction::{get_proposal_instruction_address, InstructionData},
         realm::{get_governing_token_holding_address, get_realm_address, RealmConfigArgs},
@@ -443,6 +444,12 @@ pub enum GovernanceInstruction {
     ///   4. `[signer]` Payer
     ///   5. `[]` System
     CreateTokenOwnerRecord {},
+
+    /// Updates ProgramMetadata account
+    /// The instruction dumps information implied by the program code into a persistent account
+    ///
+    ///   0. `[writable]` ProgramMetadata account. PDA seeds: ['metadata']
+    UpdateProgramMetadata {},
 }
 
 /// Creates CreateRealm instruction
@@ -1373,6 +1380,29 @@ pub fn create_token_owner_record(
     ];
 
     let instruction = GovernanceInstruction::CreateTokenOwnerRecord {};
+
+    Instruction {
+        program_id: *program_id,
+        accounts,
+        data: instruction.try_to_vec().unwrap(),
+    }
+}
+
+/// Creates UpdateProgramMetadata instruction
+pub fn upgrade_program_metadata(
+    program_id: &Pubkey,
+    // Accounts
+    payer: &Pubkey,
+) -> Instruction {
+    let program_metadata_address = get_program_metadata_address(program_id);
+
+    let accounts = vec![
+        AccountMeta::new(program_metadata_address, false),
+        AccountMeta::new(*payer, true),
+        AccountMeta::new_readonly(system_program::id(), false),
+    ];
+
+    let instruction = GovernanceInstruction::UpdateProgramMetadata {};
 
     Instruction {
         program_id: *program_id,

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -446,9 +446,11 @@ pub enum GovernanceInstruction {
     CreateTokenOwnerRecord {},
 
     /// Updates ProgramMetadata account
-    /// The instruction dumps information implied by the program code into a persistent account
+    /// The instruction dumps information implied by the program's code into a persistent account
     ///
-    ///   0. `[writable]` ProgramMetadata account. PDA seeds: ['metadata']
+    ///  0. `[writable]` ProgramMetadata account. PDA seeds: ['metadata']
+    ///  1. `[signer]` Payer
+    ///  2. `[]` System
     UpdateProgramMetadata {},
 }
 

--- a/governance/program/src/processor/mod.rs
+++ b/governance/program/src/processor/mod.rs
@@ -23,6 +23,7 @@ mod process_set_governance_delegate;
 mod process_set_realm_authority;
 mod process_set_realm_config;
 mod process_sign_off_proposal;
+mod process_update_program_metadata;
 mod process_withdraw_governing_tokens;
 
 use crate::instruction::GovernanceInstruction;
@@ -50,6 +51,7 @@ use process_set_governance_delegate::*;
 use process_set_realm_authority::*;
 use process_set_realm_config::*;
 use process_sign_off_proposal::*;
+use process_update_program_metadata::*;
 use process_withdraw_governing_tokens::*;
 
 use solana_program::{
@@ -194,6 +196,9 @@ pub fn process_instruction(
         }
         GovernanceInstruction::CreateTokenOwnerRecord {} => {
             process_create_token_owner_record(program_id, accounts)
+        }
+        GovernanceInstruction::UpdateProgramMetadata {} => {
+            process_update_program_metadata(program_id, accounts)
         }
     }
 }

--- a/governance/program/src/processor/process_create_token_owner_record.rs
+++ b/governance/program/src/processor/process_create_token_owner_record.rs
@@ -31,7 +31,7 @@ pub fn process_create_token_owner_record(
     let governing_token_mint_info = next_account_info(account_info_iter)?; // 3
     let payer_info = next_account_info(account_info_iter)?; // 4
     let system_info = next_account_info(account_info_iter)?; // 5
-    let rent = Rent::get().unwrap();
+    let rent = Rent::get()?;
 
     let realm_data = get_realm_data(program_id, realm_info)?;
     realm_data.assert_is_valid_governing_token_mint(governing_token_mint_info.key)?;

--- a/governance/program/src/processor/process_set_realm_config.rs
+++ b/governance/program/src/processor/process_set_realm_config.rs
@@ -83,7 +83,7 @@ pub fn process_set_realm_config(
                 reserved: [0; 128],
             };
 
-            let rent = Rent::get().unwrap();
+            let rent = Rent::get()?;
 
             create_and_serialize_account_signed::<RealmConfigAccount>(
                 payer_info,

--- a/governance/program/src/processor/process_update_program_metadata.rs
+++ b/governance/program/src/processor/process_update_program_metadata.rs
@@ -1,0 +1,57 @@
+//! Program state processor
+
+use borsh::BorshSerialize;
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    entrypoint::ProgramResult,
+    pubkey::Pubkey,
+    rent::Rent,
+    sysvar::Sysvar,
+};
+use spl_governance_tools::account::create_and_serialize_account_signed;
+
+use crate::state::{
+    enums::GovernanceAccountType,
+    program_metadata::{get_program_metadata_data, get_program_metadata_seeds, ProgramMetadata},
+};
+
+/// Processes UpdateProgramMetadata instruction
+pub fn process_update_program_metadata(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    let program_metadata_info = next_account_info(account_info_iter)?; // 0
+    let payer_info = next_account_info(account_info_iter)?; // 1
+    let system_info = next_account_info(account_info_iter)?; // 2
+    let rent = Rent::get().unwrap();
+
+    let version = 210; // 2.1
+
+    if program_metadata_info.data_is_empty() {
+        let program_metadata_data = ProgramMetadata {
+            account_type: GovernanceAccountType::ProgramMetadata,
+            version,
+            reserved: [0; 128],
+        };
+
+        create_and_serialize_account_signed(
+            payer_info,
+            program_metadata_info,
+            &program_metadata_data,
+            &get_program_metadata_seeds(),
+            program_id,
+            system_info,
+            &rent,
+        )?;
+    } else {
+        let mut program_metadata_data =
+            get_program_metadata_data(program_id, program_metadata_info)?;
+        program_metadata_data.version = version;
+
+        program_metadata_data.serialize(&mut *program_metadata_info.data.borrow_mut())?;
+    }
+
+    Ok(())
+}

--- a/governance/program/src/processor/process_update_program_metadata.rs
+++ b/governance/program/src/processor/process_update_program_metadata.rs
@@ -28,16 +28,16 @@ pub fn process_update_program_metadata(
     let system_info = next_account_info(account_info_iter)?; // 2
     let rent = Rent::get().unwrap();
 
-    let version = 210; // 2.1
+    const VERSION: &str = env!("CARGO_PKG_VERSION");
 
     // Put the metadata info into the logs to make it possible to extract it using Tx simulation
-    msg!("PROGRAM-METADATA:VERSION={:?}", version);
+    msg!("PROGRAM-VERSION:{:?}", VERSION);
 
     if program_metadata_info.data_is_empty() {
         let program_metadata_data = ProgramMetadata {
             account_type: GovernanceAccountType::ProgramMetadata,
-            version,
-            reserved: [0; 128],
+            version: VERSION.to_string(),
+            reserved: [0; 64],
         };
 
         create_and_serialize_account_signed(
@@ -52,7 +52,7 @@ pub fn process_update_program_metadata(
     } else {
         let mut program_metadata_data =
             get_program_metadata_data(program_id, program_metadata_info)?;
-        program_metadata_data.version = version;
+        program_metadata_data.version = VERSION.to_string();
 
         program_metadata_data.serialize(&mut *program_metadata_info.data.borrow_mut())?;
     }

--- a/governance/program/src/processor/process_update_program_metadata.rs
+++ b/governance/program/src/processor/process_update_program_metadata.rs
@@ -4,6 +4,7 @@ use borsh::BorshSerialize;
 use solana_program::{
     account_info::{next_account_info, AccountInfo},
     entrypoint::ProgramResult,
+    msg,
     pubkey::Pubkey,
     rent::Rent,
     sysvar::Sysvar,
@@ -28,6 +29,9 @@ pub fn process_update_program_metadata(
     let rent = Rent::get().unwrap();
 
     let version = 210; // 2.1
+
+    // Put the metadata info into the logs to make it possible to extract it using Tx simulation
+    msg!("PROGRAM-METADATA:VERSION={:?}", version);
 
     if program_metadata_info.data_is_empty() {
         let program_metadata_data = ProgramMetadata {

--- a/governance/program/src/processor/process_update_program_metadata.rs
+++ b/governance/program/src/processor/process_update_program_metadata.rs
@@ -28,8 +28,8 @@ pub fn process_update_program_metadata(
     let payer_info = next_account_info(account_info_iter)?; // 1
     let system_info = next_account_info(account_info_iter)?; // 2
 
-    let rent = Rent::get().unwrap();
-    let updated_at = Clock::get().unwrap().slot;
+    let rent = Rent::get()?;
+    let updated_at = Clock::get()?.slot;
 
     const VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -53,6 +53,9 @@ pub enum GovernanceAccountType {
     /// Proposal account for Governance account. A single Governance account can have multiple Proposal accounts
     /// V2 adds support for multiple vote options
     ProposalV2,
+
+    /// Program metadata account. It stores information about the particular SPL-Governance program instance
+    ProgramMetadata,
 }
 
 impl Default for GovernanceAccountType {

--- a/governance/program/src/state/mod.rs
+++ b/governance/program/src/state/mod.rs
@@ -3,6 +3,7 @@
 pub mod enums;
 pub mod governance;
 pub mod legacy;
+pub mod program_metadata;
 pub mod proposal;
 pub mod proposal_instruction;
 pub mod realm;

--- a/governance/program/src/state/program_metadata.rs
+++ b/governance/program/src/state/program_metadata.rs
@@ -20,6 +20,7 @@ pub struct ProgramMetadata {
     pub updated_at: Slot,
 
     /// The version of the program
+    /// Max 11 characters XXX.YYY.ZZZ
     pub version: String,
 
     /// Reserved
@@ -28,7 +29,7 @@ pub struct ProgramMetadata {
 
 impl AccountMaxSize for ProgramMetadata {
     fn get_max_size(&self) -> Option<usize> {
-        Some(85)
+        Some(88)
     }
 }
 
@@ -67,7 +68,7 @@ mod test {
             account_type: GovernanceAccountType::TokenOwnerRecord,
             updated_at: 10,
             reserved: [0; 64],
-            version: "11.12.15".to_string(),
+            version: "111.122.155".to_string(),
         };
 
         let size = program_metadata_data.try_to_vec().unwrap().len();

--- a/governance/program/src/state/program_metadata.rs
+++ b/governance/program/src/state/program_metadata.rs
@@ -2,8 +2,8 @@
 
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use solana_program::{
-    account_info::AccountInfo, program_error::ProgramError, program_pack::IsInitialized,
-    pubkey::Pubkey,
+    account_info::AccountInfo, clock::Slot, program_error::ProgramError,
+    program_pack::IsInitialized, pubkey::Pubkey,
 };
 use spl_governance_tools::account::{get_account_data, AccountMaxSize};
 
@@ -16,6 +16,9 @@ pub struct ProgramMetadata {
     /// Governance account type
     pub account_type: GovernanceAccountType,
 
+    /// The slot when the metadata was captured
+    pub updated_at: Slot,
+
     /// The version of the program
     pub version: String,
 
@@ -25,7 +28,7 @@ pub struct ProgramMetadata {
 
 impl AccountMaxSize for ProgramMetadata {
     fn get_max_size(&self) -> Option<usize> {
-        Some(77)
+        Some(85)
     }
 }
 
@@ -62,6 +65,7 @@ mod test {
     fn test_max_size() {
         let program_metadata_data = ProgramMetadata {
             account_type: GovernanceAccountType::TokenOwnerRecord,
+            updated_at: 10,
             reserved: [0; 64],
             version: "11.12.15".to_string(),
         };

--- a/governance/program/src/state/program_metadata.rs
+++ b/governance/program/src/state/program_metadata.rs
@@ -1,0 +1,49 @@
+//! ProgramMetadata Account
+
+use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use solana_program::{
+    account_info::AccountInfo, program_error::ProgramError, program_pack::IsInitialized,
+    pubkey::Pubkey,
+};
+use spl_governance_tools::account::{get_account_data, AccountMaxSize};
+
+use crate::state::enums::GovernanceAccountType;
+
+/// Program metadata account. It stores information about the particular SPL-Governance program instance
+#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+pub struct ProgramMetadata {
+    /// Governance account type
+    pub account_type: GovernanceAccountType,
+
+    /// The version of the program in  major.minor format with 2 decimal places used for the minor part
+    pub version: u16,
+
+    /// Reserved
+    pub reserved: [u8; 128],
+}
+
+impl AccountMaxSize for ProgramMetadata {}
+
+impl IsInitialized for ProgramMetadata {
+    fn is_initialized(&self) -> bool {
+        self.account_type == GovernanceAccountType::ProgramMetadata
+    }
+}
+
+/// Returns ProgramMetadata PDA address
+pub fn get_program_metadata_address(program_id: &Pubkey) -> Pubkey {
+    Pubkey::find_program_address(&get_program_metadata_seeds(), program_id).0
+}
+
+/// Returns ProgramMetadata PDA seeds
+pub fn get_program_metadata_seeds<'a>() -> [&'a [u8]; 1] {
+    [b"metadata"]
+}
+
+/// Deserializes account and checks owner program
+pub fn get_program_metadata_data(
+    program_id: &Pubkey,
+    program_metadata_info: &AccountInfo,
+) -> Result<ProgramMetadata, ProgramError> {
+    get_account_data::<ProgramMetadata>(program_id, program_metadata_info)
+}

--- a/governance/program/tests/process_update_program_metadata.rs
+++ b/governance/program/tests/process_update_program_metadata.rs
@@ -1,0 +1,41 @@
+#![cfg(feature = "test-bpf")]
+
+use solana_program_test::*;
+
+mod program_test;
+
+use program_test::*;
+
+#[tokio::test]
+async fn test_update_program_metadata() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    // Act
+    let program_metadata_cookie = governance_test.with_program_metadata().await;
+
+    // Assert
+    let program_metadata_account = governance_test
+        .get_program_metadata_account(&program_metadata_cookie.address)
+        .await;
+
+    assert_eq!(program_metadata_cookie.account, program_metadata_account);
+}
+
+#[tokio::test]
+async fn test_update_existing_program_metadata() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    governance_test.with_program_metadata().await;
+
+    // Act
+    let program_metadata_cookie = governance_test.with_program_metadata().await;
+
+    // Assert
+    let program_metadata_account = governance_test
+        .get_program_metadata_account(&program_metadata_cookie.address)
+        .await;
+
+    assert_eq!(program_metadata_cookie.account, program_metadata_account);
+}

--- a/governance/program/tests/process_update_program_metadata.rs
+++ b/governance/program/tests/process_update_program_metadata.rs
@@ -27,15 +27,21 @@ async fn test_update_existing_program_metadata() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
-    governance_test.with_program_metadata().await;
+    let program_metadata_cookie1 = governance_test.with_program_metadata().await;
 
     // Act
-    let program_metadata_cookie = governance_test.with_program_metadata().await;
+    governance_test.advance_clock().await;
+
+    let program_metadata_cookie2 = governance_test.with_program_metadata().await;
 
     // Assert
     let program_metadata_account = governance_test
-        .get_program_metadata_account(&program_metadata_cookie.address)
+        .get_program_metadata_account(&program_metadata_cookie2.address)
         .await;
 
-    assert_eq!(program_metadata_cookie.account, program_metadata_account);
+    assert_eq!(program_metadata_cookie2.account, program_metadata_account);
+
+    assert!(
+        program_metadata_cookie2.account.updated_at > program_metadata_cookie1.account.updated_at
+    )
 }

--- a/governance/program/tests/program_test/cookies.rs
+++ b/governance/program/tests/program_test/cookies.rs
@@ -3,8 +3,9 @@ use solana_sdk::signature::Keypair;
 use spl_governance::{
     addins::voter_weight::VoterWeightRecord,
     state::{
-        governance::Governance, proposal::ProposalV2, proposal_instruction::ProposalInstructionV2,
-        realm::Realm, realm_config::RealmConfigAccount, signatory_record::SignatoryRecord,
+        governance::Governance, program_metadata::ProgramMetadata, proposal::ProposalV2,
+        proposal_instruction::ProposalInstructionV2, realm::Realm,
+        realm_config::RealmConfigAccount, signatory_record::SignatoryRecord,
         token_owner_record::TokenOwnerRecord, vote_record::VoteRecordV2,
     },
 };
@@ -163,4 +164,10 @@ pub struct ProposalInstructionCookie {
 pub struct VoterWeightRecordCookie {
     pub address: Pubkey,
     pub account: VoterWeightRecord,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProgramMetadataCookie {
+    pub address: Pubkey,
+    pub account: ProgramMetadata,
 }

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -436,10 +436,12 @@ impl GovernanceProgramTest {
             .await
             .unwrap();
 
+        const VERSION: &str = env!("CARGO_PKG_VERSION");
+
         let account = ProgramMetadata {
             account_type: GovernanceAccountType::ProgramMetadata,
-            version: 210,
-            reserved: [0; 128],
+            version: VERSION.to_string(),
+            reserved: [0; 64],
         };
 
         let program_metadata_address = get_program_metadata_address(&self.program_id);

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -23,7 +23,7 @@ use spl_governance::{
         execute_instruction, finalize_vote, flag_instruction_error, insert_instruction,
         relinquish_vote, remove_instruction, remove_signatory, set_governance_config,
         set_governance_delegate, set_realm_authority, set_realm_config, sign_off_proposal,
-        withdraw_governing_tokens,
+        upgrade_program_metadata, withdraw_governing_tokens,
     },
     processor::process_instruction,
     state::{
@@ -36,6 +36,7 @@ use spl_governance::{
             get_program_governance_address, get_token_governance_address, Governance,
             GovernanceConfig,
         },
+        program_metadata::{get_program_metadata_address, ProgramMetadata},
         proposal::{get_proposal_address, OptionVoteResult, ProposalOption, ProposalV2, VoteType},
         proposal_instruction::{
             get_proposal_instruction_address, InstructionData, ProposalInstructionV2,
@@ -68,8 +69,8 @@ use self::{
     addins::ensure_voter_weight_addin_is_built,
     cookies::{
         GovernanceCookie, GovernedAccountCookie, GovernedMintCookie, GovernedProgramCookie,
-        GovernedTokenCookie, ProposalCookie, ProposalInstructionCookie, RealmCookie,
-        TokenOwnerRecordCookie, VoteRecordCookie,
+        GovernedTokenCookie, ProgramMetadataCookie, ProposalCookie, ProposalInstructionCookie,
+        RealmCookie, TokenOwnerRecordCookie, VoteRecordCookie,
     },
 };
 
@@ -422,6 +423,30 @@ impl GovernanceProgramTest {
             governance_authority: None,
             governance_delegate: Keypair::new(),
             voter_weight_record: None,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub async fn with_program_metadata(&mut self) -> ProgramMetadataCookie {
+        let update_program_metadata_ix =
+            upgrade_program_metadata(&self.program_id, &self.bench.payer.pubkey());
+
+        self.bench
+            .process_transaction(&[update_program_metadata_ix], None)
+            .await
+            .unwrap();
+
+        let account = ProgramMetadata {
+            account_type: GovernanceAccountType::ProgramMetadata,
+            version: 210,
+            reserved: [0; 128],
+        };
+
+        let program_metadata_address = get_program_metadata_address(&self.program_id);
+
+        ProgramMetadataCookie {
+            address: program_metadata_address,
+            account,
         }
     }
 
@@ -2206,6 +2231,13 @@ impl GovernanceProgramTest {
     pub async fn get_token_owner_record_account(&mut self, address: &Pubkey) -> TokenOwnerRecord {
         self.bench
             .get_borsh_account::<TokenOwnerRecord>(address)
+            .await
+    }
+
+    #[allow(dead_code)]
+    pub async fn get_program_metadata_account(&mut self, address: &Pubkey) -> ProgramMetadata {
+        self.bench
+            .get_borsh_account::<ProgramMetadata>(address)
             .await
     }
 

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -437,9 +437,11 @@ impl GovernanceProgramTest {
             .unwrap();
 
         const VERSION: &str = env!("CARGO_PKG_VERSION");
+        let clock = self.bench.get_clock().await;
 
         let account = ProgramMetadata {
             account_type: GovernanceAccountType::ProgramMetadata,
+            updated_at: clock.slot,
             version: VERSION.to_string(),
             reserved: [0; 64],
         };


### PR DESCRIPTION
#### Summary 

`spl-governance` is deployed using multiple instances and `governnace-ui` needs a to know what version of the program it communicates with in case the api is different between versions. 

#### Solution 

`ProgramMetadata` account was introduced to store the given instance version. The version is stored using `UpdatePorgramMetadata` instruction which dumps the program's crate version into the account and also outputs into the logs to make it possible to query the version using Tx simulation 

 