### PR TITLE
token-2022: Add scaffolding to implement token-metadata interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6890,6 +6890,7 @@ dependencies = [
  "solana-zk-token-sdk",
  "spl-memo 4.0.0",
  "spl-token 4.0.0",
+ "spl-token-metadata-interface",
  "spl-transfer-hook-interface",
  "thiserror",
 ]

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -26,8 +26,9 @@ num_enum = "0.6.1"
 solana-program = "1.16.1"
 solana-zk-token-sdk = "1.16.1"
 spl-memo = { version = "4.0.0", path = "../../memo/program", features = [ "no-entrypoint" ] }
-spl-transfer-hook-interface = { version = "0.1.0", path = "../transfer-hook-interface" }
 spl-token = { version = "4.0",  path = "../program", features = ["no-entrypoint"] }
+spl-token-metadata-interface = { version = "0.1.0", path = "../../token-metadata/interface" }
+spl-transfer-hook-interface = { version = "0.1.0", path = "../transfer-hook-interface" }
 thiserror = "1.0"
 serde = { version = "1.0.167", optional = true }
 serde_with = { version = "2.0.0", optional = true }

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -63,6 +63,8 @@ pub mod non_transferable;
 pub mod permanent_delegate;
 /// Utility to reallocate token accounts
 pub mod reallocate;
+/// Token-metadata extension
+pub mod token_metadata;
 /// Transfer Fee extension
 pub mod transfer_fee;
 /// Transfer Hook extension
