### PR TITLE
token-2022: Clarify `decode_instruction_data`

### DIFF
--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -1759,11 +1759,21 @@ pub fn decode_instruction_type<T: TryFrom<u8>>(input: &[u8]) -> Result<T, Progra
 }
 
 /// Utility function for decoding instruction data
-pub fn decode_instruction_data<T: Pod>(input: &[u8]) -> Result<&T, ProgramError> {
-    if input.len() != pod_get_packed_len::<T>().saturating_add(1) {
+///
+/// Note: This function expects the entire instruction input, including the
+/// instruction type as the first byte.  This makes the code concise and safe
+/// at the expense of clarity, allowing flows such as:
+///
+/// match decode_instruction_type(input)? {
+///     InstructionType::First => {
+///         let FirstData { ... } = decode_instruction_data(input)?;
+///     }
+/// }
+pub fn decode_instruction_data<T: Pod>(input_with_type: &[u8]) -> Result<&T, ProgramError> {
+    if input_with_type.len() != pod_get_packed_len::<T>().saturating_add(1) {
         Err(ProgramError::InvalidInstructionData)
     } else {
-        pod_from_bytes(&input[1..])
+        pod_from_bytes(&input_with_type[1..])
     }
 }
 


### PR DESCRIPTION
#### Problem

`decode_instruction_data` is a bit unclear, since it expects the full input, including the first byte for the instruction type. This can be confusing to users.

#### Solution

Since this is already used in the monorepo, it'll be too much of a headache to change this. Let's just comment the unclear behavior.

Fixes #3699