### PR TITLE
token-cli: Add token-client dependency for token-2022 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6285,6 +6285,7 @@ dependencies = [
  "spl-memo 3.0.1",
  "spl-token 3.3.0",
  "spl-token-2022 0.4.2",
+ "spl-token-client",
  "strum",
  "strum_macros",
  "tempfile",

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -29,6 +29,7 @@ solana-sdk = "=1.10.33"
 solana-transaction-status = "=1.10.33"
 spl-token = { version = "3.3", path="../program", features = [ "no-entrypoint" ] }
 spl-token-2022 = { version = "0.4", path="../program-2022", features = [ "no-entrypoint" ] }
+spl-token-client = { version = "0.1", path="../client" }
 spl-associated-token-account = { version = "1.0.5", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
 spl-memo = { version = "3.0.1", path="../../memo/program", features = ["no-entrypoint"] }
 strum = "0.24"

--- a/token/cli/src/config.rs
+++ b/token/cli/src/config.rs
@@ -13,6 +13,7 @@ use spl_token_2022::{
     extension::StateWithExtensionsOwned,
     state::{Account, Mint},
 };
+use spl_token_client::client::{ProgramClient, ProgramRpcClientSendTransaction};
 use std::{process::exit, sync::Arc};
 
 #[cfg(test)]
@@ -34,6 +35,7 @@ pub(crate) struct MintInfo {
 
 pub(crate) struct Config<'a> {
     pub(crate) rpc_client: Arc<RpcClient>,
+    pub(crate) program_client: Arc<dyn ProgramClient<ProgramRpcClientSendTransaction>>,
     pub(crate) websocket_url: String,
     pub(crate) output_format: OutputFormat,
     pub(crate) fee_payer: Pubkey,


### PR DESCRIPTION
#### Problem

We want to integrate token-2022 extensions into the token-cli, and a lot of the work is already done in the token-client.

#### Solution

Add a `program_client` field to the token cli config, which can be used when using token-2022 extensions or instructions.

This uses `config.program_client` just to get rent exemptions, which was an easy way to show that the new field exists and can be used.