### PR TITLE
spl-token-client: Depend on spl-token-2022/proof-program

### DIFF
--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -24,4 +24,4 @@ thiserror = "1.0"
 [features]
 default = ["display"]
 display = ["dep:solana-cli-output"]
-proof-program = []
+proof-program = ["spl-token-2022/proof-program"]

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.0.1"
 test-sbf = ["zk-ops"]
 default = ["zk-ops"]
 zk-ops = []
-proof-program = []
+proof-program = ["spl-token-2022/proof-program"]
 
 [build-dependencies]
 walkdir = "2"


### PR DESCRIPTION
This fixes a compilation error if spl-token-client is compiled with the proof-program feature, as it previously did not compile spl-token-2022 with the corresponding feature.