### PR TITLE
associated-token-account: Revert to using spl-token-2022

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3462,7 +3462,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-token 3.3.0",
+ "spl-token-2022",
 ]
 
 [[package]]

--- a/associated-token-account/program/Cargo.toml
+++ b/associated-token-account/program/Cargo.toml
@@ -10,11 +10,15 @@ edition = "2018"
 [features]
 no-entrypoint = []
 test-bpf = []
+# When spl-token depends on spl-token-client, which depends on this with no-entrypoint,
+# all tests fail! Normally, we want no-entrypoint, except when testing spl-token
+no-token-entrypoint = [ "spl-token/no-entrypoint" ]
+default = [ "no-token-entrypoint" ]
 
 [dependencies]
 borsh = "0.9.1"
 solana-program = "1.9.2"
-spl-token = { version = "0.1", path = "../../token/program-2022", features = ["no-entrypoint"], package = "spl-token-2022" }
+spl-token = { version = "0.1", path = "../../token/program-2022", package = "spl-token-2022" }
 
 [dev-dependencies]
 solana-program-test = "1.9.2"

--- a/associated-token-account/program/Cargo.toml
+++ b/associated-token-account/program/Cargo.toml
@@ -14,7 +14,7 @@ test-bpf = []
 [dependencies]
 borsh = "0.9.1"
 solana-program = "1.9.2"
-spl-token = { version = "3.3", path = "../../token/program", features = ["no-entrypoint"] }
+spl-token = { version = "0.1", path = "../../token/program-2022", features = ["no-entrypoint"], package = "spl-token-2022" }
 
 [dev-dependencies]
 solana-program-test = "1.9.2"

--- a/token/rust/Cargo.toml
+++ b/token/rust/Cargo.toml
@@ -10,13 +10,15 @@ version = "0.0.1"
 # When spl-token-2022 depends on this with no-entrypoint, all tests fail!
 # Normally, we want no-entrypoint, except when testing spl-token-2022
 [features]
-default = [ "spl-token-2022/no-entrypoint" ]
+default = [ "spl-token-2022/no-entrypoint", "spl-associated-token-account/no-token-entrypoint" ]
 
 [dependencies]
 async-trait = "0.1"
 solana-client = "=1.9.2"
 solana-program-test = "=1.9.2"
 solana-sdk = "=1.9.2"
-spl-associated-token-account = { version = "1.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
+# We never want the entrypoint for ATA, but we want the entrypoint for token when
+# testing token
+spl-associated-token-account = { version = "1.0", path = "../../associated-token-account/program", features = ["no-entrypoint"], default-features = false }
 spl-token-2022 = { version = "0.1", path="../program-2022" }
 thiserror = "1.0"


### PR DESCRIPTION
Now that associated-token-account v1.0.4 is out, we can point the crate back to spl-token-2022.