### PR TITLE
[token-2022] Create proof-program feature

### DIFF
--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -24,3 +24,4 @@ thiserror = "1.0"
 [features]
 default = ["display"]
 display = ["dep:solana-cli-output"]
+proof-program = []

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -3,7 +3,6 @@ use {
     solana_program_test::tokio::time,
     solana_sdk::{
         account::Account as BaseAccount,
-        epoch_info::EpochInfo,
         hash::Hash,
         instruction::Instruction,
         message::Message,
@@ -26,20 +25,24 @@ use {
         },
         instruction,
         pod::EncryptionPubkey,
-        solana_zk_token_sdk::{
-            encryption::{auth_encryption::*, elgamal::*},
-            errors::ProofError,
-            instruction::transfer_with_fee::FeeParameters,
-        },
+        solana_zk_token_sdk::errors::ProofError,
         state::{Account, AccountState, Mint, Multisig},
     },
     std::{
-        convert::TryInto,
         fmt, io,
         sync::{Arc, RwLock},
         time::{Duration, Instant},
     },
     thiserror::Error,
+};
+#[cfg(feature = "proof-program")]
+use {
+    solana_sdk::epoch_info::EpochInfo,
+    spl_token_2022::solana_zk_token_sdk::{
+        encryption::{auth_encryption::*, elgamal::*},
+        instruction::transfer_with_fee::FeeParameters,
+    },
+    std::convert::TryInto,
 };
 
 #[derive(Error, Debug)]
