### PR TITLE
token-client: memo now explicitly declares signers

### DIFF
--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -393,7 +393,7 @@ async fn command_create_token(
     }
 
     if let Some(text) = memo {
-        token.with_memo(text);
+        token.with_memo(text, vec![config.default_signer.pubkey()]);
     }
 
     let res = token
@@ -1080,7 +1080,7 @@ async fn command_burn(
 
     let token = token_client_from_config(config, &mint_info.program_id, &mint_info.address);
     if let Some(text) = memo {
-        token.with_memo(text);
+        token.with_memo(text, vec![config.default_signer.pubkey()]);
     }
 
     let res = token
@@ -1127,7 +1127,7 @@ async fn command_mint(
 
     let token = token_client_from_config(config, &mint_info.program_id, &mint_info.address);
     if let Some(text) = memo {
-        token.with_memo(text);
+        token.with_memo(text, vec![config.default_signer.pubkey()]);
     }
 
     let res = token

--- a/token/program-2022-test/tests/memo_transfer.rs
+++ b/token/program-2022-test/tests/memo_transfer.rs
@@ -131,7 +131,7 @@ async fn test_memo_transfers(
 
     // transfer with memo
     token
-        .with_memo("🦖")
+        .with_memo("🦖", vec![alice.pubkey()])
         .transfer(
             &alice_account,
             &bob_account,


### PR DESCRIPTION
this also fixes a bug where cli memos implicitly signed with `fee_payer` rather than `default_signer`

closes #3538