### PR TITLE
token-cli: Fix unexpected behavior when closing a wrapped SOL account with another wrapped SOL account as recipient

### DIFF
--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -1351,8 +1351,9 @@ fn command_close(
     recipient: Pubkey,
     bulk_signers: BulkSigners,
 ) -> CommandResult {
-    let mut is_recipient_wrapped = false;
-    if !config.sign_only {
+    let is_recipient_wrapped = if config.sign_only {
+        false
+    } else {
         let source_account = config
             .rpc_client
             .get_token_account(&account)?
@@ -1378,8 +1379,9 @@ fn command_close(
         }
 
         let recipient_account = config.rpc_client.get_token_account(&recipient)?;
-        is_recipient_wrapped = recipient_account.is_some() && recipient_account.unwrap().is_native;
-    }
+
+        recipient_account.map(|x| x.is_native).unwrap_or(false)
+    };
 
     let mut instructions = vec![close_account(
         &config.program_id,

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -3656,14 +3656,7 @@ mod tests {
         let token = create_token(&config, &payer);
         let source = create_associated_account(&config, &payer, token);
         let ui_amount = 10.0;
-        command_wrap(
-            &config,
-            ui_amount,
-            payer.pubkey(),
-            None,
-            bulk_signers,
-        )
-        .unwrap();
+        command_wrap(&config, ui_amount, payer.pubkey(), None, bulk_signers).unwrap();
 
         let recipient = get_associated_token_address_with_program_id(
             &payer.pubkey(),
@@ -3676,7 +3669,9 @@ mod tests {
             &[
                 "spl-token",
                 CommandName::Close.into(),
+                "--address",
                 &source.to_string(),
+                "--recipient",
                 &recipient.to_string(),
             ],
         );
@@ -3686,7 +3681,7 @@ mod tests {
             .get_token_account(&recipient)
             .unwrap()
             .unwrap();
-        assert_eq!(ui_account.token_amount.amount, "10");
+        assert_eq!(ui_account.token_amount.amount, "10000000000");
     }
 
     #[test]

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -39,7 +39,7 @@ use solana_sdk::{
     pubkey::Pubkey,
     signature::{Keypair, Signer},
     system_instruction, system_program,
-    transaction::Transaction
+    transaction::Transaction,
 };
 use spl_associated_token_account::{
     get_associated_token_address_with_program_id, instruction::create_associated_token_account,
@@ -1351,6 +1351,7 @@ fn command_close(
     recipient: Pubkey,
     bulk_signers: BulkSigners,
 ) -> CommandResult {
+    let mut is_recipient_wrapped = false;
     if !config.sign_only {
         let source_account = config
             .rpc_client
@@ -1375,6 +1376,9 @@ fn command_close(
             )
             .into());
         }
+
+        let recipient_account = config.rpc_client.get_token_account(&recipient)?;
+        is_recipient_wrapped = recipient_account.is_some() && recipient_account.unwrap().is_native;
     }
 
     let mut instructions = vec![close_account(
@@ -1385,11 +1389,7 @@ fn command_close(
         &config.multisigner_pubkeys,
     )?];
 
-    let recipient_account = config
-        .rpc_client
-        .get_token_account(&recipient)?;
-
-    if !recipient_account.is_none() && recipient_account.unwrap().is_native {
+    if is_recipient_wrapped {
         instructions.push(sync_native(&config.program_id, &recipient)?);
     }
 

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -3660,7 +3660,7 @@ mod tests {
             &config,
             ui_amount,
             payer.pubkey(),
-            Some(source),
+            None,
             bulk_signers,
         )
         .unwrap();


### PR DESCRIPTION
Fixes: #887

Tacked on a sync-native instruction if the destination is a wrapped account.