### PR TITLE
Override the constructor to Numberu32 and Numberu64 to resolve #2563

### DIFF
--- a/name-service/js/src/utils.ts
+++ b/name-service/js/src/utils.ts
@@ -15,6 +15,19 @@ import { HASH_PREFIX, NAME_PROGRAM_ID } from './bindings';
 import { NameRegistryState } from './state';
 
 export class Numberu32 extends BN {
+  constructor(
+      number: number | string | number[] | Uint8Array | Buffer | BN,
+      base?: number | 'hex',
+      endian?: BN.Endianness
+  ) {
+    if (BN.isBN(number)) {
+      const nbn = number as BN
+      super(nbn.toArray())
+    } else {
+      super(number, base, endian)
+    }
+  }
+
   /**
    * Convert to Buffer representation
    */
@@ -47,6 +60,19 @@ export class Numberu32 extends BN {
 }
 
 export class Numberu64 extends BN {
+  constructor(
+      number: number | string | number[] | Uint8Array | Buffer | BN,
+      base?: number | 'hex',
+      endian?: BN.Endianness
+  ) {
+    if (BN.isBN(number)) {
+        const nbn = number as BN
+        super(nbn.toArray())
+    } else {
+        super(number, base, endian)
+    }
+  }
+
   /**
    * Convert to Buffer representation
    */


### PR DESCRIPTION
…63 by overriding the constructor of BN sub classes

This PR resolves https://github.com/solana-labs/solana-program-library/issues/2563

The following code:
```
const bn = new BN(5);
const u = new Numberu64(10);
const u2 = new Numberu64(bn);

console.log("bn.toBuffer", bn.toBuffer);
console.log("u.toBuffer", u.toBuffer);
console.log("u2.toBuffer", u2.toBuffer);
```

Now results in the following output:
```
bn.toBuffer [Function: toBuffer]
u.toBuffer [Function: toBuffer]
u2.toBuffer [Function: toBuffer]
```
