### PR TITLE
Governance: add comment labels for error.rs

### DIFF
--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -137,31 +137,31 @@ pub enum GovernanceError {
 
     /// Invalid State: Can't vote
     #[error("Invalid State: Can't vote")]
-    InvalidStateCannotVote,
+    InvalidStateCannotVote, // 531
 
     /// Invalid State: Can't finalize vote
     #[error("Invalid State: Can't finalize vote")]
-    InvalidStateCannotFinalize,
+    InvalidStateCannotFinalize, // 532
 
     /// Invalid State: Can't cancel Proposal
     #[error("Invalid State: Can't cancel Proposal")]
-    InvalidStateCannotCancelProposal,
+    InvalidStateCannotCancelProposal, // 533
 
     /// Vote already relinquished
     #[error("Vote already relinquished")]
-    VoteAlreadyRelinquished,
+    VoteAlreadyRelinquished, // 534
 
     /// Can't finalize vote. Voting still in progress
     #[error("Can't finalize vote. Voting still in progress")]
-    CannotFinalizeVotingInProgress,
+    CannotFinalizeVotingInProgress, // 535
 
     /// Proposal voting time expired
     #[error("Proposal voting time expired")]
-    ProposalVotingTimeExpired,
+    ProposalVotingTimeExpired, // 536
 
     /// Invalid Signatory Mint
     #[error("Invalid Signatory Mint")]
-    InvalidSignatoryMint,
+    InvalidSignatoryMint, // 537
 
     /// Proposal does not belong to the given Governance
     #[error("Proposal does not belong to the given Governance")]


### PR DESCRIPTION
A small update of comments on `error.rs` to label missing errors with numbers.