### PR TITLE
`spl-token` cli - use default config file

### DIFF
--- a/token/cli/src/config.rs
+++ b/token/cli/src/config.rs
@@ -112,6 +112,8 @@ impl<'a> Config<'a> {
                 eprintln!("error: Could not find config file `{}`", config_file);
                 exit(1);
             })
+        } else if let Some(config_file) = &*solana_cli_config::CONFIG_FILE {
+            solana_cli_config::Config::load(config_file).unwrap_or_default()
         } else {
             solana_cli_config::Config::default()
         };

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -21,7 +21,6 @@ use solana_clap_utils::{
     offline::{self, *},
     ArgConstant,
 };
-use solana_cli_config::CONFIG_FILE;
 use solana_cli_output::{
     return_signers_data, CliSignOnlyData, CliSignature, OutputFormat, QuietDisplay,
     ReturnSignersConfig, VerboseDisplay,
@@ -1931,7 +1930,7 @@ fn app<'a, 'b>(
                 .value_name("PATH")
                 .takes_value(true)
                 .global(true)
-                .help("Configuration file to use")
+                .help("Configuration file to use"),
         )
         .arg(
             Arg::with_name("verbose")

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -21,6 +21,7 @@ use solana_clap_utils::{
     offline::{self, *},
     ArgConstant,
 };
+use solana_cli_config::CONFIG_FILE;
 use solana_cli_output::{
     return_signers_data, CliSignOnlyData, CliSignature, OutputFormat, QuietDisplay,
     ReturnSignersConfig, VerboseDisplay,
@@ -1923,15 +1924,20 @@ fn app<'a, 'b>(
         .about(crate_description!())
         .version(crate_version!())
         .setting(AppSettings::SubcommandRequiredElseHelp)
-        .arg(
-            Arg::with_name("config_file")
+        .arg({
+            let arg = Arg::with_name("config_file")
                 .short("C")
                 .long("config")
                 .value_name("PATH")
                 .takes_value(true)
                 .global(true)
-                .help("Configuration file to use"),
-        )
+                .help("Configuration file to use");
+            if let Some(ref config_file) = *CONFIG_FILE {
+                arg.default_value(config_file)
+            } else {
+                arg
+            }
+        })
         .arg(
             Arg::with_name("verbose")
                 .short("v")

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -1924,20 +1924,15 @@ fn app<'a, 'b>(
         .about(crate_description!())
         .version(crate_version!())
         .setting(AppSettings::SubcommandRequiredElseHelp)
-        .arg({
-            let arg = Arg::with_name("config_file")
+        .arg(
+            Arg::with_name("config_file")
                 .short("C")
                 .long("config")
                 .value_name("PATH")
                 .takes_value(true)
                 .global(true)
-                .help("Configuration file to use");
-            if let Some(ref config_file) = *CONFIG_FILE {
-                arg.default_value(config_file)
-            } else {
-                arg
-            }
-        })
+                .help("Configuration file to use")
+        )
         .arg(
             Arg::with_name("verbose")
                 .short("v")


### PR DESCRIPTION
## Problem
The `spl-token` uses the argument `-C` to specify the cli config file, if the argument isn't provided a default config file is created, using  the default signer `~/.config/solana/id.json`.
This behavior is inconsistent with the main `solana` cli, where in case the cli config file isn't explicitly passed, the cli will use the default cli config file at `~/.config/solana/cli/config.yml`

## Changes
These changes consolidate the default cli config file loading behavior between the `spl-token` and  `solana`.
If the file is not explicitly specified with `-C`, the default cli config at `~/.config/solana/cli/config.yml` if it exists.

Main [solana cli for reference](https://github.com/solana-labs/solana/blob/master/cli/src/clap_app.rs#L17)