### PR TITLE
token-cli: temp add wildcard to account output

### DIFF
--- a/token/cli/src/output.rs
+++ b/token/cli/src/output.rs
@@ -663,6 +663,9 @@ fn display_ui_extension(
             "    Unparseable extension:",
             "Consider upgrading to a newer version of spl-token",
         ),
+        // XXX HANA this is needed temporarily to make monorepo ci happy while the new cases are added
+        #[allow(unreachable_patterns)]
+        _ => unimplemented!(),
     }
 }
 


### PR DESCRIPTION
from the downstream projects stage ("hey, thats us!!") of monorepo ci for https://github.com/solana-labs/solana/pull/28932:
```
error[E0004]: non-exhaustive patterns: `&CpiGuard(_)` and `&PermanentDelegate(_)` not covered
--
  | --> token/cli/src/output.rs:536:11
  | \|
  | 536 \|     match ui_extension {
  | \|           ^^^^^^^^^^^^ patterns `&CpiGuard(_)` and `&PermanentDelegate(_)` not covered
  | \|
  | ::: /var/lib/buildkite-agent/builds/ci8/solana-labs/solana/account-decoder/src/parse_token_extension.rs:24:5
  | \|
  | 24  \|     CpiGuard(UiCpiGuard),
  | \|     -------- not covered
  | 25  \|     PermanentDelegate(UiPermanentDelegate),
  | \|     ----------------- not covered
  | \|
  | = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
  | = note: the matched value is of type `&UiExtension`
```

