### PR TITLE
stake-pool: Remove lamport minimum for validator removal by staker

### DIFF
--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -1193,9 +1193,22 @@ impl Processor {
             return Err(StakePoolError::ValidatorNotFound.into());
         }
 
+        // `DecreaseValidatorStake` requires a minimum of the same minimum delegation
+        // amount. With a strict minimum, a validator at 1.9x min delegation
+        // requires the following sequence to deactivate:
+        //
+        // * IncreaseValidatorStake - bring amount to 2.9x min delegation
+        // * DecreaseValidatorStake - reduce amount to 1.0x min delegation
+        // * RemoveValidatorFromPool
+        //
+        // This additional lamport buffer makes validator removal easier.
+        const LAMPORT_BUFFER_FACTOR: u64 = 2;
+
         let stake_lamports = **stake_account_info.lamports.borrow();
         let stake_minimum_delegation = stake::tools::get_minimum_delegation()?;
-        let required_lamports = minimum_stake_lamports(&meta, stake_minimum_delegation);
+        let required_lamports = minimum_stake_lamports(&meta, stake_minimum_delegation)
+            .saturating_mul(LAMPORT_BUFFER_FACTOR);
+
         if stake_lamports > required_lamports {
             msg!(
                 "Attempting to remove validator account with {} lamports, must have no more than {} lamports; \
@@ -1206,13 +1219,18 @@ impl Processor {
             return Err(StakePoolError::StakeLamportsNotEqualToMinimum.into());
         }
 
-        let current_minimum_delegation = minimum_delegation(stake_minimum_delegation);
-        if stake.delegation.stake > current_minimum_delegation {
+        // add the rent exempt reserve to the required delegation amount, since
+        // a decreasing stake must have at least rent-exemption plus minimum-delegation,
+        // and the source stake must still have minimum-delegation
+        let required_delegation = minimum_delegation(stake_minimum_delegation)
+            .saturating_mul(LAMPORT_BUFFER_FACTOR)
+            .saturating_add(meta.rent_exempt_reserve);
+        if stake.delegation.stake > required_delegation {
             msg!(
                 "Error: attempting to remove stake with delegation of {} lamports, must have no more than {} lamports; \
                 reduce using DecreaseValidatorStake first",
                 stake.delegation.stake,
-                current_minimum_delegation
+                required_delegation
             );
             return Err(StakePoolError::StakeLamportsNotEqualToMinimum.into());
         }

--- a/stake-pool/program/tests/vsa_remove.rs
+++ b/stake-pool/program/tests/vsa_remove.rs
@@ -212,17 +212,112 @@ async fn fail_with_wrong_validator_list_account() {
 }
 
 #[tokio::test]
-async fn fail_not_at_minimum() {
+async fn success_at_minimum() {
     let (mut context, stake_pool_accounts, validator_stake) = setup().await;
 
-    transfer(
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let stake_rent = rent.minimum_balance(std::mem::size_of::<stake::state::StakeState>());
+    let current_minimum_delegation = stake_pool_get_minimum_delegation(
         &mut context.banks_client,
         &context.payer,
         &context.last_blockhash,
-        &validator_stake.stake_account,
-        1_000_001,
     )
     .await;
+
+    // This is goofy, but it enforces that we can reduce down to the exact number
+    // we want to test, and also shows why the relaxed threshold is so useful!
+    let threshold_amount = (current_minimum_delegation + stake_rent) * 2;
+    let _ = simple_deposit_stake(
+        &mut context.banks_client,
+        &context.payer,
+        &context.last_blockhash,
+        &stake_pool_accounts,
+        &validator_stake,
+        threshold_amount,
+    )
+    .await
+    .unwrap();
+
+    let validator_stake_lamports =
+        get_account(&mut context.banks_client, &validator_stake.stake_account)
+            .await
+            .lamports;
+
+    // decrease to exactly the minimum
+    let decrease_amount = validator_stake_lamports - threshold_amount;
+
+    let error = stake_pool_accounts
+        .decrease_validator_stake(
+            &mut context.banks_client,
+            &context.payer,
+            &context.last_blockhash,
+            &validator_stake.stake_account,
+            &validator_stake.transient_stake_account,
+            decrease_amount,
+            validator_stake.transient_stake_seed,
+        )
+        .await;
+    assert!(error.is_none());
+
+    let error = stake_pool_accounts
+        .remove_validator_from_pool(
+            &mut context.banks_client,
+            &context.payer,
+            &context.last_blockhash,
+            &validator_stake.stake_account,
+            &validator_stake.transient_stake_account,
+        )
+        .await;
+    assert!(error.is_none());
+}
+
+#[tokio::test]
+async fn fail_not_at_minimum() {
+    let (mut context, stake_pool_accounts, validator_stake) = setup().await;
+
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let stake_rent = rent.minimum_balance(std::mem::size_of::<stake::state::StakeState>());
+    let current_minimum_delegation = stake_pool_get_minimum_delegation(
+        &mut context.banks_client,
+        &context.payer,
+        &context.last_blockhash,
+    )
+    .await;
+
+    // This is goofy, but it enforces that we can reduce down to the exact number
+    // we want to test, and also shows why the relaxed threshold is so useful!
+    let threshold_amount = (current_minimum_delegation + stake_rent) * 2;
+    let _ = simple_deposit_stake(
+        &mut context.banks_client,
+        &context.payer,
+        &context.last_blockhash,
+        &stake_pool_accounts,
+        &validator_stake,
+        threshold_amount,
+    )
+    .await
+    .unwrap();
+
+    let validator_stake_lamports =
+        get_account(&mut context.banks_client, &validator_stake.stake_account)
+            .await
+            .lamports;
+
+    // decrease one less than the minimum
+    let decrease_amount = validator_stake_lamports - threshold_amount - 1;
+
+    let error = stake_pool_accounts
+        .decrease_validator_stake(
+            &mut context.banks_client,
+            &context.payer,
+            &context.last_blockhash,
+            &validator_stake.stake_account,
+            &validator_stake.transient_stake_account,
+            decrease_amount,
+            validator_stake.transient_stake_seed,
+        )
+        .await;
+    assert!(error.is_none());
 
     let error = stake_pool_accounts
         .remove_validator_from_pool(


### PR DESCRIPTION
#### Problem

Deactivating a validator requires reducing its active stake to the minimum delegation first. However, the funds all go back to the reserve anyway, so there's no reason to gate the removal to some lamport amount.

#### Solution

Remove the lamport check.

Fixes #3994