### PR TITLE
instruction-pad: Add a new program for padding instructions

### DIFF
--- a/.github/workflows/pull-request-instruction-padding.yml
+++ b/.github/workflows/pull-request-instruction-padding.yml
@@ -1,0 +1,60 @@
+name: Instruction Pad Pull Request
+
+on:
+  pull_request:
+    paths:
+    - 'instruction-padding/**'
+    - 'ci/*-version.sh'
+    - '.github/workflows/pull-request-instruction-padding.yml'
+  push:
+    branches: [master]
+    paths:
+    - 'instruction-padding/**'
+    - 'ci/*-version.sh'
+    - '.github/workflows/pull-request-instruction-padding.yml'
+
+jobs:
+  cargo-test-sbf:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set env vars
+        run: |
+          source ci/rust-version.sh
+          echo "RUST_STABLE=$rust_stable" >> $GITHUB_ENV
+          source ci/solana-version.sh
+          echo "SOLANA_VERSION=$solana_version" >> $GITHUB_ENV
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_STABLE }}
+          override: true
+          profile: minimal
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE}}
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/rustfilt
+          key: cargo-sbf-bins-${{ runner.os }}
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/solana
+          key: solana-${{ env.SOLANA_VERSION }}
+
+      - name: Install dependencies
+        run: |
+          ./ci/install-build-deps.sh
+          ./ci/install-program-deps.sh
+          echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
+
+      - name: Build and test
+        run: ./ci/cargo-test-sbf.sh instruction-padding

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5959,6 +5959,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-instruction-padding"
+version = "0.1.0"
+dependencies = [
+ "num_enum",
+ "solana-program",
+ "solana-program-test",
+ "solana-sdk",
+]
+
+[[package]]
 name = "spl-managed-token"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
   "governance/test-sdk",
   "governance/tools",
   "governance/chat/program",
+  "instruction-padding/program",
   "libraries/math",
   "libraries/concurrent-merkle-tree",
   "libraries/merkle-tree-reference",

--- a/instruction-padding/program/Cargo.toml
+++ b/instruction-padding/program/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "spl-instruction-padding"
+version = "0.1.0"
+description = "Solana Program Library Instruction Padding Program"
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+repository = "https://github.com/solana-labs/solana-program-library"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+edition = "2018"
+
+[features]
+no-entrypoint = []
+test-sbf = []
+
+[dependencies]
+num_enum = "0.5.4"
+solana-program = "1.14.4"
+
+[dev-dependencies]
+solana-program-test = "1.14.4"
+solana-sdk = "1.14.4"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/instruction-padding/program/README.md
+++ b/instruction-padding/program/README.md
@@ -1,0 +1,24 @@
+# Instruction Pad Program
+
+A program for padding instructions with additional data or accounts, to be used
+for testing larger transactions, either more instruction data, or more accounts.
+
+The main use-case is with solana-bench-tps, where we can see the impact of larger
+transactions through TPS numbers. With that data, we can develop a fair fee model
+for large transactions.
+
+It operates with two instructions: no-op and wrap.
+
+* No-op: simply an instruction with as much data and as many accounts as desired,
+of which none will be used for processing.
+* Wrap: before the padding data and accounts, accepts a real instruction and
+required accounts, and performs a CPI into the program specified by the instruction
+
+Both of these modes add the general overhead of calling a BPF program, and
+the wrap mode adds the CPI overhead.
+
+Because of the overhead, it's best to use the instruction padding program with
+all large transaction tests, and comparing TPS numbers between:
+
+* using the program with no padding
+* using the program with data and account padding

--- a/instruction-padding/program/src/entrypoint.rs
+++ b/instruction-padding/program/src/entrypoint.rs
@@ -1,0 +1,16 @@
+//! Program entrypoint
+
+#![cfg(not(feature = "no-entrypoint"))]
+
+use solana_program::{
+    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
+};
+
+entrypoint!(process_instruction);
+fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    crate::processor::process(program_id, accounts, instruction_data)
+}

