### PR TITLE
token-2022: Add CreateNativeMint instruction

### DIFF
--- a/token/program-2022-test/tests/initialize_mint.rs
+++ b/token/program-2022-test/tests/initialize_mint.rs
@@ -17,7 +17,7 @@ use {
     spl_token_2022::{
         error::TokenError,
         extension::{mint_close_authority::MintCloseAuthority, transfer_fee, ExtensionType},
-        instruction,
+        instruction, native_mint,
         state::Mint,
     },
     spl_token_client::token::ExtensionInitializationParams,
@@ -473,4 +473,18 @@ async fn fail_fee_init_after_mint_init() {
         err,
         TransactionError::InstructionError(1, InstructionError::InvalidAccountData)
     );
+}
+
+#[tokio::test]
+async fn create_native_mint() {
+    let mut context = TestContext::new().await;
+    context.init_token_with_native_mint().await.unwrap();
+    let TokenContext { token, .. } = context.token_context.unwrap();
+
+    let mint = token.get_mint_info().await.unwrap();
+    assert_eq!(mint.base.decimals, native_mint::DECIMALS);
+    assert_eq!(mint.base.mint_authority, COption::None,);
+    assert_eq!(mint.base.supply, 0);
+    assert!(mint.base.is_initialized);
+    assert_eq!(mint.base.freeze_authority, COption::None);
 }

--- a/token/program-2022-test/tests/program_test.rs
+++ b/token/program-2022-test/tests/program_test.rs
@@ -3,7 +3,7 @@
 use {
     solana_program_test::{processor, tokio::sync::Mutex, ProgramTest, ProgramTestContext},
     solana_sdk::signer::{keypair::Keypair, Signer},
-    spl_token_2022::{id, processor::Processor},
+    spl_token_2022::{id, native_mint, processor::Processor},
     spl_token_client::{
         client::{ProgramBanksClient, ProgramBanksClientProcessTransaction, ProgramClient},
         token::{ExtensionInitializationParams, Token, TokenResult},
@@ -95,6 +95,26 @@ impl TestContext {
             freeze_authority,
         });
 
+        Ok(())
+    }
+
+    pub async fn init_token_with_native_mint(&mut self) -> TokenResult<()> {
+        let payer = keypair_clone(&self.context.lock().await.payer);
+        let client: Arc<dyn ProgramClient<ProgramBanksClientProcessTransaction>> =
+            Arc::new(ProgramBanksClient::new_from_context(
+                Arc::clone(&self.context),
+                ProgramBanksClientProcessTransaction,
+            ));
+
+        let token = Token::create_native_mint(Arc::clone(&client), &id(), payer).await?;
+        self.token_context = Some(TokenContext {
+            decimals: native_mint::DECIMALS,
+            mint_authority: Keypair::new(), /*bogus*/
+            token,
+            alice: Keypair::new(),
+            bob: Keypair::new(),
+            freeze_authority: None,
+        });
         Ok(())
     }
 }

--- a/token/program-2022/src/native_mint.rs
+++ b/token/program-2022/src/native_mint.rs
@@ -4,11 +4,17 @@
 pub const DECIMALS: u8 = 9;
 
 // The Mint for native SOL Token accounts
-solana_program::declare_id!("So11111111111111111111111111111111111111112");
+solana_program::declare_id!("9pan9bMn5HatX4EJdBwg9VgCa7Uz5HL8N1m5D3NdXejP");
+
+/// Seed for the native_mint's program-derived address
+pub const PROGRAM_ADDRESS_SEEDS: &[&[u8]] = &["native-mint".as_bytes(), &[255]];
 
 #[cfg(test)]
 mod tests {
-    use {super::*, solana_program::native_token::*};
+    use {
+        super::*,
+        solana_program::{native_token::*, pubkey::Pubkey},
+    };
 
     #[test]
     fn test_decimals() {
@@ -19,5 +25,12 @@ mod tests {
             sol_to_lamports(42.),
             crate::ui_amount_to_amount(42., DECIMALS)
         );
+    }
+
+    #[test]
+    fn expected_native_mint_id() {
+        let native_mint_id =
+            Pubkey::create_program_address(PROGRAM_ADDRESS_SEEDS, &crate::id()).unwrap();
+        assert_eq!(id(), native_mint_id);
     }
 }

--- a/token/rust/src/token.rs
+++ b/token/rust/src/token.rs
@@ -17,7 +17,7 @@ use spl_token_2022::{
     extension::{
         default_account_state, memo_transfer, transfer_fee, ExtensionType, StateWithExtensionsOwned,
     },
-    instruction,
+    instruction, native_mint,
     state::{Account, AccountState, Mint},
 };
 use std::{
@@ -268,6 +268,26 @@ where
             decimals,
         )?);
         token.process_ixs(&instructions, &[mint_account]).await?;
+
+        Ok(token)
+    }
+
+    /// Create native mint
+    pub async fn create_native_mint(
+        client: Arc<dyn ProgramClient<T>>,
+        program_id: &Pubkey,
+        payer: S,
+    ) -> TokenResult<Self> {
+        let token = Self::new(client, program_id, &native_mint::id(), payer);
+        token
+            .process_ixs(
+                &[instruction::create_native_mint(
+                    program_id,
+                    &token.payer.pubkey(),
+                )?],
+                &[&token.payer],
+            )
+            .await?;
 
         Ok(token)
     }


### PR DESCRIPTION
The native mint for SPL token was [forged by special case](https://github.com/solana-labs/solana/blob/a7598b6d78808aeab52923a4cc4137017538b9df/runtime/src/bank.rs#L6454-L6493).  For token-2022, add an idempotent instruction to create the native mint instead. This means token-2022's WSOL mint doesn't get a vanity address, something we'll all need to find a way to live with.