### PR TITLE
mergify: Don't add community label for spl team members

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,7 +6,9 @@
 pull_request_rules:
   - name: label changes from community
     conditions:
-      - author≠@core-contributors
+      - author≠@spl-maintainers
+      - author≠@spl-triage
+      - author≠@spl-write
       - author≠mergify[bot]
       - author≠dependabot[bot]
     actions:


### PR DESCRIPTION
#### Problem

@buffalojoec recent PR  #4189 was labeled as "community" even though he's on the SPL team.

#### Solution

Update the "community" label so that it doesn't happen for any of the SPL teams, and don't the "core-contributors" team, which should eventually be deprecated.