### PR TITLE
token-js: rename ExtensionType.InterestBearingMint

### DIFF
--- a/token/js/src/extensions/extensionType.ts
+++ b/token/js/src/extensions/extensionType.ts
@@ -24,7 +24,7 @@ export enum ExtensionType {
     ImmutableOwner,
     MemoTransfer,
     NonTransferable,
-    InterestBearingMint,
+    InterestBearingConfig,
     CpiGuard,
     PermanentDelegate,
 }
@@ -58,7 +58,7 @@ export function getTypeLen(e: ExtensionType): number {
             return MEMO_TRANSFER_SIZE;
         case ExtensionType.NonTransferable:
             return NON_TRANSFERABLE_SIZE;
-        case ExtensionType.InterestBearingMint:
+        case ExtensionType.InterestBearingConfig:
             return INTEREST_BEARING_MINT_CONFIG_STATE_SIZE;
         case ExtensionType.PermanentDelegate:
             return PERMANENT_DELEGATE_SIZE;
@@ -82,7 +82,7 @@ export function getAccountTypeOfMintType(e: ExtensionType): ExtensionType {
         case ExtensionType.MintCloseAuthority:
         case ExtensionType.NonTransferable:
         case ExtensionType.Uninitialized:
-        case ExtensionType.InterestBearingMint:
+        case ExtensionType.InterestBearingConfig:
         case ExtensionType.PermanentDelegate:
             return ExtensionType.Uninitialized;
     }

--- a/token/js/src/extensions/interestBearingMint/actions.ts
+++ b/token/js/src/extensions/interestBearingMint/actions.ts
@@ -37,7 +37,7 @@ export async function createInterestBearingMint(
     confirmOptions?: ConfirmOptions,
     programId = TOKEN_2022_PROGRAM_ID
 ): Promise<PublicKey> {
-    const mintLen = getMintLen([ExtensionType.InterestBearingMint]);
+    const mintLen = getMintLen([ExtensionType.InterestBearingConfig]);
     const lamports = await connection.getMinimumBalanceForRentExemption(mintLen);
     const transaction = new Transaction().add(
         SystemProgram.createAccount({

--- a/token/js/src/extensions/interestBearingMint/state.ts
+++ b/token/js/src/extensions/interestBearingMint/state.ts
@@ -23,7 +23,7 @@ export const InterestBearingMintConfigStateLayout = struct<InterestBearingMintCo
 export const INTEREST_BEARING_MINT_CONFIG_STATE_SIZE = InterestBearingMintConfigStateLayout.span;
 
 export function getInterestBearingMintConfigState(mint: Mint): InterestBearingMintConfigState | null {
-    const extensionData = getExtensionData(ExtensionType.InterestBearingMint, mint.tlvData);
+    const extensionData = getExtensionData(ExtensionType.InterestBearingConfig, mint.tlvData);
     if (extensionData !== null) {
         return InterestBearingMintConfigStateLayout.decode(extensionData);
     }


### PR DESCRIPTION
consider this a suggestion to accept or reject. this is the only variant on the `ExtensionType` enum that doesnt match the name used in token22. because the js enum is supposed to correspond 1:1 with the program enum (to the extent that the order must match too, because the js enum values are compared to the type tags stored in `tlv_data` onchain) i feel they should be identical

admittedly the name is worse. as an alternative maybe we should rename `InterestBearingConfig` instead. but either way the js should be subservient to the rust imo