### PR TITLE
token-cli: Move everything to async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6170,6 +6170,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tempfile",
+ "tokio",
  "walkdir",
 ]
 

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -32,6 +32,7 @@ spl-associated-token-account = { version = "1.0.5", path="../../associated-token
 spl-memo = { version = "3.0.1", path="../../memo/program", features = ["no-entrypoint"] }
 strum = "0.24"
 strum_macros = "0.24"
+tokio = "1.14"
 
 [dev-dependencies]
 solana-test-validator = "=1.10.29"

--- a/token/cli/src/bench.rs
+++ b/token/cli/src/bench.rs
@@ -7,8 +7,8 @@ use {
         input_validators::{is_amount, is_parsable, is_valid_pubkey},
     },
     solana_client::{
-        rpc_client::RpcClient,
-        tpu_client::{TpuClient, TpuClientConfig},
+        nonblocking::rpc_client::RpcClient, rpc_client::RpcClient as BlockingRpcClient,
+        tpu_client::TpuClient, tpu_client::TpuClientConfig,
     },
     solana_remote_wallet::remote_wallet::RemoteWalletManager,
     solana_sdk::{
@@ -16,6 +16,10 @@ use {
         system_instruction,
     },
     spl_associated_token_account::*,
+    spl_token::{
+        instruction,
+        state::{Account, Mint},
+    },
     std::{sync::Arc, time::Instant},
 };
 
@@ -160,9 +164,9 @@ impl BenchSubCommand for App<'_, '_> {
     }
 }
 
