### PR TITLE
remove decimals parameter from token client methods

### DIFF
--- a/token-upgrade/cli/src/main.rs
+++ b/token-upgrade/cli/src/main.rs
@@ -96,6 +96,7 @@ async fn process_create_escrow_account(
         program_client.clone(),
         &new_program_id,
         new_mint,
+        None,
         payer.clone(),
     );
 
@@ -536,9 +537,15 @@ mod test {
         client: Arc<dyn ProgramClient<T>>,
     ) -> Token<T> {
         let mint_account = Keypair::new();
-        let token = Token::new(client, program_id, &mint_account.pubkey(), payer);
+        let token = Token::new(
+            client,
+            program_id,
+            &mint_account.pubkey(),
+            Some(decimals),
+            payer,
+        );
         token
-            .create_mint(mint_authority, None, decimals, vec![], &[&mint_account])
+            .create_mint(mint_authority, None, vec![], &[&mint_account])
             .await
             .unwrap();
         token
@@ -670,7 +677,6 @@ mod test {
                 &burn_from,
                 &mint_authority.pubkey(),
                 amount,
-                Some(decimals),
                 &[&mint_authority],
             )
             .await
@@ -688,7 +694,6 @@ mod test {
                 &escrow,
                 &mint_authority.pubkey(),
                 amount,
-                Some(decimals),
                 &[&mint_authority],
             )
             .await
@@ -782,7 +787,6 @@ mod test {
                 &burn_from,
                 &mint_authority.pubkey(),
                 amount,
-                Some(decimals),
                 &[&mint_authority],
             )
             .await
@@ -794,7 +798,6 @@ mod test {
                 &escrow,
                 &mint_authority.pubkey(),
                 amount,
-                Some(decimals),
                 &[&mint_authority],
             )
             .await

--- a/token-upgrade/program/tests/functional.rs
+++ b/token-upgrade/program/tests/functional.rs
@@ -76,9 +76,15 @@ async fn setup_mint<T: SendTransaction>(
     client: Arc<dyn ProgramClient<T>>,
 ) -> Token<T> {
     let mint_account = Keypair::new();
-    let token = Token::new(client, program_id, &mint_account.pubkey(), payer);
+    let token = Token::new(
+        client,
+        program_id,
+        &mint_account.pubkey(),
+        Some(decimals),
+        payer,
+    );
     token
-        .create_mint(mint_authority, None, decimals, vec![], &[&mint_account])
+        .create_mint(mint_authority, None, vec![], &[&mint_account])
         .await
         .unwrap();
     token
@@ -131,7 +137,6 @@ async fn success(original_program_id: Pubkey, new_program_id: Pubkey) {
             &original_account,
             &mint_authority_pubkey,
             token_amount,
-            Some(decimals),
             &[&mint_authority],
         )
         .await
@@ -152,7 +157,6 @@ async fn success(original_program_id: Pubkey, new_program_id: Pubkey) {
             &escrow_account,
             &mint_authority_pubkey,
             token_amount,
-            Some(decimals),
             &[&mint_authority],
         )
         .await
@@ -242,7 +246,6 @@ async fn fail_incorrect_escrow_derivation(original_program_id: Pubkey, new_progr
             &original_account,
             &mint_authority_pubkey,
             token_amount,
-            Some(decimals),
             &[&mint_authority],
         )
         .await
@@ -263,7 +266,6 @@ async fn fail_incorrect_escrow_derivation(original_program_id: Pubkey, new_progr
             &escrow_account,
             &mint_authority_pubkey,
             token_amount,
-            Some(decimals),
             &[&mint_authority],
         )
         .await
@@ -351,7 +353,6 @@ async fn fail_decimals_mismatch(original_program_id: Pubkey, new_program_id: Pub
             &original_account,
             &mint_authority_pubkey,
             token_amount,
-            Some(original_decimals),
             &[&mint_authority],
         )
         .await
@@ -372,7 +373,6 @@ async fn fail_decimals_mismatch(original_program_id: Pubkey, new_program_id: Pub
             &escrow_account,
             &mint_authority_pubkey,
             token_amount,
-            Some(new_decimals),
             &[&mint_authority],
         )
         .await

--- a/token/client/tests/program-test.rs
+++ b/token/client/tests/program-test.rs
@@ -48,17 +48,12 @@ impl TestContext {
             Arc::clone(&client),
             &spl_token_2022::id(),
             &mint_account.pubkey(),
+            Some(decimals),
             Arc::new(keypair_clone(&payer)),
         );
 
         token
-            .create_mint(
-                &mint_authority_pubkey,
-                None,
-                decimals,
-                vec![],
-                &[&mint_account],
-            )
+            .create_mint(&mint_authority_pubkey, None, vec![], &[&mint_account])
             .await
             .expect("failed to create mint");
 
@@ -146,7 +141,6 @@ async fn get_or_create_associated_token_account() {
 #[tokio::test]
 async fn set_authority() {
     let TestContext {
-        decimals,
         mint_authority,
         token,
         alice,
@@ -165,7 +159,6 @@ async fn set_authority() {
             &alice_vault,
             &mint_authority.pubkey(),
             1,
-            Some(decimals),
             &vec![&mint_authority],
         )
         .await
@@ -195,7 +188,6 @@ async fn set_authority() {
             &alice_vault,
             &mint_authority.pubkey(),
             2,
-            Some(decimals),
             &vec![&mint_authority]
         )
         .await
@@ -248,7 +240,6 @@ async fn mint_to() {
             &alice_vault,
             &mint_authority.pubkey(),
             mint_amount,
-            Some(decimals),
             &vec![&mint_authority],
         )
         .await
@@ -296,7 +287,6 @@ async fn transfer() {
             &alice_vault,
             &mint_authority.pubkey(),
             mint_amount,
-            Some(decimals),
             &vec![&mint_authority],
         )
         .await
@@ -309,7 +299,6 @@ async fn transfer() {
             &bob_vault,
             &alice.pubkey(),
             transfer_amount,
-            Some(decimals),
             &vec![&alice],
         )
         .await

--- a/token/program-2022-test/tests/burn.rs
+++ b/token/program-2022-test/tests/burn.rs
@@ -14,9 +14,9 @@ use {
 
 async fn run_basic(context: TestContext) {
     let TokenContext {
-        decimals,
         mint_authority,
         token,
+        token_unchecked,
         alice,
         bob,
         ..
@@ -36,39 +36,26 @@ async fn run_basic(context: TestContext) {
             &alice_account,
             &mint_authority.pubkey(),
             amount,
-            Some(decimals),
             &vec![&mint_authority],
         )
         .await
         .unwrap();
 
     // unchecked is ok
-    token
-        .burn(&alice_account, &alice.pubkey(), 1, None, &vec![&alice])
+    token_unchecked
+        .burn(&alice_account, &alice.pubkey(), 1, &vec![&alice])
         .await
         .unwrap();
 
     // checked is ok
     token
-        .burn(
-            &alice_account,
-            &alice.pubkey(),
-            1,
-            Some(decimals),
-            &vec![&alice],
-        )
+        .burn(&alice_account, &alice.pubkey(), 1, &vec![&alice])
         .await
         .unwrap();
 
     // burn too much is not ok
     let error = token
-        .burn(
-            &alice_account,
-            &alice.pubkey(),
-            amount,
-            Some(decimals),
-            &vec![&alice],
-        )
+        .burn(&alice_account, &alice.pubkey(), amount, &vec![&alice])
         .await
         .unwrap_err();
     assert_eq!(
@@ -83,13 +70,7 @@ async fn run_basic(context: TestContext) {
 
     // wrong signer
     let error = token
-        .burn(
-            &alice_account,
-            &bob.pubkey(),
-            1,
-            Some(decimals),
-            &vec![&bob],
-        )
+        .burn(&alice_account, &bob.pubkey(), 1, &vec![&bob])
         .await
         .unwrap_err();
     assert_eq!(
@@ -127,9 +108,9 @@ async fn basic_with_extension() {
 
 async fn run_self_owned(context: TestContext) {
     let TokenContext {
-        decimals,
         mint_authority,
         token,
+        token_unchecked,
         alice,
         ..
     } = context.token_context.unwrap();
@@ -147,27 +128,20 @@ async fn run_self_owned(context: TestContext) {
             &alice_account,
             &mint_authority.pubkey(),
             amount,
-            Some(decimals),
             &vec![&mint_authority],
         )
         .await
         .unwrap();
 
     // unchecked is ok
-    token
-        .burn(&alice_account, &alice.pubkey(), 1, None, &vec![&alice])
+    token_unchecked
+        .burn(&alice_account, &alice.pubkey(), 1, &vec![&alice])
         .await
         .unwrap();
 
     // checked is ok
     token
-        .burn(
-            &alice_account,
-            &alice.pubkey(),
-            1,
-            Some(decimals),
-            &vec![&alice],
-        )
+        .burn(&alice_account, &alice.pubkey(), 1, &vec![&alice])
         .await
         .unwrap();
 }
@@ -196,7 +170,6 @@ async fn self_owned_with_extension() {
 
 async fn run_burn_and_close_system_or_incinerator(context: TestContext, non_owner: &Pubkey) {
     let TokenContext {
-        decimals,
         mint_authority,
         token,
         alice,
@@ -216,7 +189,6 @@ async fn run_burn_and_close_system_or_incinerator(context: TestContext, non_owne
             &alice_account,
             &mint_authority.pubkey(),
             1,
-            Some(decimals),
             &vec![&mint_authority],
         )
         .await
@@ -235,7 +207,6 @@ async fn run_burn_and_close_system_or_incinerator(context: TestContext, non_owne
             &non_owner_account,
             &alice.pubkey(),
             1,
-            Some(decimals),
             &vec![&alice],
         )
         .await
@@ -264,13 +235,7 @@ async fn run_burn_and_close_system_or_incinerator(context: TestContext, non_owne
 
     // but anyone can burn it
     token
-        .burn(
-            &non_owner_account,
-            &carlos.pubkey(),
-            1,
-            Some(decimals),
-            &vec![&carlos],
-        )
+        .burn(&non_owner_account, &carlos.pubkey(), 1, &vec![&carlos])
         .await
         .unwrap();
 

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -182,7 +182,6 @@ impl ConfidentialTokenAccountMeta {
                 &meta.token_account,
                 &mint_authority.pubkey(),
                 amount,
-                Some(decimals),
                 &vec![mint_authority],
             )
             .await
@@ -495,7 +494,6 @@ async fn ct_deposit() {
             &alice_meta.token_account,
             &mint_authority.pubkey(),
             65537,
-            Some(decimals),
             &vec![&mint_authority],
         )
         .await

--- a/token/program-2022-test/tests/memo_transfer.rs
+++ b/token/program-2022-test/tests/memo_transfer.rs
@@ -30,7 +30,6 @@ async fn test_memo_transfers(
     bob_account: Pubkey,
 ) {
     let TokenContext {
-        decimals,
         mint_authority,
         token,
         alice,
@@ -44,7 +43,6 @@ async fn test_memo_transfers(
             &alice_account,
             &mint_authority.pubkey(),
             4242,
-            Some(decimals),
             &vec![&mint_authority],
         )
         .await
@@ -67,7 +65,6 @@ async fn test_memo_transfers(
             &bob_account,
             &alice.pubkey(),
             10,
-            None,
             &vec![&alice],
         )
         .await
@@ -137,7 +134,6 @@ async fn test_memo_transfers(
             &bob_account,
             &alice.pubkey(),
             10,
-            None,
             &vec![&alice],
         )
         .await
@@ -185,7 +181,6 @@ async fn test_memo_transfers(
             &bob_account,
             &alice.pubkey(),
             12,
-            None,
             &vec![&alice],
         )
         .await

--- a/token/program-2022-test/tests/mint_close_authority.rs
+++ b/token/program-2022-test/tests/mint_close_authority.rs
@@ -244,7 +244,6 @@ async fn fail_close_with_supply() {
         .await
         .unwrap();
     let TokenContext {
-        decimals,
         mint_authority,
         token,
         ..
@@ -263,7 +262,6 @@ async fn fail_close_with_supply() {
             &account,
             &mint_authority.pubkey(),
             1,
-            Some(decimals),
             &vec![&mint_authority],
         )
         .await

--- a/token/program-2022-test/tests/non_transferable.rs
+++ b/token/program-2022-test/tests/non_transferable.rs
@@ -25,7 +25,6 @@ async fn transfer_checked() {
         .unwrap();
 
     let TokenContext {
-        decimals,
         mint_authority,
         token,
         alice,
@@ -56,7 +55,6 @@ async fn transfer_checked() {
             &alice_account,
             &mint_authority.pubkey(),
             test_transfer_amount,
-            Some(decimals),
             &vec![&mint_authority],
         )
         .await
@@ -78,7 +76,6 @@ async fn transfer_checked() {
             &bob_account,
             &mint_authority.pubkey(),
             test_transfer_amount,
-            Some(decimals),
             &vec![&mint_authority],
         )
         .await
@@ -91,7 +88,6 @@ async fn transfer_checked() {
             &bob_account,
             &bob.pubkey(),
             test_transfer_amount,
-            Some(decimals),
             &vec![&bob],
         )
         .await
@@ -114,7 +110,6 @@ async fn transfer_checked() {
             &alice_account,
             &bob.pubkey(),
             test_transfer_amount,
-            Some(decimals),
             &vec![&bob],
         )
         .await
@@ -161,7 +156,6 @@ async fn transfer_checked_with_fee() {
         .unwrap();
 
     let TokenContext {
-        decimals,
         mint_authority,
         token,
         alice,
@@ -195,7 +189,6 @@ async fn transfer_checked_with_fee() {
             &alice_account,
             &mint_authority.pubkey(),
             test_transfer_amount,
-            Some(decimals),
             &vec![&mint_authority],
         )
         .await
@@ -208,7 +201,6 @@ async fn transfer_checked_with_fee() {
             &alice_account,
             &alice.pubkey(),
             test_transfer_amount,
-            Some(decimals),
             &vec![&alice],
         )
         .await
@@ -231,7 +223,6 @@ async fn transfer_checked_with_fee() {
             &bob_account,
             &alice.pubkey(),
             test_transfer_amount,
-            Some(decimals),
             &vec![&alice],
         )
         .await
@@ -255,7 +246,6 @@ async fn transfer_checked_with_fee() {
             &alice_account,
             &alice.pubkey(),
             test_transfer_amount,
-            decimals,
             fee,
             &vec![&alice],
         )
@@ -280,7 +270,6 @@ async fn transfer_checked_with_fee() {
             &bob_account,
             &alice.pubkey(),
             test_transfer_amount,
-            decimals,
             fee,
             &vec![&alice],
         )

--- a/token/program-2022-test/tests/program_test.rs
+++ b/token/program-2022-test/tests/program_test.rs
@@ -15,6 +15,7 @@ pub struct TokenContext {
     pub decimals: u8,
     pub mint_authority: Keypair,
     pub token: Token<ProgramBanksClientProcessTransaction>,
+    pub token_unchecked: Token<ProgramBanksClientProcessTransaction>,
     pub alice: Keypair,
     pub bob: Keypair,
     pub freeze_authority: Option<Keypair>,
@@ -79,6 +80,15 @@ impl TestContext {
             Arc::clone(&client),
             &id(),
             &mint_account.pubkey(),
+            Some(decimals),
+            Arc::new(keypair_clone(&payer)),
+        );
+
+        let token_unchecked = Token::new(
+            Arc::clone(&client),
+            &id(),
+            &mint_account.pubkey(),
+            None,
             Arc::new(payer),
         );
 
@@ -86,7 +96,6 @@ impl TestContext {
             .create_mint(
                 &mint_authority_pubkey,
                 freeze_authority_pubkey.as_ref(),
-                decimals,
                 extension_init_params,
                 &[&mint_account],
             )
@@ -96,6 +105,7 @@ impl TestContext {
             decimals,
             mint_authority,
             token,
+            token_unchecked,
             alice: Keypair::new(),
             bob: Keypair::new(),
             freeze_authority,
@@ -112,11 +122,16 @@ impl TestContext {
                 ProgramBanksClientProcessTransaction,
             ));
 
-        let token = Token::create_native_mint(Arc::clone(&client), &id(), Arc::new(payer)).await?;
+        let token =
+            Token::create_native_mint(Arc::clone(&client), &id(), Arc::new(keypair_clone(&payer)))
+                .await?;
+        // unchecked native is never needed because decimals is known statically
+        let token_unchecked = Token::new_native(Arc::clone(&client), &id(), Arc::new(payer));
         self.token_context = Some(TokenContext {
             decimals: native_mint::DECIMALS,
             mint_authority: Keypair::new(), /*bogus*/
             token,
+            token_unchecked,
             alice: Keypair::new(),
             bob: Keypair::new(),
             freeze_authority: None,

--- a/token/program-2022-test/tests/transfer.rs
+++ b/token/program-2022-test/tests/transfer.rs
@@ -20,9 +20,9 @@ enum TestMode {
 
 async fn run_basic_transfers(context: TestContext, test_mode: TestMode) {
     let TokenContext {
-        decimals,
         mint_authority,
         token,
+        token_unchecked,
         alice,
         bob,
         ..
@@ -48,7 +48,6 @@ async fn run_basic_transfers(context: TestContext, test_mode: TestMode) {
             &alice_account,
             &mint_authority.pubkey(),
             amount,
-            Some(decimals),
             &vec![&mint_authority],
         )
         .await
@@ -56,13 +55,12 @@ async fn run_basic_transfers(context: TestContext, test_mode: TestMode) {
 
     if test_mode == TestMode::All {
         // unchecked is ok
-        token
+        token_unchecked
             .transfer(
                 &alice_account,
                 &bob_account,
                 &alice.pubkey(),
                 1,
-                None,
                 &vec![&alice],
             )
             .await
@@ -76,7 +74,6 @@ async fn run_basic_transfers(context: TestContext, test_mode: TestMode) {
             &bob_account,
             &alice.pubkey(),
             1,
-            Some(decimals),
             &vec![&alice],
         )
         .await
@@ -89,7 +86,6 @@ async fn run_basic_transfers(context: TestContext, test_mode: TestMode) {
             &bob_account,
             &alice.pubkey(),
             amount,
-            Some(decimals),
             &vec![&alice],
         )
         .await
@@ -106,14 +102,7 @@ async fn run_basic_transfers(context: TestContext, test_mode: TestMode) {
 
     // wrong signer
     let error = token
-        .transfer(
-            &alice_account,
-            &bob_account,
-            &bob.pubkey(),
-            1,
-            Some(decimals),
-            &vec![&bob],
-        )
+        .transfer(&alice_account, &bob_account, &bob.pubkey(), 1, &vec![&bob])
         .await
         .unwrap_err();
     assert_eq!(
@@ -151,9 +140,9 @@ async fn basic_with_extension() {
 
 async fn run_self_transfers(context: TestContext, test_mode: TestMode) {
     let TokenContext {
-        decimals,
         mint_authority,
         token,
+        token_unchecked,
         alice,
         ..
     } = context.token_context.unwrap();
@@ -172,7 +161,6 @@ async fn run_self_transfers(context: TestContext, test_mode: TestMode) {
             &alice_account,
             &mint_authority.pubkey(),
             amount,
-            Some(decimals),
             &vec![&mint_authority],
         )
         .await
@@ -185,19 +173,17 @@ async fn run_self_transfers(context: TestContext, test_mode: TestMode) {
             &alice_account,
             &alice.pubkey(),
             1,
-            Some(decimals),
             &vec![&alice],
         )
         .await
         .unwrap();
     if test_mode == TestMode::All {
-        token
+        token_unchecked
             .transfer(
                 &alice_account,
                 &alice_account,
                 &alice.pubkey(),
                 1,
-                None,
                 &vec![&alice],
             )
             .await
@@ -211,7 +197,6 @@ async fn run_self_transfers(context: TestContext, test_mode: TestMode) {
             &alice_account,
             &alice.pubkey(),
             amount.checked_add(1).unwrap(),
-            Some(decimals),
             &vec![&alice],
         )
         .await
@@ -251,9 +236,9 @@ async fn self_transfer_with_extension() {
 
 async fn run_self_owned(context: TestContext, test_mode: TestMode) {
     let TokenContext {
-        decimals,
         mint_authority,
         token,
+        token_unchecked,
         alice,
         bob,
         ..
@@ -278,7 +263,6 @@ async fn run_self_owned(context: TestContext, test_mode: TestMode) {
             &alice_account,
             &mint_authority.pubkey(),
             amount,
-            Some(decimals),
             &vec![&mint_authority],
         )
         .await
@@ -286,13 +270,12 @@ async fn run_self_owned(context: TestContext, test_mode: TestMode) {
 
     if test_mode == TestMode::All {
         // unchecked is ok
-        token
+        token_unchecked
             .transfer(
                 &alice_account,
                 &bob_account,
                 &alice.pubkey(),
                 1,
-                None,
                 &vec![&alice],
             )
             .await
@@ -306,7 +289,6 @@ async fn run_self_owned(context: TestContext, test_mode: TestMode) {
             &bob_account,
             &alice.pubkey(),
             1,
-            Some(decimals),
             &vec![&alice],
         )
         .await
@@ -319,7 +301,6 @@ async fn run_self_owned(context: TestContext, test_mode: TestMode) {
             &alice_account,
             &alice.pubkey(),
             1,
-            Some(decimals),
             &vec![&alice],
         )
         .await
@@ -353,7 +334,6 @@ async fn transfer_with_fee_on_mint_without_fee_configured() {
     let mut context = TestContext::new().await;
     context.init_token_with_mint(vec![]).await.unwrap();
     let TokenContext {
-        decimals,
         mint_authority,
         token,
         alice,
@@ -381,7 +361,6 @@ async fn transfer_with_fee_on_mint_without_fee_configured() {
             &alice_account,
             &mint_authority.pubkey(),
             amount,
-            Some(decimals),
             &vec![&mint_authority],
         )
         .await
@@ -394,7 +373,6 @@ async fn transfer_with_fee_on_mint_without_fee_configured() {
             &bob_account,
             &alice.pubkey(),
             1,
-            decimals,
             0,
             &vec![&alice],
         )
@@ -408,7 +386,6 @@ async fn transfer_with_fee_on_mint_without_fee_configured() {
             &bob_account,
             &alice.pubkey(),
             2,
-            decimals,
             1,
             &vec![&alice],
         )


### PR DESCRIPTION
this properly belongs on the object. as always, this interface change excludes the confidential functions, which can be stabilized when confidential transfers go in the cli

~rebase on master when #3482 lands~

closes #3648 