### PR TITLE
feat: fix `solana airdrop` amount

### DIFF
--- a/token-lending/README.md
+++ b/token-lending/README.md
@@ -10,11 +10,11 @@ Web3 bindings are available in the `./js` directory.
 
 Please note that only the lending program deployed to devnet is currently operational.
 
-| Cluster      | Program Address                                                                                                                                    |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Mainnet Beta | [`LendZqTs8gn5CTSJU1jWKhKuVpjJGom45nnwPb2AMTi`](https://explorer.solana.com/address/LendZqTs7gn5CTSJU1jWKhKuVpjJGom45nnwPb2AMTi)                   |
-| Testnet      | [`6TvznH3B2e3p2mbhufNBpgSrLx6UkgvxtVQvopEZ2kuH`](https://explorer.solana.com/address/6TvznH3B2e3p2mbhufNBpgSrLx6UkgvxtVQvopEZ2kuH?cluster=testnet) |
-| Devnet       | [`6TvznH3B2e3p2mbhufNBpgSrLx6UkgvxtVQvopEZ2kuH`](https://explorer.solana.com/address/6TvznH3B2e3p2mbhufNBpgSrLx6UkgvxtVQvopEZ2kuH?cluster=devnet)  |
+| Cluster | Program Address |
+| --- | --- |
+| Mainnet Beta | [`LendZqTs8gn5CTSJU1jWKhKuVpjJGom45nnwPb2AMTi`](https://explorer.solana.com/address/LendZqTs7gn5CTSJU1jWKhKuVpjJGom45nnwPb2AMTi) |
+| Testnet | [`6TvznH3B2e3p2mbhufNBpgSrLx6UkgvxtVQvopEZ2kuH`](https://explorer.solana.com/address/6TvznH3B2e3p2mbhufNBpgSrLx6UkgvxtVQvopEZ2kuH?cluster=testnet) |
+| Devnet | [`6TvznH3B2e3p2mbhufNBpgSrLx6UkgvxtVQvopEZ2kuH`](https://explorer.solana.com/address/6TvznH3B2e3p2mbhufNBpgSrLx6UkgvxtVQvopEZ2kuH?cluster=devnet) |
 
 ### Documentation
 

--- a/token-lending/README.md
+++ b/token-lending/README.md
@@ -10,11 +10,11 @@ Web3 bindings are available in the `./js` directory.
 
 Please note that only the lending program deployed to devnet is currently operational.
 
-| Cluster | Program Address |
-| --- | --- |
-| Mainnet Beta | [`LendZqTs8gn5CTSJU1jWKhKuVpjJGom45nnwPb2AMTi`](https://explorer.solana.com/address/LendZqTs7gn5CTSJU1jWKhKuVpjJGom45nnwPb2AMTi) |
-| Testnet | [`6TvznH3B2e3p2mbhufNBpgSrLx6UkgvxtVQvopEZ2kuH`](https://explorer.solana.com/address/6TvznH3B2e3p2mbhufNBpgSrLx6UkgvxtVQvopEZ2kuH?cluster=testnet) |
-| Devnet | [`6TvznH3B2e3p2mbhufNBpgSrLx6UkgvxtVQvopEZ2kuH`](https://explorer.solana.com/address/6TvznH3B2e3p2mbhufNBpgSrLx6UkgvxtVQvopEZ2kuH?cluster=devnet) |
+| Cluster      | Program Address                                                                                                                                    |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Mainnet Beta | [`LendZqTs8gn5CTSJU1jWKhKuVpjJGom45nnwPb2AMTi`](https://explorer.solana.com/address/LendZqTs7gn5CTSJU1jWKhKuVpjJGom45nnwPb2AMTi)                   |
+| Testnet      | [`6TvznH3B2e3p2mbhufNBpgSrLx6UkgvxtVQvopEZ2kuH`](https://explorer.solana.com/address/6TvznH3B2e3p2mbhufNBpgSrLx6UkgvxtVQvopEZ2kuH?cluster=testnet) |
+| Devnet       | [`6TvznH3B2e3p2mbhufNBpgSrLx6UkgvxtVQvopEZ2kuH`](https://explorer.solana.com/address/6TvznH3B2e3p2mbhufNBpgSrLx6UkgvxtVQvopEZ2kuH?cluster=devnet)  |
 
 ### Documentation
 
@@ -90,9 +90,9 @@ This is optional! You can skip these steps and use the [Token Lending CLI](./cli
 
 1. Score yourself some sweet SOL:
    ```shell
-   solana airdrop -k owner.json 10
-   solana airdrop -k owner.json 10
-   solana airdrop -k owner.json 10
+   solana airdrop -k owner.json 2
+   solana airdrop -k owner.json 2
+   solana airdrop -k owner.json 2
    ```
    You'll use this for transaction fees, rent for your program accounts, and initial reserve liquidity. If you run
    into issues with the airdrop command, see the [docs](https://docs.solana.com/cli/transfer-tokens#airdrop-some-tokens-to-get-started) for more info.

--- a/token-lending/README.md
+++ b/token-lending/README.md
@@ -112,10 +112,10 @@ This is optional! You can skip these steps and use the [Token Lending CLI](./cli
    ```shell
    spl-token wrap \
       --fee-payer owner.json \
-      10.0 \
+      2.0 \
       -- owner.json
 
-   # Wrapping 10 SOL into AJ2sgpgj6ZeQazPPiDyTYqN9vbj58QMaZQykB9Sr6XY
+   # Wrapping 2 SOL into AJ2sgpgj6ZeQazPPiDyTYqN9vbj58QMaZQykB9Sr6XY
    ```
    You'll use this for initial reserve liquidity. Note the SPL Token account pubkey (e.g. `AJ2sgpgj6ZeQazPPiDyTYqN9vbj58QMaZQykB9Sr6XY`).
 


### PR DESCRIPTION
`solana airdrop` request is capped at 2 now, exceeding the cap will lead to failed transactions.

This is an updated PR from #3221.