### PR TITLE
token-cli: Split out CI into separate step, run tests in serial

### DIFF
--- a/.github/workflows/pull-request-token.yml
+++ b/.github/workflows/pull-request-token.yml
@@ -176,12 +176,6 @@ jobs:
           ./ci/install-program-deps.sh
           echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
 
-      - name: Download programs
-        uses: actions/download-artifact@v2
-        with:
-          name: token-programs
-          path: target/deploy
-
       - name: Build and test
         run: |
           BUILD_DEPENDENT_PROGRAMS=1 cargo build --manifest-path ./token/cli/Cargo.toml

--- a/.github/workflows/pull-request-token.yml
+++ b/.github/workflows/pull-request-token.yml
@@ -139,3 +139,50 @@ jobs:
           name: token-programs
           path: target/deploy
       - run: ./ci/js-test-token.sh
+
+  cargo-build-test-cli:
+    runs-on: ubuntu-latest
+    needs: cargo-test-bpf
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set env vars
+        run: |
+          source ci/rust-version.sh
+          echo "RUST_STABLE=$rust_stable" >> $GITHUB_ENV
+          source ci/solana-version.sh
+          echo "SOLANA_VERSION=$solana_version" >> $GITHUB_ENV
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_STABLE }}
+          override: true
+          profile: minimal
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE }}
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/solana
+          key: solana-${{ env.SOLANA_VERSION }}
+
+      - name: Install dependencies
+        run: |
+          ./ci/install-build-deps.sh
+          ./ci/install-program-deps.sh
+          echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
+
+      - name: Download programs
+        uses: actions/download-artifact@v2
+        with:
+          name: token-programs
+          path: target/deploy
+
+      - name: Build and test
+        run: |
+          cargo test --manifest-path ./token/cli/Cargo.toml

--- a/.github/workflows/pull-request-token.yml
+++ b/.github/workflows/pull-request-token.yml
@@ -142,7 +142,6 @@ jobs:
 
   cargo-build-test-cli:
     runs-on: ubuntu-latest
-    needs: cargo-test-bpf
     steps:
       - uses: actions/checkout@v2
 
@@ -185,4 +184,5 @@ jobs:
 
       - name: Build and test
         run: |
+          BUILD_DEPENDENT_PROGRAMS=1 cargo build --manifest-path ./token/cli/Cargo.toml
           cargo test --manifest-path ./token/cli/Cargo.toml

--- a/ci/cargo-build-test.sh
+++ b/ci/cargo-build-test.sh
@@ -15,8 +15,8 @@ set -x
 make -C examples/c
 
 # Build/test all host crates
-BUILD_DEPENDENT_PROGRAMS=1 cargo +"$rust_stable" build
-cargo +"$rust_stable" test -- --nocapture
+cargo +"$rust_stable" build --workspace --exclude spl-token-cli
+cargo +"$rust_stable" test --workspace --exclude spl-token-cli -- --nocapture
 
 # Run test-client sanity check
 cargo +"$rust_stable" run --manifest-path=utils/test-client/Cargo.toml

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -3288,7 +3288,7 @@ async fn handle_tx<'a>(
 mod tests {
     use {
         super::*,
-        serial_test::parallel,
+        serial_test::serial,
         solana_sdk::{
             bpf_loader,
             signature::{write_keypair_file, Keypair, Signer},
@@ -3472,7 +3472,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[parallel(one)]
+    #[serial]
     async fn create_token_default() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -3492,7 +3492,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[parallel(two)]
+    #[serial]
     async fn supply() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -3511,7 +3511,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[parallel(three)]
+    #[serial]
     async fn create_account_default() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -3532,7 +3532,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[parallel(four)]
+    #[serial]
     async fn account_info() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -3565,7 +3565,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[parallel(one)]
+    #[serial]
     async fn balance() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -3585,7 +3585,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[parallel(two)]
+    #[serial]
     async fn mint() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -3613,7 +3613,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[parallel(three)]
+    #[serial]
     async fn balance_after_mint() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -3635,7 +3635,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[parallel(four)]
+    #[serial]
     async fn accounts() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -3659,7 +3659,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[parallel(one)]
+    #[serial]
     async fn wrap() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -3687,7 +3687,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[parallel(two)]
+    #[serial]
     async fn unwrap() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -3714,7 +3714,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[parallel(three)]
+    #[serial]
     async fn transfer() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -3748,7 +3748,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[parallel(four)]
+    #[serial]
     async fn transfer_fund_recipient() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -3781,7 +3781,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[parallel(one)]
+    #[serial]
     async fn failing_to_allow_non_system_account_recipient() {
         let (test_validator, payer) = new_validator_for_test().await;
         let config = test_config(&test_validator, &payer, &spl_token::id());
@@ -3808,7 +3808,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[parallel(two)]
+    #[serial]
     async fn allow_non_system_account_recipient() {
         let (test_validator, payer) = new_validator_for_test().await;
         let config = test_config(&test_validator, &payer, &spl_token::id());
@@ -3845,7 +3845,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[parallel(three)]
+    #[serial]
     async fn close_wrapped_sol_account() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -3892,7 +3892,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[parallel(four)]
+    #[serial]
     async fn disable_mint_authority() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -3919,7 +3919,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[parallel(one)]
+    #[serial]
     async fn gc() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -3965,7 +3965,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[parallel(two)]
+    #[serial]
     async fn set_owner() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -3994,7 +3994,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[parallel(three)]
+    #[serial]
     async fn transfer_with_account_delegate() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {
@@ -4089,7 +4089,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[parallel(four)]
+    #[serial]
     async fn burn_with_account_delegate() {
         let (test_validator, payer) = new_validator_for_test().await;
         for program_id in [spl_token::id(), spl_token_2022::id()] {


### PR DESCRIPTION
#### Problem

The token-cli tests keep failing CI.

#### Solution

Serialize all the tests.  This takes a lot longer, so also split off the tests into a separate CI step.