### PR TITLE
Add link to doc: instruction.rs

### DIFF
--- a/token/program/src/instruction.rs
+++ b/token/program/src/instruction.rs
@@ -397,7 +397,7 @@ pub enum TokenInstruction<'a> {
         /// account.
         m: u8,
     },
-    /// Like InitializeMint, but does not require the Rent sysvar to be provided
+    /// Like [`InitializeMint`], but does not require the Rent sysvar to be provided
     ///
     /// Accounts expected by this instruction:
     ///


### PR DESCRIPTION
`InitializeMint` contains important note(s), so it's better to facilitate peeking into it from `InitializeMint2`