### PR TITLE
anchor: Updates for token-2022

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -1,10 +1,13 @@
 anchor_version = "0.20.1"
-solana_version = "1.9.5"
+solana_version = "1.9.9"
 
 [workspace]
 members = [
   "governance/program",
+  "memo/program",
   "stake-pool/program",
+  "token/program",
+  "token/program-2022",
 ]
 
 [provider]
@@ -14,3 +17,4 @@ wallet = "~/.config/solana/id.json"
 [programs.mainnet]
 spl_governance = "GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw"
 spl_stake_pool = "SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy"
+spl_token_2022 = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -17,4 +17,5 @@ wallet = "~/.config/solana/id.json"
 [programs.mainnet]
 spl_governance = "GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw"
 spl_stake_pool = "SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy"
+spl_token = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
 spl_token_2022 = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"


### PR DESCRIPTION
#### Problem

Verifiable builds and publishing source code doesn't work currently, since not all required programs are included in the Anchor workspace.

#### Solution

Add required programs to publish token and token-2022.

While we're at it, upgrade the solana version to 1.9.9.