### PR TITLE
add overflow checks on release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,6 @@ exclude = [
 
 [profile.dev]
 split-debuginfo = "unpacked"
+
+[profile.release]
+overflow-checks = true


### PR DESCRIPTION
By default, overflow checks are disabled in optimized release builds. If there is an overflow in release builds, it is silenced and could potentially lead to unexpected behavior.

This PR adds `overflow-checks = true` under release profile in Cargo.toml.