### PR TITLE
Support unpacking token accounts fields partially

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3903,6 +3903,7 @@ name = "spl-token"
 version = "3.3.0"
 dependencies = [
  "arrayref",
+ "bytemuck",
  "lazy_static",
  "num-derive",
  "num-traits",

--- a/token/program-2022/src/state.rs
+++ b/token/program-2022/src/state.rs
@@ -1,7 +1,7 @@
 //! State transition types
 
 use {
-    crate::instruction::MAX_SIGNERS,
+    crate::{instruction::MAX_SIGNERS, extension::AccountType},
     arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs},
     num_enum::{IntoPrimitive, TryFromPrimitive},
     solana_program::{
@@ -290,7 +290,8 @@ fn unpack_coption_u64(src: &[u8; 12]) -> Result<COption<u64>, ProgramError> {
     }
 }
 
-const ACCOUNTTYPE_ACCOUNT: u8 = 2;
+// `spl_token_program_2022::extension::AccountType::Account` ordinal value
+const ACCOUNTTYPE_ACCOUNT: u8 = AccountType::Account as u8;
 impl GenericTokenAccount for Account {
     fn valid_account_data(account_data: &[u8]) -> bool {
         spl_token::state::Account::valid_account_data(account_data)

--- a/token/program-2022/src/state.rs
+++ b/token/program-2022/src/state.rs
@@ -415,4 +415,56 @@ pub(crate) mod test {
         let unpacked = Multisig::unpack(&packed).unwrap();
         assert_eq!(unpacked, check);
     }
+
+    #[test]
+    fn test_unpack_token_owner() {
+        // Account data length < Account::LEN, unpack will not return a key
+        let src: [u8; 12] = [0; 12];
+        let result = Account::unpack_account_owner(&src);
+        assert_eq!(result, Option::None);
+
+        // The right account data size, unpack will return some key
+        let src: [u8; Account::LEN] = [0; Account::LEN];
+        let result = Account::unpack_account_owner(&src);
+        assert!(result.is_some());
+
+        // Account data length > account data size, but not a valid extension,
+        // unpack will not return a key
+        let src: [u8; Account::LEN + 5] = [0; Account::LEN + 5];
+        let result = Account::unpack_account_owner(&src);
+        assert_eq!(result, Option::None);
+
+        // Account data length > account data size with a valid extension,
+        // expect some key returned
+        let mut src: [u8; Account::LEN + 5] = [0; Account::LEN + 5];
+        src[Account::LEN] = 2;
+        let result = Account::unpack_account_owner(&src);
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_unpack_token_mint() {
+        // Account data length < Account::LEN, unpack will not return a key
+        let src: [u8; 12] = [0; 12];
+        let result = Account::unpack_account_mint(&src);
+        assert_eq!(result, Option::None);
+
+        // The right account data size, unpack will return some key
+        let src: [u8; Account::LEN] = [0; Account::LEN];
+        let result = Account::unpack_account_mint(&src);
+        assert!(result.is_some());
+
+        // Account data length > account data size, but not a valid extension,
+        // unpack will not return a key
+        let src: [u8; Account::LEN + 5] = [0; Account::LEN + 5];
+        let result = Account::unpack_account_mint(&src);
+        assert_eq!(result, Option::None);
+
+        // Account data length > account data size with a valid extension,
+        // expect some key returned
+        let mut src: [u8; Account::LEN + 5] = [0; Account::LEN + 5];
+        src[Account::LEN] = 2;
+        let result = Account::unpack_account_mint(&src);
+        assert!(result.is_some());
+    }
 }

--- a/token/program-2022/src/state.rs
+++ b/token/program-2022/src/state.rs
@@ -1,7 +1,7 @@
 //! State transition types
 
 use {
-    crate::{instruction::MAX_SIGNERS, extension::AccountType},
+    crate::{extension::AccountType, instruction::MAX_SIGNERS},
     arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs},
     num_enum::{IntoPrimitive, TryFromPrimitive},
     solana_program::{

--- a/token/program-2022/src/state.rs
+++ b/token/program-2022/src/state.rs
@@ -10,6 +10,7 @@ use {
         program_pack::{IsInitialized, Pack, Sealed},
         pubkey::Pubkey,
     },
+    spl_token::state::GenericTokenAccount,
 };
 
 /// Mint data.
@@ -286,6 +287,17 @@ fn unpack_coption_u64(src: &[u8; 12]) -> Result<COption<u64>, ProgramError> {
         [0, 0, 0, 0] => Ok(COption::None),
         [1, 0, 0, 0] => Ok(COption::Some(u64::from_le_bytes(*body))),
         _ => Err(ProgramError::InvalidAccountData),
+    }
+}
+
+const ACCOUNTTYPE_ACCOUNT: u8 = 2;
+impl GenericTokenAccount for Account {
+    fn valid_account_data(account_data: &[u8]) -> bool {
+        spl_token::state::Account::valid_account_data(account_data)
+            || ACCOUNTTYPE_ACCOUNT
+                == *account_data
+                    .get(spl_token::state::Account::get_packed_len())
+                    .unwrap_or(&0)
     }
 }
 

--- a/token/program-2022/src/state.rs
+++ b/token/program-2022/src/state.rs
@@ -295,10 +295,7 @@ const ACCOUNTTYPE_ACCOUNT: u8 = AccountType::Account as u8;
 impl GenericTokenAccount for Account {
     fn valid_account_data(account_data: &[u8]) -> bool {
         spl_token::state::Account::valid_account_data(account_data)
-            || ACCOUNTTYPE_ACCOUNT
-                == *account_data
-                    .get(Account::LEN)
-                    .unwrap_or(&0)
+            || ACCOUNTTYPE_ACCOUNT == *account_data.get(Account::LEN).unwrap_or(&0)
     }
 }
 

--- a/token/program-2022/src/state.rs
+++ b/token/program-2022/src/state.rs
@@ -297,7 +297,7 @@ impl GenericTokenAccount for Account {
         spl_token::state::Account::valid_account_data(account_data)
             || ACCOUNTTYPE_ACCOUNT
                 == *account_data
-                    .get(spl_token::state::Account::get_packed_len())
+                    .get(Account::LEN)
                     .unwrap_or(&0)
     }
 }

--- a/token/program/Cargo.toml
+++ b/token/program/Cargo.toml
@@ -14,6 +14,7 @@ test-bpf = []
 
 [dependencies]
 arrayref = "0.3.6"
+bytemuck = "1.7.2"
 num-derive = "0.3"
 num-traits = "0.2"
 num_enum = "0.5.4"

--- a/token/program/src/state.rs
+++ b/token/program/src/state.rs
@@ -307,7 +307,7 @@ pub trait GenericTokenAccount {
     }
 
     /// Call after account length has already been verified to unpack a Pubkey at
-    /// the specified offset.
+    /// the specified offset. Panics if `account_data.len()` is less than `PUBKEY_BYTES`
     fn unpack_pubkey_unchecked(account_data: &[u8], offset: usize) -> &Pubkey {
         bytemuck::from_bytes(&account_data[offset..offset + PUBKEY_BYTES])
     }

--- a/token/program/src/state.rs
+++ b/token/program/src/state.rs
@@ -7,7 +7,7 @@ use solana_program::{
     program_error::ProgramError,
     program_option::COption,
     program_pack::{IsInitialized, Pack, Sealed},
-    pubkey::Pubkey,
+    pubkey::{Pubkey, PUBKEY_BYTES},
 };
 
 /// Mint data.
@@ -287,6 +287,64 @@ fn unpack_coption_u64(src: &[u8; 12]) -> Result<COption<u64>, ProgramError> {
     }
 }
 
