### PR TITLE
Update token-js with rent-less instructions

### DIFF
--- a/token/js/src/actions/createMint.ts
+++ b/token/js/src/actions/createMint.ts
@@ -1,8 +1,8 @@
 import type { ConfirmOptions, Connection, PublicKey, Signer } from '@solana/web3.js';
 import { Keypair, sendAndConfirmTransaction, SystemProgram, Transaction } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ID } from '../constants.js';
-import { createInitializeMintInstruction } from '../instructions/initializeMint.js';
 import { getMinimumBalanceForRentExemptMint, MINT_SIZE } from '../state/mint.js';
+import { createInitializeMint2Instruction } from '../instructions/initializeMint2.js';
 
 /**
  * Create and initialize a new mint
@@ -38,7 +38,7 @@ export async function createMint(
             lamports,
             programId,
         }),
-        createInitializeMintInstruction(keypair.publicKey, decimals, mintAuthority, freezeAuthority, programId)
+        createInitializeMint2Instruction(keypair.publicKey, decimals, mintAuthority, freezeAuthority, programId)
     );
 
     await sendAndConfirmTransaction(connection, transaction, [payer, keypair], confirmOptions);

--- a/token/js/src/instructions/associatedTokenAccount.ts
+++ b/token/js/src/instructions/associatedTokenAccount.ts
@@ -1,5 +1,5 @@
 import type { PublicKey } from '@solana/web3.js';
-import { SystemProgram, SYSVAR_RENT_PUBKEY, TransactionInstruction } from '@solana/web3.js';
+import { SystemProgram, TransactionInstruction } from '@solana/web3.js';
 import { ASSOCIATED_TOKEN_PROGRAM_ID, TOKEN_PROGRAM_ID } from '../constants.js';
 
 /**
@@ -29,7 +29,6 @@ export function createAssociatedTokenAccountInstruction(
         { pubkey: mint, isSigner: false, isWritable: false },
         { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
         { pubkey: programId, isSigner: false, isWritable: false },
-        { pubkey: SYSVAR_RENT_PUBKEY, isSigner: false, isWritable: false },
     ];
 
     return new TransactionInstruction({

--- a/token/js/src/instructions/decode.ts
+++ b/token/js/src/instructions/decode.ts
@@ -247,10 +247,3 @@ export function isUiamountToAmountInstruction(
 // ): decoded is DecodedInitializeMultisig2Instruction {
 //     return decoded.data.instruction === TokenInstruction.InitializeMultisig2;
 // }
-
-/** TODO: docs, implement */
-// export function isInitializeMint2Instruction(
-//     decoded: DecodedInstruction
-// ): decoded is DecodedInitializeMint2Instruction {
-//     return decoded.data.instruction === TokenInstruction.InitializeMint2;
-// }

--- a/token/js/src/instructions/decode.ts
+++ b/token/js/src/instructions/decode.ts
@@ -45,6 +45,8 @@ import { decodeTransferCheckedInstruction } from './transferChecked.js';
 import { TokenInstruction } from './types.js';
 import type { DecodedUiAmountToAmountInstruction } from './uiAmountToAmount.js';
 import { decodeUiAmountToAmountInstruction } from './uiAmountToAmount.js';
+import type { DecodedInitializeMint2Instruction } from './initializeMint2.js';
+import { decodeInitializeMint2Instruction } from './initializeMint2.js';
 
 /** TODO: docs */
 export type DecodedInstruction =
@@ -69,8 +71,8 @@ export type DecodedInstruction =
     | DecodedInitializeAccount3Instruction
     | DecodedAmountToUiAmountInstruction
     | DecodedUiAmountToAmountInstruction
+    | DecodedInitializeMint2Instruction
     // | DecodedInitializeMultisig2Instruction
-    // | DecodedInitializeMint2Instruction
     // TODO: implement ^ and remove `never`
     | never;
 
