### PR TITLE
Governance: Community Veto Vote

### DIFF
--- a/governance/chat/program/tests/program_test/mod.rs
+++ b/governance/chat/program/tests/program_test/mod.rs
@@ -195,6 +195,7 @@ impl GovernanceChatProgramTest {
             council_vote_threshold: VoteThreshold::YesVotePercentage(10),
             council_veto_vote_threshold: VoteThreshold::YesVotePercentage(50),
             council_vote_tipping: spl_governance::state::enums::VoteTipping::Strict,
+            community_veto_vote_threshold: VoteThreshold::YesVotePercentage(55),
         };
 
         let token_owner_record_address = get_token_owner_record_address(

--- a/governance/program/src/processor/process_create_governance.rs
+++ b/governance/program/src/processor/process_create_governance.rs
@@ -57,7 +57,7 @@ pub fn process_create_governance(
         governed_account: *governed_account_info.key,
         config,
         proposals_count: 0,
-        reserved: [0; 5],
+        reserved: [0; 4],
         voting_proposal_count: 0,
         reserved_v2: [0; 128],
     };

--- a/governance/program/src/processor/process_create_governance.rs
+++ b/governance/program/src/processor/process_create_governance.rs
@@ -57,7 +57,7 @@ pub fn process_create_governance(
         governed_account: *governed_account_info.key,
         config,
         proposals_count: 0,
-        reserved: [0; 4],
+        reserved: [0; 3],
         voting_proposal_count: 0,
         reserved_v2: [0; 128],
     };

--- a/governance/program/src/processor/process_create_mint_governance.rs
+++ b/governance/program/src/processor/process_create_mint_governance.rs
@@ -69,7 +69,7 @@ pub fn process_create_mint_governance(
         governed_account: *governed_mint_info.key,
         config,
         proposals_count: 0,
-        reserved: [0; 4],
+        reserved: [0; 3],
         voting_proposal_count: 0,
         reserved_v2: [0; 128],
     };

--- a/governance/program/src/processor/process_create_mint_governance.rs
+++ b/governance/program/src/processor/process_create_mint_governance.rs
@@ -69,7 +69,7 @@ pub fn process_create_mint_governance(
         governed_account: *governed_mint_info.key,
         config,
         proposals_count: 0,
-        reserved: [0; 5],
+        reserved: [0; 4],
         voting_proposal_count: 0,
         reserved_v2: [0; 128],
     };

--- a/governance/program/src/processor/process_create_program_governance.rs
+++ b/governance/program/src/processor/process_create_program_governance.rs
@@ -69,7 +69,7 @@ pub fn process_create_program_governance(
         governed_account: *governed_program_info.key,
         config,
         proposals_count: 0,
-        reserved: [0; 5],
+        reserved: [0; 4],
         voting_proposal_count: 0,
         reserved_v2: [0; 128],
     };

--- a/governance/program/src/processor/process_create_program_governance.rs
+++ b/governance/program/src/processor/process_create_program_governance.rs
@@ -69,7 +69,7 @@ pub fn process_create_program_governance(
         governed_account: *governed_program_info.key,
         config,
         proposals_count: 0,
-        reserved: [0; 4],
+        reserved: [0; 3],
         voting_proposal_count: 0,
         reserved_v2: [0; 128],
     };

--- a/governance/program/src/processor/process_create_token_governance.rs
+++ b/governance/program/src/processor/process_create_token_governance.rs
@@ -67,7 +67,7 @@ pub fn process_create_token_governance(
         governed_account: *governed_token_info.key,
         config,
         proposals_count: 0,
-        reserved: [0; 5],
+        reserved: [0; 4],
         voting_proposal_count: 0,
         reserved_v2: [0; 128],
     };

--- a/governance/program/src/processor/process_create_token_governance.rs
+++ b/governance/program/src/processor/process_create_token_governance.rs
@@ -67,7 +67,7 @@ pub fn process_create_token_governance(
         governed_account: *governed_token_info.key,
         config,
         proposals_count: 0,
-        reserved: [0; 4],
+        reserved: [0; 3],
         voting_proposal_count: 0,
         reserved_v2: [0; 128],
     };

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -48,14 +48,12 @@ pub struct GovernanceConfig {
 
     /// Minimum council weight a governance token owner must possess to be able to create a proposal
     pub min_council_weight_to_create_proposal: u64,
-    //
-    // The threshold for Community Veto votes
-    // Note: Community Veto vote is not supported in the current version
-    // In order to use this threshold the space from GovernanceV2.reserved must be taken to expand GovernanceConfig size
-    // pub community_veto_vote_threshold: VoteThreshold,
-    //
+
     /// Conditions under which a Council vote will complete early
     pub council_vote_tipping: VoteTipping,
+
+    /// The threshold for Community Veto votes
+    pub community_veto_vote_threshold: VoteThreshold,
 }
 
 /// Governance Account
@@ -85,7 +83,7 @@ pub struct GovernanceV2 {
     pub config: GovernanceConfig,
 
     /// Reserved space for future versions
-    pub reserved: [u8; 5],
+    pub reserved: [u8; 4],
 
     /// The number of proposals in voting state in the Governance
     pub voting_proposal_count: u16,
@@ -228,10 +226,7 @@ impl GovernanceV2 {
         let vote_threshold = if realm_data.community_mint == *vote_governing_token_mint {
             match vote_kind {
                 VoteKind::Electorate => &self.config.community_vote_threshold,
-                VoteKind::Veto => {
-                    // Community Veto vote is not supported in current version
-                    return Err(GovernanceError::GoverningTokenMintNotAllowedToVote.into());
-                }
+                VoteKind::Veto => &self.config.community_veto_vote_threshold,
             }
         } else if realm_data.config.council_mint == Some(*vote_governing_token_mint) {
             match vote_kind {
@@ -289,7 +284,7 @@ pub fn get_governance_data(
             governed_account: governance_data_v1.governed_account,
             proposals_count: governance_data_v1.proposals_count,
             config: governance_data_v1.config,
-            reserved: [0; 5],
+            reserved: [0; 4],
             voting_proposal_count: governance_data_v1.voting_proposal_count,
 
             // Add the extra reserved_v2 padding
@@ -317,7 +312,10 @@ pub fn get_governance_data(
 
         // For legacy accounts default Council VoteTipping to the Community
         governance_data.config.council_vote_tipping =
-            governance_data.config.community_vote_tipping.clone()
+            governance_data.config.community_vote_tipping.clone();
+
+        // For legacy accoutns set the community Veto threshold to Disabled
+        governance_data.config.community_veto_vote_threshold = VoteThreshold::Disabled;
     }
 
     Ok(governance_data)
@@ -574,6 +572,7 @@ mod test {
             council_veto_vote_threshold: VoteThreshold::YesVotePercentage(1),
             min_council_weight_to_create_proposal: 1,
             council_vote_tipping: VoteTipping::Strict,
+            community_veto_vote_threshold: VoteThreshold::YesVotePercentage(1),
         };
 
         // Act
@@ -598,6 +597,7 @@ mod test {
             council_veto_vote_threshold: VoteThreshold::YesVotePercentage(1),
             min_council_weight_to_create_proposal: 1,
             council_vote_tipping: VoteTipping::Strict,
+            community_veto_vote_threshold: VoteThreshold::YesVotePercentage(1),
         };
 
         // Act
@@ -622,6 +622,7 @@ mod test {
             council_veto_vote_threshold: VoteThreshold::YesVotePercentage(1),
             min_council_weight_to_create_proposal: 1,
             council_vote_tipping: VoteTipping::Strict,
+            community_veto_vote_threshold: VoteThreshold::YesVotePercentage(1),
         };
 
         // Act
@@ -646,6 +647,7 @@ mod test {
             council_veto_vote_threshold: VoteThreshold::YesVotePercentage(0),
             min_council_weight_to_create_proposal: 1,
             council_vote_tipping: VoteTipping::Strict,
+            community_veto_vote_threshold: VoteThreshold::YesVotePercentage(1),
         };
 
         // Act

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -1178,6 +1178,7 @@ mod test {
             council_vote_threshold: VoteThreshold::YesVotePercentage(60),
             council_veto_vote_threshold: VoteThreshold::YesVotePercentage(50),
             council_vote_tipping: VoteTipping::Strict,
+            community_veto_vote_threshold: VoteThreshold::YesVotePercentage(40),
         }
     }
 

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -226,9 +226,7 @@ impl RealmV2 {
             VoteKind::Veto => {
                 // When Community veto Council proposal then return council_token_mint as the Proposal governing_token_mint
                 if self.community_mint == *vote_governing_token_mint {
-                    // Community Veto is not supported in the current version
-                    return Err(GovernanceError::GoverningTokenMintNotAllowedToVote.into());
-                    //return Ok(self.config.council_mint.unwrap());
+                    return Ok(self.config.council_mint.unwrap());
                 }
 
                 // When Council veto Community proposal then return community_token_mint as the Proposal governing_token_mint

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1413,6 +1413,7 @@ impl GovernanceProgramTest {
             council_vote_threshold: VoteThreshold::YesVotePercentage(80),
             council_veto_vote_threshold: VoteThreshold::YesVotePercentage(55),
             council_vote_tipping: spl_governance::state::enums::VoteTipping::Strict,
+            community_veto_vote_threshold: VoteThreshold::YesVotePercentage(80),
         }
     }
 
@@ -1488,7 +1489,7 @@ impl GovernanceProgramTest {
             governed_account: governed_account_cookie.address,
             config: governance_config.clone(),
             proposals_count: 0,
-            reserved: [0; 5],
+            reserved: [0; 4],
             voting_proposal_count: 0,
             reserved_v2: [0; 128],
         };
@@ -1659,7 +1660,7 @@ impl GovernanceProgramTest {
             governed_account: governed_program_cookie.address,
             config,
             proposals_count: 0,
-            reserved: [0; 5],
+            reserved: [0; 4],
             voting_proposal_count: 0,
             reserved_v2: [0; 128],
         };
@@ -1783,7 +1784,7 @@ impl GovernanceProgramTest {
             governed_account: governed_mint_cookie.address,
             config: governance_config.clone(),
             proposals_count: 0,
-            reserved: [0; 5],
+            reserved: [0; 4],
             voting_proposal_count: 0,
             reserved_v2: [0; 128],
         };
@@ -1867,7 +1868,7 @@ impl GovernanceProgramTest {
             governed_account: governed_token_cookie.address,
             config,
             proposals_count: 0,
-            reserved: [0; 5],
+            reserved: [0; 4],
             voting_proposal_count: 0,
             reserved_v2: [0; 128],
         };

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1489,7 +1489,7 @@ impl GovernanceProgramTest {
             governed_account: governed_account_cookie.address,
             config: governance_config.clone(),
             proposals_count: 0,
-            reserved: [0; 4],
+            reserved: [0; 3],
             voting_proposal_count: 0,
             reserved_v2: [0; 128],
         };
@@ -1660,7 +1660,7 @@ impl GovernanceProgramTest {
             governed_account: governed_program_cookie.address,
             config,
             proposals_count: 0,
-            reserved: [0; 4],
+            reserved: [0; 3],
             voting_proposal_count: 0,
             reserved_v2: [0; 128],
         };
@@ -1784,7 +1784,7 @@ impl GovernanceProgramTest {
             governed_account: governed_mint_cookie.address,
             config: governance_config.clone(),
             proposals_count: 0,
-            reserved: [0; 4],
+            reserved: [0; 3],
             voting_proposal_count: 0,
             reserved_v2: [0; 128],
         };
@@ -1868,7 +1868,7 @@ impl GovernanceProgramTest {
             governed_account: governed_token_cookie.address,
             config,
             proposals_count: 0,
-            reserved: [0; 4],
+            reserved: [0; 3],
             voting_proposal_count: 0,
             reserved_v2: [0; 128],
         };

--- a/governance/program/tests/use_veto_vote.rs
+++ b/governance/program/tests/use_veto_vote.rs
@@ -18,7 +18,7 @@ use spl_governance_test_sdk::tools::clone_keypair;
 use crate::program_test::args::RealmSetupArgs;
 
 #[tokio::test]
-async fn test_cast_veto_vote() {
+async fn test_cast_council_veto_vote() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
@@ -111,7 +111,7 @@ async fn test_cast_veto_vote() {
 }
 
 #[tokio::test]
-async fn test_cast_veto_vote_with_community_not_allowed_to_vote_error() {
+async fn test_cast_community_veto_vote() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
@@ -123,11 +123,90 @@ async fn test_cast_veto_vote_with_community_not_allowed_to_vote_error() {
         .await
         .unwrap();
 
+    // Mint extra community tokens for total supply of 120
+    governance_test
+        .mint_community_tokens(&realm_cookie, 20)
+        .await;
+
     let mut governance_cookie = governance_test
         .with_governance(
             &realm_cookie,
             &governed_account_cookie,
             &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let proposal_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&proposal_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    let vote_record_cookie = governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Veto)
+        .await
+        .unwrap();
+
+    // Assert
+    let vote_record_account = governance_test
+        .get_vote_record_account(&vote_record_cookie.address)
+        .await;
+
+    assert_eq!(vote_record_cookie.account, vote_record_account);
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(
+        token_owner_record_cookie
+            .account
+            .governing_token_deposit_amount,
+        proposal_account.veto_vote_weight
+    );
+
+    assert_eq!(proposal_account.state, ProposalState::Vetoed);
+
+    assert_eq!(Some(120), proposal_account.max_vote_weight);
+    assert_eq!(
+        Some(
+            governance_cookie
+                .account
+                .config
+                .community_veto_vote_threshold
+        ),
+        proposal_account.vote_threshold
+    );
+}
+
+#[tokio::test]
+async fn test_cast_community_veto_vote_with_community_veto_disabled_error() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.community_veto_vote_threshold = VoteThreshold::Disabled;
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
         )
         .await
         .unwrap();

--- a/governance/program/tests/use_veto_vote.rs
+++ b/governance/program/tests/use_veto_vote.rs
@@ -1,11 +1,11 @@
 #![cfg(feature = "test-sbf")]
 
 mod program_test;
+use program_test::*;
 
 use solana_program::instruction::AccountMeta;
 use solana_program_test::tokio;
 
-use program_test::*;
 use spl_governance::{
     error::GovernanceError,
     state::{
@@ -15,7 +15,7 @@ use spl_governance::{
 };
 use spl_governance_test_sdk::tools::clone_keypair;
 
-use crate::program_test::args::RealmSetupArgs;
+use crate::program_test::args::{PluginSetupArgs, RealmSetupArgs};
 
 #[tokio::test]
 async fn test_cast_council_veto_vote() {
@@ -794,5 +794,55 @@ async fn test_cast_yes_and_veto_votes_with_yes_as_winning_vote() {
     assert_eq!(proposal_account.state, ProposalState::Succeeded);
 }
 
-// TODO: Once Veto for Community or plugin support for Council is implemented write Veto tests with plugin
-// The tests should cover scenarios where Veto voter_weight and/or max_voter_weight is resolved using the plugins
+#[tokio::test]
+async fn test_veto_vote_with_community_voter_weight_addin() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let realm_cookie = governance_test
+        .with_realm_using_addins(PluginSetupArgs::COMMUNITY_VOTER_WEIGHT)
+        .await;
+
+    let mut token_owner_record_cookie = governance_test
+        .with_community_token_owner_record(&realm_cookie)
+        .await;
+
+    governance_test
+        .with_voter_weight_addin_record(&mut token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    // Create Proposal for Council vote
+    let proposal_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&proposal_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, Vote::Veto)
+        .await
+        .unwrap();
+
+    // Assert
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(proposal_account.state, ProposalState::Vetoed);
+}


### PR DESCRIPTION
#### Summary

Enable `Community Veto` vote to make it possible for the `Community` to veto `Council` proposals.

 For existing accounts `Community Veto` is disabled as a more conservative setting which grants more governance power  to `Council`. It also consistent with setup where `Community` vote was implicitly disabled.

#### Implementation 

- `reserved` space from `Governance` account was used to make the change backward compatible.



