### PR TITLE
run more cli stuff through client

### DIFF
--- a/token/cli/src/bench.rs
+++ b/token/cli/src/bench.rs
@@ -302,7 +302,7 @@ async fn command_create_accounts(
                 messages.push(Message::new(
                     &[
                         system_instruction::create_account_with_seed(
-                            &config.fee_payer,
+                            &config.fee_payer.pubkey(),
                             address,
                             owner,
                             seed,
@@ -312,7 +312,7 @@ async fn command_create_accounts(
                         ),
                         instruction::initialize_account(&program_id, address, token, owner)?,
                     ],
-                    Some(&config.fee_payer),
+                    Some(&config.fee_payer.pubkey()),
                 ));
             }
         }
@@ -358,7 +358,7 @@ async fn command_close_accounts(
                                     owner,
                                     &[],
                                 )?],
-                                Some(&config.fee_payer),
+                                Some(&config.fee_payer.pubkey()),
                             ));
                         }
                     }
@@ -415,7 +415,7 @@ async fn command_deposit_into_or_withdraw_from(
                         amount,
                         mint_info.decimals,
                     )?],
-                    Some(&config.fee_payer),
+                    Some(&config.fee_payer.pubkey()),
                 ));
             } else {
                 eprintln!("Token account does not exist: {}", address)

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -1152,23 +1152,12 @@ async fn command_freeze(
         ),
     );
 
