### PR TITLE
stake-pool: Bump version for release, add to Anchor

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -2,7 +2,10 @@ anchor_version = "0.20.1"
 solana_version = "1.9.5"
 
 [workspace]
-members = ["governance/program"]
+members = [
+  "governance/program",
+  "stake-pool/program",
+]
 
 [provider]
 cluster = "mainnet"
@@ -10,3 +13,4 @@ wallet = "~/.config/solana/id.json"
 
 [programs.mainnet]
 spl_governance = "GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw"
+spl_stake_pool = "SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3816,7 +3816,7 @@ dependencies = [
 
 [[package]]
 name = "spl-stake-pool"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "arrayref",
  "bincode",
@@ -3838,7 +3838,7 @@ dependencies = [
 
 [[package]]
 name = "spl-stake-pool-cli"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "bincode",
  "borsh",

--- a/stake-pool/cli/Cargo.toml
+++ b/stake-pool/cli/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://spl.solana.com/stake-pool"
 license = "Apache-2.0"
 name = "spl-stake-pool-cli"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "0.6.3"
+version = "0.6.4"
 
 [dependencies]
 borsh = "0.9"
@@ -17,15 +17,15 @@ serde_json = "1.0.68"
 solana-account-decoder = "=1.9.5"
 solana-clap-utils = "=1.9.5"
 solana-cli-config = "=1.9.5"
-solana-cli-output = "1.9.5"
+solana-cli-output = "=1.9.5"
 solana-client = "=1.9.5"
 solana-logger = "=1.9.5"
 solana-program = "=1.9.5"
 solana-remote-wallet = "=1.9.5"
 solana-sdk = "=1.9.5"
-spl-associated-token-account = { version = "1.0.5", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
-spl-stake-pool = { version = "0.6", path="../program", features = [ "no-entrypoint" ] }
-spl-token = { version = "3.3", path="../../token/program", features = [ "no-entrypoint" ]  }
+spl-associated-token-account = { version = "=1.0.5", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
+spl-stake-pool = { version = "=0.6.4", path="../program", features = [ "no-entrypoint" ] }
+spl-token = { version = "=3.3.0", path="../../token/program", features = [ "no-entrypoint" ]  }
 bs58 = "0.4.0"
 bincode = "1.3.1"
 

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-stake-pool"
-version = "0.6.3"
+version = "0.6.4"
 description = "Solana Program Library Stake Pool"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"


### PR DESCRIPTION
For the new stake pool release, bump everything to 0.6.4, and also add the stake pool to `Anchor.toml` to easily do verifiable builds and publish the source to the Anchor registry.