### PR TITLE
twotx: allow git to merge the twotx ci patch

### DIFF
--- a/token/twoxtx-setup.sh
+++ b/token/twoxtx-setup.sh
@@ -20,7 +20,7 @@ if [[ ! -d twoxtx-solana ]]; then
 fi
 
 if [[ ! -f twoxtx-solana/.twoxtx-patched ]]; then
-  git -C twoxtx-solana am "$PWD"/twoxtx.patch
+  git -C twoxtx-solana am -3 "$PWD"/twoxtx.patch
   touch twoxtx-solana/.twoxtx-patched
 fi
 


### PR DESCRIPTION
this should hopefully mean we dont need to update the file all the time. i was starting on an experiement to have the ci script merge from a special twotx branch into monorepo master, and get rid of the patch file, and discovered you can actually have git fall back on the merge algorithm when a patch file fails to apply