### PR TITLE
managed-token: Cleanup unnecessary dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6218,7 +6218,6 @@ dependencies = [
 name = "spl-managed-token"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "borsh",
  "shank 0.0.5",
  "solana-program",
@@ -6227,7 +6226,6 @@ dependencies = [
  "spl-associated-token-account 1.1.2",
  "spl-token 3.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
- "tokio",
 ]
 
 [[package]]

--- a/managed-token/program/Cargo.toml
+++ b/managed-token/program/Cargo.toml
@@ -32,5 +32,3 @@ borsh = "0.9.3"
 [dev-dependencies]
 solana-program-test = "1.14.12"
 solana-sdk = "1.14.12"
-tokio = { version = "1.8.4", features = ["full"] }
-anyhow = "1.0.52"

--- a/managed-token/program/tests/test.rs
+++ b/managed-token/program/tests/test.rs
@@ -25,7 +25,7 @@ async fn process_transaction(
     client: &mut BanksClient,
     instructions: Vec<Instruction>,
     signers: Vec<&Keypair>,
-) -> anyhow::Result<Signature> {
+) -> Result<Signature, BanksClientError> {
     let mut tx = Transaction::new_with_payer(&instructions, Some(&signers[0].pubkey()));
     tx.partial_sign(&signers, client.get_latest_blockhash().await?);
     let sig = tx.signatures[0];
@@ -40,7 +40,7 @@ async fn transfer(
     payer: &Keypair,
     receiver: &Pubkey,
     amount: u64,
-) -> anyhow::Result<Signature> {
+) -> Result<Signature, BanksClientError> {
     let ixs = vec![system_instruction::transfer(
         &payer.pubkey(),
         receiver,


### PR DESCRIPTION
#### Problem

While looking at #4251, it became clear that there are some unnecessary dependencies in the managed-token program.

#### Solution

Rather than upgrading unneeded deps, just remove them!