### PR TITLE
[token-2022] Update confidential transfer for Solana 1.16.1

### DIFF
--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -479,7 +479,7 @@ async fn command_create_token(
         extensions.push(ExtensionInitializationParams::ConfidentialTransferMint {
             authority: Some(authority),
             auto_approve_new_accounts: auto_approve,
-            auditor_encryption_pubkey: None,
+            auditor_elgamal_pubkey: None,
         });
     }
 
@@ -6935,7 +6935,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn confidential_transfer() {
-        use spl_token_2022::pod::EncryptionPubkey;
+        use spl_token_2022::solana_zk_token_sdk::zk_token_elgamal::pod::ElGamalPubkey;
 
         let (test_validator, payer) = new_validator_for_test().await;
         let config =
@@ -6982,7 +6982,7 @@ mod tests {
             auto_approve,
         );
         assert_eq!(
-            Option::<EncryptionPubkey>::from(extension.auditor_encryption_pubkey),
+            Option::<ElGamalPubkey>::from(extension.auditor_elgamal_pubkey),
             None,
         );
 

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -1,4 +1,5 @@
 #![cfg(all(feature = "test-sbf"))]
+#![cfg(twoxtx)]
 
 mod program_test;
 use {
@@ -244,7 +245,7 @@ async fn confidential_transfer_initialize_and_update_mint() {
     let authority = Keypair::new();
     let auto_approve_new_accounts = true;
     let auditor_elgamal_keypair = ElGamalKeypair::new_rand();
-    let auditor_elgamal_pubkey = auditor_elgamal_keypair.public.into();
+    let auditor_elgamal_pubkey = (*auditor_elgamal_keypair.pubkey()).into();
 
     let mut context = TestContext::new().await;
     context

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -1,7 +1,7 @@
-#![cfg(all(feature = "test-sbf", feature = "proof-program"))]
-#![cfg(twoxtx)]
+#![cfg(all(feature = "test-sbf"))]
 
 mod program_test;
+#[cfg(feature = "proof-program")]
 use {
     program_test::{TestContext, TokenContext},
     solana_program_test::tokio,
@@ -31,16 +31,17 @@ use {
     std::convert::TryInto,
 };
 
-#[cfg(feature = "zk-ops")]
+#[cfg(all(feature = "zk-ops", feature = "proof-program"))]
 use {solana_sdk::epoch_info::EpochInfo, spl_token_2022::solana_zk_token_sdk::zk_token_elgamal};
 
-#[cfg(feature = "zk-ops")]
+#[cfg(all(feature = "zk-ops", feature = "proof-program"))]
 const TEST_MAXIMUM_FEE: u64 = 100;
-#[cfg(feature = "zk-ops")]
+#[cfg(all(feature = "zk-ops", feature = "proof-program"))]
 const TEST_FEE_BASIS_POINTS: u16 = 250;
+#[cfg(feature = "proof-program")]
 const TEST_MAXIMUM_PENDING_BALANCE_CREDIT_COUNTER: u64 = 2;
 
-#[cfg(feature = "zk-ops")]
+#[cfg(all(feature = "zk-ops", feature = "proof-program"))]
 fn test_epoch_info() -> EpochInfo {
     EpochInfo {
         epoch: 0,
@@ -52,6 +53,7 @@ fn test_epoch_info() -> EpochInfo {
     }
 }
 
+#[cfg(feature = "proof-program")]
 struct ConfidentialTransferMintWithKeypairs {
     ct_mint: ConfidentialTransferMint,
     ct_mint_authority: Keypair,
@@ -59,6 +61,7 @@ struct ConfidentialTransferMintWithKeypairs {
     ct_mint_withdraw_withheld_authority_encryption_keypair: ElGamalKeypair,
 }
 
+#[cfg(feature = "proof-program")]
 impl ConfidentialTransferMintWithKeypairs {
     fn new() -> Self {
         let ct_mint_authority = Keypair::new();
@@ -102,12 +105,14 @@ impl ConfidentialTransferMintWithKeypairs {
     }
 }
 
+#[cfg(feature = "proof-program")]
 struct ConfidentialTokenAccountMeta {
     token_account: Pubkey,
     elgamal_keypair: ElGamalKeypair,
     ae_key: AeKey,
 }
 
+#[cfg(feature = "proof-program")]
 impl ConfidentialTokenAccountMeta {
     async fn new<T>(token: &Token<T>, owner: &Keypair) -> Self
     where
@@ -186,7 +191,7 @@ impl ConfidentialTokenAccountMeta {
         }
     }
 
-    #[cfg(feature = "zk-ops")]
+    #[cfg(all(feature = "zk-ops", feature = "proof-program"))]
     async fn with_tokens<T>(
         token: &Token<T>,
         owner: &Keypair,
@@ -221,7 +226,7 @@ impl ConfidentialTokenAccountMeta {
         meta
     }
 
-    #[cfg(feature = "zk-ops")]
+    #[cfg(all(feature = "zk-ops", feature = "proof-program"))]
     async fn check_balances<T>(&self, token: &Token<T>, expected: ConfidentialTokenAccountBalances)
     where
         T: SendTransaction,
@@ -261,7 +266,7 @@ impl ConfidentialTokenAccountMeta {
     }
 }
 
-#[cfg(feature = "zk-ops")]
+#[cfg(all(feature = "zk-ops", feature = "proof-program"))]
 struct ConfidentialTokenAccountBalances {
     pending_balance_lo: u64,
     pending_balance_hi: u64,
@@ -269,7 +274,7 @@ struct ConfidentialTokenAccountBalances {
     decryptable_available_balance: u64,
 }
 
-#[cfg(feature = "zk-ops")]
+#[cfg(all(feature = "zk-ops", feature = "proof-program"))]
 async fn check_withheld_amount_in_mint<T>(
     token: &Token<T>,
     withdraw_withheld_authority_encryption_keypair: &ElGamalKeypair,
@@ -286,6 +291,7 @@ async fn check_withheld_amount_in_mint<T>(
     assert_eq!(decrypted_amount, expected);
 }
 
+#[cfg(feature = "proof-program")]
 #[tokio::test]
 async fn ct_initialize_and_update_mint() {
     let ConfidentialTransferMintWithKeypairs {
@@ -414,6 +420,7 @@ async fn ct_initialize_and_update_mint() {
     assert_eq!(extension.authority, None.try_into().unwrap());
 }
 
+#[cfg(feature = "proof-program")]
 #[tokio::test]
 async fn ct_configure_token_account() {
     let ConfidentialTransferMintWithKeypairs {
@@ -496,6 +503,7 @@ async fn ct_configure_token_account() {
     );
 }
 
+#[cfg(feature = "proof-program")]
 #[tokio::test]
 async fn ct_enable_disable_confidential_credits() {
     let ConfidentialTransferMintWithKeypairs { ct_mint, .. } =
@@ -545,6 +553,7 @@ async fn ct_enable_disable_confidential_credits() {
     assert!(bool::from(&extension.allow_confidential_credits));
 }
 
+#[cfg(feature = "proof-program")]
 #[tokio::test]
 async fn ct_enable_disable_non_confidential_credits() {
     let ConfidentialTransferMintWithKeypairs { ct_mint, .. } =
@@ -643,6 +652,7 @@ async fn ct_enable_disable_non_confidential_credits() {
         .unwrap();
 }
 
+#[cfg(feature = "proof-program")]
 #[tokio::test]
 async fn ct_new_account_is_empty() {
     let ConfidentialTransferMintWithKeypairs { ct_mint, .. } =
@@ -671,7 +681,7 @@ async fn ct_new_account_is_empty() {
         .unwrap();
 }
 
-#[cfg(feature = "zk-ops")]
+#[cfg(all(feature = "zk-ops", feature = "proof-program"))]
 #[tokio::test]
 async fn ct_deposit() {
     let ConfidentialTransferMintWithKeypairs { ct_mint, .. } =
@@ -802,7 +812,7 @@ async fn ct_deposit() {
     assert_eq!(extension.actual_pending_balance_credit_counter, 2.into());
 }
 
-#[cfg(feature = "zk-ops")]
+#[cfg(all(feature = "zk-ops", feature = "proof-program"))]
 #[tokio::test]
 async fn ct_withdraw() {
     let ConfidentialTransferMintWithKeypairs { ct_mint, .. } =
@@ -912,7 +922,7 @@ async fn ct_withdraw() {
         .unwrap();
 }
 
-#[cfg(feature = "zk-ops")]
+#[cfg(all(feature = "zk-ops", feature = "proof-program"))]
 #[tokio::test]
 async fn ct_transfer() {
     let ConfidentialTransferMintWithKeypairs {
@@ -1153,7 +1163,7 @@ async fn ct_transfer() {
         .await;
 }
 
-#[cfg(feature = "zk-ops")]
+#[cfg(all(feature = "zk-ops", feature = "proof-program"))]
 #[tokio::test]
 async fn ct_transfer_with_fee() {
     let ConfidentialTransferMintWithKeypairs {
@@ -1374,7 +1384,7 @@ async fn ct_transfer_with_fee() {
         .await;
 }
 
-#[cfg(feature = "zk-ops")]
+#[cfg(all(feature = "zk-ops", feature = "proof-program"))]
 #[tokio::test]
 async fn ct_withdraw_withheld_tokens_from_mint() {
     let ConfidentialTransferMintWithKeypairs {
@@ -1534,7 +1544,7 @@ async fn ct_withdraw_withheld_tokens_from_mint() {
         .await;
 }
 
-#[cfg(feature = "zk-ops")]
+#[cfg(all(feature = "zk-ops", feature = "proof-program"))]
 #[tokio::test]
 async fn ct_withdraw_withheld_tokens_from_accounts() {
     let ConfidentialTransferMintWithKeypairs {
@@ -1661,7 +1671,7 @@ async fn ct_withdraw_withheld_tokens_from_accounts() {
         .await;
 }
 
-#[cfg(feature = "zk-ops")]
+#[cfg(all(feature = "zk-ops", feature = "proof-program"))]
 #[tokio::test]
 async fn ct_transfer_memo() {
     let ConfidentialTransferMintWithKeypairs {
@@ -1772,7 +1782,7 @@ async fn ct_transfer_memo() {
         .await;
 }
 
-#[cfg(feature = "zk-ops")]
+#[cfg(all(feature = "zk-ops", feature = "proof-program"))]
 #[tokio::test]
 async fn ct_transfer_with_fee_memo() {
     let ConfidentialTransferMintWithKeypairs {

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -54,58 +54,6 @@ fn test_epoch_info() -> EpochInfo {
 }
 
 #[cfg(feature = "proof-program")]
-struct ConfidentialTransferMintWithKeypairs {
-    ct_mint: ConfidentialTransferMint,
-    ct_mint_authority: Keypair,
-    ct_mint_transfer_auditor_encryption_keypair: ElGamalKeypair,
-    ct_mint_withdraw_withheld_authority_encryption_keypair: ElGamalKeypair,
-}
-
-#[cfg(feature = "proof-program")]
-impl ConfidentialTransferMintWithKeypairs {
-    fn new() -> Self {
-        let ct_mint_authority = Keypair::new();
-        let ct_mint_transfer_auditor_encryption_keypair = ElGamalKeypair::new_rand();
-        let ct_mint_transfer_auditor_encryption_pubkey: EncryptionPubkey =
-            ct_mint_transfer_auditor_encryption_keypair
-                .public
-                .try_into()
-                .unwrap();
-        let ct_mint_withdraw_withheld_authority_encryption_keypair = ElGamalKeypair::new_rand();
-        let ct_mint_withdraw_withheld_authority_encryption_pubkey: EncryptionPubkey =
-            ct_mint_withdraw_withheld_authority_encryption_keypair
-                .public
-                .try_into()
-                .unwrap();
-        let ct_mint = ConfidentialTransferMint {
-            authority: Some(ct_mint_authority.pubkey()).try_into().unwrap(),
-            auto_approve_new_accounts: true.into(),
-            auditor_encryption_pubkey: Some(ct_mint_transfer_auditor_encryption_pubkey)
-                .try_into()
-                .unwrap(),
-            withdraw_withheld_authority_encryption_pubkey: Some(
-                ct_mint_withdraw_withheld_authority_encryption_pubkey,
-            )
-            .try_into()
-            .unwrap(),
-            withheld_amount: EncryptedWithheldAmount::zeroed(),
-        };
-        Self {
-            ct_mint,
-            ct_mint_authority,
-            ct_mint_transfer_auditor_encryption_keypair,
-            ct_mint_withdraw_withheld_authority_encryption_keypair,
-        }
-    }
-
-    fn without_auto_approve() -> Self {
-        let mut x = Self::new();
-        x.ct_mint.auto_approve_new_accounts = false.into();
-        x
-    }
-}
-
-#[cfg(feature = "proof-program")]
 struct ConfidentialTokenAccountMeta {
     token_account: Pubkey,
     elgamal_keypair: ElGamalKeypair,

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -251,7 +251,7 @@ async fn confidential_transfer_initialize_and_update_mint() {
         .init_token_with_mint(vec![
             ExtensionInitializationParams::ConfidentialTransferMint {
                 authority: Some(authority.pubkey()),
-                auto_approve_new_accounts: auto_approve_new_accounts,
+                auto_approve_new_accounts,
                 auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
             },
         ])

--- a/token/program-2022-test/tests/initialize_mint.rs
+++ b/token/program-2022-test/tests/initialize_mint.rs
@@ -22,7 +22,7 @@ use {
             ExtensionType,
         },
         instruction, native_mint,
-        pod::EncryptionPubkey,
+        solana_zk_token_sdk::zk_token_elgamal::pod::ElGamalPubkey,
         state::Mint,
     },
     spl_token_client::token::ExtensionInitializationParams,
@@ -518,7 +518,7 @@ async fn fail_invalid_extensions_combination() {
             &spl_token_2022::id(),
             &mint_account.pubkey(),
             Some(Pubkey::new_unique()),
-            EncryptionPubkey::default(),
+            ElGamalPubkey::default(),
         )
         .unwrap();
 

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -15,7 +15,6 @@ use {
         pubkey::Pubkey,
         sysvar,
     },
-    solana_zk_token_sdk::zk_token_elgamal::pod,
 };
 
 /// Confidential Transfer extension instructions
@@ -421,7 +420,7 @@ pub struct ApplyPendingBalanceData {
     /// `ApplyPendingBalance` instruction
     pub expected_pending_balance_credit_counter: PodU64,
     /// The new decryptable balance if the pending balance is applied successfully
-    pub new_decryptable_available_balance: pod::AeCiphertext,
+    pub new_decryptable_available_balance: DecryptableBalance,
 }
 
 /// Create a `InitializeMint` instruction

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -339,7 +339,7 @@ pub struct InitializeMintData {
     /// be used by the user.
     pub auto_approve_new_accounts: PodBool,
     /// New authority to decode any transfer amount in a confidential transfer.
-    pub auditor_encryption_pubkey: OptionalNonZeroEncryptionPubkey,
+    pub auditor_elgamal_pubkey: OptionalNonZeroElGamalPubkey,
 }
 
 /// Data expected by `ConfidentialTransferInstruction::UpdateMint`
@@ -350,7 +350,7 @@ pub struct UpdateMintData {
     /// be used by the user.
     pub auto_approve_new_accounts: PodBool,
     /// New authority to decode any transfer amount in a confidential transfer.
-    pub auditor_encryption_pubkey: OptionalNonZeroEncryptionPubkey,
+    pub auditor_elgamal_pubkey: OptionalNonZeroElGamalPubkey,
 }
 
 /// Data expected by `ConfidentialTransferInstruction::ConfigureAccount`
@@ -430,7 +430,7 @@ pub fn initialize_mint(
     mint: &Pubkey,
     authority: Option<Pubkey>,
     auto_approve_new_accounts: bool,
-    auditor_encryption_pubkey: Option<EncryptionPubkey>,
+    auditor_elgamal_pubkey: Option<ElGamalPubkey>,
 ) -> Result<Instruction, ProgramError> {
     check_program_account(token_program_id)?;
     let accounts = vec![AccountMeta::new(*mint, false)];
@@ -443,7 +443,7 @@ pub fn initialize_mint(
         &InitializeMintData {
             authority: authority.try_into()?,
             auto_approve_new_accounts: auto_approve_new_accounts.into(),
-            auditor_encryption_pubkey: auditor_encryption_pubkey.try_into()?,
+            auditor_elgamal_pubkey: auditor_elgamal_pubkey.try_into()?,
         },
     ))
 }
@@ -455,7 +455,7 @@ pub fn update_mint(
     mint: &Pubkey,
     authority: &Pubkey,
     auto_approve_new_accounts: bool,
-    auditor_encryption_pubkey: Option<EncryptionPubkey>,
+    auditor_elgamal_pubkey: Option<ElGamalPubkey>,
 ) -> Result<Instruction, ProgramError> {
     check_program_account(token_program_id)?;
 
@@ -471,7 +471,7 @@ pub fn update_mint(
         ConfidentialTransferInstruction::UpdateMint,
         &UpdateMintData {
             auto_approve_new_accounts: auto_approve_new_accounts.into(),
-            auditor_encryption_pubkey: auditor_encryption_pubkey.try_into()?,
+            auditor_elgamal_pubkey: auditor_elgamal_pubkey.try_into()?,
         },
     ))
 }

--- a/token/program-2022/src/extension/confidential_transfer/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer/mod.rs
@@ -6,7 +6,7 @@ use {
     },
     bytemuck::{Pod, Zeroable},
     solana_program::entrypoint::ProgramResult,
-    solana_zk_token_sdk::zk_token_elgamal::pod::{AeCiphertext, ElGamalCiphertext},
+    solana_zk_token_sdk::zk_token_elgamal::pod::{AeCiphertext, ElGamalCiphertext, ElGamalPubkey},
 };
 
 /// Maximum bit length of any deposit or transfer amount
@@ -49,7 +49,7 @@ pub struct ConfidentialTransferMint {
     pub auto_approve_new_accounts: PodBool,
 
     /// Authority to decode any transfer amount in a confidential transafer.
-    pub auditor_encryption_pubkey: OptionalNonZeroEncryptionPubkey,
+    pub auditor_elgamal_pubkey: OptionalNonZeroElGamalPubkey,
 }
 
 impl Extension for ConfidentialTransferMint {
@@ -65,12 +65,12 @@ pub struct ConfidentialTransferAccount {
     pub approved: PodBool,
 
     /// The public key associated with ElGamal encryption
-    pub encryption_pubkey: EncryptionPubkey,
+    pub elgamal_pubkey: ElGamalPubkey,
 
-    /// The low 16 bits of the pending balance (encrypted by `encryption_pubkey`)
+    /// The low 16 bits of the pending balance (encrypted by `elgamal_pubkey`)
     pub pending_balance_lo: EncryptedBalance,
 
-    /// The high 48 bits of the pending balance (encrypted by `encryption_pubkey`)
+    /// The high 48 bits of the pending balance (encrypted by `elgamal_pubkey`)
     pub pending_balance_hi: EncryptedBalance,
 
     /// The available balance (encrypted by `encrypiton_pubkey`)

--- a/token/program-2022/src/extension/confidential_transfer/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer/mod.rs
@@ -6,7 +6,7 @@ use {
     },
     bytemuck::{Pod, Zeroable},
     solana_program::entrypoint::ProgramResult,
-    solana_zk_token_sdk::zk_token_elgamal::pod,
+    solana_zk_token_sdk::zk_token_elgamal::pod::{AeCiphertext, ElGamalCiphertext},
 };
 
 /// Maximum bit length of any deposit or transfer amount
@@ -26,9 +26,9 @@ pub mod instruction;
 pub mod processor;
 
 /// ElGamal ciphertext containing an account balance
-pub type EncryptedBalance = pod::ElGamalCiphertext;
+pub type EncryptedBalance = ElGamalCiphertext;
 /// Authenticated encryption containing an account balance
-pub type DecryptableBalance = pod::AeCiphertext;
+pub type DecryptableBalance = AeCiphertext;
 
 /// Confidential transfer mint configuration
 #[repr(C)]

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -66,7 +66,7 @@ fn process_initialize_mint(
     accounts: &[AccountInfo],
     authority: &OptionalNonZeroPubkey,
     auto_approve_new_account: PodBool,
-    auditor_encryption_pubkey: &OptionalNonZeroEncryptionPubkey,
+    auditor_encryption_pubkey: &OptionalNonZeroElGamalPubkey,
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
     let mint_info = next_account_info(account_info_iter)?;
@@ -78,7 +78,7 @@ fn process_initialize_mint(
 
     confidential_transfer_mint.authority = *authority;
     confidential_transfer_mint.auto_approve_new_accounts = auto_approve_new_account;
-    confidential_transfer_mint.auditor_encryption_pubkey = *auditor_encryption_pubkey;
+    confidential_transfer_mint.auditor_elgamal_pubkey = *auditor_encryption_pubkey;
 
     Ok(())
 }
@@ -87,7 +87,7 @@ fn process_initialize_mint(
 fn process_update_mint(
     accounts: &[AccountInfo],
     auto_approve_new_account: PodBool,
-    auditor_encryption_pubkey: &OptionalNonZeroEncryptionPubkey,
+    auditor_encryption_pubkey: &OptionalNonZeroElGamalPubkey,
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
     let mint_info = next_account_info(account_info_iter)?;
@@ -111,7 +111,7 @@ fn process_update_mint(
     }
 
     confidential_transfer_mint.auto_approve_new_accounts = auto_approve_new_account;
-    confidential_transfer_mint.auditor_encryption_pubkey = *auditor_encryption_pubkey;
+    confidential_transfer_mint.auditor_elgamal_pubkey = *auditor_encryption_pubkey;
     Ok(())
 }
 
@@ -941,7 +941,7 @@ pub(crate) fn process_instruction(
                 accounts,
                 &data.authority,
                 data.auto_approve_new_accounts,
-                &data.auditor_encryption_pubkey,
+                &data.auditor_elgamal_pubkey,
             )
         }
         ConfidentialTransferInstruction::UpdateMint => {
@@ -950,7 +950,7 @@ pub(crate) fn process_instruction(
             process_update_mint(
                 accounts,
                 data.auto_approve_new_accounts,
-                &data.auditor_encryption_pubkey,
+                &data.auditor_elgamal_pubkey,
             )
         }
         ConfidentialTransferInstruction::ConfigureAccount => {

--- a/token/program-2022/src/extension/confidential_transfer_fee/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer_fee/instruction.rs
@@ -6,7 +6,8 @@ use {
     crate::{
         check_program_account,
         instruction::{encode_instruction, TokenInstruction},
-        pod::{EncryptionPubkey, OptionalNonZeroPubkey},
+        pod::OptionalNonZeroPubkey,
+        solana_zk_token_sdk::zk_token_elgamal::pod::ElGamalPubkey,
     },
     bytemuck::{Pod, Zeroable},
     num_enum::{IntoPrimitive, TryFromPrimitive},
@@ -144,7 +145,7 @@ pub struct InitializeConfidentialTransferFeeConfigData {
     pub authority: OptionalNonZeroPubkey,
 
     /// ElGamal public key used to encrypt withheld fees.
-    pub withdraw_withheld_authority_encryption_pubkey: EncryptionPubkey,
+    pub withdraw_withheld_authority_elgamal_pubkey: ElGamalPubkey,
 }
 
 /// Data expected by `ConfidentialTransferFeeInstruction::WithdrawWithheldTokensFromMint`
@@ -172,7 +173,7 @@ pub fn initialize_confidential_transfer_fee_config(
     token_program_id: &Pubkey,
     mint: &Pubkey,
     authority: Option<Pubkey>,
-    withdraw_withheld_authority_encryption_pubkey: EncryptionPubkey,
+    withdraw_withheld_authority_elgamal_pubkey: ElGamalPubkey,
 ) -> Result<Instruction, ProgramError> {
     check_program_account(token_program_id)?;
     let accounts = vec![AccountMeta::new(*mint, false)];
@@ -184,7 +185,7 @@ pub fn initialize_confidential_transfer_fee_config(
         ConfidentialTransferFeeInstruction::InitializeConfidentialTransferFeeConfig,
         &InitializeConfidentialTransferFeeConfigData {
             authority: authority.try_into()?,
-            withdraw_withheld_authority_encryption_pubkey,
+            withdraw_withheld_authority_elgamal_pubkey,
         },
     ))
 }

--- a/token/program-2022/src/extension/confidential_transfer_fee/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer_fee/mod.rs
@@ -6,7 +6,7 @@ use {
     },
     bytemuck::{Pod, Zeroable},
     solana_program::entrypoint::ProgramResult,
-    solana_zk_token_sdk::zk_token_elgamal::pod::{ElGamalCiphertext, FeeEncryption},
+    solana_zk_token_sdk::zk_token_elgamal::pod::{ElGamalCiphertext, ElGamalPubkey, FeeEncryption},
 };
 
 /// Confidential transfer fee extension instructions
@@ -24,7 +24,7 @@ pub type EncryptedWithheldAmount = ElGamalCiphertext;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct ConfidentialTransferFeeConfig {
-    /// Optional authority to set the withdraw withheld authority encryption key
+    /// Optional authority to set the withdraw withheld authority ElGamal key
     pub authority: OptionalNonZeroPubkey,
 
     /// Withheld fees from accounts must be encrypted with this ElGamal key.
@@ -32,7 +32,7 @@ pub struct ConfidentialTransferFeeConfig {
     /// Note that whoever holds the ElGamal private key for this ElGamal public key has the ability
     /// to decode any withheld fee amount that are associated with accounts. When combined with the
     /// fee parameters, the withheld fee amounts can reveal information about transfer amounts.
-    pub withdraw_withheld_authority_encryption_pubkey: EncryptionPubkey,
+    pub withdraw_withheld_authority_elgamal_pubkey: ElGamalPubkey,
 
     /// Withheld confidential transfer fee tokens that have been moved to the mint for withdrawal.
     pub withheld_amount: EncryptedWithheldAmount,

--- a/token/program-2022/src/extension/confidential_transfer_fee/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer_fee/processor.rs
@@ -14,7 +14,8 @@ use {
             BaseStateWithExtensions, StateWithExtensionsMut,
         },
         instruction::{decode_instruction_data, decode_instruction_type},
-        pod::{EncryptionPubkey, OptionalNonZeroPubkey},
+        pod::OptionalNonZeroPubkey,
+        solana_zk_token_sdk::zk_token_elgamal::pod::ElGamalPubkey,
         state::{Account, Mint},
     },
     bytemuck::Zeroable,
@@ -53,7 +54,7 @@ use {
 fn process_initialize_confidential_transfer_fee_config(
     accounts: &[AccountInfo],
     authority: &OptionalNonZeroPubkey,
-    withdraw_withheld_authority_encryption_pubkey: &EncryptionPubkey,
+    withdraw_withheld_authority_elgamal_pubkey: &ElGamalPubkey,
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
     let mint_account_info = next_account_info(account_info_iter)?;
@@ -62,8 +63,8 @@ fn process_initialize_confidential_transfer_fee_config(
     let mut mint = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut mint_data)?;
     let extension = mint.init_extension::<ConfidentialTransferFeeConfig>(true)?;
     extension.authority = *authority;
-    extension.withdraw_withheld_authority_encryption_pubkey =
-        *withdraw_withheld_authority_encryption_pubkey;
+    extension.withdraw_withheld_authority_elgamal_pubkey =
+        *withdraw_withheld_authority_elgamal_pubkey;
     extension.withheld_amount = EncryptedWithheldAmount::zeroed();
 
     Ok(())
@@ -132,17 +133,16 @@ fn process_withdraw_withheld_tokens_from_mint(
         ProofInstruction::VerifyWithdrawWithheldTokens,
         &zkp_instruction,
     )?;
-    // Check that the withdraw authority encryption public key associated with the mint is
+    // Check that the withdraw authority ElGamal public key associated with the mint is
     // consistent with what was actually used to generate the zkp.
     if proof_data.withdraw_withheld_authority_pubkey
-        != confidential_transfer_fee_config.withdraw_withheld_authority_encryption_pubkey
+        != confidential_transfer_fee_config.withdraw_withheld_authority_elgamal_pubkey
     {
         return Err(TokenError::ConfidentialTransferElGamalPubkeyMismatch.into());
     }
-    // Check that the encryption public key associated with the destination account is consistent
+    // Check that the ElGamal public key associated with the destination account is consistent
     // with what was actually used to generate the zkp.
-    if proof_data.destination_pubkey != destination_confidential_transfer_account.encryption_pubkey
-    {
+    if proof_data.destination_pubkey != destination_confidential_transfer_account.elgamal_pubkey {
         return Err(TokenError::ConfidentialTransferElGamalPubkeyMismatch.into());
     }
     // Check that the withheld amount ciphertext is consistent with the ciphertext data that was
@@ -259,19 +259,18 @@ fn process_withdraw_withheld_tokens_from_accounts(
         ProofInstruction::VerifyWithdrawWithheldTokens,
         &zkp_instruction,
     )?;
-    // Checks that the withdraw authority encryption public key associated with the mint is
+    // Checks that the withdraw authority ElGamal public key associated with the mint is
     // consistent with what was actually used to generate the zkp.
     let confidential_transfer_fee_config =
         mint.get_extension_mut::<ConfidentialTransferFeeConfig>()?;
     if proof_data.withdraw_withheld_authority_pubkey
-        != confidential_transfer_fee_config.withdraw_withheld_authority_encryption_pubkey
+        != confidential_transfer_fee_config.withdraw_withheld_authority_elgamal_pubkey
     {
         return Err(TokenError::ConfidentialTransferElGamalPubkeyMismatch.into());
     }
-    // Checks that the encryption public key associated with the destination account is consistent
+    // Checks that the ElGamal public key associated with the destination account is consistent
     // with what was actually used to generate the zkp.
-    if proof_data.destination_pubkey != destination_confidential_transfer_account.encryption_pubkey
-    {
+    if proof_data.destination_pubkey != destination_confidential_transfer_account.elgamal_pubkey {
         return Err(TokenError::ConfidentialTransferElGamalPubkeyMismatch.into());
     }
     // Checks that the withheld amount ciphertext is consistent with the ciphertext data that was
@@ -364,7 +363,7 @@ pub(crate) fn process_instruction(
             process_initialize_confidential_transfer_fee_config(
                 accounts,
                 &data.authority,
-                &data.withdraw_withheld_authority_encryption_pubkey,
+                &data.withdraw_withheld_authority_elgamal_pubkey,
             )
         }
         ConfidentialTransferFeeInstruction::WithdrawWithheldTokensFromMint => {

--- a/token/program-2022/src/lib.rs
+++ b/token/program-2022/src/lib.rs
@@ -13,6 +13,7 @@ pub mod offchain;
 pub mod onchain;
 pub mod pod;
 pub mod processor;
+pub mod proof;
 #[cfg(feature = "serde-traits")]
 pub mod serialization;
 pub mod state;

--- a/token/program-2022/src/pod.rs
+++ b/token/program-2022/src/pod.rs
@@ -60,37 +60,35 @@ impl From<OptionalNonZeroPubkey> for COption<Pubkey> {
     }
 }
 
-/// ElGamal public key used for encryption
-pub type EncryptionPubkey = ElGamalPubkey;
-/// An EncryptionPubkey that encodes `None` as all `0`, meant to be usable as a Pod type.
+/// An ElGamalPubkey that encodes `None` as all `0`, meant to be usable as a Pod type.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 #[repr(transparent)]
-pub struct OptionalNonZeroEncryptionPubkey(EncryptionPubkey);
-impl OptionalNonZeroEncryptionPubkey {
-    /// Checks equality between an OptionalNonZeroEncryptionPubkey and an EncryptionPubkey when
+pub struct OptionalNonZeroElGamalPubkey(ElGamalPubkey);
+impl OptionalNonZeroElGamalPubkey {
+    /// Checks equality between an OptionalNonZeroElGamalPubkey and an ElGamalPubkey when
     /// interpreted as bytes.
-    pub fn equals(&self, other: &EncryptionPubkey) -> bool {
+    pub fn equals(&self, other: &ElGamalPubkey) -> bool {
         &self.0 == other
     }
 }
-impl TryFrom<Option<EncryptionPubkey>> for OptionalNonZeroEncryptionPubkey {
+impl TryFrom<Option<ElGamalPubkey>> for OptionalNonZeroElGamalPubkey {
     type Error = ProgramError;
-    fn try_from(p: Option<EncryptionPubkey>) -> Result<Self, Self::Error> {
+    fn try_from(p: Option<ElGamalPubkey>) -> Result<Self, Self::Error> {
         match p {
-            None => Ok(Self(EncryptionPubkey::default())),
-            Some(encryption_pubkey) => {
-                if encryption_pubkey == EncryptionPubkey::default() {
+            None => Ok(Self(ElGamalPubkey::default())),
+            Some(elgamal_pubkey) => {
+                if elgamal_pubkey == ElGamalPubkey::default() {
                     Err(ProgramError::InvalidArgument)
                 } else {
-                    Ok(Self(encryption_pubkey))
+                    Ok(Self(elgamal_pubkey))
                 }
             }
         }
     }
 }
-impl From<OptionalNonZeroEncryptionPubkey> for Option<EncryptionPubkey> {
-    fn from(p: OptionalNonZeroEncryptionPubkey) -> Self {
-        if p.0 == EncryptionPubkey::default() {
+impl From<OptionalNonZeroElGamalPubkey> for Option<ElGamalPubkey> {
+    fn from(p: OptionalNonZeroElGamalPubkey) -> Self {
+        if p.0 == ElGamalPubkey::default() {
             None
         } else {
             Some(p.0)

--- a/token/program-2022/src/pod.rs
+++ b/token/program-2022/src/pod.rs
@@ -2,7 +2,7 @@
 use {
     bytemuck::{Pod, Zeroable},
     solana_program::{program_error::ProgramError, program_option::COption, pubkey::Pubkey},
-    solana_zk_token_sdk::zk_token_elgamal::pod,
+    solana_zk_token_sdk::zk_token_elgamal::pod::ElGamalPubkey,
     std::convert::TryFrom,
 };
 
@@ -61,7 +61,7 @@ impl From<OptionalNonZeroPubkey> for COption<Pubkey> {
 }
 
 /// ElGamal public key used for encryption
-pub type EncryptionPubkey = pod::ElGamalPubkey;
+pub type EncryptionPubkey = ElGamalPubkey;
 /// An EncryptionPubkey that encodes `None` as all `0`, meant to be usable as a Pod type.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 #[repr(transparent)]

--- a/token/program-2022/src/proof.rs
+++ b/token/program-2022/src/proof.rs
@@ -1,0 +1,27 @@
+//! Helper for processing instruction data from ZK Token proof program
+
+use {
+    bytemuck::Pod,
+    solana_program::{instruction::Instruction, msg, program_error::ProgramError},
+    solana_zk_token_sdk::{
+        instruction::ZkProofData, zk_token_proof_instruction::ProofInstruction,
+        zk_token_proof_program,
+    },
+};
+
+/// Decodes the proof context data associated with a zero-knowledge proof instruction.
+pub fn decode_proof_instruction_context<T: Pod + ZkProofData<U>, U: Pod>(
+    expected: ProofInstruction,
+    instruction: &Instruction,
+) -> Result<&U, ProgramError> {
+    if instruction.program_id != zk_token_proof_program::id()
+        || ProofInstruction::instruction_type(&instruction.data) != Some(expected)
+    {
+        msg!("Unexpected proof instruction");
+        return Err(ProgramError::InvalidInstructionData);
+    }
+
+    ProofInstruction::proof_data::<T, U>(&instruction.data)
+        .map(ZkProofData::context_data)
+        .ok_or(ProgramError::InvalidInstructionData)
+}


### PR DESCRIPTION
#### Problem
There are a number of changes to be made to the confidential transfer with the Solana 1.16 upgrade. Instead of making all the changes in a single PR, it would be nice to break up the changes in smaller PRs for each instruction. Each PR could make changes to the program, token client, and tests related to a particular instruction in the confidential transfer extension.

#### Summary of Changes
This PR is a precursor to the individual PR changes for each instruction.
- [99429af](https://github.com/solana-labs/solana-program-library/pull/4650/commits/99429af1d002cf1ff40d42367a0ec7d1e5ba25db): Currently, the entire confidential transfer test is featurized out with `#![cfg(feature = "proof-program")]` under `proof-program`. This commit assigns `#[cfg(feature = "proof-program")]` to each components in the tests. Subsequent PRs will remove these one by one.
- [3cdb6b4](https://github.com/solana-labs/solana-program-library/pull/4650/commits/3cdb6b48084546960b41e336cf9a0f9e5da745b7) Removed the struct `ConfidentialTransferMintWithKeypairs` in the tests. This is a helper struct to simplify the tests. With recent updates to the program, it seemed like this struct was adding more complexity than it was removing.
- [acee591](https://github.com/solana-labs/solana-program-library/pull/4650/commits/acee591f7e5bfe12a24131f7be7c7ea77bfe8fed): Enabled the tests for initializing and updating confidential transfer mint. This part does not need the proof program, so the tests can be enabled.
- [b489eb4](https://github.com/solana-labs/solana-program-library/pull/4650/commits/b489eb428eb92b6872279ce1317c58253f99d69b): This is a smaller commit. Every place that we use `pod::ElGamalPubkey` or `pod::AeKey`, I just switched to using `ElGamalPubkey` and `AeKey` directly to make the code a little cleaner.
- [60cdaca](https://github.com/solana-labs/solana-program-library/pull/4650/commits/60cdaca46ebf02b3e57e2c71bc48b923fccb487f): Currently, `EncryptionPubkey`, which is a type alias for `ElGamalPubkey` is used throughout the program. The original plan was to hide the "ElGamal" component under the rug and just work with `EncryptionPubkey` or `EncryptionSecretKey`. Now, we use `ElGamalPubkey` and `ElGamalSecretKey` throughout the `zk-keygen` cli, documentation, and all throughout the proof program, so using two names `EncryptionPubkey` and `ElGamalPubkey` could be quite confusing. So I just removed `EncryptionPubkey` and replaced it with `ElGamalPubkey`.
- [42d184f](https://github.com/solana-labs/solana-program-library/pull/4650/commits/42d184f07022c235bdf9437a56e99dc0d60f6e88): Added a helper function `decode_proof_instruction_context` function that decodes a zk proof instruction and extract the context. This is basically a refactor of [`decode_proof_instruction`](https://github.com/solana-labs/solana-program-library/blob/master/token/program-2022/src/extension/confidential_transfer/processor.rs#L50). I left the original `decode_proof_instruction` function in for now, but once all the instruction processors use the new `decode_proof_instruction_context` functions in subsequent PRs, it will be removed.

With the changes above, I should be able to update the other instructions for the newly updated proof program in their own split PRs.