### PR TITLE
token: Add comment to help keep instruction sets in sync

### DIFF
--- a/token/program/src/instruction.rs
+++ b/token/program/src/instruction.rs
@@ -462,6 +462,9 @@ pub enum TokenInstruction<'a> {
         /// The ui_amount of tokens to reformat.
         ui_amount: &'a str,
     },
+    // Any new variants also need to be added to program-2022 `TokenInstruction`, so that the
+    // latter remains a superset of this instruction set. New variants also need to be added to
+    // token/js/src/instructions/types.ts to maintain @solana/spl-token compatability
 }
 impl<'a> TokenInstruction<'a> {
     /// Unpacks a byte buffer into a [TokenInstruction](enum.TokenInstruction.html).


### PR DESCRIPTION
#### Problem

I broke @solana/spl-token by adding new `TokenInstruction`s and not handling them in /js
https://github.com/solana-labs/solana-program-library/pull/2949#issuecomment-1050260443

#### Solution

Add a comment to help ensure instruction sets stay in sync.
@joncinque , wdyt?