### PR TITLE
token-client: Change create_account to return T::Output

### DIFF
--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -458,7 +458,7 @@ where
     }
 
     /// Create and initialize the associated account.
-    pub async fn create_associated_token_account(&self, owner: &Pubkey) -> TokenResult<Pubkey> {
+    pub async fn create_associated_token_account(&self, owner: &Pubkey) -> TokenResult<T::Output> {
         self.process_ixs::<[&dyn Signer; 0]>(
             &[create_associated_token_account(
                 &self.payer.pubkey(),
@@ -469,7 +469,6 @@ where
             &[],
         )
         .await
-        .map(|_| self.get_associated_token_address(owner))
         .map_err(Into::into)
     }
 
@@ -478,7 +477,7 @@ where
         &self,
         account: &dyn Signer,
         owner: &Pubkey,
-    ) -> TokenResult<Pubkey> {
+    ) -> TokenResult<T::Output> {
         self.create_auxiliary_token_account_with_extension_space(account, owner, vec![])
             .await
     }
@@ -489,7 +488,7 @@ where
         account: &dyn Signer,
         owner: &Pubkey,
         extensions: Vec<ExtensionType>,
-    ) -> TokenResult<Pubkey> {
+    ) -> TokenResult<T::Output> {
         let state = self.get_mint_info().await?;
         let mint_extensions: Vec<ExtensionType> = state.get_extension_types()?;
         let mut required_extensions =
@@ -522,7 +521,6 @@ where
             &vec![account],
         )
         .await
-        .map(|_| account.pubkey())
         .map_err(Into::into)
     }
 

