### PR TITLE
token-swap: Support two token programs at once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6371,6 +6371,8 @@ dependencies = [
  "solana-sdk",
  "spl-math",
  "spl-token 3.5.0",
+ "spl-token-2022 0.4.2",
+ "test-case",
  "thiserror",
 ]
 
@@ -6674,6 +6676,28 @@ name = "termtree"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
+
+[[package]]
+name = "test-case"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07aea929e9488998b64adc414c29fe5620398f01c2e3f58164122b17e567a6d5"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c95968eedc6fc4f5c21920e0f4264f78ec5e4c56bb394f319becc1a5830b3e54"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro-error",
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
+ "syn 1.0.91",
+]
 
 [[package]]
 name = "test-client"

--- a/docs/src/token-2022/onchain.md
+++ b/docs/src/token-2022/onchain.md
@@ -2,12 +2,15 @@
 title: On-chain Program Guide
 ---
 
+## Supporting Token and Token-2022 Together In Your Program
+
 This guide is meant for on-chain program / dapp developers who want to support
 Token and Token-2022 concurrently.
 
 ## Prerequisites
 
-This guide requires the Solana CLI tool suite.
+This guide requires the Solana CLI tool suite, minimum version 1.10.33 in order
+to support all Token-2022 features.
 
 ## Motivation
 
@@ -20,6 +23,10 @@ guide walks through the steps required to support both.
 Important note: if you do not wish to support Token-2022, there is nothing to do.
 Your existing on-chain program will loudly fail if an instruction includes any
 Token-2022 mints / accounts.
+
+Most likely, your program will fail with `ProgramError::IncorrectProgramId` while
+trying to create a CPI instruction into the Token program, providing the Token-2022
+program id.
 
 ## Structure of this Guide
 
