### PR TITLE
token-cli: dont push fee_payer to bulk_signers

### DIFF
--- a/token/cli/src/config.rs
+++ b/token/cli/src/config.rs
@@ -161,9 +161,6 @@ impl<'a> Config<'a> {
                 eprintln!("error: {}", e);
                 exit(1);
             });
-        if !bulk_signers.contains(&fee_payer) {
-            bulk_signers.push(fee_payer.clone());
-        }
 
         let verbose = matches.is_present("verbose");
         let output_format = matches


### PR DESCRIPTION
unless im extremely stupid (entirely possible) this is literally all we need to do. authority is always pushed onto the vec in the relevant match arm of `process_command`, totally irrespective of anything to do with `fee_payer`. that means the `fee_payer` push is completely pointless because fees are always paid by `payer` on `Token`

closes #3509