### PR TITLE
Derive macro for TLV discriminators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,7 +189,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
  "synstructure",
@@ -201,7 +201,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -265,7 +265,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -276,7 +276,7 @@ version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 2.0.15",
 ]
@@ -423,7 +423,7 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "regex",
  "rustc-hash",
@@ -539,7 +539,7 @@ dependencies = [
  "borsh-derive-internal",
  "borsh-schema-derive-internal",
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "syn 1.0.107",
 ]
 
@@ -549,7 +549,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -560,7 +560,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -640,7 +640,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aca418a974d83d40a0c1f0c5cba6ff4bc28d8df099109ca459a2118d40b6322"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -699,7 +699,7 @@ dependencies = [
  "heck 0.3.3",
  "indexmap",
  "log",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "serde",
  "serde_json",
@@ -915,6 +915,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,7 +1083,7 @@ dependencies = [
  "cc",
  "codespan-reporting",
  "once_cell",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "scratch",
  "syn 1.0.107",
@@ -1092,7 +1101,7 @@ version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "309e4fb93eed90e1e14bea0da16b209f81813ba9fc7830c20ed151dd7bc0a4d7"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -1115,7 +1124,7 @@ checksum = "ab8bfa2e259f8ee1ce5e97824a3c55ec4404a0d772ca7fa96bf19f0752a046eb"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "strsim 0.10.0",
  "syn 2.0.15",
@@ -1195,7 +1204,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b24629208e87a2d8b396ff43b15c4afb0a69cea3fbbaa9ed9b92b7c02f0aed73"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -1206,8 +1215,8 @@ version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
- "convert_case",
- "proc-macro2 1.0.56",
+ "convert_case 0.4.0",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "rustc_version",
  "syn 1.0.107",
@@ -1295,7 +1304,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -1377,7 +1386,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f86b50932a01e7ec5c06160492ab660fb19b6bb2a7878030dd6cd68d21df9d4d"
 dependencies = [
  "enum-ordinalize",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -1418,7 +1427,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8958699f9359f0b04e691a13850d48b7de329138023876d07cbd024c2c820598"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -1431,7 +1440,7 @@ checksum = "0b166c9e378360dd5a6666a9604bb4f54ae0cac39023ffbac425e917a2a04fef"
 dependencies = [
  "num-bigint 0.4.3",
  "num-traits",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -1443,7 +1452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11f36e95862220b211a6e2aa5eca09b4fa391b13cd52ceb8035a24bf65a79de2"
 dependencies = [
  "once_cell",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -1679,7 +1688,7 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 2.0.15",
 ]
@@ -2352,7 +2361,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b939a78fa820cdfcb7ee7484466746a7377760970f6f9c6fe19f9edcc8a38d2"
 dependencies = [
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -2746,7 +2755,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -2928,7 +2937,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -3011,7 +3020,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
  "proc-macro-crate 1.1.0",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -3023,7 +3032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
 dependencies = [
  "proc-macro-crate 1.1.0",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 2.0.15",
 ]
@@ -3091,7 +3100,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -3168,7 +3177,7 @@ checksum = "734aa7a4a6390b162112523cac2923a18e4f23b917880a68c826bf6e8bf48f06"
 dependencies = [
  "Inflector",
  "proc-macro-error",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -3308,7 +3317,7 @@ checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -3349,7 +3358,7 @@ version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b95af56fee93df76d721d356ac1ca41fccf168bc448eb14049234df764ba3e76"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -3446,7 +3455,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b83ec2d0af5c5c556257ff52c9f98934e243b9fd39604bfb2a9b75ec2e97f18"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "syn 1.0.107",
 ]
 
@@ -3476,7 +3485,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
  "version_check",
@@ -3488,7 +3497,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "version_check",
 ]
@@ -3504,9 +3513,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
@@ -3599,7 +3608,7 @@ checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -3612,7 +3621,7 @@ checksum = "7345d5f0e08c0536d7ac7229952590239e77abf0a0100a1b1d890add6ea96364"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -3730,7 +3739,7 @@ version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
 ]
 
 [[package]]
@@ -4212,7 +4221,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdbda6ac5cd1321e724fa9cee216f3a61885889b896f073b8f82322789c5250e"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -4290,7 +4299,7 @@ version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 2.0.15",
 ]
@@ -4341,7 +4350,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
 dependencies = [
  "darling",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 2.0.15",
 ]
@@ -4378,7 +4387,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 2.0.15",
 ]
