### PR TITLE
Token client improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5710,7 +5710,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-client"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "async-trait",
  "solana-client",

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 license = "Apache-2.0"
 name = "spl-token-client"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "0.0.1"
+version = "0.1.0"
 
 [dependencies]
 async-trait = "0.1"

--- a/token/client/src/client.rs
+++ b/token/client/src/client.rs
@@ -1,10 +1,13 @@
-use async_trait::async_trait;
-use solana_client::rpc_client::RpcClient;
-use solana_program_test::{tokio::sync::Mutex, BanksClient, ProgramTestContext};
-use solana_sdk::{
-    account::Account, hash::Hash, pubkey::Pubkey, signature::Signature, transaction::Transaction,
+use {
+    async_trait::async_trait,
+    solana_client::rpc_client::RpcClient,
+    solana_program_test::{tokio::sync::Mutex, BanksClient, ProgramTestContext},
+    solana_sdk::{
+        account::Account, hash::Hash, pubkey::Pubkey, signature::Signature,
+        transaction::Transaction,
+    },
+    std::{fmt, future::Future, pin::Pin, sync::Arc},
 };
-use std::{fmt, future::Future, pin::Pin, sync::Arc};
 
 type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 

--- a/token/client/src/client.rs
+++ b/token/client/src/client.rs
@@ -192,25 +192,25 @@ where
 }
 
 /// Program client for `RpcClient` from crate `solana-client`.
-pub struct ProgramRpcClient<'a, ST> {
-    client: &'a RpcClient,
+pub struct ProgramRpcClient<ST> {
+    client: Arc<RpcClient>,
     send: ST,
 }
 
-impl<ST> fmt::Debug for ProgramRpcClient<'_, ST> {
+impl<ST> fmt::Debug for ProgramRpcClient<ST> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ProgramRpcClient").finish()
     }
 }
 
