### PR TITLE
token-2022: Add init transfer fee config

### DIFF
--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -906,7 +906,7 @@ mod test {
         let new_extension = state.init_extension::<TransferFeeConfig>().unwrap();
         new_extension.transfer_fee_config_authority =
             mint_transfer_fee.transfer_fee_config_authority;
-        new_extension.withheld_withdraw_authority = mint_transfer_fee.withheld_withdraw_authority;
+        new_extension.withdraw_withheld_authority = mint_transfer_fee.withdraw_withheld_authority;
         new_extension.withheld_amount = mint_transfer_fee.withheld_amount;
         new_extension.older_transfer_fee = mint_transfer_fee.older_transfer_fee;
         new_extension.newer_transfer_fee = mint_transfer_fee.newer_transfer_fee;
@@ -958,7 +958,7 @@ mod test {
         let mint_transfer_fee = test_transfer_fee_config();
         let extension = state.init_extension::<TransferFeeConfig>().unwrap();
         extension.transfer_fee_config_authority = mint_transfer_fee.transfer_fee_config_authority;
-        extension.withheld_withdraw_authority = mint_transfer_fee.withheld_withdraw_authority;
+        extension.withdraw_withheld_authority = mint_transfer_fee.withdraw_withheld_authority;
         extension.withheld_amount = mint_transfer_fee.withheld_amount;
         extension.older_transfer_fee = mint_transfer_fee.older_transfer_fee;
         extension.newer_transfer_fee = mint_transfer_fee.newer_transfer_fee;
@@ -990,7 +990,7 @@ mod test {
         let mint_transfer_fee = test_transfer_fee_config();
         let extension = state.init_extension::<TransferFeeConfig>().unwrap();
         extension.transfer_fee_config_authority = mint_transfer_fee.transfer_fee_config_authority;
-        extension.withheld_withdraw_authority = mint_transfer_fee.withheld_withdraw_authority;
+        extension.withdraw_withheld_authority = mint_transfer_fee.withdraw_withheld_authority;
         extension.withheld_amount = mint_transfer_fee.withheld_amount;
         extension.older_transfer_fee = mint_transfer_fee.older_transfer_fee;
         extension.newer_transfer_fee = mint_transfer_fee.newer_transfer_fee;

--- a/token/program-2022/src/extension/transfer_fee/instruction.rs
+++ b/token/program-2022/src/extension/transfer_fee/instruction.rs
@@ -27,7 +27,7 @@ pub enum TransferFeeInstruction {
     ///   0. `[writable]` The mint to initialize.
     InitializeTransferFeeConfig {
         /// Pubkey that may update the fees
-        fee_config_authority: COption<Pubkey>,
+        transfer_fee_config_authority: COption<Pubkey>,
         /// Withdraw instructions must be signed by this key
         withdraw_withheld_authority: COption<Pubkey>,
         /// Amount of transfer collected as fees, expressed as basis points of the
@@ -137,7 +137,8 @@ impl TransferFeeInstruction {
         let (&tag, rest) = input.split_first().ok_or(InvalidInstruction)?;
         Ok(match tag {
             0 => {
-                let (fee_config_authority, rest) = TokenInstruction::unpack_pubkey_option(rest)?;
+                let (transfer_fee_config_authority, rest) =
+                    TokenInstruction::unpack_pubkey_option(rest)?;
                 let (withdraw_withheld_authority, rest) =
                     TokenInstruction::unpack_pubkey_option(rest)?;
                 let (transfer_fee_basis_points, rest) = rest.split_at(2);
@@ -153,7 +154,7 @@ impl TransferFeeInstruction {
                     .map(u64::from_le_bytes)
                     .ok_or(InvalidInstruction)?;
                 let instruction = Self::InitializeTransferFeeConfig {
-                    fee_config_authority,
+                    transfer_fee_config_authority,
                     withdraw_withheld_authority,
                     transfer_fee_basis_points,
                     maximum_fee,
@@ -211,13 +212,13 @@ impl TransferFeeInstruction {
     pub fn pack(&self, buffer: &mut Vec<u8>) {
         match *self {
             Self::InitializeTransferFeeConfig {
-                ref fee_config_authority,
+                ref transfer_fee_config_authority,
                 ref withdraw_withheld_authority,
                 transfer_fee_basis_points,
                 maximum_fee,
             } => {
                 buffer.push(0);
-                TokenInstruction::pack_pubkey_option(fee_config_authority, buffer);
+                TokenInstruction::pack_pubkey_option(transfer_fee_config_authority, buffer);
                 TokenInstruction::pack_pubkey_option(withdraw_withheld_authority, buffer);
                 buffer.extend_from_slice(&transfer_fee_basis_points.to_le_bytes());
                 buffer.extend_from_slice(&maximum_fee.to_le_bytes());
@@ -256,14 +257,14 @@ impl TransferFeeInstruction {
 /// Create a `InitializeTransferFeeConfig` instruction
 pub fn initialize_transfer_fee_config(
     mint: Pubkey,
-    fee_config_authority: COption<Pubkey>,
+    transfer_fee_config_authority: COption<Pubkey>,
     withdraw_withheld_authority: COption<Pubkey>,
     transfer_fee_basis_points: u16,
     maximum_fee: u64,
 ) -> Instruction {
     let data = TokenInstruction::TransferFeeExtension(
         TransferFeeInstruction::InitializeTransferFeeConfig {
-            fee_config_authority,
+            transfer_fee_config_authority,
             withdraw_withheld_authority,
             transfer_fee_basis_points,
             maximum_fee,
@@ -419,7 +420,7 @@ mod test {
     fn test_instruction_packing() {
         let check = TokenInstruction::TransferFeeExtension(
             TransferFeeInstruction::InitializeTransferFeeConfig {
-                fee_config_authority: COption::Some(Pubkey::new(&[11u8; 32])),
+                transfer_fee_config_authority: COption::Some(Pubkey::new(&[11u8; 32])),
                 withdraw_withheld_authority: COption::None,
                 transfer_fee_basis_points: 111,
                 maximum_fee: u64::MAX,

--- a/token/program-2022/src/extension/transfer_fee/mod.rs
+++ b/token/program-2022/src/extension/transfer_fee/mod.rs
@@ -32,7 +32,7 @@ pub struct TransferFeeConfig {
     /// Optional authority to set the fee
     pub transfer_fee_config_authority: OptionalNonZeroPubkey,
     /// Withdraw from mint instructions must be signed by this key
-    pub withheld_withdraw_authority: OptionalNonZeroPubkey,
+    pub withdraw_withheld_authority: OptionalNonZeroPubkey,
     /// Withheld transfer fee tokens that have been moved to the mint for withdrawal
     pub withheld_amount: PodU64,
     /// Older transfer fee, used if the current epoch < new_transfer_fee.epoch
@@ -65,7 +65,7 @@ pub(crate) mod test {
                 &[10; 32],
             )))
             .unwrap(),
-            withheld_withdraw_authority: OptionalNonZeroPubkey::try_from(Some(Pubkey::new(
+            withdraw_withheld_authority: OptionalNonZeroPubkey::try_from(Some(Pubkey::new(
                 &[11; 32],
             )))
             .unwrap(),

--- a/token/program-2022/src/extension/transfer_fee/processor.rs
+++ b/token/program-2022/src/extension/transfer_fee/processor.rs
@@ -1,19 +1,51 @@
 use {
-    crate::{check_program_account, extension::transfer_fee::instruction::TransferFeeInstruction},
-    solana_program::{
-        account_info::AccountInfo, entrypoint::ProgramResult, program_option::COption,
-        pubkey::Pubkey,
+    crate::{
+        check_program_account,
+        extension::{
+            transfer_fee::{instruction::TransferFeeInstruction, TransferFee, TransferFeeConfig},
+            StateWithExtensionsMut,
+        },
+        state::Mint,
     },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        clock::Clock,
+        entrypoint::ProgramResult,
+        program_option::COption,
+        pubkey::Pubkey,
+        sysvar::Sysvar,
+    },
+    std::convert::TryInto,
 };
 
 fn process_initialize_transfer_fee_config(
-    _accounts: &[AccountInfo],
-    _fee_config_authority: COption<Pubkey>,
-    _withdraw_withheld_authority: COption<Pubkey>,
-    _transfer_fee_basis_points: u16,
-    _maximum_fee: u64,
+    accounts: &[AccountInfo],
+    transfer_fee_config_authority: COption<Pubkey>,
+    withdraw_withheld_authority: COption<Pubkey>,
+    transfer_fee_basis_points: u16,
+    maximum_fee: u64,
 ) -> ProgramResult {
-    unimplemented!();
+    let account_info_iter = &mut accounts.iter();
+    let mint_account_info = next_account_info(account_info_iter)?;
+
+    let mut mint_data = mint_account_info.data.borrow_mut();
+    let mut mint = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut mint_data)?;
+    let extension = mint.init_extension::<TransferFeeConfig>()?;
+    extension.transfer_fee_config_authority = transfer_fee_config_authority.try_into()?;
+    extension.withdraw_withheld_authority = withdraw_withheld_authority.try_into()?;
+    extension.withheld_amount = 0u64.into();
+    // To be safe, set newer and older transfer fees to the same thing on init,
+    // but only newer will actually be used
+    let epoch = Clock::get()?.epoch;
+    let transfer_fee = TransferFee {
+        epoch: epoch.into(),
+        transfer_fee_basis_points: transfer_fee_basis_points.into(),
+        maximum_fee: maximum_fee.into(),
+    };
+    extension.older_transfer_fee = transfer_fee;
+    extension.newer_transfer_fee = transfer_fee;
+
+    Ok(())
 }
 
 pub(crate) fn process_instruction(
@@ -25,13 +57,13 @@ pub(crate) fn process_instruction(
 
     match instruction {
         TransferFeeInstruction::InitializeTransferFeeConfig {
-            fee_config_authority,
+            transfer_fee_config_authority,
             withdraw_withheld_authority,
             transfer_fee_basis_points,
             maximum_fee,
         } => process_initialize_transfer_fee_config(
             accounts,
-            fee_config_authority,
+            transfer_fee_config_authority,
             withdraw_withheld_authority,
             transfer_fee_basis_points,
             maximum_fee,

--- a/token/program-2022/src/pod.rs
+++ b/token/program-2022/src/pod.rs
@@ -41,11 +41,20 @@ impl TryFrom<COption<Pubkey>> for OptionalNonZeroPubkey {
     }
 }
 impl From<OptionalNonZeroPubkey> for Option<Pubkey> {
-    fn from(p: OptionalNonZeroPubkey) -> Option<Pubkey> {
+    fn from(p: OptionalNonZeroPubkey) -> Self {
         if p.0 == Pubkey::default() {
             None
         } else {
             Some(p.0)
+        }
+    }
+}
+impl From<OptionalNonZeroPubkey> for COption<Pubkey> {
+    fn from(p: OptionalNonZeroPubkey) -> Self {
+        if p.0 == Pubkey::default() {
+            COption::None
+        } else {
+            COption::Some(p.0)
         }
     }
 }

--- a/token/program-2022/tests/mint_close_authority.rs
+++ b/token/program-2022/tests/mint_close_authority.rs
@@ -23,12 +23,11 @@ async fn success_init() {
         mint_authority,
         token,
         ..
-    } = TestContext::new(vec![
-        ExtensionInitializationParams::InitializeMintCloseAuthority {
-            close_authority: close_authority.clone(),
-        },
-    ])
-    .await;
+    } = TestContext::new(vec![ExtensionInitializationParams::MintCloseAuthority {
+        close_authority: close_authority.clone(),
+    }])
+    .await
+    .unwrap();
 
     let state = token.get_mint_info().await.unwrap();
     assert_eq!(state.base.decimals, decimals);
@@ -49,12 +48,12 @@ async fn success_init() {
 #[tokio::test]
 async fn set_authority() {
     let close_authority = Keypair::new();
-    let TestContext { token, .. } = TestContext::new(vec![
-        ExtensionInitializationParams::InitializeMintCloseAuthority {
+    let TestContext { token, .. } =
+        TestContext::new(vec![ExtensionInitializationParams::MintCloseAuthority {
             close_authority: COption::Some(close_authority.pubkey()),
-        },
-    ])
-    .await;
+        }])
+        .await
+        .unwrap();
     let new_authority = Keypair::new();
 
     // fail, wrong signature
@@ -149,12 +148,12 @@ async fn set_authority() {
 #[tokio::test]
 async fn success_close() {
     let close_authority = Keypair::new();
-    let TestContext { token, .. } = TestContext::new(vec![
-        ExtensionInitializationParams::InitializeMintCloseAuthority {
+    let TestContext { token, .. } =
+        TestContext::new(vec![ExtensionInitializationParams::MintCloseAuthority {
             close_authority: COption::Some(close_authority.pubkey()),
-        },
-    ])
-    .await;
+        }])
+        .await
+        .unwrap();
 
     let destination = Pubkey::new_unique();
     token
@@ -172,7 +171,7 @@ async fn fail_without_extension() {
         mint_authority,
         token,
         ..
-    } = TestContext::new(vec![]).await;
+    } = TestContext::new(vec![]).await.unwrap();
 
     // fail set
     let err = token
@@ -212,12 +211,11 @@ async fn fail_close_with_supply() {
         token,
         mint_authority,
         ..
-    } = TestContext::new(vec![
-        ExtensionInitializationParams::InitializeMintCloseAuthority {
-            close_authority: COption::Some(close_authority.pubkey()),
-        },
-    ])
-    .await;
+    } = TestContext::new(vec![ExtensionInitializationParams::MintCloseAuthority {
+        close_authority: COption::Some(close_authority.pubkey()),
+    }])
+    .await
+    .unwrap();
 
     // mint a token
     let owner = Pubkey::new_unique();

--- a/token/program-2022/tests/program_test.rs
+++ b/token/program-2022/tests/program_test.rs
@@ -4,11 +4,12 @@ use {
     spl_token_2022::{id, processor::Processor},
     spl_token_client::{
         client::{ProgramBanksClient, ProgramBanksClientProcessTransaction, ProgramClient},
-        token::{ExtensionInitializationParams, Token},
+        token::{ExtensionInitializationParams, Token, TokenResult},
     },
     std::sync::Arc,
 };
 
+#[derive(Debug)]
 pub struct TestContext {
     pub decimals: u8,
     pub mint_authority: Keypair,
@@ -18,7 +19,9 @@ pub struct TestContext {
 }
 
 impl TestContext {
-    pub async fn new(extension_init_params: Vec<ExtensionInitializationParams>) -> Self {
+    pub async fn new(
+        extension_init_params: Vec<ExtensionInitializationParams>,
+    ) -> TokenResult<Self> {
         let program_test = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
         let ctx = program_test.start_with_context().await;
         let ctx = Arc::new(Mutex::new(ctx));
@@ -46,16 +49,15 @@ impl TestContext {
             decimals,
             extension_init_params,
         )
-        .await
-        .expect("failed to create mint");
+        .await?;
 
-        Self {
+        Ok(Self {
             decimals,
             mint_authority,
             token,
             alice: Keypair::new(),
             bob: Keypair::new(),
-        }
+        })
     }
 }
 

--- a/token/program-2022/tests/transfer_fee.rs
+++ b/token/program-2022/tests/transfer_fee.rs
@@ -1,0 +1,100 @@
+#![cfg(feature = "test-bpf")]
+
+mod program_test;
+use {
+    program_test::TestContext,
+    solana_program_test::tokio,
+    solana_sdk::{
+        instruction::InstructionError, program_option::COption, pubkey::Pubkey, signature::Signer,
+        transaction::TransactionError, transport::TransportError,
+    },
+    spl_token_2022::extension::transfer_fee::{TransferFee, TransferFeeConfig},
+    spl_token_client::token::{ExtensionInitializationParams, TokenError as TokenClientError},
+    std::convert::TryInto,
+};
+
+fn test_transfer_fee() -> TransferFee {
+    TransferFee {
+        epoch: 0.into(),
+        transfer_fee_basis_points: 250.into(),
+        maximum_fee: 10_000_000.into(),
+    }
+}
+
+fn test_transfer_fee_config() -> TransferFeeConfig {
+    let transfer_fee = test_transfer_fee();
+    TransferFeeConfig {
+        transfer_fee_config_authority: COption::Some(Pubkey::new_unique()).try_into().unwrap(),
+        withdraw_withheld_authority: COption::Some(Pubkey::new_unique()).try_into().unwrap(),
+        withheld_amount: 0.into(),
+        older_transfer_fee: transfer_fee.clone(),
+        newer_transfer_fee: transfer_fee,
+    }
+}
+
+#[tokio::test]
+async fn success_init() {
+    let TransferFeeConfig {
+        transfer_fee_config_authority,
+        withdraw_withheld_authority,
+        newer_transfer_fee,
+        ..
+    } = test_transfer_fee_config();
+    let TestContext {
+        decimals,
+        mint_authority,
+        token,
+        ..
+    } = TestContext::new(vec![ExtensionInitializationParams::TransferFeeConfig {
+        transfer_fee_config_authority: transfer_fee_config_authority.into(),
+        withdraw_withheld_authority: withdraw_withheld_authority.into(),
+        transfer_fee_basis_points: newer_transfer_fee.transfer_fee_basis_points.into(),
+        maximum_fee: newer_transfer_fee.maximum_fee.into(),
+    }])
+    .await
+    .unwrap();
+
+    let state = token.get_mint_info().await.unwrap();
+    assert_eq!(state.base.decimals, decimals);
+    assert_eq!(
+        state.base.mint_authority,
+        COption::Some(mint_authority.pubkey())
+    );
+    assert_eq!(state.base.supply, 0);
+    assert!(state.base.is_initialized);
+    assert_eq!(state.base.freeze_authority, COption::None);
+    let extension = state.get_extension::<TransferFeeConfig>().unwrap();
+    assert_eq!(
+        extension.transfer_fee_config_authority,
+        transfer_fee_config_authority.try_into().unwrap(),
+    );
+    assert_eq!(
+        extension.withdraw_withheld_authority,
+        withdraw_withheld_authority.try_into().unwrap(),
+    );
+    assert_eq!(extension.newer_transfer_fee, newer_transfer_fee);
+    assert_eq!(extension.older_transfer_fee, newer_transfer_fee);
+}
+
+#[tokio::test]
+async fn fail_init_default_pubkey_as_authority() {
+    let TransferFeeConfig {
+        transfer_fee_config_authority,
+        newer_transfer_fee,
+        ..
+    } = test_transfer_fee_config();
+    let err = TestContext::new(vec![ExtensionInitializationParams::TransferFeeConfig {
+        transfer_fee_config_authority: transfer_fee_config_authority.into(),
+        withdraw_withheld_authority: COption::Some(Pubkey::default()),
+        transfer_fee_basis_points: newer_transfer_fee.transfer_fee_basis_points.into(),
+        maximum_fee: newer_transfer_fee.maximum_fee.into(),
+    }])
+    .await
+    .unwrap_err();
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(1, InstructionError::InvalidArgument)
+        )))
+    );
+}


### PR DESCRIPTION
#### Problem

We need to initialize fees on a mint.

#### Solution

Add that support.  There's also a couple of field renames:

* `fee_config_authority` -> `transfer_fee_config_authority`
* `withheld_withdraw_authority` -> `withdraw_withheld_authority` (this is for consistency, and because I kept getting it wrong)