### PR TITLE
[token-2022] Add support for context state accounts

### DIFF
--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -1691,7 +1691,7 @@ where
         };
 
         let proof_location = if let Some(proof_data_temp) = proof_data.as_ref() {
-            ProofLocation::Instruction(1.try_into().unwrap(), proof_data_temp)
+            ProofLocation::InstructionOffset(1.try_into().unwrap(), proof_data_temp)
         } else {
             let context_state_account = context_state_account.unwrap();
             ProofLocation::ContextStateAccount(context_state_account)
@@ -1771,7 +1771,7 @@ where
         };
 
         let proof_location = if let Some(proof_data_temp) = proof_data.as_ref() {
-            ProofLocation::Instruction(1.try_into().unwrap(), proof_data_temp)
+            ProofLocation::InstructionOffset(1.try_into().unwrap(), proof_data_temp)
         } else {
             let context_state_account = context_state_account.unwrap();
             ProofLocation::ContextStateAccount(context_state_account)
@@ -2039,7 +2039,7 @@ where
         };
 
         let proof_location = if let Some(proof_data_temp) = proof_data.as_ref() {
-            ProofLocation::Instruction(1.try_into().unwrap(), proof_data_temp)
+            ProofLocation::InstructionOffset(1.try_into().unwrap(), proof_data_temp)
         } else {
             let context_state_account = context_state_account.unwrap();
             ProofLocation::ContextStateAccount(context_state_account)
@@ -2157,7 +2157,7 @@ where
         };
 
         let proof_location = if let Some(proof_data_temp) = proof_data.as_ref() {
-            ProofLocation::Instruction(1.try_into().unwrap(), proof_data_temp)
+            ProofLocation::InstructionOffset(1.try_into().unwrap(), proof_data_temp)
         } else {
             let context_state_account = context_state_account.unwrap();
             ProofLocation::ContextStateAccount(context_state_account)
@@ -2234,7 +2234,7 @@ where
         };
 
         let proof_location = if let Some(proof_data_temp) = proof_data.as_ref() {
-            ProofLocation::Instruction(1.try_into().unwrap(), proof_data_temp)
+            ProofLocation::InstructionOffset(1.try_into().unwrap(), proof_data_temp)
         } else {
             let context_state_account = context_state_account.unwrap();
             ProofLocation::ContextStateAccount(context_state_account)

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -33,6 +33,7 @@ use {
             StateWithExtensionsOwned,
         },
         instruction, offchain,
+        proof::ProofLocation,
         solana_zk_token_sdk::{
             encryption::{
                 auth_encryption::AeKey,
@@ -1688,6 +1689,14 @@ where
                     .map_err(|_| TokenError::ProofGeneration)?,
             )
         };
+
+        let proof_location = if let Some(proof_data_temp) = proof_data.as_ref() {
+            ProofLocation::Instruction(1.try_into().unwrap(), proof_data_temp)
+        } else {
+            let context_state_account = context_state_account.unwrap();
+            ProofLocation::ContextStateAccount(context_state_account)
+        };
+
         let decryptable_balance = aes_key.encrypt(0);
 
         self.process_ixs(
@@ -1697,10 +1706,9 @@ where
                 &self.pubkey,
                 decryptable_balance,
                 maximum_pending_balance_credit_counter,
-                context_state_account,
                 authority,
                 &multisig_signers,
-                proof_data.as_ref(),
+                proof_location,
             )?,
             signing_keypairs,
         )
@@ -1762,14 +1770,20 @@ where
             )
         };
 
+        let proof_location = if let Some(proof_data_temp) = proof_data.as_ref() {
+            ProofLocation::Instruction(1.try_into().unwrap(), proof_data_temp)
+        } else {
+            let context_state_account = context_state_account.unwrap();
+            ProofLocation::ContextStateAccount(context_state_account)
+        };
+
         self.process_ixs(
             &confidential_transfer::instruction::empty_account(
                 &self.program_id,
                 account,
-                context_state_account,
                 authority,
                 &multisig_signers,
-                proof_data.as_ref(),
+                proof_location,
             )?,
             signing_keypairs,
         )
@@ -2024,6 +2038,13 @@ where
             )
         };
 
+        let proof_location = if let Some(proof_data_temp) = proof_data.as_ref() {
+            ProofLocation::Instruction(1.try_into().unwrap(), proof_data_temp)
+        } else {
+            let context_state_account = context_state_account.unwrap();
+            ProofLocation::ContextStateAccount(context_state_account)
+        };
+
         let new_decryptable_available_balance = account_info
             .new_decryptable_available_balance(withdraw_amount, aes_key)
             .map_err(|_| TokenError::AccountDecryption)?;
@@ -2036,10 +2057,9 @@ where
                 withdraw_amount,
                 decimals,
                 new_decryptable_available_balance,
-                context_state_account,
                 authority,
                 &multisig_signers,
-                proof_data.as_ref(),
+                proof_location,
             )?,
             signing_keypairs,
         )
@@ -2136,6 +2156,13 @@ where
             )
         };
 
+        let proof_location = if let Some(proof_data_temp) = proof_data.as_ref() {
+            ProofLocation::Instruction(1.try_into().unwrap(), proof_data_temp)
+        } else {
+            let context_state_account = context_state_account.unwrap();
+            ProofLocation::ContextStateAccount(context_state_account)
+        };
+
         let new_decryptable_available_balance = account_info
             .new_decryptable_available_balance(transfer_amount, source_aes_key)
             .map_err(|_| TokenError::AccountDecryption)?;
@@ -2147,10 +2174,9 @@ where
                 destination_account,
                 &self.pubkey,
                 new_decryptable_available_balance,
-                context_state_account,
                 source_authority,
                 &multisig_signers,
-                proof_data.as_ref(),
+                proof_location,
             )?,
             signing_keypairs,
         )
@@ -2207,6 +2233,13 @@ where
             )
         };
 
+        let proof_location = if let Some(proof_data_temp) = proof_data.as_ref() {
+            ProofLocation::Instruction(1.try_into().unwrap(), proof_data_temp)
+        } else {
+            let context_state_account = context_state_account.unwrap();
+            ProofLocation::ContextStateAccount(context_state_account)
+        };
+
         let new_decryptable_available_balance = account_info
             .new_decryptable_available_balance(transfer_amount, source_aes_key)
             .map_err(|_| TokenError::AccountDecryption)?;
