### PR TITLE
deps: Revert uint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7229,9 +7229,9 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "uint"
-version = "0.9.5"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+checksum = "6470ab50f482bde894a037a57064480a246dbfdd5960bd65a44824693f08da5f"
 dependencies = [
  "byteorder",
  "crunchy",


### PR DESCRIPTION
#### Problem

The bump of `uint` to version 0.9.5 in #3901 broke the build, roughly *doubling* the number of compute units for math, which broke some tests.

#### Solution

Revert the upgrade