### PR TITLE
docs: Update ATA derivation example to use `findProgramAddressSync`

### DIFF
--- a/docs/src/associated-token-account.md
+++ b/docs/src/associated-token-account.md
@@ -64,18 +64,18 @@ const SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID: PublicKey = new PublicKey(
   'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL',
 );
 
-async function findAssociatedTokenAddress(
+function findAssociatedTokenAddress(
     walletAddress: PublicKey,
     tokenMintAddress: PublicKey
-): Promise<PublicKey> {
-    return (await PublicKey.findProgramAddress(
+): PublicKey {
+    return PublicKey.findProgramAddressSync(
         [
             walletAddress.toBuffer(),
             TOKEN_PROGRAM_ID.toBuffer(),
             tokenMintAddress.toBuffer(),
         ],
         SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID
-    ))[0];
+    )[0];
 }
 ```
 


### PR DESCRIPTION
**Problem**

The async `findProgramAddress` function is deprecated in favor of `findProgramAddressSync`, and the docs don't currently reflect that.

**Changes**

Update docs to show newcomer developers that this is the method that should be used when deriving ATAs and PDAs in general.