### PR TITLE
ci: Blast directories in 2xTx build

### DIFF
--- a/.github/workflows/pull-request-token.yml
+++ b/.github/workflows/pull-request-token.yml
@@ -202,6 +202,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Remove unneeded packages for more space
+        run: bash ./ci/warning/purge-ubuntu-runner.sh
+
       - name: Set env vars
         run: |
           echo "RUST_STABLE_VERSION=1.69.0" >> $GITHUB_ENV


### PR DESCRIPTION
#### Problem

The 2xTx has recently started erroring due to running out of disk space: https://github.com/solana-labs/solana-program-library/actions/runs/5537335983/jobs/10106051181

#### Solution

Just use the solution built during #4505