### PR TITLE
Governance: Abstain

### DIFF
--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -127,11 +127,10 @@ pub fn process_cast_vote(
             )
         }
         Vote::Abstain => {
-            proposal_data.abstain_vote_weight =
-                proposal_data
-                    .abstain_vote_weight
-                    .checked_add(voter_weight)
-                    .unwrap()
+            proposal_data.abstain_vote_weight = proposal_data
+                .abstain_vote_weight
+                .checked_add(voter_weight)
+                .unwrap()
         }
     }
 

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -126,6 +126,13 @@ pub fn process_cast_vote(
                     .unwrap(),
             )
         }
+        Vote::Abstain => {
+            proposal_data.abstain_vote_weight =
+                proposal_data
+                    .abstain_vote_weight
+                    .checked_add(voter_weight)
+                    .unwrap()
+        }
     }
 
     let governing_token_mint_supply = get_spl_token_mint_supply(governing_token_mint_info)?;

--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -139,6 +139,7 @@ pub fn process_create_proposal(
         vote_type,
         options: proposal_options,
         deny_vote_weight,
+        abstain_vote_weight: 0,
 
         max_vote_weight: None,
         vote_threshold_percentage: None,

--- a/governance/program/src/processor/process_relinquish_vote.rs
+++ b/governance/program/src/processor/process_relinquish_vote.rs
@@ -88,6 +88,13 @@ pub fn process_relinquish_vote(program_id: &Pubkey, accounts: &[AccountInfo]) ->
                         .unwrap(),
                 )
             }
+            Vote::Abstain => {
+                proposal_data.abstain_vote_weight =
+                    proposal_data
+                        .abstain_vote_weight
+                        .checked_sub(vote_record_data.voter_weight)
+                        .unwrap()
+            }
         }
 
         proposal_data.serialize(&mut *proposal_info.data.borrow_mut())?;

