### PR TITLE
Add GetSeq to CMT

### DIFF
--- a/account-compression/Cargo.lock
+++ b/account-compression/Cargo.lock
@@ -350,18 +350,18 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.9.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdead85bdec19c194affaeeb670c0e41fe23de31459efd1c174d049269cf02cc"
+checksum = "c041d3eab048880cb0b86b256447da3f18859a163c3b8d8893f4e6368abe6393"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.1.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562e382481975bc61d11275ac5e62a19abd00b0547d99516a415336f183dcd0e"
+checksum = "1aca418a974d83d40a0c1f0c5cba6ff4bc28d8df099109ca459a2118d40b6322"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -851,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -1232,9 +1232,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.96"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
+checksum = "d56e159d99e6c2b93995d171050271edb50ecc5288fbc7cc17de8fdce4e58c14"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/libraries/concurrent-merkle-tree/src/concurrent_merkle_tree.rs
+++ b/libraries/concurrent-merkle-tree/src/concurrent_merkle_tree.rs
@@ -366,7 +366,7 @@ impl<const MAX_DEPTH: usize, const MAX_BUFFER_SIZE: usize>
         }
     }
 
-        /// Returns the Current Seq of the tree, the seq is the monotonic counter of the tree operations
+    /// Returns the Current Seq of the tree, the seq is the monotonic counter of the tree operations
     /// that is incremented every time a mutable operation is performed on the tree.
     pub fn  get_seq(&self) -> u64 {
         self.sequence_number

--- a/libraries/concurrent-merkle-tree/src/concurrent_merkle_tree.rs
+++ b/libraries/concurrent-merkle-tree/src/concurrent_merkle_tree.rs
@@ -366,6 +366,12 @@ impl<const MAX_DEPTH: usize, const MAX_BUFFER_SIZE: usize>
         }
     }
 
+        /// Returns the Current Seq of the tree, the seq is the monotonic counter of the tree operations
+    /// that is incremented every time a mutable operation is performed on the tree.
+    pub fn  get_seq(&self) -> u64 {
+        self.sequence_number
+    }
+
     /// Modifies the `proof` for leaf at `leaf_index`
     /// in place by fast-forwarding the given `proof` through the
     /// `changelog`s, starting at index `changelog_buffer_index`

--- a/libraries/concurrent-merkle-tree/src/concurrent_merkle_tree.rs
+++ b/libraries/concurrent-merkle-tree/src/concurrent_merkle_tree.rs
@@ -368,7 +368,7 @@ impl<const MAX_DEPTH: usize, const MAX_BUFFER_SIZE: usize>
 
     /// Returns the Current Seq of the tree, the seq is the monotonic counter of the tree operations
     /// that is incremented every time a mutable operation is performed on the tree.
-    pub fn  get_seq(&self) -> u64 {
+    pub fn get_seq(&self) -> u64 {
         self.sequence_number
     }
 


### PR DESCRIPTION
This pr adds a getSeq method to the zero copy CMT struct needed for indexing.