--- a/instruction-padding/program/src/instruction.rs
+++ b/instruction-padding/program/src/instruction.rs
@@ -1,0 +1,158 @@
+//! Instruction creators for large instructions
+
+use {
+    num_enum::{IntoPrimitive, TryFromPrimitive},
+    solana_program::{
+        instruction::{AccountMeta, Instruction},
+        program_error::ProgramError,
+        pubkey::Pubkey,
+        syscalls::{MAX_CPI_ACCOUNT_INFOS, MAX_CPI_INSTRUCTION_DATA_LEN},
+    },
+    std::{convert::TryInto, mem::size_of},
+};
+
+/// Instructions supported by the padding program, which takes in additional
+/// account data or accounts and does nothing with them. It's meant for testing
+/// larger transactions with bench-tps.
+#[derive(Clone, Copy, Debug, TryFromPrimitive, IntoPrimitive)]
+#[repr(u8)]
+pub enum PadInstruction {
+    /// Does no work, but accepts a large amount of data and accounts
+    Noop,
+    /// Wraps the provided instruction, calling the provided program via CPI
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    /// * All accounts required for the inner instruction
+    /// * The program invoked by the inner instruction
+    /// * Additional padding accounts
+    ///
+    /// Data expected by this instruction:
+    /// * WrapData
+    Wrap,
+}
+
+/// Data wrapping any inner instruction
+pub struct WrapData<'a> {
+    /// Number of accounts required by the inner instruction
+    pub num_accounts: u32,
+    /// the size of the inner instruction data
+    pub instruction_size: u32,
+    /// actual inner instruction data
+    pub instruction_data: &'a [u8],
+    // additional padding bytes come after, not captured in this struct
+}
+
+const U32_BYTES: usize = 4;
+fn unpack_u32(input: &[u8]) -> Result<(u32, &[u8]), ProgramError> {
+    let value = input
+        .get(..U32_BYTES)
+        .and_then(|slice| slice.try_into().ok())
+        .map(u32::from_le_bytes)
+        .ok_or(ProgramError::InvalidInstructionData)?;
+    Ok((value, &input[U32_BYTES..]))
+}
+
+impl<'a> WrapData<'a> {
+    /// Unpacks instruction data
+    pub fn unpack(data: &'a [u8]) -> Result<Self, ProgramError> {
+        let (num_accounts, rest) = unpack_u32(data)?;
+        let (instruction_size, rest) = unpack_u32(rest)?;
+
+        let (instruction_data, _rest) = rest.split_at(instruction_size as usize);
+        Ok(Self {
+            num_accounts,
+            instruction_size,
+            instruction_data,
+        })
+    }
+}
+
+pub fn noop(
+    program_id: Pubkey,
+    padding_accounts: Vec<AccountMeta>,
+    padding_data: u32,
+) -> Result<Instruction, ProgramError> {
+    let total_data_size = size_of::<u8>().saturating_add(padding_data as usize);
+    // crude, but can find a potential issue right away
+    if total_data_size > MAX_CPI_INSTRUCTION_DATA_LEN as usize {
+        return Err(ProgramError::InvalidInstructionData);
+    }
+    let mut data = Vec::with_capacity(total_data_size);
+    data.push(PadInstruction::Noop.into());
+    for i in 0..padding_data {
+        data.push(i.checked_rem(u8::MAX as u32).unwrap() as u8);
+    }
+
+    let num_accounts = padding_accounts.len().saturating_add(1);
+    if num_accounts > MAX_CPI_ACCOUNT_INFOS {
+        return Err(ProgramError::InvalidAccountData);
+    }
+    let mut accounts = Vec::with_capacity(num_accounts);
+    accounts.extend(padding_accounts.into_iter());
+
+    Ok(Instruction {
+        program_id,
+        accounts,
+        data,
+    })
+}
+
+pub fn wrap_instruction(
+    program_id: Pubkey,
+    instruction: Instruction,
+    padding_accounts: Vec<AccountMeta>,
+    padding_data: u32,
+) -> Result<Instruction, ProgramError> {
+    let total_data_size = size_of::<u8>()
+        .saturating_add(size_of::<u32>())
+        .saturating_add(size_of::<u32>())
+        .saturating_add(instruction.data.len())
+        .saturating_add(padding_data as usize);
+    // crude, but can find a potential issue right away
+    if total_data_size > MAX_CPI_INSTRUCTION_DATA_LEN as usize {
+        return Err(ProgramError::InvalidInstructionData);
+    }
+    let mut data = Vec::with_capacity(total_data_size);
+    data.push(PadInstruction::Wrap.into());
+    let num_accounts: u32 = instruction
+        .accounts
+        .len()
+        .try_into()
+        .map_err(|_| ProgramError::InvalidInstructionData)?;
+    data.extend(num_accounts.to_le_bytes().iter());
+
+    let data_size: u32 = instruction
+        .data
+        .len()
+        .try_into()
+        .map_err(|_| ProgramError::InvalidInstructionData)?;
+    data.extend(data_size.to_le_bytes().iter());
+    data.extend(instruction.data.into_iter());
+    for i in 0..padding_data {
+        data.push(i.checked_rem(u8::MAX as u32).unwrap() as u8);
+    }
+
+    // The format for account data goes:
+    // * accounts required for the CPI
+    // * program account to call into
+    // * additional accounts may be included as padding or to test loading / locks
+    let num_accounts = instruction
+        .accounts
+        .len()
+        .saturating_add(1)
+        .saturating_add(padding_accounts.len());
+    if num_accounts > MAX_CPI_ACCOUNT_INFOS {
+        return Err(ProgramError::InvalidAccountData);
+    }
+    let mut accounts = Vec::with_capacity(num_accounts);
+    accounts.extend(instruction.accounts.into_iter());
+    accounts.push(AccountMeta::new_readonly(instruction.program_id, false));
+    accounts.extend(padding_accounts.into_iter());
+
+    Ok(Instruction {
+        program_id,
+        accounts,
+        data,
+    })
+}