--- a/governance/program/src/processor/process_relinquish_vote.rs
+++ b/governance/program/src/processor/process_relinquish_vote.rs
@@ -89,11 +89,10 @@ pub fn process_relinquish_vote(program_id: &Pubkey, accounts: &[AccountInfo]) ->
                 )
             }
             Vote::Abstain => {
-                proposal_data.abstain_vote_weight =
-                    proposal_data
-                        .abstain_vote_weight
-                        .checked_sub(vote_record_data.voter_weight)
-                        .unwrap()
+                proposal_data.abstain_vote_weight = proposal_data
+                    .abstain_vote_weight
+                    .checked_sub(vote_record_data.voter_weight)
+                    .unwrap()
             }
         }
 

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -166,7 +166,7 @@ pub struct ProposalV2 {
 impl AccountMaxSize for ProposalV2 {
     fn get_max_size(&self) -> Option<usize> {
         let options_size: usize = self.options.iter().map(|o| o.label.len() + 19).sum();
-        Some(self.name.len() + self.description_link.len() + options_size + 199)
+        Some(self.name.len() + self.description_link.len() + options_size + 207)
     }
 }
 

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -463,31 +463,18 @@ impl ProposalV2 {
 
         let yes_vote_weight = yes_option.vote_weight;
         let deny_vote_weight = self.deny_vote_weight.unwrap();
-        let non_yes_vote_weight = self.abstain_vote_weight + deny_vote_weight;
         let max_non_abstain = max_vote_weight - self.abstain_vote_weight;
-
-        if yes_vote_weight == max_vote_weight {
-            yes_option.vote_result = OptionVoteResult::Succeeded;
-            return Some(ProposalState::Succeeded);
-        }
-
-        if non_yes_vote_weight == max_vote_weight {
-            yes_option.vote_result = OptionVoteResult::Defeated;
-            return Some(ProposalState::Defeated);
-        }
+        let max_yes_weight = max_non_abstain - deny_vote_weight;
+        let max_deny_weight = max_non_abstain - yes_vote_weight;
 
         let min_vote_threshold_weight =
             get_min_vote_threshold_weight(&config.vote_threshold_percentage, max_vote_weight)
                 .unwrap();
 
-        if yes_vote_weight >= min_vote_threshold_weight
-            && yes_vote_weight > max_non_abstain - yes_vote_weight
-        {
+        if yes_vote_weight >= min_vote_threshold_weight && yes_vote_weight > max_deny_weight {
             yes_option.vote_result = OptionVoteResult::Succeeded;
             return Some(ProposalState::Succeeded);
-        } else if non_yes_vote_weight > max_vote_weight - min_vote_threshold_weight
-            || deny_vote_weight >= max_non_abstain - deny_vote_weight
-        {
+        } else if max_yes_weight < min_vote_threshold_weight || deny_vote_weight >= max_yes_weight {
             yes_option.vote_result = OptionVoteResult::Defeated;
             return Some(ProposalState::Defeated);
         }

--- a/governance/program/src/state/vote_record.rs
+++ b/governance/program/src/state/vote_record.rs
@@ -51,6 +51,9 @@ pub enum Vote {
 
     /// Vote rejecting proposal
     Deny,
+
+    /// Declare indifference to proposal
+    Abstain,
 }
 
 /// Proposal VoteRecord
@@ -102,6 +105,7 @@ impl VoteRecordV2 {
             let vote_weight = match &self.vote {
                 Vote::Approve(_options) => VoteWeightV1::Yes(self.voter_weight),
                 Vote::Deny => VoteWeightV1::No(self.voter_weight),
+                Vote::Abstain => panic!("Cannot serialize new vote record as old vote record (it contains an abstain vote)"),
             };
 
             let vote_record_data_v1 = VoteRecordV1 {

--- a/governance/program/tests/process_cast_vote.rs
+++ b/governance/program/tests/process_cast_vote.rs
@@ -516,7 +516,7 @@ async fn test_cast_vote_with_vote_tipped_to_succeeded_by_abstain() {
     let proposal_account = governance_test
         .get_proposal_account(&proposal_cookie.address)
         .await;
-    
+
     assert_eq!(ProposalState::Succeeded, proposal_account.state);
 
     let proposal_owner_record = governance_test
@@ -657,7 +657,7 @@ async fn test_cast_vote_with_vote_tipped_to_defeated_by_abstain() {
         .with_community_token_deposit(&realm_cookie)
         .await
         .unwrap();
-    
+
     let token_owner_record_cookie4 = governance_test
         .with_community_token_deposit(&realm_cookie)
         .await
@@ -680,11 +680,7 @@ async fn test_cast_vote_with_vote_tipped_to_defeated_by_abstain() {
 
     // Act
     governance_test
-        .with_cast_vote(
-            &proposal_cookie,
-            &token_owner_record_cookie1,
-            YesNoVote::No,
-        )
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie1, YesNoVote::No)
         .await
         .unwrap();
 
@@ -711,16 +707,12 @@ async fn test_cast_vote_with_vote_tipped_to_defeated_by_abstain() {
     let proposal_account = governance_test
         .get_proposal_account(&proposal_cookie.address)
         .await;
-    
+
     assert_eq!(ProposalState::Voting, proposal_account.state);
 
     // Act
     governance_test
-        .with_cast_vote(
-            &proposal_cookie,
-            &token_owner_record_cookie3,
-            YesNoVote::No,
-        )
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie3, YesNoVote::No)
         .await
         .unwrap();
 
@@ -749,7 +741,7 @@ async fn test_cast_vote_with_vote_tipped_to_defeated_by_abstain() {
         .await;
 
     println!("{:?}", proposal_account);
-    
+
     assert_eq!(ProposalState::Defeated, proposal_account.state);
 
     let proposal_owner_record = governance_test

--- a/governance/program/tests/process_cast_vote.rs
+++ b/governance/program/tests/process_cast_vote.rs
@@ -422,6 +422,111 @@ async fn test_cast_vote_with_vote_tipped_to_succeeded() {
 }
 
 #[tokio::test]
+async fn test_cast_vote_with_vote_tipped_to_succeeded_by_abstain() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.vote_threshold_percentage = VoteThresholdPercentage::YesVote(50);
+
+    let token_owner_record_cookie1 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut account_governance_cookie = governance_test
+        .with_account_governance_using_config(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie1,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie2 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie3 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let _token_owner_record_cookie4 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie1, &mut account_governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_cast_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie1,
+            YesNoVote::Yes,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    // Act
+    governance_test
+        .with_cast_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie2,
+            YesNoVote::Yes,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    // Act
+    governance_test
+        .with_cast_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie3,
+            YesNoVote::Abstain,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    
+    assert_eq!(ProposalState::Succeeded, proposal_account.state);
+
+    let proposal_owner_record = governance_test
+        .get_token_owner_record_account(&proposal_cookie.account.token_owner_record)
+        .await;
+
+    assert_eq!(0, proposal_owner_record.outstanding_proposal_count);
+}
+
+#[tokio::test]
 async fn test_cast_vote_with_vote_tipped_to_defeated() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
@@ -510,6 +615,141 @@ async fn test_cast_vote_with_vote_tipped_to_defeated() {
         .get_proposal_account(&proposal_cookie.address)
         .await;
 
+    assert_eq!(ProposalState::Defeated, proposal_account.state);
+
+    let proposal_owner_record = governance_test
+        .get_token_owner_record_account(&proposal_cookie.account.token_owner_record)
+        .await;
+
+    assert_eq!(0, proposal_owner_record.outstanding_proposal_count);
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_vote_tipped_to_defeated_by_abstain() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.vote_threshold_percentage = VoteThresholdPercentage::YesVote(50);
+
+    let token_owner_record_cookie1 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut account_governance_cookie = governance_test
+        .with_account_governance_using_config(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie1,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie2 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie3 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+    
+    let token_owner_record_cookie4 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let _token_owner_record_cookie5 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let _token_owner_record_cookie6 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie1, &mut account_governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_cast_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie1,
+            YesNoVote::No,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    // Act
+    governance_test
+        .with_cast_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie2,
+            YesNoVote::Abstain,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    // Act
+    governance_test
+        .with_cast_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie3,
+            YesNoVote::No,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    // Act
+    governance_test
+        .with_cast_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie4,
+            YesNoVote::Abstain,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    println!("{:?}", proposal_account);
+    
     assert_eq!(ProposalState::Defeated, proposal_account.state);
 
     let proposal_owner_record = governance_test

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1626,6 +1626,7 @@ impl GovernanceProgramTest {
             vote_type: vote_type,
             options: proposal_options,
             deny_vote_weight,
+            abstain_vote_weight: 0,
 
             execution_flags: InstructionExecutionFlags::None,
             max_vote_weight: None,

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -84,6 +84,9 @@ pub enum YesNoVote {
     /// No vote
     #[allow(dead_code)]
     No,
+    /// No vote
+    #[allow(dead_code)]
+    Abstain,
 }
 
 pub struct GovernanceProgramTest {
@@ -1862,6 +1865,7 @@ impl GovernanceProgramTest {
                 weight_percentage: 100,
             }]),
             YesNoVote::No => Vote::Deny,
+            YesNoVote::Abstain => Vote::Abstain,
         };
 
         self.with_cast_multi_option_vote(proposal_cookie, token_owner_record_cookie, vote)


### PR DESCRIPTION
This adds abstain as a third vote option to v2 proposals. The purpose of abstain is twofold:
- Give everyone a voice. If voters are consciously indifferent to a proposal, they should be able to distinguish themselves from people who are simply ignorant to the proposal. This helps the community as a whole understand itself better.
- Since we have more information about votes, we can know sooner whether a proposal is defeated or succeeded, so the program can tip the vote sooner. If the min vote threshold is 20%, and we already got 30% of tokens in favor plus 60% abstaining, then the proposal passes because at most 10% can be counted against.

## Compatibility
### V1 vs V2 proposals
This change is targeted strictly at v2 proposals. I didn't add anything to the v1 proposal unless it was necessary for conversions between v1 and v2 data types. Using the v2 struct to manage v1 proposals should still work fine, but abstain votes will not be counted for v1 proposals. I don't think this causes a problem, it just means we don't get the benefits of tracking the abstain votes. Some users might get confused though because casting an abstain vote for an old v1 proposal will result in a successful instruction despite not changing the overall vote counts for the proposal. Should I add abstain to the v1 proposal? Is there space?

#### conversion details
- Converting from a v2 to v1 vote record panics if the v2 vote record has an Abstain vote.
- When converting v1 to a v2 proposal, the abstain vote count is set to 0.

Neither of these should ever become an issue because the conversion functions check the `account_type` field to determine whether a conversion is necessary, but technically the `account_type` is not actually verified by the compiler, so in theory some other code could misuse these data types.

### Memory safety
The abstain count is added somewhere in the middle of the `ProposalV2`, changing both the size and shape of the account data. Do we need to worry about that when reading or mutating existing proposals? Should I put the field at the end of the struct instead? Will proposal accounts be sufficiently large?

## Refactoring
I removed some redundant checks in the proposal tipping logic. There were basic checks to see if the yes and no vote counts are equal to the max vote. But these checks are already executed by the if statements later in the function, so I don't see how this code would ever influence the output. This removal makes the code more concise and use less compute, so I see it as an improvement. I'd love to hear the original justification though.
```rust
        if yes_vote_weight == max_vote_weight {
            yes_option.vote_result = OptionVoteResult::Succeeded;
            return Some(ProposalState::Succeeded);
        }

        if deny_vote_weight == max_vote_weight {
            yes_option.vote_result = OptionVoteResult::Defeated;
            return Some(ProposalState::Defeated);
        }
```