### PR TITLE
token-js: Add memo transfer support

### DIFF
--- a/token/js/package.json
+++ b/token/js/package.json
@@ -45,6 +45,7 @@
         "@solana/web3.js": "^1.41.0"
     },
     "devDependencies": {
+        "@solana/spl-memo": "^0.1.0",
         "@types/chai-as-promised": "^7.1.4",
         "@types/eslint": "^8.4.0",
         "@types/eslint-plugin-prettier": "^3.1.0",

--- a/token/js/src/extensions/extensionType.ts
+++ b/token/js/src/extensions/extensionType.ts
@@ -2,6 +2,7 @@ import { ACCOUNT_SIZE } from '../state/account';
 import { Mint, MINT_SIZE } from '../state/mint';
 import { MULTISIG_SIZE } from '../state/multisig';
 import { ACCOUNT_TYPE_SIZE } from './accountType';
+import { MEMO_TRANSFER_SIZE } from './memoTransfer';
 import { MINT_CLOSE_AUTHORITY_SIZE } from './mintCloseAuthority';
 import { IMMUTABLE_OWNER_SIZE } from './immutableOwner';
 import { TRANSFER_FEE_CONFIG_SIZE, TRANSFER_FEE_AMOUNT_SIZE } from './transferFee';
@@ -42,7 +43,7 @@ export function getTypeLen(e: ExtensionType): number {
         case ExtensionType.ImmutableOwner:
             return IMMUTABLE_OWNER_SIZE;
         case ExtensionType.MemoTransfer:
-            return 1;
+            return MEMO_TRANSFER_SIZE;
         default:
             throw Error(`Unknown extension type: ${e}`);
     }

--- a/token/js/src/extensions/index.ts
+++ b/token/js/src/extensions/index.ts
@@ -1,5 +1,6 @@
 export * from './accountType';
 export * from './extensionType';
+export * from './memoTransfer/index';
 export * from './mintCloseAuthority';
 export * from './immutableOwner';
 export * from './transferFee/index';

--- a/token/js/src/extensions/memoTransfer/actions.ts
+++ b/token/js/src/extensions/memoTransfer/actions.ts
@@ -1,0 +1,77 @@
+import {
+    ConfirmOptions,
+    Connection,
+    PublicKey,
+    sendAndConfirmTransaction,
+    Signer,
+    Transaction,
+    TransactionSignature,
+} from '@solana/web3.js';
+import { TOKEN_2022_PROGRAM_ID } from '../../constants';
+import {
+    createEnableRequiredMemoTransfersInstruction,
+    createDisableRequiredMemoTransfersInstruction,
+} from './instructions';
+import { getSigners } from '../../actions/internal';
+
+/**
+ * Enable memo transfers on the given account
+ *
+ * @param connection     Connection to use
+ * @param payer          Payer of the transaction fees
+ * @param account        Account to modify
+ * @param owner          Owner of the account
+ * @param multiSigners   Signing accounts if `owner` is a multisig
+ * @param confirmOptions Options for confirming the transaction
+ * @param programId      SPL Token program account
+ *
+ * @return Signature of the confirmed transaction
+ */
+export async function enableRequiredMemoTransfers(
+    connection: Connection,
+    payer: Signer,
+    account: PublicKey,
+    owner: Signer | PublicKey,
+    multiSigners: Signer[] = [],
+    confirmOptions?: ConfirmOptions,
+    programId = TOKEN_2022_PROGRAM_ID
+): Promise<TransactionSignature> {
+    const [ownerPublicKey, signers] = getSigners(owner, multiSigners);
+
+    const transaction = new Transaction().add(
+        createEnableRequiredMemoTransfersInstruction(account, ownerPublicKey, signers, programId)
+    );
+
+    return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);
+}
+
+/**
+ * Disable memo transfers on the given account
+ *
+ * @param connection     Connection to use
+ * @param payer          Payer of the transaction fees
+ * @param account        Account to modify
+ * @param owner          Owner of the account
+ * @param multiSigners   Signing accounts if `owner` is a multisig
+ * @param confirmOptions Options for confirming the transaction
+ * @param programId      SPL Token program account
+ *
+ * @return Signature of the confirmed transaction
+ */
+export async function disableRequiredMemoTransfers(
+    connection: Connection,
+    payer: Signer,
+    account: PublicKey,
+    owner: Signer | PublicKey,
+    multiSigners: Signer[] = [],
+    confirmOptions?: ConfirmOptions,
+    programId = TOKEN_2022_PROGRAM_ID
+): Promise<TransactionSignature> {
+    const [ownerPublicKey, signers] = getSigners(owner, multiSigners);
+
+    const transaction = new Transaction().add(
+        createDisableRequiredMemoTransfersInstruction(account, ownerPublicKey, signers, programId)
+    );
+
+    return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);
+}