-impl<'a, ST> ProgramRpcClient<'a, ST> {
-    pub fn new(client: &'a RpcClient, send: ST) -> Self {
+impl<ST> ProgramRpcClient<ST> {
+    pub fn new(client: Arc<RpcClient>, send: ST) -> Self {
         Self { client, send }
     }
 }
 
 #[async_trait]
-impl<ST> ProgramClient<ST> for ProgramRpcClient<'_, ST>
+impl<ST> ProgramClient<ST> for ProgramRpcClient<ST>
 where
     ST: SendTransactionRpc + Send + Sync,
 {
@@ -229,7 +229,7 @@ where
     }
 
     async fn send_transaction(&self, transaction: &Transaction) -> ProgramClientResult<ST::Output> {
-        self.send.send(self.client, transaction).await
+        self.send.send(&self.client, transaction).await
     }
 
     async fn get_account(&self, address: Pubkey) -> ProgramClientResult<Option<Account>> {

--- a/token/client/src/client.rs
+++ b/token/client/src/client.rs
@@ -74,7 +74,7 @@ impl SendTransactionRpc for ProgramRpcClientSendTransaction {
     ) -> BoxFuture<'a, ProgramClientResult<Self::Output>> {
         Box::pin(async move {
             client
-                .send_transaction(transaction)
+                .send_and_confirm_transaction(transaction)
                 .await
                 .map_err(Into::into)
         })

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -1,39 +1,41 @@
-use crate::client::{ProgramClient, ProgramClientError, SendTransaction};
-use solana_program_test::tokio::time;
-use solana_sdk::{
-    account::Account as BaseAccount,
-    epoch_info::EpochInfo,
-    hash::Hash,
-    instruction::Instruction,
-    program_error::ProgramError,
-    pubkey::Pubkey,
-    signer::{signers::Signers, Signer},
-    system_instruction,
-    transaction::Transaction,
-};
-use spl_associated_token_account::{
-    get_associated_token_address_with_program_id, instruction::create_associated_token_account,
-};
-use spl_token_2022::{
-    extension::{
-        confidential_transfer, default_account_state, memo_transfer, transfer_fee, ExtensionType,
-        StateWithExtensionsOwned,
+use {
+    crate::client::{ProgramClient, ProgramClientError, SendTransaction},
+    solana_program_test::tokio::time,
+    solana_sdk::{
+        account::Account as BaseAccount,
+        epoch_info::EpochInfo,
+        hash::Hash,
+        instruction::Instruction,
+        program_error::ProgramError,
+        pubkey::Pubkey,
+        signer::{signers::Signers, Signer},
+        system_instruction,
+        transaction::Transaction,
     },
-    instruction, native_mint,
-    solana_zk_token_sdk::{
-        encryption::{auth_encryption::*, elgamal::*},
-        errors::ProofError,
-        instruction::transfer_with_fee::FeeParameters,
+    spl_associated_token_account::{
+        get_associated_token_address_with_program_id, instruction::create_associated_token_account,
     },
-    state::{Account, AccountState, Mint},
+    spl_token_2022::{
+        extension::{
+            confidential_transfer, default_account_state, memo_transfer, transfer_fee,
+            ExtensionType, StateWithExtensionsOwned,
+        },
+        instruction, native_mint,
+        solana_zk_token_sdk::{
+            encryption::{auth_encryption::*, elgamal::*},
+            errors::ProofError,
+            instruction::transfer_with_fee::FeeParameters,
+        },
+        state::{Account, AccountState, Mint},
+    },
+    std::{
+        convert::TryInto,
+        fmt, io,
+        sync::{Arc, RwLock},
+        time::{Duration, Instant},
+    },
+    thiserror::Error,
 };
-use std::{
-    convert::TryInto,
-    fmt, io,
-    sync::{Arc, RwLock},
-    time::{Duration, Instant},
-};
-use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum TokenError {

--- a/token/client/tests/program-test.rs
+++ b/token/client/tests/program-test.rs
@@ -1,17 +1,19 @@
-use solana_program_test::{
-    tokio::{self, sync::Mutex},
-    ProgramTest,
+use {
+    solana_program_test::{
+        tokio::{self, sync::Mutex},
+        ProgramTest,
+    },
+    solana_sdk::{
+        program_option::COption,
+        signer::{keypair::Keypair, Signer},
+    },
+    spl_token_2022::{instruction, state},
+    spl_token_client::{
+        client::{ProgramBanksClient, ProgramBanksClientProcessTransaction, ProgramClient},
+        token::Token,
+    },
+    std::sync::Arc,
 };
-use solana_sdk::{
-    program_option::COption,
-    signer::{keypair::Keypair, Signer},
-};
-use spl_token_2022::{instruction, state};
-use spl_token_client::{
-    client::{ProgramBanksClient, ProgramBanksClientProcessTransaction, ProgramClient},
-    token::Token,
-};
-use std::sync::Arc;
 
 struct TestContext {
     pub decimals: u8,

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -21,4 +21,4 @@ solana-sdk = "=1.10.10"
 spl-associated-token-account = { version = "1.0.5", path = "../../associated-token-account/program" }
 spl-memo = { version = "3.0.1", path = "../../memo/program", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "0.3", path="../program-2022", features = ["no-entrypoint"] }
-spl-token-client = { version = "0.0.1", path = "../client" }
+spl-token-client = { version = "0.1.0", path = "../client" }


### PR DESCRIPTION
It's not that easy to use spl-token-client with an RpcClient (to point at a test-validator or live cluster RPC).

Changes:
- (First commit is purely cosmetic, and can be ignored in review)
- Use the nonblocking RpcClient instead of the blocking one (we're already async here)
- Arc-wrap the RpcClient in `ProgramRpcClient` so that it's easier to use for multiple calls without `will not live long enough` compile errors
- Change RpcClient `send` impl method from `send_transaction` to `send_and_confirm_transaction` - I think this is the most controversial of the changes. This approach seems the most straightforward to me, but we could instead require the caller to do any confirming they need/want. If so, we probably need to rework some things in client/src/token.rs. For instance, `Token::create_mint()` doesn't return the Output (signature) from `process_ixs()`, so there isn't currently a way for a caller to confirm that signature.