### PR TITLE
CI: Add `--max-warnings 0` to eslint to abort on errors

### DIFF
--- a/memo/ts/package.json
+++ b/memo/ts/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "npm run clean && tsc",
     "clean": "rimraf ./dist",
-    "lint": "eslint . && npm run pretty",
+    "lint": "eslint --max-warnings 0 . && npm run pretty",
     "lint:fix": "eslint . --fix && npm run pretty:fix",
     "pretty": "prettier --check '{,{src,test}/**/}*.{j,t}s'",
     "pretty:fix": "prettier --write '{,{src,test}/**/}*.{j,t}s'",

--- a/name-service/js/package.json
+++ b/name-service/js/package.json
@@ -21,7 +21,7 @@
     "dev": "tsc && node --trace-warnings dist/transfer.js",
     "build": "tsc",
     "prepublish": "tsc",
-    "lint": "yarn pretty && eslint 'src/*.ts'",
+    "lint": "yarn pretty && eslint --max-warnings 0 'src/*.ts'",
     "lint:fix": "yarn pretty:fix && eslint 'src/*.ts' --fix",
     "pretty": "prettier --check 'src/*.ts'",
     "pretty:fix": "prettier --write 'src/*.ts'",

--- a/stake-pool/js/package.json
+++ b/stake-pool/js/package.json
@@ -4,7 +4,7 @@
   "description": "SPL Stake Pool Program JS API",
   "scripts": {
     "build": "npm run clean && tsc && cross-env NODE_ENV=production rollup -c",
-    "lint": "eslint .",
+    "lint": "eslint --max-warnings 0 .",
     "lint:fix": "eslint . --fix",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/token-lending/js/package.json
+++ b/token-lending/js/package.json
@@ -25,7 +25,7 @@
         "build": "rm -rf lib/* && tsc && rollup -c && rm lib/rollup.config.d.ts",
         "deploy": "yarn docs && gh-pages -d docs -e token-lending",
         "docs": "rm -rf docs/* && typedoc",
-        "lint": "eslint . --ext .ts && prettier --check '**/*.{ts,js,json}'",
+        "lint": "eslint . --ext .ts --max-warnings 0 && prettier --check '**/*.{ts,js,json}'",
         "lint:fix": "eslint . --ext .ts --fix && prettier --write '**/*.{ts,js,json}'"
     },
     "dependencies": {

--- a/token-swap/js/package.json
+++ b/token-swap/js/package.json
@@ -33,7 +33,7 @@
     "postbuild": "echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json && echo '{\"type\":\"module\"}' > dist/esm/package.json",
     "test": "ts-node test/main.ts",
     "start-with-test-validator": "start-server-and-test 'solana-test-validator --bpf-program SwapsVeCiPHMUAtzQWZw7RjsKjgCjhwU55QGu4U1Szw ../../target/deploy/spl_token_swap.so --reset --quiet' http://localhost:8899/health test",
-    "lint": "npm run pretty && eslint .",
+    "lint": "npm run pretty && eslint --max-warnings 0 .",
     "lint:fix": "npm run pretty:fix && eslint . --fix",
     "build:program": "cargo build-bpf --manifest-path ../program/Cargo.toml",
     "pretty": "prettier --check '{,???/**/}*.ts'",

--- a/token/js/package.json
+++ b/token/js/package.json
@@ -35,7 +35,7 @@
         "test:e2e-native": "start-server-and-test 'solana-test-validator --reset --quiet' http://localhost:8899/health 'mocha test/e2e'",
         "docs": "shx rm -rf docs && NODE_OPTIONS=--max_old_space_size=4096 typedoc && shx cp .nojekyll docs/",
         "fmt": "prettier --write '{*,**/*}.{js,ts,jsx,tsx,json}'",
-        "lint": "eslint --ext .ts . && prettier --check '{*,**/*}.{js,ts,jsx,tsx,json}'",
+        "lint": "eslint --max-warnings 0 --ext .ts . && prettier --check '{*,**/*}.{js,ts,jsx,tsx,json}'",
         "lint:fix": "eslint --fix --ext .ts . && yarn fmt",
         "nuke": "shx rm -rf node_modules yarn.lock"
     },

--- a/token/js/src/instructions/initializeAccount3.ts
+++ b/token/js/src/instructions/initializeAccount3.ts
@@ -1,7 +1,7 @@
 import { TokenInstruction } from './types';
 import { struct, u8 } from '@solana/buffer-layout';
 import { publicKey } from '@solana/buffer-layout-utils';
-import { AccountMeta, PublicKey, SYSVAR_RENT_PUBKEY, TransactionInstruction } from '@solana/web3.js';
+import { AccountMeta, PublicKey, TransactionInstruction } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ID } from '../constants';
 import {
     TokenInvalidInstructionDataError,


### PR DESCRIPTION
#### Problem

If `eslint` fails during CI, CI still passes. That's no good.

#### Solution

Add `--max-warnings 0` to fail eslint properly.