### PR TITLE
Check if amount+supply not greater than u64 supply limit: Issue 1983 error if more than max supply is minted

### DIFF
--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -985,6 +985,7 @@ fn command_mint(
     let max_denom =10;
     let max_denom = u64::pow(max_denom, decimals.into());
     let max_supply = u64::MAX/max_denom;
+    //For decimals:  max(u64)/(10^decimals) with integer divsion will be the max token supply we can get
     if amount>max_supply {
         println!("WARNING: Max supply will be limited to {}",max_supply);
     };

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -943,6 +943,21 @@ fn command_burn(
     })
 }
 
+
+fn check_mint(
+    config: &Config,
+    token: Pubkey,
+    ui_amount : f64,
+) -> bool {
+    let supply = config.rpc_client.get_token_supply(&token).unwrap();
+    let amount = ui_amount;
+    if amount + supply.ui_amount.unwrap()> 18446744073709551615.0 {
+    return true;
+    };
+    return false;
+}
+    
+
 #[allow(clippy::too_many_arguments)]
 fn command_mint(
     config: &Config,
@@ -2885,6 +2900,10 @@ fn process_command(
             );
             let mint_decimals = value_of::<u8>(arg_matches, MINT_DECIMALS_ARG.name);
             let use_unchecked_instruction = arg_matches.is_present("use_unchecked_instruction");
+            if check_mint(config, token, amount) {
+                return Err("Supply requested to be minted is greater than the u64 token supply limit".to_string().into());
+            }
+            else {
             command_mint(
                 config,
                 token,
@@ -2895,6 +2914,8 @@ fn process_command(
                 use_unchecked_instruction,
                 bulk_signers,
             )
+        }
+
         }
         (CommandName::Freeze, arg_matches) => {
             let (freeze_authority_signer, freeze_authority) =

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -963,6 +963,8 @@ fn check_if_amount_overflows_supply(
 ) -> bool {
     let supply = config.rpc_client.get_token_supply(&token).unwrap();
     let amount = ui_amount;
+    //let max = u64::MAX;
+    //println!("{}", max);
     //println!("{}", supply.ui_amount.unwrap());
     //println!("{}", amount);
     //let sum1 = supply.ui_amount.unwrap()+amount;
@@ -975,7 +977,12 @@ fn check_if_amount_overflows_supply(
     println!("{}", supply.amount);
     let s = supply.amount;
     let my_int: u64 = s.parse().unwrap();
-
+    let aaa = 18446744073709551615 as u64;
+    let b = aaa as f64;
+    let ss: String = aaa.to_string();
+    let testint = ss.parse::<f64>().unwrap();
+    println!("Check {}", testint);
+    
     if amount.checked_add(my_int).is_none() {
         return true;
     };
@@ -984,6 +991,7 @@ fn check_if_amount_overflows_supply(
     return true;
     };
     return false;
+
 }
     
 
@@ -1018,25 +1026,26 @@ fn command_mint(
     let amount = 0;
     let amount = if decimals==0 {
         ui_amount
+        //spl_token::ui_amount_to_amount(ui_amount as f64, decimals)
         //println!("{}", decimals);
         //println!("{}", amount);
     }
     else {
-        spl_token::ui_amount_to_amount(ui_amount as f64, decimals)
+        spl_token::ui_amount_to_amount2(ui_amount, decimals)
         //println!("Hello");
         //println!("{}", decimals);
         //println!("{}", amount);
+
+        //Do everything in fixed point
+
     };
-
-
-
 
     //The issue happens here!
 
     // println!("{}", decimals);
     // let amount = ui_amount;
     // println!("{}", amount);
-    println!("{}", amount);
+    println!("STRANGE FUNCTION {}", amount);
     let instructions = if use_unchecked_instruction {
         vec![mint_to(
             &config.program_id,

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -1007,6 +1007,14 @@ fn command_mint(
     );
 
     let (_, decimals) = resolve_mint_info(config, &recipient, None, mint_decimals)?;
+    
+    let a =10;
+    let a = u64::pow(a, decimals.into());
+    let maxsupply = u64::MAX/a;
+    if ui_amount>maxsupply {
+        println!("WARNING: Max supply will be limited to {}",maxsupply);
+    };
+    //Code is not production level ready yet
     let amount = 0;
     let amount = if decimals==0 {
         ui_amount
@@ -1019,6 +1027,10 @@ fn command_mint(
         //println!("{}", decimals);
         //println!("{}", amount);
     };
+
+
+
+
     //The issue happens here!
 
     // println!("{}", decimals);

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -2155,6 +2155,7 @@ fn app<'a, 'b>(
                         .required(true)
                         .help("The token to mint"),
                 )
+                
                 .arg(
                     Arg::with_name("amount")
                         .validator(is_amount)
@@ -2185,6 +2186,16 @@ fn app<'a, 'b>(
                              Defaults to the client keypair."
                         ),
                 )
+                .arg(
+                    Arg::with_name("overmint")
+                        .long("overmint-tokens")
+                        .value_name("FORMAT")
+                        .global(false)
+                        .takes_value(false)
+                        //.possible_values(&["true", "json-compact"])
+                        .help("Overmint tokens and bypass check"),
+                )
+
                 .arg(mint_decimals_arg())
                 .arg(multisig_signer_arg())
                 .nonce_args(true)
@@ -2907,6 +2918,22 @@ fn process_command(
             );
             let mint_decimals = value_of::<u8>(arg_matches, MINT_DECIMALS_ARG.name);
             let use_unchecked_instruction = arg_matches.is_present("use_unchecked_instruction");
+            let overmint_flag = arg_matches.is_present("overmint");
+            //Disable overflow check - change flag name.
+
+            if overmint_flag {
+                command_mint(
+                    config,
+                    token,
+                    amount,
+                    recipient,
+                    mint_decimals,
+                    mint_authority,
+                    use_unchecked_instruction,
+                    bulk_signers,
+                )
+            }
+            else {
 
             if check_if_amount_overflows_supply(config, token, amount) {
                 return Err("Supply requested to be minted is greater than the u64 token supply limit".to_string().into());
@@ -2921,7 +2948,8 @@ fn process_command(
                 mint_authority,
                 use_unchecked_instruction,
                 bulk_signers,
-            )
+                )
+            }
         }
 
         }

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -944,7 +944,7 @@ fn command_burn(
 }
 
 
-fn check_mint(
+fn check_if_amount_overflows_supply(  
     config: &Config,
     token: Pubkey,
     ui_amount : f64,
@@ -2900,7 +2900,7 @@ fn process_command(
             );
             let mint_decimals = value_of::<u8>(arg_matches, MINT_DECIMALS_ARG.name);
             let use_unchecked_instruction = arg_matches.is_present("use_unchecked_instruction");
-            if check_mint(config, token, amount) {
+            if check_if_amount_overflows_supply(config, token, amount) {
                 return Err("Supply requested to be minted is greater than the u64 token supply limit".to_string().into());
             }
             else {

--- a/token/program/src/lib.rs
+++ b/token/program/src/lib.rs
@@ -22,7 +22,8 @@ pub fn ui_amount_to_amount(ui_amount: f64, decimals: u8) -> u64 {
     (ui_amount * 10_usize.pow(decimals as u32) as f64) as u64
 }
 
-/// test
+/// Convert the UI representation of a token amount (using the decimals field defined in its mint)
+/// to the raw amount. Used for ui_amount as u64 to have precision upto 20 digits
 pub fn ui_amount_to_amountmint(ui_amount: u64, decimals: u8) -> u64 {
     (ui_amount * 10_usize.pow(decimals as u32) as u64) as u64
 }

--- a/token/program/src/lib.rs
+++ b/token/program/src/lib.rs
@@ -22,6 +22,11 @@ pub fn ui_amount_to_amount(ui_amount: f64, decimals: u8) -> u64 {
     (ui_amount * 10_usize.pow(decimals as u32) as f64) as u64
 }
 
+/// test
+pub fn ui_amount_to_amount2(ui_amount: u64, decimals: u8) -> u64 {
+    (ui_amount * 10_usize.pow(decimals as u32) as u64) as u64
+}
+
 /// Convert a raw amount to its UI representation (using the decimals field defined in its mint)
 pub fn amount_to_ui_amount(amount: u64, decimals: u8) -> f64 {
     amount as f64 / 10_usize.pow(decimals as u32) as f64

--- a/token/program/src/lib.rs
+++ b/token/program/src/lib.rs
@@ -23,7 +23,7 @@ pub fn ui_amount_to_amount(ui_amount: f64, decimals: u8) -> u64 {
 }
 
 /// test
-pub fn ui_amount_to_amount2(ui_amount: u64, decimals: u8) -> u64 {
+pub fn ui_amount_to_amountmint(ui_amount: u64, decimals: u8) -> u64 {
     (ui_amount * 10_usize.pow(decimals as u32) as u64) as u64
 }
 


### PR DESCRIPTION
Fixed issue #1983
Total supply implemented in u64, which means that total tokens that can be minted is 18,446,744,073,709,551,615

This means that the amount requested to be minted and the total current supply, summed up, should be less than 2^64

As of this commit, an error is thrown if this sum exceeds 2^64. This happens in the check_mint function. However, the next commits in this pull request will add a flag to overmint tokens and work on the following edge cases:

Edge case 1:
After the decimals have been checked and already stated, 
Do 20-decimals = y
Now a number with y digits is the maximum token supply that one can get

Edge case 2:
In fact, another nuance would be that we’d do min(check3, 18,446,744,073,709,551,615/(10^decimals))

Edge case 3 (Not important):
Number of decimals not greater than 20
