### PR TITLE
stake-pool: Cleanup clippy, maybe fix a test

### DIFF
--- a/stake-pool/program/src/big_vec.rs
+++ b/stake-pool/program/src/big_vec.rs
@@ -1,4 +1,5 @@
 //! Big vector type, used with vectors that can't be serde'd
+#![allow(clippy::integer_arithmetic)] // checked math involves too many compute units
 
 use {
     arrayref::array_ref,

--- a/stake-pool/program/src/instruction.rs
+++ b/stake-pool/program/src/instruction.rs
@@ -64,19 +64,14 @@ pub enum StakePoolInstruction {
     ///      `find_deposit_authority_program_address`, making deposits permissionless.
     Initialize {
         /// Fee assessed as percentage of perceived rewards
-        #[allow(dead_code)] // but it's not
         fee: Fee,
         /// Fee charged per withdrawal as percentage of withdrawal
-        #[allow(dead_code)] // but it's not
         withdrawal_fee: Fee,
         /// Fee charged per deposit as percentage of deposit
-        #[allow(dead_code)] // but it's not
         deposit_fee: Fee,
         /// Percentage [0-100] of deposit_fee that goes to referrer
-        #[allow(dead_code)] // but it's not
         referral_fee: u8,
         /// Maximum expected number of validators
-        #[allow(dead_code)] // but it's not
         max_validators: u32,
     },
 
@@ -147,10 +142,8 @@ pub enum StakePoolInstruction {
     ///  9. `[]` Stake program
     DecreaseValidatorStake {
         /// amount of lamports to split into the transient stake account
-        #[allow(dead_code)] // but it's not
         lamports: u64,
         /// seed used to create transient stake account
-        #[allow(dead_code)] // but it's not
         transient_stake_seed: u64,
     },
 
@@ -185,10 +178,8 @@ pub enum StakePoolInstruction {
     ///  after it is merged.
     IncreaseValidatorStake {
         /// amount of lamports to increase on the given validator
-        #[allow(dead_code)] // but it's not
         lamports: u64,
         /// seed used to create transient stake account
-        #[allow(dead_code)] // but it's not
         transient_stake_seed: u64,
     },
 
@@ -206,11 +197,9 @@ pub enum StakePoolInstruction {
     /// Fails if the validator is not part of the stake pool.
     SetPreferredValidator {
         /// Affected operation (deposit or withdraw)
-        #[allow(dead_code)] // but it's not
         validator_type: PreferredValidatorType,
         /// Validator vote account that deposits or withdraws must go through,
         /// unset with None
-        #[allow(dead_code)] // but it's not
         validator_vote_address: Option<Pubkey>,
     },
 
@@ -233,12 +222,10 @@ pub enum StakePoolInstruction {
     ///  7. ..7+N ` [] N pairs of validator and transient stake accounts
     UpdateValidatorListBalance {
         /// Index to start updating on the validator list
-        #[allow(dead_code)] // but it's not
         start_index: u32,
         /// If true, don't try merging transient stake accounts into the reserve or
         /// validator stake account.  Useful for testing or if a particular stake
         /// account is in a bad state, but we still want to update
-        #[allow(dead_code)] // but it's not
         no_merge: bool,
     },
 
@@ -328,7 +315,6 @@ pub enum StakePoolInstruction {
     ///  1. `[s]` Manager
     SetFee {
         /// Type of fee to update and value to update it to
-        #[allow(dead_code)] // but it's not
         fee: FeeType,
     },
 
@@ -392,14 +378,11 @@ pub enum StakePoolInstruction {
     /// 7. `[]` System program id
     /// 8. `[]` Rent sysvar
     CreateTokenMetadata {
-        #[allow(dead_code)]
         /// Token name
         name: String,
-        #[allow(dead_code)]
         /// Token symbol e.g. stkSOL
         symbol: String,
         /// URI of the uploaded metadata of the spl-token
-        #[allow(dead_code)]
         uri: String,
     },
     /// Update token metadata for the stake-pool token in the
@@ -411,14 +394,11 @@ pub enum StakePoolInstruction {
     /// 3. `[w]` Token metadata account
     /// 4. `[]` Metadata program id
     UpdateTokenMetadata {
-        #[allow(dead_code)]
         /// Token name
         name: String,
-        #[allow(dead_code)]
         /// Token symbol e.g. stkSOL
         symbol: String,
         /// URI of the uploaded metadata of the spl-token
-        #[allow(dead_code)]
         uri: String,
     },
 }
@@ -923,7 +903,7 @@ pub fn update_stake_pool(
             start_index,
             no_merge,
         ));
-        start_index += MAX_VALIDATORS_TO_UPDATE as u32;
+        start_index = start_index.saturating_add(MAX_VALIDATORS_TO_UPDATE as u32);
     }
 
     let final_instructions = vec![

--- a/stake-pool/program/src/lib.rs
+++ b/stake-pool/program/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::integer_arithmetic)]
 #![deny(missing_docs)]
 
 //! A program for creating and managing pools of stake

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -1399,7 +1399,7 @@ impl Processor {
         {
             let max_split_amount = reserve_stake_account_info
                 .lamports()
-                .saturating_sub(2 * stake_rent);
+                .saturating_sub(stake_rent.saturating_mul(2));
             msg!(
                 "Reserve stake does not have enough lamports for increase, must be less than {}, {} requested",
                 max_split_amount,

--- a/stake-pool/program/tests/deposit.rs
+++ b/stake-pool/program/tests/deposit.rs
@@ -501,7 +501,6 @@ async fn fail_with_wrong_stake_program_id() {
     let mut transaction =
         Transaction::new_with_payer(&[instruction], Some(&context.payer.pubkey()));
     transaction.sign(&[&context.payer], context.last_blockhash);
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = context
         .banks_client
         .process_transaction(transaction)
@@ -551,7 +550,6 @@ async fn fail_with_wrong_token_program_id() {
         Some(&context.payer.pubkey()),
     );
     transaction.sign(&[&context.payer, &user], context.last_blockhash);
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = context
         .banks_client
         .process_transaction(transaction)

--- a/stake-pool/program/tests/deposit_sol.rs
+++ b/stake-pool/program/tests/deposit_sol.rs
@@ -163,7 +163,6 @@ async fn fail_with_wrong_token_program_id() {
         Some(&context.payer.pubkey()),
     );
     transaction.sign(&[&context.payer], context.last_blockhash);
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = context
         .banks_client
         .process_transaction(transaction)

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -154,7 +154,6 @@ pub async fn create_mint(
         &[payer, pool_mint],
         *recent_blockhash,
     );
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     banks_client
         .process_transaction(transaction)
         .await
@@ -300,7 +299,6 @@ pub async fn create_token_account(
         &signers,
         *recent_blockhash,
     );
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     banks_client
         .process_transaction(transaction)
         .await
@@ -328,7 +326,6 @@ pub async fn close_token_account(
         Some(&payer.pubkey()),
     );
     transaction.sign(&[payer, manager], *recent_blockhash);
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     banks_client
         .process_transaction(transaction)
         .await
@@ -356,7 +353,6 @@ pub async fn freeze_token_account(
         Some(&payer.pubkey()),
     );
     transaction.sign(&[payer, manager], *recent_blockhash);
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     banks_client
         .process_transaction(transaction)
         .await
@@ -388,7 +384,6 @@ pub async fn mint_tokens(
         &[payer, mint_authority],
         *recent_blockhash,
     );
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     banks_client
         .process_transaction(transaction)
         .await
@@ -420,7 +415,6 @@ pub async fn burn_tokens(
         &[payer, authority],
         *recent_blockhash,
     );
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     banks_client
         .process_transaction(transaction)
         .await
@@ -580,7 +574,6 @@ pub async fn create_stake_pool(
         signers.push(stake_deposit_authority);
     }
     transaction.sign(&signers, *recent_blockhash);
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     banks_client
         .process_transaction(transaction)
         .await
@@ -1053,7 +1046,6 @@ impl StakePoolAccounts {
             &signers,
             *recent_blockhash,
         );
-        #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
         banks_client
             .process_transaction(transaction)
             .await
@@ -1111,7 +1103,6 @@ impl StakePoolAccounts {
             &signers,
             *recent_blockhash,
         );
-        #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
         banks_client
             .process_transaction(transaction)
             .await
@@ -1154,7 +1145,6 @@ impl StakePoolAccounts {
             &[payer, user_transfer_authority],
             *recent_blockhash,
         );
-        #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
         banks_client
             .process_transaction(transaction)
             .await
@@ -1213,7 +1203,6 @@ impl StakePoolAccounts {
             &signers,
             *recent_blockhash,
         );
-        #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
         banks_client
             .process_transaction(transaction)
             .await
@@ -1258,7 +1247,6 @@ impl StakePoolAccounts {
             &[payer],
             *recent_blockhash,
         );
-        #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
         banks_client
             .process_transaction(transaction)
             .await
@@ -1289,7 +1277,6 @@ impl StakePoolAccounts {
             &[payer],
             *recent_blockhash,
         );
-        #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
         banks_client
             .process_transaction(transaction)
             .await
@@ -1315,7 +1302,6 @@ impl StakePoolAccounts {
             &[payer],
             *recent_blockhash,
         );
-        #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
         banks_client
             .process_transaction(transaction)
             .await
@@ -1367,7 +1353,6 @@ impl StakePoolAccounts {
             &[payer],
             *recent_blockhash,
         );
-        #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
         banks_client
             .process_transaction(transaction)
             .await
@@ -1402,7 +1387,6 @@ impl StakePoolAccounts {
             &[payer, &self.staker],
             *recent_blockhash,
         );
-        #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
         banks_client
             .process_transaction(transaction)
             .await
@@ -1435,7 +1419,6 @@ impl StakePoolAccounts {
             &[payer, &self.staker],
             *recent_blockhash,
         );
-        #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
         banks_client
             .process_transaction(transaction)
             .await
@@ -1472,7 +1455,6 @@ impl StakePoolAccounts {
             &[payer, &self.staker],
             *recent_blockhash,
         );
-        #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
         banks_client
             .process_transaction(transaction)
             .await
@@ -1512,7 +1494,6 @@ impl StakePoolAccounts {
             &[payer, &self.staker],
             *recent_blockhash,
         );
-        #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
         banks_client
             .process_transaction(transaction)
             .await
@@ -1543,7 +1524,6 @@ impl StakePoolAccounts {
             &[payer, &self.staker],
             *recent_blockhash,
         );
-        #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
         banks_client
             .process_transaction(transaction)
             .await

--- a/stake-pool/program/tests/initialize.rs
+++ b/stake-pool/program/tests/initialize.rs
@@ -329,7 +329,6 @@ async fn fail_with_wrong_max_validators() {
         ],
         recent_blockhash,
     );
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
@@ -785,7 +784,6 @@ async fn fail_with_wrong_token_program_id() {
         ],
         recent_blockhash,
     );
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
@@ -893,7 +891,6 @@ async fn fail_with_fee_owned_by_wrong_token_program_id() {
         ],
         recent_blockhash,
     );
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
@@ -1249,7 +1246,6 @@ async fn fail_without_manager_signature() {
         ],
         recent_blockhash,
     );
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await

--- a/stake-pool/program/tests/set_funding_authority.rs
+++ b/stake-pool/program/tests/set_funding_authority.rs
@@ -112,7 +112,6 @@ async fn fail_wrong_manager() {
         Some(&payer.pubkey()),
     );
     transaction.sign(&[&payer, &new_authority], recent_blockhash);
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
@@ -153,7 +152,6 @@ async fn fail_without_signature() {
 
     let mut transaction = Transaction::new_with_payer(&[instruction], Some(&payer.pubkey()));
     transaction.sign(&[&payer], recent_blockhash);
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await

--- a/stake-pool/program/tests/set_manager.rs
+++ b/stake-pool/program/tests/set_manager.rs
@@ -110,7 +110,6 @@ async fn test_set_manager_by_malicious() {
         Some(&payer.pubkey()),
     );
     transaction.sign(&[&payer, &new_manager], recent_blockhash);
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
@@ -152,7 +151,6 @@ async fn test_set_manager_without_existing_signature() {
 
     let mut transaction = Transaction::new_with_payer(&[instruction], Some(&payer.pubkey()));
     transaction.sign(&[&payer, &new_manager], recent_blockhash);
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
@@ -196,7 +194,6 @@ async fn test_set_manager_without_new_signature() {
 
     let mut transaction = Transaction::new_with_payer(&[instruction], Some(&payer.pubkey()));
     transaction.sign(&[&payer, &stake_pool_accounts.manager], recent_blockhash);
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
@@ -276,7 +273,6 @@ async fn test_set_manager_with_wrong_mint_for_pool_fee_acc() {
         &[&payer, &stake_pool_accounts.manager, &new_manager],
         recent_blockhash,
     );
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await

--- a/stake-pool/program/tests/set_staker.rs
+++ b/stake-pool/program/tests/set_staker.rs
@@ -126,7 +126,6 @@ async fn fail_wrong_manager() {
         Some(&payer.pubkey()),
     );
     transaction.sign(&[&payer, &new_staker], recent_blockhash);
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
@@ -167,7 +166,6 @@ async fn fail_set_staker_without_signature() {
 
     let mut transaction = Transaction::new_with_payer(&[instruction], Some(&payer.pubkey()));
     transaction.sign(&[&payer], recent_blockhash);
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await

--- a/stake-pool/program/tests/vsa_add.rs
+++ b/stake-pool/program/tests/vsa_add.rs
@@ -165,7 +165,6 @@ async fn fail_with_wrong_validator_list_account() {
         Some(&payer.pubkey()),
     );
     transaction.sign(&[&payer, &stake_pool_accounts.staker], recent_blockhash);
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
@@ -249,7 +248,6 @@ async fn fail_wrong_staker() {
         Some(&payer.pubkey()),
     );
     transaction.sign(&[&payer, &malicious], recent_blockhash);
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
@@ -304,7 +302,6 @@ async fn fail_without_signature() {
 
     let mut transaction = Transaction::new_with_payer(&[instruction], Some(&payer.pubkey()));
     transaction.sign(&[&payer], recent_blockhash);
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
@@ -359,7 +356,6 @@ async fn fail_with_wrong_stake_program_id() {
     };
     let mut transaction = Transaction::new_with_payer(&[instruction], Some(&payer.pubkey()));
     transaction.sign(&[&payer, &stake_pool_accounts.staker], recent_blockhash);
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
@@ -413,7 +409,6 @@ async fn fail_with_wrong_system_program_id() {
     };
     let mut transaction = Transaction::new_with_payer(&[instruction], Some(&payer.pubkey()));
     transaction.sign(&[&payer, &stake_pool_accounts.staker], recent_blockhash);
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await
@@ -659,7 +654,6 @@ async fn fail_with_wrong_reserve() {
         Some(&payer.pubkey()),
     );
     transaction.sign(&[&payer, &stake_pool_accounts.staker], recent_blockhash);
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = banks_client
         .process_transaction(transaction)
         .await

--- a/stake-pool/program/tests/vsa_remove.rs
+++ b/stake-pool/program/tests/vsa_remove.rs
@@ -150,7 +150,6 @@ async fn fail_with_wrong_stake_program_id() {
         &[&context.payer, &stake_pool_accounts.staker],
         context.last_blockhash,
     );
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = context
         .banks_client
         .process_transaction(transaction)
@@ -192,7 +191,6 @@ async fn fail_with_wrong_validator_list_account() {
         &[&context.payer, &stake_pool_accounts.staker],
         context.last_blockhash,
     );
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = context
         .banks_client
         .process_transaction(transaction)
@@ -318,7 +316,6 @@ async fn fail_wrong_staker() {
         Some(&context.payer.pubkey()),
     );
     transaction.sign(&[&context.payer, &malicious], context.last_blockhash);
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = context
         .banks_client
         .process_transaction(transaction)
@@ -369,7 +366,6 @@ async fn fail_no_signature() {
         &[&context.payer],
         context.last_blockhash,
     );
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = context
         .banks_client
         .process_transaction(transaction)

--- a/stake-pool/program/tests/withdraw.rs
+++ b/stake-pool/program/tests/withdraw.rs
@@ -302,7 +302,6 @@ async fn fail_with_wrong_stake_program() {
         &[&context.payer, &user_transfer_authority],
         context.last_blockhash,
     );
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = context
         .banks_client
         .process_transaction(transaction)
@@ -396,7 +395,6 @@ async fn fail_with_wrong_token_program_id() {
         &[&context.payer, &user_transfer_authority],
         context.last_blockhash,
     );
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     let transaction_error = context
         .banks_client
         .process_transaction(transaction)

--- a/stake-pool/program/tests/withdraw_edge_cases.rs
+++ b/stake-pool/program/tests/withdraw_edge_cases.rs
@@ -552,7 +552,7 @@ async fn success_and_fail_with_preferred_withdraw() {
             &deposit_info.pool_account.pubkey(),
             &preferred_validator.stake_account,
             &new_authority,
-            tokens_to_burn / 2,
+            tokens_to_burn / 3,
         )
         .await;
     assert!(error.is_none());


### PR DESCRIPTION
#### Problem

There are loads of unnecessary clippy `#[allow(...)]`s in the stake pool code, and some necessary ones.

#### Solution

* Remove all of the `#[allow(dead_code)] // but it's not` from the instructions, since those are now properly considered by the compiler.
* Remove all of the `#[allow(useless_conversion)]` from the upgrade to 1.10
* Get rid of some integer math. Note that it's still required in big_vec.rs, otherwise we blow out the compute budget.