### PR TITLE
Expanding TLV lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6782,15 +6782,12 @@ name = "spl-tlv-account-resolution"
 version = "0.1.0"
 dependencies = [
  "bytemuck",
- "num-derive",
- "num-traits",
- "num_enum 0.6.1",
  "solana-program",
  "solana-program-test",
  "solana-sdk",
  "spl-discriminator",
+ "spl-program-error",
  "spl-type-length-value",
- "thiserror",
 ]
 
 [[package]]
@@ -7103,15 +7100,11 @@ dependencies = [
 name = "spl-type-length-value"
 version = "0.1.0"
 dependencies = [
- "arrayref",
  "borsh 0.10.3",
  "bytemuck",
- "num-derive",
- "num-traits",
- "num_enum 0.6.1",
  "solana-program",
  "spl-discriminator",
- "thiserror",
+ "spl-program-error",
 ]
 
 [[package]]

--- a/libraries/tlv-account-resolution/Cargo.toml
+++ b/libraries/tlv-account-resolution/Cargo.toml
@@ -12,13 +12,10 @@ test-sbf = []
 
 [dependencies]
 bytemuck = { version = "1.13.1", features = ["derive"] }
-num-derive = "0.3"
-num-traits = "0.2"
-num_enum = "0.6.1"
 solana-program = "1.16.1"
 spl-discriminator = { version = "0.1", path = "../discriminator" }
+spl-program-error = { version = "0.1.0", path = "../program-error" }
 spl-type-length-value = { version = "0.1", path = "../type-length-value" }
-thiserror = "1.0"
 
 [dev-dependencies]
 solana-program-test = "1.16.1"

--- a/libraries/tlv-account-resolution/src/error.rs
+++ b/libraries/tlv-account-resolution/src/error.rs
@@ -1,17 +1,9 @@
 //! Error types
 
-use {
-    num_derive::FromPrimitive,
-    solana_program::{
-        decode_error::DecodeError,
-        msg,
-        program_error::{PrintProgramError, ProgramError},
-    },
-    thiserror::Error,
-};
+use spl_program_error::*;
 
 /// Errors that may be returned by the Account Resolution library.
-#[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]
+#[spl_program_error]
 pub enum AccountResolutionError {
     /// Incorrect account provided
     #[error("Incorrect account provided")]
@@ -25,48 +17,7 @@ pub enum AccountResolutionError {
     /// Some value initialized in TLV data
     #[error("Some value initialized in TLV data")]
     TlvInitialized,
-    /// Provided byte buffer too small for validation pubkeys
-    #[error("Provided byte buffer too small for validation pubkeys")]
-    BufferTooSmall,
-    /// Error in checked math operation
-    #[error("Error in checked math operation")]
-    CalculationFailure,
     /// Too many pubkeys provided
     #[error("Too many pubkeys provided")]
     TooManyPubkeys,
-    /// Provided byte buffer too large for expected type
-    #[error("Provided byte buffer too large for expected type")]
-    BufferTooLarge,
-}
-impl From<AccountResolutionError> for ProgramError {
-    fn from(e: AccountResolutionError) -> Self {
-        ProgramError::Custom(e as u32)
-    }
-}
-impl<T> DecodeError<T> for AccountResolutionError {
-    fn type_of() -> &'static str {
-        "AccountResolutionError"
-    }
-}
-
-impl PrintProgramError for AccountResolutionError {
-    fn print<E>(&self)
-    where
-        E: 'static
-            + std::error::Error
-            + DecodeError<E>
-            + PrintProgramError
-            + num_traits::FromPrimitive,
-    {
-        match self {
-            Self::IncorrectAccount => msg!("Incorrect account provided"),
-            Self::NotEnoughAccounts => msg!("Not enough accounts provided"),
-            Self::TlvUninitialized => msg!("No value initialized in TLV data"),
-            Self::TlvInitialized => msg!("Some value initialized in TLV data"),
-            Self::BufferTooSmall => msg!("Provided byte buffer too small for validation pubkeys"),
-            Self::CalculationFailure => msg!("Error in checked math operation"),
-            Self::TooManyPubkeys => msg!("Too many pubkeys provided"),
-            Self::BufferTooLarge => msg!("Provided byte buffer too large for expected type"),
-        }
-    }
 }

--- a/libraries/tlv-account-resolution/src/pod.rs
+++ b/libraries/tlv-account-resolution/src/pod.rs
@@ -1,43 +1,10 @@
 //! Pod types to be used with bytemuck for zero-copy serde
 
 use {
-    crate::error::AccountResolutionError,
     bytemuck::{Pod, Zeroable},
-    solana_program::{
-        account_info::AccountInfo, instruction::AccountMeta, program_error::ProgramError,
-        pubkey::Pubkey,
-    },
-    spl_type_length_value::pod::{pod_from_bytes, pod_from_bytes_mut, PodU32},
+    solana_program::{account_info::AccountInfo, instruction::AccountMeta, pubkey::Pubkey},
+    spl_type_length_value::pod::PodBool,
 };
-
-/// Convert a slice into a mutable `Pod` slice (zero copy)
-pub fn pod_slice_from_bytes<T: Pod>(bytes: &[u8]) -> Result<&[T], ProgramError> {
-    bytemuck::try_cast_slice(bytes).map_err(|_| ProgramError::InvalidArgument)
-}
-/// Convert a slice into a mutable `Pod` slice (zero copy)
-pub fn pod_slice_from_bytes_mut<T: Pod>(bytes: &mut [u8]) -> Result<&mut [T], ProgramError> {
-    bytemuck::try_cast_slice_mut(bytes).map_err(|_| ProgramError::InvalidArgument)
-}
-
-/// The standard `bool` is not a `Pod`, define a replacement that is
-#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
-#[repr(transparent)]
-pub struct PodBool(u8);
-impl From<bool> for PodBool {
-    fn from(b: bool) -> Self {
-        Self(if b { 1 } else { 0 })
-    }
-}
-impl From<&PodBool> for bool {
-    fn from(b: &PodBool) -> Self {
-        b.0 != 0
-    }
-}
-impl From<PodBool> for bool {
-    fn from(b: PodBool) -> Self {
-        b.0 != 0
-    }
-}
 
 /// The standard `AccountMeta` is not a `Pod`, define a replacement that is
 #[repr(C)]
@@ -85,115 +52,5 @@ impl From<&PodAccountMeta> for AccountMeta {
             is_signer: meta.is_signer.into(),
             is_writable: meta.is_writable.into(),
         }
-    }
-}
-
-const LENGTH_SIZE: usize = std::mem::size_of::<PodU32>();
-/// Special type for using a slice of `Pod`s in a zero-copy way
-pub struct PodSlice<'data, T: Pod> {
-    length: &'data PodU32,
-    data: &'data [T],
-}
-impl<'data, T: Pod> PodSlice<'data, T> {
-    /// Unpack the buffer into a slice
-    pub fn unpack<'a>(data: &'a [u8]) -> Result<Self, ProgramError>
-    where
-        'a: 'data,
-    {
-        if data.len() < LENGTH_SIZE {
-            return Err(AccountResolutionError::BufferTooSmall.into());
-        }
-        let (length, data) = data.split_at(LENGTH_SIZE);
-        let length = pod_from_bytes::<PodU32>(length)?;
-        let _max_length = max_len_for_type::<T>(data.len())?;
-        let data = pod_slice_from_bytes(data)?;
-        Ok(Self { length, data })
-    }
-
-    /// Get the slice data
-    pub fn data(&self) -> &[T] {
-        let length = u32::from(*self.length) as usize;
-        &self.data[..length]
-    }
-
-    /// Get the amount of bytes used by `num_items`
-    pub fn size_of(num_items: usize) -> Result<usize, ProgramError> {
-        std::mem::size_of::<T>()
-            .checked_mul(num_items)
-            .and_then(|len| len.checked_add(LENGTH_SIZE))
-            .ok_or_else(|| AccountResolutionError::CalculationFailure.into())
-    }
-}
-
-/// Special type for using a slice of mutable `Pod`s in a zero-copy way
-pub struct PodSliceMut<'data, T: Pod> {
-    length: &'data mut PodU32,
-    data: &'data mut [T],
-    max_length: usize,
-}
-impl<'data, T: Pod> PodSliceMut<'data, T> {
-    /// Unpack the mutable buffer into a mutable slice, with the option to
-    /// initialize the data
-    fn unpack_internal<'a>(data: &'a mut [u8], init: bool) -> Result<Self, ProgramError>
-    where
-        'a: 'data,
-    {
-        if data.len() < LENGTH_SIZE {
-            return Err(AccountResolutionError::BufferTooSmall.into());
-        }
-        let (length, data) = data.split_at_mut(LENGTH_SIZE);
-        let length = pod_from_bytes_mut::<PodU32>(length)?;
-        if init {
-            *length = 0.into();
-        }
-        let max_length = max_len_for_type::<T>(data.len())?;
-        let data = pod_slice_from_bytes_mut(data)?;
-        Ok(Self {
-            length,
-            data,
-            max_length,
-        })
-    }
-
-    /// Unpack the mutable buffer into a mutable slice
-    pub fn unpack<'a>(data: &'a mut [u8]) -> Result<Self, ProgramError>
-    where
-        'a: 'data,
-    {
-        Self::unpack_internal(data, /* init */ false)
-    }
-
-    /// Unpack the mutable buffer into a mutable slice, and initialize the
-    /// slice to 0-length
-    pub fn init<'a>(data: &'a mut [u8]) -> Result<Self, ProgramError>
-    where
-        'a: 'data,
-    {
-        Self::unpack_internal(data, /* init */ true)
-    }
-
-    /// Add another item to the slice
-    pub fn push(&mut self, t: T) -> Result<(), ProgramError> {
-        let length = u32::from(*self.length);
-        if length as usize == self.max_length {
-            Err(AccountResolutionError::BufferTooSmall.into())
-        } else {
-            self.data[length as usize] = t;
-            *self.length = length.saturating_add(1).into();
-            Ok(())
-        }
-    }
-}
-
-fn max_len_for_type<T>(data_len: usize) -> Result<usize, ProgramError> {
-    let size: usize = std::mem::size_of::<T>();
-    let max_len = data_len
-        .checked_div(size)
-        .ok_or(AccountResolutionError::CalculationFailure)?;
-    // check that it isn't overallocated
-    if max_len.saturating_mul(size) != data_len {
-        Err(AccountResolutionError::BufferTooLarge.into())
-    } else {
-        Ok(max_len)
     }
 }

