### PR TITLE
token-lending: Bump / set / pin versions for 0.2.0 crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5724,7 +5724,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-lending"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arrayref",
  "assert_matches",
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-lending-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "solana-clap-utils",

--- a/token-lending/cli/Cargo.toml
+++ b/token-lending/cli/Cargo.toml
@@ -6,18 +6,18 @@ homepage = "https://spl.solana.com/token-lending"
 license = "Apache-2.0"
 name = "spl-token-lending-cli"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "0.1.0"
+version = "0.2.0"
 
 [dependencies]
 clap = "2.33.3"
-solana-clap-utils = "1.10.10"
-solana-cli-config = "1.10.10"
-solana-client = "1.10.10"
-solana-logger = "1.10.10"
-solana-sdk = "1.10.10"
-solana-program = "1.10.10"
-spl-token-lending = { path="../program", features = [ "no-entrypoint" ] }
-spl-token = { path="../../token/program", features = [ "no-entrypoint" ]  }
+solana-clap-utils = "=1.10.10"
+solana-cli-config = "=1.10.10"
+solana-client = "=1.10.10"
+solana-logger = "=1.10.10"
+solana-sdk = "=1.10.10"
+solana-program = "=1.10.10"
+spl-token-lending = { version = "0.2", path="../program", features = [ "no-entrypoint" ] }
+spl-token = { version = "3.3", path="../../token/program", features = [ "no-entrypoint" ]  }
 
 [[bin]]
 name = "spl-token-lending"

--- a/token-lending/program/Cargo.toml
+++ b/token-lending/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-lending"
-version = "0.1.0"
+version = "0.2.0"
 description = "Solana Program Library Token Lending"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"


### PR DESCRIPTION
#### Problem

We need to release spl-token-lending-cli 0.2.0.

#### Solution

Bump all versions, and set them where needed for the crate to be properly deployed.