### PR TITLE
Account Compression: Make Noop Program Optional

### DIFF
--- a/account-compression/programs/account-compression/src/lib.rs
+++ b/account-compression/programs/account-compression/src/lib.rs
@@ -67,7 +67,7 @@ pub struct Initialize<'info> {
     pub authority: Signer<'info>,
 
     /// Program used to emit changelogs as cpi instruction data.
-    pub noop: Program<'info, Noop>,
+    pub noop: Option<Program<'info, Noop>>,
 }
 
 /// Context for inserting, appending, or replacing a leaf in the tree
@@ -85,7 +85,7 @@ pub struct Modify<'info> {
     pub authority: Signer<'info>,
 
     /// Program used to emit changelogs as cpi instruction data.
-    pub noop: Program<'info, Noop>,
+    pub noop: Option<Program<'info, Noop>>,
 }
 
 /// Context for validating a provided proof against the SPL ConcurrentMerkleTree.
@@ -122,6 +122,9 @@ pub struct CloseTree<'info> {
     #[account(mut)]
     pub recipient: AccountInfo<'info>,
 }
+
+#[derive(Accounts)]
+pub struct NoopLog {}
 
 #[program]
 pub mod spl_account_compression {
@@ -471,6 +474,10 @@ pub mod spl_account_compression {
         tree_bytes.fill(0);
         canopy_bytes.fill(0);
 
+        Ok(())
+    }
+
+    pub fn noop(_ctx: Context<NoopLog>, _data: Vec<u8>) -> Result<()> {
         Ok(())
     }
 }

--- a/account-compression/sdk/src/generated/instructions/append.ts
+++ b/account-compression/sdk/src/generated/instructions/append.ts
@@ -5,8 +5,8 @@
  * See: https://github.com/metaplex-foundation/solita
  */
 
-import * as beet from '@metaplex-foundation/beet';
-import * as web3 from '@solana/web3.js';
+import * as beet from "@metaplex-foundation/beet";
+import * as web3 from "@solana/web3.js";
 
 /**
  * @category Instructions
@@ -27,10 +27,10 @@ export const appendStruct = new beet.BeetArgsStruct<
   }
 >(
   [
-    ['instructionDiscriminator', beet.uniformFixedSizeArray(beet.u8, 8)],
-    ['leaf', beet.uniformFixedSizeArray(beet.u8, 32)],
+    ["instructionDiscriminator", beet.uniformFixedSizeArray(beet.u8, 8)],
+    ["leaf", beet.uniformFixedSizeArray(beet.u8, 32)],
   ],
-  'AppendInstructionArgs'
+  "AppendInstructionArgs"
 );
 /**
  * Accounts required by the _append_ instruction
@@ -66,7 +66,7 @@ export const appendInstructionDiscriminator = [
 export function createAppendInstruction(
   accounts: AppendInstructionAccounts,
   args: AppendInstructionArgs,
-  programId = new web3.PublicKey('cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK')
+  programId = new web3.PublicKey("cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK")
 ) {
   const [data] = appendStruct.serialize({
     instructionDiscriminator: appendInstructionDiscriminator,


### PR DESCRIPTION
Instead of CPIing to noop program to store information in instruction data, we can CPI to a special account compression instruction called `noop` that serves the same purpose.

This saves an additional 32 bytes per transaction.

Checklist
- [ ] Tests
- [ ] SDK