### PR TITLE
Fix update-solana-dependencies.sh to work on osx

### DIFF
--- a/update-solana-dependencies.sh
+++ b/update-solana-dependencies.sh
@@ -41,5 +41,5 @@ crates=(
 
 set -x
 for crate in "${crates[@]}"; do
-  sed -i'' -e "s#\(${crate} = \"\)\(=\?\).*\(\"\)#\1\2$solana_ver\3#g" "${tomls[@]}"
+  sed -E -i'' -e "s#(${crate} = \")(=?).*#\1\2${solana_ver}\"#" "${tomls[@]}"
 done


### PR DESCRIPTION
Bump deps to 1.10.0 and tweak `update-solana-dependencies.sh` to work on osx.