### PR TITLE
Governance: Veto vote 

### DIFF
--- a/governance/CHANGELOG.md
+++ b/governance/CHANGELOG.md
@@ -1,0 +1,34 @@
+# SPL Governance Changelog
+
+## v3.0.0 - development
+
+- Support separate vote threshold for `Council`
+- `Council` Veto vote
+
+## v2.2.4 - 24 Mar 2022
+
+- Support Anchor native account discriminators for `MaxVoterWeightRecord` and `VoterWeightRecord`
+
+## v2.2.3 - 09 Feb 2022
+
+- Fix serialisation of multiple instructions within a single proposal transaction
+
+## v2.2.2 - 07 Feb 2022
+
+- Native SOL Treasuries
+- Multi choice and survey style proposals
+- `voter_weight` and `max_voter_weight` addins
+- Multiple instructions per proposal transaction
+- Configurable tipping point (`Strict`, `Early`, `Disabled`)
+- Owner signed off proposals
+- `realm_authority` can create governances
+- Program metadata and version detection
+- Custom deposit amount for governance tokens
+
+## v1.1.1 - 23 Sep 2021
+
+- Constrain number of outstanding proposals per token owner to 10 at a time
+
+## v1.0.8 - 1 Aug 2021
+
+- Fist release

--- a/governance/CHANGELOG.md
+++ b/governance/CHANGELOG.md
@@ -31,4 +31,4 @@
 
 ## v1.0.8 - 1 Aug 2021
 
-- Fist release
+- First release

