### PR TITLE
[confidential-extension] Refactor and add comments for readability

### DIFF
--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -992,7 +992,10 @@ async fn ct_transfer() {
     assert_eq!(
         err,
         TokenClientError::Client(Box::new(TransportError::TransactionError(
-            TransactionError::InstructionError(0, InstructionError::InvalidAccountData)
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::ConfidentialTransferAccountHasBalance as u32)
+            )
         )))
     );
 
@@ -1202,7 +1205,10 @@ async fn ct_transfer_with_fee() {
     assert_eq!(
         err,
         TokenClientError::Client(Box::new(TransportError::TransactionError(
-            TransactionError::InstructionError(0, InstructionError::InvalidAccountData)
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::ConfidentialTransferAccountHasBalance as u32)
+            )
         )))
     );
 

--- a/token/program-2022/src/extension/confidential_transfer/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer/mod.rs
@@ -203,4 +203,13 @@ impl ConfidentialTransferAccount {
 
         Ok(())
     }
+
+    /// Increments a confidential extension pending balance credit counter.
+    pub fn increment_pending_balance_credit_counter(&mut self) -> ProgramResult {
+        self.pending_balance_credit_counter = (u64::from(self.pending_balance_credit_counter)
+            .checked_add(1)
+            .ok_or(TokenError::Overflow)?)
+        .into();
+        Ok(())
+    }
 }

