### PR TITLE
docs: Add stake pool fees page to the sidebar

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -28,6 +28,7 @@ module.exports = {
         "stake-pool",
         "stake-pool/quickstart",
         "stake-pool/overview",
+        "stake-pool/fees",
         "stake-pool/cli",
       ],
     },


### PR DESCRIPTION
#### Problem

There's a fees page for stake pools, but it's not exposed on the sidebar.

#### Solution

Add the fees page