### PR TITLE
token-js: Add default account state support

### DIFF
--- a/token/js/src/extensions/defaultAccountState/actions.ts
+++ b/token/js/src/extensions/defaultAccountState/actions.ts
@@ -1,0 +1,74 @@
+import {
+    ConfirmOptions,
+    Connection,
+    PublicKey,
+    sendAndConfirmTransaction,
+    Signer,
+    Transaction,
+    TransactionSignature,
+} from '@solana/web3.js';
+import { TOKEN_2022_PROGRAM_ID } from '../../constants';
+import { AccountState } from '../../state';
+import {
+    createInitializeDefaultAccountStateInstruction,
+    createUpdateDefaultAccountStateInstruction,
+} from './instructions';
+import { getSigners } from '../../actions/internal';
+
+/**
+ * Initialize a default account state on a mint
+ *
+ * @param connection     Connection to use
+ * @param payer          Payer of the transaction fees
+ * @param mint        Mint to initialize with extension
+ * @param state        Account state with which to initialize new accounts
+ * @param confirmOptions Options for confirming the transaction
+ * @param programId      SPL Token program account
+ *
+ * @return Signature of the confirmed transaction
+ */
+export async function initializeDefaultAccountState(
+    connection: Connection,
+    payer: Signer,
+    mint: PublicKey,
+    state: AccountState,
+    confirmOptions?: ConfirmOptions,
+    programId = TOKEN_2022_PROGRAM_ID
+): Promise<TransactionSignature> {
+    const transaction = new Transaction().add(createInitializeDefaultAccountStateInstruction(mint, state, programId));
+
+    return await sendAndConfirmTransaction(connection, transaction, [payer], confirmOptions);
+}
+
+/**
+ * Update the default account state on a mint
+ *
+ * @param connection     Connection to use
+ * @param payer          Payer of the transaction fees
+ * @param mint        Mint to modify
+ * @param state        New account state to set on created accounts
+ * @param freezeAuthority          Freeze authority of the mint
+ * @param multiSigners   Signing accounts if `freezeAuthority` is a multisig
+ * @param confirmOptions Options for confirming the transaction
+ * @param programId      SPL Token program account
+ *
+ * @return Signature of the confirmed transaction
+ */
+export async function updateDefaultAccountState(
+    connection: Connection,
+    payer: Signer,
+    mint: PublicKey,
+    state: AccountState,
+    freezeAuthority: Signer | PublicKey,
+    multiSigners: Signer[] = [],
+    confirmOptions?: ConfirmOptions,
+    programId = TOKEN_2022_PROGRAM_ID
+): Promise<TransactionSignature> {
+    const [freezeAuthorityPublicKey, signers] = getSigners(freezeAuthority, multiSigners);
+
+    const transaction = new Transaction().add(
+        createUpdateDefaultAccountStateInstruction(mint, state, freezeAuthorityPublicKey, signers, programId)
+    );
+
+    return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);
+}

--- a/token/js/src/extensions/defaultAccountState/index.ts
+++ b/token/js/src/extensions/defaultAccountState/index.ts
@@ -1,0 +1,3 @@
+export * from './actions';
+export * from './instructions';
+export * from './state';

