### PR TITLE
token-2022: Add withdraw withheld tokens from accounts

### DIFF
--- a/token/program-2022/src/extension/transfer_fee/instruction.rs
+++ b/token/program-2022/src/extension/transfer_fee/instruction.rs
@@ -97,8 +97,8 @@ pub enum TransferFeeInstruction {
     ///   3. ..3+M `[signer]` M signer accounts.
     ///   3+M+1. ..3+M+N `[writable]` The source accounts to withdraw from.
     WithdrawWithheldTokensFromAccounts {
-        /// Number of multisig signers, in addition to the authority account
-        number_of_additional_signers: u8,
+        /// Number of token accounts harvested
+        number_of_token_accounts: u8,
     },
     /// Permissionless instruction to transfer all withheld tokens to the mint.
     ///
@@ -166,10 +166,10 @@ impl TransferFeeInstruction {
             }
             2 => (Self::WithdrawWithheldTokensFromMint, rest),
             3 => {
-                let (&number_of_additional_signers, rest) =
+                let (&number_of_token_accounts, rest) =
                     rest.split_first().ok_or(InvalidInstruction)?;
                 let instruction = Self::WithdrawWithheldTokensFromAccounts {
-                    number_of_additional_signers,
+                    number_of_token_accounts,
                 };
                 (instruction, rest)
             }
@@ -216,10 +216,10 @@ impl TransferFeeInstruction {
                 buffer.push(2);
             }
             Self::WithdrawWithheldTokensFromAccounts {
-                number_of_additional_signers,
+                number_of_token_accounts,
             } => {
                 buffer.push(3);
-                buffer.push(number_of_additional_signers);
+                buffer.push(number_of_token_accounts);
             }
             Self::HarvestWithheldTokensToMint => {
                 buffer.push(4);
@@ -340,8 +340,8 @@ pub fn withdraw_withheld_tokens_from_accounts(
     sources: &[&Pubkey],
 ) -> Result<Instruction, ProgramError> {
     check_program_account(token_program_id)?;
-    let number_of_additional_signers =
-        u8::try_from(signers.len()).map_err(|_| ProgramError::InvalidInstructionData)?;
+    let number_of_token_accounts =
+        u8::try_from(sources.len()).map_err(|_| ProgramError::InvalidInstructionData)?;
     let mut accounts = Vec::with_capacity(3 + signers.len() + sources.len());
     accounts.push(AccountMeta::new_readonly(*mint, false));
     accounts.push(AccountMeta::new(*destination, false));
@@ -358,7 +358,7 @@ pub fn withdraw_withheld_tokens_from_accounts(
         accounts,
         data: TokenInstruction::TransferFeeExtension(
             TransferFeeInstruction::WithdrawWithheldTokensFromAccounts {
-                number_of_additional_signers,
+                number_of_token_accounts,
             },
         )
         .pack(),
@@ -464,14 +464,14 @@ mod test {
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
 
-        let number_of_additional_signers = 255;
+        let number_of_token_accounts = 255;
         let check = TokenInstruction::TransferFeeExtension(
             TransferFeeInstruction::WithdrawWithheldTokensFromAccounts {
-                number_of_additional_signers,
+                number_of_token_accounts,
             },
         );
         let packed = check.pack();
-        let expect = [23u8, 3, number_of_additional_signers];
+        let expect = [23u8, 3, number_of_token_accounts];
         assert_eq!(packed, expect);
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);

--- a/token/program-2022/src/extension/transfer_fee/processor.rs
+++ b/token/program-2022/src/extension/transfer_fee/processor.rs
@@ -200,6 +200,7 @@ fn process_harvest_withheld_tokens_to_mint(accounts: &[AccountInfo]) -> ProgramR
 fn process_withdraw_withheld_tokens_from_accounts(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
+    number_of_additional_signers: u8,
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
     let mint_account_info = next_account_info(account_info_iter)?;
@@ -207,6 +208,7 @@ fn process_withdraw_withheld_tokens_from_accounts(
     let authority_info = next_account_info(account_info_iter)?;
     let authority_info_data_len = authority_info.data_len();
     let account_infos = account_info_iter.as_slice();
+    let number_of_additional_signers = number_of_additional_signers as usize;
 
     let mint_data = mint_account_info.data.borrow();
     let mint = StateWithExtensions::<Mint>::unpack(&mint_data)?;
@@ -223,7 +225,7 @@ fn process_withdraw_withheld_tokens_from_accounts(
         &withdraw_withheld_authority,
         authority_info,
         authority_info_data_len,
-        account_infos,
+        &account_infos[..number_of_additional_signers],
     )?;
 
     let mut dest_account_data = dest_account_info.data.borrow_mut();
@@ -236,7 +238,7 @@ fn process_withdraw_withheld_tokens_from_accounts(
     }
     // This iterates back over any multisig signers, but since it gracefully
     // fails on those, we can support them.
-    for account_info in account_infos {
+    for account_info in &account_infos[number_of_additional_signers..] {
         // self-harvest, can't double-borrow the underlying data
         if account_info.key == dest_account_info.key {
             let token_account_extension = dest_account
@@ -301,9 +303,15 @@ pub(crate) fn process_instruction(
             msg!("TransferFeeInstruction: WithdrawWithheldTokensFromMint");
             process_withdraw_withheld_tokens_from_mint(program_id, accounts)
         }
-        TransferFeeInstruction::WithdrawWithheldTokensFromAccounts => {
+        TransferFeeInstruction::WithdrawWithheldTokensFromAccounts {
+            number_of_additional_signers,
+        } => {
             msg!("TransferFeeInstruction: WithdrawWithheldTokensFromAccounts");
-            process_withdraw_withheld_tokens_from_accounts(program_id, accounts)
+            process_withdraw_withheld_tokens_from_accounts(
+                program_id,
+                accounts,
+                number_of_additional_signers,
+            )
         }
         TransferFeeInstruction::HarvestWithheldTokensToMint => {
             msg!("TransferFeeInstruction: HarvestWithheldTokensToMint");

--- a/token/program-2022/src/extension/transfer_fee/processor.rs
+++ b/token/program-2022/src/extension/transfer_fee/processor.rs
@@ -7,7 +7,7 @@ use {
                 instruction::TransferFeeInstruction, TransferFee, TransferFeeAmount,
                 TransferFeeConfig, MAX_FEE_BASIS_POINTS,
             },
-            StateWithExtensionsMut,
+            StateWithExtensions, StateWithExtensionsMut,
         },
         processor::Processor,
         state::{Account, Mint},
@@ -154,9 +154,8 @@ fn process_withdraw_withheld_tokens_from_mint(
 
 fn harvest_from_account<'a, 'b>(
     mint_key: &'b Pubkey,
-    mint_extension: &'b mut TransferFeeConfig,
     token_account_info: &'b AccountInfo<'a>,
-) -> Result<(), TokenError> {
+) -> Result<u64, TokenError> {
     let mut token_account_data = token_account_info.data.borrow_mut();
     let mut token_account = StateWithExtensionsMut::<Account>::unpack(&mut token_account_data)
         .map_err(|_| TokenError::InvalidState)?;
@@ -168,13 +167,8 @@ fn harvest_from_account<'a, 'b>(
         .get_extension_mut::<TransferFeeAmount>()
         .map_err(|_| TokenError::InvalidState)?;
     let account_withheld_amount = u64::from(token_account_extension.withheld_amount);
-    let mint_withheld_amount = u64::from(mint_extension.withheld_amount);
-    mint_extension.withheld_amount = mint_withheld_amount
-        .checked_add(account_withheld_amount)
-        .ok_or(TokenError::Overflow)?
-        .into();
     token_account_extension.withheld_amount = 0.into();
-    Ok(())
+    Ok(account_withheld_amount)
 }
 
 fn process_harvest_withheld_tokens_to_mint(accounts: &[AccountInfo]) -> ProgramResult {
@@ -187,15 +181,91 @@ fn process_harvest_withheld_tokens_to_mint(accounts: &[AccountInfo]) -> ProgramR
     let mint_extension = mint.get_extension_mut::<TransferFeeConfig>()?;
 
     for token_account_info in token_account_infos {
-        match harvest_from_account(mint_account_info.key, mint_extension, token_account_info) {
-            // Shouldn't ever happen, but if it does, we don't want to propagate any half-done changes
-            Err(TokenError::Overflow) => return Err(TokenError::Overflow.into()),
+        match harvest_from_account(mint_account_info.key, token_account_info) {
+            Ok(amount) => {
+                let mint_withheld_amount = u64::from(mint_extension.withheld_amount);
+                mint_extension.withheld_amount = mint_withheld_amount
+                    .checked_add(amount)
+                    .ok_or(TokenError::Overflow)?
+                    .into();
+            }
             Err(e) => {
                 msg!("Error harvesting from {}: {}", token_account_info.key, e);
             }
-            Ok(_) => {}
         }
     }
+    Ok(())
+}
+
+fn process_withdraw_withheld_tokens_from_accounts(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let mint_account_info = next_account_info(account_info_iter)?;
+    let dest_account_info = next_account_info(account_info_iter)?;
+    let authority_info = next_account_info(account_info_iter)?;
+    let authority_info_data_len = authority_info.data_len();
+    let account_infos = account_info_iter.as_slice();
+
+    let mint_data = mint_account_info.data.borrow();
+    let mint = StateWithExtensions::<Mint>::unpack(&mint_data)?;
+    let extension = mint.get_extension::<TransferFeeConfig>()?;
+
+    let withdraw_withheld_authority = Option::<Pubkey>::from(extension.withdraw_withheld_authority)
+        .ok_or(TokenError::NoAuthorityExists)?;
+    // This will also iterate over the token accounts for a multisig, but
+    // it will only fail if trying to withdraw from an account that is part
+    // of the multisig, but *not* signing the transaction.
+    // This is an annoyance, but doesn't introduce any security issues.
+    Processor::validate_owner(
+        program_id,
+        &withdraw_withheld_authority,
+        authority_info,
+        authority_info_data_len,
+        account_infos,
+    )?;
+
+    let mut dest_account_data = dest_account_info.data.borrow_mut();
+    let mut dest_account = StateWithExtensionsMut::<Account>::unpack(&mut dest_account_data)?;
+    if dest_account.base.mint != *mint_account_info.key {
+        return Err(TokenError::MintMismatch.into());
+    }
+    if dest_account.base.is_frozen() {
+        return Err(TokenError::AccountFrozen.into());
+    }
+    // This iterates back over any multisig signers, but since it gracefully
+    // fails on those, we can support them.
+    for account_info in account_infos {
+        // self-harvest, can't double-borrow the underlying data
+        if account_info.key == dest_account_info.key {
+            let token_account_extension = dest_account
+                .get_extension_mut::<TransferFeeAmount>()
+                .map_err(|_| TokenError::InvalidState)?;
+            let account_withheld_amount = u64::from(token_account_extension.withheld_amount);
+            token_account_extension.withheld_amount = 0.into();
+            dest_account.base.amount = dest_account
+                .base
+                .amount
+                .checked_add(account_withheld_amount)
+                .ok_or(TokenError::Overflow)?;
+        } else {
+            match harvest_from_account(mint_account_info.key, account_info) {
+                Ok(amount) => {
+                    dest_account.base.amount = dest_account
+                        .base
+                        .amount
+                        .checked_add(amount)
+                        .ok_or(TokenError::Overflow)?;
+                }
+                Err(e) => {
+                    msg!("Error harvesting from {}: {}", account_info.key, e);
+                }
+            }
+        }
+    }
+    dest_account.pack_base();
+
     Ok(())
 }
 
@@ -232,7 +302,8 @@ pub(crate) fn process_instruction(
             process_withdraw_withheld_tokens_from_mint(program_id, accounts)
         }
         TransferFeeInstruction::WithdrawWithheldTokensFromAccounts => {
-            unimplemented!();
+            msg!("TransferFeeInstruction: WithdrawWithheldTokensFromAccounts");
+            process_withdraw_withheld_tokens_from_accounts(program_id, accounts)
         }
         TransferFeeInstruction::HarvestWithheldTokensToMint => {
             msg!("TransferFeeInstruction: HarvestWithheldTokensToMint");

--- a/token/program-2022/tests/transfer_fee.rs
+++ b/token/program-2022/tests/transfer_fee.rs
@@ -629,7 +629,29 @@ async fn set_withdraw_withheld_authority() {
         Some(new_authority.pubkey()).try_into().unwrap(),
     );
 
-    // TODO: assert new authority can withdraw withheld fees and old cannot
+    // new authority can withdraw tokens
+    let account = token
+        .create_auxiliary_token_account(&Keypair::new(), &new_authority.pubkey())
+        .await
+        .unwrap();
+    token
+        .withdraw_withheld_tokens_from_accounts(&account, &new_authority, &[&account])
+        .await
+        .unwrap();
+    // old one cannot
+    let error = token
+        .withdraw_withheld_tokens_from_accounts(&account, &withdraw_withheld_authority, &[&account])
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::OwnerMismatch as u32)
+            )
+        )))
+    );
 
     // set to none
     token
@@ -668,7 +690,37 @@ async fn set_withdraw_withheld_authority() {
         )))
     );
 
-    // TODO: assert no authority can withdraw withheld fees
+    // assert no authority can withdraw withheld fees
+    let account = token
+        .create_auxiliary_token_account(&Keypair::new(), &new_authority.pubkey())
+        .await
+        .unwrap();
+    let error = token
+        .withdraw_withheld_tokens_from_accounts(&account, &withdraw_withheld_authority, &[&account])
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::NoAuthorityExists as u32)
+            )
+        )))
+    );
+    let error = token
+        .withdraw_withheld_tokens_from_accounts(&account, &new_authority, &[&account])
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::NoAuthorityExists as u32)
+            )
+        )))
+    );
 }
 
 #[tokio::test]