@@ -4489,7 +4498,7 @@ version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd835154aa943dfc958f5a208f2e82b7d2a2c52b024229168c211ecc2d2bfd1"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "shank_macro_impl 0.0.5",
  "syn 1.0.107",
@@ -4501,7 +4510,7 @@ version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63927d22a1e8b74bda98cc6e151fcdf178b7abb0dc6c4f81e0bbf5ffe2fc4ec8"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "shank_macro_impl 0.0.11",
  "syn 1.0.107",
@@ -4514,7 +4523,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d99ad9d5137704e86e2e4a54a121b9c443c37b60ce6638a7723ab700dbd2232a"
 dependencies = [
  "anyhow",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "serde",
  "syn 1.0.107",
@@ -4527,7 +4536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce03403df682f80f4dc1efafa87a4d0cb89b03726d0565e6364bdca5b9a441"
 dependencies = [
  "anyhow",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "serde",
  "syn 1.0.107",
@@ -5087,7 +5096,7 @@ version = "1.14.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dad43ac27c4b8d7a3ce0e2cb8642a7e3b8ea5e3c29ecea38045a8518519adccf"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "rustc_version",
  "syn 1.0.107",
@@ -5649,7 +5658,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f89a14a8f1e7708fe19ee3140125e9d8279945ead74cb09e65c94dd5cf0640c3"
 dependencies = [
  "bs58",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "rustversion",
  "syn 1.0.107",
@@ -6333,7 +6342,7 @@ dependencies = [
 name = "spl-program-error-derive"
 version = "0.1.0"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 2.0.15",
 ]
@@ -6753,6 +6762,30 @@ dependencies = [
  "num-traits",
  "num_enum 0.6.1",
  "solana-program",
+ "spl-type-length-value-derive",
+ "spl-type-length-value-syn",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-type-length-value-derive"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2 1.0.60",
+ "quote 1.0.26",
+ "spl-type-length-value-syn",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "spl-type-length-value-syn"
+version = "0.1.0"
+dependencies = [
+ "convert_case 0.6.0",
+ "proc-macro2 1.0.60",
+ "quote 1.0.26",
+ "solana-program",
+ "syn 2.0.15",
  "thiserror",
 ]
 
@@ -6815,7 +6848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck 0.4.0",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "rustversion",
  "syn 1.0.107",
@@ -6850,7 +6883,7 @@ version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "unicode-ident",
 ]
@@ -6861,7 +6894,7 @@ version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "unicode-ident",
 ]
@@ -6878,7 +6911,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
  "unicode-xid 0.2.2",
@@ -6948,7 +6981,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee42b4e559f17bce0385ebf511a7beb67d5cc33c12c96b7f4e9789919d9c10f"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -6999,7 +7032,7 @@ checksum = "d10394d5d1e27794f772b6fc854c7e91a2dc26e2cbf807ad523370c2a59c0cee"
 dependencies = [
  "cfg-if 1.0.0",
  "proc-macro-error",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -7011,7 +7044,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eeb9a44b1c6a54c1ba58b152797739dba2a83ca74e18168a68c980eb142f9404"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
  "test-case-core",
@@ -7057,7 +7090,7 @@ version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 2.0.15",
 ]
@@ -7171,7 +7204,7 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -7362,7 +7395,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "prost-build 0.9.0",
  "quote 1.0.26",
  "syn 1.0.107",
@@ -7375,7 +7408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fbcd2800e34e743b9ae795867d5f77b535d3a3be69fd731e39145719752df8c"
 dependencies = [
  "prettyplease",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "prost-build 0.11.1",
  "quote 1.0.26",
  "syn 1.0.107",
@@ -7451,7 +7484,7 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -7595,9 +7628,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.8.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
@@ -7784,7 +7817,7 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
  "wasm-bindgen-shared",
@@ -7818,7 +7851,7 @@ version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
  "wasm-bindgen-backend",
@@ -8168,7 +8201,7 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65f1a51723ec88c66d5d1fe80c841f17f63587d6691901d66be9bec6c3b51f73"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
  "synstructure",

--- a/libraries/type-length-value/Cargo.toml
+++ b/libraries/type-length-value/Cargo.toml
@@ -19,6 +19,8 @@ num-derive = "0.3"
 num-traits = "0.2"
 num_enum = "0.6.1"
 solana-program = "1.14.12"
+spl-type-length-value-derive = { version = "0.1.0", path = "./derive" }
+spl-type-length-value-syn = { version = "0.1.0", path = "./syn" }
 thiserror = "1.0"
 
 [lib]

--- a/libraries/type-length-value/README.md
+++ b/libraries/type-length-value/README.md
@@ -173,10 +173,11 @@ pub struct MyInstruction2 {
 }
 
 #[derive(SplTlv)]
-#[tlv_namespace("token_program_instruction")]
+#[tlv_namespace("enum_program_instruction")]
 pub enum MyInstruction3 {
-    MintTo,
-    Transfer,
+    One,
+    Two,
+    Three,
 }
 ```
 

--- a/libraries/type-length-value/README.md
+++ b/libraries/type-length-value/README.md
@@ -145,3 +145,59 @@ state.borsh_serialize(&my_borsh).unwrap();
 let deser = state.borsh_deserialize::<MyBorsh>().unwrap();
 assert_eq!(deser, my_borsh);
 ```
+
+## Derive Macro
+
+A derive macro is also available to automate much of the above steps.
+
+To implement `TlvDiscriminator` for your struct or enum, simply add the `#[tlv_namespace("...")]` attribute to tell the macro which namespace to use for the discriminator.
+
+Examples:
+
+```rust
+use super::*;
+use solana_program::hash;
+use spl_type_length_value::discriminator::{Discriminator, TlvDiscriminator};
+
+#[derive(SplTlv)]
+#[tlv_namespace("some_particular_program_instruction")]
+pub struct MyInstruction1 {
+    arg1: String,
+    arg2: u8,
+}
+
+#[derive(SplTlv)]
+#[tlv_namespace("yet_another_program_instruction")]
+pub struct MyInstruction2 {
+    arg1: u64,
+}
+
+#[derive(SplTlv)]
+#[tlv_namespace("token_program_instruction")]
+pub enum MyInstruction3 {
+    MintTo,
+    Transfer,
+}
+```
+
+This will generate the following code:
+
+```rust
+impl TlvDiscriminator for MyInstruction1 {
+    const TLV_DISCRIMINATOR: Discriminator = Discriminator::new(MY_INSTRUCTION_1_DISCRIMINATOR);
+}
+const MY_INSTRUCTION_1_DISCRIMINATOR: [u8; Discriminator::LENGTH] = [234, 18, 32, 56, 89, 141, 37, 181]; // Sample bytes
+const MY_INSTRUCTION_1_DISCRIMINATOR_SLICE: &[u8] = &MY_INSTRUCTION_1_DISCRIMINATOR;
+
+impl TlvDiscriminator for MyInstruction2 {
+    const TLV_DISCRIMINATOR: Discriminator = Discriminator::new(MY_INSTRUCTION_2_DISCRIMINATOR);
+}
+const MY_INSTRUCTION_2_DISCRIMINATOR: [u8; Discriminator::LENGTH] = [234, 18, 32, 56, 89, 141, 37, 181]; // Sample bytes
+const MY_INSTRUCTION_2_DISCRIMINATOR_SLICE: &[u8] = &MY_INSTRUCTION_2_DISCRIMINATOR;
+
+impl TlvDiscriminator for MyInstruction3 {
+    const TLV_DISCRIMINATOR: Discriminator = Discriminator::new(MY_INSTRUCTION_3_DISCRIMINATOR);
+}
+const MY_INSTRUCTION_3_DISCRIMINATOR: [u8; Discriminator::LENGTH] = [234, 18, 32, 56, 89, 141, 37, 181]; // Sample bytes
+const MY_INSTRUCTION_3_DISCRIMINATOR_SLICE: &[u8] = &MY_INSTRUCTION_3_DISCRIMINATOR;
+```

--- a/libraries/type-length-value/derive/Cargo.toml
+++ b/libraries/type-length-value/derive/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "spl-type-length-value-derive"
+version = "0.1.0"
+description = "Derive macro library for the `spl-type-length-value` library"
+authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
+repository = "https://github.com/solana-labs/solana-program-library"
+license = "Apache-2.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+spl-type-length-value-syn = { version = "0.1.0", path = "../syn" }
+syn = { version = "2.0", features = ["extra-traits"] }

--- a/libraries/type-length-value/derive/src/lib.rs
+++ b/libraries/type-length-value/derive/src/lib.rs
@@ -1,0 +1,20 @@
+//! Derive macro library for the `spl-type-length-value` library
+
+#![deny(missing_docs)]
+#![cfg_attr(not(test), forbid(unsafe_code))]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::ToTokens;
+use spl_type_length_value_syn::TlvBuilder;
+use syn::parse_macro_input;
+
+/// Derive macro library to generate trait implementations and
+/// types for TLV
+#[proc_macro_derive(SplTlv, attributes(tlv_namespace))]
+pub fn spl_tlv(input: TokenStream) -> TokenStream {
+    parse_macro_input!(input as TlvBuilder)
+        .to_token_stream()
+        .into()
+}

--- a/libraries/type-length-value/src/lib.rs
+++ b/libraries/type-length-value/src/lib.rs
@@ -39,6 +39,14 @@ mod tests {
         arg1: u64,
     }
 
+    #[allow(dead_code)]
+    #[derive(SplTlv)]
+    #[tlv_namespace("token_program_instruction")]
+    pub enum MyInstruction3 {
+        MintTo,
+        Transfer,
+    }
+
     fn assert_discriminators<T: TlvDiscriminator>(
         namespace: &str,
         generated_bytes: [u8; 8],
@@ -65,6 +73,11 @@ mod tests {
             "yet_another_program_instruction",
             MY_INSTRUCTION_2_DISCRIMINATOR,
             MY_INSTRUCTION_2_DISCRIMINATOR_SLICE,
+        );
+        assert_discriminators::<MyInstruction3>(
+            "token_program_instruction",
+            MY_INSTRUCTION_3_DISCRIMINATOR,
+            MY_INSTRUCTION_3_DISCRIMINATOR_SLICE,
         );
     }
 }

--- a/libraries/type-length-value/src/lib.rs
+++ b/libraries/type-length-value/src/lib.rs
@@ -5,6 +5,8 @@
 #![deny(missing_docs)]
 #![cfg_attr(not(test), forbid(unsafe_code))]
 
+extern crate self as spl_type_length_value;
+
 pub mod discriminator;
 pub mod error;
 pub mod length;
@@ -13,3 +15,56 @@ pub mod state;
 
 // Export current sdk types for downstream users building with a different sdk version
 pub use solana_program;
+pub use spl_type_length_value_derive::SplTlv;
+pub use spl_type_length_value_syn::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_program::hash;
+    use spl_type_length_value::discriminator::{Discriminator, TlvDiscriminator};
+
+    #[allow(dead_code)]
+    #[derive(SplTlv)]
+    #[tlv_namespace("some_particular_program_instruction")]
+    pub struct MyInstruction1 {
+        arg1: String,
+        arg2: u8,
+    }
+
+    #[allow(dead_code)]
+    #[derive(SplTlv)]
+    #[tlv_namespace("yet_another_program_instruction")]
+    pub struct MyInstruction2 {
+        arg1: u64,
+    }
+
+    fn assert_discriminators<T: TlvDiscriminator>(
+        namespace: &str,
+        generated_bytes: [u8; 8],
+        generated_slice: &[u8],
+    ) {
+        let preimage = hash::hashv(&[namespace.as_bytes()]);
+        let mut bytes = [0u8; 8];
+        bytes.copy_from_slice(&preimage.to_bytes()[..8]);
+        let discriminator = Discriminator::new(bytes);
+
+        assert_eq!(T::TLV_DISCRIMINATOR, discriminator);
+        assert_eq!(generated_bytes, bytes);
+        assert_eq!(generated_slice, &bytes);
+    }
+
+    #[test]
+    fn test_compiles() {
+        assert_discriminators::<MyInstruction1>(
+            "some_particular_program_instruction",
+            MY_INSTRUCTION_1_DISCRIMINATOR,
+            MY_INSTRUCTION_1_DISCRIMINATOR_SLICE,
+        );
+        assert_discriminators::<MyInstruction2>(
+            "yet_another_program_instruction",
+            MY_INSTRUCTION_2_DISCRIMINATOR,
+            MY_INSTRUCTION_2_DISCRIMINATOR_SLICE,
+        );
+    }
+}

--- a/libraries/type-length-value/src/lib.rs
+++ b/libraries/type-length-value/src/lib.rs
@@ -41,10 +41,11 @@ mod tests {
 
     #[allow(dead_code)]
     #[derive(SplTlv)]
-    #[tlv_namespace("token_program_instruction")]
+    #[tlv_namespace("enum_program_instruction")]
     pub enum MyInstruction3 {
-        MintTo,
-        Transfer,
+        One,
+        Two,
+        Three,
     }
 
     fn assert_discriminators<T: TlvDiscriminator>(
@@ -75,7 +76,7 @@ mod tests {
             MY_INSTRUCTION_2_DISCRIMINATOR_SLICE,
         );
         assert_discriminators::<MyInstruction3>(
-            "token_program_instruction",
+            "enum_program_instruction",
             MY_INSTRUCTION_3_DISCRIMINATOR,
             MY_INSTRUCTION_3_DISCRIMINATOR_SLICE,
         );

--- a/libraries/type-length-value/syn/Cargo.toml
+++ b/libraries/type-length-value/syn/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "spl-type-length-value-syn"
+version = "0.1.0"
+description = "Token parsing and generating library for the `spl-type-length-value` library"
+authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
+repository = "https://github.com/solana-labs/solana-program-library"
+license = "Apache-2.0"
+edition = "2021"
+
+[dependencies]
+convert_case = "0.6"
+proc-macro2 = "1.0"
+quote = "1.0"
+solana-program = "1.14.12"
+syn = { version = "2.0", features = ["full"] }
+thiserror = "1.0.40"

--- a/libraries/type-length-value/syn/src/error.rs
+++ b/libraries/type-length-value/syn/src/error.rs
@@ -1,0 +1,12 @@
+//! Error types for the TLV parser
+
+/// Error types for the TLV parser
+#[derive(Clone, Debug, Eq, thiserror::Error, PartialEq)]
+pub enum SplTlvError {
+    /// TLV namespace attribute not provided
+    #[error("TLV namespace attribute not provided")]
+    TlvNamespaceAttributeNotProvided,
+    /// Error parsing TLV namespace attribute
+    #[error("Error parsing TLV namespace attribute")]
+    TlvNamespaceAttributeParseError,
+}

--- a/libraries/type-length-value/syn/src/lib.rs
+++ b/libraries/type-length-value/syn/src/lib.rs
@@ -58,12 +58,7 @@ impl Parse for TlvBuilder {
                 ))
             }
         }
