### PR TITLE
confidential-extension: forbid confidential transfer if nontransferable mint

### DIFF
--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -132,6 +132,7 @@ pub enum ConfidentialTransferInstruction {
     /// into their available balance at a time of their choosing.
     ///
     /// Fails if the source or destination accounts are frozen.
+    /// Fails if the associated mint is extended as `NonTransferable`.
     ///
     /// Accounts expected by this instruction:
     ///
@@ -156,6 +157,7 @@ pub enum ConfidentialTransferInstruction {
     /// Withdraw SPL Tokens from the available balance of a confidential token account.
     ///
     /// Fails if the source or destination accounts are frozen.
+    /// Fails if the associated mint is extended as `NonTransferable`.
     ///
     /// Accounts expected by this instruction:
     ///

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -181,6 +181,8 @@ pub enum ConfidentialTransferInstruction {
 
     /// Transfer tokens confidentially.
     ///
+    /// Fails if the associated mint is extended as `NonTransferable`.
+    ///
     ///   * Single owner/delegate
     ///   1. `[writable]` The source SPL Token account.
     ///   2. `[writable]` The destination SPL Token account.

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -280,6 +280,10 @@ fn process_deposit(
         return Err(TokenError::MintDecimalsMismatch.into());
     }
 
+    if mint.get_extension::<NonTransferable>().is_ok() {
+        return Err(TokenError::NonTransferable.into());
+    }
+
     // Process source account
     {
         check_program_account(token_account_info.owner)?;
@@ -397,6 +401,10 @@ fn process_withdraw(
 
     if expected_decimals != mint.base.decimals {
         return Err(TokenError::MintDecimalsMismatch.into());
+    }
+
+    if mint.get_extension::<NonTransferable>().is_ok() {
+        return Err(TokenError::NonTransferable.into());
     }
 
     let previous_instruction =

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -4,6 +4,7 @@ use {
         error::TokenError,
         extension::{
             confidential_transfer::{instruction::*, *},
+            non_transferable::NonTransferable,
             StateWithExtensions, StateWithExtensionsMut,
         },
         instruction::{decode_instruction_data, decode_instruction_type},
@@ -495,8 +496,12 @@ fn process_transfer(
     check_program_account(mint_info.owner)?;
     let mint_data = &mint_info.data.borrow_mut();
     let mint = StateWithExtensions::<Mint>::unpack(mint_data)?;
-    let confidential_transfer_mint = mint.get_extension::<ConfidentialTransferMint>()?;
 
+    if mint.get_extension::<NonTransferable>().is_ok() {
+        return Err(TokenError::NonTransferable.into());
+    }
+
+    let confidential_transfer_mint = mint.get_extension::<ConfidentialTransferMint>()?;
     let previous_instruction =
         get_instruction_relative(proof_instruction_offset, instructions_sysvar_info)?;
 


### PR DESCRIPTION
Currently, confidential transfers are still possible even if the mint is a `NonTransferable`. This pr adds a check for `NonTransferable` in the confidential transfer processor.