### PR TITLE
ci: Harden docs publish to only run with a vercel token

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -6,21 +6,22 @@ cd "$(dirname "$0")"
 # shellcheck source=ci/env.sh
 source ../ci/env.sh
 
-# Publish only from merge commits and release tags
-if [[ -n $CI ]]; then
-  if [[ -z $CI_PULL_REQUEST ]]; then
-    npm install --global docusaurus-init
-    docusaurus-init
-    npm install --global vercel
-  fi
+# Publish only if in CI, vercel token is present, and it's not a pull request
+if [[ -n $CI ]] && [[ -n $VERCEL_TOKEN ]] && [[ -z $CI_PULL_REQUEST ]]; then
+  PUBLISH_DOCS=true
+else
+  PUBLISH_DOCS=
+fi
+
+if [[ -n $PUBLISH_DOCS ]]; then
+  npm install --global docusaurus-init
+  docusaurus-init
+  npm install --global vercel
 fi
 
 # Build from /src into /build
 npm run build
 
-# Publish only from merge commits and release tags
-if [[ -n $CI ]]; then
-  if [[ -z $CI_PULL_REQUEST ]]; then
+if [[ -n $PUBLISH_DOCS ]]; then
     ./publish-docs.sh
-  fi
 fi


### PR DESCRIPTION
#### Problem

The docs CI build is failing on a push to master, since it's expecting the VERCEL_TOKEN, which isn't there.

#### Solution

Only try to publish docs if the VERCEL_TOKEN is set.