### PR TITLE
token-cli: add a catch-all pattern to cover all UiExtension instances when displaying token-22 extensions

### DIFF
--- a/token/cli/src/output.rs
+++ b/token/cli/src/output.rs
@@ -688,7 +688,7 @@ fn display_ui_extension(
         }
         // ExtensionType::Uninitialized is a hack to ensure a mint/account is never the same length as a multisig
         UiExtension::Uninitialized => Ok(()),
-        UiExtension::UnparseableExtension => writeln_name_value(
+        _ => writeln_name_value(
             f,
             "    Unparseable extension:",
             "Consider upgrading to a newer version of spl-token",


### PR DESCRIPTION
#### Problem
Due to circular dependencies with the token-cli, adding new extensions to the account-decoder in the mono repo causes ci tests to fail. `UiExtension` in the account decoder must cover all extension types, the `display_ui_extension` function in the token-cli requires all `UiExtension` types to be supported, and the ci tests require both crates to compile for any changes.

#### Summary of Changes
Replace `UiExtension::UnparseableExtension` with a catch-all pattern so that any new extensions that are added to the account-decoder are caught and processed by the token-cli.