### PR TITLE
stake-pool: Bump token-2022 to 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6190,7 +6190,7 @@ dependencies = [
  "solana-vote-program",
  "spl-math",
  "spl-token 3.5.0",
- "spl-token-2022 0.4.3",
+ "spl-token-2022 0.5.0",
  "test-case",
  "thiserror",
 ]

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -22,7 +22,7 @@ serde = "1.0.130"
 serde_derive = "1.0.103"
 solana-program = "1.14.6"
 spl-math = { version = "0.1", path = "../../libraries/math", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "0.4", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
+spl-token-2022 = { version = "0.5", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 bincode = "1.3.1"
 


### PR DESCRIPTION
#### Problem

#3714 was merged right after #3831, but still references token-2022 version 0.4, causing the build to break.

#### Solution

Bump stake pool to use token-2022 version 0.5