### PR TITLE
docs: Add token-2022 one-pager

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -8,6 +8,7 @@ module.exports = {
       collapsed: true,
       items: [
         "token-2022",
+        "token-2022/status",
         "token-2022/extensions",
         "token-2022/wallet",
         "token-2022/onchain",

--- a/docs/src/token-2022.md
+++ b/docs/src/token-2022.md
@@ -110,6 +110,7 @@ program, that creates new token accounts for either Token or Token-2022.
 To get started with Token-2022:
 
 - [Install the Solana Tools](https://docs.solana.com/cli/install-solana-cli-tools)
+- [Project Status](token-2022/status.md)
 - [Extension Guide](token-2022/extensions.mdx)
 - [Wallet Guide](token-2022/wallet.md)
 - [On-Chain Program Guide](token-2022/onchain.md)
@@ -139,19 +140,8 @@ Here are the completed audits as of 3 April 2023:
     - Review commit hash [`54695b`](https://github.com/solana-labs/solana-program-library/tree/54695b233484722458b18c0e26ebb8334f98422c/token/program-2022)
     - Final report https://github.com/solana-labs/security-audits/blob/master/spl/ZellicToken2022Audit-2022-12-05.pdf
 * Trail of Bits
-    - Review commit hash ['50abad'](https://github.com/solana-labs/solana-program-library/tree/50abadd819df2e406567d6eca31c213264c1c7cd/token/program-2022)
+    - Review commit hash [`50abad`](https://github.com/solana-labs/solana-program-library/tree/50abadd819df2e406567d6eca31c213264c1c7cd/token/program-2022)
     - Final report https://github.com/solana-labs/security-audits/blob/master/spl/TrailOfBitsToken2022Audit-2023-02-10.pdf
-
-Here are the ongoing audits:
-
 * NCC Group
-
-## Status and Upgradability
-
-The Token-2022 program is still under audit and not meant for full production use.
-All clusters have the latest program deployed **for testing and development purposes
-ONLY**.
-
-To facilitate deploying updates and security fixes, the program deployment remains
-upgradable. Once audits are complete, the deployment will be marked final and no
-further upgrades will be possible. This is expected to happen sometime in Q2 2023.
+    - Review commit hash [`4e43aa`](https://github.com/solana-labs/solana/tree/4e43aa6c18e6bb4d98559f80eb004de18bc6b418/zk-token-sdk)
+    - Final report https://github.com/solana-labs/security-audits/blob/master/spl/NCCToken2022Audit-2023-04-05.pdf

--- a/docs/src/token-2022/status.md
+++ b/docs/src/token-2022/status.md
@@ -1,0 +1,69 @@
+---
+title: Project Status
+---
+
+The Token-2022 program is still under audit and not meant for full production use.
+In the meantime, all clusters have the latest program deployed **for testing and
+development purposes ONLY**.
+
+## Timeline
+
+Here is the general program timeline and rough ETAs:
+
+| Issue | ETA |
+| --- | --- |
+| Finish program | end of May |
+| Final audit | end of June |
+| Mainnet recommendation | middle of July |
+| Freeze program | Q1 2024 |
+
+More information: https://github.com/orgs/solana-labs/projects/34
+
+## Remaining items
+
+### Zero-knowledge proof split
+
+To fit within the current transaction size limits, the zero knowledge proofs must
+be split into their component parts and uploaded to the chain through multiple
+transactions. Once the proofs exist, the user can issue a transfer and clean up
+the proofs.
+
+After splitting the proofs in the zero-knowledge token SDK, the token-2022 program
+must properly consume the new proof format.
+
+More information: https://github.com/solana-labs/solana/pull/30816
+
+### Permissioned-transfer extension
+
+There are many mutually exclusive solutions for restricting transfer of tokens,
+that all require different sets of accounts to validate a transfer.
+
+The permissioned-transfer extension allows a mint creator to specify a program
+that must be called to validate transfers. The program must conform to the
+permissioned-transfer program interface.
+
+More information: https://github.com/solana-labs/solana-program-library/pull/4105
+
+## Future work
+
+### Wallets
+
+To start, wallets need to properly handle the token-2022 program and its accounts,
+by fetching token-2022 accounts and sending instructions to the proper program.
+
+Next, to use confidential tokens, wallets need to create zero-knowledge proofs,
+which entails a new transaction flow.
+
+### Increased transaction size
+
+To support confidential transfers in one transaction, rather than split up over
+multiple transactions, the Solana network must accept transactions with a larger
+payload.
+
+More information: https://github.com/orgs/solana-labs/projects/16
+
+## Upgradability
+
+To facilitate deploying updates and security fixes, the program deployment remains
+upgradable. Once audits are complete and the program has been stable for six months,
+the deployment will be marked final and no further upgrades will be possible.

--- a/docs/src/token-2022/status.md
+++ b/docs/src/token-2022/status.md
@@ -21,6 +21,13 @@ More information: https://github.com/orgs/solana-labs/projects/34
 
 ## Remaining items
 
+### v1.14 with curve syscalls
+
+In order to use confidential tokens, the cluster must run at least version 1.14
+with the elliptic curve operations syscalls enabled.
+
+More information: https://github.com/solana-labs/solana/issues/29612
+
 ### Zero-knowledge proof split
 
 To fit within the current transaction size limits, the zero knowledge proofs must


### PR DESCRIPTION
#### Problem

Although the GitHub project information lives at https://github.com/orgs/solana-labs/projects/34/views/1, that's not really consumable by a general audience.

#### Solution

Add a token-2022 one-pager. While I was at it, I added the NCC audit, hope that's ok!