### PR TITLE
token-cli: Run tests in batches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4217,7 +4217,20 @@ checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
 dependencies = [
  "lazy_static",
  "parking_lot 0.11.2",
- "serial_test_derive",
+ "serial_test_derive 0.5.1",
+]
+
+[[package]]
+name = "serial_test"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eec42e7232e5ca56aa59d63af3c7f991fe71ee6a3ddd2d3480834cf3902b007"
+dependencies = [
+ "futures 0.3.21",
+ "lazy_static",
+ "log",
+ "parking_lot 0.12.0",
+ "serial_test_derive 0.8.0",
 ]
 
 [[package]]
@@ -4228,6 +4241,19 @@ checksum = "b2acd6defeddb41eb60bb468f8825d0cfd0c2a76bc03bfd235b6a1dc4f6a1ad5"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.14",
+ "syn 1.0.91",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1b95bb2f4f624565e8fe8140c789af7e2082c0e0561b5a82a1b678baa9703dc"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
+ "rustversion",
  "syn 1.0.91",
 ]
 
@@ -6155,7 +6181,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
- "serial_test",
+ "serial_test 0.5.1",
  "solana-program",
  "solana-program-test",
  "solana-sdk",
@@ -6208,7 +6234,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "serial_test",
+ "serial_test 0.5.1",
  "solana-program",
  "solana-program-test",
  "solana-sdk",
@@ -6244,6 +6270,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "serial_test 0.8.0",
  "solana-account-decoder",
  "solana-clap-utils",
  "solana-cli-config",

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -38,6 +38,7 @@ tokio = "1.14"
 [dev-dependencies]
 solana-test-validator = "=1.10.33"
 assert_cmd = "2.0.4"
+serial_test = "0.8.0"
 tempfile = "3.3.0"
 
 [[bin]]

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -3283,6 +3283,7 @@ async fn handle_tx<'a>(
 mod tests {
     use {
         super::*,
+        serial_test::parallel,
         solana_sdk::{
             bpf_loader,
             signature::{write_keypair_file, Keypair, Signer},
@@ -3462,6 +3463,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[parallel(one)]
     async fn create_token_default() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -3481,6 +3483,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[parallel(two)]
     async fn supply() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -3499,6 +3502,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[parallel(one)]
     async fn create_account_default() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -3519,6 +3523,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[parallel(two)]
     async fn account_info() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -3551,6 +3556,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[parallel(one)]
     async fn balance() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -3570,6 +3576,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[parallel(two)]
     async fn mint() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -3597,6 +3604,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[parallel(one)]
     async fn balance_after_mint() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -3618,6 +3626,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[parallel(two)]
     async fn accounts() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -3641,6 +3650,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[parallel(one)]
     async fn wrap() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -3668,6 +3678,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[parallel(two)]
     async fn unwrap() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -3694,6 +3705,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[parallel(one)]
     async fn transfer() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -3727,6 +3739,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[parallel(two)]
     async fn transfer_fund_recipient() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -3759,6 +3772,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[parallel(one)]
     async fn failing_to_allow_non_system_account_recipient() {
         let (test_validator, payer) = new_validator_for_test().await;
         let config = test_config(&test_validator, &payer, &spl_token::id());
@@ -3785,6 +3799,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[parallel(two)]
     async fn allow_non_system_account_recipient() {
         let (test_validator, payer) = new_validator_for_test().await;
         let config = test_config(&test_validator, &payer, &spl_token::id());
@@ -3821,6 +3836,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[parallel(one)]
     async fn close_wrapped_sol_account() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -3867,6 +3883,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[parallel(two)]
     async fn disable_mint_authority() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -3893,6 +3910,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[parallel(one)]
     async fn gc() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -3938,6 +3956,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[parallel(two)]
     async fn set_owner() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -3966,6 +3985,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[parallel(one)]
     async fn transfer_with_account_delegate() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -4060,6 +4080,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[parallel(two)]
     async fn burn_with_account_delegate() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {


### PR DESCRIPTION
#### Problem

The token cli tests have become flaky, as an outcome of running so many test validators in parallel.

#### Solution

Run the tests in two big batches using `serial_test::parallel`.  If needed, we can instead do it in three batches.  This seemed like an easy solution, but does require setting a new `parallel` for each test added, which could be annoying.  Alternatives are welcome!