### PR TITLE
fix: upcoming fees should show if we are not yet over the epoch

### DIFF
--- a/token/cli/src/output.rs
+++ b/token/cli/src/output.rs
@@ -561,7 +561,7 @@ fn display_ui_extension(
         }) => {
             writeln!(f, "  {}", style("Transfer fees:").bold())?;
 
-            if newer_transfer_fee.epoch >= epoch {
+            if epoch >= newer_transfer_fee.epoch {
                 writeln!(
                     f,
                     "    {} {}bps",


### PR DESCRIPTION
`spl-token display CKfatsPMUf8SkiURsDXs7eK6GWb4Jsd6UDbs7twMCWxo -um`

with the master branch
```
SPL Token Mint
  Address: CKfatsPMUf8SkiURsDXs7eK6GWb4Jsd6UDbs7twMCWxo
  Program: TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb
  Supply: 100000000000000
  Decimals: 5
  Mint authority: 7MyTjmRygJoCuDBUtAuSugiYZFULD2SWaoUTmtjtRDzD
  Freeze authority: 7MyTjmRygJoCuDBUtAuSugiYZFULD2SWaoUTmtjtRDzD
Extensions
  Transfer fees:
    Current fee: 690bps
    Current maximum: 3906250000000000000
    Config authority: 7MyTjmRygJoCuDBUtAuSugiYZFULD2SWaoUTmtjtRDzD
    Withdrawal authority: 7MyTjmRygJoCuDBUtAuSugiYZFULD2SWaoUTmtjtRDzD
    Withheld fees: 0
```

It gives with this commit

```
SPL Token Mint
  Address: CKfatsPMUf8SkiURsDXs7eK6GWb4Jsd6UDbs7twMCWxo
  Program: TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb
  Supply: 100000000000000
  Decimals: 5
  Mint authority: 7MyTjmRygJoCuDBUtAuSugiYZFULD2SWaoUTmtjtRDzD
  Freeze authority: 7MyTjmRygJoCuDBUtAuSugiYZFULD2SWaoUTmtjtRDzD
Extensions
  Transfer fees:
    Current fee: 0bps
    Current maximum: 3906250000000000000
    Upcoming fee: 690bps
    Upcoming maximum: 3906250000000000000
    Switchover at: Epoch 457 (1 epochs)
    Config authority: 7MyTjmRygJoCuDBUtAuSugiYZFULD2SWaoUTmtjtRDzD
    Withdrawal authority: 7MyTjmRygJoCuDBUtAuSugiYZFULD2SWaoUTmtjtRDzD
    Withheld fees: 0
```
    
Current epoch when running this was 456