### PR TITLE
Bump solana-zk-token-sdk again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3391,9 +3391,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd53a7455dfde2a29b20ee1b0f775b41df989bcf7d8a68f0fb567497c4a501fb"
+checksum = "f79e20a90b9e8c10baa62cbb396fd9af6a1e3d7b0c1c3ce84189d08d0f273ea8"
 dependencies = [
  "aes-gcm-siv",
  "arrayref",

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -19,7 +19,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 num_enum = "0.5.4"
 solana-program = "1.9.2"
-solana-zk-token-sdk = "0.3.0"
+solana-zk-token-sdk = "0.4.0"
 thiserror = "1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Bumping to newly published crate that specifies solana-program and solana-sdk dependencies as caret requirements, instead of exact.