### PR TITLE
token-2022: Assess transfer fees

### DIFF
--- a/token/program-2022/src/error.rs
+++ b/token/program-2022/src/error.rs
@@ -113,6 +113,12 @@ pub enum TokenError {
     /// Transfer fee exceeds maximum of 10,000 basis points
     #[error("Transfer fee exceeds maximum of 10,000 basis points")]
     TransferFeeExceedsMaximum,
+    /// Mint required for this account to transfer tokens, use `transfer_checked` or `transfer_checked_with_fee`
+    #[error("Mint required for this account to transfer tokens, use `transfer_checked` or `transfer_checked_with_fee`")]
+    MintRequiredForTransfer,
+    /// Calculated fee does not match expected fee
+    #[error("Calculated fee does not match expected fee")]
+    FeeMismatch,
 }
 impl From<TokenError> for ProgramError {
     fn from(e: TokenError) -> Self {

--- a/token/program-2022/src/extension/transfer_fee/mod.rs
+++ b/token/program-2022/src/extension/transfer_fee/mod.rs
@@ -4,6 +4,8 @@ use {
         pod::*,
     },
     bytemuck::{Pod, Zeroable},
+    solana_program::clock::Epoch,
+    std::{cmp, convert::TryFrom},
 };
 
 /// Transfer fee extension instructions
@@ -14,6 +16,7 @@ pub mod processor;
 
 /// Maximum possible fee in basis points is 100%, aka 10_000 basis points
 pub const MAX_FEE_BASIS_POINTS: u16 = 10_000;
+const ONE_IN_BASIS_POINTS: u128 = MAX_FEE_BASIS_POINTS as u128;
 
 /// Transfer fee information
 #[repr(C)]
@@ -26,6 +29,25 @@ pub struct TransferFee {
     /// Amount of transfer collected as fees, expressed as basis points of the
     /// transfer amount, ie. increments of 0.01%
     pub transfer_fee_basis_points: PodU16,
+}
+impl TransferFee {
+    /// Calculate the transfer fee
+    pub fn calculate(&self, amount: u64) -> Option<u64> {
+        let transfer_fee_basis_points = u16::from(self.transfer_fee_basis_points) as u128;
+        if transfer_fee_basis_points == 0 || amount == 0 {
+            Some(0)
+        } else {
+            let numerator = (amount as u128).checked_mul(transfer_fee_basis_points)?;
+            let mut raw_fee = numerator.checked_div(ONE_IN_BASIS_POINTS)?;
+            let remainder = numerator.checked_rem(ONE_IN_BASIS_POINTS)?;
+            if remainder > 0 {
+                raw_fee = raw_fee.checked_add(1)?;
+            }
+            // guaranteed to be ok
+            let raw_fee = u64::try_from(raw_fee).ok()?;
+            Some(cmp::min(raw_fee, u64::from(self.maximum_fee)))
+        }
+    }
 }
 
 /// Transfer fee extension data for mints.
@@ -42,6 +64,16 @@ pub struct TransferFeeConfig {
     pub older_transfer_fee: TransferFee,
     /// Newer transfer fee, used if the current epoch >= new_transfer_fee.epoch
     pub newer_transfer_fee: TransferFee,
+}
+impl TransferFeeConfig {
+    /// Get the fee for the given epoch
+    pub fn get_epoch_fee(&self, epoch: Epoch) -> &TransferFee {
+        if epoch >= self.newer_transfer_fee.epoch.into() {
+            &self.newer_transfer_fee
+        } else {
+            &self.older_transfer_fee
+        }
+    }
 }
 impl Extension for TransferFeeConfig {
     const TYPE: ExtensionType = ExtensionType::TransferFeeConfig;
@@ -62,6 +94,9 @@ impl Extension for TransferFeeAmount {
 pub(crate) mod test {
     use {super::*, solana_program::pubkey::Pubkey, std::convert::TryFrom};
 
+    const NEWER_EPOCH: u64 = 100;
+    const OLDER_EPOCH: u64 = 1;
+
     pub(crate) fn test_transfer_fee_config() -> TransferFeeConfig {
         TransferFeeConfig {
             transfer_fee_config_authority: OptionalNonZeroPubkey::try_from(Some(Pubkey::new(
@@ -74,15 +109,121 @@ pub(crate) mod test {
             .unwrap(),
             withheld_amount: PodU64::from(u64::MAX),
             older_transfer_fee: TransferFee {
-                epoch: PodU64::from(1),
+                epoch: PodU64::from(OLDER_EPOCH),
                 maximum_fee: PodU64::from(10),
                 transfer_fee_basis_points: PodU16::from(100),
             },
             newer_transfer_fee: TransferFee {
-                epoch: PodU64::from(100),
+                epoch: PodU64::from(NEWER_EPOCH),
                 maximum_fee: PodU64::from(5_000),
                 transfer_fee_basis_points: PodU16::from(1),
             },
         }
+    }
+
+    #[test]
+    fn epoch_fee() {
+        let transfer_fee_config = test_transfer_fee_config();
+        // during epoch 100 and after, use newer transfer fee
+        assert_eq!(
+            transfer_fee_config.get_epoch_fee(NEWER_EPOCH).epoch,
+            NEWER_EPOCH.into()
+        );
+        assert_eq!(
+            transfer_fee_config.get_epoch_fee(NEWER_EPOCH + 1).epoch,
+            NEWER_EPOCH.into()
+        );
+        assert_eq!(
+            transfer_fee_config.get_epoch_fee(u64::MAX).epoch,
+            NEWER_EPOCH.into()
+        );
+        // before that, use older transfer fee
+        assert_eq!(
+            transfer_fee_config.get_epoch_fee(NEWER_EPOCH - 1).epoch,
+            OLDER_EPOCH.into()
+        );
+        assert_eq!(
+            transfer_fee_config.get_epoch_fee(OLDER_EPOCH).epoch,
+            OLDER_EPOCH.into()
+        );
+        assert_eq!(
+            transfer_fee_config.get_epoch_fee(OLDER_EPOCH + 1).epoch,
+            OLDER_EPOCH.into()
+        );
+    }
+
+    #[test]
+    fn calculate_fee_max() {
+        let one = u64::try_from(ONE_IN_BASIS_POINTS).unwrap();
+        let transfer_fee = TransferFee {
+            epoch: PodU64::from(0),
+            maximum_fee: PodU64::from(5_000),
+            transfer_fee_basis_points: PodU16::from(1),
+        };
+        let maximum_fee = u64::from(transfer_fee.maximum_fee);
+        // hit maximum fee
+        assert_eq!(maximum_fee, transfer_fee.calculate(u64::MAX).unwrap());
+        // at exactly the max
+        assert_eq!(
+            maximum_fee,
+            transfer_fee.calculate(maximum_fee * one).unwrap()
+        );
+        // one token above, normally rounds up, but we're at the max
+        assert_eq!(
+            maximum_fee,
+            transfer_fee.calculate(maximum_fee * one + 1).unwrap()
+        );
+        // one token below, rounds up to the max
+        assert_eq!(
+            maximum_fee,
+            transfer_fee.calculate(maximum_fee * one - 1).unwrap()
+        );
+    }
+
+    #[test]
+    fn calculate_fee_min() {
+        let one = u64::try_from(ONE_IN_BASIS_POINTS).unwrap();
+        let transfer_fee = TransferFee {
+            epoch: PodU64::from(0),
+            maximum_fee: PodU64::from(5_000),
+            transfer_fee_basis_points: PodU16::from(1),
+        };
+        let minimum_fee = 1;
+        // hit minimum fee even with 1 token
+        assert_eq!(minimum_fee, transfer_fee.calculate(1).unwrap());
+        // still minimum at 2 tokens
+        assert_eq!(minimum_fee, transfer_fee.calculate(2).unwrap());
+        // still minimum at 10_000 tokens
+        assert_eq!(minimum_fee, transfer_fee.calculate(one).unwrap());
+        // 2 token fee at 10_001
+        assert_eq!(minimum_fee + 1, transfer_fee.calculate(one + 1).unwrap());
+        // zero is always zero
+        assert_eq!(0, transfer_fee.calculate(0).unwrap());
+    }
+
+    #[test]
+    fn calculate_fee_zero() {
+        let one = u64::try_from(ONE_IN_BASIS_POINTS).unwrap();
+        let transfer_fee = TransferFee {
+            epoch: PodU64::from(0),
+            maximum_fee: PodU64::from(u64::MAX),
+            transfer_fee_basis_points: PodU16::from(0),
+        };
+        // always zero fee
+        assert_eq!(0, transfer_fee.calculate(0).unwrap());
+        assert_eq!(0, transfer_fee.calculate(u64::MAX).unwrap());
+        assert_eq!(0, transfer_fee.calculate(1).unwrap());
+        assert_eq!(0, transfer_fee.calculate(one).unwrap());
+
+        let transfer_fee = TransferFee {
+            epoch: PodU64::from(0),
+            maximum_fee: PodU64::from(0),
+            transfer_fee_basis_points: PodU16::from(MAX_FEE_BASIS_POINTS),
+        };
+        // always zero fee
+        assert_eq!(0, transfer_fee.calculate(0).unwrap());
+        assert_eq!(0, transfer_fee.calculate(u64::MAX).unwrap());
+        assert_eq!(0, transfer_fee.calculate(1).unwrap());
+        assert_eq!(0, transfer_fee.calculate(one).unwrap());
     }
 }

--- a/token/program-2022/src/extension/transfer_fee/mod.rs
+++ b/token/program-2022/src/extension/transfer_fee/mod.rs
@@ -74,6 +74,10 @@ impl TransferFeeConfig {
             &self.older_transfer_fee
         }
     }
+    /// Calculate the fee for the given epoch
+    pub fn calculate_epoch_fee(&self, epoch: Epoch, amount: u64) -> Option<u64> {
+        self.get_epoch_fee(epoch).calculate(amount)
+    }
 }
 impl Extension for TransferFeeConfig {
     const TYPE: ExtensionType = ExtensionType::TransferFeeConfig;

--- a/token/program-2022/src/extension/transfer_fee/processor.rs
+++ b/token/program-2022/src/extension/transfer_fee/processor.rs
@@ -16,6 +16,7 @@ use {
         account_info::{next_account_info, AccountInfo},
         clock::Clock,
         entrypoint::ProgramResult,
+        msg,
         program_option::COption,
         pubkey::Pubkey,
         sysvar::Sysvar,
@@ -131,7 +132,10 @@ pub(crate) fn process_instruction(
             amount,
             decimals,
             fee,
-        } => Processor::process_transfer(program_id, accounts, amount, Some(decimals), Some(fee)),
+        } => {
+            msg!("Instruction: TransferCheckedWithFee");
+            Processor::process_transfer(program_id, accounts, amount, Some(decimals), Some(fee))
+        }
         TransferFeeInstruction::WithdrawWithheldTokensFromMint => {
             unimplemented!();
         }

--- a/token/program-2022/src/extension/transfer_fee/processor.rs
+++ b/token/program-2022/src/extension/transfer_fee/processor.rs
@@ -127,9 +127,11 @@ pub(crate) fn process_instruction(
             transfer_fee_basis_points,
             maximum_fee,
         ),
-        TransferFeeInstruction::TransferCheckedWithFee { .. } => {
-            unimplemented!();
-        }
+        TransferFeeInstruction::TransferCheckedWithFee {
+            amount,
+            decimals,
+            fee,
+        } => Processor::process_transfer(program_id, accounts, amount, Some(decimals), Some(fee)),
         TransferFeeInstruction::WithdrawWithheldTokensFromMint => {
             unimplemented!();
         }

--- a/token/program-2022/tests/mint_close_authority.rs
+++ b/token/program-2022/tests/mint_close_authority.rs
@@ -167,7 +167,7 @@ async fn success_close() {
         .close_account(token.get_address(), &destination, &close_authority)
         .await
         .unwrap();
-    let destination = token.get_account(destination).await.unwrap();
+    let destination = token.get_account(&destination).await.unwrap();
     assert!(destination.lamports > 0);
 }
 

--- a/token/program-2022/tests/transfer.rs
+++ b/token/program-2022/tests/transfer.rs
@@ -2,11 +2,11 @@
 
 mod program_test;
 use {
-    program_test::TestContext,
+    program_test::{TestContext, TokenContext},
     solana_program_test::tokio,
     solana_sdk::{
-        instruction::InstructionError, signature::Signer,
-        signer::keypair::Keypair, transaction::TransactionError, transport::TransportError,
+        instruction::InstructionError, signature::Signer, signer::keypair::Keypair,
+        transaction::TransactionError, transport::TransportError,
     },
     spl_token_2022::error::TokenError,
     spl_token_client::token::TokenError as TokenClientError,
@@ -14,16 +14,19 @@ use {
 
 #[tokio::test]
 async fn basic() {
-    let TestContext {
-        token,
+    let mut context = TestContext::new().await;
+    context
+        .init_token_with_mint(vec![])
+        .await
+        .unwrap();
+    let TokenContext {
+        decimals,
         mint_authority,
+        token,
         alice,
         bob,
-        decimals,
         ..
-    } = TestContext::new(vec![])
-    .await
-    .unwrap();
+    } = context.token_context.unwrap();
 
     let alice_account = Keypair::new();
     let alice_account = token
@@ -38,67 +41,68 @@ async fn basic() {
 
     // mint a token
     let amount = 10;
-    token.mint_to(&alice_account, &mint_authority, amount).await.unwrap();
+    token
+        .mint_to(&alice_account, &mint_authority, amount)
+        .await
+        .unwrap();
 
     // unchecked is ok
-    token.transfer_unchecked(
-        &alice_account,
-        &bob_account,
-        &alice,
-        1
-    ).await.unwrap();
+    token
+        .transfer_unchecked(&alice_account, &bob_account, &alice, 1)
+        .await
+        .unwrap();
 
     // checked is ok
-    token.transfer_checked(
-        &alice_account,
-        &bob_account,
-        &alice,
-        1,
-        decimals,
-    ).await.unwrap();
+    token
+        .transfer_checked(&alice_account, &bob_account, &alice, 1, decimals)
+        .await
+        .unwrap();
 
     // transfer too much is not ok
-    let error = token.transfer_checked(
-        &alice_account,
-        &bob_account,
-        &alice,
-        amount,
-        decimals,
-    ).await.unwrap_err();
+    let error = token
+        .transfer_checked(&alice_account, &bob_account, &alice, amount, decimals)
+        .await
+        .unwrap_err();
     assert_eq!(
         error,
         TokenClientError::Client(Box::new(TransportError::TransactionError(
-            TransactionError::InstructionError(0, InstructionError::Custom(TokenError::InsufficientFunds as u32))
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::InsufficientFunds as u32)
+            )
         )))
     );
 
     // wrong signer
-    let error = token.transfer_checked(
-        &alice_account,
-        &bob_account,
-        &bob,
-        1,
-        decimals,
-    ).await.unwrap_err();
+    let error = token
+        .transfer_checked(&alice_account, &bob_account, &bob, 1, decimals)
+        .await
+        .unwrap_err();
     assert_eq!(
         error,
         TokenClientError::Client(Box::new(TransportError::TransactionError(
-            TransactionError::InstructionError(0, InstructionError::Custom(TokenError::OwnerMismatch as u32))
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::OwnerMismatch as u32)
+            )
         )))
     );
 }
 
 #[tokio::test]
 async fn self_transfer() {
-    let TestContext {
-        token,
-        mint_authority,
-        alice,
+    let mut context = TestContext::new().await;
+    context
+        .init_token_with_mint(vec![])
+        .await
+        .unwrap();
+    let TokenContext {
         decimals,
+        mint_authority,
+        token,
+        alice,
         ..
-    } = TestContext::new(vec![])
-    .await
-    .unwrap();
+    } = context.token_context.unwrap();
 
     let alice_account = Keypair::new();
     let alice_account = token
@@ -108,51 +112,52 @@ async fn self_transfer() {
 
     // mint a token
     let amount = 10;
-    token.mint_to(&alice_account, &mint_authority, amount).await.unwrap();
+    token
+        .mint_to(&alice_account, &mint_authority, amount)
+        .await
+        .unwrap();
 
     // self transfer is ok
-    token.transfer_checked(
-        &alice_account,
-        &alice_account,
-        &alice,
-        1,
-        decimals,
-    ).await.unwrap();
-    token.transfer_unchecked(
-        &alice_account,
-        &alice_account,
-        &alice,
-        1,
-    ).await.unwrap();
+    token
+        .transfer_checked(&alice_account, &alice_account, &alice, 1, decimals)
+        .await
+        .unwrap();
+    token
+        .transfer_unchecked(&alice_account, &alice_account, &alice, 1)
+        .await
+        .unwrap();
 
     // too much self transfer is not ok
-    let error = token.transfer_checked(
-        &alice_account,
-        &alice_account,
-        &alice,
-        amount + 1,
-        decimals,
-    ).await.unwrap_err();
+    let error = token
+        .transfer_checked(&alice_account, &alice_account, &alice, amount + 1, decimals)
+        .await
+        .unwrap_err();
     assert_eq!(
         error,
         TokenClientError::Client(Box::new(TransportError::TransactionError(
-            TransactionError::InstructionError(0, InstructionError::Custom(TokenError::InsufficientFunds as u32))
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::InsufficientFunds as u32)
+            )
         )))
     );
 }
 
 #[tokio::test]
 async fn self_owned() {
-    let TestContext {
-        token,
-        mint_authority,
+    let mut context = TestContext::new().await;
+    context
+        .init_token_with_mint(vec![])
+        .await
+        .unwrap();
+    let TokenContext {
         decimals,
+        mint_authority,
+        token,
         alice,
         bob,
         ..
-    } = TestContext::new(vec![])
-    .await
-    .unwrap();
+    } = context.token_context.unwrap();
 
     let alice_account = token
         .create_auxiliary_token_account(&alice, &alice.pubkey())
@@ -166,31 +171,26 @@ async fn self_owned() {
 
     // mint a token
     let amount = 10;
-    token.mint_to(&alice_account, &mint_authority, amount).await.unwrap();
+    token
+        .mint_to(&alice_account, &mint_authority, amount)
+        .await
+        .unwrap();
 
     // unchecked is ok
-    token.transfer_unchecked(
-        &alice_account,
-        &bob_account,
-        &alice,
-        1
-    ).await.unwrap();
+    token
+        .transfer_unchecked(&alice_account, &bob_account, &alice, 1)
+        .await
+        .unwrap();
 
     // checked is ok
-    token.transfer_checked(
-        &alice_account,
-        &bob_account,
-        &alice,
-        1,
-        decimals,
-    ).await.unwrap();
+    token
+        .transfer_checked(&alice_account, &bob_account, &alice, 1, decimals)
+        .await
+        .unwrap();
 
     // self transfer is ok
-    token.transfer_checked(
-        &alice_account,
-        &alice_account,
-        &alice,
-        1,
-        decimals,
-    ).await.unwrap();
+    token
+        .transfer_checked(&alice_account, &alice_account, &alice, 1, decimals)
+        .await
+        .unwrap();
 }

--- a/token/program-2022/tests/transfer.rs
+++ b/token/program-2022/tests/transfer.rs
@@ -187,7 +187,7 @@ async fn self_owned() {
 }
 
 #[tokio::test]
-async fn transfer_fee() {
+async fn transfer_with_fee_on_mint_without_fee_configured() {
     let mut context = TestContext::new().await;
     context.init_token_with_mint(vec![]).await.unwrap();
     let TokenContext {

--- a/token/program-2022/tests/transfer.rs
+++ b/token/program-2022/tests/transfer.rs
@@ -1,0 +1,196 @@
+#![cfg(feature = "test-bpf")]
+
+mod program_test;
+use {
+    program_test::TestContext,
+    solana_program_test::tokio,
+    solana_sdk::{
+        instruction::InstructionError, signature::Signer,
+        signer::keypair::Keypair, transaction::TransactionError, transport::TransportError,
+    },
+    spl_token_2022::error::TokenError,
+    spl_token_client::token::TokenError as TokenClientError,
+};
+
+#[tokio::test]
+async fn basic() {
+    let TestContext {
+        token,
+        mint_authority,
+        alice,
+        bob,
+        decimals,
+        ..
+    } = TestContext::new(vec![])
+    .await
+    .unwrap();
+
+    let alice_account = Keypair::new();
+    let alice_account = token
+        .create_auxiliary_token_account(&alice_account, &alice.pubkey())
+        .await
+        .unwrap();
+    let bob_account = Keypair::new();
+    let bob_account = token
+        .create_auxiliary_token_account(&bob_account, &bob.pubkey())
+        .await
+        .unwrap();
+
+    // mint a token
+    let amount = 10;
+    token.mint_to(&alice_account, &mint_authority, amount).await.unwrap();
+
+    // unchecked is ok
+    token.transfer_unchecked(
+        &alice_account,
+        &bob_account,
+        &alice,
+        1
+    ).await.unwrap();
+
+    // checked is ok
+    token.transfer_checked(
+        &alice_account,
+        &bob_account,
+        &alice,
+        1,
+        decimals,
+    ).await.unwrap();
+
+    // transfer too much is not ok
+    let error = token.transfer_checked(
+        &alice_account,
+        &bob_account,
+        &alice,
+        amount,
+        decimals,
+    ).await.unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(0, InstructionError::Custom(TokenError::InsufficientFunds as u32))
+        )))
+    );
+
+    // wrong signer
+    let error = token.transfer_checked(
+        &alice_account,
+        &bob_account,
+        &bob,
+        1,
+        decimals,
+    ).await.unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(0, InstructionError::Custom(TokenError::OwnerMismatch as u32))
+        )))
+    );
+}
+
+#[tokio::test]
+async fn self_transfer() {
+    let TestContext {
+        token,
+        mint_authority,
+        alice,
+        decimals,
+        ..
+    } = TestContext::new(vec![])
+    .await
+    .unwrap();
+
+    let alice_account = Keypair::new();
+    let alice_account = token
+        .create_auxiliary_token_account(&alice_account, &alice.pubkey())
+        .await
+        .unwrap();
+
+    // mint a token
+    let amount = 10;
+    token.mint_to(&alice_account, &mint_authority, amount).await.unwrap();
+
+    // self transfer is ok
+    token.transfer_checked(
+        &alice_account,
+        &alice_account,
+        &alice,
+        1,
+        decimals,
+    ).await.unwrap();
+    token.transfer_unchecked(
+        &alice_account,
+        &alice_account,
+        &alice,
+        1,
+    ).await.unwrap();
+
+    // too much self transfer is not ok
+    let error = token.transfer_checked(
+        &alice_account,
+        &alice_account,
+        &alice,
+        amount + 1,
+        decimals,
+    ).await.unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(0, InstructionError::Custom(TokenError::InsufficientFunds as u32))
+        )))
+    );
+}
+
+#[tokio::test]
+async fn self_owned() {
+    let TestContext {
+        token,
+        mint_authority,
+        decimals,
+        alice,
+        bob,
+        ..
+    } = TestContext::new(vec![])
+    .await
+    .unwrap();
+
+    let alice_account = token
+        .create_auxiliary_token_account(&alice, &alice.pubkey())
+        .await
+        .unwrap();
+    let bob_account = Keypair::new();
+    let bob_account = token
+        .create_auxiliary_token_account(&bob_account, &bob.pubkey())
+        .await
+        .unwrap();
+
+    // mint a token
+    let amount = 10;
+    token.mint_to(&alice_account, &mint_authority, amount).await.unwrap();
+
+    // unchecked is ok
+    token.transfer_unchecked(
+        &alice_account,
+        &bob_account,
+        &alice,
+        1
+    ).await.unwrap();
+
+    // checked is ok
+    token.transfer_checked(
+        &alice_account,
+        &bob_account,
+        &alice,
+        1,
+        decimals,
+    ).await.unwrap();
+
+    // self transfer is ok
+    token.transfer_checked(
+        &alice_account,
+        &alice_account,
+        &alice,
+        1,
+        decimals,
+    ).await.unwrap();
+}

