### PR TITLE
stake-pool: Allow pool token mint to include metadata

### DIFF
--- a/stake-pool/program/src/state.rs
+++ b/stake-pool/program/src/state.rs
@@ -492,12 +492,14 @@ impl StakePool {
 
 /// Checks if the given extension is supported for the stake pool mint
 pub fn is_extension_supported_for_mint(extension_type: &ExtensionType) -> bool {
-    const SUPPORTED_EXTENSIONS: [ExtensionType; 5] = [
+    const SUPPORTED_EXTENSIONS: [ExtensionType; 7] = [
         ExtensionType::Uninitialized,
         ExtensionType::TransferFeeConfig,
         ExtensionType::ConfidentialTransferMint,
         ExtensionType::DefaultAccountState, // ok, but a freeze authority is not
         ExtensionType::InterestBearingConfig,
+        ExtensionType::MetadataPointer,
+        ExtensionType::TokenMetadata,
     ];
     if !SUPPORTED_EXTENSIONS.contains(extension_type) {
         msg!(


### PR DESCRIPTION
#### Problem

There's been loads of work into supporting token-metadata in token-2022, but currently, a stake pool token cannot have the `MetadataPointer` or `TokenMetadata` extensions.

#### Solution

Add the `MetadataPointer` and `TokenMetadata` extension types in the "allow list" for stake pool token mints.