### PR TITLE
Governance: Account creation workaround for existing PDA

### DIFF
--- a/governance/program/tests/process_create_realm.rs
+++ b/governance/program/tests/process_create_realm.rs
@@ -5,7 +5,10 @@ use solana_program_test::*;
 mod program_test;
 
 use program_test::*;
-use spl_governance::state::{enums::MintMaxVoteWeightSource, realm::RealmConfigArgs};
+use spl_governance::state::{
+    enums::MintMaxVoteWeightSource,
+    realm::{get_realm_address, RealmConfigArgs},
+};
 
 #[tokio::test]
 async fn test_create_realm() {
@@ -40,6 +43,27 @@ async fn test_create_realm_with_non_default_config() {
     let realm_cookie = governance_test
         .with_realm_using_config_args(&config_args)
         .await;
+
+    // Assert
+    let realm_account = governance_test
+        .get_realm_account(&realm_cookie.address)
+        .await;
+
+    assert_eq!(realm_cookie.account, realm_account);
+}
+
+#[tokio::test]
+async fn test_create_realm_for_existing_pda() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_name = format!("Realm #{}", governance_test.next_realm_id).to_string();
+    let realm_address = get_realm_address(&governance_test.program_id, &realm_name);
+
+    governance_test.bench.transfer_sol(&realm_address, 1).await;
+
+    // Act
+    let realm_cookie = governance_test.with_realm().await;
 
     // Assert
     let realm_account = governance_test

--- a/governance/test-sdk/src/lib.rs
+++ b/governance/test-sdk/src/lib.rs
@@ -196,6 +196,14 @@ impl ProgramTestBench {
         }
     }
 
+    pub async fn transfer_sol(&mut self, to_account: &Pubkey, lamports: u64) {
+        let transfer_ix = system_instruction::transfer(&self.payer.pubkey(), to_account, lamports);
+
+        self.process_transaction(&[transfer_ix], None)
+            .await
+            .unwrap();
+    }
+
     pub async fn mint_tokens(
         &mut self,
         token_mint: &Pubkey,


### PR DESCRIPTION
#### Summary 

Any `PDA` account can be created by sending `lamports` to it and then it can't be initialised by program using `create_account` instruction any longer. 

#### Solution

Use `allocate/assign` to initialise PDA when it already exists
