### PR TITLE
token-cli: Removed usage of Account::LEN as a verificaton for token account

### DIFF
--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -797,7 +797,7 @@ async fn command_transfer(
             .value
             .map(|account| {
                 (
-                    account.owner == mint_info.program_id && account.data.len() == Account::LEN,
+                    account.owner == mint_info.program_id,
                     account.owner == system_program::id(),
                 )
             });

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -66,6 +66,7 @@ use sort::{is_supported_program, sort_and_parse_token_accounts};
 
 mod bench;
 use bench::*;
+use spl_token_2022::generic_token_account::GenericTokenAccount;
 
 struct CliSignerInfo {
     pub signers: Vec<Arc<dyn Signer>>,
@@ -797,7 +798,7 @@ async fn command_transfer(
             .value
             .map(|account| {
                 (
-                    account.owner == mint_info.program_id,
+                    account.owner == mint_info.program_id && Account::valid_account_data(account.data.as_slice()),
                     account.owner == system_program::id(),
                 )
             });

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -798,7 +798,8 @@ async fn command_transfer(
             .value
             .map(|account| {
                 (
-                    account.owner == mint_info.program_id && Account::valid_account_data(account.data.as_slice()),
+                    account.owner == mint_info.program_id
+                        && Account::valid_account_data(account.data.as_slice()),
                     account.owner == system_program::id(),
                 )
             });


### PR DESCRIPTION
closes #3526 