### PR TITLE
token-wrap: Add interface description for wrapping program between two mints and/or token programs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7067,6 +7067,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-token-wrap"
+version = "0.1.0"
+dependencies = [
+ "bytemuck",
+ "num_enum 0.5.11",
+ "solana-program",
+ "spl-associated-token-account 2.0.0",
+ "spl-token 4.0.0",
+ "spl-token-2022 0.7.0",
+ "thiserror",
+]
+
+[[package]]
 name = "spl-transfer-hook-example"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ members = [
   "token-swap/program/fuzz",
   "token-upgrade/cli",
   "token-upgrade/program",
+  "token-wrap/program",
   "token/cli",
   "token/program",
   "token/program-2022",

--- a/token-wrap/program/Cargo.toml
+++ b/token-wrap/program/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "spl-token-wrap"
+version = "0.1.0"
+description = "Solana Program Library Token Wrap"
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+repository = "https://github.com/solana-labs/solana-program-library"
+license = "Apache-2.0"
+edition = "2018"
+
+[features]
+no-entrypoint = []
+test-sbf = []
+
+[dependencies]
+bytemuck = { version = "1.7.2", features = ["derive"] }
+num_enum = "0.5"
+solana-program = "1.16.1"
+spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
+spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.7", path = "../../token/program-2022", features = ["no-entrypoint"] }
+thiserror = "1.0"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/token-wrap/program/src/entrypoint.rs
+++ b/token-wrap/program/src/entrypoint.rs
@@ -1,0 +1,16 @@
+//! Program entrypoint
+
+#![cfg(all(target_os = "solana", not(feature = "no-entrypoint")))]
+
+use solana_program::{
+    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
+};
+
+entrypoint!(process_instruction);
+fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    crate::processor::process_instruction(program_id, accounts, instruction_data)
+}

--- a/token-wrap/program/src/instruction.rs
+++ b/token-wrap/program/src/instruction.rs
@@ -1,12 +1,6 @@
 //! Program instructions
 
-use {
-    num_enum::{IntoPrimitive, TryFromPrimitive},
-    solana_program::{
-        instruction::{AccountMeta, Instruction},
-        pubkey::Pubkey,
-    },
-};
+use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 /// Instructions supported by the Token Wrap program
 #[derive(Clone, Debug, PartialEq, TryFromPrimitive, IntoPrimitive)]

