### PR TITLE
Fix confidential self transfer with fees

### DIFF
--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -546,13 +546,20 @@ fn process_transfer(
             &ciphertext_hi,
             new_source_decryptable_available_balance,
         )?;
+
+        let fee_ciphertext = if token_account_info.key == destination_token_account_info.key {
+            None
+        } else {
+            Some(proof_data.fee_ciphertext)
+        };
+
         process_destination_for_transfer(
             destination_token_account_info,
             mint_info,
             &proof_data.transfer_with_fee_pubkeys.destination_pubkey,
             &ciphertext_lo,
             &ciphertext_hi,
-            Some(proof_data.fee_ciphertext),
+            fee_ciphertext,
         )?;
     } else {
         // mint is not extended for fees


### PR DESCRIPTION
Currently, a self-transfer with fees using the confidential extension incurs a fee. This PR modifies the confidential transfer processor logic so that fee amount is not deducted for self-transfers.

I initially thought that this would require an involved update to the zk-token-sdk due to the way fee amount is encrypted in the transfer amount. It turned out that this could be fixed rather simply without any updates to the sdk.