### PR TITLE
Used full out spelling to resolve confusion - related to #3330

### DIFF
--- a/docs/src/associated-token-account.md
+++ b/docs/src/associated-token-account.md
@@ -21,7 +21,7 @@ transfer, for a token transfer to succeed the recipient must have a token
 account with the compatible mint already, and somebody needs to fund that token
 account. If the recipient must fund it first, it makes things like airdrop
 campaigns difficult and just generally increases the friction of token
-transfers. AToken allows the sender to create the associated token account for
+transfers. Associated Token (program) allows the sender to create the associated token account for
 the receiver, so the token transfer just works.
 
 See the [SPL Token](token.mdx) program for more information about tokens in

--- a/docs/src/associated-token-account.md
+++ b/docs/src/associated-token-account.md
@@ -21,7 +21,7 @@ transfer, for a token transfer to succeed the recipient must have a token
 account with the compatible mint already, and somebody needs to fund that token
 account. If the recipient must fund it first, it makes things like airdrop
 campaigns difficult and just generally increases the friction of token
-transfers. Associated Token (program) allows the sender to create the associated token account for
+transfers. The Associated Token Account program allows the sender to create the associated token account for
 the receiver, so the token transfer just works.
 
 See the [SPL Token](token.mdx) program for more information about tokens in


### PR DESCRIPTION
Based on @CriesofCarrots comment. Made a new PR, because I couldn't change #3330 anymore. 
Used full out spelling of the word `AToken` to resolve confusion.