### PR TITLE
token-2022: implement SetAuthority for TransferFeeConfig and WithheldWithdraw

### DIFF
--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -766,7 +766,7 @@ pub enum AuthorityType {
     FreezeAccount,
     /// Owner of a given token account
     AccountOwner,
-    /// Authority to close a token account
+    /// Authority to close a mint or token account
     CloseAccount,
     /// Authority to set the transfer fee
     TransferFeeConfig,


### PR DESCRIPTION
#### Problem

The transfer fee config authorities cannot be configured after initialization

#### Solution

Implement SetAuthority for these types

To come later: additional test cases to check that updated withdraw_withheld_authority can withdraw and old cannot; will be much easier to code when the rust token client supports extended Accounts (via ATA) and TransferCheckedWithFee