### PR TITLE
token-2022: add tests for confidential transfer withdraw withheld tokens from mint

### DIFF
--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -1375,7 +1375,7 @@ where
     }
 
     /// Harvest withheld confidential tokens to mint
-    pub async fn confidential_transfer_harvest_withheld_tokens_to_mint<S2: Signer>(
+    pub async fn confidential_transfer_harvest_withheld_tokens_to_mint(
         &self,
         sources: &[&Pubkey],
     ) -> TokenResult<T::Output> {


### PR DESCRIPTION
Adding standard tests for the confidential transfer extension `WithdrawWithheldTokensFromMint` instruction in token-2022.