### PR TITLE
Port the remainder of the zk-token program to the ConfidentialTransfer extension

### DIFF
--- a/token/program-2022/src/error.rs
+++ b/token/program-2022/src/error.rs
@@ -85,9 +85,23 @@ pub enum TokenError {
     /// Extension already initialized on this account
     #[error("Extension already initialized on this account")]
     ExtensionAlreadyInitialized,
-    /// An account can only be closed if its confidential balance is zero"
+    /// An account can only be closed if its confidential balance is zero
     #[error("An account can only be closed if its confidential balance is zero")]
-    ConfidentialTransferStateHasBalance,
+    ConfidentialTransferAccountHasBalance,
+    /// Account not approved for confidential transfers
+    #[error("Account not approved for confidential transfers")]
+    ConfidentialTransferAccountNotApproved,
+
+    // 25
+    /// Account not accepting deposits or transfers
+    #[error("Account not accepting deposits or transfers")]
+    ConfidentialTransferDepositsAndTransfersDisabled,
+    /// ElGamal public key mismatch
+    #[error("ElGamal public key mismatch")]
+    ConfidentialTransferElGamalPubkeyMismatch,
+    /// Available balance mismatch
+    #[error("Available balance mismatch")]
+    ConfidentialTransferAvailableBalanceMismatch,
 }
 impl From<TokenError> for ProgramError {
     fn from(e: TokenError) -> Self {

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -1,31 +1,32 @@
+#[cfg(not(target_arch = "bpf"))]
+use solana_zk_token_sdk::encryption::{auth_encryption::AeCiphertext, elgamal::ElGamalPubkey};
+pub use solana_zk_token_sdk::zk_token_proof_instruction::*;
 use {
     crate::{
-        extension::confidential_transfer::{
-            get_omnibus_token_address, ConfidentialTransferAuditor,
-        },
-        id,
-        instruction::TokenInstruction,
-        pod::*,
+        extension::confidential_transfer::ConfidentialTransferMint, id,
+        instruction::TokenInstruction, pod::*,
     },
-    bytemuck::Pod,
+    bytemuck::{Pod, Zeroable},
     num_derive::{FromPrimitive, ToPrimitive},
     num_traits::{FromPrimitive, ToPrimitive},
     solana_program::{
         instruction::{AccountMeta, Instruction},
         program_error::ProgramError,
         pubkey::Pubkey,
+        sysvar,
     },
+    solana_zk_token_sdk::zk_token_elgamal::pod,
 };
 
 /// Confidential Transfer extension instructions
 #[derive(Clone, Copy, Debug, FromPrimitive, ToPrimitive)]
 #[repr(u8)]
 pub enum ConfidentialTransferInstruction {
-    /// Configures the confidential transfer auditor for a given SPL Token mint.
+    /// Initializes confidential transfers for a mint.
     ///
-    /// The `InitializeAuditor` instruction requires no signers and MUST be included within the
-    /// same Transaction as `TokenInstruction::InitializeMint`.  Otherwise another party can
-    /// initialize the auditor.
+    /// The `ConfidentialTransferInstruction::InitializeMint` instruction requires no signers
+    /// and MUST be included within the same Transaction as `TokenInstruction::InitializeMint`.
+    /// Otherwise another party can initialize the configuration.
     ///
     /// The instruction fails if the `TokenInstruction::InitializeMint` instruction has already
     /// executed for the mint.
@@ -35,42 +36,48 @@ pub enum ConfidentialTransferInstruction {
     ///   0. `[writable]` The SPL Token mint
     //
     /// Data expected by this instruction:
-    ///   `ConfidentialTransferAuditor`
+    ///   `ConfidentialTransferMint`
     ///
-    InitializeAuditor,
+    InitializeMint,
 
-    /// Configures the confidential transfer omnibus account for a given SPL Token mint.
-    ///
-    /// The instruction fails if the omnibus account is already configured for the mint.
-    ///
-    /// Accounts expected by this instruction:
-    ///
-    ///   0. `[writeable,signer]` Funding account (must be a system account)
-    ///   1. `[]` The SPL Token mint
-    ///   2. `[writable]` The omnibus SPL Token account to create, computed by `get_omnibus_token_address()`
-    ///   3. `[]` System program
-    ///
-    /// Data expected by this instruction:
-    ///   None
-    ///
-    ConfigureOmnibusAccount,
-
-    /// Updates the confidential transfer auditor for a given SPL Token mint.
+    /// Updates the confidential transfer mint configuration for a mint.
     ///
     /// Accounts expected by this instruction:
     ///
     ///   0. `[writable]` The SPL Token mint
-    ///   1. `[signer]` Confidential transfer auditor authority
-    ///   2. `[signer]` New confidential transfer auditor authority
+    ///   1. `[signer]` Confidential transfer mint authority
+    ///   2. `[signer]` New confidential transfer mint authority
     ///
     /// Data expected by this instruction:
-    ///   `ConfidentialTransferAuditor`
+    ///   `ConfidentialTransferMint`
     ///
-    UpdateAuditor,
+    UpdateMint,
+
+    /// Configures confidential transfers for a token account.
+    ///
+    /// The instruction fails if the confidential transfers are already configured, or if the mint
+    /// was not initialized with confidential transfer support.
+    ///
+    /// Upon success confidential deposits and transfers are disabled, use the
+    /// `EnableBalanceCredits` instruction to enable them.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[writeable]` The SPL Token account
+    ///   1. `[]` The corresponding SPL Token mint
+    ///   2. `[signer]` The single source account owner
+    /// or:
+    ///   2. `[]` The multisig source account owner
+    ///   3.. `[signer]` Required M signer accounts for the SPL Token Multisig account
+    ///
+    /// Data expected by this instruction:
+    ///   `ConfigureAccountInstructionData`
+    ///
+    ConfigureAccount,
 
     /// Approves a token account for confidential transfers.
     ///
-    /// Approval is only required when the `ConfidentialTransferAuditor::approve_new_accounts`
+    /// Approval is only required when the `ConfidentialTransferMint::approve_new_accounts`
     /// field is set in the SPL Token mint.  This instruction must be executed after the account
     /// owner configures their account for confidential transfers with
     /// `ConfidentialTransferInstruction::ConfigureAccount`.
@@ -85,7 +92,205 @@ pub enum ConfidentialTransferInstruction {
     ///   None
     ///
     ApproveAccount,
-    // TODO: Add remaining zk-token insructions here..
+
+    /// Prepare a token account for closing.  The account must not hold any confidential tokens in
+    /// its pending or available balances. Use
+    /// `ConfidentialTransferInstruction::DisableBalanceCredits` to block balance credit changes
+    /// first if necessary.
+    ///
+    /// Note that a newly configured account is always empty, so this instruction is not required
+    /// prior to account closing if no instructions beyond
+    /// `ConfidentialTransferInstruction::ConfigureAccount` have affected the token account.
+    ///
+    ///
+    ///   0. `[writable]` The SPL Token account
+    ///   1. `[]` Instructions sysvar
+    ///   2. `[signer]` The single account owner
+    /// or:
+    ///   2. `[]` The multisig account owner
+    ///   3.. `[signer]` Required M signer accounts for the SPL Token Multisig account
+    ///
+    /// Data expected by this instruction:
+    ///   `EmptyAccountInstructionData`
+    ///
+    EmptyAccount,
+
+    /// Deposit SPL Tokens into the pending balance of a confidential token account.
+    ///
+    /// The account owner can then invoke the `ApplyPendingBalance` instruction to roll the deposit
+    /// into their available balance at a time of their choosing.
+    ///
+    /// Fails if the source or destination accounts are frozen.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[writable]` The source SPL Token account
+    ///   1. `[writable]` The destination SPL Token account with confidential transfers configured
+    ///   2. `[]` The token mint.
+    ///   3. `[signer]` The single source account owner or delegate
+    /// or:
+    ///   3. `[]` The multisig source account owner or delegate.
+    ///   4.. `[signer]` Required M signer accounts for the SPL Token Multisig account
+    ///
+    /// Data expected by this instruction:
+    ///   `DepositInstructionData`
+    ///
+    Deposit,
+
+    /// Withdraw SPL Tokens from the available balance of a confidential token account.
+    ///
+    /// Fails if the source or destination accounts are frozen.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[writable]` The source SPL Token account with confidential transfers configured
+    ///   1. `[writable]` The destination SPL Token account
+    ///   2. `[]` The token mint.
+    ///   3. `[]` Instructions sysvar
+    ///   4. `[signer]` The single source account owner
+    /// or:
+    ///   4. `[]` The multisig  source account owner
+    ///   5.. `[signer]` Required M signer accounts for the SPL Token Multisig account
+    ///
+    /// Data expected by this instruction:
+    ///   `WithdrawInstructionData`
+    ///
+    Withdraw,
+
+    /// Transfer tokens confidentially.
+    ///
+    ///   1. `[writable]` The source SPL Token account
+    ///   2. `[writable]` The destination SPL Token account
+    ///   3. `[]` The token mint
+    ///   4. `[]` Instructions sysvar
+    ///   5. `[signer]` The single source account owner
+    /// or:
+    ///   5. `[]` The multisig  source account owner
+    ///   6.. `[signer]` Required M signer accounts for the SPL Token Multisig account
+    ///
+    /// Data expected by this instruction:
+    ///   `TransferInstructionData`
+    ///
+    Transfer,
+
+    /// Applies the pending balance to the available balance, based on the history of `Deposit`
+    /// and/or `Transfer` instructions.
+    ///
+    /// After submitting `ApplyPendingBalance`, the client should compare
+    /// `ConfidentialTransferAccount::expected_pending_balance_credit_counter` with
+    /// `ConfidentialTransferAccount::actual_applied_pending_balance_instructions`.  If they are
+    /// equal then the `ConfidentialTransferAccount::decryptable_available_balance` is consistent
+    /// with `ConfidentialTransferAccount::available_balance`. If they differ then there is more
+    /// pending balance to be applied.
+    ///
+    /// Account expected by this instruction:
+    ///
+    ///   0. `[writable]` The SPL Token account
+    ///   1. `[signer]` The single account owner
+    /// or:
+    ///   1. `[]` The multisig account owner
+    ///   2.. `[signer]` Required M signer accounts for the SPL Token Multisig account
+    ///
+    /// Data expected by this instruction:
+    ///   `ApplyPendingBalanceData`
+    ///
+    ApplyPendingBalance,
+
+    /// Enable confidential transfer `Deposit` and `Transfer` instructions for a token account.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[writable]` The SPL Token account
+    ///   1. `[signer]` Single authority
+    /// or:
+    ///   1. `[]` Multisig authority
+    ///   2.. `[signer]` Required M signer accounts for the SPL Token Multisig account
+    ///
+    /// Data expected by this instruction:
+    ///   None
+    ///
+    EnableBalanceCredits,
+
+    /// Disable confidential transfer `Deposit` and `Transfer` instructions for a token account.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[writable]` The SPL Token account
+    ///   1. `[signer]` The single account owner
+    /// or:
+    ///   1. `[]` The multisig account owner
+    ///   2.. `[signer]` Required M signer accounts for the SPL Token Multisig account
+    ///
+    /// Data expected by this instruction:
+    ///   None
+    ///
+    DisableBalanceCredits,
+}
+
+/// Data expected by `ConfidentialTransferInstruction::ConfigureAccount`
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct ConfigureAccountInstructionData {
+    /// The public key associated with the account
+    pub elgamal_pk: pod::ElGamalPubkey,
+    /// The decryptable balance (always 0) once the configure account succeeds
+    pub decryptable_zero_balance: pod::AeCiphertext,
+}
+
+/// Data expected by `ConfidentialTransferInstruction::EmptyAccount`
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct EmptyAccountInstructionData {
+    /// Relative location of the `ProofInstruction::VerifyCloseAccount` instruction to the
+    /// `EmptyAccount` instruction in the transaction
+    pub proof_instruction_offset: i8,
+}
+
+/// Data expected by `ConfidentialTransferInstruction::Deposit`
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct DepositInstructionData {
+    /// The amount of tokens to deposit
+    pub amount: PodU64,
+    /// Expected number of base 10 digits to the right of the decimal place
+    pub decimals: u8,
+}
+
+/// Data expected by `ConfidentialTransferInstruction::Withdraw`
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct WithdrawInstructionData {
+    /// The amount of tokens to withdraw
+    pub amount: PodU64,
+    /// Expected number of base 10 digits to the right of the decimal place
+    pub decimals: u8,
+    /// The new decryptable balance if the withrawal succeeds
+    pub new_decryptable_available_balance: pod::AeCiphertext,
+    /// Relative location of the `ProofInstruction::VerifyWithdraw` instruction to the `Withdraw`
+    /// instruction in the transaction
+    pub proof_instruction_offset: i8,
+}
+
+/// Data expected by `ConfidentialTransferInstruction::Transfer`
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct TransferInstructionData {
+    /// The new source decryptable balance if the transfer succeeds
+    pub new_source_decryptable_available_balance: pod::AeCiphertext,
+    /// Relative location of the `ProofInstruction::VerifyTransfer` instruction to the
+    /// `Transfer` instruction in the transaction
+    pub proof_instruction_offset: i8,
+}
+
+/// Data expected by `ConfidentialTransferInstruction::ApplyPendingBalance`
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct ApplyPendingBalanceData {
+    /// The expected number of pending balance credits since the last successful
+    /// `ApplyPendingBalance` instruction
+    pub expected_pending_balance_credit_counter: PodU64,
+    /// The new decryptable balance if the pending balance is applied successfully
+    pub new_decryptable_available_balance: pod::AeCiphertext,
 }
 
 pub(crate) fn decode_instruction_type(
@@ -121,35 +326,19 @@ fn encode_instruction<T: Pod>(
     }
 }
 
-/// Create a `InitializeAuditor` instruction
-pub fn initialize_auditor(mint: Pubkey, auditor: &ConfidentialTransferAuditor) -> Instruction {
+/// Create a `InitializeMint` instruction
+pub fn initialize_mint(mint: Pubkey, auditor: &ConfidentialTransferMint) -> Instruction {
     let accounts = vec![AccountMeta::new(mint, false)];
     encode_instruction(
         accounts,
-        ConfidentialTransferInstruction::InitializeAuditor,
+        ConfidentialTransferInstruction::InitializeMint,
         auditor,
     )
 }
-
-/// Create a `ConfigureOmnibusAccount` instruction
-pub fn configure_omnibus_account(funding_address: Pubkey, mint: Pubkey) -> Instruction {
-    let accounts = vec![
-        AccountMeta::new(funding_address, true),
-        AccountMeta::new_readonly(mint, false),
-        AccountMeta::new(get_omnibus_token_address(&mint), false),
-        AccountMeta::new_readonly(solana_program::system_program::id(), false),
-    ];
-    encode_instruction(
-        accounts,
-        ConfidentialTransferInstruction::ConfigureOmnibusAccount,
-        &(),
-    )
-}
-
-/// Create a `UpdateAuditor` instruction
-pub fn update_auditor(
+/// Create a `UpdateMint` instruction
+pub fn update_mint(
     mint: Pubkey,
-    new_auditor: &ConfidentialTransferAuditor,
+    new_auditor: &ConfidentialTransferMint,
     authority: Pubkey,
 ) -> Instruction {
     let accounts = vec![
@@ -162,9 +351,39 @@ pub fn update_auditor(
     ];
     encode_instruction(
         accounts,
-        ConfidentialTransferInstruction::UpdateAuditor,
+        ConfidentialTransferInstruction::UpdateMint,
         new_auditor,
     )
+}
+
+/// Create a `ConfigureAccount` instruction
+#[cfg(not(target_arch = "bpf"))]
+pub fn configure_account(
+    token_account: Pubkey,
+    mint: Pubkey,
+    elgamal_pk: ElGamalPubkey,
+    decryptable_zero_balance: AeCiphertext,
+    authority: Pubkey,
+    multisig_signers: &[&Pubkey],
+) -> Vec<Instruction> {
+    let mut accounts = vec![
+        AccountMeta::new(token_account, false),
+        AccountMeta::new_readonly(mint, false),
+        AccountMeta::new_readonly(authority, multisig_signers.is_empty()),
+    ];
+
+    for multisig_signer in multisig_signers.iter() {
+        accounts.push(AccountMeta::new_readonly(**multisig_signer, true));
+    }
+
+    vec![encode_instruction(
+        accounts,
+        ConfidentialTransferInstruction::ConfigureAccount,
+        &ConfigureAccountInstructionData {
+            elgamal_pk: elgamal_pk.into(),
+            decryptable_zero_balance: decryptable_zero_balance.into(),
+        },
+    )]
 }
 
 /// Create an `ApproveAccount` instruction
@@ -179,4 +398,299 @@ pub fn approve_account(mint: Pubkey, account_to_approve: Pubkey, authority: Pubk
         ConfidentialTransferInstruction::ApproveAccount,
         &(),
     )
+}
+
+/// Create an inner `EmptyAccount` instruction
+///
+/// This instruction is suitable for use with a cross-program `invoke`
+pub fn inner_empty_account(
+    token_account: Pubkey,
+    authority: Pubkey,
+    multisig_signers: &[&Pubkey],
+    proof_instruction_offset: i8,
+) -> Instruction {
+    let mut accounts = vec![
+        AccountMeta::new_readonly(token_account, false),
+        AccountMeta::new_readonly(sysvar::instructions::id(), false),
+        AccountMeta::new_readonly(authority, multisig_signers.is_empty()),
+    ];
+
+    for multisig_signer in multisig_signers.iter() {
+        accounts.push(AccountMeta::new_readonly(**multisig_signer, true));
+    }
+
+    encode_instruction(
+        accounts,
+        ConfidentialTransferInstruction::EmptyAccount,
+        &EmptyAccountInstructionData {
+            proof_instruction_offset,
+        },
+    )
+}
+
+/// Create a `EmptyAccount` instruction
+pub fn empty_account(
+    token_account: Pubkey,
+    authority: Pubkey,
+    multisig_signers: &[&Pubkey],
+    proof_data: &CloseAccountData,
+) -> Vec<Instruction> {
+    vec![
+        verify_close_account(proof_data),
+        inner_empty_account(token_account, authority, multisig_signers, -1),
+    ]
+}
+
+/// Create a `Deposit` instruction
+pub fn deposit(
+    source_token_account: Pubkey,
+    mint: Pubkey,
+    destination_token_account: Pubkey,
+    amount: u64,
+    decimals: u8,
+    authority: Pubkey,
+    multisig_signers: &[&Pubkey],
+) -> Vec<Instruction> {
+    let mut accounts = vec![
+        AccountMeta::new(source_token_account, false),
+        AccountMeta::new(destination_token_account, false),
+        AccountMeta::new_readonly(mint, false),
+        AccountMeta::new_readonly(authority, multisig_signers.is_empty()),
+    ];
+
+    for multisig_signer in multisig_signers.iter() {
+        accounts.push(AccountMeta::new_readonly(**multisig_signer, true));
+    }
+
+    vec![encode_instruction(
+        accounts,
+        ConfidentialTransferInstruction::Deposit,
+        &DepositInstructionData {
+            amount: amount.into(),
+            decimals,
+        },
+    )]
+}
+
+/// Create a inner `Withdraw` instruction
+///
+/// This instruction is suitable for use with a cross-program `invoke`
+#[allow(clippy::too_many_arguments)]
+pub fn inner_withdraw(
+    source_token_account: Pubkey,
+    destination_token_account: Pubkey,
+    mint: &Pubkey,
+    amount: u64,
+    decimals: u8,
+    new_decryptable_available_balance: pod::AeCiphertext,
+    authority: Pubkey,
+    multisig_signers: &[&Pubkey],
+    proof_instruction_offset: i8,
+) -> Instruction {
+    let mut accounts = vec![
+        AccountMeta::new(source_token_account, false),
+        AccountMeta::new(destination_token_account, false),
+        AccountMeta::new_readonly(*mint, false),
+        AccountMeta::new_readonly(sysvar::instructions::id(), false),
+        AccountMeta::new_readonly(authority, multisig_signers.is_empty()),
+    ];
+
+    for multisig_signer in multisig_signers.iter() {
+        accounts.push(AccountMeta::new_readonly(**multisig_signer, true));
+    }
+
+    encode_instruction(
+        accounts,
+        ConfidentialTransferInstruction::Withdraw,
+        &WithdrawInstructionData {
+            amount: amount.into(),
+            decimals,
+            new_decryptable_available_balance,
+            proof_instruction_offset,
+        },
+    )
+}
+
+/// Create a `Withdraw` instruction
+#[allow(clippy::too_many_arguments)]
+#[cfg(not(target_arch = "bpf"))]
+pub fn withdraw(
+    source_token_account: Pubkey,
+    destination_token_account: Pubkey,
+    mint: &Pubkey,
+    amount: u64,
+    decimals: u8,
+    new_decryptable_available_balance: AeCiphertext,
+    authority: Pubkey,
+    multisig_signers: &[&Pubkey],
+    proof_data: &WithdrawData,
+) -> Vec<Instruction> {
+    vec![
+        verify_withdraw(proof_data),
+        inner_withdraw(
+            source_token_account,
+            destination_token_account,
+            mint,
+            amount,
+            decimals,
+            new_decryptable_available_balance.into(),
+            authority,
+            multisig_signers,
+            -1,
+        ),
+    ]
+}
+
+/// Create a inner `Transfer` instruction
+///
+/// This instruction is suitable for use with a cross-program `invoke`
+#[allow(clippy::too_many_arguments)]
+pub fn inner_transfer(
+    source_token_account: Pubkey,
+    destination_token_account: Pubkey,
+    mint: Pubkey,
+    new_source_decryptable_available_balance: pod::AeCiphertext,
+    authority: Pubkey,
+    multisig_signers: &[&Pubkey],
+    proof_instruction_offset: i8,
+) -> Instruction {
+    let mut accounts = vec![
+        AccountMeta::new(source_token_account, false),
+        AccountMeta::new(destination_token_account, false),
+        AccountMeta::new_readonly(mint, false),
+        AccountMeta::new_readonly(sysvar::instructions::id(), false),
+        AccountMeta::new_readonly(authority, multisig_signers.is_empty()),
+    ];
+
+    for multisig_signer in multisig_signers.iter() {
+        accounts.push(AccountMeta::new_readonly(**multisig_signer, true));
+    }
+
+    encode_instruction(
+        accounts,
+        ConfidentialTransferInstruction::Transfer,
+        &TransferInstructionData {
+            new_source_decryptable_available_balance,
+            proof_instruction_offset,
+        },
+    )
+}
+
+/// Create a `Transfer` instruction
+#[allow(clippy::too_many_arguments)]
+#[cfg(not(target_arch = "bpf"))]
+pub fn transfer(
+    source_token_account: Pubkey,
+    destination_token_account: Pubkey,
+    mint: Pubkey,
+    new_source_decryptable_available_balance: AeCiphertext,
+    authority: Pubkey,
+    multisig_signers: &[&Pubkey],
+    proof_data: &TransferData,
+) -> Vec<Instruction> {
+    vec![
+        verify_transfer(proof_data),
+        inner_transfer(
+            source_token_account,
+            destination_token_account,
+            mint,
+            new_source_decryptable_available_balance.into(),
+            authority,
+            multisig_signers,
+            -1,
+        ),
+    ]
+}
+
+/// Create a inner `ApplyPendingBalance` instruction
+///
+/// This instruction is suitable for use with a cross-program `invoke`
+#[allow(clippy::too_many_arguments)]
+pub fn inner_apply_pending_balance(
+    token_account: Pubkey,
+    expected_pending_balance_credit_counter: u64,
+    new_decryptable_available_balance: pod::AeCiphertext,
+    authority: Pubkey,
+    multisig_signers: &[&Pubkey],
+) -> Instruction {
+    let mut accounts = vec![
+        AccountMeta::new(token_account, false),
+        AccountMeta::new_readonly(authority, multisig_signers.is_empty()),
+    ];
+
+    for multisig_signer in multisig_signers.iter() {
+        accounts.push(AccountMeta::new_readonly(**multisig_signer, true));
+    }
+
+    encode_instruction(
+        accounts,
+        ConfidentialTransferInstruction::ApplyPendingBalance,
+        &ApplyPendingBalanceData {
+            expected_pending_balance_credit_counter: expected_pending_balance_credit_counter.into(),
+            new_decryptable_available_balance,
+        },
+    )
+}
+
+/// Create a `ApplyPendingBalance` instruction
+#[cfg(not(target_arch = "bpf"))]
+pub fn apply_pending_balance(
+    token_account: Pubkey,
+    pending_balance_instructions: u64,
+    new_decryptable_available_balance: AeCiphertext,
+    authority: Pubkey,
+    multisig_signers: &[&Pubkey],
+) -> Vec<Instruction> {
+    vec![inner_apply_pending_balance(
+        token_account,
+        pending_balance_instructions,
+        new_decryptable_available_balance.into(),
+        authority,
+        multisig_signers,
+    )]
+}
+
+/// Create a `EnableBalanceCredits` instruction
+pub fn enable_balance_credits(
+    token_account: Pubkey,
+    authority: Pubkey,
+    multisig_signers: &[&Pubkey],
+) -> Vec<Instruction> {
+    let mut accounts = vec![
+        AccountMeta::new(token_account, false),
+        AccountMeta::new_readonly(authority, multisig_signers.is_empty()),
+    ];
+
+    for multisig_signer in multisig_signers.iter() {
+        accounts.push(AccountMeta::new_readonly(**multisig_signer, true));
+    }
+
+    vec![encode_instruction(
+        accounts,
+        ConfidentialTransferInstruction::EnableBalanceCredits,
+        &(),
+    )]
+}
+
+/// Create a `DisableBalanceCredits` instruction
+#[cfg(not(target_arch = "bpf"))]
+pub fn disable_balance_credits(
+    token_account: Pubkey,
+    authority: Pubkey,
+    multisig_signers: &[&Pubkey],
+) -> Vec<Instruction> {
+    let mut accounts = vec![
+        AccountMeta::new(token_account, false),
+        AccountMeta::new_readonly(authority, multisig_signers.is_empty()),
+    ];
+
+    for multisig_signer in multisig_signers.iter() {
+        accounts.push(AccountMeta::new_readonly(**multisig_signer, true));
+    }
+
+    vec![encode_instruction(
+        accounts,
+        ConfidentialTransferInstruction::DisableBalanceCredits,
+        &(),
+    )]
 }

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -1,94 +1,63 @@
 use {
     crate::{
         check_program_account,
+        error::TokenError,
         extension::{
             confidential_transfer::{instruction::*, *},
             StateWithExtensions, StateWithExtensionsMut,
         },
-        id,
         processor::Processor,
         state::{Account, Mint},
-        tools::account::create_pda_account,
     },
     solana_program::{
         account_info::{next_account_info, AccountInfo},
         entrypoint::ProgramResult,
+        instruction::Instruction,
         msg,
         program_error::ProgramError,
-        program_pack::Pack,
         pubkey::Pubkey,
-        sysvar::{rent::Rent, Sysvar},
+        sysvar::instructions::get_instruction_relative,
+    },
+    solana_zk_token_sdk::{
+        zk_token_elgamal::{ops, pod},
+        zk_token_proof_program,
     },
 };
 
-/// Processes an [InitializeAuditor] instruction.
-fn process_initialize_auditor(
+fn decode_proof_instruction<T: Pod>(
+    expected: ProofInstruction,
+    instruction: &Instruction,
+) -> Result<&T, ProgramError> {
+    if instruction.program_id != zk_token_proof_program::id()
+        || ProofInstruction::decode_type(&instruction.data) != Some(expected)
+    {
+        msg!("Unexpected proof instruction");
+        return Err(ProgramError::InvalidInstructionData);
+    }
+
+    ProofInstruction::decode_data(&instruction.data).ok_or(ProgramError::InvalidInstructionData)
+}
+
+/// Processes an [InitializeMint] instruction.
+fn process_initialize_mint(
     accounts: &[AccountInfo],
-    auditor: &ConfidentialTransferAuditor,
+    ct_mint: &ConfidentialTransferMint,
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
     let mint_info = next_account_info(account_info_iter)?;
 
     check_program_account(mint_info.owner)?;
     let mint_data = &mut mint_info.data.borrow_mut();
-    let mut mint = StateWithExtensionsMut::<Mint>::unpack_uninitialized(mint_data)?;
-    *mint.init_extension::<ConfidentialTransferAuditor>()? = *auditor;
+    let mut mint = StateWithExtensionsMut::<Mint>::unpack(mint_data)?;
+    *mint.init_extension::<ConfidentialTransferMint>()? = *ct_mint;
 
     Ok(())
 }
 
-/// Processes a [ConfigureOmnibusAccount] instruction.
-fn process_configure_omnibus_account(accounts: &[AccountInfo]) -> ProgramResult {
-    let account_info_iter = &mut accounts.iter();
-    let funder_info = next_account_info(account_info_iter)?;
-    let mint_info = next_account_info(account_info_iter)?;
-    let omnibus_info = next_account_info(account_info_iter)?;
-    let system_program_info = next_account_info(account_info_iter)?;
-
-    check_program_account(mint_info.owner)?;
-    let _mint = StateWithExtensions::<Mint>::unpack(&mint_info.data.borrow())?;
-
-    let (omnibus_token_address, omnibus_token_bump_seed) =
-        get_omnibus_token_address_with_seed(mint_info.key);
-
-    if omnibus_token_address != *omnibus_info.key {
-        msg!("Error: Omnibus token address does not match derivation");
-        return Err(ProgramError::InvalidArgument);
-    }
-
-    let omnibus_token_account_signer_seeds: &[&[_]] = &[
-        &mint_info.key.to_bytes(),
-        br"confidential_transfer_omnibus",
-        &[omnibus_token_bump_seed],
-    ];
-
-    create_pda_account(
-        funder_info,
-        &Rent::get()?,
-        Account::get_packed_len(),
-        &id(),
-        system_program_info,
-        omnibus_info,
-        omnibus_token_account_signer_seeds,
-    )?;
-
-    Processor::process(
-        &id(),
-        &[omnibus_info.clone(), mint_info.clone()],
-        &crate::instruction::initialize_account3(
-            &id(),
-            omnibus_info.key,
-            mint_info.key,
-            omnibus_info.key,
-        )?
-        .data,
-    )
-}
-
-/// Processes an [UpdateAuditor] instruction.
-fn process_update_auditor(
+/// Processes an [UpdateMint] instruction.
+fn process_update_mint(
     accounts: &[AccountInfo],
-    new_auditor: &ConfidentialTransferAuditor,
+    new_ct_mint: &ConfidentialTransferMint,
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
     let mint_info = next_account_info(account_info_iter)?;
@@ -98,13 +67,13 @@ fn process_update_auditor(
     check_program_account(mint_info.owner)?;
     let mint_data = &mut mint_info.data.borrow_mut();
     let mut mint = StateWithExtensionsMut::<Mint>::unpack(mint_data)?;
-    let auditor = mint.get_extension_mut::<ConfidentialTransferAuditor>()?;
 
     if authority_info.is_signer
         && (new_authority_info.is_signer || *new_authority_info.key == Pubkey::default())
     {
-        if new_auditor.authority == *new_authority_info.key {
-            *auditor = *new_auditor;
+        if new_ct_mint.authority == *new_authority_info.key {
+            let ct_mint = mint.get_extension_mut::<ConfidentialTransferMint>()?;
+            *ct_mint = *new_ct_mint;
             Ok(())
         } else {
             Err(ProgramError::InvalidInstructionData)
@@ -112,6 +81,82 @@ fn process_update_auditor(
     } else {
         Err(ProgramError::MissingRequiredSignature)
     }
+}
+
+/// Processes a [ConfigureAccount] instruction.
+fn process_configure_account(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    ConfigureAccountInstructionData {
+        elgamal_pk,
+        decryptable_zero_balance,
+    }: &ConfigureAccountInstructionData,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let token_account_info = next_account_info(account_info_iter)?;
+    let mint_info = next_account_info(account_info_iter)?;
+    let authority_info = next_account_info(account_info_iter)?;
+
+    check_program_account(token_account_info.owner)?;
+    let token_account_data = &mut token_account_info.data.borrow_mut();
+    let mut token_account = StateWithExtensionsMut::<Account>::unpack(token_account_data)?;
+
+    if token_account.base.mint != *mint_info.key {
+        return Err(TokenError::MintMismatch.into());
+    }
+
+    Processor::validate_owner(
+        program_id,
+        token_account_info.key,
+        token_account_info.owner,
+        authority_info,
+        account_info_iter.as_slice(),
+    )?;
+
+    check_program_account(mint_info.owner)?;
+    let mint_data = &mut mint_info.data.borrow();
+    let mint = StateWithExtensions::<Mint>::unpack(mint_data)?;
+    let ct_mint = mint.get_extension::<ConfidentialTransferMint>()?;
+
+    // TODO: Support reallocating the token account (and re-checking rent) if there's insufficient
+    // room for the new extension.
+    let mut ct_token_account = token_account.init_extension::<ConfidentialTransferAccount>()?;
+    ct_token_account.approved = ct_mint.auto_approve_new_accounts;
+    ct_token_account.elgamal_pk = *elgamal_pk;
+    ct_token_account.decryptable_available_balance = *decryptable_zero_balance;
+
+    /*
+        An ElGamal ciphertext is of the form
+          ElGamalCiphertext {
+            msg_comm: r * H + x * G
+            decrypt_handle: r * P
+          }
+
+        where
+        - G, H: constants for the system (RistrettoPoint)
+        - P: ElGamal public key component (RistrettoPoint)
+        - r: encryption randomness (Scalar)
+        - x: message (Scalar)
+
+        Upon receiving a `ConfigureAccount` instruction, the ZK Token program should encrypt x=0 (i.e.
+        Scalar::zero()) and store it as `pending_balance` and `available_balance`.
+
+        For regular encryption, it is important that r is generated from a proper randomness source. But
+        for the `ConfigureAccount` instruction, it is already known that x is always 0. So r can just be
+        set Scalar::zero().
+
+        This means that the ElGamalCiphertext should simply be
+          ElGamalCiphertext {
+            msg_comm: 0 * H + 0 * G = 0
+            decrypt_handle: 0 * P = 0
+          }
+
+        This should just be encoded as [0; 64]
+    */
+    ct_token_account.pending_balance = pod::ElGamalCiphertext::zeroed();
+    ct_token_account.available_balance = pod::ElGamalCiphertext::zeroed();
+
+    Ok(())
 }
 
 /// Processes an [ApproveAccount] instruction.
@@ -128,16 +173,487 @@ fn process_approve_account(accounts: &[AccountInfo]) -> ProgramResult {
     check_program_account(mint_info.owner)?;
     let mint_data = &mint_info.data.borrow_mut();
     let mint = StateWithExtensions::<Mint>::unpack(mint_data)?;
-    let auditor = mint.get_extension::<ConfidentialTransferAuditor>()?;
+    let ct_mint = mint.get_extension::<ConfidentialTransferMint>()?;
 
-    if authority_info.is_signer && *authority_info.key == auditor.authority {
+    if authority_info.is_signer && *authority_info.key == ct_mint.authority {
         let mut confidential_transfer_state =
-            account_to_approve.get_extension_mut::<ConfidentialTransferState>()?;
+            account_to_approve.get_extension_mut::<ConfidentialTransferAccount>()?;
         confidential_transfer_state.approved = true.into();
         Ok(())
     } else {
         Err(ProgramError::MissingRequiredSignature)
     }
+}
+
+/// Processes an [EmptyAccount] instruction.
+fn process_empty_account(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    proof_instruction_offset: i64,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let token_account_info = next_account_info(account_info_iter)?;
+    let instructions_sysvar_info = next_account_info(account_info_iter)?;
+    let authority_info = next_account_info(account_info_iter)?;
+
+    check_program_account(token_account_info.owner)?;
+    let token_account_data = &mut token_account_info.data.borrow_mut();
+    let mut token_account = StateWithExtensionsMut::<Account>::unpack(token_account_data)?;
+
+    Processor::validate_owner(
+        program_id,
+        token_account_info.key,
+        token_account_info.owner,
+        authority_info,
+        account_info_iter.as_slice(),
+    )?;
+
+    let mut ct_token_account = token_account.get_extension_mut::<ConfidentialTransferAccount>()?;
+
+    let previous_instruction =
+        get_instruction_relative(proof_instruction_offset, instructions_sysvar_info)?;
+    let proof_data = decode_proof_instruction::<CloseAccountData>(
+        ProofInstruction::VerifyCloseAccount,
+        &previous_instruction,
+    )?;
+
+    if ct_token_account.pending_balance != pod::ElGamalCiphertext::zeroed() {
+        msg!("Pending balance is not zero");
+        return Err(ProgramError::InvalidAccountData);
+    }
+
+    if ct_token_account.available_balance != proof_data.balance {
+        msg!("Available balance mismatch");
+        return Err(ProgramError::InvalidInstructionData);
+    }
+
+    ct_token_account.approved()?;
+    ct_token_account.available_balance = pod::ElGamalCiphertext::zeroed();
+    ct_token_account.closable()?;
+
+    Ok(())
+}
+
+/// Processes a [Deposit] instruction.
+fn process_deposit(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    amount: u64,
+    expected_decimals: u8,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let token_account_info = next_account_info(account_info_iter)?;
+    let receiver_token_account_info = next_account_info(account_info_iter)?;
+    let mint_info = next_account_info(account_info_iter)?;
+    let authority_info = next_account_info(account_info_iter)?;
+
+    check_program_account(mint_info.owner)?;
+    let mint_data = &mint_info.data.borrow_mut();
+    let mint = StateWithExtensions::<Mint>::unpack(mint_data)?;
+
+    if expected_decimals != mint.base.decimals {
+        return Err(TokenError::MintDecimalsMismatch.into());
+    }
+
+    // Process source account
+    {
+        check_program_account(token_account_info.owner)?;
+        let token_account_data = &mut token_account_info.data.borrow_mut();
+        let mut token_account = StateWithExtensionsMut::<Account>::unpack(token_account_data)?;
+
+        Processor::validate_owner(
+            program_id,
+            token_account_info.key,
+            token_account_info.owner,
+            authority_info,
+            account_info_iter.as_slice(),
+        )?;
+
+        if token_account.base.is_frozen() {
+            return Err(TokenError::AccountFrozen.into());
+        }
+
+        if token_account.base.mint != *mint_info.key {
+            return Err(TokenError::MintMismatch.into());
+        }
+
+        // Wrapped SOL deposits are not supported because lamports cannot be vanished.
+        assert!(!token_account.base.is_native());
+        token_account.base.amount = token_account
+            .base
+            .amount
+            .checked_sub(amount)
+            .ok_or(TokenError::Overflow)?;
+
+        token_account.pack_base();
+    }
+
+    //
+    // Finished with the source token account at this point. Drop all references to it to avoid a
+    // double borrow if the source and destination accounts are the same
+    //
+
+    // Process destination account
+    {
+        check_program_account(receiver_token_account_info.owner)?;
+        let receiver_token_account_data = &mut receiver_token_account_info.data.borrow_mut();
+        let mut receiver_token_account =
+            StateWithExtensionsMut::<Account>::unpack(receiver_token_account_data)?;
+
+        if receiver_token_account.base.is_frozen() {
+            return Err(TokenError::AccountFrozen.into());
+        }
+
+        if receiver_token_account.base.mint != *mint_info.key {
+            return Err(TokenError::MintMismatch.into());
+        }
+
+        let mut receiver_ct_token_account =
+            receiver_token_account.get_extension_mut::<ConfidentialTransferAccount>()?;
+        receiver_ct_token_account.approved()?;
+
+        if !bool::from(&receiver_ct_token_account.allow_balance_credits) {
+            return Err(TokenError::ConfidentialTransferDepositsAndTransfersDisabled.into());
+        }
+
+        receiver_ct_token_account.pending_balance =
+            ops::add_to(&receiver_ct_token_account.pending_balance, amount)
+                .ok_or(TokenError::Overflow)?;
+
+        receiver_ct_token_account.pending_balance_credit_counter =
+            (u64::from(receiver_ct_token_account.pending_balance_credit_counter)
+                .checked_add(1)
+                .ok_or(TokenError::Overflow)?)
+            .into();
+    }
+
+    Ok(())
+}
+
+/// Processes a [Withdraw] instruction.
+fn process_withdraw(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    amount: u64,
+    expected_decimals: u8,
+    new_decryptable_available_balance: pod::AeCiphertext,
+    proof_instruction_offset: i64,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let token_account_info = next_account_info(account_info_iter)?;
+    let receiver_token_account_info = next_account_info(account_info_iter)?;
+    let mint_info = next_account_info(account_info_iter)?;
+    let instructions_sysvar_info = next_account_info(account_info_iter)?;
+    let authority_info = next_account_info(account_info_iter)?;
+
+    check_program_account(mint_info.owner)?;
+    let mint_data = &mint_info.data.borrow_mut();
+    let mint = StateWithExtensions::<Mint>::unpack(mint_data)?;
+
+    if expected_decimals != mint.base.decimals {
+        return Err(TokenError::MintDecimalsMismatch.into());
+    }
+
+    let previous_instruction =
+        get_instruction_relative(proof_instruction_offset, instructions_sysvar_info)?;
+
+    let proof_data = decode_proof_instruction::<WithdrawData>(
+        ProofInstruction::VerifyWithdraw,
+        &previous_instruction,
+    )?;
+
+    // Process source account
+    {
+        check_program_account(token_account_info.owner)?;
+        let token_account_data = &mut token_account_info.data.borrow_mut();
+        let mut token_account = StateWithExtensionsMut::<Account>::unpack(token_account_data)?;
+
+        Processor::validate_owner(
+            program_id,
+            token_account_info.key,
+            token_account_info.owner,
+            authority_info,
+            account_info_iter.as_slice(),
+        )?;
+
+        if token_account.base.is_frozen() {
+            return Err(TokenError::AccountFrozen.into());
+        }
+
+        if token_account.base.mint != *mint_info.key {
+            return Err(TokenError::MintMismatch.into());
+        }
+
+        let mut ct_token_account =
+            token_account.get_extension_mut::<ConfidentialTransferAccount>()?;
+        ct_token_account.approved()?;
+
+        ct_token_account.available_balance =
+            ops::subtract_from(&ct_token_account.available_balance, amount)
+                .ok_or(TokenError::Overflow)?;
+
+        if ct_token_account.available_balance != proof_data.final_balance_ct {
+            return Err(TokenError::ConfidentialTransferAvailableBalanceMismatch.into());
+        }
+
+        ct_token_account.decryptable_available_balance = new_decryptable_available_balance;
+    }
+
+    //
+    // Finished with the source token account at this point. Drop all references to it to avoid a
+    // double borrow if the source and destination accounts are the same
+    //
+
+    // Process destination account
+    {
+        check_program_account(receiver_token_account_info.owner)?;
+        let receiver_token_account_data = &mut receiver_token_account_info.data.borrow_mut();
+        let mut receiver_token_account =
+            StateWithExtensionsMut::<Account>::unpack(receiver_token_account_data)?;
+
+        if receiver_token_account.base.is_frozen() {
+            return Err(TokenError::AccountFrozen.into());
+        }
+
+        if receiver_token_account.base.mint != *mint_info.key {
+            return Err(TokenError::MintMismatch.into());
+        }
+
+        // Wrapped SOL withdrawals are not supported because lamports cannot be apparated.
+        assert!(!receiver_token_account.base.is_native());
+        receiver_token_account.base.amount = receiver_token_account
+            .base
+            .amount
+            .checked_add(amount)
+            .ok_or(TokenError::Overflow)?;
+
+        receiver_token_account.pack_base();
+    }
+
+    Ok(())
+}
+
+/// Processes an [Transfer] instruction.
+fn process_transfer(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    new_source_decryptable_available_balance: pod::AeCiphertext,
+    proof_instruction_offset: i64,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let token_account_info = next_account_info(account_info_iter)?;
+    let receiver_token_account_info = next_account_info(account_info_iter)?;
+    let mint_info = next_account_info(account_info_iter)?;
+    let instructions_sysvar_info = next_account_info(account_info_iter)?;
+    let authority_info = next_account_info(account_info_iter)?;
+
+    check_program_account(mint_info.owner)?;
+    let mint_data = &mint_info.data.borrow_mut();
+    let mint = StateWithExtensions::<Mint>::unpack(mint_data)?;
+    let ct_mint = mint.get_extension::<ConfidentialTransferMint>()?;
+
+    let previous_instruction =
+        get_instruction_relative(proof_instruction_offset, instructions_sysvar_info)?;
+    let proof_data = decode_proof_instruction::<TransferData>(
+        ProofInstruction::VerifyTransfer,
+        &previous_instruction,
+    )?;
+
+    if proof_data.transfer_public_keys.auditor_pk != ct_mint.auditor_pk {
+        return Err(TokenError::ConfidentialTransferElGamalPubkeyMismatch.into());
+    }
+
+    // Process source account
+    {
+        check_program_account(token_account_info.owner)?;
+        let token_account_data = &mut token_account_info.data.borrow_mut();
+        let mut token_account = StateWithExtensionsMut::<Account>::unpack(token_account_data)?;
+
+        Processor::validate_owner(
+            program_id,
+            token_account_info.key,
+            token_account_info.owner,
+            authority_info,
+            account_info_iter.as_slice(),
+        )?;
+
+        if token_account.base.is_frozen() {
+            return Err(TokenError::AccountFrozen.into());
+        }
+
+        if token_account.base.mint != *mint_info.key {
+            return Err(TokenError::MintMismatch.into());
+        }
+
+        let mut ct_token_account =
+            token_account.get_extension_mut::<ConfidentialTransferAccount>()?;
+        ct_token_account.approved()?;
+        if proof_data.transfer_public_keys.source_pk != ct_token_account.elgamal_pk {
+            return Err(TokenError::ConfidentialTransferElGamalPubkeyMismatch.into());
+        }
+
+        let new_source_available_balance = {
+            // Combine commitments and handles
+            let source_lo_ct = pod::ElGamalCiphertext::from((
+                proof_data.encrypted_transfer_amount.amount_comm_lo,
+                proof_data
+                    .encrypted_transfer_amount
+                    .decrypt_handles_lo
+                    .source,
+            ));
+            let source_hi_ct = pod::ElGamalCiphertext::from((
+                proof_data.encrypted_transfer_amount.amount_comm_hi,
+                proof_data
+                    .encrypted_transfer_amount
+                    .decrypt_handles_hi
+                    .source,
+            ));
+
+            ops::subtract_with_lo_hi(
+                &ct_token_account.available_balance,
+                &source_lo_ct,
+                &source_hi_ct,
+            )
+            .ok_or(ProgramError::InvalidInstructionData)?
+        };
+
+        ct_token_account.available_balance = new_source_available_balance;
+        ct_token_account.decryptable_available_balance = new_source_decryptable_available_balance;
+    }
+
+    //
+    // Finished with the source token account at this point. Drop all references to it to avoid a
+    // double borrow if the source and destination accounts are the same
+    //
+
+    // Process destination account
+    {
+        check_program_account(receiver_token_account_info.owner)?;
+        let receiver_token_account_data = &mut receiver_token_account_info.data.borrow_mut();
+        let mut receiver_token_account =
+            StateWithExtensionsMut::<Account>::unpack(receiver_token_account_data)?;
+
+        if receiver_token_account.base.is_frozen() {
+            return Err(TokenError::AccountFrozen.into());
+        }
+
+        if receiver_token_account.base.mint != *mint_info.key {
+            return Err(TokenError::MintMismatch.into());
+        }
+
+        let mut receiver_ct_token_account =
+            receiver_token_account.get_extension_mut::<ConfidentialTransferAccount>()?;
+        receiver_ct_token_account.approved()?;
+
+        if !bool::from(&receiver_ct_token_account.allow_balance_credits) {
+            return Err(TokenError::ConfidentialTransferDepositsAndTransfersDisabled.into());
+        }
+
+        if proof_data.transfer_public_keys.dest_pk != receiver_ct_token_account.elgamal_pk {
+            return Err(TokenError::ConfidentialTransferElGamalPubkeyMismatch.into());
+        }
+
+        let new_receiver_pending_balance = {
+            let dest_lo_ct = pod::ElGamalCiphertext::from((
+                proof_data.encrypted_transfer_amount.amount_comm_lo,
+                proof_data.encrypted_transfer_amount.decrypt_handles_lo.dest,
+            ));
+
+            let dest_hi_ct = pod::ElGamalCiphertext::from((
+                proof_data.encrypted_transfer_amount.amount_comm_hi,
+                proof_data.encrypted_transfer_amount.decrypt_handles_hi.dest,
+            ));
+
+            ops::add_with_lo_hi(
+                &receiver_ct_token_account.pending_balance,
+                &dest_lo_ct,
+                &dest_hi_ct,
+            )
+            .ok_or(ProgramError::InvalidInstructionData)?
+        };
+
+        let new_receiver_pending_balance_credit_counter =
+            (u64::from(receiver_ct_token_account.pending_balance_credit_counter) + 1).into();
+
+        receiver_ct_token_account.pending_balance = new_receiver_pending_balance;
+        receiver_ct_token_account.pending_balance_credit_counter =
+            new_receiver_pending_balance_credit_counter;
+    }
+
+    Ok(())
+}
+
+/// Processes an [ApplyPendingBalance] instruction.
+fn process_apply_pending_balance(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    ApplyPendingBalanceData {
+        expected_pending_balance_credit_counter,
+        new_decryptable_available_balance,
+    }: &ApplyPendingBalanceData,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let token_account_info = next_account_info(account_info_iter)?;
+    let authority_info = next_account_info(account_info_iter)?;
+
+    check_program_account(token_account_info.owner)?;
+    let token_account_data = &mut token_account_info.data.borrow_mut();
+    let mut token_account = StateWithExtensionsMut::<Account>::unpack(token_account_data)?;
+
+    Processor::validate_owner(
+        program_id,
+        token_account_info.key,
+        token_account_info.owner,
+        authority_info,
+        account_info_iter.as_slice(),
+    )?;
+
+    let mut ct_token_account = token_account.get_extension_mut::<ConfidentialTransferAccount>()?;
+    ct_token_account.approved()?;
+
+    ct_token_account.available_balance = ops::add(
+        &ct_token_account.available_balance,
+        &ct_token_account.pending_balance,
+    )
+    .ok_or(ProgramError::InvalidInstructionData)?;
+
+    ct_token_account.actual_pending_balance_credit_counter =
+        ct_token_account.pending_balance_credit_counter;
+    ct_token_account.expected_pending_balance_credit_counter =
+        *expected_pending_balance_credit_counter;
+    ct_token_account.decryptable_available_balance = *new_decryptable_available_balance;
+    ct_token_account.pending_balance = pod::ElGamalCiphertext::zeroed();
+
+    Ok(())
+}
+
+/// Processes an [DisableBalanceCredits] or [EnableBalanceCredits] instruction.
+fn process_allow_balance_credits(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    allow_balance_credits: bool,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let token_account_info = next_account_info(account_info_iter)?;
+    let authority_info = next_account_info(account_info_iter)?;
+
+    check_program_account(token_account_info.owner)?;
+    let token_account_data = &mut token_account_info.data.borrow_mut();
+    let mut token_account = StateWithExtensionsMut::<Account>::unpack(token_account_data)?;
+
+    Processor::validate_owner(
+        program_id,
+        token_account_info.key,
+        token_account_info.owner,
+        authority_info,
+        account_info_iter.as_slice(),
+    )?;
+
+    let mut ct_token_account = token_account.get_extension_mut::<ConfidentialTransferAccount>()?;
+    ct_token_account.approved()?;
+    ct_token_account.allow_balance_credits = allow_balance_credits.into();
+
+    Ok(())
 }
 
 pub(crate) fn process_instruction(
@@ -148,27 +664,79 @@ pub(crate) fn process_instruction(
     check_program_account(program_id)?;
 
     match decode_instruction_type(input)? {
-        ConfidentialTransferInstruction::InitializeAuditor => {
-            msg!("ConfidentialTransferInstruction::InitializeAuditor");
-            process_initialize_auditor(
+        ConfidentialTransferInstruction::InitializeMint => {
+            msg!("ConfidentialTransferInstruction::InitializeMint");
+            process_initialize_mint(
                 accounts,
-                decode_instruction_data::<ConfidentialTransferAuditor>(input)?,
+                decode_instruction_data::<ConfidentialTransferMint>(input)?,
             )
         }
-        ConfidentialTransferInstruction::ConfigureOmnibusAccount => {
-            msg!("ConfidentialTransferInstruction::ConfigureOmnibusAccount");
-            process_configure_omnibus_account(accounts)
-        }
-        ConfidentialTransferInstruction::UpdateAuditor => {
-            msg!("ConfidentialTransferInstruction::UpdateAuditor");
-            process_update_auditor(
+        ConfidentialTransferInstruction::UpdateMint => {
+            msg!("ConfidentialTransferInstruction::UpdateMint");
+            process_update_mint(
                 accounts,
-                decode_instruction_data::<ConfidentialTransferAuditor>(input)?,
+                decode_instruction_data::<ConfidentialTransferMint>(input)?,
+            )
+        }
+        ConfidentialTransferInstruction::ConfigureAccount => {
+            msg!("ConfidentialTransferInstruction::ConfigureAccount");
+            process_configure_account(
+                program_id,
+                accounts,
+                decode_instruction_data::<ConfigureAccountInstructionData>(input)?,
             )
         }
         ConfidentialTransferInstruction::ApproveAccount => {
             msg!("ConfidentialTransferInstruction::ApproveAccount");
             process_approve_account(accounts)
-        } // TODO: add remaining `zk_token_program::processor.rs` here
+        }
+        ConfidentialTransferInstruction::EmptyAccount => {
+            msg!("ConfidentialTransferInstruction::EmptyAccount");
+            let data = decode_instruction_data::<EmptyAccountInstructionData>(input)?;
+            process_empty_account(program_id, accounts, data.proof_instruction_offset as i64)
+        }
+        ConfidentialTransferInstruction::Deposit => {
+            msg!("ConfidentialTransferInstruction::Deposit");
+            let data = decode_instruction_data::<DepositInstructionData>(input)?;
+            process_deposit(program_id, accounts, data.amount.into(), data.decimals)
+        }
+        ConfidentialTransferInstruction::Withdraw => {
+            msg!("ConfidentialTransferInstruction::Withdraw");
+            let data = decode_instruction_data::<WithdrawInstructionData>(input)?;
+            process_withdraw(
+                program_id,
+                accounts,
+                data.amount.into(),
+                data.decimals,
+                data.new_decryptable_available_balance,
+                data.proof_instruction_offset as i64,
+            )
+        }
+        ConfidentialTransferInstruction::Transfer => {
+            msg!("ConfidentialTransferInstruction::Transfer");
+            let data = decode_instruction_data::<TransferInstructionData>(input)?;
+            process_transfer(
+                program_id,
+                accounts,
+                data.new_source_decryptable_available_balance,
+                data.proof_instruction_offset as i64,
+            )
+        }
+        ConfidentialTransferInstruction::ApplyPendingBalance => {
+            msg!("ConfidentialTransferInstruction::ApplyPendingBalance");
+            process_apply_pending_balance(
+                program_id,
+                accounts,
+                decode_instruction_data::<ApplyPendingBalanceData>(input)?,
+            )
+        }
+        ConfidentialTransferInstruction::DisableBalanceCredits => {
+            msg!("ConfidentialTransferInstruction::DisableBalanceCredits");
+            process_allow_balance_credits(program_id, accounts, false)
+        }
+        ConfidentialTransferInstruction::EnableBalanceCredits => {
+            msg!("ConfidentialTransferInstruction::EnableBalanceCredits");
+            process_allow_balance_credits(program_id, accounts, true)
+        }
     }
 }

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -4,7 +4,7 @@ use {
     crate::{
         error::TokenError,
         extension::{
-            confidential_transfer::{ConfidentialTransferAuditor, ConfidentialTransferState},
+            confidential_transfer::{ConfidentialTransferAccount, ConfidentialTransferMint},
             mint_close_authority::MintCloseAuthority,
             transfer_fee::{TransferFeeAmount, TransferFeeConfig},
         },
@@ -435,9 +435,9 @@ pub enum ExtensionType {
     /// Includes an optional mint close authority
     MintCloseAuthority,
     /// Auditor configuration for confidential transfers
-    ConfidentialTransferAuditor,
+    ConfidentialTransferMint,
     /// State for confidential transfers
-    ConfidentialTransferState,
+    ConfidentialTransferAccount,
     /// Padding extension used to make an account exactly Multisig::LEN, used for testing
     #[cfg(test)]
     AccountPaddingTest = u16::MAX - 1,
@@ -467,11 +467,11 @@ impl ExtensionType {
             ExtensionType::TransferFeeConfig => pod_get_packed_len::<TransferFeeConfig>(),
             ExtensionType::TransferFeeAmount => pod_get_packed_len::<TransferFeeAmount>(),
             ExtensionType::MintCloseAuthority => pod_get_packed_len::<MintCloseAuthority>(),
-            ExtensionType::ConfidentialTransferAuditor => {
-                pod_get_packed_len::<ConfidentialTransferAuditor>()
+            ExtensionType::ConfidentialTransferMint => {
+                pod_get_packed_len::<ConfidentialTransferMint>()
             }
-            ExtensionType::ConfidentialTransferState => {
-                pod_get_packed_len::<ConfidentialTransferState>()
+            ExtensionType::ConfidentialTransferAccount => {
+                pod_get_packed_len::<ConfidentialTransferAccount>()
             }
             #[cfg(test)]
             ExtensionType::AccountPaddingTest => pod_get_packed_len::<AccountPaddingTest>(),
@@ -486,8 +486,8 @@ impl ExtensionType {
             ExtensionType::Uninitialized => AccountType::Uninitialized,
             ExtensionType::TransferFeeConfig
             | ExtensionType::MintCloseAuthority
-            | ExtensionType::ConfidentialTransferAuditor => AccountType::Mint,
-            ExtensionType::TransferFeeAmount | ExtensionType::ConfidentialTransferState => {
+            | ExtensionType::ConfidentialTransferMint => AccountType::Mint,
+            ExtensionType::TransferFeeAmount | ExtensionType::ConfidentialTransferAccount => {
                 AccountType::Account
             }
             #[cfg(test)]

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -218,6 +218,10 @@ pub enum TokenInstruction {
     /// Mints may be closed if they have the `MintCloseAuthority` extension and their token
     /// supply is zero
     ///
+    /// Note that if the account to close has a `ConfidentialTransferExtension`, the
+    /// `ConfidentialTransferInstruction::EmptyAccount` instruction must precede this
+    /// instruction.
+    ///
     /// Accounts expected by this instruction:
     ///
     ///   * Single owner

--- a/token/program-2022/src/lib.rs
+++ b/token/program-2022/src/lib.rs
@@ -10,7 +10,6 @@ pub mod native_mint;
 pub mod pod;
 pub mod processor;
 pub mod state;
-mod tools;
 
 #[cfg(not(feature = "no-entrypoint"))]
 mod entrypoint;

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -3,7 +3,7 @@
 use crate::{
     error::TokenError,
     extension::{
-        confidential_transfer::{self, ConfidentialTransferState},
+        confidential_transfer::{self, ConfidentialTransferAccount},
         transfer_fee, StateWithExtensionsMut,
     },
     instruction::{is_valid_signer_index, AuthorityType, TokenInstruction, MAX_SIGNERS},
@@ -662,11 +662,9 @@ impl Processor {
         )?;
 
         if let Ok(confidential_transfer_state) =
-            source_account.get_extension_mut::<ConfidentialTransferState>()
+            source_account.get_extension_mut::<ConfidentialTransferAccount>()
         {
-            if !confidential_transfer_state.closable() {
-                return Err(TokenError::ConfidentialTransferStateHasBalance.into());
-            }
+            confidential_transfer_state.closable()?
         }
 
         let dest_starting_lamports = dest_account_info.lamports();
@@ -979,8 +977,20 @@ impl PrintProgramError for TokenError {
             TokenError::ExtensionAlreadyInitialized => {
                 msg!("Error: Extension already initialized on this account")
             }
-            TokenError::ConfidentialTransferStateHasBalance => {
+            TokenError::ConfidentialTransferAccountHasBalance => {
                 msg!("Error: An account can only be closed if its confidential balance is zero")
+            }
+            TokenError::ConfidentialTransferAccountNotApproved => {
+                msg!("Error: Account not approved for confidential transfers")
+            }
+            TokenError::ConfidentialTransferDepositsAndTransfersDisabled => {
+                msg!("Error: Account not accepting deposits or transfers")
+            }
+            TokenError::ConfidentialTransferElGamalPubkeyMismatch => {
+                msg!("Error: ElGamal public key mismatch")
+            }
+            TokenError::ConfidentialTransferAvailableBalanceMismatch => {
+                msg!("Error: Available balance mismatch")
             }
         }
     }

--- a/token/program-2022/src/tools
+++ b/token/program-2022/src/tools
@@ -1,1 +1,0 @@
-../../../associated-token-account/program/src/tools


### PR DESCRIPTION
This brings over the bulk of the zk-token program.  The removal of the omnibus account and the separate zk-token PDA accounts nicely simplified parts of the original code. 

Follow up PRs will include:
* Resolving the TODO around account reallocation in the `ConfigureAccount` instruction
* Bringing over the zk-token unit tests, and likely fixing bugs as a result

cc: #https://github.com/solana-labs/spl-zk-token/issues/91