### PR TITLE
token-2022: limit incoming transfers for confidential transfer extension

### DIFF
--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -51,7 +51,7 @@ pub enum TokenError {
     AccountInvalidMint,
     #[error("proof error: {0}")]
     Proof(ProofError),
-    #[error("illegal amount")]
+    #[error("maximum deposit transfer amount exceeded")]
     MaximumDepositTransferAmountExceeded,
 }
 impl PartialEq for TokenError {

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -52,7 +52,7 @@ pub enum TokenError {
     #[error("proof error: {0}")]
     Proof(ProofError),
     #[error("illegal amount")]
-    IllegalAmount,
+    MaximumDepositTransferAmountExceeded,
 }
 impl PartialEq for TokenError {
     fn eq(&self, other: &Self) -> bool {
@@ -1074,7 +1074,7 @@ where
         decimals: u8,
     ) -> TokenResult<T::Output> {
         if amount >> confidential_transfer::MAXIMUM_DEPOSIT_TRANSFER_AMOUNT_BIT_LENGTH != 0 {
-            return Err(TokenError::IllegalAmount);
+            return Err(TokenError::MaximumDepositTransferAmountExceeded);
         }
 
         self.process_ixs(
@@ -1149,7 +1149,7 @@ where
         new_source_decryptable_available_balance: AeCiphertext,
     ) -> TokenResult<T::Output> {
         if amount >> confidential_transfer::MAXIMUM_DEPOSIT_TRANSFER_AMOUNT_BIT_LENGTH != 0 {
-            return Err(TokenError::IllegalAmount);
+            return Err(TokenError::MaximumDepositTransferAmountExceeded);
         }
 
         let source_state = self.get_account_info(source_token_account).await.unwrap();
@@ -1213,7 +1213,7 @@ where
         epoch_info: &EpochInfo,
     ) -> TokenResult<T::Output> {
         if amount >> confidential_transfer::MAXIMUM_DEPOSIT_TRANSFER_AMOUNT_BIT_LENGTH != 0 {
-            return Err(TokenError::IllegalAmount);
+            return Err(TokenError::MaximumDepositTransferAmountExceeded);
         }
 
         let source_state = self.get_account_info(source_token_account).await.unwrap();

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -51,6 +51,8 @@ pub enum TokenError {
     AccountInvalidMint,
     #[error("proof error: {0}")]
     Proof(ProofError),
+    #[error("illegal amount")]
+    IllegalAmount,
 }
 impl PartialEq for TokenError {
     fn eq(&self, other: &Self) -> bool {
@@ -1071,6 +1073,10 @@ where
         amount: u64,
         decimals: u8,
     ) -> TokenResult<T::Output> {
+        if amount >> confidential_transfer::MAXIMUM_DEPOSIT_TRANSFER_AMOUNT_BIT_LENGTH != 0 {
+            return Err(TokenError::IllegalAmount);
+        }
+
         self.process_ixs(
             &[confidential_transfer::instruction::deposit(
                 &self.program_id,
@@ -1142,6 +1148,10 @@ where
         source_elgamal_keypair: &ElGamalKeypair,
         new_source_decryptable_available_balance: AeCiphertext,
     ) -> TokenResult<T::Output> {
+        if amount >> confidential_transfer::MAXIMUM_DEPOSIT_TRANSFER_AMOUNT_BIT_LENGTH != 0 {
+            return Err(TokenError::IllegalAmount);
+        }
+
         let source_state = self.get_account_info(source_token_account).await.unwrap();
         let source_extension =
             source_state.get_extension::<confidential_transfer::ConfidentialTransferAccount>()?;
@@ -1202,6 +1212,10 @@ where
         new_source_decryptable_available_balance: AeCiphertext,
         epoch_info: &EpochInfo,
     ) -> TokenResult<T::Output> {
+        if amount >> confidential_transfer::MAXIMUM_DEPOSIT_TRANSFER_AMOUNT_BIT_LENGTH != 0 {
+            return Err(TokenError::IllegalAmount);
+        }
+
         let source_state = self.get_account_info(source_token_account).await.unwrap();
         let source_extension =
             source_state.get_extension::<confidential_transfer::ConfidentialTransferAccount>()?;

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -976,6 +976,7 @@ where
         authority: &S2,
         elgamal_pubkey: ElGamalPubkey,
         decryptable_zero_balance: AeCiphertext,
+        maximum_pending_balance_credit_counter: u64,
     ) -> TokenResult<T::Output> {
         self.process_ixs(
             &[confidential_transfer::instruction::configure_account(
@@ -984,6 +985,7 @@ where
                 &self.pubkey,
                 elgamal_pubkey.into(),
                 decryptable_zero_balance,
+                maximum_pending_balance_credit_counter,
                 &authority.pubkey(),
                 &[],
             )?],
@@ -996,6 +998,7 @@ where
         &self,
         token_account: &Pubkey,
         authority: &S2,
+        maximum_pending_balance_credit_counter: u64,
     ) -> TokenResult<(ElGamalKeypair, AeKey)> {
         let elgamal_keypair = ElGamalKeypair::new_rand();
         let ae_key = AeKey::new(authority, token_account).unwrap();
@@ -1005,6 +1008,7 @@ where
             authority,
             elgamal_keypair.public,
             ae_key.encrypt(0_u64),
+            maximum_pending_balance_credit_counter,
         )
         .await
         .map(|_| (elgamal_keypair, ae_key))

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -353,6 +353,7 @@ async fn ct_configure_token_account() {
             &alice,
             alice_meta.elgamal_keypair.public,
             alice_meta.ae_key.encrypt(0_u64),
+            TEST_MAXIMUM_PENDING_BALANCE_CREDIT_COUNTER,
         )
         .await
         .unwrap_err();

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -31,6 +31,7 @@ use {
 
 const TEST_MAXIMUM_FEE: u64 = 100;
 const TEST_FEE_BASIS_POINTS: u16 = 250;
+const TEST_MAXIMUM_PENDING_BALANCE_CREDIT_COUNTER: u64 = 1024;
 
 fn test_epoch_info() -> EpochInfo {
     EpochInfo {
@@ -102,7 +103,8 @@ impl ConfidentialTokenAccountMeta {
             .unwrap();
 
         let (elgamal_keypair, ae_key) = token
-            .confidential_transfer_configure_token_account_and_keypairs(&token_account, owner)
+            .confidential_transfer_configure_token_account_and_keypairs(&token_account, owner,
+                                                                        TEST_MAXIMUM_PENDING_BALANCE_CREDIT_COUNTER)
             .await
             .unwrap();
 

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -103,8 +103,11 @@ impl ConfidentialTokenAccountMeta {
             .unwrap();
 
         let (elgamal_keypair, ae_key) = token
-            .confidential_transfer_configure_token_account_and_keypairs(&token_account, owner,
-                                                                        TEST_MAXIMUM_PENDING_BALANCE_CREDIT_COUNTER)
+            .confidential_transfer_configure_token_account_and_keypairs(
+                &token_account,
+                owner,
+                TEST_MAXIMUM_PENDING_BALANCE_CREDIT_COUNTER,
+            )
             .await
             .unwrap();
 

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -458,7 +458,7 @@ async fn ct_deposit() {
     let alice_meta = ConfidentialTokenAccountMeta::new(&token, &alice).await;
 
     token
-        .mint_to(&alice_meta.token_account, &mint_authority, 42)
+        .mint_to(&alice_meta.token_account, &mint_authority, 65537)
         .await
         .unwrap();
 
@@ -466,7 +466,7 @@ async fn ct_deposit() {
         .get_account_info(&alice_meta.token_account)
         .await
         .unwrap();
-    assert_eq!(state.base.amount, 42);
+    assert_eq!(state.base.amount, 65537);
     let extension = state
         .get_extension::<ConfidentialTransferAccount>()
         .unwrap();
@@ -491,7 +491,7 @@ async fn ct_deposit() {
             &alice_meta.token_account,
             &alice_meta.token_account,
             &alice,
-            42,
+            65537,
             decimals,
         )
         .await
@@ -521,7 +521,7 @@ async fn ct_deposit() {
         )
         .await;
 
-    let new_decryptable_available_balance = alice_meta.ae_key.encrypt(42_u64);
+    let new_decryptable_available_balance = alice_meta.ae_key.encrypt(65537_u64);
     token
         .confidential_transfer_apply_pending_balance(
             &alice_meta.token_account,
@@ -546,18 +546,6 @@ async fn ct_deposit() {
     assert_eq!(extension.pending_balance_credit_counter, 1.into());
     assert_eq!(extension.expected_pending_balance_credit_counter, 1.into());
     assert_eq!(extension.actual_pending_balance_credit_counter, 1.into());
-
-    alice_meta
-        .check_balances(
-            &token,
-            ConfidentialTokenAccountBalances {
-                pending_balance_lo: 0,
-                pending_balance_hi: 0,
-                available_balance: 42,
-                decryptable_available_balance: 42,
-            },
-        )
-        .await;
 }
 
 #[tokio::test]

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -172,10 +172,17 @@ impl ConfidentialTokenAccountMeta {
 
         assert_eq!(
             extension
-                .pending_balance
+                .pending_balance_lo
                 .decrypt(&self.elgamal_keypair.secret)
                 .unwrap(),
-            expected.pending_balance,
+            expected.pending_balance_lo,
+        );
+        assert_eq!(
+            extension
+                .pending_balance_hi
+                .decrypt(&self.elgamal_keypair.secret)
+                .unwrap(),
+            expected.pending_balance_hi,
         );
         assert_eq!(
             extension
@@ -194,7 +201,8 @@ impl ConfidentialTokenAccountMeta {
 }
 
 struct ConfidentialTokenAccountBalances {
-    pending_balance: u64,
+    pending_balance_lo: u64,
+    pending_balance_hi: u64,
     available_balance: u64,
     decryptable_available_balance: u64,
 }
@@ -465,7 +473,11 @@ async fn ct_deposit() {
     assert_eq!(extension.expected_pending_balance_credit_counter, 0.into());
     assert_eq!(extension.actual_pending_balance_credit_counter, 0.into());
     assert_eq!(
-        extension.pending_balance,
+        extension.pending_balance_lo,
+        zk_token_elgamal::pod::ElGamalCiphertext::zeroed()
+    );
+    assert_eq!(
+        extension.pending_balance_hi,
         zk_token_elgamal::pod::ElGamalCiphertext::zeroed()
     );
     assert_eq!(
@@ -500,7 +512,8 @@ async fn ct_deposit() {
         .check_balances(
             &token,
             ConfidentialTokenAccountBalances {
-                pending_balance: 42,
+                pending_balance_lo: 42,
+                pending_balance_hi: 0,
                 available_balance: 0,
                 decryptable_available_balance: 0,
             },
@@ -537,7 +550,8 @@ async fn ct_deposit() {
         .check_balances(
             &token,
             ConfidentialTokenAccountBalances {
-                pending_balance: 0,
+                pending_balance_lo: 0,
+                pending_balance_hi: 0,
                 available_balance: 42,
                 decryptable_available_balance: 42,
             },
@@ -599,7 +613,8 @@ async fn ct_withdraw() {
         .check_balances(
             &token,
             ConfidentialTokenAccountBalances {
-                pending_balance: 0,
+                pending_balance_lo: 0,
+                pending_balance_hi: 0,
                 available_balance: 21,
                 decryptable_available_balance: 21,
             },
@@ -630,7 +645,8 @@ async fn ct_withdraw() {
         .check_balances(
             &token,
             ConfidentialTokenAccountBalances {
-                pending_balance: 0,
+                pending_balance_lo: 0,
+                pending_balance_hi: 0,
                 available_balance: 0,
                 decryptable_available_balance: 0,
             },
@@ -690,7 +706,8 @@ async fn ct_transfer() {
         .check_balances(
             &token,
             ConfidentialTokenAccountBalances {
-                pending_balance: 0,
+                pending_balance_lo: 0,
+                pending_balance_hi: 0,
                 available_balance: 42,
                 decryptable_available_balance: 42,
             },
@@ -715,7 +732,8 @@ async fn ct_transfer() {
         .check_balances(
             &token,
             ConfidentialTokenAccountBalances {
-                pending_balance: 42,
+                pending_balance_lo: 42,
+                pending_balance_hi: 0,
                 available_balance: 0,
                 decryptable_available_balance: 0,
             },
@@ -736,7 +754,8 @@ async fn ct_transfer() {
         .check_balances(
             &token,
             ConfidentialTokenAccountBalances {
-                pending_balance: 0,
+                pending_balance_lo: 0,
+                pending_balance_hi: 0,
                 available_balance: 42,
                 decryptable_available_balance: 42,
             },
@@ -760,7 +779,8 @@ async fn ct_transfer() {
         .check_balances(
             &token,
             ConfidentialTokenAccountBalances {
-                pending_balance: 0,
+                pending_balance_lo: 0,
+                pending_balance_hi: 0,
                 available_balance: 0,
                 decryptable_available_balance: 0,
             },
@@ -888,7 +908,8 @@ async fn ct_transfer_with_fee() {
         .check_balances(
             &token,
             ConfidentialTokenAccountBalances {
-                pending_balance: 0,
+                pending_balance_lo: 0,
+                pending_balance_hi: 0,
                 available_balance: 100,
                 decryptable_available_balance: 100,
             },
@@ -914,7 +935,8 @@ async fn ct_transfer_with_fee() {
         .check_balances(
             &token,
             ConfidentialTokenAccountBalances {
-                pending_balance: 100,
+                pending_balance_lo: 100,
+                pending_balance_hi: 0,
                 available_balance: 0,
                 decryptable_available_balance: 0,
             },
@@ -935,7 +957,8 @@ async fn ct_transfer_with_fee() {
         .check_balances(
             &token,
             ConfidentialTokenAccountBalances {
-                pending_balance: 0,
+                pending_balance_lo: 0,
+                pending_balance_hi: 0,
                 available_balance: 100,
                 decryptable_available_balance: 100,
             },
@@ -960,7 +983,8 @@ async fn ct_transfer_with_fee() {
         .check_balances(
             &token,
             ConfidentialTokenAccountBalances {
-                pending_balance: 0,
+                pending_balance_lo: 0,
+                pending_balance_hi: 0,
                 available_balance: 0,
                 decryptable_available_balance: 0,
             },
@@ -1103,7 +1127,8 @@ async fn ct_withdraw_withheld_tokens_from_mint() {
         .check_balances(
             &token,
             ConfidentialTokenAccountBalances {
-                pending_balance: 0,
+                pending_balance_lo: 0,
+                pending_balance_hi: 0,
                 available_balance: 100,
                 decryptable_available_balance: 100,
             },
@@ -1173,7 +1198,8 @@ async fn ct_withdraw_withheld_tokens_from_mint() {
         .check_balances(
             &token,
             ConfidentialTokenAccountBalances {
-                pending_balance: 3,
+                pending_balance_lo: 3,
+                pending_balance_hi: 0,
                 available_balance: 0,
                 decryptable_available_balance: 0,
             },

--- a/token/program-2022/src/error.rs
+++ b/token/program-2022/src/error.rs
@@ -145,6 +145,13 @@ pub enum TokenError {
     /// Non-transferable tokens can't be minted to an account without immutable ownership
     #[error("Non-transferable tokens can't be minted to an account without immutable ownership")]
     NonTransferableNeedsImmutableOwnership,
+    /// The total number of `Deposit` and `Transfer` instructions to an account cannot exceed the
+    /// associated `maximum_pending_balance_credit_counter`
+    #[error(
+        "The total number of `Deposit` and `Transfer` instructions to an account cannot exceed
+            the associated `maximum_pending_balance_credit_counter`"
+    )]
+    MaximumPendingBalanceCreditCounterExceeded,
 }
 impl From<TokenError> for ProgramError {
     fn from(e: TokenError) -> Self {

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -379,6 +379,9 @@ pub struct ConfigureAccountInstructionData {
     pub encryption_pubkey: EncryptionPubkey,
     /// The decryptable balance (always 0) once the configure account succeeds
     pub decryptable_zero_balance: DecryptableBalance,
+    /// The maximum number of despots and transfers that an account can receiver before the
+    /// `ApplyPendingBalance` is executed
+    pub maximum_pending_balance_credit_counter: PodU64,
 }
 
 /// Data expected by `ConfidentialTransferInstruction::EmptyAccount`
@@ -511,6 +514,7 @@ pub fn update_mint(
 }
 
 /// Create a `ConfigureAccount` instruction
+#[allow(clippy::too_many_arguments)]
 #[cfg(not(target_os = "solana"))]
 pub fn configure_account(
     token_program_id: &Pubkey,
@@ -518,6 +522,7 @@ pub fn configure_account(
     mint: &Pubkey,
     encryption_pubkey: EncryptionPubkey,
     decryptable_zero_balance: AeCiphertext,
+    maximum_pending_balance_credit_counter: u64,
     authority: &Pubkey,
     multisig_signers: &[&Pubkey],
 ) -> Result<Instruction, ProgramError> {
@@ -540,6 +545,7 @@ pub fn configure_account(
         &ConfigureAccountInstructionData {
             encryption_pubkey,
             decryptable_zero_balance: decryptable_zero_balance.into(),
+            maximum_pending_balance_credit_counter: maximum_pending_balance_credit_counter.into(),
         },
     ))
 }

--- a/token/program-2022/src/extension/confidential_transfer/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer/mod.rs
@@ -9,6 +9,11 @@ use {
     solana_zk_token_sdk::zk_token_elgamal::pod,
 };
 
+/// Maximum bit length of any deposit transfer amount
+///
+/// Any deposit or transfer amount must be less than 2^48
+pub const MAXIMUM_DEPOSIT_TRANSFER_AMOUNT_BIT_LENGTH: usize = 48;
+
 const PENDING_BALANCE_LO_BIT_LENGTH: usize = 16;
 const PENDING_BALANCE_HI_BIT_LENGTH: usize = 48;
 

--- a/token/program-2022/src/extension/confidential_transfer/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer/mod.rs
@@ -9,7 +9,7 @@ use {
     solana_zk_token_sdk::zk_token_elgamal::pod,
 };
 
-/// Maximum bit length of any deposit transfer amount
+/// Maximum bit length of any deposit or transfer amount
 ///
 /// Any deposit or transfer amount must be less than 2^48
 pub const MAXIMUM_DEPOSIT_TRANSFER_AMOUNT_BIT_LENGTH: usize = 48;

--- a/token/program-2022/src/extension/confidential_transfer/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer/mod.rs
@@ -91,14 +91,20 @@ pub struct ConfidentialTransferAccount {
     /// `pending_balance` may only be credited by `Deposit` or `Transfer` instructions if `true`
     pub allow_balance_credits: PodBool,
 
-    /// The total number of `Deposit` and `Transfer` instructions that have credited `pending_balance`
+    /// The total number of `Deposit` and `Transfer` instructions that have credited
+    /// `pending_balance`
     pub pending_balance_credit_counter: PodU64,
+
+    /// The maximum number of `Deposit` and `Transfer` instructions that can credit
+    /// `pending_balance` before the `ApplyPendingBalance` instruction is executed
+    pub maximum_pending_balance_credit_counter: PodU64,
 
     /// The `expected_pending_balance_credit_counter` value that was included in the last
     /// `ApplyPendingBalance` instruction
     pub expected_pending_balance_credit_counter: PodU64,
 
-    /// The actual `pending_balance_credit_counter` when the last `ApplyPendingBalance` instruction was executed
+    /// The actual `pending_balance_credit_counter` when the last `ApplyPendingBalance` instruction
+    /// was executed
     pub actual_pending_balance_credit_counter: PodU64,
 
     /// The withheld amount of fees. This will always be zero if fees are never enabled.

--- a/token/program-2022/src/extension/confidential_transfer/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer/mod.rs
@@ -9,6 +9,9 @@ use {
     solana_zk_token_sdk::zk_token_elgamal::pod,
 };
 
+const PENDING_BALANCE_LO_BIT_LENGTH: usize = 16;
+const PENDING_BALANCE_HI_BIT_LENGTH: usize = 48;
+
 /// Confidential Transfer Extension instructions
 pub mod instruction;
 

--- a/token/program-2022/src/extension/confidential_transfer/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer/mod.rs
@@ -79,8 +79,11 @@ pub struct ConfidentialTransferAccount {
     /// The public key associated with ElGamal encryption
     pub encryption_pubkey: EncryptionPubkey,
 
-    /// The pending balance (encrypted by `encryption_pubkey`)
-    pub pending_balance: EncryptedBalance,
+    /// The low 16 bits of the pending balance (encrypted by `encryption_pubkey`)
+    pub pending_balance_lo: EncryptedBalance,
+
+    /// The high 48 bits of the pending balance (encrypted by `encryption_pubkey`)
+    pub pending_balance_hi: EncryptedBalance,
 
     /// The available balance (encrypted by `encrypiton_pubkey`)
     pub available_balance: EncryptedBalance,
@@ -127,7 +130,8 @@ impl ConfidentialTransferAccount {
 
     /// Check if a `ConfidentialTransferAccount` is in a closable state
     pub fn closable(&self) -> ProgramResult {
-        if self.pending_balance == EncryptedBalance::zeroed()
+        if self.pending_balance_lo == EncryptedBalance::zeroed()
+            && self.pending_balance_hi == EncryptedBalance::zeroed()
             && self.available_balance == EncryptedBalance::zeroed()
             && self.withheld_amount == EncryptedWithheldAmount::zeroed()
         {

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -340,7 +340,9 @@ fn process_deposit(
         }
 
         if u64::from(destination_confidential_transfer_account.pending_balance_credit_counter)
-            >= u64::from(destination_confidential_transfer_account.maximum_pending_balance_credit_counter)
+            >= u64::from(
+                destination_confidential_transfer_account.maximum_pending_balance_credit_counter,
+            )
         {
             return Err(TokenError::MaximumPendingBalanceCreditCounterExceeded.into());
         }
@@ -724,7 +726,9 @@ fn process_destination_for_transfer(
     }
 
     if u64::from(destination_confidential_transfer_account.pending_balance_credit_counter)
-        >= u64::from(destination_confidential_transfer_account.maximum_pending_balance_credit_counter)
+        >= u64::from(
+            destination_confidential_transfer_account.maximum_pending_balance_credit_counter,
+        )
     {
         return Err(TokenError::MaximumPendingBalanceCreditCounterExceeded.into());
     }

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -339,8 +339,8 @@ fn process_deposit(
             return Err(TokenError::ConfidentialTransferDepositsAndTransfersDisabled.into());
         }
 
-        if destination_confidential_transfer_account.pending_balance_credit_counter
-            == destination_confidential_transfer_account.maximum_pending_balance_credit_counter
+        if u64::from(destination_confidential_transfer_account.pending_balance_credit_counter)
+            >= u64::from(destination_confidential_transfer_account.maximum_pending_balance_credit_counter)
         {
             return Err(TokenError::MaximumPendingBalanceCreditCounterExceeded.into());
         }
@@ -723,8 +723,8 @@ fn process_destination_for_transfer(
         return Err(TokenError::ConfidentialTransferElGamalPubkeyMismatch.into());
     }
 
-    if destination_confidential_transfer_account.pending_balance_credit_counter
-        == destination_confidential_transfer_account.maximum_pending_balance_credit_counter
+    if u64::from(destination_confidential_transfer_account.pending_balance_credit_counter)
+        >= u64::from(destination_confidential_transfer_account.maximum_pending_balance_credit_counter)
     {
         return Err(TokenError::MaximumPendingBalanceCreditCounterExceeded.into());
     }

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -832,6 +832,7 @@ fn process_apply_pending_balance(
         *expected_pending_balance_credit_counter;
     confidential_transfer_account.decryptable_available_balance =
         *new_decryptable_available_balance;
+    confidential_transfer_account.pending_balance_credit_counter = 0.into();
     confidential_transfer_account.pending_balance_lo = EncryptedBalance::zeroed();
     confidential_transfer_account.pending_balance_hi = EncryptedBalance::zeroed();
 

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -160,7 +160,8 @@ fn process_configure_account(
 
         This should just be encoded as [0; 64]
     */
-    confidential_transfer_account.pending_balance = EncryptedBalance::zeroed();
+    confidential_transfer_account.pending_balance_lo = EncryptedBalance::zeroed();
+    confidential_transfer_account.pending_balance_hi = EncryptedBalance::zeroed();
     confidential_transfer_account.available_balance = EncryptedBalance::zeroed();
 
     confidential_transfer_account.decryptable_available_balance = *decryptable_zero_balance;
@@ -233,7 +234,12 @@ fn process_empty_account(
         &previous_instruction,
     )?;
 
-    if confidential_transfer_account.pending_balance != EncryptedBalance::zeroed() {
+    if confidential_transfer_account.pending_balance_lo != EncryptedBalance::zeroed() {
+        msg!("Pending balance is not zero");
+        return Err(ProgramError::InvalidAccountData);
+    }
+
+    if confidential_transfer_account.pending_balance_hi != EncryptedBalance::zeroed() {
         msg!("Pending balance is not zero");
         return Err(ProgramError::InvalidAccountData);
     }
@@ -339,9 +345,15 @@ fn process_deposit(
             return Err(TokenError::MaximumPendingBalanceCreditCounterExceeded.into());
         }
 
-        destination_confidential_transfer_account.pending_balance = ops::add_to(
-            &destination_confidential_transfer_account.pending_balance,
-            amount,
+        destination_confidential_transfer_account.pending_balance_lo = ops::add_to(
+            &destination_confidential_transfer_account.pending_balance_lo,
+            amount << 48 >> 48,
+        )
+        .ok_or(ProgramError::InvalidInstructionData)?;
+
+        destination_confidential_transfer_account.pending_balance_hi = ops::add_to(
+            &destination_confidential_transfer_account.pending_balance_lo,
+            amount >> 16,
         )
         .ok_or(ProgramError::InvalidInstructionData)?;
 
@@ -715,9 +727,14 @@ fn process_destination_for_transfer(
         return Err(TokenError::MaximumPendingBalanceCreditCounterExceeded.into());
     }
 
-    let new_destination_pending_balance = ops::add_with_lo_hi(
-        &destination_confidential_transfer_account.pending_balance,
+    let new_destination_pending_balance_lo = ops::add(
+        &destination_confidential_transfer_account.pending_balance_lo,
         destination_ciphertext_lo,
+    )
+    .ok_or(ProgramError::InvalidInstructionData)?;
+
+    let new_destination_pending_balance_hi = ops::add(
+        &destination_confidential_transfer_account.pending_balance_hi,
         destination_ciphertext_hi,
     )
     .ok_or(ProgramError::InvalidInstructionData)?;
@@ -726,7 +743,8 @@ fn process_destination_for_transfer(
         (u64::from(destination_confidential_transfer_account.pending_balance_credit_counter) + 1)
             .into();
 
-    destination_confidential_transfer_account.pending_balance = new_destination_pending_balance;
+    destination_confidential_transfer_account.pending_balance_lo = new_destination_pending_balance_lo;
+    destination_confidential_transfer_account.pending_balance_hi = new_destination_pending_balance_hi;
     destination_confidential_transfer_account.pending_balance_credit_counter =
         new_destination_pending_balance_credit_counter;
 
@@ -742,7 +760,7 @@ fn process_destination_for_transfer(
 
         // subtract fee from destination pending balance
         let new_destination_pending_balance = ops::subtract(
-            &destination_confidential_transfer_account.pending_balance,
+            &destination_confidential_transfer_account.pending_balance_lo,
             &ciphertext_fee_destination,
         )
         .ok_or(ProgramError::InvalidInstructionData)?;
@@ -754,7 +772,7 @@ fn process_destination_for_transfer(
         )
         .ok_or(ProgramError::InvalidInstructionData)?;
 
-        destination_confidential_transfer_account.pending_balance = new_destination_pending_balance;
+        destination_confidential_transfer_account.pending_balance_lo = new_destination_pending_balance;
         destination_confidential_transfer_account.withheld_amount = new_withheld_amount;
     }
 
@@ -791,9 +809,10 @@ fn process_apply_pending_balance(
     let mut confidential_transfer_account =
         token_account.get_extension_mut::<ConfidentialTransferAccount>()?;
 
-    confidential_transfer_account.available_balance = ops::add(
+    confidential_transfer_account.available_balance = ops::add_with_lo_hi(
         &confidential_transfer_account.available_balance,
-        &confidential_transfer_account.pending_balance,
+        &confidential_transfer_account.pending_balance_lo,
+        &confidential_transfer_account.pending_balance_hi,
     )
     .ok_or(ProgramError::InvalidInstructionData)?;
 
@@ -803,7 +822,8 @@ fn process_apply_pending_balance(
         *expected_pending_balance_credit_counter;
     confidential_transfer_account.decryptable_available_balance =
         *new_decryptable_available_balance;
-    confidential_transfer_account.pending_balance = EncryptedBalance::zeroed();
+    confidential_transfer_account.pending_balance_lo = EncryptedBalance::zeroed();
+    confidential_transfer_account.pending_balance_hi = EncryptedBalance::zeroed();
 
     Ok(())
 }
@@ -916,12 +936,12 @@ fn process_withdraw_withheld_tokens_from_mint(
     // The proof data contains the mint withheld amount encrypted under the destination ElGamal pubkey.
     // This amount should be added to the destination pending balance.
     let new_destination_pending_balance = ops::add(
-        &destination_confidential_transfer_account.pending_balance,
+        &destination_confidential_transfer_account.pending_balance_lo,
         &proof_data.destination_ciphertext,
     )
     .ok_or(ProgramError::InvalidInstructionData)?;
 
-    destination_confidential_transfer_account.pending_balance = new_destination_pending_balance;
+    destination_confidential_transfer_account.pending_balance_lo = new_destination_pending_balance;
 
     // fee is now withdrawn, so zero out mint withheld amount
     confidential_transfer_mint.withheld_amount = EncryptedWithheldAmount::zeroed();
@@ -1036,12 +1056,12 @@ fn process_withdraw_withheld_tokens_from_accounts(
 
     // add the sum of the withheld fees to destination pending balance
     let new_destination_pending_balance = ops::add(
-        &destination_confidential_transfer_account.pending_balance,
+        &destination_confidential_transfer_account.pending_balance_lo,
         &aggregate_withheld_amount,
     )
     .ok_or(ProgramError::InvalidInstructionData)?;
 
-    destination_confidential_transfer_account.pending_balance = new_destination_pending_balance;
+    destination_confidential_transfer_account.pending_balance_lo = new_destination_pending_balance;
 
     Ok(())
 }

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -145,8 +145,9 @@ fn process_configure_account(
         - r: encryption randomness (Scalar)
         - x: message (Scalar)
 
-        Upon receiving a `ConfigureAccount` instruction, the ZK Token program should encrypt x=0 (i.e.
-        Scalar::zero()) and store it as `pending_balance` and `available_balance`.
+        Upon receiving a `ConfigureAccount` instruction, the ZK Token program should encrypt x=0
+        (i.e. Scalar::zero()) and store it as `pending_balance_lo`, `pending_balance_hi`, and
+        `available_balance`.
 
         For regular encryption, it is important that r is generated from a proper randomness source. But
         for the `ConfigureAccount` instruction, it is already known that x is always 0. So r can just be

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -340,7 +340,7 @@ fn process_deposit(
         }
 
         if u64::from(destination_confidential_transfer_account.pending_balance_credit_counter)
-            >= u64::from(
+            > u64::from(
                 destination_confidential_transfer_account.maximum_pending_balance_credit_counter,
             )
         {

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -727,7 +727,7 @@ fn process_destination_for_transfer(
     }
 
     if u64::from(destination_confidential_transfer_account.pending_balance_credit_counter)
-        >= u64::from(
+        > u64::from(
             destination_confidential_transfer_account.maximum_pending_balance_credit_counter,
         )
     {

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -1487,6 +1487,9 @@ impl PrintProgramError for TokenError {
             TokenError::NonTransferableNeedsImmutableOwnership => {
                 msg!("Non-transferable tokens can't be minted to an account without immutable ownership");
             }
+            TokenError::MaximumPendingBalanceCreditCounterExceeded => {
+                msg!("The total number of `Deposit` and `Transfer` instructions to an account cannot exceed the associated `maximum_pending_balance_credit_counter`");
+            }
         }
     }
 }


### PR DESCRIPTION
Decrypting ElGamal ciphertexts that encrypt large numbers (> 2^32) is computationally very expensive. When a confidential transfer extended account receives incoming transfers of large amounts that are accumulated into the `pending_balance` ciphertext, then it may become very expensive for users to decrypt and recover the exact amount of tokens that is held as `pending_balance`. 

To cope with this, a confidential transfer instruction is structured such that the transfer amount (a 64-bit number) is encrypted as two ciphertexts: a `lo` ciphertext that encrypts the low 32-bits of the transfer amount and a `hi` ciphertext that encrypts the high 32-bits. Since each of the `lo` and `hi` ciphertexts encrypt 32-bit numbers, they can be efficiently decrypted. Then to recover an amount that is held in the `pending_balance` ciphertext in an account, users can look up the relevant incoming transactions data, decrypt the `lo` and `hi` ciphertexts, and then update the account data (i.e. `decryptable_ciphertext`). Although this solution could be made to work, searching for and decrypting each of the relevant incoming transfer data is cumbersome and difficult to work with on the client. 

An alternative approach is to break up the `pending_balance` into two ciphertexts:
- `pending_balance_lo` that encrypts the low 32-bits of the pending balance
- `pending_balance_hi` that encrypts the high 32-bits of the pending balance
As long as these pending balance ciphertexts are guaranteed to encrypt 32-bit values, users can easily look up and decrypt the pending balance from accounts.

The main problem with having two pending balance ciphertexts is that they can overflow. If an account receives a large number of incoming transactions, then the amount that `pending_balance_lo` encrypts could grow to be larger than a 32-bit number, in which case, the ciphertext becomes hard to decrypt.

One way to cope with the overflow problem is to introduce the following changes:
1. Introduce a 2^48 [upper bound](https://github.com/solana-labs/solana-program-library/pull/3208/files#diff-56624b0356d2f9104ef0926d6f8e00090a52ba82e0c1da2ed376d3b69da05e67R15) on the transfer amount for a confidential transfer.
2. Introduce an [upper bound](https://github.com/solana-labs/solana-program-library/pull/3208/files#diff-56624b0356d2f9104ef0926d6f8e00090a52ba82e0c1da2ed376d3b69da05e67R111) (e.g. 2^16) on the number of incoming transfers that a single account can accept. Any additional incoming transfers or deposits to an account are rejected before the owner of the account submits an `ApplyPendingBalance`.

With a 2^48 upper bound, a transfer amount must be encrypted as two ciphertexts in a transfer instruction such that:
- the `lo` ciphertext encrypts the low 16-bits of the transfer amount
- the `hi` ciphertext encrypts the high 32-bits of the transfer amount
and similarly, `pending_balance_lo` and `pending_balance_hi` ciphertexts encrypt 16 and 32 bit amounts respectively.

With an upper bound of 2^16 incoming transfers to an account, the `pending_balance_lo` will overflow to  at most 2^32, which is still efficiently decryptable. `pending_balance_hi` can also overflow to encrypt numbers larger up to 2^48. However, for overflows to occur in `pending_balance_hi`, an account must receive a high volume of large transactions. Users that expect large transactions can either submit `ApplyPendingBalance` more often to flush out pending balance ciphertexts or they can maintain multiple accounts to divide up the load in receiving large transactions. Furthermore, with enough time and/or hardware, moderate amounts of overflows (encrypted amount <2^42) in `pending_balance_hi` can still be decrypted. Users that typically deal with high volume of large transactions may have access to more advanced hardware.