### PR TITLE
examples: Use txs instead of set_account in token test

### DIFF
--- a/examples/rust/transfer-tokens/src/processor.rs
+++ b/examples/rust/transfer-tokens/src/processor.rs
@@ -26,16 +26,11 @@ pub fn process_instruction(
     let account_info_iter = &mut accounts.iter();
 
     // As part of the program specification the instruction gives:
-    // 1. source token account
-    // 2. mint account
-    // 3. destination token account
-    // 4. program-derived address that owns 1.
-    // 5. token program
-    let source_info = next_account_info(account_info_iter)?;
-    let mint_info = next_account_info(account_info_iter)?;
-    let destination_info = next_account_info(account_info_iter)?;
-    let authority_info = next_account_info(account_info_iter)?;
-    let token_program_info = next_account_info(account_info_iter)?;
+    let source_info = next_account_info(account_info_iter)?; // 1.
+    let mint_info = next_account_info(account_info_iter)?; // 2.
+    let destination_info = next_account_info(account_info_iter)?; // 3.
+    let authority_info = next_account_info(account_info_iter)?; // 4.
+    let token_program_info = next_account_info(account_info_iter)?; // 5.
 
     // In order to transfer from the source account, owned by the program-derived
     // address, we must have the correct address and seeds.

--- a/examples/rust/transfer-tokens/tests/functional.rs
+++ b/examples/rust/transfer-tokens/tests/functional.rs
@@ -4,11 +4,12 @@ use {
         program_pack::Pack,
         pubkey::Pubkey,
         rent::Rent,
+        system_instruction,
     },
     solana_program_test::{processor, tokio, ProgramTest},
-    solana_sdk::{account::Account, signature::Signer, transaction::Transaction},
+    solana_sdk::{signature::Signer, signer::keypair::Keypair, transaction::Transaction},
     spl_example_transfer_tokens::processor::process_instruction,
-    spl_token::state::{Account as TokenAccount, Mint},
+    spl_token::state::{Account, Mint},
     std::str::FromStr,
 };
 
