### PR TITLE
bump/program-error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6662,7 +6662,7 @@ dependencies = [
 
 [[package]]
 name = "spl-program-error"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "lazy_static",
  "num-derive",
@@ -6676,7 +6676,7 @@ dependencies = [
 
 [[package]]
 name = "spl-program-error-derive"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "proc-macro2 1.0.60",
  "quote 1.0.26",

--- a/libraries/program-error/Cargo.toml
+++ b/libraries/program-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-program-error"
-version = "0.1.0"
+version = "0.2.0"
 description = "Library for Solana Program error attributes and derive macro for creating them"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -11,7 +11,7 @@ edition = "2021"
 num-derive = "0.3"
 num-traits = "0.2"
 solana-program = "1.16.1"
-spl-program-error-derive = { version = "0.1.0", path = "./derive" }
+spl-program-error-derive = { version = "0.2.0", path = "./derive" }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/libraries/program-error/derive/Cargo.toml
+++ b/libraries/program-error/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-program-error-derive"
-version = "0.1.0"
+version = "0.2.0"
 description = "Proc-Macro Library for Solana Program error attributes and derive macro"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token-metadata/interface/Cargo.toml
+++ b/token-metadata/interface/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 borsh = "0.10"
 solana-program = "1.16.1"
 spl-discriminator = { version = "0.1.0" , path = "../../libraries/discriminator" }
-spl-program-error = { version = "0.1.0" , path = "../../libraries/program-error" }
+spl-program-error = { version = "0.2.0" , path = "../../libraries/program-error" }
 spl-type-length-value = { version = "0.1.0", features = ["borsh"], path = "../../libraries/type-length-value" }
 
 [lib]


### PR DESCRIPTION
- `spl-program-error-derive`: 0.2.0
- `spl-program-error`: 0.2.0

Going with minor release considering the changes to required dependencies are significant.