### PR TITLE
token-2022: Allow anyone to burn/close an Account owned by the system program or the incinerator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3940,6 +3940,7 @@ name = "spl-token-2022-test"
 version = "0.0.1"
 dependencies = [
  "async-trait",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
  "spl-associated-token-account 1.0.5",

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -15,6 +15,7 @@ walkdir = "2"
 
 [dev-dependencies]
 async-trait = "0.1"
+solana-program = "=1.9.9"
 solana-program-test = "=1.9.9"
 solana-sdk = "=1.9.9"
 spl-associated-token-account = { version = "1.0.5", path = "../../associated-token-account/program" }

--- a/token/program-2022-test/tests/burn.rs
+++ b/token/program-2022-test/tests/burn.rs
@@ -149,3 +149,79 @@ async fn self_owned_with_extension() {
         .unwrap();
     run_self_owned(context).await;
 }
+
+async fn run_burn_and_close_system_or_incinerator(context: TestContext, non_owner: &Pubkey) {
+    let TokenContext {
+        decimals,
+        mint_authority,
+        token,
+        alice,
+        ..
+    } = context.token_context.unwrap();
+
+    let alice_account = Keypair::new();
+    let alice_account = token
+        .create_auxiliary_token_account(&alice_account, &alice.pubkey())
+        .await
+        .unwrap();
+
+    // mint a token
+    token
+        .mint_to(&alice_account, &mint_authority, 1)
+        .await
+        .unwrap();
+
+    // transfer token to incinerator/system
+    let non_owner_account = Keypair::new();
+    let non_owner_account = token
+        .create_auxiliary_token_account(&non_owner_account, non_owner)
+        .await
+        .unwrap();
+    token
+        .transfer_checked(&alice_account, &non_owner_account, &alice, 1, decimals)
+        .await
+        .unwrap();
+
+    // can't close when holding tokens
+    let carlos = Keypair::new();
+    let error = token
+        .close_account(&non_owner_account, &carlos.pubkey(), &carlos)
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::NonNativeHasBalance as u32)
+            )
+        )))
+    );
+
+    // but anyone can burn it
+    token
+        .burn_checked(&non_owner_account, &carlos, 1, decimals)
+        .await
+        .unwrap();
+
+    // ... and then close it
+    token.get_new_latest_blockhash().await.unwrap();
+    token
+        .close_account(&non_owner_account, &carlos.pubkey(), &carlos)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn burn_and_close_incinerator_tokens() {
+    let mut context = TestContext::new().await;
+    context.init_token_with_mint(vec![]).await.unwrap();
+    run_burn_and_close_system_or_incinerator(context, &solana_program::incinerator::id()).await;
+}
+
+#[tokio::test]
+async fn burn_and_close_system_tokens() {
+    let mut context = TestContext::new().await;
+    context.init_token_with_mint(vec![]).await.unwrap();
+    run_burn_and_close_system_or_incinerator(context, &solana_program::system_program::id()).await;
+}

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -784,35 +784,40 @@ impl Processor {
             }
         }
 
-        match source_account.base.delegate {
-            COption::Some(ref delegate) if cmp_pubkeys(authority_info.key, delegate) => {
-                Self::validate_owner(
+        if !source_account
+            .base
+            .is_owned_by_system_program_or_incinerator()
+        {
+            match source_account.base.delegate {
+                COption::Some(ref delegate) if cmp_pubkeys(authority_info.key, delegate) => {
+                    Self::validate_owner(
+                        program_id,
+                        delegate,
+                        authority_info,
+                        authority_info_data_len,
+                        account_info_iter.as_slice(),
+                    )?;
+
+                    if source_account.base.delegated_amount < amount {
+                        return Err(TokenError::InsufficientFunds.into());
+                    }
+                    source_account.base.delegated_amount = source_account
+                        .base
+                        .delegated_amount
+                        .checked_sub(amount)
+                        .ok_or(TokenError::Overflow)?;
+                    if source_account.base.delegated_amount == 0 {
+                        source_account.base.delegate = COption::None;
+                    }
+                }
+                _ => Self::validate_owner(
                     program_id,
-                    delegate,
+                    &source_account.base.owner,
                     authority_info,
                     authority_info_data_len,
                     account_info_iter.as_slice(),
-                )?;
-
-                if source_account.base.delegated_amount < amount {
-                    return Err(TokenError::InsufficientFunds.into());
-                }
-                source_account.base.delegated_amount = source_account
-                    .base
-                    .delegated_amount
-                    .checked_sub(amount)
-                    .ok_or(TokenError::Overflow)?;
-                if source_account.base.delegated_amount == 0 {
-                    source_account.base.delegate = COption::None;
-                }
+                )?,
             }
-            _ => Self::validate_owner(
-                program_id,
-                &source_account.base.owner,
-                authority_info,
-                authority_info_data_len,
-                account_info_iter.as_slice(),
-            )?,
         }
 
         // Revisit this later to see if it's worth adding a check to reduce
@@ -861,13 +866,18 @@ impl Processor {
                 .close_authority
                 .unwrap_or(source_account.base.owner);
 
-            Self::validate_owner(
-                program_id,
-                &authority,
-                authority_info,
-                authority_info_data_len,
-                account_info_iter.as_slice(),
-            )?;
+            if !source_account
+                .base
+                .is_owned_by_system_program_or_incinerator()
+            {
+                Self::validate_owner(
+                    program_id,
+                    &authority,
+                    authority_info,
+                    authority_info_data_len,
+                    account_info_iter.as_slice(),
+                )?;
+            }
 
             if let Ok(confidential_transfer_state) =
                 source_account.get_extension::<ConfidentialTransferAccount>()

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -877,6 +877,8 @@ impl Processor {
                     authority_info_data_len,
                     account_info_iter.as_slice(),
                 )?;
+            } else if !solana_program::incinerator::check_id(destination_account_info.key) {
+                return Err(ProgramError::InvalidAccountData);
             }
 
             if let Ok(confidential_transfer_state) =

--- a/token/program-2022/src/state.rs
+++ b/token/program-2022/src/state.rs
@@ -116,6 +116,11 @@ impl Account {
     pub fn is_native(&self) -> bool {
         self.is_native.is_some()
     }
+    /// Checks if a token Account's owner is the system_program or the incinerator
+    pub fn is_owned_by_system_program_or_incinerator(&self) -> bool {
+        solana_program::system_program::check_id(&self.owner)
+            || solana_program::incinerator::check_id(&self.owner)
+    }
 }
 impl Sealed for Account {}
 impl IsInitialized for Account {

--- a/token/program/src/state.rs
+++ b/token/program/src/state.rs
@@ -113,6 +113,11 @@ impl Account {
     pub fn is_native(&self) -> bool {
         self.is_native.is_some()
     }
+    /// Checks if a token Account's owner is the system_program or the incinerator
+    pub fn is_owned_by_system_program_or_incinerator(&self) -> bool {
+        solana_program::system_program::check_id(&self.owner)
+            || solana_program::incinerator::check_id(&self.owner)
+    }
 }
 impl Sealed for Account {}
 impl IsInitialized for Account {


### PR DESCRIPTION
#### Problem

The Incinerator and the System Program both own tons of token accounts due to incorrect burning procedures, wasting validator disk space.

#### Solution

If a token account is owned by one of those addresses, bypass owner/signer checks for burn and close. This allows anyone to burn those token accounts, as well as close them. The rent SOL must be burned, so close will fail if the incinerator is not passed in as the recipient.