### PR TITLE
token-2022: fix `ceil_div` variable name

### DIFF
--- a/token/program-2022/src/extension/transfer_fee/mod.rs
+++ b/token/program-2022/src/extension/transfer_fee/mod.rs
@@ -39,11 +39,11 @@ impl TransferFee {
     ///
     /// Ceiling-division `ceil[ numerator / denominator ]` can be represented as a floor-division
     /// `floor[ (numerator + denominator - 1) / denominator ]`
-    fn ceil_div(dividend: u128, divisor: u128) -> Option<u128> {
-        dividend
-            .checked_add(divisor)?
+    fn ceil_div(numerator: u128, denominator: u128) -> Option<u128> {
+        numerator
+            .checked_add(denominator)?
             .checked_sub(1)?
-            .checked_div(divisor)
+            .checked_div(denominator)
     }
 
     /// Calculate the transfer fee


### PR DESCRIPTION
The docs for the `ceil_div` function was updated so that `dividend` was updated to `numerator` and `divisor` was updated to `denominator`, but the actual variable names were not updated. This PR updates the variable names.