### PR TITLE
stake-pool: allow removing validator below minimum

### DIFF
--- a/stake-pool/program/src/instruction.rs
+++ b/stake-pool/program/src/instruction.rs
@@ -132,8 +132,8 @@ pub enum StakePoolInstruction {
     /// validator stake account, into its "transient" stake account.
     ///
     /// The instruction only succeeds if the transient stake account does not
-    /// exist. The amount of lamports to move must be at least rent-exemption
-    /// plus 1 lamport.
+    /// exist. The amount of lamports to move must be at least rent-exemption plus
+    /// `max(crate::MINIMUM_ACTIVE_STAKE, solana_program::stake::tools::get_minimum_delegation())`.
     ///
     ///  0. `[]` Stake pool
     ///  1. `[s]` Stake pool staker
@@ -230,7 +230,7 @@ pub enum StakePoolInstruction {
     ///  4. `[]` Sysvar clock
     ///  5. `[]` Sysvar stake history
     ///  6. `[]` Stake program
-    ///  7. ..7+N ` [] N pairs of validator and transient stake accounts
+    ///  7. ..7+2N ` [] N pairs of validator and transient stake accounts
     UpdateValidatorListBalance {
         /// Index to start updating on the validator list
         #[allow(dead_code)] // but it's not
@@ -355,7 +355,7 @@ pub enum StakePoolInstruction {
     ///  10. `[s]` (Optional) Stake pool sol deposit authority.
     DepositSol(u64),
 
-    ///  (Manager only) Update SOL deposit authority
+    ///  (Manager only) Update SOL deposit, stake deposit, or SOL withdrawal authority.
     ///
     ///  0. `[w]` StakePool
     ///  1. `[s]` Manager

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -1020,9 +1020,10 @@ impl Processor {
         let stake_lamports = **stake_account_info.lamports.borrow();
         let stake_minimum_delegation = stake::tools::get_minimum_delegation()?;
         let required_lamports = minimum_stake_lamports(&meta, stake_minimum_delegation);
-        if stake_lamports != required_lamports {
+        if stake_lamports > required_lamports {
             msg!(
-                "Attempting to remove validator account with {} lamports, must have {} lamports",
+                "Attempting to remove validator account with {} lamports, must have no more than {} lamports; \
+                reduce using DecreaseValidatorStake first",
                 stake_lamports,
                 required_lamports
             );
@@ -1030,9 +1031,10 @@ impl Processor {
         }
 
         let current_minimum_delegation = minimum_delegation(stake_minimum_delegation);
-        if stake.delegation.stake != current_minimum_delegation {
+        if stake.delegation.stake > current_minimum_delegation {
             msg!(
-                "Error: attempting to remove stake with delegation of {} lamports, must have {} lamports",
+                "Error: attempting to remove stake with delegation of {} lamports, must have no more than {} lamports; \
+                reduce using DecreaseValidatorStake first",
                 stake.delegation.stake,
                 current_minimum_delegation
             );
@@ -1195,7 +1197,7 @@ impl Processor {
             stake_rent.saturating_add(minimum_delegation(stake_minimum_delegation));
         if lamports < current_minimum_lamports {
             msg!(
-                "Need at least {} lamports for transient stake meet minimum delegation and rent-exempt requirements, {} provided",
+                "Need at least {} lamports for transient stake to meet minimum delegation and rent-exempt requirements, {} provided",
                 current_minimum_lamports,
                 lamports
             );


### PR DESCRIPTION
some random things i noted when reviewing the program as a whole. the comment changes are obvious enough. the change from `!=` to `>` is to cope with the possibility that `MINIMUM_DELEGATION_SOL` rises to put a poorly resourced validator below it, which otherwise would require the pool to stake _more_ to it to be able to remove it