### PR TITLE
farms: Update docs to build-bpf instead of build-sbf

### DIFF
--- a/farms/docs/fund.md
+++ b/farms/docs/fund.md
@@ -14,7 +14,7 @@ To build and deploy the Fund program, run:
 
 ```sh
 cd solana-program-library/farms/fund
-cargo build-sbf
+cargo build-bpf
 solana program deploy ../target/deploy/solana_fund.so
 ```
 

--- a/farms/docs/governance.md
+++ b/farms/docs/governance.md
@@ -4,7 +4,7 @@ To initialize the DAO, first build and deploy the governance program:
 
 ```sh
 cd solana-program-library/governance/program
-cargo build-sbf
+cargo build-bpf
 solana program deploy --commitment finalized target/deploy/spl_governance.so
 ```
 

--- a/farms/docs/quick_start.md
+++ b/farms/docs/quick_start.md
@@ -42,12 +42,12 @@ popd
 
 Alternatively, you can execute instructions directly using [HTTP Client](https://github.com/solana-labs/solana-program-library/blob/master/farms/docs/http_client.md) or [Rust Client](https://github.com/solana-labs/solana-program-library/blob/master/farms/docs/rust_client.md).
 
-To build on-chain programs, use the standard `cargo build-sbf` command for Solana programs:
+To build on-chain programs, use the standard `cargo build-bpf` command for Solana programs:
 
 ```sh
 for program in router-*; do
     pushd $program &>/dev/null
-    cargo build-sbf
+    cargo build-bpf
     popd &>/dev/null
 done
 ```
@@ -56,7 +56,7 @@ To build Vaults, specify an additional argument that tells the compiler which st
 
 ```sh
 pusdh vaults
-cargo build-sbf --no-default-features --features SBR-STAKE-LP-COMPOUND
+cargo build-bpf --no-default-features --features SBR-STAKE-LP-COMPOUND
 popd
 ```
 
@@ -66,7 +66,7 @@ Every time you re-build the vault program with another strategy, it overwrites t
 pushd vaults &>/dev/null
 for strategy in RDM SBR ORC; do
     solana-keygen new -o vault_$strategy.json
-    cargo build-sbf --no-default-features --features $strategy-STAKE-LP-COMPOUND
+    cargo build-bpf --no-default-features --features $strategy-STAKE-LP-COMPOUND
     solana program deploy --program-id vault_$strategy.json target/deploy/solana_vaults.so
 done
 popd &>/dev/null

--- a/farms/farm-sdk/build.rs
+++ b/farms/farm-sdk/build.rs
@@ -1,6 +1,6 @@
 //! Creates a file that will set constants captured from the environment.
 //! These constants represent official accounts, program ids, and names.
-//! Normally lazy_static! would work, but it is not supported with build-sbf.
+//! Normally lazy_static! would work, but it is not supported with build-bpf.
 
 use {
     solana_program::pubkey::Pubkey,

--- a/farms/vaults/Cargo.toml
+++ b/farms/vaults/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2021"
 [features]
 no-entrypoint = []
 debug = []
-test-sbf = []
 RDM-STAKE-LP-COMPOUND = []
 SBR-STAKE-LP-COMPOUND = []
 ORC-STAKE-LP-COMPOUND = []
@@ -29,4 +28,3 @@ solana-program-test = "1.9.18"
 
 [lib]
 crate-type = ["cdylib", "lib"]
-


### PR DESCRIPTION
#### Problem

The farms docs say to use `build-sbf`, but farms still use older crates that aren't compatible with `build-sbf`.

#### Solution

Update the docs to say `build-bpf` everywhere, and remove all traces of `sbf`.