### PR TITLE
program-error: Add more crate fields to publish

### DIFF
--- a/libraries/program-error/derive/Cargo.toml
+++ b/libraries/program-error/derive/Cargo.toml
@@ -1,6 +1,10 @@
 [package]
 name = "spl-program-error-derive"
 version = "0.1.0"
+description = "Proc-Macro Library for Solana Program error attributes and derive macro"
+authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
+repository = "https://github.com/solana-labs/solana-program-library"
+license = "Apache-2.0"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
#### Problem

In order to publish a crate to crates.io, it must have certain fields in its Cargo.toml, and program-error-derive is missing those.

#### Solution

Add the required fields. Note that I already published the crate with this information at https://crates.io/crates/spl-program-error-derive