### PR TITLE
stake-pool: Update program to work with minimum delegation

### DIFF
--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -45,7 +45,7 @@ use {
         find_withdraw_authority_program_address,
         instruction::{FundingType, PreferredValidatorType},
         state::{Fee, FeeType, StakePool, ValidatorList},
-        MINIMUM_ACTIVE_STAKE,
+        MINIMUM_ACTIVE_STAKE, MINIMUM_RESERVE_LAMPORTS,
     },
     std::cmp::Ordering,
     std::{process::exit, sync::Arc},
@@ -250,7 +250,7 @@ fn command_create_pool(
     let reserve_stake_balance = config
         .rpc_client
         .get_minimum_balance_for_rent_exemption(STAKE_STATE_LEN)?
-        + 1;
+        + MINIMUM_RESERVE_LAMPORTS;
     let mint_account_balance = config
         .rpc_client
         .get_minimum_balance_for_rent_exemption(spl_token::state::Mint::LEN)?;
@@ -1058,7 +1058,7 @@ fn command_list(config: &Config, stake_pool_address: &Pubkey) -> CommandResult {
     let minimum_reserve_stake_balance = config
         .rpc_client
         .get_minimum_balance_for_rent_exemption(STAKE_STATE_LEN)?
-        + 1;
+        + MINIMUM_RESERVE_LAMPORTS;
     let cli_stake_pool_stake_account_infos = validator_list
         .validators
         .iter()
@@ -1271,7 +1271,7 @@ fn prepare_withdraw_accounts(
         stake_pool.reserve_stake,
         reserve_stake.lamports
             - rpc_client.get_minimum_balance_for_rent_exemption(STAKE_STATE_LEN)?
-            - 1,
+            - MINIMUM_RESERVE_LAMPORTS,
         None,
     ));
 

--- a/stake-pool/js/src/constants.ts
+++ b/stake-pool/js/src/constants.ts
@@ -12,4 +12,4 @@ export const TRANSIENT_STAKE_SEED_PREFIX = Buffer.from('transient');
 
 // Minimum amount of staked SOL required in a validator stake account to allow
 // for merges without a mismatch on credits observed
-export const MINIMUM_ACTIVE_STAKE = LAMPORTS_PER_SOL / 1_000;
+export const MINIMUM_ACTIVE_STAKE = LAMPORTS_PER_SOL;

--- a/stake-pool/program/src/entrypoint.rs
+++ b/stake-pool/program/src/entrypoint.rs
@@ -2,10 +2,15 @@
 
 #![cfg(all(target_arch = "bpf", not(feature = "no-entrypoint")))]
 
-use crate::{error::StakePoolError, processor::Processor};
-use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,
-    program_error::PrintProgramError, pubkey::Pubkey,
+use {
+    crate::{error::StakePoolError, processor::Processor},
+    solana_program::{
+        account_info::AccountInfo,
+        entrypoint,
+        entrypoint::ProgramResult,
+        program_error::PrintProgramError,
+        pubkey::Pubkey,
+    },
 };
 
 entrypoint!(process_instruction);

--- a/stake-pool/program/src/entrypoint.rs
+++ b/stake-pool/program/src/entrypoint.rs
@@ -5,11 +5,8 @@
 use {
     crate::{error::StakePoolError, processor::Processor},
     solana_program::{
-        account_info::AccountInfo,
-        entrypoint,
-        entrypoint::ProgramResult,
-        program_error::PrintProgramError,
-        pubkey::Pubkey,
+        account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,
+        program_error::PrintProgramError, pubkey::Pubkey,
     },
 };
 

--- a/stake-pool/program/src/error.rs
+++ b/stake-pool/program/src/error.rs
@@ -1,8 +1,10 @@
 //! Error types
 
-use num_derive::FromPrimitive;
-use solana_program::{decode_error::DecodeError, program_error::ProgramError};
-use thiserror::Error;
+use {
+    num_derive::FromPrimitive,
+    solana_program::{decode_error::DecodeError, program_error::ProgramError},
+    thiserror::Error,
+};
 
 /// Errors that may be returned by the StakePool program.
 #[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]

--- a/stake-pool/program/src/lib.rs
+++ b/stake-pool/program/src/lib.rs
@@ -29,7 +29,10 @@ const TRANSIENT_STAKE_SEED_PREFIX: &[u8] = b"transient";
 
 /// Minimum amount of staked SOL required in a validator stake account to allow
 /// for merges without a mismatch on credits observed
-pub const MINIMUM_ACTIVE_STAKE: u64 = LAMPORTS_PER_SOL / 1_000;
+pub const MINIMUM_ACTIVE_STAKE: u64 = LAMPORTS_PER_SOL;
+
+/// Minimum amount of SOL in the reserve
+pub const MINIMUM_RESERVE_LAMPORTS: u64 = LAMPORTS_PER_SOL;
 
 /// Maximum amount of validator stake accounts to update per
 /// `UpdateValidatorListBalance` instruction, based on compute limits
@@ -64,7 +67,8 @@ pub fn minimum_stake_lamports(meta: &Meta) -> u64 {
 /// conversions
 #[inline]
 pub fn minimum_reserve_lamports(meta: &Meta) -> u64 {
-    meta.rent_exempt_reserve.saturating_add(1)
+    meta.rent_exempt_reserve
+        .saturating_add(MINIMUM_RESERVE_LAMPORTS)
 }
 
 /// Generates the deposit authority program address for the stake pool

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -15,16 +15,14 @@ use {
     borsh::{BorshDeserialize, BorshSerialize},
     num_traits::FromPrimitive,
     solana_program::{
-        account_info::next_account_info,
-        account_info::AccountInfo,
+        account_info::{next_account_info, AccountInfo},
         borsh::try_from_slice_unchecked,
         clock::{Clock, Epoch},
         decode_error::DecodeError,
         entrypoint::ProgramResult,
         msg,
         program::{invoke, invoke_signed},
-        program_error::PrintProgramError,
-        program_error::ProgramError,
+        program_error::{PrintProgramError, ProgramError},
         program_pack::Pack,
         pubkey::Pubkey,
         rent::Rent,
@@ -747,7 +745,7 @@ impl Processor {
         stake_pool.manager_fee_account = *manager_fee_info.key;
         stake_pool.token_program_id = *token_program_info.key;
         stake_pool.total_lamports = total_lamports;
-        stake_pool.pool_token_supply = 0;
+        stake_pool.pool_token_supply = total_lamports;
         stake_pool.last_update_epoch = Clock::get()?.epoch;
         stake_pool.lockup = stake::state::Lockup::default();
         stake_pool.epoch_fee = epoch_fee;

--- a/stake-pool/program/src/state.rs
+++ b/stake-pool/program/src/state.rs
@@ -1,6 +1,5 @@
 //! State transition types
 
-use spl_token::state::{Account, AccountState};
 use {
     crate::{
         big_vec::BigVec, error::StakePoolError, MAX_WITHDRAWAL_FEE_INCREASE,
@@ -20,6 +19,7 @@ use {
         stake::state::Lockup,
     },
     spl_math::checked_ceil_div::CheckedCeilDiv,
+    spl_token::state::{Account, AccountState},
     std::{convert::TryFrom, fmt, matches},
 };
 
@@ -535,7 +535,7 @@ impl Default for StakeStatus {
 pub struct ValidatorStakeInfo {
     /// Amount of active stake delegated to this validator, minus the minimum
     /// required stake amount of rent-exemption + `crate::MINIMUM_ACTIVE_STAKE`
-    /// (currently 0.001 SOL).
+    /// (currently 1 SOL).
     ///
     /// Note that if `last_update_epoch` does not match the current epoch then
     /// this field may not be accurate
@@ -823,10 +823,8 @@ mod test {
     use {
         super::*,
         proptest::prelude::*,
-        solana_program::borsh::{
-            get_instance_packed_len, get_packed_len, try_from_slice_unchecked,
-        },
         solana_program::{
+            borsh::{get_instance_packed_len, get_packed_len, try_from_slice_unchecked},
             clock::{DEFAULT_SLOTS_PER_EPOCH, DEFAULT_S_PER_SLOT, SECONDS_PER_DAY},
             native_token::LAMPORTS_PER_SOL,
         },

--- a/stake-pool/program/tests/deposit.rs
+++ b/stake-pool/program/tests/deposit.rs
@@ -15,11 +15,13 @@ use {
     solana_program_test::*,
     solana_sdk::{
         signature::{Keypair, Signer},
-        transaction::Transaction,
-        transaction::TransactionError,
+        transaction::{Transaction, TransactionError},
         transport::TransportError,
     },
-    spl_stake_pool::{error::StakePoolError, id, instruction, minimum_stake_lamports, state},
+    spl_stake_pool::{
+        error::StakePoolError, id, instruction, minimum_stake_lamports, state,
+        MINIMUM_RESERVE_LAMPORTS,
+    },
     spl_token::error as token_error,
 };
 
@@ -40,7 +42,7 @@ async fn setup() -> (
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            1,
+            MINIMUM_RESERVE_LAMPORTS,
         )
         .await
         .unwrap();
@@ -616,7 +618,12 @@ async fn fail_with_unknown_validator() {
     let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
     let stake_pool_accounts = StakePoolAccounts::new();
     stake_pool_accounts
-        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash, 1)
+        .initialize_stake_pool(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            MINIMUM_RESERVE_LAMPORTS,
+        )
         .await
         .unwrap();
 

--- a/stake-pool/program/tests/deposit_authority.rs
+++ b/stake-pool/program/tests/deposit_authority.rs
@@ -11,7 +11,7 @@ use {
         signature::{Keypair, Signer},
         transaction::TransactionError,
     },
-    spl_stake_pool::{error::StakePoolError, state::StakePool},
+    spl_stake_pool::{error::StakePoolError, state::StakePool, MINIMUM_RESERVE_LAMPORTS},
 };
 
 #[tokio::test]
@@ -21,7 +21,12 @@ async fn success_initialize() {
     let stake_pool_accounts = StakePoolAccounts::new_with_deposit_authority(deposit_authority);
     let deposit_authority = stake_pool_accounts.stake_deposit_authority;
     stake_pool_accounts
-        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash, 1)
+        .initialize_stake_pool(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            MINIMUM_RESERVE_LAMPORTS,
+        )
         .await
         .unwrap();
 
@@ -41,7 +46,12 @@ async fn success_deposit() {
     let stake_pool_accounts =
         StakePoolAccounts::new_with_deposit_authority(stake_deposit_authority);
     stake_pool_accounts
-        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash, 1)
+        .initialize_stake_pool(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            MINIMUM_RESERVE_LAMPORTS,
+        )
         .await
         .unwrap();
 
@@ -116,7 +126,12 @@ async fn fail_deposit_without_authority_signature() {
     let mut stake_pool_accounts =
         StakePoolAccounts::new_with_deposit_authority(stake_deposit_authority);
     stake_pool_accounts
-        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash, 1)
+        .initialize_stake_pool(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            MINIMUM_RESERVE_LAMPORTS,
+        )
         .await
         .unwrap();
 

--- a/stake-pool/program/tests/deposit_sol.rs
+++ b/stake-pool/program/tests/deposit_sol.rs
@@ -10,14 +10,13 @@ use {
     solana_program_test::*,
     solana_sdk::{
         signature::{Keypair, Signer},
-        transaction::Transaction,
-        transaction::TransactionError,
+        transaction::{Transaction, TransactionError},
         transport::TransportError,
     },
     spl_stake_pool::{
         error, id,
         instruction::{self, FundingType},
-        state,
+        state, MINIMUM_RESERVE_LAMPORTS,
     },
     spl_token::error as token_error,
 };
@@ -31,7 +30,7 @@ async fn setup() -> (ProgramTestContext, StakePoolAccounts, Keypair, Pubkey) {
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            1,
+            MINIMUM_RESERVE_LAMPORTS,
         )
         .await
         .unwrap();
@@ -258,7 +257,12 @@ async fn success_with_sol_deposit_authority() {
     let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
     let stake_pool_accounts = StakePoolAccounts::new();
     stake_pool_accounts
-        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash, 1)
+        .initialize_stake_pool(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            MINIMUM_RESERVE_LAMPORTS,
+        )
         .await
         .unwrap();
 
@@ -323,7 +327,12 @@ async fn fail_without_sol_deposit_authority_signature() {
     let sol_deposit_authority = Keypair::new();
     let stake_pool_accounts = StakePoolAccounts::new();
     stake_pool_accounts
-        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash, 1)
+        .initialize_stake_pool(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            MINIMUM_RESERVE_LAMPORTS,
+        )
         .await
         .unwrap();
 

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -24,7 +24,7 @@ use {
         find_transient_stake_program_address, find_withdraw_authority_program_address, id,
         instruction, processor,
         state::{self, FeeType, ValidatorList},
-        MINIMUM_ACTIVE_STAKE,
+        MINIMUM_ACTIVE_STAKE, MINIMUM_RESERVE_LAMPORTS,
     },
 };
 
@@ -1575,5 +1575,5 @@ pub async fn get_validator_list_sum(
         .sum();
     let rent = banks_client.get_rent().await.unwrap();
     let rent = rent.minimum_balance(std::mem::size_of::<stake::state::StakeState>());
-    validator_sum + reserve_stake.lamports - rent - 1
+    validator_sum + reserve_stake.lamports - rent - MINIMUM_RESERVE_LAMPORTS
 }

--- a/stake-pool/program/tests/increase.rs
+++ b/stake-pool/program/tests/increase.rs
@@ -15,7 +15,7 @@ use {
     },
     spl_stake_pool::{
         error::StakePoolError, find_transient_stake_program_address, id, instruction,
-        MINIMUM_ACTIVE_STAKE,
+        MINIMUM_ACTIVE_STAKE, MINIMUM_RESERVE_LAMPORTS,
     },
 };
 
@@ -29,7 +29,7 @@ async fn setup() -> (
 ) {
     let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
     let stake_pool_accounts = StakePoolAccounts::new();
-    let reserve_lamports = 100_000_000_000;
+    let reserve_lamports = 100_000_000_000 + MINIMUM_RESERVE_LAMPORTS;
     stake_pool_accounts
         .initialize_stake_pool(
             &mut banks_client,
@@ -54,7 +54,7 @@ async fn setup() -> (
         &recent_blockhash,
         &stake_pool_accounts,
         &validator_stake_account,
-        5_000_000,
+        MINIMUM_ACTIVE_STAKE,
     )
     .await
     .unwrap();
@@ -96,7 +96,7 @@ async fn success() {
 
     let rent = banks_client.get_rent().await.unwrap();
     let stake_rent = rent.minimum_balance(std::mem::size_of::<stake::state::StakeState>());
-    let increase_amount = reserve_lamports - stake_rent - 1;
+    let increase_amount = reserve_lamports - stake_rent - MINIMUM_RESERVE_LAMPORTS;
     let error = stake_pool_accounts
         .increase_validator_stake(
             &mut banks_client,

--- a/stake-pool/program/tests/set_deposit_fee.rs
+++ b/stake-pool/program/tests/set_deposit_fee.rs
@@ -13,8 +13,8 @@ use {
     },
     spl_stake_pool::{
         error, id, instruction,
-        state::StakePool,
-        state::{Fee, FeeType},
+        state::{Fee, FeeType, StakePool},
+        MINIMUM_RESERVE_LAMPORTS,
     },
 };
 
@@ -29,7 +29,7 @@ async fn setup(fee: Option<Fee>) -> (ProgramTestContext, StakePoolAccounts, Fee)
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            1,
+            MINIMUM_RESERVE_LAMPORTS,
         )
         .await
         .unwrap();

--- a/stake-pool/program/tests/set_epoch_fee.rs
+++ b/stake-pool/program/tests/set_epoch_fee.rs
@@ -14,6 +14,7 @@ use {
     spl_stake_pool::{
         error, id, instruction,
         state::{Fee, FeeType, StakePool},
+        MINIMUM_RESERVE_LAMPORTS,
     },
 };
 
@@ -25,7 +26,7 @@ async fn setup() -> (ProgramTestContext, StakePoolAccounts, Fee) {
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            1,
+            MINIMUM_RESERVE_LAMPORTS,
         )
         .await
         .unwrap();
@@ -180,7 +181,7 @@ async fn fail_not_updated() {
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            1,
+            MINIMUM_RESERVE_LAMPORTS,
         )
         .await
         .unwrap();

--- a/stake-pool/program/tests/set_funding_authority.rs
+++ b/stake-pool/program/tests/set_funding_authority.rs
@@ -12,13 +12,15 @@ use {
     },
     solana_program_test::*,
     solana_sdk::{
-        instruction::InstructionError, signature::Keypair, signature::Signer,
-        transaction::Transaction, transaction::TransactionError, transport::TransportError,
+        instruction::InstructionError,
+        signature::{Keypair, Signer},
+        transaction::{Transaction, TransactionError},
+        transport::TransportError,
     },
     spl_stake_pool::{
         error, find_deposit_authority_program_address, id,
         instruction::{self, FundingType},
-        state,
+        state, MINIMUM_RESERVE_LAMPORTS,
     },
 };
 
@@ -26,7 +28,12 @@ async fn setup() -> (BanksClient, Keypair, Hash, StakePoolAccounts, Keypair) {
     let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
     let stake_pool_accounts = StakePoolAccounts::new();
     stake_pool_accounts
-        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash, 1)
+        .initialize_stake_pool(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            MINIMUM_RESERVE_LAMPORTS,
+        )
         .await
         .unwrap();
 

--- a/stake-pool/program/tests/set_manager.rs
+++ b/stake-pool/program/tests/set_manager.rs
@@ -12,10 +12,12 @@ use {
     },
     solana_program_test::*,
     solana_sdk::{
-        instruction::InstructionError, signature::Keypair, signature::Signer,
-        transaction::Transaction, transaction::TransactionError, transport::TransportError,
+        instruction::InstructionError,
+        signature::{Keypair, Signer},
+        transaction::{Transaction, TransactionError},
+        transport::TransportError,
     },
-    spl_stake_pool::{error, id, instruction, state},
+    spl_stake_pool::{error, id, instruction, state, MINIMUM_RESERVE_LAMPORTS},
 };
 
 async fn setup() -> (
@@ -29,7 +31,12 @@ async fn setup() -> (
     let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
     let stake_pool_accounts = StakePoolAccounts::new();
     stake_pool_accounts
-        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash, 1)
+        .initialize_stake_pool(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            MINIMUM_RESERVE_LAMPORTS,
+        )
         .await
         .unwrap();
 
@@ -213,7 +220,12 @@ async fn test_set_manager_with_wrong_mint_for_pool_fee_acc() {
     let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
     let stake_pool_accounts = StakePoolAccounts::new();
     stake_pool_accounts
-        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash, 1)
+        .initialize_stake_pool(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            MINIMUM_RESERVE_LAMPORTS,
+        )
         .await
         .unwrap();
 

--- a/stake-pool/program/tests/set_preferred.rs
+++ b/stake-pool/program/tests/set_preferred.rs
@@ -17,6 +17,7 @@ use {
         error, find_transient_stake_program_address, id,
         instruction::{self, PreferredValidatorType},
         state::StakePool,
+        MINIMUM_RESERVE_LAMPORTS,
     },
 };
 
@@ -30,7 +31,12 @@ async fn setup() -> (
     let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
     let stake_pool_accounts = StakePoolAccounts::new();
     stake_pool_accounts
-        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash, 1)
+        .initialize_stake_pool(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            MINIMUM_RESERVE_LAMPORTS,
+        )
         .await
         .unwrap();
 

--- a/stake-pool/program/tests/set_referral_fee.rs
+++ b/stake-pool/program/tests/set_referral_fee.rs
@@ -14,6 +14,7 @@ use {
     spl_stake_pool::{
         error, id, instruction,
         state::{FeeType, StakePool},
+        MINIMUM_RESERVE_LAMPORTS,
     },
 };
 
@@ -28,7 +29,7 @@ async fn setup(fee: Option<u8>) -> (ProgramTestContext, StakePoolAccounts, u8) {
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            1,
+            MINIMUM_RESERVE_LAMPORTS,
         )
         .await
         .unwrap();

--- a/stake-pool/program/tests/set_staker.rs
+++ b/stake-pool/program/tests/set_staker.rs
@@ -12,17 +12,24 @@ use {
     },
     solana_program_test::*,
     solana_sdk::{
-        instruction::InstructionError, signature::Keypair, signature::Signer,
-        transaction::Transaction, transaction::TransactionError, transport::TransportError,
+        instruction::InstructionError,
+        signature::{Keypair, Signer},
+        transaction::{Transaction, TransactionError},
+        transport::TransportError,
     },
-    spl_stake_pool::{error, id, instruction, state},
+    spl_stake_pool::{error, id, instruction, state, MINIMUM_RESERVE_LAMPORTS},
 };
 
 async fn setup() -> (BanksClient, Keypair, Hash, StakePoolAccounts, Keypair) {
     let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
     let stake_pool_accounts = StakePoolAccounts::new();
     stake_pool_accounts
-        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash, 1)
+        .initialize_stake_pool(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            MINIMUM_RESERVE_LAMPORTS,
+        )
         .await
         .unwrap();
 

--- a/stake-pool/program/tests/set_withdrawal_fee.rs
+++ b/stake-pool/program/tests/set_withdrawal_fee.rs
@@ -14,6 +14,7 @@ use {
     spl_stake_pool::{
         error, id, instruction,
         state::{Fee, FeeType, StakePool},
+        MINIMUM_RESERVE_LAMPORTS,
     },
 };
 
@@ -28,7 +29,7 @@ async fn setup(fee: Option<Fee>) -> (ProgramTestContext, StakePoolAccounts, Fee)
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            1,
+            MINIMUM_RESERVE_LAMPORTS,
         )
         .await
         .unwrap();
@@ -623,7 +624,7 @@ async fn fail_not_updated() {
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            1,
+            MINIMUM_RESERVE_LAMPORTS,
         )
         .await
         .unwrap();

--- a/stake-pool/program/tests/update_stake_pool_balance.rs
+++ b/stake-pool/program/tests/update_stake_pool_balance.rs
@@ -12,7 +12,7 @@ use {
         signature::{Keypair, Signer},
         transaction::TransactionError,
     },
-    spl_stake_pool::{error::StakePoolError, state::StakePool},
+    spl_stake_pool::{error::StakePoolError, state::StakePool, MINIMUM_RESERVE_LAMPORTS},
 };
 
 async fn setup() -> (
@@ -27,7 +27,7 @@ async fn setup() -> (
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            1,
+            MINIMUM_RESERVE_LAMPORTS,
         )
         .await
         .unwrap();
@@ -260,7 +260,12 @@ async fn fail_with_wrong_validator_list() {
     let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
     let mut stake_pool_accounts = StakePoolAccounts::new();
     stake_pool_accounts
-        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash, 1)
+        .initialize_stake_pool(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            MINIMUM_RESERVE_LAMPORTS,
+        )
         .await
         .unwrap();
 
@@ -289,7 +294,12 @@ async fn fail_with_wrong_pool_fee_account() {
     let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
     let mut stake_pool_accounts = StakePoolAccounts::new();
     stake_pool_accounts
-        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash, 1)
+        .initialize_stake_pool(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            MINIMUM_RESERVE_LAMPORTS,
+        )
         .await
         .unwrap();
 
@@ -318,7 +328,12 @@ async fn fail_with_wrong_reserve() {
     let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
     let mut stake_pool_accounts = StakePoolAccounts::new();
     stake_pool_accounts
-        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash, 1)
+        .initialize_stake_pool(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            MINIMUM_RESERVE_LAMPORTS,
+        )
         .await
         .unwrap();
 

--- a/stake-pool/program/tests/update_validator_list_balance.rs
+++ b/stake-pool/program/tests/update_validator_list_balance.rs
@@ -7,13 +7,14 @@ use {
     solana_program::{borsh::try_from_slice_unchecked, program_pack::Pack, pubkey::Pubkey, stake},
     solana_program_test::*,
     solana_sdk::{
-        stake::state::{Authorized, Lockup, StakeState},
         signature::{Keypair, Signer},
+        stake::state::{Authorized, Lockup, StakeState},
         system_instruction,
         transaction::Transaction,
     },
     spl_stake_pool::{
-        find_withdraw_authority_program_address, find_transient_stake_program_address, id, instruction,
+        find_transient_stake_program_address, find_withdraw_authority_program_address, id,
+        instruction,
         state::{StakePool, StakeStatus, ValidatorList},
         MAX_VALIDATORS_TO_UPDATE, MINIMUM_ACTIVE_STAKE, MINIMUM_RESERVE_LAMPORTS,
     },
@@ -686,10 +687,20 @@ async fn success_ignoring_hijacked_transient_stake_with_authorized() {
 #[tokio::test]
 async fn success_ignoring_hijacked_transient_stake_with_lockup() {
     let hijacker = Pubkey::new_unique();
-    check_ignored_hijacked_transient_stake(None, Some(&Lockup { custodian: hijacker, ..Lockup::default() })).await;
+    check_ignored_hijacked_transient_stake(
+        None,
+        Some(&Lockup {
+            custodian: hijacker,
+            ..Lockup::default()
+        }),
+    )
+    .await;
 }
 
-async fn check_ignored_hijacked_transient_stake(hijack_authorized: Option<&Authorized>, hijack_lockup: Option<&Lockup>) {
+async fn check_ignored_hijacked_transient_stake(
+    hijack_authorized: Option<&Authorized>,
+    hijack_lockup: Option<&Lockup>,
+) {
     let num_validators = 1;
     let (mut context, stake_pool_accounts, stake_accounts, _, lamports, _, mut slot) =
         setup(num_validators).await;

--- a/stake-pool/program/tests/vsa_add.rs
+++ b/stake-pool/program/tests/vsa_add.rs
@@ -19,7 +19,10 @@ use {
         transaction::{Transaction, TransactionError},
         transport::TransportError,
     },
-    spl_stake_pool::{error::StakePoolError, find_stake_program_address, id, instruction, state},
+    spl_stake_pool::{
+        error::StakePoolError, find_stake_program_address, id, instruction, state,
+        MINIMUM_RESERVE_LAMPORTS,
+    },
 };
 
 async fn setup() -> (
@@ -32,7 +35,12 @@ async fn setup() -> (
     let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
     let stake_pool_accounts = StakePoolAccounts::new();
     stake_pool_accounts
-        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash, 1)
+        .initialize_stake_pool(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            MINIMUM_RESERVE_LAMPORTS,
+        )
         .await
         .unwrap();
 
@@ -391,7 +399,12 @@ async fn fail_add_too_many_validator_stake_accounts() {
     let mut stake_pool_accounts = StakePoolAccounts::new();
     stake_pool_accounts.max_validators = 1;
     stake_pool_accounts
-        .initialize_stake_pool(&mut banks_client, &payer, &recent_blockhash, 1)
+        .initialize_stake_pool(
+            &mut banks_client,
+            &payer,
+            &recent_blockhash,
+            MINIMUM_RESERVE_LAMPORTS,
+        )
         .await
         .unwrap();
 

--- a/stake-pool/program/tests/withdraw_sol.rs
+++ b/stake-pool/program/tests/withdraw_sol.rs
@@ -10,14 +10,13 @@ use {
     solana_program_test::*,
     solana_sdk::{
         signature::{Keypair, Signer},
-        transaction::Transaction,
-        transaction::TransactionError,
+        transaction::{Transaction, TransactionError},
     },
     spl_stake_pool::{
         error::StakePoolError,
         id,
         instruction::{self, FundingType},
-        state,
+        state, MINIMUM_RESERVE_LAMPORTS,
     },
 };
 
@@ -30,7 +29,7 @@ async fn setup() -> (ProgramTestContext, StakePoolAccounts, Keypair, Pubkey, u64
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            1,
+            MINIMUM_RESERVE_LAMPORTS,
         )
         .await
         .unwrap();

--- a/stake-pool/py/bot/rebalance.py
+++ b/stake-pool/py/bot/rebalance.py
@@ -7,13 +7,10 @@ from solana.publickey import PublicKey
 from solana.rpc.async_api import AsyncClient
 from solana.rpc.commitment import Confirmed
 
-from stake.constants import STAKE_LEN
+from stake.constants import STAKE_LEN, LAMPORTS_PER_SOL
 from stake_pool.actions import decrease_validator_stake, increase_validator_stake, update_stake_pool
+from stake_pool.constants import MINIMUM_ACTIVE_STAKE
 from stake_pool.state import StakePool, ValidatorList
-
-
-LAMPORTS_PER_SOL: int = 1_000_000_000
-MINIMUM_INCREASE_LAMPORTS: int = LAMPORTS_PER_SOL // 100
 
 
 async def get_client(endpoint: str) -> AsyncClient:
@@ -87,10 +84,10 @@ decrease of {lamports_to_decrease} below the rent exmption')
                     ))
             elif validator.active_stake_lamports < lamports_per_validator:
                 lamports_to_increase = lamports_per_validator - validator.active_stake_lamports
-                if lamports_to_increase < MINIMUM_INCREASE_LAMPORTS:
+                if lamports_to_increase < MINIMUM_ACTIVE_STAKE:
                     print(f'Skipping increase on {validator.vote_account_address}, \
 currently at {validator.active_stake_lamports} lamports, \
-increase of {lamports_to_increase} less than the minimum of {MINIMUM_INCREASE_LAMPORTS}')
+increase of {lamports_to_increase} less than the minimum of {MINIMUM_ACTIVE_STAKE}')
                 else:
                     futures.append(increase_validator_stake(
                         async_client, staker, staker, stake_pool_address,

--- a/stake-pool/py/stake/constants.py
+++ b/stake-pool/py/stake/constants.py
@@ -10,3 +10,9 @@ SYSVAR_STAKE_CONFIG_ID: PublicKey = PublicKey("StakeConfig1111111111111111111111
 
 STAKE_LEN: int = 200
 """Size of stake account."""
+
+LAMPORTS_PER_SOL: int = 1_000_000_000
+"""Number of lamports per SOL"""
+
+MINIMUM_DELEGATION: int = LAMPORTS_PER_SOL
+"""Minimum delegation allowed by the stake program"""

--- a/stake-pool/py/stake_pool/actions.py
+++ b/stake-pool/py/stake_pool/actions.py
@@ -16,6 +16,7 @@ import stake.instructions as st
 from stake.state import StakeAuthorize
 from stake_pool.constants import \
     MAX_VALIDATORS_TO_UPDATE, \
+    MINIMUM_RESERVE_LAMPORTS, \
     STAKE_POOL_PROGRAM_ID, \
     find_stake_program_address, \
     find_transient_stake_program_address, \
@@ -98,7 +99,7 @@ async def create_all(client: AsyncClient, manager: Keypair, fee: Fee, referral_f
         STAKE_POOL_PROGRAM_ID, stake_pool.public_key)
 
     reserve_stake = Keypair()
-    await create_stake(client, manager, reserve_stake, pool_withdraw_authority, 1)
+    await create_stake(client, manager, reserve_stake, pool_withdraw_authority, MINIMUM_RESERVE_LAMPORTS)
 
     pool_mint = Keypair()
     await create_mint(client, manager, pool_mint, pool_withdraw_authority)

--- a/stake-pool/py/stake_pool/constants.py
+++ b/stake-pool/py/stake_pool/constants.py
@@ -3,12 +3,19 @@
 from typing import Tuple
 
 from solana.publickey import PublicKey
+from stake.constants import MINIMUM_DELEGATION
 
 STAKE_POOL_PROGRAM_ID: PublicKey = PublicKey("SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy")
 """Public key that identifies the SPL Stake Pool program."""
 
 MAX_VALIDATORS_TO_UPDATE: int = 5
 """Maximum number of validators to update during UpdateValidatorListBalance."""
+
+MINIMUM_RESERVE_LAMPORTS: int = MINIMUM_DELEGATION
+"""Minimum balance required in the stake pool reserve"""
+
+MINIMUM_ACTIVE_STAKE: int = MINIMUM_DELEGATION
+"""Minimum active delegated staked required in a stake account"""
 
 
 def find_deposit_authority_program_address(

--- a/stake-pool/py/tests/conftest.py
+++ b/stake-pool/py/tests/conftest.py
@@ -92,7 +92,7 @@ def async_client(event_loop, solana_test_validator) -> Iterator[AsyncClient]:
 @pytest.fixture
 def payer(event_loop, async_client) -> Keypair:
     payer = Keypair()
-    airdrop_lamports = 10_000_000_000
+    airdrop_lamports = 20_000_000_000
     event_loop.run_until_complete(airdrop(async_client, payer.public_key, airdrop_lamports))
     return payer
 

--- a/stake-pool/py/tests/test_a_time_sensitive.py
+++ b/stake-pool/py/tests/test_a_time_sensitive.py
@@ -5,8 +5,9 @@ from solana.rpc.commitment import Confirmed
 from spl.token.instructions import get_associated_token_address
 
 from stake.constants import STAKE_LEN
-from stake_pool.state import StakePool, ValidatorList
 from stake_pool.actions import deposit_sol, decrease_validator_stake, increase_validator_stake, update_stake_pool
+from stake_pool.constants import MINIMUM_ACTIVE_STAKE
+from stake_pool.state import StakePool, ValidatorList
 
 
 @pytest.mark.asyncio
@@ -14,7 +15,7 @@ async def test_increase_decrease_this_is_very_slow(async_client, validators, pay
     (stake_pool_address, validator_list_address) = stake_pool_addresses
     resp = await async_client.get_minimum_balance_for_rent_exemption(STAKE_LEN)
     stake_rent_exemption = resp['result']
-    increase_amount = 100_000_000
+    increase_amount = MINIMUM_ACTIVE_STAKE * 2
     decrease_amount = increase_amount // 2
     deposit_amount = (increase_amount + stake_rent_exemption) * len(validators)
 

--- a/stake-pool/py/tests/test_bot_rebalance.py
+++ b/stake-pool/py/tests/test_bot_rebalance.py
@@ -3,9 +3,10 @@ import pytest
 from solana.rpc.commitment import Confirmed
 from spl.token.instructions import get_associated_token_address
 
-from stake.constants import STAKE_LEN
-from stake_pool.state import StakePool, ValidatorList
+from stake.constants import STAKE_LEN, LAMPORTS_PER_SOL
 from stake_pool.actions import deposit_sol
+from stake_pool.constants import MINIMUM_ACTIVE_STAKE, MINIMUM_RESERVE_LAMPORTS
+from stake_pool.state import StakePool, ValidatorList
 
 from bot.rebalance import rebalance
 
@@ -18,7 +19,7 @@ async def test_rebalance_this_is_very_slow(async_client, validators, payer, stak
     (stake_pool_address, validator_list_address) = stake_pool_addresses
     resp = await async_client.get_minimum_balance_for_rent_exemption(STAKE_LEN)
     stake_rent_exemption = resp['result']
-    increase_amount = 100_000_000
+    increase_amount = MINIMUM_ACTIVE_STAKE
     deposit_amount = (increase_amount + stake_rent_exemption) * len(validators)
 
     resp = await async_client.get_account_info(stake_pool_address, commitment=Confirmed)
@@ -32,7 +33,7 @@ async def test_rebalance_this_is_very_slow(async_client, validators, payer, stak
 
     # should only have minimum left
     resp = await async_client.get_account_info(stake_pool.reserve_stake, commitment=Confirmed)
-    assert resp['result']['value']['lamports'] == stake_rent_exemption + 1
+    assert resp['result']['value']['lamports'] == stake_rent_exemption + MINIMUM_RESERVE_LAMPORTS
 
     # should all be the same
     resp = await async_client.get_account_info(validator_list_address, commitment=Confirmed)
@@ -45,12 +46,12 @@ async def test_rebalance_this_is_very_slow(async_client, validators, payer, stak
     # Test case 2: Decrease
     print('Waiting for next epoch')
     await waiter.wait_for_next_epoch(async_client)
-    await rebalance(ENDPOINT, stake_pool_address, payer, deposit_amount / 1_000_000_000)
+    await rebalance(ENDPOINT, stake_pool_address, payer, deposit_amount / LAMPORTS_PER_SOL)
 
     # should still only have minimum left + rent exemptions from increase
     resp = await async_client.get_account_info(stake_pool.reserve_stake, commitment=Confirmed)
     reserve_lamports = resp['result']['value']['lamports']
-    assert reserve_lamports == stake_rent_exemption * (1 + len(validator_list.validators)) + 1
+    assert reserve_lamports == stake_rent_exemption * (1 + len(validator_list.validators)) + MINIMUM_RESERVE_LAMPORTS
 
     # should all be decreasing now
     resp = await async_client.get_account_info(validator_list_address, commitment=Confirmed)
@@ -63,12 +64,12 @@ async def test_rebalance_this_is_very_slow(async_client, validators, payer, stak
     # Test case 3: Do nothing
     print('Waiting for next epoch')
     await waiter.wait_for_next_epoch(async_client)
-    await rebalance(ENDPOINT, stake_pool_address, payer, deposit_amount / 1_000_000_000)
+    await rebalance(ENDPOINT, stake_pool_address, payer, deposit_amount / LAMPORTS_PER_SOL)
 
     # should still only have minimum left + rent exemptions from increase
     resp = await async_client.get_account_info(stake_pool.reserve_stake, commitment=Confirmed)
     reserve_lamports = resp['result']['value']['lamports']
-    assert reserve_lamports == stake_rent_exemption + deposit_amount + 1
+    assert reserve_lamports == stake_rent_exemption + deposit_amount + MINIMUM_RESERVE_LAMPORTS
 
     # should all be decreasing now
     resp = await async_client.get_account_info(validator_list_address, commitment=Confirmed)

--- a/stake-pool/py/tests/test_create.py
+++ b/stake-pool/py/tests/test_create.py
@@ -3,7 +3,10 @@ from solana.keypair import Keypair
 from solana.rpc.commitment import Confirmed
 from spl.token.constants import TOKEN_PROGRAM_ID
 
-from stake_pool.constants import find_withdraw_authority_program_address, STAKE_POOL_PROGRAM_ID
+from stake_pool.constants import \
+    find_withdraw_authority_program_address, \
+    MINIMUM_RESERVE_LAMPORTS, \
+    STAKE_POOL_PROGRAM_ID
 from stake_pool.state import StakePool, Fee
 
 from stake.actions import create_stake
@@ -19,7 +22,7 @@ async def test_create_stake_pool(async_client, payer):
         STAKE_POOL_PROGRAM_ID, stake_pool.public_key)
 
     reserve_stake = Keypair()
-    await create_stake(async_client, payer, reserve_stake, pool_withdraw_authority, 1)
+    await create_stake(async_client, payer, reserve_stake, pool_withdraw_authority, MINIMUM_RESERVE_LAMPORTS)
 
     pool_mint = Keypair()
     await create_mint(async_client, payer, pool_mint, pool_withdraw_authority)

--- a/stake-pool/py/tests/test_deposit_withdraw_stake.py
+++ b/stake-pool/py/tests/test_deposit_withdraw_stake.py
@@ -7,6 +7,7 @@ from stake.actions import create_stake, delegate_stake
 from stake.constants import STAKE_LEN
 from stake.state import StakeState
 from stake_pool.actions import deposit_stake, withdraw_stake, update_stake_pool
+from stake_pool.constants import MINIMUM_ACTIVE_STAKE
 from stake_pool.state import StakePool
 
 
@@ -17,7 +18,7 @@ async def test_deposit_withdraw_stake(async_client, validators, payer, stake_poo
     data = resp['result']['value']['data']
     stake_pool = StakePool.decode(data[0], data[1])
     validator = next(iter(validators))
-    stake_amount = 1_000_000
+    stake_amount = MINIMUM_ACTIVE_STAKE
     stake = Keypair()
     await create_stake(async_client, payer, stake, payer.public_key, stake_amount)
     stake = stake.public_key

--- a/stake-pool/py/tests/test_stake.py
+++ b/stake-pool/py/tests/test_stake.py
@@ -2,14 +2,15 @@ import asyncio
 import pytest
 from solana.keypair import Keypair
 
-from stake.state import StakeAuthorize
 from stake.actions import authorize, create_stake, delegate_stake
+from stake.constants import MINIMUM_DELEGATION
+from stake.state import StakeAuthorize
 
 
 @pytest.mark.asyncio
 async def test_create_stake(async_client, payer):
     stake = Keypair()
-    await create_stake(async_client, payer, stake, payer.public_key, 100_000)
+    await create_stake(async_client, payer, stake, payer.public_key, MINIMUM_DELEGATION)
 
 
 @pytest.mark.asyncio
@@ -24,7 +25,7 @@ async def test_delegate_stake(async_client, validators, payer):
 async def test_authorize_stake(async_client, payer):
     stake = Keypair()
     new_authority = Keypair()
-    await create_stake(async_client, payer, stake, payer.public_key, 1_000)
+    await create_stake(async_client, payer, stake, payer.public_key, MINIMUM_DELEGATION)
     await asyncio.gather(
         authorize(async_client, payer, payer, stake.public_key, new_authority.public_key, StakeAuthorize.STAKER),
         authorize(async_client, payer, payer, stake.public_key, new_authority.public_key, StakeAuthorize.WITHDRAWER)


### PR DESCRIPTION
#### Problem

The minimum delegation will be raised with https://github.com/solana-labs/solana/pull/24603, and the minimum reserve amount will be lowered with https://github.com/solana-labs/solana/pull/24670 -- the stake pool program needs to be ready for that!

#### Solution

Update the minimum active stake amount and the minimum reserve amount as required.  This was tested against the changes to raise the minimum delegation to 1 SOL, but not the second PR.  The hope is that the only change will be to update `MINIMUM_RESERVE_LAMPORTS` to `0`.

The best option will be to call `get_minimum_delegation` on the stake program, but that hasn't landed in any of the Solana crates yet.

We can land this PR to unblock https://github.com/solana-labs/solana/pull/24603 if needed, or keep it as a draft.  We won't redeploy the program until the new instruction makes it anyway.