### PR TITLE
ci: Bump rust stable version for twotx build

### DIFF
--- a/.github/workflows/pull-request-token.yml
+++ b/.github/workflows/pull-request-token.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Set env vars
         run: |
-          echo "RUST_STABLE_VERSION=1.63.0" >> $GITHUB_ENV
+          echo "RUST_STABLE_VERSION=1.65.0" >> $GITHUB_ENV
           source ci/rust-version.sh
           echo "RUST_STABLE=$rust_stable" >> $GITHUB_ENV
           source ci/solana-version.sh


### PR DESCRIPTION
#### Problem

The two-tx build is failing due to unsupported language features, following the bump to rust 1.65 on the monorepo. See https://github.com/solana-labs/solana-program-library/actions/runs/3446859167/jobs/5752258103 for an example

#### Solution

Bump the version to 1.65 for the twotx build