### PR TITLE
token-2022: Fix parenthesis typo in fee calculation doc

### DIFF
--- a/token/program-2022/src/extension/transfer_fee/mod.rs
+++ b/token/program-2022/src/extension/transfer_fee/mod.rs
@@ -37,8 +37,8 @@ pub struct TransferFee {
 impl TransferFee {
     /// Calculate ceiling-division
     ///
-    /// Ceiling-division `ceil[ dividend / divisor ]` can be represented as a floor-division
-    /// `floor[ dividend + (divisor - 1) / divisor ]`
+    /// Ceiling-division `ceil[ numerator / denominator ]` can be represented as a floor-division
+    /// `floor[ (numerator + denominator - 1) / denominator ]`
     fn ceil_div(dividend: u128, divisor: u128) -> Option<u128> {
         dividend
             .checked_add(divisor)?


### PR DESCRIPTION
Fixing a small typo in the description of the ceiling division function in transfer fee. `floor[ dividend + (divisor - 1) / divisor ]` should be `floor[ (dividend + divisor - 1) / divisor]`.

In the process, changing `dividend` to `numerator` and `divisor` to `denominator` to be consistent with the rest of the fee calculation functions.