### PR TITLE
token-2022: Allow alloc and realloc of unsized extensions

### DIFF
--- a/token/program-2022/src/error.rs
+++ b/token/program-2022/src/error.rs
@@ -201,6 +201,9 @@ pub enum TokenError {
     /// A mint or an account is initialized to an invalid combination of extensions
     #[error("A mint or an account is initialized to an invalid combination of extensions")]
     InvalidExtensionCombination,
+    /// Extension allocation with overwrite must use the same length
+    #[error("Extension allocation with overwrite must use the same length")]
+    InvalidLengthForAlloc,
 }
 impl From<TokenError> for ProgramError {
     fn from(e: TokenError) -> Self {
@@ -348,6 +351,9 @@ impl PrintProgramError for TokenError {
             }
             TokenError::InvalidExtensionCombination => {
                 msg!("Mint or account is initialized to an invalid combination of extensions")
+            }
+            TokenError::InvalidLengthForAlloc => {
+                msg!("Extension allocation with overwrite must use the same length")
             }
         }
     }

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -108,7 +108,7 @@ const fn adjust_len_for_multisig(account_len: usize) -> usize {
 }
 
 /// Helper function to calculate exactly how many bytes a value will take up,
-///
+/// given the value's length
 const fn add_type_and_length_to_len(value_len: usize) -> usize {
     value_len
         .saturating_add(size_of::<ExtensionType>())
@@ -166,14 +166,14 @@ fn get_extension_indices<V: Extension>(
 struct TlvDataInfo {
     /// The extension types written in the TLV buffer
     extension_types: Vec<ExtensionType>,
-    /// The total number bytes allocated for the TLV entries.
+    /// The total number bytes allocated for all TLV entries.
     ///
     /// Each TLV entry's allocated bytes comprises two bytes for the `type`, two
     /// bytes for the `length`, and `length` number of bytes for the `value`.
     used_len: usize,
 }
 
-/// Fetches the basic information about the TLV buffer by iterating through all
+/// Fetches basic information about the TLV buffer by iterating through all
 /// TLV entries.
 fn get_tlv_data_info(tlv_data: &[u8]) -> Result<TlvDataInfo, ProgramError> {
     let mut extension_types = vec![];

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -736,7 +736,7 @@ impl ExtensionType {
     /// Get the data length of the type associated with the enum
     ///
     /// Fails if the extension type is unsized
-    pub fn try_get_type_len(&self) -> Result<usize, ProgramError> {
+    fn try_get_type_len(&self) -> Result<usize, ProgramError> {
         if !self.sized() {
             return Err(ProgramError::InvalidArgument);
         }

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -325,7 +325,7 @@ pub trait BaseStateWithExtensions<S: BaseState> {
     }
 
     /// Unpack a portion of the TLV data as the desired type
-    fn get_extension<V: Extension>(&self) -> Result<&V, ProgramError> {
+    fn get_extension<V: Extension + Pod>(&self) -> Result<&V, ProgramError> {
         pod_from_bytes::<V>(self.get_extension_bytes::<V>()?)
     }
 
@@ -506,7 +506,7 @@ impl<'data, S: BaseState> StateWithExtensionsMut<'data, S> {
     }
 
     /// Unpack a portion of the TLV data as the desired type that allows modifying the type
-    pub fn get_extension_mut<V: Extension>(&mut self) -> Result<&mut V, ProgramError> {
+    pub fn get_extension_mut<V: Extension + Pod>(&mut self) -> Result<&mut V, ProgramError> {
         pod_from_bytes_mut::<V>(self.get_extension_bytes_mut::<V>()?)
     }
 
@@ -519,7 +519,7 @@ impl<'data, S: BaseState> StateWithExtensionsMut<'data, S> {
     /// data buffer. If extension is already found in the buffer, it overwrites the existing
     /// extension with the default state if `overwrite` is set. If extension found, but
     /// `overwrite` is not set, it returns error.
-    pub fn init_extension<V: Extension>(
+    pub fn init_extension<V: Extension + Pod + Default>(
         &mut self,
         overwrite: bool,
     ) -> Result<&mut V, ProgramError> {
@@ -931,7 +931,7 @@ impl BaseState for Mint {
 
 /// Trait to be implemented by all extension states, specifying which extension
 /// and account type they are associated with
-pub trait Extension: Pod + Default {
+pub trait Extension {
     /// Associated extension type enum, checked at the start of TLV entries
     const TYPE: ExtensionType;
 }

--- a/token/program-2022/src/pod.rs
+++ b/token/program-2022/src/pod.rs
@@ -163,7 +163,7 @@ pub struct PodI64([u8; 8]);
 impl_int_conversion!(PodI64, i64);
 
 /// On-chain size of a `Pod` type
-pub fn pod_get_packed_len<T: Pod>() -> usize {
+pub const fn pod_get_packed_len<T: Pod>() -> usize {
     std::mem::size_of::<T>()
 }
 


### PR DESCRIPTION
#### Problem

This is a more complete and well-separated (I hope) version of #4647.

We want to add metadata support directly in token-2022, but token-2022's extensions only support extensions whose sizes are known at compile-time.

#### Solution

Step by step, it roughly goes:

* expose the raw extension bytes (the refactor part)
* add a new trait for unsized extensions
* add new alloc and realloc functions for the unsized extensions

Everthing from ba1d352b4873a6b86c0f3323600505be82f2bffe to 57e93d13274388a0c064453c257e3d903131e4aa is refactoring, and after that you'll see the new functionality.

I can separate this into multiple PRs if needed, but I hope the progression makes more sense here!