### PR TITLE
token: Add extension support in mint init

### DIFF
--- a/token/program-2022/src/error.rs
+++ b/token/program-2022/src/error.rs
@@ -102,6 +102,9 @@ pub enum TokenError {
     /// Available balance mismatch
     #[error("Available balance mismatch")]
     ConfidentialTransferAvailableBalanceMismatch,
+    /// Mint has non-zero supply. Burn all tokens before closing the mint.
+    #[error("Mint has non-zero supply. Burn all tokens before closing the mint")]
+    MintHasSupply,
 }
 impl From<TokenError> for ProgramError {
     fn from(e: TokenError) -> Self {

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -1418,6 +1418,20 @@ pub fn get_account_data_size(
     })
 }
 
+/// Creates an `InitializeMintCloseAuthority` instruction
+pub fn initialize_mint_close_authority(
+    token_program_id: &Pubkey,
+    mint_pubkey: &Pubkey,
+    close_authority: COption<Pubkey>,
+) -> Result<Instruction, ProgramError> {
+    check_program_account(token_program_id)?;
+    Ok(Instruction {
+        program_id: *token_program_id,
+        accounts: vec![AccountMeta::new(*mint_pubkey, false)],
+        data: TokenInstruction::InitializeMintCloseAuthority { close_authority }.pack(),
+    })
+}
+
 /// Utility function that checks index is between MIN_SIGNERS and MAX_SIGNERS
 pub fn is_valid_signer_index(index: usize) -> bool {
     (MIN_SIGNERS..=MAX_SIGNERS).contains(&index)

--- a/token/program-2022/tests/initialize_mint.rs
+++ b/token/program-2022/tests/initialize_mint.rs
@@ -3,58 +3,415 @@
 mod program_test;
 use {
     program_test::TestContext,
-    solana_program_test::tokio,
-    solana_sdk::{signature::Signer, signer::keypair::Keypair},
+    solana_program_test::{processor, tokio, ProgramTest},
+    solana_sdk::{
+        instruction::InstructionError,
+        program_option::COption,
+        program_pack::Pack,
+        pubkey::Pubkey,
+        signature::Signer,
+        signer::keypair::Keypair,
+        system_instruction,
+        transaction::{Transaction, TransactionError},
+    },
+    spl_token_2022::{
+        error::TokenError,
+        extension::{mint_close_authority::MintCloseAuthority, ExtensionType},
+        id, instruction,
+        processor::Processor,
+        state::Mint,
+    },
+    spl_token_client::token::ExtensionInitializationParams,
+    std::convert::TryInto,
 };
 
 #[tokio::test]
-async fn transfer() {
+async fn success_base() {
     let TestContext {
         decimals,
         mint_authority,
         token,
-        alice,
-        bob,
         ..
-    } = TestContext::new(&[], &[]).await;
+    } = TestContext::new(vec![]).await;
 
-    let alice_vault = Keypair::new();
-    let alice_vault = token
-        .create_auxiliary_token_account(&alice_vault, &alice.pubkey())
-        .await
-        .expect("failed to create associated token account");
-    let bob_vault = Keypair::new();
-    let bob_vault = token
-        .create_auxiliary_token_account(&bob_vault, &bob.pubkey())
-        .await
-        .expect("failed to create associated token account");
-
-    let mint_amount = 10 * u64::pow(10, decimals as u32);
-    token
-        .mint_to(&alice_vault, &mint_authority, mint_amount)
-        .await
-        .expect("failed to mint token");
-
-    let transfer_amount = mint_amount.overflowing_div(3).0;
-    token
-        .transfer_checked(&alice_vault, &bob_vault, &alice, transfer_amount, decimals)
-        .await
-        .expect("failed to transfer");
-
+    let mint = token.get_mint_info().await.unwrap();
+    assert_eq!(mint.base.decimals, decimals);
     assert_eq!(
-        token
-            .get_account_info(alice_vault)
-            .await
-            .expect("failed to get account")
-            .amount,
-        mint_amount - transfer_amount
+        mint.base.mint_authority,
+        COption::Some(mint_authority.pubkey())
     );
+    assert_eq!(mint.base.supply, 0);
+    assert!(mint.base.is_initialized);
+    assert_eq!(mint.base.freeze_authority, COption::None);
+}
+
+#[tokio::test]
+async fn fail_extension_no_space() {
+    let program_test = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
+    let mut ctx = program_test.start_with_context().await;
+    let rent = ctx.banks_client.get_rent().await.unwrap();
+    let mint_account = Keypair::new();
+    let mint_authority_pubkey = Pubkey::new_unique();
+
+    let space = Mint::LEN;
+    let instructions = vec![
+        system_instruction::create_account(
+            &ctx.payer.pubkey(),
+            &mint_account.pubkey(),
+            rent.minimum_balance(space),
+            space as u64,
+            &spl_token_2022::id(),
+        ),
+        instruction::initialize_mint_close_authority(
+            &spl_token_2022::id(),
+            &mint_account.pubkey(),
+            COption::Some(mint_authority_pubkey),
+        )
+        .unwrap(),
+        instruction::initialize_mint(
+            &spl_token_2022::id(),
+            &mint_account.pubkey(),
+            &mint_authority_pubkey,
+            None,
+            9,
+        )
+        .unwrap(),
+    ];
+
+    let tx = Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer, &mint_account],
+        ctx.last_blockhash,
+    );
+    #[allow(clippy::useless_conversion)]
+    let err: TransactionError = ctx
+        .banks_client
+        .process_transaction(tx)
+        .await
+        .unwrap_err()
+        .unwrap()
+        .into();
     assert_eq!(
-        token
-            .get_account_info(bob_vault)
-            .await
-            .expect("failed to get account")
-            .amount,
-        transfer_amount
+        err,
+        TransactionError::InstructionError(1, InstructionError::InvalidAccountData)
+    );
+}
+
+#[tokio::test]
+async fn fail_extension_after_mint_init() {
+    let program_test = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
+    let mut ctx = program_test.start_with_context().await;
+    let rent = ctx.banks_client.get_rent().await.unwrap();
+    let mint_account = Keypair::new();
+    let mint_authority_pubkey = Pubkey::new_unique();
+
+    let space = ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]);
+    let instructions = vec![
+        system_instruction::create_account(
+            &ctx.payer.pubkey(),
+            &mint_account.pubkey(),
+            rent.minimum_balance(space),
+            space as u64,
+            &spl_token_2022::id(),
+        ),
+        instruction::initialize_mint(
+            &spl_token_2022::id(),
+            &mint_account.pubkey(),
+            &mint_authority_pubkey,
+            None,
+            9,
+        )
+        .unwrap(),
+        instruction::initialize_mint_close_authority(
+            &spl_token_2022::id(),
+            &mint_account.pubkey(),
+            COption::Some(mint_authority_pubkey),
+        )
+        .unwrap(),
+    ];
+
+    let tx = Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer, &mint_account],
+        ctx.last_blockhash,
+    );
+    #[allow(clippy::useless_conversion)]
+    let err: TransactionError = ctx
+        .banks_client
+        .process_transaction(tx)
+        .await
+        .unwrap_err()
+        .unwrap()
+        .into();
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(1, InstructionError::InvalidAccountData)
+    );
+}
+
+#[tokio::test]
+async fn success_extension_and_base() {
+    let close_authority = COption::Some(Pubkey::new_unique());
+    let TestContext {
+        decimals,
+        mint_authority,
+        token,
+        ..
+    } = TestContext::new(vec![
+        ExtensionInitializationParams::InitializeMintCloseAuthority {
+            close_authority: close_authority.clone(),
+        },
+    ])
+    .await;
+
+    let state = token.get_mint_info().await.unwrap();
+    assert_eq!(state.base.decimals, decimals);
+    assert_eq!(
+        state.base.mint_authority,
+        COption::Some(mint_authority.pubkey())
+    );
+    assert_eq!(state.base.supply, 0);
+    assert!(state.base.is_initialized);
+    assert_eq!(state.base.freeze_authority, COption::None);
+    let extension = state.get_extension::<MintCloseAuthority>().unwrap();
+    assert_eq!(
+        extension.close_authority,
+        close_authority.try_into().unwrap(),
+    );
+}
+
+#[tokio::test]
+async fn fail_init_overallocated_mint() {
+    let program_test = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
+    let mut ctx = program_test.start_with_context().await;
+    let rent = ctx.banks_client.get_rent().await.unwrap();
+    let mint_account = Keypair::new();
+    let mint_authority_pubkey = Pubkey::new_unique();
+
+    let space = ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]);
+    let instructions = vec![
+        system_instruction::create_account(
+            &ctx.payer.pubkey(),
+            &mint_account.pubkey(),
+            rent.minimum_balance(space),
+            space as u64,
+            &spl_token_2022::id(),
+        ),
+        instruction::initialize_mint(
+            &spl_token_2022::id(),
+            &mint_account.pubkey(),
+            &mint_authority_pubkey,
+            None,
+            9,
+        )
+        .unwrap(),
+    ];
+
+    let tx = Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer, &mint_account],
+        ctx.last_blockhash,
+    );
+    #[allow(clippy::useless_conversion)]
+    let err: TransactionError = ctx
+        .banks_client
+        .process_transaction(tx)
+        .await
+        .unwrap_err()
+        .unwrap()
+        .into();
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(1, InstructionError::InvalidAccountData)
+    );
+}
+
+#[tokio::test]
+async fn fail_account_init_after_mint_extension() {
+    let program_test = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
+    let mut ctx = program_test.start_with_context().await;
+    let rent = ctx.banks_client.get_rent().await.unwrap();
+    let mint_account = Keypair::new();
+    let mint_authority_pubkey = Pubkey::new_unique();
+    let token_account = Keypair::new();
+
+    let mint_space = ExtensionType::get_account_len::<Mint>(&[]);
+    let account_space =
+        ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]);
+    let instructions = vec![
+        system_instruction::create_account(
+            &ctx.payer.pubkey(),
+            &mint_account.pubkey(),
+            rent.minimum_balance(mint_space),
+            mint_space as u64,
+            &spl_token_2022::id(),
+        ),
+        instruction::initialize_mint(
+            &spl_token_2022::id(),
+            &mint_account.pubkey(),
+            &mint_authority_pubkey,
+            None,
+            9,
+        )
+        .unwrap(),
+        system_instruction::create_account(
+            &ctx.payer.pubkey(),
+            &token_account.pubkey(),
+            rent.minimum_balance(account_space),
+            account_space as u64,
+            &spl_token_2022::id(),
+        ),
+        instruction::initialize_mint_close_authority(
+            &spl_token_2022::id(),
+            &token_account.pubkey(),
+            COption::Some(mint_authority_pubkey),
+        )
+        .unwrap(),
+        instruction::initialize_account(
+            &spl_token_2022::id(),
+            &token_account.pubkey(),
+            &mint_account.pubkey(),
+            &mint_authority_pubkey,
+        )
+        .unwrap(),
+    ];
+
+    let tx = Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer, &mint_account, &token_account],
+        ctx.last_blockhash,
+    );
+    #[allow(clippy::useless_conversion)]
+    let err: TransactionError = ctx
+        .banks_client
+        .process_transaction(tx)
+        .await
+        .unwrap_err()
+        .unwrap()
+        .into();
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(
+            4,
+            InstructionError::Custom(TokenError::ExtensionBaseMismatch as u32)
+        )
+    );
+}
+
+#[tokio::test]
+async fn fail_account_init_after_mint_init() {
+    let program_test = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
+    let mut ctx = program_test.start_with_context().await;
+    let rent = ctx.banks_client.get_rent().await.unwrap();
+    let mint_account = Keypair::new();
+    let mint_authority_pubkey = Pubkey::new_unique();
+
+    let mint_space = ExtensionType::get_account_len::<Mint>(&[]);
+    let instructions = vec![
+        system_instruction::create_account(
+            &ctx.payer.pubkey(),
+            &mint_account.pubkey(),
+            rent.minimum_balance(mint_space),
+            mint_space as u64,
+            &spl_token_2022::id(),
+        ),
+        instruction::initialize_mint(
+            &spl_token_2022::id(),
+            &mint_account.pubkey(),
+            &mint_authority_pubkey,
+            None,
+            9,
+        )
+        .unwrap(),
+        instruction::initialize_account(
+            &spl_token_2022::id(),
+            &mint_account.pubkey(),
+            &mint_account.pubkey(),
+            &mint_authority_pubkey,
+        )
+        .unwrap(),
+    ];
+
+    let tx = Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer, &mint_account],
+        ctx.last_blockhash,
+    );
+    #[allow(clippy::useless_conversion)]
+    let err: TransactionError = ctx
+        .banks_client
+        .process_transaction(tx)
+        .await
+        .unwrap_err()
+        .unwrap()
+        .into();
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(2, InstructionError::InvalidAccountData)
+    );
+}
+
+#[tokio::test]
+async fn fail_account_init_after_mint_init_with_extension() {
+    let program_test = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
+    let mut ctx = program_test.start_with_context().await;
+    let rent = ctx.banks_client.get_rent().await.unwrap();
+    let mint_account = Keypair::new();
+    let mint_authority_pubkey = Pubkey::new_unique();
+
+    let mint_space = ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]);
+    let instructions = vec![
+        system_instruction::create_account(
+            &ctx.payer.pubkey(),
+            &mint_account.pubkey(),
+            rent.minimum_balance(mint_space),
+            mint_space as u64,
+            &spl_token_2022::id(),
+        ),
+        instruction::initialize_mint_close_authority(
+            &spl_token_2022::id(),
+            &mint_account.pubkey(),
+            COption::Some(mint_authority_pubkey),
+        )
+        .unwrap(),
+        instruction::initialize_mint(
+            &spl_token_2022::id(),
+            &mint_account.pubkey(),
+            &mint_authority_pubkey,
+            None,
+            9,
+        )
+        .unwrap(),
+        instruction::initialize_account(
+            &spl_token_2022::id(),
+            &mint_account.pubkey(),
+            &mint_account.pubkey(),
+            &mint_authority_pubkey,
+        )
+        .unwrap(),
+    ];
+
+    let tx = Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer, &mint_account],
+        ctx.last_blockhash,
+    );
+    #[allow(clippy::useless_conversion)]
+    let err: TransactionError = ctx
+        .banks_client
+        .process_transaction(tx)
+        .await
+        .unwrap_err()
+        .unwrap()
+        .into();
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(3, InstructionError::InvalidAccountData)
     );
 }

