### PR TITLE
Derive elgamal key in token client

### DIFF
--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -878,10 +878,7 @@ async fn ct_transfer_with_fee() {
             &alice_meta.token_account,
             &alice_meta.token_account,
             &alice,
-            0,   // amount
-            100, // available balance
-            &alice_meta.elgamal_keypair,
-            alice_meta.ae_key.encrypt(100_u64),
+            0,
             &epoch_info,
         )
         .await
@@ -905,10 +902,7 @@ async fn ct_transfer_with_fee() {
             &alice_meta.token_account,
             &alice_meta.token_account,
             &alice,
-            100, // amount
-            100, // available balance
-            &alice_meta.elgamal_keypair,
-            alice_meta.ae_key.encrypt(0_u64),
+            100,
             &epoch_info,
         )
         .await
@@ -948,10 +942,7 @@ async fn ct_transfer_with_fee() {
             &alice_meta.token_account,
             &bob_meta.token_account,
             &alice,
-            100, // amount
-            100, // available balance
-            &alice_meta.elgamal_keypair,
-            alice_meta.ae_key.encrypt(0_u64),
+            100,
             &epoch_info,
         )
         .await
@@ -1093,9 +1084,6 @@ async fn ct_withdraw_withheld_tokens_from_mint() {
             &bob_meta.token_account,
             &alice,
             100,
-            100,
-            &alice_meta.elgamal_keypair,
-            alice_meta.ae_key.encrypt(0_u64),
             &epoch_info,
         )
         .await
