### PR TITLE
token-swap: Support pools with mixed token and token-2022 mints

### DIFF
--- a/docs/src/token-2022/onchain.md
+++ b/docs/src/token-2022/onchain.md
@@ -230,6 +230,250 @@ do more work.
 
 ## Part II: Support Mixed Token Programs: trading a Token for a Token-2022
 
+In Part I, we looked at the minimal amount of work to support Token-2022 in your
+program. This work won't cover all cases, however. Specifically, in the token-swap
+program, most instructions involve multiple token types. If those token types are
+from different token programs, then our current implementation will fail.
+
+For example, if you want to swap tokens from the Token program for tokens from
+the Token-2022 program, then your program's instruction must provide each token
+program, so that your program may invoke them.
+
+Let's go through the steps to support both token programs in the same instruction.
+
+### Step 1: Update all instruction interfaces
+
+The first step is to update all instruction interfaces to accept a token program
+for each token type used in the program.
+
+For example, here is the previous definition for the `Swap` instruction:
+
+```rust
+///   Swap the tokens in the pool.
+///
+///   0. `[]` Token-swap
+///   1. `[]` swap authority
+///   2. `[]` user transfer authority
+///   3. `[writable]` token_(A|B) SOURCE Account, amount is transferable by user transfer authority,
+///   4. `[writable]` token_(A|B) Base Account to swap INTO.  Must be the SOURCE token.
+///   5. `[writable]` token_(A|B) Base Account to swap FROM.  Must be the DESTINATION token.
+///   6. `[writable]` token_(A|B) DESTINATION Account assigned to USER as the owner.
+///   7. `[writable]` Pool token mint, to generate trading fees
+///   8. `[writable]` Fee account, to receive trading fees
+///   9. `[]` Token program id
+///   10. `[optional, writable]` Host fee account to receive additional trading fees
+Swap {
+    pub amount_in: u64,
+    pub minimum_amount_out: u64
+}
+```
+
+`Swap` contains 3 different token types: token A, token B, and the pool token. Let's
+add a separate token program for each, transforming the instruction into:
+
+```rust
+///   Swap the tokens in the pool.
+///
+///   0. `[]` Token-swap
+///   1. `[]` swap authority
+///   2. `[]` user transfer authority
+///   3. `[writable]` token_(A|B) SOURCE Account, amount is transferable by user transfer authority,
+///   4. `[writable]` token_(A|B) Base Account to swap INTO.  Must be the SOURCE token.
+///   5. `[writable]` token_(A|B) Base Account to swap FROM.  Must be the DESTINATION token.
+///   6. `[writable]` token_(A|B) DESTINATION Account assigned to USER as the owner.
+///   7. `[writable]` Pool token mint, to generate trading fees
+///   8. `[writable]` Fee account, to receive trading fees
+///   9. `[]` Token (A|B) SOURCE program id
+///   10. `[]` Token (A|B) DESTINATION program id
+///   11. `[]` Pool Token program id
+///   12. `[optional, writable]` Host fee account to receive additional trading fees
+Swap {
+    pub amount_in: u64,
+    pub minimum_amount_out: u64
+}
+```
+
+Note the clarification on `9.`, and the new inputs of `10.` and `11.`.
+
+All of these additional accounts may make you wonder: how big will transactions
+get with these new accounts? If you are using both Token and Token-2022,
+the additional Token-2022 program will take up space in the transaction,
+32 bytes for the pubkey, and 1 byte for its index.
+
+On the flip side, if you're only using one token program at once, you will only
+incur 1 byte of overhead because of the deduplication of accounts in the Solana
+transaction format.
+
+Also note that some instructions will remain unchanged. For example, here is the
+`Initialize` instruction:
+
+```rust
+///   Initializes a new swap
+///
+///   0. `[writable, signer]` New Token-swap to create.
+///   1. `[]` swap authority derived from `create_program_address(&[Token-swap account])`
+///   2. `[]` token_a Account. Must be non zero, owned by swap authority.
+///   3. `[]` token_b Account. Must be non zero, owned by swap authority.
+///   4. `[writable]` Pool Token Mint. Must be empty, owned by swap authority.
+///   5. `[]` Pool Token Account to deposit trading and withdraw fees.
+///   Must be empty, not owned by swap authority
+///   6. `[writable]` Pool Token Account to deposit the initial pool token
+///   supply.  Must be empty, not owned by swap authority.
+///   7. `[]` Token program id
+Initialize { ... } // details omitted
+```
+
+Although we pass in token A and token B accounts, we don't actually need to invoke
+their respective token programs. We do, however, mint new pool tokens, so we must
+pass in the token program for the pool token mint.
+
+This step is mostly churn since interfaces must be updated. Don't worry if some
+tests fail after this step. We'll fix them in the next step.
+
+### Step 2: Update instruction processors
+
+If your instruction processor is expecting accounts after the added token programs,
+you may see some test failures.
+
+Specifically, in the token-swap example, the `Swap` instruction is expecting
+an optional account at the end, which has been clobbered by the added token
+programs.
+
+For this step, we'll simply pull out all of the new provided accounts. For example,
+in the `Swap` instruction processor, we'll go from:
+
+```rust
+let account_info_iter = &mut accounts.iter();
+let swap_info = next_account_info(account_info_iter)?;
+let authority_info = next_account_info(account_info_iter)?;
+let user_transfer_authority_info = next_account_info(account_info_iter)?;                     let source_info = next_account_info(account_info_iter)?;
+let swap_source_info = next_account_info(account_info_iter)?;
+let swap_destination_info = next_account_info(account_info_iter)?;
+let destination_info = next_account_info(account_info_iter)?;                                 let pool_mint_info = next_account_info(account_info_iter)?;                                   let pool_fee_account_info = next_account_info(account_info_iter)?;
+let token_program_info = next_account_info(account_info_iter)?;                       
+```
+
+To:
+
+```rust
+let account_info_iter = &mut accounts.iter();
+let swap_info = next_account_info(account_info_iter)?;
+let authority_info = next_account_info(account_info_iter)?;
+let user_transfer_authority_info = next_account_info(account_info_iter)?;
+let source_info = next_account_info(account_info_iter)?;
+let swap_source_info = next_account_info(account_info_iter)?;
+let swap_destination_info = next_account_info(account_info_iter)?;
+let destination_info = next_account_info(account_info_iter)?;
+let pool_mint_info = next_account_info(account_info_iter)?;
+let pool_fee_account_info = next_account_info(account_info_iter)?;
+let source_token_program_info = next_account_info(account_info_iter)?;
+let destination_token_program_info = next_account_info(account_info_iter)?;
+let pool_token_program_info = next_account_info(account_info_iter)?;
+```
+
+For now, just use one of those. For example, we'll just use `pool_token_program_info`
+everywhere. In the next step, we'll add some tests which will properly fail since
+we're always using the same token program.
+
+Once again, all of your tests should pass! But not for long.
+
+### Step 3: Write tests using multiple token programs at once
+
+In the spirit of test-driven development, let's start by writing some failing
+tests.
+
+Previously, our `test_case`s defined only provided one program id. Now it's
+time to mix them up and add more cases. For full coverage, we could do all
+permutations of different programs, but let's go with:
+
+* all mints belong to Token
+* all mints belong to Token-2022
+* the pool mint belongs to Token, but token A and B belong to Token-2022
+* the pool mint belongs to Token-2022, but token A and B are mixed
+
+Let's update test cases to pass in three different program ids, and then use them
+in the tests. For example, that means transforming:
+
+```rust
+#[test_case(spl_token::id(); "token")]
+#[test_case(spl_token_2022::id(); "token-2022")]
+fn test_initialize(token_program_id: Pubkey) {
+```
+
+Into:
+
+```rust
+#[test_case(spl_token::id(), spl_token::id(), spl_token::id(); "all-token")]
+#[test_case(spl_token_2022::id(), spl_token_2022::id(), spl_token_2022::id(); "all-token-2022")]
+#[test_case(spl_token::id(), spl_token_2022::id(), spl_token_2022::id(); "mixed-pool-token")]
+#[test_case(spl_token_2022::id(), spl_token_2022::id(), spl_token::id(); "mixed-pool-token-2022")]
+fn test_initialize(pool_token_program_id: Pubkey, token_a_program_id: Pubkey, token_b_program_id: Pubkey) {
+    ...
+}
+```
+
+This step may also involve churn, but take your time to go through it carefully,
+and you'll have failing tests for the `mixed-pool-token` and `mixed-pool-token-2022`
+test cases.
+
+### Step 4: Use appropriate token program in your processor
+
+Let's fix the failing tests! The errors come up because we're trying to operate
+on tokens with the wrong program in a "mixed" Token and Token-2022 environment.
+
+We need to properly use all of the `pool_token_program_info` / `token_a_program_info`
+variables that we extracted in Step 2.
+
+In the token-swap example, we'll check anywhere we filled in `pool_token_program_info`
+by default, and instead choose the correct program info. For example, when
+transferring the source tokens in `process_swap`, we currently have:
+
+```rust
+Self::token_transfer(
+    swap_info.key,
+    pool_token_program_info.clone(),
+    source_info.clone(),
+    swap_source_info.clone(),
+    user_transfer_authority_info.clone(),
+    token_swap.bump_seed(),
+    to_u64(result.source_amount_swapped)?,
+)?;
+```
+
+Let's use the correct token program, making this:
+
+```rust
+Self::token_transfer(
+    swap_info.key,
+    source_token_program_info.clone(),
+    source_info.clone(),
+    swap_source_info.clone(),
+    user_transfer_authority_info.clone(),
+    token_swap.bump_seed(),
+    to_u64(result.source_amount_swapped)?,
+)?;
+```
+
+While going through this, if you notice any owner checks for a token account or mint
+in the form of:
+
+```rust
+if token_account_info.owner != &spl_token::id() { ... }
+```
+
+You'll need to update to a new owner check from `spl_token_2022`:
+
+```rust
+if spl_token_2022::check_spl_token_program_account(token_account_info.owner).is_err() { ... }
+```
+
+In this step, because of all the test cases in token-swap, we also have to update
+the expected error due to mismatched owner token programs.
+
+It's tedious, but at this point, we have updated our program to use both Token
+and Token-2022 simultaneously. Congratulations! You're ready to be part of the
+next stage of DeFi on Solana.
+
 ## Part III: Support Specific Extensions
 
 ### Update from `transfer` to `transfer_checked`

