### PR TITLE
token-2022: add DefaultAccountState mint extension

### DIFF
--- a/token/program-2022/src/extension/default_account_state/instruction.rs
+++ b/token/program-2022/src/extension/default_account_state/instruction.rs
@@ -101,7 +101,7 @@ pub fn update_default_account_state(
     check_program_account(token_program_id)?;
     let mut accounts = vec![
         AccountMeta::new(*mint, false),
-        AccountMeta::new_readonly(*freeze_authority, true),
+        AccountMeta::new_readonly(*freeze_authority, signers.is_empty()),
     ];
     for signer_pubkey in signers.iter() {
         accounts.push(AccountMeta::new_readonly(**signer_pubkey, true));

--- a/token/program-2022/src/extension/default_account_state/instruction.rs
+++ b/token/program-2022/src/extension/default_account_state/instruction.rs
@@ -1,0 +1,115 @@
+use {
+    crate::{
+        check_program_account, error::TokenError, instruction::TokenInstruction,
+        state::AccountState,
+    },
+    num_enum::{IntoPrimitive, TryFromPrimitive},
+    solana_program::{
+        instruction::{AccountMeta, Instruction},
+        program_error::ProgramError,
+        pubkey::Pubkey,
+    },
+    std::convert::TryFrom,
+};
+
+/// Default Account State extension instructions
+#[derive(Clone, Copy, Debug, PartialEq, IntoPrimitive, TryFromPrimitive)]
+#[repr(u8)]
+pub enum DefaultAccountStateInstruction {
+    /// Initialize a new mint with the default state for new Accounts.
+    ///
+    /// Fails if the mint has already been initialized, so must be called before
+    /// `InitializeMint`.
+    ///
+    /// The mint must have exactly enough space allocated for the base mint (82
+    /// bytes), plus 83 bytes of padding, 1 byte reserved for the account type,
+    /// then space required for this extension, plus any others.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[writable]` The mint to initialize.
+    InitializeDefaultAccountState,
+    /// Update the default state for new Accounts. Only supported for mints that include the
+    /// `DefaultAccountState` extension.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   * Single authority
+    ///   0. `[writable]` The mint.
+    ///   1. `[signer]` The mint freeze authority.
+    ///
+    ///   * Multisignature authority
+    ///   0. `[writable]` The mint.
+    ///   1. `[]` The mint's multisignature freeze authority.
+    ///   2. ..2+M `[signer]` M signer accounts.
+    UpdateDefaultAccountState,
+}
+
+pub(crate) fn decode_instruction(
+    input: &[u8],
+) -> Result<(DefaultAccountStateInstruction, AccountState), ProgramError> {
+    if input.len() != 2 {
+        return Err(TokenError::InvalidInstruction.into());
+    }
+    Ok((
+        DefaultAccountStateInstruction::try_from(input[0])
+            .or(Err(TokenError::InvalidInstruction))?,
+        AccountState::try_from(input[1]).or(Err(TokenError::InvalidInstruction))?,
+    ))
+}
+
+fn encode_instruction(
+    token_program_id: &Pubkey,
+    accounts: Vec<AccountMeta>,
+    instruction_type: DefaultAccountStateInstruction,
+    state: &AccountState,
+) -> Instruction {
+    let mut data = TokenInstruction::DefaultAccountStateExtension.pack();
+    data.push(instruction_type.into());
+    data.push((*state).into());
+    Instruction {
+        program_id: *token_program_id,
+        accounts,
+        data,
+    }
+}
+
+/// Create an `InitializeDefaultAccountState` instruction
+pub fn initialize_default_account_state(
+    token_program_id: &Pubkey,
+    mint: &Pubkey,
+    state: &AccountState,
+) -> Result<Instruction, ProgramError> {
+    check_program_account(token_program_id)?;
+    let accounts = vec![AccountMeta::new(*mint, false)];
+    Ok(encode_instruction(
+        token_program_id,
+        accounts,
+        DefaultAccountStateInstruction::InitializeDefaultAccountState,
+        state,
+    ))
+}
+
+/// Create an `InitializeDefaultAccountState` instruction
+pub fn update_default_account_state(
+    token_program_id: &Pubkey,
+    mint: &Pubkey,
+    freeze_authority: &Pubkey,
+    signers: &[&Pubkey],
+    state: &AccountState,
+) -> Result<Instruction, ProgramError> {
+    check_program_account(token_program_id)?;
+    let mut accounts = vec![
+        AccountMeta::new(*mint, false),
+        AccountMeta::new_readonly(*freeze_authority, true),
+    ];
+    for signer_pubkey in signers.iter() {
+        accounts.push(AccountMeta::new_readonly(**signer_pubkey, true));
+    }
+    Ok(encode_instruction(
+        token_program_id,
+        accounts,
+        DefaultAccountStateInstruction::UpdateDefaultAccountState,
+        state,
+    ))
+}

--- a/token/program-2022/src/extension/default_account_state/instruction.rs
+++ b/token/program-2022/src/extension/default_account_state/instruction.rs
@@ -28,7 +28,7 @@ pub enum DefaultAccountStateInstruction {
     /// Accounts expected by this instruction:
     ///
     ///   0. `[writable]` The mint to initialize.
-    InitializeDefaultAccountState,
+    Initialize,
     /// Update the default state for new Accounts. Only supported for mints that include the
     /// `DefaultAccountState` extension.
     ///
@@ -42,7 +42,7 @@ pub enum DefaultAccountStateInstruction {
     ///   0. `[writable]` The mint.
     ///   1. `[]` The mint's multisignature freeze authority.
     ///   2. ..2+M `[signer]` M signer accounts.
-    UpdateDefaultAccountState,
+    Update,
 }
 
 pub(crate) fn decode_instruction(
@@ -74,7 +74,7 @@ fn encode_instruction(
     }
 }
 
-/// Create an `InitializeDefaultAccountState` instruction
+/// Create an `Initialize` instruction
 pub fn initialize_default_account_state(
     token_program_id: &Pubkey,
     mint: &Pubkey,
@@ -85,12 +85,12 @@ pub fn initialize_default_account_state(
     Ok(encode_instruction(
         token_program_id,
         accounts,
-        DefaultAccountStateInstruction::InitializeDefaultAccountState,
+        DefaultAccountStateInstruction::Initialize,
         state,
     ))
 }
 
-/// Create an `InitializeDefaultAccountState` instruction
+/// Create an `Initialize` instruction
 pub fn update_default_account_state(
     token_program_id: &Pubkey,
     mint: &Pubkey,
@@ -109,7 +109,7 @@ pub fn update_default_account_state(
     Ok(encode_instruction(
         token_program_id,
         accounts,
-        DefaultAccountStateInstruction::UpdateDefaultAccountState,
+        DefaultAccountStateInstruction::Update,
         state,
     ))
 }

--- a/token/program-2022/src/extension/default_account_state/instruction.rs
+++ b/token/program-2022/src/extension/default_account_state/instruction.rs
@@ -28,6 +28,10 @@ pub enum DefaultAccountStateInstruction {
     /// Accounts expected by this instruction:
     ///
     ///   0. `[writable]` The mint to initialize.
+    //
+    /// Data expected by this instruction:
+    ///   `crate::state::AccountState`
+    ///
     Initialize,
     /// Update the default state for new Accounts. Only supported for mints that include the
     /// `DefaultAccountState` extension.
@@ -42,6 +46,10 @@ pub enum DefaultAccountStateInstruction {
     ///   0. `[writable]` The mint.
     ///   1. `[]` The mint's multisignature freeze authority.
     ///   2. ..2+M `[signer]` M signer accounts.
+    //
+    /// Data expected by this instruction:
+    ///   `crate::state::AccountState`
+    ///
     Update,
 }
 

--- a/token/program-2022/src/extension/default_account_state/mod.rs
+++ b/token/program-2022/src/extension/default_account_state/mod.rs
@@ -1,0 +1,23 @@
+use {
+    crate::extension::{Extension, ExtensionType},
+    bytemuck::{Pod, Zeroable},
+};
+
+/// Default Account state extension instructions
+pub mod instruction;
+
+/// Default Account state extension processor
+pub mod processor;
+
+/// Default Account::state extension data for mints.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+pub struct DefaultAccountState {
+    /// Default Account::state in which new Accounts should be initialized
+    pub state: PodAccountState,
+}
+impl Extension for DefaultAccountState {
+    const TYPE: ExtensionType = ExtensionType::DefaultAccountState;
+}
+
+type PodAccountState = u8;

--- a/token/program-2022/src/extension/default_account_state/processor.rs
+++ b/token/program-2022/src/extension/default_account_state/processor.rs
@@ -20,10 +20,18 @@ use {
     },
 };
 
+fn check_valid_default_state(state: AccountState) -> ProgramResult {
+    match state {
+        AccountState::Uninitialized => Err(TokenError::InvalidState.into()),
+        _ => Ok(()),
+    }
+}
+
 fn process_initialize_default_account_state(
     accounts: &[AccountInfo],
     state: AccountState,
 ) -> ProgramResult {
+    check_valid_default_state(state)?;
     let account_info_iter = &mut accounts.iter();
     let mint_account_info = next_account_info(account_info_iter)?;
     let mut mint_data = mint_account_info.data.borrow_mut();
@@ -38,6 +46,7 @@ fn process_update_default_account_state(
     accounts: &[AccountInfo],
     state: AccountState,
 ) -> ProgramResult {
+    check_valid_default_state(state)?;
     let account_info_iter = &mut accounts.iter();
     let mint_account_info = next_account_info(account_info_iter)?;
     let freeze_authority_info = next_account_info(account_info_iter)?;

--- a/token/program-2022/src/extension/default_account_state/processor.rs
+++ b/token/program-2022/src/extension/default_account_state/processor.rs
@@ -1,0 +1,82 @@
+use {
+    crate::{
+        check_program_account,
+        error::TokenError,
+        extension::{
+            default_account_state::{
+                instruction::{decode_instruction, DefaultAccountStateInstruction},
+                DefaultAccountState,
+            },
+            StateWithExtensionsMut,
+        },
+        processor::Processor,
+        state::{AccountState, Mint},
+    },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        msg,
+        pubkey::Pubkey,
+    },
+};
+
+fn process_initialize_default_account_state(
+    accounts: &[AccountInfo],
+    state: AccountState,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let mint_account_info = next_account_info(account_info_iter)?;
+    let mut mint_data = mint_account_info.data.borrow_mut();
+    let mut mint = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut mint_data)?;
+    let extension = mint.init_extension::<DefaultAccountState>()?;
+    extension.state = state.into();
+    Ok(())
+}
+
+fn process_update_default_account_state(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    state: AccountState,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let mint_account_info = next_account_info(account_info_iter)?;
+    let freeze_authority_info = next_account_info(account_info_iter)?;
+    let freeze_authority_info_data_len = freeze_authority_info.data_len();
+
+    let mut mint_data = mint_account_info.data.borrow_mut();
+    let mut mint = StateWithExtensionsMut::<Mint>::unpack(&mut mint_data)?;
+
+    let freeze_authority =
+        Option::<Pubkey>::from(mint.base.freeze_authority).ok_or(TokenError::NoAuthorityExists)?;
+    Processor::validate_owner(
+        program_id,
+        &freeze_authority,
+        freeze_authority_info,
+        freeze_authority_info_data_len,
+        account_info_iter.as_slice(),
+    )?;
+
+    let extension = mint.get_extension_mut::<DefaultAccountState>()?;
+    extension.state = state.into();
+    Ok(())
+}
+
+pub(crate) fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    input: &[u8],
+) -> ProgramResult {
+    check_program_account(program_id)?;
+
+    let (instruction, state) = decode_instruction(input)?;
+    match instruction {
+        DefaultAccountStateInstruction::InitializeDefaultAccountState => {
+            msg!("DefaultAccountStateInstruction::InitializeDefaultAccountState");
+            process_initialize_default_account_state(accounts, state)
+        }
+        DefaultAccountStateInstruction::UpdateDefaultAccountState => {
+            msg!("DefaultAccountStateInstruction::UpdateDefaultAccountState");
+            process_update_default_account_state(program_id, accounts, state)
+        }
+    }
+}

--- a/token/program-2022/src/extension/default_account_state/processor.rs
+++ b/token/program-2022/src/extension/default_account_state/processor.rs
@@ -79,12 +79,12 @@ pub(crate) fn process_instruction(
 
     let (instruction, state) = decode_instruction(input)?;
     match instruction {
-        DefaultAccountStateInstruction::InitializeDefaultAccountState => {
-            msg!("DefaultAccountStateInstruction::InitializeDefaultAccountState");
+        DefaultAccountStateInstruction::Initialize => {
+            msg!("DefaultAccountStateInstruction::Initialize");
             process_initialize_default_account_state(accounts, state)
         }
-        DefaultAccountStateInstruction::UpdateDefaultAccountState => {
-            msg!("DefaultAccountStateInstruction::UpdateDefaultAccountState");
+        DefaultAccountStateInstruction::Update => {
+            msg!("DefaultAccountStateInstruction::Update");
             process_update_default_account_state(program_id, accounts, state)
         }
     }

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -5,6 +5,7 @@ use {
         error::TokenError,
         extension::{
             confidential_transfer::{ConfidentialTransferAccount, ConfidentialTransferMint},
+            default_account_state::DefaultAccountState,
             mint_close_authority::MintCloseAuthority,
             transfer_fee::{TransferFeeAmount, TransferFeeConfig},
         },
@@ -25,6 +26,8 @@ use {
 
 /// Confidential Transfer extension
 pub mod confidential_transfer;
+/// Default Account State extension
+pub mod default_account_state;
 /// Mint Close Authority extension
 pub mod mint_close_authority;
 /// Transfer Fee extension
@@ -508,6 +511,8 @@ pub enum ExtensionType {
     ConfidentialTransferMint,
     /// State for confidential transfers
     ConfidentialTransferAccount,
+    /// Specifies the default Account::state for new Accounts
+    DefaultAccountState,
     /// Padding extension used to make an account exactly Multisig::LEN, used for testing
     #[cfg(test)]
     AccountPaddingTest = u16::MAX - 1,
@@ -543,6 +548,7 @@ impl ExtensionType {
             ExtensionType::ConfidentialTransferAccount => {
                 pod_get_packed_len::<ConfidentialTransferAccount>()
             }
+            ExtensionType::DefaultAccountState => pod_get_packed_len::<DefaultAccountState>(),
             #[cfg(test)]
             ExtensionType::AccountPaddingTest => pod_get_packed_len::<AccountPaddingTest>(),
             #[cfg(test)]
@@ -580,7 +586,8 @@ impl ExtensionType {
             ExtensionType::Uninitialized => AccountType::Uninitialized,
             ExtensionType::TransferFeeConfig
             | ExtensionType::MintCloseAuthority
-            | ExtensionType::ConfidentialTransferMint => AccountType::Mint,
+            | ExtensionType::ConfidentialTransferMint
+            | ExtensionType::DefaultAccountState => AccountType::Mint,
             ExtensionType::TransferFeeAmount | ExtensionType::ConfidentialTransferAccount => {
                 AccountType::Account
             }

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -473,6 +473,11 @@ pub enum TokenInstruction {
     /// See `extension::confidential_transfer::instruction::ConfidentialTransferInstruction` for
     /// further details about the extended instructions that share this instruction prefix
     ConfidentialTransferExtension,
+    /// The common instruction prefix for Default Account State extension instructions.
+    ///
+    /// See `extension::default_account_state::instruction::DefaultAccountStateInstruction` for
+    /// further details about the extended instructions that share this instruction prefix
+    DefaultAccountStateExtension,
 }
 impl TokenInstruction {
     /// Unpacks a byte buffer into a [TokenInstruction](enum.TokenInstruction.html).
@@ -604,6 +609,7 @@ impl TokenInstruction {
                 Self::TransferFeeExtension(instruction)
             }
             24 => Self::ConfidentialTransferExtension,
+            25 => Self::DefaultAccountStateExtension,
             _ => return Err(TokenError::InvalidInstruction.into()),
         })
     }
@@ -716,6 +722,9 @@ impl TokenInstruction {
             }
             &Self::ConfidentialTransferExtension => {
                 buf.push(24);
+            }
+            &Self::DefaultAccountStateExtension => {
+                buf.push(25);
             }
         };
         buf

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -64,6 +64,14 @@ impl Processor {
             return Err(ProgramError::InvalidAccountData);
         }
 
+        if let Ok(default_account_state) = mint.get_extension_mut::<DefaultAccountState>() {
+            let default_account_state = AccountState::try_from(default_account_state.state)
+                .or(Err(ProgramError::InvalidAccountData))?;
+            if default_account_state == AccountState::Frozen && freeze_authority.is_none() {
+                return Err(TokenError::MintCannotFreeze.into());
+            }
+        }
+
         mint.base.mint_authority = COption::Some(mint_authority);
         mint.base.decimals = decimals;
         mint.base.is_initialized = true;

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -5,6 +5,7 @@ use crate::{
     error::TokenError,
     extension::{
         confidential_transfer::{self, ConfidentialTransferAccount},
+        default_account_state,
         mint_close_authority::MintCloseAuthority,
         transfer_fee::{self, TransferFeeAmount, TransferFeeConfig},
         ExtensionType, StateWithExtensions, StateWithExtensionsMut,
@@ -1061,6 +1062,13 @@ impl Processor {
             }
             TokenInstruction::ConfidentialTransferExtension => {
                 confidential_transfer::processor::process_instruction(
+                    program_id,
+                    accounts,
+                    &input[1..],
+                )
+            }
+            TokenInstruction::DefaultAccountStateExtension => {
+                default_account_state::processor::process_instruction(
                     program_id,
                     accounts,
                     &input[1..],

--- a/token/program-2022/src/state.rs
+++ b/token/program-2022/src/state.rs
@@ -2,7 +2,7 @@
 
 use crate::instruction::MAX_SIGNERS;
 use arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs};
-use num_enum::TryFromPrimitive;
+use num_enum::{IntoPrimitive, TryFromPrimitive};
 use solana_program::{
     program_error::ProgramError,
     program_option::COption,
@@ -173,7 +173,7 @@ impl Pack for Account {
 
 /// Account state.
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, PartialEq, TryFromPrimitive)]
+#[derive(Clone, Copy, Debug, PartialEq, IntoPrimitive, TryFromPrimitive)]
 pub enum AccountState {
     /// Account is not yet initialized
     Uninitialized,

--- a/token/program-2022/tests/default_account_state.rs
+++ b/token/program-2022/tests/default_account_state.rs
@@ -29,6 +29,7 @@ async fn success_init_default_acct_state_frozen() {
     let TokenContext {
         decimals,
         mint_authority,
+        freeze_authority,
         token,
         ..
     } = context.token_context.unwrap();
@@ -43,7 +44,7 @@ async fn success_init_default_acct_state_frozen() {
     assert!(state.base.is_initialized);
     assert_eq!(
         state.base.freeze_authority,
-        COption::Some(mint_authority.pubkey())
+        COption::Some(freeze_authority.unwrap().pubkey())
     );
     let extension = state.get_extension::<DefaultAccountState>().unwrap();
     assert_eq!(
@@ -120,6 +121,7 @@ async fn success_no_authority_init_default_acct_state_initialized() {
     let TokenContext {
         decimals,
         mint_authority,
+        freeze_authority,
         token,
         ..
     } = context.token_context.unwrap();
@@ -134,7 +136,7 @@ async fn success_no_authority_init_default_acct_state_initialized() {
     assert!(state.base.is_initialized);
     assert_eq!(
         state.base.freeze_authority,
-        COption::Some(mint_authority.pubkey())
+        COption::Some(freeze_authority.unwrap().pubkey())
     );
     let extension = state.get_extension::<DefaultAccountState>().unwrap();
     assert_eq!(
@@ -176,9 +178,12 @@ async fn end_to_end_default_account_state() {
         .unwrap();
     let TokenContext {
         mint_authority,
+        freeze_authority,
         token,
         ..
     } = context.token_context.unwrap();
+
+    let freeze_authority = freeze_authority.unwrap();
 
     let owner = Pubkey::new_unique();
     let account = Keypair::new();
@@ -205,7 +210,7 @@ async fn end_to_end_default_account_state() {
     );
 
     token
-        .set_default_account_state(&mint_authority, &AccountState::Initialized)
+        .set_default_account_state(&freeze_authority, &AccountState::Initialized)
         .await
         .unwrap();
     let state = token.get_mint_info().await.unwrap();
@@ -231,7 +236,7 @@ async fn end_to_end_default_account_state() {
             token.get_address(),
             Some(&new_authority.pubkey()),
             AuthorityType::FreezeAccount,
-            &mint_authority,
+            &freeze_authority,
         )
         .await
         .unwrap();

--- a/token/program-2022/tests/default_account_state.rs
+++ b/token/program-2022/tests/default_account_state.rs
@@ -191,8 +191,8 @@ async fn end_to_end_default_account_state() {
         .create_auxiliary_token_account(&account, &owner)
         .await
         .unwrap();
-    let account_state = token.get_account_info(account).await.unwrap();
-    assert_eq!(account_state.state, default_account_state);
+    let account_state = token.get_account_info(&account).await.unwrap();
+    assert_eq!(account_state.base.state, default_account_state);
 
     // Invalid default state
     let err = token
@@ -226,8 +226,8 @@ async fn end_to_end_default_account_state() {
         .create_auxiliary_token_account(&account, &owner)
         .await
         .unwrap();
-    let account_state = token.get_account_info(account).await.unwrap();
-    assert_eq!(account_state.state, AccountState::Initialized);
+    let account_state = token.get_account_info(&account).await.unwrap();
+    assert_eq!(account_state.base.state, AccountState::Initialized);
 
     // adjusting freeze authority adjusts default state authority
     let new_authority = Keypair::new();

--- a/token/program-2022/tests/default_account_state.rs
+++ b/token/program-2022/tests/default_account_state.rs
@@ -1,0 +1,232 @@
+#![cfg(feature = "test-bpf")]
+
+mod program_test;
+use {
+    program_test::{TestContext, TokenContext},
+    solana_program_test::tokio,
+    solana_sdk::{
+        instruction::InstructionError, program_option::COption, pubkey::Pubkey, signature::Signer,
+        signer::keypair::Keypair, transaction::TransactionError, transport::TransportError,
+    },
+    spl_token_2022::{
+        error::TokenError, extension::default_account_state::DefaultAccountState,
+        instruction::AuthorityType, state::AccountState,
+    },
+    spl_token_client::token::{ExtensionInitializationParams, TokenError as TokenClientError},
+    std::convert::TryFrom,
+};
+
+#[tokio::test]
+async fn success_init_default_acct_state_frozen() {
+    let default_account_state = AccountState::Frozen;
+    let mut context = TestContext::new().await;
+    context
+        .init_token_with_mint(vec![ExtensionInitializationParams::DefaultAccountState {
+            state: default_account_state,
+        }])
+        .await
+        .unwrap();
+    let TokenContext {
+        decimals,
+        mint_authority,
+        token,
+        ..
+    } = context.token_context.unwrap();
+
+    let state = token.get_mint_info().await.unwrap();
+    assert_eq!(state.base.decimals, decimals);
+    assert_eq!(
+        state.base.mint_authority,
+        COption::Some(mint_authority.pubkey())
+    );
+    assert_eq!(state.base.supply, 0);
+    assert!(state.base.is_initialized);
+    assert_eq!(state.base.freeze_authority, COption::None);
+    let extension = state.get_extension::<DefaultAccountState>().unwrap();
+    assert_eq!(
+        AccountState::try_from(extension.state).unwrap(),
+        default_account_state,
+    );
+}
+
+#[tokio::test]
+async fn success_init_default_acct_state_initialized() {
+    let default_account_state = AccountState::Initialized;
+    let mut context = TestContext::new().await;
+    context
+        .init_token_with_mint(vec![ExtensionInitializationParams::DefaultAccountState {
+            state: default_account_state,
+        }])
+        .await
+        .unwrap();
+    let TokenContext {
+        decimals,
+        mint_authority,
+        token,
+        ..
+    } = context.token_context.unwrap();
+
+    let state = token.get_mint_info().await.unwrap();
+    assert_eq!(state.base.decimals, decimals);
+    assert_eq!(
+        state.base.mint_authority,
+        COption::Some(mint_authority.pubkey())
+    );
+    assert_eq!(state.base.supply, 0);
+    assert!(state.base.is_initialized);
+    assert_eq!(state.base.freeze_authority, COption::None);
+    let extension = state.get_extension::<DefaultAccountState>().unwrap();
+    assert_eq!(
+        AccountState::try_from(extension.state).unwrap(),
+        default_account_state,
+    );
+}
+
+#[tokio::test]
+async fn fail_invalid_default_acct_state() {
+    let default_account_state = AccountState::Uninitialized;
+    let mut context = TestContext::new().await;
+    let err = context
+        .init_token_with_mint(vec![ExtensionInitializationParams::DefaultAccountState {
+            state: default_account_state,
+        }])
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                1,
+                InstructionError::Custom(TokenError::InvalidState as u32)
+            )
+        )))
+    );
+}
+
+#[tokio::test]
+async fn end_to_end_default_account_state() {
+    let default_account_state = AccountState::Frozen;
+    let mut context = TestContext::new().await;
+    context
+        .init_token_with_freezing_mint(vec![ExtensionInitializationParams::DefaultAccountState {
+            state: default_account_state,
+        }])
+        .await
+        .unwrap();
+    let TokenContext {
+        mint_authority,
+        token,
+        ..
+    } = context.token_context.unwrap();
+
+    let owner = Pubkey::new_unique();
+    let account = Keypair::new();
+    let account = token
+        .create_auxiliary_token_account(&account, &owner)
+        .await
+        .unwrap();
+    let account_state = token.get_account_info(account).await.unwrap();
+    assert_eq!(account_state.state, default_account_state);
+
+    // Invalid default state
+    let err = token
+        .set_default_account_state(&mint_authority, &AccountState::Uninitialized)
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::InvalidState as u32)
+            )
+        )))
+    );
+
+    token
+        .set_default_account_state(&mint_authority, &AccountState::Initialized)
+        .await
+        .unwrap();
+    let state = token.get_mint_info().await.unwrap();
+    let extension = state.get_extension::<DefaultAccountState>().unwrap();
+    assert_eq!(
+        AccountState::try_from(extension.state).unwrap(),
+        AccountState::Initialized,
+    );
+
+    let owner = Pubkey::new_unique();
+    let account = Keypair::new();
+    let account = token
+        .create_auxiliary_token_account(&account, &owner)
+        .await
+        .unwrap();
+    let account_state = token.get_account_info(account).await.unwrap();
+    assert_eq!(account_state.state, AccountState::Initialized);
+
+    // adjusting freeze authority adjusts default state authority
+    let new_authority = Keypair::new();
+    token
+        .set_authority(
+            token.get_address(),
+            Some(&new_authority.pubkey()),
+            AuthorityType::FreezeAccount,
+            &mint_authority,
+        )
+        .await
+        .unwrap();
+
+    let err = token
+        .set_default_account_state(&mint_authority, &AccountState::Frozen)
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::OwnerMismatch as u32)
+            )
+        )))
+    );
+
+    token
+        .set_default_account_state(&new_authority, &AccountState::Frozen)
+        .await
+        .unwrap();
+    let state = token.get_mint_info().await.unwrap();
+    let extension = state.get_extension::<DefaultAccountState>().unwrap();
+    assert_eq!(
+        AccountState::try_from(extension.state).unwrap(),
+        AccountState::Frozen,
+    );
+
+    token
+        .set_authority(
+            token.get_address(),
+            None,
+            AuthorityType::FreezeAccount,
+            &new_authority,
+        )
+        .await
+        .unwrap();
+
+    let err = token
+        .set_default_account_state(&new_authority, &AccountState::Initialized)
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::NoAuthorityExists as u32)
+            )
+        )))
+    );
+    let state = token.get_mint_info().await.unwrap();
+    let extension = state.get_extension::<DefaultAccountState>().unwrap();
+    assert_eq!(
+        AccountState::try_from(extension.state).unwrap(),
+        AccountState::Frozen,
+    );
+}


### PR DESCRIPTION
This PR adds a Mint-targeted extension that allows mints to define the default AccountState for new Accounts. This provides a convenient way for mint operators to establish a whitelist of accounts/users by having all new Accounts default to AccountState::Frozen, and manually thawing approved accounts.

I made the assumption that Mints with Some freeze_authority should be able to update the default Account state of new Accounts after mint initialization, allowing a Mint to stop the whitelist approach in the future.

Currently, there is nothing to prevent a Mint operator from unsetting their freeze authority while the DefaultAccountState is set to Frozen, meaning all new accounts will be frozen and un-thawable. It could be desirable to do this, thus limiting the number of active Accounts for a Mint forever. Or perhaps this is a footgun we should prevent in SetAuthority. Thoughts?

