### PR TITLE
Skip patching zk-token-sdk in twoxtx tests

### DIFF
--- a/patch.crates-io.sh
+++ b/patch.crates-io.sh
@@ -3,7 +3,24 @@
 # Patches the SPL crates for developing against a local solana monorepo
 #
 
-solana_dir=$1
+maybe_patch_zk_token_sdk=true
+positional_args=()
+while [[ -n $1 ]]; do
+  if [[ ${1:0:1} = - ]]; then
+    if [[ $1 == --no-patch-zk-token-sdk ]]; then
+      maybe_patch_zk_token_sdk=false
+      shift
+    else
+      echo "unexpected argument: $1" 1>&2
+      exit 1
+    fi
+  else
+    positional_args=($1)
+    shift
+  fi
+done
+
+solana_dir=${positional_args[0]}
 if [[ -z $solana_dir ]]; then
   echo "Usage: $0 <path-to-solana-monorepo>"
   exit 1
@@ -47,7 +64,9 @@ crates_map+=("solana-stake-program programs/stake")
 crates_map+=("solana-transaction-status transaction-status")
 crates_map+=("solana-version version")
 crates_map+=("solana-vote-program programs/vote")
-crates_map+=("solana-zk-token-sdk zk-token-sdk")
+if $maybe_patch_zk_token_sdk; then
+  crates_map+=("solana-zk-token-sdk zk-token-sdk")
+fi
 
 patch_crates=()
 for map_entry in "${crates_map[@]}"; do

--- a/token/twoxtx-setup.sh
+++ b/token/twoxtx-setup.sh
@@ -24,5 +24,5 @@ if [[ ! -f twoxtx-solana/.twoxtx-patched ]]; then
   touch twoxtx-solana/.twoxtx-patched
 fi
 
-../patch.crates-io.sh twoxtx-solana
+../patch.crates-io.sh twoxtx-solana --no-patch-zk-token-sdk
 exit 0


### PR DESCRIPTION
There may be breaking changes coming to solana-zk-token-sdk... we don't want to bust token CI for everyone when they do. Currently, twoxtx-setup.sh pulls the monorepo master and patches all the solana crates, pulling any changes merged upstream and breaking the confidential-transfer tests if they haven't been updated yet.

This PR skips patching the zk-token-sdk crate for twoxtx tests so it depends on a manual bump and stays in sync with the extension.