### PR TITLE
Editions Interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7039,6 +7039,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-token-editions-example"
+version = "0.1.0"
+dependencies = [
+ "solana-program",
+ "solana-program-test",
+ "solana-sdk",
+ "spl-token-2022 0.7.0",
+ "spl-token-client",
+ "spl-token-editions-interface",
+ "spl-token-metadata-interface",
+ "spl-type-length-value",
+ "test-case",
+]
+
+[[package]]
+name = "spl-token-editions-interface"
+version = "0.1.0"
+dependencies = [
+ "borsh 0.10.3",
+ "solana-program",
+ "spl-discriminator",
+ "spl-program-error",
+ "spl-type-length-value",
+]
+
+[[package]]
 name = "spl-token-lending"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ members = [
   "associated-token-account/program-test",
   "binary-option/program",
   "binary-oracle-pair/program",
+  "editions/example",
+  "editions/interface",
   "examples/rust/cross-program-invocation",
   "examples/rust/custom-heap",
   "examples/rust/logging",

--- a/editions/README.md
+++ b/editions/README.md
@@ -1,0 +1,97 @@
+# Editions
+
+This interface is designed to allow on-chain programs to make use of printed "copies" of token metadata, with parent-child relationships.
+
+## Metaplex Protocol
+
+Metaplex introduced the idea of [Editions](https://docs.metaplex.com/programs/token-metadata/overview#printing-editions) for tokens, a concept most projects on Solana are readily familiar with.
+
+In short, editions allow you to create an original "copy" of an token and then print new "copies" of that token. Although we're talking about "copies", the token itself is not copied. All that's being copied with Editions is the Metadata.
+
+### Create the Original
+
+Create a `MasterEdition` account for the the original token.
+
+- Mint a new SPL Token with supply of 1, decimals 0, and no mint authority.
+- Create a `Metadata` account for the token.
+- Create a `MasterEdition` account for the token.
+
+As described in [Metaplex's docs](https://docs.metaplex.com/programs/token-metadata/overview#printing-editions):
+> "The Master Edition NFT, a.k.a. Original NFT, acts as the master record that one can use to print copies, a.k.a. Print NFTs."
+
+We can infer how a `MasterEdition` account dictates the printing of copies by examining its schema below:
+
+```rust
+pub struct MasterEditionV2 {
+    pub key: Key,       // Enum value `MasterEdition`
+    pub supply: u64,
+    pub max_supply: Option<u64>,
+}
+```
+
+With Metaplex's protocol, the `MasterEdition` determines the max supply and also incrementally records the current supply, so we know **this account must always be involved with the printing of new editions**.
+
+### Print Copies
+
+Create one or more copies of the original token by creating an `Edition`, by creating new tokens that inherently "copy" the original token's metadata.
+
+- Mint a new SPL Token with supply of 1, decimals 0, and no mint authority.
+- Create a `Metadata` account for the token with the data _copied from the `Metadata` account referred to by the `MasterEdition`_.
+- Create an `Edition` account for the token pointing to the `MasterEdition` account.
+
+We can immediately see the parent-child relationship made evident within an `Edition` schema:
+
+```rust
+pub struct Edition {
+    pub key: Key,       // Enum value `Edition`
+    pub parent: Pubkey,
+    pub edition: u64,
+}
+```
+
+### Seeds
+
+The PDA seeds used to derive a `MasterEdition` and an `Edition` are the same, so that a token can only have one or the other. They are as follows:
+
+```text
+"metadata" + <token metadata program ID> + <mint address> + "edition"
+```
+
+## SPL Interface
+
+The interface - albeit strongly inspired and largely based upon Metaplex's original engineering - should be simple enough to not inundate or force anyone to comply with any preconcieved ideas of how these parent-child relationships amongst editions should interact.
+
+> Note: Changing the nomenclature of these state objects may potentially confuse people familiar with Metaplex's model, but serve to acknowledge the fact that this interface is something entirely different.
+
+### The Original
+
+This interface will dub the original token or NFT as simply an `Original`.
+
+Similar to `MasterEdition`, this state will store information pertaining to supply and maximum supply.
+
+```rust
+pub struct Original {
+    pub update_authority: OptionalNonZeroPubkey,
+    pub supply: u64,
+    pub max_supply: Option<u64>,
+}
+```
+
+### The Reprint
+
+This interface will dub copies of the original as a `Reprint`.
+
+Similar to `Edition`, this state will store information pointing back to the parent.
+
+```rust
+pub struct Reprint {
+    pub original: Pubkey,
+    pub copy: u64,
+}
+```
+
+### Seeds (SPL)
+
+It's worth noting that, as Metaplex has designed, making the seeds for these types of accounts the same is a good idea. However, this interface cannot enforce this.
+
+In the case of the interface, both states share the same SPL discriminator, thus mimic the seed pattern of Metaplex.

--- a/editions/example/Cargo.toml
+++ b/editions/example/Cargo.toml
@@ -15,13 +15,13 @@ test-sbf = []
 solana-program = "1.16.3"
 spl-token-2022 = { version = "0.7", path = "../../token/program-2022" }
 spl-token-editions-interface = { version = "0.1.0", path = "../interface" }
+spl-token-metadata-interface = { version = "0.1.0", path = "../../token-metadata/interface" }
 spl-type-length-value = { version = "0.2.0" , path = "../../libraries/type-length-value" }
 
 [dev-dependencies]
 solana-program-test = "1.16.3"
 solana-sdk = "1.16.3"
 spl-token-client = { version = "0.5", path = "../../token/client" }
-spl-token-metadata-interface = { version = "0.1.0", path = "../../token-metadata/interface" }
 test-case = "3.1"
 
 [lib]

--- a/editions/example/Cargo.toml
+++ b/editions/example/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "spl-token-editions-example"
+version = "0.1.0"
+description = "Solana Program Library Token Metadata Example Program"
+authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
+repository = "https://github.com/solana-labs/solana-program-library"
+license = "Apache-2.0"
+edition = "2021"
+
+[features]
+no-entrypoint = []
+test-sbf = []
+
+[dependencies]
+solana-program = "1.16.3"
+spl-token-2022 = { version = "0.7", path = "../../token/program-2022" }
+spl-token-editions-interface = { version = "0.1.0", path = "../interface" }
+spl-type-length-value = { version = "0.2.0" , path = "../../libraries/type-length-value" }
+
+[dev-dependencies]
+solana-program-test = "1.16.3"
+solana-sdk = "1.16.3"
+spl-token-client = { version = "0.5", path = "../../token/client" }
+spl-token-metadata-interface = { version = "0.1.0", path = "../../token-metadata/interface" }
+test-case = "3.1"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/editions/example/src/entrypoint.rs
+++ b/editions/example/src/entrypoint.rs
@@ -1,0 +1,24 @@
+//! Program entrypoint
+
+use {
+    crate::processor,
+    solana_program::{
+        account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,
+        program_error::PrintProgramError, pubkey::Pubkey,
+    },
+    spl_token_editions_interface::error::TokenEditionsError,
+};
+
+entrypoint!(process_instruction);
+fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    if let Err(error) = processor::process(program_id, accounts, instruction_data) {
+        // catch the error so we can print it
+        error.print::<TokenEditionsError>();
+        return Err(error);
+    }
+    Ok(())
+}

--- a/editions/example/src/lib.rs
+++ b/editions/example/src/lib.rs
@@ -1,0 +1,10 @@
+//! Crate defining an example program for creating SPL token editions
+
+#![allow(clippy::integer_arithmetic)]
+#![deny(missing_docs)]
+#![cfg_attr(not(test), forbid(unsafe_code))]
+
+pub mod processor;
+
+#[cfg(not(feature = "no-entrypoint"))]
+mod entrypoint;

--- a/editions/example/src/processor.rs
+++ b/editions/example/src/processor.rs
@@ -175,7 +175,7 @@ pub fn process_update_original_authority(
 pub fn process_create_reprint(
     _program_id: &Pubkey,
     accounts: &[AccountInfo],
-    _data: CreateReprint,
+    data: CreateReprint,
 ) -> ProgramResult {
     // Assumes the `Original` print has already been created,
     // as well as the mint and metadata for the original print.
@@ -264,6 +264,10 @@ pub fn process_create_reprint(
     };
 
     check_update_authority(update_authority_info, &original_print.update_authority)?;
+
+    if data.original != *original_info.key {
+        return Err(TokenEditionsError::IncorrectOriginal.into());
+    }
 
     // Update the current supply
     let copy = original_print.supply + 1;

--- a/editions/example/src/processor.rs
+++ b/editions/example/src/processor.rs
@@ -201,8 +201,7 @@ pub fn process_create_reprint(
     let original_metadata_info = next_account_info(account_info_iter)?;
     let original_mint_info = next_account_info(account_info_iter)?;
     let mint_authority_info = next_account_info(account_info_iter)?;
-    // Only needed for CPI
-    let _metadata_program_info = next_account_info(account_info_iter)?;
+    let metadata_program_info = next_account_info(account_info_iter)?;
     // No additional accounts required in this example
 
     // Mint & metadata checks on the original
@@ -276,7 +275,7 @@ pub fn process_create_reprint(
 
     // Create the reprint metadata from the original metadata
     let cpi_instruction = initialize(
-        &spl_token_2022::id(),
+        metadata_program_info.key,
         reprint_mint_info.key,
         update_authority_info.key,
         reprint_mint_info.key,

--- a/editions/example/src/processor.rs
+++ b/editions/example/src/processor.rs
@@ -1,0 +1,246 @@
+//! Program state processor
+
+use {
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        borsh::get_instance_packed_len,
+        entrypoint::ProgramResult,
+        msg,
+        program::set_return_data,
+        program_error::ProgramError,
+        program_option::COption,
+        pubkey::Pubkey,
+    },
+    spl_token_2022::{extension::StateWithExtensions, state::Mint},
+    spl_token_editions_interface::{
+        error::TokenEditionsError,
+        instruction::{
+            CreateOriginal, CreateReprint, Emit, PrintType, TokenEditionsInstruction,
+            UpdateOriginalAuthority, UpdateOriginalMaxSupply,
+        },
+        state::{get_emit_slice, OptionalNonZeroPubkey, Original, Reprint},
+    },
+    spl_type_length_value::state::{
+        realloc_and_pack_variable_len, TlvState, TlvStateBorrowed, TlvStateMut,
+    },
+};
+
+fn check_update_authority(
+    update_authority_info: &AccountInfo,
+    expected_update_authority: &OptionalNonZeroPubkey,
+) -> Result<(), ProgramError> {
+    if !update_authority_info.is_signer {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+    let update_authority = Option::<Pubkey>::from(expected_update_authority.clone())
+        .ok_or(TokenEditionsError::ImmutablePrint)?;
+    if update_authority != *update_authority_info.key {
+        return Err(TokenEditionsError::IncorrectUpdateAuthority.into());
+    }
+    Ok(())
+}
+
+/// Processes a [CreateOriginal](enum.TokenEditionsInstruction.html)
+/// instruction.
+pub fn process_create_original(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    data: CreateOriginal,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    let original_info = next_account_info(account_info_iter)?;
+    let update_authority_info = next_account_info(account_info_iter)?;
+    let _metadata_info = next_account_info(account_info_iter)?;
+    let mint_info = next_account_info(account_info_iter)?;
+    let mint_authority_info = next_account_info(account_info_iter)?;
+
+    // scope the mint authority check, in case the mint is in the same account!
+    {
+        // IMPORTANT: this example program is designed to work with any
+        // program that implements the SPL token interface, so there is no
+        // ownership check on the mint account.
+        let mint_data = mint_info.try_borrow_data()?;
+        let mint = StateWithExtensions::<Mint>::unpack(&mint_data)?;
+
+        if !mint_authority_info.is_signer {
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+        if mint.base.mint_authority.as_ref() != COption::Some(mint_authority_info.key) {
+            return Err(TokenEditionsError::IncorrectMintAuthority.into());
+        }
+    }
+
+    /* Check metadata account exists and is not empty */
+
+    // get the required size, assumes that there's enough space for the entry
+    let update_authority = OptionalNonZeroPubkey::try_from(Some(*update_authority_info.key))?;
+    let original_print = Original::new(update_authority, data.max_supply);
+
+    let instance_size = get_instance_packed_len(&original_print)?;
+
+    // allocate a TLV entry for the space and write it in
+    let mut buffer = original_info.try_borrow_mut_data()?;
+    let mut state = TlvStateMut::unpack(&mut buffer)?;
+    state.alloc::<Original>(instance_size)?;
+    state.pack_variable_len_value(&original_print)?;
+
+    Ok(())
+}
+
+/// Processes an [UpdateOriginalMaxSupply](enum.TokenEditionsInstruction.html)
+/// instruction.
+pub fn process_update_original_max_supply(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    data: UpdateOriginalMaxSupply,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    let original_info = next_account_info(account_info_iter)?;
+    let update_authority_info = next_account_info(account_info_iter)?;
+
+    let mut original_print = {
+        let buffer = original_info.try_borrow_data()?;
+        let state = TlvStateBorrowed::unpack(&buffer)?;
+        state.get_variable_len_value::<Original>()?
+    };
+
+    check_update_authority(update_authority_info, &original_print.update_authority)?;
+
+    // Update the max supply
+    original_print.update_max_supply(data.max_supply)?;
+
+    // Update the account, no realloc needed!
+    realloc_and_pack_variable_len(original_info, &original_print)?;
+
+    Ok(())
+}
+
+/// Processes a [UpdateOriginalAuthority](enum.TokenEditionsInstruction.html)
+/// instruction.
+pub fn process_update_original_authority(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    data: UpdateOriginalAuthority,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    let original_info = next_account_info(account_info_iter)?;
+    let update_authority_info = next_account_info(account_info_iter)?;
+
+    let mut original_print = {
+        let buffer = original_info.try_borrow_data()?;
+        let state = TlvStateBorrowed::unpack(&buffer)?;
+        state.get_variable_len_value::<Original>()?
+    };
+
+    check_update_authority(update_authority_info, &original_print.update_authority)?;
+
+    // Update the authority
+    original_print.update_authority = data.new_authority;
+
+    // Update the account, no realloc needed!
+    realloc_and_pack_variable_len(original_info, &original_print)?;
+
+    Ok(())
+}
+
+/// Processes a [CreateReprint](enum.TokenEditionsInstruction.html) instruction.
+pub fn process_create_reprint(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    _data: CreateReprint,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    let reprint_info = next_account_info(account_info_iter)?;
+    let _reprint_metadata_info = next_account_info(account_info_iter)?;
+    let _reprint_mint_info = next_account_info(account_info_iter)?;
+    let original_info = next_account_info(account_info_iter)?;
+    let update_authority_info = next_account_info(account_info_iter)?;
+    let _original_metadata_info = next_account_info(account_info_iter)?;
+    let _original_mint_info = next_account_info(account_info_iter)?;
+    let _mint_authority_info = next_account_info(account_info_iter)?;
+
+    let mut original_print = {
+        let buffer = original_info.try_borrow_data()?;
+        let state = TlvStateBorrowed::unpack(&buffer)?;
+        state.get_variable_len_value::<Original>()?
+    };
+
+    check_update_authority(update_authority_info, &original_print.update_authority)?;
+
+    // Update the current supply
+    original_print.update_supply(original_print.supply + 1)?;
+
+    // Update the account, no realloc needed!
+    realloc_and_pack_variable_len(original_info, &original_print)?;
+
+    let reprint = Reprint {
+        original: *original_info.key,
+        copy: 1,
+    };
+
+    let instance_size = get_instance_packed_len(&reprint)?;
+
+    // allocate a TLV entry for the space and write it in
+    let mut buffer = reprint_info.try_borrow_mut_data()?;
+    let mut state = TlvStateMut::unpack(&mut buffer)?;
+    state.alloc::<Original>(instance_size)?;
+    state.pack_variable_len_value(&reprint)?;
+
+    Ok(())
+}
+
+/// Processes an [Emit](enum.TokenEditionsInstruction.html) instruction.
+pub fn process_emit(program_id: &Pubkey, accounts: &[AccountInfo], data: Emit) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    let print_info = next_account_info(account_info_iter)?;
+
+    if print_info.owner != program_id {
+        return Err(ProgramError::IllegalOwner);
+    }
+
+    let buffer = print_info.try_borrow_data()?;
+    let state = TlvStateBorrowed::unpack(&buffer)?;
+    let print_bytes = match data.print_type {
+        PrintType::Original => state.get_bytes::<Original>()?,
+        PrintType::Reprint => state.get_bytes::<Reprint>()?,
+    };
+
+    if let Some(range) = get_emit_slice(print_bytes, data.start, data.end) {
+        set_return_data(range);
+    }
+
+    Ok(())
+}
+
+/// Processes an [Instruction](enum.Instruction.html).
+pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> ProgramResult {
+    let instruction = TokenEditionsInstruction::unpack(input)?;
+
+    match instruction {
+        TokenEditionsInstruction::CreateOriginal(data) => {
+            msg!("Instruction: CreateOriginal");
+            process_create_original(program_id, accounts, data)
+        }
+        TokenEditionsInstruction::UpdateOriginalMaxSupply(data) => {
+            msg!("Instruction: UpdateOriginalMaxSupply");
+            process_update_original_max_supply(program_id, accounts, data)
+        }
+        TokenEditionsInstruction::UpdateOriginalAuthority(data) => {
+            msg!("Instruction: UpdateOriginalAuthority");
+            process_update_original_authority(program_id, accounts, data)
+        }
+        TokenEditionsInstruction::CreateReprint(data) => {
+            msg!("Instruction: CreateReprint");
+            process_create_reprint(program_id, accounts, data)
+        }
+        TokenEditionsInstruction::Emit(data) => {
+            msg!("Instruction: Emit");
+            process_emit(program_id, accounts, data)
+        }
+    }
+}

--- a/editions/example/tests/create_original.rs
+++ b/editions/example/tests/create_original.rs
@@ -4,10 +4,22 @@ mod program_test;
 use {
     program_test::{setup, setup_metadata, setup_mint, setup_original_print},
     solana_program_test::tokio,
-    solana_sdk::{pubkey::Pubkey, signature::Signer, signer::keypair::Keypair},
-    spl_token_editions_interface::state::Original,
+    solana_sdk::{
+        instruction::InstructionError,
+        pubkey::Pubkey,
+        signature::Signer,
+        signer::keypair::Keypair,
+        system_instruction,
+        transaction::{Transaction, TransactionError},
+    },
+    spl_token_editions_interface::{
+        error::TokenEditionsError, instruction::create_original, state::Original,
+    },
     spl_token_metadata_interface::state::TokenMetadata,
-    spl_type_length_value::state::{TlvState, TlvStateBorrowed},
+    spl_type_length_value::{
+        error::TlvError,
+        state::{TlvState, TlvStateBorrowed},
+    },
 };
 
 #[tokio::test]
@@ -91,4 +103,238 @@ async fn success_create_original() {
         .get_variable_len_value::<Original>()
         .unwrap();
     assert_eq!(fetched_original_print, original_print);
+
+    // Fail doing it again, and change some params to ensure a new tx
+    {
+        let transaction = Transaction::new_signed_with_payer(
+            &[create_original(
+                &program_id,
+                &original_keypair.pubkey(),
+                &metadata_pubkey,
+                token.get_address(),
+                &mint_authority.pubkey(),
+                None, // Intentionally changed params
+                Some(500),
+            )],
+            Some(&payer.pubkey()),
+            &[&payer, &mint_authority],
+            context.last_blockhash,
+        );
+        let error = context
+            .banks_client
+            .process_transaction(transaction)
+            .await
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(
+            error,
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TlvError::TypeAlreadyExists as u32)
+            )
+        );
+    }
+}
+
+#[tokio::test]
+async fn fail_without_authority_signature() {
+    let program_id = Pubkey::new_unique();
+    let (context, client, payer) = setup(&program_id).await;
+
+    let mint_authority = Keypair::new();
+    let mint_authority_pubkey = mint_authority.pubkey();
+
+    let token_program_id = spl_token_2022::id();
+    let decimals = 0;
+
+    let update_authority = Pubkey::new_unique();
+
+    let metadata_keypair = Keypair::new();
+    let metadata_pubkey = metadata_keypair.pubkey();
+
+    let token = setup_mint(
+        &token_program_id,
+        &mint_authority_pubkey,
+        &metadata_pubkey,
+        &update_authority,
+        decimals,
+        payer.clone(),
+        client.clone(),
+    )
+    .await;
+
+    let name = "My Cool Original Print".to_string();
+    let symbol = "COOL".to_string();
+    let uri = "cool.original.print".to_string();
+    let token_metadata = TokenMetadata {
+        name,
+        symbol,
+        uri,
+        update_authority: Some(update_authority).try_into().unwrap(),
+        mint: *token.get_address(),
+        ..Default::default()
+    };
+
+    setup_metadata(
+        &token,
+        &update_authority,
+        &token_metadata,
+        &metadata_keypair,
+        &mint_authority,
+        payer.clone(),
+    )
+    .await;
+    let mut context = context.lock().await;
+
+    let original_keypair = Keypair::new();
+    let original_pubkey = original_keypair.pubkey();
+
+    let original_print = Original {
+        update_authority: Some(update_authority).try_into().unwrap(),
+        max_supply: Some(100),
+        supply: 0,
+    };
+
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let space = original_print.tlv_size_of().unwrap();
+    let rent_lamports = rent.minimum_balance(space);
+    let mut create_original_ix = create_original(
+        &program_id,
+        &original_keypair.pubkey(),
+        &metadata_pubkey,
+        token.get_address(),
+        &mint_authority.pubkey(),
+        Option::<Pubkey>::from(original_print.update_authority.clone()),
+        original_print.max_supply,
+    );
+    create_original_ix.accounts[3].is_signer = false;
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &original_pubkey,
+                rent_lamports,
+                space.try_into().unwrap(),
+                &program_id,
+            ),
+            create_original_ix,
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &original_keypair], // Missing mint authority
+        context.last_blockhash,
+    );
+
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(1, InstructionError::MissingRequiredSignature,)
+    );
+}
+
+#[tokio::test]
+async fn fail_incorrect_authority() {
+    let program_id = Pubkey::new_unique();
+    let (context, client, payer) = setup(&program_id).await;
+
+    let mint_authority = Keypair::new();
+    let mint_authority_pubkey = mint_authority.pubkey();
+
+    let token_program_id = spl_token_2022::id();
+    let decimals = 0;
+
+    let update_authority = Pubkey::new_unique();
+
+    let metadata_keypair = Keypair::new();
+    let metadata_pubkey = metadata_keypair.pubkey();
+
+    let token = setup_mint(
+        &token_program_id,
+        &mint_authority_pubkey,
+        &metadata_pubkey,
+        &update_authority,
+        decimals,
+        payer.clone(),
+        client.clone(),
+    )
+    .await;
+
+    let name = "My Cool Original Print".to_string();
+    let symbol = "COOL".to_string();
+    let uri = "cool.original.print".to_string();
+    let token_metadata = TokenMetadata {
+        name,
+        symbol,
+        uri,
+        update_authority: Some(update_authority).try_into().unwrap(),
+        mint: *token.get_address(),
+        ..Default::default()
+    };
+
+    setup_metadata(
+        &token,
+        &update_authority,
+        &token_metadata,
+        &metadata_keypair,
+        &mint_authority,
+        payer.clone(),
+    )
+    .await;
+    let mut context = context.lock().await;
+
+    let original_keypair = Keypair::new();
+    let original_pubkey = original_keypair.pubkey();
+
+    let original_print = Original {
+        update_authority: Some(update_authority).try_into().unwrap(),
+        max_supply: Some(100),
+        supply: 0,
+    };
+
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let space = original_print.tlv_size_of().unwrap();
+    let rent_lamports = rent.minimum_balance(space);
+    let mut create_original_ix = create_original(
+        &program_id,
+        &original_keypair.pubkey(),
+        &metadata_pubkey,
+        token.get_address(),
+        &original_keypair.pubkey(), // NOT the mint authority
+        Option::<Pubkey>::from(original_print.update_authority.clone()),
+        original_print.max_supply,
+    );
+    create_original_ix.accounts[3].is_signer = false;
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &original_pubkey,
+                rent_lamports,
+                space.try_into().unwrap(),
+                &program_id,
+            ),
+            create_original_ix,
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &original_keypair],
+        context.last_blockhash,
+    );
+
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(
+            1,
+            InstructionError::Custom(TokenEditionsError::IncorrectMintAuthority as u32)
+        )
+    );
 }

