### PR TITLE
token-2022: Add Reallocate instruction

### DIFF
--- a/associated-token-account/program/src/processor.rs
+++ b/associated-token-account/program/src/processor.rs
@@ -79,7 +79,7 @@ pub fn process_create_associated_token_account(
     let account_len = get_account_len(
         spl_token_mint_info,
         spl_token_program_info,
-        vec![spl_token::extension::ExtensionType::ImmutableOwner],
+        &[spl_token::extension::ExtensionType::ImmutableOwner],
     )?;
 
     create_pda_account(

--- a/associated-token-account/program/src/tools/account.rs
+++ b/associated-token-account/program/src/tools/account.rs
@@ -76,7 +76,7 @@ pub fn create_pda_account<'a>(
 pub fn get_account_len<'a>(
     mint: &AccountInfo<'a>,
     spl_token_program: &AccountInfo<'a>,
-    extension_types: Vec<ExtensionType>,
+    extension_types: &[ExtensionType],
 ) -> Result<usize, ProgramError> {
     invoke(
         &spl_token::instruction::get_account_data_size(

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -33,6 +33,8 @@ pub mod default_account_state;
 pub mod immutable_owner;
 /// Mint Close Authority extension
 pub mod mint_close_authority;
+/// Utility to reallocate token accounts
+pub mod reallocate;
 /// Transfer Fee extension
 pub mod transfer_fee;
 

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -634,7 +634,14 @@ impl ExtensionType {
 
     /// Get the TLV length for a set of ExtensionTypes
     fn get_total_tlv_len(extension_types: &[Self]) -> usize {
-        let tlv_len: usize = extension_types.iter().map(|e| e.get_tlv_len()).sum();
+        // dedupe extensions
+        let mut extensions = vec![];
+        for extension_type in extension_types {
+            if !extensions.contains(&extension_type) {
+                extensions.push(extension_type);
+            }
+        }
+        let tlv_len: usize = extensions.iter().map(|e| e.get_tlv_len()).sum();
         if tlv_len
             == Multisig::LEN
                 .saturating_sub(BASE_ACCOUNT_LENGTH)

--- a/token/program-2022/src/extension/reallocate.rs
+++ b/token/program-2022/src/extension/reallocate.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         error::TokenError,
-        extension::{AccountType, ExtensionType, StateWithExtensions, StateWithExtensionsMut},
+        extension::{set_account_type, AccountType, ExtensionType, StateWithExtensions},
         processor::Processor,
         state::Account,
     },
@@ -81,7 +81,7 @@ pub fn process_reallocate(
 
     // unpack to set account_type, if needed
     let mut token_account = token_account_info.data.borrow_mut();
-    StateWithExtensionsMut::<Account>::unpack_after_realloc(&mut token_account)?;
+    set_account_type::<Account>(&mut token_account)?;
 
     Ok(())
 }

--- a/token/program-2022/src/extension/reallocate.rs
+++ b/token/program-2022/src/extension/reallocate.rs
@@ -1,0 +1,87 @@
+use {
+    crate::{
+        error::TokenError,
+        extension::{AccountType, ExtensionType, StateWithExtensions, StateWithExtensionsMut},
+        processor::Processor,
+        state::Account,
+    },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        msg,
+        program::invoke,
+        pubkey::Pubkey,
+        system_instruction,
+        sysvar::{rent::Rent, Sysvar},
+    },
+};
+
+/// Processes a [Reallocate](enum.TokenInstruction.html) instruction
+pub fn process_reallocate(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    new_extension_types: Vec<ExtensionType>,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let token_account_info = next_account_info(account_info_iter)?;
+    let payer_info = next_account_info(account_info_iter)?;
+    let system_program_info = next_account_info(account_info_iter)?;
+    let authority_info = next_account_info(account_info_iter)?;
+    let authority_info_data_len = authority_info.data_len();
+
+    // check that account is the right type and validate owner
+    let mut current_extension_types = {
+        let token_account = token_account_info.data.borrow();
+        let account = StateWithExtensions::<Account>::unpack(&token_account)?;
+        Processor::validate_owner(
+            program_id,
+            &account.base.owner,
+            authority_info,
+            authority_info_data_len,
+            account_info_iter.as_slice(),
+        )?;
+        account.get_extension_types()?
+    };
+
+    // check that all desired extensions are for the right account type
+    if new_extension_types
+        .iter()
+        .any(|extension_type| extension_type.get_account_type() != AccountType::Account)
+    {
+        return Err(TokenError::InvalidState.into());
+    }
+    // ExtensionType::get_account_len() dedupes types, so just a dumb concatenation is fine here
+    current_extension_types.extend_from_slice(&new_extension_types);
+    let needed_account_len = ExtensionType::get_account_len::<Account>(&current_extension_types);
+
+    // if account is already large enough, return early
+    if token_account_info.data_len() >= needed_account_len {
+        return Ok(());
+    }
+
+    // reallocate
+    msg!(
+        "account needs realloc, +{:?} bytes",
+        needed_account_len - token_account_info.data_len()
+    );
+    token_account_info.realloc(needed_account_len, false)?;
+
+    // if additional lamports needed to remain rent-exempt, transfer them
+    let rent = Rent::get()?;
+    let new_minimum_balance = rent.minimum_balance(needed_account_len);
+    let lamports_diff = new_minimum_balance.saturating_sub(token_account_info.lamports());
+    invoke(
+        &system_instruction::transfer(payer_info.key, token_account_info.key, lamports_diff),
+        &[
+            payer_info.clone(),
+            token_account_info.clone(),
+            system_program_info.clone(),
+        ],
+    )?;
+
+    // unpack to set account_type, if needed
+    let mut token_account = token_account_info.data.borrow_mut();
+    StateWithExtensionsMut::<Account>::unpack_after_realloc(&mut token_account)?;
+
+    Ok(())
+}

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -11,7 +11,7 @@ use {
         program_error::ProgramError,
         program_option::COption,
         pubkey::{Pubkey, PUBKEY_BYTES},
-        sysvar,
+        system_program, sysvar,
     },
     std::{convert::TryInto, mem::size_of},
 };
@@ -495,11 +495,33 @@ pub enum TokenInstruction {
     /// Accounts expected by this instruction:
     ///
     ///   0. `[writable]`  The account to initialize.
-    //
+    ///
     /// Data expected by this instruction:
     ///   None
     ///
     InitializeImmutableOwner,
+    /// Check to see if a token account is large enough for a list of ExtensionTypes, and if not,
+    /// use reallocation to increase the data size.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   * Single owner
+    ///   0. `[writable]` The account to reallocate.
+    ///   1. `[signer, writable]` The payer account to fund reallocation
+    ///   2. `[]` System program for reallocation funding
+    ///   3. `[signer]` The account's owner.
+    ///
+    ///   * Multisignature owner
+    ///   0. `[writable]` The account to reallocate.
+    ///   1. `[signer, writable]` The payer account to fund reallocation
+    ///   2. `[]` System program for reallocation funding
+    ///   3. `[]` The account's multisignature owner/delegate.
+    ///   4. ..4+M `[signer]` M signer accounts.
+    ///
+    Reallocate {
+        /// New extension types to include in the reallocated account
+        extension_types: Vec<ExtensionType>,
+    },
 }
 impl TokenInstruction {
     /// Unpacks a byte buffer into a [TokenInstruction](enum.TokenInstruction.html).
@@ -611,6 +633,13 @@ impl TokenInstruction {
             24 => Self::ConfidentialTransferExtension,
             25 => Self::DefaultAccountStateExtension,
             26 => Self::InitializeImmutableOwner,
+            27 => {
+                let mut extension_types = vec![];
+                for chunk in rest.chunks(size_of::<ExtensionType>()) {
+                    extension_types.push(chunk.try_into()?);
+                }
+                Self::Reallocate { extension_types }
+            }
             _ => return Err(TokenError::InvalidInstruction.into()),
         })
     }
@@ -734,6 +763,14 @@ impl TokenInstruction {
             }
             &Self::InitializeImmutableOwner => {
                 buf.push(26);
+            }
+            &Self::Reallocate {
+                ref extension_types,
+            } => {
+                buf.push(27);
+                for extension_type in extension_types {
+                    buf.extend_from_slice(&<[u8; 2]>::from(*extension_type));
+                }
             }
         };
         buf
@@ -1486,6 +1523,39 @@ pub fn initialize_immutable_owner(
         program_id: *token_program_id,
         accounts: vec![AccountMeta::new(*token_account, false)],
         data: TokenInstruction::InitializeImmutableOwner.pack(),
+    })
+}
+
+/// Creates a `Reallocate` instruction
+pub fn reallocate(
+    token_program_id: &Pubkey,
+    account_pubkey: &Pubkey,
+    payer: &Pubkey,
+    owner_pubkey: &Pubkey,
+    signer_pubkeys: &[&Pubkey],
+    extension_types: &[ExtensionType],
+) -> Result<Instruction, ProgramError> {
+    check_program_account(token_program_id)?;
+
+    let mut accounts = Vec::with_capacity(4 + signer_pubkeys.len());
+    accounts.push(AccountMeta::new(*account_pubkey, false));
+    accounts.push(AccountMeta::new(*payer, true));
+    accounts.push(AccountMeta::new_readonly(system_program::id(), false));
+    accounts.push(AccountMeta::new_readonly(
+        *owner_pubkey,
+        signer_pubkeys.is_empty(),
+    ));
+    for signer_pubkey in signer_pubkeys.iter() {
+        accounts.push(AccountMeta::new_readonly(**signer_pubkey, true));
+    }
+
+    Ok(Instruction {
+        program_id: *token_program_id,
+        accounts,
+        data: TokenInstruction::Reallocate {
+            extension_types: extension_types.to_vec(),
+        }
+        .pack(),
     })
 }
 

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -1448,13 +1448,16 @@ pub fn sync_native(
 pub fn get_account_data_size(
     token_program_id: &Pubkey,
     mint_pubkey: &Pubkey,
-    extension_types: Vec<ExtensionType>,
+    extension_types: &[ExtensionType],
 ) -> Result<Instruction, ProgramError> {
     check_program_account(token_program_id)?;
     Ok(Instruction {
         program_id: *token_program_id,
         accounts: vec![AccountMeta::new_readonly(*mint_pubkey, false)],
-        data: TokenInstruction::GetAccountDataSize { extension_types }.pack(),
+        data: TokenInstruction::GetAccountDataSize {
+            extension_types: extension_types.to_vec(),
+        }
+        .pack(),
     })
 }
 

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -9,6 +9,7 @@ use {
             default_account_state::{self, DefaultAccountState},
             immutable_owner::ImmutableOwner,
             mint_close_authority::MintCloseAuthority,
+            reallocate,
             transfer_fee::{self, TransferFeeAmount, TransferFeeConfig},
             ExtensionType, StateWithExtensions, StateWithExtensionsMut,
         },
@@ -1124,6 +1125,10 @@ impl Processor {
             TokenInstruction::InitializeImmutableOwner => {
                 msg!("Instruction: InitializeImmutableOwner");
                 Self::process_initialize_immutable_owner(accounts)
+            }
+            TokenInstruction::Reallocate { extension_types } => {
+                msg!("Instruction: Reallocate");
+                reallocate::process_reallocate(program_id, accounts, extension_types)
             }
         }
     }

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -6825,7 +6825,7 @@ mod tests {
                 .to_vec(),
         );
         do_process_instruction(
-            get_account_data_size(&program_id, &mint_key, vec![]).unwrap(),
+            get_account_data_size(&program_id, &mint_key, &[]).unwrap(),
             vec![&mut mint_account],
         )
         .unwrap();
