### PR TITLE
Governance: Council membership & plugins

### DIFF
--- a/governance/addin-api/src/max_voter_weight.rs
+++ b/governance/addin-api/src/max_voter_weight.rs
@@ -6,7 +6,7 @@ use spl_governance_tools::account::AccountMaxSize;
 
 /// MaxVoterWeightRecord account
 /// The account is used as an api interface to provide max voting power to the governance program from external addin contracts
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct MaxVoterWeightRecord {
     /// VoterWeightRecord discriminator sha256("account:MaxVoterWeightRecord")[..8]
     /// Note: The discriminator size must match the addin implementing program discriminator size

--- a/governance/addin-api/src/voter_weight.rs
+++ b/governance/addin-api/src/voter_weight.rs
@@ -5,7 +5,7 @@ use solana_program::{clock::Slot, program_pack::IsInitialized, pubkey::Pubkey};
 use spl_governance_tools::account::AccountMaxSize;
 
 /// The governance action VoterWeight is evaluated for
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum VoterWeightAction {
     /// Cast vote for a proposal. Target: Proposal
     CastVote,
@@ -26,7 +26,7 @@ pub enum VoterWeightAction {
 
 /// VoterWeightRecord account
 /// The account is used as an api interface to provide voting power to the governance program from external addin contracts
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct VoterWeightRecord {
     /// VoterWeightRecord discriminator sha256("account:VoterWeightRecord")[..8]
     /// Note: The discriminator size must match the addin implementing program discriminator size

--- a/governance/addin-mock/program/src/instruction.rs
+++ b/governance/addin-mock/program/src/instruction.rs
@@ -11,7 +11,7 @@ use spl_governance_addin_api::voter_weight::VoterWeightAction;
 
 /// Instructions supported by the VoterWeight addin program
 /// This program is a mock program used by spl-governance for testing and not real addin
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 #[allow(clippy::large_enum_variant)]
 pub enum VoterWeightAddinInstruction {
     /// Sets up VoterWeightRecord owned by the program

--- a/governance/chat/program/src/instruction.rs
+++ b/governance/chat/program/src/instruction.rs
@@ -11,7 +11,7 @@ use spl_governance::instruction::with_realm_config_accounts;
 use crate::state::MessageBody;
 
 /// Instructions supported by the GovernanceChat program
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 #[allow(clippy::large_enum_variant)]
 pub enum GovernanceChatInstruction {
     /// Posts a message with a comment for a Proposal

--- a/governance/chat/program/src/processor.rs
+++ b/governance/chat/program/src/processor.rs
@@ -94,8 +94,9 @@ pub fn process_post_message(
     )?;
 
     let realm_config_info = next_account_info(account_info_iter)?; // 10
+
     let realm_config_data =
-        get_realm_config_data_for_realm(program_id, realm_config_info, realm_info.key)?;
+        get_realm_config_data_for_realm(governance_program_id, realm_config_info, realm_info.key)?;
 
     let voter_weight = token_owner_record_data.resolve_voter_weight(
         account_info_iter, // voter_weight_record *11

--- a/governance/chat/program/src/processor.rs
+++ b/governance/chat/program/src/processor.rs
@@ -18,7 +18,7 @@ use solana_program::{
 };
 use spl_governance::state::{
     governance::get_governance_data_for_realm, proposal::get_proposal_data_for_governance,
-    realm::get_realm_data, realm_config::next_realm_config_info_for_realm,
+    realm::get_realm_data, realm_config::get_realm_config_data_for_realm,
     token_owner_record::get_token_owner_record_data_for_realm,
 };
 use spl_governance_addin_api::voter_weight::VoterWeightAction;
@@ -93,15 +93,13 @@ pub fn process_post_message(
         governance_info.key,
     )?;
 
-    // Get realm_config_info from the account_info iterator and assert it has a valid PDA for the given Realm
-    let realm_config_info =
-        next_realm_config_info_for_realm(account_info_iter, program_id, realm_info.key)?; // 10
+    let realm_config_info = next_account_info(account_info_iter)?; // 10
+    let realm_config_data =
+        get_realm_config_data_for_realm(program_id, realm_config_info, realm_info.key)?;
 
     let voter_weight = token_owner_record_data.resolve_voter_weight(
-        governance_program_id,
-        realm_config_info,
+        &realm_config_data,
         account_info_iter, // 11
-        realm_info.key,
         &realm_data,
         VoterWeightAction::CommentProposal,
         proposal_info.key,

--- a/governance/chat/program/src/processor.rs
+++ b/governance/chat/program/src/processor.rs
@@ -98,9 +98,9 @@ pub fn process_post_message(
         get_realm_config_data_for_realm(program_id, realm_config_info, realm_info.key)?;
 
     let voter_weight = token_owner_record_data.resolve_voter_weight(
-        &realm_config_data,
-        account_info_iter, // 11
+        account_info_iter, // voter_weight_record *11
         &realm_data,
+        &realm_config_data,
         VoterWeightAction::CommentProposal,
         proposal_info.key,
     )?;

--- a/governance/chat/program/src/processor.rs
+++ b/governance/chat/program/src/processor.rs
@@ -18,7 +18,8 @@ use solana_program::{
 };
 use spl_governance::state::{
     governance::get_governance_data_for_realm, proposal::get_proposal_data_for_governance,
-    realm::get_realm_data, token_owner_record::get_token_owner_record_data_for_realm,
+    realm::get_realm_data, realm_config::next_realm_config_info_for_realm,
+    token_owner_record::get_token_owner_record_data_for_realm,
 };
 use spl_governance_addin_api::voter_weight::VoterWeightAction;
 use spl_governance_tools::account::create_and_serialize_account;
@@ -92,7 +93,9 @@ pub fn process_post_message(
         governance_info.key,
     )?;
 
-    let realm_config_info = next_account_info(account_info_iter)?; //10
+    // Get realm_config_info from the account_info iterator and assert it has a valid PDA for the given Realm
+    let realm_config_info =
+        next_realm_config_info_for_realm(account_info_iter, program_id, realm_info.key)?; // 10
 
     let voter_weight = token_owner_record_data.resolve_voter_weight(
         governance_program_id,

--- a/governance/chat/program/src/state.rs
+++ b/governance/chat/program/src/state.rs
@@ -8,7 +8,7 @@ use solana_program::{
 use spl_governance_tools::account::{assert_is_valid_account_of_type, AccountMaxSize};
 
 /// Defines all GovernanceChat accounts types
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum GovernanceChatAccountType {
     /// Default uninitialized account state
     Uninitialized,
@@ -18,7 +18,7 @@ pub enum GovernanceChatAccountType {
 }
 
 /// Chat message body
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum MessageBody {
     /// Text message encoded as utf-8 string
     Text(String),
@@ -29,7 +29,7 @@ pub enum MessageBody {
 }
 
 /// Chat message
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct ChatMessage {
     /// Account type
     pub account_type: GovernanceChatAccountType,

--- a/governance/chat/program/tests/program_test/mod.rs
+++ b/governance/chat/program/tests/program_test/mod.rs
@@ -13,7 +13,8 @@ use spl_governance::{
         enums::{MintMaxVoteWeightSource, VoteThreshold},
         governance::{get_governance_address, GovernanceConfig},
         proposal::{get_proposal_address, VoteType},
-        realm::get_realm_address,
+        realm::{get_realm_address, GoverningTokenConfigAccountArgs},
+        realm_config::GoverningTokenType,
         token_owner_record::get_token_owner_record_address,
     },
 };
@@ -108,13 +109,19 @@ impl GovernanceChatProgramTest {
 
         let realm_authority = Keypair::new();
 
+        let community_token_config_args = GoverningTokenConfigAccountArgs {
+            voter_weight_addin: self.voter_weight_addin_id,
+            max_voter_weight_addin: None,
+            token_type: GoverningTokenType::default(),
+        };
+
         let create_realm_ix = create_realm(
             &self.governance_program_id,
             &realm_authority.pubkey(),
             &governing_token_mint_keypair.pubkey(),
             &self.bench.payer.pubkey(),
             None,
-            self.voter_weight_addin_id,
+            Some(community_token_config_args),
             None,
             name.clone(),
             1,

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -426,6 +426,10 @@ pub enum GovernanceError {
     /// Invalid Revoke amount
     #[error("Invalid Revoke amount")]
     InvalidRevokeAmount, // 602
+
+    /// Invalid GoverningToken source
+    #[error("Invalid GoverningToken source")]
+    InvalidGoverningTokenSource, // 603
 }
 
 impl PrintProgramError for GovernanceError {

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -430,6 +430,10 @@ pub enum GovernanceError {
     /// Invalid GoverningToken source
     #[error("Invalid GoverningToken source")]
     InvalidGoverningTokenSource, // 603
+
+    /// Cannot change community TokenType to Memebership
+    #[error("Cannot change community TokenType to Memebership")]
+    CannotChangeCommunityTokenTypeToMemebership, // 604
 }
 
 impl PrintProgramError for GovernanceError {

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -411,17 +411,17 @@ pub enum GovernanceError {
     #[error("Invalid RealmConfig account address")]
     InvalidRealmConfigAddress,
 
-    /// Cannot deposit GoverningToken
-    #[error("Cannot deposit GoverningToken")]
-    CannotDepositGoverningToken, // 599
+    /// Cannot deposit GoverningTokens
+    #[error("Cannot deposit GoverningTokens")]
+    CannotDepositGoverningTokens, // 599
 
-    /// Cannot withdraw GoverningToken
-    #[error("Cannot withdraw GoverningToken")]
-    CannotWithdrawGoverningToken, // 600
+    /// Cannot withdraw GoverningTokens
+    #[error("Cannot withdraw GoverningTokens")]
+    CannotWithdrawGoverningTokens, // 600
 
-    /// Cannot revoke GoverningToken
-    #[error("Cannot revoke GoverningToken")]
-    CannotRevokeGoverningToken, // 601
+    /// Cannot revoke GoverningTokens
+    #[error("Cannot revoke GoverningTokens")]
+    CannotRevokeGoverningTokens, // 601
 
     /// Invalid Revoke amount
     #[error("Invalid Revoke amount")]

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -411,13 +411,21 @@ pub enum GovernanceError {
     #[error("Invalid RealmConfig account address")]
     InvalidRealmConfigAddress,
 
+    /// Cannot deposit GoverningToken
+    #[error("Cannot deposit GoverningToken")]
+    CannotDepositGoverningToken, // 599
+
+    /// Cannot withdraw GoverningToken
+    #[error("Cannot withdraw GoverningToken")]
+    CannotWithdrawGoverningToken, // 600
+
     /// Cannot revoke GoverningToken
     #[error("Cannot revoke GoverningToken")]
-    CannotRevokeGoverningToken, // 599
+    CannotRevokeGoverningToken, // 601
 
     /// Invalid Revoke amount
     #[error("Invalid Revoke amount")]
-    InvalidRevokeAmount, // 600
+    InvalidRevokeAmount, // 602
 }
 
 impl PrintProgramError for GovernanceError {

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -285,7 +285,7 @@ pub enum GovernanceError {
 
     /// Invalid governing token holding account
     #[error("Invalid governing token holding account")]
-    InvalidGoverningTokenHoldingAccount,
+    InvalidGoverningTokenHoldingAccount, // 567
 
     /// Realm council mint change is not supported
     #[error("Realm council mint change is not supported")]

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -406,6 +406,10 @@ pub enum GovernanceError {
     /// Cannot Relinquish in Finalizing state
     #[error("Cannot Relinquish in Finalizing state")]
     CannotRelinquishInFinalizingState,
+
+    /// Invalid RealmConfig account address
+    #[error("Invalid RealmConfig account address")]
+    InvalidRealmConfigAddress,
 }
 
 impl PrintProgramError for GovernanceError {

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -411,13 +411,13 @@ pub enum GovernanceError {
     #[error("Invalid RealmConfig account address")]
     InvalidRealmConfigAddress,
 
-    /// Cannot deposit GoverningTokens
-    #[error("Cannot deposit GoverningTokens")]
-    CannotDepositGoverningTokens, // 599
+    /// Cannot deposit dormant tokens
+    #[error("Cannot deposit dormant tokens")]
+    CannotDepositDormantTokens, // 599
 
-    /// Cannot withdraw GoverningTokens
-    #[error("Cannot withdraw GoverningTokens")]
-    CannotWithdrawGoverningTokens, // 600
+    /// Cannot withdraw membership tokens
+    #[error("Cannot withdraw membership tokens")]
+    CannotWithdrawMembershipTokens, // 600
 
     /// Cannot revoke GoverningTokens
     #[error("Cannot revoke GoverningTokens")]

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -410,6 +410,14 @@ pub enum GovernanceError {
     /// Invalid RealmConfig account address
     #[error("Invalid RealmConfig account address")]
     InvalidRealmConfigAddress,
+
+    /// Cannot revoke GoverningToken
+    #[error("Cannot revoke GoverningToken")]
+    CannotRevokeGoverningToken, // 599
+
+    /// Invalid Revoke amount
+    #[error("Invalid Revoke amount")]
+    InvalidRevokeAmount, // 600
 }
 
 impl PrintProgramError for GovernanceError {

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -261,23 +261,23 @@ pub enum GovernanceError {
 
     /// Governance PDA must sign
     #[error("Governance PDA must sign")]
-    GovernancePdaMustSign,
+    GovernancePdaMustSign, // 561
 
     /// Transaction already flagged with error
     #[error("Transaction already flagged with error")]
-    TransactionAlreadyFlaggedWithError,
+    TransactionAlreadyFlaggedWithError, // 562
 
     /// Invalid Realm for Governance
     #[error("Invalid Realm for Governance")]
-    InvalidRealmForGovernance,
+    InvalidRealmForGovernance, // 563
 
     /// Invalid Authority for Realm
     #[error("Invalid Authority for Realm")]
-    InvalidAuthorityForRealm,
+    InvalidAuthorityForRealm, // 564
 
     /// Realm has no authority
     #[error("Realm has no authority")]
-    RealmHasNoAuthority,
+    RealmHasNoAuthority, // 565
 
     /// Realm authority must sign
     #[error("Realm authority must sign")]

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -32,7 +32,7 @@ use solana_program::{
 };
 
 /// Instructions supported by the Governance program
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 #[allow(clippy::large_enum_variant)]
 pub enum GovernanceInstruction {
     /// Creates Governance Realm account which aggregates governances for given Community Mint and optional Council Mint

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -523,15 +523,14 @@ pub fn create_realm(
         false
     };
 
+    let realm_config_address = get_realm_config_address(program_id, &realm_address);
+    accounts.push(AccountMeta::new(realm_config_address, false));
+
     let community_token_config_args =
         with_governing_token_config_args(&mut accounts, community_token_config_args);
 
     let council_token_config_args =
         with_governing_token_config_args(&mut accounts, council_token_config_args);
-
-    // TODO: Move before token config accoutns
-    let realm_config_address = get_realm_config_address(program_id, &realm_address);
-    accounts.push(AccountMeta::new(realm_config_address, false));
 
     let instruction = GovernanceInstruction::CreateRealm {
         config_args: RealmConfigArgs {

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -51,9 +51,13 @@ pub enum GovernanceInstruction {
     /// 9. `[writable]` Council Token Holding account - optional unless council is used. PDA seeds: ['governance',realm,council_mint]
     ///     The account will be created with the Realm PDA as its owner
 
-    /// 10. `[]` Optional Community Voter Weight Addin Program Id
-    /// 11. `[]` Optional Max Community Voter Weight Addin Program Id
-    /// 12. `[writable]` Optional RealmConfig account. PDA seeds: ['realm-config', realm]
+    /// 10. `[writable]` RealmConfig account. PDA seeds: ['realm-config', realm]
+
+    /// 11. `[]` Optional Community Voter Weight Addin Program Id
+    /// 12. `[]` Optional Max Community Voter Weight Addin Program Id
+    ///
+    /// 13. `[]` Optional Council Voter Weight Addin Program Id
+    /// 14. `[]` Optional Max Council Voter Weight Addin Program Id
     CreateRealm {
         #[allow(dead_code)]
         /// UTF-8 encoded Governance Realm name
@@ -68,16 +72,18 @@ pub enum GovernanceInstruction {
     /// Note: If subsequent (top up) deposit is made and there are active votes for the Voter then the vote weights won't be updated automatically
     /// It can be done by relinquishing votes on active Proposals and voting again with the new weight
     ///
-    ///  0. `[]` Governance Realm account
+    ///  0. `[]` Realm account
     ///  1. `[writable]` Governing Token Holding account. PDA seeds: ['governance',realm, governing_token_mint]
-    ///  2. `[writable]` Governing Token Source account. All tokens from the account will be transferred to the Holding account
+    ///  2. `[writable]` Governing Token Source account. It can be either spl-token TokenAccount or MintAccount
+    ///      Tokens will be transferred or minted to the Holding account
     ///  3. `[signer]` Governing Token Owner account
-    ///  4. `[signer]` Governing Token Transfer authority
-    ///  5. `[writable]` Token Owner Record account. PDA seeds: ['governance',realm, governing_token_mint, governing_token_owner]
+    ///  4. `[signer]` Governing Token Source account authority
+    ///      It should be owner for TokenAccount and mint_auhtority for MintAccount
+    ///  5. `[writable]` TokenOwnerRecord account. PDA seeds: ['governance',realm, governing_token_mint, governing_token_owner]
     ///  6. `[signer]` Payer
     ///  7. `[]` System
-    ///  8. `[]` SPL Token
-    ///  9. `[]` Sysvar Rent
+    ///  8. `[]` SPL Token program
+    ///  9. `[]` RealmConfig account. PDA seeds: ['realm-config', realm]
     DepositGoverningTokens {
         /// The amount to deposit into the realm
         #[allow(dead_code)]
@@ -88,12 +94,13 @@ pub enum GovernanceInstruction {
     /// Note: It's only possible to withdraw tokens if the Voter doesn't have any outstanding active votes
     /// If there are any outstanding votes then they must be relinquished before tokens could be withdrawn
     ///
-    ///  0. `[]` Governance Realm account
+    ///  0. `[]` Realm account
     ///  1. `[writable]` Governing Token Holding account. PDA seeds: ['governance',realm, governing_token_mint]
     ///  2. `[writable]` Governing Token Destination account. All tokens will be transferred to this account
     ///  3. `[signer]` Governing Token Owner account
-    ///  4. `[writable]` Token Owner  Record account. PDA seeds: ['governance',realm, governing_token_mint, governing_token_owner]
-    ///  5. `[]` SPL Token
+    ///  4. `[writable]` TokenOwnerRecord account. PDA seeds: ['governance',realm, governing_token_mint, governing_token_owner]
+    ///  5. `[]` SPL Token program
+    ///  6. `[]` RealmConfig account. PDA seeds: ['realm-config', realm]
     WithdrawGoverningTokens {},
 
     /// Sets Governance Delegate for the given Realm and Governing Token Mint (Community or Council)
@@ -120,7 +127,7 @@ pub enum GovernanceInstruction {
     ///   5. `[]` System program
     ///   6. `[]` Sysvar Rent
     ///   7. `[signer]` Governance authority
-    ///   8. `[]` Realm Config
+    ///   8. `[]` RealmConfig account. PDA seeds: ['realm-config', realm]
     ///   9. `[]` Optional Voter Weight Record
     CreateGovernance {
         /// Governance config
@@ -141,7 +148,7 @@ pub enum GovernanceInstruction {
     ///   8. `[]` System program
     ///   9. `[]` Sysvar Rent
     ///   10. `[signer]` Governance authority
-    ///   11. `[]` Realm Config
+    ///   11. `[]` RealmConfig account. PDA seeds: ['realm-config', realm]
     ///   12. `[]` Optional Voter Weight Record
     CreateProgramGovernance {
         /// Governance config
@@ -165,7 +172,7 @@ pub enum GovernanceInstruction {
     ///   5. `[signer]` Governance Authority (Token Owner or Governance Delegate)
     ///   6. `[signer]` Payer
     ///   7. `[]` System program
-    ///   8. `[]` Realm Config
+    ///   8. `[]` RealmConfig account. PDA seeds: ['realm-config', realm]
     ///   9. `[]` Optional Voter Weight Record
     CreateProposal {
         #[allow(dead_code)]
@@ -298,7 +305,7 @@ pub enum GovernanceInstruction {
     ///           Note: In the current version only Council veto is supported
     ///   8. `[signer]` Payer
     ///   9. `[]` System program
-    ///   10. `[]` Realm Config
+    ///   10. `[]` RealmConfig account. PDA seeds: ['realm-config', realm]
     ///   11. `[]` Optional Voter Weight Record
     ///   12. `[]` Optional Max Voter Weight Record
     CastVote {
@@ -314,7 +321,7 @@ pub enum GovernanceInstruction {
     ///   2. `[writable]` Proposal account
     ///   3. `[writable]` TokenOwnerRecord of the Proposal owner        
     ///   4. `[]` Governing Token Mint
-    ///   5. `[]` Realm Config
+    ///   5. `[]` RealmConfig account. PDA seeds: ['realm-config', realm]
     ///   6. `[]` Optional Max Voter Weight Record
     FinalizeVote {},
 
@@ -358,7 +365,7 @@ pub enum GovernanceInstruction {
     ///   7. `[]` System program
     ///   8. `[]` Sysvar Rent
     ///   8. `[signer]` Governance authority
-    ///   9. `[]` Realm Config
+    ///   9. `[]` RealmConfig account. PDA seeds: ['realm-config', realm]
     ///   10. `[]` Optional Voter Weight Record
     CreateMintGovernance {
         #[allow(dead_code)]
@@ -384,7 +391,7 @@ pub enum GovernanceInstruction {
     ///   7. `[]` System program
     ///   8. `[]` Sysvar Rent
     ///   9. `[signer]` Governance authority
-    ///   10. `[]` Realm Config
+    ///   10. `[]` RealmConfig account. PDA seeds: ['realm-config', realm]
     ///   11. `[]` Optional Voter Weight Record   
     CreateTokenGovernance {
         #[allow(dead_code)]
@@ -441,10 +448,14 @@ pub enum GovernanceInstruction {
     ///       The account will be created with the Realm PDA as its owner
     ///   4. `[]` System
     ///   5. `[writable]` RealmConfig account. PDA seeds: ['realm-config', realm]
-
+    ///
     ///   6. `[]` Optional Community Voter Weight Addin Program Id    
     ///   7. `[]` Optional Max Community Voter Weight Addin Program Id    
-    ///   8. `[signer]` Optional Payer
+    ///
+    ///   8. `[]` Optional Council Voter Weight Addin Program Id    
+    ///   9. `[]` Optional Max Council Voter Weight Addin Program Id    
+    ///
+    ///   10. `[signer]` Optional Payer. Required if RealmConfig doesn't exist and needs to be created
     SetRealmConfig {
         #[allow(dead_code)]
         /// Realm config args

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -574,7 +574,7 @@ pub fn deposit_governing_tokens(
     realm: &Pubkey,
     governing_token_source: &Pubkey,
     governing_token_owner: &Pubkey,
-    governing_token_transfer_authority: &Pubkey,
+    governing_token_source_authority: &Pubkey,
     payer: &Pubkey,
     // Args
     amount: u64,
@@ -597,7 +597,7 @@ pub fn deposit_governing_tokens(
         AccountMeta::new(governing_token_holding_address, false),
         AccountMeta::new(*governing_token_source, false),
         AccountMeta::new_readonly(*governing_token_owner, true),
-        AccountMeta::new_readonly(*governing_token_transfer_authority, true),
+        AccountMeta::new_readonly(*governing_token_source_authority, true),
         AccountMeta::new(token_owner_record_address, false),
         AccountMeta::new(*payer, true),
         AccountMeta::new_readonly(system_program::id(), false),

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -1514,29 +1514,21 @@ pub fn with_governing_token_config_args(
 ) -> GoverningTokenConfigArgs {
     let governing_token_config_args = governing_token_config_args.unwrap_or_default();
 
-    let use_voter_weight_addin = if let Some(community_voter_weight_addin) =
-        governing_token_config_args.voter_weight_addin
-    {
-        accounts.push(AccountMeta::new_readonly(
-            community_voter_weight_addin,
-            false,
-        ));
-        true
-    } else {
-        false
-    };
+    let use_voter_weight_addin =
+        if let Some(voter_weight_addin) = governing_token_config_args.voter_weight_addin {
+            accounts.push(AccountMeta::new_readonly(voter_weight_addin, false));
+            true
+        } else {
+            false
+        };
 
-    let use_max_voter_weight_addin = if let Some(max_community_voter_weight_addin) =
-        governing_token_config_args.max_voter_weight_addin
-    {
-        accounts.push(AccountMeta::new_readonly(
-            max_community_voter_weight_addin,
-            false,
-        ));
-        true
-    } else {
-        false
-    };
+    let use_max_voter_weight_addin =
+        if let Some(max_voter_weight_addin) = governing_token_config_args.max_voter_weight_addin {
+            accounts.push(AccountMeta::new_readonly(max_voter_weight_addin, false));
+            true
+        } else {
+            false
+        };
 
     GoverningTokenConfigArgs {
         use_voter_weight_addin,

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -1544,7 +1544,7 @@ pub fn revoke_governing_tokens(
     let governing_token_holding_address =
         get_governing_token_holding_address(program_id, realm, governing_token_mint);
 
-    let realm_config_address = get_realm_config_address(program_id, &realm);
+    let realm_config_address = get_realm_config_address(program_id, realm);
 
     let accounts = vec![
         AccountMeta::new_readonly(*realm, false),

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -489,7 +489,7 @@ pub fn create_realm(
     community_token_mint: &Pubkey,
     payer: &Pubkey,
     council_token_mint: Option<Pubkey>,
-    community_token_args: &GoverningTokenConfigAccountArgs,
+    community_token_args: Option<GoverningTokenConfigAccountArgs>,
     // Args
     name: String,
     min_community_weight_to_create_governance: u64,
@@ -509,6 +509,8 @@ pub fn create_realm(
         AccountMeta::new_readonly(spl_token::id(), false),
         AccountMeta::new_readonly(sysvar::rent::id(), false),
     ];
+
+    let community_token_args = community_token_args.unwrap_or_default();
 
     let use_council_mint = if let Some(council_token_mint) = council_token_mint {
         let council_token_holding_address =
@@ -557,7 +559,7 @@ pub fn create_realm(
             community_token_config_args: GoverningTokenConfigArgs {
                 use_voter_weight_addin: use_community_voter_weight_addin,
                 use_max_voter_weight_addin: use_max_community_voter_weight_addin,
-                token_type: community_token_args.token_type.clone(),
+                token_type: community_token_args.token_type,
             },
             council_token_config_args: GoverningTokenConfigArgs::default(),
         },
@@ -1362,7 +1364,7 @@ pub fn set_realm_config(
     realm_authority: &Pubkey,
     council_token_mint: Option<Pubkey>,
     payer: &Pubkey,
-    community_token_args: &GoverningTokenConfigAccountArgs,
+    community_token_args: Option<GoverningTokenConfigAccountArgs>,
     // Args
     min_community_weight_to_create_governance: u64,
     community_mint_max_vote_weight_source: MintMaxVoteWeightSource,
@@ -1389,6 +1391,8 @@ pub fn set_realm_config(
     // but also when it's set to false and the addin is being  removed from the realm
     let realm_config_address = get_realm_config_address(program_id, realm);
     accounts.push(AccountMeta::new(realm_config_address, false));
+
+    let community_token_args = community_token_args.unwrap_or_default();
 
     let use_community_voter_weight_addin =
         if let Some(community_voter_weight_addin) = community_token_args.voter_weight_addin {
@@ -1425,7 +1429,7 @@ pub fn set_realm_config(
             community_token_config_args: GoverningTokenConfigArgs {
                 use_voter_weight_addin: use_community_voter_weight_addin,
                 use_max_voter_weight_addin: use_max_community_voter_weight_addin,
-                token_type: community_token_args.token_type.clone(),
+                token_type: community_token_args.token_type,
             },
             council_token_config_args: GoverningTokenConfigArgs::default(),
         },

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -590,6 +590,8 @@ pub fn deposit_governing_tokens(
     let governing_token_holding_address =
         get_governing_token_holding_address(program_id, realm, governing_token_mint);
 
+    let realm_config_address = get_realm_config_address(program_id, realm);
+
     let accounts = vec![
         AccountMeta::new_readonly(*realm, false),
         AccountMeta::new(governing_token_holding_address, false),
@@ -600,6 +602,7 @@ pub fn deposit_governing_tokens(
         AccountMeta::new(*payer, true),
         AccountMeta::new_readonly(system_program::id(), false),
         AccountMeta::new_readonly(spl_token::id(), false),
+        AccountMeta::new_readonly(realm_config_address, false),
     ];
 
     let instruction = GovernanceInstruction::DepositGoverningTokens { amount };
@@ -631,6 +634,8 @@ pub fn withdraw_governing_tokens(
     let governing_token_holding_address =
         get_governing_token_holding_address(program_id, realm, governing_token_mint);
 
+    let realm_config_address = get_realm_config_address(program_id, realm);
+
     let accounts = vec![
         AccountMeta::new_readonly(*realm, false),
         AccountMeta::new(governing_token_holding_address, false),
@@ -638,6 +643,7 @@ pub fn withdraw_governing_tokens(
         AccountMeta::new_readonly(*governing_token_owner, true),
         AccountMeta::new(token_owner_record_address, false),
         AccountMeta::new_readonly(spl_token::id(), false),
+        AccountMeta::new_readonly(realm_config_address, false),
     ];
 
     let instruction = GovernanceInstruction::WithdrawGoverningTokens {};

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -11,9 +11,9 @@ use crate::{
         program_metadata::get_program_metadata_address,
         proposal::{get_proposal_address, VoteType},
         proposal_transaction::{get_proposal_transaction_address, InstructionData},
-        realm::SetRealmAuthorityAction,
         realm::{get_governing_token_holding_address, get_realm_address, RealmConfigArgs},
-        realm_config::get_realm_config_address,
+        realm::{GoverningTokenConfigArgs, SetRealmAuthorityAction},
+        realm_config::{get_realm_config_address, GoverningTokenType},
         signatory_record::get_signatory_record_address,
         token_owner_record::get_token_owner_record_address,
         vote_record::{get_vote_record_address, Vote},
@@ -551,8 +551,12 @@ pub fn create_realm(
             use_council_mint,
             min_community_weight_to_create_governance,
             community_mint_max_vote_weight_source,
-            use_community_voter_weight_addin,
-            use_max_community_voter_weight_addin,
+            community_token_config_args: GoverningTokenConfigArgs {
+                use_voter_weight_addin: use_community_voter_weight_addin,
+                use_max_voter_weight_addin: use_max_community_voter_weight_addin,
+                token_type: GoverningTokenType::Liquid,
+            },
+            council_token_config_args: GoverningTokenConfigArgs::default(),
         },
         name,
     };
@@ -1415,8 +1419,12 @@ pub fn set_realm_config(
             use_council_mint,
             min_community_weight_to_create_governance,
             community_mint_max_vote_weight_source,
-            use_community_voter_weight_addin,
-            use_max_community_voter_weight_addin,
+            community_token_config_args: GoverningTokenConfigArgs {
+                use_voter_weight_addin: use_community_voter_weight_addin,
+                use_max_voter_weight_addin: use_max_community_voter_weight_addin,
+                token_type: GoverningTokenType::Liquid,
+            },
+            council_token_config_args: GoverningTokenConfigArgs::default(),
         },
     };
 

--- a/governance/program/src/processor/mod.rs
+++ b/governance/program/src/processor/mod.rs
@@ -19,6 +19,7 @@ mod process_insert_transaction;
 mod process_relinquish_vote;
 mod process_remove_signatory;
 mod process_remove_transaction;
+mod process_revoke_governing_tokens;
 mod process_set_governance_config;
 mod process_set_governance_delegate;
 mod process_set_realm_authority;
@@ -48,6 +49,7 @@ use process_insert_transaction::*;
 use process_relinquish_vote::*;
 use process_remove_signatory::*;
 use process_remove_transaction::*;
+use process_revoke_governing_tokens::*;
 use process_set_governance_config::*;
 use process_set_governance_delegate::*;
 use process_set_realm_authority::*;
@@ -212,6 +214,10 @@ pub fn process_instruction(
         }
         GovernanceInstruction::CreateNativeTreasury {} => {
             process_create_native_treasury(program_id, accounts)
+        }
+
+        GovernanceInstruction::RevokeGoverningTokens { amount } => {
+            process_revoke_governing_tokens(program_id, accounts, amount)
         }
     }
 }

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -150,11 +150,11 @@ pub fn process_cast_vote(
     }
 
     let max_voter_weight = proposal_data.resolve_max_voter_weight(
-        &realm_config_data,
-        vote_governing_token_mint_info,
         account_info_iter, // max_voter_weight_record  11
         realm_info.key,
         &realm_data,
+        &realm_config_data,
+        vote_governing_token_mint_info,
         &vote_kind,
     )?;
 

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -18,7 +18,7 @@ use crate::{
         governance::get_governance_data_for_realm,
         proposal::get_proposal_data_for_governance_and_governing_mint,
         realm::get_realm_data_for_governing_token_mint,
-        realm_config::next_realm_config_info_for_realm,
+        realm_config::get_realm_config_data_for_realm,
         token_owner_record::{
             get_token_owner_record_data_for_proposal_owner,
             get_token_owner_record_data_for_realm_and_governing_mint,
@@ -105,19 +105,13 @@ pub fn process_cast_vote(
         .checked_add(1)
         .unwrap();
 
-    // Note: When both voter_weight and max_voter_weight addins are used the realm_config will be deserialized twice in resolve_voter_weight() and resolve_max_voter_weight()
-    //      It can't be deserialized eagerly because some realms won't have the config if they don't use any of the advanced options
-    //      This extra deserialisation should be acceptable to keep things simple and encapsulated.
-
-    // Get realm_config_info from the account_info iterator and assert it has a valid PDA for the given Realm
-    let realm_config_info =
-        next_realm_config_info_for_realm(account_info_iter, program_id, realm_info.key)?; //9
+    let realm_config_info = next_account_info(account_info_iter)?; // 9
+    let realm_config_data =
+        get_realm_config_data_for_realm(program_id, realm_config_info, realm_info.key)?;
 
     let voter_weight = voter_token_owner_record_data.resolve_voter_weight(
-        program_id,
-        realm_config_info,
+        &realm_config_data,
         account_info_iter, // voter_weight_record  10
-        realm_info.key,
         &realm_data,
         VoterWeightAction::CastVote,
         proposal_info.key,
@@ -156,8 +150,7 @@ pub fn process_cast_vote(
     }
 
     let max_voter_weight = proposal_data.resolve_max_voter_weight(
-        program_id,
-        realm_config_info,
+        &realm_config_data,
         vote_governing_token_mint_info,
         account_info_iter, // max_voter_weight_record  11
         realm_info.key,

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -110,9 +110,9 @@ pub fn process_cast_vote(
         get_realm_config_data_for_realm(program_id, realm_config_info, realm_info.key)?;
 
     let voter_weight = voter_token_owner_record_data.resolve_voter_weight(
-        &realm_config_data,
-        account_info_iter, // voter_weight_record  10
+        account_info_iter, // voter_weight_record  *10
         &realm_data,
+        &realm_config_data,
         VoterWeightAction::CastVote,
         proposal_info.key,
     )?;

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -18,6 +18,7 @@ use crate::{
         governance::get_governance_data_for_realm,
         proposal::get_proposal_data_for_governance_and_governing_mint,
         realm::get_realm_data_for_governing_token_mint,
+        realm_config::next_realm_config_info_for_realm,
         token_owner_record::{
             get_token_owner_record_data_for_proposal_owner,
             get_token_owner_record_data_for_realm_and_governing_mint,
@@ -107,7 +108,10 @@ pub fn process_cast_vote(
     // Note: When both voter_weight and max_voter_weight addins are used the realm_config will be deserialized twice in resolve_voter_weight() and resolve_max_voter_weight()
     //      It can't be deserialized eagerly because some realms won't have the config if they don't use any of the advanced options
     //      This extra deserialisation should be acceptable to keep things simple and encapsulated.
-    let realm_config_info = next_account_info(account_info_iter)?; //9
+
+    // Get realm_config_info from the account_info iterator and assert it has a valid PDA for the given Realm
+    let realm_config_info =
+        next_realm_config_info_for_realm(account_info_iter, program_id, realm_info.key)?; //9
 
     let voter_weight = voter_token_owner_record_data.resolve_voter_weight(
         program_id,

--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -21,6 +21,7 @@ use crate::{
             ProposalOption, ProposalV2, VoteType,
         },
         realm::get_realm_data_for_governing_token_mint,
+        realm_config::next_realm_config_info_for_realm,
         token_owner_record::get_token_owner_record_data_for_realm,
         vote_record::VoteKind,
     },
@@ -81,7 +82,9 @@ pub fn process_create_proposal(
     proposal_owner_record_data
         .assert_token_owner_or_delegate_is_signer(governance_authority_info)?;
 
-    let realm_config_info = next_account_info(account_info_iter)?; // 10
+    // Get realm_config_info from the account_info iterator and assert it has a valid PDA for the given Realm
+    let realm_config_info =
+        next_realm_config_info_for_realm(account_info_iter, program_id, realm_info.key)?; // 10
 
     let voter_weight = proposal_owner_record_data.resolve_voter_weight(
         program_id,

--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -87,9 +87,9 @@ pub fn process_create_proposal(
         get_realm_config_data_for_realm(program_id, realm_config_info, realm_info.key)?;
 
     let voter_weight = proposal_owner_record_data.resolve_voter_weight(
-        &realm_config_data,
-        account_info_iter,
+        account_info_iter, // voter_weight_record  *11
         &realm_data,
+        &realm_config_data,
         VoterWeightAction::CreateProposal,
         governance_info.key,
     )?;

--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -21,7 +21,7 @@ use crate::{
             ProposalOption, ProposalV2, VoteType,
         },
         realm::get_realm_data_for_governing_token_mint,
-        realm_config::next_realm_config_info_for_realm,
+        realm_config::get_realm_config_data_for_realm,
         token_owner_record::get_token_owner_record_data_for_realm,
         vote_record::VoteKind,
     },
@@ -82,15 +82,13 @@ pub fn process_create_proposal(
     proposal_owner_record_data
         .assert_token_owner_or_delegate_is_signer(governance_authority_info)?;
 
-    // Get realm_config_info from the account_info iterator and assert it has a valid PDA for the given Realm
-    let realm_config_info =
-        next_realm_config_info_for_realm(account_info_iter, program_id, realm_info.key)?; // 10
+    let realm_config_info = next_account_info(account_info_iter)?; // 10
+    let realm_config_data =
+        get_realm_config_data_for_realm(program_id, realm_config_info, realm_info.key)?;
 
     let voter_weight = proposal_owner_record_data.resolve_voter_weight(
-        program_id,
-        realm_config_info,
+        &realm_config_data,
         account_info_iter,
-        realm_info.key,
         &realm_data,
         VoterWeightAction::CreateProposal,
         governance_info.key,

--- a/governance/program/src/processor/process_create_realm.rs
+++ b/governance/program/src/processor/process_create_realm.rs
@@ -136,12 +136,8 @@ pub fn process_create_realm(
                 .community_mint_max_vote_weight_source,
             min_community_weight_to_create_governance: realm_config_args
                 .min_community_weight_to_create_governance,
-            use_community_voter_weight_addin: realm_config_args
-                .community_token_config_args
-                .use_voter_weight_addin,
-            use_max_community_voter_weight_addin: realm_config_args
-                .community_token_config_args
-                .use_max_voter_weight_addin,
+            legacy1: 0,
+            legacy2: 0,
         },
         voting_proposal_count: 0,
         reserved_v2: [0; 128],

--- a/governance/program/src/processor/process_create_realm.rs
+++ b/governance/program/src/processor/process_create_realm.rs
@@ -30,7 +30,7 @@ pub fn process_create_realm(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
     name: String,
-    config_args: RealmConfigArgs,
+    realm_config_args: RealmConfigArgs,
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
 
@@ -49,7 +49,7 @@ pub fn process_create_realm(
         return Err(GovernanceError::RealmAlreadyExists.into());
     }
 
-    assert_valid_realm_config_args(&config_args)?;
+    assert_valid_realm_config_args(&realm_config_args)?;
 
     // Create Community token holding account
     create_spl_token_account_signed(
@@ -66,7 +66,7 @@ pub fn process_create_realm(
     )?;
 
     // Create Council token holding account
-    let council_token_mint_address = if config_args.use_council_mint {
+    let council_token_mint_address = if realm_config_args.use_council_mint {
         let council_token_mint_info = next_account_info(account_info_iter)?; // 8
         let council_token_holding_info = next_account_info(account_info_iter)?; // 9
 
@@ -94,13 +94,13 @@ pub fn process_create_realm(
     // 11, 12
     let community_token_config = resolve_governing_token_config(
         account_info_iter,
-        config_args.community_token_config_args.clone(),
+        realm_config_args.community_token_config_args.clone(),
     )?;
 
     // 13, 14
     let council_token_config = resolve_governing_token_config(
         account_info_iter,
-        config_args.council_token_config_args.clone(),
+        realm_config_args.council_token_config_args.clone(),
     )?;
 
     let realm_config_data = RealmConfigAccount {
@@ -132,14 +132,14 @@ pub fn process_create_realm(
         config: RealmConfig {
             council_mint: council_token_mint_address,
             reserved: [0; 6],
-            community_mint_max_vote_weight_source: config_args
+            community_mint_max_vote_weight_source: realm_config_args
                 .community_mint_max_vote_weight_source,
-            min_community_weight_to_create_governance: config_args
+            min_community_weight_to_create_governance: realm_config_args
                 .min_community_weight_to_create_governance,
-            use_community_voter_weight_addin: config_args
+            use_community_voter_weight_addin: realm_config_args
                 .community_token_config_args
                 .use_voter_weight_addin,
-            use_max_community_voter_weight_addin: config_args
+            use_max_community_voter_weight_addin: realm_config_args
                 .community_token_config_args
                 .use_max_voter_weight_addin,
         },

--- a/governance/program/src/processor/process_create_realm.rs
+++ b/governance/program/src/processor/process_create_realm.rs
@@ -94,13 +94,13 @@ pub fn process_create_realm(
     // 11, 12
     let community_token_config = resolve_governing_token_config(
         account_info_iter,
-        realm_config_args.community_token_config_args.clone(),
+        &realm_config_args.community_token_config_args,
     )?;
 
     // 13, 14
     let council_token_config = resolve_governing_token_config(
         account_info_iter,
-        realm_config_args.council_token_config_args.clone(),
+        &realm_config_args.council_token_config_args,
     )?;
 
     let realm_config_data = RealmConfigAccount {

--- a/governance/program/src/processor/process_create_realm.rs
+++ b/governance/program/src/processor/process_create_realm.rs
@@ -17,7 +17,10 @@ use crate::{
             assert_valid_realm_config_args, get_governing_token_holding_address_seeds,
             get_realm_address_seeds, RealmConfig, RealmConfigArgs, RealmV2,
         },
-        realm_config::{get_realm_config_address_seeds, GoverningTokenConfig, RealmConfigAccount},
+        realm_config::{
+            get_realm_config_address_seeds, GoverningTokenConfig, GoverningTokenType,
+            RealmConfigAccount, Reserved110,
+        },
     },
     tools::spl_token::create_spl_token_account_signed,
 };
@@ -110,10 +113,11 @@ pub fn process_create_realm(
             community_token_config: GoverningTokenConfig {
                 voter_weight_addin: community_voter_weight_addin,
                 max_voter_weight_addin: max_community_voter_weight_addin,
+                token_type: GoverningTokenType::Liquid,
+                reserved: [0; 8],
             },
-            council_voter_weight_addin: None,
-            council_max_vote_weight_addin: None,
-            reserved: [0; 128],
+            council_token_config: GoverningTokenConfig::default(),
+            reserved: Reserved110::default(),
         };
 
         create_and_serialize_account_signed::<RealmConfigAccount>(

--- a/governance/program/src/processor/process_create_realm.rs
+++ b/governance/program/src/processor/process_create_realm.rs
@@ -88,22 +88,32 @@ pub fn process_create_realm(
 
     // Setup config for addins
 
-    let community_voter_weight_addin = if config_args.use_community_voter_weight_addin {
+    let community_voter_weight_addin = if config_args
+        .community_token_config_args
+        .use_voter_weight_addin
+    {
         let community_voter_weight_addin_info = next_account_info(account_info_iter)?; // 10
         Some(*community_voter_weight_addin_info.key)
     } else {
         None
     };
 
-    let max_community_voter_weight_addin = if config_args.use_max_community_voter_weight_addin {
+    let max_community_voter_weight_addin = if config_args
+        .community_token_config_args
+        .use_max_voter_weight_addin
+    {
         let max_community_voter_weight_addin_info = next_account_info(account_info_iter)?; // 11
         Some(*max_community_voter_weight_addin_info.key)
     } else {
         None
     };
 
-    if config_args.use_community_voter_weight_addin
-        || config_args.use_max_community_voter_weight_addin
+    if config_args
+        .community_token_config_args
+        .use_voter_weight_addin
+        || config_args
+            .community_token_config_args
+            .use_max_voter_weight_addin
     {
         let realm_config_info = next_account_info(account_info_iter)?; // 12
 
@@ -145,8 +155,12 @@ pub fn process_create_realm(
                 .community_mint_max_vote_weight_source,
             min_community_weight_to_create_governance: config_args
                 .min_community_weight_to_create_governance,
-            use_community_voter_weight_addin: config_args.use_community_voter_weight_addin,
-            use_max_community_voter_weight_addin: config_args.use_max_community_voter_weight_addin,
+            use_community_voter_weight_addin: config_args
+                .community_token_config_args
+                .use_voter_weight_addin,
+            use_max_community_voter_weight_addin: config_args
+                .community_token_config_args
+                .use_max_voter_weight_addin,
         },
         voting_proposal_count: 0,
         reserved_v2: [0; 128],

--- a/governance/program/src/processor/process_create_realm.rs
+++ b/governance/program/src/processor/process_create_realm.rs
@@ -17,7 +17,7 @@ use crate::{
             assert_valid_realm_config_args, get_governing_token_holding_address_seeds,
             get_realm_address_seeds, RealmConfig, RealmConfigArgs, RealmV2,
         },
-        realm_config::{get_realm_config_address_seeds, RealmConfigAccount},
+        realm_config::{get_realm_config_address_seeds, GoverningTokenConfig, RealmConfigAccount},
     },
     tools::spl_token::create_spl_token_account_signed,
 };
@@ -107,8 +107,10 @@ pub fn process_create_realm(
         let realm_config_data = RealmConfigAccount {
             account_type: GovernanceAccountType::RealmConfig,
             realm: *realm_info.key,
-            community_voter_weight_addin,
-            max_community_voter_weight_addin,
+            community_token_config: GoverningTokenConfig {
+                voter_weight_addin: community_voter_weight_addin,
+                max_voter_weight_addin: max_community_voter_weight_addin,
+            },
             council_voter_weight_addin: None,
             council_max_vote_weight_addin: None,
             reserved: [0; 128],

--- a/governance/program/src/processor/process_deposit_governing_tokens.rs
+++ b/governance/program/src/processor/process_deposit_governing_tokens.rs
@@ -14,6 +14,7 @@ use crate::{
     state::{
         enums::GovernanceAccountType,
         realm::get_realm_data,
+        realm_config::get_realm_config_data_for_realm,
         token_owner_record::{
             get_token_owner_record_address_seeds, get_token_owner_record_data_for_seeds,
             TokenOwnerRecordV2,
@@ -39,6 +40,7 @@ pub fn process_deposit_governing_tokens(
     let payer_info = next_account_info(account_info_iter)?; // 6
     let system_info = next_account_info(account_info_iter)?; // 7
     let spl_token_info = next_account_info(account_info_iter)?; // 8
+    let realm_config_info = next_account_info(account_info_iter)?; // 9
 
     let rent = Rent::get()?;
 
@@ -51,6 +53,11 @@ pub fn process_deposit_governing_tokens(
         &governing_token_mint,
         governing_token_holding_info.key,
     )?;
+
+    let realm_config_data =
+        get_realm_config_data_for_realm(program_id, realm_config_info, realm_info.key)?;
+
+    realm_config_data.assert_can_deposit_governing_token(&realm_data, &governing_token_mint)?;
 
     transfer_spl_tokens(
         governing_token_source_info,

--- a/governance/program/src/processor/process_deposit_governing_tokens.rs
+++ b/governance/program/src/processor/process_deposit_governing_tokens.rs
@@ -21,8 +21,8 @@ use crate::{
         },
     },
     tools::spl_token::{
-        get_spl_token_mint, get_spl_token_owner, is_spl_token_account, is_spl_token_mint,
-        mint_spl_tokens_to, transfer_spl_tokens,
+        get_spl_token_mint, is_spl_token_account, is_spl_token_mint, mint_spl_tokens_to,
+        transfer_spl_tokens,
     },
 };
 
@@ -92,11 +92,7 @@ pub fn process_deposit_governing_tokens(
 
     if token_owner_record_info.data_is_empty() {
         // Deposited tokens can only be withdrawn by the owner so let's make sure the owner signed the transaction
-        let governing_token_owner = get_spl_token_owner(governing_token_source_info)?;
-
-        if !(governing_token_owner == *governing_token_owner_info.key
-            && governing_token_owner_info.is_signer)
-        {
+        if !governing_token_owner_info.is_signer {
             return Err(GovernanceError::GoverningTokenOwnerMustSign.into());
         }
 

--- a/governance/program/src/processor/process_finalize_vote.rs
+++ b/governance/program/src/processor/process_finalize_vote.rs
@@ -11,7 +11,7 @@ use solana_program::{
 use crate::state::{
     governance::get_governance_data_for_realm,
     proposal::get_proposal_data_for_governance_and_governing_mint,
-    realm::get_realm_data_for_governing_token_mint,
+    realm::get_realm_data_for_governing_token_mint, realm_config::next_realm_config_info_for_realm,
     token_owner_record::get_token_owner_record_data_for_proposal_owner, vote_record::VoteKind,
 };
 
@@ -43,7 +43,9 @@ pub fn process_finalize_vote(program_id: &Pubkey, accounts: &[AccountInfo]) -> P
         governing_token_mint_info.key,
     )?;
 
-    let realm_config_info = next_account_info(account_info_iter)?; // 5
+    // Get realm_config_info from the account_info iterator and assert it has a valid PDA for the given Realm
+    let realm_config_info =
+        next_realm_config_info_for_realm(account_info_iter, program_id, realm_info.key)?; //5
 
     let max_voter_weight = proposal_data.resolve_max_voter_weight(
         program_id,

--- a/governance/program/src/processor/process_finalize_vote.rs
+++ b/governance/program/src/processor/process_finalize_vote.rs
@@ -48,11 +48,11 @@ pub fn process_finalize_vote(program_id: &Pubkey, accounts: &[AccountInfo]) -> P
         get_realm_config_data_for_realm(program_id, realm_config_info, realm_info.key)?;
 
     let max_voter_weight = proposal_data.resolve_max_voter_weight(
-        &realm_config_data,
-        governing_token_mint_info,
         account_info_iter, // *6
         realm_info.key,
         &realm_data,
+        &realm_config_data,
+        governing_token_mint_info,
         &VoteKind::Electorate,
     )?;
 

--- a/governance/program/src/processor/process_finalize_vote.rs
+++ b/governance/program/src/processor/process_finalize_vote.rs
@@ -11,7 +11,7 @@ use solana_program::{
 use crate::state::{
     governance::get_governance_data_for_realm,
     proposal::get_proposal_data_for_governance_and_governing_mint,
-    realm::get_realm_data_for_governing_token_mint, realm_config::next_realm_config_info_for_realm,
+    realm::get_realm_data_for_governing_token_mint, realm_config::get_realm_config_data_for_realm,
     token_owner_record::get_token_owner_record_data_for_proposal_owner, vote_record::VoteKind,
 };
 
@@ -43,13 +43,12 @@ pub fn process_finalize_vote(program_id: &Pubkey, accounts: &[AccountInfo]) -> P
         governing_token_mint_info.key,
     )?;
 
-    // Get realm_config_info from the account_info iterator and assert it has a valid PDA for the given Realm
-    let realm_config_info =
-        next_realm_config_info_for_realm(account_info_iter, program_id, realm_info.key)?; //5
+    let realm_config_info = next_account_info(account_info_iter)?; //5
+    let realm_config_data =
+        get_realm_config_data_for_realm(program_id, realm_config_info, realm_info.key)?;
 
     let max_voter_weight = proposal_data.resolve_max_voter_weight(
-        program_id,
-        realm_config_info,
+        &realm_config_data,
         governing_token_mint_info,
         account_info_iter, // *6
         realm_info.key,

--- a/governance/program/src/processor/process_revoke_governing_tokens.rs
+++ b/governance/program/src/processor/process_revoke_governing_tokens.rs
@@ -44,7 +44,7 @@ pub fn process_revoke_governing_tokens(
     realm_data.assert_is_valid_governing_token_mint_and_holding(
         program_id,
         realm_info.key,
-        &governing_token_mint_info.key,
+        governing_token_mint_info.key,
         governing_token_holding_info.key,
     )?;
 

--- a/governance/program/src/processor/process_revoke_governing_tokens.rs
+++ b/governance/program/src/processor/process_revoke_governing_tokens.rs
@@ -61,14 +61,10 @@ pub fn process_revoke_governing_tokens(
         governing_token_mint_info.key,
     )?;
 
-    if amount > token_owner_record_data.governing_token_deposit_amount {
-        return Err(GovernanceError::InvalidRevokeAmount.into());
-    }
-
     token_owner_record_data.governing_token_deposit_amount = token_owner_record_data
         .governing_token_deposit_amount
         .checked_sub(amount)
-        .unwrap();
+        .ok_or(GovernanceError::InvalidRevokeAmount)?;
 
     token_owner_record_data.serialize(&mut *token_owner_record_info.data.borrow_mut())?;
 

--- a/governance/program/src/processor/process_revoke_governing_tokens.rs
+++ b/governance/program/src/processor/process_revoke_governing_tokens.rs
@@ -1,0 +1,86 @@
+//! Program state processor
+
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    entrypoint::ProgramResult,
+    pubkey::Pubkey,
+};
+
+use crate::{
+    error::GovernanceError,
+    state::{
+        realm::{get_realm_address_seeds, get_realm_data_for_authority},
+        realm_config::get_realm_config_data_for_realm,
+        token_owner_record::get_token_owner_record_data_for_realm_and_governing_mint,
+    },
+    tools::spl_token::burn_spl_tokens_signed,
+};
+
+/// Processes RevokeGoverningTokens instruction
+pub fn process_revoke_governing_tokens(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    amount: u64,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    let realm_info = next_account_info(account_info_iter)?; // 0
+    let realm_authority_info = next_account_info(account_info_iter)?; // 1
+
+    let governing_token_holding_info = next_account_info(account_info_iter)?; // 2
+    let token_owner_record_info = next_account_info(account_info_iter)?; // 3
+    let governing_token_mint_info = next_account_info(account_info_iter)?; // 4
+    let realm_config_info = next_account_info(account_info_iter)?; // 5
+
+    let spl_token_info = next_account_info(account_info_iter)?; // 6
+
+    let realm_data =
+        get_realm_data_for_authority(program_id, realm_info, realm_authority_info.key)?;
+
+    if !realm_authority_info.is_signer {
+        return Err(GovernanceError::RealmAuthorityMustSign.into());
+    }
+
+    realm_data.assert_is_valid_governing_token_mint_and_holding(
+        program_id,
+        realm_info.key,
+        &governing_token_mint_info.key,
+        governing_token_holding_info.key,
+    )?;
+
+    let realm_config_data =
+        get_realm_config_data_for_realm(program_id, realm_config_info, realm_info.key)?;
+
+    realm_config_data
+        .assert_can_revoke_governing_token(&realm_data, governing_token_mint_info.key)?;
+
+    let mut token_owner_record_data = get_token_owner_record_data_for_realm_and_governing_mint(
+        program_id,
+        token_owner_record_info,
+        realm_info.key,
+        governing_token_mint_info.key,
+    )?;
+
+    if amount > token_owner_record_data.governing_token_deposit_amount {
+        return Err(GovernanceError::InvalidRevokeAmount.into());
+    }
+
+    token_owner_record_data.governing_token_deposit_amount = token_owner_record_data
+        .governing_token_deposit_amount
+        .checked_sub(amount)
+        .unwrap();
+
+    token_owner_record_data.serialize(&mut *token_owner_record_info.data.borrow_mut())?;
+
+    burn_spl_tokens_signed(
+        governing_token_holding_info,
+        governing_token_mint_info,
+        realm_info,
+        &get_realm_address_seeds(&realm_data.name),
+        program_id,
+        amount,
+        spl_token_info,
+    )?;
+
+    Ok(())
+}

--- a/governance/program/src/processor/process_set_realm_config.rs
+++ b/governance/program/src/processor/process_set_realm_config.rs
@@ -127,6 +127,9 @@ pub fn process_set_realm_config(
     realm_data.config.min_community_weight_to_create_governance =
         realm_config_args.min_community_weight_to_create_governance;
 
+    realm_data.config.legacy1 = 0;
+    realm_data.config.legacy2 = 0;
+
     realm_data.serialize(&mut *realm_info.data.borrow_mut())?;
 
     Ok(())

--- a/governance/program/src/processor/process_set_realm_config.rs
+++ b/governance/program/src/processor/process_set_realm_config.rs
@@ -87,13 +87,13 @@ pub fn process_set_realm_config(
     // 6, 7
     let community_token_config = resolve_governing_token_config(
         account_info_iter,
-        realm_config_args.community_token_config_args.clone(),
+        &realm_config_args.community_token_config_args,
     )?;
 
     // 8, 9
     let council_token_config = resolve_governing_token_config(
         account_info_iter,
-        realm_config_args.council_token_config_args.clone(),
+        &realm_config_args.council_token_config_args,
     )?;
 
     realm_config_data.community_token_config = community_token_config;

--- a/governance/program/src/processor/process_set_realm_config.rs
+++ b/governance/program/src/processor/process_set_realm_config.rs
@@ -98,7 +98,7 @@ pub fn process_set_realm_config(
         let realm_config_data = RealmConfigAccount {
             account_type: GovernanceAccountType::RealmConfig,
             realm: *realm_info.key,
-            community_token_config: community_token_config.clone(),
+            community_token_config,
             council_token_config,
             reserved: Reserved110::default(),
         };

--- a/governance/program/src/processor/process_set_realm_config.rs
+++ b/governance/program/src/processor/process_set_realm_config.rs
@@ -133,14 +133,6 @@ pub fn process_set_realm_config(
     realm_data.config.min_community_weight_to_create_governance =
         realm_config_args.min_community_weight_to_create_governance;
 
-    realm_data.config.use_community_voter_weight_addin = realm_config_args
-        .community_token_config_args
-        .use_voter_weight_addin;
-
-    realm_data.config.use_max_community_voter_weight_addin = realm_config_args
-        .community_token_config_args
-        .use_max_voter_weight_addin;
-
     realm_data.serialize(&mut *realm_info.data.borrow_mut())?;
 
     Ok(())

--- a/governance/program/src/processor/process_set_realm_config.rs
+++ b/governance/program/src/processor/process_set_realm_config.rs
@@ -17,7 +17,7 @@ use crate::{
         realm::{assert_valid_realm_config_args, get_realm_data_for_authority, RealmConfigArgs},
         realm_config::{
             get_realm_config_address_seeds, get_realm_config_data_for_realm, GoverningTokenConfig,
-            RealmConfigAccount,
+            GoverningTokenType, RealmConfigAccount, Reserved110,
         },
     },
 };
@@ -110,10 +110,11 @@ pub fn process_set_realm_config(
                 community_token_config: GoverningTokenConfig {
                     voter_weight_addin: community_voter_weight_addin,
                     max_voter_weight_addin: max_community_voter_weight_addin,
+                    token_type: GoverningTokenType::Liquid,
+                    reserved: [0; 8],
                 },
-                council_voter_weight_addin: None,
-                council_max_vote_weight_addin: None,
-                reserved: [0; 128],
+                council_token_config: GoverningTokenConfig::default(),
+                reserved: Reserved110::default(),
             };
 
             let rent = Rent::get()?;

--- a/governance/program/src/processor/process_set_realm_config.rs
+++ b/governance/program/src/processor/process_set_realm_config.rs
@@ -80,14 +80,19 @@ pub fn process_set_realm_config(
 
     // Setup config for addins
 
-    let community_voter_weight_addin = if realm_config_args.use_community_voter_weight_addin {
+    let community_voter_weight_addin = if realm_config_args
+        .community_token_config_args
+        .use_voter_weight_addin
+    {
         let community_voter_weight_addin_info = next_account_info(account_info_iter)?; // 6
         Some(*community_voter_weight_addin_info.key)
     } else {
         None
     };
 
-    let max_community_voter_weight_addin = if realm_config_args.use_max_community_voter_weight_addin
+    let max_community_voter_weight_addin = if realm_config_args
+        .community_token_config_args
+        .use_max_voter_weight_addin
     {
         let max_community_voter_weight_addin_info = next_account_info(account_info_iter)?; // 7
         Some(*max_community_voter_weight_addin_info.key)
@@ -96,8 +101,12 @@ pub fn process_set_realm_config(
     };
 
     // If any of the addins is needed then update or create (if doesn't exist yet)  RealmConfigAccount
-    let update_realm_config = if realm_config_args.use_community_voter_weight_addin
-        || realm_config_args.use_max_community_voter_weight_addin
+    let update_realm_config = if realm_config_args
+        .community_token_config_args
+        .use_voter_weight_addin
+        || realm_config_args
+            .community_token_config_args
+            .use_max_voter_weight_addin
     {
         // We need the payer to pay for the new account if it's created
         let payer_info = next_account_info(account_info_iter)?; // 8
@@ -157,11 +166,13 @@ pub fn process_set_realm_config(
     realm_data.config.min_community_weight_to_create_governance =
         realm_config_args.min_community_weight_to_create_governance;
 
-    realm_data.config.use_community_voter_weight_addin =
-        realm_config_args.use_community_voter_weight_addin;
+    realm_data.config.use_community_voter_weight_addin = realm_config_args
+        .community_token_config_args
+        .use_voter_weight_addin;
 
-    realm_data.config.use_max_community_voter_weight_addin =
-        realm_config_args.use_max_community_voter_weight_addin;
+    realm_data.config.use_max_community_voter_weight_addin = realm_config_args
+        .community_token_config_args
+        .use_max_voter_weight_addin;
 
     realm_data.serialize(&mut *realm_info.data.borrow_mut())?;
 

--- a/governance/program/src/processor/process_set_realm_config.rs
+++ b/governance/program/src/processor/process_set_realm_config.rs
@@ -16,7 +16,8 @@ use crate::{
         enums::GovernanceAccountType,
         realm::{assert_valid_realm_config_args, get_realm_data_for_authority, RealmConfigArgs},
         realm_config::{
-            get_realm_config_address_seeds, get_realm_config_data_for_realm, RealmConfigAccount,
+            get_realm_config_address_seeds, get_realm_config_data_for_realm, GoverningTokenConfig,
+            RealmConfigAccount,
         },
     },
 };
@@ -106,8 +107,10 @@ pub fn process_set_realm_config(
             let realm_config_data = RealmConfigAccount {
                 account_type: GovernanceAccountType::RealmConfig,
                 realm: *realm_info.key,
-                community_voter_weight_addin,
-                max_community_voter_weight_addin,
+                community_token_config: GoverningTokenConfig {
+                    voter_weight_addin: community_voter_weight_addin,
+                    max_voter_weight_addin: max_community_voter_weight_addin,
+                },
                 council_voter_weight_addin: None,
                 council_max_vote_weight_addin: None,
                 reserved: [0; 128],
@@ -139,8 +142,10 @@ pub fn process_set_realm_config(
         let mut realm_config_data =
             get_realm_config_data_for_realm(program_id, realm_config_info, realm_info.key)?;
 
-        realm_config_data.community_voter_weight_addin = community_voter_weight_addin;
-        realm_config_data.max_community_voter_weight_addin = max_community_voter_weight_addin;
+        realm_config_data.community_token_config.voter_weight_addin = community_voter_weight_addin;
+        realm_config_data
+            .community_token_config
+            .max_voter_weight_addin = max_community_voter_weight_addin;
 
         realm_config_data.serialize(&mut *realm_config_info.data.borrow_mut())?;
     }

--- a/governance/program/src/processor/process_withdraw_governing_tokens.rs
+++ b/governance/program/src/processor/process_withdraw_governing_tokens.rs
@@ -10,6 +10,7 @@ use crate::{
     error::GovernanceError,
     state::{
         realm::{get_realm_address_seeds, get_realm_data},
+        realm_config::get_realm_config_data_for_realm,
         token_owner_record::{
             get_token_owner_record_address_seeds, get_token_owner_record_data_for_seeds,
         },
@@ -30,6 +31,7 @@ pub fn process_withdraw_governing_tokens(
     let governing_token_owner_info = next_account_info(account_info_iter)?; // 3
     let token_owner_record_info = next_account_info(account_info_iter)?; // 4
     let spl_token_info = next_account_info(account_info_iter)?; // 5
+    let realm_config_info = next_account_info(account_info_iter)?; // 6
 
     if !governing_token_owner_info.is_signer {
         return Err(GovernanceError::GoverningTokenOwnerMustSign.into());
@@ -44,6 +46,11 @@ pub fn process_withdraw_governing_tokens(
         &governing_token_mint,
         governing_token_holding_info.key,
     )?;
+
+    let realm_config_data =
+        get_realm_config_data_for_realm(program_id, realm_config_info, realm_info.key)?;
+
+    realm_config_data.assert_can_withdraw_governing_token(&realm_data, &governing_token_mint)?;
 
     let token_owner_record_address_seeds = get_token_owner_record_address_seeds(
         realm_info.key,

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -3,7 +3,7 @@
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 
 /// Defines all Governance accounts types
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum GovernanceAccountType {
     /// Default uninitialized account state
     Uninitialized,
@@ -96,7 +96,7 @@ impl Default for GovernanceAccountType {
 }
 
 /// What state a Proposal is in
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum ProposalState {
     /// Draft - Proposal enters Draft state when it's created
     Draft,
@@ -141,7 +141,7 @@ impl Default for ProposalState {
 /// The type of the vote threshold used to resolve a vote on a Proposal
 ///
 /// Note: In the current version only YesVotePercentage and Disabled thresholds are supported
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum VoteThreshold {
     /// Voting threshold of Yes votes in % required to tip the vote (Approval Quorum)
     /// It's the percentage of tokens out of the entire pool of governance tokens eligible to vote
@@ -173,7 +173,7 @@ pub enum VoteThreshold {
 /// The type of vote tipping to use on a Proposal.
 ///
 /// Vote tipping means that under some conditions voting will complete early.
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum VoteTipping {
     /// Tip when there is no way for another option to win and the vote threshold
     /// has been reached. This ignores voters withdrawing their votes.
@@ -192,7 +192,7 @@ pub enum VoteTipping {
 }
 
 /// The status of instruction execution
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum TransactionExecutionStatus {
     /// Transaction was not executed yet
     None,
@@ -205,7 +205,7 @@ pub enum TransactionExecutionStatus {
 }
 
 /// Transaction execution flags defining how instructions are executed for a Proposal
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum InstructionExecutionFlags {
     /// No execution flags are specified
     /// Instructions can be executed individually, in any order, as soon as they hold_up time expires
@@ -224,7 +224,7 @@ pub enum InstructionExecutionFlags {
 
 /// The source of max vote weight used for voting
 /// Values below 100% mint supply can be used when the governing token is fully minted but not distributed yet
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum MintMaxVoteWeightSource {
     /// Fraction (10^10 precision) of the governing mint supply is used as max vote weight
     /// The default is 100% (10^10) to use all available mint supply for voting

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -21,7 +21,7 @@ use spl_governance_tools::{
 };
 
 /// Governance config
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct GovernanceConfig {
     /// The type of the vote threshold used for community vote
     /// Note: In the current version only YesVotePercentage and Disabled thresholds are supported
@@ -56,7 +56,7 @@ pub struct GovernanceConfig {
 }
 
 /// Governance Account
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct GovernanceV2 {
     /// Account type. It can be Uninitialized, Governance, ProgramGovernance, TokenGovernance or MintGovernance
     pub account_type: GovernanceAccountType,

--- a/governance/program/src/state/legacy.rs
+++ b/governance/program/src/state/legacy.rs
@@ -18,7 +18,7 @@ use solana_program::{
 
 /// Governance Realm Account
 /// Account PDA seeds" ['governance', name]
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct RealmV1 {
     /// Governance account type
     pub account_type: GovernanceAccountType,
@@ -53,7 +53,7 @@ impl IsInitialized for RealmV1 {
 
 /// Governance Token Owner Record
 /// Account PDA seeds: ['governance', realm, token_mint, token_owner ]
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct TokenOwnerRecordV1 {
     /// Governance account type
     pub account_type: GovernanceAccountType,
@@ -101,7 +101,7 @@ impl IsInitialized for TokenOwnerRecordV1 {
 }
 
 /// Governance Account
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct GovernanceV1 {
     /// Account type. It can be Uninitialized, Governance, ProgramGovernance, TokenGovernance or MintGovernance
     pub account_type: GovernanceAccountType,
@@ -171,7 +171,7 @@ impl IsInitialized for GovernanceV1 {
 }
 
 /// Governance Proposal
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct ProposalV1 {
     /// Governance account type
     pub account_type: GovernanceAccountType,
@@ -260,7 +260,7 @@ impl IsInitialized for ProposalV1 {
 }
 
 /// Account PDA seeds: ['governance', proposal, signatory]
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct SignatoryRecordV1 {
     /// Governance account type
     pub account_type: GovernanceAccountType,
@@ -282,7 +282,7 @@ impl IsInitialized for SignatoryRecordV1 {
 }
 
 /// Proposal instruction V1
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct ProposalInstructionV1 {
     /// Governance Account type
     pub account_type: GovernanceAccountType,
@@ -315,7 +315,7 @@ impl IsInitialized for ProposalInstructionV1 {
 }
 
 /// Vote  with number of votes
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum VoteWeightV1 {
     /// Yes vote
     Yes(u64),
@@ -325,7 +325,7 @@ pub enum VoteWeightV1 {
 }
 
 /// Proposal VoteRecord
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct VoteRecordV1 {
     /// Governance account type
     pub account_type: GovernanceAccountType,

--- a/governance/program/src/state/native_treasury.rs
+++ b/governance/program/src/state/native_treasury.rs
@@ -6,7 +6,7 @@ use spl_governance_tools::account::AccountMaxSize;
 
 /// Treasury account
 /// The account has no data and can be used as a payer for instruction signed by Governance PDAs or as a native SOL treasury
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct NativeTreasury {}
 
 impl AccountMaxSize for NativeTreasury {

--- a/governance/program/src/state/program_metadata.rs
+++ b/governance/program/src/state/program_metadata.rs
@@ -10,7 +10,7 @@ use spl_governance_tools::account::{get_account_data, AccountMaxSize};
 use crate::state::enums::GovernanceAccountType;
 
 /// Program metadata account. It stores information about the particular SPL-Governance program instance
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct ProgramMetadata {
     /// Governance account type
     pub account_type: GovernanceAccountType,

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -40,7 +40,7 @@ use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use crate::state::realm_config::RealmConfigAccount;
 
 /// Proposal option vote result
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum OptionVoteResult {
     /// Vote on the option is not resolved yet
     None,
@@ -53,7 +53,7 @@ pub enum OptionVoteResult {
 }
 
 /// Proposal Option
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct ProposalOption {
     /// Option label
     pub label: String,
@@ -75,7 +75,7 @@ pub struct ProposalOption {
 }
 
 /// Proposal vote type
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum VoteType {
     /// Single choice vote with mutually exclusive choices
     /// In the SingeChoice mode there can ever be a single winner
@@ -104,7 +104,7 @@ pub enum VoteType {
 }
 
 /// Governance Proposal
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct ProposalV2 {
     /// Governance account type
     pub account_type: GovernanceAccountType,

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -30,13 +30,14 @@ use crate::{
         governance::GovernanceConfig,
         proposal_transaction::ProposalTransactionV2,
         realm::RealmV2,
-        realm_config::get_realm_config_data_for_realm,
         vote_record::Vote,
         vote_record::VoteKind,
     },
     PROGRAM_AUTHORITY_SEED,
 };
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+
+use crate::state::realm_config::RealmConfigAccount;
 
 /// Proposal option vote result
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
@@ -476,8 +477,7 @@ impl ProposalV2 {
     #[allow(clippy::too_many_arguments)]
     pub fn resolve_max_voter_weight(
         &mut self,
-        program_id: &Pubkey,
-        realm_config_info: &AccountInfo,
+        realm_config_data: &RealmConfigAccount,
         vote_governing_token_mint_info: &AccountInfo,
         account_info_iter: &mut Iter<AccountInfo>,
         realm: &Pubkey,
@@ -488,9 +488,6 @@ impl ProposalV2 {
         if realm_data.config.use_max_community_voter_weight_addin
             && realm_data.community_mint == *vote_governing_token_mint_info.key
         {
-            let realm_config_data =
-                get_realm_config_data_for_realm(program_id, realm_config_info, realm)?;
-
             let max_voter_weight_record_info = next_account_info(account_info_iter)?;
 
             let max_voter_weight_record_data =

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -485,7 +485,10 @@ impl ProposalV2 {
         vote_kind: &VoteKind,
     ) -> Result<u64, ProgramError> {
         // if the realm uses addin for max community voter weight then use the externally provided max weight
-        if realm_data.config.use_max_community_voter_weight_addin
+        if realm_config_data
+            .community_token_config
+            .max_voter_weight_addin
+            .is_some()
             && realm_data.community_mint == *vote_governing_token_mint_info.key
         {
             let max_voter_weight_record_info = next_account_info(account_info_iter)?;
@@ -1166,8 +1169,8 @@ mod test {
             config: RealmConfig {
                 council_mint: Some(Pubkey::new_unique()),
                 reserved: [0; 6],
-                use_community_voter_weight_addin: false,
-                use_max_community_voter_weight_addin: false,
+                legacy1: 0,
+                legacy2: 0,
 
                 community_mint_max_vote_weight_source:
                     MintMaxVoteWeightSource::FULL_SUPPLY_FRACTION,

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -495,7 +495,10 @@ impl ProposalV2 {
 
             let max_voter_weight_record_data =
                 get_max_voter_weight_record_data_for_realm_and_governing_token_mint(
-                    &realm_config_data.max_community_voter_weight_addin.unwrap(),
+                    &realm_config_data
+                        .community_token_config
+                        .max_voter_weight_addin
+                        .unwrap(),
                     max_voter_weight_record_info,
                     realm,
                     vote_governing_token_mint_info.key,

--- a/governance/program/src/state/proposal_transaction.rs
+++ b/governance/program/src/state/proposal_transaction.rs
@@ -25,7 +25,7 @@ use solana_program::{
 use spl_governance_tools::account::{get_account_data, AccountMaxSize};
 
 /// InstructionData wrapper. It can be removed once Borsh serialization for Instruction is supported in the SDK
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct InstructionData {
     /// Pubkey of the instruction processor that executes this instruction
     pub program_id: Pubkey,
@@ -36,7 +36,7 @@ pub struct InstructionData {
 }
 
 /// Account metadata used to define Instructions
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct AccountMetaData {
     /// An account's public key
     pub pubkey: Pubkey,
@@ -83,7 +83,7 @@ impl From<&InstructionData> for Instruction {
 }
 
 /// Account for an instruction to be executed for Proposal
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct ProposalTransactionV2 {
     /// Governance Account type
     pub account_type: GovernanceAccountType,

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -456,8 +456,10 @@ pub fn get_governing_token_holding_address(
 }
 
 /// Asserts given realm config args are correct
-pub fn assert_valid_realm_config_args(config_args: &RealmConfigArgs) -> Result<(), ProgramError> {
-    match config_args.community_mint_max_vote_weight_source {
+pub fn assert_valid_realm_config_args(
+    realm_config_args: &RealmConfigArgs,
+) -> Result<(), ProgramError> {
+    match realm_config_args.community_mint_max_vote_weight_source {
         MintMaxVoteWeightSource::SupplyFraction(fraction) => {
             if !(1..=MintMaxVoteWeightSource::SUPPLY_FRACTION_BASE).contains(&fraction) {
                 return Err(GovernanceError::InvalidMaxVoteWeightSupplyFraction.into());

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -63,6 +63,7 @@ pub struct GoverningTokenConfigArgs {
     pub token_type: GoverningTokenType,
 }
 
+#[allow(clippy::derivable_impls)]
 impl Default for GoverningTokenConfigArgs {
     fn default() -> Self {
         Self {
@@ -88,6 +89,7 @@ pub struct GoverningTokenConfigAccountArgs {
     pub token_type: GoverningTokenType,
 }
 
+#[allow(clippy::derivable_impls)]
 impl Default for GoverningTokenConfigAccountArgs {
     fn default() -> Self {
         Self {

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -120,9 +120,12 @@ pub enum SetRealmAuthorityAction {
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct RealmConfig {
     /// Indicates whether an external addin program should be used to provide voters weights for the community mint
+    /// TODO: Do we need this? Can we make RealmConfig mandatory?
+    /// Note: If removed be carefull abtou reusing the field, Force to update?
     pub use_community_voter_weight_addin: bool,
 
     /// Indicates whether an external addin program should be used to provide max voter weight for the community mint
+    /// TODO: Do we need this?
     pub use_max_community_voter_weight_addin: bool,
 
     /// Reserved space for future versions

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -63,6 +63,21 @@ pub struct GoverningTokenConfigArgs {
     pub token_type: GoverningTokenType,
 }
 
+/// Realm Config instruction args with account parametres
+#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+pub struct GoverningTokenConfigAccountArgs {
+    /// Specifies an external plugin program which should be used to provide voters weights
+    /// for the given goventing token
+    pub voter_weight_addin: Option<Pubkey>,
+
+    /// Specifies an external an external plugin program should be used to provide max voters weight
+    /// for the given goventing token
+    pub max_voter_weight_addin: Option<Pubkey>,
+
+    /// Governing token type defines how the token is used for governance power
+    pub token_type: GoverningTokenType,
+}
+
 impl Default for GoverningTokenConfigArgs {
     fn default() -> Self {
         Self {

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -121,14 +121,15 @@ pub enum SetRealmAuthorityAction {
 /// Realm Config defining Realm parameters.
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct RealmConfig {
-    /// Indicates whether an external addin program should be used to provide voters weights for the community mint
-    /// TODO: Do we need this? Can we make RealmConfig mandatory?
-    /// Note: If removed be carefull abtou reusing the field, Force to update?
-    pub use_community_voter_weight_addin: bool,
+    /// Legacy field introdcued and used in V2 as use_community_voter_weight_addin: bool
+    /// If the field is going to be reused in future version it must be taken under consideration
+    /// that for some Realms it might be already set to 1
+    pub legacy1: u8,
 
-    /// Indicates whether an external addin program should be used to provide max voter weight for the community mint
-    /// TODO: Do we need this?
-    pub use_max_community_voter_weight_addin: bool,
+    /// Legacy field introdcued and used in V2 as use_max_community_voter_weight_addin: bool
+    /// If the field is going to be reused in future version it must be taken under consideration
+    /// that for some Realms it might be already set to 1
+    pub legacy2: u8,
 
     /// Reserved space for future versions
     pub reserved: [u8; 6],
@@ -489,8 +490,8 @@ mod test {
             name: "test-realm".to_string(),
             config: RealmConfig {
                 council_mint: Some(Pubkey::new_unique()),
-                use_community_voter_weight_addin: false,
-                use_max_community_voter_weight_addin: false,
+                legacy1: 0,
+                legacy2: 0,
                 reserved: [0; 6],
                 community_mint_max_vote_weight_source: MintMaxVoteWeightSource::Absolute(100),
                 min_community_weight_to_create_governance: 10,

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -51,7 +51,7 @@ pub struct RealmConfigArgs {
 }
 
 /// Realm Config instruction args
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema, Default)]
 pub struct GoverningTokenConfigArgs {
     /// Indicates whether an external addin program should be used to provide voters weights
     /// If yes then the voters weight program account must be passed to the instruction
@@ -65,19 +65,8 @@ pub struct GoverningTokenConfigArgs {
     pub token_type: GoverningTokenType,
 }
 
-#[allow(clippy::derivable_impls)]
-impl Default for GoverningTokenConfigArgs {
-    fn default() -> Self {
-        Self {
-            use_voter_weight_addin: false,
-            use_max_voter_weight_addin: false,
-            token_type: GoverningTokenType::default(),
-        }
-    }
-}
-
 /// Realm Config instruction args with account parametres
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema, Default)]
 pub struct GoverningTokenConfigAccountArgs {
     /// Specifies an external plugin program which should be used to provide voters weights
     /// for the given goventing token
@@ -89,17 +78,6 @@ pub struct GoverningTokenConfigAccountArgs {
 
     /// Governing token type defines how the token is used for governance power
     pub token_type: GoverningTokenType,
-}
-
-#[allow(clippy::derivable_impls)]
-impl Default for GoverningTokenConfigAccountArgs {
-    fn default() -> Self {
-        Self {
-            voter_weight_addin: None,
-            max_voter_weight_addin: None,
-            token_type: GoverningTokenType::default(),
-        }
-    }
 }
 
 /// SetRealmAuthority instruction action

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -312,9 +312,9 @@ impl RealmV2 {
             get_realm_config_data_for_realm(program_id, realm_config_info, realm)?;
 
         let voter_weight = token_owner_record_data.resolve_voter_weight(
-            &realm_config_data,
             account_info_iter,
             self,
+            &realm_config_data,
             VoterWeightAction::CreateGovernance,
             realm,
         )?;

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -31,7 +31,7 @@ use crate::{
 use crate::state::realm_config::get_realm_config_data_for_realm;
 
 /// Realm Config instruction args
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct RealmConfigArgs {
     /// Indicates whether council_mint should be used
     /// If yes then council_mint account must also be passed to the instruction
@@ -51,7 +51,7 @@ pub struct RealmConfigArgs {
 }
 
 /// Realm Config instruction args
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema, Default)]
 pub struct GoverningTokenConfigArgs {
     /// Indicates whether an external addin program should be used to provide voters weights
     /// If yes then the voters weight program account must be passed to the instruction
@@ -66,7 +66,7 @@ pub struct GoverningTokenConfigArgs {
 }
 
 /// Realm Config instruction args with account parametres
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema, Default)]
 pub struct GoverningTokenConfigAccountArgs {
     /// Specifies an external plugin program which should be used to provide voters weights
     /// for the given goventing token
@@ -81,7 +81,7 @@ pub struct GoverningTokenConfigAccountArgs {
 }
 
 /// SetRealmAuthority instruction action
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum SetRealmAuthorityAction {
     /// Sets realm authority without any checks
     /// Uncheck option allows to set the realm authority to non governance accounts
@@ -97,7 +97,7 @@ pub enum SetRealmAuthorityAction {
 }
 
 /// Realm Config defining Realm parameters.
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct RealmConfig {
     /// Legacy field introdcued and used in V2 as use_community_voter_weight_addin: bool
     /// If the field is going to be reused in future version it must be taken under consideration
@@ -124,7 +124,7 @@ pub struct RealmConfig {
 
 /// Governance Realm Account
 /// Account PDA seeds" ['governance', name]
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct RealmV2 {
     /// Governance account type
     pub account_type: GovernanceAccountType,
@@ -487,7 +487,7 @@ mod test {
     }
 
     /// Realm Config instruction args
-    #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+    #[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
     pub struct RealmConfigArgsV1 {
         /// Indicates whether council_mint should be used
         /// If yes then council_mint account must also be passed to the instruction
@@ -501,7 +501,7 @@ mod test {
     }
 
     /// Instructions supported by the Governance program
-    #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+    #[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
     pub enum GovernanceInstructionV1 {
         /// Creates Governance Realm account which aggregates governances for given Community Mint and optional Council Mint
         CreateRealm {

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -5,11 +5,8 @@ use std::slice::Iter;
 
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    borsh::try_from_slice_unchecked,
-    program_error::ProgramError,
-    program_pack::IsInitialized,
-    pubkey::Pubkey,
+    account_info::AccountInfo, borsh::try_from_slice_unchecked, program_error::ProgramError,
+    program_pack::IsInitialized, pubkey::Pubkey,
 };
 use spl_governance_addin_api::voter_weight::VoterWeightAction;
 use spl_governance_tools::account::{
@@ -27,6 +24,8 @@ use crate::{
     },
     PROGRAM_AUTHORITY_SEED,
 };
+
+use crate::state::realm_config::next_realm_config_info_for_realm;
 
 /// Realm Config instruction args
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
@@ -304,7 +303,9 @@ impl RealmV2 {
 
         token_owner_record_data.assert_token_owner_or_delegate_is_signer(create_authority_info)?;
 
-        let realm_config_info = next_account_info(account_info_iter)?;
+        // Get realm_config_info from the account_info iterator and assert it has a valid PDA for the given Realm
+        let realm_config_info =
+            next_realm_config_info_for_realm(account_info_iter, program_id, realm)?;
 
         let voter_weight = token_owner_record_data.resolve_voter_weight(
             program_id,

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -63,6 +63,16 @@ pub struct GoverningTokenConfigArgs {
     pub token_type: GoverningTokenType,
 }
 
+impl Default for GoverningTokenConfigArgs {
+    fn default() -> Self {
+        Self {
+            use_voter_weight_addin: false,
+            use_max_voter_weight_addin: false,
+            token_type: GoverningTokenType::default(),
+        }
+    }
+}
+
 /// Realm Config instruction args with account parametres
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct GoverningTokenConfigAccountArgs {
@@ -78,12 +88,12 @@ pub struct GoverningTokenConfigAccountArgs {
     pub token_type: GoverningTokenType,
 }
 
-impl Default for GoverningTokenConfigArgs {
+impl Default for GoverningTokenConfigAccountArgs {
     fn default() -> Self {
         Self {
-            use_voter_weight_addin: false,
-            use_max_voter_weight_addin: false,
-            token_type: GoverningTokenType::Liquid,
+            voter_weight_addin: None,
+            max_voter_weight_addin: None,
+            token_type: GoverningTokenType::default(),
         }
     }
 }

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -21,6 +21,7 @@ use crate::{
     state::{
         enums::{GovernanceAccountType, MintMaxVoteWeightSource},
         legacy::RealmV1,
+        realm_config::GoverningTokenType,
         token_owner_record::get_token_owner_record_data_for_realm,
         vote_record::VoteKind,
     },
@@ -40,13 +41,36 @@ pub struct RealmConfigArgs {
     /// The source used for community mint max vote weight source
     pub community_mint_max_vote_weight_source: MintMaxVoteWeightSource,
 
-    /// Indicates whether an external addin program should be used to provide community voters weights
-    /// If yes then the voters weight program account must be passed to the instruction
-    pub use_community_voter_weight_addin: bool,
+    /// Community token config args
+    pub community_token_config_args: GoverningTokenConfigArgs,
 
-    /// Indicates whether an external addin program should be used to provide max voters weight for the community mint
+    /// Council token config args
+    pub council_token_config_args: GoverningTokenConfigArgs,
+}
+
+/// Realm Config instruction args
+#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+pub struct GoverningTokenConfigArgs {
+    /// Indicates whether an external addin program should be used to provide voters weights
+    /// If yes then the voters weight program account must be passed to the instruction
+    pub use_voter_weight_addin: bool,
+
+    /// Indicates whether an external addin program should be used to provide max voters weight for the token
     /// If yes then the max voter weight program account must be passed to the instruction
-    pub use_max_community_voter_weight_addin: bool,
+    pub use_max_voter_weight_addin: bool,
+
+    /// Governing token type defines how the token is used for governance
+    pub token_type: GoverningTokenType,
+}
+
+impl Default for GoverningTokenConfigArgs {
+    fn default() -> Self {
+        Self {
+            use_voter_weight_addin: false,
+            use_max_voter_weight_addin: false,
+            token_type: GoverningTokenType::Liquid,
+        }
+    }
 }
 
 /// SetRealmAuthority instruction action
@@ -495,8 +519,8 @@ mod test {
                 min_community_weight_to_create_governance: 100,
                 community_mint_max_vote_weight_source:
                     MintMaxVoteWeightSource::FULL_SUPPLY_FRACTION,
-                use_community_voter_weight_addin: false,
-                use_max_community_voter_weight_addin: false,
+                community_token_config_args: GoverningTokenConfigArgs::default(),
+                council_token_config_args: GoverningTokenConfigArgs::default(),
             },
         };
 

--- a/governance/program/src/state/realm_config.rs
+++ b/governance/program/src/state/realm_config.rs
@@ -148,6 +148,24 @@ impl RealmConfigAccount {
 
         Ok(token_config)
     }
+
+    /// Assertes the given governing token can be revoked
+    pub fn assert_can_revoke_governing_token(
+        &self,
+        realm_data: &RealmV2,
+        governing_token_mint: &Pubkey,
+    ) -> Result<(), ProgramError> {
+        let governing_token_type = &self
+            .get_token_config(realm_data, governing_token_mint)?
+            .token_type;
+
+        match governing_token_type {
+            GoverningTokenType::Membership => Ok(()),
+            GoverningTokenType::Liquid | GoverningTokenType::Dormant => {
+                Err(GovernanceError::CannotRevokeGoverningToken.into())
+            }
+        }
+    }
 }
 
 /// Deserializes RealmConfig account and checks owner program

--- a/governance/program/src/state/realm_config.rs
+++ b/governance/program/src/state/realm_config.rs
@@ -161,7 +161,7 @@ impl RealmConfigAccount {
         match governing_token_type {
             GoverningTokenType::Membership => Ok(()),
             GoverningTokenType::Liquid | GoverningTokenType::Dormant => {
-                Err(GovernanceError::CannotRevokeGoverningToken.into())
+                Err(GovernanceError::CannotRevokeGoverningTokens.into())
             }
         }
     }
@@ -178,7 +178,9 @@ impl RealmConfigAccount {
 
         match governing_token_type {
             GoverningTokenType::Membership | GoverningTokenType::Liquid => Ok(()),
-            GoverningTokenType::Dormant => Err(GovernanceError::CannotDepositGoverningToken.into()),
+            GoverningTokenType::Dormant => {
+                Err(GovernanceError::CannotDepositGoverningTokens.into())
+            }
         }
     }
 
@@ -195,7 +197,7 @@ impl RealmConfigAccount {
         match governing_token_type {
             GoverningTokenType::Dormant | GoverningTokenType::Liquid => Ok(()),
             GoverningTokenType::Membership => {
-                Err(GovernanceError::CannotWithdrawGoverningToken.into())
+                Err(GovernanceError::CannotWithdrawGoverningTokens.into())
             }
         }
     }

--- a/governance/program/src/state/realm_config.rs
+++ b/governance/program/src/state/realm_config.rs
@@ -35,6 +35,12 @@ pub enum GoverningTokenType {
     Dormant,
 }
 
+impl Default for GoverningTokenType {
+    fn default() -> Self {
+        GoverningTokenType::Liquid
+    }
+}
+
 /// GoverningTokenConfig specifies configuration for Realm governing token (Community or Council)
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct GoverningTokenConfig {
@@ -56,7 +62,7 @@ impl Default for GoverningTokenConfig {
         Self {
             voter_weight_addin: None,
             max_voter_weight_addin: None,
-            token_type: GoverningTokenType::Liquid,
+            token_type: GoverningTokenType::default(),
             reserved: [0; 8],
         }
     }

--- a/governance/program/src/state/realm_config.rs
+++ b/governance/program/src/state/realm_config.rs
@@ -166,6 +166,40 @@ impl RealmConfigAccount {
             }
         }
     }
+
+    /// Assertes the given governing token can be deposited
+    pub fn assert_can_deposit_governing_token(
+        &self,
+        realm_data: &RealmV2,
+        governing_token_mint: &Pubkey,
+    ) -> Result<(), ProgramError> {
+        let governing_token_type = &self
+            .get_token_config(realm_data, governing_token_mint)?
+            .token_type;
+
+        match governing_token_type {
+            GoverningTokenType::Membership | GoverningTokenType::Liquid => Ok(()),
+            GoverningTokenType::Dormant => Err(GovernanceError::CannotDepositGoverningToken.into()),
+        }
+    }
+
+    /// Assertes the given governing token can be withdrawn
+    pub fn assert_can_withdraw_governing_token(
+        &self,
+        realm_data: &RealmV2,
+        governing_token_mint: &Pubkey,
+    ) -> Result<(), ProgramError> {
+        let governing_token_type = &self
+            .get_token_config(realm_data, governing_token_mint)?
+            .token_type;
+
+        match governing_token_type {
+            GoverningTokenType::Dormant | GoverningTokenType::Liquid => Ok(()),
+            GoverningTokenType::Membership => {
+                Err(GovernanceError::CannotWithdrawGoverningToken.into())
+            }
+        }
+    }
 }
 
 /// Deserializes RealmConfig account and checks owner program

--- a/governance/program/src/state/realm_config.rs
+++ b/governance/program/src/state/realm_config.rs
@@ -275,7 +275,7 @@ pub fn get_realm_config_address(program_id: &Pubkey, realm: &Pubkey) -> Pubkey {
 /// Resolves GoverningTokenConfig from GoverningTokenConfigArgs and instruction accounts
 pub fn resolve_governing_token_config(
     account_info_iter: &mut Iter<AccountInfo>,
-    governing_token_config_args: GoverningTokenConfigArgs,
+    governing_token_config_args: &GoverningTokenConfigArgs,
 ) -> Result<GoverningTokenConfig, ProgramError> {
     let voter_weight_addin = if governing_token_config_args.use_voter_weight_addin {
         let voter_weight_addin_info = next_account_info(account_info_iter)?;
@@ -294,7 +294,7 @@ pub fn resolve_governing_token_config(
     Ok(GoverningTokenConfig {
         voter_weight_addin,
         max_voter_weight_addin,
-        token_type: governing_token_config_args.token_type,
+        token_type: governing_token_config_args.token_type.clone(),
         reserved: [0; 8],
     })
 }

--- a/governance/program/src/state/realm_config.rs
+++ b/governance/program/src/state/realm_config.rs
@@ -112,7 +112,6 @@ pub struct RealmConfigAccount {
     pub community_token_config: GoverningTokenConfig,
 
     /// Council token config
-    /// Note: This field is not implemented in the current version
     pub council_token_config: GoverningTokenConfig,
 
     /// Reserved

--- a/governance/program/src/state/realm_config.rs
+++ b/governance/program/src/state/realm_config.rs
@@ -188,6 +188,25 @@ pub fn resolve_governing_token_config(
     })
 }
 
+/// Returns next RealmConfigInfo from the AccountInfo iterator and validates its PDA matches the given Realm
+// PDA validation is required because RealmConfigAccount might not exist for legacy Realms
+// and then its absense is used as default RealmConfigAccount value with no plugins and Liqquid governance tokens
+pub fn next_realm_config_info_for_realm<'a, 'b, I: Iterator<Item = &'a AccountInfo<'b>>>(
+    account_info_iter: &mut I,
+    program_id: &Pubkey,
+    realm: &Pubkey,
+) -> Result<I::Item, ProgramError> {
+    let realm_config_info = next_account_info(account_info_iter)?;
+
+    let realm_config_address = get_realm_config_address(program_id, realm);
+
+    if realm_config_address != *realm_config_info.key {
+        return Err(GovernanceError::InvalidRealmConfigAddress.into());
+    }
+
+    Ok(realm_config_info)
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/governance/program/src/state/realm_config.rs
+++ b/governance/program/src/state/realm_config.rs
@@ -57,7 +57,7 @@ impl Default for GoverningTokenType {
 }
 
 /// GoverningTokenConfig specifies configuration for Realm governing token (Community or Council)
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema, Default)]
 pub struct GoverningTokenConfig {
     /// Plugin providing voter weights for the governing token
     pub voter_weight_addin: Option<Pubkey>,
@@ -70,18 +70,6 @@ pub struct GoverningTokenConfig {
 
     /// Reserved space for future versions
     pub reserved: [u8; 8],
-}
-
-#[allow(clippy::derivable_impls)]
-impl Default for GoverningTokenConfig {
-    fn default() -> Self {
-        Self {
-            voter_weight_addin: None,
-            max_voter_weight_addin: None,
-            token_type: GoverningTokenType::default(),
-            reserved: [0; 8],
-        }
-    }
 }
 
 /// Reserved 110 bytes

--- a/governance/program/src/state/realm_config.rs
+++ b/governance/program/src/state/realm_config.rs
@@ -28,7 +28,7 @@ pub enum GoverningTokenType {
     Membership,
 
     /// Dormant token is a token which is only a placeholder and its deposits are not accepted and not used for governance power within the Realm
-    /// Note: When an external voter weight plugin is used then the token type should be set to Dormant
+    /// Note: When an external voter weight plugin which takes deposits of the token is used then the type should be set to Dormant
     /// Deposit - no, dormant tokens can't be deposited into the Realm
     /// Withdraw - yes, tokens can still be withdrawn from Realm to support scenario where the config is changed while some tokens are still deposited
     /// Revoke - no, Realm authority cannot revoke dormant tokens

--- a/governance/program/src/state/realm_config.rs
+++ b/governance/program/src/state/realm_config.rs
@@ -23,15 +23,16 @@ use crate::state::realm::{RealmConfigArgs, RealmV2};
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum GoverningTokenType {
     /// Liquid token is a token which is fully liquid and the token owner retains full authority over it
-    /// Deposit - yes
-    /// Withdraw - yes  
-    /// Revoke - no, Realm authority cannot revoke liquid tokens
+    /// Deposit - Yes
+    /// Withdraw - Yes  
+    /// Revoke - No, Realm authority cannot revoke liquid tokens
     Liquid,
 
     /// Membership token is a token controlled by Realm authority
-    /// Deposit - yes, membership tokens can be deposited to gain governance power
-    /// Withdraw - no, after membership tokens are deposited they are no longer transferable and can't be withdrawn
-    /// Revoke - yes, Realm authority can Revoke (burn) membership tokens
+    /// Deposit - Yes, membership tokens can be deposited to gain governance power
+    ///           The membership tokens are conventionally minted into the holding account to keep them out of members possesion  
+    /// Withdraw - No, after membership tokens are deposited they are no longer transferable and can't be withdrawn
+    /// Revoke - Yes, Realm authority can Revoke (burn) membership tokens
     Membership,
 
     /// Dormant token is a token which is only a placeholder and its deposits are not accepted and not used for governance power within the Realm
@@ -43,9 +44,9 @@ pub enum GoverningTokenType {
     /// Note: When an external voter weight plugin which takes deposits of the token is used then the type should be set to Dormant
     /// to make the intention explicit
     ///
-    /// Deposit - no, dormant tokens can't be deposited into the Realm
-    /// Withdraw - yes, tokens can still be withdrawn from Realm to support scenario where the config is changed while some tokens are still deposited
-    /// Revoke - no, Realm authority cannot revoke dormant tokens
+    /// Deposit - No, dormant tokens can't be deposited into the Realm
+    /// Withdraw - Yes, tokens can still be withdrawn from Realm to support scenario where the config is changed while some tokens are still deposited
+    /// Revoke - No, Realm authority cannot revoke dormant tokens
     Dormant,
 }
 

--- a/governance/program/src/state/realm_config.rs
+++ b/governance/program/src/state/realm_config.rs
@@ -156,7 +156,7 @@ pub fn get_realm_config_data_for_realm(
 
         RealmConfigAccount {
             account_type: GovernanceAccountType::RealmConfig,
-            realm: realm.clone(),
+            realm: *realm,
             community_token_config: GoverningTokenConfig::default(),
             council_token_config: GoverningTokenConfig::default(),
             reserved: Reserved110::default(),

--- a/governance/program/src/state/realm_config.rs
+++ b/governance/program/src/state/realm_config.rs
@@ -35,7 +35,14 @@ pub enum GoverningTokenType {
     Membership,
 
     /// Dormant token is a token which is only a placeholder and its deposits are not accepted and not used for governance power within the Realm
+    ///
+    /// The Dormant token type is used when only a single voting population is operational. For example a Multisig starter DAO uses Council only
+    /// and sets Community as Dormant to indicate its not utilised for any governance power.
+    /// Once the starter DAO decides to decentralise then it can change the Community token to Liquid
+    ///
     /// Note: When an external voter weight plugin which takes deposits of the token is used then the type should be set to Dormant
+    /// to make the intention explicit
+    ///
     /// Deposit - no, dormant tokens can't be deposited into the Realm
     /// Withdraw - yes, tokens can still be withdrawn from Realm to support scenario where the config is changed while some tokens are still deposited
     /// Revoke - no, Realm authority cannot revoke dormant tokens
@@ -178,6 +185,8 @@ impl RealmConfigAccount {
 
         match governing_token_type {
             GoverningTokenType::Membership | GoverningTokenType::Liquid => Ok(()),
+            // Note: Preventing deposits of the Dormant type tokens is not a direct security concern
+            // It only makes the intention of not using deposited tokens as governnace power stronger
             GoverningTokenType::Dormant => Err(GovernanceError::CannotDepositDormantTokens.into()),
         }
     }

--- a/governance/program/src/state/realm_config.rs
+++ b/governance/program/src/state/realm_config.rs
@@ -20,7 +20,7 @@ use crate::state::realm::{RealmConfigArgs, RealmV2};
 /// The type of the governing token defines:
 /// 1) Who retains the authority over deposited tokens
 /// 2) Which token instructions Deposit, Withdraw and Revoke (burn) are allowed
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum GoverningTokenType {
     /// Liquid token is a token which is fully liquid and the token owner retains full authority over it
     /// Deposit - Yes
@@ -58,7 +58,7 @@ impl Default for GoverningTokenType {
 }
 
 /// GoverningTokenConfig specifies configuration for Realm governing token (Community or Council)
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema, Default)]
 pub struct GoverningTokenConfig {
     /// Plugin providing voter weights for the governing token
     pub voter_weight_addin: Option<Pubkey>,
@@ -74,7 +74,7 @@ pub struct GoverningTokenConfig {
 }
 
 /// Reserved 110 bytes
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct Reserved110 {
     /// Reserved 64 bytes
     pub reserved64: [u8; 64],
@@ -96,7 +96,7 @@ impl Default for Reserved110 {
 
 /// RealmConfig account
 /// The account is an optional extension to RealmConfig stored on Realm account
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct RealmConfigAccount {
     /// Governance account type
     pub account_type: GovernanceAccountType,

--- a/governance/program/src/state/realm_config.rs
+++ b/governance/program/src/state/realm_config.rs
@@ -27,7 +27,7 @@ pub enum GoverningTokenType {
     /// Revoke - yes, Realm authority can Revoke (burn) membership tokens
     Membership,
 
-    /// Dormant token is a token which is only a placeholder and its deposits are not accepted and not used for governance power
+    /// Dormant token is a token which is only a placeholder and its deposits are not accepted and not used for governance power within the Realm
     /// Note: When an external voter weight plugin is used then the token type should be set to Dormant
     /// Deposit - no, dormant tokens can't be deposited into the Realm
     /// Withdraw - yes, tokens can still be withdrawn from Realm to support scenario where the config is changed while some tokens are still deposited

--- a/governance/program/src/state/realm_config.rs
+++ b/governance/program/src/state/realm_config.rs
@@ -35,6 +35,7 @@ pub enum GoverningTokenType {
     Dormant,
 }
 
+#[allow(clippy::derivable_impls)]
 impl Default for GoverningTokenType {
     fn default() -> Self {
         GoverningTokenType::Liquid

--- a/governance/program/src/state/realm_config.rs
+++ b/governance/program/src/state/realm_config.rs
@@ -58,6 +58,7 @@ pub struct GoverningTokenConfig {
     pub reserved: [u8; 8],
 }
 
+#[allow(clippy::derivable_impls)]
 impl Default for GoverningTokenConfig {
     fn default() -> Self {
         Self {

--- a/governance/program/src/state/realm_config.rs
+++ b/governance/program/src/state/realm_config.rs
@@ -178,9 +178,7 @@ impl RealmConfigAccount {
 
         match governing_token_type {
             GoverningTokenType::Membership | GoverningTokenType::Liquid => Ok(()),
-            GoverningTokenType::Dormant => {
-                Err(GovernanceError::CannotDepositGoverningTokens.into())
-            }
+            GoverningTokenType::Dormant => Err(GovernanceError::CannotDepositDormantTokens.into()),
         }
     }
 
@@ -197,7 +195,7 @@ impl RealmConfigAccount {
         match governing_token_type {
             GoverningTokenType::Dormant | GoverningTokenType::Liquid => Ok(()),
             GoverningTokenType::Membership => {
-                Err(GovernanceError::CannotWithdrawGoverningTokens.into())
+                Err(GovernanceError::CannotWithdrawMembershipTokens.into())
             }
         }
     }

--- a/governance/program/src/state/realm_config.rs
+++ b/governance/program/src/state/realm_config.rs
@@ -11,7 +11,7 @@ use spl_governance_tools::account::{get_account_data, AccountMaxSize};
 use crate::{error::GovernanceError, state::enums::GovernanceAccountType};
 
 /// The type of the governing token defines:
-/// 1) Who retains authority over deposited tokens
+/// 1) Who retains the authority over deposited tokens
 /// 2) Which token instructions Deposit, Withdraw and Revoke (burn) are allowed
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum GoverningTokenType {
@@ -27,11 +27,12 @@ pub enum GoverningTokenType {
     /// Revoke - yes, Realm authority can Revoke (burn) membership tokens
     Membership,
 
-    /// Proxy token is token which is not deposited into Realm and is controlled externally (via plugins)
-    /// Deposit - no, proxy tokens can't be deposited into the Realm
+    /// Dormant token is a token which is only a placeholder and its deposits are not accepted and not used for governance power
+    /// Note: When an external voter weight plugin is used then the token type should be set to Dormant
+    /// Deposit - no, dormant tokens can't be deposited into the Realm
     /// Withdraw - yes, tokens can still be withdrawn from Realm to support scenario where the config is changed while some tokens are still deposited
-    /// Revoke - no, Realm authority cannot revoke proxy tokens
-    Proxy,
+    /// Revoke - no, Realm authority cannot revoke dormant tokens
+    Dormant,
 }
 
 /// GoverningTokenConfig specifies configuration for Realm governing token (Community or Council)

--- a/governance/program/src/state/realm_config.rs
+++ b/governance/program/src/state/realm_config.rs
@@ -10,6 +10,16 @@ use spl_governance_tools::account::{get_account_data, AccountMaxSize};
 
 use crate::{error::GovernanceError, state::enums::GovernanceAccountType};
 
+/// GoverningTokenConfig specifies configuration for Realm governing token (Community or Council)
+#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+pub struct GoverningTokenConfig {
+    /// Plugin providing voter weights for the governing token
+    pub voter_weight_addin: Option<Pubkey>,
+
+    /// Plugin providing max voter weight for the governing token
+    pub max_voter_weight_addin: Option<Pubkey>,
+}
+
 /// RealmConfig account
 /// The account is an optional extension to RealmConfig stored on Realm account
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
@@ -20,12 +30,8 @@ pub struct RealmConfigAccount {
     /// The realm the config belong to
     pub realm: Pubkey,
 
-    /// Addin providing voter weights for community token
-    pub community_voter_weight_addin: Option<Pubkey>,
-
-    /// Addin providing max vote weight for community token
-    /// Note: This field is not implemented in the current version
-    pub max_community_voter_weight_addin: Option<Pubkey>,
+    /// Community token config
+    pub community_token_config: GoverningTokenConfig,
 
     /// Addin providing voter weights for council token
     /// Note: This field is not implemented in the current version
@@ -94,8 +100,10 @@ mod test {
         let realm_config = RealmConfigAccount {
             account_type: GovernanceAccountType::RealmV2,
             realm: Pubkey::new_unique(),
-            community_voter_weight_addin: Some(Pubkey::new_unique()),
-            max_community_voter_weight_addin: Some(Pubkey::new_unique()),
+            community_token_config: GoverningTokenConfig {
+                voter_weight_addin: Some(Pubkey::new_unique()),
+                max_voter_weight_addin: Some(Pubkey::new_unique()),
+            },
             council_voter_weight_addin: Some(Pubkey::new_unique()),
             council_max_vote_weight_addin: Some(Pubkey::new_unique()),
             reserved: [0; 128],

--- a/governance/program/src/state/realm_config.rs
+++ b/governance/program/src/state/realm_config.rs
@@ -29,7 +29,7 @@ pub enum GoverningTokenType {
 
     /// Proxy token is token which is not deposited into Realm and is controlled externally (via plugins)
     /// Deposit - no, proxy tokens can't be deposited into the Realm
-    /// Withdraw - yes, tokens can still be withdrawn from Realm to support scenario where the config change is executed while some tokens are still deposited
+    /// Withdraw - yes, tokens can still be withdrawn from Realm to support scenario where the config is changed while some tokens are still deposited
     /// Revoke - no, Realm authority cannot revoke proxy tokens
     Proxy,
 }

--- a/governance/program/src/state/signatory_record.rs
+++ b/governance/program/src/state/signatory_record.rs
@@ -15,7 +15,7 @@ use crate::{error::GovernanceError, PROGRAM_AUTHORITY_SEED};
 use crate::state::{enums::GovernanceAccountType, legacy::SignatoryRecordV1};
 
 /// Account PDA seeds: ['governance', proposal, signatory]
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct SignatoryRecordV2 {
     /// Governance account type
     pub account_type: GovernanceAccountType,

--- a/governance/program/src/state/token_owner_record.rs
+++ b/governance/program/src/state/token_owner_record.rs
@@ -10,7 +10,7 @@ use crate::{
     error::GovernanceError,
     state::{
         enums::GovernanceAccountType, governance::GovernanceConfig, legacy::TokenOwnerRecordV1,
-        realm::RealmV2, realm_config::get_realm_config_data_for_realm,
+        realm::RealmV2,
     },
     PROGRAM_AUTHORITY_SEED,
 };
@@ -25,6 +25,8 @@ use solana_program::{
 };
 use spl_governance_addin_api::voter_weight::VoterWeightAction;
 use spl_governance_tools::account::{get_account_data, AccountMaxSize};
+
+use super::realm_config::RealmConfigAccount;
 
 /// Governance Token Owner Record
 /// Account PDA seeds: ['governance', realm, token_mint, token_owner ]
@@ -189,10 +191,8 @@ impl TokenOwnerRecordV2 {
     #[allow(clippy::too_many_arguments)]
     pub fn resolve_voter_weight(
         &self,
-        program_id: &Pubkey,
-        realm_config_info: &AccountInfo,
+        realm_config_data: &RealmConfigAccount,
         account_info_iter: &mut Iter<AccountInfo>,
-        realm: &Pubkey,
         realm_data: &RealmV2,
         weight_action: VoterWeightAction,
         weight_action_target: &Pubkey,
@@ -202,9 +202,6 @@ impl TokenOwnerRecordV2 {
             && realm_data.community_mint == self.governing_token_mint
         {
             let voter_weight_record_info = next_account_info(account_info_iter)?;
-
-            let realm_config_data =
-                get_realm_config_data_for_realm(program_id, realm_config_info, realm)?;
 
             let voter_weight_record_data = get_voter_weight_record_data_for_token_owner_record(
                 &realm_config_data

--- a/governance/program/src/state/token_owner_record.rs
+++ b/governance/program/src/state/token_owner_record.rs
@@ -26,7 +26,7 @@ use solana_program::{
 use spl_governance_addin_api::voter_weight::VoterWeightAction;
 use spl_governance_tools::account::{get_account_data, AccountMaxSize};
 
-use super::realm_config::RealmConfigAccount;
+use crate::state::realm_config::RealmConfigAccount;
 
 /// Governance Token Owner Record
 /// Account PDA seeds: ['governance', realm, token_mint, token_owner ]

--- a/governance/program/src/state/token_owner_record.rs
+++ b/governance/program/src/state/token_owner_record.rs
@@ -198,7 +198,10 @@ impl TokenOwnerRecordV2 {
         weight_action_target: &Pubkey,
     ) -> Result<u64, ProgramError> {
         // if the realm uses addin for community voter weight then use the externally provided weight
-        if realm_data.config.use_community_voter_weight_addin
+        if realm_config_data
+            .community_token_config
+            .voter_weight_addin
+            .is_some()
             && realm_data.community_mint == self.governing_token_mint
         {
             let voter_weight_record_info = next_account_info(account_info_iter)?;

--- a/governance/program/src/state/token_owner_record.rs
+++ b/governance/program/src/state/token_owner_record.rs
@@ -30,7 +30,7 @@ use crate::state::realm_config::RealmConfigAccount;
 
 /// Governance Token Owner Record
 /// Account PDA seeds: ['governance', realm, token_mint, token_owner ]
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct TokenOwnerRecordV2 {
     /// Governance account type
     pub account_type: GovernanceAccountType,

--- a/governance/program/src/state/token_owner_record.rs
+++ b/governance/program/src/state/token_owner_record.rs
@@ -191,26 +191,20 @@ impl TokenOwnerRecordV2 {
     #[allow(clippy::too_many_arguments)]
     pub fn resolve_voter_weight(
         &self,
-        realm_config_data: &RealmConfigAccount,
         account_info_iter: &mut Iter<AccountInfo>,
         realm_data: &RealmV2,
+        realm_config_data: &RealmConfigAccount,
         weight_action: VoterWeightAction,
         weight_action_target: &Pubkey,
     ) -> Result<u64, ProgramError> {
-        // if the realm uses addin for community voter weight then use the externally provided weight
-        if realm_config_data
-            .community_token_config
+        if let Some(voter_weight_addin) = realm_config_data
+            .get_token_config(realm_data, &self.governing_token_mint)?
             .voter_weight_addin
-            .is_some()
-            && realm_data.community_mint == self.governing_token_mint
         {
             let voter_weight_record_info = next_account_info(account_info_iter)?;
 
             let voter_weight_record_data = get_voter_weight_record_data_for_token_owner_record(
-                &realm_config_data
-                    .community_token_config
-                    .voter_weight_addin
-                    .unwrap(),
+                &voter_weight_addin,
                 voter_weight_record_info,
                 self,
             )?;

--- a/governance/program/src/state/token_owner_record.rs
+++ b/governance/program/src/state/token_owner_record.rs
@@ -197,6 +197,8 @@ impl TokenOwnerRecordV2 {
         weight_action: VoterWeightAction,
         weight_action_target: &Pubkey,
     ) -> Result<u64, ProgramError> {
+        // if the Realm is configured to use voter weight plugin for our governing_token_mint then use the externally provided voter_weight
+        // instead of governing_token_deposit_amount
         if let Some(voter_weight_addin) = realm_config_data
             .get_token_config(realm_data, &self.governing_token_mint)?
             .voter_weight_addin

--- a/governance/program/src/state/token_owner_record.rs
+++ b/governance/program/src/state/token_owner_record.rs
@@ -207,7 +207,10 @@ impl TokenOwnerRecordV2 {
                 get_realm_config_data_for_realm(program_id, realm_config_info, realm)?;
 
             let voter_weight_record_data = get_voter_weight_record_data_for_token_owner_record(
-                &realm_config_data.community_voter_weight_addin.unwrap(),
+                &realm_config_data
+                    .community_token_config
+                    .voter_weight_addin
+                    .unwrap(),
                 voter_weight_record_info,
                 self,
             )?;

--- a/governance/program/src/state/vote_record.rs
+++ b/governance/program/src/state/vote_record.rs
@@ -28,7 +28,7 @@ use crate::state::{
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct VoteChoice {
     /// The rank given to the choice by voter
-    /// Note: The filed is not used in the current version
+    /// Note: The field is not used in the current version
     pub rank: u8,
 
     /// The voter's weight percentage given by the voter to the choice

--- a/governance/program/src/state/vote_record.rs
+++ b/governance/program/src/state/vote_record.rs
@@ -25,7 +25,7 @@ use crate::state::{
 /// Voter choice for a proposal option
 /// In the current version only 1) Single choice and 2) Multiple choices proposals are supported
 /// In the future versions we can add support for 1) Quadratic voting, 2) Ranked choice voting and 3) Weighted voting
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct VoteChoice {
     /// The rank given to the choice by voter
     /// Note: The field is not used in the current version
@@ -47,7 +47,7 @@ impl VoteChoice {
 }
 
 /// User's vote
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum Vote {
     /// Vote approving choices
     Approve(Vec<VoteChoice>),
@@ -64,7 +64,7 @@ pub enum Vote {
 }
 
 /// VoteKind defines the type of the vote being cast
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum VoteKind {
     /// Electorate vote is cast by the voting population identified by governing_token_mint
     /// Approve, Deny and Abstain votes are Electorate votes
@@ -83,7 +83,7 @@ pub fn get_vote_kind(vote: &Vote) -> VoteKind {
 }
 
 /// Proposal VoteRecord
-#[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct VoteRecordV2 {
     /// Governance account type
     pub account_type: GovernanceAccountType,

--- a/governance/program/src/tools/spl_token.rs
+++ b/governance/program/src/tools/spl_token.rs
@@ -277,27 +277,7 @@ pub fn assert_is_valid_spl_token_account(account_info: &AccountInfo) -> Result<(
 
 /// Checks if the given account_info  is spl-token token account
 pub fn is_spl_token_account(account_info: &AccountInfo) -> bool {
-    if account_info.data_is_empty() {
-        return false;
-    }
-
-    if account_info.owner != &spl_token::id() {
-        return false;
-    }
-
-    if account_info.data_len() != Account::LEN {
-        return false;
-    }
-
-    // TokeAccount layout:   mint(32), owner(32), amount(8), delegate(36), state(1), ...
-    let data = account_info.try_borrow_data().unwrap();
-    let state = array_ref![data, 108, 1];
-
-    if state == &[0] {
-        return false;
-    }
-
-    true
+    assert_is_valid_spl_token_account(account_info).is_ok()
 }
 
 /// Asserts the given mint_info represents a valid SPL Token Mint account  which is initialized and belongs to spl_token program
@@ -327,27 +307,7 @@ pub fn assert_is_valid_spl_token_mint(mint_info: &AccountInfo) -> Result<(), Pro
 
 /// Checks if the given account_info is be spl-token mint account
 pub fn is_spl_token_mint(mint_info: &AccountInfo) -> bool {
-    if mint_info.data_is_empty() {
-        return false;
-    }
-
-    if mint_info.owner != &spl_token::id() {
-        return false;
-    }
-
-    if mint_info.data_len() != Mint::LEN {
-        return false;
-    }
-
-    // In token program [36, 8, 1, is_initialized(1), 36] is the layout
-    let data = mint_info.try_borrow_data().unwrap();
-    let is_initialized = array_ref![data, 45, 1];
-
-    if is_initialized == &[0] {
-        return false;
-    }
-
-    true
+    assert_is_valid_spl_token_mint(mint_info).is_ok()
 }
 
 /// Computationally cheap method to get mint from a token account

--- a/governance/program/tests/process_create_realm.rs
+++ b/governance/program/tests/process_create_realm.rs
@@ -5,13 +5,9 @@ use solana_program_test::*;
 mod program_test;
 
 use program_test::*;
-use spl_governance::state::{
-    enums::MintMaxVoteWeightSource,
-    realm::{get_realm_address, GoverningTokenConfigArgs, RealmConfigArgs},
-    realm_config::GoverningTokenConfig,
-};
+use spl_governance::state::{enums::MintMaxVoteWeightSource, realm::get_realm_address};
 
-use self::args::SetRealmConfigArgs;
+use crate::program_test::args::RealmSetupArgs;
 
 #[tokio::test]
 async fn test_create_realm() {
@@ -34,18 +30,11 @@ async fn test_create_realm_with_non_default_config() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
-    let realm_config_args = RealmConfigArgs {
+    let set_realm_config_args = RealmSetupArgs {
         use_council_mint: false,
         community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(1),
-        min_community_weight_to_create_governance: 10,
-        community_token_config_args: GoverningTokenConfigArgs::default(),
-        council_token_config_args: GoverningTokenConfigArgs::default(),
-    };
-
-    let set_realm_config_args = SetRealmConfigArgs {
-        realm_config_args,
-        community_token_config: GoverningTokenConfig::default(),
-        council_token_config: GoverningTokenConfig::default(),
+        min_community_weight_to_create_governance: 1,
+        ..Default::default()
     };
 
     // Act

--- a/governance/program/tests/process_create_realm.rs
+++ b/governance/program/tests/process_create_realm.rs
@@ -30,7 +30,7 @@ async fn test_create_realm_with_non_default_config() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
-    let set_realm_config_args = RealmSetupArgs {
+    let realm_setup_args = RealmSetupArgs {
         use_council_mint: false,
         community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(1),
         min_community_weight_to_create_governance: 1,
@@ -39,7 +39,7 @@ async fn test_create_realm_with_non_default_config() {
 
     // Act
     let realm_cookie = governance_test
-        .with_realm_using_config_args(&set_realm_config_args)
+        .with_realm_using_args(&realm_setup_args)
         .await;
 
     // Assert

--- a/governance/program/tests/process_create_realm.rs
+++ b/governance/program/tests/process_create_realm.rs
@@ -8,6 +8,7 @@ use program_test::*;
 use spl_governance::state::{
     enums::MintMaxVoteWeightSource,
     realm::{get_realm_address, GoverningTokenConfigArgs, RealmConfigArgs},
+    realm_config::GoverningTokenConfig,
 };
 
 use self::args::SetRealmConfigArgs;
@@ -43,8 +44,8 @@ async fn test_create_realm_with_non_default_config() {
 
     let set_realm_config_args = SetRealmConfigArgs {
         realm_config_args,
-        community_voter_weight_addin: None,
-        max_community_voter_weight_addin: None,
+        community_token_config: GoverningTokenConfig::default(),
+        council_token_config: GoverningTokenConfig::default(),
     };
 
     // Act

--- a/governance/program/tests/process_create_realm.rs
+++ b/governance/program/tests/process_create_realm.rs
@@ -7,7 +7,7 @@ mod program_test;
 use program_test::*;
 use spl_governance::state::{
     enums::MintMaxVoteWeightSource,
-    realm::{get_realm_address, RealmConfigArgs},
+    realm::{get_realm_address, GoverningTokenConfigArgs, RealmConfigArgs},
 };
 
 use self::args::SetRealmConfigArgs;
@@ -37,8 +37,8 @@ async fn test_create_realm_with_non_default_config() {
         use_council_mint: false,
         community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(1),
         min_community_weight_to_create_governance: 10,
-        use_community_voter_weight_addin: false,
-        use_max_community_voter_weight_addin: false,
+        community_token_config_args: GoverningTokenConfigArgs::default(),
+        council_token_config_args: GoverningTokenConfigArgs::default(),
     };
 
     let set_realm_config_args = SetRealmConfigArgs {

--- a/governance/program/tests/process_deposit_governing_tokens.rs
+++ b/governance/program/tests/process_deposit_governing_tokens.rs
@@ -296,46 +296,34 @@ async fn test_deposit_community_tokens_with_malicious_holding_account_error() {
 async fn test_deposit_community_tokens_using_mint() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
-    let _realm_cookie = governance_test.with_realm().await;
+    let realm_cookie = governance_test.with_realm().await;
 
     // Act
-    // let _token_owner_record_cookie = governance_test
-    //     .with_initial_governing_token_mint_deposit(
-    //         &realm_cookie.address,
-    //         &realm_cookie.account.community_mint,
-    //         &realm_cookie.community_mint_authority,
-    //         10,
-    //         None,
-    //     )
-    //     .await
-    //     .unwrap();
+    let token_owner_record_cookie = governance_test
+        .with_initial_governing_token_deposit_using_mint(
+            &realm_cookie.address,
+            &realm_cookie.account.community_mint,
+            &realm_cookie.community_mint_authority,
+            10,
+            None,
+        )
+        .await
+        .unwrap();
 
     // Assert
 
-    // let token_owner_record = governance_test
-    //     .get_token_owner_record_account(&token_owner_record_cookie.address)
-    //     .await;
+    let token_owner_record = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
 
-    // assert_eq!(token_owner_record_cookie.account, token_owner_record);
+    assert_eq!(token_owner_record_cookie.account, token_owner_record);
 
-    // let source_account = governance_test
-    //     .get_token_account(&token_owner_record_cookie.token_source)
-    //     .await;
+    let holding_account = governance_test
+        .get_token_account(&realm_cookie.community_token_holding_account)
+        .await;
 
-    // assert_eq!(
-    //     token_owner_record_cookie.token_source_amount
-    //         - token_owner_record_cookie
-    //             .account
-    //             .governing_token_deposit_amount,
-    //     source_account.amount
-    // );
-
-    // let holding_account = governance_test
-    //     .get_token_account(&realm_cookie.community_token_holding_account)
-    //     .await;
-
-    // assert_eq!(
-    //     token_owner_record.governing_token_deposit_amount,
-    //     holding_account.amount
-    // );
+    assert_eq!(
+        token_owner_record.governing_token_deposit_amount,
+        holding_account.amount
+    );
 }

--- a/governance/program/tests/process_deposit_governing_tokens.rs
+++ b/governance/program/tests/process_deposit_governing_tokens.rs
@@ -340,3 +340,51 @@ async fn test_deposit_community_tokens_with_malicious_holding_account_error() {
         GovernanceError::InvalidGoverningTokenHoldingAccount.into()
     );
 }
+
+#[tokio::test]
+async fn test_deposit_community_tokens_using_mint() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+    let _realm_cookie = governance_test.with_realm().await;
+
+    // Act
+    // let _token_owner_record_cookie = governance_test
+    //     .with_initial_governing_token_mint_deposit(
+    //         &realm_cookie.address,
+    //         &realm_cookie.account.community_mint,
+    //         &realm_cookie.community_mint_authority,
+    //         10,
+    //         None,
+    //     )
+    //     .await
+    //     .unwrap();
+
+    // Assert
+
+    // let token_owner_record = governance_test
+    //     .get_token_owner_record_account(&token_owner_record_cookie.address)
+    //     .await;
+
+    // assert_eq!(token_owner_record_cookie.account, token_owner_record);
+
+    // let source_account = governance_test
+    //     .get_token_account(&token_owner_record_cookie.token_source)
+    //     .await;
+
+    // assert_eq!(
+    //     token_owner_record_cookie.token_source_amount
+    //         - token_owner_record_cookie
+    //             .account
+    //             .governing_token_deposit_amount,
+    //     source_account.amount
+    // );
+
+    // let holding_account = governance_test
+    //     .get_token_account(&realm_cookie.community_token_holding_account)
+    //     .await;
+
+    // assert_eq!(
+    //     token_owner_record.governing_token_deposit_amount,
+    //     holding_account.amount
+    // );
+}

--- a/governance/program/tests/process_deposit_governing_tokens.rs
+++ b/governance/program/tests/process_deposit_governing_tokens.rs
@@ -235,55 +235,6 @@ async fn test_deposit_initial_community_tokens_with_owner_must_sign_error() {
     // Assert
     assert_eq!(error, GovernanceError::GoverningTokenOwnerMustSign.into());
 }
-#[tokio::test]
-async fn test_deposit_initial_community_tokens_with_invalid_owner_error() {
-    // Arrange
-    let mut governance_test = GovernanceProgramTest::start_new().await;
-    let realm_cookie = governance_test.with_realm().await;
-
-    let token_owner = Keypair::new();
-    let transfer_authority = Keypair::new();
-    let token_source = Keypair::new();
-
-    let invalid_owner = Keypair::new();
-
-    let amount = 10;
-
-    governance_test
-        .bench
-        .create_token_account_with_transfer_authority(
-            &token_source,
-            &realm_cookie.account.community_mint,
-            &realm_cookie.community_mint_authority,
-            amount,
-            &token_owner,
-            &transfer_authority.pubkey(),
-        )
-        .await;
-
-    let deposit_ix = deposit_governing_tokens(
-        &governance_test.program_id,
-        &realm_cookie.address,
-        &token_source.pubkey(),
-        &invalid_owner.pubkey(),
-        &transfer_authority.pubkey(),
-        &governance_test.bench.context.payer.pubkey(),
-        amount,
-        &realm_cookie.account.community_mint,
-    );
-
-    // // Act
-
-    let error = governance_test
-        .bench
-        .process_transaction(&[deposit_ix], Some(&[&transfer_authority, &invalid_owner]))
-        .await
-        .err()
-        .unwrap();
-
-    // Assert
-    assert_eq!(error, GovernanceError::GoverningTokenOwnerMustSign.into());
-}
 
 #[tokio::test]
 async fn test_deposit_community_tokens_with_malicious_holding_account_error() {

--- a/governance/program/tests/process_revoke_governing_tokens.rs
+++ b/governance/program/tests/process_revoke_governing_tokens.rs
@@ -5,7 +5,7 @@ use solana_program_test::*;
 mod program_test;
 
 use program_test::*;
-use spl_governance::state::realm_config::GoverningTokenType;
+use spl_governance::{error::GovernanceError, state::realm_config::GoverningTokenType};
 
 use crate::program_test::args::RealmSetupArgs;
 
@@ -45,4 +45,98 @@ async fn test_revoke_community_tokens() {
         .await;
 
     assert_eq!(holding_account.amount, 0);
+}
+
+#[tokio::test]
+async fn test_revoke_council_tokens() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let mut realm_config_args = RealmSetupArgs::default();
+    realm_config_args.council_token_config_args.token_type = GoverningTokenType::Membership;
+
+    let realm_cookie = governance_test
+        .with_realm_using_args(&realm_config_args)
+        .await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .revoke_council_tokens(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let token_owner_record = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(token_owner_record.governing_token_deposit_amount, 0);
+
+    let holding_account = governance_test
+        .get_token_account(&realm_cookie.council_token_holding_account.unwrap())
+        .await;
+
+    assert_eq!(holding_account.amount, 0);
+}
+
+#[tokio::test]
+async fn test_revoke_community_tokens_with_cannot_revoke_liquid_token_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .revoke_community_tokens(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, GovernanceError::CannotRevokeGoverningTokens.into());
+}
+
+#[tokio::test]
+async fn test_revoke_community_tokens_with_cannot_revoke_dormant_token_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut realm_config_args = RealmSetupArgs::default();
+    realm_config_args.community_token_config_args.token_type = GoverningTokenType::Dormant;
+
+    governance_test
+        .set_realm_config(&mut realm_cookie, &realm_config_args)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .revoke_community_tokens(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, GovernanceError::CannotRevokeGoverningTokens.into());
 }

--- a/governance/program/tests/process_revoke_governing_tokens.rs
+++ b/governance/program/tests/process_revoke_governing_tokens.rs
@@ -18,7 +18,7 @@ async fn test_revoke_community_tokens() {
     realm_config_args.community_token_config_args.token_type = GoverningTokenType::Membership;
 
     let realm_cookie = governance_test
-        .with_realm_using_config_args(&realm_config_args)
+        .with_realm_using_args(&realm_config_args)
         .await;
 
     let token_owner_record_cookie = governance_test

--- a/governance/program/tests/process_revoke_governing_tokens.rs
+++ b/governance/program/tests/process_revoke_governing_tokens.rs
@@ -7,16 +7,15 @@ mod program_test;
 use program_test::*;
 use spl_governance::state::realm_config::GoverningTokenType;
 
+use crate::program_test::args::RealmSetupArgs;
+
 #[tokio::test]
 async fn test_revoke_community_tokens() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
-    let mut realm_config_args = governance_test.get_default_set_realm_config_args();
-    realm_config_args
-        .realm_config_args
-        .community_token_config_args
-        .token_type = GoverningTokenType::Membership;
+    let mut realm_config_args = RealmSetupArgs::default();
+    realm_config_args.community_token_config_args.token_type = GoverningTokenType::Membership;
 
     let realm_cookie = governance_test
         .with_realm_using_config_args(&realm_config_args)

--- a/governance/program/tests/process_revoke_governing_tokens.rs
+++ b/governance/program/tests/process_revoke_governing_tokens.rs
@@ -1,0 +1,49 @@
+#![cfg(feature = "test-bpf")]
+
+use solana_program_test::*;
+
+mod program_test;
+
+use program_test::*;
+use spl_governance::state::realm_config::GoverningTokenType;
+
+#[tokio::test]
+async fn test_revoke_community_tokens() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let mut realm_config_args = governance_test.get_default_set_realm_config_args();
+    realm_config_args
+        .realm_config_args
+        .community_token_config_args
+        .token_type = GoverningTokenType::Membership;
+
+    let realm_cookie = governance_test
+        .with_realm_using_config_args(&realm_config_args)
+        .await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .revoke_community_tokens(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let token_owner_record = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(token_owner_record.governing_token_deposit_amount, 0);
+
+    let holding_account = governance_test
+        .get_token_account(&realm_cookie.community_token_holding_account)
+        .await;
+
+    assert_eq!(holding_account.amount, 0);
+}

--- a/governance/program/tests/process_set_realm_config.rs
+++ b/governance/program/tests/process_set_realm_config.rs
@@ -8,11 +8,7 @@ mod program_test;
 use program_test::*;
 use spl_governance::{
     error::GovernanceError,
-    state::{
-        enums::MintMaxVoteWeightSource,
-        realm::{GoverningTokenConfigArgs, RealmConfigArgs},
-        realm_config::GoverningTokenType,
-    },
+    state::{realm::GoverningTokenConfigArgs, realm_config::GoverningTokenType},
 };
 
 use self::args::SetRealmConfigArgs;
@@ -24,20 +20,7 @@ async fn test_set_realm_config() {
 
     let mut realm_cookie = governance_test.with_realm().await;
 
-    let realm_config_args = RealmConfigArgs {
-        use_council_mint: true,
-
-        community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(100),
-        min_community_weight_to_create_governance: 10,
-        community_token_config_args: GoverningTokenConfigArgs::default(),
-        council_token_config_args: GoverningTokenConfigArgs::default(),
-    };
-
-    let set_realm_config_args = SetRealmConfigArgs {
-        realm_config_args,
-        community_voter_weight_addin: None,
-        max_community_voter_weight_addin: None,
-    };
+    let set_realm_config_args = SetRealmConfigArgs::default();
 
     // Act
 
@@ -61,20 +44,7 @@ async fn test_set_realm_config_with_authority_must_sign_error() {
 
     let mut realm_cookie = governance_test.with_realm().await;
 
-    let realm_config_args = RealmConfigArgs {
-        use_council_mint: true,
-
-        community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(100),
-        min_community_weight_to_create_governance: 10,
-        community_token_config_args: GoverningTokenConfigArgs::default(),
-        council_token_config_args: GoverningTokenConfigArgs::default(),
-    };
-
-    let set_realm_config_args = SetRealmConfigArgs {
-        realm_config_args,
-        community_voter_weight_addin: None,
-        max_community_voter_weight_addin: None,
-    };
+    let set_realm_config_args = SetRealmConfigArgs::default();
 
     // Act
 
@@ -100,20 +70,7 @@ async fn test_set_realm_config_with_no_authority_error() {
 
     let mut realm_cookie = governance_test.with_realm().await;
 
-    let realm_config_args = RealmConfigArgs {
-        use_council_mint: true,
-
-        community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(100),
-        min_community_weight_to_create_governance: 10,
-        community_token_config_args: GoverningTokenConfigArgs::default(),
-        council_token_config_args: GoverningTokenConfigArgs::default(),
-    };
-
-    let set_realm_config_args = SetRealmConfigArgs {
-        realm_config_args,
-        community_voter_weight_addin: None,
-        max_community_voter_weight_addin: None,
-    };
+    let set_realm_config_args = SetRealmConfigArgs::default();
 
     governance_test
         .set_realm_authority(&realm_cookie, None)
@@ -144,20 +101,7 @@ async fn test_set_realm_config_with_invalid_authority_error() {
 
     let mut realm_cookie = governance_test.with_realm().await;
 
-    let realm_config_args = RealmConfigArgs {
-        use_council_mint: true,
-
-        community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(100),
-        min_community_weight_to_create_governance: 10,
-        community_token_config_args: GoverningTokenConfigArgs::default(),
-        council_token_config_args: GoverningTokenConfigArgs::default(),
-    };
-
-    let set_realm_config_args = SetRealmConfigArgs {
-        realm_config_args,
-        community_voter_weight_addin: None,
-        max_community_voter_weight_addin: None,
-    };
+    let set_realm_config_args = SetRealmConfigArgs::default();
 
     let realm_cookie2 = governance_test.with_realm().await;
 
@@ -183,20 +127,8 @@ async fn test_set_realm_config_with_remove_council() {
 
     let mut realm_cookie = governance_test.with_realm().await;
 
-    let realm_config_args = RealmConfigArgs {
-        use_council_mint: false,
-
-        community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(100),
-        min_community_weight_to_create_governance: 10,
-        community_token_config_args: GoverningTokenConfigArgs::default(),
-        council_token_config_args: GoverningTokenConfigArgs::default(),
-    };
-
-    let set_realm_config_args = SetRealmConfigArgs {
-        realm_config_args,
-        community_voter_weight_addin: None,
-        max_community_voter_weight_addin: None,
-    };
+    let mut set_realm_config_args = SetRealmConfigArgs::default();
+    set_realm_config_args.realm_config_args.use_council_mint = false;
 
     // Act
     governance_test
@@ -220,20 +152,7 @@ async fn test_set_realm_config_with_council_change_error() {
 
     let mut realm_cookie = governance_test.with_realm().await;
 
-    let realm_config_args = RealmConfigArgs {
-        use_council_mint: true,
-
-        community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(100),
-        min_community_weight_to_create_governance: 10,
-        community_token_config_args: GoverningTokenConfigArgs::default(),
-        council_token_config_args: GoverningTokenConfigArgs::default(),
-    };
-
-    let set_realm_config_args = SetRealmConfigArgs {
-        realm_config_args,
-        community_voter_weight_addin: None,
-        max_community_voter_weight_addin: None,
-    };
+    let set_realm_config_args = SetRealmConfigArgs::default();
 
     // Try to replace council mint
     realm_cookie.account.config.council_mint = serde::__private::Some(Pubkey::new_unique());
@@ -259,20 +178,8 @@ async fn test_set_realm_config_with_council_restore_error() {
 
     let mut realm_cookie = governance_test.with_realm().await;
 
-    let realm_config_args = RealmConfigArgs {
-        use_council_mint: false,
-
-        community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(100),
-        min_community_weight_to_create_governance: 10,
-        community_token_config_args: GoverningTokenConfigArgs::default(),
-        council_token_config_args: GoverningTokenConfigArgs::default(),
-    };
-
-    let mut set_realm_config_args = SetRealmConfigArgs {
-        realm_config_args,
-        community_voter_weight_addin: None,
-        max_community_voter_weight_addin: None,
-    };
+    let mut set_realm_config_args = SetRealmConfigArgs::default();
+    set_realm_config_args.realm_config_args.use_council_mint = false;
 
     governance_test
         .set_realm_config(&mut realm_cookie, &set_realm_config_args)
@@ -345,8 +252,12 @@ async fn test_set_realm_config_for_community_token() {
         token_type: GoverningTokenType::Dormant,
     };
 
-    set_realm_config_args.community_voter_weight_addin = Some(Pubkey::new_unique());
-    set_realm_config_args.max_community_voter_weight_addin = Some(Pubkey::new_unique());
+    set_realm_config_args
+        .community_token_config
+        .voter_weight_addin = Some(Pubkey::new_unique());
+    set_realm_config_args
+        .community_token_config
+        .max_voter_weight_addin = Some(Pubkey::new_unique());
 
     // Act
 
@@ -370,13 +281,75 @@ async fn test_set_realm_config_for_community_token() {
         realm_config_account
             .community_token_config
             .voter_weight_addin,
-        set_realm_config_args.community_voter_weight_addin
+        set_realm_config_args
+            .community_token_config
+            .voter_weight_addin
     );
 
     assert_eq!(
         realm_config_account
             .community_token_config
             .max_voter_weight_addin,
-        set_realm_config_args.max_community_voter_weight_addin
+        set_realm_config_args
+            .community_token_config
+            .max_voter_weight_addin
     );
+}
+
+#[tokio::test]
+async fn test_set_realm_config_for_council_token() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    let mut set_realm_config_args = SetRealmConfigArgs::default();
+
+    // Change Council token type to Membership and set plugins
+    set_realm_config_args
+        .realm_config_args
+        .council_token_config_args = GoverningTokenConfigArgs {
+        use_voter_weight_addin: true,
+        use_max_voter_weight_addin: true,
+        token_type: GoverningTokenType::Membership,
+    };
+
+    set_realm_config_args
+        .council_token_config
+        .voter_weight_addin = Some(Pubkey::new_unique());
+    set_realm_config_args
+        .council_token_config
+        .max_voter_weight_addin = Some(Pubkey::new_unique());
+
+    // Act
+
+    governance_test
+        .set_realm_config(&mut realm_cookie, &set_realm_config_args)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let _realm_config_account = governance_test
+        .get_realm_config_account(&realm_cookie.realm_config.address)
+        .await;
+
+    // assert_eq!(
+    //     realm_config_account.council_token_config.token_type,
+    //     GoverningTokenType::Membership
+    // );
+
+    // assert_eq!(
+    //     realm_config_account
+    //         .community_token_config
+    //         .voter_weight_addin,
+    //     set_realm_config_args.community_voter_weight_addin
+    // );
+
+    // assert_eq!(
+    //     realm_config_account
+    //         .community_token_config
+    //         .max_voter_weight_addin,
+    //     set_realm_config_args.max_community_voter_weight_addin
+    // );
 }

--- a/governance/program/tests/process_set_realm_config.rs
+++ b/governance/program/tests/process_set_realm_config.rs
@@ -20,12 +20,12 @@ async fn test_set_realm_config() {
 
     let mut realm_cookie = governance_test.with_realm().await;
 
-    let set_realm_config_args = RealmSetupArgs::default();
+    let realm_setup_args = RealmSetupArgs::default();
 
     // Act
 
     governance_test
-        .set_realm_config(&mut realm_cookie, &set_realm_config_args)
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
         .await
         .unwrap();
 
@@ -44,14 +44,14 @@ async fn test_set_realm_config_with_authority_must_sign_error() {
 
     let mut realm_cookie = governance_test.with_realm().await;
 
-    let set_realm_config_args = RealmSetupArgs::default();
+    let realm_setup_args = RealmSetupArgs::default();
 
     // Act
 
     let err = governance_test
         .set_realm_config_using_instruction(
             &mut realm_cookie,
-            &set_realm_config_args,
+            &realm_setup_args,
             |i| i.accounts[1].is_signer = false,
             Some(&[]),
         )
@@ -70,7 +70,7 @@ async fn test_set_realm_config_with_no_authority_error() {
 
     let mut realm_cookie = governance_test.with_realm().await;
 
-    let set_realm_config_args = RealmSetupArgs::default();
+    let realm_setup_args = RealmSetupArgs::default();
 
     governance_test
         .set_realm_authority(&realm_cookie, None)
@@ -82,7 +82,7 @@ async fn test_set_realm_config_with_no_authority_error() {
     let err = governance_test
         .set_realm_config_using_instruction(
             &mut realm_cookie,
-            &set_realm_config_args,
+            &realm_setup_args,
             |i| i.accounts[1].is_signer = false,
             Some(&[]),
         )
@@ -101,7 +101,7 @@ async fn test_set_realm_config_with_invalid_authority_error() {
 
     let mut realm_cookie = governance_test.with_realm().await;
 
-    let set_realm_config_args = RealmSetupArgs::default();
+    let realm_setup_args = RealmSetupArgs::default();
 
     let realm_cookie2 = governance_test.with_realm().await;
 
@@ -111,7 +111,7 @@ async fn test_set_realm_config_with_invalid_authority_error() {
     // Act
 
     let err = governance_test
-        .set_realm_config(&mut realm_cookie, &set_realm_config_args)
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
         .await
         .err()
         .unwrap();
@@ -127,12 +127,12 @@ async fn test_set_realm_config_with_remove_council() {
 
     let mut realm_cookie = governance_test.with_realm().await;
 
-    let mut set_realm_config_args = RealmSetupArgs::default();
-    set_realm_config_args.use_council_mint = false;
+    let mut realm_setup_args = RealmSetupArgs::default();
+    realm_setup_args.use_council_mint = false;
 
     // Act
     governance_test
-        .set_realm_config(&mut realm_cookie, &set_realm_config_args)
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
         .await
         .unwrap();
 
@@ -152,14 +152,14 @@ async fn test_set_realm_config_with_council_change_error() {
 
     let mut realm_cookie = governance_test.with_realm().await;
 
-    let set_realm_config_args = RealmSetupArgs::default();
+    let realm_setup_args = RealmSetupArgs::default();
 
     // Try to replace council mint
     realm_cookie.account.config.council_mint = serde::__private::Some(Pubkey::new_unique());
 
     // Act
     let err = governance_test
-        .set_realm_config(&mut realm_cookie, &set_realm_config_args)
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
         .await
         .err()
         .unwrap();
@@ -178,21 +178,21 @@ async fn test_set_realm_config_with_council_restore_error() {
 
     let mut realm_cookie = governance_test.with_realm().await;
 
-    let mut set_realm_config_args = RealmSetupArgs::default();
-    set_realm_config_args.use_council_mint = false;
+    let mut realm_setup_args = RealmSetupArgs::default();
+    realm_setup_args.use_council_mint = false;
 
     governance_test
-        .set_realm_config(&mut realm_cookie, &set_realm_config_args)
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
         .await
         .unwrap();
 
     // Try to restore council mint after removing it
-    set_realm_config_args.use_council_mint = true;
+    realm_setup_args.use_council_mint = true;
     realm_cookie.account.config.council_mint = serde::__private::Some(Pubkey::new_unique());
 
     // Act
     let err = governance_test
-        .set_realm_config(&mut realm_cookie, &set_realm_config_args)
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
         .await
         .err()
         .unwrap();
@@ -212,14 +212,14 @@ async fn test_set_realm_config_with_liquid_community_token_cannot_be_changed_to_
 
     let mut realm_cookie = governance_test.with_realm().await;
 
-    let mut set_realm_config_args = RealmSetupArgs::default();
+    let mut realm_setup_args = RealmSetupArgs::default();
 
     // Try to change Community token type to Membership
-    set_realm_config_args.community_token_config_args.token_type = GoverningTokenType::Membership;
+    realm_setup_args.community_token_config_args.token_type = GoverningTokenType::Membership;
 
     // Act
     let err = governance_test
-        .set_realm_config(&mut realm_cookie, &set_realm_config_args)
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
         .await
         .err()
         .unwrap();
@@ -238,10 +238,10 @@ async fn test_set_realm_config_for_community_token_config() {
 
     let mut realm_cookie = governance_test.with_realm().await;
 
-    let mut set_realm_config_args = RealmSetupArgs::default();
+    let mut realm_setup_args = RealmSetupArgs::default();
 
     // Change Community token type to Dormant and set plugins
-    set_realm_config_args.community_token_config_args = GoverningTokenConfigAccountArgs {
+    realm_setup_args.community_token_config_args = GoverningTokenConfigAccountArgs {
         voter_weight_addin: Some(Pubkey::new_unique()),
         max_voter_weight_addin: Some(Pubkey::new_unique()),
         token_type: GoverningTokenType::Dormant,
@@ -250,7 +250,7 @@ async fn test_set_realm_config_for_community_token_config() {
     // Act
 
     governance_test
-        .set_realm_config(&mut realm_cookie, &set_realm_config_args)
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
         .await
         .unwrap();
 
@@ -269,7 +269,7 @@ async fn test_set_realm_config_for_community_token_config() {
         realm_config_account
             .community_token_config
             .voter_weight_addin,
-        set_realm_config_args
+        realm_setup_args
             .community_token_config_args
             .voter_weight_addin
     );
@@ -278,7 +278,7 @@ async fn test_set_realm_config_for_community_token_config() {
         realm_config_account
             .community_token_config
             .max_voter_weight_addin,
-        set_realm_config_args
+        realm_setup_args
             .community_token_config_args
             .max_voter_weight_addin
     );
@@ -291,10 +291,10 @@ async fn test_set_realm_config_for_council_token_config() {
 
     let mut realm_cookie = governance_test.with_realm().await;
 
-    let mut set_realm_config_args = RealmSetupArgs::default();
+    let mut realm_setup_args = RealmSetupArgs::default();
 
     // Change Council token type to Membership and set plugins
-    set_realm_config_args.council_token_config_args = GoverningTokenConfigAccountArgs {
+    realm_setup_args.council_token_config_args = GoverningTokenConfigAccountArgs {
         voter_weight_addin: Some(Pubkey::new_unique()),
         max_voter_weight_addin: Some(Pubkey::new_unique()),
         token_type: GoverningTokenType::Membership,
@@ -303,7 +303,7 @@ async fn test_set_realm_config_for_council_token_config() {
     // Act
 
     governance_test
-        .set_realm_config(&mut realm_cookie, &set_realm_config_args)
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
         .await
         .unwrap();
 
@@ -322,13 +322,13 @@ async fn test_set_realm_config_for_council_token_config() {
     //     realm_config_account
     //         .community_token_config
     //         .voter_weight_addin,
-    //     set_realm_config_args.community_voter_weight_addin
+    //     realm_setup_args.community_voter_weight_addin
     // );
 
     // assert_eq!(
     //     realm_config_account
     //         .community_token_config
     //         .max_voter_weight_addin,
-    //     set_realm_config_args.max_community_voter_weight_addin
+    //     realm_setup_args.max_community_voter_weight_addin
     // );
 }

--- a/governance/program/tests/process_set_realm_config.rs
+++ b/governance/program/tests/process_set_realm_config.rs
@@ -309,26 +309,28 @@ async fn test_set_realm_config_for_council_token_config() {
 
     // Assert
 
-    let _realm_config_account = governance_test
+    let realm_config_account = governance_test
         .get_realm_config_account(&realm_cookie.realm_config.address)
         .await;
 
-    // assert_eq!(
-    //     realm_config_account.council_token_config.token_type,
-    //     GoverningTokenType::Membership
-    // );
+    assert_eq!(
+        realm_config_account.council_token_config.token_type,
+        GoverningTokenType::Membership
+    );
 
-    // assert_eq!(
-    //     realm_config_account
-    //         .community_token_config
-    //         .voter_weight_addin,
-    //     realm_setup_args.community_voter_weight_addin
-    // );
+    assert_eq!(
+        realm_config_account.council_token_config.voter_weight_addin,
+        realm_setup_args
+            .council_token_config_args
+            .voter_weight_addin
+    );
 
-    // assert_eq!(
-    //     realm_config_account
-    //         .community_token_config
-    //         .max_voter_weight_addin,
-    //     realm_setup_args.max_community_voter_weight_addin
-    // );
+    assert_eq!(
+        realm_config_account
+            .council_token_config
+            .max_voter_weight_addin,
+        realm_setup_args
+            .council_token_config_args
+            .max_voter_weight_addin
+    );
 }

--- a/governance/program/tests/process_set_realm_config.rs
+++ b/governance/program/tests/process_set_realm_config.rs
@@ -11,6 +11,7 @@ use spl_governance::{
     state::{
         enums::MintMaxVoteWeightSource,
         realm::{GoverningTokenConfigArgs, RealmConfigArgs},
+        realm_config::GoverningTokenType,
     },
 };
 
@@ -293,5 +294,33 @@ async fn test_set_realm_config_with_council_restore_error() {
     assert_eq!(
         err,
         GovernanceError::RealmCouncilMintChangeIsNotSupported.into()
+    );
+}
+
+#[tokio::test]
+async fn test_set_realm_config_with_liquid_community_token_cannot_be_changed_to_memebership_error()
+{
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    let mut set_realm_config_args = SetRealmConfigArgs::default();
+    set_realm_config_args
+        .realm_config_args
+        .community_token_config_args
+        .token_type = GoverningTokenType::Membership;
+
+    // Act
+    let err = governance_test
+        .set_realm_config(&mut realm_cookie, &set_realm_config_args)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(
+        err,
+        GovernanceError::CannotChangeCommunityTokenTypeToMemebership.into()
     );
 }

--- a/governance/program/tests/process_set_realm_config.rs
+++ b/governance/program/tests/process_set_realm_config.rs
@@ -8,7 +8,10 @@ mod program_test;
 use program_test::*;
 use spl_governance::{
     error::GovernanceError,
-    state::{enums::MintMaxVoteWeightSource, realm::RealmConfigArgs},
+    state::{
+        enums::MintMaxVoteWeightSource,
+        realm::{GoverningTokenConfigArgs, RealmConfigArgs},
+    },
 };
 
 use self::args::SetRealmConfigArgs;
@@ -25,8 +28,8 @@ async fn test_set_realm_config() {
 
         community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(100),
         min_community_weight_to_create_governance: 10,
-        use_community_voter_weight_addin: false,
-        use_max_community_voter_weight_addin: false,
+        community_token_config_args: GoverningTokenConfigArgs::default(),
+        council_token_config_args: GoverningTokenConfigArgs::default(),
     };
 
     let set_realm_config_args = SetRealmConfigArgs {
@@ -62,8 +65,8 @@ async fn test_set_realm_config_with_authority_must_sign_error() {
 
         community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(100),
         min_community_weight_to_create_governance: 10,
-        use_community_voter_weight_addin: false,
-        use_max_community_voter_weight_addin: false,
+        community_token_config_args: GoverningTokenConfigArgs::default(),
+        council_token_config_args: GoverningTokenConfigArgs::default(),
     };
 
     let set_realm_config_args = SetRealmConfigArgs {
@@ -101,8 +104,8 @@ async fn test_set_realm_config_with_no_authority_error() {
 
         community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(100),
         min_community_weight_to_create_governance: 10,
-        use_community_voter_weight_addin: false,
-        use_max_community_voter_weight_addin: false,
+        community_token_config_args: GoverningTokenConfigArgs::default(),
+        council_token_config_args: GoverningTokenConfigArgs::default(),
     };
 
     let set_realm_config_args = SetRealmConfigArgs {
@@ -145,8 +148,8 @@ async fn test_set_realm_config_with_invalid_authority_error() {
 
         community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(100),
         min_community_weight_to_create_governance: 10,
-        use_community_voter_weight_addin: false,
-        use_max_community_voter_weight_addin: false,
+        community_token_config_args: GoverningTokenConfigArgs::default(),
+        council_token_config_args: GoverningTokenConfigArgs::default(),
     };
 
     let set_realm_config_args = SetRealmConfigArgs {
@@ -184,8 +187,8 @@ async fn test_set_realm_config_with_remove_council() {
 
         community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(100),
         min_community_weight_to_create_governance: 10,
-        use_community_voter_weight_addin: false,
-        use_max_community_voter_weight_addin: false,
+        community_token_config_args: GoverningTokenConfigArgs::default(),
+        council_token_config_args: GoverningTokenConfigArgs::default(),
     };
 
     let set_realm_config_args = SetRealmConfigArgs {
@@ -221,8 +224,8 @@ async fn test_set_realm_config_with_council_change_error() {
 
         community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(100),
         min_community_weight_to_create_governance: 10,
-        use_community_voter_weight_addin: false,
-        use_max_community_voter_weight_addin: false,
+        community_token_config_args: GoverningTokenConfigArgs::default(),
+        council_token_config_args: GoverningTokenConfigArgs::default(),
     };
 
     let set_realm_config_args = SetRealmConfigArgs {
@@ -260,8 +263,8 @@ async fn test_set_realm_config_with_council_restore_error() {
 
         community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(100),
         min_community_weight_to_create_governance: 10,
-        use_community_voter_weight_addin: false,
-        use_max_community_voter_weight_addin: false,
+        community_token_config_args: GoverningTokenConfigArgs::default(),
+        council_token_config_args: GoverningTokenConfigArgs::default(),
     };
 
     let mut set_realm_config_args = SetRealmConfigArgs {

--- a/governance/program/tests/process_withdraw_governing_tokens.rs
+++ b/governance/program/tests/process_withdraw_governing_tokens.rs
@@ -9,9 +9,12 @@ use program_test::*;
 use solana_sdk::signature::Signer;
 
 use spl_governance::{
-    error::GovernanceError, instruction::withdraw_governing_tokens,
-    state::token_owner_record::get_token_owner_record_address,
+    error::GovernanceError,
+    instruction::withdraw_governing_tokens,
+    state::{realm_config::GoverningTokenType, token_owner_record::get_token_owner_record_address},
 };
+
+use crate::program_test::args::RealmSetupArgs;
 
 #[tokio::test]
 async fn test_withdraw_community_tokens() {
@@ -419,4 +422,66 @@ async fn test_withdraw_governing_tokens_after_proposal_cancelled() {
         token_owner_record_cookie.token_source_amount,
         source_account.amount
     );
+}
+
+#[tokio::test]
+async fn test_withdraw_council_tokens_with_cannot_withdraw_membership_tokens_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let mut realm_config_args = RealmSetupArgs::default();
+    realm_config_args.council_token_config_args.token_type = GoverningTokenType::Membership;
+
+    let realm_cookie = governance_test
+        .with_realm_using_args(&realm_config_args)
+        .await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let err = governance_test
+        .withdraw_council_tokens(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::CannotWithdrawMembershipTokens.into());
+}
+
+#[tokio::test]
+async fn test_withdraw_dormant_community_tokens() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let mut realm_cookie = governance_test.with_realm().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut realm_setup_args = RealmSetupArgs::default();
+    realm_setup_args.community_token_config_args.token_type = GoverningTokenType::Dormant;
+
+    governance_test
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .withdraw_community_tokens(&realm_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Assert
+    let token_owner_record = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(0, token_owner_record.governing_token_deposit_amount);
 }

--- a/governance/program/tests/program_test/args.rs
+++ b/governance/program/tests/program_test/args.rs
@@ -22,3 +22,49 @@ impl Default for RealmSetupArgs {
         }
     }
 }
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct PluginSetupArgs {
+    pub use_community_voter_weight_addin: bool,
+    pub use_max_community_voter_weight_addin: bool,
+    pub use_council_voter_weight_addin: bool,
+    pub use_max_council_voter_weight_addin: bool,
+}
+
+impl PluginSetupArgs {
+    #[allow(dead_code)]
+    pub const COMMUNITY_VOTER_WEIGHT: PluginSetupArgs = PluginSetupArgs {
+        use_community_voter_weight_addin: true,
+        use_max_community_voter_weight_addin: false,
+        use_council_voter_weight_addin: false,
+        use_max_council_voter_weight_addin: false,
+    };
+    #[allow(dead_code)]
+    pub const COMMUNITY_MAX_VOTER_WEIGHT: PluginSetupArgs = PluginSetupArgs {
+        use_community_voter_weight_addin: false,
+        use_max_community_voter_weight_addin: true,
+        use_council_voter_weight_addin: false,
+        use_max_council_voter_weight_addin: false,
+    };
+    #[allow(dead_code)]
+    pub const COUNCIL_VOTER_WEIGHT: PluginSetupArgs = PluginSetupArgs {
+        use_community_voter_weight_addin: false,
+        use_max_community_voter_weight_addin: false,
+        use_council_voter_weight_addin: true,
+        use_max_council_voter_weight_addin: false,
+    };
+    #[allow(dead_code)]
+    pub const COUNCIL_MAX_VOTER_WEIGHT: PluginSetupArgs = PluginSetupArgs {
+        use_community_voter_weight_addin: false,
+        use_max_community_voter_weight_addin: false,
+        use_council_voter_weight_addin: false,
+        use_max_council_voter_weight_addin: true,
+    };
+    #[allow(dead_code)]
+    pub const ALL: PluginSetupArgs = PluginSetupArgs {
+        use_community_voter_weight_addin: true,
+        use_max_community_voter_weight_addin: true,
+        use_council_voter_weight_addin: true,
+        use_max_council_voter_weight_addin: true,
+    };
+}

--- a/governance/program/tests/program_test/args.rs
+++ b/governance/program/tests/program_test/args.rs
@@ -1,30 +1,24 @@
 use spl_governance::state::{
-    enums::MintMaxVoteWeightSource,
-    realm::{GoverningTokenConfigArgs, RealmConfigArgs},
-    realm_config::GoverningTokenConfig,
+    enums::MintMaxVoteWeightSource, realm::GoverningTokenConfigAccountArgs,
 };
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct SetRealmConfigArgs {
-    pub realm_config_args: RealmConfigArgs,
-    pub community_token_config: GoverningTokenConfig,
-    pub council_token_config: GoverningTokenConfig,
+pub struct RealmSetupArgs {
+    pub use_council_mint: bool,
+    pub min_community_weight_to_create_governance: u64,
+    pub community_mint_max_vote_weight_source: MintMaxVoteWeightSource,
+    pub community_token_config_args: GoverningTokenConfigAccountArgs,
+    pub council_token_config_args: GoverningTokenConfigAccountArgs,
 }
 
-impl Default for SetRealmConfigArgs {
+impl Default for RealmSetupArgs {
     fn default() -> Self {
-        let realm_config_args = RealmConfigArgs {
-            use_council_mint: true,
-            community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(100),
-            min_community_weight_to_create_governance: 10,
-            community_token_config_args: GoverningTokenConfigArgs::default(),
-            council_token_config_args: GoverningTokenConfigArgs::default(),
-        };
-
         Self {
-            realm_config_args,
-            community_token_config: GoverningTokenConfig::default(),
-            council_token_config: GoverningTokenConfig::default(),
+            use_council_mint: true,
+            community_token_config_args: GoverningTokenConfigAccountArgs::default(),
+            council_token_config_args: GoverningTokenConfigAccountArgs::default(),
+            min_community_weight_to_create_governance: 10,
+            community_mint_max_vote_weight_source: MintMaxVoteWeightSource::FULL_SUPPLY_FRACTION,
         }
     }
 }

--- a/governance/program/tests/program_test/args.rs
+++ b/governance/program/tests/program_test/args.rs
@@ -1,21 +1,20 @@
-use solana_program::pubkey::Pubkey;
 use spl_governance::state::{
     enums::MintMaxVoteWeightSource,
     realm::{GoverningTokenConfigArgs, RealmConfigArgs},
+    realm_config::GoverningTokenConfig,
 };
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct SetRealmConfigArgs {
     pub realm_config_args: RealmConfigArgs,
-    pub community_voter_weight_addin: Option<Pubkey>,
-    pub max_community_voter_weight_addin: Option<Pubkey>,
+    pub community_token_config: GoverningTokenConfig,
+    pub council_token_config: GoverningTokenConfig,
 }
 
 impl Default for SetRealmConfigArgs {
     fn default() -> Self {
         let realm_config_args = RealmConfigArgs {
             use_council_mint: true,
-
             community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(100),
             min_community_weight_to_create_governance: 10,
             community_token_config_args: GoverningTokenConfigArgs::default(),
@@ -24,8 +23,8 @@ impl Default for SetRealmConfigArgs {
 
         Self {
             realm_config_args,
-            community_voter_weight_addin: None,
-            max_community_voter_weight_addin: None,
+            community_token_config: GoverningTokenConfig::default(),
+            council_token_config: GoverningTokenConfig::default(),
         }
     }
 }

--- a/governance/program/tests/program_test/args.rs
+++ b/governance/program/tests/program_test/args.rs
@@ -1,5 +1,8 @@
 use solana_program::pubkey::Pubkey;
-use spl_governance::state::{enums::MintMaxVoteWeightSource, realm::RealmConfigArgs};
+use spl_governance::state::{
+    enums::MintMaxVoteWeightSource,
+    realm::{GoverningTokenConfigArgs, RealmConfigArgs},
+};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct SetRealmConfigArgs {
@@ -15,8 +18,8 @@ impl Default for SetRealmConfigArgs {
 
             community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(100),
             min_community_weight_to_create_governance: 10,
-            use_community_voter_weight_addin: false,
-            use_max_community_voter_weight_addin: false,
+            community_token_config_args: GoverningTokenConfigArgs::default(),
+            council_token_config_args: GoverningTokenConfigArgs::default(),
         };
 
         Self {

--- a/governance/program/tests/program_test/cookies.rs
+++ b/governance/program/tests/program_test/cookies.rs
@@ -32,7 +32,7 @@ pub struct RealmCookie {
 
     pub realm_authority: Option<Keypair>,
 
-    pub realm_config: Option<RealmConfigCookie>,
+    pub realm_config: RealmConfigCookie,
 }
 
 #[derive(Debug)]

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1074,47 +1074,14 @@ impl GovernanceProgramTest {
             None
         };
 
-        let community_voter_weight_addin = if realm_setup_args
-            .community_token_config_args
-            .voter_weight_addin
-            .is_some()
-        {
-            realm_setup_args
-                .community_token_config_args
-                .voter_weight_addin
-        } else {
-            None
-        };
-
-        let max_community_voter_weight_addin = if realm_setup_args
-            .community_token_config_args
-            .max_voter_weight_addin
-            .is_some()
-        {
-            realm_setup_args
-                .community_token_config_args
-                .max_voter_weight_addin
-        } else {
-            None
-        };
-
-        let community_token_args = GoverningTokenConfigAccountArgs {
-            voter_weight_addin: community_voter_weight_addin,
-            max_voter_weight_addin: max_community_voter_weight_addin,
-            token_type: realm_setup_args
-                .community_token_config_args
-                .token_type
-                .clone(),
-        };
-
         let mut set_realm_config_ix = set_realm_config(
             &self.program_id,
             &realm_cookie.address,
             &realm_cookie.realm_authority.as_ref().unwrap().pubkey(),
             council_token_mint,
             &self.bench.payer.pubkey(),
-            Some(community_token_args),
-            None,
+            Some(realm_setup_args.community_token_config_args.clone()),
+            Some(realm_setup_args.council_token_config_args.clone()),
             realm_setup_args.min_community_weight_to_create_governance,
             realm_setup_args
                 .community_mint_max_vote_weight_source
@@ -1139,12 +1106,31 @@ impl GovernanceProgramTest {
             account: RealmConfigAccount {
                 account_type: GovernanceAccountType::RealmConfig,
                 realm: realm_cookie.address,
-                council_token_config: GoverningTokenConfig::default(),
                 reserved: Reserved110::default(),
                 community_token_config: GoverningTokenConfig {
-                    voter_weight_addin: community_voter_weight_addin,
-                    max_voter_weight_addin: max_community_voter_weight_addin,
-                    token_type: GoverningTokenType::Liquid,
+                    voter_weight_addin: realm_setup_args
+                        .community_token_config_args
+                        .voter_weight_addin,
+                    max_voter_weight_addin: realm_setup_args
+                        .community_token_config_args
+                        .max_voter_weight_addin,
+                    token_type: realm_setup_args
+                        .community_token_config_args
+                        .token_type
+                        .clone(),
+                    reserved: [0; 8],
+                },
+                council_token_config: GoverningTokenConfig {
+                    voter_weight_addin: realm_setup_args
+                        .council_token_config_args
+                        .voter_weight_addin,
+                    max_voter_weight_addin: realm_setup_args
+                        .council_token_config_args
+                        .max_voter_weight_addin,
+                    token_type: realm_setup_args
+                        .council_token_config_args
+                        .token_type
+                        .clone(),
                     reserved: [0; 8],
                 },
             },

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1114,7 +1114,11 @@ impl GovernanceProgramTest {
         let community_token_args = GoverningTokenConfigAccountArgs {
             voter_weight_addin: community_voter_weight_addin,
             max_voter_weight_addin: max_community_voter_weight_addin,
-            token_type: GoverningTokenType::Liquid,
+            token_type: set_realm_config_args
+                .realm_config_args
+                .community_token_config_args
+                .token_type
+                .clone(),
         };
 
         let mut set_realm_config_ix = set_realm_config(

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -216,8 +216,13 @@ impl GovernanceProgramTest {
 
         SetRealmConfigArgs {
             realm_config_args,
-            community_voter_weight_addin,
-            max_community_voter_weight_addin,
+            council_token_config: GoverningTokenConfig::default(),
+            community_token_config: GoverningTokenConfig {
+                voter_weight_addin: community_voter_weight_addin,
+                max_voter_weight_addin: max_community_voter_weight_addin,
+                token_type: GoverningTokenType::default(),
+                reserved: [0; 8],
+            },
         }
     }
 
@@ -289,8 +294,12 @@ impl GovernanceProgramTest {
         let realm_authority = Keypair::new();
 
         let community_token_args = GoverningTokenConfigAccountArgs {
-            voter_weight_addin: set_realm_config_args.community_voter_weight_addin,
-            max_voter_weight_addin: set_realm_config_args.max_community_voter_weight_addin,
+            voter_weight_addin: set_realm_config_args
+                .community_token_config
+                .voter_weight_addin,
+            max_voter_weight_addin: set_realm_config_args
+                .community_token_config
+                .max_voter_weight_addin,
             token_type: set_realm_config_args
                 .realm_config_args
                 .community_token_config_args
@@ -354,8 +363,12 @@ impl GovernanceProgramTest {
                 council_token_config: GoverningTokenConfig::default(),
                 reserved: Reserved110::default(),
                 community_token_config: GoverningTokenConfig {
-                    voter_weight_addin: set_realm_config_args.community_voter_weight_addin,
-                    max_voter_weight_addin: set_realm_config_args.max_community_voter_weight_addin,
+                    voter_weight_addin: set_realm_config_args
+                        .community_token_config
+                        .voter_weight_addin,
+                    max_voter_weight_addin: set_realm_config_args
+                        .community_token_config
+                        .max_voter_weight_addin,
                     token_type: GoverningTokenType::Liquid,
                     reserved: [0; 8],
                 },
@@ -1098,7 +1111,9 @@ impl GovernanceProgramTest {
             .community_token_config_args
             .use_voter_weight_addin
         {
-            set_realm_config_args.community_voter_weight_addin
+            set_realm_config_args
+                .community_token_config
+                .voter_weight_addin
         } else {
             None
         };
@@ -1108,7 +1123,9 @@ impl GovernanceProgramTest {
             .community_token_config_args
             .use_max_voter_weight_addin
         {
-            set_realm_config_args.max_community_voter_weight_addin
+            set_realm_config_args
+                .community_token_config
+                .max_voter_weight_addin
         } else {
             None
         };

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -335,8 +335,8 @@ impl GovernanceProgramTest {
                     .realm_config_args
                     .community_mint_max_vote_weight_source
                     .clone(),
-                use_community_voter_weight_addin: false,
-                use_max_community_voter_weight_addin: false,
+                legacy1: 0,
+                legacy2: 0,
             },
             voting_proposal_count: 0,
             reserved_v2: [0; 128],
@@ -426,8 +426,8 @@ impl GovernanceProgramTest {
                 community_mint_max_vote_weight_source:
                     MintMaxVoteWeightSource::FULL_SUPPLY_FRACTION,
                 min_community_weight_to_create_governance,
-                use_community_voter_weight_addin: false,
-                use_max_community_voter_weight_addin: false,
+                legacy1: 0,
+                legacy2: 0,
             },
             voting_proposal_count: 0,
             reserved_v2: [0; 128],

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -41,8 +41,9 @@ use spl_governance::{
             get_proposal_transaction_address, InstructionData, ProposalTransactionV2,
         },
         realm::{
-            get_governing_token_holding_address, get_realm_address, GoverningTokenConfigArgs,
-            RealmConfig, RealmConfigArgs, RealmV2, SetRealmAuthorityAction,
+            get_governing_token_holding_address, get_realm_address,
+            GoverningTokenConfigAccountArgs, GoverningTokenConfigArgs, RealmConfig,
+            RealmConfigArgs, RealmV2, SetRealmAuthorityAction,
         },
         realm_config::{
             get_realm_config_address, GoverningTokenConfig, GoverningTokenType, RealmConfigAccount,
@@ -287,14 +288,19 @@ impl GovernanceProgramTest {
 
         let realm_authority = Keypair::new();
 
+        let community_token_args = GoverningTokenConfigAccountArgs {
+            voter_weight_addin: set_realm_config_args.community_voter_weight_addin,
+            max_voter_weight_addin: set_realm_config_args.max_community_voter_weight_addin,
+            token_type: GoverningTokenType::Liquid,
+        };
+
         let create_realm_ix = create_realm(
             &self.program_id,
             &realm_authority.pubkey(),
             &community_token_mint_keypair.pubkey(),
             &self.bench.payer.pubkey(),
             council_token_mint_pubkey,
-            set_realm_config_args.community_voter_weight_addin,
-            set_realm_config_args.max_community_voter_weight_addin,
+            &community_token_args,
             name.clone(),
             set_realm_config_args
                 .realm_config_args
@@ -387,14 +393,19 @@ impl GovernanceProgramTest {
         let community_mint_max_vote_weight_source = MintMaxVoteWeightSource::FULL_SUPPLY_FRACTION;
         let min_community_weight_to_create_governance = 10;
 
+        let community_token_args = GoverningTokenConfigAccountArgs {
+            voter_weight_addin: None,
+            max_voter_weight_addin: None,
+            token_type: GoverningTokenType::Liquid,
+        };
+
         let create_realm_ix = create_realm(
             &self.program_id,
             &realm_authority.pubkey(),
             &realm_cookie.account.community_mint,
             &self.bench.context.payer.pubkey(),
             Some(council_mint),
-            None,
-            None,
+            &community_token_args,
             name.clone(),
             min_community_weight_to_create_governance,
             community_mint_max_vote_weight_source,
@@ -1033,14 +1044,19 @@ impl GovernanceProgramTest {
             None
         };
 
+        let community_token_args = GoverningTokenConfigAccountArgs {
+            voter_weight_addin: community_voter_weight_addin,
+            max_voter_weight_addin: max_community_voter_weight_addin,
+            token_type: GoverningTokenType::Liquid,
+        };
+
         let mut set_realm_config_ix = set_realm_config(
             &self.program_id,
             &realm_cookie.address,
             &realm_cookie.realm_authority.as_ref().unwrap().pubkey(),
             council_token_mint,
             &self.bench.payer.pubkey(),
-            community_voter_weight_addin,
-            max_community_voter_weight_addin,
+            &community_token_args,
             set_realm_config_args
                 .realm_config_args
                 .min_community_weight_to_create_governance,

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -301,6 +301,7 @@ impl GovernanceProgramTest {
             &self.bench.payer.pubkey(),
             council_token_mint_pubkey,
             Some(community_token_args),
+            None,
             name.clone(),
             set_realm_config_args
                 .realm_config_args
@@ -399,6 +400,7 @@ impl GovernanceProgramTest {
             &realm_cookie.account.community_mint,
             &self.bench.context.payer.pubkey(),
             Some(council_mint),
+            None,
             None,
             name.clone(),
             min_community_weight_to_create_governance,
@@ -1051,6 +1053,7 @@ impl GovernanceProgramTest {
             council_token_mint,
             &self.bench.payer.pubkey(),
             Some(community_token_args),
+            None,
             set_realm_config_args
                 .realm_config_args
                 .min_community_weight_to_create_governance,

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -767,7 +767,7 @@ impl GovernanceProgramTest {
     }
 
     #[allow(dead_code)]
-    pub async fn with_initial_governing_token_mint_deposit(
+    pub async fn with_initial_governing_token_deposit_using_mint(
         &mut self,
         realm_address: &Pubkey,
         governing_mint: &Pubkey,

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -300,7 +300,7 @@ impl GovernanceProgramTest {
             &community_token_mint_keypair.pubkey(),
             &self.bench.payer.pubkey(),
             council_token_mint_pubkey,
-            &community_token_args,
+            Some(community_token_args),
             name.clone(),
             set_realm_config_args
                 .realm_config_args
@@ -393,19 +393,13 @@ impl GovernanceProgramTest {
         let community_mint_max_vote_weight_source = MintMaxVoteWeightSource::FULL_SUPPLY_FRACTION;
         let min_community_weight_to_create_governance = 10;
 
-        let community_token_args = GoverningTokenConfigAccountArgs {
-            voter_weight_addin: None,
-            max_voter_weight_addin: None,
-            token_type: GoverningTokenType::Liquid,
-        };
-
         let create_realm_ix = create_realm(
             &self.program_id,
             &realm_authority.pubkey(),
             &realm_cookie.account.community_mint,
             &self.bench.context.payer.pubkey(),
             Some(council_mint),
-            &community_token_args,
+            None,
             name.clone(),
             min_community_weight_to_create_governance,
             community_mint_max_vote_weight_source,
@@ -1056,7 +1050,7 @@ impl GovernanceProgramTest {
             &realm_cookie.realm_authority.as_ref().unwrap().pubkey(),
             council_token_mint,
             &self.bench.payer.pubkey(),
-            &community_token_args,
+            Some(community_token_args),
             set_realm_config_args
                 .realm_config_args
                 .min_community_weight_to_create_governance,

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -44,7 +44,10 @@ use spl_governance::{
             get_governing_token_holding_address, get_realm_address, RealmConfig, RealmConfigArgs,
             RealmV2, SetRealmAuthorityAction,
         },
-        realm_config::{get_realm_config_address, GoverningTokenConfig, RealmConfigAccount},
+        realm_config::{
+            get_realm_config_address, GoverningTokenConfig, GoverningTokenType, RealmConfigAccount,
+            Reserved110,
+        },
         signatory_record::{get_signatory_record_address, SignatoryRecordV2},
         token_owner_record::{get_token_owner_record_address, TokenOwnerRecordV2},
         vote_record::{get_vote_record_address, Vote, VoteChoice, VoteRecordV2},
@@ -333,13 +336,14 @@ impl GovernanceProgramTest {
                 account: RealmConfigAccount {
                     account_type: GovernanceAccountType::RealmConfig,
                     realm: realm_address,
-                    council_voter_weight_addin: None,
-                    council_max_vote_weight_addin: None,
-                    reserved: [0; 128],
+                    council_token_config: GoverningTokenConfig::default(),
+                    reserved: Reserved110::default(),
                     community_token_config: GoverningTokenConfig {
                         voter_weight_addin: set_realm_config_args.community_voter_weight_addin,
                         max_voter_weight_addin: set_realm_config_args
                             .max_community_voter_weight_addin,
+                        token_type: GoverningTokenType::Liquid,
+                        reserved: [0; 8],
                     },
                 },
             })
@@ -1061,12 +1065,13 @@ impl GovernanceProgramTest {
                 account: RealmConfigAccount {
                     account_type: GovernanceAccountType::RealmConfig,
                     realm: realm_cookie.address,
-                    council_voter_weight_addin: None,
-                    council_max_vote_weight_addin: None,
-                    reserved: [0; 128],
+                    council_token_config: GoverningTokenConfig::default(),
+                    reserved: Reserved110::default(),
                     community_token_config: GoverningTokenConfig {
                         voter_weight_addin: community_voter_weight_addin,
                         max_voter_weight_addin: max_community_voter_weight_addin,
+                        token_type: GoverningTokenType::Liquid,
+                        reserved: [0; 8],
                     },
                 },
             })

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -41,8 +41,8 @@ use spl_governance::{
             get_proposal_transaction_address, InstructionData, ProposalTransactionV2,
         },
         realm::{
-            get_governing_token_holding_address, get_realm_address, RealmConfig, RealmConfigArgs,
-            RealmV2, SetRealmAuthorityAction,
+            get_governing_token_holding_address, get_realm_address, GoverningTokenConfigArgs,
+            RealmConfig, RealmConfigArgs, RealmV2, SetRealmAuthorityAction,
         },
         realm_config::{
             get_realm_config_address, GoverningTokenConfig, GoverningTokenType, RealmConfigAccount,
@@ -187,22 +187,31 @@ impl GovernanceProgramTest {
             use_council_mint: true,
             community_mint_max_vote_weight_source: MintMaxVoteWeightSource::FULL_SUPPLY_FRACTION,
             min_community_weight_to_create_governance: 10,
-            use_community_voter_weight_addin: self.voter_weight_addin_id.is_some(),
-            use_max_community_voter_weight_addin: self.max_voter_weight_addin_id.is_some(),
+            community_token_config_args: GoverningTokenConfigArgs {
+                use_voter_weight_addin: self.voter_weight_addin_id.is_some(),
+                use_max_voter_weight_addin: self.max_voter_weight_addin_id.is_some(),
+                token_type: GoverningTokenType::Liquid,
+            },
+            council_token_config_args: GoverningTokenConfigArgs::default(),
         };
 
-        let community_voter_weight_addin = if realm_config_args.use_community_voter_weight_addin {
+        let community_voter_weight_addin = if realm_config_args
+            .community_token_config_args
+            .use_voter_weight_addin
+        {
             self.voter_weight_addin_id
         } else {
             None
         };
 
-        let max_community_voter_weight_addin =
-            if realm_config_args.use_max_community_voter_weight_addin {
-                self.max_voter_weight_addin_id
-            } else {
-                None
-            };
+        let max_community_voter_weight_addin = if realm_config_args
+            .community_token_config_args
+            .use_max_voter_weight_addin
+        {
+            self.max_voter_weight_addin_id
+        } else {
+            None
+        };
 
         SetRealmConfigArgs {
             realm_config_args,
@@ -1006,7 +1015,8 @@ impl GovernanceProgramTest {
 
         let community_voter_weight_addin = if set_realm_config_args
             .realm_config_args
-            .use_community_voter_weight_addin
+            .community_token_config_args
+            .use_voter_weight_addin
         {
             set_realm_config_args.community_voter_weight_addin
         } else {
@@ -1015,7 +1025,8 @@ impl GovernanceProgramTest {
 
         let max_community_voter_weight_addin = if set_realm_config_args
             .realm_config_args
-            .use_max_community_voter_weight_addin
+            .community_token_config_args
+            .use_max_voter_weight_addin
         {
             set_realm_config_args.max_community_voter_weight_addin
         } else {
@@ -1055,10 +1066,12 @@ impl GovernanceProgramTest {
 
         if set_realm_config_args
             .realm_config_args
-            .use_community_voter_weight_addin
+            .community_token_config_args
+            .use_voter_weight_addin
             || set_realm_config_args
                 .realm_config_args
-                .use_max_community_voter_weight_addin
+                .community_token_config_args
+                .use_max_voter_weight_addin
         {
             realm_cookie.realm_config = Some(RealmConfigCookie {
                 address: get_realm_config_address(&self.program_id, &realm_cookie.address),

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -44,7 +44,7 @@ use spl_governance::{
             get_governing_token_holding_address, get_realm_address, RealmConfig, RealmConfigArgs,
             RealmV2, SetRealmAuthorityAction,
         },
-        realm_config::{get_realm_config_address, RealmConfigAccount},
+        realm_config::{get_realm_config_address, GoverningTokenConfig, RealmConfigAccount},
         signatory_record::{get_signatory_record_address, SignatoryRecordV2},
         token_owner_record::{get_token_owner_record_address, TokenOwnerRecordV2},
         vote_record::{get_vote_record_address, Vote, VoteChoice, VoteRecordV2},
@@ -333,13 +333,14 @@ impl GovernanceProgramTest {
                 account: RealmConfigAccount {
                     account_type: GovernanceAccountType::RealmConfig,
                     realm: realm_address,
-                    community_voter_weight_addin: set_realm_config_args
-                        .community_voter_weight_addin,
-                    max_community_voter_weight_addin: set_realm_config_args
-                        .max_community_voter_weight_addin,
                     council_voter_weight_addin: None,
                     council_max_vote_weight_addin: None,
                     reserved: [0; 128],
+                    community_token_config: GoverningTokenConfig {
+                        voter_weight_addin: set_realm_config_args.community_voter_weight_addin,
+                        max_voter_weight_addin: set_realm_config_args
+                            .max_community_voter_weight_addin,
+                    },
                 },
             })
         } else {
@@ -1060,11 +1061,13 @@ impl GovernanceProgramTest {
                 account: RealmConfigAccount {
                     account_type: GovernanceAccountType::RealmConfig,
                     realm: realm_cookie.address,
-                    community_voter_weight_addin,
-                    max_community_voter_weight_addin,
                     council_voter_weight_addin: None,
                     council_max_vote_weight_addin: None,
                     reserved: [0; 128],
+                    community_token_config: GoverningTokenConfig {
+                        voter_weight_addin: community_voter_weight_addin,
+                        max_voter_weight_addin: max_community_voter_weight_addin,
+                    },
                 },
             })
         }

--- a/governance/program/tests/setup_realm_with_all_addins.rs
+++ b/governance/program/tests/setup_realm_with_all_addins.rs
@@ -14,20 +14,20 @@ async fn test_create_realm_with_all_addins() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_all_addins().await;
 
-    let mut set_realm_config_args = RealmSetupArgs::default();
+    let mut realm_setup_args = RealmSetupArgs::default();
 
-    set_realm_config_args
+    realm_setup_args
         .community_token_config_args
         .voter_weight_addin = governance_test.voter_weight_addin_id;
 
-    set_realm_config_args
+    realm_setup_args
         .community_token_config_args
         .max_voter_weight_addin = governance_test.max_voter_weight_addin_id;
 
     // Act
 
     let realm_cookie = governance_test
-        .with_realm_using_config_args(&set_realm_config_args)
+        .with_realm_using_args(&realm_setup_args)
         .await;
 
     // Assert
@@ -54,24 +54,24 @@ async fn test_set_all_addins_for_realm_without_addins() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_all_addins().await;
 
-    let mut set_realm_config_args = RealmSetupArgs::default();
+    let mut realm_setup_args = RealmSetupArgs::default();
 
     let mut realm_cookie = governance_test
-        .with_realm_using_config_args(&set_realm_config_args)
+        .with_realm_using_args(&realm_setup_args)
         .await;
 
-    set_realm_config_args
+    realm_setup_args
         .community_token_config_args
         .voter_weight_addin = governance_test.voter_weight_addin_id;
 
-    set_realm_config_args
+    realm_setup_args
         .community_token_config_args
         .max_voter_weight_addin = governance_test.max_voter_weight_addin_id;
 
     // Act
 
     governance_test
-        .set_realm_config(&mut realm_cookie, &set_realm_config_args)
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
         .await
         .unwrap();
 
@@ -99,26 +99,26 @@ async fn test_set_all_addin_for_realm_without_council_and_addins() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_all_addins().await;
 
-    let mut set_realm_config_args = RealmSetupArgs::default();
+    let mut realm_setup_args = RealmSetupArgs::default();
 
-    set_realm_config_args.use_council_mint = false;
+    realm_setup_args.use_council_mint = false;
 
     let mut realm_cookie = governance_test
-        .with_realm_using_config_args(&set_realm_config_args)
+        .with_realm_using_args(&realm_setup_args)
         .await;
 
-    set_realm_config_args
+    realm_setup_args
         .community_token_config_args
         .voter_weight_addin = governance_test.voter_weight_addin_id;
 
-    set_realm_config_args
+    realm_setup_args
         .community_token_config_args
         .max_voter_weight_addin = governance_test.max_voter_weight_addin_id;
 
     // Act
 
     governance_test
-        .set_realm_config(&mut realm_cookie, &set_realm_config_args)
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
         .await
         .unwrap();
 
@@ -148,31 +148,31 @@ async fn test_set_all_realm_addins_for_realm_with_all_addins() {
 
     let mut realm_cookie = governance_test.with_realm().await;
 
-    let mut set_realm_config_args = RealmSetupArgs::default();
+    let mut realm_setup_args = RealmSetupArgs::default();
 
-    set_realm_config_args
+    realm_setup_args
         .community_token_config_args
         .voter_weight_addin = governance_test.voter_weight_addin_id;
 
-    set_realm_config_args
+    realm_setup_args
         .community_token_config_args
         .max_voter_weight_addin = governance_test.max_voter_weight_addin_id;
 
     let max_community_voter_weight_addin_address = Pubkey::new_unique();
 
-    set_realm_config_args
+    realm_setup_args
         .community_token_config_args
         .max_voter_weight_addin = Some(max_community_voter_weight_addin_address);
 
     let community_voter_weight_addin_address = Pubkey::new_unique();
-    set_realm_config_args
+    realm_setup_args
         .community_token_config_args
         .voter_weight_addin = Some(community_voter_weight_addin_address);
 
     // Act
 
     governance_test
-        .set_realm_config(&mut realm_cookie, &set_realm_config_args)
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
         .await
         .unwrap();
 
@@ -210,24 +210,24 @@ async fn test_set_realm_config_without_addins_for_realm_without_addins() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_all_addins().await;
 
-    let mut set_realm_config_args = RealmSetupArgs::default();
+    let mut realm_setup_args = RealmSetupArgs::default();
 
     let mut realm_cookie = governance_test
-        .with_realm_using_config_args(&set_realm_config_args)
+        .with_realm_using_args(&realm_setup_args)
         .await;
 
-    set_realm_config_args
+    realm_setup_args
         .community_token_config_args
         .max_voter_weight_addin = None;
 
-    set_realm_config_args
+    realm_setup_args
         .community_token_config_args
         .voter_weight_addin = None;
 
     // Act
 
     governance_test
-        .set_realm_config(&mut realm_cookie, &set_realm_config_args)
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
         .await
         .unwrap();
 
@@ -254,12 +254,12 @@ async fn test_set_realm_config_without_any_addins_for_realm_with_existing_addins
     let mut governance_test = GovernanceProgramTest::start_with_all_addins().await;
     let mut realm_cookie = governance_test.with_realm().await;
 
-    let set_realm_config_args = RealmSetupArgs::default();
+    let realm_setup_args = RealmSetupArgs::default();
 
     // Act
 
     governance_test
-        .set_realm_config(&mut realm_cookie, &set_realm_config_args)
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
         .await
         .unwrap();
 

--- a/governance/program/tests/setup_realm_with_all_addins.rs
+++ b/governance/program/tests/setup_realm_with_all_addins.rs
@@ -7,14 +7,28 @@ mod program_test;
 
 use program_test::*;
 
+use crate::program_test::args::RealmSetupArgs;
+
 #[tokio::test]
 async fn test_create_realm_with_all_addins() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_all_addins().await;
 
+    let mut set_realm_config_args = RealmSetupArgs::default();
+
+    set_realm_config_args
+        .community_token_config_args
+        .voter_weight_addin = governance_test.voter_weight_addin_id;
+
+    set_realm_config_args
+        .community_token_config_args
+        .max_voter_weight_addin = governance_test.max_voter_weight_addin_id;
+
     // Act
 
-    let realm_cookie = governance_test.with_realm().await;
+    let realm_cookie = governance_test
+        .with_realm_using_config_args(&set_realm_config_args)
+        .await;
 
     // Assert
 
@@ -40,31 +54,19 @@ async fn test_set_all_addins_for_realm_without_addins() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_all_addins().await;
 
-    let mut set_realm_config_args = governance_test.get_default_set_realm_config_args();
-
-    set_realm_config_args
-        .realm_config_args
-        .community_token_config_args
-        .use_max_voter_weight_addin = false;
-
-    set_realm_config_args
-        .realm_config_args
-        .community_token_config_args
-        .use_voter_weight_addin = false;
+    let mut set_realm_config_args = RealmSetupArgs::default();
 
     let mut realm_cookie = governance_test
         .with_realm_using_config_args(&set_realm_config_args)
         .await;
 
     set_realm_config_args
-        .realm_config_args
         .community_token_config_args
-        .use_voter_weight_addin = true;
+        .voter_weight_addin = governance_test.voter_weight_addin_id;
 
     set_realm_config_args
-        .realm_config_args
         .community_token_config_args
-        .use_max_voter_weight_addin = true;
+        .max_voter_weight_addin = governance_test.max_voter_weight_addin_id;
 
     // Act
 
@@ -97,33 +99,21 @@ async fn test_set_all_addin_for_realm_without_council_and_addins() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_all_addins().await;
 
-    let mut set_realm_config_args = governance_test.get_default_set_realm_config_args();
+    let mut set_realm_config_args = RealmSetupArgs::default();
 
-    set_realm_config_args
-        .realm_config_args
-        .community_token_config_args
-        .use_voter_weight_addin = false;
-
-    set_realm_config_args
-        .realm_config_args
-        .community_token_config_args
-        .use_max_voter_weight_addin = false;
-
-    set_realm_config_args.realm_config_args.use_council_mint = false;
+    set_realm_config_args.use_council_mint = false;
 
     let mut realm_cookie = governance_test
         .with_realm_using_config_args(&set_realm_config_args)
         .await;
 
     set_realm_config_args
-        .realm_config_args
         .community_token_config_args
-        .use_max_voter_weight_addin = true;
+        .voter_weight_addin = governance_test.voter_weight_addin_id;
 
     set_realm_config_args
-        .realm_config_args
         .community_token_config_args
-        .use_voter_weight_addin = true;
+        .max_voter_weight_addin = governance_test.max_voter_weight_addin_id;
 
     // Act
 
@@ -158,27 +148,25 @@ async fn test_set_all_realm_addins_for_realm_with_all_addins() {
 
     let mut realm_cookie = governance_test.with_realm().await;
 
-    let mut set_realm_config_args = governance_test.get_default_set_realm_config_args();
+    let mut set_realm_config_args = RealmSetupArgs::default();
 
     set_realm_config_args
-        .realm_config_args
         .community_token_config_args
-        .use_max_voter_weight_addin = true;
+        .voter_weight_addin = governance_test.voter_weight_addin_id;
 
     set_realm_config_args
-        .realm_config_args
         .community_token_config_args
-        .use_voter_weight_addin = true;
+        .max_voter_weight_addin = governance_test.max_voter_weight_addin_id;
 
     let max_community_voter_weight_addin_address = Pubkey::new_unique();
 
     set_realm_config_args
-        .community_token_config
+        .community_token_config_args
         .max_voter_weight_addin = Some(max_community_voter_weight_addin_address);
 
     let community_voter_weight_addin_address = Pubkey::new_unique();
     set_realm_config_args
-        .community_token_config
+        .community_token_config_args
         .voter_weight_addin = Some(community_voter_weight_addin_address);
 
     // Act
@@ -222,31 +210,19 @@ async fn test_set_realm_config_without_addins_for_realm_without_addins() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_all_addins().await;
 
-    let mut set_realm_config_args = governance_test.get_default_set_realm_config_args();
-
-    set_realm_config_args
-        .realm_config_args
-        .community_token_config_args
-        .use_max_voter_weight_addin = false;
-
-    set_realm_config_args
-        .realm_config_args
-        .community_token_config_args
-        .use_voter_weight_addin = false;
+    let mut set_realm_config_args = RealmSetupArgs::default();
 
     let mut realm_cookie = governance_test
         .with_realm_using_config_args(&set_realm_config_args)
         .await;
 
     set_realm_config_args
-        .realm_config_args
         .community_token_config_args
-        .use_max_voter_weight_addin = false;
+        .max_voter_weight_addin = None;
 
     set_realm_config_args
-        .realm_config_args
         .community_token_config_args
-        .use_voter_weight_addin = false;
+        .voter_weight_addin = None;
 
     // Act
 
@@ -278,17 +254,7 @@ async fn test_set_realm_config_without_any_addins_for_realm_with_existing_addins
     let mut governance_test = GovernanceProgramTest::start_with_all_addins().await;
     let mut realm_cookie = governance_test.with_realm().await;
 
-    let mut set_realm_config_args = governance_test.get_default_set_realm_config_args();
-
-    set_realm_config_args
-        .realm_config_args
-        .community_token_config_args
-        .use_max_voter_weight_addin = false;
-
-    set_realm_config_args
-        .realm_config_args
-        .community_token_config_args
-        .use_voter_weight_addin = false;
+    let set_realm_config_args = RealmSetupArgs::default();
 
     // Act
 

--- a/governance/program/tests/setup_realm_with_all_addins.rs
+++ b/governance/program/tests/setup_realm_with_all_addins.rs
@@ -18,18 +18,6 @@ async fn test_create_realm_with_all_addins() {
 
     // Assert
 
-    let realm_account_data = governance_test
-        .get_realm_account(&realm_cookie.address)
-        .await;
-
-    assert!(realm_account_data.config.use_community_voter_weight_addin);
-
-    assert!(
-        realm_account_data
-            .config
-            .use_max_community_voter_weight_addin
-    );
-
     let realm_config_cookie = realm_cookie.realm_config.unwrap();
 
     let realm_config_data = governance_test
@@ -37,6 +25,16 @@ async fn test_create_realm_with_all_addins() {
         .await;
 
     assert_eq!(realm_config_cookie.account, realm_config_data);
+
+    assert!(realm_config_data
+        .community_token_config
+        .voter_weight_addin
+        .is_some());
+
+    assert!(realm_config_data
+        .community_token_config
+        .max_voter_weight_addin
+        .is_some());
 }
 
 #[tokio::test]
@@ -79,18 +77,6 @@ async fn test_set_all_addins_for_realm_without_addins() {
 
     // Assert
 
-    let realm_account_data = governance_test
-        .get_realm_account(&realm_cookie.address)
-        .await;
-
-    assert!(
-        realm_account_data
-            .config
-            .use_max_community_voter_weight_addin
-    );
-
-    assert!(realm_account_data.config.use_community_voter_weight_addin);
-
     let realm_config_cookie = realm_cookie.realm_config.unwrap();
 
     let realm_config_data = governance_test
@@ -98,6 +84,16 @@ async fn test_set_all_addins_for_realm_without_addins() {
         .await;
 
     assert_eq!(realm_config_cookie.account, realm_config_data);
+
+    assert!(realm_config_data
+        .community_token_config
+        .voter_weight_addin
+        .is_some());
+
+    assert!(realm_config_data
+        .community_token_config
+        .max_voter_weight_addin
+        .is_some());
 }
 
 #[tokio::test]
@@ -142,18 +138,6 @@ async fn test_set_all_addin_for_realm_without_council_and_addins() {
 
     // Assert
 
-    let realm_account_data = governance_test
-        .get_realm_account(&realm_cookie.address)
-        .await;
-
-    assert!(
-        realm_account_data
-            .config
-            .use_max_community_voter_weight_addin
-    );
-
-    assert!(realm_account_data.config.use_community_voter_weight_addin);
-
     let realm_config_cookie = realm_cookie.realm_config.unwrap();
 
     let realm_config_data = governance_test
@@ -161,6 +145,16 @@ async fn test_set_all_addin_for_realm_without_council_and_addins() {
         .await;
 
     assert_eq!(realm_config_cookie.account, realm_config_data);
+
+    assert!(realm_config_data
+        .community_token_config
+        .voter_weight_addin
+        .is_some());
+
+    assert!(realm_config_data
+        .community_token_config
+        .max_voter_weight_addin
+        .is_some());
 }
 
 #[tokio::test]
@@ -199,18 +193,6 @@ async fn test_set_all_realm_addins_for_realm_with_all_addins() {
 
     // Assert
 
-    let realm_account_data = governance_test
-        .get_realm_account(&realm_cookie.address)
-        .await;
-
-    assert!(
-        realm_account_data
-            .config
-            .use_max_community_voter_weight_addin
-    );
-
-    assert!(realm_account_data.config.use_community_voter_weight_addin);
-
     let realm_config_cookie = realm_cookie.realm_config.unwrap();
 
     let realm_config_data = governance_test
@@ -228,6 +210,16 @@ async fn test_set_all_realm_addins_for_realm_with_all_addins() {
         realm_config_data.community_token_config.voter_weight_addin,
         Some(community_voter_weight_addin_address)
     );
+
+    assert!(realm_config_data
+        .community_token_config
+        .voter_weight_addin
+        .is_some());
+
+    assert!(realm_config_data
+        .community_token_config
+        .max_voter_weight_addin
+        .is_some());
 }
 
 #[tokio::test]
@@ -270,17 +262,21 @@ async fn test_set_realm_config_without_addins_for_realm_without_addins() {
 
     // Assert
 
-    let realm_account_data = governance_test
-        .get_realm_account(&realm_cookie.address)
+    let realm_config_cookie = realm_cookie.realm_config.unwrap();
+
+    let realm_config_data = governance_test
+        .get_realm_config_data(&realm_config_cookie.address)
         .await;
 
-    assert!(
-        !realm_account_data
-            .config
-            .use_max_community_voter_weight_addin
-    );
+    assert!(realm_config_data
+        .community_token_config
+        .voter_weight_addin
+        .is_none());
 
-    assert!(!realm_account_data.config.use_community_voter_weight_addin);
+    assert!(realm_config_data
+        .community_token_config
+        .max_voter_weight_addin
+        .is_none());
 }
 
 #[tokio::test]
@@ -310,12 +306,6 @@ async fn test_set_realm_config_without_any_addins_for_realm_with_existing_addins
 
     // Assert
 
-    let realm_account_data = governance_test
-        .get_realm_account(&realm_cookie.address)
-        .await;
-
-    assert!(!realm_account_data.config.use_community_voter_weight_addin);
-
     let realm_config_data = governance_test
         .get_realm_config_data(&realm_cookie.realm_config.unwrap().address)
         .await;
@@ -324,6 +314,7 @@ async fn test_set_realm_config_without_any_addins_for_realm_with_existing_addins
         .community_token_config
         .max_voter_weight_addin
         .is_none());
+
     assert!(realm_config_data
         .community_token_config
         .voter_weight_addin

--- a/governance/program/tests/setup_realm_with_all_addins.rs
+++ b/governance/program/tests/setup_realm_with_all_addins.rs
@@ -18,13 +18,11 @@ async fn test_create_realm_with_all_addins() {
 
     // Assert
 
-    let realm_config_cookie = realm_cookie.realm_config.unwrap();
-
     let realm_config_data = governance_test
-        .get_realm_config_data(&realm_config_cookie.address)
+        .get_realm_config_account(&realm_cookie.realm_config.address)
         .await;
 
-    assert_eq!(realm_config_cookie.account, realm_config_data);
+    assert_eq!(realm_cookie.realm_config.account, realm_config_data);
 
     assert!(realm_config_data
         .community_token_config
@@ -77,13 +75,11 @@ async fn test_set_all_addins_for_realm_without_addins() {
 
     // Assert
 
-    let realm_config_cookie = realm_cookie.realm_config.unwrap();
-
     let realm_config_data = governance_test
-        .get_realm_config_data(&realm_config_cookie.address)
+        .get_realm_config_account(&realm_cookie.realm_config.address)
         .await;
 
-    assert_eq!(realm_config_cookie.account, realm_config_data);
+    assert_eq!(realm_cookie.realm_config.account, realm_config_data);
 
     assert!(realm_config_data
         .community_token_config
@@ -138,13 +134,11 @@ async fn test_set_all_addin_for_realm_without_council_and_addins() {
 
     // Assert
 
-    let realm_config_cookie = realm_cookie.realm_config.unwrap();
-
     let realm_config_data = governance_test
-        .get_realm_config_data(&realm_config_cookie.address)
+        .get_realm_config_account(&realm_cookie.realm_config.address)
         .await;
 
-    assert_eq!(realm_config_cookie.account, realm_config_data);
+    assert_eq!(realm_cookie.realm_config.account, realm_config_data);
 
     assert!(realm_config_data
         .community_token_config
@@ -193,13 +187,11 @@ async fn test_set_all_realm_addins_for_realm_with_all_addins() {
 
     // Assert
 
-    let realm_config_cookie = realm_cookie.realm_config.unwrap();
-
     let realm_config_data = governance_test
-        .get_realm_config_data(&realm_config_cookie.address)
+        .get_realm_config_account(&realm_cookie.realm_config.address)
         .await;
 
-    assert_eq!(realm_config_cookie.account, realm_config_data);
+    assert_eq!(realm_cookie.realm_config.account, realm_config_data);
     assert_eq!(
         realm_config_data
             .community_token_config
@@ -262,10 +254,8 @@ async fn test_set_realm_config_without_addins_for_realm_without_addins() {
 
     // Assert
 
-    let realm_config_cookie = realm_cookie.realm_config.unwrap();
-
     let realm_config_data = governance_test
-        .get_realm_config_data(&realm_config_cookie.address)
+        .get_realm_config_account(&realm_cookie.realm_config.address)
         .await;
 
     assert!(realm_config_data
@@ -307,7 +297,7 @@ async fn test_set_realm_config_without_any_addins_for_realm_with_existing_addins
     // Assert
 
     let realm_config_data = governance_test
-        .get_realm_config_data(&realm_cookie.realm_config.unwrap().address)
+        .get_realm_config_account(&realm_cookie.realm_config.address)
         .await;
 
     assert!(realm_config_data

--- a/governance/program/tests/setup_realm_with_all_addins.rs
+++ b/governance/program/tests/setup_realm_with_all_addins.rs
@@ -172,11 +172,14 @@ async fn test_set_all_realm_addins_for_realm_with_all_addins() {
 
     let max_community_voter_weight_addin_address = Pubkey::new_unique();
 
-    set_realm_config_args.max_community_voter_weight_addin =
-        Some(max_community_voter_weight_addin_address);
+    set_realm_config_args
+        .community_token_config
+        .max_voter_weight_addin = Some(max_community_voter_weight_addin_address);
 
     let community_voter_weight_addin_address = Pubkey::new_unique();
-    set_realm_config_args.community_voter_weight_addin = Some(community_voter_weight_addin_address);
+    set_realm_config_args
+        .community_token_config
+        .voter_weight_addin = Some(community_voter_weight_addin_address);
 
     // Act
 

--- a/governance/program/tests/setup_realm_with_all_addins.rs
+++ b/governance/program/tests/setup_realm_with_all_addins.rs
@@ -209,11 +209,13 @@ async fn test_set_all_realm_addins_for_realm_with_all_addins() {
 
     assert_eq!(realm_config_cookie.account, realm_config_data);
     assert_eq!(
-        realm_config_data.max_community_voter_weight_addin,
+        realm_config_data
+            .community_token_config
+            .max_voter_weight_addin,
         Some(max_community_voter_weight_addin_address)
     );
     assert_eq!(
-        realm_config_data.community_voter_weight_addin,
+        realm_config_data.community_token_config.voter_weight_addin,
         Some(community_voter_weight_addin_address)
     );
 }
@@ -302,6 +304,12 @@ async fn test_set_realm_config_without_any_addins_for_realm_with_existing_addins
         .get_realm_config_data(&realm_cookie.realm_config.unwrap().address)
         .await;
 
-    assert!(realm_config_data.max_community_voter_weight_addin.is_none());
-    assert!(realm_config_data.community_voter_weight_addin.is_none());
+    assert!(realm_config_data
+        .community_token_config
+        .max_voter_weight_addin
+        .is_none());
+    assert!(realm_config_data
+        .community_token_config
+        .voter_weight_addin
+        .is_none());
 }

--- a/governance/program/tests/setup_realm_with_all_addins.rs
+++ b/governance/program/tests/setup_realm_with_all_addins.rs
@@ -48,11 +48,13 @@ async fn test_set_all_addins_for_realm_without_addins() {
 
     set_realm_config_args
         .realm_config_args
-        .use_max_community_voter_weight_addin = false;
+        .community_token_config_args
+        .use_max_voter_weight_addin = false;
 
     set_realm_config_args
         .realm_config_args
-        .use_community_voter_weight_addin = false;
+        .community_token_config_args
+        .use_voter_weight_addin = false;
 
     let mut realm_cookie = governance_test
         .with_realm_using_config_args(&set_realm_config_args)
@@ -60,11 +62,13 @@ async fn test_set_all_addins_for_realm_without_addins() {
 
     set_realm_config_args
         .realm_config_args
-        .use_community_voter_weight_addin = true;
+        .community_token_config_args
+        .use_voter_weight_addin = true;
 
     set_realm_config_args
         .realm_config_args
-        .use_max_community_voter_weight_addin = true;
+        .community_token_config_args
+        .use_max_voter_weight_addin = true;
 
     // Act
 
@@ -105,11 +109,13 @@ async fn test_set_all_addin_for_realm_without_council_and_addins() {
 
     set_realm_config_args
         .realm_config_args
-        .use_community_voter_weight_addin = false;
+        .community_token_config_args
+        .use_voter_weight_addin = false;
 
     set_realm_config_args
         .realm_config_args
-        .use_max_community_voter_weight_addin = false;
+        .community_token_config_args
+        .use_max_voter_weight_addin = false;
 
     set_realm_config_args.realm_config_args.use_council_mint = false;
 
@@ -119,11 +125,13 @@ async fn test_set_all_addin_for_realm_without_council_and_addins() {
 
     set_realm_config_args
         .realm_config_args
-        .use_max_community_voter_weight_addin = true;
+        .community_token_config_args
+        .use_max_voter_weight_addin = true;
 
     set_realm_config_args
         .realm_config_args
-        .use_community_voter_weight_addin = true;
+        .community_token_config_args
+        .use_voter_weight_addin = true;
 
     // Act
 
@@ -166,11 +174,13 @@ async fn test_set_all_realm_addins_for_realm_with_all_addins() {
 
     set_realm_config_args
         .realm_config_args
-        .use_max_community_voter_weight_addin = true;
+        .community_token_config_args
+        .use_max_voter_weight_addin = true;
 
     set_realm_config_args
         .realm_config_args
-        .use_community_voter_weight_addin = true;
+        .community_token_config_args
+        .use_voter_weight_addin = true;
 
     let max_community_voter_weight_addin_address = Pubkey::new_unique();
 
@@ -229,11 +239,13 @@ async fn test_set_realm_config_without_addins_for_realm_without_addins() {
 
     set_realm_config_args
         .realm_config_args
-        .use_max_community_voter_weight_addin = false;
+        .community_token_config_args
+        .use_max_voter_weight_addin = false;
 
     set_realm_config_args
         .realm_config_args
-        .use_community_voter_weight_addin = false;
+        .community_token_config_args
+        .use_voter_weight_addin = false;
 
     let mut realm_cookie = governance_test
         .with_realm_using_config_args(&set_realm_config_args)
@@ -241,11 +253,13 @@ async fn test_set_realm_config_without_addins_for_realm_without_addins() {
 
     set_realm_config_args
         .realm_config_args
-        .use_max_community_voter_weight_addin = false;
+        .community_token_config_args
+        .use_max_voter_weight_addin = false;
 
     set_realm_config_args
         .realm_config_args
-        .use_community_voter_weight_addin = false;
+        .community_token_config_args
+        .use_voter_weight_addin = false;
 
     // Act
 
@@ -279,11 +293,13 @@ async fn test_set_realm_config_without_any_addins_for_realm_with_existing_addins
 
     set_realm_config_args
         .realm_config_args
-        .use_max_community_voter_weight_addin = false;
+        .community_token_config_args
+        .use_max_voter_weight_addin = false;
 
     set_realm_config_args
         .realm_config_args
-        .use_community_voter_weight_addin = false;
+        .community_token_config_args
+        .use_voter_weight_addin = false;
 
     // Act
 

--- a/governance/program/tests/setup_realm_with_max_voter_weight_addin.rs
+++ b/governance/program/tests/setup_realm_with_max_voter_weight_addin.rs
@@ -141,8 +141,9 @@ async fn test_set_realm_max_voter_weight_addin_for_realm_with_existing_voter_wei
         .use_max_voter_weight_addin = true;
 
     let max_community_voter_weight_addin_address = Pubkey::new_unique();
-    set_realm_config_args.max_community_voter_weight_addin =
-        Some(max_community_voter_weight_addin_address);
+    set_realm_config_args
+        .community_token_config
+        .max_voter_weight_addin = Some(max_community_voter_weight_addin_address);
 
     // Act
 

--- a/governance/program/tests/setup_realm_with_max_voter_weight_addin.rs
+++ b/governance/program/tests/setup_realm_with_max_voter_weight_addin.rs
@@ -18,13 +18,11 @@ async fn test_create_realm_with_max_voter_weight_addin() {
 
     // Assert
 
-    let realm_config_cookie = realm_cookie.realm_config.unwrap();
-
     let realm_config_data = governance_test
-        .get_realm_config_data(&realm_config_cookie.address)
+        .get_realm_config_account(&realm_cookie.realm_config.address)
         .await;
 
-    assert_eq!(realm_config_cookie.account, realm_config_data);
+    assert_eq!(realm_cookie.realm_config.account, realm_config_data);
 
     assert!(realm_config_data
         .community_token_config
@@ -67,13 +65,11 @@ async fn test_set_realm_max_voter_weight_addin_for_realm_without_addins() {
 
     // Assert
 
-    let realm_config_cookie = realm_cookie.realm_config.unwrap();
-
     let realm_config_data = governance_test
-        .get_realm_config_data(&realm_config_cookie.address)
+        .get_realm_config_account(&realm_cookie.realm_config.address)
         .await;
 
-    assert_eq!(realm_config_cookie.account, realm_config_data);
+    assert_eq!(realm_cookie.realm_config.account, realm_config_data);
 
     assert!(realm_config_data
         .community_token_config
@@ -118,13 +114,11 @@ async fn test_set_realm_max_voter_weight_addin_for_realm_without_council_and_add
 
     // Assert
 
-    let realm_config_cookie = realm_cookie.realm_config.unwrap();
-
     let realm_config_data = governance_test
-        .get_realm_config_data(&realm_config_cookie.address)
+        .get_realm_config_account(&realm_cookie.realm_config.address)
         .await;
 
-    assert_eq!(realm_config_cookie.account, realm_config_data);
+    assert_eq!(realm_cookie.realm_config.account, realm_config_data);
 
     assert!(realm_config_data
         .community_token_config
@@ -159,13 +153,11 @@ async fn test_set_realm_max_voter_weight_addin_for_realm_with_existing_voter_wei
 
     // Assert
 
-    let realm_config_cookie = realm_cookie.realm_config.unwrap();
-
     let realm_config_data = governance_test
-        .get_realm_config_data(&realm_config_cookie.address)
+        .get_realm_config_account(&realm_cookie.realm_config.address)
         .await;
 
-    assert_eq!(realm_config_cookie.account, realm_config_data);
+    assert_eq!(realm_cookie.realm_config.account, realm_config_data);
     assert_eq!(
         realm_config_data
             .community_token_config
@@ -209,10 +201,8 @@ async fn test_set_realm_config_with_no_max_voter_weight_addin_for_realm_without_
 
     // Assert
 
-    let realm_config_cookie = realm_cookie.realm_config.unwrap();
-
     let realm_config_data = governance_test
-        .get_realm_config_data(&realm_config_cookie.address)
+        .get_realm_config_account(&realm_cookie.realm_config.address)
         .await;
 
     assert!(realm_config_data
@@ -244,7 +234,7 @@ async fn test_set_realm_config_with_no_max_voter_weight_addin_for_realm_with_exi
     // Assert
 
     let realm_config_data = governance_test
-        .get_realm_config_data(&realm_cookie.realm_config.unwrap().address)
+        .get_realm_config_account(&realm_cookie.realm_config.address)
         .await;
 
     assert!(realm_config_data

--- a/governance/program/tests/setup_realm_with_max_voter_weight_addin.rs
+++ b/governance/program/tests/setup_realm_with_max_voter_weight_addin.rs
@@ -7,14 +7,24 @@ mod program_test;
 
 use program_test::*;
 
+use crate::program_test::args::RealmSetupArgs;
+
 #[tokio::test]
 async fn test_create_realm_with_max_voter_weight_addin() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin().await;
 
+    let mut set_realm_config_args = RealmSetupArgs::default();
+
+    set_realm_config_args
+        .community_token_config_args
+        .max_voter_weight_addin = governance_test.max_voter_weight_addin_id;
+
     // Act
 
-    let realm_cookie = governance_test.with_realm().await;
+    let realm_cookie = governance_test
+        .with_realm_using_config_args(&set_realm_config_args)
+        .await;
 
     // Assert
 
@@ -35,26 +45,15 @@ async fn test_set_realm_max_voter_weight_addin_for_realm_without_addins() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin().await;
 
-    let mut set_realm_config_args = governance_test.get_default_set_realm_config_args();
-
-    set_realm_config_args
-        .realm_config_args
-        .community_token_config_args
-        .use_max_voter_weight_addin = false;
-
-    set_realm_config_args
-        .realm_config_args
-        .community_token_config_args
-        .use_voter_weight_addin = false;
+    let mut set_realm_config_args = RealmSetupArgs::default();
 
     let mut realm_cookie = governance_test
         .with_realm_using_config_args(&set_realm_config_args)
         .await;
 
     set_realm_config_args
-        .realm_config_args
         .community_token_config_args
-        .use_max_voter_weight_addin = true;
+        .max_voter_weight_addin = governance_test.max_voter_weight_addin_id;
 
     // Act
 
@@ -82,28 +81,17 @@ async fn test_set_realm_max_voter_weight_addin_for_realm_without_council_and_add
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin().await;
 
-    let mut set_realm_config_args = governance_test.get_default_set_realm_config_args();
+    let mut set_realm_config_args = RealmSetupArgs::default();
 
-    set_realm_config_args
-        .realm_config_args
-        .community_token_config_args
-        .use_voter_weight_addin = false;
-
-    set_realm_config_args
-        .realm_config_args
-        .community_token_config_args
-        .use_max_voter_weight_addin = false;
-
-    set_realm_config_args.realm_config_args.use_council_mint = false;
+    set_realm_config_args.use_council_mint = false;
 
     let mut realm_cookie = governance_test
         .with_realm_using_config_args(&set_realm_config_args)
         .await;
 
     set_realm_config_args
-        .realm_config_args
         .community_token_config_args
-        .use_max_voter_weight_addin = true;
+        .max_voter_weight_addin = governance_test.max_voter_weight_addin_id;
 
     // Act
 
@@ -133,16 +121,15 @@ async fn test_set_realm_max_voter_weight_addin_for_realm_with_existing_voter_wei
 
     let mut realm_cookie = governance_test.with_realm().await;
 
-    let mut set_realm_config_args = governance_test.get_default_set_realm_config_args();
+    let mut set_realm_config_args = RealmSetupArgs::default();
 
     set_realm_config_args
-        .realm_config_args
         .community_token_config_args
-        .use_max_voter_weight_addin = true;
+        .max_voter_weight_addin = governance_test.max_voter_weight_addin_id;
 
     let max_community_voter_weight_addin_address = Pubkey::new_unique();
     set_realm_config_args
-        .community_token_config
+        .community_token_config_args
         .max_voter_weight_addin = Some(max_community_voter_weight_addin_address);
 
     // Act
@@ -177,21 +164,15 @@ async fn test_set_realm_config_with_no_max_voter_weight_addin_for_realm_without_
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin().await;
 
-    let mut set_realm_config_args = governance_test.get_default_set_realm_config_args();
-
-    set_realm_config_args
-        .realm_config_args
-        .community_token_config_args
-        .use_max_voter_weight_addin = false;
+    let mut set_realm_config_args = RealmSetupArgs::default();
 
     let mut realm_cookie = governance_test
         .with_realm_using_config_args(&set_realm_config_args)
         .await;
 
     set_realm_config_args
-        .realm_config_args
         .community_token_config_args
-        .use_max_voter_weight_addin = false;
+        .max_voter_weight_addin = None;
 
     // Act
 
@@ -218,12 +199,7 @@ async fn test_set_realm_config_with_no_max_voter_weight_addin_for_realm_with_exi
     let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin().await;
     let mut realm_cookie = governance_test.with_realm().await;
 
-    let mut set_realm_config_args = governance_test.get_default_set_realm_config_args();
-
-    set_realm_config_args
-        .realm_config_args
-        .community_token_config_args
-        .use_max_voter_weight_addin = false;
+    let set_realm_config_args = RealmSetupArgs::default();
 
     // Act
 

--- a/governance/program/tests/setup_realm_with_max_voter_weight_addin.rs
+++ b/governance/program/tests/setup_realm_with_max_voter_weight_addin.rs
@@ -18,16 +18,6 @@ async fn test_create_realm_with_max_voter_weight_addin() {
 
     // Assert
 
-    let realm_account_data = governance_test
-        .get_realm_account(&realm_cookie.address)
-        .await;
-
-    assert!(
-        realm_account_data
-            .config
-            .use_max_community_voter_weight_addin
-    );
-
     let realm_config_cookie = realm_cookie.realm_config.unwrap();
 
     let realm_config_data = governance_test
@@ -35,6 +25,11 @@ async fn test_create_realm_with_max_voter_weight_addin() {
         .await;
 
     assert_eq!(realm_config_cookie.account, realm_config_data);
+
+    assert!(realm_config_data
+        .community_token_config
+        .max_voter_weight_addin
+        .is_some());
 }
 
 #[tokio::test]
@@ -72,16 +67,6 @@ async fn test_set_realm_max_voter_weight_addin_for_realm_without_addins() {
 
     // Assert
 
-    let realm_account_data = governance_test
-        .get_realm_account(&realm_cookie.address)
-        .await;
-
-    assert!(
-        realm_account_data
-            .config
-            .use_max_community_voter_weight_addin
-    );
-
     let realm_config_cookie = realm_cookie.realm_config.unwrap();
 
     let realm_config_data = governance_test
@@ -89,6 +74,11 @@ async fn test_set_realm_max_voter_weight_addin_for_realm_without_addins() {
         .await;
 
     assert_eq!(realm_config_cookie.account, realm_config_data);
+
+    assert!(realm_config_data
+        .community_token_config
+        .max_voter_weight_addin
+        .is_some());
 }
 
 #[tokio::test]
@@ -128,16 +118,6 @@ async fn test_set_realm_max_voter_weight_addin_for_realm_without_council_and_add
 
     // Assert
 
-    let realm_account_data = governance_test
-        .get_realm_account(&realm_cookie.address)
-        .await;
-
-    assert!(
-        realm_account_data
-            .config
-            .use_max_community_voter_weight_addin
-    );
-
     let realm_config_cookie = realm_cookie.realm_config.unwrap();
 
     let realm_config_data = governance_test
@@ -145,6 +125,11 @@ async fn test_set_realm_max_voter_weight_addin_for_realm_without_council_and_add
         .await;
 
     assert_eq!(realm_config_cookie.account, realm_config_data);
+
+    assert!(realm_config_data
+        .community_token_config
+        .max_voter_weight_addin
+        .is_some());
 }
 
 #[tokio::test]
@@ -174,16 +159,6 @@ async fn test_set_realm_max_voter_weight_addin_for_realm_with_existing_voter_wei
 
     // Assert
 
-    let realm_account_data = governance_test
-        .get_realm_account(&realm_cookie.address)
-        .await;
-
-    assert!(
-        realm_account_data
-            .config
-            .use_max_community_voter_weight_addin
-    );
-
     let realm_config_cookie = realm_cookie.realm_config.unwrap();
 
     let realm_config_data = governance_test
@@ -197,6 +172,11 @@ async fn test_set_realm_max_voter_weight_addin_for_realm_with_existing_voter_wei
             .max_voter_weight_addin,
         Some(max_community_voter_weight_addin_address)
     );
+
+    assert!(realm_config_data
+        .community_token_config
+        .max_voter_weight_addin
+        .is_some());
 }
 
 #[tokio::test]
@@ -229,15 +209,16 @@ async fn test_set_realm_config_with_no_max_voter_weight_addin_for_realm_without_
 
     // Assert
 
-    let realm_account_data = governance_test
-        .get_realm_account(&realm_cookie.address)
+    let realm_config_cookie = realm_cookie.realm_config.unwrap();
+
+    let realm_config_data = governance_test
+        .get_realm_config_data(&realm_config_cookie.address)
         .await;
 
-    assert!(
-        !realm_account_data
-            .config
-            .use_max_community_voter_weight_addin
-    );
+    assert!(realm_config_data
+        .community_token_config
+        .max_voter_weight_addin
+        .is_none());
 }
 
 #[tokio::test]
@@ -262,12 +243,6 @@ async fn test_set_realm_config_with_no_max_voter_weight_addin_for_realm_with_exi
 
     // Assert
 
-    let realm_account_data = governance_test
-        .get_realm_account(&realm_cookie.address)
-        .await;
-
-    assert!(!realm_account_data.config.use_community_voter_weight_addin);
-
     let realm_config_data = governance_test
         .get_realm_config_data(&realm_cookie.realm_config.unwrap().address)
         .await;
@@ -275,5 +250,10 @@ async fn test_set_realm_config_with_no_max_voter_weight_addin_for_realm_with_exi
     assert!(realm_config_data
         .community_token_config
         .max_voter_weight_addin
+        .is_none());
+
+    assert!(realm_config_data
+        .community_token_config
+        .voter_weight_addin
         .is_none());
 }

--- a/governance/program/tests/setup_realm_with_max_voter_weight_addin.rs
+++ b/governance/program/tests/setup_realm_with_max_voter_weight_addin.rs
@@ -14,16 +14,16 @@ async fn test_create_realm_with_max_voter_weight_addin() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin().await;
 
-    let mut set_realm_config_args = RealmSetupArgs::default();
+    let mut realm_setup_args = RealmSetupArgs::default();
 
-    set_realm_config_args
+    realm_setup_args
         .community_token_config_args
         .max_voter_weight_addin = governance_test.max_voter_weight_addin_id;
 
     // Act
 
     let realm_cookie = governance_test
-        .with_realm_using_config_args(&set_realm_config_args)
+        .with_realm_using_args(&realm_setup_args)
         .await;
 
     // Assert
@@ -45,20 +45,20 @@ async fn test_set_realm_max_voter_weight_addin_for_realm_without_addins() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin().await;
 
-    let mut set_realm_config_args = RealmSetupArgs::default();
+    let mut realm_setup_args = RealmSetupArgs::default();
 
     let mut realm_cookie = governance_test
-        .with_realm_using_config_args(&set_realm_config_args)
+        .with_realm_using_args(&realm_setup_args)
         .await;
 
-    set_realm_config_args
+    realm_setup_args
         .community_token_config_args
         .max_voter_weight_addin = governance_test.max_voter_weight_addin_id;
 
     // Act
 
     governance_test
-        .set_realm_config(&mut realm_cookie, &set_realm_config_args)
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
         .await
         .unwrap();
 
@@ -81,22 +81,22 @@ async fn test_set_realm_max_voter_weight_addin_for_realm_without_council_and_add
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin().await;
 
-    let mut set_realm_config_args = RealmSetupArgs::default();
+    let mut realm_setup_args = RealmSetupArgs::default();
 
-    set_realm_config_args.use_council_mint = false;
+    realm_setup_args.use_council_mint = false;
 
     let mut realm_cookie = governance_test
-        .with_realm_using_config_args(&set_realm_config_args)
+        .with_realm_using_args(&realm_setup_args)
         .await;
 
-    set_realm_config_args
+    realm_setup_args
         .community_token_config_args
         .max_voter_weight_addin = governance_test.max_voter_weight_addin_id;
 
     // Act
 
     governance_test
-        .set_realm_config(&mut realm_cookie, &set_realm_config_args)
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
         .await
         .unwrap();
 
@@ -121,21 +121,21 @@ async fn test_set_realm_max_voter_weight_addin_for_realm_with_existing_voter_wei
 
     let mut realm_cookie = governance_test.with_realm().await;
 
-    let mut set_realm_config_args = RealmSetupArgs::default();
+    let mut realm_setup_args = RealmSetupArgs::default();
 
-    set_realm_config_args
+    realm_setup_args
         .community_token_config_args
         .max_voter_weight_addin = governance_test.max_voter_weight_addin_id;
 
     let max_community_voter_weight_addin_address = Pubkey::new_unique();
-    set_realm_config_args
+    realm_setup_args
         .community_token_config_args
         .max_voter_weight_addin = Some(max_community_voter_weight_addin_address);
 
     // Act
 
     governance_test
-        .set_realm_config(&mut realm_cookie, &set_realm_config_args)
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
         .await
         .unwrap();
 
@@ -164,20 +164,20 @@ async fn test_set_realm_config_with_no_max_voter_weight_addin_for_realm_without_
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin().await;
 
-    let mut set_realm_config_args = RealmSetupArgs::default();
+    let mut realm_setup_args = RealmSetupArgs::default();
 
     let mut realm_cookie = governance_test
-        .with_realm_using_config_args(&set_realm_config_args)
+        .with_realm_using_args(&realm_setup_args)
         .await;
 
-    set_realm_config_args
+    realm_setup_args
         .community_token_config_args
         .max_voter_weight_addin = None;
 
     // Act
 
     governance_test
-        .set_realm_config(&mut realm_cookie, &set_realm_config_args)
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
         .await
         .unwrap();
 
@@ -199,12 +199,12 @@ async fn test_set_realm_config_with_no_max_voter_weight_addin_for_realm_with_exi
     let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin().await;
     let mut realm_cookie = governance_test.with_realm().await;
 
-    let set_realm_config_args = RealmSetupArgs::default();
+    let realm_setup_args = RealmSetupArgs::default();
 
     // Act
 
     governance_test
-        .set_realm_config(&mut realm_cookie, &set_realm_config_args)
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
         .await
         .unwrap();
 

--- a/governance/program/tests/setup_realm_with_max_voter_weight_addin.rs
+++ b/governance/program/tests/setup_realm_with_max_voter_weight_addin.rs
@@ -46,11 +46,13 @@ async fn test_set_realm_max_voter_weight_addin_for_realm_without_addins() {
 
     set_realm_config_args
         .realm_config_args
-        .use_max_community_voter_weight_addin = false;
+        .community_token_config_args
+        .use_max_voter_weight_addin = false;
 
     set_realm_config_args
         .realm_config_args
-        .use_community_voter_weight_addin = false;
+        .community_token_config_args
+        .use_voter_weight_addin = false;
 
     let mut realm_cookie = governance_test
         .with_realm_using_config_args(&set_realm_config_args)
@@ -58,7 +60,8 @@ async fn test_set_realm_max_voter_weight_addin_for_realm_without_addins() {
 
     set_realm_config_args
         .realm_config_args
-        .use_max_community_voter_weight_addin = true;
+        .community_token_config_args
+        .use_max_voter_weight_addin = true;
 
     // Act
 
@@ -97,11 +100,13 @@ async fn test_set_realm_max_voter_weight_addin_for_realm_without_council_and_add
 
     set_realm_config_args
         .realm_config_args
-        .use_community_voter_weight_addin = false;
+        .community_token_config_args
+        .use_voter_weight_addin = false;
 
     set_realm_config_args
         .realm_config_args
-        .use_max_community_voter_weight_addin = false;
+        .community_token_config_args
+        .use_max_voter_weight_addin = false;
 
     set_realm_config_args.realm_config_args.use_council_mint = false;
 
@@ -111,7 +116,8 @@ async fn test_set_realm_max_voter_weight_addin_for_realm_without_council_and_add
 
     set_realm_config_args
         .realm_config_args
-        .use_max_community_voter_weight_addin = true;
+        .community_token_config_args
+        .use_max_voter_weight_addin = true;
 
     // Act
 
@@ -152,7 +158,8 @@ async fn test_set_realm_max_voter_weight_addin_for_realm_with_existing_voter_wei
 
     set_realm_config_args
         .realm_config_args
-        .use_max_community_voter_weight_addin = true;
+        .community_token_config_args
+        .use_max_voter_weight_addin = true;
 
     let max_community_voter_weight_addin_address = Pubkey::new_unique();
     set_realm_config_args.max_community_voter_weight_addin =
@@ -201,7 +208,8 @@ async fn test_set_realm_config_with_no_max_voter_weight_addin_for_realm_without_
 
     set_realm_config_args
         .realm_config_args
-        .use_max_community_voter_weight_addin = false;
+        .community_token_config_args
+        .use_max_voter_weight_addin = false;
 
     let mut realm_cookie = governance_test
         .with_realm_using_config_args(&set_realm_config_args)
@@ -209,7 +217,8 @@ async fn test_set_realm_config_with_no_max_voter_weight_addin_for_realm_without_
 
     set_realm_config_args
         .realm_config_args
-        .use_max_community_voter_weight_addin = false;
+        .community_token_config_args
+        .use_max_voter_weight_addin = false;
 
     // Act
 
@@ -241,7 +250,8 @@ async fn test_set_realm_config_with_no_max_voter_weight_addin_for_realm_with_exi
 
     set_realm_config_args
         .realm_config_args
-        .use_max_community_voter_weight_addin = false;
+        .community_token_config_args
+        .use_max_voter_weight_addin = false;
 
     // Act
 

--- a/governance/program/tests/setup_realm_with_max_voter_weight_addin.rs
+++ b/governance/program/tests/setup_realm_with_max_voter_weight_addin.rs
@@ -185,7 +185,9 @@ async fn test_set_realm_max_voter_weight_addin_for_realm_with_existing_voter_wei
 
     assert_eq!(realm_config_cookie.account, realm_config_data);
     assert_eq!(
-        realm_config_data.max_community_voter_weight_addin,
+        realm_config_data
+            .community_token_config
+            .max_voter_weight_addin,
         Some(max_community_voter_weight_addin_address)
     );
 }
@@ -260,5 +262,8 @@ async fn test_set_realm_config_with_no_max_voter_weight_addin_for_realm_with_exi
         .get_realm_config_data(&realm_cookie.realm_config.unwrap().address)
         .await;
 
-    assert!(realm_config_data.max_community_voter_weight_addin.is_none());
+    assert!(realm_config_data
+        .community_token_config
+        .max_voter_weight_addin
+        .is_none());
 }

--- a/governance/program/tests/setup_realm_with_voter_weight_addin.rs
+++ b/governance/program/tests/setup_realm_with_voter_weight_addin.rs
@@ -18,13 +18,11 @@ async fn test_create_realm_with_voter_weight_addin() {
 
     // Assert
 
-    let realm_config_cookie = realm_cookie.realm_config.unwrap();
-
     let realm_config_data = governance_test
-        .get_realm_config_data(&realm_config_cookie.address)
+        .get_realm_config_account(&realm_cookie.realm_config.address)
         .await;
 
-    assert_eq!(realm_config_cookie.account, realm_config_data);
+    assert_eq!(realm_cookie.realm_config.account, realm_config_data);
 
     assert!(realm_config_data
         .community_token_config
@@ -61,13 +59,11 @@ async fn test_set_realm_voter_weight_addin_for_realm_without_addins() {
 
     // Assert
 
-    let realm_config_cookie = realm_cookie.realm_config.unwrap();
-
     let realm_config_data = governance_test
-        .get_realm_config_data(&realm_config_cookie.address)
+        .get_realm_config_account(&realm_cookie.realm_config.address)
         .await;
 
-    assert_eq!(realm_config_cookie.account, realm_config_data);
+    assert_eq!(realm_cookie.realm_config.account, realm_config_data);
 
     assert!(realm_config_data
         .community_token_config
@@ -105,13 +101,11 @@ async fn test_set_realm_voter_weight_addin_for_realm_without_council_and_addins(
 
     // Assert
 
-    let realm_config_cookie = realm_cookie.realm_config.unwrap();
-
     let realm_config_data = governance_test
-        .get_realm_config_data(&realm_config_cookie.address)
+        .get_realm_config_account(&realm_cookie.realm_config.address)
         .await;
 
-    assert_eq!(realm_config_cookie.account, realm_config_data);
+    assert_eq!(realm_cookie.realm_config.account, realm_config_data);
 
     assert!(realm_config_data
         .community_token_config
@@ -145,13 +139,11 @@ async fn test_set_realm_voter_weight_addin_for_realm_with_existing_voter_weight_
 
     // Assert
 
-    let realm_config_cookie = realm_cookie.realm_config.unwrap();
-
     let realm_config_data = governance_test
-        .get_realm_config_data(&realm_config_cookie.address)
+        .get_realm_config_account(&realm_cookie.realm_config.address)
         .await;
 
-    assert_eq!(realm_config_cookie.account, realm_config_data);
+    assert_eq!(realm_cookie.realm_config.account, realm_config_data);
     assert_eq!(
         realm_config_data.community_token_config.voter_weight_addin,
         Some(community_voter_weight_addin_address)
@@ -192,10 +184,8 @@ async fn test_set_realm_config_with_no_voter_weight_addin_for_realm_without_addi
 
     // Assert
 
-    let realm_config_cookie = realm_cookie.realm_config.unwrap();
-
     let realm_config_data = governance_test
-        .get_realm_config_data(&realm_config_cookie.address)
+        .get_realm_config_account(&realm_cookie.realm_config.address)
         .await;
 
     assert!(realm_config_data
@@ -226,7 +216,7 @@ async fn test_set_realm_config_with_no_voter_weight_addin_for_realm_with_existin
     // Assert
 
     let realm_config_data = governance_test
-        .get_realm_config_data(&realm_cookie.realm_config.unwrap().address)
+        .get_realm_config_account(&realm_cookie.realm_config.address)
         .await;
 
     assert!(realm_config_data

--- a/governance/program/tests/setup_realm_with_voter_weight_addin.rs
+++ b/governance/program/tests/setup_realm_with_voter_weight_addin.rs
@@ -18,12 +18,6 @@ async fn test_create_realm_with_voter_weight_addin() {
 
     // Assert
 
-    let realm_account_data = governance_test
-        .get_realm_account(&realm_cookie.address)
-        .await;
-
-    assert!(realm_account_data.config.use_community_voter_weight_addin);
-
     let realm_config_cookie = realm_cookie.realm_config.unwrap();
 
     let realm_config_data = governance_test
@@ -31,6 +25,11 @@ async fn test_create_realm_with_voter_weight_addin() {
         .await;
 
     assert_eq!(realm_config_cookie.account, realm_config_data);
+
+    assert!(realm_config_data
+        .community_token_config
+        .voter_weight_addin
+        .is_some());
 }
 
 #[tokio::test]
@@ -62,12 +61,6 @@ async fn test_set_realm_voter_weight_addin_for_realm_without_addins() {
 
     // Assert
 
-    let realm_account_data = governance_test
-        .get_realm_account(&realm_cookie.address)
-        .await;
-
-    assert!(realm_account_data.config.use_community_voter_weight_addin);
-
     let realm_config_cookie = realm_cookie.realm_config.unwrap();
 
     let realm_config_data = governance_test
@@ -75,6 +68,11 @@ async fn test_set_realm_voter_weight_addin_for_realm_without_addins() {
         .await;
 
     assert_eq!(realm_config_cookie.account, realm_config_data);
+
+    assert!(realm_config_data
+        .community_token_config
+        .voter_weight_addin
+        .is_some());
 }
 
 #[tokio::test]
@@ -107,12 +105,6 @@ async fn test_set_realm_voter_weight_addin_for_realm_without_council_and_addins(
 
     // Assert
 
-    let realm_account_data = governance_test
-        .get_realm_account(&realm_cookie.address)
-        .await;
-
-    assert!(realm_account_data.config.use_community_voter_weight_addin);
-
     let realm_config_cookie = realm_cookie.realm_config.unwrap();
 
     let realm_config_data = governance_test
@@ -120,6 +112,11 @@ async fn test_set_realm_voter_weight_addin_for_realm_without_council_and_addins(
         .await;
 
     assert_eq!(realm_config_cookie.account, realm_config_data);
+
+    assert!(realm_config_data
+        .community_token_config
+        .voter_weight_addin
+        .is_some());
 }
 
 #[tokio::test]
@@ -148,12 +145,6 @@ async fn test_set_realm_voter_weight_addin_for_realm_with_existing_voter_weight_
 
     // Assert
 
-    let realm_account_data = governance_test
-        .get_realm_account(&realm_cookie.address)
-        .await;
-
-    assert!(realm_account_data.config.use_community_voter_weight_addin);
-
     let realm_config_cookie = realm_cookie.realm_config.unwrap();
 
     let realm_config_data = governance_test
@@ -165,6 +156,11 @@ async fn test_set_realm_voter_weight_addin_for_realm_with_existing_voter_weight_
         realm_config_data.community_token_config.voter_weight_addin,
         Some(community_voter_weight_addin_address)
     );
+
+    assert!(realm_config_data
+        .community_token_config
+        .voter_weight_addin
+        .is_some());
 }
 
 #[tokio::test]
@@ -196,11 +192,16 @@ async fn test_set_realm_config_with_no_voter_weight_addin_for_realm_without_addi
 
     // Assert
 
-    let realm_account_data = governance_test
-        .get_realm_account(&realm_cookie.address)
+    let realm_config_cookie = realm_cookie.realm_config.unwrap();
+
+    let realm_config_data = governance_test
+        .get_realm_config_data(&realm_config_cookie.address)
         .await;
 
-    assert!(!realm_account_data.config.use_community_voter_weight_addin);
+    assert!(realm_config_data
+        .community_token_config
+        .voter_weight_addin
+        .is_none());
 }
 
 #[tokio::test]
@@ -223,12 +224,6 @@ async fn test_set_realm_config_with_no_voter_weight_addin_for_realm_with_existin
         .unwrap();
 
     // Assert
-
-    let realm_account_data = governance_test
-        .get_realm_account(&realm_cookie.address)
-        .await;
-
-    assert!(!realm_account_data.config.use_community_voter_weight_addin);
 
     let realm_config_data = governance_test
         .get_realm_config_data(&realm_cookie.realm_config.unwrap().address)

--- a/governance/program/tests/setup_realm_with_voter_weight_addin.rs
+++ b/governance/program/tests/setup_realm_with_voter_weight_addin.rs
@@ -128,7 +128,9 @@ async fn test_set_realm_voter_weight_addin_for_realm_with_existing_voter_weight_
         .use_voter_weight_addin = true;
 
     let community_voter_weight_addin_address = Pubkey::new_unique();
-    set_realm_config_args.community_voter_weight_addin = Some(community_voter_weight_addin_address);
+    set_realm_config_args
+        .community_token_config
+        .voter_weight_addin = Some(community_voter_weight_addin_address);
 
     // Act
 

--- a/governance/program/tests/setup_realm_with_voter_weight_addin.rs
+++ b/governance/program/tests/setup_realm_with_voter_weight_addin.rs
@@ -13,16 +13,16 @@ async fn test_create_realm_with_voter_weight_addin() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
 
-    let mut set_realm_config_args = RealmSetupArgs::default();
+    let mut realm_setup_args = RealmSetupArgs::default();
 
-    set_realm_config_args
+    realm_setup_args
         .community_token_config_args
         .voter_weight_addin = governance_test.voter_weight_addin_id;
 
     // Act
 
     let realm_cookie = governance_test
-        .with_realm_using_config_args(&set_realm_config_args)
+        .with_realm_using_args(&realm_setup_args)
         .await;
 
     // Assert
@@ -44,23 +44,23 @@ async fn test_set_realm_voter_weight_addin_for_realm_without_addins() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
 
-    let mut set_realm_config_args = RealmSetupArgs::default();
-    set_realm_config_args
+    let mut realm_setup_args = RealmSetupArgs::default();
+    realm_setup_args
         .community_token_config_args
         .voter_weight_addin = None;
 
     let mut realm_cookie = governance_test
-        .with_realm_using_config_args(&set_realm_config_args)
+        .with_realm_using_args(&realm_setup_args)
         .await;
 
-    set_realm_config_args
+    realm_setup_args
         .community_token_config_args
         .voter_weight_addin = governance_test.voter_weight_addin_id;
 
     // Act
 
     governance_test
-        .set_realm_config(&mut realm_cookie, &set_realm_config_args)
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
         .await
         .unwrap();
 
@@ -83,22 +83,22 @@ async fn test_set_realm_voter_weight_addin_for_realm_without_council_and_addins(
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
 
-    let mut set_realm_config_args = RealmSetupArgs::default();
+    let mut realm_setup_args = RealmSetupArgs::default();
 
-    set_realm_config_args.use_council_mint = false;
+    realm_setup_args.use_council_mint = false;
 
     let mut realm_cookie = governance_test
-        .with_realm_using_config_args(&set_realm_config_args)
+        .with_realm_using_args(&realm_setup_args)
         .await;
 
-    set_realm_config_args
+    realm_setup_args
         .community_token_config_args
         .voter_weight_addin = governance_test.voter_weight_addin_id;
 
     // Act
 
     governance_test
-        .set_realm_config(&mut realm_cookie, &set_realm_config_args)
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
         .await
         .unwrap();
 
@@ -121,25 +121,25 @@ async fn test_set_realm_voter_weight_addin_for_realm_with_existing_voter_weight_
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
 
-    let mut set_realm_config_args = RealmSetupArgs::default();
+    let mut realm_setup_args = RealmSetupArgs::default();
 
-    set_realm_config_args
+    realm_setup_args
         .community_token_config_args
         .voter_weight_addin = governance_test.voter_weight_addin_id;
 
     let mut realm_cookie = governance_test
-        .with_realm_using_config_args(&set_realm_config_args)
+        .with_realm_using_args(&realm_setup_args)
         .await;
 
     let community_voter_weight_addin_address = Pubkey::new_unique();
-    set_realm_config_args
+    realm_setup_args
         .community_token_config_args
         .voter_weight_addin = Some(community_voter_weight_addin_address);
 
     // Act
 
     governance_test
-        .set_realm_config(&mut realm_cookie, &set_realm_config_args)
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
         .await
         .unwrap();
 
@@ -166,24 +166,24 @@ async fn test_set_realm_config_with_no_voter_weight_addin_for_realm_without_addi
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
 
-    let mut set_realm_config_args = RealmSetupArgs::default();
+    let mut realm_setup_args = RealmSetupArgs::default();
 
-    set_realm_config_args
+    realm_setup_args
         .community_token_config_args
         .voter_weight_addin = None;
 
     let mut realm_cookie = governance_test
-        .with_realm_using_config_args(&set_realm_config_args)
+        .with_realm_using_args(&realm_setup_args)
         .await;
 
-    set_realm_config_args
+    realm_setup_args
         .community_token_config_args
         .voter_weight_addin = None;
 
     // Act
 
     governance_test
-        .set_realm_config(&mut realm_cookie, &set_realm_config_args)
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
         .await
         .unwrap();
 
@@ -205,12 +205,12 @@ async fn test_set_realm_config_with_no_voter_weight_addin_for_realm_with_existin
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
     let mut realm_cookie = governance_test.with_realm().await;
 
-    let set_realm_config_args = RealmSetupArgs::default();
+    let realm_setup_args = RealmSetupArgs::default();
 
     // Act
 
     governance_test
-        .set_realm_config(&mut realm_cookie, &set_realm_config_args)
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
         .await
         .unwrap();
 

--- a/governance/program/tests/setup_realm_with_voter_weight_addin.rs
+++ b/governance/program/tests/setup_realm_with_voter_weight_addin.rs
@@ -5,6 +5,7 @@ use solana_program_test::*;
 
 mod program_test;
 
+use crate::program_test::args::RealmSetupArgs;
 use program_test::*;
 
 #[tokio::test]
@@ -12,9 +13,17 @@ async fn test_create_realm_with_voter_weight_addin() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
 
+    let mut set_realm_config_args = RealmSetupArgs::default();
+
+    set_realm_config_args
+        .community_token_config_args
+        .voter_weight_addin = governance_test.voter_weight_addin_id;
+
     // Act
 
-    let realm_cookie = governance_test.with_realm().await;
+    let realm_cookie = governance_test
+        .with_realm_using_config_args(&set_realm_config_args)
+        .await;
 
     // Assert
 
@@ -35,20 +44,18 @@ async fn test_set_realm_voter_weight_addin_for_realm_without_addins() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
 
-    let mut set_realm_config_args = governance_test.get_default_set_realm_config_args();
+    let mut set_realm_config_args = RealmSetupArgs::default();
     set_realm_config_args
-        .realm_config_args
         .community_token_config_args
-        .use_voter_weight_addin = false;
+        .voter_weight_addin = None;
 
     let mut realm_cookie = governance_test
         .with_realm_using_config_args(&set_realm_config_args)
         .await;
 
     set_realm_config_args
-        .realm_config_args
         .community_token_config_args
-        .use_voter_weight_addin = true;
+        .voter_weight_addin = governance_test.voter_weight_addin_id;
 
     // Act
 
@@ -76,21 +83,17 @@ async fn test_set_realm_voter_weight_addin_for_realm_without_council_and_addins(
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
 
-    let mut set_realm_config_args = governance_test.get_default_set_realm_config_args();
-    set_realm_config_args
-        .realm_config_args
-        .community_token_config_args
-        .use_voter_weight_addin = false;
-    set_realm_config_args.realm_config_args.use_council_mint = false;
+    let mut set_realm_config_args = RealmSetupArgs::default();
+
+    set_realm_config_args.use_council_mint = false;
 
     let mut realm_cookie = governance_test
         .with_realm_using_config_args(&set_realm_config_args)
         .await;
 
     set_realm_config_args
-        .realm_config_args
         .community_token_config_args
-        .use_voter_weight_addin = true;
+        .voter_weight_addin = governance_test.voter_weight_addin_id;
 
     // Act
 
@@ -118,18 +121,19 @@ async fn test_set_realm_voter_weight_addin_for_realm_with_existing_voter_weight_
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
 
-    let mut realm_cookie = governance_test.with_realm().await;
-
-    let mut set_realm_config_args = governance_test.get_default_set_realm_config_args();
+    let mut set_realm_config_args = RealmSetupArgs::default();
 
     set_realm_config_args
-        .realm_config_args
         .community_token_config_args
-        .use_voter_weight_addin = true;
+        .voter_weight_addin = governance_test.voter_weight_addin_id;
+
+    let mut realm_cookie = governance_test
+        .with_realm_using_config_args(&set_realm_config_args)
+        .await;
 
     let community_voter_weight_addin_address = Pubkey::new_unique();
     set_realm_config_args
-        .community_token_config
+        .community_token_config_args
         .voter_weight_addin = Some(community_voter_weight_addin_address);
 
     // Act
@@ -162,25 +166,24 @@ async fn test_set_realm_config_with_no_voter_weight_addin_for_realm_without_addi
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
 
-    let mut realm_config_args = governance_test.get_default_set_realm_config_args();
-    realm_config_args
-        .realm_config_args
+    let mut set_realm_config_args = RealmSetupArgs::default();
+
+    set_realm_config_args
         .community_token_config_args
-        .use_voter_weight_addin = false;
+        .voter_weight_addin = None;
 
     let mut realm_cookie = governance_test
-        .with_realm_using_config_args(&realm_config_args)
+        .with_realm_using_config_args(&set_realm_config_args)
         .await;
 
-    realm_config_args
-        .realm_config_args
+    set_realm_config_args
         .community_token_config_args
-        .use_voter_weight_addin = false;
+        .voter_weight_addin = None;
 
     // Act
 
     governance_test
-        .set_realm_config(&mut realm_cookie, &realm_config_args)
+        .set_realm_config(&mut realm_cookie, &set_realm_config_args)
         .await
         .unwrap();
 
@@ -202,16 +205,12 @@ async fn test_set_realm_config_with_no_voter_weight_addin_for_realm_with_existin
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
     let mut realm_cookie = governance_test.with_realm().await;
 
-    let mut realm_config_args = governance_test.get_default_set_realm_config_args();
-    realm_config_args
-        .realm_config_args
-        .community_token_config_args
-        .use_voter_weight_addin = false;
+    let set_realm_config_args = RealmSetupArgs::default();
 
     // Act
 
     governance_test
-        .set_realm_config(&mut realm_cookie, &realm_config_args)
+        .set_realm_config(&mut realm_cookie, &set_realm_config_args)
         .await
         .unwrap();
 

--- a/governance/program/tests/setup_realm_with_voter_weight_addin.rs
+++ b/governance/program/tests/setup_realm_with_voter_weight_addin.rs
@@ -157,7 +157,7 @@ async fn test_set_realm_voter_weight_addin_for_realm_with_existing_voter_weight_
 
     assert_eq!(realm_config_cookie.account, realm_config_data);
     assert_eq!(
-        realm_config_data.community_voter_weight_addin,
+        realm_config_data.community_token_config.voter_weight_addin,
         Some(community_voter_weight_addin_address)
     );
 }
@@ -226,5 +226,8 @@ async fn test_set_realm_config_with_no_voter_weight_addin_for_realm_with_existin
         .get_realm_config_data(&realm_cookie.realm_config.unwrap().address)
         .await;
 
-    assert!(realm_config_data.community_voter_weight_addin.is_none());
+    assert!(realm_config_data
+        .community_token_config
+        .voter_weight_addin
+        .is_none());
 }

--- a/governance/program/tests/setup_realm_with_voter_weight_addin.rs
+++ b/governance/program/tests/setup_realm_with_voter_weight_addin.rs
@@ -41,7 +41,8 @@ async fn test_set_realm_voter_weight_addin_for_realm_without_addins() {
     let mut set_realm_config_args = governance_test.get_default_set_realm_config_args();
     set_realm_config_args
         .realm_config_args
-        .use_community_voter_weight_addin = false;
+        .community_token_config_args
+        .use_voter_weight_addin = false;
 
     let mut realm_cookie = governance_test
         .with_realm_using_config_args(&set_realm_config_args)
@@ -49,7 +50,8 @@ async fn test_set_realm_voter_weight_addin_for_realm_without_addins() {
 
     set_realm_config_args
         .realm_config_args
-        .use_community_voter_weight_addin = true;
+        .community_token_config_args
+        .use_voter_weight_addin = true;
 
     // Act
 
@@ -83,7 +85,8 @@ async fn test_set_realm_voter_weight_addin_for_realm_without_council_and_addins(
     let mut set_realm_config_args = governance_test.get_default_set_realm_config_args();
     set_realm_config_args
         .realm_config_args
-        .use_community_voter_weight_addin = false;
+        .community_token_config_args
+        .use_voter_weight_addin = false;
     set_realm_config_args.realm_config_args.use_council_mint = false;
 
     let mut realm_cookie = governance_test
@@ -92,7 +95,8 @@ async fn test_set_realm_voter_weight_addin_for_realm_without_council_and_addins(
 
     set_realm_config_args
         .realm_config_args
-        .use_community_voter_weight_addin = true;
+        .community_token_config_args
+        .use_voter_weight_addin = true;
 
     // Act
 
@@ -129,7 +133,8 @@ async fn test_set_realm_voter_weight_addin_for_realm_with_existing_voter_weight_
 
     set_realm_config_args
         .realm_config_args
-        .use_community_voter_weight_addin = true;
+        .community_token_config_args
+        .use_voter_weight_addin = true;
 
     let community_voter_weight_addin_address = Pubkey::new_unique();
     set_realm_config_args.community_voter_weight_addin = Some(community_voter_weight_addin_address);
@@ -170,7 +175,8 @@ async fn test_set_realm_config_with_no_voter_weight_addin_for_realm_without_addi
     let mut realm_config_args = governance_test.get_default_set_realm_config_args();
     realm_config_args
         .realm_config_args
-        .use_community_voter_weight_addin = false;
+        .community_token_config_args
+        .use_voter_weight_addin = false;
 
     let mut realm_cookie = governance_test
         .with_realm_using_config_args(&realm_config_args)
@@ -178,7 +184,8 @@ async fn test_set_realm_config_with_no_voter_weight_addin_for_realm_without_addi
 
     realm_config_args
         .realm_config_args
-        .use_community_voter_weight_addin = false;
+        .community_token_config_args
+        .use_voter_weight_addin = false;
 
     // Act
 
@@ -205,7 +212,8 @@ async fn test_set_realm_config_with_no_voter_weight_addin_for_realm_with_existin
     let mut realm_config_args = governance_test.get_default_set_realm_config_args();
     realm_config_args
         .realm_config_args
-        .use_community_voter_weight_addin = false;
+        .community_token_config_args
+        .use_voter_weight_addin = false;
 
     // Act
 

--- a/governance/program/tests/use_realm_with_all_addins.rs
+++ b/governance/program/tests/use_realm_with_all_addins.rs
@@ -12,7 +12,7 @@ async fn test_cast_vote_with_all_addin() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_all_addins().await;
 
-    let realm_cookie = governance_test.with_realm().await;
+    let realm_cookie = governance_test.with_realm_using_addins(true, true).await;
 
     let mut token_owner_record_cookie = governance_test
         .with_community_token_owner_record(&realm_cookie)
@@ -72,7 +72,7 @@ async fn test_tip_vote_with_all_addin() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_all_addins().await;
 
-    let realm_cookie = governance_test.with_realm().await;
+    let realm_cookie = governance_test.with_realm_using_addins(true, true).await;
 
     let mut token_owner_record_cookie = governance_test
         .with_community_token_owner_record(&realm_cookie)
@@ -132,7 +132,7 @@ async fn test_finalize_vote_with_all_addin() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_all_addins().await;
 
-    let realm_cookie = governance_test.with_realm().await;
+    let realm_cookie = governance_test.with_realm_using_addins(true, true).await;
 
     let mut token_owner_record_cookie = governance_test
         .with_community_token_owner_record(&realm_cookie)

--- a/governance/program/tests/use_realm_with_all_addins.rs
+++ b/governance/program/tests/use_realm_with_all_addins.rs
@@ -4,18 +4,83 @@ use solana_program_test::*;
 
 mod program_test;
 
+use program_test::args::*;
 use program_test::*;
 use spl_governance::state::enums::ProposalState;
 
 #[tokio::test]
-async fn test_cast_vote_with_all_addin() {
+async fn test_cast_community_vote_with_all_addin() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_all_addins().await;
 
-    let realm_cookie = governance_test.with_realm_using_addins(true, true).await;
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::ALL)
+        .await;
 
     let mut token_owner_record_cookie = governance_test
         .with_community_token_owner_record(&realm_cookie)
+        .await;
+
+    // voter weight 120
+    governance_test
+        .with_voter_weight_addin_record(&mut token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // max voter weight 250
+    governance_test
+        .with_max_voter_weight_addin_record_impl(&mut token_owner_record_cookie, 250, None)
+        .await
+        .unwrap();
+
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let mut governance_cookie = governance_test
+        .with_governance(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+
+    let vote_record_cookie = governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Assert
+    let vote_record_account = governance_test
+        .get_vote_record_account(&vote_record_cookie.address)
+        .await;
+
+    assert_eq!(120, vote_record_account.voter_weight);
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(proposal_account.state, ProposalState::Voting)
+}
+
+#[tokio::test]
+async fn test_cast_council_vote_with_all_addin() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_all_addins().await;
+
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::ALL)
+        .await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_council_token_owner_record(&realm_cookie)
         .await;
 
     // voter weight 120
@@ -72,7 +137,9 @@ async fn test_tip_vote_with_all_addin() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_all_addins().await;
 
-    let realm_cookie = governance_test.with_realm_using_addins(true, true).await;
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::ALL)
+        .await;
 
     let mut token_owner_record_cookie = governance_test
         .with_community_token_owner_record(&realm_cookie)
@@ -132,7 +199,9 @@ async fn test_finalize_vote_with_all_addin() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_all_addins().await;
 
-    let realm_cookie = governance_test.with_realm_using_addins(true, true).await;
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::ALL)
+        .await;
 
     let mut token_owner_record_cookie = governance_test
         .with_community_token_owner_record(&realm_cookie)

--- a/governance/program/tests/use_realm_with_max_voter_weight_addin.rs
+++ b/governance/program/tests/use_realm_with_max_voter_weight_addin.rs
@@ -13,7 +13,7 @@ async fn test_cast_vote_with_max_voter_weight_addin() {
     let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let realm_cookie = governance_test.with_realm().await;
+    let realm_cookie = governance_test.with_realm_using_addins(false, true).await;
 
     // TokenOwnerRecord with voting power of 100
     let mut token_owner_record_cookie = governance_test
@@ -62,7 +62,7 @@ async fn test_tip_vote_with_max_voter_weight_addin() {
     let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let realm_cookie = governance_test.with_realm().await;
+    let realm_cookie = governance_test.with_realm_using_addins(false, true).await;
 
     // TokenOwnerRecord with voting power of 180
     let mut token_owner_record_cookie = governance_test
@@ -112,7 +112,7 @@ async fn test_tip_vote_with_max_voter_weight_addin_and_max_below_total_cast_vote
     let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let realm_cookie = governance_test.with_realm().await;
+    let realm_cookie = governance_test.with_realm_using_addins(false, true).await;
 
     // TokenOwnerRecord with voting power of 100
     let mut token_owner_record_cookie = governance_test
@@ -162,7 +162,7 @@ async fn test_finalize_vote_with_max_voter_weight_addin() {
     let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let realm_cookie = governance_test.with_realm().await;
+    let realm_cookie = governance_test.with_realm_using_addins(false, true).await;
 
     // TokenOwnerRecord with voting power of 100
     let mut token_owner_record_cookie = governance_test
@@ -233,7 +233,7 @@ async fn test_finalize_vote_with_max_voter_weight_addin_and_max_below_total_cast
     let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let realm_cookie = governance_test.with_realm().await;
+    let realm_cookie = governance_test.with_realm_using_addins(false, true).await;
 
     // TokenOwnerRecord with voting power of 100
     let mut token_owner_record_cookie = governance_test
@@ -304,7 +304,7 @@ async fn test_cast_vote_with_max_voter_weight_addin_and_expired_record_error() {
     let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let realm_cookie = governance_test.with_realm().await;
+    let realm_cookie = governance_test.with_realm_using_addins(false, true).await;
 
     // TokenOwnerRecord with voting power of 100
     let mut token_owner_record_cookie = governance_test

--- a/governance/program/tests/use_realm_with_max_voter_weight_addin.rs
+++ b/governance/program/tests/use_realm_with_max_voter_weight_addin.rs
@@ -4,20 +4,74 @@ use solana_program_test::*;
 
 mod program_test;
 
+use program_test::args::*;
 use program_test::*;
 use spl_governance::{error::GovernanceError, state::enums::ProposalState};
 
 #[tokio::test]
-async fn test_cast_vote_with_max_voter_weight_addin() {
+async fn test_cast_vote_with_community_max_voter_weight_addin() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let realm_cookie = governance_test.with_realm_using_addins(false, true).await;
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_MAX_VOTER_WEIGHT)
+        .await;
 
     // TokenOwnerRecord with voting power of 100
     let mut token_owner_record_cookie = governance_test
         .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Bump MaxVoterWeight to 200
+    governance_test
+        .with_max_voter_weight_addin_record(&mut token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(proposal_account.state, ProposalState::Voting)
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_council_max_voter_weight_addin() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COUNCIL_MAX_VOTER_WEIGHT)
+        .await;
+
+    // TokenOwnerRecord with voting power of 100
+    let mut token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
         .await
         .unwrap();
 
@@ -62,7 +116,9 @@ async fn test_tip_vote_with_max_voter_weight_addin() {
     let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let realm_cookie = governance_test.with_realm_using_addins(false, true).await;
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_MAX_VOTER_WEIGHT)
+        .await;
 
     // TokenOwnerRecord with voting power of 180
     let mut token_owner_record_cookie = governance_test
@@ -112,7 +168,9 @@ async fn test_tip_vote_with_max_voter_weight_addin_and_max_below_total_cast_vote
     let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let realm_cookie = governance_test.with_realm_using_addins(false, true).await;
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_MAX_VOTER_WEIGHT)
+        .await;
 
     // TokenOwnerRecord with voting power of 100
     let mut token_owner_record_cookie = governance_test
@@ -162,7 +220,9 @@ async fn test_finalize_vote_with_max_voter_weight_addin() {
     let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let realm_cookie = governance_test.with_realm_using_addins(false, true).await;
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_MAX_VOTER_WEIGHT)
+        .await;
 
     // TokenOwnerRecord with voting power of 100
     let mut token_owner_record_cookie = governance_test
@@ -233,7 +293,9 @@ async fn test_finalize_vote_with_max_voter_weight_addin_and_max_below_total_cast
     let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let realm_cookie = governance_test.with_realm_using_addins(false, true).await;
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_MAX_VOTER_WEIGHT)
+        .await;
 
     // TokenOwnerRecord with voting power of 100
     let mut token_owner_record_cookie = governance_test
@@ -304,7 +366,9 @@ async fn test_cast_vote_with_max_voter_weight_addin_and_expired_record_error() {
     let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let realm_cookie = governance_test.with_realm_using_addins(false, true).await;
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_MAX_VOTER_WEIGHT)
+        .await;
 
     // TokenOwnerRecord with voting power of 100
     let mut token_owner_record_cookie = governance_test

--- a/governance/program/tests/use_realm_with_voter_weight_addin.rs
+++ b/governance/program/tests/use_realm_with_voter_weight_addin.rs
@@ -5,7 +5,9 @@ use solana_program_test::*;
 
 mod program_test;
 
+use program_test::args::*;
 use program_test::*;
+
 use spl_governance::{
     error::GovernanceError,
     state::vote_record::{Vote, VoteChoice},
@@ -13,15 +15,54 @@ use spl_governance::{
 use spl_governance_addin_api::voter_weight::VoterWeightAction;
 
 #[tokio::test]
-async fn test_create_governance_with_voter_weight_addin() {
+async fn test_create_governance_with_community_voter_weight_addin() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let realm_cookie = governance_test.with_realm_using_addins(true, false).await;
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_VOTER_WEIGHT)
+        .await;
 
     let mut token_owner_record_cookie = governance_test
         .with_community_token_owner_record(&realm_cookie)
+        .await;
+
+    governance_test
+        .with_voter_weight_addin_record(&mut token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let governance_cookie = governance_test
+        .with_governance(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    // // Assert
+    let governance_account = governance_test
+        .get_governance_account(&governance_cookie.address)
+        .await;
+
+    assert_eq!(governance_cookie.account, governance_account);
+}
+
+#[tokio::test]
+async fn test_create_governance_with_council_voter_weight_addin() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COUNCIL_VOTER_WEIGHT)
+        .await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_council_token_owner_record(&realm_cookie)
         .await;
 
     governance_test
@@ -53,7 +94,9 @@ async fn test_create_proposal_with_voter_weight_addin() {
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let realm_cookie = governance_test.with_realm_using_addins(true, false).await;
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_VOTER_WEIGHT)
+        .await;
 
     let mut token_owner_record_cookie = governance_test
         .with_community_token_owner_record(&realm_cookie)
@@ -93,7 +136,9 @@ async fn test_cast_vote_with_voter_weight_addin() {
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let realm_cookie = governance_test.with_realm_using_addins(true, false).await;
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_VOTER_WEIGHT)
+        .await;
 
     let mut token_owner_record_cookie = governance_test
         .with_community_token_owner_record(&realm_cookie)
@@ -152,7 +197,9 @@ async fn test_create_token_governance_with_voter_weight_addin() {
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
     let governed_token_cookie = governance_test.with_governed_token().await;
 
-    let realm_cookie = governance_test.with_realm_using_addins(true, false).await;
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_VOTER_WEIGHT)
+        .await;
 
     let mut token_owner_record_cookie = governance_test
         .with_community_token_owner_record(&realm_cookie)
@@ -187,7 +234,9 @@ async fn test_create_mint_governance_with_voter_weight_addin() {
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
     let governed_mint_cookie = governance_test.with_governed_mint().await;
 
-    let realm_cookie = governance_test.with_realm_using_addins(true, false).await;
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_VOTER_WEIGHT)
+        .await;
 
     let mut token_owner_record_cookie = governance_test
         .with_community_token_owner_record(&realm_cookie)
@@ -222,7 +271,9 @@ async fn test_create_program_governance_with_voter_weight_addin() {
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
     let governed_program_cookie = governance_test.with_governed_program().await;
 
-    let realm_cookie = governance_test.with_realm_using_addins(true, false).await;
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_VOTER_WEIGHT)
+        .await;
 
     let mut token_owner_record_cookie = governance_test
         .with_community_token_owner_record(&realm_cookie)
@@ -260,7 +311,9 @@ async fn test_create_governance_with_voter_weight_action_error() {
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let realm_cookie = governance_test.with_realm_using_addins(true, false).await;
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_VOTER_WEIGHT)
+        .await;
 
     let mut token_owner_record_cookie = governance_test
         .with_community_token_owner_record(&realm_cookie)
@@ -298,7 +351,9 @@ async fn test_create_governance_with_voter_weight_expiry_error() {
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let realm_cookie = governance_test.with_realm_using_addins(true, false).await;
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_VOTER_WEIGHT)
+        .await;
 
     let mut token_owner_record_cookie = governance_test
         .with_community_token_owner_record(&realm_cookie)
@@ -338,7 +393,9 @@ async fn test_cast_vote_with_voter_weight_action_error() {
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let realm_cookie = governance_test.with_realm_using_addins(true, false).await;
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_VOTER_WEIGHT)
+        .await;
 
     let mut token_owner_record_cookie = governance_test
         .with_community_token_owner_record(&realm_cookie)
@@ -394,7 +451,9 @@ async fn test_create_governance_with_voter_weight_action_target_error() {
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let realm_cookie = governance_test.with_realm_using_addins(true, false).await;
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_VOTER_WEIGHT)
+        .await;
 
     let mut token_owner_record_cookie = governance_test
         .with_community_token_owner_record(&realm_cookie)
@@ -437,7 +496,9 @@ async fn test_create_proposal_with_voter_weight_action_error() {
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let realm_cookie = governance_test.with_realm_using_addins(true, false).await;
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_VOTER_WEIGHT)
+        .await;
 
     let mut token_owner_record_cookie = governance_test
         .with_community_token_owner_record(&realm_cookie)
@@ -481,7 +542,9 @@ async fn test_create_governance_with_voter_weight_record() {
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let realm_cookie = governance_test.with_realm_using_addins(true, false).await;
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_VOTER_WEIGHT)
+        .await;
 
     let mut token_owner_record_cookie = governance_test
         .with_community_token_owner_record(&realm_cookie)

--- a/governance/program/tests/use_realm_with_voter_weight_addin.rs
+++ b/governance/program/tests/use_realm_with_voter_weight_addin.rs
@@ -18,7 +18,7 @@ async fn test_create_governance_with_voter_weight_addin() {
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let realm_cookie = governance_test.with_realm().await;
+    let realm_cookie = governance_test.with_realm_using_addins(true, false).await;
 
     let mut token_owner_record_cookie = governance_test
         .with_community_token_owner_record(&realm_cookie)
@@ -53,7 +53,7 @@ async fn test_create_proposal_with_voter_weight_addin() {
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let realm_cookie = governance_test.with_realm().await;
+    let realm_cookie = governance_test.with_realm_using_addins(true, false).await;
 
     let mut token_owner_record_cookie = governance_test
         .with_community_token_owner_record(&realm_cookie)
@@ -93,7 +93,7 @@ async fn test_cast_vote_with_voter_weight_addin() {
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let realm_cookie = governance_test.with_realm().await;
+    let realm_cookie = governance_test.with_realm_using_addins(true, false).await;
 
     let mut token_owner_record_cookie = governance_test
         .with_community_token_owner_record(&realm_cookie)
@@ -152,7 +152,7 @@ async fn test_create_token_governance_with_voter_weight_addin() {
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
     let governed_token_cookie = governance_test.with_governed_token().await;
 
-    let realm_cookie = governance_test.with_realm().await;
+    let realm_cookie = governance_test.with_realm_using_addins(true, false).await;
 
     let mut token_owner_record_cookie = governance_test
         .with_community_token_owner_record(&realm_cookie)
@@ -187,7 +187,7 @@ async fn test_create_mint_governance_with_voter_weight_addin() {
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
     let governed_mint_cookie = governance_test.with_governed_mint().await;
 
-    let realm_cookie = governance_test.with_realm().await;
+    let realm_cookie = governance_test.with_realm_using_addins(true, false).await;
 
     let mut token_owner_record_cookie = governance_test
         .with_community_token_owner_record(&realm_cookie)
@@ -222,7 +222,7 @@ async fn test_create_program_governance_with_voter_weight_addin() {
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
     let governed_program_cookie = governance_test.with_governed_program().await;
 
-    let realm_cookie = governance_test.with_realm().await;
+    let realm_cookie = governance_test.with_realm_using_addins(true, false).await;
 
     let mut token_owner_record_cookie = governance_test
         .with_community_token_owner_record(&realm_cookie)
@@ -260,7 +260,7 @@ async fn test_create_governance_with_voter_weight_action_error() {
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let realm_cookie = governance_test.with_realm().await;
+    let realm_cookie = governance_test.with_realm_using_addins(true, false).await;
 
     let mut token_owner_record_cookie = governance_test
         .with_community_token_owner_record(&realm_cookie)
@@ -298,7 +298,7 @@ async fn test_create_governance_with_voter_weight_expiry_error() {
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let realm_cookie = governance_test.with_realm().await;
+    let realm_cookie = governance_test.with_realm_using_addins(true, false).await;
 
     let mut token_owner_record_cookie = governance_test
         .with_community_token_owner_record(&realm_cookie)
@@ -338,7 +338,7 @@ async fn test_cast_vote_with_voter_weight_action_error() {
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let realm_cookie = governance_test.with_realm().await;
+    let realm_cookie = governance_test.with_realm_using_addins(true, false).await;
 
     let mut token_owner_record_cookie = governance_test
         .with_community_token_owner_record(&realm_cookie)
@@ -394,7 +394,7 @@ async fn test_create_governance_with_voter_weight_action_target_error() {
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let realm_cookie = governance_test.with_realm().await;
+    let realm_cookie = governance_test.with_realm_using_addins(true, false).await;
 
     let mut token_owner_record_cookie = governance_test
         .with_community_token_owner_record(&realm_cookie)
@@ -437,7 +437,7 @@ async fn test_create_proposal_with_voter_weight_action_error() {
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let realm_cookie = governance_test.with_realm().await;
+    let realm_cookie = governance_test.with_realm_using_addins(true, false).await;
 
     let mut token_owner_record_cookie = governance_test
         .with_community_token_owner_record(&realm_cookie)
@@ -481,7 +481,7 @@ async fn test_create_governance_with_voter_weight_record() {
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let realm_cookie = governance_test.with_realm().await;
+    let realm_cookie = governance_test.with_realm_using_addins(true, false).await;
 
     let mut token_owner_record_cookie = governance_test
         .with_community_token_owner_record(&realm_cookie)

--- a/governance/program/tests/use_veto_vote.rs
+++ b/governance/program/tests/use_veto_vote.rs
@@ -15,7 +15,7 @@ use spl_governance::{
 };
 use spl_governance_test_sdk::tools::clone_keypair;
 
-use self::args::SetRealmConfigArgs;
+use crate::program_test::args::RealmSetupArgs;
 
 #[tokio::test]
 async fn test_cast_veto_vote() {
@@ -431,8 +431,8 @@ async fn test_cast_veto_vote_with_no_council_error() {
         .unwrap();
 
     // Remove Council
-    let mut set_realm_config_args = SetRealmConfigArgs::default();
-    set_realm_config_args.realm_config_args.use_council_mint = false;
+    let mut set_realm_config_args = RealmSetupArgs::default();
+    set_realm_config_args.use_council_mint = false;
 
     governance_test
         .set_realm_config(&mut realm_cookie, &set_realm_config_args)

--- a/governance/program/tests/use_veto_vote.rs
+++ b/governance/program/tests/use_veto_vote.rs
@@ -431,11 +431,11 @@ async fn test_cast_veto_vote_with_no_council_error() {
         .unwrap();
 
     // Remove Council
-    let mut set_realm_config_args = RealmSetupArgs::default();
-    set_realm_config_args.use_council_mint = false;
+    let mut realm_setup_args = RealmSetupArgs::default();
+    realm_setup_args.use_council_mint = false;
 
     governance_test
-        .set_realm_config(&mut realm_cookie, &set_realm_config_args)
+        .set_realm_config(&mut realm_cookie, &realm_setup_args)
         .await
         .unwrap();
 


### PR DESCRIPTION
#### Summary

This change makes it possible to use `Membership` governance tokens which are not transferable and can be revoked (burnt) using proposals of the `Realm` they belong to. 

It addresses the issue with the current implementation where `Council` members can freely transfer their tokens and it's not possible to forcefully remove them from the `Council`. They can only voluntarily burn their tokens and it doesn't work in scenarios where bad actors are involved or when wallet keys are lost.

Although the most common use case is to use the `Membership` tokens for `Council` membership the implementation is symmetric and `Community` membership is also possible.

In addition to the `Membership` changes this PR makes it possible to use `voter-weight` and `max-voter-weight` plugins for `Council` to make it symmetric with the `Community` implementation. 

#### Implementation Details

- `GoverningTokenType` - A concept of a governing token type was introduced to denote how the token can be used within a `Realm`. The three token types are:
         1) `Liquid` token type is the default one and retains the old behaviour.
         2) `Membership` token type defines a token with the electable membership semantics.
         3) `Dormant` token type is a placeholder used when external plugins are enabled.

- `RevokeGoverningTokens` - The instruction allows `Realm` members to burn `Membership` tokens held in the `governing_token_holding` account. It must be signed by `realm_authority`.

- `DepositGoverningTokens` - The instruction was modified to support `spl-token` `mint` as the source of the deposit. This way `Realm` can use proposals to mint the `Membership` tokes directly into the `governing_token_holding` and hence the tokens are never in control of the individual members.

- `WithdrawGoverningTokens` - The instruction was modified to disallow withdrawals of the `Membership` tokens.

- `RealmConfigAccount` - This account is no longer optional and is always created with a `Realm`. If a legacy `Realm` doesn't have the account then it's materialised on the fly to the default value within instructions which require it.
 


