### PR TITLE
token-2022: fixup realloc_needed

### DIFF
--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -617,7 +617,16 @@ impl ExtensionType {
 
     /// Get the TLV length for a set of ExtensionTypes
     fn get_total_tlv_len(extension_types: &[Self]) -> usize {
-        extension_types.iter().map(|e| e.get_tlv_len()).sum()
+        let tlv_len: usize = extension_types.iter().map(|e| e.get_tlv_len()).sum();
+        if tlv_len
+            == Multisig::LEN
+                .saturating_sub(BASE_ACCOUNT_LENGTH)
+                .saturating_sub(size_of::<AccountType>())
+        {
+            tlv_len.saturating_add(size_of::<ExtensionType>())
+        } else {
+            tlv_len
+        }
     }
 
     /// Get the required account data length for the given ExtensionTypes
@@ -626,14 +635,9 @@ impl ExtensionType {
             S::LEN
         } else {
             let extension_size = Self::get_total_tlv_len(extension_types);
-            let account_size = extension_size
+            extension_size
                 .saturating_add(BASE_ACCOUNT_LENGTH)
-                .saturating_add(size_of::<AccountType>());
-            if account_size == Multisig::LEN {
-                account_size.saturating_add(size_of::<ExtensionType>())
-            } else {
-                account_size
-            }
+                .saturating_add(size_of::<AccountType>())
         }
     }
 

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -1392,6 +1392,10 @@ mod test {
             realloc,
             Some(ExtensionType::ImmutableOwner.get_tlv_len() + size_of::<AccountType>())
         );
+        assert_eq!(
+            account_size + realloc.unwrap(),
+            ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner])
+        );
         let mut buffer = vec![0; account_size + realloc.unwrap()];
         let mut state =
             StateWithExtensionsMut::<Account>::unpack_uninitialized(&mut buffer).unwrap();
@@ -1421,6 +1425,13 @@ mod test {
             realloc,
             Some(ExtensionType::MintCloseAuthority.get_tlv_len())
         );
+        assert_eq!(
+            mint_size + realloc.unwrap(),
+            ExtensionType::get_account_len::<Account>(&[
+                ExtensionType::TransferFeeConfig,
+                ExtensionType::MintCloseAuthority
+            ])
+        );
         let mut buffer = vec![0; mint_size + realloc.unwrap()];
         let mut state = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut buffer).unwrap();
         state.base = TEST_MINT;
@@ -1449,6 +1460,13 @@ mod test {
         assert_eq!(
             realloc,
             Some(ExtensionType::MintCloseAuthority.get_tlv_len() - size_of::<ExtensionType>())
+        );
+        assert_eq!(
+            mint_size + realloc.unwrap(),
+            ExtensionType::get_account_len::<Account>(&[
+                ExtensionType::MintPaddingTest,
+                ExtensionType::MintCloseAuthority
+            ])
         );
         let mut buffer = vec![0; mint_size + realloc.unwrap()];
         let mut state = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut buffer).unwrap();

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -1414,12 +1414,20 @@ mod test {
             None
         );
         state.init_extension::<TransferFeeConfig>().unwrap();
+        let realloc = state
+            .realloc_needed(ExtensionType::MintCloseAuthority)
+            .unwrap();
         assert_eq!(
-            state
-                .realloc_needed(ExtensionType::MintCloseAuthority)
-                .unwrap(),
+            realloc,
             Some(ExtensionType::MintCloseAuthority.get_tlv_len())
         );
+        let mut buffer = vec![0; mint_size + realloc.unwrap()];
+        let mut state = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut buffer).unwrap();
+        state.base = TEST_MINT;
+        state.pack_base();
+        state.init_account_type().unwrap();
+        state.init_extension::<TransferFeeConfig>().unwrap();
+        state.init_extension::<MintCloseAuthority>().unwrap();
 
         // buffer with multisig len
         let mint_size = ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintPaddingTest]);
@@ -1435,12 +1443,20 @@ mod test {
             None
         );
         state.init_extension::<MintPaddingTest>().unwrap();
+        let realloc = state
+            .realloc_needed(ExtensionType::MintCloseAuthority)
+            .unwrap();
         assert_eq!(
-            state
-                .realloc_needed(ExtensionType::MintCloseAuthority)
-                .unwrap(),
+            realloc,
             Some(ExtensionType::MintCloseAuthority.get_tlv_len() - size_of::<ExtensionType>())
         );
+        let mut buffer = vec![0; mint_size + realloc.unwrap()];
+        let mut state = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut buffer).unwrap();
+        state.base = TEST_MINT;
+        state.pack_base();
+        state.init_account_type().unwrap();
+        state.init_extension::<MintPaddingTest>().unwrap();
+        state.init_extension::<MintCloseAuthority>().unwrap();
 
         // huge buffer
         let mut buffer = vec![0; u16::MAX.into()];


### PR DESCRIPTION
Several issues with initial `realloc_needed()` api:
- Does not properly handle accounts with only the base state originally initialized
- Diff returned does not include the space needed for ExtensionType and Length
- Does not check whether the new ExtensionType is already initialized (which does not require reallocation)