### PR TITLE
token-2022: Add mint close authority support everywhere

### DIFF
--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -96,6 +96,7 @@ fn process_configure_account(
     let token_account_info = next_account_info(account_info_iter)?;
     let mint_info = next_account_info(account_info_iter)?;
     let authority_info = next_account_info(account_info_iter)?;
+    let authority_info_len = authority_info.data_len();
 
     check_program_account(token_account_info.owner)?;
     let token_account_data = &mut token_account_info.data.borrow_mut();
@@ -107,9 +108,9 @@ fn process_configure_account(
 
     Processor::validate_owner(
         program_id,
-        token_account_info.key,
         token_account_info.owner,
         authority_info,
+        authority_info_len,
         account_info_iter.as_slice(),
     )?;
 
@@ -195,6 +196,7 @@ fn process_empty_account(
     let token_account_info = next_account_info(account_info_iter)?;
     let instructions_sysvar_info = next_account_info(account_info_iter)?;
     let authority_info = next_account_info(account_info_iter)?;
+    let authority_info_len = authority_info.data_len();
 
     check_program_account(token_account_info.owner)?;
     let token_account_data = &mut token_account_info.data.borrow_mut();
@@ -202,9 +204,9 @@ fn process_empty_account(
 
     Processor::validate_owner(
         program_id,
-        token_account_info.key,
         token_account_info.owner,
         authority_info,
+        authority_info_len,
         account_info_iter.as_slice(),
     )?;
 
@@ -246,6 +248,7 @@ fn process_deposit(
     let receiver_token_account_info = next_account_info(account_info_iter)?;
     let mint_info = next_account_info(account_info_iter)?;
     let authority_info = next_account_info(account_info_iter)?;
+    let authority_info_len = authority_info.data_len();
 
     check_program_account(mint_info.owner)?;
     let mint_data = &mint_info.data.borrow_mut();
@@ -263,9 +266,9 @@ fn process_deposit(
 
         Processor::validate_owner(
             program_id,
-            token_account_info.key,
             token_account_info.owner,
             authority_info,
+            authority_info_len,
             account_info_iter.as_slice(),
         )?;
 
@@ -345,6 +348,7 @@ fn process_withdraw(
     let mint_info = next_account_info(account_info_iter)?;
     let instructions_sysvar_info = next_account_info(account_info_iter)?;
     let authority_info = next_account_info(account_info_iter)?;
+    let authority_info_len = authority_info.data_len();
 
     check_program_account(mint_info.owner)?;
     let mint_data = &mint_info.data.borrow_mut();
@@ -370,9 +374,9 @@ fn process_withdraw(
 
         Processor::validate_owner(
             program_id,
-            token_account_info.key,
             token_account_info.owner,
             authority_info,
+            authority_info_len,
             account_info_iter.as_slice(),
         )?;
 
@@ -446,6 +450,7 @@ fn process_transfer(
     let mint_info = next_account_info(account_info_iter)?;
     let instructions_sysvar_info = next_account_info(account_info_iter)?;
     let authority_info = next_account_info(account_info_iter)?;
+    let authority_info_len = authority_info.data_len();
 
     check_program_account(mint_info.owner)?;
     let mint_data = &mint_info.data.borrow_mut();
@@ -471,9 +476,9 @@ fn process_transfer(
 
         Processor::validate_owner(
             program_id,
-            token_account_info.key,
             token_account_info.owner,
             authority_info,
+            authority_info_len,
             account_info_iter.as_slice(),
         )?;
 
@@ -595,6 +600,7 @@ fn process_apply_pending_balance(
     let account_info_iter = &mut accounts.iter();
     let token_account_info = next_account_info(account_info_iter)?;
     let authority_info = next_account_info(account_info_iter)?;
+    let authority_info_len = authority_info.data_len();
 
     check_program_account(token_account_info.owner)?;
     let token_account_data = &mut token_account_info.data.borrow_mut();
@@ -602,9 +608,9 @@ fn process_apply_pending_balance(
 
     Processor::validate_owner(
         program_id,
-        token_account_info.key,
         token_account_info.owner,
         authority_info,
+        authority_info_len,
         account_info_iter.as_slice(),
     )?;
 
@@ -636,6 +642,7 @@ fn process_allow_balance_credits(
     let account_info_iter = &mut accounts.iter();
     let token_account_info = next_account_info(account_info_iter)?;
     let authority_info = next_account_info(account_info_iter)?;
+    let authority_info_len = authority_info.data_len();
 
     check_program_account(token_account_info.owner)?;
     let token_account_data = &mut token_account_info.data.borrow_mut();
@@ -643,9 +650,9 @@ fn process_allow_balance_credits(
 
     Processor::validate_owner(
         program_id,
-        token_account_info.key,
         token_account_info.owner,
         authority_info,
+        authority_info_len,
         account_info_iter.as_slice(),
     )?;
 

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -96,7 +96,7 @@ fn process_configure_account(
     let token_account_info = next_account_info(account_info_iter)?;
     let mint_info = next_account_info(account_info_iter)?;
     let authority_info = next_account_info(account_info_iter)?;
-    let authority_info_len = authority_info.data_len();
+    let authority_info_data_len = authority_info.data_len();
 
     check_program_account(token_account_info.owner)?;
     let token_account_data = &mut token_account_info.data.borrow_mut();
@@ -110,7 +110,7 @@ fn process_configure_account(
         program_id,
         token_account_info.owner,
         authority_info,
-        authority_info_len,
+        authority_info_data_len,
         account_info_iter.as_slice(),
     )?;
 
@@ -196,7 +196,7 @@ fn process_empty_account(
     let token_account_info = next_account_info(account_info_iter)?;
     let instructions_sysvar_info = next_account_info(account_info_iter)?;
     let authority_info = next_account_info(account_info_iter)?;
-    let authority_info_len = authority_info.data_len();
+    let authority_info_data_len = authority_info.data_len();
 
     check_program_account(token_account_info.owner)?;
     let token_account_data = &mut token_account_info.data.borrow_mut();
@@ -206,7 +206,7 @@ fn process_empty_account(
         program_id,
         token_account_info.owner,
         authority_info,
-        authority_info_len,
+        authority_info_data_len,
         account_info_iter.as_slice(),
     )?;
 
@@ -248,7 +248,7 @@ fn process_deposit(
     let receiver_token_account_info = next_account_info(account_info_iter)?;
     let mint_info = next_account_info(account_info_iter)?;
     let authority_info = next_account_info(account_info_iter)?;
-    let authority_info_len = authority_info.data_len();
+    let authority_info_data_len = authority_info.data_len();
 
     check_program_account(mint_info.owner)?;
     let mint_data = &mint_info.data.borrow_mut();
@@ -268,7 +268,7 @@ fn process_deposit(
             program_id,
             token_account_info.owner,
             authority_info,
-            authority_info_len,
+            authority_info_data_len,
             account_info_iter.as_slice(),
         )?;
 
@@ -348,7 +348,7 @@ fn process_withdraw(
     let mint_info = next_account_info(account_info_iter)?;
     let instructions_sysvar_info = next_account_info(account_info_iter)?;
     let authority_info = next_account_info(account_info_iter)?;
-    let authority_info_len = authority_info.data_len();
+    let authority_info_data_len = authority_info.data_len();
 
     check_program_account(mint_info.owner)?;
     let mint_data = &mint_info.data.borrow_mut();
@@ -376,7 +376,7 @@ fn process_withdraw(
             program_id,
             token_account_info.owner,
             authority_info,
-            authority_info_len,
+            authority_info_data_len,
             account_info_iter.as_slice(),
         )?;
 
@@ -450,7 +450,7 @@ fn process_transfer(
     let mint_info = next_account_info(account_info_iter)?;
     let instructions_sysvar_info = next_account_info(account_info_iter)?;
     let authority_info = next_account_info(account_info_iter)?;
-    let authority_info_len = authority_info.data_len();
+    let authority_info_data_len = authority_info.data_len();
 
     check_program_account(mint_info.owner)?;
     let mint_data = &mint_info.data.borrow_mut();
@@ -478,7 +478,7 @@ fn process_transfer(
             program_id,
             token_account_info.owner,
             authority_info,
-            authority_info_len,
+            authority_info_data_len,
             account_info_iter.as_slice(),
         )?;
 
@@ -600,7 +600,7 @@ fn process_apply_pending_balance(
     let account_info_iter = &mut accounts.iter();
     let token_account_info = next_account_info(account_info_iter)?;
     let authority_info = next_account_info(account_info_iter)?;
-    let authority_info_len = authority_info.data_len();
+    let authority_info_data_len = authority_info.data_len();
 
     check_program_account(token_account_info.owner)?;
     let token_account_data = &mut token_account_info.data.borrow_mut();
@@ -610,7 +610,7 @@ fn process_apply_pending_balance(
         program_id,
         token_account_info.owner,
         authority_info,
-        authority_info_len,
+        authority_info_data_len,
         account_info_iter.as_slice(),
     )?;
 
@@ -642,7 +642,7 @@ fn process_allow_balance_credits(
     let account_info_iter = &mut accounts.iter();
     let token_account_info = next_account_info(account_info_iter)?;
     let authority_info = next_account_info(account_info_iter)?;
-    let authority_info_len = authority_info.data_len();
+    let authority_info_data_len = authority_info.data_len();
 
     check_program_account(token_account_info.owner)?;
     let token_account_data = &mut token_account_info.data.borrow_mut();
@@ -652,7 +652,7 @@ fn process_allow_balance_credits(
         program_id,
         token_account_info.owner,
         authority_info,
-        authority_info_len,
+        authority_info_data_len,
         account_info_iter.as_slice(),
     )?;
 

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -238,6 +238,7 @@ impl Processor {
 
         let dest_account_info = next_account_info(account_info_iter)?;
         let authority_info = next_account_info(account_info_iter)?;
+        let authority_info_len = authority_info.data_len();
 
         let mut source_account = Account::unpack(&source_account_info.data.borrow())?;
         let mut dest_account = Account::unpack(&dest_account_info.data.borrow())?;
@@ -269,9 +270,9 @@ impl Processor {
             COption::Some(ref delegate) if authority_info.key == delegate => {
                 Self::validate_owner(
                     program_id,
-                    source_account_info.key,
                     delegate,
                     authority_info,
+                    authority_info_len,
                     account_info_iter.as_slice(),
                 )?;
                 if source_account.delegated_amount < amount {
@@ -289,9 +290,9 @@ impl Processor {
             }
             _ => Self::validate_owner(
                 program_id,
-                source_account_info.key,
                 &source_account.owner,
                 authority_info,
+                authority_info_len,
                 account_info_iter.as_slice(),
             )?,
         };
@@ -347,6 +348,7 @@ impl Processor {
         };
         let delegate_info = next_account_info(account_info_iter)?;
         let owner_info = next_account_info(account_info_iter)?;
+        let owner_info_len = owner_info.data_len();
 
         let mut source_account = Account::unpack(&source_account_info.data.borrow())?;
 
@@ -367,9 +369,9 @@ impl Processor {
 
         Self::validate_owner(
             program_id,
-            source_account_info.key,
             &source_account.owner,
             owner_info,
+            owner_info_len,
             account_info_iter.as_slice(),
         )?;
 
@@ -385,20 +387,19 @@ impl Processor {
     pub fn process_revoke(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
         let account_info_iter = &mut accounts.iter();
         let source_account_info = next_account_info(account_info_iter)?;
+        let owner_info = next_account_info(account_info_iter)?;
+        let owner_info_len = owner_info.data_len();
 
         let mut source_account = Account::unpack(&source_account_info.data.borrow())?;
-
-        let owner_info = next_account_info(account_info_iter)?;
-
         if source_account.is_frozen() {
             return Err(TokenError::AccountFrozen.into());
         }
 
         Self::validate_owner(
             program_id,
-            source_account_info.key,
             &source_account.owner,
             owner_info,
+            owner_info_len,
             account_info_iter.as_slice(),
         )?;
 
@@ -420,11 +421,11 @@ impl Processor {
         let account_info_iter = &mut accounts.iter();
         let account_info = next_account_info(account_info_iter)?;
         let authority_info = next_account_info(account_info_iter)?;
+        let authority_info_len = authority_info.data_len();
 
-        if account_info.data_len() == Account::get_packed_len() {
-            let mut account = Account::unpack(&account_info.data.borrow())?;
-
-            if account.is_frozen() {
+        let mut account_data = account_info.data.borrow_mut();
+        if let Ok(mut account) = StateWithExtensionsMut::<Account>::unpack(&mut account_data) {
+            if account.base.is_frozen() {
                 return Err(TokenError::AccountFrozen.into());
             }
 
@@ -432,81 +433,96 @@ impl Processor {
                 AuthorityType::AccountOwner => {
                     Self::validate_owner(
                         program_id,
-                        account_info.key,
-                        &account.owner,
+                        &account.base.owner,
                         authority_info,
+                        authority_info_len,
                         account_info_iter.as_slice(),
                     )?;
 
                     if let COption::Some(authority) = new_authority {
-                        account.owner = authority;
+                        account.base.owner = authority;
                     } else {
                         return Err(TokenError::InvalidInstruction.into());
                     }
 
-                    account.delegate = COption::None;
-                    account.delegated_amount = 0;
+                    account.base.delegate = COption::None;
+                    account.base.delegated_amount = 0;
 
-                    if account.is_native() {
-                        account.close_authority = COption::None;
+                    if account.base.is_native() {
+                        account.base.close_authority = COption::None;
                     }
                 }
                 AuthorityType::CloseAccount => {
-                    let authority = account.close_authority.unwrap_or(account.owner);
+                    let authority = account.base.close_authority.unwrap_or(account.base.owner);
                     Self::validate_owner(
                         program_id,
-                        account_info.key,
                         &authority,
                         authority_info,
+                        authority_info_len,
                         account_info_iter.as_slice(),
                     )?;
-                    account.close_authority = new_authority;
+                    account.base.close_authority = new_authority;
                 }
                 _ => {
                     return Err(TokenError::AuthorityTypeNotSupported.into());
                 }
             }
-            Account::pack(account, &mut account_info.data.borrow_mut())?;
-        } else if account_info.data_len() == Mint::get_packed_len() {
-            let mut mint = Mint::unpack(&account_info.data.borrow())?;
+            account.pack_base();
+        } else if let Ok(mut mint) = StateWithExtensionsMut::<Mint>::unpack(&mut account_data) {
             match authority_type {
                 AuthorityType::MintTokens => {
                     // Once a mint's supply is fixed, it cannot be undone by setting a new
                     // mint_authority
                     let mint_authority = mint
+                        .base
                         .mint_authority
                         .ok_or(Into::<ProgramError>::into(TokenError::FixedSupply))?;
                     Self::validate_owner(
                         program_id,
-                        account_info.key,
                         &mint_authority,
                         authority_info,
+                        authority_info_len,
                         account_info_iter.as_slice(),
                     )?;
-                    mint.mint_authority = new_authority;
+                    mint.base.mint_authority = new_authority;
                 }
                 AuthorityType::FreezeAccount => {
                     // Once a mint's freeze authority is disabled, it cannot be re-enabled by
                     // setting a new freeze_authority
                     let freeze_authority = mint
+                        .base
                         .freeze_authority
                         .ok_or(Into::<ProgramError>::into(TokenError::MintCannotFreeze))?;
                     Self::validate_owner(
                         program_id,
-                        account_info.key,
                         &freeze_authority,
                         authority_info,
+                        authority_info_len,
                         account_info_iter.as_slice(),
                     )?;
-                    mint.freeze_authority = new_authority;
+                    mint.base.freeze_authority = new_authority;
+                }
+                AuthorityType::CloseAccount => {
+                    let extension = mint.get_extension_mut::<MintCloseAuthority>()?;
+                    let maybe_close_authority: Option<Pubkey> = extension.close_authority.into();
+                    let close_authority =
+                        maybe_close_authority.ok_or(TokenError::AuthorityTypeNotSupported)?;
+                    Self::validate_owner(
+                        program_id,
+                        &close_authority,
+                        authority_info,
+                        authority_info_len,
+                        account_info_iter.as_slice(),
+                    )?;
+                    extension.close_authority = new_authority.try_into()?;
                 }
                 _ => {
                     return Err(TokenError::AuthorityTypeNotSupported.into());
                 }
             }
-            Mint::pack(mint, &mut account_info.data.borrow_mut())?;
+            mint.pack_base();
         } else {
-            return Err(ProgramError::InvalidArgument);
+            return Err(ProgramError::InvalidAccountData);
         }
 
         Ok(())
@@ -523,49 +539,54 @@ impl Processor {
         let mint_info = next_account_info(account_info_iter)?;
         let dest_account_info = next_account_info(account_info_iter)?;
         let owner_info = next_account_info(account_info_iter)?;
+        let owner_info_len = owner_info.data_len();
 
-        let mut dest_account = Account::unpack(&dest_account_info.data.borrow())?;
-        if dest_account.is_frozen() {
+        let mut dest_account_data = dest_account_info.data.borrow_mut();
+        let mut dest_account = StateWithExtensionsMut::<Account>::unpack(&mut dest_account_data)?;
+        if dest_account.base.is_frozen() {
             return Err(TokenError::AccountFrozen.into());
         }
 
-        if dest_account.is_native() {
+        if dest_account.base.is_native() {
             return Err(TokenError::NativeNotSupported.into());
         }
-        if mint_info.key != &dest_account.mint {
+        if mint_info.key != &dest_account.base.mint {
             return Err(TokenError::MintMismatch.into());
         }
 
-        let mut mint = Mint::unpack(&mint_info.data.borrow())?;
+        let mut mint_data = mint_info.data.borrow_mut();
+        let mut mint = StateWithExtensionsMut::<Mint>::unpack(&mut mint_data)?;
         if let Some(expected_decimals) = expected_decimals {
-            if expected_decimals != mint.decimals {
+            if expected_decimals != mint.base.decimals {
                 return Err(TokenError::MintDecimalsMismatch.into());
             }
         }
 
-        match mint.mint_authority {
+        match mint.base.mint_authority {
             COption::Some(mint_authority) => Self::validate_owner(
                 program_id,
-                mint_info.key,
                 &mint_authority,
                 owner_info,
+                owner_info_len,
                 account_info_iter.as_slice(),
             )?,
             COption::None => return Err(TokenError::FixedSupply.into()),
         }
 
-        dest_account.amount = dest_account
+        dest_account.base.amount = dest_account
+            .base
             .amount
             .checked_add(amount)
             .ok_or(TokenError::Overflow)?;
 
-        mint.supply = mint
+        mint.base.supply = mint
+            .base
             .supply
             .checked_add(amount)
             .ok_or(TokenError::Overflow)?;
 
-        Account::pack(dest_account, &mut dest_account_info.data.borrow_mut())?;
-        Mint::pack(mint, &mut mint_info.data.borrow_mut())?;
+        mint.pack_base();
+        dest_account.pack_base();
 
         Ok(())
     }
@@ -582,6 +603,7 @@ impl Processor {
         let source_account_info = next_account_info(account_info_iter)?;
         let mint_info = next_account_info(account_info_iter)?;
         let authority_info = next_account_info(account_info_iter)?;
+        let authority_info_len = authority_info.data_len();
 
         let mut source_account = Account::unpack(&source_account_info.data.borrow())?;
         let mut mint = Mint::unpack(&mint_info.data.borrow())?;
@@ -609,9 +631,9 @@ impl Processor {
             COption::Some(ref delegate) if authority_info.key == delegate => {
                 Self::validate_owner(
                     program_id,
-                    source_account_info.key,
                     delegate,
                     authority_info,
+                    authority_info_len,
                     account_info_iter.as_slice(),
                 )?;
 
@@ -628,9 +650,9 @@ impl Processor {
             }
             _ => Self::validate_owner(
                 program_id,
-                source_account_info.key,
                 &source_account.owner,
                 authority_info,
+                authority_info_len,
                 account_info_iter.as_slice(),
             )?,
         }
@@ -656,31 +678,55 @@ impl Processor {
         let source_account_info = next_account_info(account_info_iter)?;
         let dest_account_info = next_account_info(account_info_iter)?;
         let authority_info = next_account_info(account_info_iter)?;
+        let authority_info_len = authority_info.data_len();
 
         let mut source_account_data = source_account_info.data.borrow_mut();
-        let mut source_account =
-            StateWithExtensionsMut::<Account>::unpack(&mut source_account_data)?;
-        if !source_account.base.is_native() && source_account.base.amount != 0 {
-            return Err(TokenError::NonNativeHasBalance.into());
-        }
-
-        let authority = source_account
-            .base
-            .close_authority
-            .unwrap_or(source_account.base.owner);
-
-        Self::validate_owner(
-            program_id,
-            source_account_info.key,
-            &authority,
-            authority_info,
-            account_info_iter.as_slice(),
-        )?;
-
-        if let Ok(confidential_transfer_state) =
-            source_account.get_extension_mut::<ConfidentialTransferAccount>()
+        if let Ok(mut source_account) =
+            StateWithExtensionsMut::<Account>::unpack(&mut source_account_data)
         {
-            confidential_transfer_state.closable()?
+            if !source_account.base.is_native() && source_account.base.amount != 0 {
+                return Err(TokenError::NonNativeHasBalance.into());
+            }
+
+            let authority = source_account
+                .base
+                .close_authority
+                .unwrap_or(source_account.base.owner);
+
+            Self::validate_owner(
+                program_id,
+                &authority,
+                authority_info,
+                authority_info_len,
+                account_info_iter.as_slice(),
+            )?;
+
+            if let Ok(confidential_transfer_state) =
+                source_account.get_extension_mut::<ConfidentialTransferAccount>()
+            {
+                confidential_transfer_state.closable()?
+            }
+            source_account.base.amount = 0;
+            source_account.pack_base();
+        } else if let Ok(mut mint) =
+            StateWithExtensionsMut::<Mint>::unpack(&mut source_account_data)
+        {
+            let extension = mint.get_extension_mut::<MintCloseAuthority>()?;
+            let maybe_authority: Option<Pubkey> = extension.close_authority.into();
+            let authority = maybe_authority.ok_or(TokenError::AuthorityTypeNotSupported)?;
+            Self::validate_owner(
+                program_id,
+                &authority,
+                authority_info,
+                authority_info_len,
+                account_info_iter.as_slice(),
+            )?;
+
+            if mint.base.supply != 0 {
+                return Err(TokenError::MintHasSupply.into());
+            }
+        } else {
+            return Err(ProgramError::UninitializedAccount);
         }
 
         let dest_starting_lamports = dest_account_info.lamports();
@@ -689,9 +735,6 @@ impl Processor {
             .ok_or(TokenError::Overflow)?;
 
         **source_account_info.lamports.borrow_mut() = 0;
-        source_account.base.amount = 0;
-
-        source_account.pack_base();
 
         Ok(())
     }
@@ -707,6 +750,7 @@ impl Processor {
         let source_account_info = next_account_info(account_info_iter)?;
         let mint_info = next_account_info(account_info_iter)?;
         let authority_info = next_account_info(account_info_iter)?;
+        let authority_info_len = authority_info.data_len();
 
         let mut source_account = Account::unpack(&source_account_info.data.borrow())?;
         if freeze && source_account.is_frozen() || !freeze && !source_account.is_frozen() {
@@ -723,9 +767,9 @@ impl Processor {
         match mint.freeze_authority {
             COption::Some(authority) => Self::validate_owner(
                 program_id,
-                mint_info.key,
                 &authority,
                 authority_info,
+                authority_info_len,
                 account_info_iter.as_slice(),
             ),
             COption::None => Err(TokenError::MintCannotFreeze.into()),
@@ -923,23 +967,16 @@ impl Processor {
     /// Validates owner(s) are present. Used for Mints and Accounts only.
     pub fn validate_owner(
         program_id: &Pubkey,
-        account_to_validate: &Pubkey,
         expected_owner: &Pubkey,
         owner_account_info: &AccountInfo,
+        owner_account_len: usize,
         signers: &[AccountInfo],
     ) -> ProgramResult {
         if expected_owner != owner_account_info.key {
             return Err(TokenError::OwnerMismatch.into());
         }
-        // If the account is self-owned, it is *not* a multisig, so just check
-        // the signer key. Otherwise we can run into a double-borrow for the
-        // `owner_account_info`
-        if account_to_validate == owner_account_info.key {
-            if !owner_account_info.is_signer {
-                return Err(ProgramError::MissingRequiredSignature);
-            }
-        } else if program_id == owner_account_info.owner
-            && owner_account_info.data_len() == Multisig::get_packed_len()
+
+        if program_id == owner_account_info.owner && owner_account_len == Multisig::get_packed_len()
         {
             let multisig = Multisig::unpack(&owner_account_info.data.borrow())?;
             let mut num_signers = 0;
@@ -3315,7 +3352,7 @@ mod tests {
 
         // invalid account
         assert_eq!(
-            Err(ProgramError::UninitializedAccount),
+            Err(ProgramError::InvalidAccountData),
             do_process_instruction(
                 set_authority(
                     &program_id,
@@ -4894,12 +4931,13 @@ mod tests {
                 false,
                 Epoch::default(),
             );
+            let account_info_len = account_info.data_len();
             let mut borrowed_data = account_info.try_borrow_mut_data().unwrap();
             Processor::validate_owner(
                 &program_id,
                 &account_to_validate,
-                &account_to_validate,
                 &account_info,
+                account_info_len,
                 &[],
             )
             .unwrap();
@@ -4910,9 +4948,9 @@ mod tests {
         // full 11 of 11
         Processor::validate_owner(
             &program_id,
-            &account_to_validate,
             &owner_key,
             &owner_account_info,
+            owner_account_info.data_len(),
             &signers,
         )
         .unwrap();
@@ -4926,9 +4964,9 @@ mod tests {
         }
         Processor::validate_owner(
             &program_id,
-            &account_to_validate,
             &owner_key,
             &owner_account_info,
+            owner_account_info.data_len(),
             &signers,
         )
         .unwrap();
@@ -4945,9 +4983,9 @@ mod tests {
             Err(ProgramError::MissingRequiredSignature),
             Processor::validate_owner(
                 &program_id,
-                &account_to_validate,
                 &owner_key,
                 &owner_account_info,
+                owner_account_info.data_len(),
                 &signers
             )
         );
@@ -4962,9 +5000,9 @@ mod tests {
         }
         Processor::validate_owner(
             &program_id,
-            &account_to_validate,
             &owner_key,
             &owner_account_info,
+            owner_account_info.data_len(),
             &signers,
         )
         .unwrap();
@@ -4981,9 +5019,9 @@ mod tests {
             Err(ProgramError::MissingRequiredSignature),
             Processor::validate_owner(
                 &program_id,
-                &account_to_validate,
                 &owner_key,
                 &owner_account_info,
+                owner_account_info.data_len(),
                 &[]
             )
         );
@@ -4999,9 +5037,9 @@ mod tests {
             Err(ProgramError::MissingRequiredSignature),
             Processor::validate_owner(
                 &program_id,
-                &account_to_validate,
                 &owner_key,
                 &owner_account_info,
+                owner_account_info.data_len(),
                 &signers[0..1]
             )
         );
@@ -5016,9 +5054,9 @@ mod tests {
         }
         Processor::validate_owner(
             &program_id,
-            &account_to_validate,
             &owner_key,
             &owner_account_info,
+            owner_account_info.data_len(),
             &signers[5..7],
         )
         .unwrap();
@@ -5036,9 +5074,9 @@ mod tests {
             Err(ProgramError::MissingRequiredSignature),
             Processor::validate_owner(
                 &program_id,
-                &account_to_validate,
                 &owner_key,
                 &owner_account_info,
+                owner_account_info.data_len(),
                 &signers
             )
         );
@@ -5070,9 +5108,9 @@ mod tests {
                 Err(ProgramError::MissingRequiredSignature),
                 Processor::validate_owner(
                     &program_id,
-                    &account_to_validate,
                     &owner_key,
                     &owner_account_info,
+                    owner_account_info.data_len(),
                     &signers
                 )
             );

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -238,7 +238,7 @@ impl Processor {
 
         let dest_account_info = next_account_info(account_info_iter)?;
         let authority_info = next_account_info(account_info_iter)?;
-        let authority_info_len = authority_info.data_len();
+        let authority_info_data_len = authority_info.data_len();
 
         let mut source_account = Account::unpack(&source_account_info.data.borrow())?;
         let mut dest_account = Account::unpack(&dest_account_info.data.borrow())?;
@@ -272,7 +272,7 @@ impl Processor {
                     program_id,
                     delegate,
                     authority_info,
-                    authority_info_len,
+                    authority_info_data_len,
                     account_info_iter.as_slice(),
                 )?;
                 if source_account.delegated_amount < amount {
@@ -292,7 +292,7 @@ impl Processor {
                 program_id,
                 &source_account.owner,
                 authority_info,
-                authority_info_len,
+                authority_info_data_len,
                 account_info_iter.as_slice(),
             )?,
         };
@@ -348,7 +348,7 @@ impl Processor {
         };
         let delegate_info = next_account_info(account_info_iter)?;
         let owner_info = next_account_info(account_info_iter)?;
-        let owner_info_len = owner_info.data_len();
+        let owner_info_data_len = owner_info.data_len();
 
         let mut source_account = Account::unpack(&source_account_info.data.borrow())?;
 
@@ -371,7 +371,7 @@ impl Processor {
             program_id,
             &source_account.owner,
             owner_info,
-            owner_info_len,
+            owner_info_data_len,
             account_info_iter.as_slice(),
         )?;
 
@@ -388,7 +388,7 @@ impl Processor {
         let account_info_iter = &mut accounts.iter();
         let source_account_info = next_account_info(account_info_iter)?;
         let owner_info = next_account_info(account_info_iter)?;
-        let owner_info_len = owner_info.data_len();
+        let owner_info_data_len = owner_info.data_len();
 
         let mut source_account = Account::unpack(&source_account_info.data.borrow())?;
         if source_account.is_frozen() {
@@ -399,7 +399,7 @@ impl Processor {
             program_id,
             &source_account.owner,
             owner_info,
-            owner_info_len,
+            owner_info_data_len,
             account_info_iter.as_slice(),
         )?;
 
@@ -421,7 +421,7 @@ impl Processor {
         let account_info_iter = &mut accounts.iter();
         let account_info = next_account_info(account_info_iter)?;
         let authority_info = next_account_info(account_info_iter)?;
-        let authority_info_len = authority_info.data_len();
+        let authority_info_data_len = authority_info.data_len();
 
         let mut account_data = account_info.data.borrow_mut();
         if let Ok(mut account) = StateWithExtensionsMut::<Account>::unpack(&mut account_data) {
@@ -435,7 +435,7 @@ impl Processor {
                         program_id,
                         &account.base.owner,
                         authority_info,
-                        authority_info_len,
+                        authority_info_data_len,
                         account_info_iter.as_slice(),
                     )?;
 
@@ -458,7 +458,7 @@ impl Processor {
                         program_id,
                         &authority,
                         authority_info,
-                        authority_info_len,
+                        authority_info_data_len,
                         account_info_iter.as_slice(),
                     )?;
                     account.base.close_authority = new_authority;
@@ -481,10 +481,11 @@ impl Processor {
                         program_id,
                         &mint_authority,
                         authority_info,
-                        authority_info_len,
+                        authority_info_data_len,
                         account_info_iter.as_slice(),
                     )?;
                     mint.base.mint_authority = new_authority;
+                    mint.pack_base();
                 }
                 AuthorityType::FreezeAccount => {
                     // Once a mint's freeze authority is disabled, it cannot be re-enabled by
@@ -497,10 +498,11 @@ impl Processor {
                         program_id,
                         &freeze_authority,
                         authority_info,
-                        authority_info_len,
+                        authority_info_data_len,
                         account_info_iter.as_slice(),
                     )?;
                     mint.base.freeze_authority = new_authority;
+                    mint.pack_base();
                 }
                 AuthorityType::CloseAccount => {
                     let extension = mint.get_extension_mut::<MintCloseAuthority>()?;
@@ -511,7 +513,7 @@ impl Processor {
                         program_id,
                         &close_authority,
                         authority_info,
-                        authority_info_len,
+                        authority_info_data_len,
                         account_info_iter.as_slice(),
                     )?;
                     extension.close_authority = new_authority.try_into()?;
@@ -520,7 +522,6 @@ impl Processor {
                     return Err(TokenError::AuthorityTypeNotSupported.into());
                 }
             }
-            mint.pack_base();
         } else {
             return Err(ProgramError::InvalidAccountData);
         }
@@ -539,7 +540,7 @@ impl Processor {
         let mint_info = next_account_info(account_info_iter)?;
         let dest_account_info = next_account_info(account_info_iter)?;
         let owner_info = next_account_info(account_info_iter)?;
-        let owner_info_len = owner_info.data_len();
+        let owner_info_data_len = owner_info.data_len();
 
         let mut dest_account_data = dest_account_info.data.borrow_mut();
         let mut dest_account = StateWithExtensionsMut::<Account>::unpack(&mut dest_account_data)?;
@@ -567,7 +568,7 @@ impl Processor {
                 program_id,
                 &mint_authority,
                 owner_info,
-                owner_info_len,
+                owner_info_data_len,
                 account_info_iter.as_slice(),
             )?,
             COption::None => return Err(TokenError::FixedSupply.into()),
@@ -603,7 +604,7 @@ impl Processor {
         let source_account_info = next_account_info(account_info_iter)?;
         let mint_info = next_account_info(account_info_iter)?;
         let authority_info = next_account_info(account_info_iter)?;
-        let authority_info_len = authority_info.data_len();
+        let authority_info_data_len = authority_info.data_len();
 
         let mut source_account = Account::unpack(&source_account_info.data.borrow())?;
         let mut mint = Mint::unpack(&mint_info.data.borrow())?;
@@ -633,7 +634,7 @@ impl Processor {
                     program_id,
                     delegate,
                     authority_info,
-                    authority_info_len,
+                    authority_info_data_len,
                     account_info_iter.as_slice(),
                 )?;
 
@@ -652,7 +653,7 @@ impl Processor {
                 program_id,
                 &source_account.owner,
                 authority_info,
-                authority_info_len,
+                authority_info_data_len,
                 account_info_iter.as_slice(),
             )?,
         }
@@ -678,7 +679,7 @@ impl Processor {
         let source_account_info = next_account_info(account_info_iter)?;
         let dest_account_info = next_account_info(account_info_iter)?;
         let authority_info = next_account_info(account_info_iter)?;
-        let authority_info_len = authority_info.data_len();
+        let authority_info_data_len = authority_info.data_len();
 
         let mut source_account_data = source_account_info.data.borrow_mut();
         if let Ok(mut source_account) =
@@ -697,7 +698,7 @@ impl Processor {
                 program_id,
                 &authority,
                 authority_info,
-                authority_info_len,
+                authority_info_data_len,
                 account_info_iter.as_slice(),
             )?;
 
@@ -718,7 +719,7 @@ impl Processor {
                 program_id,
                 &authority,
                 authority_info,
-                authority_info_len,
+                authority_info_data_len,
                 account_info_iter.as_slice(),
             )?;
 
@@ -750,7 +751,7 @@ impl Processor {
         let source_account_info = next_account_info(account_info_iter)?;
         let mint_info = next_account_info(account_info_iter)?;
         let authority_info = next_account_info(account_info_iter)?;
-        let authority_info_len = authority_info.data_len();
+        let authority_info_data_len = authority_info.data_len();
 
         let mut source_account = Account::unpack(&source_account_info.data.borrow())?;
         if freeze && source_account.is_frozen() || !freeze && !source_account.is_frozen() {
@@ -769,7 +770,7 @@ impl Processor {
                 program_id,
                 &authority,
                 authority_info,
-                authority_info_len,
+                authority_info_data_len,
                 account_info_iter.as_slice(),
             ),
             COption::None => Err(TokenError::MintCannotFreeze.into()),
@@ -969,14 +970,15 @@ impl Processor {
         program_id: &Pubkey,
         expected_owner: &Pubkey,
         owner_account_info: &AccountInfo,
-        owner_account_len: usize,
+        owner_account_data_len: usize,
         signers: &[AccountInfo],
     ) -> ProgramResult {
         if expected_owner != owner_account_info.key {
             return Err(TokenError::OwnerMismatch.into());
         }
 
-        if program_id == owner_account_info.owner && owner_account_len == Multisig::get_packed_len()
+        if program_id == owner_account_info.owner
+            && owner_account_data_len == Multisig::get_packed_len()
         {
             let multisig = Multisig::unpack(&owner_account_info.data.borrow())?;
             let mut num_signers = 0;
@@ -4931,13 +4933,13 @@ mod tests {
                 false,
                 Epoch::default(),
             );
-            let account_info_len = account_info.data_len();
+            let account_info_data_len = account_info.data_len();
             let mut borrowed_data = account_info.try_borrow_mut_data().unwrap();
             Processor::validate_owner(
                 &program_id,
                 &account_to_validate,
                 &account_info,
-                account_info_len,
+                account_info_data_len,
                 &[],
             )
             .unwrap();

--- a/token/program-2022/tests/mint_close_authority.rs
+++ b/token/program-2022/tests/mint_close_authority.rs
@@ -1,0 +1,246 @@
+#![cfg(feature = "test-bpf")]
+
+mod program_test;
+use {
+    program_test::TestContext,
+    solana_program_test::tokio,
+    solana_sdk::{
+        instruction::InstructionError, program_option::COption, pubkey::Pubkey, signature::Signer,
+        signer::keypair::Keypair, transaction::TransactionError, transport::TransportError,
+    },
+    spl_token_2022::{
+        error::TokenError, extension::mint_close_authority::MintCloseAuthority, instruction,
+    },
+    spl_token_client::token::{ExtensionInitializationParams, TokenError as TokenClientError},
+    std::convert::TryInto,
+};
+
+#[tokio::test]
+async fn success_init() {
+    let close_authority = COption::Some(Pubkey::new_unique());
+    let TestContext {
+        decimals,
+        mint_authority,
+        token,
+        ..
+    } = TestContext::new(vec![
+        ExtensionInitializationParams::InitializeMintCloseAuthority {
+            close_authority: close_authority.clone(),
+        },
+    ])
+    .await;
+
+    let state = token.get_mint_info().await.unwrap();
+    assert_eq!(state.base.decimals, decimals);
+    assert_eq!(
+        state.base.mint_authority,
+        COption::Some(mint_authority.pubkey())
+    );
+    assert_eq!(state.base.supply, 0);
+    assert!(state.base.is_initialized);
+    assert_eq!(state.base.freeze_authority, COption::None);
+    let extension = state.get_extension::<MintCloseAuthority>().unwrap();
+    assert_eq!(
+        extension.close_authority,
+        close_authority.try_into().unwrap(),
+    );
+}
+
+#[tokio::test]
+async fn set_authority() {
+    let close_authority = Keypair::new();
+    let TestContext { token, .. } = TestContext::new(vec![
+        ExtensionInitializationParams::InitializeMintCloseAuthority {
+            close_authority: COption::Some(close_authority.pubkey()),
+        },
+    ])
+    .await;
+    let new_authority = Keypair::new();
+
+    // fail, wrong signature
+    let wrong = Keypair::new();
+    let err = token
+        .set_authority(
+            token.get_address(),
+            Some(&new_authority.pubkey()),
+            instruction::AuthorityType::CloseAccount,
+            &wrong,
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::OwnerMismatch as u32)
+            )
+        )))
+    );
+
+    // success
+    token
+        .set_authority(
+            token.get_address(),
+            Some(&new_authority.pubkey()),
+            instruction::AuthorityType::CloseAccount,
+            &close_authority,
+        )
+        .await
+        .unwrap();
+    let state = token.get_mint_info().await.unwrap();
+    let extension = state.get_extension::<MintCloseAuthority>().unwrap();
+    assert_eq!(
+        extension.close_authority,
+        Some(new_authority.pubkey()).try_into().unwrap(),
+    );
+
+    // set to none
+    token
+        .set_authority(
+            token.get_address(),
+            None,
+            instruction::AuthorityType::CloseAccount,
+            &new_authority,
+        )
+        .await
+        .unwrap();
+    let state = token.get_mint_info().await.unwrap();
+    let extension = state.get_extension::<MintCloseAuthority>().unwrap();
+    assert_eq!(extension.close_authority, None.try_into().unwrap(),);
+
+    // fail set again
+    let err = token
+        .set_authority(
+            token.get_address(),
+            Some(&close_authority.pubkey()),
+            instruction::AuthorityType::CloseAccount,
+            &new_authority,
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::AuthorityTypeNotSupported as u32)
+            )
+        )))
+    );
+
+    // fail close
+    let destination = Pubkey::new_unique();
+    let err = token
+        .close_account(token.get_address(), &destination, &new_authority)
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::AuthorityTypeNotSupported as u32)
+            )
+        )))
+    );
+}
+
+#[tokio::test]
+async fn success_close() {
+    let close_authority = Keypair::new();
+    let TestContext { token, .. } = TestContext::new(vec![
+        ExtensionInitializationParams::InitializeMintCloseAuthority {
+            close_authority: COption::Some(close_authority.pubkey()),
+        },
+    ])
+    .await;
+
+    let destination = Pubkey::new_unique();
+    token
+        .close_account(token.get_address(), &destination, &close_authority)
+        .await
+        .unwrap();
+    let destination = token.get_account(destination).await.unwrap();
+    assert!(destination.lamports > 0);
+}
+
+#[tokio::test]
+async fn fail_without_extension() {
+    let close_authority = Pubkey::new_unique();
+    let TestContext {
+        mint_authority,
+        token,
+        ..
+    } = TestContext::new(vec![]).await;
+
+    // fail set
+    let err = token
+        .set_authority(
+            token.get_address(),
+            Some(&close_authority),
+            instruction::AuthorityType::CloseAccount,
+            &mint_authority,
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(0, InstructionError::InvalidAccountData)
+        )))
+    );
+
+    // fail close
+    let destination = Pubkey::new_unique();
+    let err = token
+        .close_account(token.get_address(), &destination, &mint_authority)
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(0, InstructionError::InvalidAccountData)
+        )))
+    );
+}
+
+#[tokio::test]
+async fn fail_close_with_supply() {
+    let close_authority = Keypair::new();
+    let TestContext {
+        token,
+        mint_authority,
+        ..
+    } = TestContext::new(vec![
+        ExtensionInitializationParams::InitializeMintCloseAuthority {
+            close_authority: COption::Some(close_authority.pubkey()),
+        },
+    ])
+    .await;
+
+    // mint a token
+    let owner = Pubkey::new_unique();
+    let account = Keypair::new();
+    let account = token
+        .create_auxiliary_token_account(&account, &owner)
+        .await
+        .unwrap();
+    token.mint_to(&account, &mint_authority, 1).await.unwrap();
+
+    // fail close
+    let destination = Pubkey::new_unique();
+    let err = token
+        .close_account(token.get_address(), &destination, &close_authority)
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::MintHasSupply as u32)
+            )
+        )))
+    );
+}


### PR DESCRIPTION
Builds on #2744 , only need to look at 4904516a82545afb7900b5c5b741e5834ab87ef8

#### Problem

The mint close authority must be properly supported in `set_authority` and `close_account`.

#### Solution

Add the support.

Also, update `validate_owner` to accept the data length from the outside, since there were still double-borrow issues.  Now, we pull out the data length right at the beginning, and use that later to see if the authority account is a multisig.  Thankfully, if the authority is a multisig, then it *can't* be used for anything else in processing logic, meaning all double-borrows are avoided.