### PR TITLE
token-metadata: Add interface describing the program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6630,6 +6630,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-token-metadata-interface"
+version = "0.1.0"
+dependencies = [
+ "borsh",
+ "num-derive",
+ "num-traits",
+ "solana-program",
+ "spl-program-error",
+ "spl-type-length-value",
+ "thiserror",
+]
+
+[[package]]
 name = "spl-token-swap"
 version = "3.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
   "stateless-asks/program",
   "token-lending/cli",
   "token-lending/program",
+  "token-metadata/interface",
   "token-swap/program",
   "token-swap/program/fuzz",
   "token-upgrade/cli",

--- a/token-metadata/interface/Cargo.toml
+++ b/token-metadata/interface/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "spl-token-metadata-interface"
+version = "0.1.0"
+description = "Solana Program Library Token Metadata Interface"
+authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
+repository = "https://github.com/solana-labs/solana-program-library"
+license = "Apache-2.0"
+edition = "2021"
+
+[dependencies]
+borsh = "0.9"
+num-derive = "0.3.3"
+num-traits = "0.2"
+solana-program = "1.14.12"
+spl-program-error = { version = "0.1.0" , path = "../../libraries/program-error" }
+spl-type-length-value = { version = "0.1.0" , path = "../../libraries/type-length-value" }
+thiserror = "1.0"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/token-metadata/interface/README.md
+++ b/token-metadata/interface/README.md
@@ -1,0 +1,107 @@
+## Token-Metadata Interface
+
+An interface describing the instructions required for a program to implement
+to be considered a "token-metadata" program for SPL token mints. The interface
+can be implemented by any program.
+
+With a common interface, any wallet, dapp, or on-chain program can read the metadata,
+and any tool that creates or modifies metadata will just work with any program
+that implements the interface.
+
+There is also a `TokenMetadata` struct that may optionally be implemented, but
+is not required because of the `Emit` instruction, which indexers and other off-chain
+users can call to get metadata.
+
+### Example program
+
+Coming soon!
+
+### Motivation
+
+Token creators on Solana need all sorts of functionality for their token-metadata,
+and the Metaplex Token-Metadata program has been the one place for all metadata
+needs, leading to a feature-rich program that still might not serve all needs.
+
+At its base, token-metadata is a set of data fields associated to a particular token
+mint, so we propose an interface that serves the simplest base case with some
+compatibility with existing solutions.
+
+With this proposal implemented, fungible and non-fungible token creators will
+have two options:
+
+* implement the interface in their own program, so they can eventually extend it
+with new functionality or even other interfaces
+* use a reference program that implements the simplest case
+
+### Required Instructions
+
+All of the following instructions are listed in greater detail in the source code.
+Once the interface is decided, the information in the source code will be copied
+here.
+
+#### Initialize
+
+Initializes the token-metadata TLV entry in an account with an update authority,
+name, symbol, and URI.
+
+Must provide an SPL token mint and be signed by the mint authority.
+
+#### Update Field
+
+Updates a field in a token-metadata account. This may be an existing or totally
+new field.
+
+Must be signed by the update authority.
+
+#### Remove Key
+
+Unsets a key-value pair, clearing an existing entry.
+
+Must be signed by the update authority.
+
+#### Update Authority
+
+Sets or unsets the token-metadata update authority, which signs any future updates
+to the metadata.
+
+Must be signed by the update authority.
+
+#### Emit
+
+Emits token-metadata in the expected `TokenMetadata` state format. Although
+implementing a struct that uses the exact state is optional, this instruction is
+required.
+
+### (Optional) State
+
+A program that implements the interface may write the following data fields
+into a type-length-value entry into an account:
+
+```rust
+type Pubkey = [u8; 32];
+type OptionalNonZeroPubkey = Pubkey; // if all zeroes, interpreted as `None`
+
+pub struct TokenMetadata {
+    /// The authority that can sign to update the metadata
+    pub update_authority: OptionalNonZeroPubkey,
+    /// The associated mint, used to counter spoofing to be sure that metadata
+    /// belongs to a particular mint
+    pub mint: Pubkey,
+    /// The longer name of the token
+    pub name: String,
+    /// The shortened symbol for the token
+    pub symbol: String,
+    /// The URI pointing to richer metadata
+    pub uri: String,
+    /// Any additional metadata about the token as key-value pairs. The program
+    /// must avoid storing the same key twice.
+    pub additional_metadata: Vec<(String, String)>,
+}
+```
+
+By storing the metadata in a TLV structure, a developer who implements this
+interface in their program can freely add any other data fields in a different
+TLV entry.
+
+You can find more information about TLV / type-length-value structures at the
+[spl-type-length-value repo](https://github.com/solana-labs/solana-program-library/tree/master/libraries/type-length-value).

--- a/token-metadata/interface/src/error.rs
+++ b/token-metadata/interface/src/error.rs
@@ -1,0 +1,17 @@
+//! Interface error types
+
+use spl_program_error::*;
+
+/// Errors that may be returned by the interface.
+#[spl_program_error]
+pub enum TokenMetadataError {
+    /// Incorrect account provided
+    #[error("Incorrect account provided")]
+    IncorrectAccount,
+    /// Mint has no mint authority
+    #[error("Mint has no mint authority")]
+    MintHasNoMintAuthority,
+    /// Incorrect mint authority has signed the instruction
+    #[error("Incorrect mint authority has signed the instruction")]
+    IncorrectMintAuthority,
+}

--- a/token-metadata/interface/src/instruction.rs
+++ b/token-metadata/interface/src/instruction.rs
@@ -38,9 +38,8 @@ impl TlvDiscriminator for Initialize {
     /// Please use this discriminator in your program when matching
     const TLV_DISCRIMINATOR: Discriminator = Discriminator::new(INITIALIZE_DISCRIMINATOR);
 }
-/// First 8 bytes of `hash::hashv(&["spl-token-metadata-interface:metadata-initialize"])`
-const INITIALIZE_DISCRIMINATOR: [u8; Discriminator::LENGTH] =
-    [229, 250, 62, 140, 225, 241, 85, 223];
+/// First 8 bytes of `hash::hashv(&["spl_token_metadata_interface:initialize_account"])`
+const INITIALIZE_DISCRIMINATOR: [u8; Discriminator::LENGTH] = [210, 225, 30, 162, 88, 184, 77, 141];
 // annoying, but needed to perform a match on the value
 const INITIALIZE_DISCRIMINATOR_SLICE: &[u8] = &INITIALIZE_DISCRIMINATOR;
 
@@ -56,9 +55,9 @@ impl TlvDiscriminator for UpdateField {
     /// Please use this discriminator in your program when matching
     const TLV_DISCRIMINATOR: Discriminator = Discriminator::new(UPDATE_FIELD_DISCRIMINATOR);
 }
-/// First 8 bytes of `hash::hashv(&["spl-token-metadata-interface:update-field"])`
+/// First 8 bytes of `hash::hashv(&["spl_token_metadata_interface:updating_field"])`
 const UPDATE_FIELD_DISCRIMINATOR: [u8; Discriminator::LENGTH] =
-    [235, 206, 155, 58, 119, 75, 144, 47];
+    [221, 233, 49, 45, 181, 202, 220, 200];
 // annoying, but needed to perform a match on the value
 const UPDATE_FIELD_DISCRIMINATOR_SLICE: &[u8] = &UPDATE_FIELD_DISCRIMINATOR;
 
@@ -72,8 +71,8 @@ impl TlvDiscriminator for RemoveKey {
     /// Please use this discriminator in your program when matching
     const TLV_DISCRIMINATOR: Discriminator = Discriminator::new(REMOVE_KEY_DISCRIMINATOR);
 }
-/// First 8 bytes of `hash::hashv(&["spl-token-metadata-interface:remove-a-key"])`
-const REMOVE_KEY_DISCRIMINATOR: [u8; Discriminator::LENGTH] = [215, 0, 121, 250, 213, 141, 116, 69];
+/// First 8 bytes of `hash::hashv(&["spl_token_metadata_interface:remove_key_ix"])`
+const REMOVE_KEY_DISCRIMINATOR: [u8; Discriminator::LENGTH] = [234, 18, 32, 56, 89, 141, 37, 181];
 // annoying, but needed to perform a match on the value
 const REMOVE_KEY_DISCRIMINATOR_SLICE: &[u8] = &REMOVE_KEY_DISCRIMINATOR;
 
@@ -87,13 +86,13 @@ impl TlvDiscriminator for UpdateAuthority {
     /// Please use this discriminator in your program when matching
     const TLV_DISCRIMINATOR: Discriminator = Discriminator::new(UPDATE_AUTHORITY_DISCRIMINATOR);
 }
-/// First 8 bytes of `hash::hashv(&["spl-token-metadata-interface:update-authority"])`
+/// First 8 bytes of `hash::hashv(&["spl_token_metadata_interface:update_the_authority"])`
 const UPDATE_AUTHORITY_DISCRIMINATOR: [u8; Discriminator::LENGTH] =
-    [250, 234, 22, 114, 44, 204, 71, 84];
+    [215, 228, 166, 228, 84, 100, 86, 123];
 // annoying, but needed to perform a match on the value
 const UPDATE_AUTHORITY_DISCRIMINATOR_SLICE: &[u8] = &UPDATE_AUTHORITY_DISCRIMINATOR;
 
-/// Emit instruction data
+/// Instruction data for Emit
 #[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize)]
 pub struct Emit {
     /// Start of range of data to emit
@@ -105,8 +104,8 @@ impl TlvDiscriminator for Emit {
     /// Please use this discriminator in your program when matching
     const TLV_DISCRIMINATOR: Discriminator = Discriminator::new(EMIT_DISCRIMINATOR);
 }
-/// First 8 bytes of `hash::hashv(&["spl-token-metadata-interface:emitting"])`
-const EMIT_DISCRIMINATOR: [u8; Discriminator::LENGTH] = [224, 75, 86, 175, 2, 32, 83, 198];
+/// First 8 bytes of `hash::hashv(&["spl_token_metadata_interface:emitter"])`
+const EMIT_DISCRIMINATOR: [u8; Discriminator::LENGTH] = [250, 166, 180, 250, 13, 12, 184, 70];
 // annoying, but needed to perform a match on the value
 const EMIT_DISCRIMINATOR_SLICE: &[u8] = &EMIT_DISCRIMINATOR;
 
@@ -178,14 +177,14 @@ pub enum TokenMetadataInstruction {
     /// Data: the new authority. Can be unset using a `None` value
     UpdateAuthority(UpdateAuthority),
 
-    /// Emits the token-metadata as an event
+    /// Emits the token-metadata as return data
     ///
     /// The format of the data emitted follows exactly the `TokenMetadata`
     /// struct, but it's possible
     ///
     /// Accounts expected by this instruction:
     ///
-    ///   0. `[w]` Metadata account
+    ///   0. `[]` Metadata account
     Emit(Emit),
 }
 impl TokenMetadataInstruction {
@@ -329,6 +328,21 @@ pub fn update_authority(
     }
 }
 
+/// Creates an `Emit` instruction
+pub fn emit(
+    program_id: &Pubkey,
+    metadata: &Pubkey,
+    start: Option<u64>,
+    end: Option<u64>,
+) -> Instruction {
+    let data = TokenMetadataInstruction::Emit(Emit { start, end });
+    Instruction {
+        program_id: *program_id,
+        accounts: vec![AccountMeta::new_readonly(*metadata, false)],
+        data: data.pack(),
+    }
+}
+
 #[cfg(test)]
 mod test {
     use {super::*, crate::NAMESPACE, solana_program::hash};
@@ -358,7 +372,7 @@ mod test {
             uri: uri.to_string(),
         };
         let check = TokenMetadataInstruction::Initialize(data.clone());
-        let preimage = hash::hashv(&[format!("{NAMESPACE}:metadata-initialize").as_bytes()]);
+        let preimage = hash::hashv(&[format!("{NAMESPACE}:initialize_account").as_bytes()]);
         let discriminator = &preimage.as_ref()[..Discriminator::LENGTH];
         check_pack_unpack(check, discriminator, data);
     }
@@ -372,7 +386,7 @@ mod test {
             value: value.to_string(),
         };
         let check = TokenMetadataInstruction::UpdateField(data.clone());
-        let preimage = hash::hashv(&[format!("{NAMESPACE}:update-field").as_bytes()]);
+        let preimage = hash::hashv(&[format!("{NAMESPACE}:updating_field").as_bytes()]);
         let discriminator = &preimage.as_ref()[..Discriminator::LENGTH];
         check_pack_unpack(check, discriminator, data);
     }
@@ -383,7 +397,7 @@ mod test {
             key: "MyTestField".to_string(),
         };
         let check = TokenMetadataInstruction::RemoveKey(data.clone());
-        let preimage = hash::hashv(&[format!("{NAMESPACE}:remove-a-key").as_bytes()]);
+        let preimage = hash::hashv(&[format!("{NAMESPACE}:remove_key_ix").as_bytes()]);
         let discriminator = &preimage.as_ref()[..Discriminator::LENGTH];
         check_pack_unpack(check, discriminator, data);
     }
