### PR TITLE
fix incorrect docstrings in stake pool client instruction libraries

### DIFF
--- a/stake-pool/js/src/instructions.ts
+++ b/stake-pool/js/src/instructions.ts
@@ -416,7 +416,7 @@ export class StakePoolInstruction {
   }
 
   /**
-   * Creates a transaction instruction to deposit SOL into a stake pool.
+   * Creates a transaction instruction to deposit a stake account into a stake pool.
    */
   static depositStake(params: DepositStakeParams): TransactionInstruction {
     const {
@@ -462,7 +462,7 @@ export class StakePoolInstruction {
   }
 
   /**
-   * Creates a transaction instruction to withdraw SOL from a stake pool.
+   * Creates a transaction instruction to deposit SOL into a stake pool.
    */
   static depositSol(params: DepositSolParams): TransactionInstruction {
     const {
@@ -510,7 +510,7 @@ export class StakePoolInstruction {
   }
 
   /**
-   * Creates a transaction instruction to withdraw SOL from a stake pool.
+   * Creates a transaction instruction to withdraw active stake from a stake pool.
    */
   static withdrawStake(params: WithdrawStakeParams): TransactionInstruction {
     const {

--- a/stake-pool/py/stake_pool/instructions.py
+++ b/stake-pool/py/stake_pool/instructions.py
@@ -674,7 +674,7 @@ def remove_validator_from_pool_with_vote(
 
 
 def deposit_stake(params: DepositStakeParams) -> TransactionInstruction:
-    """Creates a transaction instruction to deposit SOL into a stake pool."""
+    """Creates a transaction instruction to deposit a stake account into a stake pool."""
     keys = [
         AccountMeta(pubkey=params.stake_pool, is_signer=False, is_writable=True),
         AccountMeta(pubkey=params.validator_list, is_signer=False, is_writable=True),
@@ -705,7 +705,7 @@ def deposit_stake(params: DepositStakeParams) -> TransactionInstruction:
 
 
 def withdraw_stake(params: WithdrawStakeParams) -> TransactionInstruction:
-    """Creates a transaction instruction to withdraw SOL from a stake pool."""
+    """Creates a transaction instruction to withdraw active stake from a stake pool."""
     return TransactionInstruction(
         keys=[
             AccountMeta(pubkey=params.stake_pool, is_signer=False, is_writable=True),


### PR DESCRIPTION
the python and ts client stake pool instructions have some incorrect docstrings