### PR TITLE
token-cli: Bump version to 2.0.16 for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6078,7 +6078,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-cli"
-version = "2.0.15"
+version = "2.0.16"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://spl.solana.com/token"
 license = "Apache-2.0"
 name = "spl-token-cli"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "2.0.15"
+version = "2.0.16"
 
 [build-dependencies]
 walkdir = "2"


### PR DESCRIPTION
#### Problem

It's time to release a new version of the token cli to pick up fixes on nonce transactions.

#### Solution

The crates are already bumped, so bump the token-cli crate version for release.