### PR TITLE
token: spell out "destination"

### DIFF
--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -480,7 +480,7 @@ where
     /// Mint new tokens
     pub async fn mint_to<S2: Signer>(
         &self,
-        dest: &Pubkey,
+        destination: &Pubkey,
         authority: &S2,
         amount: u64,
     ) -> TokenResult<()> {
@@ -488,7 +488,7 @@ where
             &[instruction::mint_to(
                 &self.program_id,
                 &self.pubkey,
-                dest,
+                destination,
                 &authority.pubkey(),
                 &[],
                 amount,


### PR DESCRIPTION
#### Problem
We seem to be about 50/50 on whether to spell out "destination". But when we don't, my brain invariably gets hung up on what a "dest" is.

#### Solution
Spell it out. There are a small handful of `dest`s remaining, due to upstream struct fields in zk-token-sdk, which I'd rather not meddle with.
No functional changes.
