### PR TITLE
stake-pool: Bump versions to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "spl-stake-pool"
-version = "0.6.4"
+version = "0.7.0"
 dependencies = [
  "arrayref",
  "bincode",
@@ -6158,7 +6158,7 @@ dependencies = [
 
 [[package]]
 name = "spl-stake-pool-cli"
-version = "0.6.4"
+version = "0.7.0"
 dependencies = [
  "bincode",
  "borsh",

--- a/stake-pool/cli/Cargo.toml
+++ b/stake-pool/cli/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://spl.solana.com/stake-pool"
 license = "Apache-2.0"
 name = "spl-stake-pool-cli"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "0.6.4"
+version = "0.7.0"
 
 [dependencies]
 borsh = "0.9"
@@ -24,7 +24,7 @@ solana-program = "=1.10.33"
 solana-remote-wallet = "=1.10.33"
 solana-sdk = "=1.10.33"
 spl-associated-token-account = { version = "=1.1.1", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
-spl-stake-pool = { version = "=0.6.4", path="../program", features = [ "no-entrypoint" ] }
+spl-stake-pool = { version = "=0.7.0", path="../program", features = [ "no-entrypoint" ] }
 spl-token = { version = "=3.5.0", path="../../token/program", features = [ "no-entrypoint" ]  }
 bs58 = "0.4.0"
 bincode = "1.3.1"

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-stake-pool"
-version = "0.6.4"
+version = "0.7.0"
 description = "Solana Program Library Stake Pool"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"


### PR DESCRIPTION
#### Problem

We have new instructions in the stake pool program to create / update pool token metadata, but the program hasn't been released anywhere.

#### Solution

First step: tag a new release so we can build a program from it!