### PR TITLE
associated-token-account: Add "CreateIdempotent" instruction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3526,11 +3526,15 @@ dependencies = [
 name = "spl-associated-token-account"
 version = "1.0.5"
 dependencies = [
+ "assert_matches",
  "borsh",
+ "num-derive",
+ "num-traits",
  "solana-program",
  "solana-program-test",
  "solana-sdk",
  "spl-token-2022",
+ "thiserror",
 ]
 
 [[package]]

--- a/associated-token-account/program/Cargo.toml
+++ b/associated-token-account/program/Cargo.toml
@@ -12,9 +12,13 @@ no-entrypoint = []
 test-bpf = []
 
 [dependencies]
+assert_matches = "1.5.0"
 borsh = "0.9.1"
+num-derive = "0.3"
+num-traits = "0.2"
 solana-program = "1.9.5"
 spl-token = { version = "0.1", path = "../../token/program-2022", package = "spl-token-2022", features = ["no-entrypoint"] }
+thiserror = "1.0"
 
 [dev-dependencies]
 solana-program-test = "1.9.5"

--- a/associated-token-account/program/src/error.rs
+++ b/associated-token-account/program/src/error.rs
@@ -1,0 +1,26 @@
+//! Error types
+
+use {
+    num_derive::FromPrimitive,
+    solana_program::{decode_error::DecodeError, program_error::ProgramError},
+    thiserror::Error,
+};
+
+/// Errors that may be returned by the program.
+#[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]
+pub enum AssociatedTokenAccountError {
+    // 0
+    /// Associated token account owner does not match address derivation
+    #[error("Associated token account owner does not match address derivation")]
+    InvalidOwner,
+}
+impl From<AssociatedTokenAccountError> for ProgramError {
+    fn from(e: AssociatedTokenAccountError) -> Self {
+        ProgramError::Custom(e as u32)
+    }
+}
+impl<T> DecodeError<T> for AssociatedTokenAccountError {
+    fn type_of() -> &'static str {
+        "AssociatedTokenAccountError"
+    }
+}

--- a/associated-token-account/program/src/lib.rs
+++ b/associated-token-account/program/src/lib.rs
@@ -3,6 +3,7 @@
 #![forbid(unsafe_code)]
 
 mod entrypoint;
+pub mod error;
 pub mod instruction;
 pub mod processor;
 pub mod tools;

