### PR TITLE
Moving `typescript-collections` to `dependencies`

### DIFF
--- a/account-compression/sdk/package.json
+++ b/account-compression/sdk/package.json
@@ -55,7 +55,8 @@
     "@metaplex-foundation/beet": "^0.7.1",
     "@metaplex-foundation/beet-solana": "^0.4.0",
     "bn.js": "^5.2.1",
-    "borsh": "^0.7.0"
+    "borsh": "^0.7.0",
+    "typescript-collections": "^1.3.3"
   },
   "peerDependencies": {
     "@solana/web3.js": "^1.50.1"
@@ -85,7 +86,6 @@
     "ts-jest-resolver": "^2.0.0",
     "ts-node": "^10.9.1",
     "typedoc": "^0.22.2",
-    "typescript": "=4.7.4",
-    "typescript-collections": "^1.3.3"
+    "typescript": "=4.7.4"
   }
 }


### PR DESCRIPTION
This package is missing from the distributed version of `@solana/spl-account-compression`

Will require cutting a new release of this SDK and ensuring that this package makes it to the destination!

found this when installing this library and noticing errors around missing packages