### PR TITLE
Fix up helper to create rent-exempt accounts

### DIFF
--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -426,7 +426,7 @@ pub async fn create_vote(
     let mut instructions = vec![system_instruction::create_account(
         &payer.pubkey(),
         &validator.pubkey(),
-        42,
+        rent.minimum_balance(0),
         0,
         &system_program::id(),
     )];


### PR DESCRIPTION
Rent-exempt requirement for accounts is coming down the pipe: solana-labs/solana#22292
The stake-pool helper `create_vote` creates a validator identity account that is rent-paying for no particular reason.