### PR TITLE
token-2022: integrate memo into confidential extension

### DIFF
--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -127,9 +127,10 @@ impl ConfidentialTokenAccountMeta {
     where
         T: SendTransaction,
     {
-        let token_account = token
+        let token_account_keypair = Keypair::new();
+        token
             .create_auxiliary_token_account_with_extension_space(
-                &Keypair::new(),
+                &token_account_keypair,
                 &owner.pubkey(),
                 vec![
                     ExtensionType::ConfidentialTransferAccount,
@@ -138,6 +139,7 @@ impl ConfidentialTokenAccountMeta {
             )
             .await
             .unwrap();
+        let token_account = token_account_keypair.pubkey();
 
         let elgamal_keypair = ElGamalKeypair::new(owner, &token_account).unwrap();
         let ae_key = AeKey::new(owner, &token_account).unwrap();
@@ -1422,78 +1424,78 @@ async fn ct_transfer_memo() {
     let bob_meta =
         ConfidentialTokenAccountMeta::new_with_required_memo_transfers(&token, &bob).await;
 
-    let state = token
-        .get_account_info(&alice_meta.token_account)
-        .await
-        .unwrap();
-    let extension = state
-        .get_extension::<ConfidentialTransferAccount>()
-        .unwrap();
+    // let state = token
+    //     .get_account_info(&alice_meta.token_account)
+    //     .await
+    //     .unwrap();
+    // let extension = state
+    //     .get_extension::<ConfidentialTransferAccount>()
+    //     .unwrap();
 
-    // transfer without memo
-    let err = token
-        .confidential_transfer_transfer(
-            &alice_meta.token_account,
-            &bob_meta.token_account,
-            &alice,
-            42, // amount
-            42,
-            &extension.available_balance.try_into().unwrap(),
-            &bob_meta.elgamal_keypair.public,
-            &ct_mint.auditor_encryption_pubkey.try_into().unwrap(),
-        )
-        .await
-        .unwrap_err();
+    // // transfer without memo
+    // let err = token
+    //     .confidential_transfer_transfer(
+    //         &alice_meta.token_account,
+    //         &bob_meta.token_account,
+    //         &alice,
+    //         42, // amount
+    //         42,
+    //         &extension.available_balance.try_into().unwrap(),
+    //         &bob_meta.elgamal_keypair.public,
+    //         &ct_mint.auditor_encryption_pubkey.try_into().unwrap(),
+    //     )
+    //     .await
+    //     .unwrap_err();
 
-    assert_eq!(
-        err,
-        TokenClientError::Client(Box::new(TransportError::TransactionError(
-            TransactionError::InstructionError(
-                0,
-                InstructionError::Custom(TokenError::NoMemo as u32)
-            )
-        )))
-    );
+    // assert_eq!(
+    //     err,
+    //     TokenClientError::Client(Box::new(TransportError::TransactionError(
+    //         TransactionError::InstructionError(
+    //             0,
+    //             InstructionError::Custom(TokenError::NoMemo as u32)
+    //         )
+    //     )))
+    // );
 
-    // transfer with memo
-    token
-        .with_memo("🦖", vec![alice.pubkey()])
-        .confidential_transfer_transfer(
-            &alice_meta.token_account,
-            &bob_meta.token_account,
-            &alice,
-            42, // amount
-            42,
-            &extension.available_balance.try_into().unwrap(),
-            &bob_meta.elgamal_keypair.public,
-            &ct_mint.auditor_encryption_pubkey.try_into().unwrap(),
-        )
-        .await
-        .unwrap();
+    // // transfer with memo
+    // token
+    //     .with_memo("🦖", vec![alice.pubkey()])
+    //     .confidential_transfer_transfer(
+    //         &alice_meta.token_account,
+    //         &bob_meta.token_account,
+    //         &alice,
+    //         42, // amount
+    //         42,
+    //         &extension.available_balance.try_into().unwrap(),
+    //         &bob_meta.elgamal_keypair.public,
+    //         &ct_mint.auditor_encryption_pubkey.try_into().unwrap(),
+    //     )
+    //     .await
+    //     .unwrap();
 
-    alice_meta
-        .check_balances(
-            &token,
-            ConfidentialTokenAccountBalances {
-                pending_balance_lo: 0,
-                pending_balance_hi: 0,
-                available_balance: 0,
-                decryptable_available_balance: 0,
-            },
-        )
-        .await;
+    // alice_meta
+    //     .check_balances(
+    //         &token,
+    //         ConfidentialTokenAccountBalances {
+    //             pending_balance_lo: 0,
+    //             pending_balance_hi: 0,
+    //             available_balance: 0,
+    //             decryptable_available_balance: 0,
+    //         },
+    //     )
+    //     .await;
 
-    bob_meta
-        .check_balances(
-            &token,
-            ConfidentialTokenAccountBalances {
-                pending_balance_lo: 42,
-                pending_balance_hi: 0,
-                available_balance: 0,
-                decryptable_available_balance: 0,
-            },
-        )
-        .await;
+    // bob_meta
+    //     .check_balances(
+    //         &token,
+    //         ConfidentialTokenAccountBalances {
+    //             pending_balance_lo: 42,
+    //             pending_balance_hi: 0,
+    //             available_balance: 0,
+    //             decryptable_available_balance: 0,
+    //         },
+    //     )
+    //     .await;
 }
 
 #[tokio::test]

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -1456,7 +1456,7 @@ async fn ct_transfer_memo() {
 
     // transfer with memo
     token
-        .with_memo("🦖")
+        .with_memo("🦖", vec![alice.pubkey()])
         .confidential_transfer_transfer(
             &alice_meta.token_account,
             &bob_meta.token_account,
@@ -1568,7 +1568,7 @@ async fn ct_transfer_with_fee_memo() {
     );
 
     token
-        .with_memo("🦖")
+        .with_memo("🦖", vec![alice.pubkey()])
         .confidential_transfer_transfer_with_fee(
             &alice_meta.token_account,
             &bob_meta.token_account,

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -814,7 +814,7 @@ async fn ct_transfer() {
         err,
         TokenClientError::Client(Box::new(TransportError::TransactionError(
             TransactionError::InstructionError(
-                1,
+                0,
                 InstructionError::Custom(
                     TokenError::MaximumPendingBalanceCreditCounterExceeded as u32
                 ),
@@ -886,7 +886,7 @@ async fn ct_transfer() {
     assert_eq!(
         err,
         TokenClientError::Client(Box::new(TransportError::TransactionError(
-            TransactionError::InstructionError(1, InstructionError::InvalidAccountData)
+            TransactionError::InstructionError(0, InstructionError::InvalidAccountData)
         )))
     );
 
@@ -1089,7 +1089,7 @@ async fn ct_transfer_with_fee() {
     assert_eq!(
         err,
         TokenClientError::Client(Box::new(TransportError::TransactionError(
-            TransactionError::InstructionError(1, InstructionError::InvalidAccountData)
+            TransactionError::InstructionError(0, InstructionError::InvalidAccountData)
         )))
     );
 

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -123,7 +123,7 @@ impl ConfidentialTokenAccountMeta {
         }
     }
 
-    async fn new_with_memo<T>(token: &Token<T>, owner: &Keypair) -> Self
+    async fn new_with_required_memo_transfers<T>(token: &Token<T>, owner: &Keypair) -> Self
     where
         T: SendTransaction,
     {
@@ -1419,7 +1419,8 @@ async fn ct_transfer_memo() {
     let alice_meta =
         ConfidentialTokenAccountMeta::with_tokens(&token, &alice, &mint_authority, 42, decimals)
             .await;
-    let bob_meta = ConfidentialTokenAccountMeta::new_with_memo(&token, &bob).await;
+    let bob_meta =
+        ConfidentialTokenAccountMeta::new_with_required_memo_transfers(&token, &bob).await;
 
     let state = token
         .get_account_info(&alice_meta.token_account)
@@ -1528,7 +1529,8 @@ async fn ct_transfer_with_fee_memo() {
     let alice_meta =
         ConfidentialTokenAccountMeta::with_tokens(&token, &alice, &mint_authority, 100, decimals)
             .await;
-    let bob_meta = ConfidentialTokenAccountMeta::new_with_memo(&token, &bob).await;
+    let bob_meta =
+        ConfidentialTokenAccountMeta::new_with_required_memo_transfers(&token, &bob).await;
 
     let state = token
         .get_account_info(&alice_meta.token_account)

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -1424,78 +1424,78 @@ async fn ct_transfer_memo() {
     let bob_meta =
         ConfidentialTokenAccountMeta::new_with_required_memo_transfers(&token, &bob).await;
 
-    // let state = token
-    //     .get_account_info(&alice_meta.token_account)
-    //     .await
-    //     .unwrap();
-    // let extension = state
-    //     .get_extension::<ConfidentialTransferAccount>()
-    //     .unwrap();
+    let state = token
+        .get_account_info(&alice_meta.token_account)
+        .await
+        .unwrap();
+    let extension = state
+        .get_extension::<ConfidentialTransferAccount>()
+        .unwrap();
 
-    // // transfer without memo
-    // let err = token
-    //     .confidential_transfer_transfer(
-    //         &alice_meta.token_account,
-    //         &bob_meta.token_account,
-    //         &alice,
-    //         42, // amount
-    //         42,
-    //         &extension.available_balance.try_into().unwrap(),
-    //         &bob_meta.elgamal_keypair.public,
-    //         &ct_mint.auditor_encryption_pubkey.try_into().unwrap(),
-    //     )
-    //     .await
-    //     .unwrap_err();
+    // transfer without memo
+    let err = token
+        .confidential_transfer_transfer(
+            &alice_meta.token_account,
+            &bob_meta.token_account,
+            &alice,
+            42, // amount
+            42,
+            &extension.available_balance.try_into().unwrap(),
+            &bob_meta.elgamal_keypair.public,
+            &ct_mint.auditor_encryption_pubkey.try_into().unwrap(),
+        )
+        .await
+        .unwrap_err();
 
-    // assert_eq!(
-    //     err,
-    //     TokenClientError::Client(Box::new(TransportError::TransactionError(
-    //         TransactionError::InstructionError(
-    //             0,
-    //             InstructionError::Custom(TokenError::NoMemo as u32)
-    //         )
-    //     )))
-    // );
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::NoMemo as u32)
+            )
+        )))
+    );
 
-    // // transfer with memo
-    // token
-    //     .with_memo("🦖", vec![alice.pubkey()])
-    //     .confidential_transfer_transfer(
-    //         &alice_meta.token_account,
-    //         &bob_meta.token_account,
-    //         &alice,
-    //         42, // amount
-    //         42,
-    //         &extension.available_balance.try_into().unwrap(),
-    //         &bob_meta.elgamal_keypair.public,
-    //         &ct_mint.auditor_encryption_pubkey.try_into().unwrap(),
-    //     )
-    //     .await
-    //     .unwrap();
+    // transfer with memo
+    token
+        .with_memo("🦖", vec![alice.pubkey()])
+        .confidential_transfer_transfer(
+            &alice_meta.token_account,
+            &bob_meta.token_account,
+            &alice,
+            42, // amount
+            42,
+            &extension.available_balance.try_into().unwrap(),
+            &bob_meta.elgamal_keypair.public,
+            &ct_mint.auditor_encryption_pubkey.try_into().unwrap(),
+        )
+        .await
+        .unwrap();
 
-    // alice_meta
-    //     .check_balances(
-    //         &token,
-    //         ConfidentialTokenAccountBalances {
-    //             pending_balance_lo: 0,
-    //             pending_balance_hi: 0,
-    //             available_balance: 0,
-    //             decryptable_available_balance: 0,
-    //         },
-    //     )
-    //     .await;
+    alice_meta
+        .check_balances(
+            &token,
+            ConfidentialTokenAccountBalances {
+                pending_balance_lo: 0,
+                pending_balance_hi: 0,
+                available_balance: 0,
+                decryptable_available_balance: 0,
+            },
+        )
+        .await;
 
-    // bob_meta
-    //     .check_balances(
-    //         &token,
-    //         ConfidentialTokenAccountBalances {
-    //             pending_balance_lo: 42,
-    //             pending_balance_hi: 0,
-    //             available_balance: 0,
-    //             decryptable_available_balance: 0,
-    //         },
-    //     )
-    //     .await;
+    bob_meta
+        .check_balances(
+            &token,
+            ConfidentialTokenAccountBalances {
+                pending_balance_lo: 42,
+                pending_balance_hi: 0,
+                available_balance: 0,
+                decryptable_available_balance: 0,
+            },
+        )
+        .await;
 }
 
 #[tokio::test]

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -603,14 +603,14 @@ pub fn empty_account(
     proof_data: &CloseAccountData,
 ) -> Result<Vec<Instruction>, ProgramError> {
     Ok(vec![
-        verify_close_account(proof_data),
         inner_empty_account(
             token_program_id,
             token_account,
             authority,
             multisig_signers,
-            -1,
+            1,
         )?, // calls check_program_account
+        verify_close_account(proof_data),
     ])
 }
 
@@ -704,7 +704,6 @@ pub fn withdraw(
     proof_data: &WithdrawData,
 ) -> Result<Vec<Instruction>, ProgramError> {
     Ok(vec![
-        verify_withdraw(proof_data),
         inner_withdraw(
             token_program_id,
             token_account,
@@ -714,8 +713,9 @@ pub fn withdraw(
             new_decryptable_available_balance.into(),
             authority,
             multisig_signers,
-            -1,
+            1,
         )?, // calls check_program_account
+        verify_withdraw(proof_data),
     ])
 }
 
@@ -772,7 +772,6 @@ pub fn transfer(
     proof_data: &TransferData,
 ) -> Result<Vec<Instruction>, ProgramError> {
     Ok(vec![
-        verify_transfer(proof_data),
         inner_transfer(
             token_program_id,
             source_token_account,
@@ -781,8 +780,9 @@ pub fn transfer(
             new_source_decryptable_available_balance.into(),
             authority,
             multisig_signers,
-            -1,
+            1,
         )?, // calls check_program_account
+        verify_transfer(proof_data),
     ])
 }
 
@@ -839,7 +839,6 @@ pub fn transfer_with_fee(
     proof_data: &TransferWithFeeData,
 ) -> Result<Vec<Instruction>, ProgramError> {
     Ok(vec![
-        verify_transfer_with_fee(proof_data),
         inner_transfer_with_fee(
             token_program_id,
             source_token_account,
@@ -848,8 +847,9 @@ pub fn transfer_with_fee(
             new_source_decryptable_available_balance.into(),
             authority,
             multisig_signers,
-            -1,
+            1,
         )?, // calls check_program_account
+        verify_transfer_with_fee(proof_data),
     ])
 }
 
@@ -1008,15 +1008,15 @@ pub fn withdraw_withheld_tokens_from_mint(
     proof_data: &WithdrawWithheldTokensData,
 ) -> Result<Vec<Instruction>, ProgramError> {
     Ok(vec![
-        verify_withdraw_withheld_tokens(proof_data),
         inner_withdraw_withheld_tokens_from_mint(
             token_program_id,
             mint,
             destination,
             authority,
             multisig_signers,
-            -1,
+            1,
         )?,
+        verify_withdraw_withheld_tokens(proof_data),
     ])
 }
 
@@ -1073,7 +1073,6 @@ pub fn withdraw_withheld_tokens_from_accounts(
     proof_data: &WithdrawWithheldTokensData,
 ) -> Result<Vec<Instruction>, ProgramError> {
     Ok(vec![
-        verify_withdraw_withheld_tokens(proof_data),
         inner_withdraw_withheld_tokens_from_accounts(
             token_program_id,
             mint,
@@ -1081,8 +1080,9 @@ pub fn withdraw_withheld_tokens_from_accounts(
             authority,
             multisig_signers,
             sources,
-            -1,
+            1,
         )?,
+        verify_withdraw_withheld_tokens(proof_data),
     ])
 }
 

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -4,6 +4,7 @@ use {
         error::TokenError,
         extension::{
             confidential_transfer::{instruction::*, *},
+            memo_transfer::{check_previous_sibling_instruction_is_memo, memo_required},
             non_transferable::NonTransferable,
             StateWithExtensions, StateWithExtensionsMut,
         },
@@ -696,6 +697,10 @@ fn process_destination_for_transfer(
 
     if destination_token_account.base.mint != *mint_info.key {
         return Err(TokenError::MintMismatch.into());
+    }
+
+    if memo_required(&destination_token_account) {
+        check_previous_sibling_instruction_is_memo()?;
     }
 
     let mut destination_confidential_transfer_account =


### PR DESCRIPTION
Confidential transfers without memo do not fail even if the destination accounts are extended to require fees. This PR fixes this so that confidential extension can work with the memo extension.