### PR TITLE
fix: stake-pool-js: add browser CJS build

### DIFF
--- a/stake-pool/js/package-lock.json
+++ b/stake-pool/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@solana/spl-stake-pool",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@solana/spl-stake-pool",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "license": "ISC",
       "dependencies": {
         "@project-serum/borsh": "^0.2.2",

--- a/stake-pool/js/package.json
+++ b/stake-pool/js/package.json
@@ -90,4 +90,3 @@
     "testEnvironment": "node"
   }
 }
-

--- a/stake-pool/js/package.json
+++ b/stake-pool/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana/spl-stake-pool",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "SPL Stake Pool Program JS API",
   "scripts": {
     "build": "npm run clean && tsc && cross-env NODE_ENV=production rollup -c",
@@ -27,7 +27,7 @@
     "access": "public"
   },
   "browser": {
-    "./dist/index.cjs.js": "./dist/index.browser.esm.js",
+    "./dist/index.cjs.js": "./dist/index.browser.cjs.js",
     "./dist/index.esm.js": "./dist/index.browser.esm.js"
   },
   "main": "dist/index.cjs.js",

--- a/stake-pool/js/rollup.config.js
+++ b/stake-pool/js/rollup.config.js
@@ -31,7 +31,69 @@ function generateConfig(configType, format) {
     },
   };
 
-  if (configType !== 'browser') {
+  if (browser) {
+    if (format === 'iife') {
+      config.external = ['http', 'https'];
+
+      config.output = [
+        {
+          file: 'dist/index.iife.js',
+          format: 'iife',
+          name: 'solanaStakePool',
+          sourcemap: true,
+        },
+        {
+          file: 'dist/index.iife.min.js',
+          format: 'iife',
+          name: 'solanaStakePool',
+          sourcemap: true,
+          plugins: [terser({ mangle: false, compress: false })],
+        },
+      ];
+    }
+    else {
+      config.output = [
+        {
+          file: 'dist/index.browser.cjs.js',
+          format: 'cjs',
+          sourcemap: true,
+        },
+        {
+          file: 'dist/index.browser.esm.js',
+          format: 'es',
+          sourcemap: true,
+        },
+      ];
+
+      // Prevent dependencies from being bundled
+      config.external = [
+        '@project-serum/borsh',
+        '@solana/buffer-layout',
+        '@solana/spl-token',
+        '@solana/web3.js',
+        'bn.js',
+        'buffer',
+      ];
+    }
+
+    // TODO: Find a workaround to avoid resolving the following JSON file:
+    // `node_modules/secp256k1/node_modules/elliptic/package.json`
+    config.plugins.push(json());
+  }
+  else {
+    config.output = [
+      {
+        file: 'dist/index.cjs.js',
+        format: 'cjs',
+        sourcemap: true,
+      },
+      {
+        file: 'dist/index.esm.js',
+        format: 'es',
+        sourcemap: true,
+      },
+    ];
+
     // Prevent dependencies from being bundled
     config.external = [
       '@project-serum/borsh',
@@ -43,83 +105,11 @@ function generateConfig(configType, format) {
     ];
   }
 
-  switch (configType) {
-    case 'browser':
-      switch (format) {
-        case 'esm': {
-          config.output = [
-            {
-              file: 'dist/index.browser.esm.js',
-              format: 'es',
-              sourcemap: true,
-            },
-          ];
-
-          // Prevent dependencies from being bundled
-          config.external = [
-            '@project-serum/borsh',
-            '@solana/buffer-layout',
-            '@solana/spl-token',
-            '@solana/web3.js',
-            'bn.js',
-            'buffer',
-          ];
-
-          break;
-        }
-        case 'iife': {
-          config.external = ['http', 'https'];
-
-          config.output = [
-            {
-              file: 'dist/index.iife.js',
-              format: 'iife',
-              name: 'solanaStakePool',
-              sourcemap: true,
-            },
-            {
-              file: 'dist/index.iife.min.js',
-              format: 'iife',
-              name: 'solanaStakePool',
-              sourcemap: true,
-              plugins: [terser({ mangle: false, compress: false })],
-            },
-          ];
-
-          break;
-        }
-        default:
-          throw new Error(`Unknown format: ${format}`);
-      }
-
-      // TODO: Find a workaround to avoid resolving the following JSON file:
-      // `node_modules/secp256k1/node_modules/elliptic/package.json`
-      config.plugins.push(json());
-
-      break;
-    case 'node':
-      config.output = [
-        {
-          file: 'dist/index.cjs.js',
-          format: 'cjs',
-          sourcemap: true,
-        },
-        {
-          file: 'dist/index.esm.js',
-          format: 'es',
-          sourcemap: true,
-        },
-      ];
-      break;
-    default:
-      throw new Error(`Unknown configType: ${configType}`);
-  }
-
   return config;
 }
 
 export default [
   generateConfig('node'),
-  generateConfig('browser', 'esm'),
+  generateConfig('browser'),
   generateConfig('browser', 'iife'),
 ];

--- a/stake-pool/js/rollup.config.js
+++ b/stake-pool/js/rollup.config.js
@@ -50,8 +50,7 @@ function generateConfig(configType, format) {
           plugins: [terser({ mangle: false, compress: false })],
         },
       ];
-    }
-    else {
+    } else {
       config.output = [
         {
           file: 'dist/index.browser.cjs.js',
@@ -79,8 +78,7 @@ function generateConfig(configType, format) {
     // TODO: Find a workaround to avoid resolving the following JSON file:
     // `node_modules/secp256k1/node_modules/elliptic/package.json`
     config.plugins.push(json());
-  }
-  else {
+  } else {
     config.output = [
       {
         file: 'dist/index.cjs.js',

--- a/stake-pool/js/tsconfig.json
+++ b/stake-pool/js/tsconfig.json
@@ -16,7 +16,5 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true
   },
-  "include": [
-    "src/**/*.ts"
-  ]
+  "include": ["src/**/*.ts"]
 }

--- a/stake-pool/js/tsconfig.json
+++ b/stake-pool/js/tsconfig.json
@@ -6,6 +6,7 @@
     "outDir": "dist",
     "declaration": true,
     "declarationDir": "dist",
+    "emitDeclarationOnly": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,


### PR DESCRIPTION
stake-pool-js links its browser CJS output to an ESM build. This is likely to cause issues for a browser build that expects CJS. This PR adds an additional CJS build for browser output, and simplifies the Rollup config a little.