### PR TITLE
ci: Exclude solana dir during patch to avoid workspace issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[profile.dev]
+split-debuginfo = "unpacked"
+
 [workspace]
 members = [
   "associated-token-account/program",
@@ -46,6 +49,3 @@ members = [
   "utils/test-client",
   "token-lending/flash_loan_receiver",
 ]
-
-[profile.dev]
-split-debuginfo = "unpacked"

--- a/patch.crates-io.sh
+++ b/patch.crates-io.sh
@@ -31,6 +31,18 @@ if [[ -f "$toolchain_file" ]]; then
   cp "$toolchain_file" .
 fi
 
+echo "Excluding $solana_dir from workspace"
+echo
+for crate in "${workspace_crates[@]}"; do
+  if grep -q "exclude.*$solana_dir" "$crate"; then
+    echo "$crate is already patched"
+  else
+    cat >> $crate << EXCLUDE
+exclude = ["$solana_dir"]
+EXCLUDE
+  fi
+done
+
 # get version from Cargo.toml first. if it is empty, get it from other places.
 solana_ver="$(readCargoVariable version "$solana_dir"/Cargo.toml)"
 solana_ver=${solana_ver:-$(readCargoVariable version "$solana_dir"/sdk/Cargo.toml)}

--- a/token/twoxtx-setup.sh
+++ b/token/twoxtx-setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Patch in a Solana v1.12 monorepo that supports 2x transactions for testing the
+# Patch in a Solana monorepo that supports 2x transactions for testing the
 # SPL Token 2022 Confidential Transfer extension
 #
 


### PR DESCRIPTION
#### Problem

The token twoxtx build is failing because of workspace dependencies in the monorepo.

#### Solution

Exclude the local solana directory when patching crates to avoid two conflicting workspaces. This is a much better version of #4121 thanks to @yihau 