### PR TITLE
token-2022: Implement `TokenMetadataInterface::UpdateField`

### DIFF
--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -29,7 +29,7 @@ use {
         solana_zk_token_sdk::{errors::ProofError, zk_token_elgamal::pod::ElGamalPubkey},
         state::{Account, AccountState, Mint, Multisig},
     },
-    spl_token_metadata_interface::state::TokenMetadata,
+    spl_token_metadata_interface::state::{Field, TokenMetadata},
     std::{
         fmt, io,
         sync::{Arc, RwLock},
@@ -2559,6 +2559,22 @@ where
         .await
     }
 
+    async fn get_additional_rent_for_new_metadata(
+        &self,
+        token_metadata: &TokenMetadata,
+    ) -> TokenResult<u64> {
+        let account = self.get_account(self.pubkey).await?;
+        let account_lamports = account.lamports;
+        let mint_state = self.unpack_mint_info(account)?;
+        let new_account_len = mint_state.try_get_new_account_len(token_metadata)?;
+        let new_rent_exempt_minimum = self
+            .client
+            .get_minimum_balance_for_rent_exemption(new_account_len)
+            .await
+            .map_err(TokenError::Client)?;
+        Ok(new_rent_exempt_minimum.saturating_sub(account_lamports))
+    }
+
     /// Initialize token-metadata on a mint
     #[allow(clippy::too_many_arguments)]
     pub async fn initialize_token_metadata_with_rent_transfer<S: Signers>(
@@ -2571,22 +2587,15 @@ where
         uri: String,
         signing_keypairs: &S,
     ) -> TokenResult<T::Output> {
-        let account = self.get_account(self.pubkey).await?;
-        let account_lamports = account.lamports;
-        let mint_state = self.unpack_mint_info(account)?;
         let token_metadata = TokenMetadata {
             name,
             symbol,
             uri,
             ..Default::default()
         };
-        let new_account_len = mint_state.try_get_new_account_len(&token_metadata)?;
-        let new_rent_exempt_minimum = self
-            .client
-            .get_minimum_balance_for_rent_exemption(new_account_len)
-            .await
-            .map_err(TokenError::Client)?;
-        let additional_lamports = new_rent_exempt_minimum.saturating_sub(account_lamports);
+        let additional_lamports = self
+            .get_additional_rent_for_new_metadata(&token_metadata)
+            .await?;
         let mut instructions = vec![];
         if additional_lamports > 0 {
             instructions.push(system_instruction::transfer(
@@ -2604,6 +2613,78 @@ where
             token_metadata.name,
             token_metadata.symbol,
             token_metadata.uri,
+        ));
+        self.process_ixs(&instructions, signing_keypairs).await
+    }
+
+    /// Update a token-metadata field on a mint
+    pub async fn update_field_in_token_metadata<S: Signers>(
+        &self,
+        update_authority: &Pubkey,
+        field: Field,
+        value: String,
+        signing_keypairs: &S,
+    ) -> TokenResult<T::Output> {
+        self.process_ixs(
+            &[spl_token_metadata_interface::instruction::update_field(
+                &self.program_id,
+                &self.pubkey,
+                update_authority,
+                field,
+                value,
+            )],
+            signing_keypairs,
+        )
+        .await
+    }
+
+    async fn get_additional_rent_for_updated_metadata(
+        &self,
+        field: Field,
+        value: String,
+    ) -> TokenResult<u64> {
+        let account = self.get_account(self.pubkey).await?;
+        let account_lamports = account.lamports;
+        let mint_state = self.unpack_mint_info(account)?;
+        let mut token_metadata = mint_state.get_variable_len_extension::<TokenMetadata>()?;
+        token_metadata.update(field, value);
+        let new_account_len = mint_state.try_get_new_account_len(&token_metadata)?;
+        let new_rent_exempt_minimum = self
+            .client
+            .get_minimum_balance_for_rent_exemption(new_account_len)
+            .await
+            .map_err(TokenError::Client)?;
+        Ok(new_rent_exempt_minimum.saturating_sub(account_lamports))
+    }
+
+    /// Update a token-metadata field on a mint. Includes a transfer for any
+    /// additional rent-exempt SOL required.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn update_field_in_token_metadata_with_rent_transfer<S: Signers>(
+        &self,
+        payer: &Pubkey,
+        update_authority: &Pubkey,
+        field: Field,
+        value: String,
+        signing_keypairs: &S,
+    ) -> TokenResult<T::Output> {
+        let additional_lamports = self
+            .get_additional_rent_for_updated_metadata(field.clone(), value.clone())
+            .await?;
+        let mut instructions = vec![];
+        if additional_lamports > 0 {
+            instructions.push(system_instruction::transfer(
+                payer,
+                &self.pubkey,
+                additional_lamports,
+            ));
+        }
+        instructions.push(spl_token_metadata_interface::instruction::update_field(
+            &self.program_id,
+            &self.pubkey,
+            update_authority,
+            field,
+            value,
         ));
         self.process_ixs(&instructions, signing_keypairs).await
     }

