### PR TITLE
token-client: Unpin solana deps, and use `solana-rpc-client`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6932,13 +6932,13 @@ dependencies = [
 
 [[package]]
 name = "spl-token-client"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "futures-util",
  "solana-cli-output",
- "solana-client",
  "solana-program-test",
+ "solana-rpc-client",
  "solana-sdk",
  "spl-associated-token-account 2.0.0",
  "spl-memo 4.0.0",

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -5,15 +5,15 @@ edition = "2021"
 license = "Apache-2.0"
 name = "spl-token-client"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "0.5.0"
+version = "0.5.1"
 
 [dependencies]
 async-trait = "0.1"
 futures-util = "0.3"
-solana-cli-output = { version = "=1.16.1", optional = true }
-solana-client = "=1.16.1"
-solana-program-test = "=1.16.1"
-solana-sdk = "=1.16.1"
+solana-cli-output = { version = "1.16.1", optional = true }
+solana-program-test = "1.16.1"
+solana-rpc-client = "1.16.1"
+solana-sdk = "1.16.1"
 # We never want the entrypoint for ATA, but we want the entrypoint for token when
 # testing token
 spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }

--- a/token/client/src/client.rs
+++ b/token/client/src/client.rs
@@ -1,7 +1,7 @@
 use {
     async_trait::async_trait,
-    solana_client::nonblocking::rpc_client::RpcClient,
     solana_program_test::{tokio::sync::Mutex, BanksClient, ProgramTestContext},
+    solana_rpc_client::nonblocking::rpc_client::RpcClient,
     solana_sdk::{
         account::Account, hash::Hash, pubkey::Pubkey, signature::Signature,
         transaction::Transaction,


### PR DESCRIPTION
#### Problem

People who want to use the `spl-token-client` crate must use the exact same version of the solana tools, which limits downstream usage.

#### Solution

Relax the dependencies. I noticed that it's always been pinned, but I can't see why we can't relax them for the client library.

And while I was at it, I noticed that we could downgrade the `solana-client` dependency to `solana-rpc-client`.