### PR TITLE
ci: Pin cargo-audit to earlier version

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -99,7 +99,7 @@ jobs:
         uses: actions-rs/install@v0.1
         with:
           crate: cargo-audit
-          version: latest
+          version: 0.17.5 # TODO use latest once repo uses Rust v1.63+
 
       - name: Run Cargo Audit
         run: ./ci/do-audit.sh


### PR DESCRIPTION
#### Problem

The audit job is failing because the newest version of cargo-audit requires Rust version 1.63.

#### Solution

Until SPL moves to Solana 1.16, we're stuck with Rust 1.60, so temporarily pin the version of cargo-audit