### PR TITLE
stake-pool-cli / token-lending-cli: Sign after balance check

### DIFF
--- a/token-lending/cli/src/main.rs
+++ b/token-lending/cli/src/main.rs
@@ -13,6 +13,7 @@ use {
     solana_program::{native_token::lamports_to_sol, program_pack::Pack, pubkey::Pubkey},
     solana_sdk::{
         commitment_config::CommitmentConfig,
+        message::Message,
         signature::{Keypair, Signer},
         system_instruction,
         transaction::Transaction,
@@ -434,7 +435,8 @@ fn command_create_lending_market(
         .rpc_client
         .get_minimum_balance_for_rent_exemption(LendingMarket::LEN)?;
 
-    let mut transaction = Transaction::new_with_payer(
+    let recent_blockhash = config.rpc_client.get_latest_blockhash()?;
+    let message = Message::new_with_blockhash(
         &[
             // Account for the lending market
             create_account(
@@ -454,20 +456,18 @@ fn command_create_lending_market(
             ),
         ],
         Some(&config.fee_payer.pubkey()),
+        &recent_blockhash,
     );
 
-    let recent_blockhash = config.rpc_client.get_latest_blockhash()?;
-    transaction.sign(
-        &vec![config.fee_payer.as_ref(), &lending_market_keypair],
-        recent_blockhash,
-    );
     check_fee_payer_balance(
         config,
-        lending_market_balance
-            + config
-                .rpc_client
-                .get_fee_for_message(transaction.message())?,
+        lending_market_balance + config.rpc_client.get_fee_for_message(&message)?,
     )?;
+    let transaction = Transaction::new(
+        &vec![config.fee_payer.as_ref(), &lending_market_keypair],
+        message,
+        recent_blockhash,
+    );
     send_transaction(config, transaction)?;
     Ok(())
 }
@@ -549,7 +549,8 @@ fn command_add_reserve(
         + liquidity_supply_balance
         + liquidity_fee_receiver_balance;
 
-    let mut transaction_1 = Transaction::new_with_payer(
+    let recent_blockhash = config.rpc_client.get_latest_blockhash()?;
+    let message_1 = Message::new_with_blockhash(
         &[
             create_account(
                 &config.fee_payer.pubkey(),
@@ -581,9 +582,10 @@ fn command_add_reserve(
             ),
         ],
         Some(&config.fee_payer.pubkey()),
+        &recent_blockhash,
     );
 
-    let mut transaction_2 = Transaction::new_with_payer(
+    let message_2 = Message::new_with_blockhash(
         &[
             create_account(
                 &config.fee_payer.pubkey(),
@@ -601,9 +603,10 @@ fn command_add_reserve(
             ),
         ],
         Some(&config.fee_payer.pubkey()),
+        &recent_blockhash,
     );
 
-    let mut transaction_3 = Transaction::new_with_payer(
+    let message_3 = Message::new_with_blockhash(
         &[
             approve(
                 &spl_token::id(),
@@ -641,10 +644,17 @@ fn command_add_reserve(
             .unwrap(),
         ],
         Some(&config.fee_payer.pubkey()),
+        &recent_blockhash,
     );
+    check_fee_payer_balance(
+        config,
+        total_balance
+            + config.rpc_client.get_fee_for_message(&message_1)?
+            + config.rpc_client.get_fee_for_message(&message_2)?
+            + config.rpc_client.get_fee_for_message(&message_3)?,
+    )?;
 
-    let recent_blockhash = config.rpc_client.get_latest_blockhash()?;
-    transaction_1.sign(
+    let transaction_1 = Transaction::new(
         &vec![
             config.fee_payer.as_ref(),
             &reserve_keypair,
@@ -652,40 +662,30 @@ fn command_add_reserve(
             &collateral_supply_keypair,
             &user_collateral_keypair,
         ],
+        message_1,
         recent_blockhash,
     );
-    transaction_2.sign(
+    send_transaction(config, transaction_1)?;
+    let transaction_2 = Transaction::new(
         &vec![
             config.fee_payer.as_ref(),
             &liquidity_supply_keypair,
             &liquidity_fee_receiver_keypair,
         ],
+        message_2,
         recent_blockhash,
     );
-    transaction_3.sign(
+    send_transaction(config, transaction_2)?;
+    let transaction_3 = Transaction::new(
         &vec![
             config.fee_payer.as_ref(),
             &source_liquidity_owner_keypair,
             &lending_market_owner_keypair,
             &user_transfer_authority_keypair,
         ],
+        message_3,
         recent_blockhash,
     );
-    check_fee_payer_balance(
-        config,
-        total_balance
-            + config
-                .rpc_client
-                .get_fee_for_message(transaction_1.message())?
-            + config
-                .rpc_client
-                .get_fee_for_message(transaction_2.message())?
-            + config
-                .rpc_client
-                .get_fee_for_message(transaction_3.message())?,
-    )?;
-    send_transaction(config, transaction_1)?;
-    send_transaction(config, transaction_2)?;
     send_transaction(config, transaction_3)?;
     Ok(())
 }


### PR DESCRIPTION
#### Problem

To use the new `get_fee_for_message` APIs, the CLIs were wrongly signing the message, and then checking the fee, which means that signatures could remain unused, making @t-nelson 's skin crawl.

#### Solution

No crawling skin! Use `Message::new_with_blockhash`, check the fee, and then sign the transaction with that.