### PR TITLE
stake-pool-cli: mark args as global

### DIFF
--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -1940,6 +1940,7 @@ fn main() {
                 .value_name("URL")
                 .takes_value(true)
                 .validator(is_url)
+                .global(true)
                 .help("JSON RPC URL for the cluster.  Default from the configuration file."),
         )
         .arg(
@@ -1948,6 +1949,7 @@ fn main() {
                 .value_name("KEYPAIR")
                 .validator(is_valid_signer)
                 .takes_value(true)
+                .global(true)
                 .help("Stake pool staker. [default: cli config keypair]"),
         )
         .arg(
@@ -1956,6 +1958,7 @@ fn main() {
                 .value_name("KEYPAIR")
                 .validator(is_valid_signer)
                 .takes_value(true)
+                .global(true)
                 .help("Stake pool manager. [default: cli config keypair]"),
         )
         .arg(
@@ -1964,6 +1967,7 @@ fn main() {
                 .value_name("KEYPAIR")
                 .validator(is_valid_signer)
                 .takes_value(true)
+                .global(true)
                 .help("Stake pool funding authority for deposits or withdrawals. [default: cli config keypair]"),
         )
         .arg(
@@ -1972,6 +1976,7 @@ fn main() {
                 .value_name("KEYPAIR")
                 .validator(is_valid_signer)
                 .takes_value(true)
+                .global(true)
                 .help("Owner of pool token account [default: cli config keypair]"),
         )
         .arg(
@@ -1980,6 +1985,7 @@ fn main() {
                 .value_name("KEYPAIR")
                 .validator(is_valid_signer)
                 .takes_value(true)
+                .global(true)
                 .help("Transaction fee payer account [default: cli config keypair]"),
         )
         .subcommand(SubCommand::with_name("create-pool")


### PR DESCRIPTION
found while testing single pool ledger support, these args dont show up in any subcommand

```
cargo run -- --help
    Finished dev [unoptimized + debuginfo] target(s) in 0.19s
     Running `/home/hana/work/solana/spl/target/debug/spl-stake-pool --help`
spl-stake-pool-cli 0.7.0
SPL-Stake-Pool Command-line Utility

USAGE:
    spl-stake-pool [FLAGS] [OPTIONS] <SUBCOMMAND>

FLAGS:  
        --dry-run      Simulate transaction instead of executing
    -h, --help         Prints help information
        --no-update    Do not automatically update the stake pool if needed
    -V, --version      Prints version information
    -v, --verbose      Show additional information

OPTIONS:
    -C, --config <PATH>                  Configuration file to use [default: /home/hana/.config/solana/cli/config.yml]
        --fee-payer <KEYPAIR>            Transaction fee payer account [default: cli config keypair]
        --funding-authority <KEYPAIR>    Stake pool funding authority for deposits or withdrawals. [default: cli config
                                         keypair]
        --url <URL>                      JSON RPC URL for the cluster.  Default from the configuration file.
        --manager <KEYPAIR>              Stake pool manager. [default: cli config keypair]
        --output <FORMAT>                Return information in specified output format [possible values: json, json-
                                         compact]
        --staker <KEYPAIR>               Stake pool staker. [default: cli config keypair]
        --token-owner <KEYPAIR>          Owner of pool token account [default: cli config keypair]
```

```
cargo run -- update --help
    Finished dev [unoptimized + debuginfo] target(s) in 0.19s
     Running `/home/hana/work/solana/spl/target/debug/spl-stake-pool update --help`
spl-stake-pool-update 
Updates all balances in the pool after validator stake accounts receive rewards.

USAGE:
    spl-stake-pool update [FLAGS] [OPTIONS] <POOL_ADDRESS>

FLAGS:
        --dry-run      Simulate transaction instead of executing
        --force        Update all balances, even if it has already been performed this epoch.
    -h, --help         Prints help information
        --no-merge     Do not automatically merge transient stakes. Useful if the stake pool is in an expected state,
                       but the balances still need to be updated.
        --no-update    Do not automatically update the stake pool if needed
    -V, --version      Prints version information
    -v, --verbose      Show additional information

OPTIONS:
    -C, --config <PATH>      Configuration file to use [default: /home/hana/.config/solana/cli/config.yml]
        --output <FORMAT>    Return information in specified output format [possible values: json, json-compact]
```

its possible that some of them should only be for a couple commands, i havent gone through them all to check, but since they were all placed at this level i assumed that was the intent