### PR TITLE
token-js: Throw if using token-2022 instructions with tokenkeg

### DIFF
--- a/token/js/src/actions/createNativeMint.ts
+++ b/token/js/src/actions/createNativeMint.ts
@@ -1,5 +1,5 @@
 import { ConfirmOptions, Connection, sendAndConfirmTransaction, Signer, Transaction } from '@solana/web3.js';
-import { TOKEN_PROGRAM_ID, NATIVE_MINT } from '../constants';
+import { TOKEN_2022_PROGRAM_ID, NATIVE_MINT_2022 } from '../constants';
 import { createCreateNativeMintInstruction } from '../instructions/index';
 
 /**
@@ -15,8 +15,8 @@ export async function createNativeMint(
     connection: Connection,
     payer: Signer,
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_PROGRAM_ID,
-    nativeMint = NATIVE_MINT
+    nativeMint = NATIVE_MINT_2022,
+    programId = TOKEN_2022_PROGRAM_ID
 ): Promise<void> {
     const transaction = new Transaction().add(
         createCreateNativeMintInstruction(payer.publicKey, programId, nativeMint)

--- a/token/js/src/constants.ts
+++ b/token/js/src/constants.ts
@@ -14,3 +14,12 @@ export const NATIVE_MINT = new PublicKey('So111111111111111111111111111111111111
 
 /** Address of the special mint for wrapped native SOL in spl-token-2022 */
 export const NATIVE_MINT_2022 = new PublicKey('9pan9bMn5HatX4EJdBwg9VgCa7Uz5HL8N1m5D3NdXejP');
+
+/** Check that the token program provided is not `Tokenkeg...`, useful when using extensions */
+export function programSupportsExtensions(programId: PublicKey): boolean {
+    if (programId === TOKEN_PROGRAM_ID) {
+        return false;
+    } else {
+        return true;
+    }
+}

