### PR TITLE
stake-pool: Remove mpl crate dependency for 1.16 upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6392,7 +6392,6 @@ dependencies = [
  "arrayref",
  "bincode",
  "borsh",
- "mpl-token-metadata",
  "num-derive",
  "num-traits",
  "num_enum 0.6.1",

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -14,7 +14,6 @@ test-sbf = []
 [dependencies]
 arrayref = "0.3.7"
 borsh = "0.9"
-mpl-token-metadata =  { version = "1.7.0", features = [ "no-entrypoint" ] }
 num-derive = "0.3"
 num-traits = "0.2"
 num_enum = "0.6.1"

--- a/stake-pool/program/src/inline_mpl_token_metadata.rs
+++ b/stake-pool/program/src/inline_mpl_token_metadata.rs
@@ -1,0 +1,137 @@
+//! Inlined MPL metadata types to avoid a direct dependency on `mpl-token-metadata'
+
+solana_program::declare_id!("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s");
+
+pub(crate) mod instruction {
+    use {
+        super::state::DataV2,
+        borsh::{BorshDeserialize, BorshSerialize},
+        solana_program::{
+            instruction::{AccountMeta, Instruction},
+            pubkey::Pubkey,
+        },
+    };
+
+    #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
+    struct CreateMetadataAccountArgsV3 {
+        /// Note that unique metadatas are disabled for now.
+        pub data: DataV2,
+        /// Whether you want your metadata to be updateable in the future.
+        pub is_mutable: bool,
+        /// UNUSED If this is a collection parent NFT.
+        pub collection_details: Option<u8>,
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn create_metadata_accounts_v3(
+        program_id: Pubkey,
+        metadata_account: Pubkey,
+        mint: Pubkey,
+        mint_authority: Pubkey,
+        payer: Pubkey,
+        update_authority: Pubkey,
+        name: String,
+        symbol: String,
+        uri: String,
+    ) -> Instruction {
+        let mut data = vec![33]; // CreateMetadataAccountV3
+        data.append(
+            &mut CreateMetadataAccountArgsV3 {
+                data: DataV2 {
+                    name,
+                    symbol,
+                    uri,
+                    seller_fee_basis_points: 0,
+                    creators: None,
+                    collection: None,
+                    uses: None,
+                },
+                is_mutable: true,
+                collection_details: None,
+            }
+            .try_to_vec()
+            .unwrap(),
+        );
+        Instruction {
+            program_id,
+            accounts: vec![
+                AccountMeta::new(metadata_account, false),
+                AccountMeta::new_readonly(mint, false),
+                AccountMeta::new_readonly(mint_authority, true),
+                AccountMeta::new(payer, true),
+                AccountMeta::new_readonly(update_authority, true),
+                AccountMeta::new_readonly(solana_program::system_program::ID, false),
+            ],
+            data,
+        }
+    }
+
+    #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
+    struct UpdateMetadataAccountArgsV2 {
+        pub data: Option<DataV2>,
+        pub update_authority: Option<Pubkey>,
+        pub primary_sale_happened: Option<bool>,
+        pub is_mutable: Option<bool>,
+    }
+    pub(crate) fn update_metadata_accounts_v2(
+        program_id: Pubkey,
+        metadata_account: Pubkey,
+        update_authority: Pubkey,
+        new_update_authority: Option<Pubkey>,
+        metadata: Option<DataV2>,
+        primary_sale_happened: Option<bool>,
+        is_mutable: Option<bool>,
+    ) -> Instruction {
+        let mut data = vec![15]; // UpdateMetadataAccountV2
+        data.append(
+            &mut UpdateMetadataAccountArgsV2 {
+                data: metadata,
+                update_authority: new_update_authority,
+                primary_sale_happened,
+                is_mutable,
+            }
+            .try_to_vec()
+            .unwrap(),
+        );
+        Instruction {
+            program_id,
+            accounts: vec![
+                AccountMeta::new(metadata_account, false),
+                AccountMeta::new_readonly(update_authority, true),
+            ],
+            data,
+        }
+    }
+}
+
+/// PDA creation helpers
+pub mod pda {
+    use {super::ID, solana_program::pubkey::Pubkey};
+    const PREFIX: &str = "metadata";
+    /// Helper to find a metadata account address
+    pub fn find_metadata_account(mint: &Pubkey) -> (Pubkey, u8) {
+        Pubkey::find_program_address(&[PREFIX.as_bytes(), ID.as_ref(), mint.as_ref()], &ID)
+    }
+}
+
+pub(crate) mod state {
+    use borsh::{BorshDeserialize, BorshSerialize};
+    #[repr(C)]
+    #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
+    pub(crate) struct DataV2 {
+        /// The name of the asset
+        pub name: String,
+        /// The symbol for the asset
+        pub symbol: String,
+        /// URI pointing to JSON representing the asset
+        pub uri: String,
+        /// Royalty basis points that goes to creators in secondary sales (0-10000)
+        pub seller_fee_basis_points: u16,
+        /// UNUSED Array of creators, optional
+        pub creators: Option<u8>,
+        /// UNUSED Collection
+        pub collection: Option<u8>,
+        /// UNUSED Uses
+        pub uses: Option<u8>,
+    }
+}

--- a/stake-pool/program/src/instruction.rs
+++ b/stake-pool/program/src/instruction.rs
@@ -7,11 +7,11 @@ use {
         find_deposit_authority_program_address, find_ephemeral_stake_program_address,
         find_stake_program_address, find_transient_stake_program_address,
         find_withdraw_authority_program_address,
+        inline_mpl_token_metadata::{self, pda::find_metadata_account},
         state::{Fee, FeeType, StakePool, ValidatorList},
         MAX_VALIDATORS_TO_UPDATE,
     },
     borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
-    mpl_token_metadata::pda::find_metadata_account,
     solana_program::{
         instruction::{AccountMeta, Instruction},
         pubkey::Pubkey,
@@ -2228,7 +2228,7 @@ pub fn update_token_metadata(
         AccountMeta::new_readonly(*manager, true),
         AccountMeta::new_readonly(stake_pool_withdraw_authority, false),
         AccountMeta::new(token_metadata, false),
-        AccountMeta::new_readonly(mpl_token_metadata::id(), false),
+        AccountMeta::new_readonly(inline_mpl_token_metadata::id(), false),
     ];
 
     Instruction {
@@ -2263,7 +2263,7 @@ pub fn create_token_metadata(
         AccountMeta::new_readonly(*pool_mint, false),
         AccountMeta::new(*payer, true),
         AccountMeta::new(token_metadata, false),
-        AccountMeta::new_readonly(mpl_token_metadata::id(), false),
+        AccountMeta::new_readonly(inline_mpl_token_metadata::id(), false),
         AccountMeta::new_readonly(system_program::id(), false),
     ];
 

--- a/stake-pool/program/src/lib.rs
+++ b/stake-pool/program/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod big_vec;
 pub mod error;
+pub mod inline_mpl_token_metadata;
 pub mod instruction;
 pub mod processor;
 pub mod state;

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -4,6 +4,12 @@ use {
     crate::{
         error::StakePoolError,
         find_deposit_authority_program_address,
+        inline_mpl_token_metadata::{
+            self,
+            instruction::{create_metadata_accounts_v3, update_metadata_accounts_v2},
+            pda::find_metadata_account,
+            state::DataV2,
+        },
         instruction::{FundingType, PreferredValidatorType, StakePoolInstruction},
         minimum_delegation, minimum_reserve_lamports, minimum_stake_lamports,
         state::{
@@ -15,11 +21,6 @@ use {
         TRANSIENT_STAKE_SEED_PREFIX,
     },
     borsh::BorshDeserialize,
-    mpl_token_metadata::{
-        instruction::{create_metadata_accounts_v3, update_metadata_accounts_v2},
-        pda::find_metadata_account,
-        state::DataV2,
-    },
     num_traits::FromPrimitive,
     solana_program::{
         account_info::{next_account_info, AccountInfo},
@@ -161,10 +162,10 @@ fn check_stake_program(program_id: &Pubkey) -> Result<(), ProgramError> {
 
 /// Check mpl metadata program
 fn check_mpl_metadata_program(program_id: &Pubkey) -> Result<(), ProgramError> {
-    if *program_id != mpl_token_metadata::id() {
+    if *program_id != inline_mpl_token_metadata::id() {
         msg!(
             "Expected mpl metadata program {}, received {}",
-            mpl_token_metadata::id(),
+            inline_mpl_token_metadata::id(),
             program_id
         );
         Err(ProgramError::IncorrectProgramId)
@@ -3512,13 +3513,6 @@ impl Processor {
             name,
             symbol,
             uri,
-            None,
-            0,
-            true,
-            true,
-            None,
-            None,
-            None,
         );
 
         let (_, stake_withdraw_bump_seed) =

--- a/stake-pool/program/tests/create_pool_token_metadata.rs
+++ b/stake-pool/program/tests/create_pool_token_metadata.rs
@@ -4,10 +4,6 @@ mod helpers;
 
 use {
     helpers::*,
-    mpl_token_metadata::{
-        state::{MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH},
-        utils::puffed_out_string,
-    },
     solana_program::{instruction::InstructionError, pubkey::Pubkey},
     solana_program_test::*,
     solana_sdk::{
@@ -49,10 +45,6 @@ async fn success(token_program_id: Pubkey) {
     let symbol = "SYM";
     let uri = "test_uri";
 
-    let puffed_name = puffed_out_string(name, MAX_NAME_LENGTH);
-    let puffed_symbol = puffed_out_string(symbol, MAX_SYMBOL_LENGTH);
-    let puffed_uri = puffed_out_string(uri, MAX_URI_LENGTH);
-
     let ix = instruction::create_token_metadata(
         &spl_stake_pool::id(),
         &stake_pool_accounts.stake_pool.pubkey(),
@@ -83,9 +75,9 @@ async fn success(token_program_id: Pubkey) {
     )
     .await;
 
-    assert_eq!(metadata.data.name, puffed_name);
-    assert_eq!(metadata.data.symbol, puffed_symbol);
-    assert_eq!(metadata.data.uri, puffed_uri);
+    assert!(metadata.name.starts_with(name));
+    assert!(metadata.symbol.starts_with(symbol));
+    assert!(metadata.uri.starts_with(uri));
 }
 
 #[tokio::test]

--- a/stake-pool/program/tests/update_pool_token_metadata.rs
+++ b/stake-pool/program/tests/update_pool_token_metadata.rs
@@ -4,10 +4,6 @@ mod helpers;
 
 use {
     helpers::*,
-    mpl_token_metadata::{
-        state::{MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH},
-        utils::puffed_out_string,
-    },
     solana_program::instruction::InstructionError,
     solana_program_test::*,
     solana_sdk::{
@@ -74,10 +70,6 @@ async fn success_update_pool_token_metadata() {
     let updated_symbol = "USYM";
     let updated_uri = "updated_uri";
 
-    let puffed_name = puffed_out_string(updated_name, MAX_NAME_LENGTH);
-    let puffed_symbol = puffed_out_string(updated_symbol, MAX_SYMBOL_LENGTH);
-    let puffed_uri = puffed_out_string(updated_uri, MAX_URI_LENGTH);
-
     let ix = instruction::update_token_metadata(
         &spl_stake_pool::id(),
         &stake_pool_accounts.stake_pool.pubkey(),
@@ -107,9 +99,9 @@ async fn success_update_pool_token_metadata() {
     )
     .await;
 
-    assert_eq!(metadata.data.name, puffed_name);
-    assert_eq!(metadata.data.symbol, puffed_symbol);
-    assert_eq!(metadata.data.uri, puffed_uri);
+    assert!(metadata.name.starts_with(updated_name));
+    assert!(metadata.symbol.starts_with(updated_symbol));
+    assert!(metadata.uri.starts_with(updated_uri));
 }
 
 #[tokio::test]


### PR DESCRIPTION
#### Problem

Because of circular dependencies between SPL and Metaplex Token Metadata, the SPL can't upgrade to Solana 1.16.

#### Solution

After trying many different options, nothing can be done directly at the source level, except for splitting out stake pools into their own repo.

This goes one of the lazy routes, and directly inlines the bits needed for metadata support in the stake pool program. If this looks ok, I'll do the same for single pools.

While implementing this, I first did just the program to make sure that everything worked exactly the same from the outside, and then I removed the mpl dependency from the tests.