### PR TITLE
Governance: Update addin accounts discriminators to Anchor compatible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3678,7 +3678,7 @@ dependencies = [
 
 [[package]]
 name = "spl-governance"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "arrayref",
  "assert_matches",
@@ -3703,7 +3703,7 @@ dependencies = [
 
 [[package]]
 name = "spl-governance-addin-api"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "borsh",
  "solana-program",
@@ -3712,7 +3712,7 @@ dependencies = [
 
 [[package]]
 name = "spl-governance-addin-mock"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "arrayref",
  "assert_matches",
@@ -3736,7 +3736,7 @@ dependencies = [
 
 [[package]]
 name = "spl-governance-chat"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "arrayref",
  "assert_matches",

--- a/governance/addin-api/Cargo.toml
+++ b/governance/addin-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-governance-addin-api"
-version = "0.1.1"
+version = "0.1.2"
 description = "Solana Program Library Governance Addin Api"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/governance/addin-api/src/max_voter_weight.rs
+++ b/governance/addin-api/src/max_voter_weight.rs
@@ -40,11 +40,13 @@ impl AccountMaxSize for MaxVoterWeightRecord {}
 
 impl MaxVoterWeightRecord {
     /// sha256("account:MaxVoterWeightRecord")[..8]
-    pub const ACCOUNT_DISCRIMINATOR: [u8; 8] = *b"9d5ff297";
+    pub const ACCOUNT_DISCRIMINATOR: [u8; 8] = [157, 95, 242, 151, 16, 98, 26, 118];
 }
 
 impl IsInitialized for MaxVoterWeightRecord {
     fn is_initialized(&self) -> bool {
         self.account_discriminator == MaxVoterWeightRecord::ACCOUNT_DISCRIMINATOR
+         // Check for legacy discriminator which is not compatible with Anchor but is used by older plugins
+        || self.account_discriminator ==*b"9d5ff297"
     }
 }

--- a/governance/addin-api/src/voter_weight.rs
+++ b/governance/addin-api/src/voter_weight.rs
@@ -73,7 +73,7 @@ pub struct VoterWeightRecord {
 
 impl VoterWeightRecord {
     /// sha256("account:VoterWeightRecord")[..8]
-    pub const ACCOUNT_DISCRIMINATOR: [u8; 8] = *b"2ef99b4b";
+    pub const ACCOUNT_DISCRIMINATOR: [u8; 8] = [46, 249, 155, 75, 153, 248, 116, 9];
 }
 
 impl AccountMaxSize for VoterWeightRecord {}
@@ -81,5 +81,7 @@ impl AccountMaxSize for VoterWeightRecord {}
 impl IsInitialized for VoterWeightRecord {
     fn is_initialized(&self) -> bool {
         self.account_discriminator == VoterWeightRecord::ACCOUNT_DISCRIMINATOR
+            // Check for legacy discriminator which is not compatible with Anchor but is used by older plugins
+            || self.account_discriminator == *b"2ef99b4b"
     }
 }

--- a/governance/addin-mock/program/Cargo.toml
+++ b/governance/addin-mock/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-governance-addin-mock"
-version = "0.1.1"
+version = "0.1.2"
 description = "Solana Program Library Governance Voter Weight Addin Program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -21,7 +21,7 @@ serde = "1.0.127"
 serde_derive = "1.0.103"
 solana-program = "1.9.9"
 spl-token = { version = "3.3", path = "../../../token/program", features = [ "no-entrypoint" ] }
-spl-governance-addin-api= { version = "0.1.1", path ="../../addin-api"}
+spl-governance-addin-api= { version = "0.1.2", path ="../../addin-api"}
 spl-governance-tools= { version = "0.1.2", path ="../../tools"}
 thiserror = "1.0"
 

--- a/governance/chat/program/Cargo.toml
+++ b/governance/chat/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-governance-chat"
-version = "0.2.4"
+version = "0.2.5"
 description = "Solana Program Library Governance Chat Program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -21,9 +21,9 @@ serde = "1.0.127"
 serde_derive = "1.0.103"
 solana-program = "1.9.9"
 spl-token = { version = "3.3", path = "../../../token/program", features = [ "no-entrypoint" ] }
-spl-governance= { version = "2.2.3", path ="../../program", features = [ "no-entrypoint" ]}
+spl-governance= { version = "2.2.4", path ="../../program", features = [ "no-entrypoint" ]}
 spl-governance-tools= { version = "0.1.2", path ="../../tools"}
-spl-governance-addin-api= { version = "0.1.1", path ="../../addin-api"}
+spl-governance-addin-api= { version = "0.1.2", path ="../../addin-api"}
 thiserror = "1.0"
 
 
@@ -34,7 +34,7 @@ proptest = "1.0"
 solana-program-test = "1.9.9"
 solana-sdk = "1.9.9"
 spl-governance-test-sdk = { version = "0.1.2", path ="../../test-sdk"}
-spl-governance-addin-mock = { version = "0.1.1", path ="../../addin-mock/program"}
+spl-governance-addin-mock = { version = "0.1.2", path ="../../addin-mock/program"}
 
 
 [lib]

--- a/governance/program/Cargo.toml
+++ b/governance/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-governance"
-version = "2.2.3"
+version = "2.2.4"
 description = "Solana Program Library Governance Program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -22,7 +22,7 @@ serde_derive = "1.0.103"
 solana-program = "1.9.9"
 spl-token = { version = "3.3", path = "../../token/program", features = [ "no-entrypoint" ] }
 spl-governance-tools= { version = "0.1.2", path ="../tools"}
-spl-governance-addin-api= { version = "0.1.1", path ="../addin-api"}
+spl-governance-addin-api= { version = "0.1.2", path ="../addin-api"}
 thiserror = "1.0"
 
 [dev-dependencies]
@@ -32,7 +32,7 @@ proptest = "1.0"
 solana-program-test = "1.9.9"
 solana-sdk = "1.9.9"
 spl-governance-test-sdk = { version = "0.1.2", path ="../test-sdk"}
-spl-governance-addin-mock = { version = "0.1.1", path ="../addin-mock/program"}
+spl-governance-addin-mock = { version = "0.1.2", path ="../addin-mock/program"}
 
 
 [lib]


### PR DESCRIPTION
#### Summary

`MaxVoterWeightRecord` and `VoterWeightRecord` are defined in `spl-governance-addin-api` but they are owned by the addin programs. In order to make them easier to use in `Anchor` based programs their discriminators were updated to match the ones automatically generated by `Anchor`.

For backward compatibility with existing addins the legacy discriminator are also considered as valid ones.

