### PR TITLE
token-cli: don't error when missing default config

### DIFF
--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -1848,20 +1848,15 @@ fn app<'a, 'b>(
         .about(crate_description!())
         .version(crate_version!())
         .setting(AppSettings::SubcommandRequiredElseHelp)
-        .arg({
-            let arg = Arg::with_name("config_file")
+        .arg(
+            Arg::with_name("config_file")
                 .short("C")
                 .long("config")
                 .value_name("PATH")
                 .takes_value(true)
                 .global(true)
-                .help("Configuration file to use");
-            if let Some(ref config_file) = *solana_cli_config::CONFIG_FILE {
-                arg.default_value(config_file)
-            } else {
-                arg
-            }
-        })
+                .help("Configuration file to use"),
+        )
         .arg(
             Arg::with_name("verbose")
                 .short("v")
@@ -2669,6 +2664,8 @@ async fn main() -> Result<(), Error> {
                 eprintln!("error: Could not find config file `{}`", config_file);
                 exit(1);
             })
+        } else if let Some(ref config_file) = *solana_cli_config::CONFIG_FILE {
+            solana_cli_config::Config::load(config_file).unwrap_or_default()
         } else {
             solana_cli_config::Config::default()
         };


### PR DESCRIPTION
fixes a regression introduced in #3166. prior to that, the config argument would default to the value of `solana_cli_config::CONFIG_FILE`, and loading the config would fall back to a default if it failed. changing the to an error protected against a missing file provided by `--config`, but also errored in the default case if they lacked the default file

this change distinguishes the three cases, erroring if the user provided a bad `--config` option, but falling back to defaults if they didnt