### PR TITLE
Adjust confidential token rust client for offline signing

### DIFF
--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -1730,8 +1730,8 @@ where
         withdraw_withheld_authority: &S2,
         destination_token_account: &Pubkey,
         destination_elgamal_pubkey: &ElGamalPubkey,
-        aggregate_withheld_amount_ciphertext: &ElGamalCiphertext,
         aggregate_withheld_amount: u64,
+        aggregate_withheld_amount_ciphertext: &ElGamalCiphertext,
         sources: &[&Pubkey],
     ) -> TokenResult<T::Output> {
         let withdraw_withheld_authority_elgamal_keypair =
@@ -1742,8 +1742,8 @@ where
             withdraw_withheld_authority,
             destination_token_account,
             destination_elgamal_pubkey,
-            aggregate_withheld_amount_ciphertext,
             aggregate_withheld_amount,
+            aggregate_withheld_amount_ciphertext,
             &withdraw_withheld_authority_elgamal_keypair,
             sources,
         )
@@ -1759,8 +1759,8 @@ where
         withdraw_withheld_authority: &S2,
         destination_token_account: &Pubkey,
         destination_elgamal_pubkey: &ElGamalPubkey,
-        aggregate_withheld_amount_ciphertext: &ElGamalCiphertext,
         aggregate_withheld_amount: u64,
+        aggregate_withheld_amount_ciphertext: &ElGamalCiphertext,
         withdraw_withheld_authority_elgamal_keypair: &ElGamalKeypair,
         sources: &[&Pubkey],
     ) -> TokenResult<T::Output> {

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -1139,7 +1139,7 @@ where
             .try_into()
             .map_err(TokenError::Proof)?;
         let decryptable_balance = decryptable_balance_ciphertext
-            .decrypt(&authenticated_encryption_key)
+            .decrypt(authenticated_encryption_key)
             .ok_or(TokenError::AccountDecryption)?;
 
         Ok(decryptable_balance)
@@ -1751,6 +1751,7 @@ where
     }
 
     /// Withdraw withheld confidential tokens from accounts using a custom decryption key
+    #[allow(clippy::too_many_arguments)]
     pub async fn confidential_transfer_withdraw_withheld_tokens_from_accounts_with_key<
         S2: Signer,
     >(

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -1106,6 +1106,134 @@ where
         .await
     }
 
