### PR TITLE
Governance: Native Treasuries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,16 +608,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctor"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
-dependencies = [
- "quote 1.0.14",
- "syn 1.0.84",
-]
-
-[[package]]
 name = "curve25519-dalek"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,17 +1082,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ghost"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5bcf1bbeab73aa4cf2fde60a846858dc036163c7c33bec309f8d17de785479"
-dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.14",
- "syn 1.0.84",
-]
-
-[[package]]
 name = "gimli"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1389,28 +1368,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "inventory"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb5160c60ba1e809707918ee329adb99d222888155835c6feedba19f6c3fd4"
-dependencies = [
- "ctor",
- "ghost",
- "inventory-impl",
-]
-
-[[package]]
-name = "inventory-impl"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e41b53715c6f0c4be49510bb82dee2c1e51c8586d885abe65396e82ed518548"
-dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.14",
- "syn 1.0.84",
 ]
 
 [[package]]
@@ -2051,38 +2008,48 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.12.4"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf6bbbe8f70d179260b3728e5d04eb012f4f0c7988e58c11433dd689cecaa72e"
+checksum = "7cf01dbf1c05af0a14c7779ed6f3aa9deac9c3419606ac9de537a2d649005720"
 dependencies = [
- "ctor",
+ "cfg-if",
  "indoc",
- "inventory",
  "libc",
  "parking_lot",
  "paste",
- "pyo3cls",
+ "pyo3-build-config",
+ "pyo3-macros",
  "unindent",
 ]
 
 [[package]]
-name = "pyo3-derive-backend"
-version = "0.12.4"
+name = "pyo3-build-config"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10ecd0eb6ed7b3d9965b4f4370b5b9e99e3e5e8742000e1c452c018f8c2a322f"
+checksum = "dbf9e4d128bfbddc898ad3409900080d8d5095c379632fbbfbb9c8cfb1fb852b"
 dependencies = [
- "proc-macro2 1.0.36",
+ "once_cell",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67701eb32b1f9a9722b4bc54b548ff9d7ebfded011c12daece7b9063be1fd755"
+dependencies = [
+ "pyo3-macros-backend",
  "quote 1.0.14",
  "syn 1.0.84",
 ]
 
 [[package]]
-name = "pyo3cls"
-version = "0.12.4"
+name = "pyo3-macros-backend"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d344fdaa6a834a06dd1720ff104ea12fe101dad2e8db89345af9db74c0bb11a0"
+checksum = "f44f09e825ee49a105f2c7b23ebee50886a9aee0746f4dd5a704138a64b0218a"
 dependencies = [
- "pyo3-derive-backend",
+ "proc-macro2 1.0.36",
+ "pyo3-build-config",
  "quote 1.0.14",
  "syn 1.0.84",
 ]

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -7,6 +7,7 @@ use crate::{
             get_account_governance_address, get_mint_governance_address,
             get_program_governance_address, get_token_governance_address, GovernanceConfig,
         },
+        native_treasury::get_native_treasury_address,
         program_metadata::get_program_metadata_address,
         proposal::{get_proposal_address, VoteType},
         proposal_instruction::{get_proposal_instruction_address, InstructionData},
@@ -452,6 +453,15 @@ pub enum GovernanceInstruction {
     ///  1. `[signer]` Payer
     ///  2. `[]` System
     UpdateProgramMetadata {},
+
+    /// Creates native SOL treasury account for a Governance account
+    /// The account has no data and can be used as a payer for instructions signed by Governance PDAs or as a native SOL treasury
+    ///
+    ///  0. `[]` Governance account the treasury account is for
+    ///  1. `[writable]` NativeTreasury account. PDA seeds: ['treasury', governance]
+    ///  2. `[signer]` Payer
+    ///  3. `[]` System
+    CreateNativeTreasury,
 }
 
 /// Creates CreateRealm instruction
@@ -1405,6 +1415,31 @@ pub fn upgrade_program_metadata(
     ];
 
     let instruction = GovernanceInstruction::UpdateProgramMetadata {};
+
+    Instruction {
+        program_id: *program_id,
+        accounts,
+        data: instruction.try_to_vec().unwrap(),
+    }
+}
+
+/// Creates CreateNativeTreasury instruction
+pub fn create_native_treasury(
+    program_id: &Pubkey,
+    // Accounts
+    governance: &Pubkey,
+    payer: &Pubkey,
+) -> Instruction {
+    let native_treasury_address = get_native_treasury_address(program_id, governance);
+
+    let accounts = vec![
+        AccountMeta::new_readonly(*governance, false),
+        AccountMeta::new(native_treasury_address, false),
+        AccountMeta::new(*payer, true),
+        AccountMeta::new_readonly(system_program::id(), false),
+    ];
+
+    let instruction = GovernanceInstruction::CreateNativeTreasury {};
 
     Instruction {
         program_id: *program_id,

--- a/governance/program/src/processor/mod.rs
+++ b/governance/program/src/processor/mod.rs
@@ -5,6 +5,7 @@ mod process_cancel_proposal;
 mod process_cast_vote;
 mod process_create_account_governance;
 mod process_create_mint_governance;
+mod process_create_native_treasury;
 mod process_create_program_governance;
 mod process_create_proposal;
 mod process_create_realm;
@@ -33,6 +34,7 @@ use process_cancel_proposal::*;
 use process_cast_vote::*;
 use process_create_account_governance::*;
 use process_create_mint_governance::*;
+use process_create_native_treasury::*;
 use process_create_program_governance::*;
 use process_create_proposal::*;
 use process_create_realm::*;
@@ -199,6 +201,9 @@ pub fn process_instruction(
         }
         GovernanceInstruction::UpdateProgramMetadata {} => {
             process_update_program_metadata(program_id, accounts)
+        }
+        GovernanceInstruction::CreateNativeTreasury {} => {
+            process_create_native_treasury(program_id, accounts)
         }
     }
 }