--- a/associated-token-account/program/src/processor.rs
+++ b/associated-token-account/program/src/processor.rs
@@ -72,24 +72,24 @@ fn process_create_associated_token_account(
     let spl_token_program_info = next_account_info(account_info_iter)?;
     let spl_token_program_id = spl_token_program_info.key;
 
-    if create_mode == CreateMode::Idempotent {
-        if associated_token_account_info.owner == spl_token_program_id {
-            let ata_data = associated_token_account_info.data.borrow();
-            if let Ok(associated_token_account) = StateWithExtensions::<Account>::unpack(&ata_data)
-            {
-                if associated_token_account.base.owner != *wallet_account_info.key {
-                    let error = AssociatedTokenAccountError::InvalidOwner;
-                    msg!("{}", error);
-                    return Err(error.into());
-                }
-                if associated_token_account.base.mint != *spl_token_mint_info.key {
-                    return Err(ProgramError::InvalidAccountData);
-                }
-                return Ok(());
+    if create_mode == CreateMode::Idempotent
+        && associated_token_account_info.owner == spl_token_program_id
+    {
+        let ata_data = associated_token_account_info.data.borrow();
+        if let Ok(associated_token_account) = StateWithExtensions::<Account>::unpack(&ata_data) {
+            if associated_token_account.base.owner != *wallet_account_info.key {
+                let error = AssociatedTokenAccountError::InvalidOwner;
+                msg!("{}", error);
+                return Err(error.into());
             }
-        } else if *associated_token_account_info.owner != system_program::id() {
-            return Err(ProgramError::IllegalOwner);
+            if associated_token_account.base.mint != *spl_token_mint_info.key {
+                return Err(ProgramError::InvalidAccountData);
+            }
+            return Ok(());
         }
+    }
+    if *associated_token_account_info.owner != system_program::id() {
+        return Err(ProgramError::IllegalOwner);
     }
 
     let rent = Rent::get()?;

--- a/associated-token-account/program/src/processor.rs
+++ b/associated-token-account/program/src/processor.rs
@@ -2,6 +2,7 @@
 
 use {
     crate::{
+        error::AssociatedTokenAccountError,
         instruction::AssociatedTokenAccountInstruction,
         tools::account::{create_pda_account, get_account_len},
         *,
@@ -15,6 +16,7 @@ use {
         program_error::ProgramError,
         pubkey::Pubkey,
         rent::Rent,
+        system_program,
         sysvar::Sysvar,
     },
     spl_token::{extension::StateWithExtensions, state::Account},
@@ -26,7 +28,7 @@ enum CreateMode {
     /// Always try to create the ATA
     Always,
     /// Only try to create the ATA if non-existent
-    IfNonExistent,
+    Idempotent,
 }
 
 /// Instruction processor
@@ -48,8 +50,8 @@ pub fn process_instruction(
         AssociatedTokenAccountInstruction::Create => {
             process_create_associated_token_account(program_id, accounts, CreateMode::Always)
         }
-        AssociatedTokenAccountInstruction::CreateIfNonExistent => {
-            process_create_associated_token_account(program_id, accounts, CreateMode::IfNonExistent)
+        AssociatedTokenAccountInstruction::CreateIdempotent => {
+            process_create_associated_token_account(program_id, accounts, CreateMode::Idempotent)
         }
     }
 }
@@ -70,18 +72,23 @@ fn process_create_associated_token_account(
     let spl_token_program_info = next_account_info(account_info_iter)?;
     let spl_token_program_id = spl_token_program_info.key;
 
-    if create_mode == CreateMode::IfNonExistent
-        && associated_token_account_info.owner == spl_token_program_id
-    {
-        let ata_data = associated_token_account_info.data.borrow();
-        if let Ok(associated_token_account) = StateWithExtensions::<Account>::unpack(&ata_data) {
-            if associated_token_account.base.owner != *wallet_account_info.key {
-                return Err(ProgramError::IllegalOwner);
+    if create_mode == CreateMode::Idempotent {
+        if associated_token_account_info.owner == spl_token_program_id {
+            let ata_data = associated_token_account_info.data.borrow();
+            if let Ok(associated_token_account) = StateWithExtensions::<Account>::unpack(&ata_data)
+            {
+                if associated_token_account.base.owner != *wallet_account_info.key {
+                    let error = AssociatedTokenAccountError::InvalidOwner;
+                    msg!("{}", error);
+                    return Err(error.into());
+                }
+                if associated_token_account.base.mint != *spl_token_mint_info.key {
+                    return Err(ProgramError::InvalidAccountData);
+                }
+                return Ok(());
             }
-            if associated_token_account.base.mint != *spl_token_mint_info.key {
-                return Err(ProgramError::InvalidAccountData);
-            }
-            return Ok(());
+        } else if *associated_token_account_info.owner != system_program::id() {
+            return Err(ProgramError::IllegalOwner);
         }
     }
 

--- a/associated-token-account/program/tests/create_idempotent.rs
+++ b/associated-token-account/program/tests/create_idempotent.rs
@@ -11,7 +11,6 @@ use {
         program_option::COption,
         program_pack::Pack,
         signature::Signer,
-        system_instruction::SystemError,
         transaction::{Transaction, TransactionError},
     },
     spl_associated_token_account::{
@@ -88,10 +87,7 @@ async fn success_account_exists() {
             .await
             .unwrap_err()
             .unwrap(),
-        TransactionError::InstructionError(
-            0,
-            InstructionError::Custom(SystemError::AccountAlreadyInUse as u32)
-        )
+        TransactionError::InstructionError(0, InstructionError::IllegalOwner)
     );
 
     // Get a new blockhash, succeed with create if non existent

--- a/associated-token-account/program/tests/create_if_non_existent.rs
+++ b/associated-token-account/program/tests/create_if_non_existent.rs
@@ -1,0 +1,175 @@
+#![cfg(feature = "test-bpf")]
+
+mod program_test;
+
+use {
+    program_test::program_test,
+    solana_program::{instruction::*, pubkey::Pubkey},
+    solana_program_test::*,
+    solana_sdk::{
+        account::Account as SolanaAccount,
+        program_option::COption,
+        program_pack::Pack,
+        signature::Signer,
+        system_instruction::SystemError,
+        transaction::{Transaction, TransactionError},
+    },
+    spl_associated_token_account::{
+        get_associated_token_address,
+        instruction::{
+            create_associated_token_account, create_associated_token_account_if_non_existent,
+        },
+    },
+    spl_token::{
+        extension::ExtensionType,
+        state::{Account, AccountState},
+    },
+};
+
+#[tokio::test]
+async fn success_account_exists() {
+    let wallet_address = Pubkey::new_unique();
+    let token_mint_address = Pubkey::new_unique();
+    let associated_token_address =
+        get_associated_token_address(&wallet_address, &token_mint_address);
+
+    let (mut banks_client, payer, recent_blockhash) =
+        program_test(token_mint_address, true).start().await;
+    let rent = banks_client.get_rent().await.unwrap();
+    let expected_token_account_len =
+        ExtensionType::get_account_len::<spl_token::state::Account>(&[
+            ExtensionType::ImmutableOwner,
+        ]);
+    let expected_token_account_balance = rent.minimum_balance(expected_token_account_len);
+
+    let instruction = create_associated_token_account_if_non_existent(
+        &payer.pubkey(),
+        &wallet_address,
+        &token_mint_address,
+        &spl_token::id(),
+    );
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&payer.pubkey()),
+        &[&payer],
+        recent_blockhash,
+    );
+    banks_client.process_transaction(transaction).await.unwrap();
+
+    // Associated account now exists
+    let associated_account = banks_client
+        .get_account(associated_token_address)
+        .await
+        .expect("get_account")
+        .expect("associated_account not none");
+    assert_eq!(associated_account.data.len(), expected_token_account_len);
+    assert_eq!(associated_account.owner, spl_token::id());
+    assert_eq!(associated_account.lamports, expected_token_account_balance);
+
+    // Old instruction fails
+    let instruction = create_associated_token_account(
+        &payer.pubkey(),
+        &wallet_address,
+        &token_mint_address,
+        &spl_token::id(),
+    );
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&payer.pubkey()),
+        &[&payer],
+        recent_blockhash,
+    );
+    assert_eq!(
+        banks_client
+            .process_transaction(transaction)
+            .await
+            .unwrap_err()
+            .unwrap(),
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(SystemError::AccountAlreadyInUse as u32)
+        )
+    );
+
+    // Get a new blockhash, succeed with create if non existent
+    let recent_blockhash = banks_client
+        .get_new_latest_blockhash(&recent_blockhash)
+        .await
+        .unwrap();
+
+    let instruction = create_associated_token_account_if_non_existent(
+        &payer.pubkey(),
+        &wallet_address,
+        &token_mint_address,
+        &spl_token::id(),
+    );
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&payer.pubkey()),
+        &[&payer],
+        recent_blockhash,
+    );
+    banks_client.process_transaction(transaction).await.unwrap();
+
+    // Associated account is unchanged
+    let associated_account = banks_client
+        .get_account(associated_token_address)
+        .await
+        .expect("get_account")
+        .expect("associated_account not none");
+    assert_eq!(associated_account.data.len(), expected_token_account_len);
+    assert_eq!(associated_account.owner, spl_token::id());
+    assert_eq!(associated_account.lamports, expected_token_account_balance);
+}
+
+#[tokio::test]
+async fn fail_account_exists_with_wrong_owner() {
+    let wallet_address = Pubkey::new_unique();
+    let token_mint_address = Pubkey::new_unique();
+    let associated_token_address =
+        get_associated_token_address(&wallet_address, &token_mint_address);
+
+    let wrong_owner = Pubkey::new_unique();
+    let mut associated_token_account =
+        SolanaAccount::new(1_000_000_000, Account::LEN, &spl_token::id());
+    let token_account = Account {
+        mint: token_mint_address,
+        owner: wrong_owner,
+        amount: 0,
+        delegate: COption::None,
+        state: AccountState::Initialized,
+        is_native: COption::None,
+        delegated_amount: 0,
+        close_authority: COption::None,
+    };
+    Account::pack(token_account, &mut associated_token_account.data).unwrap();
+    let mut pt = program_test(token_mint_address, true);
+    pt.add_account(associated_token_address, associated_token_account);
+    let (mut banks_client, payer, recent_blockhash) = pt.start().await;
+
+    // fail creating token account if non existent
+    let instruction = create_associated_token_account_if_non_existent(
+        &payer.pubkey(),
+        &wallet_address,
+        &token_mint_address,
+        &spl_token::id(),
+    );
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&payer.pubkey()),
+        &[&payer],
+        recent_blockhash,
+    );
+
+    assert_eq!(
+        banks_client
+            .process_transaction(transaction)
+            .await
+            .unwrap_err()
+            .unwrap(),
+        TransactionError::InstructionError(0, InstructionError::IllegalOwner)
+    );
+}

--- a/associated-token-account/program/tests/process_create_associated_token_account.rs
+++ b/associated-token-account/program/tests/process_create_associated_token_account.rs
@@ -213,7 +213,7 @@ async fn test_create_account_mismatch() {
             .await
             .unwrap_err()
             .unwrap(),
-        TransactionError::InstructionError(0, InstructionError::InvalidSeeds)
+        TransactionError::InstructionError(0, InstructionError::IllegalOwner)
     );
 
     let mut instruction = create_associated_token_account(


### PR DESCRIPTION
Fixes #2295

#### Problem

Lots of ATA transactions fail because they all try to create the account.

#### Solution

Add a `CreateIfNonExistent` instruction. I'm up for any better names!