### PR TITLE
Fixup TransferFee instruction docs

### DIFF
--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -279,7 +279,7 @@ pub enum ConfidentialTransferInstruction {
     ///   1. `[writable]` The fee receiver account. Must include the `TransferFeeAmount` and
     ///      `ConfidentialTransferAccount` extensions.
     ///   2. `[]` Instructions sysvar.
-    ///   3. `[]` The mint's `withdraw_withheld_authority`'s multisignature owner/delegate.
+    ///   3. `[]` The mint's multisig `withdraw_withheld_authority`.
     ///   4. ..3+M `[signer]` M signer accounts.
     ///
     /// Data expected by this instruction:
@@ -321,7 +321,7 @@ pub enum ConfidentialTransferInstruction {
     ///   1. `[writable]` The fee receiver account. Must include the `TransferFeeAmount` and
     ///      `ConfidentialTransferAccount` extensions.
     ///   2. `[]` Instructions sysvar.
-    ///   3. `[]` The mint's `withdraw_withheld_authority`'s multisignature owner/delegate.
+    ///   3. `[]` The mint's multisig `withdraw_withheld_authority`.
     ///   4. ..4+M `[signer]` M signer accounts.
     ///   4+M+1. ..3+M+N `[writable]` The source accounts to withdraw from.
     ///

--- a/token/program-2022/src/extension/transfer_fee/instruction.rs
+++ b/token/program-2022/src/extension/transfer_fee/instruction.rs
@@ -75,7 +75,7 @@ pub enum TransferFeeInstruction {
     ///   * Multisignature owner/delegate
     ///   0. `[writable]` The token mint.
     ///   1. `[writable]` The destination account.
-    ///   2. `[]` The mint's `withdraw_withheld_authority`'s multisignature owner/delegate.
+    ///   2. `[]` The mint's multisig `withdraw_withheld_authority`.
     ///   3. ..3+M `[signer]` M signer accounts.
     WithdrawWithheldTokensFromMint,
     /// Transfer all withheld tokens to an account. Signed by the mint's
@@ -93,7 +93,7 @@ pub enum TransferFeeInstruction {
     ///   * Multisignature owner/delegate
     ///   0. `[]` The token mint.
     ///   1. `[writable]` The destination account.
-    ///   2. `[]` The mint's `withdraw_withheld_authority`'s multisignature owner/delegate.
+    ///   2. `[]` The mint's multisig `withdraw_withheld_authority`.
     ///   3. ..3+M `[signer]` M signer accounts.
     ///   3+M+1. ..3+M+N `[writable]` The source accounts to withdraw from.
     WithdrawWithheldTokensFromAccounts {


### PR DESCRIPTION
The `WithdrawWithheld` ix docs use some language that doesn't make a lot of sense to describe a potential multisig `withdraw_withheld_authority`. Fix it up!
(Needs rebase on https://github.com/solana-labs/solana-program-library/pull/2961)