### PR TITLE
Bump rust versions

### DIFF
--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -18,13 +18,13 @@
 if [[ -n $RUST_STABLE_VERSION ]]; then
   stable_version="$RUST_STABLE_VERSION"
 else
-  stable_version=1.57.0
+  stable_version=1.59.0
 fi
 
 if [[ -n $RUST_NIGHTLY_VERSION ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2021-12-03
+  nightly_version=2022-02-24
 fi
 
 

--- a/name-service/program/src/state.rs
+++ b/name-service/program/src/state.rs
@@ -74,13 +74,13 @@ pub fn get_seeds_and_key(
 
     let name_class = name_class_opt.cloned().unwrap_or_default();
 
-    for b in name_class.to_bytes().to_vec() {
+    for b in name_class.to_bytes() {
         seeds_vec.push(b);
     }
 
     let parent_name_address = parent_name_address_opt.cloned().unwrap_or_default();
 
-    for b in parent_name_address.to_bytes().to_vec() {
+    for b in parent_name_address.to_bytes() {
         seeds_vec.push(b);
     }
 


### PR DESCRIPTION
CI token job keeps failing on `use of unstable library feature 'saturating_div'`.
Bump rust versions to match monorepo (`saturating_div` was stabilized in rust v1.58)