@@ -16,93 +17,114 @@ use {
 async fn success() {
     // Setup some pubkeys for the accounts
     let program_id = Pubkey::from_str("TransferTokens11111111111111111111111111111").unwrap();
-    let source_pubkey = Pubkey::new_unique();
-    let mint_pubkey = Pubkey::new_unique();
-    let destination_pubkey = Pubkey::new_unique();
-    let destination_owner_pubkey = Pubkey::new_unique();
+    let source = Keypair::new();
+    let mint = Keypair::new();
+    let destination = Keypair::new();
     let (authority_pubkey, _) = Pubkey::find_program_address(&[b"authority"], &program_id);
 
     // Add the program to the test framework
-    let rent = Rent::default();
-    let mut program_test = ProgramTest::new(
+    let program_test = ProgramTest::new(
         "spl_example_transfer_tokens",
         program_id,
         processor!(process_instruction),
     );
     let amount = 10_000;
     let decimals = 9;
-
-    // Setup the source account, owned by the program-derived address
-    let mut data = vec![0; TokenAccount::LEN];
-    TokenAccount::pack(
-        TokenAccount {
-            mint: mint_pubkey,
-            owner: authority_pubkey,
-            amount,
-            state: spl_token::state::AccountState::Initialized,
-            ..TokenAccount::default()
-        },
-        &mut data,
-    )
-    .unwrap();
-    program_test.add_account(
-        source_pubkey,
-        Account {
-            lamports: rent.minimum_balance(TokenAccount::LEN),
-            owner: spl_token::id(),
-            data,
-            ..Account::default()
-        },
-    );
-
-    // Setup the mint, used in `spl_token::instruction::transfer_checked`
-    let mut data = vec![0; Mint::LEN];
-    Mint::pack(
-        Mint {
-            supply: amount,
-            decimals,
-            is_initialized: true,
-            ..Mint::default()
-        },
-        &mut data,
-    )
-    .unwrap();
-    program_test.add_account(
-        mint_pubkey,
-        Account {
-            lamports: rent.minimum_balance(Mint::LEN),
-            owner: spl_token::id(),
-            data,
-            ..Account::default()
-        },
-    );
-
-    // Setup the destination account, used to receive tokens from the account
-    // owned by the program-derived address
-    let mut data = vec![0; TokenAccount::LEN];
-    TokenAccount::pack(
-        TokenAccount {
-            mint: mint_pubkey,
-            owner: destination_owner_pubkey,
-            amount: 0,
-            state: spl_token::state::AccountState::Initialized,
-            ..TokenAccount::default()
-        },
-        &mut data,
-    )
-    .unwrap();
-    program_test.add_account(
-        destination_pubkey,
-        Account {
-            lamports: rent.minimum_balance(TokenAccount::LEN),
-            owner: spl_token::id(),
-            data,
-            ..Account::default()
-        },
-    );
+    let rent = Rent::default();
 
     // Start the program test
     let (mut banks_client, payer, recent_blockhash) = program_test.start().await;
+
+    // Setup the mint, used in `spl_token::instruction::transfer_checked`
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &payer.pubkey(),
+                &mint.pubkey(),
+                rent.minimum_balance(Mint::LEN),
+                Mint::LEN as u64,
+                &spl_token::id(),
+            ),
+            spl_token::instruction::initialize_mint(
+                &spl_token::id(),
+                &mint.pubkey(),
+                &payer.pubkey(),
+                None,
+                decimals,
+            )
+            .unwrap(),
+        ],
+        Some(&payer.pubkey()),
+        &[&payer, &mint],
+        recent_blockhash,
+    );
+    banks_client.process_transaction(transaction).await.unwrap();
+
+    // Setup the source account, owned by the program-derived address
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &payer.pubkey(),
+                &source.pubkey(),
+                rent.minimum_balance(Account::LEN),
+                Account::LEN as u64,
+                &spl_token::id(),
+            ),
+            spl_token::instruction::initialize_account(
+                &spl_token::id(),
+                &source.pubkey(),
+                &mint.pubkey(),
+                &authority_pubkey,
+            )
+            .unwrap(),
+        ],
+        Some(&payer.pubkey()),
+        &[&payer, &source],
+        recent_blockhash,
+    );
+    banks_client.process_transaction(transaction).await.unwrap();
+
+    // Setup the destination account, used to receive tokens from the account
+    // owned by the program-derived address
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &payer.pubkey(),
+                &destination.pubkey(),
+                rent.minimum_balance(Account::LEN),
+                Account::LEN as u64,
+                &spl_token::id(),
+            ),
+            spl_token::instruction::initialize_account(
+                &spl_token::id(),
+                &destination.pubkey(),
+                &mint.pubkey(),
+                &payer.pubkey(),
+            )
+            .unwrap(),
+        ],
+        Some(&payer.pubkey()),
+        &[&payer, &destination],
+        recent_blockhash,
+    );
+    banks_client.process_transaction(transaction).await.unwrap();
+
+    // Mint some tokens to the PDA account
+    let transaction = Transaction::new_signed_with_payer(
+        &[spl_token::instruction::mint_to(
+            &spl_token::id(),
+            &mint.pubkey(),
+            &source.pubkey(),
+            &payer.pubkey(),
+            &[],
+            amount,
+        )
+        .unwrap()],
+        Some(&payer.pubkey()),
+        &[&payer],
+        recent_blockhash,
+    );
+    banks_client.process_transaction(transaction).await.unwrap();
 
     // Create an instruction following the account order expected by the program
     let transaction = Transaction::new_signed_with_payer(
@@ -110,9 +132,9 @@ async fn success() {
             program_id,
             &(),
             vec![
-                AccountMeta::new(source_pubkey, false),
-                AccountMeta::new_readonly(mint_pubkey, false),
-                AccountMeta::new(destination_pubkey, false),
+                AccountMeta::new(source.pubkey(), false),
+                AccountMeta::new_readonly(mint.pubkey(), false),
+                AccountMeta::new(destination.pubkey(), false),
                 AccountMeta::new_readonly(authority_pubkey, false),
                 AccountMeta::new_readonly(spl_token::id(), false),
             ],
@@ -127,10 +149,10 @@ async fn success() {
 
     // Check that the destination account now has `amount` tokens
     let account = banks_client
-        .get_account(destination_pubkey)
+        .get_account(destination.pubkey())
         .await
         .unwrap()
         .unwrap();
-    let token_account = TokenAccount::unpack(&account.data).unwrap();
+    let token_account = Account::unpack(&account.data).unwrap();
     assert_eq!(token_account.amount, amount);
 }


### PR DESCRIPTION
#### Problem

The token transfer example is great, but the test hardcodes a bunch of accounts and uses ProgramTest's `set_account` to set them up. This isn't indicative of how to really create token accounts, since you typically need to send transactions to the network.

#### Solution

Improve the test by actually sending transactions.