### PR TITLE
token-2022: Set transfer fee two epochs ahead

### DIFF
--- a/token/program-2022/src/extension/transfer_fee/processor.rs
+++ b/token/program-2022/src/extension/transfer_fee/processor.rs
@@ -91,15 +91,16 @@ fn process_set_transfer_fee(
     // When setting the transfer fee, we have two situations:
     // * newer transfer fee epoch <= current epoch:
     //     newer transfer fee is the active one, so overwrite older transfer fee with newer, then overwrite newer transfer fee
-    // * newer transfer fee epoch == next epoch:
+    // * newer transfer fee epoch >= next epoch:
     //     it was never used, so just overwrite next transfer fee
     let epoch = Clock::get()?.epoch;
-    let next_epoch = epoch.saturating_add(1);
     if u64::from(extension.newer_transfer_fee.epoch) <= epoch {
         extension.older_transfer_fee = extension.newer_transfer_fee;
     }
+    // set two epochs ahead to avoid rug pulls at the end of an epoch
+    let newer_fee_start_epoch = epoch.saturating_add(2);
     let transfer_fee = TransferFee {
-        epoch: next_epoch.into(),
+        epoch: newer_fee_start_epoch.into(),
         transfer_fee_basis_points: transfer_fee_basis_points.into(),
         maximum_fee: maximum_fee.into(),
     };


### PR DESCRIPTION
#### Problem

Transfer fees are currently set one epoch ahead, in order to avoid a malicious transfer-fee-configurer from imposing a massive fee out of nowhere, potentially making the token unusable.

This still has an issue however, since a truly malicious configurer can simply set the fee right before the end of the epoch, essentially achieving the same rug pull.

#### Solution

Set the epoch fee two epochs forward, giving a minimum of 1 epoch for people to react to the change.