@@ -1198,9 +1186,6 @@ async fn ct_withdraw_withheld_tokens_from_accounts() {
             &bob_meta.token_account,
             &alice,
             100,
-            100,
-            &alice_meta.elgamal_keypair,
-            alice_meta.ae_key.encrypt(0_u64),
             &epoch_info,
         )
         .await

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -1049,7 +1049,7 @@ async fn ct_withdraw_withheld_tokens_from_mint() {
     let bob_meta = ConfidentialTokenAccountMeta::new(&token, &bob).await;
 
     token
-        .confidential_transfer_withdraw_withheld_tokens_from_mint(
+        .confidential_transfer_withdraw_withheld_tokens_from_mint_with_key(
             &ct_mint_withdraw_withheld_authority,
             &ct_mint_withdraw_withheld_authority_encryption_keypair,
             &alice_meta.token_account,
@@ -1117,7 +1117,7 @@ async fn ct_withdraw_withheld_tokens_from_mint() {
     .await;
 
     token
-        .confidential_transfer_withdraw_withheld_tokens_from_mint(
+        .confidential_transfer_withdraw_withheld_tokens_from_mint_with_key(
             &ct_mint_withdraw_withheld_authority,
             &ct_mint_withdraw_withheld_authority_encryption_keypair,
             &alice_meta.token_account,
@@ -1207,12 +1207,12 @@ async fn ct_withdraw_withheld_tokens_from_accounts() {
     );
 
     token
-        .confidential_transfer_withdraw_withheld_tokens_from_accounts(
+        .confidential_transfer_withdraw_withheld_tokens_from_accounts_with_key(
             &ct_mint_withdraw_withheld_authority,
             &ct_mint_withdraw_withheld_authority_encryption_keypair,
             &alice_meta.token_account,
-            3_u64,
             &extension.withheld_amount.try_into().unwrap(),
+            3_u64,
             &[&bob_meta.token_account],
         )
         .await

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -102,14 +102,16 @@ impl ConfidentialTokenAccountMeta {
             .await
             .unwrap();
 
-        let (elgamal_keypair, ae_key) = token
-            .confidential_transfer_configure_token_account_and_keypairs(
-                &token_account,
-                owner,
-                TEST_MAXIMUM_PENDING_BALANCE_CREDIT_COUNTER,
-            )
-            .await
-            .unwrap();
+        let elgamal_keypair = ElGamalKeypair::new(owner, &token_account).unwrap();
+        let ae_key = AeKey::new(owner, &token_account).unwrap();
+
+        token.confidential_transfer_configure_token_account(
+            &token_account,
+            owner,
+            TEST_MAXIMUM_PENDING_BALANCE_CREDIT_COUNTER,
+        )
+        .await
+        .unwrap();
 
         Self {
             token_account,
@@ -351,8 +353,6 @@ async fn ct_configure_token_account() {
         .confidential_transfer_configure_token_account(
             &alice_meta.token_account,
             &alice,
-            alice_meta.elgamal_keypair.public,
-            alice_meta.ae_key.encrypt(0_u64),
             TEST_MAXIMUM_PENDING_BALANCE_CREDIT_COUNTER,
         )
         .await
@@ -430,7 +430,6 @@ async fn ct_new_account_is_empty() {
         .confidential_transfer_empty_account(
             &alice_meta.token_account,
             &alice,
-            &alice_meta.elgamal_keypair,
         )
         .await
         .unwrap();
@@ -619,9 +618,6 @@ async fn ct_withdraw() {
             &alice,
             21,
             decimals,
-            42,
-            &alice_meta.elgamal_keypair,
-            alice_meta.ae_key.encrypt(42_u64 - 21),
         )
         .await
         .unwrap();
@@ -651,9 +647,6 @@ async fn ct_withdraw() {
             &alice,
             21,
             decimals,
-            21,
-            &alice_meta.elgamal_keypair,
-            alice_meta.ae_key.encrypt(0u64),
         )
         .await
         .unwrap();
@@ -680,7 +673,6 @@ async fn ct_withdraw() {
         .confidential_transfer_empty_account(
             &alice_meta.token_account,
             &alice,
-            &alice_meta.elgamal_keypair,
         )
         .await
         .unwrap();
@@ -718,9 +710,6 @@ async fn ct_transfer() {
             &alice_meta.token_account,
             &alice,
             0,  // amount
-            42, // available balance
-            &alice_meta.elgamal_keypair,
-            alice_meta.ae_key.encrypt(42_u64),
         )
         .await
         .unwrap();
@@ -744,9 +733,6 @@ async fn ct_transfer() {
             &alice_meta.token_account,
             &alice,
             42, // amount
-            42, // available balance
-            &alice_meta.elgamal_keypair,
-            alice_meta.ae_key.encrypt(0_u64),
         )
         .await
         .unwrap();
@@ -769,9 +755,6 @@ async fn ct_transfer() {
             &alice_meta.token_account,
             &alice,
             0, // amount
-            0, // available balance
-            &alice_meta.elgamal_keypair,
-            alice_meta.ae_key.encrypt(0_u64),
         )
         .await
         .unwrap_err();
@@ -816,9 +799,6 @@ async fn ct_transfer() {
             &bob_meta.token_account,
             &alice,
             42, // amount
-            42, // available balance
-            &alice_meta.elgamal_keypair,
-            alice_meta.ae_key.encrypt(0_u64),
         )
         .await
         .unwrap();
@@ -839,7 +819,6 @@ async fn ct_transfer() {
         .confidential_transfer_empty_account(
             &alice_meta.token_account,
             &alice,
-            &alice_meta.elgamal_keypair,
         )
         .await
         .unwrap();
@@ -848,7 +827,6 @@ async fn ct_transfer() {
         .confidential_transfer_empty_account(
             &bob_meta.token_account,
             &bob,
-            &bob_meta.elgamal_keypair,
         )
         .await
         .unwrap_err();
@@ -1037,7 +1015,6 @@ async fn ct_transfer_with_fee() {
         .confidential_transfer_empty_account(
             &alice_meta.token_account,
             &alice,
-            &alice_meta.elgamal_keypair,
         )
         .await
         .unwrap();
@@ -1046,7 +1023,6 @@ async fn ct_transfer_with_fee() {
         .confidential_transfer_empty_account(
             &bob_meta.token_account,
             &bob,
-            &bob_meta.elgamal_keypair,
         )
         .await
         .unwrap_err();

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -106,7 +106,7 @@ impl ConfidentialTokenAccountMeta {
         let ae_key = AeKey::new(owner, &token_account).unwrap();
 
         token
-            .confidential_transfer_configure_token_account(
+            .confidential_transfer_configure_token_account_with_pending_counter(
                 &token_account,
                 owner,
                 TEST_MAXIMUM_PENDING_BALANCE_CREDIT_COUNTER,
@@ -150,12 +150,7 @@ impl ConfidentialTokenAccountMeta {
             .unwrap();
 
         token
-            .confidential_transfer_apply_pending_balance(
-                &meta.token_account,
-                owner,
-                1,
-                meta.ae_key.encrypt(amount),
-            )
+            .confidential_transfer_apply_pending_balance(&meta.token_account, owner, 1)
             .await
             .unwrap();
         meta
@@ -351,7 +346,7 @@ async fn ct_configure_token_account() {
 
     // Configuring an already initialized account should produce an error
     let err = token
-        .confidential_transfer_configure_token_account(
+        .confidential_transfer_configure_token_account_with_pending_counter(
             &alice_meta.token_account,
             &alice,
             TEST_MAXIMUM_PENDING_BALANCE_CREDIT_COUNTER,
@@ -552,14 +547,8 @@ async fn ct_deposit() {
         )))
     );
 
-    let new_decryptable_available_balance = alice_meta.ae_key.encrypt(65537_u64);
     token
-        .confidential_transfer_apply_pending_balance(
-            &alice_meta.token_account,
-            &alice,
-            2,
-            new_decryptable_available_balance.clone(),
-        )
+        .confidential_transfer_apply_pending_balance(&alice_meta.token_account, &alice, 2)
         .await
         .unwrap();
 
@@ -570,10 +559,6 @@ async fn ct_deposit() {
     let extension = state
         .get_extension::<ConfidentialTransferAccount>()
         .unwrap();
-    assert_eq!(
-        extension.decryptable_available_balance,
-        new_decryptable_available_balance.into(),
-    );
     assert_eq!(extension.pending_balance_credit_counter, 0.into());
     assert_eq!(extension.expected_pending_balance_credit_counter, 2.into());
     assert_eq!(extension.actual_pending_balance_credit_counter, 2.into());
@@ -767,12 +752,7 @@ async fn ct_transfer() {
     );
 
     token
-        .confidential_transfer_apply_pending_balance(
-            &alice_meta.token_account,
-            &alice,
-            2,
-            alice_meta.ae_key.encrypt(42_u64),
-        )
+        .confidential_transfer_apply_pending_balance(&alice_meta.token_account, &alice, 2)
         .await
         .unwrap();
 
@@ -840,12 +820,7 @@ async fn ct_transfer() {
         .await;
 
     token
-        .confidential_transfer_apply_pending_balance(
-            &bob_meta.token_account,
-            &bob,
-            1,
-            bob_meta.ae_key.encrypt(42_u64),
-        )
+        .confidential_transfer_apply_pending_balance(&bob_meta.token_account, &bob, 1)
         .await
         .unwrap();
 
@@ -952,12 +927,7 @@ async fn ct_transfer_with_fee() {
         .await;
 
     token
-        .confidential_transfer_apply_pending_balance(
-            &alice_meta.token_account,
-            &alice,
-            2,
-            alice_meta.ae_key.encrypt(100_u64),
-        )
+        .confidential_transfer_apply_pending_balance(&alice_meta.token_account, &alice, 2)
         .await
         .unwrap();
 
@@ -1030,12 +1000,7 @@ async fn ct_transfer_with_fee() {
         .await;
 
     token
-        .confidential_transfer_apply_pending_balance(
-            &bob_meta.token_account,
-            &bob,
-            1,
-            bob_meta.ae_key.encrypt(97_u64),
-        )
+        .confidential_transfer_apply_pending_balance(&bob_meta.token_account, &bob, 1)
         .await
         .unwrap();
 

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -105,13 +105,14 @@ impl ConfidentialTokenAccountMeta {
         let elgamal_keypair = ElGamalKeypair::new(owner, &token_account).unwrap();
         let ae_key = AeKey::new(owner, &token_account).unwrap();
 
-        token.confidential_transfer_configure_token_account(
-            &token_account,
-            owner,
-            TEST_MAXIMUM_PENDING_BALANCE_CREDIT_COUNTER,
-        )
-        .await
-        .unwrap();
+        token
+            .confidential_transfer_configure_token_account(
+                &token_account,
+                owner,
+                TEST_MAXIMUM_PENDING_BALANCE_CREDIT_COUNTER,
+            )
+            .await
+            .unwrap();
 
         Self {
             token_account,
@@ -427,10 +428,7 @@ async fn ct_new_account_is_empty() {
 
     let alice_meta = ConfidentialTokenAccountMeta::new(&token, &alice).await;
     token
-        .confidential_transfer_empty_account(
-            &alice_meta.token_account,
-            &alice,
-        )
+        .confidential_transfer_empty_account(&alice_meta.token_account, &alice)
         .await
         .unwrap();
 }
@@ -670,10 +668,7 @@ async fn ct_withdraw() {
         .await;
 
     token
-        .confidential_transfer_empty_account(
-            &alice_meta.token_account,
-            &alice,
-        )
+        .confidential_transfer_empty_account(&alice_meta.token_account, &alice)
         .await
         .unwrap();
 }
@@ -709,7 +704,7 @@ async fn ct_transfer() {
             &alice_meta.token_account,
             &alice_meta.token_account,
             &alice,
-            0,  // amount
+            0, // amount
         )
         .await
         .unwrap();
@@ -816,18 +811,12 @@ async fn ct_transfer() {
         .await;
 
     token
-        .confidential_transfer_empty_account(
-            &alice_meta.token_account,
-            &alice,
-        )
+        .confidential_transfer_empty_account(&alice_meta.token_account, &alice)
         .await
         .unwrap();
 
     let err = token
-        .confidential_transfer_empty_account(
-            &bob_meta.token_account,
-            &bob,
-        )
+        .confidential_transfer_empty_account(&bob_meta.token_account, &bob)
         .await
         .unwrap_err();
 
@@ -1012,18 +1001,12 @@ async fn ct_transfer_with_fee() {
 
     // Alice account cannot be closed since there are withheld fees from self-transfer
     token
-        .confidential_transfer_empty_account(
-            &alice_meta.token_account,
-            &alice,
-        )
+        .confidential_transfer_empty_account(&alice_meta.token_account, &alice)
         .await
         .unwrap();
 
     let err = token
-        .confidential_transfer_empty_account(
-            &bob_meta.token_account,
-            &bob,
-        )
+        .confidential_transfer_empty_account(&bob_meta.token_account, &bob)
         .await
         .unwrap_err();
 

--- a/token/program-2022/src/extension/confidential_transfer/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer/mod.rs
@@ -14,8 +14,10 @@ use {
 /// Any deposit or transfer amount must be less than 2^48
 pub const MAXIMUM_DEPOSIT_TRANSFER_AMOUNT_BIT_LENGTH: usize = 48;
 
-const PENDING_BALANCE_LO_BIT_LENGTH: usize = 16;
-const PENDING_BALANCE_HI_BIT_LENGTH: usize = 48;
+/// Bit length of the low bits of pending balance plaintext
+pub const PENDING_BALANCE_LO_BIT_LENGTH: usize = 16;
+/// Bit length of the high bits of pending balance plaintext
+pub const PENDING_BALANCE_HI_BIT_LENGTH: usize = 48;
 
 /// Confidential Transfer Extension instructions
 pub mod instruction;


### PR DESCRIPTION
Currently, the ElGamal and authenticated encryption keys are taken as input to token client instruction functions. This PR modifies the instruction functions so that the encryptions keys are deterministically derived from the owner and token account addresses. This should abstract out the encryption keys altogether and simplify the confidential transfer rust interface in the cli.