### PR TITLE
token-client: Rename metadata functions

### DIFF
--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -2547,7 +2547,7 @@ where
     }
 
     /// Initialize token-metadata on a mint
-    pub async fn initialize_token_metadata<S: Signers>(
+    pub async fn token_metadata_initialize<S: Signers>(
         &self,
         update_authority: &Pubkey,
         mint_authority: &Pubkey,
@@ -2590,7 +2590,7 @@ where
 
     /// Initialize token-metadata on a mint
     #[allow(clippy::too_many_arguments)]
-    pub async fn initialize_token_metadata_with_rent_transfer<S: Signers>(
+    pub async fn token_metadata_initialize_with_rent_transfer<S: Signers>(
         &self,
         payer: &Pubkey,
         update_authority: &Pubkey,
@@ -2631,7 +2631,7 @@ where
     }
 
     /// Update a token-metadata field on a mint
-    pub async fn update_field_in_token_metadata<S: Signers>(
+    pub async fn token_metadata_update_field<S: Signers>(
         &self,
         update_authority: &Pubkey,
         field: Field,
@@ -2673,7 +2673,7 @@ where
     /// Update a token-metadata field on a mint. Includes a transfer for any
     /// additional rent-exempt SOL required.
     #[allow(clippy::too_many_arguments)]
-    pub async fn update_field_in_token_metadata_with_rent_transfer<S: Signers>(
+    pub async fn token_metadata_update_field_with_rent_transfer<S: Signers>(
         &self,
         payer: &Pubkey,
         update_authority: &Pubkey,

--- a/token/program-2022-test/tests/token_metadata_emit.rs
+++ b/token/program-2022-test/tests/token_metadata_emit.rs
@@ -82,7 +82,7 @@ async fn success(start: Option<u64>, end: Option<u64>) {
 
     token_context
         .token
-        .initialize_token_metadata_with_rent_transfer(
+        .token_metadata_initialize_with_rent_transfer(
             &payer_pubkey,
             &update_authority.pubkey(),
             &token_context.mint_authority.pubkey(),

--- a/token/program-2022-test/tests/token_metadata_initialize.rs
+++ b/token/program-2022-test/tests/token_metadata_initialize.rs
@@ -73,7 +73,7 @@ async fn success_initialize() {
     // fails without more lamports for new rent-exemption
     let error = token_context
         .token
-        .initialize_token_metadata(
+        .token_metadata_initialize(
             &update_authority,
             &token_context.mint_authority.pubkey(),
             token_metadata.name.clone(),
@@ -94,7 +94,7 @@ async fn success_initialize() {
     let not_mint_authority = Keypair::new();
     let error = token_context
         .token
-        .initialize_token_metadata_with_rent_transfer(
+        .token_metadata_initialize_with_rent_transfer(
             &payer_pubkey,
             &update_authority,
             &not_mint_authority.pubkey(),
@@ -117,7 +117,7 @@ async fn success_initialize() {
 
     token_context
         .token
-        .initialize_token_metadata_with_rent_transfer(
+        .token_metadata_initialize_with_rent_transfer(
             &payer_pubkey,
             &update_authority,
             &token_context.mint_authority.pubkey(),
@@ -138,7 +138,7 @@ async fn success_initialize() {
     // fail double-init
     let error = token_context
         .token
-        .initialize_token_metadata_with_rent_transfer(
+        .token_metadata_initialize_with_rent_transfer(
             &payer_pubkey,
             &update_authority,
             &token_context.mint_authority.pubkey(),
@@ -183,7 +183,7 @@ async fn fail_without_metadata_pointer() {
 
     let error = token_context
         .token
-        .initialize_token_metadata_with_rent_transfer(
+        .token_metadata_initialize_with_rent_transfer(
             &payer_pubkey,
             &Pubkey::new_unique(),
             &token_context.mint_authority.pubkey(),

--- a/token/program-2022-test/tests/token_metadata_remove_key.rs
+++ b/token/program-2022-test/tests/token_metadata_remove_key.rs
@@ -80,7 +80,7 @@ async fn success_remove() {
 
     token_context
         .token
-        .initialize_token_metadata_with_rent_transfer(
+        .token_metadata_initialize_with_rent_transfer(
             &payer_pubkey,
             &update_authority.pubkey(),
             &token_context.mint_authority.pubkey(),
@@ -100,7 +100,7 @@ async fn success_remove() {
     // add the field
     token_context
         .token
-        .update_field_in_token_metadata_with_rent_transfer(
+        .token_metadata_update_field_with_rent_transfer(
             &payer_pubkey,
             &update_authority.pubkey(),
             field,
@@ -198,7 +198,7 @@ async fn fail_authority_checks() {
 
     token_context
         .token
-        .initialize_token_metadata_with_rent_transfer(
+        .token_metadata_initialize_with_rent_transfer(
             &payer_pubkey,
             &update_authority.pubkey(),
             &token_context.mint_authority.pubkey(),

--- a/token/program-2022-test/tests/token_metadata_update_authority.rs
+++ b/token/program-2022-test/tests/token_metadata_update_authority.rs
@@ -79,7 +79,7 @@ async fn success_update() {
 
     token_context
         .token
-        .initialize_token_metadata_with_rent_transfer(
+        .token_metadata_initialize_with_rent_transfer(
             &payer_pubkey,
             &authority.pubkey(),
             &token_context.mint_authority.pubkey(),
@@ -173,7 +173,7 @@ async fn fail_authority_checks() {
 
     token_context
         .token
-        .initialize_token_metadata_with_rent_transfer(
+        .token_metadata_initialize_with_rent_transfer(
             &payer_pubkey,
             &authority.pubkey(),
             &token_context.mint_authority.pubkey(),

--- a/token/program-2022-test/tests/token_metadata_update_field.rs
+++ b/token/program-2022-test/tests/token_metadata_update_field.rs
@@ -79,7 +79,7 @@ async fn success_update(field: Field, value: String) {
 
     token_context
         .token
-        .initialize_token_metadata_with_rent_transfer(
+        .token_metadata_initialize_with_rent_transfer(
             &payer_pubkey,
             &update_authority.pubkey(),
             &token_context.mint_authority.pubkey(),
@@ -98,7 +98,7 @@ async fn success_update(field: Field, value: String) {
     if new_space > old_space {
         let error = token_context
             .token
-            .update_field_in_token_metadata(
+            .token_metadata_update_field(
                 &update_authority.pubkey(),
                 field.clone(),
                 value.clone(),
@@ -117,7 +117,7 @@ async fn success_update(field: Field, value: String) {
     // transfer required lamports
     token_context
         .token
-        .update_field_in_token_metadata_with_rent_transfer(
+        .token_metadata_update_field_with_rent_transfer(
             &payer_pubkey,
             &update_authority.pubkey(),
             field,
@@ -146,7 +146,7 @@ async fn fail_authority_checks() {
     let update_authority = Keypair::new();
     token_context
         .token
-        .initialize_token_metadata_with_rent_transfer(
+        .token_metadata_initialize_with_rent_transfer(
             &payer_pubkey,
             &update_authority.pubkey(),
             &token_context.mint_authority.pubkey(),
@@ -184,7 +184,7 @@ async fn fail_authority_checks() {
     let wrong_authority = Keypair::new();
     let error = token_context
         .token
-        .update_field_in_token_metadata(
+        .token_metadata_update_field(
             &wrong_authority.pubkey(),
             Field::Name,
             "new_name".to_string(),


### PR DESCRIPTION
#### Problem

The function names for the token-metadata processors in the token client are kinda goofy, see https://github.com/solana-labs/solana-program-library/pull/4774#discussion_r1261811662

#### Solution

Rename the functions as `token_metadata_instruction` rather than `instruction_in_token_metadata`.

I'll rebase the open PRs onto this after it lands.