### PR TITLE
token-2022: Implement `TokenMetadataInstruction::Initialize`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6963,6 +6963,7 @@ dependencies = [
  "spl-memo 4.0.0",
  "spl-token 4.0.0",
  "spl-token-2022 0.7.0",
+ "spl-token-metadata-interface",
  "spl-transfer-hook-interface",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6901,6 +6901,7 @@ name = "spl-token-2022-test"
 version = "0.0.1"
 dependencies = [
  "async-trait",
+ "borsh 0.10.3",
  "futures-util",
  "solana-program",
  "solana-program-test",
@@ -6910,6 +6911,7 @@ dependencies = [
  "spl-memo 4.0.0",
  "spl-token-2022 0.7.0",
  "spl-token-client",
+ "spl-token-metadata-interface",
  "spl-transfer-hook-example",
  "spl-transfer-hook-interface",
  "test-case",

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -20,6 +20,7 @@ spl-associated-token-account = { version = "2.0", path = "../../associated-token
 spl-memo = { version = "4.0.0", path = "../../memo/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path="../program", features = [ "no-entrypoint" ] }
 spl-token-2022 = { version = "0.7", path="../program-2022" }
+spl-token-metadata-interface = { version = "0.1", path="../../token-metadata/interface" }
 spl-transfer-hook-interface = { version = "0.1", path="../transfer-hook-interface" }
 thiserror = "1.0"
 

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -29,6 +29,7 @@ use {
         solana_zk_token_sdk::{errors::ProofError, zk_token_elgamal::pod::ElGamalPubkey},
         state::{Account, AccountState, Mint, Multisig},
     },
+    spl_token_metadata_interface::state::TokenMetadata,
     std::{
         fmt, io,
         sync::{Arc, RwLock},
@@ -691,9 +692,10 @@ where
             .ok_or(TokenError::AccountNotFound)
     }
 
-    /// Retrive mint information.
-    pub async fn get_mint_info(&self) -> TokenResult<StateWithExtensionsOwned<Mint>> {
-        let account = self.get_account(self.pubkey).await?;
+    fn unpack_mint_info(
+        &self,
+        account: BaseAccount,
+    ) -> TokenResult<StateWithExtensionsOwned<Mint>> {
         if account.owner != self.program_id {
             return Err(TokenError::AccountInvalidOwner);
         }
@@ -708,6 +710,12 @@ where
         }
 
         mint_result
+    }
+
+    /// Retrive mint information.
+    pub async fn get_mint_info(&self) -> TokenResult<StateWithExtensionsOwned<Mint>> {
+        let account = self.get_account(self.pubkey).await?;
+        self.unpack_mint_info(account)
     }
 
     /// Retrieve account information.
@@ -2523,5 +2531,80 @@ where
             signing_keypairs,
         )
         .await
+    }
+
+    /// Initialize token-metadata on a mint
+    pub async fn initialize_token_metadata<S: Signers>(
+        &self,
+        update_authority: &Pubkey,
+        mint_authority: &Pubkey,
+        name: String,
+        symbol: String,
+        uri: String,
+        signing_keypairs: &S,
+    ) -> TokenResult<T::Output> {
+        self.process_ixs(
+            &[spl_token_metadata_interface::instruction::initialize(
+                &self.program_id,
+                &self.pubkey,
+                update_authority,
+                &self.pubkey,
+                mint_authority,
+                name,
+                symbol,
+                uri,
+            )],
+            signing_keypairs,
+        )
+        .await
+    }
+
+    /// Initialize token-metadata on a mint
+    #[allow(clippy::too_many_arguments)]
+    pub async fn initialize_token_metadata_with_rent_transfer<S: Signers>(
+        &self,
+        payer: &Pubkey,
+        update_authority: &Pubkey,
+        mint_authority: &Pubkey,
+        name: String,
+        symbol: String,
+        uri: String,
+        signing_keypairs: &S,
+    ) -> TokenResult<T::Output> {
+        let account = self.get_account(self.pubkey).await?;
+        let account_lamports = account.lamports;
+        let mint_state = self.unpack_mint_info(account)?;
+        let token_metadata = TokenMetadata {
+            name,
+            symbol,
+            uri,
+            ..Default::default()
+        };
+        let new_account_len = mint_state.try_get_new_account_len(&token_metadata)?;
+        let new_rent_exempt_minimum = self
+            .client
+            .get_minimum_balance_for_rent_exemption(new_account_len)
+            .await
+            .map_err(TokenError::Client)?;
+        let additional_lamports = new_rent_exempt_minimum.saturating_sub(account_lamports);
+        let mut instructions = vec![];
+        if additional_lamports > 0 {
+            instructions.push(system_instruction::transfer(
+                payer,
+                &self.pubkey,
+                additional_lamports,
+            ));
+        }
+        instructions.push(spl_token_metadata_interface::instruction::initialize(
+            &self.program_id,
+            &self.pubkey,
+            update_authority,
+            &self.pubkey,
+            mint_authority,
+            token_metadata.name,
+            token_metadata.symbol,
+            token_metadata.uri,
+        ));
+        self.process_ixs(&instructions, signing_keypairs).await
     }
 }

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -18,6 +18,7 @@ walkdir = "2"
 
 [dev-dependencies]
 async-trait = "0.1"
+borsh = "0.10"
 futures-util = "0.3"
 solana-program = "=1.16.1"
 solana-program-test = "=1.16.1"
@@ -27,6 +28,7 @@ spl-memo = { version = "4.0.0", path = "../../memo/program", features = ["no-ent
 spl-token-2022 = { version = "0.7", path="../program-2022", features = ["no-entrypoint"] }
 spl-instruction-padding = { version = "0.1.0", path="../../instruction-padding/program", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.5", path = "../client" }
+spl-token-metadata-interface = { version = "0.1", path = "../../token-metadata/interface" }
 spl-transfer-hook-example = { version = "0.1", path="../transfer-hook-example", features = ["no-entrypoint"] }
 spl-transfer-hook-interface = { version = "0.1", path="../transfer-hook-interface" }
 test-case = "3.1"

--- a/token/program-2022-test/tests/token_metadata_initialize.rs
+++ b/token/program-2022-test/tests/token_metadata_initialize.rs
@@ -1,0 +1,290 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+use {
+    borsh::BorshDeserialize,
+    program_test::TestContext,
+    solana_program_test::{processor, tokio, ProgramTest},
+    solana_sdk::{
+        instruction::InstructionError, pubkey::Pubkey, signature::Signer, signer::keypair::Keypair,
+        transaction::TransactionError, transport::TransportError,
+    },
+    spl_token_2022::{error::TokenError, extension::BaseStateWithExtensions, processor::Processor},
+    spl_token_client::token::{ExtensionInitializationParams, TokenError as TokenClientError},
+    spl_token_metadata_interface::{error::TokenMetadataError, state::TokenMetadata},
+    std::{convert::TryInto, sync::Arc},
+};
+
+fn setup_program_test() -> ProgramTest {
+    let mut program_test = ProgramTest::default();
+    program_test.add_program(
+        "spl_token_2022",
+        spl_token_2022::id(),
+        processor!(Processor::process),
+    );
+    program_test
+}
+
+async fn setup(mint: Keypair, authority: &Pubkey) -> TestContext {
+    let program_test = setup_program_test();
+
+    let context = program_test.start_with_context().await;
+    let context = Arc::new(tokio::sync::Mutex::new(context));
+    let mut context = TestContext {
+        context,
+        token_context: None,
+    };
+    let metadata_address = Some(mint.pubkey());
+    context
+        .init_token_with_mint_keypair_and_freeze_authority(
+            mint,
+            vec![ExtensionInitializationParams::MetadataPointer {
+                authority: Some(*authority),
+                metadata_address,
+            }],
+            None,
+        )
+        .await
+        .unwrap();
+    context
+}
+
+#[tokio::test]
+async fn success_initialize() {
+    let authority = Pubkey::new_unique();
+    let mint_keypair = Keypair::new();
+    let mut test_context = setup(mint_keypair, &authority).await;
+    let payer_pubkey = test_context.context.lock().await.payer.pubkey();
+    let token_context = test_context.token_context.take().unwrap();
+
+    let update_authority = Pubkey::new_unique();
+    let name = "MyTokenNeedsMetadata".to_string();
+    let symbol = "NEEDS".to_string();
+    let uri = "my.token.needs.metadata".to_string();
+    let token_metadata = TokenMetadata {
+        name,
+        symbol,
+        uri,
+        update_authority: Some(update_authority).try_into().unwrap(),
+        mint: *token_context.token.get_address(),
+        ..Default::default()
+    };
+
+    // fails without more lamports for new rent-exemption
+    let error = token_context
+        .token
+        .initialize_token_metadata(
+            &update_authority,
+            &token_context.mint_authority.pubkey(),
+            token_metadata.name.clone(),
+            token_metadata.symbol.clone(),
+            token_metadata.uri.clone(),
+            &[&token_context.mint_authority],
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InsufficientFundsForRent { account_index: 2 }
+        )))
+    );
+
+    // fail wrong signer
+    let not_mint_authority = Keypair::new();
+    let error = token_context
+        .token
+        .initialize_token_metadata_with_rent_transfer(
+            &payer_pubkey,
+            &update_authority,
+            &not_mint_authority.pubkey(),
+            token_metadata.name.clone(),
+            token_metadata.symbol.clone(),
+            token_metadata.uri.clone(),
+            &[&not_mint_authority],
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                1,
+                InstructionError::Custom(TokenMetadataError::IncorrectMintAuthority as u32)
+            )
+        )))
+    );
+
+    token_context
+        .token
+        .initialize_token_metadata_with_rent_transfer(
+            &payer_pubkey,
+            &update_authority,
+            &token_context.mint_authority.pubkey(),
+            token_metadata.name.clone(),
+            token_metadata.symbol.clone(),
+            token_metadata.uri.clone(),
+            &[&token_context.mint_authority],
+        )
+        .await
+        .unwrap();
+
+    // check that the data is correct
+    let mint_info = token_context.token.get_mint_info().await.unwrap();
+    let metadata_bytes = mint_info.get_extension_bytes::<TokenMetadata>().unwrap();
+    let fetched_metadata = TokenMetadata::try_from_slice(metadata_bytes).unwrap();
+    assert_eq!(fetched_metadata, token_metadata);
+
+    // fail double-init
+    let error = token_context
+        .token
+        .initialize_token_metadata_with_rent_transfer(
+            &payer_pubkey,
+            &update_authority,
+            &token_context.mint_authority.pubkey(),
+            token_metadata.name.clone(),
+            token_metadata.symbol.clone(),
+            token_metadata.uri.clone(),
+            &[&token_context.mint_authority],
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::ExtensionAlreadyInitialized as u32)
+            )
+        )))
+    );
+}
+
+#[tokio::test]
+async fn fail_without_metadata_pointer() {
+    let mut test_context = {
+        let mint_keypair = Keypair::new();
+        let program_test = setup_program_test();
+        let context = program_test.start_with_context().await;
+        let context = Arc::new(tokio::sync::Mutex::new(context));
+        let mut context = TestContext {
+            context,
+            token_context: None,
+        };
+        context
+            .init_token_with_mint_keypair_and_freeze_authority(mint_keypair, vec![], None)
+            .await
+            .unwrap();
+        context
+    };
+
+    let payer_pubkey = test_context.context.lock().await.payer.pubkey();
+    let token_context = test_context.token_context.take().unwrap();
+
+    let error = token_context
+        .token
+        .initialize_token_metadata_with_rent_transfer(
+            &payer_pubkey,
+            &Pubkey::new_unique(),
+            &token_context.mint_authority.pubkey(),
+            "Name".to_string(),
+            "Symbol".to_string(),
+            "URI".to_string(),
+            &[&token_context.mint_authority],
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                1,
+                InstructionError::Custom(TokenError::InvalidExtensionCombination as u32)
+            )
+        )))
+    );
+}
+
+#[tokio::test]
+async fn fail_init_in_another_mint() {
+    let authority = Pubkey::new_unique();
+    let first_mint_keypair = Keypair::new();
+    let first_mint = first_mint_keypair.pubkey();
+    let mut test_context = setup(first_mint_keypair, &authority).await;
+    let second_mint_keypair = Keypair::new();
+    let second_mint = second_mint_keypair.pubkey();
+    test_context
+        .init_token_with_mint_keypair_and_freeze_authority(
+            second_mint_keypair,
+            vec![ExtensionInitializationParams::MetadataPointer {
+                authority: Some(authority),
+                metadata_address: Some(second_mint),
+            }],
+            None,
+        )
+        .await
+        .unwrap();
+
+    let token_context = test_context.token_context.take().unwrap();
+
+    let error = token_context
+        .token
+        .process_ixs(
+            &[spl_token_metadata_interface::instruction::initialize(
+                &spl_token_2022::id(),
+                &first_mint,
+                &Pubkey::new_unique(),
+                token_context.token.get_address(),
+                &token_context.mint_authority.pubkey(),
+                "Name".to_string(),
+                "Symbol".to_string(),
+                "URI".to_string(),
+            )],
+            &[&token_context.mint_authority],
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::MintMismatch as u32)
+            )
+        )))
+    );
+}
+
+#[tokio::test]
+async fn fail_without_signature() {
+    let authority = Pubkey::new_unique();
+    let mint_keypair = Keypair::new();
+    let mut test_context = setup(mint_keypair, &authority).await;
+
+    let token_context = test_context.token_context.take().unwrap();
+
+    let mut instruction = spl_token_metadata_interface::instruction::initialize(
+        &spl_token_2022::id(),
+        token_context.token.get_address(),
+        &Pubkey::new_unique(),
+        token_context.token.get_address(),
+        &token_context.mint_authority.pubkey(),
+        "Name".to_string(),
+        "Symbol".to_string(),
+        "URI".to_string(),
+    );
+    instruction.accounts[3].is_signer = false;
+    let error = token_context
+        .token
+        .process_ixs(&[instruction], &[] as &[&dyn Signer; 0]) // yuck, but the compiler needs it
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature)
+        )))
+    );
+}

