### PR TITLE
Governance: adding error labels

### DIFF
--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -289,127 +289,127 @@ pub enum GovernanceError {
 
     /// Realm council mint change is not supported
     #[error("Realm council mint change is not supported")]
-    RealmCouncilMintChangeIsNotSupported,
+    RealmCouncilMintChangeIsNotSupported, // 568
 
     /// Invalid max voter weight absolute value
     #[error("Invalid max voter weight absolute value")]
-    InvalidMaxVoterWeightAbsoluteValue,
+    InvalidMaxVoterWeightAbsoluteValue, // 569
 
     /// Invalid max voter weight supply fraction
     #[error("Invalid max voter weight supply fraction")]
-    InvalidMaxVoterWeightSupplyFraction,
+    InvalidMaxVoterWeightSupplyFraction, // 570
 
     /// Owner doesn't have enough governing tokens to create Governance
     #[error("Owner doesn't have enough governing tokens to create Governance")]
-    NotEnoughTokensToCreateGovernance,
+    NotEnoughTokensToCreateGovernance, // 571
 
     /// Too many outstanding proposals
     #[error("Too many outstanding proposals")]
-    TooManyOutstandingProposals,
+    TooManyOutstandingProposals, // 572
 
     /// All proposals must be finalized to withdraw governing tokens
     #[error("All proposals must be finalized to withdraw governing tokens")]
-    AllProposalsMustBeFinalisedToWithdrawGoverningTokens,
+    AllProposalsMustBeFinalisedToWithdrawGoverningTokens, // 573
 
     /// Invalid VoterWeightRecord for Realm
     #[error("Invalid VoterWeightRecord for Realm")]
-    InvalidVoterWeightRecordForRealm,
+    InvalidVoterWeightRecordForRealm, // 574
 
     /// Invalid VoterWeightRecord for GoverningTokenMint
     #[error("Invalid VoterWeightRecord for GoverningTokenMint")]
-    InvalidVoterWeightRecordForGoverningTokenMint,
+    InvalidVoterWeightRecordForGoverningTokenMint, // 575
 
     /// Invalid VoterWeightRecord for TokenOwner
     #[error("Invalid VoterWeightRecord for TokenOwner")]
-    InvalidVoterWeightRecordForTokenOwner,
+    InvalidVoterWeightRecordForTokenOwner, // 576
 
     /// VoterWeightRecord expired
     #[error("VoterWeightRecord expired")]
-    VoterWeightRecordExpired,
+    VoterWeightRecordExpired, // 577
 
     /// Invalid RealmConfig for Realm
     #[error("Invalid RealmConfig for Realm")]
-    InvalidRealmConfigForRealm,
+    InvalidRealmConfigForRealm, // 578
 
     /// TokenOwnerRecord already exists
     #[error("TokenOwnerRecord already exists")]
-    TokenOwnerRecordAlreadyExists,
+    TokenOwnerRecordAlreadyExists, // 579
 
     /// Governing token deposits not allowed
     #[error("Governing token deposits not allowed")]
-    GoverningTokenDepositsNotAllowed,
+    GoverningTokenDepositsNotAllowed, // 580
 
     /// Invalid vote choice weight percentage
     #[error("Invalid vote choice weight percentage")]
-    InvalidVoteChoiceWeightPercentage,
+    InvalidVoteChoiceWeightPercentage, // 581
 
     /// Vote type not supported
     #[error("Vote type not supported")]
-    VoteTypeNotSupported,
+    VoteTypeNotSupported, // 582
 
     /// InvalidProposalOptions
     #[error("Invalid proposal options")]
-    InvalidProposalOptions,
+    InvalidProposalOptions, // 583
 
     /// Proposal is not not executable
     #[error("Proposal is not not executable")]
-    ProposalIsNotExecutable,
+    ProposalIsNotExecutable, // 584
 
     /// Invalid vote
     #[error("Invalid vote")]
-    InvalidVote,
+    InvalidVote, // 585
 
     /// Cannot execute defeated option
     #[error("Cannot execute defeated option")]
-    CannotExecuteDefeatedOption,
+    CannotExecuteDefeatedOption, // 586
 
     /// VoterWeightRecord invalid action
     #[error("VoterWeightRecord invalid action")]
-    VoterWeightRecordInvalidAction,
+    VoterWeightRecordInvalidAction, // 587
 
     /// VoterWeightRecord invalid action target
     #[error("VoterWeightRecord invalid action target")]
-    VoterWeightRecordInvalidActionTarget,
+    VoterWeightRecordInvalidActionTarget, // 588
 
     /// Invalid MaxVoterWeightRecord for Realm
     #[error("Invalid MaxVoterWeightRecord for Realm")]
-    InvalidMaxVoterWeightRecordForRealm,
+    InvalidMaxVoterWeightRecordForRealm, // 589
 
     /// Invalid MaxVoterWeightRecord for GoverningTokenMint
     #[error("Invalid MaxVoterWeightRecord for GoverningTokenMint")]
-    InvalidMaxVoterWeightRecordForGoverningTokenMint,
+    InvalidMaxVoterWeightRecordForGoverningTokenMint, // 590
 
     /// MaxVoterWeightRecord expired
     #[error("MaxVoterWeightRecord expired")]
-    MaxVoterWeightRecordExpired,
+    MaxVoterWeightRecordExpired, // 591
 
     /// Not supported VoteType
     #[error("Not supported VoteType")]
-    NotSupportedVoteType,
+    NotSupportedVoteType, // 592
 
     /// RealmConfig change not allowed
     #[error("RealmConfig change not allowed")]
-    RealmConfigChangeNotAllowed,
+    RealmConfigChangeNotAllowed, // 593
 
     /// GovernanceConfig change not allowed
     #[error("GovernanceConfig change not allowed")]
-    GovernanceConfigChangeNotAllowed,
+    GovernanceConfigChangeNotAllowed, // 594
 
     /// At least one VoteThreshold is required
     #[error("At least one VoteThreshold is required")]
-    AtLeastOneVoteThresholdRequired,
+    AtLeastOneVoteThresholdRequired, // 595
 
     /// Reserved buffer must be empty
     #[error("Reserved buffer must be empty")]
-    ReservedBufferMustBeEmpty,
+    ReservedBufferMustBeEmpty, // 596
 
     /// Cannot Relinquish in Finalizing state
     #[error("Cannot Relinquish in Finalizing state")]
-    CannotRelinquishInFinalizingState,
+    CannotRelinquishInFinalizingState, // 597
 
     /// Invalid RealmConfig account address
     #[error("Invalid RealmConfig account address")]
-    InvalidRealmConfigAddress,
+    InvalidRealmConfigAddress, // 598
 
     /// Cannot deposit dormant tokens
     #[error("Cannot deposit dormant tokens")]


### PR DESCRIPTION
An small update to add comments of error numbers to error definitions for Governance. It happens to me to get an error and it's easier to find the number when mentioned directly in source code.