--- a/governance/chat/program/src/state.rs
+++ b/governance/chat/program/src/state.rs
@@ -8,7 +8,6 @@ use solana_program::{
 use spl_governance_tools::account::{assert_is_valid_account_of_type, AccountMaxSize};
 
 /// Defines all GovernanceChat accounts types
-#[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum GovernanceChatAccountType {
     /// Default uninitialized account state

--- a/governance/chat/program/tests/program_test/mod.rs
+++ b/governance/chat/program/tests/program_test/mod.rs
@@ -186,7 +186,7 @@ impl GovernanceChatProgramTest {
             community_vote_threshold: VoteThreshold::YesVotePercentage(60),
             vote_tipping: spl_governance::state::enums::VoteTipping::Strict,
             council_vote_threshold: VoteThreshold::YesVotePercentage(10),
-            reserved: [0; 2],
+            council_veto_vote_threshold: VoteThreshold::YesVotePercentage(50),
         };
 
         let token_owner_record_address = get_token_owner_record_address(

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -164,7 +164,7 @@ pub enum GovernanceError {
 
     /// Proposal does not belong to the given Governance
     #[error("Proposal does not belong to the given Governance")]
-    InvalidGovernanceForProposal,
+    InvalidGovernanceForProposal, // 538
 
     /// Proposal does not belong to given Governing Mint"
     #[error("Proposal does not belong to given Governing Mint")]
@@ -172,87 +172,87 @@ pub enum GovernanceError {
 
     /// Current mint authority must sign transaction
     #[error("Current mint authority must sign transaction")]
-    MintAuthorityMustSign,
+    MintAuthorityMustSign, // 540
 
     /// Invalid mint authority
     #[error("Invalid mint authority")]
-    InvalidMintAuthority,
+    InvalidMintAuthority, // 542
 
     /// Mint has no authority
     #[error("Mint has no authority")]
-    MintHasNoAuthority,
+    MintHasNoAuthority, // 542
 
     /// ---- SPL Token Tools Errors ----
 
     /// Invalid Token account owner
     #[error("Invalid Token account owner")]
-    SplTokenAccountWithInvalidOwner,
+    SplTokenAccountWithInvalidOwner, // 543
 
     /// Invalid Mint account owner
     #[error("Invalid Mint account owner")]
-    SplTokenMintWithInvalidOwner,
+    SplTokenMintWithInvalidOwner, // 544
 
     /// Token Account is not initialized
     #[error("Token Account is not initialized")]
-    SplTokenAccountNotInitialized,
+    SplTokenAccountNotInitialized, // 545
 
     /// Token Account doesn't exist
     #[error("Token Account doesn't exist")]
-    SplTokenAccountDoesNotExist,
+    SplTokenAccountDoesNotExist, // 546
 
     /// Token account data is invalid
     #[error("Token account data is invalid")]
-    SplTokenInvalidTokenAccountData,
+    SplTokenInvalidTokenAccountData, // 547
 
     /// Token mint account data is invalid
     #[error("Token mint account data is invalid")]
-    SplTokenInvalidMintAccountData,
+    SplTokenInvalidMintAccountData, // 548
 
     /// Token Mint is not initialized
     #[error("Token Mint account is not initialized")]
-    SplTokenMintNotInitialized,
+    SplTokenMintNotInitialized, // 549
 
     /// Token Mint account doesn't exist
     #[error("Token Mint account doesn't exist")]
-    SplTokenMintDoesNotExist,
+    SplTokenMintDoesNotExist, // 550
 
     /// ---- Bpf Upgradable Loader Tools Errors ----
 
     /// Invalid ProgramData account Address
     #[error("Invalid ProgramData account address")]
-    InvalidProgramDataAccountAddress,
+    InvalidProgramDataAccountAddress, // 551
 
     /// Invalid ProgramData account data
     #[error("Invalid ProgramData account Data")]
-    InvalidProgramDataAccountData,
+    InvalidProgramDataAccountData, // 552
 
     /// Provided upgrade authority doesn't match current program upgrade authority
     #[error("Provided upgrade authority doesn't match current program upgrade authority")]
-    InvalidUpgradeAuthority,
+    InvalidUpgradeAuthority, // 553
 
     /// Current program upgrade authority must sign transaction
     #[error("Current program upgrade authority must sign transaction")]
-    UpgradeAuthorityMustSign,
+    UpgradeAuthorityMustSign, // 554
 
     /// Given program is not upgradable
     #[error("Given program is not upgradable")]
-    ProgramNotUpgradable,
+    ProgramNotUpgradable, // 555
 
     /// Invalid token owner
     #[error("Invalid token owner")]
-    InvalidTokenOwner,
+    InvalidTokenOwner, // 556
 
     /// Current token owner must sign transaction
     #[error("Current token owner must sign transaction")]
-    TokenOwnerMustSign,
+    TokenOwnerMustSign, // 557
 
     /// Given VoteThresholdType is not supported
     #[error("Given VoteThresholdType is not supported")]
-    VoteThresholdTypeNotSupported,
+    VoteThresholdTypeNotSupported, // 558
 
     /// Given VoteWeightSource is not supported
     #[error("Given VoteWeightSource is not supported")]
-    VoteWeightSourceNotSupported,
+    VoteWeightSourceNotSupported, // 559
 
     /// GoverningTokenMint not allowed to vote
     #[error("GoverningTokenMint not allowed to vote")]

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -401,6 +401,10 @@ pub enum GovernanceError {
     /// Reserved buffer must be empty
     #[error("Reserved buffer must be empty")]
     ReservedBufferMustBeEmpty,
+
+    /// Veto vote disabled for governing token
+    #[error("Veto vote disabled for governing token")]
+    VetoVoteDisabledForGoverningToken,
 }
 
 impl PrintProgramError for GovernanceError {

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -25,7 +25,7 @@ pub enum GovernanceError {
 
     /// Invalid Governing Token Mint
     #[error("Invalid Governing Token Mint")]
-    InvalidGoverningTokenMint,
+    InvalidGoverningTokenMint, // 503
 
     /// Governing Token Owner must sign transaction
     #[error("Governing Token Owner must sign transaction")]
@@ -45,11 +45,11 @@ pub enum GovernanceError {
 
     /// Invalid GoverningMint for TokenOwnerRecord
     #[error("Invalid GoverningMint for TokenOwnerRecord")]
-    InvalidGoverningMintForTokenOwnerRecord,
+    InvalidGoverningMintForTokenOwnerRecord, // 508
 
     /// Invalid Realm for TokenOwnerRecord
     #[error("Invalid Realm for TokenOwnerRecord")]
-    InvalidRealmForTokenOwnerRecord,
+    InvalidRealmForTokenOwnerRecord, // 509
 
     /// Invalid Proposal for ProposalTransaction,
     #[error("Invalid Proposal for ProposalTransaction,")]
@@ -168,7 +168,7 @@ pub enum GovernanceError {
 
     /// Proposal does not belong to given Governing Mint"
     #[error("Proposal does not belong to given Governing Mint")]
-    InvalidGoverningMintForProposal,
+    InvalidGoverningMintForProposal, // 539
 
     /// Current mint authority must sign transaction
     #[error("Current mint authority must sign transaction")]

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -401,10 +401,6 @@ pub enum GovernanceError {
     /// Reserved buffer must be empty
     #[error("Reserved buffer must be empty")]
     ReservedBufferMustBeEmpty,
-
-    /// Veto vote disabled for governing token
-    #[error("Veto vote disabled for governing token")]
-    VetoVoteDisabledForGoverningToken,
 }
 
 impl PrintProgramError for GovernanceError {

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -30,7 +30,6 @@ use solana_program::{
 
 /// Instructions supported by the Governance program
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
-#[repr(C)]
 #[allow(clippy::large_enum_variant)]
 pub enum GovernanceInstruction {
     /// Creates Governance Realm account which aggregates governances for given Community Mint and optional Council Mint

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -285,10 +285,10 @@ pub enum GovernanceInstruction {
     ///   1. `[writable]` Governance account
     ///   2. `[writable]` Proposal account
     ///   3. `[writable]` TokenOwnerRecord of the Proposal owner
-    ///   4. `[writable]` TokenOwnerRecord of the voter. PDA seeds: ['governance',realm, governing_token_mint, governing_token_owner]
+    ///   4. `[writable]` TokenOwnerRecord of the voter. PDA seeds: ['governance',realm, vote_governing_token_mint, governing_token_owner]
     ///   5. `[signer]` Governance Authority (Token Owner or Governance Delegate)
     ///   6. `[writable]` Proposal VoteRecord account. PDA seeds: ['governance',proposal,governing_token_owner_record]
-    ///   7. `[]` Voting Token Mint
+    ///   7. `[]` The Governing Token Mint which is used to cast the vote (vote_governing_token_mint)
     ///           The voting token mint is the governing_token_mint of the Proposal for Approve, Deny and Abstain votes
     ///           For Veto vote the voting token mint is the mint of the opposite voting population
     ///           Council mint to veto Community proposals and Community mint to veto Council proposals
@@ -323,9 +323,9 @@ pub enum GovernanceInstruction {
     ///   0. `[]` Realm account
     ///   1. `[]` Governance account
     ///   2. `[writable]` Proposal account
-    ///   3. `[writable]` TokenOwnerRecord account. PDA seeds: ['governance',realm, voting_token_mint, governing_token_owner]
+    ///   3. `[writable]` TokenOwnerRecord account. PDA seeds: ['governance',realm, vote_governing_token_mint, governing_token_owner]
     ///   4. `[writable]` Proposal VoteRecord account. PDA seeds: ['governance',proposal, governing_token_owner_record]
-    ///   5. `[]` Voting Token Mint. The Governing Token Mint which was used to cast the vote
+    ///   5. `[]` The Governing Token Mint which was used to cast the vote (vote_governing_token_mint)
     ///   6. `[signer]` Optional Governance Authority (Token Owner or Governance Delegate)
     ///       It's required only when Proposal is still being voted on
     ///   7. `[writable]` Optional Beneficiary account which would receive lamports when VoteRecord Account is disposed
@@ -1024,7 +1024,7 @@ pub fn cast_vote(
     proposal_owner_record: &Pubkey,
     voter_token_owner_record: &Pubkey,
     governance_authority: &Pubkey,
-    voting_token_mint: &Pubkey,
+    vote_governing_token_mint: &Pubkey,
     payer: &Pubkey,
     voter_weight_record: Option<Pubkey>,
     max_voter_weight_record: Option<Pubkey>,
@@ -1042,7 +1042,7 @@ pub fn cast_vote(
         AccountMeta::new(*voter_token_owner_record, false),
         AccountMeta::new_readonly(*governance_authority, true),
         AccountMeta::new(vote_record_address, false),
-        AccountMeta::new_readonly(*voting_token_mint, false),
+        AccountMeta::new_readonly(*vote_governing_token_mint, false),
         AccountMeta::new(*payer, true),
         AccountMeta::new_readonly(system_program::id(), false),
     ];
@@ -1109,7 +1109,7 @@ pub fn relinquish_vote(
     governance: &Pubkey,
     proposal: &Pubkey,
     token_owner_record: &Pubkey,
-    voting_token_mint: &Pubkey,
+    vote_governing_token_mint: &Pubkey,
     governance_authority: Option<Pubkey>,
     beneficiary: Option<Pubkey>,
 ) -> Instruction {
@@ -1121,7 +1121,7 @@ pub fn relinquish_vote(
         AccountMeta::new(*proposal, false),
         AccountMeta::new(*token_owner_record, false),
         AccountMeta::new(vote_record_address, false),
-        AccountMeta::new_readonly(*voting_token_mint, false),
+        AccountMeta::new_readonly(*vote_governing_token_mint, false),
     ];
 
     if let Some(governance_authority) = governance_authority {

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -1101,6 +1101,7 @@ pub fn finalize_vote(
 }
 
 /// Creates RelinquishVote instruction
+#[allow(clippy::too_many_arguments)]
 pub fn relinquish_vote(
     program_id: &Pubkey,
     // Accounts

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -288,7 +288,11 @@ pub enum GovernanceInstruction {
     ///   4. `[writable]` TokenOwnerRecord of the voter. PDA seeds: ['governance',realm, governing_token_mint, governing_token_owner]
     ///   5. `[signer]` Governance Authority (Token Owner or Governance Delegate)
     ///   6. `[writable]` Proposal VoteRecord account. PDA seeds: ['governance',proposal,governing_token_owner_record]
-    ///   7. `[]` Governing Token Mint
+    ///   7. `[]` Voting Token Mint
+    ///           The voting token mint is the governing_token_mint of the Proposal for Approve, Deny and Abstain votes
+    ///           For Veto vote the voting token mint is the mint of the opposite voting population
+    ///           Council can veto Community proposals and Community can veto Council proposals
+    ///           Note: In the current version only Council veto is supported
     ///   8. `[signer]` Payer
     ///   9. `[]` System program
     ///   10. `[]` Realm Config
@@ -1019,7 +1023,7 @@ pub fn cast_vote(
     proposal_owner_record: &Pubkey,
     voter_token_owner_record: &Pubkey,
     governance_authority: &Pubkey,
-    governing_token_mint: &Pubkey,
+    voting_token_mint: &Pubkey,
     payer: &Pubkey,
     voter_weight_record: Option<Pubkey>,
     max_voter_weight_record: Option<Pubkey>,
@@ -1037,7 +1041,7 @@ pub fn cast_vote(
         AccountMeta::new(*voter_token_owner_record, false),
         AccountMeta::new_readonly(*governance_authority, true),
         AccountMeta::new(vote_record_address, false),
-        AccountMeta::new_readonly(*governing_token_mint, false),
+        AccountMeta::new_readonly(*voting_token_mint, false),
         AccountMeta::new(*payer, true),
         AccountMeta::new_readonly(system_program::id(), false),
     ];

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -320,14 +320,15 @@ pub enum GovernanceInstruction {
     ///  If the Proposal is already in decided state then the instruction has no impact on the Proposal
     ///  and only allows voters to prune their outstanding votes in case they wanted to withdraw Governing tokens from the Realm
     ///
-    ///   0. `[]` Governance account
-    ///   1. `[writable]` Proposal account
-    ///   2. `[writable]` TokenOwnerRecord account. PDA seeds: ['governance',realm, governing_token_mint, governing_token_owner]
-    ///   3. `[writable]` Proposal VoteRecord account. PDA seeds: ['governance',proposal,governing_token_owner_record]
-    ///   4. `[]` Governing Token Mint
-    ///   5. `[signer]` Optional Governance Authority (Token Owner or Governance Delegate)
+    ///   0. `[]` Realm account
+    ///   1. `[]` Governance account
+    ///   2. `[writable]` Proposal account
+    ///   3. `[writable]` TokenOwnerRecord account. PDA seeds: ['governance',realm, voting_token_mint, governing_token_owner]
+    ///   4. `[writable]` Proposal VoteRecord account. PDA seeds: ['governance',proposal, governing_token_owner_record]
+    ///   5. `[]` Voting Token Mint. The Governing Token Mint which was used to cast the vote
+    ///   6. `[signer]` Optional Governance Authority (Token Owner or Governance Delegate)
     ///       It's required only when Proposal is still being voted on
-    ///   6. `[writable]` Optional Beneficiary account which would receive lamports when VoteRecord Account is disposed
+    ///   7. `[writable]` Optional Beneficiary account which would receive lamports when VoteRecord Account is disposed
     ///       It's required only when Proposal is still being voted on
     RelinquishVote,
 
@@ -1103,21 +1104,23 @@ pub fn finalize_vote(
 pub fn relinquish_vote(
     program_id: &Pubkey,
     // Accounts
+    realm: &Pubkey,
     governance: &Pubkey,
     proposal: &Pubkey,
     token_owner_record: &Pubkey,
-    governing_token_mint: &Pubkey,
+    voting_token_mint: &Pubkey,
     governance_authority: Option<Pubkey>,
     beneficiary: Option<Pubkey>,
 ) -> Instruction {
     let vote_record_address = get_vote_record_address(program_id, proposal, token_owner_record);
 
     let mut accounts = vec![
+        AccountMeta::new_readonly(*realm, false),
         AccountMeta::new_readonly(*governance, false),
         AccountMeta::new(*proposal, false),
         AccountMeta::new(*token_owner_record, false),
         AccountMeta::new(vote_record_address, false),
-        AccountMeta::new_readonly(*governing_token_mint, false),
+        AccountMeta::new_readonly(*voting_token_mint, false),
     ];
 
     if let Some(governance_authority) = governance_authority {

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -291,7 +291,7 @@ pub enum GovernanceInstruction {
     ///   7. `[]` Voting Token Mint
     ///           The voting token mint is the governing_token_mint of the Proposal for Approve, Deny and Abstain votes
     ///           For Veto vote the voting token mint is the mint of the opposite voting population
-    ///           Council can veto Community proposals and Community can veto Council proposals
+    ///           Council mint to veto Community proposals and Community mint to veto Council proposals
     ///           Note: In the current version only Council veto is supported
     ///   8. `[signer]` Payer
     ///   9. `[]` System program

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -287,7 +287,7 @@ pub enum GovernanceInstruction {
     ///   3. `[writable]` TokenOwnerRecord of the Proposal owner
     ///   4. `[writable]` TokenOwnerRecord of the voter. PDA seeds: ['governance',realm, vote_governing_token_mint, governing_token_owner]
     ///   5. `[signer]` Governance Authority (Token Owner or Governance Delegate)
-    ///   6. `[writable]` Proposal VoteRecord account. PDA seeds: ['governance',proposal,governing_token_owner_record]
+    ///   6. `[writable]` Proposal VoteRecord account. PDA seeds: ['governance',proposal,token_owner_record]
     ///   7. `[]` The Governing Token Mint which is used to cast the vote (vote_governing_token_mint)
     ///           The voting token mint is the governing_token_mint of the Proposal for Approve, Deny and Abstain votes
     ///           For Veto vote the voting token mint is the mint of the opposite voting population
@@ -324,7 +324,7 @@ pub enum GovernanceInstruction {
     ///   1. `[]` Governance account
     ///   2. `[writable]` Proposal account
     ///   3. `[writable]` TokenOwnerRecord account. PDA seeds: ['governance',realm, vote_governing_token_mint, governing_token_owner]
-    ///   4. `[writable]` Proposal VoteRecord account. PDA seeds: ['governance',proposal, governing_token_owner_record]
+    ///   4. `[writable]` Proposal VoteRecord account. PDA seeds: ['governance',proposal, token_owner_record]
     ///   5. `[]` The Governing Token Mint which was used to cast the vote (vote_governing_token_mint)
     ///   6. `[signer]` Optional Governance Authority (Token Owner or Governance Delegate)
     ///       It's required only when Proposal is still being voted on

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -16,7 +16,7 @@ use crate::{
     state::{
         enums::GovernanceAccountType,
         governance::get_governance_data_for_realm,
-        proposal::get_proposal_data_for_governance_and_governing_mint,
+        proposal::get_proposal_data_for_governance_and_governing_token_mint,
         realm::get_realm_data_for_governing_token_mint,
         token_owner_record::{
             get_token_owner_record_data_for_proposal_owner,
@@ -73,7 +73,7 @@ pub fn process_cast_vote(
         voting_token_mint_info.key,
     )?;
 
-    let mut proposal_data = get_proposal_data_for_governance_and_governing_mint(
+    let mut proposal_data = get_proposal_data_for_governance_and_governing_token_mint(
         program_id,
         proposal_info,
         governance_info.key,

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -22,7 +22,7 @@ use crate::{
             get_token_owner_record_data_for_proposal_owner,
             get_token_owner_record_data_for_realm_and_governing_mint,
         },
-        vote_record::{get_vote_record_address_seeds, Vote, VoteRecordV2},
+        vote_record::{get_vote_kind, get_vote_record_address_seeds, Vote, VoteRecordV2},
     },
 };
 
@@ -147,6 +147,8 @@ pub fn process_cast_vote(
         }
     }
 
+    let vote_kind = get_vote_kind(&vote);
+
     let max_voter_weight = proposal_data.resolve_max_voter_weight(
         program_id,
         realm_config_info,
@@ -154,13 +156,13 @@ pub fn process_cast_vote(
         account_info_iter, // max_voter_weight_record  11
         realm_info.key,
         &realm_data,
-        Some(&vote),
+        &vote_kind,
     )?;
 
     let vote_threshold = governance_data.resolve_vote_threshold(
         &realm_data,
         voting_token_mint_info.key,
-        Some(&vote),
+        &vote_kind,
     )?;
 
     if proposal_data.try_tip_vote(
@@ -168,7 +170,7 @@ pub fn process_cast_vote(
         &governance_data.config,
         clock.unix_timestamp,
         &vote_threshold,
-        &vote,
+        &vote_kind,
     )? {
         // Deserialize proposal owner and validate it's the actual owner of the proposal
         let mut proposal_owner_record_data = get_token_owner_record_data_for_proposal_owner(

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -65,11 +65,15 @@ pub fn process_cast_vote(
     let mut governance_data =
         get_governance_data_for_realm(program_id, governance_info, realm_info.key)?;
 
+    let vote_kind = get_vote_kind(&vote);
+
     // Get the governing_token_mint which the Proposal should be configured with as the voting population for the given vote
     // For Approve, Deny and Abstain votes it's the same as vote_governing_token_mint
     // For Veto it's the governing token mint of the opposite voting population
-    let proposal_governing_token_mint = realm_data
-        .get_proposal_governing_token_mint_for_vote(&vote, vote_governing_token_mint_info.key)?;
+    let proposal_governing_token_mint = realm_data.get_proposal_governing_token_mint_for_vote(
+        vote_governing_token_mint_info.key,
+        &vote_kind,
+    )?;
 
     let mut proposal_data = get_proposal_data_for_governance_and_governing_mint(
         program_id,
@@ -146,8 +150,6 @@ pub fn process_cast_vote(
             return Err(GovernanceError::NotSupportedVoteType.into());
         }
     }
-
-    let vote_kind = get_vote_kind(&vote);
 
     let max_voter_weight = proposal_data.resolve_max_voter_weight(
         program_id,

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -16,7 +16,7 @@ use crate::{
     state::{
         enums::GovernanceAccountType,
         governance::get_governance_data_for_realm,
-        proposal::get_proposal_data_for_governance_and_governing_token_mint,
+        proposal::get_proposal_data_for_governance_and_governing_mint,
         realm::get_realm_data_for_governing_token_mint,
         token_owner_record::{
             get_token_owner_record_data_for_proposal_owner,
@@ -71,7 +71,7 @@ pub fn process_cast_vote(
     let proposal_governing_token_mint =
         realm_data.get_proposal_governing_token_mint_for_vote(&vote, voting_token_mint_info.key)?;
 
-    let mut proposal_data = get_proposal_data_for_governance_and_governing_token_mint(
+    let mut proposal_data = get_proposal_data_for_governance_and_governing_mint(
         program_id,
         proposal_info,
         governance_info.key,

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -66,12 +66,10 @@ pub fn process_cast_vote(
         get_governance_data_for_realm(program_id, governance_info, realm_info.key)?;
 
     // Resolve governing_token_mint which the Proposal should be configured with as the voting population for the given vote
-    // TODO: Split resolve and assertion the that Veto is enabled
-    let proposal_governing_token_mint = realm_data.resolve_proposal_governing_token_mint_for_vote(
-        &vote,
-        &governance_data,
-        voting_token_mint_info.key,
-    )?;
+    // For Approve, Deny and Abstain votes it's the same as voting_token_mint
+    // For Veto it's the governing token mint of the opposite voting population
+    let proposal_governing_token_mint = realm_data
+        .resolve_proposal_governing_token_mint_for_vote(&vote, voting_token_mint_info.key)?;
 
     let mut proposal_data = get_proposal_data_for_governance_and_governing_token_mint(
         program_id,
@@ -117,7 +115,6 @@ pub fn process_cast_vote(
         proposal_info.key,
     )?;
 
-    // TODO: Move check for Veto here
     proposal_data.assert_valid_vote(&vote)?;
 
     // Calculate Proposal voting weights

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -44,7 +44,7 @@ pub fn process_cast_vote(
     let governance_authority_info = next_account_info(account_info_iter)?; // 5
 
     let vote_record_info = next_account_info(account_info_iter)?; // 6
-    let voting_token_mint_info = next_account_info(account_info_iter)?; // 7
+    let vote_governing_token_mint_info = next_account_info(account_info_iter)?; // 7
 
     let payer_info = next_account_info(account_info_iter)?; // 8
     let system_info = next_account_info(account_info_iter)?; // 9
@@ -59,17 +59,17 @@ pub fn process_cast_vote(
     let mut realm_data = get_realm_data_for_governing_token_mint(
         program_id,
         realm_info,
-        voting_token_mint_info.key,
+        vote_governing_token_mint_info.key,
     )?;
 
     let mut governance_data =
         get_governance_data_for_realm(program_id, governance_info, realm_info.key)?;
 
     // Get the governing_token_mint which the Proposal should be configured with as the voting population for the given vote
-    // For Approve, Deny and Abstain votes it's the same as voting_token_mint
+    // For Approve, Deny and Abstain votes it's the same as vote_governing_token_mint
     // For Veto it's the governing token mint of the opposite voting population
-    let proposal_governing_token_mint =
-        realm_data.get_proposal_governing_token_mint_for_vote(&vote, voting_token_mint_info.key)?;
+    let proposal_governing_token_mint = realm_data
+        .get_proposal_governing_token_mint_for_vote(&vote, vote_governing_token_mint_info.key)?;
 
     let mut proposal_data = get_proposal_data_for_governance_and_governing_mint(
         program_id,
@@ -84,7 +84,7 @@ pub fn process_cast_vote(
             program_id,
             voter_token_owner_record_info,
             &governance_data.realm,
-            voting_token_mint_info.key,
+            vote_governing_token_mint_info.key,
         )?;
     voter_token_owner_record_data
         .assert_token_owner_or_delegate_is_signer(governance_authority_info)?;
@@ -152,7 +152,7 @@ pub fn process_cast_vote(
     let max_voter_weight = proposal_data.resolve_max_voter_weight(
         program_id,
         realm_config_info,
-        voting_token_mint_info,
+        vote_governing_token_mint_info,
         account_info_iter, // max_voter_weight_record  11
         realm_info.key,
         &realm_data,
@@ -161,7 +161,7 @@ pub fn process_cast_vote(
 
     let vote_threshold = governance_data.resolve_vote_threshold(
         &realm_data,
-        voting_token_mint_info.key,
+        vote_governing_token_mint_info.key,
         &vote_kind,
     )?;
 

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -154,6 +154,7 @@ pub fn process_cast_vote(
         account_info_iter, // max_voter_weight_record  11
         realm_info.key,
         &realm_data,
+        Some(&vote),
     )?;
 
     let vote_threshold = governance_data.resolve_vote_threshold(

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -65,11 +65,11 @@ pub fn process_cast_vote(
     let mut governance_data =
         get_governance_data_for_realm(program_id, governance_info, realm_info.key)?;
 
-    // Resolve governing_token_mint which the Proposal should be configured with as the voting population for the given vote
+    // Get the governing_token_mint which the Proposal should be configured with as the voting population for the given vote
     // For Approve, Deny and Abstain votes it's the same as voting_token_mint
     // For Veto it's the governing token mint of the opposite voting population
-    let proposal_governing_token_mint = realm_data
-        .resolve_proposal_governing_token_mint_for_vote(&vote, voting_token_mint_info.key)?;
+    let proposal_governing_token_mint =
+        realm_data.get_proposal_governing_token_mint_for_vote(&vote, voting_token_mint_info.key)?;
 
     let mut proposal_data = get_proposal_data_for_governance_and_governing_token_mint(
         program_id,

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -169,7 +169,7 @@ pub fn process_cast_vote(
 
     if proposal_data.try_tip_vote(
         max_voter_weight,
-        &governance_data.config,
+        &governance_data.config.vote_tipping,
         clock.unix_timestamp,
         &vote_threshold,
         &vote_kind,

--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -22,6 +22,7 @@ use crate::{
         },
         realm::get_realm_data_for_governing_token_mint,
         token_owner_record::get_token_owner_record_data_for_realm,
+        vote_record::VoteKind,
     },
 };
 
@@ -64,8 +65,11 @@ pub fn process_create_proposal(
     let mut governance_data =
         get_governance_data_for_realm(program_id, governance_info, realm_info.key)?;
 
-    governance_data
-        .assert_governing_token_mint_can_vote(&realm_data, governing_token_mint_info.key)?;
+    governance_data.assert_governing_token_mint_can_vote(
+        &realm_data,
+        governing_token_mint_info.key,
+        &VoteKind::Electorate,
+    )?;
 
     let mut proposal_owner_record_data = get_token_owner_record_data_for_realm(
         program_id,

--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -146,7 +146,7 @@ pub fn process_create_proposal(
         options: proposal_options,
         deny_vote_weight,
 
-        veto_vote_weight: None,
+        veto_vote_weight: 0,
         abstain_vote_weight: None,
 
         max_vote_weight: None,

--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -154,6 +154,7 @@ pub fn process_create_proposal(
         vote_threshold: None,
 
         reserved: [0; 64],
+        reserved1: 0,
     };
 
     create_and_serialize_account_signed::<ProposalV2>(

--- a/governance/program/src/processor/process_finalize_vote.rs
+++ b/governance/program/src/processor/process_finalize_vote.rs
@@ -10,7 +10,7 @@ use solana_program::{
 
 use crate::state::{
     governance::get_governance_data_for_realm,
-    proposal::get_proposal_data_for_governance_and_governing_token_mint,
+    proposal::get_proposal_data_for_governance_and_governing_mint,
     realm::get_realm_data_for_governing_token_mint,
     token_owner_record::get_token_owner_record_data_for_proposal_owner,
 };
@@ -36,7 +36,7 @@ pub fn process_finalize_vote(program_id: &Pubkey, accounts: &[AccountInfo]) -> P
     let mut governance_data =
         get_governance_data_for_realm(program_id, governance_info, realm_info.key)?;
 
-    let mut proposal_data = get_proposal_data_for_governance_and_governing_token_mint(
+    let mut proposal_data = get_proposal_data_for_governance_and_governing_mint(
         program_id,
         proposal_info,
         governance_info.key,

--- a/governance/program/src/processor/process_finalize_vote.rs
+++ b/governance/program/src/processor/process_finalize_vote.rs
@@ -52,6 +52,7 @@ pub fn process_finalize_vote(program_id: &Pubkey, accounts: &[AccountInfo]) -> P
         account_info_iter, // *6
         realm_info.key,
         &realm_data,
+        None,
     )?;
 
     let vote_threshold =

--- a/governance/program/src/processor/process_finalize_vote.rs
+++ b/governance/program/src/processor/process_finalize_vote.rs
@@ -55,7 +55,7 @@ pub fn process_finalize_vote(program_id: &Pubkey, accounts: &[AccountInfo]) -> P
     )?;
 
     let vote_threshold =
-        governance_data.resolve_vote_threshold(&realm_data, governing_token_mint_info.key)?;
+        governance_data.resolve_vote_threshold(&realm_data, governing_token_mint_info.key, None)?;
 
     proposal_data.finalize_vote(
         max_voter_weight,

--- a/governance/program/src/processor/process_finalize_vote.rs
+++ b/governance/program/src/processor/process_finalize_vote.rs
@@ -10,7 +10,7 @@ use solana_program::{
 
 use crate::state::{
     governance::get_governance_data_for_realm,
-    proposal::get_proposal_data_for_governance_and_governing_mint,
+    proposal::get_proposal_data_for_governance_and_governing_token_mint,
     realm::get_realm_data_for_governing_token_mint,
     token_owner_record::get_token_owner_record_data_for_proposal_owner,
 };
@@ -36,7 +36,7 @@ pub fn process_finalize_vote(program_id: &Pubkey, accounts: &[AccountInfo]) -> P
     let mut governance_data =
         get_governance_data_for_realm(program_id, governance_info, realm_info.key)?;
 
-    let mut proposal_data = get_proposal_data_for_governance_and_governing_mint(
+    let mut proposal_data = get_proposal_data_for_governance_and_governing_token_mint(
         program_id,
         proposal_info,
         governance_info.key,

--- a/governance/program/src/processor/process_finalize_vote.rs
+++ b/governance/program/src/processor/process_finalize_vote.rs
@@ -12,7 +12,7 @@ use crate::state::{
     governance::get_governance_data_for_realm,
     proposal::get_proposal_data_for_governance_and_governing_mint,
     realm::get_realm_data_for_governing_token_mint,
-    token_owner_record::get_token_owner_record_data_for_proposal_owner,
+    token_owner_record::get_token_owner_record_data_for_proposal_owner, vote_record::VoteKind,
 };
 
 /// Processes FinalizeVote instruction
@@ -52,11 +52,14 @@ pub fn process_finalize_vote(program_id: &Pubkey, accounts: &[AccountInfo]) -> P
         account_info_iter, // *6
         realm_info.key,
         &realm_data,
-        None,
+        &VoteKind::Electorate,
     )?;
 
-    let vote_threshold =
-        governance_data.resolve_vote_threshold(&realm_data, governing_token_mint_info.key, None)?;
+    let vote_threshold = governance_data.resolve_vote_threshold(
+        &realm_data,
+        governing_token_mint_info.key,
+        &VoteKind::Electorate,
+    )?;
 
     proposal_data.finalize_vote(
         max_voter_weight,

--- a/governance/program/src/processor/process_relinquish_vote.rs
+++ b/governance/program/src/processor/process_relinquish_vote.rs
@@ -14,7 +14,7 @@ use crate::{
     state::{
         enums::ProposalState,
         governance::get_governance_data,
-        proposal::get_proposal_data_for_governance_and_governing_mint,
+        proposal::get_proposal_data_for_governance_and_governing_token_mint,
         token_owner_record::get_token_owner_record_data_for_realm_and_governing_mint,
         vote_record::{get_vote_record_data_for_proposal_and_token_owner, Vote},
     },
@@ -33,7 +33,7 @@ pub fn process_relinquish_vote(program_id: &Pubkey, accounts: &[AccountInfo]) ->
 
     let governance_data = get_governance_data(program_id, governance_info)?;
 
-    let mut proposal_data = get_proposal_data_for_governance_and_governing_mint(
+    let mut proposal_data = get_proposal_data_for_governance_and_governing_token_mint(
         program_id,
         proposal_info,
         governance_info.key,

--- a/governance/program/src/processor/process_relinquish_vote.rs
+++ b/governance/program/src/processor/process_relinquish_vote.rs
@@ -13,10 +13,11 @@ use crate::{
     error::GovernanceError,
     state::{
         enums::ProposalState,
-        governance::get_governance_data,
-        proposal::get_proposal_data_for_governance_and_governing_mint,
+        governance::get_governance_data_for_realm,
+        proposal::get_proposal_data_for_governance,
+        realm::get_realm_data_for_governing_token_mint,
         token_owner_record::get_token_owner_record_data_for_realm_and_governing_mint,
-        vote_record::{get_vote_record_data_for_proposal_and_token_owner, Vote},
+        vote_record::{get_vote_record_data_for_proposal_and_token_owner_record, Vote},
     },
 };
 
@@ -24,34 +25,40 @@ use crate::{
 pub fn process_relinquish_vote(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
 
-    let governance_info = next_account_info(account_info_iter)?; // 0
-    let proposal_info = next_account_info(account_info_iter)?; // 1
-    let token_owner_record_info = next_account_info(account_info_iter)?; // 2
+    let realm_info = next_account_info(account_info_iter)?; // 0
+    let governance_info = next_account_info(account_info_iter)?; // 1
+    let proposal_info = next_account_info(account_info_iter)?; // 2
+    let token_owner_record_info = next_account_info(account_info_iter)?; // 3
 
-    let vote_record_info = next_account_info(account_info_iter)?; // 3
-    let governing_token_mint_info = next_account_info(account_info_iter)?; // 4
+    let vote_record_info = next_account_info(account_info_iter)?; // 4
+    let voting_token_mint_info = next_account_info(account_info_iter)?; // 5
 
-    let governance_data = get_governance_data(program_id, governance_info)?;
-
-    let mut proposal_data = get_proposal_data_for_governance_and_governing_mint(
+    let realm_data = get_realm_data_for_governing_token_mint(
         program_id,
-        proposal_info,
-        governance_info.key,
-        governing_token_mint_info.key,
+        realm_info,
+        voting_token_mint_info.key,
     )?;
+
+    let governance_data =
+        get_governance_data_for_realm(program_id, governance_info, realm_info.key)?;
+
+    let mut proposal_data =
+        get_proposal_data_for_governance(program_id, proposal_info, governance_info.key)?;
 
     let mut token_owner_record_data = get_token_owner_record_data_for_realm_and_governing_mint(
         program_id,
         token_owner_record_info,
         &governance_data.realm,
-        governing_token_mint_info.key,
+        voting_token_mint_info.key,
     )?;
 
-    let mut vote_record_data = get_vote_record_data_for_proposal_and_token_owner(
+    let mut vote_record_data = get_vote_record_data_for_proposal_and_token_owner_record(
         program_id,
         vote_record_info,
+        &realm_data,
         proposal_info.key,
-        &token_owner_record_data.governing_token_owner,
+        &proposal_data,
+        &token_owner_record_data,
     )?;
     vote_record_data.assert_can_relinquish_vote()?;
 
@@ -89,7 +96,13 @@ pub fn process_relinquish_vote(program_id: &Pubkey, accounts: &[AccountInfo]) ->
                         .unwrap(),
                 )
             }
-            Vote::Abstain | Vote::Veto => {
+            Vote::Veto => {
+                proposal_data.veto_vote_weight = proposal_data
+                    .veto_vote_weight
+                    .checked_sub(vote_record_data.voter_weight)
+                    .unwrap();
+            }
+            Vote::Abstain => {
                 return Err(GovernanceError::NotSupportedVoteType.into());
             }
         }

--- a/governance/program/src/processor/process_relinquish_vote.rs
+++ b/governance/program/src/processor/process_relinquish_vote.rs
@@ -14,7 +14,7 @@ use crate::{
     state::{
         enums::ProposalState,
         governance::get_governance_data,
-        proposal::get_proposal_data_for_governance_and_governing_token_mint,
+        proposal::get_proposal_data_for_governance_and_governing_mint,
         token_owner_record::get_token_owner_record_data_for_realm_and_governing_mint,
         vote_record::{get_vote_record_data_for_proposal_and_token_owner, Vote},
     },
@@ -33,7 +33,7 @@ pub fn process_relinquish_vote(program_id: &Pubkey, accounts: &[AccountInfo]) ->
 
     let governance_data = get_governance_data(program_id, governance_info)?;
 
-    let mut proposal_data = get_proposal_data_for_governance_and_governing_token_mint(
+    let mut proposal_data = get_proposal_data_for_governance_and_governing_mint(
         program_id,
         proposal_info,
         governance_info.key,

--- a/governance/program/src/processor/process_relinquish_vote.rs
+++ b/governance/program/src/processor/process_relinquish_vote.rs
@@ -31,12 +31,12 @@ pub fn process_relinquish_vote(program_id: &Pubkey, accounts: &[AccountInfo]) ->
     let token_owner_record_info = next_account_info(account_info_iter)?; // 3
 
     let vote_record_info = next_account_info(account_info_iter)?; // 4
-    let voting_token_mint_info = next_account_info(account_info_iter)?; // 5
+    let vote_governing_token_mint_info = next_account_info(account_info_iter)?; // 5
 
     let realm_data = get_realm_data_for_governing_token_mint(
         program_id,
         realm_info,
-        voting_token_mint_info.key,
+        vote_governing_token_mint_info.key,
     )?;
 
     let governance_data =
@@ -49,7 +49,7 @@ pub fn process_relinquish_vote(program_id: &Pubkey, accounts: &[AccountInfo]) ->
         program_id,
         token_owner_record_info,
         &governance_data.realm,
-        voting_token_mint_info.key,
+        vote_governing_token_mint_info.key,
     )?;
 
     let mut vote_record_data = get_vote_record_data_for_proposal_and_token_owner_record(

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -3,7 +3,6 @@
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 
 /// Defines all Governance accounts types
-#[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum GovernanceAccountType {
     /// Default uninitialized account state
@@ -97,7 +96,6 @@ impl Default for GovernanceAccountType {
 }
 
 /// What state a Proposal is in
-#[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum ProposalState {
     /// Draft - Proposal enters Draft state when it's created
@@ -140,7 +138,6 @@ impl Default for ProposalState {
 /// The type of the vote threshold used to resolve a vote on a Proposal
 ///
 /// Note: In the current version only YesVotePercentage and Disabled thresholds are supported
-#[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum VoteThreshold {
     /// Voting threshold of Yes votes in % required to tip the vote (Approval Quorum)
@@ -173,7 +170,6 @@ pub enum VoteThreshold {
 /// The type of vote tipping to use on a Proposal.
 ///
 /// Vote tipping means that under some conditions voting will complete early.
-#[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum VoteTipping {
     /// Tip when there is no way for another option to win and the vote threshold
@@ -193,7 +189,6 @@ pub enum VoteTipping {
 }
 
 /// The status of instruction execution
-#[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum TransactionExecutionStatus {
     /// Transaction was not executed yet
@@ -207,7 +202,6 @@ pub enum TransactionExecutionStatus {
 }
 
 /// Transaction execution flags defining how instructions are executed for a Proposal
-#[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum InstructionExecutionFlags {
     /// No execution flags are specified
@@ -227,7 +221,6 @@ pub enum InstructionExecutionFlags {
 
 /// The source of max vote weight used for voting
 /// Values below 100% mint supply can be used when the governing token is fully minted but not distributed yet
-#[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum MintMaxVoteWeightSource {
     /// Fraction (10^10 precision) of the governing mint supply is used as max vote weight

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -167,6 +167,22 @@ pub enum VoteThreshold {
     // Any
 }
 
+/// Options for Veto vote
+#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+pub enum VetoOptions {
+    /// Only Council members can veto Community proposals
+    CouncilOnly,
+
+    /// Veto is not allowed by either voting population
+    Disabled,
+
+    /// Only Community can veto Council proposals
+    CommunityOnly,
+
+    /// Both Community and Council members can veto proposals
+    Any,
+}
+
 /// The type of vote tipping to use on a Proposal.
 ///
 /// Vote tipping means that under some conditions voting will complete early.

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -170,22 +170,6 @@ pub enum VoteThreshold {
     // Any
 }
 
-/// Options for Veto vote
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
-pub enum VetoOptions {
-    /// Only Council members can veto Community proposals
-    CouncilOnly,
-
-    /// Veto is not allowed by either voting population
-    Disabled,
-
-    /// Only Community can veto Council proposals
-    CommunityOnly,
-
-    /// Both Community and Council members can veto proposals
-    Any,
-}
-
 /// The type of vote tipping to use on a Proposal.
 ///
 /// Vote tipping means that under some conditions voting will complete early.

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -127,6 +127,9 @@ pub enum ProposalState {
     /// Same as Executing but indicates some instructions failed to execute
     /// Proposal can't be transitioned from ExecutingWithErrors to Completed state
     ExecutingWithErrors,
+
+    /// The Proposal was vetoed
+    Vetoed,
 }
 
 impl Default for ProposalState {

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -19,7 +19,7 @@ use spl_governance_tools::{
     error::GovernanceToolsError,
 };
 
-use super::enums::VetoOptions;
+use super::{enums::VetoOptions, vote_record::Vote};
 
 /// Governance config
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
@@ -208,7 +208,7 @@ impl GovernanceV2 {
         governing_token_mint: &Pubkey,
     ) -> Result<(), ProgramError> {
         // resolve_vote_threshold() asserts the vote threshold exists for the given governing_token_mint and is not disabled
-        let _ = self.resolve_vote_threshold(realm_data, governing_token_mint)?;
+        let _ = self.resolve_vote_threshold(realm_data, governing_token_mint, None)?;
 
         Ok(())
     }
@@ -218,7 +218,10 @@ impl GovernanceV2 {
         &self,
         realm_data: &RealmV2,
         governing_token_mint: &Pubkey,
+        _vote: Option<&Vote>,
     ) -> Result<VoteThreshold, ProgramError> {
+        //TODO: resolve vote threshold for Veto
+
         let vote_threshold = if realm_data.community_mint == *governing_token_mint {
             &self.config.community_vote_threshold
         } else if realm_data.config.council_mint == Some(*governing_token_mint) {

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -489,7 +489,7 @@ mod test {
 
         // Legacy GovernanceV2 with
         // 1) config.community_vote_threshold = YesVotePercentage(10)
-        // 2) config.proposal_cool_off_tim = 0
+        // 2) config.proposal_cool_off_time = 0
         let mut account_data = [
             18, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -605,7 +605,7 @@ mod test {
     }
 
     #[test]
-    fn test_assert_config_invalid_with_council_zero_yes_vet_vote_threshold() {
+    fn test_assert_config_invalid_with_council_zero_yes_veto_vote_threshold() {
         // Arrange
         let governance_config = GovernanceConfig {
             community_vote_threshold: VoteThreshold::YesVotePercentage(1),

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -206,11 +206,11 @@ impl GovernanceV2 {
     pub fn assert_governing_token_mint_can_vote(
         &self,
         realm_data: &RealmV2,
-        governing_token_mint: &Pubkey,
+        vote_governing_token_mint: &Pubkey,
         vote_kind: &VoteKind,
     ) -> Result<(), ProgramError> {
         // resolve_vote_threshold() asserts the vote threshold exists for the given governing_token_mint and is not disabled
-        let _ = self.resolve_vote_threshold(realm_data, governing_token_mint, vote_kind)?;
+        let _ = self.resolve_vote_threshold(realm_data, vote_governing_token_mint, vote_kind)?;
 
         Ok(())
     }
@@ -219,10 +219,10 @@ impl GovernanceV2 {
     pub fn resolve_vote_threshold(
         &self,
         realm_data: &RealmV2,
-        governing_token_mint: &Pubkey,
+        vote_governing_token_mint: &Pubkey,
         vote_kind: &VoteKind,
     ) -> Result<VoteThreshold, ProgramError> {
-        let vote_threshold = if realm_data.community_mint == *governing_token_mint {
+        let vote_threshold = if realm_data.community_mint == *vote_governing_token_mint {
             match vote_kind {
                 VoteKind::Electorate => &self.config.community_vote_threshold,
                 VoteKind::Veto => {
@@ -230,7 +230,7 @@ impl GovernanceV2 {
                     return Err(GovernanceError::GoverningTokenMintNotAllowedToVote.into());
                 }
             }
-        } else if realm_data.config.council_mint == Some(*governing_token_mint) {
+        } else if realm_data.config.council_mint == Some(*vote_governing_token_mint) {
             match vote_kind {
                 VoteKind::Electorate => &self.config.council_vote_threshold,
                 VoteKind::Veto => &self.config.council_veto_vote_threshold,

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -45,6 +45,7 @@ pub struct GovernanceConfig {
     pub council_vote_threshold: VoteThreshold,
 
     /// Options for Proposal veto vote
+    /// TODO: Replace with council_veto_vote_threshold
     pub veto_options: VetoOptions,
 
     /// Reserved space for future versions

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -4,9 +4,10 @@ use borsh::maybestd::io::Write;
 use crate::{
     error::GovernanceError,
     state::{
-        enums::{GovernanceAccountType, VoteThreshold, VoteTipping},
+        enums::{GovernanceAccountType, VetoOptions, VoteThreshold, VoteTipping},
         legacy::{is_governance_v1_account_type, GovernanceV1},
         realm::{assert_is_valid_realm, RealmV2},
+        vote_record::Vote,
     },
 };
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
@@ -18,8 +19,6 @@ use spl_governance_tools::{
     account::{assert_is_valid_account_of_types, get_account_data, AccountMaxSize},
     error::GovernanceToolsError,
 };
-
-use super::{enums::VetoOptions, vote_record::Vote};
 
 /// Governance config
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -20,7 +20,6 @@ use spl_governance_tools::{
 };
 
 /// Governance config
-#[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct GovernanceConfig {
     /// The type of the vote threshold used for community vote
@@ -51,7 +50,6 @@ pub struct GovernanceConfig {
 }
 
 /// Governance Account
-#[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct GovernanceV2 {
     /// Account type. It can be Uninitialized, Governance, ProgramGovernance, TokenGovernance or MintGovernance

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -19,6 +19,8 @@ use spl_governance_tools::{
     error::GovernanceToolsError,
 };
 
+use super::enums::VetoOptions;
+
 /// Governance config
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct GovernanceConfig {
@@ -42,8 +44,11 @@ pub struct GovernanceConfig {
     /// Note: In the current version only YesVotePercentage and Disabled thresholds are supported
     pub council_vote_threshold: VoteThreshold,
 
+    /// Options for Proposal veto vote
+    pub veto_options: VetoOptions,
+
     /// Reserved space for future versions
-    pub reserved: [u8; 2],
+    pub reserved: [u8; 1],
 
     /// Minimum council weight a governance token owner must possess to be able to create a proposal
     pub min_council_weight_to_create_proposal: u64,
@@ -437,7 +442,7 @@ pub fn assert_is_valid_governance_config(
         return Err(GovernanceError::AtLeastOneVoteThresholdRequired.into());
     }
 
-    if governance_config.reserved != [0, 0] {
+    if governance_config.reserved != [0] {
         return Err(GovernanceError::ReservedBufferMustBeEmpty.into());
     }
 
@@ -524,7 +529,8 @@ mod test {
             max_voting_time: 1,
             vote_tipping: VoteTipping::Strict,
             council_vote_threshold: VoteThreshold::YesVotePercentage(0),
-            reserved: [0; 2],
+            veto_options: VetoOptions::CouncilOnly,
+            reserved: [0; 1],
             min_council_weight_to_create_proposal: 1,
         };
 
@@ -547,7 +553,8 @@ mod test {
             max_voting_time: 1,
             vote_tipping: VoteTipping::Strict,
             council_vote_threshold: VoteThreshold::YesVotePercentage(1),
-            reserved: [0; 2],
+            veto_options: VetoOptions::CouncilOnly,
+            reserved: [0; 1],
             min_council_weight_to_create_proposal: 1,
         };
 
@@ -570,7 +577,8 @@ mod test {
             max_voting_time: 1,
             vote_tipping: VoteTipping::Strict,
             council_vote_threshold: VoteThreshold::Disabled,
-            reserved: [0; 2],
+            veto_options: VetoOptions::CouncilOnly,
+            reserved: [0; 1],
             min_council_weight_to_create_proposal: 1,
         };
 
@@ -593,7 +601,8 @@ mod test {
             max_voting_time: 1,
             vote_tipping: VoteTipping::Strict,
             council_vote_threshold: VoteThreshold::Disabled,
-            reserved: [0, 1],
+            veto_options: VetoOptions::CouncilOnly,
+            reserved: [1],
             min_council_weight_to_create_proposal: 1,
         };
 

--- a/governance/program/src/state/legacy.rs
+++ b/governance/program/src/state/legacy.rs
@@ -53,7 +53,6 @@ impl IsInitialized for RealmV1 {
 
 /// Governance Token Owner Record
 /// Account PDA seeds: ['governance', realm, token_mint, token_owner ]
-#[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct TokenOwnerRecordV1 {
     /// Governance account type
@@ -102,7 +101,6 @@ impl IsInitialized for TokenOwnerRecordV1 {
 }
 
 /// Governance Account
-#[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct GovernanceV1 {
     /// Account type. It can be Uninitialized, Governance, ProgramGovernance, TokenGovernance or MintGovernance
@@ -173,7 +171,6 @@ impl IsInitialized for GovernanceV1 {
 }
 
 /// Governance Proposal
-#[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct ProposalV1 {
     /// Governance account type
@@ -263,7 +260,6 @@ impl IsInitialized for ProposalV1 {
 }
 
 /// Account PDA seeds: ['governance', proposal, signatory]
-#[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct SignatoryRecordV1 {
     /// Governance account type

--- a/governance/program/src/state/program_metadata.rs
+++ b/governance/program/src/state/program_metadata.rs
@@ -10,7 +10,6 @@ use spl_governance_tools::account::{get_account_data, AccountMaxSize};
 use crate::state::enums::GovernanceAccountType;
 
 /// Program metadata account. It stores information about the particular SPL-Governance program instance
-#[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct ProgramMetadata {
     /// Governance account type

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -764,9 +764,10 @@ impl ProposalV2 {
                     return Err(GovernanceError::InvalidVote.into());
                 }
             }
-            Vote::Abstain | Vote::Veto => {
+            Vote::Abstain => {
                 return Err(GovernanceError::NotSupportedVoteType.into());
             }
+            Vote::Veto => {}
         }
 
         Ok(())
@@ -1024,7 +1025,7 @@ mod test {
     use solana_program::clock::Epoch;
 
     use crate::state::{
-        enums::{MintMaxVoteWeightSource, VetoOptions, VoteThreshold},
+        enums::{MintMaxVoteWeightSource, VoteThreshold},
         legacy::ProposalV1,
         realm::RealmConfig,
         vote_record::VoteChoice,
@@ -1143,8 +1144,7 @@ mod test {
             community_vote_threshold: VoteThreshold::YesVotePercentage(60),
             vote_tipping: VoteTipping::Strict,
             council_vote_threshold: VoteThreshold::YesVotePercentage(60),
-            veto_options: VetoOptions::CouncilOnly,
-            reserved: [0; 1],
+            council_veto_vote_threshold: VoteThreshold::YesVotePercentage(50),
         }
     }
 

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -475,7 +475,7 @@ impl ProposalV2 {
         &mut self,
         program_id: &Pubkey,
         realm_config_info: &AccountInfo,
-        governing_token_mint_info: &AccountInfo,
+        vote_governing_token_mint_info: &AccountInfo,
         account_info_iter: &mut Iter<AccountInfo>,
         realm: &Pubkey,
         realm_data: &RealmV2,
@@ -483,7 +483,7 @@ impl ProposalV2 {
     ) -> Result<u64, ProgramError> {
         // if the realm uses addin for max community voter weight then use the externally provided max weight
         if realm_data.config.use_max_community_voter_weight_addin
-            && realm_data.community_mint == *governing_token_mint_info.key
+            && realm_data.community_mint == *vote_governing_token_mint_info.key
         {
             let realm_config_data =
                 get_realm_config_data_for_realm(program_id, realm_config_info, realm)?;
@@ -495,7 +495,7 @@ impl ProposalV2 {
                     &realm_config_data.max_community_voter_weight_addin.unwrap(),
                     max_voter_weight_record_info,
                     realm,
-                    governing_token_mint_info.key,
+                    vote_governing_token_mint_info.key,
                 )?;
 
             assert_is_valid_max_voter_weight(&max_voter_weight_record_data)?;
@@ -508,11 +508,12 @@ impl ProposalV2 {
             ));
         }
 
-        let governing_token_mint_supply = get_spl_token_mint_supply(governing_token_mint_info)?;
+        let governing_token_mint_supply =
+            get_spl_token_mint_supply(vote_governing_token_mint_info)?;
 
         let max_voter_weight = self.get_max_voter_weight_from_mint_supply(
             realm_data,
-            governing_token_mint_info.key,
+            vote_governing_token_mint_info.key,
             governing_token_mint_supply,
             vote_kind,
         )?;

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -486,7 +486,7 @@ impl ProposalV2 {
 
             let max_voter_weight_record_info = next_account_info(account_info_iter)?;
 
-            let max_voter_weight_data =
+            let max_voter_weight_record_data =
                 get_max_voter_weight_record_data_for_realm_and_governing_token_mint(
                     &realm_config_data.max_community_voter_weight_addin.unwrap(),
                     max_voter_weight_record_info,
@@ -494,11 +494,13 @@ impl ProposalV2 {
                     governing_token_mint_info.key,
                 )?;
 
-            assert_is_valid_max_voter_weight(&max_voter_weight_data)?;
+            assert_is_valid_max_voter_weight(&max_voter_weight_record_data)?;
 
             // When the max voter weight addin is used it's possible it can be inaccurate and we can have more votes then the max provided by the addin
             // and we have to adjust it to whatever result is higher
-            return Ok(self.coerce_max_voter_weight(max_voter_weight_data.max_voter_weight, vote));
+            return Ok(
+                self.coerce_max_voter_weight(max_voter_weight_record_data.max_voter_weight, vote)
+            );
         }
 
         let governing_token_mint_supply = get_spl_token_mint_supply(governing_token_mint_info)?;
@@ -1566,7 +1568,7 @@ mod test {
             let current_timestamp = 15_i64;
 
             let realm = create_test_realm();
-            let governing_token_mint = proposal.governing_token_mint.clone();
+            let governing_token_mint = proposal.governing_token_mint;
             let vote = Vote::Approve(vec![]);
 
             let max_voter_weight = proposal.get_max_voter_weight_from_mint_supply(&realm,&governing_token_mint, test_case.governing_token_supply,Some(&vote)).unwrap();
@@ -1614,7 +1616,7 @@ mod test {
             let current_timestamp = 16_i64;
 
             let realm = create_test_realm();
-            let governing_token_mint = proposal.governing_token_mint.clone();
+            let governing_token_mint = proposal.governing_token_mint;
             let vote = Vote::Approve(vec![]);
 
             let max_voter_weight = proposal.get_max_voter_weight_from_mint_supply(&realm,&governing_token_mint,test_case.governing_token_supply,Some(&vote)).unwrap();
@@ -1678,7 +1680,7 @@ mod test {
             let current_timestamp = 15_i64;
 
             let realm = create_test_realm();
-            let governing_token_mint = proposal.governing_token_mint.clone();
+            let governing_token_mint = proposal.governing_token_mint;
             let vote = Vote::Approve(vec![]);
 
             let max_voter_weight = proposal.get_max_voter_weight_from_mint_supply(&realm,&governing_token_mint,governing_token_supply,Some(&vote)).unwrap();
@@ -1727,7 +1729,7 @@ mod test {
             let current_timestamp = 16_i64;
 
             let realm = create_test_realm();
-            let governing_token_mint = proposal.governing_token_mint.clone();
+            let governing_token_mint = proposal.governing_token_mint;
             let vote = Vote::Approve(vec![]);
 
             let max_voter_weight = proposal.get_max_voter_weight_from_mint_supply(&realm,&governing_token_mint,governing_token_supply,Some(&vote)).unwrap();
@@ -1766,7 +1768,7 @@ mod test {
         let community_token_supply = 200;
 
         let mut realm = create_test_realm();
-        let governing_token_mint = proposal.governing_token_mint.clone();
+        let governing_token_mint = proposal.governing_token_mint;
         let vote = Vote::Approve(vec![]);
 
         // reduce max vote weight to 100
@@ -1820,7 +1822,7 @@ mod test {
         let community_token_supply = 200;
 
         let mut realm = create_test_realm();
-        let governing_token_mint = proposal.governing_token_mint.clone();
+        let governing_token_mint = proposal.governing_token_mint;
         let vote = Vote::Approve(vec![]);
 
         // reduce max vote weight to 100
@@ -1877,7 +1879,7 @@ mod test {
         let community_token_supply = 200;
 
         let mut realm = create_test_realm();
-        let governing_token_mint = proposal.governing_token_mint.clone();
+        let governing_token_mint = proposal.governing_token_mint;
         let vote = Vote::Approve(vec![]);
 
         realm.config.community_mint_max_vote_weight_source =
@@ -1928,7 +1930,7 @@ mod test {
         let community_token_supply = 200;
 
         let mut realm = create_test_realm();
-        let governing_token_mint = proposal.governing_token_mint.clone();
+        let governing_token_mint = proposal.governing_token_mint;
         let vote = Vote::Approve(vec![]);
 
         // reduce max vote weight to 100
@@ -1979,7 +1981,7 @@ mod test {
         let community_token_supply = 200;
 
         let mut realm = create_test_realm();
-        let governing_token_mint = proposal.governing_token_mint.clone();
+        let governing_token_mint = proposal.governing_token_mint;
         let vote = Vote::Approve(vec![]);
 
         // reduce max vote weight to 100
@@ -2028,7 +2030,7 @@ mod test {
             proposal.voting_at.unwrap() + governance_config.max_voting_time as i64;
 
         let realm = create_test_realm();
-        let governing_token_mint = proposal.governing_token_mint.clone();
+        let governing_token_mint = proposal.governing_token_mint;
         let vote = Vote::Approve(vec![]);
 
         let max_voter_weight = proposal
@@ -2063,7 +2065,7 @@ mod test {
             proposal.voting_at.unwrap() + governance_config.max_voting_time as i64 + 1;
 
         let realm = create_test_realm();
-        let governing_token_mint = proposal.governing_token_mint.clone();
+        let governing_token_mint = proposal.governing_token_mint;
         let vote = Vote::Approve(vec![]);
 
         let max_voter_weight = proposal

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -140,8 +140,7 @@ pub struct ProposalV2 {
     pub deny_vote_weight: Option<u64>,
 
     /// The total weight of Veto votes
-    /// Note: Veto is not supported in the current version
-    pub veto_vote_weight: Option<u64>,
+    pub veto_vote_weight: u64,
 
     /// The total weight of  votes
     /// Note: Abstain is not supported in the current version
@@ -205,7 +204,7 @@ pub struct ProposalV2 {
 impl AccountMaxSize for ProposalV2 {
     fn get_max_size(&self) -> Option<usize> {
         let options_size: usize = self.options.iter().map(|o| o.label.len() + 19).sum();
-        Some(self.name.len() + self.description_link.len() + options_size + 295)
+        Some(self.name.len() + self.description_link.len() + options_size + 294)
     }
 }
 
@@ -764,7 +763,7 @@ impl ProposalV2 {
                 panic!("ProposalV1 doesn't support Abstain vote")
             }
 
-            if self.veto_vote_weight.is_some() {
+            if self.veto_vote_weight > 0 {
                 panic!("ProposalV1 doesn't support Veto vote")
             }
 
@@ -884,7 +883,7 @@ pub fn get_proposal_data(
                 transactions_next_index: proposal_data_v1.instructions_next_index,
             }],
             deny_vote_weight: Some(proposal_data_v1.no_votes_count),
-            veto_vote_weight: None,
+            veto_vote_weight: 0,
             abstain_vote_weight: None,
             start_voting_at: None,
             draft_at: proposal_data_v1.draft_at,
@@ -1047,7 +1046,7 @@ mod test {
             }],
             deny_vote_weight: Some(0),
             abstain_vote_weight: Some(0),
-            veto_vote_weight: Some(0),
+            veto_vote_weight: 0,
 
             execution_flags: InstructionExecutionFlags::Ordered,
 

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -508,13 +508,13 @@ impl ProposalV2 {
             ));
         }
 
-        let governing_token_mint_supply =
+        let vote_governing_token_mint_supply =
             get_spl_token_mint_supply(vote_governing_token_mint_info)?;
 
         let max_voter_weight = self.get_max_voter_weight_from_mint_supply(
             realm_data,
             vote_governing_token_mint_info.key,
-            governing_token_mint_supply,
+            vote_governing_token_mint_supply,
             vote_kind,
         )?;
 
@@ -587,9 +587,9 @@ impl ProposalV2 {
         // Note: Tipping for multiple options (single choice and multiple choices) should be possible but it requires a great deal of considerations
         //       and I decided to fight it another day
         if self.vote_type != VoteType::SingleChoice
-                    // Tipping should not be allowed for opinion only proposals (surveys without rejection) to allow everybody's voice to be heard
-                    || self.deny_vote_weight.is_none()
-                    || self.options.len() != 1
+            // Tipping should not be allowed for opinion only proposals (surveys without rejection) to allow everybody's voice to be heard
+            || self.deny_vote_weight.is_none()
+            || self.options.len() != 1
         {
             return None;
         };

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -1004,7 +1004,7 @@ mod test {
     use solana_program::clock::Epoch;
 
     use crate::state::{
-        enums::{MintMaxVoteWeightSource, VoteThreshold},
+        enums::{MintMaxVoteWeightSource, VetoOptions, VoteThreshold},
         legacy::ProposalV1,
         realm::RealmConfig,
         vote_record::VoteChoice,
@@ -1122,7 +1122,8 @@ mod test {
             community_vote_threshold: VoteThreshold::YesVotePercentage(60),
             vote_tipping: VoteTipping::Strict,
             council_vote_threshold: VoteThreshold::YesVotePercentage(60),
-            reserved: [0; 2],
+            veto_options: VetoOptions::CouncilOnly,
+            reserved: [0; 1],
         }
     }
 

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -532,7 +532,7 @@ impl ProposalV2 {
             self.voting_completed_at = Some(current_unix_timestamp);
 
             // Capture vote params to correctly display historical results
-            // Note: For Veto vote the captured params are for the Veto config
+            // Note: For Veto vote the captured params are from the Veto config
             self.max_vote_weight = Some(max_voter_weight);
             self.vote_threshold = Some(vote_threshold.clone());
 

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -553,7 +553,6 @@ impl ProposalV2 {
 
     /// Checks if vote can be tipped and automatically transitioned to Succeeded, Defeated or Vetoed state
     /// If yes then Some(ProposalState) is returned and None otherwise
-    #[allow(clippy::float_cmp)]
     pub fn try_get_tipped_vote_state(
         &mut self,
         max_voter_weight: u64,
@@ -576,7 +575,6 @@ impl ProposalV2 {
 
     /// Checks if Electorate vote can be tipped and automatically transitioned to Succeeded or Defeated state
     /// If yes then Some(ProposalState) is returned and None otherwise
-    #[allow(clippy::float_cmp)]
     fn try_get_tipped_electorate_vote_state(
         &mut self,
         max_voter_weight: u64,
@@ -646,7 +644,6 @@ impl ProposalV2 {
 
     /// Checks if vote can be tipped and transitioned to Vetoed state
     /// If yes then Some(ProposalState::Vetoed) is returned and None otherwise
-    #[allow(clippy::float_cmp)]
     fn try_get_tipped_veto_vote_state(
         &mut self,
         min_vote_threshold_weight: u64,

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -141,6 +141,7 @@ pub struct ProposalV2 {
     pub deny_vote_weight: Option<u64>,
 
     /// Reserved space for future versions
+    /// This field is a leftover from unused veto_vote_weight: Option<u64>
     pub reserved1: u8,
 
     /// The total weight of  votes

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -139,8 +139,8 @@ pub struct ProposalV2 {
     /// Without the deny option a proposal is only non executable survey
     pub deny_vote_weight: Option<u64>,
 
-    /// The total weight of Veto votes
-    pub veto_vote_weight: u64,
+    /// Reserved space for future versions
+    pub reserved1: u8,
 
     /// The total weight of  votes
     /// Note: Abstain is not supported in the current version
@@ -199,12 +199,15 @@ pub struct ProposalV2 {
 
     /// Link to proposal's description
     pub description_link: String,
+
+    /// The total weight of Veto votes
+    pub veto_vote_weight: u64,
 }
 
 impl AccountMaxSize for ProposalV2 {
     fn get_max_size(&self) -> Option<usize> {
         let options_size: usize = self.options.iter().map(|o| o.label.len() + 19).sum();
-        Some(self.name.len() + self.description_link.len() + options_size + 294)
+        Some(self.name.len() + self.description_link.len() + options_size + 295)
     }
 }
 
@@ -917,14 +920,15 @@ pub fn get_proposal_data(
             name: proposal_data_v1.name,
             description_link: proposal_data_v1.description_link,
             reserved: [0; 64],
+            reserved1: 0,
         });
     }
 
     get_account_data::<ProposalV2>(program_id, proposal_info)
 }
 
-/// Deserializes Proposal and validates it belongs to the given Governance and Governing Mint
-pub fn get_proposal_data_for_governance_and_governing_mint(
+/// Deserializes Proposal and validates it belongs to the given Governance and governing_token_mint
+pub fn get_proposal_data_for_governance_and_governing_token_mint(
     program_id: &Pubkey,
     proposal_info: &AccountInfo,
     governance: &Pubkey,
@@ -1071,6 +1075,7 @@ mod test {
             vote_threshold: Some(VoteThreshold::YesVotePercentage(100)),
 
             reserved: [0; 64],
+            reserved1: 0,
         }
     }
 

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -627,9 +627,9 @@ impl ProposalV2 {
                 // It's irrespectively of vote_tipping config because the outcome of the Proposal can't change any longer after being vetoed
                 if self.veto_vote_weight >= min_vote_threshold_weight {
                     // Note: Since we don't tip multi option votes all options vote_result would remain as None
-                    return Some(ProposalState::Vetoed);
+                    Some(ProposalState::Vetoed)
                 } else {
-                    return None;
+                    None
                 }
             }
         }

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -466,6 +466,7 @@ impl ProposalV2 {
     }
 
     /// Resolves max voter weight
+    #[allow(clippy::too_many_arguments)]
     pub fn resolve_max_voter_weight(
         &mut self,
         program_id: &Pubkey,

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -928,7 +928,7 @@ pub fn get_proposal_data(
 }
 
 /// Deserializes Proposal and validates it belongs to the given Governance and governing_token_mint
-pub fn get_proposal_data_for_governance_and_governing_token_mint(
+pub fn get_proposal_data_for_governance_and_governing_mint(
     program_id: &Pubkey,
     proposal_info: &AccountInfo,
     governance: &Pubkey,

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -517,7 +517,7 @@ impl ProposalV2 {
         vote: &Vote,
     ) -> Result<bool, ProgramError> {
         if let Some(tipped_state) =
-            self.try_get_tipped_vote_state(max_voter_weight, config, vote_threshold, &vote)
+            self.try_get_tipped_vote_state(max_voter_weight, config, vote_threshold, vote)
         {
             self.state = tipped_state;
             self.voting_completed_at = Some(current_unix_timestamp);

--- a/governance/program/src/state/proposal_transaction.rs
+++ b/governance/program/src/state/proposal_transaction.rs
@@ -26,7 +26,6 @@ use spl_governance_tools::account::{get_account_data, AccountMaxSize};
 
 /// InstructionData wrapper. It can be removed once Borsh serialization for Instruction is supported in the SDK
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
-#[repr(C)]
 pub struct InstructionData {
     /// Pubkey of the instruction processor that executes this instruction
     pub program_id: Pubkey,
@@ -38,7 +37,6 @@ pub struct InstructionData {
 
 /// Account metadata used to define Instructions
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
-#[repr(C)]
 pub struct AccountMetaData {
     /// An account's public key
     pub pubkey: Pubkey,
@@ -85,7 +83,6 @@ impl From<&InstructionData> for Instruction {
 }
 
 /// Account for an instruction to be executed for Proposal
-#[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct ProposalTransactionV2 {
     /// Governance Account type

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -22,7 +22,7 @@ use crate::{
         enums::{GovernanceAccountType, MintMaxVoteWeightSource},
         legacy::RealmV1,
         token_owner_record::get_token_owner_record_data_for_realm,
-        vote_record::Vote,
+        vote_record::VoteKind,
     },
     PROGRAM_AUTHORITY_SEED,
 };
@@ -175,32 +175,35 @@ impl RealmV2 {
         Err(GovernanceError::InvalidGoverningTokenMint.into())
     }
 
-    /// Returns the governing token mint which is used to vote on a proposal given the provided Vote and vote_governing_token_mint
+    /// Returns the governing token mint which is used to vote on a proposal given the provided Vote kind and vote_governing_token_mint
     ///
-    /// The Veto vote is cast on a proposal configured for the opposite voting population defined using governing_token_mint
+    /// Veto vote is cast on a proposal configured for the opposite voting population defined using governing_token_mint
     /// Council can veto Community vote and Community can veto Council assuming the veto for the voting population is enabled
     ///
-    /// For all votes other than Veto the vote_governing_token_mint is the same as Proposal governing_token_mint
+    /// For all votes other than Veto (Electorate votes) the vote_governing_token_mint is the same as Proposal governing_token_mint
     pub fn get_proposal_governing_token_mint_for_vote(
         &self,
-        vote: &Vote,
         vote_governing_token_mint: &Pubkey,
+        vote_kind: &VoteKind,
     ) -> Result<Pubkey, ProgramError> {
-        if *vote != Vote::Veto {
-            return Ok(*vote_governing_token_mint);
-        }
+        match vote_kind {
+            VoteKind::Electorate => Ok(*vote_governing_token_mint),
+            VoteKind::Veto => {
+                // When Community veto Council proposal then return council_token_mint as the Proposal governing_token_mint
+                if self.community_mint == *vote_governing_token_mint {
+                    // Community Veto is not supported in the current version
+                    return Err(GovernanceError::GoverningTokenMintNotAllowedToVote.into());
+                    //return Ok(self.config.council_mint.unwrap());
+                }
 
-        // When Community veto Council proposal then return council_token_mint as the Proposal governing_token_mint
-        if self.community_mint == *vote_governing_token_mint {
-            return Ok(self.config.council_mint.unwrap());
-        }
+                // When Council veto Community proposal then return community_token_mint as the Proposal governing_token_mint
+                if self.config.council_mint == Some(*vote_governing_token_mint) {
+                    return Ok(self.community_mint);
+                }
 
-        // When Council veto Community proposal then return community_token_mint as the Proposal governing_token_mint
-        if self.config.council_mint == Some(*vote_governing_token_mint) {
-            return Ok(self.community_mint);
+                Err(GovernanceError::InvalidGoverningTokenMint.into())
+            }
         }
-
-        Err(GovernanceError::InvalidGoverningTokenMint.into())
     }
 
     /// Asserts the given governing token mint and holding accounts are valid for the realm

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -175,28 +175,28 @@ impl RealmV2 {
         Err(GovernanceError::InvalidGoverningTokenMint.into())
     }
 
-    /// Returns the governing token mint which is used to vote on a proposal given the provided Vote and voting_token_mint
+    /// Returns the governing token mint which is used to vote on a proposal given the provided Vote and vote_governing_token_mint
     ///
     /// The Veto vote is cast on a proposal configured for the opposite voting population defined using governing_token_mint
     /// Council can veto Community vote and Community can veto Council assuming the veto for the voting population is enabled
     ///
-    /// For all votes other than Veto the voting_token_mint is the same as Proposal governing_token_mint
+    /// For all votes other than Veto the vote_governing_token_mint is the same as Proposal governing_token_mint
     pub fn get_proposal_governing_token_mint_for_vote(
         &self,
         vote: &Vote,
-        voting_token_mint: &Pubkey,
+        vote_governing_token_mint: &Pubkey,
     ) -> Result<Pubkey, ProgramError> {
         if *vote != Vote::Veto {
-            return Ok(*voting_token_mint);
+            return Ok(*vote_governing_token_mint);
         }
 
         // When Community veto Council proposal then return council_token_mint as the Proposal governing_token_mint
-        if self.community_mint == *voting_token_mint {
+        if self.community_mint == *vote_governing_token_mint {
             return Ok(self.config.council_mint.unwrap());
         }
 
         // When Council veto Community proposal then return community_token_mint as the Proposal governing_token_mint
-        if self.config.council_mint == Some(*voting_token_mint) {
+        if self.config.council_mint == Some(*vote_governing_token_mint) {
             return Ok(self.community_mint);
         }
 

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -181,7 +181,7 @@ impl RealmV2 {
     /// Council for Community and Community for Council assuming the veto for the voting population is enabled
     ///
     /// For all votes other than Veto the voting_token_mint is the same as Proposal governing_token_mint
-    pub fn resolve_proposal_governing_token_mint_for_vote(
+    pub fn get_proposal_governing_token_mint_for_vote(
         &self,
         vote: &Vote,
         voting_token_mint: &Pubkey,

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -178,7 +178,7 @@ impl RealmV2 {
     /// Returns the governing token mint which is used to vote on a proposal given the provided Vote and voting_token_mint
     ///
     /// The Veto vote is cast on a proposal configured for the opposite voting population defined using governing_token_mint
-    /// Council for Community and Community for Council assuming the veto for the voting population is enabled
+    /// Council can veto Community vote and Community can veto Council assuming the veto for the voting population is enabled
     ///
     /// For all votes other than Veto the voting_token_mint is the same as Proposal governing_token_mint
     pub fn get_proposal_governing_token_mint_for_vote(

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -27,7 +27,6 @@ use crate::{
 };
 
 /// Realm Config instruction args
-#[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct RealmConfigArgs {
     /// Indicates whether council_mint should be used
@@ -66,7 +65,6 @@ pub enum SetRealmAuthorityAction {
 }
 
 /// Realm Config defining Realm parameters.
-#[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct RealmConfig {
     /// Indicates whether an external addin program should be used to provide voters weights for the community mint
@@ -90,7 +88,6 @@ pub struct RealmConfig {
 
 /// Governance Realm Account
 /// Account PDA seeds" ['governance', name]
-#[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct RealmV2 {
     /// Governance account type

--- a/governance/program/src/state/signatory_record.rs
+++ b/governance/program/src/state/signatory_record.rs
@@ -12,9 +12,7 @@ use spl_governance_tools::account::{get_account_data, AccountMaxSize};
 
 use crate::{error::GovernanceError, PROGRAM_AUTHORITY_SEED};
 
-use crate::state::enums::GovernanceAccountType;
-
-use super::legacy::SignatoryRecordV1;
+use crate::state::{enums::GovernanceAccountType, legacy::SignatoryRecordV1};
 
 /// Account PDA seeds: ['governance', proposal, signatory]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]

--- a/governance/program/src/state/signatory_record.rs
+++ b/governance/program/src/state/signatory_record.rs
@@ -17,7 +17,6 @@ use crate::state::enums::GovernanceAccountType;
 use super::legacy::SignatoryRecordV1;
 
 /// Account PDA seeds: ['governance', proposal, signatory]
-#[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct SignatoryRecordV2 {
     /// Governance account type

--- a/governance/program/src/state/token_owner_record.rs
+++ b/governance/program/src/state/token_owner_record.rs
@@ -28,7 +28,6 @@ use spl_governance_tools::account::{get_account_data, AccountMaxSize};
 
 /// Governance Token Owner Record
 /// Account PDA seeds: ['governance', realm, token_mint, token_owner ]
-#[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct TokenOwnerRecordV2 {
     /// Governance account type

--- a/governance/program/src/state/vote_record.rs
+++ b/governance/program/src/state/vote_record.rs
@@ -57,7 +57,6 @@ pub enum Vote {
     Abstain,
 
     /// Veto proposal
-    /// Note: Not supported in the current version
     Veto,
 }
 

--- a/governance/program/src/state/vote_record.rs
+++ b/governance/program/src/state/vote_record.rs
@@ -221,8 +221,8 @@ pub fn get_vote_record_data_for_proposal_and_token_owner_record(
     // For Approve, Deny and Abstain votes Proposal.governing_token_mint must equal TokenOwnerRecord.governing_token_mint
     // For Veto vote it must be the governing_token_mint of the opposite voting population
     let proposal_governing_token_mint = realm_data.get_proposal_governing_token_mint_for_vote(
-        &vote_record_data.vote,
         &token_owner_record_data.governing_token_mint,
+        &get_vote_kind(&vote_record_data.vote),
     )?;
 
     if proposal_data.governing_token_mint != proposal_governing_token_mint {

--- a/governance/program/src/state/vote_record.rs
+++ b/governance/program/src/state/vote_record.rs
@@ -63,6 +63,25 @@ pub enum Vote {
     Veto,
 }
 
+/// VoteKind defines the type of the vote being cast
+#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+pub enum VoteKind {
+    /// Electorate vote is cast by the voting population identified by governing_token_mint
+    /// Approve, Deny and Abstain votes are Electorate votes
+    Electorate,
+
+    /// Vote cast by the opposite voting population to the Electorate identified by governing_token_mint
+    Veto,
+}
+
+/// Returns the VoteKind for the given Vote
+pub fn get_vote_kind(vote: &Vote) -> VoteKind {
+    match vote {
+        Vote::Approve(_) | Vote::Deny | Vote::Abstain => VoteKind::Electorate,
+        Vote::Veto => VoteKind::Veto,
+    }
+}
+
 /// Proposal VoteRecord
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct VoteRecordV2 {

--- a/governance/program/tests/process_cancel_proposal.rs
+++ b/governance/program/tests/process_cancel_proposal.rs
@@ -97,7 +97,7 @@ async fn test_cancel_proposal_with_already_completed_error() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 

--- a/governance/program/tests/process_cast_vote.rs
+++ b/governance/program/tests/process_cast_vote.rs
@@ -155,7 +155,7 @@ async fn test_cast_vote_with_invalid_mint_error() {
     let realm_cookie = governance_test.with_realm().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let token_owner_record_cookie = governance_test
+    let mut token_owner_record_cookie = governance_test
         .with_community_token_deposit(&realm_cookie)
         .await
         .unwrap();
@@ -169,13 +169,13 @@ async fn test_cast_vote_with_invalid_mint_error() {
         .await
         .unwrap();
 
-    let mut proposal_cookie = governance_test
+    let proposal_cookie = governance_test
         .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
         .await
         .unwrap();
 
     // Try to use Council Mint with Community Proposal
-    proposal_cookie.account.governing_token_mint =
+    token_owner_record_cookie.account.governing_token_mint =
         realm_cookie.account.config.council_mint.unwrap();
 
     // Act
@@ -1242,89 +1242,4 @@ async fn test_cast_council_vote() {
         Some(governance_cookie.account.config.council_vote_threshold),
         proposal_account.vote_threshold
     );
-}
-
-#[tokio::test]
-async fn test_cast_veto_vote() {
-    // Arrange
-    let mut governance_test = GovernanceProgramTest::start_new().await;
-
-    let realm_cookie = governance_test.with_realm().await;
-    let governed_account_cookie = governance_test.with_governed_account().await;
-
-    let token_owner_record_cookie = governance_test
-        .with_community_token_deposit(&realm_cookie)
-        .await
-        .unwrap();
-
-    let mut governance_cookie = governance_test
-        .with_governance(
-            &realm_cookie,
-            &governed_account_cookie,
-            &token_owner_record_cookie,
-        )
-        .await
-        .unwrap();
-
-    let proposal_cookie = governance_test
-        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
-        .await
-        .unwrap();
-
-    let clock = governance_test.bench.get_clock().await;
-
-    // Act
-    let vote_record_cookie = governance_test
-        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
-        .await
-        .unwrap();
-
-    // Assert
-    let vote_record_account = governance_test
-        .get_vote_record_account(&vote_record_cookie.address)
-        .await;
-
-    assert_eq!(vote_record_cookie.account, vote_record_account);
-
-    let proposal_account = governance_test
-        .get_proposal_account(&proposal_cookie.address)
-        .await;
-
-    assert_eq!(
-        token_owner_record_cookie
-            .account
-            .governing_token_deposit_amount,
-        proposal_account.options[0].vote_weight
-    );
-
-    assert_eq!(proposal_account.state, ProposalState::Succeeded);
-    assert_eq!(
-        proposal_account.voting_completed_at,
-        Some(clock.unix_timestamp)
-    );
-
-    assert_eq!(Some(100), proposal_account.max_vote_weight);
-    assert_eq!(
-        Some(governance_cookie.account.config.community_vote_threshold),
-        proposal_account.vote_threshold
-    );
-
-    let token_owner_record = governance_test
-        .get_token_owner_record_account(&token_owner_record_cookie.address)
-        .await;
-
-    assert_eq!(1, token_owner_record.unrelinquished_votes_count);
-    assert_eq!(1, token_owner_record.total_votes_count);
-
-    let realm_account = governance_test
-        .get_realm_account(&realm_cookie.address)
-        .await;
-
-    assert_eq!(0, realm_account.voting_proposal_count);
-
-    let governance_account = governance_test
-        .get_governance_account(&governance_cookie.address)
-        .await;
-
-    assert_eq!(0, governance_account.voting_proposal_count);
 }

--- a/governance/program/tests/process_cast_vote.rs
+++ b/governance/program/tests/process_cast_vote.rs
@@ -42,7 +42,7 @@ async fn test_cast_vote() {
 
     // Act
     let vote_record_cookie = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -139,7 +139,7 @@ async fn test_cast_vote_with_invalid_governance_error() {
 
     // Act
     let err = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .err()
         .unwrap();
@@ -180,7 +180,7 @@ async fn test_cast_vote_with_invalid_mint_error() {
 
     // Act
     let err = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .err()
         .unwrap();
@@ -225,7 +225,7 @@ async fn test_cast_vote_with_invalid_token_owner_record_mint_error() {
 
     // Act
     let err = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .err()
         .unwrap();
@@ -275,7 +275,7 @@ async fn test_cast_vote_with_invalid_token_owner_record_from_different_realm_err
 
     // Act
     let err = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .err()
         .unwrap();
@@ -320,7 +320,7 @@ async fn test_cast_vote_with_governance_authority_must_sign_error() {
 
     // Act
     let err = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .err()
         .unwrap();
@@ -374,7 +374,7 @@ async fn test_cast_vote_with_strict_vote_tipped_to_succeeded() {
 
     // Act
     governance_test
-        .with_cast_vote(
+        .with_cast_yes_no_vote(
             &proposal_cookie,
             &token_owner_record_cookie1,
             YesNoVote::Yes,
@@ -392,7 +392,7 @@ async fn test_cast_vote_with_strict_vote_tipped_to_succeeded() {
 
     // Act
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie2, YesNoVote::No)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie2, YesNoVote::No)
         .await
         .unwrap();
 
@@ -406,7 +406,7 @@ async fn test_cast_vote_with_strict_vote_tipped_to_succeeded() {
 
     // Act
     governance_test
-        .with_cast_vote(
+        .with_cast_yes_no_vote(
             &proposal_cookie,
             &token_owner_record_cookie3,
             YesNoVote::Yes,
@@ -488,7 +488,7 @@ async fn test_cast_vote_with_strict_vote_tipped_to_defeated() {
 
     // Act
     governance_test
-        .with_cast_vote(
+        .with_cast_yes_no_vote(
             &proposal_cookie,
             &token_owner_record_cookie1,
             YesNoVote::Yes,
@@ -506,7 +506,7 @@ async fn test_cast_vote_with_strict_vote_tipped_to_defeated() {
 
     // Act
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie2, YesNoVote::No)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie2, YesNoVote::No)
         .await
         .unwrap();
 
@@ -520,7 +520,7 @@ async fn test_cast_vote_with_strict_vote_tipped_to_defeated() {
 
     // Act
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie3, YesNoVote::No)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie3, YesNoVote::No)
         .await
         .unwrap();
 
@@ -597,7 +597,7 @@ async fn test_cast_vote_with_early_vote_tipped_to_succeeded() {
         .await
         .unwrap();
     governance_test
-        .with_cast_vote(
+        .with_cast_yes_no_vote(
             &proposal_cookie,
             &token_owner_record_cookie1,
             YesNoVote::Yes,
@@ -610,7 +610,7 @@ async fn test_cast_vote_with_early_vote_tipped_to_succeeded() {
     assert_eq!(ProposalState::Voting, proposal_account.state);
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie2, YesNoVote::No)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie2, YesNoVote::No)
         .await
         .unwrap();
     let proposal_account = governance_test
@@ -619,7 +619,7 @@ async fn test_cast_vote_with_early_vote_tipped_to_succeeded() {
     assert_eq!(ProposalState::Voting, proposal_account.state);
 
     governance_test
-        .with_cast_vote(
+        .with_cast_yes_no_vote(
             &proposal_cookie,
             &token_owner_record_cookie3,
             YesNoVote::Yes,
@@ -641,7 +641,7 @@ async fn test_cast_vote_with_early_vote_tipped_to_succeeded() {
         .await
         .unwrap();
     governance_test
-        .with_cast_vote(
+        .with_cast_yes_no_vote(
             &proposal_cookie,
             &token_owner_record_cookie1,
             YesNoVote::Yes,
@@ -654,7 +654,7 @@ async fn test_cast_vote_with_early_vote_tipped_to_succeeded() {
     assert_eq!(ProposalState::Voting, proposal_account.state);
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie2, YesNoVote::No)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie2, YesNoVote::No)
         .await
         .unwrap();
     let proposal_account = governance_test
@@ -663,7 +663,7 @@ async fn test_cast_vote_with_early_vote_tipped_to_succeeded() {
     assert_eq!(ProposalState::Voting, proposal_account.state);
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie3, YesNoVote::No)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie3, YesNoVote::No)
         .await
         .unwrap();
     let proposal_account = governance_test
@@ -672,7 +672,7 @@ async fn test_cast_vote_with_early_vote_tipped_to_succeeded() {
     assert_eq!(ProposalState::Voting, proposal_account.state);
 
     governance_test
-        .with_cast_vote(
+        .with_cast_yes_no_vote(
             &proposal_cookie,
             &token_owner_record_cookie4,
             YesNoVote::Yes,
@@ -686,7 +686,7 @@ async fn test_cast_vote_with_early_vote_tipped_to_succeeded() {
 
     // Act: 300 vs 200 makes it tip
     governance_test
-        .with_cast_vote(
+        .with_cast_yes_no_vote(
             &proposal_cookie,
             &token_owner_record_cookie5,
             YesNoVote::Yes,
@@ -756,7 +756,7 @@ async fn test_cast_vote_with_early_vote_tipped_to_defeated() {
 
     // Act
     governance_test
-        .with_cast_vote(
+        .with_cast_yes_no_vote(
             &proposal_cookie,
             &token_owner_record_cookie1,
             YesNoVote::Yes,
@@ -774,7 +774,7 @@ async fn test_cast_vote_with_early_vote_tipped_to_defeated() {
 
     // Act
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie2, YesNoVote::No)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie2, YesNoVote::No)
         .await
         .unwrap();
 
@@ -788,7 +788,7 @@ async fn test_cast_vote_with_early_vote_tipped_to_defeated() {
 
     // Act
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie3, YesNoVote::No)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie3, YesNoVote::No)
         .await
         .unwrap();
 
@@ -846,7 +846,7 @@ async fn test_cast_vote_with_threshold_below_50_and_vote_not_tipped() {
 
     // Act
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -915,7 +915,7 @@ async fn test_cast_vote_with_disabled_tipping_yes_votes() {
 
     // Act
     governance_test
-        .with_cast_vote(
+        .with_cast_yes_no_vote(
             &proposal_cookie,
             &token_owner_record_cookie1,
             YesNoVote::Yes,
@@ -936,7 +936,7 @@ async fn test_cast_vote_with_disabled_tipping_yes_votes() {
         .await
         .unwrap();
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie1, YesNoVote::No)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie1, YesNoVote::No)
         .await
         .unwrap();
 
@@ -986,7 +986,7 @@ async fn test_cast_vote_with_disabled_tipping_no_votes() {
 
     // Act
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie1, YesNoVote::No)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie1, YesNoVote::No)
         .await
         .unwrap();
 
@@ -1039,7 +1039,7 @@ async fn test_cast_vote_with_voting_time_expired_error() {
     // Act
 
     let err = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
         .await
         .err()
         .unwrap();
@@ -1081,7 +1081,7 @@ async fn test_cast_vote_with_cast_twice_error() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -1089,7 +1089,7 @@ async fn test_cast_vote_with_cast_twice_error() {
 
     // Act
     let err = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .err()
         .unwrap();
@@ -1130,7 +1130,7 @@ async fn test_cast_vote_with_invalid_proposal_owner_error() {
 
     // Act
     let err = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .err()
         .unwrap();
@@ -1172,7 +1172,7 @@ async fn test_cast_tipping_vote_with_invalid_proposal_owner_error() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(
+        .with_cast_yes_no_vote(
             &proposal_cookie,
             &token_owner_record_cookie2,
             YesNoVote::Yes,
@@ -1185,7 +1185,7 @@ async fn test_cast_tipping_vote_with_invalid_proposal_owner_error() {
 
     // Act
     let err = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .err()
         .unwrap();
@@ -1226,7 +1226,7 @@ async fn test_cast_council_vote() {
 
     // Act
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -1242,4 +1242,89 @@ async fn test_cast_council_vote() {
         Some(governance_cookie.account.config.council_vote_threshold),
         proposal_account.vote_threshold
     );
+}
+
+#[tokio::test]
+async fn test_cast_veto_vote() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let clock = governance_test.bench.get_clock().await;
+
+    // Act
+    let vote_record_cookie = governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Assert
+    let vote_record_account = governance_test
+        .get_vote_record_account(&vote_record_cookie.address)
+        .await;
+
+    assert_eq!(vote_record_cookie.account, vote_record_account);
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(
+        token_owner_record_cookie
+            .account
+            .governing_token_deposit_amount,
+        proposal_account.options[0].vote_weight
+    );
+
+    assert_eq!(proposal_account.state, ProposalState::Succeeded);
+    assert_eq!(
+        proposal_account.voting_completed_at,
+        Some(clock.unix_timestamp)
+    );
+
+    assert_eq!(Some(100), proposal_account.max_vote_weight);
+    assert_eq!(
+        Some(governance_cookie.account.config.community_vote_threshold),
+        proposal_account.vote_threshold
+    );
+
+    let token_owner_record = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(1, token_owner_record.unrelinquished_votes_count);
+    assert_eq!(1, token_owner_record.total_votes_count);
+
+    let realm_account = governance_test
+        .get_realm_account(&realm_cookie.address)
+        .await;
+
+    assert_eq!(0, realm_account.voting_proposal_count);
+
+    let governance_account = governance_test
+        .get_governance_account(&governance_cookie.address)
+        .await;
+
+    assert_eq!(0, governance_account.voting_proposal_count);
 }

--- a/governance/program/tests/process_create_native_treasury.rs
+++ b/governance/program/tests/process_create_native_treasury.rs
@@ -98,7 +98,7 @@ async fn test_execute_transfer_from_native_treasury() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 

--- a/governance/program/tests/process_create_token_owner_record.rs
+++ b/governance/program/tests/process_create_token_owner_record.rs
@@ -13,7 +13,9 @@ async fn test_create_token_owner_record() {
     let realm_cookie = governance_test.with_realm().await;
 
     // Act
-    let token_owner_record_cookie = governance_test.with_token_owner_record(&realm_cookie).await;
+    let token_owner_record_cookie = governance_test
+        .with_community_token_owner_record(&realm_cookie)
+        .await;
 
     // Assert
     let token_owner_record_account = governance_test

--- a/governance/program/tests/process_execute_transaction.rs
+++ b/governance/program/tests/process_execute_transaction.rs
@@ -64,7 +64,7 @@ async fn test_execute_mint_transaction() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -163,7 +163,7 @@ async fn test_execute_transfer_transaction() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -261,7 +261,7 @@ async fn test_execute_upgrade_program_transaction() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -447,7 +447,7 @@ async fn test_execute_proposal_transaction_with_invalid_state_errors() {
     // Arrange
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -553,7 +553,7 @@ async fn test_execute_proposal_transaction_for_other_proposal_error() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -643,7 +643,7 @@ async fn test_execute_mint_transaction_twice_error() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 

--- a/governance/program/tests/process_finalize_vote.rs
+++ b/governance/program/tests/process_finalize_vote.rs
@@ -48,7 +48,7 @@ async fn test_finalize_vote_to_succeeded() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -147,7 +147,7 @@ async fn test_finalize_vote_to_defeated() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
         .await
         .unwrap();
 
@@ -215,7 +215,7 @@ async fn test_finalize_vote_with_invalid_mint_error() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
         .await
         .unwrap();
 
@@ -275,7 +275,7 @@ async fn test_finalize_vote_with_invalid_governance_error() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
         .await
         .unwrap();
 
@@ -353,7 +353,7 @@ async fn test_finalize_council_vote() {
 
     // Cast vote with 47% weight, above 40% quorum but below 50%+1 to tip automatically
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 

--- a/governance/program/tests/process_flag_transaction_error.rs
+++ b/governance/program/tests/process_flag_transaction_error.rs
@@ -53,7 +53,7 @@ async fn test_execute_flag_transaction_error() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -148,7 +148,7 @@ async fn test_execute_proposal_transaction_after_flagged_with_error() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -244,7 +244,7 @@ async fn test_execute_second_transaction_after_first_transaction_flagged_with_er
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -332,7 +332,7 @@ async fn test_flag_transaction_error_with_proposal_transaction_already_executed_
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -406,7 +406,7 @@ async fn test_flag_transaction_error_with_owner_or_delegate_must_sign_error() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 

--- a/governance/program/tests/process_relinquish_vote.rs
+++ b/governance/program/tests/process_relinquish_vote.rs
@@ -250,7 +250,7 @@ async fn test_relinquish_vote_with_invalid_mint_error() {
 
     // Assert
 
-    assert_eq!(err, GovernanceError::InvalidGoverningMintForProposal.into());
+    assert_eq!(err, GovernanceError::InvalidGoverningTokenMint.into());
 }
 
 #[tokio::test]
@@ -369,7 +369,7 @@ async fn test_relinquish_vote_with_invalid_vote_record_error() {
 
     let err = governance_test
         .relinquish_vote_using_instruction(&proposal_cookie, &token_owner_record_cookie, |i| {
-            i.accounts[3] = AccountMeta::new(vote_record_cookie2.address, false)
+            i.accounts[4] = AccountMeta::new(vote_record_cookie2.address, false)
             // Try to use a vote_record for other token owner
         })
         .await

--- a/governance/program/tests/process_relinquish_vote.rs
+++ b/governance/program/tests/process_relinquish_vote.rs
@@ -214,7 +214,7 @@ async fn test_relinquish_vote_with_invalid_mint_error() {
     let realm_cookie = governance_test.with_realm().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let token_owner_record_cookie = governance_test
+    let mut token_owner_record_cookie = governance_test
         .with_community_token_deposit(&realm_cookie)
         .await
         .unwrap();
@@ -228,7 +228,7 @@ async fn test_relinquish_vote_with_invalid_mint_error() {
         .await
         .unwrap();
 
-    let mut proposal_cookie = governance_test
+    let proposal_cookie = governance_test
         .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
         .await
         .unwrap();
@@ -238,7 +238,7 @@ async fn test_relinquish_vote_with_invalid_mint_error() {
         .await
         .unwrap();
 
-    proposal_cookie.account.governing_token_mint = Pubkey::new_unique();
+    token_owner_record_cookie.account.governing_token_mint = Pubkey::new_unique();
 
     // Act
 

--- a/governance/program/tests/process_relinquish_vote.rs
+++ b/governance/program/tests/process_relinquish_vote.rs
@@ -36,7 +36,7 @@ async fn test_relinquish_voted_proposal() {
         .unwrap();
 
     let mut vote_record_cookie = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -103,7 +103,7 @@ async fn test_relinquish_active_yes_vote() {
         .unwrap();
 
     let vote_record_cookie = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -171,7 +171,7 @@ async fn test_relinquish_active_no_vote() {
         .unwrap();
 
     let vote_record_cookie = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
         .await
         .unwrap();
 
@@ -234,7 +234,7 @@ async fn test_relinquish_vote_with_invalid_mint_error() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
         .await
         .unwrap();
 
@@ -286,7 +286,7 @@ async fn test_relinquish_vote_with_governance_authority_must_sign_error() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
         .await
         .unwrap();
 
@@ -352,12 +352,12 @@ async fn test_relinquish_vote_with_invalid_vote_record_error() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
         .await
         .unwrap();
 
     let vote_record_cookie2 = governance_test
-        .with_cast_vote(
+        .with_cast_yes_no_vote(
             &proposal_cookie,
             &token_owner_record_cookie2,
             YesNoVote::Yes,
@@ -412,7 +412,7 @@ async fn test_relinquish_vote_with_already_relinquished_error() {
         .unwrap();
 
     let vote_record_cookie = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
         .await
         .unwrap();
 
@@ -482,7 +482,7 @@ async fn test_relinquish_proposal_in_voting_state_after_vote_time_ended() {
     let clock = governance_test.bench.get_clock().await;
 
     let mut vote_record_cookie = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 

--- a/governance/program/tests/process_set_governance_config.rs
+++ b/governance/program/tests/process_set_governance_config.rs
@@ -64,7 +64,7 @@ async fn test_set_governance_config() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -217,7 +217,7 @@ async fn test_set_governance_config_with_invalid_governance_authority_error() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 

--- a/governance/program/tests/process_withdraw_governing_tokens.rs
+++ b/governance/program/tests/process_withdraw_governing_tokens.rs
@@ -207,7 +207,7 @@ async fn test_withdraw_governing_tokens_with_unrelinquished_votes_error() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -253,7 +253,7 @@ async fn test_withdraw_governing_tokens_after_relinquishing_vote() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 

--- a/governance/program/tests/program_test/args.rs
+++ b/governance/program/tests/program_test/args.rs
@@ -1,9 +1,28 @@
 use solana_program::pubkey::Pubkey;
-use spl_governance::state::realm::RealmConfigArgs;
+use spl_governance::state::{enums::MintMaxVoteWeightSource, realm::RealmConfigArgs};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct SetRealmConfigArgs {
     pub realm_config_args: RealmConfigArgs,
     pub community_voter_weight_addin: Option<Pubkey>,
     pub max_community_voter_weight_addin: Option<Pubkey>,
+}
+
+impl Default for SetRealmConfigArgs {
+    fn default() -> Self {
+        let realm_config_args = RealmConfigArgs {
+            use_council_mint: true,
+
+            community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(100),
+            min_community_weight_to_create_governance: 10,
+            use_community_voter_weight_addin: false,
+            use_max_community_voter_weight_addin: false,
+        };
+
+        Self {
+            realm_config_args,
+            community_voter_weight_addin: None,
+            max_community_voter_weight_addin: None,
+        }
+    }
 }

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -2164,7 +2164,7 @@ impl GovernanceProgramTest {
             &proposal_cookie.account.token_owner_record,
             &token_owner_record_cookie.address,
             &token_owner_record_cookie.token_owner.pubkey(),
-            &proposal_cookie.account.governing_token_mint,
+            &token_owner_record_cookie.account.governing_token_mint,
             &self.bench.payer.pubkey(),
             voter_weight_record,
             max_voter_weight_record,

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -453,7 +453,7 @@ impl GovernanceProgramTest {
     }
 
     #[allow(dead_code)]
-    pub async fn with_token_owner_record(
+    pub async fn with_community_token_owner_record(
         &mut self,
         realm_cookie: &RealmCookie,
     ) -> TokenOwnerRecordCookie {

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1194,7 +1194,7 @@ impl GovernanceProgramTest {
             community_vote_threshold: VoteThreshold::YesVotePercentage(60),
             vote_tipping: spl_governance::state::enums::VoteTipping::Strict,
             council_vote_threshold: VoteThreshold::YesVotePercentage(80),
-            council_veto_vote_threshold: VoteThreshold::YesVotePercentage(50),
+            council_veto_vote_threshold: VoteThreshold::YesVotePercentage(55),
         }
     }
 

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -2069,6 +2069,7 @@ impl GovernanceProgramTest {
     ) -> Result<(), ProgramError> {
         let mut relinquish_vote_ix = relinquish_vote(
             &self.program_id,
+            &token_owner_record_cookie.account.realm,
             &proposal_cookie.account.governance,
             &proposal_cookie.address,
             &token_owner_record_cookie.address,

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1834,7 +1834,7 @@ impl GovernanceProgramTest {
             options: proposal_options,
             deny_vote_weight,
 
-            veto_vote_weight: None,
+            veto_vote_weight: 0,
             abstain_vote_weight: None,
 
             execution_flags: InstructionExecutionFlags::None,

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -2130,12 +2130,12 @@ impl GovernanceProgramTest {
             YesNoVote::No => Vote::Deny,
         };
 
-        self.with_cast_multi_option_vote(proposal_cookie, token_owner_record_cookie, vote)
+        self.with_cast_vote(proposal_cookie, token_owner_record_cookie, vote)
             .await
     }
 
     #[allow(dead_code)]
-    pub async fn with_cast_multi_option_vote(
+    pub async fn with_cast_vote(
         &mut self,
         proposal_cookie: &ProposalCookie,
         token_owner_record_cookie: &TokenOwnerRecordCookie,

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -28,7 +28,7 @@ use spl_governance::{
     state::{
         enums::{
             GovernanceAccountType, InstructionExecutionFlags, MintMaxVoteWeightSource,
-            ProposalState, TransactionExecutionStatus, VetoOptions, VoteThreshold,
+            ProposalState, TransactionExecutionStatus, VoteThreshold,
         },
         governance::{
             get_governance_address, get_mint_governance_address, get_program_governance_address,
@@ -1194,8 +1194,7 @@ impl GovernanceProgramTest {
             community_vote_threshold: VoteThreshold::YesVotePercentage(60),
             vote_tipping: spl_governance::state::enums::VoteTipping::Strict,
             council_vote_threshold: VoteThreshold::YesVotePercentage(80),
-            veto_options: VetoOptions::CouncilOnly,
-            reserved: [0; 1],
+            council_veto_vote_threshold: VoteThreshold::YesVotePercentage(50),
         }
     }
 

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -28,7 +28,7 @@ use spl_governance::{
     state::{
         enums::{
             GovernanceAccountType, InstructionExecutionFlags, MintMaxVoteWeightSource,
-            ProposalState, TransactionExecutionStatus, VoteThreshold,
+            ProposalState, TransactionExecutionStatus, VetoOptions, VoteThreshold,
         },
         governance::{
             get_governance_address, get_mint_governance_address, get_program_governance_address,
@@ -1194,7 +1194,8 @@ impl GovernanceProgramTest {
             community_vote_threshold: VoteThreshold::YesVotePercentage(60),
             vote_tipping: spl_governance::state::enums::VoteTipping::Strict,
             council_vote_threshold: VoteThreshold::YesVotePercentage(80),
-            reserved: [0; 2],
+            veto_options: VetoOptions::CouncilOnly,
+            reserved: [0; 1],
         }
     }
 

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -2073,7 +2073,7 @@ impl GovernanceProgramTest {
             &proposal_cookie.account.governance,
             &proposal_cookie.address,
             &token_owner_record_cookie.address,
-            &proposal_cookie.account.governing_token_mint,
+            &token_owner_record_cookie.account.governing_token_mint,
             Some(token_owner_record_cookie.token_owner.pubkey()),
             Some(self.bench.payer.pubkey()),
         );

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -2116,7 +2116,7 @@ impl GovernanceProgramTest {
     }
 
     #[allow(dead_code)]
-    pub async fn with_cast_vote(
+    pub async fn with_cast_yes_no_vote(
         &mut self,
         proposal_cookie: &ProposalCookie,
         token_owner_record_cookie: &TokenOwnerRecordCookie,

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -448,6 +448,7 @@ impl GovernanceProgramTest {
             &realm_cookie.account.community_mint,
             &realm_cookie.community_mint_authority,
             100,
+            None,
         )
         .await
     }
@@ -576,6 +577,7 @@ impl GovernanceProgramTest {
             &realm_cookie.account.community_mint,
             &realm_cookie.community_mint_authority,
             amount,
+            None,
         )
         .await
     }
@@ -625,6 +627,7 @@ impl GovernanceProgramTest {
             &realm_cookie.account.config.council_mint.unwrap(),
             &realm_cookie.council_mint_authority.as_ref().unwrap(),
             amount,
+            None,
         )
         .await
     }
@@ -639,6 +642,24 @@ impl GovernanceProgramTest {
             &realm_cookie.account.config.council_mint.unwrap(),
             realm_cookie.council_mint_authority.as_ref().unwrap(),
             100,
+            None,
+        )
+        .await
+    }
+
+    #[allow(dead_code)]
+    pub async fn with_community_token_deposit_by_owner(
+        &mut self,
+        realm_cookie: &RealmCookie,
+        amount: u64,
+        token_owner: Keypair,
+    ) -> Result<TokenOwnerRecordCookie, ProgramError> {
+        self.with_initial_governing_token_deposit(
+            &realm_cookie.address,
+            &realm_cookie.account.community_mint,
+            &realm_cookie.community_mint_authority,
+            amount,
+            Some(token_owner),
         )
         .await
     }
@@ -650,8 +671,9 @@ impl GovernanceProgramTest {
         governing_mint: &Pubkey,
         governing_mint_authority: &Keypair,
         amount: u64,
+        token_owner: Option<Keypair>,
     ) -> Result<TokenOwnerRecordCookie, ProgramError> {
-        let token_owner = Keypair::new();
+        let token_owner = token_owner.unwrap_or(Keypair::new());
         let token_source = Keypair::new();
 
         let transfer_authority = Keypair::new();

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1843,6 +1843,7 @@ impl GovernanceProgramTest {
             vote_threshold: None,
 
             reserved: [0; 64],
+            reserved1: 0,
         };
 
         let proposal_address = get_proposal_address(

--- a/governance/program/tests/use_proposals_with_multiple_options.rs
+++ b/governance/program/tests/use_proposals_with_multiple_options.rs
@@ -291,7 +291,7 @@ async fn test_vote_on_none_executable_single_choice_proposal_with_multiple_optio
 
     // Act
     governance_test
-        .with_cast_multi_option_vote(&proposal_cookie, &token_owner_record_cookie, vote)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, vote)
         .await
         .unwrap();
 
@@ -396,7 +396,7 @@ async fn test_vote_on_none_executable_multi_choice_proposal_with_multiple_option
 
     // Act
     governance_test
-        .with_cast_multi_option_vote(&proposal_cookie, &token_owner_record_cookie, vote)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, vote)
         .await
         .unwrap();
 
@@ -531,7 +531,7 @@ async fn test_vote_on_executable_proposal_with_multiple_options_and_partial_succ
     ]);
 
     governance_test
-        .with_cast_multi_option_vote(&proposal_cookie, &token_owner_record_cookie1, vote1)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie1, vote1)
         .await
         .unwrap();
 
@@ -551,12 +551,12 @@ async fn test_vote_on_executable_proposal_with_multiple_options_and_partial_succ
     ]);
 
     governance_test
-        .with_cast_multi_option_vote(&proposal_cookie, &token_owner_record_cookie2, vote2)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie2, vote2)
         .await
         .unwrap();
 
     governance_test
-        .with_cast_multi_option_vote(&proposal_cookie, &token_owner_record_cookie3, Vote::Deny)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie3, Vote::Deny)
         .await
         .unwrap();
 
@@ -706,7 +706,7 @@ async fn test_execute_proposal_with_multiple_options_and_partial_success() {
     // yes threshold: 100
 
     governance_test
-        .with_cast_multi_option_vote(&proposal_cookie, &token_owner_record_cookie3, Vote::Deny)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie3, Vote::Deny)
         .await
         .unwrap();
 
@@ -726,7 +726,7 @@ async fn test_execute_proposal_with_multiple_options_and_partial_success() {
     ]);
 
     governance_test
-        .with_cast_multi_option_vote(&proposal_cookie, &token_owner_record_cookie1, vote1)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie1, vote1)
         .await
         .unwrap();
 
@@ -746,7 +746,7 @@ async fn test_execute_proposal_with_multiple_options_and_partial_success() {
     ]);
 
     governance_test
-        .with_cast_multi_option_vote(&proposal_cookie, &token_owner_record_cookie2, vote2)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie2, vote2)
         .await
         .unwrap();
 
@@ -904,12 +904,12 @@ async fn test_try_execute_proposal_with_multiple_options_and_full_deny() {
         .unwrap();
 
     governance_test
-        .with_cast_multi_option_vote(&proposal_cookie, &token_owner_record_cookie1, Vote::Deny)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie1, Vote::Deny)
         .await
         .unwrap();
 
     governance_test
-        .with_cast_multi_option_vote(&proposal_cookie, &token_owner_record_cookie2, Vote::Deny)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie2, Vote::Deny)
         .await
         .unwrap();
 
@@ -1039,7 +1039,7 @@ async fn test_create_proposal_with_10_options_and_cast_vote() {
 
     // Act
     governance_test
-        .with_cast_multi_option_vote(&proposal_cookie, &token_owner_record_cookie, vote)
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, vote)
         .await
         .unwrap();
 

--- a/governance/program/tests/use_realm_with_all_addins.rs
+++ b/governance/program/tests/use_realm_with_all_addins.rs
@@ -14,8 +14,9 @@ async fn test_cast_vote_with_all_addin() {
 
     let realm_cookie = governance_test.with_realm().await;
 
-    let mut token_owner_record_cookie =
-        governance_test.with_token_owner_record(&realm_cookie).await;
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_owner_record(&realm_cookie)
+        .await;
 
     // voter weight 120
     governance_test
@@ -73,8 +74,9 @@ async fn test_tip_vote_with_all_addin() {
 
     let realm_cookie = governance_test.with_realm().await;
 
-    let mut token_owner_record_cookie =
-        governance_test.with_token_owner_record(&realm_cookie).await;
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_owner_record(&realm_cookie)
+        .await;
 
     // voter weight 120
     governance_test
@@ -132,8 +134,9 @@ async fn test_finalize_vote_with_all_addin() {
 
     let realm_cookie = governance_test.with_realm().await;
 
-    let mut token_owner_record_cookie =
-        governance_test.with_token_owner_record(&realm_cookie).await;
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_owner_record(&realm_cookie)
+        .await;
 
     // voter weight 120
     governance_test

--- a/governance/program/tests/use_realm_with_all_addins.rs
+++ b/governance/program/tests/use_realm_with_all_addins.rs
@@ -48,7 +48,7 @@ async fn test_cast_vote_with_all_addin() {
     // Act
 
     let vote_record_cookie = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -107,7 +107,7 @@ async fn test_tip_vote_with_all_addin() {
     // Act
 
     let vote_record_cookie = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
         .await
         .unwrap();
 
@@ -164,7 +164,7 @@ async fn test_finalize_vote_with_all_addin() {
         .unwrap();
 
     let vote_record_cookie = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::No)
         .await
         .unwrap();
 

--- a/governance/program/tests/use_realm_with_max_voter_weight_addin.rs
+++ b/governance/program/tests/use_realm_with_max_voter_weight_addin.rs
@@ -43,7 +43,7 @@ async fn test_cast_vote_with_max_voter_weight_addin() {
 
     // Act
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -92,7 +92,7 @@ async fn test_tip_vote_with_max_voter_weight_addin() {
 
     // Act
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -142,7 +142,7 @@ async fn test_tip_vote_with_max_voter_weight_addin_and_max_below_total_cast_vote
 
     // Act
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -191,7 +191,7 @@ async fn test_finalize_vote_with_max_voter_weight_addin() {
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -262,7 +262,7 @@ async fn test_finalize_vote_with_max_voter_weight_addin_and_max_below_total_cast
         .unwrap();
 
     governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -336,7 +336,7 @@ async fn test_cast_vote_with_max_voter_weight_addin_and_expired_record_error() {
 
     // Act
     let err = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .err()
         .unwrap();

--- a/governance/program/tests/use_realm_with_voter_weight_addin.rs
+++ b/governance/program/tests/use_realm_with_voter_weight_addin.rs
@@ -117,7 +117,7 @@ async fn test_cast_vote_with_voter_weight_addin() {
 
     // Act
     let vote_record_cookie = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -391,7 +391,7 @@ async fn test_cast_vote_with_voter_weight_action_error() {
     // Act
 
     let err = governance_test
-        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .err()
         .unwrap();

--- a/governance/program/tests/use_realm_with_voter_weight_addin.rs
+++ b/governance/program/tests/use_realm_with_voter_weight_addin.rs
@@ -21,7 +21,7 @@ async fn test_create_governance_with_voter_weight_addin() {
     let realm_cookie = governance_test.with_realm().await;
 
     let mut token_owner_record_cookie =
-        governance_test.with_token_owner_record(&realm_cookie).await;
+        governance_test.with_community_token_owner_record(&realm_cookie).await;
 
     governance_test
         .with_voter_weight_addin_record(&mut token_owner_record_cookie)
@@ -55,7 +55,7 @@ async fn test_create_proposal_with_voter_weight_addin() {
     let realm_cookie = governance_test.with_realm().await;
 
     let mut token_owner_record_cookie =
-        governance_test.with_token_owner_record(&realm_cookie).await;
+        governance_test.with_community_token_owner_record(&realm_cookie).await;
 
     governance_test
         .with_voter_weight_addin_record(&mut token_owner_record_cookie)
@@ -94,7 +94,7 @@ async fn test_cast_vote_with_voter_weight_addin() {
     let realm_cookie = governance_test.with_realm().await;
 
     let mut token_owner_record_cookie =
-        governance_test.with_token_owner_record(&realm_cookie).await;
+        governance_test.with_community_token_owner_record(&realm_cookie).await;
 
     governance_test
         .with_voter_weight_addin_record(&mut token_owner_record_cookie)
@@ -152,7 +152,7 @@ async fn test_create_token_governance_with_voter_weight_addin() {
     let realm_cookie = governance_test.with_realm().await;
 
     let mut token_owner_record_cookie =
-        governance_test.with_token_owner_record(&realm_cookie).await;
+        governance_test.with_community_token_owner_record(&realm_cookie).await;
 
     governance_test
         .with_voter_weight_addin_record(&mut token_owner_record_cookie)
@@ -186,7 +186,7 @@ async fn test_create_mint_governance_with_voter_weight_addin() {
     let realm_cookie = governance_test.with_realm().await;
 
     let mut token_owner_record_cookie =
-        governance_test.with_token_owner_record(&realm_cookie).await;
+        governance_test.with_community_token_owner_record(&realm_cookie).await;
 
     governance_test
         .with_voter_weight_addin_record(&mut token_owner_record_cookie)
@@ -220,7 +220,7 @@ async fn test_create_program_governance_with_voter_weight_addin() {
     let realm_cookie = governance_test.with_realm().await;
 
     let mut token_owner_record_cookie =
-        governance_test.with_token_owner_record(&realm_cookie).await;
+        governance_test.with_community_token_owner_record(&realm_cookie).await;
 
     governance_test
         .with_voter_weight_addin_record(&mut token_owner_record_cookie)
@@ -278,7 +278,7 @@ async fn test_create_governance_with_voter_weight_action_error() {
     let realm_cookie = governance_test.with_realm().await;
 
     let mut token_owner_record_cookie =
-        governance_test.with_token_owner_record(&realm_cookie).await;
+        governance_test.with_community_token_owner_record(&realm_cookie).await;
 
     governance_test
         .with_voter_weight_addin_record_impl(
@@ -315,7 +315,7 @@ async fn test_create_governance_with_voter_weight_expiry_error() {
     let realm_cookie = governance_test.with_realm().await;
 
     let mut token_owner_record_cookie =
-        governance_test.with_token_owner_record(&realm_cookie).await;
+        governance_test.with_community_token_owner_record(&realm_cookie).await;
 
     governance_test
         .with_voter_weight_addin_record_impl(
@@ -354,7 +354,7 @@ async fn test_cast_vote_with_voter_weight_action_error() {
     let realm_cookie = governance_test.with_realm().await;
 
     let mut token_owner_record_cookie =
-        governance_test.with_token_owner_record(&realm_cookie).await;
+        governance_test.with_community_token_owner_record(&realm_cookie).await;
 
     governance_test
         .with_voter_weight_addin_record_impl(&mut token_owner_record_cookie, 100, None, None, None)
@@ -409,7 +409,7 @@ async fn test_create_governance_with_voter_weight_action_target_error() {
     let realm_cookie = governance_test.with_realm().await;
 
     let mut token_owner_record_cookie =
-        governance_test.with_token_owner_record(&realm_cookie).await;
+        governance_test.with_community_token_owner_record(&realm_cookie).await;
 
     governance_test
         .with_voter_weight_addin_record_impl(
@@ -451,7 +451,7 @@ async fn test_create_proposal_with_voter_weight_action_error() {
     let realm_cookie = governance_test.with_realm().await;
 
     let mut token_owner_record_cookie =
-        governance_test.with_token_owner_record(&realm_cookie).await;
+        governance_test.with_community_token_owner_record(&realm_cookie).await;
 
     governance_test
         .with_voter_weight_addin_record_impl(
@@ -494,7 +494,7 @@ async fn test_create_governance_with_voter_weight_record() {
     let realm_cookie = governance_test.with_realm().await;
 
     let mut token_owner_record_cookie =
-        governance_test.with_token_owner_record(&realm_cookie).await;
+        governance_test.with_community_token_owner_record(&realm_cookie).await;
 
     governance_test.advance_clock().await;
     let clock = governance_test.bench.get_clock().await;

--- a/governance/program/tests/use_realm_with_voter_weight_addin.rs
+++ b/governance/program/tests/use_realm_with_voter_weight_addin.rs
@@ -20,8 +20,9 @@ async fn test_create_governance_with_voter_weight_addin() {
 
     let realm_cookie = governance_test.with_realm().await;
 
-    let mut token_owner_record_cookie =
-        governance_test.with_community_token_owner_record(&realm_cookie).await;
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_owner_record(&realm_cookie)
+        .await;
 
     governance_test
         .with_voter_weight_addin_record(&mut token_owner_record_cookie)
@@ -54,8 +55,9 @@ async fn test_create_proposal_with_voter_weight_addin() {
 
     let realm_cookie = governance_test.with_realm().await;
 
-    let mut token_owner_record_cookie =
-        governance_test.with_community_token_owner_record(&realm_cookie).await;
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_owner_record(&realm_cookie)
+        .await;
 
     governance_test
         .with_voter_weight_addin_record(&mut token_owner_record_cookie)
@@ -93,8 +95,9 @@ async fn test_cast_vote_with_voter_weight_addin() {
 
     let realm_cookie = governance_test.with_realm().await;
 
-    let mut token_owner_record_cookie =
-        governance_test.with_community_token_owner_record(&realm_cookie).await;
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_owner_record(&realm_cookie)
+        .await;
 
     governance_test
         .with_voter_weight_addin_record(&mut token_owner_record_cookie)
@@ -151,8 +154,9 @@ async fn test_create_token_governance_with_voter_weight_addin() {
 
     let realm_cookie = governance_test.with_realm().await;
 
-    let mut token_owner_record_cookie =
-        governance_test.with_community_token_owner_record(&realm_cookie).await;
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_owner_record(&realm_cookie)
+        .await;
 
     governance_test
         .with_voter_weight_addin_record(&mut token_owner_record_cookie)
@@ -185,8 +189,9 @@ async fn test_create_mint_governance_with_voter_weight_addin() {
 
     let realm_cookie = governance_test.with_realm().await;
 
-    let mut token_owner_record_cookie =
-        governance_test.with_community_token_owner_record(&realm_cookie).await;
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_owner_record(&realm_cookie)
+        .await;
 
     governance_test
         .with_voter_weight_addin_record(&mut token_owner_record_cookie)
@@ -219,8 +224,9 @@ async fn test_create_program_governance_with_voter_weight_addin() {
 
     let realm_cookie = governance_test.with_realm().await;
 
-    let mut token_owner_record_cookie =
-        governance_test.with_community_token_owner_record(&realm_cookie).await;
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_owner_record(&realm_cookie)
+        .await;
 
     governance_test
         .with_voter_weight_addin_record(&mut token_owner_record_cookie)
@@ -277,8 +283,9 @@ async fn test_create_governance_with_voter_weight_action_error() {
 
     let realm_cookie = governance_test.with_realm().await;
 
-    let mut token_owner_record_cookie =
-        governance_test.with_community_token_owner_record(&realm_cookie).await;
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_owner_record(&realm_cookie)
+        .await;
 
     governance_test
         .with_voter_weight_addin_record_impl(
@@ -314,8 +321,9 @@ async fn test_create_governance_with_voter_weight_expiry_error() {
 
     let realm_cookie = governance_test.with_realm().await;
 
-    let mut token_owner_record_cookie =
-        governance_test.with_community_token_owner_record(&realm_cookie).await;
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_owner_record(&realm_cookie)
+        .await;
 
     governance_test
         .with_voter_weight_addin_record_impl(
@@ -353,8 +361,9 @@ async fn test_cast_vote_with_voter_weight_action_error() {
 
     let realm_cookie = governance_test.with_realm().await;
 
-    let mut token_owner_record_cookie =
-        governance_test.with_community_token_owner_record(&realm_cookie).await;
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_owner_record(&realm_cookie)
+        .await;
 
     governance_test
         .with_voter_weight_addin_record_impl(&mut token_owner_record_cookie, 100, None, None, None)
@@ -408,8 +417,9 @@ async fn test_create_governance_with_voter_weight_action_target_error() {
 
     let realm_cookie = governance_test.with_realm().await;
 
-    let mut token_owner_record_cookie =
-        governance_test.with_community_token_owner_record(&realm_cookie).await;
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_owner_record(&realm_cookie)
+        .await;
 
     governance_test
         .with_voter_weight_addin_record_impl(
@@ -450,8 +460,9 @@ async fn test_create_proposal_with_voter_weight_action_error() {
 
     let realm_cookie = governance_test.with_realm().await;
 
-    let mut token_owner_record_cookie =
-        governance_test.with_community_token_owner_record(&realm_cookie).await;
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_owner_record(&realm_cookie)
+        .await;
 
     governance_test
         .with_voter_weight_addin_record_impl(
@@ -493,8 +504,9 @@ async fn test_create_governance_with_voter_weight_record() {
 
     let realm_cookie = governance_test.with_realm().await;
 
-    let mut token_owner_record_cookie =
-        governance_test.with_community_token_owner_record(&realm_cookie).await;
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_owner_record(&realm_cookie)
+        .await;
 
     governance_test.advance_clock().await;
     let clock = governance_test.bench.get_clock().await;

--- a/governance/program/tests/use_veto_vote.rs
+++ b/governance/program/tests/use_veto_vote.rs
@@ -157,6 +157,51 @@ async fn test_cast_veto_vote_with_community_not_allowed_to_vote_error() {
 }
 
 #[tokio::test]
+async fn test_cast_veto_vote_with_invalid_voting_mint_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let proposal_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&proposal_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+
+    // Try to use Council Veto on Council vote Proposal
+    let err = governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Veto)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::InvalidGoverningMintForProposal.into());
+}
+
+#[tokio::test]
 async fn test_cast_veto_vote_with_council_vote_vote_disabled_error() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;

--- a/governance/program/tests/use_veto_vote.rs
+++ b/governance/program/tests/use_veto_vote.rs
@@ -1,0 +1,98 @@
+#![cfg(feature = "test-bpf")]
+
+mod program_test;
+
+use solana_program_test::tokio;
+
+use program_test::*;
+use spl_governance::state::{enums::ProposalState, vote_record::Vote};
+
+#[tokio::test]
+async fn test_cast_veto_vote() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let proposal_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&proposal_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let clock = governance_test.bench.get_clock().await;
+
+    // Act
+    let vote_record_cookie = governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Veto)
+        .await
+        .unwrap();
+
+    // Assert
+    let vote_record_account = governance_test
+        .get_vote_record_account(&vote_record_cookie.address)
+        .await;
+
+    assert_eq!(vote_record_cookie.account, vote_record_account);
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(
+        token_owner_record_cookie
+            .account
+            .governing_token_deposit_amount,
+        proposal_account.veto_vote_weight
+    );
+
+    assert_eq!(proposal_account.state, ProposalState::Vetoed);
+    assert_eq!(
+        proposal_account.voting_completed_at,
+        Some(clock.unix_timestamp)
+    );
+
+    assert_eq!(Some(100), proposal_account.max_vote_weight);
+    assert_eq!(
+        Some(governance_cookie.account.config.council_veto_vote_threshold),
+        proposal_account.vote_threshold
+    );
+
+    let token_owner_record = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(1, token_owner_record.unrelinquished_votes_count);
+    assert_eq!(1, token_owner_record.total_votes_count);
+
+    let realm_account = governance_test
+        .get_realm_account(&realm_cookie.address)
+        .await;
+
+    assert_eq!(0, realm_account.voting_proposal_count);
+
+    let governance_account = governance_test
+        .get_governance_account(&governance_cookie.address)
+        .await;
+
+    assert_eq!(0, governance_account.voting_proposal_count);
+}

--- a/governance/program/tests/use_veto_vote.rs
+++ b/governance/program/tests/use_veto_vote.rs
@@ -460,3 +460,49 @@ async fn test_relinquish_veto_vote() {
 
     assert_eq!(proposal_account.state, ProposalState::Voting);
 }
+
+#[tokio::test]
+async fn test_relinquish_veto_vote_with_vote_record_for_different_voting_mint_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Mint extra council tokens for total supply of 210
+    governance_test
+        .mint_council_tokens(&realm_cookie, 110)
+        .await;
+
+    let mut governance_cookie = governance_test
+        .with_governance(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let proposal_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&proposal_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Veto)
+        .await
+        .unwrap();
+
+    // Assert
+}


### PR DESCRIPTION
#### Summary

This change makes it possible for `Council` to directly veto `Community` proposals. It gives an explicit option for the `Council` to defend DAOs from `Community` governance attacks.

`GovernanceConfig` makes it possible to create a configuration where `Council` can't vote on proposals but still can veto them.

#### Implementation Details
- `council_veto_vote_threshold` was introduced. It defines the required number of `Veto` votes to block a `Proposal` 
- Reserved space from `GovernanceConfig` was used for `council_veto_vote_threshold` and it's defaulted to `council_vote_threshold` for existing configurations. It makes the `Veto` option enabled by default for all existing DAOs
- `veto_vote_weight` on `Proposal` account was changed from `Option<u64>` to `u64` as it's not an optional field. Note: It was replaced with `reserved:u8` and moved to the end of the account struct.


#### Out Of Scope
- The `Veto` vote implementation is symmetrical and either `Council` or `Community` can cast `Veto` vote but reserved space from `GovernanceConfig` would have to be taken for the additional `VoteThreshold` configuration. 
Since the `Community` `Veto` vote is not as important as the `Council` one and should rather be disabled by default the support for it was not included in order to preserve the reserved account space.
