### PR TITLE
[token-2022] Add pubkey consistency check on account and proof data for withdraw [ZELLIC 3.2]

### DIFF
--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -424,6 +424,10 @@ fn process_withdraw(
     let mut confidential_transfer_account =
         token_account.get_extension_mut::<ConfidentialTransferAccount>()?;
 
+    if confidential_transfer_account.encryption_pubkey != proof_data.pubkey {
+        return Err(TokenError::ConfidentialTransferElGamalPubkeyMismatch.into());
+    }
+
     confidential_transfer_account.available_balance =
         ops::subtract_from(&confidential_transfer_account.available_balance, amount)
             .ok_or(ProgramError::InvalidInstructionData)?;


### PR DESCRIPTION
#### Problem
The ElGamal pubkeys that are associated with a token account and the proof data in a `Withdraw` instruction are not checked for consistency, which could lead to an inflationary bug.

#### Solution
Add the consistency check.