### PR TITLE
[token-2022] Let error from large extensions propagate out when initing an extension

### DIFF
--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -491,7 +491,7 @@ impl<'data, S: BaseState> StateWithExtensionsMut<'data, S> {
                 pod_from_bytes_mut::<Length>(&mut self.tlv_data[length_start..value_start])?;
             // maybe this becomes smarter later for dynamically sized extensions
             let length = pod_get_packed_len::<V>();
-            *length_ref = Length::try_from(length).unwrap();
+            *length_ref = Length::try_from(length)?;
 
             let value_end = value_start.saturating_add(length);
             let extension_ref =


### PR DESCRIPTION
If the length of an extension is greater than `u16::MAX`, then `init_extension` could cause a panic due to `unwrap`. It seems like we can let the error from `try_from` propagate out to the external caller in this case.

Addresses issue #3698.