### PR TITLE
fuzz: Update honggfuzz and rust version required

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1886,13 +1886,14 @@ dependencies = [
 
 [[package]]
 name = "honggfuzz"
-version = "0.5.54"
+version = "0.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bea09577d948a98a5f59b7c891e274c4fb35ad52f67782b3d0cb53b9c05301f1"
+checksum = "848e9c511092e0daa0a35a63e8e6e475a3e8f870741448b9f6028d69b142f18e"
 dependencies = [
  "arbitrary",
  "lazy_static",
- "memmap",
+ "memmap2",
+ "rustc_version",
 ]
 
 [[package]]
@@ -2469,16 +2470,6 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
-
-[[package]]
-name = "memmap"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
-dependencies = [
- "libc",
- "winapi 0.3.9",
-]
 
 [[package]]
 name = "memmap2"

--- a/ci/install-program-deps.sh
+++ b/ci/install-program-deps.sh
@@ -9,6 +9,5 @@ set -x
 
 cargo --version
 cargo install rustfilt || true
-cargo install honggfuzz --version=0.5.54 --force || true
 
 cargo +"$rust_stable" build-sbf --version

--- a/token-swap/program/fuzz/Cargo.toml
+++ b/token-swap/program/fuzz/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-honggfuzz = { version = "0.5.54" }
+honggfuzz = { version = "0.5.55" }
 arbitrary = { version = "1.0", features = ["derive"] }
 solana-program = "1.11.6"
 spl-math = { version = "0.1", path = "../../../libraries/math", features = [ "no-entrypoint" ] }


### PR DESCRIPTION
#### Problem

CI is failing at the moment on the fuzzing step because of a failure to install honggfuzz.  The installation step pulls in a newer version of `"arbitrary"` which requires a higher version of Rust.

#### Solution

Use Rust 1.63 for the fuzzing step.  Also, honggfuzz had a new release, which means that we don't need to use nightly anymore.