### PR TITLE
Governance: Use correct max size for multiple instruction transaction

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -9,4 +9,4 @@ cluster = "mainnet"
 wallet = "~/.config/solana/id.json"
 
 [programs.mainnet]
-spl_governance = "GoVEr6xcF9QGrRFJC4kt9wiCdNqZzrG7KWdrm7viDnpa"
+spl_governance = "GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3621,7 +3621,7 @@ dependencies = [
 
 [[package]]
 name = "spl-governance"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "arrayref",
  "assert_matches",

--- a/governance/chat/program/Cargo.toml
+++ b/governance/chat/program/Cargo.toml
@@ -21,7 +21,7 @@ serde = "1.0.127"
 serde_derive = "1.0.103"
 solana-program = "1.9.5"
 spl-token = { version = "3.3", path = "../../../token/program", features = [ "no-entrypoint" ] }
-spl-governance= { version = "2.2.2", path ="../../program", features = [ "no-entrypoint" ]}
+spl-governance= { version = "2.2.3", path ="../../program", features = [ "no-entrypoint" ]}
 spl-governance-tools= { version = "0.1.2", path ="../../tools"}
 spl-governance-addin-api= { version = "0.1.1", path ="../../addin-api"}
 thiserror = "1.0"

--- a/governance/program/Cargo.toml
+++ b/governance/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-governance"
-version = "2.2.2"
+version = "2.2.3"
 description = "Solana Program Library Governance Program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/governance/program/src/state/proposal_transaction.rs
+++ b/governance/program/src/state/proposal_transaction.rs
@@ -272,6 +272,7 @@ mod test {
             accounts: vec![
                 create_test_account_meta_data(),
                 create_test_account_meta_data(),
+                create_test_account_meta_data(),
             ],
             data: vec![1, 2, 3],
         }]

--- a/governance/program/src/state/proposal_transaction.rs
+++ b/governance/program/src/state/proposal_transaction.rs
@@ -125,11 +125,10 @@ impl AccountMaxSize for ProposalTransactionV2 {
         let instructions_size = self
             .instructions
             .iter()
-            .map(|i| i.accounts.len() * 34 + i.data.len())
-            .sum::<usize>()
-            + 4;
+            .map(|i| i.accounts.len() * 34 + i.data.len() + 40)
+            .sum::<usize>();
 
-        Some(instructions_size + 98)
+        Some(instructions_size + 62)
     }
 }
 


### PR DESCRIPTION
#### Summary 

`max_size` is not calculated correctly for `ProposalTransaction` with multiple instructions and serialisation fails

#### Implementation

- Fix  `max_size` calculation and add serialisation test with multiple instructions 
- Bump version to 2.2.3
