### PR TITLE
token-2022: Add PermanentDelegate extension

### DIFF
--- a/associated-token-account/program-test/tests/extended_mint.rs
+++ b/associated-token-account/program-test/tests/extended_mint.rs
@@ -17,7 +17,9 @@ use {
     },
     spl_token_2022::{
         error::TokenError,
-        extension::{transfer_fee, ExtensionType, StateWithExtensionsOwned},
+        extension::{
+            transfer_fee, BaseStateWithExtensions, ExtensionType, StateWithExtensionsOwned,
+        },
         state::{Account, Mint},
     },
 };

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -33,7 +33,7 @@ use spl_token_2022::{
     error::TokenError,
     extension::{
         mint_close_authority::MintCloseAuthority, transfer_fee::TransferFeeConfig,
-        StateWithExtensions,
+        BaseStateWithExtensions, StateWithExtensions,
     },
     state::{Account, Mint},
 };

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -43,7 +43,7 @@ use spl_token_2022::{
         memo_transfer::MemoTransfer,
         mint_close_authority::MintCloseAuthority,
         transfer_fee::{TransferFeeAmount, TransferFeeConfig},
-        ExtensionType, StateWithExtensionsOwned,
+        BaseStateWithExtensions, ExtensionType, StateWithExtensionsOwned,
     },
     instruction::*,
     state::{Account, AccountState, Mint},

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -744,6 +744,7 @@ async fn command_authorize(
         AuthorityType::TransferFeeConfig => "transfer fee authority",
         AuthorityType::WithheldWithdraw => "withdraw withheld authority",
         AuthorityType::InterestRate => "interest rate authority",
+        AuthorityType::PermanentDelegate => "permanent delegate",
     };
 
     let (mint_pubkey, previous_authority) = if !config.sign_only {
@@ -781,6 +782,7 @@ async fn command_authorize(
                         Err(format!("Mint `{}` is not interest-bearing", account))
                     }
                 }
+                AuthorityType::PermanentDelegate => unimplemented!(),
             }?;
 
             Ok((account, previous_authority))
@@ -813,7 +815,8 @@ async fn command_authorize(
                 | AuthorityType::CloseMint
                 | AuthorityType::TransferFeeConfig
                 | AuthorityType::WithheldWithdraw
-                | AuthorityType::InterestRate => Err(format!(
+                | AuthorityType::InterestRate
+                | AuthorityType::PermanentDelegate => Err(format!(
                     "Authority type `{}` not supported for SPL Token accounts",
                     auth_str
                 )),
@@ -3662,6 +3665,7 @@ async fn process_command<'a>(
                 "transfer-fee-config" => AuthorityType::TransferFeeConfig,
                 "withheld-withdraw" => AuthorityType::WithheldWithdraw,
                 "interest-rate" => AuthorityType::InterestRate,
+                "permanent-delegate" => AuthorityType::PermanentDelegate,
                 _ => unreachable!(),
             };
 

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -123,7 +123,7 @@ pub enum ExtensionInitializationParams {
     },
     NonTransferable,
     PermanentDelegate {
-        delegate: Option<Pubkey>,
+        delegate: Pubkey,
     },
 }
 impl ExtensionInitializationParams {
@@ -192,11 +192,9 @@ impl ExtensionInitializationParams {
             Self::NonTransferable => {
                 instruction::initialize_non_transferable_mint(token_program_id, mint)
             }
-            Self::PermanentDelegate { delegate } => instruction::initialize_permanent_delegate(
-                token_program_id,
-                mint,
-                delegate.as_ref(),
-            ),
+            Self::PermanentDelegate { delegate } => {
+                instruction::initialize_permanent_delegate(token_program_id, mint, &delegate)
+            }
         }
     }
 }

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -122,6 +122,9 @@ pub enum ExtensionInitializationParams {
         rate: i16,
     },
     NonTransferable,
+    PermanentDelegate {
+        delegate: Option<Pubkey>,
+    },
 }
 impl ExtensionInitializationParams {
     /// Get the extension type associated with the init params
@@ -133,6 +136,7 @@ impl ExtensionInitializationParams {
             Self::TransferFeeConfig { .. } => ExtensionType::TransferFeeConfig,
             Self::InterestBearingConfig { .. } => ExtensionType::InterestBearingConfig,
             Self::NonTransferable => ExtensionType::NonTransferable,
+            Self::PermanentDelegate { .. } => ExtensionType::PermanentDelegate,
         }
     }
     /// Generate an appropriate initialization instruction for the given mint
