### PR TITLE
spl-token-cli: Add global `--program-id` argument

### DIFF
--- a/associated-token-account/program/src/instruction.rs
+++ b/associated-token-account/program/src/instruction.rs
@@ -27,20 +27,6 @@ pub fn create_associated_token_account(
     funding_address: &Pubkey,
     wallet_address: &Pubkey,
     token_mint_address: &Pubkey,
-) -> Instruction {
-    create_associated_token_account_with_program_id(
-        funding_address,
-        wallet_address,
-        token_mint_address,
-        &spl_token::id(),
-    )
-}
-
-/// Creates CreateAssociatedTokenAccount instruction
-pub fn create_associated_token_account_with_program_id(
-    funding_address: &Pubkey,
-    wallet_address: &Pubkey,
-    token_mint_address: &Pubkey,
     token_program_id: &Pubkey,
 ) -> Instruction {
     let associated_account_address =

--- a/associated-token-account/program/src/instruction.rs
+++ b/associated-token-account/program/src/instruction.rs
@@ -26,10 +26,25 @@ pub enum AssociatedTokenAccountInstruction {
 pub fn create_associated_token_account(
     funding_address: &Pubkey,
     wallet_address: &Pubkey,
-    spl_token_mint_address: &Pubkey,
+    token_mint_address: &Pubkey,
+) -> Instruction {
+    create_associated_token_account_with_program_id(
+        funding_address,
+        wallet_address,
+        token_mint_address,
+        &spl_token::id(),
+    )
+}
+
+/// Creates CreateAssociatedTokenAccount instruction
+pub fn create_associated_token_account_with_program_id(
+    funding_address: &Pubkey,
+    wallet_address: &Pubkey,
+    token_mint_address: &Pubkey,
+    token_program_id: &Pubkey,
 ) -> Instruction {
     let associated_account_address =
-        get_associated_token_address(wallet_address, spl_token_mint_address);
+        get_associated_token_address(wallet_address, token_mint_address);
 
     let instruction_data = AssociatedTokenAccountInstruction::Create {};
 
@@ -39,9 +54,9 @@ pub fn create_associated_token_account(
             AccountMeta::new(*funding_address, true),
             AccountMeta::new(associated_account_address, false),
             AccountMeta::new_readonly(*wallet_address, false),
-            AccountMeta::new_readonly(*spl_token_mint_address, false),
+            AccountMeta::new_readonly(*token_mint_address, false),
             AccountMeta::new_readonly(solana_program::system_program::id(), false),
-            AccountMeta::new_readonly(spl_token::id(), false),
+            AccountMeta::new_readonly(*token_program_id, false),
         ],
         data: instruction_data.try_to_vec().unwrap(),
     }

--- a/associated-token-account/program/src/lib.rs
+++ b/associated-token-account/program/src/lib.rs
@@ -96,7 +96,7 @@ pub fn create_associated_token_account(
     token_mint_address: &Pubkey,
 ) -> Instruction {
     let associated_account_address =
-        get_associated_token_address(wallet_address, spl_token_mint_address);
+        get_associated_token_address(wallet_address, token_mint_address);
 
     Instruction {
         program_id: id(),

--- a/associated-token-account/program/src/lib.rs
+++ b/associated-token-account/program/src/lib.rs
@@ -20,28 +20,48 @@ solana_program::declare_id!("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
 
 pub(crate) fn get_associated_token_address_and_bump_seed(
     wallet_address: &Pubkey,
-    spl_token_mint_address: &Pubkey,
+    token_mint_address: &Pubkey,
     program_id: &Pubkey,
+    token_program_id: &Pubkey,
 ) -> (Pubkey, u8) {
     get_associated_token_address_and_bump_seed_internal(
         wallet_address,
-        spl_token_mint_address,
+        token_mint_address,
         program_id,
-        &spl_token::id(),
+        token_program_id,
     )
 }
 
 /// Derives the associated token account address for the given wallet address and token mint
 pub fn get_associated_token_address(
     wallet_address: &Pubkey,
-    spl_token_mint_address: &Pubkey,
+    token_mint_address: &Pubkey,
 ) -> Pubkey {
-    get_associated_token_address_and_bump_seed(wallet_address, spl_token_mint_address, &id()).0
+    get_associated_token_address_with_program_id(
+        wallet_address,
+        token_mint_address,
+        &spl_token::id(),
+    )
+}
+
+/// Derives the associated token account address for the given wallet address, token mint and token program id
+pub fn get_associated_token_address_with_program_id(
+    wallet_address: &Pubkey,
+    token_mint_address: &Pubkey,
+    token_program_id: &Pubkey,
+) -> Pubkey {
+    get_associated_token_address_and_bump_seed(
+        wallet_address,
+        token_mint_address,
+        &id(),
+        token_program_id,
+    )
+    .0
 }
 
 fn get_associated_token_address_and_bump_seed_internal(
     wallet_address: &Pubkey,
-    spl_token_mint_address: &Pubkey,
+    token_mint_address: &Pubkey,
     program_id: &Pubkey,
     token_program_id: &Pubkey,
 ) -> (Pubkey, u8) {
@@ -49,7 +69,7 @@ fn get_associated_token_address_and_bump_seed_internal(
         &[
             &wallet_address.to_bytes(),
             &token_program_id.to_bytes(),
-            &spl_token_mint_address.to_bytes(),
+            &token_mint_address.to_bytes(),
         ],
         program_id,
     )
@@ -73,7 +93,7 @@ fn get_associated_token_address_and_bump_seed_internal(
 pub fn create_associated_token_account(
     funding_address: &Pubkey,
     wallet_address: &Pubkey,
-    spl_token_mint_address: &Pubkey,
+    token_mint_address: &Pubkey,
 ) -> Instruction {
     let associated_account_address =
         get_associated_token_address(wallet_address, spl_token_mint_address);
@@ -84,7 +104,7 @@ pub fn create_associated_token_account(
             AccountMeta::new(*funding_address, true),
             AccountMeta::new(associated_account_address, false),
             AccountMeta::new_readonly(*wallet_address, false),
-            AccountMeta::new_readonly(*spl_token_mint_address, false),
+            AccountMeta::new_readonly(*token_mint_address, false),
             AccountMeta::new_readonly(solana_program::system_program::id(), false),
             AccountMeta::new_readonly(spl_token::id(), false),
             AccountMeta::new_readonly(sysvar::rent::id(), false),

--- a/associated-token-account/program/tests/process_create_associated_token_account.rs
+++ b/associated-token-account/program/tests/process_create_associated_token_account.rs
@@ -46,6 +46,7 @@ async fn test_associated_token_address() {
             &payer.pubkey(),
             &wallet_address,
             &token_mint_address,
+            &spl_token::id(),
         )],
         Some(&payer.pubkey()),
     );
@@ -105,6 +106,7 @@ async fn test_create_with_fewer_lamports() {
             &payer.pubkey(),
             &wallet_address,
             &token_mint_address,
+            &spl_token::id(),
         )],
         Some(&payer.pubkey()),
     );
@@ -158,6 +160,7 @@ async fn test_create_with_excess_lamports() {
             &payer.pubkey(),
             &wallet_address,
             &token_mint_address,
+            &spl_token::id(),
         )],
         Some(&payer.pubkey()),
     );
@@ -183,8 +186,12 @@ async fn test_create_account_mismatch() {
     let (mut banks_client, payer, recent_blockhash) =
         program_test(token_mint_address, true).start().await;
 
-    let mut instruction =
-        create_associated_token_account(&payer.pubkey(), &wallet_address, &token_mint_address);
+    let mut instruction = create_associated_token_account(
+        &payer.pubkey(),
+        &wallet_address,
+        &token_mint_address,
+        &spl_token::id(),
+    );
     instruction.accounts[1] = AccountMeta::new(Pubkey::default(), false); // <-- Invalid associated_account_address
 
     let mut transaction = Transaction::new_with_payer(&[instruction], Some(&payer.pubkey()));
@@ -198,8 +205,12 @@ async fn test_create_account_mismatch() {
         TransactionError::InstructionError(0, InstructionError::InvalidSeeds)
     );
 
-    let mut instruction =
-        create_associated_token_account(&payer.pubkey(), &wallet_address, &token_mint_address);
+    let mut instruction = create_associated_token_account(
+        &payer.pubkey(),
+        &wallet_address,
+        &token_mint_address,
+        &spl_token::id(),
+    );
     instruction.accounts[2] = AccountMeta::new(Pubkey::default(), false); // <-- Invalid wallet_address
 
     let mut transaction = Transaction::new_with_payer(&[instruction], Some(&payer.pubkey()));
@@ -213,8 +224,12 @@ async fn test_create_account_mismatch() {
         TransactionError::InstructionError(0, InstructionError::InvalidSeeds)
     );
 
-    let mut instruction =
-        create_associated_token_account(&payer.pubkey(), &wallet_address, &token_mint_address);
+    let mut instruction = create_associated_token_account(
+        &payer.pubkey(),
+        &wallet_address,
+        &token_mint_address,
+        &spl_token::id(),
+    );
     instruction.accounts[3] = AccountMeta::new(Pubkey::default(), false); // <-- Invalid token_mint_address
 
     let mut transaction = Transaction::new_with_payer(&[instruction], Some(&payer.pubkey()));
@@ -250,8 +265,12 @@ async fn test_create_associated_token_account_using_legacy_implicit_instruction(
         None,
     );
 
-    let mut create_associated_token_account_ix =
-        create_associated_token_account(&payer.pubkey(), &wallet_address, &token_mint_address);
+    let mut create_associated_token_account_ix = create_associated_token_account(
+        &payer.pubkey(),
+        &wallet_address,
+        &token_mint_address,
+        &spl_token::id(),
+    );
 
     // Use implicit  instruction and rent account to replicate the legacy invocation
     create_associated_token_account_ix.data = vec![];

--- a/stake-pool/cli/Cargo.toml
+++ b/stake-pool/cli/Cargo.toml
@@ -23,7 +23,7 @@ solana-logger = "=1.9.5"
 solana-program = "=1.9.5"
 solana-remote-wallet = "=1.9.5"
 solana-sdk = "=1.9.5"
-spl-associated-token-account = { version = "1.0", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
+spl-associated-token-account = { version = "1.0.5", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
 spl-stake-pool = { version = "0.6", path="../program", features = [ "no-entrypoint" ] }
 spl-token = { version = "3.3", path="../../token/program", features = [ "no-entrypoint" ]  }
 bs58 = "0.4.0"

--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -641,6 +641,7 @@ fn add_associated_token_account(
             &config.fee_payer.pubkey(),
             owner,
             mint,
+            &spl_token::id(),
         ));
 
         *rent_free_balances += min_account_balance;

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -25,7 +25,7 @@ solana-remote-wallet = "=1.9.5"
 solana-sdk = "=1.9.5"
 solana-transaction-status = "=1.9.5"
 spl-token = { version = "3.3", path="../program", features = [ "no-entrypoint" ] }
-spl-associated-token-account = { version = "1.0", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
+spl-associated-token-account = { version = "1.0.5", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
 spl-memo = { version = "3.0.1", path="../../memo/program", features = ["no-entrypoint"] }
 
 [[bin]]

--- a/token/cli/src/config.rs
+++ b/token/cli/src/config.rs
@@ -22,6 +22,7 @@ pub(crate) struct Config<'a> {
     pub(crate) sign_only: bool,
     pub(crate) dump_transaction_message: bool,
     pub(crate) multisigner_pubkeys: Vec<&'a Pubkey>,
+    pub(crate) program_id: Pubkey,
 }
 
 impl<'a> Config<'a> {
@@ -63,7 +64,7 @@ impl<'a> Config<'a> {
                 eprintln!("error: {}", e);
                 exit(1);
             });
-        get_associated_token_address(&owner, &token)
+        get_associated_token_address_with_program_id(&owner, &token, &self.program_id)
     }
 
     // Checks if an explicit address was provided, otherwise return the default address.

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -42,8 +42,7 @@ use solana_sdk::{
     transaction::Transaction,
 };
 use spl_associated_token_account::{
-    get_associated_token_address_with_program_id,
-    instruction::create_associated_token_account_with_program_id,
+    get_associated_token_address_with_program_id, instruction::create_associated_token_account,
 };
 use spl_token::{
     instruction::*,
@@ -383,7 +382,7 @@ fn command_create_account(
         (
             account,
             true,
-            vec![create_associated_token_account_with_program_id(
+            vec![create_associated_token_account(
                 &config.fee_payer,
                 &owner,
                 &token,
@@ -780,7 +779,7 @@ fn command_transfer(
                         ),
                     );
                 }
-                instructions.push(create_associated_token_account_with_program_id(
+                instructions.push(create_associated_token_account(
                     &config.fee_payer,
                     &recipient,
                     &mint_pubkey,
@@ -1093,7 +1092,7 @@ fn command_wrap(
         println_display(config, format!("Wrapping {} SOL into {}", sol, account));
         vec![
             system_instruction::transfer(&wallet_address, &account, lamports),
-            create_associated_token_account_with_program_id(
+            create_associated_token_account(
                 &config.fee_payer,
                 &wallet_address,
                 &native_mint::id(),
@@ -1548,7 +1547,7 @@ fn command_gc(
 
         if total_balance > 0 && !accounts.contains_key(&associated_token_account) {
             // Create the associated token account
-            instructions.push(vec![create_associated_token_account_with_program_id(
+            instructions.push(vec![create_associated_token_account(
                 &config.fee_payer,
                 &owner,
                 &token,

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -10,7 +10,7 @@ use solana_account_decoder::{
 };
 use solana_clap_utils::{
     fee_payer::fee_payer_arg,
-    input_parsers::{pubkey_of_signer, pubkeys_of_multiple_signers, value_of},
+    input_parsers::{pubkey_of, pubkey_of_signer, pubkeys_of_multiple_signers, value_of},
     input_validators::{
         is_amount, is_amount_or_all, is_parsable, is_url_or_moniker, is_valid_pubkey,
         is_valid_signer, normalize_to_url_if_moniker,
@@ -42,10 +42,10 @@ use solana_sdk::{
     transaction::Transaction,
 };
 use spl_associated_token_account::{
-    get_associated_token_address, instruction::create_associated_token_account,
+    get_associated_token_address_with_program_id,
+    instruction::create_associated_token_account_with_program_id,
 };
 use spl_token::{
-    self,
     instruction::*,
     native_mint,
     state::{Account, Mint, Multisig},
@@ -305,10 +305,10 @@ fn command_create_token(
             &token,
             minimum_balance_for_rent_exemption,
             Mint::LEN as u64,
-            &spl_token::id(),
+            &config.program_id,
         ),
         initialize_mint(
-            &spl_token::id(),
+            &config.program_id,
             &token,
             &authority,
             freeze_authority_pubkey.as_ref(),
@@ -371,21 +371,23 @@ fn command_create_account(
                     &account,
                     minimum_balance_for_rent_exemption,
                     Account::LEN as u64,
-                    &spl_token::id(),
+                    &config.program_id,
                 ),
-                initialize_account(&spl_token::id(), &account, &token, &owner)?,
+                initialize_account(&config.program_id, &account, &token, &owner)?,
             ],
         )
     } else {
-        let account = get_associated_token_address(&owner, &token);
+        let account =
+            get_associated_token_address_with_program_id(&owner, &token, &config.program_id);
         println_display(config, format!("Creating account {}", account));
         (
             account,
             true,
-            vec![create_associated_token_account(
+            vec![create_associated_token_account_with_program_id(
                 &config.fee_payer,
                 &owner,
                 &token,
+                &config.program_id,
             )],
         )
     };
@@ -453,10 +455,10 @@ fn command_create_multisig(
             &multisig,
             minimum_balance_for_rent_exemption,
             Multisig::LEN as u64,
-            &spl_token::id(),
+            &config.program_id,
         ),
         initialize_multisig(
-            &spl_token::id(),
+            &config.program_id,
             &multisig,
             multisig_members.iter().collect::<Vec<_>>().as_slice(),
             minimum_signers,
@@ -511,8 +513,11 @@ fn command_authorize(
             }
         } else if let Ok(token_account) = Account::unpack(&target_account.data) {
             let check_associated_token_account = || -> Result<(), Error> {
-                let maybe_associated_token_account =
-                    get_associated_token_address(&token_account.owner, &token_account.mint);
+                let maybe_associated_token_account = get_associated_token_address_with_program_id(
+                    &token_account.owner,
+                    &token_account.mint,
+                    &config.program_id,
+                );
                 if account == maybe_associated_token_account
                     && !force_authorize
                     && Some(authority) != new_authority
@@ -566,7 +571,7 @@ fn command_authorize(
     );
 
     let instructions = vec![set_authority(
-        &spl_token::id(),
+        &config.program_id,
         &account,
         new_authority.as_ref(),
         authority_type,
@@ -650,7 +655,7 @@ fn command_transfer(
     let sender = if let Some(sender) = sender {
         sender
     } else {
-        get_associated_token_address(&sender_owner, &token)
+        get_associated_token_address_with_program_id(&sender_owner, &token, &config.program_id)
     };
     let (mint_pubkey, decimals) = resolve_mint_info(config, &sender, Some(token), mint_decimals)?;
     let maybe_transfer_balance =
@@ -705,7 +710,9 @@ fn command_transfer(
             .rpc_client
             .get_account_with_commitment(&recipient, config.rpc_client.commitment())?
             .value
-            .map(|account| account.owner == spl_token::id() && account.data.len() == Account::LEN);
+            .map(|account| {
+                account.owner == config.program_id && account.data.len() == Account::LEN
+            });
 
         if recipient_account_info.is_none() && !allow_unfunded_recipient {
             return Err("Error: The recipient address is not funded. \
@@ -720,7 +727,11 @@ fn command_transfer(
     };
 
     if !recipient_is_token_account {
-        recipient_token_account = get_associated_token_address(&recipient, &mint_pubkey);
+        recipient_token_account = get_associated_token_address_with_program_id(
+            &recipient,
+            &mint_pubkey,
+            &config.program_id,
+        );
         println_display(
             config,
             format!(
@@ -740,7 +751,7 @@ fn command_transfer(
             {
                 if recipient_token_account_data.owner == system_program::id() {
                     true
-                } else if recipient_token_account_data.owner == spl_token::id() {
+                } else if recipient_token_account_data.owner == config.program_id {
                     false
                 } else {
                     return Err(
@@ -769,10 +780,11 @@ fn command_transfer(
                         ),
                     );
                 }
-                instructions.push(create_associated_token_account(
+                instructions.push(create_associated_token_account_with_program_id(
                     &config.fee_payer,
                     &recipient,
                     &mint_pubkey,
+                    &config.program_id,
                 ));
             } else {
                 return Err(
@@ -786,7 +798,7 @@ fn command_transfer(
 
     if use_unchecked_instruction {
         instructions.push(transfer(
-            &spl_token::id(),
+            &config.program_id,
             &sender,
             &recipient_token_account,
             &sender_owner,
@@ -795,7 +807,7 @@ fn command_transfer(
         )?);
     } else {
         instructions.push(transfer_checked(
-            &spl_token::id(),
+            &config.program_id,
             &sender,
             &mint_pubkey,
             &recipient_token_account,
@@ -849,7 +861,7 @@ fn command_burn(
 
     let mut instructions = if use_unchecked_instruction {
         vec![burn(
-            &spl_token::id(),
+            &config.program_id,
             &source,
             &mint_pubkey,
             &source_owner,
@@ -858,7 +870,7 @@ fn command_burn(
         )?]
     } else {
         vec![burn_checked(
-            &spl_token::id(),
+            &config.program_id,
             &source,
             &mint_pubkey,
             &source_owner,
@@ -913,7 +925,7 @@ fn command_mint(
 
     let instructions = if use_unchecked_instruction {
         vec![mint_to(
-            &spl_token::id(),
+            &config.program_id,
             &token,
             &recipient,
             &mint_authority,
@@ -922,7 +934,7 @@ fn command_mint(
         )?]
     } else {
         vec![mint_to_checked(
-            &spl_token::id(),
+            &config.program_id,
             &token,
             &recipient,
             &mint_authority,
@@ -965,7 +977,7 @@ fn command_freeze(
     );
 
     let instructions = vec![freeze_account(
-        &spl_token::id(),
+        &config.program_id,
         &account,
         &token,
         &freeze_authority,
@@ -1005,7 +1017,7 @@ fn command_thaw(
     );
 
     let instructions = vec![thaw_account(
-        &spl_token::id(),
+        &config.program_id,
         &account,
         &token,
         &freeze_authority,
@@ -1050,17 +1062,21 @@ fn command_wrap(
                 &wrapped_sol_account,
                 lamports,
                 Account::LEN as u64,
-                &spl_token::id(),
+                &config.program_id,
             ),
             initialize_account(
-                &spl_token::id(),
+                &config.program_id,
                 &wrapped_sol_account,
                 &native_mint::id(),
                 &wallet_address,
             )?,
         ]
     } else {
-        let account = get_associated_token_address(&wallet_address, &native_mint::id());
+        let account = get_associated_token_address_with_program_id(
+            &wallet_address,
+            &native_mint::id(),
+            &config.program_id,
+        );
 
         if !config.sign_only {
             if let Some(account_data) = config
@@ -1077,7 +1093,12 @@ fn command_wrap(
         println_display(config, format!("Wrapping {} SOL into {}", sol, account));
         vec![
             system_instruction::transfer(&wallet_address, &account, lamports),
-            create_associated_token_account(&config.fee_payer, &wallet_address, &native_mint::id()),
+            create_associated_token_account_with_program_id(
+                &config.fee_payer,
+                &wallet_address,
+                &native_mint::id(),
+                &config.program_id,
+            ),
         ]
     };
     if !config.sign_only {
@@ -1109,8 +1130,13 @@ fn command_unwrap(
     bulk_signers: BulkSigners,
 ) -> CommandResult {
     let use_associated_account = address.is_none();
-    let address = address
-        .unwrap_or_else(|| get_associated_token_address(&wallet_address, &native_mint::id()));
+    let address = address.unwrap_or_else(|| {
+        get_associated_token_address_with_program_id(
+            &wallet_address,
+            &native_mint::id(),
+            &config.program_id,
+        )
+    });
     println_display(config, format!("Unwrapping {}", address));
     if !config.sign_only {
         let lamports = config.rpc_client.get_balance(&address)?;
@@ -1129,7 +1155,7 @@ fn command_unwrap(
     println_display(config, format!("  Recipient: {}", &wallet_address));
 
     let instructions = vec![close_account(
-        &spl_token::id(),
+        &config.program_id,
         &address,
         &wallet_address,
         &wallet_address,
@@ -1179,7 +1205,7 @@ fn command_approve(
 
     let instructions = if use_unchecked_instruction {
         vec![approve(
-            &spl_token::id(),
+            &config.program_id,
             &account,
             &delegate,
             &owner,
@@ -1188,7 +1214,7 @@ fn command_approve(
         )?]
     } else {
         vec![approve_checked(
-            &spl_token::id(),
+            &config.program_id,
             &account,
             &mint_pubkey,
             &delegate,
@@ -1252,7 +1278,7 @@ fn command_revoke(
     }
 
     let instructions = vec![revoke(
-        &spl_token::id(),
+        &config.program_id,
         &account,
         &owner,
         &config.multisigner_pubkeys,
@@ -1310,7 +1336,7 @@ fn command_close(
     }
 
     let instructions = vec![close_account(
-        &spl_token::id(),
+        &config.program_id,
         &account,
         &recipient,
         &close_authority,
@@ -1358,7 +1384,7 @@ fn command_accounts(config: &Config, token: Option<Pubkey>, owner: Pubkey) -> Co
         &owner,
         match token {
             Some(token) => TokenAccountsFilter::Mint(token),
-            None => TokenAccountsFilter::ProgramId(spl_token::id()),
+            None => TokenAccountsFilter::ProgramId(config.program_id),
         },
     )?;
     if accounts.is_empty() {
@@ -1367,7 +1393,7 @@ fn command_accounts(config: &Config, token: Option<Pubkey>, owner: Pubkey) -> Co
     }
 
     let (mint_accounts, unsupported_accounts, max_len_balance, includes_aux) =
-        sort_and_parse_token_accounts(&owner, accounts);
+        sort_and_parse_token_accounts(&owner, accounts, &config.program_id);
     let aux_len = if includes_aux { 10 } else { 0 };
 
     let cli_token_accounts = CliTokenAccounts {
@@ -1390,7 +1416,8 @@ fn command_address(config: &Config, token: Option<Pubkey>, owner: Pubkey) -> Com
     };
     if let Some(token) = token {
         validate_mint(config, token)?;
-        let associated_token_address = get_associated_token_address(&owner, &token);
+        let associated_token_address =
+            get_associated_token_address_with_program_id(&owner, &token, &config.program_id);
         cli_address.associated_token_address = Some(associated_token_address.to_string());
     }
     Ok(config.output_format.formatted_string(&cli_address))
@@ -1404,7 +1431,8 @@ fn command_account_info(config: &Config, address: Pubkey) -> CommandResult {
         .unwrap();
     let mint = Pubkey::from_str(&account.mint).unwrap();
     let owner = Pubkey::from_str(&account.owner).unwrap();
-    let is_associated = get_associated_token_address(&owner, &mint) == address;
+    let is_associated =
+        get_associated_token_address_with_program_id(&owner, &mint, &config.program_id) == address;
     let cli_token_account = CliTokenAccount {
         address: address.to_string(),
         is_associated,
@@ -1451,7 +1479,7 @@ fn command_gc(
     println_display(config, "Fetching token accounts".to_string());
     let accounts = config
         .rpc_client
-        .get_token_accounts_by_owner(&owner, TokenAccountsFilter::ProgramId(spl_token::id()))?;
+        .get_token_accounts_by_owner(&owner, TokenAccountsFilter::ProgramId(config.program_id))?;
     if accounts.is_empty() {
         println_display(config, "Nothing to do".to_string());
         return Ok("".to_string());
@@ -1514,15 +1542,17 @@ fn command_gc(
 
     for (token, accounts) in accounts_by_token.into_iter() {
         println_display(config, format!("Processing token: {}", token));
-        let associated_token_account = get_associated_token_address(&owner, &token);
+        let associated_token_account =
+            get_associated_token_address_with_program_id(&owner, &token, &config.program_id);
         let total_balance: u64 = accounts.values().map(|account| account.0).sum();
 
         if total_balance > 0 && !accounts.contains_key(&associated_token_account) {
             // Create the associated token account
-            instructions.push(vec![create_associated_token_account(
+            instructions.push(vec![create_associated_token_account_with_program_id(
                 &config.fee_payer,
                 &owner,
                 &token,
+                &config.program_id,
             )]);
             lamports_needed += minimum_balance_for_rent_exemption;
         }
@@ -1556,7 +1586,7 @@ fn command_gc(
             if amount > 0 {
                 // Transfer the account balance into the associated token account
                 account_instructions.push(transfer_checked(
-                    &spl_token::id(),
+                    &config.program_id,
                     &address,
                     &token,
                     &associated_token_account,
@@ -1569,7 +1599,7 @@ fn command_gc(
             // Close the account if config.owner is able to
             if close_authority == owner {
                 account_instructions.push(close_account(
-                    &spl_token::id(),
+                    &config.program_id,
                     &address,
                     &owner,
                     &owner,
@@ -1621,7 +1651,7 @@ fn command_sync_native(
         config,
         false,
         0,
-        vec![sync_native(&spl_token::id(), &native_account_address)?],
+        vec![sync_native(&config.program_id, &native_account_address)?],
     )?;
     Ok(match tx_return {
         TransactionReturnData::CliSignature(signature) => {
@@ -1663,6 +1693,7 @@ impl offline::ArgsConfig for SignOnlyNeedsDelegateAddress {
 
 fn main() -> Result<(), Error> {
     let default_decimals = &format!("{}", native_mint::DECIMALS);
+    let default_program_id = spl_token::id().to_string();
     let app_matches = App::new(crate_name!())
         .about(crate_description!())
         .version(crate_version!())
@@ -1697,6 +1728,17 @@ fn main() -> Result<(), Error> {
                 .takes_value(true)
                 .possible_values(&["json", "json-compact"])
                 .help("Return information in specified output format"),
+        )
+        .arg(
+            Arg::with_name("program_id")
+                .short("p")
+                .long("program-id")
+                .value_name("ADDRESS")
+                .takes_value(true)
+                .global(true)
+                .default_value(&default_program_id)
+                .validator(is_valid_pubkey)
+                .help("SPL Token program id"),
         )
         .arg(
             Arg::with_name("json_rpc_url")
@@ -2529,6 +2571,7 @@ fn main() -> Result<(), Error> {
         let blockhash_query = BlockhashQuery::new_from_matches(matches);
         let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
         let dump_transaction_message = matches.is_present(DUMP_TRANSACTION_MESSAGE.name);
+        let program_id = pubkey_of(matches, "program_id").unwrap();
 
         let multisig_signers = signers_of(matches, MULTISIG_SIGNER_ARG.name, &mut wallet_manager)
             .unwrap_or_else(|e| {
@@ -2558,6 +2601,7 @@ fn main() -> Result<(), Error> {
             sign_only,
             dump_transaction_message,
             multisigner_pubkeys,
+            program_id,
         }
     };
 

--- a/token/cli/src/sort.rs
+++ b/token/cli/src/sort.rs
@@ -1,4 +1,4 @@
-use crate::{get_associated_token_address, output::CliTokenAccount};
+use crate::output::CliTokenAccount;
 use serde::{Deserialize, Serialize};
 use solana_account_decoder::{parse_token::TokenAccountType, UiAccountData};
 use solana_client::rpc_response::RpcKeyedAccount;
@@ -19,6 +19,7 @@ pub(crate) struct UnsupportedAccount {
 pub(crate) fn sort_and_parse_token_accounts(
     owner: &Pubkey,
     accounts: Vec<RpcKeyedAccount>,
+    program_id: &Pubkey,
 ) -> (MintAccounts, Vec<UnsupportedAccount>, usize, bool) {
     let mut mint_accounts: MintAccounts = BTreeMap::new();
     let mut unsupported_accounts = vec![];
@@ -38,7 +39,7 @@ pub(crate) fn sort_and_parse_token_accounts(
                     Ok(TokenAccountType::Account(ui_token_account)) => {
                         let mint = ui_token_account.mint.clone();
                         let is_associated = if let Ok(mint) = Pubkey::from_str(&mint) {
-                            get_associated_token_address(owner, &mint).to_string() == address
+                            spl_associated_token_account::get_associated_token_address_with_program_id(owner, &mint, program_id).to_string() == address
                         } else {
                             includes_aux = true;
                             false

--- a/token/program-2022/src/extension/confidential_transfer/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer/mod.rs
@@ -23,6 +23,8 @@ pub struct ConfidentialTransferMint {
     ///
     /// Note that setting an authority of `Pubkey::default()` is the idiomatic way to disable
     /// future changes to the configuration.
+    ///
+    /// The legacy Token Multisig account is not supported as the authority
     pub authority: Pubkey,
 
     /// Indicate if newly configured accounts must be approved by the `authority` before they may be

--- a/token/program-2022/tests/program_test.rs
+++ b/token/program-2022/tests/program_test.rs
@@ -42,6 +42,7 @@ impl TestContext {
 
         let token = Token::create_mint(
             Arc::clone(&client),
+            &id(),
             payer,
             &mint_account,
             &mint_authority_pubkey,

--- a/token/rust/Cargo.toml
+++ b/token/rust/Cargo.toml
@@ -19,6 +19,6 @@ solana-program-test = "=1.9.5"
 solana-sdk = "=1.9.5"
 # We never want the entrypoint for ATA, but we want the entrypoint for token when
 # testing token
-spl-associated-token-account = { version = "1.0", path = "../../associated-token-account/program", features = ["no-entrypoint"], default-features = false }
+spl-associated-token-account = { version = "1.0.5", path = "../../associated-token-account/program", features = ["no-entrypoint"], default-features = false }
 spl-token-2022 = { version = "0.1", path="../program-2022" }
 thiserror = "1.0"

--- a/token/rust/src/token.rs
+++ b/token/rust/src/token.rs
@@ -10,8 +10,7 @@ use solana_sdk::{
     transaction::Transaction,
 };
 use spl_associated_token_account::{
-    get_associated_token_address_with_program_id,
-    instruction::create_associated_token_account_with_program_id,
+    get_associated_token_address_with_program_id, instruction::create_associated_token_account,
 };
 use spl_token_2022::{
     extension::{transfer_fee, ExtensionType, StateWithExtensionsOwned},
@@ -181,7 +180,7 @@ where
     #[allow(clippy::too_many_arguments)]
     pub async fn create_mint<'a, S2: Signer>(
         client: Arc<dyn ProgramClient<T>>,
-        program_id: &Pubkey,
+        program_id: &'a Pubkey,
         payer: S,
         mint_account: &'a S2,
         mint_authority: &'a Pubkey,
@@ -230,7 +229,7 @@ where
     /// Create and initialize the associated account.
     pub async fn create_associated_token_account(&self, owner: &Pubkey) -> TokenResult<Pubkey> {
         self.process_ixs(
-            &[create_associated_token_account_with_program_id(
+            &[create_associated_token_account(
                 &self.payer.pubkey(),
                 owner,
                 &self.pubkey,
@@ -424,7 +423,7 @@ where
     ) -> TokenResult<T::Output> {
         self.process_ixs(
             &[transfer_fee::instruction::set_transfer_fee(
-                &id(),
+                &self.program_id,
                 &self.pubkey,
                 &authority.pubkey(),
                 &[],

--- a/token/rust/tests/program-test.rs
+++ b/token/rust/tests/program-test.rs
@@ -44,6 +44,7 @@ impl TestContext {
 
         let token = Token::create_mint(
             Arc::clone(&client),
+            &spl_token_2022::id(),
             keypair_clone(&payer),
             &mint_account,
             &mint_authority_pubkey,


### PR DESCRIPTION
It's desirable to optionally request a different SPL Token program id to `spl-token-cli`. 

Freebie: `spl-token-client` also now requires a program id as input