### PR TITLE
token-2022: Implement `TokenMetadataInstruction::UpdateAuthority`

### DIFF
--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -2701,4 +2701,23 @@ where
         ));
         self.process_ixs(&instructions, signing_keypairs).await
     }
+
+    /// Update the token-metadata authority in a mint
+    pub async fn update_authority_in_token_metadata<S: Signers>(
+        &self,
+        current_authority: &Pubkey,
+        new_authority: Option<Pubkey>,
+        signing_keypairs: &S,
+    ) -> TokenResult<T::Output> {
+        self.process_ixs(
+            &[spl_token_metadata_interface::instruction::update_authority(
+                &self.program_id,
+                &self.pubkey,
+                current_authority,
+                new_authority.try_into()?,
+            )],
+            signing_keypairs,
+        )
+        .await
+    }
 }

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -2703,7 +2703,7 @@ where
     }
 
     /// Update the token-metadata authority in a mint
-    pub async fn update_authority_in_token_metadata<S: Signers>(
+    pub async fn token_metadata_update_authority<S: Signers>(
         &self,
         current_authority: &Pubkey,
         new_authority: Option<Pubkey>,

--- a/token/program-2022-test/tests/token_metadata_update_authority.rs
+++ b/token/program-2022-test/tests/token_metadata_update_authority.rs
@@ -1,0 +1,229 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+use {
+    program_test::TestContext,
+    solana_program_test::{processor, tokio, ProgramTest},
+    solana_sdk::{
+        instruction::InstructionError,
+        pubkey::Pubkey,
+        signature::Signer,
+        signer::keypair::Keypair,
+        transaction::{Transaction, TransactionError},
+        transport::TransportError,
+    },
+    spl_token_2022::{extension::BaseStateWithExtensions, processor::Processor},
+    spl_token_client::token::{ExtensionInitializationParams, TokenError as TokenClientError},
+    spl_token_metadata_interface::{
+        error::TokenMetadataError,
+        instruction::update_authority,
+        state::{OptionalNonZeroPubkey, TokenMetadata},
+    },
+    std::{convert::TryInto, sync::Arc},
+};
+
+fn setup_program_test() -> ProgramTest {
+    let mut program_test = ProgramTest::default();
+    program_test.add_program(
+        "spl_token_2022",
+        spl_token_2022::id(),
+        processor!(Processor::process),
+    );
+    program_test
+}
+
+async fn setup(mint: Keypair, authority: &Pubkey) -> TestContext {
+    let program_test = setup_program_test();
+
+    let context = program_test.start_with_context().await;
+    let context = Arc::new(tokio::sync::Mutex::new(context));
+    let mut context = TestContext {
+        context,
+        token_context: None,
+    };
+    let metadata_address = Some(mint.pubkey());
+    context
+        .init_token_with_mint_keypair_and_freeze_authority(
+            mint,
+            vec![ExtensionInitializationParams::MetadataPointer {
+                authority: Some(*authority),
+                metadata_address,
+            }],
+            None,
+        )
+        .await
+        .unwrap();
+    context
+}
+
+#[tokio::test]
+async fn success_update() {
+    let authority = Keypair::new();
+    let mint_keypair = Keypair::new();
+    let mut test_context = setup(mint_keypair, &authority.pubkey()).await;
+    let payer_pubkey = test_context.context.lock().await.payer.pubkey();
+    let token_context = test_context.token_context.take().unwrap();
+
+    let authority = Keypair::new();
+    let name = "MySuperCoolToken".to_string();
+    let symbol = "MINE".to_string();
+    let uri = "my.super.cool.token".to_string();
+    let mut token_metadata = TokenMetadata {
+        name,
+        symbol,
+        uri,
+        update_authority: Some(authority.pubkey()).try_into().unwrap(),
+        mint: *token_context.token.get_address(),
+        ..Default::default()
+    };
+
+    token_context
+        .token
+        .initialize_token_metadata_with_rent_transfer(
+            &payer_pubkey,
+            &authority.pubkey(),
+            &token_context.mint_authority.pubkey(),
+            token_metadata.name.clone(),
+            token_metadata.symbol.clone(),
+            token_metadata.uri.clone(),
+            &[&token_context.mint_authority],
+        )
+        .await
+        .unwrap();
+
+    let new_update_authority = Keypair::new();
+    let new_update_authority_pubkey =
+        OptionalNonZeroPubkey::try_from(Some(new_update_authority.pubkey())).unwrap();
+    token_metadata.update_authority = new_update_authority_pubkey.clone();
+
+    token_context
+        .token
+        .update_authority_in_token_metadata(
+            &authority.pubkey(),
+            Some(new_update_authority.pubkey()),
+            &[&authority],
+        )
+        .await
+        .unwrap();
+
+    // check that the data is correct
+    let mint = token_context.token.get_mint_info().await.unwrap();
+    let fetched_metadata = mint.get_variable_len_extension::<TokenMetadata>().unwrap();
+    assert_eq!(fetched_metadata, token_metadata);
+
+    // unset
+    token_metadata.update_authority = None.try_into().unwrap();
+    token_context
+        .token
+        .update_authority_in_token_metadata(
+            &new_update_authority.pubkey(),
+            None,
+            &[&new_update_authority],
+        )
+        .await
+        .unwrap();
+
+    let mint = token_context.token.get_mint_info().await.unwrap();
+    let fetched_metadata = mint.get_variable_len_extension::<TokenMetadata>().unwrap();
+    assert_eq!(fetched_metadata, token_metadata);
+
+    // fail to update
+    let error = token_context
+        .token
+        .update_authority_in_token_metadata(
+            &new_update_authority.pubkey(),
+            Some(new_update_authority.pubkey()),
+            &[&new_update_authority],
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenMetadataError::ImmutableMetadata as u32)
+            )
+        )))
+    );
+}
+
+#[tokio::test]
+async fn fail_authority_checks() {
+    let program_id = spl_token_2022::id();
+    let authority = Keypair::new();
+    let mint_keypair = Keypair::new();
+    let mint_pubkey = mint_keypair.pubkey();
+    let mut test_context = setup(mint_keypair, &authority.pubkey()).await;
+    let payer_pubkey = test_context.context.lock().await.payer.pubkey();
+    let token_context = test_context.token_context.take().unwrap();
+
+    let authority = Keypair::new();
+    let name = "MySuperCoolToken".to_string();
+    let symbol = "MINE".to_string();
+    let uri = "my.super.cool.token".to_string();
+    let token_metadata = TokenMetadata {
+        name,
+        symbol,
+        uri,
+        update_authority: Some(authority.pubkey()).try_into().unwrap(),
+        mint: *token_context.token.get_address(),
+        ..Default::default()
+    };
+
+    token_context
+        .token
+        .initialize_token_metadata_with_rent_transfer(
+            &payer_pubkey,
+            &authority.pubkey(),
+            &token_context.mint_authority.pubkey(),
+            token_metadata.name.clone(),
+            token_metadata.symbol.clone(),
+            token_metadata.uri.clone(),
+            &[&token_context.mint_authority],
+        )
+        .await
+        .unwrap();
+
+    // wrong authority
+    let error = token_context
+        .token
+        .update_authority_in_token_metadata(&payer_pubkey, None, &[] as &[&dyn Signer; 0])
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenMetadataError::IncorrectUpdateAuthority as u32),
+            )
+        )))
+    );
+
+    // no signature
+    let mut context = test_context.context.lock().await;
+    let mut instruction = update_authority(
+        &program_id,
+        &mint_pubkey,
+        &authority.pubkey(),
+        None.try_into().unwrap(),
+    );
+    instruction.accounts[1].is_signer = false;
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature,)
+    );
+}