-    let instructions = vec![freeze_account(
-        &mint_info.program_id,
-        &account,
-        &mint_info.address,
-        &freeze_authority,
-        &config.multisigner_pubkeys,
-    )?];
-    let tx_return = handle_tx(
-        &CliSignerInfo {
-            signers: bulk_signers,
-        },
-        config,
-        false,
-        0,
-        instructions,
-    )
-    .await?;
+    let token = token_client_from_config(config, &mint_info.program_id, &mint_info.address);
+    let res = token
+        .freeze(&account, &freeze_authority, &bulk_signers)
+        .await?;
+
+    let tx_return = finish_tx(config, &res, false).await?;
     Ok(match tx_return {
         TransactionReturnData::CliSignature(signature) => {
             config.output_format.formatted_string(&signature)
@@ -1197,23 +1186,12 @@ async fn command_thaw(
         ),
     );
 
-    let instructions = vec![thaw_account(
-        &mint_info.program_id,
-        &account,
-        &mint_info.address,
-        &freeze_authority,
-        &config.multisigner_pubkeys,
-    )?];
-    let tx_return = handle_tx(
-        &CliSignerInfo {
-            signers: bulk_signers,
-        },
-        config,
-        false,
-        0,
-        instructions,
-    )
-    .await?;
+    let token = token_client_from_config(config, &mint_info.program_id, &mint_info.address);
+    let res = token
+        .thaw(&account, &freeze_authority, &bulk_signers)
+        .await?;
+
+    let tx_return = finish_tx(config, &res, false).await?;
     Ok(match tx_return {
         TransactionReturnData::CliSignature(signature) => {
             config.output_format.formatted_string(&signature)
@@ -1478,22 +1456,10 @@ async fn command_revoke(
         return Err(format!("No delegate on account {}", account).into());
     }
 
-    let instructions = vec![revoke(
-        &program_id,
-        &account,
-        &owner,
-        &config.multisigner_pubkeys,
-    )?];
-    let tx_return = handle_tx(
-        &CliSignerInfo {
-            signers: bulk_signers,
-        },
-        config,
-        false,
-        0,
-        instructions,
-    )
-    .await?;
+    let token = token_client_from_config(config, &program_id, &Pubkey::default());
+    let res = token.revoke(&account, &owner, &bulk_signers).await?;
+
+    let tx_return = finish_tx(config, &res, false).await?;
     Ok(match tx_return {
         TransactionReturnData::CliSignature(signature) => {
             config.output_format.formatted_string(&signature)

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -192,15 +192,6 @@ impl<T> fmt::Debug for Token<T> {
     }
 }
 
-// HANA XXX OK what are we doing
-//these are all the remaining "normal" methods to rework:
-// X transfer
-// X approve
-// X revoke
-// X close
-// * freeze
-// * thaw
-// and then just a bunch of extension ones. this isnt hard
 impl<T> Token<T>
 where
     T: SendTransaction,

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -195,9 +195,9 @@ impl<T> fmt::Debug for Token<T> {
 // HANA XXX OK what are we doing
 //these are all the remaining "normal" methods to rework:
 // X transfer
-// * approve
-// * revoke
-// * close
+// X approve
+// X revoke
+// X close
 // * freeze
 // * thaw
 // and then just a bunch of extension ones. this isnt hard
@@ -812,39 +812,45 @@ where
     }
 
     /// Freeze a token account
-    pub async fn freeze_account<S: Signer>(
+    pub async fn freeze<S: Signers>(
         &self,
         account: &Pubkey,
-        authority: &S,
+        authority: &Pubkey,
+        signing_keypairs: &S,
     ) -> TokenResult<T::Output> {
+        let multisig_signers = self.get_multisig_signers(authority, signing_keypairs);
+
         self.process_ixs(
             &[instruction::freeze_account(
                 &self.program_id,
                 account,
                 &self.pubkey,
-                &authority.pubkey(),
-                &[],
+                authority,
+                &multisig_signers.iter().collect::<Vec<_>>(),
             )?],
-            &[authority],
+            signing_keypairs,
         )
         .await
     }
 
     /// Thaw / unfreeze a token account
-    pub async fn thaw_account<S: Signer>(
+    pub async fn thaw<S: Signers>(
         &self,
         account: &Pubkey,
-        authority: &S,
+        authority: &Pubkey,
+        signing_keypairs: &S,
     ) -> TokenResult<T::Output> {
+        let multisig_signers = self.get_multisig_signers(authority, signing_keypairs);
+
         self.process_ixs(
             &[instruction::thaw_account(
                 &self.program_id,
                 account,
                 &self.pubkey,
-                &authority.pubkey(),
-                &[],
+                authority,
+                &multisig_signers.iter().collect::<Vec<_>>(),
             )?],
-            &[authority],
+            signing_keypairs,
         )
         .await
     }

--- a/token/client/tests/program-test.rs
+++ b/token/client/tests/program-test.rs
@@ -299,7 +299,14 @@ async fn transfer() {
 
     let transfer_amount = mint_amount.overflowing_div(3).0;
     token
-        .transfer_checked(&alice_vault, &bob_vault, &alice, transfer_amount, decimals)
+        .transfer(
+            &alice_vault,
+            &bob_vault,
+            &alice.pubkey(),
+            transfer_amount,
+            Some(decimals),
+            &vec![&alice],
+        )
         .await
         .expect("failed to transfer");
 

--- a/token/client/tests/program-test.rs
+++ b/token/client/tests/program-test.rs
@@ -145,6 +145,7 @@ async fn get_or_create_associated_token_account() {
 #[tokio::test]
 async fn set_authority() {
     let TestContext {
+        decimals,
         mint_authority,
         token,
         alice,
@@ -158,7 +159,13 @@ async fn set_authority() {
         .expect("failed to create associated token account");
 
     token
-        .mint_to(&alice_vault, &mint_authority, 1)
+        .mint_to(
+            &alice_vault,
+            &mint_authority.pubkey(),
+            1,
+            Some(decimals),
+            &vec![&mint_authority],
+        )
         .await
         .expect("failed to mint token");
 
@@ -182,7 +189,13 @@ async fn set_authority() {
     // TODO: compare
     // Err(Client(TransactionError(InstructionError(0, Custom(5)))))
     assert!(token
-        .mint_to(&alice_vault, &mint_authority, 2)
+        .mint_to(
+            &alice_vault,
+            &mint_authority.pubkey(),
+            2,
+            Some(decimals),
+            &vec![&mint_authority]
+        )
         .await
         .is_err());
 
@@ -228,7 +241,13 @@ async fn mint_to() {
 
     let mint_amount = 10 * u64::pow(10, decimals as u32);
     token
-        .mint_to(&alice_vault, &mint_authority, mint_amount)
+        .mint_to(
+            &alice_vault,
+            &mint_authority.pubkey(),
+            mint_amount,
+            Some(decimals),
+            &vec![&mint_authority],
+        )
         .await
         .expect("failed to mint token");
 
@@ -268,7 +287,13 @@ async fn transfer() {
 
     let mint_amount = 10 * u64::pow(10, decimals as u32);
     token
-        .mint_to(&alice_vault, &mint_authority, mint_amount)
+        .mint_to(
+            &alice_vault,
+            &mint_authority.pubkey(),
+            mint_amount,
+            Some(decimals),
+            &vec![&mint_authority],
+        )
         .await
         .expect("failed to mint token");
 

--- a/token/program-2022-test/tests/burn.rs
+++ b/token/program-2022-test/tests/burn.rs
@@ -31,7 +31,13 @@ async fn run_basic(context: TestContext) {
     // mint a token
     let amount = 10;
     token
-        .mint_to(&alice_account, &mint_authority, amount)
+        .mint_to(
+            &alice_account,
+            &mint_authority.pubkey(),
+            amount,
+            Some(decimals),
+            &vec![&mint_authority],
+        )
         .await
         .unwrap();
 
@@ -114,7 +120,13 @@ async fn run_self_owned(context: TestContext) {
     // mint a token
     let amount = 10;
     token
-        .mint_to(&alice_account, &mint_authority, amount)
+        .mint_to(
+            &alice_account,
+            &mint_authority.pubkey(),
+            amount,
+            Some(decimals),
+            &vec![&mint_authority],
+        )
         .await
         .unwrap();
 
@@ -167,7 +179,13 @@ async fn run_burn_and_close_system_or_incinerator(context: TestContext, non_owne
 
     // mint a token
     token
-        .mint_to(&alice_account, &mint_authority, 1)
+        .mint_to(
+            &alice_account,
+            &mint_authority.pubkey(),
+            1,
+            Some(decimals),
+            &vec![&mint_authority],
+        )
         .await
         .unwrap();
 

--- a/token/program-2022-test/tests/burn.rs
+++ b/token/program-2022-test/tests/burn.rs
@@ -226,7 +226,14 @@ async fn run_burn_and_close_system_or_incinerator(context: TestContext, non_owne
         .await
         .unwrap();
     token
-        .transfer_checked(&alice_account, &non_owner_account, &alice, 1, decimals)
+        .transfer(
+            &alice_account,
+            &non_owner_account,
+            &alice.pubkey(),
+            1,
+            Some(decimals),
+            &vec![&alice],
+        )
         .await
         .unwrap();
 

--- a/token/program-2022-test/tests/burn.rs
+++ b/token/program-2022-test/tests/burn.rs
@@ -42,17 +42,32 @@ async fn run_basic(context: TestContext) {
         .unwrap();
 
     // unchecked is ok
-    token.burn(&alice_account, &alice, 1).await.unwrap();
+    token
+        .burn(&alice_account, &alice.pubkey(), 1, None, &vec![&alice])
+        .await
+        .unwrap();
 
     // checked is ok
     token
-        .burn_checked(&alice_account, &alice, 1, decimals)
+        .burn(
+            &alice_account,
+            &alice.pubkey(),
+            1,
+            Some(decimals),
+            &vec![&alice],
+        )
         .await
         .unwrap();
 
     // burn too much is not ok
     let error = token
-        .burn_checked(&alice_account, &alice, amount, decimals)
+        .burn(
+            &alice_account,
+            &alice.pubkey(),
+            amount,
+            Some(decimals),
+            &vec![&alice],
+        )
         .await
         .unwrap_err();
     assert_eq!(
@@ -67,7 +82,13 @@ async fn run_basic(context: TestContext) {
 
     // wrong signer
     let error = token
-        .burn_checked(&alice_account, &bob, 1, decimals)
+        .burn(
+            &alice_account,
+            &bob.pubkey(),
+            1,
+            Some(decimals),
+            &vec![&bob],
+        )
         .await
         .unwrap_err();
     assert_eq!(
@@ -131,11 +152,20 @@ async fn run_self_owned(context: TestContext) {
         .unwrap();
 
     // unchecked is ok
-    token.burn(&alice_account, &alice, 1).await.unwrap();
+    token
+        .burn(&alice_account, &alice.pubkey(), 1, None, &vec![&alice])
+        .await
+        .unwrap();
 
     // checked is ok
     token
-        .burn_checked(&alice_account, &alice, 1, decimals)
+        .burn(
+            &alice_account,
+            &alice.pubkey(),
+            1,
+            Some(decimals),
+            &vec![&alice],
+        )
         .await
         .unwrap();
 }
@@ -223,7 +253,13 @@ async fn run_burn_and_close_system_or_incinerator(context: TestContext, non_owne
 
     // but anyone can burn it
     token
-        .burn_checked(&non_owner_account, &carlos, 1, decimals)
+        .burn(
+            &non_owner_account,
+            &carlos.pubkey(),
+            1,
+            Some(decimals),
+            &vec![&carlos],
+        )
         .await
         .unwrap();
 

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -134,7 +134,13 @@ impl ConfidentialTokenAccountMeta {
         let meta = Self::new(token, owner).await;
 
         token
-            .mint_to(&meta.token_account, mint_authority, amount)
+            .mint_to(
+                &meta.token_account,
+                &mint_authority.pubkey(),
+                amount,
+                Some(decimals),
+                &vec![mint_authority],
+            )
             .await
             .unwrap();
 
@@ -447,7 +453,13 @@ async fn ct_deposit() {
     let alice_meta = ConfidentialTokenAccountMeta::new(&token, &alice).await;
 
     token
-        .mint_to(&alice_meta.token_account, &mint_authority, 65537)
+        .mint_to(
+            &alice_meta.token_account,
+            &mint_authority.pubkey(),
+            65537,
+            Some(decimals),
+            &vec![&mint_authority],
+        )
         .await
         .unwrap();
 

--- a/token/program-2022-test/tests/delegate.rs
+++ b/token/program-2022-test/tests/delegate.rs
@@ -67,7 +67,13 @@ async fn run_basic(
     // mint tokens
     let amount = 100;
     token
-        .mint_to(&alice_account, &mint_authority, amount)
+        .mint_to(
+            &alice_account,
+            &mint_authority.pubkey(),
+            amount,
+            Some(decimals),
+            &vec![&mint_authority],
+        )
         .await
         .unwrap();
 

--- a/token/program-2022-test/tests/delegate.rs
+++ b/token/program-2022-test/tests/delegate.rs
@@ -98,12 +98,13 @@ async fn run_basic(
 
     // transfer too much is not ok
     let error = token
-        .transfer_checked(
+        .transfer(
             &alice_account,
             &bob_account,
-            &bob,
+            &bob.pubkey(),
             delegated_amount + 1,
-            decimals,
+            Some(decimals),
+            &vec![&bob],
         )
         .await
         .unwrap_err();
@@ -120,13 +121,27 @@ async fn run_basic(
     // transfer is ok
     if transfer_mode == TransferMode::All {
         token
-            .transfer_unchecked(&alice_account, &bob_account, &bob, 1)
+            .transfer(
+                &alice_account,
+                &bob_account,
+                &bob.pubkey(),
+                1,
+                None,
+                &vec![&bob],
+            )
             .await
             .unwrap();
     }
 
     token
-        .transfer_checked(&alice_account, &bob_account, &bob, 1, decimals)
+        .transfer(
+            &alice_account,
+            &bob_account,
+            &bob.pubkey(),
+            1,
+            Some(decimals),
+            &vec![&bob],
+        )
         .await
         .unwrap();
 
@@ -147,8 +162,16 @@ async fn run_basic(
         .unwrap();
 
     // wrong signer
+    let keypair = &Keypair::new();
     let error = token
-        .transfer_checked(&alice_account, &bob_account, &Keypair::new(), 1, decimals)
+        .transfer(
+            &alice_account,
+            &bob_account,
+            &keypair.pubkey(),
+            1,
+            Some(decimals),
+            &vec![keypair],
+        )
         .await
         .unwrap_err();
     assert_eq!(
@@ -166,7 +189,14 @@ async fn run_basic(
 
     // now fails
     let error = token
-        .transfer_checked(&alice_account, &bob_account, &bob, 2, decimals)
+        .transfer(
+            &alice_account,
+            &bob_account,
+            &bob.pubkey(),
+            2,
+            Some(decimals),
+            &vec![&bob],
+        )
         .await
         .unwrap_err();
     assert_eq!(

--- a/token/program-2022-test/tests/delegate.rs
+++ b/token/program-2022-test/tests/delegate.rs
@@ -131,9 +131,18 @@ async fn run_basic(
         .unwrap();
 
     // burn is ok
-    token.burn(&alice_account, &bob, 1).await.unwrap();
     token
-        .burn_checked(&alice_account, &bob, 1, decimals)
+        .burn(&alice_account, &bob.pubkey(), 1, None, &vec![&bob])
+        .await
+        .unwrap();
+    token
+        .burn(
+            &alice_account,
+            &bob.pubkey(),
+            1,
+            Some(decimals),
+            &vec![&bob],
+        )
         .await
         .unwrap();
 

--- a/token/program-2022-test/tests/delegate.rs
+++ b/token/program-2022-test/tests/delegate.rs
@@ -81,16 +81,24 @@ async fn run_basic(
     let delegated_amount = 10;
     match approve_mode {
         ApproveMode::Unchecked => token
-            .approve(&alice_account, &bob.pubkey(), &alice, delegated_amount)
+            .approve(
+                &alice_account,
+                &bob.pubkey(),
+                &alice.pubkey(),
+                delegated_amount,
+                None,
+                &vec![&alice],
+            )
             .await
             .unwrap(),
         ApproveMode::Checked => token
-            .approve_checked(
+            .approve(
                 &alice_account,
                 &bob.pubkey(),
-                &alice,
+                &alice.pubkey(),
                 delegated_amount,
-                decimals,
+                Some(decimals),
+                &vec![&alice],
             )
             .await
             .unwrap(),
@@ -185,7 +193,10 @@ async fn run_basic(
     );
 
     // revoke
-    token.revoke(&alice_account, &alice).await.unwrap();
+    token
+        .revoke(&alice_account, &alice.pubkey(), &vec![&alice])
+        .await
+        .unwrap();
 
     // now fails
     let error = token

--- a/token/program-2022-test/tests/freeze.rs
+++ b/token/program-2022-test/tests/freeze.rs
@@ -29,14 +29,22 @@ async fn basic() {
     assert_eq!(state.base.state, AccountState::Initialized);
 
     token
-        .freeze_account(&account, &freeze_authority)
+        .freeze(
+            &account,
+            &freeze_authority.pubkey(),
+            &vec![&freeze_authority],
+        )
         .await
         .unwrap();
     let state = token.get_account_info(&account).await.unwrap();
     assert_eq!(state.base.state, AccountState::Frozen);
 
     token
-        .thaw_account(&account, &freeze_authority)
+        .thaw(
+            &account,
+            &freeze_authority.pubkey(),
+            &vec![&freeze_authority],
+        )
         .await
         .unwrap();
     let state = token.get_account_info(&account).await.unwrap();

--- a/token/program-2022-test/tests/memo_transfer.rs
+++ b/token/program-2022-test/tests/memo_transfer.rs
@@ -62,7 +62,14 @@ async fn test_memo_transfers(
 
     // attempt to transfer from alice to bob without memo
     let err = token
-        .transfer_unchecked(&alice_account, &bob_account, &alice, 10)
+        .transfer(
+            &alice_account,
+            &bob_account,
+            &alice.pubkey(),
+            10,
+            None,
+            &vec![&alice],
+        )
         .await
         .unwrap_err();
     assert_eq!(
@@ -125,7 +132,14 @@ async fn test_memo_transfers(
     // transfer with memo
     token
         .with_memo("🦖")
-        .transfer_unchecked(&alice_account, &bob_account, &alice, 10)
+        .transfer(
+            &alice_account,
+            &bob_account,
+            &alice.pubkey(),
+            10,
+            None,
+            &vec![&alice],
+        )
         .await
         .unwrap();
     let bob_state = token.get_account_info(&bob_account).await.unwrap();
@@ -166,7 +180,14 @@ async fn test_memo_transfers(
 
     // transfer from alice to bob without memo
     token
-        .transfer_unchecked(&alice_account, &bob_account, &alice, 12)
+        .transfer(
+            &alice_account,
+            &bob_account,
+            &alice.pubkey(),
+            12,
+            None,
+            &vec![&alice],
+        )
         .await
         .unwrap();
     let bob_state = token.get_account_info(&bob_account).await.unwrap();

--- a/token/program-2022-test/tests/memo_transfer.rs
+++ b/token/program-2022-test/tests/memo_transfer.rs
@@ -30,6 +30,7 @@ async fn test_memo_transfers(
     bob_account: Pubkey,
 ) {
     let TokenContext {
+        decimals,
         mint_authority,
         token,
         alice,
@@ -39,7 +40,13 @@ async fn test_memo_transfers(
 
     // mint tokens
     token
-        .mint_to(&alice_account, &mint_authority, 4242)
+        .mint_to(
+            &alice_account,
+            &mint_authority.pubkey(),
+            4242,
+            Some(decimals),
+            &vec![&mint_authority],
+        )
         .await
         .unwrap();
 

--- a/token/program-2022-test/tests/mint_close_authority.rs
+++ b/token/program-2022-test/tests/mint_close_authority.rs
@@ -244,6 +244,7 @@ async fn fail_close_with_supply() {
         .await
         .unwrap();
     let TokenContext {
+        decimals,
         mint_authority,
         token,
         ..
@@ -256,7 +257,16 @@ async fn fail_close_with_supply() {
         .create_auxiliary_token_account(&account, &owner)
         .await
         .unwrap();
-    token.mint_to(&account, &mint_authority, 1).await.unwrap();
+    token
+        .mint_to(
+            &account,
+            &mint_authority.pubkey(),
+            1,
+            Some(decimals),
+            &vec![&mint_authority],
+        )
+        .await
+        .unwrap();
 
     // fail close
     let destination = Pubkey::new_unique();

--- a/token/program-2022-test/tests/transfer.rs
+++ b/token/program-2022-test/tests/transfer.rs
@@ -42,7 +42,13 @@ async fn run_basic_transfers(context: TestContext, test_mode: TestMode) {
     // mint a token
     let amount = 10;
     token
-        .mint_to(&alice_account, &mint_authority, amount)
+        .mint_to(
+            &alice_account,
+            &mint_authority.pubkey(),
+            amount,
+            Some(decimals),
+            &vec![&mint_authority],
+        )
         .await
         .unwrap();
 
@@ -131,7 +137,13 @@ async fn run_self_transfers(context: TestContext, test_mode: TestMode) {
     // mint a token
     let amount = 10;
     token
-        .mint_to(&alice_account, &mint_authority, amount)
+        .mint_to(
+            &alice_account,
+            &mint_authority.pubkey(),
+            amount,
+            Some(decimals),
+            &vec![&mint_authority],
+        )
         .await
         .unwrap();
 
@@ -208,7 +220,13 @@ async fn run_self_owned(context: TestContext, test_mode: TestMode) {
     // mint a token
     let amount = 10;
     token
-        .mint_to(&alice_account, &mint_authority, amount)
+        .mint_to(
+            &alice_account,
+            &mint_authority.pubkey(),
+            amount,
+            Some(decimals),
+            &vec![&mint_authority],
+        )
         .await
         .unwrap();
 
@@ -282,7 +300,13 @@ async fn transfer_with_fee_on_mint_without_fee_configured() {
     // mint some tokens
     let amount = 10;
     token
-        .mint_to(&alice_account, &mint_authority, amount)
+        .mint_to(
+            &alice_account,
+            &mint_authority.pubkey(),
+            amount,
+            Some(decimals),
+            &vec![&mint_authority],
+        )
         .await
         .unwrap();
 

--- a/token/program-2022-test/tests/transfer.rs
+++ b/token/program-2022-test/tests/transfer.rs
@@ -55,20 +55,41 @@ async fn run_basic_transfers(context: TestContext, test_mode: TestMode) {
     if test_mode == TestMode::All {
         // unchecked is ok
         token
-            .transfer_unchecked(&alice_account, &bob_account, &alice, 1)
+            .transfer(
+                &alice_account,
+                &bob_account,
+                &alice.pubkey(),
+                1,
+                None,
+                &vec![&alice],
+            )
             .await
             .unwrap();
     }
 
     // checked is ok
     token
-        .transfer_checked(&alice_account, &bob_account, &alice, 1, decimals)
+        .transfer(
+            &alice_account,
+            &bob_account,
+            &alice.pubkey(),
+            1,
+            Some(decimals),
+            &vec![&alice],
+        )
         .await
         .unwrap();
 
     // transfer too much is not ok
     let error = token
-        .transfer_checked(&alice_account, &bob_account, &alice, amount, decimals)
+        .transfer(
+            &alice_account,
+            &bob_account,
+            &alice.pubkey(),
+            amount,
+            Some(decimals),
+            &vec![&alice],
+        )
         .await
         .unwrap_err();
     assert_eq!(
@@ -83,7 +104,14 @@ async fn run_basic_transfers(context: TestContext, test_mode: TestMode) {
 
     // wrong signer
     let error = token
-        .transfer_checked(&alice_account, &bob_account, &bob, 1, decimals)
+        .transfer(
+            &alice_account,
+            &bob_account,
+            &bob.pubkey(),
+            1,
+            Some(decimals),
+            &vec![&bob],
+        )
         .await
         .unwrap_err();
     assert_eq!(
@@ -149,19 +177,40 @@ async fn run_self_transfers(context: TestContext, test_mode: TestMode) {
 
     // self transfer is ok
     token
-        .transfer_checked(&alice_account, &alice_account, &alice, 1, decimals)
+        .transfer(
+            &alice_account,
+            &alice_account,
+            &alice.pubkey(),
+            1,
+            Some(decimals),
+            &vec![&alice],
+        )
         .await
         .unwrap();
     if test_mode == TestMode::All {
         token
-            .transfer_unchecked(&alice_account, &alice_account, &alice, 1)
+            .transfer(
+                &alice_account,
+                &alice_account,
+                &alice.pubkey(),
+                1,
+                None,
+                &vec![&alice],
+            )
             .await
             .unwrap();
     }
 
     // too much self transfer is not ok
     let error = token
-        .transfer_checked(&alice_account, &alice_account, &alice, amount + 1, decimals)
+        .transfer(
+            &alice_account,
+            &alice_account,
+            &alice.pubkey(),
+            amount + 1,
+            Some(decimals),
+            &vec![&alice],
+        )
         .await
         .unwrap_err();
     assert_eq!(
@@ -233,20 +282,41 @@ async fn run_self_owned(context: TestContext, test_mode: TestMode) {
     if test_mode == TestMode::All {
         // unchecked is ok
         token
-            .transfer_unchecked(&alice_account, &bob_account, &alice, 1)
+            .transfer(
+                &alice_account,
+                &bob_account,
+                &alice.pubkey(),
+                1,
+                None,
+                &vec![&alice],
+            )
             .await
             .unwrap();
     }
 
     // checked is ok
     token
-        .transfer_checked(&alice_account, &bob_account, &alice, 1, decimals)
+        .transfer(
+            &alice_account,
+            &bob_account,
+            &alice.pubkey(),
+            1,
+            Some(decimals),
+            &vec![&alice],
+        )
         .await
         .unwrap();
 
     // self transfer is ok
     token
-        .transfer_checked(&alice_account, &alice_account, &alice, 1, decimals)
+        .transfer(
+            &alice_account,
+            &alice_account,
+            &alice.pubkey(),
+            1,
+            Some(decimals),
+            &vec![&alice],
+        )
         .await
         .unwrap();
 }
@@ -312,13 +382,29 @@ async fn transfer_with_fee_on_mint_without_fee_configured() {
 
     // success if expected fee is 0
     token
-        .transfer_checked_with_fee(&alice_account, &bob_account, &alice, 1, decimals, 0)
+        .transfer_with_fee(
+            &alice_account,
+            &bob_account,
+            &alice.pubkey(),
+            1,
+            decimals,
+            0,
+            &vec![&alice],
+        )
         .await
         .unwrap();
 
     // fail for anything else
     let error = token
-        .transfer_checked_with_fee(&alice_account, &bob_account, &alice, 2, decimals, 1)
+        .transfer_with_fee(
+            &alice_account,
+            &bob_account,
+            &alice.pubkey(),
+            2,
+            decimals,
+            1,
+            &vec![&alice],
+        )
         .await
         .unwrap_err();
     assert_eq!(

--- a/token/program-2022-test/tests/transfer_fee.rs
+++ b/token/program-2022-test/tests/transfer_fee.rs
@@ -799,7 +799,14 @@ async fn transfer_checked() {
 
     // fail unchecked always
     let error = token
-        .transfer_unchecked(&alice_account, &bob_account, &alice, maximum_fee)
+        .transfer(
+            &alice_account,
+            &bob_account,
+            &alice.pubkey(),
+            maximum_fee,
+            None,
+            &vec![&alice],
+        )
         .await
         .unwrap_err();
     assert_eq!(
@@ -814,12 +821,13 @@ async fn transfer_checked() {
 
     // fail because amount too high
     let error = token
-        .transfer_checked(
+        .transfer(
             &alice_account,
             &bob_account,
-            &alice,
+            &alice.pubkey(),
             alice_amount + 1,
-            decimals,
+            Some(decimals),
+            &vec![&alice],
         )
         .await
         .unwrap_err();
@@ -841,7 +849,14 @@ async fn transfer_checked() {
         .calculate_epoch_fee(0, maximum_fee)
         .unwrap();
     token
-        .transfer_checked(&alice_account, &bob_account, &alice, maximum_fee, decimals)
+        .transfer(
+            &alice_account,
+            &bob_account,
+            &alice.pubkey(),
+            maximum_fee,
+            Some(decimals),
+            &vec![&alice],
+        )
         .await
         .unwrap();
     alice_amount -= maximum_fee;
@@ -863,12 +878,13 @@ async fn transfer_checked() {
         .calculate_epoch_fee(0, transfer_amount)
         .unwrap();
     token
-        .transfer_checked(
+        .transfer(
             &alice_account,
             &bob_account,
-            &alice,
+            &alice.pubkey(),
             transfer_amount,
-            decimals,
+            Some(decimals),
+            &vec![&alice],
         )
         .await
         .unwrap();
@@ -896,12 +912,13 @@ async fn transfer_checked() {
         .unwrap();
     assert_eq!(fee, maximum_fee); // sanity
     token
-        .transfer_checked(
+        .transfer(
             &alice_account,
             &bob_account,
-            &alice,
+            &alice.pubkey(),
             transfer_amount,
-            decimals,
+            Some(decimals),
+            &vec![&alice],
         )
         .await
         .unwrap();
@@ -919,12 +936,13 @@ async fn transfer_checked() {
 
     // transfer down to 1 token
     token
-        .transfer_checked(
+        .transfer(
             &alice_account,
             &bob_account,
-            &alice,
+            &alice.pubkey(),
             alice_amount - 1,
-            decimals,
+            Some(decimals),
+            &vec![&alice],
         )
         .await
         .unwrap();
@@ -942,7 +960,14 @@ async fn transfer_checked() {
 
     // final transfer, only move tokens to withheld amount, nothing received
     token
-        .transfer_checked(&alice_account, &bob_account, &alice, 1, decimals)
+        .transfer(
+            &alice_account,
+            &bob_account,
+            &alice.pubkey(),
+            1,
+            Some(decimals),
+            &vec![&alice],
+        )
         .await
         .unwrap();
     withheld_amount += 1;
@@ -977,13 +1002,14 @@ async fn transfer_checked_with_fee() {
         .unwrap()
         + 1;
     let error = token
-        .transfer_checked_with_fee(
+        .transfer_with_fee(
             &alice_account,
             &bob_account,
-            &alice,
+            &alice.pubkey(),
             transfer_amount,
             decimals,
             fee,
+            &vec![&alice],
         )
         .await
         .unwrap_err();
@@ -1003,13 +1029,14 @@ async fn transfer_checked_with_fee() {
         .unwrap()
         - 1;
     let error = token
-        .transfer_checked_with_fee(
+        .transfer_with_fee(
             &alice_account,
             &bob_account,
-            &alice,
+            &alice.pubkey(),
             transfer_amount,
             decimals,
             fee,
+            &vec![&alice],
         )
         .await
         .unwrap_err();
@@ -1029,13 +1056,14 @@ async fn transfer_checked_with_fee() {
         .unwrap()
         - 1;
     let error = token
-        .transfer_checked_with_fee(
+        .transfer_with_fee(
             &alice_account,
             &bob_account,
-            &alice,
+            &alice.pubkey(),
             alice_amount + 1,
             decimals,
             fee,
+            &vec![&alice],
         )
         .await
         .unwrap_err();
@@ -1054,13 +1082,14 @@ async fn transfer_checked_with_fee() {
         .calculate_epoch_fee(0, transfer_amount)
         .unwrap();
     token
-        .transfer_checked_with_fee(
+        .transfer_with_fee(
             &alice_account,
             &bob_account,
-            &alice,
+            &alice.pubkey(),
             transfer_amount,
             decimals,
             fee,
+            &vec![&alice],
         )
         .await
         .unwrap();
@@ -1090,13 +1119,14 @@ async fn no_fees_from_self_transfer() {
     // self transfer, no fee assessed
     let fee = transfer_fee_config.calculate_epoch_fee(0, amount).unwrap();
     token
-        .transfer_checked_with_fee(
+        .transfer_with_fee(
             &alice_account,
             &alice_account,
-            &alice,
+            &alice.pubkey(),
             amount,
             decimals,
             fee,
+            &vec![&alice],
         )
         .await
         .unwrap();
@@ -1119,7 +1149,14 @@ async fn create_and_transfer_to_account(
         .await
         .unwrap();
     token
-        .transfer_checked(source, &account, authority, amount, decimals)
+        .transfer(
+            source,
+            &account,
+            &authority.pubkey(),
+            amount,
+            Some(decimals),
+            &vec![authority],
+        )
         .await
         .unwrap();
     account
@@ -1628,7 +1665,14 @@ async fn fail_close_with_withheld() {
     // empty the account
     let fee = transfer_fee_config.calculate_epoch_fee(0, amount).unwrap();
     token
-        .transfer_checked(&account, &alice_account, &alice, amount - fee, decimals)
+        .transfer(
+            &account,
+            &alice_account,
+            &alice.pubkey(),
+            amount - fee,
+            Some(decimals),
+            &vec![&alice],
+        )
         .await
         .unwrap();
 

--- a/token/program-2022-test/tests/transfer_fee.rs
+++ b/token/program-2022-test/tests/transfer_fee.rs
@@ -1430,7 +1430,11 @@ async fn withdraw_withheld_tokens_from_mint() {
     )
     .await;
     token
-        .freeze_account(&account, &freeze_authority)
+        .freeze(
+            &account,
+            &freeze_authority.pubkey(),
+            &vec![&freeze_authority],
+        )
         .await
         .unwrap();
     let error = token

--- a/token/program-2022-test/tests/transfer_fee.rs
+++ b/token/program-2022-test/tests/transfer_fee.rs
@@ -130,7 +130,13 @@ async fn create_mint_with_accounts(alice_amount: u64) -> TokenWithAccounts {
 
     // mint tokens
     token
-        .mint_to(&alice_account, &mint_authority, alice_amount)
+        .mint_to(
+            &alice_account,
+            &mint_authority.pubkey(),
+            alice_amount,
+            Some(decimals),
+            &vec![&mint_authority],
+        )
         .await
         .unwrap();
     TokenWithAccounts {


### PR DESCRIPTION
part of #3482. i started with `mint_to`, will also do `burn` and `transfer` since we discussed unifying the client interface of those to take `decimals: Option<u8>` and get rid of checked/unchecked variants

i dunno if im gonna do all the cli stuff but this will provide a blueprint at least as for what the changes need to look like. in short:
* the `S` on a client method type signature changes from `Signer` to `Signers`
* `authority` param changes from `&S` to `&Pubkey`
* methods take an additional param `signing_keypairs: &S`
* `get_multisig_signers` is called up top to gather pubkeys to mark as signers on token instructions
* return types change to `TokenResult<T::Output>` if not already, to enable returning signatures or (possibly partially) signed transactions
* cli flow changes, generally to:
  - create token client with `token_client_from_config`
  - call relevant token client method
  - produce `tx_return` from this result with `finish_tx`, removing all instruction creation logic and `handle_tx`
  - `match` on `tx_return` to produce user output remains unchanged
* update tests in `client/tests/` and `program-2022-tests/tests/` for the client interface change

remembering that in our bright future we are not the only consumer of the token client so its interface should remain suitable for general use