-        .map_err(|e| {
-            syn::Error::new(
-                input.span(),
-                format!("Failed to parse interface instructions: {}", e),
-            )
-        })
+        .map_err(|e| syn::Error::new(input.span(), format!("Failed to parse item: {}", e)))
     }
 }
 

--- a/libraries/type-length-value/syn/src/lib.rs
+++ b/libraries/type-length-value/syn/src/lib.rs
@@ -1,0 +1,111 @@
+//! Token parsing and generating library for the `type-length-value` library
+
+#![deny(missing_docs)]
+#![cfg_attr(not(test), forbid(unsafe_code))]
+
+mod error;
+pub mod parser;
+
+use convert_case::{Case, Casing};
+use proc_macro2::{Span, TokenStream};
+use quote::{quote, ToTokens};
+use solana_program::hash;
+use syn::{parse::Parse, Ident, Item, ItemEnum, ItemStruct, LitByteStr};
+
+use crate::error::SplTlvError;
+use crate::parser::parse_tlv_namespace;
+
+/// "Builder" struct to implement the TLV traits and
+/// types on an enum or struct
+#[derive(Debug)]
+pub struct TlvBuilder {
+    /// The struct/enum identifier
+    pub ident: Ident,
+    /// The TLV namespace
+    pub namespace: String,
+}
+
+impl TryFrom<ItemEnum> for TlvBuilder {
+    type Error = SplTlvError;
+
+    fn try_from(item_enum: ItemEnum) -> Result<Self, Self::Error> {
+        let ident = item_enum.ident;
+        let namespace = parse_tlv_namespace(&item_enum.attrs)?;
+        Ok(Self { ident, namespace })
+    }
+}
+
+impl TryFrom<ItemStruct> for TlvBuilder {
+    type Error = SplTlvError;
+
+    fn try_from(item_struct: ItemStruct) -> Result<Self, Self::Error> {
+        let ident = item_struct.ident;
+        let namespace = parse_tlv_namespace(&item_struct.attrs)?;
+        Ok(Self { ident, namespace })
+    }
+}
+
+impl Parse for TlvBuilder {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let item = Item::parse(input)?;
+        match item {
+            Item::Enum(item_enum) => item_enum.try_into(),
+            Item::Struct(item_struct) => item_struct.try_into(),
+            _ => {
+                return Err(syn::Error::new(
+                    Span::call_site(),
+                    "Only enums and structs are supported",
+                ))
+            }
+        }
+        .map_err(|e| {
+            syn::Error::new(
+                input.span(),
+                format!("Failed to parse interface instructions: {}", e),
+            )
+        })
+    }
+}
+
+impl ToTokens for TlvBuilder {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        tokens.extend::<TokenStream>(self.into());
+    }
+}
+
+impl From<&TlvBuilder> for TokenStream {
+    fn from(builder: &TlvBuilder) -> Self {
+        let ident = &builder.ident;
+        let (discriminator_name, discriminator_slice_name) = get_discriminator_const_names(ident);
+        let bytes = get_discriminator_bytes(&builder.namespace);
+        quote! {
+            impl spl_type_length_value::discriminator::TlvDiscriminator for #ident {
+                const TLV_DISCRIMINATOR: spl_type_length_value::discriminator::Discriminator = spl_type_length_value::discriminator::Discriminator::new(#discriminator_name);
+            }
+            const #discriminator_name: [u8; spl_type_length_value::discriminator::Discriminator::LENGTH] = *#bytes;
+            const #discriminator_slice_name: &[u8] = &#discriminator_name;
+        }
+    }
+}
+
+/// Builds the constant variable name for the TLV discriminator bytes
+/// ie: `INITIALIZE_DISCRIMINATOR: [u8; Discriminator::LENGTH]`
+/// and the constant variable name for the TLV discriminator slice
+/// ie: `INITIALIZE_DISCRIMINATOR_SLICE: &[u8] = &INITIALIZE_DISCRIMINATOR`
+fn get_discriminator_const_names(ident: &Ident) -> (Ident, Ident) {
+    let ident_upper = ident.to_string().to_case(Case::UpperSnake);
+    let discriminator_name = format!("{}_DISCRIMINATOR", ident_upper);
+    let discriminator_slice_name = format!("{}_DISCRIMINATOR_SLICE", ident_upper);
+    (
+        Ident::new(&discriminator_name, ident.span()),
+        Ident::new(&discriminator_slice_name, ident.span()),
+    )
+}
+
+/// Returns the bytes for the TLV namespace discriminator
+fn get_discriminator_bytes(namespace: &str) -> LitByteStr {
+    LitByteStr::new(
+        &hash::hashv(&[namespace.as_bytes()]).to_bytes()[..8],
+        Span::call_site(),
+    )
+}