--- a/libraries/tlv-account-resolution/src/state.rs
+++ b/libraries/tlv-account-resolution/src/state.rs
@@ -1,17 +1,17 @@
 //! State transition types
 
 use {
-    crate::{
-        error::AccountResolutionError,
-        pod::{PodAccountMeta, PodSlice, PodSliceMut},
-    },
+    crate::{error::AccountResolutionError, pod::PodAccountMeta},
     solana_program::{
         account_info::AccountInfo,
         instruction::{AccountMeta, Instruction},
         program_error::ProgramError,
     },
     spl_discriminator::SplDiscriminate,
-    spl_type_length_value::state::{TlvState, TlvStateBorrowed, TlvStateMut},
+    spl_type_length_value::{
+        pod::{PodSlice, PodSliceMut},
+        state::{TlvState, TlvStateBorrowed, TlvStateMut},
+    },
 };
 
 /// Stateless helper for storing additional accounts required for an instruction.

--- a/libraries/type-length-value/Cargo.toml
+++ b/libraries/type-length-value/Cargo.toml
@@ -12,15 +12,11 @@ exclude = ["js/**"]
 borsh = ["dep:borsh"]
 
 [dependencies]
-arrayref = "0.3.7"
 borsh = { version = "0.10", optional = true }
 bytemuck = { version = "1.13.1", features = ["derive"] }
