### PR TITLE
token-2022: Add support for non transferable and immutable ownership in token client

### DIFF
--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -107,6 +107,7 @@ pub enum ExtensionInitializationParams {
         rate_authority: Option<Pubkey>,
         rate: i16,
     },
+    NonTransferable,
 }
 impl ExtensionInitializationParams {
     /// Get the extension type associated with the init params
@@ -117,6 +118,7 @@ impl ExtensionInitializationParams {
             Self::MintCloseAuthority { .. } => ExtensionType::MintCloseAuthority,
             Self::TransferFeeConfig { .. } => ExtensionType::TransferFeeConfig,
             Self::InterestBearingConfig { .. } => ExtensionType::InterestBearingConfig,
+            Self::NonTransferable => ExtensionType::NonTransferable,
         }
     }
     /// Generate an appropriate initialization instruction for the given mint
@@ -169,6 +171,9 @@ impl ExtensionInitializationParams {
                 rate_authority,
                 rate,
             ),
+            Self::NonTransferable => {
+                instruction::initialize_non_transferable_mint(token_program_id, mint)
+            }
         }
     }
 }

--- a/token/program-2022-test/tests/non_transferable.rs
+++ b/token/program-2022-test/tests/non_transferable.rs
@@ -34,12 +34,13 @@ async fn transfer_checked() {
     } = context.token_context.unwrap();
 
     // create token accounts
-    let alice_account = token
+    token
         .create_auxiliary_token_account(&alice, &alice.pubkey())
         .await
         .unwrap();
+    let alice_account = alice.pubkey();
 
-    let bob_account = token
+    token
         .create_auxiliary_token_account_with_extension_space(
             &bob,
             &bob.pubkey(),
@@ -47,6 +48,7 @@ async fn transfer_checked() {
         )
         .await
         .unwrap();
+    let bob_account = bob.pubkey();
 
     // mint fails because the account does not have immutable ownership
     let error = token
@@ -168,7 +170,7 @@ async fn transfer_checked_with_fee() {
     } = context.token_context.unwrap();
 
     // create token accounts
-    let alice_account = token
+    token
         .create_auxiliary_token_account_with_extension_space(
             &alice,
             &alice.pubkey(),
@@ -176,8 +178,9 @@ async fn transfer_checked_with_fee() {
         )
         .await
         .unwrap();
+    let alice_account = alice.pubkey();
 
-    let bob_account = token
+    token
         .create_auxiliary_token_account_with_extension_space(
             &bob,
             &bob.pubkey(),
@@ -185,6 +188,7 @@ async fn transfer_checked_with_fee() {
         )
         .await
         .unwrap();
+    let bob_account = bob.pubkey();
 
     token
         .mint_to(

--- a/token/program-2022-test/tests/non_transferable.rs
+++ b/token/program-2022-test/tests/non_transferable.rs
@@ -1,0 +1,140 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+use {
+    program_test::{TestContext, TokenContext},
+    solana_program_test::tokio,
+    solana_sdk::{
+        instruction::InstructionError, program_option::COption, pubkey::Pubkey, signature::Signer,
+        signer::keypair::Keypair, transaction::TransactionError, transport::TransportError,
+    },
+    spl_token_2022::{
+        error::TokenError,
+        extension::{
+            transfer_fee::{
+                TransferFee, TransferFeeAmount, TransferFeeConfig, MAX_FEE_BASIS_POINTS,
+            },
+            ExtensionType,
+        },
+        instruction,
+    },
+    spl_token_client::{
+        client::ProgramBanksClientProcessTransaction,
+        token::{ExtensionInitializationParams, Token, TokenError as TokenClientError},
+    },
+    std::convert::TryInto,
+};
+
+#[tokio::test]
+async fn transfer_checked() {
+    let test_amount = 100;
+    let mut context = TestContext::new().await;
+    context
+        .init_token_with_mint(vec![ExtensionInitializationParams::NonTransferable])
+        .await
+        .unwrap();
+
+    let TokenContext {
+        decimals,
+        mint_authority,
+        token,
+        alice,
+        bob,
+        ..
+    } = context.token_context.unwrap();
+
+    // create token accounts
+    let alice_account = token
+        .create_auxiliary_token_account(&alice, &alice.pubkey())
+        .await
+        .unwrap();
+
+    let bob_account = token
+        .create_auxiliary_token_account_with_extension_space(
+            &bob,
+            &bob.pubkey(),
+            vec![ExtensionType::ImmutableOwner],
+        )
+        .await
+        .unwrap();
+
+    // mint fails because the account does not have immutable ownership
+    let error = token
+        .mint_to(
+            &alice_account,
+            &mint_authority.pubkey(),
+            test_amount,
+            Some(decimals),
+            &vec![&mint_authority],
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::NonTransferableNeedsImmutableOwnership as u32)
+            )
+        )))
+    );
+
+    // mint succeeds if the account has immutable ownership
+    token
+        .mint_to(
+            &bob_account,
+            &mint_authority.pubkey(),
+            test_amount,
+            Some(decimals),
+            &vec![&mint_authority],
+        )
+        .await
+        .unwrap();
+
+    // self-transfer fails
+    let error = token
+        .transfer(
+            &bob_account,
+            &bob_account,
+            &bob.pubkey(),
+            test_amount,
+            Some(decimals),
+            &vec![&bob],
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::NonTransferable as u32)
+            )
+        )))
+    );
+
+    // regular transfer fails
+    let error = token
+        .transfer(
+            &bob_account,
+            &alice_account,
+            &bob.pubkey(),
+            test_amount,
+            Some(decimals),
+            &vec![&bob],
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::NonTransferable as u32)
+            )
+        )))
+    );
+}


### PR DESCRIPTION
- Extended `ExtensionInitializationParams` for the non-transferable extension so that non-transferable extension can be easily initialized
- Tweaked `create_auxiliary_token_account_with_extension_space` in token client so that immutable owner accounts can be easily initialized
- Added basic tests for the non-transferable extension. Tests for the non-transferable confidential extension will be added in a separate PR.