### PR TITLE
token-2022: Error sooner when searching for an extension in TLV data

### DIFF
--- a/token/program-2022/src/error.rs
+++ b/token/program-2022/src/error.rs
@@ -187,6 +187,9 @@ pub enum TokenError {
     /// Account ownership cannot be changed while CPI Guard is enabled
     #[error("Account ownership cannot be changed while CPI Guard is enabled")]
     CpiGuardOwnerChangeBlocked,
+    /// Extension not found in account data
+    #[error("Extension not found in account data")]
+    ExtensionNotFound,
 }
 impl From<TokenError> for ProgramError {
     fn from(e: TokenError) -> Self {
@@ -322,6 +325,9 @@ impl PrintProgramError for TokenError {
             }
             TokenError::CpiGuardOwnerChangeBlocked => {
                 msg!("Account ownership cannot be changed while CPI Guard is enabled")
+            }
+            TokenError::ExtensionNotFound => {
+                msg!("Extension not found in account data")
             }
         }
     }


### PR DESCRIPTION
#### Problem

When searching for an extension in the TLV data, if we get to an uninitialized spot, we keep going, but when initializing we stop there.  This means that we're searching too far, and completely unnecessarily.

#### Solution

Stop the search earlier, since nothing is ever written after the `Uninitialized` spot.

Fixes  #3701