### PR TITLE
Confusion with decimals

### DIFF
--- a/docs/src/token.mdx
+++ b/docs/src/token.mdx
@@ -302,7 +302,7 @@ await mintTo(
   mint,
   tokenAccount.address,
   mintAuthority,
-  100
+  100000000000 // because decimals for the mint are set to 9 
 )
 ```
 


### PR DESCRIPTION
If decimals for the mint are set to "9", then to mint 100 tokens, you'd need to enter 100000000000

unless I am mistaken?