### PR TITLE
token-2022: Sync native balance during realloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6542,6 +6542,7 @@ dependencies = [
  "spl-token-client",
  "spl-transfer-hook-example",
  "spl-transfer-hook-interface",
+ "test-case",
  "walkdir",
 ]
 

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -29,3 +29,4 @@ spl-instruction-padding = { version = "0.1.0", path="../../instruction-padding/p
 spl-token-client = { version = "0.5", path = "../client" }
 spl-transfer-hook-example = { version = "0.1", path="../transfer-hook-example", features = ["no-entrypoint"] }
 spl-transfer-hook-interface = { version = "0.1", path="../transfer-hook-interface" }
+test-case = "3.1"

--- a/token/program-2022-test/tests/reallocate.rs
+++ b/token/program-2022-test/tests/reallocate.rs
@@ -5,12 +5,19 @@ use {
     program_test::{TestContext, TokenContext},
     solana_program_test::tokio,
     solana_sdk::{
-        instruction::InstructionError, program_option::COption, pubkey::Pubkey, signature::Signer,
-        signer::keypair::Keypair, transaction::TransactionError, transport::TransportError,
+        instruction::InstructionError,
+        program_option::COption,
+        pubkey::Pubkey,
+        signature::Signer,
+        signer::keypair::Keypair,
+        system_instruction,
+        transaction::{Transaction, TransactionError},
+        transport::TransportError,
     },
     spl_token_2022::{error::TokenError, extension::ExtensionType, state::Account},
     spl_token_client::token::{ExtensionInitializationParams, TokenError as TokenClientError},
     std::convert::TryInto,
+    test_case::test_case,
 };
 
 #[tokio::test]
@@ -189,8 +196,11 @@ async fn reallocate_without_current_extension_knowledge() {
     );
 }
 
+#[test_case(true, true ; "transfer lamports and sync")]
+#[test_case(true, false ; "transfer lamports only")]
+#[test_case(false, false ; "do not transfer")]
 #[tokio::test]
