### PR TITLE
token-client: Add fmt::Display implementation to RpcClientResponse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6187,6 +6187,7 @@ name = "spl-token-client"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "solana-cli-output",
  "solana-client",
  "solana-program-test",
  "solana-sdk",

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -9,6 +9,7 @@ version = "0.1.0"
 
 [dependencies]
 async-trait = "0.1"
+solana-cli-output = { version = "=1.11.6", optional = true }
 solana-client = "=1.11.6"
 solana-program-test = "=1.11.6"
 solana-sdk = "=1.11.6"
@@ -18,3 +19,7 @@ spl-associated-token-account = { version = "1.1", path = "../../associated-token
 spl-memo = { version = "3.0.1", path = "../../memo/program", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "0.4", path="../program-2022" }
 thiserror = "1.0"
+
+[features]
+default = ["display"]
+display = ["dep:solana-cli-output"]

--- a/token/client/src/lib.rs
+++ b/token/client/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod client;
+pub mod output;
 pub mod token;
 
 pub use spl_token_2022;

--- a/token/client/src/output.rs
+++ b/token/client/src/output.rs
@@ -1,0 +1,54 @@
+#![cfg(feature = "display")]
+
+use {crate::client::RpcClientResponse, solana_cli_output::display::writeln_transaction, std::fmt};
+
+impl fmt::Display for RpcClientResponse {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            RpcClientResponse::Signature(signature) => writeln!(f, "Signature: {}", signature),
+            RpcClientResponse::Transaction(transaction) => {
+                writeln!(f, "Transaction:")?;
+                writeln_transaction(f, &transaction.clone().into(), None, "  ", None, None)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        solana_sdk::{
+            hash::Hash,
+            pubkey::Pubkey,
+            signature::{Signature, Signer, SIGNATURE_BYTES},
+            signer::keypair::Keypair,
+            system_instruction,
+            transaction::Transaction,
+        },
+    };
+
+    #[test]
+    fn display_signature() {
+        let signature_bytes = [202u8; SIGNATURE_BYTES];
+        let signature = RpcClientResponse::Signature(Signature::new(&signature_bytes));
+        println!("{}", signature);
+    }
+
+    #[test]
+    fn display_transaction() {
+        let payer = Keypair::new();
+        let transaction = Transaction::new_signed_with_payer(
+            &[system_instruction::transfer(
+                &payer.pubkey(),
+                &Pubkey::new_unique(),
+                10,
+            )],
+            Some(&payer.pubkey()),
+            &[&payer],
+            Hash::default(),
+        );
+        let transaction = RpcClientResponse::Transaction(transaction);
+        println!("{}", transaction);
+    }
+}

--- a/update-solana-dependencies.sh
+++ b/update-solana-dependencies.sh
@@ -47,4 +47,5 @@ crates=(
 set -x
 for crate in "${crates[@]}"; do
   sed -E -i'' -e "s:(${crate} = \")(=?)${old_solana_ver}\".*:\1\2${solana_ver}\":" "${tomls[@]}"
+  sed -E -i'' -e "s:(${crate} = \{ version = \")(=?)${old_solana_ver}(\".*):\1\2${solana_ver}\3:" "${tomls[@]}"
 done


### PR DESCRIPTION
#### Problem

While working on #3593, I wanted to print the result from the token client, but the Debug printer for `Signature` gives `Signature(signature_in_base_58)`, which is not great.

#### Solution

Implement `fmt::Display` on `RpcClientResponse`, and add a feature for output that can be disable if needed.