### PR TITLE
update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6194,7 +6194,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-cli"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "assert_cmd",
  "clap 2.34.0",
@@ -6228,7 +6228,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-client"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "solana-cli-output",


### PR DESCRIPTION
missed a spot

note to any observers that we have abandoned the 0.2.1 and 2.1.1 releases at this time because of [complicated stuff about dependecny resolution breakage that isnt important], we will pick this up again when spl-token-2022 is more stable...