### PR TITLE
docs: Fix links

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -9,8 +9,8 @@ module.exports = {
       items: [
         "token-2022",
         "token-2022/extensions",
-        "token-2022/wallet-migration",
-        "token-2022/onchain-migration",
+        "token-2022/wallet",
+        "token-2022/onchain",
       ],
     },
     "token-swap",


### PR DESCRIPTION
#### Problem

When adding the new token docs, some of the filenames were changed, but not in the sidebars, causing a build error.

#### Solution

Fix the links, and in the future, consider doing a docs build in CI for PRs on docs. I thought this was happening already, but maybe we need to add one more step.