### PR TITLE
Fix `ConcurrentMerkleTreeHeader` (de)serialization

### DIFF
--- a/account-compression/programs/account-compression/src/state/concurrent_merkle_tree_header.rs
+++ b/account-compression/programs/account-compression/src/state/concurrent_merkle_tree_header.rs
@@ -3,20 +3,10 @@ use borsh::{BorshDeserialize, BorshSerialize};
 
 use crate::error::AccountCompressionError;
 
-#[derive(Debug, Copy, Clone, PartialEq, BorshDeserialize, BorshSerialize)]
-#[repr(u32)]
-pub enum CompressionAccountType {
-    /// Uninitialized
-    Uninitialized,
-
-    /// SPL ConcurrentMerkleTree data structure, may include a Canopy
-    ConcurrentMerkleTree,
-}
-
-impl std::fmt::Display for CompressionAccountType {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{:?}", &self)
-    }
+pub mod compression_account_type {
+    // Currently not explicitly used.
+    pub const _UNINITIALIZED: u64 = 0;
+    pub const CONCURRENT_MERKLE_TREE: u64 = 1;
 }
 
 /// Initialization parameters for an SPL ConcurrentMerkleTree.
@@ -35,7 +25,7 @@ impl std::fmt::Display for CompressionAccountType {
 #[repr(C)]
 pub struct ConcurrentMerkleTreeHeader {
     /// Account type
-    pub account_type: CompressionAccountType,
+    pub account_type: u64,
 
     /// Buffer of changelogs stored on-chain.
     /// Must be a power of 2; see above table for valid combinations.
@@ -66,7 +56,7 @@ impl ConcurrentMerkleTreeHeader {
         // Check header is empty
         assert_eq!(self.max_buffer_size, 0);
         assert_eq!(self.max_depth, 0);
-        self.account_type = CompressionAccountType::ConcurrentMerkleTree;
+        self.account_type = compression_account_type::CONCURRENT_MERKLE_TREE;
         self.max_buffer_size = max_buffer_size;
         self.max_depth = max_depth;
         self.authority = *authority;
@@ -76,7 +66,7 @@ impl ConcurrentMerkleTreeHeader {
     pub fn assert_valid(&self) -> Result<()> {
         require_eq!(
             self.account_type,
-            CompressionAccountType::ConcurrentMerkleTree,
+            compression_account_type::CONCURRENT_MERKLE_TREE,
             AccountCompressionError::IncorrectAccountType,
         );
         Ok(())


### PR DESCRIPTION
The `account_type` member of `ConcurrentMerkleTreeHeader` is currently an `#[repr(u32)]` enum, but borsh only uses one byte to serialize or deserialize an enum tag, which leads to issues with `try_from_slice` calls that get passed slices computed based on applying `size_of` to `ConcurrentMerkleTreeHeader`. This commit replaces the underlying type of `account_type` with an `u64` to also eliminate any padding; if that's not required or helpful we can use a narrower type and potentially move the field to be last.