@@ -394,7 +408,7 @@ mod test {
             new_authority: OptionalNonZeroPubkey::default(),
         };
         let check = TokenMetadataInstruction::UpdateAuthority(data.clone());
-        let preimage = hash::hashv(&[format!("{NAMESPACE}:update-authority").as_bytes()]);
+        let preimage = hash::hashv(&[format!("{NAMESPACE}:update_the_authority").as_bytes()]);
         let discriminator = &preimage.as_ref()[..Discriminator::LENGTH];
         check_pack_unpack(check, discriminator, data);
     }
@@ -406,7 +420,7 @@ mod test {
             end: Some(10),
         };
         let check = TokenMetadataInstruction::Emit(data.clone());
-        let preimage = hash::hashv(&[format!("{NAMESPACE}:emitting").as_bytes()]);
+        let preimage = hash::hashv(&[format!("{NAMESPACE}:emitter").as_bytes()]);
         let discriminator = &preimage.as_ref()[..Discriminator::LENGTH];
         check_pack_unpack(check, discriminator, data);
     }

--- a/token-metadata/interface/src/lib.rs
+++ b/token-metadata/interface/src/lib.rs
@@ -12,4 +12,4 @@ pub mod state;
 pub use solana_program;
 
 /// Namespace for all programs implementing token-metadata
