### PR TITLE
Enable token deposits with voting plugin

### DIFF
--- a/governance/program/src/processor/process_deposit_governing_tokens.rs
+++ b/governance/program/src/processor/process_deposit_governing_tokens.rs
@@ -45,8 +45,6 @@ pub fn process_deposit_governing_tokens(
     let realm_data = get_realm_data(program_id, realm_info)?;
     let governing_token_mint = get_spl_token_mint(governing_token_holding_info)?;
 
-    realm_data.asset_governing_tokens_deposits_allowed(&governing_token_mint)?;
-
     realm_data.assert_is_valid_governing_token_mint_and_holding(
         program_id,
         realm_info.key,

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -197,21 +197,6 @@ impl RealmV2 {
         Ok(())
     }
 
-    /// Asserts the given governing token can be deposited into the realm
-    pub fn asset_governing_tokens_deposits_allowed(
-        &self,
-        governing_token_mint: &Pubkey,
-    ) -> Result<(), ProgramError> {
-        // If the deposit is for the community token and the realm uses community voter weight addin then panic
-        if self.config.use_community_voter_weight_addin
-            && self.community_mint == *governing_token_mint
-        {
-            return Err(GovernanceError::GoverningTokenDepositsNotAllowed.into());
-        }
-
-        Ok(())
-    }
-
     /// Assert the given create authority can create governance
     pub fn assert_create_authority_can_create_governance(
         &self,

--- a/governance/program/tests/use_realm_with_voter_weight_addin.rs
+++ b/governance/program/tests/use_realm_with_voter_weight_addin.rs
@@ -249,27 +249,6 @@ async fn test_create_program_governance_with_voter_weight_addin() {
 }
 
 #[tokio::test]
-async fn test_realm_with_voter_weight_addin_with_deposits_not_allowed() {
-    // Arrange
-    let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
-    let realm_cookie = governance_test.with_realm().await;
-
-    // Act
-
-    let err = governance_test
-        .with_community_token_deposit(&realm_cookie)
-        .await
-        .err()
-        .unwrap();
-
-    // Assert
-    assert_eq!(
-        err,
-        GovernanceError::GoverningTokenDepositsNotAllowed.into()
-    );
-}
-
-#[tokio::test]
 async fn test_create_governance_with_voter_weight_action_error() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;


### PR DESCRIPTION
Now that token deposits can be used as inputs to vote plugins, remove the constraint that prevents token deposits when a vote plugin is used.