### PR TITLE
token-2022: Fix non-transferable extension for unchecked transfers

### DIFF
--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -246,7 +246,8 @@ pub async fn create_token_account(
             ),
             ExtensionType::TransferFeeAmount
             | ExtensionType::MemoTransfer
-            | ExtensionType::CpiGuard => (),
+            | ExtensionType::CpiGuard
+            | ExtensionType::NonTransferableAccount => (),
             _ => unimplemented!(),
         };
     }
@@ -288,7 +289,9 @@ pub async fn create_token_account(
                     .unwrap(),
                 )
             }
-            ExtensionType::ImmutableOwner | ExtensionType::TransferFeeAmount => (),
+            ExtensionType::ImmutableOwner
+            | ExtensionType::TransferFeeAmount
+            | ExtensionType::NonTransferableAccount => (),
             _ => unimplemented!(),
         }
     }

--- a/token/js/src/extensions/extensionType.ts
+++ b/token/js/src/extensions/extensionType.ts
@@ -9,7 +9,7 @@ import { IMMUTABLE_OWNER_SIZE } from './immutableOwner.js';
 import { INTEREST_BEARING_MINT_CONFIG_STATE_SIZE } from './interestBearingMint/state.js';
 import { MEMO_TRANSFER_SIZE } from './memoTransfer/index.js';
 import { MINT_CLOSE_AUTHORITY_SIZE } from './mintCloseAuthority.js';
-import { NON_TRANSFERABLE_SIZE } from './nonTransferable.js';
+import { NON_TRANSFERABLE_SIZE, NON_TRANSFERABLE_ACCOUNT_SIZE } from './nonTransferable.js';
 import { PERMANENT_DELEGATE_SIZE } from './permanentDelegate.js';
 import { TRANSFER_FEE_AMOUNT_SIZE, TRANSFER_FEE_CONFIG_SIZE } from './transferFee/index.js';
 
@@ -27,6 +27,7 @@ export enum ExtensionType {
     InterestBearingConfig,
     CpiGuard,
     PermanentDelegate,
+    NonTransferableAccount,
 }
 
 export const TYPE_SIZE = 2;
@@ -62,6 +63,8 @@ export function getTypeLen(e: ExtensionType): number {
             return INTEREST_BEARING_MINT_CONFIG_STATE_SIZE;
         case ExtensionType.PermanentDelegate:
             return PERMANENT_DELEGATE_SIZE;
+        case ExtensionType.NonTransferableAccount:
+            return NON_TRANSFERABLE_ACCOUNT_SIZE;
         default:
             throw Error(`Unknown extension type: ${e}`);
     }
