### PR TITLE
token-2022: plumb program_id through instruction builders

### DIFF
--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -6615,7 +6615,8 @@ mod tests {
         );
         let extended_mint_key = Pubkey::new_unique();
         do_process_instruction(
-            initialize_transfer_fee_config(&extended_mint_key, None, None, 10, 4242),
+            initialize_transfer_fee_config(&program_id, &extended_mint_key, None, None, 10, 4242)
+                .unwrap(),
             vec![&mut extended_mint_account],
         )
         .unwrap();

--- a/token/program-2022/tests/initialize_account.rs
+++ b/token/program-2022/tests/initialize_account.rs
@@ -177,12 +177,14 @@ async fn single_extension() {
             &spl_token_2022::id(),
         ),
         transfer_fee::instruction::initialize_transfer_fee_config(
+            &spl_token_2022::id(),
             &mint_account.pubkey(),
             None,
             None,
             10,
             4242,
-        ),
+        )
+        .unwrap(),
         instruction::initialize_mint(
             &spl_token_2022::id(),
             &mint_account.pubkey(),

--- a/token/program-2022/tests/initialize_mint.rs
+++ b/token/program-2022/tests/initialize_mint.rs
@@ -441,12 +441,14 @@ async fn fail_fee_init_after_mint_init() {
         )
         .unwrap(),
         transfer_fee::instruction::initialize_transfer_fee_config(
+            &spl_token_2022::id(),
             &mint_account.pubkey(),
             Some(&Pubkey::new_unique()),
             Some(&Pubkey::new_unique()),
             10,
             100,
-        ),
+        )
+        .unwrap(),
     ];
 
     let tx = Transaction::new_signed_with_payer(

--- a/token/rust/src/token.rs
+++ b/token/rust/src/token.rs
@@ -69,11 +69,15 @@ impl ExtensionInitializationParams {
         }
     }
     /// Generate an appropriate initialization instruction for the given mint
-    pub fn instruction(self, mint: &Pubkey) -> Instruction {
+    pub fn instruction(self, token_program_id: &Pubkey, mint: &Pubkey) -> Instruction {
         match self {
             Self::MintCloseAuthority { close_authority } => {
-                instruction::initialize_mint_close_authority(&id(), mint, close_authority.as_ref())
-                    .unwrap()
+                instruction::initialize_mint_close_authority(
+                    token_program_id,
+                    mint,
+                    close_authority.as_ref(),
+                )
+                .unwrap()
             }
             Self::TransferFeeConfig {
                 transfer_fee_config_authority,
@@ -81,12 +85,14 @@ impl ExtensionInitializationParams {
                 transfer_fee_basis_points,
                 maximum_fee,
             } => transfer_fee::instruction::initialize_transfer_fee_config(
+                token_program_id,
                 mint,
                 transfer_fee_config_authority.as_ref(),
                 withdraw_withheld_authority.as_ref(),
                 transfer_fee_basis_points,
                 maximum_fee,
-            ),
+            )
+            .unwrap(),
         }
     }
 }
@@ -191,7 +197,7 @@ where
         )];
         let mut init_instructions = extension_initialization_params
             .into_iter()
-            .map(|e| e.instruction(&mint_pubkey))
+            .map(|e| e.instruction(&id(), &mint_pubkey))
             .collect::<Vec<_>>();
         instructions.append(&mut init_instructions);
         instructions.push(instruction::initialize_mint(


### PR DESCRIPTION
Passing in the token program-id instead of hard-coding it will facilitate supporting multiple token program ids -- for usages like a staging program -- in the future.