@@ -83,7 +90,7 @@ If you're using `solana-test-validator` for your tests, you can include it using
 $ solana-test-validator -c TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb 
 ```
 
-Note: This step is temporary, until Token-2022 is included by default in
+**Note**: This step is temporary, until Token-2022 is included by default in
 `program-test` and `solana-test-validator`.
 
 The token-swap does not use `program-test`, so there's a bit more

--- a/docs/src/token-2022/onchain.md
+++ b/docs/src/token-2022/onchain.md
@@ -2,4 +2,229 @@
 title: On-chain Program Guide
 ---
 
-Coming soon!
+This guide is meant for on-chain program / dapp developers who want to support
+Token and Token-2022 concurrently.
+
+## Prerequisites
+
+This guide requires the Solana CLI tool suite.
+
+## Motivation
+
+On-chain program developers are accustomed to only including one token program,
+to be used for all tokens in the application.
+
+With the addition of Token-2022, developers must update on-chain programs. This
+guide walks through the steps required to support both.
+
+Important note: if you do not wish to support Token-2022, there is nothing to do.
+Your existing on-chain program will loudly fail if an instruction includes any
+Token-2022 mints / accounts.
+
+## Structure of this Guide
+
+To safely code the transition, we'll follow a test-driven development approach:
+
+* add a dependency to `spl-token-2022`
+* change tests to use `spl_token::id()` or `spl_token_2022::id()`, see that all
+tests fail with Token-2022
+* update on-chain program code to always use the instruction and deserializers from 
+`spl_token_2022`, make all tests pass
+
+Optionally, if an instruction uses more than one token mint, common to most DeFi,
+you must add an input token program account for each additional mint. Since it's
+possible to swap all types of tokens, we need to either invoke the correct token
+program.
+
+Everything here will reference real commits to the token-swap program, so
+feel free to follow along and make the changes to your program.
+
+## Part I: Support both token programs in single-token use cases
+
+### Step 1: Update dependencies
+
+In your `Cargo.toml`, add the latest `spl-token-2022` to your `dependencies`.
+Check for the latest version of `spl-token-2022` in [crates.io](https://crates.io), since
+that will typically be the version deployed to mainnet-beta.
+
+### Step 2: Add test cases for Token and Token-2022
+
+Using the `test-case` crate, you can update all tests to use both Token and
+Token-2022. For example, a test defined as:
+
+```
+#[tokio::test]
+async fn test_swap() {
+    ...
+}
+```
+
+Will become:
+
+```
+#[test_case(spl_token::id() ; "Token Program")]
+#[test_case(spl_token_2022::id() ; "Token-2022 Program")]
+#[tokio::test]
+async fn test_swap(token_program_id: Pubkey) {
+    ...
+}
+```
+
+In your program-test setup, you must include `spl_token_2022.so` at the correct
+address. You can add it as normal to `tests/fixtures/` after downloading it using:
+
+```console
+$ solana program dump TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb spl_token_2022.so
+```
+
+If you're using `solana-test-validator` for your tests, you can include it using:
+
+```console
+$ solana-test-validator -c TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb 
+```
+
+Note: This step is temporary, until Token-2022 is included by default in
+`program-test` and `solana-test-validator`.
+
+The token-swap does not use `program-test`, so there's a bit more
+boilerplate, but the same principle applies.
+
+### Step 3: Replace instruction creators
+
+Everywhere in the code that uses `spl_token::instruction` must now use
+`spl_token_2022::instruction`. The `"Token-2022 Program"` tests will still fail,
+but importantly, the `"Token Program"` tests will pass using the new instruction
+creators.
+
+If your program uses unchecked transfers, you'll see a deprecation warning:
+
+```
+warning: use of deprecated function `spl_token_2022::instruction::transfer`: please use `transfer_checked` or `transfer_checked_with_fee` instead
+```
+
+If a token has a transfer fee, an unchecked transfer will fail. We'll fix that
+later. If you want, in the meantime, feel free to add an `#[allow(deprecated)]`
+to pass CI, with a TODO or issue to transition to `transfer_checked` everywhere.
+
+### Step 4: Replace spl_token::id() with a parameter
+
+Step 2 started the transition away from a fixed program id by adding
+`token_program_id` as a parameter to the test function, but now you'll go
+through your program and tests to use it everywhere.
+
+Whenever `spl_token::id()` appears in the code, use a parameter corresponding
+either to `spl_token::id()` or `spl_token_2022::id()`.
+
+After this, all of your tests should pass! Not so fast though, there's one more
+step needed to ensure compatibility.
+
+### Step 5: Add Extensions to Tests
+
+Although all of your tests are passing, you still need to account for differences
+in accounts in token-2022.
+
+Account extensions are stored after the first 165 bytes of the account, and the
+normal `Account::unpack` and `Mint::unpack` will fail if the size of the account
+is not exactly 165 and 82, respectively.
+
+Let's make the tests fail again by adding an extension to all mint and token
+accounts.  We'll add the `MintCloseAuthority` extension to mints, and the `ImmutableOwner`
+extension to accounts.
+
+When creating mint accounts, calculate the space required before allocating, then
+include an `initialize_mint_close_authority` instruction before `initialize_mint`.
+For example this could be:
+
+```rust
+use spl_token_2022::{extension::ExtensionType, instruction::*, state::Mint};
+use solana_sdk::{system_instruction, transaction::Transaction};
+
+// Calculate the space required using the `ExtensionType`
+let space = ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]);
+
+// get the Rent object and calculate the rent required
+let rent_required = rent.minimum_balance(space);
+
+// and then create the account using those parameters
+let create_instruction = system_instruction::create_account(&payer.pubkey(), mint_pubkey, rent_required, space, token_program_id);
+
+// Important: you must initialize the mint close authority *BEFORE* initializing the mint,
+// and only when working with Token-2022, since the instruction is unsupported by Token.
+let initialize_close_authority_instruction = initialize_mint_close_authority(token_program_id, mint_pubkey, Some(close_authority)).unwrap();
+let initialize_mint_instruction = initialize_mint(token_program_id, mint_pubkey, mint_authority_pubkey, freeze_authority, 9).unwrap();
+
+// Make the transaction with all of these instructions
+let create_mint_transaction = Transaction::new(&[create_instruction, initialize_close_authority_instruction, initialize_mint_instruction], Some(&payer.pubkey));
+
+// Sign it and send it however you want!
+```
+
+The concept is similar with token accounts, but we'll use the `ImmutableOwner`
+extension, which is actually supported by both programs, but `Tokenkeg...` will
+no-op.
+
+```rust
+use spl_token_2022::{extension::ExtensionType, instruction::*, state::Account};
+use solana_sdk::{system_instruction, transaction::Transaction};
+
+// Calculate the space required using the `ExtensionType`
+let space = ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]);
+
+// get the Rent object and calculate the rent required
+let rent_required = rent.minimum_balance(space);
+
+// and then create the account using those parameters
+let create_instruction = system_instruction::create_account(&payer.pubkey(), account_pubkey, rent_required, space, token_program_id);
+
+// Important: you must initialize immutable owner *BEFORE* initializing the account
+let initialize_immutable_owner_instruction = initialize_immutable_owner(token_program_id, account_pubkey).unwrap();
+let initialize_account_instruction = initialize_account(token_program_id, account_pubkey, mint_pubkey, owner_pubkey).unwrap();
+
+// Make the transaction with all of these instructions
+let create_account_transaction = Transaction::new(&[create_instruction, initialize_immutable_owner_instruction, initialize_account_instruction], Some(&payer.pubkey));
+
+// Sign it and send it however you want!
+```
+
+After making these changes, everything fails again. Well done!
+
+### Step 6: Use `StateWithExtensions` instead of `Mint` and `Account`
+
+The test failures happen because the program is trying to deserialize a pure
+`Mint` or `Account`, and failing because there are extensions added to it.
+
+Token-2022 adds a new type called `StateWithExtensions`, which allows you to
+deserialize the base type, and then pull out any extensions on the fly. It's
+very close to the same cost as the normal `unpack`.
+
+Everywhere in your code, wherever you see `Mint::unpack` or `Account::unpack`,
+you'll have to change that to:
+
+```rust
+use spl_token_2022::{extension::StateWithExtensions, state::{Account, Mint}};
+let account_state = StateWithExtensions::<Account>::unpack(&token_account_info.data.borrow())?;
+let mint_state = StateWithExtensions::<Mint>::unpack(&mint_account_info.data.borrow())?;
+```
+
+Anytime you access fields in the state, you'll need to go through the `base`. For
+example, to access the amount, you must do:
+
+```rust
+let token_amount = account_state.base.amount;
+```
+
+So typically, you'll just need to add in `.base` wherever those fields are accessed.
+
+Once that's done, all of your tests should pass! Congratulations, your program
+is now compatible with Token-2022!
+
+If your program is using multiple token types at once, however, you will need to
+do more work.
+
+## Part II: Support Mixed Token Programs: trading a Token for a Token-2022
+
+## Part III: Support Specific Extensions
+
+### Update from `transfer` to `transfer_checked`
+
+### Take fee into account when calculating slippage

