### PR TITLE
add stake pool support support for hardware wallets in set-manager

### DIFF
--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -1718,7 +1718,7 @@ fn command_withdraw_sol(
 fn command_set_manager(
     config: &Config,
     stake_pool_address: &Pubkey,
-    new_manager: &Box<dyn Signer>,
+    new_manager: Box<dyn Signer>,
     new_fee_receiver: &Option<Pubkey>,
 ) -> CommandResult {
     if !config.no_update {
@@ -2947,12 +2947,7 @@ fn main() {
                 },
             );
             let new_fee_receiver: Option<Pubkey> = pubkey_of(arg_matches, "new_fee_receiver");
-            command_set_manager(
-                &config,
-                &stake_pool_address,
-                &new_manager,
-                &new_fee_receiver,
-            )
+            command_set_manager(&config, &stake_pool_address, new_manager, &new_fee_receiver)
         }
         ("set-staker", Some(arg_matches)) => {
             let stake_pool_address = pubkey_of(arg_matches, "pool").unwrap();

--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -1718,7 +1718,7 @@ fn command_withdraw_sol(
 fn command_set_manager(
     config: &Config,
     stake_pool_address: &Pubkey,
-    new_manager: &Option<Keypair>,
+    new_manager: &Box<dyn Signer>,
     new_fee_receiver: &Option<Pubkey>,
 ) -> CommandResult {
     if !config.no_update {
@@ -1727,10 +1727,8 @@ fn command_set_manager(
     let stake_pool = get_stake_pool(&config.rpc_client, stake_pool_address)?;
 
     // If new accounts are missing in the arguments use the old ones
-    let (new_manager_pubkey, mut signers): (Pubkey, Vec<&dyn Signer>) = match new_manager {
-        None => (stake_pool.manager, vec![]),
-        Some(value) => (value.pubkey(), vec![value]),
-    };
+    let new_manager_pubkey: Pubkey = new_manager.pubkey();
+    let mut signers: Vec<&dyn Signer> = vec![new_manager.as_ref()];
     let new_fee_receiver = match new_fee_receiver {
         None => stake_pool.manager_fee_account,
         Some(value) => {
@@ -2937,7 +2935,17 @@ fn main() {
         }
         ("set-manager", Some(arg_matches)) => {
             let stake_pool_address = pubkey_of(arg_matches, "pool").unwrap();
-            let new_manager: Option<Keypair> = keypair_of(arg_matches, "new_manager");
+            let new_manager = get_signer(
+                arg_matches,
+                "new-manager",
+                arg_matches
+                    .value_of("new_manager")
+                    .expect("new manager argument not found!"),
+                &mut wallet_manager,
+                SignerFromPathConfig {
+                    allow_null_signer: true,
+                },
+            );
             let new_fee_receiver: Option<Pubkey> = pubkey_of(arg_matches, "new_fee_receiver");
             command_set_manager(
                 &config,

--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -1718,7 +1718,7 @@ fn command_withdraw_sol(
 fn command_set_manager(
     config: &Config,
     stake_pool_address: &Pubkey,
-    new_manager: Box<dyn Signer>,
+    new_manager: &Option<Box<dyn Signer>>,
     new_fee_receiver: &Option<Pubkey>,
 ) -> CommandResult {
     if !config.no_update {
@@ -1727,8 +1727,11 @@ fn command_set_manager(
     let stake_pool = get_stake_pool(&config.rpc_client, stake_pool_address)?;
 
     // If new accounts are missing in the arguments use the old ones
-    let new_manager_pubkey: Pubkey = new_manager.pubkey();
-    let mut signers: Vec<&dyn Signer> = vec![new_manager.as_ref()];
+    let (new_manager_pubkey, mut signers): (Pubkey, Vec<&dyn Signer>) = match new_manager {
+        None => (stake_pool.manager, vec![]),
+        Some(value) => (value.pubkey(), vec![value.as_ref()]),
+    };
+
     let new_fee_receiver = match new_fee_receiver {
         None => stake_pool.manager_fee_account,
         Some(value) => {
@@ -2935,19 +2938,31 @@ fn main() {
         }
         ("set-manager", Some(arg_matches)) => {
             let stake_pool_address = pubkey_of(arg_matches, "pool").unwrap();
-            let new_manager = get_signer(
-                arg_matches,
-                "new-manager",
-                arg_matches
-                    .value_of("new_manager")
-                    .expect("new manager argument not found!"),
-                &mut wallet_manager,
-                SignerFromPathConfig {
-                    allow_null_signer: true,
-                },
-            );
+
+            let new_manager = if arg_matches.value_of("new_manager").is_some() {
+                let signer = get_signer(
+                    arg_matches,
+                    "new-manager",
+                    arg_matches
+                        .value_of("new_manager")
+                        .expect("new manager argument not found!"),
+                    &mut wallet_manager,
+                    SignerFromPathConfig {
+                        allow_null_signer: true,
+                    },
+                );
+                Some(signer)
+            } else {
+                None
+            };
+
             let new_fee_receiver: Option<Pubkey> = pubkey_of(arg_matches, "new_fee_receiver");
-            command_set_manager(&config, &stake_pool_address, new_manager, &new_fee_receiver)
+            command_set_manager(
+                &config,
+                &stake_pool_address,
+                &new_manager,
+                &new_fee_receiver,
+            )
         }
         ("set-staker", Some(arg_matches)) => {
             let stake_pool_address = pubkey_of(arg_matches, "pool").unwrap();


### PR DESCRIPTION
currently, `set-manager` cannot be used to change the stake pool manager to a hardware wallet, due to the use of `keypair_of`, which does not support a hardware wallet path. We instead use `get_signer` to get the signer, which allows hardware wallets to sign the transaction