--- a/token/js/src/extensions/memoTransfer/index.ts
+++ b/token/js/src/extensions/memoTransfer/index.ts
@@ -1,0 +1,3 @@
+export * from './actions';
+export * from './instructions';
+export * from './state';

--- a/token/js/src/extensions/memoTransfer/instructions.ts
+++ b/token/js/src/extensions/memoTransfer/instructions.ts
@@ -1,0 +1,84 @@
+import { struct, u8 } from '@solana/buffer-layout';
+import { PublicKey, Signer, TransactionInstruction } from '@solana/web3.js';
+import { TokenInstruction } from '../../instructions/types';
+import { TOKEN_2022_PROGRAM_ID } from '../../constants';
+
+export enum MemoTransferInstruction {
+    Enable = 0,
+    Disable = 1,
+}
+
+/** TODO: docs */
+export interface MemoTransferInstructionData {
+    instruction: TokenInstruction.MemoTransferExtension;
+    memoTransferInstruction: MemoTransferInstruction;
+}
+
+/** TODO: docs */
+export const memoTransferInstructionData = struct<MemoTransferInstructionData>([
+    u8('instruction'),
+    u8('memoTransferInstruction'),
+]);
+
+/**
+ * Construct an EnableRequiredMemoTransfers instruction
+ *
+ * @param account         Token account to update
+ * @param authority       The account's owner/delegate
+ * @param signers         The signer account(s)
+ * @param programId       SPL Token program account
+ *
+ * @return Instruction to add to a transaction
+ */
+export function createEnableRequiredMemoTransfersInstruction(
+    account: PublicKey,
+    authority: PublicKey,
+    multiSigners: Signer[] = [],
+    programId = TOKEN_2022_PROGRAM_ID
+): TransactionInstruction {
+    return createMemoTransferInstruction(/* enable */ true, account, authority, multiSigners, programId);
+}
+
+/**
+ * Construct a DisableMemoTransfer instruction
+ *
+ * @param account         Token account to update
+ * @param authority       The account's owner/delegate
+ * @param signers         The signer account(s)
+ * @param programId       SPL Token program account
+ *
+ * @return Instruction to add to a transaction
+ */
+export function createDisableRequiredMemoTransfersInstruction(
+    account: PublicKey,
+    authority: PublicKey,
+    multiSigners: Signer[] = [],
+    programId = TOKEN_2022_PROGRAM_ID
+): TransactionInstruction {
+    return createMemoTransferInstruction(/* enable */ false, account, authority, multiSigners, programId);
+}
+
+function createMemoTransferInstruction(
+    enable: boolean,
+    account: PublicKey,
+    authority: PublicKey,
+    multiSigners: Signer[],
+    programId: PublicKey
+): TransactionInstruction {
+    const keys = [{ pubkey: account, isSigner: false, isWritable: true }];
+    keys.push({ pubkey: authority, isSigner: !multiSigners.length, isWritable: false });
+    for (const signer of multiSigners) {
+        keys.push({ pubkey: signer.publicKey, isSigner: true, isWritable: false });
+    }
+
+    const data = Buffer.alloc(memoTransferInstructionData.span);
+    memoTransferInstructionData.encode(
+        {
+            instruction: TokenInstruction.MemoTransferExtension,
+            memoTransferInstruction: enable ? MemoTransferInstruction.Enable : MemoTransferInstruction.Disable,
+        },
+        data
+    );
+
+    return new TransactionInstruction({ keys, programId, data });
+}

