### PR TITLE
[token-2022] Add pubkey consistency check on account and proof data [ZELLIC-3.3]

### DIFF
--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -252,6 +252,10 @@ fn process_empty_account(
         return Err(ProgramError::InvalidInstructionData);
     }
 
+    if confidential_transfer_account.encryption_pubkey != proof_data.pubkey {
+        return Err(TokenError::ConfidentialTransferElGamalPubkeyMismatch.into());
+    }
+
     confidential_transfer_account.available_balance = EncryptedBalance::zeroed();
     confidential_transfer_account.closable()?;
 


### PR DESCRIPTION
#### Problem

The ElGamal pubkeys that are associated with a token account and the proof data in an `EmptyAccount` instruction are not checked for consistency, which could lead to a deflationary bug.

#### Solution

Add the consistency check.