@@ -2218,10 +2251,9 @@ where
                 destination_account,
                 &self.pubkey,
                 new_decryptable_available_balance,
-                context_state_account,
                 source_authority,
                 &multisig_signers,
-                proof_data.as_ref(),
+                proof_location,
             )?,
             signing_keypairs,
         )

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -764,6 +764,7 @@ async fn confidential_transfer_empty_account() {
         .confidential_transfer_empty_account(
             &alice_meta.token_account,
             &alice.pubkey(),
+            None,
             &alice_meta.elgamal_keypair,
             &[&alice],
         )
@@ -1123,6 +1124,7 @@ async fn confidential_transfer_withdraw() {
         .confidential_transfer_empty_account(
             &alice_meta.token_account,
             &alice.pubkey(),
+            None,
             &alice_meta.elgamal_keypair,
             &[&alice],
         )

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -777,6 +777,7 @@ async fn confidential_transfer_empty_account() {
             &alice_meta.token_account,
             &alice.pubkey(),
             None,
+            None,
             &alice_meta.elgamal_keypair,
             &[&alice],
         )
@@ -1136,6 +1137,7 @@ async fn confidential_transfer_withdraw() {
         .confidential_transfer_empty_account(
             &alice_meta.token_account,
             &alice.pubkey(),
+            None,
             None,
             &alice_meta.elgamal_keypair,
             &[&alice],
@@ -2291,6 +2293,145 @@ async fn confidential_transfer_configure_token_account_with_proof_context() {
             None,
             &elgamal_keypair,
             &aes_key,
+            &[&bob],
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(0, InstructionError::InvalidArgument,)
+        )))
+    );
+}
+
+#[tokio::test]
+async fn confidential_transfer_empty_account_with_proof_context() {
+    let authority = Keypair::new();
+    let auto_approve_new_accounts = false;
+
+    let mut context = TestContext::new().await;
+    context
+        .init_token_with_mint(vec![
+            ExtensionInitializationParams::ConfidentialTransferMint {
+                authority: Some(authority.pubkey()),
+                auto_approve_new_accounts,
+                auditor_elgamal_pubkey: None,
+            },
+        ])
+        .await
+        .unwrap();
+
+    let TokenContext {
+        token, alice, bob, ..
+    } = context.token_context.unwrap();
+
+    let alice_meta = ConfidentialTokenAccountMeta::new(&token, &alice).await;
+    let context_state_account = Keypair::new();
+
+    // create context state
+    {
+        let context_state_authority = Keypair::new();
+        let space = size_of::<ProofContextState<ZeroBalanceProofContext>>();
+
+        let instruction_type = ProofInstruction::VerifyZeroBalance;
+
+        let context_state_info = ContextStateInfo {
+            context_state_account: &context_state_account.pubkey(),
+            context_state_authority: &context_state_authority.pubkey(),
+        };
+
+        let proof_data = confidential_transfer::instruction::ZeroBalanceProofData::new(
+            &alice_meta.elgamal_keypair,
+            &ElGamalCiphertext::default(),
+        )
+        .unwrap();
+
+        let mut ctx = context.context.lock().await;
+        let rent = ctx.banks_client.get_rent().await.unwrap();
+
+        let instructions = vec![
+            system_instruction::create_account(
+                &ctx.payer.pubkey(),
+                &context_state_account.pubkey(),
+                rent.minimum_balance(space),
+                space as u64,
+                &zk_token_proof_program::id(),
+            ),
+            instruction_type.encode_verify_proof(Some(context_state_info), &proof_data),
+        ];
+
+        let tx = Transaction::new_signed_with_payer(
+            &instructions,
+            Some(&ctx.payer.pubkey()),
+            &[&ctx.payer, &context_state_account],
+            ctx.last_blockhash,
+        );
+        ctx.banks_client.process_transaction(tx).await.unwrap();
+    }
+
+    token
+        .confidential_transfer_empty_account(
+            &alice_meta.token_account,
+            &alice.pubkey(),
+            Some(&context_state_account.pubkey()),
+            None,
+            &alice_meta.elgamal_keypair,
+            &[&alice],
+        )
+        .await
+        .unwrap();
+
+    // attempt to create an account with a wrong proof type context state
+    let bob_meta = ConfidentialTokenAccountMeta::new(&token, &bob).await;
+    let context_state_account = Keypair::new();
+
+    {
+        let context_state_authority = Keypair::new();
+        let space = size_of::<ProofContextState<PubkeyValidityProofContext>>();
+
+        let instruction_type = ProofInstruction::VerifyPubkeyValidity;
+
+        let context_state_info = ContextStateInfo {
+            context_state_account: &context_state_account.pubkey(),
+            context_state_authority: &context_state_authority.pubkey(),
+        };
+
+        let proof_data =
+            confidential_transfer::instruction::PubkeyValidityData::new(&bob_meta.elgamal_keypair)
+                .unwrap();
+
+        let mut ctx = context.context.lock().await;
+        let rent = ctx.banks_client.get_rent().await.unwrap();
+
+        let instructions = vec![
+            system_instruction::create_account(
+                &ctx.payer.pubkey(),
+                &context_state_account.pubkey(),
+                rent.minimum_balance(space),
+                space as u64,
+                &zk_token_proof_program::id(),
+            ),
+            instruction_type.encode_verify_proof(Some(context_state_info), &proof_data),
+        ];
+
+        let tx = Transaction::new_signed_with_payer(
+            &instructions,
+            Some(&ctx.payer.pubkey()),
+            &[&ctx.payer, &context_state_account],
+            ctx.last_blockhash,
+        );
+        ctx.banks_client.process_transaction(tx).await.unwrap();
+    }
+
+    let err = token
+        .confidential_transfer_empty_account(
+            &bob_meta.token_account,
+            &bob.pubkey(),
+            Some(&context_state_account.pubkey()),
+            None,
+            &bob_meta.elgamal_keypair,
             &[&bob],
         )
         .await

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -2746,9 +2746,9 @@ async fn confidential_transfer_transfer_with_proof_context() {
         .await
         .unwrap();
 
+    // attempt to create an account with a wrong proof type context state
     let context_state_account = Keypair::new();
 
-    // create context state
     {
         let context_state_authority = Keypair::new();
         let space = size_of::<ProofContextState<WithdrawProofContext>>();

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -1062,6 +1062,7 @@ async fn confidential_transfer_withdraw() {
         .confidential_transfer_withdraw(
             &alice_meta.token_account,
             &alice.pubkey(),
+            None,
             0,
             decimals,
             None,
@@ -1089,6 +1090,7 @@ async fn confidential_transfer_withdraw() {
         .confidential_transfer_withdraw(
             &alice_meta.token_account,
             &alice.pubkey(),
+            None,
             42,
             decimals,
             None,
@@ -1121,6 +1123,7 @@ async fn confidential_transfer_withdraw() {
         .confidential_transfer_withdraw(
             &alice_meta.token_account,
             &alice.pubkey(),
+            None,
             1,
             decimals,
             None,
@@ -2432,6 +2435,175 @@ async fn confidential_transfer_empty_account_with_proof_context() {
             Some(&context_state_account.pubkey()),
             None,
             &bob_meta.elgamal_keypair,
+            &[&bob],
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(0, InstructionError::InvalidArgument,)
+        )))
+    );
+}
+
+#[tokio::test]
+async fn confidential_transfer_withdraw_with_proof_context() {
+    let authority = Keypair::new();
+    let auto_approve_new_accounts = true;
+
+    let mut context = TestContext::new().await;
+    context
+        .init_token_with_mint(vec![
+            ExtensionInitializationParams::ConfidentialTransferMint {
+                authority: Some(authority.pubkey()),
+                auto_approve_new_accounts,
+                auditor_elgamal_pubkey: None,
+            },
+        ])
+        .await
+        .unwrap();
+
+    let TokenContext {
+        token,
+        alice,
+        bob,
+        mint_authority,
+        decimals,
+        ..
+    } = context.token_context.unwrap();
+
+    let alice_meta = ConfidentialTokenAccountMeta::new_with_tokens(
+        &token,
+        &alice,
+        &mint_authority,
+        42,
+        decimals,
+    )
+    .await;
+
+    let context_state_account = Keypair::new();
+
+    // create context state
+    {
+        let context_state_authority = Keypair::new();
+        let space = size_of::<ProofContextState<WithdrawProofContext>>();
+
+        let instruction_type = ProofInstruction::VerifyWithdraw;
+
+        let context_state_info = ContextStateInfo {
+            context_state_account: &context_state_account.pubkey(),
+            context_state_authority: &context_state_authority.pubkey(),
+        };
+
+        let state = token
+            .get_account_info(&alice_meta.token_account)
+            .await
+            .unwrap();
+        let extension = state
+            .get_extension::<ConfidentialTransferAccount>()
+            .unwrap();
+        let current_ciphertext = extension.available_balance.try_into().unwrap();
+
+        let proof_data = confidential_transfer::instruction::WithdrawData::new(
+            0,
+            &alice_meta.elgamal_keypair,
+            42,
+            &current_ciphertext,
+        )
+        .unwrap();
+
+        let mut ctx = context.context.lock().await;
+        let rent = ctx.banks_client.get_rent().await.unwrap();
+
+        let instructions = vec![
+            system_instruction::create_account(
+                &ctx.payer.pubkey(),
+                &context_state_account.pubkey(),
+                rent.minimum_balance(space),
+                space as u64,
+                &zk_token_proof_program::id(),
+            ),
+            instruction_type.encode_verify_proof(Some(context_state_info), &proof_data),
+        ];
+
+        let tx = Transaction::new_signed_with_payer(
+            &instructions,
+            Some(&ctx.payer.pubkey()),
+            &[&ctx.payer, &context_state_account],
+            ctx.last_blockhash,
+        );
+        ctx.banks_client.process_transaction(tx).await.unwrap();
+    }
+
+    token
+        .confidential_transfer_withdraw(
+            &alice_meta.token_account,
+            &alice.pubkey(),
+            Some(&context_state_account.pubkey()),
+            0,
+            decimals,
+            None,
+            &alice_meta.elgamal_keypair,
+            &alice_meta.aes_key,
+            &[&alice],
+        )
+        .await
+        .unwrap();
+
+    // attempt to create an account with a wrong proof type context state
+    let bob_meta = ConfidentialTokenAccountMeta::new(&token, &bob).await;
+    let context_state_account = Keypair::new();
+
+    {
+        let context_state_authority = Keypair::new();
+        let space = size_of::<ProofContextState<PubkeyValidityProofContext>>();
+
+        let instruction_type = ProofInstruction::VerifyPubkeyValidity;
+
+        let context_state_info = ContextStateInfo {
+            context_state_account: &context_state_account.pubkey(),
+            context_state_authority: &context_state_authority.pubkey(),
+        };
+
+        let proof_data =
+            confidential_transfer::instruction::PubkeyValidityData::new(&bob_meta.elgamal_keypair)
+                .unwrap();
+
+        let mut ctx = context.context.lock().await;
+        let rent = ctx.banks_client.get_rent().await.unwrap();
+
+        let instructions = vec![
+            system_instruction::create_account(
+                &ctx.payer.pubkey(),
+                &context_state_account.pubkey(),
+                rent.minimum_balance(space),
+                space as u64,
+                &zk_token_proof_program::id(),
+            ),
+            instruction_type.encode_verify_proof(Some(context_state_info), &proof_data),
+        ];
+
+        let tx = Transaction::new_signed_with_payer(
+            &instructions,
+            Some(&ctx.payer.pubkey()),
+            &[&ctx.payer, &context_state_account],
+            ctx.last_blockhash,
+        );
+        ctx.banks_client.process_transaction(tx).await.unwrap();
+    }
+
+    let err = token
+        .confidential_transfer_withdraw(
+            &bob_meta.token_account,
+            &bob.pubkey(),
+            Some(&context_state_account.pubkey()),
+            0,
+            decimals,
+            None,
+            &bob_meta.elgamal_keypair,
+            &bob_meta.aes_key,
             &[&bob],
         )
         .await

--- a/token/program-2022/src/error.rs
+++ b/token/program-2022/src/error.rs
@@ -210,6 +210,11 @@ pub enum TokenError {
     /// Failed to generate a zero-knowledge proof needed for a token instruction
     #[error("Failed to generate proof")]
     ProofGeneration,
+
+    // 55
+    /// An invalid proof instruction offset was provided
+    #[error("An invalid proof instruction offset was provided ")]
+    InvalidProofInstructionOffset,
 }
 impl From<TokenError> for ProgramError {
     fn from(e: TokenError) -> Self {
@@ -366,6 +371,9 @@ impl PrintProgramError for TokenError {
             }
             TokenError::ProofGeneration => {
                 msg!("Failed to generate proof")
+            }
+            TokenError::InvalidProofInstructionOffset => {
+                msg!("An invalid proof instruction offset was provided")
             }
         }
     }

--- a/token/program-2022/src/extension/confidential_transfer/account_info.rs
+++ b/token/program-2022/src/extension/confidential_transfer/account_info.rs
@@ -15,9 +15,35 @@ use {
         instruction::{
             transfer::{FeeParameters, TransferData, TransferWithFeeData},
             withdraw::WithdrawData,
+            zero_balance::ZeroBalanceProofData,
         },
     },
 };
+
+/// Confidential transfer extension information needed to construct an `EmptyAccount` instruction.
+#[cfg(not(target_os = "solana"))]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+pub struct EmptyAccountAccountInfo {
+    /// The available balance
+    pub(crate) available_balance: EncryptedBalance,
+}
+#[cfg(not(target_os = "solana"))]
+impl EmptyAccountAccountInfo {
+    /// Create an empty account proof data.
+    pub fn generate_proof_data(
+        &self,
+        elgamal_keypair: &ElGamalKeypair,
+    ) -> Result<ZeroBalanceProofData, TokenError> {
+        let available_balance = self
+            .available_balance
+            .try_into()
+            .map_err(|_| TokenError::AccountDecryption)?;
+
+        ZeroBalanceProofData::new(elgamal_keypair, &available_balance)
+            .map_err(|_| TokenError::ProofGeneration)
+    }
+}
 
 /// Confidential Transfer extension information needed to construct an `ApplyPendingBalance`
 /// instruction.

--- a/token/program-2022/src/extension/confidential_transfer/account_info.rs
+++ b/token/program-2022/src/extension/confidential_transfer/account_info.rs
@@ -21,14 +21,12 @@ use {
 };
 
 /// Confidential transfer extension information needed to construct an `EmptyAccount` instruction.
-#[cfg(not(target_os = "solana"))]
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct EmptyAccountAccountInfo {
     /// The available balance
     pub(crate) available_balance: EncryptedBalance,
 }
-#[cfg(not(target_os = "solana"))]
 impl EmptyAccountAccountInfo {
     /// Create an empty account proof data.
     pub fn generate_proof_data(

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -587,7 +587,7 @@ pub fn configure_account(
         // constructor.
         let proof_instruction_offset: i8 = proof_instruction_offset.into();
         if proof_instruction_offset != 1 {
-            return Err(ProgramError::InvalidArgument);
+            return Err(TokenError::InvalidProofInstructionOffset.into());
         }
         instructions.push(verify_pubkey_validity(None, proof_data));
     };
@@ -689,7 +689,7 @@ pub fn empty_account(
         // arbitrary proof instruction offset, use the `inner_empty_account` constructor.
         let proof_instruction_offset: i8 = proof_instruction_offset.into();
         if proof_instruction_offset != 1 {
-            return Err(ProgramError::InvalidArgument);
+            return Err(TokenError::InvalidProofInstructionOffset.into());
         }
         instructions.push(verify_zero_balance(None, proof_data));
     };
@@ -820,7 +820,7 @@ pub fn withdraw(
         // proof instruction offset, use the `inner_withdraw` constructor.
         let proof_instruction_offset: i8 = proof_instruction_offset.into();
         if proof_instruction_offset != 1 {
-            return Err(ProgramError::InvalidArgument);
+            return Err(TokenError::InvalidProofInstructionOffset.into());
         }
         instructions.push(verify_withdraw(None, proof_data));
     };
@@ -914,7 +914,7 @@ pub fn transfer(
         // constructor.
         let proof_instruction_offset: i8 = proof_instruction_offset.into();
         if proof_instruction_offset != 1 {
-            return Err(ProgramError::InvalidArgument);
+            return Err(TokenError::InvalidProofInstructionOffset.into());
         }
         instructions.push(verify_transfer(None, proof_data));
     };
@@ -1008,7 +1008,7 @@ pub fn transfer_with_fee(
         // constructor.
         let proof_instruction_offset: i8 = proof_instruction_offset.into();
         if proof_instruction_offset != 1 {
-            return Err(ProgramError::InvalidArgument);
+            return Err(TokenError::InvalidProofInstructionOffset.into());
         }
         instructions.push(verify_transfer_with_fee(None, proof_data));
     };

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -522,7 +522,7 @@ pub fn inner_configure_account(
     ];
 
     let proof_instruction_offset = match proof_data_location {
-        ProofLocation::Instruction(proof_instruction_offset, _) => {
+        ProofLocation::InstructionOffset(proof_instruction_offset, _) => {
             accounts.push(AccountMeta::new_readonly(sysvar::instructions::id(), false));
             proof_instruction_offset.into()
         }
@@ -578,7 +578,9 @@ pub fn configure_account(
         proof_data_location,
     )?];
 
-    if let ProofLocation::Instruction(proof_instruction_offset, proof_data) = proof_data_location {
+    if let ProofLocation::InstructionOffset(proof_instruction_offset, proof_data) =
+        proof_data_location
+    {
         // This constructor appends the proof instruction right after the `ConfigureAccount`
         // instruction. This means that the proof instruction offset must be always be 1. To
         // use an arbitrary proof instruction offset, use the `inner_configure_account`
@@ -633,7 +635,7 @@ pub fn inner_empty_account(
     let mut accounts = vec![AccountMeta::new(*token_account, false)];
 
     let proof_instruction_offset = match proof_data_location {
-        ProofLocation::Instruction(proof_instruction_offset, _) => {
+        ProofLocation::InstructionOffset(proof_instruction_offset, _) => {
             accounts.push(AccountMeta::new_readonly(sysvar::instructions::id(), false));
             proof_instruction_offset.into()
         }
@@ -679,7 +681,9 @@ pub fn empty_account(
         proof_data_location,
     )?];
 
-    if let ProofLocation::Instruction(proof_instruction_offset, proof_data) = proof_data_location {
+    if let ProofLocation::InstructionOffset(proof_instruction_offset, proof_data) =
+        proof_data_location
+    {
         // This constructor appends the proof instruction right after the `EmptyAccount`
         // instruction. This means that the proof instruction offset must be always be 1. To use an
         // arbitrary proof instruction offset, use the `inner_empty_account` constructor.
@@ -749,7 +753,7 @@ pub fn inner_withdraw(
     ];
 
     let proof_instruction_offset = match proof_data_location {
-        ProofLocation::Instruction(proof_instruction_offset, _) => {
+        ProofLocation::InstructionOffset(proof_instruction_offset, _) => {
             accounts.push(AccountMeta::new_readonly(sysvar::instructions::id(), false));
             proof_instruction_offset.into()
         }
@@ -808,7 +812,9 @@ pub fn withdraw(
         proof_data_location,
     )?];
 
-    if let ProofLocation::Instruction(proof_instruction_offset, proof_data) = proof_data_location {
+    if let ProofLocation::InstructionOffset(proof_instruction_offset, proof_data) =
+        proof_data_location
+    {
         // This constructor appends the proof instruction right after the `Withdraw` instruction.
         // This means that the proof instruction offset must be always be 1. To use an arbitrary
         // proof instruction offset, use the `inner_withdraw` constructor.
@@ -844,7 +850,7 @@ pub fn inner_transfer(
     ];
 
     let proof_instruction_offset = match proof_data_location {
-        ProofLocation::Instruction(proof_instruction_offset, _) => {
+        ProofLocation::InstructionOffset(proof_instruction_offset, _) => {
             accounts.push(AccountMeta::new_readonly(sysvar::instructions::id(), false));
             proof_instruction_offset.into()
         }
@@ -899,7 +905,9 @@ pub fn transfer(
         proof_data_location,
     )?];
 
-    if let ProofLocation::Instruction(proof_instruction_offset, proof_data) = proof_data_location {
+    if let ProofLocation::InstructionOffset(proof_instruction_offset, proof_data) =
+        proof_data_location
+    {
         // This constructor appends the proof instruction right after the `ConfigureAccount`
         // instruction. This means that the proof instruction offset must be always be 1. To
         // use an arbitrary proof instruction offset, use the `inner_configure_account`
@@ -936,7 +944,7 @@ pub fn inner_transfer_with_fee(
     ];
 
     let proof_instruction_offset = match proof_data_location {
-        ProofLocation::Instruction(proof_instruction_offset, _) => {
+        ProofLocation::InstructionOffset(proof_instruction_offset, _) => {
             accounts.push(AccountMeta::new_readonly(sysvar::instructions::id(), false));
             proof_instruction_offset.into()
         }
@@ -991,7 +999,9 @@ pub fn transfer_with_fee(
         proof_data_location,
     )?];
 
-    if let ProofLocation::Instruction(proof_instruction_offset, proof_data) = proof_data_location {
+    if let ProofLocation::InstructionOffset(proof_instruction_offset, proof_data) =
+        proof_data_location
+    {
         // This constructor appends the proof instruction right after the `TransferWithFee`
         // instruction. This means that the proof instruction offset must be always be 1. To
         // use an arbitrary proof instruction offset, use the `inner_transfer_with_fee`

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -75,17 +75,19 @@ pub enum ConfidentialTransferInstruction {
     ///   * Single owner/delegate
     ///   0. `[writeable]` The SPL Token account.
     ///   1. `[]` The corresponding SPL Token mint.
-    ///   2. `[]` Instructions sysvar.
-    ///   3. `[]` Context state account for `ZeroBalanceProof` (optional)
-    ///   4. `[signer]` The single source account owner.
+    ///   2. `[]` Instructions sysvar if `PubkeyValidityProof` is included in the same transaction or
+    ///      context state account if `PubkeyValidityProof` is pre-verified into a context state
+    ///      account.
+    ///   3. `[signer]` The single source account owner.
     ///
     ///   * Multisignature owner/delegate
     ///   0. `[writeable]` The SPL Token account.
     ///   1. `[]` The corresponding SPL Token mint.
-    ///   2. `[]` Instructions sysvar.
-    ///   3. `[]` Context state account `ZeroBalanceProof` (optional)
-    ///   4. `[]` The multisig source account owner.
-    ///   5.. `[signer]` Required M signer accounts for the SPL Token Multisig account.
+    ///   2. `[]` Instructions sysvar if `PubkeyValidityProof` is included in the same transaction or
+    ///      context state account if `PubkeyValidityProof` is pre-verified into a context state
+    ///      account.
+    ///   3. `[]` The multisig source account owner.
+    ///   4.. `[signer]` Required M signer accounts for the SPL Token Multisig account.
     ///
     /// Data expected by this instruction:
     ///   `ConfigureAccountInstructionData`
@@ -127,16 +129,18 @@ pub enum ConfidentialTransferInstruction {
     ///
     ///   * Single owner/delegate
     ///   0. `[writable]` The SPL Token account.
-    ///   1. `[]` Instructions sysvar.
-    ///   2. `[]` Context state account for `ZeroBalanceProof` (optional)
-    ///   3. `[signer]` The single account owner.
+    ///   1. `[]` Instructions sysvar if `ZeroBalanceProof` is included in the same transaction or
+    ///      context state account if `ZeroBalanceProof` is pre-verified into a context state
+    ///      account.
+    ///   2. `[signer]` The single account owner.
     ///
     ///   * Multisignature owner/delegate
     ///   0. `[writable]` The SPL Token account.
-    ///   1. `[]` Instructions sysvar.
+    ///   1. `[]` Instructions sysvar if `ZeroBalanceProof` is included in the same transaction or
+    ///      context state account if `ZeroBalanceProof` is pre-verified into a context state
+    ///      account.
     ///   2. `[]` The multisig account owner.
-    ///   3. `[]` Context state account for `ZeroBalanceProof` (optional)
-    ///   4.. `[signer]` Required M signer accounts for the SPL Token Multisig account.
+    ///   3.. `[signer]` Required M signer accounts for the SPL Token Multisig account.
     ///
     /// Data expected by this instruction:
     ///   `EmptyAccountInstructionData`
@@ -182,17 +186,17 @@ pub enum ConfidentialTransferInstruction {
     ///   * Single owner/delegate
     ///   0. `[writable]` The SPL Token account.
     ///   1. `[]` The token mint.
-    ///   2. `[]` Instructions sysvar.
-    ///   3. `[]` Context state account for `WithdrawData` (optional)
-    ///   4. `[signer]` The single source account owner.
+    ///   2. `[]` Instructions sysvar if `WithdrawProof` is included in the same transaction or
+    ///      context state account if `WithdrawProof` is pre-verified into a context state account.
+    ///   3. `[signer]` The single source account owner.
     ///
     ///   * Multisignature owner/delegate
     ///   0. `[writable]` The SPL Token account.
     ///   1. `[]` The token mint.
-    ///   2. `[]` Instructions sysvar.
-    ///   3. `[]` Context state account for `WithdrawData` (optional)
-    ///   4. `[]` The multisig  source account owner.
-    ///   5.. `[signer]` Required M signer accounts for the SPL Token Multisig account.
+    ///   2. `[]` Instructions sysvar if `WithdrawProof` is included in the same transaction or
+    ///      context state account if `WithdrawProof` is pre-verified into a context state account.
+    ///   3. `[]` The multisig  source account owner.
+    ///   4.. `[signer]` Required M signer accounts for the SPL Token Multisig account.
     ///
     /// Data expected by this instruction:
     ///   `WithdrawInstructionData`
@@ -211,18 +215,20 @@ pub enum ConfidentialTransferInstruction {
     ///   1. `[writable]` The source SPL Token account.
     ///   2. `[writable]` The destination SPL Token account.
     ///   3. `[]` The token mint.
-    ///   4. `[]` Instructions sysvar.
-    ///   5. `[]` Context state account for `TransferProof` (optional)
-    ///   6. `[signer]` The single source account owner.
+    ///   4. `[]` Instructions sysvar if `TransferProof` or `TransferWithFeeProof` is included in
+    ///      the same transaction or context state account if the proof is pre-verified into a
+    ///      context state account.
+    ///   5. `[signer]` The single source account owner.
     ///
     ///   * Multisignature owner/delegate
     ///   1. `[writable]` The source SPL Token account.
     ///   2. `[writable]` The destination SPL Token account.
     ///   3. `[]` The token mint.
-    ///   4. `[]` Instructions sysvar.
-    ///   5. `[]` Context state account for `TransferProof` (optional)
-    ///   6. `[]` The multisig  source account owner.
-    ///   7.. `[signer]` Required M signer accounts for the SPL Token Multisig account.
+    ///   4. `[]` Instructions sysvar if `TransferProof` or `TransferWithFeeProof` is included in
+    ///      the same transaction or context state account if the proof is pre-verified into a
+    ///      context state account.
+    ///   5. `[]` The multisig  source account owner.
+    ///   6.. `[signer]` Required M signer accounts for the SPL Token Multisig account.
     ///
     /// Data expected by this instruction:
     ///   `TransferInstructionData`
@@ -513,11 +519,13 @@ pub fn inner_configure_account(
     let mut accounts = vec![
         AccountMeta::new(*token_account, false),
         AccountMeta::new_readonly(*mint, false),
-        AccountMeta::new_readonly(sysvar::instructions::id(), false),
     ];
 
     let proof_instruction_offset = match proof_data_location {
-        ProofLocation::Instruction(proof_instruction_offset, _) => proof_instruction_offset.into(),
+        ProofLocation::Instruction(proof_instruction_offset, _) => {
+            accounts.push(AccountMeta::new_readonly(sysvar::instructions::id(), false));
+            proof_instruction_offset.into()
+        }
         ProofLocation::ContextStateAccount(context_state_account) => {
             accounts.push(AccountMeta::new_readonly(*context_state_account, false));
             0
@@ -622,13 +630,13 @@ pub fn inner_empty_account(
     proof_data_location: ProofLocation<ZeroBalanceProofData>,
 ) -> Result<Instruction, ProgramError> {
     check_program_account(token_program_id)?;
-    let mut accounts = vec![
-        AccountMeta::new(*token_account, false),
-        AccountMeta::new_readonly(sysvar::instructions::id(), false),
-    ];
+    let mut accounts = vec![AccountMeta::new(*token_account, false)];
 
     let proof_instruction_offset = match proof_data_location {
-        ProofLocation::Instruction(proof_instruction_offset, _) => proof_instruction_offset.into(),
+        ProofLocation::Instruction(proof_instruction_offset, _) => {
+            accounts.push(AccountMeta::new_readonly(sysvar::instructions::id(), false));
+            proof_instruction_offset.into()
+        }
         ProofLocation::ContextStateAccount(context_state_account) => {
             accounts.push(AccountMeta::new_readonly(*context_state_account, false));
             0
@@ -738,11 +746,13 @@ pub fn inner_withdraw(
     let mut accounts = vec![
         AccountMeta::new(*token_account, false),
         AccountMeta::new_readonly(*mint, false),
-        AccountMeta::new_readonly(sysvar::instructions::id(), false),
     ];
 
     let proof_instruction_offset = match proof_data_location {
-        ProofLocation::Instruction(proof_instruction_offset, _) => proof_instruction_offset.into(),
+        ProofLocation::Instruction(proof_instruction_offset, _) => {
+            accounts.push(AccountMeta::new_readonly(sysvar::instructions::id(), false));
+            proof_instruction_offset.into()
+        }
         ProofLocation::ContextStateAccount(context_state_account) => {
             accounts.push(AccountMeta::new_readonly(*context_state_account, false));
             0
@@ -831,11 +841,13 @@ pub fn inner_transfer(
         AccountMeta::new(*source_token_account, false),
         AccountMeta::new(*destination_token_account, false),
         AccountMeta::new_readonly(*mint, false),
-        AccountMeta::new_readonly(sysvar::instructions::id(), false),
     ];
 
     let proof_instruction_offset = match proof_data_location {
-        ProofLocation::Instruction(proof_instruction_offset, _) => proof_instruction_offset.into(),
+        ProofLocation::Instruction(proof_instruction_offset, _) => {
+            accounts.push(AccountMeta::new_readonly(sysvar::instructions::id(), false));
+            proof_instruction_offset.into()
+        }
         ProofLocation::ContextStateAccount(context_state_account) => {
             accounts.push(AccountMeta::new_readonly(*context_state_account, false));
             0
@@ -921,11 +933,13 @@ pub fn inner_transfer_with_fee(
         AccountMeta::new(*source_token_account, false),
         AccountMeta::new(*destination_token_account, false),
         AccountMeta::new_readonly(*mint, false),
-        AccountMeta::new_readonly(sysvar::instructions::id(), false),
     ];
 
     let proof_instruction_offset = match proof_data_location {
-        ProofLocation::Instruction(proof_instruction_offset, _) => proof_instruction_offset.into(),
+        ProofLocation::Instruction(proof_instruction_offset, _) => {
+            accounts.push(AccountMeta::new_readonly(sysvar::instructions::id(), false));
+            proof_instruction_offset.into()
+        }
         ProofLocation::ContextStateAccount(context_state_account) => {
             accounts.push(AccountMeta::new_readonly(*context_state_account, false));
             0

--- a/token/program-2022/src/extension/confidential_transfer/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer/mod.rs
@@ -182,6 +182,14 @@ impl ConfidentialTransferAccount {
         Ok(())
     }
 
+    /// Return the account information needed to construct an `EmptyAccount` instruction.
+    #[cfg(not(target_os = "solana"))]
+    pub fn empty_account_account_info(&self) -> EmptyAccountAccountInfo {
+        let available_balance = self.available_balance;
+
+        EmptyAccountAccountInfo { available_balance }
+    }
+
     /// Return the account information needed to construct an `ApplyPendingBalance` instruction.
     #[cfg(not(target_os = "solana"))]
     pub fn apply_pending_balance_account_info(&self) -> ApplyPendingBalanceAccountInfo {

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -395,6 +395,13 @@ fn process_withdraw(
     let token_account_info = next_account_info(account_info_iter)?;
     let mint_info = next_account_info(account_info_iter)?;
     let instructions_sysvar_info = next_account_info(account_info_iter)?;
+
+    let context_state_account_info = if proof_instruction_offset == 0 {
+        Some(next_account_info(account_info_iter)?)
+    } else {
+        None
+    };
+
     let authority_info = next_account_info(account_info_iter)?;
     let authority_info_data_len = authority_info.data_len();
 
@@ -439,12 +446,25 @@ fn process_withdraw(
 
     // Zero-knowledge proof certifies that the account has enough available balance to withdraw the
     // amount.
-    let zkp_instruction =
-        get_instruction_relative(proof_instruction_offset, instructions_sysvar_info)?;
-    let proof_context = decode_proof_instruction_context::<WithdrawData, WithdrawProofContext>(
-        ProofInstruction::VerifyWithdraw,
-        &zkp_instruction,
-    )?;
+    let proof_context = if let Some(context_state_account_info) = context_state_account_info {
+        let context_state_account_data = context_state_account_info.data.borrow();
+        let context_state =
+            pod_from_bytes::<ProofContextState<WithdrawProofContext>>(&context_state_account_data)?;
+
+        if context_state.proof_type != ProofType::Withdraw.into() {
+            return Err(ProgramError::InvalidInstructionData);
+        }
+
+        context_state.proof_context
+    } else {
+        let zkp_instruction =
+            get_instruction_relative(proof_instruction_offset, instructions_sysvar_info)?;
+        *decode_proof_instruction_context::<WithdrawData, WithdrawProofContext>(
+            ProofInstruction::VerifyWithdraw,
+            &zkp_instruction,
+        )?
+    };
+
     // Check that the encryption public key associated with the confidential extension is
     // consistent with the public key that was actually used to generate the zkp.
     if confidential_transfer_account.elgamal_pubkey != proof_context.pubkey {

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        check_program_account,
+        check_program_account, check_zk_token_proof_program_account,
         error::TokenError,
         extension::{
             confidential_transfer::{instruction::*, *},
@@ -135,6 +135,7 @@ fn process_configure_account(
 
     // zero-knowledge proof certifies that the supplied ElGamal public key is valid
     let proof_context = if let Some(context_state_account_info) = context_state_account_info {
+        check_zk_token_proof_program_account(context_state_account_info.owner)?;
         let context_state_account_data = context_state_account_info.data.borrow();
         let context_state = pod_from_bytes::<ProofContextState<PubkeyValidityProofContext>>(
             &context_state_account_data,
@@ -252,6 +253,7 @@ fn process_empty_account(
     // An `EmptyAccount` instruction must be accompanied by a zero-knowledge proof instruction that
     // certifies that the available balance ciphertext holds the balance of 0.
     let proof_context = if let Some(context_state_account_info) = context_state_account_info {
+        check_zk_token_proof_program_account(context_state_account_info.owner)?;
         let context_state_account_data = context_state_account_info.data.borrow();
         let context_state = pod_from_bytes::<ProofContextState<ZeroBalanceProofContext>>(
             &context_state_account_data,
@@ -447,6 +449,7 @@ fn process_withdraw(
     // Zero-knowledge proof certifies that the account has enough available balance to withdraw the
     // amount.
     let proof_context = if let Some(context_state_account_info) = context_state_account_info {
+        check_zk_token_proof_program_account(context_state_account_info.owner)?;
         let context_state_account_data = context_state_account_info.data.borrow();
         let context_state =
             pod_from_bytes::<ProofContextState<WithdrawProofContext>>(&context_state_account_data)?;
@@ -541,6 +544,7 @@ fn process_transfer(
         //   1. the transfer amount is encrypted in the correct form
         //   2. the source account has enough balance to send the transfer amount
         let proof_context = if let Some(context_state_account_info) = context_state_account_info {
+            check_zk_token_proof_program_account(context_state_account_info.owner)?;
             let context_state_account_data = context_state_account_info.data.borrow();
             let context_state = pod_from_bytes::<ProofContextState<TransferProofContext>>(
                 &context_state_account_data,
@@ -606,6 +610,7 @@ fn process_transfer(
         //   2. the source account has enough balance to send the transfer amount
         //   3. the transfer fee is computed correctly and encrypted in the correct form
         let proof_context = if let Some(context_state_account_info) = context_state_account_info {
+            check_zk_token_proof_program_account(context_state_account_info.owner)?;
             let context_state_account_data = context_state_account_info.data.borrow();
             let context_state = pod_from_bytes::<ProofContextState<TransferWithFeeProofContext>>(
                 &context_state_account_data,

--- a/token/program-2022/src/lib.rs
+++ b/token/program-2022/src/lib.rs
@@ -109,6 +109,14 @@ pub fn check_spl_token_program_account(spl_token_program_id: &Pubkey) -> Program
     Ok(())
 }
 
+/// Checks that the supplied program ID is correct for the ZK Token proof program
+pub fn check_zk_token_proof_program_account(zk_token_proof_program_id: &Pubkey) -> ProgramResult {
+    if zk_token_proof_program_id != &solana_zk_token_sdk::zk_token_proof_program::id() {
+        return Err(ProgramError::IncorrectProgramId);
+    }
+    Ok(())
+}
+
 /// Checks two pubkeys for equality in a computationally cheap way using
 /// `sol_memcmp`
 pub fn cmp_pubkeys(a: &Pubkey, b: &Pubkey) -> bool {

--- a/token/program-2022/src/proof.rs
+++ b/token/program-2022/src/proof.rs
@@ -7,6 +7,7 @@ use {
         instruction::ZkProofData, zk_token_proof_instruction::ProofInstruction,
         zk_token_proof_program,
     },
+    std::num::NonZeroI8,
 };
 
 /// Decodes the proof context data associated with a zero-knowledge proof instruction.
@@ -24,25 +25,6 @@ pub fn decode_proof_instruction_context<T: Pod + ZkProofData<U>, U: Pod>(
     ProofInstruction::proof_data::<T, U>(&instruction.data)
         .map(ZkProofData::context_data)
         .ok_or(ProgramError::InvalidInstructionData)
-}
-
-/// An `i8` type guaranteed to be non-zero.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct NonZeroI8(i8);
-impl TryFrom<i8> for NonZeroI8 {
-    type Error = ProgramError;
-    fn try_from(n: i8) -> Result<Self, Self::Error> {
-        if n == 0 {
-            Err(ProgramError::InvalidArgument)
-        } else {
-            Ok(Self(n))
-        }
-    }
-}
-impl From<NonZeroI8> for i8 {
-    fn from(n: NonZeroI8) -> Self {
-        n.0
-    }
 }
 
 /// A proof location type meant to be used for arguments to instruction constructors.

--- a/token/program-2022/src/proof.rs
+++ b/token/program-2022/src/proof.rs
@@ -2,7 +2,7 @@
 
 use {
     bytemuck::Pod,
-    solana_program::{instruction::Instruction, msg, program_error::ProgramError},
+    solana_program::{instruction::Instruction, msg, program_error::ProgramError, pubkey::Pubkey},
     solana_zk_token_sdk::{
         instruction::ZkProofData, zk_token_proof_instruction::ProofInstruction,
         zk_token_proof_program,
@@ -24,4 +24,32 @@ pub fn decode_proof_instruction_context<T: Pod + ZkProofData<U>, U: Pod>(
     ProofInstruction::proof_data::<T, U>(&instruction.data)
         .map(ZkProofData::context_data)
         .ok_or(ProgramError::InvalidInstructionData)
+}
+
+/// An `i8` type guaranteed to be non-zero.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct NonZeroI8(i8);
+impl TryFrom<i8> for NonZeroI8 {
+    type Error = ProgramError;
+    fn try_from(n: i8) -> Result<Self, Self::Error> {
+        if n == 0 {
+            Err(ProgramError::InvalidArgument)
+        } else {
+            Ok(Self(n))
+        }
+    }
+}
+impl From<NonZeroI8> for i8 {
+    fn from(n: NonZeroI8) -> Self {
+        n.0
+    }
+}
+
+/// A proof location type meant to be used for arguments to instruction constructors.
+#[derive(Clone, Copy)]
+pub enum ProofLocation<'a, T> {
+    /// The proof is included in the same transaction of a corresponding token-2022 instruction.
+    Instruction(NonZeroI8, &'a T),
+    /// The proof is pre-verified into a context state account.
+    ContextStateAccount(&'a Pubkey),
 }

--- a/token/program-2022/src/proof.rs
+++ b/token/program-2022/src/proof.rs
@@ -49,7 +49,7 @@ impl From<NonZeroI8> for i8 {
 #[derive(Clone, Copy)]
 pub enum ProofLocation<'a, T> {
     /// The proof is included in the same transaction of a corresponding token-2022 instruction.
-    Instruction(NonZeroI8, &'a T),
+    InstructionOffset(NonZeroI8, &'a T),
     /// The proof is pre-verified into a context state account.
     ContextStateAccount(&'a Pubkey),
 }


### PR DESCRIPTION
#### Problem
The token-2022 confidential transfer extension instructions that require zero-knowledge proofs do not yet support context states.

#### Summary of changes
Added support for context state accounts. All the confidential transfer instructions that require zkp's have an `i8` proof instruction offset field that represents the position of the zkp instruction relative to the token-2022 instruction. Since the offset cannot be zero, I updated the program so that it if the offset is zero, it checks for a context state account.

- [8bb4d2a](https://github.com/solana-labs/solana-program-library/pull/4816/commits/8bb4d2aec8841a7689e1ca2980491fad6a5c1844): The previous PR that updated the`EmptyAccount` instruction for 1.16 did not add account info for it, so I added it in line with the rest of the zkp requiring instructions and to simplify the `generate_proof_data` interface.
- [1a99b80](https://github.com/solana-labs/solana-program-library/pull/4816/commits/1a99b8075b20bc619d612fa853cf32a3ec8cb639): Added support for context states for the `ConfigureAccount` instruction. The main changes are in `instruction.rs` and `processor.rs`. The rest of the commits model this commit.
- [f7772ea](https://github.com/solana-labs/solana-program-library/pull/4816/commits/f7772ea1e015066ae8802cba2fd05a3bcdd58c12): Added support for context states for the ``EmptyAccount` instruction.
- [6a9a77d](https://github.com/solana-labs/solana-program-library/pull/4816/commits/6a9a77dc4b40ebb146072c9312ab42f19f0c6f8b): Added support for context states for the `Withdraw` instruction.
- [426589a](https://github.com/solana-labs/solana-program-library/pull/4816/commits/426589a7521ea145ef456563bbb93d7e8f477ec0): Added support for context states for the `Transfer` instruction. The transfer instruction also requires processing of smaller zkp proof context states. I started making the changes in this PR until I realized this PR is quite long, so I decided to do it in a subsequent PR.