### PR TITLE
Add AuthorityType variant to use for mint close-authority adjustment

### DIFF
--- a/token/program-2022-test/tests/mint_close_authority.rs
+++ b/token/program-2022-test/tests/mint_close_authority.rs
@@ -67,7 +67,7 @@ async fn set_authority() {
         .set_authority(
             token.get_address(),
             Some(&new_authority.pubkey()),
-            instruction::AuthorityType::CloseAccount,
+            instruction::AuthorityType::CloseMint,
             &wrong,
         )
         .await
@@ -87,7 +87,7 @@ async fn set_authority() {
         .set_authority(
             token.get_address(),
             Some(&new_authority.pubkey()),
-            instruction::AuthorityType::CloseAccount,
+            instruction::AuthorityType::CloseMint,
             &close_authority,
         )
         .await
@@ -104,7 +104,7 @@ async fn set_authority() {
         .set_authority(
             token.get_address(),
             None,
-            instruction::AuthorityType::CloseAccount,
+            instruction::AuthorityType::CloseMint,
             &new_authority,
         )
         .await
@@ -118,7 +118,7 @@ async fn set_authority() {
         .set_authority(
             token.get_address(),
             Some(&close_authority.pubkey()),
-            instruction::AuthorityType::CloseAccount,
+            instruction::AuthorityType::CloseMint,
             &new_authority,
         )
         .await
@@ -187,7 +187,7 @@ async fn fail_without_extension() {
         .set_authority(
             token.get_address(),
             Some(&close_authority),
-            instruction::AuthorityType::CloseAccount,
+            instruction::AuthorityType::CloseMint,
             &mint_authority,
         )
         .await

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -915,12 +915,14 @@ pub enum AuthorityType {
     FreezeAccount,
     /// Owner of a given token account
     AccountOwner,
-    /// Authority to close a mint or token account
+    /// Authority to close a token account
     CloseAccount,
     /// Authority to set the transfer fee
     TransferFeeConfig,
     /// Authority to withdraw withheld tokens from a mint
     WithheldWithdraw,
+    /// Authority to close a mint account
+    CloseMint,
 }
 
 impl AuthorityType {
@@ -932,6 +934,7 @@ impl AuthorityType {
             AuthorityType::CloseAccount => 3,
             AuthorityType::TransferFeeConfig => 4,
             AuthorityType::WithheldWithdraw => 5,
+            AuthorityType::CloseMint => 6,
         }
     }
 
@@ -943,6 +946,7 @@ impl AuthorityType {
             3 => Ok(AuthorityType::CloseAccount),
             4 => Ok(AuthorityType::TransferFeeConfig),
             5 => Ok(AuthorityType::WithheldWithdraw),
+            6 => Ok(AuthorityType::CloseMint),
             _ => Err(TokenError::InvalidInstruction.into()),
         }
     }

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -610,7 +610,7 @@ impl Processor {
                     mint.base.freeze_authority = new_authority;
                     mint.pack_base();
                 }
-                AuthorityType::CloseAccount => {
+                AuthorityType::CloseMint => {
                     let extension = mint.get_extension_mut::<MintCloseAuthority>()?;
                     let maybe_close_authority: Option<Pubkey> = extension.close_authority.into();
                     let close_authority =


### PR DESCRIPTION
Mints with the `mint_close_authority` extension active expect `SetAuthority` instructions to use the `AuthorityType::CloseAccount` variant. This works, but means that it is not possible to tell if an account being modified is an Account or a Mint by inspecting the instruction. (eg. https://github.com/solana-labs/solana/pull/24537#discussion_r857848860)

This PR adds an `AuthorityType::CloseMint` variant to disambiguate. This is essentially just a cosmetic change, but follows the theme of `TransferChecked` etc exposing context within each instruction.