@@ -188,6 +192,11 @@ impl ExtensionInitializationParams {
             Self::NonTransferable => {
                 instruction::initialize_non_transferable_mint(token_program_id, mint)
             }
+            Self::PermanentDelegate { delegate } => instruction::initialize_permanent_delegate(
+                token_program_id,
+                mint,
+                delegate.as_ref(),
+            ),
         }
     }
 }

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -21,7 +21,8 @@ use {
     spl_token_2022::{
         extension::{
             confidential_transfer, cpi_guard, default_account_state, interest_bearing_mint,
-            memo_transfer, transfer_fee, ExtensionType, StateWithExtensionsOwned,
+            memo_transfer, transfer_fee, BaseStateWithExtensions, ExtensionType,
+            StateWithExtensionsOwned,
         },
         instruction,
         solana_zk_token_sdk::{

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -15,7 +15,7 @@ use {
             confidential_transfer::{
                 ConfidentialTransferAccount, ConfidentialTransferMint, EncryptedWithheldAmount,
             },
-            ExtensionType,
+            BaseStateWithExtensions, ExtensionType,
         },
         solana_zk_token_sdk::{
             encryption::{auth_encryption::*, elgamal::*},

--- a/token/program-2022-test/tests/cpi_guard.rs
+++ b/token/program-2022-test/tests/cpi_guard.rs
@@ -17,7 +17,7 @@ use {
         error::TokenError,
         extension::{
             cpi_guard::{self, CpiGuard},
-            ExtensionType,
+            BaseStateWithExtensions, ExtensionType,
         },
         instruction::{self, AuthorityType},
         processor::Processor as SplToken2022Processor,

--- a/token/program-2022-test/tests/default_account_state.rs
+++ b/token/program-2022-test/tests/default_account_state.rs
@@ -9,8 +9,10 @@ use {
         signer::keypair::Keypair, transaction::TransactionError, transport::TransportError,
     },
     spl_token_2022::{
-        error::TokenError, extension::default_account_state::DefaultAccountState,
-        instruction::AuthorityType, state::AccountState,
+        error::TokenError,
+        extension::{default_account_state::DefaultAccountState, BaseStateWithExtensions},
+        instruction::AuthorityType,
+        state::AccountState,
     },
     spl_token_client::token::{ExtensionInitializationParams, TokenError as TokenClientError},
     std::convert::TryFrom,

--- a/token/program-2022-test/tests/initialize_account.rs
+++ b/token/program-2022-test/tests/initialize_account.rs
@@ -17,7 +17,7 @@ use {
         error::TokenError,
         extension::{
             transfer_fee::{self, TransferFeeAmount},
-            ExtensionType, StateWithExtensions,
+            BaseStateWithExtensions, ExtensionType, StateWithExtensions,
         },
         instruction,
         state::{Account, Mint},

--- a/token/program-2022-test/tests/initialize_mint.rs
+++ b/token/program-2022-test/tests/initialize_mint.rs
@@ -16,7 +16,10 @@ use {
     },
     spl_token_2022::{
         error::TokenError,
-        extension::{mint_close_authority::MintCloseAuthority, transfer_fee, ExtensionType},
+        extension::{
+            mint_close_authority::MintCloseAuthority, transfer_fee, BaseStateWithExtensions,
+            ExtensionType,
+        },
         instruction, native_mint,
         state::Mint,
     },

--- a/token/program-2022-test/tests/interest_bearing_mint.rs
+++ b/token/program-2022-test/tests/interest_bearing_mint.rs
@@ -23,7 +23,7 @@ use {
     },
     spl_token_2022::{
         error::TokenError,
-        extension::interest_bearing_mint::InterestBearingConfig,
+        extension::{interest_bearing_mint::InterestBearingConfig, BaseStateWithExtensions},
         instruction::{amount_to_ui_amount, ui_amount_to_amount, AuthorityType},
         processor::Processor,
     },

--- a/token/program-2022-test/tests/memo_transfer.rs
+++ b/token/program-2022-test/tests/memo_transfer.rs
@@ -17,7 +17,7 @@ use {
     },
     spl_token_2022::{
         error::TokenError,
-        extension::{memo_transfer::MemoTransfer, ExtensionType},
+        extension::{memo_transfer::MemoTransfer, BaseStateWithExtensions, ExtensionType},
     },
     spl_token_client::token::TokenError as TokenClientError,
     std::sync::Arc,

--- a/token/program-2022-test/tests/mint_close_authority.rs
+++ b/token/program-2022-test/tests/mint_close_authority.rs
@@ -9,7 +9,9 @@ use {
         signer::keypair::Keypair, transaction::TransactionError, transport::TransportError,
     },
     spl_token_2022::{
-        error::TokenError, extension::mint_close_authority::MintCloseAuthority, instruction,
+        error::TokenError,
+        extension::{mint_close_authority::MintCloseAuthority, BaseStateWithExtensions},
+        instruction,
     },
     spl_token_client::token::{ExtensionInitializationParams, TokenError as TokenClientError},
     std::convert::TryInto,

--- a/token/program-2022-test/tests/permanent_delegate.rs
+++ b/token/program-2022-test/tests/permanent_delegate.rs
@@ -1,0 +1,274 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+use {
+    program_test::{TestContext, TokenContext},
+    solana_program_test::tokio,
+    solana_sdk::{
+        instruction::InstructionError, pubkey::Pubkey, signature::Signer, signer::keypair::Keypair,
+        transaction::TransactionError, transport::TransportError,
+    },
+    spl_token_2022::{
+        error::TokenError, extension::permanent_delegate::PermanentDelegate, instruction,
+    },
+    spl_token_client::token::{ExtensionInitializationParams, TokenError as TokenClientError},
+    std::convert::TryInto,
+};
+
+async fn setup_accounts(token_context: &TokenContext, amount: u64) -> (Pubkey, Pubkey) {
+    let alice_account = Keypair::new();
+    token_context
+        .token
+        .create_auxiliary_token_account(&alice_account, &token_context.alice.pubkey())
+        .await
+        .unwrap();
+    let alice_account = alice_account.pubkey();
+    let bob_account = Keypair::new();
+    token_context
+        .token
+        .create_auxiliary_token_account(&bob_account, &token_context.bob.pubkey())
+        .await
+        .unwrap();
+    let bob_account = bob_account.pubkey();
+
+    // mint tokens
+    token_context
+        .token
+        .mint_to(
+            &alice_account,
+            &token_context.mint_authority.pubkey(),
+            amount,
+            &[&token_context.mint_authority],
+        )
+        .await
+        .unwrap();
+    (alice_account, bob_account)
+}
+
+#[tokio::test]
+async fn success_init() {
+    let delegate = Some(Pubkey::new_unique());
+    let mut context = TestContext::new().await;
+    context
+        .init_token_with_mint(vec![ExtensionInitializationParams::PermanentDelegate {
+            delegate,
+        }])
+        .await
+        .unwrap();
+    let TokenContext { token, .. } = context.token_context.unwrap();
+
+    let state = token.get_mint_info().await.unwrap();
+    assert!(state.base.is_initialized);
+    let extension = state.get_extension::<PermanentDelegate>().unwrap();
+    assert_eq!(extension.delegate, delegate.try_into().unwrap(),);
+}
+
+#[tokio::test]
+async fn set_authority() {
+    let delegate = Keypair::new();
+    let mut context = TestContext::new().await;
+    context
+        .init_token_with_mint(vec![ExtensionInitializationParams::PermanentDelegate {
+            delegate: Some(delegate.pubkey()),
+        }])
+        .await
+        .unwrap();
+    let token_context = context.token_context.unwrap();
+    let new_delegate = Keypair::new();
+
+    // fail, wrong signature
+    let wrong = Keypair::new();
+    let err = token_context
+        .token
+        .set_authority(
+            token_context.token.get_address(),
+            &wrong.pubkey(),
+            Some(&new_delegate.pubkey()),
+            instruction::AuthorityType::PermanentDelegate,
+            &[&wrong],
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::OwnerMismatch as u32)
+            )
+        )))
+    );
+
+    // success
+    token_context
+        .token
+        .set_authority(
+            token_context.token.get_address(),
+            &delegate.pubkey(),
+            Some(&new_delegate.pubkey()),
+            instruction::AuthorityType::PermanentDelegate,
+            &[&delegate],
+        )
+        .await
+        .unwrap();
+    let state = token_context.token.get_mint_info().await.unwrap();
+    let extension = state.get_extension::<PermanentDelegate>().unwrap();
+    assert_eq!(
+        extension.delegate,
+        Some(new_delegate.pubkey()).try_into().unwrap(),
+    );
+
+    // set to none
+    token_context
+        .token
+        .set_authority(
+            token_context.token.get_address(),
+            &new_delegate.pubkey(),
+            None,
+            instruction::AuthorityType::PermanentDelegate,
+            &[&new_delegate],
+        )
+        .await
+        .unwrap();
+    let state = token_context.token.get_mint_info().await.unwrap();
+    let extension = state.get_extension::<PermanentDelegate>().unwrap();
+    assert_eq!(extension.delegate, None.try_into().unwrap(),);
+
+    // fail set again
+    let err = token_context
+        .token
+        .set_authority(
+            token_context.token.get_address(),
+            &new_delegate.pubkey(),
+            Some(&delegate.pubkey()),
+            instruction::AuthorityType::PermanentDelegate,
+            &[&new_delegate],
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::AuthorityTypeNotSupported as u32)
+            )
+        )))
+    );
+
+    // setup accounts
+    let amount = 10;
+    let (alice_account, bob_account) = setup_accounts(&token_context, amount).await;
+
+    // fail transfer
+    let error = token_context
+        .token
+        .transfer(
+            &alice_account,
+            &bob_account,
+            &new_delegate.pubkey(),
+            amount,
+            &[&new_delegate],
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::OwnerMismatch as u32)
+            )
+        )))
+    );
+}
+
+#[tokio::test]
+async fn success_transfer() {
+    let delegate = Keypair::new();
+    let mut context = TestContext::new().await;
+    context
+        .init_token_with_mint(vec![ExtensionInitializationParams::PermanentDelegate {
+            delegate: Some(delegate.pubkey()),
+        }])
+        .await
+        .unwrap();
+    let token_context = context.token_context.unwrap();
+    let amount = 10;
+    let (alice_account, bob_account) = setup_accounts(&token_context, amount).await;
+
+    token_context
+        .token
+        .transfer(
+            &alice_account,
+            &bob_account,
+            &delegate.pubkey(),
+            amount,
+            &[&delegate],
+        )
+        .await
+        .unwrap();
+
+    let destination = token_context
+        .token
+        .get_account_info(&bob_account)
+        .await
+        .unwrap();
+    assert_eq!(destination.base.amount, amount);
+}
+
+#[tokio::test]
+async fn success_burn() {
+    let delegate = Keypair::new();
+    let mut context = TestContext::new().await;
+    context
+        .init_token_with_mint(vec![ExtensionInitializationParams::PermanentDelegate {
+            delegate: Some(delegate.pubkey()),
+        }])
+        .await
+        .unwrap();
+    let token_context = context.token_context.unwrap();
+    let amount = 10;
+    let (alice_account, _) = setup_accounts(&token_context, amount).await;
+
+    token_context
+        .token
+        .burn(&alice_account, &delegate.pubkey(), amount, &[&delegate])
+        .await
+        .unwrap();
+
+    let destination = token_context
+        .token
+        .get_account_info(&alice_account)
+        .await
+        .unwrap();
+    assert_eq!(destination.base.amount, 0);
+}
+
+#[tokio::test]
+async fn fail_without_extension() {
+    let delegate = Pubkey::new_unique();
+    let mut context = TestContext::new().await;
+    context.init_token_with_mint(vec![]).await.unwrap();
+    let token_context = context.token_context.unwrap();
+
+    // fail set
+    let err = token_context
+        .token
+        .set_authority(
+            token_context.token.get_address(),
+            &token_context.mint_authority.pubkey(),
+            Some(&delegate),
+            instruction::AuthorityType::PermanentDelegate,
+            &[&token_context.mint_authority],
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(0, InstructionError::InvalidAccountData)
+        )))
+    );
+}

