### PR TITLE
patches test_lamport_transfer

### DIFF
--- a/examples/rust/transfer-lamports/tests/functional.rs
+++ b/examples/rust/transfer-lamports/tests/functional.rs
@@ -30,7 +30,7 @@ async fn test_lamport_transfer() {
     program_test.add_account(
         destination_pubkey,
         Account {
-            lamports: 5,
+            lamports: 890_875,
             ..Account::default()
         },
     );


### PR DESCRIPTION
https://github.com/solana-labs/solana/pull/26606
prevents crediting a rent paying account if the account stays rent
paying. As a result, test_lamport_transfer fails.

The commit updates destination account lamports so that after transfer
it is no longer rent paying.