### PR TITLE
Bump token to v3.5.0 and ata to v1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,7 +362,7 @@ dependencies = [
  "arrayref",
  "borsh",
  "solana-program",
- "spl-token 3.4.0",
+ "spl-token 3.5.0",
  "thiserror",
  "uint",
 ]
@@ -1473,7 +1473,7 @@ version = "1.0.0"
 dependencies = [
  "arrayref",
  "solana-program",
- "spl-token 3.4.0",
+ "spl-token 3.5.0",
 ]
 
 [[package]]
@@ -5832,14 +5832,14 @@ dependencies = [
 
 [[package]]
 name = "spl-associated-token-account"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "assert_matches",
  "borsh",
  "num-derive",
  "num-traits",
  "solana-program",
- "spl-token 3.4.0",
+ "spl-token 3.5.0",
  "spl-token-2022 0.4.2",
  "thiserror",
 ]
@@ -5851,8 +5851,8 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 1.1.0",
- "spl-token 3.4.0",
+ "spl-associated-token-account 1.1.1",
+ "spl-token 3.5.0",
  "spl-token-2022 0.4.2",
 ]
 
@@ -5866,7 +5866,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-token 3.4.0",
+ "spl-token 3.5.0",
  "thiserror",
  "uint",
 ]
@@ -5925,7 +5925,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-token 3.4.0",
+ "spl-token 3.5.0",
 ]
 
 [[package]]
@@ -5963,7 +5963,7 @@ dependencies = [
  "spl-governance-addin-mock",
  "spl-governance-test-sdk",
  "spl-governance-tools",
- "spl-token 3.4.0",
+ "spl-token 3.5.0",
  "thiserror",
 ]
 
@@ -5996,7 +5996,7 @@ dependencies = [
  "spl-governance-addin-api",
  "spl-governance-test-sdk",
  "spl-governance-tools",
- "spl-token 3.4.0",
+ "spl-token 3.5.0",
  "thiserror",
 ]
 
@@ -6022,7 +6022,7 @@ dependencies = [
  "spl-governance-addin-mock",
  "spl-governance-test-sdk",
  "spl-governance-tools",
- "spl-token 3.4.0",
+ "spl-token 3.5.0",
  "thiserror",
 ]
 
@@ -6041,7 +6041,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-token 3.4.0",
+ "spl-token 3.5.0",
  "thiserror",
 ]
 
@@ -6057,7 +6057,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-program",
- "spl-token 3.4.0",
+ "spl-token 3.5.0",
  "thiserror",
 ]
 
@@ -6152,7 +6152,7 @@ dependencies = [
  "solana-sdk",
  "solana-vote-program",
  "spl-math",
- "spl-token 3.4.0",
+ "spl-token 3.5.0",
  "thiserror",
 ]
 
@@ -6176,9 +6176,9 @@ dependencies = [
  "solana-program",
  "solana-remote-wallet",
  "solana-sdk",
- "spl-associated-token-account 1.1.0",
+ "spl-associated-token-account 1.1.1",
  "spl-stake-pool",
- "spl-token 3.4.0",
+ "spl-token 3.5.0",
 ]
 
 [[package]]
@@ -6197,7 +6197,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -6251,7 +6251,7 @@ dependencies = [
  "solana-sdk",
  "solana-zk-token-sdk 1.10.33",
  "spl-memo 3.0.1",
- "spl-token 3.4.0",
+ "spl-token 3.5.0",
  "thiserror",
 ]
 
@@ -6263,7 +6263,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 1.1.0",
+ "spl-associated-token-account 1.1.1",
  "spl-memo 3.0.1",
  "spl-token-2022 0.4.2",
  "spl-token-client",
