### PR TITLE
token-2022: disable transfer_with_fee instruction constructor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5927,7 +5927,7 @@ dependencies = [
  "num-traits",
  "solana-program",
  "spl-token 3.5.0",
- "spl-token-2022 0.6.0",
+ "spl-token-2022 0.6.1",
  "thiserror",
 ]
 
@@ -5940,7 +5940,7 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account 1.1.3",
  "spl-token 3.5.0",
- "spl-token-2022 0.6.0",
+ "spl-token-2022 0.6.1",
 ]
 
 [[package]]
@@ -6296,7 +6296,7 @@ dependencies = [
  "solana-vote-program",
  "spl-math",
  "spl-token 3.5.0",
- "spl-token-2022 0.6.0",
+ "spl-token-2022 0.6.1",
  "test-case",
  "thiserror",
 ]
@@ -6379,7 +6379,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-2022"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -6412,7 +6412,7 @@ dependencies = [
  "spl-associated-token-account 1.1.3",
  "spl-instruction-padding",
  "spl-memo 3.0.1",
- "spl-token-2022 0.6.0",
+ "spl-token-2022 0.6.1",
  "spl-token-client",
  "walkdir",
 ]
@@ -6442,7 +6442,7 @@ dependencies = [
  "spl-associated-token-account 1.1.3",
  "spl-memo 3.0.1",
  "spl-token 3.5.0",
- "spl-token-2022 0.6.0",
+ "spl-token-2022 0.6.1",
  "spl-token-client",
  "strum",
  "strum_macros",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-client"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "solana-cli-output",
@@ -6463,7 +6463,7 @@ dependencies = [
  "spl-associated-token-account 1.1.3",
  "spl-memo 3.0.1",
  "spl-token 3.5.0",
- "spl-token-2022 0.6.0",
+ "spl-token-2022 0.6.1",
  "thiserror",
 ]
 
@@ -6519,7 +6519,7 @@ dependencies = [
  "solana-sdk",
  "spl-math",
  "spl-token 3.5.0",
- "spl-token-2022 0.6.0",
+ "spl-token-2022 0.6.1",
  "test-case",
  "thiserror",
 ]
@@ -6547,7 +6547,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-token 3.5.0",
- "spl-token-2022 0.6.0",
+ "spl-token-2022 0.6.1",
  "spl-token-client",
  "test-case",
  "thiserror",
@@ -6568,7 +6568,7 @@ dependencies = [
  "solana-test-validator",
  "spl-associated-token-account 1.1.3",
  "spl-token 3.5.0",
- "spl-token-2022 0.6.0",
+ "spl-token-2022 0.6.1",
  "spl-token-client",
  "spl-token-upgrade",
  "tokio",

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -924,6 +924,7 @@ pub fn transfer(
 /// Create a `Transfer` instruction with fee proof
 #[allow(clippy::too_many_arguments)]
 #[cfg(not(target_os = "solana"))]
+#[cfg(feature = "proof-program")]
 pub fn transfer_with_fee(
     token_program_id: &Pubkey,
     source_token_account: &Pubkey,


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana-program-library/pull/4040 disables the proof components in the token-2022 program, but it missed the `transfer_with_fee` instruction constructor.

#### Summary of Changes
Temporarily disable `transfer_with_fee` constructor by including it in the `proof-program` feature.