### PR TITLE
Remove duplciate output of 'Stake Accounts' header

### DIFF
--- a/stake-pool/cli/src/output.rs
+++ b/stake-pool/cli/src/output.rs
@@ -167,8 +167,7 @@ impl VerboseDisplay for CliStakePool {
             &self.sol_referral_fee
         )?;
         writeln!(w)?;
-        writeln!(w, "Stake Accounts")?;
-        writeln!(w, "--------------")?;
+
         match &self.details {
             None => {}
             Some(details) => {
@@ -294,7 +293,6 @@ impl Display for CliStakePoolDetails {
 impl QuietDisplay for CliStakePoolDetails {}
 impl VerboseDisplay for CliStakePoolDetails {
     fn write_str(&self, w: &mut dyn Write) -> Result {
-        writeln!(w)?;
         writeln!(w, "Stake Accounts")?;
         writeln!(w, "--------------")?;
         writeln!(


### PR DESCRIPTION
**Problem:**

'list -v' command prints 'Stake accounts' header twice.
It looks as follows:

Stake Deposit Referral Fee: 50% of Stake Deposit Fee
SOL Deposit Referral Fee: 50% of SOL Deposit Fee

Stake Accounts
--------------

Stake Accounts
--------------
Reserve Account: GYEzowUBH3XeLjke9z38To1HP8T88K1MGaCq7GJYSso7	Available Balance: ◎0.062412670

**Solution:**

Remove duplicate output of 'Stake Accounts' header
