### PR TITLE
token-cli: Make BPF program builds in build.rs dependent on env var

### DIFF
--- a/ci/cargo-build-test.sh
+++ b/ci/cargo-build-test.sh
@@ -15,8 +15,8 @@ set -x
 make -C examples/c
 
 # Build/test all host crates
-cargo +"$rust_stable" build
-BUILD_DEPENDENT_PROGRAMS=1 cargo +"$rust_stable" test -- --nocapture
+BUILD_DEPENDENT_PROGRAMS=1 cargo +"$rust_stable" build
+cargo +"$rust_stable" test -- --nocapture
 
 # Run test-client sanity check
 cargo +"$rust_stable" run --manifest-path=utils/test-client/Cargo.toml

--- a/ci/cargo-build-test.sh
+++ b/ci/cargo-build-test.sh
@@ -16,7 +16,7 @@ make -C examples/c
 
 # Build/test all host crates
 cargo +"$rust_stable" build
-cargo +"$rust_stable" test -- --nocapture
+BUILD_DEPENDENT_PROGRAMS=1 cargo +"$rust_stable" test -- --nocapture
 
 # Run test-client sanity check
 cargo +"$rust_stable" run --manifest-path=utils/test-client/Cargo.toml

--- a/token/cli/build.rs
+++ b/token/cli/build.rs
@@ -46,32 +46,34 @@ fn build_bpf(program_directory: &Path) {
 }
 
 fn main() {
-    if let Ok(debug) = env::var("DEBUG") {
-        if debug == "true" {
-            let cwd = env::current_dir().expect("Unable to get current working directory");
-            let spl_token_2022_dir = cwd
-                .parent()
-                .expect("Unable to get parent directory of current working dir")
-                .join("program-2022");
-            rerun_if_changed(&spl_token_2022_dir);
-            let spl_token_dir = cwd
-                .parent()
-                .expect("Unable to get parent directory of current working dir")
-                .join("program");
-            rerun_if_changed(&spl_token_dir);
-            let spl_associated_token_account_dir = cwd
-                .parent()
-                .expect("Unable to get parent directory of current working dir")
-                .parent()
-                .expect("Unable to get parent directory of current working dir")
-                .join("associated-token-account")
-                .join("program");
-            rerun_if_changed(&spl_associated_token_account_dir);
+    let is_debug = env::var("DEBUG").map(|v| v == "true").unwrap_or(false);
+    let build_dependent_programs = env::var("BUILD_DEPENDENT_PROGRAMS")
+        .map(|v| v != "false" && v != "0")
+        .unwrap_or(false);
+    if is_debug && build_dependent_programs {
+        let cwd = env::current_dir().expect("Unable to get current working directory");
+        let spl_token_2022_dir = cwd
+            .parent()
+            .expect("Unable to get parent directory of current working dir")
+            .join("program-2022");
+        rerun_if_changed(&spl_token_2022_dir);
+        let spl_token_dir = cwd
+            .parent()
+            .expect("Unable to get parent directory of current working dir")
+            .join("program");
+        rerun_if_changed(&spl_token_dir);
+        let spl_associated_token_account_dir = cwd
+            .parent()
+            .expect("Unable to get parent directory of current working dir")
+            .parent()
+            .expect("Unable to get parent directory of current working dir")
+            .join("associated-token-account")
+            .join("program");
+        rerun_if_changed(&spl_associated_token_account_dir);
 
-            build_bpf(&spl_token_dir);
-            build_bpf(&spl_token_2022_dir);
-            build_bpf(&spl_associated_token_account_dir);
-        }
+        build_bpf(&spl_token_dir);
+        build_bpf(&spl_token_2022_dir);
+        build_bpf(&spl_associated_token_account_dir);
     }
     println!("cargo:rerun-if-changed=build.rs");
 }


### PR DESCRIPTION
#### Problem

The token-cli `build.rs` helpfully builds dependent BPF programs required for tests (token, token-2022, and associated-token-account). It's currently behind a check for the `DEBUG` environment variable, which means that it only runs on debug builds.  This is fine for the most part, but `cargo build` and even `cargo publish` do debug builds before the publish, which means that we currently can't publish the token-cli crate.

#### Solution

Add a new environment variable for building the dependent programs.

I'm not very happy with this solution, but there are literally no special environment variables set during `cargo test` which are available to `build.rs`, to tell us if we're in a testing environment.

Other options are to eliminate the file entirely or add crate feature to build the programs.  The crate feature seemed worse to me, but I can be swayed.

cc @jstarry (sorry for not publishing just yet, will do once this is sorted)