### PR TITLE
make exported compression macros usable

### DIFF
--- a/account-compression/programs/account-compression/src/lib.rs
+++ b/account-compression/programs/account-compression/src/lib.rs
@@ -40,8 +40,8 @@ pub mod zero_copy;
 pub use crate::noop::{wrap_application_data_v1, Noop};
 
 use crate::canopy::{fill_in_proof_from_canopy, update_canopy};
-use crate::error::AccountCompressionError;
-use crate::events::{AccountCompressionEvent, ChangeLogEvent};
+pub use crate::error::AccountCompressionError;
+pub use crate::events::{AccountCompressionEvent, ChangeLogEvent};
 use crate::noop::wrap_event;
 use crate::state::{
     merkle_tree_get_size, ConcurrentMerkleTreeHeader, CONCURRENT_MERKLE_TREE_HEADER_SIZE_V1,


### PR DESCRIPTION
Without these 2 exports using exported macros from macros.rs is not possible.
```
error[E0603]: enum `AccountCompressionError` is private
  --> programs/tcomp/src/shared.rs:9:5
   |
9  |     AccountCompressionError, ChangeLogEvent, ConcurrentMerkleTree,
   |     ^^^^^^^^^^^^^^^^^^^^^^^ private enum
   |
note: the enum `AccountCompressionError` is defined here

error[E0603]: enum `ChangeLogEvent` is private
  --> programs/tcomp/src/shared.rs:9:30
   |
9  |     AccountCompressionError, ChangeLogEvent, ConcurrentMerkleTree,
   |                              ^^^^^^^^^^^^^^ private enum
   |
note: the enum `ChangeLogEvent` is defined here
```