### PR TITLE
spl-governance: Add VoteTipping option

### DIFF
--- a/governance/chat/program/tests/program_test/mod.rs
+++ b/governance/chat/program/tests/program_test/mod.rs
@@ -184,7 +184,7 @@ impl GovernanceChatProgramTest {
             min_transaction_hold_up_time: 10,
             max_voting_time: 10,
             vote_threshold_percentage: VoteThresholdPercentage::YesVote(60),
-            vote_weight_source: spl_governance::state::enums::VoteWeightSource::Deposit,
+            vote_tipping: spl_governance::state::enums::VoteTipping::Strict,
             proposal_cool_off_time: 0,
         };
 

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -122,16 +122,26 @@ pub enum VoteThresholdPercentage {
     Quorum(u8),
 }
 
-/// The source of voter weights used to vote on proposals
+/// The type of vote tipping to use on a Proposal.
+///
+/// Vote tipping means that under some conditions voting will complete early.
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
-pub enum VoteWeightSource {
-    /// Governing token deposits into the Realm are used as voter weights
-    Deposit,
-    /// Governing token account snapshots as of the time a proposal entered voting state are used as voter weights
-    /// Note: Snapshot source is not supported in the current version
-    /// Support for account snapshots are required in solana and/or arweave as a prerequisite
-    Snapshot,
+pub enum VoteTipping {
+    /// Tip when there is no way for another option to win and the vote threshold
+    /// has been reached. This ignores voters withdrawing their votes.
+    ///
+    /// Currently only supported for the "yes" option in single choice votes.
+    Strict,
+
+    /// Tip when an option reaches the vote threshold and has more vote weight
+    /// than any other options.
+    ///
+    /// Currently only supported for the "yes" option in single choice votes.
+    Early,
+
+    /// Never tip the vote early.
+    Disabled,
 }
 
 /// The status of instruction execution

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -3,7 +3,7 @@
 use crate::{
     error::GovernanceError,
     state::{
-        enums::{GovernanceAccountType, VoteThresholdPercentage, VoteWeightSource},
+        enums::{GovernanceAccountType, VoteThresholdPercentage, VoteTipping},
         realm::assert_is_valid_realm,
     },
 };
@@ -34,9 +34,8 @@ pub struct GovernanceConfig {
     /// Time limit in seconds for proposal to be open for voting
     pub max_voting_time: u32,
 
-    /// The source of vote weight for voters
-    /// Note: In the current version only token deposits are accepted as vote weight
-    pub vote_weight_source: VoteWeightSource,
+    /// Conditions under which a vote will complete early
+    pub vote_tipping: VoteTipping,
 
     /// The time period in seconds within which a Proposal can be still cancelled after being voted on
     /// Once cool off time expires Proposal can't be cancelled any longer and becomes a law
@@ -286,10 +285,6 @@ pub fn assert_is_valid_governance_config(
         _ => {
             return Err(GovernanceError::VoteThresholdPercentageTypeNotSupported.into());
         }
-    }
-
-    if governance_config.vote_weight_source != VoteWeightSource::Deposit {
-        return Err(GovernanceError::VoteWeightSourceNotSupported.into());
     }
 
     if governance_config.proposal_cool_off_time > 0 {

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -25,7 +25,7 @@ use crate::{
     state::{
         enums::{
             GovernanceAccountType, InstructionExecutionFlags, MintMaxVoteWeightSource,
-            ProposalState, TransactionExecutionStatus, VoteThresholdPercentage,
+            ProposalState, TransactionExecutionStatus, VoteThresholdPercentage, VoteTipping,
         },
         governance::GovernanceConfig,
         proposal_transaction::ProposalTransactionV2,
@@ -542,13 +542,35 @@ impl ProposalV2 {
             get_min_vote_threshold_weight(&config.vote_threshold_percentage, max_vote_weight)
                 .unwrap();
 
-        if yes_vote_weight >= min_vote_threshold_weight
-            && yes_vote_weight > (max_vote_weight.saturating_sub(yes_vote_weight))
-        {
-            yes_option.vote_result = OptionVoteResult::Succeeded;
-            return Some(ProposalState::Succeeded);
-        } else if deny_vote_weight > (max_vote_weight.saturating_sub(min_vote_threshold_weight))
-            || deny_vote_weight >= (max_vote_weight.saturating_sub(deny_vote_weight))
+        match config.vote_tipping {
+            VoteTipping::Disabled => {}
+            VoteTipping::Strict => {
+                if yes_vote_weight >= min_vote_threshold_weight
+                    && yes_vote_weight > (max_vote_weight.saturating_sub(yes_vote_weight))
+                {
+                    yes_option.vote_result = OptionVoteResult::Succeeded;
+                    return Some(ProposalState::Succeeded);
+                }
+            }
+            VoteTipping::Early => {
+                solana_program::msg!(
+                    "{} {} {}",
+                    yes_vote_weight,
+                    deny_vote_weight,
+                    min_vote_threshold_weight
+                );
+                if yes_vote_weight >= min_vote_threshold_weight
+                    && yes_vote_weight > deny_vote_weight
+                {
+                    yes_option.vote_result = OptionVoteResult::Succeeded;
+                    return Some(ProposalState::Succeeded);
+                }
+            }
+        }
+
+        if !matches!(config.vote_tipping, VoteTipping::Disabled)
+            && (deny_vote_weight > (max_vote_weight.saturating_sub(min_vote_threshold_weight))
+                || deny_vote_weight >= (max_vote_weight.saturating_sub(deny_vote_weight)))
         {
             yes_option.vote_result = OptionVoteResult::Defeated;
             return Some(ProposalState::Defeated);
@@ -929,7 +951,7 @@ mod test {
     use solana_program::clock::Epoch;
 
     use crate::state::{
-        enums::{MintMaxVoteWeightSource, VoteThresholdPercentage, VoteWeightSource},
+        enums::{MintMaxVoteWeightSource, VoteThresholdPercentage},
         legacy::ProposalV1,
         realm::RealmConfig,
         vote_record::VoteChoice,
@@ -1036,7 +1058,7 @@ mod test {
             min_transaction_hold_up_time: 10,
             max_voting_time: 5,
             vote_threshold_percentage: VoteThresholdPercentage::YesVote(60),
-            vote_weight_source: VoteWeightSource::Deposit,
+            vote_tipping: VoteTipping::Strict,
             proposal_cool_off_time: 0,
         }
     }

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -553,12 +553,6 @@ impl ProposalV2 {
                 }
             }
             VoteTipping::Early => {
-                solana_program::msg!(
-                    "{} {} {}",
-                    yes_vote_weight,
-                    deny_vote_weight,
-                    min_vote_threshold_weight
-                );
                 if yes_vote_weight >= min_vote_threshold_weight
                     && yes_vote_weight > deny_vote_weight
                 {
@@ -568,7 +562,11 @@ impl ProposalV2 {
             }
         }
 
-        if !matches!(config.vote_tipping, VoteTipping::Disabled)
+        // If vote tipping isn't disabled entirely, allow a vote to complete as
+        // "defeated" if there is no possible way of reaching majority or the
+        // min_vote_threshold_weight for another option. This tipping is always
+        // strict, there's no equivalent to "early" tipping for deny votes.
+        if config.vote_tipping != VoteTipping::Disabled
             && (deny_vote_weight > (max_vote_weight.saturating_sub(min_vote_threshold_weight))
                 || deny_vote_weight >= (max_vote_weight.saturating_sub(deny_vote_weight)))
         {

--- a/governance/program/tests/process_cast_vote.rs
+++ b/governance/program/tests/process_cast_vote.rs
@@ -591,11 +591,7 @@ async fn test_cast_vote_with_early_vote_tipped_to_succeeded() {
     assert_eq!(ProposalState::Voting, proposal_account.state);
 
     governance_test
-        .with_cast_vote(
-            &proposal_cookie,
-            &token_owner_record_cookie2,
-            YesNoVote::No,
-        )
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie2, YesNoVote::No)
         .await
         .unwrap();
     let proposal_account = governance_test
@@ -639,11 +635,7 @@ async fn test_cast_vote_with_early_vote_tipped_to_succeeded() {
     assert_eq!(ProposalState::Voting, proposal_account.state);
 
     governance_test
-        .with_cast_vote(
-            &proposal_cookie,
-            &token_owner_record_cookie2,
-            YesNoVote::No,
-        )
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie2, YesNoVote::No)
         .await
         .unwrap();
     let proposal_account = governance_test
@@ -652,11 +644,7 @@ async fn test_cast_vote_with_early_vote_tipped_to_succeeded() {
     assert_eq!(ProposalState::Voting, proposal_account.state);
 
     governance_test
-        .with_cast_vote(
-            &proposal_cookie,
-            &token_owner_record_cookie3,
-            YesNoVote::No,
-        )
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie3, YesNoVote::No)
         .await
         .unwrap();
     let proposal_account = governance_test
@@ -859,7 +847,7 @@ async fn test_cast_vote_with_threshold_below_50_and_vote_not_tipped() {
 }
 
 #[tokio::test]
-async fn test_cast_vote_with_disabled_tipping() {
+async fn test_cast_vote_with_disabled_tipping_yes_votes() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
@@ -889,12 +877,12 @@ async fn test_cast_vote_with_disabled_tipping() {
     governance_test
         .mint_community_tokens(&realm_cookie, 20) // total supply: 120
         .await;
-
-    // Act: no yes tipping
     let proposal_cookie = governance_test
         .with_signed_off_proposal(&token_owner_record_cookie1, &mut account_governance_cookie)
         .await
         .unwrap();
+
+    // Act
     governance_test
         .with_cast_vote(
             &proposal_cookie,
@@ -916,6 +904,56 @@ async fn test_cast_vote_with_disabled_tipping() {
         .with_signed_off_proposal(&token_owner_record_cookie1, &mut account_governance_cookie)
         .await
         .unwrap();
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie1, YesNoVote::No)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_disabled_tipping_no_votes() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let mut governance_config = governance_test.get_default_governance_config();
+
+    governance_config.vote_tipping = VoteTipping::Disabled;
+    governance_config.vote_threshold_percentage = VoteThresholdPercentage::YesVote(10);
+
+    let token_owner_record_cookie1 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut account_governance_cookie = governance_test
+        .with_account_governance_using_config(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie1,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .mint_community_tokens(&realm_cookie, 20) // total supply: 120
+        .await;
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie1, &mut account_governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
     governance_test
         .with_cast_vote(&proposal_cookie, &token_owner_record_cookie1, YesNoVote::No)
         .await

--- a/governance/program/tests/process_cast_vote.rs
+++ b/governance/program/tests/process_cast_vote.rs
@@ -8,7 +8,7 @@ use solana_program_test::tokio;
 use program_test::*;
 use spl_governance::{
     error::GovernanceError,
-    state::enums::{ProposalState, VoteThresholdPercentage},
+    state::enums::{ProposalState, VoteThresholdPercentage, VoteTipping},
 };
 
 #[tokio::test]
@@ -325,7 +325,7 @@ async fn test_cast_vote_with_governance_authority_must_sign_error() {
 }
 
 #[tokio::test]
-async fn test_cast_vote_with_vote_tipped_to_succeeded() {
+async fn test_cast_vote_with_strict_vote_tipped_to_succeeded() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
@@ -423,7 +423,7 @@ async fn test_cast_vote_with_vote_tipped_to_succeeded() {
 }
 
 #[tokio::test]
-async fn test_cast_vote_with_vote_tipped_to_defeated() {
+async fn test_cast_vote_with_strict_vote_tipped_to_defeated() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
@@ -441,6 +441,286 @@ async fn test_cast_vote_with_vote_tipped_to_defeated() {
             &realm_cookie,
             &governed_account_cookie,
             &token_owner_record_cookie1,
+        )
+        .await
+        .unwrap();
+
+    // 100 votes
+    let token_owner_record_cookie2 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // 100 votes
+    let token_owner_record_cookie3 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Total 320 votes
+    governance_test
+        .mint_community_tokens(&realm_cookie, 20)
+        .await;
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie1, &mut account_governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_cast_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie1,
+            YesNoVote::Yes,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    // Act
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie2, YesNoVote::No)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    // Act
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie3, YesNoVote::No)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Defeated, proposal_account.state);
+
+    let proposal_owner_record = governance_test
+        .get_token_owner_record_account(&proposal_cookie.account.token_owner_record)
+        .await;
+
+    assert_eq!(0, proposal_owner_record.outstanding_proposal_count);
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_early_vote_tipped_to_succeeded() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let mut governance_config = governance_test.get_default_governance_config();
+
+    governance_config.vote_tipping = VoteTipping::Early;
+    governance_config.vote_threshold_percentage = VoteThresholdPercentage::YesVote(15);
+
+    let token_owner_record_cookie1 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut account_governance_cookie = governance_test
+        .with_account_governance_using_config(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie1,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie2 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie3 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie4 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let token_owner_record_cookie5 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .mint_community_tokens(&realm_cookie, 500) // total supply: 1000
+        .await;
+
+    // Test: tip by reaching 200 yes, 100 deny
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie1, &mut account_governance_cookie)
+        .await
+        .unwrap();
+    governance_test
+        .with_cast_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie1,
+            YesNoVote::Yes,
+        )
+        .await
+        .unwrap();
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    governance_test
+        .with_cast_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie2,
+            YesNoVote::No,
+        )
+        .await
+        .unwrap();
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    governance_test
+        .with_cast_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie3,
+            YesNoVote::Yes,
+        )
+        .await
+        .unwrap();
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    assert_eq!(ProposalState::Succeeded, proposal_account.state);
+    let proposal_owner_record = governance_test
+        .get_token_owner_record_account(&proposal_cookie.account.token_owner_record)
+        .await;
+    assert_eq!(0, proposal_owner_record.outstanding_proposal_count);
+
+    // Test: 200 vs 200 is above 15% yes, but does not tip yet
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie1, &mut account_governance_cookie)
+        .await
+        .unwrap();
+    governance_test
+        .with_cast_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie1,
+            YesNoVote::Yes,
+        )
+        .await
+        .unwrap();
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    governance_test
+        .with_cast_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie2,
+            YesNoVote::No,
+        )
+        .await
+        .unwrap();
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    governance_test
+        .with_cast_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie3,
+            YesNoVote::No,
+        )
+        .await
+        .unwrap();
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    governance_test
+        .with_cast_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie4,
+            YesNoVote::Yes,
+        )
+        .await
+        .unwrap();
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    // Act: 300 vs 200 makes it tip
+    governance_test
+        .with_cast_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie5,
+            YesNoVote::Yes,
+        )
+        .await
+        .unwrap();
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    assert_eq!(ProposalState::Succeeded, proposal_account.state);
+    let proposal_owner_record = governance_test
+        .get_token_owner_record_account(&proposal_cookie.account.token_owner_record)
+        .await;
+    assert_eq!(0, proposal_owner_record.outstanding_proposal_count);
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_early_vote_tipped_to_defeated() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let mut governance_config = governance_test.get_default_governance_config();
+
+    governance_config.vote_tipping = VoteTipping::Early;
+    governance_config.vote_threshold_percentage = VoteThresholdPercentage::YesVote(40);
+
+    // 100 votes
+    let token_owner_record_cookie1 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut account_governance_cookie = governance_test
+        .with_account_governance_using_config(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie1,
+            &governance_config,
         )
         .await
         .unwrap();
@@ -576,6 +856,77 @@ async fn test_cast_vote_with_threshold_below_50_and_vote_not_tipped() {
         .await;
 
     assert_eq!(1, proposal_owner_record.outstanding_proposal_count);
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_disabled_tipping() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let mut governance_config = governance_test.get_default_governance_config();
+
+    governance_config.vote_tipping = VoteTipping::Disabled;
+    governance_config.vote_threshold_percentage = VoteThresholdPercentage::YesVote(10);
+
+    let token_owner_record_cookie1 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut account_governance_cookie = governance_test
+        .with_account_governance_using_config(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie1,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .mint_community_tokens(&realm_cookie, 20) // total supply: 120
+        .await;
+
+    // Act: no yes tipping
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie1, &mut account_governance_cookie)
+        .await
+        .unwrap();
+    governance_test
+        .with_cast_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie1,
+            YesNoVote::Yes,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+
+    // Act: no deny tipping
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie1, &mut account_governance_cookie)
+        .await
+        .unwrap();
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie1, YesNoVote::No)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    assert_eq!(ProposalState::Voting, proposal_account.state);
 }
 
 #[tokio::test]

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1164,7 +1164,7 @@ impl GovernanceProgramTest {
             min_transaction_hold_up_time: 10,
             max_voting_time: 10,
             vote_threshold_percentage: VoteThresholdPercentage::YesVote(60),
-            vote_weight_source: spl_governance::state::enums::VoteWeightSource::Deposit,
+            vote_tipping: spl_governance::state::enums::VoteTipping::Strict,
             proposal_cool_off_time: 0,
         }
     }


### PR DESCRIPTION
This allows two new tipping styles in addition to the previous "Strict" mode:
- Early: Where a yes majority above the yes vote threshold will
  complete the vote, even if below 50% of total possible votes.
- Disabled: Where votes never complete early.

#### Implementation 

- `VoteWeightSource` was removed because it become irrelevant with `voter-weight-addin` and spot taken for `VoteTiping` option 

@SebastianBor 