### PR TITLE
Rename encryption pubkey

### DIFF
--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -949,7 +949,7 @@ where
                 &self.program_id,
                 token_account,
                 &self.pubkey,
-                elgamal_pubkey,
+                elgamal_pubkey.into(),
                 decryptable_zero_balance,
                 &authority.pubkey(),
                 &[],
@@ -1131,7 +1131,7 @@ where
             source_elgamal_keypair,
             (
                 &destination_extension.encryption_pubkey.try_into().unwrap(),
-                &ct_mint.auditor_pubkey.try_into().unwrap(),
+                &ct_mint.auditor_encryption_pubkey.try_into().unwrap(),
             ),
         )
         .map_err(TokenError::Proof)?;
@@ -1197,14 +1197,14 @@ where
             source_elgamal_keypair,
             (
                 &destination_extension.encryption_pubkey.try_into().unwrap(),
-                &ct_mint.auditor_pubkey.try_into().unwrap(),
+                &ct_mint.auditor_encryption_pubkey.try_into().unwrap(),
             ),
             FeeParameters {
                 fee_rate_basis_points: u16::from(fee_parameters.transfer_fee_basis_points),
                 maximum_fee: u64::from(fee_parameters.maximum_fee),
             },
             &ct_mint
-                .withdraw_withheld_authority_pubkey
+                .withdraw_withheld_authority_encryption_pubkey
                 .try_into()
                 .unwrap(),
         )

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -60,8 +60,10 @@ impl ConfidentialTransferMintWithKeypairs {
         let ct_mint = ConfidentialTransferMint {
             authority: ct_mint_authority.pubkey().into(),
             auto_approve_new_accounts: true.into(),
-            auditor_pubkey: ct_mint_transfer_auditor.public.into(),
-            withdraw_withheld_authority_pubkey: ct_mint_withdraw_withheld_authority.public.into(),
+            auditor_encryption_pubkey: ct_mint_transfer_auditor.public.into(),
+            withdraw_withheld_authority_encryption_pubkey: ct_mint_withdraw_withheld_authority
+                .public
+                .into(),
             withheld_amount: EncryptedWithheldAmount::zeroed(),
         };
         Self {

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -1,5 +1,5 @@
 #[cfg(not(target_arch = "bpf"))]
-use solana_zk_token_sdk::encryption::{auth_encryption::AeCiphertext, elgamal::ElGamalPubkey};
+use solana_zk_token_sdk::encryption::auth_encryption::AeCiphertext;
 pub use solana_zk_token_sdk::zk_token_proof_instruction::*;
 use {
     crate::{
@@ -516,7 +516,7 @@ pub fn configure_account(
     token_program_id: &Pubkey,
     token_account: &Pubkey,
     mint: &Pubkey,
-    encryption_pubkey: ElGamalPubkey,
+    encryption_pubkey: EncryptionPubkey,
     decryptable_zero_balance: AeCiphertext,
     authority: &Pubkey,
     multisig_signers: &[&Pubkey],
@@ -538,7 +538,7 @@ pub fn configure_account(
         TokenInstruction::ConfidentialTransferExtension,
         ConfidentialTransferInstruction::ConfigureAccount,
         &ConfigureAccountInstructionData {
-            encryption_pubkey: encryption_pubkey.into(),
+            encryption_pubkey: encryption_pubkey,
             decryptable_zero_balance: decryptable_zero_balance.into(),
         },
     ))

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -538,7 +538,7 @@ pub fn configure_account(
         TokenInstruction::ConfidentialTransferExtension,
         ConfidentialTransferInstruction::ConfigureAccount,
         &ConfigureAccountInstructionData {
-            encryption_pubkey: encryption_pubkey,
+            encryption_pubkey,
             decryptable_zero_balance: decryptable_zero_balance.into(),
         },
     ))

--- a/token/program-2022/src/extension/confidential_transfer/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer/mod.rs
@@ -50,14 +50,14 @@ pub struct ConfidentialTransferMint {
     /// * If non-zero, transfers must include ElGamal cypertext with this public key permitting the
     /// auditor to decode the transfer amount.
     /// * If all zero, auditing is currently disabled.
-    pub auditor_pubkey: EncryptionPubkey,
+    pub auditor_encryption_pubkey: EncryptionPubkey,
 
     /// * If non-zero, transfers must include ElGamal cypertext of the transfer fee with this
     /// public key. If this is the case, but the base mint is not extended for fees, then any
     /// transfer will fail.
     /// * If all zero, transfer fee is disabled. If this is the case, but the base mint is extended
     /// for fees, then any transfer will fail.
-    pub withdraw_withheld_authority_pubkey: EncryptionPubkey,
+    pub withdraw_withheld_authority_encryption_pubkey: EncryptionPubkey,
 
     /// Withheld transfer fee confidential tokens that have been moved to the mint for withdrawal.
     /// This will always be zero if fees are never enabled.
@@ -79,10 +79,10 @@ pub struct ConfidentialTransferAccount {
     /// The public key associated with ElGamal encryption
     pub encryption_pubkey: EncryptionPubkey,
 
-    /// The pending balance (encrypted by `pubkey_elgamal`)
+    /// The pending balance (encrypted by `encryption_pubkey`)
     pub pending_balance: EncryptedBalance,
 
-    /// The available balance (encrypted by `pubkey_elgamal`)
+    /// The available balance (encrypted by `encrypiton_pubkey`)
     pub available_balance: EncryptedBalance,
 
     /// The decryptable available balance

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -561,7 +561,9 @@ fn process_transfer(
             &previous_instruction,
         )?;
 
-        if proof_data.transfer_pubkeys.auditor_pubkey != confidential_transfer_mint.auditor_encryption_pubkey {
+        if proof_data.transfer_pubkeys.auditor_pubkey
+            != confidential_transfer_mint.auditor_encryption_pubkey
+        {
             return Err(TokenError::ConfidentialTransferElGamalPubkeyMismatch.into());
         }
 

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -33,10 +33,6 @@ fn decode_proof_instruction<T: Pod>(
     expected: ProofInstruction,
     instruction: &Instruction,
 ) -> Result<&T, ProgramError> {
-    if ProofInstruction::decode_type(&instruction.data) != Some(expected) {
-        msg!("decode type failed ----------------------------------");
-    }
-
     if instruction.program_id != zk_token_proof_program::id()
         || ProofInstruction::decode_type(&instruction.data) != Some(expected)
     {
@@ -486,7 +482,7 @@ fn process_transfer(
         )?;
 
         if proof_data.transfer_with_fee_pubkeys.auditor_pubkey
-            != confidential_transfer_mint.auditor_pubkey
+            != confidential_transfer_mint.auditor_encryption_pubkey
         {
             return Err(TokenError::ConfidentialTransferElGamalPubkeyMismatch.into());
         }
@@ -495,7 +491,7 @@ fn process_transfer(
         if proof_data
             .transfer_with_fee_pubkeys
             .withdraw_withheld_authority_pubkey
-            != confidential_transfer_mint.withdraw_withheld_authority_pubkey
+            != confidential_transfer_mint.withdraw_withheld_authority_encryption_pubkey
         {
             return Err(TokenError::ConfidentialTransferElGamalPubkeyMismatch.into());
         }
@@ -565,7 +561,7 @@ fn process_transfer(
             &previous_instruction,
         )?;
 
-        if proof_data.transfer_pubkeys.auditor_pubkey != confidential_transfer_mint.auditor_pubkey {
+        if proof_data.transfer_pubkeys.auditor_pubkey != confidential_transfer_mint.auditor_encryption_pubkey {
             return Err(TokenError::ConfidentialTransferElGamalPubkeyMismatch.into());
         }
 
@@ -875,7 +871,7 @@ fn process_withdraw_withheld_tokens_from_mint(
 
     // withdraw withheld authority ElGamal pubkey should match in the proof data and mint
     if proof_data.withdraw_withheld_authority_pubkey
-        != confidential_transfer_mint.withdraw_withheld_authority_pubkey
+        != confidential_transfer_mint.withdraw_withheld_authority_encryption_pubkey
     {
         return Err(TokenError::ConfidentialTransferElGamalPubkeyMismatch.into());
     }
@@ -998,7 +994,7 @@ fn process_withdraw_withheld_tokens_from_accounts(
     // withdraw withheld authority ElGamal pubkey should match in the proof data and mint
     let confidential_transfer_mint = mint.get_extension_mut::<ConfidentialTransferMint>()?;
     if proof_data.withdraw_withheld_authority_pubkey
-        != confidential_transfer_mint.withdraw_withheld_authority_pubkey
+        != confidential_transfer_mint.withdraw_withheld_authority_encryption_pubkey
     {
         return Err(TokenError::ConfidentialTransferElGamalPubkeyMismatch.into());
     }


### PR DESCRIPTION
There were some inconsistencies regarding the variable names of regular pubkey and ElGamal pubkey. After this PR:
- If a variable does not have the `pubkey` suffix, then it is a regular pubkey
- If a variable has the `encryption_pubkey` suffix, then it is an ElGamal pubkey