### PR TITLE
token-cli: support `MintCloseAuthority`

### DIFF
--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -549,34 +549,6 @@ async fn command_create_multisig(
     })
 }
 
-// HANA XXX ok im on the allhands so its hard to think ill just take notes
-// how does this flow. i want to add close mint support
-// it kinda looks like this moight work already?
-// i think i wanna move the auth_str shit into a Display impl
-// update: no its inside token22 itself and i dont want to pollute that
-//
-// so theres a giant block that only executes in not signonly
-// fetches the account, checks programid owner, gets the real programid
-// then parses the account to see if its a mint or a token account
-// for mints, it makes sure it not trying to change token account owner
-// then extracts the previous authority for later usage
-// for accounts, it likewise enforces auth type, then checks if its an ata
-// if it is it errors without a force flag (which is cleverly hidden)
-//
-// ok after all that, which is *not* performed in signonly... it does a lil printy
-// then it builds the instruction and handles it
-// so simple simple, swap out thet stuff for our client code
-// then clean up the display stuff and... i think the close impl is one line?
-//
-// ugh i need to start thinking about testing too
-// the client has no test but we have a good amount here, that tests the functions
-// doesnt test the external interface but uhhh save that for later lol
-// what do i want to test?
-// * setting a close authority allows mint to be closed
-// * close auth can be reassigned and close mint still works
-// * close mint without a close authority fails
-// * close authority cannot be set if it hasnt been
-// the latter two may not matter because the program itself should enforce (and have tests for it)
 #[allow(clippy::too_many_arguments)]
 async fn command_authorize(
     config: &Config<'_>,
@@ -587,7 +559,6 @@ async fn command_authorize(
     force_authorize: bool,
     bulk_signers: BulkSigners,
 ) -> CommandResult {
-    // XXX i can get mint address out of the giant branch shit below but maybe doesnt matter
     let token = token_client_from_config(config, &Pubkey::default());
 
     let auth_str = match authority_type {

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -3154,7 +3154,9 @@ async fn process_command<'a>(
                 .unwrap();
             let (close_authority_signer, close_authority) =
                 config.signer_or_default(arg_matches, "close_authority", &mut wallet_manager);
-            bulk_signers.push(close_authority_signer);
+            if !bulk_signers.contains(&close_authority_signer) {
+                bulk_signers.push(close_authority_signer);
+            }
             let recipient = config.pubkey_or_default(arg_matches, "recipient", &mut wallet_manager);
 
             command_close_mint(config, token, close_authority, recipient, bulk_signers).await

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -1460,7 +1460,7 @@ async fn command_close(
     }
 
     let res = token
-        .close_account(&account, &close_authority, &recipient, &bulk_signers)
+        .close_account(&account, &recipient, &close_authority, &bulk_signers)
         .await?;
 
     let tx_return = finish_tx(config, &res, false).await?;
@@ -1487,6 +1487,9 @@ async fn command_close(
 //
 // alright cool it does in fact go through close account, this is easy
 // first step make command_close go through the client
+//
+// done. i needed to refactor some shit but close_account now handles native recipient and multisig
+// so close_mint is easy. i just need different sanity checks and then the close_account call
 async fn command_close_mint(config: &Config<'_>) -> CommandResult {
     Ok("".to_string())
 }

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -781,9 +781,9 @@ where
     ) -> TokenResult<T::Output> {
         let signing_pubkeys = signing_keypairs.pubkeys();
         let multisig = if signing_pubkeys == &[*authority] {
-            signing_pubkeys.iter().collect::<Vec<_>>()
-        } else {
             vec![]
+        } else {
+            signing_pubkeys.iter().collect::<Vec<_>>()
         };
 
         let mut instructions = vec![instruction::close_account(

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -546,9 +546,9 @@ where
     ) -> TokenResult<T::Output> {
         let signing_pubkeys = signing_keypairs.pubkeys();
         let multisig = if signing_pubkeys == &[*authority] {
-            signing_pubkeys.iter().collect::<Vec<_>>()
-        } else {
             vec![]
+        } else {
+            signing_pubkeys.iter().collect::<Vec<_>>()
         };
 
         self.process_ixs(

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -545,7 +545,7 @@ where
         signing_keypairs: &S,
     ) -> TokenResult<T::Output> {
         let signing_pubkeys = signing_keypairs.pubkeys();
-        let multisig = if signing_pubkeys == [*authority] {
+        let multisig_signing_pubkeys = if signing_pubkeys == [*authority] {
             vec![]
         } else {
             signing_pubkeys.iter().collect::<Vec<_>>()
@@ -558,7 +558,7 @@ where
                 new_authority,
                 authority_type,
                 authority,
-                &multisig,
+                &multisig_signing_pubkeys,
             )?],
             signing_keypairs,
         )
@@ -780,7 +780,7 @@ where
         signing_keypairs: &S,
     ) -> TokenResult<T::Output> {
         let signing_pubkeys = signing_keypairs.pubkeys();
-        let multisig = if signing_pubkeys == [*authority] {
+        let multisig_signing_pubkeys = if signing_pubkeys == [*authority] {
             vec![]
         } else {
             signing_pubkeys.iter().collect::<Vec<_>>()
@@ -791,7 +791,7 @@ where
             account,
             destination,
             authority,
-            &multisig,
+            &multisig_signing_pubkeys,
         )?];
 
         if let Ok(Some(destination_account)) = self.client.get_account(*destination).await {

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -536,26 +536,26 @@ where
     }
 
     /// Assign a new authority to the account.
-    pub async fn set_authority<S: Signer>(
+    pub async fn set_authority<S: Signers>(
         &self,
         account: &Pubkey,
+        authority: &Pubkey,
         new_authority: Option<&Pubkey>,
         authority_type: instruction::AuthorityType,
-        owner: &S,
-    ) -> TokenResult<()> {
+        signing_keypairs: &S,
+    ) -> TokenResult<T::Output> {
         self.process_ixs(
             &[instruction::set_authority(
                 &self.program_id,
                 account,
                 new_authority,
                 authority_type,
-                &owner.pubkey(),
+                authority,
                 &[],
             )?],
-            &[owner],
+            signing_keypairs,
         )
         .await
-        .map(|_| ())
     }
 
     /// Mint new tokens

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -545,7 +545,7 @@ where
         signing_keypairs: &S,
     ) -> TokenResult<T::Output> {
         let signing_pubkeys = signing_keypairs.pubkeys();
-        let multisig = if signing_pubkeys == &[*authority] {
+        let multisig = if signing_pubkeys == [*authority] {
             vec![]
         } else {
             signing_pubkeys.iter().collect::<Vec<_>>()
@@ -780,7 +780,7 @@ where
         signing_keypairs: &S,
     ) -> TokenResult<T::Output> {
         let signing_pubkeys = signing_keypairs.pubkeys();
-        let multisig = if signing_pubkeys == &[*authority] {
+        let multisig = if signing_pubkeys == [*authority] {
             vec![]
         } else {
             signing_pubkeys.iter().collect::<Vec<_>>()
@@ -799,7 +799,7 @@ where
                 StateWithExtensionsOwned::<Account>::unpack(destination_account.data)
             {
                 if destination_obj.base.is_native() {
-                    instructions.push(instruction::sync_native(&self.program_id, &destination)?);
+                    instructions.push(instruction::sync_native(&self.program_id, destination)?);
                 }
             }
         }

--- a/token/client/tests/program-test.rs
+++ b/token/client/tests/program-test.rs
@@ -165,9 +165,10 @@ async fn set_authority() {
     token
         .set_authority(
             token.get_address(),
+            &mint_authority.pubkey(),
             None,
             instruction::AuthorityType::MintTokens,
-            &mint_authority,
+            &[&mint_authority],
         )
         .await
         .expect("failed to set authority");
@@ -188,9 +189,10 @@ async fn set_authority() {
     token
         .set_authority(
             &alice_vault,
+            &alice.pubkey(),
             Some(&bob.pubkey()),
             instruction::AuthorityType::AccountOwner,
-            &alice,
+            &[&alice],
         )
         .await
         .expect("failed to set_authority");

--- a/token/program-2022-test/tests/burn.rs
+++ b/token/program-2022-test/tests/burn.rs
@@ -188,7 +188,8 @@ async fn run_burn_and_close_system_or_incinerator(context: TestContext, non_owne
         .close_account(
             &non_owner_account,
             &solana_program::incinerator::id(),
-            &carlos,
+            &carlos.pubkey(),
+            &[&carlos],
         )
         .await
         .unwrap_err();
@@ -210,7 +211,12 @@ async fn run_burn_and_close_system_or_incinerator(context: TestContext, non_owne
 
     // closing fails if destination is not the incinerator
     let error = token
-        .close_account(&non_owner_account, &carlos.pubkey(), &carlos)
+        .close_account(
+            &non_owner_account,
+            &carlos.pubkey(),
+            &carlos.pubkey(),
+            &[&carlos],
+        )
         .await
         .unwrap_err();
     assert_eq!(
@@ -224,7 +230,8 @@ async fn run_burn_and_close_system_or_incinerator(context: TestContext, non_owne
         .close_account(
             &non_owner_account,
             &solana_program::system_program::id(),
-            &carlos,
+            &carlos.pubkey(),
+            &[&carlos],
         )
         .await
         .unwrap_err();
@@ -241,7 +248,8 @@ async fn run_burn_and_close_system_or_incinerator(context: TestContext, non_owne
         .close_account(
             &non_owner_account,
             &solana_program::incinerator::id(),
-            &carlos,
+            &carlos.pubkey(),
+            &[&carlos],
         )
         .await
         .unwrap();

--- a/token/program-2022-test/tests/default_account_state.rs
+++ b/token/program-2022-test/tests/default_account_state.rs
@@ -234,9 +234,10 @@ async fn end_to_end_default_account_state() {
     token
         .set_authority(
             token.get_address(),
+            &freeze_authority.pubkey(),
             Some(&new_authority.pubkey()),
             AuthorityType::FreezeAccount,
-            &freeze_authority,
+            &[&freeze_authority],
         )
         .await
         .unwrap();
@@ -269,9 +270,10 @@ async fn end_to_end_default_account_state() {
     token
         .set_authority(
             token.get_address(),
+            &new_authority.pubkey(),
             None,
             AuthorityType::FreezeAccount,
-            &new_authority,
+            &[&new_authority],
         )
         .await
         .unwrap();

--- a/token/program-2022-test/tests/interest_bearing_mint.rs
+++ b/token/program-2022-test/tests/interest_bearing_mint.rs
@@ -165,9 +165,10 @@ async fn set_authority() {
     token
         .set_authority(
             token.get_address(),
+            &rate_authority.pubkey(),
             Some(&new_rate_authority.pubkey()),
             AuthorityType::InterestRate,
-            &rate_authority,
+            &[&rate_authority],
         )
         .await
         .unwrap();
@@ -199,9 +200,10 @@ async fn set_authority() {
     token
         .set_authority(
             token.get_address(),
+            &new_rate_authority.pubkey(),
             None,
             AuthorityType::InterestRate,
-            &new_rate_authority,
+            &[&new_rate_authority],
         )
         .await
         .unwrap();

--- a/token/program-2022-test/tests/mint_close_authority.rs
+++ b/token/program-2022-test/tests/mint_close_authority.rs
@@ -66,9 +66,10 @@ async fn set_authority() {
     let err = token
         .set_authority(
             token.get_address(),
+            &wrong.pubkey(),
             Some(&new_authority.pubkey()),
             instruction::AuthorityType::CloseMint,
-            &wrong,
+            &[&wrong],
         )
         .await
         .unwrap_err();
@@ -86,9 +87,10 @@ async fn set_authority() {
     token
         .set_authority(
             token.get_address(),
+            &close_authority.pubkey(),
             Some(&new_authority.pubkey()),
             instruction::AuthorityType::CloseMint,
-            &close_authority,
+            &[&close_authority],
         )
         .await
         .unwrap();
@@ -103,9 +105,10 @@ async fn set_authority() {
     token
         .set_authority(
             token.get_address(),
+            &new_authority.pubkey(),
             None,
             instruction::AuthorityType::CloseMint,
-            &new_authority,
+            &[&new_authority],
         )
         .await
         .unwrap();
@@ -117,9 +120,10 @@ async fn set_authority() {
     let err = token
         .set_authority(
             token.get_address(),
+            &new_authority.pubkey(),
             Some(&close_authority.pubkey()),
             instruction::AuthorityType::CloseMint,
-            &new_authority,
+            &[&new_authority],
         )
         .await
         .unwrap_err();
@@ -186,9 +190,10 @@ async fn fail_without_extension() {
     let err = token
         .set_authority(
             token.get_address(),
+            &mint_authority.pubkey(),
             Some(&close_authority),
             instruction::AuthorityType::CloseMint,
-            &mint_authority,
+            &[&mint_authority],
         )
         .await
         .unwrap_err();

--- a/token/program-2022-test/tests/mint_close_authority.rs
+++ b/token/program-2022-test/tests/mint_close_authority.rs
@@ -140,7 +140,12 @@ async fn set_authority() {
     // fail close
     let destination = Pubkey::new_unique();
     let err = token
-        .close_account(token.get_address(), &destination, &new_authority)
+        .close_account(
+            token.get_address(),
+            &destination,
+            &new_authority.pubkey(),
+            &[&new_authority],
+        )
         .await
         .unwrap_err();
     assert_eq!(
@@ -168,7 +173,12 @@ async fn success_close() {
 
     let destination = Pubkey::new_unique();
     token
-        .close_account(token.get_address(), &destination, &close_authority)
+        .close_account(
+            token.get_address(),
+            &destination,
+            &close_authority.pubkey(),
+            &[&close_authority],
+        )
         .await
         .unwrap();
     let destination = token.get_account(&destination).await.unwrap();
@@ -207,7 +217,12 @@ async fn fail_without_extension() {
     // fail close
     let destination = Pubkey::new_unique();
     let err = token
-        .close_account(token.get_address(), &destination, &mint_authority)
+        .close_account(
+            token.get_address(),
+            &destination,
+            &mint_authority.pubkey(),
+            &[&mint_authority],
+        )
         .await
         .unwrap_err();
     assert_eq!(
@@ -246,7 +261,12 @@ async fn fail_close_with_supply() {
     // fail close
     let destination = Pubkey::new_unique();
     let err = token
-        .close_account(token.get_address(), &destination, &close_authority)
+        .close_account(
+            token.get_address(),
+            &destination,
+            &close_authority.pubkey(),
+            &[&close_authority],
+        )
         .await
         .unwrap_err();
     assert_eq!(

--- a/token/program-2022-test/tests/transfer_fee.rs
+++ b/token/program-2022-test/tests/transfer_fee.rs
@@ -1628,7 +1628,7 @@ async fn fail_close_with_withheld() {
 
     // fail to close
     let error = token
-        .close_account(&account, &Pubkey::new_unique(), &alice)
+        .close_account(&account, &Pubkey::new_unique(), &alice.pubkey(), &[&alice])
         .await
         .unwrap_err();
     assert_eq!(
@@ -1649,7 +1649,7 @@ async fn fail_close_with_withheld() {
 
     // successfully close
     token
-        .close_account(&account, &Pubkey::new_unique(), &alice)
+        .close_account(&account, &Pubkey::new_unique(), &alice.pubkey(), &[&alice])
         .await
         .unwrap();
 }

--- a/token/program-2022-test/tests/transfer_fee.rs
+++ b/token/program-2022-test/tests/transfer_fee.rs
@@ -502,9 +502,10 @@ async fn set_transfer_fee_config_authority() {
     let err = token
         .set_authority(
             token.get_address(),
+            &wrong.pubkey(),
             Some(&new_authority.pubkey()),
             instruction::AuthorityType::TransferFeeConfig,
-            &wrong,
+            &[&wrong],
         )
         .await
         .unwrap_err();
@@ -522,9 +523,10 @@ async fn set_transfer_fee_config_authority() {
     token
         .set_authority(
             token.get_address(),
+            &transfer_fee_config_authority.pubkey(),
             Some(&new_authority.pubkey()),
             instruction::AuthorityType::TransferFeeConfig,
-            &transfer_fee_config_authority,
+            &[&transfer_fee_config_authority],
         )
         .await
         .unwrap();
@@ -564,9 +566,10 @@ async fn set_transfer_fee_config_authority() {
     token
         .set_authority(
             token.get_address(),
+            &new_authority.pubkey(),
             None,
             instruction::AuthorityType::TransferFeeConfig,
-            &new_authority,
+            &[&new_authority],
         )
         .await
         .unwrap();
@@ -581,9 +584,10 @@ async fn set_transfer_fee_config_authority() {
     let err = token
         .set_authority(
             token.get_address(),
+            &new_authority.pubkey(),
             Some(&transfer_fee_config_authority.pubkey()),
             instruction::AuthorityType::TransferFeeConfig,
-            &new_authority,
+            &[&new_authority],
         )
         .await
         .unwrap_err();
@@ -642,9 +646,10 @@ async fn set_withdraw_withheld_authority() {
     let err = token
         .set_authority(
             token.get_address(),
+            &wrong.pubkey(),
             Some(&new_authority.pubkey()),
             instruction::AuthorityType::WithheldWithdraw,
-            &wrong,
+            &[&wrong],
         )
         .await
         .unwrap_err();
@@ -662,9 +667,10 @@ async fn set_withdraw_withheld_authority() {
     token
         .set_authority(
             token.get_address(),
+            &withdraw_withheld_authority.pubkey(),
             Some(&new_authority.pubkey()),
             instruction::AuthorityType::WithheldWithdraw,
-            &withdraw_withheld_authority,
+            &[&withdraw_withheld_authority],
         )
         .await
         .unwrap();
@@ -703,9 +709,10 @@ async fn set_withdraw_withheld_authority() {
     token
         .set_authority(
             token.get_address(),
+            &new_authority.pubkey(),
             None,
             instruction::AuthorityType::WithheldWithdraw,
-            &new_authority,
+            &[&new_authority],
         )
         .await
         .unwrap();
@@ -720,9 +727,10 @@ async fn set_withdraw_withheld_authority() {
     let err = token
         .set_authority(
             token.get_address(),
+            &new_authority.pubkey(),
             Some(&withdraw_withheld_authority.pubkey()),
             instruction::AuthorityType::WithheldWithdraw,
-            &new_authority,
+            &[&new_authority],
         )
         .await
         .unwrap_err();
@@ -1409,9 +1417,10 @@ async fn withdraw_withheld_tokens_from_mint() {
     token
         .set_authority(
             token.get_address(),
+            &withdraw_withheld_authority.pubkey(),
             None,
             instruction::AuthorityType::WithheldWithdraw,
-            &withdraw_withheld_authority,
+            &[&withdraw_withheld_authority],
         )
         .await
         .unwrap();


### PR DESCRIPTION
* ~add `--enable-close` flag to `create-token` that sets up a close authority~
* ~implement `close-mint` to close a mint that has a close authority~
* ~support `close-mint` in `authorize` to change a mint close authority~

~this needs to be rebased after #3469 lands~
~this is now based on the quite erroneously named `close-mint` branch so a rebase to master is trivial~
this is based on master

closes #3403 