### PR TITLE
Safety check

### DIFF
--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -766,13 +766,10 @@ fn command_transfer(
                     true
                 } else if recipient_token_account_data.owner == config.program_id {
                     if let Ok(token_account) = Account::unpack(&recipient_token_account_data.data) {
-                        if (token.owner == recipient) {
-                            false
-                        } else {
+                        if token_account.owner != recipient {
                             return Err(
-                                format!("Error: ATA address [{}] with Owner [{}] doesn't match recipient address [{}].", 
-                                recipient_token_account, token_account.owner, recipient).into(),
-                            );
+                                    format!("Error: ATA address [{}] with Owner [{}] doesn't match recipient address [{}].", 
+                                    recipient_token_account, token_account.owner, recipient).into());
                         }
                     }
                     false

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -765,6 +765,16 @@ fn command_transfer(
                 if recipient_token_account_data.owner == system_program::id() {
                     true
                 } else if recipient_token_account_data.owner == config.program_id {
+                    if let Ok(token_account) = Account::unpack(&recipient_token_account_data.data) {
+                        if (token.owner == recipient) {
+                            false
+                        } else {
+                            return Err(
+                                format!("Error: ATA address [{}] with Owner [{}] doesn't match recipient address [{}].", 
+                                recipient_token_account, token_account.owner, recipient).into(),
+                            );
+                        }
+                    }
                     false
                 } else {
                     return Err(


### PR DESCRIPTION
Decoding the ATA and checking if the owner field matches the recipient as expected.

This is after a conversation on twitter where someone used the tool to transfer tokens to a wallet whose ATAs were stolen via the authority change. This lead to a token transfer to the stolen ATA and not the desired wallet. [Twitter conversation](https://twitter.com/0xAlice_/status/1536996218429120513)