### PR TITLE
token-2022: Fail to close account with withheld fees

### DIFF
--- a/token/program-2022/src/error.rs
+++ b/token/program-2022/src/error.rs
@@ -124,6 +124,10 @@ pub enum TokenError {
     /// The owner authority cannot be changed
     #[error("The owner authority cannot be changed")]
     ImmutableOwner,
+    /// An account can only be closed if its withheld fee balance is zero, harvest fees to the
+    /// mint and try again
+    #[error("An account can only be closed if its withheld fee balance is zero, harvest fees to the mint and try again")]
+    AccountHasWithheldTransferFees,
 }
 impl From<TokenError> for ProgramError {
     fn from(e: TokenError) -> Self {

--- a/token/program-2022/src/extension/transfer_fee/mod.rs
+++ b/token/program-2022/src/extension/transfer_fee/mod.rs
@@ -1,10 +1,11 @@
 use {
     crate::{
+        error::TokenError,
         extension::{Extension, ExtensionType},
         pod::*,
     },
     bytemuck::{Pod, Zeroable},
-    solana_program::clock::Epoch,
+    solana_program::{clock::Epoch, entrypoint::ProgramResult},
     std::{cmp, convert::TryFrom},
 };
 
@@ -89,6 +90,16 @@ impl Extension for TransferFeeConfig {
 pub struct TransferFeeAmount {
     /// Amount withheld during transfers, to be harvested to the mint
     pub withheld_amount: PodU64,
+}
+impl TransferFeeAmount {
+    /// Check if the extension is in a closable state
+    pub fn closable(&self) -> ProgramResult {
+        if self.withheld_amount == 0.into() {
+            Ok(())
+        } else {
+            Err(TokenError::AccountHasWithheldTransferFees.into())
+        }
+    }
 }
 impl Extension for TransferFeeAmount {
     const TYPE: ExtensionType = ExtensionType::TransferFeeAmount;

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -841,6 +841,11 @@ impl Processor {
             {
                 confidential_transfer_state.closable()?
             }
+
+            if let Ok(transfer_fee_state) = source_account.get_extension_mut::<TransferFeeAmount>()
+            {
+                transfer_fee_state.closable()?
+            }
         } else if let Ok(mut mint) =
             StateWithExtensionsMut::<Mint>::unpack(&mut source_account_data)
         {
@@ -1272,6 +1277,9 @@ impl PrintProgramError for TokenError {
             }
             TokenError::ImmutableOwner => {
                 msg!("The owner authority cannot be changed");
+            }
+            TokenError::AccountHasWithheldTransferFees => {
+                msg!("Error: An account can only be closed if its withheld fee balance is zero, harvest fees to the mint and try again");
             }
         }
     }

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -836,12 +836,16 @@ impl Processor {
                 account_info_iter.as_slice(),
             )?;
 
+            // TODO use get_extension when
+            // https://github.com/solana-labs/solana-program-library/pull/2822 lands
             if let Ok(confidential_transfer_state) =
                 source_account.get_extension_mut::<ConfidentialTransferAccount>()
             {
                 confidential_transfer_state.closable()?
             }
 
+            // TODO use get_extension when
+            // https://github.com/solana-labs/solana-program-library/pull/2822 lands
             if let Ok(transfer_fee_state) = source_account.get_extension_mut::<TransferFeeAmount>()
             {
                 transfer_fee_state.closable()?


### PR DESCRIPTION
#### Problem

It's possible to close a token account that still has withheld fees.

#### Solution

Prevent closing an account with withheld fees.