### PR TITLE
fuzz: Fix fuzz build

### DIFF
--- a/ci/fuzz.sh
+++ b/ci/fuzz.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
 set -e
+cd "$(dirname "$0")/.."
+
+source ./ci/rust-version.sh nightly
 
 usage() {
   exitcode=0
@@ -22,7 +25,10 @@ if [[ -z $2 ]]; then
   usage "No runtime provided"
 fi
 
-HFUZZ_RUN_ARGS="--run_time $run_time --exit_upon_crash" cargo hfuzz run $fuzz_target
+# Temporary workaround using RUSTFLAGS and rust nightly due to:
+# https://github.com/rust-fuzz/honggfuzz-rs/issues/61
+# Once the issue is resolved, remove the RUSTFLAGS and nightly usage everywhere.
+RUSTFLAGS="-Znew-llvm-pass-manager=no" HFUZZ_RUN_ARGS="--run_time $run_time --exit_upon_crash" cargo +nightly-2022-02-24 hfuzz run $fuzz_target
 
 # Until https://github.com/rust-fuzz/honggfuzz-rs/issues/16 is resolved,
 # hfuzz does not return an error code on crash, so look for a crash artifact

--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -49,14 +49,14 @@ export rust_nightly_docker_image=solanalabs/rust-nightly:"$nightly_version"
   cd "$(dirname "${BASH_SOURCE[0]}")"
   case $1 in
   stable)
-     rustup_install "$rust_stable"
-     ;;
-  # nightly)
-  #    rustup_install "$rust_nightly"
-  #   ;;
+    rustup_install "$rust_stable"
+    ;;
+  nightly)
+    rustup_install "$rust_nightly"
+    ;;
   all)
-     rustup_install "$rust_stable"
-     rustup_install "$rust_nightly"
+    rustup_install "$rust_stable"
+    rustup_install "$rust_nightly"
     ;;
   *)
     echo "$0: Note: ignoring unknown argument: $1" >&2


### PR DESCRIPTION
#### Problem

Since upgrading to 1.59.0, the fuzz build doesn't work anymore, with an error just like https://github.com/rust-fuzz/honggfuzz-rs/issues/61

#### Solution

Apply a workaround to use the old LLVM pass manager, which requires Rust nightly.