### PR TITLE
token-2022: complete memo extension functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3929,6 +3929,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "solana-zk-token-sdk",
+ "spl-memo 3.0.1",
  "spl-token 3.3.0",
  "thiserror",
 ]
@@ -3941,6 +3942,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-associated-token-account 1.0.5",
+ "spl-memo 3.0.1",
  "spl-token-2022",
  "spl-token-client",
  "walkdir",

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -18,5 +18,6 @@ async-trait = "0.1"
 solana-program-test = "=1.9.9"
 solana-sdk = "=1.9.9"
 spl-associated-token-account = { version = "1.0.5", path = "../../associated-token-account/program" }
+spl-memo = { version = "3.0.1", path = "../../memo/program", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "0.2", path="../program-2022", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.0.1", path = "../client" }

--- a/token/program-2022-test/tests/memo_transfer.rs
+++ b/token/program-2022-test/tests/memo_transfer.rs
@@ -3,12 +3,28 @@
 mod program_test;
 use {
     program_test::{TestContext, TokenContext},
-    solana_program_test::tokio,
-    solana_sdk::{pubkey::Pubkey, signature::Signer},
-    spl_token_2022::extension::{memo_transfer::MemoTransfer, ExtensionType},
+    solana_program_test::{
+        tokio::{self, sync::Mutex},
+        ProgramTestContext,
+    },
+    solana_sdk::{
+        instruction::InstructionError,
+        pubkey::Pubkey,
+        signature::Signer,
+        system_instruction,
+        transaction::{Transaction, TransactionError},
+        transport::TransportError,
+    },
+    spl_token_2022::{
+        error::TokenError,
+        extension::{memo_transfer::MemoTransfer, ExtensionType},
+    },
+    spl_token_client::token::TokenError as TokenClientError,
+    std::sync::Arc,
 };
 
 async fn test_memo_transfers(
+    context: Arc<Mutex<ProgramTestContext>>,
     token_context: TokenContext,
     alice_account: Pubkey,
     bob_account: Pubkey,
@@ -38,8 +54,62 @@ async fn test_memo_transfers(
     assert!(bool::from(extension.require_incoming_transfer_memos));
 
     // attempt to transfer from alice to bob without memo
-    // TODO: should fail when token/program-2022/src/processor.rs#L376 is completed
+    let err = token
+        .transfer_unchecked(&alice_account, &bob_account, &alice, 10)
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::NoMemo as u32)
+            )
+        )))
+    );
+    let bob_state = token.get_account_info(&bob_account).await.unwrap();
+    assert_eq!(bob_state.base.amount, 0);
+
+    // attempt to transfer from alice to bob with misplaced memo
+    let mut ctx = context.lock().await;
+    #[allow(deprecated)]
+    let instructions = vec![
+        spl_memo::build_memo(&[240, 159, 166, 150], &[]),
+        system_instruction::transfer(&ctx.payer.pubkey(), &alice.pubkey(), 42),
+        spl_token_2022::instruction::transfer(
+            &spl_token_2022::id(),
+            &alice_account,
+            &bob_account,
+            &alice.pubkey(),
+            &[],
+            10,
+        )
+        .unwrap(),
+    ];
+    let tx = Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer, &alice],
+        ctx.last_blockhash,
+    );
+    let err: TransactionError = ctx
+        .banks_client
+        .process_transaction(tx)
+        .await
+        .unwrap_err()
+        .unwrap()
+        .into();
+    drop(ctx);
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(2, InstructionError::Custom(TokenError::NoMemo as u32))
+    );
+    let bob_state = token.get_account_info(&bob_account).await.unwrap();
+    assert_eq!(bob_state.base.amount, 0);
+
+    // transfer with memo
     token
+        .with_memo("🦖")
         .transfer_unchecked(&alice_account, &bob_account, &alice, 10)
         .await
         .unwrap();
@@ -83,7 +153,7 @@ async fn require_memo_transfers_without_realloc() {
         .await
         .unwrap();
 
-    test_memo_transfers(token_context, alice_account, bob_account).await;
+    test_memo_transfers(context.context, token_context, alice_account, bob_account).await;
 }
 
 #[tokio::test]
@@ -113,5 +183,5 @@ async fn require_memo_transfers_with_realloc() {
         .await
         .unwrap();
 
-    test_memo_transfers(token_context, alice_account, bob_account).await;
+    test_memo_transfers(context.context, token_context, alice_account, bob_account).await;
 }

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -20,6 +20,7 @@ num-traits = "0.2"
 num_enum = "0.5.4"
 solana-program = "1.9.9"
 solana-zk-token-sdk = "0.6.0"
+spl-memo = { version = "3.0.1", path = "../../memo/program", features = [ "no-entrypoint" ] }
 spl-token = { version = "3.3",  path = "../program", features = ["no-entrypoint"] }
 thiserror = "1.0"
 

--- a/token/program-2022/src/error.rs
+++ b/token/program-2022/src/error.rs
@@ -135,6 +135,9 @@ pub enum TokenError {
     /// mint and try again
     #[error("An account can only be closed if its withheld fee balance is zero, harvest fees to the mint and try again")]
     AccountHasWithheldTransferFees,
+    /// No memo in previous instruction; required for recipient to receive a transfer
+    #[error("No memo in previous instruction; required for recipient to receive a transfer")]
+    NoMemo,
 }
 impl From<TokenError> for ProgramError {
     fn from(e: TokenError) -> Self {


### PR DESCRIPTION
Once v1.9.6 is released and incorporated into SPL, this will wrap-up the memo extension, using the `get_processed_sibling_instruction` syscall to flesh out the Transfer `if memo_required(&dest_account)` case.

@joncinque , wdyt about what I've done in the rust client here, adding Option<memo> to all the transfer methods? I liked that better than adding `_with_memo` versions of all of them, but open to other approaches. Also, probably it should take the memo as a String instead of bytes...?