### PR TITLE
borsh: Use `to_writer` API to serialize

### DIFF
--- a/binary-option/program/src/processor.rs
+++ b/binary-option/program/src/processor.rs
@@ -11,7 +11,7 @@ use crate::{
         assert_initialized, assert_keys_equal, assert_keys_unequal, assert_owned_by,
     },
 };
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::BorshDeserialize;
 use solana_program::{
     account_info::{next_account_info, AccountInfo},
     entrypoint::ProgramResult,
@@ -175,8 +175,10 @@ pub fn process_initialize_binary_option(
     binary_option.escrow_mint_account_pubkey = *escrow_mint_info.key;
     binary_option.escrow_account_pubkey = *escrow_account_info.key;
     binary_option.owner = *update_authority_info.key;
-    binary_option.serialize(&mut *binary_option_account_info.data.borrow_mut())?;
-
+    borsh::to_writer(
+        &mut binary_option_account_info.data.borrow_mut()[..],
+        &binary_option,
+    )?;
     Ok(())
 }
 
@@ -576,7 +578,10 @@ pub fn process_trade(
         s_l,
         long_token_mint.decimals,
     )?;
-    binary_option.serialize(&mut *binary_option_account_info.data.borrow_mut())?;
+    borsh::to_writer(
+        &mut binary_option_account_info.data.borrow_mut()[..],
+        &binary_option,
+    )?;
     Ok(())
 }
 
@@ -607,7 +612,10 @@ pub fn process_settle(_program_id: &Pubkey, accounts: &[AccountInfo]) -> Program
         return Err(BinaryOptionError::InvalidWinner.into());
     }
     binary_option.settled = true;
-    binary_option.serialize(&mut *binary_option_account_info.data.borrow_mut())?;
+    borsh::to_writer(
+        &mut binary_option_account_info.data.borrow_mut()[..],
+        &binary_option,
+    )?;
     Ok(())
 }
 
@@ -724,6 +732,9 @@ pub fn process_collect(program_id: &Pubkey, accounts: &[AccountInfo]) -> Program
         )?;
         binary_option.decrement_supply(reward)?;
     }
-    binary_option.serialize(&mut *binary_option_account_info.data.borrow_mut())?;
+    borsh::to_writer(
+        &mut binary_option_account_info.data.borrow_mut()[..],
+        &binary_option,
+    )?;
     Ok(())
 }

--- a/binary-oracle-pair/program/src/processor.rs
+++ b/binary-oracle-pair/program/src/processor.rs
@@ -5,7 +5,7 @@ use crate::{
     instruction::PoolInstruction,
     state::{Decision, Pool, POOL_VERSION},
 };
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::BorshDeserialize;
 use solana_program::{
     account_info::next_account_info,
     account_info::AccountInfo,
@@ -300,8 +300,7 @@ impl Processor {
         pool.decide_end_slot = decide_end_slot;
         pool.decision = Decision::Undecided;
 
-        pool.serialize(&mut *pool_account_info.data.borrow_mut())
-            .map_err(|e| e.into())
+        borsh::to_writer(&mut pool_account_info.data.borrow_mut()[..], &pool).map_err(|e| e.into())
     }
 
     /// Process Deposit instruction
@@ -556,8 +555,7 @@ impl Processor {
             Decision::Fail
         };
 
-        pool.serialize(&mut *pool_account_info.data.borrow_mut())
-            .map_err(|e| e.into())
+        borsh::to_writer(&mut pool_account_info.data.borrow_mut()[..], &pool).map_err(|e| e.into())
     }
 
     /// Processes an instruction

--- a/record/program/src/processor.rs
+++ b/record/program/src/processor.rs
@@ -6,7 +6,7 @@ use {
         instruction::RecordInstruction,
         state::{Data, RecordData},
     },
-    borsh::{BorshDeserialize, BorshSerialize},
+    borsh::BorshDeserialize,
     solana_program::{
         account_info::{next_account_info, AccountInfo},
         entrypoint::ProgramResult,
@@ -53,8 +53,7 @@ pub fn process_instruction(
 
             account_data.authority = *authority_info.key;
             account_data.version = RecordData::CURRENT_VERSION;
-            account_data
-                .serialize(&mut *data_info.data.borrow_mut())
+            borsh::to_writer(&mut data_info.data.borrow_mut()[..], &account_data)
                 .map_err(|e| e.into())
         }
 
@@ -90,8 +89,7 @@ pub fn process_instruction(
             }
             check_authority(authority_info, &account_data.authority)?;
             account_data.authority = *new_authority_info.key;
-            account_data
-                .serialize(&mut *data_info.data.borrow_mut())
+            borsh::to_writer(&mut data_info.data.borrow_mut()[..], &account_data)
                 .map_err(|e| e.into())
         }
 
@@ -113,8 +111,7 @@ pub fn process_instruction(
                 .checked_add(data_lamports)
                 .ok_or(RecordError::Overflow)?;
             account_data.data = Data::default();
-            account_data
-                .serialize(&mut *data_info.data.borrow_mut())
+            borsh::to_writer(&mut data_info.data.borrow_mut()[..], &account_data)
                 .map_err(|e| e.into())
         }
     }

