### PR TITLE
Adding new() function for ChangeLogEvent and expose ChangeLogEventV1

### DIFF
--- a/account-compression/programs/account-compression/src/events/changelog_event.rs
+++ b/account-compression/programs/account-compression/src/events/changelog_event.rs
@@ -25,6 +25,17 @@ pub struct ChangeLogEventV1 {
     pub index: u32,
 }
 
+impl ChangeLogEvent {
+    pub fn new(id: Pubkey, path: Vec<PathNode>, seq: u64, index: u32) -> Self {
+        Self::V1(ChangeLogEventV1 {
+            id,
+            path,
+            seq,
+            index,
+        })
+    }
+}
+
 impl<const MAX_DEPTH: usize> From<(Box<ChangeLog<MAX_DEPTH>>, Pubkey, u64)>
     for Box<ChangeLogEvent>
 {

--- a/account-compression/programs/account-compression/src/events/mod.rs
+++ b/account-compression/programs/account-compression/src/events/mod.rs
@@ -7,7 +7,7 @@ mod application_data;
 mod changelog_event;
 
 pub use application_data::{ApplicationDataEvent, ApplicationDataEventV1};
-pub use changelog_event::ChangeLogEvent;
+pub use changelog_event::{ChangeLogEvent, ChangeLogEventV1};
 
 #[derive(AnchorDeserialize, AnchorSerialize)]
 #[repr(C)]


### PR DESCRIPTION
Needed by Metaplex.

### Related PRs
* https://github.com/metaplex-foundation/metaplex-program-library/pull/801
* https://github.com/metaplex-foundation/blockbuster/pull/9
* https://github.com/metaplex-foundation/digital-asset-rpc-infrastructure/pull/10