### PR TITLE
ci: Add `exclude` field, and add to it in scripts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,9 @@ members = [
   "token-lending/flash_loan_receiver",
 ]
 
+exclude = [
+]
+
 [patch.crates-io]
 # Rust 1.69+ broke ntapi v0.3.x, which doesn't contain proper fix:
 #   https://github.com/MSxDOS/ntapi/pull/12

--- a/patch.crates-io.sh
+++ b/patch.crates-io.sh
@@ -40,9 +40,7 @@ if echo "$solana_dir" | grep "^$project_root" > /dev/null; then
     if grep -q "exclude.*$solana_dir" "$crate"; then
       echo "$crate is already patched"
     else
-      cat >> $crate << EXCLUDE
-exclude = ["$solana_dir"]
-EXCLUDE
+      sed -i'' "$crate" -e "/exclude/a \ \ \"$solana_dir\","
     fi
   done
 fi

--- a/token/twoxtx-setup.sh
+++ b/token/twoxtx-setup.sh
@@ -25,11 +25,5 @@ if [[ ! -f twoxtx-solana/.twoxtx-patched ]]; then
 fi
 
 ../patch.crates-io.sh twoxtx-solana
-repo="token/twoxtx-solana"
-if sed -n '/exclude = \[/,/\]/p' ../Cargo.toml | grep -q "$repo"; then
-  echo "$repo is already excluded"
-else
-  sed -i'' ../Cargo.toml -e "/exclude/a \ \ \"$repo\","
-fi
 
 exit 0


### PR DESCRIPTION
#### Problem

 #4496 fixed up the patch table, but it was then causing issues with the 2xtx build, which was incorrectly adding the "exclude" key under the "patch.crates-io" section.

#### Solution

Rather than adding the exclude key and value in the patch script, add a default empty "exclude" key, and add to it when patching.

It looks like the twoxtx-setup script was also trying to exclude incorrectly -- since this is done in the patch script, no reason to do it twice!