### PR TITLE
made lending market authority param optional in deposit reserve liquidity

### DIFF
--- a/token-lending/js/src/instructions/depositReserveLiquidity.ts
+++ b/token-lending/js/src/instructions/depositReserveLiquidity.ts
@@ -20,8 +20,8 @@ export const depositReserveLiquidityInstruction = (
     reserveLiquiditySupply: PublicKey,
     reserveCollateralMint: PublicKey,
     lendingMarket: PublicKey,
-    lendingMarketAuthority: PublicKey,
-    transferAuthority: PublicKey
+    transferAuthority: PublicKey,
+    lendingMarketAuthority?: PublicKey
 ): TransactionInstruction => {
     const data = Buffer.alloc(DataLayout.span);
     DataLayout.encode(
@@ -39,11 +39,14 @@ export const depositReserveLiquidityInstruction = (
         { pubkey: reserveLiquiditySupply, isSigner: false, isWritable: true },
         { pubkey: reserveCollateralMint, isSigner: false, isWritable: true },
         { pubkey: lendingMarket, isSigner: false, isWritable: false },
-        { pubkey: lendingMarketAuthority, isSigner: false, isWritable: false },
         { pubkey: transferAuthority, isSigner: true, isWritable: false },
         { pubkey: SYSVAR_CLOCK_PUBKEY, isSigner: false, isWritable: false },
         { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
     ];
+
+    if (lendingMarketAuthority) {
+        keys.push({pubkey: lendingMarketAuthority, isSigner: false, isWritable: false})
+    }
 
     return new TransactionInstruction({
         keys,

--- a/token-lending/js/src/instructions/depositReserveLiquidity.ts
+++ b/token-lending/js/src/instructions/depositReserveLiquidity.ts
@@ -45,7 +45,7 @@ export const depositReserveLiquidityInstruction = (
     ];
 
     if (lendingMarketAuthority) {
-        keys.push({pubkey: lendingMarketAuthority, isSigner: false, isWritable: false})
+        keys.push({ pubkey: lendingMarketAuthority, isSigner: false, isWritable: false });
     }
 
     return new TransactionInstruction({


### PR DESCRIPTION
### **Problem**
The TypeScript implementation of `depositReserveLiquidityInstruction` currently requires supplying the `lendingMarketAuthority` pubkey. This stands in contrast with the Rust program where the `lendingMarketAuthority` is derived within the instruction itself as seen below. As a result, developers must redundantly derive the `lendingMarketAuthority` pubkey ahead of time.

```rust
/// Creates a 'DepositReserveLiquidity' instruction.
#[allow(clippy::too_many_arguments)]
pub fn deposit_reserve_liquidity(
    program_id: Pubkey,
    liquidity_amount: u64,
    source_liquidity_pubkey: Pubkey,
    destination_collateral_pubkey: Pubkey,
    reserve_pubkey: Pubkey,
    reserve_liquidity_supply_pubkey: Pubkey,
    reserve_collateral_mint_pubkey: Pubkey,
    lending_market_pubkey: Pubkey,
    user_transfer_authority_pubkey: Pubkey,
) -> Instruction {
    let (lending_market_authority_pubkey, _bump_seed) = Pubkey::find_program_address(
        &[&lending_market_pubkey.to_bytes()[..PUBKEY_BYTES]],
        &program_id,
    );
    Instruction {
        program_id,
        accounts: vec![
            AccountMeta::new(source_liquidity_pubkey, false),
            AccountMeta::new(destination_collateral_pubkey, false),
            AccountMeta::new(reserve_pubkey, false),
            AccountMeta::new(reserve_liquidity_supply_pubkey, false),
            AccountMeta::new(reserve_collateral_mint_pubkey, false),
            AccountMeta::new_readonly(lending_market_pubkey, false),
            AccountMeta::new_readonly(lending_market_authority_pubkey, false),
            AccountMeta::new_readonly(user_transfer_authority_pubkey, true),
            AccountMeta::new_readonly(sysvar::clock::id(), false),
            AccountMeta::new_readonly(spl_token::id(), false),
        ],
        data: LendingInstruction::DepositReserveLiquidity { liquidity_amount }.pack(),
    }
}
```

---

### **Summary of Changes**
These changes make supplying the `lendingMarketAuthority` parameter optional.
