### PR TITLE
Governance: Do not allow relinquishing votes in Finalising state

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -1,4 +1,4 @@
-anchor_version = "0.20.1"
+anchor_version = "0.24.2"
 solana_version = "1.10.15"
 
 [workspace]

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -1,4 +1,4 @@
-anchor_version = "0.24.2"
+anchor_version = "0.20.1"
 solana_version = "1.10.15"
 
 [workspace]

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -401,6 +401,10 @@ pub enum GovernanceError {
     /// Reserved buffer must be empty
     #[error("Reserved buffer must be empty")]
     ReservedBufferMustBeEmpty,
+
+    /// Cannot Relinquish in Voting state
+    #[error("Cannot Relinquish in Voting state")]
+    CannotRelinquishInVotingState,
 }
 
 impl PrintProgramError for GovernanceError {

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -402,9 +402,9 @@ pub enum GovernanceError {
     #[error("Reserved buffer must be empty")]
     ReservedBufferMustBeEmpty,
 
-    /// Cannot Relinquish in Voting state
-    #[error("Cannot Relinquish in Voting state")]
-    CannotRelinquishInVotingState,
+    /// Cannot Relinquish in Finalizing state
+    #[error("Cannot Relinquish in Finalizing state")]
+    CannotRelinquishInFinalizingState,
 }
 
 impl PrintProgramError for GovernanceError {

--- a/governance/program/src/processor/process_relinquish_vote.rs
+++ b/governance/program/src/processor/process_relinquish_vote.rs
@@ -116,8 +116,10 @@ pub fn process_relinquish_vote(program_id: &Pubkey, accounts: &[AccountInfo]) ->
             .checked_sub(1)
             .unwrap();
     } else {
+        // After Proposal voting time ends and it's not tipped then it enters implicit (time based) Finalizing state
+        // and relinquishing votes in this state should be disallowed
         if proposal_data.state == ProposalState::Voting {
-            return Err(GovernanceError::CannotRelinquishInVotingState.into());
+            return Err(GovernanceError::CannotRelinquishInFinalizingState.into());
         }
 
         vote_record_data.is_relinquished = true;

--- a/governance/program/src/processor/process_relinquish_vote.rs
+++ b/governance/program/src/processor/process_relinquish_vote.rs
@@ -66,7 +66,7 @@ pub fn process_relinquish_vote(program_id: &Pubkey, accounts: &[AccountInfo]) ->
 
     // If the Proposal is still being voted on then the token owner vote will be withdrawn and it won't count towards the vote outcome
     // Note: If there is no tipping point the proposal can be still in Voting state but already past the configured max_voting_time
-    //       It means it awaits manual finalization (FinalizeVote) and it should no longer be possible to withdraw the vote and we only release the tokens
+    //       It means it awaits manual finalization (FinalizeVote) and it should no longer be possible to withdraw the vote
     if proposal_data.state == ProposalState::Voting
         && !proposal_data.has_vote_time_ended(&governance_data.config, clock.unix_timestamp)
     {
@@ -117,7 +117,8 @@ pub fn process_relinquish_vote(program_id: &Pubkey, accounts: &[AccountInfo]) ->
             .unwrap();
     } else {
         // After Proposal voting time ends and it's not tipped then it enters implicit (time based) Finalizing state
-        // and relinquishing votes in this state should be disallowed
+        // and releasing tokens in this state should be disallowed
+        // In other words releasing tokens is only possible once Proposal is manually finalized using FinalizeVote
         if proposal_data.state == ProposalState::Voting {
             return Err(GovernanceError::CannotRelinquishInFinalizingState.into());
         }

--- a/governance/program/src/processor/process_relinquish_vote.rs
+++ b/governance/program/src/processor/process_relinquish_vote.rs
@@ -116,6 +116,10 @@ pub fn process_relinquish_vote(program_id: &Pubkey, accounts: &[AccountInfo]) ->
             .checked_sub(1)
             .unwrap();
     } else {
+        if proposal_data.state == ProposalState::Voting {
+            return Err(GovernanceError::CannotRelinquishInVotingState.into());
+        }
+
         vote_record_data.is_relinquished = true;
         vote_record_data.serialize(&mut *vote_record_info.data.borrow_mut())?;
     }

--- a/governance/program/tests/process_relinquish_vote.rs
+++ b/governance/program/tests/process_relinquish_vote.rs
@@ -447,7 +447,7 @@ async fn test_relinquish_vote_with_already_relinquished_error() {
 }
 
 #[tokio::test]
-async fn test_relinquish_proposal_in_voting_state_after_vote_time_ended() {
+async fn test_relinquish_proposal_in_voting_state_after_vote_time_ended_error() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
@@ -481,7 +481,7 @@ async fn test_relinquish_proposal_in_voting_state_after_vote_time_ended() {
 
     let clock = governance_test.bench.get_clock().await;
 
-    let mut vote_record_cookie = governance_test
+    governance_test
         .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
@@ -494,32 +494,13 @@ async fn test_relinquish_proposal_in_voting_state_after_vote_time_ended() {
         .await;
 
     // Act
-    governance_test
+    let err = governance_test
         .relinquish_vote(&proposal_cookie, &token_owner_record_cookie)
         .await
+        .err()
         .unwrap();
 
     // Assert
 
-    let proposal_account = governance_test
-        .get_proposal_account(&proposal_cookie.address)
-        .await;
-
-    // Proposal should be still in voting state but the vote count should not change
-    assert_eq!(100, proposal_account.options[0].vote_weight);
-    assert_eq!(ProposalState::Voting, proposal_account.state);
-
-    let token_owner_record = governance_test
-        .get_token_owner_record_account(&token_owner_record_cookie.address)
-        .await;
-
-    assert_eq!(0, token_owner_record.unrelinquished_votes_count);
-    assert_eq!(1, token_owner_record.total_votes_count);
-
-    let vote_record_account = governance_test
-        .get_vote_record_account(&vote_record_cookie.address)
-        .await;
-
-    vote_record_cookie.account.is_relinquished = true;
-    assert_eq!(vote_record_cookie.account, vote_record_account);
+    assert_eq!(err, GovernanceError::CannotRelinquishInVotingState.into());
 }

--- a/governance/program/tests/process_relinquish_vote.rs
+++ b/governance/program/tests/process_relinquish_vote.rs
@@ -447,7 +447,7 @@ async fn test_relinquish_vote_with_already_relinquished_error() {
 }
 
 #[tokio::test]
-async fn test_relinquish_proposal_in_voting_state_after_vote_time_ended_error() {
+async fn test_relinquish_proposal_with_cannot_relinquish_in_finalizing_state_error() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
@@ -502,5 +502,8 @@ async fn test_relinquish_proposal_in_voting_state_after_vote_time_ended_error() 
 
     // Assert
 
-    assert_eq!(err, GovernanceError::CannotRelinquishInVotingState.into());
+    assert_eq!(
+        err,
+        GovernanceError::CannotRelinquishInFinalizingState.into()
+    );
 }


### PR DESCRIPTION
#### Summary 

Once voting time ends and `Proposal` vote is not tipped then it enters implicit `Finalising` state and must be manually transitioned to `Succeeded` or `Defeated` state. In that interim state relinquishing `VoteRecords` should be disallowed because it creates an inconsistent state, especially when the chain clock diverges. 

#### Solution
In order to prevent inconsistent state between `Proposal` and `VoteRecords` throw error when relinquishing votes in `Finalising` state 