### PR TITLE
clippy: Remove `useless_conversion`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5924,7 +5924,6 @@ name = "spl-feature-proposal"
 version = "1.0.0"
 dependencies = [
  "borsh",
- "borsh-derive",
  "solana-program",
  "solana-program-test",
  "solana-sdk",

--- a/feature-proposal/program/Cargo.toml
+++ b/feature-proposal/program/Cargo.toml
@@ -13,7 +13,6 @@ test-sbf = []
 
 [dependencies]
 borsh = "0.9"
-borsh-derive = "0.9.0"
 solana-program = "1.14.10"
 spl-token = { version = "3.5", path = "../../token/program", features = ["no-entrypoint"] }
 

--- a/governance/test-sdk/src/lib.rs
+++ b/governance/test-sdk/src/lib.rs
@@ -75,7 +75,6 @@ impl ProgramTestBench {
 
         transaction.sign(&all_signers, recent_blockhash);
 
-        #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
         self.context
             .banks_client
             .process_transaction(transaction)

--- a/name-service/program/tests/functional.rs
+++ b/name-service/program/tests/functional.rs
@@ -199,7 +199,6 @@ pub async fn sign_send_instruction(
         payer_signers.push(s);
     }
     transaction.partial_sign(&payer_signers, ctx.last_blockhash);
-    #[allow(clippy::useless_conversion)] // Remove during upgrade to 1.10
     ctx.banks_client
         .process_transaction(transaction)
         .await

--- a/token/program-2022-test/tests/initialize_account.rs
+++ b/token/program-2022-test/tests/initialize_account.rs
@@ -143,14 +143,12 @@ async fn fail_on_invalid_mint() {
         &[&ctx.payer, &account],
         ctx.last_blockhash,
     );
-    #[allow(clippy::useless_conversion)]
-    let err: TransactionError = ctx
+    let err = ctx
         .banks_client
         .process_transaction(tx)
         .await
         .unwrap_err()
-        .unwrap()
-        .into();
+        .unwrap();
     assert_eq!(
         err,
         TransactionError::InstructionError(

--- a/token/program-2022-test/tests/initialize_mint.rs
+++ b/token/program-2022-test/tests/initialize_mint.rs
@@ -88,14 +88,12 @@ async fn fail_extension_no_space() {
         &[&ctx.payer, &mint_account],
         ctx.last_blockhash,
     );
-    #[allow(clippy::useless_conversion)]
-    let err: TransactionError = ctx
+    let err = ctx
         .banks_client
         .process_transaction(tx)
         .await
         .unwrap_err()
-        .unwrap()
-        .into();
+        .unwrap();
     assert_eq!(
         err,
         TransactionError::InstructionError(1, InstructionError::InvalidAccountData)
@@ -141,14 +139,12 @@ async fn fail_extension_after_mint_init() {
         &[&ctx.payer, &mint_account],
         ctx.last_blockhash,
     );
-    #[allow(clippy::useless_conversion)]
-    let err: TransactionError = ctx
+    let err = ctx
         .banks_client
         .process_transaction(tx)
         .await
         .unwrap_err()
-        .unwrap()
-        .into();
+        .unwrap();
     assert_eq!(
         err,
         TransactionError::InstructionError(1, InstructionError::InvalidAccountData)
@@ -221,14 +217,12 @@ async fn fail_init_overallocated_mint() {
         &[&ctx.payer, &mint_account],
         ctx.last_blockhash,
     );
-    #[allow(clippy::useless_conversion)]
-    let err: TransactionError = ctx
+    let err = ctx
         .banks_client
         .process_transaction(tx)
         .await
         .unwrap_err()
-        .unwrap()
-        .into();
+        .unwrap();
     assert_eq!(
         err,
         TransactionError::InstructionError(1, InstructionError::InvalidAccountData)
@@ -291,14 +285,12 @@ async fn fail_account_init_after_mint_extension() {
         &[&ctx.payer, &mint_account, &token_account],
         ctx.last_blockhash,
     );
-    #[allow(clippy::useless_conversion)]
-    let err: TransactionError = ctx
+    let err = ctx
         .banks_client
         .process_transaction(tx)
         .await
         .unwrap_err()
-        .unwrap()
-        .into();
+        .unwrap();
     assert_eq!(
         err,
         TransactionError::InstructionError(
@@ -348,14 +340,12 @@ async fn fail_account_init_after_mint_init() {
         &[&ctx.payer, &mint_account],
         ctx.last_blockhash,
     );
-    #[allow(clippy::useless_conversion)]
-    let err: TransactionError = ctx
+    let err = ctx
         .banks_client
         .process_transaction(tx)
         .await
         .unwrap_err()
-        .unwrap()
-        .into();
+        .unwrap();
     assert_eq!(
         err,
         TransactionError::InstructionError(2, InstructionError::InvalidAccountData)
@@ -408,14 +398,12 @@ async fn fail_account_init_after_mint_init_with_extension() {
         &[&ctx.payer, &mint_account],
         ctx.last_blockhash,
     );
-    #[allow(clippy::useless_conversion)]
-    let err: TransactionError = ctx
+    let err = ctx
         .banks_client
         .process_transaction(tx)
         .await
         .unwrap_err()
-        .unwrap()
-        .into();
+        .unwrap();
     assert_eq!(
         err,
         TransactionError::InstructionError(3, InstructionError::InvalidAccountData)
@@ -464,14 +452,12 @@ async fn fail_fee_init_after_mint_init() {
         &[&ctx.payer, &mint_account],
         ctx.last_blockhash,
     );
-    #[allow(clippy::useless_conversion)]
-    let err: TransactionError = ctx
+    let err = ctx
         .banks_client
         .process_transaction(tx)
         .await
         .unwrap_err()
-        .unwrap()
-        .into();
+        .unwrap();
     assert_eq!(
         err,
         TransactionError::InstructionError(1, InstructionError::InvalidAccountData)

--- a/token/program-2022-test/tests/memo_transfer.rs
+++ b/token/program-2022-test/tests/memo_transfer.rs
@@ -100,14 +100,12 @@ async fn test_memo_transfers(
             &[&ctx.payer, &alice],
             ctx.last_blockhash,
         );
-        #[allow(clippy::useless_conversion)]
-        let err: TransactionError = ctx
+        let err = ctx
             .banks_client
             .process_transaction(tx)
             .await
             .unwrap_err()
-            .unwrap()
-            .into();
+            .unwrap();
         drop(ctx);
         assert_eq!(
             err,

--- a/token/program/tests/close_account.rs
+++ b/token/program/tests/close_account.rs
@@ -181,14 +181,12 @@ async fn fail_init_after_close_account() {
         &[&context.payer, &owner],
         context.last_blockhash,
     );
-    #[allow(clippy::useless_conversion)]
-    let error: TransactionError = context
+    let error = context
         .banks_client
         .process_transaction(tx)
         .await
         .unwrap_err()
-        .unwrap()
-        .into();
+        .unwrap();
     assert_eq!(
         error,
         TransactionError::InstructionError(2, InstructionError::InvalidAccountData)


### PR DESCRIPTION
#### Problem

When making the banks client error more expressive, we had to add a bunch of `useless_conversion` allows in the code to keep the downstream projects build intact in #2657

#### Solution

Now that the change is rolled out, we can remove all of the `#[allow(...)]`s