### PR TITLE
[token-2022] Add doc regarding the ability of withdraw withheld authority [ZELLIC-3.4]

### DIFF
--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -110,6 +110,9 @@ pub enum ConfidentialTransferInstruction {
     /// prior to account closing if no instructions beyond
     /// `ConfidentialTransferInstruction::ConfigureAccount` have affected the token account.
     ///
+    /// In order for this instruction to be successfully processed, it must be accompanied by the
+    /// `VerifyCloseAccount` instruction of the `zk_token_proof` program in the same transaction.
+    ///
     ///   * Single owner/delegate
     ///   0. `[writable]` The SPL Token account.
     ///   1. `[]` Instructions sysvar.
@@ -157,6 +160,9 @@ pub enum ConfidentialTransferInstruction {
     /// Fails if the source or destination accounts are frozen.
     /// Fails if the associated mint is extended as `NonTransferable`.
     ///
+    /// In order for this instruction to be successfully processed, it must be accompanied by the
+    /// `VerifyWithdraw` instruction of the `zk_token_proof` program in the same transaction.
+    ///
     /// Accounts expected by this instruction:
     ///
     ///   * Single owner/delegate
@@ -178,6 +184,10 @@ pub enum ConfidentialTransferInstruction {
     Withdraw,
 
     /// Transfer tokens confidentially.
+    ///
+    /// In order for this instruction to be successfully processed, it must be accompanied by
+    /// either the `VerifyTransfer` or `VerifyTransferWithFee` instruction of the `zk_token_proof`
+    /// program in the same transaction.
     ///
     /// Fails if the associated mint is extended as `NonTransferable`.
     ///
@@ -266,6 +276,10 @@ pub enum ConfidentialTransferInstruction {
     /// Transfer all withheld confidential tokens in the mint to an account. Signed by the mint's
     /// withdraw withheld tokens authority.
     ///
+    /// In order for this instruction to be successfully processed, it must be accompanied by the
+    /// `VerifyWithdrawWithheldTokens` instruction of the `zk_token_proof` program in the same
+    /// transaction.
+    ///
     /// Accounts expected by this instruction:
     ///
     ///   * Single owner/delegate
@@ -306,6 +320,10 @@ pub enum ConfidentialTransferInstruction {
     /// authority can first move the withheld amount to the mint using
     /// `HarvestWithheldTokensToMint` and then move the withheld fees from mint to a specified
     /// destination account using `WithdrawWithheldTokensFromMint`.
+    ///
+    /// In order for this instruction to be successfully processed, it must be accompanied by the
+    /// `VerifyWithdrawWithheldTokens` instruction of the `zk_token_proof` program in the same
+    /// transaction.
     ///
     /// Accounts expected by this instruction:
     ///

--- a/token/program-2022/src/extension/confidential_transfer/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer/mod.rs
@@ -57,11 +57,20 @@ pub struct ConfidentialTransferMint {
     ///              `ConfidentialTransferInstruction::ConfigureAccount`)
     pub auto_approve_new_accounts: PodBool,
 
+    /// Authority to decode any transfer amount in a confidential transafer.
+    ///
     /// * If non-zero, transfers must include ElGamal cypertext with this public key permitting the
     /// auditor to decode the transfer amount.
     /// * If all zero, auditing is currently disabled.
     pub auditor_encryption_pubkey: EncryptionPubkey,
 
+    /// Authority to withraw withheld fees that are associated with accounts. It must be set to an
+    /// all zero pubkey if the mint is not extended for fees.
+    ///
+    /// Note that the withdraw withheld authority has the ability to decode any withheld fee
+    /// amount that are associated with accounts. When combined with the fee parameters, the
+    /// withheld fee amounts can reveal information about transfer amounts.
+    ///
     /// * If non-zero, transfers must include ElGamal cypertext of the transfer fee with this
     /// public key. If this is the case, but the base mint is not extended for fees, then any
     /// transfer will fail.


### PR DESCRIPTION
#### Problem
The withdraw withheld authority can decrypt withheld fee amounts associated with accounts, which could reveal information about transfer amounts. However, this is not fully described in the confidential extension docs.

#### Solution
Update the docs to mention that a withdraw withheld authority can decrypt withheld amounts associated with accounts. This should be added to the confidential extension docs in spl.solana.com in a separate PR.