--- a/token-swap/js/test/token-swap-test.ts
+++ b/token-swap/js/test/token-swap-test.ts
@@ -181,7 +181,7 @@ export async function createTokenSwap(
     swapPayer,
   );
 
-  assert(fetchedTokenSwap.tokenProgramId.equals(TOKEN_PROGRAM_ID));
+  assert(fetchedTokenSwap.poolTokenProgramId.equals(TOKEN_PROGRAM_ID));
   assert(fetchedTokenSwap.tokenAccountA.equals(tokenAccountA));
   assert(fetchedTokenSwap.tokenAccountB.equals(tokenAccountB));
   assert(fetchedTokenSwap.mintA.equals(mintA.publicKey));
@@ -262,6 +262,8 @@ export async function depositAllTokenTypes(): Promise<void> {
     userAccountA,
     userAccountB,
     newAccountPool,
+    TOKEN_PROGRAM_ID,
+    TOKEN_PROGRAM_ID,
     userTransferAuthority,
     POOL_TOKEN_AMOUNT,
     tokenA,
@@ -328,6 +330,8 @@ export async function withdrawAllTokenTypes(): Promise<void> {
     userAccountA,
     userAccountB,
     tokenAccountPool,
+    TOKEN_PROGRAM_ID,
+    TOKEN_PROGRAM_ID,
     userTransferAuthority,
     POOL_TOKEN_AMOUNT,
     tokenA,
@@ -411,7 +415,9 @@ export async function createAccountAndSwapAtomic(): Promise<void> {
       tokenSwap.feeAccount,
       null,
       tokenSwap.swapProgramId,
-      tokenSwap.tokenProgramId,
+      TOKEN_PROGRAM_ID,
+      TOKEN_PROGRAM_ID,
+      tokenSwap.poolTokenProgramId,
       SWAP_AMOUNT_IN,
       0,
     ),
@@ -465,6 +471,8 @@ export async function swap(): Promise<void> {
     tokenAccountA,
     tokenAccountB,
     userAccountB,
+    TOKEN_PROGRAM_ID,
+    TOKEN_PROGRAM_ID,
     poolAccount,
     userTransferAuthority,
     SWAP_AMOUNT_IN,
@@ -566,6 +574,7 @@ export async function depositSingleTokenTypeExactAmountIn(): Promise<void> {
   await tokenSwap.depositSingleTokenTypeExactAmountIn(
     userAccountA,
     newAccountPool,
+    TOKEN_PROGRAM_ID,
     userTransferAuthority,
     depositAmount,
     poolTokenA,
@@ -583,6 +592,7 @@ export async function depositSingleTokenTypeExactAmountIn(): Promise<void> {
   await tokenSwap.depositSingleTokenTypeExactAmountIn(
     userAccountB,
     newAccountPool,
+    TOKEN_PROGRAM_ID,
     userTransferAuthority,
     depositAmount,
     poolTokenB,
@@ -656,6 +666,7 @@ export async function withdrawSingleTokenTypeExactAmountOut(): Promise<void> {
   await tokenSwap.withdrawSingleTokenTypeExactAmountOut(
     userAccountA,
     tokenAccountPool,
+    TOKEN_PROGRAM_ID,
     userTransferAuthority,
     withdrawAmount,
     adjustedPoolTokenA,
@@ -675,6 +686,7 @@ export async function withdrawSingleTokenTypeExactAmountOut(): Promise<void> {
   await tokenSwap.withdrawSingleTokenTypeExactAmountOut(
     userAccountB,
     tokenAccountPool,
+    TOKEN_PROGRAM_ID,
     userTransferAuthority,
     withdrawAmount,
     adjustedPoolTokenB,

--- a/token-swap/program/fuzz/src/native_token_swap.rs
+++ b/token-swap/program/fuzz/src/native_token_swap.rs
@@ -31,7 +31,9 @@ pub struct NativeTokenSwap {
     pub token_a_mint_account: NativeAccountData,
     pub token_b_account: NativeAccountData,
     pub token_b_mint_account: NativeAccountData,
-    pub token_program_account: NativeAccountData,
+    pub pool_token_program_account: NativeAccountData,
+    pub token_a_program_account: NativeAccountData,
+    pub token_b_program_account: NativeAccountData,
 }
 
 pub fn create_program_account(program_id: Pubkey) -> NativeAccountData {
@@ -56,7 +58,9 @@ impl NativeTokenSwap {
             &spl_token_swap::id(),
         );
         let mut authority_account = create_program_account(authority_key);
-        let mut token_program_account = create_program_account(spl_token::id());
+        let mut pool_token_program_account = create_program_account(spl_token::id());
+        let token_a_program_account = create_program_account(spl_token::id());
+        let token_b_program_account = create_program_account(spl_token::id());
 
         let mut pool_mint_account = native_token::create_mint(&authority_account.key);
         let mut pool_token_account =
@@ -101,7 +105,7 @@ impl NativeTokenSwap {
                 pool_mint_account.as_account_info(),
                 pool_fee_account.as_account_info(),
                 pool_token_account.as_account_info(),
-                token_program_account.as_account_info(),
+                pool_token_program_account.as_account_info(),
             ],
         )
         .unwrap();
@@ -120,7 +124,9 @@ impl NativeTokenSwap {
             token_a_mint_account,
             token_b_account,
             token_b_mint_account,
-            token_program_account,
+            pool_token_program_account,
+            token_a_program_account,
+            token_b_program_account,
         }
     }
 
@@ -154,7 +160,7 @@ impl NativeTokenSwap {
         user_transfer_account.is_signer = true;
         do_process_instruction(
             approve(
-                &self.token_program_account.key,
+                &self.token_a_program_account.key,
                 &token_a_account.key,
                 &user_transfer_account.key,
                 &self.user_account.key,
@@ -171,6 +177,8 @@ impl NativeTokenSwap {
         .unwrap();
         let swap_instruction = instruction::swap(
             &spl_token_swap::id(),
+            &spl_token::id(),
+            &spl_token::id(),
             &spl_token::id(),
             &self.swap_account.key,
             &self.authority_account.key,
@@ -198,7 +206,9 @@ impl NativeTokenSwap {
                 token_b_account.as_account_info(),
                 self.pool_mint_account.as_account_info(),
                 self.pool_fee_account.as_account_info(),
-                self.token_program_account.as_account_info(),
+                self.token_a_program_account.as_account_info(),
+                self.token_b_program_account.as_account_info(),
+                self.pool_token_program_account.as_account_info(),
                 self.pool_token_account.as_account_info(),
             ],
         )
@@ -214,7 +224,7 @@ impl NativeTokenSwap {
         user_transfer_account.is_signer = true;
         do_process_instruction(
             approve(
-                &self.token_program_account.key,
+                &self.token_b_program_account.key,
                 &token_b_account.key,
                 &user_transfer_account.key,
                 &self.user_account.key,
@@ -233,6 +243,8 @@ impl NativeTokenSwap {
         let swap_instruction = instruction::swap(
             &spl_token_swap::id(),
             &spl_token::id(),
+            &spl_token::id(),
+            &spl_token::id(),
             &self.swap_account.key,
             &self.authority_account.key,
             &user_transfer_account.key,
@@ -259,7 +271,9 @@ impl NativeTokenSwap {
                 token_a_account.as_account_info(),
                 self.pool_mint_account.as_account_info(),
                 self.pool_fee_account.as_account_info(),
-                self.token_program_account.as_account_info(),
+                self.token_b_program_account.as_account_info(),
+                self.token_a_program_account.as_account_info(),
+                self.pool_token_program_account.as_account_info(),
                 self.pool_token_account.as_account_info(),
             ],
         )
@@ -276,7 +290,7 @@ impl NativeTokenSwap {
         user_transfer_account.is_signer = true;
         do_process_instruction(
             approve(
-                &self.token_program_account.key,
+                &self.token_a_program_account.key,
                 &token_a_account.key,
                 &user_transfer_account.key,
                 &self.user_account.key,
@@ -294,7 +308,7 @@ impl NativeTokenSwap {
 
         do_process_instruction(
             approve(
-                &self.token_program_account.key,
+                &self.token_b_program_account.key,
                 &token_b_account.key,
                 &user_transfer_account.key,
                 &self.user_account.key,
@@ -318,6 +332,8 @@ impl NativeTokenSwap {
 
         let deposit_instruction = instruction::deposit_all_token_types(
             &spl_token_swap::id(),
+            &spl_token::id(),
+            &spl_token::id(),
             &spl_token::id(),
             &self.swap_account.key,
             &self.authority_account.key,
@@ -344,7 +360,9 @@ impl NativeTokenSwap {
                 self.token_b_account.as_account_info(),
                 self.pool_mint_account.as_account_info(),
                 pool_account.as_account_info(),
-                self.token_program_account.as_account_info(),
+                self.token_a_program_account.as_account_info(),
+                self.token_b_program_account.as_account_info(),
+                self.pool_token_program_account.as_account_info(),
             ],
         )
     }
@@ -366,7 +384,7 @@ impl NativeTokenSwap {
         }
         do_process_instruction(
             approve(
-                &self.token_program_account.key,
+                &self.pool_token_program_account.key,
                 &pool_account.key,
                 &user_transfer_account.key,
                 &self.user_account.key,
@@ -384,6 +402,8 @@ impl NativeTokenSwap {
 
         let withdraw_instruction = instruction::withdraw_all_token_types(
             &spl_token_swap::id(),
+            &spl_token::id(),
+            &spl_token::id(),
             &spl_token::id(),
             &self.swap_account.key,
             &self.authority_account.key,
@@ -412,7 +432,9 @@ impl NativeTokenSwap {
                 token_a_account.as_account_info(),
                 token_b_account.as_account_info(),
                 self.pool_fee_account.as_account_info(),
-                self.token_program_account.as_account_info(),
+                self.pool_token_program_account.as_account_info(),
+                self.token_a_program_account.as_account_info(),
+                self.token_b_program_account.as_account_info(),
             ],
         )
     }
@@ -427,7 +449,7 @@ impl NativeTokenSwap {
         user_transfer_account.is_signer = true;
         do_process_instruction(
             approve(
-                &self.token_program_account.key,
+                &self.token_a_program_account.key,
                 &source_token_account.key,
                 &user_transfer_account.key,
                 &self.user_account.key,
@@ -452,6 +474,7 @@ impl NativeTokenSwap {
         let deposit_instruction = instruction::deposit_single_token_type_exact_amount_in(
             &spl_token_swap::id(),
             &spl_token::id(),
+            &spl_token::id(),
             &self.swap_account.key,
             &self.authority_account.key,
             &user_transfer_account.key,
@@ -475,7 +498,8 @@ impl NativeTokenSwap {
                 self.token_b_account.as_account_info(),
                 self.pool_mint_account.as_account_info(),
                 pool_account.as_account_info(),
-                self.token_program_account.as_account_info(),
+                self.token_a_program_account.as_account_info(),
+                self.pool_token_program_account.as_account_info(),
             ],
         )
     }
@@ -496,7 +520,7 @@ impl NativeTokenSwap {
         }
         do_process_instruction(
             approve(
-                &self.token_program_account.key,
+                &self.pool_token_program_account.key,
                 &pool_account.key,
                 &user_transfer_account.key,
                 &self.user_account.key,
@@ -514,6 +538,7 @@ impl NativeTokenSwap {
 
         let withdraw_instruction = instruction::withdraw_single_token_type_exact_amount_out(
             &spl_token_swap::id(),
+            &spl_token::id(),
             &spl_token::id(),
             &self.swap_account.key,
             &self.authority_account.key,
@@ -540,7 +565,8 @@ impl NativeTokenSwap {
                 self.token_b_account.as_account_info(),
                 destination_token_account.as_account_info(),
                 self.pool_fee_account.as_account_info(),
-                self.token_program_account.as_account_info(),
+                self.pool_token_program_account.as_account_info(),
+                self.token_a_program_account.as_account_info(),
             ],
         )
     }

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -1440,6 +1440,8 @@ mod tests {
                 swap(
                     &SWAP_PROGRAM_ID,
                     &self.token_program_id,
+                    &self.token_program_id,
+                    &self.token_program_id,
                     &self.swap_key,
                     &self.authority_key,
                     &user_transfer_key,
@@ -1531,6 +1533,8 @@ mod tests {
                 deposit_all_token_types(
                     &SWAP_PROGRAM_ID,
                     &self.token_program_id,
+                    &self.token_program_id,
+                    &self.token_program_id,
                     &self.swap_key,
                     &self.authority_key,
                     &user_transfer_authority,
@@ -1601,6 +1605,8 @@ mod tests {
                 withdraw_all_token_types(
                     &SWAP_PROGRAM_ID,
                     &self.token_program_id,
+                    &self.token_program_id,
+                    &self.token_program_id,
                     &self.swap_key,
                     &self.authority_key,
                     &user_transfer_authority_key,
@@ -1668,6 +1674,7 @@ mod tests {
                 deposit_single_token_type_exact_amount_in(
                     &SWAP_PROGRAM_ID,
                     &self.token_program_id,
+                    &self.token_program_id,
                     &self.swap_key,
                     &self.authority_key,
                     &user_transfer_authority_key,
@@ -1730,6 +1737,7 @@ mod tests {
             do_process_instruction(
                 withdraw_single_token_type_exact_amount_out(
                     &SWAP_PROGRAM_ID,
+                    &self.token_program_id,
                     &self.token_program_id,
                     &self.swap_key,
                     &self.authority_key,
@@ -3223,6 +3231,8 @@ mod tests {
                     deposit_all_token_types(
                         &SWAP_PROGRAM_ID,
                         &token_program_id,
+                        &token_program_id,
+                        &token_program_id,
                         &accounts.swap_key,
                         &accounts.authority_key,
                         &user_transfer_authority_key,
@@ -3271,6 +3281,8 @@ mod tests {
                 do_process_instruction(
                     deposit_all_token_types(
                         &SWAP_PROGRAM_ID,
+                        &wrong_key,
+                        &wrong_key,
                         &wrong_key,
                         &accounts.swap_key,
                         &accounts.authority_key,
@@ -3888,6 +3900,8 @@ mod tests {
                     withdraw_all_token_types(
                         &SWAP_PROGRAM_ID,
                         &token_program_id,
+                        &token_program_id,
+                        &token_program_id,
                         &accounts.swap_key,
                         &accounts.authority_key,
                         &user_transfer_authority_key,
@@ -3944,6 +3958,8 @@ mod tests {
                 do_process_instruction(
                     withdraw_all_token_types(
                         &SWAP_PROGRAM_ID,
+                        &wrong_key,
+                        &wrong_key,
                         &wrong_key,
                         &accounts.swap_key,
                         &accounts.authority_key,
@@ -4585,6 +4601,7 @@ mod tests {
                     deposit_single_token_type_exact_amount_in(
                         &SWAP_PROGRAM_ID,
                         &token_program_id,
+                        &token_program_id,
                         &accounts.swap_key,
                         &accounts.authority_key,
                         &user_transfer_authority_key,
@@ -4630,6 +4647,7 @@ mod tests {
                 do_process_instruction(
                     deposit_single_token_type_exact_amount_in(
                         &SWAP_PROGRAM_ID,
+                        &wrong_key,
                         &wrong_key,
                         &accounts.swap_key,
                         &accounts.authority_key,
@@ -5158,6 +5176,7 @@ mod tests {
                     withdraw_single_token_type_exact_amount_out(
                         &SWAP_PROGRAM_ID,
                         &token_program_id,
+                        &token_program_id,
                         &accounts.swap_key,
                         &accounts.authority_key,
                         &user_transfer_authority_key,
@@ -5211,6 +5230,7 @@ mod tests {
                 do_process_instruction(
                     withdraw_single_token_type_exact_amount_out(
                         &SWAP_PROGRAM_ID,
+                        &wrong_key,
                         &wrong_key,
                         &accounts.swap_key,
                         &accounts.authority_key,
@@ -5948,6 +5968,8 @@ mod tests {
             swap(
                 &SWAP_PROGRAM_ID,
                 &token_program_id,
+                &token_program_id,
+                &token_program_id,
                 &accounts.swap_key,
                 &accounts.authority_key,
                 &accounts.authority_key,
@@ -6149,6 +6171,8 @@ mod tests {
                     swap(
                         &SWAP_PROGRAM_ID,
                         &wrong_program_id,
+                        &wrong_program_id,
+                        &wrong_program_id,
                         &accounts.swap_key,
                         &accounts.authority_key,
                         &accounts.authority_key,
@@ -6223,6 +6247,8 @@ mod tests {
                 do_process_instruction(
                     swap(
                         &SWAP_PROGRAM_ID,
+                        &token_program_id,
+                        &token_program_id,
                         &token_program_id,
                         &accounts.swap_key,
                         &accounts.authority_key,
@@ -6393,6 +6419,8 @@ mod tests {
                     swap(
                         &SWAP_PROGRAM_ID,
                         &token_program_id,
+                        &token_program_id,
+                        &token_program_id,
                         &accounts.swap_key,
                         &accounts.authority_key,
                         &user_transfer_key,
@@ -6551,6 +6579,8 @@ mod tests {
                 swap(
                     &SWAP_PROGRAM_ID,
                     &token_program_id,
+                    &token_program_id,
+                    &token_program_id,
                     &accounts.swap_key,
                     &accounts.authority_key,
                     &accounts.authority_key,
@@ -6624,6 +6654,8 @@ mod tests {
                 do_process_instruction_with_fee_constraints(
                     swap(
                         &SWAP_PROGRAM_ID,
+                        &token_program_id,
+                        &token_program_id,
                         &token_program_id,
                         &accounts.swap_key,
                         &accounts.authority_key,

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -230,9 +230,9 @@ impl Processor {
         let pool_mint_info = next_account_info(account_info_iter)?;
         let fee_account_info = next_account_info(account_info_iter)?;
         let destination_info = next_account_info(account_info_iter)?;
-        let token_program_info = next_account_info(account_info_iter)?;
+        let pool_token_program_info = next_account_info(account_info_iter)?;
 
-        let token_program_id = *token_program_info.key;
+        let token_program_id = *pool_token_program_info.key;
         if SwapVersion::is_initialized(&swap_info.data.borrow()) {
             return Err(SwapError::AlreadyInUse.into());
         }
@@ -310,7 +310,7 @@ impl Processor {
 
         Self::token_mint_to(
             swap_info.key,
-            token_program_info.clone(),
+            pool_token_program_info.clone(),
             pool_mint_info.clone(),
             destination_info.clone(),
             authority_info.clone(),
@@ -352,7 +352,9 @@ impl Processor {
         let destination_info = next_account_info(account_info_iter)?;
         let pool_mint_info = next_account_info(account_info_iter)?;
         let pool_fee_account_info = next_account_info(account_info_iter)?;
-        let token_program_info = next_account_info(account_info_iter)?;
+        let source_token_program_info = next_account_info(account_info_iter)?;
+        let destination_token_program_info = next_account_info(account_info_iter)?;
+        let pool_token_program_info = next_account_info(account_info_iter)?;
 
         if swap_info.owner != program_id {
             return Err(ProgramError::IncorrectProgramId);
@@ -389,7 +391,7 @@ impl Processor {
         if *pool_fee_account_info.key != *token_swap.pool_fee_account() {
             return Err(SwapError::IncorrectFeeAccount.into());
         }
-        if *token_program_info.key != *token_swap.token_program_id() {
+        if *pool_token_program_info.key != *token_swap.token_program_id() {
             return Err(SwapError::IncorrectTokenProgramId.into());
         }
 
@@ -431,7 +433,7 @@ impl Processor {
 
         Self::token_transfer(
             swap_info.key,
-            token_program_info.clone(),
+            pool_token_program_info.clone(),
             source_info.clone(),
             swap_source_info.clone(),
             user_transfer_authority_info.clone(),
@@ -471,7 +473,7 @@ impl Processor {
                         .ok_or(SwapError::FeeCalculationFailure)?;
                     Self::token_mint_to(
                         swap_info.key,
-                        token_program_info.clone(),
+                        pool_token_program_info.clone(),
                         pool_mint_info.clone(),
                         host_fee_account_info.clone(),
                         authority_info.clone(),
@@ -482,7 +484,7 @@ impl Processor {
             }
             Self::token_mint_to(
                 swap_info.key,
-                token_program_info.clone(),
+                pool_token_program_info.clone(),
                 pool_mint_info.clone(),
                 pool_fee_account_info.clone(),
                 authority_info.clone(),
@@ -493,7 +495,7 @@ impl Processor {
 
         Self::token_transfer(
             swap_info.key,
-            token_program_info.clone(),
+            pool_token_program_info.clone(),
             swap_destination_info.clone(),
             destination_info.clone(),
             authority_info.clone(),
@@ -522,7 +524,9 @@ impl Processor {
         let token_b_info = next_account_info(account_info_iter)?;
         let pool_mint_info = next_account_info(account_info_iter)?;
         let dest_info = next_account_info(account_info_iter)?;
-        let token_program_info = next_account_info(account_info_iter)?;
+        let token_a_program_info = next_account_info(account_info_iter)?;
+        let token_b_program_info = next_account_info(account_info_iter)?;
+        let pool_token_program_info = next_account_info(account_info_iter)?;
 
         let token_swap = SwapVersion::unpack(&swap_info.data.borrow())?;
         let calculator = &token_swap.swap_curve().calculator;
@@ -537,7 +541,7 @@ impl Processor {
             token_a_info,
             token_b_info,
             pool_mint_info,
-            token_program_info,
+            pool_token_program_info,
             Some(source_a_info),
             Some(source_b_info),
             None,
@@ -581,7 +585,7 @@ impl Processor {
 
         Self::token_transfer(
             swap_info.key,
-            token_program_info.clone(),
+            pool_token_program_info.clone(),
             source_a_info.clone(),
             token_a_info.clone(),
             user_transfer_authority_info.clone(),
@@ -590,7 +594,7 @@ impl Processor {
         )?;
         Self::token_transfer(
             swap_info.key,
-            token_program_info.clone(),
+            pool_token_program_info.clone(),
             source_b_info.clone(),
             token_b_info.clone(),
             user_transfer_authority_info.clone(),
@@ -599,7 +603,7 @@ impl Processor {
         )?;
         Self::token_mint_to(
             swap_info.key,
-            token_program_info.clone(),
+            pool_token_program_info.clone(),
             pool_mint_info.clone(),
             dest_info.clone(),
             authority_info.clone(),
@@ -629,7 +633,9 @@ impl Processor {
         let dest_token_a_info = next_account_info(account_info_iter)?;
         let dest_token_b_info = next_account_info(account_info_iter)?;
         let pool_fee_account_info = next_account_info(account_info_iter)?;
-        let token_program_info = next_account_info(account_info_iter)?;
+        let pool_token_program_info = next_account_info(account_info_iter)?;
+        let token_a_program_info = next_account_info(account_info_iter)?;
+        let token_b_program_info = next_account_info(account_info_iter)?;
 
         let token_swap = SwapVersion::unpack(&swap_info.data.borrow())?;
         Self::check_accounts(
@@ -640,7 +646,7 @@ impl Processor {
             token_a_info,
             token_b_info,
             pool_mint_info,
-            token_program_info,
+            pool_token_program_info,
             Some(dest_token_a_info),
             Some(dest_token_b_info),
             Some(pool_fee_account_info),
@@ -694,7 +700,7 @@ impl Processor {
         if withdraw_fee > 0 {
             Self::token_transfer(
                 swap_info.key,
-                token_program_info.clone(),
+                pool_token_program_info.clone(),
                 source_info.clone(),
                 pool_fee_account_info.clone(),
                 user_transfer_authority_info.clone(),
@@ -704,7 +710,7 @@ impl Processor {
         }
         Self::token_burn(
             swap_info.key,
-            token_program_info.clone(),
+            pool_token_program_info.clone(),
             source_info.clone(),
             pool_mint_info.clone(),
             user_transfer_authority_info.clone(),
@@ -715,7 +721,7 @@ impl Processor {
         if token_a_amount > 0 {
             Self::token_transfer(
                 swap_info.key,
-                token_program_info.clone(),
+                pool_token_program_info.clone(),
                 token_a_info.clone(),
                 dest_token_a_info.clone(),
                 authority_info.clone(),
@@ -726,7 +732,7 @@ impl Processor {
         if token_b_amount > 0 {
             Self::token_transfer(
                 swap_info.key,
-                token_program_info.clone(),
+                pool_token_program_info.clone(),
                 token_b_info.clone(),
                 dest_token_b_info.clone(),
                 authority_info.clone(),
@@ -753,7 +759,8 @@ impl Processor {
         let swap_token_b_info = next_account_info(account_info_iter)?;
         let pool_mint_info = next_account_info(account_info_iter)?;
         let destination_info = next_account_info(account_info_iter)?;
-        let token_program_info = next_account_info(account_info_iter)?;
+        let source_token_program_info = next_account_info(account_info_iter)?;
+        let pool_token_program_info = next_account_info(account_info_iter)?;
 
         let token_swap = SwapVersion::unpack(&swap_info.data.borrow())?;
         let calculator = &token_swap.swap_curve().calculator;
@@ -788,7 +795,7 @@ impl Processor {
             swap_token_a_info,
             swap_token_b_info,
             pool_mint_info,
-            token_program_info,
+            pool_token_program_info,
             source_a_info,
             source_b_info,
             None,
@@ -824,7 +831,7 @@ impl Processor {
             TradeDirection::AtoB => {
                 Self::token_transfer(
                     swap_info.key,
-                    token_program_info.clone(),
+                    pool_token_program_info.clone(),
                     source_info.clone(),
                     swap_token_a_info.clone(),
                     user_transfer_authority_info.clone(),
@@ -835,7 +842,7 @@ impl Processor {
             TradeDirection::BtoA => {
                 Self::token_transfer(
                     swap_info.key,
-                    token_program_info.clone(),
+                    pool_token_program_info.clone(),
                     source_info.clone(),
                     swap_token_b_info.clone(),
                     user_transfer_authority_info.clone(),
@@ -846,7 +853,7 @@ impl Processor {
         }
         Self::token_mint_to(
             swap_info.key,
-            token_program_info.clone(),
+            pool_token_program_info.clone(),
             pool_mint_info.clone(),
             destination_info.clone(),
             authority_info.clone(),
@@ -874,7 +881,8 @@ impl Processor {
         let swap_token_b_info = next_account_info(account_info_iter)?;
         let destination_info = next_account_info(account_info_iter)?;
         let pool_fee_account_info = next_account_info(account_info_iter)?;
-        let token_program_info = next_account_info(account_info_iter)?;
+        let pool_token_program_info = next_account_info(account_info_iter)?;
+        let destination_token_program_info = next_account_info(account_info_iter)?;
 
         let token_swap = SwapVersion::unpack(&swap_info.data.borrow())?;
         let destination_account =
@@ -904,7 +912,7 @@ impl Processor {
             swap_token_a_info,
             swap_token_b_info,
             pool_mint_info,
-            token_program_info,
+            pool_token_program_info,
             destination_a_info,
             destination_b_info,
             Some(pool_fee_account_info),
@@ -950,7 +958,7 @@ impl Processor {
         if withdraw_fee > 0 {
             Self::token_transfer(
                 swap_info.key,
-                token_program_info.clone(),
+                pool_token_program_info.clone(),
                 source_info.clone(),
                 pool_fee_account_info.clone(),
                 user_transfer_authority_info.clone(),
@@ -960,7 +968,7 @@ impl Processor {
         }
         Self::token_burn(
             swap_info.key,
-            token_program_info.clone(),
+            pool_token_program_info.clone(),
             source_info.clone(),
             pool_mint_info.clone(),
             user_transfer_authority_info.clone(),
@@ -972,7 +980,7 @@ impl Processor {
             TradeDirection::AtoB => {
                 Self::token_transfer(
                     swap_info.key,
-                    token_program_info.clone(),
+                    pool_token_program_info.clone(),
                     swap_token_a_info.clone(),
                     destination_info.clone(),
                     authority_info.clone(),
@@ -983,7 +991,7 @@ impl Processor {
             TradeDirection::BtoA => {
                 Self::token_transfer(
                     swap_info.key,
-                    token_program_info.clone(),
+                    pool_token_program_info.clone(),
                     swap_token_b_info.clone(),
                     destination_info.clone(),
                     authority_info.clone(),
@@ -1469,6 +1477,8 @@ mod tests {
                     &mut self.pool_mint_account,
                     &mut self.pool_fee_account,
                     &mut SolanaAccount::default(),
+                    &mut SolanaAccount::default(),
+                    &mut SolanaAccount::default(),
                 ],
             )?;
 
@@ -1562,6 +1572,8 @@ mod tests {
                     &mut self.pool_mint_account,
                     depositor_pool_account,
                     &mut SolanaAccount::default(),
+                    &mut SolanaAccount::default(),
+                    &mut SolanaAccount::default(),
                 ],
             )
         }
@@ -1636,6 +1648,8 @@ mod tests {
                     token_b_account,
                     &mut self.pool_fee_account,
                     &mut SolanaAccount::default(),
+                    &mut SolanaAccount::default(),
+                    &mut SolanaAccount::default(),
                 ],
             )
         }
@@ -1698,6 +1712,7 @@ mod tests {
                     &mut self.token_b_account,
                     &mut self.pool_mint_account,
                     deposit_pool_account,
+                    &mut SolanaAccount::default(),
                     &mut SolanaAccount::default(),
                 ],
             )
@@ -1764,6 +1779,7 @@ mod tests {
                     &mut self.token_b_account,
                     destination_account,
                     &mut self.pool_fee_account,
+                    &mut SolanaAccount::default(),
                     &mut SolanaAccount::default(),
                 ],
             )
@@ -3260,6 +3276,8 @@ mod tests {
                         &mut accounts.pool_mint_account,
                         &mut pool_account,
                         &mut SolanaAccount::default(),
+                        &mut SolanaAccount::default(),
+                        &mut SolanaAccount::default(),
                     ],
                 )
             );
@@ -3310,6 +3328,8 @@ mod tests {
                         &mut accounts.token_b_account,
                         &mut accounts.pool_mint_account,
                         &mut pool_account,
+                        &mut SolanaAccount::default(),
+                        &mut SolanaAccount::default(),
                         &mut SolanaAccount::default(),
                     ],
                 )
@@ -3931,6 +3951,8 @@ mod tests {
                         &mut token_b_account,
                         &mut accounts.pool_fee_account,
                         &mut SolanaAccount::default(),
+                        &mut SolanaAccount::default(),
+                        &mut SolanaAccount::default(),
                     ],
                 )
             );
@@ -3989,6 +4011,8 @@ mod tests {
                         &mut token_a_account,
                         &mut token_b_account,
                         &mut accounts.pool_fee_account,
+                        &mut SolanaAccount::default(),
+                        &mut SolanaAccount::default(),
                         &mut SolanaAccount::default(),
                     ],
                 )
@@ -4626,6 +4650,7 @@ mod tests {
                         &mut accounts.pool_mint_account,
                         &mut pool_account,
                         &mut SolanaAccount::default(),
+                        &mut SolanaAccount::default(),
                     ],
                 )
             );
@@ -4672,6 +4697,7 @@ mod tests {
                         &mut accounts.token_b_account,
                         &mut accounts.pool_mint_account,
                         &mut pool_account,
+                        &mut SolanaAccount::default(),
                         &mut SolanaAccount::default(),
                     ],
                 )
@@ -5203,6 +5229,7 @@ mod tests {
                         &mut token_a_account,
                         &mut accounts.pool_fee_account,
                         &mut SolanaAccount::default(),
+                        &mut SolanaAccount::default(),
                     ],
                 )
             );
@@ -5257,6 +5284,7 @@ mod tests {
                         &mut accounts.token_b_account,
                         &mut token_a_account,
                         &mut accounts.pool_fee_account,
+                        &mut SolanaAccount::default(),
                         &mut SolanaAccount::default(),
                     ],
                 )
@@ -5997,6 +6025,8 @@ mod tests {
                 &mut accounts.pool_mint_account,
                 &mut accounts.pool_fee_account,
                 &mut SolanaAccount::default(),
+                &mut SolanaAccount::default(),
+                &mut SolanaAccount::default(),
                 &mut pool_account,
             ],
             &constraints,
@@ -6200,6 +6230,8 @@ mod tests {
                         &mut accounts.pool_mint_account,
                         &mut accounts.pool_fee_account,
                         &mut SolanaAccount::default(),
+                        &mut SolanaAccount::default(),
+                        &mut SolanaAccount::default(),
                     ],
                 ),
             );
@@ -6276,6 +6308,8 @@ mod tests {
                         &mut token_b_account,
                         &mut accounts.pool_mint_account,
                         &mut accounts.pool_fee_account,
+                        &mut SolanaAccount::default(),
+                        &mut SolanaAccount::default(),
                         &mut SolanaAccount::default(),
                     ],
                 ),
@@ -6448,6 +6482,8 @@ mod tests {
                         &mut accounts.pool_mint_account,
                         &mut accounts.pool_fee_account,
                         &mut SolanaAccount::default(),
+                        &mut SolanaAccount::default(),
+                        &mut SolanaAccount::default(),
                     ],
                 ),
             );
@@ -6608,6 +6644,8 @@ mod tests {
                     &mut accounts.pool_mint_account,
                     &mut accounts.pool_fee_account,
                     &mut SolanaAccount::default(),
+                    &mut SolanaAccount::default(),
+                    &mut SolanaAccount::default(),
                 ],
                 &constraints,
             )
@@ -6683,6 +6721,8 @@ mod tests {
                         &mut token_b_account,
                         &mut accounts.pool_mint_account,
                         &mut accounts.pool_fee_account,
+                        &mut SolanaAccount::default(),
+                        &mut SolanaAccount::default(),
                         &mut SolanaAccount::default(),
                         &mut bad_token_a_account,
                     ],


### PR DESCRIPTION
#### Problem

Token-2022 is out, but people may not know how to support both Token and Token-2022 within the same program.  For example, how do you swap Token tokens for Token-2022 tokens?

#### Solution

Provide another guide with step by step instructions, using the token-swap program as a testing ground.  This is part 2 of 3, so we're almost there!