### PR TITLE
[token-2022] Update confidential transfer `Transfer` and `TransferWithFee` for Solana 1.16

### DIFF
--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -104,6 +104,7 @@ impl PartialEq for TokenError {
             (Self::AccountInvalidMint, Self::AccountInvalidMint) => true,
             (Self::AccountInvalidAssociatedAddress, Self::AccountInvalidAssociatedAddress) => true,
             (Self::AccountInvalidAuxiliaryAddress, Self::AccountInvalidAuxiliaryAddress) => true,
+            (Self::ProofGeneration, Self::ProofGeneration) => true,
             (
                 Self::MaximumDepositTransferAmountExceeded,
                 Self::MaximumDepositTransferAmountExceeded,

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -21,8 +21,9 @@ use {
     spl_token_2022::{
         extension::{
             confidential_transfer::{
-                self, ApplyPendingBalanceAccountInfo, ConfidentialTransferAccount,
-                WithdrawAccountInfo,
+                self,
+                account_info::{ApplyPendingBalanceAccountInfo, WithdrawAccountInfo},
+                ConfidentialTransferAccount,
             },
             cpi_guard, default_account_state, interest_bearing_mint, memo_transfer,
             metadata_pointer, transfer_fee, transfer_hook, BaseStateWithExtensions, ExtensionType,

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -1103,7 +1103,7 @@ async fn confidential_transfer_withdraw() {
         .await;
 
     // attempt to withdraw without enough funds
-    token
+    let err = token
         .confidential_transfer_withdraw(
             &alice_meta.token_account,
             &alice.pubkey(),
@@ -1116,6 +1116,8 @@ async fn confidential_transfer_withdraw() {
         )
         .await
         .unwrap_err();
+
+    assert_eq!(err, TokenClientError::ProofGeneration);
 
     token
         .confidential_transfer_empty_account(

--- a/token/program-2022/src/extension/confidential_transfer/account_info.rs
+++ b/token/program-2022/src/extension/confidential_transfer/account_info.rs
@@ -1,4 +1,3 @@
-#[cfg(not(target_os = "solana"))]
 use {
     crate::{
         error::TokenError,
@@ -22,7 +21,6 @@ use {
 
 /// Confidential Transfer extension information needed to construct an `ApplyPendingBalance`
 /// instruction.
-#[cfg(not(target_os = "solana"))]
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct ApplyPendingBalanceAccountInfo {
@@ -36,7 +34,6 @@ pub struct ApplyPendingBalanceAccountInfo {
     /// The decryptable available balance
     pub(crate) decryptable_available_balance: DecryptableBalance,
 }
-#[cfg(not(target_os = "solana"))]
 impl ApplyPendingBalanceAccountInfo {
     /// Return the pending balance credit counter of the account.
     pub fn pending_balance_credit_counter(&self) -> u64 {
@@ -100,7 +97,6 @@ impl ApplyPendingBalanceAccountInfo {
 }
 
 /// Confidential Transfer extension information needed to construct a `Withdraw` instruction.
-#[cfg(not(target_os = "solana"))]
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct WithdrawAccountInfo {
@@ -109,7 +105,6 @@ pub struct WithdrawAccountInfo {
     /// The decryptable available balance
     pub decryptable_available_balance: DecryptableBalance,
 }
-#[cfg(not(target_os = "solana"))]
 impl WithdrawAccountInfo {
     fn decrypted_available_balance(&self, aes_key: &AeKey) -> Result<u64, TokenError> {
         let decryptable_available_balance = self
@@ -159,7 +154,6 @@ impl WithdrawAccountInfo {
 }
 
 /// Confidential Transfer extension information needed to construct a `Transfer` instruction.
-#[cfg(not(target_os = "solana"))]
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct TransferAccountInfo {
@@ -168,7 +162,6 @@ pub struct TransferAccountInfo {
     /// The decryptable available balance
     pub decryptable_available_balance: DecryptableBalance,
 }
-#[cfg(not(target_os = "solana"))]
 impl TransferAccountInfo {
     fn decrypted_available_balance(&self, aes_key: &AeKey) -> Result<u64, TokenError> {
         let decryptable_available_balance = self
@@ -268,7 +261,6 @@ impl TransferAccountInfo {
     }
 }
 
-#[cfg(not(target_os = "solana"))]
 fn combine_balances(balance_lo: u64, balance_hi: u64) -> Option<u64> {
     balance_hi
         .checked_shl(PENDING_BALANCE_LO_BIT_LENGTH)?

--- a/token/program-2022/src/extension/confidential_transfer/account_info.rs
+++ b/token/program-2022/src/extension/confidential_transfer/account_info.rs
@@ -13,7 +13,10 @@ use {
             auth_encryption::{AeCiphertext, AeKey},
             elgamal::{ElGamalKeypair, ElGamalPubkey, ElGamalSecretKey},
         },
-        instruction::{transfer::TransferData, withdraw::WithdrawData},
+        instruction::{
+            transfer::{FeeParameters, TransferData, TransferWithFeeData},
+            withdraw::WithdrawData,
+        },
     },
 };
 
@@ -178,7 +181,7 @@ impl TransferAccountInfo {
     }
 
     /// Create a transfer proof data.
-    pub fn generate_proof_data(
+    pub fn generate_transfer_proof_data(
         &self,
         transfer_amount: u64,
         elgamal_keypair: &ElGamalKeypair,
@@ -204,6 +207,48 @@ impl TransferAccountInfo {
             ),
             elgamal_keypair,
             (destination_elgamal_pubkey, auditor_elgamal_pubkey),
+        )
+        .map_err(|_| TokenError::ProofGeneration)
+    }
+
+    /// Create a transfer with fee proof data
+    #[allow(clippy::too_many_arguments)]
+    pub fn generate_transfer_with_fee_proof_data(
+        &self,
+        transfer_amount: u64,
+        elgamal_keypair: &ElGamalKeypair,
+        aes_key: &AeKey,
+        destination_elgamal_pubkey: &ElGamalPubkey,
+        auditor_elgamal_pubkey: Option<&ElGamalPubkey>,
+        withdraw_withheld_authority_elgamal_pubkey: &ElGamalPubkey,
+        fee_rate_basis_points: u16,
+        maximum_fee: u64,
+    ) -> Result<TransferWithFeeData, TokenError> {
+        let current_source_available_balance = self
+            .available_balance
+            .try_into()
+            .map_err(|_| TokenError::AccountDecryption)?;
+        let current_source_decrypted_available_balance =
+            self.decrypted_available_balance(aes_key)?;
+
+        let default_auditor_pubkey = ElGamalPubkey::default();
+        let auditor_elgamal_pubkey = auditor_elgamal_pubkey.unwrap_or(&default_auditor_pubkey);
+
+        let fee_parameters = FeeParameters {
+            fee_rate_basis_points,
+            maximum_fee,
+        };
+
+        TransferWithFeeData::new(
+            transfer_amount,
+            (
+                current_source_decrypted_available_balance,
+                &current_source_available_balance,
+            ),
+            elgamal_keypair,
+            (destination_elgamal_pubkey, auditor_elgamal_pubkey),
+            fee_parameters,
+            withdraw_withheld_authority_elgamal_pubkey,
         )
         .map_err(|_| TokenError::ProofGeneration)
     }

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -771,7 +771,6 @@ pub fn inner_transfer(
 /// Create a `Transfer` instruction with regular (no-fee) proof
 #[allow(clippy::too_many_arguments)]
 #[cfg(not(target_os = "solana"))]
-#[cfg(feature = "proof-program")]
 pub fn transfer(
     token_program_id: &Pubkey,
     source_token_account: &Pubkey,
@@ -793,8 +792,7 @@ pub fn transfer(
             multisig_signers,
             1,
         )?, // calls check_program_account
-        #[cfg(feature = "proof-program")]
-        verify_transfer(proof_data),
+        verify_transfer(None, proof_data),
     ])
 }
 

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -799,7 +799,6 @@ pub fn transfer(
 /// Create a `Transfer` instruction with fee proof
 #[allow(clippy::too_many_arguments)]
 #[cfg(not(target_os = "solana"))]
-#[cfg(feature = "proof-program")]
 pub fn transfer_with_fee(
     token_program_id: &Pubkey,
     source_token_account: &Pubkey,
@@ -821,7 +820,7 @@ pub fn transfer_with_fee(
             multisig_signers,
             1,
         )?, // calls check_program_account
-        verify_transfer_with_fee(proof_data),
+        verify_transfer_with_fee(None, proof_data),
     ])
 }
 

--- a/token/program-2022/src/extension/confidential_transfer/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer/mod.rs
@@ -208,4 +208,16 @@ impl ConfidentialTransferAccount {
             decryptable_available_balance,
         }
     }
+
+    /// Return the account information needed to construct a `Transfer` instruction.
+    #[cfg(not(target_os = "solana"))]
+    pub fn transfer_account_info(&self) -> TransferAccountInfo {
+        let available_balance = self.available_balance;
+        let decryptable_available_balance = self.decryptable_available_balance;
+
+        TransferAccountInfo {
+            available_balance,
+            decryptable_available_balance,
+        }
+    }
 }

--- a/token/program-2022/src/extension/confidential_transfer/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer/mod.rs
@@ -26,6 +26,7 @@ pub mod instruction;
 pub mod processor;
 
 /// Confidential Transfer Extension account information needed for instructions
+#[cfg(not(target_os = "solana"))]
 pub mod account_info;
 
 /// ElGamal ciphertext containing an account balance

--- a/token/program-2022/src/extension/confidential_transfer/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer/mod.rs
@@ -1,11 +1,5 @@
 #[cfg(not(target_os = "solana"))]
-use solana_zk_token_sdk::{
-    encryption::{
-        auth_encryption::{AeCiphertext, AeKey},
-        elgamal::{ElGamalKeypair, ElGamalSecretKey},
-    },
-    instruction::withdraw::WithdrawData,
-};
+use crate::extension::confidential_transfer::account_info::*;
 use {
     crate::{
         error::TokenError,
@@ -14,9 +8,7 @@ use {
     },
     bytemuck::{Pod, Zeroable},
     solana_program::entrypoint::ProgramResult,
-    solana_zk_token_sdk::zk_token_elgamal::pod::{
-        AeCiphertext as PodAeCiphertext, ElGamalCiphertext, ElGamalPubkey,
-    },
+    solana_zk_token_sdk::zk_token_elgamal::pod::{AeCiphertext, ElGamalCiphertext, ElGamalPubkey},
 };
 
 /// Maximum bit length of any deposit or transfer amount
@@ -33,10 +25,13 @@ pub mod instruction;
 /// Confidential Transfer Extension processor
 pub mod processor;
 
+/// Confidential Transfer Extension account information needed for instructions
+pub mod account_info;
+
 /// ElGamal ciphertext containing an account balance
 pub type EncryptedBalance = ElGamalCiphertext;
 /// Authenticated encryption containing an account balance
-pub type DecryptableBalance = PodAeCiphertext;
+pub type DecryptableBalance = AeCiphertext;
 
 /// Confidential transfer mint configuration
 #[repr(C)]
@@ -213,142 +208,4 @@ impl ConfidentialTransferAccount {
             decryptable_available_balance,
         }
     }
-}
-
-/// Confidential Transfer extension information needed to construct an `ApplyPendingBalance`
-/// instruction.
-#[cfg(not(target_os = "solana"))]
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
-pub struct ApplyPendingBalanceAccountInfo {
-    pending_balance_credit_counter: PodU64,
-    pending_balance_lo: EncryptedBalance,
-    pending_balance_hi: EncryptedBalance,
-    decryptable_available_balance: DecryptableBalance,
-}
-#[cfg(not(target_os = "solana"))]
-impl ApplyPendingBalanceAccountInfo {
-    /// Return the pending balance credit counter of the account.
-    pub fn pending_balance_credit_counter(&self) -> u64 {
-        self.pending_balance_credit_counter.into()
-    }
-
-    fn decrypted_pending_balance_lo(
-        &self,
-        elgamal_secret_key: &ElGamalSecretKey,
-    ) -> Result<u64, TokenError> {
-        let pending_balance_lo = self
-            .pending_balance_lo
-            .try_into()
-            .map_err(|_| TokenError::AccountDecryption)?;
-        elgamal_secret_key
-            .decrypt_u32(&pending_balance_lo)
-            .ok_or(TokenError::AccountDecryption)
-    }
-
-    fn decrypted_pending_balance_hi(
-        &self,
-        elgamal_secret_key: &ElGamalSecretKey,
-    ) -> Result<u64, TokenError> {
-        let pending_balance_hi = self
-            .pending_balance_hi
-            .try_into()
-            .map_err(|_| TokenError::AccountDecryption)?;
-        elgamal_secret_key
-            .decrypt_u32(&pending_balance_hi)
-            .ok_or(TokenError::AccountDecryption)
-    }
-
-    fn decrypted_available_balance(&self, aes_key: &AeKey) -> Result<u64, TokenError> {
-        let decryptable_available_balance = self
-            .decryptable_available_balance
-            .try_into()
-            .map_err(|_| TokenError::AccountDecryption)?;
-        aes_key
-            .decrypt(&decryptable_available_balance)
-            .ok_or(TokenError::AccountDecryption)
-    }
-
-    /// Update the decryptable available balance.
-    pub fn new_decryptable_available_balance(
-        &self,
-        elgamal_secret_key: &ElGamalSecretKey,
-        aes_key: &AeKey,
-    ) -> Result<AeCiphertext, TokenError> {
-        let decrypted_pending_balance_lo = self.decrypted_pending_balance_lo(elgamal_secret_key)?;
-        let decrypted_pending_balance_hi = self.decrypted_pending_balance_hi(elgamal_secret_key)?;
-        let pending_balance =
-            combine_balances(decrypted_pending_balance_lo, decrypted_pending_balance_hi)
-                .ok_or(TokenError::AccountDecryption)?;
-        let current_available_balance = self.decrypted_available_balance(aes_key)?;
-        let new_decrypted_available_balance = current_available_balance
-            .checked_add(pending_balance)
-            .unwrap(); // total balance cannot exceed `u64`
-
-        Ok(aes_key.encrypt(new_decrypted_available_balance))
-    }
-}
-
-/// Confidential Transfer extension information needed to construct a `Withdraw` instruction.
-#[cfg(not(target_os = "solana"))]
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
-pub struct WithdrawAccountInfo {
-    available_balance: ElGamalCiphertext,
-    decryptable_available_balance: PodAeCiphertext,
-}
-#[cfg(not(target_os = "solana"))]
-impl WithdrawAccountInfo {
-    fn decrypted_available_balance(&self, aes_key: &AeKey) -> Result<u64, TokenError> {
-        let decryptable_available_balance = self
-            .decryptable_available_balance
-            .try_into()
-            .map_err(|_| TokenError::AccountDecryption)?;
-        aes_key
-            .decrypt(&decryptable_available_balance)
-            .ok_or(TokenError::AccountDecryption)
-    }
-
-    /// Create a withdraw proof data.
-    pub fn generate_proof_data(
-        &self,
-        withdraw_amount: u64,
-        elgamal_keypair: &ElGamalKeypair,
-        aes_key: &AeKey,
-    ) -> Result<WithdrawData, TokenError> {
-        let current_available_balance = self
-            .available_balance
-            .try_into()
-            .map_err(|_| TokenError::AccountDecryption)?;
-        let current_decrypted_available_balance = self.decrypted_available_balance(aes_key)?;
-
-        WithdrawData::new(
-            withdraw_amount,
-            elgamal_keypair,
-            current_decrypted_available_balance,
-            &current_available_balance,
-        )
-        .map_err(|_| TokenError::ProofGeneration)
-    }
-
-    /// Update the decryptable available balance.
-    pub fn new_decryptable_available_balance(
-        &self,
-        withdraw_amount: u64,
-        aes_key: &AeKey,
-    ) -> Result<AeCiphertext, TokenError> {
-        let current_decrypted_available_balance = self.decrypted_available_balance(aes_key)?;
-        let new_decrypted_available_balance = current_decrypted_available_balance
-            .checked_sub(withdraw_amount)
-            .ok_or(TokenError::ProofGeneration)?;
-
-        Ok(aes_key.encrypt(new_decrypted_available_balance))
-    }
-}
-
-#[cfg(not(target_os = "solana"))]
-fn combine_balances(balance_lo: u64, balance_hi: u64) -> Option<u64> {
-    balance_hi
-        .checked_shl(PENDING_BALANCE_LO_BIT_LENGTH)?
-        .checked_add(balance_lo)
 }

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -606,6 +606,16 @@ fn process_transfer(
 }
 
 /// Extract the transfer amount ciphertext encrypted under the source ElGamal public key.
+///
+/// A transfer amount ciphertext consists of the following 32-byte components that are serialized
+/// in order:
+///   1. The `commitment` component that encodes the transfer amount.
+///   2. The `decryption handle` component with respect to the source public key.
+///   3. The `decryption handle` component with respect to the destination public key.
+///   4. The `decryption handle` component with respect to the auditor public key.
+///
+/// An ElGamal ciphertext for the source consists of the `commitment` component and the `decryption
+/// handle` component with respect to the source.
 #[cfg(feature = "zk-ops")]
 fn transfer_amount_source_ciphertext(
     transfer_amount_ciphertext: &TransferAmountCiphertext,
@@ -620,6 +630,16 @@ fn transfer_amount_source_ciphertext(
 }
 
 /// Extract the transfer amount ciphertext encrypted under the destination ElGamal public key.
+///
+/// A transfer amount ciphertext consists of the following 32-byte components that are serialized
+/// in order:
+///   1. The `commitment` component that encodes the transfer amount.
+///   2. The `decryption handle` component with respect to the source public key.
+///   3. The `decryption handle` component with respect to the destination public key.
+///   4. The `decryption handle` component with respect to the auditor public key.
+///
+/// An ElGamal ciphertext for the destination consists of the `commitment` component and the
+/// `decryption handle` component with respect to the destination public key.
 #[cfg(feature = "zk-ops")]
 fn transfer_amount_destination_ciphertext(
     transfer_amount_ciphertext: &TransferAmountCiphertext,
@@ -634,6 +654,16 @@ fn transfer_amount_destination_ciphertext(
 }
 
 /// Extract the fee amount ciphertext encrypted under the destination ElGamal public key.
+///
+/// A fee encryption amount consists of the following 32-byte components that are serialized in
+/// order:
+///   1. The `commitment` component that encodes the fee amount.
+///   2. The `decryption handle` component with respect to the destination public key.
+///   3. The `decryption handle` component with respect to the withdraw withheld authority public
+///      key.
+///
+/// An ElGamal ciphertext for the destination consists of the `commitment` component and the
+/// `decryption handle` component with respect to the destination public key.
 #[cfg(feature = "zk-ops")]
 fn fee_amount_destination_ciphertext(
     transfer_amount_ciphertext: &EncryptedFee,
@@ -649,6 +679,16 @@ fn fee_amount_destination_ciphertext(
 
 /// Extract the transfer amount ciphertext encrypted under the withdraw withheld authority ElGamal
 /// public key.
+///
+/// A fee encryption amount consists of the following 32-byte components that are serialized in
+/// order:
+///   1. The `commitment` component that encodes the fee amount.
+///   2. The `decryption handle` component with respect to the destination public key.
+///   3. The `decryption handle` component with respect to the withdraw withheld authority public
+///      key.
+///
+/// An ElGamal ciphertext for the destination consists of the `commitment` component and the
+/// `decryption handle` component with respect to the withdraw withheld authority public key.
 #[cfg(feature = "zk-ops")]
 fn fee_amount_withdraw_withheld_authority_ciphertext(
     transfer_amount_ciphertext: &EncryptedFee,


### PR DESCRIPTION
#### Problem
Confidential transfer `Transfer` and `TransferWithFee` instructions are not updated for the new Solana 1.16 changes.

#### Summary of changes
- [bdaf1fe](https://github.com/solana-labs/solana-program-library/pull/4779/commits/bdaf1fe9baf70944146f556bc3c98663898ee97b): The logic for the account info types needed for instructions was getting long, so I refactored these from `state.rs` into a separate module

- [e88c9e4](https://github.com/solana-labs/solana-program-library/pull/4779/commits/e88c9e4031e1bd912c3c934a7231f7ae322e0b26): I updated the processor and client logic for the `Transfer` instruction. This should be pretty standard except that I added helper functions that extract the relevant bits from the transfer amount and fee ciphertexts. The transfer amount and fee are encrypted under the source, destination, auditor, and/or withdraw withheld authority ElGamal pubkeys simultaneously. These helper functions extract the relevant components that are relevant for the source, destination, and/or withdraw withheld authority. The helper functions belong more naturally in the zk-token-sdk, but I inlined these for now until these are added on the monorepo side.

- [b07d480](https://github.com/solana-labs/solana-program-library/pull/4779/commits/b07d48076c3126317bbec5896b767ba8fdad1a04): The same set of changes as the previous commit for the `TransferWithFee` instruction.

- [2ce0429](https://github.com/solana-labs/solana-program-library/pull/4779/commits/2ce0429c0c4d63f3c35c500494461022e8902013): Pretty straightforward updates to the `Transfer` instruction tests.

- [8150248](https://github.com/solana-labs/solana-program-library/pull/4779/commits/8150248724406c0323d78039f0609961f98c3a65): The same set of changes as the previous commit for the `Transfer` with memo tests.

For this PR, I did not update the tests for the `TransferWithFee` since that would involve initializing the mint and account for the confidential transfer fee extension, which probably belong in a separate PR.