### PR TITLE
include version in typedoc for spl-name-service, spl-token, and spl-token-lending

### DIFF
--- a/name-service/js/package.json
+++ b/name-service/js/package.json
@@ -25,7 +25,7 @@
     "lint:fix": "yarn pretty:fix && eslint . --fix",
     "pretty": "prettier --check 'src/*.[jt]s'",
     "pretty:fix": "prettier --write 'src/*.[jt]s'",
-    "doc": "yarn typedoc src/index.ts"
+    "doc": "yarn typedoc src/index.ts --includeVersion"
   },
   "prettier": {
     "singleQuote": true

--- a/token-lending/js/package.json
+++ b/token-lending/js/package.json
@@ -24,7 +24,7 @@
     "scripts": {
         "build": "rm -rf lib/* && tsc && rollup -c && rm lib/rollup.config.d.ts",
         "deploy": "yarn docs && gh-pages -d docs -e token-lending",
-        "docs": "rm -rf docs/* && typedoc",
+        "docs": "rm -rf docs/* && typedoc --includeVersion",
         "lint": "eslint . --ext .ts && prettier --check '**/*.{ts,js,json}'",
         "lint:fix": "eslint . --ext .ts --fix && prettier --write '**/*.{ts,js,json}'"
     },

--- a/token/js/package.json
+++ b/token/js/package.json
@@ -36,7 +36,7 @@
         "test:e2e-built": "start-server-and-test 'solana-test-validator --bpf-program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA ../../target/deploy/spl_token.so --reset --quiet' http://localhost:8899/health 'mocha test/e2e'",
         "test:e2e-2022": "TEST_PROGRAM_ID=TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb start-server-and-test 'solana-test-validator --bpf-program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL ../../target/deploy/spl_associated_token_account.so --bpf-program TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb ../../target/deploy/spl_token_2022.so --reset --quiet' http://localhost:8899/health 'mocha test/e2e*'",
         "test:e2e-native": "start-server-and-test 'solana-test-validator --reset --quiet' http://localhost:8899/health 'mocha test/e2e'",
-        "docs": "shx rm -rf docs && NODE_OPTIONS=--max_old_space_size=4096 typedoc && shx cp .nojekyll docs/",
+        "docs": "shx rm -rf docs && NODE_OPTIONS=--max_old_space_size=4096 typedoc --includeVersion && shx cp .nojekyll docs/",
         "fmt": "prettier --write '{*,**/*}.{js,ts,jsx,tsx,json}'",
         "lint": "eslint --ext .ts . && prettier --check '{*,**/*}.{js,ts,jsx,tsx,json}'",
         "lint:fix": "eslint --fix --ext .ts . && yarn fmt",


### PR DESCRIPTION
I was using spl-token and had some problems and it turns out I was on the wrong version!

It's just a single argument to typedoc (`--includeVersion`) to make it put the version number in the docs.