### PR TITLE
ci: Update Cargo.lock for account compression version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5939,7 +5939,7 @@ dependencies = [
 
 [[package]]
 name = "spl-concurrent-merkle-tree"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bytemuck",
  "rand 0.7.3",


### PR DESCRIPTION
#### Problem

The account compression crate version was bumped in #4061, but the Cargo.lock file still has 0.1.2

#### Solution

Update the lockfile version too

cc @ngundotra 