--- a/token/program-2022-test/tests/permanent_delegate.rs
+++ b/token/program-2022-test/tests/permanent_delegate.rs
@@ -9,7 +9,9 @@ use {
         transaction::TransactionError, transport::TransportError,
     },
     spl_token_2022::{
-        error::TokenError, extension::permanent_delegate::PermanentDelegate, instruction,
+        error::TokenError,
+        extension::{permanent_delegate::PermanentDelegate, BaseStateWithExtensions},
+        instruction,
     },
     spl_token_client::token::{ExtensionInitializationParams, TokenError as TokenClientError},
     std::convert::TryInto,

--- a/token/program-2022-test/tests/permanent_delegate.rs
+++ b/token/program-2022-test/tests/permanent_delegate.rs
@@ -47,7 +47,7 @@ async fn setup_accounts(token_context: &TokenContext, amount: u64) -> (Pubkey, P
 
 #[tokio::test]
 async fn success_init() {
-    let delegate = Some(Pubkey::new_unique());
+    let delegate = Pubkey::new_unique();
     let mut context = TestContext::new().await;
     context
         .init_token_with_mint(vec![ExtensionInitializationParams::PermanentDelegate {
@@ -60,7 +60,7 @@ async fn success_init() {
     let state = token.get_mint_info().await.unwrap();
     assert!(state.base.is_initialized);
     let extension = state.get_extension::<PermanentDelegate>().unwrap();
-    assert_eq!(extension.delegate, delegate.try_into().unwrap(),);
+    assert_eq!(extension.delegate, Some(delegate).try_into().unwrap(),);
 }
 
 #[tokio::test]
@@ -69,7 +69,7 @@ async fn set_authority() {
     let mut context = TestContext::new().await;
     context
         .init_token_with_mint(vec![ExtensionInitializationParams::PermanentDelegate {
-            delegate: Some(delegate.pubkey()),
+            delegate: delegate.pubkey(),
         }])
         .await
         .unwrap();
@@ -190,7 +190,7 @@ async fn success_transfer() {
     let mut context = TestContext::new().await;
     context
         .init_token_with_mint(vec![ExtensionInitializationParams::PermanentDelegate {
-            delegate: Some(delegate.pubkey()),
+            delegate: delegate.pubkey(),
         }])
         .await
         .unwrap();
@@ -224,7 +224,7 @@ async fn success_burn() {
     let mut context = TestContext::new().await;
     context
         .init_token_with_mint(vec![ExtensionInitializationParams::PermanentDelegate {
-            delegate: Some(delegate.pubkey()),
+            delegate: delegate.pubkey(),
         }])
         .await
         .unwrap();

--- a/token/program-2022-test/tests/transfer_fee.rs
+++ b/token/program-2022-test/tests/transfer_fee.rs
@@ -10,8 +10,11 @@ use {
     },
     spl_token_2022::{
         error::TokenError,
-        extension::transfer_fee::{
-            TransferFee, TransferFeeAmount, TransferFeeConfig, MAX_FEE_BASIS_POINTS,
+        extension::{
+            transfer_fee::{
+                TransferFee, TransferFeeAmount, TransferFeeConfig, MAX_FEE_BASIS_POINTS,
+            },
+            BaseStateWithExtensions,
         },
         instruction,
     },

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -4,7 +4,7 @@ use {
         error::TokenError,
         extension::{
             confidential_transfer::{instruction::*, *},
-            StateWithExtensions, StateWithExtensionsMut,
+            BaseStateWithExtensions, StateWithExtensions, StateWithExtensionsMut,
         },
         instruction::{decode_instruction_data, decode_instruction_type},
         processor::Processor,

--- a/token/program-2022/src/extension/cpi_guard/mod.rs
+++ b/token/program-2022/src/extension/cpi_guard/mod.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        extension::{Extension, ExtensionType, StateWithExtensionsMut},
+        extension::{BaseStateWithExtensions, Extension, ExtensionType, StateWithExtensionsMut},
         pod::PodBool,
         state::Account,
     },

--- a/token/program-2022/src/extension/memo_transfer/mod.rs
+++ b/token/program-2022/src/extension/memo_transfer/mod.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         error::TokenError,
-        extension::{Extension, ExtensionType, StateWithExtensionsMut},
+        extension::{BaseStateWithExtensions, Extension, ExtensionType, StateWithExtensionsMut},
         pod::PodBool,
         state::Account,
     },

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -466,25 +466,6 @@ impl<'data, S: BaseState> StateWithExtensionsMut<'data, S> {
         pod_from_bytes_mut::<V>(&mut self.tlv_data[value_start..value_end])
     }
 
-    /// Unpack a portion of the TLV data as the desired type
-    pub fn get_extension<V: Extension>(&self) -> Result<&V, ProgramError> {
-        if V::TYPE.get_account_type() != S::ACCOUNT_TYPE {
-            return Err(ProgramError::InvalidAccountData);
-        }
-        let TlvIndices {
-            type_start,
-            length_start,
-            value_start,
-        } = get_extension_indices::<V>(self.tlv_data, false)?;
-
-        if self.tlv_data[type_start..].len() < V::TYPE.get_tlv_len() {
-            return Err(ProgramError::InvalidAccountData);
-        }
-        let length = pod_from_bytes::<Length>(&self.tlv_data[length_start..value_start])?;
-        let value_end = value_start.saturating_add(usize::from(*length));
-        pod_from_bytes::<V>(&self.tlv_data[value_start..value_end])
-    }
-
     /// Packs base state data into the base data portion
     pub fn pack_base(&mut self) {
         S::pack_into_slice(&self.base, self.base_data);

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -12,6 +12,7 @@ use {
             memo_transfer::MemoTransfer,
             mint_close_authority::MintCloseAuthority,
             non_transferable::NonTransferable,
+            permanent_delegate::PermanentDelegate,
             transfer_fee::{TransferFeeAmount, TransferFeeConfig},
         },
         pod::*,
@@ -48,6 +49,8 @@ pub mod memo_transfer;
 pub mod mint_close_authority;
 /// Non Transferable extension
 pub mod non_transferable;
+/// Permanent Delegate extension
+pub mod permanent_delegate;
 /// Utility to reallocate token accounts
 pub mod reallocate;
 /// Transfer Fee extension
@@ -647,6 +650,8 @@ pub enum ExtensionType {
     InterestBearingConfig,
     /// Locks privileged token operations from happening via CPI
     CpiGuard,
+    /// Includes an optional permanent delegate
+    PermanentDelegate,
     /// Padding extension used to make an account exactly Multisig::LEN, used for testing
     #[cfg(test)]
     AccountPaddingTest = u16::MAX - 1,
@@ -688,6 +693,7 @@ impl ExtensionType {
             ExtensionType::NonTransferable => pod_get_packed_len::<NonTransferable>(),
             ExtensionType::InterestBearingConfig => pod_get_packed_len::<InterestBearingConfig>(),
             ExtensionType::CpiGuard => pod_get_packed_len::<CpiGuard>(),
+            ExtensionType::PermanentDelegate => pod_get_packed_len::<PermanentDelegate>(),
             #[cfg(test)]
             ExtensionType::AccountPaddingTest => pod_get_packed_len::<AccountPaddingTest>(),
             #[cfg(test)]
@@ -744,7 +750,8 @@ impl ExtensionType {
             | ExtensionType::ConfidentialTransferMint
             | ExtensionType::DefaultAccountState
             | ExtensionType::NonTransferable
-            | ExtensionType::InterestBearingConfig => AccountType::Mint,
+            | ExtensionType::InterestBearingConfig
+            | ExtensionType::PermanentDelegate => AccountType::Mint,
             ExtensionType::ImmutableOwner
             | ExtensionType::TransferFeeAmount
             | ExtensionType::ConfidentialTransferAccount

--- a/token/program-2022/src/extension/permanent_delegate.rs
+++ b/token/program-2022/src/extension/permanent_delegate.rs
@@ -20,7 +20,7 @@ impl Extension for PermanentDelegate {
 
 /// Attempts to get the permanent delegate from the TLV data, returning None
 /// if the extension is not found
-pub fn maybe_get_permanent_delegate<S: BaseState, BSE: BaseStateWithExtensions<S>>(
+pub fn get_permanent_delegate<S: BaseState, BSE: BaseStateWithExtensions<S>>(
     state: &BSE,
 ) -> Option<Pubkey> {
     state

--- a/token/program-2022/src/extension/permanent_delegate.rs
+++ b/token/program-2022/src/extension/permanent_delegate.rs
@@ -1,0 +1,18 @@
+use {
+    crate::{
+        extension::{Extension, ExtensionType},
+        pod::*,
+    },
+    bytemuck::{Pod, Zeroable},
+};
+
+/// Permanent delegate extension data for mints.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+pub struct PermanentDelegate {
+    /// Optional authority to close the mint
+    pub delegate: OptionalNonZeroPubkey,
+}
+impl Extension for PermanentDelegate {
+    const TYPE: ExtensionType = ExtensionType::PermanentDelegate;
+}

--- a/token/program-2022/src/extension/permanent_delegate.rs
+++ b/token/program-2022/src/extension/permanent_delegate.rs
@@ -1,9 +1,10 @@
 use {
     crate::{
-        extension::{Extension, ExtensionType},
+        extension::{BaseState, BaseStateWithExtensions, Extension, ExtensionType},
         pod::*,
     },
     bytemuck::{Pod, Zeroable},
+    solana_program::pubkey::Pubkey,
 };
 
 /// Permanent delegate extension data for mints.
@@ -15,4 +16,15 @@ pub struct PermanentDelegate {
 }
 impl Extension for PermanentDelegate {
     const TYPE: ExtensionType = ExtensionType::PermanentDelegate;
+}
+
+/// Attempts to get the permanent delegate from the TLV data, returning None
+/// if the extension is not found
+pub fn maybe_get_permanent_delegate<S: BaseState, BSE: BaseStateWithExtensions<S>>(
+    state: &BSE,
+) -> Option<Pubkey> {
+    state
+        .get_extension::<PermanentDelegate>()
+        .ok()
+        .and_then(|e| Option::<Pubkey>::from(e.delegate))
 }

--- a/token/program-2022/src/extension/permanent_delegate.rs
+++ b/token/program-2022/src/extension/permanent_delegate.rs
@@ -10,7 +10,7 @@ use {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct PermanentDelegate {
-    /// Optional authority to close the mint
+    /// Optional permanent delegate for transferring or burning tokens
     pub delegate: OptionalNonZeroPubkey,
 }
 impl Extension for PermanentDelegate {

--- a/token/program-2022/src/extension/reallocate.rs
+++ b/token/program-2022/src/extension/reallocate.rs
@@ -1,7 +1,10 @@
 use {
     crate::{
         error::TokenError,
-        extension::{set_account_type, AccountType, ExtensionType, StateWithExtensions},
+        extension::{
+            set_account_type, AccountType, BaseStateWithExtensions, ExtensionType,
+            StateWithExtensions,
+        },
         processor::Processor,
         state::Account,
     },

--- a/token/program-2022/src/extension/transfer_fee/processor.rs
+++ b/token/program-2022/src/extension/transfer_fee/processor.rs
@@ -7,7 +7,7 @@ use {
                 instruction::TransferFeeInstruction, TransferFee, TransferFeeAmount,
                 TransferFeeConfig, MAX_FEE_BASIS_POINTS,
             },
-            StateWithExtensions, StateWithExtensionsMut,
+            BaseStateWithExtensions, StateWithExtensions, StateWithExtensionsMut,
         },
         processor::Processor,
         state::{Account, Mint},

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -610,6 +610,23 @@ pub enum TokenInstruction<'a> {
     /// See `extension::cpi_guard::instruction::CpiGuardInstruction` for
     /// further details about the extended instructions that share this instruction prefix
     CpiGuardExtension,
+    /// Initialize the permanent delegate on a new mint.
+    ///
+    /// Fails if the mint has already been initialized, so must be called before
+    /// `InitializeMint`.
+    ///
+    /// The mint must have exactly enough space allocated for the base mint (82
+    /// bytes), plus 83 bytes of padding, 1 byte reserved for the account type,
+    /// then space required for this extension, plus any others.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[writable]` The mint to initialize.
+    InitializePermanentDelegate {
+        /// Authority that may sign for `Transfer` instructions on any account
+        #[cfg_attr(feature = "serde-traits", serde(with = "coption_fromstr"))]
+        delegate: COption<Pubkey>,
+    },
 }
 impl<'a> TokenInstruction<'a> {
     /// Unpacks a byte buffer into a [TokenInstruction](enum.TokenInstruction.html).
@@ -741,6 +758,10 @@ impl<'a> TokenInstruction<'a> {
             32 => Self::InitializeNonTransferableMint,
             33 => Self::InterestBearingMintExtension,
             34 => Self::CpiGuardExtension,
+            35 => {
+                let (delegate, _rest) = Self::unpack_pubkey_option(rest)?;
+                Self::InitializePermanentDelegate { delegate }
+            }
             _ => return Err(TokenError::InvalidInstruction.into()),
         })
     }
@@ -896,6 +917,10 @@ impl<'a> TokenInstruction<'a> {
             &Self::CpiGuardExtension => {
                 buf.push(34);
             }
+            &Self::InitializePermanentDelegate { ref delegate } => {
+                buf.push(35);
+                Self::pack_pubkey_option(delegate, &mut buf);
+            }
         };
         buf
     }
@@ -977,6 +1002,8 @@ pub enum AuthorityType {
     CloseMint,
     /// Authority to set the interest rate
     InterestRate,
+    /// Authority to transfer or burn any tokens for a mint
+    PermanentDelegate,
 }
 
 impl AuthorityType {
@@ -990,6 +1017,7 @@ impl AuthorityType {
             AuthorityType::WithheldWithdraw => 5,
             AuthorityType::CloseMint => 6,
             AuthorityType::InterestRate => 7,
+            AuthorityType::PermanentDelegate => 8,
         }
     }
 
@@ -1003,6 +1031,7 @@ impl AuthorityType {
             5 => Ok(AuthorityType::WithheldWithdraw),
             6 => Ok(AuthorityType::CloseMint),
             7 => Ok(AuthorityType::InterestRate),
+            8 => Ok(AuthorityType::PermanentDelegate),
             _ => Err(TokenError::InvalidInstruction.into()),
         }
     }
@@ -1753,6 +1782,21 @@ pub fn initialize_non_transferable_mint(
     })
 }
 
+/// Creates an `InitializePermanentDelegate` instruction
+pub fn initialize_permanent_delegate(
+    token_program_id: &Pubkey,
+    mint_pubkey: &Pubkey,
+    delegate: Option<&Pubkey>,
+) -> Result<Instruction, ProgramError> {
+    check_program_account(token_program_id)?;
+    let delegate = delegate.cloned().into();
+    Ok(Instruction {
+        program_id: *token_program_id,
+        accounts: vec![AccountMeta::new(*mint_pubkey, false)],
+        data: TokenInstruction::InitializePermanentDelegate { delegate }.pack(),
+    })
+}
+
 /// Utility function that checks index is between MIN_SIGNERS and MAX_SIGNERS
 pub fn is_valid_signer_index(index: usize) -> bool {
     (MIN_SIGNERS..=MAX_SIGNERS).contains(&index)
@@ -2069,6 +2113,16 @@ mod test {
         let check = TokenInstruction::CreateNativeMint;
         let packed = check.pack();
         let expect = vec![31u8];
+        assert_eq!(packed, expect);
+        let unpacked = TokenInstruction::unpack(&expect).unwrap();
+        assert_eq!(unpacked, check);
+
+        let check = TokenInstruction::InitializePermanentDelegate {
+            delegate: COption::Some(Pubkey::new(&[11u8; 32])),
+        };
+        let packed = check.pack();
+        let mut expect = vec![35u8, 1];
+        expect.extend_from_slice(&[11u8; 32]);
         assert_eq!(packed, expect);
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -13,6 +13,7 @@ use {
             memo_transfer::{self, check_previous_sibling_instruction_is_memo, memo_required},
             mint_close_authority::MintCloseAuthority,
             non_transferable::NonTransferable,
+            permanent_delegate::PermanentDelegate,
             reallocate,
             transfer_fee::{self, TransferFeeAmount, TransferFeeConfig},
             ExtensionType, StateWithExtensions, StateWithExtensionsMut,
@@ -138,6 +139,13 @@ impl Processor {
         let mint_data = mint_info.data.borrow();
         let mint = StateWithExtensions::<Mint>::unpack(&mint_data)
             .map_err(|_| Into::<ProgramError>::into(TokenError::InvalidMint))?;
+        if mint
+            .get_extension::<PermanentDelegate>()
+            .map(|e| Option::<Pubkey>::from(e.delegate).is_some())
+            .unwrap_or(false)
+        {
+            msg!("Warning: Mint has a permanent delegate, so tokens in this account may be seized at any time");
+        }
         let required_extensions =
             Self::get_required_account_extensions_from_unpacked_mint(mint_info.owner, &mint)?;
         if ExtensionType::get_account_len::<Account>(&required_extensions)
@@ -279,7 +287,9 @@ impl Processor {
         if source_account.base.amount < amount {
             return Err(TokenError::InsufficientFunds.into());
         }
-        let fee = if let Some((mint_info, expected_decimals)) = expected_mint_info {
+        let (fee, maybe_permanent_delegate) = if let Some((mint_info, expected_decimals)) =
+            expected_mint_info
+        {
             if !cmp_pubkeys(&source_account.base.mint, mint_info.key) {
                 return Err(TokenError::MintMismatch.into());
             }
@@ -295,24 +305,32 @@ impl Processor {
                 return Err(TokenError::MintDecimalsMismatch.into());
             }
 
-            if let Ok(transfer_fee_config) = mint.get_extension::<TransferFeeConfig>() {
+            let fee = if let Ok(transfer_fee_config) = mint.get_extension::<TransferFeeConfig>() {
                 transfer_fee_config
                     .calculate_epoch_fee(Clock::get()?.epoch, amount)
                     .ok_or(TokenError::Overflow)?
             } else {
                 0
-            }
+            };
+
+            let maybe_permanent_delegate = mint
+                .get_extension::<PermanentDelegate>()
+                .map(|e| Option::<Pubkey>::from(e.delegate))
+                .ok()
+                .flatten();
+            (fee, maybe_permanent_delegate)
         } else {
             // Transfer fee amount extension exists on the account, but no mint
             // was provided to calculate the fee, abort
-            if source_account
+            let fee = if source_account
                 .get_extension_mut::<TransferFeeAmount>()
                 .is_ok()
             {
                 return Err(TokenError::MintRequiredForTransfer.into());
             } else {
                 0
-            }
+            };
+            (fee, None)
         };
         if let Some(expected_fee) = expected_fee {
             if expected_fee != fee {
@@ -322,8 +340,17 @@ impl Processor {
         }
 
         let self_transfer = cmp_pubkeys(source_account_info.key, destination_account_info.key);
-        match source_account.base.delegate {
-            COption::Some(ref delegate) if cmp_pubkeys(authority_info.key, delegate) => {
+        match (source_account.base.delegate, maybe_permanent_delegate) {
+            (_, Some(ref delegate)) if cmp_pubkeys(authority_info.key, delegate) => {
+                Self::validate_owner(
+                    program_id,
+                    delegate,
+                    authority_info,
+                    authority_info_data_len,
+                    account_info_iter.as_slice(),
+                )?
+            }
+            (COption::Some(ref delegate), _) if cmp_pubkeys(authority_info.key, delegate) => {
                 Self::validate_owner(
                     program_id,
                     delegate,
@@ -360,7 +387,7 @@ impl Processor {
                     }
                 }
             }
-        };
+        }
 
         // Revisit this later to see if it's worth adding a check to reduce
         // compute costs, ie:
@@ -698,6 +725,19 @@ impl Processor {
                     )?;
                     extension.rate_authority = new_authority.try_into()?;
                 }
+                AuthorityType::PermanentDelegate => {
+                    let extension = mint.get_extension_mut::<PermanentDelegate>()?;
+                    let maybe_delegate: Option<Pubkey> = extension.delegate.into();
+                    let delegate = maybe_delegate.ok_or(TokenError::AuthorityTypeNotSupported)?;
+                    Self::validate_owner(
+                        program_id,
+                        &delegate,
+                        authority_info,
+                        authority_info_data_len,
+                        account_info_iter.as_slice(),
+                    )?;
+                    extension.delegate = new_authority.try_into()?;
+                }
                 _ => {
                     return Err(TokenError::AuthorityTypeNotSupported.into());
                 }
@@ -828,13 +868,27 @@ impl Processor {
                 return Err(TokenError::MintDecimalsMismatch.into());
             }
         }
+        let maybe_permanent_delegate = mint
+            .get_extension::<PermanentDelegate>()
+            .map(|e| Option::<Pubkey>::from(e.delegate))
+            .ok()
+            .flatten();
 
         if !source_account
             .base
             .is_owned_by_system_program_or_incinerator()
         {
-            match source_account.base.delegate {
-                COption::Some(ref delegate) if cmp_pubkeys(authority_info.key, delegate) => {
+            match (source_account.base.delegate, maybe_permanent_delegate) {
+                (_, Some(ref delegate)) if cmp_pubkeys(authority_info.key, delegate) => {
+                    Self::validate_owner(
+                        program_id,
+                        delegate,
+                        authority_info,
+                        authority_info_data_len,
+                        account_info_iter.as_slice(),
+                    )?
+                }
+                (COption::Some(ref delegate), _) if cmp_pubkeys(authority_info.key, delegate) => {
                     Self::validate_owner(
                         program_id,
                         delegate,
@@ -1207,6 +1261,22 @@ impl Processor {
         Ok(())
     }
 
+    /// Processes an [InitializePermanentDelegate](enum.TokenInstruction.html) instruction
+    pub fn process_initialize_permanent_delegate(
+        accounts: &[AccountInfo],
+        delegate: COption<Pubkey>,
+    ) -> ProgramResult {
+        let account_info_iter = &mut accounts.iter();
+        let mint_account_info = next_account_info(account_info_iter)?;
+
+        let mut mint_data = mint_account_info.data.borrow_mut();
+        let mut mint = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut mint_data)?;
+        let extension = mint.init_extension::<PermanentDelegate>(true)?;
+        extension.delegate = delegate.try_into()?;
+
+        Ok(())
+    }
+
     /// Processes an [Instruction](enum.Instruction.html).
     pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> ProgramResult {
         let instruction = TokenInstruction::unpack(input)?;
@@ -1369,6 +1439,10 @@ impl Processor {
             }
             TokenInstruction::CpiGuardExtension => {
                 cpi_guard::processor::process_instruction(program_id, accounts, &input[1..])
+            }
+            TokenInstruction::InitializePermanentDelegate { delegate } => {
+                msg!("Instruction: InitializePermanentDelegate");
+                Self::process_initialize_permanent_delegate(accounts, delegate)
             }
         }
     }

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -315,9 +315,8 @@ impl Processor {
 
             let maybe_permanent_delegate = mint
                 .get_extension::<PermanentDelegate>()
-                .map(|e| Option::<Pubkey>::from(e.delegate))
                 .ok()
-                .flatten();
+                .and_then(|e| Option::<Pubkey>::from(e.delegate));
             (fee, maybe_permanent_delegate)
         } else {
             // Transfer fee amount extension exists on the account, but no mint
@@ -1264,7 +1263,7 @@ impl Processor {
     /// Processes an [InitializePermanentDelegate](enum.TokenInstruction.html) instruction
     pub fn process_initialize_permanent_delegate(
         accounts: &[AccountInfo],
-        delegate: COption<Pubkey>,
+        delegate: Pubkey,
     ) -> ProgramResult {
         let account_info_iter = &mut accounts.iter();
         let mint_account_info = next_account_info(account_info_iter)?;
@@ -1272,7 +1271,7 @@ impl Processor {
         let mut mint_data = mint_account_info.data.borrow_mut();
         let mut mint = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut mint_data)?;
         let extension = mint.init_extension::<PermanentDelegate>(true)?;
-        extension.delegate = delegate.try_into()?;
+        extension.delegate = Some(delegate).try_into()?;
 
         Ok(())
     }

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -13,7 +13,7 @@ use {
             memo_transfer::{self, check_previous_sibling_instruction_is_memo, memo_required},
             mint_close_authority::MintCloseAuthority,
             non_transferable::NonTransferable,
-            permanent_delegate::{maybe_get_permanent_delegate, PermanentDelegate},
+            permanent_delegate::{get_permanent_delegate, PermanentDelegate},
             reallocate,
             transfer_fee::{self, TransferFeeAmount, TransferFeeConfig},
             BaseStateWithExtensions, ExtensionType, StateWithExtensions, StateWithExtensionsMut,
@@ -313,7 +313,7 @@ impl Processor {
                 0
             };
 
-            let maybe_permanent_delegate = maybe_get_permanent_delegate(&mint);
+            let maybe_permanent_delegate = get_permanent_delegate(&mint);
             (fee, maybe_permanent_delegate)
         } else {
             // Transfer fee amount extension exists on the account, but no mint
@@ -863,7 +863,7 @@ impl Processor {
                 return Err(TokenError::MintDecimalsMismatch.into());
             }
         }
-        let maybe_permanent_delegate = maybe_get_permanent_delegate(&mint);
+        let maybe_permanent_delegate = get_permanent_delegate(&mint);
 
         if !source_account
             .base


### PR DESCRIPTION
#### Problem

NFT projects want to implement a Harberger Tax on the tokens, which requires the ability for an external authority to take over the tokens if needed.  A few other projects have expressed the desire for something similar, so it's time to add it in finally.

#### Solution

Add the ability for mints to specify a "permanent delegate" during initialization, that can always transfer or burn tokens, similar to a normal delegate, but with an unlimited amount, and that can't be revoked.

Also, adds a warning during account initialization that the tokens can be seized, which will probably be useful for people hit by the Harberger Tax.

cc @aeyakovenko 

Fixes #2762 Fixes #2823