### PR TITLE
Account Compression: JS SDK release 0.1.1

### DIFF
--- a/account-compression/sdk/README.md
+++ b/account-compression/sdk/README.md
@@ -1,15 +1,42 @@
-# Account Compression SDK
+# `@solana/spl-account-compression`
 
-Currently contains a typescript SDK to interact with on-chain SPL ConcurrentMerkleTrees.
+A TypeScript library for interacting with SPL Account Compression and SPL NoOp.
 
-Used to test Account Compression program.
+## Install
 
-# Setting up the Solita-based Typescript SDK
+```shell
+npm install --save @solana/spl-account-compression @solana/web3.js
+```
+
+__OR__
+
+```shell
+yarn add @solana/spl-account-compression @solana/web3.js
+```
+
+
+## Examples
+
+* Solana Program Library [tests](https://github.com/solana-labs/solana-program-library/tree/master/account-compression/sdk/tests)
+
+* Metaplex Program Library Compressed NFT [tests](https://github.com/metaplex-foundation/metaplex-program-library/tree/master/bubblegum/js/tests)
+
+## Information
+
+This on-chain program provides an interface for composing smart-contracts to create and use SPL ConcurrentMerkleTrees. The primary application of using SPL ConcurrentMerkleTrees is to make edits to off-chain data with on-chain verification.
+
+This program is targeted towards supporting [Metaplex Compressed NFTs](https://github.com/metaplex-foundation/metaplex-program-library/tree/master/bubblegum) and may be subject to change.
+
+Note: Using this program requires an indexer to parse transaction information and write relevant information to an off-chain database.
+
+A **rough draft** of the whitepaper for SPL ConcurrentMerkleTree's can be found [here](https://drive.google.com/file/d/1BOpa5OFmara50fTvL0VIVYjtg-qzHCVc/view).
+
+## Build from Source
+
+0. Install dependencies with `yarn`.
 
 1. Generate the Solita SDK with `yarn solita`.
 
 2. Then build the SDK with `yarn build`.
 
-# Testing the SDK
-
-Run `yarn test`. Expect `jest` to detect an open handle that prevents it from exiting tests naturally.
+3. Run tests with `yarn test`. (Expect `jest` to detect an open handle that prevents it from exiting naturally)

--- a/account-compression/sdk/package.json
+++ b/account-compression/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@solana/spl-account-compression",
   "description": "SPL Account Compression Program JS API",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "Solana Maintainers <maintainers@solana.foundation>",
   "repository": {
     "url": "https://github.com/solana-labs/solana-program-library",
@@ -46,11 +46,11 @@
     "borsh": "^0.7.0"
   },
   "peerDependencies": {
-    "@metaplex-foundation/beet": "^0.6.1",
-    "@metaplex-foundation/beet-solana": "^0.6.1",
     "@solana/web3.js": "^1.50.1"
   },
   "devDependencies": {
+    "@metaplex-foundation/beet": "^0.6.1",
+    "@metaplex-foundation/beet-solana": "^0.6.1",
     "@metaplex-foundation/rustbin": "^0.3.1",
     "@metaplex-foundation/solita": "0.15.2",
     "@project-serum/anchor": "^0.25.0",

--- a/account-compression/sdk/package.json
+++ b/account-compression/sdk/package.json
@@ -37,7 +37,9 @@
     "start-validator": "solana-test-validator --reset --quiet --bpf-program cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK ../target/deploy/spl_account_compression.so --bpf-program noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV ../target/deploy/spl_noop.so",
     "run-tests": "jest tests --detectOpenHandles",
     "run-tests:events": "jest tests/events --detectOpenHandles",
+    "run-tests:accounts": "jest tests/accounts --detectOpenHandles",
     "test:events": "start-server-and-test start-validator http://localhost:8899/health run-tests:events",
+    "test:accounts": "start-server-and-test start-validator http://localhost:8899/health run-tests:accounts",
     "test": "start-server-and-test start-validator http://localhost:8899/health run-tests"
   },
   "dependencies": {
@@ -49,8 +51,8 @@
     "@solana/web3.js": "^1.50.1"
   },
   "devDependencies": {
-    "@metaplex-foundation/beet": "^0.6.1",
-    "@metaplex-foundation/beet-solana": "^0.6.1",
+    "@metaplex-foundation/beet": "^0.7.1",
+    "@metaplex-foundation/beet-solana": "^0.4.0",
     "@metaplex-foundation/rustbin": "^0.3.1",
     "@metaplex-foundation/solita": "0.15.2",
     "@project-serum/anchor": "^0.25.0",

--- a/account-compression/sdk/src/accounts/ConcurrentMerkleTreeAccount.ts
+++ b/account-compression/sdk/src/accounts/ConcurrentMerkleTreeAccount.ts
@@ -1,4 +1,4 @@
-import type { PublicKey, Connection } from "@solana/web3.js";
+import type { PublicKey, Connection, Commitment, GetAccountInfoConfig } from "@solana/web3.js";
 import * as borsh from "borsh";
 import * as BN from 'bn.js';
 import * as beet from '@metaplex-foundation/beet';
@@ -35,8 +35,8 @@ export class ConcurrentMerkleTreeAccount {
         return deserializeConcurrentMerkleTree(buffer);
     }
 
-    static async fromAccountAddress(connection: Connection, publicKey: PublicKey): Promise<ConcurrentMerkleTreeAccount> {
-        const account = await connection.getAccountInfo(publicKey);
+    static async fromAccountAddress(connection: Connection, publicKey: PublicKey, commitmentOrConfig?: Commitment | GetAccountInfoConfig): Promise<ConcurrentMerkleTreeAccount> {
+        const account = await connection.getAccountInfo(publicKey, commitmentOrConfig);
         if (!account) {
             throw new Error("CMT account data unexpectedly null!");
         }
@@ -79,9 +79,13 @@ export class ConcurrentMerkleTreeAccount {
         return new BN.BN(this.tree.sequenceNumber).toNumber();
     }
 
+    getCanopyDepth(): number {
+        return getCanopyDepth(this.canopy.canopyBytes.length);
+    }
+
 };
 
-function getCanopyDepth(canopyByteLength: number): number {
+export function getCanopyDepth(canopyByteLength: number): number {
     if (canopyByteLength === 0) {
         return 0;
     }

--- a/account-compression/sdk/src/utils/index.ts
+++ b/account-compression/sdk/src/utils/index.ts
@@ -4,3 +4,39 @@ import {
 
 export const SPL_NOOP_ADDRESS = "noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV";
 export const SPL_NOOP_PROGRAM_ID = new PublicKey(SPL_NOOP_ADDRESS);
+
+type DepthSizePair = {
+  maxDepth: number,
+  maxBufferSize: number
+};
+
+const allPairs: number[][] = [
+  [3, 8],
+  [5, 8],
+  [14, 64],
+  [14, 256],
+  [14, 1024],
+  [14, 2048],
+  [20, 64],
+  [20, 256],
+  [20, 1024],
+  [20, 2048],
+  [24, 64],
+  [24, 256],
+  [24, 512],
+  [24, 1024],
+  [24, 2048],
+  [26, 512],
+  [26, 1024],
+  [26, 2048],
+  [30, 512],
+  [30, 1024],
+  [30, 2048],
+];
+
+export const ALL_DEPTH_SIZE_PAIRS: DepthSizePair[] = allPairs.map((pair) => {
+  return {
+    maxDepth: pair[0],
+    maxBufferSize: pair[1]
+  }
+})

--- a/account-compression/sdk/tests/accountCompression.test.ts
+++ b/account-compression/sdk/tests/accountCompression.test.ts
@@ -3,10 +3,7 @@ import { BN } from 'bn.js';
 import { AnchorProvider } from "@project-serum/anchor";
 import {
   Connection,
-  Signer,
   Keypair,
-  PublicKey,
-  Transaction,
   TransactionInstruction,
 } from "@solana/web3.js";
 import { assert } from "chai";

--- a/account-compression/sdk/yarn.lock
+++ b/account-compression/sdk/yarn.lock
@@ -620,10 +620,29 @@
     bs58 "^5.0.0"
     debug "^4.3.4"
 
+"@metaplex-foundation/beet-solana@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@metaplex-foundation/beet-solana/-/beet-solana-0.4.0.tgz#52891e78674aaa54e0031f1bca5bfbc40de12e8d"
+  integrity sha512-B1L94N3ZGMo53b0uOSoznbuM5GBNJ8LwSeznxBxJ+OThvfHQ4B5oMUqb+0zdLRfkKGS7Q6tpHK9P+QK0j3w2cQ==
+  dependencies:
+    "@metaplex-foundation/beet" ">=0.1.0"
+    "@solana/web3.js" "^1.56.2"
+    bs58 "^5.0.0"
+    debug "^4.3.4"
+
 "@metaplex-foundation/beet@>=0.1.0", "@metaplex-foundation/beet@^0.6.1":
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/@metaplex-foundation/beet/-/beet-0.6.1.tgz#6331bdde0648bf2cae6f9e482f8e3552db05d69f"
   integrity sha512-OYgnijLFzw0cdUlRKH5POp0unQECPOW9muJ2X3QIVyak5G6I6l/rKo72sICgPLIFKdmsi2jmnkuLY7wp14iXdw==
+  dependencies:
+    ansicolors "^0.3.2"
+    bn.js "^5.2.0"
+    debug "^4.3.3"
+
+"@metaplex-foundation/beet@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@metaplex-foundation/beet/-/beet-0.7.1.tgz#0975314211643f87b5f6f3e584fa31abcf4c612c"
+  integrity sha512-hNCEnS2WyCiYyko82rwuISsBY3KYpe828ubsd2ckeqZr7tl0WVLivGkoyA/qdiaaHEBGdGl71OpfWa2rqL3DiA==
   dependencies:
     ansicolors "^0.3.2"
     bn.js "^5.2.0"


### PR DESCRIPTION
 - Expose all maxDepth, maxBufferSize pairs
 - Add canopyDepth getter to `ConcurrentMerkleTreeAccount`
 - Fix issue that required `@metaplex-foundation/beet*` to be installed separately
 - Update README.md