### PR TITLE
token-2022: Make `Extension::get_account_len` fallible

### DIFF
--- a/associated-token-account/program-test/tests/create_idempotent.rs
+++ b/associated-token-account/program-test/tests/create_idempotent.rs
@@ -43,7 +43,7 @@ async fn success_account_exists() {
         program_test_2022(token_mint_address, true).start().await;
     let rent = banks_client.get_rent().await.unwrap();
     let expected_token_account_len =
-        ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]);
+        ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
     let expected_token_account_balance = rent.minimum_balance(expected_token_account_len);
 
     let instruction = create_associated_token_account_idempotent(
@@ -189,7 +189,7 @@ async fn fail_non_ata() {
 
     let rent = banks_client.get_rent().await.unwrap();
     let token_account_len =
-        ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]);
+        ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
     let token_account_balance = rent.minimum_balance(token_account_len);
 
     let wallet_address = Pubkey::new_unique();

--- a/associated-token-account/program-test/tests/create_idempotent.rs
+++ b/associated-token-account/program-test/tests/create_idempotent.rs
@@ -43,7 +43,7 @@ async fn success_account_exists() {
         program_test_2022(token_mint_address, true).start().await;
     let rent = banks_client.get_rent().await.unwrap();
     let expected_token_account_len =
-        ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
+        ExtensionType::try_get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
     let expected_token_account_balance = rent.minimum_balance(expected_token_account_len);
 
     let instruction = create_associated_token_account_idempotent(
@@ -189,7 +189,7 @@ async fn fail_non_ata() {
 
     let rent = banks_client.get_rent().await.unwrap();
     let token_account_len =
-        ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
+        ExtensionType::try_get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
     let token_account_balance = rent.minimum_balance(token_account_len);
 
     let wallet_address = Pubkey::new_unique();

--- a/associated-token-account/program-test/tests/extended_mint.rs
+++ b/associated-token-account/program-test/tests/extended_mint.rs
@@ -39,7 +39,7 @@ async fn test_associated_token_account_with_transfer_fees() {
     let token_mint_address = mint_account.pubkey();
     let mint_authority = Keypair::new();
     let space =
-        ExtensionType::get_account_len::<Mint>(&[ExtensionType::TransferFeeConfig]).unwrap();
+        ExtensionType::try_get_account_len::<Mint>(&[ExtensionType::TransferFeeConfig]).unwrap();
     let maximum_fee = 100;
     let mut transaction = Transaction::new_with_payer(
         &[

--- a/associated-token-account/program-test/tests/extended_mint.rs
+++ b/associated-token-account/program-test/tests/extended_mint.rs
@@ -38,7 +38,8 @@ async fn test_associated_token_account_with_transfer_fees() {
     let mint_account = Keypair::new();
     let token_mint_address = mint_account.pubkey();
     let mint_authority = Keypair::new();
-    let space = ExtensionType::get_account_len::<Mint>(&[ExtensionType::TransferFeeConfig]);
+    let space =
+        ExtensionType::get_account_len::<Mint>(&[ExtensionType::TransferFeeConfig]).unwrap();
     let maximum_fee = 100;
     let mut transaction = Transaction::new_with_payer(
         &[

--- a/associated-token-account/program-test/tests/process_create_associated_token_account.rs
+++ b/associated-token-account/program-test/tests/process_create_associated_token_account.rs
@@ -32,7 +32,7 @@ async fn test_associated_token_address() {
     let rent = banks_client.get_rent().await.unwrap();
 
     let expected_token_account_len =
-        ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]);
+        ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
     let expected_token_account_balance = rent.minimum_balance(expected_token_account_len);
 
     // Associated account does not exist
@@ -81,7 +81,7 @@ async fn test_create_with_fewer_lamports() {
         program_test_2022(token_mint_address, true).start().await;
     let rent = banks_client.get_rent().await.unwrap();
     let expected_token_account_len =
-        ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]);
+        ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
     let expected_token_account_balance = rent.minimum_balance(expected_token_account_len);
 
     // Transfer lamports into `associated_token_address` before creating it - enough to be
@@ -142,7 +142,7 @@ async fn test_create_with_excess_lamports() {
     let rent = banks_client.get_rent().await.unwrap();
 
     let expected_token_account_len =
-        ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]);
+        ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
     let expected_token_account_balance = rent.minimum_balance(expected_token_account_len);
 
     // Transfer 1 lamport into `associated_token_address` before creating it
@@ -272,7 +272,7 @@ async fn test_create_associated_token_account_using_legacy_implicit_instruction(
         program_test_2022(token_mint_address, true).start().await;
     let rent = banks_client.get_rent().await.unwrap();
     let expected_token_account_len =
-        ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]);
+        ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
     let expected_token_account_balance = rent.minimum_balance(expected_token_account_len);
 
     // Associated account does not exist

--- a/associated-token-account/program-test/tests/process_create_associated_token_account.rs
+++ b/associated-token-account/program-test/tests/process_create_associated_token_account.rs
@@ -32,7 +32,7 @@ async fn test_associated_token_address() {
     let rent = banks_client.get_rent().await.unwrap();
 
     let expected_token_account_len =
-        ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
+        ExtensionType::try_get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
     let expected_token_account_balance = rent.minimum_balance(expected_token_account_len);
 
     // Associated account does not exist
@@ -81,7 +81,7 @@ async fn test_create_with_fewer_lamports() {
         program_test_2022(token_mint_address, true).start().await;
     let rent = banks_client.get_rent().await.unwrap();
     let expected_token_account_len =
-        ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
+        ExtensionType::try_get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
     let expected_token_account_balance = rent.minimum_balance(expected_token_account_len);
 
     // Transfer lamports into `associated_token_address` before creating it - enough to be
@@ -142,7 +142,7 @@ async fn test_create_with_excess_lamports() {
     let rent = banks_client.get_rent().await.unwrap();
 
     let expected_token_account_len =
-        ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
+        ExtensionType::try_get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
     let expected_token_account_balance = rent.minimum_balance(expected_token_account_len);
 
     // Transfer 1 lamport into `associated_token_address` before creating it
@@ -272,7 +272,7 @@ async fn test_create_associated_token_account_using_legacy_implicit_instruction(
         program_test_2022(token_mint_address, true).start().await;
     let rent = banks_client.get_rent().await.unwrap();
     let expected_token_account_len =
-        ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
+        ExtensionType::try_get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
     let expected_token_account_balance = rent.minimum_balance(expected_token_account_len);
 
     // Associated account does not exist

--- a/associated-token-account/program-test/tests/recover_nested.rs
+++ b/associated-token-account/program-test/tests/recover_nested.rs
@@ -24,7 +24,7 @@ async fn create_mint(context: &mut ProgramTestContext, program_id: &Pubkey) -> (
     let mint_account = Keypair::new();
     let token_mint_address = mint_account.pubkey();
     let mint_authority = Keypair::new();
-    let space = ExtensionType::get_account_len::<Mint>(&[]);
+    let space = ExtensionType::get_account_len::<Mint>(&[]).unwrap();
     let rent = context.banks_client.get_rent().await.unwrap();
     let transaction = Transaction::new_signed_with_payer(
         &[

--- a/associated-token-account/program-test/tests/recover_nested.rs
+++ b/associated-token-account/program-test/tests/recover_nested.rs
@@ -24,7 +24,7 @@ async fn create_mint(context: &mut ProgramTestContext, program_id: &Pubkey) -> (
     let mint_account = Keypair::new();
     let token_mint_address = mint_account.pubkey();
     let mint_authority = Keypair::new();
-    let space = ExtensionType::get_account_len::<Mint>(&[]).unwrap();
+    let space = ExtensionType::try_get_account_len::<Mint>(&[]).unwrap();
     let rent = context.banks_client.get_rent().await.unwrap();
     let transaction = Transaction::new_signed_with_payer(
         &[

--- a/docs/src/token-2022/onchain.md
+++ b/docs/src/token-2022/onchain.md
@@ -147,7 +147,7 @@ use spl_token_2022::{extension::ExtensionType, instruction::*, state::Mint};
 use solana_sdk::{system_instruction, transaction::Transaction};
 
 // Calculate the space required using the `ExtensionType`
-let space = ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]);
+let space = ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]).unwrap();
 
 // get the Rent object and calculate the rent required
 let rent_required = rent.minimum_balance(space);
@@ -175,7 +175,7 @@ use spl_token_2022::{extension::ExtensionType, instruction::*, state::Account};
 use solana_sdk::{system_instruction, transaction::Transaction};
 
 // Calculate the space required using the `ExtensionType`
-let space = ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]);
+let space = ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
 
 // get the Rent object and calculate the rent required
 let rent_required = rent.minimum_balance(space);
@@ -498,15 +498,15 @@ extension to the token accounts.
 Instead of:
 
 ```rust
-let mint_space = ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]);
-let account_space = ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]);
+let mint_space = ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]).unwrap();
+let account_space = ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
 ```
 
 We'll do:
 
 ```rust
-let mint_space = ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority, ExtensionType::TransferFeeConfig]);
-let account_space = ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner, ExtensionType::TransferFeeAmount]);
+let mint_space = ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority, ExtensionType::TransferFeeConfig]).unwrap();
+let account_space = ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner, ExtensionType::TransferFeeAmount]).unwrap();
 ```
 
 And during initialization of the mint, we'll add in the instruction to initialize
@@ -725,7 +725,7 @@ use spl_token_2022::{extension::ExtensionType, instruction::*, state::Mint};
 use solana_sdk::{system_instruction, transaction::Transaction};
 
 // Calculate the space required using the `ExtensionType`
-let space = ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]);
+let space = ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]).unwrap();
 
 // get the Rent object and calculate the rent required
 let rent_required = rent.minimum_balance(space);

--- a/docs/src/token-2022/onchain.md
+++ b/docs/src/token-2022/onchain.md
@@ -147,7 +147,7 @@ use spl_token_2022::{extension::ExtensionType, instruction::*, state::Mint};
 use solana_sdk::{system_instruction, transaction::Transaction};
 
 // Calculate the space required using the `ExtensionType`
-let space = ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]).unwrap();
+let space = ExtensionType::try_get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]).unwrap();
 
 // get the Rent object and calculate the rent required
 let rent_required = rent.minimum_balance(space);
@@ -175,7 +175,7 @@ use spl_token_2022::{extension::ExtensionType, instruction::*, state::Account};
 use solana_sdk::{system_instruction, transaction::Transaction};
 
 // Calculate the space required using the `ExtensionType`
-let space = ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
+let space = ExtensionType::try_get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
 
 // get the Rent object and calculate the rent required
 let rent_required = rent.minimum_balance(space);
@@ -498,15 +498,15 @@ extension to the token accounts.
 Instead of:
 
 ```rust
-let mint_space = ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]).unwrap();
-let account_space = ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
+let mint_space = ExtensionType::try_get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]).unwrap();
+let account_space = ExtensionType::try_get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
 ```
 
 We'll do:
 
 ```rust
-let mint_space = ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority, ExtensionType::TransferFeeConfig]).unwrap();
-let account_space = ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner, ExtensionType::TransferFeeAmount]).unwrap();
+let mint_space = ExtensionType::try_get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority, ExtensionType::TransferFeeConfig]).unwrap();
+let account_space = ExtensionType::try_get_account_len::<Account>(&[ExtensionType::ImmutableOwner, ExtensionType::TransferFeeAmount]).unwrap();
 ```
 
 And during initialization of the mint, we'll add in the instruction to initialize
@@ -725,7 +725,7 @@ use spl_token_2022::{extension::ExtensionType, instruction::*, state::Mint};
 use solana_sdk::{system_instruction, transaction::Transaction};
 
 // Calculate the space required using the `ExtensionType`
-let space = ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]).unwrap();
+let space = ExtensionType::try_get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]).unwrap();
 
 // get the Rent object and calculate the rent required
 let rent_required = rent.minimum_balance(space);

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -94,7 +94,7 @@ pub async fn create_mint(
 ) -> Result<(), TransportError> {
     assert!(extension_types.is_empty() || program_id != &spl_token::id());
     let rent = banks_client.get_rent().await.unwrap();
-    let space = ExtensionType::get_account_len::<Mint>(extension_types).unwrap();
+    let space = ExtensionType::try_get_account_len::<Mint>(extension_types).unwrap();
     let mint_rent = rent.minimum_balance(space);
     let mint_pubkey = pool_mint.pubkey();
 
@@ -225,7 +225,7 @@ pub async fn create_token_account(
     extensions: &[ExtensionType],
 ) -> Result<(), TransportError> {
     let rent = banks_client.get_rent().await.unwrap();
-    let space = ExtensionType::get_account_len::<Account>(extensions).unwrap();
+    let space = ExtensionType::try_get_account_len::<Account>(extensions).unwrap();
     let account_rent = rent.minimum_balance(space);
 
     let mut instructions = vec![system_instruction::create_account(

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -94,7 +94,7 @@ pub async fn create_mint(
 ) -> Result<(), TransportError> {
     assert!(extension_types.is_empty() || program_id != &spl_token::id());
     let rent = banks_client.get_rent().await.unwrap();
-    let space = ExtensionType::get_account_len::<Mint>(extension_types);
+    let space = ExtensionType::get_account_len::<Mint>(extension_types).unwrap();
     let mint_rent = rent.minimum_balance(space);
     let mint_pubkey = pool_mint.pubkey();
 
@@ -225,7 +225,7 @@ pub async fn create_token_account(
     extensions: &[ExtensionType],
 ) -> Result<(), TransportError> {
     let rent = banks_client.get_rent().await.unwrap();
-    let space = ExtensionType::get_account_len::<Account>(extensions);
+    let space = ExtensionType::get_account_len::<Account>(extensions).unwrap();
     let account_rent = rent.minimum_balance(space);
 
     let mut instructions = vec![system_instruction::create_account(

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -2158,6 +2158,7 @@ mod tests {
                 ExtensionType::ImmutableOwner,
                 ExtensionType::TransferFeeAmount,
             ])
+            .unwrap()
         } else {
             Account::get_packed_len()
         };
@@ -2221,8 +2222,9 @@ mod tests {
                     ExtensionType::MintCloseAuthority,
                     ExtensionType::TransferFeeConfig,
                 ])
+                .unwrap()
             } else {
-                ExtensionType::get_account_len::<Mint>(&[ExtensionType::TransferFeeConfig])
+                ExtensionType::get_account_len::<Mint>(&[ExtensionType::TransferFeeConfig]).unwrap()
             }
         } else {
             Mint::get_packed_len()

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -2154,7 +2154,7 @@ mod tests {
     ) -> (Pubkey, SolanaAccount) {
         let account_key = Pubkey::new_unique();
         let space = if *program_id == spl_token_2022::id() {
-            ExtensionType::get_account_len::<Account>(&[
+            ExtensionType::try_get_account_len::<Account>(&[
                 ExtensionType::ImmutableOwner,
                 ExtensionType::TransferFeeAmount,
             ])
@@ -2218,13 +2218,14 @@ mod tests {
         let mint_key = Pubkey::new_unique();
         let space = if *program_id == spl_token_2022::id() {
             if close_authority.is_some() {
-                ExtensionType::get_account_len::<Mint>(&[
+                ExtensionType::try_get_account_len::<Mint>(&[
                     ExtensionType::MintCloseAuthority,
                     ExtensionType::TransferFeeConfig,
                 ])
                 .unwrap()
             } else {
-                ExtensionType::get_account_len::<Mint>(&[ExtensionType::TransferFeeConfig]).unwrap()
+                ExtensionType::try_get_account_len::<Mint>(&[ExtensionType::TransferFeeConfig])
+                    .unwrap()
             }
         } else {
             Mint::get_packed_len()

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -2186,7 +2186,7 @@ async fn command_required_transfer_memos(
         }
     } else {
         existing_extensions.push(ExtensionType::MemoTransfer);
-        let needed_account_len = ExtensionType::get_account_len::<Account>(&existing_extensions);
+        let needed_account_len = ExtensionType::get_account_len::<Account>(&existing_extensions)?;
         if needed_account_len > current_account_len {
             token
                 .reallocate(
@@ -2258,7 +2258,7 @@ async fn command_cpi_guard(
         }
     } else {
         existing_extensions.push(ExtensionType::CpiGuard);
-        let required_account_len = ExtensionType::get_account_len::<Account>(&existing_extensions);
+        let required_account_len = ExtensionType::get_account_len::<Account>(&existing_extensions)?;
         if required_account_len > current_account_len {
             token
                 .reallocate(

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -2186,7 +2186,8 @@ async fn command_required_transfer_memos(
         }
     } else {
         existing_extensions.push(ExtensionType::MemoTransfer);
-        let needed_account_len = ExtensionType::get_account_len::<Account>(&existing_extensions)?;
+        let needed_account_len =
+            ExtensionType::try_get_account_len::<Account>(&existing_extensions)?;
         if needed_account_len > current_account_len {
             token
                 .reallocate(
@@ -2258,7 +2259,8 @@ async fn command_cpi_guard(
         }
     } else {
         existing_extensions.push(ExtensionType::CpiGuard);
-        let required_account_len = ExtensionType::get_account_len::<Account>(&existing_extensions)?;
+        let required_account_len =
+            ExtensionType::try_get_account_len::<Account>(&existing_extensions)?;
         if required_account_len > current_account_len {
             token
                 .reallocate(

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -531,7 +531,7 @@ where
             .iter()
             .map(|e| e.extension())
             .collect::<Vec<_>>();
-        let space = ExtensionType::get_account_len::<Mint>(&extension_types);
+        let space = ExtensionType::get_account_len::<Mint>(&extension_types)?;
 
         let mut instructions = vec![system_instruction::create_account(
             &self.payer.pubkey(),
@@ -653,7 +653,7 @@ where
                 required_extensions.push(extension_type);
             }
         }
-        let space = ExtensionType::get_account_len::<Account>(&required_extensions);
+        let space = ExtensionType::get_account_len::<Account>(&required_extensions)?;
         let mut instructions = vec![system_instruction::create_account(
             &self.payer.pubkey(),
             &account.pubkey(),
@@ -1259,7 +1259,7 @@ where
             } else {
                 vec![]
             };
-            let space = ExtensionType::get_account_len::<Account>(&extensions);
+            let space = ExtensionType::get_account_len::<Account>(&extensions)?;
 
             instructions.push(system_instruction::create_account(
                 &self.payer.pubkey(),

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -531,7 +531,7 @@ where
             .iter()
             .map(|e| e.extension())
             .collect::<Vec<_>>();
-        let space = ExtensionType::get_account_len::<Mint>(&extension_types)?;
+        let space = ExtensionType::try_get_account_len::<Mint>(&extension_types)?;
 
         let mut instructions = vec![system_instruction::create_account(
             &self.payer.pubkey(),
@@ -653,7 +653,7 @@ where
                 required_extensions.push(extension_type);
             }
         }
-        let space = ExtensionType::get_account_len::<Account>(&required_extensions)?;
+        let space = ExtensionType::try_get_account_len::<Account>(&required_extensions)?;
         let mut instructions = vec![system_instruction::create_account(
             &self.payer.pubkey(),
             &account.pubkey(),
@@ -1259,7 +1259,7 @@ where
             } else {
                 vec![]
             };
-            let space = ExtensionType::get_account_len::<Account>(&extensions)?;
+            let space = ExtensionType::try_get_account_len::<Account>(&extensions)?;
 
             instructions.push(system_instruction::create_account(
                 &self.payer.pubkey(),

--- a/token/program-2022-test/tests/initialize_account.rs
+++ b/token/program-2022-test/tests/initialize_account.rs
@@ -32,7 +32,7 @@ async fn no_extensions() {
     let mint_account = Keypair::new();
     let mint_authority_pubkey = Pubkey::new_unique();
 
-    let space = ExtensionType::get_account_len::<Mint>(&[]);
+    let space = ExtensionType::get_account_len::<Mint>(&[]).unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -60,7 +60,7 @@ async fn no_extensions() {
 
     let account = Keypair::new();
     let account_owner_pubkey = Pubkey::new_unique();
-    let space = ExtensionType::get_account_len::<Account>(&[]);
+    let space = ExtensionType::get_account_len::<Account>(&[]).unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -102,7 +102,7 @@ async fn fail_on_invalid_mint() {
     let rent = ctx.banks_client.get_rent().await.unwrap();
     let mint_account = Keypair::new();
 
-    let space = ExtensionType::get_account_len::<Mint>(&[]);
+    let space = ExtensionType::get_account_len::<Mint>(&[]).unwrap();
     let instructions = vec![system_instruction::create_account(
         &ctx.payer.pubkey(),
         &mint_account.pubkey(),
@@ -120,7 +120,7 @@ async fn fail_on_invalid_mint() {
 
     let account = Keypair::new();
     let account_owner_pubkey = Pubkey::new_unique();
-    let space = ExtensionType::get_account_len::<Account>(&[]);
+    let space = ExtensionType::get_account_len::<Account>(&[]).unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -166,7 +166,8 @@ async fn single_extension() {
     let mint_account = Keypair::new();
     let mint_authority_pubkey = Pubkey::new_unique();
 
-    let space = ExtensionType::get_account_len::<Mint>(&[ExtensionType::TransferFeeConfig]);
+    let space =
+        ExtensionType::get_account_len::<Mint>(&[ExtensionType::TransferFeeConfig]).unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -203,7 +204,8 @@ async fn single_extension() {
 
     let account = Keypair::new();
     let account_owner_pubkey = Pubkey::new_unique();
-    let space = ExtensionType::get_account_len::<Account>(&[ExtensionType::TransferFeeAmount]);
+    let space =
+        ExtensionType::get_account_len::<Account>(&[ExtensionType::TransferFeeAmount]).unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -235,7 +237,7 @@ async fn single_extension() {
         .expect("account not none");
     assert_eq!(
         account_info.data.len(),
-        ExtensionType::get_account_len::<Account>(&[ExtensionType::TransferFeeAmount]),
+        ExtensionType::get_account_len::<Account>(&[ExtensionType::TransferFeeAmount]).unwrap(),
     );
     assert_eq!(account_info.owner, spl_token_2022::id());
     assert_eq!(account_info.lamports, rent.minimum_balance(space));

--- a/token/program-2022-test/tests/initialize_account.rs
+++ b/token/program-2022-test/tests/initialize_account.rs
@@ -32,7 +32,7 @@ async fn no_extensions() {
     let mint_account = Keypair::new();
     let mint_authority_pubkey = Pubkey::new_unique();
 
-    let space = ExtensionType::get_account_len::<Mint>(&[]).unwrap();
+    let space = ExtensionType::try_get_account_len::<Mint>(&[]).unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -60,7 +60,7 @@ async fn no_extensions() {
 
     let account = Keypair::new();
     let account_owner_pubkey = Pubkey::new_unique();
-    let space = ExtensionType::get_account_len::<Account>(&[]).unwrap();
+    let space = ExtensionType::try_get_account_len::<Account>(&[]).unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -102,7 +102,7 @@ async fn fail_on_invalid_mint() {
     let rent = ctx.banks_client.get_rent().await.unwrap();
     let mint_account = Keypair::new();
 
-    let space = ExtensionType::get_account_len::<Mint>(&[]).unwrap();
+    let space = ExtensionType::try_get_account_len::<Mint>(&[]).unwrap();
     let instructions = vec![system_instruction::create_account(
         &ctx.payer.pubkey(),
         &mint_account.pubkey(),
@@ -120,7 +120,7 @@ async fn fail_on_invalid_mint() {
 
     let account = Keypair::new();
     let account_owner_pubkey = Pubkey::new_unique();
-    let space = ExtensionType::get_account_len::<Account>(&[]).unwrap();
+    let space = ExtensionType::try_get_account_len::<Account>(&[]).unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -167,7 +167,7 @@ async fn single_extension() {
     let mint_authority_pubkey = Pubkey::new_unique();
 
     let space =
-        ExtensionType::get_account_len::<Mint>(&[ExtensionType::TransferFeeConfig]).unwrap();
+        ExtensionType::try_get_account_len::<Mint>(&[ExtensionType::TransferFeeConfig]).unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -205,7 +205,7 @@ async fn single_extension() {
     let account = Keypair::new();
     let account_owner_pubkey = Pubkey::new_unique();
     let space =
-        ExtensionType::get_account_len::<Account>(&[ExtensionType::TransferFeeAmount]).unwrap();
+        ExtensionType::try_get_account_len::<Account>(&[ExtensionType::TransferFeeAmount]).unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -237,7 +237,7 @@ async fn single_extension() {
         .expect("account not none");
     assert_eq!(
         account_info.data.len(),
-        ExtensionType::get_account_len::<Account>(&[ExtensionType::TransferFeeAmount]).unwrap(),
+        ExtensionType::try_get_account_len::<Account>(&[ExtensionType::TransferFeeAmount]).unwrap(),
     );
     assert_eq!(account_info.owner, spl_token_2022::id());
     assert_eq!(account_info.lamports, rent.minimum_balance(space));

--- a/token/program-2022-test/tests/initialize_mint.rs
+++ b/token/program-2022-test/tests/initialize_mint.rs
@@ -110,7 +110,8 @@ async fn fail_extension_after_mint_init() {
     let mint_account = Keypair::new();
     let mint_authority_pubkey = Pubkey::new_unique();
 
-    let space = ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]);
+    let space =
+        ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]).unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -194,7 +195,8 @@ async fn fail_init_overallocated_mint() {
     let mint_account = Keypair::new();
     let mint_authority_pubkey = Pubkey::new_unique();
 
-    let space = ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]);
+    let space =
+        ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]).unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -240,9 +242,9 @@ async fn fail_account_init_after_mint_extension() {
     let mint_authority_pubkey = Pubkey::new_unique();
     let token_account = Keypair::new();
 
-    let mint_space = ExtensionType::get_account_len::<Mint>(&[]);
+    let mint_space = ExtensionType::get_account_len::<Mint>(&[]).unwrap();
     let account_space =
-        ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]);
+        ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]).unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -310,7 +312,7 @@ async fn fail_account_init_after_mint_init() {
     let mint_account = Keypair::new();
     let mint_authority_pubkey = Pubkey::new_unique();
 
-    let mint_space = ExtensionType::get_account_len::<Mint>(&[]);
+    let mint_space = ExtensionType::get_account_len::<Mint>(&[]).unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -362,7 +364,8 @@ async fn fail_account_init_after_mint_init_with_extension() {
     let mint_account = Keypair::new();
     let mint_authority_pubkey = Pubkey::new_unique();
 
-    let mint_space = ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]);
+    let mint_space =
+        ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]).unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -420,7 +423,8 @@ async fn fail_fee_init_after_mint_init() {
     let mint_account = Keypair::new();
     let mint_authority_pubkey = Pubkey::new_unique();
 
-    let space = ExtensionType::get_account_len::<Mint>(&[ExtensionType::TransferFeeConfig]);
+    let space =
+        ExtensionType::get_account_len::<Mint>(&[ExtensionType::TransferFeeConfig]).unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -531,7 +535,8 @@ async fn fail_invalid_extensions_combination() {
     let mint_space = ExtensionType::get_account_len::<Mint>(&[
         ExtensionType::TransferFeeConfig,
         ExtensionType::ConfidentialTransferMint,
-    ]);
+    ])
+    .unwrap();
     let create_account_instruction = system_instruction::create_account(
         &ctx.payer.pubkey(),
         &mint_account.pubkey(),
@@ -571,7 +576,8 @@ async fn fail_invalid_extensions_combination() {
     let mint_space = ExtensionType::get_account_len::<Mint>(&[
         ExtensionType::TransferFeeConfig,
         ExtensionType::ConfidentialTransferFeeConfig,
-    ]);
+    ])
+    .unwrap();
     let create_account_instruction = system_instruction::create_account(
         &ctx.payer.pubkey(),
         &mint_account.pubkey(),
@@ -613,7 +619,8 @@ async fn fail_invalid_extensions_combination() {
         ExtensionType::TransferFeeConfig,
         ExtensionType::ConfidentialTransferMint,
         ExtensionType::ConfidentialTransferFeeConfig,
-    ]);
+    ])
+    .unwrap();
     let create_account_instruction = system_instruction::create_account(
         &ctx.payer.pubkey(),
         &mint_account.pubkey(),

--- a/token/program-2022-test/tests/initialize_mint.rs
+++ b/token/program-2022-test/tests/initialize_mint.rs
@@ -111,7 +111,7 @@ async fn fail_extension_after_mint_init() {
     let mint_authority_pubkey = Pubkey::new_unique();
 
     let space =
-        ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]).unwrap();
+        ExtensionType::try_get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]).unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -196,7 +196,7 @@ async fn fail_init_overallocated_mint() {
     let mint_authority_pubkey = Pubkey::new_unique();
 
     let space =
-        ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]).unwrap();
+        ExtensionType::try_get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]).unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -242,9 +242,9 @@ async fn fail_account_init_after_mint_extension() {
     let mint_authority_pubkey = Pubkey::new_unique();
     let token_account = Keypair::new();
 
-    let mint_space = ExtensionType::get_account_len::<Mint>(&[]).unwrap();
+    let mint_space = ExtensionType::try_get_account_len::<Mint>(&[]).unwrap();
     let account_space =
-        ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]).unwrap();
+        ExtensionType::try_get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]).unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -312,7 +312,7 @@ async fn fail_account_init_after_mint_init() {
     let mint_account = Keypair::new();
     let mint_authority_pubkey = Pubkey::new_unique();
 
-    let mint_space = ExtensionType::get_account_len::<Mint>(&[]).unwrap();
+    let mint_space = ExtensionType::try_get_account_len::<Mint>(&[]).unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -365,7 +365,7 @@ async fn fail_account_init_after_mint_init_with_extension() {
     let mint_authority_pubkey = Pubkey::new_unique();
 
     let mint_space =
-        ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]).unwrap();
+        ExtensionType::try_get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]).unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -424,7 +424,7 @@ async fn fail_fee_init_after_mint_init() {
     let mint_authority_pubkey = Pubkey::new_unique();
 
     let space =
-        ExtensionType::get_account_len::<Mint>(&[ExtensionType::TransferFeeConfig]).unwrap();
+        ExtensionType::try_get_account_len::<Mint>(&[ExtensionType::TransferFeeConfig]).unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -532,7 +532,7 @@ async fn fail_invalid_extensions_combination() {
     .unwrap();
 
     // initialize transfer fee and confidential transfers, but no confidential transfer fee
-    let mint_space = ExtensionType::get_account_len::<Mint>(&[
+    let mint_space = ExtensionType::try_get_account_len::<Mint>(&[
         ExtensionType::TransferFeeConfig,
         ExtensionType::ConfidentialTransferMint,
     ])
@@ -573,7 +573,7 @@ async fn fail_invalid_extensions_combination() {
     );
 
     // initialize transfer fee and confidential transfer fees, but no confidential transfers
-    let mint_space = ExtensionType::get_account_len::<Mint>(&[
+    let mint_space = ExtensionType::try_get_account_len::<Mint>(&[
         ExtensionType::TransferFeeConfig,
         ExtensionType::ConfidentialTransferFeeConfig,
     ])
@@ -615,7 +615,7 @@ async fn fail_invalid_extensions_combination() {
 
     // initialize all of transfer fee, confidential transfers, and confidential transfer fees
     // (success case)
-    let mint_space = ExtensionType::get_account_len::<Mint>(&[
+    let mint_space = ExtensionType::try_get_account_len::<Mint>(&[
         ExtensionType::TransferFeeConfig,
         ExtensionType::ConfidentialTransferMint,
         ExtensionType::ConfidentialTransferFeeConfig,

--- a/token/program-2022-test/tests/reallocate.rs
+++ b/token/program-2022-test/tests/reallocate.rs
@@ -109,7 +109,7 @@ async fn reallocate() {
     let account = token.get_account(alice_account).await.unwrap();
     assert_eq!(
         account.data.len(),
-        ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner])
+        ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap()
     );
 
     // reallocate succeeds with noop if account is already large enough
@@ -126,7 +126,7 @@ async fn reallocate() {
     let account = token.get_account(alice_account).await.unwrap();
     assert_eq!(
         account.data.len(),
-        ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner])
+        ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap()
     );
 
     // reallocate only reallocates enough for new extension, and dedupes extensions
@@ -151,6 +151,7 @@ async fn reallocate() {
             ExtensionType::ImmutableOwner,
             ExtensionType::TransferFeeAmount
         ])
+        .unwrap()
     );
 }
 
@@ -193,6 +194,7 @@ async fn reallocate_without_current_extension_knowledge() {
             ExtensionType::TransferFeeAmount,
             ExtensionType::ImmutableOwner
         ])
+        .unwrap()
     );
 }
 
@@ -262,7 +264,7 @@ async fn reallocate_updates_native_rent_exemption(
     let account = token.get_account(alice_account).await.unwrap();
     assert_eq!(
         account.data.len(),
-        ExtensionType::get_account_len::<Account>(extensions)
+        ExtensionType::get_account_len::<Account>(extensions).unwrap()
     );
     let expected_rent_exempt_reserve = {
         let mut context = context.lock().await;

--- a/token/program-2022-test/tests/reallocate.rs
+++ b/token/program-2022-test/tests/reallocate.rs
@@ -109,7 +109,7 @@ async fn reallocate() {
     let account = token.get_account(alice_account).await.unwrap();
     assert_eq!(
         account.data.len(),
-        ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap()
+        ExtensionType::try_get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap()
     );
 
     // reallocate succeeds with noop if account is already large enough
@@ -126,7 +126,7 @@ async fn reallocate() {
     let account = token.get_account(alice_account).await.unwrap();
     assert_eq!(
         account.data.len(),
-        ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap()
+        ExtensionType::try_get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap()
     );
 
     // reallocate only reallocates enough for new extension, and dedupes extensions
@@ -147,7 +147,7 @@ async fn reallocate() {
     let account = token.get_account(alice_account).await.unwrap();
     assert_eq!(
         account.data.len(),
-        ExtensionType::get_account_len::<Account>(&[
+        ExtensionType::try_get_account_len::<Account>(&[
             ExtensionType::ImmutableOwner,
             ExtensionType::TransferFeeAmount
         ])
@@ -190,7 +190,7 @@ async fn reallocate_without_current_extension_knowledge() {
     let account = token.get_account(alice_account).await.unwrap();
     assert_eq!(
         account.data.len(),
-        ExtensionType::get_account_len::<Account>(&[
+        ExtensionType::try_get_account_len::<Account>(&[
             ExtensionType::TransferFeeAmount,
             ExtensionType::ImmutableOwner
         ])
@@ -264,7 +264,7 @@ async fn reallocate_updates_native_rent_exemption(
     let account = token.get_account(alice_account).await.unwrap();
     assert_eq!(
         account.data.len(),
-        ExtensionType::get_account_len::<Account>(extensions).unwrap()
+        ExtensionType::try_get_account_len::<Account>(extensions).unwrap()
     );
     let expected_rent_exempt_reserve = {
         let mut context = context.lock().await;

--- a/token/program-2022/src/extension/reallocate.rs
+++ b/token/program-2022/src/extension/reallocate.rs
@@ -55,9 +55,10 @@ pub fn process_reallocate(
     {
         return Err(TokenError::InvalidState.into());
     }
-    // ExtensionType::get_account_len() dedupes types, so just a dumb concatenation is fine here
+    // ExtensionType::try_get_account_len() dedupes types, so just a dumb concatenation is fine here
     current_extension_types.extend_from_slice(&new_extension_types);
-    let needed_account_len = ExtensionType::get_account_len::<Account>(&current_extension_types)?;
+    let needed_account_len =
+        ExtensionType::try_get_account_len::<Account>(&current_extension_types)?;
 
     // if account is already large enough, return early
     if token_account_info.data_len() >= needed_account_len {

--- a/token/program-2022/src/extension/reallocate.rs
+++ b/token/program-2022/src/extension/reallocate.rs
@@ -57,7 +57,7 @@ pub fn process_reallocate(
     }
     // ExtensionType::get_account_len() dedupes types, so just a dumb concatenation is fine here
     current_extension_types.extend_from_slice(&new_extension_types);
-    let needed_account_len = ExtensionType::get_account_len::<Account>(&current_extension_types);
+    let needed_account_len = ExtensionType::get_account_len::<Account>(&current_extension_types)?;
 
     // if account is already large enough, return early
     if token_account_info.data_len() >= needed_account_len {

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -69,7 +69,7 @@ impl Processor {
 
         let mut mint = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut mint_data)?;
         let extension_types = mint.get_extension_types()?;
-        if ExtensionType::get_account_len::<Mint>(&extension_types) != mint_data_len {
+        if ExtensionType::get_account_len::<Mint>(&extension_types)? != mint_data_len {
             return Err(ProgramError::InvalidAccountData);
         }
         ExtensionType::check_for_invalid_mint_extension_combinations(&extension_types)?;
@@ -154,7 +154,7 @@ impl Processor {
         }
         let required_extensions =
             Self::get_required_account_extensions_from_unpacked_mint(mint_info.owner, &mint)?;
-        if ExtensionType::get_account_len::<Account>(&required_extensions)
+        if ExtensionType::get_account_len::<Account>(&required_extensions)?
             > new_account_info_data_len
         {
             return Err(ProgramError::InvalidAccountData);
@@ -1252,7 +1252,7 @@ impl Processor {
         // here
         account_extensions.extend_from_slice(&new_extension_types);
 
-        let account_len = ExtensionType::get_account_len::<Account>(&account_extensions);
+        let account_len = ExtensionType::get_account_len::<Account>(&account_extensions)?;
         set_return_data(&account_len.to_le_bytes());
 
         Ok(())
@@ -4503,7 +4503,7 @@ mod tests {
         let account_key = Pubkey::new_unique();
 
         let account_len =
-            ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]);
+            ExtensionType::get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
         let mut account_account = SolanaAccount::new(
             Rent::default().minimum_balance(account_len),
             account_len,
@@ -7384,6 +7384,7 @@ mod tests {
 
         set_expected_data(
             ExtensionType::get_account_len::<Account>(&[])
+                .unwrap()
                 .to_le_bytes()
                 .to_vec(),
         );
@@ -7395,6 +7396,7 @@ mod tests {
 
         set_expected_data(
             ExtensionType::get_account_len::<Account>(&[ExtensionType::TransferFeeAmount])
+                .unwrap()
                 .to_le_bytes()
                 .to_vec(),
         );
@@ -7416,6 +7418,7 @@ mod tests {
         let mut mint_account = native_mint();
         set_expected_data(
             ExtensionType::get_account_len::<Account>(&[])
+                .unwrap()
                 .to_le_bytes()
                 .to_vec(),
         );
@@ -7426,7 +7429,8 @@ mod tests {
         .unwrap();
 
         // Extended mint
-        let mint_len = ExtensionType::get_account_len::<Mint>(&[ExtensionType::TransferFeeConfig]);
+        let mint_len =
+            ExtensionType::get_account_len::<Mint>(&[ExtensionType::TransferFeeConfig]).unwrap();
         let mut extended_mint_account = SolanaAccount::new(
             Rent::default().minimum_balance(mint_len),
             mint_len,
@@ -7447,6 +7451,7 @@ mod tests {
 
         set_expected_data(
             ExtensionType::get_account_len::<Account>(&[ExtensionType::TransferFeeAmount])
+                .unwrap()
                 .to_le_bytes()
                 .to_vec(),
         );

--- a/token/transfer-hook-example/tests/functional.rs
+++ b/token/transfer-hook-example/tests/functional.rs
@@ -60,7 +60,7 @@ fn setup_token_accounts(
 ) {
     // add mint, source, and destination accounts by hand to always force
     // the "transferring" flag to true
-    let mint_size = ExtensionType::get_account_len::<Mint>(&[]).unwrap();
+    let mint_size = ExtensionType::try_get_account_len::<Mint>(&[]).unwrap();
     let mut mint_data = vec![0; mint_size];
     let mut state = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut mint_data).unwrap();
     let token_amount = 1_000_000_000_000;
@@ -83,7 +83,8 @@ fn setup_token_accounts(
     );
 
     let account_size =
-        ExtensionType::get_account_len::<Account>(&[ExtensionType::TransferHookAccount]).unwrap();
+        ExtensionType::try_get_account_len::<Account>(&[ExtensionType::TransferHookAccount])
+            .unwrap();
     let mut account_data = vec![0; account_size];
     let mut state =
         StateWithExtensionsMut::<Account>::unpack_uninitialized(&mut account_data).unwrap();

--- a/token/transfer-hook-example/tests/functional.rs
+++ b/token/transfer-hook-example/tests/functional.rs
@@ -60,7 +60,7 @@ fn setup_token_accounts(
 ) {
     // add mint, source, and destination accounts by hand to always force
     // the "transferring" flag to true
-    let mint_size = ExtensionType::get_account_len::<Mint>(&[]);
+    let mint_size = ExtensionType::get_account_len::<Mint>(&[]).unwrap();
     let mut mint_data = vec![0; mint_size];
     let mut state = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut mint_data).unwrap();
     let token_amount = 1_000_000_000_000;
@@ -83,7 +83,7 @@ fn setup_token_accounts(
     );
 
     let account_size =
-        ExtensionType::get_account_len::<Account>(&[ExtensionType::TransferHookAccount]);
+        ExtensionType::get_account_len::<Account>(&[ExtensionType::TransferHookAccount]).unwrap();
     let mut account_data = vec![0; account_size];
     let mut state =
         StateWithExtensionsMut::<Account>::unpack_uninitialized(&mut account_data).unwrap();


### PR DESCRIPTION
#### Problem

We want to add metadata support directly in token-2022, but token-2022's extensions only support extensions whose sizes are known at compile-time.

#### Solution

This is going to be done in a few steps for ease of review. This step just makes `ExtensionType::get_account_len` fallible, so that if you put in `ExtensionType::Metadata`, you get an error.

Thoughts on renaming the function to make that clearer? I went the lazy route and kept it the same name, but I thought about `get_static_account_len` or `get_account_len_with_sized`, but the added words didn't seem worth it.