### PR TITLE
token-js: Support MintCloseAuthority

### DIFF
--- a/token/js/package.json
+++ b/token/js/package.json
@@ -34,7 +34,7 @@
         "test": "yarn test:unit && yarn test:e2e-built && yarn test:e2e-native && yarn test:e2e-2022",
         "test:unit": "mocha test/unit",
         "test:e2e-built": "start-server-and-test 'solana-test-validator --bpf-program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA ../../target/deploy/spl_token.so --reset --quiet' http://localhost:8899/health 'mocha test/e2e'",
-        "test:e2e-2022": "TEST_PROGRAM_ID=TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb start-server-and-test 'solana-test-validator --bpf-program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL ../../target/deploy/spl_associated_token_account.so --bpf-program TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb ../../target/deploy/spl_token_2022.so --reset --quiet' http://localhost:8899/health 'mocha test/e2e'",
+        "test:e2e-2022": "TEST_PROGRAM_ID=TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb start-server-and-test 'solana-test-validator --bpf-program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL ../../target/deploy/spl_associated_token_account.so --bpf-program TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb ../../target/deploy/spl_token_2022.so --reset --quiet' http://localhost:8899/health 'mocha test/e2e*'",
         "test:e2e-native": "start-server-and-test 'solana-test-validator --reset --quiet' http://localhost:8899/health 'mocha test/e2e'",
         "docs": "shx rm -rf docs && NODE_OPTIONS=--max_old_space_size=4096 typedoc && shx cp .nojekyll docs/",
         "fmt": "prettier --write '{*,**/*}.{js,ts,jsx,tsx,json}'",

--- a/token/js/src/extensions/extensionType.ts
+++ b/token/js/src/extensions/extensionType.ts
@@ -2,6 +2,7 @@ import { ACCOUNT_SIZE } from '../state/account';
 import { Mint, MINT_SIZE } from '../state/mint';
 import { MULTISIG_SIZE } from '../state/multisig';
 import { ACCOUNT_TYPE_SIZE } from './accountType';
