### PR TITLE
[token-2022, token-cli] Update CreateMint and Authorize to support confidential extension

### DIFF
--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -834,7 +834,20 @@ async fn command_authorize(
                         ))
                     }
                 }
-                AuthorityType::ConfidentialTransferMint => unimplemented!(),
+                AuthorityType::ConfidentialTransferMint => {
+                    if let Ok(confidential_transfer_mint) =
+                        mint.get_extension::<ConfidentialTransferMint>()
+                    {
+                        Ok(COption::<Pubkey>::from(
+                            confidential_transfer_mint.authority,
+                        ))
+                    } else {
+                        Err(format!(
+                            "Mint `{}` does not support confidential transfers",
+                            account
+                        ))
+                    }
+                }
             }?;
 
             Ok((account, previous_authority))
@@ -2677,13 +2690,14 @@ fn app<'a, 'b>(
                         .possible_values(&[
                             "mint", "freeze", "owner", "close",
                             "close-mint", "transfer-fee-config", "withheld-withdraw",
-                            "interest-rate", "permanent-delegate",
+                            "interest-rate", "permanent-delegate", "confidential-transfer-mint"
                         ])
                         .index(2)
                         .required(true)
                         .help("The new authority type. \
-                            Token mints support `mint` and `freeze` authorities;\
-                            Token accounts support `owner` and `close` authorities."),
+                            Token mints support `mint`, `freeze`, and mint extension authorities; \
+                            Token accounts support `owner`, `close`, and account extension \
+                            authorities."),
                 )
                 .arg(
                     Arg::with_name("new_authority")
@@ -3757,6 +3771,7 @@ async fn process_command<'a>(
                 "withheld-withdraw" => AuthorityType::WithheldWithdraw,
                 "interest-rate" => AuthorityType::InterestRate,
                 "permanent-delegate" => AuthorityType::PermanentDelegate,
+                "confidential-transfer-mint" => AuthorityType::ConfidentialTransferMint,
                 _ => unreachable!(),
             };
 
@@ -6784,6 +6799,7 @@ mod tests {
         let token_pubkey = token_keypair.pubkey();
         let bulk_signers: Vec<Arc<dyn Signer>> =
             vec![Arc::new(clone_keypair(&payer)), Arc::new(token_keypair)];
+        let confidential_transfer_mint_authority = payer.pubkey();
         let auto_approve = true;
 
         command_create_token(
@@ -6812,6 +6828,10 @@ mod tests {
             .unwrap();
 
         assert_eq!(
+            Option::<Pubkey>::from(extension.authority),
+            Some(confidential_transfer_mint_authority),
+        );
+        assert_eq!(
             bool::from(extension.auto_approve_new_accounts),
             auto_approve,
         );
@@ -6829,6 +6849,20 @@ mod tests {
             Option::<EncryptedWithheldAmount>::from(extension.withheld_amount),
             Some(EncryptedWithheldAmount::default()),
         );
+
+        process_test_command(
+            &config,
+            &payer,
+            &[
+                "spl-token",
+                CommandName::Authorize.into(),
+                &token_pubkey.to_string(),
+                "confidential-transfer-mint",
+                "--disable",
+            ],
+        )
+        .await
+        .unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
#### Problem
The token-cli does not yet support the confidential extension (https://github.com/solana-labs/solana-program-library/issues/3065).

Most of the confidential extension instructions would need support for ElGamal keys in the monorepo clap-utils. However, `CreateMint` and `Authorize` commands should still be able to be supported without these changes.

#### Summary of Changes
Add support for confidential extension to the `CreateMint` and `Authorize` commands. The rest of the confidential extension instructions will be supported in a separate PR once clap-utils is updated.