### PR TITLE
token-2022: Add unnecessary owner checks for more clarity

### DIFF
--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -874,6 +874,8 @@ fn process_withdraw_withheld_tokens_from_mint(
     let authority_info = next_account_info(account_info_iter)?;
     let authority_info_data_len = authority_info.data_len();
 
+    // unnecessary check, but helps for clarity
+    check_program_account(mint_account_info.owner)?;
     let mut mint_data = mint_account_info.data.borrow_mut();
     let mut mint = StateWithExtensionsMut::<Mint>::unpack(&mut mint_data)?;
 
@@ -969,6 +971,8 @@ fn process_withdraw_withheld_tokens_from_accounts(
         .len()
         .saturating_sub(num_token_accounts as usize);
 
+    // unnecessary check, but helps for clarity
+    check_program_account(mint_account_info.owner)?;
     let mut mint_data = mint_account_info.data.borrow_mut();
     let mut mint = StateWithExtensionsMut::<Mint>::unpack(&mut mint_data)?;
 

--- a/token/program-2022/src/extension/transfer_fee/processor.rs
+++ b/token/program-2022/src/extension/transfer_fee/processor.rs
@@ -119,6 +119,9 @@ fn process_withdraw_withheld_tokens_from_mint(
     let authority_info = next_account_info(account_info_iter)?;
     let authority_info_data_len = authority_info.data_len();
 
+    // unnecessary check, but helps for clarity
+    check_program_account(mint_account_info.owner)?;
+
     let mut mint_data = mint_account_info.data.borrow_mut();
     let mut mint = StateWithExtensionsMut::<Mint>::unpack(&mut mint_data)?;
     let extension = mint.get_extension_mut::<TransferFeeConfig>()?;
@@ -213,6 +216,9 @@ fn process_withdraw_withheld_tokens_from_accounts(
     let num_signers = account_infos
         .len()
         .saturating_sub(num_token_accounts as usize);
+
+    // unnecessary check, but helps for clarity
+    check_program_account(mint_account_info.owner)?;
 
     let mint_data = mint_account_info.data.borrow();
     let mint = StateWithExtensions::<Mint>::unpack(&mint_data)?;


### PR DESCRIPTION
#### Problem

The fee withdrawal functions in token-2022 don't have explicit owner checks on some accounts. Although these are not exploitable, it could allow an instruction to get a little further in processing than expected.

#### Solution

Add a couple of ownership checks.  Note that the linked issue mentions the reallocate instruction, but doing it there is completely unnecessary since the runtime would break first.

Fixes #3696