### PR TITLE
add getMultipleAccounts for Token

### DIFF
--- a/token/js/package.json
+++ b/token/js/package.json
@@ -45,7 +45,7 @@
     "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
         "@solana/buffer-layout-utils": "^0.2.0",
-        "@solana/web3.js": "^1.32.0",
+        "@solana/web3.js": "^1.36.0",
         "start-server-and-test": "^1.14.0"
     },
     "devDependencies": {

--- a/token/js/src/state/account.ts
+++ b/token/js/src/state/account.ts
@@ -82,7 +82,6 @@ export const AccountLayout = struct<RawAccount>([
 /** Byte length of a token account */
 export const ACCOUNT_SIZE = AccountLayout.span;
 
-
 /**
  * Retrieve information about a token account
  *
@@ -113,7 +112,7 @@ export async function getAccount(
  *
  * @return Token account information
  */
- export async function getMultipleAccounts(
+export async function getMultipleAccounts(
     connection: Connection,
     addresses: PublicKey[],
     commitment?: Commitment,

--- a/token/js/src/state/account.ts
+++ b/token/js/src/state/account.ts
@@ -82,11 +82,7 @@ export const AccountLayout = struct<RawAccount>([
 /** Byte length of a token account */
 export const ACCOUNT_SIZE = AccountLayout.span;
 
-function info2Account(
-    info: AccountInfo<Buffer> | null,
-    address: PublicKey,
-    programId: PublicKey,
-) {
+function unpackTokenAccount(info: AccountInfo<Buffer> | null, address: PublicKey, programId: PublicKey) {
     if (!info) throw new TokenAccountNotFoundError();
     if (!info.owner.equals(programId)) throw new TokenInvalidAccountOwnerError();
     if (info.data.length < ACCOUNT_SIZE) throw new TokenInvalidAccountSizeError();
@@ -132,10 +128,10 @@ export async function getMultipleAccounts(
     programId = TOKEN_PROGRAM_ID
 ): Promise<Account[]> {
     const infos = await connection.getMultipleAccountsInfo(addresses, commitment);
-    let accounts = [];
-    for (let i=0; i < infos.length; i++) {
-        let account = info2Account(infos[i], addresses[i], programId)
-        accounts.push(account)
+    const accounts = [];
+    for (let i = 0; i < infos.length; i++) {
+        const account = unpackTokenAccount(infos[i], addresses[i], programId);
+        accounts.push(account);
     }
     return accounts;
 }
@@ -157,7 +153,7 @@ export async function getAccount(
     programId = TOKEN_PROGRAM_ID
 ): Promise<Account> {
     const info = await connection.getAccountInfo(address, commitment);
-    return info2Account(info, address, programId)
+    return unpackTokenAccount(info, address, programId);
 }
 
 /** Get the minimum lamport balance for a base token account to be rent exempt


### PR DESCRIPTION
impl of `getMultipleAccounts` allows to request **multiple token accounts in a single RPC call** compared to `getAccount` which can only get 1 account per RPC call 