@@ -6292,9 +6292,9 @@ dependencies = [
  "solana-sdk",
  "solana-test-validator",
  "solana-transaction-status",
- "spl-associated-token-account 1.1.0",
+ "spl-associated-token-account 1.1.1",
  "spl-memo 3.0.1",
- "spl-token 3.4.0",
+ "spl-token 3.5.0",
  "spl-token-2022 0.4.2",
  "spl-token-client",
  "strum",
@@ -6312,7 +6312,7 @@ dependencies = [
  "solana-client",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 1.1.0",
+ "spl-associated-token-account 1.1.1",
  "spl-memo 3.0.1",
  "spl-token-2022 0.4.2",
  "thiserror",
@@ -6335,7 +6335,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-token 3.4.0",
+ "spl-token 3.5.0",
  "thiserror",
  "uint",
 ]
@@ -6351,7 +6351,7 @@ dependencies = [
  "solana-logger",
  "solana-program",
  "solana-sdk",
- "spl-token 3.4.0",
+ "spl-token 3.5.0",
  "spl-token-lending",
 ]
 
@@ -6370,7 +6370,7 @@ dependencies = [
  "solana-program",
  "solana-sdk",
  "spl-math",
- "spl-token 3.4.0",
+ "spl-token 3.5.0",
  "thiserror",
 ]
 
@@ -6382,7 +6382,7 @@ dependencies = [
  "honggfuzz",
  "solana-program",
  "spl-math",
- "spl-token 3.4.0",
+ "spl-token 3.5.0",
  "spl-token-swap",
 ]
 
@@ -6410,8 +6410,8 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 1.1.0",
- "spl-token 3.4.0",
+ "spl-associated-token-account 1.1.1",
+ "spl-token 3.5.0",
  "thiserror",
 ]
 
@@ -6681,7 +6681,7 @@ version = "0.1.0"
 dependencies = [
  "solana-sdk",
  "spl-memo 3.0.1",
- "spl-token 3.4.0",
+ "spl-token 3.5.0",
  "spl-token-swap",
 ]
 

--- a/associated-token-account/program-test/Cargo.toml
+++ b/associated-token-account/program-test/Cargo.toml
@@ -15,5 +15,5 @@ solana-program = "1.10.33"
 solana-program-test = "1.10.33"
 solana-sdk = "1.10.33"
 spl-associated-token-account = { version = "1.1", path = "../program", features = ["no-entrypoint"] }
-spl-token = { version = "3.4", path = "../../token/program", features = ["no-entrypoint"] }
+spl-token = { version = "3.5", path = "../../token/program", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "0.4", path = "../../token/program-2022", features = ["no-entrypoint"] }

--- a/associated-token-account/program/Cargo.toml
+++ b/associated-token-account/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-associated-token-account"
-version = "1.1.0"
+version = "1.1.1"
 description = "Solana Program Library Associated Token Account"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -17,7 +17,7 @@ borsh = "0.9.1"
 num-derive = "0.3"
 num-traits = "0.2"
 solana-program = "1.10.33"
