### PR TITLE
[confidential-extension] Restrict `InitializeMint` and `UpdateMint` instructions

### DIFF
--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -20,9 +20,9 @@ use {
     },
     spl_token_2022::{
         extension::{
-            confidential_transfer, cpi_guard, default_account_state, interest_bearing_mint,
-            memo_transfer, transfer_fee, BaseStateWithExtensions, ExtensionType,
-            StateWithExtensionsOwned,
+            confidential_transfer, confidential_transfer::EncryptionPubkey, cpi_guard,
+            default_account_state, interest_bearing_mint, memo_transfer, transfer_fee,
+            BaseStateWithExtensions, ExtensionType, StateWithExtensionsOwned,
         },
         instruction,
         solana_zk_token_sdk::{
@@ -105,9 +105,9 @@ impl PartialEq for TokenError {
 pub enum ExtensionInitializationParams {
     ConfidentialTransferMint {
         authority: Option<Pubkey>,
-        auto_approve_new_account: bool,
-        auditor_encryption_pubkey: ElGamalPubkey,
-        withdraw_withheld_authority_encryption_pubkey: ElGamalPubkey,
+        auto_approve_new_accounts: bool,
+        auditor_encryption_pubkey: EncryptionPubkey,
+        withdraw_withheld_authority_encryption_pubkey: EncryptionPubkey,
     },
     DefaultAccountState {
         state: AccountState,
@@ -152,14 +152,14 @@ impl ExtensionInitializationParams {
         match self {
             Self::ConfidentialTransferMint {
                 authority,
-                auto_approve_new_account,
+                auto_approve_new_accounts,
                 auditor_encryption_pubkey,
                 withdraw_withheld_authority_encryption_pubkey,
             } => confidential_transfer::instruction::initialize_mint(
                 token_program_id,
                 mint,
                 authority.as_ref(),
-                auto_approve_new_account,
+                auto_approve_new_accounts,
                 &auditor_encryption_pubkey,
                 &withdraw_withheld_authority_encryption_pubkey,
             ),
@@ -1492,7 +1492,7 @@ where
         authority: &S,
         new_authority: Option<&S>,
         auto_approve_new_account: bool,
-        auditor_encryption_pubkey: &ElGamalPubkey,
+        auditor_encryption_pubkey: &EncryptionPubkey,
     ) -> TokenResult<T::Output> {
         let mut signers = vec![authority];
         let new_authority_pubkey = if let Some(new_authority) = new_authority {

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -1481,19 +1481,26 @@ where
     pub async fn confidential_transfer_update_mint<S: Signer>(
         &self,
         authority: &S,
-        new_ct_mint: confidential_transfer::ConfidentialTransferMint,
         new_authority: Option<&S>,
+        auto_approve_new_account: bool,
+        auditor_encryption_pubkey: &ElGamalPubkey,
     ) -> TokenResult<T::Output> {
         let mut signers = vec![authority];
-        if let Some(new_authority) = new_authority {
+        let new_authority_pubkey = if let Some(new_authority) = new_authority {
             signers.push(new_authority);
-        }
+            Some(new_authority.pubkey())
+        } else {
+            None
+        };
+
         self.process_ixs(
             &[confidential_transfer::instruction::update_mint(
                 &self.program_id,
                 &self.pubkey,
-                &new_ct_mint,
                 &authority.pubkey(),
+                new_authority_pubkey.as_ref(),
+                auto_approve_new_account,
+                auditor_encryption_pubkey,
             )?],
             &signers,
         )

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -104,7 +104,10 @@ impl PartialEq for TokenError {
 #[derive(Clone, Debug, PartialEq)]
 pub enum ExtensionInitializationParams {
     ConfidentialTransferMint {
-        ct_mint: confidential_transfer::ConfidentialTransferMint,
+        authority: Option<Pubkey>,
+        auto_approve_new_account: bool,
+        auditor_encryption_pubkey: ElGamalPubkey,
+        withdraw_withheld_authority_encryption_pubkey: ElGamalPubkey,
     },
     DefaultAccountState {
         state: AccountState,
@@ -147,13 +150,19 @@ impl ExtensionInitializationParams {
         mint: &Pubkey,
     ) -> Result<Instruction, ProgramError> {
         match self {
-            Self::ConfidentialTransferMint { ct_mint } => {
-                confidential_transfer::instruction::initialize_mint(
-                    token_program_id,
-                    mint,
-                    &ct_mint,
-                )
-            }
+            Self::ConfidentialTransferMint {
+                authority,
+                auto_approve_new_account,
+                auditor_encryption_pubkey,
+                withdraw_withheld_authority_encryption_pubkey,
+            } => confidential_transfer::instruction::initialize_mint(
+                token_program_id,
+                mint,
+                authority.as_ref(),
+                auto_approve_new_account,
+                &auditor_encryption_pubkey,
+                &withdraw_withheld_authority_encryption_pubkey,
+            ),
             Self::DefaultAccountState { state } => {
                 default_account_state::instruction::initialize_default_account_state(
                     token_program_id,

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -306,8 +306,12 @@ async fn ct_initialize_and_update_mint() {
     let err = token
         .confidential_transfer_update_mint(
             &wrong_keypair,
-            new_ct_mint,
             Some(&new_ct_mint_authority),
+            new_ct_mint.auto_approve_new_accounts.into(),
+            &new_ct_mint
+                .withdraw_withheld_authority_encryption_pubkey
+                .try_into()
+                .unwrap(),
         )
         .await
         .unwrap_err();
@@ -320,26 +324,64 @@ async fn ct_initialize_and_update_mint() {
     token
         .confidential_transfer_update_mint(
             &ct_mint_authority,
-            new_ct_mint,
             Some(&new_ct_mint_authority),
+            new_ct_mint.auto_approve_new_accounts.into(),
+            &new_ct_mint
+                .withdraw_withheld_authority_encryption_pubkey
+                .try_into()
+                .unwrap(),
         )
         .await
         .unwrap();
 
     let state = token.get_mint_info().await.unwrap();
     let extension = state.get_extension::<ConfidentialTransferMint>().unwrap();
-    assert_eq!(*extension, new_ct_mint);
+    assert_eq!(extension.authority, new_ct_mint.authority);
+    assert_eq!(
+        extension.auto_approve_new_accounts,
+        new_ct_mint.auto_approve_new_accounts
+    );
+    assert_eq!(
+        extension.auditor_encryption_pubkey,
+        new_ct_mint.auditor_encryption_pubkey
+    );
+    assert_eq!(
+        extension.withdraw_withheld_authority_encryption_pubkey,
+        ct_mint.withdraw_withheld_authority_encryption_pubkey,
+    );
+    assert_eq!(extension.withheld_amount, ct_mint.withheld_amount);
 
     // Clear the authority
     let new_ct_mint = ConfidentialTransferMint::default();
     token
-        .confidential_transfer_update_mint(&new_ct_mint_authority, new_ct_mint, None)
+        .confidential_transfer_update_mint(
+            &new_ct_mint_authority,
+            None,
+            new_ct_mint.auto_approve_new_accounts.into(),
+            &new_ct_mint
+                .withdraw_withheld_authority_encryption_pubkey
+                .try_into()
+                .unwrap(),
+        )
         .await
         .unwrap();
 
     let state = token.get_mint_info().await.unwrap();
     let extension = state.get_extension::<ConfidentialTransferMint>().unwrap();
-    assert_eq!(*extension, new_ct_mint);
+    assert_eq!(extension.authority, new_ct_mint.authority);
+    assert_eq!(
+        extension.auto_approve_new_accounts,
+        new_ct_mint.auto_approve_new_accounts
+    );
+    assert_eq!(
+        extension.auditor_encryption_pubkey,
+        new_ct_mint.auditor_encryption_pubkey
+    );
+    assert_eq!(
+        extension.withdraw_withheld_authority_encryption_pubkey,
+        ct_mint.withdraw_withheld_authority_encryption_pubkey,
+    );
+    assert_eq!(extension.withheld_amount, ct_mint.withheld_amount);
 }
 
 #[tokio::test]

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -285,7 +285,13 @@ async fn ct_initialize_and_update_mint() {
     let mut context = TestContext::new().await;
     context
         .init_token_with_mint(vec![
-            ExtensionInitializationParams::ConfidentialTransferMint { ct_mint },
+            ExtensionInitializationParams::ConfidentialTransferMint {
+                authority: Some(ct_mint.authority),
+                auto_approve_new_accounts: ct_mint.auto_approve_new_accounts.try_into().unwrap(),
+                auditor_encryption_pubkey: ct_mint.auditor_encryption_pubkey,
+                withdraw_withheld_authority_encryption_pubkey: ct_mint
+                    .withdraw_withheld_authority_encryption_pubkey,
+            },
         ])
         .await
         .unwrap();
@@ -395,7 +401,13 @@ async fn ct_configure_token_account() {
     let mut context = TestContext::new().await;
     context
         .init_token_with_mint(vec![
-            ExtensionInitializationParams::ConfidentialTransferMint { ct_mint },
+            ExtensionInitializationParams::ConfidentialTransferMint {
+                authority: Some(ct_mint.authority),
+                auto_approve_new_accounts: ct_mint.auto_approve_new_accounts.try_into().unwrap(),
+                auditor_encryption_pubkey: ct_mint.auditor_encryption_pubkey,
+                withdraw_withheld_authority_encryption_pubkey: ct_mint
+                    .withdraw_withheld_authority_encryption_pubkey,
+            },
         ])
         .await
         .unwrap();
@@ -466,7 +478,13 @@ async fn ct_enable_disable_confidential_credits() {
     let mut context = TestContext::new().await;
     context
         .init_token_with_mint(vec![
-            ExtensionInitializationParams::ConfidentialTransferMint { ct_mint },
+            ExtensionInitializationParams::ConfidentialTransferMint {
+                authority: Some(ct_mint.authority),
+                auto_approve_new_accounts: ct_mint.auto_approve_new_accounts.try_into().unwrap(),
+                auditor_encryption_pubkey: ct_mint.auditor_encryption_pubkey,
+                withdraw_withheld_authority_encryption_pubkey: ct_mint
+                    .withdraw_withheld_authority_encryption_pubkey,
+            },
         ])
         .await
         .unwrap();
@@ -508,7 +526,13 @@ async fn ct_enable_disable_non_confidential_credits() {
     let mut context = TestContext::new().await;
     context
         .init_token_with_mint(vec![
-            ExtensionInitializationParams::ConfidentialTransferMint { ct_mint },
+            ExtensionInitializationParams::ConfidentialTransferMint {
+                authority: Some(ct_mint.authority),
+                auto_approve_new_accounts: ct_mint.auto_approve_new_accounts.try_into().unwrap(),
+                auditor_encryption_pubkey: ct_mint.auditor_encryption_pubkey,
+                withdraw_withheld_authority_encryption_pubkey: ct_mint
+                    .withdraw_withheld_authority_encryption_pubkey,
+            },
         ])
         .await
         .unwrap();
@@ -599,7 +623,13 @@ async fn ct_new_account_is_empty() {
     let mut context = TestContext::new().await;
     context
         .init_token_with_mint(vec![
-            ExtensionInitializationParams::ConfidentialTransferMint { ct_mint },
+            ExtensionInitializationParams::ConfidentialTransferMint {
+                authority: Some(ct_mint.authority),
+                auto_approve_new_accounts: ct_mint.auto_approve_new_accounts.try_into().unwrap(),
+                auditor_encryption_pubkey: ct_mint.auditor_encryption_pubkey,
+                withdraw_withheld_authority_encryption_pubkey: ct_mint
+                    .withdraw_withheld_authority_encryption_pubkey,
+            },
         ])
         .await
         .unwrap();
@@ -621,7 +651,13 @@ async fn ct_deposit() {
     let mut context = TestContext::new().await;
     context
         .init_token_with_mint(vec![
-            ExtensionInitializationParams::ConfidentialTransferMint { ct_mint },
+            ExtensionInitializationParams::ConfidentialTransferMint {
+                authority: Some(ct_mint.authority),
+                auto_approve_new_accounts: ct_mint.auto_approve_new_accounts.try_into().unwrap(),
+                auditor_encryption_pubkey: ct_mint.auditor_encryption_pubkey,
+                withdraw_withheld_authority_encryption_pubkey: ct_mint
+                    .withdraw_withheld_authority_encryption_pubkey,
+            },
         ])
         .await
         .unwrap();
@@ -745,7 +781,13 @@ async fn ct_withdraw() {
     let mut context = TestContext::new().await;
     context
         .init_token_with_mint(vec![
-            ExtensionInitializationParams::ConfidentialTransferMint { ct_mint },
+            ExtensionInitializationParams::ConfidentialTransferMint {
+                authority: Some(ct_mint.authority),
+                auto_approve_new_accounts: ct_mint.auto_approve_new_accounts.try_into().unwrap(),
+                auditor_encryption_pubkey: ct_mint.auditor_encryption_pubkey,
+                withdraw_withheld_authority_encryption_pubkey: ct_mint
+                    .withdraw_withheld_authority_encryption_pubkey,
+            },
         ])
         .await
         .unwrap();
@@ -848,7 +890,13 @@ async fn ct_transfer() {
     let mut context = TestContext::new().await;
     context
         .init_token_with_mint(vec![
-            ExtensionInitializationParams::ConfidentialTransferMint { ct_mint },
+            ExtensionInitializationParams::ConfidentialTransferMint {
+                authority: Some(ct_mint.authority),
+                auto_approve_new_accounts: ct_mint.auto_approve_new_accounts.try_into().unwrap(),
+                auditor_encryption_pubkey: ct_mint.auditor_encryption_pubkey,
+                withdraw_withheld_authority_encryption_pubkey: ct_mint
+                    .withdraw_withheld_authority_encryption_pubkey,
+            },
         ])
         .await
         .unwrap();
@@ -1086,7 +1134,13 @@ async fn ct_transfer_with_fee() {
                 transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
                 maximum_fee: TEST_MAXIMUM_FEE,
             },
-            ExtensionInitializationParams::ConfidentialTransferMint { ct_mint },
+            ExtensionInitializationParams::ConfidentialTransferMint {
+                authority: Some(ct_mint.authority),
+                auto_approve_new_accounts: ct_mint.auto_approve_new_accounts.try_into().unwrap(),
+                auditor_encryption_pubkey: ct_mint.auditor_encryption_pubkey,
+                withdraw_withheld_authority_encryption_pubkey: ct_mint
+                    .withdraw_withheld_authority_encryption_pubkey,
+            },
         ])
         .await
         .unwrap();
@@ -1304,7 +1358,13 @@ async fn ct_withdraw_withheld_tokens_from_mint() {
                 transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
                 maximum_fee: TEST_MAXIMUM_FEE,
             },
-            ExtensionInitializationParams::ConfidentialTransferMint { ct_mint },
+            ExtensionInitializationParams::ConfidentialTransferMint {
+                authority: Some(ct_mint.authority),
+                auto_approve_new_accounts: ct_mint.auto_approve_new_accounts.try_into().unwrap(),
+                auditor_encryption_pubkey: ct_mint.auditor_encryption_pubkey,
+                withdraw_withheld_authority_encryption_pubkey: ct_mint
+                    .withdraw_withheld_authority_encryption_pubkey,
+            },
         ])
         .await
         .unwrap();
@@ -1460,7 +1520,13 @@ async fn ct_withdraw_withheld_tokens_from_accounts() {
                 transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
                 maximum_fee: TEST_MAXIMUM_FEE,
             },
-            ExtensionInitializationParams::ConfidentialTransferMint { ct_mint },
+            ExtensionInitializationParams::ConfidentialTransferMint {
+                authority: Some(ct_mint.authority),
+                auto_approve_new_accounts: ct_mint.auto_approve_new_accounts.try_into().unwrap(),
+                auditor_encryption_pubkey: ct_mint.auditor_encryption_pubkey,
+                withdraw_withheld_authority_encryption_pubkey: ct_mint
+                    .withdraw_withheld_authority_encryption_pubkey,
+            },
         ])
         .await
         .unwrap();
@@ -1567,7 +1633,13 @@ async fn ct_transfer_memo() {
     let mut context = TestContext::new().await;
     context
         .init_token_with_mint(vec![
-            ExtensionInitializationParams::ConfidentialTransferMint { ct_mint },
+            ExtensionInitializationParams::ConfidentialTransferMint {
+                authority: Some(ct_mint.authority),
+                auto_approve_new_accounts: ct_mint.auto_approve_new_accounts.try_into().unwrap(),
+                auditor_encryption_pubkey: ct_mint.auditor_encryption_pubkey,
+                withdraw_withheld_authority_encryption_pubkey: ct_mint
+                    .withdraw_withheld_authority_encryption_pubkey,
+            },
         ])
         .await
         .unwrap();
@@ -1675,7 +1747,13 @@ async fn ct_transfer_with_fee_memo() {
                 transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
                 maximum_fee: TEST_MAXIMUM_FEE,
             },
-            ExtensionInitializationParams::ConfidentialTransferMint { ct_mint },
+            ExtensionInitializationParams::ConfidentialTransferMint {
+                authority: Some(ct_mint.authority),
+                auto_approve_new_accounts: ct_mint.auto_approve_new_accounts.try_into().unwrap(),
+                auditor_encryption_pubkey: ct_mint.auditor_encryption_pubkey,
+                withdraw_withheld_authority_encryption_pubkey: ct_mint
+                    .withdraw_withheld_authority_encryption_pubkey,
+            },
         ])
         .await
         .unwrap();

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -1,5 +1,5 @@
 #[cfg(not(target_os = "solana"))]
-use solana_zk_token_sdk::encryption::{auth_encryption::AeCiphertext, elgamal::ElGamalPubkey};
+use solana_zk_token_sdk::encryption::auth_encryption::AeCiphertext;
 pub use solana_zk_token_sdk::zk_token_proof_instruction::*;
 use {
     crate::{
@@ -549,8 +549,8 @@ pub fn initialize_mint(
     mint: &Pubkey,
     authority: Option<&Pubkey>,
     auto_approve_new_accounts: bool,
-    auditor_encryption_pubkey: &ElGamalPubkey,
-    withdraw_withheld_authority_encryption_pubkey: &ElGamalPubkey,
+    auditor_encryption_pubkey: &EncryptionPubkey,
+    withdraw_withheld_authority_encryption_pubkey: &EncryptionPubkey,
 ) -> Result<Instruction, ProgramError> {
     check_program_account(token_program_id)?;
     let accounts = vec![AccountMeta::new(*mint, false)];
@@ -570,9 +570,9 @@ pub fn initialize_mint(
         &InitializeMintData {
             authority,
             auto_approve_new_accounts: auto_approve_new_accounts.into(),
-            auditor_encryption_pubkey: (*auditor_encryption_pubkey).into(),
+            auditor_encryption_pubkey: *auditor_encryption_pubkey,
             withdraw_withheld_authority_encryption_pubkey:
-                (*withdraw_withheld_authority_encryption_pubkey).into(),
+                *withdraw_withheld_authority_encryption_pubkey,
         },
     ))
 }
@@ -585,7 +585,7 @@ pub fn update_mint(
     authority: &Pubkey,
     new_authority: Option<&Pubkey>,
     auto_approve_new_accounts: bool,
-    auditor_encryption_pubkey: &ElGamalPubkey,
+    auditor_encryption_pubkey: &EncryptionPubkey,
 ) -> Result<Instruction, ProgramError> {
     check_program_account(token_program_id)?;
 
@@ -606,7 +606,7 @@ pub fn update_mint(
         ConfidentialTransferInstruction::UpdateMint,
         &UpdateMintData {
             auto_approve_new_accounts: auto_approve_new_accounts.into(),
-            auditor_encryption_pubkey: (*auditor_encryption_pubkey).into(),
+            auditor_encryption_pubkey: *auditor_encryption_pubkey,
         },
     ))
 }

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -55,7 +55,10 @@ fn decode_proof_instruction<T: Pod>(
 /// Processes an [InitializeMint] instruction.
 fn process_initialize_mint(
     accounts: &[AccountInfo],
-    confidential_transfer_mint: &ConfidentialTransferMint,
+    authority: &Pubkey,
+    auto_approve_new_account: PodBool,
+    auditor_encryption_pubkey: &EncryptionPubkey,
+    withdraw_withheld_authority_encryption_pubkey: &EncryptionPubkey,
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
     let mint_info = next_account_info(account_info_iter)?;
@@ -63,7 +66,14 @@ fn process_initialize_mint(
     check_program_account(mint_info.owner)?;
     let mint_data = &mut mint_info.data.borrow_mut();
     let mut mint = StateWithExtensionsMut::<Mint>::unpack_uninitialized(mint_data)?;
-    *mint.init_extension::<ConfidentialTransferMint>(true)? = *confidential_transfer_mint;
+    let confidential_transfer_mint = mint.init_extension::<ConfidentialTransferMint>(true)?;
+
+    confidential_transfer_mint.authority = *authority;
+    confidential_transfer_mint.auto_approve_new_accounts = auto_approve_new_account;
+    confidential_transfer_mint.auditor_encryption_pubkey = *auditor_encryption_pubkey;
+    confidential_transfer_mint.withdraw_withheld_authority_encryption_pubkey =
+        *withdraw_withheld_authority_encryption_pubkey;
+    confidential_transfer_mint.withheld_amount = EncryptedWithheldAmount::zeroed();
 
     Ok(())
 }
@@ -1182,9 +1192,13 @@ pub(crate) fn process_instruction(
     match decode_instruction_type(input)? {
         ConfidentialTransferInstruction::InitializeMint => {
             msg!("ConfidentialTransferInstruction::InitializeMint");
+            let data = decode_instruction_data::<InitializeMintData>(input)?;
             process_initialize_mint(
                 accounts,
-                decode_instruction_data::<ConfidentialTransferMint>(input)?,
+                &data.authority,
+                data.auto_approve_new_accounts,
+                &data.auditor_encryption_pubkey,
+                &data.withdraw_withheld_authority_encryption_pubkey,
             )
         }
         ConfidentialTransferInstruction::UpdateMint => {


### PR DESCRIPTION
#### Problem
Currently, the `InitializeMint` instruction allows the initiator to submit the entire `ConfidentialTransferMint` state, allowing it to instantiate `withheld_amount` to any ciphertext. This allows the initiator to potentially create new tokens confidentially without affecting the mint.

The `UpdateMint` instruction allows the authority to change the `withdraw_withheld_authority_encryption_pubkey` and `withheld_amount`. As in `InitializeMint`, the authority could potentially overwrite the withheld amount and create or burn tokens privately without being detected.

#### Summary of changes
This PR restricts the two instructions above. For `InitializeMint`, the initial `withheld_amount` is always set to be the zeroed ciphertext. For `UpdateMint`, modify it so that it does not affect `withdraw_withheld_authority_encryption_pubkey` and `withheld_amount`.