### PR TITLE
ci: fix `coverage.sh` and guide to run on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ $ cargo install grcov --version 0.6.1
 $ rustup toolchain install nightly-x86_64-apple-darwin
 ```
 
+on Mac M1
+
+```bash
+$ cargo install grcov
+$ rustup toolchain install nightly-aarch64-apple-darwin
+```
+
 
 ## Release Process
 SPL programs are currently tagged and released manually. Each program is

--- a/coverage.sh
+++ b/coverage.sh
@@ -90,6 +90,10 @@ find target/cov -type f -name '*.gcda' -newer target/cov/before-test ! -newer ta
 )
 
 ls -l target/cov/$reportName/index.html
-ln -sfT $reportName target/cov/LATEST
+if [[ $OSTYPE == 'darwin'* ]]; then
+  ln -sf $reportName target/cov/LATEST
+else
+  ln -sfT $reportName target/cov/LATEST
+fi
 
 exit $test_status


### PR DESCRIPTION
- How to run on macOS M1
- fix `coverage.sh` running on macOS (`ln` command on macOS not have `-T` option)

Test result:
![image](https://user-images.githubusercontent.com/535617/149314908-e92811c2-91f7-42de-bd78-4a25f89f3241.png)
![image](https://user-images.githubusercontent.com/535617/149314933-cde2ed89-c430-4cd2-a151-518a6bfc72cc.png)
