### PR TITLE
chore: replace '::set-output' with '>> $GITHUB_OUTPUT'

### DIFF
--- a/.github/workflows/pull-request-docs.yml
+++ b/.github/workflows/pull-request-docs.yml
@@ -33,13 +33,13 @@ jobs:
         id: check_files
         run: |
           echo "========== check paths of modified files =========="
-          echo "::set-output name=run_all_github_action_checks::true"
+          echo "run_all_github_action_checks=true" >> $GITHUB_OUTPUT
           git diff --name-only HEAD^ HEAD > files.txt
           while IFS= read -r file
           do
             if [[ $file != docs/** ]]; then
               echo "Found modified non-'docs' file(s)"
-              echo "::set-output name=run_all_github_action_checks::false"
+              echo "run_all_github_action_checks=false" >> $GITHUB_OUTPUT
               break
             fi
           done < files.txt

--- a/.github/workflows/pull-request-docs.yml
+++ b/.github/workflows/pull-request-docs.yml
@@ -4,10 +4,12 @@ on:
   pull_request:
     paths:
     - 'docs/**'
+    - '.github/workflows/pull-request-docs.yml'
   push:
     branches: [master]
     paths:
     - 'docs/**'
+    - '.github/workflows/pull-request-docs.yml'
 
 jobs:
   all_github_action_checks:


### PR DESCRIPTION
### Problem
[GitHub Actions: Deprecating save-state and set-output commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

### Summary of Changes
replace `::set-output` with `>> $GITHUB_OUTPUT`