### PR TITLE
CI: Add GitHub action to post message and close on "question" label

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -1,0 +1,27 @@
+question:
+  issues:
+    # Post a comment, `{issue-author}` is an optional placeholder
+    comment: >
+      Hi @{issue-author},
+
+
+      Thanks for your question!
+
+
+      We want to make sure to keep signal strong in the GitHub issue tracker &ndash; to make sure
+      that it remains the best place to track issues that affect the development of Solana itself.
+
+
+      Questions like yours deserve a purpose-built Q&A forum. Unless there exists evidence that
+      this is a bug with Solana itself, please post your question to the Solana Stack Exchange
+      using this link: https://solana.stackexchange.com/questions/ask
+
+
+      ---
+
+      _This
+      [automated message](https://github.com/solana-labs/solana-program-library/blob/master/.github/label-actions.yml)
+      is a result of having added the &lsquo;question&rsquo; tag_.
+
+    # Close the issue
+    close: true

--- a/.github/workflows/label-actions.yml
+++ b/.github/workflows/label-actions.yml
@@ -1,0 +1,15 @@
+name: "Issue Label Actions"
+
+on:
+  issues:
+    types: [labeled, unlabeled]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/label-actions@v2


### PR DESCRIPTION
#### Problem

The monorepo has a way to add an automated message and close an issue with the "question" label, as seen here https://github.com/solana-labs/solana/issues/30685#issuecomment-1482051342, but SPL does not.

#### Solution

It's useful for SPL too, so add it in!