### PR TITLE
token-swap-js: Bump to 0.4.0 for release

### DIFF
--- a/token-swap/js/package-lock.json
+++ b/token-swap/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@solana/spl-token-swap",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@solana/spl-token-swap",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@solana/buffer-layout": "^4.0.0",

--- a/token-swap/js/package.json
+++ b/token-swap/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana/spl-token-swap",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "SPL Token Swap JavaScript API",
   "license": "MIT",
   "author": "Solana Labs Maintainers <maintainers@solanalabs.com>",


### PR DESCRIPTION
#### Problem

#4149 fixed up how types are resolved in the token-swap js package, but we haven't deployed it yet.

#### Solution

Bump the version for release. This is a new minor version since there's been a lot of version bumps since 0.3.0, which changed the code a lot.