-pub const NAMESPACE: &str = "spl-token-metadata-interface";
+pub const NAMESPACE: &str = "spl_token_metadata_interface";

--- a/token-metadata/interface/src/lib.rs
+++ b/token-metadata/interface/src/lib.rs
@@ -1,0 +1,15 @@
+//! Crate defining an interface for token-metadata
+
+#![allow(clippy::integer_arithmetic)]
+#![deny(missing_docs)]
+#![cfg_attr(not(test), forbid(unsafe_code))]
+
+pub mod error;
+pub mod instruction;
+pub mod state;
+
+// Export current sdk types for downstream users building with a different sdk version
+pub use solana_program;
+
+/// Namespace for all programs implementing token-metadata
+pub const NAMESPACE: &str = "spl-token-metadata-interface";

--- a/token-metadata/interface/src/state.rs
+++ b/token-metadata/interface/src/state.rs
@@ -1,0 +1,77 @@
+//! Token-metadata interface state types
+use {
+    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
+    solana_program::{program_error::ProgramError, pubkey::Pubkey},
+    spl_type_length_value::discriminator::{Discriminator, TlvDiscriminator},
+    std::convert::TryFrom,
+};
+
+/// A Pubkey that encodes `None` as all `0`, meant to be usable as a Pod type,
+/// similar to all NonZero* number types from the bytemuck library.
+#[derive(Clone, Debug, Default, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[repr(transparent)]
+pub struct OptionalNonZeroPubkey(Pubkey);
+impl TryFrom<Option<Pubkey>> for OptionalNonZeroPubkey {
+    type Error = ProgramError;
+    fn try_from(p: Option<Pubkey>) -> Result<Self, Self::Error> {
+        match p {
+            None => Ok(Self(Pubkey::default())),
+            Some(pubkey) => {
+                if pubkey == Pubkey::default() {
+                    Err(ProgramError::InvalidArgument)
+                } else {
+                    Ok(Self(pubkey))
+                }
+            }
+        }
+    }
+}
+impl From<OptionalNonZeroPubkey> for Option<Pubkey> {
+    fn from(p: OptionalNonZeroPubkey) -> Self {
+        if p.0 == Pubkey::default() {
+            None
+        } else {
+            Some(p.0)
+        }
+    }
+}
+
+/// Data struct for all token-metadata, stored in a TLV entry
+///
+/// The type and length parts must be handled by the TLV library, and not stored
+/// as part of this struct.
+#[derive(Clone, Debug, Default, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+pub struct TokenMetadata {
+    /// The authority that can sign to update the metadata
+    pub update_authority: OptionalNonZeroPubkey,
+    /// The associated mint, used to counter spoofing to be sure that metadata
+    /// belongs to a particular mint
+    pub mint: Pubkey,
+    /// The longer name of the token
+    pub name: String,
+    /// The shortened symbol for the token
+    pub symbol: String,
+    /// The URI pointing to richer metadata
+    pub uri: String,
+    /// Any additional metadata about the token as key-value pairs. The program
+    /// must avoid storing the same key twice.
+    pub additional_metadata: Vec<(String, String)>,
+}
+impl TlvDiscriminator for TokenMetadata {
+    /// Please use this discriminator in your program when matching
+    const TLV_DISCRIMINATOR: Discriminator =
+        Discriminator::new([90, 206, 63, 159, 89, 230, 85, 173]);
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, crate::NAMESPACE, solana_program::hash};
+
+    #[test]
+    fn discriminator() {
+        let preimage = hash::hashv(&[format!("{NAMESPACE}:token-metadata").as_bytes()]);
+        let discriminator =
+            Discriminator::try_from(&preimage.as_ref()[..Discriminator::LENGTH]).unwrap();
+        assert_eq!(TokenMetadata::TLV_DISCRIMINATOR, discriminator);
+    }
+}

