### PR TITLE
ci: Re-enable twoxtx by using local `cargo-test-sbf`

### DIFF
--- a/.github/workflows/pull-request-token.yml
+++ b/.github/workflows/pull-request-token.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Build and test token-2022 twoxtx (TEMPORARY)
         run: |
           ./token/twoxtx-setup.sh
-          ./token/twoxtx-solana/cargo-test-sbf --manifest-path ./token/program-2022-test/Cargo.toml -- --nocapture
+          ./token/twoxtx-test-bpf.sh
 
   js-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-token.yml
+++ b/.github/workflows/pull-request-token.yml
@@ -80,7 +80,6 @@ jobs:
           if-no-files-found: error
 
   cargo-test-bpf-twoxtx:
-    if: ${{ false }}  # disable for now
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -104,7 +103,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE}}
+          key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE }}
 
       - name: Install dependencies
         run: |
@@ -115,7 +114,7 @@ jobs:
       - name: Build and test token-2022 twoxtx (TEMPORARY)
         run: |
           ./token/twoxtx-setup.sh
-          ./ci/cargo-test-bpf.sh token/program-2022-test
+          ./token/twoxtx-solana/cargo-test-sbf --manifest-path ./token/program-2022-test/Cargo.toml -- --nocapture
 
   js-test:
     runs-on: ubuntu-latest

--- a/token/twoxtx-setup.sh
+++ b/token/twoxtx-setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Patch in a Solana v1.11 monorepo that supports 2x transactions for testing the
+# Patch in a Solana v1.12 monorepo that supports 2x transactions for testing the
 # SPL Token 2022 Confidential Transfer extension
 #
 

--- a/token/twoxtx-test-bpf.sh
+++ b/token/twoxtx-test-bpf.sh
@@ -19,7 +19,6 @@ echo "Build required programs"
 ./twoxtx-solana/cargo-build-sbf --manifest-path ../associated-token-account/program/Cargo.toml
 
 echo "Test token-2022"
-./twoxtx-solana/cargo-test-sbf --manifest-path ./program-2022-test/Cargo.toml -- --nocapture
+./twoxtx-solana/cargo-test-sbf --jobs 2 --manifest-path ./program-2022-test/Cargo.toml -- --nocapture
 
 exit 0
-

--- a/token/twoxtx-test-bpf.sh
+++ b/token/twoxtx-test-bpf.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Run token-2022 program tests against a Solana v1.12 monorepo that supports
+# 2x transactions for testing the SPL Token 2022 Confidential Transfer extension
+#
+
+set -e
+
+here="$(dirname "$0")"
+cd "$here"
+
+if [[ ! -d twoxtx-solana ]]; then
+  echo "twoxtx-solana dir not found"
+  exit 1
+fi
+
+echo "Build required programs"
+./twoxtx-solana/cargo-build-sbf --manifest-path ./program-2022/Cargo.toml
+./twoxtx-solana/cargo-build-sbf --manifest-path ../associated-token-account/program/Cargo.toml
+
+echo "Test token-2022"
+./twoxtx-solana/cargo-test-sbf --manifest-path ./program-2022-test/Cargo.toml -- --nocapture
+
+exit 0
+

--- a/token/twoxtx.patch
+++ b/token/twoxtx.patch
@@ -8,7 +8,7 @@ board and is not a permanent solution.
 ---
  rpc/src/rpc.rs             | 16 +++++++++++-----
  sdk/src/packet.rs          |  3 ++-
- web3.js/src/transaction.ts |  4 +++-
+ web3.js/src/transaction/constants.ts |  4 +++-
  3 files changed, 16 insertions(+), 7 deletions(-)
 
 diff --git a/rpc/src/rpc.rs b/rpc/src/rpc.rs
@@ -68,8 +68,8 @@ index efea219043..473a92ecfe 100644
      #[repr(C)]
 diff --git a/web3.js/src/transaction-constants.ts b/web3.js/src/transaction-constants.ts
 index 591873f8b6..f94d5778ba 100644
---- a/web3.js/src/transaction-constants.ts
-+++ b/web3.js/src/transaction-constants.ts
+--- a/web3.js/src/transaction/constants.ts
++++ b/web3.js/src/transaction/constants.ts
 @@ -5,6 +5,6 @@
   * 40 bytes is the size of the IPv6 header
   * 8 bytes is the size of the fragment header


### PR DESCRIPTION
#### Problem

We disabled the twoxtx CI job because of incompatible rust versions, but we can actually pick up the correct version if we just use `cargo-test-sbf` from the twoxtx solana repo.

#### Solution

Just use that!

Fixes #3461 