### PR TITLE
permissioned-transfer: Add basic example program for checking permissions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6268,6 +6268,7 @@ dependencies = [
 name = "spl-permissioned-transfer"
 version = "0.1.0"
 dependencies = [
+ "arrayref",
  "bytemuck",
  "num-derive",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6452,12 +6452,14 @@ name = "spl-token-2022-test"
 version = "0.0.1"
 dependencies = [
  "async-trait",
+ "bytemuck",
  "solana-program",
  "solana-program-test",
  "solana-sdk",
  "spl-associated-token-account 1.1.3",
  "spl-instruction-padding",
  "spl-memo 3.0.1",
+ "spl-permissioned-transfer",
  "spl-token-2022 0.6.1",
  "spl-token-client",
  "walkdir",
@@ -6508,6 +6510,7 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account 1.1.3",
  "spl-memo 3.0.1",
+ "spl-permissioned-transfer",
  "spl-token 3.5.0",
  "spl-token-2022 0.6.1",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6265,6 +6265,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-permissioned-transfer"
+version = "0.1.0"
+dependencies = [
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-program",
+ "solana-program-test",
+ "solana-sdk",
+ "spl-token 3.5.0",
+ "thiserror",
+]
+
+[[package]]
 name = "spl-record"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6276,7 +6276,8 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-token 3.5.0",
+ "spl-token-2022 0.6.1",
+ "spl-token-client",
  "thiserror",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6442,6 +6442,7 @@ dependencies = [
  "solana-sdk",
  "solana-zk-token-sdk",
  "spl-memo 3.0.1",
+ "spl-permissioned-transfer",
  "spl-token 3.5.0",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ members = [
   "token-upgrade/cli",
   "token-upgrade/program",
   "token/cli",
+  "token/permissioned-transfer",
   "token/program",
   "token/program-2022",
   "token/program-2022-test",

--- a/docs/src/token-2022/extensions.mdx
+++ b/docs/src/token-2022/extensions.mdx
@@ -1202,3 +1202,88 @@ Signature: 5DQs6hzkfGq3uotESuVwF7MGeMawwfQcm1e9RHaUeVySDV6xpUzYhzdb6ygqJfsEZqewg
 
   </TabItem>
 </Tabs>
+
+### Permissioned Transfer
+
+Token creators may need more control over how their token is transferred. The
+most prominent use case revolves around NFT royalties. Whenever a token is moved,
+the creator should be entitled to royalties, but due to the design of the current
+token program, it's impossible to stop a transfer at the protocol level.
+
+Current solutions typically resort to perpetually freezing tokens, which requires
+a whole proxy layer to interact with the token. Wallets and marketplaces need
+to be aware of the proxy layer in order to properly use the token.
+
+Worse still, different royalty systems have different proxy layers for using
+their token. All in all, these systems harm composability and make development
+harder.
+
+To improve the situation, token-2022 introduces the concept of the
+permissioned-transfer interface and extension. A token creator must develop and
+deploy a program that implements the interface and then configure their token
+mint to use their program.
+
+During transfer, token-2022 calls into the program with the accounts specified
+at a well-defined program-derived address for that mint and program id. This
+call happens after all other transfer logic, so the accounts reflect the *end*
+state of the transfer.
+
+The interface description, structs, and sample program exist at
+[spl-permissioned-transfer](https://github.com/solana-labs/solana-program-library/tree/master/token/permissioned-transfer).
+A developer must implement the `Validate` instruction, and the
+`InitializeExtraAccountMetas` instruction to write the required additional account
+pubkeys into the program-derived address defined by the mint and program id.
+
+Side note: it's technically not required to implement `InitializeExtraAccountMetas`
+at that instruction descriminator. Your program may implement multiple interfaces,
+so any other instruction in your program can create the account at the program-derived
+address!
+
+The `spl-permissioned-transfer` library provides offchain and onchain helpers
+for resolving the additional accounts required. See
+[invoke.rs](https://github.com/solana-labs/solana-program-library/tree/master/token/permissioned-transfer/src/invoke.rs)
+for usage on-chain, and
+[offchain.rs](https://github.com/solana-labs/solana-program-library/tree/master/token/permissioned-transfer/src/offchain.rs)
+for fetching the additional required account metas.
+
+#### Example: Create a permissioned-transfer mint
+
+<Tabs className="unique-tabs" groupId="language-selection">
+  <TabItem value="cli" label="CLI" default>
+
+```console
+$ spl-token --program-id TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb create-token --permissioned-transfer 7N4HggYEJAtCLJdnHGCtFqfxcB5rhQCsQTze3ftYstVj
+Creating token HFg1FFaj4PqFHmkYrqbZsarNJEZT436aXAXgQFMJihwc under program TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb
+
+Address:  HFg1FFaj4PqFHmkYrqbZsarNJEZT436aXAXgQFMJihwc
+Decimals:  9
+
+Signature: 3ug4Ejs16jJgEm1WyBwDDxzh9xqPzQ3a2cmy1hSYiPFcLQi9U12HYF1Dbhzb2bx75SSydfU6W4e11dGUXaPbJqVc
+```
+
+  </TabItem>
+  <TabItem value="jsx" label="JS">
+
+Coming soon!
+
+  </TabItem>
+</Tabs>
+
+#### Example: Update permissioned-transfer program in mint
+
+<Tabs className="unique-tabs" groupId="language-selection">
+  <TabItem value="cli" label="CLI" default>
+
+```console
+$ spl-token set-permissioned-transfer-program HFg1FFaj4PqFHmkYrqbZsarNJEZT436aXAXgQFMJihwc EbPBt3XkCb9trcV4c8fidhrvoeURbDbW87Acustzyi8N
+
+Signature: 3Ffw6yjseDsL3Az5n2LjdwXXwVPYxDF3JUU1JC1KGAEb1LE68S9VN4ebtAyvKeYMHvhjdz1LJVyugGNdWHyotzay
+```
+
+  </TabItem>
+  <TabItem value="jsx" label="JS">
+
+Coming soon!
+
+  </TabItem>
+</Tabs>

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -17,6 +17,7 @@ solana-sdk = "=1.14.12"
 # testing token
 spl-associated-token-account = { version = "1.1", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-memo = { version = "3.0.1", path = "../../memo/program", features = ["no-entrypoint"] }
+spl-permissioned-transfer = { version = "0.1", path="../permissioned-transfer", features = [ "no-entrypoint", "offchain-client" ] }
 spl-token = { version = "3.5", path="../program", features = [ "no-entrypoint" ] }
 spl-token-2022 = { version = "0.6", path="../program-2022" }
 thiserror = "1.0"

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -4,7 +4,7 @@ use {
     solana_sdk::{
         account::Account as BaseAccount,
         hash::Hash,
-        instruction::Instruction,
+        instruction::{AccountMeta, Instruction},
         message::Message,
         program_error::ProgramError,
         program_pack::Pack,
@@ -17,11 +17,12 @@ use {
         get_associated_token_address_with_program_id, instruction::create_associated_token_account,
         instruction::create_associated_token_account_idempotent,
     },
+    spl_permissioned_transfer::offchain::get_extra_account_metas,
     spl_token_2022::{
         extension::{
             confidential_transfer, cpi_guard, default_account_state, interest_bearing_mint,
-            memo_transfer, transfer_fee, BaseStateWithExtensions, ExtensionType,
-            StateWithExtensionsOwned,
+            memo_transfer, permissioned_transfer, transfer_fee, BaseStateWithExtensions,
+            ExtensionType, StateWithExtensionsOwned,
         },
         instruction,
         pod::EncryptionPubkey,
@@ -133,6 +134,10 @@ pub enum ExtensionInitializationParams {
     PermanentDelegate {
         delegate: Pubkey,
     },
+    PermissionedTransfer {
+        authority: Option<Pubkey>,
+        permissioned_transfer_program_id: Option<Pubkey>,
+    },
 }
 impl ExtensionInitializationParams {
     /// Get the extension type associated with the init params
@@ -145,6 +150,7 @@ impl ExtensionInitializationParams {
             Self::InterestBearingConfig { .. } => ExtensionType::InterestBearingConfig,
             Self::NonTransferable => ExtensionType::NonTransferable,
             Self::PermanentDelegate { .. } => ExtensionType::PermanentDelegate,
+            Self::PermissionedTransfer { .. } => ExtensionType::PermissionedTransfer,
         }
     }
     /// Generate an appropriate initialization instruction for the given mint
@@ -209,6 +215,15 @@ impl ExtensionInitializationParams {
             Self::PermanentDelegate { delegate } => {
                 instruction::initialize_permanent_delegate(token_program_id, mint, &delegate)
             }
+            Self::PermissionedTransfer {
+                authority,
+                permissioned_transfer_program_id,
+            } => permissioned_transfer::instruction::initialize(
+                token_program_id,
+                mint,
+                authority,
+                permissioned_transfer_program_id,
+            ),
         }
     }
 }
@@ -239,6 +254,7 @@ pub struct Token<T> {
     nonce_authority: Option<Arc<dyn Signer>>,
     nonce_blockhash: Option<Hash>,
     memo: Arc<RwLock<Option<TokenMemo>>>,
+    permissioned_transfer_accounts: Option<Vec<Pubkey>>,
 }
 
 impl<T> fmt::Debug for Token<T> {
@@ -300,6 +316,7 @@ where
             nonce_authority: None,
             nonce_blockhash: None,
             memo: Arc::new(RwLock::new(None)),
+            permissioned_transfer_accounts: None,
         }
     }
 
@@ -326,18 +343,9 @@ where
         &self.pubkey
     }
 
-    pub fn with_payer(self, payer: Arc<dyn Signer>) -> Token<T> {
-        Token {
-            client: Arc::clone(&self.client),
-            pubkey: self.pubkey,
-            decimals: self.decimals,
-            payer,
-            program_id: self.program_id,
-            nonce_account: self.nonce_account,
-            nonce_authority: self.nonce_authority,
-            nonce_blockhash: self.nonce_blockhash,
-            memo: Arc::new(RwLock::new(None)),
-        }
+    pub fn with_payer(mut self, payer: Arc<dyn Signer>) -> Self {
+        self.payer = payer;
+        self
     }
 
     pub fn with_nonce(
@@ -345,18 +353,18 @@ where
         nonce_account: &Pubkey,
         nonce_authority: Arc<dyn Signer>,
         nonce_blockhash: &Hash,
-    ) -> Token<T> {
-        Token {
-            client: Arc::clone(&self.client),
-            pubkey: self.pubkey,
-            decimals: self.decimals,
-            payer: self.payer.clone(),
-            program_id: self.program_id,
-            nonce_account: Some(*nonce_account),
-            nonce_authority: Some(nonce_authority),
-            nonce_blockhash: Some(*nonce_blockhash),
-            memo: Arc::new(RwLock::new(None)),
-        }
+    ) -> Self {
+        self.nonce_account = Some(*nonce_account);
+        self.nonce_authority = Some(nonce_authority);
+        self.nonce_blockhash = Some(*nonce_blockhash);
+    }
+
+    pub fn with_permissioned_transfer_accounts(
+        mut self,
+        permissioned_transfer_accounts: Vec<Pubkey>,
+    ) -> Self {
+        self.permissioned_transfer_accounts = Some(permissioned_transfer_accounts);
+        self
     }
 
     pub fn with_memo<M: AsRef<str>>(&self, memo: M, signers: Vec<Pubkey>) -> &Self {
@@ -799,8 +807,8 @@ where
         let signing_pubkeys = signing_keypairs.pubkeys();
         let multisig_signers = self.get_multisig_signers(authority, &signing_pubkeys);
 
-        let instructions = if let Some(decimals) = self.decimals {
-            [instruction::transfer_checked(
+        let mut instruction = if let Some(decimals) = self.decimals {
+            instruction::transfer_checked(
                 &self.program_id,
                 source,
                 &self.pubkey,
@@ -809,20 +817,42 @@ where
                 &multisig_signers,
                 amount,
                 decimals,
-            )?]
+            )?
         } else {
             #[allow(deprecated)]
-            [instruction::transfer(
+            instruction::transfer(
                 &self.program_id,
                 source,
                 destination,
                 authority,
                 &multisig_signers,
                 amount,
-            )?]
+            )?
+        };
+        if let Some(permissioned_transfer_accounts) = &self.permissioned_transfer_accounts {
+            let additional_account_metas = permissioned_transfer_accounts
+                .iter()
+                .map(|p| AccountMeta::new_readonly(*p, false));
+            instruction.accounts.extend(additional_account_metas);
+        } else {
+            let state = self.get_mint_info().await.unwrap();
+            if let Some(program_id) =
+                permissioned_transfer::get_permissioned_transfer_program_id(&state)
+            {
+                let extra_account_metas = get_extra_account_metas(
+                    |address| self.client.get_account(address),
+                    &program_id,
+                    self.get_address(),
+                )
+                .await
+                .map_err(|_| TokenError::AccountNotFound)?;
+                extra_account_metas
+                    .into_iter()
+                    .for_each(|m| instruction.accounts.push(m));
+            }
         };
 
-        self.process_ixs(&instructions, signing_keypairs).await
+        self.process_ixs(&[instruction], signing_keypairs).await
     }
 
     /// Transfer tokens to an associated account, creating it if it does not exist
@@ -1507,6 +1537,29 @@ where
                 authority,
                 &multisig_signers,
                 new_rate,
+            )?],
+            signing_keypairs,
+        )
+        .await
+    }
+
+    /// Update permissioned transfer program id
+    pub async fn update_permissioned_transfer_program_id<S: Signers>(
+        &self,
+        authority: &Pubkey,
+        new_program_id: Option<Pubkey>,
+        signing_keypairs: &S,
+    ) -> TokenResult<T::Output> {
+        let signing_pubkeys = signing_keypairs.pubkeys();
+        let multisig_signers = self.get_multisig_signers(authority, &signing_pubkeys);
+
+        self.process_ixs(
+            &[permissioned_transfer::instruction::update(
+                &self.program_id,
+                self.get_address(),
+                authority,
+                &multisig_signers,
+                new_program_id,
             )?],
             signing_keypairs,
         )

--- a/token/permissioned-transfer/Cargo.toml
+++ b/token/permissioned-transfer/Cargo.toml
@@ -11,6 +11,7 @@ exclude = ["js/**"]
 [features]
 no-entrypoint = []
 test-sbf = []
+offchain-client = ["dep:solana-sdk"]
 
 [dependencies]
 arrayref = "0.3.6"
@@ -18,6 +19,7 @@ bytemuck = { version = "1.13.0", features = ["derive"] }
 num-derive = "0.3"
 num-traits = "0.2"
 num_enum = "0.5.9"
+solana-sdk = { version = "1.14.12", optional = true }
 solana-program = "1.14.12"
 thiserror = "1.0"
 

--- a/token/permissioned-transfer/Cargo.toml
+++ b/token/permissioned-transfer/Cargo.toml
@@ -13,6 +13,7 @@ no-entrypoint = []
 test-sbf = []
 
 [dependencies]
+arrayref = "0.3.6"
 bytemuck = { version = "1.13.0", features = ["derive"] }
 num-derive = "0.3"
 num-traits = "0.2"

--- a/token/permissioned-transfer/Cargo.toml
+++ b/token/permissioned-transfer/Cargo.toml
@@ -24,7 +24,8 @@ thiserror = "1.0"
 [dev-dependencies]
 solana-program-test = "1.14.12"
 solana-sdk = "1.14.12"
-spl-token = { version = "3.5",  path = "../program", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.6",  path = "../program-2022", features = ["no-entrypoint"] }
+spl-token-client = { version = "0.4",  path = "../client" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/token/permissioned-transfer/Cargo.toml
+++ b/token/permissioned-transfer/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "spl-permissioned-transfer"
+version = "0.1.0"
+description = "Solana Program Library Permissioned Transfer"
+authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
+repository = "https://github.com/solana-labs/solana-program-library"
+license = "Apache-2.0"
+edition = "2021"
+exclude = ["js/**"]
+
+[features]
+no-entrypoint = []
+test-sbf = []
+
+[dependencies]
+bytemuck = { version = "1.13.0", features = ["derive"] }
+num-derive = "0.3"
+num-traits = "0.2"
+num_enum = "0.5.9"
+solana-program = "1.14.12"
+thiserror = "1.0"
+
+[dev-dependencies]
+solana-program-test = "1.14.12"
+solana-sdk = "1.14.12"
+spl-token = { version = "3.5",  path = "../program", features = ["no-entrypoint"] }
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/token/permissioned-transfer/src/entrypoint.rs
+++ b/token/permissioned-transfer/src/entrypoint.rs
@@ -1,0 +1,21 @@
+//! Program entrypoint
+
+use crate::{error::PermissionedTransferError, processor};
+use solana_program::{
+    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,
+    program_error::PrintProgramError, pubkey::Pubkey,
+};
+
+entrypoint!(process_instruction);
+fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    if let Err(error) = processor::process(program_id, accounts, instruction_data) {
+        // catch the error so we can print it
+        error.print::<PermissionedTransferError>();
+        return Err(error);
+    }
+    Ok(())
+}

--- a/token/permissioned-transfer/src/error.rs
+++ b/token/permissioned-transfer/src/error.rs
@@ -26,6 +26,14 @@ pub enum PermissionedTransferError {
     /// Type already exists in TLV data
     #[error("Type already exists in TLV data")]
     TypeAlreadyExists,
+    /// No value initialized in TLV data
+    #[error("No value initialized in TLV data")]
+    TlvUninitialized,
+
+    // 5
+    /// Some value initialized in TLV data
+    #[error("Some value initialized in TLV data")]
+    TlvInitialized,
 }
 impl From<PermissionedTransferError> for ProgramError {
     fn from(e: PermissionedTransferError) -> Self {
@@ -52,6 +60,8 @@ impl PrintProgramError for PermissionedTransferError {
             Self::NotEnoughAccounts => msg!("Not enough accounts provided"),
             Self::TypeNotFound => msg!("Type not found in TLV data"),
             Self::TypeAlreadyExists => msg!("Type already exists in TLV data"),
+            Self::TlvUninitialized => msg!("No value initialized in TLV data"),
+            Self::TlvInitialized => msg!("Some value initialized in TLV data"),
         }
     }
 }

--- a/token/permissioned-transfer/src/error.rs
+++ b/token/permissioned-transfer/src/error.rs
@@ -34,6 +34,23 @@ pub enum PermissionedTransferError {
     /// Some value initialized in TLV data
     #[error("Some value initialized in TLV data")]
     TlvInitialized,
+    /// Provided byte buffer too small for validation pubkeys
+    #[error("Provided byte buffer too small for validation pubkeys")]
+    BufferTooSmall,
+    /// Error in checked math operation
+    #[error("Error in checked math operation")]
+    CalculationFailure,
+    /// Mint has no mint authority
+    #[error("Mint has no mint authority")]
+    MintHasNoMintAuthority,
+    /// Incorrect mint authority has signed the instruction
+    #[error("Incorrect mint authority has signed the instruction")]
+    IncorrectMintAuthority,
+
+    // 10
+    /// Too many pubkeys provided
+    #[error("Too many pubkeys provided")]
+    TooManyPubkeys,
 }
 impl From<PermissionedTransferError> for ProgramError {
     fn from(e: PermissionedTransferError) -> Self {
@@ -62,6 +79,13 @@ impl PrintProgramError for PermissionedTransferError {
             Self::TypeAlreadyExists => msg!("Type already exists in TLV data"),
             Self::TlvUninitialized => msg!("No value initialized in TLV data"),
             Self::TlvInitialized => msg!("Some value initialized in TLV data"),
+            Self::BufferTooSmall => msg!("Provided byte buffer too small for validation pubkeys"),
+            Self::CalculationFailure => msg!("Error in checked math operation"),
+            Self::MintHasNoMintAuthority => msg!("Mint has no mint authority"),
+            Self::IncorrectMintAuthority => {
+                msg!("Incorrect mint authority has signed the instruction")
+            }
+            Self::TooManyPubkeys => msg!("Too many pubkeys provided"),
         }
     }
 }

--- a/token/permissioned-transfer/src/error.rs
+++ b/token/permissioned-transfer/src/error.rs
@@ -51,6 +51,9 @@ pub enum PermissionedTransferError {
     /// Too many pubkeys provided
     #[error("Too many pubkeys provided")]
     TooManyPubkeys,
+    /// Provided byte buffer too large for expected type
+    #[error("Provided byte buffer too large for expected type")]
+    BufferTooLarge,
 }
 impl From<PermissionedTransferError> for ProgramError {
     fn from(e: PermissionedTransferError) -> Self {
@@ -86,6 +89,7 @@ impl PrintProgramError for PermissionedTransferError {
                 msg!("Incorrect mint authority has signed the instruction")
             }
             Self::TooManyPubkeys => msg!("Too many pubkeys provided"),
+            Self::BufferTooLarge => msg!("Provided byte buffer too large for expected type"),
         }
     }
 }

--- a/token/permissioned-transfer/src/error.rs
+++ b/token/permissioned-transfer/src/error.rs
@@ -1,0 +1,57 @@
+//! Error types
+
+use {
+    num_derive::FromPrimitive,
+    solana_program::{
+        decode_error::DecodeError,
+        msg,
+        program_error::{PrintProgramError, ProgramError},
+    },
+    thiserror::Error,
+};
+
+/// Errors that may be returned by the Token program.
+#[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]
+pub enum PermissionedTransferError {
+    // 0
+    /// Incorrect account provided
+    #[error("Incorrect account provided")]
+    IncorrectAccount,
+    /// Not enough accounts provided
+    #[error("Not enough accounts provided")]
+    NotEnoughAccounts,
+    /// Type not found in TLV data
+    #[error("Type not found in TLV data")]
+    TypeNotFound,
+    /// Type already exists in TLV data
+    #[error("Type already exists in TLV data")]
+    TypeAlreadyExists,
+}
+impl From<PermissionedTransferError> for ProgramError {
+    fn from(e: PermissionedTransferError) -> Self {
+        ProgramError::Custom(e as u32)
+    }
+}
+impl<T> DecodeError<T> for PermissionedTransferError {
+    fn type_of() -> &'static str {
+        "PermissionedTrasferError"
+    }
+}
+
+impl PrintProgramError for PermissionedTransferError {
+    fn print<E>(&self)
+    where
+        E: 'static
+            + std::error::Error
+            + DecodeError<E>
+            + PrintProgramError
+            + num_traits::FromPrimitive,
+    {
+        match self {
+            Self::IncorrectAccount => msg!("Incorrect account provided"),
+            Self::NotEnoughAccounts => msg!("Not enough accounts provided"),
+            Self::TypeNotFound => msg!("Type not found in TLV data"),
+            Self::TypeAlreadyExists => msg!("Type already exists in TLV data"),
+        }
+    }
+}

--- a/token/permissioned-transfer/src/inline_spl_token.rs
+++ b/token/permissioned-transfer/src/inline_spl_token.rs
@@ -1,0 +1,28 @@
+//! Structs required to handle verify token mints. By having the types here, we
+//! don't need to create a circular dependency between token and permissioned-transfer
+
+use {
+    crate::error::PermissionedTransferError,
+    arrayref::{array_ref, array_refs},
+    solana_program::{program_error::ProgramError, program_option::COption, pubkey::Pubkey},
+};
+
+fn unpack_coption_key(src: &[u8; 36]) -> Result<COption<Pubkey>, ProgramError> {
+    let (tag, body) = array_refs![src, 4, 32];
+    match *tag {
+        [0, 0, 0, 0] => Ok(COption::None),
+        [1, 0, 0, 0] => Ok(COption::Some(Pubkey::new_from_array(*body))),
+        _ => Err(ProgramError::InvalidAccountData),
+    }
+}
+
+/// Extract the mint authority from the account bytes
+pub fn get_mint_authority(account_data: &[u8]) -> Result<COption<Pubkey>, ProgramError> {
+    const MINT_SIZE: usize = 82;
+    if account_data.len() < MINT_SIZE {
+        Err(PermissionedTransferError::BufferTooSmall.into())
+    } else {
+        let mint_authority = array_ref![account_data, 0, 36];
+        unpack_coption_key(mint_authority)
+    }
+}

--- a/token/permissioned-transfer/src/instruction.rs
+++ b/token/permissioned-transfer/src/instruction.rs
@@ -1,0 +1,173 @@
+//! Instruction types
+
+use {
+    crate::DISCRIMINATOR_LENGTH,
+    solana_program::{
+        instruction::{AccountMeta, Instruction},
+        program_error::ProgramError,
+        pubkey::Pubkey,
+    },
+    std::convert::TryInto,
+};
+
+/// Instructions supported by the permissioned transfer program.
+#[repr(C)]
+#[derive(Clone, Debug, PartialEq)]
+pub enum PermissionedTransferInstruction {
+    /// Validates transfer accounts and additional required accounts.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[]` Source account
+    ///   1. `[]` Token mint
+    ///   2. `[]` Destination account
+    ///   3. `[]` Source account's owner/delegate
+    ///   4. `[]` Validation account
+    ///   5..5+M `[]` `M` additional accounts, written in validation account data
+    ///
+    Validate {
+        /// Amount of tokens to transfer
+        amount: u64,
+    },
+    /// Initializes the validate pubkeys struct on an account, writing into
+    /// the first open TLV space.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[w]` Validate transfer account
+    ///   1. `[]` Mint
+    ///   2. `[s]` Mint authority
+    ///   3..3+M `[]` `M` additional accounts, to be written to validation data
+    ///
+    InitializeValidationPubkeys,
+}
+/// First 8 bytes of `hash::hashv(&["permissioned-transfer:validate"])`
+const VALIDATE_DISCRIMINATOR: &[u8] = &[242, 240, 55, 155, 72, 84, 63, 231];
+/// First 8 bytes of `hash::hashv(&["permissioned-transfer:initialize-validation-pubkeys"])`
+const INITIALIZE_VALIDATION_PUBKEYS_DISCRIMINATOR: &[u8] = &[248, 8, 136, 21, 37, 96, 4, 61];
+
+impl PermissionedTransferInstruction {
+    /// Unpacks a byte buffer into a [PermissionedTransferInstruction](enum.PermissionedTransferInstruction.html).
+    pub fn unpack(input: &[u8]) -> Result<Self, ProgramError> {
+        let (discriminator, rest) = input.split_at(DISCRIMINATOR_LENGTH);
+        Ok(match discriminator {
+            VALIDATE_DISCRIMINATOR => {
+                let amount = rest
+                    .get(..8)
+                    .and_then(|slice| slice.try_into().ok())
+                    .map(u64::from_le_bytes)
+                    .ok_or(ProgramError::InvalidInstructionData)?;
+                Self::Validate { amount }
+            }
+            INITIALIZE_VALIDATION_PUBKEYS_DISCRIMINATOR => {
+                Self::InitializeValidationPubkeys
+            }
+            _ => return Err(ProgramError::InvalidInstructionData),
+        })
+    }
+
+    /// Packs a [TokenInstruction](enum.TokenInstruction.html) into a byte buffer.
+    pub fn pack(&self) -> Vec<u8> {
+        let mut buf = vec![];
+        match self {
+            Self::Validate {
+                amount,
+            } => {
+                buf.extend_from_slice(VALIDATE_DISCRIMINATOR);
+                buf.extend_from_slice(&amount.to_le_bytes());
+            }
+            Self::InitializeValidationPubkeys => {
+                buf.extend_from_slice(INITIALIZE_VALIDATION_PUBKEYS_DISCRIMINATOR);
+            }
+        };
+        buf
+    }
+}
+
+/// Creates a `Validate` instruction.
+pub fn validate(
+    program_id: &Pubkey,
+    source_pubkey: &Pubkey,
+    mint_pubkey: &Pubkey,
+    destination_pubkey: &Pubkey,
+    authority_pubkey: &Pubkey,
+    validate_state_pubkey: &Pubkey,
+    additional_pubkeys: &[&Pubkey],
+    amount: u64,
+) -> Instruction {
+    let data = PermissionedTransferInstruction::Validate { amount }.pack();
+
+    let mut accounts = vec![
+        AccountMeta::new_readonly(*source_pubkey, false),
+        AccountMeta::new_readonly(*mint_pubkey, false),
+        AccountMeta::new_readonly(*destination_pubkey, false),
+        AccountMeta::new_readonly(*authority_pubkey, false),
+        AccountMeta::new_readonly(*validate_state_pubkey, false),
+    ];
+    accounts.extend(additional_pubkeys.iter().map(|pk| AccountMeta::new_readonly(**pk, false)));
+
+    Instruction {
+        program_id: *program_id,
+        accounts,
+        data,
+    }
+}
+
+/// Creates a `InitializeValidationPubkeys` instruction.
+pub fn initialize_validation_pubkeys(
+    program_id: &Pubkey,
+    validate_state_pubkey: &Pubkey,
+    mint_pubkey: &Pubkey,
+    authority_pubkey: &Pubkey,
+    additional_pubkeys: &[&Pubkey],
+) -> Instruction {
+    let data = PermissionedTransferInstruction::InitializeValidationPubkeys.pack();
+
+    let mut accounts = vec![
+        AccountMeta::new(*validate_state_pubkey, false),
+        AccountMeta::new_readonly(*mint_pubkey, false),
+        AccountMeta::new_readonly(*authority_pubkey, false),
+    ];
+    accounts.extend(additional_pubkeys.iter().map(|pk| AccountMeta::new_readonly(**pk, false)));
+
+    Instruction {
+        program_id: *program_id,
+        accounts,
+        data,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use {super::*, crate::NAMESPACE, solana_program::hash};
+
+    #[test]
+    fn validate_packing() {
+        let amount = 111_111_111;
+        let check = PermissionedTransferInstruction::Validate {
+            amount,
+        };
+        let packed = check.pack();
+        let preimage = hash::hashv(&[&format!("{NAMESPACE}:validate").as_bytes()]);
+        let discriminator = &preimage.as_ref()[..DISCRIMINATOR_LENGTH];
+        let mut expect = vec![];
+        expect.extend_from_slice(&discriminator.as_ref());
+        expect.extend_from_slice(&amount.to_le_bytes());
+        assert_eq!(packed, expect);
+        let unpacked = PermissionedTransferInstruction::unpack(&expect).unwrap();
+        assert_eq!(unpacked, check);
+    }
+
+    #[test]
+    fn initialize_validation_pubkeys_packing() {
+        let check = PermissionedTransferInstruction::InitializeValidationPubkeys;
+        let packed = check.pack();
+        let preimage = hash::hashv(&[&format!("{NAMESPACE}:initialize-validation-pubkeys").as_bytes()]);
+        let discriminator = &preimage.as_ref()[..DISCRIMINATOR_LENGTH];
+        let mut expect = vec![];
+        expect.extend_from_slice(&discriminator.as_ref());
+        assert_eq!(packed, expect);
+        let unpacked = PermissionedTransferInstruction::unpack(&expect).unwrap();
+        assert_eq!(unpacked, check);
+    }
+}

--- a/token/permissioned-transfer/src/instruction.rs
+++ b/token/permissioned-transfer/src/instruction.rs
@@ -81,6 +81,7 @@ impl PermissionedTransferInstruction {
 }
 
 /// Creates a `Validate` instruction.
+#[allow(clippy::too_many_arguments)]
 pub fn validate(
     program_id: &Pubkey,
     source_pubkey: &Pubkey,
@@ -150,10 +151,10 @@ mod test {
         let amount = 111_111_111;
         let check = PermissionedTransferInstruction::Validate { amount };
         let packed = check.pack();
-        let preimage = hash::hashv(&[&format!("{NAMESPACE}:validate").as_bytes()]);
+        let preimage = hash::hashv(&[format!("{NAMESPACE}:validate").as_bytes()]);
         let discriminator = &preimage.as_ref()[..DISCRIMINATOR_LENGTH];
         let mut expect = vec![];
-        expect.extend_from_slice(&discriminator.as_ref());
+        expect.extend_from_slice(discriminator.as_ref());
         expect.extend_from_slice(&amount.to_le_bytes());
         assert_eq!(packed, expect);
         let unpacked = PermissionedTransferInstruction::unpack(&expect).unwrap();
@@ -165,10 +166,10 @@ mod test {
         let check = PermissionedTransferInstruction::InitializeValidationPubkeys;
         let packed = check.pack();
         let preimage =
-            hash::hashv(&[&format!("{NAMESPACE}:initialize-validation-pubkeys").as_bytes()]);
+            hash::hashv(&[format!("{NAMESPACE}:initialize-validation-pubkeys").as_bytes()]);
         let discriminator = &preimage.as_ref()[..DISCRIMINATOR_LENGTH];
         let mut expect = vec![];
-        expect.extend_from_slice(&discriminator.as_ref());
+        expect.extend_from_slice(discriminator.as_ref());
         assert_eq!(packed, expect);
         let unpacked = PermissionedTransferInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);

--- a/token/permissioned-transfer/src/instruction.rs
+++ b/token/permissioned-transfer/src/instruction.rs
@@ -6,6 +6,7 @@ use {
         instruction::{AccountMeta, Instruction},
         program_error::ProgramError,
         pubkey::Pubkey,
+        system_program,
     },
     std::convert::TryInto,
 };
@@ -37,7 +38,8 @@ pub enum PermissionedTransferInstruction {
     ///   0. `[w]` Validate transfer account
     ///   1. `[]` Mint
     ///   2. `[s]` Mint authority
-    ///   3..3+M `[]` `M` additional accounts, to be written to validation data
+    ///   3. `[]` System program
+    ///   4..4+M `[]` `M` additional accounts, to be written to validation data
     ///
     InitializeValidationPubkeys,
 }
@@ -128,6 +130,7 @@ pub fn initialize_validation_pubkeys(
         AccountMeta::new(*validate_state_pubkey, false),
         AccountMeta::new_readonly(*mint_pubkey, false),
         AccountMeta::new_readonly(*authority_pubkey, false),
+        AccountMeta::new_readonly(system_program::id(), false),
     ];
     accounts.extend(
         additional_pubkeys

--- a/token/permissioned-transfer/src/instruction.rs
+++ b/token/permissioned-transfer/src/instruction.rs
@@ -59,9 +59,7 @@ impl PermissionedTransferInstruction {
                     .ok_or(ProgramError::InvalidInstructionData)?;
                 Self::Validate { amount }
             }
-            INITIALIZE_VALIDATION_PUBKEYS_DISCRIMINATOR => {
-                Self::InitializeValidationPubkeys
-            }
+            INITIALIZE_VALIDATION_PUBKEYS_DISCRIMINATOR => Self::InitializeValidationPubkeys,
             _ => return Err(ProgramError::InvalidInstructionData),
         })
     }
@@ -70,9 +68,7 @@ impl PermissionedTransferInstruction {
     pub fn pack(&self) -> Vec<u8> {
         let mut buf = vec![];
         match self {
-            Self::Validate {
-                amount,
-            } => {
+            Self::Validate { amount } => {
                 buf.extend_from_slice(VALIDATE_DISCRIMINATOR);
                 buf.extend_from_slice(&amount.to_le_bytes());
             }
@@ -104,7 +100,11 @@ pub fn validate(
         AccountMeta::new_readonly(*authority_pubkey, false),
         AccountMeta::new_readonly(*validate_state_pubkey, false),
     ];
-    accounts.extend(additional_pubkeys.iter().map(|pk| AccountMeta::new_readonly(**pk, false)));
+    accounts.extend(
+        additional_pubkeys
+            .iter()
+            .map(|pk| AccountMeta::new_readonly(**pk, false)),
+    );
 
     Instruction {
         program_id: *program_id,
@@ -128,7 +128,11 @@ pub fn initialize_validation_pubkeys(
         AccountMeta::new_readonly(*mint_pubkey, false),
         AccountMeta::new_readonly(*authority_pubkey, false),
     ];
-    accounts.extend(additional_pubkeys.iter().map(|pk| AccountMeta::new_readonly(**pk, false)));
+    accounts.extend(
+        additional_pubkeys
+            .iter()
+            .map(|pk| AccountMeta::new_readonly(**pk, false)),
+    );
 
     Instruction {
         program_id: *program_id,
@@ -144,9 +148,7 @@ mod test {
     #[test]
     fn validate_packing() {
         let amount = 111_111_111;
-        let check = PermissionedTransferInstruction::Validate {
-            amount,
-        };
+        let check = PermissionedTransferInstruction::Validate { amount };
         let packed = check.pack();
         let preimage = hash::hashv(&[&format!("{NAMESPACE}:validate").as_bytes()]);
         let discriminator = &preimage.as_ref()[..DISCRIMINATOR_LENGTH];
@@ -162,7 +164,8 @@ mod test {
     fn initialize_validation_pubkeys_packing() {
         let check = PermissionedTransferInstruction::InitializeValidationPubkeys;
         let packed = check.pack();
-        let preimage = hash::hashv(&[&format!("{NAMESPACE}:initialize-validation-pubkeys").as_bytes()]);
+        let preimage =
+            hash::hashv(&[&format!("{NAMESPACE}:initialize-validation-pubkeys").as_bytes()]);
         let discriminator = &preimage.as_ref()[..DISCRIMINATOR_LENGTH];
         let mut expect = vec![];
         expect.extend_from_slice(&discriminator.as_ref());

--- a/token/permissioned-transfer/src/instruction.rs
+++ b/token/permissioned-transfer/src/instruction.rs
@@ -91,7 +91,7 @@ pub fn validate(
     destination_pubkey: &Pubkey,
     authority_pubkey: &Pubkey,
     validate_state_pubkey: &Pubkey,
-    additional_pubkeys: &[&Pubkey],
+    additional_accounts: &[AccountMeta],
     amount: u64,
 ) -> Instruction {
     let data = PermissionedTransferInstruction::Validate { amount }.pack();
@@ -103,11 +103,7 @@ pub fn validate(
         AccountMeta::new_readonly(*authority_pubkey, false),
         AccountMeta::new_readonly(*validate_state_pubkey, false),
     ];
-    accounts.extend(
-        additional_pubkeys
-            .iter()
-            .map(|pk| AccountMeta::new_readonly(**pk, false)),
-    );
+    accounts.extend_from_slice(additional_accounts);
 
     Instruction {
         program_id: *program_id,
@@ -122,7 +118,7 @@ pub fn initialize_extra_account_metas(
     extra_account_metas_pubkey: &Pubkey,
     mint_pubkey: &Pubkey,
     authority_pubkey: &Pubkey,
-    additional_pubkeys: &[&Pubkey],
+    additional_accounts: &[AccountMeta],
 ) -> Instruction {
     let data = PermissionedTransferInstruction::InitializeExtraAccountMetas.pack();
 
@@ -132,11 +128,7 @@ pub fn initialize_extra_account_metas(
         AccountMeta::new_readonly(*authority_pubkey, true),
         AccountMeta::new_readonly(system_program::id(), false),
     ];
-    accounts.extend(
-        additional_pubkeys
-            .iter()
-            .map(|pk| AccountMeta::new_readonly(**pk, false)),
-    );
+    accounts.extend_from_slice(additional_accounts);
 
     Instruction {
         program_id: *program_id,

--- a/token/permissioned-transfer/src/invoke.rs
+++ b/token/permissioned-transfer/src/invoke.rs
@@ -1,0 +1,72 @@
+//! On-chain program invoke helper to perform on-chain validation
+
+use {
+    crate::{
+        error::PermissionedTransferError,
+        get_extra_account_metas_address, instruction,
+        state::ExtraAccountMetas,
+        tlv::{TlvState, TlvStateBorrowed},
+    },
+    solana_program::{
+        account_info::AccountInfo, entrypoint::ProgramResult, program::invoke, pubkey::Pubkey,
+    },
+};
+
+/// Helper to perform a validation on-chain, looking through the additional
+/// account infos to create the proper instruction
+pub fn validate<'a>(
+    program_id: &Pubkey,
+    source_info: AccountInfo<'a>,
+    mint_info: AccountInfo<'a>,
+    destination_info: AccountInfo<'a>,
+    authority_info: AccountInfo<'a>,
+    additional_accounts: &[AccountInfo<'a>],
+    amount: u64,
+) -> ProgramResult {
+    // scope the borrowing to drop the account data before `invoke`
+    let (validate_instruction, account_infos) = {
+        let validation_pubkey = get_extra_account_metas_address(mint_info.key, program_id);
+        let validation_info = additional_accounts
+            .iter()
+            .find(|&x| *x.key == validation_pubkey)
+            .ok_or(PermissionedTransferError::IncorrectAccount)?;
+        let validation_info_data = validation_info.try_borrow_data()?;
+        let state = TlvStateBorrowed::unpack(&validation_info_data)?;
+        let bytes = state.get_bytes::<ExtraAccountMetas>()?;
+        let extra_account_metas = ExtraAccountMetas::unpack(bytes)?;
+        let additional_account_metas = extra_account_metas
+            .data()
+            .iter()
+            .map(|&m| m.into())
+            .collect::<Vec<_>>();
+
+        let validate_instruction = instruction::validate(
+            program_id,
+            source_info.key,
+            mint_info.key,
+            destination_info.key,
+            authority_info.key,
+            &validation_pubkey,
+            &additional_account_metas,
+            amount,
+        );
+
+        let mut account_infos = vec![
+            source_info,
+            mint_info,
+            destination_info,
+            authority_info,
+            validation_info.clone(),
+        ];
+        for account_meta in additional_account_metas {
+            let account_info = additional_accounts
+                .iter()
+                .find(|&x| *x.key == account_meta.pubkey)
+                .ok_or(PermissionedTransferError::IncorrectAccount)?
+                .clone();
+            account_infos.push(account_info);
+        }
+        (validate_instruction, account_infos)
+    };
+    invoke(&validate_instruction, &account_infos)
+}

--- a/token/permissioned-transfer/src/lib.rs
+++ b/token/permissioned-transfer/src/lib.rs
@@ -9,6 +9,7 @@
 pub mod error;
 pub mod inline_spl_token;
 pub mod instruction;
+pub mod pod;
 pub mod processor;
 pub mod state;
 pub mod tlv;

--- a/token/permissioned-transfer/src/lib.rs
+++ b/token/permissioned-transfer/src/lib.rs
@@ -29,10 +29,7 @@ pub const DISCRIMINATOR_LENGTH: usize = 8;
 const VALIDATE_STATE_SEED: &[u8] = b"validate-state";
 
 /// Get the validate state address
-pub fn get_validate_state_address(
-    mint: &Pubkey,
-    program_id: &Pubkey,
-) -> Pubkey {
+pub fn get_validate_state_address(mint: &Pubkey, program_id: &Pubkey) -> Pubkey {
     get_validate_state_address_and_bump_seed(mint, program_id).0
 }
 
@@ -40,28 +37,16 @@ pub(crate) fn get_validate_state_address_and_bump_seed(
     mint: &Pubkey,
     program_id: &Pubkey,
 ) -> (Pubkey, u8) {
-    Pubkey::find_program_address(
-        &collect_validate_state_seeds(mint),
-        program_id,
-    )
+    Pubkey::find_program_address(&collect_validate_state_seeds(mint), program_id)
 }
 
-pub(crate) fn collect_validate_state_seeds<'a>(
-    mint: &'a Pubkey,
-) -> [&'a [u8]; 2] {
-    [
-        VALIDATE_STATE_SEED,
-        mint.as_ref(),
-    ]
+pub(crate) fn collect_validate_state_seeds<'a>(mint: &'a Pubkey) -> [&'a [u8]; 2] {
+    [VALIDATE_STATE_SEED, mint.as_ref()]
 }
 
 pub(crate) fn collect_validate_state_signer_seeds<'a>(
     mint: &'a Pubkey,
     bump_seed: &'a [u8],
 ) -> [&'a [u8]; 3] {
-    [
-        VALIDATE_STATE_SEED,
-        mint.as_ref(),
-        bump_seed,
-    ]
+    [VALIDATE_STATE_SEED, mint.as_ref(), bump_seed]
 }

--- a/token/permissioned-transfer/src/lib.rs
+++ b/token/permissioned-transfer/src/lib.rs
@@ -9,6 +9,9 @@
 pub mod error;
 pub mod inline_spl_token;
 pub mod instruction;
+pub mod invoke;
+#[cfg(feature = "offchain-client")]
+pub mod offchain;
 pub mod pod;
 pub mod processor;
 pub mod state;

--- a/token/permissioned-transfer/src/lib.rs
+++ b/token/permissioned-transfer/src/lib.rs
@@ -7,6 +7,7 @@
 #![cfg_attr(not(test), forbid(unsafe_code))]
 
 pub mod error;
+pub mod inline_spl_token;
 pub mod instruction;
 pub mod processor;
 pub mod state;

--- a/token/permissioned-transfer/src/lib.rs
+++ b/token/permissioned-transfer/src/lib.rs
@@ -26,28 +26,30 @@ pub const NAMESPACE: &str = "permissioned-transfer-interface";
 /// Size for discriminator in account and instruction data
 pub const DISCRIMINATOR_LENGTH: usize = 8;
 
-/// Seed for the validation state
-const VALIDATE_STATE_SEED: &[u8] = b"validate-state";
+/// Seed for the state
+const EXTRA_ACCOUNT_METAS_SEED: &[u8] = b"extra-account-metas";
 
 /// Get the validate state address
-pub fn get_validate_state_address(mint: &Pubkey, program_id: &Pubkey) -> Pubkey {
-    get_validate_state_address_and_bump_seed(mint, program_id).0
+pub fn get_extra_account_metas_address(mint: &Pubkey, program_id: &Pubkey) -> Pubkey {
+    get_extra_account_metas_address_and_bump_seed(mint, program_id).0
 }
 
-pub(crate) fn get_validate_state_address_and_bump_seed(
+pub(crate) fn get_extra_account_metas_address_and_bump_seed(
     mint: &Pubkey,
     program_id: &Pubkey,
 ) -> (Pubkey, u8) {
-    Pubkey::find_program_address(&collect_validate_state_seeds(mint), program_id)
+    Pubkey::find_program_address(&collect_extra_account_metas_seeds(mint), program_id)
 }
 
-pub(crate) fn collect_validate_state_seeds(mint: &Pubkey) -> [&[u8]; 2] {
-    [VALIDATE_STATE_SEED, mint.as_ref()]
+pub(crate) fn collect_extra_account_metas_seeds(mint: &Pubkey) -> [&[u8]; 2] {
+    [EXTRA_ACCOUNT_METAS_SEED, mint.as_ref()]
 }
 
-pub(crate) fn collect_validate_state_signer_seeds<'a>(
+pub(crate) fn collect_extra_account_metas_signer_seeds<'a>(
     mint: &'a Pubkey,
     bump_seed: &'a [u8],
 ) -> [&'a [u8]; 3] {
-    [VALIDATE_STATE_SEED, mint.as_ref(), bump_seed]
+    [EXTRA_ACCOUNT_METAS_SEED, mint.as_ref(), bump_seed]
 }
+
+solana_program::declare_id!("pERmRFhRmg9JaJdsocrUnLLigHXrwWTxBu2SafwK2cd");

--- a/token/permissioned-transfer/src/lib.rs
+++ b/token/permissioned-transfer/src/lib.rs
@@ -1,0 +1,67 @@
+//! Crate defining an interface for performing permissioned transfers, where the
+//! token program calls into a separate program with additional accounts to be
+//! sure that a transfer has accomplished all required preconditions.
+
+#![allow(clippy::integer_arithmetic)]
+#![deny(missing_docs)]
+#![cfg_attr(not(test), forbid(unsafe_code))]
+
+pub mod error;
+pub mod instruction;
+pub mod processor;
+pub mod state;
+pub mod tlv;
+
+#[cfg(not(feature = "no-entrypoint"))]
+mod entrypoint;
+
+// Export current sdk types for downstream users building with a different sdk version
+pub use solana_program;
+use solana_program::pubkey::Pubkey;
+
+/// Namespace for all programs implementing permissioned-transfer
+pub const NAMESPACE: &str = "permissioned-transfer-interface";
+
+/// Size for discriminator in account and instruction data
+pub const DISCRIMINATOR_LENGTH: usize = 8;
+
+/// Seed for the validation state
+const VALIDATE_STATE_SEED: &[u8] = b"validate-state";
+
+/// Get the validate state address
+pub fn get_validate_state_address(
+    mint: &Pubkey,
+    program_id: &Pubkey,
+) -> Pubkey {
+    get_validate_state_address_and_bump_seed(mint, program_id).0
+}
+
+pub(crate) fn get_validate_state_address_and_bump_seed(
+    mint: &Pubkey,
+    program_id: &Pubkey,
+) -> (Pubkey, u8) {
+    Pubkey::find_program_address(
+        &collect_validate_state_seeds(mint),
+        program_id,
+    )
+}
+
+pub(crate) fn collect_validate_state_seeds<'a>(
+    mint: &'a Pubkey,
+) -> [&'a [u8]; 2] {
+    [
+        VALIDATE_STATE_SEED,
+        mint.as_ref(),
+    ]
+}
+
+pub(crate) fn collect_validate_state_signer_seeds<'a>(
+    mint: &'a Pubkey,
+    bump_seed: &'a [u8],
+) -> [&'a [u8]; 3] {
+    [
+        VALIDATE_STATE_SEED,
+        mint.as_ref(),
+        bump_seed,
+    ]
+}

--- a/token/permissioned-transfer/src/lib.rs
+++ b/token/permissioned-transfer/src/lib.rs
@@ -40,7 +40,7 @@ pub(crate) fn get_validate_state_address_and_bump_seed(
     Pubkey::find_program_address(&collect_validate_state_seeds(mint), program_id)
 }
 
-pub(crate) fn collect_validate_state_seeds<'a>(mint: &'a Pubkey) -> [&'a [u8]; 2] {
+pub(crate) fn collect_validate_state_seeds(mint: &Pubkey) -> [&[u8]; 2] {
     [VALIDATE_STATE_SEED, mint.as_ref()]
 }
 

--- a/token/permissioned-transfer/src/offchain.rs
+++ b/token/permissioned-transfer/src/offchain.rs
@@ -1,0 +1,70 @@
+//! Offchain helper for fetching required accounts to build instructions
+
+use {
+    crate::{
+        get_extra_account_metas_address,
+        state::ExtraAccountMetas,
+        tlv::{TlvState, TlvStateBorrowed},
+    },
+    solana_sdk::{
+        account::Account, instruction::AccountMeta, program_error::ProgramError, pubkey::Pubkey,
+    },
+    std::future::Future,
+};
+
+type AccountResult = Result<Option<Account>, AccountFetchError>;
+type AccountFetchError = Box<dyn std::error::Error + Send + Sync>;
+
+/// Offchain helper to get all additional required account metas for a mint
+///
+/// To be client-agnostic, this simply takes a function that will return a
+/// `Future<Account>` for the given address. Can be called in the following way:
+///
+/// ```rust,ignore
+/// use solana_client::nonblocking::rpc_client::RpcClient;
+/// use solana_sdk::pubkey::Pubkey;
+///
+/// let program_id = Pubkey::new_unique();
+/// let mint = Pubkey::new_unique();
+/// let client = RpcClient::new_mock("succeeds".to_string());
+///
+/// let extra_account_metas = get_extra_account_metas(
+///     |address| self.client.get_account(&address),
+///     &program_id,
+///     &mint,
+/// ).await;
+/// ```
+pub async fn get_extra_account_metas<F, Fut>(
+    get_account_fn: F,
+    permissioned_transfer_program_id: &Pubkey,
+    mint: &Pubkey,
+) -> Result<Vec<AccountMeta>, AccountFetchError>
+where
+    F: Fn(Pubkey) -> Fut,
+    Fut: Future<Output = AccountResult>,
+{
+    let mut instruction_metas = vec![];
+    let validation_address =
+        get_extra_account_metas_address(mint, permissioned_transfer_program_id);
+    let validation_account = get_account_fn(validation_address)
+        .await?
+        .ok_or(ProgramError::InvalidAccountData)?;
+    let state = TlvStateBorrowed::unpack(&validation_account.data)?;
+    let bytes = state.get_bytes::<ExtraAccountMetas>()?;
+    let extra_account_metas = ExtraAccountMetas::unpack(bytes)?;
+    extra_account_metas
+        .data()
+        .iter()
+        .for_each(|&m| instruction_metas.push(m.into()));
+    instruction_metas.push(AccountMeta {
+        pubkey: *permissioned_transfer_program_id,
+        is_signer: false,
+        is_writable: false,
+    });
+    instruction_metas.push(AccountMeta {
+        pubkey: validation_address,
+        is_signer: false,
+        is_writable: false,
+    });
+    Ok(instruction_metas)
+}

--- a/token/permissioned-transfer/src/pod.rs
+++ b/token/permissioned-transfer/src/pod.rs
@@ -1,0 +1,210 @@
+//! Pod types to be used with bytemuck for zero-copy serde
+
+use {
+    crate::error::PermissionedTransferError,
+    bytemuck::{Pod, Zeroable},
+    solana_program::{
+        account_info::AccountInfo, instruction::AccountMeta, program_error::ProgramError,
+        pubkey::Pubkey,
+    },
+};
+
+/// Convert a slice into a `Pod` (zero copy)
+pub fn pod_from_bytes<T: Pod>(bytes: &[u8]) -> Result<&T, ProgramError> {
+    bytemuck::try_from_bytes(bytes).map_err(|_| ProgramError::InvalidArgument)
+}
+/// Convert a slice into a mutable `Pod` (zero copy)
+pub fn pod_from_bytes_mut<T: Pod>(bytes: &mut [u8]) -> Result<&mut T, ProgramError> {
+    bytemuck::try_from_bytes_mut(bytes).map_err(|_| ProgramError::InvalidArgument)
+}
+/// Convert a slice into a mutable `Pod` slice (zero copy)
+pub fn pod_slice_from_bytes<T: Pod>(bytes: &[u8]) -> Result<&[T], ProgramError> {
+    bytemuck::try_cast_slice(bytes).map_err(|_| ProgramError::InvalidArgument)
+}
+/// Convert a slice into a mutable `Pod` slice (zero copy)
+pub fn pod_slice_from_bytes_mut<T: Pod>(bytes: &mut [u8]) -> Result<&mut [T], ProgramError> {
+    bytemuck::try_cast_slice_mut(bytes).map_err(|_| ProgramError::InvalidArgument)
+}
+
+/// Simple macro for implementing conversion functions between Pod* ints and standard ints.
+///
+/// The standard int types can cause alignment issues when placed in a `Pod`,
+/// so these replacements are usable in all `Pod`s.
+macro_rules! impl_int_conversion {
+    ($P:ty, $I:ty) => {
+        impl From<$I> for $P {
+            fn from(n: $I) -> Self {
+                Self(n.to_le_bytes())
+            }
+        }
+        impl From<$P> for $I {
+            fn from(pod: $P) -> Self {
+                Self::from_le_bytes(pod.0)
+            }
+        }
+    };
+}
+
+/// `u32` type that can be used in `Pod`s
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+#[repr(transparent)]
+pub struct PodU32([u8; 4]);
+impl_int_conversion!(PodU32, u32);
+
+/// `u16` type that can be used in `Pod`s
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+#[repr(transparent)]
+pub struct PodU16([u8; 2]);
+impl_int_conversion!(PodU16, u16);
+
+/// The standard `bool` is not a `Pod`, define a replacement that is
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+#[repr(transparent)]
+pub struct PodBool(u8);
+impl From<bool> for PodBool {
+    fn from(b: bool) -> Self {
+        Self(if b { 1 } else { 0 })
+    }
+}
+impl From<&PodBool> for bool {
+    fn from(b: &PodBool) -> Self {
+        b.0 != 0
+    }
+}
+impl From<PodBool> for bool {
+    fn from(b: PodBool) -> Self {
+        b.0 != 0
+    }
+}
+
+/// The standard `AccountMeta` is not a `Pod`, define a replacement that is
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+pub struct PodAccountMeta {
+    /// The pubkey of the account
+    pub pubkey: Pubkey,
+    /// Whether the account should sign
+    pub is_signer: PodBool,
+    /// Whether the account should be writable
+    pub is_writable: PodBool,
+}
+impl PartialEq<AccountInfo<'_>> for PodAccountMeta {
+    fn eq(&self, other: &AccountInfo) -> bool {
+        self.pubkey == *other.key
+            && self.is_signer == other.is_signer.into()
+            && self.is_writable == other.is_writable.into()
+    }
+}
+
+impl From<&AccountInfo<'_>> for PodAccountMeta {
+    fn from(account_info: &AccountInfo) -> Self {
+        Self {
+            pubkey: *account_info.key,
+            is_signer: account_info.is_signer.into(),
+            is_writable: account_info.is_writable.into(),
+        }
+    }
+}
+
+impl From<PodAccountMeta> for AccountMeta {
+    fn from(meta: PodAccountMeta) -> Self {
+        Self {
+            pubkey: meta.pubkey,
+            is_signer: meta.is_signer.into(),
+            is_writable: meta.is_writable.into(),
+        }
+    }
+}
+
+const LENGTH_SIZE: usize = std::mem::size_of::<PodU16>();
+/// Special type for using a slice of `Pod`s in a zero-copy way
+pub struct PodSlice<'data, T: Pod> {
+    length: &'data PodU16,
+    data: &'data [T],
+}
+impl<'data, T: Pod> PodSlice<'data, T> {
+    /// Unpack the buffer into a slice
+    pub fn unpack<'a>(data: &'a [u8]) -> Result<Self, ProgramError>
+    where
+        'a: 'data,
+    {
+        if data.len() < LENGTH_SIZE {
+            return Err(PermissionedTransferError::BufferTooSmall.into());
+        }
+        let (length, data) = data.split_at(LENGTH_SIZE);
+        let length = pod_from_bytes::<PodU16>(length)?;
+        let _max_length = max_len_for_type::<T>(data.len())?;
+        let data = pod_slice_from_bytes(data)?;
+        Ok(Self { length, data })
+    }
+
+    /// Get the slice data
+    pub fn data(&self) -> &[T] {
+        let length = u16::from(*self.length) as usize;
+        &self.data[..length]
+    }
+
+    /// Get the amount of bytes used by `num_items`
+    pub fn byte_size_of(num_items: usize) -> Result<usize, ProgramError> {
+        std::mem::size_of::<T>()
+            .checked_mul(num_items)
+            .and_then(|len| len.checked_add(LENGTH_SIZE))
+            .ok_or_else(|| PermissionedTransferError::CalculationFailure.into())
+    }
+}
+
+/// Special type for using a slice of mutable `Pod`s in a zero-copy way
+pub struct PodSliceMut<'data, T: Pod> {
+    length: &'data mut PodU16,
+    data: &'data mut [T],
+    max_length: usize,
+}
+impl<'data, T: Pod> PodSliceMut<'data, T> {
+    /// Unpack the mutable buffer into a mutable slice, with the option to
+    /// initialize the data
+    pub fn unpack<'a>(data: &'a mut [u8], init: bool) -> Result<Self, ProgramError>
+    where
+        'a: 'data,
+    {
+        if data.len() < LENGTH_SIZE {
+            return Err(PermissionedTransferError::BufferTooSmall.into());
+        }
+        let (length, data) = data.split_at_mut(LENGTH_SIZE);
+        let length = pod_from_bytes_mut::<PodU16>(length)?;
+        if init {
+            *length = 0.into();
+        }
+        let max_length = max_len_for_type::<T>(data.len())?;
+        let data = pod_slice_from_bytes_mut(data)?;
+        Ok(Self {
+            length,
+            data,
+            max_length,
+        })
+    }
+
+    /// Add another item to the slice
+    pub fn push(&mut self, t: T) -> Result<(), ProgramError> {
+        let length = u16::from(*self.length);
+        if length as usize == self.max_length {
+            Err(PermissionedTransferError::BufferTooSmall.into())
+        } else {
+            self.data[length as usize] = t;
+            *self.length = length.saturating_add(1).into();
+            Ok(())
+        }
+    }
+}
+
+fn max_len_for_type<T>(data_len: usize) -> Result<usize, ProgramError> {
+    let size: usize = std::mem::size_of::<T>();
+    let max_len = data_len
+        .checked_div(size)
+        .ok_or(PermissionedTransferError::CalculationFailure)?;
+    // check that it isn't overallocated
+    if max_len.saturating_mul(size) != data_len {
+        Err(PermissionedTransferError::BufferTooLarge.into())
+    } else {
+        Ok(max_len)
+    }
+}

--- a/token/permissioned-transfer/src/processor.rs
+++ b/token/permissioned-transfer/src/processor.rs
@@ -12,30 +12,30 @@ use {
 
 /// Processes a [Validate](enum.PermissionedTransferInstruction.html) instruction.
 pub fn process_validate(
-    program_id: &Pubkey,
+    _program_id: &Pubkey,
     accounts: &[AccountInfo],
-    amount: u64,
+    _amount: u64,
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
 
-    let source_account_info = next_account_info(account_info_iter)?;
-    let mint_info = next_account_info(account_info_iter)?;
-    let destination_account_info = next_account_info(account_info_iter)?;
-    let authority_info = next_account_info(account_info_iter)?;
+    let _source_account_info = next_account_info(account_info_iter)?;
+    let _mint_info = next_account_info(account_info_iter)?;
+    let _destination_account_info = next_account_info(account_info_iter)?;
+    let _authority_info = next_account_info(account_info_iter)?;
 
     Ok(())
 }
 
 /// Processes a [InitializeValidationPubkeys](enum.PermissionedTransferInstruction.html) instruction.
 pub fn process_initialize_validation_pubkeys(
-    program_id: &Pubkey,
+    _program_id: &Pubkey,
     accounts: &[AccountInfo],
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
 
-    let validation_pubkeys_info = next_account_info(account_info_iter)?;
-    let mint_info = next_account_info(account_info_iter)?;
-    let authority_info = next_account_info(account_info_iter)?;
+    let _validation_pubkeys_info = next_account_info(account_info_iter)?;
+    let _mint_info = next_account_info(account_info_iter)?;
+    let _authority_info = next_account_info(account_info_iter)?;
 
     Ok(())
 }

--- a/token/permissioned-transfer/src/processor.rs
+++ b/token/permissioned-transfer/src/processor.rs
@@ -1,0 +1,64 @@
+//! Program state processor
+
+use {
+    crate::instruction::PermissionedTransferInstruction,
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        msg,
+        pubkey::Pubkey,
+    }
+};
+
+/// Processes a [Validate](enum.PermissionedTransferInstruction.html) instruction.
+pub fn process_validate(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    amount: u64,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    let source_account_info = next_account_info(account_info_iter)?;
+    let mint_info = next_account_info(account_info_iter)?;
+    let destination_account_info = next_account_info(account_info_iter)?;
+    let authority_info = next_account_info(account_info_iter)?;
+
+    Ok(())
+}
+
+/// Processes a [InitializeValidationPubkeys](enum.PermissionedTransferInstruction.html) instruction.
+pub fn process_initialize_validation_pubkeys(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    let validation_pubkeys_info = next_account_info(account_info_iter)?;
+    let mint_info = next_account_info(account_info_iter)?;
+    let authority_info = next_account_info(account_info_iter)?;
+
+    Ok(())
+}
+
+/// Processes an [Instruction](enum.Instruction.html).
+pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> ProgramResult {
+    let instruction = PermissionedTransferInstruction::unpack(input)?;
+
+    match instruction {
+        PermissionedTransferInstruction::Validate {
+            amount,
+        } => {
+            msg!("Instruction: Validate");
+            process_validate(program_id, accounts, amount)
+        }
+        PermissionedTransferInstruction::InitializeValidationPubkeys => {
+            msg!("Instruction: InitializeValidationPubkeys");
+            process_initialize_validation_pubkeys(program_id, accounts)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // TODO
+}

--- a/token/permissioned-transfer/src/processor.rs
+++ b/token/permissioned-transfer/src/processor.rs
@@ -1,41 +1,126 @@
 //! Program state processor
 
 use {
-    crate::instruction::PermissionedTransferInstruction,
+    crate::{
+        collect_validate_state_signer_seeds,
+        error::PermissionedTransferError,
+        get_validate_state_address, get_validate_state_address_and_bump_seed, inline_spl_token,
+        instruction::PermissionedTransferInstruction,
+        state::{ValidationPubkeys, MAX_NUM_KEYS},
+        tlv::{TlvState, TlvStateBorrowed, TlvStateMut},
+    },
     solana_program::{
         account_info::{next_account_info, AccountInfo},
         entrypoint::ProgramResult,
         msg,
+        program::invoke_signed,
+        program_error::ProgramError,
         pubkey::Pubkey,
+        system_instruction,
     },
+    std::mem::size_of,
 };
 
 /// Processes a [Validate](enum.PermissionedTransferInstruction.html) instruction.
 pub fn process_validate(
-    _program_id: &Pubkey,
+    program_id: &Pubkey,
     accounts: &[AccountInfo],
     _amount: u64,
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
 
     let _source_account_info = next_account_info(account_info_iter)?;
-    let _mint_info = next_account_info(account_info_iter)?;
+    let mint_info = next_account_info(account_info_iter)?;
     let _destination_account_info = next_account_info(account_info_iter)?;
     let _authority_info = next_account_info(account_info_iter)?;
+    let validation_pubkeys_info = next_account_info(account_info_iter)?;
+
+    // For the example program, we just check that the correct pda and validation
+    // pubkeys are provided
+    let expected_validation_address = get_validate_state_address(mint_info.key, program_id);
+    if expected_validation_address != *validation_pubkeys_info.key {
+        return Err(ProgramError::InvalidSeeds);
+    }
+
+    let data = validation_pubkeys_info.try_borrow_data()?;
+    let state = TlvStateBorrowed::unpack(&data).unwrap();
+    let validation_pubkeys = state.get_value::<ValidationPubkeys>()?;
+
+    // if too many keys are provided, error
+    if account_info_iter.count() > validation_pubkeys.length as usize {
+        return Err(PermissionedTransferError::TooManyPubkeys.into());
+    }
+
+    // Let's assume that they're provided in the correct order
+    for (i, account_info) in account_info_iter.enumerate() {
+        if *account_info.key != validation_pubkeys.pubkeys[i] {
+            return Err(PermissionedTransferError::IncorrectAccount.into());
+        }
+    }
 
     Ok(())
 }
 
 /// Processes a [InitializeValidationPubkeys](enum.PermissionedTransferInstruction.html) instruction.
 pub fn process_initialize_validation_pubkeys(
-    _program_id: &Pubkey,
+    program_id: &Pubkey,
     accounts: &[AccountInfo],
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
 
-    let _validation_pubkeys_info = next_account_info(account_info_iter)?;
-    let _mint_info = next_account_info(account_info_iter)?;
-    let _authority_info = next_account_info(account_info_iter)?;
+    let validation_pubkeys_info = next_account_info(account_info_iter)?;
+    let mint_info = next_account_info(account_info_iter)?;
+    let authority_info = next_account_info(account_info_iter)?;
+    let _system_program_info = next_account_info(account_info_iter)?;
+
+    // check that the mint authority is valid without fully deserializing
+    let mint_authority = inline_spl_token::get_mint_authority(&mint_info.try_borrow_data()?)?;
+    let mint_authority = mint_authority.ok_or(PermissionedTransferError::MintHasNoMintAuthority)?;
+
+    // Check signers
+    if !authority_info.is_signer {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+    if *authority_info.key != mint_authority {
+        return Err(PermissionedTransferError::IncorrectMintAuthority.into());
+    }
+
+    // Check validation account
+    let (expected_validation_address, bump_seed) =
+        get_validate_state_address_and_bump_seed(mint_info.key, program_id);
+    if expected_validation_address != *validation_pubkeys_info.key {
+        return Err(ProgramError::InvalidSeeds);
+    }
+
+    // Create the account
+    let bump_seed = [bump_seed];
+    let signer_seeds = collect_validate_state_signer_seeds(mint_info.key, &bump_seed);
+    const VALIDATION_SIZE: u64 = size_of::<ValidationPubkeys>() as u64;
+    invoke_signed(
+        &system_instruction::allocate(validation_pubkeys_info.key, VALIDATION_SIZE),
+        &[validation_pubkeys_info.clone()],
+        &[&signer_seeds],
+    )?;
+    invoke_signed(
+        &system_instruction::assign(validation_pubkeys_info.key, program_id),
+        &[validation_pubkeys_info.clone()],
+        &[&signer_seeds],
+    )?;
+
+    // Write the data
+    let mut data = validation_pubkeys_info.try_borrow_mut_data()?;
+    let mut state = TlvStateMut::unpack(&mut data).unwrap();
+    let mut validation_pubkeys = state.init_value::<ValidationPubkeys>(false)?;
+    let length = account_info_iter.count();
+    if length > MAX_NUM_KEYS {
+        return Err(PermissionedTransferError::TooManyPubkeys.into());
+    }
+    validation_pubkeys.length = length
+        .try_into()
+        .map_err(|_| ProgramError::from(PermissionedTransferError::CalculationFailure))?;
+    for (i, account_info) in account_info_iter.enumerate() {
+        validation_pubkeys.pubkeys[i] = *account_info.key;
+    }
 
     Ok(())
 }
@@ -54,9 +139,4 @@ pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> P
             process_initialize_validation_pubkeys(program_id, accounts)
         }
     }
-}
-
-#[cfg(test)]
-mod tests {
-    // TODO
 }

--- a/token/permissioned-transfer/src/processor.rs
+++ b/token/permissioned-transfer/src/processor.rs
@@ -7,7 +7,7 @@ use {
         entrypoint::ProgramResult,
         msg,
         pubkey::Pubkey,
-    }
+    },
 };
 
 /// Processes a [Validate](enum.PermissionedTransferInstruction.html) instruction.
@@ -45,9 +45,7 @@ pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> P
     let instruction = PermissionedTransferInstruction::unpack(input)?;
 
     match instruction {
-        PermissionedTransferInstruction::Validate {
-            amount,
-        } => {
+        PermissionedTransferInstruction::Validate { amount } => {
             msg!("Instruction: Validate");
             process_validate(program_id, accounts, amount)
         }

--- a/token/permissioned-transfer/src/processor.rs
+++ b/token/permissioned-transfer/src/processor.rs
@@ -7,7 +7,7 @@ use {
         get_extra_account_metas_address, get_extra_account_metas_address_and_bump_seed,
         inline_spl_token,
         instruction::PermissionedTransferInstruction,
-        state::{ExtraAccountMetas, MAX_NUM_KEYS},
+        state::{ExtraAccountMetas, PodAccountMeta, MAX_NUM_KEYS},
         tlv::{get_len, TlvState, TlvStateBorrowed, TlvStateMut},
     },
     solana_program::{
@@ -54,8 +54,7 @@ pub fn process_validate(
 
     // Let's assume that they're provided in the correct order
     for (i, account_info) in extra_account_infos.iter().enumerate() {
-        msg!("{} vs {}", account_info.key, validation_pubkeys.pubkeys[i]);
-        if *account_info.key != validation_pubkeys.pubkeys[i] {
+        if &validation_pubkeys.metas[i] != account_info {
             return Err(PermissionedTransferError::IncorrectAccount.into());
         }
     }
@@ -122,7 +121,7 @@ pub fn process_initialize_extra_account_metas(
         .try_into()
         .map_err(|_| ProgramError::from(PermissionedTransferError::CalculationFailure))?;
     for (i, account_info) in extra_account_infos.iter().enumerate() {
-        validation_pubkeys.pubkeys[i] = *account_info.key;
+        validation_pubkeys.metas[i] = PodAccountMeta::from(account_info);
     }
 
     Ok(())

--- a/token/permissioned-transfer/src/processor.rs
+++ b/token/permissioned-transfer/src/processor.rs
@@ -2,12 +2,13 @@
 
 use {
     crate::{
-        collect_validate_state_signer_seeds,
+        collect_extra_account_metas_signer_seeds,
         error::PermissionedTransferError,
-        get_validate_state_address, get_validate_state_address_and_bump_seed, inline_spl_token,
+        get_extra_account_metas_address, get_extra_account_metas_address_and_bump_seed,
+        inline_spl_token,
         instruction::PermissionedTransferInstruction,
-        state::{ValidationPubkeys, MAX_NUM_KEYS},
-        tlv::{TlvState, TlvStateBorrowed, TlvStateMut},
+        state::{ExtraAccountMetas, MAX_NUM_KEYS},
+        tlv::{get_len, TlvState, TlvStateBorrowed, TlvStateMut},
     },
     solana_program::{
         account_info::{next_account_info, AccountInfo},
@@ -18,7 +19,6 @@ use {
         pubkey::Pubkey,
         system_instruction,
     },
-    std::mem::size_of,
 };
 
 /// Processes a [Validate](enum.PermissionedTransferInstruction.html) instruction.
@@ -33,26 +33,28 @@ pub fn process_validate(
     let mint_info = next_account_info(account_info_iter)?;
     let _destination_account_info = next_account_info(account_info_iter)?;
     let _authority_info = next_account_info(account_info_iter)?;
-    let validation_pubkeys_info = next_account_info(account_info_iter)?;
+    let extra_account_metas_info = next_account_info(account_info_iter)?;
 
     // For the example program, we just check that the correct pda and validation
     // pubkeys are provided
-    let expected_validation_address = get_validate_state_address(mint_info.key, program_id);
-    if expected_validation_address != *validation_pubkeys_info.key {
+    let expected_validation_address = get_extra_account_metas_address(mint_info.key, program_id);
+    if expected_validation_address != *extra_account_metas_info.key {
         return Err(ProgramError::InvalidSeeds);
     }
 
-    let data = validation_pubkeys_info.try_borrow_data()?;
+    let data = extra_account_metas_info.try_borrow_data()?;
     let state = TlvStateBorrowed::unpack(&data).unwrap();
-    let validation_pubkeys = state.get_value::<ValidationPubkeys>()?;
+    let validation_pubkeys = state.get_value::<ExtraAccountMetas>()?;
 
-    // if too many keys are provided, error
-    if account_info_iter.count() > validation_pubkeys.length as usize {
-        return Err(PermissionedTransferError::TooManyPubkeys.into());
+    // if incorrect number of are provided, error
+    let extra_account_infos = account_info_iter.as_slice();
+    if extra_account_infos.len() != validation_pubkeys.length as usize {
+        return Err(PermissionedTransferError::IncorrectAccount.into());
     }
 
     // Let's assume that they're provided in the correct order
-    for (i, account_info) in account_info_iter.enumerate() {
+    for (i, account_info) in extra_account_infos.iter().enumerate() {
+        msg!("{} vs {}", account_info.key, validation_pubkeys.pubkeys[i]);
         if *account_info.key != validation_pubkeys.pubkeys[i] {
             return Err(PermissionedTransferError::IncorrectAccount.into());
         }
@@ -61,14 +63,14 @@ pub fn process_validate(
     Ok(())
 }
 
-/// Processes a [InitializeValidationPubkeys](enum.PermissionedTransferInstruction.html) instruction.
-pub fn process_initialize_validation_pubkeys(
+/// Processes a [InitializeExtraAccountMetas](enum.PermissionedTransferInstruction.html) instruction.
+pub fn process_initialize_extra_account_metas(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
 
-    let validation_pubkeys_info = next_account_info(account_info_iter)?;
+    let extra_account_metas_info = next_account_info(account_info_iter)?;
     let mint_info = next_account_info(account_info_iter)?;
     let authority_info = next_account_info(account_info_iter)?;
     let _system_program_info = next_account_info(account_info_iter)?;
@@ -87,38 +89,39 @@ pub fn process_initialize_validation_pubkeys(
 
     // Check validation account
     let (expected_validation_address, bump_seed) =
-        get_validate_state_address_and_bump_seed(mint_info.key, program_id);
-    if expected_validation_address != *validation_pubkeys_info.key {
+        get_extra_account_metas_address_and_bump_seed(mint_info.key, program_id);
+    if expected_validation_address != *extra_account_metas_info.key {
         return Err(ProgramError::InvalidSeeds);
     }
 
     // Create the account
     let bump_seed = [bump_seed];
-    let signer_seeds = collect_validate_state_signer_seeds(mint_info.key, &bump_seed);
-    const VALIDATION_SIZE: u64 = size_of::<ValidationPubkeys>() as u64;
+    let signer_seeds = collect_extra_account_metas_signer_seeds(mint_info.key, &bump_seed);
+    let account_size = get_len::<ExtraAccountMetas>() as u64;
     invoke_signed(
-        &system_instruction::allocate(validation_pubkeys_info.key, VALIDATION_SIZE),
-        &[validation_pubkeys_info.clone()],
+        &system_instruction::allocate(extra_account_metas_info.key, account_size),
+        &[extra_account_metas_info.clone()],
         &[&signer_seeds],
     )?;
     invoke_signed(
-        &system_instruction::assign(validation_pubkeys_info.key, program_id),
-        &[validation_pubkeys_info.clone()],
+        &system_instruction::assign(extra_account_metas_info.key, program_id),
+        &[extra_account_metas_info.clone()],
         &[&signer_seeds],
     )?;
 
     // Write the data
-    let mut data = validation_pubkeys_info.try_borrow_mut_data()?;
+    let mut data = extra_account_metas_info.try_borrow_mut_data()?;
     let mut state = TlvStateMut::unpack(&mut data).unwrap();
-    let mut validation_pubkeys = state.init_value::<ValidationPubkeys>(false)?;
-    let length = account_info_iter.count();
+    let mut validation_pubkeys = state.init_value::<ExtraAccountMetas>(false)?;
+    let extra_account_infos = account_info_iter.as_slice();
+    let length = extra_account_infos.len();
     if length > MAX_NUM_KEYS {
         return Err(PermissionedTransferError::TooManyPubkeys.into());
     }
     validation_pubkeys.length = length
         .try_into()
         .map_err(|_| ProgramError::from(PermissionedTransferError::CalculationFailure))?;
-    for (i, account_info) in account_info_iter.enumerate() {
+    for (i, account_info) in extra_account_infos.iter().enumerate() {
         validation_pubkeys.pubkeys[i] = *account_info.key;
     }
 
@@ -134,9 +137,9 @@ pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> P
             msg!("Instruction: Validate");
             process_validate(program_id, accounts, amount)
         }
-        PermissionedTransferInstruction::InitializeValidationPubkeys => {
-            msg!("Instruction: InitializeValidationPubkeys");
-            process_initialize_validation_pubkeys(program_id, accounts)
+        PermissionedTransferInstruction::InitializeExtraAccountMetas => {
+            msg!("Instruction: InitializeExtraAccountMetas");
+            process_initialize_extra_account_metas(program_id, accounts)
         }
     }
 }

--- a/token/permissioned-transfer/src/state.rs
+++ b/token/permissioned-transfer/src/state.rs
@@ -1,0 +1,36 @@
+//! State transition types
+
+use {
+    crate::tlv::{Discriminator, Value},
+    bytemuck::{Pod, Zeroable},
+    solana_program::pubkey::Pubkey,
+};
+
+const NUM_KEYS: usize = 3;
+/// State for all pubkeys required to validate a transfer
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+pub struct ValidationPubkeys {
+    /// Number of `Pubkey` instances in the slice
+    pub length: u16,
+    /// Slice of required pubkeys to validate a transfer, along with the normal
+    /// checked-transfer accounts and this account.
+    pub pubkeys: [Pubkey; NUM_KEYS],
+}
+
+/// First 8 bytes of `hash::hashv(&["permissioned-transfer:validation-pubkeys"])`
+impl Value for ValidationPubkeys {
+    const TYPE: Discriminator = Discriminator::new([250, 175, 124, 64, 235, 120, 63, 195]);
+}
+
+#[cfg(test)]
+mod test {
+    use {super::*, crate::{DISCRIMINATOR_LENGTH, NAMESPACE}, solana_program::hash};
+
+    #[test]
+    fn discriminator() {
+        let preimage = hash::hashv(&[&format!("{NAMESPACE}:validation-pubkeys").as_bytes()]);
+        let discriminator = Discriminator::try_from(&preimage.as_ref()[..DISCRIMINATOR_LENGTH]).unwrap();
+        assert_eq!(discriminator, ValidationPubkeys::TYPE);
+    }
+}

--- a/token/permissioned-transfer/src/state.rs
+++ b/token/permissioned-transfer/src/state.rs
@@ -33,7 +33,7 @@ mod test {
 
     #[test]
     fn discriminator() {
-        let preimage = hash::hashv(&[&format!("{NAMESPACE}:validation-pubkeys").as_bytes()]);
+        let preimage = hash::hashv(&[format!("{NAMESPACE}:validation-pubkeys").as_bytes()]);
         let discriminator =
             Discriminator::try_from(&preimage.as_ref()[..DISCRIMINATOR_LENGTH]).unwrap();
         assert_eq!(discriminator, ValidationPubkeys::TYPE);

--- a/token/permissioned-transfer/src/state.rs
+++ b/token/permissioned-transfer/src/state.rs
@@ -3,7 +3,10 @@
 use {
     crate::tlv::{pod_from_bytes, pod_from_bytes_mut, Discriminator, Value},
     bytemuck::{Pod, Zeroable},
-    solana_program::{program_error::ProgramError, pubkey::Pubkey},
+    solana_program::{
+        account_info::AccountInfo, instruction::AccountMeta, program_error::ProgramError,
+        pubkey::Pubkey,
+    },
 };
 
 pub(crate) const MAX_NUM_KEYS: usize = 3;
@@ -19,7 +22,66 @@ pub struct ExtraAccountMetas {
     pub length: u16,
     /// Slice of required pubkeys to validate a transfer, along with the normal
     /// checked-transfer accounts and this account.
-    pub pubkeys: [Pubkey; MAX_NUM_KEYS],
+    pub metas: [PodAccountMeta; MAX_NUM_KEYS],
+}
+
+/// The standard `bool` is not a `Pod`, define a replacement that is
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+#[repr(transparent)]
+pub struct PodBool(u8);
+impl From<bool> for PodBool {
+    fn from(b: bool) -> Self {
+        Self(if b { 1 } else { 0 })
+    }
+}
+impl From<&PodBool> for bool {
+    fn from(b: &PodBool) -> Self {
+        b.0 != 0
+    }
+}
+impl From<PodBool> for bool {
+    fn from(b: PodBool) -> Self {
+        b.0 != 0
+    }
+}
+
+/// The standard `AccountMeta` is not a `Pod`, define a replacement that is
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+pub struct PodAccountMeta {
+    /// The pubkey of the account
+    pub pubkey: Pubkey,
+    /// Whether the account should sign
+    pub is_signer: PodBool,
+    /// Whether the account should be writable
+    pub is_writable: PodBool,
+}
+impl PartialEq<AccountInfo<'_>> for PodAccountMeta {
+    fn eq(&self, other: &AccountInfo) -> bool {
+        self.pubkey == *other.key
+            && self.is_signer == other.is_signer.into()
+            && self.is_writable == other.is_writable.into()
+    }
+}
+
+impl From<&AccountInfo<'_>> for PodAccountMeta {
+    fn from(account_info: &AccountInfo) -> Self {
+        Self {
+            pubkey: *account_info.key,
+            is_signer: account_info.is_signer.into(),
+            is_writable: account_info.is_writable.into(),
+        }
+    }
+}
+
+impl From<PodAccountMeta> for AccountMeta {
+    fn from(meta: PodAccountMeta) -> Self {
+        Self {
+            pubkey: meta.pubkey,
+            is_signer: meta.is_signer.into(),
+            is_writable: meta.is_writable.into(),
+        }
+    }
 }
 
 /// First 8 bytes of `hash::hashv(&["permissioned-transfer:validation-pubkeys"])`

--- a/token/permissioned-transfer/src/state.rs
+++ b/token/permissioned-transfer/src/state.rs
@@ -1,99 +1,30 @@
 //! State transition types
 
 use {
-    crate::tlv::{pod_from_bytes, pod_from_bytes_mut, Discriminator, Value},
-    bytemuck::{Pod, Zeroable},
-    solana_program::{
-        account_info::AccountInfo, instruction::AccountMeta, program_error::ProgramError,
-        pubkey::Pubkey,
+    crate::{
+        pod::{PodAccountMeta, PodSliceMut},
+        tlv::{Discriminator, Value},
     },
+    solana_program::program_error::ProgramError,
 };
 
-pub(crate) const MAX_NUM_KEYS: usize = 3;
 /// State for all pubkeys required to validate a transfer
-// TODO this should work with any number of pubkeys, but I'm being lazy and want
-// to use bytemuck to quickly prototype something.
-// We need to implement more functions on this in order to properly add to the slice
-// and all that, but it'll take some more time to get that working.
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
-pub struct ExtraAccountMetas {
-    /// Number of `Pubkey` instances in the slice
-    pub length: u16,
-    /// Slice of required pubkeys to validate a transfer, along with the normal
-    /// checked-transfer accounts and this account.
-    pub metas: [PodAccountMeta; MAX_NUM_KEYS],
-}
+pub type ExtraAccountMetas<'a> = PodSliceMut<'a, PodAccountMeta>;
 
-/// The standard `bool` is not a `Pod`, define a replacement that is
-#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
-#[repr(transparent)]
-pub struct PodBool(u8);
-impl From<bool> for PodBool {
-    fn from(b: bool) -> Self {
-        Self(if b { 1 } else { 0 })
-    }
-}
-impl From<&PodBool> for bool {
-    fn from(b: &PodBool) -> Self {
-        b.0 != 0
-    }
-}
-impl From<PodBool> for bool {
-    fn from(b: PodBool) -> Self {
-        b.0 != 0
-    }
-}
-
-/// The standard `AccountMeta` is not a `Pod`, define a replacement that is
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
-pub struct PodAccountMeta {
-    /// The pubkey of the account
-    pub pubkey: Pubkey,
-    /// Whether the account should sign
-    pub is_signer: PodBool,
-    /// Whether the account should be writable
-    pub is_writable: PodBool,
-}
-impl PartialEq<AccountInfo<'_>> for PodAccountMeta {
-    fn eq(&self, other: &AccountInfo) -> bool {
-        self.pubkey == *other.key
-            && self.is_signer == other.is_signer.into()
-            && self.is_writable == other.is_writable.into()
-    }
-}
-
-impl From<&AccountInfo<'_>> for PodAccountMeta {
-    fn from(account_info: &AccountInfo) -> Self {
-        Self {
-            pubkey: *account_info.key,
-            is_signer: account_info.is_signer.into(),
-            is_writable: account_info.is_writable.into(),
-        }
-    }
-}
-
-impl From<PodAccountMeta> for AccountMeta {
-    fn from(meta: PodAccountMeta) -> Self {
-        Self {
-            pubkey: meta.pubkey,
-            is_signer: meta.is_signer.into(),
-            is_writable: meta.is_writable.into(),
-        }
-    }
-}
-
-/// First 8 bytes of `hash::hashv(&["permissioned-transfer:validation-pubkeys"])`
-impl Value for ExtraAccountMetas {
+impl<'a> Value for ExtraAccountMetas<'a> {
+    /// First 8 bytes of `hash::hashv(&["permissioned-transfer:validation-pubkeys"])`
     const TYPE: Discriminator = Discriminator::new([250, 175, 124, 64, 235, 120, 63, 195]);
 
     fn try_from_bytes(bytes: &[u8]) -> Result<&Self, ProgramError> {
-        pod_from_bytes(bytes)
+        Self::unpack(bytes)
     }
 
     fn try_from_bytes_mut(bytes: &mut [u8]) -> Result<&mut Self, ProgramError> {
-        pod_from_bytes_mut(bytes)
+        Self::unpack(bytes)
+    }
+
+    fn initialize(&mut self) {
+        self.initialize()
     }
 }
 

--- a/token/permissioned-transfer/src/state.rs
+++ b/token/permissioned-transfer/src/state.rs
@@ -25,12 +25,17 @@ impl Value for ValidationPubkeys {
 
 #[cfg(test)]
 mod test {
-    use {super::*, crate::{DISCRIMINATOR_LENGTH, NAMESPACE}, solana_program::hash};
+    use {
+        super::*,
+        crate::{DISCRIMINATOR_LENGTH, NAMESPACE},
+        solana_program::hash,
+    };
 
     #[test]
     fn discriminator() {
         let preimage = hash::hashv(&[&format!("{NAMESPACE}:validation-pubkeys").as_bytes()]);
-        let discriminator = Discriminator::try_from(&preimage.as_ref()[..DISCRIMINATOR_LENGTH]).unwrap();
+        let discriminator =
+            Discriminator::try_from(&preimage.as_ref()[..DISCRIMINATOR_LENGTH]).unwrap();
         assert_eq!(discriminator, ValidationPubkeys::TYPE);
     }
 }

--- a/token/permissioned-transfer/src/state.rs
+++ b/token/permissioned-transfer/src/state.rs
@@ -2,30 +2,32 @@
 
 use {
     crate::{
-        pod::{PodAccountMeta, PodSliceMut},
-        tlv::{Discriminator, Value},
+        pod::{PodAccountMeta, PodSlice, PodSliceMut},
+        tlv::{Discriminator, TlvType},
     },
     solana_program::program_error::ProgramError,
 };
 
-/// State for all pubkeys required to validate a transfer
-pub type ExtraAccountMetas<'a> = PodSliceMut<'a, PodAccountMeta>;
+/// State for all pubkeys required to validate a transfer, accessed through a `PodSlice`
+pub struct ExtraAccountMetas;
+impl ExtraAccountMetas {
+    /// Unpack a buffer with slice data as a pod slice
+    pub fn unpack(data: &[u8]) -> Result<PodSlice<'_, PodAccountMeta>, ProgramError> {
+        PodSlice::unpack(data)
+    }
+    /// Initialize pod slice data into the given buffer
+    pub fn init(data: &mut [u8]) -> Result<PodSliceMut<'_, PodAccountMeta>, ProgramError> {
+        PodSliceMut::unpack(data, /* init */ true)
+    }
+    /// Get the byte size required to hold `num_items` items
+    pub fn byte_size_of(num_items: usize) -> Result<usize, ProgramError> {
+        PodSlice::<PodAccountMeta>::byte_size_of(num_items)
+    }
+}
 
-impl<'a> Value for ExtraAccountMetas<'a> {
+impl TlvType for ExtraAccountMetas {
     /// First 8 bytes of `hash::hashv(&["permissioned-transfer:validation-pubkeys"])`
     const TYPE: Discriminator = Discriminator::new([250, 175, 124, 64, 235, 120, 63, 195]);
-
-    fn try_from_bytes(bytes: &[u8]) -> Result<&Self, ProgramError> {
-        Self::unpack(bytes)
-    }
-
-    fn try_from_bytes_mut(bytes: &mut [u8]) -> Result<&mut Self, ProgramError> {
-        Self::unpack(bytes)
-    }
-
-    fn initialize(&mut self) {
-        self.initialize()
-    }
 }
 
 #[cfg(test)]

--- a/token/permissioned-transfer/src/state.rs
+++ b/token/permissioned-transfer/src/state.rs
@@ -14,7 +14,7 @@ pub(crate) const MAX_NUM_KEYS: usize = 3;
 // and all that, but it'll take some more time to get that working.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
-pub struct ValidationPubkeys {
+pub struct ExtraAccountMetas {
     /// Number of `Pubkey` instances in the slice
     pub length: u16,
     /// Slice of required pubkeys to validate a transfer, along with the normal
@@ -23,7 +23,7 @@ pub struct ValidationPubkeys {
 }
 
 /// First 8 bytes of `hash::hashv(&["permissioned-transfer:validation-pubkeys"])`
-impl Value for ValidationPubkeys {
+impl Value for ExtraAccountMetas {
     const TYPE: Discriminator = Discriminator::new([250, 175, 124, 64, 235, 120, 63, 195]);
 
     fn try_from_bytes(bytes: &[u8]) -> Result<&Self, ProgramError> {
@@ -48,6 +48,6 @@ mod test {
         let preimage = hash::hashv(&[format!("{NAMESPACE}:validation-pubkeys").as_bytes()]);
         let discriminator =
             Discriminator::try_from(&preimage.as_ref()[..DISCRIMINATOR_LENGTH]).unwrap();
-        assert_eq!(discriminator, ValidationPubkeys::TYPE);
+        assert_eq!(discriminator, ExtraAccountMetas::TYPE);
     }
 }

--- a/token/permissioned-transfer/src/tlv.rs
+++ b/token/permissioned-transfer/src/tlv.rs
@@ -1,0 +1,827 @@
+//! TLV structure manipulation
+
+use {
+    crate::{DISCRIMINATOR_LENGTH, error::PermissionedTransferError},
+    bytemuck::{Pod, Zeroable},
+    solana_program::program_error::ProgramError,
+    std::mem::size_of,
+};
+
+/// Convert a slice into a `Pod` (zero copy)
+pub fn pod_from_bytes<T: Pod>(bytes: &[u8]) -> Result<&T, ProgramError> {
+    bytemuck::try_from_bytes(bytes).map_err(|_| ProgramError::InvalidArgument)
+}
+/// Convert a slice into a mutable `Pod` (zero copy)
+pub fn pod_from_bytes_mut<T: Pod>(bytes: &mut [u8]) -> Result<&mut T, ProgramError> {
+    bytemuck::try_from_bytes_mut(bytes).map_err(|_| ProgramError::InvalidArgument)
+}
+
+/// Simple macro for implementing conversion functions between Pod* ints and standard ints.
+///
+/// The standard int types can cause alignment issues when placed in a `Pod`,
+/// so these replacements are usable in all `Pod`s.
+macro_rules! impl_int_conversion {
+    ($P:ty, $I:ty) => {
+        impl From<$I> for $P {
+            fn from(n: $I) -> Self {
+                Self(n.to_le_bytes())
+            }
+        }
+        impl From<$P> for $I {
+            fn from(pod: $P) -> Self {
+                Self::from_le_bytes(pod.0)
+            }
+        }
+    };
+}
+
+/// `u32` type that can be used in `Pod`s
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+#[repr(transparent)]
+pub struct PodU32([u8; 4]);
+impl_int_conversion!(PodU32, u32);
+
+/// Length in TLV structure
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+#[repr(transparent)]
+pub struct Length(PodU32);
+impl TryFrom<Length> for usize {
+    type Error = ProgramError;
+    fn try_from(n: Length) -> Result<Self, Self::Error> {
+        Self::try_from(u32::from(n.0))
+            .map_err(|_| ProgramError::AccountDataTooSmall)
+    }
+}
+impl TryFrom<usize> for Length {
+    type Error = ProgramError;
+    fn try_from(n: usize) -> Result<Self, Self::Error> {
+        u32::try_from(n)
+            .map(|v| Self(PodU32::from(v)))
+            .map_err(|_| ProgramError::AccountDataTooSmall)
+    }
+}
+
+/// Helper function to get the current TlvIndices from the current spot
+fn get_tlv_indices(type_start: usize) -> TlvIndices {
+    let length_start = type_start.saturating_add(size_of::<Discriminator>());
+    let value_start = length_start.saturating_add(size_of::<Length>());
+    TlvIndices {
+        type_start,
+        length_start,
+        value_start,
+    }
+}
+
+/// Helper struct for returning the indices of the type, length, and value in
+/// a TLV entry
+#[derive(Debug)]
+struct TlvIndices {
+    pub type_start: usize,
+    pub length_start: usize,
+    pub value_start: usize,
+}
+fn get_value_indices<V: Value>(
+    tlv_data: &[u8],
+    init: bool,
+) -> Result<TlvIndices, ProgramError> {
+    let mut start_index = 0;
+    while start_index < tlv_data.len() {
+        let tlv_indices = get_tlv_indices(start_index);
+        if tlv_data.len() < tlv_indices.value_start {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        let discriminator = Discriminator::try_from(&tlv_data[tlv_indices.type_start..tlv_indices.length_start])?;
+        if discriminator == V::TYPE {
+            // found an instance of the extension that we're initializing, return!
+            return Ok(tlv_indices);
+        // got to an empty spot, init here, or error if we're searching, since
+        // nothing is written after an Uninitialized spot
+        } else if discriminator == Discriminator::UNINITIALIZED {
+            if init {
+                return Ok(tlv_indices);
+            } else {
+                return Err(PermissionedTransferError::TypeNotFound.into());
+            }
+        } else {
+            let length = pod_from_bytes::<Length>(
+                &tlv_data[tlv_indices.length_start..tlv_indices.value_start],
+            )?;
+            let value_end_index = tlv_indices.value_start.saturating_add(usize::try_from(*length)?);
+            start_index = value_end_index;
+        }
+    }
+    Err(ProgramError::InvalidAccountData)
+}
+
+fn get_discriminators(tlv_data: &[u8]) -> Result<Vec<Discriminator>, ProgramError> {
+    let mut discriminators = vec![];
+    let mut start_index = 0;
+    while start_index < tlv_data.len() {
+        let tlv_indices = get_tlv_indices(start_index);
+        if tlv_data.len() < tlv_indices.length_start {
+            // we got to the end, but there might be some uninitialized data after
+            let remainder = &tlv_data[tlv_indices.type_start..];
+            if remainder.iter().all(|&x| x == 0) {
+                return Ok(discriminators)
+            } else {
+                return Err(ProgramError::InvalidAccountData)
+            }
+        }
+        let discriminator = Discriminator::try_from(&tlv_data[tlv_indices.type_start..tlv_indices.length_start])?;
+        if discriminator == Discriminator::UNINITIALIZED {
+            return Ok(discriminators);
+        } else {
+            if tlv_data.len() < tlv_indices.value_start {
+                // not enough bytes to store the length, malformed
+                return Err(ProgramError::InvalidAccountData);
+            }
+            discriminators.push(discriminator);
+            let length = pod_from_bytes::<Length>(
+                &tlv_data[tlv_indices.length_start..tlv_indices.value_start],
+            )?;
+
+            let value_end_index = tlv_indices.value_start.saturating_add(usize::try_from(*length)?);
+            if value_end_index > tlv_data.len() {
+                // value blows past the size of the slice, malformed
+                return Err(ProgramError::InvalidAccountData);
+            }
+            start_index = value_end_index;
+        }
+    }
+    Ok(discriminators)
+}
+
+fn get_value<V: Value>(tlv_data: &[u8]) -> Result<&V, ProgramError> {
+    let TlvIndices {
+        type_start: _,
+        length_start,
+        value_start,
+    } = get_value_indices::<V>(tlv_data, false)?;
+    // get_value_indices has checked that tlv_data is long enough to include these indices
+    let length = pod_from_bytes::<Length>(&tlv_data[length_start..value_start])?;
+    let value_end = value_start.saturating_add(usize::try_from(*length)?);
+    if tlv_data.len() < value_end {
+        return Err(ProgramError::InvalidAccountData);
+    }
+    pod_from_bytes::<V>(&tlv_data[value_start..value_end])
+}
+
+fn check_initialized(tlv_data: &[u8]) -> Result<(), ProgramError> {
+    let discriminators = get_discriminators(tlv_data)?;
+    if discriminators.is_empty() {
+        Err(ProgramError::InvalidAccountData)
+    } else {
+        Ok(())
+    }
+}
+
+fn check_uninitialized(tlv_data: &[u8]) -> Result<(), ProgramError> {
+    let discriminators = get_discriminators(tlv_data)?;
+    if discriminators.is_empty() {
+        Ok(())
+    } else {
+        Err(ProgramError::InvalidAccountData)
+    }
+}
+
+/// Trait for all TLV state
+pub trait TlvState {
+    /// Get the full buffer containing all TLV data
+    fn get_data(&self) -> &[u8];
+
+    /// Unpack a portion of the TLV data as the desired type
+    fn get_value<V: Value>(&self) -> Result<&V, ProgramError> {
+        get_value::<V>(self.get_data())
+    }
+
+    /// Iterates through the TLV entries, returning only the types
+    fn get_discriminators(&self) -> Result<Vec<Discriminator>, ProgramError> {
+        get_discriminators(self.get_data())
+    }
+}
+
+/// Encapsulates owned TLV data
+#[derive(Debug, PartialEq)]
+pub struct TlvStateOwned {
+    /// Raw TLV data, deserialized on demand
+    data: Vec<u8>,
+}
+impl TlvStateOwned {
+    /// Unpacks TLV state data
+    ///
+    /// Fails if no state is initialized or if data is too small
+    pub fn unpack(data: Vec<u8>) -> Result<Self, ProgramError> {
+        check_initialized(&data)?;
+        Ok(Self { data })
+    }
+}
+
+impl TlvState for TlvStateOwned {
+    fn get_data(&self) -> &[u8] {
+        &self.data
+    }
+}
+
+/// Encapsulates immutable base state data (mint or account) with possible extensions
+#[derive(Debug, PartialEq)]
+pub struct TlvStateBorrowed<'data> {
+    /// Slice of data containing all TLV data, deserialized on demand
+    data: &'data [u8],
+}
+impl<'data> TlvStateBorrowed<'data> {
+    /// Unpacks TLV state data
+    ///
+    /// Fails if no state is initialized or if data is too small
+    pub fn unpack(data: &'data [u8]) -> Result<Self, ProgramError> {
+        check_initialized(data)?;
+        Ok(Self { data, })
+    }
+}
+impl<'a> TlvState for TlvStateBorrowed<'a> {
+    fn get_data(&self) -> &[u8] {
+        self.data
+    }
+}
+
+/// Encapsulates mutable base state data (mint or account) with possible extensions
+#[derive(Debug, PartialEq)]
+pub struct TlvStateMut<'data> {
+    /// Slice of data containing all TLV data, deserialized on demand
+    data: &'data mut [u8],
+}
+impl<'data> TlvStateMut<'data> {
+    /// Unpacks TLV state data
+    ///
+    /// Fails if no state is initialized or if data is too small
+    pub fn unpack(data: &'data mut [u8]) -> Result<Self, ProgramError> {
+        check_initialized(&data)?;
+        Ok(Self { data })
+    }
+
+    /// Unpacks uninitialized TLV state
+    ///
+    /// Fails if any state has been initialized
+    pub fn unpack_uninitialized(data: &'data mut [u8]) -> Result<Self, ProgramError> {
+        check_uninitialized(&data)?;
+        Ok(Self { data })
+    }
+
+    /// Unpack a portion of the TLV data as the desired type that allows modifying the type
+    pub fn get_value_mut<V: Value>(&mut self) -> Result<&mut V, ProgramError> {
+        let TlvIndices {
+            type_start,
+            length_start,
+            value_start,
+        } = get_value_indices::<V>(self.data, false)?;
+
+        if self.data[type_start..].len() < size_of::<V>() {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        let length = pod_from_bytes::<Length>(&self.data[length_start..value_start])?;
+        let value_end = value_start.saturating_add(usize::try_from(*length)?);
+        pod_from_bytes_mut::<V>(&mut self.data[value_start..value_end])
+    }
+
+    /// Packs the default extension data into an open slot if not already found in the
+    /// data buffer. If extension is already found in the buffer, it overwrites the existing
+    /// extension with the default state if `overwrite` is set. If extension found, but
+    /// `overwrite` is not set, it returns error.
+    pub fn init_value<V: Value>(
+        &mut self,
+        overwrite: bool,
+    ) -> Result<&mut V, ProgramError> {
+        let TlvIndices {
+            type_start,
+            length_start,
+            value_start,
+        } = get_value_indices::<V>(self.data, true)?;
+
+        if self.data[type_start..].len() < size_of::<V>() {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        let discriminator = Discriminator::try_from(&self.data[type_start..length_start])?;
+        if discriminator == Discriminator::UNINITIALIZED || overwrite {
+            // write type
+            let discriminator_ref = &mut self.data[type_start..length_start];
+            discriminator_ref.copy_from_slice(&V::TYPE.as_ref());
+            // write length
+            let length_ref =
+                pod_from_bytes_mut::<Length>(&mut self.data[length_start..value_start])?;
+            // maybe this becomes smarter later for dynamically sized extensions
+            let length = size_of::<V>();
+            *length_ref = Length::try_from(length)?;
+
+            let value_end = value_start.saturating_add(length);
+            let extension_ref =
+                pod_from_bytes_mut::<V>(&mut self.data[value_start..value_end])?;
+            *extension_ref = V::default();
+            Ok(extension_ref)
+        } else {
+            // extension is already initialized, but no overwrite permission
+            Err(PermissionedTransferError::TypeAlreadyExists.into())
+        }
+    }
+}
+impl<'a> TlvState for TlvStateMut<'a> {
+    fn get_data(&self) -> &[u8] {
+        self.data
+    }
+}
+
+/// Discriminator used as the type in the TLV structure
+/// Type in TLV structure
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+#[repr(transparent)]
+pub struct Discriminator([u8; DISCRIMINATOR_LENGTH]);
+impl Discriminator {
+    const UNINITIALIZED: Self = Self::new([0; DISCRIMINATOR_LENGTH]);
+    /// Creates a discriminator from an array
+    pub const fn new(value: [u8; DISCRIMINATOR_LENGTH]) -> Self {
+        Self(value)
+    }
+}
+impl AsRef<[u8]> for Discriminator {
+    fn as_ref(&self) -> &[u8] {
+        &self.0[..]
+    }
+}
+impl From<u64> for Discriminator {
+    fn from(from: u64) -> Self {
+        Self(from.to_le_bytes())
+    }
+}
+impl From<[u8; DISCRIMINATOR_LENGTH]> for Discriminator {
+    fn from(from: [u8; DISCRIMINATOR_LENGTH]) -> Self {
+        Self(from)
+    }
+}
+impl TryFrom<&[u8]> for Discriminator {
+    type Error = ProgramError;
+    fn try_from(a: &[u8]) -> Result<Self, Self::Error> {
+        <[u8; DISCRIMINATOR_LENGTH]>::try_from(a).map(Self::from).map_err(|_| ProgramError::InvalidAccountData)
+    }
+}
+
+/// Trait to be implemented by all value types in the TLV structure, specifying
+/// the discriminator to check against
+pub trait Value: Pod + Default {
+    /// Associated value type enum, checked at the start of TLV entries
+    const TYPE: Discriminator;
+}
+
+#[cfg(test)]
+mod test {
+    use {
+        super::*,
+        crate::state::ValidationPubkeys,
+    };
+
+    const TEST_BUFFER: &[u8] = &[
+        1, 1, 1, 1, 1, 1, 1, 1, // discriminator
+        32, 0, 0, 0, // length
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, // value
+        0, 0, // empty, not enough for a discriminator
+    ];
+
+    #[repr(C)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+    struct TestValue {
+        data: [u8; 32]
+    }
+    impl Value for TestValue {
+        const TYPE: Discriminator = Discriminator::new([1; DISCRIMINATOR_LENGTH]);
+    }
+
+    #[repr(transparent)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+    struct TestEmptyValue;
+    impl Value for TestEmptyValue {
+        const TYPE: Discriminator = Discriminator::new([2; DISCRIMINATOR_LENGTH]);
+    }
+
+    #[test]
+    fn unpack_opaque_buffer() {
+        let state = TlvStateBorrowed::unpack(TEST_BUFFER).unwrap();
+        let value = state.get_value::<TestValue>().unwrap();
+        assert_eq!(value.data, [1; 32]);
+        assert_eq!(
+            state.get_value::<TestEmptyValue>(),
+            Err(ProgramError::InvalidAccountData)
+        );
+
+        let mut test_buffer = TEST_BUFFER.to_vec();
+        let state = TlvStateMut::unpack(&mut test_buffer).unwrap();
+        let value = state.get_value::<TestValue>().unwrap();
+        assert_eq!(value.data, [1; 32]);
+        let state = TlvStateOwned::unpack(test_buffer).unwrap();
+        let value = state.get_value::<TestValue>().unwrap();
+        assert_eq!(value.data, [1; 32]);
+    }
+
+    #[test]
+    fn fail_unpack_opaque_buffer() {
+        // input buffer too small
+        let mut buffer = vec![0, 3];
+        assert_eq!(
+            TlvStateBorrowed::unpack(&buffer),
+            Err(ProgramError::InvalidAccountData)
+        );
+        assert_eq!(
+            TlvStateMut::unpack(&mut buffer),
+            Err(ProgramError::InvalidAccountData)
+        );
+        assert_eq!(
+            TlvStateMut::unpack_uninitialized(&mut buffer),
+            Err(ProgramError::InvalidAccountData)
+        );
+
+        /*
+        // tweak the extension type
+        let mut buffer = MINT_WITH_EXTENSION.to_vec();
+        buffer[BASE_ACCOUNT_LENGTH + 1] = 2;
+        let state = StateWithExtensions::<Mint>::unpack(&buffer).unwrap();
+        assert_eq!(
+            state.get_extension::<TransferFeeConfig>(),
+            Err(ProgramError::Custom(
+                TokenError::ExtensionTypeMismatch as u32
+            ))
+        );
+
+        // tweak the length, too big
+        let mut buffer = MINT_WITH_EXTENSION.to_vec();
+        buffer[BASE_ACCOUNT_LENGTH + 3] = 100;
+        let state = StateWithExtensions::<Mint>::unpack(&buffer).unwrap();
+        assert_eq!(
+            state.get_extension::<TransferFeeConfig>(),
+            Err(ProgramError::InvalidAccountData)
+        );
+
+        // tweak the length, too small
+        let mut buffer = MINT_WITH_EXTENSION.to_vec();
+        buffer[BASE_ACCOUNT_LENGTH + 3] = 10;
+        let state = StateWithExtensions::<Mint>::unpack(&buffer).unwrap();
+        assert_eq!(
+            state.get_extension::<TransferFeeConfig>(),
+            Err(ProgramError::InvalidAccountData)
+        );
+
+        // data buffer is too small
+        let buffer = &MINT_WITH_EXTENSION[..MINT_WITH_EXTENSION.len() - 1];
+        let state = StateWithExtensions::<Mint>::unpack(buffer).unwrap();
+        assert_eq!(
+            state.get_extension::<MintCloseAuthority>(),
+            Err(ProgramError::InvalidAccountData)
+        );
+        */
+    }
+
+    #[test]
+    fn get_discriminators_with_opaque_buffer() {
+        // incorrect due to the length
+        assert_eq!(
+            get_discriminators(&[1, 0, 1, 1]).unwrap_err(),
+            ProgramError::InvalidAccountData,
+        );
+        // correct due to the good discriminator length and zero length
+        assert_eq!(
+            get_discriminators(&[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
+            vec![Discriminator::try_from(1).unwrap()]
+        );
+        // correct since it's just uninitialized data
+        assert_eq!(get_discriminators(&[0, 0, 0, 0, 0, 0, 0, 0]).unwrap(), vec![]);
+    }
+
+    #[test]
+    fn value_pack_unpack() {
+        /*
+        let mint_size = ExtensionType::get_account_len::<Mint>(&[
+            ExtensionType::MintCloseAuthority,
+            ExtensionType::TransferFeeConfig,
+        ]);
+        let mut buffer = vec![0; mint_size];
+
+        // fail unpack
+        assert_eq!(
+            StateWithExtensionsMut::<Mint>::unpack(&mut buffer),
+            Err(ProgramError::UninitializedAccount),
+        );
+
+        let mut state = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut buffer).unwrap();
+        // fail init account extension
+        assert_eq!(
+            state.init_extension::<TransferFeeAmount>(true),
+            Err(ProgramError::InvalidAccountData),
+        );
+
+        // success write extension
+        let close_authority = OptionalNonZeroPubkey::try_from(Some(Pubkey::new(&[1; 32]))).unwrap();
+        let extension = state.init_extension::<MintCloseAuthority>(true).unwrap();
+        extension.close_authority = close_authority;
+        assert_eq!(
+            &state.get_extension_types().unwrap(),
+            &[ExtensionType::MintCloseAuthority]
+        );
+
+        // fail init extension when already initialized
+        assert_eq!(
+            state.init_extension::<MintCloseAuthority>(false),
+            Err(ProgramError::Custom(
+                TokenError::ExtensionAlreadyInitialized as u32
+            ))
+        );
+
+        // fail unpack as account, a mint extension was written
+        assert_eq!(
+            StateWithExtensionsMut::<Account>::unpack_uninitialized(&mut buffer),
+            Err(ProgramError::Custom(
+                TokenError::ExtensionBaseMismatch as u32
+            ))
+        );
+
+        // fail unpack again, still no base data
+        assert_eq!(
+            StateWithExtensionsMut::<Mint>::unpack(&mut buffer.clone()),
+            Err(ProgramError::UninitializedAccount),
+        );
+
+        // write base mint
+        let mut state = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut buffer).unwrap();
+        state.base = TEST_MINT;
+        state.pack_base();
+        state.init_account_type().unwrap();
+
+        // check raw buffer
+        let mut expect = TEST_MINT_SLICE.to_vec();
+        expect.extend_from_slice(&[0; BASE_ACCOUNT_LENGTH - Mint::LEN]); // padding
+        expect.push(AccountType::Mint.into());
+        expect.extend_from_slice(&(ExtensionType::MintCloseAuthority as u16).to_le_bytes());
+        expect
+            .extend_from_slice(&(size_of::<MintCloseAuthority>() as u16).to_le_bytes());
+        expect.extend_from_slice(&[1; 32]); // data
+        expect.extend_from_slice(&[0; size_of::<ExtensionType>()]);
+        expect.extend_from_slice(&[0; size_of::<Length>()]);
+        expect.extend_from_slice(&[0; size_of::<TransferFeeConfig>()]);
+        assert_eq!(expect, buffer);
+
+        // unpack uninitialized will now fail because the Mint is now initialized
+        assert_eq!(
+            StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut buffer.clone()),
+            Err(TokenError::AlreadyInUse.into()),
+        );
+
+        // check unpacking
+        let mut state = StateWithExtensionsMut::<Mint>::unpack(&mut buffer).unwrap();
+
+        // update base
+        state.base = TEST_MINT;
+        state.base.supply += 100;
+        state.pack_base();
+
+        // check unpacking
+        let mut unpacked_extension = state.get_extension_mut::<MintCloseAuthority>().unwrap();
+        assert_eq!(*unpacked_extension, MintCloseAuthority { close_authority });
+
+        // update extension
+        let close_authority = OptionalNonZeroPubkey::try_from(None).unwrap();
+        unpacked_extension.close_authority = close_authority;
+
+        // check updates are propagated
+        let base = state.base;
+        let state = StateWithExtensions::<Mint>::unpack(&buffer).unwrap();
+        assert_eq!(state.base, base);
+        let unpacked_extension = state.get_extension::<MintCloseAuthority>().unwrap();
+        assert_eq!(*unpacked_extension, MintCloseAuthority { close_authority });
+
+        // check raw buffer
+        let mut expect = vec![0; Mint::LEN];
+        Mint::pack_into_slice(&base, &mut expect);
+        expect.extend_from_slice(&[0; BASE_ACCOUNT_LENGTH - Mint::LEN]); // padding
+        expect.push(AccountType::Mint.into());
+        expect.extend_from_slice(&(ExtensionType::MintCloseAuthority as u16).to_le_bytes());
+        expect
+            .extend_from_slice(&(size_of::<MintCloseAuthority>() as u16).to_le_bytes());
+        expect.extend_from_slice(&[0; 32]);
+        expect.extend_from_slice(&[0; size_of::<ExtensionType>()]);
+        expect.extend_from_slice(&[0; size_of::<Length>()]);
+        expect.extend_from_slice(&[0; size_of::<TransferFeeConfig>()]);
+        assert_eq!(expect, buffer);
+
+        // fail unpack as an account
+        assert_eq!(
+            StateWithExtensions::<Account>::unpack(&buffer),
+            Err(ProgramError::InvalidAccountData),
+        );
+
+        let mut state = StateWithExtensionsMut::<Mint>::unpack(&mut buffer).unwrap();
+        // init one more extension
+        let mint_transfer_fee = test_transfer_fee_config();
+        let new_extension = state.init_extension::<TransferFeeConfig>(true).unwrap();
+        new_extension.transfer_fee_config_authority =
+            mint_transfer_fee.transfer_fee_config_authority;
+        new_extension.withdraw_withheld_authority = mint_transfer_fee.withdraw_withheld_authority;
+        new_extension.withheld_amount = mint_transfer_fee.withheld_amount;
+        new_extension.older_transfer_fee = mint_transfer_fee.older_transfer_fee;
+        new_extension.newer_transfer_fee = mint_transfer_fee.newer_transfer_fee;
+
+        assert_eq!(
+            &state.get_extension_types().unwrap(),
+            &[
+                ExtensionType::MintCloseAuthority,
+                ExtensionType::TransferFeeConfig
+            ]
+        );
+
+        // check raw buffer
+        let mut expect = vec![0; Mint::LEN];
+        Mint::pack_into_slice(&base, &mut expect);
+        expect.extend_from_slice(&[0; BASE_ACCOUNT_LENGTH - Mint::LEN]); // padding
+        expect.push(AccountType::Mint.into());
+        expect.extend_from_slice(&(ExtensionType::MintCloseAuthority as u16).to_le_bytes());
+        expect
+            .extend_from_slice(&(size_of::<MintCloseAuthority>() as u16).to_le_bytes());
+        expect.extend_from_slice(&[0; 32]); // data
+        expect.extend_from_slice(&(ExtensionType::TransferFeeConfig as u16).to_le_bytes());
+        expect.extend_from_slice(&(size_of::<TransferFeeConfig>() as u16).to_le_bytes());
+        expect.extend_from_slice(pod_bytes_of(&mint_transfer_fee));
+        assert_eq!(expect, buffer);
+
+        // fail to init one more extension that does not fit
+        let mut state = StateWithExtensionsMut::<Mint>::unpack(&mut buffer).unwrap();
+        assert_eq!(
+            state.init_extension::<MintPaddingTest>(true),
+            Err(ProgramError::InvalidAccountData),
+        );
+        */
+    }
+
+    #[test]
+    fn value_any_order() {
+        /*
+        let mint_size = ExtensionType::get_account_len::<Mint>(&[
+            ExtensionType::MintCloseAuthority,
+            ExtensionType::TransferFeeConfig,
+        ]);
+        let mut buffer = vec![0; mint_size];
+
+        let mut state = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut buffer).unwrap();
+        // write extensions
+        let close_authority = OptionalNonZeroPubkey::try_from(Some(Pubkey::new(&[1; 32]))).unwrap();
+        let extension = state.init_extension::<MintCloseAuthority>(true).unwrap();
+        extension.close_authority = close_authority;
+
+        let mint_transfer_fee = test_transfer_fee_config();
+        let extension = state.init_extension::<TransferFeeConfig>(true).unwrap();
+        extension.transfer_fee_config_authority = mint_transfer_fee.transfer_fee_config_authority;
+        extension.withdraw_withheld_authority = mint_transfer_fee.withdraw_withheld_authority;
+        extension.withheld_amount = mint_transfer_fee.withheld_amount;
+        extension.older_transfer_fee = mint_transfer_fee.older_transfer_fee;
+        extension.newer_transfer_fee = mint_transfer_fee.newer_transfer_fee;
+
+        assert_eq!(
+            &state.get_extension_types().unwrap(),
+            &[
+                ExtensionType::MintCloseAuthority,
+                ExtensionType::TransferFeeConfig
+            ]
+        );
+
+        // write base mint
+        let mut state = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut buffer).unwrap();
+        state.base = TEST_MINT;
+        state.pack_base();
+        state.init_account_type().unwrap();
+
+        let mut other_buffer = vec![0; mint_size];
+        let mut state =
+            StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut other_buffer).unwrap();
+
+        // write base mint
+        state.base = TEST_MINT;
+        state.pack_base();
+        state.init_account_type().unwrap();
+
+        // write extensions in a different order
+        let mint_transfer_fee = test_transfer_fee_config();
+        let extension = state.init_extension::<TransferFeeConfig>(true).unwrap();
+        extension.transfer_fee_config_authority = mint_transfer_fee.transfer_fee_config_authority;
+        extension.withdraw_withheld_authority = mint_transfer_fee.withdraw_withheld_authority;
+        extension.withheld_amount = mint_transfer_fee.withheld_amount;
+        extension.older_transfer_fee = mint_transfer_fee.older_transfer_fee;
+        extension.newer_transfer_fee = mint_transfer_fee.newer_transfer_fee;
+
+        let close_authority = OptionalNonZeroPubkey::try_from(Some(Pubkey::new(&[1; 32]))).unwrap();
+        let extension = state.init_extension::<MintCloseAuthority>(true).unwrap();
+        extension.close_authority = close_authority;
+
+        assert_eq!(
+            &state.get_extension_types().unwrap(),
+            &[
+                ExtensionType::TransferFeeConfig,
+                ExtensionType::MintCloseAuthority
+            ]
+        );
+
+        // buffers are NOT the same because written in a different order
+        assert_ne!(buffer, other_buffer);
+        let state = StateWithExtensions::<Mint>::unpack(&buffer).unwrap();
+        let other_state = StateWithExtensions::<Mint>::unpack(&other_buffer).unwrap();
+
+        // BUT mint and extensions are the same
+        assert_eq!(
+            state.get_extension::<TransferFeeConfig>().unwrap(),
+            other_state.get_extension::<TransferFeeConfig>().unwrap()
+        );
+        assert_eq!(
+            state.get_extension::<MintCloseAuthority>().unwrap(),
+            other_state.get_extension::<MintCloseAuthority>().unwrap()
+        );
+        assert_eq!(state.base, other_state.base);
+        */
+    }
+
+    #[test]
+    fn init_nonzero_default() {
+        /*
+        let mint_size = ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintPaddingTest]);
+        let mut buffer = vec![0; mint_size];
+        let mut state = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut buffer).unwrap();
+        state.base = TEST_MINT;
+        state.pack_base();
+        state.init_account_type().unwrap();
+        let extension = state.init_extension::<MintPaddingTest>(true).unwrap();
+        assert_eq!(extension.padding1, [1; 128]);
+        assert_eq!(extension.padding2, [2; 48]);
+        assert_eq!(extension.padding3, [3; 9]);
+        */
+    }
+
+    #[test]
+    fn init_buffer_too_small() {
+        /*
+        let mint_size =
+            ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]);
+        let mut buffer = vec![0; mint_size - 1];
+        let mut state = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut buffer).unwrap();
+        let err = state
+            .init_extension::<MintCloseAuthority>(true)
+            .unwrap_err();
+        assert_eq!(err, ProgramError::InvalidAccountData);
+
+        state.tlv_data[0] = 3;
+        state.tlv_data[2] = 32;
+        let err = state.get_extension_mut::<MintCloseAuthority>().unwrap_err();
+        assert_eq!(err, ProgramError::InvalidAccountData);
+
+        let mut buffer = vec![0; Mint::LEN + 2];
+        let err = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut buffer).unwrap_err();
+        assert_eq!(err, ProgramError::InvalidAccountData);
+
+        // OK since there are two bytes for the type, which is `Uninitialized`
+        let mut buffer = vec![0; BASE_ACCOUNT_LENGTH + 3];
+        let mut state = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut buffer).unwrap();
+        let err = state.get_extension_mut::<MintCloseAuthority>().unwrap_err();
+        assert_eq!(err, ProgramError::InvalidAccountData);
+
+        assert_eq!(state.get_extension_types().unwrap(), vec![]);
+
+        // malformed since there aren't two bytes for the type
+        let mut buffer = vec![0; BASE_ACCOUNT_LENGTH + 2];
+        let state = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut buffer).unwrap();
+        assert_eq!(
+            state.get_extension_types().unwrap_err(),
+            ProgramError::InvalidAccountData
+        );
+        */
+    }
+
+    #[test]
+    fn value_with_no_data() {
+        /*
+        let account_size =
+            ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]);
+        let mut buffer = vec![0; account_size];
+        let mut state =
+            StateWithExtensionsMut::<Account>::unpack_uninitialized(&mut buffer).unwrap();
+        state.base = TEST_ACCOUNT;
+        state.pack_base();
+        state.init_account_type().unwrap();
+
+        let err = state.get_extension::<ImmutableOwner>().unwrap_err();
+        assert_eq!(
+            err,
+            ProgramError::Custom(TokenError::ExtensionNotFound as u32)
+        );
+
+        state.init_extension::<ImmutableOwner>(true).unwrap();
+        assert_eq!(
+            get_first_extension_type(state.tlv_data).unwrap(),
+            Some(ExtensionType::ImmutableOwner)
+        );
+        assert_eq!(
+            get_extension_types(state.tlv_data).unwrap(),
+            vec![ExtensionType::ImmutableOwner]
+        );
+        */
+    }
+}

--- a/token/permissioned-transfer/src/tlv.rs
+++ b/token/permissioned-transfer/src/tlv.rs
@@ -67,7 +67,7 @@ impl TryFrom<usize> for Length {
 }
 
 /// Get the current TlvIndices from the current spot
-fn get_indices_unchecked(type_start: usize) -> TlvIndices {
+const fn get_indices_unchecked(type_start: usize) -> TlvIndices {
     let length_start = type_start.saturating_add(size_of::<Discriminator>());
     let value_start = length_start.saturating_add(size_of::<Length>());
     TlvIndices {

--- a/token/permissioned-transfer/tests/functional.rs
+++ b/token/permissioned-transfer/tests/functional.rs
@@ -1,0 +1,325 @@
+// Mark this test as SBF-only due to current `ProgramTest` limitations when CPIing into the system program
+#![cfg(feature = "test-sbf")]
+
+use {
+    solana_program_test::{
+        processor,
+        tokio::{self, sync::Mutex},
+        ProgramTest, ProgramTestContext,
+    },
+    solana_sdk::{
+        instruction::{AccountMeta, InstructionError},
+        pubkey::Pubkey,
+        signature::Signer,
+        signer::keypair::Keypair,
+        system_instruction, sysvar,
+        transaction::{Transaction, TransactionError},
+    },
+    spl_permissioned_transfer::{
+        error::PermissionedTransferError,
+        get_extra_account_metas_address,
+        instruction::{initialize_extra_account_metas, validate},
+        state::ExtraAccountMetas,
+        tlv,
+    },
+    spl_token_client::{
+        client::{
+            ProgramBanksClient, ProgramBanksClientProcessTransaction, ProgramClient,
+            SendTransaction,
+        },
+        token::Token,
+    },
+    std::sync::Arc,
+};
+
+fn keypair_clone(kp: &Keypair) -> Keypair {
+    Keypair::from_bytes(&kp.to_bytes()).expect("failed to copy keypair")
+}
+
+async fn setup() -> (
+    Arc<Mutex<ProgramTestContext>>,
+    Arc<dyn ProgramClient<ProgramBanksClientProcessTransaction>>,
+    Arc<Keypair>,
+) {
+    let mut program_test = ProgramTest::new(
+        "spl_permissioned_transfer",
+        spl_permissioned_transfer::id(),
+        processor!(spl_permissioned_transfer::processor::process),
+    );
+
+    program_test.prefer_bpf(false); // simplicity in the build
+
+    program_test.add_program(
+        "spl_token_2022",
+        spl_token_2022::id(),
+        processor!(spl_token_2022::processor::Processor::process),
+    );
+
+    let context = program_test.start_with_context().await;
+    let payer = Arc::new(keypair_clone(&context.payer));
+    let context = Arc::new(Mutex::new(context));
+
+    let client: Arc<dyn ProgramClient<ProgramBanksClientProcessTransaction>> =
+        Arc::new(ProgramBanksClient::new_from_context(
+            Arc::clone(&context),
+            ProgramBanksClientProcessTransaction,
+        ));
+    (context, client, payer)
+}
+
+async fn setup_mint<T: SendTransaction>(
+    program_id: &Pubkey,
+    mint_authority: &Pubkey,
+    decimals: u8,
+    payer: Arc<Keypair>,
+    client: Arc<dyn ProgramClient<T>>,
+) -> Token<T> {
+    let mint_account = Keypair::new();
+    let token = Token::new(
+        client,
+        program_id,
+        &mint_account.pubkey(),
+        Some(decimals),
+        payer,
+    );
+    token
+        .create_mint(mint_authority, None, vec![], &[&mint_account])
+        .await
+        .unwrap();
+    token
+}
+
+#[tokio::test]
+async fn success() {
+    let (context, client, payer) = setup().await;
+
+    let token_program_id = spl_token_2022::id();
+    let wallet = Keypair::new();
+    let mint_authority = Keypair::new();
+    let mint_authority_pubkey = mint_authority.pubkey();
+
+    let decimals = 2;
+    let token = setup_mint(
+        &token_program_id,
+        &mint_authority_pubkey,
+        decimals,
+        payer.clone(),
+        client.clone(),
+    )
+    .await;
+
+    let extra_account_metas =
+        get_extra_account_metas_address(token.get_address(), &spl_permissioned_transfer::id());
+
+    token
+        .create_associated_token_account(&wallet.pubkey())
+        .await
+        .unwrap();
+    let source = token.get_associated_token_address(&wallet.pubkey());
+    let token_amount = 1_000_000_000_000;
+    token
+        .mint_to(
+            &source,
+            &mint_authority_pubkey,
+            token_amount,
+            &[&mint_authority],
+        )
+        .await
+        .unwrap();
+
+    let destination = Keypair::new();
+    token
+        .create_auxiliary_token_account(&destination, &wallet.pubkey())
+        .await
+        .unwrap();
+    let destination = destination.pubkey();
+
+    let mut context = context.lock().await;
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let rent_lamports = rent.minimum_balance(tlv::get_len::<ExtraAccountMetas>());
+    let extra_account_pubkeys = [
+        &sysvar::instructions::id(),
+        &mint_authority_pubkey,
+        &extra_account_metas,
+    ];
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::transfer(
+                &context.payer.pubkey(),
+                &extra_account_metas,
+                rent_lamports,
+            ),
+            initialize_extra_account_metas(
+                &spl_permissioned_transfer::id(),
+                &extra_account_metas,
+                token.get_address(),
+                &mint_authority_pubkey,
+                &extra_account_pubkeys,
+            ),
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &mint_authority],
+        context.last_blockhash,
+    );
+
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+
+    // fail with missing account
+    {
+        let transaction = Transaction::new_signed_with_payer(
+            &[validate(
+                &spl_permissioned_transfer::id(),
+                &source,
+                token.get_address(),
+                &destination,
+                &wallet.pubkey(),
+                &extra_account_metas,
+                &extra_account_pubkeys[..2],
+                0,
+            )],
+            Some(&context.payer.pubkey()),
+            &[&context.payer],
+            context.last_blockhash,
+        );
+        let error = context
+            .banks_client
+            .process_transaction(transaction)
+            .await
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(
+            error,
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(PermissionedTransferError::IncorrectAccount as u32),
+            )
+        );
+    }
+
+    // fail with wrong account
+    {
+        let extra_account_pubkeys = [
+            &sysvar::instructions::id(),
+            &mint_authority_pubkey,
+            &wallet.pubkey(),
+        ];
+        let transaction = Transaction::new_signed_with_payer(
+            &[validate(
+                &spl_permissioned_transfer::id(),
+                &source,
+                token.get_address(),
+                &destination,
+                &wallet.pubkey(),
+                &extra_account_metas,
+                &extra_account_pubkeys,
+                0,
+            )],
+            Some(&context.payer.pubkey()),
+            &[&context.payer],
+            context.last_blockhash,
+        );
+        let error = context
+            .banks_client
+            .process_transaction(transaction)
+            .await
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(
+            error,
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(PermissionedTransferError::IncorrectAccount as u32),
+            )
+        );
+    }
+
+    // success with correct params
+    {
+        let transaction = Transaction::new_signed_with_payer(
+            &[validate(
+                &spl_permissioned_transfer::id(),
+                &source,
+                token.get_address(),
+                &destination,
+                &wallet.pubkey(),
+                &extra_account_metas,
+                &extra_account_pubkeys,
+                0,
+            )],
+            Some(&context.payer.pubkey()),
+            &[&context.payer],
+            context.last_blockhash,
+        );
+        context
+            .banks_client
+            .process_transaction(transaction)
+            .await
+            .unwrap();
+    }
+}
+
+#[tokio::test]
+async fn fail_incorrect_derivation() {
+    let (context, client, payer) = setup().await;
+
+    let token_program_id = spl_token_2022::id();
+    let mint_authority = Keypair::new();
+    let mint_authority_pubkey = mint_authority.pubkey();
+
+    let decimals = 2;
+    let token = setup_mint(
+        &token_program_id,
+        &mint_authority_pubkey,
+        decimals,
+        payer.clone(),
+        client.clone(),
+    )
+    .await;
+
+    // wrong derivation
+    let extra_account_metas =
+        get_extra_account_metas_address(&spl_permissioned_transfer::id(), token.get_address());
+
+    let mut context = context.lock().await;
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let rent_lamports = rent.minimum_balance(tlv::get_len::<ExtraAccountMetas>());
+    let extra_account_pubkeys = [
+        &sysvar::instructions::id(),
+        &mint_authority_pubkey,
+        &extra_account_metas,
+    ];
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::transfer(
+                &context.payer.pubkey(),
+                &extra_account_metas,
+                rent_lamports,
+            ),
+            initialize_extra_account_metas(
+                &spl_permissioned_transfer::id(),
+                &extra_account_metas,
+                token.get_address(),
+                &mint_authority_pubkey,
+                &extra_account_pubkeys,
+            ),
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &mint_authority],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(1, InstructionError::InvalidSeeds)
+    );
+}

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -18,11 +18,13 @@ walkdir = "2"
 
 [dev-dependencies]
 async-trait = "0.1"
+bytemuck = { version = "1.13.0", features = ["derive"] }
 solana-program = "=1.14.12"
 solana-program-test = "=1.14.12"
 solana-sdk = "=1.14.12"
 spl-associated-token-account = { version = "1.1", path = "../../associated-token-account/program" }
 spl-memo = { version = "3.0.1", path = "../../memo/program", features = ["no-entrypoint"] }
+spl-permissioned-transfer = { version = "0.1", path="../permissioned-transfer", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "0.6", path="../program-2022", features = ["no-entrypoint"] }
 spl-instruction-padding = { version = "0.1.0", path="../../instruction-padding/program", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.5", path = "../client" }

--- a/token/program-2022-test/tests/permissioned_transfer.rs
+++ b/token/program-2022-test/tests/permissioned_transfer.rs
@@ -1,0 +1,443 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+use {
+    program_test::{TestContext, TokenContext},
+    solana_program_test::{processor, tokio, ProgramTest},
+    solana_sdk::{
+        account::Account,
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        instruction::InstructionError,
+        program_error::ProgramError,
+        pubkey::Pubkey,
+        signature::Signer,
+        signer::keypair::Keypair,
+        transaction::TransactionError,
+        transport::TransportError,
+    },
+    spl_permissioned_transfer::{
+        get_extra_account_metas_address,
+        instruction::PermissionedTransferInstruction,
+        pod::PodAccountMeta,
+        state::ExtraAccountMetas,
+        tlv::{TlvState, TlvStateBorrowed, TlvType},
+    },
+    spl_token_2022::{
+        error::TokenError,
+        extension::{permissioned_transfer::PermissionedTransfer, BaseStateWithExtensions},
+        instruction,
+        processor::Processor,
+    },
+    spl_token_client::token::{ExtensionInitializationParams, TokenError as TokenClientError},
+    std::{convert::TryInto, sync::Arc},
+};
+
+/// Test program to validate a transfer, conforms to permssioned-transfer
+/// `validate`
+pub fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    input: &[u8],
+) -> ProgramResult {
+    let instruction = PermissionedTransferInstruction::unpack(input)?;
+    let _amount = match instruction {
+        PermissionedTransferInstruction::Validate { amount } => amount,
+        _ => return Err(ProgramError::InvalidInstructionData),
+    };
+    let account_info_iter = &mut accounts.iter();
+
+    let _source_account_info = next_account_info(account_info_iter)?;
+    let mint_info = next_account_info(account_info_iter)?;
+    let _destination_account_info = next_account_info(account_info_iter)?;
+    let _authority_info = next_account_info(account_info_iter)?;
+    let extra_account_metas_info = next_account_info(account_info_iter)?;
+
+    // Only check that the correct pda and account are provided
+    let expected_validation_address = get_extra_account_metas_address(mint_info.key, program_id);
+    if expected_validation_address != *extra_account_metas_info.key {
+        return Err(ProgramError::InvalidSeeds);
+    }
+
+    let data = extra_account_metas_info.try_borrow_data()?;
+    let state = TlvStateBorrowed::unpack(&data).unwrap();
+    let bytes = state.get_bytes::<ExtraAccountMetas>()?;
+    let extra_account_metas = ExtraAccountMetas::unpack(bytes)?;
+
+    // if incorrect number of accounts is provided, error
+    let extra_account_infos = account_info_iter.as_slice();
+    let account_metas = extra_account_metas.data();
+    if extra_account_infos.len() != account_metas.len() {
+        return Err(ProgramError::InvalidInstructionData);
+    }
+
+    // Let's assume that they're provided in the correct order
+    for (i, account_info) in extra_account_infos.iter().enumerate() {
+        if &account_metas[i] != account_info {
+            return Err(ProgramError::InvalidInstructionData);
+        }
+    }
+
+    Ok(())
+}
+
+/// Test program to fail transfer validation, conforms to permssioned-transfer
+/// `validate`
+pub fn process_instruction_fail(
+    _program_id: &Pubkey,
+    _accounts: &[AccountInfo],
+    _input: &[u8],
+) -> ProgramResult {
+    Err(ProgramError::InvalidInstructionData)
+}
+
+async fn setup_accounts(token_context: &TokenContext, amount: u64) -> (Pubkey, Pubkey) {
+    let alice_account = Keypair::new();
+    token_context
+        .token
+        .create_auxiliary_token_account(&alice_account, &token_context.alice.pubkey())
+        .await
+        .unwrap();
+    let alice_account = alice_account.pubkey();
+    let bob_account = Keypair::new();
+    token_context
+        .token
+        .create_auxiliary_token_account(&bob_account, &token_context.bob.pubkey())
+        .await
+        .unwrap();
+    let bob_account = bob_account.pubkey();
+
+    // mint tokens
+    token_context
+        .token
+        .mint_to(
+            &alice_account,
+            &token_context.mint_authority.pubkey(),
+            amount,
+            &[&token_context.mint_authority],
+        )
+        .await
+        .unwrap();
+    (alice_account, bob_account)
+}
+
+async fn setup(mint: Keypair, program_id: &Pubkey, authority: &Pubkey) -> TokenContext {
+    let mut program_test = ProgramTest::default();
+    program_test.prefer_bpf(false);
+    program_test.add_program(
+        "spl_token_2022",
+        spl_token_2022::id(),
+        processor!(Processor::process),
+    );
+    program_test.add_program(
+        "my_permissioned_transfer",
+        *program_id,
+        processor!(process_instruction),
+    );
+    let account_metas = vec![
+        PodAccountMeta {
+            pubkey: Pubkey::new_unique(),
+            is_signer: false.into(),
+            is_writable: false.into(),
+        },
+        PodAccountMeta {
+            pubkey: Pubkey::new_unique(),
+            is_signer: false.into(),
+            is_writable: false.into(),
+        },
+    ];
+    let mut tlv_data = vec![];
+    tlv_data.extend_from_slice(&(account_metas.len() as u16).to_le_bytes());
+    account_metas
+        .iter()
+        .for_each(|m| tlv_data.extend_from_slice(bytemuck::bytes_of(m)));
+    let mut data = vec![];
+    data.extend_from_slice(ExtraAccountMetas::TYPE.as_ref());
+    data.extend_from_slice(&(tlv_data.len() as u32).to_le_bytes());
+    data.extend_from_slice(&tlv_data);
+    let validation_address = get_extra_account_metas_address(&mint.pubkey(), program_id);
+    program_test.add_account(
+        validation_address,
+        Account {
+            lamports: 1_000_000_000, // a lot, just to be safe
+            data,
+            owner: *program_id,
+            ..Account::default()
+        },
+    );
+
+    let context = program_test.start_with_context().await;
+    let context = Arc::new(tokio::sync::Mutex::new(context));
+    let mut context = TestContext {
+        context,
+        token_context: None,
+    };
+    context
+        .init_token_with_mint_keypair_and_freeze_authority(
+            mint,
+            vec![ExtensionInitializationParams::PermissionedTransfer {
+                authority: Some(*authority),
+                permissioned_transfer_program_id: Some(*program_id),
+            }],
+            None,
+        )
+        .await
+        .unwrap();
+    context.token_context.take().unwrap()
+}
+
+#[tokio::test]
+async fn success_init() {
+    let authority = Pubkey::new_unique();
+    let program_id = Pubkey::new_unique();
+    let mint_keypair = Keypair::new();
+    let token = setup(mint_keypair, &program_id, &authority).await.token;
+
+    let state = token.get_mint_info().await.unwrap();
+    assert!(state.base.is_initialized);
+    let extension = state.get_extension::<PermissionedTransfer>().unwrap();
+    assert_eq!(extension.authority, Some(authority).try_into().unwrap());
+    assert_eq!(extension.program_id, Some(program_id).try_into().unwrap());
+}
+
+#[tokio::test]
+async fn set_authority() {
+    let authority = Keypair::new();
+    let program_id = Pubkey::new_unique();
+    let mint_keypair = Keypair::new();
+    let token = setup(mint_keypair, &program_id, &authority.pubkey())
+        .await
+        .token;
+    let new_authority = Keypair::new();
+
+    // fail, wrong signature
+    let wrong = Keypair::new();
+    let err = token
+        .set_authority(
+            token.get_address(),
+            &wrong.pubkey(),
+            Some(&new_authority.pubkey()),
+            instruction::AuthorityType::PermissionedTransfer,
+            &[&wrong],
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::OwnerMismatch as u32)
+            )
+        )))
+    );
+
+    // success
+    token
+        .set_authority(
+            token.get_address(),
+            &authority.pubkey(),
+            Some(&new_authority.pubkey()),
+            instruction::AuthorityType::PermissionedTransfer,
+            &[&authority],
+        )
+        .await
+        .unwrap();
+    let state = token.get_mint_info().await.unwrap();
+    let extension = state.get_extension::<PermissionedTransfer>().unwrap();
+    assert_eq!(
+        extension.authority,
+        Some(new_authority.pubkey()).try_into().unwrap(),
+    );
+
+    // set to none
+    token
+        .set_authority(
+            token.get_address(),
+            &new_authority.pubkey(),
+            None,
+            instruction::AuthorityType::PermissionedTransfer,
+            &[&new_authority],
+        )
+        .await
+        .unwrap();
+    let state = token.get_mint_info().await.unwrap();
+    let extension = state.get_extension::<PermissionedTransfer>().unwrap();
+    assert_eq!(extension.authority, None.try_into().unwrap(),);
+
+    // fail set again
+    let err = token
+        .set_authority(
+            token.get_address(),
+            &new_authority.pubkey(),
+            Some(&authority.pubkey()),
+            instruction::AuthorityType::PermissionedTransfer,
+            &[&new_authority],
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::AuthorityTypeNotSupported as u32)
+            )
+        )))
+    );
+}
+
+#[tokio::test]
+async fn update_permissioned_transfer_program_id() {
+    let authority = Keypair::new();
+    let program_id = Pubkey::new_unique();
+    let mint_keypair = Keypair::new();
+    let token = setup(mint_keypair, &program_id, &authority.pubkey())
+        .await
+        .token;
+    let new_program_id = Pubkey::new_unique();
+
+    // fail, wrong signature
+    let wrong = Keypair::new();
+    let err = token
+        .update_permissioned_transfer_program_id(&wrong.pubkey(), Some(new_program_id), &[&wrong])
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::OwnerMismatch as u32)
+            )
+        )))
+    );
+
+    // success
+    token
+        .update_permissioned_transfer_program_id(
+            &authority.pubkey(),
+            Some(new_program_id),
+            &[&authority],
+        )
+        .await
+        .unwrap();
+    let state = token.get_mint_info().await.unwrap();
+    let extension = state.get_extension::<PermissionedTransfer>().unwrap();
+    assert_eq!(
+        extension.program_id,
+        Some(new_program_id).try_into().unwrap(),
+    );
+
+    // set to none
+    token
+        .update_permissioned_transfer_program_id(&authority.pubkey(), None, &[&authority])
+        .await
+        .unwrap();
+    let state = token.get_mint_info().await.unwrap();
+    let extension = state.get_extension::<PermissionedTransfer>().unwrap();
+    assert_eq!(extension.program_id, None.try_into().unwrap(),);
+}
+
+#[tokio::test]
+async fn success_transfer() {
+    let authority = Keypair::new();
+    let program_id = Pubkey::new_unique();
+    let mint_keypair = Keypair::new();
+    let token_context = setup(mint_keypair, &program_id, &authority.pubkey()).await;
+    let amount = 10;
+    let (alice_account, bob_account) = setup_accounts(&token_context, amount).await;
+
+    token_context
+        .token
+        .transfer(
+            &alice_account,
+            &bob_account,
+            &token_context.alice.pubkey(),
+            amount,
+            &[&token_context.alice],
+        )
+        .await
+        .unwrap();
+
+    let destination = token_context
+        .token
+        .get_account_info(&bob_account)
+        .await
+        .unwrap();
+    assert_eq!(destination.base.amount, amount);
+}
+
+#[tokio::test]
+async fn fail_permissioned_transfer_program() {
+    let authority = Pubkey::new_unique();
+    let program_id = Pubkey::new_unique();
+    let mint = Keypair::new();
+    let mut program_test = ProgramTest::default();
+    program_test.prefer_bpf(false);
+    program_test.add_program(
+        "spl_token_2022",
+        spl_token_2022::id(),
+        processor!(Processor::process),
+    );
+    program_test.add_program(
+        "my_permissioned_transfer",
+        program_id,
+        processor!(process_instruction_fail),
+    );
+    let mut tlv_data = vec![];
+    tlv_data.extend_from_slice(&0u16.to_le_bytes());
+    let mut data = vec![];
+    data.extend_from_slice(ExtraAccountMetas::TYPE.as_ref());
+    data.extend_from_slice(&(tlv_data.len() as u32).to_le_bytes());
+    data.extend_from_slice(&tlv_data);
+    let validation_address = get_extra_account_metas_address(&mint.pubkey(), &program_id);
+    program_test.add_account(
+        validation_address,
+        Account {
+            lamports: 1_000_000_000, // a lot, just to be safe
+            data,
+            owner: program_id,
+            ..Account::default()
+        },
+    );
+    let context = program_test.start_with_context().await;
+    let context = Arc::new(tokio::sync::Mutex::new(context));
+    let mut context = TestContext {
+        context,
+        token_context: None,
+    };
+    context
+        .init_token_with_mint_keypair_and_freeze_authority(
+            mint,
+            vec![ExtensionInitializationParams::PermissionedTransfer {
+                authority: Some(authority),
+                permissioned_transfer_program_id: Some(program_id),
+            }],
+            None,
+        )
+        .await
+        .unwrap();
+    let token_context = context.token_context.take().unwrap();
+
+    let amount = 10;
+    let (alice_account, bob_account) = setup_accounts(&token_context, amount).await;
+
+    let err = token_context
+        .token
+        .transfer(
+            &alice_account,
+            &bob_account,
+            &token_context.alice.pubkey(),
+            amount,
+            &[&token_context.alice],
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(0, InstructionError::InvalidInstructionData)
+        )))
+    );
+}

--- a/token/program-2022-test/tests/program_test.rs
+++ b/token/program-2022-test/tests/program_test.rs
@@ -42,7 +42,7 @@ impl TestContext {
         &mut self,
         extension_init_params: Vec<ExtensionInitializationParams>,
     ) -> TokenResult<()> {
-        self._init_token_with_mint(extension_init_params, None)
+        self.init_token_with_mint_and_freeze_authority(extension_init_params, None)
             .await
     }
 
@@ -51,12 +51,30 @@ impl TestContext {
         extension_init_params: Vec<ExtensionInitializationParams>,
     ) -> TokenResult<()> {
         let freeze_authority = Keypair::new();
-        self._init_token_with_mint(extension_init_params, Some(freeze_authority))
-            .await
+        self.init_token_with_mint_and_freeze_authority(
+            extension_init_params,
+            Some(freeze_authority),
+        )
+        .await
     }
 
-    pub async fn _init_token_with_mint(
+    pub async fn init_token_with_mint_and_freeze_authority(
         &mut self,
+        extension_init_params: Vec<ExtensionInitializationParams>,
+        freeze_authority: Option<Keypair>,
+    ) -> TokenResult<()> {
+        let mint_account = Keypair::new();
+        self.init_token_with_mint_keypair_and_freeze_authority(
+            mint_account,
+            extension_init_params,
+            freeze_authority,
+        )
+        .await
+    }
+
+    pub async fn init_token_with_mint_keypair_and_freeze_authority(
+        &mut self,
+        mint_account: Keypair,
         extension_init_params: Vec<ExtensionInitializationParams>,
         freeze_authority: Option<Keypair>,
     ) -> TokenResult<()> {
@@ -69,7 +87,6 @@ impl TestContext {
 
         let decimals: u8 = 9;
 
-        let mint_account = Keypair::new();
         let mint_authority = Keypair::new();
         let mint_authority_pubkey = mint_authority.pubkey();
         let freeze_authority_pubkey = freeze_authority

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -26,6 +26,7 @@ num_enum = "0.5.9"
 solana-program = "1.14.12"
 solana-zk-token-sdk = "1.14.12"
 spl-memo = { version = "3.0.1", path = "../../memo/program", features = [ "no-entrypoint" ] }
+spl-permissioned-transfer = { version = "0.1.0", path = "../permissioned-transfer", features = [ "no-entrypoint" ] }
 spl-token = { version = "3.5",  path = "../program", features = ["no-entrypoint"] }
 thiserror = "1.0"
 serde = { version = "1.0.136", optional = true }

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -13,6 +13,7 @@ use {
             mint_close_authority::MintCloseAuthority,
             non_transferable::{NonTransferable, NonTransferableAccount},
             permanent_delegate::PermanentDelegate,
+            permissioned_transfer::PermissionedTransfer,
             transfer_fee::{TransferFeeAmount, TransferFeeConfig},
         },
         pod::*,
@@ -51,6 +52,8 @@ pub mod mint_close_authority;
 pub mod non_transferable;
 /// Permanent Delegate extension
 pub mod permanent_delegate;
+/// Permissioned Transfer extension
+pub mod permissioned_transfer;
 /// Utility to reallocate token accounts
 pub mod reallocate;
 /// Transfer Fee extension
@@ -646,6 +649,8 @@ pub enum ExtensionType {
     PermanentDelegate,
     /// Indicates that the tokens in this account belong to a non-transferable mint
     NonTransferableAccount,
+    /// Mint requires a CPI to a program implementing the "permissioned transfer" interface
+    PermissionedTransfer,
     /// Padding extension used to make an account exactly Multisig::LEN, used for testing
     #[cfg(test)]
     AccountPaddingTest = u16::MAX - 1,
@@ -689,6 +694,7 @@ impl ExtensionType {
             ExtensionType::CpiGuard => pod_get_packed_len::<CpiGuard>(),
             ExtensionType::PermanentDelegate => pod_get_packed_len::<PermanentDelegate>(),
             ExtensionType::NonTransferableAccount => pod_get_packed_len::<NonTransferableAccount>(),
+            ExtensionType::PermissionedTransfer => pod_get_packed_len::<PermissionedTransfer>(),
             #[cfg(test)]
             ExtensionType::AccountPaddingTest => pod_get_packed_len::<AccountPaddingTest>(),
             #[cfg(test)]
@@ -746,7 +752,8 @@ impl ExtensionType {
             | ExtensionType::DefaultAccountState
             | ExtensionType::NonTransferable
             | ExtensionType::InterestBearingConfig
-            | ExtensionType::PermanentDelegate => AccountType::Mint,
+            | ExtensionType::PermanentDelegate
+            | ExtensionType::PermissionedTransfer => AccountType::Mint,
             ExtensionType::ImmutableOwner
             | ExtensionType::TransferFeeAmount
             | ExtensionType::ConfidentialTransferAccount

--- a/token/program-2022/src/extension/permissioned_transfer/instruction.rs
+++ b/token/program-2022/src/extension/permissioned_transfer/instruction.rs
@@ -1,0 +1,122 @@
+use {
+    crate::{
+        check_program_account,
+        instruction::{encode_instruction, TokenInstruction},
+        pod::OptionalNonZeroPubkey,
+    },
+    bytemuck::{Pod, Zeroable},
+    num_enum::{IntoPrimitive, TryFromPrimitive},
+    solana_program::{
+        instruction::{AccountMeta, Instruction},
+        program_error::ProgramError,
+        pubkey::Pubkey,
+    },
+    std::convert::TryInto,
+};
+
+/// Permissioned transfer mint extension instructions
+#[derive(Clone, Copy, Debug, PartialEq, IntoPrimitive, TryFromPrimitive)]
+#[repr(u8)]
+pub enum PermissionedTransferInstruction {
+    /// Initialize a new mint with permissioned transfer.
+    ///
+    /// Fails if the mint has already been initialized, so must be called before
+    /// `InitializeMint`.
+    ///
+    /// The mint must have exactly enough space allocated for the base mint (82
+    /// bytes), plus 83 bytes of padding, 1 byte reserved for the account type,
+    /// then space required for this extension, plus any others.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[writable]` The mint to initialize.
+    ///
+    /// Data expected by this instruction:
+    ///   `crate::extension::permissioned_transfer::instruction::InitializeInstructionData`
+    ///
+    Initialize,
+    /// Update the permissioned transfer program id. Only supported for mints that
+    /// include the `PermissionedTransfer` extension.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   * Single authority
+    ///   0. `[writable]` The mint.
+    ///   1. `[signer]` The permissioned transfer authority.
+    ///
+    ///   * Multisignature authority
+    ///   0. `[writable]` The mint.
+    ///   1. `[]` The mint's permissioned transfer authority.
+    ///   2. ..2+M `[signer]` M signer accounts.
+    ///
+    /// Data expected by this instruction:
+    ///   `crate::extension::permissioned_transfer::UpdateInstructionData`
+    ///
+    Update,
+}
+
+/// Data expected by `Initialize`
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct InitializeInstructionData {
+    /// The public key for the account that can update the program id
+    pub authority: OptionalNonZeroPubkey,
+    /// The program id that validates transfers
+    pub permissioned_transfer_program_id: OptionalNonZeroPubkey,
+}
+
+/// Data expected by `Update`
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct UpdateInstructionData {
+    /// The program id that validates transfers
+    pub permissioned_transfer_program_id: OptionalNonZeroPubkey,
+}
+
+/// Create an `Initialize` instruction
+pub fn initialize(
+    token_program_id: &Pubkey,
+    mint: &Pubkey,
+    authority: Option<Pubkey>,
+    permissioned_transfer_program_id: Option<Pubkey>,
+) -> Result<Instruction, ProgramError> {
+    check_program_account(token_program_id)?;
+    let accounts = vec![AccountMeta::new(*mint, false)];
+    Ok(encode_instruction(
+        token_program_id,
+        accounts,
+        TokenInstruction::PermissionedTransferExtension,
+        PermissionedTransferInstruction::Initialize,
+        &InitializeInstructionData {
+            authority: authority.try_into()?,
+            permissioned_transfer_program_id: permissioned_transfer_program_id.try_into()?,
+        },
+    ))
+}
+
+/// Create an `Update` instruction
+pub fn update(
+    token_program_id: &Pubkey,
+    mint: &Pubkey,
+    authority: &Pubkey,
+    signers: &[&Pubkey],
+    permissioned_transfer_program_id: Option<Pubkey>,
+) -> Result<Instruction, ProgramError> {
+    check_program_account(token_program_id)?;
+    let mut accounts = vec![
+        AccountMeta::new(*mint, false),
+        AccountMeta::new_readonly(*authority, signers.is_empty()),
+    ];
+    for signer_pubkey in signers.iter() {
+        accounts.push(AccountMeta::new_readonly(**signer_pubkey, true));
+    }
+    Ok(encode_instruction(
+        token_program_id,
+        accounts,
+        TokenInstruction::PermissionedTransferExtension,
+        PermissionedTransferInstruction::Update,
+        &UpdateInstructionData {
+            permissioned_transfer_program_id: permissioned_transfer_program_id.try_into()?,
+        },
+    ))
+}

--- a/token/program-2022/src/extension/permissioned_transfer/mod.rs
+++ b/token/program-2022/src/extension/permissioned_transfer/mod.rs
@@ -1,0 +1,25 @@
+use {
+    crate::{
+        extension::{Extension, ExtensionType},
+        pod::OptionalNonZeroPubkey,
+    },
+    bytemuck::{Pod, Zeroable},
+};
+
+/// Instructions for the PermissionedTransfer extension
+pub mod instruction;
+/// Instruction processor for the PermissionedTransfer extension
+pub mod processor;
+
+/// Close authority extension data for mints.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+pub struct PermissionedTransfer {
+    /// Authority that can set the permissioned transfer program id
+    pub authority: OptionalNonZeroPubkey,
+    /// Program that authorizes the transfer
+    pub permissioned_transfer_program_id: OptionalNonZeroPubkey,
+}
+impl Extension for PermissionedTransfer {
+    const TYPE: ExtensionType = ExtensionType::PermissionedTransfer;
+}

--- a/token/program-2022/src/extension/permissioned_transfer/mod.rs
+++ b/token/program-2022/src/extension/permissioned_transfer/mod.rs
@@ -1,9 +1,10 @@
 use {
     crate::{
-        extension::{Extension, ExtensionType},
+        extension::{BaseState, BaseStateWithExtensions, Extension, ExtensionType},
         pod::OptionalNonZeroPubkey,
     },
     bytemuck::{Pod, Zeroable},
+    solana_program::pubkey::Pubkey,
 };
 
 /// Instructions for the PermissionedTransfer extension
@@ -18,8 +19,29 @@ pub struct PermissionedTransfer {
     /// Authority that can set the permissioned transfer program id
     pub authority: OptionalNonZeroPubkey,
     /// Program that authorizes the transfer
-    pub permissioned_transfer_program_id: OptionalNonZeroPubkey,
+    pub program_id: OptionalNonZeroPubkey,
 }
+
+/// Indicates that the tokens from this account belong to a permissioned-transfer mint
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+#[repr(transparent)]
+pub struct PermissionedTransferAccount;
+
 impl Extension for PermissionedTransfer {
     const TYPE: ExtensionType = ExtensionType::PermissionedTransfer;
+}
+
+impl Extension for PermissionedTransferAccount {
+    const TYPE: ExtensionType = ExtensionType::PermissionedTransferAccount;
+}
+
+/// Attempts to get the permissioned transfer program id from the TLV data, returning
+/// None if the extension is not found
+pub fn get_permissioned_transfer_program_id<S: BaseState, BSE: BaseStateWithExtensions<S>>(
+    state: &BSE,
+) -> Option<Pubkey> {
+    state
+        .get_extension::<PermissionedTransfer>()
+        .ok()
+        .and_then(|e| Option::<Pubkey>::from(e.program_id))
 }

--- a/token/program-2022/src/extension/permissioned_transfer/processor.rs
+++ b/token/program-2022/src/extension/permissioned_transfer/processor.rs
@@ -1,0 +1,116 @@
+use {
+    crate::{
+        check_program_account,
+        error::TokenError,
+        extension::{
+            permissioned_transfer::{
+                instruction::{
+                    InitializeInstructionData, PermissionedTransferInstruction,
+                    UpdateInstructionData,
+                },
+                PermissionedTransfer,
+            },
+            StateWithExtensionsMut,
+        },
+        instruction::{decode_instruction_data, decode_instruction_type},
+        pod::OptionalNonZeroPubkey,
+        processor::Processor,
+        state::Mint,
+    },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        msg,
+        program_error::ProgramError,
+        pubkey::Pubkey,
+    },
+};
+
+fn process_initialize(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    authority: &OptionalNonZeroPubkey,
+    permissioned_transfer_program_id: &OptionalNonZeroPubkey,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let mint_account_info = next_account_info(account_info_iter)?;
+    let mut mint_data = mint_account_info.data.borrow_mut();
+    let mut mint = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut mint_data)?;
+
+    let extension = mint.init_extension::<PermissionedTransfer>(true)?;
+    extension.authority = *authority;
+
+    if let Some(permissioned_transfer_program_id) =
+        Option::<Pubkey>::from(*permissioned_transfer_program_id)
+    {
+        if permissioned_transfer_program_id == *program_id {
+            return Err(ProgramError::IncorrectProgramId);
+        }
+    }
+    extension.permissioned_transfer_program_id = *permissioned_transfer_program_id;
+    Ok(())
+}
+
+fn process_update(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    new_program_id: &OptionalNonZeroPubkey,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let mint_account_info = next_account_info(account_info_iter)?;
+    let owner_info = next_account_info(account_info_iter)?;
+    let owner_info_data_len = owner_info.data_len();
+
+    let mut mint_data = mint_account_info.data.borrow_mut();
+    let mut mint = StateWithExtensionsMut::<Mint>::unpack(&mut mint_data)?;
+    let extension = mint.get_extension_mut::<PermissionedTransfer>()?;
+    let authority =
+        Option::<Pubkey>::from(extension.authority).ok_or(TokenError::NoAuthorityExists)?;
+
+    Processor::validate_owner(
+        program_id,
+        &authority,
+        owner_info,
+        owner_info_data_len,
+        account_info_iter.as_slice(),
+    )?;
+
+    if let Some(new_program_id) = Option::<Pubkey>::from(*new_program_id) {
+        if new_program_id == *program_id {
+            return Err(ProgramError::IncorrectProgramId);
+        }
+    }
+
+    extension.permissioned_transfer_program_id = *new_program_id;
+    Ok(())
+}
+
+pub(crate) fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    input: &[u8],
+) -> ProgramResult {
+    check_program_account(program_id)?;
+    match decode_instruction_type(input)? {
+        PermissionedTransferInstruction::Initialize => {
+            msg!("PermissionedTransferInstruction::Initialize");
+            let InitializeInstructionData {
+                authority,
+                permissioned_transfer_program_id,
+            } = decode_instruction_data(input)?;
+            process_initialize(
+                program_id,
+                accounts,
+                authority,
+                permissioned_transfer_program_id,
+            )
+        }
+        PermissionedTransferInstruction::Update => {
+            msg!("PermissionedTransferInstruction::Update");
+            let UpdateInstructionData {
+                permissioned_transfer_program_id,
+            } = decode_instruction_data(input)?;
+            process_update(program_id, accounts, permissioned_transfer_program_id)
+        }
+    }
+}

--- a/token/program-2022/src/extension/permissioned_transfer/processor.rs
+++ b/token/program-2022/src/extension/permissioned_transfer/processor.rs
@@ -47,7 +47,7 @@ fn process_initialize(
             return Err(ProgramError::IncorrectProgramId);
         }
     }
-    extension.permissioned_transfer_program_id = *permissioned_transfer_program_id;
+    extension.program_id = *permissioned_transfer_program_id;
     Ok(())
 }
 
@@ -81,7 +81,7 @@ fn process_update(
         }
     }
 
-    extension.permissioned_transfer_program_id = *new_program_id;
+    extension.program_id = *new_program_id;
     Ok(())
 }
 

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -630,6 +630,12 @@ pub enum TokenInstruction<'a> {
         /// Authority that may sign for `Transfer`s and `Burn`s on any account
         delegate: Pubkey,
     },
+    /// The common instruction prefix for permissioned transfer extension instructions.
+    ///
+    /// See `extension::permissioned_transfer::instruction::PermissionedTransferInstruction`
+    /// for further details about the extended instructions that share this instruction
+    /// prefix
+    PermissionedTransferExtension,
 }
 impl<'a> TokenInstruction<'a> {
     /// Unpacks a byte buffer into a [TokenInstruction](enum.TokenInstruction.html).
@@ -765,6 +771,7 @@ impl<'a> TokenInstruction<'a> {
                 let (delegate, _rest) = Self::unpack_pubkey(rest)?;
                 Self::InitializePermanentDelegate { delegate }
             }
+            36 => Self::PermissionedTransferExtension,
             _ => return Err(TokenError::InvalidInstruction.into()),
         })
     }
@@ -924,6 +931,9 @@ impl<'a> TokenInstruction<'a> {
                 buf.push(35);
                 buf.extend_from_slice(delegate.as_ref());
             }
+            &Self::PermissionedTransferExtension => {
+                buf.push(36);
+            }
         };
         buf
     }
@@ -1010,6 +1020,8 @@ pub enum AuthorityType {
     /// Authority to update confidential transfer mint and aprove accounts for confidential
     /// transfers
     ConfidentialTransferMint,
+    /// Authority to set the permissioned transfer program id
+    PermissionedTransfer,
 }
 
 impl AuthorityType {
@@ -1025,6 +1037,7 @@ impl AuthorityType {
             AuthorityType::InterestRate => 7,
             AuthorityType::PermanentDelegate => 8,
             AuthorityType::ConfidentialTransferMint => 9,
+            AuthorityType::PermissionedTransfer => 10,
         }
     }
 
@@ -1040,6 +1053,7 @@ impl AuthorityType {
             7 => Ok(AuthorityType::InterestRate),
             8 => Ok(AuthorityType::PermanentDelegate),
             9 => Ok(AuthorityType::ConfidentialTransferMint),
+            10 => Ok(AuthorityType::PermissionedTransfer),
             _ => Err(TokenError::InvalidInstruction.into()),
         }
     }


### PR DESCRIPTION
#### Problem

We want to add permissioned transfers to token-2022, in a similar vein as #3888. The slight difference is that we'll only store the program id in the mint in token-2022, and the rest of the logic is done by the program.

#### Solution

Outline the interface that should be implemented by other devs, along with a simple example program.

Here's the full list of things to do:

- [x] make permissioned-transfer program
- [x] add end-to-end tests
- [x] improve `ValidationPubkeys` to be any length (currently hardcoded to 3 to work simply with bytemuck)
- [x] add on-chain instruction creator which reads `ValidationPubkeys` and pulls out accounts from an `AccountInfo` iterator
- [x] add hook to token-2022 to store the program id and call `validate` if a permissioned token program is specified
- [ ] add on-chain instruction creator which reads a `Mint` and pulls out all additional accounts from an `AccountInfo` iterator
- [ ] add to CI