### PR TITLE
ci: Fix twoxtx build by properly patching crates

### DIFF
--- a/patch.crates-io.sh
+++ b/patch.crates-io.sh
@@ -9,6 +9,30 @@ if [[ -z $solana_dir ]]; then
   exit 1
 fi
 
+copyCargoSection() {
+  declare section="$1"
+  declare source_cargo_toml="$2"
+  declare destination_cargo_toml="$3"
+
+  if grep -q "\[$section\]" "$destination_cargo_toml"; then
+    echo "$destination_cargo_toml already has $section"
+  else
+    copy_package_info=false
+    while read line;
+    do
+      if [[ ("$line" == "" || "$line" = \[*) && "$copy_package_info" == "true" ]]; then
+        copy_package_info=false
+      fi
+      if [[ "$line" == "[$section]" ]]; then
+        copy_package_info=true
+      fi
+      if [[ "$copy_package_info" == "true" ]]; then
+        echo "$line" >> "$destination_cargo_toml"
+      fi
+    done < "$source_cargo_toml"
+  fi
+}
+
 workspace_crates=(
   Cargo.toml
 )
@@ -37,27 +61,72 @@ solana_ver=${solana_ver:-$(readCargoVariable version "$solana_dir"/sdk/Cargo.tom
 
 crates_map=()
 crates_map+=("solana-account-decoder account-decoder")
+crates_map+=("solana-address-lookup-table-program programs/address-lookup-table")
 crates_map+=("solana-banks-client banks-client")
+crates_map+=("solana-banks-interface banks-interface")
 crates_map+=("solana-banks-server banks-server")
+crates_map+=("solana-bench-tps bench-tps")
+crates_map+=("solana-bloom bloom")
 crates_map+=("solana-bpf-loader-program programs/bpf_loader")
+crates_map+=("solana-bucket-map bucket_map")
+crates_map+=("solana-connection-cache connection-cache")
 crates_map+=("solana-clap-utils clap-utils")
 crates_map+=("solana-clap-v3-utils clap-v3-utils")
+crates_map+=("solana-cli cli")
 crates_map+=("solana-cli-config cli-config")
 crates_map+=("solana-cli-output cli-output")
 crates_map+=("solana-client client")
+crates_map+=("solana-compute-budget-program programs/compute-budget")
+crates_map+=("solana-config-program programs/config")
 crates_map+=("solana-core core")
+crates_map+=("solana-download-utils download-utils")
+crates_map+=("solana-entry entry")
+crates_map+=("solana-faucet faucet")
+crates_map+=("solana-frozen-abi frozen-abi")
+crates_map+=("solana-frozen-abi-macro frozen-abi/macro")
+crates_map+=("solana-genesis genesis")
+crates_map+=("solana-genesis-utils genesis-utils")
+crates_map+=("solana-geyser-plugin-interface geyser-plugin-interface")
+crates_map+=("solana-geyser-plugin-manager geyser-plugin-manager")
+crates_map+=("solana-gossip gossip")
+crates_map+=("solana-ledger ledger")
+crates_map+=("solana-local-cluster local-cluster")
 crates_map+=("solana-logger logger")
+crates_map+=("solana-measure measure")
+crates_map+=("solana-merkle-tree merkle-tree")
+crates_map+=("solana-metrics metrics")
+crates_map+=("solana-net-utils net-utils")
 crates_map+=("solana-notifier notifier")
-crates_map+=("solana-remote-wallet remote-wallet")
+crates_map+=("solana-perf perf")
+crates_map+=("solana-poh poh")
 crates_map+=("solana-program sdk/program")
+crates_map+=("solana-program-runtime program-runtime")
 crates_map+=("solana-program-test program-test")
+crates_map+=("solana-pubsub-client pubsub-client")
+crates_map+=("solana-quic-client quic-client")
+crates_map+=("solana-rayon-threadlimit rayon-threadlimit")
+crates_map+=("solana-remote-wallet remote-wallet")
+crates_map+=("solana-rpc rpc")
+crates_map+=("solana-rpc-client rpc-client")
+crates_map+=("solana-rpc-client-api rpc-client-api")
+crates_map+=("solana-rpc-client-nonce-utils rpc-client-nonce-utils")
 crates_map+=("solana-runtime runtime")
 crates_map+=("solana-sdk sdk")
+crates_map+=("solana-sdk-macro sdk/macro")
+crates_map+=("solana-send-transaction-service send-transaction-service")
 crates_map+=("solana-stake-program programs/stake")
+crates_map+=("solana-storage-bigtable storage-bigtable")
+crates_map+=("solana-storage-proto storage-proto")
+crates_map+=("solana-streamer streamer")
+crates_map+=("solana-sys-tuner sys-tuner")
 crates_map+=("solana-test-validator test-validator")
+crates_map+=("solana-thin-client thin-client")
+crates_map+=("solana-tpu-client tpu-client")
 crates_map+=("solana-transaction-status transaction-status")
+crates_map+=("solana-udp-client udp-client")
 crates_map+=("solana-version version")
 crates_map+=("solana-vote-program programs/vote")
+crates_map+=("solana-zk-token-proof-program programs/zk-token-proof")
 crates_map+=("solana-zk-token-sdk zk-token-sdk")
 
 patch_crates=()
@@ -80,6 +149,24 @@ for crate in "${workspace_crates[@]}"; do
 $(printf "%s\n" "${patch_crates[@]}")
 PATCH
   fi
+done
+
+echo "Copying workspace package info"
+echo
+for crate in "${workspace_crates[@]}"; do
+  copyCargoSection "workspace.package" "$solana_dir/Cargo.toml" "$crate"
+done
+
+echo "Copying workspace dependencies"
+echo
+for crate in "${workspace_crates[@]}"; do
+  copyCargoSection "workspace.dependencies" "$solana_dir/Cargo.toml" "$crate"
+done
+echo "Rewriting solana crate paths"
+echo
+for map_entry in "${crates_map[@]}"; do
+  read -r crate_name crate_path <<<"$map_entry"
+  sed -E -i'' -e "s:(${crate_name} = \{ path = \")${crate_path}(\".*):\1${solana_dir}/${crate_path}\2:" "${workspace_crates[@]}"
 done
 
 ./update-solana-dependencies.sh "$solana_ver"

--- a/token/twoxtx-setup.sh
+++ b/token/twoxtx-setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Patch in a Solana v1.12 monorepo that supports 2x transactions for testing the
+# Patch in a Solana monorepo that supports 2x transactions for testing the
 # SPL Token 2022 Confidential Transfer extension
 #
 

--- a/update-solana-dependencies.sh
+++ b/update-solana-dependencies.sh
@@ -21,27 +21,72 @@ while IFS='' read -r line; do tomls+=("$line"); done < <(find . -name Cargo.toml
 
 crates=(
   solana-account-decoder
+  solana-address-lookup-table-program
   solana-banks-client
+  solana-banks-interface
   solana-banks-server
+  solana-bench-tps
+  solana-bloom
   solana-bpf-loader-program
+  solana-bucket-map
+  solana-connection-cache
   solana-clap-utils
   solana-clap-v3-utils
+  solana-cli
   solana-cli-config
   solana-cli-output
   solana-client
+  solana-compute-budget-program
+  solana-config-program
   solana-core
+  solana-download-utils
+  solana-entry
+  solana-faucet
+  solana-frozen-abi
+  solana-frozen-abi-macro
+  solana-genesis
+  solana-genesis-utils
+  solana-geyser-plugin-interface
+  solana-geyser-plugin-manager
+  solana-gossip
+  solana-ledger
+  solana-local-cluster
   solana-logger
+  solana-measure
+  solana-merkle-tree
+  solana-metrics
+  solana-net-utils
   solana-notifier
+  solana-perf
+  solana-poh
   solana-program
+  solana-program-runtime
   solana-program-test
+  solana-pubsub-client
+  solana-quic-client
+  solana-rayon-threadlimit
   solana-remote-wallet
+  solana-rpc
+  solana-rpc-client
+  solana-rpc-client-api
+  solana-rpc-client-nonce-utils
   solana-runtime
   solana-sdk
+  solana-sdk-macro
+  solana-send-transaction-service
   solana-stake-program
+  solana-storage-bigtable
+  solana-storage-proto
+  solana-streamer
+  solana-sys-tuner
   solana-test-validator
+  solana-thin-client
+  solana-tpu-client
   solana-transaction-status
-  solana-vote-program
+  solana-udp-client
   solana-version
+  solana-vote-program
+  solana-zk-token-proof-program
   solana-zk-token-sdk
 )
 


### PR DESCRIPTION
#### Problem

The twoxtx build is failing to properly patch the local checkout of the monorepo because of workspace dependencies.

#### Solution

It's a bit of a kludge, but just copy over the workspace dependencies and package info from the top-level Cargo.toml, and rewrite the paths. Since it only does something different if `[workspace.package]` and `[workspace.dependencies]` are defined, it's meant to work with the downstream build on older and newer versions of the monrepo.