### PR TITLE
token-2022: Add metadata pointer extension

### DIFF
--- a/token/program-2022-test/tests/metadata_pointer.rs
+++ b/token/program-2022-test/tests/metadata_pointer.rs
@@ -1,0 +1,257 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+use {
+    program_test::TestContext,
+    solana_program_test::{processor, tokio, ProgramTest},
+    solana_sdk::{
+        instruction::InstructionError, pubkey::Pubkey, signature::Signer, signer::keypair::Keypair,
+        transaction::TransactionError, transport::TransportError,
+    },
+    spl_token_2022::{
+        error::TokenError,
+        extension::{metadata_pointer::MetadataPointer, BaseStateWithExtensions},
+        instruction,
+        processor::Processor,
+    },
+    spl_token_client::token::{ExtensionInitializationParams, TokenError as TokenClientError},
+    std::{convert::TryInto, sync::Arc},
+};
+
+fn setup_program_test() -> ProgramTest {
+    let mut program_test = ProgramTest::default();
+    program_test.prefer_bpf(false);
+    program_test.add_program(
+        "spl_token_2022",
+        spl_token_2022::id(),
+        processor!(Processor::process),
+    );
+    program_test
+}
+
+async fn setup(mint: Keypair, metadata_address: &Pubkey, authority: &Pubkey) -> TestContext {
+    let program_test = setup_program_test();
+
+    let context = program_test.start_with_context().await;
+    let context = Arc::new(tokio::sync::Mutex::new(context));
+    let mut context = TestContext {
+        context,
+        token_context: None,
+    };
+    context
+        .init_token_with_mint_keypair_and_freeze_authority(
+            mint,
+            vec![ExtensionInitializationParams::MetadataPointer {
+                authority: Some(*authority),
+                metadata_address: Some(*metadata_address),
+            }],
+            None,
+        )
+        .await
+        .unwrap();
+    context
+}
+
+#[tokio::test]
+async fn success_init() {
+    let authority = Pubkey::new_unique();
+    let metadata_address = Pubkey::new_unique();
+    let mint_keypair = Keypair::new();
+    let token = setup(mint_keypair, &metadata_address, &authority)
+        .await
+        .token_context
+        .take()
+        .unwrap()
+        .token;
+
+    let state = token.get_mint_info().await.unwrap();
+    assert!(state.base.is_initialized);
+    let extension = state.get_extension::<MetadataPointer>().unwrap();
+    assert_eq!(extension.authority, Some(authority).try_into().unwrap());
+    assert_eq!(
+        extension.metadata_address,
+        Some(metadata_address).try_into().unwrap()
+    );
+}
+
+#[tokio::test]
+async fn fail_init_all_none() {
+    let mut program_test = ProgramTest::default();
+    program_test.prefer_bpf(false);
+    program_test.add_program(
+        "spl_token_2022",
+        spl_token_2022::id(),
+        processor!(Processor::process),
+    );
+    let context = program_test.start_with_context().await;
+    let context = Arc::new(tokio::sync::Mutex::new(context));
+    let mut context = TestContext {
+        context,
+        token_context: None,
+    };
+    let err = context
+        .init_token_with_mint_keypair_and_freeze_authority(
+            Keypair::new(),
+            vec![ExtensionInitializationParams::MetadataPointer {
+                authority: None,
+                metadata_address: None,
+            }],
+            None,
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                1,
+                InstructionError::Custom(TokenError::InvalidInstruction as u32)
+            )
+        )))
+    );
+}
+
+#[tokio::test]
+async fn set_authority() {
+    let authority = Keypair::new();
+    let metadata_address = Pubkey::new_unique();
+    let mint_keypair = Keypair::new();
+    let token = setup(mint_keypair, &metadata_address, &authority.pubkey())
+        .await
+        .token_context
+        .take()
+        .unwrap()
+        .token;
+    let new_authority = Keypair::new();
+
+    // fail, wrong signature
+    let wrong = Keypair::new();
+    let err = token
+        .set_authority(
+            token.get_address(),
+            &wrong.pubkey(),
+            Some(&new_authority.pubkey()),
+            instruction::AuthorityType::MetadataPointer,
+            &[&wrong],
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::OwnerMismatch as u32)
+            )
+        )))
+    );
+
+    // success
+    token
+        .set_authority(
+            token.get_address(),
+            &authority.pubkey(),
+            Some(&new_authority.pubkey()),
+            instruction::AuthorityType::MetadataPointer,
+            &[&authority],
+        )
+        .await
+        .unwrap();
+    let state = token.get_mint_info().await.unwrap();
+    let extension = state.get_extension::<MetadataPointer>().unwrap();
+    assert_eq!(
+        extension.authority,
+        Some(new_authority.pubkey()).try_into().unwrap(),
+    );
+
+    // set to none
+    token
+        .set_authority(
+            token.get_address(),
+            &new_authority.pubkey(),
+            None,
+            instruction::AuthorityType::MetadataPointer,
+            &[&new_authority],
+        )
+        .await
+        .unwrap();
+    let state = token.get_mint_info().await.unwrap();
+    let extension = state.get_extension::<MetadataPointer>().unwrap();
+    assert_eq!(extension.authority, None.try_into().unwrap(),);
+
+    // fail set again
+    let err = token
+        .set_authority(
+            token.get_address(),
+            &new_authority.pubkey(),
+            Some(&authority.pubkey()),
+            instruction::AuthorityType::MetadataPointer,
+            &[&new_authority],
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::AuthorityTypeNotSupported as u32)
+            )
+        )))
+    );
+}
+
+#[tokio::test]
+async fn update_metadata_address() {
+    let authority = Keypair::new();
+    let metadata_address = Pubkey::new_unique();
+    let mint_keypair = Keypair::new();
+    let token = setup(mint_keypair, &metadata_address, &authority.pubkey())
+        .await
+        .token_context
+        .take()
+        .unwrap()
+        .token;
+    let new_metadata_address = Pubkey::new_unique();
+
+    // fail, wrong signature
+    let wrong = Keypair::new();
+    let err = token
+        .update_metadata_address(&wrong.pubkey(), Some(new_metadata_address), &[&wrong])
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::OwnerMismatch as u32)
+            )
+        )))
+    );
+
+    // success
+    token
+        .update_metadata_address(
+            &authority.pubkey(),
+            Some(new_metadata_address),
+            &[&authority],
+        )
+        .await
+        .unwrap();
+    let state = token.get_mint_info().await.unwrap();
+    let extension = state.get_extension::<MetadataPointer>().unwrap();
+    assert_eq!(
+        extension.metadata_address,
+        Some(new_metadata_address).try_into().unwrap(),
+    );
+
+    // set to none
+    token
+        .update_metadata_address(&authority.pubkey(), None, &[&authority])
+        .await
+        .unwrap();
+    let state = token.get_mint_info().await.unwrap();
+    let extension = state.get_extension::<MetadataPointer>().unwrap();
+    assert_eq!(extension.metadata_address, None.try_into().unwrap(),);
+}