@@ -6839,7 +6839,7 @@ mod tests {
             get_account_data_size(
                 &program_id,
                 &mint_key,
-                vec![
+                &[
                     ExtensionType::TransferFeeAmount,
                     ExtensionType::TransferFeeAmount, // Duplicate user input ignored...
                 ],
@@ -6857,7 +6857,7 @@ mod tests {
                 .to_vec(),
         );
         do_process_instruction(
-            get_account_data_size(&program_id, &mint_key, vec![]).unwrap(),
+            get_account_data_size(&program_id, &mint_key, &[]).unwrap(),
             vec![&mut mint_account],
         )
         .unwrap();
@@ -6888,7 +6888,7 @@ mod tests {
                 .to_vec(),
         );
         do_process_instruction(
-            get_account_data_size(&program_id, &mint_key, vec![]).unwrap(),
+            get_account_data_size(&program_id, &mint_key, &[]).unwrap(),
             vec![&mut extended_mint_account],
         )
         .unwrap();
@@ -6897,7 +6897,7 @@ mod tests {
             get_account_data_size(
                 &program_id,
                 &mint_key,
-                vec![ExtensionType::TransferFeeAmount], // User extension that's also added by the mint ignored...
+                &[ExtensionType::TransferFeeAmount], // User extension that's also added by the mint ignored...
             )
             .unwrap(),
             vec![&mut extended_mint_account],
@@ -6924,7 +6924,7 @@ mod tests {
 
         assert_eq!(
             do_process_instruction(
-                get_account_data_size(&program_id, &invalid_mint_key, vec![]).unwrap(),
+                get_account_data_size(&program_id, &invalid_mint_key, &[]).unwrap(),
                 vec![&mut invalid_mint_account],
             ),
             Err(TokenError::InvalidMint.into())
@@ -6949,7 +6949,7 @@ mod tests {
 
         assert_eq!(
             do_process_instruction(
-                get_account_data_size(&program_id, &invalid_mint_key, vec![]).unwrap(),
+                get_account_data_size(&program_id, &invalid_mint_key, &[]).unwrap(),
                 vec![&mut invalid_mint_account],
             ),
             Err(ProgramError::IncorrectProgramId)

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -969,18 +969,15 @@ impl Processor {
     /// Processes a [GetAccountDataSize](enum.TokenInstruction.html) instruction
     pub fn process_get_account_data_size(
         accounts: &[AccountInfo],
-        extension_types: Vec<ExtensionType>,
+        new_extension_types: Vec<ExtensionType>,
     ) -> ProgramResult {
         let account_info_iter = &mut accounts.iter();
         let mint_account_info = next_account_info(account_info_iter)?;
 
         let mut account_extensions = Self::get_required_account_extensions(mint_account_info)?;
-
-        for extension_type in extension_types {
-            if !account_extensions.contains(&extension_type) {
-                account_extensions.push(extension_type);
-            }
-        }
+        // ExtensionType::get_account_len() dedupes types, so just a dumb concatenation is fine
+        // here
+        account_extensions.extend_from_slice(&new_extension_types);
 
         let account_len = ExtensionType::get_account_len::<Account>(&account_extensions);
         set_return_data(&account_len.to_le_bytes());

--- a/token/program-2022/tests/reallocate.rs
+++ b/token/program-2022/tests/reallocate.rs
@@ -1,0 +1,164 @@
+#![cfg(feature = "test-bpf")]
+
+mod program_test;
+use {
+    program_test::{TestContext, TokenContext},
+    solana_program_test::tokio,
+    solana_sdk::{
+        instruction::InstructionError, program_option::COption, pubkey::Pubkey, signature::Signer,
+        signer::keypair::Keypair, transaction::TransactionError, transport::TransportError,
+    },
+    spl_token_2022::{error::TokenError, extension::ExtensionType, state::Account},
+    spl_token_client::token::{ExtensionInitializationParams, TokenError as TokenClientError},
+    std::convert::TryInto,
+};
+
+#[tokio::test]
+async fn reallocate() {
+    let mut context = TestContext::new().await;
+    context.init_token_with_mint(vec![]).await.unwrap();
+    let TokenContext {
+        token,
+        alice,
+        mint_authority,
+        ..
+    } = context.token_context.unwrap();
+
+    // reallocate fails on wrong account type
+    let error = token
+        .reallocate(
+            token.get_address(),
+            &mint_authority,
+            &[ExtensionType::ImmutableOwner],
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(0, InstructionError::InvalidAccountData)
+        )))
+    );
+
+    // create account just large enough for base
+    let alice_account = Keypair::new();
+    let alice_account = token
+        .create_auxiliary_token_account(&alice_account, &alice.pubkey())
+        .await
+        .unwrap();
+
+    // reallocate fails on invalid extension type
+    let error = token
+        .reallocate(&alice_account, &alice, &[ExtensionType::MintCloseAuthority])
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::InvalidState as u32)
+            )
+        )))
+    );
+
+    // reallocate fails on invalid authority
+    let error = token
+        .reallocate(
+            &alice_account,
+            &mint_authority,
+            &[ExtensionType::ImmutableOwner],
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::OwnerMismatch as u32)
+            )
+        )))
+    );
+
+    // reallocate succeeds
+    token
+        .reallocate(&alice_account, &alice, &[ExtensionType::ImmutableOwner])
+        .await
+        .unwrap();
+    let account = token.get_account(&alice_account).await.unwrap();
+    assert_eq!(
+        account.data.len(),
+        ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner])
+    );
+
+    // reallocate succeeds with noop if account is already large enough
+    token
+        .reallocate(&alice_account, &alice, &[ExtensionType::ImmutableOwner])
+        .await
+        .unwrap();
+    let account = token.get_account(&alice_account).await.unwrap();
+    assert_eq!(
+        account.data.len(),
+        ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner])
+    );
+
+    // reallocate only reallocates enough for new extension, and dedupes extensions
+    token
+        .reallocate(
+            &alice_account,
+            &alice,
+            &[
+                ExtensionType::ImmutableOwner,
+                ExtensionType::ImmutableOwner,
+                ExtensionType::TransferFeeAmount,
+                ExtensionType::TransferFeeAmount,
+            ],
+        )
+        .await
+        .unwrap();
+    let account = token.get_account(&alice_account).await.unwrap();
+    assert_eq!(
+        account.data.len(),
+        ExtensionType::get_account_len::<Account>(&[
+            ExtensionType::ImmutableOwner,
+            ExtensionType::TransferFeeAmount
+        ])
+    );
+}
+
+#[tokio::test]
+async fn reallocate_without_current_extension_knowledge() {
+    let mut context = TestContext::new().await;
+    context
+        .init_token_with_mint(vec![ExtensionInitializationParams::TransferFeeConfig {
+            transfer_fee_config_authority: COption::Some(Pubkey::new_unique()).try_into().unwrap(),
+            withdraw_withheld_authority: COption::Some(Pubkey::new_unique()).try_into().unwrap(),
+            transfer_fee_basis_points: 250,
+            maximum_fee: 10_000_000,
+        }])
+        .await
+        .unwrap();
+    let TokenContext { token, alice, .. } = context.token_context.unwrap();
+
+    // create account just large enough for TransferFeeAmount extension
+    let alice_account = Keypair::new();
+    let alice_account = token
+        .create_auxiliary_token_account(&alice_account, &alice.pubkey())
+        .await
+        .unwrap();
+
+    // reallocate resizes account to accommodate new and existing extensions
+    token
+        .reallocate(&alice_account, &alice, &[ExtensionType::ImmutableOwner])
+        .await
+        .unwrap();
+    let account = token.get_account(&alice_account).await.unwrap();
+    assert_eq!(
+        account.data.len(),
+        ExtensionType::get_account_len::<Account>(&[
+            ExtensionType::TransferFeeAmount,
+            ExtensionType::ImmutableOwner
+        ])
+    );
+}

--- a/token/rust/src/token.rs
+++ b/token/rust/src/token.rs
@@ -620,4 +620,25 @@ where
         )
         .await
     }
+
+    /// Reallocate a token account to be large enough for a set of ExtensionTypes
+    pub async fn reallocate<S2: Signer>(
+        &self,
+        account: &Pubkey,
+        authority: &S2,
+        extension_types: &[ExtensionType],
+    ) -> TokenResult<T::Output> {
+        self.process_ixs(
+            &[instruction::reallocate(
+                &self.program_id,
+                account,
+                &self.payer.pubkey(),
+                &authority.pubkey(),
+                &[],
+                extension_types,
+            )?],
+            &[authority],
+        )
+        .await
+    }
 }


### PR DESCRIPTION
Some extensions are opt-in for token account owners at any time after the account has been initialized. In these cases, the owner needs the ability to reallocate their token account data to be large enough to hold the new extension. Previous approaches attempted to do this in the initialization logic of the specific extension, but borrows on the token account were messy, and it was inefficient to include additional reallocation-specific accounts (payer and system-program) on every initialization.

This PR adds a separate Reallocate instruction to handle the data resize and rent-exempt-reserve funding for a provided set of extensions.

First and last commits can be ignored for the purposes of discussion