### PR TITLE
token-2022: Force refresh blockhash on no-op transaction

### DIFF
--- a/token/program-2022/tests/reallocate.rs
+++ b/token/program-2022/tests/reallocate.rs
@@ -93,6 +93,7 @@ async fn reallocate() {
     );
 
     // reallocate succeeds with noop if account is already large enough
+    token.get_new_latest_blockhash().await.unwrap();
     token
         .reallocate(&alice_account, &alice, &[ExtensionType::ImmutableOwner])
         .await


### PR DESCRIPTION
#### Problem

The realloc test can be flaky due to the no-op repeated transaction.

#### Solution

Force-refresh the blockhash in the test.  The implementation is stolen from `program-test`'s extension to `BanksClient` of `get_new_latest_blockhash`.