--- a/token/program-2022/src/extension/metadata_pointer/instruction.rs
+++ b/token/program-2022/src/extension/metadata_pointer/instruction.rs
@@ -1,0 +1,122 @@
+use {
+    crate::{
+        check_program_account,
+        instruction::{encode_instruction, TokenInstruction},
+        pod::OptionalNonZeroPubkey,
+    },
+    bytemuck::{Pod, Zeroable},
+    num_enum::{IntoPrimitive, TryFromPrimitive},
+    solana_program::{
+        instruction::{AccountMeta, Instruction},
+        program_error::ProgramError,
+        pubkey::Pubkey,
+    },
+    std::convert::TryInto,
+};
+
+/// Metadata pointer extension instructions
+#[derive(Clone, Copy, Debug, PartialEq, IntoPrimitive, TryFromPrimitive)]
+#[repr(u8)]
+pub enum MetadataPointerInstruction {
+    /// Initialize a new mint with a metadata pointer
+    ///
+    /// Fails if the mint has already been initialized, so must be called before
+    /// `InitializeMint`.
+    ///
+    /// The mint must have exactly enough space allocated for the base mint (82
+    /// bytes), plus 83 bytes of padding, 1 byte reserved for the account type,
+    /// then space required for this extension, plus any others.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[writable]` The mint to initialize.
+    ///
+    /// Data expected by this instruction:
+    ///   `crate::extension::metadata_pointer::instruction::InitializeInstructionData`
+    ///
+    Initialize,
+    /// Update the metadata pointer address. Only supported for mints that
+    /// include the `MetadataPointer` extension.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   * Single authority
+    ///   0. `[writable]` The mint.
+    ///   1. `[signer]` The metadata pointer authority.
+    ///
+    ///   * Multisignature authority
+    ///   0. `[writable]` The mint.
+    ///   1. `[]` The mint's metadata pointer authority.
+    ///   2. ..2+M `[signer]` M signer accounts.
+    ///
+    /// Data expected by this instruction:
+    ///   `crate::extension::metadata_pointer::instruction::UpdateInstructionData`
+    ///
+    Update,
+}
+
+/// Data expected by `Initialize`
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct InitializeInstructionData {
+    /// The public key for the account that can update the metadata address
+    pub authority: OptionalNonZeroPubkey,
+    /// The account address that holds the metadata
+    pub metadata_address: OptionalNonZeroPubkey,
+}
+
+/// Data expected by `Update`
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct UpdateInstructionData {
+    /// The new account address that holds the metadata
+    pub metadata_address: OptionalNonZeroPubkey,
+}
+
+/// Create an `Initialize` instruction
+pub fn initialize(
+    token_program_id: &Pubkey,
+    mint: &Pubkey,
+    authority: Option<Pubkey>,
+    metadata_address: Option<Pubkey>,
+) -> Result<Instruction, ProgramError> {
+    check_program_account(token_program_id)?;
+    let accounts = vec![AccountMeta::new(*mint, false)];
+    Ok(encode_instruction(
+        token_program_id,
+        accounts,
+        TokenInstruction::MetadataPointerExtension,
+        MetadataPointerInstruction::Initialize,
+        &InitializeInstructionData {
+            authority: authority.try_into()?,
+            metadata_address: metadata_address.try_into()?,
+        },
+    ))
+}
+
+/// Create an `Update` instruction
+pub fn update(
+    token_program_id: &Pubkey,
+    mint: &Pubkey,
+    authority: &Pubkey,
+    signers: &[&Pubkey],
+    metadata_address: Option<Pubkey>,
+) -> Result<Instruction, ProgramError> {
+    check_program_account(token_program_id)?;
+    let mut accounts = vec![
+        AccountMeta::new(*mint, false),
+        AccountMeta::new_readonly(*authority, signers.is_empty()),
+    ];
+    for signer_pubkey in signers.iter() {
+        accounts.push(AccountMeta::new_readonly(**signer_pubkey, true));
+    }
+    Ok(encode_instruction(
+        token_program_id,
+        accounts,
+        TokenInstruction::MetadataPointerExtension,
+        MetadataPointerInstruction::Update,
+        &UpdateInstructionData {
+            metadata_address: metadata_address.try_into()?,
+        },
+    ))
+}

