### PR TITLE
token-2022/confidential-transfer: check pubkey and ciphertext assocaited with proof data to token accounts

### DIFF
--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -253,7 +253,7 @@ fn process_empty_account(
     }
 
     if confidential_transfer_account.encryption_pubkey != proof_data.pubkey {
-        return Err(TokenError::ConfidentialTransferElGamalPubkeyMismatch.into())
+        return Err(TokenError::ConfidentialTransferElGamalPubkeyMismatch.into());
     }
 
     confidential_transfer_account.available_balance = EncryptedBalance::zeroed();
@@ -681,7 +681,7 @@ fn process_source_for_transfer(
         .ok_or(ProgramError::InvalidInstructionData)?
     };
 
-    iif new_source_available_balance != *expected_new_source_available_balance {
+    if new_source_available_balance != *expected_new_source_available_balance {
         return Err(TokenError::ConfidentialTransferBalanceMismatch.into());
     }
 


### PR DESCRIPTION
Some of the components that are associated with the zk instruction data are not checked to the data components associated with accounts, which could lead to some vulnerabilities. This PR adds these checks.