### PR TITLE
token-manager-registry: ABI for performing managed token transfers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6399,6 +6399,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-token-manager-registry"
+version = "0.1.0"
+dependencies = [
+ "solana-program",
+ "solana-program-test",
+ "solana-sdk",
+ "spl-token-2022 0.5.0",
+]
+
+[[package]]
 name = "spl-token-swap"
 version = "3.0.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6086,6 +6086,7 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token 3.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-manager-registry",
  "thiserror",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
   "stateless-asks/program",
   "token-lending/cli",
   "token-lending/program",
+  "token-manager-registry/program",
   "token-swap/program",
   "token-swap/program/fuzz",
   "token-upgrade/cli",

--- a/managed-token/program/Cargo.toml
+++ b/managed-token/program/Cargo.toml
@@ -26,6 +26,7 @@ solana-program = "1.14.10"
 shank = "^0.0.5"
 spl-token = { version = "3.5.0", features = ["no-entrypoint"] }
 spl-associated-token-account = { version = "1.1.1", features = [ "no-entrypoint", ] }
+spl-token-manager-registry = { path = "../../token-manager-registry/program", version = "0.1", features = [ "no-entrypoint", ] }
 thiserror = "^1.0.24"
 borsh = "0.9.3"
 

--- a/managed-token/program/src/accounts.rs
+++ b/managed-token/program/src/accounts.rs
@@ -9,6 +9,7 @@ pub struct InitializeMint<'a, 'info> {
     pub mint: &'a AccountInfo<'info>,
     pub payer: &'a AccountInfo<'info>,
     pub upstream_authority: &'a AccountInfo<'info>,
+    pub unified_transfer: &'a AccountInfo<'info>,
     pub system_program: &'a AccountInfo<'info>,
     pub token_program: &'a AccountInfo<'info>,
 }
@@ -20,6 +21,7 @@ impl<'a, 'info> InitializeMint<'a, 'info> {
             mint: next_account_info(account_iter)?,
             payer: next_account_info(account_iter)?,
             upstream_authority: next_account_info(account_iter)?,
+            unified_transfer: next_account_info(account_iter)?,
             system_program: next_account_info(account_iter)?,
             token_program: next_account_info(account_iter)?,
         };
@@ -142,7 +144,7 @@ impl<'a, 'info> InitializeAccount<'a, 'info> {
     }
 }
 
