### PR TITLE
ci: Only copy monorepo toolchain file if it exists

### DIFF
--- a/patch.crates-io.sh
+++ b/patch.crates-io.sh
@@ -24,7 +24,12 @@ solana_dir=$(cd "$solana_dir" && pwd)
 cd "$(dirname "$0")"
 
 source "$solana_dir"/scripts/read-cargo-variable.sh
-cp "$solana_dir"/rust-toolchain.toml .
+
+# The toolchain file only exists in version >= 1.15
+toolchain_file="$solana_dir"/rust-toolchain.toml
+if [[ -f "$toolchain_file" ]]; then
+  cp "$toolchain_file" .
+fi
 
 # get version from Cargo.toml first. if it is empty, get it from other places.
 solana_ver="$(readCargoVariable version "$solana_dir"/Cargo.toml)"


### PR DESCRIPTION
#### Problem

The patch crates io script tries to use the version of Rust from the monorepo by copying the rust-toolchain.toml file, but this file doesn't exist for releases prior to 1.15.

#### Solution

Only copy the toolchain file if it exists. Since this is blocking the monorepo on 1.14 currently, I'll merge this right away.