### PR TITLE
token-2022: Add compatibility test for instructions

### DIFF
--- a/token/program/src/instruction.rs
+++ b/token/program/src/instruction.rs
@@ -1392,7 +1392,7 @@ pub fn get_account_data_size(
 
     Ok(Instruction {
         program_id: *token_program_id,
-        accounts: vec![AccountMeta::new(*mint_pubkey, false)],
+        accounts: vec![AccountMeta::new_readonly(*mint_pubkey, false)],
         data: TokenInstruction::GetAccountDataSize.pack(),
     })
 }


### PR DESCRIPTION
#### Problem

While doing the work to parse token-2022 and token-v3 instructions, it became clear that we're not totally sure about the compatibility between token-2022 and token-v3.

#### Solution

Since token-2022 is meant to be a superset of token-v3, be sure that all of the instruction creators make the same exact instructions.  This way, when testing instruction parsing on the validator, we can be sure that we only need to support the token-2022 variants.

This actually uncovered a bug!