### PR TITLE
single-pool: fix default deposit helper

### DIFF
--- a/stake-pool/single-pool/src/instruction.rs
+++ b/stake-pool/single-pool/src/instruction.rs
@@ -329,6 +329,7 @@ pub fn withdraw_stake(
 /// Uses a fixed address for each wallet and vote account combination to make it easier to find for deposits.
 /// This is an optional helper function; deposits can come from any owned stake account without lockup.
 pub fn create_and_delegate_user_stake(
+    vote_account_address: &Pubkey,
     pool_address: &Pubkey,
     user_wallet: &Pubkey,
     rent: &Rent,
@@ -346,7 +347,7 @@ pub fn create_and_delegate_user_stake(
         &deposit_address,
         user_wallet,
         &deposit_seed,
-        pool_address,
+        vote_account_address,
         &stake::state::Authorized::auto(user_wallet),
         &stake::state::Lockup::default(),
         lamports,

--- a/stake-pool/single-pool/tests/deposit.rs
+++ b/stake-pool/single-pool/tests/deposit.rs
@@ -169,13 +169,12 @@ async fn success_with_seed(activate: bool) {
     let accounts = SinglePoolAccounts::default();
     let rent = context.banks_client.get_rent().await.unwrap();
     let minimum_stake = accounts.initialize(&mut context).await;
-    let alice_default_stake = find_default_deposit_account_address(
-        &accounts.vote_account.pubkey(),
-        &accounts.alice.pubkey(),
-    );
+    let alice_default_stake =
+        find_default_deposit_account_address(&accounts.pool, &accounts.alice.pubkey());
 
     let instructions = instruction::create_and_delegate_user_stake(
         &accounts.vote_account.pubkey(),
+        &accounts.pool,
         &accounts.alice.pubkey(),
         &rent,
         minimum_stake,


### PR DESCRIPTION
this fixes the default deposit address helper once and for all, discovered while testing the cli. the issue here was a) we want the address seeded from the pool for regularity, b) the stake program needs the vote account to delegate to, not the address used in the seed, and c) i was accidentally passing in the vote account in tests so this mistake in the interface went undetected 

this should be the final 1.0 commit to the program. note this doesnt affect anything except an instruction helper