--- a/token/program-2022-test/tests/token_metadata_update_field.rs
+++ b/token/program-2022-test/tests/token_metadata_update_field.rs
@@ -1,0 +1,204 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+use {
+    program_test::TestContext,
+    solana_program_test::{processor, tokio, ProgramTest},
+    solana_sdk::{
+        instruction::InstructionError, pubkey::Pubkey, signature::Signer, signer::keypair::Keypair,
+        transaction::TransactionError, transport::TransportError,
+    },
+    spl_token_2022::{extension::BaseStateWithExtensions, processor::Processor},
+    spl_token_client::token::{ExtensionInitializationParams, TokenError as TokenClientError},
+    spl_token_metadata_interface::{
+        error::TokenMetadataError,
+        instruction::update_field,
+        state::{Field, TokenMetadata},
+    },
+    std::{convert::TryInto, sync::Arc},
+    test_case::test_case,
+};
+
+fn setup_program_test() -> ProgramTest {
+    let mut program_test = ProgramTest::default();
+    program_test.add_program(
+        "spl_token_2022",
+        spl_token_2022::id(),
+        processor!(Processor::process),
+    );
+    program_test
+}
+
+async fn setup(mint: Keypair, authority: &Pubkey) -> TestContext {
+    let program_test = setup_program_test();
+
+    let context = program_test.start_with_context().await;
+    let context = Arc::new(tokio::sync::Mutex::new(context));
+    let mut context = TestContext {
+        context,
+        token_context: None,
+    };
+    let metadata_address = Some(mint.pubkey());
+    context
+        .init_token_with_mint_keypair_and_freeze_authority(
+            mint,
+            vec![ExtensionInitializationParams::MetadataPointer {
+                authority: Some(*authority),
+                metadata_address,
+            }],
+            None,
+        )
+        .await
+        .unwrap();
+    context
+}
+
+#[test_case(Field::Name, "This is my larger name".to_string() ; "larger name")]
+#[test_case(Field::Name, "Smaller".to_string() ; "smaller name")]
+#[test_case(Field::Key("my new field".to_string()), "Some data for the new field!".to_string() ; "new field")]
+#[tokio::test]
+async fn success_update(field: Field, value: String) {
+    let authority = Keypair::new();
+    let mint_keypair = Keypair::new();
+    let mut test_context = setup(mint_keypair, &authority.pubkey()).await;
+    let payer_pubkey = test_context.context.lock().await.payer.pubkey();
+    let token_context = test_context.token_context.take().unwrap();
+
+    let update_authority = Keypair::new();
+    let name = "MySuperCoolToken".to_string();
+    let symbol = "MINE".to_string();
+    let uri = "my.super.cool.token".to_string();
+    let mut token_metadata = TokenMetadata {
+        name,
+        symbol,
+        uri,
+        update_authority: Some(update_authority.pubkey()).try_into().unwrap(),
+        mint: *token_context.token.get_address(),
+        ..Default::default()
+    };
+
+    token_context
+        .token
+        .initialize_token_metadata_with_rent_transfer(
+            &payer_pubkey,
+            &update_authority.pubkey(),
+            &token_context.mint_authority.pubkey(),
+            token_metadata.name.clone(),
+            token_metadata.symbol.clone(),
+            token_metadata.uri.clone(),
+            &[&token_context.mint_authority],
+        )
+        .await
+        .unwrap();
+
+    let old_space = token_metadata.tlv_size_of().unwrap();
+    token_metadata.update(field.clone(), value.clone());
+    let new_space = token_metadata.tlv_size_of().unwrap();
+
+    if new_space > old_space {
+        let error = token_context
+            .token
+            .update_field_in_token_metadata(
+                &update_authority.pubkey(),
+                field.clone(),
+                value.clone(),
+                &[&update_authority],
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(
+            error,
+            TokenClientError::Client(Box::new(TransportError::TransactionError(
+                TransactionError::InsufficientFundsForRent { account_index: 2 }
+            )))
+        );
+    }
+
+    // transfer required lamports
+    token_context
+        .token
+        .update_field_in_token_metadata_with_rent_transfer(
+            &payer_pubkey,
+            &update_authority.pubkey(),
+            field,
+            value,
+            &[&update_authority],
+        )
+        .await
+        .unwrap();
+
+    // check that the account looks good
+    let mint_info = token_context.token.get_mint_info().await.unwrap();
+    let fetched_metadata = mint_info
+        .get_variable_len_extension::<TokenMetadata>()
+        .unwrap();
+    assert_eq!(fetched_metadata, token_metadata);
+}
+
+#[tokio::test]
+async fn fail_authority_checks() {
+    let authority = Keypair::new();
+    let mint_keypair = Keypair::new();
+    let mut test_context = setup(mint_keypair, &authority.pubkey()).await;
+    let payer_pubkey = test_context.context.lock().await.payer.pubkey();
+    let token_context = test_context.token_context.take().unwrap();
+
+    let update_authority = Keypair::new();
+    token_context
+        .token
+        .initialize_token_metadata_with_rent_transfer(
+            &payer_pubkey,
+            &update_authority.pubkey(),
+            &token_context.mint_authority.pubkey(),
+            "MySuperCoolToken".to_string(),
+            "MINE".to_string(),
+            "my.super.cool.token".to_string(),
+            &[&token_context.mint_authority],
+        )
+        .await
+        .unwrap();
+
+    // no signature
+    let mut instruction = update_field(
+        &spl_token_2022::id(),
+        token_context.token.get_address(),
+        &update_authority.pubkey(),
+        Field::Name,
+        "new_name".to_string(),
+    );
+    instruction.accounts[1].is_signer = false;
+
+    let error = token_context
+        .token
+        .process_ixs(&[instruction], &[] as &[&dyn Signer; 0]) // yuck, but the compiler needs it
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature)
+        )))
+    );
+
+    // wrong authority
+    let wrong_authority = Keypair::new();
+    let error = token_context
+        .token
+        .update_field_in_token_metadata(
+            &wrong_authority.pubkey(),
+            Field::Name,
+            "new_name".to_string(),
+            &[&wrong_authority],
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenMetadataError::IncorrectUpdateAuthority as u32)
+            )
+        )))
+    );
+}

