### PR TITLE
[compression] added function to locate ChangeLogEvent from transaction

### DIFF
--- a/account-compression/sdk/src/events/index.ts
+++ b/account-compression/sdk/src/events/index.ts
@@ -115,10 +115,6 @@ export function getAllChangeLogEventV1FromTransaction(
       // this noop cpi is not a changelog event. do nothing with it.
     }
   }
-
-  // when no changeLogEvents were found, throw an error
-  if (changeLogEvents.length == 0)
-    throw Error("Unable to locate any `ChangeLogEventV1` events");
-
+  
   return changeLogEvents;
 }

--- a/account-compression/sdk/src/events/index.ts
+++ b/account-compression/sdk/src/events/index.ts
@@ -1,8 +1,11 @@
+import { bs58 } from '@project-serum/anchor/dist/cjs/utils/bytes';
 import BN from 'bn.js';
 
 import { ChangeLogEventV1 } from '../types';
 import { accountCompressionEventBeet } from '../generated/types/AccountCompressionEvent';
 import { ApplicationDataEvent, ChangeLogEventV1 as CLV1 } from '../generated';
+import { PublicKey, TransactionResponse } from '@solana/web3.js';
+import { SPL_NOOP_PROGRAM_ID } from '../constants';
 
 /**
  * Helper method for indexing a {@link ConcurrentMerkleTree}
@@ -45,4 +48,71 @@ export function deserializeApplicationDataEvent(
     default:
       throw Error('Unable to decode buffer as ApplicationDataEvent');
   }
+}
+
+/**
+ * Helper function to extract the ChangeLogEvent V1 from a TransactionResponse
+ * @param txResponse - TransactionResponse from the `@solana/web3.js`
+ * @param programId - PublicKey of the program (aka `programId`) that utilized the leaf on the tree
+ * @param noopProgramId - program id of the noop program used (default: `SPL_NOOP_PROGRAM_ID`)
+ * @returns
+ */ 
+export function getChangeLogEventV1FromTransaction(
+  txResponse: TransactionResponse,
+  programId: PublicKey,
+  noopProgramId: PublicKey = SPL_NOOP_PROGRAM_ID,
+){
+  // ensure a transaction response was provided
+  if (!txResponse) throw Error("No txResponse provided");
+
+  // find the correct index of the `programId` instruction
+  const relevantIndex =
+  txResponse.transaction.message.compiledInstructions.findIndex(
+    (instruction) => {
+      return (
+        txResponse?.transaction.message.staticAccountKeys[
+          instruction.programIdIndex
+        ].toBase58() === programId.toBase58()
+      );
+    }
+  );
+
+  // locate the noop's inner instructions called via cpi from `programId`
+  const relevantInnerIxs = txResponse!.meta?.innerInstructions?.[
+    relevantIndex
+  ].instructions.filter((instruction) => {
+    return (
+      txResponse?.transaction.message.staticAccountKeys[
+        instruction.programIdIndex
+      ].toBase58() === noopProgramId.toBase58()
+    );
+  });
+
+  // when no valid noop instructions are found, throw an error
+  if (!relevantInnerIxs || relevantInnerIxs.length == 0)
+    throw Error('Unable to locate valid noop instructions');
+
+  let changeLogEvent: ChangeLogEventV1 | undefined = undefined;
+  
+  /**
+   * note: the ChangeLogEvent V1 is expected to be at position `1`, 
+   * and normally expect only 2 `relevantInnerIx`
+   * so this sort method is more efficient for most uses cases
+  */
+  for (let i = relevantInnerIxs.length - 1; i > 0; i--) {
+    try {
+      changeLogEvent = deserializeChangeLogEventV1(
+        Buffer.from(bs58.decode(relevantInnerIxs[i]?.data!))
+      );
+
+    } catch (__) {
+      // do nothing, invalid data is handled just after this for loop
+    }
+  }
+
+  // when no `changeLogEvent` was found, throw an error
+  if (typeof changeLogEvent == 'undefined')
+    throw Error('Unable to locate the ChangeLogEventV1');
+
+  return changeLogEvent;
 }


### PR DESCRIPTION
Added a helper function named `getAllChangeLogEventV1FromTransaction` to locate and return an array of ChangeLogEventV1 from a [TransactionResponse](https://solana-labs.github.io/solana-web3.js/types/TransactionResponse.html) or [VersionedTransactionResponse](https://solana-labs.github.io/solana-web3.js/types/VersionedTransactionResponse.html) 

Among other things, this will enable people to more easily locate the leaf index that was utilized during an interaction with the tree.