### PR TITLE
[token-2022] Remove transfer with fee instruction

### DIFF
--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -1208,23 +1208,6 @@ pub(crate) fn process_instruction(
             #[cfg(not(feature = "zk-ops"))]
             Err(ProgramError::InvalidInstructionData)
         }
-        ConfidentialTransferInstruction::TransferWithFee => {
-            msg!("ConfidentialTransferInstruction::TransferWithFee");
-            #[cfg(feature = "zk-ops")]
-            {
-                let data = decode_instruction_data::<TransferInstructionData>(input)?;
-                process_transfer(
-                    program_id,
-                    accounts,
-                    data.new_source_decryptable_available_balance,
-                    data.proof_instruction_offset as i64,
-                )
-            }
-            #[cfg(not(feature = "zk-ops"))]
-            {
-                Err(ProgramError::InvalidInstructionData)
-            }
-        }
         ConfidentialTransferInstruction::ApplyPendingBalance => {
             msg!("ConfidentialTransferInstruction::ApplyPendingBalance");
             #[cfg(feature = "zk-ops")]


### PR DESCRIPTION
#### Problem
The confidential extension `Transfer` and `TransferWithFee` instructions are identical except for the zk proof instruction that should accompany it in the same transaction.

#### Solution
Remove the `TransferWithFee` instruction. The instruction processor can already distinguish whether to process a transfer instruction with respect to fee by checking if the mint is extended for fees.

Fixes #3704 