### PR TITLE
token-cli: Remove unused indicatif dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6501,7 +6501,6 @@ dependencies = [
  "assert_cmd",
  "clap 2.34.0",
  "console",
- "indicatif",
  "serde",
  "serde_derive",
  "serde_json",

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -14,7 +14,6 @@ walkdir = "2"
 [dependencies]
 clap = "2.33.3"
 console = "0.15.5"
-indicatif = "0.16.2"
 serde = "1.0.163"
 serde_derive = "1.0.103"
 serde_json = "1.0.96"


### PR DESCRIPTION
#### Problem

 #4291 is trying to bump the "indicatif" dependency in the token-cli, but it's totally unused!

#### Solution

Remove the dependency