### PR TITLE
CI: Add cargo audit, just like in the monorepo

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,6 +15,7 @@ jobs:
     needs:
       - rustfmt
       - clippy
+      - audit
       - cargo-build-test
     steps:
       - run: echo "Done"
@@ -77,6 +78,31 @@ jobs:
         with:
           command: clippy
           args: -Zunstable-options --workspace --all-targets -- --deny=warnings
+
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set env vars
+        run: |
+          source ci/rust-version.sh
+          echo "RUST_STABLE=$rust_stable" >> $GITHUB_ENV
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_STABLE }}
+          override: true
+          profile: minimal
+
+      - name: Install Cargo Audit
+        uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-audit
+          version: latest
+
+      - name: Run Cargo Audit
+        run: ./ci/do-audit.sh
 
   cargo-build-test:
     runs-on: ubuntu-latest

--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -e
+cd "$(dirname "$0")/.."
+source ./ci/rust-version.sh stable
+
+cargo_audit_ignores=(
+  # failure is officially deprecated/unmaintained
+  #
+  # Blocked on multiple upstream crates removing their `failure` dependency.
+  --ignore RUSTSEC-2020-0036
+
+  # Potential segfault in the time crate
+  #
+  # Blocked on chrono and solana_rbpf updating `time` to >= 0.2.23
+  --ignore RUSTSEC-2020-0071
+
+  # chrono: Potential segfault in `localtime_r` invocations
+  #
+  # Blocked due to no safe upgrade
+  # https://github.com/chronotope/chrono/issues/499
+  --ignore RUSTSEC-2020-0159
+
+  # memmap is officially deprecated/unmaintained, used by honggfuzz
+  #
+  # Blcoked on honggfuzz, fixed in https://github.com/rust-fuzz/honggfuzz-rs/pull/55
+  # need to update honggfuzz dependency whenever the next version is released
+  --ignore RUSTSEC-2020-0077
+)
+cargo +"$rust_stable" audit "${cargo_audit_ignores[@]}"


### PR DESCRIPTION
#### Problem

We should know if SPL is using insecure crates.

#### Solution

Just like in the monorepo's https://github.com/solana-labs/solana/blob/master/ci/do-audit.sh, run `cargo audit` on every pull request.  Thankfully, SPL has a smaller number of dependencies, which makes it easier to manage.  The `ignore`s here are all from the monorepo, except for the `memmap` one, which comes from `honggfuzz`, only used in testing.

Inspired by #2703 -- @silas-x, what do you think of this?  I had a hard time finding info about some of the extra flags used for `cargo audit` in your PR, so if there's anything that you think is missing in this, please let me know!