@@ -807,6 +809,8 @@ pub enum ExtensionType {
     ConfidentialTransferFeeAmount,
     /// Mint contains a pointer to another account (or the same account) that holds metadata
     MetadataPointer,
+    /// Mint contains token-metadata
+    TokenMetadata,
     /// Test unsized mint extension
     #[cfg(test)]
     UnsizedMintTest = u16::MAX - 2,
@@ -838,6 +842,7 @@ impl ExtensionType {
     /// be added here by hand
     const fn sized(&self) -> bool {
         match self {
+            ExtensionType::TokenMetadata => false,
             #[cfg(test)]
             ExtensionType::UnsizedMintTest => false,
             _ => true,
@@ -879,6 +884,7 @@ impl ExtensionType {
                 pod_get_packed_len::<ConfidentialTransferFeeAmount>()
             }
             ExtensionType::MetadataPointer => pod_get_packed_len::<MetadataPointer>(),
+            ExtensionType::TokenMetadata => unreachable!(),
             #[cfg(test)]
             ExtensionType::AccountPaddingTest => pod_get_packed_len::<AccountPaddingTest>(),
             #[cfg(test)]
@@ -939,7 +945,8 @@ impl ExtensionType {
             | ExtensionType::PermanentDelegate
             | ExtensionType::TransferHook
             | ExtensionType::ConfidentialTransferFeeConfig
-            | ExtensionType::MetadataPointer => AccountType::Mint,
+            | ExtensionType::MetadataPointer
+            | ExtensionType::TokenMetadata => AccountType::Mint,
             ExtensionType::ImmutableOwner
             | ExtensionType::TransferFeeAmount
             | ExtensionType::ConfidentialTransferAccount

--- a/token/program-2022/src/extension/token_metadata/mod.rs
+++ b/token/program-2022/src/extension/token_metadata/mod.rs
@@ -1,0 +1,11 @@
+use {
+    crate::extension::{Extension, ExtensionType},
+    spl_token_metadata_interface::state::TokenMetadata,
+};
+
+/// Instruction processor for the TokenMetadata extension
+pub mod processor;
+
+impl Extension for TokenMetadata {
+    const TYPE: ExtensionType = ExtensionType::TokenMetadata;
+}

--- a/token/program-2022/src/extension/token_metadata/processor.rs
+++ b/token/program-2022/src/extension/token_metadata/processor.rs
@@ -1,0 +1,79 @@
+//! Token-metadata processor
+
+use {
+    solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, msg, pubkey::Pubkey},
+    spl_token_metadata_interface::instruction::{
+        Emit, Initialize, RemoveKey, TokenMetadataInstruction, UpdateAuthority, UpdateField,
+    },
+};
+
+/// Processes a [Initialize](enum.TokenMetadataInstruction.html) instruction.
+pub fn process_initialize(
+    _program_id: &Pubkey,
+    _accounts: &[AccountInfo],
+    _data: Initialize,
+) -> ProgramResult {
+    Ok(())
+}
+
+/// Processes an [UpdateField](enum.TokenMetadataInstruction.html) instruction.
+pub fn process_update_field(
+    _program_id: &Pubkey,
+    _accounts: &[AccountInfo],
+    _data: UpdateField,
+) -> ProgramResult {
+    Ok(())
+}
+
+/// Processes a [RemoveKey](enum.TokenMetadataInstruction.html) instruction.
+pub fn process_remove_key(
+    _program_id: &Pubkey,
+    _accounts: &[AccountInfo],
+    _data: RemoveKey,
+) -> ProgramResult {
+    Ok(())
+}
+
+/// Processes a [UpdateAuthority](enum.TokenMetadataInstruction.html) instruction.
+pub fn process_update_authority(
+    _program_id: &Pubkey,
+    _accounts: &[AccountInfo],
+    _data: UpdateAuthority,
+) -> ProgramResult {
+    Ok(())
+}
+
+/// Processes an [Emit](enum.TokenMetadataInstruction.html) instruction.
+pub fn process_emit(_program_id: &Pubkey, _accounts: &[AccountInfo], _data: Emit) -> ProgramResult {
+    Ok(())
+}
+
+/// Processes an [Instruction](enum.Instruction.html).
+pub fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction: TokenMetadataInstruction,
+) -> ProgramResult {
+    match instruction {
+        TokenMetadataInstruction::Initialize(data) => {
+            msg!("TokenMetadataInstruction: Initialize");
+            process_initialize(program_id, accounts, data)
+        }
+        TokenMetadataInstruction::UpdateField(data) => {
+            msg!("TokenMetadataInstruction: UpdateField");
+            process_update_field(program_id, accounts, data)
+        }
+        TokenMetadataInstruction::RemoveKey(data) => {
+            msg!("TokenMetadataInstruction: RemoveKey");
+            process_remove_key(program_id, accounts, data)
+        }
+        TokenMetadataInstruction::UpdateAuthority(data) => {
+            msg!("TokenMetadataInstruction: UpdateAuthority");
+            process_update_authority(program_id, accounts, data)
+        }
+        TokenMetadataInstruction::Emit(data) => {
+            msg!("TokenMetadataInstruction: Emit");
+            process_emit(program_id, accounts, data)
+        }
+    }
+}

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -18,7 +18,7 @@ use {
             mint_close_authority::MintCloseAuthority,
             non_transferable::{NonTransferable, NonTransferableAccount},
             permanent_delegate::{get_permanent_delegate, PermanentDelegate},
-            reallocate,
+            reallocate, token_metadata,
             transfer_fee::{self, TransferFeeAmount, TransferFeeConfig},
             transfer_hook::{self, TransferHook, TransferHookAccount},
             AccountType, BaseStateWithExtensions, ExtensionType, StateWithExtensions,
@@ -41,6 +41,7 @@ use {
         system_instruction, system_program,
         sysvar::{rent::Rent, Sysvar},
     },
+    spl_token_metadata_interface::instruction::TokenMetadataInstruction,
     std::convert::{TryFrom, TryInto},
 };
 
@@ -1465,188 +1466,206 @@ impl Processor {
 
     /// Processes an [Instruction](enum.Instruction.html).
     pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> ProgramResult {
-        let instruction = TokenInstruction::unpack(input)?;
-
-        match instruction {
-            TokenInstruction::InitializeMint {
-                decimals,
-                mint_authority,
-                freeze_authority,
-            } => {
-                msg!("Instruction: InitializeMint");
-                Self::process_initialize_mint(accounts, decimals, mint_authority, freeze_authority)
+        if let Ok(instruction) = TokenInstruction::unpack(input) {
+            match instruction {
+                TokenInstruction::InitializeMint {
+                    decimals,
+                    mint_authority,
+                    freeze_authority,
+                } => {
+                    msg!("Instruction: InitializeMint");
+                    Self::process_initialize_mint(
+                        accounts,
+                        decimals,
+                        mint_authority,
+                        freeze_authority,
+                    )
+                }
+                TokenInstruction::InitializeMint2 {
+                    decimals,
+                    mint_authority,
+                    freeze_authority,
+                } => {
+                    msg!("Instruction: InitializeMint2");
+                    Self::process_initialize_mint2(
+                        accounts,
+                        decimals,
+                        mint_authority,
+                        freeze_authority,
+                    )
+                }
+                TokenInstruction::InitializeAccount => {
+                    msg!("Instruction: InitializeAccount");
+                    Self::process_initialize_account(accounts)
+                }
+                TokenInstruction::InitializeAccount2 { owner } => {
+                    msg!("Instruction: InitializeAccount2");
+                    Self::process_initialize_account2(accounts, owner)
+                }
+                TokenInstruction::InitializeAccount3 { owner } => {
+                    msg!("Instruction: InitializeAccount3");
+                    Self::process_initialize_account3(accounts, owner)
+                }
+                TokenInstruction::InitializeMultisig { m } => {
+                    msg!("Instruction: InitializeMultisig");
+                    Self::process_initialize_multisig(accounts, m)
+                }
+                TokenInstruction::InitializeMultisig2 { m } => {
+                    msg!("Instruction: InitializeMultisig2");
+                    Self::process_initialize_multisig2(accounts, m)
+                }
+                #[allow(deprecated)]
+                TokenInstruction::Transfer { amount } => {
+                    msg!("Instruction: Transfer");
+                    Self::process_transfer(program_id, accounts, amount, None, None)
+                }
+                TokenInstruction::Approve { amount } => {
+                    msg!("Instruction: Approve");
+                    Self::process_approve(program_id, accounts, amount, None)
+                }
+                TokenInstruction::Revoke => {
+                    msg!("Instruction: Revoke");
+                    Self::process_revoke(program_id, accounts)
+                }
+                TokenInstruction::SetAuthority {
+                    authority_type,
+                    new_authority,
+                } => {
+                    msg!("Instruction: SetAuthority");
+                    Self::process_set_authority(program_id, accounts, authority_type, new_authority)
+                }
+                TokenInstruction::MintTo { amount } => {
+                    msg!("Instruction: MintTo");
+                    Self::process_mint_to(program_id, accounts, amount, None)
+                }
+                TokenInstruction::Burn { amount } => {
+                    msg!("Instruction: Burn");
+                    Self::process_burn(program_id, accounts, amount, None)
+                }
+                TokenInstruction::CloseAccount => {
+                    msg!("Instruction: CloseAccount");
+                    Self::process_close_account(program_id, accounts)
+                }
+                TokenInstruction::FreezeAccount => {
+                    msg!("Instruction: FreezeAccount");
+                    Self::process_toggle_freeze_account(program_id, accounts, true)
+                }
+                TokenInstruction::ThawAccount => {
+                    msg!("Instruction: ThawAccount");
+                    Self::process_toggle_freeze_account(program_id, accounts, false)
+                }
+                TokenInstruction::TransferChecked { amount, decimals } => {
+                    msg!("Instruction: TransferChecked");
+                    Self::process_transfer(program_id, accounts, amount, Some(decimals), None)
+                }
+                TokenInstruction::ApproveChecked { amount, decimals } => {
+                    msg!("Instruction: ApproveChecked");
+                    Self::process_approve(program_id, accounts, amount, Some(decimals))
+                }
+                TokenInstruction::MintToChecked { amount, decimals } => {
+                    msg!("Instruction: MintToChecked");
+                    Self::process_mint_to(program_id, accounts, amount, Some(decimals))
+                }
+                TokenInstruction::BurnChecked { amount, decimals } => {
+                    msg!("Instruction: BurnChecked");
+                    Self::process_burn(program_id, accounts, amount, Some(decimals))
+                }
+                TokenInstruction::SyncNative => {
+                    msg!("Instruction: SyncNative");
+                    Self::process_sync_native(accounts)
+                }
+                TokenInstruction::GetAccountDataSize { extension_types } => {
+                    msg!("Instruction: GetAccountDataSize");
+                    Self::process_get_account_data_size(accounts, extension_types)
+                }
+                TokenInstruction::InitializeMintCloseAuthority { close_authority } => {
+                    msg!("Instruction: InitializeMintCloseAuthority");
+                    Self::process_initialize_mint_close_authority(accounts, close_authority)
+                }
+                TokenInstruction::TransferFeeExtension(instruction) => {
+                    transfer_fee::processor::process_instruction(program_id, accounts, instruction)
+                }
+                TokenInstruction::ConfidentialTransferExtension => {
+                    confidential_transfer::processor::process_instruction(
+                        program_id,
+                        accounts,
+                        &input[1..],
+                    )
+                }
+                TokenInstruction::DefaultAccountStateExtension => {
+                    default_account_state::processor::process_instruction(
+                        program_id,
+                        accounts,
+                        &input[1..],
+                    )
+                }
+                TokenInstruction::InitializeImmutableOwner => {
+                    msg!("Instruction: InitializeImmutableOwner");
+                    Self::process_initialize_immutable_owner(accounts)
+                }
+                TokenInstruction::AmountToUiAmount { amount } => {
+                    msg!("Instruction: AmountToUiAmount");
+                    Self::process_amount_to_ui_amount(accounts, amount)
+                }
+                TokenInstruction::UiAmountToAmount { ui_amount } => {
+                    msg!("Instruction: UiAmountToAmount");
+                    Self::process_ui_amount_to_amount(accounts, ui_amount)
+                }
+                TokenInstruction::Reallocate { extension_types } => {
+                    msg!("Instruction: Reallocate");
+                    reallocate::process_reallocate(program_id, accounts, extension_types)
+                }
+                TokenInstruction::MemoTransferExtension => {
+                    memo_transfer::processor::process_instruction(program_id, accounts, &input[1..])
+                }
+                TokenInstruction::CreateNativeMint => {
+                    msg!("Instruction: CreateNativeMint");
+                    Self::process_create_native_mint(accounts)
+                }
+                TokenInstruction::InitializeNonTransferableMint => {
+                    msg!("Instruction: InitializeNonTransferableMint");
+                    Self::process_initialize_non_transferable_mint(accounts)
+                }
+                TokenInstruction::InterestBearingMintExtension => {
+                    interest_bearing_mint::processor::process_instruction(
+                        program_id,
+                        accounts,
+                        &input[1..],
+                    )
+                }
+                TokenInstruction::CpiGuardExtension => {
+                    cpi_guard::processor::process_instruction(program_id, accounts, &input[1..])
+                }
+                TokenInstruction::InitializePermanentDelegate { delegate } => {
+                    msg!("Instruction: InitializePermanentDelegate");
+                    Self::process_initialize_permanent_delegate(accounts, delegate)
+                }
+                TokenInstruction::TransferHookExtension => {
+                    transfer_hook::processor::process_instruction(program_id, accounts, &input[1..])
+                }
+                TokenInstruction::ConfidentialTransferFeeExtension => {
+                    confidential_transfer_fee::processor::process_instruction(
+                        program_id,
+                        accounts,
+                        &input[1..],
+                    )
+                }
+                TokenInstruction::WithdrawExcessLamports => {
+                    msg!("Instruction: WithdrawExcessLamports");
+                    Self::process_withdraw_excess_lamports(program_id, accounts)
+                }
+                TokenInstruction::MetadataPointerExtension => {
+                    metadata_pointer::processor::process_instruction(
+                        program_id,
+                        accounts,
+                        &input[1..],
+                    )
+                }
             }
-            TokenInstruction::InitializeMint2 {
-                decimals,
-                mint_authority,
-                freeze_authority,
-            } => {
-                msg!("Instruction: InitializeMint2");
-                Self::process_initialize_mint2(accounts, decimals, mint_authority, freeze_authority)
-            }
-            TokenInstruction::InitializeAccount => {
-                msg!("Instruction: InitializeAccount");
-                Self::process_initialize_account(accounts)
-            }
-            TokenInstruction::InitializeAccount2 { owner } => {
-                msg!("Instruction: InitializeAccount2");
-                Self::process_initialize_account2(accounts, owner)
-            }
-            TokenInstruction::InitializeAccount3 { owner } => {
-                msg!("Instruction: InitializeAccount3");
-                Self::process_initialize_account3(accounts, owner)
-            }
-            TokenInstruction::InitializeMultisig { m } => {
-                msg!("Instruction: InitializeMultisig");
-                Self::process_initialize_multisig(accounts, m)
-            }
-            TokenInstruction::InitializeMultisig2 { m } => {
-                msg!("Instruction: InitializeMultisig2");
-                Self::process_initialize_multisig2(accounts, m)
-            }
-            #[allow(deprecated)]
-            TokenInstruction::Transfer { amount } => {
-                msg!("Instruction: Transfer");
-                Self::process_transfer(program_id, accounts, amount, None, None)
-            }
-            TokenInstruction::Approve { amount } => {
-                msg!("Instruction: Approve");
-                Self::process_approve(program_id, accounts, amount, None)
-            }
-            TokenInstruction::Revoke => {
-                msg!("Instruction: Revoke");
-                Self::process_revoke(program_id, accounts)
-            }
-            TokenInstruction::SetAuthority {
-                authority_type,
-                new_authority,
-            } => {
-                msg!("Instruction: SetAuthority");
-                Self::process_set_authority(program_id, accounts, authority_type, new_authority)
-            }
-            TokenInstruction::MintTo { amount } => {
-                msg!("Instruction: MintTo");
-                Self::process_mint_to(program_id, accounts, amount, None)
-            }
-            TokenInstruction::Burn { amount } => {
-                msg!("Instruction: Burn");
-                Self::process_burn(program_id, accounts, amount, None)
-            }
-            TokenInstruction::CloseAccount => {
-                msg!("Instruction: CloseAccount");
-                Self::process_close_account(program_id, accounts)
-            }
-            TokenInstruction::FreezeAccount => {
-                msg!("Instruction: FreezeAccount");
-                Self::process_toggle_freeze_account(program_id, accounts, true)
-            }
-            TokenInstruction::ThawAccount => {
-                msg!("Instruction: ThawAccount");
-                Self::process_toggle_freeze_account(program_id, accounts, false)
-            }
-            TokenInstruction::TransferChecked { amount, decimals } => {
-                msg!("Instruction: TransferChecked");
-                Self::process_transfer(program_id, accounts, amount, Some(decimals), None)
-            }
-            TokenInstruction::ApproveChecked { amount, decimals } => {
-                msg!("Instruction: ApproveChecked");
-                Self::process_approve(program_id, accounts, amount, Some(decimals))
-            }
-            TokenInstruction::MintToChecked { amount, decimals } => {
-                msg!("Instruction: MintToChecked");
-                Self::process_mint_to(program_id, accounts, amount, Some(decimals))
-            }
-            TokenInstruction::BurnChecked { amount, decimals } => {
-                msg!("Instruction: BurnChecked");
-                Self::process_burn(program_id, accounts, amount, Some(decimals))
-            }
-            TokenInstruction::SyncNative => {
-                msg!("Instruction: SyncNative");
-                Self::process_sync_native(accounts)
-            }
-            TokenInstruction::GetAccountDataSize { extension_types } => {
-                msg!("Instruction: GetAccountDataSize");
-                Self::process_get_account_data_size(accounts, extension_types)
-            }
-            TokenInstruction::InitializeMintCloseAuthority { close_authority } => {
-                msg!("Instruction: InitializeMintCloseAuthority");
-                Self::process_initialize_mint_close_authority(accounts, close_authority)
-            }
-            TokenInstruction::TransferFeeExtension(instruction) => {
-                transfer_fee::processor::process_instruction(program_id, accounts, instruction)
-            }
-            TokenInstruction::ConfidentialTransferExtension => {
-                confidential_transfer::processor::process_instruction(
-                    program_id,
-                    accounts,
-                    &input[1..],
-                )
-            }
-            TokenInstruction::DefaultAccountStateExtension => {
-                default_account_state::processor::process_instruction(
-                    program_id,
-                    accounts,
-                    &input[1..],
-                )
-            }
-            TokenInstruction::InitializeImmutableOwner => {
-                msg!("Instruction: InitializeImmutableOwner");
-                Self::process_initialize_immutable_owner(accounts)
-            }
-            TokenInstruction::AmountToUiAmount { amount } => {
-                msg!("Instruction: AmountToUiAmount");
-                Self::process_amount_to_ui_amount(accounts, amount)
-            }
-            TokenInstruction::UiAmountToAmount { ui_amount } => {
-                msg!("Instruction: UiAmountToAmount");
-                Self::process_ui_amount_to_amount(accounts, ui_amount)
-            }
-            TokenInstruction::Reallocate { extension_types } => {
-                msg!("Instruction: Reallocate");
-                reallocate::process_reallocate(program_id, accounts, extension_types)
-            }
-            TokenInstruction::MemoTransferExtension => {
-                memo_transfer::processor::process_instruction(program_id, accounts, &input[1..])
-            }
-            TokenInstruction::CreateNativeMint => {
-                msg!("Instruction: CreateNativeMint");
-                Self::process_create_native_mint(accounts)
-            }
-            TokenInstruction::InitializeNonTransferableMint => {
-                msg!("Instruction: InitializeNonTransferableMint");
-                Self::process_initialize_non_transferable_mint(accounts)
-            }
-            TokenInstruction::InterestBearingMintExtension => {
-                interest_bearing_mint::processor::process_instruction(
-                    program_id,
-                    accounts,
-                    &input[1..],
-                )
-            }
-            TokenInstruction::CpiGuardExtension => {
-                cpi_guard::processor::process_instruction(program_id, accounts, &input[1..])
-            }
-            TokenInstruction::InitializePermanentDelegate { delegate } => {
-                msg!("Instruction: InitializePermanentDelegate");
-                Self::process_initialize_permanent_delegate(accounts, delegate)
-            }
-            TokenInstruction::TransferHookExtension => {
-                transfer_hook::processor::process_instruction(program_id, accounts, &input[1..])
-            }
-            TokenInstruction::ConfidentialTransferFeeExtension => {
-                confidential_transfer_fee::processor::process_instruction(
-                    program_id,
-                    accounts,
-                    &input[1..],
-                )
-            }
-            TokenInstruction::WithdrawExcessLamports => {
-                msg!("Instruction: WithdrawExcessLamports");
-                Self::process_withdraw_excess_lamports(program_id, accounts)
-            }
-            TokenInstruction::MetadataPointerExtension => {
-                metadata_pointer::processor::process_instruction(program_id, accounts, &input[1..])
-            }
+        } else if let Ok(instruction) = TokenMetadataInstruction::unpack(input) {
+            token_metadata::processor::process_instruction(program_id, accounts, instruction)
+        } else {
+            Err(TokenError::InvalidInstruction.into())
         }
     }
 


### PR DESCRIPTION
#### Problem

We want to implement the token-metadata interface in token-2022, but we've only laid the groundwork for handling variable-length extensions, and none of the actual implementation.

#### Solution

This one's pretty simple, just putting in the scaffolding for handling a token-metadata instruction, no real functional bits yet:

* adds `ExtensionType::TokenMetadata` and marks it as variable-length
* parses incoming instructions as `TokenMetadataInstruction` *after* the token-2022 instructions -- this is the bulk of the change, and it's all white-space
* forwards `TokenMetadataInstruction` to specific processors, which are all empty