--- a/token/program-2022/src/extension/token_metadata/processor.rs
+++ b/token/program-2022/src/extension/token_metadata/processor.rs
@@ -27,6 +27,21 @@ use {
     },
 };
 
+fn check_update_authority(
+    update_authority_info: &AccountInfo,
+    expected_update_authority: &OptionalNonZeroPubkey,
+) -> Result<(), ProgramError> {
+    if !update_authority_info.is_signer {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+    let update_authority = Option::<Pubkey>::from(expected_update_authority.clone())
+        .ok_or(TokenMetadataError::ImmutableMetadata)?;
+    if update_authority != *update_authority_info.key {
+        return Err(TokenMetadataError::IncorrectUpdateAuthority.into());
+    }
+    Ok(())
+}
+
 /// Processes a [Initialize](enum.TokenMetadataInstruction.html) instruction.
 pub fn process_initialize(
     _program_id: &Pubkey,
@@ -89,9 +104,29 @@ pub fn process_initialize(
 /// Processes an [UpdateField](enum.TokenMetadataInstruction.html) instruction.
 pub fn process_update_field(
     _program_id: &Pubkey,
-    _accounts: &[AccountInfo],
-    _data: UpdateField,
+    accounts: &[AccountInfo],
+    data: UpdateField,
 ) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let metadata_info = next_account_info(account_info_iter)?;
+    let update_authority_info = next_account_info(account_info_iter)?;
+
+    // deserialize the metadata, but scope the data borrow since we'll probably
+    // realloc the account
+    let mut token_metadata = {
+        let buffer = metadata_info.try_borrow_data()?;
+        let mint = StateWithExtensions::<Mint>::unpack(&buffer)?;
+        mint.get_variable_len_extension::<TokenMetadata>()?
+    };
+
+    check_update_authority(update_authority_info, &token_metadata.update_authority)?;
+
+    // Update the field
+    token_metadata.update(data.field, data.value);
+
+    // Update / realloc the account
+    alloc_and_serialize::<Mint, _>(metadata_info, &token_metadata, true)?;
+
     Ok(())
 }
 


### PR DESCRIPTION
#### Problem

As one of the steps in #4648, Token-2022 needs to implement the token-metadata interface's `UpdateField` to be a token-metadata program.

#### Solution

This builds directly on #4744, so you just need to look at the last three commits. This has the same structure as the `Initialize` PR:

* processor implementation
* token client support
* tests