### PR TITLE
token-js: Support non-transferable mint

### DIFF
--- a/token/js/src/extensions/extensionType.ts
+++ b/token/js/src/extensions/extensionType.ts
@@ -5,6 +5,7 @@ import { ACCOUNT_TYPE_SIZE } from './accountType';
 import { MINT_CLOSE_AUTHORITY_SIZE } from './mintCloseAuthority';
 import { IMMUTABLE_OWNER_SIZE } from './immutableOwner';
 import { TRANSFER_FEE_CONFIG_SIZE, TRANSFER_FEE_AMOUNT_SIZE } from './transferFee';
+import { NON_TRANSFERABLE_SIZE } from './nonTransferable';
 
 export enum ExtensionType {
     Uninitialized,
@@ -16,6 +17,7 @@ export enum ExtensionType {
     DefaultAccountState,
     ImmutableOwner,
     MemoTransfer,
+    NonTransferable,
 }
 
 export const TYPE_SIZE = 2;
@@ -43,6 +45,8 @@ export function getTypeLen(e: ExtensionType): number {
             return IMMUTABLE_OWNER_SIZE;
         case ExtensionType.MemoTransfer:
             return 1;
+        case ExtensionType.NonTransferable:
+            return NON_TRANSFERABLE_SIZE;
         default:
             throw Error(`Unknown extension type: ${e}`);
     }
@@ -60,6 +64,7 @@ export function getAccountTypeOfMintType(e: ExtensionType): ExtensionType {
         case ExtensionType.ImmutableOwner:
         case ExtensionType.MemoTransfer:
         case ExtensionType.MintCloseAuthority:
+        case ExtensionType.NonTransferable:
         case ExtensionType.Uninitialized:
             return ExtensionType.Uninitialized;
     }

--- a/token/js/src/extensions/index.ts
+++ b/token/js/src/extensions/index.ts
@@ -2,4 +2,5 @@ export * from './accountType';
 export * from './extensionType';
 export * from './mintCloseAuthority';
 export * from './immutableOwner';
+export * from './nonTransferable';
 export * from './transferFee/index';

--- a/token/js/src/extensions/nonTransferable.ts
+++ b/token/js/src/extensions/nonTransferable.ts
@@ -1,0 +1,20 @@
+import { struct } from '@solana/buffer-layout';
+import { Mint } from '../state/mint';
+import { ExtensionType, getExtensionData } from './extensionType';
+
+/** Non-transferable state as stored by the program */
+export interface NonTransferable {} // eslint-disable-line
+
+/** Buffer layout for de/serializing an account */
+export const NonTransferableLayout = struct<NonTransferable>([]);
+
+export const NON_TRANSFERABLE_SIZE = NonTransferableLayout.span;
+
+export function getNonTransferable(mint: Mint): NonTransferable | null {
+    const extensionData = getExtensionData(ExtensionType.NonTransferable, mint.tlvData);
+    if (extensionData !== null) {
+        return NonTransferableLayout.decode(extensionData);
+    } else {
+        return null;
+    }
+}

--- a/token/js/src/instructions/index.ts
+++ b/token/js/src/instructions/index.ts
@@ -24,6 +24,7 @@ export * from './initializeMint2'; //     20
 export * from './initializeImmutableOwner'; //  22
 export * from './initializeMintCloseAuthority'; // 23
 export * from './createNativeMint'; //    29
+export * from './initializeNonTransferableMint'; //    32
 
 export * from './decode';
 

--- a/token/js/src/instructions/initializeNonTransferableMint.ts
+++ b/token/js/src/instructions/initializeNonTransferableMint.ts
@@ -1,0 +1,38 @@
+import { struct, u8 } from '@solana/buffer-layout';
+import { PublicKey, TransactionInstruction } from '@solana/web3.js';
+import { TokenInstruction } from './types';
+
+/** Deserialized instruction for the initiation of an immutable owner account */
+export interface InitializeNonTransferableMintInstructionData {
+    instruction: TokenInstruction.InitializeNonTransferableMint;
+}
+
+/** The struct that represents the instruction data as it is read by the program */
+export const initializeNonTransferableMintInstructionData = struct<InitializeNonTransferableMintInstructionData>([
+    u8('instruction'),
+]);
+
+/**
+ * Construct an InitializeNonTransferableMint instruction
+ *
+ * @param mint           Mint Account to make non-transferable
+ * @param programId         SPL Token program account
+ *
+ * @return Instruction to add to a transaction
+ */
+export function createInitializeNonTransferableMintInstruction(
+    mint: PublicKey,
+    programId: PublicKey
+): TransactionInstruction {
+    const keys = [{ pubkey: mint, isSigner: false, isWritable: true }];
+
+    const data = Buffer.alloc(initializeNonTransferableMintInstructionData.span);
+    initializeNonTransferableMintInstructionData.encode(
+        {
+            instruction: TokenInstruction.InitializeNonTransferableMint,
+        },
+        data
+    );
+
+    return new TransactionInstruction({ keys, programId, data });
+}

--- a/token/js/src/instructions/types.ts
+++ b/token/js/src/instructions/types.ts
@@ -32,4 +32,5 @@ export enum TokenInstruction {
     Reallocate = 29,
     MemoTransferExtension = 30,
     CreateNativeMint = 31,
+    InitializeNonTransferableMint = 32,
 }

--- a/token/js/test/e2e-2022/nonTransferableMint.test.ts
+++ b/token/js/test/e2e-2022/nonTransferableMint.test.ts
@@ -1,0 +1,106 @@
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+chai.use(chaiAsPromised);
+
+import {
+    sendAndConfirmTransaction,
+    Connection,
+    Keypair,
+    PublicKey,
+    Signer,
+    SystemProgram,
+    Transaction,
+} from '@solana/web3.js';
+import {
+    createInitializeMintInstruction,
+    createInitializeNonTransferableMintInstruction,
+    createInitializeImmutableOwnerInstruction,
+    createInitializeAccountInstruction,
+    mintTo,
+    getAccountLen,
+    getMint,
+    getMintLen,
+    getNonTransferable,
+    transfer,
+    ExtensionType,
+} from '../../src';
+import { TEST_PROGRAM_ID, newAccountWithLamports, getConnection } from '../common';
+
+const TEST_TOKEN_DECIMALS = 2;
+const EXTENSIONS = [ExtensionType.NonTransferable];
+describe('nonTransferable', () => {
+    let connection: Connection;
+    let payer: Signer;
+    let mint: PublicKey;
+    let mintAuthority: Keypair;
+    before(async () => {
+        connection = await getConnection();
+        payer = await newAccountWithLamports(connection, 1000000000);
+        mintAuthority = Keypair.generate();
+    });
+    beforeEach(async () => {
+        const mintKeypair = Keypair.generate();
+        mint = mintKeypair.publicKey;
+        const mintLen = getMintLen(EXTENSIONS);
+        const lamports = await connection.getMinimumBalanceForRentExemption(mintLen);
+
+        const transaction = new Transaction().add(
+            SystemProgram.createAccount({
+                fromPubkey: payer.publicKey,
+                newAccountPubkey: mint,
+                space: mintLen,
+                lamports,
+                programId: TEST_PROGRAM_ID,
+            }),
+            createInitializeNonTransferableMintInstruction(mint, TEST_PROGRAM_ID),
+            createInitializeMintInstruction(mint, TEST_TOKEN_DECIMALS, mintAuthority.publicKey, null, TEST_PROGRAM_ID)
+        );
+
+        await sendAndConfirmTransaction(connection, transaction, [payer, mintKeypair], undefined);
+    });
+    it('fails transfer', async () => {
+        const mintInfo = await getMint(connection, mint, undefined, TEST_PROGRAM_ID);
+        const nonTransferable = getNonTransferable(mintInfo);
+        expect(nonTransferable).to.not.be.null;
+
+        const owner = Keypair.generate();
+        const accountLen = getAccountLen([ExtensionType.ImmutableOwner]);
+        const lamports = await connection.getMinimumBalanceForRentExemption(accountLen);
+
+        const sourceKeypair = Keypair.generate();
+        const source = sourceKeypair.publicKey;
+        let transaction = new Transaction().add(
+            SystemProgram.createAccount({
+                fromPubkey: payer.publicKey,
+                newAccountPubkey: source,
+                space: accountLen,
+                lamports,
+                programId: TEST_PROGRAM_ID,
+            }),
+            createInitializeImmutableOwnerInstruction(source, TEST_PROGRAM_ID),
+            createInitializeAccountInstruction(source, mint, owner.publicKey, TEST_PROGRAM_ID)
+        );
+        await sendAndConfirmTransaction(connection, transaction, [payer, sourceKeypair], undefined);
+
+        const destinationKeypair = Keypair.generate();
+        const destination = destinationKeypair.publicKey;
+        transaction = new Transaction().add(
+            SystemProgram.createAccount({
+                fromPubkey: payer.publicKey,
+                newAccountPubkey: destination,
+                space: accountLen,
+                lamports,
+                programId: TEST_PROGRAM_ID,
+            }),
+            createInitializeImmutableOwnerInstruction(destination, TEST_PROGRAM_ID),
+            createInitializeAccountInstruction(destination, mint, owner.publicKey, TEST_PROGRAM_ID)
+        );
+        await sendAndConfirmTransaction(connection, transaction, [payer, destinationKeypair], undefined);
+
+        const amount = BigInt(1000);
+        await mintTo(connection, payer, mint, source, mintAuthority, amount, [], undefined, TEST_PROGRAM_ID);
+
+        expect(transfer(connection, payer, source, destination, owner, amount, [], undefined, TEST_PROGRAM_ID)).to.be
+            .rejected;
+    });
+});


### PR DESCRIPTION
#### Problem

Non-transferable token mints are supported in token-2022, but there are no JS bindings to interact with it.

#### Solution

Add JS bindings and tests.