### PR TITLE
docs: Remove dangling comma in JSON config

### DIFF
--- a/docs/publish-docs.sh
+++ b/docs/publish-docs.sh
@@ -17,7 +17,7 @@ fi
 cat > "$CONFIG_FILE" <<EOF
 {
   "name": "$PROJECT_NAME",
-  "scope": "$VERCEL_SCOPE",
+  "scope": "$VERCEL_SCOPE"
 }
 EOF
 


### PR DESCRIPTION
#### Problem

 #4110 tried to fix the docs build, but messed up because of a dangling comma, which made the config file invalid JSON.

#### Solution

Remove the dangling comma