### PR TITLE
scripts: Update solana_version in Anchor.toml with dependencies

### DIFF
--- a/update-solana-dependencies.sh
+++ b/update-solana-dependencies.sh
@@ -14,6 +14,7 @@ source ./ci/solana-version.sh
 old_solana_ver=${solana_version#v}
 
 sed -i'' -e "s#solana_version=v.*#solana_version=v${solana_ver}#" ./ci/solana-version.sh
+sed -i'' -e "s#solana_version = \".*\"#solana_version = \"${solana_ver}\"#" ./Anchor.toml
 
 declare tomls=()
 while IFS='' read -r line; do tomls+=("$line"); done < <(find . -name Cargo.toml)


### PR DESCRIPTION
#### Problem

The `solana_version` in `Anchor.toml` isn't updated with the rest of the dependencies during `update-solana-dependencies.sh`, which leads to awkward updates later on bundled up with other changes.

#### Solution

Also update `solana_version` during `update-solana-dependencies.sh`