### PR TITLE
Governance: Do not tip on max vote weight when tipping Disabled

### DIFF
--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -599,16 +599,6 @@ impl ProposalV2 {
         let yes_vote_weight = yes_option.vote_weight;
         let deny_vote_weight = self.deny_vote_weight.unwrap();
 
-        if yes_vote_weight == max_voter_weight {
-            yes_option.vote_result = OptionVoteResult::Succeeded;
-            return Some(ProposalState::Succeeded);
-        }
-
-        if deny_vote_weight == max_voter_weight {
-            yes_option.vote_result = OptionVoteResult::Defeated;
-            return Some(ProposalState::Defeated);
-        }
-
         match vote_tipping {
             VoteTipping::Disabled => {}
             VoteTipping::Strict => {

--- a/governance/program/tests/process_cast_vote.rs
+++ b/governance/program/tests/process_cast_vote.rs
@@ -1397,7 +1397,7 @@ async fn test_cast_vote_with_disabled_tipping_and_max_no_votes() {
 }
 
 #[tokio::test]
-async fn test_cast_vote_with_strict_tipping_and_inflated_max_voter_weight_votes() {
+async fn test_cast_vote_with_strict_tipping_and_inflated_max_vote_weight() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 


### PR DESCRIPTION
#### Summary

When vote tipping is disabled the vote should not end early even if `max_voter_weight` worth of `vote_weight` have been cast.