### PR TITLE
token-lending: Add version to spl-token dependency

### DIFF
--- a/token-lending/program/Cargo.toml
+++ b/token-lending/program/Cargo.toml
@@ -17,7 +17,7 @@ bytemuck = "1.7.2"
 num-derive = "0.3"
 num-traits = "0.2"
 solana-program = "1.10.10"
-spl-token = { path = "../../token/program", features = [ "no-entrypoint" ] }
+spl-token = { version = "3.3", path = "../../token/program", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 uint = "0.9"
 


### PR DESCRIPTION
#### Problem

`token-lending` doesn't specify a version for its `spl-token` dependency, making it impossible to publish.

#### Solution

Add a version.