### PR TITLE
ci: Split up token job to avoid using all disk space

### DIFF
--- a/.github/workflows/pull-request-token.yml
+++ b/.github/workflows/pull-request-token.yml
@@ -61,12 +61,6 @@ jobs:
       - name: Build and test token
         run: ./ci/cargo-test-sbf.sh token
 
-      - name: Build and test ATA
-        run: ./ci/cargo-test-sbf.sh associated-token-account
-
-      - name: Build and test transfer hook example
-        run: ./ci/cargo-test-sbf.sh token/transfer-hook-example
-
       - name: Build and test token-2022 with "serde" activated
         run: |
           cargo +"${{ env.RUST_STABLE }}" test \
@@ -79,6 +73,103 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: token-programs
+          path: "target/deploy/*.so"
+          if-no-files-found: error
+
+  cargo-test-sbf-transfer-hook:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set env vars
+        run: |
+          source ci/rust-version.sh
+          echo "RUST_STABLE=$rust_stable" >> $GITHUB_ENV
+          source ci/solana-version.sh
+          echo "SOLANA_VERSION=$solana_version" >> $GITHUB_ENV
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_STABLE }}
+          override: true
+          profile: minimal
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE}}
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/rustfilt
+          key: cargo-sbf-bins-${{ runner.os }}
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/solana
+          key: solana-${{ env.SOLANA_VERSION }}
+
+      - name: Install dependencies
+        run: |
+          ./ci/install-build-deps.sh
+          ./ci/install-program-deps.sh
+          echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
+
+      - name: Build and test transfer hook example
+        run: ./ci/cargo-test-sbf.sh token/transfer-hook-example
+
+  cargo-test-sbf-associated-token-account:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set env vars
+        run: |
+          source ci/rust-version.sh
+          echo "RUST_STABLE=$rust_stable" >> $GITHUB_ENV
+          source ci/solana-version.sh
+          echo "SOLANA_VERSION=$solana_version" >> $GITHUB_ENV
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_STABLE }}
+          override: true
+          profile: minimal
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE}}
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/rustfilt
+          key: cargo-sbf-bins-${{ runner.os }}
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/solana
+          key: solana-${{ env.SOLANA_VERSION }}
+
+      - name: Install dependencies
+        run: |
+          ./ci/install-build-deps.sh
+          ./ci/install-program-deps.sh
+          echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
+
+      - name: Build and test ATA
+        run: ./ci/cargo-test-sbf.sh associated-token-account
+
+      - name: Upload program
+        uses: actions/upload-artifact@v2
+        with:
+          name: associated-token-account-program
           path: "target/deploy/*.so"
           if-no-files-found: error
 
@@ -125,7 +216,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NODE_VERSION: 16.x
-    needs: cargo-test-sbf
+    needs: [cargo-test-sbf, cargo-test-sbf-associated-token-account]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ env.NODE_VERSION }}
@@ -142,6 +233,11 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: token-programs
+          path: target/deploy
+      - name: Download associated-token-account program
+        uses: actions/download-artifact@v2
+        with:
+          name: associated-token-account-program
           path: target/deploy
       - run: ./ci/js-test-token.sh
 

--- a/associated-token-account/program-test/tests/program_test.rs
+++ b/associated-token-account/program-test/tests/program_test.rs
@@ -13,6 +13,7 @@ pub fn program_test(token_mint_address: Pubkey, use_latest_spl_token: bool) -> P
     );
 
     if use_latest_spl_token {
+        pc.prefer_bpf(false);
         // TODO: Remove when spl-token is available by default in program-test
         pc.add_program(
             "spl_token",
@@ -52,6 +53,7 @@ pub fn program_test_2022(
     );
 
     if use_latest_spl_token_2022 {
+        pc.prefer_bpf(false);
         // TODO: Remove when spl-token-2022 is available by default in program-test
         pc.add_program(
             "spl_token_2022",


### PR DESCRIPTION
#### Problem

The token CI job is failing due to no space left on device, ie https://github.com/solana-labs/solana-program-library/actions/runs/5164629307/jobs/9303653512?pr=4450

#### Solution

Move the ATA and transfer hook example builds to separate steps. The transfer hook tests have no other dependencies, so it's easy. The ATA tests currently use the BPF version of token-2022, but the tests are fine with the fake native version too. Finally, the JS tests require the ATA program, so it's uploaded / downloaded separately.