### PR TITLE
TLV Derive Macro for Borsh Variable Length

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7196,6 +7196,26 @@ dependencies = [
  "solana-program",
  "spl-discriminator",
  "spl-program-error",
+ "spl-type-length-value-derive",
+]
+
+[[package]]
+name = "spl-type-length-value-derive"
+version = "0.0.1"
+dependencies = [
+ "proc-macro2 1.0.63",
+ "quote 1.0.29",
+ "syn 2.0.23",
+]
+
+[[package]]
+name = "spl-type-length-value-derive-test"
+version = "0.0.1"
+dependencies = [
+ "borsh 0.10.3",
+ "solana-program",
+ "spl-discriminator",
+ "spl-type-length-value",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7201,7 +7201,7 @@ dependencies = [
 
 [[package]]
 name = "spl-type-length-value-derive"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.29",
@@ -7210,7 +7210,7 @@ dependencies = [
 
 [[package]]
 name = "spl-type-length-value-derive-test"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "borsh 0.10.3",
  "solana-program",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
   "libraries/program-error",
   "libraries/tlv-account-resolution",
   "libraries/type-length-value",
+  "libraries/type-length-value-derive-test",
   "memo/program",
   "name-service/program",
   "managed-token/program",

--- a/libraries/type-length-value-derive-test/Cargo.toml
+++ b/libraries/type-length-value-derive-test/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "spl-type-length-value-derive-test"
+version = "0.0.1"
+description = "Testing Derive Macro Library for SPL Type Length Value traits"
+authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
+repository = "https://github.com/solana-labs/solana-program-library"
+license = "Apache-2.0"
+edition = "2021"
+
+[dev-dependencies]
+borsh = "0.10"
+solana-program = "1.16"
+spl-discriminator = { version = "0.1.0", path = "../discriminator" }
+spl-type-length-value = { version = "0.2.0", path = "../type-length-value", features = ["derive"] }

--- a/libraries/type-length-value-derive-test/Cargo.toml
+++ b/libraries/type-length-value-derive-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-type-length-value-derive-test"
-version = "0.0.1"
+version = "0.1.0"
 description = "Testing Derive Macro Library for SPL Type Length Value traits"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/libraries/type-length-value-derive-test/src/lib.rs
+++ b/libraries/type-length-value-derive-test/src/lib.rs
@@ -1,15 +1,15 @@
-//! Test crate to avoid making `borsh` a direct dependency of `spl-type-length-value`.
-//! You can't use a derive macro from within the same crate that the macro is defined, so we need this extra crate for just testing the macro itself.
+//! Test crate to avoid making `borsh` a direct dependency of
+//! `spl-type-length-value`. You can't use a derive macro from within the same
+//! crate that the macro is defined, so we need this extra crate for just
+//! testing the macro itself.
 
 #[cfg(test)]
 pub mod test {
-    use solana_program::borsh::{get_instance_packed_len, try_from_slice_unchecked};
-    use spl_type_length_value::variable_len_pack::VariableLenPack;
-
     use {
         borsh::{BorshDeserialize, BorshSerialize},
+        solana_program::borsh::{get_instance_packed_len, try_from_slice_unchecked},
         spl_discriminator::SplDiscriminate,
-        spl_type_length_value::SplBorshVariableLenPack,
+        spl_type_length_value::{variable_len_pack::VariableLenPack, SplBorshVariableLenPack},
     };
 
     #[derive(

--- a/libraries/type-length-value-derive-test/src/lib.rs
+++ b/libraries/type-length-value-derive-test/src/lib.rs
@@ -35,19 +35,21 @@ pub mod test {
             plate: [0; 7],
         };
 
-        let dst = &mut [0u8; 15];
-
-        assert_eq!(
-            borsh::to_writer(&mut dst[..], &vehicle).unwrap(),
-            vehicle.pack_into_slice(&mut dst[..]).unwrap()
-        );
-
         assert_eq!(
             get_instance_packed_len::<Vehicle>(&vehicle).unwrap(),
             vehicle.get_packed_len().unwrap()
         );
 
-        let buffer = dst.clone();
+        let dst1 = &mut [0u8; 15];
+        borsh::to_writer(&mut dst1[..], &vehicle).unwrap();
+
+        let dst2 = &mut [0u8; 15];
+        vehicle.pack_into_slice(&mut dst2[..]).unwrap();
+
+        assert_eq!(dst1, dst2,);
+
+        let mut buffer = [0u8; 15];
+        buffer.copy_from_slice(&dst1[..]);
 
         assert_eq!(
             try_from_slice_unchecked::<Vehicle>(&buffer).unwrap(),

--- a/libraries/type-length-value-derive-test/src/lib.rs
+++ b/libraries/type-length-value-derive-test/src/lib.rs
@@ -1,0 +1,57 @@
+//! Test crate to avoid making `borsh` a direct dependency of `spl-type-length-value`.
+//! You can't use a derive macro from within the same crate that the macro is defined, so we need this extra crate for just testing the macro itself.
+
+#[cfg(test)]
+pub mod test {
+    use solana_program::borsh::{get_instance_packed_len, try_from_slice_unchecked};
+    use spl_type_length_value::variable_len_pack::VariableLenPack;
+
+    use {
+        borsh::{BorshDeserialize, BorshSerialize},
+        spl_discriminator::SplDiscriminate,
+        spl_type_length_value::SplBorshVariableLenPack,
+    };
+
+    #[derive(
+        Clone,
+        Debug,
+        Default,
+        PartialEq,
+        BorshDeserialize,
+        BorshSerialize,
+        SplDiscriminate,
+        SplBorshVariableLenPack,
+    )]
+    #[discriminator_hash_input("vehicle::my_vehicle")]
+    pub struct Vehicle {
+        vin: [u8; 8],
+        plate: [u8; 7],
+    }
+
+    #[test]
+    fn test_derive() {
+        let vehicle = Vehicle {
+            vin: [0; 8],
+            plate: [0; 7],
+        };
+
+        let dst = &mut [0u8; 15];
+
+        assert_eq!(
+            borsh::to_writer(&mut dst[..], &vehicle).unwrap(),
+            vehicle.pack_into_slice(&mut dst[..]).unwrap()
+        );
+
+        assert_eq!(
+            get_instance_packed_len::<Vehicle>(&vehicle).unwrap(),
+            vehicle.get_packed_len().unwrap()
+        );
+
+        let buffer = dst.clone();
+
+        assert_eq!(
+            try_from_slice_unchecked::<Vehicle>(&buffer).unwrap(),
+            Vehicle::unpack_from_slice(&buffer).unwrap()
+        );
+    }
+}

--- a/libraries/type-length-value/Cargo.toml
+++ b/libraries/type-length-value/Cargo.toml
@@ -8,11 +8,15 @@ license = "Apache-2.0"
 edition = "2021"
 exclude = ["js/**"]
 
+[features]
+derive = ["dep:spl-type-length-value-derive"]
+
 [dependencies]
 bytemuck = { version = "1.13.1", features = ["derive"] }
 solana-program = "1.16.3"
 spl-discriminator = { version = "0.1.0", path = "../discriminator" }
 spl-program-error = { version = "0.2.0", path = "../program-error" }
+spl-type-length-value-derive = { version = "0.0.1", path = "./derive", optional = true }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/libraries/type-length-value/Cargo.toml
+++ b/libraries/type-length-value/Cargo.toml
@@ -16,7 +16,7 @@ bytemuck = { version = "1.13.1", features = ["derive"] }
 solana-program = "1.16.3"
 spl-discriminator = { version = "0.1.0", path = "../discriminator" }
 spl-program-error = { version = "0.2.0", path = "../program-error" }
-spl-type-length-value-derive = { version = "0.0.1", path = "./derive", optional = true }
+spl-type-length-value-derive = { version = "0.1.0", path = "./derive", optional = true }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/libraries/type-length-value/derive/Cargo.toml
+++ b/libraries/type-length-value/derive/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "spl-type-length-value-derive"
+version = "0.0.1"
+description = "Derive Macro Library for SPL Type Length Value traits"
+authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
+repository = "https://github.com/solana-labs/solana-program-library"
+license = "Apache-2.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "2.0", features = ["full"] }

--- a/libraries/type-length-value/derive/Cargo.toml
+++ b/libraries/type-length-value/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-type-length-value-derive"
-version = "0.0.1"
+version = "0.1.0"
 description = "Derive Macro Library for SPL Type Length Value traits"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/libraries/type-length-value/derive/src/builder.rs
+++ b/libraries/type-length-value/derive/src/builder.rs
@@ -1,0 +1,91 @@
+//! The actual token generator for the macro
+use {
+    proc_macro2::{Span, TokenStream},
+    quote::{quote, ToTokens},
+    syn::{parse::Parse, Generics, Ident, Item, ItemEnum, ItemStruct, WhereClause},
+};
+
+pub struct SplBorshVariableLenPackBuilder {
+    /// The struct/enum identifier
+    pub ident: Ident,
+    /// The item's generic arguments (if any)
+    pub generics: Generics,
+    /// The item's where clause for generics (if any)
+    pub where_clause: Option<WhereClause>,
+}
+
+impl TryFrom<ItemEnum> for SplBorshVariableLenPackBuilder {
+    type Error = syn::Error;
+
+    fn try_from(item_enum: ItemEnum) -> Result<Self, Self::Error> {
+        let ident = item_enum.ident;
+        let where_clause = item_enum.generics.where_clause.clone();
+        let generics = item_enum.generics;
+        Ok(Self {
+            ident,
+            generics,
+            where_clause,
+        })
+    }
+}
+
+impl TryFrom<ItemStruct> for SplBorshVariableLenPackBuilder {
+    type Error = syn::Error;
+
+    fn try_from(item_struct: ItemStruct) -> Result<Self, Self::Error> {
+        let ident = item_struct.ident;
+        let where_clause = item_struct.generics.where_clause.clone();
+        let generics = item_struct.generics;
+        Ok(Self {
+            ident,
+            generics,
+            where_clause,
+        })
+    }
+}
+
+impl Parse for SplBorshVariableLenPackBuilder {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let item = Item::parse(input)?;
+        match item {
+            Item::Enum(item_enum) => item_enum.try_into(),
+            Item::Struct(item_struct) => item_struct.try_into(),
+            _ => {
+                return Err(syn::Error::new(
+                    Span::call_site(),
+                    "Only enums and structs are supported",
+                ))
+            }
+        }
+        .map_err(|e| syn::Error::new(input.span(), format!("Failed to parse item: {}", e)))
+    }
+}
+
+impl ToTokens for SplBorshVariableLenPackBuilder {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        tokens.extend::<TokenStream>(self.into());
+    }
+}
+
+impl From<&SplBorshVariableLenPackBuilder> for TokenStream {
+    fn from(builder: &SplBorshVariableLenPackBuilder) -> Self {
+        let ident = &builder.ident;
+        let generics = &builder.generics;
+        let where_clause = &builder.where_clause;
+        quote! {
+            impl #generics spl_type_length_value::variable_len_pack::VariableLenPack for #ident #generics #where_clause {
+                fn pack_into_slice(&self, dst: &mut [u8]) -> Result<(), solana_program::program_error::ProgramError> {
+                    borsh::to_writer(&mut dst[..], self).map_err(Into::into)
+                }
+
+                fn unpack_from_slice(src: &[u8]) -> Result<Self, solana_program::program_error::ProgramError> {
+                    solana_program::borsh::try_from_slice_unchecked(src).map_err(Into::into)
+                }
+
+                fn get_packed_len(&self) -> Result<usize, solana_program::program_error::ProgramError> {
+                    solana_program::borsh::get_instance_packed_len(self).map_err(Into::into)
+                }
+            }
+        }
+    }
+}

