### PR TITLE
Fix twoxtx setup vis-a-vis workspace inheritance

### DIFF
--- a/.github/workflows/pull-request-token.yml
+++ b/.github/workflows/pull-request-token.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Build and test token-2022 twoxtx (TEMPORARY)
         run: |
           ./token/twoxtx-setup.sh
-          cargo +${{ env.RUST_STABLE_VERSION }} test-sbf --manifest-path token/program-2022-test/Cargo.toml -- --nocapture
+          ./token/twoxtx-solana/cargo-test-sbf --manifest-path token/program-2022-test/Cargo.toml -- --nocapture
 
   js-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-token.yml
+++ b/.github/workflows/pull-request-token.yml
@@ -114,6 +114,8 @@ jobs:
       - name: Build and test token-2022 twoxtx (TEMPORARY)
         run: |
           ./token/twoxtx-setup.sh
+          ./token/twoxtx-solana/cargo-build-sbf --manifest-path token/program-2022/Cargo.toml
+          ./token/twoxtx-solana/cargo-build-sbf --manifest-path instruction-padding/program/Cargo.toml
           ./token/twoxtx-solana/cargo-test-sbf --manifest-path token/program-2022-test/Cargo.toml -- --nocapture
 
   js-test:

--- a/token/twoxtx-setup.sh
+++ b/token/twoxtx-setup.sh
@@ -25,4 +25,11 @@ if [[ ! -f twoxtx-solana/.twoxtx-patched ]]; then
 fi
 
 ../patch.crates-io.sh twoxtx-solana
+repo="token/twoxtx-solana"
+if sed -n '/exclude = \[/,/\]/p' ../Cargo.toml | grep -q "$repo"; then
+  echo "$repo is already excluded"
+else
+  sed -i'' ../Cargo.toml -e "/exclude/a \ \ \"$repo\","
+fi
+
 exit 0


### PR DESCRIPTION
The cargo-test-sbf-twoxtx CI job seems broken since the monorepo landed workspace inheritance.
SPL is on v1.60, and workspace inheritance was added in v1.64. So the twotx job probably needs to inherit the monorepo's rust toolchain and use the monorepo's `cargo-test-sbf`

Also, the SPL workspace needs to exclude the nested twoxtx-solana monorepo.

Needs rebase on #4064 