### PR TITLE
token-cli: Add non-transferable mint creation

### DIFF
--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -2168,6 +2168,7 @@ fn app<'a, 'b>(
                 .arg(
                     Arg::with_name("enable_non_transferable")
                         .long("enable-non-transferable")
+                        .alias("enable-nontransferable")
                         .takes_value(false)
                         .help(
                             "Permanently force tokens to be non-transferable. Thay may still be burned."


### PR DESCRIPTION
#### Problem

The non-transferable mint extension exists, but isn't usable in the CLI

#### Solution

Add the ability to create a non-transferable token mint