### PR TITLE
token-client: Add simulation support to ProgramClient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7010,9 +7010,11 @@ version = "0.5.1"
 dependencies = [
  "async-trait",
  "futures-util",
+ "solana-banks-interface",
  "solana-cli-output",
  "solana-program-test",
  "solana-rpc-client",
+ "solana-rpc-client-api",
  "solana-sdk",
  "spl-associated-token-account 2.0.0",
  "spl-memo 4.0.0",

--- a/token-metadata/example/tests/program_test.rs
+++ b/token-metadata/example/tests/program_test.rs
@@ -9,7 +9,7 @@ use {
     spl_token_client::{
         client::{
             ProgramBanksClient, ProgramBanksClientProcessTransaction, ProgramClient,
-            SendTransaction,
+            SendTransaction, SimulateTransaction,
         },
         token::Token,
     },
@@ -56,7 +56,7 @@ pub async fn setup(
     (context, client, payer)
 }
 
-pub async fn setup_mint<T: SendTransaction>(
+pub async fn setup_mint<T: SendTransaction + SimulateTransaction>(
     program_id: &Pubkey,
     mint_authority: &Pubkey,
     decimals: u8,

--- a/token-upgrade/cli/src/main.rs
+++ b/token-upgrade/cli/src/main.rs
@@ -497,7 +497,7 @@ mod test {
         super::*,
         solana_sdk::{bpf_loader_upgradeable, signer::keypair::Keypair},
         solana_test_validator::{TestValidator, TestValidatorGenesis, UpgradeableProgramInfo},
-        spl_token_client::client::{ProgramClient, SendTransaction},
+        spl_token_client::client::{ProgramClient, SendTransaction, SimulateTransaction},
         std::path::PathBuf,
     };
 
@@ -533,7 +533,7 @@ mod test {
         test_validator_genesis.start_async().await
     }
 
-    async fn setup_mint<T: SendTransaction>(
+    async fn setup_mint<T: SendTransaction + SimulateTransaction>(
         program_id: &Pubkey,
         mint_authority: &Pubkey,
         decimals: u8,

--- a/token-upgrade/program/tests/functional.rs
+++ b/token-upgrade/program/tests/functional.rs
@@ -17,7 +17,7 @@ use {
     spl_token_client::{
         client::{
             ProgramBanksClient, ProgramBanksClientProcessTransaction, ProgramClient,
-            SendTransaction,
+            SendTransaction, SimulateTransaction,
         },
         token::Token,
     },
@@ -68,7 +68,7 @@ async fn setup() -> (
     (context, client, payer)
 }
 
-async fn setup_mint<T: SendTransaction>(
+async fn setup_mint<T: SendTransaction + SimulateTransaction>(
     program_id: &Pubkey,
     mint_authority: &Pubkey,
     decimals: u8,

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -4598,6 +4598,10 @@ async fn finish_tx<'a>(
                 signature: signature.to_string(),
             }))
         }
+        RpcClientResponse::Simulation(_) => {
+            // Implement this once the CLI supports dry-running / simulation
+            unreachable!()
+        }
     }
 }
 

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -10,9 +10,11 @@ version = "0.5.1"
 [dependencies]
 async-trait = "0.1"
 futures-util = "0.3"
+solana-banks-interface = "1.16.3"
 solana-cli-output = { version = "1.16.3", optional = true }
 solana-program-test = "1.16.3"
 solana-rpc-client = "1.16.3"
+solana-rpc-client-api = "1.16.3"
 solana-sdk = "1.16.3"
 # We never want the entrypoint for ATA, but we want the entrypoint for token when
 # testing token

--- a/token/client/src/client.rs
+++ b/token/client/src/client.rs
@@ -150,10 +150,6 @@ impl SimulateTransactionRpc for ProgramRpcClientSendTransaction {
         transaction: &'a Transaction,
     ) -> BoxFuture<'a, ProgramClientResult<Self::SimulationOutput>> {
         Box::pin(async move {
-            if !transaction.is_signed() {
-                return Err("Cannot send transaction: not fully signed".into());
-            }
-
             client
                 .simulate_transaction(transaction)
                 .await

--- a/token/client/src/client.rs
+++ b/token/client/src/client.rs
@@ -1,7 +1,9 @@
 use {
     async_trait::async_trait,
+    solana_banks_interface::BanksTransactionResultWithSimulation,
     solana_program_test::{tokio::sync::Mutex, BanksClient, ProgramTestContext},
     solana_rpc_client::nonblocking::rpc_client::RpcClient,
+    solana_rpc_client_api::response::RpcSimulateTransactionResult,
     solana_sdk::{
         account::Account, hash::Hash, pubkey::Pubkey, signature::Signature,
         transaction::Transaction,
@@ -16,6 +18,11 @@ pub trait SendTransaction {
     type Output;
 }
 
+/// Basic trait for simulating transactions in a validator.
+pub trait SimulateTransaction {
+    type SimulationOutput;
+}
+
 /// Extends basic `SendTransaction` trait with function `send` where client is `&mut BanksClient`.
 /// Required for `ProgramBanksClient`.
 pub trait SendTransactionBanksClient: SendTransaction {
@@ -24,6 +31,16 @@ pub trait SendTransactionBanksClient: SendTransaction {
         client: &'a mut BanksClient,
         transaction: Transaction,
     ) -> BoxFuture<'a, ProgramClientResult<Self::Output>>;
+}
+
+/// Extends basic `SimulateTransaction` trait with function `simulation` where client is `&mut BanksClient`.
+/// Required for `ProgramBanksClient`.
+pub trait SimulateTransactionBanksClient: SimulateTransaction {
+    fn simulate<'a>(
+        &self,
+        client: &'a mut BanksClient,
+        transaction: Transaction,
+    ) -> BoxFuture<'a, ProgramClientResult<Self::SimulationOutput>>;
 }
 
 /// Send transaction to validator using `BanksClient::process_transaction`.
@@ -49,6 +66,25 @@ impl SendTransactionBanksClient for ProgramBanksClientProcessTransaction {
     }
 }
 
+impl SimulateTransaction for ProgramBanksClientProcessTransaction {
+    type SimulationOutput = BanksTransactionResultWithSimulation;
+}
+
+impl SimulateTransactionBanksClient for ProgramBanksClientProcessTransaction {
+    fn simulate<'a>(
+        &self,
+        client: &'a mut BanksClient,
+        transaction: Transaction,
+    ) -> BoxFuture<'a, ProgramClientResult<Self::SimulationOutput>> {
+        Box::pin(async move {
+            client
+                .simulate_transaction(transaction)
+                .await
+                .map_err(Into::into)
+        })
+    }
+}
+
 /// Extends basic `SendTransaction` trait with function `send` where client is `&RpcClient`.
 /// Required for `ProgramRpcClient`.
 pub trait SendTransactionRpc: SendTransaction {
@@ -59,6 +95,16 @@ pub trait SendTransactionRpc: SendTransaction {
     ) -> BoxFuture<'a, ProgramClientResult<Self::Output>>;
 }
 
+/// Extends basic `SimulateTransaction` trait with function `simulate` where client is `&RpcClient`.
+/// Required for `ProgramRpcClient`.
+pub trait SimulateTransactionRpc: SimulateTransaction {
+    fn simulate<'a>(
+        &self,
+        client: &'a RpcClient,
+        transaction: &'a Transaction,
+    ) -> BoxFuture<'a, ProgramClientResult<Self::SimulationOutput>>;
+}
+
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ProgramRpcClientSendTransaction;
 
@@ -66,6 +112,7 @@ pub struct ProgramRpcClientSendTransaction;
 pub enum RpcClientResponse {
     Signature(Signature),
     Transaction(Transaction),
+    Simulation(RpcSimulateTransactionResult),
 }
 
 impl SendTransaction for ProgramRpcClientSendTransaction {
@@ -92,6 +139,30 @@ impl SendTransactionRpc for ProgramRpcClientSendTransaction {
     }
 }
 
+impl SimulateTransaction for ProgramRpcClientSendTransaction {
+    type SimulationOutput = RpcClientResponse;
+}
+
+impl SimulateTransactionRpc for ProgramRpcClientSendTransaction {
+    fn simulate<'a>(
+        &self,
+        client: &'a RpcClient,
+        transaction: &'a Transaction,
+    ) -> BoxFuture<'a, ProgramClientResult<Self::SimulationOutput>> {
+        Box::pin(async move {
+            if !transaction.is_signed() {
+                return Err("Cannot send transaction: not fully signed".into());
+            }
+
+            client
+                .simulate_transaction(transaction)
+                .await
+                .map(|r| RpcClientResponse::Simulation(r.value))
+                .map_err(Into::into)
+        })
+    }
+}
+
 pub type ProgramClientError = Box<dyn std::error::Error + Send + Sync>;
 pub type ProgramClientResult<T> = Result<T, ProgramClientError>;
 
