### PR TITLE
Account Compression: Add CMT checks for out of bounds leaf indices and initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5757,7 +5757,7 @@ dependencies = [
 
 [[package]]
 name = "spl-concurrent-merkle-tree"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bytemuck",
  "rand 0.7.3",

--- a/account-compression/Cargo.lock
+++ b/account-compression/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "spl-concurrent-merkle-tree"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bytemuck",
  "solana-program",

--- a/account-compression/programs/account-compression/Cargo.toml
+++ b/account-compression/programs/account-compression/Cargo.toml
@@ -20,7 +20,7 @@ default = []
 [dependencies]
 anchor-lang = "0.25.0"
 bytemuck = "1.8.0"
-spl-concurrent-merkle-tree = {  path="../../../libraries/concurrent-merkle-tree", features = [ "sol-log" ]}
+spl-concurrent-merkle-tree = { version="0.1.2", path="../../../libraries/concurrent-merkle-tree", features = [ "sol-log" ]}
 spl-noop = { version = "0.1.3", path="../noop", features = [ "no-entrypoint" ]}
 
 [profile.release]

--- a/account-compression/programs/account-compression/Cargo.toml
+++ b/account-compression/programs/account-compression/Cargo.toml
@@ -20,7 +20,7 @@ default = []
 [dependencies]
 anchor-lang = "0.25.0"
 bytemuck = "1.8.0"
-spl-concurrent-merkle-tree = { version = "0.1.1", path="../../../libraries/concurrent-merkle-tree", features = [ "sol-log" ]}
+spl-concurrent-merkle-tree = {  path="../../../libraries/concurrent-merkle-tree", features = [ "sol-log" ]}
 spl-noop = { version = "0.1.3", path="../noop", features = [ "no-entrypoint" ]}
 
 [profile.release]

--- a/account-compression/programs/account-compression/src/error.rs
+++ b/account-compression/programs/account-compression/src/error.rs
@@ -14,11 +14,6 @@ pub enum AccountCompressionError {
     #[msg("Incorrect leaf length. Expected vec of 32 bytes")]
     IncorrectLeafLength,
 
-    /// Tree information cannot be processed because the provided leaf_index
-    /// is out of bounds of tree's maximum leaf capacity
-    #[msg("Leaf index of concurrent merkle tree is out of bounds")]
-    LeafIndexOutOfBounds,
-
     /// A modification to the tree was invalid and a changelog was not emitted.
     /// The proof may be invalid or out-of-date, or the provided leaf hash was invalid.
     #[msg("Concurrent merkle tree error")]
@@ -47,6 +42,11 @@ pub enum AccountCompressionError {
     /// Incorrect account type
     #[msg("Account provided has incorrect account type")]
     IncorrectAccountType,
+
+    /// Tree information cannot be processed because the provided leaf_index
+    /// is out of bounds of tree's maximum leaf capacity
+    #[msg("Leaf index of concurrent merkle tree is out of bounds")]
+    LeafIndexOutOfBounds,
 }
 
 impl From<&ConcurrentMerkleTreeError> for AccountCompressionError {

--- a/account-compression/programs/account-compression/src/error.rs
+++ b/account-compression/programs/account-compression/src/error.rs
@@ -14,6 +14,11 @@ pub enum AccountCompressionError {
     #[msg("Incorrect leaf length. Expected vec of 32 bytes")]
     IncorrectLeafLength,
 
+    /// Tree information cannot be processed because the provided leaf_index
+    /// is out of bounds of tree's maximum leaf capacity
+    #[msg("Leaf index of concurrent merkle tree is out of bounds")]
+    LeafIndexOutOfBounds,
+
     /// A modification to the tree was invalid and a changelog was not emitted.
     /// The proof may be invalid or out-of-date, or the provided leaf hash was invalid.
     #[msg("Concurrent merkle tree error")]

--- a/account-compression/programs/account-compression/src/lib.rs
+++ b/account-compression/programs/account-compression/src/lib.rs
@@ -352,6 +352,7 @@ pub mod spl_account_compression {
 
         let header = ConcurrentMerkleTreeHeader::try_from_slice(header_bytes)?;
         header.assert_valid_authority(&ctx.accounts.authority.key())?;
+        header.assert_valid_leaf_index(index)?;
 
         let merkle_tree_size = merkle_tree_get_size(&header)?;
         let (tree_bytes, canopy_bytes) = rest.split_at_mut(merkle_tree_size);
@@ -428,6 +429,7 @@ pub mod spl_account_compression {
 
         let header = ConcurrentMerkleTreeHeader::try_from_slice(header_bytes)?;
         header.assert_valid()?;
+        header.assert_valid_leaf_index(index)?;
 
         let merkle_tree_size = merkle_tree_get_size(&header)?;
         let (tree_bytes, canopy_bytes) = rest.split_at_mut(merkle_tree_size);
@@ -498,6 +500,7 @@ pub mod spl_account_compression {
 
         let header = ConcurrentMerkleTreeHeader::try_from_slice(header_bytes)?;
         header.assert_valid_authority(&ctx.accounts.authority.key())?;
+        header.assert_valid_leaf_index(index)?;
 
         let merkle_tree_size = merkle_tree_get_size(&header)?;
         let (tree_bytes, canopy_bytes) = rest.split_at_mut(merkle_tree_size);

--- a/account-compression/programs/account-compression/src/state/concurrent_merkle_tree_header.rs
+++ b/account-compression/programs/account-compression/src/state/concurrent_merkle_tree_header.rs
@@ -139,4 +139,11 @@ impl ConcurrentMerkleTreeHeader {
         }
         Ok(())
     }
+
+    pub fn assert_valid_leaf_index(&self, leaf_index: u32) -> Result<()> {
+        if leaf_index >= (1 << self.get_max_depth()) {
+            return Err(AccountCompressionError::LeafIndexOutOfBounds.into());
+        }
+        Ok(())
+    }
 }

--- a/account-compression/sdk/idl/spl_account_compression.json
+++ b/account-compression/sdk/idl/spl_account_compression.json
@@ -590,36 +590,41 @@
     },
     {
       "code": 6001,
+      "name": "LeafIndexOutOfBounds",
+      "msg": "Leaf index of concurrent merkle tree is out of bounds"
+    },
+    {
+      "code": 6002,
       "name": "ConcurrentMerkleTreeError",
       "msg": "Concurrent merkle tree error"
     },
     {
-      "code": 6002,
+      "code": 6003,
       "name": "ZeroCopyError",
       "msg": "Issue zero copying concurrent merkle tree data"
     },
     {
-      "code": 6003,
+      "code": 6004,
       "name": "ConcurrentMerkleTreeConstantsError",
       "msg": "An unsupported max depth or max buffer size constant was provided"
     },
     {
-      "code": 6004,
+      "code": 6005,
       "name": "CanopyLengthMismatch",
       "msg": "Expected a different byte length for the merkle tree canopy"
     },
     {
-      "code": 6005,
+      "code": 6006,
       "name": "IncorrectAuthority",
       "msg": "Provided authority does not match expected tree authority"
     },
     {
-      "code": 6006,
+      "code": 6007,
       "name": "IncorrectAccountOwner",
       "msg": "Account is owned by a different program, expected it to be owned by this program"
     },
     {
-      "code": 6007,
+      "code": 6008,
       "name": "IncorrectAccountType",
       "msg": "Account provided has incorrect account type"
     }

--- a/account-compression/sdk/idl/spl_account_compression.json
+++ b/account-compression/sdk/idl/spl_account_compression.json
@@ -590,43 +590,43 @@
     },
     {
       "code": 6001,
-      "name": "LeafIndexOutOfBounds",
-      "msg": "Leaf index of concurrent merkle tree is out of bounds"
-    },
-    {
-      "code": 6002,
       "name": "ConcurrentMerkleTreeError",
       "msg": "Concurrent merkle tree error"
     },
     {
-      "code": 6003,
+      "code": 6002,
       "name": "ZeroCopyError",
       "msg": "Issue zero copying concurrent merkle tree data"
     },
     {
-      "code": 6004,
+      "code": 6003,
       "name": "ConcurrentMerkleTreeConstantsError",
       "msg": "An unsupported max depth or max buffer size constant was provided"
     },
     {
-      "code": 6005,
+      "code": 6004,
       "name": "CanopyLengthMismatch",
       "msg": "Expected a different byte length for the merkle tree canopy"
     },
     {
-      "code": 6006,
+      "code": 6005,
       "name": "IncorrectAuthority",
       "msg": "Provided authority does not match expected tree authority"
     },
     {
-      "code": 6007,
+      "code": 6006,
       "name": "IncorrectAccountOwner",
       "msg": "Account is owned by a different program, expected it to be owned by this program"
     },
     {
-      "code": 6008,
+      "code": 6007,
       "name": "IncorrectAccountType",
       "msg": "Account provided has incorrect account type"
+    },
+    {
+      "code": 6008,
+      "name": "LeafIndexOutOfBounds",
+      "msg": "Leaf index of concurrent merkle tree is out of bounds"
     }
   ],
   "metadata": {

--- a/account-compression/sdk/package.json
+++ b/account-compression/sdk/package.json
@@ -38,8 +38,10 @@
     "run-tests": "jest tests --detectOpenHandles",
     "run-tests:events": "jest tests/events --detectOpenHandles",
     "run-tests:accounts": "jest tests/accounts --detectOpenHandles",
+    "run-tests:e2e": "jest accountCompression.test.ts --detectOpenHandles",
     "test:events": "start-server-and-test start-validator http://localhost:8899/health run-tests:events",
     "test:accounts": "start-server-and-test start-validator http://localhost:8899/health run-tests:accounts",
+    "test:e2e": "start-server-and-test start-validator http://localhost:8899/health run-tests:e2e",
     "test": "start-server-and-test start-validator http://localhost:8899/health run-tests"
   },
   "dependencies": {

--- a/account-compression/sdk/src/generated/errors/index.ts
+++ b/account-compression/sdk/src/generated/errors/index.ts
@@ -35,13 +35,36 @@ createErrorFromNameLookup.set(
 )
 
 /**
+ * LeafIndexOutOfBounds: 'Leaf index of concurrent merkle tree is out of bounds'
+ *
+ * @category Errors
+ * @category generated
+ */
+export class LeafIndexOutOfBoundsError extends Error {
+  readonly code: number = 0x1771
+  readonly name: string = 'LeafIndexOutOfBounds'
+  constructor() {
+    super('Leaf index of concurrent merkle tree is out of bounds')
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, LeafIndexOutOfBoundsError)
+    }
+  }
+}
+
+createErrorFromCodeLookup.set(0x1771, () => new LeafIndexOutOfBoundsError())
+createErrorFromNameLookup.set(
+  'LeafIndexOutOfBounds',
+  () => new LeafIndexOutOfBoundsError()
+)
+
+/**
  * ConcurrentMerkleTreeError: 'Concurrent merkle tree error'
  *
  * @category Errors
  * @category generated
  */
 export class ConcurrentMerkleTreeErrorError extends Error {
-  readonly code: number = 0x1771
+  readonly code: number = 0x1772
   readonly name: string = 'ConcurrentMerkleTreeError'
   constructor() {
     super('Concurrent merkle tree error')
@@ -52,7 +75,7 @@ export class ConcurrentMerkleTreeErrorError extends Error {
 }
 
 createErrorFromCodeLookup.set(
-  0x1771,
+  0x1772,
   () => new ConcurrentMerkleTreeErrorError()
 )
 createErrorFromNameLookup.set(
@@ -67,7 +90,7 @@ createErrorFromNameLookup.set(
  * @category generated
  */
 export class ZeroCopyErrorError extends Error {
-  readonly code: number = 0x1772
+  readonly code: number = 0x1773
   readonly name: string = 'ZeroCopyError'
   constructor() {
     super('Issue zero copying concurrent merkle tree data')
@@ -77,7 +100,7 @@ export class ZeroCopyErrorError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x1772, () => new ZeroCopyErrorError())
+createErrorFromCodeLookup.set(0x1773, () => new ZeroCopyErrorError())
 createErrorFromNameLookup.set('ZeroCopyError', () => new ZeroCopyErrorError())
 
 /**
@@ -87,7 +110,7 @@ createErrorFromNameLookup.set('ZeroCopyError', () => new ZeroCopyErrorError())
  * @category generated
  */
 export class ConcurrentMerkleTreeConstantsErrorError extends Error {
-  readonly code: number = 0x1773
+  readonly code: number = 0x1774
   readonly name: string = 'ConcurrentMerkleTreeConstantsError'
   constructor() {
     super('An unsupported max depth or max buffer size constant was provided')
@@ -98,7 +121,7 @@ export class ConcurrentMerkleTreeConstantsErrorError extends Error {
 }
 
 createErrorFromCodeLookup.set(
-  0x1773,
+  0x1774,
   () => new ConcurrentMerkleTreeConstantsErrorError()
 )
 createErrorFromNameLookup.set(
@@ -113,7 +136,7 @@ createErrorFromNameLookup.set(
  * @category generated
  */
 export class CanopyLengthMismatchError extends Error {
-  readonly code: number = 0x1774
+  readonly code: number = 0x1775
   readonly name: string = 'CanopyLengthMismatch'
   constructor() {
     super('Expected a different byte length for the merkle tree canopy')
@@ -123,7 +146,7 @@ export class CanopyLengthMismatchError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x1774, () => new CanopyLengthMismatchError())
+createErrorFromCodeLookup.set(0x1775, () => new CanopyLengthMismatchError())
 createErrorFromNameLookup.set(
   'CanopyLengthMismatch',
   () => new CanopyLengthMismatchError()
@@ -136,7 +159,7 @@ createErrorFromNameLookup.set(
  * @category generated
  */
 export class IncorrectAuthorityError extends Error {
-  readonly code: number = 0x1775
+  readonly code: number = 0x1776
   readonly name: string = 'IncorrectAuthority'
   constructor() {
     super('Provided authority does not match expected tree authority')
@@ -146,7 +169,7 @@ export class IncorrectAuthorityError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x1775, () => new IncorrectAuthorityError())
+createErrorFromCodeLookup.set(0x1776, () => new IncorrectAuthorityError())
 createErrorFromNameLookup.set(
   'IncorrectAuthority',
   () => new IncorrectAuthorityError()
@@ -159,7 +182,7 @@ createErrorFromNameLookup.set(
  * @category generated
  */
 export class IncorrectAccountOwnerError extends Error {
-  readonly code: number = 0x1776
+  readonly code: number = 0x1777
   readonly name: string = 'IncorrectAccountOwner'
   constructor() {
     super(
@@ -171,7 +194,7 @@ export class IncorrectAccountOwnerError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x1776, () => new IncorrectAccountOwnerError())
+createErrorFromCodeLookup.set(0x1777, () => new IncorrectAccountOwnerError())
 createErrorFromNameLookup.set(
   'IncorrectAccountOwner',
   () => new IncorrectAccountOwnerError()
@@ -184,7 +207,7 @@ createErrorFromNameLookup.set(
  * @category generated
  */
 export class IncorrectAccountTypeError extends Error {
-  readonly code: number = 0x1777
+  readonly code: number = 0x1778
   readonly name: string = 'IncorrectAccountType'
   constructor() {
     super('Account provided has incorrect account type')
@@ -194,7 +217,7 @@ export class IncorrectAccountTypeError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x1777, () => new IncorrectAccountTypeError())
+createErrorFromCodeLookup.set(0x1778, () => new IncorrectAccountTypeError())
 createErrorFromNameLookup.set(
   'IncorrectAccountType',
   () => new IncorrectAccountTypeError()

--- a/account-compression/sdk/src/generated/errors/index.ts
+++ b/account-compression/sdk/src/generated/errors/index.ts
@@ -35,36 +35,13 @@ createErrorFromNameLookup.set(
 )
 
 /**
- * LeafIndexOutOfBounds: 'Leaf index of concurrent merkle tree is out of bounds'
- *
- * @category Errors
- * @category generated
- */
-export class LeafIndexOutOfBoundsError extends Error {
-  readonly code: number = 0x1771
-  readonly name: string = 'LeafIndexOutOfBounds'
-  constructor() {
-    super('Leaf index of concurrent merkle tree is out of bounds')
-    if (typeof Error.captureStackTrace === 'function') {
-      Error.captureStackTrace(this, LeafIndexOutOfBoundsError)
-    }
-  }
-}
-
-createErrorFromCodeLookup.set(0x1771, () => new LeafIndexOutOfBoundsError())
-createErrorFromNameLookup.set(
-  'LeafIndexOutOfBounds',
-  () => new LeafIndexOutOfBoundsError()
-)
-
-/**
  * ConcurrentMerkleTreeError: 'Concurrent merkle tree error'
  *
  * @category Errors
  * @category generated
  */
 export class ConcurrentMerkleTreeErrorError extends Error {
-  readonly code: number = 0x1772
+  readonly code: number = 0x1771
   readonly name: string = 'ConcurrentMerkleTreeError'
   constructor() {
     super('Concurrent merkle tree error')
@@ -75,7 +52,7 @@ export class ConcurrentMerkleTreeErrorError extends Error {
 }
 
 createErrorFromCodeLookup.set(
-  0x1772,
+  0x1771,
   () => new ConcurrentMerkleTreeErrorError()
 )
 createErrorFromNameLookup.set(
@@ -90,7 +67,7 @@ createErrorFromNameLookup.set(
  * @category generated
  */
 export class ZeroCopyErrorError extends Error {
-  readonly code: number = 0x1773
+  readonly code: number = 0x1772
   readonly name: string = 'ZeroCopyError'
   constructor() {
     super('Issue zero copying concurrent merkle tree data')
@@ -100,7 +77,7 @@ export class ZeroCopyErrorError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x1773, () => new ZeroCopyErrorError())
+createErrorFromCodeLookup.set(0x1772, () => new ZeroCopyErrorError())
 createErrorFromNameLookup.set('ZeroCopyError', () => new ZeroCopyErrorError())
 
 /**
@@ -110,7 +87,7 @@ createErrorFromNameLookup.set('ZeroCopyError', () => new ZeroCopyErrorError())
  * @category generated
  */
 export class ConcurrentMerkleTreeConstantsErrorError extends Error {
-  readonly code: number = 0x1774
+  readonly code: number = 0x1773
   readonly name: string = 'ConcurrentMerkleTreeConstantsError'
   constructor() {
     super('An unsupported max depth or max buffer size constant was provided')
@@ -121,7 +98,7 @@ export class ConcurrentMerkleTreeConstantsErrorError extends Error {
 }
 
 createErrorFromCodeLookup.set(
-  0x1774,
+  0x1773,
   () => new ConcurrentMerkleTreeConstantsErrorError()
 )
 createErrorFromNameLookup.set(
@@ -136,7 +113,7 @@ createErrorFromNameLookup.set(
  * @category generated
  */
 export class CanopyLengthMismatchError extends Error {
-  readonly code: number = 0x1775
+  readonly code: number = 0x1774
   readonly name: string = 'CanopyLengthMismatch'
   constructor() {
     super('Expected a different byte length for the merkle tree canopy')
@@ -146,7 +123,7 @@ export class CanopyLengthMismatchError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x1775, () => new CanopyLengthMismatchError())
+createErrorFromCodeLookup.set(0x1774, () => new CanopyLengthMismatchError())
 createErrorFromNameLookup.set(
   'CanopyLengthMismatch',
   () => new CanopyLengthMismatchError()
@@ -159,7 +136,7 @@ createErrorFromNameLookup.set(
  * @category generated
  */
 export class IncorrectAuthorityError extends Error {
-  readonly code: number = 0x1776
+  readonly code: number = 0x1775
   readonly name: string = 'IncorrectAuthority'
   constructor() {
     super('Provided authority does not match expected tree authority')
@@ -169,7 +146,7 @@ export class IncorrectAuthorityError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x1776, () => new IncorrectAuthorityError())
+createErrorFromCodeLookup.set(0x1775, () => new IncorrectAuthorityError())
 createErrorFromNameLookup.set(
   'IncorrectAuthority',
   () => new IncorrectAuthorityError()
@@ -182,7 +159,7 @@ createErrorFromNameLookup.set(
  * @category generated
  */
 export class IncorrectAccountOwnerError extends Error {
-  readonly code: number = 0x1777
+  readonly code: number = 0x1776
   readonly name: string = 'IncorrectAccountOwner'
   constructor() {
     super(
@@ -194,7 +171,7 @@ export class IncorrectAccountOwnerError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x1777, () => new IncorrectAccountOwnerError())
+createErrorFromCodeLookup.set(0x1776, () => new IncorrectAccountOwnerError())
 createErrorFromNameLookup.set(
   'IncorrectAccountOwner',
   () => new IncorrectAccountOwnerError()
@@ -207,7 +184,7 @@ createErrorFromNameLookup.set(
  * @category generated
  */
 export class IncorrectAccountTypeError extends Error {
-  readonly code: number = 0x1778
+  readonly code: number = 0x1777
   readonly name: string = 'IncorrectAccountType'
   constructor() {
     super('Account provided has incorrect account type')
@@ -217,10 +194,33 @@ export class IncorrectAccountTypeError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x1778, () => new IncorrectAccountTypeError())
+createErrorFromCodeLookup.set(0x1777, () => new IncorrectAccountTypeError())
 createErrorFromNameLookup.set(
   'IncorrectAccountType',
   () => new IncorrectAccountTypeError()
+)
+
+/**
+ * LeafIndexOutOfBounds: 'Leaf index of concurrent merkle tree is out of bounds'
+ *
+ * @category Errors
+ * @category generated
+ */
+export class LeafIndexOutOfBoundsError extends Error {
+  readonly code: number = 0x1778
+  readonly name: string = 'LeafIndexOutOfBounds'
+  constructor() {
+    super('Leaf index of concurrent merkle tree is out of bounds')
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, LeafIndexOutOfBoundsError)
+    }
+  }
+}
+
+createErrorFromCodeLookup.set(0x1778, () => new LeafIndexOutOfBoundsError())
+createErrorFromNameLookup.set(
+  'LeafIndexOutOfBounds',
+  () => new LeafIndexOutOfBoundsError()
 )
 
 /**

--- a/account-compression/sdk/tests/accountCompression.test.ts
+++ b/account-compression/sdk/tests/accountCompression.test.ts
@@ -662,7 +662,6 @@ describe("Account Compression", () => {
     });
     it(`Attempt to replace a leaf beyond the tree's capacity`, async () => {
       // Ensure that this fails
-
       let outOfBoundsIndex = 8;
       const index = outOfBoundsIndex;
       const newLeaf = hash(
@@ -688,9 +687,8 @@ describe("Account Compression", () => {
 
       try {
         await execute(provider, [replaceIx], [payer]);
-        throw Error("This replace instruction should have failed");
+        throw Error("This replace instruction should have failed because the leaf index is OOB");
       } catch (_e) { }
     });
   });
 });
-

--- a/account-compression/sdk/tests/accountCompression.test.ts
+++ b/account-compression/sdk/tests/accountCompression.test.ts
@@ -650,4 +650,47 @@ describe("Account Compression", () => {
       }
     });
   });
+  describe(`Having created a tree with 8 leaves`, () => {
+    beforeEach(async () => {
+      [cmtKeypair, offChainTree] = await createTreeOnChain(
+        provider,
+        payer,
+        1 << 3,
+        3,
+        8,
+      );
+    });
+    it(`Attempt to replace a leaf beyond the tree's capacity`, async () => {
+      // Ensure that this fails
+
+      let outOfBoundsIndex = 8;
+      const index = outOfBoundsIndex;
+      const newLeaf = hash(
+        payer.publicKey.toBuffer(),
+        Buffer.from(new BN(outOfBoundsIndex).toArray())
+      );
+      let proof;
+      let node;
+      node = offChainTree.leaves[outOfBoundsIndex - 1].node
+      proof = getProofOfLeaf(offChainTree, index - 1);
+
+      const replaceIx = createReplaceIx(
+        payer,
+        cmtKeypair.publicKey,
+        offChainTree.root,
+        node,
+        newLeaf,
+        index,
+        proof.map((treeNode) => {
+          return treeNode.node;
+        })
+      );
+
+      try {
+        await execute(provider, [replaceIx], [payer]);
+        throw Error("This replace instruction should have failed");
+      } catch (_e) { }
+    });
+  });
 });
+

--- a/account-compression/sdk/tests/utils.ts
+++ b/account-compression/sdk/tests/utils.ts
@@ -17,6 +17,7 @@ import {
     createInitEmptyMerkleTreeIx,
     createAllocTreeIx,
     createAppendIx,
+    ALL_DEPTH_SIZE_PAIRS,
 } from '../src'
 import {
     buildTree,

--- a/libraries/concurrent-merkle-tree/Cargo.toml
+++ b/libraries/concurrent-merkle-tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-concurrent-merkle-tree"
-version = "0.1.1"
+version = "0.1.2"
 description = "Solana Program Library Concurrent Merkle Tree"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/libraries/concurrent-merkle-tree/src/concurrent_merkle_tree.rs
+++ b/libraries/concurrent-merkle-tree/src/concurrent_merkle_tree.rs
@@ -1,5 +1,3 @@
-use std::cmp::max;
-
 use crate::{
     changelog::ChangeLog,
     error::ConcurrentMerkleTreeError,
@@ -25,7 +23,6 @@ fn check_leaf_index(leaf_index: u32, max_depth: usize) -> Result<(), ConcurrentM
     if leaf_index >= (1 << max_depth) {
         return Err(ConcurrentMerkleTreeError::LeafIndexOutOfBounds);
     }
-    solana_logging!("Fuck");
     Ok(())
 }
 

--- a/libraries/concurrent-merkle-tree/src/error.rs
+++ b/libraries/concurrent-merkle-tree/src/error.rs
@@ -31,10 +31,8 @@ pub enum ConcurrentMerkleTreeError {
     #[error("Root not found in changelog buffer")]
     RootNotFound,
 
-    /// Valid proof was passed to a leaf, but its value has changed since the proof was issued
-    #[error(
-        "Valid proof was passed to a leaf, but its value has changed since the proof was issued"
-    )]
+    /// The tree's current leaf value does not match the supplied proof's leaf value
+    #[error("This tree's current leaf value does not match the supplied proof's leaf value")]
     LeafContentsModified,
 
     /// Tree has at least 1 non-EMTPY leaf

--- a/libraries/concurrent-merkle-tree/src/error.rs
+++ b/libraries/concurrent-merkle-tree/src/error.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum ConcurrentMerkleTreeError {
     /// Received an index larger than the rightmost index
-    #[error("Received an index larger than the rightmost index")]
+    #[error("Received an index larger than the rightmost index, or greater than (1 << max_depth)")]
     LeafIndexOutOfBounds,
 
     /// Invalid root recomputed from proof

--- a/libraries/concurrent-merkle-tree/src/error.rs
+++ b/libraries/concurrent-merkle-tree/src/error.rs
@@ -23,6 +23,10 @@ pub enum ConcurrentMerkleTreeError {
     #[error("Tree already initialized")]
     TreeAlreadyInitialized,
 
+    /// This tree has not yet been initialized
+    #[error("Tree needs to be initialized before using")]
+    TreeNotInitialized,
+
     /// Root passed as argument cannot be found in stored changelog buffer
     #[error("Root not found in changelog buffer")]
     RootNotFound,

--- a/libraries/concurrent-merkle-tree/src/error.rs
+++ b/libraries/concurrent-merkle-tree/src/error.rs
@@ -1,7 +1,7 @@
 use thiserror::Error;
 
 /// Concurrent merkle tree operation errors
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum ConcurrentMerkleTreeError {
     /// Received an index larger than the rightmost index
     #[error("Received an index larger than the rightmost index, or greater than (1 << max_depth)")]

--- a/libraries/concurrent-merkle-tree/tests/tests.rs
+++ b/libraries/concurrent-merkle-tree/tests/tests.rs
@@ -40,6 +40,62 @@ async fn test_initialize() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_bypass_initialize() {
+    let (mut cmt, off_chain_tree) = setup();
+    let mut rng = thread_rng();
+    let leaf = rng.gen::<[u8; 32]>();
+
+    if let Err(ConcurrentMerkleTreeError::TreeNotInitialized) = cmt.append(leaf) {
+    } else {
+        panic!("Expected TreeNotInitialized error when appending to uninitialized tree")
+    }
+
+    if let Err(ConcurrentMerkleTreeError::TreeNotInitialized) = cmt.set_leaf(
+        off_chain_tree.get_root(),
+        [0; 32],
+        leaf,
+        &off_chain_tree.get_proof_of_leaf(0),
+        0,
+    ) {
+    } else {
+        panic!("Expected TreeNotInitialized error when appending to uninitialized tree")
+    }
+
+    if let Err(ConcurrentMerkleTreeError::TreeNotInitialized) = cmt.set_leaf(
+        off_chain_tree.get_root(),
+        [0; 32],
+        leaf,
+        &off_chain_tree.get_proof_of_leaf(0),
+        0,
+    ) {
+    } else {
+        panic!("Expected TreeNotInitialized error when setting a leaf on an uninitialized tree")
+    }
+
+    if let Err(ConcurrentMerkleTreeError::TreeNotInitialized) = cmt.prove_leaf(
+        off_chain_tree.get_root(),
+        leaf,
+        &off_chain_tree.get_proof_of_leaf(0),
+        0,
+    ) {
+    } else {
+        panic!(
+            "Expected TreeNotInitialized error when proving a leaf exists on an uninitialized tree"
+        )
+    }
+
+    if let Err(ConcurrentMerkleTreeError::TreeNotInitialized) = cmt.fill_empty_or_append(
+        off_chain_tree.get_root(),
+        leaf,
+        &off_chain_tree.get_proof_of_leaf(0),
+        0,
+    ) {
+    } else {
+        panic!("Expected TreeNotInitialized error when filling an empty leaf or appending to uninitialized tree")
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_append() {
     let (mut cmt, mut off_chain_tree) = setup();
     let mut rng = thread_rng();

--- a/libraries/concurrent-merkle-tree/tests/tests.rs
+++ b/libraries/concurrent-merkle-tree/tests/tests.rs
@@ -83,7 +83,8 @@ async fn test_bypass_initialize() {
             leaf,
             &off_chain_tree.get_proof_of_leaf(0),
             0,
-        ).unwrap_err(), 
+        )
+        .unwrap_err(),
         "Expected TreeNotInitialized error when filling an empty leaf or appending to uninitialized tree"
     );
 }

--- a/libraries/concurrent-merkle-tree/tests/tests.rs
+++ b/libraries/concurrent-merkle-tree/tests/tests.rs
@@ -45,54 +45,47 @@ async fn test_bypass_initialize() {
     let mut rng = thread_rng();
     let leaf = rng.gen::<[u8; 32]>();
 
-    if let Err(ConcurrentMerkleTreeError::TreeNotInitialized) = cmt.append(leaf) {
-    } else {
-        panic!("Expected TreeNotInitialized error when appending to uninitialized tree")
-    }
+    assert_eq!(
+        ConcurrentMerkleTreeError::TreeNotInitialized,
+        cmt.append(leaf).unwrap_err(),
+        "Expected TreeNotInitialized error when appending to uninitialized tree"
+    );
 
-    if let Err(ConcurrentMerkleTreeError::TreeNotInitialized) = cmt.set_leaf(
-        off_chain_tree.get_root(),
-        [0; 32],
-        leaf,
-        &off_chain_tree.get_proof_of_leaf(0),
-        0,
-    ) {
-    } else {
-        panic!("Expected TreeNotInitialized error when appending to uninitialized tree")
-    }
-
-    if let Err(ConcurrentMerkleTreeError::TreeNotInitialized) = cmt.set_leaf(
-        off_chain_tree.get_root(),
-        [0; 32],
-        leaf,
-        &off_chain_tree.get_proof_of_leaf(0),
-        0,
-    ) {
-    } else {
-        panic!("Expected TreeNotInitialized error when setting a leaf on an uninitialized tree")
-    }
-
-    if let Err(ConcurrentMerkleTreeError::TreeNotInitialized) = cmt.prove_leaf(
-        off_chain_tree.get_root(),
-        leaf,
-        &off_chain_tree.get_proof_of_leaf(0),
-        0,
-    ) {
-    } else {
-        panic!(
-            "Expected TreeNotInitialized error when proving a leaf exists on an uninitialized tree"
+    assert_eq!(
+        ConcurrentMerkleTreeError::TreeNotInitialized,
+        cmt.set_leaf(
+            off_chain_tree.get_root(),
+            [0; 32],
+            leaf,
+            &off_chain_tree.get_proof_of_leaf(0),
+            0
         )
-    }
+        .unwrap_err(),
+        "Expected TreeNotInitialized error when setting a leaf on an uninitialized tree"
+    );
 
-    if let Err(ConcurrentMerkleTreeError::TreeNotInitialized) = cmt.fill_empty_or_append(
-        off_chain_tree.get_root(),
-        leaf,
-        &off_chain_tree.get_proof_of_leaf(0),
-        0,
-    ) {
-    } else {
-        panic!("Expected TreeNotInitialized error when filling an empty leaf or appending to uninitialized tree")
-    }
+    assert_eq!(
+        ConcurrentMerkleTreeError::TreeNotInitialized,
+        cmt.prove_leaf(
+            off_chain_tree.get_root(),
+            leaf,
+            &off_chain_tree.get_proof_of_leaf(0),
+            0,
+        )
+        .unwrap_err(),
+        "Expected TreeNotInitialized error when proving a leaf exists on an uninitialized tree"
+    );
+
+    assert_eq!(
+        ConcurrentMerkleTreeError::TreeNotInitialized,
+        cmt.fill_empty_or_append(
+            off_chain_tree.get_root(),
+            leaf,
+            &off_chain_tree.get_proof_of_leaf(0),
+            0,
+        ).unwrap_err(), 
+        "Expected TreeNotInitialized error when filling an empty leaf or appending to uninitialized tree"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Add checks to prevent `leaf_index` accesses beyond `rightmost_proof.index`