### PR TITLE
Confidential transfer extension

### DIFF
--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -1,11 +1,19 @@
 use {
-    crate::{id, instruction::TokenInstruction, pod::*},
+    crate::{
+        extension::confidential_transfer::{
+            get_omnibus_token_address, ConfidentialTransferAuditor,
+        },
+        id,
+        instruction::TokenInstruction,
+        pod::*,
+    },
     bytemuck::Pod,
     num_derive::{FromPrimitive, ToPrimitive},
     num_traits::{FromPrimitive, ToPrimitive},
     solana_program::{
         instruction::{AccountMeta, Instruction},
         program_error::ProgramError,
+        pubkey::Pubkey,
     },
 };
 
@@ -13,8 +21,71 @@ use {
 #[derive(Clone, Copy, Debug, FromPrimitive, ToPrimitive)]
 #[repr(u8)]
 pub enum ConfidentialTransferInstruction {
-    /// TODO: inline `zk_token_program::instructions::ZkTokenInstruction` here
-    Todo,
+    /// Configures the confidential transfer auditor for a given SPL Token mint.
+    ///
+    /// The `InitializeAuditor` instruction requires no signers and MUST be included within the
+    /// same Transaction as `TokenInstruction::InitializeMint`.  Otherwise another party can
+    /// initialize the auditor.
+    ///
+    /// The instruction fails if the `TokenInstruction::InitializeMint` instruction has already
+    /// executed for the mint.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[writable]` The SPL Token mint
+    //
+    /// Data expected by this instruction:
+    ///   `ConfidentialTransferAuditor`
+    ///
+    InitializeAuditor,
+
+    /// Configures the confidential transfer omnibus account for a given SPL Token mint.
+    ///
+    /// The instruction fails if the omnibus account is already configured for the mint.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[writeable,signer]` Funding account (must be a system account)
+    ///   1. `[]` The SPL Token mint
+    ///   2. `[writable]` The omnibus SPL Token account to create, computed by `get_omnibus_token_address()`
+    ///   3. `[]` System program
+    ///
+    /// Data expected by this instruction:
+    ///   None
+    ///
+    ConfigureOmnibusAccount,
+
+    /// Updates the confidential transfer auditor for a given SPL Token mint.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[writable]` The SPL Token mint
+    ///   1. `[signer]` Confidential transfer auditor authority
+    ///   2. `[signer]` New confidential transfer auditor authority
+    ///
+    /// Data expected by this instruction:
+    ///   `ConfidentialTransferAuditor`
+    ///
+    UpdateAuditor,
+
+    /// Approves a token account for confidential transfers.
+    ///
+    /// Approval is only required when the `ConfidentialTransferAuditor::approve_new_accounts`
+    /// field is set in the SPL Token mint.  This instruction must be executed after the account
+    /// owner configures their account for confidential transfers with
+    /// `ConfidentialTransferInstruction::ConfigureAccount`.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[writable]` The SPL Token account to approve
+    ///   1. `[]` The SPL Token mint
+    ///   2. `[signer]` Confidential transfer auditor authority
+    ///
+    /// Data expected by this instruction:
+    ///   None
+    ///
+    ApproveAccount,
+    // TODO: Add remaining zk-token insructions here..
 }
 
 pub(crate) fn decode_instruction_type(
@@ -50,7 +121,62 @@ fn encode_instruction<T: Pod>(
     }
 }
 
-/// Create a `Todo` instruction
-pub fn todo() -> Instruction {
-    encode_instruction(vec![], ConfidentialTransferInstruction::Todo, &())
+/// Create a `InitializeAuditor` instruction
+pub fn initialize_auditor(mint: Pubkey, auditor: &ConfidentialTransferAuditor) -> Instruction {
+    let accounts = vec![AccountMeta::new(mint, false)];
+    encode_instruction(
+        accounts,
+        ConfidentialTransferInstruction::InitializeAuditor,
+        auditor,
+    )
+}
+
+/// Create a `ConfigureOmnibusAccount` instruction
+pub fn configure_omnibus_account(funding_address: Pubkey, mint: Pubkey) -> Instruction {
+    let accounts = vec![
+        AccountMeta::new(funding_address, true),
+        AccountMeta::new_readonly(mint, false),
+        AccountMeta::new(get_omnibus_token_address(&mint), false),
+        AccountMeta::new_readonly(solana_program::system_program::id(), false),
+    ];
+    encode_instruction(
+        accounts,
+        ConfidentialTransferInstruction::ConfigureOmnibusAccount,
+        &(),
+    )
+}
+
+/// Create a `UpdateAuditor` instruction
+pub fn update_auditor(
+    mint: Pubkey,
+    new_auditor: &ConfidentialTransferAuditor,
+    authority: Pubkey,
+) -> Instruction {
+    let accounts = vec![
+        AccountMeta::new(mint, false),
+        AccountMeta::new_readonly(authority, true),
+        AccountMeta::new_readonly(
+            new_auditor.authority,
+            new_auditor.authority != Pubkey::default(),
+        ),
+    ];
+    encode_instruction(
+        accounts,
+        ConfidentialTransferInstruction::UpdateAuditor,
+        new_auditor,
+    )
+}
+
+/// Create an `ApproveAccount` instruction
+pub fn approve_account(mint: Pubkey, account_to_approve: Pubkey, authority: Pubkey) -> Instruction {
+    let accounts = vec![
+        AccountMeta::new(account_to_approve, false),
+        AccountMeta::new_readonly(mint, false),
+        AccountMeta::new_readonly(authority, true),
+    ];
+    encode_instruction(
+        accounts,
+        ConfidentialTransferInstruction::ApproveAccount,
+        &(),
+    )
 }

--- a/token/program-2022/src/extension/confidential_transfer/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer/mod.rs
@@ -1,6 +1,12 @@
 use {
-    crate::extension::{AccountType, Extension, ExtensionType},
+    crate::{
+        extension::{AccountType, Extension, ExtensionType},
+        id,
+        pod::*,
+    },
     bytemuck::{Pod, Zeroable},
+    solana_program::pubkey::Pubkey,
+    solana_zk_token_sdk::zk_token_elgamal::pod,
 };
 
 /// Confidential Transfer Extension instructions
@@ -11,9 +17,26 @@ pub mod processor;
 
 /// Transfer auditor configuration
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+#[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
 pub struct ConfidentialTransferAuditor {
-    // TODO: inline `zk_token_program::state::Auditor` here
+    /// Authority to modify the auditor configuration
+    ///
+    /// Note that setting an authority of `Pubkey::default()` is the idiomatic way to disable
+    /// future changes to the configuration.
+    pub authority: Pubkey,
+
+    /// Indicate if newly configured accounts must be approved by the auditor before they may be
+    /// used by the user.
+    ///
+    /// * If `true`, the auditor authority must approve newly configured accounts (see
+    ///              `ConfidentialTransferInstruction::ConfigureAccount`)
+    /// * If `false`, no approval is required and new accounts may be used immediately
+    pub approve_new_accounts: PodBool,
+
+    /// * If non-zero, transfers must include ElGamal cypertext with this public key permitting the
+    /// auditor to decode the transfer amount.
+    /// * If all zero, auditing is currently disabled.
+    pub auditor_pk: pod::ElGamalPubkey,
 }
 
 impl Extension for ConfidentialTransferAuditor {
@@ -25,10 +48,28 @@ impl Extension for ConfidentialTransferAuditor {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct ConfidentialTransferState {
+    /// `true` if this account has been approved for use. All confidential transfer operations for
+    /// the account will fail until approval is granted.
+    pub approved: PodBool,
     // TODO: inline `zk_token_program::state::ZkAccount` here
 }
 
 impl Extension for ConfidentialTransferState {
     const TYPE: ExtensionType = ExtensionType::ConfidentialTransferState;
     const ACCOUNT_TYPE: AccountType = AccountType::Account;
+}
+
+pub(crate) fn get_omnibus_token_address_with_seed(token_mint: &Pubkey) -> (Pubkey, u8) {
+    Pubkey::find_program_address(
+        &[token_mint.as_ref(), br"confidential_transfer_omnibus"],
+        &id(),
+    )
+}
+
+/// Derive the address of the Omnibus SPL Token account for a given SPL Token mint
+///
+/// The omnibus account is a central token account that holds all SPL Tokens deposited for
+/// confidential transfer by all users
+pub fn get_omnibus_token_address(token_mint: &Pubkey) -> Pubkey {
+    get_omnibus_token_address_with_seed(token_mint).0
 }

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -1,19 +1,174 @@
 use {
-    super::instruction::*,
-    solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, msg, pubkey::Pubkey},
+    crate::{
+        check_program_account,
+        extension::{
+            confidential_transfer::{instruction::*, *},
+            StateWithExtensions, StateWithExtensionsMut,
+        },
+        id,
+        processor::Processor,
+        state::{Account, Mint},
+        tools::account::create_pda_account,
+    },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        msg,
+        program_error::ProgramError,
+        program_pack::Pack,
+        pubkey::Pubkey,
+        sysvar::{rent::Rent, Sysvar},
+    },
 };
 
-/// TODO: inline `zk_token_program::processor.rs` here
-pub fn process_instruction(
-    _program_id: &Pubkey,
-    _accounts: &[AccountInfo],
+/// Processes an [InitializeAuditor] instruction.
+fn process_initialize_auditor(
+    accounts: &[AccountInfo],
+    auditor: &ConfidentialTransferAuditor,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let mint_info = next_account_info(account_info_iter)?;
+
+    check_program_account(mint_info.owner)?;
+    let mint_data = &mut mint_info.data.borrow_mut();
+    let mut mint = StateWithExtensionsMut::<Mint>::unpack_uninitialized(mint_data)?;
+    *mint.init_extension::<ConfidentialTransferAuditor>()? = *auditor;
+
+    Ok(())
+}
+
+/// Processes a [ConfigureOmnibusAccount] instruction.
+fn process_configure_omnibus_account(accounts: &[AccountInfo]) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let funder_info = next_account_info(account_info_iter)?;
+    let mint_info = next_account_info(account_info_iter)?;
+    let omnibus_info = next_account_info(account_info_iter)?;
+    let system_program_info = next_account_info(account_info_iter)?;
+
+    check_program_account(mint_info.owner)?;
+    let _mint = StateWithExtensions::<Mint>::unpack(&mint_info.data.borrow())?;
+
+    let (omnibus_token_address, omnibus_token_bump_seed) =
+        get_omnibus_token_address_with_seed(mint_info.key);
+
+    if omnibus_token_address != *omnibus_info.key {
+        msg!("Error: Omnibus token address does not match derivation");
+        return Err(ProgramError::InvalidArgument);
+    }
+
+    let omnibus_token_account_signer_seeds: &[&[_]] = &[
+        &mint_info.key.to_bytes(),
+        br"confidential_transfer_omnibus",
+        &[omnibus_token_bump_seed],
+    ];
+
+    create_pda_account(
+        funder_info,
+        &Rent::get()?,
+        Account::get_packed_len(),
+        &id(),
+        system_program_info,
+        omnibus_info,
+        omnibus_token_account_signer_seeds,
+    )?;
+
+    Processor::process(
+        &id(),
+        &[omnibus_info.clone(), mint_info.clone()],
+        &crate::instruction::initialize_account3(
+            &id(),
+            omnibus_info.key,
+            mint_info.key,
+            omnibus_info.key,
+        )?
+        .data,
+    )
+}
+
+/// Processes an [UpdateAuditor] instruction.
+fn process_update_auditor(
+    accounts: &[AccountInfo],
+    new_auditor: &ConfidentialTransferAuditor,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let mint_info = next_account_info(account_info_iter)?;
+    let authority_info = next_account_info(account_info_iter)?;
+    let new_authority_info = next_account_info(account_info_iter)?;
+
+    check_program_account(mint_info.owner)?;
+    let mint_data = &mut mint_info.data.borrow_mut();
+    let mut mint = StateWithExtensionsMut::<Mint>::unpack(mint_data)?;
+    let auditor = mint.get_extension_mut::<ConfidentialTransferAuditor>()?;
+
+    if authority_info.is_signer
+        && (new_authority_info.is_signer || *new_authority_info.key == Pubkey::default())
+    {
+        if new_auditor.authority == *new_authority_info.key {
+            *auditor = *new_auditor;
+            Ok(())
+        } else {
+            Err(ProgramError::InvalidInstructionData)
+        }
+    } else {
+        Err(ProgramError::MissingRequiredSignature)
+    }
+}
+
+/// Processes an [ApproveAccount] instruction.
+fn process_approve_account(accounts: &[AccountInfo]) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let account_to_approve_info = next_account_info(account_info_iter)?;
+    let mint_info = next_account_info(account_info_iter)?;
+    let authority_info = next_account_info(account_info_iter)?;
+
+    check_program_account(account_to_approve_info.owner)?;
+    let account_to_approve_data = &mut account_to_approve_info.data.borrow_mut();
+    let mut account_to_approve = StateWithExtensionsMut::<Mint>::unpack(account_to_approve_data)?;
+
+    check_program_account(mint_info.owner)?;
+    let mint_data = &mint_info.data.borrow_mut();
+    let mint = StateWithExtensions::<Mint>::unpack(mint_data)?;
+    let auditor = mint.get_extension::<ConfidentialTransferAuditor>()?;
+
+    if authority_info.is_signer && *authority_info.key == auditor.authority {
+        let mut confidential_transfer_state =
+            account_to_approve.get_extension_mut::<ConfidentialTransferState>()?;
+        confidential_transfer_state.approved = true.into();
+        Ok(())
+    } else {
+        Err(ProgramError::MissingRequiredSignature)
+    }
+}
+
+pub(crate) fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
     input: &[u8],
 ) -> ProgramResult {
+    check_program_account(program_id)?;
+
     match decode_instruction_type(input)? {
-        ConfidentialTransferInstruction::Todo => {
-            let todo_data = decode_instruction_data::<()>(input)?;
-            msg!("Todo: {:?}", todo_data);
-            Ok(())
+        ConfidentialTransferInstruction::InitializeAuditor => {
+            msg!("ConfidentialTransferInstruction::InitializeAuditor");
+            process_initialize_auditor(
+                accounts,
+                decode_instruction_data::<ConfidentialTransferAuditor>(input)?,
+            )
         }
+        ConfidentialTransferInstruction::ConfigureOmnibusAccount => {
+            msg!("ConfidentialTransferInstruction::ConfigureOmnibusAccount");
+            process_configure_omnibus_account(accounts)
+        }
+        ConfidentialTransferInstruction::UpdateAuditor => {
+            msg!("ConfidentialTransferInstruction::UpdateAuditor");
+            process_update_auditor(
+                accounts,
+                decode_instruction_data::<ConfidentialTransferAuditor>(input)?,
+            )
+        }
+        ConfidentialTransferInstruction::ApproveAccount => {
+            msg!("ConfidentialTransferInstruction::ApproveAccount");
+            process_approve_account(accounts)
+        } // TODO: add remaining `zk_token_program::processor.rs` here
     }
 }

--- a/token/program-2022/src/lib.rs
+++ b/token/program-2022/src/lib.rs
@@ -10,6 +10,7 @@ pub mod native_mint;
 pub mod pod;
 pub mod processor;
 pub mod state;
+mod tools;
 
 #[cfg(not(feature = "no-entrypoint"))]
 mod entrypoint;

--- a/token/program-2022/src/tools
+++ b/token/program-2022/src/tools
@@ -1,0 +1,1 @@
+../../../associated-token-account/program/src/tools


### PR DESCRIPTION
Rewrite of the zk-token program as token 2022 extension.

TODO: Only a couple instructions have been implemented so far, to test out the new extension framework.  PRing this early to share what the code of a reasonably complex extension currently looks like

cc: https://github.com/solana-labs/spl-zk-token/issues/91