### PR TITLE
Open Discussion For Permissioned Transfer Extension

### DIFF
--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -13,6 +13,7 @@ use {
             mint_close_authority::MintCloseAuthority,
             non_transferable::NonTransferable,
             permanent_delegate::PermanentDelegate,
+            transfer_authority::{TransferAuthorityAccount, TransferAuthorityMint},
             transfer_fee::{TransferFeeAmount, TransferFeeConfig},
         },
         pod::*,
@@ -53,6 +54,8 @@ pub mod non_transferable;
 pub mod permanent_delegate;
 /// Utility to reallocate token accounts
 pub mod reallocate;
+/// Transfer authority extension
+pub mod transfer_authority;
 /// Transfer Fee extension
 pub mod transfer_fee;
 
@@ -641,6 +644,10 @@ pub enum ExtensionType {
     CpiGuard,
     /// Includes an optional permanent delegate
     PermanentDelegate,
+    /// Config for transfer authority on mint
+    TransferAuthorityMint,
+    /// Config for transfer authority on account
+    TransferAuthorityAccount,
     /// Padding extension used to make an account exactly Multisig::LEN, used for testing
     #[cfg(test)]
     AccountPaddingTest = u16::MAX - 1,
@@ -683,6 +690,10 @@ impl ExtensionType {
             ExtensionType::InterestBearingConfig => pod_get_packed_len::<InterestBearingConfig>(),
             ExtensionType::CpiGuard => pod_get_packed_len::<CpiGuard>(),
             ExtensionType::PermanentDelegate => pod_get_packed_len::<PermanentDelegate>(),
+            ExtensionType::TransferAuthorityMint => pod_get_packed_len::<TransferAuthorityMint>(),
+            ExtensionType::TransferAuthorityAccount => {
+                pod_get_packed_len::<TransferAuthorityAccount>()
+            }
             #[cfg(test)]
             ExtensionType::AccountPaddingTest => pod_get_packed_len::<AccountPaddingTest>(),
             #[cfg(test)]
@@ -740,12 +751,14 @@ impl ExtensionType {
             | ExtensionType::DefaultAccountState
             | ExtensionType::NonTransferable
             | ExtensionType::InterestBearingConfig
-            | ExtensionType::PermanentDelegate => AccountType::Mint,
+            | ExtensionType::PermanentDelegate
+            | ExtensionType::TransferAuthorityMint => AccountType::Mint,
             ExtensionType::ImmutableOwner
             | ExtensionType::TransferFeeAmount
             | ExtensionType::ConfidentialTransferAccount
             | ExtensionType::MemoTransfer
-            | ExtensionType::CpiGuard => AccountType::Account,
+            | ExtensionType::CpiGuard
+            | ExtensionType::TransferAuthorityAccount => AccountType::Account,
             #[cfg(test)]
             ExtensionType::AccountPaddingTest => AccountType::Account,
             #[cfg(test)]

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -13,7 +13,7 @@ use {
             mint_close_authority::MintCloseAuthority,
             non_transferable::NonTransferable,
             permanent_delegate::PermanentDelegate,
-            transfer_authority::{TransferAuthorityAccount, TransferAuthorityMint},
+            permissioned_transfer::{PermissionedTransferAccount, PermissionedTransferMint},
             transfer_fee::{TransferFeeAmount, TransferFeeConfig},
         },
         pod::*,
@@ -54,8 +54,8 @@ pub mod non_transferable;
 pub mod permanent_delegate;
 /// Utility to reallocate token accounts
 pub mod reallocate;
-/// Transfer authority extension
-pub mod transfer_authority;
+/// permissioned authority extension
+pub mod permissioned_transfer;
 /// Transfer Fee extension
 pub mod transfer_fee;
 
@@ -644,10 +644,10 @@ pub enum ExtensionType {
     CpiGuard,
     /// Includes an optional permanent delegate
     PermanentDelegate,
-    /// Config for transfer authority on mint
-    TransferAuthorityMint,
-    /// Config for transfer authority on account
-    TransferAuthorityAccount,
+    /// Config for permissioned authority on mint
+    PermissionedTransferMint,
+    /// Config for permissioned authority on account
+    PermissionedTransferAccount,
     /// Padding extension used to make an account exactly Multisig::LEN, used for testing
     #[cfg(test)]
     AccountPaddingTest = u16::MAX - 1,
@@ -690,9 +690,11 @@ impl ExtensionType {
             ExtensionType::InterestBearingConfig => pod_get_packed_len::<InterestBearingConfig>(),
             ExtensionType::CpiGuard => pod_get_packed_len::<CpiGuard>(),
             ExtensionType::PermanentDelegate => pod_get_packed_len::<PermanentDelegate>(),
-            ExtensionType::TransferAuthorityMint => pod_get_packed_len::<TransferAuthorityMint>(),
-            ExtensionType::TransferAuthorityAccount => {
-                pod_get_packed_len::<TransferAuthorityAccount>()
+            ExtensionType::PermissionedTransferMint => {
+                pod_get_packed_len::<PermissionedTransferMint>()
+            }
+            ExtensionType::PermissionedTransferAccount => {
+                pod_get_packed_len::<PermissionedTransferAccount>()
             }
             #[cfg(test)]
             ExtensionType::AccountPaddingTest => pod_get_packed_len::<AccountPaddingTest>(),
@@ -752,13 +754,13 @@ impl ExtensionType {
             | ExtensionType::NonTransferable
             | ExtensionType::InterestBearingConfig
             | ExtensionType::PermanentDelegate
-            | ExtensionType::TransferAuthorityMint => AccountType::Mint,
+            | ExtensionType::PermissionedTransferMint => AccountType::Mint,
             ExtensionType::ImmutableOwner
             | ExtensionType::TransferFeeAmount
             | ExtensionType::ConfidentialTransferAccount
             | ExtensionType::MemoTransfer
             | ExtensionType::CpiGuard
-            | ExtensionType::TransferAuthorityAccount => AccountType::Account,
+            | ExtensionType::PermissionedTransferAccount => AccountType::Account,
             #[cfg(test)]
             ExtensionType::AccountPaddingTest => AccountType::Account,
             #[cfg(test)]

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -52,10 +52,10 @@ pub mod mint_close_authority;
 pub mod non_transferable;
 /// Permanent Delegate extension
 pub mod permanent_delegate;
-/// Utility to reallocate token accounts
-pub mod reallocate;
 /// permissioned authority extension
 pub mod permissioned_transfer;
+/// Utility to reallocate token accounts
+pub mod reallocate;
 /// Transfer Fee extension
 pub mod transfer_fee;
 
@@ -537,6 +537,7 @@ impl<'data, S: BaseState> StateWithExtensionsMut<'data, S> {
             // ConfidentialTransfers are currently opt-in only, so this is a no-op for extra safety
             // on InitializeAccount
             ExtensionType::ConfidentialTransferAccount => Ok(()),
+            ExtensionType::PermissionedTransferAccount => Ok(()),
             #[cfg(test)]
             ExtensionType::AccountPaddingTest => {
                 self.init_extension::<AccountPaddingTest>(true).map(|_| ())
@@ -781,6 +782,10 @@ impl ExtensionType {
                 #[cfg(test)]
                 ExtensionType::MintPaddingTest => {
                     account_extension_types.push(ExtensionType::AccountPaddingTest);
+                }
+                #[cfg(test)]
+                ExtensionType::PermissionedTransferMint => {
+                    account_extension_types.push(ExtensionType::PermissionedTransferAccount);
                 }
                 _ => {}
             }

--- a/token/program-2022/src/extension/permissioned_transfer.rs
+++ b/token/program-2022/src/extension/permissioned_transfer.rs
@@ -21,8 +21,9 @@ use {
 /// Maximum number of additional accounts for a transfer authority
 pub const MAX_ADDITIONAL_ACCOUNTS: usize = 3;
 
-/// 8 byte instruction discriminator computed from hash("global:permissioned_transfer")
-pub const PERMISSIONED_TRANSFER_INSTRUCTION_DATA: [u8; 8] = [117, 253, 134, 34, 247, 198, 166, 231];
+/// 8 byte instruction discriminator computed from hash("global:permissioned_token_transfer")
+pub const PERMISSIONED_TOKEN_TRANSFER_INSTRUCTION_DATA: [u8; 8] =
+    [86, 153, 189, 33, 202, 29, 46, 92];
 
 /// Transfer authority extension data for mints.
 #[repr(C)]
@@ -77,7 +78,11 @@ pub fn permissioned_transfer_check<'info, S: BaseState, BSE: BaseStateWithExtens
             invoke(
                 &Instruction {
                     program_id,
-                    data: [PERMISSIONED_TRANSFER_INSTRUCTION_DATA, amount.to_le_bytes()].concat(),
+                    data: [
+                        PERMISSIONED_TOKEN_TRANSFER_INSTRUCTION_DATA,
+                        amount.to_le_bytes(),
+                    ]
+                    .concat(),
                     accounts: account_metas,
                 },
                 &acount_infos,

--- a/token/program-2022/src/extension/permissioned_transfer.rs
+++ b/token/program-2022/src/extension/permissioned_transfer.rs
@@ -21,6 +21,9 @@ use {
 /// Maximum number of additional accounts for a transfer authority
 pub const MAX_ADDITIONAL_ACCOUNTS: usize = 3;
 
+/// 8 byte instruction discriminator computed from hash("global:permissioned_transfer")
+pub const PERMISSIONED_TRANSFER_INSTRUCTION_DATA: [u8; 8] = [117, 253, 134, 34, 247, 198, 166, 231];
+
 /// Transfer authority extension data for mints.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
@@ -74,7 +77,7 @@ pub fn permissioned_transfer_check<'info, S: BaseState, BSE: BaseStateWithExtens
             invoke(
                 &Instruction {
                     program_id,
-                    data: [].to_vec(),
+                    data: PERMISSIONED_TRANSFER_INSTRUCTION_DATA.to_vec(),
                     accounts: account_metas,
                 },
                 &acount_infos,

--- a/token/program-2022/src/extension/permissioned_transfer.rs
+++ b/token/program-2022/src/extension/permissioned_transfer.rs
@@ -51,7 +51,7 @@ pub fn permissioned_transfer_check<'info, S: BaseState, BSE: BaseStateWithExtens
     mint_info: &AccountInfo<'info>,
     source_account_info: &AccountInfo<'info>,
     destination_account_info: &AccountInfo<'info>,
-    _amount: u64,
+    amount: u64,
     account_info_iter: &mut Iter<AccountInfo<'info>>,
 ) -> ProgramResult {
     if let Some(permissioned_transfer_mint) =
@@ -77,7 +77,7 @@ pub fn permissioned_transfer_check<'info, S: BaseState, BSE: BaseStateWithExtens
             invoke(
                 &Instruction {
                     program_id,
-                    data: PERMISSIONED_TRANSFER_INSTRUCTION_DATA.to_vec(),
+                    data: [PERMISSIONED_TRANSFER_INSTRUCTION_DATA, amount.to_le_bytes()].concat(),
                     accounts: account_metas,
                 },
                 &acount_infos,

--- a/token/program-2022/src/extension/permissioned_transfer.rs
+++ b/token/program-2022/src/extension/permissioned_transfer.rs
@@ -37,10 +37,7 @@ impl Extension for PermissionedTransferMint {
 /// Transfer authority extension data for mints.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
-pub struct PermissionedTransferAccount {
-    /// Boolean for whether this account is for a mint that requires transfer authority cpi
-    pub permissioned_transfer_enabled: PodBool,
-}
+pub struct PermissionedTransferAccount {}
 impl Extension for PermissionedTransferAccount {
     const TYPE: ExtensionType = ExtensionType::PermissionedTransferAccount;
 }

--- a/token/program-2022/src/extension/transfer_authority.rs
+++ b/token/program-2022/src/extension/transfer_authority.rs
@@ -46,14 +46,27 @@ impl Extension for TransferAuthorityAccount {
 }
 
 /// Call CPI to transfer authority to check if transfer is valid
-pub fn transfer_authority_check<S: BaseState, BSE: BaseStateWithExtensions<S>>(
-    state: &BSE,
-    account_info_iter: &mut Iter<AccountInfo>,
+pub fn transfer_authority_check<'info, S: BaseState, BSE: BaseStateWithExtensions<S>>(
+    mint_state: &BSE,
+    mint_info: &AccountInfo<'info>,
+    source_account_info: &AccountInfo<'info>,
+    destination_account_info: &AccountInfo<'info>,
+    _amount: u64,
+    account_info_iter: &mut Iter<AccountInfo<'info>>,
 ) -> ProgramResult {
-    if let Some(transfer_authority_mint) = state.get_extension::<TransferAuthorityMint>().ok() {
+    if let Some(transfer_authority_mint) = mint_state.get_extension::<TransferAuthorityMint>().ok()
+    {
         if let Some(program_id) = Option::<Pubkey>::from(transfer_authority_mint.program_id) {
             let mut account_metas = Vec::new();
+            account_metas.push(AccountMeta::new(*mint_info.key, false));
+            account_metas.push(AccountMeta::new(*source_account_info.key, false));
+            account_metas.push(AccountMeta::new(*destination_account_info.key, false));
+
             let mut acount_infos = Vec::new();
+            acount_infos.push(mint_info.clone());
+            acount_infos.push(source_account_info.clone());
+            acount_infos.push(destination_account_info.clone());
+
             for additional_account in transfer_authority_mint.additional_accounts.iter() {
                 if let Some(pubkey) = Option::<Pubkey>::from(*additional_account) {
                     account_metas.push(AccountMeta::new(pubkey, false));

--- a/token/program-2022/src/extension/transfer_authority.rs
+++ b/token/program-2022/src/extension/transfer_authority.rs
@@ -1,0 +1,74 @@
+use std::slice::Iter;
+
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    entrypoint::ProgramResult,
+    instruction::{AccountMeta, Instruction},
+    program::invoke,
+    pubkey::Pubkey,
+};
+
+use super::{BaseState, BaseStateWithExtensions};
+
+use {
+    crate::{
+        extension::{Extension, ExtensionType},
+        pod::*,
+    },
+    bytemuck::{Pod, Zeroable},
+};
+
+/// Maximum number of additional accounts for a transfer authority
+pub const MAX_ADDITIONAL_ACCOUNTS: usize = 3;
+
+/// Transfer authority extension data for mints.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+pub struct TransferAuthorityMint {
+    /// Program ID to CPI to on transfer
+    pub program_id: OptionalNonZeroPubkey,
+    /// Additional accounts required for transfer
+    pub additional_accounts: [OptionalNonZeroPubkey; MAX_ADDITIONAL_ACCOUNTS],
+}
+impl Extension for TransferAuthorityMint {
+    const TYPE: ExtensionType = ExtensionType::TransferAuthorityMint;
+}
+
+/// Transfer authority extension data for mints.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+pub struct TransferAuthorityAccount {
+    /// Boolean for whether this account is for a mint that requires transfer authority cpi
+    pub require_transfer_authority: PodBool,
+}
+impl Extension for TransferAuthorityAccount {
+    const TYPE: ExtensionType = ExtensionType::TransferAuthorityAccount;
+}
+
+/// Call CPI to transfer authority to check if transfer is valid
+pub fn transfer_authority_check<S: BaseState, BSE: BaseStateWithExtensions<S>>(
+    state: &BSE,
+    account_info_iter: &mut Iter<AccountInfo>,
+) -> ProgramResult {
+    if let Some(transfer_authority_mint) = state.get_extension::<TransferAuthorityMint>().ok() {
+        if let Some(program_id) = Option::<Pubkey>::from(transfer_authority_mint.program_id) {
+            let mut account_metas = Vec::new();
+            let mut acount_infos = Vec::new();
+            for additional_account in transfer_authority_mint.additional_accounts.iter() {
+                if let Some(pubkey) = Option::<Pubkey>::from(*additional_account) {
+                    account_metas.push(AccountMeta::new(pubkey, false));
+                    acount_infos.push(next_account_info(account_info_iter)?.clone());
+                }
+            }
+            invoke(
+                &Instruction {
+                    program_id,
+                    data: [].to_vec(),
+                    accounts: account_metas,
+                },
+                &acount_infos,
+            )?;
+        }
+    }
+    Ok(())
+}

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -630,7 +630,7 @@ pub enum TokenInstruction<'a> {
         /// Authority that may sign for `Transfer`s and `Burn`s on any account
         delegate: Pubkey,
     },
-    /// Initialize the transfer authority on a new mint.
+    /// Initialize the permissioned transfer on a new mint.
     ///
     /// Fails if the mint has already been initialized, so must be called before
     /// `InitializeMint`.
@@ -645,7 +645,7 @@ pub enum TokenInstruction<'a> {
     ///
     /// Data expected by this instruction:
     ///   Pubkey for the permanent delegate
-    InitializeTransferAuthority {
+    InitializePermissionedTransfer {
         /// Program ID to CPI to on transfer
         program_id: Pubkey,
         /// Additional accounts required for transfer
@@ -792,7 +792,7 @@ impl<'a> TokenInstruction<'a> {
                 for chunk in rest.chunks(size_of::<Pubkey>()) {
                     additional_accounts.push(Pubkey::new(chunk));
                 }
-                Self::InitializeTransferAuthority {
+                Self::InitializePermissionedTransfer {
                     program_id,
                     additional_accounts,
                 }
@@ -956,7 +956,7 @@ impl<'a> TokenInstruction<'a> {
                 buf.push(35);
                 buf.extend_from_slice(delegate.as_ref());
             }
-            &Self::InitializeTransferAuthority {
+            &Self::InitializePermissionedTransfer {
                 ref program_id,
                 ref additional_accounts,
             } => {

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -961,6 +961,10 @@ impl<'a> TokenInstruction<'a> {
                 ref additional_accounts,
             } => {
                 buf.push(36);
+                buf.extend_from_slice(program_id.as_ref());
+                for account in additional_accounts {
+                    buf.extend_from_slice(account.as_ref());
+                }
             }
         };
         buf

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -1289,7 +1289,7 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes an [InitializeTransferAuthority](enum.TokenInstruction.html) instruction
+    /// Processes an [InitializePermissionedTransfer](enum.TokenInstruction.html) instruction
     pub fn process_initialize_permissioned_transfer(
         accounts: &[AccountInfo],
         program_id: Pubkey,

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -317,7 +317,14 @@ impl Processor {
             };
 
             // check transfer authority
-            transfer_authority_check(&mint, account_info_iter)?;
+            transfer_authority_check(
+                &mint,
+                mint_info,
+                source_account_info,
+                destination_account_info,
+                amount,
+                account_info_iter,
+            )?;
 
             let maybe_permanent_delegate = get_permanent_delegate(&mint);
             (fee, maybe_permanent_delegate)
@@ -507,9 +514,6 @@ impl Processor {
             if expected_decimals != mint.base.decimals {
                 return Err(TokenError::MintDecimalsMismatch.into());
             }
-
-            // check transfer authority
-            transfer_authority_check(&mint, account_info_iter)?;
         }
 
         Self::validate_owner(


### PR DESCRIPTION
POC
this is purely for the sake of discussion right now and just put some code there to show what I mean before continuing

**Problem**
Given lots of arguments over interfaces on solana not existing, there are many mutually exclusive solutions for restricting transfer of tokens (examples below)

https://github.com/solana-labs/solana-program-library/tree/master/managed-token
https://github.com/magiceden-oss/open_creator_protocol
https://github.com/magiceden-oss/community-managed-token
https://github.com/cardinal-labs/cardinal-creator-standard

They all require a new account being passed into to every program and wallet or dapp to call a new program for transfer. The problem is the interface gets pushed to the client and its a big problem to have to update clients to get access to a new implementation for example. 

**Suggestion**
One type of “interface” could be instead using a transfer authority in token22 such that it has a defined program and list of accounts it can CPI to on transfer that can either error or not. This way all transfers can still go through token-program first and then cpi to another program to handle checks

This program can define the accounts it wants for the given mint and then configure itself to fail based on data it has in those accounts.

**Discussion**
1. Is this something labs would accept
2. Extension would ideally be re-sizeable with realloc rather than fixed size for the list of additional_accounts but this is not considered at all here for sake of discussion and left with fixed size
3. Naming of TransferAuthority kind of conflicts with the other authorities which are all change-able via the “SetAuthority” Instruction so maybe a different name is better ---> Renamed to PermissionedTransfer
3. This extensions pushes the signers back in the accounts iterator because it requires additional account_infos. Those could come AFTER signers if desired but it seemed okay to go before signers but i didnt think too closely yet
4. The unlucky part about this approach is that transfer right now does not always take in Mint account, it seems `TokenInstruction::Transfer` does not include the mint necessarily and `TokenInstruction::TransferChecked` does
       - `TokenInstruction::Transfer` is deprecated - is this planning to be removed entirely? The reason this extension would also need extension state on the account to indicate the mint is a required account on transfer - Similar to how `TransferFeeAmount` extension works it looks to just break on the non checked transfer
5. Of course since this is just for discussion there is no tests or client code right now
