### PR TITLE
single-validator stake pool program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6289,6 +6289,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-single-validator-pool"
+version = "1.0.0"
+dependencies = [
+ "arrayref",
+ "borsh",
+ "mpl-token-metadata",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-program",
+ "spl-associated-token-account 1.1.3",
+ "spl-token 3.5.0",
+ "thiserror",
+]
+
+[[package]]
 name = "spl-stake-pool"
 version = "0.7.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
   "record/program",
   "shared-memory/program",
   "stake-pool/cli",
+  "stake-pool/single-pool",
   "stake-pool/program",
   "stateless-asks/program",
   "token-lending/cli",

--- a/stake-pool/single-pool/Cargo.toml
+++ b/stake-pool/single-pool/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "spl-single-validator-pool"
+version = "1.0.0"
+description = "Solana Program Library Single-Validator Stake Pool"
+authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
+repository = "https://github.com/solana-labs/solana-program-library"
+license = "Apache-2.0"
+edition = "2021"
+
+[features]
+no-entrypoint = []
+test-sbf = []
+
+[dependencies]
+arrayref = "0.3.6"
+borsh = "0.9"
+mpl-token-metadata =  { version = "1.7.0", features = [ "no-entrypoint" ] }
+num-derive = "0.3"
+num-traits = "0.2"
+num_enum = "0.5.9"
+solana-program = "1.14.12"
+spl-token = { version = "3.5", path = "../../token/program", features = [ "no-entrypoint" ] }
+spl-associated-token-account = { version = "1.1", path = "../../associated-token-account/program", features = [ "no-entrypoint" ] }
+thiserror = "1.0"
+
+[lib]
+crate-type = ["cdylib", "lib"]

--- a/stake-pool/single-pool/program-id.md
+++ b/stake-pool/single-pool/program-id.md
@@ -1,0 +1,1 @@
+3cqnsMsT6LE96pxv7GR4di5rLqHDZZbR3FbeSUeRLFqY

--- a/stake-pool/single-pool/src/entrypoint.rs
+++ b/stake-pool/single-pool/src/entrypoint.rs
@@ -1,0 +1,26 @@
+//! Program entrypoint
+
+#![cfg(all(target_os = "solana", not(feature = "no-entrypoint")))]
+
+use {
+    crate::{error::SinglePoolError, processor::Processor},
+    solana_program::{
+        account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,
+        program_error::PrintProgramError, pubkey::Pubkey,
+    },
+};
+
+entrypoint!(process_instruction);
+fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    if let Err(error) = Processor::process(program_id, accounts, instruction_data) {
+        // catch the error so we can print it
+        error.print::<SinglePoolError>();
+        Err(error)
+    } else {
+        Ok(())
+    }
+}

--- a/stake-pool/single-pool/src/error.rs
+++ b/stake-pool/single-pool/src/error.rs
@@ -1,0 +1,125 @@
+//! Error types
+
+use {
+    solana_program::{
+        decode_error::DecodeError,
+        msg,
+        program_error::{PrintProgramError, ProgramError},
+    },
+    thiserror::Error,
+};
+
+/// Errors that may be returned by the SinglePool program.
+#[derive(Clone, Debug, Eq, Error, num_derive::FromPrimitive, PartialEq)]
+pub enum SinglePoolError {
+    // 0.
+    /// Provided pool stake account does not match stake account derived for validator vote account.
+    #[error("InvalidPoolStakeAccount")]
+    InvalidPoolStakeAccount,
+    /// Provided pool authority does not match authority derived for validator vote account.
+    #[error("InvalidPoolAuthority")]
+    InvalidPoolAuthority,
+    /// Provided pool mint does not match mint derived for validator vote account.
+    #[error("InvalidPoolMint")]
+    InvalidPoolMint,
+    /// Provided metadata account does not match metadata account derived for pool mint.
+    #[error("InvalidMetadataAccount")]
+    InvalidMetadataAccount,
+    /// Authorized withdrawer provided for metadata update does not match the vote account.
+    #[error("InvalidMetadataSigner")]
+    InvalidMetadataSigner,
+
+    // 5.
+    /// Not enough lamports provided for deposit to result in one pool token.
+    #[error("DepositTooSmall")]
+    DepositTooSmall,
+    /// Not enough pool tokens provided to withdraw stake worth one lamport.
+    #[error("WithdrawalTooSmall")]
+    WithdrawalTooSmall,
+    /// Not enough stake to cover the provided quantity of pool tokens.
+    /// (Generally this should not happen absent user error, but may if the minimum delegation increases.)
+    #[error("WithdrawalTooLarge")]
+    WithdrawalTooLarge,
+    /// Required signature is missing.
+    #[error("SignatureMissing")]
+    SignatureMissing,
+    /// Stake account is not in the state expected by the program.
+    #[error("WrongStakeState")]
+    WrongStakeState,
+
+    // 10.
+    /// Unsigned subtraction crossed the zero.
+    #[error("ArithmeticOverflow")]
+    ArithmeticOverflow,
+    /// A calculation failed unexpectedly.
+    /// (This error should never be surfaced; it stands in for failure conditions that should never be reached.)
+    #[error("UnexpectedMathError")]
+    UnexpectedMathError,
+    /// The V0_23_5 vote account type is unsupported and should be upgraded via `convert_to_current()`.
+    #[error("LegacyVoteAccount")]
+    LegacyVoteAccount,
+    /// Failed to parse vote account.
+    #[error("UnparseableVoteAccount")]
+    UnparseableVoteAccount,
+    /// Incorrect number of lamports provided for rent-exemption when initializing.
+    #[error("WrongRentAmount")]
+    WrongRentAmount,
+
+    // 15.
+    /// Attempted to deposit from or withdraw to pool stake account.
+    #[error("InvalidPoolAccountUsage")]
+    InvalidPoolAccountUsage,
+}
+impl From<SinglePoolError> for ProgramError {
+    fn from(e: SinglePoolError) -> Self {
+        ProgramError::Custom(e as u32)
+    }
+}
+impl<T> DecodeError<T> for SinglePoolError {
+    fn type_of() -> &'static str {
+        "Single-Validator Stake Pool Error"
+    }
+}
+impl PrintProgramError for SinglePoolError {
+    fn print<E>(&self)
+    where
+        E: 'static
+            + std::error::Error
+            + DecodeError<E>
+            + PrintProgramError
+            + num_traits::FromPrimitive,
+    {
+        match self {
+            SinglePoolError::InvalidPoolStakeAccount =>
+                msg!("Error: Provided pool stake account does not match stake account derived for validator vote account."),
+            SinglePoolError::InvalidPoolAuthority =>
+                msg!("Error: Provided pool authority does not match authority derived for validator vote account."),
+            SinglePoolError::InvalidPoolMint =>
+                msg!("Error: Provided pool mint does not match mint derived for validator vote account."),
+            SinglePoolError::InvalidMetadataAccount =>
+                msg!("Error: Provided metadata account does not match metadata account derived for pool mint."),
+            SinglePoolError::InvalidMetadataSigner =>
+                msg!("Error: Authorized withdrawer provided for metadata update does not match the vote account."),
+            SinglePoolError::DepositTooSmall =>
+                msg!("Error: Not enough lamports provided for deposit to result in one pool token."),
+            SinglePoolError::WithdrawalTooSmall =>
+                msg!("Error: Not enough pool tokens provided to withdraw stake worth one lamport."),
+            SinglePoolError::WithdrawalTooLarge =>
+                msg!("Error: Not enough stake to cover the provided quantity of pool tokens. \
+                     (Generally this should not happen absent user error, but may if the minimum delegation increases.)"),
+            SinglePoolError::SignatureMissing => msg!("Error: Required signature is missing."),
+            SinglePoolError::WrongStakeState => msg!("Error: Stake account is not in the state expected by the program."),
+            SinglePoolError::ArithmeticOverflow => msg!("Error: Unsigned subtraction crossed the zero."),
+            SinglePoolError::UnexpectedMathError =>
+                msg!("Error: A calculation failed unexpectedly. \
+                     (This error should never be surfaced; it stands in for failure conditions that should never be reached.)"),
+            SinglePoolError::UnparseableVoteAccount => msg!("Error: Failed to parse vote account."),
+            SinglePoolError::LegacyVoteAccount =>
+                msg!("Error: The V0_23_5 vote account type is unsupported and should be upgraded via `convert_to_current()`."),
+            SinglePoolError::WrongRentAmount =>
+                msg!("Error: Incorrect number of lamports provided for rent-exemption when initializing."),
+            SinglePoolError::InvalidPoolAccountUsage =>
+                msg!("Error: Attempted to deposit from or withdraw to pool stake account."),
+        }
+    }
+}