@@ -1144,6 +1196,61 @@ async fn max_harvest_withheld_tokens_to_mint() {
 }
 
 #[tokio::test]
+async fn max_withdraw_withheld_tokens_from_accounts() {
+    let amount = TEST_MAXIMUM_FEE;
+    let alice_amount = amount * 100;
+    let TokenWithAccounts {
+        token,
+        withdraw_withheld_authority,
+        transfer_fee_config,
+        alice,
+        alice_account,
+        decimals,
+        ..
+    } = create_mint_with_accounts(alice_amount).await;
+
+    // withdraw from max accounts, which is around 35: 1 mint, 1 destination, 1 authority,
+    // 32 accounts
+    // see https://docs.solana.com/proposals/transactions-v2#problem
+    let destination = token
+        .create_auxiliary_token_account(&Keypair::new(), &alice.pubkey())
+        .await
+        .unwrap();
+    let mut accounts = vec![];
+    let max_accounts = 32;
+    for _ in 0..max_accounts {
+        let account = create_and_transfer_to_account(
+            &token,
+            &alice_account,
+            &alice,
+            &alice.pubkey(),
+            amount,
+            decimals,
+        )
+        .await;
+        accounts.push(account);
+    }
+    let accounts: Vec<_> = accounts.iter().collect();
+    let accumulated_fees =
+        max_accounts * transfer_fee_config.calculate_epoch_fee(0, amount).unwrap();
+    token
+        .withdraw_withheld_tokens_from_accounts(
+            &destination,
+            &withdraw_withheld_authority,
+            &accounts,
+        )
+        .await
+        .unwrap();
+    for account in accounts {
+        let state = token.get_account_info(account).await.unwrap();
+        let extension = state.get_extension::<TransferFeeAmount>().unwrap();
+        assert_eq!(extension.withheld_amount, 0.into());
+    }
+    let state = token.get_account_info(&destination).await.unwrap();
+    assert_eq!(state.base.amount, accumulated_fees);
+}
+
+#[tokio::test]
 async fn withdraw_withheld_tokens_from_mint() {
     let amount = TEST_MAXIMUM_FEE;
     let alice_amount = amount * 100;
@@ -1301,6 +1408,137 @@ async fn withdraw_withheld_tokens_from_mint() {
     let TokenContext { token, .. } = context.token_context.take().unwrap();
     let error = token
         .withdraw_withheld_tokens_from_mint(&account, &withdraw_withheld_authority)
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::MintMismatch as u32)
+            )
+        )))
+    );
+}
+
+#[tokio::test]
+async fn withdraw_withheld_tokens_from_accounts() {
+    let amount = TEST_MAXIMUM_FEE;
+    let alice_amount = amount * 100;
+    let TokenWithAccounts {
+        mut context,
+        token,
+        withdraw_withheld_authority,
+        alice,
+        alice_account,
+        decimals,
+        ..
+    } = create_mint_with_accounts(alice_amount).await;
+
+    // wrong signer
+    let error = token
+        .withdraw_withheld_tokens_from_accounts(&alice_account, &Keypair::new(), &[])
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::OwnerMismatch as u32)
+            )
+        )))
+    );
+
+    // withdraw from zero accounts
+    token
+        .withdraw_withheld_tokens_from_accounts(&alice_account, &withdraw_withheld_authority, &[])
+        .await
+        .unwrap();
+    let state = token.get_account_info(&alice_account).await.unwrap();
+    assert_eq!(state.base.amount, alice_amount);
+
+    // self-harvest from one account
+    let account = create_and_transfer_to_account(
+        &token,
+        &alice_account,
+        &alice,
+        &alice.pubkey(),
+        amount,
+        decimals,
+    )
+    .await;
+    token
+        .withdraw_withheld_tokens_from_accounts(&account, &withdraw_withheld_authority, &[&account])
+        .await
+        .unwrap();
+    let state = token.get_account_info(&account).await.unwrap();
+    let extension = state.get_extension::<TransferFeeAmount>().unwrap();
+    // we transferred to this account, and then withdrew the fee to it, so it's
+    // like doing a fee-less transfer!
+    assert_eq!(extension.withheld_amount, 0.into());
+    assert_eq!(state.base.amount, amount);
+
+    // harvest again from the same account
+    token
+        .withdraw_withheld_tokens_from_accounts(
+            &alice_account,
+            &withdraw_withheld_authority,
+            &[&account],
+        )
+        .await
+        .unwrap();
+    let state = token.get_account_info(&account).await.unwrap();
+    let extension = state.get_extension::<TransferFeeAmount>().unwrap();
+    assert_eq!(extension.withheld_amount, 0.into());
+    assert_eq!(state.base.amount, amount);
+    let state = token.get_account_info(&alice_account).await.unwrap();
+    assert_eq!(state.base.amount, alice_amount - amount);
+
+    // no fail harvesting from account belonging to different mint, but nothing
+    // happens
+    let account = create_and_transfer_to_account(
+        &token,
+        &alice_account,
+        &alice,
+        &alice.pubkey(),
+        amount,
+        decimals,
+    )
+    .await;
+    context
+        .init_token_with_mint(vec![ExtensionInitializationParams::TransferFeeConfig {
+            transfer_fee_config_authority: Some(Pubkey::new_unique()),
+            withdraw_withheld_authority: Some(withdraw_withheld_authority.pubkey()),
+            transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
+            maximum_fee: TEST_MAXIMUM_FEE,
+        }])
+        .await
+        .unwrap();
+    let TokenContext { token, .. } = context.token_context.take().unwrap();
+    let withdraw_account = token
+        .create_auxiliary_token_account(&Keypair::new(), &alice.pubkey())
+        .await
+        .unwrap();
+    token
+        .withdraw_withheld_tokens_from_accounts(
+            &withdraw_account,
+            &withdraw_withheld_authority,
+            &[&account],
+        )
+        .await
+        .unwrap();
+    let state = token.get_mint_info().await.unwrap();
+    let extension = state.get_extension::<TransferFeeConfig>().unwrap();
+    assert_eq!(extension.withheld_amount, 0.into());
+
+    // fail withdrawing into account on different mint
+    let error = token
+        .withdraw_withheld_tokens_from_accounts(
+            &account,
+            &withdraw_withheld_authority,
+            &[&withdraw_account],
+        )
         .await
         .unwrap_err();
     assert_eq!(

--- a/token/program-2022/tests/transfer_fee.rs
+++ b/token/program-2022/tests/transfer_fee.rs
@@ -1054,8 +1054,9 @@ async fn create_and_transfer_to_account(
     amount: u64,
     decimals: u8,
 ) -> Pubkey {
+    let account = Keypair::new();
     let account = token
-        .create_auxiliary_token_account(&Keypair::new(), owner)
+        .create_auxiliary_token_account(&account, owner)
         .await
         .unwrap();
     token

--- a/token/rust/src/token.rs
+++ b/token/rust/src/token.rs
@@ -597,4 +597,27 @@ where
         )
         .await
     }
+
+    /// Withdraw withheld tokens from accounts
+    pub async fn withdraw_withheld_tokens_from_accounts<S2: Signer>(
+        &self,
+        destination: &Pubkey,
+        authority: &S2,
+        sources: &[&Pubkey],
+    ) -> TokenResult<T::Output> {
+        self.process_ixs(
+            &[
+                transfer_fee::instruction::withdraw_withheld_tokens_from_accounts(
+                    &self.program_id,
+                    &self.pubkey,
+                    destination,
+                    &authority.pubkey(),
+                    &[],
+                    sources,
+                )?,
+            ],
+            &[authority],
+        )
+        .await
+    }
 }


### PR DESCRIPTION
#### Problem

Harvesting tokens + withdrawing from the mint is great, but it's also useful to withdraw directly from the accounts to avoid taking a write lock on the mint too much.

#### Solution

Implement `withdraw_withheld_tokens_from_accounts`!