### PR TITLE
deps: Update uint to 0.9.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7229,9 +7229,9 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "uint"
-version = "0.9.1"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6470ab50f482bde894a037a57064480a246dbfdd5960bd65a44824693f08da5f"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
 dependencies = [
  "byteorder",
  "crunchy",


### PR DESCRIPTION
#### Problem

SPL is still on uint version 0.9.1, but 0.9.5 exists.

#### Solution

Update the dep!