### PR TITLE
Fix downstream dependencies for `spl-program-error`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6634,12 +6634,9 @@ name = "spl-token-metadata-interface"
 version = "0.1.0"
 dependencies = [
  "borsh",
- "num-derive",
- "num-traits",
  "solana-program",
  "spl-program-error",
  "spl-type-length-value",
- "thiserror",
 ]
 
 [[package]]

--- a/libraries/program-error/Cargo.toml
+++ b/libraries/program-error/Cargo.toml
@@ -8,15 +8,15 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-num-derive = "0.3.3"
-num-traits = "0.2.15"
+num-derive = "0.3"
+num-traits = "0.2"
 solana-program = "1.14.12"
 spl-program-error-derive = { version = "0.1.0", path = "./derive" }
-thiserror = "1.0.32"
+thiserror = "1.0"
 
 [dev-dependencies]
-lazy_static = "1.4.0"
-serial_test = "2.0.0"
+lazy_static = "1.4"
+serial_test = "2.0"
 solana-sdk = "1.14.12"
 
 [lib]

--- a/libraries/program-error/derive/src/macro_impl.rs
+++ b/libraries/program-error/derive/src/macro_impl.rs
@@ -104,6 +104,7 @@ pub fn spl_program_error(input: ItemEnum) -> proc_macro2::TokenStream {
     let print_program_error = print_program_error(ident, variants);
     quote! {
         #[derive(Clone, Debug, Eq, thiserror::Error, num_derive::FromPrimitive, PartialEq)]
+        #[num_traits = "num_traits"]
         #input
 
         #into_program_error

--- a/libraries/program-error/src/lib.rs
+++ b/libraries/program-error/src/lib.rs
@@ -8,10 +8,10 @@ extern crate self as spl_program_error;
 
 // Make these available downstream for the macro to work without
 // additional imports
-pub use num_derive::FromPrimitive;
+pub use num_derive;
 pub use num_traits;
 pub use solana_program;
 pub use spl_program_error_derive::{
     spl_program_error, DecodeError, IntoProgramError, PrintProgramError,
 };
-pub use thiserror::Error;
+pub use thiserror;

--- a/token-metadata/interface/Cargo.toml
+++ b/token-metadata/interface/Cargo.toml
@@ -9,12 +9,9 @@ edition = "2021"
 
 [dependencies]
 borsh = "0.9"
-num-derive = "0.3.3"
-num-traits = "0.2"
 solana-program = "1.14.12"
 spl-program-error = { version = "0.1.0" , path = "../../libraries/program-error" }
 spl-type-length-value = { version = "0.1.0" , path = "../../libraries/type-length-value" }
-thiserror = "1.0"
 
 [lib]
 crate-type = ["cdylib", "lib"]


### PR DESCRIPTION
This PR fixes the requirement for crates that wish to use `spl-program-error` to have to import `thiserror`, `num-derive`, and `num-traits`.

Note: This will NOT require these crates to be present in the Cargo.toml file to use the **procedural macro attribute** `#[spl_program_error]`, however, if you decide to use any of the **derive macros** you'll need to import these crates.