### PR TITLE
Governance: Move reserved space to GovernanceConfig

### DIFF
--- a/governance/chat/program/tests/program_test/mod.rs
+++ b/governance/chat/program/tests/program_test/mod.rs
@@ -196,6 +196,7 @@ impl GovernanceChatProgramTest {
             council_veto_vote_threshold: VoteThreshold::YesVotePercentage(50),
             council_vote_tipping: spl_governance::state::enums::VoteTipping::Strict,
             community_veto_vote_threshold: VoteThreshold::YesVotePercentage(55),
+            reserved: [0; 3],
         };
 
         let token_owner_record_address = get_token_owner_record_address(

--- a/governance/program/src/processor/process_create_governance.rs
+++ b/governance/program/src/processor/process_create_governance.rs
@@ -57,7 +57,6 @@ pub fn process_create_governance(
         governed_account: *governed_account_info.key,
         config,
         proposals_count: 0,
-        reserved: [0; 3],
         voting_proposal_count: 0,
         reserved_v2: [0; 128],
     };

--- a/governance/program/src/processor/process_create_mint_governance.rs
+++ b/governance/program/src/processor/process_create_mint_governance.rs
@@ -69,7 +69,6 @@ pub fn process_create_mint_governance(
         governed_account: *governed_mint_info.key,
         config,
         proposals_count: 0,
-        reserved: [0; 3],
         voting_proposal_count: 0,
         reserved_v2: [0; 128],
     };

--- a/governance/program/src/processor/process_create_program_governance.rs
+++ b/governance/program/src/processor/process_create_program_governance.rs
@@ -69,7 +69,6 @@ pub fn process_create_program_governance(
         governed_account: *governed_program_info.key,
         config,
         proposals_count: 0,
-        reserved: [0; 3],
         voting_proposal_count: 0,
         reserved_v2: [0; 128],
     };

--- a/governance/program/src/processor/process_create_token_governance.rs
+++ b/governance/program/src/processor/process_create_token_governance.rs
@@ -67,7 +67,6 @@ pub fn process_create_token_governance(
         governed_account: *governed_token_info.key,
         config,
         proposals_count: 0,
-        reserved: [0; 3],
         voting_proposal_count: 0,
         reserved_v2: [0; 128],
     };

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -54,6 +54,9 @@ pub struct GovernanceConfig {
 
     /// The threshold for Community Veto votes
     pub community_veto_vote_threshold: VoteThreshold,
+
+    /// Reserved space for future versions
+    pub reserved: [u8; 3],
 }
 
 /// Governance Account
@@ -81,9 +84,6 @@ pub struct GovernanceV2 {
 
     /// Governance config
     pub config: GovernanceConfig,
-
-    /// Reserved space for future versions
-    pub reserved: [u8; 3],
 
     /// The number of proposals in voting state in the Governance
     pub voting_proposal_count: u16,
@@ -284,7 +284,6 @@ pub fn get_governance_data(
             governed_account: governance_data_v1.governed_account,
             proposals_count: governance_data_v1.proposals_count,
             config: governance_data_v1.config,
-            reserved: [0; 3],
             voting_proposal_count: governance_data_v1.voting_proposal_count,
 
             // Add the extra reserved_v2 padding
@@ -575,6 +574,7 @@ mod test {
             min_council_weight_to_create_proposal: 1,
             council_vote_tipping: VoteTipping::Strict,
             community_veto_vote_threshold: VoteThreshold::YesVotePercentage(1),
+            reserved: [0; 3],
         };
 
         // Act
@@ -600,6 +600,7 @@ mod test {
             min_council_weight_to_create_proposal: 1,
             council_vote_tipping: VoteTipping::Strict,
             community_veto_vote_threshold: VoteThreshold::YesVotePercentage(1),
+            reserved: [0; 3],
         };
 
         // Act
@@ -625,6 +626,7 @@ mod test {
             min_council_weight_to_create_proposal: 1,
             council_vote_tipping: VoteTipping::Strict,
             community_veto_vote_threshold: VoteThreshold::YesVotePercentage(1),
+            reserved: [0; 3],
         };
 
         // Act
@@ -650,6 +652,7 @@ mod test {
             min_council_weight_to_create_proposal: 1,
             council_vote_tipping: VoteTipping::Strict,
             community_veto_vote_threshold: VoteThreshold::YesVotePercentage(1),
+            reserved: [0; 3],
         };
 
         // Act
@@ -675,6 +678,7 @@ mod test {
             min_council_weight_to_create_proposal: 1,
             community_veto_vote_threshold: VoteThreshold::YesVotePercentage(0),
             community_vote_tipping: VoteTipping::Strict,
+            reserved: [0; 3],
         };
 
         // Act

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -1179,6 +1179,7 @@ mod test {
             council_veto_vote_threshold: VoteThreshold::YesVotePercentage(50),
             council_vote_tipping: VoteTipping::Strict,
             community_veto_vote_threshold: VoteThreshold::YesVotePercentage(40),
+            reserved: [0; 3],
         }
     }
 

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1415,6 +1415,7 @@ impl GovernanceProgramTest {
             council_veto_vote_threshold: VoteThreshold::YesVotePercentage(55),
             council_vote_tipping: spl_governance::state::enums::VoteTipping::Strict,
             community_veto_vote_threshold: VoteThreshold::YesVotePercentage(80),
+            reserved: [0; 3],
         }
     }
 
@@ -1489,7 +1490,6 @@ impl GovernanceProgramTest {
             governed_account: governed_account_cookie.address,
             config: governance_config.clone(),
             proposals_count: 0,
-            reserved: [0; 3],
             voting_proposal_count: 0,
             reserved_v2: [0; 128],
         };
@@ -1658,7 +1658,6 @@ impl GovernanceProgramTest {
             governed_account: governed_program_cookie.address,
             config,
             proposals_count: 0,
-            reserved: [0; 3],
             voting_proposal_count: 0,
             reserved_v2: [0; 128],
         };
@@ -1780,7 +1779,6 @@ impl GovernanceProgramTest {
             governed_account: governed_mint_cookie.address,
             config: governance_config.clone(),
             proposals_count: 0,
-            reserved: [0; 3],
             voting_proposal_count: 0,
             reserved_v2: [0; 128],
         };
@@ -1862,7 +1860,6 @@ impl GovernanceProgramTest {
             governed_account: governed_token_cookie.address,
             config,
             proposals_count: 0,
-            reserved: [0; 3],
             voting_proposal_count: 0,
             reserved_v2: [0; 128],
         };


### PR DESCRIPTION
#### Summary

Move `reserved` space to `GovernanceConfig` to make it easier to use it in backward compatible way for future `config` changes.