### PR TITLE
program-error: Use "full" feature to get `ItemEnum`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6328,7 +6328,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2 1.0.56",
  "quote 1.0.26",
- "syn 1.0.107",
+ "syn 2.0.15",
 ]
 
 [[package]]

--- a/libraries/program-error/derive/Cargo.toml
+++ b/libraries/program-error/derive/Cargo.toml
@@ -9,4 +9,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0", features = ["extra-traits"] }
+syn = { version = "2.0", features = ["full"] }

--- a/libraries/program-error/derive/src/macro_impl.rs
+++ b/libraries/program-error/derive/src/macro_impl.rs
@@ -85,7 +85,7 @@ pub fn print_program_error(
 fn get_error_message(variant: &Variant) -> Option<String> {
     let attrs = &variant.attrs;
     for attr in attrs {
-        if attr.path.is_ident("error") {
+        if attr.path().is_ident("error") {
             if let Ok(lit_str) = attr.parse_args::<LitStr>() {
                 return Some(lit_str.value());
             }


### PR DESCRIPTION
#### Problem

While trying to publish or build the program-error-derive subcrate, you'll get:

```
error[E0432]: unresolved import `syn::ItemEnum`
 --> libraries/program-error/derive/src/macro_impl.rs:3:56
  |
3 | use syn::{punctuated::Punctuated, token::Comma, Ident, ItemEnum, LitStr, Variant};
  |                                                        ^^^^^^^^ no `ItemEnum` in the root

error[E0432]: unresolved import `syn::ItemEnum`
  --> libraries/program-error/derive/src/lib.rs:20:30
   |
20 | use syn::{parse_macro_input, ItemEnum};
   |                              ^^^^^^^^ no `ItemEnum` in the root

For more information about this error, try `rustc --explain E0432`.
error: could not compile `spl-program-error-derive` due to 2 previous errors
```

#### Solution

According to https://docs.rs/syn/latest/syn/struct.ItemEnum.html, `ItemEnum` is only available if you're using the `full` feature, so use that! While I was at it, I upgraded to syn version 2 since it was very simple. Let me know if that's an issue!