### PR TITLE
token: Fix some spelling mistakes

### DIFF
--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -407,7 +407,7 @@ pub struct WithdrawInstructionData {
     pub amount: PodU64,
     /// Expected number of base 10 digits to the right of the decimal place
     pub decimals: u8,
-    /// The new decryptable balance if the withrawal succeeds
+    /// The new decryptable balance if the withdrawal succeeds
     pub new_decryptable_available_balance: DecryptableBalance,
     /// Relative location of the `ProofInstruction::VerifyWithdraw` instruction to the `Withdraw`
     /// instruction in the transaction

--- a/token/program-2022/src/extension/confidential_transfer/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer/mod.rs
@@ -59,7 +59,7 @@ pub struct ConfidentialTransferMint {
 
     /// Authority to decode any transfer amount in a confidential transafer.
     ///
-    /// * If non-zero, transfers must include ElGamal cypertext with this public key permitting the
+    /// * If non-zero, transfers must include ElGamal cyphertext with this public key permitting the
     /// auditor to decode the transfer amount.
     /// * If all zero, auditing is currently disabled.
     pub auditor_encryption_pubkey: EncryptionPubkey,
@@ -71,7 +71,7 @@ pub struct ConfidentialTransferMint {
     /// amount that are associated with accounts. When combined with the fee parameters, the
     /// withheld fee amounts can reveal information about transfer amounts.
     ///
-    /// * If non-zero, transfers must include ElGamal cypertext of the transfer fee with this
+    /// * If non-zero, transfers must include ElGamal cyphertext of the transfer fee with this
     /// public key. If this is the case, but the base mint is not extended for fees, then any
     /// transfer will fail.
     /// * If all zero, transfer fee is disabled. If this is the case, but the base mint is extended

--- a/token/program-2022/src/extension/interest_bearing_mint/mod.rs
+++ b/token/program-2022/src/extension/interest_bearing_mint/mod.rs
@@ -88,7 +88,7 @@ impl InterestBearingConfig {
         Some(scaled_amount_with_interest.to_string())
     }
 
-    /// Try to convert a UI represenation of a token amount to its raw amount using the given decimals
+    /// Try to convert a UI representation of a token amount to its raw amount using the given decimals
     /// field
     pub fn try_ui_amount_into_amount(
         &self,

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -1616,7 +1616,7 @@ mod test {
         let err = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut buffer).unwrap_err();
         assert_eq!(err, ProgramError::InvalidAccountData);
 
-        // ok since there are two bytes for the type, which is `Uninitialized`
+        // OK since there are two bytes for the type, which is `Uninitialized`
         let mut buffer = vec![0; BASE_ACCOUNT_LENGTH + 3];
         let mut state = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut buffer).unwrap();
         let err = state.get_extension_mut::<MintCloseAuthority>().unwrap_err();
@@ -1624,7 +1624,7 @@ mod test {
 
         assert_eq!(state.get_extension_types().unwrap(), vec![]);
 
-        // malformed since there aren't too bytes for the type
+        // malformed since there aren't two bytes for the type
         let mut buffer = vec![0; BASE_ACCOUNT_LENGTH + 2];
         let state = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut buffer).unwrap();
         assert_eq!(

--- a/token/program-2022/src/lib.rs
+++ b/token/program-2022/src/lib.rs
@@ -64,12 +64,12 @@ pub fn amount_to_ui_amount_string_trimmed(amount: u64, decimals: u8) -> String {
     s
 }
 
-/// Try to convert a UI represenation of a token amount to its raw amount using the given decimals
+/// Try to convert a UI representation of a token amount to its raw amount using the given decimals
 /// field
 pub fn try_ui_amount_into_amount(ui_amount: String, decimals: u8) -> Result<u64, ProgramError> {
     let decimals = decimals as usize;
     let mut parts = ui_amount.split('.');
-    let mut amount_str = parts.next().unwrap().to_string(); // splitting a string, even an empty one, will always yield an iterator of at least len == 1
+    let mut amount_str = parts.next().unwrap().to_string(); // splitting a string, even an empty one, will always yield an iterator of at least length == 1
     let after_decimal = parts.next().unwrap_or("");
     let after_decimal = after_decimal.trim_end_matches('0');
     if (amount_str.is_empty() && after_decimal.is_empty())

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -6407,7 +6407,7 @@ mod tests {
         let account = Account::unpack_unchecked(&account_account.data).unwrap();
         assert_eq!(account.amount, u64::MAX);
 
-        // atttempt to mint one more to the other account
+        // attempt to mint one more to the other account
         assert_eq!(
             Err(TokenError::Overflow.into()),
             do_process_instruction(

--- a/token/program-2022/src/state.rs
+++ b/token/program-2022/src/state.rs
@@ -468,7 +468,7 @@ pub(crate) mod test {
         let result = Account::unpack_account_owner(&src);
         assert!(result.is_none());
 
-        // Account data length is multi-sig data size with a valid extension and initalized,
+        // Account data length is multi-sig data size with a valid extension and initialized,
         // expect none
         let mut src: [u8; Multisig::LEN] = [0; Multisig::LEN];
         src[ACCOUNT_INITIALIZED_INDEX] = AccountState::Initialized as u8;
@@ -502,7 +502,7 @@ pub(crate) mod test {
         let result = Account::unpack_account_mint(&src);
         assert_eq!(result, Option::None);
 
-        // Account data length > account data size with a valid extension and initalized,
+        // Account data length > account data size with a valid extension and initialized,
         // expect some key returned
         let mut src: [u8; Account::LEN + 5] = [0; Account::LEN + 5];
         src[ACCOUNT_INITIALIZED_INDEX] = AccountState::Initialized as u8;
@@ -510,13 +510,13 @@ pub(crate) mod test {
         let result = Account::unpack_account_mint(&src);
         assert!(result.is_some());
 
-        // Account data length > account data size with a valid extension but uninitalized,
+        // Account data length > account data size with a valid extension but uninitialized,
         // expect none
         src[ACCOUNT_INITIALIZED_INDEX] = AccountState::Uninitialized as u8;
         let result = Account::unpack_account_mint(&src);
         assert!(result.is_none());
 
-        // Account data length is multi-sig data size with a valid extension and initalized,
+        // Account data length is multi-sig data size with a valid extension and initialized,
         // expect none
         let mut src: [u8; Multisig::LEN] = [0; Multisig::LEN];
         src[ACCOUNT_INITIALIZED_INDEX] = AccountState::Initialized as u8;

--- a/token/program/src/instruction.rs
+++ b/token/program/src/instruction.rs
@@ -466,7 +466,7 @@ pub enum TokenInstruction<'a> {
     },
     // Any new variants also need to be added to program-2022 `TokenInstruction`, so that the
     // latter remains a superset of this instruction set. New variants also need to be added to
-    // token/js/src/instructions/types.ts to maintain @solana/spl-token compatability
+    // token/js/src/instructions/types.ts to maintain @solana/spl-token compatibility
 }
 impl<'a> TokenInstruction<'a> {
     /// Unpacks a byte buffer into a [TokenInstruction](enum.TokenInstruction.html).

--- a/token/program/src/lib.rs
+++ b/token/program/src/lib.rs
@@ -53,12 +53,12 @@ pub fn amount_to_ui_amount_string_trimmed(amount: u64, decimals: u8) -> String {
     s
 }
 
-/// Try to convert a UI represenation of a token amount to its raw amount using the given decimals
+/// Try to convert a UI representation of a token amount to its raw amount using the given decimals
 /// field
 pub fn try_ui_amount_into_amount(ui_amount: String, decimals: u8) -> Result<u64, ProgramError> {
     let decimals = decimals as usize;
     let mut parts = ui_amount.split('.');
-    let mut amount_str = parts.next().unwrap().to_string(); // splitting a string, even an empty one, will always yield an iterator of at least len == 1
+    let mut amount_str = parts.next().unwrap().to_string(); // splitting a string, even an empty one, will always yield an iterator of at least length == 1
     let after_decimal = parts.next().unwrap_or("");
     let after_decimal = after_decimal.trim_end_matches('0');
     if (amount_str.is_empty() && after_decimal.is_empty())

--- a/token/program/src/processor.rs
+++ b/token/program/src/processor.rs
@@ -6066,7 +6066,7 @@ mod tests {
         let account = Account::unpack_unchecked(&account_account.data).unwrap();
         assert_eq!(account.amount, u64::MAX);
 
-        // atttempt to mint one more to the other account
+        // attempt to mint one more to the other account
         assert_eq!(
             Err(TokenError::Overflow.into()),
             do_process_instruction(

--- a/token/program/src/state.rs
+++ b/token/program/src/state.rs
@@ -435,7 +435,7 @@ mod tests {
         let result = Account::unpack_account_owner(&src);
         assert_eq!(result, Option::None);
 
-        // The right account data size and intialized, unpack will return some key
+        // The right account data size and initialized, unpack will return some key
         let mut src: [u8; Account::LEN] = [0; Account::LEN];
         src[ACCOUNT_INITIALIZED_INDEX] = AccountState::Initialized as u8;
         let result = Account::unpack_account_owner(&src);


### PR DESCRIPTION
#### Problem

I made a typo, as pointed out at https://github.com/solana-labs/solana-program-library/pull/3762#discussion_r1005944946

#### Solution

This isn't ready for CI yet, but I've been using `cargo spellcheck` https://github.com/drahnr/cargo-spellcheck to check for other errors with a pretty small additional dictionary and checking rules. Here are the results of fixing the token program and program-2022 crates.