--- a/token/program-2022/src/extension/confidential_transfer/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer/mod.rs
@@ -141,7 +141,7 @@ impl Extension for ConfidentialTransferAccount {
 }
 
 impl ConfidentialTransferAccount {
-    /// Check if a `ConfidentialTransferAccount` has been approved for use
+    /// Check if a `ConfidentialTransferAccount` has been approved for use.
     pub fn approved(&self) -> ProgramResult {
         if bool::from(&self.approved) {
             Ok(())
@@ -150,7 +150,7 @@ impl ConfidentialTransferAccount {
         }
     }
 
-    /// Check if a `ConfidentialTransferAccount` is in a closable state
+    /// Check if a `ConfidentialTransferAccount` is in a closable state.
     pub fn closable(&self) -> ProgramResult {
         if self.pending_balance_lo == EncryptedBalance::zeroed()
             && self.pending_balance_hi == EncryptedBalance::zeroed()
@@ -164,12 +164,43 @@ impl ConfidentialTransferAccount {
     }
 
     /// Check if a base account of a `ConfidentialTransferAccount` accepts non-confidential
-    /// transfers
+    /// transfers.
     pub fn non_confidential_transfer_allowed(&self) -> ProgramResult {
         if bool::from(&self.allow_non_confidential_credits) {
             Ok(())
         } else {
             Err(TokenError::NonConfidentialTransfersDisabled.into())
         }
+    }
+
+    /// Checks if a `ConfidentialTransferAccount` is configured to send funds.
+    pub fn valid_as_source(&self) -> ProgramResult {
+        self.approved()
+    }
+
+    /// Checks if a confidential extension is configured to receive funds.
+    ///
+    /// A destination account can receive funds if the following conditions are satisfied:
+    ///   1. The account is approved by the confidential transfer mint authority
+    ///   2. The account is not disabled by the account owner
+    ///   3. The number of credits into the account has reached the maximum credit counter
+    pub fn valid_as_destination(&self) -> ProgramResult {
+        self.approved()?;
+
+        if !bool::from(self.allow_confidential_credits) {
+            return Err(TokenError::ConfidentialTransferDepositsAndTransfersDisabled.into());
+        }
+
+        let new_destination_pending_balance_credit_counter =
+            u64::from(self.pending_balance_credit_counter)
+                .checked_add(1)
+                .ok_or(TokenError::Overflow)?;
+        if new_destination_pending_balance_credit_counter
+            > u64::from(self.maximum_pending_balance_credit_counter)
+        {
+            return Err(TokenError::MaximumPendingBalanceCreditCounterExceeded.into());
+        }
+
+        Ok(())
     }
 }

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -416,7 +416,8 @@ fn process_withdraw(
         token_account.get_extension_mut::<ConfidentialTransferAccount>()?;
     confidential_transfer_account.valid_as_source()?;
 
-    // Zero-knowledge proof certifies that a ciphertext encrypts a non-negative 64-bit number
+    // Zero-knowledge proof certifies that the account has enough available balance to withdraw the
+    // amount.
     let zkp_instruction =
         get_instruction_relative(proof_instruction_offset, instructions_sysvar_info)?;
     let proof_data = decode_proof_instruction::<WithdrawData>(
@@ -973,28 +974,29 @@ fn process_withdraw_withheld_tokens_from_mint(
         destination_account.get_extension_mut::<ConfidentialTransferAccount>()?;
     destination_confidential_transfer_account.valid_as_destination()?;
 
-    // verify consistency of proof data
-    let previous_instruction =
+    // Zero-knowledge proof certifies that the exact withheld amount is credited to the source
+    // account.
+    let zkp_instruction =
         get_instruction_relative(proof_instruction_offset, instructions_sysvar_info)?;
     let proof_data = decode_proof_instruction::<WithdrawWithheldTokensData>(
         ProofInstruction::VerifyWithdrawWithheldTokens,
-        &previous_instruction,
+        &zkp_instruction,
     )?;
-
-    // withdraw withheld authority ElGamal pubkey should match in the proof data and mint
+    // Checks that the withdraw authority encryption public key associated with the mint is
+    // consistent with what was actually used to generate the zkp.
     if proof_data.withdraw_withheld_authority_pubkey
         != confidential_transfer_mint.withdraw_withheld_authority_encryption_pubkey
     {
         return Err(TokenError::ConfidentialTransferElGamalPubkeyMismatch.into());
     }
-
-    // destination ElGamal pubkey should match in the proof data and destination account
+    // Checks that the encryption public key associated with the destination account is consistent
+    // with what was actually used to generate the zkp.
     if proof_data.destination_pubkey != destination_confidential_transfer_account.encryption_pubkey
     {
         return Err(TokenError::ConfidentialTransferElGamalPubkeyMismatch.into());
     }
-
-    // withheld amount ciphertext must match in the proof data and mint
+    // Checks that the withheld amount ciphertext is consistent with the ciphertext data that was
+    // actually used to generate the zkp.
     if proof_data.withdraw_withheld_authority_ciphertext
         != confidential_transfer_mint.withheld_amount
     {
@@ -1002,7 +1004,7 @@ fn process_withdraw_withheld_tokens_from_mint(
     }
 
     // The proof data contains the mint withheld amount encrypted under the destination ElGamal pubkey.
-    // This amount should be added to the destination pending balance.
+    // This amount is added to the destination pending balance.
     let new_destination_pending_balance = ops::add(
         &destination_confidential_transfer_account.pending_balance_lo,
         &proof_data.destination_ciphertext,
@@ -1017,7 +1019,7 @@ fn process_withdraw_withheld_tokens_from_mint(
             .ok_or(ProgramError::InvalidInstructionData)?)
         .into();
 
-    // fee is now withdrawn, so zero out mint withheld amount
+    // Fee is now withdrawn, so zero out the mint withheld amount.
     confidential_transfer_mint.withheld_amount = EncryptedWithheldAmount::zeroed();
 
     Ok(())
@@ -1069,7 +1071,7 @@ fn process_withdraw_withheld_tokens_from_accounts(
         return Err(TokenError::AccountFrozen.into());
     }
 
-    // sum up the withheld amounts in all the accounts
+    // Sum up the withheld amounts in all the accounts.
     let mut aggregate_withheld_amount = EncryptedWithheldAmount::zeroed();
     for account_info in &account_infos[num_signers..] {
         // self-harvest, can't double-borrow the underlying data
@@ -1104,34 +1106,36 @@ fn process_withdraw_withheld_tokens_from_accounts(
         destination_account.get_extension_mut::<ConfidentialTransferAccount>()?;
     destination_confidential_transfer_account.valid_as_destination()?;
 
-    // verify consistency of proof data
-    let previous_instruction =
+    // Zero-knowledge proof certifies that the exact aggregate withheld amount is credited to the
+    // source account.
+    let zkp_instruction =
         get_instruction_relative(proof_instruction_offset, instructions_sysvar_info)?;
     let proof_data = decode_proof_instruction::<WithdrawWithheldTokensData>(
         ProofInstruction::VerifyWithdrawWithheldTokens,
-        &previous_instruction,
+        &zkp_instruction,
     )?;
-
-    // withdraw withheld authority ElGamal pubkey should match in the proof data and mint
+    // Checks that the withdraw authority encryption public key associated with the mint is
+    // consistent with what was actually used to generate the zkp.
     let confidential_transfer_mint = mint.get_extension_mut::<ConfidentialTransferMint>()?;
     if proof_data.withdraw_withheld_authority_pubkey
         != confidential_transfer_mint.withdraw_withheld_authority_encryption_pubkey
     {
         return Err(TokenError::ConfidentialTransferElGamalPubkeyMismatch.into());
     }
-
-    // destination ElGamal pubkey should match in the proof data and destination account
+    // Checks that the encryption public key associated with the destination account is consistent
+    // with what was actually used to generate the zkp.
     if proof_data.destination_pubkey != destination_confidential_transfer_account.encryption_pubkey
     {
         return Err(TokenError::ConfidentialTransferElGamalPubkeyMismatch.into());
     }
-
-    // withheld amount ciphertext must match in the proof data and mint
+    // Checks that the withheld amount ciphertext is consistent with the ciphertext data that was
+    // actually used to generate the zkp.
     if proof_data.withdraw_withheld_authority_ciphertext != aggregate_withheld_amount {
         return Err(TokenError::ConfidentialTransferBalanceMismatch.into());
     }
 
-    // add the sum of the withheld fees to destination pending balance
+    // The proof data contains the mint withheld amount encrypted under the destination ElGamal pubkey.
+    // This amount is added to the destination pending balance.
     let new_destination_pending_balance = ops::add(
         &destination_confidential_transfer_account.pending_balance_lo,
         &proof_data.destination_ciphertext,


### PR DESCRIPTION
Summary of changes:
- Refactor `check_source_confidential_account` function into `valid_as_source` method 
- Refactor `check_destination_confidential_account` function into `valid_as_dest` method
- Organize pending balance counter increment into `increment_pending_balance_credit_counter` method
- Skip ciphertext arithmetic on `Deposit` and `Withdraw` if the amount is zero (issue #3560)
- Rename `previous_instruction` to `zkp_instruction` and other minor variable renaming for consistency
- Add comments on potentially confusing parts of the code