@@ -104,13 +106,11 @@ export function decodeInstruction(
     if (type === TokenInstruction.SyncNative) return decodeSyncNativeInstruction(instruction, programId);
     if (type === TokenInstruction.AmountToUiAmount) return decodeAmountToUiAmountInstruction(instruction, programId);
     if (type === TokenInstruction.UiAmountToAmount) return decodeUiAmountToAmountInstruction(instruction, programId);
-    // TODO: implement
     if (type === TokenInstruction.InitializeAccount3)
         return decodeInitializeAccount3Instruction(instruction, programId);
+    if (type === TokenInstruction.InitializeMint2) return decodeInitializeMint2Instruction(instruction, programId);
     // TODO: implement
     if (type === TokenInstruction.InitializeMultisig2) throw new TokenInvalidInstructionTypeError();
-    // TODO: implement
-    if (type === TokenInstruction.InitializeMint2) throw new TokenInvalidInstructionTypeError();
 
     throw new TokenInvalidInstructionTypeError();
 }

--- a/token/js/src/instructions/decode.ts
+++ b/token/js/src/instructions/decode.ts
@@ -69,9 +69,9 @@ export type DecodedInstruction =
     | DecodedInitializeAccount2Instruction
     | DecodedSyncNativeInstruction
     | DecodedInitializeAccount3Instruction
+    | DecodedInitializeMint2Instruction
     | DecodedAmountToUiAmountInstruction
     | DecodedUiAmountToAmountInstruction
-    | DecodedInitializeMint2Instruction
     // | DecodedInitializeMultisig2Instruction
     // TODO: implement ^ and remove `never`
     | never;
