### PR TITLE
stake-pool: Add "IncreaseAdditionalValidatorStake" instruction

### DIFF
--- a/stake-pool/program/src/lib.rs
+++ b/stake-pool/program/src/lib.rs
@@ -28,6 +28,9 @@ const AUTHORITY_WITHDRAW: &[u8] = b"withdraw";
 /// Seed for transient stake account
 const TRANSIENT_STAKE_SEED_PREFIX: &[u8] = b"transient";
 
+/// Seed for ephemeral stake account
+const EPHEMERAL_STAKE_SEED_PREFIX: &[u8] = b"ephemeral";
+
 /// Minimum amount of staked lamports required in a validator stake account to allow
 /// for merges without a mismatch on credits observed
 pub const MINIMUM_ACTIVE_STAKE: u64 = 1_000_000;
@@ -131,6 +134,22 @@ pub fn find_transient_stake_program_address(
         &[
             TRANSIENT_STAKE_SEED_PREFIX,
             vote_account_address.as_ref(),
+            stake_pool_address.as_ref(),
+            &seed.to_le_bytes(),
+        ],
+        program_id,
+    )
+}
+
+/// Generates the ephemeral program address for stake pool redelegation
+pub fn find_ephemeral_stake_program_address(
+    program_id: &Pubkey,
+    stake_pool_address: &Pubkey,
+    seed: u64,
+) -> (Pubkey, u8) {
+    Pubkey::find_program_address(
+        &[
+            EPHEMERAL_STAKE_SEED_PREFIX,
             stake_pool_address.as_ref(),
             &seed.to_le_bytes(),
         ],

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -1487,8 +1487,17 @@ impl Processor {
                 reserve_stake_account_info
             };
 
+        let transient_stake_bump_seed = check_transient_stake_address(
+            program_id,
+            stake_pool_info.key,
+            transient_stake_account_info.key,
+            vote_account_address,
+            transient_stake_seed,
+        )?;
+
         if validator_stake_info.transient_stake_lamports > 0 {
-            // transient stake exists, try to merge from the source account
+            // transient stake exists, try to merge from the source account,
+            // which is always an ephemeral account
             Self::stake_merge(
                 stake_pool_info.key,
                 source_stake_account_info.clone(),
@@ -1502,13 +1511,6 @@ impl Processor {
             )?;
         } else {
             // no transient stake, split
-            let transient_stake_bump_seed = check_transient_stake_address(
-                program_id,
-                stake_pool_info.key,
-                transient_stake_account_info.key,
-                vote_account_address,
-                transient_stake_seed,
-            )?;
             let transient_stake_account_signer_seeds: &[&[_]] = &[
                 TRANSIENT_STAKE_SEED_PREFIX,
                 &vote_account_address.to_bytes(),

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -10,7 +10,8 @@ use {
             is_extension_supported_for_mint, AccountType, Fee, FeeType, StakePool, StakeStatus,
             StakeWithdrawSource, ValidatorList, ValidatorListHeader, ValidatorStakeInfo,
         },
-        AUTHORITY_DEPOSIT, AUTHORITY_WITHDRAW, TRANSIENT_STAKE_SEED_PREFIX,
+        AUTHORITY_DEPOSIT, AUTHORITY_WITHDRAW, EPHEMERAL_STAKE_SEED_PREFIX,
+        TRANSIENT_STAKE_SEED_PREFIX,
     },
     borsh::{BorshDeserialize, BorshSerialize},
     mpl_token_metadata::{
@@ -93,6 +94,23 @@ fn check_transient_stake_address(
         seed,
     );
     if transient_stake_address != *stake_account_address {
+        Err(StakePoolError::InvalidStakeAccountAddress.into())
+    } else {
+        Ok(bump_seed)
+    }
+}
+
+/// Check address validity for an ephemeral stake account
+fn check_ephemeral_stake_address(
+    program_id: &Pubkey,
+    stake_pool_address: &Pubkey,
+    stake_account_address: &Pubkey,
+    seed: u64,
+) -> Result<u8, ProgramError> {
+    // Check stake account address validity
+    let (ephemeral_stake_address, bump_seed) =
+        crate::find_ephemeral_stake_program_address(program_id, stake_pool_address, seed);
+    if ephemeral_stake_address != *stake_account_address {
         Err(StakePoolError::InvalidStakeAccountAddress.into())
     } else {
         Ok(bump_seed)
@@ -1262,6 +1280,7 @@ impl Processor {
         accounts: &[AccountInfo],
         lamports: u64,
         transient_stake_seed: u64,
+        maybe_ephemeral_stake_seed: Option<u64>,
     ) -> ProgramResult {
         let account_info_iter = &mut accounts.iter();
         let stake_pool_info = next_account_info(account_info_iter)?;
@@ -1269,13 +1288,22 @@ impl Processor {
         let withdraw_authority_info = next_account_info(account_info_iter)?;
         let validator_list_info = next_account_info(account_info_iter)?;
         let reserve_stake_account_info = next_account_info(account_info_iter)?;
+        let maybe_ephemeral_stake_account_info = maybe_ephemeral_stake_seed
+            .map(|_| next_account_info(account_info_iter))
+            .transpose()?;
         let transient_stake_account_info = next_account_info(account_info_iter)?;
         let validator_stake_account_info = next_account_info(account_info_iter)?;
         let validator_vote_account_info = next_account_info(account_info_iter)?;
         let clock_info = next_account_info(account_info_iter)?;
         let clock = &Clock::from_account_info(clock_info)?;
-        let rent_info = next_account_info(account_info_iter)?;
-        let rent = &Rent::from_account_info(rent_info)?;
+        let rent = if maybe_ephemeral_stake_seed.is_some() {
+            // instruction with ephemeral account doesn't take the rent account
+            Rent::get()?
+        } else {
+            // legacy instruction takes the rent account
+            let rent_info = next_account_info(account_info_iter)?;
+            Rent::from_account_info(rent_info)?
+        };
         let stake_history_info = next_account_info(account_info_iter)?;
         let stake_config_info = next_account_info(account_info_iter)?;
         let system_program_info = next_account_info(account_info_iter)?;
@@ -1327,7 +1355,19 @@ impl Processor {
         }
         let mut validator_stake_info = maybe_validator_stake_info.unwrap();
         if validator_stake_info.transient_stake_lamports > 0 {
-            return Err(StakePoolError::TransientAccountInUse.into());
+            if maybe_ephemeral_stake_seed.is_none() {
+                msg!("Attempting to increase stake on a validator with transient stake, use IncreaseAdditionalValidatorStake with the existing seed");
+                return Err(StakePoolError::TransientAccountInUse.into());
+            }
+            if transient_stake_seed != validator_stake_info.transient_seed_suffix {
+                msg!(
+                    "Transient stake already exists with seed {}, you must use that one",
+                    validator_stake_info.transient_seed_suffix
+                );
+                return Err(ProgramError::InvalidSeeds);
+            }
+            // Let the runtime check to see if the merge is valid, so there's no
+            // explicit check here that the transient stake is increasing
         }
 
         // Check that the validator stake account is actually delegated to the right
@@ -1356,21 +1396,6 @@ impl Processor {
                 return Err(StakePoolError::WrongStakeState.into());
             }
         }
-
-        let transient_stake_bump_seed = check_transient_stake_address(
-            program_id,
-            stake_pool_info.key,
-            transient_stake_account_info.key,
-            vote_account_address,
-            transient_stake_seed,
-        )?;
-        let transient_stake_account_signer_seeds: &[&[_]] = &[
-            TRANSIENT_STAKE_SEED_PREFIX,
-            &vote_account_address.to_bytes(),
-            &stake_pool_info.key.to_bytes(),
-            &transient_stake_seed.to_le_bytes(),
-            &[transient_stake_bump_seed],
-        ];
 
         if validator_stake_info.status != StakeStatus::Active {
             msg!("Validator is marked for removal and no longer allows increases");
@@ -1410,37 +1435,136 @@ impl Processor {
             return Err(ProgramError::InsufficientFunds);
         }
 
-        create_stake_account(
-            transient_stake_account_info.clone(),
-            transient_stake_account_signer_seeds,
-            system_program_info.clone(),
-        )?;
+        let maybe_split_from_account_info =
+            if let Some(ephemeral_stake_seed) = maybe_ephemeral_stake_seed {
+                let ephemeral_stake_account_info = maybe_ephemeral_stake_account_info.unwrap();
+                let ephemeral_stake_bump_seed = check_ephemeral_stake_address(
+                    program_id,
+                    stake_pool_info.key,
+                    ephemeral_stake_account_info.key,
+                    ephemeral_stake_seed,
+                )?;
+                let ephemeral_stake_account_signer_seeds: &[&[_]] = &[
+                    EPHEMERAL_STAKE_SEED_PREFIX,
+                    &stake_pool_info.key.to_bytes(),
+                    &ephemeral_stake_seed.to_le_bytes(),
+                    &[ephemeral_stake_bump_seed],
+                ];
+                create_stake_account(
+                    ephemeral_stake_account_info.clone(),
+                    ephemeral_stake_account_signer_seeds,
+                    system_program_info.clone(),
+                )?;
 
-        // split into transient stake account
-        Self::stake_split(
-            stake_pool_info.key,
-            reserve_stake_account_info.clone(),
-            withdraw_authority_info.clone(),
-            AUTHORITY_WITHDRAW,
-            stake_pool.stake_withdraw_bump_seed,
-            total_lamports,
-            transient_stake_account_info.clone(),
-        )?;
+                // split into ephemeral stake account
+                Self::stake_split(
+                    stake_pool_info.key,
+                    reserve_stake_account_info.clone(),
+                    withdraw_authority_info.clone(),
+                    AUTHORITY_WITHDRAW,
+                    stake_pool.stake_withdraw_bump_seed,
+                    total_lamports,
+                    ephemeral_stake_account_info.clone(),
+                )?;
 
-        // activate transient stake to validator
-        Self::stake_delegate(
-            transient_stake_account_info.clone(),
-            validator_vote_account_info.clone(),
-            clock_info.clone(),
-            stake_history_info.clone(),
-            stake_config_info.clone(),
-            withdraw_authority_info.clone(),
-            stake_pool_info.key,
-            AUTHORITY_WITHDRAW,
-            stake_pool.stake_withdraw_bump_seed,
-        )?;
+                // activate stake to validator
+                Self::stake_delegate(
+                    ephemeral_stake_account_info.clone(),
+                    validator_vote_account_info.clone(),
+                    clock_info.clone(),
+                    stake_history_info.clone(),
+                    stake_config_info.clone(),
+                    withdraw_authority_info.clone(),
+                    stake_pool_info.key,
+                    AUTHORITY_WITHDRAW,
+                    stake_pool.stake_withdraw_bump_seed,
+                )?;
+                if validator_stake_info.transient_stake_lamports > 0 {
+                    // transient stake exists, try to merge
+                    Self::stake_merge(
+                        stake_pool_info.key,
+                        ephemeral_stake_account_info.clone(),
+                        withdraw_authority_info.clone(),
+                        AUTHORITY_WITHDRAW,
+                        stake_pool.stake_withdraw_bump_seed,
+                        transient_stake_account_info.clone(),
+                        clock_info.clone(),
+                        stake_history_info.clone(),
+                        stake_program_info.clone(),
+                    )?;
+                    None
+                } else {
+                    // otherwise, split everything from the ephemeral stake, into the transient
+                    Some(ephemeral_stake_account_info)
+                }
+            } else {
+                // if no ephemeral account is provided, split everything from the
+                // reserve account, into the transient stake account
+                Some(reserve_stake_account_info)
+            };
 
-        validator_stake_info.transient_stake_lamports = total_lamports;
+        if let Some(split_from_account_info) = maybe_split_from_account_info {
+            let transient_stake_bump_seed = check_transient_stake_address(
+                program_id,
+                stake_pool_info.key,
+                transient_stake_account_info.key,
+                vote_account_address,
+                transient_stake_seed,
+            )?;
+            let transient_stake_account_signer_seeds: &[&[_]] = &[
+                TRANSIENT_STAKE_SEED_PREFIX,
+                &vote_account_address.to_bytes(),
+                &stake_pool_info.key.to_bytes(),
+                &transient_stake_seed.to_le_bytes(),
+                &[transient_stake_bump_seed],
+            ];
+
+            create_stake_account(
+                transient_stake_account_info.clone(),
+                transient_stake_account_signer_seeds,
+                system_program_info.clone(),
+            )?;
+
+            // split into transient stake account
+            Self::stake_split(
+                stake_pool_info.key,
+                split_from_account_info.clone(),
+                withdraw_authority_info.clone(),
+                AUTHORITY_WITHDRAW,
+                stake_pool.stake_withdraw_bump_seed,
+                total_lamports,
+                transient_stake_account_info.clone(),
+            )?;
+
+            // Activate transient stake to validator if necessary
+            let stake_state = try_from_slice_unchecked::<stake::state::StakeState>(
+                &transient_stake_account_info.data.borrow(),
+            )?;
+            match stake_state {
+                // if it was delegated on or before this epoch, we're good
+                stake::state::StakeState::Stake(_, stake)
+                    if stake.delegation.activation_epoch <= clock.epoch => {}
+                // all other situations, delegate!
+                _ => {
+                    Self::stake_delegate(
+                        transient_stake_account_info.clone(),
+                        validator_vote_account_info.clone(),
+                        clock_info.clone(),
+                        stake_history_info.clone(),
+                        stake_config_info.clone(),
+                        withdraw_authority_info.clone(),
+                        stake_pool_info.key,
+                        AUTHORITY_WITHDRAW,
+                        stake_pool.stake_withdraw_bump_seed,
+                    )?;
+                }
+            }
+        }
+
+        validator_stake_info.transient_stake_lamports = validator_stake_info
+            .transient_stake_lamports
+            .checked_add(total_lamports)
+            .ok_or(StakePoolError::CalculationFailure)?;
         validator_stake_info.transient_seed_suffix = transient_stake_seed;
 
         Ok(())
@@ -3136,6 +3260,21 @@ impl Processor {
                     accounts,
                     lamports,
                     transient_stake_seed,
+                    None,
+                )
+            }
+            StakePoolInstruction::IncreaseAdditionalValidatorStake {
+                lamports,
+                transient_stake_seed,
+                ephemeral_stake_seed,
+            } => {
+                msg!("Instruction: IncreaseAdditionalValidatorStake");
+                Self::process_increase_validator_stake(
+                    program_id,
+                    accounts,
+                    lamports,
+                    transient_stake_seed,
+                    Some(ephemeral_stake_seed),
                 )
             }
             StakePoolInstruction::SetPreferredValidator {


### PR DESCRIPTION
#### Problem

As brought up during the single validator manager proposal #3881, there's an annoying "attack" vector where a person puts in the minimum stake delegation at the start of an epoch and immediately increases stake on the validator, preventing later SOL deposits from being activated.

#### Solution

There's nothing technically stopping two activating stakes from merging, so introduce a new instruction on the stake pool program which allows for a second increase in an epoch.

The normal instruction splits into the transient account and then activates it, so this instruction:

* splits into an ephemeral stake account
* if the transient account exists: merges the ephemeral stake account into the transient stake account\
* if the transient account doesn't exist: splits from ephemeral into transient, so pools can transition to always using this new instruction