### PR TITLE
token-cli: Move cmd test into a separate file

### DIFF
--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -3170,14 +3170,13 @@ fn handle_tx(
 mod tests {
     use {
         super::*,
-        assert_cmd::prelude::*,
         solana_client::blockhash_query::Source,
         solana_sdk::{
             bpf_loader,
             signature::{Keypair, Signer},
         },
         solana_test_validator::{ProgramInfo, TestValidator, TestValidatorGenesis},
-        std::{path::PathBuf, process::Command},
+        std::path::PathBuf,
     };
 
     fn clone_keypair(keypair: &Keypair) -> Keypair {
@@ -3714,17 +3713,5 @@ mod tests {
         let ui_account = config.rpc_client.get_token_account(&aux).unwrap().unwrap();
         assert_eq!(ui_account.mint, token.to_string());
         assert_eq!(ui_account.owner, aux_string);
-    }
-
-    #[test]
-    fn invalid_config_will_cause_commands_to_fail() {
-        let mut cmd = Command::cargo_bin("spl-token").unwrap();
-        let args = &["address", "--config", "~/nonexistent/config.yml"];
-
-        cmd.args(args)
-            .assert()
-            .stderr("error: Could not find config file `~/nonexistent/config.yml`\n");
-
-        cmd.args(args).assert().code(1).failure();
     }
 }

--- a/token/cli/tests/config.rs
+++ b/token/cli/tests/config.rs
@@ -1,0 +1,11 @@
+use assert_cmd::cmd::Command;
+
+#[test]
+fn invalid_config_will_cause_commands_to_fail() {
+    let mut cmd = Command::cargo_bin("spl-token").unwrap();
+    let args = &["address", "--config", "~/nonexistent/config.yml"];
+    cmd.args(args)
+        .assert()
+        .stderr("error: Could not find config file `~/nonexistent/config.yml`\n");
+    cmd.args(args).assert().code(1).failure();
+}


### PR DESCRIPTION
#### Problem

The test using `assert_cmd` is done as a unit test, which causes an error when running, saying that the binary doesn't exist.

#### Solution

This is a known issue with `assert_cmd`, and the tests are supposed to be in a separate `tests` directory, so just move the test.