### PR TITLE
[token-2022] Enable confidential payments only feature

### DIFF
--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -2151,36 +2151,80 @@ where
     }
 
     /// Enable confidential transfer `Deposit` and `Transfer` instructions for a token account
-    pub async fn confidential_transfer_enable_balance_credits<S: Signer>(
+    pub async fn confidential_transfer_enable_confidential_credits<S: Signer>(
         &self,
         token_account: &Pubkey,
         authority: &S,
     ) -> TokenResult<T::Output> {
         self.process_ixs(
-            &[confidential_transfer::instruction::enable_balance_credits(
-                &self.program_id,
-                token_account,
-                &authority.pubkey(),
-                &[],
-            )?],
+            &[
+                confidential_transfer::instruction::enable_confidential_credits(
+                    &self.program_id,
+                    token_account,
+                    &authority.pubkey(),
+                    &[],
+                )?,
+            ],
             &[authority],
         )
         .await
     }
 
     /// Disable confidential transfer `Deposit` and `Transfer` instructions for a token account
-    pub async fn confidential_transfer_disable_balance_credits<S: Signer>(
+    pub async fn confidential_transfer_disable_confidential_credits<S: Signer>(
         &self,
         token_account: &Pubkey,
         authority: &S,
     ) -> TokenResult<T::Output> {
         self.process_ixs(
-            &[confidential_transfer::instruction::disable_balance_credits(
-                &self.program_id,
-                token_account,
-                &authority.pubkey(),
-                &[],
-            )?],
+            &[
+                confidential_transfer::instruction::disable_confidential_credits(
+                    &self.program_id,
+                    token_account,
+                    &authority.pubkey(),
+                    &[],
+                )?,
+            ],
+            &[authority],
+        )
+        .await
+    }
+
+    /// Enable a confidential extension token account to receive non-confidential payments
+    pub async fn confidential_transfer_enable_non_confidential_credits<S: Signer>(
+        &self,
+        token_account: &Pubkey,
+        authority: &S,
+    ) -> TokenResult<T::Output> {
+        self.process_ixs(
+            &[
+                confidential_transfer::instruction::enable_non_confidential_credits(
+                    &self.program_id,
+                    token_account,
+                    &authority.pubkey(),
+                    &[],
+                )?,
+            ],
+            &[authority],
+        )
+        .await
+    }
+
+    /// Disable a confidential extension token account to receive non-confidential payments
+    pub async fn confidential_transfer_disable_non_confidential_credits<S: Signer>(
+        &self,
+        token_account: &Pubkey,
+        authority: &S,
+    ) -> TokenResult<T::Output> {
+        self.process_ixs(
+            &[
+                confidential_transfer::instruction::disable_non_confidential_credits(
+                    &self.program_id,
+                    token_account,
+                    &authority.pubkey(),
+                    &[],
+                )?,
+            ],
             &[authority],
         )
         .await

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -2210,7 +2210,7 @@ where
         .await
     }
 
-    /// Disable a confidential extension token account to receive non-confidential payments
+    /// Disable non-confidential payments for a confidential extension token account
     pub async fn confidential_transfer_disable_non_confidential_credits<S: Signer>(
         &self,
         token_account: &Pubkey,

--- a/token/program-2022/src/error.rs
+++ b/token/program-2022/src/error.rs
@@ -190,6 +190,9 @@ pub enum TokenError {
     /// Extension not found in account data
     #[error("Extension not found in account data")]
     ExtensionNotFound,
+    /// Account does not accept non-confidential transfers
+    #[error("Non-confidential transfers disabled")]
+    NonConfidentialTransfersDisabled,
 }
 impl From<TokenError> for ProgramError {
     fn from(e: TokenError) -> Self {
@@ -328,6 +331,9 @@ impl PrintProgramError for TokenError {
             }
             TokenError::ExtensionNotFound => {
                 msg!("Extension not found in account data")
+            }
+            TokenError::NonConfidentialTransfersDisabled => {
+                msg!("Non-confidential transfers disabled")
             }
         }
     }

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -284,7 +284,7 @@ pub enum ConfidentialTransferInstruction {
     ///
     DisableConfidentialCredits,
 
-    /// Configure a base account of a confidential extension to accept incoming non-confidential
+    /// Configure an account with the confidential extension to accept incoming non-confidential
     /// transfers.
     ///
     /// Accounts expected by this instruction:
@@ -303,7 +303,7 @@ pub enum ConfidentialTransferInstruction {
     ///
     EnableNonConfidentialCredits,
 
-    /// Configure a base account of a confidential extension to reject any incoming
+    /// Configure an account with the confidential extension to reject any incoming
     /// non-confidential transfers.
     ///
     /// This instruction can be used to configure a confidential extension account to exclusively

--- a/token/program-2022/src/extension/confidential_transfer/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer/mod.rs
@@ -110,8 +110,11 @@ pub struct ConfidentialTransferAccount {
     /// The decryptable available balance
     pub decryptable_available_balance: DecryptableBalance,
 
-    /// `pending_balance` may only be credited by `Deposit` or `Transfer` instructions if `true`
-    pub allow_balance_credits: PodBool,
+    /// If `false`, the extended account rejects any incoming confidential transfers
+    pub allow_confidential_credits: PodBool,
+
+    /// If `false`, the base account rejects any incoming confidential transfers
+    pub allow_non_confidential_credits: PodBool,
 
     /// The total number of `Deposit` and `Transfer` instructions that have credited
     /// `pending_balance`
@@ -157,6 +160,16 @@ impl ConfidentialTransferAccount {
             Ok(())
         } else {
             Err(TokenError::ConfidentialTransferAccountHasBalance.into())
+        }
+    }
+
+    /// Check if a base account of a `ConfidentialTransferAccount` accepts non-confidential
+    /// transfers
+    pub fn non_confidential_transfer_allowed(&self) -> ProgramResult {
+        if bool::from(&self.allow_non_confidential_credits) {
+            Ok(())
+        } else {
+            Err(TokenError::NonConfidentialTransfersDisabled.into())
         }
     }
 }

--- a/token/program-2022/src/extension/confidential_transfer/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer/mod.rs
@@ -113,7 +113,7 @@ pub struct ConfidentialTransferAccount {
     /// If `false`, the extended account rejects any incoming confidential transfers
     pub allow_confidential_credits: PodBool,
 
-    /// If `false`, the base account rejects any incoming confidential transfers
+    /// If `false`, the base account rejects any incoming transfers
     pub allow_non_confidential_credits: PodBool,
 
     /// The total number of `Deposit` and `Transfer` instructions that have credited

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -62,7 +62,7 @@ fn check_destination_confidential_account(
 ) -> ProgramResult {
     destination_confidential_transfer_account.approved()?;
 
-    if !bool::from(&destination_confidential_transfer_account.allow_balance_credits) {
+    if !bool::from(&destination_confidential_transfer_account.allow_confidential_credits) {
         return Err(TokenError::ConfidentialTransferDepositsAndTransfersDisabled.into());
     }
 
@@ -215,10 +215,11 @@ fn process_configure_account(
     confidential_transfer_account.available_balance = EncryptedBalance::zeroed();
 
     confidential_transfer_account.decryptable_available_balance = *decryptable_zero_balance;
-    confidential_transfer_account.allow_balance_credits = true.into();
+    confidential_transfer_account.allow_confidential_credits = true.into();
     confidential_transfer_account.pending_balance_credit_counter = 0.into();
     confidential_transfer_account.expected_pending_balance_credit_counter = 0.into();
     confidential_transfer_account.actual_pending_balance_credit_counter = 0.into();
+    confidential_transfer_account.allow_non_confidential_credits = true.into();
     confidential_transfer_account.withheld_amount = EncryptedWithheldAmount::zeroed();
 
     Ok(())
@@ -866,11 +867,11 @@ fn process_apply_pending_balance(
     Ok(())
 }
 
-/// Processes an [DisableBalanceCredits] or [EnableBalanceCredits] instruction.
-fn process_allow_balance_credits(
+/// Processes an [DisableConfidentialCredits] or [EnableConfidentialCredits] instruction.
+fn process_allow_confidential_credits(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
-    allow_balance_credits: bool,
+    allow_confidential_credits: bool,
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
     let token_account_info = next_account_info(account_info_iter)?;
@@ -891,7 +892,38 @@ fn process_allow_balance_credits(
 
     let mut confidential_transfer_account =
         token_account.get_extension_mut::<ConfidentialTransferAccount>()?;
-    confidential_transfer_account.allow_balance_credits = allow_balance_credits.into();
+    confidential_transfer_account.allow_confidential_credits = allow_confidential_credits.into();
+
+    Ok(())
+}
+
+/// Processes an [DisableConfidentialCredits] or [EnableConfidentialCredits] instruction.
+fn process_allow_non_confidential_credits(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    allow_non_confidential_credits: bool,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let token_account_info = next_account_info(account_info_iter)?;
+    let authority_info = next_account_info(account_info_iter)?;
+    let authority_info_data_len = authority_info.data_len();
+
+    check_program_account(token_account_info.owner)?;
+    let token_account_data = &mut token_account_info.data.borrow_mut();
+    let mut token_account = StateWithExtensionsMut::<Account>::unpack(token_account_data)?;
+
+    Processor::validate_owner(
+        program_id,
+        &token_account.base.owner,
+        authority_info,
+        authority_info_data_len,
+        account_info_iter.as_slice(),
+    )?;
+
+    let mut confidential_transfer_account =
+        token_account.get_extension_mut::<ConfidentialTransferAccount>()?;
+    confidential_transfer_account.allow_non_confidential_credits =
+        allow_non_confidential_credits.into();
 
     Ok(())
 }
@@ -1278,13 +1310,21 @@ pub(crate) fn process_instruction(
                 Err(ProgramError::InvalidInstructionData)
             }
         }
-        ConfidentialTransferInstruction::DisableBalanceCredits => {
-            msg!("ConfidentialTransferInstruction::DisableBalanceCredits");
-            process_allow_balance_credits(program_id, accounts, false)
+        ConfidentialTransferInstruction::DisableConfidentialCredits => {
+            msg!("ConfidentialTransferInstruction::DisableConfidentialCredits");
+            process_allow_confidential_credits(program_id, accounts, false)
         }
-        ConfidentialTransferInstruction::EnableBalanceCredits => {
-            msg!("ConfidentialTransferInstruction::EnableBalanceCredits");
-            process_allow_balance_credits(program_id, accounts, true)
+        ConfidentialTransferInstruction::EnableConfidentialCredits => {
+            msg!("ConfidentialTransferInstruction::EnableConfidentialCredits");
+            process_allow_confidential_credits(program_id, accounts, true)
+        }
+        ConfidentialTransferInstruction::DisableNonConfidentialCredits => {
+            msg!("ConfidentialTransferInstruction::DisableNonConfidentialCredits");
+            process_allow_non_confidential_credits(program_id, accounts, false)
+        }
+        ConfidentialTransferInstruction::EnableNonConfidentialCredits => {
+            msg!("ConfidentialTransferInstruction::EnableNonConfidentialCredits");
+            process_allow_non_confidential_credits(program_id, accounts, true)
         }
         ConfidentialTransferInstruction::WithdrawWithheldTokensFromMint => {
             msg!("ConfidentialTransferInstruction::WithdrawWithheldTokensFromMint");

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -867,7 +867,7 @@ fn process_apply_pending_balance(
     Ok(())
 }
 
-/// Processes an [DisableConfidentialCredits] or [EnableConfidentialCredits] instruction.
+/// Processes a [DisableConfidentialCredits] or [EnableConfidentialCredits] instruction.
 fn process_allow_confidential_credits(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -897,7 +897,7 @@ fn process_allow_confidential_credits(
     Ok(())
 }
 
-/// Processes an [DisableConfidentialCredits] or [EnableConfidentialCredits] instruction.
+/// Processes an [DisableNonConfidentialCredits] or [EnableNonConfidentialCredits] instruction.
 fn process_allow_non_confidential_credits(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -412,6 +412,12 @@ impl Processor {
             check_previous_sibling_instruction_is_memo()?;
         }
 
+        if let Ok(confidential_transfer_state) =
+            destination_account.get_extension::<ConfidentialTransferAccount>()
+        {
+            confidential_transfer_state.non_confidential_transfer_allowed()?
+        }
+
         source_account.base.amount = source_account
             .base
             .amount


### PR DESCRIPTION
#### Problem
For some applications, a user may wish to receive token payments only confidentially. However, there is currently no mechanism that allows this functionality in the token-2022 program.

#### Summary of Changes
- Add a new `allow_non_confidential_credits` field in the confidential account extension
- Update the `process_transfer` such that if `allow_non_confidential_credits` is `false`, then the transfer fails
- Add the `EnableConfidentialCredits` and `DisableConfidentialCredits` instructions that updates the `allow_non_confidential_credits` field

Closes #3631 