### PR TITLE
Patch ntapi for windows build with rust 1.69+

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2864,8 +2864,7 @@ dependencies = [
 [[package]]
 name = "ntapi"
 version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+source = "git+https://github.com/solana-labs/ntapi?rev=5980bbab2e0501a8100eb88c12222d664ccb3a0a#5980bbab2e0501a8100eb88c12222d664ccb3a0a"
 dependencies = [
  "winapi 0.3.9",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2863,8 +2863,8 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.3.6"
-source = "git+https://github.com/solana-labs/ntapi?rev=5980bbab2e0501a8100eb88c12222d664ccb3a0a#5980bbab2e0501a8100eb88c12222d664ccb3a0a"
+version = "0.3.7"
+source = "git+https://github.com/solana-labs/ntapi?rev=97ede981a1777883ff86d142b75024b023f04fad#97ede981a1777883ff86d142b75024b023f04fad"
 dependencies = [
  "winapi 0.3.9",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,8 @@ members = [
   "utils/test-client",
   "token-lending/flash_loan_receiver",
 ]
+
+[patch.crates-io]
+# Rust 1.69+ broke ntapi v0.3.x, which doesn't contain proper fix:
+#   https://github.com/MSxDOS/ntapi/pull/12
+ntapi = { git = "https://github.com/solana-labs/ntapi", rev = "5980bbab2e0501a8100eb88c12222d664ccb3a0a" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,4 +57,4 @@ members = [
 [patch.crates-io]
 # Rust 1.69+ broke ntapi v0.3.x, which doesn't contain proper fix:
 #   https://github.com/MSxDOS/ntapi/pull/12
-ntapi = { git = "https://github.com/solana-labs/ntapi", rev = "5980bbab2e0501a8100eb88c12222d664ccb3a0a" }
+ntapi = { git = "https://github.com/solana-labs/ntapi", rev = "97ede981a1777883ff86d142b75024b023f04fad" }


### PR DESCRIPTION
the solana monorepo's tarballs bundle `spl-token-cli` for convenience. and that fancy repo uses still shiny rust v1.69 (im eyeing for 1.70 soon). and `ntapi` (one of monorepo dep hell) is pulled into this spl repo. and it isn't buildable anymore with the rust when targeted to the Windows os.

it's currently worked around with this yet another sinful hack...: https://github.com/solana-labs/solana/pull/31970#discussion_r1218039494 

~so, this pr needs to be shipped rather promptly after merge to be included in spl-token-cli v2.4.1....~ (EDIT: the monorepo-side cli-arg based patch for cargo install spl-token-cli seem to a better approach.)


links:
- https://github.com/solana-labs/solana/pull/31961
- https://github.com/solana-labs/solana/pull/31970
- https://github.com/solana-labs/solana/pull/31971
- https://github.com/solana-labs/solana/pull/31981