### PR TITLE
Governance: Use mint authority to revoke membership tokens

### DIFF
--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -494,10 +494,10 @@ pub enum GovernanceInstruction {
     /// Note: If there are active votes for the TokenOwner then the vote weights won't be updated automatically
     ///
     ///  0. `[]` Realm account
-    ///  1. `[signer]`  Realm authority    
-    ///  2. `[writable]` Governing Token Holding account. PDA seeds: ['governance',realm, governing_token_mint]
-    ///  3. `[writable]` TokenOwnerRecord account. PDA seeds: ['governance',realm, governing_token_mint, governing_token_owner]
-    ///  4. `[writable]` GoverningTokenMint
+    ///  1. `[writable]` Governing Token Holding account. PDA seeds: ['governance',realm, governing_token_mint]
+    ///  2. `[writable]` TokenOwnerRecord account. PDA seeds: ['governance',realm, governing_token_mint, governing_token_owner]
+    ///  3. `[writable]` GoverningTokenMint
+    ///  4. `[signer]` GoverningTokenMint mint_authority
     ///  5. `[]` RealmConfig account. PDA seeds: ['realm-config', realm]
     ///  6. `[]` SPL Token program
     RevokeGoverningTokens {
@@ -1545,9 +1545,9 @@ pub fn revoke_governing_tokens(
     program_id: &Pubkey,
     // Accounts
     realm: &Pubkey,
-    realm_authority: &Pubkey,
     governing_token_owner: &Pubkey,
     governing_token_mint: &Pubkey,
+    governing_token_mint_authority: &Pubkey,
     // Args
     amount: u64,
 ) -> Instruction {
@@ -1565,10 +1565,10 @@ pub fn revoke_governing_tokens(
 
     let accounts = vec![
         AccountMeta::new_readonly(*realm, false),
-        AccountMeta::new_readonly(*realm_authority, true),
         AccountMeta::new(governing_token_holding_address, false),
         AccountMeta::new(token_owner_record_address, false),
         AccountMeta::new(*governing_token_mint, false),
+        AccountMeta::new_readonly(*governing_token_mint_authority, true),
         AccountMeta::new_readonly(realm_config_address, false),
         AccountMeta::new_readonly(spl_token::id(), false),
     ];

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -78,7 +78,7 @@ pub enum GovernanceInstruction {
     ///      Tokens will be transferred or minted to the Holding account
     ///  3. `[signer]` Governing Token Owner account
     ///  4. `[signer]` Governing Token Source account authority
-    ///      It should be owner for TokenAccount and mint_auhtority for MintAccount
+    ///      It should be owner for TokenAccount and mint_authority for MintAccount
     ///  5. `[writable]` TokenOwnerRecord account. PDA seeds: ['governance',realm, governing_token_mint, governing_token_owner]
     ///  6. `[signer]` Payer
     ///  7. `[]` System

--- a/governance/program/tests/process_revoke_governing_tokens.rs
+++ b/governance/program/tests/process_revoke_governing_tokens.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "test-bpf")]
+#![cfg(feature = "test-sbf")]
 
 use solana_program::pubkey::Pubkey;
 use solana_program_test::*;

--- a/governance/program/tests/process_revoke_governing_tokens.rs
+++ b/governance/program/tests/process_revoke_governing_tokens.rs
@@ -201,7 +201,7 @@ async fn test_revoke_council_tokens_with_invalid_mint_authority_error() {
         .await
         .unwrap();
 
-    // Try to use fake auhtority
+    // Try to use fake authority
     let mint_authority = Keypair::new();
 
     // Act
@@ -484,7 +484,7 @@ async fn test_revoke_council_tokens_with_community_mint_error() {
         .await
         .unwrap();
 
-    // Try to use mint and auhtority for Community to revoke Council token
+    // Try to use mint and authority for Community to revoke Council token
     let governing_token_mint = realm_cookie.account.community_mint.clone();
     let governing_token_mint_authority = clone_keypair(&realm_cookie.community_mint_authority);
     let governing_token_holding_address = get_governing_token_holding_address(
@@ -533,7 +533,7 @@ async fn test_revoke_council_tokens_with_not_matching_mint_and_authority_error()
         .await
         .unwrap();
 
-    // Try to use a valid mint and auhtority not matching the Council mint
+    // Try to use a valid mint and authority not matching the Council mint
     let governing_token_mint = realm_cookie.account.community_mint.clone();
     let governing_token_mint_authority = clone_keypair(&realm_cookie.community_mint_authority);
 

--- a/governance/program/tests/program_test/cookies.rs
+++ b/governance/program/tests/program_test/cookies.rs
@@ -36,7 +36,7 @@ pub struct RealmCookie {
 }
 
 impl RealmCookie {
-    pub fn get_mint_auhtority(&self, governing_token_mint: &Pubkey) -> &Keypair {
+    pub fn get_mint_authority(&self, governing_token_mint: &Pubkey) -> &Keypair {
         if *governing_token_mint == self.account.community_mint {
             &self.community_mint_authority
         } else if Some(*governing_token_mint) == self.account.config.council_mint {

--- a/governance/program/tests/program_test/cookies.rs
+++ b/governance/program/tests/program_test/cookies.rs
@@ -35,6 +35,18 @@ pub struct RealmCookie {
     pub realm_config: RealmConfigCookie,
 }
 
+impl RealmCookie {
+    pub fn get_mint_auhtority(&self, governing_token_mint: &Pubkey) -> &Keypair {
+        if *governing_token_mint == self.account.community_mint {
+            &self.community_mint_authority
+        } else if Some(*governing_token_mint) == self.account.config.council_mint {
+            &self.council_mint_authority.as_ref().unwrap()
+        } else {
+            panic!("Invalid governing_token_mint")
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct RealmConfigCookie {
     pub address: Pubkey,

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1303,18 +1303,20 @@ impl GovernanceProgramTest {
         instruction_override: F,
         signers_override: Option<&[&Keypair]>,
     ) -> Result<(), ProgramError> {
+        let governing_token_mint_auhtority = realm_cookie.get_mint_auhtority(governing_token_mint);
+
         let mut revoke_governing_tokens_ix = revoke_governing_tokens(
             &self.program_id,
             &realm_cookie.address,
-            &realm_cookie.account.authority.unwrap(),
             &token_owner_record_cookie.account.governing_token_owner,
             governing_token_mint,
+            &governing_token_mint_auhtority.pubkey(),
             amount,
         );
 
         instruction_override(&mut revoke_governing_tokens_ix);
 
-        let default_signers = &[realm_cookie.realm_authority.as_ref().unwrap()];
+        let default_signers = &[governing_token_mint_auhtority];
         let signers = signers_override.unwrap_or(default_signers);
 
         self.bench

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1303,20 +1303,20 @@ impl GovernanceProgramTest {
         instruction_override: F,
         signers_override: Option<&[&Keypair]>,
     ) -> Result<(), ProgramError> {
-        let governing_token_mint_auhtority = realm_cookie.get_mint_auhtority(governing_token_mint);
+        let governing_token_mint_authority = realm_cookie.get_mint_authority(governing_token_mint);
 
         let mut revoke_governing_tokens_ix = revoke_governing_tokens(
             &self.program_id,
             &realm_cookie.address,
             &token_owner_record_cookie.account.governing_token_owner,
             governing_token_mint,
-            &governing_token_mint_auhtority.pubkey(),
+            &governing_token_mint_authority.pubkey(),
             amount,
         );
 
         instruction_override(&mut revoke_governing_tokens_ix);
 
-        let default_signers = &[governing_token_mint_auhtority];
+        let default_signers = &[governing_token_mint_authority];
         let signers = signers_override.unwrap_or(default_signers);
 
         self.bench


### PR DESCRIPTION
#### Summary

Use `governing_token_mint_authority` instead of `realm_authority` to authorise `Membership` tokens revocation.

The `mint_authority` can mint the `Membership` tokens and hence has ultimate power over the governance tokens because it could dilute any existing governance structure by minting more tokens. It makes then more sense to use the same authority to authorise revocation (burn) of those tokens instead of the `realm_authority` which doesn't have to be the same. 
