### PR TITLE
Governance: Allow token owner to revoke their own membership

### DIFF
--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -505,7 +505,9 @@ pub enum GovernanceInstruction {
     ///  1. `[writable]` Governing Token Holding account. PDA seeds: ['governance',realm, governing_token_mint]
     ///  2. `[writable]` TokenOwnerRecord account. PDA seeds: ['governance',realm, governing_token_mint, governing_token_owner]
     ///  3. `[writable]` GoverningTokenMint
-    ///  4. `[signer]` GoverningTokenMint mint_authority
+    ///  4. `[signer]` Revoke authority which can be either of:
+    ///                1) GoverningTokenMint mint_authority to forcefully revoke the membership tokens
+    ///                2) GoverningTokenOwner who voluntarily revokes their own membership
     ///  5. `[]` RealmConfig account. PDA seeds: ['realm-config', realm]
     ///  6. `[]` SPL Token program
     RevokeGoverningTokens {
@@ -1566,7 +1568,7 @@ pub fn revoke_governing_tokens(
     realm: &Pubkey,
     governing_token_owner: &Pubkey,
     governing_token_mint: &Pubkey,
-    governing_token_mint_authority: &Pubkey,
+    revoke_authority: &Pubkey,
     // Args
     amount: u64,
 ) -> Instruction {
@@ -1587,7 +1589,7 @@ pub fn revoke_governing_tokens(
         AccountMeta::new(governing_token_holding_address, false),
         AccountMeta::new(token_owner_record_address, false),
         AccountMeta::new(*governing_token_mint, false),
-        AccountMeta::new_readonly(*governing_token_mint_authority, true),
+        AccountMeta::new_readonly(*revoke_authority, true),
         AccountMeta::new_readonly(realm_config_address, false),
         AccountMeta::new_readonly(spl_token::id(), false),
     ];

--- a/governance/program/src/state/realm_config.rs
+++ b/governance/program/src/state/realm_config.rs
@@ -124,7 +124,7 @@ impl RealmConfigAccount {
         Ok(token_config)
     }
 
-    /// Assertes the given governing token can be revoked
+    /// Asserts the given governing token can be revoked
     pub fn assert_can_revoke_governing_token(
         &self,
         realm_data: &RealmV2,

--- a/governance/program/tests/process_revoke_governing_tokens.rs
+++ b/governance/program/tests/process_revoke_governing_tokens.rs
@@ -267,7 +267,7 @@ async fn test_revoke_council_tokens_with_mint_authority_must_sign_error() {
 }
 
 #[tokio::test]
-async fn test_revoke_council_tokens_with_invalid_mint_authority_error() {
+async fn test_revoke_council_tokens_with_invalid_revoke_authority_error() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
 
@@ -283,19 +283,16 @@ async fn test_revoke_council_tokens_with_invalid_mint_authority_error() {
         .await
         .unwrap();
 
-    // Try to use fake authority
-    let mint_authority = Keypair::new();
-
     // Act
     let err = governance_test
         .revoke_governing_tokens_using_instruction(
             &realm_cookie,
             &token_owner_record_cookie,
             &realm_cookie.account.config.council_mint.unwrap(),
-            realm_cookie.council_mint_authority.as_ref().unwrap(),
+            &Keypair::new(), // Try to use fake authority
             1,
-            |i| i.accounts[4].pubkey = mint_authority.pubkey(), // mint_authority
-            Some(&[&mint_authority]),
+            NopOverride,
+            None,
         )
         .await
         .err()

--- a/governance/program/tests/process_revoke_governing_tokens.rs
+++ b/governance/program/tests/process_revoke_governing_tokens.rs
@@ -93,6 +93,48 @@ async fn test_revoke_council_tokens() {
 }
 
 #[tokio::test]
+async fn test_revoke_own_council_tokens() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let mut realm_config_args = RealmSetupArgs::default();
+    realm_config_args.council_token_config_args.token_type = GoverningTokenType::Membership;
+
+    let realm_cookie = governance_test
+        .with_realm_using_args(&realm_config_args)
+        .await;
+
+    let token_owner_record_cookie = governance_test
+        .with_council_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    // Act
+    governance_test
+        .revoke_governing_tokens_using_instruction(
+            &realm_cookie,
+            &token_owner_record_cookie,
+            &realm_cookie.account.config.council_mint.unwrap(),
+            &token_owner_record_cookie.token_owner,
+            token_owner_record_cookie
+                .account
+                .governing_token_deposit_amount,
+            NopOverride,
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Assert
+
+    let token_owner_record = governance_test
+        .get_token_owner_record_account(&token_owner_record_cookie.address)
+        .await;
+
+    assert_eq!(token_owner_record.governing_token_deposit_amount, 0);
+}
+
+#[tokio::test]
 async fn test_revoke_community_tokens_with_cannot_revoke_liquid_token_error() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;
@@ -171,6 +213,7 @@ async fn test_revoke_council_tokens_with_mint_authority_must_sign_error() {
             &realm_cookie,
             &token_owner_record_cookie,
             &realm_cookie.account.config.council_mint.unwrap(),
+            realm_cookie.council_mint_authority.as_ref().unwrap(),
             1,
             |i| i.accounts[4].is_signer = false, // mint_authority
             Some(&[]),
@@ -210,6 +253,7 @@ async fn test_revoke_council_tokens_with_invalid_mint_authority_error() {
             &realm_cookie,
             &token_owner_record_cookie,
             &realm_cookie.account.config.council_mint.unwrap(),
+            realm_cookie.council_mint_authority.as_ref().unwrap(),
             1,
             |i| i.accounts[4].pubkey = mint_authority.pubkey(), // mint_authority
             Some(&[&mint_authority]),
@@ -253,6 +297,7 @@ async fn test_revoke_council_tokens_with_invalid_token_holding_error() {
             &realm_cookie,
             &token_owner_record_cookie,
             &realm_cookie.account.config.council_mint.unwrap(),
+            realm_cookie.council_mint_authority.as_ref().unwrap(),
             1,
             |i| i.accounts[1].pubkey = governing_token_holding_address, // governing_token_holding_address
             None,
@@ -295,6 +340,7 @@ async fn test_revoke_council_tokens_with_other_realm_config_account_error() {
             &realm_cookie,
             &token_owner_record_cookie,
             &realm_cookie.account.config.council_mint.unwrap(),
+            realm_cookie.council_mint_authority.as_ref().unwrap(),
             1,
             |i| i.accounts[5].pubkey = realm_cookie2.realm_config.address, //realm_config_address
             None,
@@ -334,6 +380,7 @@ async fn test_revoke_council_tokens_with_invalid_realm_config_account_address_er
             &realm_cookie,
             &token_owner_record_cookie,
             &realm_cookie.account.config.council_mint.unwrap(),
+            realm_cookie.council_mint_authority.as_ref().unwrap(),
             1,
             |i| i.accounts[5].pubkey = realm_config_address, // realm_config_address
             None,
@@ -376,6 +423,7 @@ async fn test_revoke_council_tokens_with_token_owner_record_for_different_mint_e
             &realm_cookie,
             &token_owner_record_cookie,
             &realm_cookie.account.config.council_mint.unwrap(),
+            realm_cookie.council_mint_authority.as_ref().unwrap(),
             1,
             |i| i.accounts[2].pubkey = token_owner_record_cookie2.address, // token_owner_record_address
             None,
@@ -415,6 +463,7 @@ async fn test_revoke_council_tokens_with_too_large_amount_error() {
             &realm_cookie,
             &token_owner_record_cookie,
             &realm_cookie.account.config.council_mint.unwrap(),
+            realm_cookie.council_mint_authority.as_ref().unwrap(),
             200,
             NopOverride,
             None,
@@ -451,6 +500,7 @@ async fn test_revoke_council_tokens_with_partial_revoke_amount() {
             &realm_cookie,
             &token_owner_record_cookie,
             &realm_cookie.account.config.council_mint.unwrap(),
+            realm_cookie.council_mint_authority.as_ref().unwrap(),
             5,
             NopOverride,
             None,
@@ -499,6 +549,7 @@ async fn test_revoke_council_tokens_with_community_mint_error() {
             &realm_cookie,
             &token_owner_record_cookie,
             &realm_cookie.account.config.council_mint.unwrap(),
+            realm_cookie.council_mint_authority.as_ref().unwrap(),
             1,
             |i| {
                 i.accounts[1].pubkey = governing_token_holding_address;
@@ -543,6 +594,7 @@ async fn test_revoke_council_tokens_with_not_matching_mint_and_authority_error()
             &realm_cookie,
             &token_owner_record_cookie,
             &realm_cookie.account.config.council_mint.unwrap(),
+            realm_cookie.council_mint_authority.as_ref().unwrap(),
             1,
             |i| {
                 i.accounts[3].pubkey = governing_token_mint;

--- a/governance/program/tests/program_test/cookies.rs
+++ b/governance/program/tests/program_test/cookies.rs
@@ -36,18 +36,6 @@ pub struct RealmCookie {
     pub realm_config: RealmConfigCookie,
 }
 
-impl RealmCookie {
-    pub fn get_mint_authority(&self, governing_token_mint: &Pubkey) -> &Keypair {
-        if *governing_token_mint == self.account.community_mint {
-            &self.community_mint_authority
-        } else if Some(*governing_token_mint) == self.account.config.council_mint {
-            self.council_mint_authority.as_ref().unwrap()
-        } else {
-            panic!("Invalid governing_token_mint")
-        }
-    }
-}
-
 #[derive(Debug)]
 pub struct RealmConfigCookie {
     pub address: Pubkey,

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1276,6 +1276,7 @@ impl GovernanceProgramTest {
             realm_cookie,
             token_owner_record_cookie,
             &realm_cookie.account.community_mint,
+            &realm_cookie.community_mint_authority,
             token_owner_record_cookie
                 .account
                 .governing_token_deposit_amount,
@@ -1295,6 +1296,7 @@ impl GovernanceProgramTest {
             realm_cookie,
             token_owner_record_cookie,
             &realm_cookie.account.config.council_mint.unwrap(),
+            realm_cookie.council_mint_authority.as_ref().unwrap(),
             token_owner_record_cookie
                 .account
                 .governing_token_deposit_amount,
@@ -1310,24 +1312,23 @@ impl GovernanceProgramTest {
         realm_cookie: &RealmCookie,
         token_owner_record_cookie: &TokenOwnerRecordCookie,
         governing_token_mint: &Pubkey,
+        revoke_authority: &Keypair,
         amount: u64,
         instruction_override: F,
         signers_override: Option<&[&Keypair]>,
     ) -> Result<(), ProgramError> {
-        let governing_token_mint_authority = realm_cookie.get_mint_authority(governing_token_mint);
-
         let mut revoke_governing_tokens_ix = revoke_governing_tokens(
             &self.program_id,
             &realm_cookie.address,
             &token_owner_record_cookie.account.governing_token_owner,
             governing_token_mint,
-            &governing_token_mint_authority.pubkey(),
+            &revoke_authority.pubkey(),
             amount,
         );
 
         instruction_override(&mut revoke_governing_tokens_ix);
 
-        let default_signers = &[governing_token_mint_authority];
+        let default_signers = &[revoke_authority];
         let signers = signers_override.unwrap_or(default_signers);
 
         self.bench

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1307,6 +1307,7 @@ impl GovernanceProgramTest {
     }
 
     #[allow(dead_code)]
+    #[allow(clippy::too_many_arguments)]
     pub async fn revoke_governing_tokens_using_instruction<F: Fn(&mut Instruction)>(
         &mut self,
         realm_cookie: &RealmCookie,


### PR DESCRIPTION
#### Summary

Make it possible for the owner of governing `Membership` token to voluntarily revoke its own memebership