### PR TITLE
Update associated-token-account.md

### DIFF
--- a/docs/src/associated-token-account.md
+++ b/docs/src/associated-token-account.md
@@ -84,7 +84,7 @@ async function findAssociatedTokenAddress(
 
 If the associated token account for a given wallet address does not yet exist,
 it may be created by *anybody* by issuing a transaction containing the
-instruction returned by [create_associated_token_account](https://docs.rs/spl-associated-token-account/latest/spl_associated_token_account/fn.create_associated_token_account.html).
+instruction returned by [create_associated_token_account](https://docs.rs/spl-associated-token-account/latest/spl_associated_token_account/instruction/fn.create_associated_token_account.html).
 
 Regardless of creator the new associated token account will be fully owned by
 the wallet, as if the wallet itself had created it.


### PR DESCRIPTION
The create_associated_token_account was linked with the previous deprecated function. I have attached the newly updated instruction create_associated_token_account instruction.