### PR TITLE
docs: Be really clear that token-2022 is still under audit

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -55,6 +55,10 @@ the Solana Mainnet Beta. Currently, this includes:
 If you discover a critical security issue in an out-of-scope program, your finding
 may still be valuable.
 
+[token-2022](https://github.com/solana-labs/solana-program-library/tree/master/token/program-2022)
+is still under audit and not meant for full production use. In the meantime, all
+clusters have the latest program deployed **for testing and development purposes ONLY**.
+
 Many programs, including
 [token-swap](https://github.com/solana-labs/solana-program-library/tree/master/token-swap/program)
 and [token-lending](https://github.com/solana-labs/solana-program-library/tree/master/token-lending/program),

--- a/docs/src/token-2022.md
+++ b/docs/src/token-2022.md
@@ -6,7 +6,11 @@ A token program on the Solana blockchain, defining a common implementation for
 fungible and non-fungible tokens.
 
 The Token-2022 Program is a superset of the functionality provided by the
-[Token Program](token.mdx), deployed to all networks.
+[Token Program](token.mdx).
+
+The program is still under audit and not meant for full production use. In the
+meantime, all clusters have the latest program deployed **for testing and development
+purposes ONLY**.
 
 | Information | Account Address |
 | --- | --- |

--- a/token/program-2022/README.md
+++ b/token/program-2022/README.md
@@ -1,0 +1,17 @@
+# Token-2022 program
+
+A token program on the Solana blockchain, usable for fungible and non-fungible tokens.
+
+This program provides an interface and implementation that third parties can
+utilize to create and use their tokens.
+
+Full documentation is available at https://spl.solana.com/token-2022
+
+The Token-2022 program is still under audit and not meant for full production use.
+In the meantime, all clusters have the latest program deployed **for testing and
+development purposes ONLY**.
+
+## Audit
+
+The repository [README](https://github.com/solana-labs/solana-program-library#audits)
+contains information about program audits.

--- a/token/program/README.md
+++ b/token/program/README.md
@@ -7,8 +7,6 @@ utilize to create and use their tokens.
 
 Full documentation is available at https://spl.solana.com/token
 
-JavaScript bindings are available in the `./js` directory.
-
 ## Audit
 
 The repository [README](https://github.com/solana-labs/solana-program-library#audits)


### PR DESCRIPTION
#### Problem

Only the token-2022 status page is very clear that the program is still under audit, but people may miss that information.

#### Solution

Add the information to the top-level token-2022 docs page, the program's README, and the repo SECURITY page.