### PR TITLE
Update repo to `edition = "2021"`

### DIFF
--- a/account-compression/programs/account-compression/Cargo.toml
+++ b/account-compression/programs/account-compression/Cargo.toml
@@ -5,7 +5,7 @@ description = "Solana Program Library Account Compression Program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/account-compression/programs/noop/Cargo.toml
+++ b/account-compression/programs/noop/Cargo.toml
@@ -5,7 +5,7 @@ description = "Solana Program Library No-op Program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/associated-token-account/program-test/Cargo.toml
+++ b/associated-token-account/program-test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 description = "SPL Associated Token Account Program Tests"
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 name = "spl-associated-token-account-test"
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/associated-token-account/program/Cargo.toml
+++ b/associated-token-account/program/Cargo.toml
@@ -5,7 +5,7 @@ description = "Solana Program Library Associated Token Account"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 no-entrypoint = []

--- a/binary-option/program/Cargo.toml
+++ b/binary-option/program/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "binary-option"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 license = "WTFPL"
 
 [features]

--- a/binary-oracle-pair/program/Cargo.toml
+++ b/binary-oracle-pair/program/Cargo.toml
@@ -5,7 +5,7 @@ description = "Solana Program Library Binary Oracle Pair"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 test-sbf = []

--- a/examples/rust/cross-program-invocation/Cargo.toml
+++ b/examples/rust/cross-program-invocation/Cargo.toml
@@ -5,7 +5,7 @@ description = "Solana Program Library Cross Program Invocation Example"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/examples/rust/custom-heap/Cargo.toml
+++ b/examples/rust/custom-heap/Cargo.toml
@@ -5,7 +5,7 @@ description = "Solana Program Library Custom Heap Example"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/examples/rust/logging/Cargo.toml
+++ b/examples/rust/logging/Cargo.toml
@@ -5,7 +5,7 @@ description = "Solana Program Library Logging Example"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/examples/rust/sysvar/Cargo.toml
+++ b/examples/rust/sysvar/Cargo.toml
@@ -5,7 +5,7 @@ description = "Solana Program Library Sysvar Example"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/examples/rust/transfer-lamports/Cargo.toml
+++ b/examples/rust/transfer-lamports/Cargo.toml
@@ -5,7 +5,7 @@ description = "Solana Program Library Transfer Lamports Example"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 no-entrypoint = []

--- a/feature-proposal/cli/Cargo.toml
+++ b/feature-proposal/cli/Cargo.toml
@@ -5,7 +5,7 @@ description = "SPL Feature Proposal Command-line Utility"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 chrono = "0.4.22"

--- a/feature-proposal/program/Cargo.toml
+++ b/feature-proposal/program/Cargo.toml
@@ -5,7 +5,7 @@ description = "Solana Program Library Feature Proposal Program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 no-entrypoint = []

--- a/governance/addin-api/Cargo.toml
+++ b/governance/addin-api/Cargo.toml
@@ -5,7 +5,7 @@ description = "Solana Program Library Governance Addin Api"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 borsh = "0.9.1"

--- a/governance/addin-mock/program/Cargo.toml
+++ b/governance/addin-mock/program/Cargo.toml
@@ -5,7 +5,7 @@ description = "Solana Program Library Governance Voter Weight Addin Program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 no-entrypoint = []

--- a/governance/chat/program/Cargo.toml
+++ b/governance/chat/program/Cargo.toml
@@ -5,7 +5,7 @@ description = "Solana Program Library Governance Chat Program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 no-entrypoint = []

--- a/governance/program/Cargo.toml
+++ b/governance/program/Cargo.toml
@@ -5,7 +5,7 @@ description = "Solana Program Library Governance Program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 no-entrypoint = []

--- a/governance/test-sdk/Cargo.toml
+++ b/governance/test-sdk/Cargo.toml
@@ -5,7 +5,7 @@ description = "Solana Program Library Governance Program Test SDK"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 arrayref = "0.3.6"

--- a/governance/tools/Cargo.toml
+++ b/governance/tools/Cargo.toml
@@ -5,7 +5,7 @@ description = "Solana Program Library Governance Tools"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 arrayref = "0.3.6"

--- a/instruction-padding/program/Cargo.toml
+++ b/instruction-padding/program/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
-edition = "2018"
+edition = "2021"
 
 [features]
 no-entrypoint = []

--- a/libraries/concurrent-merkle-tree/Cargo.toml
+++ b/libraries/concurrent-merkle-tree/Cargo.toml
@@ -5,7 +5,7 @@ description = "Solana Program Library Concurrent Merkle Tree"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 log = []

--- a/libraries/math/Cargo.toml
+++ b/libraries/math/Cargo.toml
@@ -5,7 +5,7 @@ description = "Solana Program Library Math"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 no-entrypoint = []