--- a/token-swap/program/Cargo.toml
+++ b/token-swap/program/Cargo.toml
@@ -20,15 +20,17 @@ num-traits = "0.2"
 solana-program = "1.10.33"
 spl-math = { version = "0.1", path = "../../libraries/math", features = [ "no-entrypoint" ] }
 spl-token = { version = "3.5", path = "../../token/program", features = [ "no-entrypoint" ] }
+spl-token-2022 = { version = "0.4", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
 roots = { version = "0.0.7", optional = true }
 
 [dev-dependencies]
-solana-sdk = "1.10.33"
 proptest = "1.0"
-sim =  { path = "./sim" }
 roots = "0.0.7"
+sim =  { path = "./sim" }
+solana-sdk = "1.10.33"
+test-case = "2.2"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -83,7 +83,7 @@ impl Processor {
         let authority_signature_seeds = [&swap_bytes[..32], &[bump_seed]];
         let signers = &[&authority_signature_seeds[..]];
 
-        let ix = spl_token::instruction::burn(
+        let ix = spl_token_2022::instruction::burn(
             token_program.key,
             burn_account.key,
             mint.key,
@@ -112,7 +112,7 @@ impl Processor {
         let swap_bytes = swap.to_bytes();
         let authority_signature_seeds = [&swap_bytes[..32], &[bump_seed]];
         let signers = &[&authority_signature_seeds[..]];
-        let ix = spl_token::instruction::mint_to(
+        let ix = spl_token_2022::instruction::mint_to(
             token_program.key,
             mint.key,
             destination.key,
@@ -141,7 +141,7 @@ impl Processor {
         let swap_bytes = swap.to_bytes();
         let authority_signature_seeds = [&swap_bytes[..32], &[bump_seed]];
         let signers = &[&authority_signature_seeds[..]];
-        let ix = spl_token::instruction::transfer(
+        let ix = spl_token_2022::instruction::transfer(
             token_program.key,
             source.key,
             destination.key,
@@ -1113,7 +1113,7 @@ mod tests {
     };
     use solana_program::{instruction::Instruction, program_stubs, rent::Rent};
     use solana_sdk::account::{create_account_for_test, create_is_signer_account_infos, Account};
-    use spl_token::{
+    use spl_token_2022::{
         error::TokenError,
         instruction::{
             approve, freeze_account, initialize_account, initialize_mint, mint_to, revoke,

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -141,6 +141,7 @@ impl Processor {
         let swap_bytes = swap.to_bytes();
         let authority_signature_seeds = [&swap_bytes[..32], &[bump_seed]];
         let signers = &[&authority_signature_seeds[..]];
+        #[allow(deprecated)]
         let ix = spl_token_2022::instruction::transfer(
             token_program.key,
             source.key,
@@ -1139,7 +1140,7 @@ mod tests {
             let mut new_account_infos = vec![];
 
             // mimic check for token program in accounts
-            if !account_infos.iter().any(|x| *x.key == spl_token::id()) {
+            if !account_infos.iter().any(|x| *x.key == spl_token::id() || *x.key == spl_token_2022::id()) {
                 return Err(ProgramError::InvalidAccountData);
             }
 
@@ -1225,7 +1226,7 @@ mod tests {
                 Pubkey::find_program_address(&[&swap_key.to_bytes()[..]], &SWAP_PROGRAM_ID);
 
             let (pool_mint_key, mut pool_mint_account) =
-                create_mint(&spl_token::id(), &authority_key, None);
+                create_mint(&token_program_id, &authority_key, None);
             let (pool_token_key, pool_token_account) = mint_token(
                 token_program_id,
                 &pool_mint_key,
@@ -1243,7 +1244,7 @@ mod tests {
                 0,
             );
             let (token_a_mint_key, mut token_a_mint_account) =
-                create_mint(&spl_token::id(), user_key, None);
+                create_mint(&token_program_id, user_key, None);
             let (token_a_key, token_a_account) = mint_token(
                 token_program_id,
                 &token_a_mint_key,
@@ -1253,7 +1254,7 @@ mod tests {
                 token_a_amount,
             );
             let (token_b_mint_key, mut token_b_mint_account) =
-                create_mint(&spl_token::id(), user_key, None);
+                create_mint(&token_program_id, user_key, None);
             let (token_b_key, token_b_account) = mint_token(
                 token_program_id,
                 &token_b_mint_key,


### PR DESCRIPTION
#### Problem

Token-2022 is out on all networks, but it's not clear how to integrate it in on-chain programs.

#### Solution

Add some docs with a concrete example using token-swap.  This only covers the simplest migration towards supporting both token and token-2022, but not both in the same instruction. That'll happen in a separate PR.

@jacobcreech no need to look at the program changes, but any comments on the doc are extremely appreciated :smile: 

This PR will be merged without squash so that we can link all of the commits in the doc aftewards.