### PR TITLE
token-2022: Implement initialize and update metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6873,6 +6873,7 @@ dependencies = [
  "solana-zk-token-sdk",
  "spl-memo 4.0.0",
  "spl-token 4.0.0",
+ "spl-token-metadata-interface",
  "spl-transfer-hook-interface",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6857,6 +6857,7 @@ name = "spl-token-2022"
 version = "0.7.0"
 dependencies = [
  "arrayref",
+ "borsh 0.10.3",
  "bytemuck",
  "lazy_static",
  "num-derive 0.4.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6884,6 +6884,7 @@ name = "spl-token-2022-test"
 version = "0.0.1"
 dependencies = [
  "async-trait",
+ "borsh 0.10.3",
  "futures-util",
  "solana-program",
  "solana-program-test",
@@ -6893,6 +6894,7 @@ dependencies = [
  "spl-memo 4.0.0",
  "spl-token-2022 0.7.0",
  "spl-token-client",
+ "spl-token-metadata-interface",
  "spl-transfer-hook-example",
  "spl-transfer-hook-interface",
  "test-case",
@@ -6946,6 +6948,7 @@ dependencies = [
  "spl-memo 4.0.0",
  "spl-token 4.0.0",
  "spl-token-2022 0.7.0",
+ "spl-token-metadata-interface",
  "spl-transfer-hook-interface",
  "thiserror",
 ]

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -20,6 +20,7 @@ spl-associated-token-account = { version = "2.0", path = "../../associated-token
 spl-memo = { version = "4.0.0", path = "../../memo/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path="../program", features = [ "no-entrypoint" ] }
 spl-token-2022 = { version = "0.7", path="../program-2022" }
+spl-token-metadata-interface = { version = "0.1", path="../../token-metadata/interface" }
 spl-transfer-hook-interface = { version = "0.1", path="../transfer-hook-interface" }
 thiserror = "1.0"
 

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -18,6 +18,7 @@ walkdir = "2"
 
 [dev-dependencies]
 async-trait = "0.1"
+borsh = "0.10"
 futures-util = "0.3"
 solana-program = "=1.16.1"
 solana-program-test = "=1.16.1"
@@ -27,6 +28,7 @@ spl-memo = { version = "4.0.0", path = "../../memo/program", features = ["no-ent
 spl-token-2022 = { version = "0.7", path="../program-2022", features = ["no-entrypoint"] }
 spl-instruction-padding = { version = "0.1.0", path="../../instruction-padding/program", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.5", path = "../client" }
+spl-token-metadata-interface = { version = "0.1", path = "../../token-metadata/interface" }
 spl-transfer-hook-example = { version = "0.1", path="../transfer-hook-example", features = ["no-entrypoint"] }
 spl-transfer-hook-interface = { version = "0.1", path="../transfer-hook-interface" }
 test-case = "3.1"

--- a/token/program-2022-test/tests/token_metadata_initialize.rs
+++ b/token/program-2022-test/tests/token_metadata_initialize.rs
@@ -1,0 +1,119 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+use {
+    borsh::BorshDeserialize,
+    program_test::TestContext,
+    solana_program_test::{processor, tokio, ProgramTest},
+    solana_sdk::{
+        instruction::InstructionError,
+        pubkey::Pubkey,
+        signature::Signer,
+        signer::keypair::Keypair,
+        transaction::{Transaction, TransactionError},
+        transport::TransportError,
+    },
+    spl_token_2022::{error::TokenError, extension::BaseStateWithExtensions, processor::Processor},
+    spl_token_client::token::{ExtensionInitializationParams, TokenError as TokenClientError},
+    spl_token_metadata_interface::{
+        error::TokenMetadataError,
+        state::{OptionalNonZeroPubkey, TokenMetadata},
+    },
+    std::{convert::TryInto, sync::Arc},
+};
+
+fn setup_program_test() -> ProgramTest {
+    let mut program_test = ProgramTest::default();
+    program_test.add_program(
+        "spl_token_2022",
+        spl_token_2022::id(),
+        processor!(Processor::process),
+    );
+    program_test
+}
+
+async fn setup(mint: Keypair, authority: &Pubkey) -> TestContext {
+    let program_test = setup_program_test();
+
+    let context = program_test.start_with_context().await;
+    let context = Arc::new(tokio::sync::Mutex::new(context));
+    let mut context = TestContext {
+        context,
+        token_context: None,
+    };
+    let metadata_address = Some(mint.pubkey());
+    context
+        .init_token_with_mint_keypair_and_freeze_authority(
+            mint,
+            vec![ExtensionInitializationParams::MetadataPointer {
+                authority: Some(*authority),
+                metadata_address,
+            }],
+            None,
+        )
+        .await
+        .unwrap();
+    context
+}
+
+#[tokio::test]
+async fn success_initialize() {
+    let authority = Pubkey::new_unique();
+    let mint_keypair = Keypair::new();
+    let mut test_context = setup(mint_keypair, &authority).await;
+    let payer_pubkey = test_context.context.lock().await.payer.pubkey();
+    let token_context = test_context.token_context.take().unwrap();
+
+    let update_authority = Pubkey::new_unique();
+    let name = "MyTokenNeedsMetadata".to_string();
+    let symbol = "NEEDS".to_string();
+    let uri = "my.token.needs.metadata".to_string();
+    let token_metadata = TokenMetadata {
+        name,
+        symbol,
+        uri,
+        update_authority: Some(update_authority).try_into().unwrap(),
+        mint: *token_context.token.get_address(),
+        ..Default::default()
+    };
+
+    // fails without more lamports for new rent-exemption
+    let error = token_context
+        .token
+        .initialize_token_metadata(
+            &update_authority,
+            &token_context.mint_authority.pubkey(),
+            token_metadata.name.clone(),
+            token_metadata.symbol.clone(),
+            token_metadata.uri.clone(),
+            &[&token_context.mint_authority],
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InsufficientFundsForRent { account_index: 2 }
+        )))
+    );
+
+    token_context
+        .token
+        .initialize_token_metadata_with_rent_transfer(
+            &payer_pubkey,
+            &update_authority,
+            &token_context.mint_authority.pubkey(),
+            token_metadata.name.clone(),
+            token_metadata.symbol.clone(),
+            token_metadata.uri.clone(),
+            &[&token_context.mint_authority],
+        )
+        .await
+        .unwrap();
+
+    // check that the data is correct
+    let mint_info = token_context.token.get_mint_info().await.unwrap();
+    let metadata_bytes = mint_info.get_extension_bytes::<TokenMetadata>().unwrap();
+    let fetched_metadata = TokenMetadata::try_from_slice(&metadata_bytes).unwrap();
+    assert_eq!(fetched_metadata, token_metadata);
+}

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -26,8 +26,9 @@ num_enum = "0.6.1"
 solana-program = "1.16.1"
 solana-zk-token-sdk = "1.16.1"
 spl-memo = { version = "4.0.0", path = "../../memo/program", features = [ "no-entrypoint" ] }
-spl-transfer-hook-interface = { version = "0.1.0", path = "../transfer-hook-interface" }
 spl-token = { version = "4.0",  path = "../program", features = ["no-entrypoint"] }
+spl-token-metadata-interface = { version = "0.1.0", path = "../../token-metadata/interface" }
+spl-transfer-hook-interface = { version = "0.1.0", path = "../transfer-hook-interface" }
 thiserror = "1.0"
 serde = { version = "1.0.164", optional = true }
 serde_with = { version = "2.0.0", optional = true }

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -19,6 +19,7 @@ proof-program = []
 
 [dependencies]
 arrayref = "0.3.7"
+borsh = "0.10"
 bytemuck = { version = "1.13.1", features = ["derive"] }
 num-derive = "0.4"
 num-traits = "0.2"

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -64,6 +64,8 @@ pub mod non_transferable;
 pub mod permanent_delegate;
 /// Utility to reallocate token accounts
 pub mod reallocate;
+/// Token-metadata extension
+pub mod token_metadata;
 /// Transfer Fee extension
 pub mod transfer_fee;
 /// Transfer Hook extension
@@ -855,6 +857,8 @@ pub enum ExtensionType {
     ConfidentialTransferFeeAmount,
     /// Mint contains a pointer to another account (or the same account) that holds metadata
     MetadataPointer,
+    /// Mint contains token-metadata
+    TokenMetadata,
     /// Test unsized mint extension
     #[cfg(test)]
     UnsizedMintTest = u16::MAX - 2,
@@ -886,6 +890,7 @@ impl ExtensionType {
     /// be added here by hand
     const fn sized(&self) -> bool {
         match self {
+            ExtensionType::TokenMetadata => false,
             #[cfg(test)]
             ExtensionType::UnsizedMintTest => false,
             _ => true,
@@ -927,6 +932,7 @@ impl ExtensionType {
                 pod_get_packed_len::<ConfidentialTransferFeeAmount>()
             }
             ExtensionType::MetadataPointer => pod_get_packed_len::<MetadataPointer>(),
+            ExtensionType::TokenMetadata => unreachable!(),
             #[cfg(test)]
             ExtensionType::AccountPaddingTest => pod_get_packed_len::<AccountPaddingTest>(),
             #[cfg(test)]
@@ -987,7 +993,8 @@ impl ExtensionType {
             | ExtensionType::PermanentDelegate
             | ExtensionType::TransferHook
             | ExtensionType::ConfidentialTransferFeeConfig
-            | ExtensionType::MetadataPointer => AccountType::Mint,
+            | ExtensionType::MetadataPointer
+            | ExtensionType::TokenMetadata => AccountType::Mint,
             ExtensionType::ImmutableOwner
             | ExtensionType::TransferFeeAmount
             | ExtensionType::ConfidentialTransferAccount

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -324,16 +324,16 @@ fn get_extension_bytes_mut<S: BaseState, V: Extension>(
         return Err(ProgramError::InvalidAccountData);
     }
     let TlvIndices {
-        type_start,
+        type_start: _,
         length_start,
         value_start,
     } = get_extension_indices::<V>(tlv_data, false)?;
-
-    if tlv_data[type_start..].len() < add_type_and_length_to_len(V::TYPE.try_get_type_len()?) {
-        return Err(ProgramError::InvalidAccountData);
-    }
+    // get_extension_indices has checked that tlv_data is long enough to include these indices
     let length = pod_from_bytes::<Length>(&tlv_data[length_start..value_start])?;
     let value_end = value_start.saturating_add(usize::from(*length));
+    if tlv_data.len() < value_end {
+        return Err(ProgramError::InvalidAccountData);
+    }
     Ok(&mut tlv_data[value_start..value_end])
 }
 

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -26,6 +26,7 @@ use {
     bytemuck::{Pod, Zeroable},
     num_enum::{IntoPrimitive, TryFromPrimitive},
     solana_program::{
+        account_info::AccountInfo,
         program_error::ProgramError,
         program_pack::{IsInitialized, Pack},
     },
@@ -1124,12 +1125,51 @@ impl Extension for AccountPaddingTest {
     const TYPE: ExtensionType = ExtensionType::AccountPaddingTest;
 }
 
+/// Packs an unsized extension into a new TLV space
+///
+/// This function reallocates the account as needed to accommodate for the
+/// change in space, then allocates in the TLV buffer, and finally writes the
+/// bytes.
+pub fn alloc_and_serialize<S: BaseState, V: UnsizedExtension>(
+    account_info: &AccountInfo,
+    value_bytes: &[u8],
+) -> Result<(), ProgramError> {
+    let previous_account_len = account_info.try_data_len()?;
+    let new_account_len = {
+        let data = account_info.try_borrow_data()?;
+        let state = StateWithExtensions::<S>::unpack(&data)?;
+        state.get_new_account_len::<V>(value_bytes.len())?
+    };
+
+    if previous_account_len < new_account_len {
+        // size increased, so realloc the account first
+        account_info.realloc(new_account_len, false)?;
+    }
+
+    let mut buffer = account_info.try_borrow_mut_data()?;
+    // write the account type if needed, so that the next unpack works
+    if previous_account_len <= BASE_ACCOUNT_LENGTH {
+        buffer[BASE_ACCOUNT_LENGTH] = S::ACCOUNT_TYPE.into();
+    }
+
+    // now alloc in the TLV buffer and write the data
+    let mut state = StateWithExtensionsMut::<S>::unpack(&mut buffer)?;
+    let data = state.alloc::<V>(value_bytes.len(), false)?;
+    data.copy_from_slice(value_bytes);
+    Ok(())
+}
+
 #[cfg(test)]
 mod test {
     use {
         super::*,
         crate::state::test::{TEST_ACCOUNT, TEST_ACCOUNT_SLICE, TEST_MINT, TEST_MINT_SLICE},
-        solana_program::pubkey::Pubkey,
+        solana_program::{
+            account_info::{Account as GetAccount, IntoAccountInfo},
+            clock::Epoch,
+            entrypoint::MAX_PERMITTED_DATA_INCREASE,
+            pubkey::Pubkey,
+        },
         transfer_fee::test::test_transfer_fee_config,
     };
 
@@ -2121,5 +2161,90 @@ mod test {
             .get_new_account_len::<UnsizedMintTest>(value_len)
             .unwrap();
         assert_eq!(new_len, current_len);
+    }
+
+    /// Test helper for mimicking the data layout an on-chain `AccountInfo`,
+    /// which permits "reallocs" as the Solana runtime does it
+    struct SolanaAccountData {
+        data: Vec<u8>,
+        lamports: u64,
+        owner: Pubkey,
+    }
+    impl SolanaAccountData {
+        /// Create a new fake solana account data. The underlying vector is
+        /// overallocated to mimic the runtime
+        fn new(account_data: &[u8]) -> Self {
+            let mut data = vec![];
+            data.extend_from_slice(&(account_data.len() as u64).to_le_bytes());
+            data.extend_from_slice(account_data);
+            data.extend_from_slice(&[0; MAX_PERMITTED_DATA_INCREASE]);
+            Self {
+                data,
+                lamports: 10,
+                owner: Pubkey::new_unique(),
+            }
+        }
+
+        /// Data lops off the first 8 bytes, since those store the size of the
+        /// account for the Solana runtime
+        fn data(&self) -> &[u8] {
+            let start = size_of::<u64>();
+            let len = self.len();
+            &self.data[start..start + len]
+        }
+
+        /// Gets the runtime length of the account data
+        fn len(&self) -> usize {
+            self.data
+                .get(..size_of::<u64>())
+                .and_then(|slice| slice.try_into().ok())
+                .map(u64::from_le_bytes)
+                .unwrap() as usize
+        }
+    }
+    impl GetAccount for SolanaAccountData {
+        fn get(&mut self) -> (&mut u64, &mut [u8], &Pubkey, bool, Epoch) {
+            // need to pull out the data here to avoid a double-mutable borrow
+            let start = size_of::<u64>();
+            let len = self.len();
+            (
+                &mut self.lamports,
+                &mut self.data[start..start + len],
+                &self.owner,
+                false,
+                Epoch::default(),
+            )
+        }
+    }
+    #[test]
+    fn alloc_new_tlv_in_account_info() {
+        const VALUE_LEN: usize = 10;
+        let base_account_size = Mint::LEN;
+        let mut buffer = vec![0; base_account_size];
+        let mut state = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut buffer).unwrap();
+        state.base = TEST_MINT;
+        state.pack_base();
+
+        let mut data = SolanaAccountData::new(&buffer);
+        let key = Pubkey::new_unique();
+        let account_info = (&key, &mut data).into_account_info();
+        let value_bytes = [255; VALUE_LEN];
+
+        alloc_and_serialize::<Mint, UnsizedMintTest>(&account_info, &value_bytes).unwrap();
+        let new_account_len =
+            BASE_ACCOUNT_LENGTH + size_of::<AccountType>() + add_type_and_length_to_len(VALUE_LEN);
+        assert_eq!(data.len(), new_account_len);
+        let state = StateWithExtensions::<Mint>::unpack(data.data()).unwrap();
+        assert_eq!(
+            state.get_extension_bytes::<UnsizedMintTest>().unwrap(),
+            value_bytes
+        );
+
+        // alloc again fails
+        let account_info = (&key, &mut data).into_account_info();
+        assert_eq!(
+            alloc_and_serialize::<Mint, UnsizedMintTest>(&account_info, &value_bytes).unwrap_err(),
+            TokenError::ExtensionAlreadyInitialized.into()
+        );
     }
 }

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -1159,6 +1159,51 @@ pub fn alloc_and_serialize<S: BaseState, V: UnsizedExtension>(
     Ok(())
 }
 
+/// Packs an unsized extension into an existing TLV space
+///
+/// This function reallocates the account as needed to accommodate for the
+/// change in space, then reallocates in the TLV buffer, and finally writes the
+/// bytes.
+pub fn realloc_and_serialize<S: BaseState, V: UnsizedExtension>(
+    account_info: &AccountInfo,
+    new_value_bytes: &[u8],
+) -> Result<(), ProgramError> {
+    let previous_account_len = account_info.try_data_len()?;
+    let new_value_len = new_value_bytes.len();
+    let new_account_len = {
+        let data = account_info.try_borrow_data()?;
+        let state = StateWithExtensions::<S>::unpack(&data)?;
+        state.get_new_account_len::<V>(new_value_bytes.len())?
+    };
+
+    if previous_account_len < new_account_len {
+        // account size increased, so realloc the account, then the TLV entry, then write data
+        account_info.realloc(new_account_len, true)?;
+        let mut buffer = account_info.try_borrow_mut_data()?;
+        let mut state = StateWithExtensionsMut::<S>::unpack(&mut buffer)?;
+        let data = state.realloc::<V>(new_value_len)?;
+        data.copy_from_slice(new_value_bytes);
+    } else {
+        // do it backwards otherwise, write the state, realloc TLV, then the account
+        let mut buffer = account_info.try_borrow_mut_data()?;
+        let mut state = StateWithExtensionsMut::<S>::unpack(&mut buffer)?;
+        let data = state.get_extension_bytes_mut::<V>()?;
+        data.copy_from_slice(new_value_bytes);
+
+        let removed_bytes = previous_account_len
+            .checked_sub(new_account_len)
+            .ok_or(ProgramError::AccountDataTooSmall)?;
+        if removed_bytes > 0 {
+            // we decreased the size, so need to realloc the TLV, then the account
+            state.realloc::<V>(new_value_len)?;
+            // this is probably fine, but be safe and avoid invalidating references
+            drop(buffer);
+            account_info.realloc(new_account_len, false)?;
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod test {
     use {

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -2076,4 +2076,50 @@ mod test {
             ProgramError::InvalidAccountData,
         );
     }
+
+    #[test]
+    fn account_len() {
+        let value_len = 10;
+        let account_size =
+            BASE_ACCOUNT_LENGTH + size_of::<AccountType>() + add_type_and_length_to_len(value_len);
+        let mut buffer = vec![0; account_size];
+        let mut state = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut buffer).unwrap();
+
+        // allocate for a new extension, new length must include padding, 1 byte
+        // for account type, 2 bytes for type, 2 for length
+        let current_len = state.get_account_len().unwrap();
+        assert_eq!(current_len, Mint::LEN);
+        let new_len = state
+            .get_new_account_len::<UnsizedMintTest>(value_len)
+            .unwrap();
+        assert_eq!(
+            new_len
+                .checked_sub(BASE_ACCOUNT_LENGTH)
+                .and_then(|x| x.checked_sub(size_of::<AccountType>()))
+                .unwrap(),
+            add_type_and_length_to_len(value_len)
+        );
+
+        let _ = state.alloc::<UnsizedMintTest>(value_len, false).unwrap();
+        let current_len = state.get_account_len().unwrap();
+        assert_eq!(current_len, new_len);
+
+        // reallocate to smaller
+        let new_len = state
+            .get_new_account_len::<UnsizedMintTest>(value_len - 1)
+            .unwrap();
+        assert_eq!(current_len.checked_sub(new_len).unwrap(), 1);
+
+        // reallocate to larger
+        let new_len = state
+            .get_new_account_len::<UnsizedMintTest>(value_len + 1)
+            .unwrap();
+        assert_eq!(new_len.checked_sub(current_len).unwrap(), 1);
+
+        // reallocate to same
+        let new_len = state
+            .get_new_account_len::<UnsizedMintTest>(value_len)
+            .unwrap();
+        assert_eq!(new_len, current_len);
+    }
 }

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -374,6 +374,39 @@ pub trait BaseStateWithExtensions<S: BaseState> {
             Ok(adjust_len_for_multisig(total_len))
         }
     }
+
+    /// Calculate the new expected size if the state allocates the given number
+    /// of bytes for the given extension type.
+    ///
+    /// Provides the correct answer regardless if the extension is already present
+    /// in the TLV data.
+    fn get_new_account_len<V: UnsizedExtension>(
+        &self,
+        new_extension_len: usize,
+    ) -> Result<usize, ProgramError> {
+        // get the new length used by the extension
+        let new_extension_len = add_type_and_length_to_len(new_extension_len);
+        let tlv_info = get_tlv_data_info(self.get_tlv_data())?;
+        // If we're adding an extension, then we must have at least BASE_ACCOUNT_LENGTH
+        // and account type
+        let current_len = tlv_info
+            .used_len
+            .saturating_add(BASE_ACCOUNT_LENGTH)
+            .saturating_add(size_of::<AccountType>());
+        let new_len = if tlv_info.extension_types.is_empty() {
+            current_len.saturating_add(new_extension_len)
+        } else {
+            // get the current length used by the extension
+            let current_extension_len = self
+                .get_extension_bytes::<V>()
+                .map(|x| add_type_and_length_to_len(x.len()))
+                .unwrap_or(0);
+            current_len
+                .saturating_sub(current_extension_len)
+                .saturating_add(new_extension_len)
+        };
+        Ok(adjust_len_for_multisig(new_len))
+    }
 }
 
 /// Encapsulates owned immutable base state data (mint or account) with possible extensions

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -360,6 +360,20 @@ pub trait BaseStateWithExtensions<S: BaseState> {
     fn get_first_extension_type(&self) -> Result<Option<ExtensionType>, ProgramError> {
         get_first_extension_type(self.get_tlv_data())
     }
+
+    /// Get the total number of bytes used by TLV entries and the base type
+    fn get_account_len(&self) -> Result<usize, ProgramError> {
+        let info = get_tlv_data_info(self.get_tlv_data())?;
+        if info.extension_types.is_empty() {
+            Ok(S::LEN)
+        } else {
+            let total_len = info
+                .used_len
+                .saturating_add(BASE_ACCOUNT_LENGTH)
+                .saturating_add(size_of::<AccountType>());
+            Ok(adjust_len_for_multisig(total_len))
+        }
+    }
 }
 
 /// Encapsulates owned immutable base state data (mint or account) with possible extensions

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -1178,7 +1178,7 @@ pub fn realloc_and_serialize<S: BaseState, V: UnsizedExtension>(
 
     if previous_account_len < new_account_len {
         // account size increased, so realloc the account, then the TLV entry, then write data
-        account_info.realloc(new_account_len, true)?;
+        account_info.realloc(new_account_len, false)?;
         let mut buffer = account_info.try_borrow_mut_data()?;
         let mut state = StateWithExtensionsMut::<S>::unpack(&mut buffer)?;
         let data = state.realloc::<V>(new_value_len)?;
@@ -1188,7 +1188,12 @@ pub fn realloc_and_serialize<S: BaseState, V: UnsizedExtension>(
         let mut buffer = account_info.try_borrow_mut_data()?;
         let mut state = StateWithExtensionsMut::<S>::unpack(&mut buffer)?;
         let data = state.get_extension_bytes_mut::<V>()?;
-        data.copy_from_slice(new_value_bytes);
+
+        // This check avoids a panic in the next line, but it shouldn't ever happen
+        if data.len() < new_value_len {
+            return Err(ProgramError::AccountDataTooSmall);
+        }
+        data[..new_value_len].copy_from_slice(new_value_bytes);
 
         let removed_bytes = previous_account_len
             .checked_sub(new_account_len)
@@ -2291,5 +2296,69 @@ mod test {
             alloc_and_serialize::<Mint, UnsizedMintTest>(&account_info, &value_bytes).unwrap_err(),
             TokenError::ExtensionAlreadyInitialized.into()
         );
+    }
+
+    #[test]
+    fn realloc_tlv_in_account_info() {
+        const ALLOC_SIZE: usize = 5;
+        const BIG_SIZE: usize = 10;
+        const SMALL_SIZE: usize = 2;
+        let account_size =
+            ExtensionType::try_get_account_len::<Mint>(&[ExtensionType::MetadataPointer]).unwrap()
+                + add_type_and_length_to_len(ALLOC_SIZE);
+        let mut buffer = vec![0; account_size];
+        let mut state = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut buffer).unwrap();
+        state.base = TEST_MINT;
+        state.pack_base();
+        state.init_account_type().unwrap();
+
+        // alloc both types
+        let _ = state.alloc::<UnsizedMintTest>(ALLOC_SIZE, false).unwrap();
+        let max_pubkey =
+            OptionalNonZeroPubkey::try_from(Some(Pubkey::new_from_array([255; 32]))).unwrap();
+        let extension = state.init_extension::<MetadataPointer>(false).unwrap();
+        extension.authority = max_pubkey;
+        extension.metadata_address = max_pubkey;
+
+        // reallocate to smaller, make sure existing extension is fine
+        let mut data = SolanaAccountData::new(&buffer);
+        let key = Pubkey::new_unique();
+        let account_info = (&key, &mut data).into_account_info();
+        let value_bytes = [1; SMALL_SIZE];
+        realloc_and_serialize::<Mint, UnsizedMintTest>(&account_info, &value_bytes).unwrap();
+
+        let state = StateWithExtensions::<Mint>::unpack(data.data()).unwrap();
+        let extension = state.get_extension::<MetadataPointer>().unwrap();
+        assert_eq!(extension.authority, max_pubkey);
+        assert_eq!(extension.metadata_address, max_pubkey);
+        let extension_bytes = state.get_extension_bytes::<UnsizedMintTest>().unwrap();
+        assert_eq!(extension_bytes, value_bytes);
+        assert_eq!(data.len(), state.get_account_len().unwrap());
+
+        // reallocate to larger
+        let account_info = (&key, &mut data).into_account_info();
+        let value_bytes = [2; BIG_SIZE];
+        realloc_and_serialize::<Mint, UnsizedMintTest>(&account_info, &value_bytes).unwrap();
+
+        let state = StateWithExtensions::<Mint>::unpack(data.data()).unwrap();
+        let extension = state.get_extension::<MetadataPointer>().unwrap();
+        assert_eq!(extension.authority, max_pubkey);
+        assert_eq!(extension.metadata_address, max_pubkey);
+        let extension_bytes = state.get_extension_bytes::<UnsizedMintTest>().unwrap();
+        assert_eq!(extension_bytes, value_bytes);
+        assert_eq!(data.len(), state.get_account_len().unwrap());
+
+        // reallocate to same
+        let account_info = (&key, &mut data).into_account_info();
+        let value_bytes = [3; BIG_SIZE];
+        realloc_and_serialize::<Mint, UnsizedMintTest>(&account_info, &value_bytes).unwrap();
+
+        let state = StateWithExtensions::<Mint>::unpack(data.data()).unwrap();
+        let extension = state.get_extension::<MetadataPointer>().unwrap();
+        assert_eq!(extension.authority, max_pubkey);
+        assert_eq!(extension.metadata_address, max_pubkey);
+        let extension_bytes = state.get_extension_bytes::<UnsizedMintTest>().unwrap();
+        assert_eq!(extension_bytes, value_bytes);
+        assert_eq!(data.len(), state.get_account_len().unwrap());
     }
 }

--- a/token/program-2022/src/extension/token_metadata/mod.rs
+++ b/token/program-2022/src/extension/token_metadata/mod.rs
@@ -1,0 +1,12 @@
+use {
+    crate::extension::{Extension, ExtensionType, UnsizedExtension},
+    spl_token_metadata_interface::state::TokenMetadata,
+};
+
+/// Instruction processor for the TokenMetadata extension
+pub mod processor;
+
+impl Extension for TokenMetadata {
+    const TYPE: ExtensionType = ExtensionType::TokenMetadata;
+}
+impl UnsizedExtension for TokenMetadata {}

--- a/token/program-2022/src/extension/token_metadata/processor.rs
+++ b/token/program-2022/src/extension/token_metadata/processor.rs
@@ -1,0 +1,86 @@
+//! Token-metadata processor
+
+use {
+    solana_program::{
+        account_info::AccountInfo,
+        entrypoint::ProgramResult,
+        msg,
+        pubkey::Pubkey,
+    },
+    spl_token_metadata_interface::{
+        instruction::{
+            Emit, Initialize, RemoveKey, TokenMetadataInstruction, UpdateAuthority, UpdateField,
+        },
+    },
+};
+
+/// Processes a [Initialize](enum.TokenMetadataInstruction.html) instruction.
+pub fn process_initialize(
+    _program_id: &Pubkey,
+    _accounts: &[AccountInfo],
+    _data: Initialize,
+) -> ProgramResult {
+    Ok(())
+}
+
+/// Processes an [UpdateField](enum.TokenMetadataInstruction.html) instruction.
+pub fn process_update_field(
+    _program_id: &Pubkey,
+    _accounts: &[AccountInfo],
+    _data: UpdateField,
+) -> ProgramResult {
+    Ok(())
+}
+
+/// Processes a [RemoveKey](enum.TokenMetadataInstruction.html) instruction.
+pub fn process_remove_key(
+    _program_id: &Pubkey,
+    _accounts: &[AccountInfo],
+    _data: RemoveKey,
+) -> ProgramResult {
+    Ok(())
+}
+
+/// Processes a [UpdateAuthority](enum.TokenMetadataInstruction.html) instruction.
+pub fn process_update_authority(
+    _program_id: &Pubkey,
+    _accounts: &[AccountInfo],
+    _data: UpdateAuthority,
+) -> ProgramResult {
+    Ok(())
+}
+
+/// Processes an [Emit](enum.TokenMetadataInstruction.html) instruction.
+pub fn process_emit(_program_id: &Pubkey, _accounts: &[AccountInfo], _data: Emit) -> ProgramResult {
+    Ok(())
+}
+
+/// Processes an [Instruction](enum.Instruction.html).
+pub fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction: TokenMetadataInstruction,
+) -> ProgramResult {
+    match instruction {
+        TokenMetadataInstruction::Initialize(data) => {
+            msg!("TokenMetadataInstruction: Initialize");
+            process_initialize(program_id, accounts, data)
+        }
+        TokenMetadataInstruction::UpdateField(data) => {
+            msg!("TokenMetadataInstruction: UpdateField");
+            process_update_field(program_id, accounts, data)
+        }
+        TokenMetadataInstruction::RemoveKey(data) => {
+            msg!("TokenMetadataInstruction: RemoveKey");
+            process_remove_key(program_id, accounts, data)
+        }
+        TokenMetadataInstruction::UpdateAuthority(data) => {
+            msg!("TokenMetadataInstruction: UpdateAuthority");
+            process_update_authority(program_id, accounts, data)
+        }
+        TokenMetadataInstruction::Emit(data) => {
+            msg!("TokenMetadataInstruction: Emit");
+            process_emit(program_id, accounts, data)
+        }
+    }
+}

--- a/token/program-2022/src/extension/token_metadata/processor.rs
+++ b/token/program-2022/src/extension/token_metadata/processor.rs
@@ -1,25 +1,80 @@
 //! Token-metadata processor
 
 use {
+    crate::{
+        check_program_account,
+        error::TokenError,
+        extension::{alloc_and_serialize, StateWithExtensions},
+        state::Mint,
+    },
+    borsh::BorshSerialize,
     solana_program::{
-        account_info::AccountInfo,
+        account_info::{next_account_info, AccountInfo},
         entrypoint::ProgramResult,
         msg,
+        program_error::ProgramError,
+        program_option::COption,
         pubkey::Pubkey,
     },
     spl_token_metadata_interface::{
+        error::TokenMetadataError,
         instruction::{
             Emit, Initialize, RemoveKey, TokenMetadataInstruction, UpdateAuthority, UpdateField,
         },
+        state::{OptionalNonZeroPubkey, TokenMetadata},
     },
 };
 
 /// Processes a [Initialize](enum.TokenMetadataInstruction.html) instruction.
 pub fn process_initialize(
     _program_id: &Pubkey,
-    _accounts: &[AccountInfo],
-    _data: Initialize,
+    accounts: &[AccountInfo],
+    data: Initialize,
 ) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    let metadata_info = next_account_info(account_info_iter)?;
+    let update_authority_info = next_account_info(account_info_iter)?;
+    let mint_info = next_account_info(account_info_iter)?;
+    let mint_authority_info = next_account_info(account_info_iter)?;
+
+    // check that the mint and metadata accounts are the same, since the metadata
+    // extension should only describe itself
+    if metadata_info.key != mint_info.key {
+        msg!("Metadata for a mint must be initialized in the mint itself.");
+        return Err(TokenError::MintMismatch.into());
+    }
+
+    // scope the mint authority check, since the mint is in the same account!
+    {
+        check_program_account(mint_info.owner)?;
+        let mint_data = mint_info.try_borrow_data()?;
+        let mint = StateWithExtensions::<Mint>::unpack(&mint_data)?;
+
+        if !mint_authority_info.is_signer {
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+        if mint.base.mint_authority.as_ref() != COption::Some(mint_authority_info.key) {
+            return Err(TokenMetadataError::IncorrectMintAuthority.into());
+        }
+    }
+
+    // Create the token metadata
+    let update_authority = OptionalNonZeroPubkey::try_from(Some(*update_authority_info.key))?;
+    let token_metadata = TokenMetadata {
+        name: data.name,
+        symbol: data.symbol,
+        uri: data.uri,
+        update_authority,
+        mint: *mint_info.key,
+        ..Default::default()
+    };
+
+    // allocate a TLV entry for the space and write it in, assumes that there's
+    // enough SOL for the new rent-exemption
+    let token_metadata_bytes = token_metadata.try_to_vec()?;
+    alloc_and_serialize::<Mint, TokenMetadata>(metadata_info, &token_metadata_bytes).unwrap();
+
     Ok(())
 }
 

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -18,7 +18,7 @@ use {
             mint_close_authority::MintCloseAuthority,
             non_transferable::{NonTransferable, NonTransferableAccount},
             permanent_delegate::{get_permanent_delegate, PermanentDelegate},
-            reallocate,
+            reallocate, token_metadata,
             transfer_fee::{self, TransferFeeAmount, TransferFeeConfig},
             transfer_hook::{self, TransferHook, TransferHookAccount},
             BaseStateWithExtensions, ExtensionType, StateWithExtensions, StateWithExtensionsMut,
@@ -40,6 +40,7 @@ use {
         system_instruction, system_program,
         sysvar::{rent::Rent, Sysvar},
     },
+    spl_token_metadata_interface::instruction::TokenMetadataInstruction,
     std::convert::{TryFrom, TryInto},
 };
 
@@ -1457,8 +1458,15 @@ impl Processor {
 
     /// Processes an [Instruction](enum.Instruction.html).
     pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> ProgramResult {
-        let instruction = TokenInstruction::unpack(input)?;
+        if let Ok(instruction) = TokenMetadataInstruction::unpack(input) {
+            return token_metadata::processor::process_instruction(
+                program_id,
+                accounts,
+                instruction,
+            );
+        }
 
+        let instruction = TokenInstruction::unpack(input)?;
         match instruction {
             TokenInstruction::InitializeMint {
                 decimals,


### PR DESCRIPTION
To showcase how #4661 will work, here are some sample implementations for `initialize` in 3591ce52e395ed577f5d757f7ee7e0fed9c7fb0e and `update` in 967d1ac0a1b4b87ef7cbeefae23ec0ee9bf77d5d token-metadata.

You can also see the required client code at 4366ebed0158d66ea7ecdbae1f20d7297c1d2b73 and a test at b7fe62437bc4eea8e649bd92a37c5c6e6f1948bf

They're a bit messier than the example token-metadata program, which uses a different TLV library, but here they are for reference:

* initialize: https://github.com/solana-labs/solana-program-library/blob/8869fb8757cfb9c75141f02d56dd4056fdc3938d/token-metadata/example/src/processor.rs#L73-L87
* update: https://github.com/solana-labs/solana-program-library/blob/8869fb8757cfb9c75141f02d56dd4056fdc3938d/token-metadata/example/src/processor.rs#L104-L116

They mainly look different because the other TLV library has some neat borsh helpers. When I wrote #4661, I was in a bad mood with borsh, so I didn't add those helpers. Maybe we add those in #4661 to make it neater and harder to mess up?