### PR TITLE
CMT: add method to check if Concurrent Merkle Tree is empty

### DIFF
--- a/libraries/concurrent-merkle-tree/src/error.rs
+++ b/libraries/concurrent-merkle-tree/src/error.rs
@@ -32,4 +32,8 @@ pub enum ConcurrentMerkleTreeError {
         "Valid proof was passed to a leaf, but its value has changed since the proof was issued"
     )]
     LeafContentsModified,
+
+    /// Tree has at least 1 non-EMTPY leaf
+    #[error("Tree is not empty")]
+    TreeNonEmpty,
 }


### PR DESCRIPTION
Needed for closing on-chain trees