### PR TITLE
[token-2022] Update confidential transfer withdraw for Solana 1.16

### DIFF
--- a/token/program-2022/src/error.rs
+++ b/token/program-2022/src/error.rs
@@ -207,6 +207,9 @@ pub enum TokenError {
     /// Failed to decrypt a confidential transfer account
     #[error("Failed to decrypt a confidential transfer account")]
     AccountDecryption,
+    /// Failed to generate a zero-knowledge proof needed for a token instruction
+    #[error("Failed to generate proof")]
+    ProofGeneration,
 }
 impl From<TokenError> for ProgramError {
     fn from(e: TokenError) -> Self {
@@ -360,6 +363,9 @@ impl PrintProgramError for TokenError {
             }
             TokenError::AccountDecryption => {
                 msg!("Failed to decrypt a confidential transfer account")
+            }
+            TokenError::ProofGeneration => {
+                msg!("Failed to generate proof")
             }
         }
     }

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -702,7 +702,6 @@ pub fn inner_withdraw(
 /// Create a `Withdraw` instruction
 #[allow(clippy::too_many_arguments)]
 #[cfg(not(target_os = "solana"))]
-#[cfg(feature = "proof-program")]
 pub fn withdraw(
     token_program_id: &Pubkey,
     token_account: &Pubkey,
@@ -726,8 +725,7 @@ pub fn withdraw(
             multisig_signers,
             1,
         )?, // calls check_program_account
-        #[cfg(feature = "proof-program")]
-        verify_withdraw(proof_data),
+        verify_withdraw(None, proof_data),
     ])
 }
 


### PR DESCRIPTION
#### Problem
Confidential transfer withdraw instruction is not u9pdated for the new Solana 1.16 changes.

#### Summary of Changes
Updated the processor, client, and tests relating to the withdraw instruction. These are relatively simpler changes with just two commits. The withdraw instruction does fit into a single transaction, so I did not divide up the proof.

Some notable change is in the error. In the client, I changed the error variant `Proof(ProofError)` to `ProofGeneration`. Previously, `Proof(ProofError)` held the specific proof error from the zk-token-sdk. Now, I simplified it to just `ProofGeneration` because that is technically the only type of proof related error in the client and since the proof generation logic for the withdraw proof is now shoved into token-2022, propagating the error further could be a little complicated. This technically changes the error interface, so I am not sure if it is better to deprecate the variant and create a new variant.