### PR TITLE
[token-2022, confidential-extension] Add confidential transfer authority type

### DIFF
--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -753,6 +753,7 @@ async fn command_authorize(
         AuthorityType::WithheldWithdraw => "withdraw withheld authority",
         AuthorityType::InterestRate => "interest rate authority",
         AuthorityType::PermanentDelegate => "permanent delegate",
+        AuthorityType::ConfidentialTransfer => "confidential transfer authority",
     };
 
     let (mint_pubkey, previous_authority) = if !config.sign_only {
@@ -800,6 +801,7 @@ async fn command_authorize(
                         ))
                     }
                 }
+                AuthorityType::ConfidentialTransfer => unimplemented!(),
             }?;
 
             Ok((account, previous_authority))
@@ -833,7 +835,8 @@ async fn command_authorize(
                 | AuthorityType::TransferFeeConfig
                 | AuthorityType::WithheldWithdraw
                 | AuthorityType::InterestRate
-                | AuthorityType::PermanentDelegate => Err(format!(
+                | AuthorityType::PermanentDelegate
+                | AuthorityType::ConfidentialTransfer => Err(format!(
                     "Authority type `{}` not supported for SPL Token accounts",
                     auth_str
                 )),

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -753,7 +753,7 @@ async fn command_authorize(
         AuthorityType::WithheldWithdraw => "withdraw withheld authority",
         AuthorityType::InterestRate => "interest rate authority",
         AuthorityType::PermanentDelegate => "permanent delegate",
-        AuthorityType::ConfidentialTransfer => "confidential transfer authority",
+        AuthorityType::ConfidentialTransferMint => "confidential transfer mint authority",
     };
 
     let (mint_pubkey, previous_authority) = if !config.sign_only {
@@ -801,7 +801,7 @@ async fn command_authorize(
                         ))
                     }
                 }
-                AuthorityType::ConfidentialTransfer => unimplemented!(),
+                AuthorityType::ConfidentialTransferMint => unimplemented!(),
             }?;
 
             Ok((account, previous_authority))
