### PR TITLE
discriminator: Remove dependency on "full" feature

### DIFF
--- a/libraries/discriminator/derive/Cargo.toml
+++ b/libraries/discriminator/derive/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 quote = "1.0"
 spl-discriminator-syn = { version = "0.1.0", path = "../syn" }
-syn = { version = "2.0", features = ["full"] }
+syn = "2.0"
 
 [lib]
 proc-macro = true

--- a/libraries/discriminator/src/lib.rs
+++ b/libraries/discriminator/src/lib.rs
@@ -38,45 +38,16 @@ mod tests {
 
     #[allow(dead_code)]
     #[derive(SplDiscriminate)]
-    #[discriminator_hash_input("global:my_instruction_with_lifetime")]
-    pub struct MyInstruction3<'a> {
-        data: &'a [u8],
+    #[discriminator_hash_input("my_crate_public_instruction")]
+    pub(crate) struct MyInstruction3 {
+        arg1: String,
     }
 
     #[allow(dead_code)]
     #[derive(SplDiscriminate)]
-    #[discriminator_hash_input("global:my_instruction_with_one_generic")]
-    pub struct MyInstruction4<T> {
-        data: T,
-    }
-
-    #[allow(dead_code)]
-    #[derive(SplDiscriminate)]
-    #[discriminator_hash_input("global:my_instruction_with_one_generic_and_lifetime")]
-    pub struct MyInstruction5<'b, T> {
-        data: &'b [T],
-    }
-
-    #[allow(dead_code)]
-    #[derive(SplDiscriminate)]
-    #[discriminator_hash_input("global:my_instruction_with_multiple_generics_and_lifetime")]
-    pub struct MyInstruction6<'c, U, V> {
-        data1: &'c [U],
-        data2: &'c [V],
-    }
-
-    #[allow(dead_code)]
-    #[derive(SplDiscriminate)]
-    #[discriminator_hash_input(
-        "global:my_instruction_with_multiple_generics_and_lifetime_and_where"
-    )]
-    pub struct MyInstruction7<'c, U, V>
-    where
-        U: Clone + Copy,
-        V: Clone + Copy,
-    {
-        data1: &'c [U],
-        data2: &'c [V],
+    #[discriminator_hash_input("my_private_instruction")]
+    struct MyInstruction4 {
+        arg1: u8,
     }
 
     fn assert_discriminator<T: spl_discriminator::discriminator::SplDiscriminate>(
@@ -114,17 +85,8 @@ mod tests {
 
         assert_discriminator::<MyInstruction1>("my_first_instruction");
         assert_discriminator::<MyInstruction2>("global:my_second_instruction");
-        assert_discriminator::<MyInstruction3<'_>>("global:my_instruction_with_lifetime");
-        assert_discriminator::<MyInstruction4<u8>>("global:my_instruction_with_one_generic");
-        assert_discriminator::<MyInstruction5<'_, u8>>(
-            "global:my_instruction_with_one_generic_and_lifetime",
-        );
-        assert_discriminator::<MyInstruction6<'_, u8, u8>>(
-            "global:my_instruction_with_multiple_generics_and_lifetime",
-        );
-        assert_discriminator::<MyInstruction7<'_, u8, u8>>(
-            "global:my_instruction_with_multiple_generics_and_lifetime_and_where",
-        );
+        assert_discriminator::<MyInstruction3>("my_crate_public_instruction");
+        assert_discriminator::<MyInstruction4>("my_private_instruction");
     }
 }
 

--- a/libraries/discriminator/syn/Cargo.toml
+++ b/libraries/discriminator/syn/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 proc-macro2 = "1.0"
 quote = "1.0"
 solana-program = "1.16.1"
-syn = { version = "2.0", features = ["full"] }
+syn = "2.0"
 thiserror = "1.0"
 
 [lib]

--- a/libraries/discriminator/syn/src/lib.rs
+++ b/libraries/discriminator/syn/src/lib.rs
@@ -7,11 +7,11 @@ mod error;
 pub mod parser;
 
 use {
-    crate::{error::SplDiscriminateError, parser::parse_hash_input},
+    crate::parser::parse_hash_input,
     proc_macro2::{Span, TokenStream},
     quote::{quote, ToTokens},
     solana_program::hash,
-    syn::{parse::Parse, Generics, Ident, Item, ItemEnum, ItemStruct, LitByteStr, WhereClause},
+    syn::{ext::IdentExt, parse::Parse, Attribute, Ident, LitByteStr, Token, Visibility},
 };
 
 /// "Builder" struct to implement the `SplDiscriminate` trait
