### PR TITLE
deps: Upgrade base64 to 0.21.0, remove where it's not used

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,6 +364,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
 name = "base64ct"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6111,7 +6117,7 @@ version = "3.1.1"
 dependencies = [
  "arrayref",
  "assert_matches",
- "base64 0.13.0",
+ "base64 0.21.0",
  "bincode",
  "borsh",
  "num-derive",
@@ -6145,7 +6151,6 @@ version = "0.1.3"
 dependencies = [
  "arrayref",
  "assert_matches",
- "base64 0.13.0",
  "bincode",
  "borsh",
  "num-derive",
@@ -6169,7 +6174,6 @@ version = "0.2.7"
 dependencies = [
  "arrayref",
  "assert_matches",
- "base64 0.13.0",
  "bincode",
  "borsh",
  "num-derive",
@@ -6558,7 +6562,7 @@ version = "0.2.0"
 dependencies = [
  "arrayref",
  "assert_matches",
- "base64 0.13.0",
+ "base64 0.21.0",
  "bytemuck",
  "log",
  "num-derive",

--- a/governance/addin-mock/program/Cargo.toml
+++ b/governance/addin-mock/program/Cargo.toml
@@ -28,7 +28,6 @@ thiserror = "1.0"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-base64 = "0.13"
 proptest = "1.1"
 solana-program-test = "1.14.12"
 solana-sdk = "1.14.12"

--- a/governance/chat/program/Cargo.toml
+++ b/governance/chat/program/Cargo.toml
@@ -29,7 +29,6 @@ thiserror = "1.0"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-base64 = "0.13"
 proptest = "1.1"
 solana-program-test = "1.14.12"
 solana-sdk = "1.14.12"

--- a/governance/program/Cargo.toml
+++ b/governance/program/Cargo.toml
@@ -27,7 +27,7 @@ thiserror = "1.0"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-base64 = "0.13"
+base64 = "0.21"
 proptest = "1.1"
 solana-program-test = "1.14.12"
 solana-sdk = "1.14.12"

--- a/governance/program/src/state/proposal_transaction.rs
+++ b/governance/program/src/state/proposal_transaction.rs
@@ -248,11 +248,12 @@ pub fn get_proposal_transaction_data_for_proposal(
 #[cfg(test)]
 mod test {
 
-    use std::str::FromStr;
-
-    use solana_program::{bpf_loader_upgradeable, clock::Epoch};
-
-    use super::*;
+    use {
+        super::*,
+        base64::{engine::general_purpose, Engine as _},
+        solana_program::{bpf_loader_upgradeable, clock::Epoch},
+        std::str::FromStr,
+    };
 
     fn create_test_account_meta_data() -> AccountMetaData {
         AccountMetaData {
@@ -341,7 +342,7 @@ mod test {
         instruction_data.serialize(&mut instruction_bytes).unwrap();
 
         // base64 encoded message is accepted as the input in the UI
-        let base64 = base64::encode(instruction_bytes.clone());
+        let encoded = general_purpose::STANDARD_NO_PAD.encode(&instruction_bytes);
 
         // Assert
         let instruction =
@@ -349,7 +350,7 @@ mod test {
 
         assert_eq!(upgrade_instruction, instruction);
 
-        assert_eq!(base64,"Aqj2kU6IobDiEBU+92OuKwDCuT0WwSTSwFN6EASAAAAHAAAAchkHXTU9jF+rKpILT6dzsVyNI9NsQy9cab+GGvdwNn0AAfh2HVruy2YibpgcQUmJf5att5YdPXSv1k2pRAKAfpSWAAFDVQuXWos2urmegSPblI813GlTm7CJ/8rv+9yzNE3yfwAB3Gw+apCyfrRNqJ6f1160Htkx+uYZT6FIILQ3WzNA4KwAAQan1RcZLFxRIYzJTD1K8X9Y2u4Im6H9ROPb2YoAAAAAAAAGp9UXGMd0yShWY5hpHV62i164o5tLbVxzVVshAAAAAAAA3Gw+apCyfrRNqJ6f1160Htkx+uYZT6FIILQ3WzNA4KwBAAQAAAADAAAA");
+        assert_eq!(encoded,"Aqj2kU6IobDiEBU+92OuKwDCuT0WwSTSwFN6EASAAAAHAAAAchkHXTU9jF+rKpILT6dzsVyNI9NsQy9cab+GGvdwNn0AAfh2HVruy2YibpgcQUmJf5att5YdPXSv1k2pRAKAfpSWAAFDVQuXWos2urmegSPblI813GlTm7CJ/8rv+9yzNE3yfwAB3Gw+apCyfrRNqJ6f1160Htkx+uYZT6FIILQ3WzNA4KwAAQan1RcZLFxRIYzJTD1K8X9Y2u4Im6H9ROPb2YoAAAAAAAAGp9UXGMd0yShWY5hpHV62i164o5tLbVxzVVshAAAAAAAA3Gw+apCyfrRNqJ6f1160Htkx+uYZT6FIILQ3WzNA4KwBAAQAAAADAAAA");
     }
 
     #[test]

--- a/token-lending/program/Cargo.toml
+++ b/token-lending/program/Cargo.toml
@@ -23,7 +23,7 @@ uint = "0.9"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-base64 = "0.13"
+base64 = "0.21"
 log = "0.4.14"
 proptest = "1.1"
 solana-program-test = "1.14.12"

--- a/token-lending/program/tests/helpers/genesis.rs
+++ b/token-lending/program/tests/helpers/genesis.rs
@@ -1,3 +1,4 @@
+use base64::{engine::general_purpose, Engine as _};
 use serde::{Deserialize, Serialize};
 use solana_program::bpf_loader_upgradeable;
 use solana_program_test::*;
@@ -24,7 +25,7 @@ impl From<Account> for Base64Account {
             owner: account.owner.to_string(),
             balance: account.lamports,
             executable: account.executable,
-            data: base64::encode(&account.data),
+            data: general_purpose::STANDARD_NO_PAD.encode(&account.data),
         }
     }
 }


### PR DESCRIPTION
#### Problem

#4163 is trying to upgrade the base64 crate, which has a new API. While fixing this, I noticed that a bunch of governance crates declare base64 as a dev dependency but never use it.

#### Solution

Upgrade base64 to 0.21, use the new API, remove it where it isn't used