+import { MINT_CLOSE_AUTHORITY_SIZE } from './mintCloseAuthority';
 
 export enum ExtensionType {
     Uninitialized,
@@ -29,7 +30,7 @@ export function getTypeLen(e: ExtensionType): number {
         case ExtensionType.TransferFeeAmount:
             return 8;
         case ExtensionType.MintCloseAuthority:
-            return 32;
+            return MINT_CLOSE_AUTHORITY_SIZE;
         case ExtensionType.ConfidentialTransferMint:
             return 97;
         case ExtensionType.ConfidentialTransferAccount:

--- a/token/js/src/extensions/index.ts
+++ b/token/js/src/extensions/index.ts
@@ -1,2 +1,3 @@
 export * from './accountType';
 export * from './extensionType';
+export * from './mintCloseAuthority';

--- a/token/js/src/extensions/mintCloseAuthority.ts
+++ b/token/js/src/extensions/mintCloseAuthority.ts
@@ -1,0 +1,24 @@
+import { struct } from '@solana/buffer-layout';
+import { publicKey } from '@solana/buffer-layout-utils';
+import { PublicKey } from '@solana/web3.js';
+import { Mint } from '../state/mint';
+import { ExtensionType, getExtensionData } from './extensionType';
+
+/** MintCloseAuthority as stored by the program */
+export interface MintCloseAuthority {
+    closeAuthority: PublicKey;
+}
+
+/** Buffer layout for de/serializing a mint */
+export const MintCloseAuthorityLayout = struct<MintCloseAuthority>([publicKey('closeAuthority')]);
+
+export const MINT_CLOSE_AUTHORITY_SIZE = MintCloseAuthorityLayout.span;
+
+export function getMintCloseAuthority(mint: Mint): MintCloseAuthority | null {
+    const extensionData = getExtensionData(ExtensionType.MintCloseAuthority, mint.tlvData);
+    if (extensionData !== null) {
+        return MintCloseAuthorityLayout.decode(extensionData);
+    } else {
+        return null;
+    }
+}

--- a/token/js/src/instructions/index.ts
+++ b/token/js/src/instructions/index.ts
@@ -21,6 +21,7 @@ export * from './syncNative'; //          17
 export * from './initializeAccount3'; //  18
 export * from './initializeMultisig2'; // 19
 export * from './initializeMint2'; //     20
+export * from './initializeMintCloseAuthority'; // 23
 export * from './createNativeMint'; //    29
 
 export * from './decode';

--- a/token/js/src/instructions/initializeMintCloseAuthority.ts
+++ b/token/js/src/instructions/initializeMintCloseAuthority.ts
@@ -1,0 +1,137 @@
+import { struct, u8 } from '@solana/buffer-layout';
+import { publicKey } from '@solana/buffer-layout-utils';
+import { AccountMeta, PublicKey, TransactionInstruction } from '@solana/web3.js';
+import {
+    TokenInvalidInstructionDataError,
+    TokenInvalidInstructionKeysError,
+    TokenInvalidInstructionProgramError,
+    TokenInvalidInstructionTypeError,
+} from '../errors';
+import { TokenInstruction } from './types';
+
+/** TODO: docs */
+export interface InitializeMintCloseAuthorityInstructionData {
+    instruction: TokenInstruction.InitializeMintCloseAuthority;
+    closeAuthorityOption: 1 | 0;
+    closeAuthority: PublicKey;
+}
+
+/** TODO: docs */
+export const initializeMintCloseAuthorityInstructionData = struct<InitializeMintCloseAuthorityInstructionData>([
+    u8('instruction'),
+    u8('closeAuthorityOption'),
+    publicKey('closeAuthority'),
+]);
+
+/**
+ * Construct an InitializeMintCloseAuthority instruction
+ *
+ * @param mint            Token mint account
+ * @param closeAuthority  Optional authority that can close the mint
+ * @param programId       SPL Token program account
+ *
+ * @return Instruction to add to a transaction
+ */
+export function createInitializeMintCloseAuthorityInstruction(
+    mint: PublicKey,
+    closeAuthority: PublicKey | null,
+    programId: PublicKey
+): TransactionInstruction {
+    const keys = [{ pubkey: mint, isSigner: false, isWritable: true }];
+
+    const data = Buffer.alloc(initializeMintCloseAuthorityInstructionData.span);
+    initializeMintCloseAuthorityInstructionData.encode(
+        {
+            instruction: TokenInstruction.InitializeMintCloseAuthority,
+            closeAuthorityOption: closeAuthority ? 1 : 0,
+            closeAuthority: closeAuthority || new PublicKey(0),
+        },
+        data
+    );
+
+    return new TransactionInstruction({ keys, programId, data });
+}
+
+/** A decoded, valid InitializeMintCloseAuthority instruction */
+export interface DecodedInitializeMintCloseAuthorityInstruction {
+    programId: PublicKey;
+    keys: {
+        mint: AccountMeta;
+    };
+    data: {
+        instruction: TokenInstruction.InitializeMintCloseAuthority;
+        closeAuthority: PublicKey | null;
+    };
+}
+
+/**
+ * Decode an InitializeMintCloseAuthority instruction and validate it
+ *
+ * @param instruction Transaction instruction to decode
+ * @param programId   SPL Token program account
+ *
+ * @return Decoded, valid instruction
+ */
+export function decodeInitializeMintCloseAuthorityInstruction(
+    instruction: TransactionInstruction,
+    programId: PublicKey
+): DecodedInitializeMintCloseAuthorityInstruction {
+    if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
+    if (instruction.data.length !== initializeMintCloseAuthorityInstructionData.span)
+        throw new TokenInvalidInstructionDataError();
+
+    const {
+        keys: { mint },
+        data,
+    } = decodeInitializeMintCloseAuthorityInstructionUnchecked(instruction);
+    if (data.instruction !== TokenInstruction.InitializeMintCloseAuthority)
+        throw new TokenInvalidInstructionTypeError();
+    if (!mint) throw new TokenInvalidInstructionKeysError();
+
+    return {
+        programId,
+        keys: {
+            mint,
+        },
+        data,
+    };
+}
+
+/** A decoded, non-validated InitializeMintCloseAuthority instruction */
+export interface DecodedInitializeMintCloseAuthorityInstructionUnchecked {
+    programId: PublicKey;
+    keys: {
+        mint: AccountMeta | undefined;
+    };
+    data: {
+        instruction: number;
+        closeAuthority: PublicKey | null;
+    };
+}
+
+/**
+ * Decode an InitializeMintCloseAuthority instruction without validating it
+ *
+ * @param instruction Transaction instruction to decode
+ *
+ * @return Decoded, non-validated instruction
+ */
+export function decodeInitializeMintCloseAuthorityInstructionUnchecked({
+    programId,
+    keys: [mint],
+    data,
+}: TransactionInstruction): DecodedInitializeMintCloseAuthorityInstructionUnchecked {
+    const { instruction, closeAuthorityOption, closeAuthority } =
+        initializeMintCloseAuthorityInstructionData.decode(data);
+
+    return {
+        programId,
+        keys: {
+            mint,
+        },
+        data: {
+            instruction,
+            closeAuthority: closeAuthorityOption ? closeAuthority : null,
+        },
+    };
+}

--- a/token/js/test/e2e-2022/closeMint.test.ts
+++ b/token/js/test/e2e-2022/closeMint.test.ts
@@ -1,0 +1,90 @@
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+chai.use(chaiAsPromised);
+
+import {
+    sendAndConfirmTransaction,
+    Connection,
+    Keypair,
+    PublicKey,
+    Signer,
+    SystemProgram,
+    Transaction,
+} from '@solana/web3.js';
+import {
+    createAccount,
+    createInitializeMintInstruction,
+    createInitializeMintCloseAuthorityInstruction,
+    closeAccount,
+    mintTo,
+    getMintLen,
+    ExtensionType,
+} from '../../src';
+import { TEST_PROGRAM_ID, newAccountWithLamports, getConnection } from '../common';
+
+const TEST_TOKEN_DECIMALS = 2;
+const EXTENSIONS = [ExtensionType.MintCloseAuthority];
+describe('closeMint', () => {
+    let connection: Connection;
+    let payer: Signer;
+    let mint: PublicKey;
+    let mintAuthority: Keypair;
+    let closeAuthority: Keypair;
+    let account: PublicKey;
+    let destination: PublicKey;
+    before(async () => {
+        connection = await getConnection();
+        payer = await newAccountWithLamports(connection, 1000000000);
+        mintAuthority = Keypair.generate();
+        closeAuthority = Keypair.generate();
+    });
+    beforeEach(async () => {
+        const mintKeypair = Keypair.generate();
+        mint = mintKeypair.publicKey;
+        const mintLen = getMintLen(EXTENSIONS);
+        const lamports = await connection.getMinimumBalanceForRentExemption(mintLen);
+
+        const transaction = new Transaction().add(
+            SystemProgram.createAccount({
+                fromPubkey: payer.publicKey,
+                newAccountPubkey: mint,
+                space: mintLen,
+                lamports,
+                programId: TEST_PROGRAM_ID,
+            }),
+            createInitializeMintCloseAuthorityInstruction(mint, closeAuthority.publicKey, TEST_PROGRAM_ID),
+            createInitializeMintInstruction(mint, TEST_TOKEN_DECIMALS, mintAuthority.publicKey, null, TEST_PROGRAM_ID)
+        );
+
+        await sendAndConfirmTransaction(connection, transaction, [payer, mintKeypair], undefined);
+    });
+    it('failsWithNonZeroAmount', async () => {
+        const owner = Keypair.generate();
+        destination = Keypair.generate().publicKey;
+        account = await createAccount(connection, payer, mint, owner.publicKey, undefined, undefined, TEST_PROGRAM_ID);
+        const amount = BigInt(1000);
+        await mintTo(connection, payer, mint, account, mintAuthority, amount, [], undefined, TEST_PROGRAM_ID);
+        expect(closeAccount(connection, payer, mint, destination, closeAuthority, [], undefined, TEST_PROGRAM_ID)).to.be
+            .rejected;
+    });
+    it('works', async () => {
+        destination = Keypair.generate().publicKey;
+        const accountInfo = await connection.getAccountInfo(mint);
+        let rentExemptAmount;
+        expect(accountInfo).to.not.be.null;
+        if (accountInfo !== null) {
+            rentExemptAmount = accountInfo.lamports;
+        }
+
+        await closeAccount(connection, payer, mint, destination, closeAuthority, [], undefined, TEST_PROGRAM_ID);
+
+        const closedInfo = await connection.getAccountInfo(mint);
+        expect(closedInfo).to.be.null;
+
+        const destinationInfo = await connection.getAccountInfo(destination);
+        expect(destinationInfo).to.not.be.null;
+        if (destinationInfo !== null) {
+            expect(destinationInfo.lamports).to.eql(rentExemptAmount);
+        }
+    });
+});

--- a/token/js/test/unit/decode.test.ts
+++ b/token/js/test/unit/decode.test.ts
@@ -1,0 +1,18 @@
+import { Keypair } from '@solana/web3.js';
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { createInitializeMintCloseAuthorityInstruction, TOKEN_2022_PROGRAM_ID } from '../../src';
+
+chai.use(chaiAsPromised);
+
+describe('spl-token-2022 instructions', () => {
+    it('InitializeMintCloseAuthority', () => {
+        const ix = createInitializeMintCloseAuthorityInstruction(
+            Keypair.generate().publicKey,
+            Keypair.generate().publicKey,
+            TOKEN_2022_PROGRAM_ID
+        );
+        expect(ix.programId).to.eql(TOKEN_2022_PROGRAM_ID);
+        expect(ix.keys).to.have.length(1);
+    });
+});


### PR DESCRIPTION
#### Problem

We need to add JS bindings for the extensions, including `MintCloseAuthority`.

#### Solution

Add the support!

This commit can be used as a template for adding all other extensions, since it shows the instruction + state + tests to add.

The one missing part is how an `action` should be defined.  This part is a bit tricky because we want extensions to be composable with each other.  Typically, there's an action like `createMint` to easily `await`, but we can't have a specific function for each combination of extensions, ie `createMintWithMintCloseAuthorityAndTransferFee`.

Most likely, we should go with some builder model to add extensions before calling `createMint`, but we can save that for another set of PRs.