### PR TITLE
stake-pool: Use `Pubkey::as_ref()` instead of `to_bytes()`

### DIFF
--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -386,8 +386,7 @@ impl Processor {
         authority_type: &[u8],
         bump_seed: u8,
     ) -> Result<(), ProgramError> {
-        let authority_signature_seeds =
-            [&stake_pool.to_bytes()[..32], authority_type, &[bump_seed]];
+        let authority_signature_seeds = [stake_pool.as_ref(), authority_type, &[bump_seed]];
         let signers = &[&authority_signature_seeds[..]];
 
         let ix = stake::instruction::delegate_stake(
@@ -419,8 +418,7 @@ impl Processor {
         authority_type: &[u8],
         bump_seed: u8,
     ) -> Result<(), ProgramError> {
-        let authority_signature_seeds =
-            [&stake_pool.to_bytes()[..32], authority_type, &[bump_seed]];
+        let authority_signature_seeds = [stake_pool.as_ref(), authority_type, &[bump_seed]];
         let signers = &[&authority_signature_seeds[..]];
 
         let ix = stake::instruction::deactivate_stake(stake_info.key, authority_info.key);
@@ -438,8 +436,7 @@ impl Processor {
         amount: u64,
         split_stake: AccountInfo<'a>,
     ) -> Result<(), ProgramError> {
-        let me_bytes = stake_pool.to_bytes();
-        let authority_signature_seeds = [&me_bytes[..32], authority_type, &[bump_seed]];
+        let authority_signature_seeds = [stake_pool.as_ref(), authority_type, &[bump_seed]];
         let signers = &[&authority_signature_seeds[..]];
 
         let split_instruction =
@@ -467,8 +464,7 @@ impl Processor {
         stake_history: AccountInfo<'a>,
         stake_program_info: AccountInfo<'a>,
     ) -> Result<(), ProgramError> {
-        let me_bytes = stake_pool.to_bytes();
-        let authority_signature_seeds = [&me_bytes[..32], authority_type, &[bump_seed]];
+        let authority_signature_seeds = [stake_pool.as_ref(), authority_type, &[bump_seed]];
         let signers = &[&authority_signature_seeds[..]];
 
         let merge_instruction =
@@ -540,8 +536,7 @@ impl Processor {
         clock: AccountInfo<'a>,
         stake_program_info: AccountInfo<'a>,
     ) -> Result<(), ProgramError> {
-        let me_bytes = stake_pool.to_bytes();
-        let authority_signature_seeds = [&me_bytes[..32], authority_type, &[bump_seed]];
+        let authority_signature_seeds = [stake_pool.as_ref(), authority_type, &[bump_seed]];
         let signers = &[&authority_signature_seeds[..]];
 
         let authorize_instruction = stake::instruction::authorize(
@@ -591,8 +586,7 @@ impl Processor {
         stake_program_info: AccountInfo<'a>,
         lamports: u64,
     ) -> Result<(), ProgramError> {
-        let me_bytes = stake_pool.to_bytes();
-        let authority_signature_seeds = [&me_bytes[..32], authority_type, &[bump_seed]];
+        let authority_signature_seeds = [stake_pool.as_ref(), authority_type, &[bump_seed]];
         let signers = &[&authority_signature_seeds[..]];
         let custodian_pubkey = None;
 
@@ -630,8 +624,7 @@ impl Processor {
         vote_account: AccountInfo<'a>,
         stake_config: AccountInfo<'a>,
     ) -> Result<(), ProgramError> {
-        let me_bytes = stake_pool.to_bytes();
-        let authority_signature_seeds = [&me_bytes[..32], authority_type, &[bump_seed]];
+        let authority_signature_seeds = [stake_pool.as_ref(), authority_type, &[bump_seed]];
         let signers = &[&authority_signature_seeds[..]];
 
         let redelegate_instruction = &stake::instruction::redelegate(
@@ -687,8 +680,7 @@ impl Processor {
         bump_seed: u8,
         amount: u64,
     ) -> Result<(), ProgramError> {
-        let me_bytes = stake_pool.to_bytes();
-        let authority_signature_seeds = [&me_bytes[..32], authority_type, &[bump_seed]];
+        let authority_signature_seeds = [stake_pool.as_ref(), authority_type, &[bump_seed]];
         let signers = &[&authority_signature_seeds[..]];
 
         let ix = spl_token_2022::instruction::mint_to(
@@ -1403,7 +1395,7 @@ impl Processor {
                 )?;
                 let ephemeral_stake_account_signer_seeds: &[&[_]] = &[
                     EPHEMERAL_STAKE_SEED_PREFIX,
-                    &stake_pool_info.key.to_bytes(),
+                    stake_pool_info.key.as_ref(),
                     &ephemeral_stake_seed.to_le_bytes(),
                     &[ephemeral_stake_bump_seed],
                 ];
@@ -1466,8 +1458,8 @@ impl Processor {
         } else {
             let transient_stake_account_signer_seeds: &[&[_]] = &[
                 TRANSIENT_STAKE_SEED_PREFIX,
-                &vote_account_address.to_bytes(),
-                &stake_pool_info.key.to_bytes(),
+                vote_account_address.as_ref(),
+                stake_pool_info.key.as_ref(),
                 &transient_stake_seed.to_le_bytes(),
                 &[transient_stake_bump_seed],
             ];
@@ -1678,7 +1670,7 @@ impl Processor {
                 )?;
                 let ephemeral_stake_account_signer_seeds: &[&[_]] = &[
                     EPHEMERAL_STAKE_SEED_PREFIX,
-                    &stake_pool_info.key.to_bytes(),
+                    stake_pool_info.key.as_ref(),
                     &ephemeral_stake_seed.to_le_bytes(),
                     &[ephemeral_stake_bump_seed],
                 ];
@@ -1744,8 +1736,8 @@ impl Processor {
             // no transient stake, split
             let transient_stake_account_signer_seeds: &[&[_]] = &[
                 TRANSIENT_STAKE_SEED_PREFIX,
-                &vote_account_address.to_bytes(),
-                &stake_pool_info.key.to_bytes(),
+                vote_account_address.as_ref(),
+                stake_pool_info.key.as_ref(),
                 &transient_stake_seed.to_le_bytes(),
                 &[transient_stake_bump_seed],
             ];
@@ -1954,8 +1946,8 @@ impl Processor {
             )?;
             let source_transient_stake_account_signer_seeds: &[&[_]] = &[
                 TRANSIENT_STAKE_SEED_PREFIX,
-                &vote_account_address.to_bytes(),
-                &stake_pool_info.key.to_bytes(),
+                vote_account_address.as_ref(),
+                stake_pool_info.key.as_ref(),
                 &source_transient_stake_seed.to_le_bytes(),
                 &[source_transient_stake_bump_seed],
             ];
@@ -1987,7 +1979,7 @@ impl Processor {
             )?;
             let ephemeral_stake_account_signer_seeds: &[&[_]] = &[
                 EPHEMERAL_STAKE_SEED_PREFIX,
-                &stake_pool_info.key.to_bytes(),
+                stake_pool_info.key.as_ref(),
                 &ephemeral_stake_seed.to_le_bytes(),
                 &[ephemeral_stake_bump_seed],
             ];
@@ -2090,8 +2082,8 @@ impl Processor {
                 )?;
                 let destination_transient_stake_account_signer_seeds: &[&[_]] = &[
                     TRANSIENT_STAKE_SEED_PREFIX,
-                    &vote_account_address.to_bytes(),
-                    &stake_pool_info.key.to_bytes(),
+                    vote_account_address.as_ref(),
+                    stake_pool_info.key.as_ref(),
                     &destination_transient_stake_seed.to_le_bytes(),
                     &[destination_transient_stake_bump_seed],
                 ];
@@ -3576,7 +3568,7 @@ impl Processor {
             crate::find_withdraw_authority_program_address(program_id, stake_pool_info.key);
 
         let token_mint_authority_signer_seeds: &[&[_]] = &[
-            &stake_pool_info.key.to_bytes()[..32],
+            stake_pool_info.key.as_ref(),
             AUTHORITY_WITHDRAW,
             &[stake_withdraw_bump_seed],
         ];
@@ -3657,7 +3649,7 @@ impl Processor {
             crate::find_withdraw_authority_program_address(program_id, stake_pool_info.key);
 
         let token_mint_authority_signer_seeds: &[&[_]] = &[
-            &stake_pool_info.key.to_bytes()[..32],
+            stake_pool_info.key.as_ref(),
             AUTHORITY_WITHDRAW,
             &[stake_withdraw_bump_seed],
         ];

--- a/stake-pool/program/src/state.rs
+++ b/stake-pool/program/src/state.rs
@@ -62,7 +62,7 @@ pub struct StakePool {
     /// signed by this authority. If no deposit authority is specified,
     /// then the stake pool will default to the result of:
     /// `Pubkey::find_program_address(
-    ///     &[&stake_pool_address.to_bytes()[..32], b"deposit"],
+    ///     &[&stake_pool_address.as_ref(), b"deposit"],
     ///     program_id,
     /// )`
     pub stake_deposit_authority: Pubkey,
@@ -273,11 +273,7 @@ impl StakePool {
         bump_seed: u8,
     ) -> Result<(), ProgramError> {
         let expected_address = Pubkey::create_program_address(
-            &[
-                &stake_pool_address.to_bytes()[..32],
-                authority_seed,
-                &[bump_seed],
-            ],
+            &[stake_pool_address.as_ref(), authority_seed, &[bump_seed]],
             program_id,
         )?;
 

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -2429,8 +2429,8 @@ pub fn add_stake_pool_account(
 ) {
     let mut stake_pool_bytes = stake_pool.try_to_vec().unwrap();
     // more room for optionals
-    stake_pool_bytes.extend_from_slice(&Pubkey::default().to_bytes());
-    stake_pool_bytes.extend_from_slice(&Pubkey::default().to_bytes());
+    stake_pool_bytes.extend_from_slice(Pubkey::default().as_ref());
+    stake_pool_bytes.extend_from_slice(Pubkey::default().as_ref());
     let stake_pool_account = SolanaAccount::create(
         ACCOUNT_RENT_EXEMPTION,
         stake_pool_bytes,

--- a/stake-pool/program/tests/huge_pool.rs
+++ b/stake-pool/program/tests/huge_pool.rs
@@ -25,7 +25,7 @@ use {
 // the test require so many helper accounts.
 // 20k is also a very safe number for the current upper bound of the network.
 const MAX_POOL_SIZE_WITH_REQUESTED_COMPUTE_UNITS: u32 = 20_000;
-const MAX_POOL_SIZE: u32 = 3_000;
+const MAX_POOL_SIZE: u32 = 3_200;
 const STAKE_AMOUNT: u64 = 200_000_000_000;
 
 async fn setup(


### PR DESCRIPTION
#### Problem

When using `Pubkey`s as `&[u8]`s, the stake pool program does `Pubkey::to_bytes()`, which creates a copy of the data into a new array. This is inefficient copying of existing data, and `as_ref()` has been shown to reduce compute usage in the past.

#### Solution

Switch to using `as_ref()` rather than `to_bytes()` everywhere. While I was at it, I tweaked the `huge_pool` test value to the current maximum, which is 3300 validators with 200k compute units. This PR has no impact on the max pool size supported, but at least it reduces compute units a little bit for other instructions.