--- a/stake-pool/single-pool/src/instruction.rs
+++ b/stake-pool/single-pool/src/instruction.rs
@@ -1,0 +1,386 @@
+//! Instruction types
+
+#![allow(clippy::too_many_arguments)]
+
+use {
+    crate::{
+        find_default_deposit_account_address, find_pool_authority_address, find_pool_mint_address,
+        find_pool_stake_address, USER_STAKE_SEED,
+    },
+    borsh::{BorshDeserialize, BorshSerialize},
+    mpl_token_metadata::pda::find_metadata_account,
+    solana_program::{
+        instruction::{AccountMeta, Instruction},
+        program_pack::Pack,
+        pubkey::Pubkey,
+        rent::Rent,
+        stake, system_instruction, system_program, sysvar,
+    },
+};
+
+/// Instructions supported by the SinglePool program.
+#[repr(C)]
+#[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize)]
+pub enum SinglePoolInstruction {
+    ///   Initialize the mint and stake account for a new single-validator pool.
+    ///   The pool stake account must contain the rent-exempt minimum plus the minimum delegation.
+    ///   No tokens will be minted: to deposit more, use `Deposit` after `InitializeStake`.
+    ///
+    ///   0. `[]` Validator vote account
+    ///   1. `[w]` Pool stake account
+    ///   2. `[]` Pool authority
+    ///   3. `[w]` Pool token mint
+    ///   4. `[]` Rent sysvar
+    ///   5. `[]` Clock sysvar
+    ///   6. `[]` Stake history sysvar
+    ///   7. `[]` Stake config sysvar
+    ///   8. `[]` System program
+    ///   9. `[]` Token program
+    ///  10. `[]` Stake program
+    InitializePool,
+
+    ///   Deposit stake into the pool.  The output is a "pool" token representing fractional
+    ///   ownership of the pool stake. Inputs are converted to the current ratio.
+    ///
+    ///   0. `[w]` Pool stake account
+    ///   1. `[]` Pool authority
+    ///   2. `[w]` Pool token mint
+    ///   3. `[w]` User stake account to join to the pool
+    ///   4. `[w]` User account to receive pool tokens
+    ///   5. `[w]` User account to receive lamports
+    ///   6. `[]` Clock sysvar
+    ///   7. `[]` Stake history sysvar
+    ///   8. `[]` Token program
+    ///   9. `[]` Stake program
+    DepositStake {
+        /// Validator vote account address
+        vote_account_address: Pubkey,
+    },
+
+    ///   Redeem tokens issued by this pool for stake at the current ratio.
+    ///
+    ///   0. `[w]` Pool stake account
+    ///   1. `[]` Pool authority
+    ///   2. `[w]` Pool token mint
+    ///   3. `[w]` User stake account to receive stake at
+    ///   4. `[w]` User account to take pool tokens from
+    ///   5. `[]` Clock sysvar
+    ///   6. `[]` Token program
+    ///   7. `[]` Stake program
+    WithdrawStake {
+        /// Validator vote account address
+        vote_account_address: Pubkey,
+        /// User authority for the new stake account
+        user_stake_authority: Pubkey,
+        /// Amount of tokens to redeem for stake
+        token_amount: u64,
+    },
+
+    ///   Create token metadata for the stake-pool token in the metaplex-token program.
+    ///   Step three of the permissionless three-stage initialization flow.
+    ///   Note this instruction is not necessary for the pool to operate, to ensure we cannot
+    ///   be broken by upstream.
+    ///
+    ///   0. `[]` Pool authority
+    ///   1. `[]` Pool token mint
+    ///   2. `[s, w]` Payer for creation of token metadata account
+    ///   3. `[w]` Token metadata account
+    ///   4. `[]` Metadata program id
+    ///   5. `[]` System program id
+    CreateTokenMetadata {
+        /// Validator vote account address
+        vote_account_address: Pubkey,
+    },
+
+    ///   Update token metadata for the stake-pool token in the metaplex-token program.
+    ///
+    ///   0. `[]` Validator vote account
+    ///   1. `[]` Pool authority
+    ///   2. `[s]` Vote account authorized withdrawer
+    ///   3. `[w]` Token metadata account
+    ///   4. `[]` Metadata program id
+    UpdateTokenMetadata {
+        /// Token name
+        name: String,
+        /// Token symbol e.g. stkSOL
+        symbol: String,
+        /// URI of the uploaded metadata of the spl-token
+        uri: String,
+    },
+}
+
+/// Creates all necessary instructions to initialize the stake pool.
+pub fn initialize(
+    program_id: &Pubkey,
+    vote_account: &Pubkey,
+    payer: &Pubkey,
+    rent: &Rent,
+    minimum_delegation: u64,
+) -> Vec<Instruction> {
+    let stake_address = find_pool_stake_address(program_id, vote_account);
+    let stake_space = std::mem::size_of::<stake::state::StakeState>();
+    let stake_rent_plus_one = rent
+        .minimum_balance(stake_space)
+        .saturating_add(minimum_delegation);
+
+    let mint_address = find_pool_mint_address(program_id, vote_account);
+    let mint_rent = rent.minimum_balance(spl_token::state::Mint::LEN);
+
+    vec![
+        system_instruction::transfer(payer, &stake_address, stake_rent_plus_one),
+        system_instruction::transfer(payer, &mint_address, mint_rent),
+        initialize_pool(program_id, vote_account),
+        create_token_metadata(program_id, vote_account, payer),
+    ]
+}
+
+/// Creates an `InitializePool` instruction.
+pub fn initialize_pool(program_id: &Pubkey, vote_account: &Pubkey) -> Instruction {
+    let mint_address = find_pool_mint_address(program_id, vote_account);
+
+    let data = SinglePoolInstruction::InitializePool.try_to_vec().unwrap();
+    let accounts = vec![
+        AccountMeta::new_readonly(*vote_account, false),
+        AccountMeta::new(find_pool_stake_address(program_id, vote_account), false),
+        AccountMeta::new_readonly(find_pool_authority_address(program_id, vote_account), false),
+        AccountMeta::new(mint_address, false),
+        AccountMeta::new_readonly(sysvar::rent::id(), false),
+        AccountMeta::new_readonly(sysvar::clock::id(), false),
+        AccountMeta::new_readonly(sysvar::stake_history::id(), false),
+        AccountMeta::new_readonly(stake::config::id(), false),
+        AccountMeta::new_readonly(system_program::id(), false),
+        AccountMeta::new_readonly(spl_token::id(), false),
+        AccountMeta::new_readonly(stake::program::id(), false),
+    ];
+
+    Instruction {
+        program_id: *program_id,
+        accounts,
+        data,
+    }
+}
+
+/// Creates all necessary instructions to deposit stake.
+pub fn deposit(
+    program_id: &Pubkey,
+    vote_account: &Pubkey,
+    user_stake_account: &Pubkey,
+    user_token_account: &Pubkey,
+    user_lamport_account: &Pubkey,
+    user_withdraw_authority: &Pubkey,
+) -> Vec<Instruction> {
+    let pool_authority = find_pool_authority_address(program_id, vote_account);
+
+    vec![
+        stake::instruction::authorize(
+            user_stake_account,
+            user_withdraw_authority,
+            &pool_authority,
+            stake::state::StakeAuthorize::Staker,
+            None,
+        ),
+        stake::instruction::authorize(
+            user_stake_account,
+            user_withdraw_authority,
+            &pool_authority,
+            stake::state::StakeAuthorize::Withdrawer,
+            None,
+        ),
+        deposit_stake(
+            program_id,
+            vote_account,
+            user_stake_account,
+            user_token_account,
+            user_lamport_account,
+        ),
+    ]
+}
+
+/// Creates a `DepositStake` instruction.
+pub fn deposit_stake(
+    program_id: &Pubkey,
+    vote_account: &Pubkey,
+    user_stake_account: &Pubkey,
+    user_token_account: &Pubkey,
+    user_lamport_account: &Pubkey,
+) -> Instruction {
+    let data = SinglePoolInstruction::DepositStake {
+        vote_account_address: *vote_account,
+    }
+    .try_to_vec()
+    .unwrap();
+
+    let accounts = vec![
+        AccountMeta::new(find_pool_stake_address(program_id, vote_account), false),
+        AccountMeta::new_readonly(find_pool_authority_address(program_id, vote_account), false),
+        AccountMeta::new(find_pool_mint_address(program_id, vote_account), false),
+        AccountMeta::new(*user_stake_account, false),
+        AccountMeta::new(*user_token_account, false),
+        AccountMeta::new(*user_lamport_account, false),
+        AccountMeta::new_readonly(sysvar::clock::id(), false),
+        AccountMeta::new_readonly(sysvar::stake_history::id(), false),
+        AccountMeta::new_readonly(spl_token::id(), false),
+        AccountMeta::new_readonly(stake::program::id(), false),
+    ];
+
+    Instruction {
+        program_id: *program_id,
+        accounts,
+        data,
+    }
+}
+
+/// Creates all necessary instructions to withdraw stake into a given stake account.
+/// If a new stake account is required, the user should first include `system_instruction::create_account`
+/// with account size `std::mem::size_of::<stake::state::StakeState>()` and owner `stake::program::id()`.
+pub fn withdraw(
+    program_id: &Pubkey,
+    vote_account: &Pubkey,
+    user_stake_account: &Pubkey,
+    user_stake_authority: &Pubkey,
+    user_token_account: &Pubkey,
+    user_token_authority: &Pubkey,
+    token_amount: u64,
+) -> Vec<Instruction> {
+    let pool_authority = find_pool_authority_address(program_id, vote_account);
+
+    vec![
+        spl_token::instruction::approve(
+            &spl_token::id(),
+            user_token_account,
+            &pool_authority,
+            user_token_authority,
+            &[],
+            token_amount,
+        )
+        .unwrap(),
+        withdraw_stake(
+            program_id,
+            vote_account,
+            user_stake_account,
+            user_stake_authority,
+            user_token_account,
+            token_amount,
+        ),
+    ]
+}
+
+/// Creates a `WithdrawStake` instruction.
+pub fn withdraw_stake(
+    program_id: &Pubkey,
+    vote_account: &Pubkey,
+    user_stake_account: &Pubkey,
+    user_stake_authority: &Pubkey,
+    user_token_account: &Pubkey,
+    token_amount: u64,
+) -> Instruction {
+    let data = SinglePoolInstruction::WithdrawStake {
+        vote_account_address: *vote_account,
+        user_stake_authority: *user_stake_authority,
+        token_amount,
+    }
+    .try_to_vec()
+    .unwrap();
+
+    let accounts = vec![
+        AccountMeta::new(find_pool_stake_address(program_id, vote_account), false),
+        AccountMeta::new_readonly(find_pool_authority_address(program_id, vote_account), false),
+        AccountMeta::new(find_pool_mint_address(program_id, vote_account), false),
+        AccountMeta::new(*user_stake_account, false),
+        AccountMeta::new(*user_token_account, false),
+        AccountMeta::new_readonly(sysvar::clock::id(), false),
+        AccountMeta::new_readonly(spl_token::id(), false),
+        AccountMeta::new_readonly(stake::program::id(), false),
+    ];
+
+    Instruction {
+        program_id: *program_id,
+        accounts,
+        data,
+    }
+}
+
+/// Creates necessary instructions to create and delegate a new stake account to a given validator.
+/// Uses a fixed address for each wallet and vote account combination to make it easier to find for deposits.
+/// This is an optional helper function; deposits can come from any owned stake account without lockup.
+pub fn create_and_delegate_user_stake(
+    vote_account: &Pubkey,
+    user_wallet: &Pubkey,
+    lamports: u64,
+) -> Vec<Instruction> {
+    stake::instruction::create_account_with_seed_and_delegate_stake(
+        user_wallet,
+        &find_default_deposit_account_address(vote_account, user_wallet),
+        vote_account,
+        USER_STAKE_SEED,
+        vote_account,
+        &stake::state::Authorized {
+            staker: *user_wallet,
+            withdrawer: *user_wallet,
+        },
+        &stake::state::Lockup::default(),
+        lamports,
+    )
+}
+
+/// Creates a `CreateTokenMetadata` instruction.
+pub fn create_token_metadata(
+    program_id: &Pubkey,
+    vote_account: &Pubkey,
+    payer: &Pubkey,
+) -> Instruction {
+    let pool_authority = find_pool_authority_address(program_id, vote_account);
+    let pool_mint = find_pool_mint_address(program_id, vote_account);
+    let (token_metadata, _) = find_metadata_account(&pool_mint);
+    let data = SinglePoolInstruction::CreateTokenMetadata {
+        vote_account_address: *vote_account,
+    }
+    .try_to_vec()
+    .unwrap();
+
+    let accounts = vec![
+        AccountMeta::new_readonly(pool_authority, false),
+        AccountMeta::new_readonly(pool_mint, false),
+        AccountMeta::new(*payer, true),
+        AccountMeta::new(token_metadata, false),
+        AccountMeta::new_readonly(mpl_token_metadata::id(), false),
+        AccountMeta::new_readonly(system_program::id(), false),
+    ];
+
+    Instruction {
+        program_id: *program_id,
+        accounts,
+        data,
+    }
+}
+
+/// Creates an `UpdateTokenMetadata` instruction.
+pub fn update_token_metadata(
+    program_id: &Pubkey,
+    vote_account: &Pubkey,
+    authorized_withdrawer: &Pubkey,
+    name: String,
+    symbol: String,
+    uri: String,
+) -> Instruction {
+    let pool_authority = find_pool_authority_address(program_id, vote_account);
+    let pool_mint = find_pool_mint_address(program_id, vote_account);
+    let (token_metadata, _) = find_metadata_account(&pool_mint);
+    let data = SinglePoolInstruction::UpdateTokenMetadata { name, symbol, uri }
+        .try_to_vec()
+        .unwrap();
+
+    let accounts = vec![
+        AccountMeta::new_readonly(*vote_account, false),
+        AccountMeta::new_readonly(pool_authority, false),
+        AccountMeta::new_readonly(*authorized_withdrawer, true),
+        AccountMeta::new(token_metadata, false),
+        AccountMeta::new_readonly(mpl_token_metadata::id(), false),
+    ];
+
+    Instruction {
+        program_id: *program_id,
+        accounts,
+        data,
+    }
+}