@@ -1588,6 +1591,7 @@ where
     }
 
     /// Approves a token account for confidential transfers
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_approve_account<S: Signer>(
         &self,
         token_account: &Pubkey,
@@ -1654,6 +1658,7 @@ where
 
     /// Fetch and decrypt the available balance of a confidential token account using the uniquely
     /// derived decryption key from a signer
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_get_available_balance<S: Signer>(
         &self,
         token_account: &Pubkey,
@@ -1671,6 +1676,7 @@ where
 
     /// Fetch and decrypt the available balance of a confidential token account using a custom
     /// decryption key
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_get_available_balance_with_key(
         &self,
         token_account: &Pubkey,
@@ -1693,6 +1699,7 @@ where
 
     /// Fetch and decrypt the pending balance of a confidential token account using the uniquely
     /// derived decryption key from a signer
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_get_pending_balance<S: Signer>(
         &self,
         token_account: &Pubkey,
@@ -1707,6 +1714,7 @@ where
 
     /// Fetch and decrypt the pending balance of a confidential token account using a custom
     /// decryption key
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_get_pending_balance_with_key(
         &self,
         token_account: &Pubkey,
@@ -1733,6 +1741,7 @@ where
         Ok(pending_balance)
     }
 
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_get_withheld_amount<S: Signer>(
         &self,
         withdraw_withheld_authority: &S,
@@ -1749,6 +1758,7 @@ where
         .await
     }
 
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_get_withheld_amount_with_key(
         &self,
         withdraw_withheld_authority_elgamal_keypair: &ElGamalKeypair,
@@ -1775,6 +1785,7 @@ where
     }
 
     /// Fetch the ElGamal public key associated with a confidential token account
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_get_encryption_pubkey<S: Signer>(
         &self,
         token_account: &Pubkey,
@@ -1791,6 +1802,7 @@ where
     }
 
     /// Fetch the ElGamal pubkey key of the auditor associated with a confidential token mint
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_get_auditor_encryption_pubkey<S: Signer>(
         &self,
     ) -> TokenResult<Option<ElGamalPubkey>> {
@@ -1811,6 +1823,7 @@ where
 
     /// Fetch the ElGamal pubkey key of the withdraw withheld authority associated with a
     /// confidential token mint
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_get_withdraw_withheld_authority_encryption_pubkey<
         S: Signer,
     >(
@@ -1832,6 +1845,7 @@ where
     }
 
     /// Deposit SPL Tokens into the pending balance of a confidential token account
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_deposit<S: Signer>(
         &self,
         token_account: &Pubkey,
@@ -2028,6 +2042,7 @@ where
     /// Transfer tokens confidentially with fee using the uniquely derived decryption keys from a
     /// signer
     #[allow(clippy::too_many_arguments)]
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_transfer_with_fee<S: Signer>(
         &self,
         source_token_account: &Pubkey,
@@ -2066,6 +2081,7 @@ where
 
     /// Transfer tokens confidential with fee using custom decryption keys
     #[allow(clippy::too_many_arguments)]
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_transfer_with_fee_with_key<S: Signer>(
         &self,
         source_token_account: &Pubkey,
@@ -2133,6 +2149,7 @@ where
 
     /// Applies the confidential transfer pending balance to the available balance using the
     /// uniquely derived decryption key
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_apply_pending_balance<S: Signer>(
         &self,
         token_account: &Pubkey,
@@ -2157,6 +2174,7 @@ where
 
     /// Applies the confidential transfer pending balance to the available balance using a custom
     /// decryption key
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_apply_pending_balance_with_key<S: Signer>(
         &self,
         token_account: &Pubkey,
@@ -2185,6 +2203,7 @@ where
     }
 
     /// Enable confidential transfer `Deposit` and `Transfer` instructions for a token account
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_enable_confidential_credits<S: Signer>(
         &self,
         token_account: &Pubkey,
@@ -2205,6 +2224,7 @@ where
     }
 
     /// Disable confidential transfer `Deposit` and `Transfer` instructions for a token account
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_disable_confidential_credits<S: Signer>(
         &self,
         token_account: &Pubkey,
@@ -2225,6 +2245,7 @@ where
     }
 
     /// Enable a confidential extension token account to receive non-confidential payments
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_enable_non_confidential_credits<S: Signer>(
         &self,
         token_account: &Pubkey,
@@ -2245,6 +2266,7 @@ where
     }
 
     /// Disable non-confidential payments for a confidential extension token account
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_disable_non_confidential_credits<S: Signer>(
         &self,
         token_account: &Pubkey,
@@ -2390,6 +2412,7 @@ where
     }
 
     /// Harvest withheld confidential tokens to mint
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_harvest_withheld_tokens_to_mint(
         &self,
         sources: &[&Pubkey],

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -1516,6 +1516,7 @@ where
     }
 
     /// Configures confidential transfers for a token account
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_configure_token_account<S: Signer>(
         &self,
         token_account: &Pubkey,
@@ -1532,6 +1533,7 @@ where
         .await
     }
 
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_configure_token_account_with_pending_counter<S: Signer>(
         &self,
         token_account: &Pubkey,
@@ -1554,6 +1556,7 @@ where
         .await
     }
 
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_configure_token_account_with_pending_counter_and_keypair<
         S: Signer,
     >(
@@ -1603,6 +1606,7 @@ where
     }
 
     /// Prepare a token account with the confidential transfer extension for closing
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_empty_account<S: Signer>(
         &self,
         token_account: &Pubkey,
@@ -1618,6 +1622,7 @@ where
         .await
     }
 
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_empty_account_with_keypair<S: Signer>(
         &self,
         token_account: &Pubkey,
@@ -1856,6 +1861,7 @@ where
     /// Withdraw SPL Tokens from the available balance of a confidential token account using the
     /// uniquely derived decryption key from a signer
     #[allow(clippy::too_many_arguments)]
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_withdraw<S: Signer>(
         &self,
         token_account: &Pubkey,
@@ -1886,6 +1892,7 @@ where
     /// Withdraw SPL Tokens from the available balance of a confidential token account using custom
     /// keys
     #[allow(clippy::too_many_arguments)]
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_withdraw_with_key<S: Signer>(
         &self,
         token_account: &Pubkey,
@@ -1930,6 +1937,7 @@ where
 
     /// Transfer tokens confidentially using the uniquely derived decryption keys from a signer
     #[allow(clippy::too_many_arguments)]
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_transfer<S: Signer>(
         &self,
         source_token_account: &Pubkey,
@@ -1964,6 +1972,7 @@ where
 
     /// Transfer tokens confidentially using custom decryption keys
     #[allow(clippy::too_many_arguments)]
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_transfer_with_key<S: Signer>(
         &self,
         source_token_account: &Pubkey,
@@ -2256,6 +2265,7 @@ where
     }
 
     /// Withdraw withheld confidential tokens from mint using the uniquely derived decryption key
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_withdraw_withheld_tokens_from_mint<S: Signer>(
         &self,
         withdraw_withheld_authority: &S,
@@ -2281,6 +2291,7 @@ where
     }
 
     /// Withdraw withheld confidential tokens from mint using a custom decryption key
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_withdraw_withheld_tokens_from_mint_with_key<S: Signer>(
         &self,
         withdraw_withheld_authority: &S,
@@ -2314,6 +2325,7 @@ where
 
     /// Withdraw withheld confidential tokens from accounts using the uniquely derived decryption
     /// key
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_withdraw_withheld_tokens_from_accounts<S: Signer>(
         &self,
         withdraw_withheld_authority: &S,
@@ -2341,6 +2353,7 @@ where
 
     /// Withdraw withheld confidential tokens from accounts using a custom decryption key
     #[allow(clippy::too_many_arguments)]
+    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_withdraw_withheld_tokens_from_accounts_with_key<
         S: Signer,
     >(

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/solana-labs/solana-program-library"
 version = "0.0.1"
 
 [features]
-test-sbf = []
+test-sbf = ["zk-ops"]
 default = ["zk-ops"]
 zk-ops = []
 proof-program = []

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -11,6 +11,7 @@ version = "0.0.1"
 test-sbf = []
 default = ["zk-ops"]
 zk-ops = []
+proof-program = []
 
 [build-dependencies]
 walkdir = "2"

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "test-sbf")]
+#![cfg(all(feature = "test-sbf", feature = "proof-program"))]
 #![cfg(twoxtx)]
 
 mod program_test;

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -15,6 +15,7 @@ serde-traits = ["serde", "serde_with"]
 # Remove these features once the underlying syscalls are released on all networks
 default = ["zk-ops"]
 zk-ops = []
+proof-program = []
 
 [dependencies]
 arrayref = "0.3.6"

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -642,6 +642,7 @@ pub fn inner_configure_account(
 /// Create a `ConfigureAccount` instruction
 #[allow(clippy::too_many_arguments)]
 #[cfg(not(target_os = "solana"))]
+#[cfg(feature = "proof-program")]
 pub fn configure_account(
     token_program_id: &Pubkey,
     token_account: &Pubkey,
@@ -650,7 +651,7 @@ pub fn configure_account(
     maximum_pending_balance_credit_counter: u64,
     authority: &Pubkey,
     multisig_signers: &[&Pubkey],
-    #[cfg(feature = "proof-program")] proof_data: &PubkeyValidityData,
+    proof_data: &PubkeyValidityData,
 ) -> Result<Vec<Instruction>, ProgramError> {
     Ok(vec![
         inner_configure_account(
@@ -723,12 +724,13 @@ pub fn inner_empty_account(
 }
 
 /// Create a `EmptyAccount` instruction
+#[cfg(feature = "proof-program")]
 pub fn empty_account(
     token_program_id: &Pubkey,
     token_account: &Pubkey,
     authority: &Pubkey,
     multisig_signers: &[&Pubkey],
-    #[cfg(feature = "proof-program")] proof_data: &CloseAccountData,
+    proof_data: &CloseAccountData,
 ) -> Result<Vec<Instruction>, ProgramError> {
     Ok(vec![
         inner_empty_account(
@@ -821,6 +823,7 @@ pub fn inner_withdraw(
 /// Create a `Withdraw` instruction
 #[allow(clippy::too_many_arguments)]
 #[cfg(not(target_os = "solana"))]
+#[cfg(feature = "proof-program")]
 pub fn withdraw(
     token_program_id: &Pubkey,
     token_account: &Pubkey,
@@ -830,7 +833,7 @@ pub fn withdraw(
     new_decryptable_available_balance: AeCiphertext,
     authority: &Pubkey,
     multisig_signers: &[&Pubkey],
-    #[cfg(feature = "proof-program")] proof_data: &WithdrawData,
+    proof_data: &WithdrawData,
 ) -> Result<Vec<Instruction>, ProgramError> {
     Ok(vec![
         inner_withdraw(
@@ -891,6 +894,7 @@ pub fn inner_transfer(
 /// Create a `Transfer` instruction with regular (no-fee) proof
 #[allow(clippy::too_many_arguments)]
 #[cfg(not(target_os = "solana"))]
+#[cfg(feature = "proof-program")]
 pub fn transfer(
     token_program_id: &Pubkey,
     source_token_account: &Pubkey,
@@ -899,7 +903,7 @@ pub fn transfer(
     new_source_decryptable_available_balance: AeCiphertext,
     authority: &Pubkey,
     multisig_signers: &[&Pubkey],
-    #[cfg(feature = "proof-program")] proof_data: &TransferData,
+    proof_data: &TransferData,
 ) -> Result<Vec<Instruction>, ProgramError> {
     Ok(vec![
         inner_transfer(
@@ -1123,13 +1127,14 @@ pub fn inner_withdraw_withheld_tokens_from_mint(
 }
 
 /// Create a `WithdrawWithheldTokensFromMint` instruction
+#[cfg(feature = "proof-program")]
 pub fn withdraw_withheld_tokens_from_mint(
     token_program_id: &Pubkey,
     mint: &Pubkey,
     destination: &Pubkey,
     authority: &Pubkey,
     multisig_signers: &[&Pubkey],
-    #[cfg(feature = "proof-program")] proof_data: &WithdrawWithheldTokensData,
+    proof_data: &WithdrawWithheldTokensData,
 ) -> Result<Vec<Instruction>, ProgramError> {
     Ok(vec![
         inner_withdraw_withheld_tokens_from_mint(
@@ -1188,6 +1193,7 @@ pub fn inner_withdraw_withheld_tokens_from_accounts(
 }
 
 /// Create a `WithdrawWithheldTokensFromAccounts` instruction
+#[cfg(feature = "proof-program")]
 pub fn withdraw_withheld_tokens_from_accounts(
     token_program_id: &Pubkey,
     mint: &Pubkey,
@@ -1195,7 +1201,7 @@ pub fn withdraw_withheld_tokens_from_accounts(
     authority: &Pubkey,
     multisig_signers: &[&Pubkey],
     sources: &[&Pubkey],
-    #[cfg(feature = "proof-program")] proof_data: &WithdrawWithheldTokensData,
+    proof_data: &WithdrawWithheldTokensData,
 ) -> Result<Vec<Instruction>, ProgramError> {
     Ok(vec![
         inner_withdraw_withheld_tokens_from_accounts(

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -650,7 +650,7 @@ pub fn configure_account(
     maximum_pending_balance_credit_counter: u64,
     authority: &Pubkey,
     multisig_signers: &[&Pubkey],
-    proof_data: &PubkeyValidityData,
+    #[cfg(feature = "proof-program")] proof_data: &PubkeyValidityData,
 ) -> Result<Vec<Instruction>, ProgramError> {
     Ok(vec![
         inner_configure_account(
@@ -663,6 +663,7 @@ pub fn configure_account(
             multisig_signers,
             1,
         )?,
+        #[cfg(feature = "proof-program")]
         verify_pubkey_validity(proof_data),
     ])
 }
@@ -727,7 +728,7 @@ pub fn empty_account(
     token_account: &Pubkey,
     authority: &Pubkey,
     multisig_signers: &[&Pubkey],
-    proof_data: &CloseAccountData,
+    #[cfg(feature = "proof-program")] proof_data: &CloseAccountData,
 ) -> Result<Vec<Instruction>, ProgramError> {
     Ok(vec![
         inner_empty_account(
@@ -737,6 +738,7 @@ pub fn empty_account(
             multisig_signers,
             1,
         )?, // calls check_program_account
+        #[cfg(feature = "proof-program")]
         verify_close_account(proof_data),
     ])
 }
@@ -828,7 +830,7 @@ pub fn withdraw(
     new_decryptable_available_balance: AeCiphertext,
     authority: &Pubkey,
     multisig_signers: &[&Pubkey],
-    proof_data: &WithdrawData,
+    #[cfg(feature = "proof-program")] proof_data: &WithdrawData,
 ) -> Result<Vec<Instruction>, ProgramError> {
     Ok(vec![
         inner_withdraw(
@@ -842,6 +844,7 @@ pub fn withdraw(
             multisig_signers,
             1,
         )?, // calls check_program_account
+        #[cfg(feature = "proof-program")]
         verify_withdraw(proof_data),
     ])
 }
@@ -896,7 +899,7 @@ pub fn transfer(
     new_source_decryptable_available_balance: AeCiphertext,
     authority: &Pubkey,
     multisig_signers: &[&Pubkey],
-    proof_data: &TransferData,
+    #[cfg(feature = "proof-program")] proof_data: &TransferData,
 ) -> Result<Vec<Instruction>, ProgramError> {
     Ok(vec![
         inner_transfer(
@@ -909,6 +912,7 @@ pub fn transfer(
             multisig_signers,
             1,
         )?, // calls check_program_account
+        #[cfg(feature = "proof-program")]
         verify_transfer(proof_data),
     ])
 }
@@ -1125,7 +1129,7 @@ pub fn withdraw_withheld_tokens_from_mint(
     destination: &Pubkey,
     authority: &Pubkey,
     multisig_signers: &[&Pubkey],
-    proof_data: &WithdrawWithheldTokensData,
+    #[cfg(feature = "proof-program")] proof_data: &WithdrawWithheldTokensData,
 ) -> Result<Vec<Instruction>, ProgramError> {
     Ok(vec![
         inner_withdraw_withheld_tokens_from_mint(
@@ -1136,6 +1140,7 @@ pub fn withdraw_withheld_tokens_from_mint(
             multisig_signers,
             1,
         )?,
+        #[cfg(feature = "proof-program")]
         verify_withdraw_withheld_tokens(proof_data),
     ])
 }
@@ -1190,7 +1195,7 @@ pub fn withdraw_withheld_tokens_from_accounts(
     authority: &Pubkey,
     multisig_signers: &[&Pubkey],
     sources: &[&Pubkey],
-    proof_data: &WithdrawWithheldTokensData,
+    #[cfg(feature = "proof-program")] proof_data: &WithdrawWithheldTokensData,
 ) -> Result<Vec<Instruction>, ProgramError> {
     Ok(vec![
         inner_withdraw_withheld_tokens_from_accounts(
@@ -1202,6 +1207,7 @@ pub fn withdraw_withheld_tokens_from_accounts(
             sources,
             1,
         )?,
+        #[cfg(feature = "proof-program")]
         verify_withdraw_withheld_tokens(proof_data),
     ])
 }


### PR DESCRIPTION
#### Problem
There is a PR in progress https://github.com/solana-labs/solana/pull/29996 that updates the proof verification program so that it break token-2022 confidential transfer. This results in downstream CI tests to fail.

#### Summary of Changes
Temporarily create a `proof-program` feature in the token-2022 program to disable the components that uses the proof program. Once https://github.com/solana-labs/solana/pull/29996 is merged and solana-program is updated, either make the `proof-program` feature as default or remove the feature altogether.