### PR TITLE
Governance: Add council_vote_tipping

### DIFF
--- a/feature-proposal/cli/src/main.rs
+++ b/feature-proposal/cli/src/main.rs
@@ -358,12 +358,12 @@ fn process_propose(
         the proposal by first looking up their token account address:"
     );
     println!(
-        "    $ spl-token --owner ~/validator-keypair.json accounts {}",
+        "    $ spl-token accounts --owner ~/validator-keypair.json {}",
         mint_address
     );
     println!("and then submit their vote by running:");
     println!(
-        "    $ spl-token --owner ~/validator-keypair.json transfer <TOKEN_ACCOUNT_ADDRESS> ALL {}",
+        "    $ spl-token transfer --owner ~/validator-keypair.json <TOKEN_ACCOUNT_ADDRESS> ALL {}",
         acceptance_token_address
     );
     println!();

--- a/governance/chat/program/tests/program_test/mod.rs
+++ b/governance/chat/program/tests/program_test/mod.rs
@@ -191,9 +191,10 @@ impl GovernanceChatProgramTest {
             min_transaction_hold_up_time: 10,
             max_voting_time: 10,
             community_vote_threshold: VoteThreshold::YesVotePercentage(60),
-            vote_tipping: spl_governance::state::enums::VoteTipping::Strict,
+            community_vote_tipping: spl_governance::state::enums::VoteTipping::Strict,
             council_vote_threshold: VoteThreshold::YesVotePercentage(10),
             council_veto_vote_threshold: VoteThreshold::YesVotePercentage(50),
+            council_vote_tipping: spl_governance::state::enums::VoteTipping::Strict,
         };
 
         let token_owner_record_address = get_token_owner_record_address(

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -78,7 +78,7 @@ pub enum GovernanceInstruction {
     ///      Tokens will be transferred or minted to the Holding account
     ///  3. `[signer]` Governing Token Owner account
     ///  4. `[signer]` Governing Token Source account authority
-    ///      It should be owner for TokenAccount and mint_auhtority for MintAccount
+    ///      It should be owner for TokenAccount and mint_authority for MintAccount
     ///  5. `[writable]` TokenOwnerRecord account. PDA seeds: ['governance',realm, governing_token_mint, governing_token_owner]
     ///  6. `[signer]` Payer
     ///  7. `[]` System
@@ -494,10 +494,10 @@ pub enum GovernanceInstruction {
     /// Note: If there are active votes for the TokenOwner then the vote weights won't be updated automatically
     ///
     ///  0. `[]` Realm account
-    ///  1. `[signer]`  Realm authority    
-    ///  2. `[writable]` Governing Token Holding account. PDA seeds: ['governance',realm, governing_token_mint]
-    ///  3. `[writable]` TokenOwnerRecord account. PDA seeds: ['governance',realm, governing_token_mint, governing_token_owner]
-    ///  4. `[writable]` GoverningTokenMint
+    ///  1. `[writable]` Governing Token Holding account. PDA seeds: ['governance',realm, governing_token_mint]
+    ///  2. `[writable]` TokenOwnerRecord account. PDA seeds: ['governance',realm, governing_token_mint, governing_token_owner]
+    ///  3. `[writable]` GoverningTokenMint
+    ///  4. `[signer]` GoverningTokenMint mint_authority
     ///  5. `[]` RealmConfig account. PDA seeds: ['realm-config', realm]
     ///  6. `[]` SPL Token program
     RevokeGoverningTokens {
@@ -1545,9 +1545,9 @@ pub fn revoke_governing_tokens(
     program_id: &Pubkey,
     // Accounts
     realm: &Pubkey,
-    realm_authority: &Pubkey,
     governing_token_owner: &Pubkey,
     governing_token_mint: &Pubkey,
+    governing_token_mint_authority: &Pubkey,
     // Args
     amount: u64,
 ) -> Instruction {
@@ -1565,10 +1565,10 @@ pub fn revoke_governing_tokens(
 
     let accounts = vec![
         AccountMeta::new_readonly(*realm, false),
-        AccountMeta::new_readonly(*realm_authority, true),
         AccountMeta::new(governing_token_holding_address, false),
         AccountMeta::new(token_owner_record_address, false),
         AccountMeta::new(*governing_token_mint, false),
+        AccountMeta::new_readonly(*governing_token_mint_authority, true),
         AccountMeta::new_readonly(realm_config_address, false),
         AccountMeta::new_readonly(spl_token::id(), false),
     ];

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -166,7 +166,7 @@ pub fn process_cast_vote(
 
     if proposal_data.try_tip_vote(
         max_voter_weight,
-        &governance_data.config.community_vote_tipping,
+        governance_data.get_vote_tipping(&realm_data, vote_governing_token_mint_info.key)?,
         clock.unix_timestamp,
         &vote_threshold,
         &vote_kind,

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -166,7 +166,7 @@ pub fn process_cast_vote(
 
     if proposal_data.try_tip_vote(
         max_voter_weight,
-        &governance_data.config.vote_tipping,
+        &governance_data.config.community_vote_tipping,
         clock.unix_timestamp,
         &vote_threshold,
         &vote_kind,

--- a/governance/program/src/processor/process_create_governance.rs
+++ b/governance/program/src/processor/process_create_governance.rs
@@ -57,7 +57,7 @@ pub fn process_create_governance(
         governed_account: *governed_account_info.key,
         config,
         proposals_count: 0,
-        reserved: [0; 6],
+        reserved: [0; 5],
         voting_proposal_count: 0,
         reserved_v2: [0; 128],
     };

--- a/governance/program/src/processor/process_create_mint_governance.rs
+++ b/governance/program/src/processor/process_create_mint_governance.rs
@@ -69,7 +69,7 @@ pub fn process_create_mint_governance(
         governed_account: *governed_mint_info.key,
         config,
         proposals_count: 0,
-        reserved: [0; 6],
+        reserved: [0; 5],
         voting_proposal_count: 0,
         reserved_v2: [0; 128],
     };

--- a/governance/program/src/processor/process_create_program_governance.rs
+++ b/governance/program/src/processor/process_create_program_governance.rs
@@ -69,7 +69,7 @@ pub fn process_create_program_governance(
         governed_account: *governed_program_info.key,
         config,
         proposals_count: 0,
-        reserved: [0; 6],
+        reserved: [0; 5],
         voting_proposal_count: 0,
         reserved_v2: [0; 128],
     };

--- a/governance/program/src/processor/process_create_token_governance.rs
+++ b/governance/program/src/processor/process_create_token_governance.rs
@@ -67,7 +67,7 @@ pub fn process_create_token_governance(
         governed_account: *governed_token_info.key,
         config,
         proposals_count: 0,
-        reserved: [0; 6],
+        reserved: [0; 5],
         voting_proposal_count: 0,
         reserved_v2: [0; 128],
     };

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -248,6 +248,23 @@ impl GovernanceV2 {
 
         Ok(vote_threshold.clone())
     }
+
+    /// Returns VoteTipping for the given governing_token_mint
+    pub fn get_vote_tipping(
+        &self,
+        realm_data: &RealmV2,
+        governing_token_mint: &Pubkey,
+    ) -> Result<&VoteTipping, ProgramError> {
+        let vote_tipping = if *governing_token_mint == realm_data.community_mint {
+            &self.config.community_vote_tipping
+        } else if Some(*governing_token_mint) == realm_data.config.council_mint {
+            &self.config.council_vote_tipping
+        } else {
+            return Err(GovernanceError::InvalidGoverningTokenMint.into());
+        };
+
+        Ok(vote_tipping)
+    }
 }
 
 /// Deserializes Governance account and checks owner program

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -36,8 +36,8 @@ pub struct GovernanceConfig {
     /// Time limit in seconds for proposal to be open for voting
     pub max_voting_time: u32,
 
-    /// Conditions under which a vote will complete early
-    pub vote_tipping: VoteTipping,
+    /// Conditions under which a Community vote will complete early
+    pub community_vote_tipping: VoteTipping,
 
     /// The type of the vote threshold used for council vote
     /// Note: In the current version only YesVotePercentage and Disabled thresholds are supported
@@ -53,6 +53,9 @@ pub struct GovernanceConfig {
     // Note: Community Veto vote is not supported in the current version
     // In order to use this threshold the space from GovernanceV2.reserved must be taken to expand GovernanceConfig size
     // pub community_veto_vote_threshold: VoteThreshold,
+    //
+    /// Conditions under which a Council vote will complete early
+    pub council_vote_tipping: VoteTipping,
 }
 
 /// Governance Account
@@ -82,7 +85,7 @@ pub struct GovernanceV2 {
     pub config: GovernanceConfig,
 
     /// Reserved space for future versions
-    pub reserved: [u8; 6],
+    pub reserved: [u8; 5],
 
     /// The number of proposals in voting state in the Governance
     pub voting_proposal_count: u16,
@@ -180,7 +183,7 @@ impl GovernanceV2 {
         } else if is_governance_v1_account_type(&self.account_type) {
             // V1 account can't be resized and we have to translate it back to the original format
 
-            // If reserved_v2 is used it must be individually asses for v1 backward compatibility impact
+            // If reserved_v2 is used it must be individually assesed for v1 backward compatibility impact
             if self.reserved_v2 != [0; 128] {
                 panic!("Extended data not supported by GovernanceV1")
             }
@@ -191,7 +194,7 @@ impl GovernanceV2 {
                 governed_account: self.governed_account,
                 proposals_count: self.proposals_count,
                 config: self.config,
-                reserved: self.reserved,
+                reserved: [0; 6],
                 voting_proposal_count: self.voting_proposal_count,
             };
 
@@ -269,7 +272,7 @@ pub fn get_governance_data(
             governed_account: governance_data_v1.governed_account,
             proposals_count: governance_data_v1.proposals_count,
             config: governance_data_v1.config,
-            reserved: governance_data_v1.reserved,
+            reserved: [0; 5],
             voting_proposal_count: governance_data_v1.voting_proposal_count,
 
             // Add the extra reserved_v2 padding
@@ -294,6 +297,10 @@ pub fn get_governance_data(
         // The assumption here is that council should have Veto vote enabled by default and equal to council_vote_threshold
         governance_data.config.council_veto_vote_threshold =
             governance_data.config.council_vote_threshold.clone();
+
+        // For legacy accounts default Council VoteTipping to the Community
+        governance_data.config.council_vote_tipping =
+            governance_data.config.community_vote_tipping.clone()
     }
 
     Ok(governance_data)
@@ -545,10 +552,11 @@ mod test {
             min_community_weight_to_create_proposal: 1,
             min_transaction_hold_up_time: 1,
             max_voting_time: 1,
-            vote_tipping: VoteTipping::Strict,
+            community_vote_tipping: VoteTipping::Strict,
             council_vote_threshold: VoteThreshold::YesVotePercentage(0),
             council_veto_vote_threshold: VoteThreshold::YesVotePercentage(1),
             min_council_weight_to_create_proposal: 1,
+            council_vote_tipping: VoteTipping::Strict,
         };
 
         // Act
@@ -568,10 +576,11 @@ mod test {
             min_community_weight_to_create_proposal: 1,
             min_transaction_hold_up_time: 1,
             max_voting_time: 1,
-            vote_tipping: VoteTipping::Strict,
+            community_vote_tipping: VoteTipping::Strict,
             council_vote_threshold: VoteThreshold::YesVotePercentage(1),
             council_veto_vote_threshold: VoteThreshold::YesVotePercentage(1),
             min_council_weight_to_create_proposal: 1,
+            council_vote_tipping: VoteTipping::Strict,
         };
 
         // Act
@@ -591,10 +600,11 @@ mod test {
             min_community_weight_to_create_proposal: 1,
             min_transaction_hold_up_time: 1,
             max_voting_time: 1,
-            vote_tipping: VoteTipping::Strict,
+            community_vote_tipping: VoteTipping::Strict,
             council_vote_threshold: VoteThreshold::Disabled,
             council_veto_vote_threshold: VoteThreshold::YesVotePercentage(1),
             min_council_weight_to_create_proposal: 1,
+            council_vote_tipping: VoteTipping::Strict,
         };
 
         // Act
@@ -614,10 +624,11 @@ mod test {
             min_community_weight_to_create_proposal: 1,
             min_transaction_hold_up_time: 1,
             max_voting_time: 1,
-            vote_tipping: VoteTipping::Strict,
+            community_vote_tipping: VoteTipping::Strict,
             council_vote_threshold: VoteThreshold::YesVotePercentage(1),
             council_veto_vote_threshold: VoteThreshold::YesVotePercentage(0),
             min_council_weight_to_create_proposal: 1,
+            council_vote_tipping: VoteTipping::Strict,
         };
 
         // Act

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -599,16 +599,6 @@ impl ProposalV2 {
         let yes_vote_weight = yes_option.vote_weight;
         let deny_vote_weight = self.deny_vote_weight.unwrap();
 
-        if yes_vote_weight == max_voter_weight {
-            yes_option.vote_result = OptionVoteResult::Succeeded;
-            return Some(ProposalState::Succeeded);
-        }
-
-        if deny_vote_weight == max_voter_weight {
-            yes_option.vote_result = OptionVoteResult::Defeated;
-            return Some(ProposalState::Defeated);
-        }
-
         match vote_tipping {
             VoteTipping::Disabled => {}
             VoteTipping::Strict => {

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -1174,9 +1174,10 @@ mod test {
             min_transaction_hold_up_time: 10,
             max_voting_time: 5,
             community_vote_threshold: VoteThreshold::YesVotePercentage(60),
-            vote_tipping: VoteTipping::Strict,
+            community_vote_tipping: VoteTipping::Strict,
             council_vote_threshold: VoteThreshold::YesVotePercentage(60),
             council_veto_vote_threshold: VoteThreshold::YesVotePercentage(50),
+            council_vote_tipping: VoteTipping::Strict,
         }
     }
 

--- a/governance/program/tests/process_cast_vote.rs
+++ b/governance/program/tests/process_cast_vote.rs
@@ -9,12 +9,10 @@ use program_test::*;
 use spl_governance::{
     error::GovernanceError,
     state::{
-        enums::{MintMaxVoteWeightSource, ProposalState, VoteThreshold, VoteTipping},
+        enums::{ProposalState, VoteThreshold, VoteTipping},
         vote_record::Vote,
     },
 };
-
-use crate::program_test::args::RealmSetupArgs;
 
 #[tokio::test]
 async fn test_cast_vote() {
@@ -1299,155 +1297,41 @@ async fn test_cast_vote_with_invalid_realm_config_account_address_error() {
 }
 
 #[tokio::test]
-async fn test_cast_vote_with_disabled_tipping_and_max_yes_votes() {
+async fn test_cast_early_council_vote_with_disabled_community_vote_tipping() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
     let realm_cookie = governance_test.with_realm().await;
     let governed_account_cookie = governance_test.with_governed_account().await;
 
-    let mut governance_config = governance_test.get_default_governance_config();
-
-    governance_config.vote_tipping = VoteTipping::Disabled;
-    governance_config.community_vote_threshold = VoteThreshold::YesVotePercentage(10);
-
-    let token_owner_record_cookie1 = governance_test
-        .with_community_token_deposit(&realm_cookie)
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
         .await
         .unwrap();
-
-    let mut _governance_cookie = governance_test
-        .with_governance_using_config(
-            &realm_cookie,
-            &governed_account_cookie,
-            &token_owner_record_cookie1,
-            &governance_config,
-        )
-        .await
-        .unwrap();
-
-    let proposal_cookie = governance_test
-        .with_signed_off_proposal(&token_owner_record_cookie1, &mut _governance_cookie)
-        .await
-        .unwrap();
-
-    // Act
-    governance_test
-        .with_cast_yes_no_vote(
-            &proposal_cookie,
-            &token_owner_record_cookie1,
-            YesNoVote::Yes,
-        )
-        .await
-        .unwrap();
-
-    // Assert
-
-    let proposal_account = governance_test
-        .get_proposal_account(&proposal_cookie.address)
-        .await;
-    assert_eq!(ProposalState::Voting, proposal_account.state);
-}
-
-#[tokio::test]
-async fn test_cast_vote_with_disabled_tipping_and_max_no_votes() {
-    // Arrange
-    let mut governance_test = GovernanceProgramTest::start_new().await;
-
-    let realm_cookie = governance_test.with_realm().await;
-    let governed_account_cookie = governance_test.with_governed_account().await;
 
     let mut governance_config = governance_test.get_default_governance_config();
 
-    governance_config.vote_tipping = VoteTipping::Disabled;
-    governance_config.community_vote_threshold = VoteThreshold::YesVotePercentage(10);
+    governance_config.community_vote_tipping = VoteTipping::Disabled;
+    governance_config.council_vote_tipping = VoteTipping::Early;
 
-    let token_owner_record_cookie1 = governance_test
-        .with_community_token_deposit(&realm_cookie)
-        .await
-        .unwrap();
-
-    let mut _governance_cookie = governance_test
+    let mut governance_cookie = governance_test
         .with_governance_using_config(
             &realm_cookie,
             &governed_account_cookie,
-            &token_owner_record_cookie1,
+            &token_owner_record_cookie,
             &governance_config,
         )
         .await
         .unwrap();
 
     let proposal_cookie = governance_test
-        .with_signed_off_proposal(&token_owner_record_cookie1, &mut _governance_cookie)
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
         .await
         .unwrap();
 
     // Act
     governance_test
-        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie1, YesNoVote::No)
-        .await
-        .unwrap();
-
-    // Assert
-
-    let proposal_account = governance_test
-        .get_proposal_account(&proposal_cookie.address)
-        .await;
-    assert_eq!(ProposalState::Voting, proposal_account.state);
-}
-
-#[tokio::test]
-async fn test_cast_vote_with_strict_tipping_and_inflated_max_vote_weight() {
-    // Arrange
-    let mut governance_test = GovernanceProgramTest::start_new().await;
-
-    // Reduce max voter weight to 50% for the cast vote to be above max_voter_weight
-    let mut realm_config_args = RealmSetupArgs::default();
-    realm_config_args.community_mint_max_vote_weight_source =
-        MintMaxVoteWeightSource::SupplyFraction(MintMaxVoteWeightSource::SUPPLY_FRACTION_BASE / 2);
-
-    let realm_cookie = governance_test
-        .with_realm_using_args(&realm_config_args)
-        .await;
-
-    let governed_account_cookie = governance_test.with_governed_account().await;
-
-    let governance_config = governance_test.get_default_governance_config();
-
-    // Mint and deposit 100 tokens to Member
-    let token_owner_record_cookie1 = governance_test
-        .with_community_token_deposit(&realm_cookie)
-        .await
-        .unwrap();
-
-    // Mint 20 community tokens to increase total supply to 120
-    // It gives us max_voter_weight==60 which is below the cast vote weight of 100
-    governance_test
-        .mint_community_tokens(&realm_cookie, 20)
-        .await;
-
-    let mut _governance_cookie = governance_test
-        .with_governance_using_config(
-            &realm_cookie,
-            &governed_account_cookie,
-            &token_owner_record_cookie1,
-            &governance_config,
-        )
-        .await
-        .unwrap();
-
-    let proposal_cookie = governance_test
-        .with_signed_off_proposal(&token_owner_record_cookie1, &mut _governance_cookie)
-        .await
-        .unwrap();
-
-    // Act
-    governance_test
-        .with_cast_yes_no_vote(
-            &proposal_cookie,
-            &token_owner_record_cookie1,
-            YesNoVote::Yes,
-        )
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
         .await
         .unwrap();
 
@@ -1457,7 +1341,5 @@ async fn test_cast_vote_with_strict_tipping_and_inflated_max_vote_weight() {
         .get_proposal_account(&proposal_cookie.address)
         .await;
 
-    assert_eq!(ProposalState::Succeeded, proposal_account.state);
-    // max_vote_weight should be coerced from 60 to 100
-    assert_eq!(proposal_account.max_vote_weight, Some(100))
+    assert_eq!(proposal_account.state, ProposalState::Succeeded);
 }

--- a/governance/program/tests/process_cast_vote.rs
+++ b/governance/program/tests/process_cast_vote.rs
@@ -554,7 +554,7 @@ async fn test_cast_vote_with_early_vote_tipped_to_succeeded() {
 
     let mut governance_config = governance_test.get_default_governance_config();
 
-    governance_config.vote_tipping = VoteTipping::Early;
+    governance_config.community_vote_tipping = VoteTipping::Early;
     governance_config.community_vote_threshold = VoteThreshold::YesVotePercentage(15);
 
     let token_owner_record_cookie1 = governance_test
@@ -718,7 +718,7 @@ async fn test_cast_vote_with_early_vote_tipped_to_defeated() {
 
     let mut governance_config = governance_test.get_default_governance_config();
 
-    governance_config.vote_tipping = VoteTipping::Early;
+    governance_config.community_vote_tipping = VoteTipping::Early;
     governance_config.community_vote_threshold = VoteThreshold::YesVotePercentage(40);
 
     // 100 votes
@@ -892,7 +892,7 @@ async fn test_cast_vote_with_disabled_tipping_yes_votes() {
 
     let mut governance_config = governance_test.get_default_governance_config();
 
-    governance_config.vote_tipping = VoteTipping::Disabled;
+    governance_config.community_vote_tipping = VoteTipping::Disabled;
     governance_config.community_vote_threshold = VoteThreshold::YesVotePercentage(10);
 
     let token_owner_record_cookie1 = governance_test
@@ -963,7 +963,7 @@ async fn test_cast_vote_with_disabled_tipping_no_votes() {
 
     let mut governance_config = governance_test.get_default_governance_config();
 
-    governance_config.vote_tipping = VoteTipping::Disabled;
+    governance_config.community_vote_tipping = VoteTipping::Disabled;
     governance_config.community_vote_threshold = VoteThreshold::YesVotePercentage(10);
 
     let token_owner_record_cookie1 = governance_test

--- a/governance/program/tests/process_cast_vote.rs
+++ b/governance/program/tests/process_cast_vote.rs
@@ -9,10 +9,12 @@ use program_test::*;
 use spl_governance::{
     error::GovernanceError,
     state::{
-        enums::{ProposalState, VoteThreshold, VoteTipping},
+        enums::{MintMaxVoteWeightSource, ProposalState, VoteThreshold, VoteTipping},
         vote_record::Vote,
     },
 };
+
+use crate::program_test::args::RealmSetupArgs;
 
 #[tokio::test]
 async fn test_cast_vote() {
@@ -1398,4 +1400,168 @@ async fn test_cast_community_vote_with_early_council_and_disabled_community_vote
         .await;
 
     assert_eq!(proposal_account.state, ProposalState::Voting);
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_disabled_tipping_and_max_yes_votes() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let mut governance_config = governance_test.get_default_governance_config();
+
+    governance_config.community_vote_tipping = VoteTipping::Disabled;
+    governance_config.community_vote_threshold = VoteThreshold::YesVotePercentage(10);
+
+    let token_owner_record_cookie1 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut _governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie1,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie1, &mut _governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_cast_yes_no_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie1,
+            YesNoVote::Yes,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_disabled_tipping_and_max_no_votes() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let mut governance_config = governance_test.get_default_governance_config();
+
+    governance_config.community_vote_tipping = VoteTipping::Disabled;
+    governance_config.community_vote_threshold = VoteThreshold::YesVotePercentage(10);
+
+    let token_owner_record_cookie1 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut _governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie1,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie1, &mut _governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie1, YesNoVote::No)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_strict_tipping_and_inflated_max_vote_weight() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    // Reduce max voter weight to 50% for the cast vote to be above max_voter_weight
+    let mut realm_config_args = RealmSetupArgs::default();
+    realm_config_args.community_mint_max_vote_weight_source =
+        MintMaxVoteWeightSource::SupplyFraction(MintMaxVoteWeightSource::SUPPLY_FRACTION_BASE / 2);
+
+    let realm_cookie = governance_test
+        .with_realm_using_args(&realm_config_args)
+        .await;
+
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let governance_config = governance_test.get_default_governance_config();
+
+    // Mint and deposit 100 tokens to Member
+    let token_owner_record_cookie1 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Mint 20 community tokens to increase total supply to 120
+    // It gives us max_voter_weight==60 which is below the cast vote weight of 100
+    governance_test
+        .mint_community_tokens(&realm_cookie, 20)
+        .await;
+
+    let mut _governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie1,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie1, &mut _governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_cast_yes_no_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie1,
+            YesNoVote::Yes,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Succeeded, proposal_account.state);
+    // max_vote_weight should be coerced from 60 to 100
+    assert_eq!(proposal_account.max_vote_weight, Some(100))
 }

--- a/governance/program/tests/process_cast_vote.rs
+++ b/governance/program/tests/process_cast_vote.rs
@@ -9,10 +9,12 @@ use program_test::*;
 use spl_governance::{
     error::GovernanceError,
     state::{
-        enums::{ProposalState, VoteThreshold, VoteTipping},
+        enums::{MintMaxVoteWeightSource, ProposalState, VoteThreshold, VoteTipping},
         vote_record::Vote,
     },
 };
+
+use crate::program_test::args::RealmSetupArgs;
 
 #[tokio::test]
 async fn test_cast_vote() {
@@ -1294,4 +1296,168 @@ async fn test_cast_vote_with_invalid_realm_config_account_address_error() {
 
     // Assert
     assert_eq!(err, GovernanceError::InvalidRealmConfigAddress.into());
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_disabled_tipping_and_max_yes_votes() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let mut governance_config = governance_test.get_default_governance_config();
+
+    governance_config.vote_tipping = VoteTipping::Disabled;
+    governance_config.community_vote_threshold = VoteThreshold::YesVotePercentage(10);
+
+    let token_owner_record_cookie1 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut _governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie1,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie1, &mut _governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_cast_yes_no_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie1,
+            YesNoVote::Yes,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_disabled_tipping_and_max_no_votes() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let mut governance_config = governance_test.get_default_governance_config();
+
+    governance_config.vote_tipping = VoteTipping::Disabled;
+    governance_config.community_vote_threshold = VoteThreshold::YesVotePercentage(10);
+
+    let token_owner_record_cookie1 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut _governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie1,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie1, &mut _governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie1, YesNoVote::No)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+    assert_eq!(ProposalState::Voting, proposal_account.state);
+}
+
+#[tokio::test]
+async fn test_cast_vote_with_strict_tipping_and_inflated_max_vote_weight() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    // Reduce max voter weight to 50% for the cast vote to be above max_voter_weight
+    let mut realm_config_args = RealmSetupArgs::default();
+    realm_config_args.community_mint_max_vote_weight_source =
+        MintMaxVoteWeightSource::SupplyFraction(MintMaxVoteWeightSource::SUPPLY_FRACTION_BASE / 2);
+
+    let realm_cookie = governance_test
+        .with_realm_using_args(&realm_config_args)
+        .await;
+
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let governance_config = governance_test.get_default_governance_config();
+
+    // Mint and deposit 100 tokens to Member
+    let token_owner_record_cookie1 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Mint 20 community tokens to increase total supply to 120
+    // It gives us max_voter_weight==60 which is below the cast vote weight of 100
+    governance_test
+        .mint_community_tokens(&realm_cookie, 20)
+        .await;
+
+    let mut _governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie1,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie1, &mut _governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_cast_yes_no_vote(
+            &proposal_cookie,
+            &token_owner_record_cookie1,
+            YesNoVote::Yes,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Succeeded, proposal_account.state);
+    // max_vote_weight should be coerced from 60 to 100
+    assert_eq!(proposal_account.max_vote_weight, Some(100))
 }

--- a/governance/program/tests/process_cast_vote.rs
+++ b/governance/program/tests/process_cast_vote.rs
@@ -1329,6 +1329,10 @@ async fn test_cast_early_council_vote_with_disabled_community_vote_tipping() {
         .await
         .unwrap();
 
+    governance_test
+        .mint_community_tokens(&realm_cookie, 20)
+        .await;
+
     // Act
     governance_test
         .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
@@ -1342,4 +1346,56 @@ async fn test_cast_early_council_vote_with_disabled_community_vote_tipping() {
         .await;
 
     assert_eq!(proposal_account.state, ProposalState::Succeeded);
+}
+
+#[tokio::test]
+async fn test_cast_community_vote_with_early_council_and_disabled_community_vote_tipping() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_config = governance_test.get_default_governance_config();
+
+    governance_config.community_vote_tipping = VoteTipping::Disabled;
+    governance_config.council_vote_tipping = VoteTipping::Early;
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .mint_community_tokens(&realm_cookie, 20)
+        .await;
+
+    // Act
+    governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .unwrap();
+
+    // Assert
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(proposal_account.state, ProposalState::Voting);
 }

--- a/governance/program/tests/process_revoke_governing_tokens.rs
+++ b/governance/program/tests/process_revoke_governing_tokens.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "test-bpf")]
+#![cfg(feature = "test-sbf")]
 
 use solana_program::pubkey::Pubkey;
 use solana_program_test::*;
@@ -11,7 +11,7 @@ use spl_governance::{
     error::GovernanceError,
     state::{realm::get_governing_token_holding_address, realm_config::GoverningTokenType},
 };
-use spl_governance_test_sdk::tools::NopOverride;
+use spl_governance_test_sdk::tools::{clone_keypair, NopOverride};
 
 use crate::program_test::args::RealmSetupArgs;
 use solana_sdk::signature::{Keypair, Signer};
@@ -149,7 +149,7 @@ async fn test_revoke_community_tokens_with_cannot_revoke_dormant_token_error() {
 }
 
 #[tokio::test]
-async fn test_revoke_council_tokens_with_realm_authority_must_sign_error() {
+async fn test_revoke_council_tokens_with_mint_authority_must_sign_error() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
@@ -172,7 +172,7 @@ async fn test_revoke_council_tokens_with_realm_authority_must_sign_error() {
             &token_owner_record_cookie,
             &realm_cookie.account.config.council_mint.unwrap(),
             1,
-            |i| i.accounts[1].is_signer = false, // realm_authority
+            |i| i.accounts[4].is_signer = false, // mint_authority
             Some(&[]),
         )
         .await
@@ -181,11 +181,11 @@ async fn test_revoke_council_tokens_with_realm_authority_must_sign_error() {
 
     // Assert
 
-    assert_eq!(err, GovernanceError::RealmAuthorityMustSign.into());
+    assert_eq!(err, GovernanceError::MintAuthorityMustSign.into());
 }
 
 #[tokio::test]
-async fn test_revoke_council_tokens_with_invalid_realm_authority_error() {
+async fn test_revoke_council_tokens_with_invalid_mint_authority_error() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
@@ -201,8 +201,8 @@ async fn test_revoke_council_tokens_with_invalid_realm_authority_error() {
         .await
         .unwrap();
 
-    // Try to use fake auhtority
-    let realm_authority = Keypair::new();
+    // Try to use fake authority
+    let mint_authority = Keypair::new();
 
     // Act
     let err = governance_test
@@ -211,8 +211,8 @@ async fn test_revoke_council_tokens_with_invalid_realm_authority_error() {
             &token_owner_record_cookie,
             &realm_cookie.account.config.council_mint.unwrap(),
             1,
-            |i| i.accounts[1].pubkey = realm_authority.pubkey(), // realm_authority
-            Some(&[&realm_authority]),
+            |i| i.accounts[4].pubkey = mint_authority.pubkey(), // mint_authority
+            Some(&[&mint_authority]),
         )
         .await
         .err()
@@ -220,7 +220,7 @@ async fn test_revoke_council_tokens_with_invalid_realm_authority_error() {
 
     // Assert
 
-    assert_eq!(err, GovernanceError::InvalidAuthorityForRealm.into());
+    assert_eq!(err, GovernanceError::InvalidMintAuthority.into());
 }
 
 #[tokio::test]
@@ -254,7 +254,7 @@ async fn test_revoke_council_tokens_with_invalid_token_holding_error() {
             &token_owner_record_cookie,
             &realm_cookie.account.config.council_mint.unwrap(),
             1,
-            |i| i.accounts[2].pubkey = governing_token_holding_address, // governing_token_holding_address
+            |i| i.accounts[1].pubkey = governing_token_holding_address, // governing_token_holding_address
             None,
         )
         .await
@@ -377,7 +377,7 @@ async fn test_revoke_council_tokens_with_token_owner_record_for_different_mint_e
             &token_owner_record_cookie,
             &realm_cookie.account.config.council_mint.unwrap(),
             1,
-            |i| i.accounts[3].pubkey = token_owner_record_cookie2.address, // token_owner_record_address
+            |i| i.accounts[2].pubkey = token_owner_record_cookie2.address, // token_owner_record_address
             None,
         )
         .await
@@ -465,4 +465,99 @@ async fn test_revoke_council_tokens_with_partial_revoke_amount() {
         .await;
 
     assert_eq!(token_owner_record.governing_token_deposit_amount, 95);
+}
+
+#[tokio::test]
+async fn test_revoke_council_tokens_with_community_mint_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let mut realm_config_args = RealmSetupArgs::default();
+    realm_config_args.council_token_config_args.token_type = GoverningTokenType::Membership;
+
+    let realm_cookie = governance_test
+        .with_realm_using_args(&realm_config_args)
+        .await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Try to use mint and authority for Community to revoke Council token
+    let governing_token_mint = realm_cookie.account.community_mint.clone();
+    let governing_token_mint_authority = clone_keypair(&realm_cookie.community_mint_authority);
+    let governing_token_holding_address = get_governing_token_holding_address(
+        &governance_test.program_id,
+        &realm_cookie.address,
+        &governing_token_mint,
+    );
+
+    // Act
+    let err = governance_test
+        .revoke_governing_tokens_using_instruction(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &realm_cookie.account.config.council_mint.unwrap(),
+            1,
+            |i| {
+                i.accounts[1].pubkey = governing_token_holding_address;
+                i.accounts[3].pubkey = governing_token_mint;
+                i.accounts[4].pubkey = governing_token_mint_authority.pubkey();
+            }, // mint_authority
+            Some(&[&governing_token_mint_authority]),
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(err, GovernanceError::CannotRevokeGoverningTokens.into());
+}
+
+#[tokio::test]
+async fn test_revoke_council_tokens_with_not_matching_mint_and_authority_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let mut realm_config_args = RealmSetupArgs::default();
+    realm_config_args.council_token_config_args.token_type = GoverningTokenType::Membership;
+
+    let realm_cookie = governance_test
+        .with_realm_using_args(&realm_config_args)
+        .await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Try to use a valid mint and authority not matching the Council mint
+    let governing_token_mint = realm_cookie.account.community_mint.clone();
+    let governing_token_mint_authority = clone_keypair(&realm_cookie.community_mint_authority);
+
+    // Act
+    let err = governance_test
+        .revoke_governing_tokens_using_instruction(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &realm_cookie.account.config.council_mint.unwrap(),
+            1,
+            |i| {
+                i.accounts[3].pubkey = governing_token_mint;
+                i.accounts[4].pubkey = governing_token_mint_authority.pubkey();
+            }, // mint_authority
+            Some(&[&governing_token_mint_authority]),
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_eq!(
+        err,
+        GovernanceError::InvalidGoverningTokenHoldingAccount.into()
+    );
 }

--- a/governance/program/tests/program_test/cookies.rs
+++ b/governance/program/tests/program_test/cookies.rs
@@ -35,6 +35,18 @@ pub struct RealmCookie {
     pub realm_config: RealmConfigCookie,
 }
 
+impl RealmCookie {
+    pub fn get_mint_authority(&self, governing_token_mint: &Pubkey) -> &Keypair {
+        if *governing_token_mint == self.account.community_mint {
+            &self.community_mint_authority
+        } else if Some(*governing_token_mint) == self.account.config.council_mint {
+            &self.council_mint_authority.as_ref().unwrap()
+        } else {
+            panic!("Invalid governing_token_mint")
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct RealmConfigCookie {
     pub address: Pubkey,

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1409,9 +1409,10 @@ impl GovernanceProgramTest {
             min_transaction_hold_up_time: 10,
             max_voting_time: 10,
             community_vote_threshold: VoteThreshold::YesVotePercentage(60),
-            vote_tipping: spl_governance::state::enums::VoteTipping::Strict,
+            community_vote_tipping: spl_governance::state::enums::VoteTipping::Strict,
             council_vote_threshold: VoteThreshold::YesVotePercentage(80),
             council_veto_vote_threshold: VoteThreshold::YesVotePercentage(55),
+            council_vote_tipping: spl_governance::state::enums::VoteTipping::Strict,
         }
     }
 
@@ -1487,7 +1488,7 @@ impl GovernanceProgramTest {
             governed_account: governed_account_cookie.address,
             config: governance_config.clone(),
             proposals_count: 0,
-            reserved: [0; 6],
+            reserved: [0; 5],
             voting_proposal_count: 0,
             reserved_v2: [0; 128],
         };
@@ -1658,7 +1659,7 @@ impl GovernanceProgramTest {
             governed_account: governed_program_cookie.address,
             config,
             proposals_count: 0,
-            reserved: [0; 6],
+            reserved: [0; 5],
             voting_proposal_count: 0,
             reserved_v2: [0; 128],
         };
@@ -1782,7 +1783,7 @@ impl GovernanceProgramTest {
             governed_account: governed_mint_cookie.address,
             config: governance_config.clone(),
             proposals_count: 0,
-            reserved: [0; 6],
+            reserved: [0; 5],
             voting_proposal_count: 0,
             reserved_v2: [0; 128],
         };
@@ -1866,7 +1867,7 @@ impl GovernanceProgramTest {
             governed_account: governed_token_cookie.address,
             config,
             proposals_count: 0,
-            reserved: [0; 6],
+            reserved: [0; 5],
             voting_proposal_count: 0,
             reserved_v2: [0; 128],
         };

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1303,18 +1303,20 @@ impl GovernanceProgramTest {
         instruction_override: F,
         signers_override: Option<&[&Keypair]>,
     ) -> Result<(), ProgramError> {
+        let governing_token_mint_authority = realm_cookie.get_mint_authority(governing_token_mint);
+
         let mut revoke_governing_tokens_ix = revoke_governing_tokens(
             &self.program_id,
             &realm_cookie.address,
-            &realm_cookie.account.authority.unwrap(),
             &token_owner_record_cookie.account.governing_token_owner,
             governing_token_mint,
+            &governing_token_mint_authority.pubkey(),
             amount,
         );
 
         instruction_override(&mut revoke_governing_tokens_ix);
 
-        let default_signers = &[realm_cookie.realm_authority.as_ref().unwrap()];
+        let default_signers = &[governing_token_mint_authority];
         let signers = signers_override.unwrap_or(default_signers);
 
         self.bench


### PR DESCRIPTION
#### Summary 

Make it possible to have different `vote_tipping` settings for `Community` and `Council`.

It allows to create a governance structure where both `Community` and `Council` can control the same assets but with different voting rules. For example a governance to control program upgrades could use the following settings:

 - `Community` `vote_tipping` set to `Disabled`  meaning its vote can't end early and always must last the configured amount to time.
 - `Council` `vote_tipping` set to `Early` meaning it has power to create and execute fast forward emergency proposals to upgrade security vulnerabilities. 

#### Implementation details
- `council_vote_tipping` was added to `GovernanceConfig` struct. It used reserved space making the change backward compatible with previous versions and the binary account layout.