### PR TITLE
token-2022: Bump program, cli, and client for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6398,7 +6398,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-cli"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_cmd",
  "clap 2.34.0",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-client"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "solana-cli-output",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6517,7 +6517,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-upgrade"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "num-derive",
  "num-traits",
@@ -6534,7 +6534,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-upgrade-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap 3.2.17",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4567,7 +4567,7 @@ dependencies = [
  "solana-sdk",
  "solana-vote-program",
  "spl-token 3.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token-2022 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-2022 0.5.0",
  "thiserror",
  "zstd",
 ]
@@ -4818,7 +4818,7 @@ dependencies = [
  "solana-transaction-status",
  "solana-version",
  "solana-vote-program",
- "spl-token-2022 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-2022 0.5.0",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -5135,7 +5135,7 @@ dependencies = [
  "solana-transaction-status",
  "solana-vote-program",
  "spl-token 3.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token-2022 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-2022 0.5.0",
  "static_assertions",
  "tempfile",
  "thiserror",
@@ -5435,7 +5435,7 @@ dependencies = [
  "solana-version",
  "solana-vote-program",
  "spl-token 3.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token-2022 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-2022 0.5.0",
  "stream-cancel",
  "thiserror",
  "tokio",
@@ -5753,7 +5753,7 @@ dependencies = [
  "spl-associated-token-account 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-memo 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token 3.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token-2022 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-2022 0.5.0",
  "thiserror",
 ]
 
@@ -5890,7 +5890,7 @@ dependencies = [
  "num-traits",
  "solana-program",
  "spl-token 3.5.0",
- "spl-token-2022 0.5.0",
+ "spl-token-2022 0.6.0",
  "thiserror",
 ]
 
@@ -5906,7 +5906,7 @@ dependencies = [
  "num-traits",
  "solana-program",
  "spl-token 3.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token-2022 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-2022 0.5.0",
  "thiserror",
 ]
 
@@ -5919,7 +5919,7 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account 1.1.2",
  "spl-token 3.5.0",
- "spl-token-2022 0.5.0",
+ "spl-token-2022 0.6.0",
 ]
 
 [[package]]
@@ -6275,7 +6275,7 @@ dependencies = [
  "solana-vote-program",
  "spl-math",
  "spl-token 3.5.0",
- "spl-token-2022 0.5.0",
+ "spl-token-2022 0.6.0",
  "test-case",
  "thiserror",
 ]
@@ -6341,6 +6341,24 @@ dependencies = [
 [[package]]
 name = "spl-token-2022"
 version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0edb869dbe159b018f17fb9bfa67118c30f232d7f54a73742bc96794dff77ed8"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-program",
+ "solana-zk-token-sdk",
+ "spl-memo 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token 3.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-token-2022"
+version = "0.6.0"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -6363,24 +6381,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-token-2022"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0edb869dbe159b018f17fb9bfa67118c30f232d7f54a73742bc96794dff77ed8"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "num_enum",
- "solana-program",
- "solana-zk-token-sdk",
- "spl-memo 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token 3.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
-]
-
-[[package]]
 name = "spl-token-2022-test"
 version = "0.0.1"
 dependencies = [
@@ -6391,7 +6391,7 @@ dependencies = [
  "spl-associated-token-account 1.1.2",
  "spl-instruction-padding",
  "spl-memo 3.0.1",
- "spl-token-2022 0.5.0",
+ "spl-token-2022 0.6.0",
  "spl-token-client",
  "walkdir",
 ]
@@ -6421,7 +6421,7 @@ dependencies = [
  "spl-associated-token-account 1.1.2",
  "spl-memo 3.0.1",
  "spl-token 3.5.0",
- "spl-token-2022 0.5.0",
+ "spl-token-2022 0.6.0",
  "spl-token-client",
  "strum",
  "strum_macros",
@@ -6442,7 +6442,7 @@ dependencies = [
  "spl-associated-token-account 1.1.2",
  "spl-memo 3.0.1",
  "spl-token 3.5.0",
- "spl-token-2022 0.5.0",
+ "spl-token-2022 0.6.0",
  "thiserror",
 ]
 
@@ -6498,7 +6498,7 @@ dependencies = [
  "solana-sdk",
  "spl-math",
  "spl-token 3.5.0",
- "spl-token-2022 0.5.0",
+ "spl-token-2022 0.6.0",
  "test-case",
  "thiserror",
 ]
@@ -6526,7 +6526,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-token 3.5.0",
- "spl-token-2022 0.5.0",
+ "spl-token-2022 0.6.0",
  "spl-token-client",
  "test-case",
  "thiserror",
@@ -6547,7 +6547,7 @@ dependencies = [
  "solana-test-validator",
  "spl-associated-token-account 1.1.2",
  "spl-token 3.5.0",
- "spl-token-2022 0.5.0",
+ "spl-token-2022 0.6.0",
  "spl-token-client",
  "spl-token-upgrade",
  "tokio",

--- a/associated-token-account/program-test/Cargo.toml
+++ b/associated-token-account/program-test/Cargo.toml
@@ -16,4 +16,4 @@ solana-program-test = "1.14.12"
 solana-sdk = "1.14.12"
 spl-associated-token-account = { version = "1.1", path = "../program", features = ["no-entrypoint"] }
 spl-token = { version = "3.5", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "0.5", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.6", path = "../../token/program-2022", features = ["no-entrypoint"] }

--- a/associated-token-account/program/Cargo.toml
+++ b/associated-token-account/program/Cargo.toml
@@ -18,7 +18,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 solana-program = "1.14.12"
 spl-token = { version = "3.5", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "0.5", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.6", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [lib]

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -22,7 +22,7 @@ serde = "1.0.130"
 serde_derive = "1.0.103"
 solana-program = "1.14.12"
 spl-math = { version = "0.1", path = "../../libraries/math", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "0.5", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
+spl-token-2022 = { version = "0.6", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 bincode = "1.3.1"
 

--- a/token-swap/program/Cargo.toml
+++ b/token-swap/program/Cargo.toml
@@ -20,7 +20,7 @@ num-traits = "0.2"
 solana-program = "1.14.12"
 spl-math = { version = "0.1", path = "../../libraries/math", features = [ "no-entrypoint" ] }
 spl-token = { version = "3.5", path = "../../token/program", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "0.5", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
+spl-token-2022 = { version = "0.6", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
 roots = { version = "0.0.7", optional = true }

--- a/token-upgrade/cli/Cargo.toml
+++ b/token-upgrade/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-upgrade-cli"
-version = "0.1.0"
+version = "0.1.1"
 description = "SPL Token Upgrade Command-line Utility"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token-upgrade/cli/Cargo.toml
+++ b/token-upgrade/cli/Cargo.toml
@@ -22,7 +22,7 @@ solana-sdk = "1.14.12"
 spl-associated-token-account = { version = "1.1", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token = { version = "3.5", path = "../../token/program", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "0.5", path = "../../token/program-2022", features = ["no-entrypoint"] }
-spl-token-client = { version = "0.3", path = "../../token/client" }
+spl-token-client = { version = "0.4", path = "../../token/client" }
 spl-token-upgrade = { version = "0.1", path = "../program", features = ["no-entrypoint"] }
 tokio = { version = "1", features = ["full"] }
 

--- a/token-upgrade/cli/Cargo.toml
+++ b/token-upgrade/cli/Cargo.toml
@@ -21,7 +21,7 @@ solana-remote-wallet = "1.14.12"
 solana-sdk = "1.14.12"
 spl-associated-token-account = { version = "1.1", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token = { version = "3.5", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "0.5", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.6", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.4", path = "../../token/client" }
 spl-token-upgrade = { version = "0.1", path = "../program", features = ["no-entrypoint"] }
 tokio = { version = "1", features = ["full"] }

--- a/token-upgrade/program/Cargo.toml
+++ b/token-upgrade/program/Cargo.toml
@@ -16,7 +16,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 num_enum = "0.5.9"
 solana-program = "1.14.12"
-spl-token-2022 = { version = "0.5", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.6", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/token-upgrade/program/Cargo.toml
+++ b/token-upgrade/program/Cargo.toml
@@ -23,7 +23,7 @@ thiserror = "1.0"
 solana-program-test = "1.14.12"
 solana-sdk = "1.14.12"
 spl-token = { version = "3.5", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-client = { version = "0.3", path = "../../token/client" }
+spl-token-client = { version = "0.4", path = "../../token/client" }
 test-case = "2.2"
 
 [lib]

--- a/token-upgrade/program/Cargo.toml
+++ b/token-upgrade/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-upgrade"
-version = "0.1.0"
+version = "0.1.1"
 description = "Solana Program Library Token Upgrade"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://spl.solana.com/token"
 license = "Apache-2.0"
 name = "spl-token-cli"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "2.2.0"
+version = "2.3.0"
 
 [build-dependencies]
 walkdir = "2"
@@ -29,7 +29,7 @@ solana-sdk = "=1.14.12"
 solana-transaction-status = "=1.14.12"
 spl-token = { version = "3.5", path="../program", features = [ "no-entrypoint" ] }
 spl-token-2022 = { version = "0.5", path="../program-2022", features = [ "no-entrypoint" ] }
-spl-token-client = { version = "0.3", path="../client" }
+spl-token-client = { version = "0.4", path="../client" }
 spl-associated-token-account = { version = "1.1", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
 spl-memo = { version = "3.0.1", path="../../memo/program", features = ["no-entrypoint"] }
 strum = "0.24"

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -28,7 +28,7 @@ solana-remote-wallet = "=1.14.12"
 solana-sdk = "=1.14.12"
 solana-transaction-status = "=1.14.12"
 spl-token = { version = "3.5", path="../program", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "0.5", path="../program-2022", features = [ "no-entrypoint" ] }
+spl-token-2022 = { version = "0.6", path="../program-2022", features = [ "no-entrypoint" ] }
 spl-token-client = { version = "0.4", path="../client" }
 spl-associated-token-account = { version = "1.1", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
 spl-memo = { version = "3.0.1", path="../../memo/program", features = ["no-entrypoint"] }

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -18,7 +18,7 @@ solana-sdk = "=1.14.12"
 spl-associated-token-account = { version = "1.1", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-memo = { version = "3.0.1", path = "../../memo/program", features = ["no-entrypoint"] }
 spl-token = { version = "3.5", path="../program", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "0.5", path="../program-2022" }
+spl-token-2022 = { version = "0.6", path="../program-2022" }
 thiserror = "1.0"
 
 [features]

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "spl-token-client"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "0.3.0"
+version = "0.4.0"
 
 [dependencies]
 async-trait = "0.1"

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -22,6 +22,6 @@ solana-program-test = "=1.14.12"
 solana-sdk = "=1.14.12"
 spl-associated-token-account = { version = "1.1", path = "../../associated-token-account/program" }
 spl-memo = { version = "3.0.1", path = "../../memo/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "0.5", path="../program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.6", path="../program-2022", features = ["no-entrypoint"] }
 spl-instruction-padding = { version = "0.1.0", path="../../instruction-padding/program", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.4", path = "../client" }

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -24,4 +24,4 @@ spl-associated-token-account = { version = "1.1", path = "../../associated-token
 spl-memo = { version = "3.0.1", path = "../../memo/program", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "0.5", path="../program-2022", features = ["no-entrypoint"] }
 spl-instruction-padding = { version = "0.1.0", path="../../instruction-padding/program", features = ["no-entrypoint"] }
-spl-token-client = { version = "0.3", path = "../client" }
+spl-token-client = { version = "0.4", path = "../client" }

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-2022"
-version = "0.5.0"
+version = "0.6.0"
 description = "Solana Program Library Token 2022"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"


### PR DESCRIPTION
#### Problem

We've had a few changes to token-2022 since 0.5.0, including confidential transfer instruction changes, a fix to non-transferable tokens, and a CLI fix.

The CLI fix is the main driver for this, since it would be good to get a release out with the fix.

#### Solution

Bump token-cli, token-client, and token-2022 for a new release. Let me know if you have any additional bits you want to sneak in before cutting!