--- a/token-metadata/interface/src/state.rs
+++ b/token-metadata/interface/src/state.rs
@@ -60,7 +60,7 @@ pub struct TokenMetadata {
 impl TlvDiscriminator for TokenMetadata {
     /// Please use this discriminator in your program when matching
     const TLV_DISCRIMINATOR: Discriminator =
-        Discriminator::new([90, 206, 63, 159, 89, 230, 85, 173]);
+        Discriminator::new([112, 132, 90, 90, 11, 88, 157, 87]);
 }
 
 #[cfg(test)]
@@ -69,7 +69,7 @@ mod tests {
 
     #[test]
     fn discriminator() {
-        let preimage = hash::hashv(&[format!("{NAMESPACE}:token-metadata").as_bytes()]);
+        let preimage = hash::hashv(&[format!("{NAMESPACE}:token_metadata").as_bytes()]);
         let discriminator =
             Discriminator::try_from(&preimage.as_ref()[..Discriminator::LENGTH]).unwrap();
         assert_eq!(TokenMetadata::TLV_DISCRIMINATOR, discriminator);


### PR DESCRIPTION
#### Problem

For the motivations given in https://forum.solana.com/t/srfc-00017-token-metadata-interface/283, we need a token-metadata interface

#### Solution

Add the interface first, and after that, an example program implementing all the instructions.

There are a couple of main differences to the proposal:

* the metadata struct is more flexible, providing room for any additional fields
* the state is marked as optional, but there's an "emit" instruction for indexers

Note: the strings used to determine the instruction discriminators may look wacky, but they ensured byte sequences that started with high bytes. Token-2022 will implement this, and it only uses 1 byte for instructions, and I wanted to ensure that there would never be any collision between existing or future token-2022 instructions and these.

cc @austbot 