-num-derive = "0.3"
-num-traits = "0.2"
-num_enum = "0.6.1"
 solana-program = "1.16.1"
 spl-discriminator = { version = "0.1.0", path = "../discriminator" }
-thiserror = "1.0"
+spl-program-error = { version = "0.1.0", path = "../program-error" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/libraries/type-length-value/src/error.rs
+++ b/libraries/type-length-value/src/error.rs
@@ -1,48 +1,23 @@
 //! Error types
 
-use {
-    num_derive::FromPrimitive,
-    solana_program::{
-        decode_error::DecodeError,
-        msg,
-        program_error::{PrintProgramError, ProgramError},
-    },
-    thiserror::Error,
-};
+use spl_program_error::*;
 
 /// Errors that may be returned by the Token program.
-#[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]
+#[spl_program_error]
 pub enum TlvError {
-    // 0
     /// Type not found in TLV data
     #[error("Type not found in TLV data")]
     TypeNotFound,
     /// Type already exists in TLV data
     #[error("Type already exists in TLV data")]
     TypeAlreadyExists,
-}
-impl From<TlvError> for ProgramError {
-    fn from(e: TlvError) -> Self {
-        ProgramError::Custom(e as u32)
-    }
-}
-impl<T> DecodeError<T> for TlvError {
-    fn type_of() -> &'static str {
-        "TlvError"
-    }
-}
-impl PrintProgramError for TlvError {
-    fn print<E>(&self)
-    where
-        E: 'static
-            + std::error::Error
-            + DecodeError<E>
-            + PrintProgramError
-            + num_traits::FromPrimitive,
-    {
-        match self {
-            Self::TypeNotFound => msg!("Type not found in TLV data"),
-            Self::TypeAlreadyExists => msg!("Type already exists in TLV data"),
-        }
-    }
+    /// Error in checked math operation
+    #[error("Error in checked math operation")]
+    CalculationFailure,
+    /// Provided byte buffer too small for expected type
+    #[error("Provided byte buffer too small for expected type")]
+    BufferTooSmall,
+    /// Provided byte buffer too large for expected type
+    #[error("Provided byte buffer too large for expected type")]
+    BufferTooLarge,
 }

