### PR TITLE
token-swap: Prepare v3.0.0 release for testnet and devnet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5857,7 +5857,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-swap"
-version = "2.1.0"
+version = "3.0.0"
 dependencies = [
  "arbitrary",
  "arrayref",

--- a/docs/src/token-swap.md
+++ b/docs/src/token-swap.md
@@ -5,13 +5,23 @@ title: Token Swap Program
 A Uniswap-like exchange for the Token program on the Solana blockchain,
 implementing multiple automated market maker (AMM) curves.
 
-Here is some important developer information regarding the program deployed on devnet,
-testnet, and mainnet-beta:
+## Available Deployments
 
-| Information | Account Address |
-| --- | --- |
-| Token Swap Program | `SwaPpA9LAaLfeLi3a68M4DjnLqgtticKg6CnyNwgAC8` |
-| Fee Owner | `HfoTxFR1Tm6kGmWgYWD6J7YHVy1UwqSULUGVLXkJqaKN` |
+
+| Network | Version | Program Address | Fee Owner Address |
+| --- | --- | --- |
+| Devnet, Testnet | 3.0.0 | `SwapsVeCiPHMUAtzQWZw7RjsKjgCjhwU55QGu4U1Szw` | Any |
+| All | 2.0.0 | `SwaPpA9LAaLfeLi3a68M4DjnLqgtticKg6CnyNwgAC8` | `HfoTxFR1Tm6kGmWgYWD6J7YHVy1UwqSULUGVLXkJqaKN` |
+
+The Token Swap Program was deployed to all networks by the Serum team at
+`SwaPpA9LAaLfeLi3a68M4DjnLqgtticKg6CnyNwgAC8`, requiring a fee owner of
+`HfoTxFR1Tm6kGmWgYWD6J7YHVy1UwqSULUGVLXkJqaKN`, but that version was deprecated
+in the middle of 2021.  Though that program still exists, it is not actively
+maintained.
+
+For devnet and testnet, please use the maintainted deployment at
+`SwapsVeCiPHMUAtzQWZw7RjsKjgCjhwU55QGu4U1Szw`, and for mainnet, please use any
+other AMM project on Solana. Almost all of these were based on Token Swap!
 
 Check out
 [program repository](https://github.com/solana-labs/solana-program-library/tree/master/token-swap)

--- a/token-swap/README.md
+++ b/token-swap/README.md
@@ -1,13 +1,12 @@
 # Token Swap Program
 
-A Uniswap-like exchange for the Token program on the Solana blockchain, deployed
-to `SwaPpA9LAaLfeLi3a68M4DjnLqgtticKg6CnyNwgAC8` on all networks.
+A Uniswap-like exchange for the Token program on the Solana blockchain.
 
 Full documentation is available at https://spl.solana.com/token-swap
 
 JavaScript bindings are available in the `./js` directory.
 
-## Building
+## Building master
 
 To build a development version of the Token Swap program, you can use the normal
 build command for Solana programs:
@@ -16,10 +15,12 @@ build command for Solana programs:
 cargo build-bpf
 ```
 
-For production versions, the Token Swap Program contains a `production` feature
-to fix constraints on fees and fee account owner. A developer can
-deploy the program, allow others to create pools, and earn a "protocol fee" on
-all activity.
+## Building mainnet v2.0.0
+
+For the version deployed to `SwaPpA9LAaLfeLi3a68M4DjnLqgtticKg6CnyNwgAC8`,
+the Token Swap Program contains a `production` feature to fix constraints on fees
+and fee account owner. A developer can deploy the program, allow others to create
+pools, and earn a "protocol fee" on all activity.
 
 Since Solana programs cannot contain any modifiable state, we must hard-code
 all constraints into the program.  `SwapConstraints` in `program/src/constraints.rs`

--- a/token-swap/js/package-lock.json
+++ b/token-swap/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@solana/spl-token-swap",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@solana/spl-token-swap",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@solana/buffer-layout": "^4.0.0",

--- a/token-swap/js/package.json
+++ b/token-swap/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana/spl-token-swap",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "SPL Token Swap JavaScript API",
   "license": "MIT",
   "author": "Solana Maintainers <maintainers@solana.foundation>",
@@ -32,7 +32,7 @@
     "build": "tsc -p tsconfig.json && tsc-esm -p tsconfig.json && tsc -p tsconfig.cjs.json",
     "postbuild": "echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json && echo '{\"type\":\"module\"}' > dist/esm/package.json",
     "test": "ts-node test/main.ts",
-    "start-with-test-validator": "start-server-and-test 'solana-test-validator --bpf-program SwaPpA9LAaLfeLi3a68M4DjnLqgtticKg6CnyNwgAC8 ../../target/deploy/spl_token_swap.so --reset --quiet' http://localhost:8899/health test",
+    "start-with-test-validator": "start-server-and-test 'solana-test-validator --bpf-program SwapsVeCiPHMUAtzQWZw7RjsKjgCjhwU55QGu4U1Szw ../../target/deploy/spl_token_swap.so --reset --quiet' http://localhost:8899/health test",
     "lint": "npm run pretty && eslint .",
     "lint:fix": "npm run pretty:fix && eslint . --fix",
     "build:program": "cargo build-bpf --manifest-path ../program/Cargo.toml",

--- a/token-swap/js/src/index.ts
+++ b/token-swap/js/src/index.ts
@@ -20,6 +20,10 @@ import * as Layout from './layout';
 import {loadAccount} from './util/account';
 
 export const TOKEN_SWAP_PROGRAM_ID: PublicKey = new PublicKey(
+  'SwapsVeCiPHMUAtzQWZw7RjsKjgCjhwU55QGu4U1Szw',
+);
+
+export const OLD_TOKEN_SWAP_PROGRAM_ID: PublicKey = new PublicKey(
   'SwaPpA9LAaLfeLi3a68M4DjnLqgtticKg6CnyNwgAC8',
 );
 

--- a/token-swap/program/Cargo.toml
+++ b/token-swap/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-swap"
-version = "2.1.0"
+version = "3.0.0"
 description = "Solana Program Library Token Swap"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token-swap/program/program-id.md
+++ b/token-swap/program/program-id.md
@@ -1,1 +1,1 @@
-SwaPpA9LAaLfeLi3a68M4DjnLqgtticKg6CnyNwgAC8
+SwapsVeCiPHMUAtzQWZw7RjsKjgCjhwU55QGu4U1Szw

--- a/token-swap/program/src/lib.rs
+++ b/token-swap/program/src/lib.rs
@@ -15,4 +15,4 @@ mod entrypoint;
 // Export current sdk types for downstream users building with a different sdk version
 pub use solana_program;
 
-solana_program::declare_id!("SwaPpA9LAaLfeLi3a68M4DjnLqgtticKg6CnyNwgAC8");
+solana_program::declare_id!("SwapsVeCiPHMUAtzQWZw7RjsKjgCjhwU55QGu4U1Szw");


### PR DESCRIPTION
#### Problem

People still use token-swap v2 on all networks, but it's unmaintained.

#### Solution

Prepare and release token-swap v3, meant for education and testing on devnet and testnet.  There will never be a mainnet release of this program, to avoid cannibalizing other ecosystem projects.