+    /// Fetch and decrypt the available balance of a confidential token account using the uniquely
+    /// derived decryption key from a signer
+    pub async fn confidential_transfer_get_available_balance<S2: Signer>(
+        &self,
+        token_account: &Pubkey,
+        authority: &S2,
+    ) -> TokenResult<u64> {
+        let authenticated_encryption_key =
+            AeKey::new(authority, token_account).map_err(TokenError::Key)?;
+
+        self.confidential_transfer_get_available_balance_with_key(
+            token_account,
+            &authenticated_encryption_key,
+        ).await
+    }
+
+    /// Fetch and decrypt the available balance of a confidential token account using a custom
+    /// decryption key
+    pub async fn confidential_transfer_get_available_balance_with_key(
+        &self,
+        token_account: &Pubkey,
+        authenticated_encryption_key: &AeKey,
+    ) -> TokenResult<u64> {
+        let state = self.get_account_info(token_account).await.unwrap();
+        let extension =
+            state.get_extension::<confidential_transfer::ConfidentialTransferAccount>()?;
+
+        let decryptable_balance_ciphertext: AeCiphertext = extension
+            .decryptable_available_balance
+            .try_into()
+            .map_err(TokenError::Proof)?;
+        let decryptable_balance = decryptable_balance_ciphertext
+            .decrypt(&authenticated_encryption_key)
+            .ok_or(TokenError::AccountDecryption)?;
+
+        Ok(decryptable_balance)
+    }
+
+    /// Fetch and decrypt the pending balance of a confidential token account using the uniquely
+    /// derived decryption key from a signer
+    pub async fn confidential_transfer_get_pending_balance<S2: Signer>(
+        &self,
+        token_account: &Pubkey,
+        authority: &S2,
+    ) -> TokenResult<u64> {
+        let elgamal_keypair =
+            ElGamalKeypair::new(authority, token_account)
+                .map_err(TokenError::Key)?;
+
+        self.confidential_transfer_get_pending_balance_with_key(
+            token_account,
+            &elgamal_keypair,
+        )
+        .await
+    }
+
+    /// Fetch and decrypt the pending balance of a confidential token account using a custom
+    /// decryption key
+    pub async fn confidential_transfer_get_pending_balance_with_key(
+        &self,
+        token_account: &Pubkey,
+        elgamal_keypair: &ElGamalKeypair,
+    ) -> TokenResult<u64> {
+        let state = self.get_account_info(token_account).await.unwrap();
+        let extension =
+            state.get_extension::<confidential_transfer::ConfidentialTransferAccount>()?;
+
+        // decrypt pending balance
+        let pending_balance_lo = extension
+            .pending_balance_lo
+            .decrypt(&elgamal_keypair.secret)
+            .ok_or(TokenError::AccountDecryption)?;
+        let pending_balance_hi = extension
+            .pending_balance_hi
+            .decrypt(&elgamal_keypair.secret)
+            .ok_or(TokenError::AccountDecryption)?;
+
+        let pending_balance = pending_balance_lo.checked_add(
+            pending_balance_hi << confidential_transfer::PENDING_BALANCE_HI_BIT_LENGTH,
+            )
+            .ok_or(TokenError::AccountDecryption)?;
+
+        Ok(pending_balance)
+    }
+
+    /// Fetch the ElGamal public key associated with a confidential token account
+    pub async fn confidential_transfer_get_encryption_pubkey<S2: Signer>(
+        &self,
+        token_account: &Pubkey,
+    ) -> TokenResult<ElGamalPubkey> {
+        let state = self.get_account_info(token_account).await.unwrap();
+        let extension =
+            state.get_extension::<confidential_transfer::ConfidentialTransferAccount>()?;
+        let encryption_pubkey = extension.encryption_pubkey.try_into().map_err(TokenError::Proof)?;
+
+        Ok(encryption_pubkey)
+    }
+
+    /// Fetch the ElGamal pubkey key of the auditor associated with a confidential token mint
+    pub async fn confidential_transfer_get_auditor_encryption_pubkey<S2: Signer>(
+        &self,
+        token_account: &Pubkey,
+        authority: &S2,
+    ) -> TokenResult<ElGamalPubkey> {
+        let mint_state = self.get_mint_info().await.unwrap();
+        let ct_mint =
+            mint_state.get_extension::<confidential_transfer::ConfidentialTransferMint>()?;
+        let auditor_pubkey = ct_mint.auditor_encryption_pubkey.try_into().map_err(TokenError::Proof)?;
+
+        Ok(auditor_pubkey)
+    }
+
+    /// Fetch the ElGamal pubkey key of the withdraw withheld authority associated with a
+    /// confidential token mint
+    pub async fn confidential_transfer_get_withdraw_withheld_authority_encryption_pubkey<S2: Signer>(
+        &self,
+        token_account: &Pubkey,
+        authority: &S2,
+    ) -> TokenResult<ElGamalPubkey> {
+        let mint_state = self.get_mint_info().await.unwrap();
+        let ct_mint =
+            mint_state.get_extension::<confidential_transfer::ConfidentialTransferMint>()?;
+        let auditor_pubkey =
+            ct_mint.withdraw_withheld_authority_encryption_pubkey.try_into().map_err(TokenError::Proof)?;
+
+        Ok(auditor_pubkey)
+    }
+
     /// Deposit SPL Tokens into the pending balance of a confidential token account
     pub async fn confidential_transfer_deposit<S2: Signer>(
         &self,
@@ -1135,7 +1263,8 @@ where
         .await
     }
 