--- a/stake-pool/program/src/big_vec.rs
+++ b/stake-pool/program/src/big_vec.rs
@@ -3,7 +3,7 @@
 
 use {
     arrayref::array_ref,
-    borsh::{BorshDeserialize, BorshSerialize},
+    borsh::BorshDeserialize,
     solana_program::{
         program_error::ProgramError, program_memory::sol_memmove, program_pack::Pack,
     },
@@ -79,7 +79,7 @@ impl<'data> BigVec<'data> {
         }
 
         let mut vec_len_ref = &mut self.data[0..VEC_SIZE_BYTES];
-        vec_len.serialize(&mut vec_len_ref)?;
+        borsh::to_writer(&mut vec_len_ref, &vec_len)?;
 
         Ok(())
     }
@@ -116,7 +116,7 @@ impl<'data> BigVec<'data> {
         let end_index = start_index + T::LEN;
 
         vec_len += 1;
-        vec_len.serialize(&mut vec_len_ref)?;
+        borsh::to_writer(&mut vec_len_ref, &vec_len)?;
 
         if self.data.len() < end_index {
             return Err(ProgramError::AccountDataTooSmall);
@@ -252,7 +252,7 @@ mod tests {
         const LEN: usize = 8;
         fn pack_into_slice(&self, data: &mut [u8]) {
             let mut data = data;
-            self.value.serialize(&mut data).unwrap();
+            borsh::to_writer(&mut data, &self.value).unwrap();
         }
         fn unpack_from_slice(src: &[u8]) -> Result<Self, ProgramError> {
             Ok(TestStruct {

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -14,7 +14,7 @@ use {
         AUTHORITY_DEPOSIT, AUTHORITY_WITHDRAW, EPHEMERAL_STAKE_SEED_PREFIX,
         TRANSIENT_STAKE_SEED_PREFIX,
     },
-    borsh::{BorshDeserialize, BorshSerialize},
+    borsh::BorshDeserialize,
     mpl_token_metadata::{
         instruction::{create_metadata_accounts_v3, update_metadata_accounts_v2},
         pda::find_metadata_account,
@@ -901,7 +901,10 @@ impl Processor {
             )?;
         }
 
-        validator_list.serialize(&mut *validator_list_info.data.borrow_mut())?;
+        borsh::to_writer(
+            &mut validator_list_info.data.borrow_mut()[..],
+            &validator_list,
+        )?;
 
         stake_pool.account_type = AccountType::StakePool;
         stake_pool.manager = *manager_info.key;
@@ -932,8 +935,7 @@ impl Processor {
         stake_pool.last_epoch_pool_token_supply = 0;
         stake_pool.last_epoch_total_lamports = 0;
 
-        stake_pool
-            .serialize(&mut *stake_pool_info.data.borrow_mut())
+        borsh::to_writer(&mut stake_pool_info.data.borrow_mut()[..], &stake_pool)
             .map_err(|e| e.into())
     }
 
@@ -1216,7 +1218,7 @@ impl Processor {
         if stake_pool.preferred_withdraw_validator_vote_address == Some(vote_account_address) {
             stake_pool.preferred_withdraw_validator_vote_address = None;
         }
-        stake_pool.serialize(&mut *stake_pool_info.data.borrow_mut())?;
+        borsh::to_writer(&mut stake_pool_info.data.borrow_mut()[..], &stake_pool)?;
 
         Ok(())
     }
@@ -2136,7 +2138,7 @@ impl Processor {
                 stake_pool.preferred_withdraw_validator_vote_address = vote_account_address
             }
         };
-        stake_pool.serialize(&mut *stake_pool_info.data.borrow_mut())?;
+        borsh::to_writer(&mut stake_pool_info.data.borrow_mut()[..], &stake_pool)?;
         Ok(())
     }
 
@@ -2549,7 +2551,7 @@ impl Processor {
         let pool_mint = StateWithExtensions::<Mint>::unpack(&pool_mint_data)?;
         stake_pool.pool_token_supply = pool_mint.base.supply;
 
-        stake_pool.serialize(&mut *stake_pool_info.data.borrow_mut())?;
+        borsh::to_writer(&mut stake_pool_info.data.borrow_mut()[..], &stake_pool)?;
 
         Ok(())
     }
@@ -2842,7 +2844,7 @@ impl Processor {
             .total_lamports
             .checked_add(total_deposit_lamports)
             .ok_or(StakePoolError::CalculationFailure)?;
-        stake_pool.serialize(&mut *stake_pool_info.data.borrow_mut())?;
+        borsh::to_writer(&mut stake_pool_info.data.borrow_mut()[..], &stake_pool)?;
 
         validator_stake_info.active_stake_lamports = validator_stake_account_info.lamports();
 
@@ -2992,7 +2994,7 @@ impl Processor {
             .total_lamports
             .checked_add(deposit_lamports)
             .ok_or(StakePoolError::CalculationFailure)?;
-        stake_pool.serialize(&mut *stake_pool_info.data.borrow_mut())?;
+        borsh::to_writer(&mut stake_pool_info.data.borrow_mut()[..], &stake_pool)?;
 
         Ok(())
     }
@@ -3272,7 +3274,7 @@ impl Processor {
             .total_lamports
             .checked_sub(withdraw_lamports)
             .ok_or(StakePoolError::CalculationFailure)?;
-        stake_pool.serialize(&mut *stake_pool_info.data.borrow_mut())?;
+        borsh::to_writer(&mut stake_pool_info.data.borrow_mut()[..], &stake_pool)?;
 
         if let Some((validator_list_item, withdraw_source)) = validator_list_item_info {
             match withdraw_source {
@@ -3450,7 +3452,7 @@ impl Processor {
             .total_lamports
             .checked_sub(withdraw_lamports)
             .ok_or(StakePoolError::CalculationFailure)?;
-        stake_pool.serialize(&mut *stake_pool_info.data.borrow_mut())?;
+        borsh::to_writer(&mut stake_pool_info.data.borrow_mut()[..], &stake_pool)?;
 
         Ok(())
     }
@@ -3642,7 +3644,7 @@ impl Processor {
 
         stake_pool.manager = *new_manager_info.key;
         stake_pool.manager_fee_account = *new_manager_fee_info.key;
-        stake_pool.serialize(&mut *stake_pool_info.data.borrow_mut())?;
+        borsh::to_writer(&mut stake_pool_info.data.borrow_mut()[..], &stake_pool)?;
         Ok(())
     }
 
@@ -3671,7 +3673,7 @@ impl Processor {
 
         fee.check_too_high()?;
         stake_pool.update_fee(&fee)?;
-        stake_pool.serialize(&mut *stake_pool_info.data.borrow_mut())?;
+        borsh::to_writer(&mut stake_pool_info.data.borrow_mut()[..], &stake_pool)?;
         Ok(())
     }
 
@@ -3695,7 +3697,7 @@ impl Processor {
             return Err(StakePoolError::SignatureMissing.into());
         }
         stake_pool.staker = *new_staker_info.key;
-        stake_pool.serialize(&mut *stake_pool_info.data.borrow_mut())?;
+        borsh::to_writer(&mut stake_pool_info.data.borrow_mut()[..], &stake_pool)?;
         Ok(())
     }
 
@@ -3729,7 +3731,7 @@ impl Processor {
             FundingType::SolDeposit => stake_pool.sol_deposit_authority = new_authority,
             FundingType::SolWithdraw => stake_pool.sol_withdraw_authority = new_authority,
         }
-        stake_pool.serialize(&mut *stake_pool_info.data.borrow_mut())?;
+        borsh::to_writer(&mut stake_pool_info.data.borrow_mut()[..], &stake_pool)?;
         Ok(())
     }
 

--- a/stake-pool/program/src/state.rs
+++ b/stake-pool/program/src/state.rs
@@ -701,7 +701,7 @@ impl Pack for ValidatorStakeInfo {
         let mut data = data;
         // Removing this unwrap would require changing from `Pack` to some other
         // trait or `bytemuck`, so it stays in for now
-        self.serialize(&mut data).unwrap();
+        borsh::to_writer(&mut data, self).unwrap();
     }
     fn unpack_from_slice(src: &[u8]) -> Result<Self, ProgramError> {
         let unpacked = Self::try_from_slice(src)?;
@@ -1043,7 +1043,7 @@ mod test {
         let stake_list = uninitialized_validator_list();
         let mut byte_vec = vec![0u8; size];
         let mut bytes = byte_vec.as_mut_slice();
-        stake_list.serialize(&mut bytes).unwrap();
+        borsh::to_writer(&mut bytes, &stake_list).unwrap();
         let stake_list_unpacked = try_from_slice_unchecked::<ValidatorList>(&byte_vec).unwrap();
         assert_eq!(stake_list_unpacked, stake_list);
 
@@ -1057,7 +1057,7 @@ mod test {
         };
         let mut byte_vec = vec![0u8; size];
         let mut bytes = byte_vec.as_mut_slice();
-        stake_list.serialize(&mut bytes).unwrap();
+        borsh::to_writer(&mut bytes, &stake_list).unwrap();
         let stake_list_unpacked = try_from_slice_unchecked::<ValidatorList>(&byte_vec).unwrap();
         assert_eq!(stake_list_unpacked, stake_list);
 
@@ -1065,7 +1065,7 @@ mod test {
         let stake_list = test_validator_list(max_validators);
         let mut byte_vec = vec![0u8; size];
         let mut bytes = byte_vec.as_mut_slice();
-        stake_list.serialize(&mut bytes).unwrap();
+        borsh::to_writer(&mut bytes, &stake_list).unwrap();
         let stake_list_unpacked = try_from_slice_unchecked::<ValidatorList>(&byte_vec).unwrap();
         assert_eq!(stake_list_unpacked, stake_list);
     }


### PR DESCRIPTION
#### Problem

The `borsh::to_writer` API has been available in borsh for some time, and it gives clearer semantics for slices.

#### Solution

Use that API in all programs