### PR TITLE
token-cli: Support DefaultAccountState extension

### DIFF
--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -5587,6 +5587,7 @@ mod tests {
             true,
             None,
             None,
+            None,
             bulk_signers,
         )
         .await
@@ -5635,6 +5636,7 @@ mod tests {
             token_pubkey,
             payer.pubkey(),
             true,
+            false,
             false,
             None,
             None,

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -425,9 +425,10 @@ async fn command_create_token(
     }
 
     if let Some(state) = default_account_state {
-        if !enable_freeze {
-            return Err("Token requires a freeze authority to default to frozen accounts".into());
-        }
+        assert!(
+            enable_freeze,
+            "Token requires a freeze authority to default to frozen accounts"
+        );
         extensions.push(ExtensionInitializationParams::DefaultAccountState { state })
     }
 


### PR DESCRIPTION
#### Problem

The default account state extension exists, but isn't supported in the CLI.

#### Solution

Add support for the extension through a flag during `create-token` called `default-frozen-accounts` and a new command `update-default-account-state`.

I don't feel strongly about the flag names, so happy to bikeshed.  We could make it `--default-account-state initialized` or `--default-account-state frozen` as an alternative to be totally flexible during mint initialization, but that seemed more confusing, since people might feel compelled to use `--default-account-state initialized` as a "sensible default", when really they don't want the extension at all.

Fixes #3404