### PR TITLE
token: Reassign and reallocate accounts on close

### DIFF
--- a/token/program-2022-test/tests/close_account.rs
+++ b/token/program-2022-test/tests/close_account.rs
@@ -1,0 +1,167 @@
+#![cfg(feature = "test-bpf")]
+
+mod program_test;
+use {
+    program_test::TestContext,
+    solana_program_test::tokio,
+    solana_sdk::{
+        instruction::InstructionError, program_pack::Pack, pubkey::Pubkey, signature::Signer,
+        signer::keypair::Keypair, system_instruction, transaction::TransactionError,
+        transport::TransportError,
+    },
+    spl_token_2022::{instruction, state::Account},
+    spl_token_client::token::{ExtensionInitializationParams, TokenError as TokenClientError},
+};
+
+#[tokio::test]
+async fn success_init_after_close_account() {
+    let mut context = TestContext::new().await;
+    let payer = Keypair::from_bytes(&context.context.lock().await.payer.to_bytes()).unwrap();
+    context.init_token_with_mint(vec![]).await.unwrap();
+    let token = context.token_context.take().unwrap().token;
+    let token_program_id = spl_token_2022::id();
+    let owner = Keypair::new();
+    let token_account_keypair = Keypair::new();
+    let token_account = token
+        .create_auxiliary_token_account(&token_account_keypair, &owner.pubkey())
+        .await
+        .unwrap();
+
+    let destination = Pubkey::new_unique();
+    token
+        .process_ixs(
+            &[
+                instruction::close_account(
+                    &token_program_id,
+                    &token_account,
+                    &destination,
+                    &owner.pubkey(),
+                    &[],
+                )
+                .unwrap(),
+                system_instruction::create_account(
+                    &payer.pubkey(),
+                    &token_account,
+                    1_000_000_000,
+                    Account::LEN as u64,
+                    &token_program_id,
+                ),
+                instruction::initialize_account(
+                    &token_program_id,
+                    &token_account,
+                    token.get_address(),
+                    &owner.pubkey(),
+                )
+                .unwrap(),
+            ],
+            &[&owner, &payer, &token_account_keypair],
+        )
+        .await
+        .unwrap();
+    let destination = token.get_account(&destination).await.unwrap();
+    assert!(destination.lamports > 0);
+}
+
+#[tokio::test]
+async fn fail_init_after_close_account() {
+    let mut context = TestContext::new().await;
+    let payer = Keypair::from_bytes(&context.context.lock().await.payer.to_bytes()).unwrap();
+    context.init_token_with_mint(vec![]).await.unwrap();
+    let token = context.token_context.take().unwrap().token;
+    let token_program_id = spl_token_2022::id();
+    let owner = Keypair::new();
+    let token_account = token
+        .create_auxiliary_token_account(&Keypair::new(), &owner.pubkey())
+        .await
+        .unwrap();
+
+    let destination = Pubkey::new_unique();
+    let error = token
+        .process_ixs(
+            &[
+                instruction::close_account(
+                    &token_program_id,
+                    &token_account,
+                    &destination,
+                    &owner.pubkey(),
+                    &[],
+                )
+                .unwrap(),
+                system_instruction::transfer(&payer.pubkey(), &token_account, 1_000_000_000),
+                instruction::initialize_account(
+                    &token_program_id,
+                    &token_account,
+                    token.get_address(),
+                    &owner.pubkey(),
+                )
+                .unwrap(),
+            ],
+            &[&owner, &payer],
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(2, InstructionError::InvalidAccountData,)
+        )))
+    );
+    let error = token.get_account(&destination).await.unwrap_err();
+    assert_eq!(error, TokenClientError::AccountNotFound);
+}
+
+#[tokio::test]
+async fn fail_init_after_close_mint() {
+    let close_authority = Keypair::new();
+    let mut context = TestContext::new().await;
+    let payer = Keypair::from_bytes(&context.context.lock().await.payer.to_bytes()).unwrap();
+    context
+        .init_token_with_mint(vec![ExtensionInitializationParams::MintCloseAuthority {
+            close_authority: Some(close_authority.pubkey()),
+        }])
+        .await
+        .unwrap();
+    let token = context.token_context.take().unwrap().token;
+    let token_program_id = spl_token_2022::id();
+
+    let destination = Pubkey::new_unique();
+    let error = token
+        .process_ixs(
+            &[
+                instruction::close_account(
+                    &token_program_id,
+                    token.get_address(),
+                    &destination,
+                    &close_authority.pubkey(),
+                    &[],
+                )
+                .unwrap(),
+                system_instruction::transfer(&payer.pubkey(), token.get_address(), 1_000_000_000),
+                instruction::initialize_mint_close_authority(
+                    &token_program_id,
+                    token.get_address(),
+                    None,
+                )
+                .unwrap(),
+                instruction::initialize_mint(
+                    &token_program_id,
+                    token.get_address(),
+                    &close_authority.pubkey(),
+                    None,
+                    0,
+                )
+                .unwrap(),
+            ],
+            &[&close_authority, &payer],
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(2, InstructionError::InvalidAccountData,)
+        )))
+    );
+    let error = token.get_account(&destination).await.unwrap_err();
+    assert_eq!(error, TokenClientError::AccountNotFound);
+}

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -1787,7 +1787,7 @@ pub(crate) fn encode_instruction<T: Into<u8>, D: Pod>(
 
 #[cfg(test)]
 mod test {
-    use {super::*, proptest::prelude::*};
+    use super::*;
 
     #[test]
     fn test_instruction_packing() {
@@ -2283,15 +2283,5 @@ mod test {
             &mint_pubkey,
             ui_amount,
         ));
-    }
-
-    proptest! {
-        #![proptest_config(ProptestConfig::with_cases(1024))]
-        #[test]
-        fn test_instruction_unpack_panic(
-            data in prop::collection::vec(any::<u8>(), 0..255)
-        ) {
-            let _no_panic = TokenInstruction::unpack(&data);
-        }
     }
 }