--- a/instruction-padding/program/src/lib.rs
+++ b/instruction-padding/program/src/lib.rs
@@ -1,0 +1,6 @@
+mod entrypoint;
+pub mod instruction;
+pub mod processor;
+
+pub use solana_program;
+solana_program::declare_id!("iXpADd6AW1k5FaaXum5qHbSqyd7TtoN6AD7suVa83MF");

--- a/instruction-padding/program/src/processor.rs
+++ b/instruction-padding/program/src/processor.rs
@@ -1,0 +1,57 @@
+use {
+    crate::instruction::{PadInstruction, WrapData},
+    solana_program::{
+        account_info::AccountInfo,
+        entrypoint::ProgramResult,
+        instruction::{AccountMeta, Instruction},
+        program::invoke,
+        program_error::ProgramError,
+        pubkey::Pubkey,
+    },
+    std::convert::TryInto,
+};
+
+pub fn process(
+    _program_id: &Pubkey,
+    account_infos: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    let (tag, rest) = instruction_data
+        .split_first()
+        .ok_or(ProgramError::InvalidInstructionData)?;
+    match (*tag)
+        .try_into()
+        .map_err(|_| ProgramError::InvalidInstructionData)?
+    {
+        PadInstruction::Noop => Ok(()),
+        PadInstruction::Wrap => {
+            let WrapData {
+                num_accounts,
+                instruction_size,
+                instruction_data,
+            } = WrapData::unpack(rest)?;
+            let mut data = Vec::with_capacity(instruction_size as usize);
+            data.extend_from_slice(instruction_data);
+
+            let program_id = *account_infos[num_accounts as usize].key;
+
+            let accounts = account_infos
+                .iter()
+                .take(num_accounts as usize)
+                .map(|a| AccountMeta {
+                    pubkey: *a.key,
+                    is_signer: a.is_signer,
+                    is_writable: a.is_writable,
+                })
+                .collect::<Vec<_>>();
+
+            let instruction = Instruction {
+                program_id,
+                accounts,
+                data,
+            };
+
+            invoke(&instruction, &account_infos[..num_accounts as usize])
+        }
+    }
+}

