### PR TITLE
spl-token-cli: Bump to 2.0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3904,7 +3904,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-cli"
-version = "2.0.15"
+version = "2.0.16"
 dependencies = [
  "clap",
  "console 0.14.1",

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://spl.solana.com/token"
 license = "Apache-2.0"
 name = "spl-token-cli"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "2.0.15"
+version = "2.0.16"
 
 [dependencies]
 clap = "2.33.3"


### PR DESCRIPTION
In order to have recent changes on `spl-token-cli`, just a simple bump to `2.0.16` to permit an update on crates!