--- a/token-wrap/program/src/instruction.rs
+++ b/token-wrap/program/src/instruction.rs
@@ -1,0 +1,84 @@
+//! Program instructions
+
+use {
+    num_enum::{IntoPrimitive, TryFromPrimitive},
+    solana_program::{
+        instruction::{AccountMeta, Instruction},
+        pubkey::Pubkey,
+    },
+};
+
+/// Instructions supported by the Token Wrap program
+#[derive(Clone, Debug, PartialEq, TryFromPrimitive, IntoPrimitive)]
+#[repr(u8)]
+pub enum TokenWrapInstruction {
+    /// Create a wrapped token mint
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    /// 0. `[writeable,signer]` Funding account for mint and backpointer (must be a system account)
+    /// 1. `[writeable]` Unallocated wrapped mint account to create, address must be:
+    ///     `get_wrapped_mint_address(unwrapped_mint_address, wrapped_token_program_id)`
+    /// 2. `[writeable]` Unallocated wrapped backpointer account to create
+    ///     `get_wrapped_mint_backpointer_address(wrapped_mint_address)`
+    /// 3. `[]` Existing unwrapped mint
+    /// 4. `[]` System program
+    /// 5. `[]` SPL Token program for wrapped mint
+    ///
+    /// Data expected by this instruction:
+    ///   * bool: true = idempotent creation, false = non-idempotent creation
+    ///
+    CreateMint,
+
+    /// Wrap tokens
+    ///
+    /// Move a user's unwrapped tokens into an escrow account and mint the same
+    /// number of wrapped tokens into the provided account.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    /// 0. `[writeable]` Unwrapped token account to wrap
+    /// 1. `[writeable]` Escrow of unwrapped tokens, must be owned by:
+    ///     `get_wrapped_mint_authority(wrapped_mint_address)`
+    /// 2. `[]` Unwrapped token mint
+    /// 3. `[writeable]` Wrapped mint, must be initialized, address must be:
+    ///     `get_wrapped_mint_address(unwrapped_mint_address, wrapped_token_program_id)`
+    /// 4. `[writeable]` Recipient wrapped token account
+    /// 5. `[]` Escrow mint authority, address must be:
+    ///     `get_wrapped_mint_authority(wrapped_mint)`
+    /// 6. `[]` SPL Token program for unwrapped mint
+    /// 7. `[]` SPL Token program for wrapped mint
+    /// 8. `[signer]` Transfer authority on unwrapped token account
+    /// 8..8+M. `[signer]` (Optional) M multisig signers on unwrapped token account
+    ///
+    /// Data expected by this instruction:
+    ///   * little-endian u64 representing the amount to wrap
+    ///
+    Wrap,
+
+    /// Unwrap tokens
+    ///
+    /// Burn user wrapped tokens and transfer the same amount of unwrapped tokens
+    /// from the escrow account to the provided account.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    /// 0. `[writeable]` Wrapped token account to unwrap
+    /// 1. `[writeable]` Wrapped mint, address must be:
+    ///     `get_wrapped_mint_address(unwrapped_mint_address, wrapped_token_program_id)`
+    /// 2. `[writeable]` Escrow of unwrapped tokens, must be owned by:
+    ///     `get_wrapped_mint_authority(wrapped_mint_address)`
+    /// 3. `[writeable]` Recipient unwrapped tokens
+    /// 4. `[]` Unwrapped token mint
+    /// 5. `[]` Escrow unwrapped token authority
+    ///     `get_wrapped_mint_authority(wrapped_mint)`
+    /// 6. `[]` SPL Token program for wrapped mint
+    /// 7. `[]` SPL Token program for unwrapped mint
+    /// 8. `[signer]` Transfer authority on wrapped token account
+    /// 8..8+M. `[signer]` (Optional) M multisig signers on wrapped token account
+    ///
+    /// Data expected by this instruction:
+    ///   * little-endian u64 representing the amount to unwrap
+    ///
+    Unwrap,
+}

--- a/token-wrap/program/src/lib.rs
+++ b/token-wrap/program/src/lib.rs
@@ -15,8 +15,14 @@ solana_program::declare_id!("TwRapQCDhWkZRrDaHfZGuHxkZ91gHDRkyuzNqeU5MgR");
 
 const WRAPPED_MINT_SEED: &[u8] = br"mint";
 
-pub(crate) fn get_wrapped_mint_address_with_seed(unwrapped_mint: &Pubkey, wrapped_token_program_id: &Pubkey) -> (Pubkey, u8) {
-    Pubkey::find_program_address(&get_wrapped_mint_seeds(unwrapped_mint, wrapped_token_program_id), &id())
+pub(crate) fn get_wrapped_mint_address_with_seed(
+    unwrapped_mint: &Pubkey,
+    wrapped_token_program_id: &Pubkey,
+) -> (Pubkey, u8) {
+    Pubkey::find_program_address(
+        &get_wrapped_mint_seeds(unwrapped_mint, wrapped_token_program_id),
+        &id(),
+    )
 }
 
 pub(crate) fn get_wrapped_mint_seeds<'a>(
@@ -30,7 +36,7 @@ pub(crate) fn get_wrapped_mint_seeds<'a>(
     ]
 }
 
-pub(crate) fn get_wrapped_mint_signer_seeds<'a>(
+pub(crate) fn _get_wrapped_mint_signer_seeds<'a>(
     unwrapped_mint: &'a Pubkey,
     wrapped_token_program_id: &'a Pubkey,
     bump_seed: &'a [u8],
@@ -44,28 +50,31 @@ pub(crate) fn get_wrapped_mint_signer_seeds<'a>(
 }
 
 /// Derive the SPL Token wrapped mint address associated with an unwrapped mint