--- a/editions/example/tests/create_original.rs
+++ b/editions/example/tests/create_original.rs
@@ -1,0 +1,94 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+use {
+    program_test::{setup, setup_metadata, setup_mint, setup_original_print},
+    solana_program_test::tokio,
+    solana_sdk::{pubkey::Pubkey, signature::Signer, signer::keypair::Keypair},
+    spl_token_editions_interface::state::Original,
+    spl_token_metadata_interface::state::TokenMetadata,
+    spl_type_length_value::state::{TlvState, TlvStateBorrowed},
+};
+
+#[tokio::test]
+async fn success_create_original() {
+    let program_id = Pubkey::new_unique();
+    let (context, client, payer) = setup(&program_id).await;
+
+    let mint_authority = Keypair::new();
+    let mint_authority_pubkey = mint_authority.pubkey();
+
+    let token_program_id = spl_token_2022::id();
+    let decimals = 0;
+
+    let update_authority = Pubkey::new_unique();
+
+    let metadata_keypair = Keypair::new();
+    let metadata_pubkey = metadata_keypair.pubkey();
+
+    let token = setup_mint(
+        &token_program_id,
+        &mint_authority_pubkey,
+        &metadata_pubkey,
+        &update_authority,
+        decimals,
+        payer.clone(),
+        client.clone(),
+    )
+    .await;
+
+    let name = "My Cool Original Print".to_string();
+    let symbol = "COOL".to_string();
+    let uri = "cool.original.print".to_string();
+    let token_metadata = TokenMetadata {
+        name,
+        symbol,
+        uri,
+        update_authority: Some(update_authority).try_into().unwrap(),
+        mint: *token.get_address(),
+        ..Default::default()
+    };
+
+    setup_metadata(
+        &token,
+        &update_authority,
+        &token_metadata,
+        &metadata_keypair,
+        &mint_authority,
+        payer.clone(),
+    )
+    .await;
+    let mut context = context.lock().await;
+
+    let original_keypair = Keypair::new();
+    let original_pubkey = original_keypair.pubkey();
+
+    let original_print = Original {
+        update_authority: Some(update_authority).try_into().unwrap(),
+        max_supply: Some(100),
+        supply: 0,
+    };
+
+    setup_original_print(
+        &mut context,
+        &program_id,
+        &metadata_pubkey,
+        token.get_address(),
+        &original_print,
+        &original_keypair,
+        &mint_authority,
+    )
+    .await;
+
+    let fetched_original_account = context
+        .banks_client
+        .get_account(original_pubkey)
+        .await
+        .unwrap()
+        .unwrap();
+    let fetched_original_state = TlvStateBorrowed::unpack(&fetched_original_account.data).unwrap();
+    let fetched_original_print = fetched_original_state
+        .get_variable_len_value::<Original>()
+        .unwrap();
+    assert_eq!(fetched_original_print, original_print);
+}

--- a/editions/example/tests/create_reprint.rs
+++ b/editions/example/tests/create_reprint.rs
@@ -4,8 +4,20 @@ mod program_test;
 use {
     program_test::{setup, setup_metadata, setup_mint, setup_original_print, setup_reprint},
     solana_program_test::tokio,
-    solana_sdk::{pubkey::Pubkey, signature::Signer, signer::keypair::Keypair},
-    spl_token_editions_interface::state::{Original, Reprint},
+    solana_sdk::{
+        instruction::InstructionError,
+        pubkey::Pubkey,
+        signature::Signer,
+        signer::keypair::Keypair,
+        system_instruction,
+        transaction::{Transaction, TransactionError},
+    },
+    spl_token_2022::error::TokenError,
+    spl_token_editions_interface::{
+        error::TokenEditionsError,
+        instruction::create_reprint,
+        state::{Original, Reprint},
+    },
     spl_token_metadata_interface::state::TokenMetadata,
     spl_type_length_value::state::{TlvState, TlvStateBorrowed},
 };