--- a/libraries/type-length-value/derive/src/lib.rs
+++ b/libraries/type-length-value/derive/src/lib.rs
@@ -8,10 +8,10 @@ extern crate proc_macro;
 
 mod builder;
 
-use builder::SplBorshVariableLenPackBuilder;
-use proc_macro::TokenStream;
-use quote::ToTokens;
-use syn::parse_macro_input;
+use {
+    builder::SplBorshVariableLenPackBuilder, proc_macro::TokenStream, quote::ToTokens,
+    syn::parse_macro_input,
+};
 
 /// Derive macro to add `VariableLenPack` trait for borsh-implemented types
 #[proc_macro_derive(SplBorshVariableLenPack)]

--- a/libraries/type-length-value/derive/src/lib.rs
+++ b/libraries/type-length-value/derive/src/lib.rs
@@ -1,0 +1,22 @@
+//! Crate defining a derive macro for a basic borsh implementation of
+//! the trait `VariableLenPack`.
+
+#![deny(missing_docs)]
+#![cfg_attr(not(test), forbid(unsafe_code))]
+
+extern crate proc_macro;
+
+mod builder;
+
+use builder::SplBorshVariableLenPackBuilder;
+use proc_macro::TokenStream;
+use quote::ToTokens;
+use syn::parse_macro_input;
+
+/// Derive macro to add `VariableLenPack` trait for borsh-implemented types
+#[proc_macro_derive(SplBorshVariableLenPack)]
+pub fn spl_borsh_variable_len_pack(input: TokenStream) -> TokenStream {
+    parse_macro_input!(input as SplBorshVariableLenPackBuilder)
+        .to_token_stream()
+        .into()
+}

