### PR TITLE
Bump ATA to v1.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2735,7 +2735,7 @@ dependencies = [
  "num-traits",
  "shank 0.0.11",
  "solana-program",
- "spl-associated-token-account 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-associated-token-account 1.1.2",
  "spl-token 3.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
@@ -5771,7 +5771,7 @@ dependencies = [
  "solana-metrics",
  "solana-sdk",
  "solana-vote-program",
- "spl-associated-token-account 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-associated-token-account 1.1.2",
  "spl-memo 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token 3.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token-2022 0.5.0",
@@ -5904,20 +5904,6 @@ dependencies = [
 [[package]]
 name = "spl-associated-token-account"
 version = "1.1.2"
-dependencies = [
- "assert_matches",
- "borsh",
- "num-derive",
- "num-traits",
- "solana-program",
- "spl-token 3.5.0",
- "spl-token-2022 0.6.0",
- "thiserror",
-]
-
-[[package]]
-name = "spl-associated-token-account"
-version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbc000f0fdf1f12f99d77d398137c1751345b18c88258ce0f99b7872cf6c9bd6"
 dependencies = [
@@ -5932,13 +5918,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-associated-token-account"
+version = "1.1.3"
+dependencies = [
+ "assert_matches",
+ "borsh",
+ "num-derive",
+ "num-traits",
+ "solana-program",
+ "spl-token 3.5.0",
+ "spl-token-2022 0.6.0",
+ "thiserror",
+]
+
+[[package]]
 name = "spl-associated-token-account-test"
 version = "0.0.1"
 dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 1.1.2",
+ "spl-associated-token-account 1.1.3",
  "spl-token 3.5.0",
  "spl-token-2022 0.6.0",
 ]
@@ -6190,7 +6190,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-associated-token-account 1.1.2",
  "spl-token 3.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "tokio",
@@ -6321,7 +6321,7 @@ dependencies = [
  "solana-program",
  "solana-remote-wallet",
  "solana-sdk",
- "spl-associated-token-account 1.1.2",
+ "spl-associated-token-account 1.1.3",
  "spl-stake-pool",
  "spl-token 3.5.0",
 ]
@@ -6409,7 +6409,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 1.1.2",
+ "spl-associated-token-account 1.1.3",
  "spl-instruction-padding",
  "spl-memo 3.0.1",
  "spl-token-2022 0.6.0",
@@ -6439,7 +6439,7 @@ dependencies = [
  "solana-sdk",
  "solana-test-validator",
  "solana-transaction-status",
- "spl-associated-token-account 1.1.2",
+ "spl-associated-token-account 1.1.3",
  "spl-memo 3.0.1",
  "spl-token 3.5.0",
  "spl-token-2022 0.6.0",
@@ -6460,7 +6460,7 @@ dependencies = [
  "solana-client",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 1.1.2",
+ "spl-associated-token-account 1.1.3",
  "spl-memo 3.0.1",
  "spl-token 3.5.0",
  "spl-token-2022 0.6.0",
@@ -6566,7 +6566,7 @@ dependencies = [
  "solana-remote-wallet",
  "solana-sdk",
  "solana-test-validator",
- "spl-associated-token-account 1.1.2",
+ "spl-associated-token-account 1.1.3",
  "spl-token 3.5.0",
  "spl-token-2022 0.6.0",
  "spl-token-client",
@@ -6584,7 +6584,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 1.1.2",
+ "spl-associated-token-account 1.1.3",
  "spl-token 3.5.0",
  "thiserror",
 ]

--- a/associated-token-account/program/Cargo.toml
+++ b/associated-token-account/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-associated-token-account"
-version = "1.1.2"
+version = "1.1.3"
 description = "Solana Program Library Associated Token Account"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/stake-pool/cli/Cargo.toml
+++ b/stake-pool/cli/Cargo.toml
@@ -23,7 +23,7 @@ solana-logger = "=1.14.12"
 solana-program = "=1.14.12"
 solana-remote-wallet = "=1.14.12"
 solana-sdk = "=1.14.12"
-spl-associated-token-account = { version = "=1.1.2", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
+spl-associated-token-account = { version = "=1.1.3", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
 spl-stake-pool = { version = "=0.7.0", path="../program", features = [ "no-entrypoint" ] }
 spl-token = { version = "=3.5.0", path="../../token/program", features = [ "no-entrypoint" ]  }
 bs58 = "0.4.0"


### PR DESCRIPTION
Bump ATA to v1.1.3 that uses token-2022 0.6.