### PR TITLE
Metadata pointer extension

### DIFF
--- a/token/program-2022/src/extension/mint_metadata.rs
+++ b/token/program-2022/src/extension/mint_metadata.rs
@@ -1,0 +1,19 @@
+use solana_program::pubkey::Pubkey;
+
+use {
+    crate::extension::{Extension, ExtensionType},
+    bytemuck::{Pod, Zeroable},
+};
+
+/// Mint metadata extension data for mints.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+pub struct MintMetadata {
+    /// Schema of metadata
+    pub schema: u8,
+    /// Additional accounts required for transfer
+    pub address: Pubkey,
+}
+impl Extension for MintMetadata {
+    const TYPE: ExtensionType = ExtensionType::MintMetadata;
+}

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -11,6 +11,7 @@ use {
             interest_bearing_mint::InterestBearingConfig,
             memo_transfer::MemoTransfer,
             mint_close_authority::MintCloseAuthority,
+            mint_metadata::MintMetadata,
             non_transferable::NonTransferable,
             permanent_delegate::PermanentDelegate,
             transfer_fee::{TransferFeeAmount, TransferFeeConfig},
@@ -47,6 +48,8 @@ pub mod interest_bearing_mint;
 pub mod memo_transfer;
 /// Mint Close Authority extension
 pub mod mint_close_authority;
+/// Mint metadata extension
+pub mod mint_metadata;
 /// Non Transferable extension
 pub mod non_transferable;
 /// Permanent Delegate extension
@@ -641,6 +644,8 @@ pub enum ExtensionType {
     CpiGuard,
     /// Includes an optional permanent delegate
     PermanentDelegate,
+    /// Add metadata address to the mint
+    MintMetadata,
     /// Padding extension used to make an account exactly Multisig::LEN, used for testing
     #[cfg(test)]
     AccountPaddingTest = u16::MAX - 1,
@@ -683,6 +688,7 @@ impl ExtensionType {
             ExtensionType::InterestBearingConfig => pod_get_packed_len::<InterestBearingConfig>(),
             ExtensionType::CpiGuard => pod_get_packed_len::<CpiGuard>(),
             ExtensionType::PermanentDelegate => pod_get_packed_len::<PermanentDelegate>(),
+            ExtensionType::MintMetadata => pod_get_packed_len::<MintMetadata>(),
             #[cfg(test)]
             ExtensionType::AccountPaddingTest => pod_get_packed_len::<AccountPaddingTest>(),
             #[cfg(test)]
@@ -740,7 +746,8 @@ impl ExtensionType {
             | ExtensionType::DefaultAccountState
             | ExtensionType::NonTransferable
             | ExtensionType::InterestBearingConfig
-            | ExtensionType::PermanentDelegate => AccountType::Mint,
+            | ExtensionType::PermanentDelegate
+            | ExtensionType::MintMetadata => AccountType::Mint,
             ExtensionType::ImmutableOwner
             | ExtensionType::TransferFeeAmount
             | ExtensionType::ConfidentialTransferAccount


### PR DESCRIPTION
An example for an extension that points to metadata address with a schema type

**Summary**
Right now, it is just "assumed" metadata exists in the token-metadata program and it means that address gets hard-coded, but this extension would allow wallet / dapps to look for the specific metadata address that could exist in any program

The idea here is this would create a strong relationship between mint and metadata address specifically

**Solution**
This suggestion would add an extension that can be used on a `mint` account to specify a specific metadata address to use. This could live under any program and use any pre-defined schema for the data

**Schemas**
The PR also includes a single byte for the schema type. This can be used to indicate what kind of data exists at that address

Open to suggestions for how schemas should work, but i was thinking schema: 0 would deserialize as metaplex metadata and then other people can use the same schema, and new schemas can be registered somewhere else, separate program probably, that registers how to deserialize the data at that metadata address

cc @nothing0012 @joncinque 