### PR TITLE
track rust version when using local monorepo

### DIFF
--- a/patch.crates-io.sh
+++ b/patch.crates-io.sh
@@ -24,6 +24,8 @@ solana_dir=$(cd "$solana_dir" && pwd)
 cd "$(dirname "$0")"
 
 source "$solana_dir"/scripts/read-cargo-variable.sh
+cp "$solana_dir"/rust-toolchain.toml .
+
 # get version from Cargo.toml first. if it is empty, get it from other places.
 solana_ver="$(readCargoVariable version "$solana_dir"/Cargo.toml)"
 solana_ver=${solana_ver:-$(readCargoVariable version "$solana_dir"/sdk/Cargo.toml)}


### PR DESCRIPTION
as it stands, if you run `./patch.crates-io.sh /path/to/solana`, it updates you to the monorepo crates, but leaves you on the spl version of rust. this causes breakage when monorepo uses features that are stable on their version but unstable on ours

monorepo uses `rust-toolchain.toml` now so the fix is simple! and correct, since we always track the monorepo rust version when we formally update