### PR TITLE
Use spl-token-2022 in ATA program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3462,7 +3462,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-token 3.2.0",
+ "spl-token-2022",
 ]
 
 [[package]]

--- a/associated-token-account/program/Cargo.toml
+++ b/associated-token-account/program/Cargo.toml
@@ -14,7 +14,7 @@ test-bpf = []
 [dependencies]
 borsh = "0.9.1"
 solana-program = "1.9.2"
-spl-token = { version = "3.2", path = "../../token/program", features = ["no-entrypoint"] }
+spl-token = { version = "0.1", path = "../../token/program-2022", features = ["no-entrypoint"], package = "spl-token-2022" }
 
 [dev-dependencies]
 solana-program-test = "1.9.2"

--- a/associated-token-account/program/tests/process_create_associated_token_account.rs
+++ b/associated-token-account/program/tests/process_create_associated_token_account.rs
@@ -286,7 +286,7 @@ async fn test_create_associated_token_account_using_deprecated_instruction_creat
         get_associated_token_address(&wallet_address, &token_mint_address);
 
     let (mut banks_client, payer, recent_blockhash) =
-        program_test(token_mint_address, false).start().await;
+        program_test(token_mint_address, true).start().await;
     let rent = banks_client.get_rent().await.unwrap();
     let expected_token_account_balance = rent.minimum_balance(spl_token::state::Account::LEN);
 


### PR DESCRIPTION
Very soon we'll want to update the ATA program to create extension-enabled accounts.
Update spl-token dependency to spl-token-2022 to pull in necessary apis, like InitializeAccount and upcoming GetAccountDataSize.