### PR TITLE
example: Token transfer with PDA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5905,6 +5905,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-example-transfer-tokens"
+version = "1.0.0"
+dependencies = [
+ "solana-program",
+ "solana-program-test",
+ "solana-sdk",
+ "spl-token 3.5.0",
+]
+
+[[package]]
 name = "spl-feature-proposal"
 version = "1.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "examples/rust/logging",
   "examples/rust/sysvar",
   "examples/rust/transfer-lamports",
+  "examples/rust/transfer-tokens",
   "feature-proposal/program",
   "feature-proposal/cli",
   "governance/addin-mock/program",

--- a/examples/rust/transfer-tokens/Cargo.toml
+++ b/examples/rust/transfer-tokens/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "spl-example-transfer-tokens"
+version = "1.0.0"
+description = "Solana Program Library Transfer Tokens Example"
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+repository = "https://github.com/solana-labs/solana-program-library"
+license = "Apache-2.0"
+edition = "2021"
+
+[features]
+no-entrypoint = []
+test-sbf = []
+
+[dependencies]
+solana-program = "1.14.10"
+spl-token = { version = "3.5", path = "../../../token/program", features = [ "no-entrypoint" ] }
+
+[dev-dependencies]
+solana-program-test = "1.14.10"
+solana-sdk = "1.14.10"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/examples/rust/transfer-tokens/src/entrypoint.rs
+++ b/examples/rust/transfer-tokens/src/entrypoint.rs
@@ -1,0 +1,16 @@
+//! Program entrypoint
+
+#![cfg(not(feature = "no-entrypoint"))]
+
+use solana_program::{
+    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
+};
+
+entrypoint!(process_instruction);
+fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    crate::processor::process_instruction(program_id, accounts, instruction_data)
+}

--- a/examples/rust/transfer-tokens/src/lib.rs
+++ b/examples/rust/transfer-tokens/src/lib.rs
@@ -1,0 +1,6 @@
+//! A program demonstrating the transfer of lamports
+#![deny(missing_docs)]
+#![forbid(unsafe_code)]
+
+mod entrypoint;
+pub mod processor;

--- a/examples/rust/transfer-tokens/src/processor.rs
+++ b/examples/rust/transfer-tokens/src/processor.rs
@@ -1,0 +1,80 @@
+//! Program instruction processor
+
+use {
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        msg,
+        program::invoke_signed,
+        program_error::ProgramError,
+        program_pack::Pack,
+        pubkey::Pubkey,
+    },
+    spl_token::{
+        instruction::transfer_checked,
+        state::{Account, Mint},
+    },
+};
+
+/// Instruction processor
+pub fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    _instruction_data: &[u8],
+) -> ProgramResult {
+    // Create an iterator to safely reference accounts in the slice
+    let account_info_iter = &mut accounts.iter();
+
+    // As part of the program specification the instruction gives:
+    // 1. source token account
+    // 2. mint account
+    // 3. destination token account
+    // 4. program-derived address that owns 1.
+    // 5. token program
+    let source_info = next_account_info(account_info_iter)?;
+    let mint_info = next_account_info(account_info_iter)?;
+    let destination_info = next_account_info(account_info_iter)?;
+    let authority_info = next_account_info(account_info_iter)?;
+    let token_program_info = next_account_info(account_info_iter)?;
+
+    // In order to transfer from the source account, owned by the program-derived
+    // address, we must have the correct address and seeds.
+    let (expected_authority, bump_seed) = Pubkey::find_program_address(&[b"authority"], program_id);
+    if expected_authority != *authority_info.key {
+        return Err(ProgramError::InvalidSeeds);
+    }
+
+    // The program transfers everything out of its account, so extract that from
+    // the account data.
+    let source_account = Account::unpack(&source_info.try_borrow_data()?)?;
+    let amount = source_account.amount;
+
+    // The program uses `transfer_checked`, which requires the number of decimals
+    // in the mint, so extract that from the account data too.
+    let mint = Mint::unpack(&mint_info.try_borrow_data()?)?;
+    let decimals = mint.decimals;
+
+    // Invoke the transfer
+    msg!("Attempting to transfer {} tokens", amount);
+    invoke_signed(
+        &transfer_checked(
+            token_program_info.key,
+            source_info.key,
+            mint_info.key,
+            destination_info.key,
+            authority_info.key,
+            &[], // no multisig allowed
+            amount,
+            decimals,
+        )
+        .unwrap(),
+        &[
+            source_info.clone(),
+            mint_info.clone(),
+            destination_info.clone(),
+            authority_info.clone(),
+            token_program_info.clone(), // not required, but better for clarity
+        ],
+        &[&[b"authority", &[bump_seed]]],
+    )
+}

