### PR TITLE
token-2022: fix confidential transfer tests

### DIFF
--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -538,7 +538,6 @@ async fn ct_withdraw() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn ct_transfer() {
     let ConfidentialTransferMintWithKeypairs { ct_mint, .. } =
         ConfidentialTransferMintWithKeypairs::new();

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -24,7 +24,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 num_enum = "0.5.4"
 solana-program = "1.10.8"
-solana-zk-token-sdk = "1.10.1-pre1"
+solana-zk-token-sdk = "1.10.8"
 spl-memo = { version = "3.0.1", path = "../../memo/program", features = [ "no-entrypoint" ] }
 spl-token = { version = "3.3",  path = "../program", features = ["no-entrypoint"] }
 thiserror = "1.0"


### PR DESCRIPTION
The zk-token-sdk is upgraded to 1.10.8. The confidential transfer test that was ignored previously ([#3000](https://github.com/solana-labs/solana-program-library/issues/3000)) should now work.