### PR TITLE
Governance: MultiChoice type Weighted

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2987,16 +2987,28 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.38"
+version = "0.10.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
+checksum = "518915b97df115dd36109bfa429a48b8f737bd05508cf9588977b599648926d2"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
  "once_cell",
+ "openssl-macros",
  "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2 1.0.50",
+ "quote 1.0.21",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3016,9 +3028,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.72"
+version = "0.9.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
+checksum = "666416d899cf077260dac8698d60a60b435a46d57e82acb1be3d0dad87284e5b"
 dependencies = [
  "autocfg",
  "cc",

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -494,6 +494,10 @@ pub enum GovernanceError {
     /// Total vote weight must be 100%
     #[error("Total vote weight must be 100%")]
     TotalVoteWeightMustBe100Percent, // 619
+
+    /// Invalid multi choice proposal parameters
+    #[error("Invalid multi choice proposal parameters")]
+    InvalidMultiChoiceProposalParameters, // 620
 }
 
 impl PrintProgramError for GovernanceError {

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -470,7 +470,7 @@ pub enum GovernanceError {
     ///Invalid state for proposal state transition to Completed
     #[error("Invalid state for proposal state transition to Completed")]
     InvalidStateToCompleteProposal, // 613
-    
+
     /// Invalid number of vote choices
     #[error("Invalid number of vote choices")]
     InvalidNumberOfVoteChoices, // 614

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -475,9 +475,9 @@ pub enum GovernanceError {
     #[error("Ranked vote is not supported")]
     RankedVoteIsNotSupported, // 614
 
-    /// Vote weight must be 100%
-    #[error("Vote weight must be 100%")]
-    VoteWeightMustBe100Percent, // 615
+    /// Choice weight must be 100%
+    #[error("Choice weight must be 100%")]
+    ChoiceWeightMustBe100Percent, // 615
 
     /// Single choice only is allowed
     #[error("Single choice only is allowed")]

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -355,9 +355,9 @@ pub enum GovernanceError {
     #[error("Proposal is not not executable")]
     ProposalIsNotExecutable, // 584
 
-    /// Invalid vote
-    #[error("Invalid vote")]
-    InvalidVote, // 585
+    /// Deny vote is not allowed
+    #[error("Deny vote is not allowed")]
+    DenyVoteIsNotAllowed, // 585
 
     /// Cannot execute defeated option
     #[error("Cannot execute defeated option")]
@@ -466,6 +466,30 @@ pub enum GovernanceError {
     /// Invalid State: Proposal is not in final state
     #[error("Invalid State: Proposal is not in final state")]
     InvalidStateNotFinal, // 612
+
+    /// Invalid number of vote choices
+    #[error("Invalid number of vote choices")]
+    InvalidNumberOfVoteChoices, // 613
+
+    /// Ranked vote is not supported
+    #[error("Ranked vote is not supported")]
+    RankedVoteIsNotSupported, // 614
+
+    /// Vote weight must be 100%
+    #[error("Vote weight must be 100%")]
+    VoteWeightMustBe100Percent, // 615
+
+    /// Single choice only is allowed
+    #[error("Single choice only is allowed")]
+    SingleChoiceOnlyIsAllowed, // 616
+
+    /// At least single choice is required
+    #[error("At least single choice is required")]
+    AtLeastSingleChoiceIsRequired, // 617
+
+    /// Total vote weight must be 100%
+    #[error("Total vote weight must be 100%")]
+    TotalVoteWeightMustBe100Percent, // 618
 }
 
 impl PrintProgramError for GovernanceError {

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -115,7 +115,7 @@ pub enum VoteType {
 #[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum MultiChoiceType {
     /// Multiple options can be approved with full weight allocated to each approved option
-    Approval,
+    FullWeight,
 
     /// Multiple options can be approved with weight allocated proportionally to the percentage of the total weight
     /// The full weight has to be voted among the approved options, i.e., 100% of the weight has to be allocated
@@ -907,7 +907,7 @@ impl ProposalV2 {
                         }
                     }
                     VoteType::MultiChoice {
-                        choice_type: MultiChoiceType::Approval,
+                        choice_type: MultiChoiceType::FullWeight,
                         min_voter_options: _,
                         max_voter_options: _,
                         max_winning_options: _,
@@ -1329,7 +1329,7 @@ mod test {
     fn test_max_size() {
         let mut proposal = create_test_proposal();
         proposal.vote_type = VoteType::MultiChoice {
-            choice_type: MultiChoiceType::Approval,
+            choice_type: MultiChoiceType::FullWeight,
             min_voter_options: 1,
             max_voter_options: 1,
             max_winning_options: 1,
@@ -1344,7 +1344,7 @@ mod test {
     fn test_multi_option_proposal_max_size() {
         let mut proposal = create_test_multi_option_proposal();
         proposal.vote_type = VoteType::MultiChoice {
-            choice_type: MultiChoiceType::Approval,
+            choice_type: MultiChoiceType::FullWeight,
             min_voter_options: 1,
             max_voter_options: 3,
             max_winning_options: 3,
@@ -2604,7 +2604,7 @@ mod test {
         // Arrange
         let mut proposal = create_test_multi_option_proposal();
         proposal.vote_type = VoteType::MultiChoice {
-            choice_type: MultiChoiceType::Approval,
+            choice_type: MultiChoiceType::FullWeight,
             min_voter_options: 1,
             max_voter_options: 4,
             max_winning_options: 4,
@@ -2641,7 +2641,7 @@ mod test {
         // Arrange
         let mut proposal = create_test_multi_option_proposal();
         proposal.vote_type = VoteType::MultiChoice {
-            choice_type: MultiChoiceType::Approval,
+            choice_type: MultiChoiceType::FullWeight,
             min_voter_options: 1,
             max_voter_options: 3,
             max_winning_options: 3,
@@ -2682,7 +2682,7 @@ mod test {
         // Arrange
         let mut proposal = create_test_multi_option_proposal();
         proposal.vote_type = VoteType::MultiChoice {
-            choice_type: MultiChoiceType::Approval,
+            choice_type: MultiChoiceType::FullWeight,
             min_voter_options: 1,
             max_voter_options: 3,
             max_winning_options: 3,
@@ -2723,7 +2723,7 @@ mod test {
     ) {
         // Arrange
         let vote_type = VoteType::MultiChoice {
-            choice_type: MultiChoiceType::Approval,
+            choice_type: MultiChoiceType::FullWeight,
             min_voter_options: 1,
             max_voter_options: 3,
             max_winning_options: 3,
@@ -2742,7 +2742,7 @@ mod test {
     pub fn test_assert_valid_proposal_options_with_no_options_for_multi_choice_vote_error() {
         // Arrange
         let vote_type = VoteType::MultiChoice {
-            choice_type: MultiChoiceType::Approval,
+            choice_type: MultiChoiceType::FullWeight,
             min_voter_options: 1,
             max_voter_options: 3,
             max_winning_options: 3,
@@ -2775,7 +2775,7 @@ mod test {
     pub fn test_assert_valid_proposal_options_for_multi_choice_vote() {
         // Arrange
         let vote_type = VoteType::MultiChoice {
-            choice_type: MultiChoiceType::Approval,
+            choice_type: MultiChoiceType::FullWeight,
             min_voter_options: 1,
             max_voter_options: 3,
             max_winning_options: 3,
@@ -2798,7 +2798,7 @@ mod test {
     pub fn test_assert_valid_proposal_options_for_multi_choice_vote_with_empty_option_error() {
         // Arrange
         let vote_type = VoteType::MultiChoice {
-            choice_type: MultiChoiceType::Approval,
+            choice_type: MultiChoiceType::FullWeight,
             min_voter_options: 1,
             max_voter_options: 3,
             max_winning_options: 3,

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -87,6 +87,10 @@ pub enum VoteType {
     /// Ex. voters are given 5 options, can choose up to 3 (max_voter_options)
     /// and only 1 (max_winning_options) option can win and be executed
     MultiChoice {
+        /// Type of MultiChoice
+        #[allow(dead_code)]
+        choice_type: MultiChoiceType,
+
         /// The max number of options a voter can choose
         /// By default it equals to the number of available options
         /// Note: In the current version the limit is not supported and not enforced yet
@@ -100,18 +104,19 @@ pub enum VoteType {
         #[allow(dead_code)]
         max_winning_options: u8,
     },
+}
+
+/// Type of MultiChoice.
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
+pub enum MultiChoiceType {
+    /// Normal multi choice type that requires decision for only one option when voting.
+    Approval,
 
     /// The multi weighted choice behaves the same way as the MultiChoice
     /// while it considers the weight_percentage defined in the VoteChoice
-    MultiWeightedChoice {
-        /// The max number of options a voter can choose; see MultiChoice
-        #[allow(dead_code)]
-        max_voter_options: u8,
-
-        /// The max number of wining options; see MultiChoice
-        #[allow(dead_code)]
-        max_winning_options: u8,
-    },
+    Weighted,
+    // Quadartic multi choice, not available yet
+    // Quadratic,
 }
 
 /// Governance Proposal
@@ -221,7 +226,7 @@ pub struct ProposalV2 {
 impl AccountMaxSize for ProposalV2 {
     fn get_max_size(&self) -> Option<usize> {
         let options_size: usize = self.options.iter().map(|o| o.label.len() + 19).sum();
-        Some(self.name.len() + self.description_link.len() + options_size + 295)
+        Some(self.name.len() + self.description_link.len() + options_size + 296)
     }
 }
 
@@ -453,7 +458,7 @@ impl ProposalV2 {
             // If none of the individual options succeeded then the proposal as a whole is defeated
             ProposalState::Defeated
         } else {
-            match self.vote_type {
+            match &self.vote_type {
                 VoteType::SingleChoice => {
                     let proposal_state = if best_succeeded_option_count > 1 {
                         // If there is more than one winning option then the single choice proposal is considered as defeated
@@ -475,10 +480,7 @@ impl ProposalV2 {
                     proposal_state
                 }
                 VoteType::MultiChoice {
-                    max_voter_options: _n,
-                    max_winning_options: _m,
-                }
-                | VoteType::MultiWeightedChoice {
+                    choice_type: _t,
                     max_voter_options: _n,
                     max_winning_options: _m,
                 } => {
@@ -845,7 +847,8 @@ impl ProposalV2 {
                         return Err(GovernanceError::InvalidVote.into());
                     }
 
-                    if let VoteType::MultiWeightedChoice {
+                    if let VoteType::MultiChoice {
+                        choice_type: MultiChoiceType::Weighted,
                         max_voter_options: _m,
                         max_winning_options: _n,
                     } = self.vote_type
@@ -869,6 +872,7 @@ impl ProposalV2 {
                         }
                     }
                     VoteType::MultiChoice {
+                        choice_type: MultiChoiceType::Approval,
                         max_voter_options: _n,
                         max_winning_options: _m,
                     } => {
@@ -876,7 +880,8 @@ impl ProposalV2 {
                             return Err(GovernanceError::InvalidVote.into());
                         }
                     }
-                    VoteType::MultiWeightedChoice {
+                    VoteType::MultiChoice {
+                        choice_type: MultiChoiceType::Weighted,
                         max_voter_options: _n,
                         max_winning_options: _m,
                     } => {
@@ -1126,17 +1131,14 @@ pub fn assert_valid_proposal_options(
     }
 
     if let VoteType::MultiChoice {
+        choice_type: _choice_type,
         max_voter_options,
         max_winning_options,
-    }
-    | VoteType::MultiWeightedChoice {
-        max_voter_options,
-        max_winning_options,
-    } = *vote_type
+    } = vote_type
     {
         if options.len() == 1
-            || max_voter_options as usize != options.len()
-            || max_winning_options as usize != options.len()
+            || *max_voter_options as usize != options.len()
+            || *max_winning_options as usize != options.len()
         {
             return Err(GovernanceError::InvalidProposalOptions.into());
         }
@@ -1289,6 +1291,7 @@ mod test {
     fn test_max_size() {
         let mut proposal = create_test_proposal();
         proposal.vote_type = VoteType::MultiChoice {
+            choice_type: MultiChoiceType::Approval,
             max_voter_options: 1,
             max_winning_options: 1,
         };
@@ -1302,6 +1305,7 @@ mod test {
     fn test_multi_option_proposal_max_size() {
         let mut proposal = create_test_multi_option_proposal();
         proposal.vote_type = VoteType::MultiChoice {
+            choice_type: MultiChoiceType::Approval,
             max_voter_options: 3,
             max_winning_options: 3,
         };
@@ -2551,6 +2555,7 @@ mod test {
         // Arrange
         let mut proposal = create_test_multi_option_proposal();
         proposal.vote_type = VoteType::MultiChoice {
+            choice_type: MultiChoiceType::Approval,
             max_voter_options: 3,
             max_winning_options: 3,
         };
@@ -2587,6 +2592,7 @@ mod test {
         // Arrange
         let mut proposal = create_test_multi_option_proposal();
         proposal.vote_type = VoteType::MultiChoice {
+            choice_type: MultiChoiceType::Approval,
             max_voter_options: 3,
             max_winning_options: 3,
         };
@@ -2623,6 +2629,7 @@ mod test {
     ) {
         // Arrange
         let vote_type = VoteType::MultiChoice {
+            choice_type: MultiChoiceType::Approval,
             max_voter_options: 3,
             max_winning_options: 3,
         };
@@ -2640,6 +2647,7 @@ mod test {
     pub fn test_assert_valid_proposal_options_with_no_options_for_multi_choice_vote_error() {
         // Arrange
         let vote_type = VoteType::MultiChoice {
+            choice_type: MultiChoiceType::Approval,
             max_voter_options: 3,
             max_winning_options: 3,
         };
@@ -2671,6 +2679,7 @@ mod test {
     pub fn test_assert_valid_proposal_options_for_multi_choice_vote() {
         // Arrange
         let vote_type = VoteType::MultiChoice {
+            choice_type: MultiChoiceType::Approval,
             max_voter_options: 3,
             max_winning_options: 3,
         };
@@ -2692,6 +2701,7 @@ mod test {
     pub fn test_assert_valid_proposal_options_for_multi_choice_vote_with_empty_option_error() {
         // Arrange
         let vote_type = VoteType::MultiChoice {
+            choice_type: MultiChoiceType::Approval,
             max_voter_options: 3,
             max_winning_options: 3,
         };
@@ -2714,7 +2724,8 @@ mod test {
         // Multi weighted choice may be weighted but sum of choices has to be 100%
         // Arrange
         let mut proposal = create_test_multi_option_proposal();
-        proposal.vote_type = VoteType::MultiWeightedChoice {
+        proposal.vote_type = VoteType::MultiChoice {
+            choice_type: MultiChoiceType::Weighted,
             max_voter_options: 3,
             max_winning_options: 3,
         };
@@ -2750,7 +2761,8 @@ mod test {
         // Multi weighted choice may be weighted to 100% and 0% rest
         // Arrange
         let mut proposal = create_test_multi_option_proposal();
-        proposal.vote_type = VoteType::MultiWeightedChoice {
+        proposal.vote_type = VoteType::MultiChoice {
+            choice_type: MultiChoiceType::Weighted,
             max_voter_options: 3,
             max_winning_options: 3,
         };
@@ -2785,7 +2797,8 @@ mod test {
     pub fn test_assert_valid_vote_with_no_choices_for_multi_weighted_choice_error() {
         // Arrange
         let mut proposal = create_test_multi_option_proposal();
-        proposal.vote_type = VoteType::MultiWeightedChoice {
+        proposal.vote_type = VoteType::MultiChoice {
+            choice_type: MultiChoiceType::Weighted,
             max_voter_options: 2,
             max_winning_options: 2,
         };
@@ -2821,7 +2834,8 @@ mod test {
         // Multi weighted choice does not permit vote with sum weight over 100%
         // Arrange
         let mut proposal = create_test_multi_option_proposal();
-        proposal.vote_type = VoteType::MultiWeightedChoice {
+        proposal.vote_type = VoteType::MultiChoice {
+            choice_type: MultiChoiceType::Weighted,
             max_voter_options: 3,
             max_winning_options: 3,
         };
@@ -2856,7 +2870,8 @@ mod test {
     pub fn test_assert_valid_proposal_options_with_invalid_choice_number_for_multi_weighted_choice_vote_error(
     ) {
         // Arrange
-        let vote_type = VoteType::MultiWeightedChoice {
+        let vote_type = VoteType::MultiChoice {
+            choice_type: MultiChoiceType::Weighted,
             max_voter_options: 3,
             max_winning_options: 3,
         };
@@ -2874,7 +2889,8 @@ mod test {
     pub fn test_assert_valid_proposal_options_with_no_options_for_multi_weighted_choice_vote_error()
     {
         // Arrange
-        let vote_type = VoteType::MultiWeightedChoice {
+        let vote_type = VoteType::MultiChoice {
+            choice_type: MultiChoiceType::Weighted,
             max_voter_options: 3,
             max_winning_options: 3,
         };
@@ -2891,7 +2907,8 @@ mod test {
     #[test]
     pub fn test_assert_valid_proposal_options_for_multi_weighted_choice_vote() {
         // Arrange
-        let vote_type = VoteType::MultiWeightedChoice {
+        let vote_type = VoteType::MultiChoice {
+            choice_type: MultiChoiceType::Weighted,
             max_voter_options: 3,
             max_winning_options: 3,
         };
@@ -2913,7 +2930,8 @@ mod test {
     pub fn test_assert_valid_proposal_options_for_multi_weighted_choice_vote_with_empty_option_error(
     ) {
         // Arrange
-        let vote_type = VoteType::MultiWeightedChoice {
+        let vote_type = VoteType::MultiChoice {
+            choice_type: MultiChoiceType::Weighted,
             max_voter_options: 3,
             max_winning_options: 3,
         };
@@ -2934,7 +2952,8 @@ mod test {
     #[test]
     pub fn test_assert_more_than_ten_proposal_options_for_multi_weighted_choice_error() {
         // Arrange
-        let vote_type = VoteType::MultiWeightedChoice {
+        let vote_type = VoteType::MultiChoice {
+            choice_type: MultiChoiceType::Weighted,
             max_voter_options: 3,
             max_winning_options: 3,
         };
@@ -2963,7 +2982,8 @@ mod test {
     #[test]
     pub fn test_assert_same_label_options_for_multi_weighted_choice_error() {
         // Arrange
-        let vote_type = VoteType::MultiWeightedChoice {
+        let vote_type = VoteType::MultiChoice {
+            choice_type: MultiChoiceType::Weighted,
             max_voter_options: 1,
             max_winning_options: 1,
         };

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -91,21 +91,25 @@ pub enum VoteType {
         #[allow(dead_code)]
         choice_type: MultiChoiceType,
 
-        /// The min number of options a voter must choose, the default is 1
-        /// Note: In the current version the limit is not supported and not enforced yet
+        /// The min number of options a voter must choose
+        ///
+        /// Note: In the current version the limit is not supported and not enforced
+        /// and must always be set to 1
         #[allow(dead_code)]
         min_voter_options: u8,
 
         /// The max number of options a voter can choose
-        /// By default it equals to the number of available options
-        /// Note: In the current version the limit is not supported and not enforced yet
+        ///
+        /// Note: In the current version the limit is not supported and not enforced
+        /// and must always be set to the number of available options
         #[allow(dead_code)]
         max_voter_options: u8,
 
         /// The max number of wining options
         /// For executable proposals it limits how many options can be executed for a Proposal
-        /// By default it equals to the number of available options
-        /// Note: In the current version the limit is not supported and not enforced yet
+        ///
+        /// Note: In the current version the limit is not supported and not enforced
+        /// and must always be set to the number of available options
         #[allow(dead_code)]
         max_winning_options: u8,
     },
@@ -1169,7 +1173,7 @@ pub fn assert_valid_proposal_options(
 
     if let VoteType::MultiChoice {
         choice_type: _,
-        min_voter_options: _,
+        min_voter_options,
         max_voter_options,
         max_winning_options,
     } = vote_type
@@ -1177,8 +1181,9 @@ pub fn assert_valid_proposal_options(
         if options.len() == 1
             || *max_voter_options as usize != options.len()
             || *max_winning_options as usize != options.len()
+            || *min_voter_options != 1
         {
-            return Err(GovernanceError::InvalidProposalOptions.into());
+            return Err(GovernanceError::InvalidMultiChoiceProposalParameters.into());
         }
     }
 
@@ -2735,7 +2740,10 @@ mod test {
         let result = assert_valid_proposal_options(&options, &vote_type);
 
         // Assert
-        assert_eq!(result, Err(GovernanceError::InvalidProposalOptions.into()));
+        assert_eq!(
+            result,
+            Err(GovernanceError::InvalidMultiChoiceProposalParameters.into())
+        );
     }
 
     #[test]
@@ -3033,7 +3041,10 @@ mod test {
         let result = assert_valid_proposal_options(&options, &vote_type);
 
         // Assert
-        assert_eq!(result, Err(GovernanceError::InvalidProposalOptions.into()));
+        assert_eq!(
+            result,
+            Err(GovernanceError::InvalidMultiChoiceProposalParameters.into())
+        );
     }
 
     #[test]
@@ -3126,25 +3137,6 @@ mod test {
             "option 10".to_string(),
             "option 11".to_string(),
         ];
-
-        // Act
-        let result = assert_valid_proposal_options(&options, &vote_type);
-
-        // Assert
-        assert_eq!(result, Err(GovernanceError::InvalidProposalOptions.into()));
-    }
-
-    #[test]
-    pub fn test_assert_same_label_options_for_multi_weighted_choice_error() {
-        // Arrange
-        let vote_type = VoteType::MultiChoice {
-            choice_type: MultiChoiceType::Weighted,
-            min_voter_options: 1,
-            max_voter_options: 1,
-            max_winning_options: 1,
-        };
-
-        let options = vec!["option 1".to_string(), "option 1".to_string()];
 
         // Act
         let result = assert_valid_proposal_options(&options, &vote_type);

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -2605,7 +2605,7 @@ mod test {
     }
 
     #[test]
-    pub fn test_assert_valid_multi_choice_approval_vote() {
+    pub fn test_assert_valid_multi_choice_full_weight_vote() {
         // Arrange
         let mut proposal = create_test_multi_option_proposal();
         proposal.vote_type = VoteType::MultiChoice {

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -91,6 +91,11 @@ pub enum VoteType {
         #[allow(dead_code)]
         choice_type: MultiChoiceType,
 
+        /// The min number of options a voter mast choose, the default is 1
+        /// Note: In the current version the limit is not supported and not enforced yet
+        #[allow(dead_code)]
+        min_voter_options: u8,
+
         /// The max number of options a voter can choose
         /// By default it equals to the number of available options
         /// Note: In the current version the limit is not supported and not enforced yet
@@ -224,7 +229,7 @@ pub struct ProposalV2 {
 impl AccountMaxSize for ProposalV2 {
     fn get_max_size(&self) -> Option<usize> {
         let options_size: usize = self.options.iter().map(|o| o.label.len() + 19).sum();
-        Some(self.name.len() + self.description_link.len() + options_size + 296)
+        Some(self.name.len() + self.description_link.len() + options_size + 297)
     }
 }
 
@@ -478,9 +483,10 @@ impl ProposalV2 {
                     proposal_state
                 }
                 VoteType::MultiChoice {
-                    choice_type: _t,
-                    max_voter_options: _n,
-                    max_winning_options: _m,
+                    choice_type: _,
+                    max_voter_options: _,
+                    max_winning_options: _,
+                    min_voter_options: _,
                 } => {
                     // If any option succeeded for multi choice then the proposal as a whole succeeded as well
                     ProposalState::Succeeded
@@ -851,6 +857,7 @@ impl ProposalV2 {
                         match self.vote_type {
                             VoteType::MultiChoice {
                                 choice_type: MultiChoiceType::Weighted,
+                                min_voter_options: _,
                                 max_voter_options: _,
                                 max_winning_options: _,
                             } => {
@@ -879,8 +886,9 @@ impl ProposalV2 {
                     }
                     VoteType::MultiChoice {
                         choice_type: MultiChoiceType::Approval,
-                        max_voter_options: _n,
-                        max_winning_options: _m,
+                        min_voter_options: _,
+                        max_voter_options: _,
+                        max_winning_options: _,
                     } => {
                         if choice_count == 0 {
                             return Err(GovernanceError::AtLeastSingleChoiceIsRequired.into());
@@ -888,8 +896,9 @@ impl ProposalV2 {
                     }
                     VoteType::MultiChoice {
                         choice_type: MultiChoiceType::Weighted,
-                        max_voter_options: _n,
-                        max_winning_options: _m,
+                        min_voter_options: _,
+                        max_voter_options: _,
+                        max_winning_options: _,
                     } => {
                         if choice_count == 0 {
                             return Err(GovernanceError::AtLeastSingleChoiceIsRequired.into());
@@ -1137,7 +1146,8 @@ pub fn assert_valid_proposal_options(
     }
 
     if let VoteType::MultiChoice {
-        choice_type: _choice_type,
+        choice_type: _,
+        min_voter_options: _,
         max_voter_options,
         max_winning_options,
     } = vote_type
@@ -1298,6 +1308,7 @@ mod test {
         let mut proposal = create_test_proposal();
         proposal.vote_type = VoteType::MultiChoice {
             choice_type: MultiChoiceType::Approval,
+            min_voter_options: 1,
             max_voter_options: 1,
             max_winning_options: 1,
         };
@@ -1312,6 +1323,7 @@ mod test {
         let mut proposal = create_test_multi_option_proposal();
         proposal.vote_type = VoteType::MultiChoice {
             choice_type: MultiChoiceType::Approval,
+            min_voter_options: 1,
             max_voter_options: 3,
             max_winning_options: 3,
         };
@@ -2571,6 +2583,7 @@ mod test {
         let mut proposal = create_test_multi_option_proposal();
         proposal.vote_type = VoteType::MultiChoice {
             choice_type: MultiChoiceType::Approval,
+            min_voter_options: 1,
             max_voter_options: 4,
             max_winning_options: 4,
         };
@@ -2607,6 +2620,7 @@ mod test {
         let mut proposal = create_test_multi_option_proposal();
         proposal.vote_type = VoteType::MultiChoice {
             choice_type: MultiChoiceType::Approval,
+            min_voter_options: 1,
             max_voter_options: 3,
             max_winning_options: 3,
         };
@@ -2647,6 +2661,7 @@ mod test {
         let mut proposal = create_test_multi_option_proposal();
         proposal.vote_type = VoteType::MultiChoice {
             choice_type: MultiChoiceType::Approval,
+            min_voter_options: 1,
             max_voter_options: 3,
             max_winning_options: 3,
         };
@@ -2687,6 +2702,7 @@ mod test {
         // Arrange
         let vote_type = VoteType::MultiChoice {
             choice_type: MultiChoiceType::Approval,
+            min_voter_options: 1,
             max_voter_options: 3,
             max_winning_options: 3,
         };
@@ -2705,6 +2721,7 @@ mod test {
         // Arrange
         let vote_type = VoteType::MultiChoice {
             choice_type: MultiChoiceType::Approval,
+            min_voter_options: 1,
             max_voter_options: 3,
             max_winning_options: 3,
         };
@@ -2737,6 +2754,7 @@ mod test {
         // Arrange
         let vote_type = VoteType::MultiChoice {
             choice_type: MultiChoiceType::Approval,
+            min_voter_options: 1,
             max_voter_options: 3,
             max_winning_options: 3,
         };
@@ -2759,6 +2777,7 @@ mod test {
         // Arrange
         let vote_type = VoteType::MultiChoice {
             choice_type: MultiChoiceType::Approval,
+            min_voter_options: 1,
             max_voter_options: 3,
             max_winning_options: 3,
         };
@@ -2783,6 +2802,7 @@ mod test {
         let mut proposal = create_test_multi_option_proposal();
         proposal.vote_type = VoteType::MultiChoice {
             choice_type: MultiChoiceType::Weighted,
+            min_voter_options: 1,
             max_voter_options: 3,
             max_winning_options: 3,
         };
@@ -2820,6 +2840,7 @@ mod test {
         let mut proposal = create_test_multi_option_proposal();
         proposal.vote_type = VoteType::MultiChoice {
             choice_type: MultiChoiceType::Weighted,
+            min_voter_options: 1,
             max_voter_options: 3,
             max_winning_options: 3,
         };
@@ -2857,6 +2878,7 @@ mod test {
         let mut proposal = create_test_multi_option_proposal();
         proposal.vote_type = VoteType::MultiChoice {
             choice_type: MultiChoiceType::Weighted,
+            min_voter_options: 1,
             max_voter_options: 2,
             max_winning_options: 2,
         };
@@ -2897,6 +2919,7 @@ mod test {
         let mut proposal = create_test_multi_option_proposal();
         proposal.vote_type = VoteType::MultiChoice {
             choice_type: MultiChoiceType::Weighted,
+            min_voter_options: 1,
             max_voter_options: 3,
             max_winning_options: 3,
         };
@@ -2936,6 +2959,7 @@ mod test {
         // Arrange
         let vote_type = VoteType::MultiChoice {
             choice_type: MultiChoiceType::Weighted,
+            min_voter_options: 1,
             max_voter_options: 3,
             max_winning_options: 3,
         };
@@ -2955,6 +2979,7 @@ mod test {
         // Arrange
         let vote_type = VoteType::MultiChoice {
             choice_type: MultiChoiceType::Weighted,
+            min_voter_options: 1,
             max_voter_options: 3,
             max_winning_options: 3,
         };
@@ -2973,6 +2998,7 @@ mod test {
         // Arrange
         let vote_type = VoteType::MultiChoice {
             choice_type: MultiChoiceType::Weighted,
+            min_voter_options: 1,
             max_voter_options: 3,
             max_winning_options: 3,
         };
@@ -2996,6 +3022,7 @@ mod test {
         // Arrange
         let vote_type = VoteType::MultiChoice {
             choice_type: MultiChoiceType::Weighted,
+            min_voter_options: 1,
             max_voter_options: 3,
             max_winning_options: 3,
         };
@@ -3018,6 +3045,7 @@ mod test {
         // Arrange
         let vote_type = VoteType::MultiChoice {
             choice_type: MultiChoiceType::Weighted,
+            min_voter_options: 1,
             max_voter_options: 3,
             max_winning_options: 3,
         };
@@ -3048,6 +3076,7 @@ mod test {
         // Arrange
         let vote_type = VoteType::MultiChoice {
             choice_type: MultiChoiceType::Weighted,
+            min_voter_options: 1,
             max_voter_options: 1,
             max_winning_options: 1,
         };

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -109,14 +109,12 @@ pub enum VoteType {
 /// Type of MultiChoice.
 #[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub enum MultiChoiceType {
-    /// Multiple options can be approved with full weight allocated to each approved option.
+    /// Multiple options can be approved with full weight allocated to each approved option
     Approval,
 
-    /// Multiple options can be approved with weight allocated proportionally to the percentage of the total weight.
-    /// The full weight has to be voted among the approved options, i.e., 100% of the weight has to be allocated.
+    /// Multiple options can be approved with weight allocated proportionally to the percentage of the total weight
+    /// The full weight has to be voted among the approved options, i.e., 100% of the weight has to be allocated
     Weighted,
-    // Quadartic multi choice, not available yet
-    // Quadratic,
 }
 
 /// Governance Proposal

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -862,7 +862,9 @@ impl ProposalV2 {
                             }
                             _ => {
                                 if choice.weight_percentage != 100 {
-                                    return Err(GovernanceError::VoteWeightMustBe100Percent.into());
+                                    return Err(
+                                        GovernanceError::ChoiceWeightMustBe100Percent.into()
+                                    );
                                 }
                             }
                         }
@@ -2640,7 +2642,7 @@ mod test {
     }
 
     #[test]
-    pub fn test_assert_valid_vote_with_not_full_percentage_choices_error() {
+    pub fn test_assert_valid_vote_with_choice_weight_not_100_percent_error() {
         // Arrange
         let mut proposal = create_test_multi_option_proposal();
         proposal.vote_type = VoteType::MultiChoice {
@@ -2675,7 +2677,7 @@ mod test {
         // Assert
         assert_eq!(
             result,
-            Err(GovernanceError::VoteWeightMustBe100Percent.into())
+            Err(GovernanceError::ChoiceWeightMustBe100Percent.into())
         );
     }
 

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -91,7 +91,7 @@ pub enum VoteType {
         #[allow(dead_code)]
         choice_type: MultiChoiceType,
 
-        /// The min number of options a voter mast choose, the default is 1
+        /// The min number of options a voter must choose, the default is 1
         /// Note: In the current version the limit is not supported and not enforced yet
         #[allow(dead_code)]
         min_voter_options: u8,

--- a/governance/program/src/state/vote_record.rs
+++ b/governance/program/src/state/vote_record.rs
@@ -22,7 +22,7 @@ use crate::state::{
 };
 
 /// Voter choice for a proposal option
-/// In the current version only 1) Single choice, 2) Multiple choices proposals are supported and 3) Weighted voting
+/// In the current version only 1) Single choice, 2) Multiple choices proposals and 3) Weighted voting are supported
 /// In the future versions we can add support for 1) Quadratic voting and 2) Ranked choice voting
 #[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
 pub struct VoteChoice {

--- a/governance/program/src/state/vote_record.rs
+++ b/governance/program/src/state/vote_record.rs
@@ -38,7 +38,12 @@ impl VoteChoice {
     /// Returns the choice weight given the voter's weight
     pub fn get_choice_weight(&self, voter_weight: u64) -> Result<u64, ProgramError> {
         Ok(match self.weight_percentage {
-            0..=100 => (voter_weight as u128 * self.weight_percentage as u128 / 100_u128) as u64,
+            100 => voter_weight, // Avoid any rounding errors for full weight
+            0..=99 => (voter_weight as u128)
+                .checked_mul(self.weight_percentage as u128)
+                .unwrap()
+                .checked_div(100)
+                .unwrap() as u64,
             _ => return Err(GovernanceError::InvalidVoteChoiceWeightPercentage.into()),
         })
     }

--- a/governance/program/src/state/vote_record.rs
+++ b/governance/program/src/state/vote_record.rs
@@ -317,12 +317,17 @@ mod test {
     }
 
     #[test]
-    fn test_vote_record_error() {
+    fn test_get_choice_weight_with_invalid_weight_percentage_error() {
+        // Arrange
         let vote_choice = VoteChoice {
             rank: 0,
             weight_percentage: 127,
         };
+
+        // Act
         let result = vote_choice.get_choice_weight(100);
+
+        // Assert
         assert_eq!(
             Err(GovernanceError::InvalidVoteChoiceWeightPercentage.into()),
             result
@@ -330,40 +335,65 @@ mod test {
     }
 
     #[test]
-    fn test_vote_record() {
+    fn test_get_choice_weight() {
+        // Arrange
         let vote_choice = VoteChoice {
             rank: 0,
             weight_percentage: 100,
         };
+
+        // Act
         let result = vote_choice.get_choice_weight(100);
+
+        // Assert
         assert_eq!(Ok(100_u64), result);
 
+        // Arrange
         let vote_choice = VoteChoice {
             rank: 0,
             weight_percentage: 0,
         };
+
+        // Act
         let result = vote_choice.get_choice_weight(100);
+
+        // Assert
         assert_eq!(Ok(0_u64), result);
 
+        // Arrange
         let vote_choice = VoteChoice {
             rank: 0,
             weight_percentage: 33,
         };
+
+        // Act
         let result = vote_choice.get_choice_weight(100);
+
+        // Assert
         assert_eq!(Ok(33_u64), result);
 
+        // Arrange
         let vote_choice = VoteChoice {
             rank: 0,
             weight_percentage: 34,
         };
+
+        // Act
         let result = vote_choice.get_choice_weight(100);
+
+        // Assert
         assert_eq!(Ok(34_u64), result);
 
+        // Arrange
         let vote_choice = VoteChoice {
             rank: 0,
             weight_percentage: 50,
         };
+
+        // Act
         let result = vote_choice.get_choice_weight(u64::MAX);
+
+        // Assert
         assert_eq!(Ok(u64::MAX / 2), result);
     }
 }

--- a/governance/program/src/state/vote_record.rs
+++ b/governance/program/src/state/vote_record.rs
@@ -38,7 +38,9 @@ impl VoteChoice {
     /// Returns the choice weight given the voter's weight
     pub fn get_choice_weight(&self, voter_weight: u64) -> Result<u64, ProgramError> {
         Ok(match self.weight_percentage {
-            100 => voter_weight, // Avoid any rounding errors for full weight
+            // Avoid any rounding errors for full weight
+            100 => voter_weight,
+            // Note: The total weight for all choices might not equal voter_weight due to rounding errors
             0..=99 => (voter_weight as u128)
                 .checked_mul(self.weight_percentage as u128)
                 .unwrap()

--- a/governance/program/tests/use_proposals_with_multiple_options.rs
+++ b/governance/program/tests/use_proposals_with_multiple_options.rs
@@ -1135,15 +1135,10 @@ async fn test_vote_multi_weighted_choice_proposal_non_executable() {
         .await
         .unwrap();
 
-    let signatory_record_cookie = governance_test
-        .with_signatory(&proposal_cookie, &token_owner_record_cookie)
-        .await
-        .unwrap();
-
     let clock = governance_test.bench.get_clock().await;
 
     governance_test
-        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .sign_off_proposal_by_owner(&proposal_cookie, &token_owner_record_cookie)
         .await
         .unwrap();
 
@@ -1323,13 +1318,8 @@ async fn test_vote_multi_weighted_choice_proposal_with_partial_success() {
         .await
         .unwrap();
 
-    let signatory_record_cookie = governance_test
-        .with_signatory(&proposal_cookie, &token_owner_record_cookie1)
-        .await
-        .unwrap();
-
     governance_test
-        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .sign_off_proposal_by_owner(&proposal_cookie, &token_owner_record_cookie1)
         .await
         .unwrap();
 
@@ -1537,13 +1527,8 @@ async fn test_vote_multi_weighted_choice_proposal_with_multi_success() {
         .await
         .unwrap();
 
-    let signatory_record_cookie = governance_test
-        .with_signatory(&proposal_cookie, &token_owner_record_cookie1)
-        .await
-        .unwrap();
-
     governance_test
-        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .sign_off_proposal_by_owner(&proposal_cookie, &token_owner_record_cookie1)
         .await
         .unwrap();
 
@@ -1711,13 +1696,8 @@ async fn test_vote_multi_weighted_choice_proposal_executable_with_full_deny() {
         .await
         .unwrap();
 
-    let signatory_record_cookie = governance_test
-        .with_signatory(&proposal_cookie, &token_owner_record_cookie1)
-        .await
-        .unwrap();
-
     governance_test
-        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .sign_off_proposal_by_owner(&proposal_cookie, &token_owner_record_cookie1)
         .await
         .unwrap();
 

--- a/governance/program/tests/use_proposals_with_multiple_options.rs
+++ b/governance/program/tests/use_proposals_with_multiple_options.rs
@@ -1079,3 +1079,678 @@ async fn test_create_proposal_with_10_options_and_cast_vote() {
 
     assert_eq!(ProposalState::Completed, proposal_account.state);
 }
+
+#[tokio::test]
+async fn test_vote_multi_weighted_choice_proposal_non_executable() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.community_vote_threshold = VoteThreshold::YesVotePercentage(30);
+
+    let mut governance_cookie = governance_test
+        .with_governance_using_config(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_multi_option_proposal(
+            &token_owner_record_cookie,
+            &mut governance_cookie,
+            vec![
+                "option 1".to_string(),
+                "option 2".to_string(),
+                "option 3".to_string(),
+                "option 4".to_string(),
+            ],
+            false,
+            VoteType::MultiWeightedChoice {
+                max_winning_options: 4,
+                max_voter_options: 4,
+            },
+        )
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    let clock = governance_test.bench.get_clock().await;
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    let vote = Vote::Approve(vec![
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 30,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 29,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 41,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 0,
+        },
+    ]);
+
+    // Act
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie, vote)
+        .await
+        .unwrap();
+
+    // Advance timestamp past max_voting_time
+    governance_test
+        .advance_clock_past_timestamp(
+            governance_cookie.account.config.max_voting_time as i64 + clock.unix_timestamp,
+        )
+        .await;
+
+    governance_test
+        .finalize_vote(&realm_cookie, &proposal_cookie, None)
+        .await
+        .unwrap();
+
+    // Assert
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(
+        OptionVoteResult::Succeeded,
+        proposal_account.options[0].vote_result
+    );
+    assert_eq!(
+        OptionVoteResult::Defeated,
+        proposal_account.options[1].vote_result
+    );
+    assert_eq!(
+        OptionVoteResult::Succeeded,
+        proposal_account.options[2].vote_result
+    );
+    assert_eq!(
+        OptionVoteResult::Defeated,
+        proposal_account.options[3].vote_result
+    );
+    assert_eq!(
+        (token_owner_record_cookie.token_source_amount as f32 * 0.3) as u64,
+        proposal_account.options[0].vote_weight
+    );
+    assert_eq!(
+        (token_owner_record_cookie.token_source_amount as f32 * 0.29) as u64,
+        proposal_account.options[1].vote_weight
+    );
+    assert_eq!(
+        (token_owner_record_cookie.token_source_amount as f32 * 0.41) as u64,
+        proposal_account.options[2].vote_weight
+    );
+    assert_eq!(0_u64, proposal_account.options[3].vote_weight);
+
+    // None executable proposal transitions to Completed when vote is finalized
+    assert_eq!(ProposalState::Completed, proposal_account.state);
+}
+
+#[tokio::test]
+async fn test_vote_multi_weighted_choice_proposal_with_partial_success() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_mint_cookie = governance_test.with_governed_mint().await;
+
+    // 100 tokens each, sum 300 tokens
+    let token_owner_record_cookie1 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+    let token_owner_record_cookie2 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+    let token_owner_record_cookie3 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // 60 tokes approval quorum as 20% of 300 is 60
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.community_vote_threshold = VoteThreshold::YesVotePercentage(20);
+
+    let mut governance_cookie = governance_test
+        .with_mint_governance_using_config(
+            &realm_cookie,
+            &governed_mint_cookie,
+            &token_owner_record_cookie1,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_multi_option_proposal(
+            &token_owner_record_cookie1,
+            &mut governance_cookie,
+            vec![
+                "option 1".to_string(),
+                "option 2".to_string(),
+                "option 3".to_string(),
+                "option 4".to_string(),
+            ],
+            true,
+            VoteType::MultiWeightedChoice {
+                max_winning_options: 4,
+                max_voter_options: 4,
+            },
+        )
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie1 = governance_test
+        .with_mint_tokens_transaction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie1,
+            0,
+            Some(0),
+            None,
+        )
+        .await
+        .unwrap();
+    let proposal_transaction_cookie2 = governance_test
+        .with_mint_tokens_transaction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie1,
+            1,
+            Some(0),
+            None,
+        )
+        .await
+        .unwrap();
+    let proposal_transaction_cookie3 = governance_test
+        .with_mint_tokens_transaction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie1,
+            2,
+            Some(0),
+            None,
+        )
+        .await
+        .unwrap();
+    let proposal_transaction_cookie4 = governance_test
+        .with_mint_tokens_transaction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie1,
+            3,
+            Some(0),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(&proposal_cookie, &token_owner_record_cookie1)
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    // vote1:
+    //   deny: 100
+    // vote2 + vote3:
+    //   choice 1: 0 -> Defeated
+    //   choice 2: 91 -> Defeated (91 is over 60, 20% from 300, but deny overrules)
+    //   choice 3: 101 -> Success
+    //   choice 4: 8 -> Defeated (below of 60)
+
+    let vote1 = Vote::Approve(vec![
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 0,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 30,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 70,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 0,
+        },
+    ]);
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie1, vote1)
+        .await
+        .expect("Voting the vote 1 of owner 1 should succeed");
+
+    let vote2 = Vote::Approve(vec![
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 0,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 61,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 31,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 8,
+        },
+    ]);
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie2, vote2)
+        .await
+        .expect("Voting the vote 1 of owner 1 should succeed");
+
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie3, Vote::Deny)
+        .await
+        .expect("Casting deny vote of owner 3 should succeed");
+
+    // Advance timestamp past max_voting_time
+    governance_test
+        .advance_clock_by_min_timespan(governance_cookie.account.config.max_voting_time as u64)
+        .await;
+    governance_test
+        .finalize_vote(&realm_cookie, &proposal_cookie, None)
+        .await
+        .unwrap();
+    // Advance timestamp past hold_up_time
+    governance_test
+        .advance_clock_by_min_timespan(proposal_transaction_cookie1.account.hold_up_time as u64)
+        .await;
+
+    let mut proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Succeeded, proposal_account.state);
+
+    // Act
+    let transaction1_err = governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie1)
+        .await
+        .expect_err("Choice 1 should fail to execute, it hasn't got enough votes");
+    let transaction2_err = governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie2)
+        .await
+        .expect_err("Choice 2 should fail to execute, it hasn't got enough votes");
+    governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie3)
+        .await
+        .expect("Choice 3 should be executed as it won the poll");
+    let transaction4_err = governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie4)
+        .await
+        .expect_err("Choice 4 should be executed as the winner has been executed already");
+
+    // Assert
+    proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Completed, proposal_account.state);
+
+    assert_eq!(
+        transaction1_err,
+        GovernanceError::CannotExecuteDefeatedOption.into()
+    );
+    assert_eq!(
+        transaction2_err,
+        GovernanceError::CannotExecuteDefeatedOption.into()
+    );
+    assert_eq!(
+        transaction4_err,
+        GovernanceError::InvalidStateCannotExecuteTransaction.into()
+    );
+}
+
+#[tokio::test]
+async fn test_vote_multi_weighted_choice_proposal_with_multi_success() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_mint_cookie = governance_test.with_governed_mint().await;
+
+    // 100 tokens each, sum 300 tokens
+    let token_owner_record_cookie1 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+    let token_owner_record_cookie2 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // 60 tokes approval quorum as 30% of 200 is 60
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.community_vote_threshold = VoteThreshold::YesVotePercentage(30);
+
+    let mut governance_cookie = governance_test
+        .with_mint_governance_using_config(
+            &realm_cookie,
+            &governed_mint_cookie,
+            &token_owner_record_cookie1,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_multi_option_proposal(
+            &token_owner_record_cookie1,
+            &mut governance_cookie,
+            vec![
+                "option 1".to_string(),
+                "option 2".to_string(),
+                "option 3".to_string(),
+            ],
+            true,
+            VoteType::MultiWeightedChoice {
+                max_winning_options: 3,
+                max_voter_options: 3,
+            },
+        )
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie1 = governance_test
+        .with_mint_tokens_transaction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie1,
+            0,
+            Some(0),
+            None,
+        )
+        .await
+        .unwrap();
+    let proposal_transaction_cookie2 = governance_test
+        .with_mint_tokens_transaction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie1,
+            1,
+            Some(0),
+            None,
+        )
+        .await
+        .unwrap();
+    let proposal_transaction_cookie3 = governance_test
+        .with_mint_tokens_transaction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie1,
+            2,
+            Some(0),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(&proposal_cookie, &token_owner_record_cookie1)
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    // vote1 + vote2:
+    //   choice 1: 28 -> Defeated (below 60)
+    //   choice 2: 105 -> Success
+    //   choice 3: 61 -> Success
+
+    let vote1 = Vote::Approve(vec![
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 14,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 55,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 31,
+        },
+    ]);
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie1, vote1)
+        .await
+        .expect("Voting the vote 1 of owner 1 should succeed");
+
+    let vote2 = Vote::Approve(vec![
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 20,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 50,
+        },
+        VoteChoice {
+            rank: 0,
+            weight_percentage: 30,
+        },
+    ]);
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie2, vote2)
+        .await
+        .expect("Voting the vote 1 of owner 1 should succeed");
+
+    // Advance timestamp past max_voting_time
+    governance_test
+        .advance_clock_by_min_timespan(governance_cookie.account.config.max_voting_time as u64)
+        .await;
+    governance_test
+        .finalize_vote(&realm_cookie, &proposal_cookie, None)
+        .await
+        .unwrap();
+    // Advance timestamp past hold_up_time
+    governance_test
+        .advance_clock_by_min_timespan(proposal_transaction_cookie1.account.hold_up_time as u64)
+        .await;
+
+    let mut proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Succeeded, proposal_account.state);
+
+    // Act
+    let transaction1_err = governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie1)
+        .await
+        .expect_err("Choice 1 should fail to execute, it hasn't got enough votes");
+    governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie2)
+        .await
+        .expect("Choice 2 should be executed as it passed the poll");
+    governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie3)
+        .await
+        .expect("Choice 3 should be executed as it passed the poll");
+
+    // Assert
+    proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Completed, proposal_account.state);
+
+    assert_eq!(
+        transaction1_err,
+        GovernanceError::CannotExecuteDefeatedOption.into()
+    );
+}
+
+#[tokio::test]
+async fn test_vote_multi_weighted_choice_proposal_executable_with_full_deny() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_mint_cookie = governance_test.with_governed_mint().await;
+
+    // 100 tokens
+    let token_owner_record_cookie1 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // 100 tokens
+    let token_owner_record_cookie2 = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_config = governance_test.get_default_governance_config();
+    governance_config.community_vote_threshold = VoteThreshold::YesVotePercentage(3);
+
+    let mut governance_cookie = governance_test
+        .with_mint_governance_using_config(
+            &realm_cookie,
+            &governed_mint_cookie,
+            &token_owner_record_cookie1,
+            &governance_config,
+        )
+        .await
+        .unwrap();
+
+    let mut proposal_cookie = governance_test
+        .with_multi_option_proposal(
+            &token_owner_record_cookie1,
+            &mut governance_cookie,
+            vec!["option 1".to_string(), "option 2".to_string()],
+            true,
+            VoteType::MultiWeightedChoice {
+                max_winning_options: 2,
+                max_voter_options: 2,
+            },
+        )
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie1 = governance_test
+        .with_mint_tokens_transaction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie1,
+            0,
+            Some(0),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let proposal_transaction_cookie2 = governance_test
+        .with_mint_tokens_transaction(
+            &governed_mint_cookie,
+            &mut proposal_cookie,
+            &token_owner_record_cookie1,
+            1,
+            Some(0),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(&proposal_cookie, &token_owner_record_cookie1)
+        .await
+        .unwrap();
+
+    governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .unwrap();
+
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie1, Vote::Deny)
+        .await
+        .expect("Casting deny vote for owner 1 should succeed");
+    governance_test
+        .with_cast_vote(&proposal_cookie, &token_owner_record_cookie2, Vote::Deny)
+        .await
+        .expect("Casting deny vote for owner 1 should succeed");
+
+    // Advance timestamp past max_voting_time
+    governance_test
+        .advance_clock_by_min_timespan(governance_cookie.account.config.max_voting_time as u64)
+        .await;
+
+    governance_test
+        .finalize_vote(&realm_cookie, &proposal_cookie, None)
+        .await
+        .unwrap();
+
+    // Advance timestamp past hold_up_time
+    governance_test
+        .advance_clock_by_min_timespan(proposal_transaction_cookie1.account.hold_up_time as u64)
+        .await;
+
+    let proposal_account = governance_test
+        .get_proposal_account(&proposal_cookie.address)
+        .await;
+
+    assert_eq!(ProposalState::Defeated, proposal_account.state);
+
+    // Act
+    let transaction1_err = governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie1)
+        .await
+        .expect_err("The proposal was denied, error on choice 1 execution expected");
+    let transaction2_err = governance_test
+        .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie2)
+        .await
+        .expect_err("The proposal was denied, error on choice 2 execution expected");
+
+    // Assert
+    assert_eq!(
+        transaction1_err,
+        GovernanceError::InvalidStateCannotExecuteTransaction.into()
+    );
+    assert_eq!(
+        transaction2_err,
+        GovernanceError::InvalidStateCannotExecuteTransaction.into()
+    );
+}

--- a/governance/program/tests/use_proposals_with_multiple_options.rs
+++ b/governance/program/tests/use_proposals_with_multiple_options.rs
@@ -94,6 +94,7 @@ async fn test_create_proposal_with_multiple_choice_options_and_without_deny_opti
             false,
             VoteType::MultiChoice {
                 choice_type: MultiChoiceType::Approval,
+                min_voter_options: 1,
                 max_winning_options: 2,
                 max_voter_options: 2,
             },
@@ -109,6 +110,7 @@ async fn test_create_proposal_with_multiple_choice_options_and_without_deny_opti
         proposal_account.vote_type,
         VoteType::MultiChoice {
             choice_type: MultiChoiceType::Approval,
+            min_voter_options: 1,
             max_winning_options: 2,
             max_voter_options: 2,
         }
@@ -364,6 +366,7 @@ async fn test_vote_on_none_executable_multi_choice_proposal_with_multiple_option
             false,
             VoteType::MultiChoice {
                 choice_type: MultiChoiceType::Approval,
+                min_voter_options: 1,
                 max_winning_options: 3,
                 max_voter_options: 3,
             },
@@ -493,6 +496,7 @@ async fn test_vote_on_executable_proposal_with_multiple_options_and_partial_succ
             true,
             VoteType::MultiChoice {
                 choice_type: MultiChoiceType::Approval,
+                min_voter_options: 1,
                 max_winning_options: 3,
                 max_voter_options: 3,
             },
@@ -655,6 +659,7 @@ async fn test_execute_proposal_with_multiple_options_and_partial_success() {
             true,
             VoteType::MultiChoice {
                 choice_type: MultiChoiceType::Approval,
+                min_voter_options: 1,
                 max_winning_options: 3,
                 max_voter_options: 3,
             },
@@ -863,6 +868,7 @@ async fn test_try_execute_proposal_with_multiple_options_and_full_deny() {
             true,
             VoteType::MultiChoice {
                 choice_type: MultiChoiceType::Approval,
+                min_voter_options: 1,
                 max_winning_options: 3,
                 max_voter_options: 3,
             },
@@ -1029,6 +1035,7 @@ async fn test_create_proposal_with_10_options_and_cast_vote() {
             false,
             VoteType::MultiChoice {
                 choice_type: MultiChoiceType::Approval,
+                min_voter_options: 1,
                 max_winning_options: options_len,
                 max_voter_options: options_len,
             },
@@ -1080,6 +1087,7 @@ async fn test_create_proposal_with_10_options_and_cast_vote() {
         proposal_account.vote_type,
         VoteType::MultiChoice {
             choice_type: MultiChoiceType::Approval,
+            min_voter_options: 1,
             max_winning_options: options_len,
             max_voter_options: options_len,
         }
@@ -1128,6 +1136,7 @@ async fn test_vote_multi_weighted_choice_proposal_non_executable() {
             false,
             VoteType::MultiChoice {
                 choice_type: MultiChoiceType::Weighted,
+                min_voter_options: 1,
                 max_winning_options: 4,
                 max_voter_options: 4,
             },
@@ -1266,6 +1275,7 @@ async fn test_vote_multi_weighted_choice_proposal_with_partial_success() {
             true,
             VoteType::MultiChoice {
                 choice_type: MultiChoiceType::Weighted,
+                min_voter_options: 1,
                 max_winning_options: 4,
                 max_voter_options: 4,
             },
@@ -1486,6 +1496,7 @@ async fn test_vote_multi_weighted_choice_proposal_with_multi_success() {
             true,
             VoteType::MultiChoice {
                 choice_type: MultiChoiceType::Weighted,
+                min_voter_options: 1,
                 max_winning_options: 3,
                 max_voter_options: 3,
             },
@@ -1665,6 +1676,7 @@ async fn test_vote_multi_weighted_choice_proposal_executable_with_full_deny() {
             true,
             VoteType::MultiChoice {
                 choice_type: MultiChoiceType::Weighted,
+                min_voter_options: 1,
                 max_winning_options: 2,
                 max_voter_options: 2,
             },

--- a/governance/program/tests/use_proposals_with_multiple_options.rs
+++ b/governance/program/tests/use_proposals_with_multiple_options.rs
@@ -93,7 +93,7 @@ async fn test_create_proposal_with_multiple_choice_options_and_without_deny_opti
             options,
             false,
             VoteType::MultiChoice {
-                choice_type: MultiChoiceType::Approval,
+                choice_type: MultiChoiceType::FullWeight,
                 min_voter_options: 1,
                 max_winning_options: 2,
                 max_voter_options: 2,
@@ -109,7 +109,7 @@ async fn test_create_proposal_with_multiple_choice_options_and_without_deny_opti
     assert_eq!(
         proposal_account.vote_type,
         VoteType::MultiChoice {
-            choice_type: MultiChoiceType::Approval,
+            choice_type: MultiChoiceType::FullWeight,
             min_voter_options: 1,
             max_winning_options: 2,
             max_voter_options: 2,
@@ -365,7 +365,7 @@ async fn test_vote_on_none_executable_multi_choice_proposal_with_multiple_option
             ],
             false,
             VoteType::MultiChoice {
-                choice_type: MultiChoiceType::Approval,
+                choice_type: MultiChoiceType::FullWeight,
                 min_voter_options: 1,
                 max_winning_options: 3,
                 max_voter_options: 3,
@@ -495,7 +495,7 @@ async fn test_vote_on_executable_proposal_with_multiple_options_and_partial_succ
             ],
             true,
             VoteType::MultiChoice {
-                choice_type: MultiChoiceType::Approval,
+                choice_type: MultiChoiceType::FullWeight,
                 min_voter_options: 1,
                 max_winning_options: 3,
                 max_voter_options: 3,
@@ -658,7 +658,7 @@ async fn test_execute_proposal_with_multiple_options_and_partial_success() {
             ],
             true,
             VoteType::MultiChoice {
-                choice_type: MultiChoiceType::Approval,
+                choice_type: MultiChoiceType::FullWeight,
                 min_voter_options: 1,
                 max_winning_options: 3,
                 max_voter_options: 3,
@@ -867,7 +867,7 @@ async fn test_try_execute_proposal_with_multiple_options_and_full_deny() {
             ],
             true,
             VoteType::MultiChoice {
-                choice_type: MultiChoiceType::Approval,
+                choice_type: MultiChoiceType::FullWeight,
                 min_voter_options: 1,
                 max_winning_options: 3,
                 max_voter_options: 3,
@@ -1034,7 +1034,7 @@ async fn test_create_proposal_with_10_options_and_cast_vote() {
             options,
             false,
             VoteType::MultiChoice {
-                choice_type: MultiChoiceType::Approval,
+                choice_type: MultiChoiceType::FullWeight,
                 min_voter_options: 1,
                 max_winning_options: options_len,
                 max_voter_options: options_len,
@@ -1086,7 +1086,7 @@ async fn test_create_proposal_with_10_options_and_cast_vote() {
     assert_eq!(
         proposal_account.vote_type,
         VoteType::MultiChoice {
-            choice_type: MultiChoiceType::Approval,
+            choice_type: MultiChoiceType::FullWeight,
             min_voter_options: 1,
             max_winning_options: options_len,
             max_voter_options: options_len,


### PR DESCRIPTION
#### Summary
Implementation of `Weighted` multi choice vote type. The implementation makes the `MultiChoice` `VoteType` to be of either `Approval` type (existing behaviour) or `Weighted` that makes possible to vote with percentage of the full vote weight.

####  Backward compatibility notes
The change is not backward compatible for multi choice proposals. However the option has never been exposed in the UI and hence hasn't been used. In case there is an unknown instance of spl-gov which uses it it would only affect historical proposals which couldn't be loaded