### PR TITLE
[token-2022] Update confidential transfer {enable,disable} confidential credits and empty account for Solana 1.16

### DIFF
--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -2276,85 +2276,97 @@ where
     }
 
     /// Enable confidential transfer `Deposit` and `Transfer` instructions for a token account
-    #[cfg(feature = "proof-program")]
-    pub async fn confidential_transfer_enable_confidential_credits<S: Signer>(
+    pub async fn confidential_transfer_enable_confidential_credits<S: Signers>(
         &self,
-        token_account: &Pubkey,
-        authority: &S,
+        account: &Pubkey,
+        authority: &Pubkey,
+        signing_keypairs: &S,
     ) -> TokenResult<T::Output> {
+        let signing_pubkeys = signing_keypairs.pubkeys();
+        let multisig_signers = self.get_multisig_signers(authority, &signing_pubkeys);
+
         self.process_ixs(
             &[
                 confidential_transfer::instruction::enable_confidential_credits(
                     &self.program_id,
-                    token_account,
-                    &authority.pubkey(),
-                    &[],
+                    account,
+                    authority,
+                    &multisig_signers,
                 )?,
             ],
-            &[authority],
+            signing_keypairs,
         )
         .await
     }
 
     /// Disable confidential transfer `Deposit` and `Transfer` instructions for a token account
-    #[cfg(feature = "proof-program")]
-    pub async fn confidential_transfer_disable_confidential_credits<S: Signer>(
+    pub async fn confidential_transfer_disable_confidential_credits<S: Signers>(
         &self,
-        token_account: &Pubkey,
-        authority: &S,
+        account: &Pubkey,
+        authority: &Pubkey,
+        signing_keypairs: &S,
     ) -> TokenResult<T::Output> {
+        let signing_pubkeys = signing_keypairs.pubkeys();
+        let multisig_signers = self.get_multisig_signers(authority, &signing_pubkeys);
+
         self.process_ixs(
             &[
                 confidential_transfer::instruction::disable_confidential_credits(
                     &self.program_id,
-                    token_account,
-                    &authority.pubkey(),
-                    &[],
+                    account,
+                    authority,
+                    &multisig_signers,
                 )?,
             ],
-            &[authority],
+            signing_keypairs,
         )
         .await
     }
 
     /// Enable a confidential extension token account to receive non-confidential payments
-    #[cfg(feature = "proof-program")]
-    pub async fn confidential_transfer_enable_non_confidential_credits<S: Signer>(
+    pub async fn confidential_transfer_enable_non_confidential_credits<S: Signers>(
         &self,
-        token_account: &Pubkey,
-        authority: &S,
+        account: &Pubkey,
+        authority: &Pubkey,
+        signing_keypairs: &S,
     ) -> TokenResult<T::Output> {
+        let signing_pubkeys = signing_keypairs.pubkeys();
+        let multisig_signers = self.get_multisig_signers(authority, &signing_pubkeys);
+
         self.process_ixs(
             &[
                 confidential_transfer::instruction::enable_non_confidential_credits(
                     &self.program_id,
-                    token_account,
-                    &authority.pubkey(),
-                    &[],
+                    account,
+                    authority,
+                    &multisig_signers,
                 )?,
             ],
-            &[authority],
+            signing_keypairs,
         )
         .await
     }
 
     /// Disable non-confidential payments for a confidential extension token account
-    #[cfg(feature = "proof-program")]
-    pub async fn confidential_transfer_disable_non_confidential_credits<S: Signer>(
+    pub async fn confidential_transfer_disable_non_confidential_credits<S: Signers>(
         &self,
-        token_account: &Pubkey,
-        authority: &S,
+        account: &Pubkey,
+        authority: &Pubkey,
+        signing_keypairs: &S,
     ) -> TokenResult<T::Output> {
+        let signing_pubkeys = signing_keypairs.pubkeys();
+        let multisig_signers = self.get_multisig_signers(authority, &signing_pubkeys);
+
         self.process_ixs(
             &[
                 confidential_transfer::instruction::disable_non_confidential_credits(
                     &self.program_id,
-                    token_account,
-                    &authority.pubkey(),
-                    &[],
+                    account,
+                    authority,
+                    &multisig_signers,
                 )?,
             ],
-            &[authority],
+            signing_keypairs,
         )
         .await
     }

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -1686,34 +1686,21 @@ where
     }
 
     /// Prepare a token account with the confidential transfer extension for closing
-    #[cfg(feature = "proof-program")]
-    pub async fn confidential_transfer_empty_account<S: Signer>(
+    pub async fn confidential_transfer_empty_account<S: Signers>(
         &self,
-        token_account: &Pubkey,
-        authority: &S,
-    ) -> TokenResult<T::Output> {
-        let elgamal_keypair =
-            ElGamalKeypair::new(authority, token_account).map_err(TokenError::Key)?;
-        self.confidential_transfer_empty_account_with_keypair(
-            token_account,
-            authority,
-            &elgamal_keypair,
-        )
-        .await
-    }
-
-    #[cfg(feature = "proof-program")]
-    pub async fn confidential_transfer_empty_account_with_keypair<S: Signer>(
-        &self,
-        token_account: &Pubkey,
-        authority: &S,
+        account: &Pubkey,
+        authority: &Pubkey,
         elgamal_keypair: &ElGamalKeypair,
+        signing_keypairs: &S,
     ) -> TokenResult<T::Output> {
-        let state = self.get_account_info(token_account).await.unwrap();
+        let signing_pubkeys = signing_keypairs.pubkeys();
+        let multisig_signers = self.get_multisig_signers(authority, &signing_pubkeys);
+
+        let state = self.get_account_info(account).await.unwrap();
         let extension =
             state.get_extension::<confidential_transfer::ConfidentialTransferAccount>()?;
 
-        let proof_data = confidential_transfer::instruction::CloseAccountData::new(
+        let proof_data = confidential_transfer::instruction::ZeroBalanceProofData::new(
             elgamal_keypair,
             &extension.available_balance.try_into().unwrap(),
         )
@@ -1722,12 +1709,12 @@ where
         self.process_ixs(
             &confidential_transfer::instruction::empty_account(
                 &self.program_id,
-                token_account,
-                &authority.pubkey(),
-                &[],
+                account,
+                authority,
+                &multisig_signers,
                 &proof_data,
             )?,
-            &[authority],
+            signing_keypairs,
         )
         .await
     }

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -519,7 +519,6 @@ async fn confidential_enable_disable_confidential_credits() {
     assert!(bool::from(&extension.allow_confidential_credits));
 }
 
-#[cfg(feature = "proof-program")]
 #[tokio::test]
 async fn confidential_transfer_enable_disable_non_confidential_credits() {
     let authority = Keypair::new();

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -462,21 +462,20 @@ async fn confidential_transfer_configure_token_account() {
     );
 }
 
-#[cfg(feature = "proof-program")]
 #[tokio::test]
-async fn ct_enable_disable_confidential_credits() {
-    let ConfidentialTransferMintWithKeypairs { ct_mint, .. } =
-        ConfidentialTransferMintWithKeypairs::new();
+async fn confidential_enable_disable_confidential_credits() {
+    let authority = Keypair::new();
+    let auto_approve_new_accounts = true;
+    let auditor_elgamal_keypair = ElGamalKeypair::new_rand();
+    let auditor_elgamal_pubkey = (*auditor_elgamal_keypair.pubkey()).into();
+
     let mut context = TestContext::new().await;
     context
         .init_token_with_mint(vec![
             ExtensionInitializationParams::ConfidentialTransferMint {
-                authority: ct_mint.authority.into(),
-                auto_approve_new_accounts: ct_mint.auto_approve_new_accounts.try_into().unwrap(),
-                auditor_elgamal_pubkey: ct_mint.auditor_elgamal_pubkey.into(),
-                withdraw_withheld_authority_elgamal_pubkey: ct_mint
-                    .withdraw_withheld_authority_elgamal_pubkey
-                    .into(),
+                authority: Some(authority.pubkey()),
+                auto_approve_new_accounts,
+                auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
             },
         ])
         .await
@@ -486,7 +485,11 @@ async fn ct_enable_disable_confidential_credits() {
     let alice_meta = ConfidentialTokenAccountMeta::new(&token, &alice).await;
 
     token
-        .confidential_transfer_disable_confidential_credits(&alice_meta.token_account, &alice)
+        .confidential_transfer_disable_confidential_credits(
+            &alice_meta.token_account,
+            &alice.pubkey(),
+            &[&alice],
+        )
         .await
         .unwrap();
     let state = token
@@ -499,7 +502,11 @@ async fn ct_enable_disable_confidential_credits() {
     assert!(!bool::from(&extension.allow_confidential_credits));
 
     token
-        .confidential_transfer_enable_confidential_credits(&alice_meta.token_account, &alice)
+        .confidential_transfer_enable_confidential_credits(
+            &alice_meta.token_account,
+            &alice.pubkey(),
+            &[&alice],
+        )
         .await
         .unwrap();
     let state = token
@@ -514,19 +521,19 @@ async fn ct_enable_disable_confidential_credits() {
 
 #[cfg(feature = "proof-program")]
 #[tokio::test]
-async fn ct_enable_disable_non_confidential_credits() {
-    let ConfidentialTransferMintWithKeypairs { ct_mint, .. } =
-        ConfidentialTransferMintWithKeypairs::new();
+async fn confidential_transfer_enable_disable_non_confidential_credits() {
+    let authority = Keypair::new();
+    let auto_approve_new_accounts = true;
+    let auditor_elgamal_keypair = ElGamalKeypair::new_rand();
+    let auditor_elgamal_pubkey = (*auditor_elgamal_keypair.pubkey()).into();
+
     let mut context = TestContext::new().await;
     context
         .init_token_with_mint(vec![
             ExtensionInitializationParams::ConfidentialTransferMint {
-                authority: ct_mint.authority.into(),
-                auto_approve_new_accounts: ct_mint.auto_approve_new_accounts.try_into().unwrap(),
-                auditor_elgamal_pubkey: ct_mint.auditor_elgamal_pubkey.into(),
-                withdraw_withheld_authority_elgamal_pubkey: ct_mint
-                    .withdraw_withheld_authority_elgamal_pubkey
-                    .into(),
+                authority: Some(authority.pubkey()),
+                auto_approve_new_accounts,
+                auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
             },
         ])
         .await
@@ -553,7 +560,11 @@ async fn ct_enable_disable_non_confidential_credits() {
         .unwrap();
 
     token
-        .confidential_transfer_disable_non_confidential_credits(&bob_meta.token_account, &bob)
+        .confidential_transfer_disable_non_confidential_credits(
+            &bob_meta.token_account,
+            &bob.pubkey(),
+            &[&bob],
+        )
         .await
         .unwrap();
     let state = token
@@ -587,7 +598,11 @@ async fn ct_enable_disable_non_confidential_credits() {
     );
 
     token
-        .confidential_transfer_enable_non_confidential_credits(&bob_meta.token_account, &bob)
+        .confidential_transfer_enable_non_confidential_credits(
+            &bob_meta.token_account,
+            &bob.pubkey(),
+            &[&bob],
+        )
         .await
         .unwrap();
     let state = token

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -605,13 +605,12 @@ pub fn inner_empty_account(
 }
 
 /// Create a `EmptyAccount` instruction
-#[cfg(feature = "proof-program")]
 pub fn empty_account(
     token_program_id: &Pubkey,
     token_account: &Pubkey,
     authority: &Pubkey,
     multisig_signers: &[&Pubkey],
-    proof_data: &CloseAccountData,
+    proof_data: &ZeroBalanceProofData,
 ) -> Result<Vec<Instruction>, ProgramError> {
     Ok(vec![
         inner_empty_account(
@@ -621,8 +620,7 @@ pub fn empty_account(
             multisig_signers,
             1,
         )?, // calls check_program_account
-        #[cfg(feature = "proof-program")]
-        verify_close_account(proof_data),
+        verify_zero_balance(None, proof_data),
     ])
 }
 


### PR DESCRIPTION
#### Problem
Confidential transfer {enable,disable} confidential credits and empty account instructions are not updated for the new Solana 1.16 changes.

#### Summary of changes
The changes in this PR are pretty straightforward.
- [6bc7e1b](https://github.com/solana-labs/solana-program-library/pull/4664/commits/6bc7e1b5ab75c5b7b9f7ef27980fae26f8913ccd): Updated the client code for the {enable, disable} confidential credits instructions. Previously, they did not support multisig. The functions are updated to be in-line with the rest of the client functions.
- [12d888c](https://github.com/solana-labs/solana-program-library/pull/4664/commits/12d888ca0efe4141694d45802179de67c26e0b7c): Updated the test code for {enable, disable} confidential credits instructions.
- [7f4b1cb](https://github.com/solana-labs/solana-program-library/pull/4664/commits/7f4b1cb7d6436689b86ef9e367b3e5a496159a04): Updated the client and processor code for the empty account instruction.
- [0f11226](https://github.com/solana-labs/solana-program-library/pull/4664/commits/0f11226af5b6970b01e41756cd2ff882d46418ac): Updated the test code for the empty account instruction.
- [2758213](https://github.com/solana-labs/solana-program-library/pull/4664/commits/2758213705a9e3ac84a8b7edbc28fab99d83a0cb): Oops, I forgot to unfeaturize the test for {enable,disable} non-confidential credits instructions, so I unfeaturized it.