### PR TITLE
Strip extension account-type prefixes

### DIFF
--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -4,7 +4,7 @@ use {
     crate::{
         extension::{
             mint_close_authority::MintCloseAuthority,
-            transfer_fee::{AccountTransferFee, MintTransferFee},
+            transfer_fee::{TransferFeeAmount, TransferFeeConfig},
         },
         pod::*,
         state::{Account, Mint, Multisig},
@@ -327,9 +327,9 @@ pub enum ExtensionType {
     /// Used as padding if the account size would otherwise be 355, same as a multisig
     Uninitialized,
     /// Includes a transfer fee and accompanying authorities to withdraw and set the fee
-    MintTransferFee,
+    TransferFeeConfig,
     /// Includes withheld transfer fees
-    AccountTransferFee,
+    TransferFeeAmount,
     /// Includes an optional mint close authority
     MintCloseAuthority,
     /// Padding extension used to make an account exactly Multisig::LEN, used for testing
@@ -358,8 +358,8 @@ impl ExtensionType {
     pub fn get_associated_type_len(&self) -> usize {
         match self {
             ExtensionType::Uninitialized => 0,
-            ExtensionType::MintTransferFee => pod_get_packed_len::<MintTransferFee>(),
-            ExtensionType::AccountTransferFee => pod_get_packed_len::<AccountTransferFee>(),
+            ExtensionType::TransferFeeConfig => pod_get_packed_len::<TransferFeeConfig>(),
+            ExtensionType::TransferFeeAmount => pod_get_packed_len::<TransferFeeAmount>(),
             ExtensionType::MintCloseAuthority => pod_get_packed_len::<MintCloseAuthority>(),
             #[cfg(test)]
             ExtensionType::AccountPaddingTest => pod_get_packed_len::<AccountPaddingTest>(),
@@ -448,7 +448,7 @@ mod test {
         super::*,
         crate::state::test::{TEST_ACCOUNT, TEST_ACCOUNT_SLICE, TEST_MINT, TEST_MINT_SLICE},
         solana_program::pubkey::Pubkey,
-        transfer_fee::test::test_mint_transfer_fee,
+        transfer_fee::test::test_transfer_fee_config,
     };
 
     const MINT_WITH_EXTENSION: &[u8] = &[
@@ -474,7 +474,7 @@ mod test {
         let close_authority = OptionalNonZeroPubkey::try_from(Some(Pubkey::new(&[1; 32]))).unwrap();
         assert_eq!(extension.close_authority, close_authority);
         assert_eq!(
-            state.get_extension::<MintTransferFee>(),
+            state.get_extension::<TransferFeeConfig>(),
             Err(ProgramError::InvalidAccountData)
         );
         assert_eq!(
@@ -506,7 +506,7 @@ mod test {
         buffer[BASE_ACCOUNT_LENGTH + 1] = 2;
         let state = StateWithExtensions::<Mint>::unpack(&buffer).unwrap();
         assert_eq!(
-            state.get_extension::<MintTransferFee>(),
+            state.get_extension::<TransferFeeConfig>(),
             Err(ProgramError::InvalidAccountData)
         );
 
@@ -515,7 +515,7 @@ mod test {
         buffer[BASE_ACCOUNT_LENGTH + 3] = 100;
         let state = StateWithExtensions::<Mint>::unpack(&buffer).unwrap();
         assert_eq!(
-            state.get_extension::<MintTransferFee>(),
+            state.get_extension::<TransferFeeConfig>(),
             Err(ProgramError::InvalidAccountData)
         );
 
@@ -524,7 +524,7 @@ mod test {
         buffer[BASE_ACCOUNT_LENGTH + 3] = 10;
         let state = StateWithExtensions::<Mint>::unpack(&buffer).unwrap();
         assert_eq!(
-            state.get_extension::<MintTransferFee>(),
+            state.get_extension::<TransferFeeConfig>(),
             Err(ProgramError::InvalidAccountData)
         );
     }
@@ -533,7 +533,7 @@ mod test {
     fn mint_with_extension_pack_unpack() {
         let mint_size = get_account_len(&[
             ExtensionType::MintCloseAuthority,
-            ExtensionType::MintTransferFee,
+            ExtensionType::TransferFeeConfig,
         ]);
         let mut buffer = vec![0; mint_size];
 
@@ -546,7 +546,7 @@ mod test {
         let mut state = StateWithExtensionsMut::<Mint>::unpack_unchecked(&mut buffer).unwrap();
         // fail init account extension
         assert_eq!(
-            state.init_extension::<AccountTransferFee>(),
+            state.init_extension::<TransferFeeAmount>(),
             Err(ProgramError::InvalidAccountData),
         );
 
@@ -578,7 +578,7 @@ mod test {
         expect.extend_from_slice(&[1; 32]); // data
         expect.extend_from_slice(&[0; size_of::<ExtensionType>()]);
         expect.extend_from_slice(&[0; size_of::<Length>()]);
-        expect.extend_from_slice(&[0; size_of::<MintTransferFee>()]);
+        expect.extend_from_slice(&[0; size_of::<TransferFeeConfig>()]);
         assert_eq!(expect, buffer);
 
         // check unpacking
@@ -616,7 +616,7 @@ mod test {
         expect.extend_from_slice(&[0; 32]);
         expect.extend_from_slice(&[0; size_of::<ExtensionType>()]);
         expect.extend_from_slice(&[0; size_of::<Length>()]);
-        expect.extend_from_slice(&[0; size_of::<MintTransferFee>()]);
+        expect.extend_from_slice(&[0; size_of::<TransferFeeConfig>()]);
         assert_eq!(expect, buffer);
 
         // fail unpack as an account
@@ -627,8 +627,8 @@ mod test {
 
         let mut state = StateWithExtensionsMut::<Mint>::unpack(&mut buffer).unwrap();
         // init one more extension
-        let mint_transfer_fee = test_mint_transfer_fee();
-        let new_extension = state.init_extension::<MintTransferFee>().unwrap();
+        let mint_transfer_fee = test_transfer_fee_config();
+        let new_extension = state.init_extension::<TransferFeeConfig>().unwrap();
         new_extension.transfer_fee_config_authority =
             mint_transfer_fee.transfer_fee_config_authority;
         new_extension.withheld_withdraw_authority = mint_transfer_fee.withheld_withdraw_authority;
@@ -645,8 +645,8 @@ mod test {
         expect
             .extend_from_slice(&(pod_get_packed_len::<MintCloseAuthority>() as u16).to_le_bytes());
         expect.extend_from_slice(&[0; 32]); // data
-        expect.extend_from_slice(&(ExtensionType::MintTransferFee as u16).to_le_bytes());
-        expect.extend_from_slice(&(pod_get_packed_len::<MintTransferFee>() as u16).to_le_bytes());
+        expect.extend_from_slice(&(ExtensionType::TransferFeeConfig as u16).to_le_bytes());
+        expect.extend_from_slice(&(pod_get_packed_len::<TransferFeeConfig>() as u16).to_le_bytes());
         expect.extend_from_slice(pod_bytes_of(&mint_transfer_fee));
         assert_eq!(expect, buffer);
 
@@ -662,7 +662,7 @@ mod test {
     fn mint_extension_any_order() {
         let mint_size = get_account_len(&[
             ExtensionType::MintCloseAuthority,
-            ExtensionType::MintTransferFee,
+            ExtensionType::TransferFeeConfig,
         ]);
         let mut buffer = vec![0; mint_size];
 
@@ -672,8 +672,8 @@ mod test {
         let extension = state.init_extension::<MintCloseAuthority>().unwrap();
         extension.close_authority = close_authority;
 
-        let mint_transfer_fee = test_mint_transfer_fee();
-        let extension = state.init_extension::<MintTransferFee>().unwrap();
+        let mint_transfer_fee = test_transfer_fee_config();
+        let extension = state.init_extension::<TransferFeeConfig>().unwrap();
         extension.transfer_fee_config_authority = mint_transfer_fee.transfer_fee_config_authority;
         extension.withheld_withdraw_authority = mint_transfer_fee.withheld_withdraw_authority;
         extension.withheld_amount = mint_transfer_fee.withheld_amount;
@@ -698,8 +698,8 @@ mod test {
         state.init_account_type();
 
         // write extensions in a different order
-        let mint_transfer_fee = test_mint_transfer_fee();
-        let extension = state.init_extension::<MintTransferFee>().unwrap();
+        let mint_transfer_fee = test_transfer_fee_config();
+        let extension = state.init_extension::<TransferFeeConfig>().unwrap();
         extension.transfer_fee_config_authority = mint_transfer_fee.transfer_fee_config_authority;
         extension.withheld_withdraw_authority = mint_transfer_fee.withheld_withdraw_authority;
         extension.withheld_amount = mint_transfer_fee.withheld_amount;
@@ -717,8 +717,8 @@ mod test {
 
         // BUT mint and extensions are the same
         assert_eq!(
-            state.get_extension::<MintTransferFee>().unwrap(),
-            other_state.get_extension::<MintTransferFee>().unwrap()
+            state.get_extension::<TransferFeeConfig>().unwrap(),
+            other_state.get_extension::<TransferFeeConfig>().unwrap()
         );
         assert_eq!(
             state.get_extension::<MintCloseAuthority>().unwrap(),
@@ -764,7 +764,7 @@ mod test {
 
     #[test]
     fn account_with_extension_pack_unpack() {
-        let account_size = get_account_len(&[ExtensionType::AccountTransferFee]);
+        let account_size = get_account_len(&[ExtensionType::TransferFeeAmount]);
         let mut buffer = vec![0; account_size];
 
         // fail unpack
@@ -776,12 +776,12 @@ mod test {
         let mut state = StateWithExtensionsMut::<Account>::unpack_unchecked(&mut buffer).unwrap();
         // fail init mint extension
         assert_eq!(
-            state.init_extension::<MintTransferFee>(),
+            state.init_extension::<TransferFeeConfig>(),
             Err(ProgramError::InvalidAccountData),
         );
         // success write extension
         let withheld_amount = PodU64::from(u64::MAX);
-        let extension = state.init_extension::<AccountTransferFee>().unwrap();
+        let extension = state.init_extension::<TransferFeeAmount>().unwrap();
         extension.withheld_amount = withheld_amount;
 
         // fail unpack again, still no base data
@@ -800,9 +800,8 @@ mod test {
         // check raw buffer
         let mut expect = TEST_ACCOUNT_SLICE.to_vec();
         expect.push(AccountType::Account.into());
-        expect.extend_from_slice(&(ExtensionType::AccountTransferFee as u16).to_le_bytes());
-        expect
-            .extend_from_slice(&(pod_get_packed_len::<AccountTransferFee>() as u16).to_le_bytes());
+        expect.extend_from_slice(&(ExtensionType::TransferFeeAmount as u16).to_le_bytes());
+        expect.extend_from_slice(&(pod_get_packed_len::<TransferFeeAmount>() as u16).to_le_bytes());
         expect.extend_from_slice(&u64::from(withheld_amount).to_le_bytes());
         assert_eq!(expect, buffer);
 
@@ -817,8 +816,8 @@ mod test {
         assert_eq!(state.base, new_base);
 
         // check unpacking
-        let mut unpacked_extension = state.get_extension_mut::<AccountTransferFee>().unwrap();
-        assert_eq!(*unpacked_extension, AccountTransferFee { withheld_amount });
+        let mut unpacked_extension = state.get_extension_mut::<TransferFeeAmount>().unwrap();
+        assert_eq!(*unpacked_extension, TransferFeeAmount { withheld_amount });
 
         // update extension
         let withheld_amount = PodU64::from(u32::MAX as u64);
@@ -827,16 +826,15 @@ mod test {
         // check updates are propagated
         let state = StateWithExtensions::<Account>::unpack(&buffer).unwrap();
         assert_eq!(state.base, new_base);
-        let unpacked_extension = state.get_extension::<AccountTransferFee>().unwrap();
-        assert_eq!(*unpacked_extension, AccountTransferFee { withheld_amount });
+        let unpacked_extension = state.get_extension::<TransferFeeAmount>().unwrap();
+        assert_eq!(*unpacked_extension, TransferFeeAmount { withheld_amount });
 
         // check raw buffer
         let mut expect = vec![0; Account::LEN];
         Account::pack_into_slice(&new_base, &mut expect);
         expect.push(AccountType::Account.into());
-        expect.extend_from_slice(&(ExtensionType::AccountTransferFee as u16).to_le_bytes());
-        expect
-            .extend_from_slice(&(pod_get_packed_len::<AccountTransferFee>() as u16).to_le_bytes());
+        expect.extend_from_slice(&(ExtensionType::TransferFeeAmount as u16).to_le_bytes());
+        expect.extend_from_slice(&(pod_get_packed_len::<TransferFeeAmount>() as u16).to_le_bytes());
         expect.extend_from_slice(&u64::from(withheld_amount).to_le_bytes());
         assert_eq!(expect, buffer);
 

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -326,7 +326,7 @@ impl Default for AccountType {
 pub enum ExtensionType {
     /// Used as padding if the account size would otherwise be 355, same as a multisig
     Uninitialized,
-    /// Includes a transfer fee and accompanying authorities to withdraw and set the fee
+    /// Includes transfer fee rate info and accompanying authorities to withdraw and set the fee
     TransferFeeConfig,
     /// Includes withheld transfer fees
     TransferFeeAmount,

--- a/token/program-2022/src/extension/transfer_fee.rs
+++ b/token/program-2022/src/extension/transfer_fee.rs
@@ -22,7 +22,7 @@ pub struct TransferFee {
 /// Transfer fee extension data for mints.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
-pub struct MintTransferFee {
+pub struct TransferFeeConfig {
     /// Optional authority to set the fee
     pub transfer_fee_config_authority: OptionalNonZeroPubkey,
     /// Withdraw from mint instructions must be signed by this key
@@ -34,20 +34,20 @@ pub struct MintTransferFee {
     /// Newer transfer fee, used if the current epoch >= new_transfer_fee.epoch
     pub newer_transfer_fee: TransferFee,
 }
-impl Extension for MintTransferFee {
-    const TYPE: ExtensionType = ExtensionType::MintTransferFee;
+impl Extension for TransferFeeConfig {
+    const TYPE: ExtensionType = ExtensionType::TransferFeeConfig;
     const ACCOUNT_TYPE: AccountType = AccountType::Mint;
 }
 
 /// Transfer fee extension data for accounts.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
-pub struct AccountTransferFee {
+pub struct TransferFeeAmount {
     /// Amount withheld during transfers, to be harvested to the mint
     pub withheld_amount: PodU64,
 }
-impl Extension for AccountTransferFee {
-    const TYPE: ExtensionType = ExtensionType::AccountTransferFee;
+impl Extension for TransferFeeAmount {
+    const TYPE: ExtensionType = ExtensionType::TransferFeeAmount;
     const ACCOUNT_TYPE: AccountType = AccountType::Account;
 }
 
@@ -55,8 +55,8 @@ impl Extension for AccountTransferFee {
 pub(crate) mod test {
     use {super::*, solana_program::pubkey::Pubkey, std::convert::TryFrom};
 
-    pub(crate) fn test_mint_transfer_fee() -> MintTransferFee {
-        MintTransferFee {
+    pub(crate) fn test_transfer_fee_config() -> TransferFeeConfig {
+        TransferFeeConfig {
             transfer_fee_config_authority: OptionalNonZeroPubkey::try_from(Some(Pubkey::new(
                 &[10; 32],
             )))

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -93,8 +93,8 @@ pub enum TokenInstruction {
     /// amounts of SOL and Tokens will be transferred to the destination
     /// account.
     ///
-    /// If either account contains an `AccountTransferFee` extension, this will fail.
-    /// Mints with the `MintTransferFee` extension are required in order to assess the fee.
+    /// If either account contains an `TransferFeeAmount` extension, this will fail.
+    /// Mints with the `TransferFeeConfig` extension are required in order to assess the fee.
     ///
     /// Accounts expected by this instruction:
     ///
@@ -207,7 +207,7 @@ pub enum TokenInstruction {
     /// Close an account by transferring all its SOL to the destination account.
     /// Non-native accounts may only be closed if its token amount is zero.
     ///
-    /// Accounts with the `AccountTransferFee` extension may only be closed if the withheld
+    /// Accounts with the `TransferFeeAmount` extension may only be closed if the withheld
     /// amount is zero.
     ///
     /// Mints may be closed if they have the `MintCloseAuthority` extension and their token
@@ -267,7 +267,7 @@ pub enum TokenInstruction {
     /// decimals value is checked by the caller.  This may be useful when
     /// creating transactions offline or within a hardware wallet.
     ///
-    /// If either account contains an `AccountTransferFee` extension, the fee is
+    /// If either account contains an `TransferFeeAmount` extension, the fee is
     /// withheld in the destination account.
     ///
     /// Accounts expected by this instruction:
@@ -466,7 +466,7 @@ pub enum TokenInstruction {
     /// Accounts expected by this instruction:
     ///
     ///   0. `[writable]` The mint to initialize.
-    InitializeMintTransferFee {
+    InitializeTransferFeeConfig {
         /// Pubkey that may update the fees
         fee_config_authority: COption<Pubkey>,
         /// Withdraw instructions must be signed by this key
@@ -482,9 +482,9 @@ pub enum TokenInstruction {
     /// Accounts expected by this instruction:
     ///
     ///   * Single owner/delegate
-    ///   0. `[writable]` The source account. Must include the `AccountTransferFee` extension.
-    ///   1. `[]` The token mint. Must include the `MintTransferFee` extension.
-    ///   2. `[writable]` The destination account. Must include the `AccountTransferFee` extension.
+    ///   0. `[writable]` The source account. Must include the `TransferFeeAmount` extension.
+    ///   1. `[]` The token mint. Must include the `TransferFeeConfig` extension.
+    ///   2. `[writable]` The destination account. Must include the `TransferFeeAmount` extension.
     ///   3. `[signer]` The source account's owner/delegate.
     ///
     ///   * Multisignature owner/delegate
@@ -508,8 +508,8 @@ pub enum TokenInstruction {
     /// Accounts expected by this instruction:
     ///
     ///   * Single owner/delegate
-    ///   0. `[writable]` The token mint. Must include the `MintTransferFee` extension.
-    ///   1. `[writable]` The fee receiver account. Must include the `AccountTransferFee` extension
+    ///   0. `[writable]` The token mint. Must include the `TransferFeeConfig` extension.
+    ///   1. `[writable]` The fee receiver account. Must include the `TransferFeeAmount` extension
     ///      associated with the provided mint.
     ///   2. `[signer]` The mint's `withdraw_withheld_authority`.
     ///
@@ -525,8 +525,8 @@ pub enum TokenInstruction {
     /// Accounts expected by this instruction:
     ///
     ///   * Single owner/delegate
-    ///   0. `[]` The token mint. Must include the `MintTransferFee` extension.
-    ///   1. `[writable]` The fee receiver account. Must include the `AccountTransferFee`
+    ///   0. `[]` The token mint. Must include the `TransferFeeConfig` extension.
+    ///   1. `[writable]` The fee receiver account. Must include the `TransferFeeAmount`
     ///      extension and be associated with the provided mint.
     ///   2. `[signer]` The mint's `withdraw_withheld_authority`.
     ///   3. ..3+N `[writable]` The source accounts to withdraw from.
@@ -542,7 +542,7 @@ pub enum TokenInstruction {
     ///
     /// Succeeds for frozen accounts.
     ///
-    /// Accounts provided should include the `AccountTransferFee` extension. If not,
+    /// Accounts provided should include the `TransferFeeAmount` extension. If not,
     /// the account is skipped.
     ///
     /// Accounts expected by this instruction:
@@ -550,7 +550,7 @@ pub enum TokenInstruction {
     ///   0. `[writable]` The mint.
     ///   1. ..1+N `[writable]` The source accounts to harvest from.
     HarvestWithheldTokensToMint,
-    /// Set transfer fee. Only supported for mints that include the `MintTransferFee` extension.
+    /// Set transfer fee. Only supported for mints that include the `TransferFeeConfig` extension.
     ///
     /// Accounts expected by this instruction:
     ///
@@ -709,7 +709,7 @@ impl TokenInstruction {
                     .ok()
                     .map(u64::from_le_bytes)
                     .ok_or(InvalidInstruction)?;
-                Self::InitializeMintTransferFee {
+                Self::InitializeTransferFeeConfig {
                     fee_config_authority,
                     withdraw_withheld_authority,
                     transfer_fee_basis_points,
@@ -861,7 +861,7 @@ impl TokenInstruction {
                 buf.push(22);
                 Self::pack_pubkey_option(close_authority, &mut buf);
             }
-            &Self::InitializeMintTransferFee {
+            &Self::InitializeTransferFeeConfig {
                 ref fee_config_authority,
                 ref withdraw_withheld_authority,
                 transfer_fee_basis_points,
@@ -1825,7 +1825,7 @@ mod test {
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
 
-        let check = TokenInstruction::InitializeMintTransferFee {
+        let check = TokenInstruction::InitializeTransferFeeConfig {
             fee_config_authority: COption::Some(Pubkey::new(&[11u8; 32])),
             withdraw_withheld_authority: COption::None,
             transfer_fee_basis_points: 111,

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -833,7 +833,7 @@ impl Processor {
             TokenInstruction::InitializeMintCloseAuthority { .. } => {
                 unimplemented!();
             }
-            TokenInstruction::InitializeMintTransferFee { .. } => {
+            TokenInstruction::InitializeTransferFeeConfig { .. } => {
                 unimplemented!();
             }
             TokenInstruction::TransferCheckedWithFee { .. } => {


### PR DESCRIPTION
Every extension documents its account type, so Mint/Account prefixes aren't really necessary. (Also, I can envision an extension that may have the same data structure for both Mint and Account implementations.)

This PR removes Mint and Account prefixes from TransferFee extensions.
`MintCloseAuthority` is kept as-is, since token Accounts already have close-authorities in their base state.