### PR TITLE
ci: Separate token-2022 serde test step

### DIFF
--- a/.github/workflows/pull-request-token.yml
+++ b/.github/workflows/pull-request-token.yml
@@ -61,20 +61,44 @@ jobs:
       - name: Build and test token
         run: ./ci/cargo-test-sbf.sh token
 
-      - name: Build and test token-2022 with "serde" activated
-        run: |
-          cargo +"${{ env.RUST_STABLE }}" test \
-            --manifest-path=token/program-2022/Cargo.toml \
-            --features serde-traits \
-            -- --nocapture
-          exit 0
-
       - name: Upload programs
         uses: actions/upload-artifact@v2
         with:
           name: token-programs
           path: "target/deploy/*.so"
           if-no-files-found: error
+
+  cargo-test-token-2022-serde:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set env vars
+        run: |
+          source ci/rust-version.sh
+          echo "RUST_STABLE=$rust_stable" >> $GITHUB_ENV
+          source ci/solana-version.sh
+          echo "SOLANA_VERSION=$solana_version" >> $GITHUB_ENV
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_STABLE }}
+          override: true
+          profile: minimal
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE}}
+
+      - name: Test token-2022 with "serde" activated
+        run: |
+          cargo test \
+            --manifest-path=token/program-2022/Cargo.toml \
+            --features serde-traits \
+            -- --nocapture
 
   cargo-test-sbf-transfer-hook:
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### Problem

The token `cargo-test-sbf` is the slowest part of the token CI.

#### Solution

The token-2022 serde test step has no dependencies on any other part of the token CI test step, so separate it out!