### PR TITLE
typedocs: Fixup deployment

### DIFF
--- a/memo/js/package.json
+++ b/memo/js/package.json
@@ -43,7 +43,7 @@
         "test:e2e": "start-server-and-test 'solana-test-validator -r -q' http://localhost:8899/health 'jest test/e2e'",
         "deploy": "npm run deploy:docs",
         "docs": "shx rm -rf docs && typedoc && shx cp .nojekyll docs/",
-        "deploy:docs": "npm run docs && gh-pages --dist memo/js --dotfiles"
+        "deploy:docs": "npm run docs && gh-pages --dest memo/js --dist docs --dotfiles"
     },
     "peerDependencies": {
         "@solana/web3.js": "^1.20.0"

--- a/token/js/package.json
+++ b/token/js/package.json
@@ -47,7 +47,7 @@
         "test:build-programs": "cargo build-sbf --manifest-path ../program/Cargo.toml && cargo build-sbf --manifest-path ../program-2022/Cargo.toml && cargo build-sbf --manifest-path ../../associated-token-account/program/Cargo.toml",
         "deploy": "npm run deploy:docs",
         "docs": "shx rm -rf docs && typedoc && shx cp .nojekyll docs/",
-        "deploy:docs": "npm run docs && gh-pages --dist token/js --dotfiles"
+        "deploy:docs": "npm run docs && gh-pages --dest token/js --dist docs --dotfiles"
     },
     "peerDependencies": {
         "@solana/web3.js": "^1.47.4"


### PR DESCRIPTION
#### Problem

As pointed out in #4552, the JS docs were no longer appearing.

#### Solution

Fixup the deploy step to use the correct source and destination directories.  Now https://solana-labs.github.io/solana-program-library/token/js/ is all good!