### PR TITLE
token/js - make unpack functions consistent

### DIFF
--- a/token/js/examples/transferFee.ts
+++ b/token/js/examples/transferFee.ts
@@ -133,7 +133,7 @@ import {
     });
     const accountsToWithdrawFrom = [];
     for (const accountInfo of allAccounts) {
-        const account = unpackAccount(accountInfo.account, accountInfo.pubkey, TOKEN_2022_PROGRAM_ID);
+        const account = unpackAccount(accountInfo.pubkey, accountInfo.account, TOKEN_2022_PROGRAM_ID);
         const transferFeeAmount = getTransferFeeAmount(account);
         if (transferFeeAmount !== null && transferFeeAmount.withheldAmount > BigInt(0)) {
             accountsToWithdrawFrom.push(accountInfo.pubkey);

--- a/token/js/package.json
+++ b/token/js/package.json
@@ -46,7 +46,7 @@
         "@solana/web3.js": "^1.41.0"
     },
     "devDependencies": {
-        "@solana/spl-memo": "^0.1.0",
+        "@solana/spl-memo": "^0.2.0",
         "@types/chai-as-promised": "^7.1.4",
         "@types/eslint": "^8.4.0",
         "@types/eslint-plugin-prettier": "^3.1.0",

--- a/token/js/package.json
+++ b/token/js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/spl-token",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/solana-program-library",
     "license": "Apache-2.0",

--- a/token/js/src/state/account.ts
+++ b/token/js/src/state/account.ts
@@ -99,7 +99,7 @@ export async function getAccount(
     programId = TOKEN_PROGRAM_ID
 ): Promise<Account> {
     const info = await connection.getAccountInfo(address, commitment);
-    return unpackAccount(info, address, programId);
+    return unpackAccount(address, info, programId);
 }
 
 /**
@@ -119,12 +119,7 @@ export async function getMultipleAccounts(
     programId = TOKEN_PROGRAM_ID
 ): Promise<Account[]> {
     const infos = await connection.getMultipleAccountsInfo(addresses, commitment);
-    const accounts = [];
-    for (let i = 0; i < infos.length; i++) {
-        const account = unpackAccount(infos[i], addresses[i], programId);
-        accounts.push(account);
-    }
-    return accounts;
+    return addresses.map((address, i) => unpackAccount(address, infos[i], programId))
 }
 
 /** Get the minimum lamport balance for a base token account to be rent exempt
@@ -158,16 +153,18 @@ export async function getMinimumBalanceForRentExemptAccountWithExtensions(
 }
 
 /**
- * Unpacks a token account
- * @param info the token account on-chain account
- * @param address TokenAccount
+ * Unpack a token account
+ *
+ * @param address   Token account
+ * @param info      Token account data
  * @param programId SPL Token program account
- * @returns
+ *
+ * @return Unpacked account
  */
 export function unpackAccount(
-    info: AccountInfo<Buffer> | null,
     address: PublicKey,
-    programId: PublicKey = TOKEN_PROGRAM_ID
+    info: AccountInfo<Buffer> | null,
+    programId = TOKEN_PROGRAM_ID
 ): Account {
     if (!info) throw new TokenAccountNotFoundError();
     if (!info.owner.equals(programId)) throw new TokenInvalidAccountOwnerError();

--- a/token/js/src/state/account.ts
+++ b/token/js/src/state/account.ts
@@ -119,7 +119,7 @@ export async function getMultipleAccounts(
     programId = TOKEN_PROGRAM_ID
 ): Promise<Account[]> {
     const infos = await connection.getMultipleAccountsInfo(addresses, commitment);
-    return addresses.map((address, i) => unpackAccount(address, infos[i], programId))
+    return addresses.map((address, i) => unpackAccount(address, infos[i], programId));
 }
 
 /** Get the minimum lamport balance for a base token account to be rent exempt

--- a/token/js/src/state/account.ts
+++ b/token/js/src/state/account.ts
@@ -159,7 +159,7 @@ export async function getMinimumBalanceForRentExemptAccountWithExtensions(
  * @param info      Token account data
  * @param programId SPL Token program account
  *
- * @return Unpacked account
+ * @return Unpacked token account
  */
 export function unpackAccount(
     address: PublicKey,

--- a/token/js/src/state/mint.ts
+++ b/token/js/src/state/mint.ts
@@ -89,11 +89,7 @@ export async function getMint(
  *
  * @return Unpacked mint
  */
-export function unpackMint(
-    address: PublicKey,
-    info: AccountInfo<Buffer> | null,
-    programId = TOKEN_PROGRAM_ID
-): Mint {
+export function unpackMint(address: PublicKey, info: AccountInfo<Buffer> | null, programId = TOKEN_PROGRAM_ID): Mint {
     if (!info) throw new TokenAccountNotFoundError();
     if (!info.owner.equals(programId)) throw new TokenInvalidAccountOwnerError();
     if (info.data.length < MINT_SIZE) throw new TokenInvalidAccountSizeError();

--- a/token/js/src/state/mint.ts
+++ b/token/js/src/state/mint.ts
@@ -77,20 +77,22 @@ export async function getMint(
     programId = TOKEN_PROGRAM_ID
 ): Promise<Mint> {
     const info = await connection.getAccountInfo(address, commitment);
-    return unpackMint(info, address, programId);
+    return unpackMint(address, info, programId);
 }
 
 /**
- * Unpacks a mint
- * @param info the mint on-chain account
- * @param address Mint
+ * Unpack a mint
+ *
+ * @param address   Mint account
+ * @param info      Mint account data
  * @param programId SPL Token program account
- * @returns
+ *
+ * @return Unpacked mint
  */
 export function unpackMint(
-    info: AccountInfo<Buffer> | null,
     address: PublicKey,
-    programId: PublicKey = TOKEN_PROGRAM_ID
+    info: AccountInfo<Buffer> | null,
+    programId = TOKEN_PROGRAM_ID
 ): Mint {
     if (!info) throw new TokenAccountNotFoundError();
     if (!info.owner.equals(programId)) throw new TokenInvalidAccountOwnerError();

--- a/token/js/src/state/multisig.ts
+++ b/token/js/src/state/multisig.ts
@@ -1,6 +1,6 @@
 import { struct, u8 } from '@solana/buffer-layout';
 import { bool, publicKey } from '@solana/buffer-layout-utils';
-import { AccountInfo, Commitment, Connection, PublicKey } from "@solana/web3.js";
+import { AccountInfo, Commitment, Connection, PublicKey } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ID } from '../constants';
 import { TokenAccountNotFoundError, TokenInvalidAccountOwnerError, TokenInvalidAccountSizeError } from '../errors';
 

--- a/token/js/yarn.lock
+++ b/token/js/yarn.lock
@@ -143,10 +143,10 @@
   dependencies:
     buffer "~6.0.3"
 
-"@solana/spl-memo@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@solana/spl-memo/-/spl-memo-0.1.0.tgz#2578a48da5184b306195bef0d658dec532b46c74"
-  integrity sha512-2Ob89TYXVkLXsdRIsVh9H/9rJrVXpOTapn/f/32n5/B8JRaSRBcVBLIAgAwSjMH1oJdBlmBO0lt8+cbWBrRLuA==
+"@solana/spl-memo@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@solana/spl-memo/-/spl-memo-0.2.0.tgz#adfd4085f3243108a4a6b2f6d08ab8aacc96b382"
+  integrity sha512-qXsayORFdgnnorLXF6XFV2/xaz3T3mHlG6aYsLlhSidPHjaaV0DcJRrYJoO4zMuMyO/s/lJ1vqczthLiV0WjKw==
   dependencies:
     "@solana/web3.js" "^1.41.0"
     buffer "^6.0.3"


### PR DESCRIPTION
The new unpack functions haven't been published to npm yet. This gets their argument order consistent with other lib functions, and updates to the latest spl-memo before releasing.