### PR TITLE
clippy: Deny integer arithmetic, add allows where needed

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -Zunstable-options --workspace --all-targets -- --deny=warnings
+          args: -Zunstable-options --workspace --all-targets --features test-sbf -- --deny=warnings --deny=clippy::integer_arithmetic
 
   audit:
     runs-on: ubuntu-latest

--- a/binary-option/program/src/lib.rs
+++ b/binary-option/program/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 pub mod entrypoint;
 pub mod error;
 pub mod instruction;

--- a/binary-oracle-pair/program/tests/tests.rs
+++ b/binary-oracle-pair/program/tests/tests.rs
@@ -128,6 +128,7 @@ pub async fn make_decision(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn make_withdraw(
     program_context: &mut ProgramTestContext,
     pool_account: &Pubkey,
@@ -446,6 +447,11 @@ impl TestPool {
         banks_client.process_transaction(transaction).await.unwrap();
     }
 }
+impl Default for TestPool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 pub async fn create_mint(
     banks_client: &mut BanksClient,
@@ -467,7 +473,7 @@ pub async fn create_mint(
             spl_token::instruction::initialize_mint(
                 &spl_token::id(),
                 &mint_account.pubkey(),
-                &owner,
+                owner,
                 None,
                 0,
             )

--- a/examples/rust/cross-program-invocation/tests/functional.rs
+++ b/examples/rust/cross-program-invocation/tests/functional.rs
@@ -16,7 +16,7 @@ use {
 
 #[tokio::test]
 async fn test_cross_program_invocation() {
-    let program_id = Pubkey::from_str(&"invoker111111111111111111111111111111111111").unwrap();
+    let program_id = Pubkey::from_str("invoker111111111111111111111111111111111111").unwrap();
     let (allocated_pubkey, bump_seed) =
         Pubkey::find_program_address(&[b"You pass butter"], &program_id);
     let mut program_test = ProgramTest::new(

--- a/examples/rust/transfer-lamports/src/processor.rs
+++ b/examples/rust/transfer-lamports/src/processor.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 //! Program instruction processor
 
 use solana_program::{

--- a/feature-proposal/cli/src/main.rs
+++ b/feature-proposal/cli/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 use {
     chrono::{DateTime, NaiveDateTime, SecondsFormat, Utc},
     clap::{

--- a/governance/chat/program/src/lib.rs
+++ b/governance/chat/program/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![deny(missing_docs)]
 //! Governance Chat program
 

--- a/governance/chat/program/tests/program_test/mod.rs
+++ b/governance/chat/program/tests/program_test/mod.rs
@@ -296,7 +296,7 @@ impl GovernanceChatProgramTest {
             token_owner_record_address,
             token_owner,
             governing_token_mint: governing_token_mint_keypair.pubkey(),
-            governing_token_mint_authority: governing_token_mint_authority,
+            governing_token_mint_authority,
             voter_weight_record,
         }
     }

--- a/governance/program/src/lib.rs
+++ b/governance/program/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![deny(missing_docs)]
 //! A Governance program for the Solana blockchain.
 

--- a/governance/program/tests/process_cast_vote.rs
+++ b/governance/program/tests/process_cast_vote.rs
@@ -1506,9 +1506,12 @@ async fn test_cast_vote_with_strict_tipping_and_inflated_max_vote_weight() {
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
     // Reduce max voter weight to 50% for the cast vote to be above max_voter_weight
-    let mut realm_config_args = RealmSetupArgs::default();
-    realm_config_args.community_mint_max_vote_weight_source =
-        MintMaxVoteWeightSource::SupplyFraction(MintMaxVoteWeightSource::SUPPLY_FRACTION_BASE / 2);
+    let realm_config_args = RealmSetupArgs {
+        community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(
+            MintMaxVoteWeightSource::SUPPLY_FRACTION_BASE / 2,
+        ),
+        ..Default::default()
+    };
 
     let realm_cookie = governance_test
         .with_realm_using_args(&realm_config_args)

--- a/governance/program/tests/process_create_governance.rs
+++ b/governance/program/tests/process_create_governance.rs
@@ -219,7 +219,7 @@ async fn test_create_governance_using_realm_authority() {
             &realm_cookie,
             &governed_account_cookie,
             None,
-            &realm_authority,
+            realm_authority,
             None,
             &config,
             None,
@@ -252,7 +252,7 @@ async fn test_create_governance_using_realm_authority_with_authority_must_sign_e
             &realm_cookie,
             &governed_account_cookie,
             None,
-            &realm_authority,
+            realm_authority,
             None,
             &config,
             Some(&[]),
@@ -309,8 +309,10 @@ async fn test_create_governance_with_community_disabled_error() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
-    let mut realm_config_args = RealmSetupArgs::default();
-    realm_config_args.min_community_weight_to_create_governance = u64::MAX;
+    let realm_config_args = RealmSetupArgs {
+        min_community_weight_to_create_governance: u64::MAX,
+        ..Default::default()
+    };
 
     let realm_cookie = governance_test
         .with_realm_using_args(&realm_config_args)

--- a/governance/program/tests/process_relinquish_vote.rs
+++ b/governance/program/tests/process_relinquish_vote.rs
@@ -426,7 +426,7 @@ async fn test_relinquish_vote_with_already_relinquished_error() {
         .get_vote_record_account(&vote_record_cookie.address)
         .await;
 
-    assert_eq!(true, vote_record_account.is_relinquished);
+    assert!(vote_record_account.is_relinquished);
 
     governance_test
         .mint_community_tokens(&realm_cookie, 10)

--- a/governance/program/tests/process_revoke_governing_tokens.rs
+++ b/governance/program/tests/process_revoke_governing_tokens.rs
@@ -485,7 +485,7 @@ async fn test_revoke_council_tokens_with_community_mint_error() {
         .unwrap();
 
     // Try to use mint and authority for Community to revoke Council token
-    let governing_token_mint = realm_cookie.account.community_mint.clone();
+    let governing_token_mint = realm_cookie.account.community_mint;
     let governing_token_mint_authority = clone_keypair(&realm_cookie.community_mint_authority);
     let governing_token_holding_address = get_governing_token_holding_address(
         &governance_test.program_id,
@@ -534,7 +534,7 @@ async fn test_revoke_council_tokens_with_not_matching_mint_and_authority_error()
         .unwrap();
 
     // Try to use a valid mint and authority not matching the Council mint
-    let governing_token_mint = realm_cookie.account.community_mint.clone();
+    let governing_token_mint = realm_cookie.account.community_mint;
     let governing_token_mint_authority = clone_keypair(&realm_cookie.community_mint_authority);
 
     // Act

--- a/governance/program/tests/process_set_realm_config.rs
+++ b/governance/program/tests/process_set_realm_config.rs
@@ -127,8 +127,10 @@ async fn test_set_realm_config_with_remove_council() {
 
     let mut realm_cookie = governance_test.with_realm().await;
 
-    let mut realm_setup_args = RealmSetupArgs::default();
-    realm_setup_args.use_council_mint = false;
+    let realm_setup_args = RealmSetupArgs {
+        use_council_mint: false,
+        ..Default::default()
+    };
 
     // Act
     governance_test
@@ -178,8 +180,10 @@ async fn test_set_realm_config_with_council_restore_error() {
 
     let mut realm_cookie = governance_test.with_realm().await;
 
-    let mut realm_setup_args = RealmSetupArgs::default();
-    realm_setup_args.use_council_mint = false;
+    let mut realm_setup_args = RealmSetupArgs {
+        use_council_mint: false,
+        ..Default::default()
+    };
 
     governance_test
         .set_realm_config(&mut realm_cookie, &realm_setup_args)
@@ -238,13 +242,14 @@ async fn test_set_realm_config_for_community_token_config() {
 
     let mut realm_cookie = governance_test.with_realm().await;
 
-    let mut realm_setup_args = RealmSetupArgs::default();
-
     // Change Community token type to Dormant and set plugins
-    realm_setup_args.community_token_config_args = GoverningTokenConfigAccountArgs {
-        voter_weight_addin: Some(Pubkey::new_unique()),
-        max_voter_weight_addin: Some(Pubkey::new_unique()),
-        token_type: GoverningTokenType::Dormant,
+    let realm_setup_args = RealmSetupArgs {
+        community_token_config_args: GoverningTokenConfigAccountArgs {
+            voter_weight_addin: Some(Pubkey::new_unique()),
+            max_voter_weight_addin: Some(Pubkey::new_unique()),
+            token_type: GoverningTokenType::Dormant,
+        },
+        ..Default::default()
     };
 
     // Act
@@ -291,13 +296,14 @@ async fn test_set_realm_config_for_council_token_config() {
 
     let mut realm_cookie = governance_test.with_realm().await;
 
-    let mut realm_setup_args = RealmSetupArgs::default();
-
     // Change Council token type to Membership and set plugins
-    realm_setup_args.council_token_config_args = GoverningTokenConfigAccountArgs {
-        voter_weight_addin: Some(Pubkey::new_unique()),
-        max_voter_weight_addin: Some(Pubkey::new_unique()),
-        token_type: GoverningTokenType::Membership,
+    let realm_setup_args = RealmSetupArgs {
+        council_token_config_args: GoverningTokenConfigAccountArgs {
+            voter_weight_addin: Some(Pubkey::new_unique()),
+            max_voter_weight_addin: Some(Pubkey::new_unique()),
+            token_type: GoverningTokenType::Membership,
+        },
+        ..Default::default()
     };
 
     // Act

--- a/governance/program/tests/process_sign_off_proposal.rs
+++ b/governance/program/tests/process_sign_off_proposal.rs
@@ -63,7 +63,7 @@ async fn test_sign_off_proposal() {
         .get_signatory_record_account(&signatory_record_cookie.address)
         .await;
 
-    assert_eq!(true, signatory_record_account.signed_off);
+    assert!(signatory_record_account.signed_off);
 
     let realm_account = governance_test
         .get_realm_account(&realm_cookie.address)

--- a/governance/program/tests/program_test/cookies.rs
+++ b/governance/program/tests/program_test/cookies.rs
@@ -40,7 +40,7 @@ impl RealmCookie {
         if *governing_token_mint == self.account.community_mint {
             &self.community_mint_authority
         } else if Some(*governing_token_mint) == self.account.config.council_mint {
-            &self.council_mint_authority.as_ref().unwrap()
+            self.council_mint_authority.as_ref().unwrap()
         } else {
             panic!("Invalid governing_token_mint")
         }

--- a/governance/program/tests/setup_realm_with_all_addins.rs
+++ b/governance/program/tests/setup_realm_with_all_addins.rs
@@ -99,9 +99,10 @@ async fn test_set_all_addin_for_realm_without_council_and_addins() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_all_addins().await;
 
-    let mut realm_setup_args = RealmSetupArgs::default();
-
-    realm_setup_args.use_council_mint = false;
+    let mut realm_setup_args = RealmSetupArgs {
+        use_council_mint: false,
+        ..Default::default()
+    };
 
     let mut realm_cookie = governance_test
         .with_realm_using_args(&realm_setup_args)

--- a/governance/program/tests/setup_realm_with_max_voter_weight_addin.rs
+++ b/governance/program/tests/setup_realm_with_max_voter_weight_addin.rs
@@ -81,9 +81,10 @@ async fn test_set_realm_max_voter_weight_addin_for_realm_without_council_and_add
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_max_voter_weight_addin().await;
 
-    let mut realm_setup_args = RealmSetupArgs::default();
-
-    realm_setup_args.use_council_mint = false;
+    let mut realm_setup_args = RealmSetupArgs {
+        use_council_mint: false,
+        ..Default::default()
+    };
 
     let mut realm_cookie = governance_test
         .with_realm_using_args(&realm_setup_args)

--- a/governance/program/tests/setup_realm_with_voter_weight_addin.rs
+++ b/governance/program/tests/setup_realm_with_voter_weight_addin.rs
@@ -83,9 +83,10 @@ async fn test_set_realm_voter_weight_addin_for_realm_without_council_and_addins(
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_with_voter_weight_addin().await;
 
-    let mut realm_setup_args = RealmSetupArgs::default();
-
-    realm_setup_args.use_council_mint = false;
+    let mut realm_setup_args = RealmSetupArgs {
+        use_council_mint: false,
+        ..Default::default()
+    };
 
     let mut realm_cookie = governance_test
         .with_realm_using_args(&realm_setup_args)

--- a/governance/program/tests/use_proposals_with_multiple_options.rs
+++ b/governance/program/tests/use_proposals_with_multiple_options.rs
@@ -110,7 +110,7 @@ async fn test_create_proposal_with_multiple_choice_options_and_without_deny_opti
             max_voter_options: 2,
         }
     );
-    assert!(!proposal_account.deny_vote_weight.is_some());
+    assert!(proposal_account.deny_vote_weight.is_none());
 
     assert_eq!(proposal_cookie.account, proposal_account);
 }
@@ -1075,7 +1075,7 @@ async fn test_create_proposal_with_10_options_and_cast_vote() {
             max_voter_options: options_len,
         }
     );
-    assert!(!proposal_account.deny_vote_weight.is_some());
+    assert!(proposal_account.deny_vote_weight.is_none());
 
     assert_eq!(ProposalState::Completed, proposal_account.state);
 }

--- a/governance/program/tests/use_veto_vote.rs
+++ b/governance/program/tests/use_veto_vote.rs
@@ -510,8 +510,10 @@ async fn test_cast_veto_vote_with_no_council_error() {
         .unwrap();
 
     // Remove Council
-    let mut realm_setup_args = RealmSetupArgs::default();
-    realm_setup_args.use_council_mint = false;
+    let realm_setup_args = RealmSetupArgs {
+        use_council_mint: false,
+        ..Default::default()
+    };
 
     governance_test
         .set_realm_config(&mut realm_cookie, &realm_setup_args)

--- a/governance/test-sdk/src/lib.rs
+++ b/governance/test-sdk/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 use std::borrow::Borrow;
 
 use borsh::BorshDeserialize;

--- a/libraries/concurrent-merkle-tree/src/lib.rs
+++ b/libraries/concurrent-merkle-tree/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 //! # Concurrent Merkle Tree
 //!
 //! This crate is a Solana-optimized implementation of the

--- a/libraries/concurrent-merkle-tree/tests/tests.rs
+++ b/libraries/concurrent-merkle-tree/tests/tests.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 use rand::thread_rng;
 use rand::{self, Rng};
 use spl_concurrent_merkle_tree::concurrent_merkle_tree::ConcurrentMerkleTree;

--- a/libraries/math/src/approximations.rs
+++ b/libraries/math/src/approximations.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 //! Approximation calculations
 
 use {

--- a/libraries/math/src/precise_number.rs
+++ b/libraries/math/src/precise_number.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 //! Defines PreciseNumber, a U256 wrapper with float-like operations
 
 use crate::uint::U256;

--- a/libraries/math/src/processor.rs
+++ b/libraries/math/src/processor.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 //! Program state processor
 
 use {

--- a/libraries/math/src/uint.rs
+++ b/libraries/math/src/uint.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 //! Large uint types
 
 // required for clippy

--- a/libraries/merkle-tree-reference/src/lib.rs
+++ b/libraries/merkle-tree-reference/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 use solana_program::keccak::hashv;
 use std::cell::RefCell;
 use std::collections::VecDeque;

--- a/name-service/program/src/processor.rs
+++ b/name-service/program/src/processor.rs
@@ -95,7 +95,7 @@ impl Processor {
             invoke_signed(
                 &system_instruction::allocate(
                     &name_account_key,
-                    (NameRecordHeader::LEN + space as usize) as u64,
+                    NameRecordHeader::LEN.saturating_add(space as usize) as u64,
                 ),
                 &[name_account.clone(), system_program.clone()],
                 &[&seeds.chunks(32).collect::<Vec<&[u8]>>()],
@@ -158,7 +158,11 @@ impl Processor {
             return Err(ProgramError::InvalidArgument);
         }
 
-        write_data(name_account, &data, NameRecordHeader::LEN + offset as usize);
+        write_data(
+            name_account,
+            &data,
+            NameRecordHeader::LEN.saturating_add(offset as usize),
+        );
 
         Ok(())
     }
@@ -229,7 +233,7 @@ impl Processor {
         // Close the account by transferring the rent sol
         let source_amount: &mut u64 = &mut name_account.lamports.borrow_mut();
         let dest_amount: &mut u64 = &mut refund_target.lamports.borrow_mut();
-        *dest_amount += *source_amount;
+        *dest_amount = dest_amount.saturating_add(*source_amount);
         *source_amount = 0;
 
         Ok(())

--- a/name-service/program/src/state.rs
+++ b/name-service/program/src/state.rs
@@ -54,7 +54,7 @@ impl IsInitialized for NameRecordHeader {
 
 pub fn write_data(account: &AccountInfo, input: &[u8], offset: usize) {
     let mut account_data = account.data.borrow_mut();
-    account_data[offset..offset + input.len()].copy_from_slice(input);
+    account_data[offset..offset.saturating_add(input.len())].copy_from_slice(input);
 }
 
 ////////////////////////////////////////////////////////////

--- a/name-service/program/tests/functional.rs
+++ b/name-service/program/tests/functional.rs
@@ -11,8 +11,8 @@ use solana_sdk::{
     transport::TransportError,
 };
 use spl_name_service::{
-    entrypoint::process_instruction,
     instruction::{create, delete, transfer, update, NameRegistryInstruction},
+    processor::Processor,
     state::{get_seeds_and_key, NameRecordHeader, HASH_PREFIX},
 };
 
@@ -24,7 +24,7 @@ async fn test_name_service() {
     let program_test = ProgramTest::new(
         "spl_name_service",
         program_id,
-        processor!(process_instruction),
+        processor!(Processor::process_instruction),
     );
 
     let mut ctx = program_test.start_with_context().await;
@@ -49,7 +49,7 @@ async fn test_name_service() {
         program_id,
         NameRegistryInstruction::Create {
             hashed_name: hashed_root_name,
-            lamports: rent.minimum_balance(space + NameRecordHeader::LEN),
+            lamports: rent.minimum_balance(space.saturating_add(NameRecordHeader::LEN)),
             space: space as u32,
         },
         root_name_account_key,
@@ -65,8 +65,7 @@ async fn test_name_service() {
         .unwrap();
 
     let name_record_header = NameRecordHeader::unpack_from_slice(
-        &mut &ctx
-            .banks_client
+        &ctx.banks_client
             .get_account(root_name_account_key)
             .await
             .unwrap()
@@ -93,7 +92,7 @@ async fn test_name_service() {
         program_id,
         NameRegistryInstruction::Create {
             hashed_name,
-            lamports: rent.minimum_balance(space + NameRecordHeader::LEN),
+            lamports: rent.minimum_balance(space.saturating_add(NameRecordHeader::LEN)),
             space: space as u32,
         },
         name_account_key,
@@ -113,8 +112,7 @@ async fn test_name_service() {
     .unwrap();
 
     let name_record_header = NameRecordHeader::unpack_from_slice(
-        &mut &ctx
-            .banks_client
+        &ctx.banks_client
             .get_account(name_account_key)
             .await
             .unwrap()
@@ -140,8 +138,7 @@ async fn test_name_service() {
         .unwrap();
 
     let name_record_header = NameRecordHeader::unpack_from_slice(
-        &mut &ctx
-            .banks_client
+        &ctx.banks_client
             .get_account(name_account_key)
             .await
             .unwrap()
@@ -168,8 +165,7 @@ async fn test_name_service() {
     .unwrap();
 
     let name_record_header = NameRecordHeader::unpack_from_slice(
-        &mut &ctx
-            .banks_client
+        &ctx.banks_client
             .get_account(name_account_key)
             .await
             .unwrap()

--- a/record/program/src/processor.rs
+++ b/record/program/src/processor.rs
@@ -68,8 +68,8 @@ pub fn process_instruction(
                 return Err(ProgramError::UninitializedAccount);
             }
             check_authority(authority_info, &account_data.authority)?;
-            let start = RecordData::WRITABLE_START_INDEX + offset as usize;
-            let end = start + data.len();
+            let start = RecordData::WRITABLE_START_INDEX.saturating_add(offset as usize);
+            let end = start.saturating_add(data.len());
             if end > data_info.data.borrow().len() {
                 Err(ProgramError::AccountDataTooSmall)
             } else {

--- a/shared-memory/program/src/lib.rs
+++ b/shared-memory/program/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![deny(missing_docs)]
 //! Shared memory program for the Solana blockchain.
 //

--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 mod client;
 mod output;
 

--- a/stake-pool/program/src/lib.rs
+++ b/stake-pool/program/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![deny(missing_docs)]
 
 //! A program for creating and managing pools of stake

--- a/stake-pool/program/tests/create_pool_token_metadata.rs
+++ b/stake-pool/program/tests/create_pool_token_metadata.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 mod helpers;
 
@@ -45,9 +46,9 @@ async fn success_create_pool_token_metadata() {
     let symbol = "SYM";
     let uri = "test_uri";
 
-    let puffed_name = puffed_out_string(&name, MAX_NAME_LENGTH);
-    let puffed_symbol = puffed_out_string(&symbol, MAX_SYMBOL_LENGTH);
-    let puffed_uri = puffed_out_string(&uri, MAX_URI_LENGTH);
+    let puffed_name = puffed_out_string(name, MAX_NAME_LENGTH);
+    let puffed_symbol = puffed_out_string(symbol, MAX_SYMBOL_LENGTH);
+    let puffed_uri = puffed_out_string(uri, MAX_URI_LENGTH);
 
     let ix = instruction::create_token_metadata(
         &spl_stake_pool::id(),
@@ -79,9 +80,9 @@ async fn success_create_pool_token_metadata() {
     )
     .await;
 
-    assert_eq!(metadata.data.name.to_string(), puffed_name);
-    assert_eq!(metadata.data.symbol.to_string(), puffed_symbol);
-    assert_eq!(metadata.data.uri.to_string(), puffed_uri);
+    assert_eq!(metadata.data.name, puffed_name);
+    assert_eq!(metadata.data.symbol, puffed_symbol);
+    assert_eq!(metadata.data.uri, puffed_uri);
 }
 
 #[tokio::test]

--- a/stake-pool/program/tests/decrease.rs
+++ b/stake-pool/program/tests/decrease.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/stake-pool/program/tests/deposit.rs
+++ b/stake-pool/program/tests/deposit.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/stake-pool/program/tests/deposit_authority.rs
+++ b/stake-pool/program/tests/deposit_authority.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/stake-pool/program/tests/deposit_sol.rs
+++ b/stake-pool/program/tests/deposit_sol.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/stake-pool/program/tests/force_destake.rs
+++ b/stake-pool/program/tests/force_destake.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/stake-pool/program/tests/huge_pool.rs
+++ b/stake-pool/program/tests/huge_pool.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/stake-pool/program/tests/increase.rs
+++ b/stake-pool/program/tests/increase.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/stake-pool/program/tests/initialize.rs
+++ b/stake-pool/program/tests/initialize.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/stake-pool/program/tests/set_deposit_fee.rs
+++ b/stake-pool/program/tests/set_deposit_fee.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/stake-pool/program/tests/set_epoch_fee.rs
+++ b/stake-pool/program/tests/set_epoch_fee.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/stake-pool/program/tests/set_funding_authority.rs
+++ b/stake-pool/program/tests/set_funding_authority.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/stake-pool/program/tests/set_manager.rs
+++ b/stake-pool/program/tests/set_manager.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/stake-pool/program/tests/set_preferred.rs
+++ b/stake-pool/program/tests/set_preferred.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/stake-pool/program/tests/set_referral_fee.rs
+++ b/stake-pool/program/tests/set_referral_fee.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/stake-pool/program/tests/set_staker.rs
+++ b/stake-pool/program/tests/set_staker.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/stake-pool/program/tests/set_withdrawal_fee.rs
+++ b/stake-pool/program/tests/set_withdrawal_fee.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/stake-pool/program/tests/update_pool_token_metadata.rs
+++ b/stake-pool/program/tests/update_pool_token_metadata.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 mod helpers;
 
@@ -73,9 +74,9 @@ async fn success_update_pool_token_metadata() {
     let updated_symbol = "USYM";
     let updated_uri = "updated_uri";
 
-    let puffed_name = puffed_out_string(&updated_name, MAX_NAME_LENGTH);
-    let puffed_symbol = puffed_out_string(&updated_symbol, MAX_SYMBOL_LENGTH);
-    let puffed_uri = puffed_out_string(&updated_uri, MAX_URI_LENGTH);
+    let puffed_name = puffed_out_string(updated_name, MAX_NAME_LENGTH);
+    let puffed_symbol = puffed_out_string(updated_symbol, MAX_SYMBOL_LENGTH);
+    let puffed_uri = puffed_out_string(updated_uri, MAX_URI_LENGTH);
 
     let ix = instruction::update_token_metadata(
         &spl_stake_pool::id(),
@@ -106,9 +107,9 @@ async fn success_update_pool_token_metadata() {
     )
     .await;
 
-    assert_eq!(metadata.data.name.to_string(), puffed_name);
-    assert_eq!(metadata.data.symbol.to_string(), puffed_symbol);
-    assert_eq!(metadata.data.uri.to_string(), puffed_uri);
+    assert_eq!(metadata.data.name, puffed_name);
+    assert_eq!(metadata.data.symbol, puffed_symbol);
+    assert_eq!(metadata.data.uri, puffed_uri);
 }
 
 #[tokio::test]

--- a/stake-pool/program/tests/update_stake_pool_balance.rs
+++ b/stake-pool/program/tests/update_stake_pool_balance.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/stake-pool/program/tests/update_validator_list_balance.rs
+++ b/stake-pool/program/tests/update_validator_list_balance.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/stake-pool/program/tests/vsa_add.rs
+++ b/stake-pool/program/tests/vsa_add.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/stake-pool/program/tests/vsa_remove.rs
+++ b/stake-pool/program/tests/vsa_remove.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/stake-pool/program/tests/withdraw.rs
+++ b/stake-pool/program/tests/withdraw.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/stake-pool/program/tests/withdraw_sol.rs
+++ b/stake-pool/program/tests/withdraw_sol.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/token-lending/cli/src/main.rs
+++ b/token-lending/cli/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 use {
     clap::{
         crate_description, crate_name, crate_version, value_t, App, AppSettings, Arg, ArgMatches,

--- a/token-lending/program/src/lib.rs
+++ b/token-lending/program/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![deny(missing_docs)]
 
 //! A lending program for the Solana blockchain.

--- a/token-lending/program/tests/borrow_obligation_liquidity.rs
+++ b/token-lending/program/tests/borrow_obligation_liquidity.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/token-lending/program/tests/deposit_obligation_collateral.rs
+++ b/token-lending/program/tests/deposit_obligation_collateral.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/token-lending/program/tests/deposit_reserve_liquidity.rs
+++ b/token-lending/program/tests/deposit_reserve_liquidity.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/token-lending/program/tests/flash_loan.rs
+++ b/token-lending/program/tests/flash_loan.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;
@@ -35,7 +36,7 @@ async fn test_success() {
     test.prefer_bpf(false);
     test.add_program(
         "flash_loan_receiver",
-        receiver_program_id.clone(),
+        receiver_program_id,
         processor!(helpers::flash_loan_receiver::process_instruction),
     );
 
@@ -94,11 +95,8 @@ async fn test_success() {
             usdc_test_reserve.liquidity_fee_receiver_pubkey,
             usdc_test_reserve.liquidity_host_pubkey,
             lending_market.pubkey,
-            receiver_program_id.clone(),
-            vec![AccountMeta::new_readonly(
-                receiver_authority_pubkey.clone(),
-                false,
-            )],
+            receiver_program_id,
+            vec![AccountMeta::new_readonly(receiver_authority_pubkey, false)],
         )],
         Some(&payer.pubkey()),
     );
@@ -155,7 +153,7 @@ async fn test_failure() {
     test.prefer_bpf(false);
     test.add_program(
         "flash_loan_receiver",
-        flash_loan_receiver_program_id.clone(),
+        flash_loan_receiver_program_id,
         processor!(helpers::flash_loan_receiver::process_instruction),
     );
 
@@ -206,11 +204,8 @@ async fn test_failure() {
             usdc_test_reserve.liquidity_fee_receiver_pubkey,
             usdc_test_reserve.liquidity_host_pubkey,
             lending_market.pubkey,
-            flash_loan_receiver_program_id.clone(),
-            vec![AccountMeta::new_readonly(
-                receiver_authority_pubkey.clone(),
-                false,
-            )],
+            flash_loan_receiver_program_id,
+            vec![AccountMeta::new_readonly(receiver_authority_pubkey, false)],
         )],
         Some(&payer.pubkey()),
     );

--- a/token-lending/program/tests/helpers/mod.rs
+++ b/token-lending/program/tests/helpers/mod.rs
@@ -506,7 +506,7 @@ impl TestLendingMarket {
         );
 
         let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
-        transaction.sign(&[&payer, &lending_market_keypair], recent_blockhash);
+        transaction.sign(&[payer, &lending_market_keypair], recent_blockhash);
         assert_matches!(banks_client.process_transaction(transaction).await, Ok(()));
 
         TestLendingMarket {
@@ -628,7 +628,7 @@ impl TestLendingMarket {
 
         let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
         transaction.sign(
-            &[&payer, &user_accounts_owner, &user_transfer_authority],
+            &[payer, user_accounts_owner, &user_transfer_authority],
             recent_blockhash,
         );
         assert!(banks_client.process_transaction(transaction).await.is_ok());
@@ -1102,11 +1102,11 @@ pub fn add_oracle(
         product_pubkey,
         u32::MAX as u64,
         oracle_program_id.pubkey(),
-        &format!("{}.bin", product_pubkey.to_string()),
+        &format!("{}.bin", product_pubkey),
     );
 
     // Add Pyth price account after setting the price
-    let filename = &format!("{}.bin", price_pubkey.to_string());
+    let filename = &format!("{}.bin", price_pubkey);
     let mut pyth_price_data = read_file(find_file(filename).unwrap_or_else(|| {
         panic!("Unable to locate {}", filename);
     }));
@@ -1154,12 +1154,12 @@ pub async fn create_and_mint_to_token_account(
 ) -> Pubkey {
     if let Some(mint_authority) = mint_authority {
         let account_pubkey =
-            create_token_account(banks_client, mint_pubkey, &payer, Some(authority), None).await;
+            create_token_account(banks_client, mint_pubkey, payer, Some(authority), None).await;
 
         mint_to(
             banks_client,
             mint_pubkey,
-            &payer,
+            payer,
             account_pubkey,
             mint_authority,
             amount,
@@ -1171,7 +1171,7 @@ pub async fn create_and_mint_to_token_account(
         create_token_account(
             banks_client,
             mint_pubkey,
-            &payer,
+            payer,
             Some(authority),
             Some(amount),
         )
@@ -1213,7 +1213,7 @@ pub async fn create_token_account(
     );
 
     let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
-    transaction.sign(&[&payer, &token_keypair], recent_blockhash);
+    transaction.sign(&[payer, &token_keypair], recent_blockhash);
 
     assert_matches!(banks_client.process_transaction(transaction).await, Ok(()));
 

--- a/token-lending/program/tests/init_lending_market.rs
+++ b/token-lending/program/tests/init_lending_market.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/token-lending/program/tests/init_obligation.rs
+++ b/token-lending/program/tests/init_obligation.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/token-lending/program/tests/init_reserve.rs
+++ b/token-lending/program/tests/init_reserve.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/token-lending/program/tests/liquidate_obligation.rs
+++ b/token-lending/program/tests/liquidate_obligation.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/token-lending/program/tests/modify_reserve_config.rs
+++ b/token-lending/program/tests/modify_reserve_config.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/token-lending/program/tests/obligation_end_to_end.rs
+++ b/token-lending/program/tests/obligation_end_to_end.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/token-lending/program/tests/redeem_reserve_collateral.rs
+++ b/token-lending/program/tests/redeem_reserve_collateral.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/token-lending/program/tests/refresh_obligation.rs
+++ b/token-lending/program/tests/refresh_obligation.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/token-lending/program/tests/refresh_reserve.rs
+++ b/token-lending/program/tests/refresh_reserve.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/token-lending/program/tests/repay_obligation_liquidity.rs
+++ b/token-lending/program/tests/repay_obligation_liquidity.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/token-lending/program/tests/set_lending_market_owner.rs
+++ b/token-lending/program/tests/set_lending_market_owner.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/token-lending/program/tests/withdraw_obligation_collateral.rs
+++ b/token-lending/program/tests/withdraw_obligation_collateral.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![cfg(feature = "test-sbf")]
 
 mod helpers;

--- a/token-swap/program/fuzz/src/instructions.rs
+++ b/token-swap/program/fuzz/src/instructions.rs
@@ -1,5 +1,4 @@
-use std::sync::Arc;
-
+#![allow(clippy::integer_arithmetic)]
 use {
     arbitrary::Arbitrary,
     honggfuzz::fuzz,
@@ -25,7 +24,10 @@ use {
         native_token::{get_token_balance, transfer},
         native_token_swap::NativeTokenSwap,
     },
-    std::collections::{HashMap, HashSet},
+    std::{
+        collections::{HashMap, HashSet},
+        sync::Arc,
+    },
 };
 
 #[derive(Debug, Arbitrary, Clone)]

--- a/token-swap/program/fuzz/src/lib.rs
+++ b/token-swap/program/fuzz/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 pub mod native_account_data;
 pub mod native_processor;
 pub mod native_token;

--- a/token-swap/program/src/lib.rs
+++ b/token-swap/program/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![deny(missing_docs)]
 
 //! An Uniswap-like program for the Solana blockchain.

--- a/token-upgrade/program/src/instruction.rs
+++ b/token-upgrade/program/src/instruction.rs
@@ -52,7 +52,7 @@ pub fn exchange(
     original_multisig_signers: &[&Pubkey],
 ) -> Instruction {
     let escrow_authority = get_token_upgrade_authority_address(original_mint, new_mint, program_id);
-    let mut accounts = Vec::with_capacity(9 + original_multisig_signers.len());
+    let mut accounts = Vec::with_capacity(9usize.saturating_add(original_multisig_signers.len()));
     accounts.push(AccountMeta::new(*original_account, false));
     accounts.push(AccountMeta::new(*original_mint, false));
     accounts.push(AccountMeta::new(*new_escrow, false));

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 use clap::{
     crate_description, crate_name, crate_version, value_t, value_t_or_exit, App, AppSettings, Arg,
     ArgMatches, SubCommand,

--- a/token/client/src/lib.rs
+++ b/token/client/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 pub mod client;
 pub mod output;
 pub mod token;

--- a/token/program-2022-test/tests/delegate.rs
+++ b/token/program-2022-test/tests/delegate.rs
@@ -115,7 +115,7 @@ async fn run_basic(
             &alice_account,
             &bob_account,
             &bob.pubkey(),
-            delegated_amount + 1,
+            delegated_amount.checked_add(1).unwrap(),
             Some(decimals),
             &vec![&bob],
         )

--- a/token/program-2022-test/tests/interest_bearing_mint.rs
+++ b/token/program-2022-test/tests/interest_bearing_mint.rs
@@ -314,14 +314,14 @@ async fn amount_conversions() {
     let TokenContext { token, .. } = context.token_context.take().unwrap();
 
     // warp forward, so interest is accrued
-    let warp_slot = 1_000;
-    let initial_num_warps = 10;
+    let warp_slot: u64 = 1_000;
+    let initial_num_warps: u64 = 10;
     for i in 1..initial_num_warps {
         context
             .context
             .lock()
             .await
-            .warp_to_slot(i * warp_slot)
+            .warp_to_slot(i.checked_mul(warp_slot).unwrap())
             .unwrap();
     }
 

--- a/token/program-2022-test/tests/transfer.rs
+++ b/token/program-2022-test/tests/transfer.rs
@@ -210,7 +210,7 @@ async fn run_self_transfers(context: TestContext, test_mode: TestMode) {
             &alice_account,
             &alice_account,
             &alice.pubkey(),
-            amount + 1,
+            amount.checked_add(1).unwrap(),
             Some(decimals),
             &vec![&alice],
         )

--- a/token/program-2022/src/lib.rs
+++ b/token/program-2022/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![deny(missing_docs)]
 #![cfg_attr(not(test), forbid(unsafe_code))]
 

--- a/token/program/src/lib.rs
+++ b/token/program/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![deny(missing_docs)]
 #![cfg_attr(not(test), forbid(unsafe_code))]
 

--- a/token/program/tests/close_account.rs
+++ b/token/program/tests/close_account.rs
@@ -36,10 +36,10 @@ async fn setup_mint_and_account(
                 &mint.pubkey(),
                 rent.minimum_balance(space),
                 space as u64,
-                &token_program_id,
+                token_program_id,
             ),
             instruction::initialize_mint(
-                &token_program_id,
+                token_program_id,
                 &mint.pubkey(),
                 &mint_authority_pubkey,
                 None,
@@ -60,18 +60,18 @@ async fn setup_mint_and_account(
                 &token_account.pubkey(),
                 rent.minimum_balance(space),
                 space as u64,
-                &token_program_id,
+                token_program_id,
             ),
             instruction::initialize_account(
-                &token_program_id,
+                token_program_id,
                 &token_account.pubkey(),
                 &mint.pubkey(),
-                &owner,
+                owner,
             )
             .unwrap(),
         ],
         Some(&context.payer.pubkey()),
-        &[&context.payer, &token_account],
+        &[&context.payer, token_account],
         context.last_blockhash,
     );
     context.banks_client.process_transaction(tx).await.unwrap();


### PR DESCRIPTION
#### Problem

Per #3588, adding overflow checks might not be the best idea due to performance and potentially dangerous panics, but we should avoid doing integer math wherever possible.

#### Solution

Following the example of the monorepo add `--deny=clippy::integer_arithmetic` to the clippy run, and add the proper `#[allow(clippy::integer_arithmetic)]` at the top of libraries and tools that currently break this.  This way, we can remove those allows little by little.

While doing this, I noticed that we weren't actually running clippy on most program tests because they're behind the `test-sbf` feature, so now we'll clippy the program tests too.

And then I made a bunch of little fixes where it seemed easy.