--- a/token/program-2022/src/extension/token_metadata/processor.rs
+++ b/token/program-2022/src/extension/token_metadata/processor.rs
@@ -49,6 +49,8 @@ pub fn process_initialize(
 
     // scope the mint authority check, since the mint is in the same account!
     {
+        // This check isn't really needed since we'll be writing into the account,
+        // but auditors like it
         check_program_account(mint_info.owner)?;
         let mint_data = mint_info.try_borrow_data()?;
         let mint = StateWithExtensions::<Mint>::unpack(&mint_data)?;

--- a/token/program-2022/src/extension/token_metadata/processor.rs
+++ b/token/program-2022/src/extension/token_metadata/processor.rs
@@ -1,18 +1,86 @@
 //! Token-metadata processor
 
 use {
-    solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, msg, pubkey::Pubkey},
-    spl_token_metadata_interface::instruction::{
-        Emit, Initialize, RemoveKey, TokenMetadataInstruction, UpdateAuthority, UpdateField,
+    crate::{
+        check_program_account,
+        error::TokenError,
+        extension::{
+            alloc_and_serialize, metadata_pointer::MetadataPointer, BaseStateWithExtensions,
+            StateWithExtensions,
+        },
+        state::Mint,
+    },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        msg,
+        program_error::ProgramError,
+        program_option::COption,
+        pubkey::Pubkey,
+    },
+    spl_token_metadata_interface::{
+        error::TokenMetadataError,
+        instruction::{
+            Emit, Initialize, RemoveKey, TokenMetadataInstruction, UpdateAuthority, UpdateField,
+        },
+        state::{OptionalNonZeroPubkey, TokenMetadata},
     },
 };
 
 /// Processes a [Initialize](enum.TokenMetadataInstruction.html) instruction.
 pub fn process_initialize(
     _program_id: &Pubkey,
-    _accounts: &[AccountInfo],
-    _data: Initialize,
+    accounts: &[AccountInfo],
+    data: Initialize,
 ) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    let metadata_info = next_account_info(account_info_iter)?;
+    let update_authority_info = next_account_info(account_info_iter)?;
+    let mint_info = next_account_info(account_info_iter)?;
+    let mint_authority_info = next_account_info(account_info_iter)?;
+
+    // check that the mint and metadata accounts are the same, since the metadata
+    // extension should only describe itself
+    if metadata_info.key != mint_info.key {
+        msg!("Metadata for a mint must be initialized in the mint itself.");
+        return Err(TokenError::MintMismatch.into());
+    }
+
+    // scope the mint authority check, since the mint is in the same account!
+    {
+        check_program_account(mint_info.owner)?;
+        let mint_data = mint_info.try_borrow_data()?;
+        let mint = StateWithExtensions::<Mint>::unpack(&mint_data)?;
+
+        if !mint_authority_info.is_signer {
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+        if mint.base.mint_authority.as_ref() != COption::Some(mint_authority_info.key) {
+            return Err(TokenMetadataError::IncorrectMintAuthority.into());
+        }
+
+        if mint.get_extension::<MetadataPointer>().is_err() {
+            msg!("A mint with metadata must have the metadata-pointer extension initialized");
+            return Err(TokenError::InvalidExtensionCombination.into());
+        }
+    }
+
+    // Create the token metadata
+    let update_authority = OptionalNonZeroPubkey::try_from(Some(*update_authority_info.key))?;
+    let token_metadata = TokenMetadata {
+        name: data.name,
+        symbol: data.symbol,
+        uri: data.uri,
+        update_authority,
+        mint: *mint_info.key,
+        ..Default::default()
+    };
+
+    // allocate a TLV entry for the space and write it in, assumes that there's
+    // enough SOL for the new rent-exemption
+    alloc_and_serialize::<Mint, _>(metadata_info, &token_metadata, false)?;
+
     Ok(())
 }
 


### PR DESCRIPTION
#### Problem

As one of the steps in #4648, Token-2022 needs to implement the token-metadata interface to be a token-metadata program, but there's only the bare scaffolding for it.

#### Solution

Start with the basic instruction: initialization! This also adds support in the token-client and some tests, in separate commits, so you can go through them piece by piece.