### PR TITLE
token-2022: Bump version for next release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5415,7 +5415,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-token 3.3.0",
- "spl-token-2022 0.3.0",
+ "spl-token-2022 0.4.0",
  "thiserror",
 ]
 
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-2022"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -5834,7 +5834,7 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account 1.0.5",
  "spl-memo 3.0.1",
- "spl-token-2022 0.3.0",
+ "spl-token-2022 0.4.0",
  "spl-token-client",
  "walkdir",
 ]
@@ -5876,7 +5876,7 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account 1.0.5",
  "spl-memo 3.0.1",
- "spl-token-2022 0.3.0",
+ "spl-token-2022 0.4.0",
  "thiserror",
 ]
 

--- a/associated-token-account/program/Cargo.toml
+++ b/associated-token-account/program/Cargo.toml
@@ -18,7 +18,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 solana-program = "1.10.15"
 spl-token = { version = "3.3", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "0.3", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.4", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -16,5 +16,5 @@ solana-sdk = "=1.10.19"
 # testing token
 spl-associated-token-account = { version = "1.0.5", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-memo = { version = "3.0.1", path = "../../memo/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "0.3", path="../program-2022" }
+spl-token-2022 = { version = "0.4", path="../program-2022" }
 thiserror = "1.0"

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -20,5 +20,5 @@ solana-program-test = "=1.10.19"
 solana-sdk = "=1.10.19"
 spl-associated-token-account = { version = "1.0.5", path = "../../associated-token-account/program" }
 spl-memo = { version = "3.0.1", path = "../../memo/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "0.3", path="../program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.4", path="../program-2022", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.1.0", path = "../client" }

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-2022"
-version = "0.3.0"
+version = "0.4.0"
 description = "Solana Program Library Token 2022"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"


### PR DESCRIPTION
#### Problem

It's time to release a new token-2022, but the version is still at 0.3.0

#### Solution

Bump it to 0.4.0 everywhere to tag the next release.