### PR TITLE
[token-2022] Check expected new source ciphertext in processing confidential transfer [ZELLIC 3.1]

### DIFF
--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -585,6 +585,7 @@ fn process_transfer(
             &proof_data.transfer_with_fee_pubkeys.source_pubkey,
             &source_ciphertext_lo,
             &source_ciphertext_hi,
+            &proof_data.new_source_ciphertext,
             new_source_decryptable_available_balance,
         )?;
 
@@ -643,6 +644,7 @@ fn process_transfer(
             &proof_data.transfer_pubkeys.source_pubkey,
             &source_ciphertext_lo,
             &source_ciphertext_hi,
+            &proof_data.new_source_ciphertext,
             new_source_decryptable_available_balance,
         )?;
 
@@ -679,6 +681,7 @@ fn process_source_for_transfer(
     source_encryption_pubkey: &EncryptionPubkey,
     source_ciphertext_lo: &EncryptedBalance,
     source_ciphertext_hi: &EncryptedBalance,
+    expected_new_source_available_balance: &EncryptedBalance,
     new_source_decryptable_available_balance: DecryptableBalance,
 ) -> ProgramResult {
     check_program_account(token_account_info.owner)?;
@@ -718,6 +721,10 @@ fn process_source_for_transfer(
         )
         .ok_or(ProgramError::InvalidInstructionData)?
     };
+
+    if new_source_available_balance != *expected_new_source_available_balance {
+        return Err(TokenError::ConfidentialTransferBalanceMismatch.into());
+    }
 
     confidential_transfer_account.available_balance = new_source_available_balance;
     confidential_transfer_account.decryptable_available_balance =


### PR DESCRIPTION
#### Problem
In the confidential extension, the proof instruction for a confidential transfer instruction contains an expected `new_source_ciphertext` field that represents the new source account's new spendable balance. The zero-knowledge proof is checked with respect to this field, guaranteeing that the source account's new spendable balance is solvent. However, the token-2022 processor does not verify whether this ciphertext is computed correctly with respect to the original source account's spendable balance.

#### Summary of changes
Check that the ciphertext in the proof data is consistent with the original source account data in the instruction processor.