### PR TITLE
Allow the confidential transfer extension to block `CloseAccount`

### DIFF
--- a/token/program-2022/src/error.rs
+++ b/token/program-2022/src/error.rs
@@ -85,6 +85,9 @@ pub enum TokenError {
     /// Extension already initialized on this account
     #[error("Extension already initialized on this account")]
     ExtensionAlreadyInitialized,
+    /// An account can only be closed if its confidential balance is zero"
+    #[error("An account can only be closed if its confidential balance is zero")]
+    ConfidentialTransferStateHasBalance,
 }
 impl From<TokenError> for ProgramError {
     fn from(e: TokenError) -> Self {


### PR DESCRIPTION
Token accounts with confidential transfers enabled may not be closed until their confidential side is also closed.  Plumb this hook into the normal `CloseAccount` instruction to motivate more discussion around the current extension API