### PR TITLE
token-2022: GetAccountDataSize instruction now accepts user-provided extension types

### DIFF
--- a/associated-token-account/program/src/tools/account.rs
+++ b/associated-token-account/program/src/tools/account.rs
@@ -78,7 +78,7 @@ pub fn get_account_len<'a>(
     spl_token_program: &AccountInfo<'a>,
 ) -> Result<usize, ProgramError> {
     invoke(
-        &spl_token::instruction::get_account_data_size(spl_token_program.key, mint.key)?,
+        &spl_token::instruction::get_account_data_size(spl_token_program.key, mint.key, vec![])?,
         &[mint.clone(), spl_token_program.clone()],
     )?;
     get_return_data()

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -958,11 +958,20 @@ impl Processor {
     }
 
     /// Processes a [GetAccountDataSize](enum.TokenInstruction.html) instruction
-    pub fn process_get_account_data_size(accounts: &[AccountInfo]) -> ProgramResult {
+    pub fn process_get_account_data_size(
+        accounts: &[AccountInfo],
+        extension_types: Vec<ExtensionType>,
+    ) -> ProgramResult {
         let account_info_iter = &mut accounts.iter();
         let mint_account_info = next_account_info(account_info_iter)?;
 
-        let account_extensions = Self::get_required_account_extensions(mint_account_info)?;
+        let mut account_extensions = Self::get_required_account_extensions(mint_account_info)?;
+
+        for extension_type in extension_types {
+            if !account_extensions.contains(&extension_type) {
+                account_extensions.push(extension_type);
+            }
+        }
 
         let account_len = ExtensionType::get_account_len::<Account>(&account_extensions);
         set_return_data(&account_len.to_le_bytes());
@@ -1071,9 +1080,9 @@ impl Processor {
                 msg!("Instruction: SyncNative");
                 Self::process_sync_native(accounts)
             }
-            TokenInstruction::GetAccountDataSize => {
+            TokenInstruction::GetAccountDataSize { extension_types } => {
                 msg!("Instruction: GetAccountDataSize");
-                Self::process_get_account_data_size(accounts)
+                Self::process_get_account_data_size(accounts, extension_types)
             }
             TokenInstruction::InitializeMintCloseAuthority { close_authority } => {
                 msg!("Instruction: InitializeMintCloseAuthority");
@@ -6721,7 +6730,26 @@ mod tests {
                 .to_vec(),
         );
         do_process_instruction(
-            get_account_data_size(&program_id, &mint_key).unwrap(),
+            get_account_data_size(&program_id, &mint_key, vec![]).unwrap(),
+            vec![&mut mint_account],
+        )
+        .unwrap();
+
+        set_expected_data(
+            ExtensionType::get_account_len::<Account>(&[ExtensionType::TransferFeeAmount])
+                .to_le_bytes()
+                .to_vec(),
+        );
+        do_process_instruction(
+            get_account_data_size(
+                &program_id,
+                &mint_key,
+                vec![
+                    ExtensionType::TransferFeeAmount,
+                    ExtensionType::TransferFeeAmount, // Duplicate user input ignored...
+                ],
+            )
+            .unwrap(),
             vec![&mut mint_account],
         )
         .unwrap();
@@ -6734,7 +6762,7 @@ mod tests {
                 .to_vec(),
         );
         do_process_instruction(
-            get_account_data_size(&program_id, &mint_key).unwrap(),
+            get_account_data_size(&program_id, &mint_key, vec![]).unwrap(),
             vec![&mut mint_account],
         )
         .unwrap();
@@ -6765,7 +6793,18 @@ mod tests {
                 .to_vec(),
         );
         do_process_instruction(
-            get_account_data_size(&program_id, &mint_key).unwrap(),
+            get_account_data_size(&program_id, &mint_key, vec![]).unwrap(),
+            vec![&mut extended_mint_account],
+        )
+        .unwrap();
+
+        do_process_instruction(
+            get_account_data_size(
+                &program_id,
+                &mint_key,
+                vec![ExtensionType::TransferFeeAmount], // User extension that's also added by the mint ignored...
+            )
+            .unwrap(),
             vec![&mut extended_mint_account],
         )
         .unwrap();
@@ -6790,7 +6829,7 @@ mod tests {
 
         assert_eq!(
             do_process_instruction(
-                get_account_data_size(&program_id, &invalid_mint_key).unwrap(),
+                get_account_data_size(&program_id, &invalid_mint_key, vec![]).unwrap(),
                 vec![&mut invalid_mint_account],
             ),
             Err(TokenError::InvalidMint.into())
@@ -6815,7 +6854,7 @@ mod tests {
 
         assert_eq!(
             do_process_instruction(
-                get_account_data_size(&program_id, &invalid_mint_key).unwrap(),
+                get_account_data_size(&program_id, &invalid_mint_key, vec![]).unwrap(),
                 vec![&mut invalid_mint_account],
             ),
             Err(ProgramError::IncorrectProgramId)


### PR DESCRIPTION
When the user wants to allocate a token account with optional extensions, there's no convenient method to figure the size required for those extensions.  This is in contrast to mandatory extensions, where `GetAccountDataSize` can be used to compute the size.

Extend `GetAccountDataSize` to allow the caller to pass in a list of additional `ExtensionTypes` they intend to initialize on the account.

Context: this'll be used by the ATA program to add an extension in a future PR to ATA accounts to prevent ownership transfers (cc: #2640)