--- a/token/program-2022/tests/transfer_fee.rs
+++ b/token/program-2022/tests/transfer_fee.rs
@@ -10,7 +10,9 @@ use {
     },
     spl_token_2022::{
         error::TokenError,
-        extension::transfer_fee::{TransferFee, TransferFeeConfig, MAX_FEE_BASIS_POINTS},
+        extension::transfer_fee::{
+            TransferFee, TransferFeeAmount, TransferFeeConfig, MAX_FEE_BASIS_POINTS,
+        },
         instruction,
     },
     spl_token_client::token::{ExtensionInitializationParams, TokenError as TokenClientError},
@@ -565,4 +567,365 @@ async fn set_withdraw_withheld_authority() {
     );
 
     // TODO: assert no authority can withdraw withheld fees
+}
+
+#[tokio::test]
+async fn transfer_checked() {
+    let TransferFeeConfigWithKeypairs {
+        transfer_fee_config_authority,
+        withdraw_withheld_authority,
+        transfer_fee_config,
+        ..
+    } = test_transfer_fee_config_with_keypairs();
+    let mut context = TestContext::new().await;
+    let transfer_fee_basis_points = u16::from(
+        transfer_fee_config
+            .newer_transfer_fee
+            .transfer_fee_basis_points,
+    );
+    let maximum_fee = u64::from(transfer_fee_config.newer_transfer_fee.maximum_fee);
+    context
+        .init_token_with_mint(vec![ExtensionInitializationParams::TransferFeeConfig {
+            transfer_fee_config_authority: transfer_fee_config_authority.pubkey().into(),
+            withdraw_withheld_authority: withdraw_withheld_authority.pubkey().into(),
+            transfer_fee_basis_points,
+            maximum_fee,
+        }])
+        .await
+        .unwrap();
+    let TokenContext {
+        decimals,
+        mint_authority,
+        token,
+        alice,
+        bob,
+        ..
+    } = context.token_context.unwrap();
+
+    // token account is self-owned just to test another case
+    let alice_account = token
+        .create_auxiliary_token_account(&alice, &alice.pubkey())
+        .await
+        .unwrap();
+    let bob_account = Keypair::new();
+    let bob_account = token
+        .create_auxiliary_token_account(&bob_account, &bob.pubkey())
+        .await
+        .unwrap();
+
+    // mint a lot of tokens, 100x max fee
+    let mut alice_amount = maximum_fee * 100;
+    token
+        .mint_to(&alice_account, &mint_authority, alice_amount)
+        .await
+        .unwrap();
+
+    // fail unchecked always
+    let error = token
+        .transfer_unchecked(&alice_account, &bob_account, &alice, maximum_fee)
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::MintRequiredForTransfer as u32)
+            )
+        )))
+    );
+
+    // fail because amount too high
+    let error = token
+        .transfer_checked(
+            &alice_account,
+            &bob_account,
+            &alice,
+            alice_amount + 1,
+            decimals,
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::InsufficientFunds as u32)
+            )
+        )))
+    );
+
+    let mut withheld_amount = 0;
+    let mut transferred_amount = 0;
+
+    // success, clean calculation for transfer fee
+    let fee = transfer_fee_config
+        .calculate_epoch_fee(0, maximum_fee)
+        .unwrap();
+    token
+        .transfer_checked(&alice_account, &bob_account, &alice, maximum_fee, decimals)
+        .await
+        .unwrap();
+    alice_amount -= maximum_fee;
+    withheld_amount += fee;
+    transferred_amount += maximum_fee - fee;
+
+    let alice_state = token.get_account_info(&alice_account).await.unwrap();
+    assert_eq!(alice_state.base.amount, alice_amount);
+    let extension = alice_state.get_extension::<TransferFeeAmount>().unwrap();
+    assert_eq!(extension.withheld_amount, 0.into());
+    let bob_state = token.get_account_info(&bob_account).await.unwrap();
+    assert_eq!(bob_state.base.amount, transferred_amount);
+    let extension = bob_state.get_extension::<TransferFeeAmount>().unwrap();
+    assert_eq!(extension.withheld_amount, withheld_amount.into());
+
+    // success, rounded up transfer fee
+    let transfer_amount = maximum_fee - 1;
+    let fee = transfer_fee_config
+        .calculate_epoch_fee(0, transfer_amount)
+        .unwrap();
+    token
+        .transfer_checked(
+            &alice_account,
+            &bob_account,
+            &alice,
+            transfer_amount,
+            decimals,
+        )
+        .await
+        .unwrap();
+    alice_amount -= transfer_amount;
+    withheld_amount += fee;
+    transferred_amount += transfer_amount - fee;
+    let alice_state = token.get_account_info(&alice_account).await.unwrap();
+    assert_eq!(alice_state.base.amount, alice_amount);
+    let extension = alice_state.get_extension::<TransferFeeAmount>().unwrap();
+    assert_eq!(extension.withheld_amount, 0.into());
+    let bob_state = token.get_account_info(&bob_account).await.unwrap();
+    assert_eq!(bob_state.base.amount, transferred_amount);
+    let extension = bob_state.get_extension::<TransferFeeAmount>().unwrap();
+    assert_eq!(extension.withheld_amount, withheld_amount.into());
+
+    // success, maximum fee kicks in
+    let transfer_amount =
+        1 + maximum_fee * (MAX_FEE_BASIS_POINTS as u64) / (transfer_fee_basis_points as u64);
+    let fee = transfer_fee_config
+        .calculate_epoch_fee(0, transfer_amount)
+        .unwrap();
+    assert_eq!(fee, maximum_fee); // sanity
+    token
+        .transfer_checked(
+            &alice_account,
+            &bob_account,
+            &alice,
+            transfer_amount,
+            decimals,
+        )
+        .await
+        .unwrap();
+    alice_amount -= transfer_amount;
+    withheld_amount += fee;
+    transferred_amount += transfer_amount - fee;
+    let alice_state = token.get_account_info(&alice_account).await.unwrap();
+    assert_eq!(alice_state.base.amount, alice_amount);
+    let extension = alice_state.get_extension::<TransferFeeAmount>().unwrap();
+    assert_eq!(extension.withheld_amount, 0.into());
+    let bob_state = token.get_account_info(&bob_account).await.unwrap();
+    assert_eq!(bob_state.base.amount, transferred_amount);
+    let extension = bob_state.get_extension::<TransferFeeAmount>().unwrap();
+    assert_eq!(extension.withheld_amount, withheld_amount.into());
+
+    // transfer down to 1 token
+    token
+        .transfer_checked(
+            &alice_account,
+            &bob_account,
+            &alice,
+            alice_amount - 1,
+            decimals,
+        )
+        .await
+        .unwrap();
+    transferred_amount += alice_amount - 1 - maximum_fee;
+    alice_amount = 1;
+    withheld_amount += maximum_fee;
+    let alice_state = token.get_account_info(&alice_account).await.unwrap();
+    assert_eq!(alice_state.base.amount, alice_amount);
+    let extension = alice_state.get_extension::<TransferFeeAmount>().unwrap();
+    assert_eq!(extension.withheld_amount, 0.into());
+    let bob_state = token.get_account_info(&bob_account).await.unwrap();
+    assert_eq!(bob_state.base.amount, transferred_amount);
+    let extension = bob_state.get_extension::<TransferFeeAmount>().unwrap();
+    assert_eq!(extension.withheld_amount, withheld_amount.into());
+
+    // final transfer, only move tokens to withheld amount, nothing received
+    token
+        .transfer_checked(&alice_account, &bob_account, &alice, 1, decimals)
+        .await
+        .unwrap();
+    withheld_amount += 1;
+    let alice_state = token.get_account_info(&alice_account).await.unwrap();
+    assert_eq!(alice_state.base.amount, 0);
+    let extension = alice_state.get_extension::<TransferFeeAmount>().unwrap();
+    assert_eq!(extension.withheld_amount, 0.into());
+    let bob_state = token.get_account_info(&bob_account).await.unwrap();
+    assert_eq!(bob_state.base.amount, transferred_amount);
+    let extension = bob_state.get_extension::<TransferFeeAmount>().unwrap();
+    assert_eq!(extension.withheld_amount, withheld_amount.into());
+}
+
+#[tokio::test]
+async fn transfer_checked_with_fee() {
+    let TransferFeeConfigWithKeypairs {
+        transfer_fee_config_authority,
+        withdraw_withheld_authority,
+        transfer_fee_config,
+        ..
+    } = test_transfer_fee_config_with_keypairs();
+    let mut context = TestContext::new().await;
+    let transfer_fee_basis_points = u16::from(
+        transfer_fee_config
+            .newer_transfer_fee
+            .transfer_fee_basis_points,
+    );
+    let maximum_fee = u64::from(transfer_fee_config.newer_transfer_fee.maximum_fee);
+    context
+        .init_token_with_mint(vec![ExtensionInitializationParams::TransferFeeConfig {
+            transfer_fee_config_authority: transfer_fee_config_authority.pubkey().into(),
+            withdraw_withheld_authority: withdraw_withheld_authority.pubkey().into(),
+            transfer_fee_basis_points,
+            maximum_fee,
+        }])
+        .await
+        .unwrap();
+    let TokenContext {
+        decimals,
+        mint_authority,
+        token,
+        alice,
+        bob,
+        ..
+    } = context.token_context.unwrap();
+
+    let alice_account = Keypair::new();
+    let alice_account = token
+        .create_auxiliary_token_account(&alice_account, &alice.pubkey())
+        .await
+        .unwrap();
+    let bob_account = Keypair::new();
+    let bob_account = token
+        .create_auxiliary_token_account(&bob_account, &bob.pubkey())
+        .await
+        .unwrap();
+
+    // mint a lot of tokens, 100x max fee
+    let alice_amount = maximum_fee * 100;
+    token
+        .mint_to(&alice_account, &mint_authority, alice_amount)
+        .await
+        .unwrap();
+
+    // incorrect fee, too high
+    let transfer_amount = maximum_fee;
+    let fee = transfer_fee_config
+        .calculate_epoch_fee(0, transfer_amount)
+        .unwrap()
+        + 1;
+    let error = token
+        .transfer_checked_with_fee(
+            &alice_account,
+            &bob_account,
+            &alice,
+            transfer_amount,
+            decimals,
+            fee,
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::FeeMismatch as u32)
+            )
+        )))
+    );
+
+    // incorrect fee, too low
+    let fee = transfer_fee_config
+        .calculate_epoch_fee(0, transfer_amount)
+        .unwrap()
+        - 1;
+    let error = token
+        .transfer_checked_with_fee(
+            &alice_account,
+            &bob_account,
+            &alice,
+            transfer_amount,
+            decimals,
+            fee,
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::FeeMismatch as u32)
+            )
+        )))
+    );
+
+    // correct fee, not enough tokens
+    let fee = transfer_fee_config
+        .calculate_epoch_fee(0, alice_amount + 1)
+        .unwrap()
+        - 1;
+    let error = token
+        .transfer_checked_with_fee(
+            &alice_account,
+            &bob_account,
+            &alice,
+            alice_amount + 1,
+            decimals,
+            fee,
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::InsufficientFunds as u32)
+            )
+        )))
+    );
+
+    // correct fee
+    let fee = transfer_fee_config
+        .calculate_epoch_fee(0, transfer_amount)
+        .unwrap();
+    token
+        .transfer_checked_with_fee(
+            &alice_account,
+            &bob_account,
+            &alice,
+            transfer_amount,
+            decimals,
+            fee,
+        )
+        .await
+        .unwrap();
+    let alice_state = token.get_account_info(&alice_account).await.unwrap();
+    assert_eq!(alice_state.base.amount, alice_amount - transfer_amount);
+    let extension = alice_state.get_extension::<TransferFeeAmount>().unwrap();
+    assert_eq!(extension.withheld_amount, 0.into());
+    let bob_state = token.get_account_info(&bob_account).await.unwrap();
+    assert_eq!(bob_state.base.amount, transfer_amount - fee);
+    let extension = bob_state.get_extension::<TransferFeeAmount>().unwrap();
+    assert_eq!(extension.withheld_amount, fee.into());
 }

