### PR TITLE
stateless-asks: Remove metaplex dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2652,36 +2652,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "metaplex-token-metadata"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abcc939f0afdc6db054b9998a1292d0a016244b382462e61cfc7c570624982cb"
-dependencies = [
- "arrayref",
- "borsh",
- "metaplex-token-vault",
- "num-derive",
- "num-traits",
- "solana-program",
- "spl-token 3.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
-]
-
-[[package]]
-name = "metaplex-token-vault"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5211991ba3273df89cd5e0f6f558bc8d7453c87c0546f915b4a319e1541df33"
-dependencies = [
- "borsh",
- "num-derive",
- "num-traits",
- "solana-program",
- "spl-token 3.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6757,7 +6727,6 @@ name = "stateless-asks"
 version = "0.1.0"
 dependencies = [
  "borsh",
- "metaplex-token-metadata",
  "solana-program",
  "solana-program-test",
  "solana-sdk",

--- a/stateless-asks/program/Cargo.toml
+++ b/stateless-asks/program/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 [features]
 no-entrypoint = []
 test-sbf = []
-metaplex = []
 
 [dependencies]
 borsh = "0.9.1"

--- a/stateless-asks/program/Cargo.toml
+++ b/stateless-asks/program/Cargo.toml
@@ -9,13 +9,13 @@ edition = "2021"
 [features]
 no-entrypoint = []
 test-sbf = []
+metaplex = []
 
 [dependencies]
 borsh = "0.9.1"
 solana-program = "1.14.12"
 spl-token = { version = "3.5", path = "../../token/program", features = ["no-entrypoint"] }
 spl-associated-token-account = {version = "1.1", path = "../../associated-token-account/program", features = ["no-entrypoint"]}
-metaplex-token-metadata = { version = "0.0.1", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/stateless-asks/program/src/processor.rs
+++ b/stateless-asks/program/src/processor.rs
@@ -1,6 +1,5 @@
 //! Program state processor
 
-
 use {
     crate::{
         error::UtilError,
@@ -25,10 +24,7 @@ use {
 };
 
 pub(crate) mod inline_mpl_token_metadata {
-    use {
-        borsh::BorshDeserialize,
-        solana_program::pubkey::Pubkey,
-    };
+    use {borsh::BorshDeserialize, solana_program::pubkey::Pubkey};
     solana_program::declare_id!("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s");
 
     #[derive(Clone, BorshDeserialize, Debug, PartialEq, Eq)]
@@ -292,7 +288,9 @@ fn pay_creator_fees<'a>(
     if *metadata_info.owner != inline_mpl_token_metadata::id() {
         return Err(ProgramError::InvalidAccountData);
     }
-    let metadata = try_from_slice_unchecked::<inline_mpl_token_metadata::Metadata>(&metadata_info.try_borrow_data()?)?;
+    let metadata = try_from_slice_unchecked::<inline_mpl_token_metadata::Metadata>(
+        &metadata_info.try_borrow_data()?,
+    )?;
     let fees = metadata.data.seller_fee_basis_points;
     let total_fee = (fees as u64)
         .checked_mul(size)


### PR DESCRIPTION
#### Problem

As mentioned in #4588, upgrading to 1.16 is essentially impossible due to metaplex dependencies in SPL.

#### Solution

We may just want to remove this at some point, but for now, we inline some stuff.