-spl-token = { version = "3.4", path = "../../token/program", features = ["no-entrypoint"] }
+spl-token = { version = "3.5", path = "../../token/program", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "0.4", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"
 

--- a/binary-oracle-pair/program/Cargo.toml
+++ b/binary-oracle-pair/program/Cargo.toml
@@ -14,7 +14,7 @@ test-bpf = []
 num-derive = "0.3"
 num-traits = "0.2"
 solana-program = "1.10.33"
-spl-token = { version = "3.4", path = "../../token/program", features = [ "no-entrypoint" ] }
+spl-token = { version = "3.5", path = "../../token/program", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 uint = "0.9"
 borsh = "0.9.1"

--- a/feature-proposal/program/Cargo.toml
+++ b/feature-proposal/program/Cargo.toml
@@ -15,7 +15,7 @@ test-bpf = []
 borsh = "0.9"
 borsh-derive = "0.9.0"
 solana-program = "1.10.33"
-spl-token = { version = "3.4", path = "../../token/program", features = ["no-entrypoint"] }
+spl-token = { version = "3.5", path = "../../token/program", features = ["no-entrypoint"] }
 
 [dev-dependencies]
 solana-program-test = "1.10.33"

--- a/governance/addin-mock/program/Cargo.toml
+++ b/governance/addin-mock/program/Cargo.toml
@@ -20,7 +20,7 @@ num-traits = "0.2"
 serde = "1.0.127"
 serde_derive = "1.0.103"
 solana-program = "1.10.33"
-spl-token = { version = "3.4", path = "../../../token/program", features = [ "no-entrypoint" ] }
+spl-token = { version = "3.5", path = "../../../token/program", features = [ "no-entrypoint" ] }
 spl-governance-addin-api= { version = "0.1.2", path ="../../addin-api"}
 spl-governance-tools= { version = "0.1.2", path ="../../tools"}
 thiserror = "1.0"

--- a/governance/chat/program/Cargo.toml
+++ b/governance/chat/program/Cargo.toml
@@ -20,7 +20,7 @@ num-traits = "0.2"
 serde = "1.0.127"
 serde_derive = "1.0.103"
 solana-program = "1.10.33"
-spl-token = { version = "3.4", path = "../../../token/program", features = [ "no-entrypoint" ] }
+spl-token = { version = "3.5", path = "../../../token/program", features = [ "no-entrypoint" ] }
 spl-governance= { version = "3.0.0", path ="../../program", features = [ "no-entrypoint" ]}
 spl-governance-tools= { version = "0.1.2", path ="../../tools"}
 spl-governance-addin-api= { version = "0.1.2", path ="../../addin-api"}

--- a/governance/program/Cargo.toml
+++ b/governance/program/Cargo.toml
@@ -20,7 +20,7 @@ num-traits = "0.2"
 serde = "1.0.130"
 serde_derive = "1.0.103"
 solana-program = "1.10.33"
-spl-token = { version = "3.4", path = "../../token/program", features = [ "no-entrypoint" ] }
+spl-token = { version = "3.5", path = "../../token/program", features = [ "no-entrypoint" ] }
 spl-governance-tools= { version = "0.1.2", path ="../tools"}
 spl-governance-addin-api= { version = "0.1.2", path ="../addin-api"}
 thiserror = "1.0"

--- a/governance/test-sdk/Cargo.toml
+++ b/governance/test-sdk/Cargo.toml
@@ -19,7 +19,5 @@ serde_derive = "1.0.103"
 solana-program = "1.10.33"
 solana-program-test = "1.10.33"
 solana-sdk = "1.10.33"
-spl-token = { version = "3.4", path = "../../token/program", features = [ "no-entrypoint" ] }
+spl-token = { version = "3.5", path = "../../token/program", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
-
-

--- a/governance/tools/Cargo.toml
+++ b/governance/tools/Cargo.toml
@@ -16,5 +16,5 @@ num-traits = "0.2"
 serde = "1.0.127"
 serde_derive = "1.0.103"
 solana-program = "1.10.33"
-spl-token = { version = "3.4", path = "../../token/program", features = [ "no-entrypoint" ] }
+spl-token = { version = "3.5", path = "../../token/program", features = [ "no-entrypoint" ] }
 thiserror = "1.0"

--- a/stake-pool/cli/Cargo.toml
+++ b/stake-pool/cli/Cargo.toml
@@ -23,9 +23,9 @@ solana-logger = "=1.10.33"
 solana-program = "=1.10.33"
 solana-remote-wallet = "=1.10.33"
 solana-sdk = "=1.10.33"
-spl-associated-token-account = { version = "=1.1.0", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
+spl-associated-token-account = { version = "=1.1.1", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
 spl-stake-pool = { version = "=0.6.4", path="../program", features = [ "no-entrypoint" ] }
-spl-token = { version = "=3.4.0", path="../../token/program", features = [ "no-entrypoint" ]  }
+spl-token = { version = "=3.5.0", path="../../token/program", features = [ "no-entrypoint" ]  }
 bs58 = "0.4.0"
 bincode = "1.3.1"
 

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -22,7 +22,7 @@ serde = "1.0.130"
 serde_derive = "1.0.103"
 solana-program = "1.10.33"
 spl-math = { version = "0.1", path = "../../libraries/math", features = [ "no-entrypoint" ] }
-spl-token = { version = "3.4", path = "../../token/program", features = [ "no-entrypoint" ] }
+spl-token = { version = "3.5", path = "../../token/program", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 bincode = "1.3.1"
 

--- a/stateless-asks/program/Cargo.toml
+++ b/stateless-asks/program/Cargo.toml
@@ -13,7 +13,7 @@ test-bpf = []
 [dependencies]
 borsh = "0.9.1"
 solana-program = "1.10.33"
-spl-token = { version = "3.4", path = "../../token/program", features = ["no-entrypoint"] }
+spl-token = { version = "3.5", path = "../../token/program", features = ["no-entrypoint"] }
 spl-associated-token-account = {version = "1.1", path = "../../associated-token-account/program", features = ["no-entrypoint"]}
 metaplex-token-metadata = { version = "0.0.1", features = ["no-entrypoint"] }
 thiserror = "1.0"

--- a/token-lending/cli/Cargo.toml
+++ b/token-lending/cli/Cargo.toml
@@ -17,7 +17,7 @@ solana-logger = "=1.10.33"
 solana-sdk = "=1.10.33"
 solana-program = "=1.10.33"
 spl-token-lending = { version = "0.2", path="../program", features = [ "no-entrypoint" ] }
-spl-token = { version = "3.4", path="../../token/program", features = [ "no-entrypoint" ]  }
+spl-token = { version = "3.5", path="../../token/program", features = [ "no-entrypoint" ]  }
 
 [[bin]]
 name = "spl-token-lending"

--- a/token-lending/flash_loan_receiver/Cargo.toml
+++ b/token-lending/flash_loan_receiver/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 arrayref = "0.3.6"
 solana-program = "1.10.33"
-spl-token = { version = "3.4", path = "../../token/program", features=["no-entrypoint"] }
+spl-token = { version = "3.5", path = "../../token/program", features=["no-entrypoint"] }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/token-lending/program/Cargo.toml
+++ b/token-lending/program/Cargo.toml
@@ -17,7 +17,7 @@ bytemuck = "1.7.2"
 num-derive = "0.3"
 num-traits = "0.2"
 solana-program = "1.10.33"
-spl-token = { version = "3.4", path = "../../token/program", features = [ "no-entrypoint" ] }
+spl-token = { version = "3.5", path = "../../token/program", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 uint = "0.9"
 

--- a/token-swap/program/Cargo.toml
+++ b/token-swap/program/Cargo.toml
@@ -19,7 +19,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 solana-program = "1.10.33"
 spl-math = { version = "0.1", path = "../../libraries/math", features = [ "no-entrypoint" ] }
-spl-token = { version = "3.4", path = "../../token/program", features = [ "no-entrypoint" ] }
+spl-token = { version = "3.5", path = "../../token/program", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
 roots = { version = "0.0.7", optional = true }

--- a/token-swap/program/fuzz/Cargo.toml
+++ b/token-swap/program/fuzz/Cargo.toml
@@ -13,7 +13,7 @@ honggfuzz = { version = "0.5.54" }
 arbitrary = { version = "1.0", features = ["derive"] }
 solana-program = "1.10.33"
 spl-math = { version = "0.1", path = "../../../libraries/math", features = [ "no-entrypoint" ] }
-spl-token = { version = "3.4", path = "../../../token/program", features = [ "no-entrypoint" ] }
+spl-token = { version = "3.5", path = "../../../token/program", features = [ "no-entrypoint" ] }
 spl-token-swap = { path = "..", features = ["fuzz", "no-entrypoint"] }
 
 [[bin]]

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -27,7 +27,7 @@ solana-logger = "=1.10.33"
 solana-remote-wallet = "=1.10.33"
 solana-sdk = "=1.10.33"
 solana-transaction-status = "=1.10.33"
-spl-token = { version = "3.4", path="../program", features = [ "no-entrypoint" ] }
+spl-token = { version = "3.5", path="../program", features = [ "no-entrypoint" ] }
 spl-token-2022 = { version = "0.4", path="../program-2022", features = [ "no-entrypoint" ] }
 spl-token-client = { version = "0.1", path="../client" }
 spl-associated-token-account = { version = "1.1", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -25,7 +25,7 @@ num_enum = "0.5.4"
 solana-program = "1.10.33"
 solana-zk-token-sdk = "1.10.33"
 spl-memo = { version = "3.0.1", path = "../../memo/program", features = [ "no-entrypoint" ] }
-spl-token = { version = "3.4",  path = "../program", features = ["no-entrypoint"] }
+spl-token = { version = "3.5",  path = "../program", features = ["no-entrypoint"] }
 thiserror = "1.0"
 serde = { version = "1.0.136", optional = true }
 serde_with = { version = "1.14.0", optional = true }

--- a/token/program/Cargo.toml
+++ b/token/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token"
-version = "3.4.0"
+version = "3.5.0"
 description = "Solana Program Library Token"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"


### PR DESCRIPTION
#### Problem

In preparation for the crate release of spl-token and spl-associated-token-account, we need to bump the versions.

#### Solution

Bump!