### PR TITLE
token-lending: Fix maximum withdrawal value calculation

### DIFF
--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -1002,7 +1002,9 @@ fn process_withdraw_obligation_collateral(
         msg!("Obligation deposited value is zero");
         return Err(LendingError::ObligationDepositsZero.into());
     } else {
-        let max_withdraw_value = obligation.max_withdraw_value()?;
+        let max_withdraw_value = obligation.max_withdraw_value(Rate::from_percent(
+            withdraw_reserve.config.loan_to_value_ratio,
+        ))?;
         if max_withdraw_value == Decimal::zero() {
             msg!("Maximum withdraw value is zero");
             return Err(LendingError::WithdrawTooLarge.into());

--- a/token-lending/program/src/state/obligation.rs
+++ b/token-lending/program/src/state/obligation.rs
@@ -91,15 +91,19 @@ impl Obligation {
     }
 
     /// Calculate the maximum collateral value that can be withdrawn
-    pub fn max_withdraw_value(&self) -> Result<Decimal, ProgramError> {
-        let required_deposit_value = self
-            .borrowed_value
-            .try_mul(self.deposited_value)?
-            .try_div(self.allowed_borrow_value)?;
-        if required_deposit_value >= self.deposited_value {
+    pub fn max_withdraw_value(
+        &self,
+        withdraw_collateral_ltv: Rate,
+    ) -> Result<Decimal, ProgramError> {
+        if self.allowed_borrow_value <= self.borrowed_value {
             return Ok(Decimal::zero());
         }
-        self.deposited_value.try_sub(required_deposit_value)
+        if withdraw_collateral_ltv == Rate::zero() {
+            return Ok(self.deposited_value);
+        }
+        self.allowed_borrow_value
+            .try_sub(self.borrowed_value)?
+            .try_div(withdraw_collateral_ltv)
     }
 
     /// Calculate the maximum liquidity value that can be borrowed


### PR DESCRIPTION
#### Problem

`max_withdraw_value` is incorrectly calculated because it uses `allowed_borrow_value` which represents the average LTV, not the LTV of the actual asset to withdraw.

#### Solution

Correctly calculate the max withdraw value using the LTV of the applicable asset.