### PR TITLE
Governance: Use saturating sub to decrease voting proposal count

### DIFF
--- a/governance/program/src/processor/process_cancel_proposal.rs
+++ b/governance/program/src/processor/process_cancel_proposal.rs
@@ -50,14 +50,12 @@ pub fn process_cancel_proposal(program_id: &Pubkey, accounts: &[AccountInfo]) ->
 
     if proposal_data.state == ProposalState::Voting {
         // Update Realm voting_proposal_count
-        realm_data.voting_proposal_count = realm_data.voting_proposal_count.checked_sub(1).unwrap();
+        realm_data.voting_proposal_count = realm_data.voting_proposal_count.saturating_sub(1);
         realm_data.serialize(&mut *realm_info.data.borrow_mut())?;
 
         // Update  Governance voting_proposal_count
-        governance_data.voting_proposal_count = governance_data
-            .voting_proposal_count
-            .checked_sub(1)
-            .unwrap();
+        governance_data.voting_proposal_count =
+            governance_data.voting_proposal_count.saturating_sub(1);
         governance_data.serialize(&mut *governance_info.data.borrow_mut())?;
     }
 

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -167,14 +167,12 @@ pub fn process_cast_vote(
         };
 
         // Update Realm voting_proposal_count
-        realm_data.voting_proposal_count = realm_data.voting_proposal_count.checked_sub(1).unwrap();
+        realm_data.voting_proposal_count = realm_data.voting_proposal_count.saturating_sub(1);
         realm_data.serialize(&mut *realm_info.data.borrow_mut())?;
 
         // Update  Governance voting_proposal_count
-        governance_data.voting_proposal_count = governance_data
-            .voting_proposal_count
-            .checked_sub(1)
-            .unwrap();
+        governance_data.voting_proposal_count =
+            governance_data.voting_proposal_count.saturating_sub(1);
         governance_data.serialize(&mut *governance_info.data.borrow_mut())?;
     }
 

--- a/governance/program/src/processor/process_finalize_vote.rs
+++ b/governance/program/src/processor/process_finalize_vote.rs
@@ -74,14 +74,11 @@ pub fn process_finalize_vote(program_id: &Pubkey, accounts: &[AccountInfo]) -> P
     proposal_data.serialize(&mut *proposal_info.data.borrow_mut())?;
 
     // Update Realm voting_proposal_count
-    realm_data.voting_proposal_count = realm_data.voting_proposal_count.checked_sub(1).unwrap();
+    realm_data.voting_proposal_count = realm_data.voting_proposal_count.saturating_sub(1);
     realm_data.serialize(&mut *realm_info.data.borrow_mut())?;
 
     // Update  Governance voting_proposal_count
-    governance_data.voting_proposal_count = governance_data
-        .voting_proposal_count
-        .checked_sub(1)
-        .unwrap();
+    governance_data.voting_proposal_count = governance_data.voting_proposal_count.saturating_sub(1);
     governance_data.serialize(&mut *governance_info.data.borrow_mut())?;
 
     Ok(())

--- a/governance/program/src/processor/process_set_governance_config.rs
+++ b/governance/program/src/processor/process_set_governance_config.rs
@@ -35,6 +35,7 @@ pub fn process_set_governance_config(
     // Note: Config change leaves voting proposals in unpredictable state and it's DAOs responsibility
     // to ensure the changes are made when there are no proposals in voting state
     // For example changing approval quorum could accidentally make proposals to succeed which would otherwise be defeated
+    // The check wouldn't have any effect when upgrading from V1 to V2 because it was not tracked in V1
 
     // if governance_data.voting_proposal_count > 0 {
     //     return Err(GovernanceError::GovernanceConfigChangeNotAllowed.into());

--- a/governance/program/src/processor/process_set_realm_config.rs
+++ b/governance/program/src/processor/process_set_realm_config.rs
@@ -43,6 +43,7 @@ pub fn process_set_realm_config(
     // Note: Config change leaves voting proposals in unpredictable state and it's DAOs responsibility
     // to ensure the changes are made when there are no proposals in voting state
     // For example changing voter-weight or max-voter-weight addin could accidentally make proposals to succeed which would otherwise be defeated
+    // The check wouldn't have any effect when upgrading from V1 to V2 because it was not tracked in V1
 
     // if realm_data.voting_proposal_count > 0 {
     //     return Err(GovernanceError::RealmConfigChangeNotAllowed.into());


### PR DESCRIPTION
#### Summary

After upgrading to `v2` existing realms won't have `voting_proposal_count` and hence transition to completed state would result in underflow

#### Implementation 

Use `saturating_sub` instead of `checked_sub`