--- a/libraries/type-length-value/src/lib.rs
+++ b/libraries/type-length-value/src/lib.rs
@@ -11,5 +11,9 @@ pub mod pod;
 pub mod state;
 pub mod variable_len_pack;
 
-// Export current sdk types for downstream users building with a different sdk version
+// Export current sdk types for downstream users building with a different sdk
+// version
 pub use solana_program;
+// Expose derive macro on feature flag
+#[cfg(feature = "derive")]
+pub use spl_type_length_value_derive::SplBorshVariableLenPack;

--- a/libraries/type-length-value/src/pod.rs
+++ b/libraries/type-length-value/src/pod.rs
@@ -23,7 +23,8 @@ pub fn pod_slice_from_bytes_mut<T: Pod>(bytes: &mut [u8]) -> Result<&mut [T], Pr
     bytemuck::try_cast_slice_mut(bytes).map_err(|_| ProgramError::InvalidArgument)
 }
 
-/// Simple macro for implementing conversion functions between Pod* ints and standard ints.
+/// Simple macro for implementing conversion functions between Pod* ints and
+/// standard ints.
 ///
 /// The standard int types can cause alignment issues when placed in a `Pod`,
 /// so these replacements are usable in all `Pod`s.

--- a/libraries/type-length-value/src/state.rs
+++ b/libraries/type-length-value/src/state.rs
@@ -146,8 +146,8 @@ fn get_bytes<V: SplDiscriminate>(tlv_data: &[u8]) -> Result<&[u8], ProgramError>
 /// For example, if we have two distinct types, one which is an 8-byte array
 /// of value `[0, 1, 0, 0, 0, 0, 0, 0]` and discriminator
 /// `[1, 1, 1, 1, 1, 1, 1, 1]`, and another which is just a single `u8` of value
