### PR TITLE
chore: update ci install dep script

### DIFF
--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -2,14 +2,6 @@
 
 set -ex
 
-wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-sudo apt-add-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main"
-sudo apt-get update
-sudo apt-get install -y clang-7 --allow-unauthenticated
-sudo apt-get install -y openssl --allow-unauthenticated
-sudo apt-get install -y libssl-dev --allow-unauthenticated
-sudo apt-get install -y libssl1.1 --allow-unauthenticated
-sudo apt-get install -y libudev-dev
-sudo apt-get install -y binutils-dev
-sudo apt-get install -y libunwind-dev
-clang-7 --version
+sudo apt install libudev-dev -y
+sudo apt install binutils-dev -y
+sudo apt install libunwind-dev -y

--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -27,7 +27,6 @@ else
   nightly_version=2022-02-24
 fi
 
-
 export rust_stable="$stable_version"
 export rust_stable_docker_image=solanalabs/rust:"$stable_version"
 


### PR DESCRIPTION
I think `ci/install-build-deps.sh` was migrated from travis and not everything need to install when we use Github Actions.

I use a lint commit to trigger these affected actions and all of them passed.

- [x] [pull-request-libraries.yml](https://github.com/solana-labs/solana-program-library/actions/runs/2493082231)
- [x] [pull-request-stake-pool.yml](https://github.com/solana-labs/solana-program-library/actions/runs/2493082229)
- [x] [pull-request-record.yml](https://github.com/solana-labs/solana-program-library/actions/runs/2493082226)
- [x] [pull-request-feature-proposal.yml](https://github.com/solana-labs/solana-program-library/actions/runs/2493082228)
- [x] [pull-request-shared-memory.yml](https://github.com/solana-labs/solana-program-library/actions/runs/2493082222)
- [x] [pull-request-token-lending.yml](https://github.com/solana-labs/solana-program-library/actions/runs/2493082225)
- [x] [pull-request-memo.yml](https://github.com/solana-labs/solana-program-library/actions/runs/2493082220)
- [x] [pull-request-token-swap.yml](https://github.com/solana-labs/solana-program-library/actions/runs/2493082235)
- [x] [pull-request-name-service.yml](https://github.com/solana-labs/solana-program-library/actions/runs/2493082232)
- [x] [pull-request-governance.yml](https://github.com/solana-labs/solana-program-library/actions/runs/2493082230)
- [x] [pull-request.yml](https://github.com/solana-labs/solana-program-library/actions/runs/2493082221)
- [x] [pull-request-binary-oracle-pair.yml](https://github.com/solana-labs/solana-program-library/actions/runs/2493082223)
- [x] [pull-request-examples.yml](https://github.com/solana-labs/solana-program-library/actions/runs/2493082227)
- [x] [pull-request-token.yml](https://github.com/solana-labs/solana-program-library/actions/runs/2493082219)

`fuzz-nightly.yml` is also an affected action but I haven't a better way to trigger it so I ran it in my fork project.
- [x] [fuzz-nightly.yml](https://github.com/yihau/solana-program-library/actions/runs/2493317256)