-pub fn get_wrapped_mint_address(unwrapped_mint: &Pubkey, wrapped_token_program_id: &Pubkey) -> Pubkey {
+pub fn get_wrapped_mint_address(
+    unwrapped_mint: &Pubkey,
+    wrapped_token_program_id: &Pubkey,
+) -> Pubkey {
     get_wrapped_mint_address_with_seed(unwrapped_mint, wrapped_token_program_id).0
 }
 
 const WRAPPED_MINT_AUTHORITY_SEED: &[u8] = br"authority";
 
-pub(crate) fn get_wrapped_mint_authority_seeds<'a>(
-    wrapped_mint: &'a Pubkey,
-) -> [&'a [u8]; 2] {
+pub(crate) fn get_wrapped_mint_authority_seeds(wrapped_mint: &Pubkey) -> [&[u8]; 2] {
     [WRAPPED_MINT_AUTHORITY_SEED, wrapped_mint.as_ref()]
 }
 
-pub(crate) fn get_wrapped_mint_authority_signer_seeds<'a>(
+pub(crate) fn _get_wrapped_mint_authority_signer_seeds<'a>(
     wrapped_mint: &'a Pubkey,
     bump_seed: &'a [u8],
 ) -> [&'a [u8]; 3] {
-    [WRAPPED_MINT_AUTHORITY_SEED, wrapped_mint.as_ref(), bump_seed]
+    [
+        WRAPPED_MINT_AUTHORITY_SEED,
+        wrapped_mint.as_ref(),
+        bump_seed,
+    ]
 }
 
