### PR TITLE
associated-token-account: Bump dependent token version to 3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3853,7 +3853,7 @@ dependencies = [
  "solana-client",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 1.0.3",
+ "spl-associated-token-account 1.0.4",
  "spl-token-2022",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3462,7 +3462,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-token-2022",
+ "spl-token 3.3.0",
 ]
 
 [[package]]
@@ -3941,7 +3941,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 1.0.3",
+ "spl-associated-token-account 1.0.4",
  "spl-token 3.3.0",
  "thiserror",
 ]

--- a/associated-token-account/program/Cargo.toml
+++ b/associated-token-account/program/Cargo.toml
@@ -14,7 +14,7 @@ test-bpf = []
 [dependencies]
 borsh = "0.9.1"
 solana-program = "1.9.2"
-spl-token = { version = "0.1", path = "../../token/program-2022", features = ["no-entrypoint"], package = "spl-token-2022" }
+spl-token = { version = "3.3", path = "../../token/program", features = ["no-entrypoint"] }
 
 [dev-dependencies]
 solana-program-test = "1.9.2"

--- a/associated-token-account/program/src/lib.rs
+++ b/associated-token-account/program/src/lib.rs
@@ -9,12 +9,7 @@ pub mod tools;
 
 // Export current SDK types for downstream users building with a different SDK version
 pub use solana_program;
-use solana_program::{
-    instruction::{AccountMeta, Instruction},
-    program_pack::Pack,
-    pubkey::Pubkey,
-    sysvar,
-};
+use solana_program::{instruction::Instruction, program_pack::Pack, pubkey::Pubkey};
 
 solana_program::declare_id!("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
 
@@ -65,28 +60,19 @@ fn get_associated_token_address_and_bump_seed_internal(
 ///   3. `[]` The token mint for the new associated token account
 ///   4. `[]` System program
 ///   5. `[]` SPL Token program
-///   6. `[]` Rent sysvar
 ///
-// TODO: Uncomment after 1.0.4 is released
-// #[deprecated(
-//     since = "1.0.4",
-//     note = "please use `instruction::create_associated_token_account` instead"
-// )]
+#[deprecated(
+    since = "1.0.4",
+    note = "please use `instruction::create_associated_token_account` instead"
+)]
 pub fn create_associated_token_account(
     funding_address: &Pubkey,
     wallet_address: &Pubkey,
     spl_token_mint_address: &Pubkey,
 ) -> Instruction {
-    let mut instruction = instruction::create_associated_token_account(
+    instruction::create_associated_token_account(
         funding_address,
         wallet_address,
         spl_token_mint_address,
-    );
-
-    // TODO: Remove after ATA 1.0.4 and Token  >3.2.0 are released (Token::InitializeAccount3 is required if rent account is not provided)
-    instruction
-        .accounts
-        .push(AccountMeta::new_readonly(sysvar::rent::id(), false));
-
-    instruction
+    )
 }

--- a/associated-token-account/program/tests/process_create_associated_token_account.rs
+++ b/associated-token-account/program/tests/process_create_associated_token_account.rs
@@ -300,6 +300,7 @@ async fn test_create_associated_token_account_using_deprecated_instruction_creat
     );
 
     // Use legacy instruction creator
+    #[allow(deprecated)]
     let create_associated_token_account_ix = deprecated_create_associated_token_account(
         &payer.pubkey(),
         &wallet_address,

--- a/associated-token-account/program/tests/program_test.rs
+++ b/associated-token-account/program/tests/program_test.rs
@@ -12,7 +12,7 @@ pub fn program_test(token_mint_address: Pubkey, use_latest_spl_token: bool) -> P
     );
 
     if use_latest_spl_token {
-        // TODO: Remove after Token >3.2.0 is released
+        // TODO: Remove after Token >3.2.0 is available by default in program-test
         pc.add_program(
             "spl_token",
             spl_token::id(),

--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -37,7 +37,9 @@ use {
         system_instruction,
         transaction::Transaction,
     },
-    spl_associated_token_account::{create_associated_token_account, get_associated_token_address},
+    spl_associated_token_account::{
+        get_associated_token_address, instruction::create_associated_token_account,
+    },
     spl_stake_pool::state::ValidatorStakeInfo,
     spl_stake_pool::{
         self, find_stake_program_address, find_transient_stake_program_address,

--- a/stateless-asks/program/Cargo.toml
+++ b/stateless-asks/program/Cargo.toml
@@ -14,7 +14,7 @@ test-bpf = []
 borsh = "0.9.1"
 solana-program = "1.9.2"
 spl-token = { version = "3.3", path = "../../token/program", features = ["no-entrypoint"] }
-spl-associated-token-account = {version = "1.0.3", features = ["no-entrypoint"]}
+spl-associated-token-account = {version = "1.0", path = "../../associated-token-account/program", features = ["no-entrypoint"]}
 metaplex-token-metadata = { version = "0.0.1", features = ["no-entrypoint"] }
 thiserror = "1.0"
 

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -41,7 +41,9 @@ use solana_sdk::{
     system_instruction, system_program,
     transaction::Transaction,
 };
-use spl_associated_token_account::*;
+use spl_associated_token_account::{
+    get_associated_token_address, instruction::create_associated_token_account,
+};
 use spl_token::{
     self,
     instruction::*,

--- a/token/rust/Cargo.toml
+++ b/token/rust/Cargo.toml
@@ -17,6 +17,6 @@ async-trait = "0.1"
 solana-client = "=1.9.2"
 solana-program-test = "=1.9.2"
 solana-sdk = "=1.9.2"
-spl-associated-token-account = { version = "1.0", features = ["no-entrypoint"] }
+spl-associated-token-account = { version = "1.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "0.1", path="../program-2022" }
 thiserror = "1.0"

--- a/token/rust/src/token.rs
+++ b/token/rust/src/token.rs
@@ -10,7 +10,9 @@ use solana_sdk::{
     system_instruction,
     transaction::Transaction,
 };
-use spl_associated_token_account::{create_associated_token_account, get_associated_token_address};
+use spl_associated_token_account::{
+    get_associated_token_address, instruction::create_associated_token_account,
+};
 use spl_token_2022::{
     extension::{transfer_fee, ExtensionType, StateWithExtensionsOwned},
     id, instruction,


### PR DESCRIPTION
#### Problem

We jumped the gun a little bit with ATA by linking it to spl-token-2022, and we'll need a version of the crate linked to token 3.3.0.

#### Solution

Bump the version and update the program to use `initialize_account3`.  As soon as this is merged, I'll publish the crate and revert the Cargo.toml change.