### PR TITLE
stake-pool: Revert huge pool number to 3k

### DIFF
--- a/stake-pool/program/tests/huge_pool.rs
+++ b/stake-pool/program/tests/huge_pool.rs
@@ -25,7 +25,7 @@ use {
 // the test require so many helper accounts.
 // 20k is also a very safe number for the current upper bound of the network.
 const MAX_POOL_SIZE_WITH_REQUESTED_COMPUTE_UNITS: u32 = 20_000;
-const MAX_POOL_SIZE: u32 = 3_200;
+const MAX_POOL_SIZE: u32 = 3_000;
 const STAKE_AMOUNT: u64 = 200_000_000_000;
 
 async fn setup(


### PR DESCRIPTION
#### Problem

The monorepo downstream build is failing due to the bumped up huge pool number, see https://buildkite.com/solana-labs/solana/builds/89326

#### Solution

Bump it back down to 3k, where it was before