### PR TITLE
Governance: Add max_executable_options to VoteType

### DIFF
--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -57,7 +57,15 @@ pub struct Governance {
     /// Governance Realm
     pub realm: Pubkey,
 
-    /// Account governed by this Governance. It can be for example Program account, Mint account or Token Account
+    /// Account governed by this Governance and/or PDA identity seed
+    /// It can be Program account, Mint account, Token account or any other account
+    ///
+    /// Note: The account doesn't have to exist. In that case the filed is only a PDA seed
+    ///
+    /// Note: Setting governed_account doesn't give any authority over the governed account
+    /// The relevant authorities for specific account types must be transferred to the Governance PDA
+    /// Ex: mint_authority/freeze_authority for a Mint account
+    /// or upgrade_authority for a Program account should be transferred to the Governance PDA
     pub governed_account: Pubkey,
 
     /// Running count of proposals

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -60,10 +60,10 @@ pub struct Governance {
     /// Account governed by this Governance and/or PDA identity seed
     /// It can be Program account, Mint account, Token account or any other account
     ///
-    /// Note: The account doesn't have to exist. In that case the filed is only a PDA seed
+    /// Note: The account doesn't have to exist. In that case the field is only a PDA seed
     ///
     /// Note: Setting governed_account doesn't give any authority over the governed account
-    /// The relevant authorities for specific account types must be transferred to the Governance PDA
+    /// The relevant authorities for specific account types must still be transferred to the Governance PDA
     /// Ex: mint_authority/freeze_authority for a Mint account
     /// or upgrade_authority for a Program account should be transferred to the Governance PDA
     pub governed_account: Pubkey,

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -73,10 +73,23 @@ pub enum VoteType {
     /// Note: Yes/No vote is a single choice (Yes) vote with the deny option (No)
     SingleChoice,
 
-    /// Multiple options can be selected with up to N choices per voter
-    /// By default N equals to the number of available options
-    /// Note: In the current version the N limit is not supported and not enforced yet
-    MultiChoice(u16),
+    /// Multiple options can be selected with up to max_voter_options per voter
+    /// and with up to max_executable_options of wining options eligible for execution
+    /// Ex. voters are given 5 options, can choose up to 3 (max_voter_options)
+    /// and only 1 (max_executable_options) wining option can be executed
+    MultiChoice {
+        /// The max number of options a voter can choose
+        /// By default it equals to the number of available options
+        /// Note: In the current version the limit is not supported and not enforced yet
+        #[allow(dead_code)]
+        max_voter_options: u16,
+
+        /// The max number of wining options which can be executed
+        /// By default it equals to the number of available options
+        /// Note: In the current version the limit is not supported and not enforced yet
+        #[allow(dead_code)]
+        max_executable_options: u16,
+    },
 }
 
 /// Governance Proposal
@@ -163,7 +176,7 @@ pub struct ProposalV2 {
 impl AccountMaxSize for ProposalV2 {
     fn get_max_size(&self) -> Option<usize> {
         let options_size: usize = self.options.iter().map(|o| o.label.len() + 19).sum();
-        Some(self.name.len() + self.description_link.len() + options_size + 199)
+        Some(self.name.len() + self.description_link.len() + options_size + 201)
     }
 }
 
@@ -352,7 +365,10 @@ impl ProposalV2 {
 
                     proposal_state
                 }
-                VoteType::MultiChoice(_n) => {
+                VoteType::MultiChoice {
+                    max_voter_options: _n,
+                    max_executable_options: _m,
+                } => {
                     // If any option succeeded for multi choice then the proposal as a whole succeeded as well
                     ProposalState::Succeeded
                 }
@@ -617,7 +633,10 @@ impl ProposalV2 {
                             return Err(GovernanceError::InvalidVote.into());
                         }
                     }
-                    VoteType::MultiChoice(_n) => {
+                    VoteType::MultiChoice {
+                        max_voter_options: _n,
+                        max_executable_options: _m,
+                    } => {
                         if choice_count == 0 {
                             return Err(GovernanceError::InvalidVote.into());
                         }
@@ -831,8 +850,15 @@ pub fn assert_valid_proposal_options(
         return Err(GovernanceError::InvalidProposalOptions.into());
     }
 
-    if let VoteType::MultiChoice(n) = *vote_type {
-        if options.len() == 1 || n as usize != options.len() {
+    if let VoteType::MultiChoice {
+        max_voter_options,
+        max_executable_options,
+    } = *vote_type
+    {
+        if options.len() == 1
+            || max_voter_options as usize != options.len()
+            || max_executable_options as usize != options.len()
+        {
             return Err(GovernanceError::InvalidProposalOptions.into());
         }
     }
@@ -964,7 +990,10 @@ mod test {
     #[test]
     fn test_max_size() {
         let mut proposal = create_test_proposal();
-        proposal.vote_type = VoteType::MultiChoice(1);
+        proposal.vote_type = VoteType::MultiChoice {
+            max_voter_options: 1,
+            max_executable_options: 1,
+        };
 
         let size = proposal.try_to_vec().unwrap().len();
 
@@ -974,7 +1003,10 @@ mod test {
     #[test]
     fn test_multi_option_proposal_max_size() {
         let mut proposal = create_test_multi_option_proposal();
-        proposal.vote_type = VoteType::MultiChoice(3);
+        proposal.vote_type = VoteType::MultiChoice {
+            max_voter_options: 3,
+            max_executable_options: 3,
+        };
 
         let size = proposal.try_to_vec().unwrap().len();
 
@@ -1909,7 +1941,10 @@ mod test {
     pub fn test_assert_valid_vote_with_no_choices_for_multi_choice_error() {
         // Arrange
         let mut proposal = create_test_multi_option_proposal();
-        proposal.vote_type = VoteType::MultiChoice(3);
+        proposal.vote_type = VoteType::MultiChoice {
+            max_voter_options: 3,
+            max_executable_options: 3,
+        };
 
         let choices = vec![
             VoteChoice {
@@ -1942,7 +1977,10 @@ mod test {
     pub fn test_assert_valid_proposal_options_with_invalid_choice_number_for_multi_choice_vote_error(
     ) {
         // Arrange
-        let vote_type = VoteType::MultiChoice(3);
+        let vote_type = VoteType::MultiChoice {
+            max_voter_options: 3,
+            max_executable_options: 3,
+        };
 
         let options = vec!["option 1".to_string(), "option 2".to_string()];
 
@@ -1956,7 +1994,10 @@ mod test {
     #[test]
     pub fn test_assert_valid_proposal_options_with_no_options_for_multi_choice_vote_error() {
         // Arrange
-        let vote_type = VoteType::MultiChoice(3);
+        let vote_type = VoteType::MultiChoice {
+            max_voter_options: 3,
+            max_executable_options: 3,
+        };
 
         let options = vec![];
 
@@ -1984,7 +2025,10 @@ mod test {
     #[test]
     pub fn test_assert_valid_proposal_options_for_multi_choice_vote() {
         // Arrange
-        let vote_type = VoteType::MultiChoice(3);
+        let vote_type = VoteType::MultiChoice {
+            max_voter_options: 3,
+            max_executable_options: 3,
+        };
 
         let options = vec![
             "option 1".to_string(),
@@ -2002,7 +2046,10 @@ mod test {
     #[test]
     pub fn test_assert_valid_proposal_options_for_multi_choice_vote_with_empty_option_error() {
         // Arrange
-        let vote_type = VoteType::MultiChoice(3);
+        let vote_type = VoteType::MultiChoice {
+            max_voter_options: 3,
+            max_executable_options: 3,
+        };
 
         let options = vec![
             "".to_string(),

--- a/governance/program/tests/use_proposals_with_multiple_options.rs
+++ b/governance/program/tests/use_proposals_with_multiple_options.rs
@@ -91,7 +91,10 @@ async fn test_create_proposal_with_multiple_choice_options_and_without_deny_opti
             &mut account_governance_cookie,
             options,
             false,
-            VoteType::MultiChoice(2),
+            VoteType::MultiChoice {
+                max_executable_options: 2,
+                max_voter_options: 2,
+            },
         )
         .await
         .unwrap();
@@ -100,7 +103,13 @@ async fn test_create_proposal_with_multiple_choice_options_and_without_deny_opti
         .get_proposal_account(&proposal_cookie.address)
         .await;
 
-    assert_eq!(proposal_account.vote_type, VoteType::MultiChoice(2));
+    assert_eq!(
+        proposal_account.vote_type,
+        VoteType::MultiChoice {
+            max_executable_options: 2,
+            max_voter_options: 2,
+        }
+    );
     assert!(!proposal_account.deny_vote_weight.is_some());
 
     assert_eq!(proposal_cookie.account, proposal_account);
@@ -350,7 +359,10 @@ async fn test_vote_on_none_executable_multi_choice_proposal_with_multiple_option
                 "option 3".to_string(),
             ],
             false,
-            VoteType::MultiChoice(3),
+            VoteType::MultiChoice {
+                max_executable_options: 3,
+                max_voter_options: 3,
+            },
         )
         .await
         .unwrap();
@@ -475,7 +487,10 @@ async fn test_vote_on_executable_proposal_with_multiple_options_and_partial_succ
                 "option 3".to_string(),
             ],
             true,
-            VoteType::MultiChoice(3),
+            VoteType::MultiChoice {
+                max_executable_options: 3,
+                max_voter_options: 3,
+            },
         )
         .await
         .unwrap();
@@ -633,7 +648,10 @@ async fn test_execute_proposal_with_multiple_options_and_partial_success() {
                 "option 3".to_string(),
             ],
             true,
-            VoteType::MultiChoice(3),
+            VoteType::MultiChoice {
+                max_executable_options: 3,
+                max_voter_options: 3,
+            },
         )
         .await
         .unwrap();
@@ -836,7 +854,10 @@ async fn test_try_execute_proposal_with_multiple_options_and_full_deny() {
                 "option 3".to_string(),
             ],
             true,
-            VoteType::MultiChoice(3),
+            VoteType::MultiChoice {
+                max_executable_options: 3,
+                max_voter_options: 3,
+            },
         )
         .await
         .unwrap();


### PR DESCRIPTION
#### Summary

Make it possible to define how many wining options for a proposal can be executed. 

#### Implementation 
This PR only added the required fields to `VoteType` and leaves the implementation for `V3`

