### PR TITLE
bump/token-2022

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6294,7 +6294,7 @@ dependencies = [
  "num-traits",
  "solana-program",
  "spl-token 4.0.0",
- "spl-token-2022 1.0.0",
+ "spl-token-2022 0.7.0",
  "thiserror",
 ]
 
@@ -6323,7 +6323,7 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account 1.1.3",
  "spl-token 4.0.0",
- "spl-token-2022 1.0.0",
+ "spl-token-2022 0.7.0",
 ]
 
 [[package]]
@@ -6747,7 +6747,7 @@ dependencies = [
  "solana-vote-program",
  "spl-math",
  "spl-token 4.0.0",
- "spl-token-2022 1.0.0",
+ "spl-token-2022 0.7.0",
  "test-case",
  "thiserror",
 ]
@@ -6843,7 +6843,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-2022"
-version = "1.0.0"
+version = "0.7.0"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -6878,7 +6878,7 @@ dependencies = [
  "spl-associated-token-account 1.1.3",
  "spl-instruction-padding",
  "spl-memo 3.0.1",
- "spl-token-2022 1.0.0",
+ "spl-token-2022 0.7.0",
  "spl-token-client",
  "spl-transfer-hook-example",
  "spl-transfer-hook-interface",
@@ -6910,7 +6910,7 @@ dependencies = [
  "spl-associated-token-account 1.1.3",
  "spl-memo 3.0.1",
  "spl-token 4.0.0",
- "spl-token-2022 1.0.0",
+ "spl-token-2022 0.7.0",
  "spl-token-client",
  "strum 0.25.0",
  "strum_macros 0.25.0",
@@ -6932,7 +6932,7 @@ dependencies = [
  "spl-associated-token-account 1.1.3",
  "spl-memo 3.0.1",
  "spl-token 4.0.0",
- "spl-token-2022 1.0.0",
+ "spl-token-2022 0.7.0",
  "spl-transfer-hook-interface",
  "thiserror",
 ]
@@ -6977,7 +6977,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-token-2022 1.0.0",
+ "spl-token-2022 0.7.0",
  "spl-token-client",
  "spl-token-metadata-interface",
  "spl-type-length-value",
@@ -7010,7 +7010,7 @@ dependencies = [
  "solana-sdk",
  "spl-math",
  "spl-token 4.0.0",
- "spl-token-2022 1.0.0",
+ "spl-token-2022 0.7.0",
  "test-case",
  "thiserror",
 ]
@@ -7038,7 +7038,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-token 4.0.0",
- "spl-token-2022 1.0.0",
+ "spl-token-2022 0.7.0",
  "spl-token-client",
  "test-case",
  "thiserror",
@@ -7059,7 +7059,7 @@ dependencies = [
  "solana-test-validator",
  "spl-associated-token-account 1.1.3",
  "spl-token 4.0.0",
- "spl-token-2022 1.0.0",
+ "spl-token-2022 0.7.0",
  "spl-token-client",
  "spl-token-upgrade",
  "tokio",
@@ -7075,7 +7075,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-tlv-account-resolution",
- "spl-token-2022 1.0.0",
+ "spl-token-2022 0.7.0",
  "spl-transfer-hook-interface",
  "spl-type-length-value",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4760,7 +4760,7 @@ dependencies = [
  "solana-config-program",
  "solana-sdk",
  "spl-token 3.5.0",
- "spl-token-2022 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-2022 0.6.1",
  "thiserror",
  "zstd",
 ]
@@ -5340,7 +5340,7 @@ dependencies = [
  "solana-transaction-status",
  "solana-vote-program",
  "spl-token 3.5.0",
- "spl-token-2022 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-2022 0.6.1",
  "static_assertions",
  "tempfile",
  "thiserror",
@@ -5716,7 +5716,7 @@ dependencies = [
  "solana-version",
  "solana-vote-program",
  "spl-token 3.5.0",
- "spl-token-2022 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-2022 0.6.1",
  "stream-cancel",
  "thiserror",
  "tokio",
@@ -5767,7 +5767,7 @@ dependencies = [
  "solana-sdk",
  "solana-transaction-status",
  "solana-version",
- "spl-token-2022 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-2022 0.6.1",
  "thiserror",
 ]
 
@@ -6141,7 +6141,7 @@ dependencies = [
  "spl-associated-token-account 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-memo 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token 3.5.0",
- "spl-token-2022 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-2022 0.6.1",
  "thiserror",
 ]
 
@@ -6294,7 +6294,7 @@ dependencies = [
  "num-traits",
  "solana-program",
  "spl-token 4.0.0",
- "spl-token-2022 0.6.1",
+ "spl-token-2022 1.0.0",
  "thiserror",
 ]
 
@@ -6310,7 +6310,7 @@ dependencies = [
  "num-traits",
  "solana-program",
  "spl-token 3.5.0",
- "spl-token-2022 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-2022 0.6.1",
  "thiserror",
 ]
 
@@ -6323,7 +6323,7 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account 1.1.3",
  "spl-token 4.0.0",
- "spl-token-2022 0.6.1",
+ "spl-token-2022 1.0.0",
 ]
 
 [[package]]
@@ -6747,7 +6747,7 @@ dependencies = [
  "solana-vote-program",
  "spl-math",
  "spl-token 4.0.0",
- "spl-token-2022 0.6.1",
+ "spl-token-2022 1.0.0",
  "test-case",
  "thiserror",
 ]
@@ -6826,6 +6826,24 @@ dependencies = [
 [[package]]
 name = "spl-token-2022"
 version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0043b590232c400bad5ee9eb983ced003d15163c4c5d56b090ac6d9a57457b47"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "num_enum 0.5.11",
+ "solana-program",
+ "solana-zk-token-sdk",
+ "spl-memo 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token 3.5.0",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-token-2022"
+version = "1.0.0"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -6849,24 +6867,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-token-2022"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0043b590232c400bad5ee9eb983ced003d15163c4c5d56b090ac6d9a57457b47"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "num_enum 0.5.11",
- "solana-program",
- "solana-zk-token-sdk",
- "spl-memo 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token 3.5.0",
- "thiserror",
-]
-
-[[package]]
 name = "spl-token-2022-test"
 version = "0.0.1"
 dependencies = [
@@ -6878,7 +6878,7 @@ dependencies = [
  "spl-associated-token-account 1.1.3",
  "spl-instruction-padding",
  "spl-memo 3.0.1",
- "spl-token-2022 0.6.1",
+ "spl-token-2022 1.0.0",
  "spl-token-client",
  "spl-transfer-hook-example",
  "spl-transfer-hook-interface",
@@ -6910,7 +6910,7 @@ dependencies = [
  "spl-associated-token-account 1.1.3",
  "spl-memo 3.0.1",
  "spl-token 4.0.0",
- "spl-token-2022 0.6.1",
+ "spl-token-2022 1.0.0",
  "spl-token-client",
  "strum 0.25.0",
  "strum_macros 0.25.0",
@@ -6932,7 +6932,7 @@ dependencies = [
  "spl-associated-token-account 1.1.3",
  "spl-memo 3.0.1",
  "spl-token 4.0.0",
- "spl-token-2022 0.6.1",
+ "spl-token-2022 1.0.0",
  "spl-transfer-hook-interface",
  "thiserror",
 ]
@@ -6977,7 +6977,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-token-2022 0.6.1",
+ "spl-token-2022 1.0.0",
  "spl-token-client",
  "spl-token-metadata-interface",
  "spl-type-length-value",
@@ -7010,7 +7010,7 @@ dependencies = [
  "solana-sdk",
  "spl-math",
  "spl-token 4.0.0",
- "spl-token-2022 0.6.1",
+ "spl-token-2022 1.0.0",
  "test-case",
  "thiserror",
 ]
@@ -7038,7 +7038,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-token 4.0.0",
- "spl-token-2022 0.6.1",
+ "spl-token-2022 1.0.0",
  "spl-token-client",
  "test-case",
  "thiserror",
@@ -7059,7 +7059,7 @@ dependencies = [
  "solana-test-validator",
  "spl-associated-token-account 1.1.3",
  "spl-token 4.0.0",
- "spl-token-2022 0.6.1",
+ "spl-token-2022 1.0.0",
  "spl-token-client",
  "spl-token-upgrade",
  "tokio",
@@ -7075,7 +7075,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-tlv-account-resolution",
- "spl-token-2022 0.6.1",
+ "spl-token-2022 1.0.0",
  "spl-transfer-hook-interface",
  "spl-type-length-value",
 ]

--- a/associated-token-account/program-test/Cargo.toml
+++ b/associated-token-account/program-test/Cargo.toml
@@ -16,4 +16,4 @@ solana-program-test = "1.16.1"
 solana-sdk = "1.16.1"
 spl-associated-token-account = { version = "1.1", path = "../program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "0.6", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "1.0", path = "../../token/program-2022", features = ["no-entrypoint"] }

--- a/associated-token-account/program-test/Cargo.toml
+++ b/associated-token-account/program-test/Cargo.toml
@@ -16,4 +16,4 @@ solana-program-test = "1.16.1"
 solana-sdk = "1.16.1"
 spl-associated-token-account = { version = "1.1", path = "../program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "1.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.7", path = "../../token/program-2022", features = ["no-entrypoint"] }

--- a/associated-token-account/program/Cargo.toml
+++ b/associated-token-account/program/Cargo.toml
@@ -18,7 +18,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 solana-program = "1.16.1"
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "0.6", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "1.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [lib]

--- a/associated-token-account/program/Cargo.toml
+++ b/associated-token-account/program/Cargo.toml
@@ -18,7 +18,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 solana-program = "1.16.1"
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "1.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.7", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [lib]

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -21,7 +21,7 @@ serde = "1.0.164"
 serde_derive = "1.0.103"
 solana-program = "1.16.1"
 spl-math = { version = "0.2", path = "../../libraries/math", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "0.6", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
+spl-token-2022 = { version = "1.0", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 bincode = "1.3.1"
 

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -21,7 +21,7 @@ serde = "1.0.164"
 serde_derive = "1.0.103"
 solana-program = "1.16.1"
 spl-math = { version = "0.2", path = "../../libraries/math", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "1.0", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
+spl-token-2022 = { version = "0.7", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 bincode = "1.3.1"
 

--- a/token-metadata/example/Cargo.toml
+++ b/token-metadata/example/Cargo.toml
@@ -13,7 +13,7 @@ test-sbf = []
 
 [dependencies]
 solana-program = "1.16.1"
-spl-token-2022 = { version = "0.6.0", path = "../../token/program-2022" }
+spl-token-2022 = { version = "1.0", path = "../../token/program-2022" }
 spl-token-metadata-interface = { version = "0.1.0", path = "../interface" }
 spl-type-length-value = { version = "0.2.0" , path = "../../libraries/type-length-value", features = ["borsh"] }
 

--- a/token-metadata/example/Cargo.toml
+++ b/token-metadata/example/Cargo.toml
@@ -13,7 +13,7 @@ test-sbf = []
 
 [dependencies]
 solana-program = "1.16.1"
-spl-token-2022 = { version = "1.0", path = "../../token/program-2022" }
+spl-token-2022 = { version = "0.7", path = "../../token/program-2022" }
 spl-token-metadata-interface = { version = "0.1.0", path = "../interface" }
 spl-type-length-value = { version = "0.2.0" , path = "../../libraries/type-length-value", features = ["borsh"] }
 

--- a/token-swap/program/Cargo.toml
+++ b/token-swap/program/Cargo.toml
@@ -20,7 +20,7 @@ num-traits = "0.2"
 solana-program = "1.16.1"
 spl-math = { version = "0.2", path = "../../libraries/math", features = [ "no-entrypoint" ] }
 spl-token = { version = "4.0", path = "../../token/program", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "1.0", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
+spl-token-2022 = { version = "0.7", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
 roots = { version = "0.0.8", optional = true }

--- a/token-swap/program/Cargo.toml
+++ b/token-swap/program/Cargo.toml
@@ -20,7 +20,7 @@ num-traits = "0.2"
 solana-program = "1.16.1"
 spl-math = { version = "0.2", path = "../../libraries/math", features = [ "no-entrypoint" ] }
 spl-token = { version = "4.0", path = "../../token/program", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "0.6", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
+spl-token-2022 = { version = "1.0", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
 roots = { version = "0.0.8", optional = true }

--- a/token-upgrade/cli/Cargo.toml
+++ b/token-upgrade/cli/Cargo.toml
@@ -21,7 +21,7 @@ solana-remote-wallet = "1.16.1"
 solana-sdk = "1.16.1"
 spl-associated-token-account = { version = "1.1", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "0.6", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "1.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.5", path = "../../token/client" }
 spl-token-upgrade = { version = "0.1", path = "../program", features = ["no-entrypoint"] }
 tokio = { version = "1", features = ["full"] }

--- a/token-upgrade/cli/Cargo.toml
+++ b/token-upgrade/cli/Cargo.toml
@@ -21,7 +21,7 @@ solana-remote-wallet = "1.16.1"
 solana-sdk = "1.16.1"
 spl-associated-token-account = { version = "1.1", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "1.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.7", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.5", path = "../../token/client" }
 spl-token-upgrade = { version = "0.1", path = "../program", features = ["no-entrypoint"] }
 tokio = { version = "1", features = ["full"] }

--- a/token-upgrade/program/Cargo.toml
+++ b/token-upgrade/program/Cargo.toml
@@ -16,7 +16,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 num_enum = "0.6.1"
 solana-program = "1.16.1"
-spl-token-2022 = { version = "1.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.7", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/token-upgrade/program/Cargo.toml
+++ b/token-upgrade/program/Cargo.toml
@@ -16,7 +16,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 num_enum = "0.6.1"
 solana-program = "1.16.1"
-spl-token-2022 = { version = "0.6", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "1.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -27,7 +27,7 @@ solana-remote-wallet = "=1.16.1"
 solana-sdk = "=1.16.1"
 solana-transaction-status = "=1.16.1"
 spl-token = { version = "4.0", path="../program", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "0.6", path="../program-2022", features = [ "no-entrypoint" ] }
+spl-token-2022 = { version = "1.0", path="../program-2022", features = [ "no-entrypoint" ] }
 spl-token-client = { version = "0.5", path="../client" }
 spl-associated-token-account = { version = "1.1", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
 spl-memo = { version = "3.0.1", path="../../memo/program", features = ["no-entrypoint"] }

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -27,7 +27,7 @@ solana-remote-wallet = "=1.16.1"
 solana-sdk = "=1.16.1"
 solana-transaction-status = "=1.16.1"
 spl-token = { version = "4.0", path="../program", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "1.0", path="../program-2022", features = [ "no-entrypoint" ] }
+spl-token-2022 = { version = "0.7", path="../program-2022", features = [ "no-entrypoint" ] }
 spl-token-client = { version = "0.5", path="../client" }
 spl-associated-token-account = { version = "1.1", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
 spl-memo = { version = "3.0.1", path="../../memo/program", features = ["no-entrypoint"] }

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -19,7 +19,7 @@ solana-sdk = "=1.16.1"
 spl-associated-token-account = { version = "1.1", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-memo = { version = "3.0.1", path = "../../memo/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path="../program", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "1.0", path="../program-2022" }
+spl-token-2022 = { version = "0.7", path="../program-2022" }
 spl-transfer-hook-interface = { version = "0.1", path="../transfer-hook-interface" }
 thiserror = "1.0"
 

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -19,7 +19,7 @@ solana-sdk = "=1.16.1"
 spl-associated-token-account = { version = "1.1", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-memo = { version = "3.0.1", path = "../../memo/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path="../program", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "0.6", path="../program-2022" }
+spl-token-2022 = { version = "1.0", path="../program-2022" }
 spl-transfer-hook-interface = { version = "0.1", path="../transfer-hook-interface" }
 thiserror = "1.0"
 

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -24,7 +24,7 @@ solana-program-test = "=1.16.1"
 solana-sdk = "=1.16.1"
 spl-associated-token-account = { version = "1.1", path = "../../associated-token-account/program" }
 spl-memo = { version = "3.0.1", path = "../../memo/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "0.6", path="../program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "1.0", path="../program-2022", features = ["no-entrypoint"] }
 spl-instruction-padding = { version = "0.1.0", path="../../instruction-padding/program", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.5", path = "../client" }
 spl-transfer-hook-example = { version = "0.1", path="../transfer-hook-example", features = ["no-entrypoint"] }

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -24,7 +24,7 @@ solana-program-test = "=1.16.1"
 solana-sdk = "=1.16.1"
 spl-associated-token-account = { version = "1.1", path = "../../associated-token-account/program" }
 spl-memo = { version = "3.0.1", path = "../../memo/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "1.0", path="../program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.7", path="../program-2022", features = ["no-entrypoint"] }
 spl-instruction-padding = { version = "0.1.0", path="../../instruction-padding/program", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.5", path = "../client" }
 spl-transfer-hook-example = { version = "0.1", path="../transfer-hook-example", features = ["no-entrypoint"] }

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-2022"
-version = "0.6.1"
+version = "1.0.0"
 description = "Solana Program Library Token 2022"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-2022"
-version = "1.0.0"
+version = "0.7.0"
 description = "Solana Program Library Token 2022"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token/transfer-hook-example/Cargo.toml
+++ b/token/transfer-hook-example/Cargo.toml
@@ -15,7 +15,7 @@ test-sbf = []
 arrayref = "0.3.7"
 solana-program = "1.16.1"
 spl-tlv-account-resolution = { version = "0.2.0" , path = "../../libraries/tlv-account-resolution" }
-spl-token-2022 = { version = "0.6",  path = "../program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "1.0",  path = "../program-2022", features = ["no-entrypoint"] }
 spl-transfer-hook-interface = { version = "0.1.0" , path = "../transfer-hook-interface" }
 spl-type-length-value = { version = "0.2.0" , path = "../../libraries/type-length-value" }
 

--- a/token/transfer-hook-example/Cargo.toml
+++ b/token/transfer-hook-example/Cargo.toml
@@ -15,7 +15,7 @@ test-sbf = []
 arrayref = "0.3.7"
 solana-program = "1.16.1"
 spl-tlv-account-resolution = { version = "0.2.0" , path = "../../libraries/tlv-account-resolution" }
-spl-token-2022 = { version = "1.0",  path = "../program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.7",  path = "../program-2022", features = ["no-entrypoint"] }
 spl-transfer-hook-interface = { version = "0.1.0" , path = "../transfer-hook-interface" }
 spl-type-length-value = { version = "0.2.0" , path = "../../libraries/type-length-value" }
 


### PR DESCRIPTION
- `spl-token-2022`: 1.0.0
- `spl-transfer-hook-interface`: 0.1.0
- `spl-transfer-hook-example`: 0.1.0

The two `transfer-hook` crates were 0.0.1 on crates.io, so we don't actually need to bump them, just publish them.