### PR TITLE
Bump zk token sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.3.0",
  "cpufeatures",
  "opaque-debug",
 ]
@@ -56,7 +56,7 @@ checksum = "589c637f0e68c877bbd59a4599bbe849cac8e5f3e4b5a3ebae8f528cd218dcdc"
 dependencies = [
  "aead",
  "aes",
- "cipher",
+ "cipher 0.3.0",
  "ctr",
  "polyval",
  "subtle",
@@ -346,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.7.3"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439989e6b8c38d1b6570a384ef1e49c8848128f5a97f3914baef02920842712f"
+checksum = "0e851ca7c24871e7336801608a4797d7376545b6928a10d32d75685687141ead"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -479,6 +479,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -634,6 +644,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,14 +689,14 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
 dependencies = [
- "cipher",
+ "cipher 0.3.0",
 ]
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
 dependencies = [
  "byteorder",
  "digest",
@@ -1451,6 +1471,15 @@ dependencies = [
  "quote 1.0.14",
  "syn 1.0.84",
  "unindent",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1f03d4ab4d5dc9ec2d219f86c15d2a15fc08239d1cd3b2d6a19717c0a2f443"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -3482,9 +3511,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "0.8.1"
+version = "1.10.1-pre1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b149253f9ed1afb68b3161b53b62b637d0dd7a3b328dffdc8bb5878d48358e"
+checksum = "1cfe2e56c739d38cd1f9492baf9cb5a885e7d3331701ab4c7d65f50637d47b6e"
 dependencies = [
  "aes-gcm-siv",
  "arrayref",
@@ -3492,7 +3521,7 @@ dependencies = [
  "bincode",
  "bytemuck",
  "byteorder",
- "cipher",
+ "cipher 0.4.3",
  "curve25519-dalek",
  "getrandom 0.1.16",
  "lazy_static",

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -1126,8 +1126,8 @@ where
             ),
             source_elgamal_keypair,
             (
-                &destination_extension.pubkey_elgamal.try_into().unwrap(),
-                &ct_mint.pubkey_auditor.try_into().unwrap(),
+                &destination_extension.encryption_pubkey.try_into().unwrap(),
+                &ct_mint.auditor_pubkey.try_into().unwrap(),
             ),
         )
         .map_err(TokenError::Proof)?;

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -45,8 +45,8 @@ impl ConfidentialTransferMintWithKeypairs {
         let ct_mint = ConfidentialTransferMint {
             authority: ct_mint_authority.pubkey().into(),
             auto_approve_new_accounts: true.into(),
-            pubkey_auditor: ct_mint_transfer_auditor.public.into(),
-            pubkey_withdraw_withheld_authority: ct_mint_withdraw_withheld_authority.public.into(),
+            auditor_pubkey: ct_mint_transfer_auditor.public.into(),
+            withdraw_withheld_authority_pubkey: ct_mint_withdraw_withheld_authority.public.into(),
             withheld_amount: EncryptedWithheldAmount::zeroed(),
         };
         Self {
@@ -235,7 +235,7 @@ async fn ct_configure_token_account() {
     assert!(!bool::from(&extension.approved));
     assert!(bool::from(&extension.allow_balance_credits));
     assert_eq!(
-        extension.pubkey_elgamal,
+        extension.encryption_pubkey,
         alice_meta.elgamal_keypair.public.into()
     );
     assert_eq!(

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -19,7 +19,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 num_enum = "0.5.4"
 solana-program = "1.9.9"
-solana-zk-token-sdk = "0.8.1"
+solana-zk-token-sdk = "1.10.1-pre1"
 spl-memo = { version = "3.0.1", path = "../../memo/program", features = [ "no-entrypoint" ] }
 spl-token = { version = "3.3",  path = "../program", features = ["no-entrypoint"] }
 thiserror = "1.0"

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -353,7 +353,7 @@ pub enum ConfidentialTransferInstruction {
 #[repr(C)]
 pub struct ConfigureAccountInstructionData {
     /// The public key associated with the account
-    pub elgamal_pubkey: EncryptionPubkey,
+    pub encryption_pubkey: EncryptionPubkey,
     /// The decryptable balance (always 0) once the configure account succeeds
     pub decryptable_zero_balance: DecryptableBalance,
 }
@@ -514,7 +514,7 @@ pub fn configure_account(
     token_program_id: &Pubkey,
     token_account: &Pubkey,
     mint: &Pubkey,
-    elgamal_pubkey: ElGamalPubkey,
+    encryption_pubkey: ElGamalPubkey,
     decryptable_zero_balance: AeCiphertext,
     authority: &Pubkey,
     multisig_signers: &[&Pubkey],
@@ -535,7 +535,7 @@ pub fn configure_account(
         accounts,
         ConfidentialTransferInstruction::ConfigureAccount,
         &ConfigureAccountInstructionData {
-            elgamal_pubkey: elgamal_pubkey.into(),
+            encryption_pubkey: encryption_pubkey.into(),
             decryptable_zero_balance: decryptable_zero_balance.into(),
         },
     ))

--- a/token/program-2022/src/extension/confidential_transfer/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer/mod.rs
@@ -50,14 +50,14 @@ pub struct ConfidentialTransferMint {
     /// * If non-zero, transfers must include ElGamal cypertext with this public key permitting the
     /// auditor to decode the transfer amount.
     /// * If all zero, auditing is currently disabled.
-    pub pubkey_auditor: EncryptionPubkey,
+    pub auditor_pubkey: EncryptionPubkey,
 
     /// * If non-zero, transfers must include ElGamal cypertext of the transfer fee with this
     /// public key. If this is the case, but the base mint is not extended for fees, then any
     /// transfer will fail.
     /// * If all zero, transfer fee is disabled. If this is the case, but the base mint is extended
     /// for fees, then any transfer will fail.
-    pub pubkey_withdraw_withheld_authority: EncryptionPubkey,
+    pub withdraw_withheld_authority_pubkey: EncryptionPubkey,
 
     /// Withheld transfer fee confidential tokens that have been moved to the mint for withdrawal.
     /// This will always be zero if fees are never enabled.
@@ -77,7 +77,7 @@ pub struct ConfidentialTransferAccount {
     pub approved: PodBool,
 
     /// The public key associated with ElGamal encryption
-    pub pubkey_elgamal: EncryptionPubkey,
+    pub encryption_pubkey: EncryptionPubkey,
 
     /// The pending balance (encrypted by `pubkey_elgamal`)
     pub pending_balance: EncryptedBalance,

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -679,7 +679,8 @@ fn process_destination_for_transfer(
         return Err(TokenError::ConfidentialTransferDepositsAndTransfersDisabled.into());
     }
 
-    if *destination_encryption_pubkey != destination_confidential_transfer_account.encryption_pubkey {
+    if *destination_encryption_pubkey != destination_confidential_transfer_account.encryption_pubkey
+    {
         return Err(TokenError::ConfidentialTransferElGamalPubkeyMismatch.into());
     }
 
@@ -867,7 +868,8 @@ fn process_withdraw_withheld_tokens_from_mint(
     }
 
     // destination ElGamal pubkey should match in the proof data and destination account
-    if proof_data.destination_pubkey != destination_confidential_transfer_account.encryption_pubkey {
+    if proof_data.destination_pubkey != destination_confidential_transfer_account.encryption_pubkey
+    {
         return Err(TokenError::ConfidentialTransferElGamalPubkeyMismatch.into());
     }
 
@@ -988,7 +990,8 @@ fn process_withdraw_withheld_tokens_from_accounts(
     }
 
     // destination ElGamal pubkey should match in the proof data and destination account
-    if proof_data.destination_pubkey != destination_confidential_transfer_account.encryption_pubkey {
+    if proof_data.destination_pubkey != destination_confidential_transfer_account.encryption_pubkey
+    {
         return Err(TokenError::ConfidentialTransferElGamalPubkeyMismatch.into());
     }
 


### PR DESCRIPTION
Upgrading to zk-token-sdk `1.10.1-pre1`. Just updating the variable names in this PR. Will update range proof in a subsequent PR.