### PR TITLE
toolchain: Pin repo to 1.59.0 using rust-toolchain.toml

### DIFF
--- a/ci/read-cargo-variable.sh
+++ b/ci/read-cargo-variable.sh
@@ -1,0 +1,14 @@
+# source this file
+
+readCargoVariable() {
+  declare variable="$1"
+  declare Cargo_toml="$2"
+
+  while read -r name equals value _; do
+    if [[ $name = "$variable" && $equals = = ]]; then
+      echo "${value//\"/}"
+      return
+    fi
+  done < <(cat "$Cargo_toml")
+  echo "Unable to locate $variable in $Cargo_toml" 1>&2
+}

--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -18,7 +18,9 @@
 if [[ -n $RUST_STABLE_VERSION ]]; then
   stable_version="$RUST_STABLE_VERSION"
 else
-  stable_version=1.59.0
+  base="$(dirname "${BASH_SOURCE[0]}")"
+  source "$base/read-cargo-variable.sh"
+  stable_version=$(readCargoVariable channel "$base/../rust-toolchain.toml")
 fi
 
 if [[ -n $RUST_NIGHTLY_VERSION ]]; then

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.59.0"


### PR DESCRIPTION
#### Problem

It's not clear what version of rust to use when testing / running SPL stuff.

#### (Partial) Solution

Specify the channel in `rust-toolchain.toml`, and use that in `ci/rust-version.sh`. This doesn't resolve the issue of knowing which version of nightly to use, but at least building / fmt is covered.