### PR TITLE
[token-js] Switch to associated token address sync.

### DIFF
--- a/token/js/src/actions/createAssociatedTokenAccount.ts
+++ b/token/js/src/actions/createAssociatedTokenAccount.ts
@@ -2,7 +2,7 @@ import type { ConfirmOptions, Connection, PublicKey, Signer } from '@solana/web3
 import { sendAndConfirmTransaction, Transaction } from '@solana/web3.js';
 import { ASSOCIATED_TOKEN_PROGRAM_ID, TOKEN_PROGRAM_ID } from '../constants.js';
 import { createAssociatedTokenAccountInstruction } from '../instructions/associatedTokenAccount.js';
-import { getAssociatedTokenAddress } from '../state/mint.js';
+import { getAssociatedTokenAddressSync } from '../state/mint.js';
 
 /**
  * Create and initialize a new associated token account
@@ -26,7 +26,7 @@ export async function createAssociatedTokenAccount(
     programId = TOKEN_PROGRAM_ID,
     associatedTokenProgramId = ASSOCIATED_TOKEN_PROGRAM_ID
 ): Promise<PublicKey> {
-    const associatedToken = await getAssociatedTokenAddress(mint, owner, false, programId, associatedTokenProgramId);
+    const associatedToken = getAssociatedTokenAddressSync(mint, owner, false, programId, associatedTokenProgramId);
 
     const transaction = new Transaction().add(
         createAssociatedTokenAccountInstruction(

--- a/token/js/src/actions/createAssociatedTokenAccountIdempotent.ts
+++ b/token/js/src/actions/createAssociatedTokenAccountIdempotent.ts
@@ -2,7 +2,7 @@ import type { ConfirmOptions, Connection, PublicKey, Signer } from '@solana/web3
 import { sendAndConfirmTransaction, Transaction } from '@solana/web3.js';
 import { ASSOCIATED_TOKEN_PROGRAM_ID, TOKEN_PROGRAM_ID } from '../constants.js';
 import { createAssociatedTokenAccountIdempotentInstruction } from '../instructions/associatedTokenAccount.js';
-import { getAssociatedTokenAddress } from '../state/mint.js';
+import { getAssociatedTokenAddressSync } from '../state/mint.js';
 
 /**
  * Create and initialize a new associated token account
@@ -27,7 +27,7 @@ export async function createAssociatedTokenAccountIdempotent(
     programId = TOKEN_PROGRAM_ID,
     associatedTokenProgramId = ASSOCIATED_TOKEN_PROGRAM_ID
 ): Promise<PublicKey> {
-    const associatedToken = await getAssociatedTokenAddress(mint, owner, false, programId, associatedTokenProgramId);
+    const associatedToken = getAssociatedTokenAddressSync(mint, owner, false, programId, associatedTokenProgramId);
 
     const transaction = new Transaction().add(
         createAssociatedTokenAccountIdempotentInstruction(

--- a/token/js/src/actions/createWrappedNativeAccount.ts
+++ b/token/js/src/actions/createWrappedNativeAccount.ts
@@ -5,7 +5,7 @@ import { createAssociatedTokenAccountInstruction } from '../instructions/associa
 import { createInitializeAccountInstruction } from '../instructions/initializeAccount.js';
 import { createSyncNativeInstruction } from '../instructions/syncNative.js';
 import { ACCOUNT_SIZE, getMinimumBalanceForRentExemptAccount } from '../state/account.js';
-import { getAssociatedTokenAddress } from '../state/mint.js';
+import { getAssociatedTokenAddressSync } from '../state/mint.js';
 import { createAccount } from './createAccount.js';
 
 /**
@@ -36,7 +36,7 @@ export async function createWrappedNativeAccount(
 
     // If a keypair isn't provided, create the account at the owner's ATA for the native mint and return its address
     if (!keypair) {
-        const associatedToken = await getAssociatedTokenAddress(
+        const associatedToken = getAssociatedTokenAddressSync(
             nativeMint,
             owner,
             false,

--- a/token/js/src/actions/getOrCreateAssociatedTokenAccount.ts
+++ b/token/js/src/actions/getOrCreateAssociatedTokenAccount.ts
@@ -10,7 +10,7 @@ import {
 import { createAssociatedTokenAccountInstruction } from '../instructions/associatedTokenAccount.js';
 import type { Account } from '../state/account.js';
 import { getAccount } from '../state/account.js';
-import { getAssociatedTokenAddress } from '../state/mint.js';
+import { getAssociatedTokenAddressSync } from '../state/mint.js';
 
 /**
  * Retrieve the associated token account, or create it if it doesn't exist
@@ -38,7 +38,7 @@ export async function getOrCreateAssociatedTokenAccount(
     programId = TOKEN_PROGRAM_ID,
     associatedTokenProgramId = ASSOCIATED_TOKEN_PROGRAM_ID
 ): Promise<Account> {
-    const associatedToken = await getAssociatedTokenAddress(
+    const associatedToken = getAssociatedTokenAddressSync(
         mint,
         owner,
         allowOwnerOffCurve,


### PR DESCRIPTION
Replace asynchronous `getAssociatedTokenAddress` calls with synchronous `getAssociatedTokenAddressSync`. 