### PR TITLE
confidential-extension: Restrict deposit source and withdraw dest to base accounts

### DIFF
--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -1426,30 +1426,27 @@ where
     #[allow(clippy::too_many_arguments)]
     pub async fn confidential_transfer_withdraw<S: Signer>(
         &self,
-        source_token_account: &Pubkey,
-        destination_token_account: &Pubkey,
-        source_token_authority: &S,
+        token_account: &Pubkey,
+        token_authority: &S,
         amount: u64,
-        source_available_balance: u64,
-        source_available_balance_ciphertext: &ElGamalCiphertext,
+        available_balance: u64,
+        available_balance_ciphertext: &ElGamalCiphertext,
         decimals: u8,
     ) -> TokenResult<T::Output> {
-        let source_elgamal_keypair =
-            ElGamalKeypair::new(source_token_authority, source_token_account)
-                .map_err(TokenError::Key)?;
-        let source_authenticated_encryption_key =
-            AeKey::new(source_token_authority, source_token_account).map_err(TokenError::Key)?;
+        let elgamal_keypair =
+            ElGamalKeypair::new(token_authority, token_account).map_err(TokenError::Key)?;
+        let authenticated_encryption_key =
+            AeKey::new(token_authority, token_account).map_err(TokenError::Key)?;
 
         self.confidential_transfer_withdraw_with_key(
-            source_token_account,
-            destination_token_account,
-            source_token_authority,
+            token_account,
+            token_authority,
             amount,
             decimals,
-            source_available_balance,
-            source_available_balance_ciphertext,
-            &source_elgamal_keypair,
-            &source_authenticated_encryption_key,
+            available_balance,
+            available_balance_ciphertext,
+            &elgamal_keypair,
+            &authenticated_encryption_key,
         )
         .await
     }
