### PR TITLE
token-cli: Specify that `default-account-state` takes a value

### DIFF
--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -2253,6 +2253,7 @@ fn app<'a, 'b>(
                     Arg::with_name("default_account_state")
                         .long("default-account-state")
                         .requires("enable_freeze")
+                        .takes_value(true)
                         .possible_values(&["initialized", "frozen"])
                         .help("Specify that accounts have a default state. \
                             Note: specifying \"initialized\" adds an extension, which gives \


### PR DESCRIPTION
#### Problem

The default account state extension isn't working because the `default-account-state` flag doesn't say to take a value.

#### Solution

Specify `takes_value`