-pub(crate) fn bench_process_command(
+pub(crate) async fn bench_process_command(
     matches: &ArgMatches<'_>,
-    config: &Config,
+    config: &Config<'_>,
     mut signers: Vec<Box<dyn Signer>>,
     wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> CommandResult {
@@ -179,7 +183,7 @@ pub(crate) fn bench_process_command(
                 config.signer_or_default(arg_matches, "owner", wallet_manager);
             signers.push(owner_signer);
 
-            command_create_accounts(config, signers, &token, n, &owner)?;
+            command_create_accounts(config, signers, &token, n, &owner).await?;
         }
         ("close-accounts", Some(arg_matches)) => {
             let token = pubkey_of_signer(arg_matches, "token", wallet_manager)
@@ -190,7 +194,7 @@ pub(crate) fn bench_process_command(
                 config.signer_or_default(arg_matches, "owner", wallet_manager);
             signers.push(owner_signer);
 
-            command_close_accounts(config, signers, &token, n, &owner)?;
+            command_close_accounts(config, signers, &token, n, &owner).await?;
         }
         ("deposit-into", Some(arg_matches)) => {
             let token = pubkey_of_signer(arg_matches, "token", wallet_manager)
@@ -209,7 +213,8 @@ pub(crate) fn bench_process_command(
 
             command_deposit_into_or_withdraw_from(
                 config, signers, &token, n, &owner, ui_amount, &from, true,
-            )?;
+            )
+            .await?;
         }
         ("withdraw-from", Some(arg_matches)) => {
             let token = pubkey_of_signer(arg_matches, "token", wallet_manager)
@@ -228,7 +233,8 @@ pub(crate) fn bench_process_command(
 
             command_deposit_into_or_withdraw_from(
                 config, signers, &token, n, &owner, ui_amount, &to, false,
-            )?;
+            )
+            .await?;
         }
         _ => unreachable!(),
     }
@@ -260,18 +266,19 @@ fn get_token_addresses_with_seed(
         .collect()
 }
 
-fn is_valid_token(rpc_client: &RpcClient, token: &Pubkey) -> Result<(), Error> {
-    let mint_account_data = rpc_client
+async fn is_valid_token(rpc_client: &RpcClient, token: &Pubkey) -> Result<(), Error> {
+    let mint_account = rpc_client
         .get_account_data(token)
+        .await
         .map_err(|err| format!("Token mint {} does not exist: {}", token, err))?;
 
-    spl_token::state::Mint::unpack(&mint_account_data)
+    Mint::unpack(&mint_account)
         .map(|_| ())
         .map_err(|err| format!("Invalid token mint {}: {}", token, err).into())
 }
 
-fn command_create_accounts(
-    config: &Config,
+async fn command_create_accounts(
+    config: &Config<'_>,
     signers: Vec<Box<dyn Signer>>,
     token: &Pubkey,
     n: usize,
@@ -280,10 +287,11 @@ fn command_create_accounts(
     let rpc_client = &config.rpc_client;
 
     println!("Scanning accounts...");
-    is_valid_token(rpc_client, token)?;
+    is_valid_token(rpc_client, token).await?;
 
     let minimum_balance_for_rent_exemption = rpc_client
-        .get_minimum_balance_for_rent_exemption(spl_token::state::Account::get_packed_len())?;
+        .get_minimum_balance_for_rent_exemption(Account::get_packed_len())
+        .await?;
 
     let mut lamports_required = 0;
 
@@ -292,7 +300,8 @@ fn command_create_accounts(
     let mut messages = vec![];
     for address_chunk in token_addresses_with_seed.chunks(100) {
         let accounts_chunk = rpc_client
-            .get_multiple_accounts(&address_chunk.iter().map(|x| x.0).collect::<Vec<_>>())?;
+            .get_multiple_accounts(&address_chunk.iter().map(|x| x.0).collect::<Vec<_>>())
+            .await?;
 
         for (account, (address, seed)) in accounts_chunk.iter().zip(address_chunk) {
             if account.is_none() {
@@ -305,15 +314,10 @@ fn command_create_accounts(
                             owner,
                             seed,
                             minimum_balance_for_rent_exemption,
-                            spl_token::state::Account::get_packed_len() as u64,
+                            Account::get_packed_len() as u64,
                             &config.program_id,
                         ),
-                        spl_token::instruction::initialize_account(
-                            &config.program_id,
-                            address,
-                            token,
-                            owner,
-                        )?,
+                        instruction::initialize_account(&config.program_id, address, token, owner)?,
                     ],
                     Some(&config.fee_payer),
                 ));
@@ -321,11 +325,11 @@ fn command_create_accounts(
         }
     }
 
-    send_messages(config, &messages, lamports_required, signers)
+    send_messages(config, &messages, lamports_required, signers).await
 }
 
-fn command_close_accounts(
-    config: &Config,
+async fn command_close_accounts(
+    config: &Config<'_>,
     signers: Vec<Box<dyn Signer>>,
     token: &Pubkey,
     n: usize,
@@ -334,18 +338,19 @@ fn command_close_accounts(
     let rpc_client = &config.rpc_client;
 
     println!("Scanning accounts...");
-    is_valid_token(rpc_client, token)?;
+    is_valid_token(rpc_client, token).await?;
 
     let token_addresses_with_seed =
         get_token_addresses_with_seed(&config.program_id, token, owner, n);
     let mut messages = vec![];
     for address_chunk in token_addresses_with_seed.chunks(100) {
         let accounts_chunk = rpc_client
-            .get_multiple_accounts(&address_chunk.iter().map(|x| x.0).collect::<Vec<_>>())?;
+            .get_multiple_accounts(&address_chunk.iter().map(|x| x.0).collect::<Vec<_>>())
+            .await?;
 
         for (account, (address, _seed)) in accounts_chunk.iter().zip(address_chunk) {
             if let Some(account) = account {
-                match spl_token::state::Account::unpack(&account.data) {
+                match Account::unpack(&account.data) {
                     Ok(token_account) => {
                         if token_account.amount != 0 {
                             eprintln!(
@@ -354,7 +359,7 @@ fn command_close_accounts(
                             );
                         } else {
                             messages.push(Message::new(
-                                &[spl_token::instruction::close_account(
+                                &[instruction::close_account(
                                     &config.program_id,
                                     address,
                                     owner,
@@ -373,12 +378,12 @@ fn command_close_accounts(
         }
     }
 
-    send_messages(config, &messages, 0, signers)
+    send_messages(config, &messages, 0, signers).await
 }
 
 #[allow(clippy::too_many_arguments)]
-fn command_deposit_into_or_withdraw_from(
-    config: &Config,
+async fn command_deposit_into_or_withdraw_from(
+    config: &Config<'_>,
     signers: Vec<Box<dyn Signer>>,
     token: &Pubkey,
     n: usize,
@@ -390,9 +395,10 @@ fn command_deposit_into_or_withdraw_from(
     let rpc_client = &config.rpc_client;
 
     println!("Scanning accounts...");
-    is_valid_token(rpc_client, token)?;
+    is_valid_token(rpc_client, token).await?;
 
-    let (mint_pubkey, decimals) = crate::resolve_mint_info(config, from_or_to, Some(*token), None)?;
+    let (mint_pubkey, decimals) =
+        crate::resolve_mint_info(config, from_or_to, Some(*token), None).await?;
     if mint_pubkey != *token {
         return Err(format!("Source account {} is not a {} token", from_or_to, token).into());
     }
@@ -403,12 +409,13 @@ fn command_deposit_into_or_withdraw_from(
     let mut messages = vec![];
     for address_chunk in token_addresses_with_seed.chunks(100) {
         let accounts_chunk = rpc_client
-            .get_multiple_accounts(&address_chunk.iter().map(|x| x.0).collect::<Vec<_>>())?;
+            .get_multiple_accounts(&address_chunk.iter().map(|x| x.0).collect::<Vec<_>>())
+            .await?;
 
         for (account, (address, _seed)) in accounts_chunk.iter().zip(address_chunk) {
             if account.is_some() {
                 messages.push(Message::new(
-                    &[spl_token::instruction::transfer_checked(
+                    &[instruction::transfer_checked(
                         &config.program_id,
                         if deposit_into { from_or_to } else { address },
                         token,
@@ -426,11 +433,11 @@ fn command_deposit_into_or_withdraw_from(
         }
     }
 
-    send_messages(config, &messages, 0, signers)
+    send_messages(config, &messages, 0, signers).await
 }
 
-fn send_messages(
-    config: &Config,
+async fn send_messages(
+    config: &Config<'_>,
     messages: &[Message],
     mut lamports_required: u64,
     signers: Vec<Box<dyn Signer>>,
@@ -442,7 +449,8 @@ fn send_messages(
 
     let (_blockhash, fee_calculator, _last_valid_block_height) = config
         .rpc_client
-        .get_recent_blockhash_with_commitment(config.rpc_client.commitment())?
+        .get_recent_blockhash_with_commitment(config.rpc_client.commitment())
+        .await?
         .value;
 
     lamports_required += messages
@@ -456,17 +464,18 @@ fn send_messages(
         Sol(lamports_required)
     );
 
-    crate::check_fee_payer_balance(config, lamports_required)?;
+    crate::check_fee_payer_balance(config, lamports_required).await?;
 
+    // TODO use async tpu client once it's available in 1.11
     let start = Instant::now();
+    let rpc_client = BlockingRpcClient::new(config.rpc_client.url());
     let tpu_client = TpuClient::new(
-        config.rpc_client.clone(),
+        Arc::new(rpc_client),
         &config.websocket_url,
         TpuClientConfig::default(),
     )?;
     let transaction_errors =
         tpu_client.send_and_confirm_messages_with_spinner(messages, &signers)?;
-
     for (i, transaction_error) in transaction_errors.into_iter().enumerate() {
         if let Some(transaction_error) = transaction_error {
             println!("Message {} failed with {:?}", i, transaction_error);

--- a/token/cli/src/config.rs
+++ b/token/cli/src/config.rs
@@ -4,7 +4,7 @@ use solana_clap_utils::{
     keypair::{pubkey_from_path, signer_from_path_with_config, SignerFromPathConfig},
 };
 use solana_cli_output::OutputFormat;
-use solana_client::{blockhash_query::BlockhashQuery, rpc_client::RpcClient};
+use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_remote_wallet::remote_wallet::RemoteWalletManager;
 use solana_sdk::{pubkey::Pubkey, signature::Signer};
 use spl_associated_token_account::*;
@@ -29,7 +29,6 @@ pub(crate) struct Config<'a> {
     pub(crate) default_keypair: KeypairOrPath,
     pub(crate) nonce_account: Option<Pubkey>,
     pub(crate) nonce_authority: Option<Pubkey>,
-    pub(crate) blockhash_query: BlockhashQuery,
     pub(crate) sign_only: bool,
     pub(crate) dump_transaction_message: bool,
     pub(crate) multisigner_pubkeys: Vec<&'a Pubkey>,
@@ -39,9 +38,9 @@ pub(crate) struct Config<'a> {
 impl<'a> Config<'a> {
     // Check if an explicit token account address was provided, otherwise
     // return the associated token address for the default address.
-    pub(crate) fn associated_token_address_or_override(
+    pub(crate) async fn associated_token_address_or_override(
         &self,
-        arg_matches: &ArgMatches,
+        arg_matches: &ArgMatches<'_>,
         override_name: &str,
         wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
     ) -> Pubkey {
@@ -52,13 +51,14 @@ impl<'a> Config<'a> {
             wallet_manager,
             token,
         )
+        .await
     }
 
     // Check if an explicit token account address was provided, otherwise
     // return the associated token address for the default address.
-    pub(crate) fn associated_token_address_for_token_or_override(
+    pub(crate) async fn associated_token_address_for_token_or_override(
         &self,
-        arg_matches: &ArgMatches,
+        arg_matches: &ArgMatches<'_>,
         override_name: &str,
         wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
         token: Option<Pubkey>,


### PR DESCRIPTION
#### Problem

We need to move the token cli to async in order to use the rust token-client with token-2022 extensions.

#### Solution

Move it all to async!  No functional changes here, but some of the tests were slightly rewritten to more easily slot in token-2022 later.

Note: the async TpuClient will only come in with 1.11, so `spl-token bench` is still blocking.