-pub(crate) fn get_wrapped_mint_authority_with_seed(
-    wrapped_mint: &Pubkey,
-) -> (Pubkey, u8) {
+pub(crate) fn get_wrapped_mint_authority_with_seed(wrapped_mint: &Pubkey) -> (Pubkey, u8) {
     Pubkey::find_program_address(&get_wrapped_mint_authority_seeds(wrapped_mint), &id())
 }
 
@@ -76,23 +85,28 @@ pub fn get_wrapped_mint_authority(wrapped_mint: &Pubkey) -> Pubkey {
 
 const WRAPPED_MINT_BACKPOINTER_SEED: &[u8] = br"backpointer";
 
-pub(crate) fn get_wrapped_mint_backpointer_address_seeds<'a>(
-    wrapped_mint: &'a Pubkey,
-) -> [&'a [u8]; 2] {
+pub(crate) fn get_wrapped_mint_backpointer_address_seeds(wrapped_mint: &Pubkey) -> [&[u8]; 2] {
     [WRAPPED_MINT_BACKPOINTER_SEED, wrapped_mint.as_ref()]
 }
 
-pub(crate) fn get_wrapped_mint_backpointer_address_signer_seeds<'a>(
+pub(crate) fn _get_wrapped_mint_backpointer_address_signer_seeds<'a>(
     wrapped_mint: &'a Pubkey,
     bump_seed: &'a [u8],
 ) -> [&'a [u8]; 3] {
-    [WRAPPED_MINT_BACKPOINTER_SEED, wrapped_mint.as_ref(), bump_seed]
+    [
+        WRAPPED_MINT_BACKPOINTER_SEED,
+        wrapped_mint.as_ref(),
+        bump_seed,
+    ]
 }
 
 pub(crate) fn get_wrapped_mint_backpointer_address_with_seed(
     wrapped_mint: &Pubkey,
 ) -> (Pubkey, u8) {
-    Pubkey::find_program_address(&get_wrapped_mint_backpointer_address_seeds(wrapped_mint), &id())
+    Pubkey::find_program_address(
+        &get_wrapped_mint_backpointer_address_seeds(wrapped_mint),
+        &id(),
+    )
 }
 
 /// Derive the SPL Token wrapped mint backpointer address

--- a/token-wrap/program/src/lib.rs
+++ b/token-wrap/program/src/lib.rs
@@ -1,0 +1,101 @@
+//! Token Wrap program
+#![deny(missing_docs)]
+#![forbid(unsafe_code)]
+
+mod entrypoint;
+pub mod instruction;
+pub mod processor;
+pub mod state;
+
+// Export current SDK types for downstream users building with a different SDK version
+pub use solana_program;
+use solana_program::pubkey::Pubkey;
+
+solana_program::declare_id!("TwRapQCDhWkZRrDaHfZGuHxkZ91gHDRkyuzNqeU5MgR");
+
+const WRAPPED_MINT_SEED: &[u8] = br"mint";
+
+pub(crate) fn get_wrapped_mint_address_with_seed(unwrapped_mint: &Pubkey, wrapped_token_program_id: &Pubkey) -> (Pubkey, u8) {
+    Pubkey::find_program_address(&get_wrapped_mint_seeds(unwrapped_mint, wrapped_token_program_id), &id())
+}
+
+pub(crate) fn get_wrapped_mint_seeds<'a>(
+    unwrapped_mint: &'a Pubkey,
+    wrapped_token_program_id: &'a Pubkey,
+) -> [&'a [u8]; 3] {
+    [
+        WRAPPED_MINT_SEED,
+        unwrapped_mint.as_ref(),
+        wrapped_token_program_id.as_ref(),
+    ]
+}
+
+pub(crate) fn get_wrapped_mint_signer_seeds<'a>(
+    unwrapped_mint: &'a Pubkey,
+    wrapped_token_program_id: &'a Pubkey,
+    bump_seed: &'a [u8],
+) -> [&'a [u8]; 4] {
+    [
+        WRAPPED_MINT_SEED,
+        unwrapped_mint.as_ref(),
+        wrapped_token_program_id.as_ref(),
+        bump_seed,
+    ]
+}
+
+/// Derive the SPL Token wrapped mint address associated with an unwrapped mint
+pub fn get_wrapped_mint_address(unwrapped_mint: &Pubkey, wrapped_token_program_id: &Pubkey) -> Pubkey {
+    get_wrapped_mint_address_with_seed(unwrapped_mint, wrapped_token_program_id).0
+}
+
+const WRAPPED_MINT_AUTHORITY_SEED: &[u8] = br"authority";
+
+pub(crate) fn get_wrapped_mint_authority_seeds<'a>(
+    wrapped_mint: &'a Pubkey,
+) -> [&'a [u8]; 2] {
+    [WRAPPED_MINT_AUTHORITY_SEED, wrapped_mint.as_ref()]
+}
+
+pub(crate) fn get_wrapped_mint_authority_signer_seeds<'a>(
+    wrapped_mint: &'a Pubkey,
+    bump_seed: &'a [u8],
+) -> [&'a [u8]; 3] {
+    [WRAPPED_MINT_AUTHORITY_SEED, wrapped_mint.as_ref(), bump_seed]
+}
+
+pub(crate) fn get_wrapped_mint_authority_with_seed(
+    wrapped_mint: &Pubkey,
+) -> (Pubkey, u8) {
+    Pubkey::find_program_address(&get_wrapped_mint_authority_seeds(wrapped_mint), &id())
+}
+
+/// Derive the SPL Token wrapped mint authority address
+pub fn get_wrapped_mint_authority(wrapped_mint: &Pubkey) -> Pubkey {
+    get_wrapped_mint_authority_with_seed(wrapped_mint).0
+}
+
+const WRAPPED_MINT_BACKPOINTER_SEED: &[u8] = br"backpointer";
+
+pub(crate) fn get_wrapped_mint_backpointer_address_seeds<'a>(
+    wrapped_mint: &'a Pubkey,
+) -> [&'a [u8]; 2] {
+    [WRAPPED_MINT_BACKPOINTER_SEED, wrapped_mint.as_ref()]
+}
+
+pub(crate) fn get_wrapped_mint_backpointer_address_signer_seeds<'a>(
+    wrapped_mint: &'a Pubkey,
+    bump_seed: &'a [u8],
+) -> [&'a [u8]; 3] {
+    [WRAPPED_MINT_BACKPOINTER_SEED, wrapped_mint.as_ref(), bump_seed]
+}
+
+pub(crate) fn get_wrapped_mint_backpointer_address_with_seed(
+    wrapped_mint: &Pubkey,
+) -> (Pubkey, u8) {
+    Pubkey::find_program_address(&get_wrapped_mint_backpointer_address_seeds(wrapped_mint), &id())
+}
+
+/// Derive the SPL Token wrapped mint backpointer address
+pub fn get_wrapped_mint_backpointer_address(wrapped_mint: &Pubkey) -> Pubkey {
+    get_wrapped_mint_backpointer_address_with_seed(wrapped_mint).0
+}

