### PR TITLE
stake-pool: Make transaction signatures unique in withdraw test

### DIFF
--- a/stake-pool/program/tests/withdraw.rs
+++ b/stake-pool/program/tests/withdraw.rs
@@ -678,6 +678,8 @@ async fn fail_with_not_enough_tokens() {
     )
     .await;
 
+    // generate a new authority each time to make each transaction unique
+    let new_authority = Pubkey::new_unique();
     let transaction_error = stake_pool_accounts
         .withdraw_stake(
             &mut context.banks_client,
@@ -715,6 +717,7 @@ async fn fail_with_not_enough_tokens() {
     )
     .await;
 
+    // generate a new authority each time to make each transaction unique
     let new_authority = Pubkey::new_unique();
     let transaction_error = stake_pool_accounts
         .withdraw_stake(


### PR DESCRIPTION
#### Problem

There are still new failures in the stake pool tests. The most recent one https://github.com/solana-labs/solana-program-library/actions/runs/3576868159/jobs/6015187724 is likely due to running the same transaction signature twice.

#### Solution

Make the transaction different to force a new signature.