### PR TITLE
Update help text for `propose`

### DIFF
--- a/feature-proposal/cli/src/main.rs
+++ b/feature-proposal/cli/src/main.rs
@@ -358,12 +358,12 @@ fn process_propose(
         the proposal by first looking up their token account address:"
     );
     println!(
-        "    $ spl-token --owner ~/validator-keypair.json accounts {}",
+        "    $ spl-token accounts --owner ~/validator-keypair.json {}",
         mint_address
     );
     println!("and then submit their vote by running:");
     println!(
-        "    $ spl-token --owner ~/validator-keypair.json transfer <TOKEN_ACCOUNT_ADDRESS> ALL {}",
+        "    $ spl-token transfer --owner ~/validator-keypair.json <TOKEN_ACCOUNT_ADDRESS> ALL {}",
         acceptance_token_address
     );
     println!();


### PR DESCRIPTION
After running `solana-test-validator` (version v1.11.6) to test out the process for doing a feature proposal, I ran into issues with the commands that `spl-feature-proposal propose` spat out.

The fix was simple, I just needed to move the subcommand before the `--owner` flag.