### PR TITLE
Governance: Proposals signed off by owner

### DIFF
--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -33,7 +33,7 @@ pub enum GovernanceError {
 
     /// Governing Token Owner or Delegate  must sign transaction
     #[error("Governing Token Owner or Delegate  must sign transaction")]
-    GoverningTokenOwnerOrDelegateMustSign,
+    GoverningTokenOwnerOrDelegateMustSign, // 505
 
     /// All votes must be relinquished to withdraw governing tokens
     #[error("All votes must be relinquished to withdraw governing tokens")]
@@ -53,47 +53,47 @@ pub enum GovernanceError {
 
     /// Invalid Proposal for ProposalTransaction,
     #[error("Invalid Proposal for ProposalTransaction,")]
-    InvalidProposalForProposalTransaction,
+    InvalidProposalForProposalTransaction, // 510
 
     /// Invalid Signatory account address
     #[error("Invalid Signatory account address")]
-    InvalidSignatoryAddress,
+    InvalidSignatoryAddress, // 511
 
     /// Signatory already signed off
     #[error("Signatory already signed off")]
-    SignatoryAlreadySignedOff,
+    SignatoryAlreadySignedOff, // 512
 
     /// Signatory must sign
     #[error("Signatory must sign")]
-    SignatoryMustSign,
+    SignatoryMustSign, // 513
 
     /// Invalid Proposal Owner
     #[error("Invalid Proposal Owner")]
-    InvalidProposalOwnerAccount,
+    InvalidProposalOwnerAccount, // 514
 
     /// Invalid Proposal for VoterRecord
     #[error("Invalid Proposal for VoterRecord")]
-    InvalidProposalForVoterRecord,
+    InvalidProposalForVoterRecord, // 515
 
     /// Invalid GoverningTokenOwner  for VoteRecord
     #[error("Invalid GoverningTokenOwner for VoteRecord")]
-    InvalidGoverningTokenOwnerForVoteRecord,
+    InvalidGoverningTokenOwnerForVoteRecord, // 516
 
     /// Invalid Governance config: Vote threshold percentage out of range"
     #[error("Invalid Governance config: Vote threshold percentage out of range")]
-    InvalidVoteThresholdPercentage,
+    InvalidVoteThresholdPercentage, // 517
 
     /// Proposal for the given Governance, Governing Token Mint and index already exists
     #[error("Proposal for the given Governance, Governing Token Mint and index already exists")]
-    ProposalAlreadyExists,
+    ProposalAlreadyExists, // 518
 
     /// Token Owner already voted on the Proposal
     #[error("Token Owner already voted on the Proposal")]
-    VoteAlreadyExists,
+    VoteAlreadyExists, // 519
 
     /// Owner doesn't have enough governing tokens to create Proposal
     #[error("Owner doesn't have enough governing tokens to create Proposal")]
-    NotEnoughTokensToCreateProposal,
+    NotEnoughTokensToCreateProposal, // 520
 
     /// Invalid State: Can't edit Signatories
     #[error("Invalid State: Can't edit Signatories")]
@@ -132,7 +132,7 @@ pub enum GovernanceError {
 
     /// Invalid State: Can't sign off
     #[error("Invalid State: Can't sign off")]
-    InvalidStateCannotSignOff,
+    InvalidStateCannotSignOff, // 530
 
     /// Invalid State: Can't vote
     #[error("Invalid State: Can't vote")]

--- a/governance/program/src/processor/process_sign_off_proposal.rs
+++ b/governance/program/src/processor/process_sign_off_proposal.rs
@@ -51,6 +51,7 @@ pub fn process_sign_off_proposal(program_id: &Pubkey, accounts: &[AccountInfo]) 
             proposal_info.key,
             signatory_info.key,
         )?;
+
         signatory_record_data.assert_can_sign_off(signatory_info)?;
 
         signatory_record_data.signed_off = true;

--- a/governance/program/src/processor/process_sign_off_proposal.rs
+++ b/governance/program/src/processor/process_sign_off_proposal.rs
@@ -12,6 +12,7 @@ use solana_program::{
 use crate::state::{
     enums::ProposalState, proposal::get_proposal_data,
     signatory_record::get_signatory_record_data_for_seeds,
+    token_owner_record::get_token_owner_record_data_for_proposal_owner,
 };
 
 /// Processes SignOffProposal instruction
@@ -29,26 +30,42 @@ pub fn process_sign_off_proposal(program_id: &Pubkey, accounts: &[AccountInfo]) 
     let mut proposal_data = get_proposal_data(program_id, proposal_info)?;
     proposal_data.assert_can_sign_off()?;
 
-    let mut signatory_record_data = get_signatory_record_data_for_seeds(
-        program_id,
-        signatory_record_info,
-        proposal_info.key,
-        signatory_info.key,
-    )?;
-    signatory_record_data.assert_can_sign_off(signatory_info)?;
+    // If the owner of the proposal hasn't appointed any signatories then can sign off the proposal themself
+    if proposal_data.signatories_count == 0 {
+        let proposal_owner_record_info = next_account_info(account_info_iter)?; // 4
 
-    signatory_record_data.signed_off = true;
-    signatory_record_data.serialize(&mut *signatory_record_info.data.borrow_mut())?;
+        let proposal_owner_record_data = get_token_owner_record_data_for_proposal_owner(
+            program_id,
+            proposal_owner_record_info,
+            &proposal_data.token_owner_record,
+        )?;
 
-    if proposal_data.signatories_signed_off_count == 0 {
+        // Proposal owner (TokenOwner) or its governance_delegate must be the signatory and sign this transaction
+        proposal_owner_record_data.assert_token_owner_or_delegate_is_signer(signatory_info)?;
+
         proposal_data.signing_off_at = Some(clock.unix_timestamp);
-        proposal_data.state = ProposalState::SigningOff;
-    }
+    } else {
+        let mut signatory_record_data = get_signatory_record_data_for_seeds(
+            program_id,
+            signatory_record_info,
+            proposal_info.key,
+            signatory_info.key,
+        )?;
+        signatory_record_data.assert_can_sign_off(signatory_info)?;
 
-    proposal_data.signatories_signed_off_count = proposal_data
-        .signatories_signed_off_count
-        .checked_add(1)
-        .unwrap();
+        signatory_record_data.signed_off = true;
+        signatory_record_data.serialize(&mut *signatory_record_info.data.borrow_mut())?;
+
+        if proposal_data.signatories_signed_off_count == 0 {
+            proposal_data.signing_off_at = Some(clock.unix_timestamp);
+            proposal_data.state = ProposalState::SigningOff;
+        }
+
+        proposal_data.signatories_signed_off_count = proposal_data
+            .signatories_signed_off_count
+            .checked_add(1)
+            .unwrap();
+    }
 
     // If all Signatories signed off we can start voting
     if proposal_data.signatories_signed_off_count == proposal_data.signatories_count {

--- a/governance/program/tests/process_sign_off_proposal.rs
+++ b/governance/program/tests/process_sign_off_proposal.rs
@@ -113,3 +113,51 @@ async fn test_sign_off_proposal_with_signatory_must_sign_error() {
     // Assert
     assert_eq!(err, GovernanceError::SignatoryMustSign.into());
 }
+
+#[tokio::test]
+async fn test_sign_off_proposal_by_owner() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut account_governance_cookie = governance_test
+        .with_account_governance(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut account_governance_cookie)
+        .await
+        .unwrap();
+
+    let clock = governance_test.bench.get_clock().await;
+
+    // Act
+    governance_test
+        .sign_off_proposal_by_owner(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(0, proposal_account.signatories_count);
+    assert_eq!(0, proposal_account.signatories_signed_off_count);
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+    assert_eq!(Some(clock.unix_timestamp), proposal_account.signing_off_at);
+    assert_eq!(Some(clock.unix_timestamp), proposal_account.voting_at);
+    assert_eq!(Some(clock.slot), proposal_account.voting_at_slot);
+}


### PR DESCRIPTION
#### Summary

Make it possible for a proposal owner to sign off the proposal themself
Adding signatories to a proposal is optional and entirely at the discretion of the proposal owner
This PR simplifies the proposal creation workflow when an owner can directly sing off a proposal without creating signatory record for themself.

