### PR TITLE
Allow partial voter weight relinquishment

### DIFF
--- a/governance/addin-api/src/voter_weight.rs
+++ b/governance/addin-api/src/voter_weight.rs
@@ -22,6 +22,9 @@ pub enum VoterWeightAction {
     /// Signs off a proposal for a governance. Target: Proposal
     /// Note: SignOffProposal is not supported in the current version
     SignOffProposal,
+
+    /// Revoke vote. Target: VoteRecord
+    RevokeVote,
 }
 
 /// VoterWeightRecord account

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -64,7 +64,7 @@ pub enum GovernanceInstruction {
         name: String,
 
         #[allow(dead_code)]
-        /// Realm config args     
+        /// Realm config args
         config_args: RealmConfigArgs,
     },
 
@@ -121,7 +121,7 @@ pub enum GovernanceInstruction {
     ///   0. `[]` Realm account the created Governance belongs to
     ///   1. `[writable]` Account Governance account. PDA seeds: ['account-governance', realm, governed_account]
     ///   2. `[]` Account governed by this Governance
-    ///       Note: The account doesn't have to exist and can be only used as a unique identifier for the Governance account  
+    ///       Note: The account doesn't have to exist and can be only used as a unique identifier for the Governance account
     ///   3. `[]` Governing TokenOwnerRecord account (Used only if not signed by RealmAuthority)
     ///   4. `[signer]` Payer
     ///   5. `[]` System program
@@ -316,10 +316,10 @@ pub enum GovernanceInstruction {
 
     /// Finalizes vote in case the Vote was not automatically tipped within max_voting_time period
     ///
-    ///   0. `[writable]` Realm account    
+    ///   0. `[writable]` Realm account
     ///   1. `[writable]` Governance account
     ///   2. `[writable]` Proposal account
-    ///   3. `[writable]` TokenOwnerRecord of the Proposal owner        
+    ///   3. `[writable]` TokenOwnerRecord of the Proposal owner
     ///   4. `[]` Governing Token Mint
     ///   5. `[]` RealmConfig account. PDA seeds: ['realm-config', realm]
     ///   6. `[]` Optional Max Voter Weight Record
@@ -340,6 +340,8 @@ pub enum GovernanceInstruction {
     ///       It's required only when Proposal is still being voted on
     ///   7. `[writable]` Optional Beneficiary account which would receive lamports when VoteRecord Account is disposed
     ///       It's required only when Proposal is still being voted on
+    ///   8. `[] Optional VoterWeightRecord if a partial revocation is being requested.
+    ///   9. `[] Optional RealmConfig. Required if 8. is provided.`
     RelinquishVote,
 
     /// Executes a Transaction in the Proposal
@@ -355,11 +357,11 @@ pub enum GovernanceInstruction {
 
     /// Creates Mint Governance account which governs a mint
     ///
-    ///   0. `[]` Realm account the created Governance belongs to    
+    ///   0. `[]` Realm account the created Governance belongs to
     ///   1. `[writable]` Mint Governance account. PDA seeds: ['mint-governance', realm, governed_mint]
     ///   2. `[writable]` Mint governed by this Governance account
     ///   3. `[signer]` Current Mint authority (MintTokens and optionally FreezeAccount)
-    ///   4. `[]` Governing TokenOwnerRecord account (Used only if not signed by RealmAuthority)   
+    ///   4. `[]` Governing TokenOwnerRecord account (Used only if not signed by RealmAuthority)
     ///   5. `[signer]` Payer
     ///   6. `[]` SPL Token program
     ///   7. `[]` System program
@@ -381,18 +383,18 @@ pub enum GovernanceInstruction {
 
     /// Creates Token Governance account which governs a token account
     ///
-    ///   0. `[]` Realm account the created Governance belongs to    
+    ///   0. `[]` Realm account the created Governance belongs to
     ///   1. `[writable]` Token Governance account. PDA seeds: ['token-governance', realm, governed_token]
     ///   2. `[writable]` Token account governed by this Governance account
     ///   3. `[signer]` Current token account authority (AccountOwner and optionally CloseAccount)
-    ///   4. `[]` Governing TokenOwnerRecord account (Used only if not signed by RealmAuthority)       
+    ///   4. `[]` Governing TokenOwnerRecord account (Used only if not signed by RealmAuthority)
     ///   5. `[signer]` Payer
     ///   6. `[]` SPL Token program
     ///   7. `[]` System program
     ///   8. `[]` Sysvar Rent
     ///   9. `[signer]` Governance authority
     ///   10. `[]` RealmConfig account. PDA seeds: ['realm-config', realm]
-    ///   11. `[]` Optional Voter Weight Record   
+    ///   11. `[]` Optional Voter Weight Record
     CreateTokenGovernance {
         #[allow(dead_code)]
         /// Governance config
@@ -407,7 +409,7 @@ pub enum GovernanceInstruction {
 
     /// Sets GovernanceConfig for a Governance
     ///
-    ///   0. `[]` Realm account the Governance account belongs to    
+    ///   0. `[]` Realm account the Governance account belongs to
     ///   1. `[writable, signer]` The Governance account the config is for
     SetGovernanceConfig {
         #[allow(dead_code)]
@@ -422,14 +424,14 @@ pub enum GovernanceInstruction {
     ///
     ///   0. `[writable]` Proposal account
     ///   1. `[]` TokenOwnerRecord account of the Proposal owner
-    ///   2. `[signer]` Governance Authority (Token Owner or Governance Delegate)    
+    ///   2. `[signer]` Governance Authority (Token Owner or Governance Delegate)
     ///   3. `[writable]` ProposalTransaction account to flag
     FlagTransactionError,
 
     /// Sets new Realm authority
     ///
     ///   0. `[writable]` Realm account
-    ///   1. `[signer]` Current Realm authority    
+    ///   1. `[signer]` Current Realm authority
     ///   2. `[]` New realm authority. Must be one of the realm governances when set
     SetRealmAuthority {
         #[allow(dead_code)]
@@ -439,7 +441,7 @@ pub enum GovernanceInstruction {
 
     /// Sets realm config
     ///   0. `[writable]` Realm account
-    ///   1. `[signer]`  Realm authority    
+    ///   1. `[signer]`  Realm authority
     ///   2. `[]` Council Token Mint - optional
     ///       Note: In the current version it's only possible to remove council mint (set it to None)
     ///       After setting council to None it won't be possible to withdraw the tokens from the Realm any longer
@@ -449,11 +451,11 @@ pub enum GovernanceInstruction {
     ///   4. `[]` System
     ///   5. `[writable]` RealmConfig account. PDA seeds: ['realm-config', realm]
     ///
-    ///   6. `[]` Optional Community Voter Weight Addin Program Id    
-    ///   7. `[]` Optional Max Community Voter Weight Addin Program Id    
+    ///   6. `[]` Optional Community Voter Weight Addin Program Id
+    ///   7. `[]` Optional Max Community Voter Weight Addin Program Id
     ///
-    ///   8. `[]` Optional Council Voter Weight Addin Program Id    
-    ///   9. `[]` Optional Max Council Voter Weight Addin Program Id    
+    ///   8. `[]` Optional Council Voter Weight Addin Program Id
+    ///   9. `[]` Optional Max Council Voter Weight Addin Program Id
     ///
     ///   10. `[signer]` Optional Payer. Required if RealmConfig doesn't exist and needs to be created
     SetRealmConfig {
@@ -468,7 +470,7 @@ pub enum GovernanceInstruction {
     ///   0. `[]` Realm account
     ///   1. `[]` Governing Token Owner account
     ///   2. `[writable]` TokenOwnerRecord account. PDA seeds: ['governance',realm, governing_token_mint, governing_token_owner]
-    ///   3. `[]` Governing Token Mint   
+    ///   3. `[]` Governing Token Mint
     ///   4. `[signer]` Payer
     ///   5. `[]` System
     CreateTokenOwnerRecord {},
@@ -1131,6 +1133,7 @@ pub fn relinquish_vote(
     vote_governing_token_mint: &Pubkey,
     governance_authority: Option<Pubkey>,
     beneficiary: Option<Pubkey>,
+    revoke_record: Option<Pubkey>,
 ) -> Instruction {
     let vote_record_address = get_vote_record_address(program_id, proposal, token_owner_record);
 
@@ -1146,6 +1149,14 @@ pub fn relinquish_vote(
     if let Some(governance_authority) = governance_authority {
         accounts.push(AccountMeta::new_readonly(governance_authority, true));
         accounts.push(AccountMeta::new(beneficiary.unwrap(), false));
+    }
+
+    if let Some(revoke_record) = revoke_record {
+        accounts.push(AccountMeta::new_readonly(revoke_record, false));
+        accounts.push(AccountMeta::new_readonly(
+            get_realm_config_address(program_id, realm),
+            false,
+        ));
     }
 
     let instruction = GovernanceInstruction::RelinquishVote {};

--- a/governance/program/src/processor/process_relinquish_vote.rs
+++ b/governance/program/src/processor/process_relinquish_vote.rs
@@ -7,15 +7,21 @@ use solana_program::{
     pubkey::Pubkey,
     sysvar::Sysvar,
 };
+use spl_governance_addin_api::voter_weight::VoterWeightAction;
 use spl_governance_tools::account::dispose_account;
 
 use crate::{
+    addins::voter_weight::{
+        assert_is_valid_voter_weight,
+        get_revoke_delegated_voter_weight_record_data_for_token_owner_record,
+    },
     error::GovernanceError,
     state::{
         enums::ProposalState,
         governance::get_governance_data_for_realm,
         proposal::get_proposal_data_for_governance,
         realm::get_realm_data_for_governing_token_mint,
+        realm_config::get_realm_config_data_for_realm,
         token_owner_record::get_token_owner_record_data_for_realm_and_governing_mint,
         vote_record::{get_vote_record_data_for_proposal_and_token_owner_record, Vote},
     },
@@ -70,20 +76,53 @@ pub fn process_relinquish_vote(program_id: &Pubkey, accounts: &[AccountInfo]) ->
     if proposal_data.state == ProposalState::Voting
         && !proposal_data.has_vote_time_ended(&governance_data.config, clock.unix_timestamp)
     {
-        let governance_authority_info = next_account_info(account_info_iter)?; // 5
-        let beneficiary_info = next_account_info(account_info_iter)?; // 6
+        let governance_authority_info = next_account_info(account_info_iter)?; // 6
+        let beneficiary_info = next_account_info(account_info_iter)?; // 7
 
-        // Note: It's only required to sign by governing_authority if relinquishing the vote results in vote change
-        // If the Proposal is already decided then anybody can prune active votes for token owner
-        token_owner_record_data
-            .assert_token_owner_or_delegate_is_signer(governance_authority_info)?;
+        let max_weight_to_relinquish = match next_account_info(account_info_iter) {
+            // 8
+            Ok(relinquish_info) => {
+                let realm_config_data = get_realm_config_data_for_realm(
+                    program_id,
+                    next_account_info(account_info_iter)?, // 9
+                    realm_info.key,
+                )?;
+                let relinquish_data =
+                    get_revoke_delegated_voter_weight_record_data_for_token_owner_record(
+                        &realm_config_data
+                            .community_token_config
+                            .voter_weight_addin
+                            .unwrap(),
+                        relinquish_info,
+                        &token_owner_record_data,
+                        governance_authority_info,
+                    )?;
+
+                assert_is_valid_voter_weight(
+                    &relinquish_data,
+                    VoterWeightAction::RevokeVote,
+                    vote_record_info.key,
+                )?;
+
+                relinquish_data.voter_weight
+            }
+            Err(_) => {
+                // Note: It's only required to sign by governing_authority if relinquishing the vote results in vote change
+                // If the Proposal is already decided then anybody can prune active votes for token owner
+                token_owner_record_data
+                    .assert_token_owner_or_delegate_is_signer(governance_authority_info)?;
+                u64::max_value()
+            }
+        };
+
+        let weight_to_relinquish = vote_record_data.voter_weight.min(max_weight_to_relinquish);
 
         match vote_record_data.vote {
-            Vote::Approve(choices) => {
+            Vote::Approve(ref choices) => {
                 for (option, choice) in proposal_data.options.iter_mut().zip(choices) {
                     option.vote_weight = option
                         .vote_weight
-                        .checked_sub(choice.get_choice_weight(vote_record_data.voter_weight)?)
+                        .checked_sub(choice.get_choice_weight(weight_to_relinquish)?)
                         .unwrap();
                 }
             }
@@ -92,14 +131,14 @@ pub fn process_relinquish_vote(program_id: &Pubkey, accounts: &[AccountInfo]) ->
                     proposal_data
                         .deny_vote_weight
                         .unwrap()
-                        .checked_sub(vote_record_data.voter_weight)
+                        .checked_sub(weight_to_relinquish)
                         .unwrap(),
                 )
             }
             Vote::Veto => {
                 proposal_data.veto_vote_weight = proposal_data
                     .veto_vote_weight
-                    .checked_sub(vote_record_data.voter_weight)
+                    .checked_sub(weight_to_relinquish)
                     .unwrap();
             }
             Vote::Abstain => {
@@ -109,12 +148,22 @@ pub fn process_relinquish_vote(program_id: &Pubkey, accounts: &[AccountInfo]) ->
 
         proposal_data.serialize(&mut *proposal_info.data.borrow_mut())?;
 
-        dispose_account(vote_record_info, beneficiary_info);
+        if vote_record_data.voter_weight <= weight_to_relinquish {
+            dispose_account(vote_record_info, beneficiary_info);
 
-        token_owner_record_data.total_votes_count = token_owner_record_data
-            .total_votes_count
-            .checked_sub(1)
-            .unwrap();
+            token_owner_record_data.total_votes_count = token_owner_record_data
+                .total_votes_count
+                .checked_sub(1)
+                .unwrap();
+        } else {
+            vote_record_data.voter_weight = vote_record_data
+                .voter_weight
+                .checked_sub(weight_to_relinquish)
+                .unwrap();
+            vote_record_data.serialize(&mut *vote_record_info.data.borrow_mut())?;
+
+            return Ok(());
+        }
     } else {
         // After Proposal voting time ends and it's not tipped then it enters implicit (time based) Finalizing state
         // and releasing tokens in this state should be disallowed


### PR DESCRIPTION
This PR extends the functionality of the existing vote relinquishment system to allow partial relinquishment.

There are two major aspects to this PR:
 - Extending the voter weight addin API by creating a `RevokeVote` `VoteRecord` type.
 - Allowing an optional `RevokeVote` `VoteRecord` to be provided as part of a `RelinquishVote` instruction. The governance program will then only relinquish up to the provided vote weight.

The PR is mainly intended to support advanced delegation functionality.

Sorry, I accidentally included some trailing whitespace removal. But it was naughty whitespace anyway.