@@ -99,7 +170,7 @@ pub type ProgramClientResult<T> = Result<T, ProgramClientError>;
 #[async_trait]
 pub trait ProgramClient<ST>
 where
-    ST: SendTransaction,
+    ST: SendTransaction + SimulateTransaction,
 {
     async fn get_minimum_balance_for_rent_exemption(
         &self,
@@ -111,6 +182,11 @@ where
     async fn send_transaction(&self, transaction: &Transaction) -> ProgramClientResult<ST::Output>;
 
     async fn get_account(&self, address: Pubkey) -> ProgramClientResult<Option<Account>>;
+
+    async fn simulate_transaction(
+        &self,
+        transaction: &Transaction,
+    ) -> ProgramClientResult<ST::SimulationOutput>;
 }
 
 enum ProgramBanksClientContext {
@@ -163,7 +239,7 @@ impl<ST> ProgramBanksClient<ST> {
 #[async_trait]
 impl<ST> ProgramClient<ST> for ProgramBanksClient<ST>
 where
-    ST: SendTransactionBanksClient + Send + Sync,
+    ST: SendTransactionBanksClient + SimulateTransactionBanksClient + Send + Sync,
 {
     async fn get_minimum_balance_for_rent_exemption(
         &self,
@@ -189,6 +265,17 @@ where
         self.run_in_lock(|client| {
             let transaction = transaction.clone();
             self.send.send(client, transaction)
+        })
+        .await
+    }
+
+    async fn simulate_transaction(
+        &self,
+        transaction: &Transaction,
+    ) -> ProgramClientResult<ST::SimulationOutput> {
+        self.run_in_lock(|client| {
+            let transaction = transaction.clone();
+            self.send.simulate(client, transaction)
         })
         .await
     }
@@ -222,7 +309,7 @@ impl<ST> ProgramRpcClient<ST> {
 #[async_trait]
 impl<ST> ProgramClient<ST> for ProgramRpcClient<ST>
 where
-    ST: SendTransactionRpc + Send + Sync,
+    ST: SendTransactionRpc + SimulateTransactionRpc + Send + Sync,
 {
     async fn get_minimum_balance_for_rent_exemption(
         &self,
@@ -240,6 +327,13 @@ where
 
     async fn send_transaction(&self, transaction: &Transaction) -> ProgramClientResult<ST::Output> {
         self.send.send(&self.client, transaction).await
+    }
+
+    async fn simulate_transaction(
+        &self,
+        transaction: &Transaction,
+    ) -> ProgramClientResult<ST::SimulationOutput> {
+        self.send.simulate(&self.client, transaction).await
     }
 
     async fn get_account(&self, address: Pubkey) -> ProgramClientResult<Option<Account>> {
@@ -275,7 +369,10 @@ impl<ST> ProgramOfflineClient<ST> {
 #[async_trait]
 impl<ST> ProgramClient<ST> for ProgramOfflineClient<ST>
 where
-    ST: SendTransaction<Output = RpcClientResponse> + Send + Sync,
+    ST: SendTransaction<Output = RpcClientResponse>
+        + SimulateTransaction<SimulationOutput = RpcClientResponse>
+        + Send
+        + Sync,
 {
     async fn get_minimum_balance_for_rent_exemption(
         &self,
@@ -289,6 +386,13 @@ where
     }
 
     async fn send_transaction(&self, transaction: &Transaction) -> ProgramClientResult<ST::Output> {
+        Ok(RpcClientResponse::Transaction(transaction.clone()))
+    }
+
+    async fn simulate_transaction(
+        &self,
+        transaction: &Transaction,
+    ) -> ProgramClientResult<ST::SimulationOutput> {
         Ok(RpcClientResponse::Transaction(transaction.clone()))
     }
 

--- a/token/client/src/output.rs
+++ b/token/client/src/output.rs
@@ -10,6 +10,11 @@ impl fmt::Display for RpcClientResponse {
                 writeln!(f, "Transaction:")?;
                 writeln_transaction(f, &transaction.clone().into(), None, "  ", None, None)
             }
+            RpcClientResponse::Simulation(result) => {
+                writeln!(f, "Simulation:")?;
+                // maybe implement another formatter on simulation result?
+                writeln!(f, "{result:?}")
+            }
         }
     }
 }

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -104,7 +104,7 @@ impl ConfidentialTokenAccountMeta {
         maximum_pending_balance_credit_counter: u64,
     ) -> Self
     where
-        T: SendTransaction,
+        T: SendTransaction + SimulateTransaction,
     {
         let token_account_keypair = Keypair::new();
         token

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -25,7 +25,7 @@ use {
         },
     },
     spl_token_client::{
-        client::SendTransaction,
+        client::{SendTransaction, SimulateTransaction},
         token::{ExtensionInitializationParams, Token, TokenError as TokenClientError},
     },
     std::convert::TryInto,
@@ -62,7 +62,7 @@ struct ConfidentialTokenAccountMeta {
 impl ConfidentialTokenAccountMeta {
     async fn new<T>(token: &Token<T>, owner: &Keypair) -> Self
     where
-        T: SendTransaction,
+        T: SendTransaction + SimulateTransaction,
     {
         let token_account_keypair = Keypair::new();
         token
@@ -143,7 +143,7 @@ impl ConfidentialTokenAccountMeta {
     #[cfg(all(feature = "zk-ops", feature = "proof-program"))]
     async fn new_with_required_memo_transfers<T>(token: &Token<T>, owner: &Keypair) -> Self
     where
-        T: SendTransaction,
+        T: SendTransaction + SimulateTransaction,
     {
         let token_account_keypair = Keypair::new();
         token
@@ -196,7 +196,7 @@ impl ConfidentialTokenAccountMeta {
         decimals: u8,
     ) -> Self
     where
-        T: SendTransaction,
+        T: SendTransaction + SimulateTransaction,
     {
         let meta = Self::new(token, owner).await;
 
@@ -238,7 +238,7 @@ impl ConfidentialTokenAccountMeta {
     #[cfg(feature = "zk-ops")]
     async fn check_balances<T>(&self, token: &Token<T>, expected: ConfidentialTokenAccountBalances)
     where
-        T: SendTransaction,
+        T: SendTransaction + SimulateTransaction,
     {
         let state = token.get_account_info(&self.token_account).await.unwrap();
         let extension = state
@@ -289,7 +289,7 @@ async fn check_withheld_amount_in_mint<T>(
     withdraw_withheld_authority_elgamal_keypair: &ElGamalKeypair,
     expected: u64,
 ) where
-    T: SendTransaction,
+    T: SendTransaction + SimulateTransaction,
 {
     let state = token.get_mint_info().await.unwrap();
     let extension = state.get_extension::<ConfidentialTransferMint>().unwrap();


### PR DESCRIPTION
#### Problem

While working on the token-metadata `emit` instruction, which writes the token-metadata bytes into return data, I realized that we can't simulate transactions using the token-client.

#### Solution

Support transaction simulation! I went with a separate set of traits rather than adding simulation to the `SendTransaction` trait, in the case that we want to add tpu-client support. In that case, it would be a new client that *does not* support simulation, so it wouldn't implement those traits.

Since the RPC simulation results don't have any normal formatters, I just went with the default `Debug` one. Where would be the best place to implement that?

I'm not sure if either of you was already thinking about this, but I hope it lines up with your expectations! If not, I'm happy to drop it and go another route.