### PR TITLE
token-js: Update @solana/web3.js dependency

### DIFF
--- a/token/js/package.json
+++ b/token/js/package.json
@@ -45,7 +45,7 @@
     "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
         "@solana/buffer-layout-utils": "^0.2.0",
-        "@solana/web3.js": "^1.32.0",
+        "@solana/web3.js": "^1.36.0",
         "start-server-and-test": "^1.14.0"
     },
     "devDependencies": {

--- a/token/js/yarn.lock
+++ b/token/js/yarn.lock
@@ -150,10 +150,10 @@
   dependencies:
     buffer "~6.0.3"
 
-"@solana/web3.js@^1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.32.0.tgz#b9821de52d0e773c363516c3dcef9be701295d82"
-  integrity sha512-jquZ/VBvM3zXAaTJvdWd9mlP0WiZaZqjji0vw5UAsb5IKIossrLhHtyUqMfo41Qkdwu1aVwf7YWG748i4XIJnw==
+"@solana/web3.js@^1.32.0", "@solana/web3.js@^1.36.0":
+  version "1.36.0"
+  resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.36.0.tgz#79d7d5217b49b80139f4de68953adc5b9a9a264f"
+  integrity sha512-RNT1451iRR7TyW7EJKMCrH/0OXawIe4zVm0DWQASwXlR/u1jmW6FrmH0lujIh7cGTlfOVbH+2ZU9AVUPLBFzwA==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@ethersproject/sha2" "^5.5.0"


### PR DESCRIPTION
#### Problem

Updating the token-js package to the newest web3.js causes an issue when resolving buffer-layout-utils.  We need the newest version in order to land #2990

#### Solution

Update package.json and yarn.lock for the change.