### PR TITLE
token-cli: support CpiGuard and PermanentDelegate

### DIFF
--- a/token/cli/src/output.rs
+++ b/token/cli/src/output.rs
@@ -191,6 +191,8 @@ pub(crate) struct CliTokenAccount {
     pub(crate) is_associated: bool,
     #[serde(flatten)]
     pub(crate) account: UiTokenAccount,
+    #[serde(skip_serializing)]
+    pub(crate) has_permanent_delegate: bool,
 }
 
 impl QuietDisplay for CliTokenAccount {}
@@ -255,6 +257,22 @@ impl fmt::Display for CliTokenAccount {
         if !self.is_associated {
             writeln!(f)?;
             writeln!(f, "* Please run `spl-token gc` to clean up Aux accounts")?;
+        }
+
+        if self.has_permanent_delegate {
+            writeln!(f)?;
+            writeln!(
+                f,
+                "* {} ",
+                style("This token has a permanent delegate!").bold()
+            )?;
+            writeln!(
+                f,
+                "  This means the mint may withdraw {} funds from this account at {} time.",
+                style("all").bold(),
+                style("any").bold(),
+            )?;
+            writeln!(f, "  If this was not adequately disclosed to you, you may be dealing with a malicious mint.")?;
         }
 
         Ok(())

--- a/token/cli/src/sort.rs
+++ b/token/cli/src/sort.rs
@@ -76,6 +76,7 @@ pub(crate) fn sort_and_parse_token_accounts(
                         program_id: program_id.to_string(),
                         account: ui_token_account,
                         is_associated,
+                        has_permanent_delegate: false,
                     };
 
                     let entry = cli_accounts.entry(btree_key);


### PR DESCRIPTION
heres what the warning looks like, happy to debate wording:

![perm-del](https://user-images.githubusercontent.com/81144685/208554269-1aec37bd-5c94-4d50-9168-406b248aa6ab.png)

part of #3771 