### PR TITLE
docs: Clarify audit status of all programs, no S word

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,25 +10,38 @@ portable across all implementations.
 
 For more information see the [SPL documentation](https://spl.solana.com) and the [Token TypeDocs](https://solana-labs.github.io/solana-program-library/token/js/).
 
-## Note
+## Audits
 
 Only a subset of programs within the Solana Program Library repo are deployed to
-the Solana Mainnet Beta and maintained by the team. Currently, this includes:
+the Solana Mainnet Beta. Currently, this includes:
 
-* [associated-token-account](https://github.com/solana-labs/solana-program-library/tree/master/associated-token-account/program)
-* [feature-proposal](https://github.com/solana-labs/solana-program-library/tree/master/feature-proposal/program)
-* [governance](https://github.com/solana-labs/solana-program-library/tree/master/governance/program)
-* [memo](https://github.com/solana-labs/solana-program-library/tree/master/memo/program)
-* [name-service](https://github.com/solana-labs/solana-program-library/tree/master/name-service/program)
-* [stake-pool](https://github.com/solana-labs/solana-program-library/tree/master/stake-pool/program)
-* [token](https://github.com/solana-labs/solana-program-library/tree/master/token/program)
+| Program | Last Audit Date | Version |
+| --- | --- | --- |
+| [token](https://github.com/solana-labs/solana-program-library/tree/master/token/program) | 2022-08-04 (Peer review) | [3.4.0](https://github.com/solana-labs/solana-program-library/releases/tag/token-v3.4.0) |
+| [associated-token-account](https://github.com/solana-labs/solana-program-library/tree/master/associated-token-account/program) | 2022-08-04 (Peer review) | [1.1.0](https://github.com/solana-labs/solana-program-library/releases/tag/associated-token-account-v1.1.0) |
+| [token-2022](https://github.com/solana-labs/solana-program-library/tree/master/token/program-2022) | [2022-12-05](https://github.com/solana-labs/security-audits/blob/master/spl/ZellicToken2022Audit-2022-12-05.pdf) | [0.5.0](https://github.com/solana-labs/solana-program-library/releases/tag/token-2022-v0.5.0) |
+| [governance](https://github.com/solana-labs/solana-program-library/tree/master/governance/program) | N/A | [3.1.0](https://github.com/solana-labs/solana-program-library/releases/tag/governance-v3.1.0) |
+| [stake-pool](https://github.com/solana-labs/solana-program-library/tree/master/stake-pool/program) | [2023-01-31](https://github.com/solana-labs/security-audits/blob/master/spl/NeodymeStakePoolAudit-2023-01-31.pdf) | [1.0.0]() |
+| [account-compression](https://github.com/solana-labs/solana-program-library/tree/master/account-compression/programs/account-compression) | [2022-12-05](https://github.com/solana-labs/security-audits/blob/master/spl/OtterSecAccountCompressionAudit-2022-12-03.pdf) | [0.1.3](https://github.com/solana-labs/solana-program-library/releases/tag/account-compression-v0.1.3) |
+| [shared-memory](https://github.com/solana-labs/solana-program-library/tree/master/shared-memory/program) | [2021-02-25](https://github.com/solana-labs/security-audits/blob/master/spl/KudelskiTokenSwapSharedMemAudit-2021-02-25.pdf) | [1.0.0](https://github.com/solana-labs/solana-program-library/commit/b40e0dd3fd6c0e509dc1e8dd3da0a6d609035bbd) |
+| [feature-proposal](https://github.com/solana-labs/solana-program-library/tree/master/feature-proposal/program) | Not audited | [1.0.0](https://github.com/solana-labs/solana-program-library/releases/tag/feature-proposal-v1.0.0) |
+| [name-service](https://github.com/solana-labs/solana-program-library/tree/master/name-service/program) | Not audited | [0.3.0](https://github.com/solana-labs/solana-program-library/releases/tag/name-service-v0.3.0) |
+| [memo](https://github.com/solana-labs/solana-program-library/tree/master/memo/program) | Not audited | [3.0.0](https://github.com/solana-labs/solana-program-library/releases/tag/memo-v3.0.0) |
 
-All other programs are maintained on a best-effort basis with community support
-and the team has no plans to deploy them to Mainnet Beta at this time. Many
-programs, including
-[token-swap](https://github.com/solana-labs/solana-program-library/tree/master/token-swap/program)
-and [token-lending](https://github.com/solana-labs/solana-program-library/tree/master/token-lending/program),
-are not audited, so fork and deploy them at your own risk.
+All other programs are updated on a best-effort basis with community support,
+and the team has no plans to deploy them to Mainnet Beta at this time. These
+programs are not audited, so fork and deploy them at your own risk. Here is the
+full list of unaudited programs:
+
+* [binary-option](https://github.com/solana-labs/solana-program-library/tree/master/binary-option/program)
+* [binary-oracle-pair](https://github.com/solana-labs/solana-program-library/tree/master/binary-oracle-pair/program)
+* [instruction-padding](https://github.com/solana-labs/solana-program-library/tree/master/instruction-padding/program)
+* [managed-token](https://github.com/solana-labs/solana-program-library/tree/master/managed-token/program)
+* [record](https://github.com/solana-labs/solana-program-library/tree/master/record/program)
+* [stateless-asks](https://github.com/solana-labs/solana-program-library/tree/master/stateless-asks/program)
+* [token-lending](https://github.com/solana-labs/solana-program-library/tree/master/token-lending/program)
+* [token-swap](https://github.com/solana-labs/solana-program-library/tree/master/token-swap/program)
+* [token-upgrade](https://github.com/solana-labs/solana-program-library/tree/master/token-upgrade/program)
 
 More information about the repository's security policy at
 [SECURITY.md](https://github.com/solana-labs/solana-program-library/tree/master/SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -28,10 +28,9 @@ the Solana Mainnet Beta. Currently, this includes:
 | [name-service](https://github.com/solana-labs/solana-program-library/tree/master/name-service/program) | Not audited | [0.3.0](https://github.com/solana-labs/solana-program-library/releases/tag/name-service-v0.3.0) |
 | [memo](https://github.com/solana-labs/solana-program-library/tree/master/memo/program) | Not audited | [3.0.0](https://github.com/solana-labs/solana-program-library/releases/tag/memo-v3.0.0) |
 
-All other programs are updated on a best-effort basis with community support,
-and the team has no plans to deploy them to Mainnet Beta at this time. These
-programs are not audited, so fork and deploy them at your own risk. Here is the
-full list of unaudited programs:
+All other programs may be updated from time to time. These programs are not
+audited, so fork and deploy them at your own risk. Here is the full list of
+unaudited programs:
 
 * [binary-option](https://github.com/solana-labs/solana-program-library/tree/master/binary-option/program)
 * [binary-oracle-pair](https://github.com/solana-labs/solana-program-library/tree/master/binary-oracle-pair/program)
@@ -45,6 +44,9 @@ full list of unaudited programs:
 
 More information about the repository's security policy at
 [SECURITY.md](https://github.com/solana-labs/solana-program-library/tree/master/SECURITY.md).
+
+The [security-audits repo](https://github.com/solana-labs/security-audits) contains
+all past and present program audits.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ The Solana Program Library (SPL) is a collection of on-chain programs targeting
 the [Sealevel parallel
 runtime](https://medium.com/solana-labs/sealevel-parallel-processing-thousands-of-smart-contracts-d814b378192).
 These programs are tested against Solana's implementation of Sealevel,
-solana-runtime, and some are deployed to mainnet-beta.  As others implement Sealevel, we
-will graciously accept patches to ensure the programs here are portable across
-all implementations.
+solana-runtime, and some are deployed to Mainnet Beta.  As others implement
+Sealevel, we will graciously accept patches to ensure the programs here are
+portable across all implementations.
 
 For more information see the [SPL documentation](https://spl.solana.com) and the [Token TypeDocs](https://solana-labs.github.io/solana-program-library/token/js/).
 
@@ -23,8 +23,9 @@ the Solana Mainnet Beta and maintained by the team. Currently, this includes:
 * [stake-pool](https://github.com/solana-labs/solana-program-library/tree/master/stake-pool/program)
 * [token](https://github.com/solana-labs/solana-program-library/tree/master/token/program)
 
-All other programs are updated on a best-effort basis with community involvement.
-Many programs, including
+All other programs are maintained on a best-effort basis with community support
+and the team has no plans to deploy them to Mainnet Beta at this time. Many
+programs, including
 [token-swap](https://github.com/solana-labs/solana-program-library/tree/master/token-swap/program)
 and [token-lending](https://github.com/solana-labs/solana-program-library/tree/master/token-lending/program),
 are not audited, so fork and deploy them at your own risk.
@@ -91,9 +92,9 @@ Solutions to a few issues you might run into are mentioned here.
     Update your Rust and Cargo to the latest versions and re-run `cargo build-sbf` in the relevant `<program-name>` directory,
     or run it at the repository root to rebuild all on-chain programs.
 
-2. [Error while loading shared libraries. (libssl.so.1.1)](https://solana.stackexchange.com/questions/3029/anchor-test-error-while-loading-shared-libraries-libssl-so-1-1)
+2. [Error while loading shared libraries. (libssl.so.1.1)](https://solana.stackexchange.com/q/3029/36)
 
-    A working solution was mentioned [here](https://solana.stackexchange.com/questions/3029/anchor-test-error-while-loading-shared-libraries-libssl-so-1-1).
+    A working solution was mentioned [here](https://solana.stackexchange.com/q/3029/36).
     Install libssl.
     ```bash
     wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1l-1ubuntu1.2_amd64.deb

--- a/README.md
+++ b/README.md
@@ -1,21 +1,36 @@
-[![Build status][travis-image]][travis-url]
-
-[travis-image]:
-https://travis-ci.org/solana-labs/solana-program-library.svg?branch=master
-[travis-url]: https://travis-ci.org/solana-labs/solana-program-library
-
 # Solana Program Library
 
 The Solana Program Library (SPL) is a collection of on-chain programs targeting
 the [Sealevel parallel
 runtime](https://medium.com/solana-labs/sealevel-parallel-processing-thousands-of-smart-contracts-d814b378192).
 These programs are tested against Solana's implementation of Sealevel,
-solana-runtime, and deployed to its mainnet.  As others implement Sealevel, we
+solana-runtime, and some are deployed to mainnet-beta.  As others implement Sealevel, we
 will graciously accept patches to ensure the programs here are portable across
 all implementations.
 
 For more information see the [SPL documentation](https://spl.solana.com) and the [Token TypeDocs](https://solana-labs.github.io/solana-program-library/token/js/).
 
+## Note
+
+Only a subset of programs within the Solana Program Library repo are deployed to
+the Solana Mainnet Beta and maintained by the team. Currently, this includes:
+
+* [associated-token-account](https://github.com/solana-labs/solana-program-library/tree/master/associated-token-account/program)
+* [feature-proposal](https://github.com/solana-labs/solana-program-library/tree/master/feature-proposal/program)
+* [governance](https://github.com/solana-labs/solana-program-library/tree/master/governance/program)
+* [memo](https://github.com/solana-labs/solana-program-library/tree/master/memo/program)
+* [name-service](https://github.com/solana-labs/solana-program-library/tree/master/name-service/program)
+* [stake-pool](https://github.com/solana-labs/solana-program-library/tree/master/stake-pool/program)
+* [token](https://github.com/solana-labs/solana-program-library/tree/master/token/program)
+
+All other programs are updated on a best-effort basis with community involvement.
+Many programs, including
+[token-swap](https://github.com/solana-labs/solana-program-library/tree/master/token-swap/program)
+and [token-lending](https://github.com/solana-labs/solana-program-library/tree/master/token-lending/program),
+are not audited, so fork and deploy them at your own risk.
+
+More information about the repository's security policy at
+[SECURITY.md](https://github.com/solana-labs/solana-program-library/tree/master/SECURITY.md).
 
 ## Development
 
@@ -68,6 +83,7 @@ Integration testing may be performed via the per-project .js bindings.  See the
 [token program's js project](token/js) for an example.
 
 ### Common Issues
+
 Solutions to a few issues you might run into are mentioned here.
 
 1. `Failed to open: ../../deploy/spl_<program-name>.so`
@@ -75,9 +91,9 @@ Solutions to a few issues you might run into are mentioned here.
     Update your Rust and Cargo to the latest versions and re-run `cargo build-sbf` in the relevant `<program-name>` directory,
     or run it at the repository root to rebuild all on-chain programs.
 
-2. [Error while loading shared libraries. (libssl.so.1.1)](https://github.com/project-serum/anchor/issues/1831)
+2. [Error while loading shared libraries. (libssl.so.1.1)](https://solana.stackexchange.com/questions/3029/anchor-test-error-while-loading-shared-libraries-libssl-so-1-1)
 
-    A working solution was mentioned [here](https://github.com/project-serum/anchor/issues/1831#issuecomment-1109124934).
+    A working solution was mentioned [here](https://solana.stackexchange.com/questions/3029/anchor-test-error-while-loading-shared-libraries-libssl-so-1-1).
     Install libssl.
     ```bash
     wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1l-1ubuntu1.2_amd64.deb
@@ -110,6 +126,7 @@ $ rustup toolchain install nightly-x86_64-apple-darwin
 
 
 ## Release Process
+
 SPL programs are currently tagged and released manually. Each program is
 versioned independently of the others, with all new development occurring on
 master. Once a program is tested and deemed ready for release:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,7 +42,7 @@ for details on classes of bugs and payment amounts.
 ## Scope
 
 Only a subset of programs within the Solana Program Library repo are deployed to
-the Solana Mainnet Beta and maintained by the team. Currently, this includes:
+the Solana Mainnet Beta. Currently, this includes:
 
 * [associated-token-account](https://github.com/solana-labs/solana-program-library/tree/master/associated-token-account/program)
 * [feature-proposal](https://github.com/solana-labs/solana-program-library/tree/master/feature-proposal/program)

--- a/account-compression/README.md
+++ b/account-compression/README.md
@@ -29,3 +29,8 @@ With a built local SDK, the test suite can be ran with:
 1. `yarn link @solana/spl-account-compression`
 2. `yarn`
 3. `yarn test`
+
+## Audit
+
+The repository [README](https://github.com/solana-labs/solana-program-library#audits)
+contains information about program audits.

--- a/binary-option/README.md
+++ b/binary-option/README.md
@@ -12,6 +12,10 @@ Now suppose the Bucks win Game 3, and the estimated probability of the Bucks win
 
 We'll discuss this mechanism in more detail later.
 
+## Note
+
+This code is unaudited. Use at your own risk.
+
 ## Client Setup 
 First, clone down the repository (TODO publish to PyPI)
 

--- a/binary-option/README.md
+++ b/binary-option/README.md
@@ -12,9 +12,10 @@ Now suppose the Bucks win Game 3, and the estimated probability of the Bucks win
 
 We'll discuss this mechanism in more detail later.
 
-## Note
+## Audit
 
-This code is unaudited. Use at your own risk.
+The repository [README](https://github.com/solana-labs/solana-program-library#audits)
+contains information about program audits.
 
 ## Client Setup 
 First, clone down the repository (TODO publish to PyPI)

--- a/binary-oracle-pair/README.md
+++ b/binary-oracle-pair/README.md
@@ -1,4 +1,4 @@
-Simple Oracle Pair Token
+# Simple Oracle Pair Token
 
 1. pick a deposit token
 2. pick the decider's pubkey
@@ -10,3 +10,7 @@ the mint term end slot.  After the decide term end slot the `Pass`
 token converts 1:1 with the deposit token if and only if the decider
 had set `pass` before the end of the decide term, otherwise the `Fail`
 token converts 1:1 with the deposit token.
+
+## Note
+
+This code is unaudited. Use at your own risk.

--- a/binary-oracle-pair/README.md
+++ b/binary-oracle-pair/README.md
@@ -11,6 +11,7 @@ token converts 1:1 with the deposit token if and only if the decider
 had set `pass` before the end of the decide term, otherwise the `Fail`
 token converts 1:1 with the deposit token.
 
-## Note
+## Audit
 
-This code is unaudited. Use at your own risk.
+The repository [README](https://github.com/solana-labs/solana-program-library#audits)
+contains information about program audits.

--- a/docs/src/token-lending.md
+++ b/docs/src/token-lending.md
@@ -5,6 +5,7 @@ title: Token-Lending Program
 A lending protocol for the Token program on the Solana blockchain inspired by
 Aave and Compound.
 
-## Note
+## Audit
 
-This code is unaudited. Use at your own risk.
+The repository [README](https://github.com/solana-labs/solana-program-library#audits)
+contains information about program audits.

--- a/docs/src/token-lending.md
+++ b/docs/src/token-lending.md
@@ -2,13 +2,9 @@
 title: Token-Lending Program
 ---
 
-A lending protocol for the Token program on the Solana blockchain inspired by Aave and Compound.
+A lending protocol for the Token program on the Solana blockchain inspired by
+Aave and Compound.
 
+## Note
 
-### On-Chain Programs
-
-| Cluster | Program Address |
-| --- | --- |
-| Mainnet Beta | [`LendZqTs8gn5CTSJU1jWKhKuVpjJGom45nnwPb2AMTi`](https://explorer.solana.com/address/LendZqTs7gn5CTSJU1jWKhKuVpjJGom45nnwPb2AMTi) |
-| Testnet | [`LendZqTs8gn5CTSJU1jWKhKuVpjJGom45nnwPb2AMTi`](https://explorer.solana.com/address/LendZqTs8gn5CTSJU1jWKhKuVpjJGom45nnwPb2AMTi?cluster=testnet) |
-| Devnet | [`LendZqTs8gn5CTSJU1jWKhKuVpjJGom45nnwPb2AMTi`](https://explorer.solana.com/address/LendZqTs8gn5CTSJU1jWKhKuVpjJGom45nnwPb2AMTi?cluster=devnet) |
+This code is unaudited. Use at your own risk.

--- a/docs/src/token-swap.md
+++ b/docs/src/token-swap.md
@@ -5,9 +5,10 @@ title: Token Swap Program
 A Uniswap-like exchange for the Token program on the Solana blockchain,
 implementing multiple automated market maker (AMM) curves.
 
-## Note
+## Audit
 
-This code is unaudited. Use at your own risk.
+The repository [README](https://github.com/solana-labs/solana-program-library#audits)
+contains information about program audits.
 
 ## Available Deployments
 

--- a/docs/src/token-swap.md
+++ b/docs/src/token-swap.md
@@ -16,8 +16,8 @@ This code is unaudited. Use at your own risk.
 | Testnet | 3.0.0 | `SwapsVeCiPHMUAtzQWZw7RjsKjgCjhwU55QGu4U1Szw` |
 | Devnet | 3.0.0 | `SwapsVeCiPHMUAtzQWZw7RjsKjgCjhwU55QGu4U1Szw` |
 
-For mainnet, please use any other AMM project on Solana. Some were based on
-Token Swap!
+While third-party deployments of token-swap exist on Mainnet Beta, the team has
+no plans to deploy it themselves.
 
 Check out the
 [program repository](https://github.com/solana-labs/solana-program-library/tree/master/token-swap)

--- a/docs/src/token-swap.md
+++ b/docs/src/token-swap.md
@@ -5,25 +5,21 @@ title: Token Swap Program
 A Uniswap-like exchange for the Token program on the Solana blockchain,
 implementing multiple automated market maker (AMM) curves.
 
+## Note
+
+This code is unaudited. Use at your own risk.
+
 ## Available Deployments
 
-
-| Network | Version | Program Address | Fee Owner Address |
+| Network | Version | Program Address |
 | --- | --- | --- |
-| Devnet, Testnet | 3.0.0 | `SwapsVeCiPHMUAtzQWZw7RjsKjgCjhwU55QGu4U1Szw` | Any |
-| All | 2.0.0 | `SwaPpA9LAaLfeLi3a68M4DjnLqgtticKg6CnyNwgAC8` | `HfoTxFR1Tm6kGmWgYWD6J7YHVy1UwqSULUGVLXkJqaKN` |
+| Testnet | 3.0.0 | `SwapsVeCiPHMUAtzQWZw7RjsKjgCjhwU55QGu4U1Szw` |
+| Devnet | 3.0.0 | `SwapsVeCiPHMUAtzQWZw7RjsKjgCjhwU55QGu4U1Szw` |
 
-The Token Swap Program was deployed to all networks by the Serum team at
-`SwaPpA9LAaLfeLi3a68M4DjnLqgtticKg6CnyNwgAC8`, requiring a fee owner of
-`HfoTxFR1Tm6kGmWgYWD6J7YHVy1UwqSULUGVLXkJqaKN`, but that version was deprecated
-in the middle of 2021.  Though that program still exists, it is not actively
-maintained.
+For mainnet, please use any other AMM project on Solana. Some were based on
+Token Swap!
 
-For devnet and testnet, please use the maintained deployment at
-`SwapsVeCiPHMUAtzQWZw7RjsKjgCjhwU55QGu4U1Szw`, and for mainnet, please use any
-other AMM project on Solana. Almost all of these were based on Token Swap!
-
-Check out
+Check out the
 [program repository](https://github.com/solana-labs/solana-program-library/tree/master/token-swap)
 for more developer information.
 
@@ -66,8 +62,7 @@ bindings](https://github.com/solana-labs/solana-program-library/blob/master/toke
 are available that support loading the Token Swap Program on to a chain and
 issuing instructions.
 
-Example user interface built and maintained by Serum team is available
-[here](https://github.com/project-serum/oyster-swap)
+Example user interface is available [here](https://github.com/solana-labs/oyster-swap).
 
 ## Operational overview
 

--- a/docs/src/token-upgrade.md
+++ b/docs/src/token-upgrade.md
@@ -8,6 +8,10 @@ tokens from one mint to another.
 The program provides a simple mechanism for burning the original tokens and receiving
 an equal number of new tokens from an escrow account controlled by the program.
 
+## Note
+
+This code is unaudited. Use at your own risk.
+
 ## Background
 
 Token-2022 contains many new features for mint owners to customize the behavior

--- a/docs/src/token-upgrade.md
+++ b/docs/src/token-upgrade.md
@@ -8,9 +8,10 @@ tokens from one mint to another.
 The program provides a simple mechanism for burning the original tokens and receiving
 an equal number of new tokens from an escrow account controlled by the program.
 
-## Note
+## Audit
 
-This code is unaudited. Use at your own risk.
+The repository [README](https://github.com/solana-labs/solana-program-library#audits)
+contains information about program audits.
 
 ## Background
 

--- a/examples/c/README.md
+++ b/examples/c/README.md
@@ -20,3 +20,8 @@ To build the examples and run the tests:
 ```bash
 $ make
 ```
+
+## Audit
+
+The repository [README](https://github.com/solana-labs/solana-program-library#audits)
+contains information about program audits.

--- a/examples/rust/README.md
+++ b/examples/rust/README.md
@@ -9,6 +9,7 @@ with a live cluster.
 The root [README](../../README.md) gives instructions on how to build and test
 these examples.
 
-## Note
+## Audit
 
-This code is unaudited. Use at your own risk.
+The repository [README](https://github.com/solana-labs/solana-program-library#audits)
+contains information about program audits.

--- a/examples/rust/README.md
+++ b/examples/rust/README.md
@@ -8,3 +8,7 @@ with a live cluster.
 
 The root [README](../../README.md) gives instructions on how to build and test
 these examples.
+
+## Note
+
+This code is unaudited. Use at your own risk.

--- a/farms/docs/intro.md
+++ b/farms/docs/intro.md
@@ -16,9 +16,10 @@ This source code is an example that third parties can utilize to create and use 
 
 To quickly build, test and deploy Solana Farms and try it out in action, please follow the [Quick Start](https://github.com/solana-labs/solana-program-library/blob/master/farms/docs/quick_start.md) guide.
 
-## Note
+## Audit
 
-This code is unaudited. Use at your own risk.
+The repository [README](https://github.com/solana-labs/solana-program-library#audits)
+contains information about program audits.
 
 ## Dive in
 

--- a/farms/docs/intro.md
+++ b/farms/docs/intro.md
@@ -16,6 +16,10 @@ This source code is an example that third parties can utilize to create and use 
 
 To quickly build, test and deploy Solana Farms and try it out in action, please follow the [Quick Start](https://github.com/solana-labs/solana-program-library/blob/master/farms/docs/quick_start.md) guide.
 
+## Note
+
+This code is unaudited. Use at your own risk.
+
 ## Dive in
 
 If you want to learn more about the tools and building blocks of the Solana Farms suite, follow the links below:

--- a/governance/README.md
+++ b/governance/README.md
@@ -197,3 +197,8 @@ the DAO until the token is distributed.
 ### Proposal Workflow
 
 ![Proposal Workflow](./resources/governance-workflow.jpg)
+
+## Audit
+
+The repository [README](https://github.com/solana-labs/solana-program-library#audits)
+contains information about program audits.

--- a/instruction-padding/program/README.md
+++ b/instruction-padding/program/README.md
@@ -22,3 +22,7 @@ all large transaction tests, and comparing TPS numbers between:
 
 * using the program with no padding
 * using the program with data and account padding
+
+## Note
+
+This code is unaudited. Use at your own risk.

--- a/instruction-padding/program/README.md
+++ b/instruction-padding/program/README.md
@@ -23,6 +23,7 @@ all large transaction tests, and comparing TPS numbers between:
 * using the program with no padding
 * using the program with data and account padding
 
-## Note
+## Audit
 
-This code is unaudited. Use at your own risk.
+The repository [README](https://github.com/solana-labs/solana-program-library#audits)
+contains information about program audits.

--- a/libraries/math/README.md
+++ b/libraries/math/README.md
@@ -2,6 +2,7 @@
 
 Library with utilities for on-chain math.
 
-## Note
+## Audit
 
-This code is unaudited. Use at your own risk.
+The repository [README](https://github.com/solana-labs/solana-program-library#audits)
+contains information about program audits.

--- a/libraries/math/README.md
+++ b/libraries/math/README.md
@@ -1,0 +1,7 @@
+# Math
+
+Library with utilities for on-chain math.
+
+## Note
+
+This code is unaudited. Use at your own risk.

--- a/managed-token/README.md
+++ b/managed-token/README.md
@@ -4,6 +4,7 @@ On-chain program for "managed tokens", SPL tokens that are perpetually frozen,
 and must be used through this program, which will thaw the account, perform an
 instruction, and re-freeze the account.
 
-## Note
+## Audit
 
-This code is unaudited. Use at your own risk.
+The repository [README](https://github.com/solana-labs/solana-program-library#audits)
+contains information about program audits.

--- a/managed-token/README.md
+++ b/managed-token/README.md
@@ -1,0 +1,9 @@
+# Managed Token
+
+On-chain program for "managed tokens", SPL tokens that are perpetually frozen,
+and must be used through this program, which will thaw the account, perform an
+instruction, and re-freeze the account.
+
+## Note
+
+This code is unaudited. Use at your own risk.

--- a/memo/README.md
+++ b/memo/README.md
@@ -7,3 +7,8 @@ record a string on-chain, stored in the instruction data of a successful
 transaction, and optionally verify the originator.
 
 Full documentation is available at https://spl.solana.com/memo
+
+## Audit
+
+The repository [README](https://github.com/solana-labs/solana-program-library#audits)
+contains information about program audits.

--- a/name-service/README.md
+++ b/name-service/README.md
@@ -9,3 +9,8 @@ utilize to create and use their own version of a name service of any kind.
 Full documentation is available at https://spl.solana.com/name-service
 
 JavaScript binding are available in the `./js` directory.
+
+## Audit
+
+The repository [README](https://github.com/solana-labs/solana-program-library#audits)
+contains information about program audits.

--- a/name-service/js/src/utils.ts
+++ b/name-service/js/src/utils.ts
@@ -132,7 +132,6 @@ export async function getNameOwner(
   return NameRegistryState.retrieve(connection, nameAccountKey);
 }
 
-//Taken from Serum
 export async function getFilteredProgramAccounts(
   connection: Connection,
   programId: PublicKey,

--- a/record/program/README.md
+++ b/record/program/README.md
@@ -1,0 +1,8 @@
+# Record
+
+On-chain program for writing arbitrary data to an account, authorized by an
+owner of the account.
+
+## Note
+
+This code is unaudited. Use at your own risk.

--- a/record/program/README.md
+++ b/record/program/README.md
@@ -3,6 +3,7 @@
 On-chain program for writing arbitrary data to an account, authorized by an
 owner of the account.
 
-## Note
+## Audit
 
-This code is unaudited. Use at your own risk.
+The repository [README](https://github.com/solana-labs/solana-program-library#audits)
+contains information about program audits.

--- a/shared-memory/README.md
+++ b/shared-memory/README.md
@@ -4,3 +4,8 @@ A shared-memory program on the Solana blockchain, usable for sharing data
 between programs or within cross-program invocations.
 
 Full documentation is available at https://spl.solana.com/shared-memory
+
+## Audit
+
+The repository [README](https://github.com/solana-labs/solana-program-library#audits)
+contains information about program audits.

--- a/stake-pool/README.md
+++ b/stake-pool/README.md
@@ -7,3 +7,8 @@ The command-line interface tool is available in the `./cli` directory.
 Javascript bindings are available in the `./js` directory.
 
 Python bindings are available in the `./py` directory.
+
+## Audit
+
+The repository [README](https://github.com/solana-labs/solana-program-library#audits)
+contains information about program audits.

--- a/stateless-asks/README.md
+++ b/stateless-asks/README.md
@@ -21,6 +21,7 @@ the offer off-chain.
 
 To cancel, the maker simply needs to cancel the delegation.
 
-## Note
+## Audit
 
-This code is unaudited. Use at your own risk.
+The repository [README](https://github.com/solana-labs/solana-program-library#audits)
+contains information about program audits.

--- a/stateless-asks/README.md
+++ b/stateless-asks/README.md
@@ -1,22 +1,26 @@
 # Stateless Offer
 
- Simple program to make token offers to any bidder that can satisfy
- the constraints.
+Simple program to make token offers to any bidder that can satisfy
+the constraints.
 
- This program is stateless.  It is up to the maker to advertise.  It
- uses the PDA as a one way hash of the offer that the maker wants
- to create.  The maker then only needs to approve their token to the
- PDA address for the taker to receive the items.  The maker doesn't
- need to be online to complete the transaction, but needs to advertise
- the offer off-chain.
+This program is stateless.  It is up to the maker to advertise.  It
+uses the PDA as a one way hash of the offer that the maker wants
+to create.  The maker then only needs to approve their token to the
+PDA address for the taker to receive the items.  The maker doesn't
+need to be online to complete the transaction, but needs to advertise
+the offer off-chain.
 
- ## Maker
- 1. compute the offer PDA
- 2. approve the token delegation for the amount to the PDA
- 3. publish the offer off-chain
+## Maker
+1. compute the offer PDA
+2. approve the token delegation for the amount to the PDA
+3. publish the offer off-chain
 
- ## Taker
- 1. Create the offer TX
- 2. Submit the TX to the stateless-offer program
+## Taker
+1. Create the offer TX
+2. Submit the TX to the stateless-offer program
 
- To cancel, the maker simply needs to cancel the delegation.
+To cancel, the maker simply needs to cancel the delegation.
+
+## Note
+
+This code is unaudited. Use at your own risk.

--- a/token-lending/README.md
+++ b/token-lending/README.md
@@ -6,14 +6,14 @@ Full documentation is available at https://spl.solana.com/token-lending
 
 Web3 bindings are available in the `./js` directory.
 
-### On-chain programs
+## Note
 
-Please note that only the lending program deployed to devnet is currently operational.
+This code is unaudited. Use at your own risk.
+
+### On-chain programs
 
 | Cluster | Program Address |
 | --- | --- |
-| Mainnet Beta | [`LendZqTs8gn5CTSJU1jWKhKuVpjJGom45nnwPb2AMTi`](https://explorer.solana.com/address/LendZqTs7gn5CTSJU1jWKhKuVpjJGom45nnwPb2AMTi) |
-| Testnet | [`6TvznH3B2e3p2mbhufNBpgSrLx6UkgvxtVQvopEZ2kuH`](https://explorer.solana.com/address/6TvznH3B2e3p2mbhufNBpgSrLx6UkgvxtVQvopEZ2kuH?cluster=testnet) |
 | Devnet | [`6TvznH3B2e3p2mbhufNBpgSrLx6UkgvxtVQvopEZ2kuH`](https://explorer.solana.com/address/6TvznH3B2e3p2mbhufNBpgSrLx6UkgvxtVQvopEZ2kuH?cluster=devnet) |
 
 ### Documentation

--- a/token-lending/README.md
+++ b/token-lending/README.md
@@ -6,9 +6,10 @@ Full documentation is available at https://spl.solana.com/token-lending
 
 Web3 bindings are available in the `./js` directory.
 
-## Note
+## Audit
 
-This code is unaudited. Use at your own risk.
+The repository [README](https://github.com/solana-labs/solana-program-library#audits)
+contains information about program audits.
 
 ### On-chain programs
 

--- a/token-lending/program/src/pyth.rs
+++ b/token-lending/program/src/pyth.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-/// Derived from https://github.com/project-serum/anchor/blob/9224e0fa99093943a6190e396bccbc3387e5b230/examples/pyth/programs/pyth/src/pc.rs
+/// Derived from https://github.com/coral-xyz/anchor/blob/9224e0fa99093943a6190e396bccbc3387e5b230/examples/pyth/programs/pyth/src/pc.rs
 use bytemuck::{
     cast_slice, cast_slice_mut, from_bytes, from_bytes_mut, try_cast_slice, try_cast_slice_mut,
     Pod, PodCastError, Zeroable,

--- a/token-swap/README.md
+++ b/token-swap/README.md
@@ -6,9 +6,10 @@ Full documentation is available at https://spl.solana.com/token-swap
 
 JavaScript bindings are available in the `./js` directory.
 
-## Note
+## Audit
 
-This code is unaudited. Use at your own risk.
+The repository [README](https://github.com/solana-labs/solana-program-library#audits)
+contains information about program audits.
 
 ## Building master
 

--- a/token-swap/README.md
+++ b/token-swap/README.md
@@ -6,6 +6,10 @@ Full documentation is available at https://spl.solana.com/token-swap
 
 JavaScript bindings are available in the `./js` directory.
 
+## Note
+
+This code is unaudited. Use at your own risk.
+
 ## Building master
 
 To build a development version of the Token Swap program, you can use the normal
@@ -13,26 +17,6 @@ build command for Solana programs:
 
 ```sh
 cargo build-sbf
-```
-
-## Building mainnet v2.0.0
-
-For the version deployed to `SwaPpA9LAaLfeLi3a68M4DjnLqgtticKg6CnyNwgAC8`,
-the Token Swap Program contains a `production` feature to fix constraints on fees
-and fee account owner. A developer can deploy the program, allow others to create
-pools, and earn a "protocol fee" on all activity.
-
-Since Solana programs cannot contain any modifiable state, we must hard-code
-all constraints into the program.  `SwapConstraints` in `program/src/constraints.rs`
-contains all hard-coded fields for fees.  Additionally the
-`SWAP_PROGRAM_OWNER_FEE_ADDRESS` environment variable specifies the public key
-that must own all fee accounts.
-
-You can build the production version of Token Swap running on devnet, testnet, and
-mainnet-beta using the following command:
-
-```sh
-SWAP_PROGRAM_OWNER_FEE_ADDRESS=HfoTxFR1Tm6kGmWgYWD6J7YHVy1UwqSULUGVLXkJqaKN cargo build-sbf --features=production
 ```
 
 ## Testing
@@ -86,10 +70,4 @@ Then run all tests:
 
 ```sh
 npm run start-with-test-validator
-```
-
-If you are testing a production build, use:
-
-```sh
-SWAP_PROGRAM_OWNER_FEE_ADDRESS="HfoTxFR1Tm6kGmWgYWD6J7YHVy1UwqSULUGVLXkJqaKN" npm run start-with-test-validator
 ```

--- a/token-swap/proposals/DynamicMarketMaking.md
+++ b/token-swap/proposals/DynamicMarketMaking.md
@@ -1,6 +1,6 @@
-# Serum DEX Dynamic market making curve for token-swap
+# Openbook DEX Dynamic market making curve for token-swap
 
-Implement a curve for token-swap that accepts serum CLOB dex for the same pair. Implementation should 'split'/'route' portion of order using predefined curve for the pool and the rest to the dex as IOC order. Dynamic curve should find ideal size of the order based on the curve parameters and market depth for a given DEX.
+Implement a curve for token-swap that accepts CLOB dex for the same pair. Implementation should 'split'/'route' portion of order using predefined curve for the pool and the rest to the dex as IOC order. Dynamic curve should find ideal size of the order based on the curve parameters and market depth for a given DEX.
 
 Ideas: 
 * CLOB fee discounts 
@@ -10,4 +10,4 @@ Ideas:
     - AMM should charge same fee structure with 30bps difference from fees in CLOB
 
 ## Links
-1. CLOB implementation: https://github.com/project-serum/serum-dex/tree/master/dex
+1. CLOB implementation: https://github.com/openbook-dex/program/tree/master/dex

--- a/token-swap/proposals/DynamicMarketMaking.md
+++ b/token-swap/proposals/DynamicMarketMaking.md
@@ -1,6 +1,10 @@
 # Openbook DEX Dynamic market making curve for token-swap
 
-Implement a curve for token-swap that accepts CLOB dex for the same pair. Implementation should 'split'/'route' portion of order using predefined curve for the pool and the rest to the dex as IOC order. Dynamic curve should find ideal size of the order based on the curve parameters and market depth for a given DEX.
+Implement a curve for token-swap that accepts CLOB dex for the same pair.
+Implementation should 'split'/'route' portion of order using predefined curve
+for the pool and the rest to the dex as IOC order. Dynamic curve should find
+ideal size of the order based on the curve parameters and market depth for a
+given DEX.
 
 Ideas: 
 * CLOB fee discounts 

--- a/token-upgrade/README.md
+++ b/token-upgrade/README.md
@@ -3,6 +3,7 @@
 The Token Upgrade Program provides a stateless protocol for permanently converting
 tokens from one mint to another.
 
-## Note
+## Audit
 
-This code is unaudited. Use at your own risk.
+The repository [README](https://github.com/solana-labs/solana-program-library#audits)
+contains information about program audits.

--- a/token-upgrade/README.md
+++ b/token-upgrade/README.md
@@ -1,0 +1,8 @@
+# Token Upgrade
+
+The Token Upgrade Program provides a stateless protocol for permanently converting
+tokens from one mint to another.
+
+## Note
+
+This code is unaudited. Use at your own risk.

--- a/token/README.md
+++ b/token/README.md
@@ -8,3 +8,8 @@ utilize to create and use their tokens.
 Full documentation is available at https://spl.solana.com/token
 
 JavaScript bindings are available in the `./js` directory.
+
+## Audit
+
+The repository [README](https://github.com/solana-labs/solana-program-library#audits)
+contains information about program audits.


### PR DESCRIPTION
#### Problem

Although the information is in the security policy, it's hard to find out which programs have been audited.  Also, we still use the S word in a few places in the docs.

#### Solution

* Add disclaimers to all unaudited program READMEs and docs
* Replace / remove the S-word with openbook / coral
* Add the list of actively maintained programs to the top-level README

Sorry that this is a bit of a kitchen-sink PR, but I'm hoping it won't be too annoying to read through since it's all docs changes.