### PR TITLE
`spl-discriminator` generic arg support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6359,6 +6359,7 @@ dependencies = [
 name = "spl-discriminator"
 version = "0.1.0"
 dependencies = [
+ "borsh 0.10.3",
  "bytemuck",
  "solana-program",
  "spl-discriminator-derive",

--- a/libraries/discriminator/Cargo.toml
+++ b/libraries/discriminator/Cargo.toml
@@ -7,7 +7,11 @@ repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
 edition = "2021"
 
+[features]
+borsh = ["dep:borsh"]
+
 [dependencies]
+borsh = { version = "0.10", optional = true }
 bytemuck = { version = "1.13.1", features = ["derive"] }
 solana-program = "1.16.1"
 spl-discriminator-derive = { version = "0.1.0", path = "./derive" }

--- a/libraries/discriminator/src/discriminator.rs
+++ b/libraries/discriminator/src/discriminator.rs
@@ -14,6 +14,10 @@ pub trait SplDiscriminate {
 }
 
 /// Array Discriminator type
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 #[repr(transparent)]
 pub struct ArrayDiscriminator([u8; ArrayDiscriminator::LENGTH]);
@@ -64,5 +68,15 @@ impl TryFrom<&[u8]> for ArrayDiscriminator {
         <[u8; Self::LENGTH]>::try_from(a)
             .map(Self::from)
             .map_err(|_| ProgramError::InvalidAccountData)
+    }
+}
+impl From<ArrayDiscriminator> for [u8; 8] {
+    fn from(from: ArrayDiscriminator) -> Self {
+        from.0
+    }
+}
+impl From<ArrayDiscriminator> for u64 {
+    fn from(from: ArrayDiscriminator) -> Self {
+        u64::from_le_bytes(from.0)
     }
 }


### PR DESCRIPTION
This PR adds `borsh` AND generic support for the `#[derive(SplDiscriminate)]` macro.

You can now apply this macro to structs/enums with:
- One lifetime specifier: `MyItem<'a>`
- Multiple lifetime specifiers: `MyItem<'a, 'b>`
- Generic type arguments: `MyItem<T>`
- Multiple generic type arguments: `MyItem<U, V>`
- Generic types with trait constraints (where clauses): `MyItem<T> where T: Copy`
- *Any combination of the above

I've also implemented `BorshDeserialize` and `BorshSerialize` for the `ArrayDiscriminator` struct, so one can now use this array of 8 bytes in any types that use `BorshDeserialize` or `BorshSerialize`.

Lastly, added a couple conversions for `ArrayDiscriminator` to go _into_ a `[u8; 8]` and _into_ a `u64`