### PR TITLE
token-2022: Refactor extension instruction encoding / decoding

### DIFF
--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -6,6 +6,7 @@ use {
             confidential_transfer::{instruction::*, *},
             StateWithExtensions, StateWithExtensionsMut,
         },
+        instruction::{decode_instruction_data, decode_instruction_type},
         processor::Processor,
         state::{Account, Mint},
     },

--- a/token/program-2022/src/extension/memo_transfer/instruction.rs
+++ b/token/program-2022/src/extension/memo_transfer/instruction.rs
@@ -1,12 +1,14 @@
 use {
-    crate::{check_program_account, error::TokenError, instruction::TokenInstruction},
+    crate::{
+        check_program_account,
+        instruction::{encode_instruction, TokenInstruction},
+    },
     num_enum::{IntoPrimitive, TryFromPrimitive},
     solana_program::{
         instruction::{AccountMeta, Instruction},
         program_error::ProgramError,
         pubkey::Pubkey,
     },
-    std::convert::TryFrom,
 };
 
 /// Default Account State extension instructions
@@ -44,30 +46,6 @@ pub enum RequiredMemoTransfersInstruction {
     Disable,
 }
 
-pub(crate) fn decode_instruction(
-    input: &[u8],
-) -> Result<RequiredMemoTransfersInstruction, ProgramError> {
-    if input.len() != 1 {
-        return Err(TokenError::InvalidInstruction.into());
-    }
-    RequiredMemoTransfersInstruction::try_from(input[0])
-        .map_err(|_| TokenError::InvalidInstruction.into())
-}
-
-fn encode_instruction(
-    token_program_id: &Pubkey,
-    accounts: Vec<AccountMeta>,
-    instruction_type: RequiredMemoTransfersInstruction,
-) -> Instruction {
-    let mut data = TokenInstruction::MemoTransferExtension.pack();
-    data.push(instruction_type.into());
-    Instruction {
-        program_id: *token_program_id,
-        accounts,
-        data,
-    }
-}
-
 /// Create an `Enable` instruction
 pub fn enable_required_transfer_memos(
     token_program_id: &Pubkey,
@@ -86,7 +64,9 @@ pub fn enable_required_transfer_memos(
     Ok(encode_instruction(
         token_program_id,
         accounts,
+        TokenInstruction::MemoTransferExtension,
         RequiredMemoTransfersInstruction::Enable,
+        &(),
     ))
 }
 
@@ -108,6 +88,8 @@ pub fn disable_required_transfer_memos(
     Ok(encode_instruction(
         token_program_id,
         accounts,
+        TokenInstruction::MemoTransferExtension,
         RequiredMemoTransfersInstruction::Disable,
+        &(),
     ))
 }

--- a/token/program-2022/src/extension/memo_transfer/processor.rs
+++ b/token/program-2022/src/extension/memo_transfer/processor.rs
@@ -2,12 +2,10 @@ use {
     crate::{
         check_program_account,
         extension::{
-            memo_transfer::{
-                instruction::{decode_instruction, RequiredMemoTransfersInstruction},
-                MemoTransfer,
-            },
+            memo_transfer::{instruction::RequiredMemoTransfersInstruction, MemoTransfer},
             StateWithExtensionsMut,
         },
+        instruction::decode_instruction_type,
         processor::Processor,
         state::Account,
     },
@@ -85,8 +83,7 @@ pub(crate) fn process_instruction(
 ) -> ProgramResult {
     check_program_account(program_id)?;
 
-    let instruction = decode_instruction(input)?;
-    match instruction {
+    match decode_instruction_type(input)? {
         RequiredMemoTransfersInstruction::Enable => {
             msg!("RequiredMemoTransfersInstruction::Enable");
             process_enable_required_memo_transfers(program_id, accounts)


### PR DESCRIPTION
#### Problem

There are a lot of copies of instruction encoding / decoding in the extensions.

#### Solution

Unify most of them!  A few notes:

* the default account extension can't easily follow this model because the data passed in is `AccountState`, and not `Pod`, so I excluded it from this
* this changes the confidential token instruction to use `num_enum` instead of `num_traits`, which has a bit more in terms of type and size safety