### PR TITLE
token-2022: Refactor for unsized extension support

### DIFF
--- a/token/program-2022/src/pod.rs
+++ b/token/program-2022/src/pod.rs
@@ -163,7 +163,7 @@ pub struct PodI64([u8; 8]);
 impl_int_conversion!(PodI64, i64);
 
 /// On-chain size of a `Pod` type
-pub fn pod_get_packed_len<T: Pod>() -> usize {
+pub const fn pod_get_packed_len<T: Pod>() -> usize {
     std::mem::size_of::<T>()
 }
 


### PR DESCRIPTION
#### Problem

We want to add metadata support directly in token-2022, but token-2022's extensions only support extensions whose sizes are known at compile-time.

#### Solution

This is just a refactor, moving some functions and parameters around, and adding some more return info from other functions. No functional changes are contained here for ease of review in the next bit, which starts to add new functionality, after #4646 lands too.

Roughly, the steps after that go:

* add `alloc` in the public interface, for allocating bytes to an extension
* add `UnsizedExtension` trait, which specifies that an extension can use `alloc` and `realloc`. This is for compile-time safety, to keep using the in-place `get_extension` for all other extensions
* add `realloc`, for an existing extension (ripping off https://github.com/solana-labs/solana-program-library/blob/ed8818c53438b32f96a77f86752e98db02a764ef/libraries/type-length-value/src/state.rs#L358)
* add helpers for fetching the sizes of all TLV entries, along with calculating a new size for a realloc
* add `realloc` for the whole account (ripping off https://github.com/solana-labs/solana-program-library/blob/ed8818c53438b32f96a77f86752e98db02a764ef/libraries/type-length-value/src/state.rs#L414)

Once that's all in place, it'll be a breeze to implement the metadata instructions!