--- a/token-wrap/program/src/processor.rs
+++ b/token-wrap/program/src/processor.rs
@@ -1,22 +1,15 @@
 //! Program state processor
 
 use {
-    crate::{instruction::TokenWrapInstruction, state::Backpointer},
-    solana_program::{
-        account_info::{next_account_info, AccountInfo},
-        entrypoint::ProgramResult,
-        msg,
-        program::{invoke, invoke_signed},
-        program_error::ProgramError,
-        pubkey::Pubkey,
-    },
-    spl_token_2022::instruction::{decode_instruction_type, decode_instruction_data},
+    crate::instruction::TokenWrapInstruction,
+    solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey},
+    spl_token_2022::instruction::decode_instruction_type,
 };
 
 /// Instruction processor
 pub fn process_instruction(
-    program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    _program_id: &Pubkey,
+    _accounts: &[AccountInfo],
     input: &[u8],
 ) -> ProgramResult {
     match decode_instruction_type(input)? {

--- a/token-wrap/program/src/processor.rs
+++ b/token-wrap/program/src/processor.rs
@@ -1,0 +1,33 @@
+//! Program state processor
+
+use {
+    crate::{instruction::TokenWrapInstruction, state::Backpointer},
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        msg,
+        program::{invoke, invoke_signed},
+        program_error::ProgramError,
+        pubkey::Pubkey,
+    },
+    spl_token_2022::instruction::{decode_instruction_type, decode_instruction_data},
+};
+
+/// Instruction processor
+pub fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    input: &[u8],
+) -> ProgramResult {
+    match decode_instruction_type(input)? {
+        TokenWrapInstruction::CreateMint => {
+            unimplemented!();
+        }
+        TokenWrapInstruction::Wrap => {
+            unimplemented!();
+        }
+        TokenWrapInstruction::Unwrap => {
+            unimplemented!();
+        }
+    }
+}

--- a/token-wrap/program/src/state.rs
+++ b/token-wrap/program/src/state.rs
@@ -2,7 +2,7 @@
 
 use {
     bytemuck::{Pod, Zeroable},
-    solana_program::pubkey::Pubkey
+    solana_program::pubkey::Pubkey,
 };
 
 /// Backpointer

--- a/token-wrap/program/src/state.rs
+++ b/token-wrap/program/src/state.rs
@@ -1,0 +1,24 @@
+//! Program state
+
+use {
+    bytemuck::{Pod, Zeroable},
+    solana_program::pubkey::Pubkey
+};
+
+/// Backpointer
+///
+/// Since the backpointer account address is derived from the wrapped mint, it
+/// allows clients to easily work with wrapped tokens.
+///
+/// Try to fetch the account at `get_wrapped_mint_backpointer_address`.
+///  * if it doesn't exist, then the token is not wrapped
+///  * if it exists, read the data in the account as the unwrapped mint address
+///
+/// With this info, clients can easily unwrap tokens, even if they don't know
+/// the origin.
+#[derive(Copy, Clone, Debug, PartialEq, Pod, Zeroable)]
+#[repr(transparent)]
+pub struct Backpointer {
+    /// Address that the wrapped mint is wrapping
+    pub unwrapped_mint: Pubkey,
+}


### PR DESCRIPTION
#### Problem

Token-2022 adoption will take a long time since many different systems need to make invasive changes.

#### Proposed changes

Add an SPL token wrapping program which allows for easy interoperability of tokens, in case some systems never upgrade.  It's possible to wrap tokens in either direction, token -> token-2022 or token-2022 -> token, and then use them with any existing ecosystem.

The only piece of state required is a backpointer to the unwrapped mint address, which allows clients to figure out if their token is wrapped, and then how to unwrap it.

The functionality for unwrap will look very similar to the token-upgrade program #3436, since you're burning on one side and transferring from another.  `Wrap` will be the opposite: transfer then mint.

Note that since the wrapped mint also uses the wrapped token program as a seed, this program can work with more than two token programs, in the hope that the ecosystem gets there.