### PR TITLE
token-2022: Basic integration with rust client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3817,6 +3817,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "solana-zk-token-sdk",
+ "spl-token-client",
  "thiserror",
 ]
 
@@ -3853,7 +3854,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-associated-token-account 1.0.3",
- "spl-token 3.2.0",
+ "spl-token-2022",
  "thiserror",
 ]
 

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -26,6 +26,7 @@ thiserror = "1.0"
 lazy_static = "1.4.0"
 solana-program-test = "1.9.2"
 solana-sdk = "1.9.2"
+spl-token-client = { version = "0.0.1", path = "../rust", default-features = false }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -481,7 +481,7 @@ impl ExtensionType {
     }
 
     /// Get the required account data length for the given ExtensionTypes
-    pub fn get_account_len<S: BaseState>(extension_types: &[ExtensionType]) -> usize {
+    pub fn get_account_len<S: BaseState>(extension_types: &[Self]) -> usize {
         if extension_types.is_empty() {
             S::LEN
         } else {

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -480,6 +480,30 @@ impl ExtensionType {
         }
     }
 
+    /// Get the required account data length for the given ExtensionTypes
+    pub fn get_account_len<S: BaseState>(extension_types: &[ExtensionType]) -> usize {
+        if extension_types.is_empty() {
+            S::LEN
+        } else {
+            let extension_size: usize = extension_types
+                .iter()
+                .map(|e| {
+                    e.get_type_len()
+                        .saturating_add(size_of::<ExtensionType>())
+                        .saturating_add(pod_get_packed_len::<Length>())
+                })
+                .sum();
+            let account_size = extension_size
+                .saturating_add(BASE_ACCOUNT_LENGTH)
+                .saturating_add(size_of::<AccountType>());
+            if account_size == Multisig::LEN {
+                account_size.saturating_add(size_of::<ExtensionType>())
+            } else {
+                account_size
+            }
+        }
+    }
+
     /// Get the associated account type
     pub fn get_account_type(&self) -> AccountType {
         match self {
@@ -515,26 +539,6 @@ impl ExtensionType {
             }
         }
         account_extension_types
-    }
-}
-
-/// Get the required account data length for the given ExtensionTypes
-pub fn get_account_len(extension_types: &[ExtensionType]) -> usize {
-    let extension_size: usize = extension_types
-        .iter()
-        .map(|e| {
-            e.get_type_len()
-                .saturating_add(size_of::<ExtensionType>())
-                .saturating_add(pod_get_packed_len::<Length>())
-        })
-        .sum();
-    let account_size = extension_size
-        .saturating_add(BASE_ACCOUNT_LENGTH)
-        .saturating_add(size_of::<AccountType>());
-    if account_size == Multisig::LEN {
-        account_size.saturating_add(size_of::<ExtensionType>())
-    } else {
-        account_size
     }
 }
 
@@ -707,7 +711,7 @@ mod test {
 
     #[test]
     fn mint_with_extension_pack_unpack() {
-        let mint_size = get_account_len(&[
+        let mint_size = ExtensionType::get_account_len::<Mint>(&[
             ExtensionType::MintCloseAuthority,
             ExtensionType::TransferFeeConfig,
         ]);
@@ -868,7 +872,7 @@ mod test {
 
     #[test]
     fn mint_extension_any_order() {
-        let mint_size = get_account_len(&[
+        let mint_size = ExtensionType::get_account_len::<Mint>(&[
             ExtensionType::MintCloseAuthority,
             ExtensionType::TransferFeeConfig,
         ]);
@@ -956,7 +960,7 @@ mod test {
             StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut buffer),
             Err(ProgramError::InvalidAccountData),
         );
-        let mint_size = get_account_len(&[ExtensionType::MintPaddingTest]);
+        let mint_size = ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintPaddingTest]);
         assert_eq!(mint_size, Multisig::LEN + size_of::<ExtensionType>());
         let mut buffer = vec![0; mint_size];
 
@@ -990,7 +994,8 @@ mod test {
 
     #[test]
     fn account_with_extension_pack_unpack() {
-        let account_size = get_account_len(&[ExtensionType::TransferFeeAmount]);
+        let account_size =
+            ExtensionType::get_account_len::<Account>(&[ExtensionType::TransferFeeAmount]);
         let mut buffer = vec![0; account_size];
 
         // fail unpack
@@ -1089,7 +1094,8 @@ mod test {
             StateWithExtensionsMut::<Account>::unpack_uninitialized(&mut buffer),
             Err(ProgramError::InvalidAccountData),
         );
-        let account_size = get_account_len(&[ExtensionType::AccountPaddingTest]);
+        let account_size =
+            ExtensionType::get_account_len::<Account>(&[ExtensionType::AccountPaddingTest]);
         assert_eq!(account_size, Multisig::LEN + size_of::<ExtensionType>());
         let mut buffer = vec![0; account_size];
 
@@ -1169,5 +1175,29 @@ mod test {
                 ExtensionType::TransferFeeAmount
             ]
         );
+    }
+
+    #[test]
+    fn mint_without_extensions() {
+        let space = ExtensionType::get_account_len::<Mint>(&[]);
+        let mut buffer = vec![0; space];
+        assert_eq!(
+            StateWithExtensionsMut::<Account>::unpack_uninitialized(&mut buffer),
+            Err(ProgramError::InvalidAccountData),
+        );
+
+        // write base account
+        let mut state = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut buffer).unwrap();
+        state.base = TEST_MINT;
+        state.pack_base();
+        state.init_account_type().unwrap();
+
+        // fail init extension
+        assert_eq!(
+            state.init_extension::<TransferFeeConfig>(),
+            Err(ProgramError::InvalidAccountData),
+        );
+
+        assert_eq!(TEST_MINT_SLICE, buffer);
     }
 }

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -5,7 +5,7 @@ use crate::{
     error::TokenError,
     extension::{
         confidential_transfer::{self, ConfidentialTransferAccount},
-        get_account_len, transfer_fee, ExtensionType, StateWithExtensions, StateWithExtensionsMut,
+        transfer_fee, ExtensionType, StateWithExtensions, StateWithExtensionsMut,
     },
     instruction::{is_valid_signer_index, AuthorityType, TokenInstruction, MAX_SIGNERS},
     state::{Account, AccountState, Mint, Multisig},
@@ -775,7 +775,7 @@ impl Processor {
 
         let account_extensions = ExtensionType::get_account_extensions(&mint_extensions);
 
-        let account_len = get_account_len(&account_extensions);
+        let account_len = ExtensionType::get_account_len::<Account>(&account_extensions);
         set_return_data(&account_len.to_le_bytes());
 
         Ok(())
@@ -6304,7 +6304,11 @@ mod tests {
         )
         .unwrap();
 
-        set_expected_data(get_account_len(&[]).to_le_bytes().to_vec());
+        set_expected_data(
+            ExtensionType::get_account_len::<Account>(&[])
+                .to_le_bytes()
+                .to_vec(),
+        );
         do_process_instruction(
             get_account_data_size(&program_id, &mint_key).unwrap(),
             vec![&mut mint_account],

--- a/token/program-2022/tests/initialize_mint.rs
+++ b/token/program-2022/tests/initialize_mint.rs
@@ -1,0 +1,60 @@
+#![cfg(feature = "test-bpf")]
+
+mod program_test;
+use {
+    program_test::TestContext,
+    solana_program_test::tokio,
+    solana_sdk::{signature::Signer, signer::keypair::Keypair},
+};
+
+#[tokio::test]
+async fn transfer() {
+    let TestContext {
+        decimals,
+        mint_authority,
+        token,
+        alice,
+        bob,
+        ..
+    } = TestContext::new(&[], &[]).await;
+
+    let alice_vault = Keypair::new();
+    let alice_vault = token
+        .create_auxiliary_token_account(&alice_vault, &alice.pubkey())
+        .await
+        .expect("failed to create associated token account");
+    let bob_vault = Keypair::new();
+    let bob_vault = token
+        .create_auxiliary_token_account(&bob_vault, &bob.pubkey())
+        .await
+        .expect("failed to create associated token account");
+
+    let mint_amount = 10 * u64::pow(10, decimals as u32);
+    token
+        .mint_to(&alice_vault, &mint_authority, mint_amount)
+        .await
+        .expect("failed to mint token");
+
+    let transfer_amount = mint_amount.overflowing_div(3).0;
+    token
+        .transfer_checked(&alice_vault, &bob_vault, &alice, transfer_amount, decimals)
+        .await
+        .expect("failed to transfer");
+
+    assert_eq!(
+        token
+            .get_account_info(alice_vault)
+            .await
+            .expect("failed to get account")
+            .amount,
+        mint_amount - transfer_amount
+    );
+    assert_eq!(
+        token
+            .get_account_info(bob_vault)
+            .await
+            .expect("failed to get account")
+            .amount,
+        transfer_amount
+    );
+}

--- a/token/program-2022/tests/program_test.rs
+++ b/token/program-2022/tests/program_test.rs
@@ -1,0 +1,71 @@
+use {
+    solana_program_test::{processor, tokio::sync::Mutex, ProgramTest},
+    solana_sdk::{
+        instruction::Instruction,
+        signer::{keypair::Keypair, Signer},
+    },
+    spl_token_2022::{extension::ExtensionType, id, processor::Processor},
+    spl_token_client::{
+        client::{ProgramBanksClient, ProgramBanksClientProcessTransaction, ProgramClient},
+        token::Token,
+    },
+    std::sync::Arc,
+};
+
+pub struct TestContext {
+    pub decimals: u8,
+    pub mint_authority: Keypair,
+    pub token: Token<ProgramBanksClientProcessTransaction, Keypair>,
+    pub alice: Keypair,
+    pub bob: Keypair,
+}
+
+impl TestContext {
+    pub async fn new(
+        extension_types: &[ExtensionType],
+        extension_instructions: &[Instruction],
+    ) -> Self {
+        let program_test = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
+        let ctx = program_test.start_with_context().await;
+        let ctx = Arc::new(Mutex::new(ctx));
+
+        let payer = keypair_clone(&ctx.lock().await.payer);
+
+        let client: Arc<dyn ProgramClient<ProgramBanksClientProcessTransaction>> =
+            Arc::new(ProgramBanksClient::new_from_context(
+                Arc::clone(&ctx),
+                ProgramBanksClientProcessTransaction,
+            ));
+
+        let decimals: u8 = 9;
+
+        let mint_account = Keypair::new();
+        let mint_authority = Keypair::new();
+        let mint_authority_pubkey = mint_authority.pubkey();
+
+        let token = Token::create_mint(
+            Arc::clone(&client),
+            payer,
+            &mint_account,
+            &mint_authority_pubkey,
+            None,
+            decimals,
+            extension_types,
+            extension_instructions,
+        )
+        .await
+        .expect("failed to create mint");
+
+        Self {
+            decimals,
+            mint_authority,
+            token,
+            alice: Keypair::new(),
+            bob: Keypair::new(),
+        }
+    }
+}
+
+fn keypair_clone(kp: &Keypair) -> Keypair {
+    Keypair::from_bytes(&kp.to_bytes()).expect("failed to copy keypair")
+}

--- a/token/rust/Cargo.toml
+++ b/token/rust/Cargo.toml
@@ -7,11 +7,16 @@ name = "spl-token-client"
 repository = "https://github.com/solana-labs/solana-program-library"
 version = "0.0.1"
 
+# When spl-token-2022 depends on this with no-entrypoint, all tests fail!
+# Normally, we want no-entrypoint, except when testing spl-token-2022
+[features]
+default = [ "spl-token-2022/no-entrypoint" ]
+
 [dependencies]
 async-trait = "0.1"
 solana-client = "=1.9.2"
 solana-program-test = "=1.9.2"
 solana-sdk = "=1.9.2"
 spl-associated-token-account = { version = "1.0", features = ["no-entrypoint"] }
-spl-token = { version = "3.2", path="../program", features = [ "no-entrypoint" ] }
+spl-token-2022 = { version = "0.1", path="../program-2022" }
 thiserror = "1.0"

--- a/token/rust/src/lib.rs
+++ b/token/rust/src/lib.rs
@@ -1,4 +1,4 @@
 pub mod client;
 pub mod token;
 
-pub use spl_token;
+pub use spl_token_2022;

--- a/token/rust/tests/program-test.rs
+++ b/token/rust/tests/program-test.rs
@@ -6,7 +6,7 @@ use solana_sdk::{
     program_option::COption,
     signer::{keypair::Keypair, Signer},
 };
-use spl_token::{instruction, state};
+use spl_token_2022::{instruction, state};
 use spl_token_client::{
     client::{ProgramBanksClient, ProgramBanksClientProcessTransaction, ProgramClient},
     token::Token,
@@ -49,6 +49,8 @@ impl TestContext {
             &mint_authority_pubkey,
             None,
             decimals,
+            &[],
+            &[],
         )
         .await
         .expect("failed to create mint");
@@ -68,6 +70,9 @@ fn keypair_clone(kp: &Keypair) -> Keypair {
     Keypair::from_bytes(&kp.to_bytes()).expect("failed to copy keypair")
 }
 
+// TODO unignore once spl-token-2022 becomes spl-token, and is included in
+// ProgramTest by default
+#[ignore]
 #[tokio::test]
 async fn associated_token_account() {
     let TestContext { token, alice, .. } = TestContext::new().await;
@@ -100,6 +105,9 @@ async fn associated_token_account() {
     );
 }
 
+// TODO unignore once spl-token-2022 becomes spl-token, and is included in
+// ProgramTest by default
+#[ignore]
 #[tokio::test]
 async fn get_or_create_associated_token_account() {
     let TestContext { token, alice, .. } = TestContext::new().await;
@@ -122,6 +130,9 @@ async fn get_or_create_associated_token_account() {
     );
 }
 
+// TODO unignore once spl-token-2022 becomes spl-token, and is included in
+// ProgramTest by default
+#[ignore]
 #[tokio::test]
 async fn set_authority() {
     let TestContext {
@@ -185,6 +196,9 @@ async fn set_authority() {
     );
 }
 
+// TODO unignore once spl-token-2022 becomes spl-token, and is included in
+// ProgramTest by default
+#[ignore]
 #[tokio::test]
 async fn mint_to() {
     let TestContext {
@@ -216,6 +230,9 @@ async fn mint_to() {
     );
 }
 
+// TODO unignore once spl-token-2022 becomes spl-token, and is included in
+// ProgramTest by default
+#[ignore]
 #[tokio::test]
 async fn transfer() {
     let TestContext {
@@ -244,7 +261,7 @@ async fn transfer() {
 
     let transfer_amount = mint_amount.overflowing_div(3).0;
     token
-        .transfer(&alice_vault, &bob_vault, &alice, transfer_amount)
+        .transfer_checked(&alice_vault, &bob_vault, &alice, transfer_amount, decimals)
         .await
         .expect("failed to transfer");
 


### PR DESCRIPTION
#### Problem

We want to use the rust client to simplify the 2022 tests.

#### Solution

Use it!  A few notes:

* while adding extension support, it borked on the base case of no extensions, so I fixed that up
* the `no-entrypoint` feature took me about an hour of debugging trying to figure out why the program was doing nothing