### PR TITLE
ci: Update openssl crate per RUST-SEC advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3007,9 +3007,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.22.0+1.1.1q"
+version = "111.25.0+1.1.1t"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
+checksum = "3173cd3626c43e3854b1b727422a276e568d9ec5fe8cec197822cf52cfb743d6"
 dependencies = [
  "cc",
 ]


### PR DESCRIPTION
#### Problem

Just like https://github.com/solana-labs/solana/pull/30173, there's a [vuln](https://rustsec.org/advisories/RUSTSEC-2023-0007) in the openssl-src dependency

#### Summary of Changes

Update to 111.25 where it's used.