### PR TITLE
Refactor command_create_token to use token client

### DIFF
--- a/token/client/src/client.rs
+++ b/token/client/src/client.rs
@@ -79,6 +79,10 @@ impl SendTransactionRpc for ProgramRpcClientSendTransaction {
         transaction: &'a Transaction,
     ) -> BoxFuture<'a, ProgramClientResult<Self::Output>> {
         Box::pin(async move {
+            if !transaction.is_signed() {
+                return Err("Cannot send transaction: not fully signed".into());
+            }
+
             client
                 .send_and_confirm_transaction(transaction)
                 .await

--- a/token/client/tests/program-test.rs
+++ b/token/client/tests/program-test.rs
@@ -18,7 +18,7 @@ use {
 struct TestContext {
     pub decimals: u8,
     pub mint_authority: Keypair,
-    pub token: Token<ProgramBanksClientProcessTransaction, Keypair>,
+    pub token: Token<ProgramBanksClientProcessTransaction>,
 
     pub alice: Keypair,
     pub bob: Keypair,
@@ -44,18 +44,23 @@ impl TestContext {
         let mint_authority = Keypair::new();
         let mint_authority_pubkey = mint_authority.pubkey();
 
-        let token = Token::create_mint(
+        let token = Token::new(
             Arc::clone(&client),
             &spl_token_2022::id(),
-            keypair_clone(&payer),
-            &mint_account,
-            &mint_authority_pubkey,
-            None,
-            decimals,
-            vec![],
-        )
-        .await
-        .expect("failed to create mint");
+            &mint_account.pubkey(),
+            Arc::new(keypair_clone(&payer)),
+        );
+
+        token
+            .create_mint(
+                &mint_authority_pubkey,
+                None,
+                decimals,
+                vec![],
+                &[&mint_account],
+            )
+            .await
+            .expect("failed to create mint");
 
         Self {
             decimals,

--- a/token/program-2022-test/tests/sync_native.rs
+++ b/token/program-2022-test/tests/sync_native.rs
@@ -17,7 +17,7 @@ use {
 };
 
 async fn run_basic(
-    token: Token<ProgramBanksClientProcessTransaction, Keypair>,
+    token: Token<ProgramBanksClientProcessTransaction>,
     context: Arc<Mutex<ProgramTestContext>>,
     account: Pubkey,
 ) {

--- a/token/program-2022-test/tests/transfer_fee.rs
+++ b/token/program-2022-test/tests/transfer_fee.rs
@@ -74,7 +74,7 @@ fn test_transfer_fee_config_with_keypairs() -> TransferFeeConfigWithKeypairs {
 
 struct TokenWithAccounts {
     context: TestContext,
-    token: Token<ProgramBanksClientProcessTransaction, Keypair>,
+    token: Token<ProgramBanksClientProcessTransaction>,
     transfer_fee_config: TransferFeeConfig,
     withdraw_withheld_authority: Keypair,
     freeze_authority: Keypair,
@@ -1093,7 +1093,7 @@ async fn no_fees_from_self_transfer() {
 }
 
 async fn create_and_transfer_to_account(
-    token: &Token<ProgramBanksClientProcessTransaction, Keypair>,
+    token: &Token<ProgramBanksClientProcessTransaction>,
     source: &Pubkey,
     authority: &Keypair,
     owner: &Pubkey,


### PR DESCRIPTION
draft because:
* ~i had a small question about the memo handling~
* ~i need to rebase again when #3449 lands~
* ~i need to reverse merge out the close authority stubs~
* ~we need a new solana monorepo version to bring in the `Signers` impl (so this actually wont build at all for you as-is)~

but (other than that!!) this is basically done

this pr implements a full flow for `command_create_token` to go through the token client, including support for nonce mode offline signing. this is prerequisite work to #3403 