### PR TITLE
token-2022: Add freeze / thaw through StateWithExtensions

### DIFF
--- a/token/program-2022/tests/freeze.rs
+++ b/token/program-2022/tests/freeze.rs
@@ -1,0 +1,44 @@
+#![cfg(feature = "test-bpf")]
+
+mod program_test;
+use {
+    program_test::{TestContext, TokenContext},
+    solana_program_test::tokio,
+    solana_sdk::{signature::Signer, signer::keypair::Keypair},
+    spl_token_2022::state::AccountState,
+};
+
+#[tokio::test]
+async fn basic() {
+    let mut context = TestContext::new().await;
+    context.init_token_with_freezing_mint(vec![]).await.unwrap();
+    let TokenContext {
+        freeze_authority,
+        token,
+        alice,
+        ..
+    } = context.token_context.unwrap();
+    let freeze_authority = freeze_authority.unwrap();
+
+    let account = Keypair::new();
+    let account = token
+        .create_auxiliary_token_account(&account, &alice.pubkey())
+        .await
+        .unwrap();
+    let state = token.get_account_info(&account).await.unwrap();
+    assert_eq!(state.base.state, AccountState::Initialized);
+
+    token
+        .freeze_account(&account, &freeze_authority)
+        .await
+        .unwrap();
+    let state = token.get_account_info(&account).await.unwrap();
+    assert_eq!(state.base.state, AccountState::Frozen);
+
+    token
+        .thaw_account(&account, &freeze_authority)
+        .await
+        .unwrap();
+    let state = token.get_account_info(&account).await.unwrap();
+    assert_eq!(state.base.state, AccountState::Initialized);
+}

--- a/token/rust/src/token.rs
+++ b/token/rust/src/token.rs
@@ -481,6 +481,44 @@ where
         .await
     }
 
+    /// Freeze a token account
+    pub async fn freeze_account<S2: Signer>(
+        &self,
+        account: &Pubkey,
+        authority: &S2,
+    ) -> TokenResult<T::Output> {
+        self.process_ixs(
+            &[instruction::freeze_account(
+                &self.program_id,
+                account,
+                &self.pubkey,
+                &authority.pubkey(),
+                &[],
+            )?],
+            &[authority],
+        )
+        .await
+    }
+
+    /// Thaw / unfreeze a token account
+    pub async fn thaw_account<S2: Signer>(
+        &self,
+        account: &Pubkey,
+        authority: &S2,
+    ) -> TokenResult<T::Output> {
+        self.process_ixs(
+            &[instruction::thaw_account(
+                &self.program_id,
+                account,
+                &self.pubkey,
+                &authority.pubkey(),
+                &[],
+            )?],
+            &[authority],
+        )
+        .await
+    }
+
     /// Set transfer fee
     pub async fn set_transfer_fee<S2: Signer>(
         &self,
@@ -535,6 +573,27 @@ where
                 sources,
             )?],
             &[&self.payer],
+        )
+        .await
+    }
+
+    /// Withdraw withheld tokens from mint
+    pub async fn withdraw_withheld_tokens_from_mint<S2: Signer>(
+        &self,
+        destination: &Pubkey,
+        authority: &S2,
+    ) -> TokenResult<T::Output> {
+        self.process_ixs(
+            &[
+                transfer_fee::instruction::withdraw_withheld_tokens_from_mint(
+                    &self.program_id,
+                    &self.pubkey,
+                    destination,
+                    &authority.pubkey(),
+                    &[],
+                )?,
+            ],
+            &[authority],
         )
         .await
     }


### PR DESCRIPTION
#### Problem

Freeze / thaw still use `Account::unpack` and `Mint::unpack`, making them incompatible with extensions.

#### Solution

Use `StateWithExtensions{,Mut}` and add a very basic program-test for it.