@@ -19,6 +31,7 @@ async fn success_create_reprint() {
     let mint_authority_pubkey = mint_authority.pubkey();
 
     let token_program_id = spl_token_2022::id();
+    let metadata_program_id = spl_token_2022::id();
     let decimals = 0;
 
     let update_authority_keypair = Keypair::new();
@@ -73,11 +86,160 @@ async fn success_create_reprint() {
         payer.clone(),
     )
     .await;
+    let mut context = context.lock().await;
+
+    let original_keypair = Keypair::new();
+    let original_pubkey = original_keypair.pubkey();
+
+    let original_print = Original {
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        max_supply: Some(100),
+        supply: 0,
+    };
+
+    setup_original_print(
+        &mut context,
+        &program_id,
+        &original_metadata_pubkey,
+        original_token.get_address(),
+        &original_print,
+        &original_keypair,
+        &mint_authority,
+    )
+    .await;
+
+    let reprint_keypair = Keypair::new();
+    let reprint_pubkey = reprint_keypair.pubkey();
+
+    let reprint = Reprint {
+        original: original_pubkey,
+        copy: 1,
+    };
+
+    setup_reprint(
+        &mut context,
+        &program_id,
+        &reprint_metadata_pubkey,
+        reprint_token.get_address(),
+        &original_pubkey,
+        &original_metadata_pubkey,
+        original_token.get_address(),
+        &metadata_program_id,
+        &reprint,
+        &token_metadata,
+        &reprint_keypair,
+        &update_authority_keypair,
+        &mint_authority,
+    )
+    .await;
+
+    let fetched_reprint_account = context
+        .banks_client
+        .get_account(reprint_pubkey)
+        .await
+        .unwrap()
+        .unwrap();
+    let fetched_reprint_state = TlvStateBorrowed::unpack(&fetched_reprint_account.data).unwrap();
+    let fetched_reprint = fetched_reprint_state
+        .get_variable_len_value::<Reprint>()
+        .unwrap();
+    assert_eq!(fetched_reprint, reprint);
+
+    // Fail trying to create a copy in the same account as the original
+    {
+        let transaction = Transaction::new_signed_with_payer(
+            &[create_reprint(
+                &program_id,
+                &original_keypair.pubkey(),   // Reprint
+                &original_metadata_pubkey,    // Reprint
+                original_token.get_address(), // Reprint
+                &original_keypair.pubkey(),
+                &update_authority_pubkey,
+                &original_metadata_pubkey,
+                original_token.get_address(),
+                &mint_authority.pubkey(),
+                &metadata_program_id,
+            )],
+            Some(&payer.pubkey()),
+            &[&payer, &update_authority_keypair, &mint_authority],
+            context.last_blockhash,
+        );
+        let error = context
+            .banks_client
+            .process_transaction(transaction)
+            .await
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(
+            error,
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::ExtensionAlreadyInitialized as u32)
+            )
+        );
+    }
+}
+
+#[tokio::test]
+async fn fail_without_authority_signature() {
+    let program_id = Pubkey::new_unique();
+    let (context, client, payer) = setup(&program_id).await;
+
+    let mint_authority = Keypair::new();
+    let mint_authority_pubkey = mint_authority.pubkey();
+
+    let token_program_id = spl_token_2022::id();
+    let metadata_program_id = spl_token_2022::id();
+    let decimals = 0;
+
+    let update_authority_keypair = Keypair::new();
+    let update_authority_pubkey = update_authority_keypair.pubkey();
+
+    let original_metadata_keypair = Keypair::new();
+    let original_metadata_pubkey = original_metadata_keypair.pubkey();
+
+    let original_token = setup_mint(
+        &token_program_id,
+        &mint_authority_pubkey,
+        &original_metadata_pubkey,
+        &update_authority_pubkey,
+        decimals,
+        payer.clone(),
+        client.clone(),
+    )
+    .await;
+
+    let reprint_metadata_keypair = Keypair::new();
+    let reprint_metadata_pubkey = reprint_metadata_keypair.pubkey();
+
+    let reprint_token = setup_mint(
+        &token_program_id,
+        &mint_authority_pubkey,
+        &reprint_metadata_pubkey,
+        &update_authority_pubkey,
+        decimals,
+        payer.clone(),
+        client.clone(),
+    )
+    .await;
+
+    let name = "My Cool Original Print".to_string();
+    let symbol = "COOL".to_string();
+    let uri = "cool.original.print".to_string();
+    let token_metadata = TokenMetadata {
+        name,
+        symbol,
+        uri,
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        mint: *original_token.get_address(),
+        ..Default::default()
+    };
+
     setup_metadata(
-        &reprint_token,
+        &original_token,
         &update_authority_pubkey,
         &token_metadata,
-        &reprint_metadata_keypair,
+        &original_metadata_keypair,
         &mint_authority,
         payer.clone(),
     )
@@ -104,41 +266,324 @@ async fn success_create_reprint() {
     )
     .await;
 
-    let reprint_metadata_keypair = Keypair::new();
-    let reprint_metadata_pubkey = reprint_metadata_keypair.pubkey();
-
     let reprint_keypair = Keypair::new();
-    let reprint_pubkey = reprint_keypair.pubkey();
+    let _reprint_pubkey = reprint_keypair.pubkey();
 
-    let reprint = Reprint {
+    let reprint_data = Reprint {
         original: original_pubkey,
         copy: 1,
     };
 
-    setup_reprint(
-        &mut context,
+    let rent = context.banks_client.get_rent().await.unwrap();
+
+    let token_metadata_space = token_metadata.tlv_size_of().unwrap();
+    let token_metadata_rent_lamports = rent.minimum_balance(token_metadata_space);
+
+    let reprint_space = reprint_data.tlv_size_of().unwrap();
+    let reprint_rent_lamports = rent.minimum_balance(reprint_space);
+
+    // Fail missing update authority
+
+    let mut create_reprint_ix = create_reprint(
         &program_id,
+        &reprint_keypair.pubkey(),
         &reprint_metadata_pubkey,
         reprint_token.get_address(),
         &original_pubkey,
+        &update_authority_pubkey,
         &original_metadata_pubkey,
         original_token.get_address(),
-        &reprint,
-        &reprint_keypair,
-        &update_authority_keypair,
+        &mint_authority.pubkey(),
+        &metadata_program_id,
+    );
+    create_reprint_ix.accounts[4].is_signer = false;
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &reprint_keypair.pubkey(),
+                reprint_rent_lamports,
+                reprint_space.try_into().unwrap(),
+                &program_id,
+            ),
+            // Fund the mint with extra rent for metadata
+            system_instruction::transfer(
+                &context.payer.pubkey(),
+                reprint_token.get_address(),
+                token_metadata_rent_lamports,
+            ),
+            create_reprint_ix,
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &reprint_keypair, &mint_authority], // Missing update authority
+        context.last_blockhash,
+    );
+
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(2, InstructionError::MissingRequiredSignature,)
+    );
+
+    // Fail missing mint authority
+
+    let mut create_reprint_ix = create_reprint(
+        &program_id,
+        &reprint_keypair.pubkey(),
+        &reprint_metadata_pubkey,
+        reprint_token.get_address(),
+        &original_pubkey,
+        &update_authority_pubkey,
+        &original_metadata_pubkey,
+        original_token.get_address(),
+        &mint_authority.pubkey(),
+        &metadata_program_id,
+    );
+    create_reprint_ix.accounts[7].is_signer = false;
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &reprint_keypair.pubkey(),
+                reprint_rent_lamports,
+                reprint_space.try_into().unwrap(),
+                &program_id,
+            ),
+            // Fund the mint with extra rent for metadata
+            system_instruction::transfer(
+                &context.payer.pubkey(),
+                reprint_token.get_address(),
+                token_metadata_rent_lamports,
+            ),
+            create_reprint_ix,
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &reprint_keypair, &update_authority_keypair], // Missing mint authority
+        context.last_blockhash,
+    );
+
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(2, InstructionError::MissingRequiredSignature,)
+    );
+}
+
+#[tokio::test]
+async fn fail_incorrect_authority() {
+    let program_id = Pubkey::new_unique();
+    let (context, client, payer) = setup(&program_id).await;
+
+    let mint_authority = Keypair::new();
+    let mint_authority_pubkey = mint_authority.pubkey();
+
+    let token_program_id = spl_token_2022::id();
+    let metadata_program_id = spl_token_2022::id();
+    let decimals = 0;
+
+    let update_authority_keypair = Keypair::new();
+    let update_authority_pubkey = update_authority_keypair.pubkey();
+
+    let original_metadata_keypair = Keypair::new();
+    let original_metadata_pubkey = original_metadata_keypair.pubkey();
+
+    let original_token = setup_mint(
+        &token_program_id,
+        &mint_authority_pubkey,
+        &original_metadata_pubkey,
+        &update_authority_pubkey,
+        decimals,
+        payer.clone(),
+        client.clone(),
+    )
+    .await;
+
+    let reprint_metadata_keypair = Keypair::new();
+    let reprint_metadata_pubkey = reprint_metadata_keypair.pubkey();
+
+    let reprint_token = setup_mint(
+        &token_program_id,
+        &mint_authority_pubkey,
+        &reprint_metadata_pubkey,
+        &update_authority_pubkey,
+        decimals,
+        payer.clone(),
+        client.clone(),
+    )
+    .await;
+
+    let name = "My Cool Original Print".to_string();
+    let symbol = "COOL".to_string();
+    let uri = "cool.original.print".to_string();
+    let token_metadata = TokenMetadata {
+        name,
+        symbol,
+        uri,
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        mint: *original_token.get_address(),
+        ..Default::default()
+    };
+
+    setup_metadata(
+        &original_token,
+        &update_authority_pubkey,
+        &token_metadata,
+        &original_metadata_keypair,
+        &mint_authority,
+        payer.clone(),
+    )
+    .await;
+    let mut context = context.lock().await;
+
+    let original_keypair = Keypair::new();
+    let original_pubkey = original_keypair.pubkey();
+
+    let original_print = Original {
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        max_supply: Some(100),
+        supply: 0,
+    };
+
+    setup_original_print(
+        &mut context,
+        &program_id,
+        &original_metadata_pubkey,
+        original_token.get_address(),
+        &original_print,
+        &original_keypair,
         &mint_authority,
     )
     .await;
 
-    let fetched_reprint_account = context
+    let reprint_keypair = Keypair::new();
+    let reprint_pubkey = reprint_keypair.pubkey();
+
+    let reprint_data = Reprint {
+        original: original_pubkey,
+        copy: 1,
+    };
+
+    let rent = context.banks_client.get_rent().await.unwrap();
+
+    let token_metadata_space = token_metadata.tlv_size_of().unwrap();
+    let token_metadata_rent_lamports = rent.minimum_balance(token_metadata_space);
+
+    let reprint_space = reprint_data.tlv_size_of().unwrap();
+    let reprint_rent_lamports = rent.minimum_balance(reprint_space);
+
+    // Fail incorrect update authority
+
+    let mut create_reprint_ix = create_reprint(
+        &program_id,
+        &reprint_keypair.pubkey(),
+        &reprint_metadata_pubkey,
+        reprint_token.get_address(),
+        &original_pubkey,
+        &reprint_pubkey, // NOT the update authority
+        &original_metadata_pubkey,
+        original_token.get_address(),
+        &mint_authority.pubkey(),
+        &metadata_program_id,
+    );
+    create_reprint_ix.accounts[4].is_signer = false;
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &reprint_keypair.pubkey(),
+                reprint_rent_lamports,
+                reprint_space.try_into().unwrap(),
+                &program_id,
+            ),
+            // Fund the mint with extra rent for metadata
+            system_instruction::transfer(
+                &context.payer.pubkey(),
+                reprint_token.get_address(),
+                token_metadata_rent_lamports,
+            ),
+            create_reprint_ix,
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &reprint_keypair, &mint_authority],
+        context.last_blockhash,
+    );
+
+    let error = context
         .banks_client
-        .get_account(reprint_pubkey)
+        .process_transaction(transaction)
         .await
-        .unwrap()
+        .unwrap_err()
         .unwrap();
-    let fetched_reprint_state = TlvStateBorrowed::unpack(&fetched_reprint_account.data).unwrap();
-    let fetched_reprint = fetched_reprint_state
-        .get_variable_len_value::<Reprint>()
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(
+            2,
+            InstructionError::Custom(TokenEditionsError::IncorrectUpdateAuthority as u32)
+        )
+    );
+
+    // Fail missing mint authority
+
+    let mut create_reprint_ix = create_reprint(
+        &program_id,
+        &reprint_keypair.pubkey(),
+        &reprint_metadata_pubkey,
+        reprint_token.get_address(),
+        &original_pubkey,
+        &update_authority_pubkey,
+        &original_metadata_pubkey,
+        original_token.get_address(),
+        &reprint_pubkey, // NOT the mint authority
+        &metadata_program_id,
+    );
+    create_reprint_ix.accounts[7].is_signer = false;
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &reprint_keypair.pubkey(),
+                reprint_rent_lamports,
+                reprint_space.try_into().unwrap(),
+                &program_id,
+            ),
+            // Fund the mint with extra rent for metadata
+            system_instruction::transfer(
+                &context.payer.pubkey(),
+                reprint_token.get_address(),
+                token_metadata_rent_lamports,
+            ),
+            create_reprint_ix,
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &reprint_keypair, &update_authority_keypair],
+        context.last_blockhash,
+    );
+
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
         .unwrap();
-    assert_eq!(fetched_reprint, reprint);
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(
+            2,
+            InstructionError::Custom(TokenEditionsError::IncorrectMintAuthority as u32)
+        )
+    );
 }

--- a/editions/example/tests/create_reprint.rs
+++ b/editions/example/tests/create_reprint.rs
@@ -1,0 +1,144 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+use {
+    program_test::{setup, setup_metadata, setup_mint, setup_original_print, setup_reprint},
+    solana_program_test::tokio,
+    solana_sdk::{pubkey::Pubkey, signature::Signer, signer::keypair::Keypair},
+    spl_token_editions_interface::state::{Original, Reprint},
+    spl_token_metadata_interface::state::TokenMetadata,
+    spl_type_length_value::state::{TlvState, TlvStateBorrowed},
+};
+
+#[tokio::test]
+async fn success_create_reprint() {
+    let program_id = Pubkey::new_unique();
+    let (context, client, payer) = setup(&program_id).await;
+
+    let mint_authority = Keypair::new();
+    let mint_authority_pubkey = mint_authority.pubkey();
+
+    let token_program_id = spl_token_2022::id();
+    let decimals = 0;
+
+    let update_authority_keypair = Keypair::new();
+    let update_authority_pubkey = update_authority_keypair.pubkey();
+
+    let original_metadata_keypair = Keypair::new();
+    let original_metadata_pubkey = original_metadata_keypair.pubkey();
+
+    let original_token = setup_mint(
+        &token_program_id,
+        &mint_authority_pubkey,
+        &original_metadata_pubkey,
+        &update_authority_pubkey,
+        decimals,
+        payer.clone(),
+        client.clone(),
+    )
+    .await;
+
+    let reprint_metadata_keypair = Keypair::new();
+    let reprint_metadata_pubkey = reprint_metadata_keypair.pubkey();
+
+    let reprint_token = setup_mint(
+        &token_program_id,
+        &mint_authority_pubkey,
+        &reprint_metadata_pubkey,
+        &update_authority_pubkey,
+        decimals,
+        payer.clone(),
+        client.clone(),
+    )
+    .await;
+
+    let name = "My Cool Original Print".to_string();
+    let symbol = "COOL".to_string();
+    let uri = "cool.original.print".to_string();
+    let token_metadata = TokenMetadata {
+        name,
+        symbol,
+        uri,
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        mint: *original_token.get_address(),
+        ..Default::default()
+    };
+
+    setup_metadata(
+        &original_token,
+        &update_authority_pubkey,
+        &token_metadata,
+        &original_metadata_keypair,
+        &mint_authority,
+        payer.clone(),
+    )
+    .await;
+    setup_metadata(
+        &reprint_token,
+        &update_authority_pubkey,
+        &token_metadata,
+        &reprint_metadata_keypair,
+        &mint_authority,
+        payer.clone(),
+    )
+    .await;
+    let mut context = context.lock().await;
+
+    let original_keypair = Keypair::new();
+    let original_pubkey = original_keypair.pubkey();
+
+    let original_print = Original {
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        max_supply: Some(100),
+        supply: 0,
+    };
+
+    setup_original_print(
+        &mut context,
+        &program_id,
+        &original_metadata_pubkey,
+        original_token.get_address(),
+        &original_print,
+        &original_keypair,
+        &mint_authority,
+    )
+    .await;
+
+    let reprint_metadata_keypair = Keypair::new();
+    let reprint_metadata_pubkey = reprint_metadata_keypair.pubkey();
+
+    let reprint_keypair = Keypair::new();
+    let reprint_pubkey = reprint_keypair.pubkey();
+
+    let reprint = Reprint {
+        original: original_pubkey,
+        copy: 1,
+    };
+
+    setup_reprint(
+        &mut context,
+        &program_id,
+        &reprint_metadata_pubkey,
+        reprint_token.get_address(),
+        &original_pubkey,
+        &original_metadata_pubkey,
+        original_token.get_address(),
+        &reprint,
+        &reprint_keypair,
+        &update_authority_keypair,
+        &mint_authority,
+    )
+    .await;
+
+    let fetched_reprint_account = context
+        .banks_client
+        .get_account(reprint_pubkey)
+        .await
+        .unwrap()
+        .unwrap();
+    let fetched_reprint_state = TlvStateBorrowed::unpack(&fetched_reprint_account.data).unwrap();
+    let fetched_reprint = fetched_reprint_state
+        .get_variable_len_value::<Reprint>()
+        .unwrap();
+    assert_eq!(fetched_reprint, reprint);
+}

