### PR TITLE
token-js: move start-server-and-test dep to devDependencies

### DIFF
--- a/token/js/package.json
+++ b/token/js/package.json
@@ -42,8 +42,7 @@
     "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
         "@solana/buffer-layout-utils": "^0.2.0",
-        "@solana/web3.js": "^1.41.0",
-        "start-server-and-test": "^1.14.0"
+        "@solana/web3.js": "^1.41.0"
     },
     "devDependencies": {
         "@types/chai-as-promised": "^7.1.4",
@@ -63,6 +62,7 @@
         "mocha": "^9.1.4",
         "prettier": "^2.5.1",
         "shx": "^0.3.4",
+        "start-server-and-test": "^1.14.0",
         "ts-node": "^10.4.0",
         "tslib": "^2.3.1",
         "typedoc": "^0.22.11",


### PR DESCRIPTION
This patch moves the `start-server-and-test` dependencies to devDependencies which should shave off a few deps when using this library :) 