### PR TITLE
Account Compression TS SDK: add `MerkleTree` static functions

### DIFF
--- a/account-compression/sdk/package.json
+++ b/account-compression/sdk/package.json
@@ -56,6 +56,7 @@
     "@metaplex-foundation/beet-solana": "^0.4.0",
     "bn.js": "^5.2.1",
     "borsh": "^0.7.0",
+    "js-sha3": "^0.8.0",
     "typescript-collections": "^1.3.3"
   },
   "peerDependencies": {
@@ -80,7 +81,6 @@
     "gh-pages": "^4.0.0",
     "jest": "^29.0.1",
     "jest-config": "^29.0.1",
-    "js-sha3": "^0.8.0",
     "start-server-and-test": "^1.14.0",
     "ts-jest": "^28.0.8",
     "ts-jest-resolver": "^2.0.0",

--- a/account-compression/sdk/package.json
+++ b/account-compression/sdk/package.json
@@ -49,6 +49,7 @@
     "test:events": "start-server-and-test start-validator http://localhost:8899/health run-tests:events",
     "test:accounts": "start-server-and-test start-validator http://localhost:8899/health run-tests:accounts",
     "test:e2e": "start-server-and-test start-validator http://localhost:8899/health run-tests:e2e",
+    "test:merkle-tree": "jest tests/merkleTree.test.ts --detectOpenHandles",
     "test": "start-server-and-test start-validator http://localhost:8899/health run-tests"
   },
   "dependencies": {

--- a/account-compression/sdk/src/merkle-tree/index.ts
+++ b/account-compression/sdk/src/merkle-tree/index.ts
@@ -1,6 +1,6 @@
-import pkg from "js-sha3";
-import * as Collections from "typescript-collections";
-import { PublicKey } from "@solana/web3.js";
+import pkg from 'js-sha3';
+import * as Collections from 'typescript-collections';
+import { PublicKey } from '@solana/web3.js';
 const { keccak_256 } = pkg;
 
 let CACHE_EMPTY_NODE = new Map<number, Buffer>();
@@ -98,7 +98,7 @@ export class MerkleTree {
     let node = this.leaves[leafIndex];
 
     let height = 0;
-    while (typeof node.parent !== "undefined") {
+    while (typeof node.parent !== 'undefined') {
       if (minimizeProofHeight && height >= treeHeight) {
         break;
       }
@@ -113,7 +113,7 @@ export class MerkleTree {
         if (!hashed.equals(parent.node)) {
           console.log(hashed);
           console.log(parent.node);
-          throw new Error("Invariant broken when hashing left node");
+          throw new Error('Invariant broken when hashing left node');
         }
       } else {
         proof.push(parent.left!);
@@ -122,7 +122,7 @@ export class MerkleTree {
         if (!hashed.equals(parent.node)) {
           console.log(hashed);
           console.log(parent.node);
-          throw new Error("Invariant broken when hashing right node");
+          throw new Error('Invariant broken when hashing right node');
         }
       }
       node = parent;
@@ -143,7 +143,7 @@ export class MerkleTree {
     let node = leaf;
 
     var i = 0;
-    while (typeof node.parent !== "undefined") {
+    while (typeof node.parent !== 'undefined') {
       if (verbose) {
         console.log(`${i}: ${Uint8Array.from(node.node)}`);
       }
@@ -175,8 +175,15 @@ export class MerkleTree {
     return node;
   }
 
+  /**
+   * Verifies that a root matches the proof.
+   * @param root Root of a MerkleTree
+   * @param merkleTreeProof Proof to a leaf in the MerkleTree
+   * @param verbose Whether to print hashed nodes
+   * @returns Whether the proof is valid
+   */
   static verify(
-    root: string,
+    root: Buffer,
     merkleTreeProof: MerkleTreeProof,
     verbose: boolean = false
   ): boolean {
@@ -184,9 +191,9 @@ export class MerkleTree {
     const rehashed = new PublicKey(node).toString();
     const received = new PublicKey(root).toString();
     if (rehashed !== received) {
-      throw new Error(
-        `Roots don't match! Expected ${rehashed} got ${received}`
-      );
+      if (verbose)
+        console.log(`Roots don't match! Expected ${rehashed} got ${received}`);
+      return false;
     }
     if (verbose) console.log(`Hashed ${rehashed} got ${received}`);
     return rehashed === received;

--- a/account-compression/sdk/src/merkle-tree/index.ts
+++ b/account-compression/sdk/src/merkle-tree/index.ts
@@ -74,13 +74,13 @@ export class MerkleTree {
   ): MerkleTree {
     const _leaves: Buffer[] = [];
     for (let i = 0; i < 2 ** depth; i++) {
-      if (i < leaves.length) {
+      if (i >= leaves.length) {
         _leaves.push(leaves[i]);
       } else {
-        leaves.push(Buffer.alloc(32));
+        _leaves.push(Buffer.alloc(32));
       }
     }
-    return new MerkleTree(leaves);
+    return new MerkleTree(_leaves);
   }
 
   getRoot(): Buffer {
@@ -178,17 +178,17 @@ export class MerkleTree {
   static verify(
     root: string,
     merkleTreeProof: MerkleTreeProof,
-    verbose = false
+    verbose: boolean = false
   ): boolean {
     const node = MerkleTree.hashProof(merkleTreeProof, verbose);
     const rehashed = new PublicKey(node).toString();
     const received = new PublicKey(root).toString();
-    if (verbose) console.log(`hashed ${rehashed} got ${received}`);
     if (rehashed !== received) {
       throw new Error(
         `Roots don't match! Expected ${rehashed} got ${received}`
       );
     }
+    if (verbose) console.log(`Hashed ${rehashed} got ${received}`);
     return rehashed === received;
   }
 }

--- a/account-compression/sdk/src/merkle-tree/index.ts
+++ b/account-compression/sdk/src/merkle-tree/index.ts
@@ -1,6 +1,6 @@
-import pkg from 'js-sha3';
-import * as Collections from 'typescript-collections';
-import { PublicKey } from '@solana/web3.js';
+import pkg from "js-sha3";
+import * as Collections from "typescript-collections";
+import { PublicKey } from "@solana/web3.js";
 const { keccak_256 } = pkg;
 
 let CACHE_EMPTY_NODE = new Map<number, Buffer>();
@@ -62,7 +62,7 @@ export class MerkleTree {
   /**
    * This is the recommended way to create MerkleTrees.
    * If you're trying to match an on-chain MerkleTree,
-   * set `depth` to `ConcurrentMerkleTreeAccount.getMaxDepth()`
+   * set `depth` to `{@link ConcurrentMerkleTreeAccount}.getMaxDepth()`
    *
    * @param leaves leaves of the tree
    * @param depth number of levels in the tree
@@ -98,7 +98,7 @@ export class MerkleTree {
     let node = this.leaves[leafIndex];
 
     let height = 0;
-    while (typeof node.parent !== 'undefined') {
+    while (typeof node.parent !== "undefined") {
       if (minimizeProofHeight && height >= treeHeight) {
         break;
       }
@@ -113,7 +113,7 @@ export class MerkleTree {
         if (!hashed.equals(parent.node)) {
           console.log(hashed);
           console.log(parent.node);
-          throw new Error('Invariant broken when hashing left node');
+          throw new Error("Invariant broken when hashing left node");
         }
       } else {
         proof.push(parent.left!);
@@ -122,7 +122,7 @@ export class MerkleTree {
         if (!hashed.equals(parent.node)) {
           console.log(hashed);
           console.log(parent.node);
-          throw new Error('Invariant broken when hashing right node');
+          throw new Error("Invariant broken when hashing right node");
         }
       }
       node = parent;
@@ -143,7 +143,7 @@ export class MerkleTree {
     let node = leaf;
 
     var i = 0;
-    while (typeof node.parent !== 'undefined') {
+    while (typeof node.parent !== "undefined") {
       if (verbose) {
         console.log(`${i}: ${Uint8Array.from(node.node)}`);
       }

--- a/account-compression/sdk/src/merkle-tree/index.ts
+++ b/account-compression/sdk/src/merkle-tree/index.ts
@@ -74,7 +74,7 @@ export class MerkleTree {
   ): MerkleTree {
     const _leaves: Buffer[] = [];
     for (let i = 0; i < 2 ** depth; i++) {
-      if (i >= leaves.length) {
+      if (i < leaves.length) {
         _leaves.push(leaves[i]);
       } else {
         _leaves.push(Buffer.alloc(32));

--- a/account-compression/sdk/tests/merkleTree.test.ts
+++ b/account-compression/sdk/tests/merkleTree.test.ts
@@ -1,0 +1,34 @@
+import { assert } from "chai";
+import * as crypto from "crypto";
+
+import { emptyNode, MerkleTree } from "../src";
+
+describe("MerkleTree tests", () => {
+  it("Check constructor equivalence for depth 2 tree", () => {
+    const leaves = [
+      crypto.randomBytes(32),
+      crypto.randomBytes(32),
+      crypto.randomBytes(32),
+    ];
+    const rawLeaves = leaves.concat(emptyNode(0));
+    const merkleTreeRaw = new MerkleTree(rawLeaves);
+    const merkleTreeSparse = MerkleTree.sparseMerkleTreeFromLeaves(leaves, 2);
+
+    assert(merkleTreeRaw.root.equals(merkleTreeSparse.root));
+  });
+
+  const TEST_DEPTH = 14;
+  it(`Check proofs for 2^${TEST_DEPTH} tree`, () => {
+    const leaves: Buffer[] = [];
+    for (let i = 0; i < 2 ** TEST_DEPTH; i++) {
+      leaves.push(crypto.randomBytes(32));
+    }
+    const merkleTree = new MerkleTree(leaves);
+
+    // Check proofs
+    for (let i = 0; i < leaves.length; i++) {
+      const proof = merkleTree.getProof(i);
+      assert(MerkleTree.verify(merkleTree.getRoot(), proof));
+    }
+  });
+});


### PR DESCRIPTION
Additions:
- Easier to use constructor method `sparseMerkleTreeFromLeaves` which by default creates sparse MerkleTree leaves for you
- Easier to use `verify` & `hashProof` methods (now static)

Fix:
- Move `js-sha3` to dependencies, instead of `devDependencies`