--- a/token/rust/src/token.rs
+++ b/token/rust/src/token.rs
@@ -3,7 +3,6 @@ use solana_sdk::{
     account::Account as BaseAccount,
     instruction::Instruction,
     program_error::ProgramError,
-    program_pack::Pack,
     pubkey::Pubkey,
     signer::{signers::Signers, Signer},
     system_instruction,
@@ -248,16 +247,20 @@ where
         account: &S,
         owner: &Pubkey,
     ) -> TokenResult<Pubkey> {
+        let state = self.get_mint_info().await?;
+        let mint_extensions: Vec<ExtensionType> = state.get_extension_types()?;
+        let extensions = ExtensionType::get_required_init_account_extensions(&mint_extensions);
+        let space = ExtensionType::get_account_len::<Account>(&extensions);
         self.process_ixs(
             &[
                 system_instruction::create_account(
                     &self.payer.pubkey(),
                     &account.pubkey(),
                     self.client
-                        .get_minimum_balance_for_rent_exemption(Account::LEN)
+                        .get_minimum_balance_for_rent_exemption(space)
                         .await
                         .map_err(TokenError::Client)?,
-                    Account::LEN as u64,
+                    space as u64,
                     &self.program_id,
                 ),
                 instruction::initialize_account(
@@ -275,9 +278,9 @@ where
     }
 
     /// Retrieve a raw account
-    pub async fn get_account(&self, account: Pubkey) -> TokenResult<BaseAccount> {
+    pub async fn get_account(&self, account: &Pubkey) -> TokenResult<BaseAccount> {
         self.client
-            .get_account(account)
+            .get_account(*account)
             .await
             .map_err(TokenError::Client)?
             .ok_or(TokenError::AccountNotFound)
@@ -285,7 +288,7 @@ where
 
     /// Retrive mint information.
     pub async fn get_mint_info(&self) -> TokenResult<StateWithExtensionsOwned<Mint>> {
-        let account = self.get_account(self.pubkey).await?;
+        let account = self.get_account(&self.pubkey).await?;
         if account.owner != self.program_id {
             return Err(TokenError::AccountInvalidOwner);
         }
@@ -294,13 +297,16 @@ where
     }
 
     /// Retrieve account information.
-    pub async fn get_account_info(&self, account: Pubkey) -> TokenResult<Account> {
+    pub async fn get_account_info(
+        &self,
+        account: &Pubkey,
+    ) -> TokenResult<StateWithExtensionsOwned<Account>> {
         let account = self.get_account(account).await?;
         if account.owner != self.program_id {
             return Err(TokenError::AccountInvalidOwner);
         }
-        let account = Account::unpack_from_slice(&account.data)?;
-        if account.mint != *self.get_address() {
+        let account = StateWithExtensionsOwned::<Account>::unpack(account.data)?;
+        if account.base.mint != *self.get_address() {
             return Err(TokenError::AccountInvalidMint);
         }
 
@@ -311,14 +317,14 @@ where
     pub async fn get_or_create_associated_account_info(
         &self,
         owner: &Pubkey,
-    ) -> TokenResult<Account> {
+    ) -> TokenResult<StateWithExtensionsOwned<Account>> {
         let account = self.get_associated_token_address(owner);
-        match self.get_account_info(account).await {
+        match self.get_account_info(&account).await {
             Ok(account) => Ok(account),
             // AccountInvalidOwner is possible if account already received some lamports.
             Err(TokenError::AccountNotFound) | Err(TokenError::AccountInvalidOwner) => {
                 self.create_associated_token_account(owner).await?;
-                self.get_account_info(account).await
+                self.get_account_info(&account).await
             }
             Err(error) => Err(error),
         }

--- a/token/rust/src/token.rs
+++ b/token/rust/src/token.rs
@@ -370,6 +370,29 @@ where
     }
 
     /// Transfer tokens to another account
+    pub async fn transfer_unchecked<S2: Signer>(
+        &self,
+        source: &Pubkey,
+        destination: &Pubkey,
+        authority: &S2,
+        amount: u64,
+    ) -> TokenResult<T::Output> {
+        self.process_ixs(
+            #[allow(deprecated)]
+            &[instruction::transfer(
+                &self.program_id,
+                source,
+                destination,
+                &authority.pubkey(),
+                &[],
+                amount,
+            )?],
+            &[authority],
+        )
+        .await
+    }
+
+    /// Transfer tokens to another account
     pub async fn transfer_checked<S2: Signer>(
         &self,
         source: &Pubkey,
@@ -388,6 +411,33 @@ where
                 &[],
                 amount,
                 decimals,
+            )?],
+            &[authority],
+        )
+        .await
+    }
+
+    /// Transfer tokens to another account, given an expected fee
+    pub async fn transfer_checked_with_fee<S2: Signer>(
+        &self,
+        source: &Pubkey,
+        destination: &Pubkey,
+        authority: &S2,
+        amount: u64,
+        decimals: u8,
+        fee: u64,
+    ) -> TokenResult<T::Output> {
+        self.process_ixs(
+            &[transfer_fee::instruction::transfer_checked_with_fee(
+                &self.program_id,
+                source,
+                &self.pubkey,
+                destination,
+                &authority.pubkey(),
+                &[],
+                amount,
+                decimals,
+                fee,
             )?],
             &[authority],
         )

--- a/token/rust/tests/program-test.rs
+++ b/token/rust/tests/program-test.rs
@@ -89,9 +89,10 @@ async fn associated_token_account() {
 
     assert_eq!(
         token
-            .get_account_info(alice_vault)
+            .get_account_info(&alice_vault)
             .await
-            .expect("failed to get account info"),
+            .expect("failed to get account info")
+            .base,
         state::Account {
             mint: *token.get_address(),
             owner: alice.pubkey(),
@@ -116,7 +117,8 @@ async fn get_or_create_associated_token_account() {
         token
             .get_or_create_associated_account_info(&alice.pubkey())
             .await
-            .expect("failed to get account info"),
+            .expect("failed to get account info")
+            .base,
         state::Account {
             mint: *token.get_address(),
             owner: alice.pubkey(),
@@ -188,9 +190,10 @@ async fn set_authority() {
 
     assert_eq!(
         token
-            .get_account_info(alice_vault)
+            .get_account_info(&alice_vault)
             .await
             .expect("failed to get account info")
+            .base
             .owner,
         bob.pubkey(),
     );
@@ -222,9 +225,10 @@ async fn mint_to() {
 
     assert_eq!(
         token
-            .get_account_info(alice_vault)
+            .get_account_info(&alice_vault)
             .await
             .expect("failed to get account")
+            .base
             .amount,
         mint_amount
     );
@@ -267,17 +271,19 @@ async fn transfer() {
 
     assert_eq!(
         token
-            .get_account_info(alice_vault)
+            .get_account_info(&alice_vault)
             .await
             .expect("failed to get account")
+            .base
             .amount,
         mint_amount - transfer_amount
     );
     assert_eq!(
         token
-            .get_account_info(bob_vault)
+            .get_account_info(&bob_vault)
             .await
             .expect("failed to get account")
+            .base
             .amount,
         transfer_amount
     );


### PR DESCRIPTION
#### Problem

Transfer fees need to get assessed during transfers.

#### Solution

Assess those fees!  The commits on this were done purposely:

* commit 1 just reorders the normal transfer logic using `StateWithExtensionsMut`, no logic changes
* commit 2 adds some simple `TokenClient`-based tests, mostly boiler-plate
* commit 3 implements the transfer fees
* commit 4 adds more tests