### PR TITLE
Governance: Add test to assert flash loan attack is not possible

### DIFF
--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -97,38 +97,39 @@ pub enum GovernanceError {
 
     /// Invalid State: Can't edit Signatories
     #[error("Invalid State: Can't edit Signatories")]
-    InvalidStateCannotEditSignatories,
+    InvalidStateCannotEditSignatories, // 521
 
     /// Invalid Proposal state
     #[error("Invalid Proposal state")]
-    InvalidProposalState,
+    InvalidProposalState, // 522
+
     /// Invalid State: Can't edit transactions
     #[error("Invalid State: Can't edit transactions")]
-    InvalidStateCannotEditTransactions,
+    InvalidStateCannotEditTransactions, // 523
 
     /// Invalid State: Can't execute transaction
     #[error("Invalid State: Can't execute transaction")]
-    InvalidStateCannotExecuteTransaction,
+    InvalidStateCannotExecuteTransaction, // 524
 
     /// Can't execute transaction within its hold up time
     #[error("Can't execute transaction within its hold up time")]
-    CannotExecuteTransactionWithinHoldUpTime,
+    CannotExecuteTransactionWithinHoldUpTime, // 525
 
     /// Transaction already executed
     #[error("Transaction already executed")]
-    TransactionAlreadyExecuted,
+    TransactionAlreadyExecuted, // 526
 
     /// Invalid Transaction index
     #[error("Invalid Transaction index")]
-    InvalidTransactionIndex,
+    InvalidTransactionIndex, // 527
 
     /// Transaction hold up time is below the min specified by Governance
     #[error("Transaction hold up time is below the min specified by Governance")]
-    TransactionHoldUpTimeBelowRequiredMin,
+    TransactionHoldUpTimeBelowRequiredMin, // 528
 
     /// Transaction at the given index for the Proposal already exists
     #[error("Transaction at the given index for the Proposal already exists")]
-    TransactionAlreadyExists,
+    TransactionAlreadyExists, // 529
 
     /// Invalid State: Can't sign off
     #[error("Invalid State: Can't sign off")]

--- a/governance/program/tests/process_execute_transaction.rs
+++ b/governance/program/tests/process_execute_transaction.rs
@@ -54,6 +54,7 @@ async fn test_execute_mint_transaction() {
             &token_owner_record_cookie,
             0,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -384,6 +385,7 @@ async fn test_execute_proposal_transaction_with_invalid_state_errors() {
             &token_owner_record_cookie,
             0,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -543,6 +545,7 @@ async fn test_execute_proposal_transaction_for_other_proposal_error() {
             &token_owner_record_cookie,
             0,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -628,6 +631,7 @@ async fn test_execute_mint_transaction_twice_error() {
             &token_owner_record_cookie,
             0,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -670,4 +674,76 @@ async fn test_execute_mint_transaction_twice_error() {
 
     // Assert
     assert_eq!(err, GovernanceError::TransactionAlreadyExecuted.into());
+}
+
+#[tokio::test]
+async fn test_execute_transaction_with_create_proposal_and_execute_in_single_slot_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_mint_cookie = governance_test.with_governed_mint().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.min_transaction_hold_up_time = 0;
+
+    let mut mint_governance_cookie = governance_test
+        .with_mint_governance_using_config(
+            &realm_cookie,
+            &governed_mint_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut mint_governance_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie = governance_test
+        .with_mint_tokens_transaction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie,
+            0,
+            None,
+            Some(0),
+        )
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::CannotExecuteTransactionWithinHoldUpTime.into()
+    );
 }

--- a/governance/program/tests/process_flag_transaction_error.rs
+++ b/governance/program/tests/process_flag_transaction_error.rs
@@ -138,6 +138,7 @@ async fn test_execute_proposal_transaction_after_flagged_with_error() {
             &token_owner_record_cookie,
             0,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -234,6 +235,7 @@ async fn test_execute_second_transaction_after_first_transaction_flagged_with_er
             &token_owner_record_cookie,
             0,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -315,6 +317,7 @@ async fn test_flag_transaction_error_with_proposal_transaction_already_executed_
             &mut proposal_cookie,
             &token_owner_record_cookie,
             0,
+            None,
             None,
         )
         .await

--- a/governance/program/tests/process_set_governance_config.rs
+++ b/governance/program/tests/process_set_governance_config.rs
@@ -207,6 +207,7 @@ async fn test_set_governance_config_with_invalid_governance_authority_error() {
             0,
             None,
             &mut set_governance_config_ix,
+            None,
         )
         .await
         .unwrap();

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -2245,6 +2245,7 @@ impl GovernanceProgramTest {
             0,
             None,
             &mut set_governance_config_ix,
+            None,
         )
         .await
     }
@@ -2257,6 +2258,7 @@ impl GovernanceProgramTest {
         token_owner_record_cookie: &TokenOwnerRecordCookie,
         option_index: u8,
         index: Option<u16>,
+        hold_up_time: Option<u32>,
     ) -> Result<ProposalTransactionCookie, ProgramError> {
         let token_account_keypair = Keypair::new();
         self.bench
@@ -2283,6 +2285,7 @@ impl GovernanceProgramTest {
             option_index,
             index,
             &mut instruction,
+            hold_up_time,
         )
         .await
     }
@@ -2320,6 +2323,7 @@ impl GovernanceProgramTest {
             0,
             index,
             &mut instruction,
+            None,
         )
         .await
     }
@@ -2345,6 +2349,7 @@ impl GovernanceProgramTest {
             0,
             None,
             &mut transfer_ix,
+            None,
         )
         .await
     }