--- a/stake-pool/single-pool/src/lib.rs
+++ b/stake-pool/single-pool/src/lib.rs
@@ -1,0 +1,82 @@
+#![deny(missing_docs)]
+
+//! A program for liquid staking with a single validator
+
+pub mod error;
+pub mod instruction;
+pub mod processor;
+
+#[cfg(not(feature = "no-entrypoint"))]
+pub mod entrypoint;
+
+// export current sdk types for downstream users building with a different sdk version
+pub use solana_program;
+use solana_program::pubkey::Pubkey;
+
+// XXX TODO FIXME change this
+// (XXX ask how do we as a company handle privkeys for our onchain programs?)
+solana_program::declare_id!("3cqnsMsT6LE96pxv7GR4di5rLqHDZZbR3FbeSUeRLFqY");
+
+const POOL_STAKE_PREFIX: &[u8] = b"stake";
+const POOL_AUTHORITY_PREFIX: &[u8] = b"authority";
+const POOL_MINT_PREFIX: &[u8] = b"mint";
+
+const MINT_DECIMALS: u8 = 9;
+
+// authorized withdrawer starts immediately after the enum tag
+const VOTE_STATE_START: usize = 4;
+const VOTE_STATE_END: usize = 36;
+
+const USER_STAKE_SEED: &str = "single-pool-user-stake";
+
+fn find_address_and_bump(
+    program_id: &Pubkey,
+    vote_account_address: &Pubkey,
+    prefix: &[u8],
+) -> (Pubkey, u8) {
+    Pubkey::find_program_address(&[prefix, vote_account_address.as_ref()], program_id)
+}
+
+fn find_pool_stake_address_and_bump(
+    program_id: &Pubkey,
+    vote_account_address: &Pubkey,
+) -> (Pubkey, u8) {
+    find_address_and_bump(program_id, vote_account_address, POOL_STAKE_PREFIX)
+}
+
+fn find_pool_authority_address_and_bump(
+    program_id: &Pubkey,
+    vote_account_address: &Pubkey,
+) -> (Pubkey, u8) {
+    find_address_and_bump(program_id, vote_account_address, POOL_AUTHORITY_PREFIX)
+}
+
+fn find_pool_mint_address_and_bump(
+    program_id: &Pubkey,
+    vote_account_address: &Pubkey,
+) -> (Pubkey, u8) {
+    find_address_and_bump(program_id, vote_account_address, POOL_MINT_PREFIX)
+}
+
+/// Find the canonical stake account address for a given vote account.
+pub fn find_pool_stake_address(program_id: &Pubkey, vote_account_address: &Pubkey) -> Pubkey {
+    find_pool_stake_address_and_bump(program_id, vote_account_address).0
+}
+
+/// Find the canonical authority address for a given vote account.
+pub fn find_pool_authority_address(program_id: &Pubkey, vote_account_address: &Pubkey) -> Pubkey {
+    find_pool_authority_address_and_bump(program_id, vote_account_address).0
+}
+
+/// Find the canonical token mint address for a given vote account.
+pub fn find_pool_mint_address(program_id: &Pubkey, vote_account_address: &Pubkey) -> Pubkey {
+    find_pool_mint_address_and_bump(program_id, vote_account_address).0
+}
+
+/// Find the address of the default intermediate account that holds activating user stake before deposit.
+pub fn find_default_deposit_account_address(
+    vote_account_address: &Pubkey,
+    user_wallet_address: &Pubkey,
+) -> Pubkey {
+    Pubkey::create_with_seed(vote_account_address, USER_STAKE_SEED, user_wallet_address).unwrap()
+}

