### PR TITLE
token-js: Bump version to 0.3.6 for release

### DIFF
--- a/token/js/package-lock.json
+++ b/token/js/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@solana/spl-token",
-    "version": "0.3.4",
+    "version": "0.3.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@solana/spl-token",
-            "version": "0.3.4",
+            "version": "0.3.6",
             "license": "Apache-2.0",
             "dependencies": {
                 "@solana/buffer-layout": "^4.0.0",

--- a/token/js/package.json
+++ b/token/js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@solana/spl-token",
     "description": "SPL Token Program JS API",
-    "version": "0.3.5",
+    "version": "0.3.6",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/solana-program-library",
     "license": "Apache-2.0",


### PR DESCRIPTION
#### Problem

The `CreateIdempotent` ATA instruction binding was added a few weeks ago, but there's no new release of `spl-token` that includes it.

#### Solution

Bump the version to release.