### PR TITLE
token-cli: Use async RPC client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6036,6 +6036,7 @@ dependencies = [
  "spl-token 3.3.0",
  "strum",
  "strum_macros",
+ "tokio",
  "walkdir",
 ]
 

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -32,6 +32,7 @@ spl-associated-token-account = { version = "1.0.5", path="../../associated-token
 spl-memo = { version = "3.0.1", path="../../memo/program", features = ["no-entrypoint"] }
 strum = "0.24"
 strum_macros = "0.24"
+tokio = "1.14"
 
 [dev-dependencies]
 solana-test-validator = "=1.10.29"

--- a/token/cli/src/sort.rs
+++ b/token/cli/src/sort.rs
@@ -16,6 +16,10 @@ pub(crate) struct UnsupportedAccount {
     pub err: String,
 }
 
+pub(crate) fn is_supported_program(program_name: &str) -> bool {
+    program_name == "spl-token"
+}
+
 pub(crate) fn sort_and_parse_token_accounts(
     owner: &Pubkey,
     accounts: Vec<RpcKeyedAccount>,
@@ -29,7 +33,7 @@ pub(crate) fn sort_and_parse_token_accounts(
         let address = keyed_account.pubkey;
 
         if let UiAccountData::Json(parsed_account) = keyed_account.account.data {
-            if parsed_account.program != "spl-token" {
+            if !is_supported_program(&parsed_account.program) {
                 unsupported_accounts.push(UnsupportedAccount {
                     address,
                     err: format!("Unsupported account program: {}", parsed_account.program),


### PR DESCRIPTION
#### Problem

In order to more easily integrate with token-2022, which uses the `token-client`, the entire CLI needs to go async.

#### Solution

Move everything to async!  These changes were strongly coupled to #3071, so I tried to decouple them as much as possible.  The idea is that there aren't any functional changes, just a lot of refactors in order to be `async`, and then a few places where we figure out the correct `program_id` based on the mentioned mint or token account, rather than using `config.program_id`.  That'll help with the token-2022 support work.

Note: the async `TpuClient` will only come in with 1.11, so `spl-token bench` is still blocking.