--- a/token/js/src/errors.ts
+++ b/token/js/src/errors.ts
@@ -59,3 +59,8 @@ export class TokenInvalidInstructionDataError extends TokenError {
 export class TokenInvalidInstructionTypeError extends TokenError {
     name = 'TokenInvalidInstructionTypeError';
 }
+
+/** Thrown if the program does not support the desired instruction */
+export class TokenUnsupportedInstructionError extends TokenError {
+    name = 'TokenUnsupportedInstructionError';
+}

--- a/token/js/src/extensions/defaultAccountState/instructions.ts
+++ b/token/js/src/extensions/defaultAccountState/instructions.ts
@@ -2,7 +2,8 @@ import { struct, u8 } from '@solana/buffer-layout';
 import { PublicKey, Signer, TransactionInstruction } from '@solana/web3.js';
 import { AccountState } from '../../state/account';
 import { TokenInstruction } from '../../instructions/types';
-import { TOKEN_2022_PROGRAM_ID } from '../../constants';
+import { programSupportsExtensions, TOKEN_2022_PROGRAM_ID } from '../../constants';
+import { TokenUnsupportedInstructionError } from '../../errors';
 
 export enum DefaultAccountStateInstruction {
     Initialize = 0,
@@ -37,6 +38,9 @@ export function createInitializeDefaultAccountStateInstruction(
     accountState: AccountState,
     programId = TOKEN_2022_PROGRAM_ID
 ): TransactionInstruction {
+    if (!programSupportsExtensions(programId)) {
+        throw new TokenUnsupportedInstructionError();
+    }
     const keys = [{ pubkey: mint, isSigner: false, isWritable: true }];
     const data = Buffer.alloc(defaultAccountStateInstructionData.span);
     defaultAccountStateInstructionData.encode(
@@ -69,6 +73,9 @@ export function createUpdateDefaultAccountStateInstruction(
     multiSigners: Signer[] = [],
     programId = TOKEN_2022_PROGRAM_ID
 ): TransactionInstruction {
+    if (!programSupportsExtensions(programId)) {
+        throw new TokenUnsupportedInstructionError();
+    }
     const keys = [{ pubkey: mint, isSigner: false, isWritable: true }];
     keys.push({ pubkey: freezeAuthority, isSigner: !multiSigners.length, isWritable: false });
     for (const signer of multiSigners) {

--- a/token/js/src/extensions/memoTransfer/instructions.ts
+++ b/token/js/src/extensions/memoTransfer/instructions.ts
@@ -1,7 +1,8 @@
 import { struct, u8 } from '@solana/buffer-layout';
 import { PublicKey, Signer, TransactionInstruction } from '@solana/web3.js';
 import { TokenInstruction } from '../../instructions/types';
-import { TOKEN_2022_PROGRAM_ID } from '../../constants';
+import { programSupportsExtensions, TOKEN_2022_PROGRAM_ID } from '../../constants';
+import { TokenUnsupportedInstructionError } from '../../errors';
 
 export enum MemoTransferInstruction {
     Enable = 0,
@@ -65,6 +66,9 @@ function createMemoTransferInstruction(
     multiSigners: Signer[],
     programId: PublicKey
 ): TransactionInstruction {
+    if (!programSupportsExtensions(programId)) {
+        throw new TokenUnsupportedInstructionError();
+    }
     const keys = [{ pubkey: account, isSigner: false, isWritable: true }];
     keys.push({ pubkey: authority, isSigner: !multiSigners.length, isWritable: false });
     for (const signer of multiSigners) {

--- a/token/js/src/extensions/transferFee/instructions.ts
+++ b/token/js/src/extensions/transferFee/instructions.ts
@@ -2,13 +2,14 @@ import { struct, u8, u16 } from '@solana/buffer-layout';
 import { publicKey, u64 } from '@solana/buffer-layout-utils';
 import { AccountMeta, PublicKey, Signer, TransactionInstruction } from '@solana/web3.js';
 import {
+    TokenUnsupportedInstructionError,
     TokenInvalidInstructionDataError,
     TokenInvalidInstructionKeysError,
     TokenInvalidInstructionProgramError,
     TokenInvalidInstructionTypeError,
 } from '../../errors';
 import { TokenInstruction } from '../../instructions/types';
-import { TOKEN_2022_PROGRAM_ID } from '../../constants';
+import { programSupportsExtensions, TOKEN_2022_PROGRAM_ID } from '../../constants';
 
 export enum TransferFeeInstruction {
     InitializeTransferFeeConfig = 0,
@@ -65,6 +66,9 @@ export function createInitializeTransferFeeConfigInstruction(
     maximumFee: BigInt,
     programId = TOKEN_2022_PROGRAM_ID
 ): TransactionInstruction {
+    if (!programSupportsExtensions(programId)) {
+        throw new TokenUnsupportedInstructionError();
+    }
     const keys = [{ pubkey: mint, isSigner: false, isWritable: true }];
 
     const data = Buffer.alloc(initializeTransferFeeConfigInstructionData.span);
@@ -235,6 +239,9 @@ export function createTransferCheckedWithFeeInstruction(
     multiSigners: Signer[] = [],
     programId = TOKEN_2022_PROGRAM_ID
 ): TransactionInstruction {
+    if (!programSupportsExtensions(programId)) {
+        throw new TokenUnsupportedInstructionError();
+    }
     const data = Buffer.alloc(transferCheckedWithFeeInstructionData.span);
     transferCheckedWithFeeInstructionData.encode(
         {
@@ -398,6 +405,9 @@ export function createWithdrawWithheldTokensFromMintInstruction(
     signers: Signer[] = [],
     programId = TOKEN_2022_PROGRAM_ID
 ): TransactionInstruction {
+    if (!programSupportsExtensions(programId)) {
+        throw new TokenUnsupportedInstructionError();
+    }
     const data = Buffer.alloc(withdrawWithheldTokensFromMintInstructionData.span);
     withdrawWithheldTokensFromMintInstructionData.encode(
         {
@@ -550,6 +560,9 @@ export function createWithdrawWithheldTokensFromAccountsInstruction(
     sources: PublicKey[],
     programId = TOKEN_2022_PROGRAM_ID
 ): TransactionInstruction {
+    if (!programSupportsExtensions(programId)) {
+        throw new TokenUnsupportedInstructionError();
+    }
     const data = Buffer.alloc(withdrawWithheldTokensFromAccountsInstructionData.span);
     withdrawWithheldTokensFromAccountsInstructionData.encode(
         {
@@ -712,6 +725,9 @@ export function createHarvestWithheldTokensToMintInstruction(
     sources: PublicKey[],
     programId = TOKEN_2022_PROGRAM_ID
 ): TransactionInstruction {
+    if (!programSupportsExtensions(programId)) {
+        throw new TokenUnsupportedInstructionError();
+    }
     const data = Buffer.alloc(harvestWithheldTokensToMintInstructionData.span);
     harvestWithheldTokensToMintInstructionData.encode(
         {

--- a/token/js/src/instructions/createNativeMint.ts
+++ b/token/js/src/instructions/createNativeMint.ts
@@ -1,7 +1,9 @@
 import { struct, u8 } from '@solana/buffer-layout';
 import { PublicKey, TransactionInstruction, SystemProgram } from '@solana/web3.js';
-import { TOKEN_PROGRAM_ID, NATIVE_MINT } from '../constants';
+import { TOKEN_2022_PROGRAM_ID, NATIVE_MINT_2022 } from '../constants';
 import { TokenInstruction } from './types';
+import { TokenUnsupportedInstructionError } from '../errors';
+import { programSupportsExtensions } from '../constants';
 
 /** TODO: docs */
 export interface CreateNativeMintInstructionData {
@@ -23,9 +25,12 @@ export const createNativeMintInstructionData = struct<CreateNativeMintInstructio
  */
 export function createCreateNativeMintInstruction(
     payer: PublicKey,
-    programId = TOKEN_PROGRAM_ID,
-    nativeMintId = NATIVE_MINT
+    nativeMintId = NATIVE_MINT_2022,
+    programId = TOKEN_2022_PROGRAM_ID
 ): TransactionInstruction {
+    if (!programSupportsExtensions(programId)) {
+        throw new TokenUnsupportedInstructionError();
+    }
     const keys = [
         { pubkey: payer, isSigner: true, isWritable: true },
         { pubkey: nativeMintId, isSigner: false, isWritable: true },

--- a/token/js/src/instructions/initializeMintCloseAuthority.ts
+++ b/token/js/src/instructions/initializeMintCloseAuthority.ts
@@ -2,12 +2,14 @@ import { struct, u8 } from '@solana/buffer-layout';
 import { publicKey } from '@solana/buffer-layout-utils';
 import { AccountMeta, PublicKey, TransactionInstruction } from '@solana/web3.js';
 import {
+    TokenUnsupportedInstructionError,
     TokenInvalidInstructionDataError,
     TokenInvalidInstructionKeysError,
     TokenInvalidInstructionProgramError,
     TokenInvalidInstructionTypeError,
 } from '../errors';
 import { TokenInstruction } from './types';
+import { programSupportsExtensions } from '../constants';
 
 /** TODO: docs */
 export interface InitializeMintCloseAuthorityInstructionData {
@@ -37,6 +39,9 @@ export function createInitializeMintCloseAuthorityInstruction(
     closeAuthority: PublicKey | null,
     programId: PublicKey
 ): TransactionInstruction {
+    if (!programSupportsExtensions(programId)) {
+        throw new TokenUnsupportedInstructionError();
+    }
     const keys = [{ pubkey: mint, isSigner: false, isWritable: true }];
 
     const data = Buffer.alloc(initializeMintCloseAuthorityInstructionData.span);

--- a/token/js/src/instructions/initializeNonTransferableMint.ts
+++ b/token/js/src/instructions/initializeNonTransferableMint.ts
@@ -1,6 +1,8 @@
 import { struct, u8 } from '@solana/buffer-layout';
 import { PublicKey, TransactionInstruction } from '@solana/web3.js';
 import { TokenInstruction } from './types';
+import { TokenUnsupportedInstructionError } from '../errors';
+import { programSupportsExtensions } from '../constants';
 
 /** Deserialized instruction for the initiation of an immutable owner account */
 export interface InitializeNonTransferableMintInstructionData {
@@ -24,6 +26,9 @@ export function createInitializeNonTransferableMintInstruction(
     mint: PublicKey,
     programId: PublicKey
 ): TransactionInstruction {
+    if (!programSupportsExtensions(programId)) {
+        throw new TokenUnsupportedInstructionError();
+    }
     const keys = [{ pubkey: mint, isSigner: false, isWritable: true }];
 
     const data = Buffer.alloc(initializeNonTransferableMintInstructionData.span);

--- a/token/js/test/e2e/native.test.ts
+++ b/token/js/test/e2e/native.test.ts
@@ -38,7 +38,7 @@ describe('native', () => {
             nativeMint = NATIVE_MINT;
         } else {
             nativeMint = NATIVE_MINT_2022;
-            await createNativeMint(connection, payer, undefined, TEST_PROGRAM_ID, nativeMint);
+            await createNativeMint(connection, payer, undefined, nativeMint, TEST_PROGRAM_ID);
         }
     });
     beforeEach(async () => {

--- a/token/js/test/unit/programId.test.ts
+++ b/token/js/test/unit/programId.test.ts
@@ -1,0 +1,73 @@
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { PublicKey } from '@solana/web3.js';
+import {
+    AccountState,
+    createCreateNativeMintInstruction,
+    createEnableRequiredMemoTransfersInstruction,
+    createInitializeNonTransferableMintInstruction,
+    createInitializeTransferFeeConfigInstruction,
+    createInitializeMintCloseAuthorityInstruction,
+    createInitializeDefaultAccountStateInstruction,
+    NATIVE_MINT,
+    NATIVE_MINT_2022,
+    TOKEN_PROGRAM_ID,
+    TOKEN_2022_PROGRAM_ID,
+    TokenUnsupportedInstructionError,
+} from '../../src';
+chai.use(chaiAsPromised);
+
+describe('unsupported extensions in spl-token', () => {
+    const mint = new PublicKey('7o36UsWR1JQLpZ9PE2gn9L4SQ69CNNiWAXd4Jt7rqz9Z');
+    const account = new PublicKey('7o36UsWR1JQLpZ9PE2gn9L4SQ69CNNiWAXd4Jt7rqz9Z');
+    const authority = new PublicKey('7o36UsWR1JQLpZ9PE2gn9L4SQ69CNNiWAXd4Jt7rqz9Z');
+    const payer = new PublicKey('7o36UsWR1JQLpZ9PE2gn9L4SQ69CNNiWAXd4Jt7rqz9Z');
+    it('initializeMintCloseAuthority', () => {
+        expect(function () {
+            createInitializeMintCloseAuthorityInstruction(mint, null, TOKEN_PROGRAM_ID);
+        }).to.throw(TokenUnsupportedInstructionError);
+        expect(function () {
+            createInitializeMintCloseAuthorityInstruction(mint, null, TOKEN_2022_PROGRAM_ID);
+        }).to.not.throw(TokenUnsupportedInstructionError);
+    });
+    it('defaultAccountState', () => {
+        expect(function () {
+            createInitializeDefaultAccountStateInstruction(mint, AccountState.Frozen, TOKEN_PROGRAM_ID);
+        }).to.throw(TokenUnsupportedInstructionError);
+        expect(function () {
+            createInitializeDefaultAccountStateInstruction(mint, AccountState.Frozen, TOKEN_2022_PROGRAM_ID);
+        }).to.not.throw(TokenUnsupportedInstructionError);
+    });
+    it('memoTransfer', () => {
+        expect(function () {
+            createEnableRequiredMemoTransfersInstruction(account, authority, [], TOKEN_PROGRAM_ID);
+        }).to.throw(TokenUnsupportedInstructionError);
+        expect(function () {
+            createEnableRequiredMemoTransfersInstruction(account, authority, [], TOKEN_2022_PROGRAM_ID);
+        }).to.not.throw(TokenUnsupportedInstructionError);
+    });
+    it('transferFee', () => {
+        expect(function () {
+            createInitializeTransferFeeConfigInstruction(mint, null, null, 0, BigInt(0), TOKEN_PROGRAM_ID);
+        }).to.throw(TokenUnsupportedInstructionError);
+        expect(function () {
+            createInitializeTransferFeeConfigInstruction(mint, null, null, 0, BigInt(0), TOKEN_2022_PROGRAM_ID);
+        }).to.not.throw(TokenUnsupportedInstructionError);
+    });
+    it('nativeMint', () => {
+        expect(function () {
+            createCreateNativeMintInstruction(payer, NATIVE_MINT, TOKEN_PROGRAM_ID);
+        }).to.throw(TokenUnsupportedInstructionError);
+        expect(function () {
+            createCreateNativeMintInstruction(payer, NATIVE_MINT_2022, TOKEN_2022_PROGRAM_ID);
+        }).to.not.throw(TokenUnsupportedInstructionError);
+    });
+    it('nonTransferableMint', () => {
+        expect(function () {
+            createInitializeNonTransferableMintInstruction(mint, TOKEN_PROGRAM_ID);
+        }).to.throw(TokenUnsupportedInstructionError);
+        expect(function () {
+            createInitializeNonTransferableMintInstruction(mint, TOKEN_2022_PROGRAM_ID);
+        }).to.not.throw(TokenUnsupportedInstructionError);
+    });
+});


### PR DESCRIPTION
#### Problem

The spl-token JS package contains token-2022 and tokenkeg support in the same package, but people may get confused and try to use token-2022 features in tokenkeg.

#### Solution

Surface errors as soon as possible, by having instruction creators throw if the provided program id is `Tokenkeg...`