### PR TITLE
docs: Update token-2022 audits

### DIFF
--- a/docs/src/token-2022.md
+++ b/docs/src/token-2022.md
@@ -130,19 +130,21 @@ For information about the types and instructions, the Rust docs are available at
 The Token-2022 Program is currently under multiple audits to ensure safety of
 funds. All audits will be published here as they are completed.
 
-Here are the completed audits as of 12 December 2022:
+Here are the completed audits as of 3 April 2023:
 
 * Halborn
     - Review commit hash [`c3137a`](https://github.com/solana-labs/solana-program-library/tree/c3137af9dfa2cc0873cc84c4418dea88ac542965/token/program-2022)
-    - Final report https://github.com/solana-labs/security-audits/blob/master/spl/HalbornToken2022Audit.pdf
+    - Final report https://github.com/solana-labs/security-audits/blob/master/spl/HalbornToken2022Audit-2022-07-27.pdf
 * Zellic
     - Review commit hash [`54695b`](https://github.com/solana-labs/solana-program-library/tree/54695b233484722458b18c0e26ebb8334f98422c/token/program-2022)
-    - Final report https://github.com/solana-labs/security-audits/blob/master/spl/ZellicToken2022Audit.pdf
+    - Final report https://github.com/solana-labs/security-audits/blob/master/spl/ZellicToken2022Audit-2022-12-05.pdf
+* Trail of Bits
+    - Review commit hash ['50abad'](https://github.com/solana-labs/solana-program-library/tree/50abadd819df2e406567d6eca31c213264c1c7cd/token/program-2022)
+    - Final report https://github.com/solana-labs/security-audits/blob/master/spl/TrailOfBitsToken2022Audit-2023-02-10.pdf
 
 Here are the ongoing audits:
 
 * NCC Group
-* Trail of Bits
 
 ## Status and Upgradability
 
@@ -152,4 +154,4 @@ ONLY**.
 
 To facilitate deploying updates and security fixes, the program deployment remains
 upgradable. Once audits are complete, the deployment will be marked final and no
-further upgrades will be possible. This is expected to happen sometime in Q1 2023.
+further upgrades will be possible. This is expected to happen sometime in Q2 2023.


### PR DESCRIPTION
#### Problem

The token-2022 audits are out of date, and incorrectly linked.

#### Solution

Add the trail of bits audit, and use the correct links.