### PR TITLE
Add note that `--mint-authority` is public key when uploading signed transactions

### DIFF
--- a/name-service/js/package.json
+++ b/name-service/js/package.json
@@ -25,7 +25,7 @@
     "lint:fix": "yarn pretty:fix && eslint . --fix",
     "pretty": "prettier --check 'src/*.[jt]s'",
     "pretty:fix": "prettier --write 'src/*.[jt]s'",
-    "doc": "yarn typedoc src/index.ts"
+    "doc": "yarn typedoc src/index.ts --includeVersion"
   },
   "prettier": {
     "singleQuote": true

--- a/token-lending/js/package.json
+++ b/token-lending/js/package.json
@@ -24,7 +24,7 @@
     "scripts": {
         "build": "rm -rf lib/* && tsc && rollup -c && rm lib/rollup.config.d.ts",
         "deploy": "yarn docs && gh-pages -d docs -e token-lending",
-        "docs": "rm -rf docs/* && typedoc",
+        "docs": "rm -rf docs/* && typedoc --includeVersion",
         "lint": "eslint . --ext .ts && prettier --check '**/*.{ts,js,json}'",
         "lint:fix": "eslint . --ext .ts --fix && prettier --write '**/*.{ts,js,json}'"
     },

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -2100,7 +2100,9 @@ fn main() -> Result<(), Error> {
                         .help(
                             "Specify the mint authority keypair. \
                              This may be a keypair file or the ASK keyword. \
-                             Defaults to the client keypair."
+                             Defaults to the client keypair. \
+                             Provide a public key instead for sending transactions \
+                              that have been signed offline"
                         ),
                 )
                 .arg(mint_decimals_arg())

--- a/token/js/package.json
+++ b/token/js/package.json
@@ -36,7 +36,7 @@
         "test:e2e-built": "start-server-and-test 'solana-test-validator --bpf-program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA ../../target/deploy/spl_token.so --reset --quiet' http://localhost:8899/health 'mocha test/e2e'",
         "test:e2e-2022": "TEST_PROGRAM_ID=TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb start-server-and-test 'solana-test-validator --bpf-program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL ../../target/deploy/spl_associated_token_account.so --bpf-program TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb ../../target/deploy/spl_token_2022.so --reset --quiet' http://localhost:8899/health 'mocha test/e2e*'",
         "test:e2e-native": "start-server-and-test 'solana-test-validator --reset --quiet' http://localhost:8899/health 'mocha test/e2e'",
-        "docs": "shx rm -rf docs && NODE_OPTIONS=--max_old_space_size=4096 typedoc && shx cp .nojekyll docs/",
+        "docs": "shx rm -rf docs && NODE_OPTIONS=--max_old_space_size=4096 typedoc --includeVersion && shx cp .nojekyll docs/",
         "fmt": "prettier --write '{*,**/*}.{js,ts,jsx,tsx,json}'",
         "lint": "eslint --ext .ts . && prettier --check '{*,**/*}.{js,ts,jsx,tsx,json}'",
         "lint:fix": "eslint --fix --ext .ts . && yarn fmt",


### PR DESCRIPTION
I was struggling to upload my transaction when I realized that this flag can be a public key instead of a keypair (or ASK keyword)