### PR TITLE
token-swap: Migrate to `transfer_checked`

### DIFF
--- a/docs/src/token-2022/onchain.md
+++ b/docs/src/token-2022/onchain.md
@@ -474,8 +474,147 @@ It's tedious, but at this point, we have updated our program to use both Token
 and Token-2022 simultaneously. Congratulations! You're ready to be part of the
 next stage of DeFi on Solana.
 
-## Part III: Support Specific Extensions
+## Part III: Support All Extensions
 
-### Update from `transfer` to `transfer_checked`
+It seems like our program is working perfectly and that it won't have any issues
+processing Token-2022 mints.
 
-### Take fee into account when calculating slippage
+Unfortunately, there's one more bit of work required for full compatibility in
+token-swap. Since the program is using `transfer` instead of `transfer_checked`,
+it will fail for certain mints.
+
+We must upgrade to using `transfer_checked` if we want to support all extensions
+in Token-2022. As always, let's start by making our tests fail.
+
+### Step 1: Add transfer fee extension to Token-2022 tests
+
+The Token-2022 tests currently initialize the `MintCloseAuthority` extension.
+Let's add the `TransferFeeConfig` extension to the mint, and the `TransferFeeAmount`
+extension to the token accounts.
+
+Instead of:
+
+```rust
+let mint_space = ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]);
+let account_space = ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]);
+```
+
+We'll do:
+
+```rust
+let mint_space = ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority, ExtensionType::TransferFeeConfig]);
+let account_space = ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner, ExtensionType::TransferFeeAmount]);
+```
+
+And during initialization of the mint, we'll add in the instruction to initialize
+the transfer fee config to the initialization transaction:
+
+```rust
+let rate_authority = Keypair::new();
+let withdraw_authority = Keypair::new();
+
+let instruction = spl_token_2022::extension::transfer_fee::instruction::initialize_transfer_fee_config(
+    program_id, &mint_key, rate_authority.pubkey(), withdraw_authority.pubkey(), 0, 0
+).unwrap();
+```
+
+With this step, some of the Token-2022 test variants fail with: "Mint required 
+for this account to transfer tokens, use `transfer_checked` or 
+`transfer_checked_with_fee`".
+
+### Step 2: Add mints to instructions that use `transfer`
+
+The biggest difference between `transfer` and `transfer_checked` is the presence
+of the mint for the tokens. First, we must provide the mint account for every
+instruction that uses `transfer`.
+
+For example, the swap instruction becomes:
+
+```rust
+///   Swap the tokens in the pool.
+///
+///   0. `[]` Token-swap
+///   1. `[]` swap authority
+///   2. `[]` user transfer authority
+///   3. `[writable]` token_(A|B) SOURCE Account, amount is transferable by user transfer authority,
+///   4. `[writable]` token_(A|B) Base Account to swap INTO.  Must be the SOURCE token.
+///   5. `[writable]` token_(A|B) Base Account to swap FROM.  Must be the DESTINATION token.
+///   6. `[writable]` token_(A|B) DESTINATION Account assigned to USER as the owner.
+///   7. `[writable]` Pool token mint, to generate trading fees
+///   8. `[writable]` Fee account, to receive trading fees
+///   9. `[]` Token (A|B) SOURCE mint
+///   10. `[]` Token (A|B) DESTINATION mint
+///   11. `[]` Token (A|B) SOURCE program id
+///   12. `[]` Token (A|B) DESTINATION program id
+///   13. `[]` Pool Token program id
+///   14. `[optional, writable]` Host fee account to receive additional trading fees
+Swap(...),
+```
+
+Note the addition of `Token (A|B) SOURCE mint` and `Token (A|B) DESTINATION mint`.
+The pool token mint is already included, so we're safe there.
+
+Next, in the processor code, we'll extract these additional accounts, but we
+won't use them yet.
+
+For swap, the beginning becomes:
+
+```rust
+let account_info_iter = &mut accounts.iter();
+let swap_info = next_account_info(account_info_iter)?;
+let authority_info = next_account_info(account_info_iter)?;
+let user_transfer_authority_info = next_account_info(account_info_iter)?;
+let source_info = next_account_info(account_info_iter)?;
+let swap_source_info = next_account_info(account_info_iter)?;
+let swap_destination_info = next_account_info(account_info_iter)?;
+let destination_info = next_account_info(account_info_iter)?;
+let pool_mint_info = next_account_info(account_info_iter)?;
+let pool_fee_account_info = next_account_info(account_info_iter)?;
+let source_token_mint_info = next_account_info(account_info_iter)?;
+let destination_token_mint_info = next_account_info(account_info_iter)?;
+let source_token_program_info = next_account_info(account_info_iter)?;
+let destination_token_program_info = next_account_info(account_info_iter)?;
+let pool_token_program_info = next_account_info(account_info_iter)?;
+```
+
+Note the addition of `source_token_mint_info` and `destination_token_mint_info`.
+
+We'll go through every instruction that uses `transfer`, which for token-swap,
+includes `swap`, `deposit_all_token_types`, `withdraw_all_token_types`,
+`deposit_single_token_type_exact_amount_in`, and
+`withdraw_single_token_type_exact_amount_out`.
+
+By the end of this, some of the Token-2022 tests still fail, but the Token
+tests all pass.
+
+### Step 3: Change `transfer` to `transfer_checked` instruction
+
+Everything's in place to use `transfer_checked`, so the next step will thankfully
+be quite simple and get all of our tests to pass.
+
+Where we normally use `spl_token_2022::instruction::transfer`, we'll instead use
+`spl_token_2022::instruction::transfer_checked`, also providing the mint account
+info and decimals.
+
+For example, we can do:
+
+```rust
+let decimals = StateWithExtensions::<Mint>::unpack(&mint.data.borrow()).map(|m| m.base)?.decimals;
+let ix = spl_token_2022::instruction::transfer_checked(
+  token_program.key,
+  source.key,
+  mint.key,
+  destination.key,
+  authority.key,
+  &[],
+  amount,
+  decimals,
+)?;
+invoke(
+  &ix,
+  &[source, mint, destination, authority, token_program],
+)
+```
+
+After this step, all of your tests should pass once again, so congratulations
+again!

