### PR TITLE
token-2022: Support extensions in InitializeAccount variations

### DIFF
--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -373,6 +373,38 @@ impl<'data, S: BaseState> StateWithExtensionsMut<'data, S> {
         self.init_or_get_extension(true)
     }
 
+    /// Packs the relevant Extension of an ExtensionType into an open slot if not already
+    /// found in the data buffer, otherwise overwrites the Extension
+    pub fn init_extension_from_type(
+        &mut self,
+        extension_type: ExtensionType,
+    ) -> Result<(), ProgramError> {
+        match extension_type {
+            ExtensionType::Uninitialized => Ok(()),
+            ExtensionType::TransferFeeConfig => {
+                self.init_extension::<TransferFeeConfig>().map(|_| ())
+            }
+            ExtensionType::TransferFeeAmount => {
+                self.init_extension::<TransferFeeAmount>().map(|_| ())
+            }
+            ExtensionType::MintCloseAuthority => {
+                self.init_extension::<MintCloseAuthority>().map(|_| ())
+            }
+            ExtensionType::ConfidentialTransferMint => self
+                .init_extension::<ConfidentialTransferMint>()
+                .map(|_| ()),
+            ExtensionType::ConfidentialTransferAccount => self
+                .init_extension::<ConfidentialTransferAccount>()
+                .map(|_| ()),
+            #[cfg(test)]
+            ExtensionType::AccountPaddingTest => {
+                self.init_extension::<AccountPaddingTest>().map(|_| ())
+            }
+            #[cfg(test)]
+            ExtensionType::MintPaddingTest => self.init_extension::<MintPaddingTest>().map(|_| ()),
+        }
+    }
+
     /// Write the account type into the buffer, done during the base
     /// state initialization
     /// Noops if there is no room for an extension in the account, needed for

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -295,7 +295,7 @@ impl<'data, S: BaseState> StateWithExtensionsMut<'data, S> {
         let (base_data, rest) = input.split_at_mut(S::LEN);
         let base = S::unpack_unchecked(base_data)?;
         if base.is_initialized() {
-            return Err(ProgramError::InvalidAccountData);
+            return Err(TokenError::AlreadyInUse.into());
         }
         if let Some((account_type_index, tlv_start_index)) = type_and_tlv_indices::<S>(rest)? {
             let account_type = AccountType::try_from(rest[account_type_index])
@@ -783,7 +783,7 @@ mod test {
         // unpack uninitialized will now fail because the Mint is now initialized
         assert_eq!(
             StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut buffer.clone()),
-            Err(ProgramError::InvalidAccountData),
+            Err(TokenError::AlreadyInUse.into()),
         );
 
         // check unpacking

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -373,26 +373,20 @@ impl<'data, S: BaseState> StateWithExtensionsMut<'data, S> {
         self.init_or_get_extension(true)
     }
 
-    /// Packs the relevant Extension of an ExtensionType into an open slot if not already
-    /// found in the data buffer, otherwise overwrites the Extension
-    pub fn init_extension_from_type(
+    /// If `extension_type` is an Account-associated ExtensionType, this method packs the relevant
+    /// Extension of an ExtensionType into an open slot if not already found in the data buffer,
+    /// otherwise overwrites the Extension. For all other ExtensionTypes, this is a no-op.
+    pub fn init_account_extension_from_type(
         &mut self,
         extension_type: ExtensionType,
     ) -> Result<(), ProgramError> {
+        if extension_type.get_account_type() != AccountType::Account {
+            return Ok(());
+        }
         match extension_type {
-            ExtensionType::Uninitialized => Ok(()),
-            ExtensionType::TransferFeeConfig => {
-                self.init_extension::<TransferFeeConfig>().map(|_| ())
-            }
             ExtensionType::TransferFeeAmount => {
                 self.init_extension::<TransferFeeAmount>().map(|_| ())
             }
-            ExtensionType::MintCloseAuthority => {
-                self.init_extension::<MintCloseAuthority>().map(|_| ())
-            }
-            ExtensionType::ConfidentialTransferMint => self
-                .init_extension::<ConfidentialTransferMint>()
-                .map(|_| ()),
             ExtensionType::ConfidentialTransferAccount => self
                 .init_extension::<ConfidentialTransferAccount>()
                 .map(|_| ()),
@@ -400,8 +394,7 @@ impl<'data, S: BaseState> StateWithExtensionsMut<'data, S> {
             ExtensionType::AccountPaddingTest => {
                 self.init_extension::<AccountPaddingTest>().map(|_| ())
             }
-            #[cfg(test)]
-            ExtensionType::MintPaddingTest => self.init_extension::<MintPaddingTest>().map(|_| ()),
+            _ => unreachable!(),
         }
     }
 

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -368,14 +368,14 @@ impl<'data, S: BaseState> StateWithExtensionsMut<'data, S> {
     }
 
     /// Packs the extension data into an open slot if not already found in the
-    /// data buffer, otherwise overwrites itself
+    /// data buffer
     pub fn init_extension<V: Extension>(&mut self) -> Result<&mut V, ProgramError> {
         self.init_or_get_extension(true)
     }
 
     /// If `extension_type` is an Account-associated ExtensionType, this method packs the relevant
-    /// Extension of an ExtensionType into an open slot if not already found in the data buffer,
-    /// otherwise overwrites the Extension. For all other ExtensionTypes, this is a no-op.
+    /// Extension of an ExtensionType into an open slot if not already found in the data buffer.
+    /// For all other ExtensionTypes, this is a no-op.
     pub fn init_account_extension_from_type(
         &mut self,
         extension_type: ExtensionType,

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -113,6 +113,11 @@ impl Processor {
 
         // get_required_account_extensions checks mint validity
         let required_extensions = Self::get_required_account_extensions(mint_info)?;
+        if ExtensionType::get_account_len::<Account>(&required_extensions)
+            > new_account_info_data_len
+        {
+            return Err(ProgramError::InvalidAccountData);
+        }
         for extension in required_extensions {
             account.init_account_extension_from_type(extension)?;
         }

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -957,7 +957,9 @@ impl Processor {
         let state = StateWithExtensions::<Mint>::unpack(&mint_data)
             .map_err(|_| Into::<ProgramError>::into(TokenError::InvalidMint))?;
         let mint_extensions: Vec<ExtensionType> = state.get_extension_types()?;
-        Ok(ExtensionType::get_account_extensions(&mint_extensions))
+        Ok(ExtensionType::get_required_init_account_extensions(
+            &mint_extensions,
+        ))
     }
 }
 

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -1137,6 +1137,25 @@ mod tests {
         Rent::default().minimum_balance(Multisig::get_packed_len())
     }
 
+    fn native_mint() -> SolanaAccount {
+        let mut rent_sysvar = rent_sysvar();
+        let mut mint_account =
+            SolanaAccount::new(mint_minimum_balance(), Mint::get_packed_len(), &crate::id());
+        do_process_instruction(
+            initialize_mint(
+                &crate::id(),
+                &crate::native_mint::id(),
+                &Pubkey::default(),
+                None,
+                9,
+            )
+            .unwrap(),
+            vec![&mut mint_account, &mut rent_sysvar],
+        )
+        .unwrap();
+        mint_account
+    }
+
     #[test]
     fn test_print_error() {
         let error = return_token_error_as_program_error();
@@ -5355,8 +5374,7 @@ mod tests {
     #[test]
     fn test_native_token() {
         let program_id = crate::id();
-        let mut mint_account =
-            SolanaAccount::new(mint_minimum_balance(), Mint::get_packed_len(), &program_id);
+        let mut mint_account = native_mint();
         let account_key = Pubkey::new_unique();
         let mut account_account = SolanaAccount::new(
             account_minimum_balance() + 40,

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -114,7 +114,7 @@ impl Processor {
         // get_required_account_extensions checks mint validity
         let required_extensions = Self::get_required_account_extensions(mint_info)?;
         for extension in required_extensions {
-            account.init_extension_from_type(extension)?;
+            account.init_account_extension_from_type(extension)?;
         }
 
         account.base.mint = *mint_info.key;

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -114,7 +114,7 @@ impl Processor {
         // get_required_account_extensions checks mint validity
         let required_extensions = Self::get_required_account_extensions(mint_info)?;
         if ExtensionType::get_account_len::<Account>(&required_extensions)
-            > new_account_info_data_len
+            != new_account_info_data_len
         {
             return Err(ProgramError::InvalidAccountData);
         }

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -768,12 +768,7 @@ impl Processor {
         let account_info_iter = &mut accounts.iter();
         let mint_account_info = next_account_info(account_info_iter)?;
 
-        check_program_account(mint_account_info.owner)?;
-        let mint_data = mint_account_info.data.borrow();
-        let state = StateWithExtensions::<Mint>::unpack(&mint_data)?;
-        let mint_extensions: Vec<ExtensionType> = state.get_extension_types()?;
-
-        let account_extensions = ExtensionType::get_account_extensions(&mint_extensions);
+        let account_extensions = Self::get_required_account_extensions(mint_account_info)?;
 
         let account_len = ExtensionType::get_account_len::<Account>(&account_extensions);
         set_return_data(&account_len.to_le_bytes());
@@ -946,6 +941,16 @@ impl Processor {
             return Err(ProgramError::MissingRequiredSignature);
         }
         Ok(())
+    }
+
+    fn get_required_account_extensions(
+        mint_account_info: &AccountInfo,
+    ) -> Result<Vec<ExtensionType>, ProgramError> {
+        check_program_account(mint_account_info.owner)?;
+        let mint_data = mint_account_info.data.borrow();
+        let state = StateWithExtensions::<Mint>::unpack(&mint_data)?;
+        let mint_extensions: Vec<ExtensionType> = state.get_extension_types()?;
+        Ok(ExtensionType::get_account_extensions(&mint_extensions))
     }
 }
 

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -6343,6 +6343,19 @@ mod tests {
         )
         .unwrap();
 
+        // Native mint
+        let mut mint_account = native_mint();
+        set_expected_data(
+            ExtensionType::get_account_len::<Account>(&[])
+                .to_le_bytes()
+                .to_vec(),
+        );
+        do_process_instruction(
+            get_account_data_size(&program_id, &mint_key).unwrap(),
+            vec![&mut mint_account],
+        )
+        .unwrap();
+
         // TODO: Extended mint
 
         // Invalid mint


### PR DESCRIPTION
InitializeAccount variations should initialize extensions required by the mint.
This PR adds that support.

Base and native mint cases are covered by existing test suite. The extended-mint cases still need testing, but I wanted to PR this now because: (a) that testing will be a lot easier when InitializeMint implementations for extensions are done; and (b) I wanted to see what you think of `StateWithExtensionsMut::init_extension_from_type()` and the error-type change in `StateWithExtensionsMut::unpack_uninitialized()` now. Thoughts?