--- a/editions/example/tests/emit.rs
+++ b/editions/example/tests/emit.rs
@@ -171,16 +171,16 @@ async fn success(start: Option<u64>, end: Option<u64>) {
         &mut context,
         &program_id,
         &reprint_metadata_pubkey,
+        &update_authority_pubkey,
         reprint_token.get_address(),
         &original_pubkey,
         &original_metadata_pubkey,
         original_token.get_address(),
         &metadata_program_id,
-        &reprint,
-        &token_metadata,
         &reprint_keypair,
-        &update_authority_keypair,
         &mint_authority,
+        &mint_authority,
+        &token_metadata,
     )
     .await;
 

--- a/editions/example/tests/emit.rs
+++ b/editions/example/tests/emit.rs
@@ -1,0 +1,216 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+use {
+    program_test::{setup, setup_metadata, setup_mint, setup_original_print, setup_reprint},
+    solana_program_test::{tokio, ProgramTestContext},
+    solana_sdk::{
+        borsh::try_from_slice_unchecked, program::MAX_RETURN_DATA, pubkey::Pubkey,
+        signature::Signer, signer::keypair::Keypair, transaction::Transaction,
+    },
+    spl_token_editions_interface::{
+        borsh::{BorshDeserialize, BorshSerialize},
+        instruction::{emit, PrintType},
+        state::{get_emit_slice, Original, Reprint},
+    },
+    spl_token_metadata_interface::state::TokenMetadata,
+    test_case::test_case,
+};
+
+#[allow(clippy::too_many_arguments)]
+async fn check_emit<V: BorshDeserialize + BorshSerialize + std::fmt::Debug + PartialEq>(
+    context: &mut ProgramTestContext,
+    print_type: PrintType,
+    print_buffer: Vec<u8>,
+    print_pubkey: &Pubkey,
+    start: Option<u64>,
+    end: Option<u64>,
+    program_id: &Pubkey,
+    payer: &Keypair,
+    check_print_data: V,
+) {
+    let transaction = Transaction::new_signed_with_payer(
+        &[emit(program_id, print_pubkey, print_type, start, end)],
+        Some(&payer.pubkey()),
+        &[payer],
+        context.last_blockhash,
+    );
+    let simulation = context
+        .banks_client
+        .simulate_transaction(transaction)
+        .await
+        .unwrap();
+
+    if let Some(check_buffer) = get_emit_slice(&print_buffer, start, end) {
+        if !check_buffer.is_empty() {
+            // pad the data if necessary
+            let mut return_data = vec![0; MAX_RETURN_DATA];
+            let simulation_return_data =
+                simulation.simulation_details.unwrap().return_data.unwrap();
+            assert_eq!(simulation_return_data.program_id, *program_id);
+            return_data[..simulation_return_data.data.len()]
+                .copy_from_slice(&simulation_return_data.data);
+
+            assert_eq!(*check_buffer, return_data[..check_buffer.len()]);
+            // we're sure that we're getting the full data, so also compare the deserialized
+            // type
+            if start.is_none() && end.is_none() {
+                let emitted_token_edition = try_from_slice_unchecked::<V>(&return_data).unwrap();
+                assert_eq!(check_print_data, emitted_token_edition);
+            }
+        } else {
+            assert!(simulation.simulation_details.unwrap().return_data.is_none());
+        }
+    } else {
+        assert!(simulation.simulation_details.unwrap().return_data.is_none());
+    }
+}
+
+#[test_case(Some(40), Some(40) ; "zero bytes")]
+#[test_case(Some(40), Some(41) ; "one byte")]
+#[test_case(Some(1_000_000), Some(1_000_001) ; "too far")]
+#[test_case(Some(50), Some(49) ; "wrong way")]
+#[test_case(Some(50), None ; "truncate start")]
+#[test_case(None, Some(50) ; "truncate end")]
+#[test_case(None, None ; "full data")]
+#[tokio::test]
+async fn success(start: Option<u64>, end: Option<u64>) {
+    let program_id = Pubkey::new_unique();
+    let (context, client, payer) = setup(&program_id).await;
+
+    let mint_authority = Keypair::new();
+    let mint_authority_pubkey = mint_authority.pubkey();
+
+    let token_program_id = spl_token_2022::id();
+    let metadata_program_id = spl_token_2022::id();
+    let decimals = 0;
+
+    let update_authority_keypair = Keypair::new();
+    let update_authority_pubkey = update_authority_keypair.pubkey();
+
+    let original_metadata_keypair = Keypair::new();
+    let original_metadata_pubkey = original_metadata_keypair.pubkey();
+
+    let original_token = setup_mint(
+        &token_program_id,
+        &mint_authority_pubkey,
+        &original_metadata_pubkey,
+        &update_authority_pubkey,
+        decimals,
+        payer.clone(),
+        client.clone(),
+    )
+    .await;
+
+    let reprint_metadata_keypair = Keypair::new();
+    let reprint_metadata_pubkey = reprint_metadata_keypair.pubkey();
+
+    let reprint_token = setup_mint(
+        &token_program_id,
+        &mint_authority_pubkey,
+        &reprint_metadata_pubkey,
+        &update_authority_pubkey,
+        decimals,
+        payer.clone(),
+        client.clone(),
+    )
+    .await;
+
+    let name = "My Cool Original Print".to_string();
+    let symbol = "COOL".to_string();
+    let uri = "cool.original.print".to_string();
+    let token_metadata = TokenMetadata {
+        name,
+        symbol,
+        uri,
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        mint: *original_token.get_address(),
+        ..Default::default()
+    };
+
+    setup_metadata(
+        &original_token,
+        &update_authority_pubkey,
+        &token_metadata,
+        &original_metadata_keypair,
+        &mint_authority,
+        payer.clone(),
+    )
+    .await;
+    let mut context = context.lock().await;
+
+    let original_keypair = Keypair::new();
+    let original_pubkey = original_keypair.pubkey();
+
+    let original_print = Original {
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        max_supply: Some(100),
+        supply: 1, // Supply will be 1 after printing a reprint
+    };
+
+    setup_original_print(
+        &mut context,
+        &program_id,
+        &original_metadata_pubkey,
+        original_token.get_address(),
+        &original_print,
+        &original_keypair,
+        &mint_authority,
+    )
+    .await;
+
+    let reprint_keypair = Keypair::new();
+    let reprint_pubkey = reprint_keypair.pubkey();
+
+    let reprint = Reprint {
+        original: original_pubkey,
+        copy: 1,
+    };
+
+    setup_reprint(
+        &mut context,
+        &program_id,
+        &reprint_metadata_pubkey,
+        reprint_token.get_address(),
+        &original_pubkey,
+        &original_metadata_pubkey,
+        original_token.get_address(),
+        &metadata_program_id,
+        &reprint,
+        &token_metadata,
+        &reprint_keypair,
+        &update_authority_keypair,
+        &mint_authority,
+    )
+    .await;
+
+    // Original
+    let original_buffer = original_print.try_to_vec().unwrap();
+    check_emit::<Original>(
+        &mut context,
+        PrintType::Original,
+        original_buffer,
+        &original_pubkey,
+        start,
+        end,
+        &program_id,
+        &payer,
+        original_print,
+    )
+    .await;
+
+    // Reprint
+    let reprint_buffer = reprint.try_to_vec().unwrap();
+    check_emit::<Reprint>(
+        &mut context,
+        PrintType::Reprint,
+        reprint_buffer,
+        &reprint_pubkey,
+        start,
+        end,
+        &program_id,
+        &payer,
+        reprint,
+    )
+    .await;
+}

--- a/editions/example/tests/program_test.rs
+++ b/editions/example/tests/program_test.rs
@@ -160,23 +160,23 @@ pub async fn setup_reprint(
     context: &mut ProgramTestContext,
     editions_program_id: &Pubkey,
     reprint_metadata: &Pubkey,
+    reprint_metadata_update_authority: &Pubkey,
     reprint_mint: &Pubkey,
     original_pubkey: &Pubkey,
     original_metadata: &Pubkey,
     original_mint: &Pubkey,
     metadata_program_id: &Pubkey,
-    reprint_data: &Reprint,
-    token_metadata: &TokenMetadata,
     reprint_keypair: &Keypair,
-    update_authority: &Keypair,
-    mint_authority: &Keypair,
+    reprint_mint_authority: &Keypair,
+    original_mint_authority: &Keypair,
+    token_metadata: &TokenMetadata,
 ) {
     let rent = context.banks_client.get_rent().await.unwrap();
 
     let token_metadata_space = token_metadata.tlv_size_of().unwrap();
     let token_metadata_rent_lamports = rent.minimum_balance(token_metadata_space);
 
-    let reprint_space = reprint_data.tlv_size_of().unwrap();
+    let reprint_space = Reprint::default().tlv_size_of().unwrap();
     let reprint_rent_lamports = rent.minimum_balance(reprint_space);
 
     let transaction = Transaction::new_signed_with_payer(
@@ -198,12 +198,13 @@ pub async fn setup_reprint(
                 editions_program_id,
                 &reprint_keypair.pubkey(),
                 reprint_metadata,
+                reprint_metadata_update_authority,
                 reprint_mint,
+                &reprint_mint_authority.pubkey(),
                 original_pubkey,
-                &update_authority.pubkey(),
                 original_metadata,
                 original_mint,
-                &mint_authority.pubkey(),
+                &original_mint_authority.pubkey(),
                 metadata_program_id,
             ),
         ],
@@ -211,8 +212,8 @@ pub async fn setup_reprint(
         &[
             &context.payer,
             reprint_keypair,
-            update_authority,
-            mint_authority,
+            reprint_mint_authority,
+            original_mint_authority,
         ],
         context.last_blockhash,
     );

--- a/editions/example/tests/program_test.rs
+++ b/editions/example/tests/program_test.rs
@@ -1,0 +1,211 @@
+#![cfg(feature = "test-sbf")]
+
+use {
+    solana_program_test::{processor, tokio::sync::Mutex, ProgramTest, ProgramTestContext},
+    solana_sdk::{
+        pubkey::Pubkey, signature::Signer, signer::keypair::Keypair, system_instruction,
+        transaction::Transaction,
+    },
+    spl_token_client::{
+        client::{
+            ProgramBanksClient, ProgramBanksClientProcessTransaction, ProgramClient,
+            SendTransaction,
+        },
+        token::{ExtensionInitializationParams, Token},
+    },
+    spl_token_editions_interface::{
+        instruction::{create_original, create_reprint},
+        state::{Original, Reprint},
+    },
+    spl_token_metadata_interface::state::TokenMetadata,
+    std::sync::Arc,
+};
+
+fn keypair_clone(kp: &Keypair) -> Keypair {
+    Keypair::from_bytes(&kp.to_bytes()).expect("failed to copy keypair")
+}
+
+pub async fn setup(
+    program_id: &Pubkey,
+) -> (
+    Arc<Mutex<ProgramTestContext>>,
+    Arc<dyn ProgramClient<ProgramBanksClientProcessTransaction>>,
+    Arc<Keypair>,
+) {
+    let mut program_test = ProgramTest::new(
+        "spl_token_editions_example",
+        *program_id,
+        processor!(spl_token_editions_example::processor::process),
+    );
+
+    program_test.prefer_bpf(false); // simplicity in the build
+    program_test.add_program(
+        "spl_token_2022",
+        spl_token_2022::id(),
+        processor!(spl_token_2022::processor::Processor::process),
+    );
+
+    let context = program_test.start_with_context().await;
+    let payer = Arc::new(keypair_clone(&context.payer));
+    let context = Arc::new(Mutex::new(context));
+
+    let client: Arc<dyn ProgramClient<ProgramBanksClientProcessTransaction>> =
+        Arc::new(ProgramBanksClient::new_from_context(
+            Arc::clone(&context),
+            ProgramBanksClientProcessTransaction,
+        ));
+    (context, client, payer)
+}
+
+pub async fn setup_mint<T: SendTransaction>(
+    program_id: &Pubkey,
+    mint_authority: &Pubkey,
+    metadata: &Pubkey,
+    update_authority: &Pubkey,
+    decimals: u8,
+    payer: Arc<Keypair>,
+    client: Arc<dyn ProgramClient<T>>,
+) -> Token<T> {
+    let mint_account = Keypair::new();
+    let token = Token::new(
+        client,
+        program_id,
+        &mint_account.pubkey(),
+        Some(decimals),
+        payer,
+    );
+    token
+        .create_mint(
+            mint_authority,
+            None,
+            vec![ExtensionInitializationParams::MetadataPointer {
+                authority: Some(*update_authority),
+                metadata_address: Some(*metadata),
+            }],
+            &[&mint_account],
+        )
+        .await
+        .unwrap();
+    token
+}
+
+pub async fn setup_metadata<T: SendTransaction>(
+    token: &Token<T>,
+    update_authority: &Pubkey,
+    token_metadata: &TokenMetadata,
+    _metadata_keypair: &Keypair,
+    mint_authority: &Keypair,
+    payer: Arc<Keypair>,
+) {
+    token
+        .token_metadata_initialize_with_rent_transfer(
+            &payer.pubkey(),
+            update_authority,
+            &mint_authority.pubkey(),
+            token_metadata.name.clone(),
+            token_metadata.symbol.clone(),
+            token_metadata.uri.clone(),
+            &[&payer, mint_authority],
+        )
+        .await
+        .unwrap();
+}
+
+pub async fn setup_original_print(
+    context: &mut ProgramTestContext,
+    editions_program_id: &Pubkey,
+    metadata: &Pubkey,
+    mint: &Pubkey,
+    original_data: &Original,
+    original_keypair: &Keypair,
+    mint_authority: &Keypair,
+) {
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let space = original_data.tlv_size_of().unwrap();
+    let rent_lamports = rent.minimum_balance(space);
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &original_keypair.pubkey(),
+                rent_lamports,
+                space.try_into().unwrap(),
+                editions_program_id,
+            ),
+            create_original(
+                editions_program_id,
+                &original_keypair.pubkey(),
+                Option::<Pubkey>::from(original_data.update_authority.clone()),
+                metadata,
+                mint,
+                &mint_authority.pubkey(),
+                original_data.max_supply,
+            ),
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, original_keypair, mint_authority],
+        context.last_blockhash,
+    );
+
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+}
+
+#[allow(clippy::too_many_arguments)]
+#[allow(dead_code)]
+pub async fn setup_reprint(
+    context: &mut ProgramTestContext,
+    editions_program_id: &Pubkey,
+    reprint_metadata: &Pubkey,
+    reprint_mint: &Pubkey,
+    original_pubkey: &Pubkey,
+    original_metadata: &Pubkey,
+    original_mint: &Pubkey,
+    reprint_data: &Reprint,
+    reprint_keypair: &Keypair,
+    update_authority: &Keypair,
+    mint_authority: &Keypair,
+) {
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let space = reprint_data.tlv_size_of().unwrap();
+    let rent_lamports = rent.minimum_balance(space);
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &reprint_keypair.pubkey(),
+                rent_lamports,
+                space.try_into().unwrap(),
+                editions_program_id,
+            ),
+            create_reprint(
+                editions_program_id,
+                &reprint_keypair.pubkey(),
+                reprint_metadata,
+                reprint_mint,
+                original_pubkey,
+                &update_authority.pubkey(),
+                original_metadata,
+                original_mint,
+                &mint_authority.pubkey(),
+            ),
+        ],
+        Some(&context.payer.pubkey()),
+        &[
+            &context.payer,
+            reprint_keypair,
+            update_authority,
+            mint_authority,
+        ],
+        context.last_blockhash,
+    );
+
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+}

