### PR TITLE
ci: Add exception for tokio in audit job

### DIFF
--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -9,5 +9,11 @@ cargo_audit_ignores=(
   #
   # Blocked on chrono updating `time` to >= 0.2.23
   --ignore RUSTSEC-2020-0071
+
+  # tokio: vulnerability affecting named pipes on Windows
+  #
+  # Exception is a stopgap to unblock CI
+  # https://github.com/solana-labs/solana/issues/29586
+  --ignore RUSTSEC-2023-0001
 )
 cargo +"$rust_stable" audit "${cargo_audit_ignores[@]}"


### PR DESCRIPTION
#### Problem

There was a security vulnerability issued on tokio 1.14.  https://github.com/solana-labs/solana/pull/29585 added an exception for this advisory.

#### Solution

Do the same thing in SPL, and add the exception.