### PR TITLE
[token-cli] Enable offline `set-transfer-fee`

### DIFF
--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -3603,6 +3603,7 @@ fn app<'a, 'b>(
                     )
                 )
                 .arg(mint_decimals_arg())
+                .offline_args_config(&SignOnlyNeedsMintDecimals{})
         )
 }
 


### PR DESCRIPTION
#### Problem
Currently, it is not possible to update transfer fees in the token-cli. Furthermore, on `--mint-decimals` argument, the `set-transfer-fee` panics (issue #4098).

#### Summary of changes
Add the ability to create `UpdateTransferFee` instruction offline. This should also close #4098.