### PR TITLE
token-cli: Add no-op client

### DIFF
--- a/token/cli/src/config.rs
+++ b/token/cli/src/config.rs
@@ -69,7 +69,7 @@ impl<'a> Config<'a> {
         ));
         let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
         let program_client: Arc<dyn ProgramClient<ProgramRpcClientSendTransaction>> = if sign_only {
-            let blockhash = value_of(matches, BLOCKHASH_ARG.name);
+            let blockhash = value_of(matches, BLOCKHASH_ARG.name).unwrap_or_default();
             Arc::new(ProgramOfflineClient::new(
                 blockhash,
                 ProgramRpcClientSendTransaction,

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -3138,7 +3138,7 @@ async fn handle_tx<'a>(
 ) -> Result<TransactionReturnData, Error> {
     let fee_payer = Some(&config.fee_payer);
 
-    let recent_blockhash = config.rpc_client.get_latest_blockhash().await?;
+    let recent_blockhash = config.program_client.get_latest_blockhash().await?;
     let message = if let Some(nonce_account) = config.nonce_account.as_ref() {
         let mut message = Message::new_with_nonce(
             instructions,
@@ -3151,9 +3151,9 @@ async fn handle_tx<'a>(
     } else {
         Message::new_with_blockhash(&instructions, fee_payer, &recent_blockhash)
     };
-    let fee = config.rpc_client.get_fee_for_message(&message).await?;
 
     if !config.sign_only {
+        let fee = config.rpc_client.get_fee_for_message(&message).await?;
         check_fee_payer_balance(config, minimum_balance_for_rent_exemption + fee).await?;
     }
 

--- a/token/client/src/client.rs
+++ b/token/client/src/client.rs
@@ -243,7 +243,7 @@ where
 
 /// Program client for offline signing.
 pub struct ProgramOfflineClient<ST> {
-    maybe_blockhash: Option<Hash>,
+    blockhash: Hash,
     _send: ST,
 }
 
@@ -254,9 +254,9 @@ impl<ST> fmt::Debug for ProgramOfflineClient<ST> {
 }
 
 impl<ST> ProgramOfflineClient<ST> {
-    pub fn new(maybe_blockhash: Option<Hash>, send: ST) -> Self {
+    pub fn new(blockhash: Hash, send: ST) -> Self {
         Self {
-            maybe_blockhash,
+            blockhash,
             _send: send,
         }
     }
@@ -275,7 +275,7 @@ where
     }
 
     async fn get_latest_blockhash(&self) -> ProgramClientResult<Hash> {
-        Ok(self.maybe_blockhash.unwrap())
+        Ok(self.blockhash)
     }
 
     async fn send_transaction(&self, transaction: &Transaction) -> ProgramClientResult<ST::Output> {


### PR DESCRIPTION
#### Problem

In order to make offline signing work with `TokenClient`, we need to avoid going out to the network, the token client will by default try to send off transactions.

#### (Potential) Solution

Implement a no-op / offline client type that can be substituted in if `--sign-only` is specified.