-async fn reallocate_syncs_native() {
+async fn reallocate_syncs_native(transfer_lamports: bool, sync_native: bool) {
     let mut context = TestContext::new().await;
     context.init_token_with_native_mint().await.unwrap();
     let TokenContext { token, alice, .. } = context.token_context.unwrap();
@@ -203,9 +213,41 @@ async fn reallocate_syncs_native() {
         .unwrap();
     let alice_account = alice_account.pubkey();
 
+    // transfer more lamports
+    let transfer_amount = 1_000_000_000;
+    if transfer_lamports {
+        let mut context = context.lock().await;
+        let instructions = vec![system_instruction::transfer(
+            &context.payer.pubkey(),
+            &alice_account,
+            transfer_amount,
+        )];
+        let tx = Transaction::new_signed_with_payer(
+            &instructions,
+            Some(&context.payer.pubkey()),
+            &[&context.payer],
+            context.last_blockhash,
+        );
+        context.banks_client.process_transaction(tx).await.unwrap();
+    }
+
+    // amount in the account should be 0 no matter what
+    let account_info = token.get_account_info(&alice_account).await.unwrap();
+    assert_eq!(account_info.base.amount, 0);
+
+    if sync_native {
+        token.sync_native(&alice_account).await.unwrap();
+        let account_info = token.get_account_info(&alice_account).await.unwrap();
+        if transfer_lamports {
+            assert_eq!(account_info.base.amount, transfer_amount);
+        } else {
+            assert_eq!(account_info.base.amount, 0);
+        }
+    }
+
     let token_account = token.get_account_info(&alice_account).await.unwrap();
     let pre_amount = token_account.base.amount;
-    let pre_is_native = token_account.base.is_native.unwrap();
+    let pre_rent_exempt_reserve = token_account.base.is_native.unwrap();
 
     // reallocate resizes account to accommodate new extension
     token
@@ -223,17 +265,32 @@ async fn reallocate_syncs_native() {
         account.data.len(),
         ExtensionType::get_account_len::<Account>(&[ExtensionType::CpiGuard])
     );
-    let rent_exempt_reserve = {
+    let expected_rent_exempt_reserve = {
         let mut context = context.lock().await;
         let rent = context.banks_client.get_rent().await.unwrap();
         rent.minimum_balance(account.data.len())
     };
     let token_account = token.get_account_info(&alice_account).await.unwrap();
     let post_amount = token_account.base.amount;
-    let post_is_native = token_account.base.is_native.unwrap();
-    // amount of lamports should be totally unchanged
-    assert_eq!(pre_amount, post_amount);
+    let post_rent_exempt_reserve = token_account.base.is_native.unwrap();
+    if transfer_lamports && !sync_native {
+        let rent_diff = expected_rent_exempt_reserve
+            .checked_sub(pre_rent_exempt_reserve)
+            .unwrap();
+        // if we didn't sync and transferred lamports, the extra required rent
+        // exemption lamports are taken from the unsynced lamports
+        assert_eq!(
+            post_amount,
+            pre_amount
+                .checked_add(transfer_amount)
+                .and_then(|x| x.checked_sub(rent_diff))
+                .unwrap()
+        );
+    } else {
+        // amount of lamports should be totally unchanged otherwise
+        assert_eq!(pre_amount, post_amount);
+    }
     // but rent exempt reserve should change
-    assert_eq!(post_is_native, rent_exempt_reserve);
-    assert!(pre_is_native < post_is_native);
+    assert_eq!(post_rent_exempt_reserve, expected_rent_exempt_reserve);
+    assert!(pre_rent_exempt_reserve < post_rent_exempt_reserve);
 }

--- a/token/program-2022/src/extension/reallocate.rs
+++ b/token/program-2022/src/extension/reallocate.rs
@@ -97,10 +97,9 @@ pub fn process_reallocate(
 
     // sync the rent exempt reserve for native accounts
     let mut token_account = StateWithExtensionsMut::<Account>::unpack(&mut token_account_data)?;
-    if token_account.base.is_native() {
+    if let Some(native_amount) = native_amount {
         // sanity check that there are enough lamports to cover the token amount
         // and the rent exempt reserve
-        let native_amount = native_amount.ok_or(TokenError::InvalidState)?;
         let lamports_in_account_data = native_amount
             .checked_add(new_minimum_balance)
             .ok_or(TokenError::Overflow)?;

--- a/token/program-2022/src/extension/reallocate.rs
+++ b/token/program-2022/src/extension/reallocate.rs
@@ -100,7 +100,9 @@ pub fn process_reallocate(
         let mut token_account = StateWithExtensionsMut::<Account>::unpack(&mut token_account_data)?;
         // sanity check that there are enough lamports to cover the token amount
         // and the rent exempt reserve
-        let minimum_lamports = native_token_amount.saturating_add(new_rent_exempt_reserve);
+        let minimum_lamports = new_rent_exempt_reserve
+            .checked_add(native_token_amount)
+            .ok_or(TokenError::Overflow)?;
         if token_account_info.lamports() < minimum_lamports {
             return Err(TokenError::InvalidState.into());
         }

--- a/token/program-2022/src/extension/reallocate.rs
+++ b/token/program-2022/src/extension/reallocate.rs
@@ -100,8 +100,8 @@ pub fn process_reallocate(
         let mut token_account = StateWithExtensionsMut::<Account>::unpack(&mut token_account_data)?;
         // sanity check that there are enough lamports to cover the token amount
         // and the rent exempt reserve
-        let lamports_in_account_data = native_token_amount.saturating_add(new_rent_exempt_reserve);
-        if token_account_info.lamports() < lamports_in_account_data {
+        let minimum_lamports = native_token_amount.saturating_add(new_rent_exempt_reserve);
+        if token_account_info.lamports() < minimum_lamports {
             return Err(TokenError::InvalidState.into());
         }
         token_account.base.is_native = COption::Some(new_rent_exempt_reserve);


### PR DESCRIPTION
#### Problem

As kindly pointed out by @ryoqun, when reallocating a native account, we don't update the rent amount stored in `is_native`, meaning that the rent exempt reserve falls out of sync.

#### Solution

During realloc, also update the rent-exempt reserve in native accounts.