### PR TITLE
Governance: removing limit for number of options to be part of a proposal

### DIFF
--- a/governance/program/src/processor/mod.rs
+++ b/governance/program/src/processor/mod.rs
@@ -97,15 +97,17 @@ pub fn process_instruction(
         vote_type,
         options,
         use_deny_option,
+        proposal_seed,
     } = &instruction
     {
         // Do not iterate through options
-        msg!("GOVERNANCE-INSTRUCTION: CreateProposal {{name: {:?}, description_link: {:?}, vote_type: {:?}, use_deny_option: {:?}, number of options: {} }}",
+        msg!("GOVERNANCE-INSTRUCTION: CreateProposal {{name: {:?}, description_link: {:?}, vote_type: {:?}, use_deny_option: {:?}, number of options: {}, proposal seed: {} }}",
             name,
             description_link,
             vote_type,
             use_deny_option,
-            options.len()
+            options.len(),
+            proposal_seed
         );
     } else if let GovernanceInstruction::CastVote {
         vote: Vote::Approve(v),

--- a/governance/program/src/processor/mod.rs
+++ b/governance/program/src/processor/mod.rs
@@ -30,6 +30,7 @@ mod process_update_program_metadata;
 mod process_withdraw_governing_tokens;
 
 use crate::instruction::GovernanceInstruction;
+use crate::state::vote_record::Vote;
 
 use process_add_signatory::*;
 use process_cancel_proposal::*;
@@ -89,6 +90,31 @@ pub fn process_instruction(
             option_index,
             index,
             hold_up_time
+        );
+    } else if let GovernanceInstruction::CreateProposal {
+        name,
+        description_link,
+        vote_type,
+        options,
+        use_deny_option,
+    } = &instruction
+    {
+        // Do not iterate through options
+        msg!("GOVERNANCE-INSTRUCTION: CreateProposal {{name: {:?}, description_link: {:?}, vote_type: {:?}, use_deny_option: {:?}, number of options: {} }}",
+            name,
+            description_link,
+            vote_type,
+            use_deny_option,
+            options.len()
+        );
+    } else if let GovernanceInstruction::CastVote {
+        vote: Vote::Approve(v),
+    } = &instruction
+    {
+        // Do not iterate through options
+        msg!(
+            "GOVERNANCE-INSTRUCTION: CastVote {{Vote::Approve (number of options: {:?}) }}",
+            v.len()
         );
     } else {
         msg!("GOVERNANCE-INSTRUCTION: {:?}", instruction);

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -1083,7 +1083,7 @@ pub fn assert_valid_proposal_options(
     options: &[String],
     vote_type: &VoteType,
 ) -> Result<(), ProgramError> {
-    if options.is_empty() || options.len() > 10 {
+    if options.is_empty() {
         return Err(GovernanceError::InvalidProposalOptions.into());
     }
 


### PR DESCRIPTION
The current implementation defines an hard limit of max 10 options being part of a proposal. This removes the limit and let the processing to push to whatever number.
In current state it's possible to propose 10s of options for the proposal otherwise an copute limit is hit. When the coputation limit is increased with the `ComputeBudget` instruction it was possible to work with 200 of options. That limits would be good to be investigated further.