### PR TITLE
Governance: Implement Absolute max voter weight source

### DIFF
--- a/governance/chat/program/tests/program_test/mod.rs
+++ b/governance/chat/program/tests/program_test/mod.rs
@@ -10,7 +10,7 @@ use spl_governance::{
         deposit_governing_tokens,
     },
     state::{
-        enums::{MintMaxVoteWeightSource, VoteThreshold},
+        enums::{MintMaxVoterWeightSource, VoteThreshold},
         governance::{get_governance_address, GovernanceConfig},
         proposal::{get_proposal_address, VoteType},
         realm::{get_realm_address, GoverningTokenConfigAccountArgs},
@@ -125,7 +125,7 @@ impl GovernanceChatProgramTest {
             None,
             name.clone(),
             1,
-            MintMaxVoteWeightSource::FULL_SUPPLY_FRACTION,
+            MintMaxVoterWeightSource::FULL_SUPPLY_FRACTION,
         );
 
         self.bench

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -291,9 +291,9 @@ pub enum GovernanceError {
     #[error("Realm council mint change is not supported")]
     RealmCouncilMintChangeIsNotSupported,
 
-    /// Not supported mint max vote weight sourcef
-    #[error("Not supported mint max vote weight source")]
-    MintMaxVoteWeightSourceNotSupported,
+    /// Invalid max vote weight absolute value
+    #[error("Invalid max vote weight absolute value")]
+    InvalidMaxVoteWeightAbsoluteValue,
 
     /// Invalid max vote weight supply fraction
     #[error("Invalid max vote weight supply fraction")]

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -291,13 +291,13 @@ pub enum GovernanceError {
     #[error("Realm council mint change is not supported")]
     RealmCouncilMintChangeIsNotSupported,
 
-    /// Invalid max vote weight absolute value
-    #[error("Invalid max vote weight absolute value")]
-    InvalidMaxVoteWeightAbsoluteValue,
+    /// Invalid max voter weight absolute value
+    #[error("Invalid max voter weight absolute value")]
+    InvalidMaxVoterWeightAbsoluteValue,
 
-    /// Invalid max vote weight supply fraction
-    #[error("Invalid max vote weight supply fraction")]
-    InvalidMaxVoteWeightSupplyFraction,
+    /// Invalid max voter weight supply fraction
+    #[error("Invalid max voter weight supply fraction")]
+    InvalidMaxVoterWeightSupplyFraction,
 
     /// Owner doesn't have enough governing tokens to create Governance
     #[error("Owner doesn't have enough governing tokens to create Governance")]

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     state::{
-        enums::MintMaxVoteWeightSource,
+        enums::MintMaxVoterWeightSource,
         governance::{
             get_governance_address, get_mint_governance_address, get_program_governance_address,
             get_token_governance_address, GovernanceConfig,
@@ -522,7 +522,7 @@ pub fn create_realm(
     // Args
     name: String,
     min_community_weight_to_create_governance: u64,
-    community_mint_max_vote_weight_source: MintMaxVoteWeightSource,
+    community_mint_max_voter_weight_source: MintMaxVoterWeightSource,
 ) -> Instruction {
     let realm_address = get_realm_address(program_id, &name);
     let community_token_holding_address =
@@ -563,7 +563,7 @@ pub fn create_realm(
         config_args: RealmConfigArgs {
             use_council_mint,
             min_community_weight_to_create_governance,
-            community_mint_max_vote_weight_source,
+            community_mint_max_voter_weight_source,
             community_token_config_args,
             council_token_config_args,
         },
@@ -1379,7 +1379,7 @@ pub fn set_realm_config(
     council_token_config_args: Option<GoverningTokenConfigAccountArgs>,
     // Args
     min_community_weight_to_create_governance: u64,
-    community_mint_max_vote_weight_source: MintMaxVoteWeightSource,
+    community_mint_max_voter_weight_source: MintMaxVoterWeightSource,
 ) -> Instruction {
     let mut accounts = vec![
         AccountMeta::new(*realm, false),
@@ -1416,7 +1416,7 @@ pub fn set_realm_config(
         config_args: RealmConfigArgs {
             use_council_mint,
             min_community_weight_to_create_governance,
-            community_mint_max_vote_weight_source,
+            community_mint_max_voter_weight_source,
             community_token_config_args,
             council_token_config_args,
         },

--- a/governance/program/src/processor/process_create_realm.rs
+++ b/governance/program/src/processor/process_create_realm.rs
@@ -132,8 +132,8 @@ pub fn process_create_realm(
         config: RealmConfig {
             council_mint: council_token_mint_address,
             reserved: [0; 6],
-            community_mint_max_vote_weight_source: realm_config_args
-                .community_mint_max_vote_weight_source,
+            community_mint_max_voter_weight_source: realm_config_args
+                .community_mint_max_voter_weight_source,
             min_community_weight_to_create_governance: realm_config_args
                 .min_community_weight_to_create_governance,
             legacy1: 0,

--- a/governance/program/src/processor/process_set_realm_config.rs
+++ b/governance/program/src/processor/process_set_realm_config.rs
@@ -121,8 +121,8 @@ pub fn process_set_realm_config(
     }
 
     // Update RealmConfig (Realm.config field)
-    realm_data.config.community_mint_max_vote_weight_source =
-        realm_config_args.community_mint_max_vote_weight_source;
+    realm_data.config.community_mint_max_voter_weight_source =
+        realm_config_args.community_mint_max_voter_weight_source;
 
     realm_data.config.min_community_weight_to_create_governance =
         realm_config_args.min_community_weight_to_create_governance;

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -230,8 +230,7 @@ pub enum MintMaxVoteWeightSource {
     /// The default is 100% (10^10) to use all available mint supply for voting
     SupplyFraction(u64),
 
-    /// Absolute value, irrelevant of the actual mint supply, is used as max vote weight
-    /// Note: this option is not implemented in the current version
+    /// Absolute value, irrelevant of the actual mint supply, is used as max voter weight
     Absolute(u64),
 }
 

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -225,7 +225,7 @@ pub enum InstructionExecutionFlags {
 /// The source of max vote weight used for voting
 /// Values below 100% mint supply can be used when the governing token is fully minted but not distributed yet
 #[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
-pub enum MintMaxVoteWeightSource {
+pub enum MintMaxVoterWeightSource {
     /// Fraction (10^10 precision) of the governing mint supply is used as max vote weight
     /// The default is 100% (10^10) to use all available mint supply for voting
     SupplyFraction(u64),
@@ -234,11 +234,11 @@ pub enum MintMaxVoteWeightSource {
     Absolute(u64),
 }
 
-impl MintMaxVoteWeightSource {
+impl MintMaxVoterWeightSource {
     /// Base for mint supply fraction calculation
     pub const SUPPLY_FRACTION_BASE: u64 = 10_000_000_000;
 
     /// 100% of mint supply
-    pub const FULL_SUPPLY_FRACTION: MintMaxVoteWeightSource =
-        MintMaxVoteWeightSource::SupplyFraction(MintMaxVoteWeightSource::SUPPLY_FRACTION_BASE);
+    pub const FULL_SUPPLY_FRACTION: MintMaxVoterWeightSource =
+        MintMaxVoterWeightSource::SupplyFraction(MintMaxVoterWeightSource::SUPPLY_FRACTION_BASE);
 }

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -447,7 +447,7 @@ impl ProposalV2 {
             MintMaxVoterWeightSource::Absolute(value) => value,
         };
 
-        // When the fraction or absolute vlaue is used it's possible we can go over the calculated max_vote_weight
+        // When the fraction or absolute value is used it's possible we can go over the calculated max_vote_weight
         // and we have to adjust it in case more votes have been cast
         Ok(self.coerce_max_voter_weight(max_voter_weight, vote_kind))
     }

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -24,7 +24,7 @@ use crate::{
     error::GovernanceError,
     state::{
         enums::{
-            GovernanceAccountType, InstructionExecutionFlags, MintMaxVoteWeightSource,
+            GovernanceAccountType, InstructionExecutionFlags, MintMaxVoterWeightSource,
             ProposalState, TransactionExecutionStatus, VoteThreshold, VoteTipping,
         },
         governance::GovernanceConfig,
@@ -432,19 +432,19 @@ impl ProposalV2 {
             return Ok(governing_token_mint_supply);
         }
 
-        let max_voter_weight = match realm_data.config.community_mint_max_vote_weight_source {
-            MintMaxVoteWeightSource::SupplyFraction(fraction) => {
-                if fraction == MintMaxVoteWeightSource::SUPPLY_FRACTION_BASE {
+        let max_voter_weight = match realm_data.config.community_mint_max_voter_weight_source {
+            MintMaxVoterWeightSource::SupplyFraction(fraction) => {
+                if fraction == MintMaxVoterWeightSource::SUPPLY_FRACTION_BASE {
                     return Ok(governing_token_mint_supply);
                 }
 
                 (governing_token_mint_supply as u128)
                     .checked_mul(fraction as u128)
                     .unwrap()
-                    .checked_div(MintMaxVoteWeightSource::SUPPLY_FRACTION_BASE as u128)
+                    .checked_div(MintMaxVoterWeightSource::SUPPLY_FRACTION_BASE as u128)
                     .unwrap() as u64
             }
-            MintMaxVoteWeightSource::Absolute(value) => value,
+            MintMaxVoterWeightSource::Absolute(value) => value,
         };
 
         // When the fraction or absolute vlaue is used it's possible we can go over the calculated max_vote_weight
@@ -1055,7 +1055,7 @@ mod test {
     use solana_program::clock::Epoch;
 
     use crate::state::{
-        enums::{MintMaxVoteWeightSource, VoteThreshold},
+        enums::{MintMaxVoterWeightSource, VoteThreshold},
         legacy::ProposalV1,
         realm::RealmConfig,
         vote_record::VoteChoice,
@@ -1156,8 +1156,8 @@ mod test {
                 legacy1: 0,
                 legacy2: 0,
 
-                community_mint_max_vote_weight_source:
-                    MintMaxVoteWeightSource::FULL_SUPPLY_FRACTION,
+                community_mint_max_voter_weight_source:
+                    MintMaxVoterWeightSource::FULL_SUPPLY_FRACTION,
                 min_community_weight_to_create_governance: 10,
             },
             voting_proposal_count: 0,
@@ -1799,9 +1799,9 @@ mod test {
         let vote_tipping = VoteTipping::Strict;
 
         // reduce max vote weight to 100
-        realm.config.community_mint_max_vote_weight_source =
-            MintMaxVoteWeightSource::SupplyFraction(
-                MintMaxVoteWeightSource::SUPPLY_FRACTION_BASE / 2,
+        realm.config.community_mint_max_voter_weight_source =
+            MintMaxVoterWeightSource::SupplyFraction(
+                MintMaxVoterWeightSource::SUPPLY_FRACTION_BASE / 2,
             );
 
         let max_voter_weight = proposal
@@ -1852,8 +1852,8 @@ mod test {
         let vote_tipping = VoteTipping::Strict;
 
         // set max vote weight to 100
-        realm.config.community_mint_max_vote_weight_source =
-            MintMaxVoteWeightSource::Absolute(community_token_supply / 2);
+        realm.config.community_mint_max_voter_weight_source =
+            MintMaxVoterWeightSource::Absolute(community_token_supply / 2);
 
         let max_voter_weight = proposal
             .get_max_voter_weight_from_mint_supply(
@@ -1903,9 +1903,9 @@ mod test {
         let vote_tipping = VoteTipping::Strict;
 
         // reduce max vote weight to 100
-        realm.config.community_mint_max_vote_weight_source =
-            MintMaxVoteWeightSource::SupplyFraction(
-                MintMaxVoteWeightSource::SUPPLY_FRACTION_BASE / 2,
+        realm.config.community_mint_max_voter_weight_source =
+            MintMaxVoterWeightSource::SupplyFraction(
+                MintMaxVoterWeightSource::SUPPLY_FRACTION_BASE / 2,
             );
 
         // vote above reduced supply
@@ -1958,9 +1958,9 @@ mod test {
         let vote_kind = VoteKind::Electorate;
         let vote_tipping = VoteTipping::Strict;
 
-        realm.config.community_mint_max_vote_weight_source =
-            MintMaxVoteWeightSource::SupplyFraction(
-                MintMaxVoteWeightSource::SUPPLY_FRACTION_BASE / 2,
+        realm.config.community_mint_max_voter_weight_source =
+            MintMaxVoterWeightSource::SupplyFraction(
+                MintMaxVoterWeightSource::SUPPLY_FRACTION_BASE / 2,
             );
         realm.config.council_mint = Some(proposal.governing_token_mint);
 
@@ -2010,9 +2010,9 @@ mod test {
         let vote_kind = VoteKind::Electorate;
 
         // reduce max vote weight to 100
-        realm.config.community_mint_max_vote_weight_source =
-            MintMaxVoteWeightSource::SupplyFraction(
-                MintMaxVoteWeightSource::SUPPLY_FRACTION_BASE / 2,
+        realm.config.community_mint_max_voter_weight_source =
+            MintMaxVoterWeightSource::SupplyFraction(
+                MintMaxVoterWeightSource::SUPPLY_FRACTION_BASE / 2,
             );
 
         let max_voter_weight = proposal
@@ -2061,9 +2061,9 @@ mod test {
         let vote_kind = VoteKind::Electorate;
 
         // reduce max vote weight to 100
-        realm.config.community_mint_max_vote_weight_source =
-            MintMaxVoteWeightSource::SupplyFraction(
-                MintMaxVoteWeightSource::SUPPLY_FRACTION_BASE / 2,
+        realm.config.community_mint_max_voter_weight_source =
+            MintMaxVoterWeightSource::SupplyFraction(
+                MintMaxVoterWeightSource::SUPPLY_FRACTION_BASE / 2,
             );
 
         // vote above reduced supply

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -19,7 +19,7 @@ use spl_governance_tools::account::{
 use crate::{
     error::GovernanceError,
     state::{
-        enums::{GovernanceAccountType, MintMaxVoteWeightSource},
+        enums::{GovernanceAccountType, MintMaxVoterWeightSource},
         legacy::RealmV1,
         realm_config::GoverningTokenType,
         token_owner_record::get_token_owner_record_data_for_realm,
@@ -41,7 +41,7 @@ pub struct RealmConfigArgs {
     pub min_community_weight_to_create_governance: u64,
 
     /// The source used for community mint max vote weight source
-    pub community_mint_max_vote_weight_source: MintMaxVoteWeightSource,
+    pub community_mint_max_voter_weight_source: MintMaxVoterWeightSource,
 
     /// Community token config args
     pub community_token_config_args: GoverningTokenConfigArgs,
@@ -116,7 +116,7 @@ pub struct RealmConfig {
     pub min_community_weight_to_create_governance: u64,
 
     /// The source used for community mint max vote weight source
-    pub community_mint_max_vote_weight_source: MintMaxVoteWeightSource,
+    pub community_mint_max_voter_weight_source: MintMaxVoterWeightSource,
 
     /// Optional council mint
     pub council_mint: Option<Pubkey>,
@@ -435,15 +435,15 @@ pub fn get_governing_token_holding_address(
 pub fn assert_valid_realm_config_args(
     realm_config_args: &RealmConfigArgs,
 ) -> Result<(), ProgramError> {
-    match realm_config_args.community_mint_max_vote_weight_source {
-        MintMaxVoteWeightSource::SupplyFraction(fraction) => {
-            if !(1..=MintMaxVoteWeightSource::SUPPLY_FRACTION_BASE).contains(&fraction) {
-                return Err(GovernanceError::InvalidMaxVoteWeightSupplyFraction.into());
+    match realm_config_args.community_mint_max_voter_weight_source {
+        MintMaxVoterWeightSource::SupplyFraction(fraction) => {
+            if !(1..=MintMaxVoterWeightSource::SUPPLY_FRACTION_BASE).contains(&fraction) {
+                return Err(GovernanceError::InvalidMaxVoterWeightSupplyFraction.into());
             }
         }
-        MintMaxVoteWeightSource::Absolute(amount) => {
-            if amount == 0 {
-                return Err(GovernanceError::InvalidMaxVoteWeightAbsoluteValue.into());
+        MintMaxVoterWeightSource::Absolute(value) => {
+            if value == 0 {
+                return Err(GovernanceError::InvalidMaxVoterWeightAbsoluteValue.into());
             }
         }
     }
@@ -473,7 +473,7 @@ mod test {
                 legacy1: 0,
                 legacy2: 0,
                 reserved: [0; 6],
-                community_mint_max_vote_weight_source: MintMaxVoteWeightSource::Absolute(100),
+                community_mint_max_voter_weight_source: MintMaxVoterWeightSource::Absolute(100),
                 min_community_weight_to_create_governance: 10,
             },
 
@@ -497,7 +497,7 @@ mod test {
         pub min_community_weight_to_create_governance: u64,
 
         /// The source used for community mint max vote weight source
-        pub community_mint_max_vote_weight_source: MintMaxVoteWeightSource,
+        pub community_mint_max_voter_weight_source: MintMaxVoterWeightSource,
     }
 
     /// Instructions supported by the Governance program
@@ -530,8 +530,8 @@ mod test {
             config_args: RealmConfigArgs {
                 use_council_mint: true,
                 min_community_weight_to_create_governance: 100,
-                community_mint_max_vote_weight_source:
-                    MintMaxVoteWeightSource::FULL_SUPPLY_FRACTION,
+                community_mint_max_voter_weight_source:
+                    MintMaxVoterWeightSource::FULL_SUPPLY_FRACTION,
                 community_token_config_args: GoverningTokenConfigArgs::default(),
                 council_token_config_args: GoverningTokenConfigArgs::default(),
             },
@@ -550,8 +550,8 @@ mod test {
         if let GovernanceInstructionV1::CreateRealm { name, config_args } = create_realm_ix_v1 {
             assert_eq!("test-realm", name);
             assert_eq!(
-                MintMaxVoteWeightSource::FULL_SUPPLY_FRACTION,
-                config_args.community_mint_max_vote_weight_source
+                MintMaxVoterWeightSource::FULL_SUPPLY_FRACTION,
+                config_args.community_mint_max_voter_weight_source
             );
         } else {
             panic!("Can't deserialize v1 CreateRealm instruction from v2");

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -441,8 +441,10 @@ pub fn assert_valid_realm_config_args(
                 return Err(GovernanceError::InvalidMaxVoteWeightSupplyFraction.into());
             }
         }
-        MintMaxVoteWeightSource::Absolute(_) => {
-            return Err(GovernanceError::MintMaxVoteWeightSourceNotSupported.into())
+        MintMaxVoteWeightSource::Absolute(amount) => {
+            if amount == 0 {
+                return Err(GovernanceError::InvalidMaxVoteWeightAbsoluteValue.into());
+            }
         }
     }
 

--- a/governance/program/tests/process_cast_vote.rs
+++ b/governance/program/tests/process_cast_vote.rs
@@ -9,7 +9,7 @@ use program_test::*;
 use spl_governance::{
     error::GovernanceError,
     state::{
-        enums::{MintMaxVoteWeightSource, ProposalState, VoteThreshold, VoteTipping},
+        enums::{MintMaxVoterWeightSource, ProposalState, VoteThreshold, VoteTipping},
         vote_record::Vote,
     },
 };
@@ -1507,8 +1507,8 @@ async fn test_cast_vote_with_strict_tipping_and_inflated_max_vote_weight() {
 
     // Reduce max voter weight to 50% for the cast vote to be above max_voter_weight
     let realm_config_args = RealmSetupArgs {
-        community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(
-            MintMaxVoteWeightSource::SUPPLY_FRACTION_BASE / 2,
+        community_mint_max_voter_weight_source: MintMaxVoterWeightSource::SupplyFraction(
+            MintMaxVoterWeightSource::SUPPLY_FRACTION_BASE / 2,
         ),
         ..Default::default()
     };

--- a/governance/program/tests/process_create_realm.rs
+++ b/governance/program/tests/process_create_realm.rs
@@ -51,6 +51,36 @@ async fn test_create_realm_with_non_default_config() {
 }
 
 #[tokio::test]
+async fn test_create_realm_with_max_voter_weight_absolute_value() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_setup_args = RealmSetupArgs {
+        community_mint_max_vote_weight_source: MintMaxVoteWeightSource::Absolute(1),
+        ..Default::default()
+    };
+
+    // Act
+    let realm_cookie = governance_test
+        .with_realm_using_args(&realm_setup_args)
+        .await;
+
+    // Assert
+    let realm_account = governance_test
+        .get_realm_account(&realm_cookie.address)
+        .await;
+
+    assert_eq!(realm_cookie.account, realm_account);
+    assert_eq!(
+        realm_cookie
+            .account
+            .config
+            .community_mint_max_vote_weight_source,
+        MintMaxVoteWeightSource::Absolute(1)
+    );
+}
+
+#[tokio::test]
 async fn test_create_realm_for_existing_pda() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;

--- a/governance/program/tests/process_create_realm.rs
+++ b/governance/program/tests/process_create_realm.rs
@@ -5,7 +5,7 @@ use solana_program_test::*;
 mod program_test;
 
 use program_test::*;
-use spl_governance::state::{enums::MintMaxVoteWeightSource, realm::get_realm_address};
+use spl_governance::state::{enums::MintMaxVoterWeightSource, realm::get_realm_address};
 
 use crate::program_test::args::RealmSetupArgs;
 
@@ -32,7 +32,7 @@ async fn test_create_realm_with_non_default_config() {
 
     let realm_setup_args = RealmSetupArgs {
         use_council_mint: false,
-        community_mint_max_vote_weight_source: MintMaxVoteWeightSource::SupplyFraction(1),
+        community_mint_max_voter_weight_source: MintMaxVoterWeightSource::SupplyFraction(1),
         min_community_weight_to_create_governance: 1,
         ..Default::default()
     };
@@ -56,7 +56,7 @@ async fn test_create_realm_with_max_voter_weight_absolute_value() {
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
     let realm_setup_args = RealmSetupArgs {
-        community_mint_max_vote_weight_source: MintMaxVoteWeightSource::Absolute(1),
+        community_mint_max_voter_weight_source: MintMaxVoterWeightSource::Absolute(1),
         ..Default::default()
     };
 
@@ -75,8 +75,8 @@ async fn test_create_realm_with_max_voter_weight_absolute_value() {
         realm_cookie
             .account
             .config
-            .community_mint_max_vote_weight_source,
-        MintMaxVoteWeightSource::Absolute(1)
+            .community_mint_max_voter_weight_source,
+        MintMaxVoterWeightSource::Absolute(1)
     );
 }
 

--- a/governance/program/tests/program_test/args.rs
+++ b/governance/program/tests/program_test/args.rs
@@ -1,12 +1,12 @@
 use spl_governance::state::{
-    enums::MintMaxVoteWeightSource, realm::GoverningTokenConfigAccountArgs,
+    enums::MintMaxVoterWeightSource, realm::GoverningTokenConfigAccountArgs,
 };
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct RealmSetupArgs {
     pub use_council_mint: bool,
     pub min_community_weight_to_create_governance: u64,
-    pub community_mint_max_vote_weight_source: MintMaxVoteWeightSource,
+    pub community_mint_max_voter_weight_source: MintMaxVoterWeightSource,
     pub community_token_config_args: GoverningTokenConfigAccountArgs,
     pub council_token_config_args: GoverningTokenConfigAccountArgs,
 }
@@ -18,7 +18,7 @@ impl Default for RealmSetupArgs {
             community_token_config_args: GoverningTokenConfigAccountArgs::default(),
             council_token_config_args: GoverningTokenConfigAccountArgs::default(),
             min_community_weight_to_create_governance: 10,
-            community_mint_max_vote_weight_source: MintMaxVoteWeightSource::FULL_SUPPLY_FRACTION,
+            community_mint_max_voter_weight_source: MintMaxVoterWeightSource::FULL_SUPPLY_FRACTION,
         }
     }
 }

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -28,7 +28,7 @@ use spl_governance::{
     processor::process_instruction,
     state::{
         enums::{
-            GovernanceAccountType, InstructionExecutionFlags, MintMaxVoteWeightSource,
+            GovernanceAccountType, InstructionExecutionFlags, MintMaxVoterWeightSource,
             ProposalState, TransactionExecutionStatus, VoteThreshold,
         },
         governance::{
@@ -320,7 +320,7 @@ impl GovernanceProgramTest {
             name.clone(),
             realm_setup_args.min_community_weight_to_create_governance,
             realm_setup_args
-                .community_mint_max_vote_weight_source
+                .community_mint_max_voter_weight_source
                 .clone(),
         );
 
@@ -342,8 +342,8 @@ impl GovernanceProgramTest {
 
                 min_community_weight_to_create_governance: realm_setup_args
                     .min_community_weight_to_create_governance,
-                community_mint_max_vote_weight_source: realm_setup_args
-                    .community_mint_max_vote_weight_source
+                community_mint_max_voter_weight_source: realm_setup_args
+                    .community_mint_max_voter_weight_source
                     .clone(),
                 legacy1: 0,
                 legacy2: 0,
@@ -411,7 +411,7 @@ impl GovernanceProgramTest {
 
         let realm_authority = Keypair::new();
 
-        let community_mint_max_vote_weight_source = MintMaxVoteWeightSource::FULL_SUPPLY_FRACTION;
+        let community_mint_max_voter_weight_source = MintMaxVoterWeightSource::FULL_SUPPLY_FRACTION;
         let min_community_weight_to_create_governance = 10;
 
         let create_realm_ix = create_realm(
@@ -424,7 +424,7 @@ impl GovernanceProgramTest {
             None,
             name.clone(),
             min_community_weight_to_create_governance,
-            community_mint_max_vote_weight_source,
+            community_mint_max_voter_weight_source,
         );
 
         self.bench
@@ -443,8 +443,8 @@ impl GovernanceProgramTest {
                 council_mint: Some(council_mint),
                 reserved: [0; 6],
 
-                community_mint_max_vote_weight_source:
-                    MintMaxVoteWeightSource::FULL_SUPPLY_FRACTION,
+                community_mint_max_voter_weight_source:
+                    MintMaxVoterWeightSource::FULL_SUPPLY_FRACTION,
                 min_community_weight_to_create_governance,
                 legacy1: 0,
                 legacy2: 0,
@@ -1145,7 +1145,7 @@ impl GovernanceProgramTest {
             Some(realm_setup_args.council_token_config_args.clone()),
             realm_setup_args.min_community_weight_to_create_governance,
             realm_setup_args
-                .community_mint_max_vote_weight_source
+                .community_mint_max_voter_weight_source
                 .clone(),
         );
 
@@ -1158,8 +1158,8 @@ impl GovernanceProgramTest {
         realm_cookie
             .account
             .config
-            .community_mint_max_vote_weight_source = realm_setup_args
-            .community_mint_max_vote_weight_source
+            .community_mint_max_voter_weight_source = realm_setup_args
+            .community_mint_max_voter_weight_source
             .clone();
 
         realm_cookie.realm_config = RealmConfigCookie {


### PR DESCRIPTION
#### Summary 

Implement `Absolute` option for `community_mint_max_voter_weight_source` to support static values not related to the governance token supply