### PR TITLE
Expose more types from CMT

### DIFF
--- a/account-compression/Cargo.lock
+++ b/account-compression/Cargo.lock
@@ -1200,7 +1200,7 @@ dependencies = [
 
 [[package]]
 name = "spl-account-compression"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anchor-lang",
  "bytemuck",

--- a/account-compression/programs/account-compression/Cargo.toml
+++ b/account-compression/programs/account-compression/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-account-compression"
-version = "0.1.4"
+version = "0.1.5"
 description = "Solana Program Library Account Compression Program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/account-compression/programs/account-compression/src/state/concurrent_merkle_tree_header.rs
+++ b/account-compression/programs/account-compression/src/state/concurrent_merkle_tree_header.rs
@@ -108,6 +108,12 @@ impl ConcurrentMerkleTreeHeader {
         }
     }
 
+    pub fn get_creation_slot(&self) -> u64 {
+        match &self.header {
+            ConcurrentMerkleTreeHeaderData::V1(header) => header.creation_slot,
+        }
+    }
+
     pub fn set_new_authority(&mut self, new_authority: &Pubkey) {
         match self.header {
             ConcurrentMerkleTreeHeaderData::V1(ref mut header) => {

--- a/account-compression/programs/account-compression/src/state/mod.rs
+++ b/account-compression/programs/account-compression/src/state/mod.rs
@@ -2,7 +2,5 @@
 mod concurrent_merkle_tree_header;
 mod path_node;
 
-pub use concurrent_merkle_tree_header::{
-    ConcurrentMerkleTreeHeader, CONCURRENT_MERKLE_TREE_HEADER_SIZE_V1,
-};
+pub use concurrent_merkle_tree_header::*;
 pub use path_node::PathNode;


### PR DESCRIPTION
Indexing CMT is made difficult without additional types.
Consider when needing to ensure we have not missed a tree while indexing. We will need an account data source.
* Geyser
* RPC Via GPA

If we get the raw account data and deserialize it into a `ConcurrentMerkleTreeHeader` we will not be able to introspect the data version or event the account type.

This pr exposes new types and bumps the version. Please consider this contribution as it could be a blocker to the additional layer of merkle tree backfilling needed for Metaplex Read API.

I also add a `get_creation_slot` on the Main header struct as a convenience feature as I'm relatively sure that information will be present in all data versions.
