### PR TITLE
Update account list for CreateMintGovernance instruction

### DIFF
--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -348,7 +348,6 @@ pub enum GovernanceInstruction {
     ///   5. `[signer]` Payer
     ///   6. `[]` SPL Token program
     ///   7. `[]` System program
-    ///   8. `[]` Sysvar Rent
     ///   8. `[signer]` Governance authority
     ///   9. `[]` Realm Config
     ///   10. `[]` Optional Voter Weight Record


### PR DESCRIPTION
As per the `processor/process_create_mint_governance.rs` file the Sysvar Rent account need not be passed by the client because the program gets it using `Rent::get()?;` on line 50.