### PR TITLE
Add GetAccountDataSize implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3809,6 +3809,7 @@ version = "0.1.0"
 dependencies = [
  "arrayref",
  "bytemuck",
+ "lazy_static",
  "num-derive",
  "num-traits",
  "num_enum",

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -23,6 +23,7 @@ solana-zk-token-sdk = "0.1.0"
 thiserror = "1.0"
 
 [dev-dependencies]
+lazy_static = "1.4.0"
 solana-program-test = "1.9.2"
 solana-sdk = "1.9.2"
 

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -496,6 +496,26 @@ impl ExtensionType {
             ExtensionType::MintPaddingTest => AccountType::Mint,
         }
     }
+
+    /// Get the list of required AccountType::Account ExtensionTypes based on a set of
+    /// AccountType::Mint ExtensionTypes
+    pub fn get_account_extensions(mint_extension_types: &[Self]) -> Vec<Self> {
+        let mut account_extension_types = vec![];
+        for extension_type in mint_extension_types {
+            #[allow(clippy::single_match)]
+            match extension_type {
+                ExtensionType::TransferFeeConfig => {
+                    account_extension_types.push(ExtensionType::TransferFeeAmount);
+                }
+                #[cfg(test)]
+                ExtensionType::MintPaddingTest => {
+                    account_extension_types.push(ExtensionType::AccountPaddingTest);
+                }
+                _ => {}
+            }
+        }
+        account_extension_types
+    }
 }
 
 /// Get the required account data length for the given ExtensionTypes
@@ -516,26 +536,6 @@ pub fn get_account_len(extension_types: &[ExtensionType]) -> usize {
     } else {
         account_size
     }
-}
-
-/// Get the list of required AccountType::Account ExtensionTypes based on a set of
-/// AccountType::Mint ExtensionTypes
-pub fn get_account_extensions(mint_extension_types: &[ExtensionType]) -> Vec<ExtensionType> {
-    let mut account_extension_types = vec![];
-    for extension_type in mint_extension_types {
-        #[allow(clippy::single_match)]
-        match extension_type {
-            ExtensionType::TransferFeeConfig => {
-                account_extension_types.push(ExtensionType::TransferFeeAmount);
-            }
-            #[cfg(test)]
-            ExtensionType::MintPaddingTest => {
-                account_extension_types.push(ExtensionType::AccountPaddingTest);
-            }
-            _ => {}
-        }
-    }
-    account_extension_types
 }
 
 /// Trait for base states, specifying the associated enum
@@ -1129,7 +1129,10 @@ mod test {
             ExtensionType::MintCloseAuthority,
             ExtensionType::Uninitialized,
         ];
-        assert_eq!(get_account_extensions(&mint_extensions), vec![]);
+        assert_eq!(
+            ExtensionType::get_account_extensions(&mint_extensions),
+            vec![]
+        );
 
         // One mint extension with required account extension, one without
         let mint_extensions = vec![
@@ -1137,7 +1140,7 @@ mod test {
             ExtensionType::MintCloseAuthority,
         ];
         assert_eq!(
-            get_account_extensions(&mint_extensions),
+            ExtensionType::get_account_extensions(&mint_extensions),
             vec![ExtensionType::TransferFeeAmount]
         );
 
@@ -1147,7 +1150,7 @@ mod test {
             ExtensionType::MintPaddingTest,
         ];
         assert_eq!(
-            get_account_extensions(&mint_extensions),
+            ExtensionType::get_account_extensions(&mint_extensions),
             vec![
                 ExtensionType::TransferFeeAmount,
                 ExtensionType::AccountPaddingTest
@@ -1160,7 +1163,7 @@ mod test {
             ExtensionType::TransferFeeConfig,
         ];
         assert_eq!(
-            get_account_extensions(&mint_extensions),
+            ExtensionType::get_account_extensions(&mint_extensions),
             vec![
                 ExtensionType::TransferFeeAmount,
                 ExtensionType::TransferFeeAmount

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -1405,6 +1405,19 @@ pub fn sync_native(
     })
 }
 
+/// Creates a `GetAccountDataSize` instruction
+pub fn get_account_data_size(
+    token_program_id: &Pubkey,
+    mint_pubkey: &Pubkey,
+) -> Result<Instruction, ProgramError> {
+    check_program_account(token_program_id)?;
+    Ok(Instruction {
+        program_id: *token_program_id,
+        accounts: vec![AccountMeta::new_readonly(*mint_pubkey, false)],
+        data: TokenInstruction::GetAccountDataSize.pack(),
+    })
+}
+
 /// Utility function that checks index is between MIN_SIGNERS and MAX_SIGNERS
 pub fn is_valid_signer_index(index: usize) -> bool {
     (MIN_SIGNERS..=MAX_SIGNERS).contains(&index)

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -1029,6 +1029,15 @@ mod tests {
     use solana_sdk::account::{
         create_account_for_test, create_is_signer_account_infos, Account as SolanaAccount,
     };
+    use std::sync::{Arc, RwLock};
+
+    lazy_static::lazy_static! {
+        static ref EXPECTED_DATA: Arc<RwLock<Vec<u8>>> = Arc::new(RwLock::new(Vec::new()));
+    }
+
+    fn _set_expected_data(expected_data: Vec<u8>) {
+        *EXPECTED_DATA.write().unwrap() = expected_data;
+    }
 
     struct SyscallStubs {}
     impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
@@ -1061,6 +1070,10 @@ mod tests {
                 *(var_addr as *mut _ as *mut Rent) = Rent::default();
             }
             solana_program::entrypoint::SUCCESS
+        }
+
+        fn sol_set_return_data(&mut self, data: &[u8]) {
+            assert_eq!(&*EXPECTED_DATA.read().unwrap(), data)
         }
     }
 

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -5,8 +5,7 @@ use crate::{
     error::TokenError,
     extension::{
         confidential_transfer::{self, ConfidentialTransferAccount},
-        get_account_extensions, get_account_len, transfer_fee, ExtensionType, StateWithExtensions,
-        StateWithExtensionsMut,
+        get_account_len, transfer_fee, ExtensionType, StateWithExtensions, StateWithExtensionsMut,
     },
     instruction::{is_valid_signer_index, AuthorityType, TokenInstruction, MAX_SIGNERS},
     state::{Account, AccountState, Mint, Multisig},
@@ -774,7 +773,7 @@ impl Processor {
         let state = StateWithExtensions::<Mint>::unpack(&mint_data)?;
         let mint_extensions: Vec<ExtensionType> = state.get_extension_types()?;
 
-        let account_extensions = get_account_extensions(&mint_extensions);
+        let account_extensions = ExtensionType::get_account_extensions(&mint_extensions);
 
         let account_len = get_account_len(&account_extensions);
         set_return_data(&account_len.to_le_bytes());


### PR DESCRIPTION
The ATA program is going to need to know the minimum length of new accounts based on required extensions. This PR plumbs in the GetAccountDataSize instruction for ATA to CPI.

Couple notes:
- `get_account_extensions()` doesn't do any duplicate checking of either input Mint extensions or output Account extensions at the moment. We don't intend to support extensions that can exist in a Mint as duplicate, and currently none of the Mint extensions on the horizon have overlapping Account extension requirements, so I chose to make this helper as simple as possible. But we can update later if either of those predicates turns out to be false.
- the test for `process_get_account_data_size` is not complete, but I think the extension cases will be easier to write once InitializeMint is implemented