@@ -19,62 +19,31 @@ use {
 pub struct SplDiscriminateBuilder {
     /// The struct/enum identifier
     pub ident: Ident,
-    /// The item's generic arguments (if any)
-    pub generics: Generics,
-    /// The item's where clause for generics (if any)
-    pub where_clause: Option<WhereClause>,
     /// The TLV hash_input
     pub hash_input: String,
 }
 
-impl TryFrom<ItemEnum> for SplDiscriminateBuilder {
-    type Error = SplDiscriminateError;
-
-    fn try_from(item_enum: ItemEnum) -> Result<Self, Self::Error> {
-        let ident = item_enum.ident;
-        let where_clause = item_enum.generics.where_clause.clone();
-        let generics = item_enum.generics;
-        let hash_input = parse_hash_input(&item_enum.attrs)?;
-        Ok(Self {
-            ident,
-            generics,
-            where_clause,
-            hash_input,
-        })
-    }
-}
-
-impl TryFrom<ItemStruct> for SplDiscriminateBuilder {
-    type Error = SplDiscriminateError;
-
-    fn try_from(item_struct: ItemStruct) -> Result<Self, Self::Error> {
-        let ident = item_struct.ident;
-        let where_clause = item_struct.generics.where_clause.clone();
-        let generics = item_struct.generics;
-        let hash_input = parse_hash_input(&item_struct.attrs)?;
-        Ok(Self {
-            ident,
-            generics,
-            where_clause,
-            hash_input,
-        })
-    }
-}
-
 impl Parse for SplDiscriminateBuilder {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-        let item = Item::parse(input)?;
-        match item {
-            Item::Enum(item_enum) => item_enum.try_into(),
-            Item::Struct(item_struct) => item_struct.try_into(),
-            _ => {
-                return Err(syn::Error::new(
-                    Span::call_site(),
-                    "Only enums and structs are supported",
-                ))
-            }
+        let attrs = input.call(Attribute::parse_outer)?;
+        let hash_input = parse_hash_input(&attrs)
+            .map_err(|e| syn::Error::new(input.span(), format!("Failed to parse item: {}", e)))?;
+        if input.peek(Token![pub]) {
+            input.parse::<Visibility>()?;
         }
-        .map_err(|e| syn::Error::new(input.span(), format!("Failed to parse item: {}", e)))
+        if input.peek(Token![struct]) ||input.peek(Token![enum]) {
+            input.call(Ident::parse_any)?;
+        }
+        let ident = input.parse::<Ident>()?;
+        // just consume the rest
+        input.step(|cursor| {
+            let mut rest = *cursor;
+            while let Some((_, next)) = rest.token_tree() {
+                rest = next;
+            }
+            Ok(((), rest))
+        })?;
+        Ok(Self { ident, hash_input })
     }
 }
 
@@ -87,11 +56,9 @@ impl ToTokens for SplDiscriminateBuilder {
 impl From<&SplDiscriminateBuilder> for TokenStream {
     fn from(builder: &SplDiscriminateBuilder) -> Self {
         let ident = &builder.ident;
-        let generics = &builder.generics;
-        let where_clause = &builder.where_clause;
         let bytes = get_discriminator_bytes(&builder.hash_input);
         quote! {
-            impl #generics spl_discriminator::discriminator::SplDiscriminate for #ident #generics #where_clause {
+            impl spl_discriminator::discriminator::SplDiscriminate for #ident {
                 const SPL_DISCRIMINATOR: spl_discriminator::discriminator::ArrayDiscriminator
                     = spl_discriminator::discriminator::ArrayDiscriminator::new(*#bytes);
             }


### PR DESCRIPTION
#### Problem

There are many recompilations when working on spl crates, starting with `spl-discriminator-syn`, probably due to crates that are recompiled with different feature sets.

#### Solution

I tried a few different things, including specifying all `syn` usage to use the features `full` and `extra-traits`, to line up with solana-sdk-macro. I also tried to remove the dependency on the full in one crate, which also didn't really have an effect.

This is the result of that second effort. Unfortunately, it means that generics, lifetimes, and where clauses are no longer supported. The `ItemEnum` and `ItemStruct` parsers are really nifty!