### PR TITLE
Governance: Limit proposal options to 10

### DIFF
--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -232,7 +232,7 @@ pub enum GovernanceInstruction {
     InsertTransaction {
         #[allow(dead_code)]
         /// The index of the option the transaction is for
-        option_index: u16,
+        option_index: u8,
         #[allow(dead_code)]
         /// Transaction index to be inserted at.
         index: u16,
@@ -1168,7 +1168,7 @@ pub fn insert_transaction(
     governance_authority: &Pubkey,
     payer: &Pubkey,
     // Args
-    option_index: u16,
+    option_index: u8,
     index: u16,
     hold_up_time: u32,
     instructions: Vec<InstructionData>,

--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -151,7 +151,7 @@ pub fn process_create_proposal(
         max_voting_time: None,
         vote_threshold_percentage: None,
 
-        reserved: [0; 8],
+        reserved: [0; 64],
     };
 
     create_and_serialize_account_signed::<ProposalV2>(

--- a/governance/program/src/processor/process_insert_transaction.rs
+++ b/governance/program/src/processor/process_insert_transaction.rs
@@ -28,7 +28,7 @@ use crate::{
 pub fn process_insert_transaction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
-    option_index: u16,
+    option_index: u8,
     instruction_index: u16,
     hold_up_time: u32,
     instructions: Vec<InstructionData>,

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -193,7 +193,7 @@ pub struct ProposalV2 {
     pub vote_threshold_percentage: Option<VoteThresholdPercentage>,
 
     /// Reserved space for future versions
-    pub reserved: [u8; 8],
+    pub reserved: [u8; 64],
 
     /// Proposal name
     pub name: String,
@@ -205,7 +205,7 @@ pub struct ProposalV2 {
 impl AccountMaxSize for ProposalV2 {
     fn get_max_size(&self) -> Option<usize> {
         let options_size: usize = self.options.iter().map(|o| o.label.len() + 19).sum();
-        Some(self.name.len() + self.description_link.len() + options_size + 239)
+        Some(self.name.len() + self.description_link.len() + options_size + 295)
     }
 }
 
@@ -897,7 +897,7 @@ pub fn get_proposal_data(
             vote_threshold_percentage: proposal_data_v1.vote_threshold_percentage,
             name: proposal_data_v1.name,
             description_link: proposal_data_v1.description_link,
-            reserved: [0; 8],
+            reserved: [0; 64],
         });
     }
 
@@ -1051,7 +1051,7 @@ mod test {
             max_voting_time: Some(0),
             vote_threshold_percentage: Some(VoteThresholdPercentage::YesVote(100)),
 
-            reserved: [0; 8],
+            reserved: [0; 64],
         }
     }
 

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -90,14 +90,14 @@ pub enum VoteType {
         /// By default it equals to the number of available options
         /// Note: In the current version the limit is not supported and not enforced yet
         #[allow(dead_code)]
-        max_voter_options: u16,
+        max_voter_options: u8,
 
         /// The max number of wining options
         /// For executable proposals it limits how many options can be executed for a Proposal
         /// By default it equals to the number of available options
         /// Note: In the current version the limit is not supported and not enforced yet
         #[allow(dead_code)]
-        max_winning_options: u16,
+        max_winning_options: u8,
     },
 }
 
@@ -205,7 +205,7 @@ pub struct ProposalV2 {
 impl AccountMaxSize for ProposalV2 {
     fn get_max_size(&self) -> Option<usize> {
         let options_size: usize = self.options.iter().map(|o| o.label.len() + 19).sum();
-        Some(self.name.len() + self.description_link.len() + options_size + 241)
+        Some(self.name.len() + self.description_link.len() + options_size + 239)
     }
 }
 
@@ -968,7 +968,7 @@ pub fn assert_valid_proposal_options(
     options: &[String],
     vote_type: &VoteType,
 ) -> Result<(), ProgramError> {
-    if options.is_empty() {
+    if options.is_empty() || options.len() > 10 {
         return Err(GovernanceError::InvalidProposalOptions.into());
     }
 

--- a/governance/program/src/state/proposal_transaction.rs
+++ b/governance/program/src/state/proposal_transaction.rs
@@ -95,7 +95,7 @@ pub struct ProposalTransactionV2 {
     pub proposal: Pubkey,
 
     /// The option index the instruction belongs to
-    pub option_index: u16,
+    pub option_index: u8,
 
     /// Unique transaction index within it's parent Proposal
     pub transaction_index: u16,
@@ -125,7 +125,7 @@ impl AccountMaxSize for ProposalTransactionV2 {
             .sum::<usize>()
             + 4;
 
-        Some(instructions_size + 91)
+        Some(instructions_size + 90)
     }
 }
 
@@ -166,7 +166,7 @@ impl ProposalTransactionV2 {
 /// Returns ProposalTransaction PDA seeds
 pub fn get_proposal_transaction_address_seeds<'a>(
     proposal: &'a Pubkey,
-    option_index: &'a [u8; 2],               // u16 le bytes
+    option_index: &'a [u8; 1],               // u8 le bytes
     instruction_index_le_bytes: &'a [u8; 2], // u16 le bytes
 ) -> [&'a [u8]; 4] {
     [
@@ -181,7 +181,7 @@ pub fn get_proposal_transaction_address_seeds<'a>(
 pub fn get_proposal_transaction_address<'a>(
     program_id: &Pubkey,
     proposal: &'a Pubkey,
-    option_index_le_bytes: &'a [u8; 2],      // u16 le bytes
+    option_index_le_bytes: &'a [u8; 1],      // u8 le bytes
     instruction_index_le_bytes: &'a [u8; 2], // u16 le bytes
 ) -> Pubkey {
     Pubkey::find_program_address(

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1809,7 +1809,7 @@ impl GovernanceProgramTest {
             max_voting_time: None,
             vote_threshold_percentage: None,
 
-            reserved: [0; 8],
+            reserved: [0; 64],
         };
 
         let proposal_address = get_proposal_address(

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -2197,7 +2197,7 @@ impl GovernanceProgramTest {
         governed_mint_cookie: &GovernedMintCookie,
         proposal_cookie: &mut ProposalCookie,
         token_owner_record_cookie: &TokenOwnerRecordCookie,
-        option_index: u16,
+        option_index: u8,
         index: Option<u16>,
     ) -> Result<ProposalTransactionCookie, ProgramError> {
         let token_account_keypair = Keypair::new();
@@ -2366,7 +2366,7 @@ impl GovernanceProgramTest {
         &mut self,
         proposal_cookie: &mut ProposalCookie,
         token_owner_record_cookie: &TokenOwnerRecordCookie,
-        option_index: u16,
+        option_index: u8,
         index: Option<u16>,
     ) -> Result<ProposalTransactionCookie, ProgramError> {
         // Create NOP instruction as a placeholder
@@ -2392,7 +2392,7 @@ impl GovernanceProgramTest {
         &mut self,
         proposal_cookie: &mut ProposalCookie,
         token_owner_record_cookie: &TokenOwnerRecordCookie,
-        option_index: u16,
+        option_index: u8,
         index: Option<u16>,
         instruction: &mut Instruction,
     ) -> Result<ProposalTransactionCookie, ProgramError> {


### PR DESCRIPTION
#### Summary 

- Limit proposal options to 10 to avoid exceeding computation limit
- Increase `Proposal` reserved space to 64 bytes. Even though the runtime would support changing account size in the future version it'll still be very difficult for Governance accounts if other programs read the accounts. 