+const SPL_TOKEN_ACCOUNT_MINT_OFFSET: usize = 0;
+const SPL_TOKEN_ACCOUNT_OWNER_OFFSET: usize = 32;
+const SPL_TOKEN_ACCOUNT_LENGTH: usize = 165;
+
+/// A trait of the generic token account for unpacking an account's fields
+/// partially and returning their references efficiently.
+pub trait GenericTokenAccount {
+    /// Check if the account data is a valid token account
+    fn valid_account_data(account_data: &[u8]) -> bool;
+
+    /// Call after account length has already been verified to unpack the account owner
+    fn unpack_account_owner_unchecked(account_data: &[u8]) -> &Pubkey {
+        Self::unpack_pubkey_unchecked(account_data, SPL_TOKEN_ACCOUNT_OWNER_OFFSET)
+    }
+
+    /// Call after account length has already been verified to unpack the account mint
+    fn unpack_account_mint_unchecked(account_data: &[u8]) -> &Pubkey {
+        Self::unpack_pubkey_unchecked(account_data, SPL_TOKEN_ACCOUNT_MINT_OFFSET)
+    }
+
+    /// Call after account length has already been verified to unpack a Pubkey at
+    /// the specified offset.
+    fn unpack_pubkey_unchecked(account_data: &[u8], offset: usize) -> &Pubkey {
+        bytemuck::from_bytes(&account_data[offset..offset + PUBKEY_BYTES])
+    }
+
+    /// Function for unpacking the account owner from the account data.
+    fn unpack_account_owner(account_data: &[u8]) -> Option<&Pubkey> {
+        if Self::valid_account_data(account_data) {
+            Some(Self::unpack_account_owner_unchecked(account_data))
+        } else {
+            None
+        }
+    }
+
+    /// Function for unpacking the account mint from the account data.
+    fn unpack_account_mint(account_data: &[u8]) -> Option<&Pubkey> {
+        if Self::valid_account_data(account_data) {
+            Some(Self::unpack_account_mint_unchecked(account_data))
+        } else {
+            None
+        }
+    }
+}
+
+impl Account {
+    /// Return the packed account data length in bytes.
+    pub fn get_packed_len() -> usize {
+        SPL_TOKEN_ACCOUNT_LENGTH
+    }
+}
+
+impl GenericTokenAccount for Account {
+    fn valid_account_data(account_data: &[u8]) -> bool {
+        account_data.len() == SPL_TOKEN_ACCOUNT_LENGTH
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -359,5 +417,41 @@ mod tests {
         src[1] = 1;
         let result = unpack_coption_u64(&src).unwrap_err();
         assert_eq!(result, ProgramError::InvalidAccountData);
+    }
+
+    #[test]
+    fn test_unpack_token_owner() {
+        // Account data length < SPL_TOKEN_ACCOUNT_LENGTH, unpack will not return a key
+        let src: [u8; 12] = [0; 12];
+        let result = Account::unpack_account_owner(&src);
+        assert_eq!(result, Option::None);
+
+        // The right account data size, unpack will return some key
+        let src: [u8; SPL_TOKEN_ACCOUNT_LENGTH] = [0; SPL_TOKEN_ACCOUNT_LENGTH];
+        let result = Account::unpack_account_owner(&src);
+        assert!(result.is_some());
+
+        // Account data length > account data size, unpack will return some key
+        let src: [u8; SPL_TOKEN_ACCOUNT_LENGTH + 5] = [0; SPL_TOKEN_ACCOUNT_LENGTH + 5];
+        let result = Account::unpack_account_owner(&src);
+        assert_eq!(result, Option::None);
+    }
+
+    #[test]
+    fn test_unpack_token_mint() {
+        // Account data length < SPL_TOKEN_ACCOUNT_LENGTH, unpack will not return a key
+        let src: [u8; 12] = [0; 12];
+        let result = Account::unpack_account_mint(&src);
+        assert_eq!(result, Option::None);
+
+        // The right account data size, unpack will return some key
+        let src: [u8; SPL_TOKEN_ACCOUNT_LENGTH] = [0; SPL_TOKEN_ACCOUNT_LENGTH];
+        let result = Account::unpack_account_mint(&src);
+        assert!(result.is_some());
+
+        // Account data length > account data size, unpack will return some key
+        let src: [u8; SPL_TOKEN_ACCOUNT_LENGTH + 5] = [0; SPL_TOKEN_ACCOUNT_LENGTH + 5];
+        let result = Account::unpack_account_mint(&src);
+        assert_eq!(result, Option::None);
     }
 }


### PR DESCRIPTION
In certain applications, there is a need to quickly unpacking some subfields of the account without unpacking the whole account to take actions such as creating secondary indexes. The code implemented here was adapted from solana-runtime.   