### PR TITLE
token[-2022]: Add proptest for unpacking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6195,6 +6195,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
+ "proptest",
  "serial_test 0.5.1",
  "solana-program",
  "solana-program-test",

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -1787,7 +1787,7 @@ pub(crate) fn encode_instruction<T: Into<u8>, D: Pod>(
 
 #[cfg(test)]
 mod test {
-    use super::*;
+    use {super::*, proptest::prelude::*};
 
     #[test]
     fn test_instruction_packing() {
@@ -2283,5 +2283,15 @@ mod test {
             &mint_pubkey,
             ui_amount,
         ));
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(1024))]
+        #[test]
+        fn test_instruction_unpack_panic(
+            data in prop::collection::vec(any::<u8>(), 0..255)
+        ) {
+            let _no_panic = TokenInstruction::unpack(&data);
+        }
     }
 }

--- a/token/program/Cargo.toml
+++ b/token/program/Cargo.toml
@@ -23,6 +23,7 @@ thiserror = "1.0"
 
 [dev-dependencies]
 lazy_static = "1.4.0"
+proptest = "1.0"
 serial_test = "0.5.1"
 solana-program-test = "1.10.33"
 solana-sdk = "1.10.33"

--- a/token/program/src/instruction.rs
+++ b/token/program/src/instruction.rs
@@ -1431,7 +1431,7 @@ pub fn is_valid_signer_index(index: usize) -> bool {
 
 #[cfg(test)]
 mod test {
-    use super::*;
+    use {super::*, proptest::prelude::*};
 
     #[test]
     fn test_instruction_packing() {
@@ -1674,14 +1674,13 @@ mod test {
         assert_eq!(unpacked, check);
     }
 
-    #[test]
-    fn test_instruction_unpack_panic() {
-        for i in 0..255u8 {
-            for j in 1..10 {
-                let mut data = vec![0; j];
-                data[0] = i;
-                let _no_panic = TokenInstruction::unpack(&data);
-            }
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(1024))]
+        #[test]
+        fn test_instruction_unpack_panic(
+            data in prop::collection::vec(any::<u8>(), 0..255)
+        ) {
+            let _no_panic = TokenInstruction::unpack(&data);
         }
     }
 }


### PR DESCRIPTION
#### Problem

Token instruction unpacking shouldn't fail.

#### Solution

Add a proptest to give more coverage of test cases.  This generates a vector of random bytes and tries to unpack it as an instruction.  Note that this just generates a random 1024 tests every time `cargo test` is invoked.

The next step should be a top-level fuzz, similar to how token-swap is fuzzed.  #3420 will cover that