### PR TITLE
Governance: Track proposals in Voting state for realms and governances

### DIFF
--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -385,6 +385,14 @@ pub enum GovernanceError {
     /// Not supported VoteType
     #[error("Not supported VoteType")]
     NotSupportedVoteType,
+
+    /// RealmConfig change not allowed
+    #[error("RealmConfig change not allowed")]
+    RealmConfigChangeNotAllowed,
+
+    /// GovernanceConfig change not allowed
+    #[error("GovernanceConfig change not allowed")]
+    GovernanceConfigChangeNotAllowed,
 }
 
 impl PrintProgramError for GovernanceError {

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -280,7 +280,7 @@ pub enum GovernanceError {
 
     /// Realm authority must sign
     #[error("Realm authority must sign")]
-    RealmAuthorityMustSign,
+    RealmAuthorityMustSign, // 566
 
     /// Invalid governing token holding account
     #[error("Invalid governing token holding account")]
@@ -290,7 +290,7 @@ pub enum GovernanceError {
     #[error("Realm council mint change is not supported")]
     RealmCouncilMintChangeIsNotSupported,
 
-    /// Not supported mint max vote weight source
+    /// Not supported mint max vote weight sourcef
     #[error("Not supported mint max vote weight source")]
     MintMaxVoteWeightSourceNotSupported,
 

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -292,11 +292,9 @@ pub enum GovernanceInstruction {
     ///   6. `[]` Governing Token Mint
     ///   7. `[signer]` Payer
     ///   8. `[]` System program
-    ///   9. `[]` Rent sysvar
-    ///   10. `[]` Clock sysvar
-    ///   11. `[]` Realm Config
-    ///   12. `[]` Optional Voter Weight Record
-    ///   13. `[]` Optional Max Voter Weight Record
+    ///   9. `[]` Realm Config
+    ///   10. `[]` Optional Voter Weight Record
+    ///   11. `[]` Optional Max Voter Weight Record
     CastVote {
         #[allow(dead_code)]
         /// User's vote
@@ -1051,8 +1049,6 @@ pub fn cast_vote(
         AccountMeta::new_readonly(*governing_token_mint, false),
         AccountMeta::new(*payer, true),
         AccountMeta::new_readonly(system_program::id(), false),
-        AccountMeta::new_readonly(sysvar::rent::id(), false),
-        AccountMeta::new_readonly(sysvar::clock::id(), false),
     ];
 
     with_realm_config_accounts(

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -258,11 +258,11 @@ pub enum GovernanceInstruction {
 
     /// Cancels Proposal by changing its state to Canceled
     ///
-    ///   0. `[writable]` Proposal account
-    ///   1. `[writable]`  TokenOwnerRecord account of the  Proposal owner
-    ///   2. `[signer]` Governance Authority (Token Owner or Governance Delegate)
-    ///   3. `[]` Clock sysvar
-    ///   4. `[]` Governance account
+    ///   0. `[writable]` Realm account
+    ///   1. `[writable]` Governance account
+    ///   2. `[writable]` Proposal account
+    ///   3. `[writable]`  TokenOwnerRecord account of the  Proposal owner
+    ///   4. `[signer]` Governance Authority (Token Owner or Governance Delegate)
     CancelProposal,
 
     /// Signs off Proposal indicating the Signatory approves the Proposal
@@ -1152,17 +1152,19 @@ pub fn relinquish_vote(
 pub fn cancel_proposal(
     program_id: &Pubkey,
     // Accounts
+    realm: &Pubkey,
+    governance: &Pubkey,
     proposal: &Pubkey,
     proposal_owner_record: &Pubkey,
     governance_authority: &Pubkey,
-    governance: &Pubkey,
 ) -> Instruction {
     let accounts = vec![
+        AccountMeta::new(*realm, false),
+        AccountMeta::new(*governance, false),
         AccountMeta::new(*proposal, false),
         AccountMeta::new(*proposal_owner_record, false),
         AccountMeta::new_readonly(*governance_authority, true),
         AccountMeta::new_readonly(sysvar::clock::id(), false),
-        AccountMeta::new_readonly(*governance, false),
     ];
 
     let instruction = GovernanceInstruction::CancelProposal {};

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -593,7 +593,6 @@ pub fn deposit_governing_tokens(
         AccountMeta::new(*payer, true),
         AccountMeta::new_readonly(system_program::id(), false),
         AccountMeta::new_readonly(spl_token::id(), false),
-        AccountMeta::new_readonly(sysvar::rent::id(), false),
     ];
 
     let instruction = GovernanceInstruction::DepositGoverningTokens { amount };
@@ -752,7 +751,6 @@ pub fn create_program_governance(
         AccountMeta::new(*payer, true),
         AccountMeta::new_readonly(bpf_loader_upgradeable::id(), false),
         AccountMeta::new_readonly(system_program::id(), false),
-        AccountMeta::new_readonly(sysvar::rent::id(), false),
         AccountMeta::new_readonly(*create_authority, true),
     ];
 
@@ -797,7 +795,6 @@ pub fn create_mint_governance(
         AccountMeta::new(*payer, true),
         AccountMeta::new_readonly(spl_token::id(), false),
         AccountMeta::new_readonly(system_program::id(), false),
-        AccountMeta::new_readonly(sysvar::rent::id(), false),
         AccountMeta::new_readonly(*create_authority, true),
     ];
 
@@ -842,7 +839,6 @@ pub fn create_token_governance(
         AccountMeta::new(*payer, true),
         AccountMeta::new_readonly(spl_token::id(), false),
         AccountMeta::new_readonly(system_program::id(), false),
-        AccountMeta::new_readonly(sysvar::rent::id(), false),
         AccountMeta::new_readonly(*create_authority, true),
     ];
 
@@ -1152,7 +1148,6 @@ pub fn cancel_proposal(
         AccountMeta::new(*proposal, false),
         AccountMeta::new(*proposal_owner_record, false),
         AccountMeta::new_readonly(*governance_authority, true),
-        AccountMeta::new_readonly(sysvar::clock::id(), false),
     ];
 
     let instruction = GovernanceInstruction::CancelProposal {};

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -282,8 +282,8 @@ pub enum GovernanceInstruction {
     ///  By doing so you indicate you approve or disapprove of running the Proposal set of transactions
     ///  If you tip the consensus then the transactions can begin to be run after their hold up time
     ///
-    ///   0. `[]` Realm account
-    ///   1. `[]` Governance account
+    ///   0. `[writable]` Realm account
+    ///   1. `[writable]` Governance account
     ///   2. `[writable]` Proposal account
     ///   4. `[writable]` TokenOwnerRecord of the Proposal owner    
     ///   3. `[writable]` TokenOwnerRecord of the voter. PDA seeds: ['governance',realm, governing_token_mint, governing_token_owner]
@@ -303,8 +303,8 @@ pub enum GovernanceInstruction {
 
     /// Finalizes vote in case the Vote was not automatically tipped within max_voting_time period
     ///
-    ///   0. `[]` Realm account    
-    ///   1. `[]` Governance account
+    ///   0. `[writable]` Realm account    
+    ///   1. `[writable]` Governance account
     ///   2. `[writable]` Proposal account
     ///   3. `[writable]` TokenOwnerRecord of the Proposal owner        
     ///   4. `[]` Governing Token Mint
@@ -1030,8 +1030,8 @@ pub fn cast_vote(
         get_vote_record_address(program_id, proposal, voter_token_owner_record);
 
     let mut accounts = vec![
-        AccountMeta::new_readonly(*realm, false),
-        AccountMeta::new_readonly(*governance, false),
+        AccountMeta::new(*realm, false),
+        AccountMeta::new(*governance, false),
         AccountMeta::new(*proposal, false),
         AccountMeta::new(*proposal_owner_record, false),
         AccountMeta::new(*voter_token_owner_record, false),

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -931,7 +931,6 @@ pub fn add_signatory(
         AccountMeta::new(signatory_record_address, false),
         AccountMeta::new(*payer, true),
         AccountMeta::new_readonly(system_program::id(), false),
-        AccountMeta::new_readonly(sysvar::rent::id(), false),
     ];
 
     let instruction = GovernanceInstruction::AddSignatory {

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -1071,8 +1071,8 @@ pub fn finalize_vote(
     max_voter_weight_record: Option<Pubkey>,
 ) -> Instruction {
     let mut accounts = vec![
-        AccountMeta::new_readonly(*realm, false),
-        AccountMeta::new_readonly(*governance, false),
+        AccountMeta::new(*realm, false),
+        AccountMeta::new(*governance, false),
         AccountMeta::new(*proposal, false),
         AccountMeta::new(*proposal_owner_record, false),
         AccountMeta::new_readonly(*governing_token_mint, false),

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -706,7 +706,6 @@ pub fn create_governance(
         AccountMeta::new_readonly(*token_owner_record, false),
         AccountMeta::new(*payer, true),
         AccountMeta::new_readonly(system_program::id(), false),
-        AccountMeta::new_readonly(sysvar::rent::id(), false),
         AccountMeta::new_readonly(*create_authority, true),
     ];
 

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -308,9 +308,8 @@ pub enum GovernanceInstruction {
     ///   2. `[writable]` Proposal account
     ///   3. `[writable]` TokenOwnerRecord of the Proposal owner        
     ///   4. `[]` Governing Token Mint
-    ///   5. `[]` Clock sysvar
-    ///   6. `[]` Realm Config
-    ///   7. `[]` Optional Max Voter Weight Record
+    ///   5. `[]` Realm Config
+    ///   6. `[]` Optional Max Voter Weight Record
     FinalizeVote {},
 
     ///  Relinquish Vote removes voter weight from a Proposal and removes it from voter's active votes
@@ -1085,7 +1084,6 @@ pub fn finalize_vote(
         AccountMeta::new(*proposal, false),
         AccountMeta::new(*proposal_owner_record, false),
         AccountMeta::new_readonly(*governing_token_mint, false),
-        AccountMeta::new_readonly(sysvar::clock::id(), false),
     ];
 
     with_realm_config_accounts(

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -409,7 +409,6 @@ pub enum GovernanceInstruction {
     ///   1. `[]` TokenOwnerRecord account of the Proposal owner
     ///   2. `[signer]` Governance Authority (Token Owner or Governance Delegate)    
     ///   3. `[writable]` ProposalTransaction account to flag
-    ///   4. `[]` Clock sysvar
     FlagTransactionError,
 
     /// Sets new Realm authority
@@ -1301,7 +1300,6 @@ pub fn flag_transaction_error(
         AccountMeta::new_readonly(*token_owner_record, false),
         AccountMeta::new_readonly(*governance_authority, true),
         AccountMeta::new(*proposal_transaction, false),
-        AccountMeta::new_readonly(sysvar::clock::id(), false),
     ];
 
     let instruction = GovernanceInstruction::FlagTransactionError {};

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -271,12 +271,13 @@ pub enum GovernanceInstruction {
     /// it's entirely at the discretion of the Proposal owner
     /// If Proposal owner doesn't designate any signatories then can sign off the Proposal themself
     ///
-    ///   0. `[writable]` Proposal account
-    ///   1. `[writable]` Signatory Record account
-    ///   2. `[signer]` Signatory account signing off the Proposal
+    ///   0. `[writable]` Realm account
+    ///   1. `[writable]` Proposal account
+    ///   2. `[writable]` Signatory Record account
+    ///   3. `[signer]` Signatory account signing off the Proposal
     ///       Or Proposal owner if the owner hasn't appointed any signatories
-    ///   3. `[]` Clock sysvar
-    ///   4. `[]` Optional TokenOwnerRecord of the Proposal owner when self signing off the Proposal
+    ///   4. `[]` Clock sysvar
+    ///   5. `[]` Optional TokenOwnerRecord of the Proposal owner when self signing off the Proposal
     SignOffProposal,
 
     ///  Uses your voter weight (deposited Community or Council tokens) to cast a vote on a Proposal
@@ -992,6 +993,7 @@ pub fn remove_signatory(
 pub fn sign_off_proposal(
     program_id: &Pubkey,
     // Accounts
+    realm: &Pubkey,
     proposal: &Pubkey,
     signatory: &Pubkey,
     proposal_owner_record: Option<&Pubkey>,
@@ -999,6 +1001,7 @@ pub fn sign_off_proposal(
     let signatory_record_address = get_signatory_record_address(program_id, proposal, signatory);
 
     let mut accounts = vec![
+        AccountMeta::new(*realm, false),
         AccountMeta::new(*proposal, false),
         AccountMeta::new(signatory_record_address, false),
         AccountMeta::new_readonly(*signatory, true),

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -272,11 +272,11 @@ pub enum GovernanceInstruction {
     /// If Proposal owner doesn't designate any signatories then can sign off the Proposal themself
     ///
     ///   0. `[writable]` Realm account
-    ///   1. `[writable]` Proposal account
-    ///   2. `[writable]` Signatory Record account
-    ///   3. `[signer]` Signatory account signing off the Proposal
+    ///   1. `[writable]` Realm account
+    ///   2. `[writable]` Governance account
+    ///   3. `[writable]` Signatory Record account
+    ///   4. `[signer]` Signatory account signing off the Proposal
     ///       Or Proposal owner if the owner hasn't appointed any signatories
-    ///   4. `[]` Clock sysvar
     ///   5. `[]` Optional TokenOwnerRecord of the Proposal owner when self signing off the Proposal
     SignOffProposal,
 
@@ -994,6 +994,7 @@ pub fn sign_off_proposal(
     program_id: &Pubkey,
     // Accounts
     realm: &Pubkey,
+    governance: &Pubkey,
     proposal: &Pubkey,
     signatory: &Pubkey,
     proposal_owner_record: Option<&Pubkey>,
@@ -1002,10 +1003,10 @@ pub fn sign_off_proposal(
 
     let mut accounts = vec![
         AccountMeta::new(*realm, false),
+        AccountMeta::new(*governance, false),
         AccountMeta::new(*proposal, false),
         AccountMeta::new(signatory_record_address, false),
         AccountMeta::new_readonly(*signatory, true),
-        AccountMeta::new_readonly(sysvar::clock::id(), false),
     ];
 
     if let Some(proposal_owner_record) = proposal_owner_record {

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -335,8 +335,7 @@ pub enum GovernanceInstruction {
     ///
     ///   0. `[writable]` Proposal account
     ///   1. `[writable]` ProposalTransaction account you wish to execute
-    ///   2. `[]` Clock sysvar
-    ///   3+ Any extra accounts that are part of the transaction, in order
+    ///   2+ Any extra accounts that are part of the transaction, in order
     ExecuteTransaction,
 
     /// Creates Mint Governance account which governs a mint
@@ -1255,7 +1254,6 @@ pub fn execute_transaction(
         AccountMeta::new_readonly(*governance, false),
         AccountMeta::new(*proposal, false),
         AccountMeta::new(*proposal_transaction, false),
-        AccountMeta::new_readonly(sysvar::clock::id(), false),
         AccountMeta::new_readonly(*instruction_program_id, false),
     ];
 

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -163,10 +163,8 @@ pub enum GovernanceInstruction {
     ///   5. `[signer]` Governance Authority (Token Owner or Governance Delegate)
     ///   6. `[signer]` Payer
     ///   7. `[]` System program
-    ///   8. `[]` Rent sysvar
-    ///   9. `[]` Clock sysvar
-    ///   10. `[]` Realm Config
-    ///   11. `[]` Optional Voter Weight Record
+    ///   8. `[]` Realm Config
+    ///   9. `[]` Optional Voter Weight Record
     CreateProposal {
         #[allow(dead_code)]
         /// UTF-8 encoded name of the proposal
@@ -903,8 +901,6 @@ pub fn create_proposal(
         AccountMeta::new_readonly(*governance_authority, true),
         AccountMeta::new(*payer, true),
         AccountMeta::new_readonly(system_program::id(), false),
-        AccountMeta::new_readonly(sysvar::rent::id(), false),
-        AccountMeta::new_readonly(sysvar::clock::id(), false),
     ];
 
     with_realm_config_accounts(program_id, &mut accounts, realm, voter_weight_record, None);

--- a/governance/program/src/processor/process_add_signatory.rs
+++ b/governance/program/src/processor/process_add_signatory.rs
@@ -33,8 +33,7 @@ pub fn process_add_signatory(
     let payer_info = next_account_info(account_info_iter)?; // 4
     let system_info = next_account_info(account_info_iter)?; // 5
 
-    let rent_sysvar_info = next_account_info(account_info_iter)?; // 6
-    let rent = &Rent::from_account_info(rent_sysvar_info)?;
+    let rent = Rent::get()?;
 
     let mut proposal_data = get_proposal_data(program_id, proposal_info)?;
     proposal_data.assert_can_edit_signatories()?;
@@ -61,7 +60,7 @@ pub fn process_add_signatory(
         &get_signatory_record_address_seeds(proposal_info.key, &signatory),
         program_id,
         system_info,
-        rent,
+        &rent,
     )?;
 
     proposal_data.signatories_count = proposal_data.signatories_count.checked_add(1).unwrap();

--- a/governance/program/src/processor/process_cancel_proposal.rs
+++ b/governance/program/src/processor/process_cancel_proposal.rs
@@ -10,8 +10,8 @@ use solana_program::{
 };
 
 use crate::state::{
-    enums::ProposalState, governance::get_governance_data,
-    proposal::get_proposal_data_for_governance,
+    enums::ProposalState, governance::get_governance_data_for_realm,
+    proposal::get_proposal_data_for_governance, realm::get_realm_data,
     token_owner_record::get_token_owner_record_data_for_proposal_owner,
 };
 
@@ -19,16 +19,18 @@ use crate::state::{
 pub fn process_cancel_proposal(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
 
-    let proposal_info = next_account_info(account_info_iter)?; // 0
-    let proposal_owner_record_info = next_account_info(account_info_iter)?; // 1
-    let governance_authority_info = next_account_info(account_info_iter)?; // 2
+    let realm_info = next_account_info(account_info_iter)?; // 0
+    let governance_info = next_account_info(account_info_iter)?; // 1
+    let proposal_info = next_account_info(account_info_iter)?; // 2
+    let proposal_owner_record_info = next_account_info(account_info_iter)?; // 3
+    let governance_authority_info = next_account_info(account_info_iter)?; // 4
 
-    let clock_info = next_account_info(account_info_iter)?; // 3
-    let clock = Clock::from_account_info(clock_info)?;
+    let clock = Clock::get()?;
 
-    let governance_info = next_account_info(account_info_iter)?; // 4
+    let mut realm_data = get_realm_data(program_id, realm_info)?;
 
-    let governance_data = get_governance_data(program_id, governance_info)?;
+    let mut governance_data =
+        get_governance_data_for_realm(program_id, governance_info, realm_info.key)?;
 
     let mut proposal_data =
         get_proposal_data_for_governance(program_id, proposal_info, governance_info.key)?;
@@ -45,6 +47,17 @@ pub fn process_cancel_proposal(program_id: &Pubkey, accounts: &[AccountInfo]) ->
 
     proposal_owner_record_data.decrease_outstanding_proposal_count();
     proposal_owner_record_data.serialize(&mut *proposal_owner_record_info.data.borrow_mut())?;
+
+    if proposal_data.state == ProposalState::Voting {
+        realm_data.voting_proposal_count = realm_data.voting_proposal_count.checked_sub(1).unwrap();
+        realm_data.serialize(&mut *realm_info.data.borrow_mut())?;
+
+        governance_data.voting_proposal_count = governance_data
+            .voting_proposal_count
+            .checked_sub(1)
+            .unwrap();
+        governance_data.serialize(&mut *governance_info.data.borrow_mut())?;
+    }
 
     proposal_data.state = ProposalState::Cancelled;
     proposal_data.closed_at = Some(clock.unix_timestamp);

--- a/governance/program/src/processor/process_cancel_proposal.rs
+++ b/governance/program/src/processor/process_cancel_proposal.rs
@@ -49,9 +49,11 @@ pub fn process_cancel_proposal(program_id: &Pubkey, accounts: &[AccountInfo]) ->
     proposal_owner_record_data.serialize(&mut *proposal_owner_record_info.data.borrow_mut())?;
 
     if proposal_data.state == ProposalState::Voting {
+        // Update Realm voting_proposal_count
         realm_data.voting_proposal_count = realm_data.voting_proposal_count.checked_sub(1).unwrap();
         realm_data.serialize(&mut *realm_info.data.borrow_mut())?;
 
+        // Update  Governance voting_proposal_count
         governance_data.voting_proposal_count = governance_data
             .voting_proposal_count
             .checked_sub(1)

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -58,12 +58,12 @@ pub fn process_cast_vote(
         return Err(GovernanceError::VoteAlreadyExists.into());
     }
 
-    let realm_data = get_realm_data_for_governing_token_mint(
+    let mut realm_data = get_realm_data_for_governing_token_mint(
         program_id,
         realm_info,
         governing_token_mint_info.key,
     )?;
-    let governance_data =
+    let mut governance_data =
         get_governance_data_for_realm(program_id, governance_info, realm_info.key)?;
 
     let mut proposal_data = get_proposal_data_for_governance_and_governing_mint(
@@ -165,6 +165,17 @@ pub fn process_cast_vote(
             proposal_owner_record_data
                 .serialize(&mut *proposal_owner_record_info.data.borrow_mut())?;
         };
+
+        // Update Realm voting_proposal_count
+        realm_data.voting_proposal_count = realm_data.voting_proposal_count.checked_sub(1).unwrap();
+        realm_data.serialize(&mut *realm_info.data.borrow_mut())?;
+
+        // Update  Governance voting_proposal_count
+        governance_data.voting_proposal_count = governance_data
+            .voting_proposal_count
+            .checked_sub(1)
+            .unwrap();
+        governance_data.serialize(&mut *governance_info.data.borrow_mut())?;
     }
 
     voter_token_owner_record_data

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -51,11 +51,8 @@ pub fn process_cast_vote(
     let payer_info = next_account_info(account_info_iter)?; // 8
     let system_info = next_account_info(account_info_iter)?; // 9
 
-    let rent_sysvar_info = next_account_info(account_info_iter)?; // 10
-    let rent = &Rent::from_account_info(rent_sysvar_info)?;
-
-    let clock_info = next_account_info(account_info_iter)?; // 11
-    let clock = Clock::from_account_info(clock_info)?;
+    let rent = Rent::get()?;
+    let clock = Clock::get()?;
 
     if !vote_record_info.data_is_empty() {
         return Err(GovernanceError::VoteAlreadyExists.into());
@@ -101,12 +98,12 @@ pub fn process_cast_vote(
     // Note: When both voter_weight and max_voter_weight addins are used the realm_config will be deserialized twice in resolve_voter_weight() and resolve_max_voter_weight()
     //      It can't be deserialized eagerly because some realms won't have the config if they don't use any of the advanced options
     //      This extra deserialisation should be acceptable to keep things simple and encapsulated.
-    let realm_config_info = next_account_info(account_info_iter)?; //12
+    let realm_config_info = next_account_info(account_info_iter)?; //9
 
     let voter_weight = voter_token_owner_record_data.resolve_voter_weight(
         program_id,
         realm_config_info,
-        account_info_iter,
+        account_info_iter, // voter_weight_record  10
         realm_info.key,
         &realm_data,
         VoterWeightAction::CastVote,
@@ -143,7 +140,7 @@ pub fn process_cast_vote(
         program_id,
         realm_config_info,
         governing_token_mint_info,
-        account_info_iter,
+        account_info_iter, // max_voter_weight_record  11
         realm_info.key,
         &realm_data,
     )?;
@@ -192,7 +189,7 @@ pub fn process_cast_vote(
         &get_vote_record_address_seeds(proposal_info.key, voter_token_owner_record_info.key),
         program_id,
         system_info,
-        rent,
+        &rent,
     )?;
 
     Ok(())

--- a/governance/program/src/processor/process_create_governance.rs
+++ b/governance/program/src/processor/process_create_governance.rs
@@ -44,12 +44,12 @@ pub fn process_create_governance(
 
     let realm_data = get_realm_data(program_id, realm_info)?;
 
-    realm_data.assert_can_create_governance(
+    realm_data.assert_create_authority_can_create_governance(
         program_id,
         realm_info.key,
         token_owner_record_info,
         create_authority_info,
-        account_info_iter, // 8, 9
+        account_info_iter, // realm_config_info 8, voter_weight_record_info 9
     )?;
 
     let governance_data = Governance {

--- a/governance/program/src/processor/process_create_governance.rs
+++ b/governance/program/src/processor/process_create_governance.rs
@@ -35,10 +35,9 @@ pub fn process_create_governance(
     let payer_info = next_account_info(account_info_iter)?; // 4
     let system_info = next_account_info(account_info_iter)?; // 5
 
-    let rent_sysvar_info = next_account_info(account_info_iter)?; // 6
-    let rent = &Rent::from_account_info(rent_sysvar_info)?;
+    let rent = Rent::get()?;
 
-    let create_authority_info = next_account_info(account_info_iter)?; // 7
+    let create_authority_info = next_account_info(account_info_iter)?; // 6
 
     assert_valid_create_governance_args(program_id, &config, realm_info)?;
 
@@ -49,7 +48,7 @@ pub fn process_create_governance(
         realm_info.key,
         token_owner_record_info,
         create_authority_info,
-        account_info_iter, // realm_config_info 8, voter_weight_record_info 9
+        account_info_iter, // realm_config_info 7, voter_weight_record_info 8
     )?;
 
     let governance_data = Governance {
@@ -69,7 +68,7 @@ pub fn process_create_governance(
         &get_governance_address_seeds(realm_info.key, governed_account_info.key),
         program_id,
         system_info,
-        rent,
+        &rent,
     )?;
 
     Ok(())

--- a/governance/program/src/processor/process_create_governance.rs
+++ b/governance/program/src/processor/process_create_governance.rs
@@ -58,7 +58,8 @@ pub fn process_create_governance(
         governed_account: *governed_account_info.key,
         config,
         proposals_count: 0,
-        reserved: [0; 8],
+        reserved: [0; 6],
+        voting_proposal_count: 0,
     };
 
     create_and_serialize_account_signed::<Governance>(

--- a/governance/program/src/processor/process_create_mint_governance.rs
+++ b/governance/program/src/processor/process_create_mint_governance.rs
@@ -70,7 +70,8 @@ pub fn process_create_mint_governance(
         governed_account: *governed_mint_info.key,
         config,
         proposals_count: 0,
-        reserved: [0; 8],
+        reserved: [0; 6],
+        voting_proposal_count: 0,
     };
 
     create_and_serialize_account_signed::<Governance>(

--- a/governance/program/src/processor/process_create_mint_governance.rs
+++ b/governance/program/src/processor/process_create_mint_governance.rs
@@ -47,10 +47,9 @@ pub fn process_create_mint_governance(
 
     let system_info = next_account_info(account_info_iter)?; // 7
 
-    let rent_sysvar_info = next_account_info(account_info_iter)?; // 8
-    let rent = &Rent::from_account_info(rent_sysvar_info)?;
+    let rent = Rent::get()?;
 
-    let create_authority_info = next_account_info(account_info_iter)?; // 9
+    let create_authority_info = next_account_info(account_info_iter)?; // 8
 
     assert_valid_create_governance_args(program_id, &config, realm_info)?;
 
@@ -61,7 +60,7 @@ pub fn process_create_mint_governance(
         realm_info.key,
         token_owner_record_info,
         create_authority_info,
-        account_info_iter, // realm_config_info 10, voter_weight_record_info 11
+        account_info_iter, // realm_config_info 9, voter_weight_record_info 10
     )?;
 
     let mint_governance_data = Governance {
@@ -81,7 +80,7 @@ pub fn process_create_mint_governance(
         &get_mint_governance_address_seeds(realm_info.key, governed_mint_info.key),
         program_id,
         system_info,
-        rent,
+        &rent,
     )?;
 
     if transfer_mint_authorities {

--- a/governance/program/src/processor/process_create_mint_governance.rs
+++ b/governance/program/src/processor/process_create_mint_governance.rs
@@ -56,12 +56,12 @@ pub fn process_create_mint_governance(
 
     let realm_data = get_realm_data(program_id, realm_info)?;
 
-    realm_data.assert_can_create_governance(
+    realm_data.assert_create_authority_can_create_governance(
         program_id,
         realm_info.key,
         token_owner_record_info,
         create_authority_info,
-        account_info_iter, // 10, 11
+        account_info_iter, // realm_config_info 10, voter_weight_record_info 11
     )?;
 
     let mint_governance_data = Governance {

--- a/governance/program/src/processor/process_create_program_governance.rs
+++ b/governance/program/src/processor/process_create_program_governance.rs
@@ -47,10 +47,9 @@ pub fn process_create_program_governance(
 
     let system_info = next_account_info(account_info_iter)?; // 8
 
-    let rent_sysvar_info = next_account_info(account_info_iter)?; // 9
-    let rent = &Rent::from_account_info(rent_sysvar_info)?;
+    let rent = Rent::get()?;
 
-    let create_authority_info = next_account_info(account_info_iter)?; // 10
+    let create_authority_info = next_account_info(account_info_iter)?; // 9
 
     assert_valid_create_governance_args(program_id, &config, realm_info)?;
 
@@ -81,7 +80,7 @@ pub fn process_create_program_governance(
         &get_program_governance_address_seeds(realm_info.key, governed_program_info.key),
         program_id,
         system_info,
-        rent,
+        &rent,
     )?;
 
     if transfer_upgrade_authority {

--- a/governance/program/src/processor/process_create_program_governance.rs
+++ b/governance/program/src/processor/process_create_program_governance.rs
@@ -70,7 +70,8 @@ pub fn process_create_program_governance(
         governed_account: *governed_program_info.key,
         config,
         proposals_count: 0,
-        reserved: [0; 8],
+        reserved: [0; 6],
+        voting_proposal_count: 0,
     };
 
     create_and_serialize_account_signed::<Governance>(

--- a/governance/program/src/processor/process_create_program_governance.rs
+++ b/governance/program/src/processor/process_create_program_governance.rs
@@ -56,12 +56,12 @@ pub fn process_create_program_governance(
 
     let realm_data = get_realm_data(program_id, realm_info)?;
 
-    realm_data.assert_can_create_governance(
+    realm_data.assert_create_authority_can_create_governance(
         program_id,
         realm_info.key,
         token_owner_record_info,
         create_authority_info,
-        account_info_iter, // 10, 11
+        account_info_iter, // realm_config_info 10, voter_weight_record_info 11
     )?;
 
     let program_governance_data = Governance {

--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -49,11 +49,8 @@ pub fn process_create_proposal(
     let payer_info = next_account_info(account_info_iter)?; // 6
     let system_info = next_account_info(account_info_iter)?; // 7
 
-    let rent_sysvar_info = next_account_info(account_info_iter)?; // 8
-    let rent = &Rent::from_account_info(rent_sysvar_info)?;
-
-    let clock_info = next_account_info(account_info_iter)?; // 9
-    let clock = Clock::from_account_info(clock_info)?;
+    let rent = Rent::get()?;
+    let clock = Clock::get()?;
 
     if !proposal_info.data_is_empty() {
         return Err(GovernanceError::ProposalAlreadyExists.into());
@@ -168,7 +165,7 @@ pub fn process_create_proposal(
         ),
         program_id,
         system_info,
-        rent,
+        &rent,
     )?;
 
     governance_data.proposals_count = governance_data.proposals_count.checked_add(1).unwrap();

--- a/governance/program/src/processor/process_create_realm.rs
+++ b/governance/program/src/processor/process_create_realm.rs
@@ -130,7 +130,7 @@ pub fn process_create_realm(
         community_mint: *governance_token_mint_info.key,
 
         name: name.clone(),
-        reserved: [0; 8],
+        reserved: [0; 6],
         authority: Some(*realm_authority_info.key),
         config: RealmConfig {
             council_mint: council_token_mint_address,
@@ -142,6 +142,7 @@ pub fn process_create_realm(
             use_community_voter_weight_addin: config_args.use_community_voter_weight_addin,
             use_max_community_voter_weight_addin: config_args.use_max_community_voter_weight_addin,
         },
+        voting_proposal_count: 0,
     };
 
     create_and_serialize_account_signed::<Realm>(

--- a/governance/program/src/processor/process_create_token_governance.rs
+++ b/governance/program/src/processor/process_create_token_governance.rs
@@ -45,10 +45,9 @@ pub fn process_create_token_governance(
 
     let system_info = next_account_info(account_info_iter)?; // 7
 
-    let rent_sysvar_info = next_account_info(account_info_iter)?; // 8
-    let rent = &Rent::from_account_info(rent_sysvar_info)?;
+    let rent = Rent::get()?;
 
-    let create_authority_info = next_account_info(account_info_iter)?; // 9
+    let create_authority_info = next_account_info(account_info_iter)?; // 8
 
     assert_valid_create_governance_args(program_id, &config, realm_info)?;
 
@@ -59,7 +58,7 @@ pub fn process_create_token_governance(
         realm_info.key,
         token_owner_record_info,
         create_authority_info,
-        account_info_iter, // realm_config_info 10, voter_weight_record_info 11
+        account_info_iter, // realm_config_info 9, voter_weight_record_info 10
     )?;
 
     let token_governance_data = Governance {
@@ -79,7 +78,7 @@ pub fn process_create_token_governance(
         &get_token_governance_address_seeds(realm_info.key, governed_token_info.key),
         program_id,
         system_info,
-        rent,
+        &rent,
     )?;
 
     if transfer_account_authorities {

--- a/governance/program/src/processor/process_create_token_governance.rs
+++ b/governance/program/src/processor/process_create_token_governance.rs
@@ -54,12 +54,12 @@ pub fn process_create_token_governance(
 
     let realm_data = get_realm_data(program_id, realm_info)?;
 
-    realm_data.assert_can_create_governance(
+    realm_data.assert_create_authority_can_create_governance(
         program_id,
         realm_info.key,
         token_owner_record_info,
         create_authority_info,
-        account_info_iter, // 10, 11
+        account_info_iter, // realm_config_info 10, voter_weight_record_info 11
     )?;
 
     let token_governance_data = Governance {

--- a/governance/program/src/processor/process_create_token_governance.rs
+++ b/governance/program/src/processor/process_create_token_governance.rs
@@ -68,7 +68,8 @@ pub fn process_create_token_governance(
         governed_account: *governed_token_info.key,
         config,
         proposals_count: 0,
-        reserved: [0; 8],
+        reserved: [0; 6],
+        voting_proposal_count: 0,
     };
 
     create_and_serialize_account_signed::<Governance>(

--- a/governance/program/src/processor/process_deposit_governing_tokens.rs
+++ b/governance/program/src/processor/process_deposit_governing_tokens.rs
@@ -41,8 +41,7 @@ pub fn process_deposit_governing_tokens(
     let system_info = next_account_info(account_info_iter)?; // 7
     let spl_token_info = next_account_info(account_info_iter)?; // 8
 
-    let rent_sysvar_info = next_account_info(account_info_iter)?; // 9
-    let rent = &Rent::from_account_info(rent_sysvar_info)?;
+    let rent = Rent::get()?;
 
     let realm_data = get_realm_data(program_id, realm_info)?;
     let governing_token_mint = get_spl_token_mint(governing_token_holding_info)?;
@@ -100,7 +99,7 @@ pub fn process_deposit_governing_tokens(
             &token_owner_record_address_seeds,
             program_id,
             system_info,
-            rent,
+            &rent,
         )?;
     } else {
         let mut token_owner_record_data = get_token_owner_record_data_for_seeds(

--- a/governance/program/src/processor/process_execute_transaction.rs
+++ b/governance/program/src/processor/process_execute_transaction.rs
@@ -26,8 +26,7 @@ pub fn process_execute_transaction(program_id: &Pubkey, accounts: &[AccountInfo]
     let proposal_info = next_account_info(account_info_iter)?; // 1
     let proposal_transaction_info = next_account_info(account_info_iter)?; // 2
 
-    let clock_info = next_account_info(account_info_iter)?; // 3
-    let clock = Clock::from_account_info(clock_info)?;
+    let clock = Clock::get()?;
 
     let governance_data = get_governance_data(program_id, governance_info)?;
 

--- a/governance/program/src/processor/process_finalize_vote.rs
+++ b/governance/program/src/processor/process_finalize_vote.rs
@@ -30,12 +30,12 @@ pub fn process_finalize_vote(program_id: &Pubkey, accounts: &[AccountInfo]) -> P
 
     let clock = Clock::get()?;
 
-    let realm_data = get_realm_data_for_governing_token_mint(
+    let mut realm_data = get_realm_data_for_governing_token_mint(
         program_id,
         realm_info,
         governing_token_mint_info.key,
     )?;
-    let governance_data =
+    let mut governance_data =
         get_governance_data_for_realm(program_id, governance_info, realm_info.key)?;
 
     let mut proposal_data = get_proposal_data_for_governance_and_governing_mint(
@@ -72,6 +72,17 @@ pub fn process_finalize_vote(program_id: &Pubkey, accounts: &[AccountInfo]) -> P
     proposal_owner_record_data.serialize(&mut *proposal_owner_record_info.data.borrow_mut())?;
 
     proposal_data.serialize(&mut *proposal_info.data.borrow_mut())?;
+
+    // Update Realm voting_proposal_count
+    realm_data.voting_proposal_count = realm_data.voting_proposal_count.checked_sub(1).unwrap();
+    realm_data.serialize(&mut *realm_info.data.borrow_mut())?;
+
+    // Update  Governance voting_proposal_count
+    governance_data.voting_proposal_count = governance_data
+        .voting_proposal_count
+        .checked_sub(1)
+        .unwrap();
+    governance_data.serialize(&mut *governance_info.data.borrow_mut())?;
 
     Ok(())
 }

--- a/governance/program/src/processor/process_finalize_vote.rs
+++ b/governance/program/src/processor/process_finalize_vote.rs
@@ -28,8 +28,7 @@ pub fn process_finalize_vote(program_id: &Pubkey, accounts: &[AccountInfo]) -> P
 
     let governing_token_mint_info = next_account_info(account_info_iter)?; // 4
 
-    let clock_info = next_account_info(account_info_iter)?; // 5
-    let clock = Clock::from_account_info(clock_info)?;
+    let clock = Clock::get()?;
 
     let realm_data = get_realm_data_for_governing_token_mint(
         program_id,
@@ -46,13 +45,13 @@ pub fn process_finalize_vote(program_id: &Pubkey, accounts: &[AccountInfo]) -> P
         governing_token_mint_info.key,
     )?;
 
-    let realm_config_info = next_account_info(account_info_iter)?; // 6
+    let realm_config_info = next_account_info(account_info_iter)?; // 5
 
     let max_voter_weight = proposal_data.resolve_max_voter_weight(
         program_id,
         realm_config_info,
         governing_token_mint_info,
-        account_info_iter, // *7
+        account_info_iter, // *6
         realm_info.key,
         &realm_data,
     )?;

--- a/governance/program/src/processor/process_flag_transaction_error.rs
+++ b/governance/program/src/processor/process_flag_transaction_error.rs
@@ -28,8 +28,7 @@ pub fn process_flag_transaction_error(
 
     let proposal_transaction_info = next_account_info(account_info_iter)?; // 3
 
-    let clock_info = next_account_info(account_info_iter)?; // 4
-    let clock = Clock::from_account_info(clock_info)?;
+    let clock = Clock::get()?;
 
     let mut proposal_data = get_proposal_data(program_id, proposal_info)?;
 

--- a/governance/program/src/processor/process_set_governance_config.rs
+++ b/governance/program/src/processor/process_set_governance_config.rs
@@ -25,11 +25,21 @@ pub fn process_set_governance_config(
     // Only governance PDA via a proposal can authorize change to its own config
     if !governance_info.is_signer {
         return Err(GovernanceError::GovernancePdaMustSign.into());
-    }
+    };
 
     assert_is_valid_governance_config(&config)?;
 
     let mut governance_data = get_governance_data(program_id, governance_info)?;
+
+    // Until we have Veto implemented it's better to allow config change as the defence of last resort against governance attacks
+    // Note: Config change leaves voting proposals in unpredictable state and it's DAOs responsibility
+    // to ensure the changes are made when there are no proposals in voting state
+    // For example changing approval quorum could accidentally make proposals to succeed which would otherwise be defeated
+
+    // if governance_data.voting_proposal_count > 0 {
+    //     return Err(GovernanceError::GovernanceConfigChangeNotAllowed.into());
+    // }
+
     governance_data.config = config;
 
     governance_data.serialize(&mut *governance_info.data.borrow_mut())?;

--- a/governance/program/src/processor/process_set_realm_config.rs
+++ b/governance/program/src/processor/process_set_realm_config.rs
@@ -39,6 +39,15 @@ pub fn process_set_realm_config(
         return Err(GovernanceError::RealmAuthorityMustSign.into());
     }
 
+    // Until we have Veto implemented it's better to allow config change as the defence of last resort against governance attacks
+    // Note: Config change leaves voting proposals in unpredictable state and it's DAOs responsibility
+    // to ensure the changes are made when there are no proposals in voting state
+    // For example changing voter-weight or max-voter-weight addin could accidentally make proposals to succeed which would otherwise be defeated
+
+    // if realm_data.voting_proposal_count > 0 {
+    //     return Err(GovernanceError::RealmConfigChangeNotAllowed.into());
+    // }
+
     assert_valid_realm_config_args(&realm_config_args)?;
 
     // Setup council

--- a/governance/program/src/processor/process_sign_off_proposal.rs
+++ b/governance/program/src/processor/process_sign_off_proposal.rs
@@ -10,7 +10,8 @@ use solana_program::{
 };
 
 use crate::state::{
-    enums::ProposalState, proposal::get_proposal_data,
+    enums::ProposalState, governance::get_governance_data_for_realm,
+    proposal::get_proposal_data_for_governance, realm::get_realm_data,
     signatory_record::get_signatory_record_data_for_seeds,
     token_owner_record::get_token_owner_record_data_for_proposal_owner,
 };
@@ -19,16 +20,23 @@ use crate::state::{
 pub fn process_sign_off_proposal(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
 
-    let _realm_info = next_account_info(account_info_iter)?; // 0
-    let proposal_info = next_account_info(account_info_iter)?; // 1
+    let realm_info = next_account_info(account_info_iter)?; // 0
+    let governance_info = next_account_info(account_info_iter)?; // 1
+    let proposal_info = next_account_info(account_info_iter)?; // 2
 
-    let signatory_record_info = next_account_info(account_info_iter)?; // 2
-    let signatory_info = next_account_info(account_info_iter)?; // 3
+    let signatory_record_info = next_account_info(account_info_iter)?; // 3
+    let signatory_info = next_account_info(account_info_iter)?; // 4
 
-    let clock_info = next_account_info(account_info_iter)?; // 4
-    let clock = Clock::from_account_info(clock_info)?;
+    let clock = Clock::get()?;
 
-    let mut proposal_data = get_proposal_data(program_id, proposal_info)?;
+    let mut realm_data = get_realm_data(program_id, realm_info)?;
+
+    let mut governance_data =
+        get_governance_data_for_realm(program_id, governance_info, realm_info.key)?;
+
+    let mut proposal_data =
+        get_proposal_data_for_governance(program_id, proposal_info, governance_info.key)?;
+
     proposal_data.assert_can_sign_off()?;
 
     // If the owner of the proposal hasn't appointed any signatories then can sign off the proposal themself
@@ -77,6 +85,15 @@ pub fn process_sign_off_proposal(program_id: &Pubkey, accounts: &[AccountInfo]) 
     }
 
     proposal_data.serialize(&mut *proposal_info.data.borrow_mut())?;
+
+    realm_data.voting_proposal_count = realm_data.voting_proposal_count.checked_add(1).unwrap();
+    realm_data.serialize(&mut *realm_info.data.borrow_mut())?;
+
+    governance_data.voting_proposal_count = governance_data
+        .voting_proposal_count
+        .checked_add(1)
+        .unwrap();
+    governance_data.serialize(&mut *governance_info.data.borrow_mut())?;
 
     Ok(())
 }

--- a/governance/program/src/processor/process_sign_off_proposal.rs
+++ b/governance/program/src/processor/process_sign_off_proposal.rs
@@ -24,8 +24,7 @@ pub fn process_sign_off_proposal(program_id: &Pubkey, accounts: &[AccountInfo]) 
     let governance_info = next_account_info(account_info_iter)?; // 1
     let proposal_info = next_account_info(account_info_iter)?; // 2
 
-    let signatory_record_info = next_account_info(account_info_iter)?; // 3
-    let signatory_info = next_account_info(account_info_iter)?; // 4
+    let signatory_info = next_account_info(account_info_iter)?; // 3
 
     let clock = Clock::get()?;
 
@@ -41,7 +40,7 @@ pub fn process_sign_off_proposal(program_id: &Pubkey, accounts: &[AccountInfo]) 
 
     // If the owner of the proposal hasn't appointed any signatories then can sign off the proposal themself
     if proposal_data.signatories_count == 0 {
-        let proposal_owner_record_info = next_account_info(account_info_iter)?; // 5
+        let proposal_owner_record_info = next_account_info(account_info_iter)?; // 4
 
         let proposal_owner_record_data = get_token_owner_record_data_for_proposal_owner(
             program_id,
@@ -54,6 +53,8 @@ pub fn process_sign_off_proposal(program_id: &Pubkey, accounts: &[AccountInfo]) 
 
         proposal_data.signing_off_at = Some(clock.unix_timestamp);
     } else {
+        let signatory_record_info = next_account_info(account_info_iter)?; // 4
+
         let mut signatory_record_data = get_signatory_record_data_for_seeds(
             program_id,
             signatory_record_info,

--- a/governance/program/src/processor/process_sign_off_proposal.rs
+++ b/governance/program/src/processor/process_sign_off_proposal.rs
@@ -19,12 +19,13 @@ use crate::state::{
 pub fn process_sign_off_proposal(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
 
-    let proposal_info = next_account_info(account_info_iter)?; // 0
+    let _realm_info = next_account_info(account_info_iter)?; // 0
+    let proposal_info = next_account_info(account_info_iter)?; // 1
 
-    let signatory_record_info = next_account_info(account_info_iter)?; // 1
-    let signatory_info = next_account_info(account_info_iter)?; // 2
+    let signatory_record_info = next_account_info(account_info_iter)?; // 2
+    let signatory_info = next_account_info(account_info_iter)?; // 3
 
-    let clock_info = next_account_info(account_info_iter)?; // 3
+    let clock_info = next_account_info(account_info_iter)?; // 4
     let clock = Clock::from_account_info(clock_info)?;
 
     let mut proposal_data = get_proposal_data(program_id, proposal_info)?;
@@ -32,7 +33,7 @@ pub fn process_sign_off_proposal(program_id: &Pubkey, accounts: &[AccountInfo]) 
 
     // If the owner of the proposal hasn't appointed any signatories then can sign off the proposal themself
     if proposal_data.signatories_count == 0 {
-        let proposal_owner_record_info = next_account_info(account_info_iter)?; // 4
+        let proposal_owner_record_info = next_account_info(account_info_iter)?; // 5
 
         let proposal_owner_record_data = get_token_owner_record_data_for_proposal_owner(
             program_id,

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -74,7 +74,10 @@ pub struct Governance {
     pub config: GovernanceConfig,
 
     /// Reserved space for future versions
-    pub reserved: [u8; 8],
+    pub reserved: [u8; 6],
+
+    /// The number of proposals in voting state in the Governance
+    pub voting_proposal_count: u16,
 }
 
 impl AccountMaxSize for Governance {}

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -1087,7 +1087,7 @@ mod test {
         Realm {
             account_type: GovernanceAccountType::Realm,
             community_mint: Pubkey::new_unique(),
-            reserved: [0; 8],
+            reserved: [0; 6],
 
             authority: Some(Pubkey::new_unique()),
             name: "test-realm".to_string(),
@@ -1101,6 +1101,7 @@ mod test {
                     MintMaxVoteWeightSource::FULL_SUPPLY_FRACTION,
                 min_community_tokens_to_create_governance: 10,
             },
+            voting_proposal_count: 0,
         }
     }
 

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -176,7 +176,7 @@ impl Realm {
     }
 
     /// Assert the given create authority can create governance
-    pub fn assert_can_create_governance(
+    pub fn assert_create_authority_can_create_governance(
         &self,
         program_id: &Pubkey,
         realm: &Pubkey,

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -98,7 +98,10 @@ pub struct Realm {
     pub config: RealmConfig,
 
     /// Reserved space for future versions
-    pub reserved: [u8; 8],
+    pub reserved: [u8; 6],
+
+    /// The number of proposals in voting state in the Realm
+    pub voting_proposal_count: u16,
 
     /// Realm authority. The authority must sign transactions which update the realm config
     /// The authority should be transferred to Realm Governance to make the Realm self governed through proposals
@@ -329,7 +332,7 @@ mod test {
         let realm = Realm {
             account_type: GovernanceAccountType::Realm,
             community_mint: Pubkey::new_unique(),
-            reserved: [0; 8],
+            reserved: [0; 6],
 
             authority: Some(Pubkey::new_unique()),
             name: "test-realm".to_string(),
@@ -341,6 +344,8 @@ mod test {
                 community_mint_max_vote_weight_source: MintMaxVoteWeightSource::Absolute(100),
                 min_community_tokens_to_create_governance: 10,
             },
+
+            voting_proposal_count: 0,
         };
 
         let size = realm.try_to_vec().unwrap().len();

--- a/governance/program/tests/process_cancel_proposal.rs
+++ b/governance/program/tests/process_cancel_proposal.rs
@@ -55,6 +55,18 @@ async fn test_cancel_proposal() {
         .await;
 
     assert_eq!(0, token_owner_record_account.outstanding_proposal_count);
+
+    let realm_account = governance_test
+        .get_realm_account(&realm_cookie.address)
+        .await;
+
+    assert_eq!(0, realm_account.voting_proposal_count);
+
+    let governance_account = governance_test
+        .get_governance_account(&governance_cookie.address)
+        .await;
+
+    assert_eq!(0, governance_account.voting_proposal_count);
 }
 
 #[tokio::test]
@@ -245,4 +257,16 @@ async fn test_cancel_proposal_in_voting_state() {
         .await;
 
     assert_eq!(ProposalState::Cancelled, proposal_account.state);
+
+    let realm_account = governance_test
+        .get_realm_account(&realm_cookie.address)
+        .await;
+
+    assert_eq!(0, realm_account.voting_proposal_count);
+
+    let governance_account = governance_test
+        .get_governance_account(&governance_cookie.address)
+        .await;
+
+    assert_eq!(0, governance_account.voting_proposal_count);
 }

--- a/governance/program/tests/process_cast_vote.rs
+++ b/governance/program/tests/process_cast_vote.rs
@@ -82,6 +82,18 @@ async fn test_cast_vote() {
 
     assert_eq!(1, token_owner_record.unrelinquished_votes_count);
     assert_eq!(1, token_owner_record.total_votes_count);
+
+    let realm_account = governance_test
+        .get_realm_account(&realm_cookie.address)
+        .await;
+
+    assert_eq!(0, realm_account.voting_proposal_count);
+
+    let governance_account = governance_test
+        .get_governance_account(&governance_cookie.address)
+        .await;
+
+    assert_eq!(0, governance_account.voting_proposal_count);
 }
 
 #[tokio::test]
@@ -415,6 +427,18 @@ async fn test_cast_vote_with_strict_vote_tipped_to_succeeded() {
         .await;
 
     assert_eq!(0, proposal_owner_record.outstanding_proposal_count);
+
+    let realm_account = governance_test
+        .get_realm_account(&realm_cookie.address)
+        .await;
+
+    assert_eq!(0, realm_account.voting_proposal_count);
+
+    let governance_account = governance_test
+        .get_governance_account(&governance_cookie.address)
+        .await;
+
+    assert_eq!(0, governance_account.voting_proposal_count);
 }
 
 #[tokio::test]
@@ -839,6 +863,18 @@ async fn test_cast_vote_with_threshold_below_50_and_vote_not_tipped() {
         .await;
 
     assert_eq!(1, proposal_owner_record.outstanding_proposal_count);
+
+    let realm_account = governance_test
+        .get_realm_account(&realm_cookie.address)
+        .await;
+
+    assert_eq!(1, realm_account.voting_proposal_count);
+
+    let governance_account = governance_test
+        .get_governance_account(&governance_cookie.address)
+        .await;
+
+    assert_eq!(1, governance_account.voting_proposal_count);
 }
 
 #[tokio::test]

--- a/governance/program/tests/process_finalize_vote.rs
+++ b/governance/program/tests/process_finalize_vote.rs
@@ -100,6 +100,18 @@ async fn test_finalize_vote_to_succeeded() {
         .await;
 
     assert_eq!(0, proposal_owner_record.outstanding_proposal_count);
+
+    let realm_account = governance_test
+        .get_realm_account(&realm_cookie.address)
+        .await;
+
+    assert_eq!(0, realm_account.voting_proposal_count);
+
+    let governance_account = governance_test
+        .get_governance_account(&governance_cookie.address)
+        .await;
+
+    assert_eq!(0, governance_account.voting_proposal_count);
 }
 
 #[tokio::test]

--- a/governance/program/tests/process_sign_off_proposal.rs
+++ b/governance/program/tests/process_sign_off_proposal.rs
@@ -116,7 +116,7 @@ async fn test_sign_off_proposal_with_signatory_must_sign_error() {
         .sign_off_proposal_using_instruction(
             &proposal_cookie,
             &signatory_record_cookie,
-            |i| i.accounts[4].is_signer = false, // signatory
+            |i| i.accounts[3].is_signer = false, // signatory
             Some(&[]),
         )
         .await
@@ -208,7 +208,7 @@ async fn test_sign_off_proposal_by_owner_with_owner_must_sign_error() {
         .sign_off_proposal_by_owner_using_instruction(
             &proposal_cookie,
             &token_owner_record_cookie,
-            |i| i.accounts[4].is_signer = false, // signatory
+            |i| i.accounts[3].is_signer = false, // signatory
             Some(&[]),
         )
         .await
@@ -308,6 +308,5 @@ async fn test_sign_off_proposal_by_owner_with_existing_signatories_error() {
 
     // Assert
 
-    // The instruction fails with AccountDoesNotExist because SignatoryRecord doesn't exist for owner
-    assert_eq!(err, GovernanceToolsError::AccountDoesNotExist.into());
+    assert_eq!(err, GovernanceError::InvalidSignatoryAddress.into());
 }

--- a/governance/program/tests/process_sign_off_proposal.rs
+++ b/governance/program/tests/process_sign_off_proposal.rs
@@ -104,7 +104,7 @@ async fn test_sign_off_proposal_with_signatory_must_sign_error() {
         .sign_off_proposal_using_instruction(
             &proposal_cookie,
             &signatory_record_cookie,
-            |i| i.accounts[2].is_signer = false, // signatory
+            |i| i.accounts[3].is_signer = false, // signatory
             Some(&[]),
         )
         .await
@@ -196,7 +196,7 @@ async fn test_sign_off_proposal_by_owner_with_owner_must_sign_error() {
         .sign_off_proposal_by_owner_using_instruction(
             &proposal_cookie,
             &token_owner_record_cookie,
-            |i| i.accounts[2].is_signer = false, // signatory
+            |i| i.accounts[3].is_signer = false, // signatory
             Some(&[]),
         )
         .await

--- a/governance/program/tests/process_sign_off_proposal.rs
+++ b/governance/program/tests/process_sign_off_proposal.rs
@@ -6,7 +6,6 @@ use solana_program_test::tokio;
 
 use program_test::*;
 use spl_governance::{error::GovernanceError, state::enums::ProposalState};
-use spl_governance_tools::error::GovernanceToolsError;
 
 #[tokio::test]
 async fn test_sign_off_proposal() {

--- a/governance/program/tests/process_sign_off_proposal.rs
+++ b/governance/program/tests/process_sign_off_proposal.rs
@@ -65,6 +65,18 @@ async fn test_sign_off_proposal() {
         .await;
 
     assert_eq!(true, signatory_record_account.signed_off);
+
+    let realm_account = governance_test
+        .get_realm_account(&realm_cookie.address)
+        .await;
+
+    assert_eq!(1, realm_account.voting_proposal_count);
+
+    let governance_account = governance_test
+        .get_governance_account(&governance_cookie.address)
+        .await;
+
+    assert_eq!(1, governance_account.voting_proposal_count);
 }
 
 #[tokio::test]
@@ -104,7 +116,7 @@ async fn test_sign_off_proposal_with_signatory_must_sign_error() {
         .sign_off_proposal_using_instruction(
             &proposal_cookie,
             &signatory_record_cookie,
-            |i| i.accounts[3].is_signer = false, // signatory
+            |i| i.accounts[4].is_signer = false, // signatory
             Some(&[]),
         )
         .await
@@ -196,7 +208,7 @@ async fn test_sign_off_proposal_by_owner_with_owner_must_sign_error() {
         .sign_off_proposal_by_owner_using_instruction(
             &proposal_cookie,
             &token_owner_record_cookie,
-            |i| i.accounts[3].is_signer = false, // signatory
+            |i| i.accounts[4].is_signer = false, // signatory
             Some(&[]),
         )
         .await

--- a/governance/program/tests/program_test/cookies.rs
+++ b/governance/program/tests/program_test/cookies.rs
@@ -140,6 +140,7 @@ pub struct ProposalCookie {
     pub address: Pubkey,
     pub account: ProposalV2,
 
+    pub realm: Pubkey,
     pub proposal_owner: Pubkey,
 }
 

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1242,7 +1242,8 @@ impl GovernanceProgramTest {
             governed_account: governed_account_cookie.address,
             config: governance_config.clone(),
             proposals_count: 0,
-            reserved: [0; 8],
+            reserved: [0; 6],
+            voting_proposal_count: 0,
         };
 
         let default_signers = &[create_authority];
@@ -1409,7 +1410,8 @@ impl GovernanceProgramTest {
             governed_account: governed_program_cookie.address,
             config,
             proposals_count: 0,
-            reserved: [0; 8],
+            reserved: [0; 6],
+            voting_proposal_count: 0,
         };
 
         let program_governance_address = get_program_governance_address(
@@ -1531,7 +1533,8 @@ impl GovernanceProgramTest {
             governed_account: governed_mint_cookie.address,
             config: governance_config.clone(),
             proposals_count: 0,
-            reserved: [0; 8],
+            reserved: [0; 6],
+            voting_proposal_count: 0,
         };
 
         let mint_governance_address = get_mint_governance_address(
@@ -1613,7 +1616,8 @@ impl GovernanceProgramTest {
             governed_account: governed_token_cookie.address,
             config,
             proposals_count: 0,
-            reserved: [0; 8],
+            reserved: [0; 6],
+            voting_proposal_count: 0,
         };
 
         let token_governance_address = get_token_governance_address(
@@ -1920,6 +1924,7 @@ impl GovernanceProgramTest {
         let mut sign_off_proposal_ix = sign_off_proposal(
             &self.program_id,
             &proposal_cookie.realm,
+            &proposal_cookie.account.governance,
             &proposal_cookie.address,
             &token_owner_record_cookie.account.governing_token_owner,
             Some(&token_owner_record_cookie.address),
@@ -1963,6 +1968,7 @@ impl GovernanceProgramTest {
         let mut sign_off_proposal_ix = sign_off_proposal(
             &self.program_id,
             &proposal_cookie.realm,
+            &proposal_cookie.account.governance,
             &proposal_cookie.address,
             &signatory_record_cookie.signatory.pubkey(),
             None,

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -2063,10 +2063,11 @@ impl GovernanceProgramTest {
     ) -> Result<(), ProgramError> {
         let cancel_proposal_transaction = cancel_proposal(
             &self.program_id,
+            &proposal_cookie.realm,
+            &proposal_cookie.account.governance,
             &proposal_cookie.address,
             &token_owner_record_cookie.address,
             &token_owner_record_cookie.token_owner.pubkey(),
-            &proposal_cookie.account.governance,
         );
 
         self.bench

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -303,7 +303,7 @@ impl GovernanceProgramTest {
             community_mint: community_token_mint_keypair.pubkey(),
 
             name,
-            reserved: [0; 8],
+            reserved: [0; 6],
             authority: Some(realm_authority.pubkey()),
             config: RealmConfig {
                 council_mint: council_token_mint_pubkey,
@@ -319,6 +319,7 @@ impl GovernanceProgramTest {
                 use_community_voter_weight_addin: false,
                 use_max_community_voter_weight_addin: false,
             },
+            voting_proposal_count: 0,
         };
 
         let realm_config_cookie = if set_realm_config_args.community_voter_weight_addin.is_some()
@@ -394,7 +395,7 @@ impl GovernanceProgramTest {
             community_mint: realm_cookie.account.community_mint,
 
             name,
-            reserved: [0; 8],
+            reserved: [0; 6],
             authority: Some(realm_authority.pubkey()),
             config: RealmConfig {
                 council_mint: Some(council_mint),
@@ -406,6 +407,7 @@ impl GovernanceProgramTest {
                 use_community_voter_weight_addin: false,
                 use_max_community_voter_weight_addin: false,
             },
+            voting_proposal_count: 0,
         };
 
         let community_token_holding_address = get_governing_token_holding_address(
@@ -1817,6 +1819,7 @@ impl GovernanceProgramTest {
             address: proposal_address,
             account,
             proposal_owner: governance_authority.pubkey(),
+            realm: governance_cookie.account.realm,
         })
     }
 
@@ -1916,6 +1919,7 @@ impl GovernanceProgramTest {
     ) -> Result<(), ProgramError> {
         let mut sign_off_proposal_ix = sign_off_proposal(
             &self.program_id,
+            &proposal_cookie.realm,
             &proposal_cookie.address,
             &token_owner_record_cookie.account.governing_token_owner,
             Some(&token_owner_record_cookie.address),
@@ -1958,6 +1962,7 @@ impl GovernanceProgramTest {
     ) -> Result<(), ProgramError> {
         let mut sign_off_proposal_ix = sign_off_proposal(
             &self.program_id,
+            &proposal_cookie.realm,
             &proposal_cookie.address,
             &signatory_record_cookie.signatory.pubkey(),
             None,

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1250,7 +1250,7 @@ impl GovernanceProgramTest {
         let signers = signers_override.unwrap_or(default_signers);
 
         if signers.len() == 0 {
-            create_governance_ix.accounts[7].is_signer = false;
+            create_governance_ix.accounts[6].is_signer = false;
         }
 
         self.bench

--- a/governance/tools/src/error.rs
+++ b/governance/tools/src/error.rs
@@ -17,7 +17,7 @@ pub enum GovernanceToolsError {
 
     /// Account doesn't exist
     #[error("Account doesn't exist")]
-    AccountDoesNotExist,
+    AccountDoesNotExist, // 1101
 
     /// Invalid account owner
     #[error("Invalid account owner")]


### PR DESCRIPTION
#### Summary 

Track the number of proposals in voting state at the `Realm` and `Governance` level to make it impossible to change `RealmConfig` and `GovernanceConfig`  while there are proposals in voting state for them. 

It's also helps with UI performance to have the number of proposals in voting state at these level already calculated.

#### Implementation 

The check to prevent config changes are not enabled in the PR because they can work as the defence of last resort against governance attacks until we have `Veto` vote implemented.



