### PR TITLE
token-2022: Remove `reallocate` and `sibling-instruction` features

### DIFF
--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -12,9 +12,7 @@ exclude = ["js/**"]
 no-entrypoint = []
 test-bpf = []
 # Remove these features once the underlying syscalls are released on all networks
-default = ["reallocate", "sibling-instruction", "zk-ops"]
-reallocate = []
-sibling-instruction = []
+default = ["zk-ops"]
 zk-ops = []
 
 [dependencies]

--- a/token/program-2022/src/extension/memo_transfer/mod.rs
+++ b/token/program-2022/src/extension/memo_transfer/mod.rs
@@ -1,18 +1,14 @@
 use {
     crate::{
+        error::TokenError,
         extension::{Extension, ExtensionType, StateWithExtensionsMut},
         pod::PodBool,
         state::Account,
     },
     bytemuck::{Pod, Zeroable},
-    solana_program::program_error::ProgramError,
-};
-
-// Remove feature once sibling instruction syscall is available on all networks
-#[cfg(feature = "sibling-instruction")]
-use {
-    crate::error::TokenError,
-    solana_program::{instruction::get_processed_sibling_instruction, pubkey::Pubkey},
+    solana_program::{
+        instruction::get_processed_sibling_instruction, program_error::ProgramError, pubkey::Pubkey,
+    },
 };
 
 /// Memo Transfer extension instructions
@@ -42,17 +38,14 @@ pub fn memo_required(account_state: &StateWithExtensionsMut<Account>) -> bool {
 
 /// Check if the previous sibling instruction is a memo
 pub fn check_previous_sibling_instruction_is_memo() -> Result<(), ProgramError> {
-    #[cfg(feature = "sibling-instruction")]
-    {
-        let is_memo_program = |program_id: &Pubkey| -> bool {
-            program_id == &spl_memo::id() || program_id == &spl_memo::v1::id()
-        };
-        let previous_instruction = get_processed_sibling_instruction(0);
-        match previous_instruction {
-            Some(instruction) if is_memo_program(&instruction.program_id) => {}
-            _ => {
-                return Err(TokenError::NoMemo.into());
-            }
+    let is_memo_program = |program_id: &Pubkey| -> bool {
+        program_id == &spl_memo::id() || program_id == &spl_memo::v1::id()
+    };
+    let previous_instruction = get_processed_sibling_instruction(0);
+    match previous_instruction {
+        Some(instruction) if is_memo_program(&instruction.program_id) => {}
+        _ => {
+            return Err(TokenError::NoMemo.into());
         }
     }
     Ok(())

--- a/token/program-2022/src/extension/reallocate.rs
+++ b/token/program-2022/src/extension/reallocate.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "reallocate")]
 use {
     crate::{
         error::TokenError,
@@ -17,18 +16,7 @@ use {
     },
 };
 
-/// Stub implementation to remove when reallocate is released on all networks
-#[cfg(not(feature = "reallocate"))]
-pub fn process_reallocate(
-    _program_id: &solana_program::pubkey::Pubkey,
-    _accounts: &[solana_program::account_info::AccountInfo],
-    _new_extension_types: Vec<crate::extension::ExtensionType>,
-) -> solana_program::entrypoint::ProgramResult {
-    Err(solana_program::program_error::ProgramError::InvalidInstructionData)
-}
-
 /// Processes a [Reallocate](enum.TokenInstruction.html) instruction
-#[cfg(feature = "reallocate")]
 pub fn process_reallocate(
     program_id: &Pubkey,
     accounts: &[AccountInfo],


### PR DESCRIPTION
#### Problem

The reallocate and sibling instruction features were enabled on mainnet on epochs 310 and 311, respectively.  But token-2022 still has features for their usage.

#### Solution

Remove the features to prep for the next release.