### PR TITLE
bump token-cli to 2.0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6262,7 +6262,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-cli"
-version = "2.0.16"
+version = "2.0.17"
 dependencies = [
  "assert_cmd",
  "clap 2.34.0",

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://spl.solana.com/token"
 license = "Apache-2.0"
 name = "spl-token-cli"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "2.0.16"
+version = "2.0.17"
 
 [build-dependencies]
 walkdir = "2"


### PR DESCRIPTION
release has already been made and lives in the `token-cli-v2.0.17-branch` branch