### PR TITLE
CI: Bump openssl for audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2770,9 +2770,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.20.0+1.1.1o"
+version = "111.22.0+1.1.1q"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92892c4f87d56e376e469ace79f1128fdaded07646ddf73aa0be4706ff712dec"
+checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
 dependencies = [
  "cc",
 ]


### PR DESCRIPTION
#### Problem

Audit is currently failing in CI.

#### Solution

Same as https://github.com/solana-labs/solana/pull/26410, we need to bump openssl.