@@ -836,7 +836,7 @@ async fn command_authorize(
                 | AuthorityType::WithheldWithdraw
                 | AuthorityType::InterestRate
                 | AuthorityType::PermanentDelegate
-                | AuthorityType::ConfidentialTransfer => Err(format!(
+                | AuthorityType::ConfidentialTransferMint => Err(format!(
                     "Authority type `{}` not supported for SPL Token accounts",
                     auth_str
                 )),

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -1491,28 +1491,18 @@ where
     pub async fn confidential_transfer_update_mint<S: Signer>(
         &self,
         authority: &S,
-        new_authority: Option<&S>,
         auto_approve_new_account: bool,
         auditor_encryption_pubkey: Option<EncryptionPubkey>,
     ) -> TokenResult<T::Output> {
-        let mut signers = vec![authority];
-        let new_authority_pubkey = if let Some(new_authority) = new_authority {
-            signers.push(new_authority);
-            Some(new_authority.pubkey())
-        } else {
-            None
-        };
-
         self.process_ixs(
             &[confidential_transfer::instruction::update_mint(
                 &self.program_id,
                 &self.pubkey,
                 &authority.pubkey(),
-                new_authority_pubkey.as_ref(),
                 auto_approve_new_account,
                 auditor_encryption_pubkey,
             )?],
-            &signers,
+            &[authority],
         )
         .await
     }

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -323,7 +323,7 @@ async fn ct_initialize_and_update_mint() {
             token.get_address(),
             &wrong_keypair.pubkey(),
             Some(&new_ct_mint_authority.pubkey()),
-            instruction::AuthorityType::ConfidentialTransfer,
+            instruction::AuthorityType::ConfidentialTransferMint,
             &[&wrong_keypair],
         )
         .await
@@ -344,7 +344,7 @@ async fn ct_initialize_and_update_mint() {
             token.get_address(),
             &ct_mint_authority.pubkey(),
             Some(&new_ct_mint_authority.pubkey()),
-            instruction::AuthorityType::ConfidentialTransfer,
+            instruction::AuthorityType::ConfidentialTransferMint,
             &[&ct_mint_authority],
         )
         .await
@@ -403,7 +403,7 @@ async fn ct_initialize_and_update_mint() {
             token.get_address(),
             &new_ct_mint_authority.pubkey(),
             None,
-            instruction::AuthorityType::ConfidentialTransfer,
+            instruction::AuthorityType::ConfidentialTransferMint,
             &[&new_ct_mint_authority],
         )
         .await

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -46,6 +46,8 @@ pub enum ConfidentialTransferInstruction {
 
     /// Updates the confidential transfer mint configuration for a mint.
     ///
+    /// Use `TokenInstruction::SetAuthority` to update the confidential transfer mint authority.
+    ///
     /// The `withdraw_withheld_authority_encryption_pubkey` and `withheld_amount` ciphertext are
     /// not updatable.
     ///
@@ -53,7 +55,6 @@ pub enum ConfidentialTransferInstruction {
     ///
     ///   0. `[writable]` The SPL Token mint.
     ///   1. `[signer]` Confidential transfer mint authority.
-    ///   2. `[signer]` New confidential transfer mint authority.
     ///
     /// Data expected by this instruction:
     ///   `UpdateMintData`
@@ -576,21 +577,15 @@ pub fn update_mint(
     token_program_id: &Pubkey,
     mint: &Pubkey,
     authority: &Pubkey,
-    new_authority: Option<&Pubkey>,
     auto_approve_new_accounts: bool,
     auditor_encryption_pubkey: Option<EncryptionPubkey>,
 ) -> Result<Instruction, ProgramError> {
     check_program_account(token_program_id)?;
 
-    let mut accounts = vec![
+    let accounts = vec![
         AccountMeta::new(*mint, false),
         AccountMeta::new_readonly(*authority, true),
     ];
-    if let Some(new_authority) = new_authority {
-        accounts.push(AccountMeta::new_readonly(*new_authority, true));
-    } else {
-        accounts.push(AccountMeta::new_readonly(Pubkey::default(), false));
-    }
 
     Ok(encode_instruction(
         token_program_id,

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -1009,7 +1009,7 @@ pub enum AuthorityType {
     PermanentDelegate,
     /// Authority to update confidential transfer mint and aprove accounts for confidential
     /// transfers
-    ConfidentialTransfer,
+    ConfidentialTransferMint,
 }
 
 impl AuthorityType {
@@ -1024,7 +1024,7 @@ impl AuthorityType {
             AuthorityType::CloseMint => 6,
             AuthorityType::InterestRate => 7,
             AuthorityType::PermanentDelegate => 8,
-            AuthorityType::ConfidentialTransfer => 9,
+            AuthorityType::ConfidentialTransferMint => 9,
         }
     }
 
@@ -1039,7 +1039,7 @@ impl AuthorityType {
             6 => Ok(AuthorityType::CloseMint),
             7 => Ok(AuthorityType::InterestRate),
             8 => Ok(AuthorityType::PermanentDelegate),
-            9 => Ok(AuthorityType::ConfidentialTransfer),
+            9 => Ok(AuthorityType::ConfidentialTransferMint),
             _ => Err(TokenError::InvalidInstruction.into()),
         }
     }

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -1007,6 +1007,9 @@ pub enum AuthorityType {
     InterestRate,
     /// Authority to transfer or burn any tokens for a mint
     PermanentDelegate,
+    /// Authority to update confidential transfer mint and aprove accounts for confidential
+    /// transfers
+    ConfidentialTransfer,
 }
 
 impl AuthorityType {
@@ -1021,6 +1024,7 @@ impl AuthorityType {
             AuthorityType::CloseMint => 6,
             AuthorityType::InterestRate => 7,
             AuthorityType::PermanentDelegate => 8,
+            AuthorityType::ConfidentialTransfer => 9,
         }
     }
 
@@ -1035,6 +1039,7 @@ impl AuthorityType {
             6 => Ok(AuthorityType::CloseMint),
             7 => Ok(AuthorityType::InterestRate),
             8 => Ok(AuthorityType::PermanentDelegate),
+            9 => Ok(AuthorityType::ConfidentialTransfer),
             _ => Err(TokenError::InvalidInstruction.into()),
         }
     }

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -741,16 +741,16 @@ impl Processor {
                     )?;
                     extension.delegate = new_authority.try_into()?;
                 }
-                AuthorityType::ConfidentialTransfer => {
+                AuthorityType::ConfidentialTransferMint => {
                     let extension = mint.get_extension_mut::<ConfidentialTransferMint>()?;
                     let maybe_confidential_transfer_mint_authority: Option<Pubkey> =
                         extension.authority.into();
-                    let confidential_transfer_authority =
+                    let confidential_transfer_mint_authority =
                         maybe_confidential_transfer_mint_authority
                             .ok_or(TokenError::AuthorityTypeNotSupported)?;
                     Self::validate_owner(
                         program_id,
-                        &confidential_transfer_authority,
+                        &confidential_transfer_mint_authority,
                         authority_info,
                         authority_info_data_len,
                         account_info_iter.as_slice(),


### PR DESCRIPTION
#### Problem
In token-2022, there is currently an inconsistency in the way authorities associated with extensions are updated. In the confidential transfer (CT) extension, the instruction `ConfidentialTransferInstruction::UpdateMint` must be used to update the mint authority. However, in the rest of token-2022, `TokenInstruction::SetAuthority` instruction is used to update the authorities. 

#### Summary of Changes
- Extend the `AuthorityType` to include `AuthorityType::ConfidentialTransfer` and update the `SetAuthority` instruction to support confidential transfer authority
- Limit the `ConfidentialTransferInstruction::UpdateMint` to only update the mint parameters, not the authority.

##### Additional Safety when Updating the Confidential Transfer Authority
In addition to fixing the inconsistency, separating the ability to (1) update the CT mint authority and (2), update the rest of the CT mint parameters into two separate instructions can add an extra layer of safety for users when updating the mint.

If the authority is updated to None and the `ConfidentialTransferMint.auto_approve_new_accounts` is updated to false, then no new accounts can ever be approved for confidential transfers. Currently, a user can update both of these fields using the single `UpdateMint` instruction. With the changes above, the user must submit two different instructions to update the fields.