### PR TITLE
token-2022: Support extensions in `SyncNative`

### DIFF
--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -722,6 +722,15 @@ where
         .await
     }
 
+    /// Sync native account lamports
+    pub async fn sync_native(&self, account: &Pubkey) -> TokenResult<T::Output> {
+        self.process_ixs::<[&dyn Signer; 0]>(
+            &[instruction::sync_native(&self.program_id, account)?],
+            &[],
+        )
+        .await
+    }
+
     /// Set transfer fee
     pub async fn set_transfer_fee<S2: Signer>(
         &self,

--- a/token/program-2022-test/tests/sync_native.rs
+++ b/token/program-2022-test/tests/sync_native.rs
@@ -1,0 +1,82 @@
+#![cfg(feature = "test-bpf")]
+
+mod program_test;
+use {
+    program_test::{TestContext, TokenContext},
+    solana_program_test::{
+        tokio::{self, sync::Mutex},
+        ProgramTestContext,
+    },
+    solana_sdk::{
+        pubkey::Pubkey, signature::Signer, signer::keypair::Keypair, system_instruction,
+        transaction::Transaction,
+    },
+    spl_token_2022::extension::ExtensionType,
+    spl_token_client::{client::ProgramBanksClientProcessTransaction, token::Token},
+    std::sync::Arc,
+};
+
+async fn run_basic(
+    token: Token<ProgramBanksClientProcessTransaction, Keypair>,
+    context: Arc<Mutex<ProgramTestContext>>,
+    account: Pubkey,
+) {
+    let account_info = token.get_account_info(&account).await.unwrap();
+    assert_eq!(account_info.base.amount, 0);
+
+    // system transfer to account
+    let amount = 1_000;
+    {
+        let mut context = context.lock().await;
+        let instructions = vec![system_instruction::transfer(
+            &context.payer.pubkey(),
+            &account,
+            amount,
+        )];
+        let tx = Transaction::new_signed_with_payer(
+            &instructions,
+            Some(&context.payer.pubkey()),
+            &[&context.payer],
+            context.last_blockhash,
+        );
+        context.banks_client.process_transaction(tx).await.unwrap();
+    }
+    let account_info = token.get_account_info(&account).await.unwrap();
+    assert_eq!(account_info.base.amount, 0);
+
+    token.sync_native(&account).await.unwrap();
+    let account_info = token.get_account_info(&account).await.unwrap();
+    assert_eq!(account_info.base.amount, amount);
+}
+
+#[tokio::test]
+async fn basic() {
+    let mut context = TestContext::new().await;
+    context.init_token_with_native_mint().await.unwrap();
+    let TokenContext { token, alice, .. } = context.token_context.unwrap();
+    let context = context.context.clone();
+
+    let account = token
+        .create_auxiliary_token_account(&Keypair::new(), &alice.pubkey())
+        .await
+        .unwrap();
+    run_basic(token, context, account).await;
+}
+
+#[tokio::test]
+async fn basic_with_extension() {
+    let mut context = TestContext::new().await;
+    context.init_token_with_native_mint().await.unwrap();
+    let TokenContext { token, alice, .. } = context.token_context.unwrap();
+    let context = context.context.clone();
+
+    let account = token
+        .create_auxiliary_token_account_with_extension_space(
+            &Keypair::new(),
+            &alice.pubkey(),
+            vec![ExtensionType::ImmutableOwner],
+        )
+        .await
+        .unwrap();
+    run_basic(token, context, account).await;
+}


### PR DESCRIPTION
#### Problem

Extensions aren't supported in `SyncNative`, so native accounts created with `ImmutableOwner`, as done with ATA, fail to sync.  This PR assumes that we want native mint accounts to support extensions, which for `ImmutableOwner`, makes sense to me.  We'll have to write a carve-out for the native mint in confidential transfers though.

#### Solution

Use `StateWithExtensionsMut` in `process_sync_native`.