### PR TITLE
Governance: Explicit disabled weight thresholds

### DIFF
--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -434,6 +434,10 @@ pub enum GovernanceError {
     /// Cannot change community TokenType to Memebership
     #[error("Cannot change community TokenType to Memebership")]
     CannotChangeCommunityTokenTypeToMemebership, // 604
+
+    /// Voter weight threshold disabled
+    #[error("Voter weight threshold disabled")]
+    VoterWeightThresholdDisabled, // 605
 }
 
 impl PrintProgramError for GovernanceError {

--- a/governance/program/src/state/token_owner_record.rs
+++ b/governance/program/src/state/token_owner_record.rs
@@ -124,6 +124,12 @@ impl TokenOwnerRecordV2 {
                 return Err(GovernanceError::InvalidGoverningTokenMint.into());
             };
 
+        // If the weight threshold is set to u64::MAX then it indicates explicitly Disabled value
+        // which should prevent any possiblity of using it
+        if min_weight_to_create_proposal == u64::MAX {
+            return Err(GovernanceError::VoterWeightThresholdDisabled.into());
+        }
+
         if voter_weight < min_weight_to_create_proposal {
             return Err(GovernanceError::NotEnoughTokensToCreateProposal.into());
         }
@@ -152,6 +158,12 @@ impl TokenOwnerRecordV2 {
             } else {
                 return Err(GovernanceError::InvalidGoverningTokenMint.into());
             };
+
+        // If the weight threshold is set to u64::MAX then it indicates explicitly Disabled value
+        // which should prevent any possiblity of using it
+        if min_weight_to_create_governance == u64::MAX {
+            return Err(GovernanceError::VoterWeightThresholdDisabled.into());
+        }
 
         if voter_weight < min_weight_to_create_governance {
             return Err(GovernanceError::NotEnoughTokensToCreateGovernance.into());


### PR DESCRIPTION
#### Summary 

Make it possible to explicitly disable voter weight thresholds to create governances and proposals. 
The purpose of this change is to have strong guaranteed to prevent governance or proposal creation by given governance population. 

#### Implementation 

Ideally `Option<u64>` should be used to indicate the optionality of the value but In order to preserve backward compatibility with existing realms the value of `u64::MAX` was used to denote Disabled thresholds.

