### PR TITLE
Governance: Realm authority validation

### DIFF
--- a/governance/program/src/processor/mod.rs
+++ b/governance/program/src/processor/mod.rs
@@ -190,9 +190,9 @@ pub fn process_instruction(
         GovernanceInstruction::FlagInstructionError {} => {
             process_flag_instruction_error(program_id, accounts)
         }
-        GovernanceInstruction::SetRealmAuthority {
-            new_realm_authority,
-        } => process_set_realm_authority(program_id, accounts, new_realm_authority),
+        GovernanceInstruction::SetRealmAuthority { remove_authority } => {
+            process_set_realm_authority(program_id, accounts, remove_authority)
+        }
         GovernanceInstruction::SetRealmConfig { config_args } => {
             process_set_realm_config(program_id, accounts, config_args)
         }

--- a/governance/program/src/processor/process_set_realm_authority.rs
+++ b/governance/program/src/processor/process_set_realm_authority.rs
@@ -34,6 +34,8 @@ pub fn process_set_realm_authority(
         None
     } else {
         // Ensure the new realm authority is one of the governances from the realm
+        // Note: This is not a security feature because governance creation is only gated with min_community_tokens_to_create_governance
+        //       The check is done to prevent scenarios where the authority could be accidentally set to a wrong or none existing account
         let new_realm_authority_info = next_account_info(account_info_iter)?; // 2
         assert_governance_for_realm(program_id, new_realm_authority_info, realm_info.key)?;
 

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -127,6 +127,16 @@ pub fn get_governance_data_for_realm(
     Ok(governance_data)
 }
 
+/// Checks the given account is a governance account and belongs to the given realm
+pub fn assert_governance_for_realm(
+    program_id: &Pubkey,
+    governance_info: &AccountInfo,
+    realm: &Pubkey,
+) -> Result<(), ProgramError> {
+    get_governance_data_for_realm(program_id, governance_info, realm)?;
+    Ok(())
+}
+
 /// Returns ProgramGovernance PDA seeds
 pub fn get_program_governance_address_seeds<'a>(
     realm: &'a Pubkey,

--- a/governance/program/src/state/legacy.rs
+++ b/governance/program/src/state/legacy.rs
@@ -83,7 +83,7 @@ pub struct RealmV1 {
     pub reserved: [u8; 8],
 
     /// Realm authority. The authority must sign transactions which update the realm config
-    /// The authority should be transferer to Realm Governance to make the Realm self governed through proposals
+    /// The authority should be transferred to Realm Governance to make the Realm self governed through proposals
     pub authority: Option<Pubkey>,
 
     /// Governance Realm name

--- a/governance/program/src/state/legacy.rs
+++ b/governance/program/src/state/legacy.rs
@@ -83,7 +83,7 @@ pub struct RealmV1 {
     pub reserved: [u8; 8],
 
     /// Realm authority. The authority must sign transactions which update the realm config
-    /// The authority can be transferer to Realm Governance and hence make the Realm self governed through proposals
+    /// The authority should be transferer to Realm Governance to make the Realm self governed through proposals
     pub authority: Option<Pubkey>,
 
     /// Governance Realm name

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -70,7 +70,7 @@ pub struct Realm {
     pub reserved: [u8; 8],
 
     /// Realm authority. The authority must sign transactions which update the realm config
-    /// The authority can be transferer to Realm Governance and hence make the Realm self governed through proposals
+    /// The authority should be transferer to Realm Governance to make the Realm self governed through proposals
     pub authority: Option<Pubkey>,
 
     /// Governance Realm name

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -70,7 +70,7 @@ pub struct Realm {
     pub reserved: [u8; 8],
 
     /// Realm authority. The authority must sign transactions which update the realm config
-    /// The authority should be transferer to Realm Governance to make the Realm self governed through proposals
+    /// The authority should be transferred to Realm Governance to make the Realm self governed through proposals
     pub authority: Option<Pubkey>,
 
     /// Governance Realm name

--- a/governance/program/tests/process_set_realm_authority.rs
+++ b/governance/program/tests/process_set_realm_authority.rs
@@ -7,6 +7,7 @@ mod program_test;
 
 use program_test::*;
 use spl_governance::error::GovernanceError;
+use spl_governance_tools::error::GovernanceToolsError;
 
 #[tokio::test]
 async fn test_set_realm_authority() {
@@ -15,7 +16,23 @@ async fn test_set_realm_authority() {
 
     let realm_cookie = governance_test.with_realm().await;
 
-    let new_realm_authority = Pubkey::new_unique();
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let account_governance_cookie = governance_test
+        .with_account_governance(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let new_realm_authority = account_governance_cookie.address;
 
     // Act
     governance_test
@@ -29,6 +46,26 @@ async fn test_set_realm_authority() {
         .await;
 
     assert_eq!(realm_account.authority, Some(new_realm_authority));
+}
+
+#[tokio::test]
+async fn test_set_realm_authority_with_non_existing_new_authority_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let new_realm_authority = Pubkey::new_unique();
+
+    // Act
+    let err = governance_test
+        .set_realm_authority(&realm_cookie, &Some(new_realm_authority))
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceToolsError::AccountDoesNotExist.into());
 }
 
 #[tokio::test]
@@ -124,4 +161,43 @@ async fn test_set_realm_authority_with_authority_must_sign_error() {
 
     // Assert
     assert_eq!(err, GovernanceError::RealmAuthorityMustSign.into());
+}
+
+#[tokio::test]
+async fn test_set_realm_authority_with_governance_from_other_realm_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    // Setup other realm
+    let realm_cookie2 = governance_test.with_realm().await;
+
+    let governed_account_cookie2 = governance_test.with_governed_account().await;
+
+    let token_owner_record_cookie2 = governance_test
+        .with_community_token_deposit(&realm_cookie2)
+        .await
+        .unwrap();
+
+    let account_governance_cookie2 = governance_test
+        .with_account_governance(
+            &realm_cookie2,
+            &governed_account_cookie2,
+            &token_owner_record_cookie2,
+        )
+        .await
+        .unwrap();
+
+    let new_realm_authority = account_governance_cookie2.address;
+
+    // Act
+    let err = governance_test
+        .set_realm_authority(&realm_cookie, &Some(new_realm_authority))
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::InvalidRealmForGovernance.into());
 }


### PR DESCRIPTION
#### Summary

When  a `realm` is created its `realm_authority` is initially set to some wallet (usually the realm's creator). 
After governances are added to the `realm` then one of them is elected as the `realm_authority` 

The purpose of this change it to prevent footgun scenario where the authority could be set to none existing or wrong account 