--- a/token/program-2022/tests/program_test.rs
+++ b/token/program-2022/tests/program_test.rs
@@ -1,13 +1,10 @@
 use {
     solana_program_test::{processor, tokio::sync::Mutex, ProgramTest},
-    solana_sdk::{
-        instruction::Instruction,
-        signer::{keypair::Keypair, Signer},
-    },
-    spl_token_2022::{extension::ExtensionType, id, processor::Processor},
+    solana_sdk::signer::{keypair::Keypair, Signer},
+    spl_token_2022::{id, processor::Processor},
     spl_token_client::{
         client::{ProgramBanksClient, ProgramBanksClientProcessTransaction, ProgramClient},
-        token::Token,
+        token::{ExtensionInitializationParams, Token},
     },
     std::sync::Arc,
 };
@@ -21,10 +18,7 @@ pub struct TestContext {
 }
 
 impl TestContext {
-    pub async fn new(
-        extension_types: &[ExtensionType],
-        extension_instructions: &[Instruction],
-    ) -> Self {
+    pub async fn new(extension_init_params: Vec<ExtensionInitializationParams>) -> Self {
         let program_test = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
         let ctx = program_test.start_with_context().await;
         let ctx = Arc::new(Mutex::new(ctx));
@@ -50,8 +44,7 @@ impl TestContext {
             &mint_authority_pubkey,
             None,
             decimals,
-            extension_types,
-            extension_instructions,
+            extension_init_params,
         )
         .await
         .expect("failed to create mint");

--- a/token/rust/tests/program-test.rs
+++ b/token/rust/tests/program-test.rs
@@ -49,8 +49,7 @@ impl TestContext {
             &mint_authority_pubkey,
             None,
             decimals,
-            &[],
-            &[],
+            vec![],
         )
         .await
         .expect("failed to create mint");
@@ -167,7 +166,7 @@ async fn set_authority() {
         .get_mint_info()
         .await
         .expect("failed to get mint info");
-    assert!(mint.mint_authority.is_none());
+    assert!(mint.base.mint_authority.is_none());
 
     // TODO: compare
     // Err(Client(TransactionError(InstructionError(0, Custom(5)))))


### PR DESCRIPTION
#### Problem

People want to initialize mints with extensions

#### Solution

Add that ability.  A few notes from this PR:

* introduces `StateWithExtensionsOwned`, used in testing and client situations, where the TLV data is owned instead of borrowed.  There's some copy-pasta because vec uses `split_off` and slice uses `split_at`
* can initialize a mint close authority
* initialize mint supports extensions
* `ExtensionInitializationParams` for cleaner init!

Edit: Reduced the scope of this to just initialization and tests. The actual support for the mint close authority will come in a separate PR