### PR TITLE
stake-pool: Add tolerance for stake accounts at minimum

### DIFF
--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -844,10 +844,9 @@ impl Processor {
         if header.max_validators == validator_list.len() {
             return Err(ProgramError::AccountDataTooSmall);
         }
-        let maybe_validator_stake_info = validator_list.find::<ValidatorStakeInfo>(
-            validator_vote_info.key.as_ref(),
-            ValidatorStakeInfo::memcmp_pubkey,
-        );
+        let maybe_validator_stake_info = validator_list.find::<ValidatorStakeInfo, _>(|x| {
+            ValidatorStakeInfo::memcmp_pubkey(x, validator_vote_info.key)
+        });
         if maybe_validator_stake_info.is_some() {
             return Err(StakePoolError::ValidatorAlreadyAdded.into());
         }
@@ -994,10 +993,9 @@ impl Processor {
 
         let (meta, stake) = get_stake_state(stake_account_info)?;
         let vote_account_address = stake.delegation.voter_pubkey;
-        let maybe_validator_stake_info = validator_list.find_mut::<ValidatorStakeInfo>(
-            vote_account_address.as_ref(),
-            ValidatorStakeInfo::memcmp_pubkey,
-        );
+        let maybe_validator_stake_info = validator_list.find_mut::<ValidatorStakeInfo, _>(|x| {
+            ValidatorStakeInfo::memcmp_pubkey(x, &vote_account_address)
+        });
         if maybe_validator_stake_info.is_none() {
             msg!(
                 "Vote account {} not found in stake pool",
@@ -1154,10 +1152,9 @@ impl Processor {
         let (meta, stake) = get_stake_state(validator_stake_account_info)?;
         let vote_account_address = stake.delegation.voter_pubkey;
 
-        let maybe_validator_stake_info = validator_list.find_mut::<ValidatorStakeInfo>(
-            vote_account_address.as_ref(),
-            ValidatorStakeInfo::memcmp_pubkey,
-        );
+        let maybe_validator_stake_info = validator_list.find_mut::<ValidatorStakeInfo, _>(|x| {
+            ValidatorStakeInfo::memcmp_pubkey(x, &vote_account_address)
+        });
         if maybe_validator_stake_info.is_none() {
             msg!(
                 "Vote account {} not found in stake pool",
@@ -1316,10 +1313,9 @@ impl Processor {
 
         let vote_account_address = validator_vote_account_info.key;
 
-        let maybe_validator_stake_info = validator_list.find_mut::<ValidatorStakeInfo>(
-            vote_account_address.as_ref(),
-            ValidatorStakeInfo::memcmp_pubkey,
-        );
+        let maybe_validator_stake_info = validator_list.find_mut::<ValidatorStakeInfo, _>(|x| {
+            ValidatorStakeInfo::memcmp_pubkey(x, vote_account_address)
+        });
         if maybe_validator_stake_info.is_none() {
             msg!(
                 "Vote account {} not found in stake pool",
@@ -1481,10 +1477,9 @@ impl Processor {
         }
 
         if let Some(vote_account_address) = vote_account_address {
-            let maybe_validator_stake_info = validator_list.find::<ValidatorStakeInfo>(
-                vote_account_address.as_ref(),
-                ValidatorStakeInfo::memcmp_pubkey,
-            );
+            let maybe_validator_stake_info = validator_list.find::<ValidatorStakeInfo, _>(|x| {
+                ValidatorStakeInfo::memcmp_pubkey(x, &vote_account_address)
+            });
             match maybe_validator_stake_info {
                 Some(vsi) => {
                     if vsi.status != StakeStatus::Active {
@@ -2031,10 +2026,9 @@ impl Processor {
         }
 
         let mut validator_stake_info = validator_list
-            .find_mut::<ValidatorStakeInfo>(
-                vote_account_address.as_ref(),
-                ValidatorStakeInfo::memcmp_pubkey,
-            )
+            .find_mut::<ValidatorStakeInfo, _>(|x| {
+                ValidatorStakeInfo::memcmp_pubkey(x, &vote_account_address)
+            })
             .ok_or(StakePoolError::ValidatorNotFound)?;
         check_validator_stake_address(
             program_id,
@@ -2442,17 +2436,27 @@ impl Processor {
         let meta = stake_state.meta().ok_or(StakePoolError::WrongStakeState)?;
         let required_lamports = minimum_stake_lamports(&meta, stake_minimum_delegation);
 
+        let lamports_per_pool_token = stake_pool
+            .get_lamports_per_pool_token()
+            .ok_or(StakePoolError::CalculationFailure)?;
+        let minimum_lamports_with_tolerance =
+            required_lamports.saturating_add(lamports_per_pool_token);
+
         let has_active_stake = validator_list
-            .find::<ValidatorStakeInfo>(
-                &required_lamports.to_le_bytes(),
-                ValidatorStakeInfo::active_lamports_not_equal,
-            )
+            .find::<ValidatorStakeInfo, _>(|x| {
+                ValidatorStakeInfo::active_lamports_greater_than(
+                    x,
+                    &minimum_lamports_with_tolerance,
+                )
+            })
             .is_some();
         let has_transient_stake = validator_list
-            .find::<ValidatorStakeInfo>(
-                &0u64.to_le_bytes(),
-                ValidatorStakeInfo::transient_lamports_not_equal,
-            )
+            .find::<ValidatorStakeInfo, _>(|x| {
+                ValidatorStakeInfo::transient_lamports_greater_than(
+                    x,
+                    &minimum_lamports_with_tolerance,
+                )
+            })
             .is_some();
 
         let validator_list_item_info = if *stake_split_from.key == stake_pool.reserve_stake {
@@ -2478,10 +2482,9 @@ impl Processor {
                 stake_pool.preferred_withdraw_validator_vote_address
             {
                 let preferred_validator_info = validator_list
-                    .find::<ValidatorStakeInfo>(
-                        preferred_withdraw_validator.as_ref(),
-                        ValidatorStakeInfo::memcmp_pubkey,
-                    )
+                    .find::<ValidatorStakeInfo, _>(|x| {
+                        ValidatorStakeInfo::memcmp_pubkey(x, &preferred_withdraw_validator)
+                    })
                     .ok_or(StakePoolError::ValidatorNotFound)?;
                 let available_lamports = preferred_validator_info
                     .active_stake_lamports
@@ -2493,10 +2496,9 @@ impl Processor {
             }
 
             let validator_stake_info = validator_list
-                .find_mut::<ValidatorStakeInfo>(
-                    vote_account_address.as_ref(),
-                    ValidatorStakeInfo::memcmp_pubkey,
-                )
+                .find_mut::<ValidatorStakeInfo, _>(|x| {
+                    ValidatorStakeInfo::memcmp_pubkey(x, &vote_account_address)
+                })
                 .ok_or(StakePoolError::ValidatorNotFound)?;
 
             let withdraw_source = if has_active_stake {

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -2488,7 +2488,7 @@ impl Processor {
                     .ok_or(StakePoolError::ValidatorNotFound)?;
                 let available_lamports = preferred_validator_info
                     .active_stake_lamports
-                    .saturating_sub(required_lamports);
+                    .saturating_sub(minimum_lamports_with_tolerance);
                 if preferred_withdraw_validator != vote_account_address && available_lamports > 0 {
                     msg!("Validator vote address {} is preferred for withdrawals, it currently has {} lamports available. Please withdraw those before using other validator stake accounts.", preferred_withdraw_validator, preferred_validator_info.active_stake_lamports);
                     return Err(StakePoolError::IncorrectWithdrawVoteAddress.into());

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -2551,23 +2551,7 @@ impl Processor {
                 }
                 StakeWithdrawSource::ValidatorRemoval => {
                     let split_from_lamports = stake_split_from.lamports();
-                    // The upper bound for reasonable tolerance is twice the lamports per
-                    // pool token because we have two sources of rounding. The first happens
-                    // when reducing the stake account to as close to the minimum as possible,
-                    // and the second happens on this withdrawal.
-                    //
-                    // For example, if the pool token is extremely valuable, it might only
-                    // be possible to reduce the stake account to a minimum of
-                    // `stake_rent + minimum_delegation + lamports_per_pool_token - 1`.
-                    //
-                    // After that, the minimum amount of pool tokens to get to this amount
-                    // may actually be worth
-                    // `stake_rent + minimum_delegation + lamports_per_pool_token * 2 - 2`.
-                    // We give an extra grace on this check of two lamports, which should be
-                    // reasonable. At worst, it just means that a withdrawer is losing out
-                    // on two lamports.
-                    let upper_bound = split_from_lamports
-                        .saturating_add(lamports_per_pool_token.saturating_mul(2));
+                    let upper_bound = split_from_lamports.saturating_add(lamports_per_pool_token);
                     if withdraw_lamports < split_from_lamports || withdraw_lamports > upper_bound {
                         msg!(
                             "Cannot withdraw a whole account worth {} lamports, \

--- a/stake-pool/program/tests/huge_pool.rs
+++ b/stake-pool/program/tests/huge_pool.rs
@@ -20,7 +20,7 @@ use {
     },
 };
 
-const HUGE_POOL_SIZE: u32 = 2_000;
+const HUGE_POOL_SIZE: u32 = 3_300;
 const STAKE_AMOUNT: u64 = 200_000_000_000;
 
 async fn setup(

--- a/stake-pool/program/tests/update_validator_list_balance.rs
+++ b/stake-pool/program/tests/update_validator_list_balance.rs
@@ -96,6 +96,11 @@ async fn setup(
     // Warp forward so the stakes properly activate, and deposit
     slot += slots_per_epoch;
     context.warp_to_slot(slot).unwrap();
+    let last_blockhash = context
+        .banks_client
+        .get_new_latest_blockhash(&context.last_blockhash)
+        .await
+        .unwrap();
 
     stake_pool_accounts
         .update_all(
@@ -111,12 +116,6 @@ async fn setup(
         )
         .await;
 
-    let last_blockhash = context
-        .banks_client
-        .get_new_latest_blockhash(&context.last_blockhash)
-        .await
-        .unwrap();
-
     for deposit_account in &mut deposit_accounts {
         deposit_account
             .deposit_stake(
@@ -130,6 +129,11 @@ async fn setup(
 
     slot += slots_per_epoch;
     context.warp_to_slot(slot).unwrap();
+    let last_blockhash = context
+        .banks_client
+        .get_new_latest_blockhash(&context.last_blockhash)
+        .await
+        .unwrap();
 
     stake_pool_accounts
         .update_all(
@@ -418,6 +422,11 @@ async fn merge_into_validator_stake() {
 
     // Warp just a little bit to get a new blockhash and update again
     context.warp_to_slot(slot + 10).unwrap();
+    let last_blockhash = context
+        .banks_client
+        .get_new_latest_blockhash(&last_blockhash)
+        .await
+        .unwrap();
 
     // Update, should not change, no merges yet
     let error = stake_pool_accounts

--- a/stake-pool/program/tests/withdraw.rs
+++ b/stake-pool/program/tests/withdraw.rs
@@ -678,6 +678,8 @@ async fn fail_with_not_enough_tokens() {
     )
     .await;
 
+    // generate a new authority each time to make each transaction unique
+    let new_authority = Pubkey::new_unique();
     let transaction_error = stake_pool_accounts
         .withdraw_stake(
             &mut context.banks_client,
@@ -715,6 +717,7 @@ async fn fail_with_not_enough_tokens() {
     )
     .await;
 
+    // generate a new authority each time to make each transaction unique
     let new_authority = Pubkey::new_unique();
     let transaction_error = stake_pool_accounts
         .withdraw_stake(

--- a/stake-pool/program/tests/withdraw_edge_cases.rs
+++ b/stake-pool/program/tests/withdraw_edge_cases.rs
@@ -538,6 +538,7 @@ async fn success_and_fail_with_preferred_withdraw() {
     );
 
     // success from preferred
+    let new_authority = Pubkey::new_unique();
     let error = stake_pool_accounts
         .withdraw_stake(
             &mut context.banks_client,


### PR DESCRIPTION
#### Problem

As the value of stake pool tokens increase, it could become impossible to reduce a stake account to its minimum value due to rounding.

#### Solution

This is a very tricky problem, but to give at least some cushion, round up to the lamports-per-pool-token value.

While working on this, I refactored the `BigVec` search to go through a closure rather than a function pointer, and it reduced compute unit consumption so much that the max pool size has increased by 50%!