### PR TITLE
token-2022: bump program and client for a patch release

### DIFF
--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "spl-token-client"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "0.4.0"
+version = "0.4.1"
 
 [dependencies]
 async-trait = "0.1"

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-2022"
-version = "0.6.0"
+version = "0.6.1"
 description = "Solana Program Library Token 2022"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"


### PR DESCRIPTION
#### Problem
There is a breaking update to the zk proof program (https://github.com/solana-labs/solana/pull/29996) in the monorepo that breaks downstream builds. https://github.com/solana-labs/solana-program-library/pull/4040 temporarily disables token-2022 components that rely on the proof program. A new patch of the token-2022 program should be released.

#### Summary of Changes
Bumping the token-2022 program and client to prepare for the patch release. Once the monorepo updates to this patch release, the downstream ci failure should be fixed.