--- a/token/client/tests/program-test.rs
+++ b/token/client/tests/program-test.rs
@@ -84,10 +84,11 @@ fn keypair_clone(kp: &Keypair) -> Keypair {
 async fn associated_token_account() {
     let TestContext { token, alice, .. } = TestContext::new().await;
 
-    let alice_vault = token
+    token
         .create_associated_token_account(&alice.pubkey())
         .await
         .expect("failed to create associated token account");
+    let alice_vault = token.get_associated_token_address(&alice.pubkey());
 
     assert_eq!(
         token.get_associated_token_address(&alice.pubkey()),
@@ -153,10 +154,11 @@ async fn set_authority() {
         ..
     } = TestContext::new().await;
 
-    let alice_vault = token
+    token
         .create_associated_token_account(&alice.pubkey())
         .await
         .expect("failed to create associated token account");
+    let alice_vault = token.get_associated_token_address(&alice.pubkey());
 
     token
         .mint_to(
@@ -234,10 +236,11 @@ async fn mint_to() {
         ..
     } = TestContext::new().await;
 
-    let alice_vault = token
+    token
         .create_associated_token_account(&alice.pubkey())
         .await
         .expect("failed to create associated token account");
+    let alice_vault = token.get_associated_token_address(&alice.pubkey());
 
     let mint_amount = 10 * u64::pow(10, decimals as u32);
     token
@@ -276,14 +279,16 @@ async fn transfer() {
         ..
     } = TestContext::new().await;
 
-    let alice_vault = token
+    token
         .create_associated_token_account(&alice.pubkey())
         .await
         .expect("failed to create associated token account");
-    let bob_vault = token
+    let alice_vault = token.get_associated_token_address(&alice.pubkey());
+    token
         .create_associated_token_account(&bob.pubkey())
         .await
         .expect("failed to create associated token account");
+    let bob_vault = token.get_associated_token_address(&bob.pubkey());
 
     let mint_amount = 10 * u64::pow(10, decimals as u32);
     token

--- a/token/program-2022-test/tests/burn.rs
+++ b/token/program-2022-test/tests/burn.rs
@@ -23,10 +23,11 @@ async fn run_basic(context: TestContext) {
     } = context.token_context.unwrap();
 
     let alice_account = Keypair::new();
-    let alice_account = token
+    token
         .create_auxiliary_token_account(&alice_account, &alice.pubkey())
         .await
         .unwrap();
+    let alice_account = alice_account.pubkey();
 
     // mint a token
     let amount = 10;
@@ -133,10 +134,11 @@ async fn run_self_owned(context: TestContext) {
         ..
     } = context.token_context.unwrap();
 
-    let alice_account = token
+    token
         .create_auxiliary_token_account(&alice, &alice.pubkey())
         .await
         .unwrap();
+    let alice_account = alice.pubkey();
 
     // mint a token
     let amount = 10;
@@ -202,10 +204,11 @@ async fn run_burn_and_close_system_or_incinerator(context: TestContext, non_owne
     } = context.token_context.unwrap();
 
     let alice_account = Keypair::new();
-    let alice_account = token
+    token
         .create_auxiliary_token_account(&alice_account, &alice.pubkey())
         .await
         .unwrap();
+    let alice_account = alice_account.pubkey();
 
     // mint a token
     token
@@ -221,10 +224,11 @@ async fn run_burn_and_close_system_or_incinerator(context: TestContext, non_owne
 
     // transfer token to incinerator/system
     let non_owner_account = Keypair::new();
-    let non_owner_account = token
+    token
         .create_auxiliary_token_account(&non_owner_account, non_owner)
         .await
         .unwrap();
+    let non_owner_account = non_owner_account.pubkey();
     token
         .transfer(
             &alice_account,

--- a/token/program-2022-test/tests/close_account.rs
+++ b/token/program-2022-test/tests/close_account.rs
@@ -22,10 +22,11 @@ async fn success_init_after_close_account() {
     let token_program_id = spl_token_2022::id();
     let owner = Keypair::new();
     let token_account_keypair = Keypair::new();
-    let token_account = token
+    token
         .create_auxiliary_token_account(&token_account_keypair, &owner.pubkey())
         .await
         .unwrap();
+    let token_account = token_account_keypair.pubkey();
 
     let destination = Pubkey::new_unique();
     token
@@ -70,10 +71,12 @@ async fn fail_init_after_close_account() {
     let token = context.token_context.take().unwrap().token;
     let token_program_id = spl_token_2022::id();
     let owner = Keypair::new();
-    let token_account = token
-        .create_auxiliary_token_account(&Keypair::new(), &owner.pubkey())
+    let token_account_keypair = Keypair::new();
+    token
+        .create_auxiliary_token_account(&token_account_keypair, &owner.pubkey())
         .await
         .unwrap();
+    let token_account = token_account_keypair.pubkey();
 
     let destination = Pubkey::new_unique();
     let error = token

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -58,7 +58,7 @@ impl ConfidentialTransferMintWithKeypairs {
         let ct_mint_transfer_auditor_encryption_keypair = ElGamalKeypair::new_rand();
         let ct_mint_withdraw_withheld_authority_encryption_keypair = ElGamalKeypair::new_rand();
         let ct_mint = ConfidentialTransferMint {
-            authority: ct_mint_authority.pubkey().into(),
+            authority: ct_mint_authority.pubkey(),
             auto_approve_new_accounts: true.into(),
             auditor_encryption_pubkey: ct_mint_transfer_auditor_encryption_keypair.public.into(),
             withdraw_withheld_authority_encryption_pubkey:
@@ -93,14 +93,16 @@ impl ConfidentialTokenAccountMeta {
     where
         T: SendTransaction,
     {
-        let token_account = token
+        let token_account_keypair = Keypair::new();
+        token
             .create_auxiliary_token_account_with_extension_space(
-                &Keypair::new(),
+                &token_account_keypair,
                 &owner.pubkey(),
                 vec![ExtensionType::ConfidentialTransferAccount],
             )
             .await
             .unwrap();
+        let token_account = token_account_keypair.pubkey();
 
         let elgamal_keypair = ElGamalKeypair::new(owner, &token_account).unwrap();
         let ae_key = AeKey::new(owner, &token_account).unwrap();

--- a/token/program-2022-test/tests/default_account_state.rs
+++ b/token/program-2022-test/tests/default_account_state.rs
@@ -187,10 +187,11 @@ async fn end_to_end_default_account_state() {
 
     let owner = Pubkey::new_unique();
     let account = Keypair::new();
-    let account = token
+    token
         .create_auxiliary_token_account(&account, &owner)
         .await
         .unwrap();
+    let account = account.pubkey();
     let account_state = token.get_account_info(&account).await.unwrap();
     assert_eq!(account_state.base.state, default_account_state);
 
@@ -222,10 +223,11 @@ async fn end_to_end_default_account_state() {
 
     let owner = Pubkey::new_unique();
     let account = Keypair::new();
-    let account = token
+    token
         .create_auxiliary_token_account(&account, &owner)
         .await
         .unwrap();
+    let account = account.pubkey();
     let account_state = token.get_account_info(&account).await.unwrap();
     assert_eq!(account_state.base.state, AccountState::Initialized);
 

--- a/token/program-2022-test/tests/delegate.rs
+++ b/token/program-2022-test/tests/delegate.rs
@@ -46,23 +46,28 @@ async fn run_basic(
     } = context.token_context.unwrap();
 
     let alice_account = match owner_mode {
-        OwnerMode::SelfOwned => token
-            .create_auxiliary_token_account(&alice, &alice.pubkey())
-            .await
-            .unwrap(),
+        OwnerMode::SelfOwned => {
+            token
+                .create_auxiliary_token_account(&alice, &alice.pubkey())
+                .await
+                .unwrap();
+            alice.pubkey()
+        }
         OwnerMode::External => {
             let alice_account = Keypair::new();
             token
                 .create_auxiliary_token_account(&alice_account, &alice.pubkey())
                 .await
-                .unwrap()
+                .unwrap();
+            alice_account.pubkey()
         }
     };
     let bob_account = Keypair::new();
-    let bob_account = token
+    token
         .create_auxiliary_token_account(&bob_account, &bob.pubkey())
         .await
         .unwrap();
+    let bob_account = bob_account.pubkey();
 
     // mint tokens
     let amount = 100;

--- a/token/program-2022-test/tests/freeze.rs
+++ b/token/program-2022-test/tests/freeze.rs
@@ -21,10 +21,11 @@ async fn basic() {
     let freeze_authority = freeze_authority.unwrap();
 
     let account = Keypair::new();
-    let account = token
+    token
         .create_auxiliary_token_account(&account, &alice.pubkey())
         .await
         .unwrap();
+    let account = account.pubkey();
     let state = token.get_account_info(&account).await.unwrap();
     assert_eq!(state.base.state, AccountState::Initialized);
 

--- a/token/program-2022-test/tests/memo_transfer.rs
+++ b/token/program-2022-test/tests/memo_transfer.rs
@@ -201,12 +201,13 @@ async fn require_memo_transfers_without_realloc() {
     let token_context = context.token_context.unwrap();
 
     // create token accounts
-    let alice_account = token_context
+    token_context
         .token
         .create_auxiliary_token_account(&token_context.alice, &token_context.alice.pubkey())
         .await
         .unwrap();
-    let bob_account = token_context
+    let alice_account = token_context.alice.pubkey();
+    token_context
         .token
         .create_auxiliary_token_account_with_extension_space(
             &token_context.bob,
@@ -215,6 +216,7 @@ async fn require_memo_transfers_without_realloc() {
         )
         .await
         .unwrap();
+    let bob_account = token_context.bob.pubkey();
 
     test_memo_transfers(context.context, token_context, alice_account, bob_account).await;
 }
@@ -226,16 +228,18 @@ async fn require_memo_transfers_with_realloc() {
     let token_context = context.token_context.unwrap();
 
     // create token accounts
-    let alice_account = token_context
+    token_context
         .token
         .create_auxiliary_token_account(&token_context.alice, &token_context.alice.pubkey())
         .await
         .unwrap();
-    let bob_account = token_context
+    let alice_account = token_context.alice.pubkey();
+    token_context
         .token
         .create_auxiliary_token_account(&token_context.bob, &token_context.bob.pubkey())
         .await
         .unwrap();
+    let bob_account = token_context.bob.pubkey();
     token_context
         .token
         .reallocate(

--- a/token/program-2022-test/tests/mint_close_authority.rs
+++ b/token/program-2022-test/tests/mint_close_authority.rs
@@ -253,10 +253,11 @@ async fn fail_close_with_supply() {
     // mint a token
     let owner = Pubkey::new_unique();
     let account = Keypair::new();
-    let account = token
+    token
         .create_auxiliary_token_account(&account, &owner)
         .await
         .unwrap();
+    let account = account.pubkey();
     token
         .mint_to(
             &account,

--- a/token/program-2022-test/tests/reallocate.rs
+++ b/token/program-2022-test/tests/reallocate.rs
@@ -42,10 +42,11 @@ async fn reallocate() {
 
     // create account just large enough for base
     let alice_account = Keypair::new();
-    let alice_account = token
+    token
         .create_auxiliary_token_account(&alice_account, &alice.pubkey())
         .await
         .unwrap();
+    let alice_account = alice_account.pubkey();
 
     // reallocate fails on invalid extension type
     let error = token
@@ -144,10 +145,11 @@ async fn reallocate_without_current_extension_knowledge() {
 
     // create account just large enough for TransferFeeAmount extension
     let alice_account = Keypair::new();
-    let alice_account = token
+    token
         .create_auxiliary_token_account(&alice_account, &alice.pubkey())
         .await
         .unwrap();
+    let alice_account = alice_account.pubkey();
 
     // reallocate resizes account to accommodate new and existing extensions
     token

--- a/token/program-2022-test/tests/sync_native.rs
+++ b/token/program-2022-test/tests/sync_native.rs
@@ -56,10 +56,12 @@ async fn basic() {
     let TokenContext { token, alice, .. } = context.token_context.unwrap();
     let context = context.context.clone();
 
-    let account = token
-        .create_auxiliary_token_account(&Keypair::new(), &alice.pubkey())
+    let account = Keypair::new();
+    token
+        .create_auxiliary_token_account(&account, &alice.pubkey())
         .await
         .unwrap();
+    let account = account.pubkey();
     run_basic(token, context, account).await;
 }
 
@@ -70,13 +72,15 @@ async fn basic_with_extension() {
     let TokenContext { token, alice, .. } = context.token_context.unwrap();
     let context = context.context.clone();
 
-    let account = token
+    let account = Keypair::new();
+    token
         .create_auxiliary_token_account_with_extension_space(
-            &Keypair::new(),
+            &account,
             &alice.pubkey(),
             vec![ExtensionType::ImmutableOwner],
         )
         .await
         .unwrap();
+    let account = account.pubkey();
     run_basic(token, context, account).await;
 }

--- a/token/program-2022-test/tests/transfer.rs
+++ b/token/program-2022-test/tests/transfer.rs
@@ -29,15 +29,17 @@ async fn run_basic_transfers(context: TestContext, test_mode: TestMode) {
     } = context.token_context.unwrap();
 
     let alice_account = Keypair::new();
-    let alice_account = token
+    token
         .create_auxiliary_token_account(&alice_account, &alice.pubkey())
         .await
         .unwrap();
+    let alice_account = alice_account.pubkey();
     let bob_account = Keypair::new();
-    let bob_account = token
+    token
         .create_auxiliary_token_account(&bob_account, &bob.pubkey())
         .await
         .unwrap();
+    let bob_account = bob_account.pubkey();
 
     // mint a token
     let amount = 10;
@@ -157,10 +159,11 @@ async fn run_self_transfers(context: TestContext, test_mode: TestMode) {
     } = context.token_context.unwrap();
 
     let alice_account = Keypair::new();
-    let alice_account = token
+    token
         .create_auxiliary_token_account(&alice_account, &alice.pubkey())
         .await
         .unwrap();
+    let alice_account = alice_account.pubkey();
 
     // mint a token
     let amount = 10;
@@ -256,15 +259,17 @@ async fn run_self_owned(context: TestContext, test_mode: TestMode) {
         ..
     } = context.token_context.unwrap();
 
-    let alice_account = token
+    token
         .create_auxiliary_token_account(&alice, &alice.pubkey())
         .await
         .unwrap();
+    let alice_account = alice.pubkey();
     let bob_account = Keypair::new();
-    let bob_account = token
+    token
         .create_auxiliary_token_account(&bob_account, &bob.pubkey())
         .await
         .unwrap();
+    let bob_account = bob_account.pubkey();
 
     // mint a token
     let amount = 10;
@@ -357,15 +362,17 @@ async fn transfer_with_fee_on_mint_without_fee_configured() {
     } = context.token_context.unwrap();
 
     let alice_account = Keypair::new();
-    let alice_account = token
+    token
         .create_auxiliary_token_account(&alice_account, &alice.pubkey())
         .await
         .unwrap();
+    let alice_account = alice_account.pubkey();
     let bob_account = Keypair::new();
-    let bob_account = token
+    token
         .create_auxiliary_token_account(&bob_account, &bob.pubkey())
         .await
         .unwrap();
+    let bob_account = bob_account.pubkey();
 
     // mint some tokens
     let amount = 10;

--- a/token/program-2022-test/tests/transfer_fee.rs
+++ b/token/program-2022-test/tests/transfer_fee.rs
@@ -118,15 +118,17 @@ async fn create_mint_with_accounts(alice_amount: u64) -> TokenWithAccounts {
     } = context.token_context.take().unwrap();
 
     // token account is self-owned just to test another case
-    let alice_account = token
+    token
         .create_auxiliary_token_account(&alice, &alice.pubkey())
         .await
         .unwrap();
+    let alice_account = alice.pubkey();
     let bob_account = Keypair::new();
-    let bob_account = token
+    token
         .create_auxiliary_token_account(&bob_account, &bob.pubkey())
         .await
         .unwrap();
+    let bob_account = bob_account.pubkey();
 
     // mint tokens
     token
@@ -688,10 +690,12 @@ async fn set_withdraw_withheld_authority() {
     );
 
     // new authority can withdraw tokens
-    let account = token
-        .create_auxiliary_token_account(&Keypair::new(), &new_authority.pubkey())
+    let account = Keypair::new();
+    token
+        .create_auxiliary_token_account(&account, &new_authority.pubkey())
         .await
         .unwrap();
+    let account = account.pubkey();
     token
         .withdraw_withheld_tokens_from_accounts(&account, &new_authority, &[&account])
         .await
@@ -751,10 +755,12 @@ async fn set_withdraw_withheld_authority() {
     );
 
     // assert no authority can withdraw withheld fees
-    let account = token
-        .create_auxiliary_token_account(&Keypair::new(), &new_authority.pubkey())
+    let account = Keypair::new();
+    token
+        .create_auxiliary_token_account(&account, &new_authority.pubkey())
         .await
         .unwrap();
+    let account = account.pubkey();
     let error = token
         .withdraw_withheld_tokens_from_accounts(&account, &withdraw_withheld_authority, &[&account])
         .await
@@ -1144,10 +1150,12 @@ async fn create_and_transfer_to_account(
     amount: u64,
     decimals: u8,
 ) -> Pubkey {
-    let account = token
-        .create_auxiliary_token_account(&Keypair::new(), owner)
+    let account = Keypair::new();
+    token
+        .create_auxiliary_token_account(&account, owner)
         .await
         .unwrap();
+    let account = account.pubkey();
     token
         .transfer(
             source,
@@ -1297,10 +1305,12 @@ async fn max_withdraw_withheld_tokens_from_accounts() {
     // withdraw from max accounts, which is around 35: 1 mint, 1 destination, 1 authority,
     // 32 accounts
     // see https://docs.solana.com/proposals/transactions-v2#problem
-    let destination = token
-        .create_auxiliary_token_account(&Keypair::new(), &alice.pubkey())
+    let destination = Keypair::new();
+    token
+        .create_auxiliary_token_account(&destination, &alice.pubkey())
         .await
         .unwrap();
+    let destination = destination.pubkey();
     let mut accounts = vec![];
     let max_accounts = 32;
     for _ in 0..max_accounts {
@@ -1606,10 +1616,12 @@ async fn withdraw_withheld_tokens_from_accounts() {
         .await
         .unwrap();
     let TokenContext { token, .. } = context.token_context.take().unwrap();
-    let withdraw_account = token
-        .create_auxiliary_token_account(&Keypair::new(), &alice.pubkey())
+    let withdraw_account = Keypair::new();
+    token
+        .create_auxiliary_token_account(&withdraw_account, &alice.pubkey())
         .await
         .unwrap();
+    let withdraw_account = withdraw_account.pubkey();
     token
         .withdraw_withheld_tokens_from_accounts(
             &withdraw_account,


### PR DESCRIPTION
#### Problem

The token client's `create_associated_account` and `create_auxiliary_account` functions return the pubkey of the created account, which is nifty in tests, but not usable in CLIs where we want a transaction signature.

I came across this issue while writing a CLI for the token-upgrade program. One of the commands just creates a token account, but I wasn't able to display the transaction info because of the previous return type.

#### Solution

Change the output of the the create account functions to `T::Output`, and fixup all tests that use it.