@@ -2415,6 +2420,7 @@ impl GovernanceProgramTest {
             0,
             None,
             &mut upgrade_ix,
+            None,
         )
         .await
     }
@@ -2441,6 +2447,7 @@ impl GovernanceProgramTest {
             option_index,
             index,
             &mut instruction,
+            None,
         )
         .await
     }
@@ -2453,8 +2460,9 @@ impl GovernanceProgramTest {
         option_index: u8,
         index: Option<u16>,
         instruction: &mut Instruction,
+        hold_up_time: Option<u32>,
     ) -> Result<ProposalTransactionCookie, ProgramError> {
-        let hold_up_time = 15;
+        let hold_up_time = hold_up_time.unwrap_or(15);
 
         let instruction_data: InstructionData = instruction.clone().into();
         let mut yes_option = &mut proposal_cookie.account.options[0];

--- a/governance/program/tests/use_proposals_with_multiple_options.rs
+++ b/governance/program/tests/use_proposals_with_multiple_options.rs
@@ -663,6 +663,7 @@ async fn test_execute_proposal_with_multiple_options_and_partial_success() {
             &token_owner_record_cookie1,
             0,
             Some(0),
+            None,
         )
         .await
         .unwrap();
@@ -674,6 +675,7 @@ async fn test_execute_proposal_with_multiple_options_and_partial_success() {
             &token_owner_record_cookie1,
             1,
             Some(0),
+            None,
         )
         .await
         .unwrap();
@@ -685,6 +687,7 @@ async fn test_execute_proposal_with_multiple_options_and_partial_success() {
             &token_owner_record_cookie1,
             2,
             Some(0),
+            None,
         )
         .await
         .unwrap();
@@ -867,6 +870,7 @@ async fn test_try_execute_proposal_with_multiple_options_and_full_deny() {
             &token_owner_record_cookie1,
             0,
             Some(0),
+            None,
         )
         .await
         .unwrap();
@@ -878,6 +882,7 @@ async fn test_try_execute_proposal_with_multiple_options_and_full_deny() {
             &token_owner_record_cookie1,
             1,
             Some(0),
+            None,
         )
         .await
         .unwrap();
@@ -889,6 +894,7 @@ async fn test_try_execute_proposal_with_multiple_options_and_full_deny() {
             &token_owner_record_cookie1,
             2,
             Some(0),
+            None,
         )
         .await
         .unwrap();


### PR DESCRIPTION
#### Summary

Create a test to assert a flash loan attack is not possible 

Within the same transaction, an attacker can flash loan a large amount of governance tokens, deposit them, create a proposal on a mint governance, insert a transaction to mint themself infinite tokens, vote and tip the proposal to 
success, execute the transaction, and finally repay the flashloan with a profit