--- a/examples/rust/transfer-tokens/tests/functional.rs
+++ b/examples/rust/transfer-tokens/tests/functional.rs
@@ -1,0 +1,136 @@
+use {
+    solana_program::{
+        instruction::{AccountMeta, Instruction},
+        program_pack::Pack,
+        pubkey::Pubkey,
+        rent::Rent,
+    },
+    solana_program_test::{processor, tokio, ProgramTest},
+    solana_sdk::{account::Account, signature::Signer, transaction::Transaction},
+    spl_example_transfer_tokens::processor::process_instruction,
+    spl_token::state::{Account as TokenAccount, Mint},
+    std::str::FromStr,
+};
+
+#[tokio::test]
+async fn success() {
+    // Setup some pubkeys for the accounts
+    let program_id = Pubkey::from_str("TransferTokens11111111111111111111111111111").unwrap();
+    let source_pubkey = Pubkey::new_unique();
+    let mint_pubkey = Pubkey::new_unique();
+    let destination_pubkey = Pubkey::new_unique();
+    let destination_owner_pubkey = Pubkey::new_unique();
+    let (authority_pubkey, _) = Pubkey::find_program_address(&[b"authority"], &program_id);
+
+    // Add the program to the test framework
+    let rent = Rent::default();
+    let mut program_test = ProgramTest::new(
+        "spl_example_transfer_tokens",
+        program_id,
+        processor!(process_instruction),
+    );
+    let amount = 10_000;
+    let decimals = 9;
+
+    // Setup the source account, owned by the program-derived address
+    let mut data = vec![0; TokenAccount::LEN];
+    TokenAccount::pack(
+        TokenAccount {
+            mint: mint_pubkey,
+            owner: authority_pubkey,
+            amount,
+            state: spl_token::state::AccountState::Initialized,
+            ..TokenAccount::default()
+        },
+        &mut data,
+    )
+    .unwrap();
+    program_test.add_account(
+        source_pubkey,
+        Account {
+            lamports: rent.minimum_balance(TokenAccount::LEN),
+            owner: spl_token::id(),
+            data,
+            ..Account::default()
+        },
+    );
+
+    // Setup the mint, used in `spl_token::instruction::transfer_checked`
+    let mut data = vec![0; Mint::LEN];
+    Mint::pack(
+        Mint {
+            supply: amount,
+            decimals,
+            is_initialized: true,
+            ..Mint::default()
+        },
+        &mut data,
+    )
+    .unwrap();
+    program_test.add_account(
+        mint_pubkey,
+        Account {
+            lamports: rent.minimum_balance(Mint::LEN),
+            owner: spl_token::id(),
+            data,
+            ..Account::default()
+        },
+    );
+
+    // Setup the destination account, used to receive tokens from the account
+    // owned by the program-derived address
+    let mut data = vec![0; TokenAccount::LEN];
+    TokenAccount::pack(
+        TokenAccount {
+            mint: mint_pubkey,
+            owner: destination_owner_pubkey,
+            amount: 0,
+            state: spl_token::state::AccountState::Initialized,
+            ..TokenAccount::default()
+        },
+        &mut data,
+    )
+    .unwrap();
+    program_test.add_account(
+        destination_pubkey,
+        Account {
+            lamports: rent.minimum_balance(TokenAccount::LEN),
+            owner: spl_token::id(),
+            data,
+            ..Account::default()
+        },
+    );
+
+    // Start the program test
+    let (mut banks_client, payer, recent_blockhash) = program_test.start().await;
+
+    // Create an instruction following the account order expected by the program
+    let transaction = Transaction::new_signed_with_payer(
+        &[Instruction::new_with_bincode(
+            program_id,
+            &(),
+            vec![
+                AccountMeta::new(source_pubkey, false),
+                AccountMeta::new_readonly(mint_pubkey, false),
+                AccountMeta::new(destination_pubkey, false),
+                AccountMeta::new_readonly(authority_pubkey, false),
+                AccountMeta::new_readonly(spl_token::id(), false),
+            ],
+        )],
+        Some(&payer.pubkey()),
+        &[&payer],
+        recent_blockhash,
+    );
+
+    // See that the transaction processes successfully
+    banks_client.process_transaction(transaction).await.unwrap();
+
+    // Check that the destination account now has `amount` tokens
+    let account = banks_client
+        .get_account(destination_pubkey)
+        .await
+        .unwrap()
+        .unwrap();
+    let token_account = TokenAccount::unpack(&account.data).unwrap();
+    assert_eq!(token_account.amount, amount);
+}


### PR DESCRIPTION
#### Problem

There's no program-test example that uses spl-token, and I want to demo one.

#### Solution

Add a simple example "giver" program that simply transfers tokens from a PDA-owned account.

Fixes  #829