--- a/token/program-2022/src/extension/metadata_pointer/mod.rs
+++ b/token/program-2022/src/extension/metadata_pointer/mod.rs
@@ -1,0 +1,26 @@
+use {
+    crate::{
+        extension::{Extension, ExtensionType},
+        pod::OptionalNonZeroPubkey,
+    },
+    bytemuck::{Pod, Zeroable},
+};
+
+/// Instructions for the MetadataPointer extension
+pub mod instruction;
+/// Instruction processor for the MetadataPointer extension
+pub mod processor;
+
+/// Metadata pointer extension data for mints.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+pub struct MetadataPointer {
+    /// Authority that can set the metadata address
+    pub authority: OptionalNonZeroPubkey,
+    /// Account address that holds the metadata
+    pub metadata_address: OptionalNonZeroPubkey,
+}
+
+impl Extension for MetadataPointer {
+    const TYPE: ExtensionType = ExtensionType::MetadataPointer;
+}

--- a/token/program-2022/src/extension/metadata_pointer/processor.rs
+++ b/token/program-2022/src/extension/metadata_pointer/processor.rs
@@ -1,0 +1,100 @@
+use {
+    crate::{
+        check_program_account,
+        error::TokenError,
+        extension::{
+            metadata_pointer::{
+                instruction::{
+                    InitializeInstructionData, MetadataPointerInstruction, UpdateInstructionData,
+                },
+                MetadataPointer,
+            },
+            StateWithExtensionsMut,
+        },
+        instruction::{decode_instruction_data, decode_instruction_type},
+        pod::OptionalNonZeroPubkey,
+        processor::Processor,
+        state::Mint,
+    },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        msg,
+        pubkey::Pubkey,
+    },
+};
+
+fn process_initialize(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    authority: &OptionalNonZeroPubkey,
+    metadata_address: &OptionalNonZeroPubkey,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let mint_account_info = next_account_info(account_info_iter)?;
+    let mut mint_data = mint_account_info.data.borrow_mut();
+    let mut mint = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut mint_data)?;
+
+    let extension = mint.init_extension::<MetadataPointer>(true)?;
+    extension.authority = *authority;
+
+    if Option::<Pubkey>::from(*authority).is_none()
+        && Option::<Pubkey>::from(*metadata_address).is_none()
+    {
+        msg!("The metadata pointer extension requires at least an authority or an address for initialization, neither was provided");
+        return Err(TokenError::InvalidInstruction)?;
+    }
+    extension.metadata_address = *metadata_address;
+    Ok(())
+}
+
+fn process_update(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    new_metadata_address: &OptionalNonZeroPubkey,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let mint_account_info = next_account_info(account_info_iter)?;
+    let owner_info = next_account_info(account_info_iter)?;
+    let owner_info_data_len = owner_info.data_len();
+
+    let mut mint_data = mint_account_info.data.borrow_mut();
+    let mut mint = StateWithExtensionsMut::<Mint>::unpack(&mut mint_data)?;
+    let extension = mint.get_extension_mut::<MetadataPointer>()?;
+    let authority =
+        Option::<Pubkey>::from(extension.authority).ok_or(TokenError::NoAuthorityExists)?;
+
+    Processor::validate_owner(
+        program_id,
+        &authority,
+        owner_info,
+        owner_info_data_len,
+        account_info_iter.as_slice(),
+    )?;
+
+    extension.metadata_address = *new_metadata_address;
+    Ok(())
+}
+
+pub(crate) fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    input: &[u8],
+) -> ProgramResult {
+    check_program_account(program_id)?;
+    match decode_instruction_type(input)? {
+        MetadataPointerInstruction::Initialize => {
+            msg!("MetadataPointerInstruction::Initialize");
+            let InitializeInstructionData {
+                authority,
+                metadata_address,
+            } = decode_instruction_data(input)?;
+            process_initialize(program_id, accounts, authority, metadata_address)
+        }
+        MetadataPointerInstruction::Update => {
+            msg!("MetadataPointerInstruction::Update");
+            let UpdateInstructionData { metadata_address } = decode_instruction_data(input)?;
+            process_update(program_id, accounts, metadata_address)
+        }
+    }
+}

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -13,6 +13,7 @@ use {
             immutable_owner::ImmutableOwner,
             interest_bearing_mint::InterestBearingConfig,
             memo_transfer::MemoTransfer,
+            metadata_pointer::MetadataPointer,
             mint_close_authority::MintCloseAuthority,
             non_transferable::{NonTransferable, NonTransferableAccount},
             permanent_delegate::PermanentDelegate,
@@ -51,6 +52,8 @@ pub mod immutable_owner;
 pub mod interest_bearing_mint;
 /// Memo Transfer extension
 pub mod memo_transfer;
+/// Metadata Pointer extension
+pub mod metadata_pointer;
 /// Mint Close Authority extension
 pub mod mint_close_authority;
 /// Non Transferable extension
@@ -665,6 +668,8 @@ pub enum ExtensionType {
     ConfidentialTransferFeeConfig,
     /// Includes confidential withheld transfer fees
     ConfidentialTransferFeeAmount,
+    /// Mint contains a pointer to another account (or the same account) that holds metadata
+    MetadataPointer,
     /// Padding extension used to make an account exactly Multisig::LEN, used for testing
     #[cfg(test)]
     AccountPaddingTest = u16::MAX - 1,
@@ -716,6 +721,7 @@ impl ExtensionType {
             ExtensionType::ConfidentialTransferFeeAmount => {
                 pod_get_packed_len::<ConfidentialTransferFeeAmount>()
             }
+            ExtensionType::MetadataPointer => pod_get_packed_len::<MetadataPointer>(),
             #[cfg(test)]
             ExtensionType::AccountPaddingTest => pod_get_packed_len::<AccountPaddingTest>(),
             #[cfg(test)]
@@ -775,7 +781,8 @@ impl ExtensionType {
             | ExtensionType::InterestBearingConfig
             | ExtensionType::PermanentDelegate
             | ExtensionType::TransferHook
-            | ExtensionType::ConfidentialTransferFeeConfig => AccountType::Mint,
+            | ExtensionType::ConfidentialTransferFeeConfig
+            | ExtensionType::MetadataPointer => AccountType::Mint,
             ExtensionType::ImmutableOwner
             | ExtensionType::TransferFeeAmount
             | ExtensionType::ConfidentialTransferAccount

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -657,6 +657,12 @@ pub enum TokenInstruction<'a> {
     /// 2. `[signer]` Authority
     /// 3. ..2+M `[signer]` M signer accounts.
     WithdrawExcessLamports,
+    /// The common instruction prefix for metadata pointer extension instructions.
+    ///
+    /// See `extension::metadata_pointer::instruction::MetadataPointerInstruction`
+    /// for further details about the extended instructions that share this instruction
+    /// prefix
+    MetadataPointerExtension,
 }
 impl<'a> TokenInstruction<'a> {
     /// Unpacks a byte buffer into a [TokenInstruction](enum.TokenInstruction.html).
@@ -795,6 +801,7 @@ impl<'a> TokenInstruction<'a> {
             36 => Self::TransferHookExtension,
             37 => Self::ConfidentialTransferFeeExtension,
             38 => Self::WithdrawExcessLamports,
+            39 => Self::MetadataPointerExtension,
             _ => return Err(TokenError::InvalidInstruction.into()),
         })
     }
@@ -963,6 +970,9 @@ impl<'a> TokenInstruction<'a> {
             &Self::WithdrawExcessLamports => {
                 buf.push(38);
             }
+            &Self::MetadataPointerExtension => {
+                buf.push(39);
+            }
         };
         buf
     }
@@ -1053,6 +1063,8 @@ pub enum AuthorityType {
     TransferHookProgramId,
     /// Authority to set the withdraw withheld authority encryption key
     ConfidentialTransferFeeConfig,
+    /// Authority to set the metadata address
+    MetadataPointer,
 }
 
 impl AuthorityType {
@@ -1070,6 +1082,7 @@ impl AuthorityType {
             AuthorityType::ConfidentialTransferMint => 9,
             AuthorityType::TransferHookProgramId => 10,
             AuthorityType::ConfidentialTransferFeeConfig => 11,
+            AuthorityType::MetadataPointer => 12,
         }
     }
 
@@ -1087,6 +1100,7 @@ impl AuthorityType {
             9 => Ok(AuthorityType::ConfidentialTransferMint),
             10 => Ok(AuthorityType::TransferHookProgramId),
             11 => Ok(AuthorityType::ConfidentialTransferFeeConfig),
+            12 => Ok(AuthorityType::MetadataPointer),
             _ => Err(TokenError::InvalidInstruction.into()),
         }
     }


### PR DESCRIPTION
#### Problem

As the world of token-metadata potentially fractures between many different programs, it will be impossible to know which metadata address is correct.

#### Solution

Store the correct metadata address directly in a mint extension. A wallet just needs to fetch the mint, read out the metadata address, and then fetch that address.

Note that there is *NO* functionality with this address, and it's just storing two addresses -- the update authority, and the metadata account address.

Most of this is copy-pasted from the transfer hook program id management, and it's meant to be extremely simple.

cc @austbot and @jnwng 