### PR TITLE
Make spl-token-2022 instruction decoders pub

### DIFF
--- a/token/program-2022/src/extension/default_account_state/instruction.rs
+++ b/token/program-2022/src/extension/default_account_state/instruction.rs
@@ -53,7 +53,7 @@ pub enum DefaultAccountStateInstruction {
     Update,
 }
 
-pub(crate) fn decode_instruction(
+pub fn decode_instruction(
     input: &[u8],
 ) -> Result<(DefaultAccountStateInstruction, AccountState), ProgramError> {
     if input.len() != 2 {

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -1686,7 +1686,7 @@ pub fn is_valid_signer_index(index: usize) -> bool {
 }
 
 /// Utility function for decoding just the instruction type
-pub(crate) fn decode_instruction_type<T: TryFrom<u8>>(input: &[u8]) -> Result<T, ProgramError> {
+pub fn decode_instruction_type<T: TryFrom<u8>>(input: &[u8]) -> Result<T, ProgramError> {
     if input.is_empty() {
         Err(ProgramError::InvalidInstructionData)
     } else {
@@ -1695,7 +1695,7 @@ pub(crate) fn decode_instruction_type<T: TryFrom<u8>>(input: &[u8]) -> Result<T,
 }
 
 /// Utility function for decoding instruction data
-pub(crate) fn decode_instruction_data<T: Pod>(input: &[u8]) -> Result<&T, ProgramError> {
+pub fn decode_instruction_data<T: Pod>(input: &[u8]) -> Result<&T, ProgramError> {
     if input.len() != pod_get_packed_len::<T>().saturating_add(1) {
         Err(ProgramError::InvalidInstructionData)
     } else {


### PR DESCRIPTION
If we want to parse spl-token-2022 instructions in Rpc, we need the instruction decoders for `default_account_state` and `confidential_token_transfer` instructions (or have to duplicate them by hand 🤢 ). This PR makes them available downstream.

As an aside: I looked at removing `default_account_state`'s custom decoder to use the generic ones, as I had obviously forgotten why I didn't use them in the first place. Unfortunately, a `repr(u8)` enum cannot derive `Pod`. It arguably doesn't need to, but the trait bound prevents calling something like `decode_instruction_data::<AccountState>(input)`