### PR TITLE
spl-token-client: Added a new function get_or_create_associated_token_account (#3220)

### DIFF
--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -430,6 +430,22 @@ where
             .ok_or(TokenError::AccountNotFound)
     }
 
+    /// Retrieve a raw associated account or create one if not exists
+    pub async fn get_or_create_associated_token_account(
+        &self,
+        owner: &Pubkey,
+    ) -> TokenResult<BaseAccount> {
+        let account = self.get_associated_token_address(owner);
+        match self.get_account(&account).await {
+            Ok(account) => Ok(account),
+            Err(TokenError::AccountNotFound) => {
+                self.create_associated_token_account(owner).await?;
+                self.get_account(&account).await
+            }
+            Err(error) => Err(error),
+        }
+    }
+
     /// Retrive mint information.
     pub async fn get_mint_info(&self) -> TokenResult<StateWithExtensionsOwned<Mint>> {
         let account = self.get_account(&self.pubkey).await?;

--- a/token/client/tests/program-test.rs
+++ b/token/client/tests/program-test.rs
@@ -4,6 +4,7 @@ use {
         ProgramTest,
     },
     solana_sdk::{
+        account::Account,
         program_option::COption,
         signer::{keypair::Keypair, Signer},
     },
@@ -130,6 +131,20 @@ async fn get_or_create_associated_token_account() {
             is_native: COption::None,
             delegated_amount: 0,
             close_authority: COption::None,
+        }
+    );
+
+    assert_eq!(
+        token
+            .get_or_create_associated_token_account(&alice.pubkey())
+            .await
+            .expect("failed to get account"),
+        Account {
+            lamports: 0,
+            data: vec![],
+            owner: alice.pubkey(),
+            executable: false,
+            rent_epoch: 0
         }
     );
 }


### PR DESCRIPTION
Fixes (#3220 )
* Added function get_or_create_associated_token_account which
  create a new account if not found and returns the raw account.

I have few doubts regarding the function :
1). There is already a function quite similar to this ,```get_or_create_associated_account_info```, can you please tell me how the new function would be different from this, currently i implemented the function to return a raw account instead of account information.

https://github.com/solana-labs/solana-program-library/blob/0f316fb3575b4acdebb51e7d84f97d397b17290d/token/client/src/token.rs#L461

2). I am not able to test the function , getting the following error if run the ignored test in https://github.com/solana-labs/solana-program-library/tree/master/token/client/tests
![22](https://user-images.githubusercontent.com/56029409/174779907-ed9ceed2-9895-44db-a622-0aefe937b026.png)