--- a/token-swap/js/src/index.ts
+++ b/token-swap/js/src/index.ts
@@ -455,6 +455,8 @@ export class TokenSwap {
    * @param poolSource Pool's source token account
    * @param poolDestination Pool's destination token account
    * @param userDestination User's destination token account
+   * @param sourceMint Mint for the source token
+   * @param destinationMint Mint for the destination token
    * @param sourceTokenProgramId Program id for the source token
    * @param destinationTokenProgramId Program id for the destination token
    * @param hostFeeAccount Host account to gather fees
@@ -467,6 +469,8 @@ export class TokenSwap {
     poolSource: PublicKey,
     poolDestination: PublicKey,
     userDestination: PublicKey,
+    sourceMint: PublicKey,
+    destinationMint: PublicKey,
     sourceTokenProgramId: PublicKey,
     destinationTokenProgramId: PublicKey,
     hostFeeAccount: PublicKey | null,
@@ -489,6 +493,8 @@ export class TokenSwap {
           this.poolToken,
           this.feeAccount,
           hostFeeAccount,
+          sourceMint,
+          destinationMint,
           this.swapProgramId,
           sourceTokenProgramId,
           destinationTokenProgramId,
@@ -513,6 +519,8 @@ export class TokenSwap {
     poolMint: PublicKey,
     feeAccount: PublicKey,
     hostFeeAccount: PublicKey | null,
+    sourceMint: PublicKey,
+    destinationMint: PublicKey,
     swapProgramId: PublicKey,
     sourceTokenProgramId: PublicKey,
     destinationTokenProgramId: PublicKey,
@@ -546,6 +554,8 @@ export class TokenSwap {
       {pubkey: userDestination, isSigner: false, isWritable: true},
       {pubkey: poolMint, isSigner: false, isWritable: true},
       {pubkey: feeAccount, isSigner: false, isWritable: true},
+      {pubkey: sourceMint, isSigner: false, isWritable: false},
+      {pubkey: destinationMint, isSigner: false, isWritable: false},
       {pubkey: sourceTokenProgramId, isSigner: false, isWritable: false},
       {pubkey: destinationTokenProgramId, isSigner: false, isWritable: false},
       {pubkey: poolTokenProgramId, isSigner: false, isWritable: false},
@@ -597,6 +607,8 @@ export class TokenSwap {
           this.tokenAccountB,
           this.poolToken,
           poolAccount,
+          this.mintA,
+          this.mintB,
           this.swapProgramId,
           tokenProgramIdA,
           tokenProgramIdB,
@@ -621,6 +633,8 @@ export class TokenSwap {
     intoB: PublicKey,
     poolToken: PublicKey,
     poolAccount: PublicKey,
+    mintA: PublicKey,
+    mintB: PublicKey,
     swapProgramId: PublicKey,
     tokenProgramIdA: PublicKey,
     tokenProgramIdB: PublicKey,
@@ -657,6 +671,8 @@ export class TokenSwap {
       {pubkey: intoB, isSigner: false, isWritable: true},
       {pubkey: poolToken, isSigner: false, isWritable: true},
       {pubkey: poolAccount, isSigner: false, isWritable: true},
+      {pubkey: mintA, isSigner: false, isWritable: false},
+      {pubkey: mintB, isSigner: false, isWritable: false},
       {pubkey: tokenProgramIdA, isSigner: false, isWritable: false},
       {pubkey: tokenProgramIdB, isSigner: false, isWritable: false},
       {pubkey: poolTokenProgramId, isSigner: false, isWritable: false},
@@ -707,6 +723,8 @@ export class TokenSwap {
           this.tokenAccountB,
           userAccountA,
           userAccountB,
+          this.mintA,
+          this.mintB,
           this.swapProgramId,
           this.poolTokenProgramId,
           tokenProgramIdA,
@@ -732,6 +750,8 @@ export class TokenSwap {
     fromB: PublicKey,
     userAccountA: PublicKey,
     userAccountB: PublicKey,
+    mintA: PublicKey,
+    mintB: PublicKey,
     swapProgramId: PublicKey,
     poolTokenProgramId: PublicKey,
     tokenProgramIdA: PublicKey,
@@ -769,6 +789,8 @@ export class TokenSwap {
       {pubkey: userAccountA, isSigner: false, isWritable: true},
       {pubkey: userAccountB, isSigner: false, isWritable: true},
       {pubkey: feeAccount, isSigner: false, isWritable: true},
+      {pubkey: mintA, isSigner: false, isWritable: false},
+      {pubkey: mintB, isSigner: false, isWritable: false},
       {pubkey: poolTokenProgramId, isSigner: false, isWritable: false},
       {pubkey: tokenProgramIdA, isSigner: false, isWritable: false},
       {pubkey: tokenProgramIdB, isSigner: false, isWritable: false},
@@ -784,6 +806,7 @@ export class TokenSwap {
    * Deposit one side of tokens into the pool
    * @param userAccount User account to deposit token A or B
    * @param poolAccount User account to receive pool tokens
+   * @param sourceMint Mint for the source token
    * @param sourceTokenProgramId Program id for the source token
    * @param userTransferAuthority Account delegated to transfer user's tokens
    * @param sourceTokenAmount The amount of token A or B to deposit
@@ -792,6 +815,7 @@ export class TokenSwap {
   async depositSingleTokenTypeExactAmountIn(
     userAccount: PublicKey,
     poolAccount: PublicKey,
+    sourceMint: PublicKey,
     sourceTokenProgramId: PublicKey,
     userTransferAuthority: Account,
     sourceTokenAmount: number | Numberu64,
@@ -810,6 +834,7 @@ export class TokenSwap {
           this.tokenAccountB,
           this.poolToken,
           poolAccount,
+          sourceMint,
           this.swapProgramId,
           sourceTokenProgramId,
           this.poolTokenProgramId,
@@ -831,6 +856,7 @@ export class TokenSwap {
     intoB: PublicKey,
     poolToken: PublicKey,
     poolAccount: PublicKey,
+    sourceMint: PublicKey,
     swapProgramId: PublicKey,
     sourceTokenProgramId: PublicKey,
     poolTokenProgramId: PublicKey,
@@ -864,6 +890,7 @@ export class TokenSwap {
       {pubkey: intoB, isSigner: false, isWritable: true},
       {pubkey: poolToken, isSigner: false, isWritable: true},
       {pubkey: poolAccount, isSigner: false, isWritable: true},
+      {pubkey: sourceMint, isSigner: false, isWritable: false},
       {pubkey: sourceTokenProgramId, isSigner: false, isWritable: false},
       {pubkey: poolTokenProgramId, isSigner: false, isWritable: false},
     ];
@@ -879,6 +906,7 @@ export class TokenSwap {
    *
    * @param userAccount User account to receive token A or B
    * @param poolAccount User account to burn pool token
+   * @param destinationMint Mint for the destination token
    * @param destinationTokenProgramId Program id for the destination token
    * @param userTransferAuthority Account delegated to transfer user's tokens
    * @param destinationTokenAmount The amount of token A or B to withdraw
@@ -887,6 +915,7 @@ export class TokenSwap {
   async withdrawSingleTokenTypeExactAmountOut(
     userAccount: PublicKey,
     poolAccount: PublicKey,
+    destinationMint: PublicKey,
     destinationTokenProgramId: PublicKey,
     userTransferAuthority: Account,
     destinationTokenAmount: number | Numberu64,
@@ -906,6 +935,7 @@ export class TokenSwap {
           this.tokenAccountA,
           this.tokenAccountB,
           userAccount,
+          destinationMint,
           this.swapProgramId,
           this.poolTokenProgramId,
           destinationTokenProgramId,
@@ -928,6 +958,7 @@ export class TokenSwap {
     fromA: PublicKey,
     fromB: PublicKey,
     userAccount: PublicKey,
+    destinationMint: PublicKey,
     swapProgramId: PublicKey,
     poolTokenProgramId: PublicKey,
     destinationTokenProgramId: PublicKey,
@@ -964,6 +995,7 @@ export class TokenSwap {
       {pubkey: fromB, isSigner: false, isWritable: true},
       {pubkey: userAccount, isSigner: false, isWritable: true},
       {pubkey: feeAccount, isSigner: false, isWritable: true},
+      {pubkey: destinationMint, isSigner: false, isWritable: false},
       {pubkey: poolTokenProgramId, isSigner: false, isWritable: false},
       {pubkey: destinationTokenProgramId, isSigner: false, isWritable: false},
     ];

--- a/token-swap/js/test/token-swap-test.ts
+++ b/token-swap/js/test/token-swap-test.ts
@@ -414,6 +414,8 @@ export async function createAccountAndSwapAtomic(): Promise<void> {
       tokenSwap.poolToken,
       tokenSwap.feeAccount,
       null,
+      tokenSwap.mintA,
+      tokenSwap.mintB,
       tokenSwap.swapProgramId,
       TOKEN_PROGRAM_ID,
       TOKEN_PROGRAM_ID,
@@ -471,6 +473,8 @@ export async function swap(): Promise<void> {
     tokenAccountA,
     tokenAccountB,
     userAccountB,
+    tokenSwap.mintA,
+    tokenSwap.mintB,
     TOKEN_PROGRAM_ID,
     TOKEN_PROGRAM_ID,
     poolAccount,
@@ -574,6 +578,7 @@ export async function depositSingleTokenTypeExactAmountIn(): Promise<void> {
   await tokenSwap.depositSingleTokenTypeExactAmountIn(
     userAccountA,
     newAccountPool,
+    tokenSwap.mintA,
     TOKEN_PROGRAM_ID,
     userTransferAuthority,
     depositAmount,
@@ -592,6 +597,7 @@ export async function depositSingleTokenTypeExactAmountIn(): Promise<void> {
   await tokenSwap.depositSingleTokenTypeExactAmountIn(
     userAccountB,
     newAccountPool,
+    tokenSwap.mintB,
     TOKEN_PROGRAM_ID,
     userTransferAuthority,
     depositAmount,
@@ -666,6 +672,7 @@ export async function withdrawSingleTokenTypeExactAmountOut(): Promise<void> {
   await tokenSwap.withdrawSingleTokenTypeExactAmountOut(
     userAccountA,
     tokenAccountPool,
+    tokenSwap.mintA,
     TOKEN_PROGRAM_ID,
     userTransferAuthority,
     withdrawAmount,
@@ -686,6 +693,7 @@ export async function withdrawSingleTokenTypeExactAmountOut(): Promise<void> {
   await tokenSwap.withdrawSingleTokenTypeExactAmountOut(
     userAccountB,
     tokenAccountPool,
+    tokenSwap.mintB,
     TOKEN_PROGRAM_ID,
     userTransferAuthority,
     withdrawAmount,

--- a/token-swap/program/fuzz/src/instructions.rs
+++ b/token-swap/program/fuzz/src/instructions.rs
@@ -354,6 +354,7 @@ fn run_fuzz_instruction(
             let pool_account = pool_accounts.get_mut(&pool_token_id).unwrap();
             token_swap.deposit_single_token_type_exact_amount_in(
                 source_token_account,
+                trade_direction,
                 pool_account,
                 instruction,
             )
@@ -371,6 +372,7 @@ fn run_fuzz_instruction(
             let pool_account = pool_accounts.get_mut(&pool_token_id).unwrap();
             token_swap.withdraw_single_token_type_exact_amount_out(
                 pool_account,
+                trade_direction,
                 destination_token_account,
                 instruction,
             )


### PR DESCRIPTION
#### Problem

If people follow the on-chain program migration docs, they may get stuck if their program uses `transfer` instead of `transfer_checked` everywhere.

#### Solution

Provide docs and example for how to migrate to `transfer_checked`, using token-swap example once again.

There will be one more doc after this, for using specific extensions, and after that we'll be good from the on-chain side, I hope.