### PR TITLE
token-2022: bump version to 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5814,7 +5814,7 @@ dependencies = [
  "num-traits",
  "solana-program",
  "spl-token 3.5.0",
- "spl-token-2022 0.4.3",
+ "spl-token-2022 0.5.0",
  "thiserror",
 ]
 
@@ -5843,7 +5843,7 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account 1.1.1",
  "spl-token 3.5.0",
- "spl-token-2022 0.4.3",
+ "spl-token-2022 0.5.0",
 ]
 
 [[package]]
@@ -6271,7 +6271,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-2022"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -6304,7 +6304,7 @@ dependencies = [
  "spl-associated-token-account 1.1.1",
  "spl-instruction-padding",
  "spl-memo 3.0.1",
- "spl-token-2022 0.4.3",
+ "spl-token-2022 0.5.0",
  "spl-token-client",
  "walkdir",
 ]
@@ -6334,7 +6334,7 @@ dependencies = [
  "spl-associated-token-account 1.1.1",
  "spl-memo 3.0.1",
  "spl-token 3.5.0",
- "spl-token-2022 0.4.3",
+ "spl-token-2022 0.5.0",
  "spl-token-client",
  "strum",
  "strum_macros",
@@ -6355,7 +6355,7 @@ dependencies = [
  "spl-associated-token-account 1.1.1",
  "spl-memo 3.0.1",
  "spl-token 3.5.0",
- "spl-token-2022 0.4.3",
+ "spl-token-2022 0.5.0",
  "thiserror",
 ]
 
@@ -6411,7 +6411,7 @@ dependencies = [
  "solana-sdk",
  "spl-math",
  "spl-token 3.5.0",
- "spl-token-2022 0.4.3",
+ "spl-token-2022 0.5.0",
  "test-case",
  "thiserror",
 ]
@@ -6439,7 +6439,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-token 3.5.0",
- "spl-token-2022 0.4.3",
+ "spl-token-2022 0.5.0",
  "spl-token-client",
  "test-case",
  "thiserror",
@@ -6460,7 +6460,7 @@ dependencies = [
  "solana-test-validator",
  "spl-associated-token-account 1.1.1",
  "spl-token 3.5.0",
- "spl-token-2022 0.4.3",
+ "spl-token-2022 0.5.0",
  "spl-token-client",
  "spl-token-upgrade",
  "tokio",

--- a/associated-token-account/program-test/Cargo.toml
+++ b/associated-token-account/program-test/Cargo.toml
@@ -16,4 +16,4 @@ solana-program-test = "1.14.6"
 solana-sdk = "1.14.6"
 spl-associated-token-account = { version = "1.1", path = "../program", features = ["no-entrypoint"] }
 spl-token = { version = "3.5", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "0.4", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.5", path = "../../token/program-2022", features = ["no-entrypoint"] }

--- a/associated-token-account/program/Cargo.toml
+++ b/associated-token-account/program/Cargo.toml
@@ -18,7 +18,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 solana-program = "1.14.6"
 spl-token = { version = "3.5", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "0.4", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.5", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [lib]

--- a/token-swap/program/Cargo.toml
+++ b/token-swap/program/Cargo.toml
@@ -20,7 +20,7 @@ num-traits = "0.2"
 solana-program = "1.14.6"
 spl-math = { version = "0.1", path = "../../libraries/math", features = [ "no-entrypoint" ] }
 spl-token = { version = "3.5", path = "../../token/program", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "0.4", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
+spl-token-2022 = { version = "0.5", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
 roots = { version = "0.0.7", optional = true }

--- a/token-upgrade/cli/Cargo.toml
+++ b/token-upgrade/cli/Cargo.toml
@@ -21,7 +21,7 @@ solana-remote-wallet = "1.14.6"
 solana-sdk = "1.14.6"
 spl-associated-token-account = { version = "1.1", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token = { version = "3.5", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "0.4", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.5", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.2.1", path = "../../token/client" }
 spl-token-upgrade = { version = "0.1", path = "../program", features = ["no-entrypoint"] }
 tokio = { version = "1", features = ["full"] }

--- a/token-upgrade/program/Cargo.toml
+++ b/token-upgrade/program/Cargo.toml
@@ -16,7 +16,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 num_enum = "0.5.4"
 solana-program = "1.14.6"
-spl-token-2022 = { version = "0.4", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.5", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -28,7 +28,7 @@ solana-remote-wallet = "=1.14.6"
 solana-sdk = "=1.14.6"
 solana-transaction-status = "=1.14.6"
 spl-token = { version = "3.5", path="../program", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "0.4", path="../program-2022", features = [ "no-entrypoint" ] }
+spl-token-2022 = { version = "0.5", path="../program-2022", features = [ "no-entrypoint" ] }
 spl-token-client = { version = "0.2.1", path="../client" }
 spl-associated-token-account = { version = "1.1", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
 spl-memo = { version = "3.0.1", path="../../memo/program", features = ["no-entrypoint"] }

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -18,7 +18,7 @@ solana-sdk = "=1.14.6"
 spl-associated-token-account = { version = "1.1", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-memo = { version = "3.0.1", path = "../../memo/program", features = ["no-entrypoint"] }
 spl-token = { version = "3.5", path="../program", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "0.4", path="../program-2022" }
+spl-token-2022 = { version = "0.5", path="../program-2022" }
 thiserror = "1.0"
 
 [features]

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -21,6 +21,6 @@ solana-program-test = "=1.14.6"
 solana-sdk = "=1.14.6"
 spl-associated-token-account = { version = "1.1", path = "../../associated-token-account/program" }
 spl-memo = { version = "3.0.1", path = "../../memo/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "0.4", path="../program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.5", path="../program-2022", features = ["no-entrypoint"] }
 spl-instruction-padding = { version = "0.1.0", path="../../instruction-padding/program", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.2.1", path = "../client" }

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-2022"
-version = "0.4.3"
+version = "0.5.0"
 description = "Solana Program Library Token 2022"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"


### PR DESCRIPTION
as described in other issues, im going to start the (somewhat complicated) release process, which in total will look like:
* bump token22. cargo release
* change monorepo version of token22 to match
* bump versions of token cli, token client, and token upgrade cli. cargo release 

this is just for the first bullet. please lmk if theres any changes you want to get into token22 before this

part of #3776 
