### PR TITLE
[confidential-extension] Use `OptionalNonZeroPubkey` and `OptionalNonZeroEncryptionPubkey` for confidential extension

### DIFF
--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -158,7 +158,7 @@ impl ExtensionInitializationParams {
             } => confidential_transfer::instruction::initialize_mint(
                 token_program_id,
                 mint,
-                authority.as_ref(),
+                authority,
                 auto_approve_new_accounts,
                 &auditor_encryption_pubkey,
                 &withdraw_withheld_authority_encryption_pubkey,

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -65,7 +65,7 @@ impl ConfidentialTransferMintWithKeypairs {
         let ct_mint_transfer_auditor_encryption_keypair = ElGamalKeypair::new_rand();
         let ct_mint_withdraw_withheld_authority_encryption_keypair = ElGamalKeypair::new_rand();
         let ct_mint = ConfidentialTransferMint {
-            authority: ct_mint_authority.pubkey(),
+            authority: Some(ct_mint_authority.pubkey()).try_into().unwrap(),
             auto_approve_new_accounts: true.into(),
             auditor_encryption_pubkey: ct_mint_transfer_auditor_encryption_keypair.public.into(),
             withdraw_withheld_authority_encryption_pubkey:
@@ -286,7 +286,7 @@ async fn ct_initialize_and_update_mint() {
     context
         .init_token_with_mint(vec![
             ExtensionInitializationParams::ConfidentialTransferMint {
-                authority: Some(ct_mint.authority),
+                authority: ct_mint.authority.into(),
                 auto_approve_new_accounts: ct_mint.auto_approve_new_accounts.try_into().unwrap(),
                 auditor_encryption_pubkey: ct_mint.auditor_encryption_pubkey,
                 withdraw_withheld_authority_encryption_pubkey: ct_mint
@@ -305,7 +305,7 @@ async fn ct_initialize_and_update_mint() {
     // Change the authority
     let new_ct_mint_authority = Keypair::new();
     let new_ct_mint = ConfidentialTransferMint {
-        authority: new_ct_mint_authority.pubkey(),
+        authority: Some(new_ct_mint_authority.pubkey()).try_into().unwrap(),
         ..ConfidentialTransferMint::default()
     };
 
@@ -402,7 +402,7 @@ async fn ct_configure_token_account() {
     context
         .init_token_with_mint(vec![
             ExtensionInitializationParams::ConfidentialTransferMint {
-                authority: Some(ct_mint.authority),
+                authority: ct_mint.authority.into(),
                 auto_approve_new_accounts: ct_mint.auto_approve_new_accounts.try_into().unwrap(),
                 auditor_encryption_pubkey: ct_mint.auditor_encryption_pubkey,
                 withdraw_withheld_authority_encryption_pubkey: ct_mint
@@ -479,7 +479,7 @@ async fn ct_enable_disable_confidential_credits() {
     context
         .init_token_with_mint(vec![
             ExtensionInitializationParams::ConfidentialTransferMint {
-                authority: Some(ct_mint.authority),
+                authority: ct_mint.authority.into(),
                 auto_approve_new_accounts: ct_mint.auto_approve_new_accounts.try_into().unwrap(),
                 auditor_encryption_pubkey: ct_mint.auditor_encryption_pubkey,
                 withdraw_withheld_authority_encryption_pubkey: ct_mint
@@ -527,7 +527,7 @@ async fn ct_enable_disable_non_confidential_credits() {
     context
         .init_token_with_mint(vec![
             ExtensionInitializationParams::ConfidentialTransferMint {
-                authority: Some(ct_mint.authority),
+                authority: ct_mint.authority.into(),
                 auto_approve_new_accounts: ct_mint.auto_approve_new_accounts.try_into().unwrap(),
                 auditor_encryption_pubkey: ct_mint.auditor_encryption_pubkey,
                 withdraw_withheld_authority_encryption_pubkey: ct_mint
@@ -624,7 +624,7 @@ async fn ct_new_account_is_empty() {
     context
         .init_token_with_mint(vec![
             ExtensionInitializationParams::ConfidentialTransferMint {
-                authority: Some(ct_mint.authority),
+                authority: ct_mint.authority.into(),
                 auto_approve_new_accounts: ct_mint.auto_approve_new_accounts.try_into().unwrap(),
                 auditor_encryption_pubkey: ct_mint.auditor_encryption_pubkey,
                 withdraw_withheld_authority_encryption_pubkey: ct_mint
@@ -652,7 +652,7 @@ async fn ct_deposit() {
     context
         .init_token_with_mint(vec![
             ExtensionInitializationParams::ConfidentialTransferMint {
-                authority: Some(ct_mint.authority),
+                authority: ct_mint.authority.into(),
                 auto_approve_new_accounts: ct_mint.auto_approve_new_accounts.try_into().unwrap(),
                 auditor_encryption_pubkey: ct_mint.auditor_encryption_pubkey,
                 withdraw_withheld_authority_encryption_pubkey: ct_mint
@@ -782,7 +782,7 @@ async fn ct_withdraw() {
     context
         .init_token_with_mint(vec![
             ExtensionInitializationParams::ConfidentialTransferMint {
-                authority: Some(ct_mint.authority),
+                authority: ct_mint.authority.into(),
                 auto_approve_new_accounts: ct_mint.auto_approve_new_accounts.try_into().unwrap(),
                 auditor_encryption_pubkey: ct_mint.auditor_encryption_pubkey,
                 withdraw_withheld_authority_encryption_pubkey: ct_mint
@@ -891,7 +891,7 @@ async fn ct_transfer() {
     context
         .init_token_with_mint(vec![
             ExtensionInitializationParams::ConfidentialTransferMint {
-                authority: Some(ct_mint.authority),
+                authority: ct_mint.authority.into(),
                 auto_approve_new_accounts: ct_mint.auto_approve_new_accounts.try_into().unwrap(),
                 auditor_encryption_pubkey: ct_mint.auditor_encryption_pubkey,
                 withdraw_withheld_authority_encryption_pubkey: ct_mint
@@ -1135,7 +1135,7 @@ async fn ct_transfer_with_fee() {
                 maximum_fee: TEST_MAXIMUM_FEE,
             },
             ExtensionInitializationParams::ConfidentialTransferMint {
-                authority: Some(ct_mint.authority),
+                authority: ct_mint.authority.into(),
                 auto_approve_new_accounts: ct_mint.auto_approve_new_accounts.try_into().unwrap(),
                 auditor_encryption_pubkey: ct_mint.auditor_encryption_pubkey,
                 withdraw_withheld_authority_encryption_pubkey: ct_mint
@@ -1359,7 +1359,7 @@ async fn ct_withdraw_withheld_tokens_from_mint() {
                 maximum_fee: TEST_MAXIMUM_FEE,
             },
             ExtensionInitializationParams::ConfidentialTransferMint {
-                authority: Some(ct_mint.authority),
+                authority: ct_mint.authority.into(),
                 auto_approve_new_accounts: ct_mint.auto_approve_new_accounts.try_into().unwrap(),
                 auditor_encryption_pubkey: ct_mint.auditor_encryption_pubkey,
                 withdraw_withheld_authority_encryption_pubkey: ct_mint
@@ -1521,7 +1521,7 @@ async fn ct_withdraw_withheld_tokens_from_accounts() {
                 maximum_fee: TEST_MAXIMUM_FEE,
             },
             ExtensionInitializationParams::ConfidentialTransferMint {
-                authority: Some(ct_mint.authority),
+                authority: ct_mint.authority.into(),
                 auto_approve_new_accounts: ct_mint.auto_approve_new_accounts.try_into().unwrap(),
                 auditor_encryption_pubkey: ct_mint.auditor_encryption_pubkey,
                 withdraw_withheld_authority_encryption_pubkey: ct_mint
@@ -1634,7 +1634,7 @@ async fn ct_transfer_memo() {
     context
         .init_token_with_mint(vec![
             ExtensionInitializationParams::ConfidentialTransferMint {
-                authority: Some(ct_mint.authority),
+                authority: ct_mint.authority.into(),
                 auto_approve_new_accounts: ct_mint.auto_approve_new_accounts.try_into().unwrap(),
                 auditor_encryption_pubkey: ct_mint.auditor_encryption_pubkey,
                 withdraw_withheld_authority_encryption_pubkey: ct_mint
@@ -1748,7 +1748,7 @@ async fn ct_transfer_with_fee_memo() {
                 maximum_fee: TEST_MAXIMUM_FEE,
             },
             ExtensionInitializationParams::ConfidentialTransferMint {
-                authority: Some(ct_mint.authority),
+                authority: ct_mint.authority.into(),
                 auto_approve_new_accounts: ct_mint.auto_approve_new_accounts.try_into().unwrap(),
                 auditor_encryption_pubkey: ct_mint.auditor_encryption_pubkey,
                 withdraw_withheld_authority_encryption_pubkey: ct_mint

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -431,7 +431,7 @@ pub enum ConfidentialTransferInstruction {
 pub struct InitializeMintData {
     /// Authority to modify the `ConfidentialTransferMint` configuration and to approve new
     /// accounts.
-    pub authority: Pubkey,
+    pub authority: OptionalNonZeroPubkey,
     /// Determines if newly configured accounts must be approved by the `authority` before they may
     /// be used by the user.
     pub auto_approve_new_accounts: PodBool,
@@ -547,7 +547,7 @@ pub struct WithdrawWithheldTokensFromAccountsData {
 pub fn initialize_mint(
     token_program_id: &Pubkey,
     mint: &Pubkey,
-    authority: Option<&Pubkey>,
+    authority: Option<Pubkey>,
     auto_approve_new_accounts: bool,
     auditor_encryption_pubkey: &EncryptionPubkey,
     withdraw_withheld_authority_encryption_pubkey: &EncryptionPubkey,
@@ -555,20 +555,13 @@ pub fn initialize_mint(
     check_program_account(token_program_id)?;
     let accounts = vec![AccountMeta::new(*mint, false)];
 
-    // TODO: use `OptionalNonZeroPubkey`
-    let authority = if let Some(authority) = authority {
-        *authority
-    } else {
-        Pubkey::default()
-    };
-
     Ok(encode_instruction(
         token_program_id,
         accounts,
         TokenInstruction::ConfidentialTransferExtension,
         ConfidentialTransferInstruction::InitializeMint,
         &InitializeMintData {
-            authority,
+            authority: authority.try_into()?,
             auto_approve_new_accounts: auto_approve_new_accounts.into(),
             auditor_encryption_pubkey: *auditor_encryption_pubkey,
             withdraw_withheld_authority_encryption_pubkey:

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -436,9 +436,9 @@ pub struct InitializeMintData {
     /// be used by the user.
     pub auto_approve_new_accounts: PodBool,
     /// New authority to decode any transfer amount in a confidential transfer.
-    pub auditor_encryption_pubkey: EncryptionPubkey,
+    pub auditor_encryption_pubkey: OptionalNonZeroEncryptionPubkey,
     /// Authority to withdraw withheld fees that are associated with accounts.
-    pub withdraw_withheld_authority_encryption_pubkey: EncryptionPubkey,
+    pub withdraw_withheld_authority_encryption_pubkey: OptionalNonZeroEncryptionPubkey,
 }
 
 /// Data expected by `ConfidentialTransferInstruction::UpdateMint`
@@ -449,7 +449,7 @@ pub struct UpdateMintData {
     /// be used by the user.
     pub auto_approve_new_accounts: PodBool,
     /// New authority to decode any transfer amount in a confidential transfer.
-    pub auditor_encryption_pubkey: EncryptionPubkey,
+    pub auditor_encryption_pubkey: OptionalNonZeroEncryptionPubkey,
 }
 
 /// Data expected by `ConfidentialTransferInstruction::ConfigureAccount`
@@ -549,8 +549,8 @@ pub fn initialize_mint(
     mint: &Pubkey,
     authority: Option<Pubkey>,
     auto_approve_new_accounts: bool,
-    auditor_encryption_pubkey: &EncryptionPubkey,
-    withdraw_withheld_authority_encryption_pubkey: &EncryptionPubkey,
+    auditor_encryption_pubkey: Option<EncryptionPubkey>,
+    withdraw_withheld_authority_encryption_pubkey: Option<EncryptionPubkey>,
 ) -> Result<Instruction, ProgramError> {
     check_program_account(token_program_id)?;
     let accounts = vec![AccountMeta::new(*mint, false)];
@@ -563,9 +563,9 @@ pub fn initialize_mint(
         &InitializeMintData {
             authority: authority.try_into()?,
             auto_approve_new_accounts: auto_approve_new_accounts.into(),
-            auditor_encryption_pubkey: *auditor_encryption_pubkey,
+            auditor_encryption_pubkey: auditor_encryption_pubkey.try_into()?,
             withdraw_withheld_authority_encryption_pubkey:
-                *withdraw_withheld_authority_encryption_pubkey,
+                withdraw_withheld_authority_encryption_pubkey.try_into()?,
         },
     ))
 }
@@ -578,7 +578,7 @@ pub fn update_mint(
     authority: &Pubkey,
     new_authority: Option<&Pubkey>,
     auto_approve_new_accounts: bool,
-    auditor_encryption_pubkey: &EncryptionPubkey,
+    auditor_encryption_pubkey: Option<EncryptionPubkey>,
 ) -> Result<Instruction, ProgramError> {
     check_program_account(token_program_id)?;
 
@@ -599,7 +599,7 @@ pub fn update_mint(
         ConfidentialTransferInstruction::UpdateMint,
         &UpdateMintData {
             auto_approve_new_accounts: auto_approve_new_accounts.into(),
-            auditor_encryption_pubkey: *auditor_encryption_pubkey,
+            auditor_encryption_pubkey: auditor_encryption_pubkey.try_into()?,
         },
     ))
 }

--- a/token/program-2022/src/extension/confidential_transfer/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer/mod.rs
@@ -5,7 +5,7 @@ use {
         pod::*,
     },
     bytemuck::{Pod, Zeroable},
-    solana_program::{entrypoint::ProgramResult, pubkey::Pubkey},
+    solana_program::entrypoint::ProgramResult,
     solana_zk_token_sdk::zk_token_elgamal::pod,
 };
 
@@ -43,11 +43,8 @@ pub struct ConfidentialTransferMint {
     /// Authority to modify the `ConfidentialTransferMint` configuration and to approve new
     /// accounts (if `auto_approve_new_accounts` is true)
     ///
-    /// Note that setting an authority of `Pubkey::default()` is the idiomatic way to disable
-    /// future changes to the configuration.
-    ///
     /// The legacy Token Multisig account is not supported as the authority
-    pub authority: Pubkey,
+    pub authority: OptionalNonZeroPubkey,
 
     /// Indicate if newly configured accounts must be approved by the `authority` before they may be
     /// used by the user.

--- a/token/program-2022/src/extension/confidential_transfer/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer/mod.rs
@@ -25,8 +25,6 @@ pub mod instruction;
 /// Confidential Transfer Extension processor
 pub mod processor;
 
-/// ElGamal public key used for encryption
-pub type EncryptionPubkey = pod::ElGamalPubkey;
 /// ElGamal ciphertext containing an account balance
 pub type EncryptedBalance = pod::ElGamalCiphertext;
 /// Authenticated encryption containing an account balance
@@ -55,25 +53,21 @@ pub struct ConfidentialTransferMint {
     pub auto_approve_new_accounts: PodBool,
 
     /// Authority to decode any transfer amount in a confidential transafer.
-    ///
-    /// * If non-zero, transfers must include ElGamal cyphertext with this public key permitting the
-    /// auditor to decode the transfer amount.
-    /// * If all zero, auditing is currently disabled.
-    pub auditor_encryption_pubkey: EncryptionPubkey,
+    pub auditor_encryption_pubkey: OptionalNonZeroEncryptionPubkey,
 
-    /// Authority to withraw withheld fees that are associated with accounts. It must be set to an
-    /// all zero pubkey if the mint is not extended for fees.
+    /// Authority to withraw withheld fees that are associated with accounts. It must be set to
+    /// `None` if the mint is not extended for fees.
     ///
     /// Note that the withdraw withheld authority has the ability to decode any withheld fee
     /// amount that are associated with accounts. When combined with the fee parameters, the
     /// withheld fee amounts can reveal information about transfer amounts.
     ///
-    /// * If non-zero, transfers must include ElGamal cyphertext of the transfer fee with this
+    /// * If not `None`, transfers must include ElGamal cyphertext of the transfer fee with this
     /// public key. If this is the case, but the base mint is not extended for fees, then any
     /// transfer will fail.
-    /// * If all zero, transfer fee is disabled. If this is the case, but the base mint is extended
+    /// * If `None`, transfer fee is disabled. If this is the case, but the base mint is extended
     /// for fees, then any transfer will fail.
-    pub withdraw_withheld_authority_encryption_pubkey: EncryptionPubkey,
+    pub withdraw_withheld_authority_encryption_pubkey: OptionalNonZeroEncryptionPubkey,
 
     /// Withheld transfer fee confidential tokens that have been moved to the mint for withdrawal.
     /// This will always be zero if fees are never enabled.

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -55,7 +55,7 @@ fn decode_proof_instruction<T: Pod>(
 /// Processes an [InitializeMint] instruction.
 fn process_initialize_mint(
     accounts: &[AccountInfo],
-    authority: &Pubkey,
+    authority: &OptionalNonZeroPubkey,
     auto_approve_new_account: PodBool,
     auditor_encryption_pubkey: &EncryptionPubkey,
     withdraw_withheld_authority_encryption_pubkey: &EncryptionPubkey,
@@ -93,18 +93,26 @@ fn process_update_mint(
     let mint_data = &mut mint_info.data.borrow_mut();
     let mut mint = StateWithExtensionsMut::<Mint>::unpack(mint_data)?;
     let confidential_transfer_mint = mint.get_extension_mut::<ConfidentialTransferMint>()?;
+    let maybe_confidential_transfer_mint_authority: Option<Pubkey> =
+        confidential_transfer_mint.authority.into();
+    let confidential_transfer_mint_authority =
+        maybe_confidential_transfer_mint_authority.ok_or(TokenError::NoAuthorityExists)?;
 
-    if authority_info.is_signer
-        && confidential_transfer_mint.authority == *authority_info.key
-        && (new_authority_info.is_signer || *new_authority_info.key == Pubkey::default())
+    if !authority_info.is_signer
+        || confidential_transfer_mint_authority != *authority_info.key
+        || (!new_authority_info.is_signer && *new_authority_info.key != Pubkey::default())
     {
-        confidential_transfer_mint.authority = *new_authority_info.key;
-        confidential_transfer_mint.auto_approve_new_accounts = auto_approve_new_account;
-        confidential_transfer_mint.auditor_encryption_pubkey = *auditor_encryption_pubkey;
-        Ok(())
-    } else {
-        Err(ProgramError::MissingRequiredSignature)
+        return Err(ProgramError::MissingRequiredSignature);
     }
+
+    if *new_authority_info.key == Pubkey::default() {
+        confidential_transfer_mint.authority = None.try_into()?;
+    } else {
+        confidential_transfer_mint.authority = Some(*new_authority_info.key).try_into()?;
+    }
+    confidential_transfer_mint.auto_approve_new_accounts = auto_approve_new_account;
+    confidential_transfer_mint.auditor_encryption_pubkey = *auditor_encryption_pubkey;
+    Ok(())
 }
 
 /// Processes a [ConfigureAccount] instruction.
@@ -191,8 +199,12 @@ fn process_approve_account(accounts: &[AccountInfo]) -> ProgramResult {
     let mint_data = &mint_info.data.borrow_mut();
     let mint = StateWithExtensions::<Mint>::unpack(mint_data)?;
     let confidential_transfer_mint = mint.get_extension::<ConfidentialTransferMint>()?;
+    let maybe_confidential_transfer_mint_authority: Option<Pubkey> =
+        confidential_transfer_mint.authority.into();
+    let confidential_transfer_mint_authority =
+        maybe_confidential_transfer_mint_authority.ok_or(TokenError::NoAuthorityExists)?;
 
-    if authority_info.is_signer && *authority_info.key == confidential_transfer_mint.authority {
+    if authority_info.is_signer && *authority_info.key == confidential_transfer_mint_authority {
         let mut confidential_transfer_state =
             token_account.get_extension_mut::<ConfidentialTransferAccount>()?;
         confidential_transfer_state.approved = true.into();

--- a/token/program-2022/src/pod.rs
+++ b/token/program-2022/src/pod.rs
@@ -2,6 +2,7 @@
 use {
     bytemuck::{Pod, Zeroable},
     solana_program::{program_error::ProgramError, program_option::COption, pubkey::Pubkey},
+    solana_zk_token_sdk::zk_token_elgamal::pod,
     std::convert::TryFrom,
 };
 
@@ -52,6 +53,68 @@ impl From<OptionalNonZeroPubkey> for Option<Pubkey> {
 impl From<OptionalNonZeroPubkey> for COption<Pubkey> {
     fn from(p: OptionalNonZeroPubkey) -> Self {
         if p.0 == Pubkey::default() {
+            COption::None
+        } else {
+            COption::Some(p.0)
+        }
+    }
+}
+
+/// ElGamal public key used for encryption
+pub type EncryptionPubkey = pod::ElGamalPubkey;
+/// An EncryptionPubkey that encodes `None` as all `0`, meant to be usable as a Pod type.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+#[repr(transparent)]
+pub struct OptionalNonZeroEncryptionPubkey(EncryptionPubkey);
+impl OptionalNonZeroEncryptionPubkey {
+    /// Checks equality between an OptionalNonZeroEncryptionPubkey and an EncryptionPubkey when
+    /// itnerpretted as bytes.
+    pub fn equals(&self, other: &EncryptionPubkey) -> bool {
+        &self.0 == other
+    }
+}
+impl TryFrom<Option<EncryptionPubkey>> for OptionalNonZeroEncryptionPubkey {
+    type Error = ProgramError;
+    fn try_from(p: Option<EncryptionPubkey>) -> Result<Self, Self::Error> {
+        match p {
+            None => Ok(Self(EncryptionPubkey::default())),
+            Some(encryption_pubkey) => {
+                if encryption_pubkey == EncryptionPubkey::default() {
+                    Err(ProgramError::InvalidArgument)
+                } else {
+                    Ok(Self(encryption_pubkey))
+                }
+            }
+        }
+    }
+}
+impl TryFrom<COption<EncryptionPubkey>> for OptionalNonZeroEncryptionPubkey {
+    type Error = ProgramError;
+    fn try_from(p: COption<EncryptionPubkey>) -> Result<Self, Self::Error> {
+        match p {
+            COption::None => Ok(Self(EncryptionPubkey::default())),
+            COption::Some(encryption_pubkey) => {
+                if encryption_pubkey == EncryptionPubkey::default() {
+                    Err(ProgramError::InvalidArgument)
+                } else {
+                    Ok(Self(encryption_pubkey))
+                }
+            }
+        }
+    }
+}
+impl From<OptionalNonZeroEncryptionPubkey> for Option<EncryptionPubkey> {
+    fn from(p: OptionalNonZeroEncryptionPubkey) -> Self {
+        if p.0 == EncryptionPubkey::default() {
+            None
+        } else {
+            Some(p.0)
+        }
+    }
+}
+impl From<OptionalNonZeroEncryptionPubkey> for COption<EncryptionPubkey> {
+    fn from(p: OptionalNonZeroEncryptionPubkey) -> Self {
+        if p.0 == EncryptionPubkey::default() {
             COption::None
         } else {
             COption::Some(p.0)

--- a/token/program-2022/src/pod.rs
+++ b/token/program-2022/src/pod.rs
@@ -68,7 +68,7 @@ pub type EncryptionPubkey = pod::ElGamalPubkey;
 pub struct OptionalNonZeroEncryptionPubkey(EncryptionPubkey);
 impl OptionalNonZeroEncryptionPubkey {
     /// Checks equality between an OptionalNonZeroEncryptionPubkey and an EncryptionPubkey when
-    /// itnerpretted as bytes.
+    /// interpreted as bytes.
     pub fn equals(&self, other: &EncryptionPubkey) -> bool {
         &self.0 == other
     }

--- a/token/program-2022/src/pod.rs
+++ b/token/program-2022/src/pod.rs
@@ -88,36 +88,12 @@ impl TryFrom<Option<EncryptionPubkey>> for OptionalNonZeroEncryptionPubkey {
         }
     }
 }
-impl TryFrom<COption<EncryptionPubkey>> for OptionalNonZeroEncryptionPubkey {
-    type Error = ProgramError;
-    fn try_from(p: COption<EncryptionPubkey>) -> Result<Self, Self::Error> {
-        match p {
-            COption::None => Ok(Self(EncryptionPubkey::default())),
-            COption::Some(encryption_pubkey) => {
-                if encryption_pubkey == EncryptionPubkey::default() {
-                    Err(ProgramError::InvalidArgument)
-                } else {
-                    Ok(Self(encryption_pubkey))
-                }
-            }
-        }
-    }
-}
 impl From<OptionalNonZeroEncryptionPubkey> for Option<EncryptionPubkey> {
     fn from(p: OptionalNonZeroEncryptionPubkey) -> Self {
         if p.0 == EncryptionPubkey::default() {
             None
         } else {
             Some(p.0)
-        }
-    }
-}
-impl From<OptionalNonZeroEncryptionPubkey> for COption<EncryptionPubkey> {
-    fn from(p: OptionalNonZeroEncryptionPubkey) -> Self {
-        if p.0 == EncryptionPubkey::default() {
-            COption::None
-        } else {
-            COption::Some(p.0)
         }
     }
 }


### PR DESCRIPTION
Summary of changes:
- Add `OptionalNonZeroEncryptionPubkey` struct
- Use `OptionalNonZeroPubkey` and `OptionalNonZeroEncryptionPubkey` for the optional pubkey fields in the confidential extension mint

Closes issue #3941 