### PR TITLE
Decrease MAX_POOL_SIZE in huge_pool test to make it work with rust 1.65

### DIFF
--- a/stake-pool/program/tests/huge_pool.rs
+++ b/stake-pool/program/tests/huge_pool.rs
@@ -25,7 +25,7 @@ use {
 // the test require so many helper accounts.
 // 20k is also a very safe number for the current upper bound of the network.
 const MAX_POOL_SIZE_WITH_REQUESTED_COMPUTE_UNITS: u32 = 20_000;
-const MAX_POOL_SIZE: u32 = 3_300;
+const MAX_POOL_SIZE: u32 = 3_000;
 const STAKE_AMOUNT: u64 = 200_000_000_000;
 
 async fn setup(


### PR DESCRIPTION
The new rust compiler and standard library generate slightly increased number of SBF instructions, which triggers failure of the stake-pool/program/tests/huge_pool.rs test due to running over the compute budget limit. I would like to decrease the maximum size of the pool to make the test pass when compiled by the new toolchain.