### PR TITLE
token-swap-js: Bump version for release

### DIFF
--- a/token-swap/js/package-lock.json
+++ b/token-swap/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@solana/spl-token-swap",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@solana/spl-token-swap",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@solana/buffer-layout": "^4.0.0",

--- a/token-swap/js/package.json
+++ b/token-swap/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana/spl-token-swap",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "SPL Token Swap JavaScript API",
   "license": "MIT",
   "author": "Solana Maintainers <maintainers@solana.foundation>",


### PR DESCRIPTION
#### Problem

#3364 fixed the references to esm files in package.json, but this fix is not available on npm.

#### Solution

Bump the version to 0.2.1 for a new release.