@@ -1459,44 +1456,42 @@ where
     #[allow(clippy::too_many_arguments)]
     pub async fn confidential_transfer_withdraw_with_key<S: Signer>(
         &self,
-        source_token_account: &Pubkey,
-        destination_token_account: &Pubkey,
-        source_token_authority: &S,
+        token_account: &Pubkey,
+        token_authority: &S,
         amount: u64,
         decimals: u8,
-        source_available_balance: u64,
-        source_available_balance_ciphertext: &ElGamalCiphertext,
-        source_elgamal_keypair: &ElGamalKeypair,
-        source_authenticated_encryption_key: &AeKey,
+        available_balance: u64,
+        available_balance_ciphertext: &ElGamalCiphertext,
+        elgamal_keypair: &ElGamalKeypair,
+        authenticated_encryption_key: &AeKey,
     ) -> TokenResult<T::Output> {
         let proof_data = confidential_transfer::instruction::WithdrawData::new(
             amount,
-            source_elgamal_keypair,
-            source_available_balance,
-            source_available_balance_ciphertext,
+            elgamal_keypair,
+            available_balance,
+            available_balance_ciphertext,
         )
         .map_err(TokenError::Proof)?;
 
-        let source_remaining_balance = source_available_balance
+        let remaining_balance = available_balance
             .checked_sub(amount)
             .ok_or(TokenError::NotEnoughFunds)?;
-        let new_source_decryptable_available_balance =
-            source_authenticated_encryption_key.encrypt(source_remaining_balance);
+        let new_decryptable_available_balance =
+            authenticated_encryption_key.encrypt(remaining_balance);
 
         self.process_ixs(
             &confidential_transfer::instruction::withdraw(
                 &self.program_id,
-                source_token_account,
-                destination_token_account,
+                token_account,
                 &self.pubkey,
                 amount,
                 decimals,
-                new_source_decryptable_available_balance,
-                &source_token_authority.pubkey(),
+                new_decryptable_available_balance,
+                &token_authority.pubkey(),
                 &[],
                 &proof_data,
             )?,
-            &[source_token_authority],
+            &[token_authority],
         )
         .await
     }

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -1397,9 +1397,8 @@ where
     /// Deposit SPL Tokens into the pending balance of a confidential token account
     pub async fn confidential_transfer_deposit<S: Signer>(
         &self,
-        source_token_account: &Pubkey,
-        destination_token_account: &Pubkey,
-        source_token_authority: &S,
+        token_account: &Pubkey,
+        token_authority: &S,
         amount: u64,
         decimals: u8,
     ) -> TokenResult<T::Output> {
@@ -1410,15 +1409,14 @@ where
         self.process_ixs(
             &[confidential_transfer::instruction::deposit(
                 &self.program_id,
-                source_token_account,
+                token_account,
                 &self.pubkey,
-                destination_token_account,
                 amount,
                 decimals,
-                &source_token_authority.pubkey(),
+                &token_authority.pubkey(),
                 &[],
             )?],
-            &[source_token_authority],
+            &[token_authority],
         )
         .await
     }

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -147,13 +147,7 @@ impl ConfidentialTokenAccountMeta {
             .unwrap();
 
         token
-            .confidential_transfer_deposit(
-                &meta.token_account,
-                &meta.token_account,
-                owner,
-                amount,
-                decimals,
-            )
+            .confidential_transfer_deposit(&meta.token_account, owner, amount, decimals)
             .await
             .unwrap();
 
@@ -490,13 +484,7 @@ async fn ct_deposit() {
     );
 
     token
-        .confidential_transfer_deposit(
-            &alice_meta.token_account,
-            &alice_meta.token_account,
-            &alice,
-            65537,
-            decimals,
-        )
+        .confidential_transfer_deposit(&alice_meta.token_account, &alice, 65537, decimals)
         .await
         .unwrap();
 
@@ -525,24 +513,12 @@ async fn ct_deposit() {
         .await;
 
     token
-        .confidential_transfer_deposit(
-            &alice_meta.token_account,
-            &alice_meta.token_account,
-            &alice,
-            0,
-            decimals,
-        )
+        .confidential_transfer_deposit(&alice_meta.token_account, &alice, 0, decimals)
         .await
         .unwrap();
 
     let err = token
-        .confidential_transfer_deposit(
-            &alice_meta.token_account,
-            &alice_meta.token_account,
-            &alice,
-            0,
-            decimals,
-        )
+        .confidential_transfer_deposit(&alice_meta.token_account, &alice, 0, decimals)
         .await
         .unwrap_err();
 
@@ -611,7 +587,6 @@ async fn ct_withdraw() {
     token
         .confidential_transfer_withdraw(
             &alice_meta.token_account,
-            &alice_meta.token_account,
             &alice,
             21,
             42,
@@ -644,7 +619,6 @@ async fn ct_withdraw() {
 
     token
         .confidential_transfer_withdraw(
-            &alice_meta.token_account,
             &alice_meta.token_account,
             &alice,
             21,

--- a/token/program-2022/src/error.rs
+++ b/token/program-2022/src/error.rs
@@ -156,6 +156,9 @@ pub enum TokenError {
             the associated `maximum_pending_balance_credit_counter`"
     )]
     MaximumPendingBalanceCreditCounterExceeded,
+    /// The deposit amount for the confidential extension exceeds the maximum limit
+    #[error("Deposit amount exceeds maximum limit")]
+    MaximumDepositAmountExceeded,
 }
 impl From<TokenError> for ProgramError {
     fn from(e: TokenError) -> Self {
@@ -267,6 +270,9 @@ impl PrintProgramError for TokenError {
             }
             TokenError::MaximumPendingBalanceCreditCounterExceeded => {
                 msg!("The total number of `Deposit` and `Transfer` instructions to an account cannot exceed the associated `maximum_pending_balance_credit_counter`");
+            }
+            TokenError::MaximumDepositAmountExceeded => {
+                msg!("Deposit amount exceeds maximum limit")
             }
         }
     }

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -160,17 +160,17 @@ pub enum ConfidentialTransferInstruction {
     /// Accounts expected by this instruction:
     ///
     ///   * Single owner/delegate
-    ///   1. `[writable]` The SPL Token account.
-    ///   2. `[]` The token mint.
-    ///   3. `[]` Instructions sysvar.
-    ///   4. `[signer]` The single source account owner.
+    ///   0. `[writable]` The SPL Token account.
+    ///   1. `[]` The token mint.
+    ///   2. `[]` Instructions sysvar.
+    ///   3. `[signer]` The single source account owner.
     ///
     ///   * Multisignature owner/delegate
-    ///   1. `[writable]` The SPL Token account.
-    ///   2. `[]` The token mint.
-    ///   3. `[]` Instructions sysvar.
-    ///   4. `[]` The multisig  source account owner.
-    ///   5.. `[signer]` Required M signer accounts for the SPL Token Multisig account.
+    ///   0. `[writable]` The SPL Token account.
+    ///   1. `[]` The token mint.
+    ///   2. `[]` Instructions sysvar.
+    ///   3. `[]` The multisig  source account owner.
+    ///   4.. `[signer]` Required M signer accounts for the SPL Token Multisig account.
     ///
     /// Data expected by this instruction:
     ///   `WithdrawInstructionData`

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -131,23 +131,25 @@ pub enum ConfidentialTransferInstruction {
     /// The account owner can then invoke the `ApplyPendingBalance` instruction to roll the deposit
     /// into their available balance at a time of their choosing.
     ///
+<<<<<<< HEAD
     /// Fails if the source or destination accounts are frozen.
     /// Fails if the associated mint is extended as `NonTransferable`.
+=======
+    /// Fails if the account is frozen.
+>>>>>>> 1668db8e (restrict deposit source account to base account)
     ///
     /// Accounts expected by this instruction:
     ///
     ///   * Single owner/delegate
-    ///   0. `[writable]` The source SPL Token account.
-    ///   1. `[writable]` The destination SPL Token account with confidential transfers configured.
-    ///   2. `[]` The token mint.
-    ///   3. `[signer]` The single source account owner or delegate.
+    ///   0. `[writable]` The SPL Token account.
+    ///   1. `[]` The token mint.
+    ///   2. `[signer]` The single account owner or delegate.
     ///
     ///   * Multisignature owner/delegate
-    ///   0. `[writable]` The source SPL Token account.
-    ///   1. `[writable]` The destination SPL Token account with confidential transfers configured.
-    ///   2. `[]` The token mint.
-    ///   3. `[]` The multisig source account owner or delegate.
-    ///   4.. `[signer]` Required M signer accounts for the SPL Token Multisig account.
+    ///   0. `[writable]` The SPL Token account.
+    ///   1. `[]` The token mint.
+    ///   2. `[]` The multisig account owner or delegate.
+    ///   3.. `[signer]` Required M signer accounts for the SPL Token Multisig account.
     ///
     /// Data expected by this instruction:
     ///   `DepositInstructionData`
@@ -622,9 +624,8 @@ pub fn empty_account(
 #[allow(clippy::too_many_arguments)]
 pub fn deposit(
     token_program_id: &Pubkey,
-    source_token_account: &Pubkey,
+    token_account: &Pubkey,
     mint: &Pubkey,
-    destination_token_account: &Pubkey,
     amount: u64,
     decimals: u8,
     authority: &Pubkey,
@@ -632,8 +633,7 @@ pub fn deposit(
 ) -> Result<Instruction, ProgramError> {
     check_program_account(token_program_id)?;
     let mut accounts = vec![
-        AccountMeta::new(*source_token_account, false),
-        AccountMeta::new(*destination_token_account, false),
+        AccountMeta::new(*token_account, false),
         AccountMeta::new_readonly(*mint, false),
         AccountMeta::new_readonly(*authority, multisig_signers.is_empty()),
     ];

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -131,12 +131,8 @@ pub enum ConfidentialTransferInstruction {
     /// The account owner can then invoke the `ApplyPendingBalance` instruction to roll the deposit
     /// into their available balance at a time of their choosing.
     ///
-<<<<<<< HEAD
     /// Fails if the source or destination accounts are frozen.
     /// Fails if the associated mint is extended as `NonTransferable`.
-=======
-    /// Fails if the account is frozen.
->>>>>>> 1668db8e (restrict deposit source account to base account)
     ///
     /// Accounts expected by this instruction:
     ///
@@ -164,15 +160,13 @@ pub enum ConfidentialTransferInstruction {
     /// Accounts expected by this instruction:
     ///
     ///   * Single owner/delegate
-    ///   0. `[writable]` The source SPL Token account with confidential transfers configured.
-    ///   1. `[writable]` The destination SPL Token account.
+    ///   1. `[writable]` The SPL Token account.
     ///   2. `[]` The token mint.
     ///   3. `[]` Instructions sysvar.
     ///   4. `[signer]` The single source account owner.
     ///
     ///   * Multisignature owner/delegate
-    ///   0. `[writable]` The source SPL Token account with confidential transfers configured.
-    ///   1. `[writable]` The destination SPL Token account.
+    ///   1. `[writable]` The SPL Token account.
     ///   2. `[]` The token mint.
     ///   3. `[]` Instructions sysvar.
     ///   4. `[]` The multisig  source account owner.
@@ -660,8 +654,7 @@ pub fn deposit(
 #[allow(clippy::too_many_arguments)]
 pub fn inner_withdraw(
     token_program_id: &Pubkey,
-    source_token_account: &Pubkey,
-    destination_token_account: &Pubkey,
+    token_account: &Pubkey,
     mint: &Pubkey,
     amount: u64,
     decimals: u8,
@@ -672,8 +665,7 @@ pub fn inner_withdraw(
 ) -> Result<Instruction, ProgramError> {
     check_program_account(token_program_id)?;
     let mut accounts = vec![
-        AccountMeta::new(*source_token_account, false),
-        AccountMeta::new(*destination_token_account, false),
+        AccountMeta::new(*token_account, false),
         AccountMeta::new_readonly(*mint, false),
         AccountMeta::new_readonly(sysvar::instructions::id(), false),
         AccountMeta::new_readonly(*authority, multisig_signers.is_empty()),
@@ -702,8 +694,7 @@ pub fn inner_withdraw(
 #[cfg(not(target_os = "solana"))]
 pub fn withdraw(
     token_program_id: &Pubkey,
-    source_token_account: &Pubkey,
-    destination_token_account: &Pubkey,
+    token_account: &Pubkey,
     mint: &Pubkey,
     amount: u64,
     decimals: u8,
@@ -716,8 +707,7 @@ pub fn withdraw(
         verify_withdraw(proof_data),
         inner_withdraw(
             token_program_id,
-            source_token_account,
-            destination_token_account,
+            token_account,
             mint,
             amount,
             decimals,

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -267,7 +267,6 @@ fn process_deposit(
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
     let token_account_info = next_account_info(account_info_iter)?;
-    // let destination_token_account_info = next_account_info(account_info_iter)?;
     let mint_info = next_account_info(account_info_iter)?;
     let authority_info = next_account_info(account_info_iter)?;
     let authority_info_data_len = authority_info.data_len();


### PR DESCRIPTION
Currently, the deposit source and withdraw destination accounts for the confidential extension instructions can differ from the base account for the extension, which can act as an alternate way to transfer tokens (issue [#3519](https://github.com/solana-labs/solana-program-library/issues/3519)). 

Summary:
- limit the deposit source and withdraw destination accounts to base accounts only
- limit deposit amounts to a 48-bit number