### PR TITLE
token-2022: add more tests

### DIFF
--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -1113,10 +1113,15 @@ impl PrintProgramError for TokenError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::instruction::*;
+    use crate::{
+        extension::transfer_fee::instruction::initialize_transfer_fee_config, instruction::*,
+    };
     use solana_program::{
-        account_info::IntoAccountInfo, clock::Epoch, instruction::Instruction, program_error,
-        sysvar::rent,
+        account_info::IntoAccountInfo,
+        clock::Epoch,
+        instruction::Instruction,
+        program_error,
+        sysvar::{clock::Clock, rent},
     };
     use solana_sdk::account::{
         create_account_for_test, create_is_signer_account_infos, Account as SolanaAccount,
@@ -1144,8 +1149,11 @@ mod tests {
             Err(ProgramError::Custom(42)) // Not supported
         }
 
-        fn sol_get_clock_sysvar(&self, _var_addr: *mut u8) -> u64 {
-            program_error::UNSUPPORTED_SYSVAR
+        fn sol_get_clock_sysvar(&self, var_addr: *mut u8) -> u64 {
+            unsafe {
+                *(var_addr as *mut _ as *mut Clock) = Clock::default();
+            }
+            solana_program::entrypoint::SUCCESS
         }
 
         fn sol_get_epoch_schedule_sysvar(&self, _var_addr: *mut u8) -> u64 {
@@ -6597,7 +6605,35 @@ mod tests {
         )
         .unwrap();
 
-        // TODO: Extended mint
+        // Extended mint
+        let mint_len = ExtensionType::get_account_len::<Mint>(&[ExtensionType::TransferFeeConfig]);
+        let mut extended_mint_account = SolanaAccount::new(
+            Rent::default().minimum_balance(mint_len),
+            mint_len,
+            &program_id,
+        );
+        let extended_mint_key = Pubkey::new_unique();
+        do_process_instruction(
+            initialize_transfer_fee_config(&extended_mint_key, None, None, 10, 4242),
+            vec![&mut extended_mint_account],
+        )
+        .unwrap();
+        do_process_instruction(
+            initialize_mint(&program_id, &extended_mint_key, &owner_key, None, 2).unwrap(),
+            vec![&mut extended_mint_account, &mut rent_sysvar],
+        )
+        .unwrap();
+
+        set_expected_data(
+            ExtensionType::get_account_len::<Account>(&[ExtensionType::TransferFeeAmount])
+                .to_le_bytes()
+                .to_vec(),
+        );
+        do_process_instruction(
+            get_account_data_size(&program_id, &mint_key).unwrap(),
+            vec![&mut extended_mint_account],
+        )
+        .unwrap();
 
         // Invalid mint
         let mut invalid_mint_account = SolanaAccount::new(

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -149,6 +149,7 @@ impl Processor {
         };
 
         account.pack_base();
+        account.init_account_type()?;
 
         Ok(())
     }

--- a/token/program-2022/tests/initialize_account.rs
+++ b/token/program-2022/tests/initialize_account.rs
@@ -1,0 +1,256 @@
+#![cfg(feature = "test-bpf")]
+
+use {
+    solana_program_test::{processor, tokio, ProgramTest},
+    solana_sdk::{
+        instruction::InstructionError,
+        program_pack::Pack,
+        pubkey::Pubkey,
+        signature::Signer,
+        signer::keypair::Keypair,
+        system_instruction,
+        transaction::{Transaction, TransactionError},
+    },
+    spl_token_2022::{
+        error::TokenError,
+        extension::{
+            transfer_fee::{self, TransferFeeAmount},
+            ExtensionType, StateWithExtensions,
+        },
+        id, instruction,
+        processor::Processor,
+        state::{Account, Mint},
+    },
+};
+
+#[tokio::test]
+async fn no_extensions() {
+    let program_test = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
+    let mut ctx = program_test.start_with_context().await;
+    let rent = ctx.banks_client.get_rent().await.unwrap();
+    let mint_account = Keypair::new();
+    let mint_authority_pubkey = Pubkey::new_unique();
+
+    let space = ExtensionType::get_account_len::<Mint>(&[]);
+    let instructions = vec![
+        system_instruction::create_account(
+            &ctx.payer.pubkey(),
+            &mint_account.pubkey(),
+            rent.minimum_balance(space),
+            space as u64,
+            &spl_token_2022::id(),
+        ),
+        instruction::initialize_mint(
+            &spl_token_2022::id(),
+            &mint_account.pubkey(),
+            &mint_authority_pubkey,
+            None,
+            9,
+        )
+        .unwrap(),
+    ];
+    let tx = Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer, &mint_account],
+        ctx.last_blockhash,
+    );
+    ctx.banks_client.process_transaction(tx).await.unwrap();
+
+    let account = Keypair::new();
+    let account_owner_pubkey = Pubkey::new_unique();
+    let space = ExtensionType::get_account_len::<Account>(&[]);
+    let instructions = vec![
+        system_instruction::create_account(
+            &ctx.payer.pubkey(),
+            &account.pubkey(),
+            rent.minimum_balance(space),
+            space as u64,
+            &spl_token_2022::id(),
+        ),
+        instruction::initialize_account3(
+            &spl_token_2022::id(),
+            &account.pubkey(),
+            &mint_account.pubkey(),
+            &account_owner_pubkey,
+        )
+        .unwrap(),
+    ];
+    let tx = Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer, &account],
+        ctx.last_blockhash,
+    );
+    ctx.banks_client.process_transaction(tx).await.unwrap();
+    let account_info = ctx
+        .banks_client
+        .get_account(account.pubkey())
+        .await
+        .expect("get_account")
+        .expect("account not none");
+    assert_eq!(account_info.data.len(), spl_token_2022::state::Account::LEN);
+    assert_eq!(account_info.owner, spl_token_2022::id());
+    assert_eq!(account_info.lamports, rent.minimum_balance(space));
+}
+
+#[tokio::test]
+async fn fail_on_invalid_mint() {
+    let program_test = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
+    let mut ctx = program_test.start_with_context().await;
+    let rent = ctx.banks_client.get_rent().await.unwrap();
+    let mint_account = Keypair::new();
+
+    let space = ExtensionType::get_account_len::<Mint>(&[]);
+    let instructions = vec![system_instruction::create_account(
+        &ctx.payer.pubkey(),
+        &mint_account.pubkey(),
+        rent.minimum_balance(space),
+        space as u64,
+        &spl_token_2022::id(),
+    )];
+    let tx = Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer, &mint_account],
+        ctx.last_blockhash,
+    );
+    ctx.banks_client.process_transaction(tx).await.unwrap();
+
+    let account = Keypair::new();
+    let account_owner_pubkey = Pubkey::new_unique();
+    let space = ExtensionType::get_account_len::<Account>(&[]);
+    let instructions = vec![
+        system_instruction::create_account(
+            &ctx.payer.pubkey(),
+            &account.pubkey(),
+            rent.minimum_balance(space),
+            space as u64,
+            &spl_token_2022::id(),
+        ),
+        instruction::initialize_account3(
+            &spl_token_2022::id(),
+            &account.pubkey(),
+            &mint_account.pubkey(),
+            &account_owner_pubkey,
+        )
+        .unwrap(),
+    ];
+    let tx = Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer, &account],
+        ctx.last_blockhash,
+    );
+    #[allow(clippy::useless_conversion)]
+    let err: TransactionError = ctx
+        .banks_client
+        .process_transaction(tx)
+        .await
+        .unwrap_err()
+        .unwrap()
+        .into();
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(
+            1,
+            InstructionError::Custom(TokenError::InvalidMint as u32)
+        )
+    );
+}
+
+#[tokio::test]
+async fn single_extension() {
+    let program_test = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
+    let mut ctx = program_test.start_with_context().await;
+    let rent = ctx.banks_client.get_rent().await.unwrap();
+    let mint_account = Keypair::new();
+    let mint_authority_pubkey = Pubkey::new_unique();
+
+    let space = ExtensionType::get_account_len::<Mint>(&[ExtensionType::TransferFeeConfig]);
+    let instructions = vec![
+        system_instruction::create_account(
+            &ctx.payer.pubkey(),
+            &mint_account.pubkey(),
+            rent.minimum_balance(space),
+            space as u64,
+            &spl_token_2022::id(),
+        ),
+        transfer_fee::instruction::initialize_transfer_fee_config(
+            &mint_account.pubkey(),
+            None,
+            None,
+            10,
+            4242,
+        ),
+        instruction::initialize_mint(
+            &spl_token_2022::id(),
+            &mint_account.pubkey(),
+            &mint_authority_pubkey,
+            None,
+            9,
+        )
+        .unwrap(),
+    ];
+    let tx = Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer, &mint_account],
+        ctx.last_blockhash,
+    );
+    ctx.banks_client.process_transaction(tx).await.unwrap();
+
+    let account = Keypair::new();
+    let account_owner_pubkey = Pubkey::new_unique();
+    let space = ExtensionType::get_account_len::<Account>(&[ExtensionType::TransferFeeAmount]);
+    let instructions = vec![
+        system_instruction::create_account(
+            &ctx.payer.pubkey(),
+            &account.pubkey(),
+            rent.minimum_balance(space),
+            space as u64,
+            &spl_token_2022::id(),
+        ),
+        instruction::initialize_account3(
+            &spl_token_2022::id(),
+            &account.pubkey(),
+            &mint_account.pubkey(),
+            &account_owner_pubkey,
+        )
+        .unwrap(),
+    ];
+    let tx = Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer, &account],
+        ctx.last_blockhash,
+    );
+    ctx.banks_client.process_transaction(tx).await.unwrap();
+    let account_info = ctx
+        .banks_client
+        .get_account(account.pubkey())
+        .await
+        .expect("get_account")
+        .expect("account not none");
+    assert_eq!(
+        account_info.data.len(),
+        ExtensionType::get_account_len::<Account>(&[ExtensionType::TransferFeeAmount]),
+    );
+    assert_eq!(account_info.owner, spl_token_2022::id());
+    assert_eq!(account_info.lamports, rent.minimum_balance(space));
+    let state = StateWithExtensions::<Account>::unpack(&account_info.data).unwrap();
+    assert_eq!(state.base.mint, mint_account.pubkey());
+    assert_eq!(
+        &state.get_extension_types().unwrap(),
+        &[ExtensionType::TransferFeeAmount]
+    );
+    let unpacked_extension = state.get_extension::<TransferFeeAmount>().unwrap();
+    assert_eq!(
+        *unpacked_extension,
+        TransferFeeAmount {
+            withheld_amount: 0.into()
+        }
+    );
+}
+
+// TODO: add test for multiple Account extensions when memo extension is present


### PR DESCRIPTION
Now that InitializeMint with extensions is supported, can flesh out TODOs:
- test_get_account_data_size unit test with extended mint
- ProgramTest tests for InitializeAccounts

More tests via rust client to come after ATA support is complete in #2738

Needs rebase on #2782