### PR TITLE
fix stake-pool/program/tests/update_validator_list_balance test

### DIFF
--- a/stake-pool/program/tests/update_validator_list_balance.rs
+++ b/stake-pool/program/tests/update_validator_list_balance.rs
@@ -209,7 +209,11 @@ async fn success() {
         &stake_pool_accounts.validator_list.pubkey(),
     )
     .await;
-    assert!(new_lamports > initial_lamports);
+
+    // With partition rewards, the reward is paid after reward interval
+    // So the lamports and credits_observed won't change at the start of the new epoch
+    // TODO: check lamport reward after reward interval.
+    assert!(new_lamports == initial_lamports);
 
     let stake_pool_info = get_account(
         &mut context.banks_client,

--- a/stake-pool/program/tests/update_validator_list_balance.rs
+++ b/stake-pool/program/tests/update_validator_list_balance.rs
@@ -213,7 +213,7 @@ async fn success() {
     // With partition rewards, the reward is paid after reward interval
     // So the lamports and credits_observed won't change at the start of the new epoch
     // TODO: check lamport reward after reward interval.
-    assert!(new_lamports == initial_lamports);
+    // assert!(new_lamports > initial_lamports);
 
     let stake_pool_info = get_account(
         &mut context.banks_client,


### PR DESCRIPTION
With partitioned stake rewards, the rewards are no longer credited on the start block of the epoch. Therefore, the assert in the test that checks for rewards at the start block of the epoch is broken. 
TODO Update the test once we have the rpc method ready to query the reward interval. 