### PR TITLE
token-cli: Add compatibility for token-2022

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6167,6 +6167,7 @@ dependencies = [
  "spl-associated-token-account 1.0.5",
  "spl-memo 3.0.1",
  "spl-token 3.3.0",
+ "spl-token-2022 0.4.1",
  "strum",
  "strum_macros",
  "tempfile",

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -28,6 +28,7 @@ solana-remote-wallet = "=1.10.29"
 solana-sdk = "=1.10.29"
 solana-transaction-status = "=1.10.29"
 spl-token = { version = "3.3", path="../program", features = [ "no-entrypoint" ] }
+spl-token-2022 = { version = "0.4", path="../program-2022", features = [ "no-entrypoint" ] }
 spl-associated-token-account = { version = "1.0.5", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
 spl-memo = { version = "3.0.1", path="../../memo/program", features = ["no-entrypoint"] }
 strum = "0.24"

--- a/token/cli/src/bench.rs
+++ b/token/cli/src/bench.rs
@@ -16,7 +16,8 @@ use {
         system_instruction,
     },
     spl_associated_token_account::*,
-    spl_token::{
+    spl_token_2022::{
+        extension::StateWithExtensions,
         instruction,
         state::{Account, Mint},
     },
@@ -265,7 +266,7 @@ async fn get_valid_mint_program_id(
         .await
         .map_err(|err| format!("Token mint {} does not exist: {}", token, err))?;
 
-    Mint::unpack(&mint_account.data)
+    StateWithExtensions::<Mint>::unpack(&mint_account.data)
         .map_err(|err| format!("Invalid token mint {}: {}", token, err))?;
     Ok(mint_account.owner)
 }
@@ -341,9 +342,9 @@ async fn command_close_accounts(
 
         for (account, (address, _seed)) in accounts_chunk.iter().zip(address_chunk) {
             if let Some(account) = account {
-                match Account::unpack(&account.data) {
+                match StateWithExtensions::<Account>::unpack(&account.data) {
                     Ok(token_account) => {
-                        if token_account.amount != 0 {
+                        if token_account.base.amount != 0 {
                             eprintln!(
                                 "Token account {} holds a balance; unable to close it",
                                 address,

--- a/token/cli/src/sort.rs
+++ b/token/cli/src/sort.rs
@@ -16,6 +16,10 @@ pub(crate) struct UnsupportedAccount {
     pub err: String,
 }
 
+pub(crate) fn is_supported_program(program_name: &str) -> bool {
+    program_name == "spl-token" || program_name == "spl-token-2022"
+}
+
 pub(crate) fn sort_and_parse_token_accounts(
     owner: &Pubkey,
     accounts: Vec<RpcKeyedAccount>,
@@ -29,7 +33,7 @@ pub(crate) fn sort_and_parse_token_accounts(
         let address = keyed_account.pubkey;
 
         if let UiAccountData::Json(parsed_account) = keyed_account.account.data {
-            if parsed_account.program != "spl-token" {
+            if !is_supported_program(&parsed_account.program) {
                 unsupported_accounts.push(UnsupportedAccount {
                     address,
                     err: format!("Unsupported account program: {}", parsed_account.program),


### PR DESCRIPTION
#### Problem

The token CLI only works with `Tokenkeg...` and not `Tokenz...`.

#### Solution

Support both of them at once!  Most of the changes here involve deserializing accounts with extensions, and passing in the program id correctly.