@@ -104,11 +104,11 @@ export function decodeInstruction(
     if (type === TokenInstruction.InitializeAccount2)
         return decodeInitializeAccount2Instruction(instruction, programId);
     if (type === TokenInstruction.SyncNative) return decodeSyncNativeInstruction(instruction, programId);
-    if (type === TokenInstruction.AmountToUiAmount) return decodeAmountToUiAmountInstruction(instruction, programId);
-    if (type === TokenInstruction.UiAmountToAmount) return decodeUiAmountToAmountInstruction(instruction, programId);
     if (type === TokenInstruction.InitializeAccount3)
         return decodeInitializeAccount3Instruction(instruction, programId);
     if (type === TokenInstruction.InitializeMint2) return decodeInitializeMint2Instruction(instruction, programId);
+    if (type === TokenInstruction.AmountToUiAmount) return decodeAmountToUiAmountInstruction(instruction, programId);
+    if (type === TokenInstruction.UiAmountToAmount) return decodeUiAmountToAmountInstruction(instruction, programId);
     // TODO: implement
     if (type === TokenInstruction.InitializeMultisig2) throw new TokenInvalidInstructionTypeError();
 
@@ -118,13 +118,6 @@ export function decodeInstruction(
 /** TODO: docs */
 export function isInitializeMintInstruction(decoded: DecodedInstruction): decoded is DecodedInitializeMintInstruction {
     return decoded.data.instruction === TokenInstruction.InitializeMint;
-}
-
-/** TODO: docs */
-export function isInitializeMint2Instruction(
-    decoded: DecodedInstruction
-): decoded is DecodedInitializeMint2Instruction {
-    return decoded.data.instruction === TokenInstruction.InitializeMint2;
 }
 
 /** TODO: docs */
@@ -227,6 +220,20 @@ export function isInitializeAccount3Instruction(
     return decoded.data.instruction === TokenInstruction.InitializeAccount3;
 }
 
+/** TODO: docs, implement */
+// export function isInitializeMultisig2Instruction(
+//     decoded: DecodedInstruction
+// ): decoded is DecodedInitializeMultisig2Instruction {
+//     return decoded.data.instruction === TokenInstruction.InitializeMultisig2;
+// }
+
+/** TODO: docs */
+export function isInitializeMint2Instruction(
+    decoded: DecodedInstruction
+): decoded is DecodedInitializeMint2Instruction {
+    return decoded.data.instruction === TokenInstruction.InitializeMint2;
+}
+
 /** TODO: docs */
 export function isAmountToUiAmountInstruction(
     decoded: DecodedInstruction
@@ -240,10 +247,3 @@ export function isUiamountToAmountInstruction(
 ): decoded is DecodedUiAmountToAmountInstruction {
     return decoded.data.instruction === TokenInstruction.UiAmountToAmount;
 }
-
-/** TODO: docs, implement */
-// export function isInitializeMultisig2Instruction(
-//     decoded: DecodedInstruction
-// ): decoded is DecodedInitializeMultisig2Instruction {
-//     return decoded.data.instruction === TokenInstruction.InitializeMultisig2;
-// }

--- a/token/js/src/instructions/decode.ts
+++ b/token/js/src/instructions/decode.ts
@@ -121,6 +121,13 @@ export function isInitializeMintInstruction(decoded: DecodedInstruction): decode
 }
 
 /** TODO: docs */
+export function isInitializeMint2Instruction(
+    decoded: DecodedInstruction
+): decoded is DecodedInitializeMint2Instruction {
+    return decoded.data.instruction === TokenInstruction.InitializeMint2;
+}
+
+/** TODO: docs */
 export function isInitializeAccountInstruction(
     decoded: DecodedInstruction
 ): decoded is DecodedInitializeAccountInstruction {

--- a/token/js/src/instructions/initializeMint2.ts
+++ b/token/js/src/instructions/initializeMint2.ts
@@ -1,1 +1,153 @@
-export {}; // TODO: implement
+import { struct, u8 } from '@solana/buffer-layout';
+import { publicKey } from '@solana/buffer-layout-utils';
+import type { AccountMeta } from '@solana/web3.js';
+import { PublicKey, TransactionInstruction } from '@solana/web3.js';
+import { TOKEN_PROGRAM_ID } from '../constants.js';
+import {
+    TokenInvalidInstructionDataError,
+    TokenInvalidInstructionKeysError,
+    TokenInvalidInstructionProgramError,
+    TokenInvalidInstructionTypeError,
+} from '../errors.js';
+import { TokenInstruction } from './types.js';
+
+/** TODO: docs */
+export interface InitializeMint2InstructionData {
+    instruction: TokenInstruction.InitializeMint2;
+    decimals: number;
+    mintAuthority: PublicKey;
+    freezeAuthorityOption: 1 | 0;
+    freezeAuthority: PublicKey;
+}
+
+/** TODO: docs */
+export const initializeMint2InstructionData = struct<InitializeMint2InstructionData>([
+    u8('instruction'),
+    u8('decimals'),
+    publicKey('mintAuthority'),
+    u8('freezeAuthorityOption'),
+    publicKey('freezeAuthority'),
+]);
+
+/**
+ * Construct an InitializeMint2 instruction
+ *
+ * @param mint            Token mint account
+ * @param decimals        Number of decimals in token account amounts
+ * @param mintAuthority   Minting authority
+ * @param freezeAuthority Optional authority that can freeze token accounts
+ * @param programId       SPL Token program account
+ *
+ * @return Instruction to add to a transaction
+ */
+export function createInitializeMint2Instruction(
+    mint: PublicKey,
+    decimals: number,
+    mintAuthority: PublicKey,
+    freezeAuthority: PublicKey | null,
+    programId = TOKEN_PROGRAM_ID
+): TransactionInstruction {
+    const keys = [{ pubkey: mint, isSigner: false, isWritable: true }];
+
+    const data = Buffer.alloc(initializeMint2InstructionData.span);
+    initializeMint2InstructionData.encode(
+        {
+            instruction: TokenInstruction.InitializeMint2,
+            decimals,
+            mintAuthority,
+            freezeAuthorityOption: freezeAuthority ? 1 : 0,
+            freezeAuthority: freezeAuthority || new PublicKey(0),
+        },
+        data
+    );
+
+    return new TransactionInstruction({ keys, programId, data });
+}
+
+/** A decoded, valid InitializeMint2 instruction */
+export interface DecodedInitializeMint2Instruction {
+    programId: PublicKey;
+    keys: {
+        mint: AccountMeta;
+    };
+    data: {
+        instruction: TokenInstruction.InitializeMint2;
+        decimals: number;
+        mintAuthority: PublicKey;
+        freezeAuthority: PublicKey | null;
+    };
+}
+
+/**
+ * Decode an InitializeMint2 instruction and validate it
+ *
+ * @param instruction Transaction instruction to decode
+ * @param programId   SPL Token program account
+ *
+ * @return Decoded, valid instruction
+ */
+export function decodeInitializeMint2Instruction(
+    instruction: TransactionInstruction,
+    programId = TOKEN_PROGRAM_ID
+): DecodedInitializeMint2Instruction {
+    if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
+    if (instruction.data.length !== initializeMint2InstructionData.span) throw new TokenInvalidInstructionDataError();
+
+    const {
+        keys: { mint },
+        data,
+    } = decodeInitializeMint2InstructionUnchecked(instruction);
+    if (data.instruction !== TokenInstruction.InitializeMint2) throw new TokenInvalidInstructionTypeError();
+    if (!mint) throw new TokenInvalidInstructionKeysError();
+
+    return {
+        programId,
+        keys: {
+            mint,
+        },
+        data,
+    };
+}
+
+/** A decoded, non-validated InitializeMint2 instruction */
+export interface DecodedInitializeMint2InstructionUnchecked {
+    programId: PublicKey;
+    keys: {
+        mint: AccountMeta | undefined;
+    };
+    data: {
+        instruction: number;
+        decimals: number;
+        mintAuthority: PublicKey;
+        freezeAuthority: PublicKey | null;
+    };
+}
+
+/**
+ * Decode an InitializeMint2 instruction without validating it
+ *
+ * @param instruction Transaction instruction to decode
+ *
+ * @return Decoded, non-validated instruction
+ */
+export function decodeInitializeMint2InstructionUnchecked({
+    programId,
+    keys: [mint],
+    data,
+}: TransactionInstruction): DecodedInitializeMint2InstructionUnchecked {
+    const { instruction, decimals, mintAuthority, freezeAuthorityOption, freezeAuthority } =
+        initializeMint2InstructionData.decode(data);
+
+    return {
+        programId,
+        keys: {
+            mint,
+        },
+        data: {
+            instruction,
+            decimals,
+            mintAuthority,
+            freezeAuthority: freezeAuthorityOption ? freezeAuthority : null,
+        },
+    };
+}

--- a/token/js/test/unit/index.test.ts
+++ b/token/js/test/unit/index.test.ts
@@ -6,6 +6,7 @@ import {
     createAssociatedTokenAccountInstruction,
     createReallocateInstruction,
     createInitializeMintInstruction,
+    createInitializeMint2Instruction,
     createSyncNativeInstruction,
     createTransferCheckedInstruction,
     getAssociatedTokenAddress,
@@ -42,6 +43,17 @@ describe('spl-token instructions', () => {
         const ix = createInitializeMintInstruction(Keypair.generate().publicKey, 9, Keypair.generate().publicKey, null);
         expect(ix.programId).to.eql(TOKEN_PROGRAM_ID);
         expect(ix.keys).to.have.length(2);
+    });
+
+    it('InitializeMint2', () => {
+        const ix = createInitializeMint2Instruction(
+            Keypair.generate().publicKey,
+            9,
+            Keypair.generate().publicKey,
+            null
+        );
+        expect(ix.programId).to.eql(TOKEN_PROGRAM_ID);
+        expect(ix.keys).to.have.length(1);
     });
 
     it('SyncNative', () => {
@@ -97,6 +109,18 @@ describe('spl-token-2022 instructions', () => {
         );
         expect(ix.programId).to.eql(TOKEN_2022_PROGRAM_ID);
         expect(ix.keys).to.have.length(2);
+    });
+
+    it('InitializeMint2', () => {
+        const ix = createInitializeMint2Instruction(
+            Keypair.generate().publicKey,
+            9,
+            Keypair.generate().publicKey,
+            null,
+            TOKEN_2022_PROGRAM_ID
+        );
+        expect(ix.programId).to.eql(TOKEN_2022_PROGRAM_ID);
+        expect(ix.keys).to.have.length(1);
     });
 
     it('SyncNative', () => {

--- a/token/js/test/unit/index.test.ts
+++ b/token/js/test/unit/index.test.ts
@@ -139,7 +139,7 @@ describe('spl-associated-token-account instructions', () => {
             Keypair.generate().publicKey
         );
         expect(ix.programId).to.eql(ASSOCIATED_TOKEN_PROGRAM_ID);
-        expect(ix.keys).to.have.length(7);
+        expect(ix.keys).to.have.length(6);
     });
 });
 


### PR DESCRIPTION
Implemented the `InitializeMint2` instruction and updated the `createAssociatedTokenAccount` instruction builder to not use rent anymore. In addition, I defaulted the createMint instruction to use the new `InitializeMint2` handler. Not sure if there's a good reason not to do that? Would love to hear any reasons if they do exist. 