### PR TITLE
token-2022: Add delegate self-revoke

### DIFF
--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -152,11 +152,11 @@ pub enum TokenInstruction {
     ///
     ///   * Single owner
     ///   0. `[writable]` The source account.
-    ///   1. `[signer]` The source account owner.
+    ///   1. `[signer]` The source account owner or current delegate.
     ///
     ///   * Multisignature owner
     ///   0. `[writable]` The source account.
-    ///   1. `[]` The source account's multisignature owner.
+    ///   1. `[]` The source account's multisignature owner or current delegate.
     ///   2. ..2+M `[signer]` M signer accounts
     Revoke,
     /// Sets a new authority of a mint or account.

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -471,21 +471,32 @@ impl Processor {
     pub fn process_revoke(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
         let account_info_iter = &mut accounts.iter();
         let source_account_info = next_account_info(account_info_iter)?;
-        let owner_info = next_account_info(account_info_iter)?;
-        let owner_info_data_len = owner_info.data_len();
+        let authority_info = next_account_info(account_info_iter)?;
+        let authority_info_data_len = authority_info.data_len();
 
         let mut source_account = Account::unpack(&source_account_info.data.borrow())?;
         if source_account.is_frozen() {
             return Err(TokenError::AccountFrozen.into());
         }
 
-        Self::validate_owner(
-            program_id,
-            &source_account.owner,
-            owner_info,
-            owner_info_data_len,
-            account_info_iter.as_slice(),
-        )?;
+        match source_account.delegate {
+            COption::Some(ref delegate) if cmp_pubkeys(authority_info.key, delegate) => {
+                Self::validate_owner(
+                    program_id,
+                    delegate,
+                    authority_info,
+                    authority_info_data_len,
+                    account_info_iter.as_slice(),
+                )?;
+            }
+            _ => Self::validate_owner(
+                program_id,
+                &source_account.owner,
+                authority_info,
+                authority_info_data_len,
+                account_info_iter.as_slice(),
+            )?,
+        };
 
         source_account.delegate = COption::None;
         source_account.delegated_amount = 0;
@@ -3248,6 +3259,36 @@ mod tests {
             ],
         )
         .unwrap();
+
+        // approve to source
+        do_process_instruction_dups(
+            approve_checked(
+                &program_id,
+                &account2_key,
+                &mint_key,
+                &account2_key,
+                &owner_key,
+                &[],
+                500,
+                2,
+            )
+            .unwrap(),
+            vec![
+                account2_info.clone(),
+                mint_info.clone(),
+                account2_info.clone(),
+                owner_info.clone(),
+            ],
+        )
+        .unwrap();
+
+        // source-delegate revoke, force account2 to be a signer
+        let account2_info: AccountInfo = (&account2_key, true, &mut account2_account).into();
+        do_process_instruction_dups(
+            revoke(&program_id, &account2_key, &account2_key, &[]).unwrap(),
+            vec![account2_info.clone(), account2_info.clone()],
+        )
+        .unwrap();
     }
 
     #[test]
@@ -3453,6 +3494,44 @@ mod tests {
             vec![&mut account_account, &mut owner_account],
         )
         .unwrap();
+
+        // approve delegate 3
+        do_process_instruction(
+            approve_checked(
+                &program_id,
+                &account_key,
+                &mint_key,
+                &delegate_key,
+                &owner_key,
+                &[],
+                100,
+                2,
+            )
+            .unwrap(),
+            vec![
+                &mut account_account,
+                &mut mint_account,
+                &mut delegate_account,
+                &mut owner_account,
+            ],
+        )
+        .unwrap();
+
+        // revoke by delegate
+        do_process_instruction(
+            revoke(&program_id, &account_key, &delegate_key, &[]).unwrap(),
+            vec![&mut account_account, &mut delegate_account],
+        )
+        .unwrap();
+
+        // fails the second time
+        assert_eq!(
+            Err(TokenError::OwnerMismatch.into()),
+            do_process_instruction(
+                revoke(&program_id, &account_key, &delegate_key, &[]).unwrap(),
+                vec![&mut account_account, &mut delegate_account],
+            )
+        );
     }
 
     #[test]

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -479,24 +479,18 @@ impl Processor {
             return Err(TokenError::AccountFrozen.into());
         }
 
-        match source_account.delegate {
-            COption::Some(ref delegate) if cmp_pubkeys(authority_info.key, delegate) => {
-                Self::validate_owner(
-                    program_id,
-                    delegate,
-                    authority_info,
-                    authority_info_data_len,
-                    account_info_iter.as_slice(),
-                )?;
-            }
-            _ => Self::validate_owner(
-                program_id,
-                &source_account.owner,
-                authority_info,
-                authority_info_data_len,
-                account_info_iter.as_slice(),
-            )?,
-        };
+        Self::validate_owner(
+            program_id,
+            match source_account.delegate {
+                COption::Some(ref delegate) if cmp_pubkeys(authority_info.key, delegate) => {
+                    delegate
+                }
+                _ => &source_account.owner,
+            },
+            authority_info,
+            authority_info_data_len,
+            account_info_iter.as_slice(),
+        )?;
 
         source_account.delegate = COption::None;
         source_account.delegated_amount = 0;


### PR DESCRIPTION
#### Problem

Delegates cannot revoke themselves.  Currently, a delegate can only reset the delegate by transferring out the entire delegated amount, which is not great UX.

#### Solution

Let delegates also revoke.

Fixes #2747 