### PR TITLE
Fixup tests to use rent-exempt accounts

### DIFF
--- a/name-service/program/tests/functional.rs
+++ b/name-service/program/tests/functional.rs
@@ -43,12 +43,14 @@ async fn test_name_service() {
         None,
     );
 
+    let space = 1_000usize;
+    let rent = ctx.banks_client.get_rent().await.unwrap();
     let create_name_instruction = create(
         program_id,
         NameRegistryInstruction::Create {
             hashed_name: hashed_root_name,
-            lamports: 1_000_000,
-            space: 1_000,
+            lamports: rent.minimum_balance(space + NameRecordHeader::LEN),
+            space: space as u32,
         },
         root_name_account_key,
         ctx.payer.pubkey(),
@@ -91,8 +93,8 @@ async fn test_name_service() {
         program_id,
         NameRegistryInstruction::Create {
             hashed_name,
-            lamports: 1_000_000,
-            space: 1_000,
+            lamports: rent.minimum_balance(space + NameRecordHeader::LEN),
+            space: space as u32,
         },
         name_account_key,
         ctx.payer.pubkey(),


### PR DESCRIPTION
Rent-exempt requirement for accounts is coming down the pipe: https://github.com/solana-labs/solana/pull/22292
Several tests in this repository create rent-paying accounts. Since these account balances appear to be arbitrary, this PR fixes those tests up to use rent-exempt amounts.

@mvines , any concerns here? I didn't see any fundamental reason for these rent-paying accounts.

There are also some stake-pool tests that are failing. Will be addressed in a separate PR.