### PR TITLE
Governance: Vote change in a single transaction

### DIFF
--- a/governance/program/src/processor/process_relinquish_vote.rs
+++ b/governance/program/src/processor/process_relinquish_vote.rs
@@ -109,7 +109,7 @@ pub fn process_relinquish_vote(program_id: &Pubkey, accounts: &[AccountInfo]) ->
 
         proposal_data.serialize(&mut *proposal_info.data.borrow_mut())?;
 
-        dispose_account(vote_record_info, beneficiary_info);
+        dispose_account(vote_record_info, beneficiary_info)?;
 
         token_owner_record_data.total_votes_count = token_owner_record_data
             .total_votes_count

--- a/governance/program/src/processor/process_remove_signatory.rs
+++ b/governance/program/src/processor/process_remove_signatory.rs
@@ -50,7 +50,7 @@ pub fn process_remove_signatory(
 
     proposal_data.serialize(&mut *proposal_info.data.borrow_mut())?;
 
-    dispose_account(signatory_record_info, beneficiary_info);
+    dispose_account(signatory_record_info, beneficiary_info)?;
 
     Ok(())
 }

--- a/governance/program/src/processor/process_remove_transaction.rs
+++ b/governance/program/src/processor/process_remove_transaction.rs
@@ -40,7 +40,7 @@ pub fn process_remove_transaction(program_id: &Pubkey, accounts: &[AccountInfo])
         proposal_info.key,
     )?;
 
-    dispose_account(proposal_transaction_info, beneficiary_info);
+    dispose_account(proposal_transaction_info, beneficiary_info)?;
 
     let mut option = &mut proposal_data.options[proposal_transaction_data.option_index as usize];
     option.transactions_count = option.transactions_count.checked_sub(1).unwrap();

--- a/governance/tools/src/account.rs
+++ b/governance/tools/src/account.rs
@@ -256,9 +256,12 @@ pub fn assert_is_valid_account_of_types<T: BorshDeserialize + PartialEq, F: Fn(&
     Ok(())
 }
 
-/// Disposes account by transferring its lamports to the beneficiary account and zeros its data
+/// Disposes account by transferring its lamports to the beneficiary account, resizing data to 0 and changing program owner to SystemProgram
 // After transaction completes the runtime would remove the account with no lamports
-pub fn dispose_account(account_info: &AccountInfo, beneficiary_info: &AccountInfo) {
+pub fn dispose_account(
+    account_info: &AccountInfo,
+    beneficiary_info: &AccountInfo,
+) -> Result<(), ProgramError> {
     let account_lamports = account_info.lamports();
     **account_info.lamports.borrow_mut() = 0;
 
@@ -267,7 +270,6 @@ pub fn dispose_account(account_info: &AccountInfo, beneficiary_info: &AccountInf
         .checked_add(account_lamports)
         .unwrap();
 
-    let mut account_data = account_info.data.borrow_mut();
-
-    account_data.fill(0);
+    account_info.assign(&system_program::id());
+    account_info.realloc(0, false)
 }


### PR DESCRIPTION
#### Summary
In order to support `ChangeVote` instruction semantics it must be possible to call `RelinquishVote` and `CastVote` in a single transaction. 

#### Implementation Details
`dispose_account` was changed to reallocate account data to 0 and assign it back to `SystemProgram`. This change allows to reallocate `VoteRecord` account in `CastVote` within a single transaction after it was previously disposed by `RelinquishVote`