### PR TITLE
Issue #1805 - reverse logic for --recipient-is-ata-owner

### DIFF
--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -943,6 +943,21 @@ fn command_burn(
     })
 }
 
+
+fn check_mint(
+    config: &Config,
+    token: Pubkey,
+    ui_amount : f64,
+) -> bool {
+    let supply = config.rpc_client.get_token_supply(&token).unwrap();
+    let amount = ui_amount;
+    if amount + supply.ui_amount.unwrap()> 18446744073709551615.0 {
+    return true;
+    };
+    return false;
+}
+    
+
 #[allow(clippy::too_many_arguments)]
 fn command_mint(
     config: &Config,
@@ -2885,6 +2900,10 @@ fn process_command(
             );
             let mint_decimals = value_of::<u8>(arg_matches, MINT_DECIMALS_ARG.name);
             let use_unchecked_instruction = arg_matches.is_present("use_unchecked_instruction");
+            if check_mint(config, token, amount) {
+                return Err("Supply requested to be minted is greater than the u64 token supply limit".to_string().into());
+            }
+            else {
             command_mint(
                 config,
                 token,
@@ -2895,6 +2914,8 @@ fn process_command(
                 use_unchecked_instruction,
                 bulk_signers,
             )
+        }
+
         }
         (CommandName::Freeze, arg_matches) => {
             let (freeze_authority_signer, freeze_authority) =

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -674,7 +674,7 @@ fn command_transfer(
     allow_unfunded_recipient: bool,
     fund_recipient: bool,
     mint_decimals: Option<u8>,
-    recipient_is_ata_owner: bool,
+    no_recipient_is_ata_owner: bool,
     use_unchecked_instruction: bool,
     memo: Option<String>,
     bulk_signers: BulkSigners,
@@ -766,7 +766,7 @@ fn command_transfer(
             .map(|(recipient_is_token_account, _)| recipient_is_token_account)
             .unwrap_or(false)
     } else {
-        !recipient_is_ata_owner
+        no_recipient_is_ata_owner
     };
 
     if !recipient_is_token_account {
@@ -2097,8 +2097,8 @@ fn app<'a, 'b>(
                         .help("Send tokens to the recipient even if the recipient is not a wallet owned by System Program."),
                 )
                 .arg(
-                    Arg::with_name("recipient_is_ata_owner")
-                        .long("recipient-is-ata-owner")
+                    Arg::with_name("no_recipient_is_ata_owner")
+                        .long("no-recipient-is-ata-owner")
                         .takes_value(false)
                         .requires("sign_only")
                         .help("In sign-only mode, specifies that the recipient is the owner of the associated token account rather than an actual token account"),
@@ -2842,7 +2842,7 @@ fn process_command(
             let allow_unfunded_recipient = arg_matches.is_present("allow_empty_recipient")
                 || arg_matches.is_present("allow_unfunded_recipient");
 
-            let recipient_is_ata_owner = arg_matches.is_present("recipient_is_ata_owner");
+            let no_recipient_is_ata_owner = arg_matches.is_present("no_recipient_is_ata_owner");
             let use_unchecked_instruction = arg_matches.is_present("use_unchecked_instruction");
             let memo = value_t!(arg_matches, "memo", String).ok();
 
@@ -2856,7 +2856,7 @@ fn process_command(
                 allow_unfunded_recipient,
                 fund_recipient,
                 mint_decimals,
-                recipient_is_ata_owner,
+                no_recipient_is_ata_owner,
                 use_unchecked_instruction,
                 memo,
                 bulk_signers,

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -963,6 +963,8 @@ fn check_if_amount_overflows_supply(
 ) -> bool {
     let supply = config.rpc_client.get_token_supply(&token).unwrap();
     let amount = ui_amount;
+    //let max = u64::MAX;
+    //println!("{}", max);
     //println!("{}", supply.ui_amount.unwrap());
     //println!("{}", amount);
     //let sum1 = supply.ui_amount.unwrap()+amount;
@@ -975,7 +977,12 @@ fn check_if_amount_overflows_supply(
     println!("{}", supply.amount);
     let s = supply.amount;
     let my_int: u64 = s.parse().unwrap();
-
+    let aaa = 18446744073709551615 as u64;
+    let b = aaa as f64;
+    let ss: String = aaa.to_string();
+    let testint = ss.parse::<f64>().unwrap();
+    println!("Check {}", testint);
+    
     if amount.checked_add(my_int).is_none() {
         return true;
     };
@@ -984,6 +991,7 @@ fn check_if_amount_overflows_supply(
     return true;
     };
     return false;
+
 }
     
 
@@ -1018,25 +1026,26 @@ fn command_mint(
     let amount = 0;
     let amount = if decimals==0 {
         ui_amount
+        //spl_token::ui_amount_to_amount(ui_amount as f64, decimals)
         //println!("{}", decimals);
         //println!("{}", amount);
     }
     else {
-        spl_token::ui_amount_to_amount(ui_amount as f64, decimals)
+        spl_token::ui_amount_to_amount2(ui_amount, decimals)
         //println!("Hello");
         //println!("{}", decimals);
         //println!("{}", amount);
+
+        //Do everything in fixed point
+
     };
-
-
-
 
     //The issue happens here!
 
     // println!("{}", decimals);
     // let amount = ui_amount;
     // println!("{}", amount);
-    println!("{}", amount);
+    println!("STRANGE FUNCTION {}", amount);
     let instructions = if use_unchecked_instruction {
         vec![mint_to(
             &config.program_id,

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -1007,6 +1007,14 @@ fn command_mint(
     );
 
     let (_, decimals) = resolve_mint_info(config, &recipient, None, mint_decimals)?;
+    
+    let a =10;
+    let a = u64::pow(a, decimals.into());
+    let maxsupply = u64::MAX/a;
+    if ui_amount>maxsupply {
+        println!("WARNING: Max supply will be limited to {}",maxsupply);
+    };
+    //Code is not production level ready yet
     let amount = 0;
     let amount = if decimals==0 {
         ui_amount
@@ -1019,6 +1027,10 @@ fn command_mint(
         //println!("{}", decimals);
         //println!("{}", amount);
     };
+
+
+
+
     //The issue happens here!
 
     // println!("{}", decimals);

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -944,7 +944,7 @@ fn command_burn(
 }
 
 
-fn check_mint(
+fn check_if_amount_overflows_supply(  
     config: &Config,
     token: Pubkey,
     ui_amount : f64,
@@ -2900,7 +2900,7 @@ fn process_command(
             );
             let mint_decimals = value_of::<u8>(arg_matches, MINT_DECIMALS_ARG.name);
             let use_unchecked_instruction = arg_matches.is_present("use_unchecked_instruction");
-            if check_mint(config, token, amount) {
+            if check_if_amount_overflows_supply(config, token, amount) {
                 return Err("Supply requested to be minted is greater than the u64 token supply limit".to_string().into());
             }
             else {

--- a/token/program/src/lib.rs
+++ b/token/program/src/lib.rs
@@ -22,7 +22,8 @@ pub fn ui_amount_to_amount(ui_amount: f64, decimals: u8) -> u64 {
     (ui_amount * 10_usize.pow(decimals as u32) as f64) as u64
 }
 
-/// test
+/// Convert the UI representation of a token amount (using the decimals field defined in its mint)
+/// to the raw amount. Used for ui_amount as u64 to have precision upto 20 digits
 pub fn ui_amount_to_amountmint(ui_amount: u64, decimals: u8) -> u64 {
     (ui_amount * 10_usize.pow(decimals as u32) as u64) as u64
 }

--- a/token/program/src/lib.rs
+++ b/token/program/src/lib.rs
@@ -22,6 +22,11 @@ pub fn ui_amount_to_amount(ui_amount: f64, decimals: u8) -> u64 {
     (ui_amount * 10_usize.pow(decimals as u32) as f64) as u64
 }
 
+/// test
+pub fn ui_amount_to_amount2(ui_amount: u64, decimals: u8) -> u64 {
+    (ui_amount * 10_usize.pow(decimals as u32) as u64) as u64
+}
+
 /// Convert a raw amount to its UI representation (using the decimals field defined in its mint)
 pub fn amount_to_ui_amount(amount: u64, decimals: u8) -> f64 {
     amount as f64 / 10_usize.pow(decimals as u32) as f64

--- a/token/program/src/lib.rs
+++ b/token/program/src/lib.rs
@@ -23,7 +23,7 @@ pub fn ui_amount_to_amount(ui_amount: f64, decimals: u8) -> u64 {
 }
 
 /// test
-pub fn ui_amount_to_amount2(ui_amount: u64, decimals: u8) -> u64 {
+pub fn ui_amount_to_amountmint(ui_amount: u64, decimals: u8) -> u64 {
     (ui_amount * 10_usize.pow(decimals as u32) as u64) as u64
 }
 


### PR DESCRIPTION
Pull request for issue #1805 

Retained --recipient-is-ata-owner as a hidden flag and, if passed, warn the user that the behavior is now default, the flag is deprecated and can be removed.

New flag called --no-recipient-is-ata-owner to match convention of other CLI tools. Reverse the logic for the flag.