-/// `4` with the discriminator `[2, 2, 2, 2, 2, 2, 2, 2]`, we can deserialize this
-/// buffer as follows:
+/// `4` with the discriminator `[2, 2, 2, 2, 2, 2, 2, 2]`, we can deserialize
+/// this buffer as follows:
 ///
 /// ```
 /// use {
@@ -242,7 +242,8 @@ impl TlvState for TlvStateOwned {
     }
 }
 
-/// Encapsulates immutable base state data (mint or account) with possible extensions
+/// Encapsulates immutable base state data (mint or account) with possible
+/// extensions
 #[derive(Debug, PartialEq)]
 pub struct TlvStateBorrowed<'data> {
     /// Slice of data containing all TLV data, deserialized on demand
@@ -263,7 +264,8 @@ impl<'a> TlvState for TlvStateBorrowed<'a> {
     }
 }
 
-/// Encapsulates mutable base state data (mint or account) with possible extensions
+/// Encapsulates mutable base state data (mint or account) with possible
+/// extensions
 #[derive(Debug, PartialEq)]
 pub struct TlvStateMut<'data> {
     /// Slice of data containing all TLV data, deserialized on demand
@@ -278,7 +280,8 @@ impl<'data> TlvStateMut<'data> {
         Ok(Self { data })
     }
 
