### PR TITLE
deps: Update bytemuck_derive to 1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e215f8c2f9f79cb53c8335e687ffd07d5bfcb6fe5fc80723762d0be46e7cc54"
+checksum = "562e382481975bc61d11275ac5e62a19abd00b0547d99516a415336f183dcd0e"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.14",


### PR DESCRIPTION
#### Problem

Downstream builds are failing because of mixed versions of `bytemuck_derive`.

#### Solution

Update the dependency to 1.1