### PR TITLE
Fix ESM type exports in spl-token-swap

### DIFF
--- a/token-swap/js/package.json
+++ b/token-swap/js/package.json
@@ -21,7 +21,8 @@
   "sideEffects": false,
   "exports": {
       "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts"
   },
   "files": [
     "dist",


### PR DESCRIPTION
When importing @solana/spl-token-swap as an ESM module, the typescript compiler is unable to resolve the types, we need to export them from package.json.