### PR TITLE
token-2022: make extension instruction builders consistent with vanilla token

### DIFF
--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -327,8 +327,8 @@ fn encode_instruction<T: Pod>(
 }
 
 /// Create a `InitializeMint` instruction
-pub fn initialize_mint(mint: Pubkey, auditor: &ConfidentialTransferMint) -> Instruction {
-    let accounts = vec![AccountMeta::new(mint, false)];
+pub fn initialize_mint(mint: &Pubkey, auditor: &ConfidentialTransferMint) -> Instruction {
+    let accounts = vec![AccountMeta::new(*mint, false)];
     encode_instruction(
         accounts,
         ConfidentialTransferInstruction::InitializeMint,
@@ -337,13 +337,13 @@ pub fn initialize_mint(mint: Pubkey, auditor: &ConfidentialTransferMint) -> Inst
 }
 /// Create a `UpdateMint` instruction
 pub fn update_mint(
-    mint: Pubkey,
+    mint: &Pubkey,
     new_auditor: &ConfidentialTransferMint,
-    authority: Pubkey,
+    authority: &Pubkey,
 ) -> Instruction {
     let accounts = vec![
-        AccountMeta::new(mint, false),
-        AccountMeta::new_readonly(authority, true),
+        AccountMeta::new(*mint, false),
+        AccountMeta::new_readonly(*authority, true),
         AccountMeta::new_readonly(
             new_auditor.authority,
             new_auditor.authority != Pubkey::default(),
@@ -359,17 +359,17 @@ pub fn update_mint(
 /// Create a `ConfigureAccount` instruction
 #[cfg(not(target_arch = "bpf"))]
 pub fn configure_account(
-    token_account: Pubkey,
-    mint: Pubkey,
+    token_account: &Pubkey,
+    mint: &Pubkey,
     elgamal_pk: ElGamalPubkey,
     decryptable_zero_balance: AeCiphertext,
-    authority: Pubkey,
+    authority: &Pubkey,
     multisig_signers: &[&Pubkey],
 ) -> Vec<Instruction> {
     let mut accounts = vec![
-        AccountMeta::new(token_account, false),
-        AccountMeta::new_readonly(mint, false),
-        AccountMeta::new_readonly(authority, multisig_signers.is_empty()),
+        AccountMeta::new(*token_account, false),
+        AccountMeta::new_readonly(*mint, false),
+        AccountMeta::new_readonly(*authority, multisig_signers.is_empty()),
     ];
 
     for multisig_signer in multisig_signers.iter() {
@@ -387,11 +387,15 @@ pub fn configure_account(
 }
 
 /// Create an `ApproveAccount` instruction
-pub fn approve_account(mint: Pubkey, account_to_approve: Pubkey, authority: Pubkey) -> Instruction {
+pub fn approve_account(
+    mint: &Pubkey,
+    account_to_approve: &Pubkey,
+    authority: &Pubkey,
+) -> Instruction {
     let accounts = vec![
-        AccountMeta::new(account_to_approve, false),
-        AccountMeta::new_readonly(mint, false),
-        AccountMeta::new_readonly(authority, true),
+        AccountMeta::new(*account_to_approve, false),
+        AccountMeta::new_readonly(*mint, false),
+        AccountMeta::new_readonly(*authority, true),
     ];
     encode_instruction(
         accounts,
@@ -404,15 +408,15 @@ pub fn approve_account(mint: Pubkey, account_to_approve: Pubkey, authority: Pubk
 ///
 /// This instruction is suitable for use with a cross-program `invoke`
 pub fn inner_empty_account(
-    token_account: Pubkey,
-    authority: Pubkey,
+    token_account: &Pubkey,
+    authority: &Pubkey,
     multisig_signers: &[&Pubkey],
     proof_instruction_offset: i8,
 ) -> Instruction {
     let mut accounts = vec![
-        AccountMeta::new_readonly(token_account, false),
+        AccountMeta::new_readonly(*token_account, false),
         AccountMeta::new_readonly(sysvar::instructions::id(), false),
-        AccountMeta::new_readonly(authority, multisig_signers.is_empty()),
+        AccountMeta::new_readonly(*authority, multisig_signers.is_empty()),
     ];
 
     for multisig_signer in multisig_signers.iter() {
@@ -430,8 +434,8 @@ pub fn inner_empty_account(
 
 /// Create a `EmptyAccount` instruction
 pub fn empty_account(
-    token_account: Pubkey,
-    authority: Pubkey,
+    token_account: &Pubkey,
+    authority: &Pubkey,
     multisig_signers: &[&Pubkey],
     proof_data: &CloseAccountData,
 ) -> Vec<Instruction> {
@@ -443,19 +447,19 @@ pub fn empty_account(
 
 /// Create a `Deposit` instruction
 pub fn deposit(
-    source_token_account: Pubkey,
-    mint: Pubkey,
-    destination_token_account: Pubkey,
+    source_token_account: &Pubkey,
+    mint: &Pubkey,
+    destination_token_account: &Pubkey,
     amount: u64,
     decimals: u8,
-    authority: Pubkey,
+    authority: &Pubkey,
     multisig_signers: &[&Pubkey],
 ) -> Vec<Instruction> {
     let mut accounts = vec![
-        AccountMeta::new(source_token_account, false),
-        AccountMeta::new(destination_token_account, false),
-        AccountMeta::new_readonly(mint, false),
-        AccountMeta::new_readonly(authority, multisig_signers.is_empty()),
+        AccountMeta::new(*source_token_account, false),
+        AccountMeta::new(*destination_token_account, false),
+        AccountMeta::new_readonly(*mint, false),
+        AccountMeta::new_readonly(*authority, multisig_signers.is_empty()),
     ];
 
     for multisig_signer in multisig_signers.iter() {
@@ -477,22 +481,22 @@ pub fn deposit(
 /// This instruction is suitable for use with a cross-program `invoke`
 #[allow(clippy::too_many_arguments)]
 pub fn inner_withdraw(
-    source_token_account: Pubkey,
-    destination_token_account: Pubkey,
+    source_token_account: &Pubkey,
+    destination_token_account: &Pubkey,
     mint: &Pubkey,
     amount: u64,
     decimals: u8,
     new_decryptable_available_balance: pod::AeCiphertext,
-    authority: Pubkey,
+    authority: &Pubkey,
     multisig_signers: &[&Pubkey],
     proof_instruction_offset: i8,
 ) -> Instruction {
     let mut accounts = vec![
-        AccountMeta::new(source_token_account, false),
-        AccountMeta::new(destination_token_account, false),
+        AccountMeta::new(*source_token_account, false),
+        AccountMeta::new(*destination_token_account, false),
         AccountMeta::new_readonly(*mint, false),
         AccountMeta::new_readonly(sysvar::instructions::id(), false),
-        AccountMeta::new_readonly(authority, multisig_signers.is_empty()),
+        AccountMeta::new_readonly(*authority, multisig_signers.is_empty()),
     ];
 
     for multisig_signer in multisig_signers.iter() {
@@ -515,13 +519,13 @@ pub fn inner_withdraw(
 #[allow(clippy::too_many_arguments)]
 #[cfg(not(target_arch = "bpf"))]
 pub fn withdraw(
-    source_token_account: Pubkey,
-    destination_token_account: Pubkey,
+    source_token_account: &Pubkey,
+    destination_token_account: &Pubkey,
     mint: &Pubkey,
     amount: u64,
     decimals: u8,
     new_decryptable_available_balance: AeCiphertext,
-    authority: Pubkey,
+    authority: &Pubkey,
     multisig_signers: &[&Pubkey],
     proof_data: &WithdrawData,
 ) -> Vec<Instruction> {
@@ -546,20 +550,20 @@ pub fn withdraw(
 /// This instruction is suitable for use with a cross-program `invoke`
 #[allow(clippy::too_many_arguments)]
 pub fn inner_transfer(
-    source_token_account: Pubkey,
-    destination_token_account: Pubkey,
-    mint: Pubkey,
+    source_token_account: &Pubkey,
+    destination_token_account: &Pubkey,
+    mint: &Pubkey,
     new_source_decryptable_available_balance: pod::AeCiphertext,
-    authority: Pubkey,
+    authority: &Pubkey,
     multisig_signers: &[&Pubkey],
     proof_instruction_offset: i8,
 ) -> Instruction {
     let mut accounts = vec![
-        AccountMeta::new(source_token_account, false),
-        AccountMeta::new(destination_token_account, false),
-        AccountMeta::new_readonly(mint, false),
+        AccountMeta::new(*source_token_account, false),
+        AccountMeta::new(*destination_token_account, false),
+        AccountMeta::new_readonly(*mint, false),
         AccountMeta::new_readonly(sysvar::instructions::id(), false),
-        AccountMeta::new_readonly(authority, multisig_signers.is_empty()),
+        AccountMeta::new_readonly(*authority, multisig_signers.is_empty()),
     ];
 
     for multisig_signer in multisig_signers.iter() {
@@ -580,11 +584,11 @@ pub fn inner_transfer(
 #[allow(clippy::too_many_arguments)]
 #[cfg(not(target_arch = "bpf"))]
 pub fn transfer(
-    source_token_account: Pubkey,
-    destination_token_account: Pubkey,
-    mint: Pubkey,
+    source_token_account: &Pubkey,
+    destination_token_account: &Pubkey,
+    mint: &Pubkey,
     new_source_decryptable_available_balance: AeCiphertext,
-    authority: Pubkey,
+    authority: &Pubkey,
     multisig_signers: &[&Pubkey],
     proof_data: &TransferData,
 ) -> Vec<Instruction> {
@@ -607,15 +611,15 @@ pub fn transfer(
 /// This instruction is suitable for use with a cross-program `invoke`
 #[allow(clippy::too_many_arguments)]
 pub fn inner_apply_pending_balance(
-    token_account: Pubkey,
+    token_account: &Pubkey,
     expected_pending_balance_credit_counter: u64,
     new_decryptable_available_balance: pod::AeCiphertext,
-    authority: Pubkey,
+    authority: &Pubkey,
     multisig_signers: &[&Pubkey],
 ) -> Instruction {
     let mut accounts = vec![
-        AccountMeta::new(token_account, false),
-        AccountMeta::new_readonly(authority, multisig_signers.is_empty()),
+        AccountMeta::new(*token_account, false),
+        AccountMeta::new_readonly(*authority, multisig_signers.is_empty()),
     ];
 
     for multisig_signer in multisig_signers.iter() {
@@ -635,10 +639,10 @@ pub fn inner_apply_pending_balance(
 /// Create a `ApplyPendingBalance` instruction
 #[cfg(not(target_arch = "bpf"))]
 pub fn apply_pending_balance(
-    token_account: Pubkey,
+    token_account: &Pubkey,
     pending_balance_instructions: u64,
     new_decryptable_available_balance: AeCiphertext,
-    authority: Pubkey,
+    authority: &Pubkey,
     multisig_signers: &[&Pubkey],
 ) -> Vec<Instruction> {
     vec![inner_apply_pending_balance(
@@ -652,13 +656,13 @@ pub fn apply_pending_balance(
 
 /// Create a `EnableBalanceCredits` instruction
 pub fn enable_balance_credits(
-    token_account: Pubkey,
-    authority: Pubkey,
+    token_account: &Pubkey,
+    authority: &Pubkey,
     multisig_signers: &[&Pubkey],
 ) -> Vec<Instruction> {
     let mut accounts = vec![
-        AccountMeta::new(token_account, false),
-        AccountMeta::new_readonly(authority, multisig_signers.is_empty()),
+        AccountMeta::new(*token_account, false),
+        AccountMeta::new_readonly(*authority, multisig_signers.is_empty()),
     ];
 
     for multisig_signer in multisig_signers.iter() {
@@ -675,13 +679,13 @@ pub fn enable_balance_credits(
 /// Create a `DisableBalanceCredits` instruction
 #[cfg(not(target_arch = "bpf"))]
 pub fn disable_balance_credits(
-    token_account: Pubkey,
-    authority: Pubkey,
+    token_account: &Pubkey,
+    authority: &Pubkey,
     multisig_signers: &[&Pubkey],
 ) -> Vec<Instruction> {
     let mut accounts = vec![
-        AccountMeta::new(token_account, false),
-        AccountMeta::new_readonly(authority, multisig_signers.is_empty()),
+        AccountMeta::new(*token_account, false),
+        AccountMeta::new_readonly(*authority, multisig_signers.is_empty()),
     ];
 
     for multisig_signer in multisig_signers.iter() {

--- a/token/program-2022/src/extension/transfer_fee/instruction.rs
+++ b/token/program-2022/src/extension/transfer_fee/instruction.rs
@@ -256,12 +256,14 @@ impl TransferFeeInstruction {
 
 /// Create a `InitializeTransferFeeConfig` instruction
 pub fn initialize_transfer_fee_config(
-    mint: Pubkey,
-    transfer_fee_config_authority: COption<Pubkey>,
-    withdraw_withheld_authority: COption<Pubkey>,
+    mint: &Pubkey,
+    transfer_fee_config_authority: Option<&Pubkey>,
+    withdraw_withheld_authority: Option<&Pubkey>,
     transfer_fee_basis_points: u16,
     maximum_fee: u64,
 ) -> Instruction {
+    let transfer_fee_config_authority = transfer_fee_config_authority.cloned().into();
+    let withdraw_withheld_authority = withdraw_withheld_authority.cloned().into();
     let data = TokenInstruction::TransferFeeExtension(
         TransferFeeInstruction::InitializeTransferFeeConfig {
             transfer_fee_config_authority,
@@ -274,7 +276,7 @@ pub fn initialize_transfer_fee_config(
 
     Instruction {
         program_id: id(),
-        accounts: vec![AccountMeta::new(mint, false)],
+        accounts: vec![AccountMeta::new(*mint, false)],
         data,
     }
 }
@@ -282,11 +284,11 @@ pub fn initialize_transfer_fee_config(
 /// Create a `TransferCheckedWithFee` instruction
 #[allow(clippy::too_many_arguments)]
 pub fn transfer_checked_with_fee(
-    source: Pubkey,
-    mint: Pubkey,
-    destination: Pubkey,
-    authority: Pubkey,
-    signers: &[Pubkey],
+    source: &Pubkey,
+    mint: &Pubkey,
+    destination: &Pubkey,
+    authority: &Pubkey,
+    signers: &[&Pubkey],
     amount: u64,
     decimals: u8,
     fee: u64,
@@ -300,12 +302,12 @@ pub fn transfer_checked_with_fee(
         .pack();
 
     let mut accounts = Vec::with_capacity(4 + signers.len());
-    accounts.push(AccountMeta::new(source, false));
-    accounts.push(AccountMeta::new_readonly(mint, false));
-    accounts.push(AccountMeta::new(destination, false));
-    accounts.push(AccountMeta::new_readonly(authority, signers.is_empty()));
+    accounts.push(AccountMeta::new(*source, false));
+    accounts.push(AccountMeta::new_readonly(*mint, false));
+    accounts.push(AccountMeta::new(*destination, false));
+    accounts.push(AccountMeta::new_readonly(*authority, signers.is_empty()));
     for signer in signers.iter() {
-        accounts.push(AccountMeta::new_readonly(*signer, true));
+        accounts.push(AccountMeta::new_readonly(**signer, true));
     }
 
     Instruction {
@@ -317,17 +319,17 @@ pub fn transfer_checked_with_fee(
 
 /// Creates a `WithdrawWithheldTokensFromMint` instruction
 pub fn withdraw_withheld_tokens_from_mint(
-    mint: Pubkey,
-    destination: Pubkey,
-    authority: Pubkey,
-    signers: &[Pubkey],
+    mint: &Pubkey,
+    destination: &Pubkey,
+    authority: &Pubkey,
+    signers: &[&Pubkey],
 ) -> Instruction {
     let mut accounts = Vec::with_capacity(3 + signers.len());
-    accounts.push(AccountMeta::new(mint, false));
-    accounts.push(AccountMeta::new(destination, false));
-    accounts.push(AccountMeta::new_readonly(authority, signers.is_empty()));
+    accounts.push(AccountMeta::new(*mint, false));
+    accounts.push(AccountMeta::new(*destination, false));
+    accounts.push(AccountMeta::new_readonly(*authority, signers.is_empty()));
     for signer in signers.iter() {
-        accounts.push(AccountMeta::new_readonly(*signer, true));
+        accounts.push(AccountMeta::new_readonly(**signer, true));
     }
 
     Instruction {
@@ -342,21 +344,21 @@ pub fn withdraw_withheld_tokens_from_mint(
 
 /// Creates a `WithdrawWithheldTokensFromAccounts` instruction
 pub fn withdraw_withheld_tokens_from_accounts(
-    mint: Pubkey,
-    destination: Pubkey,
-    authority: Pubkey,
-    signers: &[Pubkey],
-    sources: &[Pubkey],
+    mint: &Pubkey,
+    destination: &Pubkey,
+    authority: &Pubkey,
+    signers: &[&Pubkey],
+    sources: &[&Pubkey],
 ) -> Instruction {
     let mut accounts = Vec::with_capacity(3 + signers.len() + sources.len());
-    accounts.push(AccountMeta::new_readonly(mint, false));
-    accounts.push(AccountMeta::new(destination, false));
-    accounts.push(AccountMeta::new_readonly(authority, signers.is_empty()));
+    accounts.push(AccountMeta::new_readonly(*mint, false));
+    accounts.push(AccountMeta::new(*destination, false));
+    accounts.push(AccountMeta::new_readonly(*authority, signers.is_empty()));
     for signer in signers.iter() {
-        accounts.push(AccountMeta::new_readonly(*signer, true));
+        accounts.push(AccountMeta::new_readonly(**signer, true));
     }
     for source in sources.iter() {
-        accounts.push(AccountMeta::new(*source, false));
+        accounts.push(AccountMeta::new(**source, false));
     }
 
     Instruction {
@@ -370,11 +372,11 @@ pub fn withdraw_withheld_tokens_from_accounts(
 }
 
 /// Creates a `HarvestWithheldTokensToMint` instruction
-pub fn harvest_withheld_tokens_to_mint(mint: Pubkey, sources: &[Pubkey]) -> Instruction {
+pub fn harvest_withheld_tokens_to_mint(mint: &Pubkey, sources: &[&Pubkey]) -> Instruction {
     let mut accounts = Vec::with_capacity(1 + sources.len());
-    accounts.push(AccountMeta::new(mint, false));
+    accounts.push(AccountMeta::new(*mint, false));
     for source in sources.iter() {
-        accounts.push(AccountMeta::new(*source, false));
+        accounts.push(AccountMeta::new(**source, false));
     }
     Instruction {
         program_id: id(),
@@ -388,17 +390,17 @@ pub fn harvest_withheld_tokens_to_mint(mint: Pubkey, sources: &[Pubkey]) -> Inst
 
 /// Creates a `SetTransferFee` instruction
 pub fn set_transfer_fee(
-    mint: Pubkey,
-    authority: Pubkey,
-    signers: &[Pubkey],
+    mint: &Pubkey,
+    authority: &Pubkey,
+    signers: &[&Pubkey],
     transfer_fee_basis_points: u16,
     maximum_fee: u64,
 ) -> Instruction {
     let mut accounts = Vec::with_capacity(2 + signers.len());
-    accounts.push(AccountMeta::new(mint, false));
-    accounts.push(AccountMeta::new_readonly(authority, signers.is_empty()));
+    accounts.push(AccountMeta::new(*mint, false));
+    accounts.push(AccountMeta::new_readonly(*authority, signers.is_empty()));
     for signer in signers.iter() {
-        accounts.push(AccountMeta::new_readonly(*signer, true));
+        accounts.push(AccountMeta::new_readonly(**signer, true));
     }
 
     Instruction {

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -1422,9 +1422,10 @@ pub fn get_account_data_size(
 pub fn initialize_mint_close_authority(
     token_program_id: &Pubkey,
     mint_pubkey: &Pubkey,
-    close_authority: COption<Pubkey>,
+    close_authority: Option<&Pubkey>,
 ) -> Result<Instruction, ProgramError> {
     check_program_account(token_program_id)?;
+    let close_authority = close_authority.cloned().into();
     Ok(Instruction {
         program_id: *token_program_id,
         accounts: vec![AccountMeta::new(*mint_pubkey, false)],

--- a/token/program-2022/tests/initialize_mint.rs
+++ b/token/program-2022/tests/initialize_mint.rs
@@ -65,7 +65,7 @@ async fn fail_extension_no_space() {
         instruction::initialize_mint_close_authority(
             &spl_token_2022::id(),
             &mint_account.pubkey(),
-            COption::Some(mint_authority_pubkey),
+            Some(&mint_authority_pubkey),
         )
         .unwrap(),
         instruction::initialize_mint(
@@ -126,7 +126,7 @@ async fn fail_extension_after_mint_init() {
         instruction::initialize_mint_close_authority(
             &spl_token_2022::id(),
             &mint_account.pubkey(),
-            COption::Some(mint_authority_pubkey),
+            Some(&mint_authority_pubkey),
         )
         .unwrap(),
     ];
@@ -153,7 +153,7 @@ async fn fail_extension_after_mint_init() {
 
 #[tokio::test]
 async fn success_extension_and_base() {
-    let close_authority = COption::Some(Pubkey::new_unique());
+    let close_authority = Some(Pubkey::new_unique());
     let TestContext {
         decimals,
         mint_authority,
@@ -266,7 +266,7 @@ async fn fail_account_init_after_mint_extension() {
         instruction::initialize_mint_close_authority(
             &spl_token_2022::id(),
             &token_account.pubkey(),
-            COption::Some(mint_authority_pubkey),
+            Some(&mint_authority_pubkey),
         )
         .unwrap(),
         instruction::initialize_account(
@@ -375,7 +375,7 @@ async fn fail_account_init_after_mint_init_with_extension() {
         instruction::initialize_mint_close_authority(
             &spl_token_2022::id(),
             &mint_account.pubkey(),
-            COption::Some(mint_authority_pubkey),
+            Some(&mint_authority_pubkey),
         )
         .unwrap(),
         instruction::initialize_mint(
@@ -441,9 +441,9 @@ async fn fail_fee_init_after_mint_init() {
         )
         .unwrap(),
         transfer_fee::instruction::initialize_transfer_fee_config(
-            mint_account.pubkey(),
-            COption::Some(Pubkey::new_unique()),
-            COption::Some(Pubkey::new_unique()),
+            &mint_account.pubkey(),
+            Some(&Pubkey::new_unique()),
+            Some(&Pubkey::new_unique()),
             10,
             100,
         ),

--- a/token/program-2022/tests/mint_close_authority.rs
+++ b/token/program-2022/tests/mint_close_authority.rs
@@ -17,7 +17,7 @@ use {
 
 #[tokio::test]
 async fn success_init() {
-    let close_authority = COption::Some(Pubkey::new_unique());
+    let close_authority = Some(Pubkey::new_unique());
     let TestContext {
         decimals,
         mint_authority,
@@ -50,7 +50,7 @@ async fn set_authority() {
     let close_authority = Keypair::new();
     let TestContext { token, .. } =
         TestContext::new(vec![ExtensionInitializationParams::MintCloseAuthority {
-            close_authority: COption::Some(close_authority.pubkey()),
+            close_authority: Some(close_authority.pubkey()),
         }])
         .await
         .unwrap();
@@ -150,7 +150,7 @@ async fn success_close() {
     let close_authority = Keypair::new();
     let TestContext { token, .. } =
         TestContext::new(vec![ExtensionInitializationParams::MintCloseAuthority {
-            close_authority: COption::Some(close_authority.pubkey()),
+            close_authority: Some(close_authority.pubkey()),
         }])
         .await
         .unwrap();
@@ -212,7 +212,7 @@ async fn fail_close_with_supply() {
         mint_authority,
         ..
     } = TestContext::new(vec![ExtensionInitializationParams::MintCloseAuthority {
-        close_authority: COption::Some(close_authority.pubkey()),
+        close_authority: Some(close_authority.pubkey()),
     }])
     .await
     .unwrap();

--- a/token/program-2022/tests/transfer_fee.rs
+++ b/token/program-2022/tests/transfer_fee.rs
@@ -85,7 +85,7 @@ async fn fail_init_default_pubkey_as_authority() {
     } = test_transfer_fee_config();
     let err = TestContext::new(vec![ExtensionInitializationParams::TransferFeeConfig {
         transfer_fee_config_authority: transfer_fee_config_authority.into(),
-        withdraw_withheld_authority: COption::Some(Pubkey::default()),
+        withdraw_withheld_authority: Some(Pubkey::default()),
         transfer_fee_basis_points: newer_transfer_fee.transfer_fee_basis_points.into(),
         maximum_fee: newer_transfer_fee.maximum_fee.into(),
     }])

--- a/token/rust/src/token.rs
+++ b/token/rust/src/token.rs
@@ -3,7 +3,6 @@ use solana_sdk::{
     account::Account as BaseAccount,
     instruction::Instruction,
     program_error::ProgramError,
-    program_option::COption,
     program_pack::Pack,
     pubkey::Pubkey,
     signer::{signers::Signers, Signer},
@@ -52,11 +51,11 @@ impl PartialEq for TokenError {
 #[derive(Clone, Debug, PartialEq)]
 pub enum ExtensionInitializationParams {
     MintCloseAuthority {
-        close_authority: COption<Pubkey>,
+        close_authority: Option<Pubkey>,
     },
     TransferFeeConfig {
-        transfer_fee_config_authority: COption<Pubkey>,
-        withdraw_withheld_authority: COption<Pubkey>,
+        transfer_fee_config_authority: Option<Pubkey>,
+        withdraw_withheld_authority: Option<Pubkey>,
         transfer_fee_basis_points: u16,
         maximum_fee: u64,
     },
@@ -73,7 +72,8 @@ impl ExtensionInitializationParams {
     pub fn instruction(self, mint: &Pubkey) -> Instruction {
         match self {
             Self::MintCloseAuthority { close_authority } => {
-                instruction::initialize_mint_close_authority(&id(), mint, close_authority).unwrap()
+                instruction::initialize_mint_close_authority(&id(), mint, close_authority.as_ref())
+                    .unwrap()
             }
             Self::TransferFeeConfig {
                 transfer_fee_config_authority,
@@ -81,9 +81,9 @@ impl ExtensionInitializationParams {
                 transfer_fee_basis_points,
                 maximum_fee,
             } => transfer_fee::instruction::initialize_transfer_fee_config(
-                *mint,
-                transfer_fee_config_authority,
-                withdraw_withheld_authority,
+                mint,
+                transfer_fee_config_authority.as_ref(),
+                withdraw_withheld_authority.as_ref(),
                 transfer_fee_basis_points,
                 maximum_fee,
             ),


### PR DESCRIPTION
#### Problem

Started writing some tests using extension ix builders. It's really tedious to have to remember which instructions and which fields take a Pubkey by reference vs not. Also, users shouldn't have to know about COptions at all.

#### Solution

Rewrite ix builders to use `&Pubkey` and `Option` consistently and handle conversions/deref under the hood
