### PR TITLE
Refactor `test_create_program_governance`

### DIFF
--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -2,6 +2,7 @@
 
 set -ex
 
+sudo apt update
 sudo apt install libudev-dev -y
 sudo apt install binutils-dev -y
 sudo apt install libunwind-dev -y


### PR DESCRIPTION
Splits the unrealistically large transaction, which has 88 instructions and can not be send over the network, generated by `with_governed_program()` into many.

This change is necessary because [this PR](https://github.com/solana-labs/solana/pull/27938) will limit the number of instructions per transaction explicitly.