### PR TITLE
token-2022: bump compute limit for close test

### DIFF
--- a/token/program-2022/tests/assert_instruction_count.rs
+++ b/token/program-2022/tests/assert_instruction_count.rs
@@ -286,7 +286,7 @@ async fn burn() {
 #[tokio::test]
 async fn close_account() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
-    pt.set_compute_max_units(6_000); // last known 1783
+    pt.set_compute_max_units(8_000); // last known 1783
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();


### PR DESCRIPTION
#### Problem

The monorepo downstream job is failing because of compute unit usage in `close_account` test: https://buildkite.com/solana-labs/solana/builds/63871#bb2e1442-b5cb-422f-bcd3-2fe6e67a6819

#### Solution

Bump limit