### PR TITLE
managed-token: Remove ignored profile.release

### DIFF
--- a/managed-token/program/Cargo.toml
+++ b/managed-token/program/Cargo.toml
@@ -34,8 +34,3 @@ solana-program-test = "1.14.4"
 solana-sdk = "1.14.4"
 tokio = { version = "1.8.4", features = ["full"] }
 anyhow = "1.0.52"
-
-[profile.release]
-lto = "fat"
-codegen-units = 1
-overflow-checks = true


### PR DESCRIPTION
#### Problem

The SPL build currently gives this warning every time:

```
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /home/jon/src/solana/solana-program-library/managed-token/program/Cargo.toml
workspace: /home/jon/src/solana/solana-program-library/Cargo.toml
```

#### Solution

Remove the ignored `profile.release` configuration in managed-token.