### PR TITLE
docs: Scrub all references to token-list

### DIFF
--- a/docs/src/token.mdx
+++ b/docs/src/token.mdx
@@ -1819,11 +1819,12 @@ The sender's wallet must not require that the recipient's main wallet address
 hold a balance before allowing the transfer.
 
 ### Registry for token details
+
 At the moment there exist two solutions for Token Mint registries:
 
-* hard coded addresses in the wallet or dapp
-* [spl-token-registry](https://www.npmjs.com/package/@solana/spl-token-registry)
-package, maintained at [https://github.com/solana-labs/token-list](https://github.com/solana-labs/token-list)
+* Hard coded addresses in the wallet or dapp
+* Metaplex Token Metadata. Learn more at the
+[Token Metadata Documentation](https://docs.metaplex.com/programs/token-metadata/)
 
 **A decentralized solution is in progress.**
 

--- a/docs/src/token.mdx
+++ b/docs/src/token.mdx
@@ -1820,11 +1820,13 @@ hold a balance before allowing the transfer.
 
 ### Registry for token details
 
-At the moment there exist two solutions for Token Mint registries:
+At the moment there exist a few solutions for Token Mint registries:
 
 * Hard coded addresses in the wallet or dapp
 * Metaplex Token Metadata. Learn more at the
 [Token Metadata Documentation](https://docs.metaplex.com/programs/token-metadata/)
+* The deprecated token-list repo has
+[instructions for creating your own metadata](https://github.com/solana-labs/token-list#this-repository-is-eol-)
 
 **A decentralized solution is in progress.**
 

--- a/name-service/js/README.md
+++ b/name-service/js/README.md
@@ -1,6 +1,6 @@
 # Name Service JavaScript bindings
 
-[![npm](https://img.shields.io/npm/v/@solana/spl-name-service)](https://unpkg.com/@solana/spl-name-service@latest/) [![GitHub license](https://img.shields.io/badge/license-APACHE-blue.svg)](https://github.com/solana-labs/token-list/blob/b3fa86b3fdd9c817139e38641d46c5a892542a52/LICENSE)
+[![npm](https://img.shields.io/npm/v/@solana/spl-name-service)](https://unpkg.com/@solana/spl-name-service@latest/)
 
 Full documentation is available at https://spl.solana.com/name-service
 


### PR DESCRIPTION
#### Problem

https://github.com/solana-labs/token-list has been archived for awhile, but our docs still recommend to use it.

#### Solution

Change to a link to Metaplex docs. Also, why was it referenced in the name service JS bindings? The world may never know