### PR TITLE
token-2022: Remove redundant mint initialization check [ZELLIC-4.3]

### DIFF
--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -61,10 +61,6 @@ impl Processor {
         }
 
         let mut mint = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut mint_data)?;
-        if mint.base.is_initialized {
-            return Err(TokenError::AlreadyInUse.into());
-        }
-
         let extension_types = mint.get_extension_types()?;
         if ExtensionType::get_account_len::<Mint>(&extension_types) != mint_data_len {
             return Err(ProgramError::InvalidAccountData);


### PR DESCRIPTION
#### Problem

During `unpack_uninitialized`, there's a check to make sure that the base is not initialized https://github.com/solana-labs/solana-program-library/blob/12c11f6f9c42be5d232403335f46d3a3a82da46d/token/program-2022/src/extension/mod.rs#L388-L390, but we check it anyway during mint initialization.

#### Solution

Remove the redundant check.