### PR TITLE
[compression] expose macros for invoking getter/setters on const generic CMT

### DIFF
--- a/account-compression/Cargo.lock
+++ b/account-compression/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "spl-concurrent-merkle-tree"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bytemuck",
  "solana-program",

--- a/account-compression/programs/account-compression/Cargo.toml
+++ b/account-compression/programs/account-compression/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-account-compression"
-version = "0.1.8"
+version = "0.1.9"
 description = "Solana Program Library Account Compression Program"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/account-compression/programs/account-compression/src/macros.rs
+++ b/account-compression/programs/account-compression/src/macros.rs
@@ -6,6 +6,7 @@ enum TreeLoad {
 
 /// This macro applies functions on a ConcurrentMerkleT:ee and emits leaf information
 /// needed to sync the merkle tree state with off-chain indexers.
+#[macro_export]
 macro_rules! _merkle_tree_depth_size_apply_fn {
     ($max_depth:literal, $max_size:literal, $id:ident, $bytes:ident, $func:ident, TreeLoad::Mutable, $($arg:tt)*)
      => {
@@ -51,6 +52,7 @@ macro_rules! _merkle_tree_depth_size_apply_fn {
 /// This applies a given function on a ConcurrentMerkleTree by
 /// allowing the compiler to infer the size of the tree based
 /// upon the header information stored on-chain
+#[macro_export]
 macro_rules! _merkle_tree_apply_fn {
     ($header:ident, $($arg:tt)*) => {
         // Note: max_buffer_size MUST be a power of 2


### PR DESCRIPTION
bumps crate version to 0.1.9

Previously exported macros were unusable bc inner macros were private. Now fixed.