### PR TITLE
associated-token-account: Fail create idempotent for non-ata

### DIFF
--- a/associated-token-account/program/src/processor.rs
+++ b/associated-token-account/program/src/processor.rs
@@ -72,6 +72,17 @@ fn process_create_associated_token_account(
     let spl_token_program_info = next_account_info(account_info_iter)?;
     let spl_token_program_id = spl_token_program_info.key;
 
+    let (associated_token_address, bump_seed) = get_associated_token_address_and_bump_seed_internal(
+        wallet_account_info.key,
+        spl_token_mint_info.key,
+        program_id,
+        spl_token_program_id,
+    );
+    if associated_token_address != *associated_token_account_info.key {
+        msg!("Error: Associated address does not match seed derivation");
+        return Err(ProgramError::InvalidSeeds);
+    }
+
     if create_mode == CreateMode::Idempotent
         && associated_token_account_info.owner == spl_token_program_id
     {
@@ -93,17 +104,6 @@ fn process_create_associated_token_account(
     }
 
     let rent = Rent::get()?;
-
-    let (associated_token_address, bump_seed) = get_associated_token_address_and_bump_seed_internal(
-        wallet_account_info.key,
-        spl_token_mint_info.key,
-        program_id,
-        spl_token_program_id,
-    );
-    if associated_token_address != *associated_token_account_info.key {
-        msg!("Error: Associated address does not match seed derivation");
-        return Err(ProgramError::InvalidSeeds);
-    }
 
     let associated_token_account_signer_seeds: &[&[_]] = &[
         &wallet_account_info.key.to_bytes(),

--- a/associated-token-account/program/tests/process_create_associated_token_account.rs
+++ b/associated-token-account/program/tests/process_create_associated_token_account.rs
@@ -213,7 +213,7 @@ async fn test_create_account_mismatch() {
             .await
             .unwrap_err()
             .unwrap(),
-        TransactionError::InstructionError(0, InstructionError::IllegalOwner)
+        TransactionError::InstructionError(0, InstructionError::InvalidSeeds)
     );
 
     let mut instruction = create_associated_token_account(


### PR DESCRIPTION
#### Problem

The `CreateIdempotent` instruction gives a false positive on valid non-associated token accounts.

#### Solution

Move the address derivation check higher to be covered by `CreateIdempotent`.

Thanks @ryoqun for noticing this!