### PR TITLE
Governance: future proof v2 Proposal account

### DIFF
--- a/governance/addin-api/src/voter_weight.rs
+++ b/governance/addin-api/src/voter_weight.rs
@@ -18,6 +18,10 @@ pub enum VoterWeightAction {
 
     /// Create a proposal for a governance. Target: Governance
     CreateProposal,
+
+    /// Signs off a proposal for a governance. Target: Proposal
+    /// Note: SignOffProposal is not supported in the current version
+    SignOffProposal,
 }
 
 /// VoterWeightRecord account

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -381,6 +381,10 @@ pub enum GovernanceError {
     /// MaxVoterWeightRecord expired
     #[error("MaxVoterWeightRecord expired")]
     MaxVoterWeightRecordExpired,
+
+    /// Not supported VoteType
+    #[error("Not supported VoteType")]
+    NotSupportedVoteType,
 }
 
 impl PrintProgramError for GovernanceError {

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -134,6 +134,9 @@ pub fn process_cast_vote(
                     .unwrap(),
             )
         }
+        Vote::Abstain | Vote::Veto => {
+            return Err(GovernanceError::NotSupportedVoteType.into());
+        }
     }
 
     let max_voter_weight = proposal_data.resolve_max_voter_weight(

--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -132,6 +132,7 @@ pub fn process_create_proposal(
         name,
         description_link,
 
+        start_at: None,
         draft_at: clock.unix_timestamp,
         signing_off_at: None,
         voting_at: None,

--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -132,7 +132,7 @@ pub fn process_create_proposal(
         name,
         description_link,
 
-        start_at: None,
+        start_voting_at: None,
         draft_at: clock.unix_timestamp,
         signing_off_at: None,
         voting_at: None,

--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -151,7 +151,10 @@ pub fn process_create_proposal(
         abstain_vote_weight: None,
 
         max_vote_weight: None,
+        max_voting_time: None,
         vote_threshold_percentage: None,
+
+        reserved: [0; 8],
     };
 
     create_and_serialize_account_signed::<ProposalV2>(

--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -146,6 +146,9 @@ pub fn process_create_proposal(
         options: proposal_options,
         deny_vote_weight,
 
+        veto_vote_weight: None,
+        abstain_vote_weight: None,
+
         max_vote_weight: None,
         vote_threshold_percentage: None,
     };

--- a/governance/program/src/processor/process_relinquish_vote.rs
+++ b/governance/program/src/processor/process_relinquish_vote.rs
@@ -9,12 +9,15 @@ use solana_program::{
 };
 use spl_governance_tools::account::dispose_account;
 
-use crate::state::{
-    enums::ProposalState,
-    governance::get_governance_data,
-    proposal::get_proposal_data_for_governance_and_governing_mint,
-    token_owner_record::get_token_owner_record_data_for_realm_and_governing_mint,
-    vote_record::{get_vote_record_data_for_proposal_and_token_owner, Vote},
+use crate::{
+    error::GovernanceError,
+    state::{
+        enums::ProposalState,
+        governance::get_governance_data,
+        proposal::get_proposal_data_for_governance_and_governing_mint,
+        token_owner_record::get_token_owner_record_data_for_realm_and_governing_mint,
+        vote_record::{get_vote_record_data_for_proposal_and_token_owner, Vote},
+    },
 };
 
 use borsh::BorshSerialize;
@@ -87,6 +90,9 @@ pub fn process_relinquish_vote(program_id: &Pubkey, accounts: &[AccountInfo]) ->
                         .checked_sub(vote_record_data.voter_weight)
                         .unwrap(),
                 )
+            }
+            Vote::Abstain | Vote::Veto => {
+                return Err(GovernanceError::NotSupportedVoteType.into());
             }
         }
 

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -742,6 +742,9 @@ impl ProposalV2 {
                     return Err(GovernanceError::InvalidVote.into());
                 }
             }
+            Vote::Abstain | Vote::Veto => {
+                return Err(GovernanceError::NotSupportedVoteType.into());
+            }
         }
 
         Ok(())

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -978,6 +978,8 @@ pub fn assert_valid_proposal_options(
         }
     }
 
