### PR TITLE
ci: Re-enable twotx job

### DIFF
--- a/.github/workflows/pull-request-token.yml
+++ b/.github/workflows/pull-request-token.yml
@@ -80,14 +80,13 @@ jobs:
           if-no-files-found: error
 
   cargo-test-sbf-twoxtx:
-    if: ${{ false }}  # disable for now
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
       - name: Set env vars
         run: |
-          echo "RUST_STABLE_VERSION=1.60.0" >> $GITHUB_ENV
+          echo "RUST_STABLE_VERSION=1.63.0" >> $GITHUB_ENV
           source ci/rust-version.sh
           echo "RUST_STABLE=$rust_stable" >> $GITHUB_ENV
           source ci/solana-version.sh
@@ -104,7 +103,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE}}
+          key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE }}
 
       - name: Install dependencies
         run: |

--- a/token/twoxtx-setup.sh
+++ b/token/twoxtx-setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Patch in a Solana v1.11 monorepo that supports 2x transactions for testing the
+# Patch in a Solana v1.12 monorepo that supports 2x transactions for testing the
 # SPL Token 2022 Confidential Transfer extension
 #
 

--- a/token/twoxtx.patch
+++ b/token/twoxtx.patch
@@ -1,24 +1,24 @@
-From 935ad2c371da8405bb85922b9941d35b3dc68ceb Mon Sep 17 00:00:00 2001
-From: Steven Czabaniuk <steven@solana.com>
-Date: Wed, 29 Sep 2021 15:43:36 -0500
-Subject: [PATCH] feat: double PACKET_DATA_SIZE
+From aa223c645791be158a597efb8579270dbe5bdd82 Mon Sep 17 00:00:00 2001
+From: Jon Cinque <jon.cinque@gmail.com>
+Date: Wed, 31 Aug 2022 01:02:34 +0200
+Subject: [PATCH] [PATCH] feat: double PACKET_DATA_SIZE
 
 Try blind double of PACKET_DATA_SIZE; this double things across the
 board and is not a permanent solution.
 ---
- rpc/src/rpc.rs             | 16 +++++++++++-----
- sdk/src/packet.rs          |  3 ++-
- web3.js/src/transaction/constants.ts |  4 +++-
- 3 files changed, 16 insertions(+), 7 deletions(-)
+ rpc/src/rpc.rs                       | 16 +++++++++++-----
+ sdk/src/packet.rs                    |  3 ++-
+ web3.js/src/transaction/constants.ts |  2 +-
+ 3 files changed, 14 insertions(+), 7 deletions(-)
 
 diff --git a/rpc/src/rpc.rs b/rpc/src/rpc.rs
-index 1a0dcdeb6c..e33492fa84 100644
+index 8d5d12f033..9d46a315ce 100644
 --- a/rpc/src/rpc.rs
 +++ b/rpc/src/rpc.rs
-@@ -4214,8 +4214,11 @@ pub mod rpc_obsolete_v1_7 {
+@@ -4393,8 +4393,11 @@ pub mod rpc_obsolete_v1_7 {
      }
  }
-
+ 
 -const MAX_BASE58_SIZE: usize = 1683; // Golden, bump if PACKET_DATA_SIZE changes
 -const MAX_BASE64_SIZE: usize = 1644; // Golden, bump if PACKET_DATA_SIZE changes
 +// These values need to be updated if PACKET_DATA_SIZE changes. The correct values can
