### PR TITLE
single-validator-manager: Add interface and starter docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2714,7 +2714,7 @@ dependencies = [
  "num-traits",
  "shank",
  "solana-program",
- "spl-associated-token-account 1.1.1",
+ "spl-associated-token-account 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token 3.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
@@ -4474,9 +4474,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d9ce0c9c8f31a12168e302de30066f1c4823be876281540f554ee0a5906777c"
+checksum = "8e319617cd926e48d3521849c38b1a9b282a37d87c74e7524d796f4fd64bb050"
 dependencies = [
  "Inflector",
  "base64 0.13.0",
@@ -4492,16 +4492,16 @@ dependencies = [
  "solana-sdk",
  "solana-vote-program",
  "spl-token 3.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token-2022 0.4.2",
+ "spl-token-2022 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "zstd",
 ]
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c8425a9c136af32b0108ea41fc0e84d5fd49937460af89acb50548eb769630"
+checksum = "df996750c5a514d36b8aa35f63661ae743c52a95960c9cec4600a45d181f46c7"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -4520,9 +4520,9 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff67d45b124a4c9f615056a9924475b3824f5983d4075e2cb39f23d39c4ef3b2"
+checksum = "a03d21338c579b621b26cb3c8ef05a417d3852891cef46312cb4df00574b8371"
 dependencies = [
  "borsh",
  "futures 0.3.21",
@@ -4537,9 +4537,9 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b800a9a6b0bc27fa8f4f7495638b5d9edef153aa21e207e5194fb3d9e3ee0244"
+checksum = "a1b83bf0d8b1cac6f7f82d872f660e5b1a54c1c8698d4706972237391fc7eff2"
 dependencies = [
  "serde",
  "solana-sdk",
@@ -4548,9 +4548,9 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-server"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f0f36c85f211e7623c550ece7a9e01a84c789ef4842d46a5d63bda27310cfa"
+checksum = "1c6d523f852b125d700e797d6a9517adf36c867369311fef1cf6b343e2fa797e"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -4568,9 +4568,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e87f81f1d00d3d156cae89c5fa3d4d76e18703c8fcea9a74dc85ae99d3b54c9c"
+checksum = "cbb00c4c9b32ac0ec7cb73f8d8aee2fb42b9f3c170b5721de60ba1c9544a56de"
 dependencies = [
  "bv",
  "fnv",
@@ -4587,9 +4587,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99a18b885930ea1c1bf64a4591a6c2c1baa54c77188993d8b52220f0b277c81c"
+checksum = "197e44180b0b5fdba6814a03d8ee3692325b579465286389bc85f693f507b403"
 dependencies = [
  "bincode",
  "byteorder",
@@ -4606,9 +4606,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bucket-map"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86cabc88b4af4c20e7828af8c87aaf7b61eb230e0cf505120a0b362206bea6c6"
+checksum = "8161bbbdaf7f0c21e2af497e436851c2a10ff17721ef1b6b53dc0b2a83883abe"
 dependencies = [
  "log",
  "memmap2",
@@ -4621,9 +4621,9 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5fa9dbaeb7d37bafa67f8d349a860cbb3ee667219df4be0645eac42bb79abb"
+checksum = "9f01fb8496fdd7f6c5994182b55b7d3a29b94a0ff09ce25fe6e810743996914a"
 dependencies = [
  "chrono",
  "clap 2.34.0",
@@ -4639,9 +4639,9 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-v3-utils"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45b3e0778e65a0160c8484c9cb45c68c104cf3ef3f260649581206360473817"
+checksum = "bc77c1c5831ca8a5a7f6accad9c7361938bebea5e605c0e0bdda742d62c5513c"
 dependencies = [
  "chrono",
  "clap 3.2.17",
@@ -4657,9 +4657,9 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ed1ff6d7015e6ca1f2179f5363836a4227848d72826aaff5924230128dd59c"
+checksum = "3dc0c843ad3db6f791b8279aeae0d61f0151709d574edde56d17fa0f7f2230d5"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -4673,9 +4673,9 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ad09022b6c50c3ad2e4dd70243cb261992850953c420184866dafbd10d8090"
+checksum = "5670f553b334a4d319fada54af2d5e93847e89d28595a8c0f86bc2fef1588faa"
 dependencies = [
  "Inflector",
  "base64 0.13.0",
@@ -4700,9 +4700,9 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f3a976b2e4d652d6d5c4c9fa4164107d2dc3a4a282facf779bf8aafca304a4"
+checksum = "67dd2fd7ba13f301d953073463a479890f21d930819794d7a9e80ace61dc8904"
 dependencies = [
  "async-mutex",
  "async-trait",
@@ -4743,7 +4743,7 @@ dependencies = [
  "solana-transaction-status",
  "solana-version",
  "solana-vote-program",
- "spl-token-2022 0.4.2",
+ "spl-token-2022 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -4754,9 +4754,9 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75537f1d0e896b7ca97a85fe9b5be955d376417a7bf8566e73f4a13495bee221"
+checksum = "6f2de1835ca9bb54d759f42bcbafe4db251bd211217c5f7d4d164ea21e6e9b14"
 dependencies = [
  "solana-program-runtime",
  "solana-sdk",
@@ -4764,9 +4764,9 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab35456437ac9bafb685ffa168c65ae364024ca7b2264cf3379fdd1a8e27491"
+checksum = "3fdfe7c2946d9f552cd91fffb8a991eb40465f70586d5fb71f9a49dc0cd296f5"
 dependencies = [
  "bincode",
  "chrono",
@@ -4778,9 +4778,9 @@ dependencies = [
 
 [[package]]
 name = "solana-core"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c45858cfd75cb10dc10ddf2e236e4b293d4bb22a3256184f13c8e9ad23ce7fd0"
+checksum = "c30aca35d901c8313145855a05bcc031bc0109a738e5bfffaf03018321a42247"
 dependencies = [
  "ahash",
  "base64 0.13.0",
@@ -4839,9 +4839,9 @@ dependencies = [
 
 [[package]]
 name = "solana-entry"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f85de86ab694f0f653950d4ba0696079fb73a426667c617c25d9a3c76e3ed3c7"
+checksum = "9b856f8b351ba69de50d11f0c27b725abd6d4cbc51ccd9e142f848f18fd51639"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -4862,9 +4862,9 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15a1cfb4d850c458e682591519db57e321773d021337e31beb2e0f9b0cd20445"
+checksum = "ce450d5c9114569329f0e6900a53be424f77ba07ed932b5d57a3bfb55afefe41"
 dependencies = [
  "bincode",
  "byteorder",
@@ -4886,9 +4886,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fae9453c906a52b00c6d668508214377163cf59776cfa8e09ef740a2a493f87d"
+checksum = "a73da3a286cf0d1ab25d669c17a3c2b5fe1334f8262b9673cb22912d92a94b14"
 dependencies = [
  "ahash",
  "blake3",
@@ -4920,9 +4920,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e29cd0fef92aee046267cdd69d8aa8b31cd3549991ea6f2c6076b21064e235fb"
+checksum = "c88a0446927b49aee9b40ec1c6a96be562a9de543a0c58483a8520f99f454f36"
 dependencies = [
  "proc-macro2 1.0.43",
  "quote 1.0.21",
@@ -4932,9 +4932,9 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-plugin-interface"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee5c8e0aaaf3597ac163dc38e41ad0f01f4ce6870868cc3bb2f994a3a1b2dab"
+checksum = "438aecb67a3936e22290196715296c3b71a95432df2e70e95af751d89c45e787"
 dependencies = [
  "log",
  "solana-sdk",
@@ -4944,9 +4944,9 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f425d712fd8c280cdc325114da5389a4c70151b79d697a3bca2a5b045db6a82"
+checksum = "bf47e5557c7c971a69904d45fcda7592c520412c6282ce03a7eb96b3b059b5cf"
 dependencies = [
  "bs58",
  "crossbeam-channel",
@@ -4966,9 +4966,9 @@ dependencies = [
 
 [[package]]
 name = "solana-gossip"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda9ca60d7902039a2d6cf7a327a409a8bf21a91ca442d9f7fdcc8390c2f5906"
+checksum = "d5f0834f5698c2d343364c7737ba204a9d2dae0363b161172f603dd59dc1e011"
 dependencies = [
  "bincode",
  "bv",
@@ -5011,9 +5011,9 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ea89a38ce1b99da8b5c9741ff20a09f3dc4f68444120123f38295d25e6e8c4"
+checksum = "9965a8d801c1e69f8ad6220391691158f9dda0f969a14f84503deef7a96a7144"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -5060,7 +5060,7 @@ dependencies = [
  "solana-transaction-status",
  "solana-vote-program",
  "spl-token 3.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token-2022 0.4.2",
+ "spl-token-2022 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "static_assertions",
  "tempfile",
  "thiserror",
@@ -5071,9 +5071,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d255b73f0c0e1eaa34280094f1304a783ea9394dbf2f8b749a3661e948ca5551"
+checksum = "48ec3aec81a83a876c68b6225d7eaf465b97e2d88ff33b2426e77ba08eded7ce"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -5082,9 +5082,9 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa24a1809c27862f29f5fb836bd6f0987ffb265192aa9aefa3ce7cdfa2175c64"
+checksum = "cecc0ddf9b0db68e2e92664b6e0432acf9d1739b3a6bc76a466c910d88d0ba98"
 dependencies = [
  "log",
  "solana-sdk",
@@ -5092,9 +5092,9 @@ dependencies = [
 
 [[package]]
 name = "solana-merkle-tree"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47834143423546d42228e535c5468ca5c5eaaf20e13cb61bfb345405d3342fa"
+checksum = "65d285004a0724449e3e93892eb38dd8f58c397971058ab82ad169545bcaa4da"
 dependencies = [
  "fast-math",
  "matches",
@@ -5103,9 +5103,9 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22429c3b3126e22420e310df04c94a35d0e7e03398f56c0d4864c14330469621"
+checksum = "684c01d65b3b5a546afaff2fd83e9117d0842a1e805a47acba26b461a8b26a4b"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -5117,9 +5117,9 @@ dependencies = [
 
 [[package]]
 name = "solana-net-utils"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e92bb28da2b2f8c449ef398b4d0954a07f982a3f065ef6f2ae9ec059c0a00744"
+checksum = "dc95e2746f871dc2fa7e115a05158148b1522e9c1c99f3e7e3cc02f68dad8a19"
 dependencies = [
  "bincode",
  "clap 3.2.17",
@@ -5139,9 +5139,9 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "699eb01472f1de28e4e183c3e2f988d9f8056fe2d7f4917f5319227b3a8cb3a8"
+checksum = "94c36a9572ac81be290f006a09aa53d14ce5fb8634345e7bc4fc3c89c0596bfe"
 dependencies = [
  "ahash",
  "bincode",
@@ -5166,9 +5166,9 @@ dependencies = [
 
 [[package]]
 name = "solana-poh"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d561d7b111c4f74e1f923486623e52f48564d91f256afcd78e1b07be67193b"
+checksum = "abbb5548f0c4ada36f76e54da817b279682a074fadecdd6012d1624293072ce9"
 dependencies = [
  "core_affinity",
  "crossbeam-channel",
@@ -5185,9 +5185,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0eeda17e271e11864d48b35eeaefed9591305b4d47266caf3f8b11b9271833d"
+checksum = "927d3d7e49093e601811a89ede4a9698059fb819871b3eba88a6cb0c964040fe"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -5234,9 +5234,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdc41f421fbfbe76084582b7e9329638172ad815720aa1e64941e164d70d07d6"
+checksum = "7ddadda3f8b3944188ca93988033cbe5decf569271b5fcc0cd9338282115a47d"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -5261,9 +5261,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program-test"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791d58ebc2daf32ddc7ac1136d2981ba995ebd932f495b5c430cec7b21b1104e"
+checksum = "417a2ce701c6c65593a1ae4d654998a7aef9ab69abc7087dc2b999d42eff14da"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -5286,9 +5286,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ffc35a541a1aa220d3cfe789b0f3be37e3573060b03ba8a75134ab48fbee390"
+checksum = "8bd7d70fdf385e1b67d8d43a7d2c5db60e0dc667de4cfee1471cead6563e6878"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -5296,9 +5296,9 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f7de542f86247cd88682b00ff8a47415d0cccebcea2b765609fc505944df3e9"
+checksum = "3b5ebbd2a1790e6cd1b594027bdb75da17b410958773fc0f521ff3ee20791dfa"
 dependencies = [
  "console 0.15.0",
  "dialoguer",
@@ -5316,9 +5316,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fc8b77bfd50faf5f805643caa6b9bb0663a0de5381e14552a18a1e454e0a7e3"
+checksum = "869c584a2d04193f3a9bfc2a3117a2123a3a5f6a9f3eb510736279e0bdefaea9"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -5360,7 +5360,7 @@ dependencies = [
  "solana-version",
  "solana-vote-program",
  "spl-token 3.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token-2022 0.4.2",
+ "spl-token-2022 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "stream-cancel",
  "thiserror",
  "tokio",
@@ -5369,9 +5369,9 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9983b3d82901545d6bb4ca96a5f6e1b9a3b5212bc89d8adb269d0ad54da9d01"
+checksum = "a9bc515c9119a108e67aacb4b8241bddf5fdcaea9a404cfdca75b69418d9be04"
 dependencies = [
  "arrayref",
  "bincode",
@@ -5429,9 +5429,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fe62f7fe938607437ed29b0e95b4cffc7db186bf04fea6a98d92319da941b1"
+checksum = "6c925686af7b3235245997acdac126e53c78bab8b924b11434ca5ec45259114d"
 dependencies = [
  "assert_matches",
  "base64 0.13.0",
@@ -5480,9 +5480,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f9abf0bdba679d93c5624043ae3dcbf529ed2251c281cc615fa55c8dc2f0bd"
+checksum = "f511aecadeab3ebc0db10e78d9e7b571dffe1744c0003d6602f537581c3448cf"
 dependencies = [
  "bs58",
  "proc-macro2 1.0.43",
@@ -5493,9 +5493,9 @@ dependencies = [
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "277042c36bc74e07710a0cbc004ed99ece5fe8487c674b22d0d984264a4b2a85"
+checksum = "c4caef6a83ebb24b78b19f5a894d6ab10c196322217ccceeec5d4fd2b594b36d"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -5508,9 +5508,9 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5dceeddfe119e84eb6e3fee97a4c309e92dbf3c56e3e053b363b8b3a0e3837"
+checksum = "2c794a81a68d12192fc08064431b32a0bc9976c7df67c6921fda99604d7bea6e"
 dependencies = [
  "bincode",
  "log",
@@ -5531,9 +5531,9 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f27dac813403d2c57bbdb987794b43b56b87bb7232e038aecc176e05cbdcbd"
+checksum = "054a84a2304588bc15d0765ac86d20ee38b5a866e05d76cdfd6d6a95cbc62372"
 dependencies = [
  "backoff",
  "bincode",
@@ -5565,9 +5565,9 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "415351d10c3cc5e030065b5b4badad1116be8ec464fab6e8ba3c739214270e69"
+checksum = "3d51ddec84ea16dde3ebaa64dc8920ac3bc7647c34ca2b25bc53a38bad39ca6c"
 dependencies = [
  "bincode",
  "bs58",
@@ -5582,9 +5582,9 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f717b890579125bcfc1f4c20ed3037bb67360b58a87b7bebc4175dc1ccd872d"
+checksum = "971e56ca8c6bcd2f36992dd04b6bf65f0786bba55e458bdaa42ddc9c948f39dd"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -5611,9 +5611,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sys-tuner"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77d727abd3961bbb650b2c48b05dd8825bc7ea771d43dcecc8992c05436663f"
+checksum = "375a4cbf29903cfd0a8e7c9393424937655780e583dc14dcb1ac7ace536f706a"
 dependencies = [
  "clap 2.34.0",
  "libc",
@@ -5628,9 +5628,9 @@ dependencies = [
 
 [[package]]
 name = "solana-test-validator"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66f185db3401903c1a87d1c3c69801503250f84b6feac48a9526215d147fc166"
+checksum = "0b24790333a663d1c4d38f0f9d7299d532cbc0fcfad107b29873bfe79b80dd67"
 dependencies = [
  "base64 0.13.0",
  "log",
@@ -5654,9 +5654,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03de2ada50e18dd7d22ecf319bb7276c567d6040c0d74b5191338db4d8bac979"
+checksum = "58138ee0d2c3f0b3be7e7d8a5bfafdd3fafe66e108b8934169b8b7ecfe8ac60e"
 dependencies = [
  "Inflector",
  "base64 0.13.0",
@@ -5674,18 +5674,18 @@ dependencies = [
  "solana-metrics",
  "solana-sdk",
  "solana-vote-program",
- "spl-associated-token-account 1.1.1",
+ "spl-associated-token-account 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-memo 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token 3.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token-2022 0.4.2",
+ "spl-token-2022 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-version"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c7c5a3d9b205b6fbce9228c37bb7b9ad562f99ba6aaa9854643cb200a27fe2"
+checksum = "d976c2590fb565b2e07ff3659deb94774f3a7edf90ddcaa62078164740b8fee5"
 dependencies = [
  "log",
  "rustc_version",
@@ -5699,9 +5699,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e09284940dece2f4906105cb5905530a5076c39b1bf00a61990c66693feb2a"
+checksum = "ffc47706ca644433d7681f3fe3e0b30094260065ae86a53ae4f92078a7cd4bf4"
 dependencies = [
  "bincode",
  "log",
@@ -5720,9 +5720,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a999e4a64db00060aaed9c47fdc16418c51d20468f62a62562bfa1bd0ea0fa0"
+checksum = "d7704396dcd9338e6ac72137908ad5781edd023767d6e6d6b0a68938b8d86fb5"
 dependencies = [
  "bytemuck",
  "getrandom 0.1.16",
@@ -5735,9 +5735,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.14.6"
+version = "1.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5b9d83227b8bdfe5c7b73693aab59942fb3a18a47633284affadd28d65f454"
+checksum = "facf969af237320649c2ea99be5f75e98cba9b6e3217d9ddc5cbf3497c0282f9"
 dependencies = [
  "aes-gcm-siv",
  "arrayref",
@@ -5806,22 +5806,6 @@ dependencies = [
 
 [[package]]
 name = "spl-associated-token-account"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a33ecc83137583902c3e13c02f34151c8b2f2b74120f9c2b3ff841953e083d"
-dependencies = [
- "assert_matches",
- "borsh",
- "num-derive",
- "num-traits",
- "solana-program",
- "spl-token 3.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token-2022 0.4.2",
- "thiserror",
-]
-
-[[package]]
-name = "spl-associated-token-account"
 version = "1.1.2"
 dependencies = [
  "assert_matches",
@@ -5831,6 +5815,22 @@ dependencies = [
  "solana-program",
  "spl-token 3.5.0",
  "spl-token-2022 0.5.0",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-associated-token-account"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc000f0fdf1f12f99d77d398137c1751345b18c88258ce0f99b7872cf6c9bd6"
+dependencies = [
+ "assert_matches",
+ "borsh",
+ "num-derive",
+ "num-traits",
+ "solana-program",
+ "spl-token 3.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-2022 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
 
@@ -6084,7 +6084,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 1.1.1",
+ "spl-associated-token-account 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token 3.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "tokio",
@@ -6168,6 +6168,29 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
+]
+
+[[package]]
+name = "spl-single-validator-manager"
+version = "0.1.0"
+dependencies = [
+ "borsh",
+ "bytemuck",
+ "mpl-token-metadata",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "serde",
+ "serde_derive",
+ "solana-program",
+ "solana-program-test",
+ "solana-sdk",
+ "solana-vote-program",
+ "spl-associated-token-account 1.1.2",
+ "spl-stake-pool",
+ "spl-token 3.5.0",
+ "spl-token-2022 0.5.0",
+ "thiserror",
 ]
 
 [[package]]
@@ -6255,24 +6278,6 @@ dependencies = [
 
 [[package]]
 name = "spl-token-2022"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a97cbf60b91b610c846ccf8eecca96d92a24a19ffbf9fe06cd0c84e76ec45e"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "num_enum",
- "solana-program",
- "solana-zk-token-sdk",
- "spl-memo 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token 3.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
-]
-
-[[package]]
-name = "spl-token-2022"
 version = "0.5.0"
 dependencies = [
  "arrayref",
@@ -6292,6 +6297,24 @@ dependencies = [
  "solana-zk-token-sdk",
  "spl-memo 3.0.1",
  "spl-token 3.5.0",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-token-2022"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0edb869dbe159b018f17fb9bfa67118c30f232d7f54a73742bc96794dff77ed8"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-program",
+ "solana-zk-token-sdk",
+ "spl-memo 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token 3.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
   "managed-token/program",
   "record/program",
   "shared-memory/program",
+  "single-validator-manager/program",
   "stake-pool/cli",
   "stake-pool/program",
   "stateless-asks/program",

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -31,6 +31,7 @@ module.exports = {
         "stake-pool/cli",
       ],
     },
+    "single-validator-manager",
     "feature-proposal",
     {
       type: "category",

--- a/docs/src/single-validator-manager.md
+++ b/docs/src/single-validator-manager.md
@@ -1,0 +1,122 @@
+---
+title: Single Validator Stake Pool Manager Program
+---
+
+A work-in-progress program for permissionless management of stake pools that are
+only delegated to one validator.
+
+## Operation
+
+The single-validator manager program defines a canonical stake pool for any
+validator on the network, which can be created by anyone.
+
+The program manages the "delegation strategy" of the pool, which is to maximize
+the amount of stake on one validator, while maintaining a small amount of SOL
+in the reserve for small stakers.
+
+### Create Pool
+
+The `CreateStakePool` instruction allows anyone to create the canonical stake
+pool for a validator, at the cost of ~0.0124 SOL for account rent-exemption of
+the stake pool, validator list, reserve, mint, and fee account.
+
+After the pool is created, the reserve requires at least stake rent-exemption plus
+the minimum delegation amount to actually add the validator to the pool, which
+costs 1.0028288 SOL. The user receives pool tokens for this deposit.
+
+After the SOL deposit, the `AddValidatorToPool` instruction on the pool management
+program allows anyone to add the stake account for that validator.
+
+Once the added stake account is active, anyone may deposit stake accounts.
+
+### Depositing and withdrawing stake
+
+If stakers deposit or withdraw stake accounts from the pool, everything works
+seamlessly. Stakers receive pool tokens for their deposited stake account, and
+may use the pool tokens to withdraw a stake account.
+
+Activated stake accounts on the same validator are all fungible, so there's no
+other economics to worry about.
+
+### Depositing and withdrawing SOL
+
+As mentioned in the fees section, only SOL deposits have a fee, and everything
+else can be done freely.
+
+To maximize returns for pool depositors, the program allows anyone to maximally
+deploy the reserve to the validator, with important limits.
+
+Single-validator stake pools are an option for small stakers to earn inflation
+rewards by staking their SOL, but if stakers have less than the minimum delegation
+amount, they cannot withdraw stake accounts, so they need a way to withdraw SOL
+from the reserve.
+
+To give a way out for these users, the reserve aims to maintain the minimum delegation
+amount plus stake rent-exemption, or 1.0028288 SOL. If the reserve has less than
+this amount, any user can call `DecreaseValidatorStake` to decrease the minimum
+delegation amount plus rent-exemption.
+
+On the other hand, if the reserve receives enough SOL deposits equalling at least
+two times this amount, then anyone can call `IncreaseValidatorStake` on the manager
+program to activate everything in the reserve, minus the minimum delegation plus
+rent-exemption.
+
+### Griefing
+
+The permissionless increase instruction allows an attack to make the pool less
+performant.
+
+For example, at the start of the epoch, a malicious user can deposit enough SOL to get
+just above the limit for increasing, and immediate run the increase. This prevents
+the activation of subsequent SOL deposits until the next epoch.
+
+However, this attack only works for one epoch, since at the start of the next
+epoch, anyone can activate all of the remaining stake. For this reason, SOL
+depositors are charged 2 epochs of rewards in fees. This inflates the value of
+pool tokens, covering for any economic attacks.
+
+With the permissionless decrease instruction, a similar attack is possible.
+
+For example, if the reserve is at its target amount of 1.0028288 SOL, an attacker
+can withdraw 1 lamport from the reserve, then decrease another 1.0028288 SOL.
+
+Question: should the threshold for allowing decreases be 1 / 2 minimum delegation
+in the reserve? That way, the previous attack is more costly, but it means delegators
+with more than 1 / 2 minimum delegation need to wait longer to get out of the pool.
+That might be an acceptable tradeoff.
+
+## Fees
+
+Pools are configured with a SOL deposit fee of 8 basis points, which corresponds
+to the rewards received over two epochs. This way, no user can deposit SOL and
+immediately withdraw a stake account at the end of an epoch to steal rewards
+from the pool.
+
+All other fees are 0 so that pools mimic the reward structure of native staking.
+
+The program also exposes a permissionless `BurnFees` instruction to allow anyone
+to burn the pool tokens in the fee account, which increases the value of all
+other pool tokens.
+
+## Token Metadata
+
+Since each pool is guaranteed to only include one validator, the validator operator
+should be allowed to upload whatever token metadata they wish. The `CreateTokenMetadata`
+and `UpdateTokenMetadata` instructions allow the authorized voter on the validator
+to work with the token metadata.
+
+Question: should the information be pulled from the validator-info? Or should
+some other authority than the authorized voter do it?
+
+## Existing pools
+
+Since the program is completely permissionless and stateless, existing stake pools
+may transition the pool to program management by setting the manager and staker
+to the correct program-derived address.
+
+The management program exposes more instructions to make sure that all single-validator
+pools are equal:
+
+* `ResetFees`: put all the fees to the amounts described in the fees section
+* `RemoveFundingAuthorities`: open the pool to all deposits and withdrawals of SOL and stake
+* `RemoveValidatorFromPool`: get rid of any other validator in the pool

--- a/single-validator-manager/program/Cargo.toml
+++ b/single-validator-manager/program/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "spl-single-validator-manager"
+version = "0.1.0"
+description = "Solana Program Library Single Validator Stake Pool Manager"
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+repository = "https://github.com/solana-labs/solana-program-library"
+license = "Apache-2.0"
+edition = "2018"
+
+[features]
+no-entrypoint = []
+test-sbf = []
+
+[dependencies]
+borsh = "0.9"
+bytemuck = "1.8"
+mpl-token-metadata =  { version = "1.3.1", features = [ "no-entrypoint" ] }
+num-derive = "0.3"
+num-traits = "0.2"
+num_enum = "0.5.4"
+serde = "1.0.130"
+serde_derive = "1.0.103"
+solana-program = "1.14.10"
+spl-associated-token-account = { version = "1.1", path = "../../associated-token-account/program", features = [ "no-entrypoint" ] }
+spl-stake-pool = { version = "0.7", path = "../../stake-pool/program", features = [ "no-entrypoint" ] }
+spl-token = { version = "3.5", path = "../../token/program", features = [ "no-entrypoint" ] }
+spl-token-2022 = { version = "0.5", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
+thiserror = "1.0"
+
+[dev-dependencies]
+solana-program-test = "1.14.10"
+solana-sdk = "1.14.10"
+solana-vote-program = "1.14.10"
+spl-token = { version = "3.5", path = "../../token/program", features = [ "no-entrypoint" ] }
+
+[lib]
+crate-type = ["cdylib", "lib"]

--- a/single-validator-manager/program/src/entrypoint.rs
+++ b/single-validator-manager/program/src/entrypoint.rs
@@ -1,0 +1,26 @@
+//! Program entrypoint
+
+#![cfg(all(target_os = "solana", not(feature = "no-entrypoint")))]
+
+use {
+    crate::{error::SingleValidatorManagerError, processor::process},
+    solana_program::{
+        account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,
+        program_error::PrintProgramError, pubkey::Pubkey,
+    },
+};
+
+entrypoint!(process_instruction);
+fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    if let Err(error) = process(program_id, accounts, instruction_data) {
+        // catch the error so we can print it
+        error.print::<SingleValidatorManagerError>();
+        Err(error)
+    } else {
+        Ok(())
+    }
+}

--- a/single-validator-manager/program/src/error.rs
+++ b/single-validator-manager/program/src/error.rs
@@ -1,0 +1,106 @@
+//! Error types
+
+use {
+    num_derive::FromPrimitive,
+    solana_program::{
+        decode_error::DecodeError,
+        msg,
+        program_error::{PrintProgramError, ProgramError},
+    },
+    thiserror::Error,
+};
+
+/// Errors that may be returned by the single validator manager program.
+#[repr(u8)]
+#[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]
+pub enum SingleValidatorManagerError {
+    /// The instruction cannot be decoded
+    #[error("InvalidInstruction")]
+    InvalidInstruction,
+    /// The account cannot be initialized because it is already being used.
+    #[error("AlreadyInUse")]
+    AlreadyInUse,
+    /// The calculation failed.
+    #[error("CalculationFailure")]
+    CalculationFailure,
+    /// Required signature is missing.
+    #[error("SignatureMissing")]
+    SignatureMissing,
+    /// Stake account for this validator not found in the pool.
+    #[error("ValidatorNotFound")]
+    ValidatorNotFound,
+    /// Stake account address not properly derived from the validator address.
+    #[error("InvalidStakeAccountAddress")]
+    InvalidStakeAccountAddress,
+    /// Validator stake account is not found in the list.
+    #[error("UnknownValidatorStakeAccount")]
+    UnknownValidatorStakeAccount,
+    /// Invalid validator stake list account.
+    #[error("InvalidValidatorStakeList")]
+    InvalidValidatorStakeList,
+    /// Invalid manager fee account.
+    #[error("InvalidFeeAccount")]
+    InvalidFeeAccount,
+    /// Stake account voting for this validator already exists in the pool.
+    #[error("ValidatorAlreadyAdded")]
+    ValidatorAlreadyAdded,
+    /// Wrong minting authority set for mint pool account
+    #[error("IncorrectMintAuthority")]
+    IncorrectMintAuthority,
+    /// Incorrect pool staker account.
+    #[error("IncorrectStaker")]
+    IncorrectStaker,
+    /// Incorrect manager account.
+    #[error("IncorrectManager")]
+    IncorrectManager,
+    /// Incorrect reserve account.
+    #[error("IncorrectReserve")]
+    IncorrectReserve,
+    /// The lamports in the validator stake account is not equal to the minimum
+    #[error("StakeLamportsNotEqualToMinimum")]
+    StakeLamportsNotEqualToMinimum,
+    /// Provided metadata account does not match metadata account derived for pool mint
+    #[error("InvalidMetadataAccount")]
+    InvalidMetadataAccount,
+}
+impl From<SingleValidatorManagerError> for ProgramError {
+    fn from(e: SingleValidatorManagerError) -> Self {
+        ProgramError::Custom(e as u32)
+    }
+}
+impl<T> DecodeError<T> for SingleValidatorManagerError {
+    fn type_of() -> &'static str {
+        "Single Validator Stake Pool Manager Error"
+    }
+}
+impl PrintProgramError for SingleValidatorManagerError {
+    fn print<E>(&self)
+    where
+        E: 'static
+            + std::error::Error
+            + DecodeError<E>
+            + PrintProgramError
+            + num_traits::FromPrimitive,
+    {
+        match self {
+            SingleValidatorManagerError::InvalidInstruction => msg!("Error: The instruction cannot be decoded"),
+            SingleValidatorManagerError::AlreadyInUse => msg!("Error: The account cannot be initialized because it is already being used"),
+            SingleValidatorManagerError::CalculationFailure => msg!("Error: The calculation failed"),
+            SingleValidatorManagerError::SignatureMissing => msg!("Error: Required signature is missing"),
+            SingleValidatorManagerError::InvalidValidatorStakeList => msg!("Error: Invalid validator stake list account"),
+            SingleValidatorManagerError::InvalidFeeAccount => msg!("Error: Invalid manager fee account"),
+            SingleValidatorManagerError::ValidatorAlreadyAdded => msg!("Error: Stake account voting for this validator already exists in the pool"),
+            SingleValidatorManagerError::ValidatorNotFound => msg!("Error: Stake account for this validator not found in the pool"),
+            SingleValidatorManagerError::InvalidStakeAccountAddress => msg!("Error: Stake account address not properly derived from the validator address"),
+            SingleValidatorManagerError::UnknownValidatorStakeAccount => {
+                msg!("Error: Validator stake account is not found in the list storage")
+            }
+            SingleValidatorManagerError::IncorrectMintAuthority => msg!("Error: Incorrect mint authority set for mint pool account"),
+            SingleValidatorManagerError::IncorrectStaker => msg!("Error: Incorrect pool staker account"),
+            SingleValidatorManagerError::IncorrectManager => msg!("Error: Incorrect pool manager account"),
+            SingleValidatorManagerError::IncorrectReserve => msg!("Error: Incorrect pool reserve account"),
+            SingleValidatorManagerError::StakeLamportsNotEqualToMinimum => msg!("Error: The lamports in the validator stake account is not equal to the minimum"),
+            SingleValidatorManagerError::InvalidMetadataAccount => msg!("Error: Metadata account derived from pool mint account does not match the one passed to program"),
+        }
+    }
+}

--- a/single-validator-manager/program/src/instruction.rs
+++ b/single-validator-manager/program/src/instruction.rs
@@ -1,0 +1,694 @@
+//! Instruction types
+
+use {
+    crate::{
+        error::SingleValidatorManagerError,
+        pda::{
+            ManagerAddress, MintAddress, ReserveAddress, StakePoolAddress, ValidatorListAddress,
+        },
+    },
+    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
+    bytemuck::Pod,
+    mpl_token_metadata::pda::find_metadata_account,
+    num_enum::{IntoPrimitive, TryFromPrimitive},
+    solana_program::{
+        borsh::get_packed_len,
+        instruction::{AccountMeta, Instruction},
+        program_error::ProgramError,
+        pubkey::Pubkey,
+        stake, system_program, sysvar,
+    },
+    spl_associated_token_account::get_associated_token_address_with_program_id,
+    spl_stake_pool::{
+        find_stake_program_address, find_transient_stake_program_address,
+        find_withdraw_authority_program_address,
+    },
+    std::{convert::TryFrom, num::NonZeroU32},
+};
+
+/// Instructions supported by the StakePool program.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, TryFromPrimitive, IntoPrimitive)]
+pub enum SingleValidatorManagerInstruction {
+    ///   Creates a new StakePool for one validator.
+    ///
+    ///   The rent-exemption lamports for the stake pool, validator list, pool
+    ///   mint, and fee account amount to 12,388,800 lamports, or ~0.0124 SOL.
+    ///
+    ///   0. `[sw]` Payer for the stake pool accounts
+    ///   1. `[]` Validator vote account for the single validator stake pool
+    ///   2. `[w]` Uninitialized stake pool to create.
+    ///   3. `[w]` Uninitialized validator stake list storage account
+    ///   4. `[w]` Uninitialized reserve stake account.
+    ///   5. `[w]` Uninitialized pool token mint.
+    ///   6. `[w]` Uninitialized pool token account to collect the fees.
+    ///   7. `[]` Manager
+    ///   8. `[]` Stake pool withdraw authority
+    ///   9. `[]` System program id
+    ///  10. `[]` Stake program id
+    ///  11. `[]` Token program id
+    ///  12. `[]` Stake pool program id
+    CreateStakePool,
+
+    ///   Adds the single validator stake account to the pool.
+    ///
+    ///   The stake account will have the rent-exempt amount plus
+    ///   `max(crate::MINIMUM_ACTIVE_STAKE, solana_program::stake::tools::get_minimum_delegation())`.
+    ///   It is funded from the stake pool reserve.
+    ///
+    ///   0. `[w]` Stake pool
+    ///   1. `[]` Staker
+    ///   2. `[w]` Reserve stake account
+    ///   3. `[]` Stake pool withdraw authority
+    ///   4. `[w]` Validator stake list storage account
+    ///   5. `[w]` Stake account to add to the pool
+    ///   6. `[]` Validator vote account for the single validator stake pool
+    ///   7. `[]` Rent sysvar
+    ///   8. `[]` Clock sysvar
+    ///   9. '[]' Stake history sysvar
+    ///  10. '[]' Stake config sysvar
+    ///  11. `[]` System program
+    ///  12. `[]` Stake program
+    ///  13. `[]` Stake pool program
+    ///
+    ///  userdata: optional non-zero u32 seed used for generating the validator
+    ///  stake address
+    AddValidatorToPool,
+
+    ///   Removes a non-canonical validator from the pool, deactivating its stake
+    ///
+    ///   This is useful if an existing stake pool is assigned to the management
+    ///   program, but has additional validators.
+    ///
+    ///   0. `[]` Validator vote account for the single validator stake pool
+    ///   1. `[w]` Stake pool
+    ///   2. `[]` Staker
+    ///   3. `[]` Stake pool withdraw authority
+    ///   4. `[w]` Validator stake list storage account
+    ///   5. `[w]` Stake account to remove from the pool
+    ///   6. `[]` Transient stake account, to check that that we're not trying to activate
+    ///   7. `[]` Sysvar clock
+    ///   8. `[]` Stake program
+    ///   9. `[]` Stake pool program
+    RemoveValidatorFromPool,
+
+    /// Decrease active stake on a validator, eventually moving it to the reserve
+    ///
+    /// The instruction only succeeds if the stake pool reserve has less than
+    /// the minimum delegation amount. It allows small pool token holders to
+    /// withdraw their tokens from the pool.
+    ///
+    /// This instruction can also be used on additional validators that are not
+    /// the single validator, if an existing stake pool was reassigned to this
+    /// management program.
+    ///
+    ///  0. `[]` Validator vote account for the single validator stake pool
+    ///  1. `[]` Stake pool
+    ///  2. `[]` Stake pool staker
+    ///  3. `[]` Stake pool withdraw authority
+    ///  4. `[w]` Validator list
+    ///  5. `[w]` Canonical stake account to split from
+    ///  6. `[w]` Transient stake account to receive split
+    ///  7. `[]` Clock sysvar
+    ///  8. `[]` Rent sysvar
+    ///  9. `[]` System program
+    /// 10. `[]` Stake program
+    /// 11. `[]` Stake pool program
+    ///
+    /// userdata: seed to use for transient stake account
+    DecreaseValidatorStake,
+
+    /// Increase stake on the validator from the reserve account
+    ///
+    /// This instruction only succeeds if the stake pool reserve has more than
+    /// the `2 * (minimum_delegation_amount + rent_exemption) + rent_exemption`,
+    /// and will activate enough to leave `minimum_delegation_amount + 2 * rent_exemption`.
+    ///
+    ///  0. `[]` Stake pool
+    ///  1. `[]` Stake pool staker
+    ///  2. `[]` Stake pool withdraw authority
+    ///  3. `[w]` Validator list
+    ///  4. `[w]` Stake pool reserve stake
+    ///  5. `[w]` Transient stake account
+    ///  6. `[]` Validator stake account
+    ///  7. `[]` Validator vote account for the single validator stake pool
+    ///  8. '[]' Clock sysvar
+    ///  9. '[]' Rent sysvar
+    /// 10. `[]` Stake History sysvar
+    /// 11. `[]` Stake Config sysvar
+    /// 12. `[]` System program
+    /// 13. `[]` Stake program
+    /// 14. `[]` Stake pool program
+    ///
+    ///  userdata: seed to use for transient stake account
+    IncreaseValidatorStake,
+
+    /// Burn collected fee tokens, increasing the value of the pool tokens
+    ///
+    /// Fees are required on SOL deposits to avoid an attack vector to leech
+    /// value from the pool, by depositing SOL and immediately withdrawing a
+    /// stake account.
+    ///
+    /// By default, fees are collected into a token account owned by the program,
+    /// and are meant to be burned to increase the value of pool tokens on SOL
+    /// deposit.
+    ///
+    /// After burning fees, users should run `update_stake_pool_balance` to
+    /// accurately reflect the increased value of their pool tokens.
+    ///
+    /// 0. `[]` Validator that the pool should be delegated to
+    /// 1. `[]` Stake pool
+    /// 2. `[]` Manager
+    /// 3. `[w]` Fee account
+    /// 4. `[w]` Pool mint
+    /// 5. `[]` Token program id
+    /// 6. `[]` Stake pool program id
+    BurnFees,
+
+    ///  Update fees to the amount required by the program
+    ///
+    ///  This is useful for existing pools that are assigned to the management
+    ///  program, and are configured with different fees.
+    ///
+    ///  0. `[]` Validator that the pool should be delegated to
+    ///  1. `[w]` StakePool
+    ///  2. `[]` Manager
+    ///  3. `[]` Stake pool program
+    ResetFees,
+
+    ///  Remove funding authorities, if already set.
+    ///
+    ///  Single-validator pool should have no restrictions on deposits or
+    ///  withdrawals. This is useful for existing pools that are assigned to the
+    ///  management program, and are configured with funding authorities.
+    ///
+    ///  0. `[]` Validator that the pool should be delegated to
+    ///  1. `[w]` StakePool
+    ///  2. `[]` Manager
+    ///  3. `[]` Stake pool program
+    RemoveFundingAuthorities,
+
+    /// Create token metadata for the stake-pool token in the metaplex-token program.
+    ///
+    /// Must be signed by the authorized voter for the validator.
+    ///
+    ///  0. `[s]` Authorized voter for validator
+    ///  1. `[]` Validator that the pool should be delegated to
+    ///  2. `[]` Stake pool
+    ///  3. `[]` Manager
+    ///  4. `[]` Stake pool withdraw authority
+    ///  5. `[]` Pool token mint account
+    ///  6. `[s, w]` Payer for creation of token metadata account
+    ///  7. `[w]` Token metadata account
+    ///  8. `[]` Metadata program id
+    ///  9. `[]` System program id
+    /// 10. `[]` Rent sysvar
+    /// 11. `[]` Stake pool program id
+    ///
+    /// userdata: new `TokenMetadata`
+    CreateTokenMetadata,
+
+    /// Update token metadata for the stake-pool token in the metaplex-token program.
+    ///
+    /// Must be signed by the authorized voter for the validator.
+    ///
+    /// 0. `[s]` Authorized voter for validator
+    /// 1. `[]` Validator that the pool should be delegated to
+    /// 2. `[]` Stake pool
+    /// 3. `[]` Manager
+    /// 4. `[]` Stake pool withdraw authority
+    /// 5. `[w]` Token metadata account
+    /// 6. `[]` Metadata program id
+    /// 7. `[]` Stake pool program id
+    ///
+    /// userdata: new `TokenMetadata`
+    UpdateTokenMetadata,
+}
+
+/// Struct used for creating and updating the pool token metadata, needs to use
+/// Borsh encoding to work with Metaplex token metadata
+#[derive(Clone, Debug, BorshSchema, BorshSerialize, BorshDeserialize)]
+pub struct TokenMetadata {
+    /// Token name
+    pub name: String,
+    /// Token symbol e.g. stkSOL
+    pub symbol: String,
+    /// URI of the uploaded metadata of the spl-token
+    pub uri: String,
+}
+
+/// Utility function for decoding just the instruction type
+pub fn decode_instruction_type<T: TryFrom<u8>>(input: &[u8]) -> Result<T, ProgramError> {
+    if input.is_empty() {
+        Err(ProgramError::InvalidInstructionData)
+    } else {
+        T::try_from(input[0]).map_err(|_| SingleValidatorManagerError::InvalidInstruction.into())
+    }
+}
+
+/// Utility function for decoding instruction data
+///
+/// Note: This function expects the entire instruction input, including the
+/// instruction type as the first byte.  This makes the code concise and safe
+/// at the expense of clarity, allowing flows such as:
+///
+/// match decode_instruction_type(input)? {
+///     InstructionType::First => {
+///         let FirstData { ... } = decode_instruction_data(input)?;
+///     }
+/// }
+pub fn decode_instruction_data<T: Pod>(input_with_type: &[u8]) -> Result<&T, ProgramError> {
+    if input_with_type.len() != std::mem::size_of::<T>().saturating_add(1) {
+        Err(ProgramError::InvalidInstructionData)
+    } else {
+        bytemuck::try_from_bytes(&input_with_type[1..]).map_err(|_| ProgramError::InvalidArgument)
+    }
+}
+
+/// Utility function for decoding instruction data serialized with Borsh
+pub fn decode_instruction_data_with_borsh<T: BorshDeserialize + BorshSchema>(
+    input_with_type: &[u8],
+) -> Result<T, ProgramError> {
+    if input_with_type.len() != get_packed_len::<T>().saturating_add(1) {
+        Err(ProgramError::InvalidInstructionData)
+    } else {
+        T::try_from_slice(&input_with_type[1..]).map_err(|_| ProgramError::InvalidArgument)
+    }
+}
+
+/// Utility function for encoding bytemuck instruction data
+pub(crate) fn encode_instruction<T: Pod>(
+    program_id: &Pubkey,
+    accounts: Vec<AccountMeta>,
+    instruction_type: SingleValidatorManagerInstruction,
+    instruction_data: &T,
+) -> Instruction {
+    let mut data = vec![];
+    data.push(u8::from(instruction_type));
+    data.extend_from_slice(bytemuck::bytes_of(instruction_data));
+    Instruction {
+        program_id: *program_id,
+        accounts,
+        data,
+    }
+}
+
+/// Utility function for encoding borsh instruction data
+pub(crate) fn encode_instruction_with_borsh<T: BorshSerialize>(
+    program_id: &Pubkey,
+    accounts: Vec<AccountMeta>,
+    instruction_type: SingleValidatorManagerInstruction,
+    instruction_data: &T,
+) -> Instruction {
+    let mut data = vec![];
+    data.push(u8::from(instruction_type));
+    data.append(&mut instruction_data.try_to_vec().unwrap());
+    Instruction {
+        program_id: *program_id,
+        accounts,
+        data,
+    }
+}
+
+/// Creates an 'create_stake_pool' instruction.
+pub fn create_stake_pool(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    validator: &Pubkey,
+    stake_pool_program_id: &Pubkey,
+) -> Instruction {
+    let (stake_pool, _) = StakePoolAddress::find(program_id, validator, stake_pool_program_id);
+    let (validator_list, _) =
+        ValidatorListAddress::find(program_id, validator, stake_pool_program_id);
+    let (reserve, _) = ReserveAddress::find(program_id, validator, stake_pool_program_id);
+    let (mint, _) = MintAddress::find(program_id, validator, stake_pool_program_id);
+    let (manager, _) = ManagerAddress::find(program_id, validator, stake_pool_program_id);
+    let fee_account =
+        get_associated_token_address_with_program_id(&manager, &mint, &spl_token::id());
+    let (stake_pool_withdraw_authority, _) =
+        find_withdraw_authority_program_address(stake_pool_program_id, &stake_pool);
+    let accounts = vec![
+        AccountMeta::new(*payer, true),
+        AccountMeta::new_readonly(*validator, false),
+        AccountMeta::new(stake_pool, false),
+        AccountMeta::new(validator_list, false),
+        AccountMeta::new(reserve, false),
+        AccountMeta::new(mint, false),
+        AccountMeta::new(fee_account, false),
+        AccountMeta::new_readonly(manager, false),
+        AccountMeta::new_readonly(stake_pool_withdraw_authority, false),
+        AccountMeta::new_readonly(system_program::id(), false),
+        AccountMeta::new_readonly(stake::program::id(), false),
+        AccountMeta::new_readonly(spl_token::id(), false),
+        AccountMeta::new_readonly(*stake_pool_program_id, false),
+    ];
+    encode_instruction(
+        program_id,
+        accounts,
+        SingleValidatorManagerInstruction::CreateStakePool,
+        &(),
+    )
+}
+
+/// Creates `AddValidatorToPool` instruction
+pub fn add_validator_to_pool(
+    program_id: &Pubkey,
+    validator: &Pubkey,
+    stake_pool_program_id: &Pubkey,
+    seed: Option<NonZeroU32>,
+) -> Instruction {
+    let (stake_pool, _) = StakePoolAddress::find(program_id, validator, stake_pool_program_id);
+    let (validator_list, _) =
+        ValidatorListAddress::find(program_id, validator, stake_pool_program_id);
+    let (reserve, _) = ReserveAddress::find(program_id, validator, stake_pool_program_id);
+    let (manager, _) = ManagerAddress::find(program_id, validator, stake_pool_program_id);
+    let (stake_pool_withdraw_authority, _) =
+        find_withdraw_authority_program_address(stake_pool_program_id, &stake_pool);
+    let (stake, _) =
+        find_stake_program_address(stake_pool_program_id, validator, &stake_pool, seed);
+    let accounts = vec![
+        AccountMeta::new(stake_pool, false),
+        AccountMeta::new_readonly(manager, false),
+        AccountMeta::new(reserve, false),
+        AccountMeta::new_readonly(stake_pool_withdraw_authority, false),
+        AccountMeta::new(validator_list, false),
+        AccountMeta::new(stake, false),
+        AccountMeta::new_readonly(*validator, false),
+        AccountMeta::new_readonly(sysvar::rent::id(), false),
+        AccountMeta::new_readonly(sysvar::clock::id(), false),
+        AccountMeta::new_readonly(sysvar::stake_history::id(), false),
+        AccountMeta::new_readonly(stake::config::id(), false),
+        AccountMeta::new_readonly(system_program::id(), false),
+        AccountMeta::new_readonly(stake::program::id(), false),
+        AccountMeta::new_readonly(*stake_pool_program_id, false),
+    ];
+    encode_instruction(
+        program_id,
+        accounts,
+        SingleValidatorManagerInstruction::AddValidatorToPool,
+        &seed.map(|s| s.get()).unwrap_or(0),
+    )
+}
+
+/// Creates `RemoveValidatorFromPool` instruction
+pub fn remove_validator_from_pool(
+    program_id: &Pubkey,
+    validator: &Pubkey,
+    stake_pool_program_id: &Pubkey,
+    validator_to_remove: &Pubkey,
+    validator_stake_seed: Option<NonZeroU32>,
+    transient_stake_seed: u64,
+) -> Instruction {
+    let (stake_pool, _) = StakePoolAddress::find(program_id, validator, stake_pool_program_id);
+    let (validator_list, _) =
+        ValidatorListAddress::find(program_id, validator, stake_pool_program_id);
+    let (manager, _) = ManagerAddress::find(program_id, validator, stake_pool_program_id);
+    let (stake_pool_withdraw_authority, _) =
+        find_withdraw_authority_program_address(stake_pool_program_id, &stake_pool);
+    let (stake, _) = find_stake_program_address(
+        stake_pool_program_id,
+        validator_to_remove,
+        &stake_pool,
+        validator_stake_seed,
+    );
+    let (transient_stake, _) = find_transient_stake_program_address(
+        stake_pool_program_id,
+        validator_to_remove,
+        &stake_pool,
+        transient_stake_seed,
+    );
+    let accounts = vec![
+        AccountMeta::new_readonly(*validator, false),
+        AccountMeta::new(stake_pool, false),
+        AccountMeta::new_readonly(manager, false),
+        AccountMeta::new_readonly(stake_pool_withdraw_authority, false),
+        AccountMeta::new(validator_list, false),
+        AccountMeta::new(stake, false),
+        AccountMeta::new_readonly(transient_stake, false),
+        AccountMeta::new_readonly(sysvar::clock::id(), false),
+        AccountMeta::new_readonly(stake::program::id(), false),
+        AccountMeta::new_readonly(*stake_pool_program_id, false),
+    ];
+    encode_instruction(
+        program_id,
+        accounts,
+        SingleValidatorManagerInstruction::RemoveValidatorFromPool,
+        &(),
+    )
+}
+
+/// Creates `DecreaseValidatorStake` instruction (rebalance from main validator account to
+/// transient account)
+pub fn decrease_validator_stake(
+    program_id: &Pubkey,
+    validator: &Pubkey,
+    stake_pool_program_id: &Pubkey,
+    validator_to_decrease: &Pubkey,
+    validator_stake_seed: Option<NonZeroU32>,
+    transient_stake_seed: u64,
+) -> Instruction {
+    let (stake_pool, _) = StakePoolAddress::find(program_id, validator, stake_pool_program_id);
+    let (validator_list, _) =
+        ValidatorListAddress::find(program_id, validator, stake_pool_program_id);
+    let (reserve, _) = ReserveAddress::find(program_id, validator, stake_pool_program_id);
+    let (manager, _) = ManagerAddress::find(program_id, validator, stake_pool_program_id);
+    let (stake_pool_withdraw_authority, _) =
+        find_withdraw_authority_program_address(stake_pool_program_id, &stake_pool);
+    let (stake, _) = find_stake_program_address(
+        stake_pool_program_id,
+        validator_to_decrease,
+        &stake_pool,
+        validator_stake_seed,
+    );
+    let (transient_stake, _) = find_transient_stake_program_address(
+        stake_pool_program_id,
+        validator_to_decrease,
+        &stake_pool,
+        transient_stake_seed,
+    );
+
+    let accounts = vec![
+        AccountMeta::new_readonly(*validator, false),
+        AccountMeta::new_readonly(stake_pool, false),
+        AccountMeta::new_readonly(manager, false),
+        AccountMeta::new_readonly(stake_pool_withdraw_authority, false),
+        AccountMeta::new(validator_list, false),
+        AccountMeta::new(stake, false),
+        AccountMeta::new(transient_stake, false),
+        AccountMeta::new_readonly(sysvar::clock::id(), false),
+        AccountMeta::new_readonly(sysvar::rent::id(), false),
+        AccountMeta::new_readonly(system_program::id(), false),
+        AccountMeta::new_readonly(stake::program::id(), false),
+        AccountMeta::new_readonly(*stake_pool_program_id, false),
+    ];
+    encode_instruction(
+        program_id,
+        accounts,
+        SingleValidatorManagerInstruction::DecreaseValidatorStake,
+        &transient_stake_seed,
+    )
+}
+
+/// Creates `IncreaseValidatorStake` instruction (rebalance from reserve account to
+/// transient account)
+pub fn increase_validator_stake(
+    program_id: &Pubkey,
+    validator: &Pubkey,
+    stake_pool_program_id: &Pubkey,
+    validator_stake_seed: Option<NonZeroU32>,
+    transient_stake_seed: u64,
+) -> Instruction {
+    let (stake_pool, _) = StakePoolAddress::find(program_id, validator, stake_pool_program_id);
+    let (validator_list, _) =
+        ValidatorListAddress::find(program_id, validator, stake_pool_program_id);
+    let (reserve, _) = ReserveAddress::find(program_id, validator, stake_pool_program_id);
+    let (manager, _) = ManagerAddress::find(program_id, validator, stake_pool_program_id);
+    let (stake_pool_withdraw_authority, _) =
+        find_withdraw_authority_program_address(stake_pool_program_id, &stake_pool);
+    let (stake, _) = find_stake_program_address(
+        stake_pool_program_id,
+        validator,
+        &stake_pool,
+        validator_stake_seed,
+    );
+    let (transient_stake, _) = find_transient_stake_program_address(
+        stake_pool_program_id,
+        validator,
+        &stake_pool,
+        transient_stake_seed,
+    );
+    let accounts = vec![
+        AccountMeta::new_readonly(stake_pool, false),
+        AccountMeta::new_readonly(manager, false),
+        AccountMeta::new_readonly(stake_pool_withdraw_authority, false),
+        AccountMeta::new(validator_list, false),
+        AccountMeta::new(reserve, false),
+        AccountMeta::new(transient_stake, false),
+        AccountMeta::new_readonly(stake, false),
+        AccountMeta::new_readonly(*validator, false),
+        AccountMeta::new_readonly(sysvar::clock::id(), false),
+        AccountMeta::new_readonly(sysvar::rent::id(), false),
+        AccountMeta::new_readonly(sysvar::stake_history::id(), false),
+        AccountMeta::new_readonly(stake::config::id(), false),
+        AccountMeta::new_readonly(system_program::id(), false),
+        AccountMeta::new_readonly(stake::program::id(), false),
+        AccountMeta::new_readonly(*stake_pool_program_id, false),
+    ];
+    encode_instruction(
+        program_id,
+        accounts,
+        SingleValidatorManagerInstruction::IncreaseValidatorStake,
+        &transient_stake_seed,
+    )
+}
+
+/// Creates a `ResetFees` instruction.
+pub fn reset_fees(
+    program_id: &Pubkey,
+    validator: &Pubkey,
+    stake_pool_program_id: &Pubkey,
+) -> Instruction {
+    let (stake_pool, _) = StakePoolAddress::find(program_id, validator, stake_pool_program_id);
+    let (manager, _) = ManagerAddress::find(program_id, validator, stake_pool_program_id);
+    let accounts = vec![
+        AccountMeta::new_readonly(*validator, false),
+        AccountMeta::new(stake_pool, false),
+        AccountMeta::new_readonly(manager, false),
+        AccountMeta::new_readonly(*stake_pool_program_id, false),
+    ];
+    encode_instruction(
+        program_id,
+        accounts,
+        SingleValidatorManagerInstruction::ResetFees,
+        &(),
+    )
+}
+
+/// Creates a `RemoveFundingAuthorities` instruction.
+pub fn remove_funding_authorities(
+    program_id: &Pubkey,
+    validator: &Pubkey,
+    stake_pool_program_id: &Pubkey,
+) -> Instruction {
+    let (stake_pool, _) = StakePoolAddress::find(program_id, validator, stake_pool_program_id);
+    let (manager, _) = ManagerAddress::find(program_id, validator, stake_pool_program_id);
+    let accounts = vec![
+        AccountMeta::new_readonly(*validator, false),
+        AccountMeta::new(stake_pool, false),
+        AccountMeta::new_readonly(manager, false),
+        AccountMeta::new_readonly(*stake_pool_program_id, false),
+    ];
+    encode_instruction(
+        program_id,
+        accounts,
+        SingleValidatorManagerInstruction::RemoveFundingAuthorities,
+        &(),
+    )
+}
+
+/// Creates an instruction to update metadata in the mpl token metadata program account for
+/// the pool token
+pub fn update_token_metadata(
+    program_id: &Pubkey,
+    authorized_voter: &Pubkey,
+    validator: &Pubkey,
+    stake_pool_program_id: &Pubkey,
+    name: String,
+    symbol: String,
+    uri: String,
+) -> Instruction {
+    let (stake_pool, _) = StakePoolAddress::find(program_id, validator, stake_pool_program_id);
+    let (manager, _) = ManagerAddress::find(program_id, validator, stake_pool_program_id);
+    let (mint, _) = MintAddress::find(program_id, validator, stake_pool_program_id);
+    let (stake_pool_withdraw_authority, _) =
+        find_withdraw_authority_program_address(program_id, &stake_pool);
+    let (token_metadata, _) = find_metadata_account(&mint);
+    let accounts = vec![
+        AccountMeta::new_readonly(*authorized_voter, true),
+        AccountMeta::new_readonly(*validator, false),
+        AccountMeta::new_readonly(stake_pool, false),
+        AccountMeta::new_readonly(manager, false),
+        AccountMeta::new_readonly(stake_pool_withdraw_authority, false),
+        AccountMeta::new(token_metadata, false),
+        AccountMeta::new_readonly(mpl_token_metadata::id(), false),
+        AccountMeta::new_readonly(*stake_pool_program_id, false),
+    ];
+    encode_instruction_with_borsh(
+        program_id,
+        accounts,
+        SingleValidatorManagerInstruction::UpdateTokenMetadata,
+        &TokenMetadata { name, symbol, uri },
+    )
+}
+
+/// Creates an instruction to create metadata using the mpl token metadata program for
+/// the pool token
+pub fn create_token_metadata(
+    program_id: &Pubkey,
+    authorized_voter: &Pubkey,
+    validator: &Pubkey,
+    stake_pool_program_id: &Pubkey,
+    payer: &Pubkey,
+    name: String,
+    symbol: String,
+    uri: String,
+) -> Instruction {
+    let (stake_pool, _) = StakePoolAddress::find(program_id, validator, stake_pool_program_id);
+    let (manager, _) = ManagerAddress::find(program_id, validator, stake_pool_program_id);
+    let (mint, _) = MintAddress::find(program_id, validator, stake_pool_program_id);
+    let (stake_pool_withdraw_authority, _) =
+        find_withdraw_authority_program_address(program_id, &stake_pool);
+    let (token_metadata, _) = find_metadata_account(&mint);
+    let accounts = vec![
+        AccountMeta::new_readonly(*authorized_voter, true),
+        AccountMeta::new_readonly(*validator, false),
+        AccountMeta::new_readonly(stake_pool, false),
+        AccountMeta::new_readonly(manager, false),
+        AccountMeta::new_readonly(stake_pool_withdraw_authority, false),
+        AccountMeta::new_readonly(mint, false),
+        AccountMeta::new(*payer, true),
+        AccountMeta::new(token_metadata, false),
+        AccountMeta::new_readonly(mpl_token_metadata::id(), false),
+        AccountMeta::new_readonly(system_program::id(), false),
+        AccountMeta::new_readonly(sysvar::rent::id(), false),
+        AccountMeta::new_readonly(*stake_pool_program_id, false),
+    ];
+    encode_instruction_with_borsh(
+        program_id,
+        accounts,
+        SingleValidatorManagerInstruction::CreateTokenMetadata,
+        &TokenMetadata { name, symbol, uri },
+    )
+}
+
+#[cfg(test)]
+mod test {
+    use {
+        super::*,
+        solana_program::{
+            borsh::get_instance_packed_len, program_pack::Pack, rent::Rent,
+            stake::state::StakeState,
+        },
+        spl_stake_pool::state::{StakePool, ValidatorList},
+        spl_token_2022::state::{Account, Mint},
+    };
+
+    #[test]
+    fn test_total_pool_rent() {
+        let rent = Rent::default();
+        let sizes = vec![
+            get_packed_len::<StakePool>(),
+            get_instance_packed_len(&ValidatorList::new(1)).unwrap(),
+            std::mem::size_of::<StakeState>(),
+            Mint::LEN,
+            Account::LEN,
+        ];
+        assert_eq!(
+            sizes
+                .into_iter()
+                .map(|x| rent.minimum_balance(x))
+                .sum::<u64>(),
+            12_388_800
+        );
+    }
+}

--- a/single-validator-manager/program/src/lib.rs
+++ b/single-validator-manager/program/src/lib.rs
@@ -17,7 +17,7 @@ use spl_stake_pool::state::Fee;
 
 /// The SOL deposit fee required for all program-managed pools, 5 basis points
 pub const SOL_DEPOSIT_FEE: Fee = Fee {
-    numerator: 5,
+    numerator: 8,
     denominator: 10_000,
 };
 

--- a/single-validator-manager/program/src/lib.rs
+++ b/single-validator-manager/program/src/lib.rs
@@ -1,0 +1,24 @@
+#![allow(clippy::integer_arithmetic)]
+#![deny(missing_docs)]
+
+//! A program for creating and managing pools of stake delegated to a single validator
+
+pub mod error;
+pub mod instruction;
+pub mod pda;
+pub mod processor;
+
+#[cfg(not(feature = "no-entrypoint"))]
+pub mod entrypoint;
+
+// Export current sdk types for downstream users building with a different sdk version
+pub use solana_program;
+use spl_stake_pool::state::Fee;
+
+/// The SOL deposit fee required for all program-managed pools, 5 basis points
+pub const SOL_DEPOSIT_FEE: Fee = Fee {
+    numerator: 5,
+    denominator: 10_000,
+};
+
+solana_program::declare_id!("SVPoo3ud9JDXTNXUAo7o8NgwkDVgcfnwRMoS8r6oP6G");

--- a/single-validator-manager/program/src/pda.rs
+++ b/single-validator-manager/program/src/pda.rs
@@ -1,0 +1,65 @@
+//! Defines all program-derived addresses used by the program
+
+use solana_program::pubkey::Pubkey;
+
+macro_rules! impl_program_address {
+    ($address:ident, $seed:ident) => {
+        /// Defines a program-derived address
+        pub struct $address;
+        impl $address {
+            /// Generates the program address
+            pub fn find(
+                program_id: &Pubkey,
+                validator: &Pubkey,
+                stake_pool_program_id: &Pubkey,
+            ) -> (Pubkey, u8) {
+                Pubkey::find_program_address(
+                    &Self::collect_seeds(validator, stake_pool_program_id),
+                    program_id,
+                )
+            }
+
+            /// Generates the seeds for checking
+            pub(crate) fn collect_seeds<'a>(
+                validator: &'a Pubkey,
+                stake_pool_program_id: &'a Pubkey,
+            ) -> [&'a [u8]; 3] {
+                [$seed, validator.as_ref(), stake_pool_program_id.as_ref()]
+            }
+
+            /// Generates the seeds for signing
+            pub(crate) fn collect_signer_seeds<'a>(
+                validator: &'a Pubkey,
+                stake_pool_program_id: &'a Pubkey,
+                bump_seed: &'a [u8],
+            ) -> [&'a [u8]; 4] {
+                [
+                    $seed,
+                    validator.as_ref(),
+                    stake_pool_program_id.as_ref(),
+                    bump_seed,
+                ]
+            }
+        }
+    };
+}
+
+/// Seed for stake pool manager and staker
+const MANAGER_SEED: &[u8] = b"manager";
+impl_program_address!(ManagerAddress, MANAGER_SEED);
+
+/// Seed for stake pool address
+const STAKE_POOL_SEED: &[u8] = b"stake-pool";
+impl_program_address!(StakePoolAddress, STAKE_POOL_SEED);
+
+/// Seed for validator list address
+const VALIDATOR_LIST_SEED: &[u8] = b"validator-list";
+impl_program_address!(ValidatorListAddress, VALIDATOR_LIST_SEED);
+
+/// Seed for stake pool mint
+const MINT_SEED: &[u8] = b"mint";
+impl_program_address!(MintAddress, MINT_SEED);
+
+/// Seed for stake pool reserve
+const RESERVE_SEED: &[u8] = b"reserve";
+impl_program_address!(ReserveAddress, RESERVE_SEED);

--- a/single-validator-manager/program/src/processor.rs
+++ b/single-validator-manager/program/src/processor.rs
@@ -1,0 +1,362 @@
+//! Program state processor
+
+use {
+    crate::instruction::{
+        decode_instruction_data, decode_instruction_data_with_borsh, decode_instruction_type,
+        SingleValidatorManagerInstruction, TokenMetadata,
+    },
+    mpl_token_metadata::{
+        instruction::{create_metadata_accounts_v3, update_metadata_accounts_v2},
+        pda::find_metadata_account,
+        state::DataV2,
+    },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        borsh::try_from_slice_unchecked,
+        clock::{Clock, Epoch},
+        decode_error::DecodeError,
+        entrypoint::ProgramResult,
+        msg,
+        program::{invoke, invoke_signed},
+        program_error::ProgramError,
+        pubkey::Pubkey,
+        rent::Rent,
+        stake, system_instruction, system_program,
+        sysvar::Sysvar,
+    },
+    spl_token_2022::{
+        check_spl_token_program_account,
+        extension::{BaseStateWithExtensions, StateWithExtensions},
+        state::Mint,
+    },
+    std::num::NonZeroU32,
+};
+
+/// Check system program address
+fn check_system_program(program_id: &Pubkey) -> Result<(), ProgramError> {
+    if *program_id != system_program::id() {
+        msg!(
+            "Expected system program {}, received {}",
+            system_program::id(),
+            program_id
+        );
+        Err(ProgramError::IncorrectProgramId)
+    } else {
+        Ok(())
+    }
+}
+
+/// Check stake program address
+fn check_stake_program(program_id: &Pubkey) -> Result<(), ProgramError> {
+    if *program_id != stake::program::id() {
+        msg!(
+            "Expected stake program {}, received {}",
+            stake::program::id(),
+            program_id
+        );
+        Err(ProgramError::IncorrectProgramId)
+    } else {
+        Ok(())
+    }
+}
+
+/// Check mpl metadata program
+fn check_mpl_metadata_program(program_id: &Pubkey) -> Result<(), ProgramError> {
+    if *program_id != mpl_token_metadata::id() {
+        msg!(
+            "Expected mpl metadata program {}, received {}",
+            mpl_token_metadata::id(),
+            program_id
+        );
+        Err(ProgramError::IncorrectProgramId)
+    } else {
+        Ok(())
+    }
+}
+
+/// Check rent sysvar correctness
+fn check_rent_sysvar(sysvar_key: &Pubkey) -> Result<(), ProgramError> {
+    if *sysvar_key != solana_program::sysvar::rent::id() {
+        msg!(
+            "Expected rent sysvar {}, received {}",
+            solana_program::sysvar::rent::id(),
+            sysvar_key
+        );
+        Err(ProgramError::InvalidArgument)
+    } else {
+        Ok(())
+    }
+}
+
+/// Check account owner is the given program
+fn check_account_owner(
+    account_info: &AccountInfo,
+    program_id: &Pubkey,
+) -> Result<(), ProgramError> {
+    if *program_id != *account_info.owner {
+        msg!(
+            "Expected account to be owned by program {}, received {}",
+            program_id,
+            account_info.owner
+        );
+        Err(ProgramError::IncorrectProgramId)
+    } else {
+        Ok(())
+    }
+}
+
+/// Create a stake account on a PDA without transferring lamports
+fn create_stake_account<'a>(
+    stake_account_info: AccountInfo<'a>,
+    stake_account_signer_seeds: &[&[u8]],
+    system_program_info: AccountInfo<'a>,
+) -> Result<(), ProgramError> {
+    invoke_signed(
+        &system_instruction::allocate(
+            stake_account_info.key,
+            std::mem::size_of::<stake::state::StakeState>() as u64,
+        ),
+        &[stake_account_info.clone(), system_program_info.clone()],
+        &[stake_account_signer_seeds],
+    )?;
+    invoke_signed(
+        &system_instruction::assign(stake_account_info.key, &stake::program::id()),
+        &[stake_account_info, system_program_info],
+        &[stake_account_signer_seeds],
+    )
+}
+
+/// Issue stake::instruction::authorize instructions to update both authorities
+fn stake_authorize<'a>(
+    stake_account: AccountInfo<'a>,
+    stake_authority: AccountInfo<'a>,
+    new_stake_authority: &Pubkey,
+    clock: AccountInfo<'a>,
+    stake_program_info: AccountInfo<'a>,
+) -> Result<(), ProgramError> {
+    let authorize_instruction = stake::instruction::authorize(
+        stake_account.key,
+        stake_authority.key,
+        new_stake_authority,
+        stake::state::StakeAuthorize::Staker,
+        None,
+    );
+
+    invoke(
+        &authorize_instruction,
+        &[
+            stake_account.clone(),
+            clock.clone(),
+            stake_authority.clone(),
+            stake_program_info.clone(),
+        ],
+    )?;
+
+    let authorize_instruction = stake::instruction::authorize(
+        stake_account.key,
+        stake_authority.key,
+        new_stake_authority,
+        stake::state::StakeAuthorize::Withdrawer,
+        None,
+    );
+
+    invoke(
+        &authorize_instruction,
+        &[stake_account, clock, stake_authority, stake_program_info],
+    )
+}
+
+/// Issue stake::instruction::authorize instructions to update both authorities
+#[allow(clippy::too_many_arguments)]
+fn stake_authorize_signed<'a>(
+    stake_pool: &Pubkey,
+    stake_account: AccountInfo<'a>,
+    stake_authority: AccountInfo<'a>,
+    authority_type: &[u8],
+    bump_seed: u8,
+    new_stake_authority: &Pubkey,
+    clock: AccountInfo<'a>,
+    stake_program_info: AccountInfo<'a>,
+) -> Result<(), ProgramError> {
+    let me_bytes = stake_pool.to_bytes();
+    let authority_signature_seeds = [&me_bytes[..32], authority_type, &[bump_seed]];
+    let signers = &[&authority_signature_seeds[..]];
+
+    let authorize_instruction = stake::instruction::authorize(
+        stake_account.key,
+        stake_authority.key,
+        new_stake_authority,
+        stake::state::StakeAuthorize::Staker,
+        None,
+    );
+
+    invoke_signed(
+        &authorize_instruction,
+        &[
+            stake_account.clone(),
+            clock.clone(),
+            stake_authority.clone(),
+            stake_program_info.clone(),
+        ],
+        signers,
+    )?;
+
+    let authorize_instruction = stake::instruction::authorize(
+        stake_account.key,
+        stake_authority.key,
+        new_stake_authority,
+        stake::state::StakeAuthorize::Withdrawer,
+        None,
+    );
+    invoke_signed(
+        &authorize_instruction,
+        &[stake_account, clock, stake_authority, stake_program_info],
+        signers,
+    )
+}
+
+/// Issue a spl_token `Burn` instruction.
+#[allow(clippy::too_many_arguments)]
+fn token_burn<'a>(
+    token_program: AccountInfo<'a>,
+    burn_account: AccountInfo<'a>,
+    mint: AccountInfo<'a>,
+    authority: AccountInfo<'a>,
+    amount: u64,
+) -> Result<(), ProgramError> {
+    let ix = spl_token_2022::instruction::burn(
+        token_program.key,
+        burn_account.key,
+        mint.key,
+        authority.key,
+        &[],
+        amount,
+    )?;
+
+    invoke(&ix, &[burn_account, mint, authority, token_program])
+}
+
+/// Processes `CreateStakePool` instruction.
+fn process_create_stake_pool(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
+    Ok(())
+}
+
+/// Processes `AddValidatorToPool` instruction.
+fn process_add_validator_to_pool(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    raw_validator_seed: &u32,
+) -> ProgramResult {
+    Ok(())
+}
+
+/// Processes `RemoveValidatorFromPool` instruction.
+fn process_remove_validator_from_pool(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+) -> ProgramResult {
+    Ok(())
+}
+
+/// Processes `DecreaseValidatorStake` instruction.
+fn process_decrease_validator_stake(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    transient_stake_seed: &u64,
+) -> ProgramResult {
+    Ok(())
+}
+
+/// Processes `IncreaseValidatorStake` instruction.
+fn process_increase_validator_stake(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    transient_stake_seed: &u64,
+) -> ProgramResult {
+    Ok(())
+}
+
+fn process_create_pool_token_metadata(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    token_metadata: TokenMetadata,
+) -> ProgramResult {
+    Ok(())
+}
+
+fn process_update_pool_token_metadata(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    token_metadata: TokenMetadata,
+) -> ProgramResult {
+    Ok(())
+}
+
+/// Processes [ResetFees](enum.Instruction.html).
+fn process_reset_fees(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
+    Ok(())
+}
+
+/// Processes [RemoveFundingAuthorities](enum.Instruction.html).
+fn process_remove_funding_authorities(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+) -> ProgramResult {
+    Ok(())
+}
+
+/// Processes [BurnFees](enum.Instruction.html).
+fn process_burn_fees(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
+    Ok(())
+}
+
+/// Processes [Instruction](enum.Instruction.html).
+pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> ProgramResult {
+    match decode_instruction_type(input)? {
+        SingleValidatorManagerInstruction::CreateStakePool => {
+            msg!("Instruction: Create stake pool");
+            process_create_stake_pool(program_id, accounts)
+        }
+        SingleValidatorManagerInstruction::AddValidatorToPool => {
+            msg!("Instruction: AddValidatorToPool");
+            let seed = decode_instruction_data::<u32>(input)?;
+            process_add_validator_to_pool(program_id, accounts, seed)
+        }
+        SingleValidatorManagerInstruction::RemoveValidatorFromPool => {
+            msg!("Instruction: RemoveValidatorFromPool");
+            process_remove_validator_from_pool(program_id, accounts)
+        }
+        SingleValidatorManagerInstruction::DecreaseValidatorStake => {
+            msg!("Instruction: DecreaseValidatorStake");
+            let transient_stake_seed = decode_instruction_data::<u64>(input)?;
+            process_decrease_validator_stake(program_id, accounts, transient_stake_seed)
+        }
+        SingleValidatorManagerInstruction::IncreaseValidatorStake => {
+            msg!("Instruction: IncreaseValidatorStake");
+            let transient_stake_seed = decode_instruction_data::<u64>(input)?;
+            process_increase_validator_stake(program_id, accounts, transient_stake_seed)
+        }
+        SingleValidatorManagerInstruction::ResetFees => {
+            msg!("Instruction: ResetFees");
+            process_reset_fees(program_id, accounts)
+        }
+        SingleValidatorManagerInstruction::RemoveFundingAuthorities => {
+            msg!("Instruction: RemoveFundingAuthorities");
+            process_remove_funding_authorities(program_id, accounts)
+        }
+        SingleValidatorManagerInstruction::BurnFees => {
+            msg!("Instruction: BurnFees");
+            process_burn_fees(program_id, accounts)
+        }
+        SingleValidatorManagerInstruction::CreateTokenMetadata => {
+            msg!("Instruction: CreateTokenMetadata");
+            let token_metadata = decode_instruction_data_with_borsh::<TokenMetadata>(input)?;
+            process_create_pool_token_metadata(program_id, accounts, token_metadata)
+        }
+        SingleValidatorManagerInstruction::UpdateTokenMetadata => {
+            msg!("Instruction: UpdateTokenMetadata");
+            let token_metadata = decode_instruction_data_with_borsh::<TokenMetadata>(input)?;
+            process_update_pool_token_metadata(program_id, accounts, token_metadata)
+        }
+    }
+}


### PR DESCRIPTION
#### Problem

To help with smaller stakers contend with a higher minimum delegation program, we need a protocol for permissionless management of single-validator stake pools.

#### Solution

Start here with some intro docs and an interface description. Some of it is boiler-plate copy-pasted from the stake pool program that will likely be needed. The focus is on the docs and `instruction.rs`.

Feel free to add anyone else that I might have missed. The program should be quite simple, but the fees and general operation for increase / decrease need to be economically sound first.

Note: once we settle on a name, I'll reserve the crates. I don't love `single-validator-manager`, but it should be clear that this program is *managing* stake pools, and not a stake pool itself. I worry that `single-validator-stake-pool` gives the wrong impression, and that `single-validator-stake-pool-manager` is a mouthful.