--- a/token/js/src/extensions/defaultAccountState/instructions.ts
+++ b/token/js/src/extensions/defaultAccountState/instructions.ts
@@ -1,0 +1,89 @@
+import { struct, u8 } from '@solana/buffer-layout';
+import { PublicKey, Signer, TransactionInstruction } from '@solana/web3.js';
+import { AccountState } from '../../state/account';
+import { TokenInstruction } from '../../instructions/types';
+import { TOKEN_2022_PROGRAM_ID } from '../../constants';
+
+export enum DefaultAccountStateInstruction {
+    Initialize = 0,
+    Update = 1,
+}
+
+/** TODO: docs */
+export interface DefaultAccountStateInstructionData {
+    instruction: TokenInstruction.DefaultAccountStateExtension;
+    defaultAccountStateInstruction: DefaultAccountStateInstruction;
+    accountState: AccountState;
+}
+
+/** TODO: docs */
+export const defaultAccountStateInstructionData = struct<DefaultAccountStateInstructionData>([
+    u8('instruction'),
+    u8('defaultAccountStateInstruction'),
+    u8('accountState'),
+]);
+
+/**
+ * Construct an InitializeDefaultAccountState instruction
+ *
+ * @param mint         Mint to initialize
+ * @param accountState Default account state to set on all new accounts
+ * @param programId    SPL Token program account
+ *
+ * @return Instruction to add to a transaction
+ */
+export function createInitializeDefaultAccountStateInstruction(
+    mint: PublicKey,
+    accountState: AccountState,
+    programId = TOKEN_2022_PROGRAM_ID
+): TransactionInstruction {
+    const keys = [{ pubkey: mint, isSigner: false, isWritable: true }];
+    const data = Buffer.alloc(defaultAccountStateInstructionData.span);
+    defaultAccountStateInstructionData.encode(
+        {
+            instruction: TokenInstruction.DefaultAccountStateExtension,
+            defaultAccountStateInstruction: DefaultAccountStateInstruction.Initialize,
+            accountState,
+        },
+        data
+    );
+
+    return new TransactionInstruction({ keys, programId, data });
+}
+
+/**
+ * Construct an UpdateDefaultAccountState instruction
+ *
+ * @param mint         Mint to update
+ * @param accountState    Default account state to set on all accounts
+ * @param freezeAuthority       The mint's freeze authority
+ * @param signers         The signer account(s) for a multisig
+ * @param programId       SPL Token program account
+ *
+ * @return Instruction to add to a transaction
+ */
+export function createUpdateDefaultAccountStateInstruction(
+    mint: PublicKey,
+    accountState: AccountState,
+    freezeAuthority: PublicKey,
+    multiSigners: Signer[] = [],
+    programId = TOKEN_2022_PROGRAM_ID
+): TransactionInstruction {
+    const keys = [{ pubkey: mint, isSigner: false, isWritable: true }];
+    keys.push({ pubkey: freezeAuthority, isSigner: !multiSigners.length, isWritable: false });
+    for (const signer of multiSigners) {
+        keys.push({ pubkey: signer.publicKey, isSigner: true, isWritable: false });
+    }
+
+    const data = Buffer.alloc(defaultAccountStateInstructionData.span);
+    defaultAccountStateInstructionData.encode(
+        {
+            instruction: TokenInstruction.DefaultAccountStateExtension,
+            defaultAccountStateInstruction: DefaultAccountStateInstruction.Update,
+            accountState,
+        },
+        data
+    );
+
+    return new TransactionInstruction({ keys, programId, data });
+}

--- a/token/js/src/extensions/defaultAccountState/state.ts
+++ b/token/js/src/extensions/defaultAccountState/state.ts
@@ -1,0 +1,24 @@
+import { struct, u8 } from '@solana/buffer-layout';
+import { AccountState } from '../../state';
+import { Mint } from '../../state';
+import { ExtensionType, getExtensionData } from '../extensionType';
+
+/** DefaultAccountState as stored by the program */
+export interface DefaultAccountState {
+    /** Default AccountState in which new accounts are initialized */
+    state: AccountState;
+}
+
+/** Buffer layout for de/serializing a transfer fee config extension */
+export const DefaultAccountStateLayout = struct<DefaultAccountState>([u8('state')]);
+
+export const DEFAULT_ACCOUNT_STATE_SIZE = DefaultAccountStateLayout.span;
+
+export function getDefaultAccountState(mint: Mint): DefaultAccountState | null {
+    const extensionData = getExtensionData(ExtensionType.DefaultAccountState, mint.tlvData);
+    if (extensionData !== null) {
+        return DefaultAccountStateLayout.decode(extensionData);
+    } else {
+        return null;
+    }
+}

--- a/token/js/src/extensions/extensionType.ts
+++ b/token/js/src/extensions/extensionType.ts
@@ -2,6 +2,7 @@ import { ACCOUNT_SIZE } from '../state/account';
 import { Mint, MINT_SIZE } from '../state/mint';
 import { MULTISIG_SIZE } from '../state/multisig';
 import { ACCOUNT_TYPE_SIZE } from './accountType';
+import { DEFAULT_ACCOUNT_STATE_SIZE } from './defaultAccountState';
 import { MINT_CLOSE_AUTHORITY_SIZE } from './mintCloseAuthority';
 import { IMMUTABLE_OWNER_SIZE } from './immutableOwner';
 import { TRANSFER_FEE_CONFIG_SIZE, TRANSFER_FEE_AMOUNT_SIZE } from './transferFee';