@@ -29,17 +29,17 @@ index 1a0dcdeb6c..e33492fa84 100644
  fn decode_and_deserialize<T>(
      encoded: String,
      encoding: TransactionBinaryEncoding,
-@@ -7749,7 +7752,7 @@ pub mod tests {
+@@ -8285,7 +8288,7 @@ pub mod tests {
      }
-
+ 
      #[test]
 -    fn test_worst_case_encoded_tx_goldens() {
 +    fn test_max_encoded_tx_goldens() {
          let ff_tx = vec![0xffu8; PACKET_DATA_SIZE];
          let tx58 = bs58::encode(&ff_tx).into_string();
          assert_eq!(tx58.len(), MAX_BASE58_SIZE);
-@@ -7759,8 +7762,11 @@ pub mod tests {
-
+@@ -8295,8 +8298,11 @@ pub mod tests {
+ 
      #[test]
      fn test_decode_and_deserialize_too_large_payloads_fail() {
 -        // +2 because +1 still fits in base64 encoded worst-case
@@ -53,31 +53,32 @@ index 1a0dcdeb6c..e33492fa84 100644
          let tx58 = bs58::encode(&tx_ser).into_string();
          let tx58_len = tx58.len();
 diff --git a/sdk/src/packet.rs b/sdk/src/packet.rs
-index efea219043..473a92ecfe 100644
+index 412375e35f..112d962fe8 100644
 --- a/sdk/src/packet.rs
 +++ b/sdk/src/packet.rs
-@@ -12,7 +12,8 @@ use {
+@@ -15,7 +15,8 @@ static_assertions::const_assert_eq!(PACKET_DATA_SIZE, 1232);
  ///   1280 is IPv6 minimum MTU
  ///   40 bytes is the size of the IPv6 header
  ///   8 bytes is the size of the fragment header
 -pub const PACKET_DATA_SIZE: usize = 1280 - 40 - 8;
 +/// Double the minimum to support larger than MTU transactions
 +pub const PACKET_DATA_SIZE: usize = 2 * (1280 - 40 - 8);
-
+ 
  bitflags! {
      #[repr(C)]
 diff --git a/web3.js/src/transaction/constants.ts b/web3.js/src/transaction/constants.ts
-index 591873f8b6..f94d5778ba 100644
+index 075337e8dc..618d48cdfd 100644
 --- a/web3.js/src/transaction/constants.ts
 +++ b/web3.js/src/transaction/constants.ts
-@@ -5,6 +5,6 @@
+@@ -5,7 +5,7 @@
   * 40 bytes is the size of the IPv6 header
   * 8 bytes is the size of the fragment header
   */
 -export const PACKET_DATA_SIZE = 1280 - 40 - 8;
 +export const PACKET_DATA_SIZE = 2464;
+ 
+ export const VERSION_PREFIX_MASK = 0x7f;
+ 
+-- 
+2.37.2
 
- export const SIGNATURE_LENGTH_IN_BYTES = 64;
-
---
-2.32.0 (Apple Git-132)

--- a/token/twoxtx.patch
+++ b/token/twoxtx.patch
@@ -8,7 +8,7 @@ board and is not a permanent solution.
 ---
  rpc/src/rpc.rs             | 16 +++++++++++-----
  sdk/src/packet.rs          |  3 ++-
- web3.js/src/transaction.ts |  4 +++-
+ web3.js/src/transaction/constants.ts |  4 +++-
  3 files changed, 16 insertions(+), 7 deletions(-)
 
 diff --git a/rpc/src/rpc.rs b/rpc/src/rpc.rs
@@ -66,10 +66,10 @@ index efea219043..473a92ecfe 100644
 
  bitflags! {
      #[repr(C)]
-diff --git a/web3.js/src/transaction-constants.ts b/web3.js/src/transaction-constants.ts
+diff --git a/web3.js/src/transaction/constants.ts b/web3.js/src/transaction/constants.ts
 index 591873f8b6..f94d5778ba 100644
---- a/web3.js/src/transaction-constants.ts
-+++ b/web3.js/src/transaction-constants.ts
+--- a/web3.js/src/transaction/constants.ts
++++ b/web3.js/src/transaction/constants.ts
 @@ -5,6 +5,6 @@
   * 40 bytes is the size of the IPv6 header
   * 8 bytes is the size of the fragment header


### PR DESCRIPTION
#### Problem

This is another attempt at #3465 -- we disabled the twoxtx CI job because of incompatible rust versions, but we can actually pick up the correct version if we just use cargo-test-sbf from the twoxtx solana repo.

#### Solution

Just use that!

Fixes https://github.com/solana-labs/solana-program-library/issues/3461