--- a/libraries/type-length-value/src/pod.rs
+++ b/libraries/type-length-value/src/pod.rs
@@ -1,6 +1,7 @@
 //! Pod types to be used with bytemuck for zero-copy serde
 
 use {
+    crate::error::TlvError,
     bytemuck::{Pod, Zeroable},
     solana_program::program_error::ProgramError,
 };
@@ -12,6 +13,14 @@ pub fn pod_from_bytes<T: Pod>(bytes: &[u8]) -> Result<&T, ProgramError> {
 /// Convert a slice into a mutable `Pod` (zero copy)
 pub fn pod_from_bytes_mut<T: Pod>(bytes: &mut [u8]) -> Result<&mut T, ProgramError> {
     bytemuck::try_from_bytes_mut(bytes).map_err(|_| ProgramError::InvalidArgument)
+}
+/// Convert a slice into a mutable `Pod` slice (zero copy)
+pub fn pod_slice_from_bytes<T: Pod>(bytes: &[u8]) -> Result<&[T], ProgramError> {
+    bytemuck::try_cast_slice(bytes).map_err(|_| ProgramError::InvalidArgument)
+}
+/// Convert a slice into a mutable `Pod` slice (zero copy)
+pub fn pod_slice_from_bytes_mut<T: Pod>(bytes: &mut [u8]) -> Result<&mut [T], ProgramError> {
+    bytemuck::try_cast_slice_mut(bytes).map_err(|_| ProgramError::InvalidArgument)
 }
 
 /// Simple macro for implementing conversion functions between Pod* ints and standard ints.
@@ -38,3 +47,133 @@ macro_rules! impl_int_conversion {
 #[repr(transparent)]
 pub struct PodU32([u8; 4]);
 impl_int_conversion!(PodU32, u32);
+
+/// The standard `bool` is not a `Pod`, define a replacement that is
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+#[repr(transparent)]
+pub struct PodBool(u8);
+impl From<bool> for PodBool {
+    fn from(b: bool) -> Self {
+        Self(if b { 1 } else { 0 })
+    }
+}
+impl From<&PodBool> for bool {
+    fn from(b: &PodBool) -> Self {
+        b.0 != 0
+    }
+}
+impl From<PodBool> for bool {
+    fn from(b: PodBool) -> Self {
+        b.0 != 0
+    }
+}
+
+const LENGTH_SIZE: usize = std::mem::size_of::<PodU32>();
+/// Special type for using a slice of `Pod`s in a zero-copy way
+pub struct PodSlice<'data, T: Pod> {
+    length: &'data PodU32,
+    data: &'data [T],
+}
+impl<'data, T: Pod> PodSlice<'data, T> {
+    /// Unpack the buffer into a slice
+    pub fn unpack<'a>(data: &'a [u8]) -> Result<Self, ProgramError>
+    where
+        'a: 'data,
+    {
+        if data.len() < LENGTH_SIZE {
+            return Err(TlvError::BufferTooSmall.into());
+        }
+        let (length, data) = data.split_at(LENGTH_SIZE);
+        let length = pod_from_bytes::<PodU32>(length)?;
+        let _max_length = max_len_for_type::<T>(data.len())?;
+        let data = pod_slice_from_bytes(data)?;
+        Ok(Self { length, data })
+    }
+
+    /// Get the slice data
+    pub fn data(&self) -> &[T] {
+        let length = u32::from(*self.length) as usize;
+        &self.data[..length]
+    }
+
+    /// Get the amount of bytes used by `num_items`
+    pub fn size_of(num_items: usize) -> Result<usize, ProgramError> {
+        std::mem::size_of::<T>()
+            .checked_mul(num_items)
+            .and_then(|len| len.checked_add(LENGTH_SIZE))
+            .ok_or_else(|| TlvError::CalculationFailure.into())
+    }
+}
+
+/// Special type for using a slice of mutable `Pod`s in a zero-copy way
+pub struct PodSliceMut<'data, T: Pod> {
+    length: &'data mut PodU32,
+    data: &'data mut [T],
+    max_length: usize,
+}
+impl<'data, T: Pod> PodSliceMut<'data, T> {
+    /// Unpack the mutable buffer into a mutable slice, with the option to
+    /// initialize the data
+    fn unpack_internal<'a>(data: &'a mut [u8], init: bool) -> Result<Self, ProgramError>
+    where
+        'a: 'data,
+    {
+        if data.len() < LENGTH_SIZE {
+            return Err(TlvError::BufferTooSmall.into());
+        }
+        let (length, data) = data.split_at_mut(LENGTH_SIZE);
+        let length = pod_from_bytes_mut::<PodU32>(length)?;
+        if init {
+            *length = 0.into();
+        }
+        let max_length = max_len_for_type::<T>(data.len())?;
+        let data = pod_slice_from_bytes_mut(data)?;
+        Ok(Self {
+            length,
+            data,
+            max_length,
+        })
+    }
+
+    /// Unpack the mutable buffer into a mutable slice
+    pub fn unpack<'a>(data: &'a mut [u8]) -> Result<Self, ProgramError>
+    where
+        'a: 'data,
+    {
+        Self::unpack_internal(data, /* init */ false)
+    }
+
+    /// Unpack the mutable buffer into a mutable slice, and initialize the
+    /// slice to 0-length
+    pub fn init<'a>(data: &'a mut [u8]) -> Result<Self, ProgramError>
+    where
+        'a: 'data,
+    {
+        Self::unpack_internal(data, /* init */ true)
+    }
+
+    /// Add another item to the slice
+    pub fn push(&mut self, t: T) -> Result<(), ProgramError> {
+        let length = u32::from(*self.length);
+        if length as usize == self.max_length {
+            Err(TlvError::BufferTooSmall.into())
+        } else {
+            self.data[length as usize] = t;
+            *self.length = length.saturating_add(1).into();
+            Ok(())
+        }
+    }
+}
+
+fn max_len_for_type<T>(data_len: usize) -> Result<usize, ProgramError> {
+    let size: usize = std::mem::size_of::<T>();
+    let max_len = data_len
+        .checked_div(size)
+        .ok_or(TlvError::CalculationFailure)?;
+    // check that it isn't overallocated
+    if max_len.saturating_mul(size) != data_len {
+        Err(TlvError::BufferTooLarge.into())
+    } else {
+        Ok(max_len)
+    }
+}

--- a/token-metadata/example/Cargo.toml
+++ b/token-metadata/example/Cargo.toml
@@ -13,7 +13,7 @@ test-sbf = []
 
 [dependencies]
 solana-program = "1.16.1"
-spl-type-length-value = { version = "0.1.0" , path = "../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.1.0" , path = "../../libraries/type-length-value", features = ["borsh"] }
 spl-token-2022 = { version = "0.6.0", path = "../../token/program-2022" }
 spl-token-metadata-interface = { version = "0.1.0", path = "../interface" }
 


### PR DESCRIPTION
This PR seeks to make progress toward building out the TLV library (`type-length-value`) to be more robust and cover a wider range of generic use cases for TLV.
- Moves `PodSlice` and associated types/functions into `type-length-value`, rather than `tlv-account-resolution`
- Cuts unnecessary dependencies and trait impls in favor of `spl-program-error`

The `PodSlice` types I felt are extremely useful and might be useful to other TLV use cases - beyond just account resolution. It's my belief that they should be included in the standard library. Open to feedback!