### PR TITLE
token-cli: Always use supplied blockhash for nonce txs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6447,7 +6447,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-cli"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "assert_cmd",
  "clap 2.34.0",
@@ -6481,7 +6481,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-client"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "solana-cli-output",

--- a/token-upgrade/cli/Cargo.toml
+++ b/token-upgrade/cli/Cargo.toml
@@ -22,7 +22,7 @@ solana-sdk = "1.14.12"
 spl-associated-token-account = { version = "1.1", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token = { version = "3.5", path = "../../token/program", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "0.6", path = "../../token/program-2022", features = ["no-entrypoint"] }
-spl-token-client = { version = "0.4", path = "../../token/client" }
+spl-token-client = { version = "0.5", path = "../../token/client" }
 spl-token-upgrade = { version = "0.1", path = "../program", features = ["no-entrypoint"] }
 tokio = { version = "1", features = ["full"] }
 

--- a/token-upgrade/program/Cargo.toml
+++ b/token-upgrade/program/Cargo.toml
@@ -23,7 +23,7 @@ thiserror = "1.0"
 solana-program-test = "1.14.12"
 solana-sdk = "1.14.12"
 spl-token = { version = "3.5", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-client = { version = "0.4", path = "../../token/client" }
+spl-token-client = { version = "0.5", path = "../../token/client" }
 test-case = "2.2"
 
 [lib]

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://spl.solana.com/token"
 license = "Apache-2.0"
 name = "spl-token-cli"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "2.3.0"
+version = "2.4.0"
 
 [build-dependencies]
 walkdir = "2"
@@ -29,7 +29,7 @@ solana-sdk = "=1.14.12"
 solana-transaction-status = "=1.14.12"
 spl-token = { version = "3.5", path="../program", features = [ "no-entrypoint" ] }
 spl-token-2022 = { version = "0.6", path="../program-2022", features = [ "no-entrypoint" ] }
-spl-token-client = { version = "0.4", path="../client" }
+spl-token-client = { version = "0.5", path="../client" }
 spl-associated-token-account = { version = "1.1", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
 spl-memo = { version = "3.0.1", path="../../memo/program", features = ["no-entrypoint"] }
 strum = "0.24"

--- a/token/cli/src/config.rs
+++ b/token/cli/src/config.rs
@@ -11,8 +11,8 @@ use solana_cli_output::OutputFormat;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_remote_wallet::remote_wallet::RemoteWalletManager;
 use solana_sdk::{
-    account::Account as RawAccount, commitment_config::CommitmentConfig, pubkey::Pubkey,
-    signature::Signer,
+    account::Account as RawAccount, commitment_config::CommitmentConfig, hash::Hash,
+    pubkey::Pubkey, signature::Signer,
 };
 use spl_associated_token_account::*;
 use spl_token_2022::{
@@ -39,6 +39,7 @@ pub(crate) struct Config<'a> {
     pub(crate) fee_payer: Option<Arc<dyn Signer>>,
     pub(crate) nonce_account: Option<Pubkey>,
     pub(crate) nonce_authority: Option<Arc<dyn Signer>>,
+    pub(crate) nonce_blockhash: Option<Hash>,
     pub(crate) sign_only: bool,
     pub(crate) dump_transaction_message: bool,
     pub(crate) multisigner_pubkeys: Vec<&'a Pubkey>,
@@ -255,6 +256,7 @@ impl<'a> Config<'a> {
                 (default_program_id, false)
             };
 
+        let nonce_blockhash = value_of(matches, BLOCKHASH_ARG.name);
         Self {
             default_signer,
             rpc_client,
@@ -264,6 +266,7 @@ impl<'a> Config<'a> {
             fee_payer,
             nonce_account,
             nonce_authority,
+            nonce_blockhash,
             sign_only,
             dump_transaction_message,
             multisigner_pubkeys,

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -2352,11 +2352,17 @@ impl offline::ArgsConfig for SignOnlyNeedsFullMintSpec {
     fn sign_only_arg<'a, 'b>(&self, arg: Arg<'a, 'b>) -> Arg<'a, 'b> {
         arg.requires_all(&[MINT_ADDRESS_ARG.name, MINT_DECIMALS_ARG.name])
     }
+    fn signer_arg<'a, 'b>(&self, arg: Arg<'a, 'b>) -> Arg<'a, 'b> {
+        arg.requires_all(&[MINT_ADDRESS_ARG.name, MINT_DECIMALS_ARG.name])
+    }
 }
 
 struct SignOnlyNeedsMintDecimals {}
 impl offline::ArgsConfig for SignOnlyNeedsMintDecimals {
     fn sign_only_arg<'a, 'b>(&self, arg: Arg<'a, 'b>) -> Arg<'a, 'b> {
+        arg.requires_all(&[MINT_DECIMALS_ARG.name])
+    }
+    fn signer_arg<'a, 'b>(&self, arg: Arg<'a, 'b>) -> Arg<'a, 'b> {
         arg.requires_all(&[MINT_DECIMALS_ARG.name])
     }
 }
@@ -2366,11 +2372,17 @@ impl offline::ArgsConfig for SignOnlyNeedsMintAddress {
     fn sign_only_arg<'a, 'b>(&self, arg: Arg<'a, 'b>) -> Arg<'a, 'b> {
         arg.requires_all(&[MINT_ADDRESS_ARG.name])
     }
+    fn signer_arg<'a, 'b>(&self, arg: Arg<'a, 'b>) -> Arg<'a, 'b> {
+        arg.requires_all(&[MINT_ADDRESS_ARG.name])
+    }
 }
 
 struct SignOnlyNeedsDelegateAddress {}
 impl offline::ArgsConfig for SignOnlyNeedsDelegateAddress {
     fn sign_only_arg<'a, 'b>(&self, arg: Arg<'a, 'b>) -> Arg<'a, 'b> {
+        arg.requires_all(&[DELEGATE_ADDRESS_ARG.name])
+    }
+    fn signer_arg<'a, 'b>(&self, arg: Arg<'a, 'b>) -> Arg<'a, 'b> {
         arg.requires_all(&[DELEGATE_ADDRESS_ARG.name])
     }
 }

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -178,8 +178,6 @@ pub fn mint_address_arg<'a, 'b>() -> Arg<'a, 'b> {
         .takes_value(true)
         .value_name("MINT_ADDRESS")
         .validator(is_valid_pubkey)
-        .requires(SIGN_ONLY_ARG.name)
-        .requires(BLOCKHASH_ARG.name)
         .help(MINT_ADDRESS_ARG.help)
 }
 
@@ -213,8 +211,6 @@ pub fn delegate_address_arg<'a, 'b>() -> Arg<'a, 'b> {
         .takes_value(true)
         .value_name("DELEGATE_ADDRESS")
         .validator(is_valid_pubkey)
-        .requires(SIGN_ONLY_ARG.name)
-        .requires(BLOCKHASH_ARG.name)
         .help(DELEGATE_ADDRESS_ARG.help)
 }
 

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -193,8 +193,6 @@ pub fn mint_decimals_arg<'a, 'b>() -> Arg<'a, 'b> {
         .takes_value(true)
         .value_name("MINT_DECIMALS")
         .validator(is_mint_decimals)
-        .requires(SIGN_ONLY_ARG.name)
-        .requires(BLOCKHASH_ARG.name)
         .help(MINT_DECIMALS_ARG.help)
 }
 
@@ -367,10 +365,16 @@ fn token_client_from_config(
         config.fee_payer()?.clone(),
     );
 
-    if let (Some(nonce_account), Some(nonce_authority)) =
-        (config.nonce_account, &config.nonce_authority)
-    {
-        Ok(token.with_nonce(&nonce_account, Arc::clone(nonce_authority)))
+    if let (Some(nonce_account), Some(nonce_authority), Some(nonce_blockhash)) = (
+        config.nonce_account,
+        &config.nonce_authority,
+        config.nonce_blockhash,
+    ) {
+        Ok(token.with_nonce(
+            &nonce_account,
+            Arc::clone(nonce_authority),
+            &nonce_blockhash,
+        ))
     } else {
         Ok(token)
     }
@@ -385,10 +389,16 @@ fn native_token_client_from_config(
         config.fee_payer()?.clone(),
     );
 
-    if let (Some(nonce_account), Some(nonce_authority)) =
-        (config.nonce_account, &config.nonce_authority)
-    {
-        Ok(token.with_nonce(&nonce_account, Arc::clone(nonce_authority)))
+    if let (Some(nonce_account), Some(nonce_authority), Some(nonce_blockhash)) = (
+        config.nonce_account,
+        &config.nonce_authority,
+        config.nonce_blockhash,
+    ) {
+        Ok(token.with_nonce(
+            &nonce_account,
+            Arc::clone(nonce_authority),
+            &nonce_blockhash,
+        ))
     } else {
         Ok(token)
     }
@@ -4417,6 +4427,7 @@ mod tests {
             default_signer: Some(Arc::new(clone_keypair(payer))),
             nonce_account: None,
             nonce_authority: None,
+            nonce_blockhash: None,
             sign_only: false,
             dump_transaction_message: false,
             multisigner_pubkeys: vec![],
@@ -4443,6 +4454,7 @@ mod tests {
             default_signer: None,
             nonce_account: None,
             nonce_authority: None,
+            nonce_blockhash: None,
             sign_only: false,
             dump_transaction_message: false,
             multisigner_pubkeys: vec![],

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "spl-token-client"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "0.4.1"
+version = "0.5.0"
 
 [dependencies]
 async-trait = "0.1"

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -25,4 +25,4 @@ spl-associated-token-account = { version = "1.1", path = "../../associated-token
 spl-memo = { version = "3.0.1", path = "../../memo/program", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "0.6", path="../program-2022", features = ["no-entrypoint"] }
 spl-instruction-padding = { version = "0.1.0", path="../../instruction-padding/program", features = ["no-entrypoint"] }
-spl-token-client = { version = "0.4", path = "../client" }
+spl-token-client = { version = "0.5", path = "../client" }


### PR DESCRIPTION
#### Problem

The supplied `--blockhash` arg is ignored when online and finally sending the transaction, making it impossible to work with nonces.


#### Solution

Plumb the nonce blockhash down and use it.