### PR TITLE
DO NOT MERGE associated-token-account: Show how to revert for local dev

### DIFF
--- a/associated-token-account/program/Cargo.toml
+++ b/associated-token-account/program/Cargo.toml
@@ -14,7 +14,7 @@ test-bpf = []
 [dependencies]
 borsh = "0.9.1"
 solana-program = "1.9.2"
-spl-token = { version = "0.1", path = "../../token/program-2022", features = ["no-entrypoint"], package = "spl-token-2022" }
+spl-token = { version = "3", path = "../../token/program", features = ["no-entrypoint"] }
 
 [dev-dependencies]
 solana-program-test = "1.9.2"


### PR DESCRIPTION
#### Problem

If people want to develop against master, CLIs using the ATA program will fail because they're trying to access the normal token program, but the ATA library will be using spl-token-2022.

#### Solution

Do not merge this, but show how to revert back to spl-token for local development for anyone who needs it.