### PR TITLE
token-metadata: Update program crates to Solana 1.16.1

### DIFF
--- a/token-metadata/example/Cargo.toml
+++ b/token-metadata/example/Cargo.toml
@@ -12,14 +12,14 @@ no-entrypoint = []
 test-sbf = []
 
 [dependencies]
-solana-program = "1.14.12"
+solana-program = "1.16.1"
 spl-type-length-value = { version = "0.1.0" , path = "../../libraries/type-length-value" }
 spl-token-2022 = { version = "0.6.0", path = "../../token/program-2022" }
 spl-token-metadata-interface = { version = "0.1.0", path = "../interface" }
 
 [dev-dependencies]
-solana-program-test = "1.14.12"
-solana-sdk = "1.14.12"
+solana-program-test = "1.16.1"
+solana-sdk = "1.16.1"
 spl-token-client = { version = "0.5", path = "../../token/client" }
 test-case = "3.1"
 


### PR DESCRIPTION
#### Problem

Even though the rest of the repo is explicitly using 1.16.1, the token-metadata example program missed the boat during a rebase.

#### Solution

Bump up the crates explicitly to bring them in line with the rest of the repo