### PR TITLE
js: move `types` condition to the front

### DIFF
--- a/account-compression/sdk/package.json
+++ b/account-compression/sdk/package.json
@@ -26,9 +26,9 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "require": "./dist/cjs/index.js",
-      "import": "./dist/cjs/index.js",
-      "types": "./dist/types/index.d.ts"
+      "import": "./dist/cjs/index.js"
     },
     "./idl/spl_account_compression.json": "./idl/spl_account_compression.json"
   },

--- a/memo/js/package.json
+++ b/memo/js/package.json
@@ -23,9 +23,9 @@
     "module": "./lib/esm/index.js",
     "types": "./lib/types/index.d.ts",
     "exports": {
+        "types": "./lib/types/index.d.ts",
         "require": "./lib/cjs/index.js",
-        "import": "./lib/esm/index.js",
-        "types": "./lib/types/index.d.ts"
+        "import": "./lib/esm/index.js"
     },
     "scripts": {
         "nuke": "shx rm -rf node_modules package-lock.json || true",

--- a/token-swap/js/package.json
+++ b/token-swap/js/package.json
@@ -20,9 +20,9 @@
   "module": "dist/esm/index.js",
   "sideEffects": false,
   "exports": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "types": "./dist/types/index.d.ts"
+      "require": "./dist/cjs/index.js"
   },
   "files": [
     "dist",

--- a/token/js/package.json
+++ b/token/js/package.json
@@ -23,9 +23,9 @@
     "module": "./lib/esm/index.js",
     "types": "./lib/types/index.d.ts",
     "exports": {
+        "types": "./lib/types/index.d.ts",
         "require": "./lib/cjs/index.js",
-        "import": "./lib/esm/index.js",
-        "types": "./lib/types/index.d.ts"
+        "import": "./lib/esm/index.js"
     },
     "scripts": {
         "nuke": "shx rm -rf node_modules package-lock.json || true",


### PR DESCRIPTION
I moved `types` condition to the front. `package.json#exports` are **order-sensitive** - they are always matched from the top to the bottom. When a match is found then it should be used and no further matching should occur. 

Right now, the current setup works in TypeScript but it's considered a bug and it should not be relied upon, see the thread and the comment [here](https://github.com/microsoft/TypeScript/issues/50762#issuecomment-1528318260). For that reason, I would like to fix all popular packages that misconfigured their `exports` this way so the bug can be fixed in TypeScript.

⚠️ this PR focuses solely on fixing "🐛 Used fallback condition" problem but the "👺 Masquerading as ESM" and "⚠️ ESM (dynamic import only)" remain here. You can check the reported errors [here](https://arethetypeswrong.github.io/?p=%40solana%2Fspl-token%400.3.7)