--- a/governance/program/src/processor/process_create_native_treasury.rs
+++ b/governance/program/src/processor/process_create_native_treasury.rs
@@ -5,6 +5,7 @@ use solana_program::{
     entrypoint::ProgramResult,
     pubkey::Pubkey,
     rent::Rent,
+    system_program,
     sysvar::Sysvar,
 };
 use spl_governance_tools::account::create_and_serialize_account_signed2;
@@ -38,7 +39,7 @@ pub fn process_create_native_treasury(
         &native_treasury_data,
         &get_native_treasury_address_seeds(governance_info.key),
         program_id,
-        system_info.key,
+        &system_program::id(),
         system_info,
         &rent,
     )?;

--- a/governance/program/src/processor/process_create_native_treasury.rs
+++ b/governance/program/src/processor/process_create_native_treasury.rs
@@ -39,7 +39,7 @@ pub fn process_create_native_treasury(
         &native_treasury_data,
         &get_native_treasury_address_seeds(governance_info.key),
         program_id,
-        &system_program::id(),
+        &system_program::id(), // System program as the PDA owner
         system_info,
         &rent,
     )?;

--- a/governance/program/src/processor/process_create_native_treasury.rs
+++ b/governance/program/src/processor/process_create_native_treasury.rs
@@ -1,0 +1,43 @@
+//! Program state processor
+
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    entrypoint::ProgramResult,
+    pubkey::Pubkey,
+    rent::Rent,
+    sysvar::Sysvar,
+};
+use spl_governance_tools::account::create_and_serialize_account_signed;
+
+use crate::state::native_treasury::{get_native_treasury_address_seeds, NativeTreasury};
+
+/// Processes CreateNativeTreasury instruction
+pub fn process_create_native_treasury(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    let governance_info = next_account_info(account_info_iter)?; // 0
+    let native_treasury_info = next_account_info(account_info_iter)?; // 1
+    let payer_info = next_account_info(account_info_iter)?; // 2
+    let system_info = next_account_info(account_info_iter)?; // 3
+
+    let rent = Rent::get()?;
+
+    // TODO: Assert is valid Governance
+
+    let native_treasury_data = NativeTreasury {};
+
+    create_and_serialize_account_signed(
+        payer_info,
+        native_treasury_info,
+        &native_treasury_data,
+        &get_native_treasury_address_seeds(governance_info.key),
+        program_id,
+        system_info,
+        &rent,
+    )?;
+
+    Ok(())
+}

