### PR TITLE
Bump zk-token-sdk and impl Default for confidential-transfer extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1627,13 +1627,13 @@ dependencies = [
 
 [[package]]
 name = "merlin"
-version = "2.0.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e261cf0f8b3c42ded9f7d2bb59dea03aa52bc8a1cbc7482f9fc3fd1229d3b42"
+checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
  "byteorder",
  "keccak",
- "rand_core 0.5.1",
+ "rand_core 0.6.3",
  "zeroize",
 ]
 
@@ -3391,9 +3391,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2243307ab81fedd2f7e3b4b2b541ab0314cc4a26aebbf7ed6ddb839808cb244"
+checksum = "bd53a7455dfde2a29b20ee1b0f775b41df989bcf7d8a68f0fb567497c4a501fb"
 dependencies = [
  "aes-gcm-siv",
  "arrayref",

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -19,7 +19,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 num_enum = "0.5.4"
 solana-program = "1.9.2"
-solana-zk-token-sdk = "0.1.0"
+solana-zk-token-sdk = "0.3.0"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/token/program-2022/src/extension/confidential_transfer/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer/mod.rs
@@ -17,7 +17,7 @@ pub mod processor;
 
 /// Confidential transfer mint configuration
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct ConfidentialTransferMint {
     /// Authority to modify the `ConfidentialTransferMint` configuration
     ///
@@ -45,7 +45,7 @@ impl Extension for ConfidentialTransferMint {
 
 /// Confidential account state
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct ConfidentialTransferAccount {
     /// `true` if this account has been approved for use. All confidential transfer operations for
     /// the account will fail until approval is granted.


### PR DESCRIPTION
Unblocks initialization of extensions with default values (#2746 ) by implementing Default for the confidential-transfer extensions