### PR TITLE
Governance config nonce

### DIFF
--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -498,6 +498,10 @@ pub enum GovernanceError {
     /// Invalid multi choice proposal parameters
     #[error("Invalid multi choice proposal parameters")]
     InvalidMultiChoiceProposalParameters, // 620
+    
+    /// Governance configuration has changed
+    #[error("Governance configuration has changed")]
+    GovernanceConfigChanged, // 621
 }
 
 impl PrintProgramError for GovernanceError {

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -82,6 +82,7 @@ pub fn process_cast_vote(
         governance_info.key,
         &proposal_governing_token_mint,
     )?;
+    proposal_data.assert_should_not_be_invalidated(governance_data.config_nonce)?;
     proposal_data.assert_can_cast_vote(&governance_data.config, &vote, clock.unix_timestamp)?;
 
     let mut voter_token_owner_record_data =

--- a/governance/program/src/processor/process_create_governance.rs
+++ b/governance/program/src/processor/process_create_governance.rs
@@ -9,7 +9,7 @@ use crate::{
         },
         realm::get_realm_data,
     },
-    tools::structs::Reserved120,
+    tools::structs::Reserved112,
 };
 use solana_program::{
     account_info::{next_account_info, AccountInfo},
@@ -60,8 +60,9 @@ pub fn process_create_governance(
         governed_account: *governed_account_info.key,
         config,
         reserved1: 0,
-        reserved_v2: Reserved120::default(),
+        reserved_v2: Reserved112::default(),
         active_proposal_count: 0,
+        config_nonce: 0,
     };
 
     create_and_serialize_account_signed::<GovernanceV2>(

--- a/governance/program/src/processor/process_create_mint_governance.rs
+++ b/governance/program/src/processor/process_create_mint_governance.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     tools::{
         spl_token::{assert_spl_token_mint_authority_is_signer, set_spl_token_account_authority},
-        structs::Reserved120,
+        structs::Reserved112,
     },
 };
 use solana_program::{
@@ -70,8 +70,9 @@ pub fn process_create_mint_governance(
         governed_account: *governed_mint_info.key,
         config,
         reserved1: 0,
-        reserved_v2: Reserved120::default(),
+        reserved_v2: Reserved112::default(),
         active_proposal_count: 0,
+        config_nonce: 0,
     };
 
     create_and_serialize_account_signed::<GovernanceV2>(

--- a/governance/program/src/processor/process_create_program_governance.rs
+++ b/governance/program/src/processor/process_create_program_governance.rs
@@ -14,7 +14,7 @@ use crate::{
         bpf_loader_upgradeable::{
             assert_program_upgrade_authority_is_signer, set_program_upgrade_authority,
         },
-        structs::Reserved120,
+        structs::Reserved112,
     },
 };
 use solana_program::{
@@ -72,8 +72,9 @@ pub fn process_create_program_governance(
         governed_account: *governed_program_info.key,
         config,
         reserved1: 0,
-        reserved_v2: Reserved120::default(),
+        reserved_v2: Reserved112::default(),
         active_proposal_count: 0,
+        config_nonce: 0,
     };
 
     create_and_serialize_account_signed::<GovernanceV2>(

--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -161,8 +161,10 @@ pub fn process_create_proposal(
         max_voting_time: None,
         vote_threshold: None,
 
-        reserved: [0; 64],
+        reserved: [0; 56],
         reserved1: 0,
+        
+        governance_config_nonce: governance_data.config_nonce,
     };
 
     create_and_serialize_account_signed::<ProposalV2>(

--- a/governance/program/src/processor/process_create_token_governance.rs
+++ b/governance/program/src/processor/process_create_token_governance.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     tools::{
         spl_token::{assert_spl_token_owner_is_signer, set_spl_token_account_authority},
-        structs::Reserved120,
+        structs::Reserved112,
     },
 };
 use solana_program::{
@@ -70,8 +70,9 @@ pub fn process_create_token_governance(
         governed_account: *governed_token_info.key,
         config,
         reserved1: 0,
-        reserved_v2: Reserved120::default(),
+        reserved_v2: Reserved112::default(),
         active_proposal_count: 0,
+        config_nonce: 0,
     };
 
     create_and_serialize_account_signed::<GovernanceV2>(

--- a/governance/program/src/processor/process_finalize_vote.rs
+++ b/governance/program/src/processor/process_finalize_vote.rs
@@ -9,6 +9,7 @@ use solana_program::{
 };
 
 use crate::state::{
+    enums::ProposalState,
     governance::get_governance_data_for_realm,
     proposal::get_proposal_data_for_governance_and_governing_mint,
     realm::get_realm_data_for_governing_token_mint, realm_config::get_realm_config_data_for_realm,
@@ -43,31 +44,37 @@ pub fn process_finalize_vote(program_id: &Pubkey, accounts: &[AccountInfo]) -> P
         governing_token_mint_info.key,
     )?;
 
-    let realm_config_info = next_account_info(account_info_iter)?; //5
-    let realm_config_data =
-        get_realm_config_data_for_realm(program_id, realm_config_info, realm_info.key)?;
+    // Invalidate the proposal if the governance config changed
+    if proposal_data.should_invalidate(governance_data.config_nonce){
+        proposal_data.state = ProposalState::Invalidated;
+        proposal_data.closed_at = Some(clock.unix_timestamp);
+    } else {
+        let realm_config_info = next_account_info(account_info_iter)?; //5
+        let realm_config_data =
+            get_realm_config_data_for_realm(program_id, realm_config_info, realm_info.key)?;
 
-    let max_voter_weight = proposal_data.resolve_max_voter_weight(
-        account_info_iter, // *6
-        realm_info.key,
-        &realm_data,
-        &realm_config_data,
-        governing_token_mint_info,
-        &VoteKind::Electorate,
-    )?;
+        let max_voter_weight = proposal_data.resolve_max_voter_weight(
+            account_info_iter, // *6
+            realm_info.key,
+            &realm_data,
+            &realm_config_data,
+            governing_token_mint_info,
+            &VoteKind::Electorate,
+        )?;
 
-    let vote_threshold = governance_data.resolve_vote_threshold(
-        &realm_data,
-        governing_token_mint_info.key,
-        &VoteKind::Electorate,
-    )?;
+        let vote_threshold = governance_data.resolve_vote_threshold(
+            &realm_data,
+            governing_token_mint_info.key,
+            &VoteKind::Electorate,
+        )?;
 
-    proposal_data.finalize_vote(
-        max_voter_weight,
-        &governance_data.config,
-        clock.unix_timestamp,
-        &vote_threshold,
-    )?;
+        proposal_data.finalize_vote(
+            max_voter_weight,
+            &governance_data.config,
+            clock.unix_timestamp,
+            &vote_threshold,
+        )?;
+    }
 
     let mut proposal_owner_record_data = get_token_owner_record_data_for_proposal_owner(
         program_id,

--- a/governance/program/src/processor/process_set_governance_config.rs
+++ b/governance/program/src/processor/process_set_governance_config.rs
@@ -30,11 +30,8 @@ pub fn process_set_governance_config(
 
     let mut governance_data = get_governance_data(program_id, governance_info)?;
 
-    // Note: Config change leaves voting proposals in unpredictable state and it's DAOs responsibility
-    // to ensure the changes are made when there are no proposals in voting state
-    // For example changing approval quorum could accidentally make proposals to succeed which would otherwise be defeated
-
     governance_data.config = config;
+    governance_data.config_nonce = governance_data.config_nonce.checked_add(1).unwrap();
 
     governance_data.serialize(&mut governance_info.data.borrow_mut()[..])?;
 

--- a/governance/program/src/processor/process_sign_off_proposal.rs
+++ b/governance/program/src/processor/process_sign_off_proposal.rs
@@ -32,12 +32,13 @@ pub fn process_sign_off_proposal(program_id: &Pubkey, accounts: &[AccountInfo]) 
     // Governance account data is no longer used in the current version but we still have to load it to validate Realm -> Governance -> Proposal relationship
     // It could be replaced with PDA check but the account is going to be needed in future versions once we support mandatory signatories
     // and hence keeping it as it is
-    let _governance_data =
+    let governance_data =
         get_governance_data_for_realm(program_id, governance_info, realm_info.key)?;
 
     let mut proposal_data =
         get_proposal_data_for_governance(program_id, proposal_info, governance_info.key)?;
 
+    proposal_data.assert_should_not_be_invalidated(governance_data.config_nonce)?;
     proposal_data.assert_can_sign_off()?;
 
     // If the owner of the proposal hasn't appointed any signatories then can sign off the proposal themself

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -129,6 +129,9 @@ pub enum ProposalState {
 
     /// The Proposal was vetoed
     Vetoed,
+    
+    /// The Proposal was invalidated by Governance changes
+    Invalidated
 }
 
 /// The type of the vote threshold used to resolve a vote on a Proposal

--- a/governance/program/src/tools/structs.rs
+++ b/governance/program/src/tools/structs.rs
@@ -25,21 +25,21 @@ impl Default for Reserved110 {
 
 /// Reserved 120 bytes
 #[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
-pub struct Reserved120 {
+pub struct Reserved112 {
     /// Reserved 64 bytes
     pub reserved64: [u8; 64],
     /// Reserved 32 bytes
     pub reserved32: [u8; 32],
-    /// Reserved 4 bytes
-    pub reserved24: [u8; 24],
+    /// Reserved 16 bytes
+    pub reserved20: [u8; 16],
 }
 
-impl Default for Reserved120 {
+impl Default for Reserved112 {
     fn default() -> Self {
         Self {
             reserved64: [0; 64],
             reserved32: [0; 32],
-            reserved24: [0; 24],
+            reserved20: [0; 16],
         }
     }
 }

--- a/governance/program/tests/process_cast_vote.rs
+++ b/governance/program/tests/process_cast_vote.rs
@@ -1603,3 +1603,88 @@ async fn test_cast_approve_vote_with_cannot_vote_in_cool_off_time_error() {
 
     assert_eq!(err, GovernanceError::VoteNotAllowedInCoolOffTime.into());
 }
+
+#[tokio::test]
+async fn test_cast_vote_when_governance_config_changed_err() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_signed_off_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    // Change governance config
+    {
+        let mut proposal_cookie = governance_test
+            .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+            .await
+            .unwrap();
+
+        let signatory_record_cookie = governance_test
+            .with_signatory(&proposal_cookie, &token_owner_record_cookie)
+            .await
+            .unwrap();
+
+        let mut new_governance_config = governance_test.get_default_governance_config();
+
+        new_governance_config.community_vote_threshold = VoteThreshold::YesVotePercentage(40);
+
+        let proposal_transaction_cookie = governance_test
+            .with_set_governance_config_transaction(
+                &mut proposal_cookie,
+                &token_owner_record_cookie,
+                &new_governance_config,
+            )
+            .await
+            .unwrap();
+
+        governance_test
+            .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+            .await
+            .unwrap();
+
+        governance_test
+            .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+            .await
+            .unwrap();
+
+        governance_test
+            .advance_clock_by_min_timespan(proposal_transaction_cookie.account.hold_up_time as u64)
+            .await;
+
+        governance_test
+            .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie)
+            .await
+            .unwrap();
+
+        governance_test.advance_clock().await;
+    }
+
+    // Act
+    let err = governance_test
+        .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::GovernanceConfigChanged.into());
+}

--- a/governance/program/tests/process_set_governance_config.rs
+++ b/governance/program/tests/process_set_governance_config.rs
@@ -85,6 +85,7 @@ async fn test_set_governance_config() {
         .await;
 
     assert_eq!(new_governance_config, governance_account.config);
+    assert_eq!(governance_account.config_nonce, 1);
 }
 
 #[tokio::test]

--- a/governance/program/tests/process_sign_off_proposal.rs
+++ b/governance/program/tests/process_sign_off_proposal.rs
@@ -6,7 +6,7 @@ use solana_program::pubkey::Pubkey;
 use solana_program_test::tokio;
 
 use program_test::*;
-use spl_governance::{error::GovernanceError, state::enums::ProposalState};
+use spl_governance::{error::GovernanceError, state::enums::{ProposalState, VoteThreshold}};
 use spl_governance_tools::error::GovernanceToolsError;
 
 #[tokio::test]
@@ -394,4 +394,94 @@ async fn test_sign_off_proposal_with_non_existing_realm_error() {
     // Assert
 
     assert_eq!(err, GovernanceToolsError::AccountDoesNotExist.into());
+}
+
+#[tokio::test]
+async fn test_sign_off_proposal_when_governance_config_changed_err() {
+    // Arrange
+    let mut governance_test = GovernanceProgramTest::start_new().await;
+
+    let realm_cookie = governance_test.with_realm().await;
+    let governed_account_cookie = governance_test.with_governed_account().await;
+
+    let token_owner_record_cookie = governance_test
+        .with_community_token_deposit(&realm_cookie)
+        .await
+        .unwrap();
+
+    let mut governance_cookie = governance_test
+        .with_governance(
+            &realm_cookie,
+            &governed_account_cookie,
+            &token_owner_record_cookie,
+        )
+        .await
+        .unwrap();
+
+    let proposal_cookie = governance_test
+        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+        .await
+        .unwrap();
+
+    let signatory_record_cookie = governance_test
+        .with_signatory(&proposal_cookie, &token_owner_record_cookie)
+        .await
+        .unwrap();
+
+    // Change governance config
+    {
+        let mut proposal_cookie = governance_test
+            .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
+            .await
+            .unwrap();
+
+        let signatory_record_cookie = governance_test
+            .with_signatory(&proposal_cookie, &token_owner_record_cookie)
+            .await
+            .unwrap();
+
+        let mut new_governance_config = governance_test.get_default_governance_config();
+
+        new_governance_config.community_vote_threshold = VoteThreshold::YesVotePercentage(40);
+
+        let proposal_transaction_cookie = governance_test
+            .with_set_governance_config_transaction(
+                &mut proposal_cookie,
+                &token_owner_record_cookie,
+                &new_governance_config,
+            )
+            .await
+            .unwrap();
+
+        governance_test
+            .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+            .await
+            .unwrap();
+
+        governance_test
+            .with_cast_yes_no_vote(&proposal_cookie, &token_owner_record_cookie, YesNoVote::Yes)
+            .await
+            .unwrap();
+
+        governance_test
+            .advance_clock_by_min_timespan(proposal_transaction_cookie.account.hold_up_time as u64)
+            .await;
+
+        governance_test
+            .execute_proposal_transaction(&proposal_cookie, &proposal_transaction_cookie)
+            .await
+            .unwrap();
+
+        governance_test.advance_clock().await;
+    }
+
+    // Act
+    let err = governance_test
+        .sign_off_proposal(&proposal_cookie, &signatory_record_cookie)
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_eq!(err, GovernanceError::GovernanceConfigChanged.into());
 }

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -58,7 +58,7 @@ use spl_governance::{
     },
     tools::{
         bpf_loader_upgradeable::get_program_data_address,
-        structs::{Reserved110, Reserved120},
+        structs::{Reserved110, Reserved112},
     },
 };
 use spl_governance_addin_api::{
@@ -1501,8 +1501,9 @@ impl GovernanceProgramTest {
             governed_account: governed_account_cookie.address,
             config: governance_config.clone(),
             reserved1: 0,
-            reserved_v2: Reserved120::default(),
+            reserved_v2: Reserved112::default(),
             active_proposal_count: 0,
+            config_nonce: 0,
         };
 
         let default_signers = &[create_authority];
@@ -1671,8 +1672,9 @@ impl GovernanceProgramTest {
             governed_account: governed_program_cookie.address,
             config,
             reserved1: 0,
-            reserved_v2: Reserved120::default(),
+            reserved_v2: Reserved112::default(),
             active_proposal_count: 0,
+            config_nonce: 0,
         };
 
         let program_governance_address = get_program_governance_address(
@@ -1792,8 +1794,9 @@ impl GovernanceProgramTest {
             governed_account: governed_mint_cookie.address,
             config: governance_config.clone(),
             reserved1: 0,
-            reserved_v2: Reserved120::default(),
+            reserved_v2: Reserved112::default(),
             active_proposal_count: 0,
+            config_nonce: 0,
         };
 
         let mint_governance_address = get_mint_governance_address(
@@ -1873,8 +1876,9 @@ impl GovernanceProgramTest {
             governed_account: governed_token_cookie.address,
             config,
             reserved1: 0,
-            reserved_v2: Reserved120::default(),
+            reserved_v2: Reserved112::default(),
             active_proposal_count: 0,
+            config_nonce: 0,
         };
 
         let token_governance_address = get_token_governance_address(
@@ -2066,8 +2070,10 @@ impl GovernanceProgramTest {
             max_voting_time: None,
             vote_threshold: None,
 
-            reserved: [0; 64],
+            reserved: [0; 56],
             reserved1: 0,
+
+            governance_config_nonce: governance_cookie.account.config_nonce,
         };
 
         let proposal_address = get_proposal_address(


### PR DESCRIPTION
Adds a configuration nonce to Governance.

The idea is that changing the Governance configuration can leave proposals in an invalid state. Currently it's up to the administrators of a Governance to ensure that config changes happen only when there are no active proposals.

This PR adds a new ProposalState, Invalidated, to which Proposals can be moved with `finalize` if they are invalidated by a governance configuration change. If a proposal should be invalidated, actions that advance proposal state result in an error. Completed proposals remain valid.