@@ -38,7 +39,7 @@ export function getTypeLen(e: ExtensionType): number {
         case ExtensionType.ConfidentialTransferAccount:
             return 286;
         case ExtensionType.DefaultAccountState:
-            return 1;
+            return DEFAULT_ACCOUNT_STATE_SIZE;
         case ExtensionType.ImmutableOwner:
             return IMMUTABLE_OWNER_SIZE;
         case ExtensionType.MemoTransfer:

--- a/token/js/src/extensions/index.ts
+++ b/token/js/src/extensions/index.ts
@@ -1,4 +1,5 @@
 export * from './accountType';
+export * from './defaultAccountState/index';
 export * from './extensionType';
 export * from './mintCloseAuthority';
 export * from './immutableOwner';

--- a/token/js/test/e2e-2022/defaultAccountState.test.ts
+++ b/token/js/test/e2e-2022/defaultAccountState.test.ts
@@ -1,0 +1,115 @@
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+chai.use(chaiAsPromised);
+
+import {
+    sendAndConfirmTransaction,
+    Connection,
+    Keypair,
+    PublicKey,
+    Signer,
+    SystemProgram,
+    Transaction,
+} from '@solana/web3.js';
+import {
+    AccountState,
+    createAccount,
+    createInitializeMintInstruction,
+    createInitializeDefaultAccountStateInstruction,
+    getAccount,
+    getDefaultAccountState,
+    getMint,
+    getMintLen,
+    updateDefaultAccountState,
+    ExtensionType,
+} from '../../src';
+import { TEST_PROGRAM_ID, newAccountWithLamports, getConnection } from '../common';
+
+const TEST_STATE = AccountState.Frozen;
+const TEST_TOKEN_DECIMALS = 2;
+const EXTENSIONS = [ExtensionType.DefaultAccountState];
+describe('defaultAccountState', () => {
+    let connection: Connection;
+    let payer: Signer;
+    let mint: PublicKey;
+    let mintAuthority: Keypair;
+    let freezeAuthority: Keypair;
+    before(async () => {
+        connection = await getConnection();
+        payer = await newAccountWithLamports(connection, 1000000000);
+        mintAuthority = Keypair.generate();
+        freezeAuthority = Keypair.generate();
+    });
+    beforeEach(async () => {
+        const mintKeypair = Keypair.generate();
+        mint = mintKeypair.publicKey;
+        const mintLen = getMintLen(EXTENSIONS);
+        const lamports = await connection.getMinimumBalanceForRentExemption(mintLen);
+
+        const transaction = new Transaction().add(
+            SystemProgram.createAccount({
+                fromPubkey: payer.publicKey,
+                newAccountPubkey: mint,
+                space: mintLen,
+                lamports,
+                programId: TEST_PROGRAM_ID,
+            }),
+            createInitializeDefaultAccountStateInstruction(mint, TEST_STATE, TEST_PROGRAM_ID),
+            createInitializeMintInstruction(
+                mint,
+                TEST_TOKEN_DECIMALS,
+                mintAuthority.publicKey,
+                freezeAuthority.publicKey,
+                TEST_PROGRAM_ID
+            )
+        );
+
+        await sendAndConfirmTransaction(connection, transaction, [payer, mintKeypair], undefined);
+    });
+    it('defaults to frozen', async () => {
+        const mintInfo = await getMint(connection, mint, undefined, TEST_PROGRAM_ID);
+        const defaultAccountState = getDefaultAccountState(mintInfo);
+        expect(defaultAccountState).to.not.be.null;
+        if (defaultAccountState !== null) {
+            expect(defaultAccountState.state).to.eql(TEST_STATE);
+        }
+        const owner = Keypair.generate();
+        const account = await createAccount(
+            connection,
+            payer,
+            mint,
+            owner.publicKey,
+            undefined,
+            undefined,
+            TEST_PROGRAM_ID
+        );
+        const accountInfo = await getAccount(connection, account, undefined, TEST_PROGRAM_ID);
+        expect(accountInfo.isFrozen).to.be.true;
+        expect(accountInfo.isInitialized).to.be.true;
+    });
+    it('defaults to initialized after update', async () => {
+        await updateDefaultAccountState(
+            connection,
+            payer,
+            mint,
+            AccountState.Initialized,
+            freezeAuthority,
+            [],
+            undefined,
+            TEST_PROGRAM_ID
+        );
+        const owner = Keypair.generate();
+        const account = await createAccount(
+            connection,
+            payer,
+            mint,
+            owner.publicKey,
+            undefined,
+            undefined,
+            TEST_PROGRAM_ID
+        );
+        const accountInfo = await getAccount(connection, account, undefined, TEST_PROGRAM_ID);
+        expect(accountInfo.isFrozen).to.be.false;
+        expect(accountInfo.isInitialized).to.be.true;
+    });
+});


### PR DESCRIPTION
#### Problem

Token-2022 allows for a default account state (initialized or frozen) on all new accounts, but the JS bindings don't exist for it.

#### Solution

Add the bindings and tests.

Fixes #2958 