--- a/governance/program/src/processor/process_create_native_treasury.rs
+++ b/governance/program/src/processor/process_create_native_treasury.rs
@@ -8,7 +8,7 @@ use solana_program::{
     system_program,
     sysvar::Sysvar,
 };
-use spl_governance_tools::account::create_and_serialize_account_signed2;
+use spl_governance_tools::account::create_and_serialize_account_with_owner_signed;
 
 use crate::state::{
     governance::assert_is_valid_governance,
@@ -33,7 +33,7 @@ pub fn process_create_native_treasury(
 
     let native_treasury_data = NativeTreasury {};
 
-    create_and_serialize_account_signed2(
+    create_and_serialize_account_with_owner_signed(
         payer_info,
         native_treasury_info,
         &native_treasury_data,

--- a/governance/program/src/processor/process_create_native_treasury.rs
+++ b/governance/program/src/processor/process_create_native_treasury.rs
@@ -9,7 +9,10 @@ use solana_program::{
 };
 use spl_governance_tools::account::create_and_serialize_account_signed2;
 
-use crate::state::native_treasury::{get_native_treasury_address_seeds, NativeTreasury};
+use crate::state::{
+    governance::assert_is_valid_governance,
+    native_treasury::{get_native_treasury_address_seeds, NativeTreasury},
+};
 
 /// Processes CreateNativeTreasury instruction
 pub fn process_create_native_treasury(
@@ -25,7 +28,7 @@ pub fn process_create_native_treasury(
 
     let rent = Rent::get()?;
 
-    // TODO: Assert is valid Governance
+    assert_is_valid_governance(program_id, governance_info)?;
 
     let native_treasury_data = NativeTreasury {};
 

--- a/governance/program/src/processor/process_create_native_treasury.rs
+++ b/governance/program/src/processor/process_create_native_treasury.rs
@@ -7,7 +7,7 @@ use solana_program::{
     rent::Rent,
     sysvar::Sysvar,
 };
-use spl_governance_tools::account::create_and_serialize_account_signed;
+use spl_governance_tools::account::create_and_serialize_account_signed2;
 
 use crate::state::native_treasury::{get_native_treasury_address_seeds, NativeTreasury};
 
@@ -29,12 +29,13 @@ pub fn process_create_native_treasury(
 
     let native_treasury_data = NativeTreasury {};
 
-    create_and_serialize_account_signed(
+    create_and_serialize_account_signed2(
         payer_info,
         native_treasury_info,
         &native_treasury_data,
         &get_native_treasury_address_seeds(governance_info.key),
         program_id,
+        system_info.key,
         system_info,
         &rent,
     )?;

--- a/governance/program/src/processor/process_execute_instruction.rs
+++ b/governance/program/src/processor/process_execute_instruction.rs
@@ -48,7 +48,7 @@ pub fn process_execute_instruction(program_id: &Pubkey, accounts: &[AccountInfo]
 
     let instruction_account_infos = account_info_iter.as_slice();
 
-    let mut signer_seeds: Vec<&[&[u8]]> = vec![];
+    let mut signers_seeds: Vec<&[&[u8]]> = vec![];
 
     // Sign the transaction using the governance PDA
     let mut governance_seeds = governance_data.get_governance_address_seeds()?.to_vec();
@@ -56,7 +56,7 @@ pub fn process_execute_instruction(program_id: &Pubkey, accounts: &[AccountInfo]
     let bump = &[bump_seed];
     governance_seeds.push(bump);
 
-    signer_seeds.push(&governance_seeds[..]);
+    signers_seeds.push(&governance_seeds[..]);
 
     // Sign the transaction using the governance treasury PDA if required by the instruction
     let mut treasury_seeds = get_native_treasury_address_seeds(governance_info.key).to_vec();
@@ -69,10 +69,10 @@ pub fn process_execute_instruction(program_id: &Pubkey, accounts: &[AccountInfo]
         .any(|a| a.key == &treasury_address)
     {
         treasury_seeds.push(treasury_bump);
-        signer_seeds.push(&treasury_seeds[..]);
+        signers_seeds.push(&treasury_seeds[..]);
     }
 
-    invoke_signed(&instruction, instruction_account_infos, &signer_seeds[..])?;
+    invoke_signed(&instruction, instruction_account_infos, &signers_seeds[..])?;
 
     // Update proposal and instruction accounts
     if proposal_data.state == ProposalState::Succeeded {

--- a/governance/program/src/processor/process_execute_instruction.rs
+++ b/governance/program/src/processor/process_execute_instruction.rs
@@ -65,7 +65,7 @@ pub fn process_execute_instruction(program_id: &Pubkey, accounts: &[AccountInfo]
     let treasury_bump = &[treasury_bump_seed];
 
     if instruction_account_infos
-        .into_iter()
+        .iter()
         .any(|a| a.key == &treasury_address)
     {
         treasury_seeds.push(treasury_bump);

--- a/governance/program/src/processor/process_execute_instruction.rs
+++ b/governance/program/src/processor/process_execute_instruction.rs
@@ -59,6 +59,20 @@ pub fn process_execute_instruction(program_id: &Pubkey, accounts: &[AccountInfo]
     let treasury_bump = &[treasury_bump_seed];
     treasury_seeds.push(treasury_bump);
 
+    //let address = get_native_treasury_address(program_id, governance_info.key);
+
+    // // if instruction_account_infos.len() == 3 {
+    // //     panic!("INVALID NO")
+    // // }
+
+    // for acc in instruction_account_infos {
+    //     if *acc.key == address {
+    //         if acc.owner == program_id {
+    //             // return Ok(());
+    //         }
+    //     }
+    // }
+
     invoke_signed(
         &instruction,
         instruction_account_infos,

--- a/governance/program/src/processor/process_execute_instruction.rs
+++ b/governance/program/src/processor/process_execute_instruction.rs
@@ -13,6 +13,7 @@ use solana_program::{
 use crate::state::{
     enums::{InstructionExecutionStatus, ProposalState},
     governance::get_governance_data,
+    native_treasury::get_native_treasury_address_seeds,
     proposal::{get_proposal_data_for_governance, OptionVoteResult},
     proposal_instruction::get_proposal_instruction_data_for_proposal,
 };
@@ -52,10 +53,16 @@ pub fn process_execute_instruction(program_id: &Pubkey, accounts: &[AccountInfo]
     let bump = &[bump_seed];
     governance_seeds.push(bump);
 
+    // TODO: Add treasury seeds only if the treasury account is present instruction_account_infos
+    let mut treasury_seeds = get_native_treasury_address_seeds(governance_info.key).to_vec();
+    let (_, treasury_bump_seed) = Pubkey::find_program_address(&treasury_seeds, program_id);
+    let treasury_bump = &[treasury_bump_seed];
+    treasury_seeds.push(treasury_bump);
+
     invoke_signed(
         &instruction,
         instruction_account_infos,
-        &[&governance_seeds[..]],
+        &[&governance_seeds[..], &treasury_seeds[..]],
     )?;
 
     // Update proposal and instruction accounts

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -56,10 +56,6 @@ pub enum GovernanceAccountType {
 
     /// Program metadata account. It stores information about the particular SPL-Governance program instance
     ProgramMetadata,
-
-    /// NativeTreasury account
-    /// The account has no data and can be used as payer for instructions signed by Governance PDAs or as native SOL treasury
-    NativeTreasury,
 }
 
 impl Default for GovernanceAccountType {

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -56,6 +56,10 @@ pub enum GovernanceAccountType {
 
     /// Program metadata account. It stores information about the particular SPL-Governance program instance
     ProgramMetadata,
+
+    /// NativeTreasury account
+    /// The account has no data and can be used as payer for instructions signed by Governance PDAs or as native SOL treasury
+    NativeTreasury,
 }
 
 impl Default for GovernanceAccountType {

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -13,7 +13,7 @@ use solana_program::{
     pubkey::Pubkey,
 };
 use spl_governance_tools::{
-    account::{get_account_data, AccountMaxSize},
+    account::{assert_is_valid_account2, get_account_data, AccountMaxSize},
     error::GovernanceToolsError,
 };
 
@@ -223,6 +223,23 @@ pub fn get_account_governance_address<'a>(
         program_id,
     )
     .0
+}
+
+/// Checks whether governance account exists, is initialized and owned by the Governance program
+pub fn assert_is_valid_governance(
+    program_id: &Pubkey,
+    governance_info: &AccountInfo,
+) -> Result<(), ProgramError> {
+    assert_is_valid_account2(
+        governance_info,
+        &[
+            GovernanceAccountType::AccountGovernance,
+            GovernanceAccountType::ProgramGovernance,
+            GovernanceAccountType::TokenGovernance,
+            GovernanceAccountType::MintGovernance,
+        ],
+        program_id,
+    )
 }
 
 /// Validates args supplied to create governance account

--- a/governance/program/src/state/mod.rs
+++ b/governance/program/src/state/mod.rs
@@ -3,6 +3,7 @@
 pub mod enums;
 pub mod governance;
 pub mod legacy;
+pub mod native_treasury;
 pub mod program_metadata;
 pub mod proposal;
 pub mod proposal_instruction;
@@ -10,5 +11,4 @@ pub mod realm;
 pub mod realm_config;
 pub mod signatory_record;
 pub mod token_owner_record;
-pub mod native_treasury;
 pub mod vote_record;

--- a/governance/program/src/state/mod.rs
+++ b/governance/program/src/state/mod.rs
@@ -10,4 +10,5 @@ pub mod realm;
 pub mod realm_config;
 pub mod signatory_record;
 pub mod token_owner_record;
+pub mod native_treasury;
 pub mod vote_record;

--- a/governance/program/src/state/native_treasury.rs
+++ b/governance/program/src/state/native_treasury.rs
@@ -16,7 +16,7 @@ impl AccountMaxSize for NativeTreasury {
 }
 
 /// Returns NativeTreasury PDA seeds
-pub fn get_native_treasury_address_seeds<'a>(governance: &'a Pubkey) -> [&'a [u8]; 2] {
+pub fn get_native_treasury_address_seeds(governance: &Pubkey) -> [&[u8]; 2] {
     [b"treasury", governance.as_ref()]
 }
 

--- a/governance/program/src/state/native_treasury.rs
+++ b/governance/program/src/state/native_treasury.rs
@@ -1,0 +1,26 @@
+//! Native treasury account
+
+use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use solana_program::pubkey::Pubkey;
+use spl_governance_tools::account::AccountMaxSize;
+
+/// Treasury account
+/// The account has no data and can be used as a payer for instruction signed by Governance PDAs or as a native SOL treasury
+#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+pub struct NativeTreasury {}
+
+impl AccountMaxSize for NativeTreasury {
+    fn get_max_size(&self) -> Option<usize> {
+        Some(0)
+    }
+}
+
+/// Returns NativeTreasury PDA seeds
+pub fn get_native_treasury_address_seeds<'a>(governance: &'a Pubkey) -> [&'a [u8]; 2] {
+    [b"treasury", governance.as_ref()]
+}
+
+/// Returns NativeTreasury PDA address
+pub fn get_native_treasury_address(program_id: &Pubkey, governance: &Pubkey) -> Pubkey {
+    Pubkey::find_program_address(&get_native_treasury_address_seeds(governance), program_id).0
+}

--- a/governance/program/src/state/native_treasury.rs
+++ b/governance/program/src/state/native_treasury.rs
@@ -17,7 +17,7 @@ impl AccountMaxSize for NativeTreasury {
 
 /// Returns NativeTreasury PDA seeds
 pub fn get_native_treasury_address_seeds(governance: &Pubkey) -> [&[u8]; 2] {
-    [b"treasury", governance.as_ref()]
+    [b"native-treasury", governance.as_ref()]
 }
 
 /// Returns NativeTreasury PDA address

--- a/governance/program/tests/process_create_native_treasury.rs
+++ b/governance/program/tests/process_create_native_treasury.rs
@@ -40,10 +40,4 @@ async fn test_create_native_treasury() {
         .await;
 
     assert_eq!(native_treasury_cookie.account, native_treasury_account);
-
-    let acc = governance_test
-        .bench
-        .get_account(&native_treasury_cookie.address)
-        .await
-        .unwrap();
 }

--- a/governance/program/tests/process_create_native_treasury.rs
+++ b/governance/program/tests/process_create_native_treasury.rs
@@ -41,3 +41,76 @@ async fn test_create_native_treasury() {
 
     assert_eq!(native_treasury_cookie.account, native_treasury_account);
 }
+
+#[tokio::test]
+async fn test_execute_transfer_from_native_treasury() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut account_governance_cookie = governance_test
+        .with_account_governance(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let _native_treasury_cookie = governance_test
+        .with_native_treasury(&account_governance_cookie)
+        .await;
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut account_governance_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let wallet_cookie = governance_test.bench.with_wallet().await;
+
+    let proposal_instruction_cookie = governance_test
+        .with_native_transfer_instruction(
+            &account_governance_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            &wallet_cookie,
+            1,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Advance timestamp past hold_up_time
+    governance_test
+        .advance_clock_by_min_timespan(proposal_instruction_cookie.account.hold_up_time as u64)
+        .await;
+
+    // Act
+    // governance_test
+    //     .execute_instruction(&proposal_cookie, &proposal_instruction_cookie)
+    //     .await
+    //     .unwrap();
+
+    // Assert
+}

--- a/governance/program/tests/process_create_native_treasury.rs
+++ b/governance/program/tests/process_create_native_treasury.rs
@@ -1,0 +1,49 @@
+#![cfg(feature = "test-bpf")]
+
+use solana_program_test::*;
+
+mod program_test;
+
+use program_test::*;
+
+#[tokio::test]
+async fn test_create_native_treasury() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let account_governance_cookie = governance_test
+        .with_account_governance(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    // Act
+    let native_treasury_cookie = governance_test
+        .with_native_treasury(&account_governance_cookie)
+        .await;
+
+    // Assert
+
+    let native_treasury_account = governance_test
+        .get_native_treasury_account(&native_treasury_cookie.address)
+        .await;
+
+    assert_eq!(native_treasury_cookie.account, native_treasury_account);
+
+    let acc = governance_test
+        .bench
+        .get_account(&native_treasury_cookie.address)
+        .await
+        .unwrap();
+}

--- a/governance/program/tests/process_create_native_treasury.rs
+++ b/governance/program/tests/process_create_native_treasury.rs
@@ -86,7 +86,7 @@ async fn test_execute_transfer_from_native_treasury() {
             &mut proposal_cookie,
             &token_owner_record_cookie,
             &wallet_cookie,
-            1,
+            100,
         )
         .await
         .unwrap();
@@ -107,10 +107,20 @@ async fn test_execute_transfer_from_native_treasury() {
         .await;
 
     // Act
-    // governance_test
-    //     .execute_instruction(&proposal_cookie, &proposal_instruction_cookie)
-    //     .await
-    //     .unwrap();
+    governance_test
+        .execute_instruction(&proposal_cookie, &proposal_instruction_cookie)
+        .await
+        .unwrap();
 
     // Assert
+    let wallet_account = governance_test
+        .bench
+        .get_account(&wallet_cookie.address)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        wallet_account.lamports,
+        wallet_cookie.account.lamports + 100
+    )
 }

--- a/governance/program/tests/process_create_native_treasury.rs
+++ b/governance/program/tests/process_create_native_treasury.rs
@@ -64,7 +64,7 @@ async fn test_execute_transfer_from_native_treasury() {
         .await
         .unwrap();
 
-    let _native_treasury_cookie = governance_test
+    governance_test
         .with_native_treasury(&account_governance_cookie)
         .await;
 
@@ -79,6 +79,7 @@ async fn test_execute_transfer_from_native_treasury() {
         .unwrap();
 
     let wallet_cookie = governance_test.bench.with_wallet().await;
+    let transfer_amount = 100;
 
     let proposal_instruction_cookie = governance_test
         .with_native_transfer_instruction(
@@ -86,7 +87,7 @@ async fn test_execute_transfer_from_native_treasury() {
             &mut proposal_cookie,
             &token_owner_record_cookie,
             &wallet_cookie,
-            100,
+            transfer_amount,
         )
         .await
         .unwrap();
@@ -121,6 +122,6 @@ async fn test_execute_transfer_from_native_treasury() {
 
     assert_eq!(
         wallet_account.lamports,
-        wallet_cookie.account.lamports + 100
+        wallet_cookie.account.lamports + transfer_amount
     )
 }

--- a/governance/program/tests/program_test/cookies.rs
+++ b/governance/program/tests/program_test/cookies.rs
@@ -3,8 +3,8 @@ use solana_sdk::signature::Keypair;
 use spl_governance::{
     addins::voter_weight::VoterWeightRecord,
     state::{
-        governance::Governance, program_metadata::ProgramMetadata, proposal::ProposalV2,
-        proposal_instruction::ProposalInstructionV2, realm::Realm,
+        governance::Governance, native_treasury::NativeTreasury, program_metadata::ProgramMetadata,
+        proposal::ProposalV2, proposal_instruction::ProposalInstructionV2, realm::Realm,
         realm_config::RealmConfigAccount, signatory_record::SignatoryRecord,
         token_owner_record::TokenOwnerRecord, vote_record::VoteRecordV2,
     },
@@ -170,4 +170,10 @@ pub struct VoterWeightRecordCookie {
 pub struct ProgramMetadataCookie {
     pub address: Pubkey,
     pub account: ProgramMetadata,
+}
+
+#[derive(Debug, Clone)]
+pub struct NativeTreasuryCookie {
+    pub address: Pubkey,
+    pub account: NativeTreasury,
 }

--- a/governance/test-sdk/src/cookies.rs
+++ b/governance/test-sdk/src/cookies.rs
@@ -4,3 +4,8 @@ use solana_program::pubkey::Pubkey;
 pub struct TokenAccountCookie {
     pub address: Pubkey,
 }
+
+#[derive(Debug)]
+pub struct WalletCookie {
+    pub address: Pubkey,
+}

--- a/governance/test-sdk/src/cookies.rs
+++ b/governance/test-sdk/src/cookies.rs
@@ -1,4 +1,5 @@
 use solana_program::pubkey::Pubkey;
+use solana_sdk::account::Account;
 
 #[derive(Debug)]
 pub struct TokenAccountCookie {
@@ -8,4 +9,5 @@ pub struct TokenAccountCookie {
 #[derive(Debug)]
 pub struct WalletCookie {
     pub address: Pubkey,
+    pub account: Account,
 }

--- a/governance/test-sdk/src/lib.rs
+++ b/governance/test-sdk/src/lib.rs
@@ -1,11 +1,11 @@
 use std::borrow::Borrow;
 
 use borsh::BorshDeserialize;
-use cookies::TokenAccountCookie;
+use cookies::{TokenAccountCookie, WalletCookie};
 use solana_program::{
     borsh::try_from_slice_unchecked, clock::Clock, instruction::Instruction,
     program_error::ProgramError, program_pack::Pack, pubkey::Pubkey, rent::Rent,
-    system_instruction, sysvar,
+    system_instruction, system_program, sysvar,
 };
 use solana_program_test::{ProgramTest, ProgramTestContext};
 use solana_sdk::{account::Account, signature::Keypair, signer::Signer, transaction::Transaction};
@@ -80,6 +80,27 @@ impl ProgramTestBench {
             .map_err(|e| map_transaction_error(e.into()))?;
 
         Ok(())
+    }
+
+    pub async fn with_wallet(&mut self) -> WalletCookie {
+        let account_rent = self.rent.minimum_balance(0);
+        let account_keypair = Keypair::new();
+
+        let create_account_ix = system_instruction::create_account(
+            &self.context.payer.pubkey(),
+            &account_keypair.pubkey(),
+            account_rent,
+            0,
+            &system_program::id(),
+        );
+
+        self.process_transaction(&[create_account_ix], Some(&[&account_keypair]))
+            .await
+            .unwrap();
+
+        WalletCookie {
+            address: account_keypair.pubkey(),
+        }
     }
 
     pub async fn create_mint(&mut self, mint_keypair: &Keypair, mint_authority: &Pubkey) {

--- a/governance/test-sdk/src/lib.rs
+++ b/governance/test-sdk/src/lib.rs
@@ -98,8 +98,17 @@ impl ProgramTestBench {
             .await
             .unwrap();
 
+        let account = Account {
+            lamports: account_rent,
+            data: vec![],
+            owner: system_program::id(),
+            executable: false,
+            rent_epoch: 0,
+        };
+
         WalletCookie {
             address: account_keypair.pubkey(),
+            account,
         }
     }
 

--- a/governance/tools/src/account.rs
+++ b/governance/tools/src/account.rs
@@ -81,7 +81,7 @@ pub fn create_and_serialize_account_signed<'a, T: BorshSerialize + AccountMaxSiz
     system_info: &AccountInfo<'a>,
     rent: &Rent,
 ) -> Result<(), ProgramError> {
-    create_and_serialize_account_signed2(
+    create_and_serialize_account_with_owner_signed(
         payer_info,
         account_info,
         account_data,
@@ -96,7 +96,7 @@ pub fn create_and_serialize_account_signed<'a, T: BorshSerialize + AccountMaxSiz
 /// Creates a new account and serializes data into it using the provided seeds to invoke signed CPI call
 /// Note: This functions also checks the provided account PDA matches the supplied seeds
 #[allow(clippy::too_many_arguments)]
-pub fn create_and_serialize_account_signed_with_owner<'a, T: BorshSerialize + AccountMaxSize>(
+pub fn create_and_serialize_account_with_owner_signed<'a, T: BorshSerialize + AccountMaxSize>(
     payer_info: &AccountInfo<'a>,
     account_info: &AccountInfo<'a>,
     account_data: &T,

--- a/governance/tools/src/account.rs
+++ b/governance/tools/src/account.rs
@@ -96,7 +96,7 @@ pub fn create_and_serialize_account_signed<'a, T: BorshSerialize + AccountMaxSiz
 /// Creates a new account and serializes data into it using the provided seeds to invoke signed CPI call
 /// Note: This functions also checks the provided account PDA matches the supplied seeds
 #[allow(clippy::too_many_arguments)]
-pub fn create_and_serialize_account_signed2<'a, T: BorshSerialize + AccountMaxSize>(
+pub fn create_and_serialize_account_signed_with_owner<'a, T: BorshSerialize + AccountMaxSize>(
     payer_info: &AccountInfo<'a>,
     account_info: &AccountInfo<'a>,
     account_data: &T,

--- a/governance/tools/src/account.rs
+++ b/governance/tools/src/account.rs
@@ -95,6 +95,7 @@ pub fn create_and_serialize_account_signed<'a, T: BorshSerialize + AccountMaxSiz
 
 /// Creates a new account and serializes data into it using the provided seeds to invoke signed CPI call
 /// Note: This functions also checks the provided account PDA matches the supplied seeds
+#[allow(clippy::too_many_arguments)]
 pub fn create_and_serialize_account_signed2<'a, T: BorshSerialize + AccountMaxSize>(
     payer_info: &AccountInfo<'a>,
     account_info: &AccountInfo<'a>,

--- a/governance/tools/src/account.rs
+++ b/governance/tools/src/account.rs
@@ -187,6 +187,15 @@ pub fn assert_is_valid_account<T: BorshDeserialize + PartialEq>(
     expected_account_type: T,
     owner_program_id: &Pubkey,
 ) -> Result<(), ProgramError> {
+    assert_is_valid_account2(account_info, &[expected_account_type], owner_program_id)
+}
+/// Asserts the given account is not empty, owned by the given program and one of the expected types
+/// Note: The function assumes the account type T is stored as the first element in the account data
+pub fn assert_is_valid_account2<T: BorshDeserialize + PartialEq>(
+    account_info: &AccountInfo,
+    expected_account_types: &[T],
+    owner_program_id: &Pubkey,
+) -> Result<(), ProgramError> {
     if account_info.owner != owner_program_id {
         return Err(GovernanceToolsError::InvalidAccountOwner.into());
     }
@@ -197,7 +206,7 @@ pub fn assert_is_valid_account<T: BorshDeserialize + PartialEq>(
 
     let account_type: T = try_from_slice_unchecked(&account_info.data.borrow())?;
 
-    if account_type != expected_account_type {
+    if expected_account_types.iter().all(|a| a != &account_type) {
         return Err(GovernanceToolsError::InvalidAccountType.into());
     };
 


### PR DESCRIPTION
#### Summary

At present `spl-governance` supports only `spl-token ` based treasury accounts and it's not possible to have a native SOL treasury. Only `wSOL` is supported which is both confusing and inconvenient for users.

Its also not possible to pay for execution of proposal instructions using DAO treasury and personal wallets a currently used. 

#### Solution

Create a `NativeTreasury` account which is a PDA without any data and make it possible to associate it with `Governance` accounts. This way any proposal instruction executed for the governance can use the funds from the associated SOL treasury account or in the simple case the instruction can be just a native SOL transfer. 