--- a/token/js/src/extensions/memoTransfer/state.ts
+++ b/token/js/src/extensions/memoTransfer/state.ts
@@ -1,0 +1,24 @@
+import { struct } from '@solana/buffer-layout';
+import { bool } from '@solana/buffer-layout-utils';
+import { Account } from '../../state';
+import { ExtensionType, getExtensionData } from '../extensionType';
+
+/** MemoTransfer as stored by the program */
+export interface MemoTransfer {
+    /** Require transfers into this account to be accompanied by a memo */
+    requireIncomingTransferMemos: boolean;
+}
+
+/** Buffer layout for de/serializing a transfer fee config extension */
+export const MemoTransferLayout = struct<MemoTransfer>([bool('requireIncomingTransferMemos')]);
+
+export const MEMO_TRANSFER_SIZE = MemoTransferLayout.span;
+
+export function getMemoTransfer(account: Account): MemoTransfer | null {
+    const extensionData = getExtensionData(ExtensionType.MemoTransfer, account.tlvData);
+    if (extensionData !== null) {
+        return MemoTransferLayout.decode(extensionData);
+    } else {
+        return null;
+    }
+}

--- a/token/js/src/instructions/initializeAccount3.ts
+++ b/token/js/src/instructions/initializeAccount3.ts
@@ -1,7 +1,7 @@
 import { TokenInstruction } from './types';
 import { struct, u8 } from '@solana/buffer-layout';
 import { publicKey } from '@solana/buffer-layout-utils';
