### PR TITLE
ci: Update rust-nightly to 2022-04-01

### DIFF
--- a/ci/fuzz.sh
+++ b/ci/fuzz.sh
@@ -28,7 +28,7 @@ fi
 # Temporary workaround using RUSTFLAGS and rust nightly due to:
 # https://github.com/rust-fuzz/honggfuzz-rs/issues/61
 # Once the issue is resolved, remove the RUSTFLAGS and nightly usage everywhere.
-RUSTFLAGS="-Znew-llvm-pass-manager=no" HFUZZ_RUN_ARGS="--run_time $run_time --exit_upon_crash" cargo +nightly-2022-02-24 hfuzz run $fuzz_target
+RUSTFLAGS="-Znew-llvm-pass-manager=no" HFUZZ_RUN_ARGS="--run_time $run_time --exit_upon_crash" cargo +"$rust_nightly" hfuzz run $fuzz_target
 
 # Until https://github.com/rust-fuzz/honggfuzz-rs/issues/16 is resolved,
 # hfuzz does not return an error code on crash, so look for a crash artifact

--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -26,7 +26,7 @@ fi
 if [[ -n $RUST_NIGHTLY_VERSION ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2022-02-24
+  nightly_version=2022-04-01
 fi
 
 export rust_stable="$stable_version"

--- a/stake-pool/program/src/state.rs
+++ b/stake-pool/program/src/state.rs
@@ -20,7 +20,7 @@ use {
     },
     spl_math::checked_ceil_div::CheckedCeilDiv,
     spl_token::state::{Account, AccountState},
-    std::{convert::TryFrom, fmt, matches},
+    std::{borrow::Borrow, convert::TryFrom, fmt, matches},
 };
 
 /// Enum representing the account type managed by the program
@@ -289,7 +289,7 @@ impl StakePool {
         &self,
         manager_fee_info: &AccountInfo,
     ) -> Result<(), ProgramError> {
-        let token_account = Account::unpack(&manager_fee_info.data.borrow())?;
+        let token_account = Account::unpack(&manager_fee_info.try_borrow_data()?)?;
         if manager_fee_info.owner != &self.token_program_id
             || token_account.state != AccountState::Initialized
             || token_account.mint != self.pool_mint
@@ -684,7 +684,7 @@ impl ValidatorListHeader {
 
     /// Extracts the validator list into its header and internal BigVec
     pub fn deserialize_vec(data: &mut [u8]) -> Result<(Self, BigVec), ProgramError> {
-        let mut data_mut = &data[..];
+        let mut data_mut = data.borrow();
         let header = ValidatorListHeader::deserialize(&mut data_mut)?;
         let length = get_instance_packed_len(&header)?;
 


### PR DESCRIPTION
#### Problem

SPL was upgraded  to Rust 1.60, but nightly is still on 2022-02-24.

#### Solution

Bring them in line with the monorepo, and upgrade rust nightly to 2022-04-01.  There was only one additional nit to fix.