### PR TITLE
TLV: Add `VariableLenPack` trait to remove borsh dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7141,7 +7141,6 @@ dependencies = [
 name = "spl-type-length-value"
 version = "0.2.0"
 dependencies = [
- "borsh 0.10.3",
  "bytemuck",
  "solana-program",
  "spl-discriminator",

--- a/libraries/type-length-value/Cargo.toml
+++ b/libraries/type-length-value/Cargo.toml
@@ -8,11 +8,7 @@ license = "Apache-2.0"
 edition = "2021"
 exclude = ["js/**"]
 
-[features]
-borsh = ["dep:borsh"]
-
 [dependencies]
-borsh = { version = "0.10", optional = true }
 bytemuck = { version = "1.13.1", features = ["derive"] }
 solana-program = "1.16.1"
 spl-discriminator = { version = "0.1.0", path = "../discriminator" }

--- a/libraries/type-length-value/src/lib.rs
+++ b/libraries/type-length-value/src/lib.rs
@@ -9,7 +9,7 @@ pub mod error;
 pub mod length;
 pub mod pod;
 pub mod state;
-pub mod unsized_pack;
+pub mod variable_len_pack;
 
 // Export current sdk types for downstream users building with a different sdk version
 pub use solana_program;

--- a/libraries/type-length-value/src/lib.rs
+++ b/libraries/type-length-value/src/lib.rs
@@ -9,6 +9,7 @@ pub mod error;
 pub mod length;
 pub mod pod;
 pub mod state;
+pub mod unsized_pack;
 
 // Export current sdk types for downstream users building with a different sdk version
 pub use solana_program;

--- a/libraries/type-length-value/src/state.rs
+++ b/libraries/type-length-value/src/state.rs
@@ -320,7 +320,7 @@ impl<'data> TlvStateMut<'data> {
     ) -> Result<(), ProgramError> {
         let data = self.get_bytes_mut::<V>()?;
         // NOTE: Do *not* use `pack`, since the length check will cause
-        // reallocations to smaller sizes fail
+        // reallocations to smaller sizes to fail
         value.pack_into_slice(data)
     }
 

--- a/libraries/type-length-value/src/state.rs
+++ b/libraries/type-length-value/src/state.rs
@@ -5,9 +5,10 @@ use {
         error::TlvError,
         length::Length,
         pod::{pod_from_bytes, pod_from_bytes_mut},
+        unsized_pack::UnsizedPack,
     },
     bytemuck::Pod,
-    solana_program::program_error::ProgramError,
+    solana_program::{account_info::AccountInfo, program_error::ProgramError},
     spl_discriminator::{ArrayDiscriminator, SplDiscriminate},
     std::{cmp::Ordering, mem::size_of},
 };
@@ -196,13 +197,10 @@ pub trait TlvState {
         pod_from_bytes::<V>(data)
     }
 
-    /// Unpacks a portion of the TLV data as the desired Borsh type
-    #[cfg(feature = "borsh")]
-    fn borsh_deserialize<V: SplDiscriminate + borsh::BorshDeserialize>(
-        &self,
-    ) -> Result<V, ProgramError> {
+    /// Unpacks a portion of the TLV data as the desired unsized type
+    fn get_unsized_value<V: SplDiscriminate + UnsizedPack>(&self) -> Result<V, ProgramError> {
         let data = get_bytes::<V>(self.get_data())?;
-        solana_program::borsh::try_from_slice_unchecked::<V>(data).map_err(Into::into)
+        V::unpack_from_slice(data)
     }
 
     /// Unpack a portion of the TLV data as bytes
@@ -312,15 +310,16 @@ impl<'data> TlvStateMut<'data> {
         Ok(extension_ref)
     }
 
-    /// Packs a borsh-serializable value into its appropriate data segment. Assumes
-    /// that space has already been allocated for the given type
-    #[cfg(feature = "borsh")]
-    pub fn borsh_serialize<V: SplDiscriminate + borsh::BorshSerialize>(
+    /// Packs an unsized value into its appropriate data segment. Assumes that
+    /// space has already been allocated for the given type
+    pub fn pack_unsized_value<V: SplDiscriminate + UnsizedPack>(
         &mut self,
         value: &V,
     ) -> Result<(), ProgramError> {
         let data = self.get_bytes_mut::<V>()?;
-        borsh::to_writer(&mut data[..], value).map_err(Into::into)
+        // NOTE: Do *not* use `pack`, since the length check will cause
+        // reallocations to smaller sizes fail
+        value.pack_into_slice(data)
     }
 
     /// Allocate the given number of bytes for the given SplDiscriminate
@@ -408,11 +407,10 @@ impl<'a> TlvState for TlvStateMut<'a> {
     }
 }
 
-/// Packs a borsh-serializable value into an existing TLV space, reallocating
+/// Packs an unsized value into an existing TLV space, reallocating
 /// the account and TLV as needed to accommodate for any change in space
-#[cfg(feature = "borsh")]
-pub fn realloc_and_borsh_serialize<V: SplDiscriminate + borsh::BorshSerialize>(
-    account_info: &solana_program::account_info::AccountInfo,
+pub fn realloc_and_pack_unsized<V: SplDiscriminate + UnsizedPack>(
+    account_info: &AccountInfo,
     value: &V,
 ) -> Result<(), ProgramError> {
     let previous_length = {
@@ -424,7 +422,7 @@ pub fn realloc_and_borsh_serialize<V: SplDiscriminate + borsh::BorshSerialize>(
         } = get_indices(&data, V::SPL_DISCRIMINATOR, false)?;
         usize::try_from(*pod_from_bytes::<Length>(&data[length_start..value_start])?)?
     };
-    let new_length = solana_program::borsh::get_instance_packed_len(&value)?;
+    let new_length = value.get_packed_len()?;
     let previous_account_size = account_info.try_data_len()?;
     if previous_length < new_length {
         // size increased, so realloc the account, then the TLV entry, then write data
@@ -435,12 +433,12 @@ pub fn realloc_and_borsh_serialize<V: SplDiscriminate + borsh::BorshSerialize>(
         let mut buffer = account_info.try_borrow_mut_data()?;
         let mut state = TlvStateMut::unpack(&mut buffer)?;
         state.realloc::<V>(new_length)?;
-        state.borsh_serialize(value)?;
+        state.pack_unsized_value(value)?;
     } else {
         // do it backwards otherwise, write the state, realloc TLV, then the account
         let mut buffer = account_info.try_borrow_mut_data()?;
         let mut state = TlvStateMut::unpack(&mut buffer)?;
-        state.borsh_serialize(value)?;
+        state.pack_unsized_value(value)?;
         let removed_bytes = previous_length
             .checked_sub(new_length)
             .ok_or(ProgramError::AccountDataTooSmall)?;
@@ -891,57 +889,60 @@ mod test {
             ProgramError::InvalidAccountData,
         );
     }
-}
-#[cfg(all(test, feature = "borsh"))]
-mod borsh_test {
-    use super::*;
-    #[derive(Clone, Debug, PartialEq, borsh::BorshDeserialize, borsh::BorshSerialize)]
-    struct TestBorsh {
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct TestUnsized {
         data: String, // test with a variable length type
-        inner: TestInnerBorsh,
     }
-    #[derive(Clone, Debug, PartialEq, borsh::BorshDeserialize, borsh::BorshSerialize)]
-    struct TestInnerBorsh {
-        data: String,
-    }
-    impl SplDiscriminate for TestBorsh {
+    impl SplDiscriminate for TestUnsized {
         const SPL_DISCRIMINATOR: ArrayDiscriminator =
             ArrayDiscriminator::new([5; ArrayDiscriminator::LENGTH]);
     }
+    impl UnsizedPack for TestUnsized {
+        fn pack_into_slice(&self, dst: &mut [u8]) -> Result<(), ProgramError> {
+            dst[..8].copy_from_slice(&self.data.len().to_le_bytes());
+            dst[8..].copy_from_slice(self.data.as_bytes());
+            Ok(())
+        }
+        fn unpack_from_slice(src: &[u8]) -> Result<Self, ProgramError> {
+            let length = u64::from_le_bytes(src[..8].try_into().unwrap());
+            if src[8..].len() != length as usize {
+                return Err(ProgramError::InvalidAccountData);
+            }
+            let data = std::str::from_utf8(&src[8..]).unwrap().to_string();
+            Ok(Self { data })
+        }
+        fn get_packed_len(&self) -> Result<usize, ProgramError> {
+            Ok(size_of::<u64>().saturating_add(self.data.len()))
+        }
+    }
     #[test]
-    fn borsh_value() {
+    fn unsized_value() {
         let initial_data = "This is a pretty cool test!";
-        let initial_inner_data = "And it gets even cooler!";
         // exactly the right size
-        let tlv_size = 4 + initial_data.len() + 4 + initial_inner_data.len();
+        let tlv_size = 8 + initial_data.len();
         let account_size = get_base_len() + tlv_size;
         let mut buffer = vec![0; account_size];
         let mut state = TlvStateMut::unpack(&mut buffer).unwrap();
 
         // don't actually need to hold onto the data!
-        let _ = state.alloc::<TestBorsh>(tlv_size).unwrap();
-        let test_borsh = TestBorsh {
+        let _ = state.alloc::<TestUnsized>(tlv_size).unwrap();
+        let test_unsized = TestUnsized {
             data: initial_data.to_string(),
-            inner: TestInnerBorsh {
-                data: initial_inner_data.to_string(),
-            },
         };
-        state.borsh_serialize(&test_borsh).unwrap();
-        let deser = state.borsh_deserialize::<TestBorsh>().unwrap();
-        assert_eq!(deser, test_borsh);
+        state.pack_unsized_value(&test_unsized).unwrap();
+        let deser = state.get_unsized_value::<TestUnsized>().unwrap();
+        assert_eq!(deser, test_unsized);
 
         // writing too much data fails
         let too_much_data = "This is a pretty cool test!?";
         assert_eq!(
             state
-                .borsh_serialize(&TestBorsh {
+                .pack_unsized_value(&TestUnsized {
                     data: too_much_data.to_string(),
-                    inner: TestInnerBorsh {
-                        data: initial_inner_data.to_string(),
-                    }
                 })
                 .unwrap_err(),
-            ProgramError::BorshIoError("failed to write whole buffer".to_string()),
+            ProgramError::InvalidAccountData
         );
     }
 }

--- a/libraries/type-length-value/src/unsized_pack.rs
+++ b/libraries/type-length-value/src/unsized_pack.rs
@@ -1,0 +1,29 @@
+//! The [`UnsizedPack`] serialization trait.
+
+use solana_program::program_error::ProgramError;
+
+/// Trait that mimics a lot of the functionality of `solana_program::program_pack::Pack`
+/// but specifically works for variable-size types.
+pub trait UnsizedPack {
+    /// Writes the serialized form of the instance into the given slice
+    fn pack_into_slice(&self, dst: &mut [u8]) -> Result<(), ProgramError>;
+
+    /// Deserializes the type from the given slice
+    // The `Result` enum wrapping this requires that `Self` be sized. Maybe we
+    // can do something more clever here?
+    fn unpack_from_slice(src: &[u8]) -> Result<Self, ProgramError>
+    where
+        Self: Sized;
+
+    /// Gets the packed length for a given instance of the type
+    fn get_packed_len(&self) -> Result<usize, ProgramError>;
+
+    /// Safely write the contents to the type into the given slice
+    fn pack(&self, dst: &mut [u8]) -> Result<(), ProgramError> {
+        if dst.len() != self.get_packed_len()? {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        self.pack_into_slice(dst)?;
+        Ok(())
+    }
+}

--- a/libraries/type-length-value/src/variable_len_pack.rs
+++ b/libraries/type-length-value/src/variable_len_pack.rs
@@ -1,16 +1,14 @@
-//! The [`UnsizedPack`] serialization trait.
+//! The [`VariableLenPack`] serialization trait.
 
 use solana_program::program_error::ProgramError;
 
 /// Trait that mimics a lot of the functionality of `solana_program::program_pack::Pack`
 /// but specifically works for variable-size types.
-pub trait UnsizedPack {
+pub trait VariableLenPack {
     /// Writes the serialized form of the instance into the given slice
     fn pack_into_slice(&self, dst: &mut [u8]) -> Result<(), ProgramError>;
 
     /// Deserializes the type from the given slice
-    // The `Result` enum wrapping this requires that `Self` be sized. Maybe we
-    // can do something more clever here?
     fn unpack_from_slice(src: &[u8]) -> Result<Self, ProgramError>
     where
         Self: Sized;
@@ -23,7 +21,6 @@ pub trait UnsizedPack {
         if dst.len() != self.get_packed_len()? {
             return Err(ProgramError::InvalidAccountData);
         }
-        self.pack_into_slice(dst)?;
-        Ok(())
+        self.pack_into_slice(dst)
     }
 }

--- a/token-metadata/example/Cargo.toml
+++ b/token-metadata/example/Cargo.toml
@@ -15,7 +15,7 @@ test-sbf = []
 solana-program = "1.16.1"
 spl-token-2022 = { version = "0.7", path = "../../token/program-2022" }
 spl-token-metadata-interface = { version = "0.1.0", path = "../interface" }
-spl-type-length-value = { version = "0.2.0" , path = "../../libraries/type-length-value", features = ["borsh"] }
+spl-type-length-value = { version = "0.2.0" , path = "../../libraries/type-length-value" }
 
 [dev-dependencies]
 solana-program-test = "1.16.1"

--- a/token-metadata/example/src/processor.rs
+++ b/token-metadata/example/src/processor.rs
@@ -20,7 +20,7 @@ use {
         state::{OptionalNonZeroPubkey, TokenMetadata},
     },
     spl_type_length_value::state::{
-        realloc_and_borsh_serialize, TlvState, TlvStateBorrowed, TlvStateMut,
+        realloc_and_pack_unsized, TlvState, TlvStateBorrowed, TlvStateMut,
     },
 };
 
@@ -84,7 +84,7 @@ pub fn process_initialize(
     let mut buffer = metadata_info.try_borrow_mut_data()?;
     let mut state = TlvStateMut::unpack(&mut buffer)?;
     state.alloc::<TokenMetadata>(instance_size)?;
-    state.borsh_serialize(&token_metadata)?;
+    state.pack_unsized_value(&token_metadata)?;
 
     Ok(())
 }
@@ -104,7 +104,7 @@ pub fn process_update_field(
     let mut token_metadata = {
         let buffer = metadata_info.try_borrow_data()?;
         let state = TlvStateBorrowed::unpack(&buffer)?;
-        state.borsh_deserialize::<TokenMetadata>()?
+        state.get_unsized_value::<TokenMetadata>()?
     };
 
     check_update_authority(update_authority_info, &token_metadata.update_authority)?;
@@ -113,7 +113,7 @@ pub fn process_update_field(
     token_metadata.update(data.field, data.value);
 
     // Update / realloc the account
-    realloc_and_borsh_serialize(metadata_info, &token_metadata)?;
+    realloc_and_pack_unsized(metadata_info, &token_metadata)?;
 
     Ok(())
 }
@@ -133,14 +133,14 @@ pub fn process_remove_key(
     let mut token_metadata = {
         let buffer = metadata_info.try_borrow_data()?;
         let state = TlvStateBorrowed::unpack(&buffer)?;
-        state.borsh_deserialize::<TokenMetadata>()?
+        state.get_unsized_value::<TokenMetadata>()?
     };
 
     check_update_authority(update_authority_info, &token_metadata.update_authority)?;
     if !token_metadata.remove_key(&data.key) && !data.idempotent {
         return Err(TokenMetadataError::KeyNotFound.into());
     }
-    realloc_and_borsh_serialize(metadata_info, &token_metadata)?;
+    realloc_and_pack_unsized(metadata_info, &token_metadata)?;
 
     Ok(())
 }
@@ -160,13 +160,13 @@ pub fn process_update_authority(
     let mut token_metadata = {
         let buffer = metadata_info.try_borrow_data()?;
         let state = TlvStateBorrowed::unpack(&buffer)?;
-        state.borsh_deserialize::<TokenMetadata>()?
+        state.get_unsized_value::<TokenMetadata>()?
     };
 
     check_update_authority(update_authority_info, &token_metadata.update_authority)?;
     token_metadata.update_authority = data.new_authority;
     // Update the account, no realloc needed!
-    realloc_and_borsh_serialize(metadata_info, &token_metadata)?;
+    realloc_and_pack_unsized(metadata_info, &token_metadata)?;
 
     Ok(())
 }

--- a/token-metadata/example/tests/initialize.rs
+++ b/token-metadata/example/tests/initialize.rs
@@ -76,7 +76,7 @@ async fn success_initialize() {
         .unwrap();
     let fetched_metadata_state = TlvStateBorrowed::unpack(&fetched_metadata_account.data).unwrap();
     let fetched_metadata = fetched_metadata_state
-        .borsh_deserialize::<TokenMetadata>()
+        .get_unsized_value::<TokenMetadata>()
         .unwrap();
     assert_eq!(fetched_metadata, token_metadata);
 

--- a/token-metadata/example/tests/initialize.rs
+++ b/token-metadata/example/tests/initialize.rs
@@ -76,7 +76,7 @@ async fn success_initialize() {
         .unwrap();
     let fetched_metadata_state = TlvStateBorrowed::unpack(&fetched_metadata_account.data).unwrap();
     let fetched_metadata = fetched_metadata_state
-        .get_unsized_value::<TokenMetadata>()
+        .get_variable_len_value::<TokenMetadata>()
         .unwrap();
     assert_eq!(fetched_metadata, token_metadata);
 

--- a/token-metadata/example/tests/remove_key.rs
+++ b/token-metadata/example/tests/remove_key.rs
@@ -111,7 +111,7 @@ async fn success_remove() {
     );
     let fetched_metadata_state = TlvStateBorrowed::unpack(&fetched_metadata_account.data).unwrap();
     let fetched_metadata = fetched_metadata_state
-        .borsh_deserialize::<TokenMetadata>()
+        .get_unsized_value::<TokenMetadata>()
         .unwrap();
     assert_eq!(fetched_metadata, token_metadata);
 

--- a/token-metadata/example/tests/remove_key.rs
+++ b/token-metadata/example/tests/remove_key.rs
@@ -111,7 +111,7 @@ async fn success_remove() {
     );
     let fetched_metadata_state = TlvStateBorrowed::unpack(&fetched_metadata_account.data).unwrap();
     let fetched_metadata = fetched_metadata_state
-        .get_unsized_value::<TokenMetadata>()
+        .get_variable_len_value::<TokenMetadata>()
         .unwrap();
     assert_eq!(fetched_metadata, token_metadata);
 

--- a/token-metadata/example/tests/update_authority.rs
+++ b/token-metadata/example/tests/update_authority.rs
@@ -100,7 +100,7 @@ async fn success_update() {
     );
     let fetched_metadata_state = TlvStateBorrowed::unpack(&fetched_metadata_account.data).unwrap();
     let fetched_metadata = fetched_metadata_state
-        .borsh_deserialize::<TokenMetadata>()
+        .get_unsized_value::<TokenMetadata>()
         .unwrap();
     assert_eq!(fetched_metadata, token_metadata);
 
@@ -135,7 +135,7 @@ async fn success_update() {
     );
     let fetched_metadata_state = TlvStateBorrowed::unpack(&fetched_metadata_account.data).unwrap();
     let fetched_metadata = fetched_metadata_state
-        .borsh_deserialize::<TokenMetadata>()
+        .get_unsized_value::<TokenMetadata>()
         .unwrap();
     assert_eq!(fetched_metadata, token_metadata);
 

--- a/token-metadata/example/tests/update_authority.rs
+++ b/token-metadata/example/tests/update_authority.rs
@@ -100,7 +100,7 @@ async fn success_update() {
     );
     let fetched_metadata_state = TlvStateBorrowed::unpack(&fetched_metadata_account.data).unwrap();
     let fetched_metadata = fetched_metadata_state
-        .get_unsized_value::<TokenMetadata>()
+        .get_variable_len_value::<TokenMetadata>()
         .unwrap();
     assert_eq!(fetched_metadata, token_metadata);
 
@@ -135,7 +135,7 @@ async fn success_update() {
     );
     let fetched_metadata_state = TlvStateBorrowed::unpack(&fetched_metadata_account.data).unwrap();
     let fetched_metadata = fetched_metadata_state
-        .get_unsized_value::<TokenMetadata>()
+        .get_variable_len_value::<TokenMetadata>()
         .unwrap();
     assert_eq!(fetched_metadata, token_metadata);
 

--- a/token-metadata/example/tests/update_field.rs
+++ b/token-metadata/example/tests/update_field.rs
@@ -144,7 +144,7 @@ async fn success_update(field: Field, value: String) {
     );
     let fetched_metadata_state = TlvStateBorrowed::unpack(&fetched_metadata_account.data).unwrap();
     let fetched_metadata = fetched_metadata_state
-        .borsh_deserialize::<TokenMetadata>()
+        .get_unsized_value::<TokenMetadata>()
         .unwrap();
     assert_eq!(fetched_metadata, token_metadata);
 }

--- a/token-metadata/example/tests/update_field.rs
+++ b/token-metadata/example/tests/update_field.rs
@@ -144,7 +144,7 @@ async fn success_update(field: Field, value: String) {
     );
     let fetched_metadata_state = TlvStateBorrowed::unpack(&fetched_metadata_account.data).unwrap();
     let fetched_metadata = fetched_metadata_state
-        .get_unsized_value::<TokenMetadata>()
+        .get_variable_len_value::<TokenMetadata>()
         .unwrap();
     assert_eq!(fetched_metadata, token_metadata);
 }

--- a/token-metadata/interface/Cargo.toml
+++ b/token-metadata/interface/Cargo.toml
@@ -12,7 +12,7 @@ borsh = "0.10"
 solana-program = "1.16.1"
 spl-discriminator = { version = "0.1.0" , path = "../../libraries/discriminator" }
 spl-program-error = { version = "0.2.0" , path = "../../libraries/program-error" }
-spl-type-length-value = { version = "0.2.0", features = ["borsh"], path = "../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.2.0", path = "../../libraries/type-length-value" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/token-metadata/interface/src/state.rs
+++ b/token-metadata/interface/src/state.rs
@@ -10,7 +10,7 @@ use {
     spl_discriminator::{ArrayDiscriminator, SplDiscriminate},
     spl_type_length_value::{
         state::{TlvState, TlvStateBorrowed},
-        unsized_pack::UnsizedPack,
+        variable_len_pack::VariableLenPack,
     },
     std::convert::TryFrom,
 };
@@ -124,7 +124,7 @@ impl TokenMetadata {
         data.get(start..end)
     }
 }
-impl UnsizedPack for TokenMetadata {
+impl VariableLenPack for TokenMetadata {
     fn pack_into_slice(&self, dst: &mut [u8]) -> Result<(), ProgramError> {
         borsh::to_writer(&mut dst[..], self).map_err(Into::into)
     }

--- a/token-metadata/interface/src/state.rs
+++ b/token-metadata/interface/src/state.rs
@@ -2,9 +2,16 @@
 
 use {
     borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
-    solana_program::{borsh::get_instance_packed_len, program_error::ProgramError, pubkey::Pubkey},
+    solana_program::{
+        borsh::{get_instance_packed_len, try_from_slice_unchecked},
+        program_error::ProgramError,
+        pubkey::Pubkey,
+    },
     spl_discriminator::{ArrayDiscriminator, SplDiscriminate},
-    spl_type_length_value::state::{TlvState, TlvStateBorrowed},
+    spl_type_length_value::{
+        state::{TlvState, TlvStateBorrowed},
+        unsized_pack::UnsizedPack,
+    },
     std::convert::TryFrom,
 };
 
@@ -115,6 +122,17 @@ impl TokenMetadata {
         let start = start.unwrap_or(0) as usize;
         let end = end.map(|x| x as usize).unwrap_or(data.len());
         data.get(start..end)
+    }
+}
+impl UnsizedPack for TokenMetadata {
+    fn pack_into_slice(&self, dst: &mut [u8]) -> Result<(), ProgramError> {
+        borsh::to_writer(&mut dst[..], self).map_err(Into::into)
+    }
+    fn unpack_from_slice(src: &[u8]) -> Result<Self, ProgramError> {
+        try_from_slice_unchecked(src).map_err(Into::into)
+    }
+    fn get_packed_len(&self) -> Result<usize, ProgramError> {
+        get_instance_packed_len(self).map_err(Into::into)
     }
 }
 


### PR DESCRIPTION
#### Problem

As mentioned in #4719 and https://github.com/solana-labs/solana-program-library/pull/4661#discussion_r1254769560, the approach of using borsh directly has some issues, and it'll be better to go through another trait.

#### Solution

Implement the `UnsizedPack` trait, remove borsh, and use it in the token-metadata interface / example. The first commit is entirely in the TLV library, and the second is just how it's used in the token-metadata program.

I have to say, this felt very good. This removes the borsh dependency *and* the feature, which makes the TLV library much neater. 

Fixes #4719