-import { AccountMeta, PublicKey, SYSVAR_RENT_PUBKEY, TransactionInstruction } from '@solana/web3.js';
+import { AccountMeta, PublicKey, TransactionInstruction } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ID } from '../constants';
 import {
     TokenInvalidInstructionDataError,

--- a/token/js/test/e2e-2022/memoTransfer.test.ts
+++ b/token/js/test/e2e-2022/memoTransfer.test.ts
@@ -1,0 +1,128 @@
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+chai.use(chaiAsPromised);
+
+import {
+    sendAndConfirmTransaction,
+    Connection,
+    Keypair,
+    PublicKey,
+    Signer,
+    SystemProgram,
+    Transaction,
+} from '@solana/web3.js';
+import { createMemoInstruction } from '@solana/spl-memo';
+import {
+    createAccount,
+    createMint,
+    createEnableRequiredMemoTransfersInstruction,
+    createInitializeAccountInstruction,
+    createTransferInstruction,
+    getAccount,
+    getMemoTransfer,
+    disableRequiredMemoTransfers,
+    enableRequiredMemoTransfers,
+    mintTo,
+    transfer,
+    getAccountLen,
+    ExtensionType,
+} from '../../src';
+import { TEST_PROGRAM_ID, newAccountWithLamports, getConnection } from '../common';
+
+const TEST_TOKEN_DECIMALS = 2;
+const TRANSFER_AMOUNT = 1_000;
+const EXTENSIONS = [ExtensionType.MemoTransfer];
+describe('memoTransfer', () => {
+    let connection: Connection;
+    let payer: Signer;
+    let owner: Keypair;
+    let mint: PublicKey;
+    let mintAuthority: Keypair;
+    let source: PublicKey;
+    let destination: PublicKey;
+    before(async () => {
+        connection = await getConnection();
+        payer = await newAccountWithLamports(connection, 1000000000);
+        mintAuthority = Keypair.generate();
+        owner = Keypair.generate();
+    });
+    beforeEach(async () => {
+        const mintKeypair = Keypair.generate();
+        mint = await createMint(
+            connection,
+            payer,
+            mintAuthority.publicKey,
+            mintAuthority.publicKey,
+            TEST_TOKEN_DECIMALS,
+            mintKeypair,
+            undefined,
+            TEST_PROGRAM_ID
+        );
+
+        source = await createAccount(
+            connection,
+            payer,
+            mint,
+            owner.publicKey,
+            undefined, // uses ATA by default
+            undefined,
+            TEST_PROGRAM_ID
+        );
+
+        const destinationKeypair = Keypair.generate();
+        destination = destinationKeypair.publicKey;
+        const accountLen = getAccountLen(EXTENSIONS);
+        const lamports = await connection.getMinimumBalanceForRentExemption(accountLen);
+
+        const transaction = new Transaction().add(
+            SystemProgram.createAccount({
+                fromPubkey: payer.publicKey,
+                newAccountPubkey: destination,
+                space: accountLen,
+                lamports,
+                programId: TEST_PROGRAM_ID,
+            }),
+            createInitializeAccountInstruction(destination, mint, owner.publicKey, TEST_PROGRAM_ID),
+            createEnableRequiredMemoTransfersInstruction(destination, owner.publicKey, [], TEST_PROGRAM_ID)
+        );
+
+        await sendAndConfirmTransaction(connection, transaction, [payer, owner, destinationKeypair], undefined);
+        await mintTo(
+            connection,
+            payer,
+            mint,
+            source,
+            mintAuthority,
+            TRANSFER_AMOUNT * 10,
+            [],
+            undefined,
+            TEST_PROGRAM_ID
+        );
+    });
+    it('fails without memo when enabled', async () => {
+        const accountInfo = await getAccount(connection, destination, undefined, TEST_PROGRAM_ID);
+        const memoTransfer = getMemoTransfer(accountInfo);
+        expect(memoTransfer).to.not.be.null;
+        if (memoTransfer !== null) {
+            expect(memoTransfer.requireIncomingTransferMemos).to.be.true;
+        }
+        expect(transfer(connection, payer, source, destination, owner, TRANSFER_AMOUNT, [], undefined, TEST_PROGRAM_ID))
+            .to.be.rejected;
+    });
+    it('works without memo when disabled', async () => {
+        await disableRequiredMemoTransfers(connection, payer, destination, owner, [], undefined, TEST_PROGRAM_ID);
+        await transfer(connection, payer, source, destination, owner, TRANSFER_AMOUNT, [], undefined, TEST_PROGRAM_ID);
+        await enableRequiredMemoTransfers(connection, payer, destination, owner, [], undefined, TEST_PROGRAM_ID);
+        expect(transfer(connection, payer, source, destination, owner, TRANSFER_AMOUNT, [], undefined, TEST_PROGRAM_ID))
+            .to.be.rejected;
+    });
+    it('works with memo when enabled', async () => {
+        const transaction = new Transaction().add(
+            createMemoInstruction('transfer with a memo', [payer.publicKey, owner.publicKey]),
+            createTransferInstruction(source, destination, owner.publicKey, TRANSFER_AMOUNT, [], TEST_PROGRAM_ID)
+        );
+        await sendAndConfirmTransaction(connection, transaction, [payer, owner], {
+            preflightCommitment: 'confirmed',
+        });
+    });
+});

--- a/token/js/yarn.lock
+++ b/token/js/yarn.lock
@@ -143,6 +143,14 @@
   dependencies:
     buffer "~6.0.3"
 
+"@solana/spl-memo@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@solana/spl-memo/-/spl-memo-0.1.0.tgz#2578a48da5184b306195bef0d658dec532b46c74"
+  integrity sha512-2Ob89TYXVkLXsdRIsVh9H/9rJrVXpOTapn/f/32n5/B8JRaSRBcVBLIAgAwSjMH1oJdBlmBO0lt8+cbWBrRLuA==
+  dependencies:
+    "@solana/web3.js" "^1.41.0"
+    buffer "^6.0.3"
+
 "@solana/web3.js@^1.32.0", "@solana/web3.js@^1.41.0":
   version "1.41.10"
   resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.41.10.tgz#fb1bf7d8ca25f126a2166fed1733fe357298a076"
@@ -595,7 +603,7 @@ buffer@6.0.1:
     base64-js "^1.3.1"
     ieee754 "^1.2.1"
 
-buffer@~6.0.3:
+buffer@^6.0.3, buffer@~6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
   integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==


### PR DESCRIPTION
#### Problem

An extension requiring incoming transfers to have a memo exists in token-2022, but isn't supported in JS.

#### Solution

Add the bindings!

Fixes #2960