### PR TITLE
token-2022: Bump version for 0.4.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5649,7 +5649,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-token 3.3.0",
- "spl-token-2022 0.4.0",
+ "spl-token-2022 0.4.1",
  "thiserror",
 ]
 
@@ -6039,7 +6039,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-2022"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -6071,7 +6071,7 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account 1.0.5",
  "spl-memo 3.0.1",
- "spl-token-2022 0.4.0",
+ "spl-token-2022 0.4.1",
  "spl-token-client",
  "walkdir",
 ]
@@ -6115,7 +6115,7 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account 1.0.5",
  "spl-memo 3.0.1",
- "spl-token-2022 0.4.0",
+ "spl-token-2022 0.4.1",
  "thiserror",
 ]
 

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-2022"
-version = "0.4.0"
+version = "0.4.1"
 description = "Solana Program Library Token 2022"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"


### PR DESCRIPTION
Problem
It's time to release a new token-2022, but the version is still at 0.4.0

Solution
Bump it to 0.4.1 everywhere to tag the next release.

---

p.s. open that Cargo.lock file to be sure :)

/cc @joncinque 