### PR TITLE
fix small typo

### DIFF
--- a/docs/src/name-service.md
+++ b/docs/src/name-service.md
@@ -44,7 +44,7 @@ any kind of decentralized governance signing program could be used.
 - Twitter handles can be added as names of one specific name class. The class
   authority of will therefore hold the right to add a Twitter handle name. This
   enables the verification of Twitter accounts for example by asking the user to
-  tweet his pubkey or a signed message. A bot that holds the private issuing
+  tweet their pubkey or a signed message. A bot that holds the private issuing
   authority key can then sign the Create instruction (with a metadata_authority
   that is the tweeted pubkey) and send it back to the user who will then submit
   it to the program.
@@ -54,4 +54,4 @@ Therefore, another way of using this program would be to create a name
 (`"verified-twitter-handles"` for example) with the `Pubkey::default()` class
 and with the owner being the authority. That way verified Twitter names could be
 issued as child names of this parent by the owner, leaving the user as being
-able to modify the data of his Twitter name registry.
+able to modify the data of their Twitter name registry.

--- a/farms/README.md
+++ b/farms/README.md
@@ -89,7 +89,7 @@ A command-line tool for on-chain data management (init/upload/delete/lookup) and
 
 A Vault contract implementation. Individual yield farming strategies are stored under the `strategies` sub-folder. `RDM-STAKE-LP-COMPOUND` strategy works as follows:
 
-- User deposits tokens into a Vault with add_liquidity transaction. For example, Vault `RDM.STC.RAY-SRM` takes RAY and SRM tokens. To get a list of available Vaults, one can use the `client.get_vaults()` function or `api/v1/vaults` RPC call. Vault tokens are minted back to the user to represent his share in the Vault.
+- User deposits tokens into a Vault with add_liquidity transaction. For example, Vault `RDM.STC.RAY-SRM` takes RAY and SRM tokens. To get a list of available Vaults, one can use the `client.get_vaults()` function or `api/v1/vaults` RPC call. Vault tokens are minted back to the user to represent their share in the Vault.
 - Vault sends user tokens to the corresponding Raydium Pool, receives LP tokens, and stakes them to the Raydium Farm.
 - Vaults should be cranked on a periodic basis. Crank operation is permissionless and can be done by anyone. And it is executed for the entire Vault, not per individual user. Crank consists of three steps: 1. Harvest Farm rewards (in one or both tokens); 2. Rebalance rewards to get proper amounts of each token; 3. Place rewards back into the Pool and stake received LP tokens. A small Vault fee is taken from rewards, and it can be used to incentivize Crank operations.
 - Upon liquidity removal, the user gets original tokens back in amounts proportional to Vault tokens they hold. Vault tokens are then burned.


### PR DESCRIPTION
Fixed a small typo that refers to a user as a "his" vs. "their" which is used everywhere else in the repo