### PR TITLE
docs: Add scope from secrets

### DIFF
--- a/.github/workflows/spl_action.yml
+++ b/.github/workflows/spl_action.yml
@@ -24,3 +24,4 @@ jobs:
          ./build.sh
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_SCOPE: ${{ secrets.VERCEL_SCOPE }}

--- a/docs/publish-docs.sh
+++ b/docs/publish-docs.sh
@@ -17,7 +17,7 @@ fi
 cat > "$CONFIG_FILE" <<EOF
 {
   "name": "$PROJECT_NAME",
-  "scope": "solana-labs"
+  "scope": "$VERCEL_SCOPE",
 }
 EOF
 


### PR DESCRIPTION
#### Problem

The scope for docs has changed, but SPL didn't get the update.

#### Solution

`VERCEL_SCOPE` is defined on the repo, so consume it in the action / script!