--- a/libraries/type-length-value/syn/src/parser.rs
+++ b/libraries/type-length-value/syn/src/parser.rs
@@ -1,0 +1,38 @@
+//! Parser for the `syn` crate to parse the
+//! `#[tlv_namespace = "..."]` attribute
+
+use syn::{
+    parse::{Parse, ParseStream},
+    token::Comma,
+    Attribute, LitStr,
+};
+
+use crate::error::SplTlvError;
+
+/// Struct used for `syn` parsing of the TLV namespace attribute
+/// #[tlv_namespace = "..."]
+struct TlvNamespaceValueParser {
+    value: LitStr,
+    _comma: Option<Comma>,
+}
+
+impl Parse for TlvNamespaceValueParser {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let value: LitStr = input.parse()?;
+        let _comma: Option<Comma> = input.parse().unwrap_or(None);
+        Ok(TlvNamespaceValueParser { value, _comma })
+    }
+}
+
+/// Parses the TLV namespace from the `#[tlv_namespace = "...")]` attribute
+pub fn parse_tlv_namespace(attrs: &[Attribute]) -> Result<String, SplTlvError> {
+    match attrs.iter().find(|a| a.path().is_ident("tlv_namespace")) {
+        Some(attr) => {
+            let parsed_args = attr
+                .parse_args::<TlvNamespaceValueParser>()
+                .map_err(|_| SplTlvError::TlvNamespaceAttributeParseError)?;
+            Ok(parsed_args.value.value())
+        }
+        None => Err(SplTlvError::TlvNamespaceAttributeNotProvided),
+    }
+}


### PR DESCRIPTION
This PR introduces a derive macro for automatically generating the tokens to:
- Implement the `TlvDiscriminator` trait for a struct or enum
- Establish constants for the discriminator bytes and slice

RFC:
- Naming convention of the derive macro: `SplTlv`
- Should we continue to house the constants outside of any trait implementation? I understand this was likely due to the fact it must be manually set (ie. `[u8; 8]`) and can't be derived as a constant. But with a macro, we can do this. But it will require some re-writes of existing constant value handling