### PR TITLE
token-2022: Enforce maximum transfer fee of 10k bps

### DIFF
--- a/token/program-2022/src/error.rs
+++ b/token/program-2022/src/error.rs
@@ -108,6 +108,11 @@ pub enum TokenError {
     /// No authority exists to perform the desired operation
     #[error("No authority exists to perform the desired operation")]
     NoAuthorityExists,
+
+    // 30
+    /// Transfer fee exceeds maximum of 10,000 basis points
+    #[error("Transfer fee exceeds maximum of 10,000 basis points")]
+    TransferFeeExceedsMaximum,
 }
 impl From<TokenError> for ProgramError {
     fn from(e: TokenError) -> Self {

--- a/token/program-2022/src/extension/transfer_fee/mod.rs
+++ b/token/program-2022/src/extension/transfer_fee/mod.rs
@@ -12,6 +12,9 @@ pub mod instruction;
 /// Transfer fee extension processor
 pub mod processor;
 
+/// Maximum possible fee in basis points is 100%, aka 10_000 basis points
+pub const MAX_FEE_BASIS_POINTS: u16 = 10_000;
+
 /// Transfer fee information
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]

--- a/token/program-2022/src/extension/transfer_fee/processor.rs
+++ b/token/program-2022/src/extension/transfer_fee/processor.rs
@@ -3,7 +3,10 @@ use {
         check_program_account,
         error::TokenError,
         extension::{
-            transfer_fee::{instruction::TransferFeeInstruction, TransferFee, TransferFeeConfig},
+            transfer_fee::{
+                instruction::TransferFeeInstruction, TransferFee, TransferFeeConfig,
+                MAX_FEE_BASIS_POINTS,
+            },
             StateWithExtensionsMut,
         },
         processor::Processor,
@@ -36,6 +39,10 @@ fn process_initialize_transfer_fee_config(
     extension.transfer_fee_config_authority = transfer_fee_config_authority.try_into()?;
     extension.withdraw_withheld_authority = withdraw_withheld_authority.try_into()?;
     extension.withheld_amount = 0u64.into();
+
+    if transfer_fee_basis_points > MAX_FEE_BASIS_POINTS {
+        return Err(TokenError::TransferFeeExceedsMaximum.into());
+    }
     // To be safe, set newer and older transfer fees to the same thing on init,
     // but only newer will actually be used
     let epoch = Clock::get()?.epoch;
@@ -75,6 +82,10 @@ fn process_set_transfer_fee(
         authority_info_data_len,
         account_info_iter.as_slice(),
     )?;
+
+    if transfer_fee_basis_points > MAX_FEE_BASIS_POINTS {
+        return Err(TokenError::TransferFeeExceedsMaximum.into());
+    }
 
     // When setting the transfer fee, we have two situations:
     // * newer transfer fee epoch <= current epoch:

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -1141,6 +1141,9 @@ impl PrintProgramError for TokenError {
             TokenError::NoAuthorityExists => {
                 msg!("Error: No authority exists to perform the desired operation");
             }
+            TokenError::TransferFeeExceedsMaximum => {
+                msg!("Error: Transfer fee exceeds maximum of 10,000 basis points");
+            }
         }
     }
 }


### PR DESCRIPTION
#### Problem

It's possible to set a transfer fee above 10k basis points, which means that you assess more than all of the amount transferred.  Discovered this one while testing transfer fees.

#### Solution

Enforce a maximum transfer fee of 10,000 basis points.