### PR TITLE
token-2022: Permit new token accounts to be overallocated

### DIFF
--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -140,7 +140,7 @@ impl Processor {
         let required_extensions =
             Self::get_required_account_extensions_from_unpacked_mint(mint_info.owner, &mint)?;
         if ExtensionType::get_account_len::<Account>(&required_extensions)
-            != new_account_info_data_len
+            > new_account_info_data_len
         {
             return Err(ProgramError::InvalidAccountData);
         }


### PR DESCRIPTION
It's ok to allocated more account data than what's needed by the required extensions, as maybe the user wants to mix in some optional extensions as well