### PR TITLE
[token-2022] Update confidential transfer configure account for 1.16

### DIFF
--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -1663,20 +1663,24 @@ where
     }
 
     /// Approves a token account for confidential transfers
-    #[cfg(feature = "proof-program")]
-    pub async fn confidential_transfer_approve_account<S: Signer>(
+    pub async fn confidential_transfer_approve_account<S: Signers>(
         &self,
-        token_account: &Pubkey,
-        authority: &S,
+        account: &Pubkey,
+        authority: &Pubkey,
+        signing_keypairs: &S,
     ) -> TokenResult<T::Output> {
+        let signing_pubkeys = signing_keypairs.pubkeys();
+        let multisig_signers = self.get_multisig_signers(authority, &signing_pubkeys);
+
         self.process_ixs(
             &[confidential_transfer::instruction::approve_account(
                 &self.program_id,
-                token_account,
+                account,
                 &self.pubkey,
-                &authority.pubkey(),
+                authority,
+                &multisig_signers,
             )?],
-            &[authority],
+            signing_keypairs,
         )
         .await
     }

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -1596,21 +1596,26 @@ where
     }
 
     /// Update confidential transfer mint
-    pub async fn confidential_transfer_update_mint<S: Signer>(
+    pub async fn confidential_transfer_update_mint<S: Signers>(
         &self,
-        authority: &S,
+        authority: &Pubkey,
         auto_approve_new_account: bool,
         auditor_elgamal_pubkey: Option<ElGamalPubkey>,
+        signing_keypairs: &S,
     ) -> TokenResult<T::Output> {
+        let signing_pubkeys = signing_keypairs.pubkeys();
+        let multisig_signers = self.get_multisig_signers(authority, &signing_pubkeys);
+
         self.process_ixs(
             &[confidential_transfer::instruction::update_mint(
                 &self.program_id,
                 &self.pubkey,
-                &authority.pubkey(),
+                authority,
+                &multisig_signers,
                 auto_approve_new_account,
                 auditor_elgamal_pubkey,
             )?],
-            &[authority],
+            signing_keypairs,
         )
         .await
     }

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -421,7 +421,11 @@ async fn confidential_transfer_configure_token_account() {
     );
 
     token
-        .confidential_transfer_approve_account(&alice_meta.token_account, &authority)
+        .confidential_transfer_approve_account(
+            &alice_meta.token_account,
+            &authority.pubkey(),
+            &[&authority],
+        )
         .await
         .unwrap();
 

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -319,9 +319,10 @@ async fn confidential_transfer_initialize_and_update_mint() {
 
     let err = token
         .confidential_transfer_update_mint(
-            &authority,
+            &authority.pubkey(),
             new_auto_approve_new_accounts,
             new_auditor_elgamal_pubkey,
+            &[&authority],
         )
         .await
         .unwrap_err();
@@ -338,9 +339,10 @@ async fn confidential_transfer_initialize_and_update_mint() {
 
     token
         .confidential_transfer_update_mint(
-            &new_authority,
+            &new_authority.pubkey(),
             new_auto_approve_new_accounts,
             new_auditor_elgamal_pubkey,
+            &[&new_authority],
         )
         .await
         .unwrap();

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -459,16 +459,13 @@ pub fn update_mint(
     auditor_elgamal_pubkey: Option<ElGamalPubkey>,
 ) -> Result<Instruction, ProgramError> {
     check_program_account(token_program_id)?;
-
     let mut accounts = vec![
         AccountMeta::new(*mint, false),
         AccountMeta::new_readonly(*authority, multisig_signers.is_empty()),
     ];
-
     for multisig_signer in multisig_signers.iter() {
         accounts.push(AccountMeta::new_readonly(**multisig_signer, true));
     }
-
     Ok(encode_instruction(
         token_program_id,
         accounts,
@@ -555,13 +552,17 @@ pub fn approve_account(
     account_to_approve: &Pubkey,
     mint: &Pubkey,
     authority: &Pubkey,
+    multisig_signers: &[&Pubkey],
 ) -> Result<Instruction, ProgramError> {
     check_program_account(token_program_id)?;
-    let accounts = vec![
+    let mut accounts = vec![
         AccountMeta::new(*account_to_approve, false),
         AccountMeta::new_readonly(*mint, false),
-        AccountMeta::new_readonly(*authority, true),
+        AccountMeta::new_readonly(*authority, multisig_signers.is_empty()),
     ];
+    for multisig_signer in multisig_signers.iter() {
+        accounts.push(AccountMeta::new_readonly(**multisig_signer, true));
+    }
     Ok(encode_instruction(
         token_program_id,
         accounts,

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -524,7 +524,6 @@ pub fn inner_configure_account(
 /// Create a `ConfigureAccount` instruction
 #[allow(clippy::too_many_arguments)]
 #[cfg(not(target_os = "solana"))]
-#[cfg(feature = "proof-program")]
 pub fn configure_account(
     token_program_id: &Pubkey,
     token_account: &Pubkey,
@@ -546,8 +545,7 @@ pub fn configure_account(
             multisig_signers,
             1,
         )?,
-        #[cfg(feature = "proof-program")]
-        verify_pubkey_validity(proof_data),
+        verify_pubkey_validity(None, proof_data),
     ])
 }
 

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -454,15 +454,20 @@ pub fn update_mint(
     token_program_id: &Pubkey,
     mint: &Pubkey,
     authority: &Pubkey,
+    multisig_signers: &[&Pubkey],
     auto_approve_new_accounts: bool,
     auditor_elgamal_pubkey: Option<ElGamalPubkey>,
 ) -> Result<Instruction, ProgramError> {
     check_program_account(token_program_id)?;
 
-    let accounts = vec![
+    let mut accounts = vec![
         AccountMeta::new(*mint, false),
-        AccountMeta::new_readonly(*authority, true),
+        AccountMeta::new_readonly(*authority, multisig_signers.is_empty()),
     ];
+
+    for multisig_signer in multisig_signers.iter() {
+        accounts.push(AccountMeta::new_readonly(**multisig_signer, true));
+    }
 
     Ok(encode_instruction(
         token_program_id,


### PR DESCRIPTION
#### Problem
Confidential transfer configure account instruction is not updated for the new Solana 1.16 changes.

#### Summary of changes
- [b9a5682](https://github.com/solana-labs/solana-program-library/pull/4663/commits/b9a56828ecdad6625f1d62a28081ce63aa6fe04d): The `UpdateMint` instruction constructor and toiken client functions have not been touched for some time and they currently do not support multisig signers. I updated functions to support multisig signers. This should have been a part of the previous PR https://github.com/solana-labs/solana-program-library/pull/4650, which was missed.
- [3cc330b](https://github.com/solana-labs/solana-program-library/pull/4663/commits/3cc330b5b59aa51553c1042e0eb198887e454ffe):
  - Updated `ConfigureAccount` instruction constructor and processor and brought them out of `proof-program` feature.
  - Updated configure account token client. Previously, the token client function was a mess having three different functions each one accepting different parameters. I merged these functions into a single function in-line with the rest of the token client functions for the other instructions. 
    - It takes in an optional `maximum_pending_balance_credit_counter`, which is set to be a default value if not provided.  I put the default constant inside the client function itself since I did not see a clean place to put it. I can move it elsewhere if there are suggestions. The maximum credit counter limits how many times a confidential transfer account can be creditted (via deposits or confidential transfers). This is to prevent ElGamal ciphertexts from overflowing, making them difficult to decrypt.
    - The function also takes in `elgamal_keypair` and `aes_key` as input. Ideally, these parameters can also be optional so that they can be derived from signers when they are `None`, but unfortunately, the zk-token-sdk does not yet support these keys from being derived from `Signers` (only `Signer`). This part can perhaps be updated in the future in a separate PR.
- [21f2b49](https://github.com/solana-labs/solana-program-library/pull/4663/commits/21f2b49829053e40900b18b9b5e9fad5f11da6f2): I unfeaturized and updated `ConfidentialTokenAccountMeta`, which is a private helper type in tests. The changes are straightforward, just updating the interface for solana 1.16.
- [5b92b73](https://github.com/solana-labs/solana-program-library/pull/4663/commits/5b92b732967e21941d6d88dc2b99d3bf91b2ec3b): Updated the tests for the configure account instruction. I these should be straightforward.
- [464dfd6](https://github.com/solana-labs/solana-program-library/pull/4663/commits/464dfd6166005ea187b1f57a8aec4eb62ad119c2): I also updated the `ApproveAccount` instruction constructor and token client. This is a separate instruction, but since it is simple, I thought I could squeeze it into this PR.