--- a/libraries/merkle-tree-reference/Cargo.toml
+++ b/libraries/merkle-tree-reference/Cargo.toml
@@ -5,7 +5,7 @@ description = "Reference implementation of a merkle tree"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 solana-program = "1.10.33"

--- a/managed-token/program/Cargo.toml
+++ b/managed-token/program/Cargo.toml
@@ -5,7 +5,7 @@ description = "Solana Program Library Token Swap"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/memo/program/Cargo.toml
+++ b/memo/program/Cargo.toml
@@ -5,7 +5,7 @@ description = "Solana Program Library Memo"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 no-entrypoint = []

--- a/name-service/program/Cargo.toml
+++ b/name-service/program/Cargo.toml
@@ -8,7 +8,7 @@ authors = [
   "Solana Maintainers <maintainers@solana.foundation>"
 ]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/record/program/Cargo.toml
+++ b/record/program/Cargo.toml
@@ -5,7 +5,7 @@ description = "Solana Program Library Record Program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 no-entrypoint = []

--- a/shared-memory/program/Cargo.toml
+++ b/shared-memory/program/Cargo.toml
@@ -5,7 +5,7 @@ description = "Solana Program Library Shared-memory"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 test-sbf = []

--- a/stake-pool/cli/Cargo.toml
+++ b/stake-pool/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 description = "SPL-Stake-Pool Command-line Utility"
-edition = "2018"
+edition = "2021"
 homepage = "https://spl.solana.com/stake-pool"
 license = "Apache-2.0"
 name = "spl-stake-pool-cli"

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -5,7 +5,7 @@ description = "Solana Program Library Stake Pool"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 no-entrypoint = []

--- a/stateless-asks/program/Cargo.toml
+++ b/stateless-asks/program/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stateless-asks"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/token-lending/cli/Cargo.toml
+++ b/token-lending/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 description = "SPL Token Lending CLI"
-edition = "2018"
+edition = "2021"
 homepage = "https://spl.solana.com/token-lending"
 license = "Apache-2.0"
 name = "spl-token-lending-cli"

--- a/token-lending/flash_loan_receiver/Cargo.toml
+++ b/token-lending/flash_loan_receiver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flash_loan_receiver"
 version = "1.0.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 arrayref = "0.3.6"

--- a/token-lending/program/Cargo.toml
+++ b/token-lending/program/Cargo.toml
@@ -5,7 +5,7 @@ description = "Solana Program Library Token Lending"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 no-entrypoint = []

--- a/token-swap/program/Cargo.toml
+++ b/token-swap/program/Cargo.toml
@@ -5,7 +5,7 @@ description = "Solana Program Library Token Swap"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 no-entrypoint = []

--- a/token-swap/program/fuzz/Cargo.toml
+++ b/token-swap/program/fuzz/Cargo.toml
@@ -5,7 +5,7 @@ description = "Solana Program Library Token Swap Fuzzer"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/token-upgrade/cli/Cargo.toml
+++ b/token-upgrade/cli/Cargo.toml
@@ -5,7 +5,7 @@ description = "SPL Token Upgrade Command-line Utility"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [build-dependencies]
 walkdir = "2"

--- a/token-upgrade/program/Cargo.toml
+++ b/token-upgrade/program/Cargo.toml
@@ -5,7 +5,7 @@ description = "Solana Program Library Token Upgrade"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 no-entrypoint = []

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 description = "SPL-Token Command-line Utility"
-edition = "2018"
+edition = "2021"
 homepage = "https://spl.solana.com/token"
 license = "Apache-2.0"
 name = "spl-token-cli"

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 description = "SPL-Token Rust Client"
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 name = "spl-token-client"
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 description = "SPL-Token 2022 Integration Tests"
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 name = "spl-token-2022-test"
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -5,7 +5,7 @@ description = "Solana Program Library Token 2022"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 exclude = ["js/**"]
 
 [features]

--- a/token/program/Cargo.toml
+++ b/token/program/Cargo.toml
@@ -5,7 +5,7 @@ description = "Solana Program Library Token"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 exclude = ["js/**"]
 
 [features]

--- a/utils/cgen/Cargo.toml
+++ b/utils/cgen/Cargo.toml
@@ -3,7 +3,7 @@ name = "cgen"
 version = "0.1.0"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 cbindgen = "=0.16.0"

--- a/utils/test-client/Cargo.toml
+++ b/utils/test-client/Cargo.toml
@@ -3,7 +3,7 @@ name = "test-client"
 version = "0.1.0"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 # Used to ensure that SPL programs are buildable by external clients
 


### PR DESCRIPTION
#### Problem

The monorepo has been on the 2021 edition of cargo for some time, but SPL isn't.

#### Solution

Update the edition to 2021. `cargo fix --edition` didn't make any changes when I ran it.