@@ -83,6 +86,7 @@ export function isMintExtension(e: ExtensionType): boolean {
         case ExtensionType.ImmutableOwner:
         case ExtensionType.MemoTransfer:
         case ExtensionType.CpiGuard:
+        case ExtensionType.NonTransferableAccount:
             return false;
         default:
             throw Error(`Unknown extension type: ${e}`);
@@ -96,6 +100,7 @@ export function isAccountExtension(e: ExtensionType): boolean {
         case ExtensionType.ImmutableOwner:
         case ExtensionType.MemoTransfer:
         case ExtensionType.CpiGuard:
+        case ExtensionType.NonTransferableAccount:
             return true;
         case ExtensionType.Uninitialized:
         case ExtensionType.TransferFeeConfig:
@@ -117,6 +122,8 @@ export function getAccountTypeOfMintType(e: ExtensionType): ExtensionType {
             return ExtensionType.TransferFeeAmount;
         case ExtensionType.ConfidentialTransferMint:
             return ExtensionType.ConfidentialTransferAccount;
+        case ExtensionType.NonTransferable:
+            return ExtensionType.NonTransferableAccount;
         case ExtensionType.TransferFeeAmount:
         case ExtensionType.ConfidentialTransferAccount:
         case ExtensionType.CpiGuard:
@@ -124,10 +131,10 @@ export function getAccountTypeOfMintType(e: ExtensionType): ExtensionType {
         case ExtensionType.ImmutableOwner:
         case ExtensionType.MemoTransfer:
         case ExtensionType.MintCloseAuthority:
-        case ExtensionType.NonTransferable:
         case ExtensionType.Uninitialized:
         case ExtensionType.InterestBearingConfig:
         case ExtensionType.PermanentDelegate:
+        case ExtensionType.NonTransferableAccount:
             return ExtensionType.Uninitialized;
     }
 }

--- a/token/js/src/extensions/nonTransferable.ts
+++ b/token/js/src/extensions/nonTransferable.ts
@@ -1,17 +1,31 @@
 import { struct } from '@solana/buffer-layout';
+import type { Account } from '../state/account.js';
 import type { Mint } from '../state/mint.js';
 import { ExtensionType, getExtensionData } from './extensionType.js';
 
-/** Non-transferable state as stored by the program */
+/** Non-transferable mint state as stored by the program */
 export interface NonTransferable {} // eslint-disable-line
+
+/** Non-transferable token account state as stored by the program */
+export interface NonTransferableAccount {} // eslint-disable-line
 
 /** Buffer layout for de/serializing an account */
 export const NonTransferableLayout = struct<NonTransferable>([]);
 
 export const NON_TRANSFERABLE_SIZE = NonTransferableLayout.span;
+export const NON_TRANSFERABLE_ACCOUNT_SIZE = NonTransferableLayout.span;
 
 export function getNonTransferable(mint: Mint): NonTransferable | null {
     const extensionData = getExtensionData(ExtensionType.NonTransferable, mint.tlvData);
+    if (extensionData !== null) {
+        return NonTransferableLayout.decode(extensionData);
+    } else {
+        return null;
+    }
+}
+
+export function getNonTransferableAccount(account: Account): NonTransferableAccount | null {
+    const extensionData = getExtensionData(ExtensionType.NonTransferableAccount, account.tlvData);
     if (extensionData !== null) {
         return NonTransferableLayout.decode(extensionData);
     } else {

--- a/token/js/test/e2e-2022/nonTransferableMint.test.ts
+++ b/token/js/test/e2e-2022/nonTransferableMint.test.ts
@@ -57,7 +57,7 @@ describe('nonTransferable', () => {
         expect(nonTransferable).to.not.be.null;
 
         const owner = Keypair.generate();
-        const accountLen = getAccountLen([ExtensionType.ImmutableOwner]);
+        const accountLen = getAccountLen([ExtensionType.ImmutableOwner, ExtensionType.NonTransferableAccount]);
         const lamports = await connection.getMinimumBalanceForRentExemption(accountLen);
 
         const sourceKeypair = Keypair.generate();

--- a/token/program-2022-test/tests/non_transferable.rs
+++ b/token/program-2022-test/tests/non_transferable.rs
@@ -16,7 +16,7 @@ use {
 };
 
 #[tokio::test]
-async fn transfer_checked() {
+async fn transfer() {
     let test_transfer_amount = 100;
     let mut context = TestContext::new().await;
     context
@@ -27,6 +27,7 @@ async fn transfer_checked() {
     let TokenContext {
         mint_authority,
         token,
+        token_unchecked,
         alice,
         bob,
         ..
@@ -124,6 +125,28 @@ async fn transfer_checked() {
             )
         )))
     );
+
+    // regular unchecked transfer fails
+    let error = token_unchecked
+        .transfer(
+            &bob_account,
+            &alice_account,
+            &bob.pubkey(),
+            test_transfer_amount,
+            &[&bob],
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::NonTransferable as u32)
+            )
+        )))
+    );
 }
 
 #[tokio::test]
@@ -158,6 +181,7 @@ async fn transfer_checked_with_fee() {
     let TokenContext {
         mint_authority,
         token,
+        token_unchecked,
         alice,
         bob,
         ..
@@ -218,6 +242,28 @@ async fn transfer_checked_with_fee() {
 
     // regular transfer fails
     let error = token
+        .transfer(
+            &alice_account,
+            &bob_account,
+            &alice.pubkey(),
+            test_transfer_amount,
+            &[&alice],
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::NonTransferable as u32)
+            )
+        )))
+    );
+
+    // unchecked transfer fails
+    let error = token_unchecked
         .transfer(
             &alice_account,
             &bob_account,

--- a/token/program-2022/src/extension/non_transferable.rs
+++ b/token/program-2022/src/extension/non_transferable.rs
@@ -8,6 +8,15 @@ use {
 #[repr(transparent)]
 pub struct NonTransferable;
 
+/// Indicates that the tokens from this account belong to a non-transferable mint
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+#[repr(transparent)]
+pub struct NonTransferableAccount;
+
 impl Extension for NonTransferable {
     const TYPE: ExtensionType = ExtensionType::NonTransferable;
+}
+
+impl Extension for NonTransferableAccount {
+    const TYPE: ExtensionType = ExtensionType::NonTransferableAccount;
 }


### PR DESCRIPTION
#### Problem

The non-transferable token status is only stored on the mint, so during an unchecked transfer of non-transferable tokens, the instruction processor doesn't know to restrict the transfer.

#### Solution

Add a bit to non-transferable token accounts to show that they shouldn't be transferred, even during unchecked transfers.