### PR TITLE
DO NOT MERGE: Borsh vs bincode numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3799,6 +3799,7 @@ dependencies = [
 name = "spl-math"
 version = "0.1.0"
 dependencies = [
+ "bincode",
  "borsh",
  "borsh-derive",
  "num-derive",

--- a/libraries/math/Cargo.toml
+++ b/libraries/math/Cargo.toml
@@ -12,6 +12,7 @@ no-entrypoint = []
 test-bpf = []
 
 [dependencies]
+bincode = "1.3.3"
 borsh = "0.9"
 borsh-derive = "0.9.0"
 num-derive = "0.3"

--- a/libraries/math/src/instruction.rs
+++ b/libraries/math/src/instruction.rs
@@ -3,7 +3,10 @@
 use {
     crate::id,
     borsh::{BorshDeserialize, BorshSerialize},
-    solana_program::instruction::Instruction,
+    solana_program::{
+        instruction::{AccountMeta, Instruction},
+        pubkey::Pubkey,
+    },
 };
 
 /// Instructions supported by the math program, used for testing instruction
@@ -74,6 +77,16 @@ pub enum MathInstruction {
     ///
     /// No accounts required for this instruction
     Noop,
+    /// Deserialize with Borsh
+    ///
+    /// Accounts required for this instruction:
+    /// 0. Stake account
+    Borsh,
+    /// Deserialize with Bincode
+    ///
+    /// Accounts required for this instruction:
+    /// 0. Stake account
+    Bincode,
 }
 
 /// Create PreciseSquareRoot instruction
@@ -165,6 +178,24 @@ pub fn noop() -> Instruction {
         program_id: id(),
         accounts: vec![],
         data: MathInstruction::Noop.try_to_vec().unwrap(),
+    }
+}
+
+/// Create Borsh instruction
+pub fn borsh(stake: &Pubkey) -> Instruction {
+    Instruction {
+        program_id: id(),
+        accounts: vec![AccountMeta::new_readonly(*stake, false)],
+        data: MathInstruction::Borsh.try_to_vec().unwrap(),
+    }
+}
+
+/// Create Bincode instruction
+pub fn bincode(stake: &Pubkey) -> Instruction {
+    Instruction {
+        program_id: id(),
+        accounts: vec![AccountMeta::new_readonly(*stake, false)],
+        data: MathInstruction::Bincode.try_to_vec().unwrap(),
     }
 }
 


### PR DESCRIPTION
#### Problem

The advantages of Borsh over bincode aren't documented anywhere with real numbers.

#### Solution

Provide one example of deserializing a stake account with borsh vs bincode.  The difference is really staggering! bincode takes up almost 10x compute units for one account deserialization, and that doesn't include the overhead for making the instruction call.