### PR TITLE
token-cli: load config if exists without -C

### DIFF
--- a/token/cli/src/config.rs
+++ b/token/cli/src/config.rs
@@ -57,6 +57,8 @@ impl<'a> Config<'a> {
                 eprintln!("error: Could not find config file `{}`", config_file);
                 exit(1);
             })
+        } else if let Some(config_file) = &*solana_cli_config::CONFIG_FILE {
+            solana_cli_config::Config::load(config_file).unwrap_or_default()
         } else {
             solana_cli_config::Config::default()
         };


### PR DESCRIPTION
looks like this branch of the if statement got dropped on the floor in a rebase because me and the outside contributor were working on the code at the same time. without it, `config.yml` is never loaded

closes #3630