### PR TITLE
token-2022-test: Use updated generic types for Token client in confidentials

### DIFF
--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -89,7 +89,7 @@ struct ConfidentialTokenAccountMeta {
 }
 
 impl ConfidentialTokenAccountMeta {
-    async fn new<T>(token: &Token<T, Keypair>, owner: &Keypair) -> Self
+    async fn new<T>(token: &Token<T>, owner: &Keypair) -> Self
     where
         T: SendTransaction,
     {
@@ -122,7 +122,7 @@ impl ConfidentialTokenAccountMeta {
     }
 
     async fn with_tokens<T>(
-        token: &Token<T, Keypair>,
+        token: &Token<T>,
         owner: &Keypair,
         mint_authority: &Keypair,
         amount: u64,
@@ -156,11 +156,8 @@ impl ConfidentialTokenAccountMeta {
         meta
     }
 
-    async fn check_balances<T>(
-        &self,
-        token: &Token<T, Keypair>,
-        expected: ConfidentialTokenAccountBalances,
-    ) where
+    async fn check_balances<T>(&self, token: &Token<T>, expected: ConfidentialTokenAccountBalances)
+    where
         T: SendTransaction,
     {
         let state = token.get_account_info(&self.token_account).await.unwrap();
@@ -206,7 +203,7 @@ struct ConfidentialTokenAccountBalances {
 }
 
 async fn check_withheld_amount_in_mint<T>(
-    token: &Token<T, Keypair>,
+    token: &Token<T>,
     withdraw_withheld_authority_encryption_keypair: &ElGamalKeypair,
     expected: u64,
 ) where


### PR DESCRIPTION
#### Problem

The confidential tests currently don't compile because they're still using the old generic parameters for `Token` as `Token<T, Keypair>` rather than `Token<T>`.

#### Solution

Very simple, just get rid of the removed generic param.