-    /// Unpack a portion of the TLV data as the desired type that allows modifying the type
+    /// Unpack a portion of the TLV data as the desired type that allows
+    /// modifying the type
     pub fn get_value_mut<V: SplDiscriminate + Pod>(&mut self) -> Result<&mut V, ProgramError> {
         let data = self.get_bytes_mut::<V>()?;
         pod_from_bytes_mut::<V>(data)
@@ -312,8 +315,8 @@ impl<'data> TlvStateMut<'data> {
         Ok(extension_ref)
     }
 
-    /// Packs a variable-length value into its appropriate data segment. Assumes that
-    /// space has already been allocated for the given type
+    /// Packs a variable-length value into its appropriate data segment. Assumes
+    /// that space has already been allocated for the given type
     pub fn pack_variable_len_value<V: SplDiscriminate + VariableLenPack>(
         &mut self,
         value: &V,
@@ -352,10 +355,10 @@ impl<'data> TlvStateMut<'data> {
         }
     }
 
-    /// Reallocate the given number of bytes for the given SplDiscriminate. If the new
-    /// length is smaller, it will compact the rest of the buffer and zero out
-    /// the difference at the end. If it's larger, it will move the rest of
-    /// the buffer data and zero out the new data.
+    /// Reallocate the given number of bytes for the given SplDiscriminate. If
+    /// the new length is smaller, it will compact the rest of the buffer
+    /// and zero out the difference at the end. If it's larger, it will move
+    /// the rest of the buffer data and zero out the new data.
     pub fn realloc<V: SplDiscriminate>(
         &mut self,
         length: usize,
@@ -469,8 +472,10 @@ fn check_data(tlv_data: &[u8]) -> Result<(), ProgramError> {
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use bytemuck::{Pod, Zeroable};
+    use {
+        super::*,
+        bytemuck::{Pod, Zeroable},
+    };
 
     const TEST_BUFFER: &[u8] = &[
         1, 1, 1, 1, 1, 1, 1, 1, // discriminator

--- a/libraries/type-length-value/src/variable_len_pack.rs
+++ b/libraries/type-length-value/src/variable_len_pack.rs
@@ -2,8 +2,9 @@
 
 use solana_program::program_error::ProgramError;
 
-/// Trait that mimics a lot of the functionality of `solana_program::program_pack::Pack`
-/// but specifically works for variable-size types.
+/// Trait that mimics a lot of the functionality of
+/// `solana_program::program_pack::Pack` but specifically works for
+/// variable-size types.
 pub trait VariableLenPack {
     /// Writes the serialized form of the instance into the given slice
     fn pack_into_slice(&self, dst: &mut [u8]) -> Result<(), ProgramError>;


### PR DESCRIPTION
Broken off of #4768 (1/3)

---

This PR adds a derive macro to `spl-type-length-value` for simply adding the `VariableLenPack` trait with borsh methods for those who do not wish to implement a custom implementation of the tratit.

It simply mimics the `TokenMetadata` state implementation of `VariableLenPack`:

```rust
impl VariableLenPack for TokenMetadata {
    fn pack_into_slice(&self, dst: &mut [u8]) -> Result<(), ProgramError> {
        borsh::to_writer(&mut dst[..], self).map_err(Into::into)
    }
    fn unpack_from_slice(src: &[u8]) -> Result<Self, ProgramError> {
        try_from_slice_unchecked(src).map_err(Into::into)
    }
    fn get_packed_len(&self) -> Result<usize, ProgramError> {
        get_instance_packed_len(self).map_err(Into::into)
    }
}
```

---

I've also taken special care to set up a separate crate for testing the derive macro in order to keep `borsh` out of the dependencies for `spl-type-length-value`