### PR TITLE
lending: Add instruction for changing reserve configuration after initialization

### DIFF
--- a/token-lending/program/tests/helpers/mod.rs
+++ b/token-lending/program/tests/helpers/mod.rs
@@ -63,7 +63,7 @@ pub const SRM_PYTH_PRICE: &str = "992moaMQKs32GKZ9dxi8keyM2bUmbrwBZpK4p2K6X5Vs";
 
 pub const USDC_MINT: &str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 
-trait AddPacked {
+pub trait AddPacked {
     fn add_packable_account<T: Pack>(
         &mut self,
         pubkey: Pubkey,

--- a/token-lending/program/tests/modify_reserve_config.rs
+++ b/token-lending/program/tests/modify_reserve_config.rs
@@ -2,7 +2,6 @@
 
 mod helpers;
 
-use helpers::AddPacked;
 use helpers::*;
 use solana_program::pubkey::Pubkey;
 use solana_program_test::*;

--- a/token-lending/program/tests/modify_reserve_config.rs
+++ b/token-lending/program/tests/modify_reserve_config.rs
@@ -1,0 +1,381 @@
+#![cfg(feature = "test-bpf")]
+
+mod helpers;
+
+use helpers::AddPacked;
+use helpers::*;
+use solana_program::pubkey::Pubkey;
+use solana_program_test::*;
+use solana_sdk::{
+    instruction::InstructionError,
+    signature::{read_keypair_file, Keypair, Signer},
+    transaction::{Transaction, TransactionError},
+};
+use spl_token_lending::{
+    error::LendingError,
+    instruction::modify_reserve_config,
+    processor::process_instruction,
+    state::{
+        InitLendingMarketParams, LendingMarket, ReserveConfig, ReserveFees,
+        INITIAL_COLLATERAL_RATIO,
+    },
+};
+
+#[tokio::test]
+async fn modify_reserve_config_success() {
+    let mut test = ProgramTest::new(
+        "spl_token_lending",
+        spl_token_lending::id(),
+        processor!(process_instruction),
+    );
+
+    test.set_compute_max_units(70_000);
+
+    let user_accounts_owner = Keypair::new();
+    let lending_market = add_lending_market(&mut test);
+    let sol_oracle = add_sol_oracle(&mut test);
+
+    const SOL_DEPOSIT_AMOUNT_LAMPORTS: u64 = 10 * LAMPORTS_TO_SOL * INITIAL_COLLATERAL_RATIO;
+    const SOL_RESERVE_COLLATERAL_LAMPORTS: u64 = 2 * SOL_DEPOSIT_AMOUNT_LAMPORTS;
+
+    let sol_test_reserve = add_reserve(
+        &mut test,
+        &lending_market,
+        &sol_oracle,
+        &user_accounts_owner,
+        AddReserveArgs {
+            user_liquidity_amount: SOL_RESERVE_COLLATERAL_LAMPORTS,
+            liquidity_amount: SOL_RESERVE_COLLATERAL_LAMPORTS,
+            liquidity_mint_decimals: 9,
+            liquidity_mint_pubkey: spl_token::native_mint::id(),
+            config: TEST_RESERVE_CONFIG,
+            mark_fresh: true,
+            ..AddReserveArgs::default()
+        },
+    );
+
+    let (mut banks_client, payer, recent_blockhash) = test.start().await;
+
+    const OPTIMAL_UTILIZATION_RATE_CHANGE: u8 = 10;
+
+    let new_config = ReserveConfig {
+        optimal_utilization_rate: TEST_RESERVE_CONFIG.optimal_utilization_rate
+            - OPTIMAL_UTILIZATION_RATE_CHANGE,
+        loan_to_value_ratio: 50,
+        liquidation_bonus: 5,
+        liquidation_threshold: 55,
+        min_borrow_rate: 0,
+        optimal_borrow_rate: 4,
+        max_borrow_rate: 30,
+        fees: ReserveFees {
+            borrow_fee_wad: 100_000_000_000,
+            flash_loan_fee_wad: 3_000_000_000_000_000,
+            host_fee_percentage: 20,
+        },
+    };
+
+    let mut transaction = Transaction::new_with_payer(
+        &[modify_reserve_config(
+            spl_token_lending::id(),
+            new_config,
+            sol_test_reserve.pubkey,
+            lending_market.pubkey,
+            lending_market.owner.pubkey(),
+        )],
+        Some(&payer.pubkey()),
+    );
+
+    transaction.sign(&[&payer, &lending_market.owner], recent_blockhash);
+
+    banks_client
+        .process_transaction(transaction)
+        .await
+        .map_err(|e| e.unwrap())
+        .unwrap();
+
+    let reserve_info = sol_test_reserve.get_state(&mut banks_client).await;
+    assert_eq!(
+        reserve_info.config.optimal_utilization_rate,
+        TEST_RESERVE_CONFIG.optimal_utilization_rate - OPTIMAL_UTILIZATION_RATE_CHANGE
+    );
+}
+
+#[tokio::test]
+#[should_panic(expected = "Transaction::sign failed with error KeypairPubkeyMismatch")]
+async fn wrong_signer_of_lending_market_cannot_change_reserve_config() {
+    let mut test = ProgramTest::new(
+        "spl_token_lending",
+        spl_token_lending::id(),
+        processor!(process_instruction),
+    );
+
+    test.set_compute_max_units(70_000);
+
+    let user_accounts_owner = Keypair::new();
+    let lending_market = add_lending_market(&mut test);
+    let sol_oracle = add_sol_oracle(&mut test);
+
+    const SOL_DEPOSIT_AMOUNT_LAMPORTS: u64 = 10 * LAMPORTS_TO_SOL * INITIAL_COLLATERAL_RATIO;
+    const SOL_RESERVE_COLLATERAL_LAMPORTS: u64 = 2 * SOL_DEPOSIT_AMOUNT_LAMPORTS;
+
+    let sol_test_reserve = add_reserve(
+        &mut test,
+        &lending_market,
+        &sol_oracle,
+        &user_accounts_owner,
+        AddReserveArgs {
+            user_liquidity_amount: SOL_RESERVE_COLLATERAL_LAMPORTS,
+            liquidity_amount: SOL_RESERVE_COLLATERAL_LAMPORTS,
+            liquidity_mint_decimals: 9,
+            liquidity_mint_pubkey: spl_token::native_mint::id(),
+            config: TEST_RESERVE_CONFIG,
+            mark_fresh: true,
+            ..AddReserveArgs::default()
+        },
+    );
+
+    let mut other_lending_market = add_lending_market(&mut test);
+    let other_lending_market_owner = Keypair::new();
+    other_lending_market.owner = other_lending_market_owner;
+
+    let (mut _banks_client, payer, recent_blockhash) = test.start().await;
+
+    const OPTIMAL_UTILIZATION_RATE_CHANGE: u8 = 10;
+
+    let new_config = ReserveConfig {
+        optimal_utilization_rate: TEST_RESERVE_CONFIG.optimal_utilization_rate
+            - OPTIMAL_UTILIZATION_RATE_CHANGE,
+        loan_to_value_ratio: 50,
+        liquidation_bonus: 5,
+        liquidation_threshold: 55,
+        min_borrow_rate: 0,
+        optimal_borrow_rate: 4,
+        max_borrow_rate: 30,
+        fees: ReserveFees {
+            borrow_fee_wad: 100_000_000_000,
+            flash_loan_fee_wad: 3_000_000_000_000_000,
+            host_fee_percentage: 20,
+        },
+    };
+
+    let mut transaction = Transaction::new_with_payer(
+        &[modify_reserve_config(
+            spl_token_lending::id(),
+            new_config,
+            sol_test_reserve.pubkey,
+            lending_market.pubkey,
+            lending_market.owner.pubkey(),
+        )],
+        Some(&payer.pubkey()),
+    );
+
+    transaction.sign(&[&payer, &other_lending_market.owner], recent_blockhash);
+}
+
+#[tokio::test]
+async fn owner_of_different_lending_market_cannot_change_reserve_config() {
+    let mut test = ProgramTest::new(
+        "spl_token_lending",
+        spl_token_lending::id(),
+        processor!(process_instruction),
+    );
+
+    test.set_compute_max_units(70_000);
+
+    let user_accounts_owner = Keypair::new();
+    let lending_market = add_lending_market(&mut test);
+    let sol_oracle = add_sol_oracle(&mut test);
+
+    const SOL_DEPOSIT_AMOUNT_LAMPORTS: u64 = 10 * LAMPORTS_TO_SOL * INITIAL_COLLATERAL_RATIO;
+    const SOL_RESERVE_COLLATERAL_LAMPORTS: u64 = 2 * SOL_DEPOSIT_AMOUNT_LAMPORTS;
+
+    let sol_test_reserve = add_reserve(
+        &mut test,
+        &lending_market,
+        &sol_oracle,
+        &user_accounts_owner,
+        AddReserveArgs {
+            user_liquidity_amount: SOL_RESERVE_COLLATERAL_LAMPORTS,
+            liquidity_amount: SOL_RESERVE_COLLATERAL_LAMPORTS,
+            liquidity_mint_decimals: 9,
+            liquidity_mint_pubkey: spl_token::native_mint::id(),
+            config: TEST_RESERVE_CONFIG,
+            mark_fresh: true,
+            ..AddReserveArgs::default()
+        },
+    );
+
+    // Add a different lending market with a *different* owner
+    let lending_market_pubkey = Pubkey::new_unique();
+    let (lending_market_authority, bump_seed) =
+        Pubkey::find_program_address(&[lending_market_pubkey.as_ref()], &spl_token_lending::id());
+
+    let lending_market_owner = Keypair::new();
+    let oracle_program_id = read_keypair_file("tests/fixtures/oracle_program_id.json")
+        .unwrap()
+        .pubkey();
+
+    test.add_packable_account(
+        lending_market_pubkey,
+        u32::MAX as u64,
+        &LendingMarket::new(InitLendingMarketParams {
+            bump_seed,
+            owner: lending_market_owner.pubkey(),
+            quote_currency: QUOTE_CURRENCY,
+            token_program_id: spl_token::id(),
+            oracle_program_id,
+        }),
+        &spl_token_lending::id(),
+    );
+
+    let other_lending_market = TestLendingMarket {
+        pubkey: lending_market_pubkey,
+        owner: lending_market_owner,
+        authority: lending_market_authority,
+        quote_currency: QUOTE_CURRENCY,
+        oracle_program_id,
+    };
+
+    let (mut banks_client, payer, recent_blockhash) = test.start().await;
+    // Test modify reserve config instruction
+    const OPTIMAL_UTILIZATION_RATE_CHANGE: u8 = 10;
+
+    let new_config = ReserveConfig {
+        optimal_utilization_rate: TEST_RESERVE_CONFIG.optimal_utilization_rate
+            - OPTIMAL_UTILIZATION_RATE_CHANGE,
+        loan_to_value_ratio: 50,
+        liquidation_bonus: 5,
+        liquidation_threshold: 55,
+        min_borrow_rate: 0,
+        optimal_borrow_rate: 4,
+        max_borrow_rate: 30,
+        fees: ReserveFees {
+            borrow_fee_wad: 100_000_000_000,
+            flash_loan_fee_wad: 3_000_000_000_000_000,
+            host_fee_percentage: 20,
+        },
+    };
+
+    let mut transaction = Transaction::new_with_payer(
+        &[modify_reserve_config(
+            spl_token_lending::id(),
+            new_config,
+            sol_test_reserve.pubkey,
+            other_lending_market.pubkey,
+            other_lending_market.owner.pubkey(),
+        )],
+        Some(&payer.pubkey()),
+    );
+
+    transaction.sign(&[&payer, &other_lending_market.owner], recent_blockhash);
+
+    let result = banks_client
+        .process_transaction(transaction)
+        .await
+        .map_err(|e| e.unwrap());
+
+    assert_eq!(
+        result.unwrap_err(),
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(LendingError::InvalidAccountInput as u32)
+        )
+    );
+
+    let reserve_info = sol_test_reserve.get_state(&mut banks_client).await;
+    assert_eq!(
+        reserve_info.config.optimal_utilization_rate,
+        TEST_RESERVE_CONFIG.optimal_utilization_rate
+    );
+}
+
+#[tokio::test]
+async fn correct_owner_providing_wrong_lending_market_fails() {
+    // When the correct owner of the lending market and reserve provides, perhaps inadvertently,
+    // a lending market that is different from the given reserve's corresponding lending market,
+    // then the transaction to modify the current reserve config should fail.
+    let mut test = ProgramTest::new(
+        "spl_token_lending",
+        spl_token_lending::id(),
+        processor!(process_instruction),
+    );
+
+    test.set_compute_max_units(70_000);
+
+    let user_accounts_owner = Keypair::new();
+    let lending_market = add_lending_market(&mut test);
+    let sol_oracle = add_sol_oracle(&mut test);
+
+    const SOL_DEPOSIT_AMOUNT_LAMPORTS: u64 = 10 * LAMPORTS_TO_SOL * INITIAL_COLLATERAL_RATIO;
+    const SOL_RESERVE_COLLATERAL_LAMPORTS: u64 = 2 * SOL_DEPOSIT_AMOUNT_LAMPORTS;
+
+    let sol_test_reserve = add_reserve(
+        &mut test,
+        &lending_market,
+        &sol_oracle,
+        &user_accounts_owner,
+        AddReserveArgs {
+            user_liquidity_amount: SOL_RESERVE_COLLATERAL_LAMPORTS,
+            liquidity_amount: SOL_RESERVE_COLLATERAL_LAMPORTS,
+            liquidity_mint_decimals: 9,
+            liquidity_mint_pubkey: spl_token::native_mint::id(),
+            config: TEST_RESERVE_CONFIG,
+            mark_fresh: true,
+            ..AddReserveArgs::default()
+        },
+    );
+
+    let other_lending_market = add_lending_market(&mut test);
+
+    let (mut banks_client, payer, recent_blockhash) = test.start().await;
+
+    const OPTIMAL_UTILIZATION_RATE_CHANGE: u8 = 10;
+
+    let new_config = ReserveConfig {
+        optimal_utilization_rate: TEST_RESERVE_CONFIG.optimal_utilization_rate
+            - OPTIMAL_UTILIZATION_RATE_CHANGE,
+        loan_to_value_ratio: 50,
+        liquidation_bonus: 5,
+        liquidation_threshold: 55,
+        min_borrow_rate: 0,
+        optimal_borrow_rate: 4,
+        max_borrow_rate: 30,
+        fees: ReserveFees {
+            borrow_fee_wad: 100_000_000_000,
+            flash_loan_fee_wad: 3_000_000_000_000_000,
+            host_fee_percentage: 20,
+        },
+    };
+
+    let mut transaction = Transaction::new_with_payer(
+        &[modify_reserve_config(
+            spl_token_lending::id(),
+            new_config,
+            sol_test_reserve.pubkey,
+            other_lending_market.pubkey,
+            other_lending_market.owner.pubkey(),
+        )],
+        Some(&payer.pubkey()),
+    );
+
+    transaction.sign(&[&payer, &lending_market.owner], recent_blockhash); //lending_market.owner == other_lending_market.owner, defined by `add_lending_market`
+
+    let result = banks_client
+        .process_transaction(transaction)
+        .await
+        .map_err(|e| e.unwrap());
+
+    assert_eq!(
+        result.unwrap_err(),
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(LendingError::InvalidAccountInput as u32)
+        )
+    );
+
+    let reserve_info = sol_test_reserve.get_state(&mut banks_client).await;
+    assert_eq!(
+        reserve_info.config.optimal_utilization_rate,
+        TEST_RESERVE_CONFIG.optimal_utilization_rate
+    );
+}


### PR DESCRIPTION
# Issue & Change Summary
**Issue**: Addresses [issue #1000](https://github.com/solana-labs/solana-program-library/issues/1000)
Reserve configuration values (LTV ratio, liquidation params, APY curve params, etc.) can not be adjusted after the reserve is initialized.

**Summary of changes**:

-  Created an instruction variant `ModifyReserveConfig`, with unpack and pack implementations
- In the processor, created `process_modify_reserve_config` to handle the instruction
- Wrote tests in `modify_reserve_config.rs` to test that the reserve config can be changed and only by the correct lending market owner

# Change Detail & Notes (Not required - one can also just examine code. Only read if additional context is helpful)
**Approach - Steps**:
1. Created `ModifyReserveConfig` instruction variant, with pack & unpack implementations, and created a function to create the instruction. The instruction requires 3 accounts: Reserve account(writable), Lending market account, Lending market owner(signer)
2. In the processor, created `process_modify_reserve_config` which:
    1. Checks the config parameters, with the same rules as those in `init_reserve`
    2. Checks that the provided lending market & owner is correct and corresponds to the reserve to be modified
    3. Changes the reserve state by replacing the old `ReserveConfig` within `Reserve` with the newly provided `ReserveConfig`
3. Refactor the config parameter checks (duplicated in both `process_init_reserve` and `process_modify_reserve_config`) into a helper function `validate_reserve_configs`. Modify both previous functions to use `validate_reserve_configs`
4. Wrote tests in `modify_reserve_config.rs`, which specifically test the following:
    1. Reserve configs can be changed with the correct lending market owner
    2. Reserve configs cannot be changed by a different lending market owner
    3. Reserve configs cannot be changed if the same owner provides a lending market that corresponds to a different `Reserve` state

**Note**: Tangentially, it seems that the `init_reserve.rs` tests (unmodified by this PR) are not passing. The error given is `InstructionError(8, NotEnoughAccountKeys)` by the MintTo call within `process_init_reserve`. However, I was not able to identify what account was missing. More [logs on the error here if helpful](https://gist.github.com/throwbackjams/47c598badc1700adc64c3443b409cf09)