### PR TITLE
Add getrandom dependency

### DIFF
--- a/instruction-padding/program/Cargo.toml
+++ b/instruction-padding/program/Cargo.toml
@@ -19,6 +19,7 @@ solana-program = "1.16.1"
 [dev-dependencies]
 solana-program-test = "1.16.1"
 solana-sdk = "1.16.1"
+getrandom = { version = "0.2.8", features = ["custom"] }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/memo/program/Cargo.toml
+++ b/memo/program/Cargo.toml
@@ -17,6 +17,7 @@ solana-program = "1.16.1"
 [dev-dependencies]
 solana-program-test = "1.16.1"
 solana-sdk = "1.16.1"
+getrandom = { version = "0.2.8", features = ["custom"] }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/name-service/program/Cargo.toml
+++ b/name-service/program/Cargo.toml
@@ -18,9 +18,10 @@ test-sbf = []
 
 [dependencies]
 solana-program = "1.16.1"
-num-traits = "0.2"
 borsh = "0.10"
+getrandom = { version = "0.2.8", features = ["custom"] }
 num-derive = "0.4.0"
+num-traits = "0.2"
 thiserror = "1.0.41"
 
 [dev-dependencies]

--- a/token/program/Cargo.toml
+++ b/token/program/Cargo.toml
@@ -19,6 +19,7 @@ num-derive = "0.4"
 num-traits = "0.2"
 num_enum = "0.6.1"
 solana-program = "1.16.1"
+getrandom = { version = "0.2.8", features = ["custom"] }
 thiserror = "1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
### Problem

`borsh` update lead to `hashbrown` update which adds dependency on `getrandom`.
All this lead to turning off spl downstream build in solana ci.
Details are in https://github.com/solana-labs/solana/issues/32378

### Solution

Following [this giude](https://github.com/solana-labs/solana/blob/52fe7eb1cf1dd48893dece4e947987dfca192fac/docs/src/developing/on-chain-programs/developing-rust.md?plain=1#L240), add explicit dependency on getrandom where needed with custom features