--- a/stake-pool/single-pool/src/processor.rs
+++ b/stake-pool/single-pool/src/processor.rs
@@ -1,0 +1,1031 @@
+//! program state processor
+
+use {
+    crate::{
+        error::SinglePoolError, instruction::SinglePoolInstruction, MINT_DECIMALS,
+        POOL_AUTHORITY_PREFIX, POOL_MINT_PREFIX, POOL_STAKE_PREFIX, VOTE_STATE_END,
+        VOTE_STATE_START,
+    },
+    borsh::BorshDeserialize,
+    mpl_token_metadata::{
+        instruction::{create_metadata_accounts_v3, update_metadata_accounts_v2},
+        pda::find_metadata_account,
+        state::DataV2,
+    },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        borsh::try_from_slice_unchecked,
+        entrypoint::ProgramResult,
+        msg,
+        native_token::LAMPORTS_PER_SOL,
+        program::invoke_signed,
+        program_error::ProgramError,
+        program_pack::Pack,
+        pubkey::Pubkey,
+        rent::Rent,
+        stake::{
+            self,
+            state::{Meta, Stake, StakeState},
+        },
+        stake_history::Epoch,
+        system_instruction, system_program,
+        sysvar::{clock::Clock, Sysvar},
+        vote::program as vote_program,
+    },
+    spl_token::state::Mint,
+};
+
+/// Calculate pool tokens to mint, given outstanding token supply, pool active stake, and deposit active stake
+fn calculate_deposit_amount(
+    pre_token_supply: u64,
+    pre_pool_stake: u64,
+    user_stake_to_deposit: u64,
+) -> Option<u64> {
+    if pre_pool_stake == 0 || pre_token_supply == 0 {
+        Some(user_stake_to_deposit)
+    } else {
+        u64::try_from(
+            (user_stake_to_deposit as u128)
+                .checked_mul(pre_token_supply as u128)?
+                .checked_div(pre_pool_stake as u128)?,
+        )
+        .ok()
+    }
+}
+
+/// Calculate pool stake to return, given outstanding token supply, pool active stake, and tokens to redeem
+fn calculate_withdraw_amount(
+    pre_token_supply: u64,
+    pre_pool_stake: u64,
+    user_tokens_to_burn: u64,
+) -> Option<u64> {
+    let numerator = (user_tokens_to_burn as u128).checked_mul(pre_pool_stake as u128)?;
+    let denominator = pre_token_supply as u128;
+    if numerator < denominator || denominator == 0 {
+        Some(0)
+    } else {
+        u64::try_from(numerator.checked_div(denominator)?).ok()
+    }
+}
+
+/// Deserialize the stake state from AccountInfo
+fn get_stake_state(stake_account_info: &AccountInfo) -> Result<(Meta, Stake), ProgramError> {
+    let stake_state = try_from_slice_unchecked::<StakeState>(&stake_account_info.data.borrow())?;
+
+    match stake_state {
+        StakeState::Stake(meta, stake) => Ok((meta, stake)),
+        _ => Err(SinglePoolError::WrongStakeState.into()),
+    }
+}
+
+/// Deserialize the stake amount from AccountInfo
+fn get_stake_amount(stake_account_info: &AccountInfo) -> Result<u64, ProgramError> {
+    Ok(get_stake_state(stake_account_info)?.1.delegation.stake)
+}
+
+/// Determine if stake is active
+fn is_stake_active_without_history(stake: &Stake, current_epoch: Epoch) -> bool {
+    stake.delegation.activation_epoch < current_epoch
+        && stake.delegation.deactivation_epoch == Epoch::MAX
+}
+
+/// Check pool stake account address for the validator vote account
+fn check_pool_stake_address(
+    program_id: &Pubkey,
+    vote_account_address: &Pubkey,
+    address: &Pubkey,
+) -> Result<u8, ProgramError> {
+    let (pool_stake_address, bump_seed) =
+        crate::find_pool_stake_address_and_bump(program_id, vote_account_address);
+    if *address != pool_stake_address {
+        msg!(
+            "Incorrect pool stake address for vote {}, expected {}, received {}",
+            vote_account_address,
+            pool_stake_address,
+            address
+        );
+        Err(SinglePoolError::InvalidPoolStakeAccount.into())
+    } else {
+        Ok(bump_seed)
+    }
+}
+
+/// Check pool authority address for the validator vote account
+fn check_pool_authority_address(
+    program_id: &Pubkey,
+    vote_account_address: &Pubkey,
+    address: &Pubkey,
+) -> Result<u8, ProgramError> {
+    let (pool_authority_address, bump_seed) =
+        crate::find_pool_authority_address_and_bump(program_id, vote_account_address);
+    if *address != pool_authority_address {
+        msg!(
+            "Incorrect pool authority address for vote {}, expected {}, received {}",
+            vote_account_address,
+            pool_authority_address,
+            address
+        );
+        Err(SinglePoolError::InvalidPoolAuthority.into())
+    } else {
+        Ok(bump_seed)
+    }
+}
+
+/// Check pool mint address for the validator vote account
+fn check_pool_mint_address(
+    program_id: &Pubkey,
+    vote_account_address: &Pubkey,
+    address: &Pubkey,
+) -> Result<u8, ProgramError> {
+    let (pool_mint_address, bump_seed) =
+        crate::find_pool_mint_address_and_bump(program_id, vote_account_address);
+    if *address != pool_mint_address {
+        msg!(
+            "Incorrect pool mint address for vote {}, expected {}, received {}",
+            vote_account_address,
+            pool_mint_address,
+            address
+        );
+        Err(SinglePoolError::InvalidPoolMint.into())
+    } else {
+        Ok(bump_seed)
+    }
+}
+
+/// Check vote account is owned by the vote program and not a legacy variant
+fn check_vote_account(vote_account_info: &AccountInfo) -> Result<(), ProgramError> {
+    check_account_owner(vote_account_info, &vote_program::id())?;
+
+    let vote_account_data = &vote_account_info.try_borrow_data()?;
+    let state_variant = vote_account_data
+        .get(..VOTE_STATE_START)
+        .and_then(|s| s.try_into().ok())
+        .ok_or(SinglePoolError::UnparseableVoteAccount)?;
+
+    match u32::from_le_bytes(state_variant) {
+        1 => Ok(()),
+        0 => Err(SinglePoolError::LegacyVoteAccount.into()),
+        _ => Err(SinglePoolError::UnparseableVoteAccount.into()),
+    }
+}
+
+/// Check mpl metadata account address for the pool mint
+fn check_mpl_metadata_account_address(
+    metadata_address: &Pubkey,
+    pool_mint: &Pubkey,
+) -> Result<(), ProgramError> {
+    let (metadata_account_pubkey, _) = find_metadata_account(pool_mint);
+    if metadata_account_pubkey != *metadata_address {
+        Err(SinglePoolError::InvalidMetadataAccount.into())
+    } else {
+        Ok(())
+    }
+}
+
+/// Check system program address
+fn check_system_program(program_id: &Pubkey) -> Result<(), ProgramError> {
+    if *program_id != system_program::id() {
+        msg!(
+            "Expected system program {}, received {}",
+            system_program::id(),
+            program_id
+        );
+        Err(ProgramError::IncorrectProgramId)
+    } else {
+        Ok(())
+    }
+}
+
+/// Check token program address
+fn check_token_program(address: &Pubkey) -> Result<(), ProgramError> {
+    if *address != spl_token::id() {
+        msg!(
+            "Incorrect token program, expected {}, received {}",
+            spl_token::id(),
+            address
+        );
+        Err(ProgramError::IncorrectProgramId)
+    } else {
+        Ok(())
+    }
+}
+
+/// Check stake program address
+fn check_stake_program(program_id: &Pubkey) -> Result<(), ProgramError> {
+    if *program_id != stake::program::id() {
+        msg!(
+            "Expected stake program {}, received {}",
+            stake::program::id(),
+            program_id
+        );
+        Err(ProgramError::IncorrectProgramId)
+    } else {
+        Ok(())
+    }
+}
+
+/// Check mpl metadata program
+fn check_mpl_metadata_program(program_id: &Pubkey) -> Result<(), ProgramError> {
+    if *program_id != mpl_token_metadata::id() {
+        msg!(
+            "Expected mpl metadata program {}, received {}",
+            mpl_token_metadata::id(),
+            program_id
+        );
+        Err(ProgramError::IncorrectProgramId)
+    } else {
+        Ok(())
+    }
+}
+
+/// Check account owner is the given program
+fn check_account_owner(
+    account_info: &AccountInfo,
+    program_id: &Pubkey,
+) -> Result<(), ProgramError> {
+    if *program_id != *account_info.owner {
+        msg!(
+            "Expected account to be owned by program {}, received {}",
+            program_id,
+            account_info.owner
+        );
+        Err(ProgramError::IncorrectProgramId)
+    } else {
+        Ok(())
+    }
+}
+
+/// Minimum delegation to create a pool
+/// We floor at 1sol to avoid over-minting tokens before the relevant feature is active
+fn minimum_delegation() -> Result<u64, ProgramError> {
+    Ok(std::cmp::max(
+        stake::tools::get_minimum_delegation()?,
+        LAMPORTS_PER_SOL,
+    ))
+}
+
+/// Program state handler.
+pub struct Processor {}
+impl Processor {
+    #[allow(clippy::too_many_arguments)]
+    fn stake_merge<'a>(
+        vote_account_key: &Pubkey,
+        source_account: AccountInfo<'a>,
+        authority: AccountInfo<'a>,
+        bump_seed: u8,
+        destination_account: AccountInfo<'a>,
+        clock: AccountInfo<'a>,
+        stake_history: AccountInfo<'a>,
+    ) -> Result<(), ProgramError> {
+        let authority_seeds = &[
+            POOL_AUTHORITY_PREFIX,
+            vote_account_key.as_ref(),
+            &[bump_seed],
+        ];
+        let signers = &[&authority_seeds[..]];
+
+        invoke_signed(
+            &stake::instruction::merge(destination_account.key, source_account.key, authority.key)
+                [0],
+            &[
+                destination_account,
+                source_account,
+                clock,
+                stake_history,
+                authority,
+            ],
+            signers,
+        )
+    }
+
+    fn stake_split<'a>(
+        vote_account_key: &Pubkey,
+        stake_account: AccountInfo<'a>,
+        authority: AccountInfo<'a>,
+        bump_seed: u8,
+        amount: u64,
+        split_stake: AccountInfo<'a>,
+    ) -> Result<(), ProgramError> {
+        let authority_seeds = &[
+            POOL_AUTHORITY_PREFIX,
+            vote_account_key.as_ref(),
+            &[bump_seed],
+        ];
+        let signers = &[&authority_seeds[..]];
+
+        let split_instruction =
+            stake::instruction::split(stake_account.key, authority.key, amount, split_stake.key);
+
+        invoke_signed(
+            split_instruction.last().unwrap(),
+            &[stake_account, split_stake, authority],
+            signers,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn stake_authorize<'a>(
+        vote_account_key: &Pubkey,
+        stake_account: AccountInfo<'a>,
+        stake_authority: AccountInfo<'a>,
+        bump_seed: u8,
+        new_stake_authority: &Pubkey,
+        clock: AccountInfo<'a>,
+    ) -> Result<(), ProgramError> {
+        let authority_seeds = &[
+            POOL_AUTHORITY_PREFIX,
+            vote_account_key.as_ref(),
+            &[bump_seed],
+        ];
+        let signers = &[&authority_seeds[..]];
+
+        let authorize_instruction = stake::instruction::authorize(
+            stake_account.key,
+            stake_authority.key,
+            new_stake_authority,
+            stake::state::StakeAuthorize::Staker,
+            None,
+        );
+
+        invoke_signed(
+            &authorize_instruction,
+            &[
+                stake_account.clone(),
+                clock.clone(),
+                stake_authority.clone(),
+            ],
+            signers,
+        )?;
+
+        let authorize_instruction = stake::instruction::authorize(
+            stake_account.key,
+            stake_authority.key,
+            new_stake_authority,
+            stake::state::StakeAuthorize::Withdrawer,
+            None,
+        );
+        invoke_signed(
+            &authorize_instruction,
+            &[stake_account, clock, stake_authority],
+            signers,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn stake_withdraw<'a>(
+        vote_account_key: &Pubkey,
+        stake_account: AccountInfo<'a>,
+        stake_authority: AccountInfo<'a>,
+        bump_seed: u8,
+        destination_account: AccountInfo<'a>,
+        clock: AccountInfo<'a>,
+        stake_history: AccountInfo<'a>,
+        lamports: u64,
+    ) -> Result<(), ProgramError> {
+        let authority_seeds = &[
+            POOL_AUTHORITY_PREFIX,
+            vote_account_key.as_ref(),
+            &[bump_seed],
+        ];
+        let signers = &[&authority_seeds[..]];
+
+        let withdraw_instruction = stake::instruction::withdraw(
+            stake_account.key,
+            stake_authority.key,
+            destination_account.key,
+            lamports,
+            None,
+        );
+
+        invoke_signed(
+            &withdraw_instruction,
+            &[
+                stake_account,
+                destination_account,
+                clock,
+                stake_history,
+                stake_authority,
+            ],
+            signers,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn token_mint_to<'a>(
+        vote_account_key: &Pubkey,
+        token_program: AccountInfo<'a>,
+        mint: AccountInfo<'a>,
+        destination: AccountInfo<'a>,
+        authority: AccountInfo<'a>,
+        bump_seed: u8,
+        amount: u64,
+    ) -> Result<(), ProgramError> {
+        let authority_seeds = &[
+            POOL_AUTHORITY_PREFIX,
+            vote_account_key.as_ref(),
+            &[bump_seed],
+        ];
+        let signers = &[&authority_seeds[..]];
+
+        let ix = spl_token::instruction::mint_to(
+            token_program.key,
+            mint.key,
+            destination.key,
+            authority.key,
+            &[],
+            amount,
+        )?;
+
+        invoke_signed(&ix, &[mint, destination, authority], signers)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn token_burn<'a>(
+        vote_account_key: &Pubkey,
+        token_program: AccountInfo<'a>,
+        burn_account: AccountInfo<'a>,
+        mint: AccountInfo<'a>,
+        authority: AccountInfo<'a>,
+        bump_seed: u8,
+        amount: u64,
+    ) -> Result<(), ProgramError> {
+        let authority_seeds = &[
+            POOL_AUTHORITY_PREFIX,
+            vote_account_key.as_ref(),
+            &[bump_seed],
+        ];
+        let signers = &[&authority_seeds[..]];
+
+        let ix = spl_token::instruction::burn(
+            token_program.key,
+            burn_account.key,
+            mint.key,
+            authority.key,
+            &[],
+            amount,
+        )?;
+
+        invoke_signed(&ix, &[burn_account, mint, authority], signers)
+    }
+
+    fn process_initialize_pool(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
+        let account_info_iter = &mut accounts.iter();
+        let vote_account_info = next_account_info(account_info_iter)?;
+        let pool_stake_info = next_account_info(account_info_iter)?;
+        let pool_authority_info = next_account_info(account_info_iter)?;
+        let pool_mint_info = next_account_info(account_info_iter)?;
+        let rent_info = next_account_info(account_info_iter)?;
+        let rent = &Rent::from_account_info(rent_info)?;
+        let clock_info = next_account_info(account_info_iter)?;
+        let stake_history_info = next_account_info(account_info_iter)?;
+        let stake_config_info = next_account_info(account_info_iter)?;
+        let system_program_info = next_account_info(account_info_iter)?;
+        let token_program_info = next_account_info(account_info_iter)?;
+        let stake_program_info = next_account_info(account_info_iter)?;
+
+        check_vote_account(vote_account_info)?;
+        let stake_bump_seed =
+            check_pool_stake_address(program_id, vote_account_info.key, pool_stake_info.key)?;
+        let authority_bump_seed = check_pool_authority_address(
+            program_id,
+            vote_account_info.key,
+            pool_authority_info.key,
+        )?;
+        let mint_bump_seed =
+            check_pool_mint_address(program_id, vote_account_info.key, pool_mint_info.key)?;
+        check_system_program(system_program_info.key)?;
+        check_token_program(token_program_info.key)?;
+        check_stake_program(stake_program_info.key)?;
+
+        let stake_seeds = &[
+            POOL_STAKE_PREFIX,
+            vote_account_info.key.as_ref(),
+            &[stake_bump_seed],
+        ];
+        let stake_signers = &[&stake_seeds[..]];
+
+        let authority_seeds = &[
+            POOL_AUTHORITY_PREFIX,
+            vote_account_info.key.as_ref(),
+            &[authority_bump_seed],
+        ];
+        let authority_signers = &[&authority_seeds[..]];
+
+        let mint_seeds = &[
+            POOL_MINT_PREFIX,
+            vote_account_info.key.as_ref(),
+            &[mint_bump_seed],
+        ];
+        let mint_signers = &[&mint_seeds[..]];
+
+        // create the pool mint. user has already transferred in rent
+        let mint_space = spl_token::state::Mint::LEN;
+
+        invoke_signed(
+            &system_instruction::allocate(pool_mint_info.key, mint_space as u64),
+            &[pool_mint_info.clone()],
+            mint_signers,
+        )?;
+
+        invoke_signed(
+            &system_instruction::assign(pool_mint_info.key, token_program_info.key),
+            &[pool_mint_info.clone()],
+            mint_signers,
+        )?;
+
+        invoke_signed(
+            &spl_token::instruction::initialize_mint2(
+                token_program_info.key,
+                pool_mint_info.key,
+                pool_authority_info.key,
+                None,
+                MINT_DECIMALS,
+            )?,
+            &[pool_mint_info.clone()],
+            authority_signers,
+        )?;
+
+        // create the pool stake account. user has already transferred in rent plus at least the minimum
+        let minimum_delegation = minimum_delegation()?;
+        let stake_space = std::mem::size_of::<stake::state::StakeState>();
+        let stake_rent_plus_initial = rent
+            .minimum_balance(stake_space)
+            .saturating_add(minimum_delegation);
+
+        if pool_stake_info.lamports() < stake_rent_plus_initial {
+            return Err(SinglePoolError::WrongRentAmount.into());
+        }
+
+        let authorized = stake::state::Authorized::auto(pool_authority_info.key);
+
+        invoke_signed(
+            &system_instruction::allocate(pool_stake_info.key, stake_space as u64),
+            &[pool_stake_info.clone()],
+            stake_signers,
+        )?;
+
+        invoke_signed(
+            &system_instruction::assign(pool_stake_info.key, stake_program_info.key),
+            &[pool_stake_info.clone()],
+            stake_signers,
+        )?;
+
+        invoke_signed(
+            &stake::instruction::initialize_checked(pool_stake_info.key, &authorized),
+            &[
+                pool_stake_info.clone(),
+                rent_info.clone(),
+                pool_authority_info.clone(),
+                pool_authority_info.clone(),
+            ],
+            authority_signers,
+        )?;
+
+        // delegate stake so it activates
+        invoke_signed(
+            &stake::instruction::delegate_stake(
+                pool_stake_info.key,
+                pool_authority_info.key,
+                vote_account_info.key,
+            ),
+            &[
+                pool_stake_info.clone(),
+                vote_account_info.clone(),
+                clock_info.clone(),
+                stake_history_info.clone(),
+                stake_config_info.clone(),
+                pool_authority_info.clone(),
+            ],
+            authority_signers,
+        )?;
+
+        Ok(())
+    }
+
+    fn process_deposit_stake(
+        program_id: &Pubkey,
+        accounts: &[AccountInfo],
+        vote_account_address: &Pubkey,
+    ) -> ProgramResult {
+        let account_info_iter = &mut accounts.iter();
+        let pool_stake_info = next_account_info(account_info_iter)?;
+        let pool_authority_info = next_account_info(account_info_iter)?;
+        let pool_mint_info = next_account_info(account_info_iter)?;
+        let user_stake_info = next_account_info(account_info_iter)?;
+        let user_token_account_info = next_account_info(account_info_iter)?;
+        let user_lamport_account_info = next_account_info(account_info_iter)?;
+        let clock_info = next_account_info(account_info_iter)?;
+        let clock = &Clock::from_account_info(clock_info)?;
+        let stake_history_info = next_account_info(account_info_iter)?;
+        let token_program_info = next_account_info(account_info_iter)?;
+        let stake_program_info = next_account_info(account_info_iter)?;
+
+        check_pool_stake_address(program_id, vote_account_address, pool_stake_info.key)?;
+        let bump_seed = check_pool_authority_address(
+            program_id,
+            vote_account_address,
+            pool_authority_info.key,
+        )?;
+        check_pool_mint_address(program_id, vote_account_address, pool_mint_info.key)?;
+        check_token_program(token_program_info.key)?;
+        check_stake_program(stake_program_info.key)?;
+
+        if pool_stake_info.key == user_stake_info.key {
+            return Err(SinglePoolError::InvalidPoolAccountUsage.into());
+        }
+
+        let minimum_delegation = minimum_delegation()?;
+
+        let (_, pool_stake_state) = get_stake_state(pool_stake_info)?;
+        let pre_pool_stake = pool_stake_state
+            .delegation
+            .stake
+            .saturating_sub(minimum_delegation);
+        msg!("Available stake pre merge {}", pre_pool_stake);
+
+        // user can deposit active stake into an active pool or inactive stake into an activating pool
+        let (_, user_stake_state) = get_stake_state(user_stake_info)?;
+        if is_stake_active_without_history(&pool_stake_state, clock.epoch)
+            != is_stake_active_without_history(&user_stake_state, clock.epoch)
+        {
+            return Err(SinglePoolError::WrongStakeState.into());
+        }
+
+        // merge the user stake account, which is preauthed to us, into the pool stake account
+        // this merge succeeding implicitly validates authority/lockup of the user stake account
+        Self::stake_merge(
+            vote_account_address,
+            user_stake_info.clone(),
+            pool_authority_info.clone(),
+            bump_seed,
+            pool_stake_info.clone(),
+            clock_info.clone(),
+            stake_history_info.clone(),
+        )?;
+
+        let (pool_stake_meta, pool_stake_state) = get_stake_state(pool_stake_info)?;
+        let post_pool_stake = pool_stake_state
+            .delegation
+            .stake
+            .saturating_sub(minimum_delegation);
+        let post_pool_lamports = pool_stake_info.lamports();
+        msg!("Available stake post merge {}", post_pool_stake);
+
+        // stake lamports added, as a stake difference
+        let stake_added = post_pool_stake
+            .checked_sub(pre_pool_stake)
+            .ok_or(SinglePoolError::ArithmeticOverflow)?;
+
+        // we calculate absolute rather than relative to deposit amount to allow claiming lamports mistakenly transferred in
+        let excess_lamports = post_pool_lamports
+            .checked_sub(pool_stake_state.delegation.stake)
+            .and_then(|amount| amount.checked_sub(pool_stake_meta.rent_exempt_reserve))
+            .ok_or(SinglePoolError::ArithmeticOverflow)?;
+
+        // sanity check: we have not somehow gone below the minimum
+        if post_pool_stake < minimum_delegation {
+            return Err(SinglePoolError::UnexpectedMathError.into());
+        }
+
+        // sanity check: the user stake account is empty
+        if user_stake_info.lamports() != 0 {
+            return Err(SinglePoolError::UnexpectedMathError.into());
+        }
+
+        let token_supply = {
+            let pool_mint_data = pool_mint_info.try_borrow_data()?;
+            let pool_mint = Mint::unpack_from_slice(&pool_mint_data)?;
+            pool_mint.supply
+        };
+
+        // deposit amount is determined off stake because we return excess rent
+        let new_pool_tokens = calculate_deposit_amount(token_supply, pre_pool_stake, stake_added)
+            .ok_or(SinglePoolError::UnexpectedMathError)?;
+
+        if new_pool_tokens == 0 {
+            return Err(SinglePoolError::DepositTooSmall.into());
+        }
+
+        // mint tokens to the user corresponding to their stake deposit
+        Self::token_mint_to(
+            vote_account_address,
+            token_program_info.clone(),
+            pool_mint_info.clone(),
+            user_token_account_info.clone(),
+            pool_authority_info.clone(),
+            bump_seed,
+            new_pool_tokens,
+        )?;
+
+        // return the lamports their stake account previously held for rent-exemption
+        if excess_lamports > 0 {
+            Self::stake_withdraw(
+                vote_account_address,
+                pool_stake_info.clone(),
+                pool_authority_info.clone(),
+                bump_seed,
+                user_lamport_account_info.clone(),
+                clock_info.clone(),
+                stake_history_info.clone(),
+                excess_lamports,
+            )?;
+        }
+
+        Ok(())
+    }
+
+    fn process_withdraw_stake(
+        program_id: &Pubkey,
+        accounts: &[AccountInfo],
+        vote_account_address: &Pubkey,
+        user_stake_authority: &Pubkey,
+        token_amount: u64,
+    ) -> ProgramResult {
+        let account_info_iter = &mut accounts.iter();
+        let pool_stake_info = next_account_info(account_info_iter)?;
+        let pool_authority_info = next_account_info(account_info_iter)?;
+        let pool_mint_info = next_account_info(account_info_iter)?;
+        let user_stake_info = next_account_info(account_info_iter)?;
+        let user_token_account_info = next_account_info(account_info_iter)?;
+        let clock_info = next_account_info(account_info_iter)?;
+        let token_program_info = next_account_info(account_info_iter)?;
+        let stake_program_info = next_account_info(account_info_iter)?;
+
+        check_pool_stake_address(program_id, vote_account_address, pool_stake_info.key)?;
+        let bump_seed = check_pool_authority_address(
+            program_id,
+            vote_account_address,
+            pool_authority_info.key,
+        )?;
+        check_pool_mint_address(program_id, vote_account_address, pool_mint_info.key)?;
+        check_token_program(token_program_info.key)?;
+        check_stake_program(stake_program_info.key)?;
+
+        if pool_stake_info.key == user_stake_info.key {
+            return Err(SinglePoolError::InvalidPoolAccountUsage.into());
+        }
+
+        let minimum_delegation = minimum_delegation()?;
+
+        let pre_pool_stake = get_stake_amount(pool_stake_info)?.saturating_sub(minimum_delegation);
+        msg!("Available stake pre split {}", pre_pool_stake);
+
+        let token_supply = {
+            let pool_mint_data = pool_mint_info.try_borrow_data()?;
+            let pool_mint = Mint::unpack_from_slice(&pool_mint_data)?;
+            pool_mint.supply
+        };
+
+        // withdraw amount is determined off stake just like deposit amount
+        let withdraw_stake = calculate_withdraw_amount(token_supply, pre_pool_stake, token_amount)
+            .ok_or(SinglePoolError::UnexpectedMathError)?;
+
+        if withdraw_stake == 0 {
+            return Err(SinglePoolError::WithdrawalTooSmall.into());
+        }
+
+        // the second case should never be true, but its best to be sure
+        if withdraw_stake > pre_pool_stake || withdraw_stake == pool_stake_info.lamports() {
+            return Err(SinglePoolError::WithdrawalTooLarge.into());
+        }
+
+        // burn user tokens corresponding to the amount of stake they wish to withdraw
+        Self::token_burn(
+            vote_account_address,
+            token_program_info.clone(),
+            user_token_account_info.clone(),
+            pool_mint_info.clone(),
+            pool_authority_info.clone(),
+            bump_seed,
+            token_amount,
+        )?;
+
+        // split stake into a blank stake account the user has created for this purpose
+        Self::stake_split(
+            vote_account_address,
+            pool_stake_info.clone(),
+            pool_authority_info.clone(),
+            bump_seed,
+            withdraw_stake,
+            user_stake_info.clone(),
+        )?;
+
+        // assign both authorities on the new stake account to the user
+        Self::stake_authorize(
+            vote_account_address,
+            user_stake_info.clone(),
+            pool_authority_info.clone(),
+            bump_seed,
+            user_stake_authority,
+            clock_info.clone(),
+        )?;
+
+        let post_pool_stake = get_stake_amount(pool_stake_info)?.saturating_sub(minimum_delegation);
+        msg!("Available stake post split {}", post_pool_stake);
+
+        Ok(())
+    }
+
+    fn process_create_pool_token_metadata(
+        program_id: &Pubkey,
+        accounts: &[AccountInfo],
+        vote_account_address: &Pubkey,
+    ) -> ProgramResult {
+        let account_info_iter = &mut accounts.iter();
+        let pool_authority_info = next_account_info(account_info_iter)?;
+        let pool_mint_info = next_account_info(account_info_iter)?;
+        let payer_info = next_account_info(account_info_iter)?;
+        let metadata_info = next_account_info(account_info_iter)?;
+        let mpl_token_metadata_program_info = next_account_info(account_info_iter)?;
+        let system_program_info = next_account_info(account_info_iter)?;
+
+        let bump_seed = check_pool_authority_address(
+            program_id,
+            vote_account_address,
+            pool_authority_info.key,
+        )?;
+        check_pool_mint_address(program_id, vote_account_address, pool_mint_info.key)?;
+        check_system_program(system_program_info.key)?;
+        check_account_owner(payer_info, &system_program::id())?;
+        check_mpl_metadata_program(mpl_token_metadata_program_info.key)?;
+        check_mpl_metadata_account_address(metadata_info.key, pool_mint_info.key)?;
+
+        if !payer_info.is_signer {
+            msg!("Payer did not sign metadata creation");
+            return Err(SinglePoolError::SignatureMissing.into());
+        }
+
+        // checking the mint exists confirms pool is initialized
+        {
+            let pool_mint_data = pool_mint_info.try_borrow_data()?;
+            let _ = Mint::unpack_from_slice(&pool_mint_data)?;
+        }
+
+        let vote_address_str = vote_account_address.to_string();
+        let token_name = format!("SPL Single Pool {}", &vote_address_str[0..15]);
+        let token_symbol = format!("st{}", &vote_address_str[0..7]);
+
+        let new_metadata_instruction = create_metadata_accounts_v3(
+            *mpl_token_metadata_program_info.key,
+            *metadata_info.key,
+            *pool_mint_info.key,
+            *pool_authority_info.key,
+            *payer_info.key,
+            *pool_authority_info.key,
+            token_name,
+            token_symbol,
+            "".to_string(),
+            None,
+            0,
+            true,
+            true,
+            None,
+            None,
+            None,
+        );
+
+        let authority_seeds = &[
+            POOL_AUTHORITY_PREFIX,
+            vote_account_address.as_ref(),
+            &[bump_seed],
+        ];
+        let signers = &[&authority_seeds[..]];
+
+        invoke_signed(
+            &new_metadata_instruction,
+            &[
+                metadata_info.clone(),
+                pool_mint_info.clone(),
+                pool_authority_info.clone(),
+                payer_info.clone(),
+                pool_authority_info.clone(),
+                system_program_info.clone(),
+            ],
+            signers,
+        )?;
+
+        Ok(())
+    }
+
+    fn process_update_pool_token_metadata(
+        program_id: &Pubkey,
+        accounts: &[AccountInfo],
+        name: String,
+        symbol: String,
+        uri: String,
+    ) -> ProgramResult {
+        let account_info_iter = &mut accounts.iter();
+        let vote_account_info = next_account_info(account_info_iter)?;
+        let pool_authority_info = next_account_info(account_info_iter)?;
+        let authorized_withdrawer_info = next_account_info(account_info_iter)?;
+        let metadata_info = next_account_info(account_info_iter)?;
+        let mpl_token_metadata_program_info = next_account_info(account_info_iter)?;
+
+        check_vote_account(vote_account_info)?;
+        let bump_seed = check_pool_authority_address(
+            program_id,
+            vote_account_info.key,
+            pool_authority_info.key,
+        )?;
+        let pool_mint_address = crate::find_pool_mint_address(program_id, vote_account_info.key);
+        check_mpl_metadata_program(mpl_token_metadata_program_info.key)?;
+        check_mpl_metadata_account_address(metadata_info.key, &pool_mint_address)?;
+
+        // we use authorized_withdrawer to authenticate the caller controls the vote account
+        // this is safer than using an authorized_voter since those keys live hot
+        // and validator-operators we spoke with indicated this would be their preference as well
+        let vote_account_data = &vote_account_info.try_borrow_data()?;
+        let vote_account_withdrawer = vote_account_data
+            .get(VOTE_STATE_START..VOTE_STATE_END)
+            .map(Pubkey::new)
+            .ok_or(SinglePoolError::UnparseableVoteAccount)?;
+
+        if *authorized_withdrawer_info.key != vote_account_withdrawer {
+            msg!("Vote account authorized withdrawer does not match the account provided.");
+            return Err(SinglePoolError::InvalidMetadataSigner.into());
+        }
+
+        if !authorized_withdrawer_info.is_signer {
+            msg!("Vote account authorized withdrawer did not sign metadata update.");
+            return Err(SinglePoolError::SignatureMissing.into());
+        }
+
+        let update_metadata_accounts_instruction = update_metadata_accounts_v2(
+            *mpl_token_metadata_program_info.key,
+            *metadata_info.key,
+            *pool_authority_info.key,
+            None,
+            Some(DataV2 {
+                name,
+                symbol,
+                uri,
+                seller_fee_basis_points: 0,
+                creators: None,
+                collection: None,
+                uses: None,
+            }),
+            None,
+            Some(true),
+        );
+
+        let authority_seeds = &[
+            POOL_AUTHORITY_PREFIX,
+            vote_account_info.key.as_ref(),
+            &[bump_seed],
+        ];
+        let signers = &[&authority_seeds[..]];
+
+        invoke_signed(
+            &update_metadata_accounts_instruction,
+            &[metadata_info.clone(), pool_authority_info.clone()],
+            signers,
+        )?;
+
+        Ok(())
+    }
+
+    /// Processes [Instruction](enum.Instruction.html).
+    pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> ProgramResult {
+        let instruction = SinglePoolInstruction::try_from_slice(input)?;
+        match instruction {
+            SinglePoolInstruction::InitializePool => {
+                msg!("Instruction: InitializePool");
+                Self::process_initialize_pool(program_id, accounts)
+            }
+            SinglePoolInstruction::DepositStake {
+                vote_account_address,
+            } => {
+                msg!("Instruction: DepositStake");
+                Self::process_deposit_stake(program_id, accounts, &vote_account_address)
+            }
+            SinglePoolInstruction::WithdrawStake {
+                vote_account_address,
+                user_stake_authority,
+                token_amount,
+            } => {
+                msg!("Instruction: WithdrawStake");
+                Self::process_withdraw_stake(
+                    program_id,
+                    accounts,
+                    &vote_account_address,
+                    &user_stake_authority,
+                    token_amount,
+                )
+            }
+            SinglePoolInstruction::CreateTokenMetadata {
+                vote_account_address,
+            } => {
+                msg!("Instruction: CreateTokenMetadata");
+                Self::process_create_pool_token_metadata(
+                    program_id,
+                    accounts,
+                    &vote_account_address,
+                )
+            }
+            SinglePoolInstruction::UpdateTokenMetadata { name, symbol, uri } => {
+                msg!("Instruction: UpdateTokenMetadata");
+                Self::process_update_pool_token_metadata(program_id, accounts, name, symbol, uri)
+            }
+        }
+    }
+}


### PR DESCRIPTION
this is obviously a very rough sketch, but just to give an idea of what i had in mind re: "what if the 1lamp minimum stays and we did a new single-validator stake pool program instead of an automated manager on top of the existing one"

welcome to the stake birdbath

```
hana@laptop:stake-pool$ wc program/src/*
   366   1222  12000 program/src/big_vec.rs
    26     59    711 program/src/entrypoint.rs
   154    530   5592 program/src/error.rs
  1736   5652  64508 program/src/instruction.rs
   175    552   5369 program/src/lib.rs
  3950   9342 167792 program/src/processor.rs
  1329   4483  49937 program/src/state.rs
  7736  21840 305909 total
hana@laptop:stake-pool$ wc birdbath/src/*
   26    59   711 birdbath/src/entrypoint.rs
  154   530  5592 birdbath/src/error.rs
  261   648  8991 birdbath/src/instruction.rs
   45   135  1352 birdbath/src/lib.rs
  974  2817 38164 birdbath/src/processor.rs
 1460  4189 54810 total
```

when i said "reduced attack surface" this is basically what i meant. we can get rid of ~80% of the code, including all the tricky calculations, fees, multiple stake accounts, different validators, all kinds of stuff just gets deleted. bigvec and all state go away (although i might stick the validator pubkey on the signing authority just to make the code "feel" safer)

right now this only has five instructions: initialize, deposit, withdraw, create metaplex metadata, update metaplex metadata. i realized while doing my deletions that the fourth instruction can go away too, and we can just stick that in initialize

a possible fifth (nee sixth) instruction would be a mechanism for a user to deposit sol, to give a "click to stake" ux where they dont need to run two transactions. i had a few ideas of how to do this, but the common theme is they create a stake account, delegate it, and assign its authorities to the program. these transient stake accounts could be swept into the main pool account permissionlessly, and tokens would be minted to the user when this happens, so no fees and no reserve are required

obvi no need to "review" just curious what you think. lines 395-720 of processor.rs are the interesting bits

part of #4077 