-    /// Withdraw SPL Tokens from the available balance of a confidential token account
+    /// Withdraw SPL Tokens from the available balance of a confidential token account using the
+    /// uniquely derived decryption key from a signer
     #[allow(clippy::too_many_arguments)]
     pub async fn confidential_transfer_withdraw<S2: Signer>(
         &self,
@@ -1143,46 +1272,34 @@ where
         destination_token_account: &Pubkey,
         source_token_authority: &S2,
         amount: u64,
+        source_available_balance: u64,
+        source_available_balance_ciphertext: &ElGamalCiphertext,
         decimals: u8,
     ) -> TokenResult<T::Output> {
-        let state = self.get_account_info(source_token_account).await.unwrap();
-        let extension =
-            state.get_extension::<confidential_transfer::ConfidentialTransferAccount>()?;
-
         let source_elgamal_keypair =
             ElGamalKeypair::new(source_token_authority, source_token_account)
                 .map_err(TokenError::Key)?;
         let source_authenticated_encryption_key =
             AeKey::new(source_token_authority, source_token_account).map_err(TokenError::Key)?;
 
-        let source_decryptable_balance_ciphertext: AeCiphertext = extension
-            .decryptable_available_balance
-            .try_into()
-            .map_err(TokenError::Proof)?;
-        let source_decryptable_balance = source_decryptable_balance_ciphertext
-            .decrypt(&source_authenticated_encryption_key)
-            .ok_or(TokenError::AccountDecryption)?;
-        let source_remaining_balance = source_decryptable_balance
-            .checked_sub(amount)
-            .ok_or(TokenError::NotEnoughFunds)?;
-        let new_source_decryptable_available_balance =
-            source_authenticated_encryption_key.encrypt(source_remaining_balance);
-
-        self.confidential_transfer_withdraw_with_keypair(
+        self.confidential_transfer_withdraw_with_key(
             source_token_account,
             destination_token_account,
             source_token_authority,
             amount,
             decimals,
-            source_decryptable_balance,
+            source_available_balance,
+            source_available_balance_ciphertext,
             &source_elgamal_keypair,
-            new_source_decryptable_available_balance,
+            &source_authenticated_encryption_key,
         )
         .await
     }
 
+    /// Withdraw SPL Tokens from the available balance of a confidential token account using custom
+    /// keys
     #[allow(clippy::too_many_arguments)]
-    pub async fn confidential_transfer_withdraw_with_keypair<S2: Signer>(
+    pub async fn confidential_transfer_withdraw_with_key<S2: Signer>(
         &self,
         source_token_account: &Pubkey,
         destination_token_account: &Pubkey,
@@ -1190,20 +1307,23 @@ where
         amount: u64,
         decimals: u8,
         source_available_balance: u64,
+        source_available_balance_ciphertext: &ElGamalCiphertext,
         source_elgamal_keypair: &ElGamalKeypair,
-        new_source_decryptable_available_balance: AeCiphertext,
+        source_authenticated_encryption_key: &AeKey,
     ) -> TokenResult<T::Output> {
-        let state = self.get_account_info(source_token_account).await.unwrap();
-        let extension =
-            state.get_extension::<confidential_transfer::ConfidentialTransferAccount>()?;
-
         let proof_data = confidential_transfer::instruction::WithdrawData::new(
             amount,
             source_elgamal_keypair,
             source_available_balance,
-            &extension.available_balance.try_into().unwrap(),
+            source_available_balance_ciphertext,
         )
         .map_err(TokenError::Proof)?;
+
+        let source_remaining_balance = source_available_balance
+            .checked_sub(amount)
+            .ok_or(TokenError::NotEnoughFunds)?;
+        let new_source_decryptable_available_balance =
+            source_authenticated_encryption_key.encrypt(source_remaining_balance);
 
         self.process_ixs(
             &confidential_transfer::instruction::withdraw(
@@ -1223,7 +1343,7 @@ where
         .await
     }
 
-    /// Transfer tokens confidentially
+    /// Transfer tokens confidentially using the uniquely derived decryption keys from a signer
     #[allow(clippy::too_many_arguments)]
     pub async fn confidential_transfer_transfer<S2: Signer>(
         &self,
@@ -1231,47 +1351,33 @@ where
         destination_token_account: &Pubkey,
         source_token_authority: &S2,
         amount: u64,
+        source_available_balance: u64,
+        source_available_balance_ciphertext: &ElGamalCiphertext,
+        destination_elgamal_pubkey: &ElGamalPubkey,
+        auditor_elgamal_pubkey: &ElGamalPubkey,
     ) -> TokenResult<T::Output> {
-        if amount >> confidential_transfer::MAXIMUM_DEPOSIT_TRANSFER_AMOUNT_BIT_LENGTH != 0 {
-            return Err(TokenError::MaximumDepositTransferAmountExceeded);
-        }
-
-        let source_state = self.get_account_info(source_token_account).await.unwrap();
-        let source_extension =
-            source_state.get_extension::<confidential_transfer::ConfidentialTransferAccount>()?;
-
         let source_elgamal_keypair =
             ElGamalKeypair::new(source_token_authority, source_token_account)
                 .map_err(TokenError::Key)?;
         let source_authenticated_encryption_key =
             AeKey::new(source_token_authority, source_token_account).map_err(TokenError::Key)?;
 
-        let source_decryptable_available_balance_ciphertext: AeCiphertext = source_extension
-            .decryptable_available_balance
-            .try_into()
-            .map_err(TokenError::Proof)?;
-        let source_decryptable_available_balance = source_decryptable_available_balance_ciphertext
-            .decrypt(&source_authenticated_encryption_key)
-            .ok_or(TokenError::AccountDecryption)?;
-        let source_remaining_available_balance = source_decryptable_available_balance
-            .checked_sub(amount)
-            .ok_or(TokenError::NotEnoughFunds)?;
-        let new_source_decryptable_available_balance =
-            source_authenticated_encryption_key.encrypt(source_remaining_available_balance);
-
         self.confidential_transfer_transfer_with_key(
             source_token_account,
             destination_token_account,
             source_token_authority,
             amount,
-            source_decryptable_available_balance,
+            source_available_balance,
+            source_available_balance_ciphertext,
+            destination_elgamal_pubkey,
+            auditor_elgamal_pubkey,
             &source_elgamal_keypair,
-            new_source_decryptable_available_balance,
+            &source_authenticated_encryption_key,
         )
         .await
     }
 
-    /// Transfer tokens confidentially
+    /// Transfer tokens confidentially using custom decryption keys
     #[allow(clippy::too_many_arguments)]
     pub async fn confidential_transfer_transfer_with_key<S2: Signer>(
         &self,
@@ -1280,43 +1386,35 @@ where
         source_token_authority: &S2,
         amount: u64,
         source_available_balance: u64,
+        source_available_balance_ciphertext: &ElGamalCiphertext,
+        destination_elgamal_pubkey: &ElGamalPubkey,
+        auditor_elgamal_pubkey: &ElGamalPubkey,
         source_elgamal_keypair: &ElGamalKeypair,
-        new_source_decryptable_available_balance: AeCiphertext,
+        source_authenticated_encryption_key: &AeKey,
     ) -> TokenResult<T::Output> {
         if amount >> confidential_transfer::MAXIMUM_DEPOSIT_TRANSFER_AMOUNT_BIT_LENGTH != 0 {
             return Err(TokenError::MaximumDepositTransferAmountExceeded);
         }
 
-        let source_state = self.get_account_info(source_token_account).await.unwrap();
-        let source_extension =
-            source_state.get_extension::<confidential_transfer::ConfidentialTransferAccount>()?;
-
-        let destination_state = self
-            .get_account_info(destination_token_account)
-            .await
-            .unwrap();
-        let destination_extension = destination_state
-            .get_extension::<confidential_transfer::ConfidentialTransferAccount>(
-        )?;
-
-        let mint_state = self.get_mint_info().await.unwrap();
-        let ct_mint = mint_state
-            .get_extension::<confidential_transfer::ConfidentialTransferMint>()
-            .unwrap();
-
         let proof_data = confidential_transfer::instruction::TransferData::new(
             amount,
             (
                 source_available_balance,
-                &source_extension.available_balance.try_into().unwrap(),
+                source_available_balance_ciphertext,
             ),
             source_elgamal_keypair,
             (
-                &destination_extension.encryption_pubkey.try_into().unwrap(),
-                &ct_mint.auditor_encryption_pubkey.try_into().unwrap(),
+                destination_elgamal_pubkey,
+                auditor_elgamal_pubkey,
             ),
         )
         .map_err(TokenError::Proof)?;
+
+        let source_remaining_balance = source_available_balance
+            .checked_sub(amount)
+            .ok_or(TokenError::NotEnoughFunds)?;
+        let new_source_available_balance =
+            source_authenticated_encryption_key.encrypt(source_remaining_balance);
 
         self.process_ixs(
             &confidential_transfer::instruction::transfer(
@@ -1324,7 +1422,7 @@ where
                 source_token_account,
                 destination_token_account,
                 &self.pubkey,
-                new_source_decryptable_available_balance,
+                new_source_available_balance,
                 &source_token_authority.pubkey(),
                 &[],
                 &proof_data,
@@ -1334,7 +1432,8 @@ where
         .await
     }
 
-    /// Transfer tokens confidentially with fee
+    /// Transfer tokens confidentially with fee using the uniquely derived decryption keys from a
+    /// signer
     #[allow(clippy::too_many_arguments)]
     pub async fn confidential_transfer_transfer_with_fee<S2: Signer>(
         &self,
@@ -1342,48 +1441,37 @@ where
         destination_token_account: &Pubkey,
         source_token_authority: &S2,
         amount: u64,
+        source_available_balance: u64,
+        source_available_balance_ciphertext: &ElGamalCiphertext,
+        destination_elgamal_pubkey: &ElGamalPubkey,
+        auditor_elgamal_pubkey: &ElGamalPubkey,
+        withdraw_withheld_authority_elgamal_pubkey: &ElGamalPubkey,
         epoch_info: &EpochInfo,
     ) -> TokenResult<T::Output> {
-        if amount >> confidential_transfer::MAXIMUM_DEPOSIT_TRANSFER_AMOUNT_BIT_LENGTH != 0 {
-            return Err(TokenError::MaximumDepositTransferAmountExceeded);
-        }
-
-        let source_state = self.get_account_info(source_token_account).await.unwrap();
-        let source_extension =
-            source_state.get_extension::<confidential_transfer::ConfidentialTransferAccount>()?;
-
         let source_elgamal_keypair =
             ElGamalKeypair::new(source_token_authority, source_token_account)
                 .map_err(TokenError::Key)?;
         let source_authenticated_encryption_key =
             AeKey::new(source_token_authority, source_token_account).map_err(TokenError::Key)?;
 
-        let source_decryptable_available_balance_ciphertext: AeCiphertext = source_extension
-            .decryptable_available_balance
-            .try_into()
-            .map_err(TokenError::Proof)?;
-        let source_decryptable_available_balance = source_decryptable_available_balance_ciphertext
-            .decrypt(&source_authenticated_encryption_key)
-            .ok_or(TokenError::AccountDecryption)?;
-        let source_remaining_available_balance = source_decryptable_available_balance
-            .checked_sub(amount)
-            .ok_or(TokenError::NotEnoughFunds)?;
-        let new_source_decryptable_available_balance =
-            source_authenticated_encryption_key.encrypt(source_remaining_available_balance);
-
         self.confidential_transfer_transfer_with_fee_with_key(
             source_token_account,
             destination_token_account,
             source_token_authority,
             amount,
-            source_decryptable_available_balance,
+            source_available_balance,
+            source_available_balance_ciphertext,
+            destination_elgamal_pubkey,
+            auditor_elgamal_pubkey,
+            withdraw_withheld_authority_elgamal_pubkey,
             &source_elgamal_keypair,
-            new_source_decryptable_available_balance,
+            &source_authenticated_encryption_key,
             epoch_info,
         )
         .await
     }
 
+    /// Transfer tokens confidential with fee using custom decryption keys
     #[allow(clippy::too_many_arguments)]
     pub async fn confidential_transfer_transfer_with_fee_with_key<S2: Signer>(
         &self,
@@ -1392,58 +1480,49 @@ where
         source_token_authority: &S2,
         amount: u64,
         source_available_balance: u64,
+        source_available_balance_ciphertext: &ElGamalCiphertext,
+        destination_elgamal_pubkey: &ElGamalPubkey,
+        auditor_elgamal_pubkey: &ElGamalPubkey,
+        withdraw_withheld_authority_elgamal_pubkey: &ElGamalPubkey,
         source_elgamal_keypair: &ElGamalKeypair,
-        new_source_decryptable_available_balance: AeCiphertext,
+        source_authenticated_encryption_key: &AeKey,
         epoch_info: &EpochInfo,
     ) -> TokenResult<T::Output> {
         if amount >> confidential_transfer::MAXIMUM_DEPOSIT_TRANSFER_AMOUNT_BIT_LENGTH != 0 {
             return Err(TokenError::MaximumDepositTransferAmountExceeded);
         }
 
-        let source_state = self.get_account_info(source_token_account).await.unwrap();
-        let source_extension =
-            source_state.get_extension::<confidential_transfer::ConfidentialTransferAccount>()?;
-
-        let destination_state = self
-            .get_account_info(destination_token_account)
-            .await
-            .unwrap();
-        let destination_extension = destination_state
-            .get_extension::<confidential_transfer::ConfidentialTransferAccount>(
-        )?;
-
+        // TODO: take transfer fee params as input
         let mint_state = self.get_mint_info().await.unwrap();
         let transfer_fee_config = mint_state
             .get_extension::<transfer_fee::TransferFeeConfig>()
             .unwrap();
-
         let fee_parameters = transfer_fee_config.get_epoch_fee(epoch_info.epoch);
-
-        let ct_mint = mint_state
-            .get_extension::<confidential_transfer::ConfidentialTransferMint>()
-            .unwrap();
 
         let proof_data = confidential_transfer::instruction::TransferWithFeeData::new(
             amount,
             (
                 source_available_balance,
-                &source_extension.available_balance.try_into().unwrap(),
+                source_available_balance_ciphertext,
             ),
             source_elgamal_keypair,
             (
-                &destination_extension.encryption_pubkey.try_into().unwrap(),
-                &ct_mint.auditor_encryption_pubkey.try_into().unwrap(),
+                destination_elgamal_pubkey,
+                auditor_elgamal_pubkey,
             ),
             FeeParameters {
                 fee_rate_basis_points: u16::from(fee_parameters.transfer_fee_basis_points),
                 maximum_fee: u64::from(fee_parameters.maximum_fee),
             },
-            &ct_mint
-                .withdraw_withheld_authority_encryption_pubkey
-                .try_into()
-                .unwrap(),
+            withdraw_withheld_authority_elgamal_pubkey,
         )
         .map_err(TokenError::Proof)?;
+
+        let source_remaining_balance = source_available_balance
+            .checked_sub(amount)
+            .ok_or(TokenError::NotEnoughFunds)?;
+        let new_source_decryptable_balance =
+            source_authenticated_encryption_key.encrypt(source_remaining_balance);
 
         self.process_ixs(
             &confidential_transfer::instruction::transfer_with_fee(
@@ -1451,7 +1530,7 @@ where
                 source_token_account,
                 destination_token_account,
                 &self.pubkey,
-                new_source_decryptable_available_balance,
+                new_source_decryptable_balance,
                 &source_token_authority.pubkey(),
                 &[],
                 &proof_data,
@@ -1461,71 +1540,51 @@ where
         .await
     }
 
-    /// Applies the confidential transfer pending balance to the available balance
+    /// Applies the confidential transfer pending balance to the available balance using the
+    /// uniquely derived decryption key
     pub async fn confidential_transfer_apply_pending_balance<S2: Signer>(
         &self,
         token_account: &Pubkey,
         authority: &S2,
+        available_balance: u64,
+        pending_balance: u64,
         expected_pending_balance_credit_counter: u64,
     ) -> TokenResult<T::Output> {
-        let state = self.get_account_info(token_account).await.unwrap();
-        let extension =
-            state.get_extension::<confidential_transfer::ConfidentialTransferAccount>()?;
-
-        let elgamal_keypair =
-            ElGamalKeypair::new(authority, token_account).map_err(TokenError::Key)?;
         let authenticated_encryption_key =
             AeKey::new(authority, token_account).map_err(TokenError::Key)?;
-
-        // decrypt current decryptable balance
-        let decryptable_available_balance_ciphertext: AeCiphertext = extension
-            .decryptable_available_balance
-            .try_into()
-            .map_err(TokenError::Proof)?;
-        let decryptable_balance = decryptable_available_balance_ciphertext
-            .decrypt(&authenticated_encryption_key)
-            .ok_or(TokenError::AccountDecryption)?;
-
-        // decrypt pending balance
-        let pending_balance_lo = extension
-            .pending_balance_lo
-            .decrypt(&elgamal_keypair.secret)
-            .ok_or(TokenError::AccountDecryption)?;
-        let pending_balance_hi = extension
-            .pending_balance_hi
-            .decrypt(&elgamal_keypair.secret)
-            .ok_or(TokenError::AccountDecryption)?;
-
-        // add decryptable balance with pending balance and re-encrypt
-        let new_decryptable_available_balance = decryptable_balance
-            .checked_add(pending_balance_hi << confidential_transfer::PENDING_BALANCE_HI_BIT_LENGTH)
-            .and_then(|sum| sum.checked_add(pending_balance_lo))
-            .ok_or(TokenError::AccountDecryption)?;
-        let new_decryptable_available_balance_ciphertext =
-            authenticated_encryption_key.encrypt(new_decryptable_available_balance);
 
         self.confidential_transfer_apply_pending_balance_with_key(
             token_account,
             authority,
+            available_balance,
+            pending_balance,
             expected_pending_balance_credit_counter,
-            new_decryptable_available_balance_ciphertext,
+            &authenticated_encryption_key,
         )
         .await
     }
 
+    /// Applies the confidential transfer pending balance to the available balance using a custom
+    /// decryption key
     pub async fn confidential_transfer_apply_pending_balance_with_key<S2: Signer>(
         &self,
         token_account: &Pubkey,
         authority: &S2,
+        available_balance: u64,
+        pending_balance: u64,
         expected_pending_balance_credit_counter: u64,
-        new_decryptable_available_balance: AeCiphertext,
+        authenticated_encryption_key: &AeKey,
     ) -> TokenResult<T::Output> {
+        let new_decryptable_balance = available_balance.checked_add(pending_balance).unwrap();
+        let new_decryptable_balance_ciphertext =
+            authenticated_encryption_key.encrypt(new_decryptable_balance);
+
         self.process_ixs(
             &[confidential_transfer::instruction::apply_pending_balance(
                 &self.program_id,
                 token_account,
                 expected_pending_balance_credit_counter,
-                new_decryptable_available_balance,
+                new_decryptable_balance_ciphertext,
                 &authority.pubkey(),
                 &[],
             )?],

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -1119,7 +1119,8 @@ where
         self.confidential_transfer_get_available_balance_with_key(
             token_account,
             &authenticated_encryption_key,
-        ).await
+        )
+        .await
     }
 
     /// Fetch and decrypt the available balance of a confidential token account using a custom
@@ -1152,14 +1153,10 @@ where
         authority: &S2,
     ) -> TokenResult<u64> {
         let elgamal_keypair =
-            ElGamalKeypair::new(authority, token_account)
-                .map_err(TokenError::Key)?;
+            ElGamalKeypair::new(authority, token_account).map_err(TokenError::Key)?;
 
-        self.confidential_transfer_get_pending_balance_with_key(
-            token_account,
-            &elgamal_keypair,
-        )
-        .await
+        self.confidential_transfer_get_pending_balance_with_key(token_account, &elgamal_keypair)
+            .await
     }
 
     /// Fetch and decrypt the pending balance of a confidential token account using a custom
@@ -1183,9 +1180,8 @@ where
             .decrypt(&elgamal_keypair.secret)
             .ok_or(TokenError::AccountDecryption)?;
 
-        let pending_balance = pending_balance_lo.checked_add(
-            pending_balance_hi << confidential_transfer::PENDING_BALANCE_HI_BIT_LENGTH,
-            )
+        let pending_balance = pending_balance_lo
+            .checked_add(pending_balance_hi << confidential_transfer::PENDING_BALANCE_HI_BIT_LENGTH)
             .ok_or(TokenError::AccountDecryption)?;
 
         Ok(pending_balance)
@@ -1240,7 +1236,10 @@ where
         let state = self.get_account_info(token_account).await.unwrap();
         let extension =
             state.get_extension::<confidential_transfer::ConfidentialTransferAccount>()?;
-        let encryption_pubkey = extension.encryption_pubkey.try_into().map_err(TokenError::Proof)?;
+        let encryption_pubkey = extension
+            .encryption_pubkey
+            .try_into()
+            .map_err(TokenError::Proof)?;
 
         Ok(encryption_pubkey)
     }
@@ -1252,21 +1251,28 @@ where
         let mint_state = self.get_mint_info().await.unwrap();
         let ct_mint =
             mint_state.get_extension::<confidential_transfer::ConfidentialTransferMint>()?;
-        let auditor_pubkey = ct_mint.auditor_encryption_pubkey.try_into().map_err(TokenError::Proof)?;
+        let auditor_pubkey = ct_mint
+            .auditor_encryption_pubkey
+            .try_into()
+            .map_err(TokenError::Proof)?;
 
         Ok(auditor_pubkey)
     }
 
     /// Fetch the ElGamal pubkey key of the withdraw withheld authority associated with a
     /// confidential token mint
-    pub async fn confidential_transfer_get_withdraw_withheld_authority_encryption_pubkey<S2: Signer>(
+    pub async fn confidential_transfer_get_withdraw_withheld_authority_encryption_pubkey<
+        S2: Signer,
+    >(
         &self,
     ) -> TokenResult<ElGamalPubkey> {
         let mint_state = self.get_mint_info().await.unwrap();
         let ct_mint =
             mint_state.get_extension::<confidential_transfer::ConfidentialTransferMint>()?;
-        let auditor_pubkey =
-            ct_mint.withdraw_withheld_authority_encryption_pubkey.try_into().map_err(TokenError::Proof)?;
+        let auditor_pubkey = ct_mint
+            .withdraw_withheld_authority_encryption_pubkey
+            .try_into()
+            .map_err(TokenError::Proof)?;
 
         Ok(auditor_pubkey)
     }
@@ -1440,10 +1446,7 @@ where
                 source_available_balance_ciphertext,
             ),
             source_elgamal_keypair,
-            (
-                destination_elgamal_pubkey,
-                auditor_elgamal_pubkey,
-            ),
+            (destination_elgamal_pubkey, auditor_elgamal_pubkey),
         )
         .map_err(TokenError::Proof)?;
 
@@ -1543,10 +1546,7 @@ where
                 source_available_balance_ciphertext,
             ),
             source_elgamal_keypair,
-            (
-                destination_elgamal_pubkey,
-                auditor_elgamal_pubkey,
-            ),
+            (destination_elgamal_pubkey, auditor_elgamal_pubkey),
             FeeParameters {
                 fee_rate_basis_points: u16::from(fee_parameters.transfer_fee_basis_points),
                 maximum_fee: u64::from(fee_parameters.maximum_fee),

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -592,7 +592,9 @@ async fn ct_withdraw() {
         .get_account_info(&alice_meta.token_account)
         .await
         .unwrap();
-    let extension = state.get_extension::<ConfidentialTransferAccount>().unwrap();
+    let extension = state
+        .get_extension::<ConfidentialTransferAccount>()
+        .unwrap();
     assert_eq!(state.base.amount, 0);
 
     token
@@ -612,7 +614,9 @@ async fn ct_withdraw() {
         .get_account_info(&alice_meta.token_account)
         .await
         .unwrap();
-    let extension = state.get_extension::<ConfidentialTransferAccount>().unwrap();
+    let extension = state
+        .get_extension::<ConfidentialTransferAccount>()
+        .unwrap();
     assert_eq!(state.base.amount, 21);
 
     alice_meta
@@ -693,7 +697,9 @@ async fn ct_transfer() {
         .get_account_info(&alice_meta.token_account)
         .await
         .unwrap();
-    let extension = state.get_extension::<ConfidentialTransferAccount>().unwrap();
+    let extension = state
+        .get_extension::<ConfidentialTransferAccount>()
+        .unwrap();
 
     // Self-transfer of 0 tokens
     token
@@ -726,7 +732,9 @@ async fn ct_transfer() {
         .get_account_info(&alice_meta.token_account)
         .await
         .unwrap();
-    let extension = state.get_extension::<ConfidentialTransferAccount>().unwrap();
+    let extension = state
+        .get_extension::<ConfidentialTransferAccount>()
+        .unwrap();
 
     // Self-transfer of N tokens
     token
@@ -759,7 +767,9 @@ async fn ct_transfer() {
         .get_account_info(&alice_meta.token_account)
         .await
         .unwrap();
-    let extension = state.get_extension::<ConfidentialTransferAccount>().unwrap();
+    let extension = state
+        .get_extension::<ConfidentialTransferAccount>()
+        .unwrap();
 
     let err = token
         .confidential_transfer_transfer(
@@ -808,7 +818,9 @@ async fn ct_transfer() {
         .get_account_info(&alice_meta.token_account)
         .await
         .unwrap();
-    let extension = state.get_extension::<ConfidentialTransferAccount>().unwrap();
+    let extension = state
+        .get_extension::<ConfidentialTransferAccount>()
+        .unwrap();
 
     token
         .confidential_transfer_transfer(
@@ -922,7 +934,9 @@ async fn ct_transfer_with_fee() {
         .get_account_info(&alice_meta.token_account)
         .await
         .unwrap();
-    let extension = state.get_extension::<ConfidentialTransferAccount>().unwrap();
+    let extension = state
+        .get_extension::<ConfidentialTransferAccount>()
+        .unwrap();
 
     // Self-transfer of 0 tokens
     token
@@ -935,7 +949,10 @@ async fn ct_transfer_with_fee() {
             &extension.available_balance.try_into().unwrap(),
             &alice_meta.elgamal_keypair.public,
             &ct_mint.auditor_encryption_pubkey.try_into().unwrap(),
-            &ct_mint.withdraw_withheld_authority_encryption_pubkey.try_into().unwrap(),
+            &ct_mint
+                .withdraw_withheld_authority_encryption_pubkey
+                .try_into()
+                .unwrap(),
             &epoch_info,
         )
         .await
@@ -964,7 +981,10 @@ async fn ct_transfer_with_fee() {
             &extension.available_balance.try_into().unwrap(),
             &alice_meta.elgamal_keypair.public,
             &ct_mint.auditor_encryption_pubkey.try_into().unwrap(),
-            &ct_mint.withdraw_withheld_authority_encryption_pubkey.try_into().unwrap(),
+            &ct_mint
+                .withdraw_withheld_authority_encryption_pubkey
+                .try_into()
+                .unwrap(),
             &epoch_info,
         )
         .await
@@ -1009,7 +1029,10 @@ async fn ct_transfer_with_fee() {
             &extension.available_balance.try_into().unwrap(),
             &bob_meta.elgamal_keypair.public,
             &ct_mint.auditor_encryption_pubkey.try_into().unwrap(),
-            &ct_mint.withdraw_withheld_authority_encryption_pubkey.try_into().unwrap(),
+            &ct_mint
+                .withdraw_withheld_authority_encryption_pubkey
+                .try_into()
+                .unwrap(),
             &epoch_info,
         )
         .await
@@ -1150,7 +1173,9 @@ async fn ct_withdraw_withheld_tokens_from_mint() {
         .get_account_info(&alice_meta.token_account)
         .await
         .unwrap();
-    let extension = state.get_extension::<ConfidentialTransferAccount>().unwrap();
+    let extension = state
+        .get_extension::<ConfidentialTransferAccount>()
+        .unwrap();
 
     // Test fee is 2.5% so the withheld fees should be 3
     token
@@ -1163,7 +1188,10 @@ async fn ct_withdraw_withheld_tokens_from_mint() {
             &extension.available_balance.try_into().unwrap(),
             &bob_meta.elgamal_keypair.public,
             &ct_mint.auditor_encryption_pubkey.try_into().unwrap(),
-            &ct_mint.withdraw_withheld_authority_encryption_pubkey.try_into().unwrap(),
+            &ct_mint
+                .withdraw_withheld_authority_encryption_pubkey
+                .try_into()
+                .unwrap(),
             &epoch_info,
         )
         .await
@@ -1265,8 +1293,13 @@ async fn ct_withdraw_withheld_tokens_from_accounts() {
             .await;
     let bob_meta = ConfidentialTokenAccountMeta::new(&token, &bob).await;
 
-    let state = token.get_account_info(&alice_meta.token_account).await.unwrap();
-    let extension = state.get_extension::<ConfidentialTransferAccount>().unwrap();
+    let state = token
+        .get_account_info(&alice_meta.token_account)
+        .await
+        .unwrap();
+    let extension = state
+        .get_extension::<ConfidentialTransferAccount>()
+        .unwrap();
 
     // Test fee is 2.5% so the withheld fees should be 3
     token


### PR DESCRIPTION
- Added client functions to fetch and decrypt specific confidential token account state information
- Updated confidential token client functions so that it takes in confidential token account state as input for offline signing of transactions