-pub struct Mint<'a, 'info> {
+pub struct MintTo<'a, 'info> {
     pub mint: &'a AccountInfo<'info>,
     pub token_account: &'a AccountInfo<'info>,
     pub upstream_authority: &'a AccountInfo<'info>,
@@ -150,7 +152,7 @@ pub struct Mint<'a, 'info> {
     pub token_program: &'a AccountInfo<'info>,
 }
 
-impl<'a, 'info> Mint<'a, 'info> {
+impl<'a, 'info> MintTo<'a, 'info> {
     pub fn load(accounts: &'a [AccountInfo<'info>]) -> Result<Self, ProgramError> {
         let account_iter = &mut accounts.iter();
         let ctx = Self {
@@ -491,6 +493,50 @@ impl<'a, 'info> Revoke<'a, 'info> {
             ProgramError::MissingRequiredSignature,
             "Owner must sign for modification",
         )?;
+        Ok(ctx)
+    }
+}
+
+pub struct GetTransferAccounts<'a, 'info> {
+    pub mint: &'a AccountInfo<'info>,
+    pub unified_transfer: &'a AccountInfo<'info>,
+}
+
+impl<'a, 'info> GetTransferAccounts<'a, 'info> {
+    pub fn load(accounts: &'a [AccountInfo<'info>]) -> Result<Self, ProgramError> {
+        let account_iter = &mut accounts.iter();
+        let ctx = Self {
+            mint: next_account_info(account_iter)?,
+            unified_transfer: next_account_info(account_iter)?,
+        };
+        // Do checks
+        Ok(ctx)
+    }
+}
+
+pub struct UnifiedTransfer<'a, 'info> {
+    pub source: &'a AccountInfo<'info>,
+    pub mint: &'a AccountInfo<'info>,
+    pub destination: &'a AccountInfo<'info>,
+    pub owner: &'a AccountInfo<'info>,
+    pub upstream_authority: &'a AccountInfo<'info>,
+    pub freeze_authority: &'a AccountInfo<'info>,
+    pub token_program: &'a AccountInfo<'info>,
+}
+
+impl<'a, 'info> UnifiedTransfer<'a, 'info> {
+    pub fn load(accounts: &'a [AccountInfo<'info>]) -> Result<Self, ProgramError> {
+        let account_iter = &mut accounts.iter();
+        let ctx = Self {
+            source: next_account_info(account_iter)?,
+            mint: next_account_info(account_iter)?,
+            destination: next_account_info(account_iter)?,
+            owner: next_account_info(account_iter)?,
+            upstream_authority: next_account_info(account_iter)?,
+            freeze_authority: next_account_info(account_iter)?,
+            token_program: next_account_info(account_iter)?,
+        };
+        // Do checks
         Ok(ctx)
     }
 }

--- a/managed-token/program/src/instruction.rs
+++ b/managed-token/program/src/instruction.rs
@@ -17,8 +17,9 @@ pub enum ManagedTokenInstruction {
     #[account(0, writable, signer, name = "mint")]
     #[account(1, writable, signer, name = "payer")]
     #[account(2, name = "upstream_authority")]
-    #[account(3, name = "system_program", desc = "System program")]
-    #[account(4, name = "token_program", desc = "Token program")]
+    #[account(3, writable, name = "unified_transfer")]
+    #[account(4, name = "system_program", desc = "System program")]
+    #[account(5, name = "token_program", desc = "Token program")]
     InitializeMint {
         decimals: u8,
     },
@@ -87,12 +88,26 @@ pub enum ManagedTokenInstruction {
     #[account(4, name = "freeze_authority")]
     #[account(5, name = "token_program", desc = "Token program")]
     Revoke,
+
+    #[account(0, name = "mint")]
+    #[account(1, name = "unified_transfer")]
+    GetTransferAccounts,
+
+    #[account(0, writable, name = "src_account")]
+    #[account(1, name = "mint")]
+    #[account(2, writable, name = "dst_account")]
+    #[account(3, signer, name = "owner")]
+    #[account(4, signer, name = "upstream_authority")]
+    #[account(5, name = "freeze_authority")]
+    #[account(6, name = "token_program", desc = "Token program")]
+    UnifiedTransfer { amount: u64 },
 }
 
 pub fn create_initialize_mint_instruction(
     mint: &Pubkey,
     payer: &Pubkey,
     upstream_authority: &Pubkey,
+    unified_transfer: &Pubkey,
     decimals: u8,
 ) -> Result<Instruction, ProgramError> {
     Ok(Instruction {
@@ -101,6 +116,7 @@ pub fn create_initialize_mint_instruction(
             AccountMeta::new(*mint, true),
             AccountMeta::new(*payer, true),
             AccountMeta::new_readonly(*upstream_authority, false),
+            AccountMeta::new(*unified_transfer, false),
             AccountMeta::new_readonly(system_program::id(), false),
             AccountMeta::new_readonly(spl_token::id(), false),
         ],

--- a/managed-token/program/src/token.rs
+++ b/managed-token/program/src/token.rs
@@ -99,15 +99,15 @@ pub(crate) fn transfer<'a, 'b>(
     )
 }
 
+// TODO JON HACK FOR THE TEST
 pub(crate) fn mint_to<'a, 'b>(
     mint: &'a AccountInfo<'b>,
     account: &'a AccountInfo<'b>,
     owner: &'a AccountInfo<'b>,
     token_program: &'a AccountInfo<'b>,
     amount: u64,
-    seeds: &[Vec<u8>],
 ) -> ProgramResult {
-    invoke_signed(
+    invoke(
         &spl_token::instruction::mint_to(
             token_program.key,
             mint.key,
@@ -122,7 +122,6 @@ pub(crate) fn mint_to<'a, 'b>(
             account.clone(),
             owner.clone(),
         ],
-        &[&seeds.iter().map(|s| s.as_slice()).collect::<Vec<&[u8]>>()],
     )
 }
 

--- a/managed-token/program/tests/test.rs
+++ b/managed-token/program/tests/test.rs
@@ -6,7 +6,7 @@ use solana_sdk::{
     native_token::LAMPORTS_PER_SOL,
     pubkey::Pubkey,
     signature::Signature,
-    signature::{Keypair, Signer},
+    signature::{signers::Signers, Keypair, Signer},
     system_instruction,
     transaction::Transaction,
 };
@@ -14,20 +14,28 @@ use solana_sdk::{
 use spl_associated_token_account::{
     get_associated_token_address, instruction::create_associated_token_account,
 };
-use spl_managed_token::instruction::*;
+use spl_managed_token::{get_unified_transfer_address, instruction::*};
 use spl_token::state::Account as TokenAccount;
+use spl_token_manager_registry::{
+    bytes_to_account_meta, create_get_transfer_accounts_instruction, create_register_instruction,
+    create_unified_transfer_instruction, find_manager_registration_address, ACCOUNT_META_BYTES,
+};
 
 pub fn sol(amount: f64) -> u64 {
     (amount * LAMPORTS_PER_SOL as f64) as u64
 }
 
-async fn process_transaction(
+async fn process_transaction<S: Signers>(
     client: &mut BanksClient,
-    instructions: Vec<Instruction>,
-    signers: Vec<&Keypair>,
+    instructions: &[Instruction],
+    signers: &S,
 ) -> anyhow::Result<Signature> {
-    let mut tx = Transaction::new_with_payer(&instructions, Some(&signers[0].pubkey()));
-    tx.partial_sign(&signers, client.get_latest_blockhash().await?);
+    let tx = Transaction::new_signed_with_payer(
+        instructions,
+        Some(&signers.pubkeys()[0]),
+        signers,
+        client.get_latest_blockhash().await?,
+    );
     let sig = tx.signatures[0];
     client
         .process_transaction_with_commitment(tx, CommitmentLevel::Confirmed)
@@ -41,12 +49,8 @@ async fn transfer(
     receiver: &Pubkey,
     amount: u64,
 ) -> anyhow::Result<Signature> {
-    let ixs = vec![system_instruction::transfer(
-        &payer.pubkey(),
-        receiver,
-        amount,
-    )];
-    process_transaction(context, ixs, vec![payer]).await
+    let ix = system_instruction::transfer(&payer.pubkey(), receiver, amount);
+    process_transaction(context, &[ix], &[payer]).await
 }
 
 fn spl_managed_token_test() -> ProgramTest {
@@ -67,10 +71,16 @@ async fn test_spl_managed_token_basic() {
         .unwrap();
     let mint = Keypair::new();
     let mint_key = mint.pubkey();
-    let create_ix =
-        create_initialize_mint_instruction(&mint_key, &authority.pubkey(), &authority.pubkey(), 0)
-            .unwrap();
-    process_transaction(lwc, vec![create_ix], vec![&authority, &mint])
+    let unified_transfer = get_unified_transfer_address(&spl_managed_token::id(), &mint_key);
+    let create_ix = create_initialize_mint_instruction(
+        &mint_key,
+        &authority.pubkey(),
+        &authority.pubkey(),
+        &unified_transfer,
+        0,
+    )
+    .unwrap();
+    process_transaction(lwc, &[create_ix], &[&authority, &mint])
         .await
         .unwrap();
 
@@ -92,14 +102,14 @@ async fn test_spl_managed_token_basic() {
         .unwrap();
         let mint_to_ix =
             create_mint_to_instruction(&mint_key, k, &authority.pubkey(), 1000).unwrap();
-        process_transaction(lwc, vec![create_ata, mint_to_ix], vec![&authority])
+        process_transaction(lwc, &[create_ata, mint_to_ix], &[&authority])
             .await
             .unwrap();
     }
 
     let create_eve =
         create_associated_token_account(&authority.pubkey(), &eve_key, &mint_key, &spl_token::id());
-    process_transaction(lwc, vec![create_eve], vec![&authority])
+    process_transaction(lwc, &[create_eve], &[&authority])
         .await
         .unwrap();
 
@@ -114,21 +124,17 @@ async fn test_spl_managed_token_basic() {
     )
     .unwrap();
 
-    assert!(
-        process_transaction(lwc, vec![failed_transfer_ix], vec![&alice])
-            .await
-            .is_err()
-    );
+    assert!(process_transaction(lwc, &[failed_transfer_ix], &[&alice])
+        .await
+        .is_err());
 
     let eve_ix =
         create_transfer_instruction(&alice_key, &eve_key, &mint_key, &authority.pubkey(), 100)
             .unwrap();
 
-    assert!(
-        process_transaction(lwc, vec![eve_ix], vec![&alice, &authority])
-            .await
-            .is_err()
-    );
+    assert!(process_transaction(lwc, &[eve_ix], &[&alice, &authority])
+        .await
+        .is_err());
 
     let successful_transfer_ix =
         create_transfer_instruction(&alice_key, &bob_key, &mint_key, &authority.pubkey(), 100)
@@ -137,8 +143,8 @@ async fn test_spl_managed_token_basic() {
 
     process_transaction(
         lwc,
-        vec![successful_transfer_ix, burn_ix],
-        vec![&alice, &authority],
+        &[successful_transfer_ix, burn_ix],
+        &[&alice, &authority],
     )
     .await
     .unwrap();
@@ -154,10 +160,16 @@ async fn test_spl_managed_token_with_approve_and_revoke() {
         .unwrap();
     let mint = Keypair::new();
     let mint_key = mint.pubkey();
-    let create_ix =
-        create_initialize_mint_instruction(&mint_key, &authority.pubkey(), &authority.pubkey(), 0)
-            .unwrap();
-    process_transaction(lwc, vec![create_ix], vec![&authority, &mint])
+    let unified_transfer = get_unified_transfer_address(&spl_managed_token::id(), &mint_key);
+    let create_ix = create_initialize_mint_instruction(
+        &mint_key,
+        &authority.pubkey(),
+        &authority.pubkey(),
+        &unified_transfer,
+        0,
+    )
+    .unwrap();
+    process_transaction(lwc, &[create_ix], &[&authority, &mint])
         .await
         .unwrap();
 
@@ -187,8 +199,8 @@ async fn test_spl_managed_token_with_approve_and_revoke() {
             .unwrap();
     process_transaction(
         lwc,
-        vec![create_alice_ata_ix, mint_to_ix, delegate_ix],
-        vec![&alice, &authority],
+        &[create_alice_ata_ix, mint_to_ix, delegate_ix],
+        &[&alice, &authority],
     )
     .await
     .unwrap();
@@ -203,7 +215,7 @@ async fn test_spl_managed_token_with_approve_and_revoke() {
         .eq(&COption::Some(bob_key)));
 
     let revoke_ix = create_revoke_instruction(&mint_key, &alice_key, &authority.pubkey()).unwrap();
-    process_transaction(lwc, vec![revoke_ix], vec![&alice, &authority])
+    process_transaction(lwc, &[revoke_ix], &[&alice, &authority])
         .await
         .unwrap();
 
@@ -227,10 +239,16 @@ async fn test_spl_managed_token_with_delegate_transfer() {
         .unwrap();
     let mint = Keypair::new();
     let mint_key = mint.pubkey();
-    let create_ix =
-        create_initialize_mint_instruction(&mint_key, &authority.pubkey(), &authority.pubkey(), 0)
-            .unwrap();
-    process_transaction(lwc, vec![create_ix], vec![&authority, &mint])
+    let unified_transfer = get_unified_transfer_address(&spl_managed_token::id(), &mint_key);
+    let create_ix = create_initialize_mint_instruction(
+        &mint_key,
+        &authority.pubkey(),
+        &authority.pubkey(),
+        &unified_transfer,
+        0,
+    )
+    .unwrap();
+    process_transaction(lwc, &[create_ix], &[&authority, &mint])
         .await
         .unwrap();
 
@@ -262,8 +280,8 @@ async fn test_spl_managed_token_with_delegate_transfer() {
             .unwrap();
     process_transaction(
         lwc,
-        vec![create_alice_ata_ix, mint_to_ix, delegate_ix],
-        vec![&alice, &authority],
+        &[create_alice_ata_ix, mint_to_ix, delegate_ix],
+        &[&alice, &authority],
     )
     .await
     .unwrap();
@@ -295,8 +313,8 @@ async fn test_spl_managed_token_with_delegate_transfer() {
     .unwrap();
     process_transaction(
         lwc,
-        vec![create_eve_ata_ix, successful_transfer_ix],
-        vec![&bob, &authority],
+        &[create_eve_ata_ix, successful_transfer_ix],
+        &[&bob, &authority],
     )
     .await
     .unwrap();
@@ -310,4 +328,145 @@ async fn test_spl_managed_token_with_delegate_transfer() {
         .amount
             == 1
     );
+}
+
+#[tokio::test]
+async fn success_with_unified_transfer() {
+    let mut program_test = spl_managed_token_test();
+    program_test.prefer_bpf(false); // simplicity in the build
+    program_test.add_program(
+        "spl_token_manager_registry",
+        spl_token_manager_registry::id(),
+        processor!(spl_token_manager_registry::processor::process_instruction),
+    );
+    let mut context = program_test.start_with_context().await;
+
+    let authority = Keypair::new();
+    transfer(
+        &mut context.banks_client,
+        &context.payer,
+        &authority.pubkey(),
+        sol(10.0),
+    )
+    .await
+    .unwrap();
+    let mint = Keypair::new();
+    let mint_pubkey = mint.pubkey();
+    let unified_transfer = get_unified_transfer_address(&spl_managed_token::id(), &mint_pubkey);
+    let create_ix = create_initialize_mint_instruction(
+        &mint_pubkey,
+        &authority.pubkey(),
+        &authority.pubkey(),
+        &unified_transfer,
+        0,
+    )
+    .unwrap();
+    process_transaction(
+        &mut context.banks_client,
+        &[create_ix],
+        &[&authority, &mint],
+    )
+    .await
+    .unwrap();
+
+    // setup accounts
+    let alice = Keypair::new();
+    let alice_key = alice.pubkey();
+    let bob = Keypair::new();
+    let bob_key = bob.pubkey();
+
+    for k in [&alice_key, &bob_key] {
+        transfer(&mut context.banks_client, &context.payer, k, sol(1.0))
+            .await
+            .unwrap();
+        let create_ata = create_initialize_account_instruction(
+            &mint_pubkey,
+            k,
+            &authority.pubkey(),
+            &authority.pubkey(),
+        )
+        .unwrap();
+        let mint_to_ix =
+            create_mint_to_instruction(&mint_pubkey, k, &authority.pubkey(), 1000).unwrap();
+        process_transaction(
+            &mut context.banks_client,
+            &[create_ata, mint_to_ix],
+            &[&authority],
+        )
+        .await
+        .unwrap();
+    }
+
+    println!("Do a unified transfer!");
+    println!("Zeroth, setup the manager program registration");
+    let manager_registration_pubkey =
+        find_manager_registration_address(&spl_token_manager_registry::id(), &mint_pubkey);
+    let ix = create_register_instruction(
+        &spl_token_manager_registry::id(),
+        &authority.pubkey(),
+        &mint_pubkey,
+        &authority.pubkey(),
+        &manager_registration_pubkey,
+        &spl_managed_token::id(),
+    );
+    process_transaction(&mut context.banks_client, &[ix], &[&authority])
+        .await
+        .unwrap();
+
+    println!(
+        "First, figure out the manager program. Note: this is pedantic since we know already."
+    );
+    let registration = context
+        .banks_client
+        .get_account(manager_registration_pubkey)
+        .await
+        .unwrap()
+        .unwrap();
+    let manager_program_id = Pubkey::new(&registration.data);
+
+    println!("Second, get the required accounts");
+    let ix = create_get_transfer_accounts_instruction(
+        &manager_program_id,
+        &mint_pubkey,
+        &unified_transfer,
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&authority.pubkey()),
+        &[&authority],
+        context.last_blockhash,
+    );
+    let simulation_result = context
+        .banks_client
+        .simulate_transaction_with_commitment(tx, CommitmentLevel::Confirmed)
+        .await
+        .unwrap();
+    let data = simulation_result
+        .simulation_details
+        .unwrap()
+        .return_data
+        .unwrap()
+        .data;
+    let num_accounts = data[0] as usize;
+    let metas = data[1..]
+        .chunks(ACCOUNT_META_BYTES)
+        .map(bytes_to_account_meta)
+        .collect::<Vec<_>>();
+    assert_eq!(metas.len(), num_accounts);
+
+    println!("Finally, execute the transfer");
+    let source = get_associated_token_address(&alice_key, &mint_pubkey);
+    let destination = get_associated_token_address(&bob_key, &mint_pubkey);
+    let ix = create_unified_transfer_instruction(
+        &manager_program_id,
+        &source,
+        &mint_pubkey,
+        &destination,
+        &alice_key,
+        100,
+        &metas,
+    );
+    process_transaction(&mut context.banks_client, &[ix], &[&alice, &authority])
+        .await
+        .unwrap();
 }

--- a/token-manager-registry/program/Cargo.toml
+++ b/token-manager-registry/program/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "spl-token-manager-registry"
+version = "0.1.0"
+description = "Solana Program Library Token Manager Registry"
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+repository = "https://github.com/solana-labs/solana-program-library"
+license = "Apache-2.0"
+edition = "2018"
+
+[features]
+no-entrypoint = []
+test-sbf = []
+
+[dependencies]
+solana-program = "1.4.10"
+spl-token-2022 = { version = "0.5", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
+
+[dev-dependencies]
+solana-program-test = "1.4.10"
+solana-sdk = "1.4.10"
+
+[lib]
+crate-type = ["cdylib", "lib"]

--- a/token-manager-registry/program/src/entrypoint.rs
+++ b/token-manager-registry/program/src/entrypoint.rs
@@ -1,0 +1,16 @@
+//! Program entrypoint
+
+#![cfg(not(feature = "no-entrypoint"))]
+
+use solana_program::{
+    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
+};
+
+entrypoint!(process_instruction);
+fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    crate::processor::process_instruction(program_id, accounts, instruction_data)
+}

--- a/token-manager-registry/program/src/lib.rs
+++ b/token-manager-registry/program/src/lib.rs
@@ -1,0 +1,26 @@
+//! A program demonstrating how to register a token manager program
+#![deny(missing_docs)]
+#![forbid(unsafe_code)]
+
+mod entrypoint;
+pub mod processor;
+
+pub use solana_program;
+use solana_program::{declare_id, pubkey::Pubkey};
+
+/// Generates the registration address for a mint
+///
+/// The registration address defines the program id to be used for the transfer
+/// resolution
+pub fn find_manager_registration_address(program_id: &Pubkey, mint_address: &Pubkey) -> Pubkey {
+    find_manager_registration_address_internal(program_id, mint_address).0
+}
+
+pub(crate) fn find_manager_registration_address_internal(
+    program_id: &Pubkey,
+    mint_address: &Pubkey,
+) -> (Pubkey, u8) {
+    Pubkey::find_program_address(&[mint_address.as_ref()], program_id)
+}
+
+declare_id!("TMreguGXkTM37TkytTJ4mQMgEBaYSBajFsuFFHL25DJ");

--- a/token-manager-registry/program/src/lib.rs
+++ b/token-manager-registry/program/src/lib.rs
@@ -6,7 +6,12 @@ mod entrypoint;
 pub mod processor;
 
 pub use solana_program;
-use solana_program::{declare_id, pubkey::Pubkey};
+use solana_program::{
+    declare_id,
+    instruction::{AccountMeta, Instruction},
+    pubkey::{Pubkey, PUBKEY_BYTES},
+    system_program,
+};
 
 /// Generates the registration address for a mint
 ///
@@ -21,6 +26,92 @@ pub(crate) fn find_manager_registration_address_internal(
     mint_address: &Pubkey,
 ) -> (Pubkey, u8) {
     Pubkey::find_program_address(&[mint_address.as_ref()], program_id)
+}
+
+/// Create instruction to register the mint with a manager program id
+pub fn create_register_instruction(
+    program_id: &Pubkey,
+    payer: &Pubkey,
+    mint: &Pubkey,
+    mint_authority: &Pubkey,
+    manager_registration: &Pubkey,
+    manager_program: &Pubkey,
+) -> Instruction {
+    Instruction::new_with_bytes(
+        *program_id,
+        &[],
+        vec![
+            AccountMeta::new(*payer, true),
+            AccountMeta::new_readonly(*mint, false),
+            AccountMeta::new_readonly(*mint_authority, true),
+            AccountMeta::new(*manager_registration, false),
+            AccountMeta::new_readonly(*manager_program, false),
+            AccountMeta::new_readonly(system_program::id(), false),
+        ],
+    )
+}
+
+/// Create instruction to transfer tokens using the given management program
+pub fn create_get_transfer_accounts_instruction(
+    program_id: &Pubkey,
+    mint: &Pubkey,
+    unified_transfer: &Pubkey,
+) -> Instruction {
+    let instruction_bytes = vec![8u8]; // for the example, this is hard-coded from the managed token program
+    Instruction::new_with_bytes(
+        *program_id,
+        &instruction_bytes,
+        vec![
+            AccountMeta::new_readonly(*mint, false),
+            AccountMeta::new_readonly(*unified_transfer, false),
+        ],
+    )
+}
+
+/// Create instruction to transfer tokens using the given management program
+pub fn create_unified_transfer_instruction(
+    program_id: &Pubkey,
+    source: &Pubkey,
+    mint: &Pubkey,
+    destination: &Pubkey,
+    owner: &Pubkey,
+    amount: u64,
+    additional_metas: &[AccountMeta],
+) -> Instruction {
+    let mut instruction_bytes = vec![9u8]; // for the example, this is hard-coded from
+                                           // the managed token program
+    instruction_bytes.extend_from_slice(&amount.to_le_bytes());
+    let mut accounts = vec![
+        AccountMeta::new(*source, false),
+        AccountMeta::new_readonly(*mint, false),
+        AccountMeta::new(*destination, false),
+        AccountMeta::new_readonly(*owner, true),
+    ];
+    accounts.extend_from_slice(additional_metas);
+    Instruction::new_with_bytes(*program_id, &instruction_bytes, accounts)
+}
+
+/// Size of an encoded account meta in the return data
+pub const ACCOUNT_META_BYTES: usize = 34;
+const IS_SIGNER_BYTE: usize = 33;
+
+/// Convert from the return data format to an account meta to be used in an instruction.
+///
+/// The format goes:
+/// * 32 bytes for the pubkey
+/// * 1 byte for is_writable, 0 == readonly
+/// * 1 byte for is_signer, 0 == not signer
+pub fn bytes_to_account_meta(bytes: &[u8]) -> AccountMeta {
+    // return data is capped at 0, so fill it out
+    let mut filled_bytes = vec![0u8; ACCOUNT_META_BYTES];
+    filled_bytes[0..bytes.len()].copy_from_slice(bytes);
+    let is_signer = filled_bytes[IS_SIGNER_BYTE] != 0;
+    let pubkey = Pubkey::new(&filled_bytes[0..PUBKEY_BYTES]);
+    if filled_bytes[PUBKEY_BYTES] == 0 {
+        AccountMeta::new_readonly(pubkey, is_signer)
+    } else {
+        AccountMeta::new(pubkey, is_signer)
+    }
 }
 
 declare_id!("TMreguGXkTM37TkytTJ4mQMgEBaYSBajFsuFFHL25DJ");

--- a/token-manager-registry/program/src/processor.rs
+++ b/token-manager-registry/program/src/processor.rs
@@ -1,0 +1,102 @@
+#![allow(clippy::integer_arithmetic)]
+//! Program instruction processor
+
+use {
+    crate::find_manager_registration_address_internal,
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        program::{invoke, invoke_signed},
+        program_error::ProgramError,
+        pubkey::{Pubkey, PUBKEY_BYTES},
+        rent::Rent,
+        system_instruction, system_program,
+        sysvar::Sysvar,
+    },
+    spl_token_2022::{
+        check_spl_token_program_account, extension::StateWithExtensions, state::Mint,
+    },
+};
+
+/// Instruction processor, writes the pubkey of the managing program to the
+/// registration address, so that anyone can look up the managing program from
+/// the mint address using `crate::find_manager_registration_address()`, and
+/// read the managing program address from there.
+pub fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    _instruction_data: &[u8],
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    let payer_info = next_account_info(account_info_iter)?;
+    let mint_info = next_account_info(account_info_iter)?;
+    let mint_authority_info = next_account_info(account_info_iter)?;
+    let manager_registration_info = next_account_info(account_info_iter)?;
+    let manager_program_info = next_account_info(account_info_iter)?;
+    let system_program_info = next_account_info(account_info_iter)?;
+
+    if system_program_info.key != &system_program::id() {
+        return Err(ProgramError::IncorrectProgramId);
+    }
+
+    // Check mint is actually a mint
+    check_spl_token_program_account(mint_info.owner)?;
+    let mint_data = mint_info.try_borrow_data()?;
+    let mint = StateWithExtensions::<Mint>::unpack(&mint_data)?;
+
+    // Check mint authority is correct and signed
+    if !mint.base.mint_authority.contains(mint_authority_info.key) {
+        return Err(ProgramError::InvalidAccountData);
+    }
+    if !mint_authority_info.is_signer {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    // Check manager registration account address is correct
+    let (expected_registration_address, bump_seed) =
+        find_manager_registration_address_internal(program_id, mint_info.key);
+    if &expected_registration_address != manager_registration_info.key {
+        return Err(ProgramError::InvalidSeeds);
+    }
+    let signer_seeds = [mint_info.key.as_ref(), &[bump_seed]];
+
+    // Create the account with 32 bytes, and write 32 bytes
+    invoke_signed(
+        &system_instruction::allocate(manager_registration_info.key, PUBKEY_BYTES as u64),
+        &[
+            manager_registration_info.clone(),
+            system_program_info.clone(),
+        ],
+        &[&signer_seeds],
+    )?;
+    invoke_signed(
+        &system_instruction::assign(manager_registration_info.key, program_id),
+        &[
+            manager_registration_info.clone(),
+            system_program_info.clone(),
+        ],
+        &[&signer_seeds],
+    )?;
+    let rent = Rent::get()?;
+    let rent_exemption = rent.minimum_balance(PUBKEY_BYTES);
+    let transfer_amount = rent_exemption.saturating_sub(manager_registration_info.try_lamports()?);
+    if transfer_amount > 0 {
+        invoke(
+            &system_instruction::transfer(
+                payer_info.key,
+                manager_registration_info.key,
+                transfer_amount,
+            ),
+            &[
+                payer_info.clone(),
+                manager_registration_info.clone(),
+                system_program_info.clone(),
+            ],
+        )?;
+    }
+    let mut data = manager_registration_info.try_borrow_mut_data()?;
+    data.copy_from_slice(manager_program_info.key.as_ref());
+
+    Ok(())
+}

--- a/token-manager-registry/program/tests/functional.rs
+++ b/token-manager-registry/program/tests/functional.rs
@@ -1,0 +1,75 @@
+#![cfg(feature = "test-sbf")]
+use {
+    solana_program::{
+        instruction::{AccountMeta, Instruction},
+        program_pack::Pack,
+        pubkey::Pubkey,
+    },
+    solana_program_test::{processor, tokio, ProgramTest},
+    solana_sdk::{
+        account::Account, program_option::COption, signature::Signer, signer::keypair::Keypair,
+        system_program, transaction::Transaction,
+    },
+    spl_token_2022::state::Mint,
+    spl_token_manager_registry::{
+        find_manager_registration_address, processor::process_instruction,
+    },
+};
+
+const LAMPORTS: u64 = 2_000_000;
+
+#[tokio::test]
+async fn write_program_id() {
+    let program_id = spl_token_manager_registry::id();
+    let mint_pubkey = Pubkey::new_unique();
+    let mint_authority = Keypair::new();
+    let manager_program_pubkey = Pubkey::new_unique();
+    let manager_registration_pubkey = find_manager_registration_address(&program_id, &mint_pubkey);
+    let mut program_test = ProgramTest::new(
+        "spl_token_manager_registry",
+        program_id,
+        processor!(process_instruction),
+    );
+    let mut data = vec![0u8; Mint::LEN];
+    let mint = Mint {
+        mint_authority: COption::Some(mint_authority.pubkey()),
+        is_initialized: true,
+        ..Mint::default()
+    };
+    Mint::pack(mint, &mut data).unwrap();
+    program_test.add_account(
+        mint_pubkey,
+        Account {
+            lamports: LAMPORTS,
+            owner: spl_token_2022::id(),
+            data,
+            ..Account::default()
+        },
+    );
+    let (mut banks_client, payer, recent_blockhash) = program_test.start().await;
+
+    let mut transaction = Transaction::new_with_payer(
+        &[Instruction::new_with_bytes(
+            program_id,
+            &[],
+            vec![
+                AccountMeta::new(payer.pubkey(), true),
+                AccountMeta::new_readonly(mint_pubkey, false),
+                AccountMeta::new_readonly(mint_authority.pubkey(), true),
+                AccountMeta::new(manager_registration_pubkey, false),
+                AccountMeta::new_readonly(manager_program_pubkey, false),
+                AccountMeta::new_readonly(system_program::id(), false),
+            ],
+        )],
+        Some(&payer.pubkey()),
+    );
+    transaction.sign(&[&payer, &mint_authority], recent_blockhash);
+    banks_client.process_transaction(transaction).await.unwrap();
+
+    let registration_account = banks_client
+        .get_account(manager_registration_pubkey)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(&registration_account.data, manager_program_pubkey.as_ref());
+}


### PR DESCRIPTION
#### Problem

With many different token metadata / royalty standards, it becomes very difficult for marketplaces to figure out how to move tokens. #3888 does a great job at summarizing the issue.

#### Solution

This is a POC of how a unified system could work between all metadata standards.  TLDR

* centralized registry says which program manages the mint
* manager program implements `GetTransferAccounts` and `UnifiedTransfer` with the precise ABI. In this example, `GetTransferAccounts` is instruction data of just `[8]`, and `UnifiedTransfer` is `[9, <amount_as_little_endian_u64>]`
* marketplace uses registry + `GetTransferAccounts` + `UnifiedTransfer` to move any token

There exists a centralized (yay) token manager registry, where the mint authority registers that their mint is managed by a certain program. This simply writes the program id of the managing program. So if someone uses this with spl-managed-token for mint A, the `PDA(mint A, token manager registry)` will have the pubkey for spl-managed-token.

A marketplace wants to transfer an A token.

First they fetch the managing program id by looking at the data stored at `PDA(mint A, token manager registry)`, and they see that it's spl-managed-token.

Next, they simulate a transaction with `GetTransferAccounts` on spl-managed-token, providing the mint and one more account given by `PDA(mint, spl-managed-token)`. The return data on this transaction gives the account metas required *on top* of the source, mint, destination, and owner.

Last, they call `UnifiedTransfer` with the source, mint, destination, owner, amount, and additional account metas.

You can see the whole flow at `success_with_unified_transfer`. It's a little goofy, but I think it conveys the core ideas. All of this is totally open to more changes, your feedback is very appreciated!

cc @jnwng @jpbogle please tag everyone who might be interested