### PR TITLE
ci: Separate twoxtx build step, match Rust version

### DIFF
--- a/.github/workflows/pull-request-token.yml
+++ b/.github/workflows/pull-request-token.yml
@@ -80,6 +80,8 @@ jobs:
           if-no-files-found: error
 
   cargo-test-bpf-twoxtx:
+    runs-on: ubuntu-latest
+    steps:
       - uses: actions/checkout@v2
 
       - name: Set env vars
@@ -109,7 +111,8 @@ jobs:
           echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
 
       - name: Build and test token-2022 twoxtx (TEMPORARY)
-        run: | ./token/twoxtx-setup.sh
+        run: |
+          ./token/twoxtx-setup.sh
           ./ci/cargo-test-bpf.sh token/program-2022-test
 
   js-test:

--- a/.github/workflows/pull-request-token.yml
+++ b/.github/workflows/pull-request-token.yml
@@ -6,12 +6,14 @@ on:
     - 'associated-token-account/**'
     - 'token/**'
     - 'ci/*-version.sh'
+    - '.github/workflows/pull-request-token.yml'
   push:
     branches: [master]
     paths:
     - 'associated-token-account/**'
     - 'token/**'
     - 'ci/*-version.sh'
+    - '.github/workflows/pull-request-token.yml'
 
 jobs:
   cargo-test-bpf:

--- a/.github/workflows/pull-request-token.yml
+++ b/.github/workflows/pull-request-token.yml
@@ -62,11 +62,6 @@ jobs:
       - name: Build and test ATA
         run: ./ci/cargo-test-bpf.sh associated-token-account
 
-      - name: Build and test token-2022 twoxtx (TEMPORARY)
-        run: |
-          ./token/twoxtx-setup.sh
-          ./ci/cargo-test-bpf.sh token/program-2022-test
-
       - name: Build and test token-2022 with "serde" activated
         run: |
           cargo +"${{ env.RUST_STABLE }}" test \
@@ -81,6 +76,39 @@ jobs:
           name: token-programs
           path: "target/deploy/*.so"
           if-no-files-found: error
+
+  cargo-test-bpf-twoxtx:
+      - uses: actions/checkout@v2
+
+      - name: Set env vars
+        run: |
+          source ci/rust-version.sh 1.60.0
+          echo "RUST_STABLE=$rust_stable" >> $GITHUB_ENV
+          source ci/solana-version.sh
+          echo "SOLANA_VERSION=$solana_version" >> $GITHUB_ENV
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_STABLE }}
+          override: true
+          profile: minimal
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE}}
+
+      - name: Install dependencies
+        run: |
+          ./ci/install-build-deps.sh
+          ./ci/install-program-deps.sh
+          echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
+
+      - name: Build and test token-2022 twoxtx (TEMPORARY)
+        run: | ./token/twoxtx-setup.sh
+          ./ci/cargo-test-bpf.sh token/program-2022-test
 
   js-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-token.yml
+++ b/.github/workflows/pull-request-token.yml
@@ -88,6 +88,7 @@ jobs:
         run: |
           source ci/rust-version.sh 1.60.0
           echo "RUST_STABLE=$rust_stable" >> $GITHUB_ENV
+          echo "RUST_STABLE_VERSION=$rust_stable" >> $GITHUB_ENV
           source ci/solana-version.sh
           echo "SOLANA_VERSION=$solana_version" >> $GITHUB_ENV
 

--- a/.github/workflows/pull-request-token.yml
+++ b/.github/workflows/pull-request-token.yml
@@ -86,9 +86,9 @@ jobs:
 
       - name: Set env vars
         run: |
-          source ci/rust-version.sh 1.60.0
+          echo "RUST_STABLE_VERSION=1.60.0" >> $GITHUB_ENV
+          source ci/rust-version.sh
           echo "RUST_STABLE=$rust_stable" >> $GITHUB_ENV
-          echo "RUST_STABLE_VERSION=$rust_stable" >> $GITHUB_ENV
           source ci/solana-version.sh
           echo "SOLANA_VERSION=$solana_version" >> $GITHUB_ENV
 

--- a/token/twoxtx-setup.sh
+++ b/token/twoxtx-setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Patch in a Solana v1.10 monorepo that supports 2x transactions for testing the
+# Patch in a Solana v1.11 monorepo that supports 2x transactions for testing the
 # SPL Token 2022 Confidential Transfer extension
 #
 


### PR DESCRIPTION
#### Problem

The token CI is failing on the twoxtx step, because spl is still using Rust 1.59.0, but the monorepo is at 1.60.0, and depends on features stabilized in 1.60.0

#### Solution

Split out the twoxtx build step, and use the correct version of Rust there.