--- a/token/program-2022-test/tests/token_metadata_update_authority.rs
+++ b/token/program-2022-test/tests/token_metadata_update_authority.rs
@@ -98,7 +98,7 @@ async fn success_update() {
 
     token_context
         .token
-        .update_authority_in_token_metadata(
+        .token_metadata_update_authority(
             &authority.pubkey(),
             Some(new_update_authority.pubkey()),
             &[&authority],
@@ -115,7 +115,7 @@ async fn success_update() {
     token_metadata.update_authority = None.try_into().unwrap();
     token_context
         .token
-        .update_authority_in_token_metadata(
+        .token_metadata_update_authority(
             &new_update_authority.pubkey(),
             None,
             &[&new_update_authority],
@@ -130,7 +130,7 @@ async fn success_update() {
     // fail to update
     let error = token_context
         .token
-        .update_authority_in_token_metadata(
+        .token_metadata_update_authority(
             &new_update_authority.pubkey(),
             Some(new_update_authority.pubkey()),
             &[&new_update_authority],
@@ -188,7 +188,7 @@ async fn fail_authority_checks() {
     // wrong authority
     let error = token_context
         .token
-        .update_authority_in_token_metadata(&payer_pubkey, None, &[] as &[&dyn Signer; 0])
+        .token_metadata_update_authority(&payer_pubkey, None, &[] as &[&dyn Signer; 0])
         .await
         .unwrap_err();
     assert_eq!(

--- a/token/program-2022/src/extension/token_metadata/processor.rs
+++ b/token/program-2022/src/extension/token_metadata/processor.rs
@@ -149,8 +149,8 @@ pub fn process_update_authority(
     let metadata_info = next_account_info(account_info_iter)?;
     let update_authority_info = next_account_info(account_info_iter)?;
 
-    // deserialize the metadata, but scope the data borrow since we'll probably
-    // realloc the account
+    // deserialize the metadata, but scope the data borrow since we'll write
+    // to the account later
     let mut token_metadata = {
         let buffer = metadata_info.try_borrow_data()?;
         let mint = StateWithExtensions::<Mint>::unpack(&buffer)?;

--- a/token/program-2022/src/extension/token_metadata/processor.rs
+++ b/token/program-2022/src/extension/token_metadata/processor.rs
@@ -142,9 +142,26 @@ pub fn process_remove_key(
 /// Processes a [UpdateAuthority](enum.TokenMetadataInstruction.html) instruction.
 pub fn process_update_authority(
     _program_id: &Pubkey,
-    _accounts: &[AccountInfo],
-    _data: UpdateAuthority,
+    accounts: &[AccountInfo],
+    data: UpdateAuthority,
 ) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let metadata_info = next_account_info(account_info_iter)?;
+    let update_authority_info = next_account_info(account_info_iter)?;
+
+    // deserialize the metadata, but scope the data borrow since we'll probably
+    // realloc the account
+    let mut token_metadata = {
+        let buffer = metadata_info.try_borrow_data()?;
+        let mint = StateWithExtensions::<Mint>::unpack(&buffer)?;
+        mint.get_variable_len_extension::<TokenMetadata>()?
+    };
+
+    check_update_authority(update_authority_info, &token_metadata.update_authority)?;
+    token_metadata.update_authority = data.new_authority;
+    // Update the account, no realloc needed!
+    alloc_and_serialize::<Mint, _>(metadata_info, &token_metadata, true)?;
+
     Ok(())
 }
 


### PR DESCRIPTION
#### Problem

As part of #4648, token-2022 needs to implement `TokenMetadataInstruction::UpdateAuthority` to be a token-metadata program.

#### Solution

Very similar to the example implementation https://github.com/solana-labs/solana-program-library/blob/142708116b57ae11bcfc33758962059c7ddf11c6/token-metadata/example/src/processor.rs#L149-L172

And tests (https://github.com/solana-labs/solana-program-library/blob/master/token-metadata/example/tests/update_authority.rs

Implement them!