--- a/token/program/src/instruction.rs
+++ b/token/program/src/instruction.rs
@@ -1447,7 +1447,7 @@ pub fn is_valid_signer_index(index: usize) -> bool {
 
 #[cfg(test)]
 mod test {
-    use {super::*, proptest::prelude::*};
+    use super::*;
 
     #[test]
     fn test_instruction_packing() {

--- a/token/program/src/instruction.rs
+++ b/token/program/src/instruction.rs
@@ -519,9 +519,6 @@ impl<'a> TokenInstruction<'a> {
             10 => Self::FreezeAccount,
             11 => Self::ThawAccount,
             12 => {
-                if rest.len() < 8 {
-                    return Err(TokenError::InvalidInstruction.into());
-                }
                 let (amount, rest) = rest.split_at(8);
                 let amount = amount
                     .try_into()
@@ -533,9 +530,6 @@ impl<'a> TokenInstruction<'a> {
                 Self::TransferChecked { amount, decimals }
             }
             13 => {
-                if rest.len() < 8 {
-                    return Err(TokenError::InvalidInstruction.into());
-                }
                 let (amount, rest) = rest.split_at(8);
                 let amount = amount
                     .try_into()
@@ -547,9 +541,6 @@ impl<'a> TokenInstruction<'a> {
                 Self::ApproveChecked { amount, decimals }
             }
             14 => {
-                if rest.len() < 8 {
-                    return Err(TokenError::InvalidInstruction.into());
-                }
                 let (amount, rest) = rest.split_at(8);
                 let amount = amount
                     .try_into()
@@ -561,9 +552,6 @@ impl<'a> TokenInstruction<'a> {
                 Self::MintToChecked { amount, decimals }
             }
             15 => {
-                if rest.len() < 8 {
-                    return Err(TokenError::InvalidInstruction.into());
-                }
                 let (amount, rest) = rest.split_at(8);
                 let amount = amount
                     .try_into()
@@ -600,9 +588,6 @@ impl<'a> TokenInstruction<'a> {
             21 => Self::GetAccountDataSize,
             22 => Self::InitializeImmutableOwner,
             23 => {
-                if rest.len() < 8 {
-                    return Err(TokenError::InvalidInstruction.into());
-                }
                 let (amount, _rest) = rest.split_at(8);
                 let amount = amount
                     .try_into()
@@ -1703,16 +1688,5 @@ mod test {
         assert_eq!(packed, expect);
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
-    }
-
-    #[test]
-    fn test_instruction_unpack_panic() {
-        for i in 0..255u8 {
-            for j in 1..10 {
-                let mut data = vec![0; j];
-                data[0] = i;
-                let _no_panic = TokenInstruction::unpack(&data);
-            }
-        }
     }
 }

--- a/token/program/tests/close_account.rs
+++ b/token/program/tests/close_account.rs
@@ -1,0 +1,202 @@
+#![cfg(feature = "test-bpf")]
+
+use {
+    solana_program_test::{processor, tokio, ProgramTest, ProgramTestContext},
+    solana_sdk::{
+        instruction::InstructionError,
+        program_pack::Pack,
+        pubkey::Pubkey,
+        signature::Signer,
+        signer::keypair::Keypair,
+        system_instruction,
+        transaction::{Transaction, TransactionError},
+    },
+    spl_token::{
+        instruction,
+        processor::Processor,
+        state::{Account, Mint},
+    },
+};
+
+async fn setup_mint_and_account(
+    context: &mut ProgramTestContext,
+    mint: &Keypair,
+    token_account: &Keypair,
+    owner: &Pubkey,
+    token_program_id: &Pubkey,
+) {
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let mint_authority_pubkey = Pubkey::new_unique();
+
+    let space = Mint::LEN;
+    let tx = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &mint.pubkey(),
+                rent.minimum_balance(space),
+                space as u64,
+                &token_program_id,
+            ),
+            instruction::initialize_mint(
+                &token_program_id,
+                &mint.pubkey(),
+                &mint_authority_pubkey,
+                None,
+                9,
+            )
+            .unwrap(),
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, mint],
+        context.last_blockhash,
+    );
+    context.banks_client.process_transaction(tx).await.unwrap();
+    let space = Account::LEN;
+    let tx = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &token_account.pubkey(),
+                rent.minimum_balance(space),
+                space as u64,
+                &token_program_id,
+            ),
+            instruction::initialize_account(
+                &token_program_id,
+                &token_account.pubkey(),
+                &mint.pubkey(),
+                &owner,
+            )
+            .unwrap(),
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &token_account],
+        context.last_blockhash,
+    );
+    context.banks_client.process_transaction(tx).await.unwrap();
+}
+
+#[tokio::test]
+async fn success_init_after_close_account() {
+    let program_test =
+        ProgramTest::new("spl_token", spl_token::id(), processor!(Processor::process));
+    let mut context = program_test.start_with_context().await;
+    let mint = Keypair::new();
+    let token_account = Keypair::new();
+    let owner = Keypair::new();
+    let token_program_id = spl_token::id();
+    setup_mint_and_account(
+        &mut context,
+        &mint,
+        &token_account,
+        &owner.pubkey(),
+        &token_program_id,
+    )
+    .await;
+
+    let destination = Pubkey::new_unique();
+    let tx = Transaction::new_signed_with_payer(
+        &[
+            instruction::close_account(
+                &token_program_id,
+                &token_account.pubkey(),
+                &destination,
+                &owner.pubkey(),
+                &[],
+            )
+            .unwrap(),
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &token_account.pubkey(),
+                1_000_000_000,
+                Account::LEN as u64,
+                &token_program_id,
+            ),
+            instruction::initialize_account(
+                &token_program_id,
+                &token_account.pubkey(),
+                &mint.pubkey(),
+                &owner.pubkey(),
+            )
+            .unwrap(),
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &owner, &token_account],
+        context.last_blockhash,
+    );
+    context.banks_client.process_transaction(tx).await.unwrap();
+    let destination = context
+        .banks_client
+        .get_account(destination)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(destination.lamports > 0);
+}
+
+#[tokio::test]
+async fn fail_init_after_close_account() {
+    let program_test =
+        ProgramTest::new("spl_token", spl_token::id(), processor!(Processor::process));
+    let mut context = program_test.start_with_context().await;
+    let mint = Keypair::new();
+    let token_account = Keypair::new();
+    let owner = Keypair::new();
+    let token_program_id = spl_token::id();
+    setup_mint_and_account(
+        &mut context,
+        &mint,
+        &token_account,
+        &owner.pubkey(),
+        &token_program_id,
+    )
+    .await;
+
+    let destination = Pubkey::new_unique();
+    let tx = Transaction::new_signed_with_payer(
+        &[
+            instruction::close_account(
+                &token_program_id,
+                &token_account.pubkey(),
+                &destination,
+                &owner.pubkey(),
+                &[],
+            )
+            .unwrap(),
+            system_instruction::transfer(
+                &context.payer.pubkey(),
+                &token_account.pubkey(),
+                1_000_000_000,
+            ),
+            instruction::initialize_account(
+                &token_program_id,
+                &token_account.pubkey(),
+                &mint.pubkey(),
+                &owner.pubkey(),
+            )
+            .unwrap(),
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &owner],
+        context.last_blockhash,
+    );
+    #[allow(clippy::useless_conversion)]
+    let error: TransactionError = context
+        .banks_client
+        .process_transaction(tx)
+        .await
+        .unwrap_err()
+        .unwrap()
+        .into();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(2, InstructionError::InvalidAccountData)
+    );
+    assert!(context
+        .banks_client
+        .get_account(destination)
+        .await
+        .unwrap()
+        .is_none());
+}


### PR DESCRIPTION
#### Problem

Closing token accounts sets data to 0, but it's still possible to re-use closed accounts by initializing again in the same transaction.

#### Solution

Completely close the account by reassigning it back to the system program and reallocating the account to 0, as if it were totally new.