### PR TITLE
Approximation of Natural Log

### DIFF
--- a/libraries/math/src/approximations.rs
+++ b/libraries/math/src/approximations.rs
@@ -49,7 +49,7 @@ pub fn sqrt<T: PrimInt + CheckedShl + CheckedShr>(radicand: T) -> Option<T> {
 /// $$ ln(x) = (n-1)*ln(10) + 2 * \sum{ y^{2k+1} \over 2k+1 } $$
 /// where x = A * 10^(n-1) such that 0 <= A < 10
 /// and y = (A-1)/(A+1)
-pub fn ln<T: Float + Copy>(input: T) -> Option<T> {
+pub fn ln<T: Float + Clone>(input: T) -> Option<T> {
     if input.le(&T::zero()) {
         return None; // fail for less than or equal to 0
     }

--- a/libraries/math/src/approximations.rs
+++ b/libraries/math/src/approximations.rs
@@ -1,11 +1,7 @@
 //! Approximation calculations
 
-use std::fmt::Display;
-
-use num_traits::{Float, Unsigned};
-
 use {
-    num_traits::{CheckedShl, CheckedShr, PrimInt},
+    num_traits::{CheckedShl, CheckedShr, PrimInt, Float},
     std::cmp::Ordering,
 };
 
@@ -45,10 +41,6 @@ pub fn sqrt<T: PrimInt + CheckedShl + CheckedShr>(radicand: T) -> Option<T> {
     Some(result)
 }
 
-/// Accurate value of natural log of 10.
-/// Used in calculating approximations of ln(x).
-pub const LN10: f32 = 2.302585092994046;
-
 /// Calculate approximate natural log of a number
 /// using Taylor series of Log_e(x)
 ///     
@@ -57,34 +49,34 @@ pub const LN10: f32 = 2.302585092994046;
 /// $$ ln(x) = 2 * \sum{ y^{2k+1} \over 2k+1 } $$
 /// where y = (A-1)/(A+1) and x = A * 10^(n-1) 
 /// such that 0 <= A < 10
-pub fn ln<T: Float>(input: T) -> Option<T> {
+pub fn ln<T: Float + Copy>(input: T) -> Option<T> {
     if input.le(&T::zero()) {
         return None; // fail for less than or equal to 0
     }
 
     // x = A * 10^(n-1)
     let mut mantissa = input.clone();
-    while mantissa.floor() > T::from(10 as f32).unwrap() {
-        mantissa = mantissa.div(T::from(10 as f32).unwrap());
+    while mantissa.floor() > T::from(10_f64).unwrap() {
+        mantissa = mantissa.div(T::from(10_f64).unwrap());
     }
     
     // number of digits of input before decimal
     let mut temp_mantx = mantissa.clone();
     let mut n = 1;
     while temp_mantx.floor() != input.floor() {
-        temp_mantx = temp_mantx.mul(T::from(10 as f32).unwrap());
+        temp_mantx = temp_mantx.mul(T::from(10_f64).unwrap());
         n += 1;
     };
 
-    let y: T = (mantissa - T::from(1 as f32).unwrap()) / (mantissa + T::from(1 as f32).unwrap());
+    let y: T = (mantissa - T::from(1_f64).unwrap()) / (mantissa + T::from(1_f64).unwrap());
     
-    let mut sum: T = T::from(0 as f32).unwrap();
+    let mut sum: T = T::from(0_f64).unwrap();
     for k in 0..25 {
         sum = sum.add(y.powi(2*k + 1).div(T::from(2*k + 1).unwrap()));
     }
 
-    sum = sum.mul(T::from(2 as f32).unwrap());
-    Some(sum.add( T::from(LN10 * (n - 1) as f32).unwrap() ))
+    sum = sum.mul(T::from(2_f64).unwrap());
+    Some(sum.add( T::from(std::f64::consts::LN_10 * (n - 1) as f64).unwrap() ))
 }
 
 /// Calculate the normal cdf of the given number

--- a/libraries/math/src/approximations.rs
+++ b/libraries/math/src/approximations.rs
@@ -69,7 +69,7 @@ pub fn ln<T: Float + Clone>(input: T) -> Option<T> {
         sum += 2_f64 * y.powi(2*k + 1) / ((2*k + 1) as f64);
     }
 
-    T::from(sum + ( std::f64::consts::LN_10 * (n - 1) as f64 ))
+    T::from(sum + (std::f64::consts::LN_10 * (n - 1) as f64))
 }
 
 /// Calculate the normal cdf of the given number
@@ -154,13 +154,13 @@ mod tests {
 
     fn check_ln(input: f32) {
         if input <= 0_f32 {
-            assert!(ln(input).is_none() == true);
+            assert!(ln(input).is_none());
             return;
         }
 
         let approx_log = ln(input).unwrap();
         let std_log = input.ln();
-        let error = (approx_log - std_log).abs();
+        let error = (approx_log - std_log).abs() as f64;
         assert!(error <= 0.000_000_000_1);
     }
 

--- a/libraries/math/src/approximations.rs
+++ b/libraries/math/src/approximations.rs
@@ -54,29 +54,22 @@ pub fn ln<T: Float + Clone>(input: T) -> Option<T> {
         return None; // fail for less than or equal to 0
     }
 
-    let mut mantissa = input.clone();
-    while mantissa.floor() > T::from(10_f32).unwrap() {
-        mantissa = mantissa.div(T::from(10_f32).unwrap());
-    }
-    
     // number of digits of input before decimal
-    let mut n: i32 = 1;
-    let mut temp_mantx = mantissa.clone();
-    while temp_mantx.floor() != input.floor() {
-        temp_mantx = temp_mantx.mul(T::from(10_f32).unwrap());
+    let mut n = 1;
+    let mut mantissa = input.to_f64().unwrap();
+    while mantissa.floor() > 10_f64 {
+        mantissa /= 10_f64;
         n += 1;
-    };
-    
-    // y = (A-1)/(A+1)
-    let y: T = (mantissa - T::from(1_f32).unwrap()) / (mantissa + T::from(1_f32).unwrap());
-    
-    let mut sum: T = T::from(0_f32).unwrap();
-    for k in 0..(25*n) {
-        sum = sum.add(y.powi(2*k + 1).div(T::from(2*k + 1).unwrap()));
     }
 
-    sum = sum.mul(T::from(2_f32).unwrap());
-    Some(sum.add( T::from(std::f32::consts::LN_10 * (n - 1) as f32).unwrap() ))
+    // y = (A-1)/(A+1)
+    let y = (mantissa - 1_f64) / (mantissa + 1_f64);
+    let mut sum = 0_f64;
+    for k in 0..50 {
+        sum += 2_f64 * y.powi(2*k + 1) / ((2*k + 1) as f64);
+    }
+
+    T::from(sum + ( std::f64::consts::LN_10 * (n - 1) as f64 ))
 }
 
 /// Calculate the normal cdf of the given number
@@ -168,7 +161,7 @@ mod tests {
         let approx_log = ln(input).unwrap();
         let std_log = input.ln();
         let error = (approx_log - std_log).abs();
-        assert!(error <= 0.000_01);
+        assert!(error <= 0.000_000_000_1);
     }
 
     #[test]

--- a/libraries/math/src/approximations.rs
+++ b/libraries/math/src/approximations.rs
@@ -46,35 +46,37 @@ pub fn sqrt<T: PrimInt + CheckedShl + CheckedShr>(radicand: T) -> Option<T> {
 }
 
 /// Accurate value of natural log of 10.
+/// Used in calculating approximations of ln(x).
 pub const LN10: f32 = 2.302585092994046;
+
 /// Calculate approximate natural log of a number
 /// using Taylor series of Log_e(x)
 ///     
 /// Ideas from https://math.stackexchange.com/a/977836
 /// 
 /// $$ ln(x) = 2 * \sum{ y^{2k+1} \over 2k+1 } $$
-/// where y = (A-1)/(A+1)
-/// where x = A * 10^(n-1)
+/// where y = (A-1)/(A+1) and x = A * 10^(n-1) 
+/// such that 0 <= A < 10
 pub fn ln<T: Float>(input: T) -> Option<T> {
     if input.le(&T::zero()) {
         return None; // fail for less than or equal to 0
     }
 
     // x = A * 10^(n-1)
-    let mut mantx = input.clone();
-    while mantx.floor() > T::from(10 as f32).unwrap() {
-        mantx = mantx.div(T::from(10 as f32).unwrap());
+    let mut mantissa = input.clone();
+    while mantissa.floor() > T::from(10 as f32).unwrap() {
+        mantissa = mantissa.div(T::from(10 as f32).unwrap());
     }
     
     // number of digits of input before decimal
-    let mut temp_mantx = mantx.clone();
+    let mut temp_mantx = mantissa.clone();
     let mut n = 1;
     while temp_mantx.floor() != input.floor() {
         temp_mantx = temp_mantx.mul(T::from(10 as f32).unwrap());
         n += 1;
     };
 
-    let y: T = (mantx - T::from(1 as f32).unwrap()) / (mantx + T::from(1 as f32).unwrap());
+    let y: T = (mantissa - T::from(1 as f32).unwrap()) / (mantissa + T::from(1 as f32).unwrap());
     
     let mut sum: T = T::from(0 as f32).unwrap();
     for k in 0..25 {
@@ -167,16 +169,9 @@ mod tests {
     }
 
 
-    #[test]
     fn check_ln() {
-        let result = ln(0.56276);
-        println!("{}", result.unwrap());
+        
     }
-
-    // fn check_ln(i:f32) {
-    //     let result = ln(i);
-
-    // }
 
     #[test]
     fn test_ln_min_max() {
@@ -186,10 +181,10 @@ mod tests {
         }
     }
 
-    // proptest! {
-    //     #[test]
-    //     fn test_ln(a in 1..10) {
-    //         check_ln(a as f32);
-    //     }
-    // }
+    proptest! {
+        #[test]
+        fn test_ln(a in 1..10) {
+            // check_ln(a as f32);
+        }
+    }
 }

--- a/libraries/math/src/instruction.rs
+++ b/libraries/math/src/instruction.rs
@@ -89,6 +89,14 @@ pub enum MathInstruction {
         argument: f32,
     },
 
+    /// Approximate Natural Log of a float
+    ///
+    /// No accounts required for this instruction
+    F32ApproximateNaturalLog {
+        /// The argument
+        argument: f32,
+    },
+
     /// The Normal CDF of a float
     ///
     /// No accounts required for this instruction
@@ -203,6 +211,17 @@ pub fn f32_natural_log(argument: f32) -> Instruction {
         program_id: id(),
         accounts: vec![],
         data: MathInstruction::F32NaturalLog { argument }
+            .try_to_vec()
+            .unwrap(),
+    }
+}
+
+/// Create F32 Approximate Natural Log instruction
+pub fn f32_approx_natural_log(argument: f32) -> Instruction {
+    Instruction {
+        program_id: id(),
+        accounts: vec![],
+        data: MathInstruction::F32ApproximateNaturalLog { argument }
             .try_to_vec()
             .unwrap(),
     }
@@ -360,6 +379,19 @@ mod tests {
         assert_eq!(
             instruction.data,
             MathInstruction::F32NaturalLog { argument: f32::MAX }
+                .try_to_vec()
+                .unwrap()
+        );
+        assert_eq!(instruction.program_id, crate::id())
+    }
+
+    #[test]
+    fn test_f32_approx_natural_log() {
+        let instruction = f32_approx_natural_log(f32::MAX);
+        assert_eq!(0, instruction.accounts.len());
+        assert_eq!(
+            instruction.data,
+            MathInstruction::F32ApproximateNaturalLog { argument: f32::MAX }
                 .try_to_vec()
                 .unwrap()
         );

--- a/libraries/math/src/processor.rs
+++ b/libraries/math/src/processor.rs
@@ -2,7 +2,7 @@
 
 use {
     crate::{
-        approximations::{f32_normal_cdf, sqrt},
+        approximations::{f32_normal_cdf, ln, sqrt},
         instruction::MathInstruction,
         precise_number::PreciseNumber,
     },
@@ -52,7 +52,7 @@ fn f32_natural_log(argument: f32) -> f32 {
 /// f32_approx_natural_log
 #[inline(never)]
 fn f32_approx_natural_log(argument: f32) -> f32 {
-    argument.ln()
+    ln(argument).unwrap()
 }
 
 /// Instruction processor

--- a/libraries/math/src/processor.rs
+++ b/libraries/math/src/processor.rs
@@ -49,6 +49,12 @@ fn f32_natural_log(argument: f32) -> f32 {
     argument.ln()
 }
 
+/// f32_approx_natural_log
+#[inline(never)]
+fn f32_approx_natural_log(argument: f32) -> f32 {
+    argument.ln()
+}
+
 /// Instruction processor
 pub fn process_instruction(
     _program_id: &Pubkey,
@@ -132,6 +138,14 @@ pub fn process_instruction(
             msg!("Calculating f32 Natural Log");
             sol_log_compute_units();
             let result = f32_natural_log(argument);
+            sol_log_compute_units();
+            msg!("{}", result as u64);
+            Ok(())
+        }
+        MathInstruction::F32ApproximateNaturalLog { argument } => {
+            msg!("Calculating f32 Approximate Natural Log");
+            sol_log_compute_units();
+            let result = f32_approx_natural_log(argument);
             sol_log_compute_units();
             msg!("{}", result as u64);
             Ok(())

--- a/libraries/math/src/processor.rs
+++ b/libraries/math/src/processor.rs
@@ -51,7 +51,7 @@ fn f32_natural_log(argument: f32) -> f32 {
 
 /// f32_approx_natural_log
 #[inline(never)]
-fn f32_approx_natural_log(argument: f32) -> f32 {
+fn f32_approx_natural_log(argument: f32) -> PreciseNumber {
     ln(argument).unwrap()
 }
 
@@ -147,7 +147,7 @@ pub fn process_instruction(
             sol_log_compute_units();
             let result = f32_approx_natural_log(argument);
             sol_log_compute_units();
-            msg!("{}", result as u64);
+            msg!("{}", result);
             Ok(())
         }
         MathInstruction::F32NormalCDF { argument } => {

--- a/libraries/math/tests/instruction_count.rs
+++ b/libraries/math/tests/instruction_count.rs
@@ -190,7 +190,7 @@ async fn test_approx_natural_log() {
     let mut transaction = Transaction::new_with_payer(
         &[instruction::f32_approx_natural_log(1_f32.exp())],
         Some(&payer.pubkey()),
-    ); 
+    );
     transaction.sign(&[&payer], recent_blockhash);
     banks_client.process_transaction(transaction).await.unwrap();
 }

--- a/libraries/math/tests/instruction_count.rs
+++ b/libraries/math/tests/instruction_count.rs
@@ -180,6 +180,22 @@ async fn test_f32_natural_log() {
 }
 
 #[tokio::test]
+async fn test_approx_natural_log() {
+    let mut pc = ProgramTest::new("spl_math", id(), processor!(process_instruction));
+
+    pc.set_compute_max_units(3500);
+
+    let (mut banks_client, payer, recent_blockhash) = pc.start().await;
+
+    let mut transaction = Transaction::new_with_payer(
+        &[approximations::ln(1_f32.exp())],
+        Some(&payer.pubkey()),
+    ); 
+    transaction.sign(&[&payer], recent_blockhash);
+    banks_client.process_transaction(transaction).await.unwrap();
+}
+
+#[tokio::test]
 async fn test_f32_normal_cdf() {
     let mut pc = ProgramTest::new("spl_math", id(), processor!(process_instruction));
 

--- a/libraries/math/tests/instruction_count.rs
+++ b/libraries/math/tests/instruction_count.rs
@@ -188,7 +188,7 @@ async fn test_approx_natural_log() {
     let (mut banks_client, payer, recent_blockhash) = pc.start().await;
 
     let mut transaction = Transaction::new_with_payer(
-        &[approximations::ln(1_f32.exp())],
+        &[instruction::f32_approx_natural_log(1_f32.exp())],
         Some(&payer.pubkey()),
     ); 
     transaction.sign(&[&payer], recent_blockhash);


### PR DESCRIPTION
## Description
Added an approximation for `ln` using a Taylor series approximation 
Closes: #3163 

Ideas were taken from https://math.stackexchange.com/a/977836
The following form of the Taylor series expansion of $ln(x)$ was used
$$ ln(x) = (n-1)*ln(10) + 2 * \sum{ y^{2i+1} \over 2i+1 } $$
$$ \forall i \epsilon 0, 1, 2, ... p $$
where $y= {A−1 \over A+1}$, such that $x = A ×10^{n−1}$ and $0≤A<10$
Checking for convergence was not an issue because this form of the Taylor series is known to converge quickly.

## Code
The tests for this still need to be written properly, although the function does perform satisfactorily.
The traits for arguments might be incorrect but I can change those if I'm told what sorts of inputs need to be taken.

## Results
Here I've tabulated the performance of the function with increasing inputs
| Input | Approx. | Actual | Error |
| ----- | ------- | ------ | ----- |
| 0.56276 | -0.5749020294731245 | -0.5749020294731245 | 0 |
| 0.35213 | -1.0437548533833947 | -1.043754853383395 | 0.0000000000000002220446049250313 |
| 0.6 | -0.5108256237659905 | -0.5108256237659907 | 0.0000000000000002220446049250313 |
| 1 | 0 | 0 | 0 |
| 3.5242 | 1.2596534601524871 | 1.2596534601524931 | -0.000000000000005995204332975845 |
| 12.487 | 2.5246881351084447 | 2.524688103133008 | 0.000000031975436520781386 |
| 3248.152436 | 8.085841728372603 | 8.085841632446295 | 0.00000009592630867416574 |
| 21348.1328491 | 9.968719688359453 | 9.968719560457707 | 0.00000012790174608312554 |
| 542436.43243 | 13.203826818605346 | 13.203826182286956 | 0.0000006363183899793512 |

The error slowly increases as the input becomes larger.