### PR TITLE
Extends withdraw functionality in stake pool

### DIFF
--- a/stake-pool/cli/scripts/withdraw.sh
+++ b/stake-pool/cli/scripts/withdraw.sh
@@ -16,11 +16,12 @@ create_keypair () {
 }
 
 create_stake_account () {
+  authority=$1
   while read -r validator
   do
     solana-keygen new --no-passphrase -o "$keys_dir/stake_account_$validator.json"
-    solana create-stake-account "$keys_dir/stake_account_$validator.json" 2 --withdraw-authority "$keys_dir/stake_account_$validator.json" --stake-authority "$keys_dir/stake_account_$validator.json"
-    solana delegate-stake --force "$keys_dir/stake_account_$validator.json"  "$validator" --stake-authority "$keys_dir/stake_account_$validator.json"
+    solana create-stake-account "$keys_dir/stake_account_$validator.json" 2 
+    solana delegate-stake --force "$keys_dir/stake_account_$validator.json"  "$validator" 
   done < "$validator_list"
 }
 
@@ -51,14 +52,16 @@ spl_stake_pool=spl-stake-pool
 
 stake_pool_pubkey=$(solana-keygen pubkey "$stake_pool_keyfile")
 keys_dir=keys
-create_stake_account
-echo "Waiting for stakes to activate, this may take awhile depending on the network!"
-echo "If you are running on localnet with 32 slots per epoch, wait 12 seconds..."
-sleep 12
 
 echo "Setting up keys directory $keys_dir"
 mkdir -p $keys_dir
 authority=$keys_dir/authority.json
+
+create_stake_account $authority
+echo "Waiting for stakes to activate, this may take awhile depending on the network!"
+echo "If you are running on localnet with 32 slots per epoch, wait 12 seconds..."
+sleep 12
+
 echo "Setting up authority for withdrawn stake accounts at $authority"
 create_keypair $authority
 

--- a/stake-pool/js/src/index.ts
+++ b/stake-pool/js/src/index.ts
@@ -33,7 +33,6 @@ import {
   ValidatorList,
   ValidatorListLayout,
   ValidatorStakeInfo,
-  ParsedInfo,
 } from './layouts';
 import { MAX_VALIDATORS_TO_UPDATE, MINIMUM_ACTIVE_STAKE, STAKE_POOL_PROGRAM_ID } from './constants';
 import { create } from 'superstruct';
@@ -110,8 +109,7 @@ export async function getStakeAccount(
   if (program != 'stake') {
     throw new Error('Not a stake account');
   }
-  const info = create(result.data.parsed, ParsedInfo);
-  const parsed = create(info, StakeAccount);
+  const parsed = create(result.data.parsed, StakeAccount);
 
   return parsed;
 }
