### PR TITLE
ci: Bump Node from v12 to v14 for spl-token downstream users

### DIFF
--- a/.github/workflows/pull-request-token-lending.yml
+++ b/.github/workflows/pull-request-token-lending.yml
@@ -69,7 +69,7 @@ jobs:
   js-test:
     runs-on: ubuntu-latest
     env:
-      NODE_VERSION: 12.x
+      NODE_VERSION: 14.x
     needs: cargo-test-bpf
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pull-request-token-swap.yml
+++ b/.github/workflows/pull-request-token-swap.yml
@@ -84,7 +84,7 @@ jobs:
   js-test:
     runs-on: ubuntu-latest
     env:
-      NODE_VERSION: 12.x
+      NODE_VERSION: 14.x
     needs: cargo-test-bpf
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
#### Problem

#3046 failed CI on token-lending JS because it's using Node 12 whereas `@solana/spl-token` requires version 14.

#### Solution

Bump the CI environment to use Node 14 where it was using 12 before.