### PR TITLE
ci: Update twotx.patch to apply properly

### DIFF
--- a/token/twoxtx.patch
+++ b/token/twoxtx.patch
@@ -1,21 +1,19 @@
-From aa223c645791be158a597efb8579270dbe5bdd82 Mon Sep 17 00:00:00 2001
+From 1899e603ebf036b2d0ea0728907bd6f8ffc26406 Mon Sep 17 00:00:00 2001
 From: Jon Cinque <jon.cinque@gmail.com>
-Date: Wed, 31 Aug 2022 01:02:34 +0200
-Subject: [PATCH] [PATCH] feat: double PACKET_DATA_SIZE
+Date: Mon, 24 Oct 2022 20:19:43 -0400
+Subject: [PATCH] feat: double PACKET_DATA_SIZE
 
-Try blind double of PACKET_DATA_SIZE; this double things across the
-board and is not a permanent solution.
 ---
- rpc/src/rpc.rs                       | 16 +++++++++++-----
+ rpc/src/rpc.rs                       | 17 ++++++++++++-----
  sdk/src/packet.rs                    |  3 ++-
- web3.js/src/transaction/constants.ts |  2 +-
- 3 files changed, 14 insertions(+), 7 deletions(-)
+ web3.js/src/transaction/constants.ts |  4 +++-
+ 3 files changed, 17 insertions(+), 7 deletions(-)
 
 diff --git a/rpc/src/rpc.rs b/rpc/src/rpc.rs
-index 8d5d12f033..9d46a315ce 100644
+index 11838cf1bc..f429fc5abb 100644
 --- a/rpc/src/rpc.rs
 +++ b/rpc/src/rpc.rs
-@@ -4393,8 +4393,11 @@ pub mod rpc_obsolete_v1_7 {
+@@ -4415,8 +4415,11 @@ pub mod rpc_obsolete_v1_7 {
      }
  }
  
@@ -29,7 +27,7 @@ index 8d5d12f033..9d46a315ce 100644
  fn decode_and_deserialize<T>(
      encoded: String,
      encoding: TransactionBinaryEncoding,
-@@ -8285,7 +8288,7 @@ pub mod tests {
+@@ -8376,7 +8379,7 @@ pub mod tests {
      }
  
      #[test]
@@ -38,7 +36,7 @@ index 8d5d12f033..9d46a315ce 100644
          let ff_tx = vec![0xffu8; PACKET_DATA_SIZE];
          let tx58 = bs58::encode(&ff_tx).into_string();
          assert_eq!(tx58.len(), MAX_BASE58_SIZE);
-@@ -8295,8 +8298,11 @@ pub mod tests {
+@@ -8386,8 +8389,12 @@ pub mod tests {
  
      #[test]
      fn test_decode_and_deserialize_too_large_payloads_fail() {
@@ -49,11 +47,12 @@ index 8d5d12f033..9d46a315ce 100644
 +        // So, we need 4 - (PACKET_DATA_SIZE % 3) extra bytes to ensure we'll spill over
 +        let extra_bytes = 4 - (PACKET_DATA_SIZE % 3);
 +        let too_big = PACKET_DATA_SIZE + extra_bytes;
++
          let tx_ser = vec![0xffu8; too_big];
+ 
          let tx58 = bs58::encode(&tx_ser).into_string();
-         let tx58_len = tx58.len();
 diff --git a/sdk/src/packet.rs b/sdk/src/packet.rs
-index 412375e35f..112d962fe8 100644
+index 08389860f9..12714028d7 100644
 --- a/sdk/src/packet.rs
 +++ b/sdk/src/packet.rs
 @@ -15,7 +15,8 @@ static_assertions::const_assert_eq!(PACKET_DATA_SIZE, 1232);
@@ -67,18 +66,21 @@ index 412375e35f..112d962fe8 100644
  bitflags! {
      #[repr(C)]
 diff --git a/web3.js/src/transaction/constants.ts b/web3.js/src/transaction/constants.ts
-index 075337e8dc..618d48cdfd 100644
+index 075337e8dc..3d4960464f 100644
 --- a/web3.js/src/transaction/constants.ts
 +++ b/web3.js/src/transaction/constants.ts
-@@ -5,7 +5,7 @@
+@@ -4,8 +4,10 @@
+  * 1280 is IPv6 minimum MTU
   * 40 bytes is the size of the IPv6 header
   * 8 bytes is the size of the fragment header
++ *
++ * Double the minimum for larger transactions
   */
 -export const PACKET_DATA_SIZE = 1280 - 40 - 8;
-+export const PACKET_DATA_SIZE = 2464;
++export const PACKET_DATA_SIZE = 2 * (1280 - 40 - 8);
  
  export const VERSION_PREFIX_MASK = 0x7f;
  
 -- 
-2.37.2
+2.38.1
 


### PR DESCRIPTION
#### Problem

The twoxtx step is failing due to an outdated patch, see https://github.com/solana-labs/solana-program-library/actions/runs/3316735829/jobs/5478868796 for an example.

#### Solution

Update the patch!