### PR TITLE
Upgrade rust version to 1.69.0 and cargo audit to 1.17.6

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -3,11 +3,11 @@ name: Pull Request
 on:
   pull_request:
     paths-ignore:
-    - 'docs/**'
+      - "docs/**"
   push:
     branches: [master]
     paths-ignore:
-    - 'docs/**'
+      - "docs/**"
 
 jobs:
   all_github_action_checks:
@@ -99,7 +99,7 @@ jobs:
         uses: actions-rs/install@v0.1
         with:
           crate: cargo-audit
-          version: 0.16.0 # TODO use latest once repo uses Rust v1.63+
+          version: 0.17.6
 
       - name: Run Cargo Audit
         run: ./ci/do-audit.sh

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.60.0"
+channel = "1.69.0"


### PR DESCRIPTION
- Update rust version to 1.69.0 that the mono uses
- Update `cargo audit` version to the latest version 1.17.6