### PR TITLE
Account Compression: 0.1.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5752,7 +5752,7 @@ dependencies = [
 
 [[package]]
 name = "spl-concurrent-merkle-tree"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bytemuck",
  "rand 0.7.3",

--- a/account-compression/Cargo.lock
+++ b/account-compression/Cargo.lock
@@ -1200,7 +1200,7 @@ dependencies = [
 
 [[package]]
 name = "spl-account-compression"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anchor-lang",
  "bytemuck",
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "spl-concurrent-merkle-tree"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bytemuck",
  "solana-program",
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "spl-noop"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "solana-program",
 ]

--- a/account-compression/programs/account-compression/Cargo.toml
+++ b/account-compression/programs/account-compression/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-account-compression"
-version = "0.1.0"
+version = "0.1.1"
 description = "Solana Program Library Account Compression Program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -20,8 +20,8 @@ default = []
 [dependencies]
 anchor-lang = "0.25.0"
 bytemuck = "1.8.0"
-spl-concurrent-merkle-tree = { version = "0.1.0", path="../../../libraries/concurrent-merkle-tree", features = [ "sol-log" ]}
-spl-noop = { version = "0.1.0", path="../noop", features = [ "no-entrypoint" ]}
+spl-concurrent-merkle-tree = { version = "0.1.1", path="../../../libraries/concurrent-merkle-tree", features = [ "sol-log" ]}
+spl-noop = { version = "0.1.1", path="../noop", features = [ "no-entrypoint" ]}
 
 [profile.release]
 overflow-checks = true

--- a/account-compression/programs/noop/Cargo.toml
+++ b/account-compression/programs/noop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-noop"
-version = "0.1.0"
+version = "0.1.1"
 description = "Solana Program Library No-op Program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/account-compression/sdk/idl/spl_account_compression.json
+++ b/account-compression/sdk/idl/spl_account_compression.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "0.1.1",
   "name": "spl_account_compression",
   "instructions": [
     {

--- a/libraries/concurrent-merkle-tree/Cargo.toml
+++ b/libraries/concurrent-merkle-tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-concurrent-merkle-tree"
-version = "0.1.0"
+version = "0.1.1"
 description = "Solana Program Library Concurrent Merkle Tree"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"


### PR DESCRIPTION
- Update program ids for `spl-noop`, `spl-account-compression`
- Add instruction to remove empty tree for `spl-account-compression`
- Update `concurrent-merkle-tree` library to support checking empty tree condition