### PR TITLE
Bump/associated token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6138,7 +6138,7 @@ dependencies = [
  "solana-account-decoder",
  "solana-address-lookup-table-program",
  "solana-sdk",
- "spl-associated-token-account 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-associated-token-account 1.1.3",
  "spl-memo 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token 3.5.0",
  "spl-token-2022 0.6.1",
@@ -6287,20 +6287,6 @@ dependencies = [
 [[package]]
 name = "spl-associated-token-account"
 version = "1.1.3"
-dependencies = [
- "assert_matches",
- "borsh 0.10.3",
- "num-derive",
- "num-traits",
- "solana-program",
- "spl-token 4.0.0",
- "spl-token-2022 0.7.0",
- "thiserror",
-]
-
-[[package]]
-name = "spl-associated-token-account"
-version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978dba3bcbe88d0c2c58366c254d9ea41c5f73357e72fc0bdee4d6b5fc99c8f4"
 dependencies = [
@@ -6315,13 +6301,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-associated-token-account"
+version = "1.2.0"
+dependencies = [
+ "assert_matches",
+ "borsh 0.10.3",
+ "num-derive",
+ "num-traits",
+ "solana-program",
+ "spl-token 4.0.0",
+ "spl-token-2022 0.7.0",
+ "thiserror",
+]
+
+[[package]]
 name = "spl-associated-token-account-test"
 version = "0.0.1"
 dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 1.1.3",
+ "spl-associated-token-account 1.2.0",
  "spl-token 4.0.0",
  "spl-token-2022 0.7.0",
 ]
@@ -6600,7 +6600,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-associated-token-account 1.1.3",
  "spl-token 3.5.0",
  "thiserror",
 ]
@@ -6722,7 +6722,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "solana-vote-program",
- "spl-associated-token-account 1.1.3",
+ "spl-associated-token-account 1.2.0",
  "spl-token 4.0.0",
  "test-case",
  "thiserror",
@@ -6772,7 +6772,7 @@ dependencies = [
  "solana-program",
  "solana-remote-wallet",
  "solana-sdk",
- "spl-associated-token-account 1.1.3",
+ "spl-associated-token-account 1.2.0",
  "spl-stake-pool",
  "spl-token 4.0.0",
 ]
@@ -6875,7 +6875,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 1.1.3",
+ "spl-associated-token-account 1.2.0",
  "spl-instruction-padding",
  "spl-memo 3.0.1",
  "spl-token-2022 0.7.0",
@@ -6907,7 +6907,7 @@ dependencies = [
  "solana-sdk",
  "solana-test-validator",
  "solana-transaction-status",
- "spl-associated-token-account 1.1.3",
+ "spl-associated-token-account 1.2.0",
  "spl-memo 3.0.1",
  "spl-token 4.0.0",
  "spl-token-2022 0.7.0",
@@ -6929,7 +6929,7 @@ dependencies = [
  "solana-client",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 1.1.3",
+ "spl-associated-token-account 1.2.0",
  "spl-memo 3.0.1",
  "spl-token 4.0.0",
  "spl-token-2022 0.7.0",
@@ -7057,7 +7057,7 @@ dependencies = [
  "solana-remote-wallet",
  "solana-sdk",
  "solana-test-validator",
- "spl-associated-token-account 1.1.3",
+ "spl-associated-token-account 1.2.0",
  "spl-token 4.0.0",
  "spl-token-2022 0.7.0",
  "spl-token-client",
@@ -7115,7 +7115,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 1.1.3",
+ "spl-associated-token-account 1.2.0",
  "spl-token 4.0.0",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6600,8 +6600,8 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 1.1.3",
- "spl-token 3.5.0",
+ "spl-associated-token-account 1.2.0",
+ "spl-token 4.0.0",
  "thiserror",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6302,7 +6302,7 @@ dependencies = [
 
 [[package]]
 name = "spl-associated-token-account"
-version = "1.2.0"
+version = "2.0.0"
 dependencies = [
  "assert_matches",
  "borsh 0.10.3",
@@ -6321,7 +6321,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 1.2.0",
+ "spl-associated-token-account 2.0.0",
  "spl-token 4.0.0",
  "spl-token-2022 0.7.0",
 ]
@@ -6600,7 +6600,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 1.2.0",
+ "spl-associated-token-account 2.0.0",
  "spl-token 4.0.0",
  "thiserror",
 ]
@@ -6722,7 +6722,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "solana-vote-program",
- "spl-associated-token-account 1.2.0",
+ "spl-associated-token-account 2.0.0",
  "spl-token 4.0.0",
  "test-case",
  "thiserror",
@@ -6772,7 +6772,7 @@ dependencies = [
  "solana-program",
  "solana-remote-wallet",
  "solana-sdk",
- "spl-associated-token-account 1.2.0",
+ "spl-associated-token-account 2.0.0",
  "spl-stake-pool",
  "spl-token 4.0.0",
 ]
@@ -6875,7 +6875,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 1.2.0",
+ "spl-associated-token-account 2.0.0",
  "spl-instruction-padding",
  "spl-memo 3.0.1",
  "spl-token-2022 0.7.0",
@@ -6907,7 +6907,7 @@ dependencies = [
  "solana-sdk",
  "solana-test-validator",
  "solana-transaction-status",
- "spl-associated-token-account 1.2.0",
+ "spl-associated-token-account 2.0.0",
  "spl-memo 3.0.1",
  "spl-token 4.0.0",
  "spl-token-2022 0.7.0",
@@ -6929,7 +6929,7 @@ dependencies = [
  "solana-client",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 1.2.0",
+ "spl-associated-token-account 2.0.0",
  "spl-memo 3.0.1",
  "spl-token 4.0.0",
  "spl-token-2022 0.7.0",
@@ -7057,7 +7057,7 @@ dependencies = [
  "solana-remote-wallet",
  "solana-sdk",
  "solana-test-validator",
- "spl-associated-token-account 1.2.0",
+ "spl-associated-token-account 2.0.0",
  "spl-token 4.0.0",
  "spl-token-2022 0.7.0",
  "spl-token-client",
@@ -7115,7 +7115,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 1.2.0",
+ "spl-associated-token-account 2.0.0",
  "spl-token 4.0.0",
  "thiserror",
 ]

--- a/associated-token-account/program-test/Cargo.toml
+++ b/associated-token-account/program-test/Cargo.toml
@@ -14,6 +14,6 @@ test-sbf = []
 solana-program = "1.16.1"
 solana-program-test = "1.16.1"
 solana-sdk = "1.16.1"
-spl-associated-token-account = { version = "1.2", path = "../program", features = ["no-entrypoint"] }
+spl-associated-token-account = { version = "2.0", path = "../program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "0.7", path = "../../token/program-2022", features = ["no-entrypoint"] }

--- a/associated-token-account/program-test/Cargo.toml
+++ b/associated-token-account/program-test/Cargo.toml
@@ -14,6 +14,6 @@ test-sbf = []
 solana-program = "1.16.1"
 solana-program-test = "1.16.1"
 solana-sdk = "1.16.1"
-spl-associated-token-account = { version = "1.1", path = "../program", features = ["no-entrypoint"] }
+spl-associated-token-account = { version = "1.2", path = "../program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "0.7", path = "../../token/program-2022", features = ["no-entrypoint"] }

--- a/associated-token-account/program/Cargo.toml
+++ b/associated-token-account/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-associated-token-account"
-version = "1.1.3"
+version = "1.2.0"
 description = "Solana Program Library Associated Token Account"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/associated-token-account/program/Cargo.toml
+++ b/associated-token-account/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-associated-token-account"
-version = "1.2.0"
+version = "2.0.0"
 description = "Solana Program Library Associated Token Account"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/managed-token/program/Cargo.toml
+++ b/managed-token/program/Cargo.toml
@@ -25,7 +25,7 @@ test = []
 borsh = "0.10"
 shank = "^0.0.5"
 solana-program = "1.16.1"
-spl-associated-token-account = { version = "1.2", path = "../../associated-token-account/program", features = [ "no-entrypoint", ] }
+spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = [ "no-entrypoint", ] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
 thiserror = "^1.0.40"
 

--- a/managed-token/program/Cargo.toml
+++ b/managed-token/program/Cargo.toml
@@ -22,12 +22,12 @@ default = []
 test = []
 
 [dependencies]
-solana-program = "1.16.1"
-shank = "^0.0.5"
-spl-token = { version = "3.5.0", features = ["no-entrypoint"] }
-spl-associated-token-account = { version = "1.1.1", features = [ "no-entrypoint", ] }
-thiserror = "^1.0.40"
 borsh = "0.10"
+shank = "^0.0.5"
+solana-program = "1.16.1"
+spl-associated-token-account = { version = "1.2", path = "../../associated-token-account/program", features = [ "no-entrypoint", ] }
+spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
+thiserror = "^1.0.40"
 
 [dev-dependencies]
 solana-program-test = "1.16.1"

--- a/stake-pool/cli/Cargo.toml
+++ b/stake-pool/cli/Cargo.toml
@@ -23,7 +23,7 @@ solana-logger = "=1.16.1"
 solana-program = "=1.16.1"
 solana-remote-wallet = "=1.16.1"
 solana-sdk = "=1.16.1"
-spl-associated-token-account = { version = "=1.1.3", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
+spl-associated-token-account = { version = "=1.2", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
 spl-stake-pool = { version = "=0.7.0", path="../program", features = [ "no-entrypoint" ] }
 spl-token = { version = "=4.0", path="../../token/program", features = [ "no-entrypoint" ]  }
 bs58 = "0.4.0"

--- a/stake-pool/cli/Cargo.toml
+++ b/stake-pool/cli/Cargo.toml
@@ -23,7 +23,7 @@ solana-logger = "=1.16.1"
 solana-program = "=1.16.1"
 solana-remote-wallet = "=1.16.1"
 solana-sdk = "=1.16.1"
-spl-associated-token-account = { version = "=1.2", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
+spl-associated-token-account = { version = "=2.0", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
 spl-stake-pool = { version = "=0.7.0", path="../program", features = [ "no-entrypoint" ] }
 spl-token = { version = "=4.0", path="../../token/program", features = [ "no-entrypoint" ]  }
 bs58 = "0.4.0"

--- a/stake-pool/single-pool/Cargo.toml
+++ b/stake-pool/single-pool/Cargo.toml
@@ -19,7 +19,7 @@ num-traits = "0.2"
 num_enum = "0.6.1"
 solana-program = "1.16.1"
 spl-token = { version = "4.0", path = "../../token/program", features = [ "no-entrypoint" ] }
-spl-associated-token-account = { version = "1.2", path = "../../associated-token-account/program", features = [ "no-entrypoint" ] }
+spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/stake-pool/single-pool/Cargo.toml
+++ b/stake-pool/single-pool/Cargo.toml
@@ -19,7 +19,7 @@ num-traits = "0.2"
 num_enum = "0.6.1"
 solana-program = "1.16.1"
 spl-token = { version = "4.0", path = "../../token/program", features = [ "no-entrypoint" ] }
-spl-associated-token-account = { version = "1.1", path = "../../associated-token-account/program", features = [ "no-entrypoint" ] }
+spl-associated-token-account = { version = "1.2", path = "../../associated-token-account/program", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/stateless-asks/program/Cargo.toml
+++ b/stateless-asks/program/Cargo.toml
@@ -14,7 +14,7 @@ test-sbf = []
 borsh = "0.10"
 solana-program = "1.16.1"
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-associated-token-account = {version = "1.1", path = "../../associated-token-account/program", features = ["no-entrypoint"]}
+spl-associated-token-account = {version = "1.2", path = "../../associated-token-account/program", features = ["no-entrypoint"]}
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/stateless-asks/program/Cargo.toml
+++ b/stateless-asks/program/Cargo.toml
@@ -14,7 +14,7 @@ test-sbf = []
 borsh = "0.10"
 solana-program = "1.16.1"
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-associated-token-account = {version = "1.2", path = "../../associated-token-account/program", features = ["no-entrypoint"]}
+spl-associated-token-account = {version = "2.0", path = "../../associated-token-account/program", features = ["no-entrypoint"]}
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/token-upgrade/cli/Cargo.toml
+++ b/token-upgrade/cli/Cargo.toml
@@ -19,7 +19,7 @@ solana-client = "1.16.1"
 solana-logger = "1.16.1"
 solana-remote-wallet = "1.16.1"
 solana-sdk = "1.16.1"
-spl-associated-token-account = { version = "1.1", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
+spl-associated-token-account = { version = "1.2", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "0.7", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.5", path = "../../token/client" }

--- a/token-upgrade/cli/Cargo.toml
+++ b/token-upgrade/cli/Cargo.toml
@@ -19,7 +19,7 @@ solana-client = "1.16.1"
 solana-logger = "1.16.1"
 solana-remote-wallet = "1.16.1"
 solana-sdk = "1.16.1"
-spl-associated-token-account = { version = "1.2", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
+spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "0.7", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.5", path = "../../token/client" }

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -29,7 +29,7 @@ solana-transaction-status = "=1.16.1"
 spl-token = { version = "4.0", path="../program", features = [ "no-entrypoint" ] }
 spl-token-2022 = { version = "0.7", path="../program-2022", features = [ "no-entrypoint" ] }
 spl-token-client = { version = "0.5", path="../client" }
-spl-associated-token-account = { version = "1.2", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
+spl-associated-token-account = { version = "2.0", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
 spl-memo = { version = "3.0.1", path="../../memo/program", features = ["no-entrypoint"] }
 strum = "0.25"
 strum_macros = "0.25"

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -29,7 +29,7 @@ solana-transaction-status = "=1.16.1"
 spl-token = { version = "4.0", path="../program", features = [ "no-entrypoint" ] }
 spl-token-2022 = { version = "0.7", path="../program-2022", features = [ "no-entrypoint" ] }
 spl-token-client = { version = "0.5", path="../client" }
-spl-associated-token-account = { version = "1.1", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
+spl-associated-token-account = { version = "1.2", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
 spl-memo = { version = "3.0.1", path="../../memo/program", features = ["no-entrypoint"] }
 strum = "0.25"
 strum_macros = "0.25"

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -16,7 +16,7 @@ solana-program-test = "=1.16.1"
 solana-sdk = "=1.16.1"
 # We never want the entrypoint for ATA, but we want the entrypoint for token when
 # testing token
-spl-associated-token-account = { version = "1.2", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
+spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-memo = { version = "3.0.1", path = "../../memo/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path="../program", features = [ "no-entrypoint" ] }
 spl-token-2022 = { version = "0.7", path="../program-2022" }

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -16,7 +16,7 @@ solana-program-test = "=1.16.1"
 solana-sdk = "=1.16.1"
 # We never want the entrypoint for ATA, but we want the entrypoint for token when
 # testing token
-spl-associated-token-account = { version = "1.1", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
+spl-associated-token-account = { version = "1.2", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-memo = { version = "3.0.1", path = "../../memo/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path="../program", features = [ "no-entrypoint" ] }
 spl-token-2022 = { version = "0.7", path="../program-2022" }

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -22,7 +22,7 @@ futures-util = "0.3"
 solana-program = "=1.16.1"
 solana-program-test = "=1.16.1"
 solana-sdk = "=1.16.1"
-spl-associated-token-account = { version = "1.1", path = "../../associated-token-account/program" }
+spl-associated-token-account = { version = "1.2", path = "../../associated-token-account/program" }
 spl-memo = { version = "3.0.1", path = "../../memo/program", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "0.7", path="../program-2022", features = ["no-entrypoint"] }
 spl-instruction-padding = { version = "0.1.0", path="../../instruction-padding/program", features = ["no-entrypoint"] }

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -22,7 +22,7 @@ futures-util = "0.3"
 solana-program = "=1.16.1"
 solana-program-test = "=1.16.1"
 solana-sdk = "=1.16.1"
-spl-associated-token-account = { version = "1.2", path = "../../associated-token-account/program" }
+spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program" }
 spl-memo = { version = "3.0.1", path = "../../memo/program", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "0.7", path="../program-2022", features = ["no-entrypoint"] }
 spl-instruction-padding = { version = "0.1.0", path="../../instruction-padding/program", features = ["no-entrypoint"] }


### PR DESCRIPTION
`spl-associated-token-account`: 2.0.0

Also adjusted dependencies for `managed-token` since they were pointing to crates.io instead of the crates alongside it in the workspace