+    // TODO: Check for duplicated option labels
+
     if options.iter().any(|o| o.is_empty()) {
         return Err(GovernanceError::InvalidProposalOptions.into());
     }

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -82,9 +82,9 @@ pub enum VoteType {
     SingleChoice,
 
     /// Multiple options can be selected with up to max_voter_options per voter
-    /// and with up to max_executable_options of wining options eligible for execution
+    /// and with up to max_winning_options of successful options
     /// Ex. voters are given 5 options, can choose up to 3 (max_voter_options)
-    /// and only 1 (max_executable_options) wining option can be executed
+    /// and only 1 (max_winning_options) option can win and be executed
     MultiChoice {
         /// The max number of options a voter can choose
         /// By default it equals to the number of available options
@@ -92,11 +92,12 @@ pub enum VoteType {
         #[allow(dead_code)]
         max_voter_options: u16,
 
-        /// The max number of wining options which can be executed
+        /// The max number of wining options
+        /// For executable proposals it limits how many options can be executed for a Proposal
         /// By default it equals to the number of available options
         /// Note: In the current version the limit is not supported and not enforced yet
         #[allow(dead_code)]
-        max_executable_options: u16,
+        max_winning_options: u16,
     },
 }
 
@@ -380,7 +381,7 @@ impl ProposalV2 {
                 }
                 VoteType::MultiChoice {
                     max_voter_options: _n,
-                    max_executable_options: _m,
+                    max_winning_options: _m,
                 } => {
                     // If any option succeeded for multi choice then the proposal as a whole succeeded as well
                     ProposalState::Succeeded
@@ -716,7 +717,7 @@ impl ProposalV2 {
                     }
                     VoteType::MultiChoice {
                         max_voter_options: _n,
-                        max_executable_options: _m,
+                        max_winning_options: _m,
                     } => {
                         if choice_count == 0 {
                             return Err(GovernanceError::InvalidVote.into());
@@ -935,12 +936,12 @@ pub fn assert_valid_proposal_options(
 
     if let VoteType::MultiChoice {
         max_voter_options,
-        max_executable_options,
+        max_winning_options,
     } = *vote_type
     {
         if options.len() == 1
             || max_voter_options as usize != options.len()
-            || max_executable_options as usize != options.len()
+            || max_winning_options as usize != options.len()
         {
             return Err(GovernanceError::InvalidProposalOptions.into());
         }
@@ -1078,7 +1079,7 @@ mod test {
         let mut proposal = create_test_proposal();
         proposal.vote_type = VoteType::MultiChoice {
             max_voter_options: 1,
-            max_executable_options: 1,
+            max_winning_options: 1,
         };
 
         let size = proposal.try_to_vec().unwrap().len();
@@ -1091,7 +1092,7 @@ mod test {
         let mut proposal = create_test_multi_option_proposal();
         proposal.vote_type = VoteType::MultiChoice {
             max_voter_options: 3,
-            max_executable_options: 3,
+            max_winning_options: 3,
         };
 
         let size = proposal.try_to_vec().unwrap().len();
@@ -2037,7 +2038,7 @@ mod test {
         let mut proposal = create_test_multi_option_proposal();
         proposal.vote_type = VoteType::MultiChoice {
             max_voter_options: 3,
-            max_executable_options: 3,
+            max_winning_options: 3,
         };
 
         let choices = vec![
@@ -2073,7 +2074,7 @@ mod test {
         // Arrange
         let vote_type = VoteType::MultiChoice {
             max_voter_options: 3,
-            max_executable_options: 3,
+            max_winning_options: 3,
         };
 
         let options = vec!["option 1".to_string(), "option 2".to_string()];
@@ -2090,7 +2091,7 @@ mod test {
         // Arrange
         let vote_type = VoteType::MultiChoice {
             max_voter_options: 3,
-            max_executable_options: 3,
+            max_winning_options: 3,
         };
 
         let options = vec![];
@@ -2121,7 +2122,7 @@ mod test {
         // Arrange
         let vote_type = VoteType::MultiChoice {
             max_voter_options: 3,
-            max_executable_options: 3,
+            max_winning_options: 3,
         };
 
         let options = vec![
@@ -2142,7 +2143,7 @@ mod test {
         // Arrange
         let vote_type = VoteType::MultiChoice {
             max_voter_options: 3,
-            max_executable_options: 3,
+            max_winning_options: 3,
         };
 
         let options = vec![

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -132,11 +132,19 @@ pub struct ProposalV2 {
     /// Proposal options
     pub options: Vec<ProposalOption>,
 
-    /// The weight of the Proposal rejection votes
+    /// The total weight of the Proposal rejection votes
     /// If the proposal has no deny option then the weight is None
     /// Only proposals with the deny option can have executable instructions attached to them
     /// Without the deny option a proposal is only non executable survey
     pub deny_vote_weight: Option<u64>,
+
+    /// The total weight of Veto votes
+    /// Note: Veto is not supported in V2
+    pub veto_vote_weight: Option<u64>,
+
+    /// The total weight of  votes
+    /// Note: Abstain is not supported in V2
+    pub abstain_vote_weight: Option<u64>,
 
     /// When the Proposal was created and entered Draft state
     pub draft_at: UnixTimestamp,
@@ -184,7 +192,7 @@ pub struct ProposalV2 {
 impl AccountMaxSize for ProposalV2 {
     fn get_max_size(&self) -> Option<usize> {
         let options_size: usize = self.options.iter().map(|o| o.label.len() + 19).sum();
-        Some(self.name.len() + self.description_link.len() + options_size + 201)
+        Some(self.name.len() + self.description_link.len() + options_size + 219)
     }
 }
 
@@ -837,6 +845,8 @@ pub fn get_proposal_data(
                 transactions_next_index: proposal_data_v1.instructions_next_index,
             }],
             deny_vote_weight: Some(proposal_data_v1.no_votes_count),
+            veto_vote_weight: None,
+            abstain_vote_weight: None,
             draft_at: proposal_data_v1.draft_at,
             signing_off_at: proposal_data_v1.signing_off_at,
             voting_at: proposal_data_v1.voting_at,
@@ -989,6 +999,8 @@ mod test {
                 transactions_next_index: 10,
             }],
             deny_vote_weight: Some(0),
+            abstain_vote_weight: Some(0),
+            veto_vote_weight: Some(0),
 
             execution_flags: InstructionExecutionFlags::Ordered,
 

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -182,10 +182,18 @@ pub struct ProposalV2 {
     /// after vote was completed.
     pub max_vote_weight: Option<u64>,
 
+    /// Max voting time for the proposal if different from parent Governance  (only higher value possible)
+    /// Note: This field is not used in the current version
+    pub max_voting_time: Option<u32>,
+
     /// The vote threshold percentage at the time Proposal was decided
     /// It's used to show correct vote results for historical proposals in cases when the threshold
     /// was changed for governance config after vote was completed.
+    /// TODO: Use this field to override the threshold from parent Governance (only higher value possible)
     pub vote_threshold_percentage: Option<VoteThresholdPercentage>,
+
+    /// Reserved space for future versions
+    pub reserved: [u8; 8],
 
     /// Proposal name
     pub name: String,
@@ -197,7 +205,7 @@ pub struct ProposalV2 {
 impl AccountMaxSize for ProposalV2 {
     fn get_max_size(&self) -> Option<usize> {
         let options_size: usize = self.options.iter().map(|o| o.label.len() + 19).sum();
-        Some(self.name.len() + self.description_link.len() + options_size + 228)
+        Some(self.name.len() + self.description_link.len() + options_size + 241)
     }
 }
 
@@ -758,6 +766,10 @@ impl ProposalV2 {
                 panic!("ProposalV1 doesn't support start time")
             }
 
+            if self.max_voting_time.is_some() {
+                panic!("ProposalV1 doesn't support max voting time")
+            }
+
             let proposal_data_v1 = ProposalV1 {
                 account_type: self.account_type,
                 governance: self.governance,
@@ -874,9 +886,11 @@ pub fn get_proposal_data(
             closed_at: proposal_data_v1.closed_at,
             execution_flags: proposal_data_v1.execution_flags,
             max_vote_weight: proposal_data_v1.max_vote_weight,
+            max_voting_time: None,
             vote_threshold_percentage: proposal_data_v1.vote_threshold_percentage,
             name: proposal_data_v1.name,
             description_link: proposal_data_v1.description_link,
+            reserved: [0; 8],
         });
     }
 
@@ -1024,7 +1038,10 @@ mod test {
 
             execution_flags: InstructionExecutionFlags::Ordered,
 
+            max_voting_time: Some(0),
             vote_threshold_percentage: Some(VoteThresholdPercentage::YesVote(100)),
+
+            reserved: [0; 8],
         }
     }
 

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -189,7 +189,7 @@ pub struct ProposalV2 {
     /// The vote threshold percentage at the time Proposal was decided
     /// It's used to show correct vote results for historical proposals in cases when the threshold
     /// was changed for governance config after vote was completed.
-    /// TODO: Use this field to override the threshold from parent Governance (only higher value possible)
+    /// TODO: Use this field to override for the threshold from parent Governance (only higher value possible)
     pub vote_threshold_percentage: Option<VoteThresholdPercentage>,
 
     /// Reserved space for future versions
@@ -979,6 +979,7 @@ pub fn assert_valid_proposal_options(
     }
 
     // TODO: Check for duplicated option labels
+    // The options are identified by index so it's ok for now
 
     if options.iter().any(|o| o.is_empty()) {
         return Err(GovernanceError::InvalidProposalOptions.into());

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -149,7 +149,7 @@ pub struct ProposalV2 {
 
     /// Optional start time if the Proposal should not enter voting state immediately after being signed off
     /// Note: start_at is not supported in the current version
-    pub start_at: Option<UnixTimestamp>,
+    pub start_voting_at: Option<UnixTimestamp>,
 
     /// When the Proposal was created and entered Draft state
     pub draft_at: UnixTimestamp,
@@ -754,7 +754,7 @@ impl ProposalV2 {
                 panic!("ProposalV1 doesn't support Veto vote")
             }
 
-            if self.start_at.is_some() {
+            if self.start_voting_at.is_some() {
                 panic!("ProposalV1 doesn't support start time")
             }
 
@@ -864,7 +864,7 @@ pub fn get_proposal_data(
             deny_vote_weight: Some(proposal_data_v1.no_votes_count),
             veto_vote_weight: None,
             abstain_vote_weight: None,
-            start_at: None,
+            start_voting_at: None,
             draft_at: proposal_data_v1.draft_at,
             signing_off_at: proposal_data_v1.signing_off_at,
             voting_at: proposal_data_v1.voting_at,
@@ -998,7 +998,7 @@ mod test {
             description_link: "This is my description".to_string(),
             name: "This is my name".to_string(),
 
-            start_at: Some(0),
+            start_voting_at: Some(0),
             draft_at: 10,
             signing_off_at: Some(10),
 

--- a/governance/program/src/state/vote_record.rs
+++ b/governance/program/src/state/vote_record.rs
@@ -51,6 +51,14 @@ pub enum Vote {
 
     /// Vote rejecting proposal
     Deny,
+
+    /// Declare indifference to proposal
+    /// Note: Not supported in the current version
+    Abstain,
+
+    /// Veto proposal
+    /// Note: Not supported in the current version
+    Veto,
 }
 
 /// Proposal VoteRecord
@@ -102,6 +110,9 @@ impl VoteRecordV2 {
             let vote_weight = match &self.vote {
                 Vote::Approve(_options) => VoteWeightV1::Yes(self.voter_weight),
                 Vote::Deny => VoteWeightV1::No(self.voter_weight),
+                Vote::Abstain | Vote::Veto => {
+                    panic!("Vote type: {:?} not supported by VoteRecordV1", &self.vote)
+                }
             };
 
             let vote_record_data_v1 = VoteRecordV1 {

--- a/governance/program/tests/process_cast_vote.rs
+++ b/governance/program/tests/process_cast_vote.rs
@@ -533,8 +533,8 @@ async fn test_cast_vote_with_early_vote_tipped_to_succeeded() {
         .await
         .unwrap();
 
-    let mut account_governance_cookie = governance_test
-        .with_account_governance_using_config(
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
             &realm_cookie,
             &governed_account_cookie,
             &token_owner_record_cookie1,
@@ -569,7 +569,7 @@ async fn test_cast_vote_with_early_vote_tipped_to_succeeded() {
 
     // Test: tip by reaching 200 yes, 100 deny
     let proposal_cookie = governance_test
-        .with_signed_off_proposal(&token_owner_record_cookie1, &mut account_governance_cookie)
+        .with_signed_off_proposal(&token_owner_record_cookie1, &mut governance_cookie)
         .await
         .unwrap();
     governance_test
@@ -613,7 +613,7 @@ async fn test_cast_vote_with_early_vote_tipped_to_succeeded() {
 
     // Test: 200 vs 200 is above 15% yes, but does not tip yet
     let proposal_cookie = governance_test
-        .with_signed_off_proposal(&token_owner_record_cookie1, &mut account_governance_cookie)
+        .with_signed_off_proposal(&token_owner_record_cookie1, &mut governance_cookie)
         .await
         .unwrap();
     governance_test
@@ -698,8 +698,8 @@ async fn test_cast_vote_with_early_vote_tipped_to_defeated() {
         .await
         .unwrap();
 
-    let mut account_governance_cookie = governance_test
-        .with_account_governance_using_config(
+    let mut _governance_cookie = governance_test
+        .with_governance_using_config(
             &realm_cookie,
             &governed_account_cookie,
             &token_owner_record_cookie1,
@@ -726,7 +726,7 @@ async fn test_cast_vote_with_early_vote_tipped_to_defeated() {
         .await;
 
     let proposal_cookie = governance_test
-        .with_signed_off_proposal(&token_owner_record_cookie1, &mut account_governance_cookie)
+        .with_signed_off_proposal(&token_owner_record_cookie1, &mut _governance_cookie)
         .await
         .unwrap();
 
@@ -859,8 +859,8 @@ async fn test_cast_vote_with_disabled_tipping_yes_votes() {
         .await
         .unwrap();
 
-    let mut account_governance_cookie = governance_test
-        .with_account_governance_using_config(
+    let mut _governance_cookie = governance_test
+        .with_governance_using_config(
             &realm_cookie,
             &governed_account_cookie,
             &token_owner_record_cookie1,
@@ -873,7 +873,7 @@ async fn test_cast_vote_with_disabled_tipping_yes_votes() {
         .mint_community_tokens(&realm_cookie, 20) // total supply: 120
         .await;
     let proposal_cookie = governance_test
-        .with_signed_off_proposal(&token_owner_record_cookie1, &mut account_governance_cookie)
+        .with_signed_off_proposal(&token_owner_record_cookie1, &mut _governance_cookie)
         .await
         .unwrap();
 
@@ -896,7 +896,7 @@ async fn test_cast_vote_with_disabled_tipping_yes_votes() {
 
     // Act: no deny tipping
     let proposal_cookie = governance_test
-        .with_signed_off_proposal(&token_owner_record_cookie1, &mut account_governance_cookie)
+        .with_signed_off_proposal(&token_owner_record_cookie1, &mut _governance_cookie)
         .await
         .unwrap();
     governance_test
@@ -930,8 +930,8 @@ async fn test_cast_vote_with_disabled_tipping_no_votes() {
         .await
         .unwrap();
 
-    let mut account_governance_cookie = governance_test
-        .with_account_governance_using_config(
+    let mut _governance_cookie = governance_test
+        .with_governance_using_config(
             &realm_cookie,
             &governed_account_cookie,
             &token_owner_record_cookie1,
@@ -944,7 +944,7 @@ async fn test_cast_vote_with_disabled_tipping_no_votes() {
         .mint_community_tokens(&realm_cookie, 20) // total supply: 120
         .await;
     let proposal_cookie = governance_test
-        .with_signed_off_proposal(&token_owner_record_cookie1, &mut account_governance_cookie)
+        .with_signed_off_proposal(&token_owner_record_cookie1, &mut _governance_cookie)
         .await
         .unwrap();
 

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1778,7 +1778,7 @@ impl GovernanceProgramTest {
             state: ProposalState::Draft,
             signatories_count: 0,
 
-            start_at: None,
+            start_voting_at: None,
             draft_at: clock.unix_timestamp,
             signing_off_at: None,
 

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1794,6 +1794,9 @@ impl GovernanceProgramTest {
             options: proposal_options,
             deny_vote_weight,
 
+            veto_vote_weight: None,
+            abstain_vote_weight: None,
+
             execution_flags: InstructionExecutionFlags::None,
             max_vote_weight: None,
             vote_threshold_percentage: None,

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1800,7 +1800,10 @@ impl GovernanceProgramTest {
 
             execution_flags: InstructionExecutionFlags::None,
             max_vote_weight: None,
+            max_voting_time: None,
             vote_threshold_percentage: None,
+
+            reserved: [0; 8],
         };
 
         let proposal_address = get_proposal_address(

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1778,6 +1778,7 @@ impl GovernanceProgramTest {
             state: ProposalState::Draft,
             signatories_count: 0,
 
+            start_at: None,
             draft_at: clock.unix_timestamp,
             signing_off_at: None,
 

--- a/governance/program/tests/use_proposals_with_multiple_options.rs
+++ b/governance/program/tests/use_proposals_with_multiple_options.rs
@@ -92,7 +92,7 @@ async fn test_create_proposal_with_multiple_choice_options_and_without_deny_opti
             options,
             false,
             VoteType::MultiChoice {
-                max_executable_options: 2,
+                max_winning_options: 2,
                 max_voter_options: 2,
             },
         )
@@ -106,7 +106,7 @@ async fn test_create_proposal_with_multiple_choice_options_and_without_deny_opti
     assert_eq!(
         proposal_account.vote_type,
         VoteType::MultiChoice {
-            max_executable_options: 2,
+            max_winning_options: 2,
             max_voter_options: 2,
         }
     );
@@ -360,7 +360,7 @@ async fn test_vote_on_none_executable_multi_choice_proposal_with_multiple_option
             ],
             false,
             VoteType::MultiChoice {
-                max_executable_options: 3,
+                max_winning_options: 3,
                 max_voter_options: 3,
             },
         )
@@ -488,7 +488,7 @@ async fn test_vote_on_executable_proposal_with_multiple_options_and_partial_succ
             ],
             true,
             VoteType::MultiChoice {
-                max_executable_options: 3,
+                max_winning_options: 3,
                 max_voter_options: 3,
             },
         )
@@ -649,7 +649,7 @@ async fn test_execute_proposal_with_multiple_options_and_partial_success() {
             ],
             true,
             VoteType::MultiChoice {
-                max_executable_options: 3,
+                max_winning_options: 3,
                 max_voter_options: 3,
             },
         )
@@ -853,7 +853,7 @@ async fn test_try_execute_proposal_with_multiple_options_and_full_deny() {
             ],
             true,
             VoteType::MultiChoice {
-                max_executable_options: 3,
+                max_winning_options: 3,
                 max_voter_options: 3,
             },
         )


### PR DESCRIPTION
#### Summary 

Add fields to `Proposal` account as placeholders to be implemented in future versions
- `start_voting_at` - Allows to optionally specify a future start time for voting when a proposal doesn't automatically enters `Voting` state after being signed off 
- `veto_vote_weight` - `Veto` votes for either community or council members to veto each other vote
- `abstain_vote_weight` - `Abstain` vote to support explicit indifference to a proposal and/or earlier vote tipping  
- `max_voting_time`- Make it possible to extend the voting time specified in the parent `Governance` 


Add options to `VoterWeightAction`
- `SignOffProposal` - action for `VoterWeightRecord` to support gated proposal signing 
