### PR TITLE
token-2022: Add account-level alloc and realloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6892,6 +6892,7 @@ dependencies = [
  "spl-token 4.0.0",
  "spl-token-metadata-interface",
  "spl-transfer-hook-interface",
+ "spl-type-length-value",
  "thiserror",
 ]
 

--- a/associated-token-account/program-test/tests/create_idempotent.rs
+++ b/associated-token-account/program-test/tests/create_idempotent.rs
@@ -43,7 +43,8 @@ async fn success_account_exists() {
         program_test_2022(token_mint_address, true).start().await;
     let rent = banks_client.get_rent().await.unwrap();
     let expected_token_account_len =
-        ExtensionType::try_get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
+        ExtensionType::try_calculate_account_len::<Account>(&[ExtensionType::ImmutableOwner])
+            .unwrap();
     let expected_token_account_balance = rent.minimum_balance(expected_token_account_len);
 
     let instruction = create_associated_token_account_idempotent(
@@ -189,7 +190,8 @@ async fn fail_non_ata() {
 
     let rent = banks_client.get_rent().await.unwrap();
     let token_account_len =
-        ExtensionType::try_get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
+        ExtensionType::try_calculate_account_len::<Account>(&[ExtensionType::ImmutableOwner])
+            .unwrap();
     let token_account_balance = rent.minimum_balance(token_account_len);
 
     let wallet_address = Pubkey::new_unique();

--- a/associated-token-account/program-test/tests/extended_mint.rs
+++ b/associated-token-account/program-test/tests/extended_mint.rs
@@ -39,7 +39,8 @@ async fn test_associated_token_account_with_transfer_fees() {
     let token_mint_address = mint_account.pubkey();
     let mint_authority = Keypair::new();
     let space =
-        ExtensionType::try_get_account_len::<Mint>(&[ExtensionType::TransferFeeConfig]).unwrap();
+        ExtensionType::try_calculate_account_len::<Mint>(&[ExtensionType::TransferFeeConfig])
+            .unwrap();
     let maximum_fee = 100;
     let mut transaction = Transaction::new_with_payer(
         &[

--- a/associated-token-account/program-test/tests/process_create_associated_token_account.rs
+++ b/associated-token-account/program-test/tests/process_create_associated_token_account.rs
@@ -32,7 +32,8 @@ async fn test_associated_token_address() {
     let rent = banks_client.get_rent().await.unwrap();
 
     let expected_token_account_len =
-        ExtensionType::try_get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
+        ExtensionType::try_calculate_account_len::<Account>(&[ExtensionType::ImmutableOwner])
+            .unwrap();
     let expected_token_account_balance = rent.minimum_balance(expected_token_account_len);
 
     // Associated account does not exist
@@ -81,7 +82,8 @@ async fn test_create_with_fewer_lamports() {
         program_test_2022(token_mint_address, true).start().await;
     let rent = banks_client.get_rent().await.unwrap();
     let expected_token_account_len =
-        ExtensionType::try_get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
+        ExtensionType::try_calculate_account_len::<Account>(&[ExtensionType::ImmutableOwner])
+            .unwrap();
     let expected_token_account_balance = rent.minimum_balance(expected_token_account_len);
 
     // Transfer lamports into `associated_token_address` before creating it - enough to be
@@ -142,7 +144,8 @@ async fn test_create_with_excess_lamports() {
     let rent = banks_client.get_rent().await.unwrap();
 
     let expected_token_account_len =
-        ExtensionType::try_get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
+        ExtensionType::try_calculate_account_len::<Account>(&[ExtensionType::ImmutableOwner])
+            .unwrap();
     let expected_token_account_balance = rent.minimum_balance(expected_token_account_len);
 
     // Transfer 1 lamport into `associated_token_address` before creating it
@@ -272,7 +275,8 @@ async fn test_create_associated_token_account_using_legacy_implicit_instruction(
         program_test_2022(token_mint_address, true).start().await;
     let rent = banks_client.get_rent().await.unwrap();
     let expected_token_account_len =
-        ExtensionType::try_get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
+        ExtensionType::try_calculate_account_len::<Account>(&[ExtensionType::ImmutableOwner])
+            .unwrap();
     let expected_token_account_balance = rent.minimum_balance(expected_token_account_len);
 
     // Associated account does not exist

--- a/associated-token-account/program-test/tests/recover_nested.rs
+++ b/associated-token-account/program-test/tests/recover_nested.rs
@@ -24,7 +24,7 @@ async fn create_mint(context: &mut ProgramTestContext, program_id: &Pubkey) -> (
     let mint_account = Keypair::new();
     let token_mint_address = mint_account.pubkey();
     let mint_authority = Keypair::new();
-    let space = ExtensionType::try_get_account_len::<Mint>(&[]).unwrap();
+    let space = ExtensionType::try_calculate_account_len::<Mint>(&[]).unwrap();
     let rent = context.banks_client.get_rent().await.unwrap();
     let transaction = Transaction::new_signed_with_payer(
         &[

--- a/docs/src/token-2022/onchain.md
+++ b/docs/src/token-2022/onchain.md
@@ -147,7 +147,7 @@ use spl_token_2022::{extension::ExtensionType, instruction::*, state::Mint};
 use solana_sdk::{system_instruction, transaction::Transaction};
 
 // Calculate the space required using the `ExtensionType`
-let space = ExtensionType::try_get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]).unwrap();
+let space = ExtensionType::try_calculate_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]).unwrap();
 
 // get the Rent object and calculate the rent required
 let rent_required = rent.minimum_balance(space);
@@ -175,7 +175,7 @@ use spl_token_2022::{extension::ExtensionType, instruction::*, state::Account};
 use solana_sdk::{system_instruction, transaction::Transaction};
 
 // Calculate the space required using the `ExtensionType`
-let space = ExtensionType::try_get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
+let space = ExtensionType::try_calculate_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
 
 // get the Rent object and calculate the rent required
 let rent_required = rent.minimum_balance(space);
@@ -498,15 +498,15 @@ extension to the token accounts.
 Instead of:
 
 ```rust
-let mint_space = ExtensionType::try_get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]).unwrap();
-let account_space = ExtensionType::try_get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
+let mint_space = ExtensionType::try_calculate_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]).unwrap();
+let account_space = ExtensionType::try_calculate_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap();
 ```
 
 We'll do:
 
 ```rust
-let mint_space = ExtensionType::try_get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority, ExtensionType::TransferFeeConfig]).unwrap();
-let account_space = ExtensionType::try_get_account_len::<Account>(&[ExtensionType::ImmutableOwner, ExtensionType::TransferFeeAmount]).unwrap();
+let mint_space = ExtensionType::try_calculate_account_len::<Mint>(&[ExtensionType::MintCloseAuthority, ExtensionType::TransferFeeConfig]).unwrap();
+let account_space = ExtensionType::try_calculate_account_len::<Account>(&[ExtensionType::ImmutableOwner, ExtensionType::TransferFeeAmount]).unwrap();
 ```
 
 And during initialization of the mint, we'll add in the instruction to initialize
@@ -725,7 +725,7 @@ use spl_token_2022::{extension::ExtensionType, instruction::*, state::Mint};
 use solana_sdk::{system_instruction, transaction::Transaction};
 
 // Calculate the space required using the `ExtensionType`
-let space = ExtensionType::try_get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]).unwrap();
+let space = ExtensionType::try_calculate_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]).unwrap();
 
 // get the Rent object and calculate the rent required
 let rent_required = rent.minimum_balance(space);

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -94,7 +94,7 @@ pub async fn create_mint(
 ) -> Result<(), TransportError> {
     assert!(extension_types.is_empty() || program_id != &spl_token::id());
     let rent = banks_client.get_rent().await.unwrap();
-    let space = ExtensionType::try_get_account_len::<Mint>(extension_types).unwrap();
+    let space = ExtensionType::try_calculate_account_len::<Mint>(extension_types).unwrap();
     let mint_rent = rent.minimum_balance(space);
     let mint_pubkey = pool_mint.pubkey();
 
@@ -225,7 +225,7 @@ pub async fn create_token_account(
     extensions: &[ExtensionType],
 ) -> Result<(), TransportError> {
     let rent = banks_client.get_rent().await.unwrap();
-    let space = ExtensionType::try_get_account_len::<Account>(extensions).unwrap();
+    let space = ExtensionType::try_calculate_account_len::<Account>(extensions).unwrap();
     let account_rent = rent.minimum_balance(space);
 
     let mut instructions = vec![system_instruction::create_account(

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -2154,7 +2154,7 @@ mod tests {
     ) -> (Pubkey, SolanaAccount) {
         let account_key = Pubkey::new_unique();
         let space = if *program_id == spl_token_2022::id() {
-            ExtensionType::try_get_account_len::<Account>(&[
+            ExtensionType::try_calculate_account_len::<Account>(&[
                 ExtensionType::ImmutableOwner,
                 ExtensionType::TransferFeeAmount,
             ])
@@ -2218,14 +2218,16 @@ mod tests {
         let mint_key = Pubkey::new_unique();
         let space = if *program_id == spl_token_2022::id() {
             if close_authority.is_some() {
-                ExtensionType::try_get_account_len::<Mint>(&[
+                ExtensionType::try_calculate_account_len::<Mint>(&[
                     ExtensionType::MintCloseAuthority,
                     ExtensionType::TransferFeeConfig,
                 ])
                 .unwrap()
             } else {
-                ExtensionType::try_get_account_len::<Mint>(&[ExtensionType::TransferFeeConfig])
-                    .unwrap()
+                ExtensionType::try_calculate_account_len::<Mint>(&[
+                    ExtensionType::TransferFeeConfig,
+                ])
+                .unwrap()
             }
         } else {
             Mint::get_packed_len()

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -2195,7 +2195,7 @@ async fn command_required_transfer_memos(
     } else {
         existing_extensions.push(ExtensionType::MemoTransfer);
         let needed_account_len =
-            ExtensionType::try_get_account_len::<Account>(&existing_extensions)?;
+            ExtensionType::try_calculate_account_len::<Account>(&existing_extensions)?;
         if needed_account_len > current_account_len {
             token
                 .reallocate(
@@ -2268,7 +2268,7 @@ async fn command_cpi_guard(
     } else {
         existing_extensions.push(ExtensionType::CpiGuard);
         let required_account_len =
-            ExtensionType::try_get_account_len::<Account>(&existing_extensions)?;
+            ExtensionType::try_calculate_account_len::<Account>(&existing_extensions)?;
         if required_account_len > current_account_len {
             token
                 .reallocate(

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -531,7 +531,7 @@ where
             .iter()
             .map(|e| e.extension())
             .collect::<Vec<_>>();
-        let space = ExtensionType::try_get_account_len::<Mint>(&extension_types)?;
+        let space = ExtensionType::try_calculate_account_len::<Mint>(&extension_types)?;
 
         let mut instructions = vec![system_instruction::create_account(
             &self.payer.pubkey(),
@@ -653,7 +653,7 @@ where
                 required_extensions.push(extension_type);
             }
         }
-        let space = ExtensionType::try_get_account_len::<Account>(&required_extensions)?;
+        let space = ExtensionType::try_calculate_account_len::<Account>(&required_extensions)?;
         let mut instructions = vec![system_instruction::create_account(
             &self.payer.pubkey(),
             &account.pubkey(),
@@ -1259,7 +1259,7 @@ where
             } else {
                 vec![]
             };
-            let space = ExtensionType::try_get_account_len::<Account>(&extensions)?;
+            let space = ExtensionType::try_calculate_account_len::<Account>(&extensions)?;
 
             instructions.push(system_instruction::create_account(
                 &self.payer.pubkey(),

--- a/token/program-2022-test/tests/initialize_account.rs
+++ b/token/program-2022-test/tests/initialize_account.rs
@@ -32,7 +32,7 @@ async fn no_extensions() {
     let mint_account = Keypair::new();
     let mint_authority_pubkey = Pubkey::new_unique();
 
-    let space = ExtensionType::try_get_account_len::<Mint>(&[]).unwrap();
+    let space = ExtensionType::try_calculate_account_len::<Mint>(&[]).unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -60,7 +60,7 @@ async fn no_extensions() {
 
     let account = Keypair::new();
     let account_owner_pubkey = Pubkey::new_unique();
-    let space = ExtensionType::try_get_account_len::<Account>(&[]).unwrap();
+    let space = ExtensionType::try_calculate_account_len::<Account>(&[]).unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -102,7 +102,7 @@ async fn fail_on_invalid_mint() {
     let rent = ctx.banks_client.get_rent().await.unwrap();
     let mint_account = Keypair::new();
 
-    let space = ExtensionType::try_get_account_len::<Mint>(&[]).unwrap();
+    let space = ExtensionType::try_calculate_account_len::<Mint>(&[]).unwrap();
     let instructions = vec![system_instruction::create_account(
         &ctx.payer.pubkey(),
         &mint_account.pubkey(),
@@ -120,7 +120,7 @@ async fn fail_on_invalid_mint() {
 
     let account = Keypair::new();
     let account_owner_pubkey = Pubkey::new_unique();
-    let space = ExtensionType::try_get_account_len::<Account>(&[]).unwrap();
+    let space = ExtensionType::try_calculate_account_len::<Account>(&[]).unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -167,7 +167,8 @@ async fn single_extension() {
     let mint_authority_pubkey = Pubkey::new_unique();
 
     let space =
-        ExtensionType::try_get_account_len::<Mint>(&[ExtensionType::TransferFeeConfig]).unwrap();
+        ExtensionType::try_calculate_account_len::<Mint>(&[ExtensionType::TransferFeeConfig])
+            .unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -205,7 +206,8 @@ async fn single_extension() {
     let account = Keypair::new();
     let account_owner_pubkey = Pubkey::new_unique();
     let space =
-        ExtensionType::try_get_account_len::<Account>(&[ExtensionType::TransferFeeAmount]).unwrap();
+        ExtensionType::try_calculate_account_len::<Account>(&[ExtensionType::TransferFeeAmount])
+            .unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -237,7 +239,8 @@ async fn single_extension() {
         .expect("account not none");
     assert_eq!(
         account_info.data.len(),
-        ExtensionType::try_get_account_len::<Account>(&[ExtensionType::TransferFeeAmount]).unwrap(),
+        ExtensionType::try_calculate_account_len::<Account>(&[ExtensionType::TransferFeeAmount])
+            .unwrap(),
     );
     assert_eq!(account_info.owner, spl_token_2022::id());
     assert_eq!(account_info.lamports, rent.minimum_balance(space));

--- a/token/program-2022-test/tests/initialize_mint.rs
+++ b/token/program-2022-test/tests/initialize_mint.rs
@@ -111,7 +111,8 @@ async fn fail_extension_after_mint_init() {
     let mint_authority_pubkey = Pubkey::new_unique();
 
     let space =
-        ExtensionType::try_get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]).unwrap();
+        ExtensionType::try_calculate_account_len::<Mint>(&[ExtensionType::MintCloseAuthority])
+            .unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -196,7 +197,8 @@ async fn fail_init_overallocated_mint() {
     let mint_authority_pubkey = Pubkey::new_unique();
 
     let space =
-        ExtensionType::try_get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]).unwrap();
+        ExtensionType::try_calculate_account_len::<Mint>(&[ExtensionType::MintCloseAuthority])
+            .unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -242,9 +244,10 @@ async fn fail_account_init_after_mint_extension() {
     let mint_authority_pubkey = Pubkey::new_unique();
     let token_account = Keypair::new();
 
-    let mint_space = ExtensionType::try_get_account_len::<Mint>(&[]).unwrap();
+    let mint_space = ExtensionType::try_calculate_account_len::<Mint>(&[]).unwrap();
     let account_space =
-        ExtensionType::try_get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]).unwrap();
+        ExtensionType::try_calculate_account_len::<Mint>(&[ExtensionType::MintCloseAuthority])
+            .unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -312,7 +315,7 @@ async fn fail_account_init_after_mint_init() {
     let mint_account = Keypair::new();
     let mint_authority_pubkey = Pubkey::new_unique();
 
-    let mint_space = ExtensionType::try_get_account_len::<Mint>(&[]).unwrap();
+    let mint_space = ExtensionType::try_calculate_account_len::<Mint>(&[]).unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -365,7 +368,8 @@ async fn fail_account_init_after_mint_init_with_extension() {
     let mint_authority_pubkey = Pubkey::new_unique();
 
     let mint_space =
-        ExtensionType::try_get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]).unwrap();
+        ExtensionType::try_calculate_account_len::<Mint>(&[ExtensionType::MintCloseAuthority])
+            .unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -424,7 +428,8 @@ async fn fail_fee_init_after_mint_init() {
     let mint_authority_pubkey = Pubkey::new_unique();
 
     let space =
-        ExtensionType::try_get_account_len::<Mint>(&[ExtensionType::TransferFeeConfig]).unwrap();
+        ExtensionType::try_calculate_account_len::<Mint>(&[ExtensionType::TransferFeeConfig])
+            .unwrap();
     let instructions = vec![
         system_instruction::create_account(
             &ctx.payer.pubkey(),
@@ -532,7 +537,7 @@ async fn fail_invalid_extensions_combination() {
     .unwrap();
 
     // initialize transfer fee and confidential transfers, but no confidential transfer fee
-    let mint_space = ExtensionType::try_get_account_len::<Mint>(&[
+    let mint_space = ExtensionType::try_calculate_account_len::<Mint>(&[
         ExtensionType::TransferFeeConfig,
         ExtensionType::ConfidentialTransferMint,
     ])
@@ -573,7 +578,7 @@ async fn fail_invalid_extensions_combination() {
     );
 
     // initialize transfer fee and confidential transfer fees, but no confidential transfers
-    let mint_space = ExtensionType::try_get_account_len::<Mint>(&[
+    let mint_space = ExtensionType::try_calculate_account_len::<Mint>(&[
         ExtensionType::TransferFeeConfig,
         ExtensionType::ConfidentialTransferFeeConfig,
     ])
@@ -615,7 +620,7 @@ async fn fail_invalid_extensions_combination() {
 
     // initialize all of transfer fee, confidential transfers, and confidential transfer fees
     // (success case)
-    let mint_space = ExtensionType::try_get_account_len::<Mint>(&[
+    let mint_space = ExtensionType::try_calculate_account_len::<Mint>(&[
         ExtensionType::TransferFeeConfig,
         ExtensionType::ConfidentialTransferMint,
         ExtensionType::ConfidentialTransferFeeConfig,

--- a/token/program-2022-test/tests/reallocate.rs
+++ b/token/program-2022-test/tests/reallocate.rs
@@ -109,7 +109,8 @@ async fn reallocate() {
     let account = token.get_account(alice_account).await.unwrap();
     assert_eq!(
         account.data.len(),
-        ExtensionType::try_get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap()
+        ExtensionType::try_calculate_account_len::<Account>(&[ExtensionType::ImmutableOwner])
+            .unwrap()
     );
 
     // reallocate succeeds with noop if account is already large enough
@@ -126,7 +127,8 @@ async fn reallocate() {
     let account = token.get_account(alice_account).await.unwrap();
     assert_eq!(
         account.data.len(),
-        ExtensionType::try_get_account_len::<Account>(&[ExtensionType::ImmutableOwner]).unwrap()
+        ExtensionType::try_calculate_account_len::<Account>(&[ExtensionType::ImmutableOwner])
+            .unwrap()
     );
 
     // reallocate only reallocates enough for new extension, and dedupes extensions
@@ -147,7 +149,7 @@ async fn reallocate() {
     let account = token.get_account(alice_account).await.unwrap();
     assert_eq!(
         account.data.len(),
-        ExtensionType::try_get_account_len::<Account>(&[
+        ExtensionType::try_calculate_account_len::<Account>(&[
             ExtensionType::ImmutableOwner,
             ExtensionType::TransferFeeAmount
         ])
@@ -190,7 +192,7 @@ async fn reallocate_without_current_extension_knowledge() {
     let account = token.get_account(alice_account).await.unwrap();
     assert_eq!(
         account.data.len(),
-        ExtensionType::try_get_account_len::<Account>(&[
+        ExtensionType::try_calculate_account_len::<Account>(&[
             ExtensionType::TransferFeeAmount,
             ExtensionType::ImmutableOwner
         ])
@@ -264,7 +266,7 @@ async fn reallocate_updates_native_rent_exemption(
     let account = token.get_account(alice_account).await.unwrap();
     assert_eq!(
         account.data.len(),
-        ExtensionType::try_get_account_len::<Account>(extensions).unwrap()
+        ExtensionType::try_calculate_account_len::<Account>(extensions).unwrap()
     );
     let expected_rent_exempt_reserve = {
         let mut context = context.lock().await;

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -29,6 +29,7 @@ spl-memo = { version = "4.0.0", path = "../../memo/program", features = [ "no-en
 spl-token = { version = "4.0",  path = "../program", features = ["no-entrypoint"] }
 spl-token-metadata-interface = { version = "0.1.0", path = "../../token-metadata/interface" }
 spl-transfer-hook-interface = { version = "0.1.0", path = "../transfer-hook-interface" }
+spl-type-length-value = { version = "0.2.0", path = "../../libraries/type-length-value" }
 thiserror = "1.0"
 serde = { version = "1.0.168", optional = true }
 serde_with = { version = "2.0.0", optional = true }

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -326,16 +326,16 @@ fn get_extension_bytes_mut<S: BaseState, V: Extension>(
         return Err(ProgramError::InvalidAccountData);
     }
     let TlvIndices {
-        type_start,
+        type_start: _,
         length_start,
         value_start,
     } = get_extension_indices::<V>(tlv_data, false)?;
-
-    if tlv_data[type_start..].len() < add_type_and_length_to_len(V::TYPE.try_get_type_len()?) {
-        return Err(ProgramError::InvalidAccountData);
-    }
+    // get_extension_indices has checked that tlv_data is long enough to include these indices
     let length = pod_from_bytes::<Length>(&tlv_data[length_start..value_start])?;
     let value_end = value_start.saturating_add(usize::from(*length));
+    if tlv_data.len() < value_end {
+        return Err(ProgramError::InvalidAccountData);
+    }
     Ok(&mut tlv_data[value_start..value_end])
 }
 

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -270,6 +270,9 @@ fn check_account_type<S: BaseState>(account_type: AccountType) -> Result<(), Pro
 /// that. We do a special case checking for a Multisig length, because those
 /// aren't extensible under any circumstances.
 const BASE_ACCOUNT_LENGTH: usize = Account::LEN;
+/// Helper that tacks on the AccountType length, which gives the minimum for any
+/// account with extensions
+const BASE_ACCOUNT_AND_TYPE_LENGTH: usize = BASE_ACCOUNT_LENGTH + size_of::<AccountType>();
 
 fn type_and_tlv_indices<S: BaseState>(
     rest_input: &[u8],
@@ -370,10 +373,7 @@ pub trait BaseStateWithExtensions<S: BaseState> {
         if info.extension_types.is_empty() {
             Ok(S::LEN)
         } else {
-            let total_len = info
-                .used_len
-                .saturating_add(BASE_ACCOUNT_LENGTH)
-                .saturating_add(size_of::<AccountType>());
+            let total_len = info.used_len.saturating_add(BASE_ACCOUNT_AND_TYPE_LENGTH);
             Ok(adjust_len_for_multisig(total_len))
         }
     }
@@ -394,8 +394,7 @@ pub trait BaseStateWithExtensions<S: BaseState> {
         // and account type
         let current_len = tlv_info
             .used_len
-            .saturating_add(BASE_ACCOUNT_LENGTH)
-            .saturating_add(size_of::<AccountType>());
+            .saturating_add(BASE_ACCOUNT_AND_TYPE_LENGTH);
         let new_len = if tlv_info.extension_types.is_empty() {
             current_len.saturating_add(new_extension_len)
         } else {
@@ -973,9 +972,7 @@ impl ExtensionType {
             Ok(S::LEN)
         } else {
             let extension_size = Self::try_get_total_tlv_len(extension_types)?;
-            let total_len = extension_size
-                .saturating_add(BASE_ACCOUNT_LENGTH)
-                .saturating_add(size_of::<AccountType>());
+            let total_len = extension_size.saturating_add(BASE_ACCOUNT_AND_TYPE_LENGTH);
             Ok(adjust_len_for_multisig(total_len))
         }
     }

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -1155,7 +1155,7 @@ pub fn alloc_and_serialize<S: BaseState, V: UnsizedExtension>(
     let mut buffer = account_info.try_borrow_mut_data()?;
     // write the account type if needed, so that the next unpack works
     if previous_account_len <= BASE_ACCOUNT_LENGTH {
-        buffer[BASE_ACCOUNT_LENGTH] = S::ACCOUNT_TYPE.into();
+        set_account_type::<S>(*buffer)?;
     }
 
     // now alloc in the TLV buffer and write the data

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -622,7 +622,7 @@ impl<'data, S: BaseState> StateWithExtensionsMut<'data, S> {
         overwrite: bool,
     ) -> Result<&mut V, ProgramError> {
         let length = pod_get_packed_len::<V>();
-        let buffer = self.alloc_internal::<V>(length, overwrite)?;
+        let buffer = self.alloc::<V>(length, overwrite)?;
         let extension_ref = pod_from_bytes_mut::<V>(buffer)?;
         *extension_ref = V::default();
         Ok(extension_ref)
@@ -707,11 +707,11 @@ impl<'data, S: BaseState> StateWithExtensionsMut<'data, S> {
         value: &V,
         overwrite: bool,
     ) -> Result<(), ProgramError> {
-        let data = self.alloc_internal::<V>(value.get_packed_len()?, overwrite)?;
+        let data = self.alloc::<V>(value.get_packed_len()?, overwrite)?;
         value.pack_into_slice(data)
     }
 
-    fn alloc_internal<V: Extension>(
+    fn alloc<V: Extension>(
         &mut self,
         length: usize,
         overwrite: bool,
@@ -2277,7 +2277,7 @@ mod test {
             BASE_ACCOUNT_AND_TYPE_LENGTH.saturating_add(add_type_and_length_to_len(value_len))
         );
 
-        let _ = state
+        state
             .init_variable_len_extension::<VariableLenMintTest>(&variable_len, false)
             .unwrap();
         let current_len = state.try_get_account_len().unwrap();

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -362,6 +362,20 @@ pub trait BaseStateWithExtensions<S: BaseState> {
     fn get_first_extension_type(&self) -> Result<Option<ExtensionType>, ProgramError> {
         get_first_extension_type(self.get_tlv_data())
     }
+
+    /// Get the total number of bytes used by TLV entries and the base type
+    fn get_account_len(&self) -> Result<usize, ProgramError> {
+        let info = get_tlv_data_info(self.get_tlv_data())?;
+        if info.extension_types.is_empty() {
+            Ok(S::LEN)
+        } else {
+            let total_len = info
+                .used_len
+                .saturating_add(BASE_ACCOUNT_LENGTH)
+                .saturating_add(size_of::<AccountType>());
+            Ok(adjust_len_for_multisig(total_len))
+        }
+    }
 }
 
 /// Encapsulates owned immutable base state data (mint or account) with possible extensions

--- a/token/program-2022/src/extension/reallocate.rs
+++ b/token/program-2022/src/extension/reallocate.rs
@@ -55,10 +55,10 @@ pub fn process_reallocate(
     {
         return Err(TokenError::InvalidState.into());
     }
-    // ExtensionType::try_get_account_len() dedupes types, so just a dumb concatenation is fine here
+    // ExtensionType::try_calculate_account_len() dedupes types, so just a dumb concatenation is fine here
     current_extension_types.extend_from_slice(&new_extension_types);
     let needed_account_len =
-        ExtensionType::try_get_account_len::<Account>(&current_extension_types)?;
+        ExtensionType::try_calculate_account_len::<Account>(&current_extension_types)?;
 
     // if account is already large enough, return early
     if token_account_info.data_len() >= needed_account_len {

--- a/token/transfer-hook-example/tests/functional.rs
+++ b/token/transfer-hook-example/tests/functional.rs
@@ -60,7 +60,7 @@ fn setup_token_accounts(
 ) {
     // add mint, source, and destination accounts by hand to always force
     // the "transferring" flag to true
-    let mint_size = ExtensionType::try_get_account_len::<Mint>(&[]).unwrap();
+    let mint_size = ExtensionType::try_calculate_account_len::<Mint>(&[]).unwrap();
     let mut mint_data = vec![0; mint_size];
     let mut state = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut mint_data).unwrap();
     let token_amount = 1_000_000_000_000;
@@ -83,7 +83,7 @@ fn setup_token_accounts(
     );
 
     let account_size =
-        ExtensionType::try_get_account_len::<Account>(&[ExtensionType::TransferHookAccount])
+        ExtensionType::try_calculate_account_len::<Account>(&[ExtensionType::TransferHookAccount])
             .unwrap();
     let mut account_data = vec![0; account_size];
     let mut state =


### PR DESCRIPTION
#### Problem

We have many helpers now for allocating and reallocating individual entries in the TLV buffer, but we still can't realloc the underlying `AccountInfo` whenever we add or update an unsized extension.

In the token-metadata interface, the metadata is written after the mint is initialized. During mint initialization, we check to make sure that there's no extra allocated space, to be safe.

This means that during token-metadata initialization, we have to realloc the underlying account in order to write the new data. During updates, we have to realloc the extension to fit the new data size.

#### Solution

Add a few sets of functions and helpers to get this done:

* get the current number of bytes used in the account
* get the future number of bytes used in the account
* for init: realloc the account, alloc the extension, then write the data
* for update: realloc the account, realloc the extension, and write the data (the order here is tricky, which is why we test a bit)

The commits should show a clear story, but let me know if there's anything unclear or if you want me to break anything up! This is the last step, since after this we can confidently do anything with the accounts and TLV buffer. The token-metadata implementation in token-2022 just needs to call into these functions.