--- a/editions/example/tests/update_original_authority.rs
+++ b/editions/example/tests/update_original_authority.rs
@@ -1,0 +1,158 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+use {
+    program_test::{setup, setup_metadata, setup_mint, setup_original_print},
+    solana_program_test::tokio,
+    solana_sdk::{
+        pubkey::Pubkey, signature::Signer, signer::keypair::Keypair, transaction::Transaction,
+    },
+    spl_token_editions_interface::{instruction::update_original_authority, state::Original},
+    spl_token_metadata_interface::state::TokenMetadata,
+    spl_type_length_value::state::{TlvState, TlvStateBorrowed},
+};
+
+#[tokio::test]
+async fn success_update_original_max_supply() {
+    let program_id = Pubkey::new_unique();
+    let (context, client, payer) = setup(&program_id).await;
+
+    let mint_authority = Keypair::new();
+    let mint_authority_pubkey = mint_authority.pubkey();
+
+    let token_program_id = spl_token_2022::id();
+    let decimals = 0;
+
+    let update_authority_keypair = Keypair::new();
+    let update_authority_pubkey = update_authority_keypair.pubkey();
+
+    let metadata_keypair = Keypair::new();
+    let metadata_pubkey = metadata_keypair.pubkey();
+
+    let token = setup_mint(
+        &token_program_id,
+        &mint_authority_pubkey,
+        &metadata_pubkey,
+        &update_authority_pubkey,
+        decimals,
+        payer.clone(),
+        client.clone(),
+    )
+    .await;
+
+    let name = "My Cool Original Print".to_string();
+    let symbol = "COOL".to_string();
+    let uri = "cool.original.print".to_string();
+    let token_metadata = TokenMetadata {
+        name,
+        symbol,
+        uri,
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        mint: *token.get_address(),
+        ..Default::default()
+    };
+
+    setup_metadata(
+        &token,
+        &update_authority_pubkey,
+        &token_metadata,
+        &metadata_keypair,
+        &mint_authority,
+        payer.clone(),
+    )
+    .await;
+    let mut context = context.lock().await;
+
+    let original_keypair = Keypair::new();
+    let original_pubkey = original_keypair.pubkey();
+
+    let original_print = Original {
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        max_supply: Some(100),
+        supply: 0,
+    };
+
+    setup_original_print(
+        &mut context,
+        &program_id,
+        &metadata_pubkey,
+        token.get_address(),
+        &original_print,
+        &original_keypair,
+        &mint_authority,
+    )
+    .await;
+
+    // Can change to new pubkey
+
+    let new_authority_keypair = Keypair::new();
+    let new_authority_pubkey = new_authority_keypair.pubkey();
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[update_original_authority(
+            &program_id,
+            &original_pubkey,
+            &update_authority_pubkey,
+            Some(new_authority_pubkey),
+        )],
+        Some(&payer.pubkey()),
+        &[&payer, &update_authority_keypair],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+
+    let fetched_original_account = context
+        .banks_client
+        .get_account(original_pubkey)
+        .await
+        .unwrap()
+        .unwrap();
+    let fetched_original_state = TlvStateBorrowed::unpack(&fetched_original_account.data).unwrap();
+    let fetched_original_print = fetched_original_state
+        .get_variable_len_value::<Original>()
+        .unwrap();
+    assert_eq!(
+        Option::<Pubkey>::from(fetched_original_print.update_authority),
+        Some(new_authority_pubkey),
+    );
+
+    // Can change to `None`
+
+    let second_new_authority = None;
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[update_original_authority(
+            &program_id,
+            &original_pubkey,
+            &new_authority_pubkey,
+            second_new_authority,
+        )],
+        Some(&payer.pubkey()),
+        &[&payer, &new_authority_keypair],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+
+    let fetched_original_account = context
+        .banks_client
+        .get_account(original_pubkey)
+        .await
+        .unwrap()
+        .unwrap();
+    let fetched_original_state = TlvStateBorrowed::unpack(&fetched_original_account.data).unwrap();
+    let fetched_original_print = fetched_original_state
+        .get_variable_len_value::<Original>()
+        .unwrap();
+    assert_eq!(
+        Option::<Pubkey>::from(fetched_original_print.update_authority),
+        second_new_authority
+    );
+}

--- a/editions/example/tests/update_original_authority.rs
+++ b/editions/example/tests/update_original_authority.rs
@@ -5,9 +5,15 @@ use {
     program_test::{setup, setup_metadata, setup_mint, setup_original_print},
     solana_program_test::tokio,
     solana_sdk::{
-        pubkey::Pubkey, signature::Signer, signer::keypair::Keypair, transaction::Transaction,
+        instruction::InstructionError,
+        pubkey::Pubkey,
+        signature::Signer,
+        signer::keypair::Keypair,
+        transaction::{Transaction, TransactionError},
     },
-    spl_token_editions_interface::{instruction::update_original_authority, state::Original},
+    spl_token_editions_interface::{
+        error::TokenEditionsError, instruction::update_original_authority, state::Original,
+    },
     spl_token_metadata_interface::state::TokenMetadata,
     spl_type_length_value::state::{TlvState, TlvStateBorrowed},
 };
@@ -154,5 +160,131 @@ async fn success_update_original_max_supply() {
     assert_eq!(
         Option::<Pubkey>::from(fetched_original_print.update_authority),
         second_new_authority
+    );
+}
+
+#[tokio::test]
+async fn fail_authority_checks() {
+    let program_id = Pubkey::new_unique();
+    let (context, client, payer) = setup(&program_id).await;
+
+    let mint_authority = Keypair::new();
+    let mint_authority_pubkey = mint_authority.pubkey();
+
+    let token_program_id = spl_token_2022::id();
+    let decimals = 0;
+
+    let update_authority_keypair = Keypair::new();
+    let update_authority_pubkey = update_authority_keypair.pubkey();
+
+    let metadata_keypair = Keypair::new();
+    let metadata_pubkey = metadata_keypair.pubkey();
+
+    let token = setup_mint(
+        &token_program_id,
+        &mint_authority_pubkey,
+        &metadata_pubkey,
+        &update_authority_pubkey,
+        decimals,
+        payer.clone(),
+        client.clone(),
+    )
+    .await;
+
+    let name = "My Cool Original Print".to_string();
+    let symbol = "COOL".to_string();
+    let uri = "cool.original.print".to_string();
+    let token_metadata = TokenMetadata {
+        name,
+        symbol,
+        uri,
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        mint: *token.get_address(),
+        ..Default::default()
+    };
+
+    setup_metadata(
+        &token,
+        &update_authority_pubkey,
+        &token_metadata,
+        &metadata_keypair,
+        &mint_authority,
+        payer.clone(),
+    )
+    .await;
+    let mut context = context.lock().await;
+
+    let original_keypair = Keypair::new();
+    let original_pubkey = original_keypair.pubkey();
+
+    let original_print = Original {
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        max_supply: Some(100),
+        supply: 0,
+    };
+
+    setup_original_print(
+        &mut context,
+        &program_id,
+        &metadata_pubkey,
+        token.get_address(),
+        &original_print,
+        &original_keypair,
+        &mint_authority,
+    )
+    .await;
+
+    let new_authority_keypair = Keypair::new();
+    let new_authority_pubkey = new_authority_keypair.pubkey();
+
+    // No signature
+    let mut update_authority_ix = update_original_authority(
+        &program_id,
+        &original_pubkey,
+        &update_authority_pubkey,
+        Some(new_authority_pubkey),
+    );
+    update_authority_ix.accounts[1].is_signer = false;
+    let transaction = Transaction::new_signed_with_payer(
+        &[update_authority_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature,)
+    );
+
+    // Wrong authority
+    let transaction = Transaction::new_signed_with_payer(
+        &[update_original_authority(
+            &program_id,
+            &original_pubkey,
+            &original_pubkey,
+            Some(new_authority_pubkey),
+        )],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &original_keypair],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(TokenEditionsError::IncorrectUpdateAuthority as u32),
+        )
     );
 }

--- a/editions/example/tests/update_original_max_supply.rs
+++ b/editions/example/tests/update_original_max_supply.rs
@@ -19,7 +19,7 @@ use {
 };
 
 #[tokio::test]
-async fn success_update_original_authority() {
+async fn success_update_original_max_supply() {
     let program_id = Pubkey::new_unique();
     let (context, client, payer) = setup(&program_id).await;
 

--- a/editions/example/tests/update_original_max_supply.rs
+++ b/editions/example/tests/update_original_max_supply.rs
@@ -1,0 +1,116 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+use {
+    program_test::{setup, setup_metadata, setup_mint, setup_original_print},
+    solana_program_test::tokio,
+    solana_sdk::{
+        pubkey::Pubkey, signature::Signer, signer::keypair::Keypair, transaction::Transaction,
+    },
+    spl_token_editions_interface::{instruction::update_original_max_supply, state::Original},
+    spl_token_metadata_interface::state::TokenMetadata,
+    spl_type_length_value::state::{TlvState, TlvStateBorrowed},
+};
+
+#[tokio::test]
+async fn success_update_original_authority() {
+    let program_id = Pubkey::new_unique();
+    let (context, client, payer) = setup(&program_id).await;
+
+    let mint_authority = Keypair::new();
+    let mint_authority_pubkey = mint_authority.pubkey();
+
+    let token_program_id = spl_token_2022::id();
+    let decimals = 0;
+
+    let update_authority_keypair = Keypair::new();
+    let update_authority_pubkey = update_authority_keypair.pubkey();
+
+    let metadata_keypair = Keypair::new();
+    let metadata_pubkey = metadata_keypair.pubkey();
+
+    let token = setup_mint(
+        &token_program_id,
+        &mint_authority_pubkey,
+        &metadata_pubkey,
+        &update_authority_pubkey,
+        decimals,
+        payer.clone(),
+        client.clone(),
+    )
+    .await;
+
+    let name = "My Cool Original Print".to_string();
+    let symbol = "COOL".to_string();
+    let uri = "cool.original.print".to_string();
+    let token_metadata = TokenMetadata {
+        name,
+        symbol,
+        uri,
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        mint: *token.get_address(),
+        ..Default::default()
+    };
+
+    setup_metadata(
+        &token,
+        &update_authority_pubkey,
+        &token_metadata,
+        &metadata_keypair,
+        &mint_authority,
+        payer.clone(),
+    )
+    .await;
+    let mut context = context.lock().await;
+
+    let original_keypair = Keypair::new();
+    let original_pubkey = original_keypair.pubkey();
+
+    let original_print = Original {
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        max_supply: Some(100),
+        supply: 0,
+    };
+
+    setup_original_print(
+        &mut context,
+        &program_id,
+        &metadata_pubkey,
+        token.get_address(),
+        &original_print,
+        &original_keypair,
+        &mint_authority,
+    )
+    .await;
+
+    let new_max_supply = Some(200);
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[update_original_max_supply(
+            &program_id,
+            &original_pubkey,
+            &update_authority_pubkey,
+            new_max_supply,
+        )],
+        Some(&payer.pubkey()),
+        &[&payer, &update_authority_keypair],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+
+    let fetched_original_account = context
+        .banks_client
+        .get_account(original_pubkey)
+        .await
+        .unwrap()
+        .unwrap();
+    let fetched_original_state = TlvStateBorrowed::unpack(&fetched_original_account.data).unwrap();
+    let fetched_original_print = fetched_original_state
+        .get_variable_len_value::<Original>()
+        .unwrap();
+    assert_eq!(fetched_original_print.max_supply, new_max_supply);
+}

--- a/editions/example/tests/update_original_max_supply.rs
+++ b/editions/example/tests/update_original_max_supply.rs
@@ -5,9 +5,15 @@ use {
     program_test::{setup, setup_metadata, setup_mint, setup_original_print},
     solana_program_test::tokio,
     solana_sdk::{
-        pubkey::Pubkey, signature::Signer, signer::keypair::Keypair, transaction::Transaction,
+        instruction::InstructionError,
+        pubkey::Pubkey,
+        signature::Signer,
+        signer::keypair::Keypair,
+        transaction::{Transaction, TransactionError},
     },
-    spl_token_editions_interface::{instruction::update_original_max_supply, state::Original},
+    spl_token_editions_interface::{
+        error::TokenEditionsError, instruction::update_original_max_supply, state::Original,
+    },
     spl_token_metadata_interface::state::TokenMetadata,
     spl_type_length_value::state::{TlvState, TlvStateBorrowed},
 };
@@ -113,4 +119,129 @@ async fn success_update_original_authority() {
         .get_variable_len_value::<Original>()
         .unwrap();
     assert_eq!(fetched_original_print.max_supply, new_max_supply);
+}
+
+#[tokio::test]
+async fn fail_authority_checks() {
+    let program_id = Pubkey::new_unique();
+    let (context, client, payer) = setup(&program_id).await;
+
+    let mint_authority = Keypair::new();
+    let mint_authority_pubkey = mint_authority.pubkey();
+
+    let token_program_id = spl_token_2022::id();
+    let decimals = 0;
+
+    let update_authority_keypair = Keypair::new();
+    let update_authority_pubkey = update_authority_keypair.pubkey();
+
+    let metadata_keypair = Keypair::new();
+    let metadata_pubkey = metadata_keypair.pubkey();
+
+    let token = setup_mint(
+        &token_program_id,
+        &mint_authority_pubkey,
+        &metadata_pubkey,
+        &update_authority_pubkey,
+        decimals,
+        payer.clone(),
+        client.clone(),
+    )
+    .await;
+
+    let name = "My Cool Original Print".to_string();
+    let symbol = "COOL".to_string();
+    let uri = "cool.original.print".to_string();
+    let token_metadata = TokenMetadata {
+        name,
+        symbol,
+        uri,
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        mint: *token.get_address(),
+        ..Default::default()
+    };
+
+    setup_metadata(
+        &token,
+        &update_authority_pubkey,
+        &token_metadata,
+        &metadata_keypair,
+        &mint_authority,
+        payer.clone(),
+    )
+    .await;
+    let mut context = context.lock().await;
+
+    let original_keypair = Keypair::new();
+    let original_pubkey = original_keypair.pubkey();
+
+    let original_print = Original {
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        max_supply: Some(100),
+        supply: 0,
+    };
+
+    setup_original_print(
+        &mut context,
+        &program_id,
+        &metadata_pubkey,
+        token.get_address(),
+        &original_print,
+        &original_keypair,
+        &mint_authority,
+    )
+    .await;
+
+    let new_max_supply = Some(200);
+
+    // No signature
+    let mut update_supply_ix = update_original_max_supply(
+        &program_id,
+        &original_pubkey,
+        &update_authority_pubkey,
+        new_max_supply,
+    );
+    update_supply_ix.accounts[1].is_signer = false;
+    let transaction = Transaction::new_signed_with_payer(
+        &[update_supply_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature,)
+    );
+
+    // Wrong authority
+    let transaction = Transaction::new_signed_with_payer(
+        &[update_original_max_supply(
+            &program_id,
+            &original_pubkey,
+            &original_pubkey,
+            new_max_supply,
+        )],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &original_keypair],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(TokenEditionsError::IncorrectUpdateAuthority as u32),
+        )
+    );
 }