--- a/instruction-padding/program/tests/noop.rs
+++ b/instruction-padding/program/tests/noop.rs
@@ -1,0 +1,38 @@
+#![cfg(feature = "test-sbf")]
+
+use {
+    solana_program_test::{processor, tokio, ProgramTest},
+    solana_sdk::{
+        instruction::AccountMeta, pubkey::Pubkey, signature::Signer, transaction::Transaction,
+    },
+    spl_instruction_padding::{instruction::noop, processor::process},
+};
+
+#[tokio::test]
+async fn success_with_noop() {
+    let program_id = Pubkey::new_unique();
+    let program_test = ProgramTest::new("spl_instruction_padding", program_id, processor!(process));
+
+    let mut context = program_test.start_with_context().await;
+
+    let padding_accounts = vec![
+        AccountMeta::new_readonly(Pubkey::new_unique(), false),
+        AccountMeta::new_readonly(Pubkey::new_unique(), false),
+        AccountMeta::new_readonly(Pubkey::new_unique(), false),
+    ];
+
+    let padding_data = 800;
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[noop(program_id, padding_accounts, padding_data).unwrap()],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+}

--- a/instruction-padding/program/tests/system.rs
+++ b/instruction-padding/program/tests/system.rs
@@ -1,0 +1,62 @@
+#![cfg(feature = "test-sbf")]
+
+use {
+    solana_program_test::{processor, tokio, ProgramTest},
+    solana_sdk::{
+        instruction::AccountMeta, native_token::LAMPORTS_PER_SOL, pubkey::Pubkey,
+        signature::Signer, system_instruction, transaction::Transaction,
+    },
+    spl_instruction_padding::{instruction::wrap_instruction, processor::process},
+};
+
+#[tokio::test]
+async fn success_with_padded_transfer_data() {
+    let program_id = Pubkey::new_unique();
+    let program_test = ProgramTest::new("spl_instruction_padding", program_id, processor!(process));
+
+    let mut context = program_test.start_with_context().await;
+    let to = Pubkey::new_unique();
+
+    let transfer_amount = LAMPORTS_PER_SOL;
+    let transfer_instruction =
+        system_instruction::transfer(&context.payer.pubkey(), &to, transfer_amount);
+
+    let padding_accounts = vec![
+        AccountMeta::new_readonly(Pubkey::new_unique(), false),
+        AccountMeta::new_readonly(Pubkey::new_unique(), false),
+        AccountMeta::new_readonly(Pubkey::new_unique(), false),
+    ];
+
+    let padding_data = 800;
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[wrap_instruction(
+            program_id,
+            transfer_instruction,
+            padding_accounts,
+            padding_data,
+        )
+        .unwrap()],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+
+    // make sure the transfer went through
+    assert_eq!(
+        transfer_amount,
+        context
+            .banks_client
+            .get_account(to)
+            .await
+            .unwrap()
+            .unwrap()
+            .lamports
+    );
+}


### PR DESCRIPTION
#### Problem

For testing the effect of larger transaction sizes on the network, it's useful to have a program that just accepts large transactions and either no-ops or CPIs into some other program.

This can be integrated into bench-tps to see the effect with huge numbers of transactions, as done in https://github.com/solana-labs/solana/pull/27495

#### Solution

Start with the program, build / publish it, then add the bench-tps parts from https://github.com/solana-labs/solana/pull/27495