### PR TITLE
Run full CI on version updates

### DIFF
--- a/.github/workflows/pull-request-binary-oracle-pair.yml
+++ b/.github/workflows/pull-request-binary-oracle-pair.yml
@@ -5,11 +5,13 @@ on:
     paths:
     - 'binary-oracle-pair/**'
     - 'token/**'
+    - 'ci/*-version.sh'
   push:
     branches: [master]
     paths:
     - 'binary-oracle-pair/**'
     - 'token/**'
+    - 'ci/*-version.sh'
 
 jobs:
   cargo-test-bpf:

--- a/.github/workflows/pull-request-examples.yml
+++ b/.github/workflows/pull-request-examples.yml
@@ -4,10 +4,12 @@ on:
   pull_request:
     paths:
     - 'examples/rust/**'
+    - 'ci/*-version.sh'
   push:
     branches: [master]
     paths:
     - 'examples/rust/**'
+    - 'ci/*-version.sh'
 
 jobs:
   cargo-test-bpf:

--- a/.github/workflows/pull-request-feature-proposal.yml
+++ b/.github/workflows/pull-request-feature-proposal.yml
@@ -5,11 +5,13 @@ on:
     paths:
     - 'feature-proposal/**'
     - 'token/**'
+    - 'ci/*-version.sh'
   push:
     branches: [master]
     paths:
     - 'feature-proposal/**'
     - 'token/**'
+    - 'ci/*-version.sh'
 
 jobs:
   cargo-test-bpf:

--- a/.github/workflows/pull-request-governance.yml
+++ b/.github/workflows/pull-request-governance.yml
@@ -5,11 +5,13 @@ on:
     paths:
     - 'governance/**'
     - 'token/**'
+    - 'ci/*-version.sh'
   push:
     branches: [master]
     paths:
     - 'governance/**'
     - 'token/**'
+    - 'ci/*-version.sh'
 
 jobs:
   cargo-test-bpf:

--- a/.github/workflows/pull-request-libraries.yml
+++ b/.github/workflows/pull-request-libraries.yml
@@ -4,10 +4,12 @@ on:
   pull_request:
     paths:
     - 'libraries/**'
+    - 'ci/*-version.sh'
   push:
     branches: [master]
     paths:
     - 'libraries/**'
+    - 'ci/*-version.sh'
 
 jobs:
   cargo-test-bpf:

--- a/.github/workflows/pull-request-memo.yml
+++ b/.github/workflows/pull-request-memo.yml
@@ -4,10 +4,12 @@ on:
   pull_request:
     paths:
     - 'memo/**'
+    - 'ci/*-version.sh'
   push:
     branches: [master]
     paths:
     - 'memo/**'
+    - 'ci/*-version.sh'
 
 jobs:
   cargo-test-bpf:

--- a/.github/workflows/pull-request-name-service.yml
+++ b/.github/workflows/pull-request-name-service.yml
@@ -4,10 +4,12 @@ on:
   pull_request:
     paths:
     - 'name-service/**'
+    - 'ci/*-version.sh'
   push:
     branches: [master]
     paths:
     - 'name-service/**'
+    - 'ci/*-version.sh'
 
 jobs:
   cargo-test-bpf:

--- a/.github/workflows/pull-request-record.yml
+++ b/.github/workflows/pull-request-record.yml
@@ -4,10 +4,12 @@ on:
   pull_request:
     paths:
     - 'record/**'
+    - 'ci/*-version.sh'
   push:
     branches: [master]
     paths:
     - 'record/**'
+    - 'ci/*-version.sh'
 
 jobs:
   cargo-test-bpf:

--- a/.github/workflows/pull-request-shared-memory.yml
+++ b/.github/workflows/pull-request-shared-memory.yml
@@ -4,10 +4,12 @@ on:
   pull_request:
     paths:
     - 'shared-memory/**'
+    - 'ci/*-version.sh'
   push:
     branches: [master]
     paths:
     - 'shared-memory/**'
+    - 'ci/*-version.sh'
 
 jobs:
   cargo-test-bpf:

--- a/.github/workflows/pull-request-stake-pool.yml
+++ b/.github/workflows/pull-request-stake-pool.yml
@@ -5,11 +5,13 @@ on:
     paths:
     - 'stake-pool/**'
     - 'token/**'
+    - 'ci/*-version.sh'
   push:
     branches: [master]
     paths:
     - 'stake-pool/**'
     - 'token/**'
+    - 'ci/*-version.sh'
 
 jobs:
   cargo-test-bpf:

--- a/.github/workflows/pull-request-token-lending.yml
+++ b/.github/workflows/pull-request-token-lending.yml
@@ -5,11 +5,13 @@ on:
     paths:
     - 'token-lending/**'
     - 'token/**'
+    - 'ci/*-version.sh'
   push:
     branches: [master]
     paths:
     - 'token-lending/**'
     - 'token/**'
+    - 'ci/*-version.sh'
 
 jobs:
   cargo-test-bpf:

--- a/.github/workflows/pull-request-token-swap.yml
+++ b/.github/workflows/pull-request-token-swap.yml
@@ -6,12 +6,14 @@ on:
     - 'token-swap/**'
     - 'token/**'
     - 'libraries/math/**'
+    - 'ci/*-version.sh'
   push:
     branches: [master]
     paths:
     - 'token-swap/**'
     - 'token/**'
     - 'libraries/math/**'
+    - 'ci/*-version.sh'
 
 jobs:
   cargo-test-bpf:

--- a/.github/workflows/pull-request-token.yml
+++ b/.github/workflows/pull-request-token.yml
@@ -5,11 +5,13 @@ on:
     paths:
     - 'associated-token-account/**'
     - 'token/**'
+    - 'ci/*-version.sh'
   push:
     branches: [master]
     paths:
     - 'associated-token-account/**'
     - 'token/**'
+    - 'ci/*-version.sh'
 
 jobs:
   cargo-test-bpf:


### PR DESCRIPTION
I [bumped the rust version](https://github.com/solana-labs/solana-program-library/pull/2978), and didn't realize I had broken the token-swap fuzz CI because the program-specific CI jobs didn't run.

This PR updates the CI rules to run all the CI jobs on all rust- or solana-version bumps