@@ -393,7 +391,7 @@ export async function withdrawStake(
       poolAmount,
     });
   } else if (stakeReceiverAccount && stakeReceiverAccount?.type == 'delegated') {
-    const voteAccount = stakeReceiverAccount.info.stake?.delegation.voter;
+    const voteAccount = stakeReceiverAccount.info?.stake?.delegation.voter;
     if (!voteAccount) throw new Error(`Invalid stake reciever ${stakeReceiver} delegation`);
     const validatorListAccount = await connection.getAccountInfo(
       stakePool.account.data.validatorList,
@@ -415,7 +413,7 @@ export async function withdrawStake(
 
       const stakeAccount = await connection.getAccountInfo(stakeAccountAddress);
       if (!stakeAccount) {
-        throw new Error('Invalid Stake Account');
+        throw new Error(`Preferred withdraw valdator's stake account is invalid`);
       }
 
       const availableForWithdrawal = calcLamportsWithdrawAmount(

--- a/stake-pool/js/src/layouts.ts
+++ b/stake-pool/js/src/layouts.ts
@@ -2,6 +2,7 @@ import { publicKey, struct, u32, u64, u8, option, vec } from '@project-serum/bor
 import { Lockup, PublicKey } from '@solana/web3.js';
 import { AccountInfo } from '@solana/spl-token';
 import BN from 'bn.js';
+import { Infer, number, nullable, enums, type, coerce, instance, string, any } from 'superstruct';
 
 export interface Fee {
   denominator: BN;
@@ -32,6 +33,63 @@ export enum AccountType {
   StakePool,
   ValidatorList,
 }
+
+export const BigNumFromString = coerce(instance(BN), string(), (value) => {
+  if (typeof value === 'string') return new BN(value, 10);
+  throw new Error('invalid big num');
+});
+
+export const PublicKeyFromString = coerce(
+  instance(PublicKey),
+  string(),
+  (value) => new PublicKey(value),
+);
+
+export type StakeAccountType = Infer<typeof StakeAccountType>;
+export const StakeAccountType = enums(['uninitialized', 'initialized', 'delegated', 'rewardsPool']);
+
+export type ParsedInfo = Infer<typeof ParsedInfo>;
+export const ParsedInfo = type({
+  type: string(),
+  info: any(),
+});
+
+export type StakeMeta = Infer<typeof StakeMeta>;
+export const StakeMeta = type({
+  rentExemptReserve: BigNumFromString,
+  authorized: type({
+    staker: PublicKeyFromString,
+    withdrawer: PublicKeyFromString,
+  }),
+  lockup: type({
+    unixTimestamp: number(),
+    epoch: number(),
+    custodian: PublicKeyFromString,
+  }),
+});
+
+export type StakeAccountInfo = Infer<typeof StakeAccountInfo>;
+export const StakeAccountInfo = type({
+  meta: StakeMeta,
+  stake: nullable(
+    type({
+      delegation: type({
+        voter: PublicKeyFromString,
+        stake: BigNumFromString,
+        activationEpoch: BigNumFromString,
+        deactivationEpoch: BigNumFromString,
+        warmupCooldownRate: number(),
+      }),
+      creditsObserved: number(),
+    }),
+  ),
+});
+
+export type StakeAccount = Infer<typeof StakeAccount>;
+export const StakeAccount = type({
+  type: StakeAccountType,
+  info: StakeAccountInfo,
+});
 
 export interface StakePool {
   accountType: AccountType;

--- a/stake-pool/js/src/layouts.ts
+++ b/stake-pool/js/src/layouts.ts
@@ -2,7 +2,17 @@ import { publicKey, struct, u32, u64, u8, option, vec } from '@project-serum/bor
 import { Lockup, PublicKey } from '@solana/web3.js';
 import { AccountInfo } from '@solana/spl-token';
 import BN from 'bn.js';
-import { Infer, number, nullable, enums, type, coerce, instance, string, any } from 'superstruct';
+import {
+  Infer,
+  number,
+  nullable,
+  enums,
+  type,
+  coerce,
+  instance,
+  string,
+  optional,
+} from 'superstruct';
 
 export interface Fee {
   denominator: BN;
@@ -48,12 +58,6 @@ export const PublicKeyFromString = coerce(
 export type StakeAccountType = Infer<typeof StakeAccountType>;
 export const StakeAccountType = enums(['uninitialized', 'initialized', 'delegated', 'rewardsPool']);
 
-export type ParsedInfo = Infer<typeof ParsedInfo>;
-export const ParsedInfo = type({
-  type: string(),
-  info: any(),
-});
-
 export type StakeMeta = Infer<typeof StakeMeta>;
 export const StakeMeta = type({
   rentExemptReserve: BigNumFromString,
@@ -88,7 +92,7 @@ export const StakeAccountInfo = type({
 export type StakeAccount = Infer<typeof StakeAccount>;
 export const StakeAccount = type({
   type: StakeAccountType,
-  info: StakeAccountInfo,
+  info: optional(StakeAccountInfo),
 });
 
 export interface StakePool {

--- a/stake-pool/js/test/instructions.test.ts
+++ b/stake-pool/js/test/instructions.test.ts
@@ -23,8 +23,9 @@ import {
   mockStakeAccount,
   mockTokenAccount,
   mockValidatorList,
-  mockVotersStakeAccount,
+  mockValidatorsStakeAccount,
   stakePoolMock,
+  CONSTANTS,
 } from './mocks';
 
 describe('StakePoolProgram', () => {
@@ -152,7 +153,7 @@ describe('StakePoolProgram', () => {
         if (pubKey == stakePoolAddress) {
           return stakePoolAccount;
         }
-        if (pubKey.toBase58() == '9q2rZU5RujvyD9dmYKhzJAZfG4aGBbvQ8rWY52jCNBai') {
+        if (pubKey.equals(CONSTANTS.poolTokenAccount)) {
           return null;
         }
         return null;
@@ -168,7 +169,7 @@ describe('StakePoolProgram', () => {
         if (pubKey == stakePoolAddress) {
           return stakePoolAccount;
         }
-        if (pubKey.toBase58() == 'GQkqTamwqjaNDfsbNm7r3aXPJ4oTSqKC3d5t2PF9Smqd') {
+        if (pubKey.equals(CONSTANTS.poolTokenAccount)) {
           return mockTokenAccount(0);
         }
         return null;
@@ -188,7 +189,7 @@ describe('StakePoolProgram', () => {
         if (pubKey == stakePoolAddress) {
           return stakePoolAccount;
         }
-        if (pubKey.toBase58() == 'GQkqTamwqjaNDfsbNm7r3aXPJ4oTSqKC3d5t2PF9Smqd') {
+        if (pubKey.equals(CONSTANTS.poolTokenAccount)) {
           return mockTokenAccount(LAMPORTS_PER_SOL);
         }
         return null;
@@ -222,7 +223,7 @@ describe('StakePoolProgram', () => {
         if (pubKey == stakePoolAddress) {
           return stakePoolAccount;
         }
-        if (pubKey.toBase58() == 'GQkqTamwqjaNDfsbNm7r3aXPJ4oTSqKC3d5t2PF9Smqd') {
+        if (pubKey.equals(CONSTANTS.poolTokenAccount)) {
           return mockTokenAccount(0);
         }
         return null;
@@ -241,10 +242,10 @@ describe('StakePoolProgram', () => {
         if (pubKey == stakePoolAddress) {
           return stakePoolAccount;
         }
-        if (pubKey.toBase58() == 'GQkqTamwqjaNDfsbNm7r3aXPJ4oTSqKC3d5t2PF9Smqd') {
+        if (pubKey.equals(CONSTANTS.poolTokenAccount)) {
           return mockTokenAccount(LAMPORTS_PER_SOL * 2);
         }
-        if (pubKey.toBase58() == stakePoolMock.validatorList.toBase58()) {
+        if (pubKey.equals(stakePoolMock.validatorList)) {
           return mockValidatorList();
         }
         return null;
@@ -264,24 +265,23 @@ describe('StakePoolProgram', () => {
         if (pubKey == stakePoolAddress) {
           return stakePoolAccount;
         }
-        if (pubKey.toBase58() == '1111111111111111111111111111111Z') {
+        if (pubKey.equals(CONSTANTS.poolTokenAccount)) {
           return mockTokenAccount(LAMPORTS_PER_SOL * 2);
         }
-        if (pubKey.toBase58() == stakePoolMock.validatorList.toBase58()) {
+        if (pubKey.equals(stakePoolMock.validatorList)) {
           return mockValidatorList();
         }
-        if (pubKey.toBase58() == new PublicKey(32).toBase58()) return mockVotersStakeAccount();
+        if (pubKey.equals(CONSTANTS.validatorStakeAccountAddress))
+          return mockValidatorsStakeAccount();
         return null;
       });
       connection.getParsedAccountInfo = jest.fn(async (pubKey: PublicKey) => {
-        if (pubKey.toBase58() == stakeReceiver.toBase58()) {
+        if (pubKey.equals(stakeReceiver)) {
           return mockStakeAccount();
         }
         return null;
       });
-      PublicKey.findProgramAddress = jest.fn(async (): Promise<[PublicKey, number]> => {
-        return [new PublicKey(32), 32];
-      });
+
       const res = await withdrawStake(
         connection,
         stakePoolAddress,

--- a/stake-pool/js/test/instructions.test.ts
+++ b/stake-pool/js/test/instructions.test.ts
@@ -15,17 +15,20 @@ import {
   depositSol,
   withdrawSol,
   withdrawStake,
+  getStakeAccount,
 } from '../src';
 
 import { decodeData } from '../src/utils';
 
 import {
-  mockStakeAccount,
+  mockRpc,
   mockTokenAccount,
   mockValidatorList,
   mockValidatorsStakeAccount,
   stakePoolMock,
   CONSTANTS,
+  stakeAccountData,
+  uninitializedStakeAccount,
 } from './mocks';
 
 describe('StakePoolProgram', () => {
@@ -277,7 +280,7 @@ describe('StakePoolProgram', () => {
       });
       connection.getParsedAccountInfo = jest.fn(async (pubKey: PublicKey) => {
         if (pubKey.equals(stakeReceiver)) {
-          return mockStakeAccount();
+          return mockRpc(stakeAccountData);
         }
         return null;
       });
@@ -298,6 +301,20 @@ describe('StakePoolProgram', () => {
       expect(res.signers).toHaveLength(2);
       expect(res.stakeReceiver).toEqual(stakeReceiver);
       expect(res.totalRentFreeBalances).toEqual(10000);
+    });
+  });
+  describe('getStakeAccount', () => {
+    it.only('returns an uninitialized parsed stake account', async () => {
+      const stakeAccount = new PublicKey(20);
+      connection.getParsedAccountInfo = jest.fn(async (pubKey: PublicKey) => {
+        if (pubKey.equals(stakeAccount)) {
+          return mockRpc(uninitializedStakeAccount);
+        }
+        return null;
+      });
+      const parsedStakeAccount = await getStakeAccount(connection, stakeAccount);
+      expect((connection.getParsedAccountInfo as jest.Mock).mock.calls.length).toBe(1);
+      expect(parsedStakeAccount).toEqual(uninitializedStakeAccount.parsed);
     });
   });
 });

--- a/stake-pool/js/test/layouts.test.ts
+++ b/stake-pool/js/test/layouts.test.ts
@@ -1,6 +1,13 @@
-import { StakePoolLayout, ValidatorListLayout, ValidatorList } from '../src/layouts';
+import { create } from 'superstruct';
+import {
+  StakePoolLayout,
+  ValidatorListLayout,
+  ValidatorList,
+  ParsedInfo,
+  StakeAccount,
+} from '../src/layouts';
 import { deepStrictEqualBN } from './equal';
-import { stakePoolMock, validatorListMock } from './mocks';
+import { stakePoolMock, validatorListMock, mockStakeAccount, stakeAccountData } from './mocks';
 
 describe('layouts', () => {
   describe('StakePoolAccount', () => {
@@ -30,6 +37,15 @@ describe('layouts', () => {
       ValidatorListLayout.encode(validatorListMock, encodedData);
       const decodedData = ValidatorListLayout.decode(encodedData);
       deepStrictEqualBN(decodedData, validatorListMock);
+    });
+  });
+
+  describe('StakeAccount', () => {
+    it('should succesfully return a typed response for json parsed stake account', () => {
+      const result = mockStakeAccount().value;
+      const info = create(result.data.parsed, ParsedInfo);
+      const parsed = create(info, StakeAccount);
+      expect(parsed).toEqual(stakeAccountData.parsed);
     });
   });
 });

--- a/stake-pool/js/test/layouts.test.ts
+++ b/stake-pool/js/test/layouts.test.ts
@@ -1,13 +1,6 @@
-import { create } from 'superstruct';
-import {
-  StakePoolLayout,
-  ValidatorListLayout,
-  ValidatorList,
-  ParsedInfo,
-  StakeAccount,
-} from '../src/layouts';
+import { StakePoolLayout, ValidatorListLayout, ValidatorList } from '../src/layouts';
 import { deepStrictEqualBN } from './equal';
-import { stakePoolMock, validatorListMock, mockStakeAccount, stakeAccountData } from './mocks';
+import { stakePoolMock, validatorListMock } from './mocks';
 
 describe('layouts', () => {
   describe('StakePoolAccount', () => {
@@ -37,15 +30,6 @@ describe('layouts', () => {
       ValidatorListLayout.encode(validatorListMock, encodedData);
       const decodedData = ValidatorListLayout.decode(encodedData);
       deepStrictEqualBN(decodedData, validatorListMock);
-    });
-  });
-
-  describe('StakeAccount', () => {
-    it('should succesfully return a typed response for json parsed stake account', () => {
-      const result = mockStakeAccount().value;
-      const info = create(result.data.parsed, ParsedInfo);
-      const parsed = create(info, StakeAccount);
-      expect(parsed).toEqual(stakeAccountData.parsed);
     });
   });
 });

--- a/stake-pool/js/test/mocks.ts
+++ b/stake-pool/js/test/mocks.ts
@@ -1,4 +1,4 @@
-import { AccountInfo, LAMPORTS_PER_SOL, PublicKey } from '@solana/web3.js';
+import { AccountInfo, LAMPORTS_PER_SOL, PublicKey, StakeProgram } from '@solana/web3.js';
 import BN from 'bn.js';
 import { ValidatorStakeInfo } from '../src';
 import { ValidatorStakeInfoStatus, AccountLayout, ValidatorListLayout } from '../src/layouts';
@@ -127,6 +127,33 @@ export function mockTokenAccount(amount = 0) {
   return <AccountInfo<any>>{
     executable: true,
     owner: new PublicKey(0),
+    lamports: amount,
+    data,
+  };
+}
+
+export function mockStakeAccount(amount = 0) {
+  const data = Buffer.alloc(1024);
+  AccountLayout.encode(
+    {
+      state: 0,
+      mint: stakePoolMock.poolMint,
+      owner: StakeProgram.programId,
+      amount: new BN(amount),
+      delegate: new PublicKey(14),
+      // delegatedAmount: new BN(0),
+      // isNative: new BN(0),
+      // isNativeOption:0,
+      // closeAuthority: 0,
+      // delegateOption:0,
+      // closeAuthorityOption:0
+    },
+    data,
+  );
+
+  return <AccountInfo<any>>{
+    executable: true,
+    owner: StakeProgram.programId,
     lamports: amount,
     data,
   };

--- a/stake-pool/js/test/mocks.ts
+++ b/stake-pool/js/test/mocks.ts
@@ -1,4 +1,4 @@
-import { AccountInfo, LAMPORTS_PER_SOL, PublicKey, StakeProgram } from '@solana/web3.js';
+import { AccountInfo, LAMPORTS_PER_SOL, PublicKey } from '@solana/web3.js';
 import BN from 'bn.js';
 import { ValidatorStakeInfo } from '../src';
 import { ValidatorStakeInfoStatus, AccountLayout, ValidatorListLayout } from '../src/layouts';
@@ -132,29 +132,65 @@ export function mockTokenAccount(amount = 0) {
   };
 }
 
-export function mockStakeAccount(amount = 0) {
-  const data = Buffer.alloc(1024);
-  AccountLayout.encode(
-    {
-      state: 0,
-      mint: stakePoolMock.poolMint,
-      owner: StakeProgram.programId,
-      amount: new BN(amount),
-      delegate: new PublicKey(14),
-      // delegatedAmount: new BN(0),
-      // isNative: new BN(0),
-      // isNativeOption:0,
-      // closeAuthority: 0,
-      // delegateOption:0,
-      // closeAuthorityOption:0
-    },
+const mockRpc = (data: any) => {
+  const value = {
+    owner: 'Stake11111111111111111111111111111111',
+    lamports: LAMPORTS_PER_SOL,
     data,
-  );
+    executable: false,
+    rentEpoch: 0,
+  };
+  const result = {
+    context: {
+      slot: 11,
+    },
+    value: value,
+  };
+  return result;
+};
 
+export function mockStakeAccount(): any {
+  const data = {
+    program: 'stake',
+    parsed: {
+      type: 'delegated',
+      info: {
+        meta: {
+          rentExemptReserve: new BN(1),
+          lockup: {
+            epoch: 32,
+            unixTimestamp: 2,
+            custodian: new PublicKey(12),
+          },
+          authorized: {
+            staker: new PublicKey(12),
+            withdrawer: new PublicKey(12),
+          },
+        },
+        stake: {
+          delegation: {
+            voter: new PublicKey(
+              new BN('e4e37d6f2e80c0bb0f3da8a06304e57be5cda6efa2825b86780aa320d9784cf8', 'hex'),
+            ),
+            stake: new BN(0),
+            activationEpoch: new BN(1),
+            deactivationEpoch: new BN(1),
+            warmupCooldownRate: 1.2,
+          },
+          creditsObserved: 1,
+        },
+      },
+    },
+  };
+  return mockRpc(data);
+}
+
+export function mockVotersStakeAccount() {
+  const data = Buffer.alloc(1024);
   return <AccountInfo<any>>{
     executable: true,
-    owner: StakeProgram.programId,
-    lamports: amount,
+    owner: new PublicKey(0),
+    lamports: 3000000000,
     data,
   };
 }

--- a/stake-pool/js/test/mocks.ts
+++ b/stake-pool/js/test/mocks.ts
@@ -1,7 +1,16 @@
-import { AccountInfo, LAMPORTS_PER_SOL, PublicKey } from '@solana/web3.js';
+import { AccountInfo, LAMPORTS_PER_SOL, PublicKey, StakeProgram } from '@solana/web3.js';
 import BN from 'bn.js';
 import { ValidatorStakeInfo } from '../src';
 import { ValidatorStakeInfoStatus, AccountLayout, ValidatorListLayout } from '../src/layouts';
+
+export const CONSTANTS = {
+  poolTokenAccount: new PublicKey(
+    new BN('e4f53a3a11521b9171c942ff91183ec8db4e6f347bb9aa7d4a814b7874bfd15c', 'hex'),
+  ),
+  validatorStakeAccountAddress: new PublicKey(
+    new BN('69184b7f1bc836271c4ac0e29e53eb38a38ea0e7bcde693c45b30d1592a5a678', 'hex'),
+  ),
+};
 
 export const stakePoolMock = {
   accountType: 1,
@@ -132,11 +141,44 @@ export function mockTokenAccount(amount = 0) {
   };
 }
 
-const mockRpc = (data: any) => {
+export const stakeAccountData = {
+  program: 'stake',
+  parsed: {
+    type: 'delegated',
+    info: {
+      meta: {
+        rentExemptReserve: new BN(1),
+        lockup: {
+          epoch: 32,
+          unixTimestamp: 2,
+          custodian: new PublicKey(12),
+        },
+        authorized: {
+          staker: new PublicKey(12),
+          withdrawer: new PublicKey(12),
+        },
+      },
+      stake: {
+        delegation: {
+          voter: new PublicKey(
+            new BN('e4e37d6f2e80c0bb0f3da8a06304e57be5cda6efa2825b86780aa320d9784cf8', 'hex'),
+          ),
+          stake: new BN(0),
+          activationEpoch: new BN(1),
+          deactivationEpoch: new BN(1),
+          warmupCooldownRate: 1.2,
+        },
+        creditsObserved: 1,
+      },
+    },
+  },
+};
+
+export function mockStakeAccount(): any {
   const value = {
-    owner: 'Stake11111111111111111111111111111111',
+    owner: StakeProgram.programId,
     lamports: LAMPORTS_PER_SOL,
-    data,
+    data: stakeAccountData,
     executable: false,
     rentEpoch: 0,
   };
@@ -147,49 +189,13 @@ const mockRpc = (data: any) => {
     value: value,
   };
   return result;
-};
-
-export function mockStakeAccount(): any {
-  const data = {
-    program: 'stake',
-    parsed: {
-      type: 'delegated',
-      info: {
-        meta: {
-          rentExemptReserve: new BN(1),
-          lockup: {
-            epoch: 32,
-            unixTimestamp: 2,
-            custodian: new PublicKey(12),
-          },
-          authorized: {
-            staker: new PublicKey(12),
-            withdrawer: new PublicKey(12),
-          },
-        },
-        stake: {
-          delegation: {
-            voter: new PublicKey(
-              new BN('e4e37d6f2e80c0bb0f3da8a06304e57be5cda6efa2825b86780aa320d9784cf8', 'hex'),
-            ),
-            stake: new BN(0),
-            activationEpoch: new BN(1),
-            deactivationEpoch: new BN(1),
-            warmupCooldownRate: 1.2,
-          },
-          creditsObserved: 1,
-        },
-      },
-    },
-  };
-  return mockRpc(data);
 }
 
-export function mockVotersStakeAccount() {
+export function mockValidatorsStakeAccount() {
   const data = Buffer.alloc(1024);
   return <AccountInfo<any>>{
-    executable: true,
-    owner: new PublicKey(0),
+    executable: false,
+    owner: StakeProgram.programId,
     lamports: 3000000000,
     data,
   };

--- a/stake-pool/js/test/mocks.ts
+++ b/stake-pool/js/test/mocks.ts
@@ -141,6 +141,23 @@ export function mockTokenAccount(amount = 0) {
   };
 }
 
+export const mockRpc = (data: any): any => {
+  const value = {
+    owner: StakeProgram.programId,
+    lamports: LAMPORTS_PER_SOL,
+    data: data,
+    executable: false,
+    rentEpoch: 0,
+  };
+  const result = {
+    context: {
+      slot: 11,
+    },
+    value: value,
+  };
+  return result;
+};
+
 export const stakeAccountData = {
   program: 'stake',
   parsed: {
@@ -174,22 +191,12 @@ export const stakeAccountData = {
   },
 };
 
-export function mockStakeAccount(): any {
-  const value = {
-    owner: StakeProgram.programId,
-    lamports: LAMPORTS_PER_SOL,
-    data: stakeAccountData,
-    executable: false,
-    rentEpoch: 0,
-  };
-  const result = {
-    context: {
-      slot: 11,
-    },
-    value: value,
-  };
-  return result;
-}
+export const uninitializedStakeAccount = {
+  program: 'stake',
+  parsed: {
+    type: 'uninitialized',
+  },
+};
 
 export function mockValidatorsStakeAccount() {
   const data = Buffer.alloc(1024);


### PR DESCRIPTION
This PR adds :-
1). Merge the stake account if stake receiver is initialized.
2). Mock tests for the js and withdraw with stake receiver in the cli scripts.

Instead of changing the stake pool program the withdraw functionality is extended in tools. The stake pool program always performs split with a new stake account and if the ```stake_receiver``` is initialized , the withdrawn stakes are merged with the ```stake_receiver```

closes #1421 