### PR TITLE
token-js: Bump version to 0.3.8 for publish

### DIFF
--- a/token/js/package-lock.json
+++ b/token/js/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@solana/spl-token",
-    "version": "0.3.7",
+    "version": "0.3.8",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@solana/spl-token",
-            "version": "0.3.7",
+            "version": "0.3.8",
             "license": "Apache-2.0",
             "dependencies": {
                 "@solana/buffer-layout": "^4.0.0",

--- a/token/js/package.json
+++ b/token/js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@solana/spl-token",
     "description": "SPL Token Program JS API",
-    "version": "0.3.7",
+    "version": "0.3.8",
     "author": "Solana Labs Maintainers <maintainers@solanalabs.com>",
     "repository": "https://github.com/solana-labs/solana-program-library",
     "license": "Apache-2.0",


### PR DESCRIPTION
#### Problem

#4149 fixed Typescript resolution, but it hasn't been published to npm.

#### Solution

Bump the version before relase