--- a/editions/interface/Cargo.toml
+++ b/editions/interface/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "spl-token-editions-interface"
+version = "0.1.0"
+description = "Solana Program Library Token Metadata Interface"
+authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
+repository = "https://github.com/solana-labs/solana-program-library"
+license = "Apache-2.0"
+edition = "2021"
+
+[dependencies]
+borsh = "0.10"
+solana-program = "1.16.3"
+spl-discriminator = { version = "0.1.0" , path = "../../libraries/discriminator" }
+spl-program-error = { version = "0.2.0" , path = "../../libraries/program-error" }
+spl-type-length-value = { version = "0.2.0", path = "../../libraries/type-length-value" }
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/editions/interface/README.md
+++ b/editions/interface/README.md
@@ -2,17 +2,19 @@
 
 This interface is designed to allow on-chain programs to make use of printed "copies" of token metadata, with parent-child relationships.
 
-## Metaplex Protocol
-
 Metaplex introduced the idea of [Editions](https://docs.metaplex.com/programs/token-metadata/overview#printing-editions) for tokens, a concept most projects on Solana are readily familiar with.
 
-In short, editions allow you to create an original "copy" of an token and then print new "copies" of that token. Although we're talking about "copies", the token itself is not copied. All that's being copied with Editions is the Metadata.
+In short, editions allow you to create an original "copy" of a token and then print new "copies" of that token. Although we're talking about "copies", the token itself is not copied. All that's being copied with Editions is the **token metadata**.
+
+## Metaplex Protocol
+
+Below is an overview of how Metaplex's Editions work.
 
 ### Create the Original
 
 Create a `MasterEdition` account for the the original token.
 
-- Mint a new SPL Token with supply of 1, decimals 0, and no mint authority.
+- Mint a new SPL Token.
 - Create a `Metadata` account for the token.
 - Create a `MasterEdition` account for the token.
 
@@ -35,7 +37,7 @@ With Metaplex's protocol, the `MasterEdition` determines the max supply and also
 
 Create one or more copies of the original token by creating an `Edition`, by creating new tokens that inherently "copy" the original token's metadata.
 
-- Mint a new SPL Token with supply of 1, decimals 0, and no mint authority.
+- Mint a new SPL Token.
 - Create a `Metadata` account for the token with the data _copied from the `Metadata` account referred to by the `MasterEdition`_.
 - Create an `Edition` account for the token pointing to the `MasterEdition` account.
 
@@ -59,13 +61,13 @@ The PDA seeds used to derive a `MasterEdition` and an `Edition` are the same, so
 
 ## SPL Interface
 
-The interface - albeit strongly inspired and largely based upon Metaplex's original engineering - should be simple enough to not inundate or force anyone to comply with any preconcieved ideas of how these parent-child relationships amongst editions should interact.
+The interface - albeit strongly inspired by and largely based upon Metaplex's original engineering - should be simple enough to not inundate or force anyone to comply with any preconcieved ideas of how these parent-child relationships amongst editions should interact.
 
 > Note: Changing the nomenclature of these state objects may potentially confuse people familiar with Metaplex's model, but serve to acknowledge the fact that this interface is something entirely different.
 
 ### The Original
 
-This interface will dub the original token or NFT as simply an `Original`.
+This interface will dub the original token metadata simply as an `Original`.
 
 Similar to `MasterEdition`, this state will store information pertaining to supply and maximum supply.
 
@@ -94,4 +96,14 @@ pub struct Reprint {
 
 It's worth noting that, as Metaplex has designed, making the seeds for these types of accounts the same is a good idea. However, this interface cannot enforce this.
 
-In the case of the interface, both states share the same SPL discriminator, thus mimic the seed pattern of Metaplex.
+In the case of the interface, both states share the same **SPL discriminator**, thus mimicking the conflicting seed pattern of Metaplex.
+
+> Note: Although the naming conventions `Original` and `Reprint` exist in the instruction nomonclature, this interface cannot enforce state.
+
+### Working with Metadata
+
+Editions work closely with token metadata, so it makes sense to implement _both_ the SPL Token Metadata interface as well as the SPL Token Editions interface within the same on-chain program.
+
+However, this is not required! As long as the mint authority is correct, a program that implements the SPL Token Editions interface can create `Original` prints and simply CPI into the proper Token Metadata program to create `Reprint` copies!
+
+To see this concept in action, and more details on implementing the SPL Token Editions interface, see the `example` program in this repository.

--- a/editions/interface/README.md
+++ b/editions/interface/README.md
@@ -1,10 +1,16 @@
 # Editions
 
-This interface is designed to allow on-chain programs to make use of printed "copies" of token metadata, with parent-child relationships.
+This interface is designed to allow on-chain programs to make use of printed
+"copies" of token metadata, with parent-child relationships.
 
-Metaplex introduced the idea of [Editions](https://docs.metaplex.com/programs/token-metadata/overview#printing-editions) for tokens, a concept most projects on Solana are readily familiar with.
+Metaplex introduced the idea of 
+[Editions](https://docs.metaplex.com/programs/token-metadata/overview#printing-editions)
+for tokens, a concept most projects on Solana are readily familiar with.
 
-In short, editions allow you to create an original "copy" of a token and then print new "copies" of that token. Although we're talking about "copies", the token itself is not copied. All that's being copied with Editions is the **token metadata**.
+In short, editions allow you to create an original "copy" of a token and then
+print new "copies" of that token. Although we're talking about "copies", the
+token itself is not copied. All that's being copied with Editions is the
+**token metadata**.
 
 ## Metaplex Protocol
 
@@ -18,10 +24,13 @@ Create a `MasterEdition` account for the the original token.
 - Create a `Metadata` account for the token.
 - Create a `MasterEdition` account for the token.
 
-As described in [Metaplex's docs](https://docs.metaplex.com/programs/token-metadata/overview#printing-editions):
-> "The Master Edition NFT, a.k.a. Original NFT, acts as the master record that one can use to print copies, a.k.a. Print NFTs."
+As described in 
+[Metaplex's docs](https://docs.metaplex.com/programs/token-metadata/overview#printing-editions):
+> "The Master Edition NFT, a.k.a. Original NFT, acts as the master record that
+> one can use to print copies, a.k.a. Print NFTs."
 
-We can infer how a `MasterEdition` account dictates the printing of copies by examining its schema below:
+We can infer how a `MasterEdition` account dictates the printing of copies by
+examining its schema below:
 
 ```rust
 pub struct MasterEditionV2 {
@@ -31,17 +40,23 @@ pub struct MasterEditionV2 {
 }
 ```
 
-With Metaplex's protocol, the `MasterEdition` determines the max supply and also incrementally records the current supply, so we know **this account must always be involved with the printing of new editions**.
+With Metaplex's protocol, the `MasterEdition` determines the max supply and
+also incrementally records the current supply, so we know **this account must
+always be involved with the printing of new editions**.
 
 ### Print Copies
 
-Create one or more copies of the original token by creating an `Edition`, by creating new tokens that inherently "copy" the original token's metadata.
+Create one or more copies of the original token by creating an `Edition`, by
+creating new tokens that inherently "copy" the original token's metadata.
 
 - Mint a new SPL Token.
-- Create a `Metadata` account for the token with the data _copied from the `Metadata` account referred to by the `MasterEdition`_.
-- Create an `Edition` account for the token pointing to the `MasterEdition` account.
+- Create a `Metadata` account for the token with the data _copied from the
+`Metadata` account referred to by the `MasterEdition`_.
+- Create an `Edition` account for the token pointing to the `MasterEdition`
+account.
 
-We can immediately see the parent-child relationship made evident within an `Edition` schema:
+We can immediately see the parent-child relationship made evident within
+an `Edition` schema:
 
 ```rust
 pub struct Edition {
@@ -53,7 +68,8 @@ pub struct Edition {
 
 ### Seeds
 
-The PDA seeds used to derive a `MasterEdition` and an `Edition` are the same, so that a token can only have one or the other. They are as follows:
+The PDA seeds used to derive a `MasterEdition` and an `Edition` are the same,
+so that a token can only have one or the other. They are as follows:
 
 ```text
 "metadata" + <token metadata program ID> + <mint address> + "edition"
@@ -61,15 +77,21 @@ The PDA seeds used to derive a `MasterEdition` and an `Edition` are the same, so
 
 ## SPL Interface
 
-The interface - albeit strongly inspired by and largely based upon Metaplex's original engineering - should be simple enough to not inundate or force anyone to comply with any preconcieved ideas of how these parent-child relationships amongst editions should interact.
+The interface - albeit strongly inspired by and largely based upon Metaplex's
+original engineering - should be simple enough to not inundate or force anyone
+to comply with any preconcieved ideas of how these parent-child relationships
+amongst editions should interact.
 
-> Note: Changing the nomenclature of these state objects may potentially confuse people familiar with Metaplex's model, but serve to acknowledge the fact that this interface is something entirely different.
+> Note: Changing the nomenclature of these state objects may potentially
+> confuse people familiar with Metaplex's model, but serve to acknowledge
+> the fact that this interface is something entirely different.
 
 ### The Original
 
 This interface will dub the original token metadata simply as an `Original`.
 
-Similar to `MasterEdition`, this state will store information pertaining to supply and maximum supply.
+Similar to `MasterEdition`, this state will store information pertaining to
+supply and maximum supply.
 
 ```rust
 pub struct Original {
@@ -83,7 +105,8 @@ pub struct Original {
 
 This interface will dub copies of the original as a `Reprint`.
 
-Similar to `Edition`, this state will store information pointing back to the parent.
+Similar to `Edition`, this state will store information pointing back to
+the parent.
 
 ```rust
 pub struct Reprint {
@@ -92,18 +115,32 @@ pub struct Reprint {
 }
 ```
 
+> Note: Sending a `CreateReprint` instruction requires two signatures -
+> the mint authority of the reprint token _and_ the mint authority of the
+> original token. However, these can be the same account.
+
 ### Seeds (SPL)
 
-It's worth noting that, as Metaplex has designed, making the seeds for these types of accounts the same is a good idea. However, this interface cannot enforce this.
+It's worth noting that, as Metaplex has designed, making the seeds for these
+types of accounts the same is a good idea. However, this interface cannot
+enforce this.
 
-In the case of the interface, both states share the same **SPL discriminator**, thus mimicking the conflicting seed pattern of Metaplex.
+In the case of the interface, both states share the same **SPL discriminator**,
+thus mimicking the conflicting seed pattern of Metaplex.
 
-> Note: Although the naming conventions `Original` and `Reprint` exist in the instruction nomonclature, this interface cannot enforce state.
+> Note: Although the naming conventions `Original` and `Reprint` exist in the
+> instruction nomenclature, this interface cannot enforce state.
 
 ### Working with Metadata
 
-Editions work closely with token metadata, so it makes sense to implement _both_ the SPL Token Metadata interface as well as the SPL Token Editions interface within the same on-chain program.
+Editions work closely with token metadata, so it makes sense to implement
+_both_ the SPL Token Metadata interface as well as the SPL Token Editions
+interface within the same on-chain program.
 
-However, this is not required! As long as the mint authority is correct, a program that implements the SPL Token Editions interface can create `Original` prints and simply CPI into the proper Token Metadata program to create `Reprint` copies!
+However, this is not required! As long as the mint authority is correct,
+a program that implements the SPL Token Editions interface can create
+`Original` prints and simply CPI into the proper Token Metadata program
+to create `Reprint` copies!
 
-To see this concept in action, and more details on implementing the SPL Token Editions interface, see the `example` program in this repository.
+To see this concept in action, and more details on implementing the SPL Token
+Editions interface, see the `example` program in this repository.

--- a/editions/interface/src/error.rs
+++ b/editions/interface/src/error.rs
@@ -23,4 +23,7 @@ pub enum TokenEditionsError {
     /// Original print has no update authority
     #[error("Original print has no update authority")]
     ImmutablePrint,
+    /// Incorrect original print provided
+    #[error("Incorrect original print provided")]
+    IncorrectOriginal,
 }

--- a/editions/interface/src/error.rs
+++ b/editions/interface/src/error.rs
@@ -1,0 +1,23 @@
+//! Interface error types
+
+use spl_program_error::*;
+
+/// Errors that may be returned by the interface.
+#[spl_program_error]
+pub enum TokenEditionsError {
+    /// Supply is greater than proposed max supply
+    #[error("Supply is greater than proposed max supply")]
+    SupplyExceedsNewMaxSupply,
+    /// Supply is greater than max supply
+    #[error("Supply is greater than max supply")]
+    SupplyExceedsMaxSupply,
+    /// Incorrect mint authority has signed the instruction
+    #[error("Incorrect mint authority has signed the instruction")]
+    IncorrectMintAuthority,
+    /// Incorrect original print update authority has signed the instruction
+    #[error("Incorrect original print update authority has signed the instruction")]
+    IncorrectUpdateAuthority,
+    /// Original print has no update authority
+    #[error("Original print has no update authority")]
+    ImmutablePrint,
+}

--- a/editions/interface/src/error.rs
+++ b/editions/interface/src/error.rs
@@ -14,6 +14,9 @@ pub enum TokenEditionsError {
     /// Incorrect mint authority has signed the instruction
     #[error("Incorrect mint authority has signed the instruction")]
     IncorrectMintAuthority,
+    /// Incorrect metadata associated with mint
+    #[error("Incorrect metadata associated with mint")]
+    IncorrectMetadata,
     /// Incorrect original print update authority has signed the instruction
     #[error("Incorrect original print update authority has signed the instruction")]
     IncorrectUpdateAuthority,

--- a/editions/interface/src/instruction.rs
+++ b/editions/interface/src/instruction.rs
@@ -76,10 +76,10 @@ pub enum TokenEditionsInstruction {
     ///
     /// Accounts expected by this instruction:
     ///
-    ///   0. `[w]` Original
-    ///   1. `[]` Metadata
-    ///   2. `[]` Mint
-    ///   3. `[s]` Mint authority
+    ///   0. `[w]`  Original
+    ///   1. `[]`   Metadata
+    ///   2. `[]`   Mint
+    ///   3. `[s]`  Mint authority
     ///
     /// Data: `CreateOriginal`: max_supply: `Option<u64>`
     CreateOriginal(CreateOriginal),
@@ -88,8 +88,8 @@ pub enum TokenEditionsInstruction {
     ///
     /// Accounts expected by this instruction:
     ///
-    ///   0. `[w]` Original
-    ///   1. `[s]` Update authority
+    ///   0. `[w]`  Original
+    ///   1. `[s]`  Update authority
     ///
     /// Data: `UpdateOriginalMaxSupply`: max_supply: `Option<u64>`
     UpdateOriginalMaxSupply(UpdateOriginalMaxSupply),
@@ -98,8 +98,8 @@ pub enum TokenEditionsInstruction {
     ///
     /// Accounts expected by this instruction:
     ///
-    ///   0. `[w]` Original
-    ///   1. `[s]` Current update authority
+    ///   0. `[w]`  Original
+    ///   1. `[s]`  Current update authority
     ///
     /// Data: the new authority. Can be unset using a `None` value
     UpdateOriginalAuthority(UpdateOriginalAuthority),
@@ -111,16 +111,17 @@ pub enum TokenEditionsInstruction {
     ///
     /// Accounts expected by this instruction:
     ///
-    ///   0. `[w]` Reprint
-    ///   1. `[w]` Reprint Metadata
-    ///   2. `[]` Reprint Mint
-    ///   3. `[w]` Original
-    ///   4. `[s]` Update authority
-    ///   5. `[]` Original Metadata
-    ///   6. `[]` Original Mint
-    ///   7. `[s]` Mint authority
-    ///   8. `[]` Metadata program
-    ///   8..8+M `[]` `M` additional accounts, written in validation account
+    ///   0. `[w]`  Reprint
+    ///   1. `[w]`  Reprint Metadata
+    ///   2. `[]`   Reprint Metadata Update Authority
+    ///   3. `[]`   Reprint Mint
+    ///   4. `[s]`  Reprint Mint Authority
+    ///   5. `[w]`  Original
+    ///   6. `[]`   Original Metadata
+    ///   7. `[]`   Original Mint
+    ///   8. `[s]`  Original Mint Authority
+    ///   9. `[]`   Metadata program
+    ///   9..9+M `[]` `M` additional accounts, written in validation account
     /// data
     ///
     /// Data: `CreateReprint`: original: `Pubkey`, copy: `u64`
@@ -282,12 +283,13 @@ pub fn create_reprint(
     program_id: &Pubkey,
     reprint: &Pubkey,
     reprint_metadata: &Pubkey,
+    reprint_metadata_update_authority: &Pubkey,
     reprint_mint: &Pubkey,
+    reprint_mint_authority: &Pubkey,
     original: &Pubkey,
-    update_authority: &Pubkey,
     original_metadata: &Pubkey,
     original_mint: &Pubkey,
-    mint_authority: &Pubkey,
+    original_mint_authority: &Pubkey,
     metadata_program_id: &Pubkey,
 ) -> Instruction {
     let data = TokenEditionsInstruction::CreateReprint(CreateReprint {
@@ -298,12 +300,13 @@ pub fn create_reprint(
         accounts: vec![
             AccountMeta::new(*reprint, false),
             AccountMeta::new(*reprint_metadata, false),
-            AccountMeta::new(*reprint_mint, false),
+            AccountMeta::new_readonly(*reprint_metadata_update_authority, false),
+            AccountMeta::new_readonly(*reprint_mint, false),
+            AccountMeta::new_readonly(*reprint_mint_authority, true),
             AccountMeta::new(*original, false),
-            AccountMeta::new_readonly(*update_authority, true),
             AccountMeta::new_readonly(*original_metadata, false),
             AccountMeta::new_readonly(*original_mint, false),
-            AccountMeta::new_readonly(*mint_authority, true),
+            AccountMeta::new_readonly(*original_mint_authority, true),
             AccountMeta::new_readonly(*metadata_program_id, false),
         ],
         data: data.pack(),

--- a/editions/interface/src/instruction.rs
+++ b/editions/interface/src/instruction.rs
@@ -1,0 +1,409 @@
+//! Instruction types
+
+use {
+    crate::state::OptionalNonZeroPubkey,
+    borsh::{BorshDeserialize, BorshSerialize},
+    solana_program::{
+        instruction::{AccountMeta, Instruction},
+        program_error::ProgramError,
+        pubkey::Pubkey,
+    },
+    spl_discriminator::{ArrayDiscriminator, SplDiscriminate},
+};
+
+/// Instruction data for creating a new `Original` print
+#[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize, SplDiscriminate)]
+#[discriminator_hash_input("spl_token_editions_interface:create_original")]
+pub struct CreateOriginal {
+    /// Update authority for the original print
+    pub update_authority: OptionalNonZeroPubkey,
+    /// The maximum supply of copies of this print
+    pub max_supply: Option<u64>,
+}
+
+/// Update the max supply of an `Original` print
+#[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize, SplDiscriminate)]
+#[discriminator_hash_input("spl_token_editions_interface:update_original_max_supply")]
+pub struct UpdateOriginalMaxSupply {
+    /// New max supply for the original print
+    pub max_supply: Option<u64>,
+}
+
+/// Update authority instruction data
+#[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize, SplDiscriminate)]
+#[discriminator_hash_input("spl_token_editions_interface:update_original_authority")]
+pub struct UpdateOriginalAuthority {
+    /// New authority for the original print, or unset if `None`
+    pub new_authority: OptionalNonZeroPubkey,
+}
+
+/// Instruction data for creating a new `Reprint` of an `Original` print
+#[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize, SplDiscriminate)]
+#[discriminator_hash_input("spl_token_editions_interface:create_reprint")]
+pub struct CreateReprint {
+    /// The pubkey of the `Original` print
+    pub original: Pubkey,
+}
+
+/// Instruction data for Emit
+#[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize, SplDiscriminate)]
+#[discriminator_hash_input("spl_token_editions_interface:emitter")]
+pub struct Emit {
+    /// Which type of print to emit
+    pub print_type: PrintType,
+    /// Start of range of data to emit
+    pub start: Option<u64>,
+    /// End of range of data to emit
+    pub end: Option<u64>,
+}
+
+/// The type of print
+#[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize)]
+pub enum PrintType {
+    /// Original print
+    Original,
+    /// Reprint
+    Reprint,
+}
+
+/// All instructions that must be implemented in the token-editions interface
+#[derive(Clone, Debug, PartialEq)]
+pub enum TokenEditionsInstruction {
+    /// Create a new `Original` print
+    ///
+    /// Assumes one has already created a mint and a metadata account for the
+    /// print.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[w]` Original
+    ///   1. `[]` Update authority
+    ///   2. `[]` Metadata
+    ///   3. `[]` Mint
+    ///   4. `[s]` Mint authority
+    ///
+    /// Data: `CreateOriginal`: max_supply: `Option<u64>`
+    CreateOriginal(CreateOriginal),
+
+    /// Update the max supply of an `Original` print
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[w]` Original
+    ///   1. `[s]` Update authority
+    ///
+    /// Data: `UpdateOriginalMaxSupply`: max_supply: `Option<u64>`
+    UpdateOriginalMaxSupply(UpdateOriginalMaxSupply),
+
+    /// Update the authority of an `Original` print
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[w]` Original
+    ///   1. `[s]` Current update authority
+    ///
+    /// Data: the new authority. Can be unset using a `None` value
+    UpdateOriginalAuthority(UpdateOriginalAuthority),
+
+    /// Create a new `Reprint` of an `Original` print
+    ///
+    /// Assumes the `Original` print has already been created.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[w]` Reprint
+    ///   1. `[w]` Reprint Metadata
+    ///   2. `[]` Reprint Mint
+    ///   3. `[]` Original
+    ///   4. `[]` Update authority
+    ///   5. `[]` Original Metadata
+    ///   6. `[]` Original Mint
+    ///   7. `[s]` Mint authority
+    ///
+    /// Data: `CreateReprint`: original: `Pubkey`
+    CreateReprint(CreateReprint),
+
+    /// Emits the print edition as return data
+    ///
+    /// The format of the data emitted follows either the `Original` or
+    /// `Reprint` struct,  but it's possible that the account data is stored in
+    /// another format by the program.
+    ///
+    /// With this instruction, a program that implements the token-editions
+    /// interface can return `Original` or `Reprint` without adhering to the
+    /// specific byte layout of the structs in any accounts.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[]` Original _or_ Reprint account
+    Emit(Emit),
+}
+impl TokenEditionsInstruction {
+    /// Unpacks a byte buffer into a
+    /// [TokenEditionsInstruction](enum.TokenEditionsInstruction.html).
+    pub fn unpack(input: &[u8]) -> Result<Self, ProgramError> {
+        if input.len() < ArrayDiscriminator::LENGTH {
+            return Err(ProgramError::InvalidInstructionData);
+        }
+        let (discriminator, rest) = input.split_at(ArrayDiscriminator::LENGTH);
+        Ok(match discriminator {
+            CreateOriginal::SPL_DISCRIMINATOR_SLICE => {
+                let data = CreateOriginal::try_from_slice(rest)?;
+                Self::CreateOriginal(data)
+            }
+            UpdateOriginalMaxSupply::SPL_DISCRIMINATOR_SLICE => {
+                let data = UpdateOriginalMaxSupply::try_from_slice(rest)?;
+                Self::UpdateOriginalMaxSupply(data)
+            }
+            UpdateOriginalAuthority::SPL_DISCRIMINATOR_SLICE => {
+                let data = UpdateOriginalAuthority::try_from_slice(rest)?;
+                Self::UpdateOriginalAuthority(data)
+            }
+            CreateReprint::SPL_DISCRIMINATOR_SLICE => {
+                let data = CreateReprint::try_from_slice(rest)?;
+                Self::CreateReprint(data)
+            }
+            Emit::SPL_DISCRIMINATOR_SLICE => {
+                let data = Emit::try_from_slice(rest)?;
+                Self::Emit(data)
+            }
+            _ => return Err(ProgramError::InvalidInstructionData),
+        })
+    }
+
+    /// Packs a [TokenEditionsInstruction](enum.TokenEditionsInstruction.html)
+    /// into a byte buffer.
+    pub fn pack(&self) -> Vec<u8> {
+        let mut buf = vec![];
+        match self {
+            Self::CreateOriginal(data) => {
+                buf.extend_from_slice(CreateOriginal::SPL_DISCRIMINATOR_SLICE);
+                buf.append(&mut data.try_to_vec().unwrap());
+            }
+            Self::UpdateOriginalMaxSupply(data) => {
+                buf.extend_from_slice(UpdateOriginalMaxSupply::SPL_DISCRIMINATOR_SLICE);
+                buf.append(&mut data.try_to_vec().unwrap());
+            }
+            Self::UpdateOriginalAuthority(data) => {
+                buf.extend_from_slice(UpdateOriginalAuthority::SPL_DISCRIMINATOR_SLICE);
+                buf.append(&mut data.try_to_vec().unwrap());
+            }
+            Self::CreateReprint(data) => {
+                buf.extend_from_slice(CreateReprint::SPL_DISCRIMINATOR_SLICE);
+                buf.append(&mut data.try_to_vec().unwrap());
+            }
+            Self::Emit(data) => {
+                buf.extend_from_slice(Emit::SPL_DISCRIMINATOR_SLICE);
+                buf.append(&mut data.try_to_vec().unwrap());
+            }
+        };
+        buf
+    }
+}
+
+/// Creates a `CreateOriginal` instruction
+pub fn create_original(
+    program_id: &Pubkey,
+    original: &Pubkey,
+    update_authority: Option<Pubkey>,
+    metadata: &Pubkey,
+    mint: &Pubkey,
+    mint_authority: &Pubkey,
+    max_supply: Option<u64>,
+) -> Instruction {
+    let (update_authority, update_authority_pubkey) = {
+        (
+            OptionalNonZeroPubkey::try_from(update_authority)
+                .expect("Failed to deserialize pubkey for update authority"),
+            match update_authority {
+                Some(pubkey) => pubkey,
+                None => *program_id,
+            },
+        )
+    };
+    let data = TokenEditionsInstruction::CreateOriginal(CreateOriginal {
+        update_authority,
+        max_supply,
+    });
+    Instruction {
+        program_id: *program_id,
+        accounts: vec![
+            AccountMeta::new(*original, false),
+            AccountMeta::new_readonly(update_authority_pubkey, false),
+            AccountMeta::new_readonly(*metadata, false),
+            AccountMeta::new_readonly(*mint, false),
+            AccountMeta::new_readonly(*mint_authority, true),
+        ],
+        data: data.pack(),
+    }
+}
+
+/// Creates a `UpdateOriginalMaxSupply` instruction
+pub fn update_original_max_supply(
+    program_id: &Pubkey,
+    original: &Pubkey,
+    update_authority: &Pubkey,
+    max_supply: Option<u64>,
+) -> Instruction {
+    let data =
+        TokenEditionsInstruction::UpdateOriginalMaxSupply(UpdateOriginalMaxSupply { max_supply });
+    Instruction {
+        program_id: *program_id,
+        accounts: vec![
+            AccountMeta::new(*original, false),
+            AccountMeta::new_readonly(*update_authority, true),
+        ],
+        data: data.pack(),
+    }
+}
+
+/// Creates a `UpdateOriginalAuthority` instruction
+pub fn update_original_authority(
+    program_id: &Pubkey,
+    original: &Pubkey,
+    current_authority: &Pubkey,
+    new_authority: Option<Pubkey>,
+) -> Instruction {
+    let new_authority = OptionalNonZeroPubkey::try_from(new_authority)
+        .expect("Failed to deserialize pubkey for update authority");
+    let data = TokenEditionsInstruction::UpdateOriginalAuthority(UpdateOriginalAuthority {
+        new_authority,
+    });
+    Instruction {
+        program_id: *program_id,
+        accounts: vec![
+            AccountMeta::new(*original, false),
+            AccountMeta::new_readonly(*current_authority, true),
+        ],
+        data: data.pack(),
+    }
+}
+
+/// Creates a `CreateReprint` instruction
+#[allow(clippy::too_many_arguments)]
+pub fn create_reprint(
+    program_id: &Pubkey,
+    reprint: &Pubkey,
+    reprint_metadata: &Pubkey,
+    reprint_mint: &Pubkey,
+    original: &Pubkey,
+    update_authority: &Pubkey,
+    original_metadata: &Pubkey,
+    original_mint: &Pubkey,
+    mint_authority: &Pubkey,
+) -> Instruction {
+    let data = TokenEditionsInstruction::CreateReprint(CreateReprint {
+        original: *original,
+    });
+    Instruction {
+        program_id: *program_id,
+        accounts: vec![
+            AccountMeta::new(*reprint, false),
+            AccountMeta::new(*reprint_metadata, false),
+            AccountMeta::new_readonly(*reprint_mint, false),
+            AccountMeta::new(*original, false),
+            AccountMeta::new_readonly(*update_authority, true),
+            AccountMeta::new_readonly(*original_metadata, false),
+            AccountMeta::new_readonly(*original_mint, false),
+            AccountMeta::new_readonly(*mint_authority, true),
+        ],
+        data: data.pack(),
+    }
+}
+
+/// Creates an `Emit` instruction
+pub fn emit(
+    program_id: &Pubkey,
+    print: &Pubkey,
+    print_type: PrintType,
+    start: Option<u64>,
+    end: Option<u64>,
+) -> Instruction {
+    let data = TokenEditionsInstruction::Emit(Emit {
+        print_type,
+        start,
+        end,
+    });
+    Instruction {
+        program_id: *program_id,
+        accounts: vec![AccountMeta::new_readonly(*print, false)],
+        data: data.pack(),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use {super::*, crate::NAMESPACE, solana_program::hash};
+
+    fn check_pack_unpack<T: BorshSerialize>(
+        instruction: TokenEditionsInstruction,
+        discriminator: &[u8],
+        data: T,
+    ) {
+        let mut expect = vec![];
+        expect.extend_from_slice(discriminator.as_ref());
+        expect.append(&mut data.try_to_vec().unwrap());
+        let packed = instruction.pack();
+        assert_eq!(packed, expect);
+        let unpacked = TokenEditionsInstruction::unpack(&expect).unwrap();
+        assert_eq!(unpacked, instruction);
+    }
+
+    #[test]
+    fn create_original_pack() {
+        let data = CreateOriginal {
+            update_authority: OptionalNonZeroPubkey::default(),
+            max_supply: Some(100),
+        };
+        let check = TokenEditionsInstruction::CreateOriginal(data.clone());
+        let preimage = hash::hashv(&[format!("{NAMESPACE}:create_original").as_bytes()]);
+        let discriminator = &preimage.as_ref()[..ArrayDiscriminator::LENGTH];
+        check_pack_unpack(check, discriminator, data);
+    }
+
+    #[test]
+    fn update_original_max_supply_pack() {
+        let data = UpdateOriginalMaxSupply {
+            max_supply: Some(200),
+        };
+        let check = TokenEditionsInstruction::UpdateOriginalMaxSupply(data.clone());
+        let preimage = hash::hashv(&[format!("{NAMESPACE}:update_original_max_supply").as_bytes()]);
+        let discriminator = &preimage.as_ref()[..ArrayDiscriminator::LENGTH];
+        check_pack_unpack(check, discriminator, data);
+    }
+
+    #[test]
+    fn update_authority_pack() {
+        let data = UpdateOriginalAuthority {
+            new_authority: OptionalNonZeroPubkey::default(),
+        };
+        let check = TokenEditionsInstruction::UpdateOriginalAuthority(data.clone());
+        let preimage = hash::hashv(&[format!("{NAMESPACE}:update_original_authority").as_bytes()]);
+        let discriminator = &preimage.as_ref()[..ArrayDiscriminator::LENGTH];
+        check_pack_unpack(check, discriminator, data);
+    }
+
+    #[test]
+    fn create_reprint_pack() {
+        let data = CreateReprint {
+            original: Pubkey::new_unique(),
+        };
+        let check = TokenEditionsInstruction::CreateReprint(data.clone());
+        let preimage = hash::hashv(&[format!("{NAMESPACE}:create_reprint").as_bytes()]);
+        let discriminator = &preimage.as_ref()[..ArrayDiscriminator::LENGTH];
+        check_pack_unpack(check, discriminator, data);
+    }
+
+    #[test]
+    fn emit_pack() {
+        let data = Emit {
+            print_type: PrintType::Original,
+            start: None,
+            end: Some(10),
+        };
+        let check = TokenEditionsInstruction::Emit(data.clone());
+        let preimage = hash::hashv(&[format!("{NAMESPACE}:emitter").as_bytes()]);
+        let discriminator = &preimage.as_ref()[..ArrayDiscriminator::LENGTH];
+        check_pack_unpack(check, discriminator, data);
+    }
+}

--- a/editions/interface/src/lib.rs
+++ b/editions/interface/src/lib.rs
@@ -1,0 +1,17 @@
+//! Crate defining an interface for token-editions
+
+#![allow(clippy::integer_arithmetic)]
+#![deny(missing_docs)]
+#![cfg_attr(not(test), forbid(unsafe_code))]
+
+pub mod error;
+pub mod instruction;
+pub mod state;
+
+// Export current sdk types for downstream users building with a different sdk
+// version
+// Export borsh for downstream users
+pub use {borsh, solana_program};
+
+/// Namespace for all programs implementing token-editions
+pub const NAMESPACE: &str = "spl_token_editions_interface";

--- a/editions/interface/src/state.rs
+++ b/editions/interface/src/state.rs
@@ -202,4 +202,36 @@ mod tests {
         original_print.update_max_supply(new_max_supply).unwrap();
         assert_eq!(original_print.max_supply, new_max_supply);
     }
+
+    #[test]
+    fn update_current_supply() {
+        let mut original_print = Original {
+            max_supply: Some(1),
+            ..Default::default()
+        };
+
+        original_print.update_supply(1).unwrap();
+        assert_eq!(original_print.supply, 1);
+
+        // Try to set the current supply to 2, which is greater than the max supply
+        assert_eq!(
+            original_print.update_supply(2),
+            Err(ProgramError::from(
+                TokenEditionsError::SupplyExceedsMaxSupply
+            ))
+        );
+
+        // Test with a `None` max supply
+        let mut original_print = Original {
+            max_supply: None,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            original_print.update_supply(1),
+            Err(ProgramError::from(
+                TokenEditionsError::SupplyExceedsMaxSupply
+            ))
+        );
+    }
 }

--- a/editions/interface/src/state.rs
+++ b/editions/interface/src/state.rs
@@ -1,0 +1,205 @@
+//! Token-edition interface state types
+
+use {
+    crate::error::TokenEditionsError,
+    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
+    solana_program::{
+        borsh::{get_instance_packed_len, try_from_slice_unchecked},
+        program_error::ProgramError,
+        pubkey::Pubkey,
+    },
+    spl_discriminator::SplDiscriminate,
+    spl_type_length_value::{
+        state::{TlvState, TlvStateBorrowed},
+        variable_len_pack::VariableLenPack,
+    },
+};
+
+/// A Pubkey that encodes `None` as all `0`, meant to be usable as a Pod type,
+/// similar to all NonZero* number types from the bytemuck library.
+#[derive(Clone, Debug, Default, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[repr(transparent)]
+pub struct OptionalNonZeroPubkey(Pubkey);
+impl TryFrom<Option<Pubkey>> for OptionalNonZeroPubkey {
+    type Error = ProgramError;
+    fn try_from(p: Option<Pubkey>) -> Result<Self, Self::Error> {
+        match p {
+            None => Ok(Self(Pubkey::default())),
+            Some(pubkey) => {
+                if pubkey == Pubkey::default() {
+                    Err(ProgramError::InvalidArgument)
+                } else {
+                    Ok(Self(pubkey))
+                }
+            }
+        }
+    }
+}
+impl From<OptionalNonZeroPubkey> for Option<Pubkey> {
+    fn from(p: OptionalNonZeroPubkey) -> Self {
+        if p.0 == Pubkey::default() {
+            None
+        } else {
+            Some(p.0)
+        }
+    }
+}
+
+/// Get the slice corresponding to the given start and end range
+pub fn get_emit_slice(data: &[u8], start: Option<u64>, end: Option<u64>) -> Option<&[u8]> {
+    let start = start.unwrap_or(0) as usize;
+    let end = end.map(|x| x as usize).unwrap_or(data.len());
+    data.get(start..end)
+}
+
+/// Data struct for an `Original` print
+#[derive(
+    Clone, Debug, Default, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema, SplDiscriminate,
+)]
+#[discriminator_hash_input("spl_token_editions_interface:print")]
+pub struct Original {
+    /// The authority that can sign to update the original print
+    pub update_authority: OptionalNonZeroPubkey,
+    /// The current supply of copies of this print
+    pub supply: u64,
+    /// The maximum supply of copies of this print
+    pub max_supply: Option<u64>,
+}
+impl Original {
+    /// Gives the total size of this struct as a TLV entry in an account
+    pub fn tlv_size_of(&self) -> Result<usize, ProgramError> {
+        TlvStateBorrowed::get_base_len()
+            .checked_add(get_instance_packed_len(self)?)
+            .ok_or(ProgramError::InvalidAccountData)
+    }
+
+    /// Creates a new `Original` print state
+    pub fn new(update_authority: OptionalNonZeroPubkey, max_supply: Option<u64>) -> Self {
+        Self {
+            update_authority,
+            supply: 0,
+            max_supply,
+        }
+    }
+
+    /// Updates the max supply for an original print
+    pub fn update_max_supply(&mut self, max_supply: Option<u64>) -> Result<(), ProgramError> {
+        // The new max supply cannot be less than the current supply
+        if let Some(new_max_supply) = max_supply {
+            if new_max_supply < self.supply {
+                return Err(TokenEditionsError::SupplyExceedsNewMaxSupply.into());
+            }
+        } else if self.supply > 0 {
+            return Err(TokenEditionsError::SupplyExceedsNewMaxSupply.into());
+        }
+        self.max_supply = max_supply;
+        Ok(())
+    }
+
+    /// Updates the supply for an original print
+    pub fn update_supply(&mut self, new_supply: u64) -> Result<(), ProgramError> {
+        // The new supply cannot be greater than the max supply
+        if let Some(max_supply) = self.max_supply {
+            if new_supply > max_supply {
+                return Err(TokenEditionsError::SupplyExceedsMaxSupply.into());
+            }
+        } else if new_supply > 0 {
+            return Err(TokenEditionsError::SupplyExceedsMaxSupply.into());
+        }
+        self.supply = new_supply;
+        Ok(())
+    }
+}
+impl VariableLenPack for Original {
+    fn pack_into_slice(&self, dst: &mut [u8]) -> Result<(), ProgramError> {
+        borsh::to_writer(&mut dst[..], self).map_err(Into::into)
+    }
+    fn unpack_from_slice(src: &[u8]) -> Result<Self, ProgramError> {
+        try_from_slice_unchecked(src).map_err(Into::into)
+    }
+    fn get_packed_len(&self) -> Result<usize, ProgramError> {
+        get_instance_packed_len(self).map_err(Into::into)
+    }
+}
+
+/// Data struct for a `Reprint` of an `Original` print
+#[derive(
+    Clone, Debug, Default, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema, SplDiscriminate,
+)]
+#[discriminator_hash_input("spl_token_editions_interface:print")]
+pub struct Reprint {
+    /// The pubkey of the `Original` print
+    pub original: Pubkey,
+    /// The copy number of this `Reprint`
+    pub copy: u64,
+}
+impl Reprint {
+    /// Gives the total size of this struct as a TLV entry in an account
+    pub fn tlv_size_of(&self) -> Result<usize, ProgramError> {
+        TlvStateBorrowed::get_base_len()
+            .checked_add(get_instance_packed_len(self)?)
+            .ok_or(ProgramError::InvalidAccountData)
+    }
+}
+impl VariableLenPack for Reprint {
+    fn pack_into_slice(&self, dst: &mut [u8]) -> Result<(), ProgramError> {
+        borsh::to_writer(&mut dst[..], self).map_err(Into::into)
+    }
+    fn unpack_from_slice(src: &[u8]) -> Result<Self, ProgramError> {
+        try_from_slice_unchecked(src).map_err(Into::into)
+    }
+    fn get_packed_len(&self) -> Result<usize, ProgramError> {
+        get_instance_packed_len(self).map_err(Into::into)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, crate::NAMESPACE, solana_program::hash, spl_discriminator::ArrayDiscriminator};
+
+    #[test]
+    fn discriminators() {
+        let preimage = hash::hashv(&[format!("{NAMESPACE}:print").as_bytes()]);
+        let discriminator =
+            ArrayDiscriminator::try_from(&preimage.as_ref()[..ArrayDiscriminator::LENGTH]).unwrap();
+        assert_eq!(Original::SPL_DISCRIMINATOR, discriminator);
+        assert_eq!(Reprint::SPL_DISCRIMINATOR, discriminator);
+    }
+
+    #[test]
+    fn update_max_supply() {
+        // Test with a `Some` max supply
+        let max_supply = Some(10);
+        let mut original_print = Original {
+            max_supply,
+            ..Default::default()
+        };
+
+        let new_max_supply = Some(30);
+        original_print.update_max_supply(new_max_supply).unwrap();
+        assert_eq!(original_print.max_supply, new_max_supply);
+
+        // Change the current supply to 30
+        original_print.supply = 30;
+
+        // Try to set the max supply to 20, which is less than the current supply
+        let new_max_supply = Some(20);
+        assert_eq!(
+            original_print.update_max_supply(new_max_supply),
+            Err(ProgramError::from(
+                TokenEditionsError::SupplyExceedsNewMaxSupply
+            ))
+        );
+
+        // Test with a `None` max supply
+        let max_supply = None;
+        let mut original_print = Original {
+            max_supply,
+            ..Default::default()
+        };
+
+        let new_max_supply = Some(30);
+        original_print.update_max_supply(new_max_supply).unwrap();
+        assert_eq!(original_print.max_supply, new_max_supply);
+    }
+}

--- a/editions/interface/src/state.rs
+++ b/editions/interface/src/state.rs
@@ -89,8 +89,6 @@ impl Original {
             if new_max_supply < self.supply {
                 return Err(TokenEditionsError::SupplyExceedsNewMaxSupply.into());
             }
-        } else if self.supply > 0 {
-            return Err(TokenEditionsError::SupplyExceedsNewMaxSupply.into());
         }
         self.max_supply = max_supply;
         Ok(())
@@ -103,8 +101,6 @@ impl Original {
             if new_supply > max_supply {
                 return Err(TokenEditionsError::SupplyExceedsMaxSupply.into());
             }
-        } else if new_supply > 0 {
-            return Err(TokenEditionsError::SupplyExceedsMaxSupply.into());
         }
         self.supply = new_supply;
         Ok(())
@@ -227,11 +223,7 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(
-            original_print.update_supply(1),
-            Err(ProgramError::from(
-                TokenEditionsError::SupplyExceedsMaxSupply
-            ))
-        );
+        original_print.update_supply(1).unwrap();
+        assert_eq!(original_print.supply, 1);
     }
 }


### PR DESCRIPTION
This PR introduces an interface for Token Editions. With this interface, on-chain programs can create tokens that are "originals" and then "print copies" of these tokens using specific additional metadata - dubbed `Original` and `Reprint`.