### PR TITLE
token-js: Add reallocate instruction implementation

### DIFF
--- a/token/js/src/instructions/index.ts
+++ b/token/js/src/instructions/index.ts
@@ -23,7 +23,8 @@ export * from './initializeMultisig2'; // 19
 export * from './initializeMint2'; //     20
 export * from './initializeImmutableOwner'; //  22
 export * from './initializeMintCloseAuthority'; // 23
-export * from './createNativeMint'; //    29
+export * from './reallocate'; //    29
+export * from './createNativeMint'; //    31
 export * from './initializeNonTransferableMint'; //    32
 
 export * from './decode';

--- a/token/js/src/instructions/reallocate.ts
+++ b/token/js/src/instructions/reallocate.ts
@@ -1,0 +1,53 @@
+import { seq, struct, u8, u16 } from '@solana/buffer-layout';
+import { PublicKey, Signer, SystemProgram, TransactionInstruction } from '@solana/web3.js';
+import { programSupportsExtensions, TOKEN_2022_PROGRAM_ID } from '../constants';
+import { TokenUnsupportedInstructionError } from '../errors';
+import { addSigners } from './internal';
+import { TokenInstruction } from './types';
+import { ExtensionType } from '../extensions';
+
+/** TODO: docs */
+export interface ReallocateInstructionData {
+    instruction: TokenInstruction.Reallocate;
+    extensionTypes: ExtensionType[];
+}
+
+/**
+ * Construct a Reallocate instruction
+ *
+ * @param account        Address of the token account
+ * @param payer          Address paying for the reallocation
+ * @param extensionTypes Extensions to reallocate for
+ * @param owner          Owner of the account
+ * @param multiSigners   Signing accounts if `owner` is a multisig
+ * @param programId      SPL Token program account
+ *
+ * @return Instruction to add to a transaction
+ */
+export function createReallocateInstruction(
+    account: PublicKey,
+    payer: PublicKey,
+    extensionTypes: ExtensionType[],
+    owner: PublicKey,
+    multiSigners: Signer[] = [],
+    programId = TOKEN_2022_PROGRAM_ID
+): TransactionInstruction {
+    if (!programSupportsExtensions(programId)) {
+        throw new TokenUnsupportedInstructionError();
+    }
+    const baseKeys = [
+        { pubkey: account, isSigner: false, isWritable: true },
+        { pubkey: payer, isSigner: true, isWritable: true },
+        { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ];
+    const keys = addSigners(baseKeys, owner, multiSigners);
+
+    const reallocateInstructionData = struct<ReallocateInstructionData>([
+        u8('instruction'),
+        seq(u16(), extensionTypes.length, 'extensionTypes'),
+    ]);
+    const data = Buffer.alloc(reallocateInstructionData.span);
+    reallocateInstructionData.encode({ instruction: TokenInstruction.Reallocate, extensionTypes }, data);
+
+    return new TransactionInstruction({ keys, programId, data });
+}

--- a/token/js/test/e2e-2022/reallocate.test.ts
+++ b/token/js/test/e2e-2022/reallocate.test.ts
@@ -1,0 +1,57 @@
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+chai.use(chaiAsPromised);
+
+import { Connection, Keypair, PublicKey, Signer, Transaction, sendAndConfirmTransaction } from '@solana/web3.js';
+
+import { ExtensionType, createAccount, createMint, createReallocateInstruction, getAccountLen } from '../../src';
+
+import { TEST_PROGRAM_ID, newAccountWithLamports, getConnection } from '../common';
+const TEST_TOKEN_DECIMALS = 2;
+const EXTENSIONS = [ExtensionType.ImmutableOwner];
+describe('reallocate', () => {
+    let connection: Connection;
+    let payer: Signer;
+    let owner: Keypair;
+    let account: PublicKey;
+    let mint: PublicKey;
+    before(async () => {
+        connection = await getConnection();
+        payer = await newAccountWithLamports(connection, 1000000000);
+    });
+    beforeEach(async () => {
+        const mintAuthority = Keypair.generate();
+        const mintKeypair = Keypair.generate();
+        mint = await createMint(
+            connection,
+            payer,
+            mintAuthority.publicKey,
+            mintAuthority.publicKey,
+            TEST_TOKEN_DECIMALS,
+            mintKeypair,
+            undefined,
+            TEST_PROGRAM_ID
+        );
+        owner = Keypair.generate();
+        account = await createAccount(connection, payer, mint, owner.publicKey, undefined, undefined, TEST_PROGRAM_ID);
+    });
+    it('works', async () => {
+        const transaction = new Transaction().add(
+            createReallocateInstruction(
+                account,
+                payer.publicKey,
+                EXTENSIONS,
+                owner.publicKey,
+                undefined,
+                TEST_PROGRAM_ID
+            )
+        );
+        await sendAndConfirmTransaction(connection, transaction, [payer, owner], undefined);
+        const info = await connection.getAccountInfo(account);
+        expect(info).to.not.be.null;
+        if (info !== null) {
+            const expectedAccountLen = getAccountLen(EXTENSIONS);
+            expect(info.data.length).to.eql(expectedAccountLen);
+        }
+    });
+});

--- a/token/js/test/unit/index.test.ts
+++ b/token/js/test/unit/index.test.ts
@@ -4,12 +4,14 @@ import chaiAsPromised from 'chai-as-promised';
 import {
     ASSOCIATED_TOKEN_PROGRAM_ID,
     createAssociatedTokenAccountInstruction,
+    createReallocateInstruction,
     createInitializeMintInstruction,
     createSyncNativeInstruction,
     createTransferCheckedInstruction,
     getAssociatedTokenAddress,
     TOKEN_PROGRAM_ID,
     TOKEN_2022_PROGRAM_ID,
+    TokenInstruction,
     TokenOwnerOffCurveError,
     getAccountLen,
     ExtensionType,
@@ -99,6 +101,18 @@ describe('spl-token-2022 instructions', () => {
         const ix = createSyncNativeInstruction(Keypair.generate().publicKey, TOKEN_2022_PROGRAM_ID);
         expect(ix.programId).to.eql(TOKEN_2022_PROGRAM_ID);
         expect(ix.keys).to.have.length(1);
+    });
+
+    it('Reallocate', () => {
+        const publicKey = Keypair.generate().publicKey;
+        const extensionTypes = [ExtensionType.MintCloseAuthority, ExtensionType.TransferFeeConfig];
+        const ix = createReallocateInstruction(publicKey, publicKey, extensionTypes, publicKey);
+        expect(ix.programId).to.eql(TOKEN_2022_PROGRAM_ID);
+        expect(ix.keys).to.have.length(4);
+        console.error(ix.data);
+        expect(ix.data[0]).to.eql(TokenInstruction.Reallocate);
+        expect(ix.data[1]).to.eql(extensionTypes[0]);
+        expect(ix.data[3]).to.eql(extensionTypes[1]);
     });
 });
 


### PR DESCRIPTION
#### Problem

`Reallocate` is an available instruction in token-2022 to add more space to token accounts, but the JS bindings don't use it yet.

#### Solution

Implement the reallocate instruction and add a test.

Fixes #2956