### PR TITLE
Custom build.rs for program-2022-test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3942,6 +3942,7 @@ dependencies = [
  "spl-associated-token-account 1.0.5",
  "spl-token-2022",
  "spl-token-client",
+ "walkdir",
 ]
 
 [[package]]

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -10,6 +10,9 @@ version = "0.0.1"
 [features]
 test-bpf = []
 
+[build-dependencies]
+walkdir = "2"
+
 [dev-dependencies]
 async-trait = "0.1"
 solana-program-test = "=1.9.5"

--- a/token/program-2022-test/build.rs
+++ b/token/program-2022-test/build.rs
@@ -41,8 +41,14 @@ fn main() {
     let spl_token_2022_toml = spl_token_2022_dir.join("Cargo.toml");
     let spl_token_2022_toml = format!("{}", spl_token_2022_toml.display());
     let args = vec!["build-bpf", "--manifest-path", &spl_token_2022_toml];
-    let _output = Command::new("cargo")
+    let output = Command::new("cargo")
         .args(&args)
         .output()
         .expect("Error running cargo build-bpf");
+    if let Ok(output_str) = std::str::from_utf8(&output.stdout) {
+        let subs = output_str.split('\n');
+        for sub in subs {
+            println!("cargo:warning=(not a warning) {}", sub);
+        }
+    }
 }

--- a/token/program-2022-test/build.rs
+++ b/token/program-2022-test/build.rs
@@ -1,0 +1,48 @@
+extern crate walkdir;
+
+use {
+    std::{env, path::Path, process::Command},
+    walkdir::WalkDir,
+};
+
+fn rerun_if_changed(directory: &Path) {
+    let src = directory.join("src");
+    let files_in_src: Vec<_> = WalkDir::new(src)
+        .into_iter()
+        .map(|entry| entry.unwrap())
+        .filter(|entry| {
+            if !entry.file_type().is_file() {
+                return false;
+            }
+            true
+        })
+        .map(|f| f.path().to_str().unwrap().to_owned())
+        .collect();
+
+    for file in files_in_src {
+        if !Path::new(&file).is_file() {
+            panic!("{} is not a file", file);
+        }
+        println!("cargo:rerun-if-changed={}", file);
+    }
+    let toml = directory.join("Cargo.toml").to_str().unwrap().to_owned();
+    println!("cargo:rerun-if-changed={}", toml);
+}
+
+fn main() {
+    let cwd = env::current_dir().expect("Unable to get current working directory");
+    let spl_token_2022_dir = cwd
+        .parent()
+        .expect("Unable to get parent directory of current working dir")
+        .join("program-2022");
+    rerun_if_changed(&spl_token_2022_dir);
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let spl_token_2022_toml = spl_token_2022_dir.join("Cargo.toml");
+    let spl_token_2022_toml = format!("{}", spl_token_2022_toml.display());
+    let args = vec!["build-bpf", "--manifest-path", &spl_token_2022_toml];
+    let _output = Command::new("cargo")
+        .args(&args)
+        .output()
+        .expect("Error running cargo build-bpf");
+}


### PR DESCRIPTION
#### Problem

Running the program-2022-test suite uses the most recently built spl_token_2022.so, leading to potentially tedious debugging, if you've made changes to the program, but haven't explicitly rebuilt it.

#### Solution

Add custom build.rs to program-2022-test that runs `cargo build-bpf --manifest-path <path/to/program-2022>` if any of the program files have been modified.

@joncinque , can you give this a try and see what you think? Particularly, how do you like the logging in the 2nd commit? I thought it felt weird to not have the .so info and etc, but it is a bit yelly, since the warning was the only way I could figure out how to expose the output. I'm torn about whether to keep or drop that commit.
Incidentally, that logging will appear on every `cargo test-bpf` in program-2022-test, the same way that it does for a direct build or test in `program-2022`