### PR TITLE
improve `spl-token accounts`

### DIFF
--- a/token/cli/src/config.rs
+++ b/token/cli/src/config.rs
@@ -43,7 +43,7 @@ pub(crate) struct Config<'a> {
     pub(crate) dump_transaction_message: bool,
     pub(crate) multisigner_pubkeys: Vec<&'a Pubkey>,
     pub(crate) program_id: Pubkey,
-    pub(crate) explicit_program: bool,
+    pub(crate) restrict_to_program_id: bool,
 }
 
 impl<'a> Config<'a> {
@@ -216,7 +216,7 @@ impl<'a> Config<'a> {
         let dump_transaction_message = matches.is_present(DUMP_TRANSACTION_MESSAGE.name);
 
         let default_program_id = spl_token::id();
-        let (program_id, explicit_program) =
+        let (program_id, restrict_to_program_id) =
             if let Some(program_id) = value_of(matches, "program_id") {
                 (program_id, true)
             } else if !sign_only {
@@ -252,7 +252,7 @@ impl<'a> Config<'a> {
             dump_transaction_message,
             multisigner_pubkeys,
             program_id,
-            explicit_program,
+            restrict_to_program_id,
         }
     }
 

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -64,7 +64,7 @@ mod output;
 use output::*;
 
 mod sort;
-use sort::sort_and_parse_token_accounts;
+use sort::{sort_and_parse_token_accounts, AccountFilter};
 
 mod bench;
 use bench::*;
@@ -1540,6 +1540,8 @@ async fn command_accounts(
     config: &Config<'_>,
     maybe_token: Option<Pubkey>,
     owner: Pubkey,
+    account_filter: AccountFilter,
+    print_addresses: bool,
 ) -> CommandResult {
     let filters = if let Some(token_pubkey) = maybe_token {
         let _ = config.get_mint_info(&token_pubkey, None).await?;
@@ -1565,9 +1567,19 @@ async fn command_accounts(
     let accounts = accounts.into_iter().flatten().collect();
 
     let cli_token_accounts =
-        sort_and_parse_token_accounts(&owner, accounts, maybe_token.is_some())?;
+        sort_and_parse_token_accounts(&owner, accounts, maybe_token.is_some(), account_filter)?;
 
-    Ok(config.output_format.formatted_string(&cli_token_accounts))
+    if print_addresses {
+        Ok(cli_token_accounts
+            .accounts
+            .into_iter()
+            .flatten()
+            .map(|a| a.address)
+            .collect::<Vec<_>>()
+            .join("\n"))
+    } else {
+        Ok(config.output_format.formatted_string(&cli_token_accounts))
+    }
 }
 
 async fn command_address(
@@ -2781,6 +2793,34 @@ fn app<'a, 'b>(
                         .index(1)
                         .help("Limit results to the given token. [Default: list accounts for all tokens]"),
                 )
+                .arg(
+                    Arg::with_name("delegated")
+                        .long("delegated")
+                        .takes_value(false)
+                        .conflicts_with("closeable")
+                        .help(
+                            "Limit results to accounts with transfer delegations"
+                        ),
+                )
+                .arg(
+                    Arg::with_name("closeable")
+                        .long("closeable")
+                        .takes_value(false)
+                        .conflicts_with("delegated")
+                        .help(
+                            "Limit results to accounts with external close authorities"
+                        ),
+                )
+                .arg(
+                    Arg::with_name("addresses")
+                        .long("addresses")
+                        .takes_value(false)
+                        .conflicts_with("verbose")
+                        .conflicts_with("output_format")
+                        .help(
+                            "Print token account addresses only"
+                        ),
+                )
                 .arg(owner_address_arg())
         )
         .subcommand(
@@ -3418,7 +3458,22 @@ async fn process_command<'a>(
         (CommandName::Accounts, arg_matches) => {
             let token = pubkey_of_signer(arg_matches, "token", &mut wallet_manager).unwrap();
             let owner = config.pubkey_or_default(arg_matches, "owner", &mut wallet_manager);
-            command_accounts(config, token, owner).await
+            let filter = if arg_matches.is_present("delegated") {
+                AccountFilter::Delegated
+            } else if arg_matches.is_present("closeable") {
+                AccountFilter::Closeable
+            } else {
+                AccountFilter::All
+            };
+
+            command_accounts(
+                config,
+                token,
+                owner,
+                filter,
+                arg_matches.is_present("addresses"),
+            )
+            .await
         }
         (CommandName::Address, arg_matches) => {
             let token = pubkey_of_signer(arg_matches, "token", &mut wallet_manager).unwrap();

--- a/token/cli/src/output.rs
+++ b/token/cli/src/output.rs
@@ -328,24 +328,20 @@ impl QuietDisplay for CliTokenAccounts {}
 impl VerboseDisplay for CliTokenAccounts {
     fn write_str(&self, w: &mut dyn fmt::Write) -> fmt::Result {
         let mut gc_alert = false;
-        if self.explicit_token {
-            writeln!(
-                w,
+        let header = if self.explicit_token {
+            format!(
                 "{:<44}  {:<44}  {:<3$}",
                 "Program", "Account", "Balance", self.max_len_balance
-            )?;
-            writeln!(
-                w,
-                "-------------------------------------------------------------"
-            )?;
+            )
         } else {
-            writeln!(
-                w,
+            format!(
                 "{:<44}  {:<44}  {:<44}  {:<4$}",
                 "Program", "Token", "Account", "Balance", self.max_len_balance
-            )?;
-            writeln!(w, "----------------------------------------------------------------------------------------------------------")?;
-        }
+            )
+        };
+        writeln!(w, "{}", header)?;
+        writeln!(w, "{}", "-".repeat(header.len() + 8))?;
+
         for accounts_list in self.accounts.iter() {
             let mut aux_counter = 1;
             for account in accounts_list {
@@ -408,20 +404,14 @@ impl VerboseDisplay for CliTokenAccounts {
 impl fmt::Display for CliTokenAccounts {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut gc_alert = false;
-        if self.explicit_token {
-            writeln!(f, "{:<1$}", "Balance", self.max_len_balance)?;
-            writeln!(f, "-------------")?;
+        let header = if self.explicit_token {
+            format!("{:<1$}", "Balance", self.max_len_balance)
         } else {
-            writeln!(
-                f,
-                "{:<44}  {:<44}  {:<3$}",
-                "Program", "Token", "Balance", self.max_len_balance
-            )?;
-            writeln!(
-                f,
-                "---------------------------------------------------------------"
-            )?;
-        }
+            format!("{:<44}  {:<2$}", "Token", "Balance", self.max_len_balance)
+        };
+        writeln!(f, "{}", header)?;
+        writeln!(f, "{}", "-".repeat(header.len() + 8))?;
+
         for accounts_list in self.accounts.iter() {
             let mut aux_counter = 1;
             for account in accounts_list {
@@ -441,8 +431,7 @@ impl fmt::Display for CliTokenAccounts {
                 if self.explicit_token {
                     writeln!(
                         f,
-                        "{:<44}  {:<4$}{:<5$}{}",
-                        account.program_id,
+                        "{:<3$}{:<4$}{}",
                         account.account.token_amount.real_number_string_trimmed(),
                         maybe_aux,
                         maybe_frozen,
@@ -452,8 +441,7 @@ impl fmt::Display for CliTokenAccounts {
                 } else {
                     writeln!(
                         f,
-                        "{:<44}  {:<44}  {:<5$}{:<6$}{}",
-                        account.program_id,
+                        "{:<44}  {:<4$}{:<5$}{}",
                         account.account.mint,
                         account.account.token_amount.real_number_string_trimmed(),
                         maybe_aux,

--- a/token/cli/src/sort.rs
+++ b/token/cli/src/sort.rs
@@ -1,14 +1,15 @@
-use crate::output::CliTokenAccount;
+use crate::output::{CliTokenAccount, CliTokenAccounts};
 use serde::{Deserialize, Serialize};
 use solana_account_decoder::{parse_token::TokenAccountType, UiAccountData};
 use solana_client::rpc_response::RpcKeyedAccount;
 use solana_sdk::pubkey::Pubkey;
+use spl_associated_token_account::get_associated_token_address_with_program_id;
 use std::{
     collections::{btree_map::Entry, BTreeMap},
     str::FromStr,
 };
 
-pub(crate) type MintAccounts = BTreeMap<String, Vec<CliTokenAccount>>;
+type Error = Box<dyn std::error::Error + Send + Sync>;
 
 #[derive(Serialize, Deserialize)]
 pub(crate) struct UnsupportedAccount {
@@ -16,84 +17,84 @@ pub(crate) struct UnsupportedAccount {
     pub err: String,
 }
 
-pub(crate) fn is_supported_program(program_name: &str) -> bool {
-    program_name == "spl-token" || program_name == "spl-token-2022"
-}
-
 pub(crate) fn sort_and_parse_token_accounts(
     owner: &Pubkey,
     accounts: Vec<RpcKeyedAccount>,
-    program_id: &Pubkey,
-) -> (MintAccounts, Vec<UnsupportedAccount>, usize, bool) {
-    let mut mint_accounts: MintAccounts = BTreeMap::new();
+    explicit_token: bool,
+) -> Result<CliTokenAccounts, Error> {
+    let mut cli_accounts: BTreeMap<(Pubkey, Pubkey), Vec<CliTokenAccount>> = BTreeMap::new();
     let mut unsupported_accounts = vec![];
     let mut max_len_balance = 0;
     let mut includes_aux = false;
+
     for keyed_account in accounts {
-        let address = keyed_account.pubkey;
+        let address_str = keyed_account.pubkey;
+        let address = Pubkey::from_str(&address_str)?;
+        let program_id = Pubkey::from_str(&keyed_account.account.owner)?;
 
         if let UiAccountData::Json(parsed_account) = keyed_account.account.data {
-            if !is_supported_program(&parsed_account.program) {
-                unsupported_accounts.push(UnsupportedAccount {
-                    address,
-                    err: format!("Unsupported account program: {}", parsed_account.program),
-                });
-            } else {
-                match serde_json::from_value(parsed_account.parsed) {
-                    Ok(TokenAccountType::Account(ui_token_account)) => {
-                        let mint = ui_token_account.mint.clone();
-                        let is_associated = if let Ok(mint) = Pubkey::from_str(&mint) {
-                            spl_associated_token_account::get_associated_token_address_with_program_id(owner, &mint, program_id).to_string() == address
-                        } else {
-                            includes_aux = true;
-                            false
-                        };
-                        let len_balance = ui_token_account
+            match serde_json::from_value(parsed_account.parsed) {
+                Ok(TokenAccountType::Account(ui_token_account)) => {
+                    let mint = Pubkey::from_str(&ui_token_account.mint)?;
+                    let btree_key = (program_id, mint);
+                    let is_associated =
+                        get_associated_token_address_with_program_id(owner, &mint, &program_id)
+                            == address;
+
+                    if is_associated {
+                        includes_aux = true;
+                    }
+
+                    max_len_balance = max_len_balance.max(
+                        ui_token_account
                             .token_amount
                             .real_number_string_trimmed()
-                            .len();
-                        max_len_balance = max_len_balance.max(len_balance);
-                        let parsed_account = CliTokenAccount {
-                            address,
-                            program_id: program_id.to_string(),
-                            decimals: None,
-                            account: ui_token_account,
-                            is_associated,
-                        };
-                        let entry = mint_accounts.entry(mint);
-                        match entry {
-                            Entry::Occupied(_) => {
-                                entry.and_modify(|e| e.push(parsed_account));
-                            }
-                            Entry::Vacant(_) => {
-                                entry.or_insert_with(|| vec![parsed_account]);
-                            }
+                            .len(),
+                    );
+
+                    let cli_account = CliTokenAccount {
+                        address: address_str,
+                        program_id: program_id.to_string(),
+                        account: ui_token_account,
+                        is_associated,
+                    };
+
+                    let entry = cli_accounts.entry(btree_key);
+                    match entry {
+                        Entry::Occupied(_) => {
+                            entry.and_modify(|e| {
+                                if is_associated {
+                                    e.insert(0, cli_account)
+                                } else {
+                                    e.push(cli_account)
+                                }
+                            });
+                        }
+                        Entry::Vacant(_) => {
+                            entry.or_insert_with(|| vec![cli_account]);
                         }
                     }
-                    Ok(_) => unsupported_accounts.push(UnsupportedAccount {
-                        address,
-                        err: "Not a token account".to_string(),
-                    }),
-                    Err(err) => unsupported_accounts.push(UnsupportedAccount {
-                        address,
-                        err: format!("Account parse failure: {}", err),
-                    }),
                 }
+                Ok(_) => unsupported_accounts.push(UnsupportedAccount {
+                    address: address_str,
+                    err: "Not a token account".to_string(),
+                }),
+                Err(err) => unsupported_accounts.push(UnsupportedAccount {
+                    address: address_str,
+                    err: format!("Account parse failure: {}", err),
+                }),
             }
-        } else {
-            unsupported_accounts.push(UnsupportedAccount {
-                address,
-                err: "Unsupported account data format".to_string(),
-            });
         }
     }
-    for (_, array) in mint_accounts.iter_mut() {
-        array.sort_by(|a, b| b.is_associated.cmp(&a.is_associated));
-    }
-    (
-        mint_accounts,
+
+    Ok(CliTokenAccounts {
+        accounts: cli_accounts
+            .into_iter()
+            .map(|(_key, accounts_list)| accounts_list)
+            .collect(),
         unsupported_accounts,
         max_len_balance,
-        includes_aux,
-    )
+        aux_len: if includes_aux { 10 } else { 0 },
+        explicit_token,
+    })
 }


### PR DESCRIPTION
* ~fetch for all programs by default~
* ~display program an account belongs to~
* ~display delegate/close authority~
* ~filter by delegate/close authority~
* ~output nothing but token account addresses~

first two are for better token22 ergonomics, latter three are for conveniently viewing and revoking unwanted permissions

closes #3602