### PR TITLE
Token JS, Memo JS: add eslint-plugin-require-extensions

### DIFF
--- a/memo/js/.eslintrc
+++ b/memo/js/.eslintrc
@@ -3,12 +3,14 @@
     "extends": [
         "eslint:recommended",
         "plugin:@typescript-eslint/recommended",
-        "plugin:prettier/recommended"
+        "plugin:prettier/recommended",
+        "plugin:require-extensions/recommended"
     ],
     "parser": "@typescript-eslint/parser",
     "plugins": [
         "@typescript-eslint",
-        "prettier"
+        "prettier",
+        "require-extensions"
     ],
     "rules": {
         "@typescript-eslint/ban-ts-comment": "off",
@@ -16,5 +18,15 @@
         "@typescript-eslint/no-unused-vars": "off",
         "@typescript-eslint/no-empty-interface": "off",
         "@typescript-eslint/consistent-type-imports": "error"
-    }
+    },
+    "overrides": [
+        {
+            "files": [
+                "test/**/*"
+            ],
+            "rules": {
+                "require-extensions/require-extensions": "off"
+            }
+        }
+    ]
 }

--- a/memo/js/package-lock.json
+++ b/memo/js/package-lock.json
@@ -24,6 +24,7 @@
                 "eslint": "^8.20.0",
                 "eslint-config-prettier": "^8.5.0",
                 "eslint-plugin-prettier": "^4.2.1",
+                "eslint-plugin-require-extensions": "^0.1.1",
                 "gh-pages": "^3.2.3",
                 "jest": "^28.1.3",
                 "prettier": "^2.7.1",
@@ -6383,6 +6384,18 @@
                 "eslint-config-prettier": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/eslint-plugin-require-extensions": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-require-extensions/-/eslint-plugin-require-extensions-0.1.1.tgz",
+            "integrity": "sha512-qSF0vPCxFck0ady5QmPc57ehGbJkqNBXFaBOrGD6XoLFckLdxxraNVj9P4JOxa9AefIhsLJVe3YMGBhrg4bG0A==",
+            "dev": true,
+            "engines": {
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "eslint": "*"
             }
         },
         "node_modules/eslint-scope": {
@@ -19205,6 +19218,13 @@
             "requires": {
                 "prettier-linter-helpers": "^1.0.0"
             }
+        },
+        "eslint-plugin-require-extensions": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-require-extensions/-/eslint-plugin-require-extensions-0.1.1.tgz",
+            "integrity": "sha512-qSF0vPCxFck0ady5QmPc57ehGbJkqNBXFaBOrGD6XoLFckLdxxraNVj9P4JOxa9AefIhsLJVe3YMGBhrg4bG0A==",
+            "dev": true,
+            "requires": {}
         },
         "eslint-scope": {
             "version": "5.1.1",

--- a/memo/js/package.json
+++ b/memo/js/package.json
@@ -64,6 +64,7 @@
         "eslint": "^8.20.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.2.1",
+        "eslint-plugin-require-extensions": "^0.1.1",
         "gh-pages": "^3.2.3",
         "jest": "^28.1.3",
         "prettier": "^2.7.1",

--- a/token/js/.eslintrc
+++ b/token/js/.eslintrc
@@ -3,12 +3,14 @@
     "extends": [
         "eslint:recommended",
         "plugin:@typescript-eslint/recommended",
-        "plugin:prettier/recommended"
+        "plugin:prettier/recommended",
+        "plugin:require-extensions/recommended"
     ],
     "parser": "@typescript-eslint/parser",
     "plugins": [
         "@typescript-eslint",
-        "prettier"
+        "prettier",
+        "require-extensions"
     ],
     "rules": {
         "@typescript-eslint/ban-ts-comment": "off",
@@ -16,5 +18,16 @@
         "@typescript-eslint/no-unused-vars": "off",
         "@typescript-eslint/no-empty-interface": "off",
         "@typescript-eslint/consistent-type-imports": "error"
-    }
+    },
+    "overrides": [
+        {
+            "files": [
+                "examples/**/*",
+                "test/**/*"
+            ],
+            "rules": {
+                "require-extensions/require-extensions": "off"
+            }
+        }
+    ]
 }

--- a/token/js/package-lock.json
+++ b/token/js/package-lock.json
@@ -29,6 +29,7 @@
                 "eslint": "^8.20.0",
                 "eslint-config-prettier": "^8.5.0",
                 "eslint-plugin-prettier": "^4.2.1",
+                "eslint-plugin-require-extensions": "^0.1.1",
                 "gh-pages": "^3.2.3",
                 "mocha": "^9.1.4",
                 "prettier": "^2.7.1",
@@ -4592,6 +4593,18 @@
                 "eslint-config-prettier": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/eslint-plugin-require-extensions": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-require-extensions/-/eslint-plugin-require-extensions-0.1.1.tgz",
+            "integrity": "sha512-qSF0vPCxFck0ady5QmPc57ehGbJkqNBXFaBOrGD6XoLFckLdxxraNVj9P4JOxa9AefIhsLJVe3YMGBhrg4bG0A==",
+            "dev": true,
+            "engines": {
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "eslint": "*"
             }
         },
         "node_modules/eslint-scope": {
@@ -13653,6 +13666,13 @@
             "requires": {
                 "prettier-linter-helpers": "^1.0.0"
             }
+        },
+        "eslint-plugin-require-extensions": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-require-extensions/-/eslint-plugin-require-extensions-0.1.1.tgz",
+            "integrity": "sha512-qSF0vPCxFck0ady5QmPc57ehGbJkqNBXFaBOrGD6XoLFckLdxxraNVj9P4JOxa9AefIhsLJVe3YMGBhrg4bG0A==",
+            "dev": true,
+            "requires": {}
         },
         "eslint-scope": {
             "version": "5.1.1",

--- a/token/js/package.json
+++ b/token/js/package.json
@@ -73,6 +73,7 @@
         "eslint": "^8.20.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.2.1",
+        "eslint-plugin-require-extensions": "^0.1.1",
         "gh-pages": "^3.2.3",
         "mocha": "^9.1.4",
         "prettier": "^2.7.1",


### PR DESCRIPTION
This adds a lint rule to enforce correct use of .js file extensions.

See https://github.com/solana-labs/eslint-plugin-require-extensions and https://github.com/solana-labs/wallet-adapter/issues/546 for context.