### PR TITLE
token-2022: overwrite with init_extension using default state

### DIFF
--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -411,16 +411,16 @@ impl<'data, S: BaseState> StateWithExtensionsMut<'data, S> {
         S::pack_into_slice(&self.base, self.base_data);
     }
 
-    /// Packs the extension data into an open slot if not already found in the
-    /// data buffer
+    /// Packs the default extension data into an open slot if not already found in the
+    /// data buffer, otherwise overwrites the existing extension with the default state
     pub fn init_extension<V: Extension>(&mut self) -> Result<&mut V, ProgramError> {
         self.init_or_get_extension(true)
     }
 
     /// If `extension_type` is an Account-associated ExtensionType that requires initialization on
-    /// InitializeAccount, this method packs the relevant Extension of an ExtensionType into an
-    /// open slot if not already found in the data buffer. For all other ExtensionTypes, this is a
-    /// no-op.
+    /// InitializeAccount, this method packs the default relevant Extension of an ExtensionType
+    /// into an open slot if not already found in the data buffer, otherwise overwrites the
+    /// existing extension with the default state. For all other ExtensionTypes, this is a no-op.
     pub fn init_account_extension_from_type(
         &mut self,
         extension_type: ExtensionType,

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -85,12 +85,8 @@ fn get_extension_indices<V: Extension>(
                 start_index = tlv_indices.length_start;
             }
         } else if extension_type == V::TYPE {
-            // found an instance of the extension that we're initializing, abort!
-            if init {
-                return Err(TokenError::ExtensionAlreadyInitialized.into());
-            } else {
-                return Ok(tlv_indices);
-            }
+            // found an instance of the extension that we're initializing, return!
+            return Ok(tlv_indices);
         } else if v_account_type != account_type {
             return Err(TokenError::ExtensionTypeMismatch.into());
         } else {
@@ -394,7 +390,10 @@ impl<'data, S: BaseState> StateWithExtensionsMut<'data, S> {
             *length_ref = Length::try_from(length).unwrap();
 
             let value_end = value_start.saturating_add(length);
-            pod_from_bytes_mut::<V>(&mut self.tlv_data[value_start..value_end])
+            let extension_ref =
+                pod_from_bytes_mut::<V>(&mut self.tlv_data[value_start..value_end])?;
+            *extension_ref = V::default();
+            Ok(extension_ref)
         } else {
             let length = pod_from_bytes::<Length>(&self.tlv_data[length_start..value_start])?;
             let value_end = value_start.saturating_add(usize::from(*length));
@@ -627,7 +626,7 @@ impl BaseState for Mint {
 
 /// Trait to be implemented by all extension states, specifying which extension
 /// and account type they are associated with
-pub trait Extension: Pod {
+pub trait Extension: Pod + Default {
     /// Associated extension type enum, checked at the start of TLV entries
     const TYPE: ExtensionType;
 }
@@ -651,10 +650,20 @@ pub struct MintPaddingTest {
 impl Extension for MintPaddingTest {
     const TYPE: ExtensionType = ExtensionType::MintPaddingTest;
 }
+#[cfg(test)]
+impl Default for MintPaddingTest {
+    fn default() -> Self {
+        Self {
+            padding1: [1; 128],
+            padding2: [2; 48],
+            padding3: [3; 9],
+        }
+    }
+}
 /// Account version of the MintPadding
 #[cfg(test)]
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct AccountPaddingTest(MintPaddingTest);
 #[cfg(test)]
 impl Extension for AccountPaddingTest {
@@ -808,14 +817,6 @@ mod test {
         assert_eq!(
             &state.get_extension_types().unwrap(),
             &[ExtensionType::MintCloseAuthority]
-        );
-
-        // fail init again
-        assert_eq!(
-            state.init_extension::<MintCloseAuthority>(),
-            Err(ProgramError::Custom(
-                TokenError::ExtensionAlreadyInitialized as u32
-            )),
         );
 
         // fail unpack as account, a mint extension was written
@@ -1270,5 +1271,19 @@ mod test {
         );
 
         assert_eq!(TEST_MINT_SLICE, buffer);
+    }
+
+    #[test]
+    fn test_init_nonzero_default() {
+        let mint_size = ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintPaddingTest]);
+        let mut buffer = vec![0; mint_size];
+        let mut state = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut buffer).unwrap();
+        state.base = TEST_MINT;
+        state.pack_base();
+        state.init_account_type().unwrap();
+        let extension = state.init_extension::<MintPaddingTest>().unwrap();
+        assert_eq!(extension.padding1, [1; 128]);
+        assert_eq!(extension.padding2, [2; 48]);
+        assert_eq!(extension.padding3, [3; 9]);
     }
 }


### PR DESCRIPTION
As discussed in this thread https://github.com/solana-labs/solana-program-library/pull/2743#discussion_r785221520, this PR explores overwriting any existing data for an ExtensionType when `init_extension()` is called, using `Type::default()`. This enables future extensions to be initialized with non-zero default data.
@joncinque wdyt?

~~This is still marked as draft because of the `default()` implementation. I think ideally Extension becomes `trait Extension: Pod + Default`, but the ConfidentialTransfer state structs will need to have Default impl first. At a glance, it looks to me like it would be okay to add a `Self::zeroed()` default to each of those structs, but need to confirm with @samkim-crypto~~

(edit) Default implemented upstream, so it is now `trait Extension: Pod + Default` 🎉 