### PR TITLE
token-cli: add `--recipient-owner` to mint

### DIFF
--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -2656,7 +2656,7 @@ fn app<'a, 'b>(
                 .arg(
                     Arg::with_name("recipient")
                         .validator(is_valid_pubkey)
-                        .value_name("RECIPIENT_ADDRESS or RECIPIENT_TOKEN_ACCOUNT_ADDRESS")
+                        .value_name("RECIPIENT_WALLET_ADDRESS or RECIPIENT_TOKEN_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .index(3)
                         .required(true)
@@ -2791,9 +2791,19 @@ fn app<'a, 'b>(
                         .validator(is_valid_pubkey)
                         .value_name("RECIPIENT_TOKEN_ACCOUNT_ADDRESS")
                         .takes_value(true)
+                        .conflicts_with("recipient_owner")
                         .index(3)
                         .help("The token account address of recipient \
                             [default: associated token account for --mint-authority]"),
+                )
+                .arg(
+                    Arg::with_name("recipient_owner")
+                        .long("recipient-owner")
+                        .validator(is_valid_pubkey)
+                        .value_name("RECIPIENT_WALLET_ADDRESS")
+                        .takes_value(true)
+                        .conflicts_with("recipient")
+                        .help("The owner of the recipient associated token account"),
                 )
                 .arg(
                     Arg::with_name("mint_authority")
@@ -3773,6 +3783,10 @@ async fn process_command<'a>(
                 pubkey_of_signer(arg_matches, "recipient", &mut wallet_manager).unwrap()
             {
                 address
+            } else if let Some(address) =
+                pubkey_of_signer(arg_matches, "recipient_owner", &mut wallet_manager).unwrap()
+            {
+                get_associated_token_address_with_program_id(&address, &token, &config.program_id)
             } else {
                 let owner = config.default_signer()?.pubkey();
                 config.associated_token_address_for_token_and_program(
@@ -4714,21 +4728,74 @@ mod tests {
             let config = test_config_with_default_signer(&test_validator, &payer, program_id);
             let token = create_token(&config, &payer).await;
             let account = create_associated_account(&config, &payer, token).await;
-            let result = process_test_command(
+            let mut amount = 0;
+
+            // mint via implicit owner
+            process_test_command(
                 &config,
                 &payer,
                 &[
                     "spl-token",
                     CommandName::Mint.into(),
                     &token.to_string(),
-                    "100",
+                    "1",
                 ],
             )
-            .await;
-            result.unwrap();
-            let account = config.rpc_client.get_account(&account).await.unwrap();
-            let token_account = StateWithExtensionsOwned::<Account>::unpack(account.data).unwrap();
-            assert_eq!(token_account.base.amount, 100);
+            .await
+            .unwrap();
+            amount += 1;
+
+            let account_data = config.rpc_client.get_account(&account).await.unwrap();
+            let token_account =
+                StateWithExtensionsOwned::<Account>::unpack(account_data.data).unwrap();
+            assert_eq!(token_account.base.amount, amount);
+            assert_eq!(token_account.base.mint, token);
+            assert_eq!(token_account.base.owner, payer.pubkey());
+
+            // mint via explicit recipient
+            process_test_command(
+                &config,
+                &payer,
+                &[
+                    "spl-token",
+                    CommandName::Mint.into(),
+                    &token.to_string(),
+                    "1",
+                    &account.to_string(),
+                ],
+            )
+            .await
+            .unwrap();
+            amount += 1;
+
+            let account_data = config.rpc_client.get_account(&account).await.unwrap();
+            let token_account =
+                StateWithExtensionsOwned::<Account>::unpack(account_data.data).unwrap();
+            assert_eq!(token_account.base.amount, amount);
+            assert_eq!(token_account.base.mint, token);
+            assert_eq!(token_account.base.owner, payer.pubkey());
+
+            // mint via explicit owner
+            process_test_command(
+                &config,
+                &payer,
+                &[
+                    "spl-token",
+                    CommandName::Mint.into(),
+                    &token.to_string(),
+                    "1",
+                    "--recipient-owner",
+                    &payer.pubkey().to_string(),
+                ],
+            )
+            .await
+            .unwrap();
+            amount += 1;
+
+            let account_data = config.rpc_client.get_account(&account).await.unwrap();
+            let token_account =
+                StateWithExtensionsOwned::<Account>::unpack(account_data.data).unwrap();
+            assert_eq!(token_account.base.amount, amount);
             assert_eq!(token_account.base.mint, token);
             assert_eq!(token_account.base.owner, payer.pubkey());
         }

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -70,13 +70,13 @@ use bench::*;
 pub const OWNER_ADDRESS_ARG: ArgConstant<'static> = ArgConstant {
     name: "owner",
     long: "owner",
-    help: "Address of the token's owner. Defaults to the client keypair address.",
+    help: "Address of the primary authority controlling a mint or account. Defaults to the client keypair address.",
 };
 
 pub const OWNER_KEYPAIR_ARG: ArgConstant<'static> = ArgConstant {
     name: "owner",
     long: "owner",
-    help: "Keypair of the token's owner. Defaults to the client keypair.",
+    help: "Keypair of the primary authority controlling a mint or account. Defaults to the client keypair.",
 };
 
 pub const MINT_ADDRESS_ARG: ArgConstant<'static> = ArgConstant {
@@ -1345,13 +1345,8 @@ async fn command_wrap(
     let lamports = sol_to_lamports(sol);
     let token = native_token_client_from_config(config)?;
 
-    let account = wrapped_sol_account.unwrap_or_else(|| {
-        get_associated_token_address_with_program_id(
-            &wallet_address,
-            token.get_address(),
-            &config.program_id,
-        )
-    });
+    let account =
+        wrapped_sol_account.unwrap_or_else(|| token.get_associated_token_address(&wallet_address));
 
     println_display(config, format!("Wrapping {} SOL into {}", sol, account));
 
@@ -1404,13 +1399,8 @@ async fn command_unwrap(
     let use_associated_account = maybe_account.is_none();
     let token = native_token_client_from_config(config)?;
 
-    let account = maybe_account.unwrap_or_else(|| {
-        get_associated_token_address_with_program_id(
-            &wallet_address,
-            token.get_address(),
-            &config.program_id,
-        )
-    });
+    let account =
+        maybe_account.unwrap_or_else(|| token.get_associated_token_address(&wallet_address));
 
     println_display(config, format!("Unwrapping {}", account));
 
@@ -2802,7 +2792,8 @@ fn app<'a, 'b>(
                         .value_name("RECIPIENT_TOKEN_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .index(3)
-                        .help("The token account address of recipient [default: associated token account for --owner]"),
+                        .help("The token account address of recipient \
+                            [default: associated token account for --mint-authority]"),
                 )
                 .arg(
                     Arg::with_name("mint_authority")
@@ -2950,6 +2941,7 @@ fn app<'a, 'b>(
                              Defaults to the client keypair."
                         ),
                 )
+                .arg(owner_address_arg())
                 .arg(multisig_signer_arg())
                 .nonce_args(true)
                 .offline_args(),
@@ -3024,7 +3016,6 @@ fn app<'a, 'b>(
                         .help("Token of the associated account to close. \
                               To close a specific account, use the `--address` parameter instead"),
                 )
-                .arg(owner_address_arg())
                 .arg(
                     Arg::with_name("recipient")
                         .long("recipient")
@@ -3057,6 +3048,7 @@ fn app<'a, 'b>(
                         .help("Specify the token account to close \
                             [default: owner's associated token account]"),
                 )
+                .arg(owner_address_arg())
                 .arg(multisig_signer_arg())
                 .nonce_args(true)
         )
@@ -3072,7 +3064,6 @@ fn app<'a, 'b>(
                         .required(true)
                         .help("Token to close"),
                 )
-                .arg(owner_address_arg())
                 .arg(
                     Arg::with_name("recipient")
                         .long("recipient")
@@ -3093,6 +3084,7 @@ fn app<'a, 'b>(
                             Defaults to the client keypair.",
                         ),
                 )
+                .arg(owner_address_arg())
                 .arg(multisig_signer_arg())
                 .nonce_args(true)
                 .offline_args(),


### PR DESCRIPTION
went ahead and did my suggestion in the issue, since i think its right. also cleaned up a few owner-related things to hopefully reduce ambiguity

closes #3684