### PR TITLE
Add memo to transfer()

### DIFF
--- a/token/js/src/constants.ts
+++ b/token/js/src/constants.ts
@@ -6,6 +6,9 @@ export const TOKEN_PROGRAM_ID = new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9
 /** Address of the SPL Token 2022 program */
 export const TOKEN_2022_PROGRAM_ID = new PublicKey('TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb');
 
+/** Address the Solana Memo program */
+export const MEMO_PROGRAM_ID = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr";
+
 /** Address of the SPL Associated Token Account program */
 export const ASSOCIATED_TOKEN_PROGRAM_ID = new PublicKey('ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL');
 

--- a/token/js/test/e2e/transfer.test.ts
+++ b/token/js/test/e2e/transfer.test.ts
@@ -15,6 +15,7 @@ import {
     approve,
     approveChecked,
     revoke,
+    MEMO_PROGRAM_ID,
 } from '../../src';
 
 import { TEST_PROGRAM_ID, newAccountWithLamports, getConnection } from '../common';
@@ -72,6 +73,27 @@ describe('transfer', () => {
     });
     it('transfer', async () => {
         await transfer(connection, payer, account1, account2, owner1, amount, [], undefined, TEST_PROGRAM_ID);
+
+        const destAccountInfo = await getAccount(connection, account2, undefined, TEST_PROGRAM_ID);
+        expect(destAccountInfo.amount).to.eql(amount);
+
+        const sourceAccountInfo = await getAccount(connection, account1, undefined, TEST_PROGRAM_ID);
+        expect(sourceAccountInfo.amount).to.eql(BigInt(0));
+    });
+    it('transfer() with memo', async () => {
+        await transfer(
+            connection,
+            payer,
+            account1,
+            account2,
+            owner1,
+            amount,
+            [],
+            undefined,
+            TEST_PROGRAM_ID,
+            MEMO_PROGRAM_ID,
+            'Concert tickets'
+        );
 
         const destAccountInfo = await getAccount(connection, account2, undefined, TEST_PROGRAM_ID);
         expect(destAccountInfo.amount).to.eql(amount);


### PR DESCRIPTION
In Solana's native token documentation, there is frequently examples of using memos. Eg: [Solana Cookbook](https://solanacookbook.com/references/basic-transactions.html#how-to-add-a-memo-to-a-transaction) or [Quicknode documentation](https://www.quicknode.com/guides/solana-development/how-to-use-the-solana-memo-program) - memos provide a handy way to see the reason for a transactions, eg comparing the same transaction in Phantom versus [Portal](https://getportal.app/) (using the memo app):

![image](https://user-images.githubusercontent.com/172594/197781553-aaa63fc2-6479-410f-8a5e-920d1164bfdc.png)

However `transfer()`, SPL's high level tool, doesn't allow memos on Token transactions. 

This PR adds an optional `memo` for SPL transactions and an associated test. If memo is `undefined` or `null` or an empty string, no memo will be made. The change is compatible with the existing function signature of `transfer()` as it only adds options and does not change the order.