### PR TITLE
Collections Interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7039,6 +7039,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-token-collections-example"
+version = "0.1.0"
+dependencies = [
+ "solana-program",
+ "solana-program-test",
+ "solana-sdk",
+ "spl-token-2022 0.7.0",
+ "spl-token-client",
+ "spl-token-collections-interface",
+ "spl-token-metadata-interface",
+ "spl-type-length-value",
+ "test-case",
+]
+
+[[package]]
+name = "spl-token-collections-interface"
+version = "0.1.0"
+dependencies = [
+ "borsh 0.10.3",
+ "solana-program",
+ "spl-discriminator",
+ "spl-program-error",
+ "spl-type-length-value",
+]
+
+[[package]]
 name = "spl-token-lending"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7253,7 +7253,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.29",
- "syn 2.0.23",
+ "syn 2.0.26",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ members = [
   "associated-token-account/program-test",
   "binary-option/program",
   "binary-oracle-pair/program",
+  "collections/example",
+  "collections/interface",
   "examples/rust/cross-program-invocation",
   "examples/rust/custom-heap",
   "examples/rust/logging",

--- a/collections/example/Cargo.toml
+++ b/collections/example/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "spl-token-collections-example"
+version = "0.1.0"
+description = "Solana Program Library Token Metadata Example Program"
+authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
+repository = "https://github.com/solana-labs/solana-program-library"
+license = "Apache-2.0"
+edition = "2021"
+
+[features]
+no-entrypoint = []
+test-sbf = []
+
+[dependencies]
+solana-program = "1.16.3"
+spl-token-2022 = { version = "0.7", path = "../../token/program-2022" }
+spl-token-collections-interface = { version = "0.1.0", path = "../interface" }
+spl-token-metadata-interface = { version = "0.1.0", path = "../../token-metadata/interface" }
+spl-type-length-value = { version = "0.2.0" , path = "../../libraries/type-length-value" }
+
+[dev-dependencies]
+solana-program-test = "1.16.3"
+solana-sdk = "1.16.3"
+spl-token-client = { version = "0.5", path = "../../token/client" }
+test-case = "3.1"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/collections/example/src/entrypoint.rs
+++ b/collections/example/src/entrypoint.rs
@@ -1,0 +1,24 @@
+//! Program entrypoint
+
+use {
+    crate::processor,
+    solana_program::{
+        account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,
+        program_error::PrintProgramError, pubkey::Pubkey,
+    },
+    spl_token_collections_interface::error::TokenCollectionsError,
+};
+
+entrypoint!(process_instruction);
+fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    if let Err(error) = processor::process(program_id, accounts, instruction_data) {
+        // catch the error so we can print it
+        error.print::<TokenCollectionsError>();
+        return Err(error);
+    }
+    Ok(())
+}

--- a/collections/example/src/lib.rs
+++ b/collections/example/src/lib.rs
@@ -1,0 +1,10 @@
+//! Crate defining an example program for creating SPL token collections
+
+#![allow(clippy::integer_arithmetic)]
+#![deny(missing_docs)]
+#![cfg_attr(not(test), forbid(unsafe_code))]
+
+pub mod processor;
+
+#[cfg(not(feature = "no-entrypoint"))]
+mod entrypoint;

--- a/collections/example/src/processor.rs
+++ b/collections/example/src/processor.rs
@@ -1,0 +1,302 @@
+//! Program state processor
+
+use {
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        borsh::get_instance_packed_len,
+        entrypoint::ProgramResult,
+        msg,
+        program::set_return_data,
+        program_error::ProgramError,
+        program_option::COption,
+        pubkey::Pubkey,
+    },
+    spl_token_2022::{extension::StateWithExtensions, state::Mint},
+    spl_token_collections_interface::{
+        error::TokenCollectionsError,
+        instruction::{
+            CreateCollection, CreateMember, Emit, ItemType, TokenCollectionsInstruction,
+            UpdateCollectionAuthority, UpdateCollectionMaxSize,
+        },
+        state::{get_emit_slice, Collection, Member, OptionalNonZeroPubkey},
+    },
+    spl_type_length_value::state::{
+        realloc_and_pack_variable_len, TlvState, TlvStateBorrowed, TlvStateMut,
+    },
+};
+
+fn check_update_authority(
+    update_authority_info: &AccountInfo,
+    expected_update_authority: &OptionalNonZeroPubkey,
+) -> Result<(), ProgramError> {
+    if !update_authority_info.is_signer {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+    let update_authority = Option::<Pubkey>::from(expected_update_authority.clone())
+        .ok_or(TokenCollectionsError::ImmutableCollection)?;
+    if update_authority != *update_authority_info.key {
+        return Err(TokenCollectionsError::IncorrectUpdateAuthority.into());
+    }
+    Ok(())
+}
+
+/// Processes a [CreateCollection](enum.TokenCollectionsInstruction.html)
+/// instruction.
+pub fn process_create_collection(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    data: CreateCollection,
+) -> ProgramResult {
+    // Assumes one has already created a mint for the
+    // collection.
+    let account_info_iter = &mut accounts.iter();
+
+    // Accounts expected by this instruction:
+    //
+    //   0. `[w]`  Collection
+    //   1. `[]`   Mint
+    //   2. `[s]`  Mint authority
+    let collection_info = next_account_info(account_info_iter)?;
+    let mint_info = next_account_info(account_info_iter)?;
+    let mint_authority_info = next_account_info(account_info_iter)?;
+
+    {
+        // IMPORTANT: this example program is designed to work with any
+        // program that implements the SPL token interface, so there is no
+        // ownership check on the mint account.
+        let mint_data = mint_info.try_borrow_data()?;
+        let mint = StateWithExtensions::<Mint>::unpack(&mint_data)?;
+
+        if !mint_authority_info.is_signer {
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+        if mint.base.mint_authority.as_ref() != COption::Some(mint_authority_info.key) {
+            return Err(TokenCollectionsError::IncorrectMintAuthority.into());
+        }
+    }
+
+    let collection = Collection::new(data.update_authority, data.max_size);
+    let instance_size = get_instance_packed_len(&collection)?;
+
+    // Allocate a TLV entry for the space and write it in
+    let mut buffer = collection_info.try_borrow_mut_data()?;
+    let mut state = TlvStateMut::unpack(&mut buffer)?;
+    state.alloc::<Collection>(instance_size)?;
+    state.pack_variable_len_value(&collection)?;
+
+    Ok(())
+}
+
+/// Processes an
+/// [UpdateCollectionMaxSize](enum.TokenCollectionsInstruction.html)
+/// instruction.
+pub fn process_update_collection_max_size(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    data: UpdateCollectionMaxSize,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    // Accounts expected by this instruction:
+    //
+    //   0. `[w]`  Collection
+    //   1. `[s]`  Update authority
+    let collection_info = next_account_info(account_info_iter)?;
+    let update_authority_info = next_account_info(account_info_iter)?;
+
+    let mut collection = {
+        let buffer = collection_info.try_borrow_data()?;
+        let state = TlvStateBorrowed::unpack(&buffer)?;
+        state.get_variable_len_value::<Collection>()?
+    };
+
+    check_update_authority(update_authority_info, &collection.update_authority)?;
+
+    // Update the max size
+    collection.update_max_size(data.max_size)?;
+
+    // Update the account, no realloc needed!
+    realloc_and_pack_variable_len(collection_info, &collection)?;
+
+    Ok(())
+}
+
+/// Processes a
+/// [UpdateCollectionAuthority](enum.TokenCollectionsInstruction.html)
+/// instruction.
+pub fn process_update_collection_authority(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    data: UpdateCollectionAuthority,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    // Accounts expected by this instruction:
+    //
+    //   0. `[w]`  Collection
+    //   1. `[s]`  Current update authority
+    let collection_info = next_account_info(account_info_iter)?;
+    let update_authority_info = next_account_info(account_info_iter)?;
+
+    let mut collection = {
+        let buffer = collection_info.try_borrow_data()?;
+        let state = TlvStateBorrowed::unpack(&buffer)?;
+        state.get_variable_len_value::<Collection>()?
+    };
+
+    check_update_authority(update_authority_info, &collection.update_authority)?;
+
+    // Update the authority
+    collection.update_authority = data.new_authority;
+
+    // Update the account, no realloc needed!
+    realloc_and_pack_variable_len(collection_info, &collection)?;
+
+    Ok(())
+}
+
+/// Processes a [CreateMember](enum.TokenCollectionsInstruction.html)
+/// instruction.
+pub fn process_create_member(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    data: CreateMember,
+) -> ProgramResult {
+    // Assumes the `Collection` has already been created,
+    // as well as the mint for the member.
+    let account_info_iter = &mut accounts.iter();
+
+    // Accounts expected by this instruction:
+    //
+    //   0. `[w]`  Member
+    //   2. `[]`   Member Mint
+    //   7. `[s]`  Member Mint authority
+    //   3. `[w]`  Collection
+    //   6. `[]`   Collection Mint
+    //   7. `[s]`  Collection Mint authority
+    let member_info = next_account_info(account_info_iter)?;
+    let member_mint_info = next_account_info(account_info_iter)?;
+    let member_mint_authority_info = next_account_info(account_info_iter)?;
+    let collection_info = next_account_info(account_info_iter)?;
+    let collection_mint_info = next_account_info(account_info_iter)?;
+    let collection_mint_authority_info = next_account_info(account_info_iter)?;
+
+    // Mint checks on the member
+    {
+        // IMPORTANT: this example program is designed to work with any
+        // program that implements the SPL token interface, so there is no
+        // ownership check on the mint account.
+        let member_mint_data = member_mint_info.try_borrow_data()?;
+        let member_mint = StateWithExtensions::<Mint>::unpack(&member_mint_data)?;
+
+        if !member_mint_authority_info.is_signer {
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+        if member_mint.base.mint_authority.as_ref() != COption::Some(member_mint_authority_info.key)
+        {
+            return Err(TokenCollectionsError::IncorrectMintAuthority.into());
+        }
+    }
+
+    // Mint checks on the collection
+    {
+        // IMPORTANT: this example program is designed to work with any
+        // program that implements the SPL token interface, so there is no
+        // ownership check on the mint account.
+        let collection_mint_data = collection_mint_info.try_borrow_data()?;
+        let collection_mint = StateWithExtensions::<Mint>::unpack(&collection_mint_data)?;
+
+        if !collection_mint_authority_info.is_signer {
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+        if collection_mint.base.mint_authority.as_ref()
+            != COption::Some(collection_mint_authority_info.key)
+        {
+            return Err(TokenCollectionsError::IncorrectMintAuthority.into());
+        }
+    }
+
+    if data.collection != *collection_info.key {
+        return Err(TokenCollectionsError::IncorrectCollection.into());
+    }
+
+    // Increment the size of the collection
+    let mut collection = {
+        let buffer = collection_info.try_borrow_data()?;
+        let state = TlvStateBorrowed::unpack(&buffer)?;
+        state.get_variable_len_value::<Collection>()?
+    };
+    collection.update_size(collection.size + 1)?;
+    realloc_and_pack_variable_len(collection_info, &collection)?;
+
+    // Create the new collection member
+    let member = Member {
+        collection: data.collection,
+    };
+    let instance_size = get_instance_packed_len(&member)?;
+
+    // allocate a TLV entry for the space and write it in
+    let mut buffer = member_info.try_borrow_mut_data()?;
+    let mut state = TlvStateMut::unpack(&mut buffer)?;
+    state.alloc::<Member>(instance_size)?;
+    state.pack_variable_len_value(&member)?;
+
+    Ok(())
+}
+
+/// Processes an [Emit](enum.TokenCollectionsInstruction.html) instruction.
+pub fn process_emit(program_id: &Pubkey, accounts: &[AccountInfo], data: Emit) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    // Accounts expected by this instruction:
+    //
+    //   0. `[]` Collection or Member account
+    let print_info = next_account_info(account_info_iter)?;
+
+    if print_info.owner != program_id {
+        return Err(ProgramError::IllegalOwner);
+    }
+
+    let buffer = print_info.try_borrow_data()?;
+    let state = TlvStateBorrowed::unpack(&buffer)?;
+
+    // `print_type` determines which asset we're working with
+    let item_bytes = match data.item_type {
+        ItemType::Collection => state.get_bytes::<Collection>()?,
+        ItemType::Member => state.get_bytes::<Member>()?,
+    };
+
+    if let Some(range) = get_emit_slice(item_bytes, data.start, data.end) {
+        set_return_data(range);
+    }
+
+    Ok(())
+}
+
+/// Processes an [Instruction](enum.Instruction.html).
+pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> ProgramResult {
+    let instruction = TokenCollectionsInstruction::unpack(input)?;
+
+    match instruction {
+        TokenCollectionsInstruction::CreateCollection(data) => {
+            msg!("Instruction: CreateCollection");
+            process_create_collection(program_id, accounts, data)
+        }
+        TokenCollectionsInstruction::UpdateCollectionMaxSize(data) => {
+            msg!("Instruction: UpdateCollectionMaxSize");
+            process_update_collection_max_size(program_id, accounts, data)
+        }
+        TokenCollectionsInstruction::UpdateCollectionAuthority(data) => {
+            msg!("Instruction: UpdateCollectionAuthority");
+            process_update_collection_authority(program_id, accounts, data)
+        }
+        TokenCollectionsInstruction::CreateMember(data) => {
+            msg!("Instruction: CreateMember");
+            process_create_member(program_id, accounts, data)
+        }
+        TokenCollectionsInstruction::Emit(data) => {
+            msg!("Instruction: Emit");
+            process_emit(program_id, accounts, data)
+        }
+    }
+}

--- a/collections/example/tests/create_collection.rs
+++ b/collections/example/tests/create_collection.rs
@@ -1,0 +1,337 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+use {
+    program_test::{setup, setup_collection, setup_metadata, setup_mint},
+    solana_program_test::tokio,
+    solana_sdk::{
+        instruction::InstructionError,
+        pubkey::Pubkey,
+        signature::Signer,
+        signer::keypair::Keypair,
+        system_instruction,
+        transaction::{Transaction, TransactionError},
+    },
+    spl_token_collections_interface::{
+        error::TokenCollectionsError, instruction::create_collection, state::Collection,
+    },
+    spl_token_metadata_interface::state::TokenMetadata,
+    spl_type_length_value::{
+        error::TlvError,
+        state::{TlvState, TlvStateBorrowed},
+    },
+};
+
+#[tokio::test]
+async fn success_create_collection() {
+    let program_id = Pubkey::new_unique();
+    let (context, client, payer) = setup(&program_id).await;
+
+    let mint_authority = Keypair::new();
+    let mint_authority_pubkey = mint_authority.pubkey();
+
+    let token_program_id = spl_token_2022::id();
+    let decimals = 0;
+
+    let update_authority = Pubkey::new_unique();
+
+    let metadata_keypair = Keypair::new();
+    let metadata_pubkey = metadata_keypair.pubkey();
+
+    let token = setup_mint(
+        &token_program_id,
+        &mint_authority_pubkey,
+        &metadata_pubkey,
+        &update_authority,
+        decimals,
+        payer.clone(),
+        client.clone(),
+    )
+    .await;
+
+    let name = "My Cool Collection".to_string();
+    let symbol = "COOL".to_string();
+    let uri = "cool.collection.com".to_string();
+    let token_metadata = TokenMetadata {
+        name,
+        symbol,
+        uri,
+        update_authority: Some(update_authority).try_into().unwrap(),
+        mint: *token.get_address(),
+        ..Default::default()
+    };
+
+    setup_metadata(
+        &token,
+        &update_authority,
+        &token_metadata,
+        &metadata_keypair,
+        &mint_authority,
+        payer.clone(),
+    )
+    .await;
+    let mut context = context.lock().await;
+
+    let collection_keypair = Keypair::new();
+    let collection_pubkey = collection_keypair.pubkey();
+
+    let collection_data = Collection {
+        update_authority: Some(update_authority).try_into().unwrap(),
+        max_size: Some(100),
+        size: 0,
+    };
+
+    setup_collection(
+        &mut context,
+        &program_id,
+        token.get_address(),
+        &collection_data,
+        &collection_keypair,
+        &mint_authority,
+    )
+    .await;
+
+    let fetched_collection_account = context
+        .banks_client
+        .get_account(collection_pubkey)
+        .await
+        .unwrap()
+        .unwrap();
+    let fetched_collection_state =
+        TlvStateBorrowed::unpack(&fetched_collection_account.data).unwrap();
+    let fetched_collection_data = fetched_collection_state
+        .get_variable_len_value::<Collection>()
+        .unwrap();
+    assert_eq!(fetched_collection_data, collection_data);
+
+    // Fail doing it again, and change some params to ensure a new tx
+    {
+        let transaction = Transaction::new_signed_with_payer(
+            &[create_collection(
+                &program_id,
+                &collection_keypair.pubkey(),
+                token.get_address(),
+                &mint_authority.pubkey(),
+                None, // Intentionally changed params
+                Some(500),
+            )],
+            Some(&payer.pubkey()),
+            &[&payer, &mint_authority],
+            context.last_blockhash,
+        );
+        let error = context
+            .banks_client
+            .process_transaction(transaction)
+            .await
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(
+            error,
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TlvError::TypeAlreadyExists as u32)
+            )
+        );
+    }
+}
+
+#[tokio::test]
+async fn fail_without_authority_signature() {
+    let program_id = Pubkey::new_unique();
+    let (context, client, payer) = setup(&program_id).await;
+
+    let mint_authority = Keypair::new();
+    let mint_authority_pubkey = mint_authority.pubkey();
+
+    let token_program_id = spl_token_2022::id();
+    let decimals = 0;
+
+    let update_authority = Pubkey::new_unique();
+
+    let metadata_keypair = Keypair::new();
+    let metadata_pubkey = metadata_keypair.pubkey();
+
+    let token = setup_mint(
+        &token_program_id,
+        &mint_authority_pubkey,
+        &metadata_pubkey,
+        &update_authority,
+        decimals,
+        payer.clone(),
+        client.clone(),
+    )
+    .await;
+
+    let name = "My Cool Collection Print".to_string();
+    let symbol = "COOL".to_string();
+    let uri = "cool.collection.print".to_string();
+    let token_metadata = TokenMetadata {
+        name,
+        symbol,
+        uri,
+        update_authority: Some(update_authority).try_into().unwrap(),
+        mint: *token.get_address(),
+        ..Default::default()
+    };
+
+    setup_metadata(
+        &token,
+        &update_authority,
+        &token_metadata,
+        &metadata_keypair,
+        &mint_authority,
+        payer.clone(),
+    )
+    .await;
+    let mut context = context.lock().await;
+
+    let collection_keypair = Keypair::new();
+    let collection_pubkey = collection_keypair.pubkey();
+
+    let collection_data = Collection {
+        update_authority: Some(update_authority).try_into().unwrap(),
+        max_size: Some(100),
+        size: 0,
+    };
+
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let space = collection_data.tlv_size_of().unwrap();
+    let rent_lamports = rent.minimum_balance(space);
+    let mut create_collection_ix = create_collection(
+        &program_id,
+        &collection_keypair.pubkey(),
+        token.get_address(),
+        &mint_authority.pubkey(),
+        Option::<Pubkey>::from(collection_data.update_authority.clone()),
+        collection_data.max_size,
+    );
+    create_collection_ix.accounts[2].is_signer = false;
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &collection_pubkey,
+                rent_lamports,
+                space.try_into().unwrap(),
+                &program_id,
+            ),
+            create_collection_ix,
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &collection_keypair], // Missing mint authority
+        context.last_blockhash,
+    );
+
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(1, InstructionError::MissingRequiredSignature,)
+    );
+}
+
+#[tokio::test]
+async fn fail_incorrect_authority() {
+    let program_id = Pubkey::new_unique();
+    let (context, client, payer) = setup(&program_id).await;
+
+    let mint_authority = Keypair::new();
+    let mint_authority_pubkey = mint_authority.pubkey();
+
+    let token_program_id = spl_token_2022::id();
+    let decimals = 0;
+
+    let update_authority = Pubkey::new_unique();
+
+    let metadata_keypair = Keypair::new();
+    let metadata_pubkey = metadata_keypair.pubkey();
+
+    let token = setup_mint(
+        &token_program_id,
+        &mint_authority_pubkey,
+        &metadata_pubkey,
+        &update_authority,
+        decimals,
+        payer.clone(),
+        client.clone(),
+    )
+    .await;
+
+    let name = "My Cool Collection Print".to_string();
+    let symbol = "COOL".to_string();
+    let uri = "cool.collection.print".to_string();
+    let token_metadata = TokenMetadata {
+        name,
+        symbol,
+        uri,
+        update_authority: Some(update_authority).try_into().unwrap(),
+        mint: *token.get_address(),
+        ..Default::default()
+    };
+
+    setup_metadata(
+        &token,
+        &update_authority,
+        &token_metadata,
+        &metadata_keypair,
+        &mint_authority,
+        payer.clone(),
+    )
+    .await;
+    let mut context = context.lock().await;
+
+    let collection_keypair = Keypair::new();
+    let collection_pubkey = collection_keypair.pubkey();
+
+    let collection_data = Collection {
+        update_authority: Some(update_authority).try_into().unwrap(),
+        max_size: Some(100),
+        size: 0,
+    };
+
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let space = collection_data.tlv_size_of().unwrap();
+    let rent_lamports = rent.minimum_balance(space);
+    let mut create_collection_ix = create_collection(
+        &program_id,
+        &collection_keypair.pubkey(),
+        token.get_address(),
+        &collection_keypair.pubkey(), // NOT the mint authority
+        Option::<Pubkey>::from(collection_data.update_authority.clone()),
+        collection_data.max_size,
+    );
+    create_collection_ix.accounts[2].is_signer = false;
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &collection_pubkey,
+                rent_lamports,
+                space.try_into().unwrap(),
+                &program_id,
+            ),
+            create_collection_ix,
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &collection_keypair],
+        context.last_blockhash,
+    );
+
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(
+            1,
+            InstructionError::Custom(TokenCollectionsError::IncorrectMintAuthority as u32)
+        )
+    );
+}

--- a/collections/example/tests/create_collection.rs
+++ b/collections/example/tests/create_collection.rs
@@ -162,9 +162,9 @@ async fn fail_without_authority_signature() {
     )
     .await;
 
-    let name = "My Cool Collection Print".to_string();
+    let name = "My Cool Collection".to_string();
     let symbol = "COOL".to_string();
-    let uri = "cool.collection.print".to_string();
+    let uri = "cool.collection.com".to_string();
     let token_metadata = TokenMetadata {
         name,
         symbol,
@@ -261,9 +261,9 @@ async fn fail_incorrect_authority() {
     )
     .await;
 
-    let name = "My Cool Collection Print".to_string();
+    let name = "My Cool Collection".to_string();
     let symbol = "COOL".to_string();
-    let uri = "cool.collection.print".to_string();
+    let uri = "cool.collection.com".to_string();
     let token_metadata = TokenMetadata {
         name,
         symbol,

--- a/collections/example/tests/create_member.rs
+++ b/collections/example/tests/create_member.rs
@@ -1,0 +1,536 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+use {
+    program_test::{setup, setup_collection, setup_member, setup_metadata, setup_mint},
+    solana_program_test::tokio,
+    solana_sdk::{
+        instruction::InstructionError,
+        pubkey::Pubkey,
+        signature::Signer,
+        signer::keypair::Keypair,
+        system_instruction,
+        transaction::{Transaction, TransactionError},
+    },
+    spl_token_collections_interface::{
+        error::TokenCollectionsError,
+        instruction::create_member,
+        state::{Collection, Member},
+    },
+    spl_token_metadata_interface::state::TokenMetadata,
+    spl_type_length_value::state::{TlvState, TlvStateBorrowed},
+};
+
+#[tokio::test]
+async fn success_create_member() {
+    let program_id = Pubkey::new_unique();
+    let (context, client, payer) = setup(&program_id).await;
+
+    let mint_authority = Keypair::new();
+    let mint_authority_pubkey = mint_authority.pubkey();
+
+    let token_program_id = spl_token_2022::id();
+    let decimals = 0;
+
+    let update_authority_keypair = Keypair::new();
+    let update_authority_pubkey = update_authority_keypair.pubkey();
+
+    let collection_metadata_keypair = Keypair::new();
+    let collection_metadata_pubkey = collection_metadata_keypair.pubkey();
+
+    let collection_token = setup_mint(
+        &token_program_id,
+        &mint_authority_pubkey,
+        &collection_metadata_pubkey,
+        &update_authority_pubkey,
+        decimals,
+        payer.clone(),
+        client.clone(),
+    )
+    .await;
+
+    let member_metadata_keypair = Keypair::new();
+    let member_metadata_pubkey = member_metadata_keypair.pubkey();
+
+    let member_token = setup_mint(
+        &token_program_id,
+        &mint_authority_pubkey,
+        &member_metadata_pubkey,
+        &update_authority_pubkey,
+        decimals,
+        payer.clone(),
+        client.clone(),
+    )
+    .await;
+
+    let name = "My Cool Collection Print".to_string();
+    let symbol = "COOL".to_string();
+    let uri = "cool.collection.print".to_string();
+    let token_metadata = TokenMetadata {
+        name,
+        symbol,
+        uri,
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        mint: *collection_token.get_address(),
+        ..Default::default()
+    };
+
+    setup_metadata(
+        &collection_token,
+        &update_authority_pubkey,
+        &token_metadata,
+        &collection_metadata_keypair,
+        &mint_authority,
+        payer.clone(),
+    )
+    .await;
+    let mut context = context.lock().await;
+
+    let collection_keypair = Keypair::new();
+    let collection_pubkey = collection_keypair.pubkey();
+
+    let collection = Collection {
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        max_size: Some(100),
+        size: 0,
+    };
+
+    setup_collection(
+        &mut context,
+        &program_id,
+        collection_token.get_address(),
+        &collection,
+        &collection_keypair,
+        &mint_authority,
+    )
+    .await;
+
+    let member_keypair = Keypair::new();
+    let member_pubkey = member_keypair.pubkey();
+
+    let member = Member {
+        collection: collection_pubkey,
+    };
+
+    setup_member(
+        &mut context,
+        &program_id,
+        member_token.get_address(),
+        &collection_pubkey,
+        collection_token.get_address(),
+        &member_keypair,
+        &mint_authority,
+        &mint_authority,
+    )
+    .await;
+
+    let fetched_member_account = context
+        .banks_client
+        .get_account(member_pubkey)
+        .await
+        .unwrap()
+        .unwrap();
+    let fetched_member_state = TlvStateBorrowed::unpack(&fetched_member_account.data).unwrap();
+    let fetched_member = fetched_member_state
+        .get_variable_len_value::<Member>()
+        .unwrap();
+    assert_eq!(fetched_member, member);
+}
+
+#[tokio::test]
+async fn fail_without_authority_signature() {
+    let program_id = Pubkey::new_unique();
+    let (context, client, payer) = setup(&program_id).await;
+
+    let collection_mint_authority = Keypair::new();
+    let collection_mint_authority_pubkey = collection_mint_authority.pubkey();
+
+    let member_mint_authority = Keypair::new();
+    let member_mint_authority_pubkey = member_mint_authority.pubkey();
+
+    let token_program_id = spl_token_2022::id();
+    let decimals = 0;
+
+    let update_authority_keypair = Keypair::new();
+    let update_authority_pubkey = update_authority_keypair.pubkey();
+
+    let collection_metadata_keypair = Keypair::new();
+    let collection_metadata_pubkey = collection_metadata_keypair.pubkey();
+
+    let collection_token = setup_mint(
+        &token_program_id,
+        &collection_mint_authority_pubkey,
+        &collection_metadata_pubkey,
+        &update_authority_pubkey,
+        decimals,
+        payer.clone(),
+        client.clone(),
+    )
+    .await;
+
+    let member_metadata_keypair = Keypair::new();
+    let member_metadata_pubkey = member_metadata_keypair.pubkey();
+
+    let member_token = setup_mint(
+        &token_program_id,
+        &member_mint_authority_pubkey,
+        &member_metadata_pubkey,
+        &update_authority_pubkey,
+        decimals,
+        payer.clone(),
+        client.clone(),
+    )
+    .await;
+
+    let name = "My Cool Collection Print".to_string();
+    let symbol = "COOL".to_string();
+    let uri = "cool.collection.print".to_string();
+    let token_metadata = TokenMetadata {
+        name,
+        symbol,
+        uri,
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        mint: *collection_token.get_address(),
+        ..Default::default()
+    };
+
+    setup_metadata(
+        &collection_token,
+        &update_authority_pubkey,
+        &token_metadata,
+        &collection_metadata_keypair,
+        &collection_mint_authority,
+        payer.clone(),
+    )
+    .await;
+    let mut context = context.lock().await;
+
+    let collection_keypair = Keypair::new();
+    let collection_pubkey = collection_keypair.pubkey();
+
+    let collection = Collection {
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        max_size: Some(100),
+        size: 0,
+    };
+
+    setup_collection(
+        &mut context,
+        &program_id,
+        collection_token.get_address(),
+        &collection,
+        &collection_keypair,
+        &collection_mint_authority,
+    )
+    .await;
+
+    let member_keypair = Keypair::new();
+    let _member_pubkey = member_keypair.pubkey();
+
+    let member_data = Member {
+        collection: collection_pubkey,
+    };
+
+    let rent = context.banks_client.get_rent().await.unwrap();
+
+    let token_metadata_space = token_metadata.tlv_size_of().unwrap();
+    let token_metadata_rent_lamports = rent.minimum_balance(token_metadata_space);
+
+    let member_space = member_data.tlv_size_of().unwrap();
+    let member_rent_lamports = rent.minimum_balance(member_space);
+
+    // Fail missing member mint authority
+
+    let mut create_member_ix = create_member(
+        &program_id,
+        &member_keypair.pubkey(),
+        member_token.get_address(),
+        &member_mint_authority.pubkey(),
+        &collection_keypair.pubkey(),
+        collection_token.get_address(),
+        &collection_mint_authority.pubkey(),
+    );
+    create_member_ix.accounts[2].is_signer = false;
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &member_keypair.pubkey(),
+                member_rent_lamports,
+                member_space.try_into().unwrap(),
+                &program_id,
+            ),
+            // Fund the mint with extra rent for metadata
+            system_instruction::transfer(
+                &context.payer.pubkey(),
+                member_token.get_address(),
+                token_metadata_rent_lamports,
+            ),
+            create_member_ix,
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &member_keypair, &collection_mint_authority], /* Missing member mint
+                                                                         * authority */
+        context.last_blockhash,
+    );
+
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(2, InstructionError::MissingRequiredSignature,)
+    );
+
+    // Fail missing collection mint authority
+
+    let mut create_member_ix = create_member(
+        &program_id,
+        &member_keypair.pubkey(),
+        member_token.get_address(),
+        &member_mint_authority.pubkey(),
+        &collection_keypair.pubkey(),
+        collection_token.get_address(),
+        &collection_mint_authority.pubkey(),
+    );
+    create_member_ix.accounts[5].is_signer = false;
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &member_keypair.pubkey(),
+                member_rent_lamports,
+                member_space.try_into().unwrap(),
+                &program_id,
+            ),
+            // Fund the mint with extra rent for metadata
+            system_instruction::transfer(
+                &context.payer.pubkey(),
+                member_token.get_address(),
+                token_metadata_rent_lamports,
+            ),
+            create_member_ix,
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &member_keypair, &member_mint_authority], /* Missing collection mint
+                                                                     * authority */
+        context.last_blockhash,
+    );
+
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(2, InstructionError::MissingRequiredSignature,)
+    );
+}
+
+#[tokio::test]
+async fn fail_incorrect_authority() {
+    let program_id = Pubkey::new_unique();
+    let (context, client, payer) = setup(&program_id).await;
+
+    let collection_mint_authority = Keypair::new();
+    let collection_mint_authority_pubkey = collection_mint_authority.pubkey();
+
+    let member_mint_authority = Keypair::new();
+    let member_mint_authority_pubkey = member_mint_authority.pubkey();
+
+    let token_program_id = spl_token_2022::id();
+    let decimals = 0;
+
+    let update_authority_keypair = Keypair::new();
+    let update_authority_pubkey = update_authority_keypair.pubkey();
+
+    let collection_metadata_keypair = Keypair::new();
+    let collection_metadata_pubkey = collection_metadata_keypair.pubkey();
+
+    let collection_token = setup_mint(
+        &token_program_id,
+        &collection_mint_authority_pubkey,
+        &collection_metadata_pubkey,
+        &update_authority_pubkey,
+        decimals,
+        payer.clone(),
+        client.clone(),
+    )
+    .await;
+
+    let member_metadata_keypair = Keypair::new();
+    let member_metadata_pubkey = member_metadata_keypair.pubkey();
+
+    let member_token = setup_mint(
+        &token_program_id,
+        &member_mint_authority_pubkey,
+        &member_metadata_pubkey,
+        &update_authority_pubkey,
+        decimals,
+        payer.clone(),
+        client.clone(),
+    )
+    .await;
+
+    let name = "My Cool Collection Print".to_string();
+    let symbol = "COOL".to_string();
+    let uri = "cool.collection.print".to_string();
+    let token_metadata = TokenMetadata {
+        name,
+        symbol,
+        uri,
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        mint: *collection_token.get_address(),
+        ..Default::default()
+    };
+
+    setup_metadata(
+        &collection_token,
+        &update_authority_pubkey,
+        &token_metadata,
+        &collection_metadata_keypair,
+        &collection_mint_authority,
+        payer.clone(),
+    )
+    .await;
+    let mut context = context.lock().await;
+
+    let collection_keypair = Keypair::new();
+    let collection_pubkey = collection_keypair.pubkey();
+
+    let collection = Collection {
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        max_size: Some(100),
+        size: 0,
+    };
+
+    setup_collection(
+        &mut context,
+        &program_id,
+        collection_token.get_address(),
+        &collection,
+        &collection_keypair,
+        &collection_mint_authority,
+    )
+    .await;
+
+    let member_keypair = Keypair::new();
+    let _member_pubkey = member_keypair.pubkey();
+
+    let member_data = Member {
+        collection: collection_pubkey,
+    };
+
+    let rent = context.banks_client.get_rent().await.unwrap();
+
+    let token_metadata_space = token_metadata.tlv_size_of().unwrap();
+    let token_metadata_rent_lamports = rent.minimum_balance(token_metadata_space);
+
+    let member_space = member_data.tlv_size_of().unwrap();
+    let member_rent_lamports = rent.minimum_balance(member_space);
+
+    // Fail incorrect member mint authority
+
+    let mut create_member_ix = create_member(
+        &program_id,
+        &member_keypair.pubkey(),
+        member_token.get_address(),
+        &collection_mint_authority.pubkey(), // NOT the member mint authority
+        &collection_keypair.pubkey(),
+        collection_token.get_address(),
+        &collection_mint_authority.pubkey(),
+    );
+    create_member_ix.accounts[2].is_signer = false;
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &member_keypair.pubkey(),
+                member_rent_lamports,
+                member_space.try_into().unwrap(),
+                &program_id,
+            ),
+            // Fund the mint with extra rent for metadata
+            system_instruction::transfer(
+                &context.payer.pubkey(),
+                member_token.get_address(),
+                token_metadata_rent_lamports,
+            ),
+            create_member_ix,
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &member_keypair, &collection_mint_authority],
+        context.last_blockhash,
+    );
+
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(
+            2,
+            InstructionError::Custom(TokenCollectionsError::IncorrectMintAuthority as u32)
+        )
+    );
+
+    // Fail missing collection mint authority
+
+    let mut create_member_ix = create_member(
+        &program_id,
+        &member_keypair.pubkey(),
+        member_token.get_address(),
+        &member_mint_authority.pubkey(),
+        &collection_keypair.pubkey(),
+        collection_token.get_address(),
+        &member_mint_authority.pubkey(), // NOT the collection mint authority
+    );
+    create_member_ix.accounts[5].is_signer = false;
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &member_keypair.pubkey(),
+                member_rent_lamports,
+                member_space.try_into().unwrap(),
+                &program_id,
+            ),
+            // Fund the mint with extra rent for metadata
+            system_instruction::transfer(
+                &context.payer.pubkey(),
+                member_token.get_address(),
+                token_metadata_rent_lamports,
+            ),
+            create_member_ix,
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &member_keypair, &member_mint_authority],
+        context.last_blockhash,
+    );
+
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(
+            2,
+            InstructionError::Custom(TokenCollectionsError::IncorrectMintAuthority as u32)
+        )
+    );
+}

--- a/collections/example/tests/create_member.rs
+++ b/collections/example/tests/create_member.rs
@@ -63,9 +63,9 @@ async fn success_create_member() {
     )
     .await;
 
-    let name = "My Cool Collection Print".to_string();
+    let name = "My Cool Collection".to_string();
     let symbol = "COOL".to_string();
-    let uri = "cool.collection.print".to_string();
+    let uri = "cool.collection.com".to_string();
     let token_metadata = TokenMetadata {
         name,
         symbol,
@@ -80,6 +80,30 @@ async fn success_create_member() {
         &update_authority_pubkey,
         &token_metadata,
         &collection_metadata_keypair,
+        &mint_authority,
+        payer.clone(),
+    )
+    .await;
+
+    // For demonstration purposes, we'll set up _different_ metadata for
+    // the collection member
+    let name = "I'm a member of the Cool Collection!".to_string();
+    let symbol = "YAY".to_string();
+    let uri = "i.am.a.member".to_string();
+    let token_metadata = TokenMetadata {
+        name,
+        symbol,
+        uri,
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        mint: *member_token.get_address(),
+        ..Default::default()
+    };
+
+    setup_metadata(
+        &member_token,
+        &update_authority_pubkey,
+        &token_metadata,
+        &member_metadata_keypair,
         &mint_authority,
         payer.clone(),
     )
@@ -182,9 +206,9 @@ async fn fail_without_authority_signature() {
     )
     .await;
 
-    let name = "My Cool Collection Print".to_string();
+    let name = "My Cool Collection".to_string();
     let symbol = "COOL".to_string();
-    let uri = "cool.collection.print".to_string();
+    let uri = "cool.collection.com".to_string();
     let token_metadata = TokenMetadata {
         name,
         symbol,
@@ -200,6 +224,30 @@ async fn fail_without_authority_signature() {
         &token_metadata,
         &collection_metadata_keypair,
         &collection_mint_authority,
+        payer.clone(),
+    )
+    .await;
+
+    // For demonstration purposes, we'll set up _different_ metadata for
+    // the collection member
+    let name = "I'm a member of the Cool Collection!".to_string();
+    let symbol = "YAY".to_string();
+    let uri = "i.am.a.member".to_string();
+    let token_metadata = TokenMetadata {
+        name,
+        symbol,
+        uri,
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        mint: *member_token.get_address(),
+        ..Default::default()
+    };
+
+    setup_metadata(
+        &member_token,
+        &update_authority_pubkey,
+        &token_metadata,
+        &member_metadata_keypair,
+        &member_mint_authority,
         payer.clone(),
     )
     .await;
@@ -379,9 +427,9 @@ async fn fail_incorrect_authority() {
     )
     .await;
 
-    let name = "My Cool Collection Print".to_string();
+    let name = "My Cool Collection".to_string();
     let symbol = "COOL".to_string();
-    let uri = "cool.collection.print".to_string();
+    let uri = "cool.collection.com".to_string();
     let token_metadata = TokenMetadata {
         name,
         symbol,
@@ -397,6 +445,30 @@ async fn fail_incorrect_authority() {
         &token_metadata,
         &collection_metadata_keypair,
         &collection_mint_authority,
+        payer.clone(),
+    )
+    .await;
+
+    // For demonstration purposes, we'll set up _different_ metadata for
+    // the collection member
+    let name = "I'm a member of the Cool Collection!".to_string();
+    let symbol = "YAY".to_string();
+    let uri = "i.am.a.member".to_string();
+    let token_metadata = TokenMetadata {
+        name,
+        symbol,
+        uri,
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        mint: *member_token.get_address(),
+        ..Default::default()
+    };
+
+    setup_metadata(
+        &member_token,
+        &update_authority_pubkey,
+        &token_metadata,
+        &member_metadata_keypair,
+        &member_mint_authority,
         payer.clone(),
     )
     .await;

--- a/collections/example/tests/emit.rs
+++ b/collections/example/tests/emit.rs
@@ -1,0 +1,208 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+use {
+    program_test::{setup, setup_collection, setup_member, setup_metadata, setup_mint},
+    solana_program_test::{tokio, ProgramTestContext},
+    solana_sdk::{
+        borsh::try_from_slice_unchecked, program::MAX_RETURN_DATA, pubkey::Pubkey,
+        signature::Signer, signer::keypair::Keypair, transaction::Transaction,
+    },
+    spl_token_collections_interface::{
+        borsh::{BorshDeserialize, BorshSerialize},
+        instruction::{emit, ItemType},
+        state::{get_emit_slice, Collection, Member},
+    },
+    spl_token_metadata_interface::state::TokenMetadata,
+    test_case::test_case,
+};
+
+#[allow(clippy::too_many_arguments)]
+async fn check_emit<V: BorshDeserialize + BorshSerialize + std::fmt::Debug + PartialEq>(
+    context: &mut ProgramTestContext,
+    item_type: ItemType,
+    print_buffer: Vec<u8>,
+    print_pubkey: &Pubkey,
+    start: Option<u64>,
+    end: Option<u64>,
+    program_id: &Pubkey,
+    payer: &Keypair,
+    check_print_data: V,
+) {
+    let transaction = Transaction::new_signed_with_payer(
+        &[emit(program_id, print_pubkey, item_type, start, end)],
+        Some(&payer.pubkey()),
+        &[payer],
+        context.last_blockhash,
+    );
+    let simulation = context
+        .banks_client
+        .simulate_transaction(transaction)
+        .await
+        .unwrap();
+
+    if let Some(check_buffer) = get_emit_slice(&print_buffer, start, end) {
+        if !check_buffer.is_empty() {
+            // pad the data if necessary
+            let mut return_data = vec![0; MAX_RETURN_DATA];
+            let simulation_return_data =
+                simulation.simulation_details.unwrap().return_data.unwrap();
+            assert_eq!(simulation_return_data.program_id, *program_id);
+            return_data[..simulation_return_data.data.len()]
+                .copy_from_slice(&simulation_return_data.data);
+
+            assert_eq!(*check_buffer, return_data[..check_buffer.len()]);
+            // we're sure that we're getting the full data, so also compare the deserialized
+            // type
+            if start.is_none() && end.is_none() {
+                let emitted_token_collection = try_from_slice_unchecked::<V>(&return_data).unwrap();
+                assert_eq!(check_print_data, emitted_token_collection);
+            }
+        } else {
+            assert!(simulation.simulation_details.unwrap().return_data.is_none());
+        }
+    } else {
+        assert!(simulation.simulation_details.unwrap().return_data.is_none());
+    }
+}
+
+#[test_case(Some(40), Some(40) ; "zero bytes")]
+#[test_case(Some(40), Some(41) ; "one byte")]
+#[test_case(Some(1_000_000), Some(1_000_001) ; "too far")]
+#[test_case(Some(50), Some(49) ; "wrong way")]
+#[test_case(Some(50), None ; "truncate start")]
+#[test_case(None, Some(50) ; "truncate end")]
+#[test_case(None, None ; "full data")]
+#[tokio::test]
+async fn success(start: Option<u64>, end: Option<u64>) {
+    let program_id = Pubkey::new_unique();
+    let (context, client, payer) = setup(&program_id).await;
+
+    let mint_authority = Keypair::new();
+    let mint_authority_pubkey = mint_authority.pubkey();
+
+    let token_program_id = spl_token_2022::id();
+    let decimals = 0;
+
+    let update_authority_keypair = Keypair::new();
+    let update_authority_pubkey = update_authority_keypair.pubkey();
+
+    let collection_metadata_keypair = Keypair::new();
+    let collection_metadata_pubkey = collection_metadata_keypair.pubkey();
+
+    let collection_token = setup_mint(
+        &token_program_id,
+        &mint_authority_pubkey,
+        &collection_metadata_pubkey,
+        &update_authority_pubkey,
+        decimals,
+        payer.clone(),
+        client.clone(),
+    )
+    .await;
+
+    let member_metadata_keypair = Keypair::new();
+    let member_metadata_pubkey = member_metadata_keypair.pubkey();
+
+    let member_token = setup_mint(
+        &token_program_id,
+        &mint_authority_pubkey,
+        &member_metadata_pubkey,
+        &update_authority_pubkey,
+        decimals,
+        payer.clone(),
+        client.clone(),
+    )
+    .await;
+
+    let name = "My Cool Collection Print".to_string();
+    let symbol = "COOL".to_string();
+    let uri = "cool.collection.print".to_string();
+    let token_metadata = TokenMetadata {
+        name,
+        symbol,
+        uri,
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        mint: *collection_token.get_address(),
+        ..Default::default()
+    };
+
+    setup_metadata(
+        &collection_token,
+        &update_authority_pubkey,
+        &token_metadata,
+        &collection_metadata_keypair,
+        &mint_authority,
+        payer.clone(),
+    )
+    .await;
+    let mut context = context.lock().await;
+
+    let collection_keypair = Keypair::new();
+    let collection_pubkey = collection_keypair.pubkey();
+
+    let collection = Collection {
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        max_size: Some(100),
+        size: 1, // Supply will be 1 after printing a member
+    };
+
+    setup_collection(
+        &mut context,
+        &program_id,
+        collection_token.get_address(),
+        &collection,
+        &collection_keypair,
+        &mint_authority,
+    )
+    .await;
+
+    let member_keypair = Keypair::new();
+    let member_pubkey = member_keypair.pubkey();
+
+    let member = Member {
+        collection: collection_pubkey,
+    };
+
+    setup_member(
+        &mut context,
+        &program_id,
+        member_token.get_address(),
+        &collection_pubkey,
+        collection_token.get_address(),
+        &member_keypair,
+        &mint_authority,
+        &mint_authority,
+    )
+    .await;
+
+    // Collection
+    let collection_buffer = collection.try_to_vec().unwrap();
+    check_emit::<Collection>(
+        &mut context,
+        ItemType::Collection,
+        collection_buffer,
+        &collection_pubkey,
+        start,
+        end,
+        &program_id,
+        &payer,
+        collection,
+    )
+    .await;
+
+    // Member
+    let member_buffer = member.try_to_vec().unwrap();
+    check_emit::<Member>(
+        &mut context,
+        ItemType::Member,
+        member_buffer,
+        &member_pubkey,
+        start,
+        end,
+        &program_id,
+        &payer,
+        member,
+    )
+    .await;
+}

--- a/collections/example/tests/emit.rs
+++ b/collections/example/tests/emit.rs
@@ -115,9 +115,9 @@ async fn success(start: Option<u64>, end: Option<u64>) {
     )
     .await;
 
-    let name = "My Cool Collection Print".to_string();
+    let name = "My Cool Collection".to_string();
     let symbol = "COOL".to_string();
-    let uri = "cool.collection.print".to_string();
+    let uri = "cool.collection.com".to_string();
     let token_metadata = TokenMetadata {
         name,
         symbol,
@@ -132,6 +132,30 @@ async fn success(start: Option<u64>, end: Option<u64>) {
         &update_authority_pubkey,
         &token_metadata,
         &collection_metadata_keypair,
+        &mint_authority,
+        payer.clone(),
+    )
+    .await;
+
+    // For demonstration purposes, we'll set up _different_ metadata for
+    // the collection member
+    let name = "I'm a member of the Cool Collection!".to_string();
+    let symbol = "YAY".to_string();
+    let uri = "i.am.a.member".to_string();
+    let token_metadata = TokenMetadata {
+        name,
+        symbol,
+        uri,
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        mint: *member_token.get_address(),
+        ..Default::default()
+    };
+
+    setup_metadata(
+        &member_token,
+        &update_authority_pubkey,
+        &token_metadata,
+        &member_metadata_keypair,
         &mint_authority,
         payer.clone(),
     )

--- a/collections/example/tests/program_test.rs
+++ b/collections/example/tests/program_test.rs
@@ -1,0 +1,205 @@
+#![cfg(feature = "test-sbf")]
+
+use {
+    solana_program_test::{processor, tokio::sync::Mutex, ProgramTest, ProgramTestContext},
+    solana_sdk::{
+        pubkey::Pubkey, signature::Signer, signer::keypair::Keypair, system_instruction,
+        transaction::Transaction,
+    },
+    spl_token_client::{
+        client::{
+            ProgramBanksClient, ProgramBanksClientProcessTransaction, ProgramClient,
+            SendTransaction,
+        },
+        token::{ExtensionInitializationParams, Token},
+    },
+    spl_token_collections_interface::{
+        instruction::{create_collection, create_member},
+        state::{Collection, Member},
+    },
+    spl_token_metadata_interface::state::TokenMetadata,
+    std::sync::Arc,
+};
+
+fn keypair_clone(kp: &Keypair) -> Keypair {
+    Keypair::from_bytes(&kp.to_bytes()).expect("failed to copy keypair")
+}
+
+pub async fn setup(
+    program_id: &Pubkey,
+) -> (
+    Arc<Mutex<ProgramTestContext>>,
+    Arc<dyn ProgramClient<ProgramBanksClientProcessTransaction>>,
+    Arc<Keypair>,
+) {
+    let mut program_test = ProgramTest::new(
+        "spl_token_collections_example",
+        *program_id,
+        processor!(spl_token_collections_example::processor::process),
+    );
+
+    program_test.prefer_bpf(false); // simplicity in the build
+    program_test.add_program(
+        "spl_token_2022",
+        spl_token_2022::id(),
+        processor!(spl_token_2022::processor::Processor::process),
+    );
+
+    let context = program_test.start_with_context().await;
+    let payer = Arc::new(keypair_clone(&context.payer));
+    let context = Arc::new(Mutex::new(context));
+
+    let client: Arc<dyn ProgramClient<ProgramBanksClientProcessTransaction>> =
+        Arc::new(ProgramBanksClient::new_from_context(
+            Arc::clone(&context),
+            ProgramBanksClientProcessTransaction,
+        ));
+    (context, client, payer)
+}
+
+pub async fn setup_mint<T: SendTransaction>(
+    program_id: &Pubkey,
+    mint_authority: &Pubkey,
+    metadata: &Pubkey,
+    update_authority: &Pubkey,
+    decimals: u8,
+    payer: Arc<Keypair>,
+    client: Arc<dyn ProgramClient<T>>,
+) -> Token<T> {
+    let mint_account = Keypair::new();
+    let token = Token::new(
+        client,
+        program_id,
+        &mint_account.pubkey(),
+        Some(decimals),
+        payer,
+    );
+    token
+        .create_mint(
+            mint_authority,
+            None,
+            vec![ExtensionInitializationParams::MetadataPointer {
+                authority: Some(*update_authority),
+                metadata_address: Some(*metadata),
+            }],
+            &[&mint_account],
+        )
+        .await
+        .unwrap();
+    token
+}
+
+pub async fn setup_metadata<T: SendTransaction>(
+    token: &Token<T>,
+    update_authority: &Pubkey,
+    token_metadata: &TokenMetadata,
+    _metadata_keypair: &Keypair,
+    mint_authority: &Keypair,
+    payer: Arc<Keypair>,
+) {
+    token
+        .token_metadata_initialize_with_rent_transfer(
+            &payer.pubkey(),
+            update_authority,
+            &mint_authority.pubkey(),
+            token_metadata.name.clone(),
+            token_metadata.symbol.clone(),
+            token_metadata.uri.clone(),
+            &[&payer, mint_authority],
+        )
+        .await
+        .unwrap();
+}
+
+pub async fn setup_collection(
+    context: &mut ProgramTestContext,
+    collections_program_id: &Pubkey,
+    mint: &Pubkey,
+    collection_data: &Collection,
+    collection_keypair: &Keypair,
+    mint_authority: &Keypair,
+) {
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let space = collection_data.tlv_size_of().unwrap();
+    let rent_lamports = rent.minimum_balance(space);
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &collection_keypair.pubkey(),
+                rent_lamports,
+                space.try_into().unwrap(),
+                collections_program_id,
+            ),
+            create_collection(
+                collections_program_id,
+                &collection_keypair.pubkey(),
+                mint,
+                &mint_authority.pubkey(),
+                Option::<Pubkey>::from(collection_data.update_authority.clone()),
+                collection_data.max_size,
+            ),
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, collection_keypair, mint_authority],
+        context.last_blockhash,
+    );
+
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+}
+
+#[allow(clippy::too_many_arguments)]
+#[allow(dead_code)]
+pub async fn setup_member(
+    context: &mut ProgramTestContext,
+    collections_program_id: &Pubkey,
+    member_mint: &Pubkey,
+    collection_pubkey: &Pubkey,
+    collection_mint: &Pubkey,
+    member_keypair: &Keypair,
+    member_mint_authority: &Keypair,
+    collection_mint_authority: &Keypair,
+) {
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let member_space = Member::default().tlv_size_of().unwrap();
+    let member_rent_lamports = rent.minimum_balance(member_space);
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &member_keypair.pubkey(),
+                member_rent_lamports,
+                member_space.try_into().unwrap(),
+                collections_program_id,
+            ),
+            create_member(
+                collections_program_id,
+                &member_keypair.pubkey(),
+                member_mint,
+                &member_mint_authority.pubkey(),
+                collection_pubkey,
+                collection_mint,
+                &collection_mint_authority.pubkey(),
+            ),
+        ],
+        Some(&context.payer.pubkey()),
+        &[
+            &context.payer,
+            member_keypair,
+            member_mint_authority,
+            collection_mint_authority,
+        ],
+        context.last_blockhash,
+    );
+
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+}

--- a/collections/example/tests/update_collection_authority.rs
+++ b/collections/example/tests/update_collection_authority.rs
@@ -1,0 +1,290 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+use {
+    program_test::{setup, setup_collection, setup_metadata, setup_mint},
+    solana_program_test::tokio,
+    solana_sdk::{
+        instruction::InstructionError,
+        pubkey::Pubkey,
+        signature::Signer,
+        signer::keypair::Keypair,
+        transaction::{Transaction, TransactionError},
+    },
+    spl_token_collections_interface::{
+        error::TokenCollectionsError, instruction::update_collection_authority, state::Collection,
+    },
+    spl_token_metadata_interface::state::TokenMetadata,
+    spl_type_length_value::state::{TlvState, TlvStateBorrowed},
+};
+
+#[tokio::test]
+async fn success_update_collection_max_size() {
+    let program_id = Pubkey::new_unique();
+    let (context, client, payer) = setup(&program_id).await;
+
+    let mint_authority = Keypair::new();
+    let mint_authority_pubkey = mint_authority.pubkey();
+
+    let token_program_id = spl_token_2022::id();
+    let decimals = 0;
+
+    let update_authority_keypair = Keypair::new();
+    let update_authority_pubkey = update_authority_keypair.pubkey();
+
+    let metadata_keypair = Keypair::new();
+    let metadata_pubkey = metadata_keypair.pubkey();
+
+    let token = setup_mint(
+        &token_program_id,
+        &mint_authority_pubkey,
+        &metadata_pubkey,
+        &update_authority_pubkey,
+        decimals,
+        payer.clone(),
+        client.clone(),
+    )
+    .await;
+
+    let name = "My Cool Collection".to_string();
+    let symbol = "COOL".to_string();
+    let uri = "cool.collection.print".to_string();
+    let token_metadata = TokenMetadata {
+        name,
+        symbol,
+        uri,
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        mint: *token.get_address(),
+        ..Default::default()
+    };
+
+    setup_metadata(
+        &token,
+        &update_authority_pubkey,
+        &token_metadata,
+        &metadata_keypair,
+        &mint_authority,
+        payer.clone(),
+    )
+    .await;
+    let mut context = context.lock().await;
+
+    let collection_keypair = Keypair::new();
+    let collection_pubkey = collection_keypair.pubkey();
+
+    let collection = Collection {
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        max_size: Some(100),
+        size: 0,
+    };
+
+    setup_collection(
+        &mut context,
+        &program_id,
+        token.get_address(),
+        &collection,
+        &collection_keypair,
+        &mint_authority,
+    )
+    .await;
+
+    // Can change to new pubkey
+
+    let new_authority_keypair = Keypair::new();
+    let new_authority_pubkey = new_authority_keypair.pubkey();
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[update_collection_authority(
+            &program_id,
+            &collection_pubkey,
+            &update_authority_pubkey,
+            Some(new_authority_pubkey),
+        )],
+        Some(&payer.pubkey()),
+        &[&payer, &update_authority_keypair],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+
+    let fetched_collection_account = context
+        .banks_client
+        .get_account(collection_pubkey)
+        .await
+        .unwrap()
+        .unwrap();
+    let fetched_collection_state =
+        TlvStateBorrowed::unpack(&fetched_collection_account.data).unwrap();
+    let fetched_collection = fetched_collection_state
+        .get_variable_len_value::<Collection>()
+        .unwrap();
+    assert_eq!(
+        Option::<Pubkey>::from(fetched_collection.update_authority),
+        Some(new_authority_pubkey),
+    );
+
+    // Can change to `None`
+
+    let second_new_authority = None;
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[update_collection_authority(
+            &program_id,
+            &collection_pubkey,
+            &new_authority_pubkey,
+            second_new_authority,
+        )],
+        Some(&payer.pubkey()),
+        &[&payer, &new_authority_keypair],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+
+    let fetched_collection_account = context
+        .banks_client
+        .get_account(collection_pubkey)
+        .await
+        .unwrap()
+        .unwrap();
+    let fetched_collection_state =
+        TlvStateBorrowed::unpack(&fetched_collection_account.data).unwrap();
+    let fetched_collection = fetched_collection_state
+        .get_variable_len_value::<Collection>()
+        .unwrap();
+    assert_eq!(
+        Option::<Pubkey>::from(fetched_collection.update_authority),
+        second_new_authority
+    );
+}
+
+#[tokio::test]
+async fn fail_authority_checks() {
+    let program_id = Pubkey::new_unique();
+    let (context, client, payer) = setup(&program_id).await;
+
+    let mint_authority = Keypair::new();
+    let mint_authority_pubkey = mint_authority.pubkey();
+
+    let token_program_id = spl_token_2022::id();
+    let decimals = 0;
+
+    let update_authority_keypair = Keypair::new();
+    let update_authority_pubkey = update_authority_keypair.pubkey();
+
+    let metadata_keypair = Keypair::new();
+    let metadata_pubkey = metadata_keypair.pubkey();
+
+    let token = setup_mint(
+        &token_program_id,
+        &mint_authority_pubkey,
+        &metadata_pubkey,
+        &update_authority_pubkey,
+        decimals,
+        payer.clone(),
+        client.clone(),
+    )
+    .await;
+
+    let name = "My Cool Collection".to_string();
+    let symbol = "COOL".to_string();
+    let uri = "cool.collection.print".to_string();
+    let token_metadata = TokenMetadata {
+        name,
+        symbol,
+        uri,
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        mint: *token.get_address(),
+        ..Default::default()
+    };
+
+    setup_metadata(
+        &token,
+        &update_authority_pubkey,
+        &token_metadata,
+        &metadata_keypair,
+        &mint_authority,
+        payer.clone(),
+    )
+    .await;
+    let mut context = context.lock().await;
+
+    let collection_keypair = Keypair::new();
+    let collection_pubkey = collection_keypair.pubkey();
+
+    let collection = Collection {
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        max_size: Some(100),
+        size: 0,
+    };
+
+    setup_collection(
+        &mut context,
+        &program_id,
+        token.get_address(),
+        &collection,
+        &collection_keypair,
+        &mint_authority,
+    )
+    .await;
+
+    let new_authority_keypair = Keypair::new();
+    let new_authority_pubkey = new_authority_keypair.pubkey();
+
+    // No signature
+    let mut update_authority_ix = update_collection_authority(
+        &program_id,
+        &collection_pubkey,
+        &update_authority_pubkey,
+        Some(new_authority_pubkey),
+    );
+    update_authority_ix.accounts[1].is_signer = false;
+    let transaction = Transaction::new_signed_with_payer(
+        &[update_authority_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature,)
+    );
+
+    // Wrong authority
+    let transaction = Transaction::new_signed_with_payer(
+        &[update_collection_authority(
+            &program_id,
+            &collection_pubkey,
+            &collection_pubkey,
+            Some(new_authority_pubkey),
+        )],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &collection_keypair],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(TokenCollectionsError::IncorrectUpdateAuthority as u32),
+        )
+    );
+}

--- a/collections/example/tests/update_collection_authority.rs
+++ b/collections/example/tests/update_collection_authority.rs
@@ -48,7 +48,7 @@ async fn success_update_collection_max_size() {
 
     let name = "My Cool Collection".to_string();
     let symbol = "COOL".to_string();
-    let uri = "cool.collection.print".to_string();
+    let uri = "cool.collection.com".to_string();
     let token_metadata = TokenMetadata {
         name,
         symbol,
@@ -194,7 +194,7 @@ async fn fail_authority_checks() {
 
     let name = "My Cool Collection".to_string();
     let symbol = "COOL".to_string();
-    let uri = "cool.collection.print".to_string();
+    let uri = "cool.collection.com".to_string();
     let token_metadata = TokenMetadata {
         name,
         symbol,

--- a/collections/example/tests/update_collection_max_size.rs
+++ b/collections/example/tests/update_collection_max_size.rs
@@ -151,7 +151,7 @@ async fn fail_authority_checks() {
 
     let name = "My Cool Collection".to_string();
     let symbol = "COOL".to_string();
-    let uri = "cool.collection.print".to_string();
+    let uri = "cool.collection.com".to_string();
     let token_metadata = TokenMetadata {
         name,
         symbol,

--- a/collections/example/tests/update_collection_max_size.rs
+++ b/collections/example/tests/update_collection_max_size.rs
@@ -1,0 +1,246 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+use {
+    program_test::{setup, setup_collection, setup_metadata, setup_mint},
+    solana_program_test::tokio,
+    solana_sdk::{
+        instruction::InstructionError,
+        pubkey::Pubkey,
+        signature::Signer,
+        signer::keypair::Keypair,
+        transaction::{Transaction, TransactionError},
+    },
+    spl_token_collections_interface::{
+        error::TokenCollectionsError, instruction::update_collection_max_size, state::Collection,
+    },
+    spl_token_metadata_interface::state::TokenMetadata,
+    spl_type_length_value::state::{TlvState, TlvStateBorrowed},
+};
+
+#[tokio::test]
+async fn success_update_collection_max_size() {
+    let program_id = Pubkey::new_unique();
+    let (context, client, payer) = setup(&program_id).await;
+
+    let mint_authority = Keypair::new();
+    let mint_authority_pubkey = mint_authority.pubkey();
+
+    let token_program_id = spl_token_2022::id();
+    let decimals = 0;
+
+    let update_authority_keypair = Keypair::new();
+    let update_authority_pubkey = update_authority_keypair.pubkey();
+
+    let metadata_keypair = Keypair::new();
+    let metadata_pubkey = metadata_keypair.pubkey();
+
+    let token = setup_mint(
+        &token_program_id,
+        &mint_authority_pubkey,
+        &metadata_pubkey,
+        &update_authority_pubkey,
+        decimals,
+        payer.clone(),
+        client.clone(),
+    )
+    .await;
+
+    let name = "My Cool Collection".to_string();
+    let symbol = "COOL".to_string();
+    let uri = "cool.collection.com".to_string();
+    let token_metadata = TokenMetadata {
+        name,
+        symbol,
+        uri,
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        mint: *token.get_address(),
+        ..Default::default()
+    };
+
+    setup_metadata(
+        &token,
+        &update_authority_pubkey,
+        &token_metadata,
+        &metadata_keypair,
+        &mint_authority,
+        payer.clone(),
+    )
+    .await;
+    let mut context = context.lock().await;
+
+    let collection_keypair = Keypair::new();
+    let collection_pubkey = collection_keypair.pubkey();
+
+    let collection_data = Collection {
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        max_size: Some(100),
+        size: 0,
+    };
+
+    setup_collection(
+        &mut context,
+        &program_id,
+        token.get_address(),
+        &collection_data,
+        &collection_keypair,
+        &mint_authority,
+    )
+    .await;
+
+    let new_max_size = Some(200);
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[update_collection_max_size(
+            &program_id,
+            &collection_pubkey,
+            &update_authority_pubkey,
+            new_max_size,
+        )],
+        Some(&payer.pubkey()),
+        &[&payer, &update_authority_keypair],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+
+    let fetched_collection_account = context
+        .banks_client
+        .get_account(collection_pubkey)
+        .await
+        .unwrap()
+        .unwrap();
+    let fetched_collection_state =
+        TlvStateBorrowed::unpack(&fetched_collection_account.data).unwrap();
+    let fetched_collection_data = fetched_collection_state
+        .get_variable_len_value::<Collection>()
+        .unwrap();
+    assert_eq!(fetched_collection_data.max_size, new_max_size);
+}
+
+#[tokio::test]
+async fn fail_authority_checks() {
+    let program_id = Pubkey::new_unique();
+    let (context, client, payer) = setup(&program_id).await;
+
+    let mint_authority = Keypair::new();
+    let mint_authority_pubkey = mint_authority.pubkey();
+
+    let token_program_id = spl_token_2022::id();
+    let decimals = 0;
+
+    let update_authority_keypair = Keypair::new();
+    let update_authority_pubkey = update_authority_keypair.pubkey();
+
+    let metadata_keypair = Keypair::new();
+    let metadata_pubkey = metadata_keypair.pubkey();
+
+    let token = setup_mint(
+        &token_program_id,
+        &mint_authority_pubkey,
+        &metadata_pubkey,
+        &update_authority_pubkey,
+        decimals,
+        payer.clone(),
+        client.clone(),
+    )
+    .await;
+
+    let name = "My Cool Collection".to_string();
+    let symbol = "COOL".to_string();
+    let uri = "cool.collection.print".to_string();
+    let token_metadata = TokenMetadata {
+        name,
+        symbol,
+        uri,
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        mint: *token.get_address(),
+        ..Default::default()
+    };
+
+    setup_metadata(
+        &token,
+        &update_authority_pubkey,
+        &token_metadata,
+        &metadata_keypair,
+        &mint_authority,
+        payer.clone(),
+    )
+    .await;
+    let mut context = context.lock().await;
+
+    let collection_keypair = Keypair::new();
+    let collection_pubkey = collection_keypair.pubkey();
+
+    let collection_data = Collection {
+        update_authority: Some(update_authority_pubkey).try_into().unwrap(),
+        max_size: Some(100),
+        size: 0,
+    };
+
+    setup_collection(
+        &mut context,
+        &program_id,
+        token.get_address(),
+        &collection_data,
+        &collection_keypair,
+        &mint_authority,
+    )
+    .await;
+
+    let new_max_size = Some(200);
+
+    // No signature
+    let mut update_size_ix = update_collection_max_size(
+        &program_id,
+        &collection_pubkey,
+        &update_authority_pubkey,
+        new_max_size,
+    );
+    update_size_ix.accounts[1].is_signer = false;
+    let transaction = Transaction::new_signed_with_payer(
+        &[update_size_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature,)
+    );
+
+    // Wrong authority
+    let transaction = Transaction::new_signed_with_payer(
+        &[update_collection_max_size(
+            &program_id,
+            &collection_pubkey,
+            &collection_pubkey,
+            new_max_size,
+        )],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &collection_keypair],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(TokenCollectionsError::IncorrectUpdateAuthority as u32),
+        )
+    );
+}

--- a/collections/interface/Cargo.toml
+++ b/collections/interface/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "spl-token-collections-interface"
+version = "0.1.0"
+description = "Solana Program Library Token Metadata Interface"
+authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
+repository = "https://github.com/solana-labs/solana-program-library"
+license = "Apache-2.0"
+edition = "2021"
+
+[dependencies]
+borsh = "0.10"
+solana-program = "1.16.3"
+spl-discriminator = { version = "0.1.0" , path = "../../libraries/discriminator" }
+spl-program-error = { version = "0.2.0" , path = "../../libraries/program-error" }
+spl-type-length-value = { version = "0.2.0", path = "../../libraries/type-length-value" }
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/collections/interface/README.md
+++ b/collections/interface/README.md
@@ -1,0 +1,181 @@
+# Collections
+
+This interface is designed to allow on-chain programs to group tokens
+into a `Collection`.
+
+A `Collection` serves to identify members of a published group based on
+token mint and metadata.
+
+## Metaplex Protocol
+
+Below is an overview of how Metaplex's Collections work.
+
+In summary, a unique Collection NFT marks a collection, while any members of
+the collection (or group) store a pointer within their token metadata that
+points to that unique collection.
+
+### The Collection NFT
+
+Metaplex makes use of a "Collection NFT" - which is specified to be an NFT
+regardless of whether or not the tokens in the collection are NFTs. This is
+because of the unique non-fungible nature of NFTs, which serves as a great
+way to make sure Collection accounts are also non-fungible.
+
+- Mint a new SPL Token.
+- Create a `Metadata` account for the token.
+  - Inside the `Metadata` data schema, populate the `CollectionDetails` field
+
+As we can see, metadata for a mint that serves as a Collection (an NFT) is
+the same as any other metadata schema, but makes use of one specific field.
+
+```rust
+pub struct Metadata {
+    ...
+    pub collection_details: Option<CollectionDetails>,  // Configurations marking an NFT as a Collection NFT
+    ...
+}
+```
+
+Taking a closer look at the `CollectionDetails`, we can see it contains
+minimal data, but it's presence as `Some()` value instead of `None` is enough
+to mark the NFT as a collection - plus the spefication of a `u64` as the
+**collection size**, which is the current number of collection members.
+
+```rust
+pub enum CollectionDetails {
+    V1 {
+        size: u64, // Number of collection members
+    },
+}
+```
+
+### A Collection Member
+
+Taking a look at the metadata schema again, we know that if we're working
+with a token who's a member of a collection, the configurations will instead
+live within `Collection`.
+
+```rust
+pub struct Metadata {
+    ...
+    pub collection: Option<Collection>,     // Configurations marking a token as a member of a collection
+    ...
+}
+```
+
+The data within `Collection` simply points back to the Collection NFT itself
+and also specifies whether or not this token is a **verified member** of the
+collection it claims to be a member of.
+
+```rust
+pub struct Collection {
+    pub verified: bool,
+    pub key: Pubkey,
+}
+```
+
+### Verifying a Collection Member
+
+Verifying a token as a member of a collection simply requires the signature
+of the mint authority of the Collection NFT to authorize the token in question
+as a verified member of the collection.
+
+### Using Both Configs at the Same Time
+
+It's possible for a token (specifically an NFT for Metaplex) to populate
+both the `CollectionDetails` and the `Collection` fields in its metadata.
+This means you're working with a **nested collection**, where the Collection
+NFT with both configs is a member of a **root collection** but also is a
+collection itself, with it's own members. Those members would then be sub-members
+of the root collection. This can be chained even more.
+
+## SPL Interface
+
+The SPL Token Collections interface works quite similarly to the Metaplex
+layout described above, only the configurations don't need to be stored
+within a token metadata schema, and the interface itself can't enforce a
+collection as an NFT only.
+
+Other than that, the concept of "One-to-Many" relationships works essentially
+the same.
+
+> Note: The SPL Collections interface is quite similar to the SPL Editions
+> interface. In fact, they only differ in a few subtle ways. More details
+> under [Overview](#overview)
+
+### Overview
+
+The SPL Collections and SPL Editions interfaces share much of the same state
+and instruction architecture.
+
+- Both interfaces employ a One-to-Many relationship from a parent to its
+children.
+- Both interfaces leverage the concept of a maximum "supply" or "size"
+(`u64`).
+- This maximum value, and any other values within the parent state, can only
+be changed by an `update_authority`.
+- The Emit instruction (view function) can be used to emit either kind of
+asset.
+
+However, here's where these interfaces differ:
+
+| SPL Editions | SPL Collections |
+| :----------- | :-------------- |
+| When a `Reprint` is created from an `Original`, the token metadata of the `Original` is copied and becomes the token metadata of the `Reprint`. | When a `Member` is created (or "registered"), nothing happens with the member's metadata. It can look completely different than the collection's token metadata. |
+| SPL discriminators are **the same** for both `Original` and `Reprint` state, thus preventing any account using unique TLV entries from storing both in the same data buffer. | SPL discriminators are **different** for `Collection` and `Member`, thus allowing the inclusion of both state types within a TLV-encoded data buffer (nested collections).
+
+### The Collection
+
+A `Collection` in the SPL Token Collections interface is simply a parent in
+the parent-child relationship between collections and members, that's it!
+A collection is not enforced to be any NFT or specific token. It can be
+any token. Ultimately it's up to the on-chain program implementing the interface
+to determine how to create unique collection parents (or whether or not they
+want to).
+
+A `Collection` is also fairly decoupled from token metadata. Unlike the SPL
+Editions interface, creating members of a collection (children in the parent-
+child relationships) does not require the collection's (parent's) token
+metadata. This means that **a metadata account is not required to create a
+collection**.
+
+Although not enforced by the interface, it's _recommended_ to make the
+update authority of a collection the same as the collection's metadata
+update authority.
+
+### The Member
+
+The collection `Member` data simply points back to the collection (parent)
+that it's associated with.
+
+You'll notice there's no concept of "verified" collection members. Let's
+explore why.
+
+Metaplex's protocol ties collection details directly into metadata, which means
+anyone can create metadata for their token, and just insert the pointer to
+whatever collection they want, since all you need to create metadata for a
+token is the signature of the token's mint authority.
+
+With the SPL Token Collections interface, the state data that marks a token
+as a member of a collection is merely an arbitrary piece of state with a
+pointer, and it's completely decoupled from token metadata. One can choose
+to include this bit of state in the same account as a token's metadata, using
+TLV-encoded entries, or they can choose to store this in a separate account
+altogether.
+
+For this reason, the SPL Token Collections interface has no concept of
+"verified" and "unverified" collection members. Instead, the **collection's
+mint authority must also sign** any instruction that intends to create a member
+of its collection.
+
+### Nested Collections
+
+Since the SPL discriminators for both states (`Collection` and `Member`) are
+different, nested collections leveraging the SPL Collections interface work
+just the same as Metaplex's nested collections described above.
+
+However, one noteworthy feature of the SPL Collections interface's nested
+collections is that one on-chain program can implement the interface, and
+another on-chain program can _also_ implement the interface, but create
+collections that are sub-collections of the first on-chain program's
+collections! (I know, confusing, but awesome).

--- a/collections/interface/src/error.rs
+++ b/collections/interface/src/error.rs
@@ -1,0 +1,26 @@
+//! Interface error types
+
+use spl_program_error::*;
+
+/// Errors that may be returned by the interface.
+#[spl_program_error]
+pub enum TokenCollectionsError {
+    /// Size is greater than proposed max size
+    #[error("Size is greater than proposed max size")]
+    SizeExceedsNewMaxSize,
+    /// Size is greater than max size
+    #[error("Size is greater than max size")]
+    SizeExceedsMaxSize,
+    /// Incorrect mint authority has signed the instruction
+    #[error("Incorrect mint authority has signed the instruction")]
+    IncorrectMintAuthority,
+    /// Incorrect collection update authority has signed the instruction
+    #[error("Incorrect collection update authority has signed the instruction")]
+    IncorrectUpdateAuthority,
+    /// Collection has no update authority
+    #[error("Collection has no update authority")]
+    ImmutableCollection,
+    /// Incorrect collection provided
+    #[error("Incorrect collection provided")]
+    IncorrectCollection,
+}

--- a/collections/interface/src/instruction.rs
+++ b/collections/interface/src/instruction.rs
@@ -1,0 +1,404 @@
+//! Instruction types
+
+use {
+    crate::state::OptionalNonZeroPubkey,
+    borsh::{BorshDeserialize, BorshSerialize},
+    solana_program::{
+        instruction::{AccountMeta, Instruction},
+        program_error::ProgramError,
+        pubkey::Pubkey,
+    },
+    spl_discriminator::{ArrayDiscriminator, SplDiscriminate},
+};
+
+/// Instruction data for creating a new `Collection`
+#[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize, SplDiscriminate)]
+#[discriminator_hash_input("spl_token_collections_interface:create_collection")]
+pub struct CreateCollection {
+    /// Update authority for the collection
+    pub update_authority: OptionalNonZeroPubkey,
+    /// The maximum number of collection members
+    pub max_size: Option<u64>,
+}
+
+/// Update the max size of a `Collection`
+#[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize, SplDiscriminate)]
+#[discriminator_hash_input("spl_token_collections_interface:update_collection_max_size")]
+pub struct UpdateCollectionMaxSize {
+    /// New max size for the collection
+    pub max_size: Option<u64>,
+}
+
+/// Update authority instruction data
+#[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize, SplDiscriminate)]
+#[discriminator_hash_input("spl_token_collections_interface:update_collection_authority")]
+pub struct UpdateCollectionAuthority {
+    /// New authority for the collection, or unset if `None`
+    pub new_authority: OptionalNonZeroPubkey,
+}
+
+/// Instruction data for creating a new `Member` of a `Collection`
+#[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize, SplDiscriminate)]
+#[discriminator_hash_input("spl_token_collections_interface:create_member")]
+pub struct CreateMember {
+    /// The pubkey of the `Collection`
+    pub collection: Pubkey,
+}
+
+/// Instruction data for Emit
+#[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize, SplDiscriminate)]
+#[discriminator_hash_input("spl_token_collections_interface:emitter")]
+pub struct Emit {
+    /// Which type of item to emit
+    pub item_type: ItemType,
+    /// Start of range of data to emit
+    pub start: Option<u64>,
+    /// End of range of data to emit
+    pub end: Option<u64>,
+}
+
+/// The type of item
+#[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize)]
+pub enum ItemType {
+    /// Collection
+    Collection,
+    /// Member
+    Member,
+}
+
+/// All instructions that must be implemented in the token-collections interface
+#[derive(Clone, Debug, PartialEq)]
+pub enum TokenCollectionsInstruction {
+    /// Create a new `Collection`
+    ///
+    /// Assumes one has already created a mint for the
+    /// collection.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[w]`  Collection
+    ///   1. `[]`   Mint
+    ///   2. `[s]`  Mint authority
+    ///
+    /// Data: `CreateCollection`: max_size: `Option<u64>`
+    CreateCollection(CreateCollection),
+
+    /// Update the max size of a `Collection`
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[w]`  Collection
+    ///   1. `[s]`  Update authority
+    ///
+    /// Data: `UpdateCollectionMaxSize`: max_size: `Option<u64>`
+    UpdateCollectionMaxSize(UpdateCollectionMaxSize),
+
+    /// Update the authority of a `Collection`
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[w]`  Collection
+    ///   1. `[s]`  Current update authority
+    ///
+    /// Data: the new authority. Can be unset using a `None` value
+    UpdateCollectionAuthority(UpdateCollectionAuthority),
+
+    /// Create a new `Member` of a `Collection`
+    ///
+    /// Assumes the `Collection` has already been created,
+    /// as well as the mint for the member.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[w]`  Member
+    ///   1. `[]`   Member Mint
+    ///   2. `[s]`  Member Mint authority
+    ///   3. `[w]`  Collection
+    ///   4. `[]`   Collection Mint
+    ///   5. `[s]`  Collection Mint authority
+    ///
+    /// Data: `CreateMember`: collection: `Pubkey`
+    CreateMember(CreateMember),
+
+    /// Emits the collection or member as return data
+    ///
+    /// The format of the data emitted follows either the `Collection` or
+    /// `Member` struct,  but it's possible that the account data is stored in
+    /// another format by the program.
+    ///
+    /// With this instruction, a program that implements the token-collections
+    /// interface can return `Collection` or `Member` without adhering to the
+    /// specific byte layout of the structs in any accounts.
+    ///
+    /// The dictation of which data to emit is determined by the `ItemType`
+    /// enum argument to the instruction data.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[]`   Collection _or_ Member account
+    Emit(Emit),
+}
+impl TokenCollectionsInstruction {
+    /// Unpacks a byte buffer into a
+    /// [TokenCollectionsInstruction](enum.TokenCollectionsInstruction.html).
+    pub fn unpack(input: &[u8]) -> Result<Self, ProgramError> {
+        if input.len() < ArrayDiscriminator::LENGTH {
+            return Err(ProgramError::InvalidInstructionData);
+        }
+        let (discriminator, rest) = input.split_at(ArrayDiscriminator::LENGTH);
+        Ok(match discriminator {
+            CreateCollection::SPL_DISCRIMINATOR_SLICE => {
+                let data = CreateCollection::try_from_slice(rest)?;
+                Self::CreateCollection(data)
+            }
+            UpdateCollectionMaxSize::SPL_DISCRIMINATOR_SLICE => {
+                let data = UpdateCollectionMaxSize::try_from_slice(rest)?;
+                Self::UpdateCollectionMaxSize(data)
+            }
+            UpdateCollectionAuthority::SPL_DISCRIMINATOR_SLICE => {
+                let data = UpdateCollectionAuthority::try_from_slice(rest)?;
+                Self::UpdateCollectionAuthority(data)
+            }
+            CreateMember::SPL_DISCRIMINATOR_SLICE => {
+                let data = CreateMember::try_from_slice(rest)?;
+                Self::CreateMember(data)
+            }
+            Emit::SPL_DISCRIMINATOR_SLICE => {
+                let data = Emit::try_from_slice(rest)?;
+                Self::Emit(data)
+            }
+            _ => return Err(ProgramError::InvalidInstructionData),
+        })
+    }
+
+    /// Packs a [TokenCollectionsInstruction](enum.TokenCollectionsInstruction.
+    /// html) into a byte buffer.
+    pub fn pack(&self) -> Vec<u8> {
+        let mut buf = vec![];
+        match self {
+            Self::CreateCollection(data) => {
+                buf.extend_from_slice(CreateCollection::SPL_DISCRIMINATOR_SLICE);
+                buf.append(&mut data.try_to_vec().unwrap());
+            }
+            Self::UpdateCollectionMaxSize(data) => {
+                buf.extend_from_slice(UpdateCollectionMaxSize::SPL_DISCRIMINATOR_SLICE);
+                buf.append(&mut data.try_to_vec().unwrap());
+            }
+            Self::UpdateCollectionAuthority(data) => {
+                buf.extend_from_slice(UpdateCollectionAuthority::SPL_DISCRIMINATOR_SLICE);
+                buf.append(&mut data.try_to_vec().unwrap());
+            }
+            Self::CreateMember(data) => {
+                buf.extend_from_slice(CreateMember::SPL_DISCRIMINATOR_SLICE);
+                buf.append(&mut data.try_to_vec().unwrap());
+            }
+            Self::Emit(data) => {
+                buf.extend_from_slice(Emit::SPL_DISCRIMINATOR_SLICE);
+                buf.append(&mut data.try_to_vec().unwrap());
+            }
+        };
+        buf
+    }
+}
+
+/// Creates a `CreateCollection` instruction
+pub fn create_collection(
+    program_id: &Pubkey,
+    collection: &Pubkey,
+    mint: &Pubkey,
+    mint_authority: &Pubkey,
+    update_authority: Option<Pubkey>,
+    max_size: Option<u64>,
+) -> Instruction {
+    let update_authority = OptionalNonZeroPubkey::try_from(update_authority)
+        .expect("Failed to deserialize `Option<Pubkey>`");
+    let data = TokenCollectionsInstruction::CreateCollection(CreateCollection {
+        update_authority,
+        max_size,
+    });
+    Instruction {
+        program_id: *program_id,
+        accounts: vec![
+            AccountMeta::new(*collection, false),
+            AccountMeta::new_readonly(*mint, false),
+            AccountMeta::new_readonly(*mint_authority, true),
+        ],
+        data: data.pack(),
+    }
+}
+
+/// Creates a `UpdateCollectionMaxSize` instruction
+pub fn update_collection_max_size(
+    program_id: &Pubkey,
+    collection: &Pubkey,
+    update_authority: &Pubkey,
+    max_size: Option<u64>,
+) -> Instruction {
+    let data =
+        TokenCollectionsInstruction::UpdateCollectionMaxSize(UpdateCollectionMaxSize { max_size });
+    Instruction {
+        program_id: *program_id,
+        accounts: vec![
+            AccountMeta::new(*collection, false),
+            AccountMeta::new_readonly(*update_authority, true),
+        ],
+        data: data.pack(),
+    }
+}
+
+/// Creates a `UpdateCollectionAuthority` instruction
+pub fn update_collection_authority(
+    program_id: &Pubkey,
+    collection: &Pubkey,
+    current_authority: &Pubkey,
+    new_authority: Option<Pubkey>,
+) -> Instruction {
+    let new_authority = OptionalNonZeroPubkey::try_from(new_authority)
+        .expect("Failed to deserialize `Option<Pubkey>`");
+    let data = TokenCollectionsInstruction::UpdateCollectionAuthority(UpdateCollectionAuthority {
+        new_authority,
+    });
+    Instruction {
+        program_id: *program_id,
+        accounts: vec![
+            AccountMeta::new(*collection, false),
+            AccountMeta::new_readonly(*current_authority, true),
+        ],
+        data: data.pack(),
+    }
+}
+
+/// Creates a `CreateMember` instruction
+#[allow(clippy::too_many_arguments)]
+pub fn create_member(
+    program_id: &Pubkey,
+    member: &Pubkey,
+    member_mint: &Pubkey,
+    member_mint_authority: &Pubkey,
+    collection: &Pubkey,
+    collection_mint: &Pubkey,
+    collection_mint_authority: &Pubkey,
+) -> Instruction {
+    let data = TokenCollectionsInstruction::CreateMember(CreateMember {
+        collection: *collection,
+    });
+    Instruction {
+        program_id: *program_id,
+        accounts: vec![
+            AccountMeta::new(*member, false),
+            AccountMeta::new_readonly(*member_mint, false),
+            AccountMeta::new_readonly(*member_mint_authority, true),
+            AccountMeta::new(*collection, false),
+            AccountMeta::new_readonly(*collection_mint, false),
+            AccountMeta::new_readonly(*collection_mint_authority, true),
+        ],
+        data: data.pack(),
+    }
+}
+
+/// Creates an `Emit` instruction
+pub fn emit(
+    program_id: &Pubkey,
+    item: &Pubkey,
+    item_type: ItemType,
+    start: Option<u64>,
+    end: Option<u64>,
+) -> Instruction {
+    let data = TokenCollectionsInstruction::Emit(Emit {
+        item_type,
+        start,
+        end,
+    });
+    Instruction {
+        program_id: *program_id,
+        accounts: vec![AccountMeta::new_readonly(*item, false)],
+        data: data.pack(),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use {super::*, crate::NAMESPACE, solana_program::hash};
+
+    fn check_pack_unpack<T: BorshSerialize>(
+        instruction: TokenCollectionsInstruction,
+        discriminator: &[u8],
+        data: T,
+    ) {
+        let mut expect = vec![];
+        expect.extend_from_slice(discriminator.as_ref());
+        expect.append(&mut data.try_to_vec().unwrap());
+        let packed = instruction.pack();
+        assert_eq!(packed, expect);
+        let unpacked = TokenCollectionsInstruction::unpack(&expect).unwrap();
+        assert_eq!(unpacked, instruction);
+    }
+
+    #[test]
+    fn create_collection_pack() {
+        let data = CreateCollection {
+            update_authority: OptionalNonZeroPubkey::default(),
+            max_size: Some(100),
+        };
+        let check = TokenCollectionsInstruction::CreateCollection(data.clone());
+        let preimage = hash::hashv(&[format!("{NAMESPACE}:create_collection").as_bytes()]);
+        let discriminator = &preimage.as_ref()[..ArrayDiscriminator::LENGTH];
+        check_pack_unpack(check, discriminator, data);
+    }
+
+    #[test]
+    fn update_collection_max_size_pack() {
+        let data = UpdateCollectionMaxSize {
+            max_size: Some(200),
+        };
+        let check = TokenCollectionsInstruction::UpdateCollectionMaxSize(data.clone());
+        let preimage = hash::hashv(&[format!("{NAMESPACE}:update_collection_max_size").as_bytes()]);
+        let discriminator = &preimage.as_ref()[..ArrayDiscriminator::LENGTH];
+        check_pack_unpack(check, discriminator, data);
+    }
+
+    #[test]
+    fn update_authority_pack() {
+        let data = UpdateCollectionAuthority {
+            new_authority: OptionalNonZeroPubkey::default(),
+        };
+        let check = TokenCollectionsInstruction::UpdateCollectionAuthority(data.clone());
+        let preimage =
+            hash::hashv(&[format!("{NAMESPACE}:update_collection_authority").as_bytes()]);
+        let discriminator = &preimage.as_ref()[..ArrayDiscriminator::LENGTH];
+        check_pack_unpack(check, discriminator, data);
+    }
+
+    #[test]
+    fn create_member_pack() {
+        let data = CreateMember {
+            collection: Pubkey::new_unique(),
+        };
+        let check = TokenCollectionsInstruction::CreateMember(data.clone());
+        let preimage = hash::hashv(&[format!("{NAMESPACE}:create_member").as_bytes()]);
+        let discriminator = &preimage.as_ref()[..ArrayDiscriminator::LENGTH];
+        check_pack_unpack(check, discriminator, data);
+    }
+
+    #[test]
+    fn emit_pack() {
+        let preimage = hash::hashv(&[format!("{NAMESPACE}:emitter").as_bytes()]);
+        let discriminator = &preimage.as_ref()[..ArrayDiscriminator::LENGTH];
+
+        let collection_data = Emit {
+            item_type: ItemType::Collection,
+            start: None,
+            end: Some(10),
+        };
+        let collection_check = TokenCollectionsInstruction::Emit(collection_data.clone());
+        check_pack_unpack(collection_check, discriminator, collection_data);
+
+        let member_data = Emit {
+            item_type: ItemType::Member,
+            start: None,
+            end: Some(7),
+        };
+        let member_check = TokenCollectionsInstruction::Emit(member_data.clone());
+        check_pack_unpack(member_check, discriminator, member_data);
+    }
+}

--- a/collections/interface/src/lib.rs
+++ b/collections/interface/src/lib.rs
@@ -1,0 +1,18 @@
+//! Crate defining an interface for token-collections
+
+#![allow(clippy::integer_arithmetic)]
+#![deny(missing_docs)]
+#![cfg_attr(not(test), forbid(unsafe_code))]
+
+pub mod error;
+pub mod instruction;
+pub mod state;
+
+// Export current sdk types for downstream users building with a different sdk
+// version
+// Export borsh for downstream users
+pub use borsh;
+pub use solana_program;
+
+/// Namespace for all programs implementing token-collections
+pub const NAMESPACE: &str = "spl_token_collections_interface";

--- a/collections/interface/src/state.rs
+++ b/collections/interface/src/state.rs
@@ -1,0 +1,231 @@
+//! Token-collection interface state types
+
+use {
+    crate::error::TokenCollectionsError,
+    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
+    solana_program::{
+        borsh::{get_instance_packed_len, try_from_slice_unchecked},
+        program_error::ProgramError,
+        pubkey::Pubkey,
+    },
+    spl_discriminator::SplDiscriminate,
+    spl_type_length_value::{
+        state::{TlvState, TlvStateBorrowed},
+        variable_len_pack::VariableLenPack,
+    },
+};
+
+/// A Pubkey that encodes `None` as all `0`, meant to be usable as a Pod type,
+/// similar to all NonZero* number types from the bytemuck library.
+#[derive(Clone, Debug, Default, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
+#[repr(transparent)]
+pub struct OptionalNonZeroPubkey(Pubkey);
+impl TryFrom<Option<Pubkey>> for OptionalNonZeroPubkey {
+    type Error = ProgramError;
+    fn try_from(p: Option<Pubkey>) -> Result<Self, Self::Error> {
+        match p {
+            None => Ok(Self(Pubkey::default())),
+            Some(pubkey) => {
+                if pubkey == Pubkey::default() {
+                    Err(ProgramError::InvalidArgument)
+                } else {
+                    Ok(Self(pubkey))
+                }
+            }
+        }
+    }
+}
+impl From<OptionalNonZeroPubkey> for Option<Pubkey> {
+    fn from(p: OptionalNonZeroPubkey) -> Self {
+        if p.0 == Pubkey::default() {
+            None
+        } else {
+            Some(p.0)
+        }
+    }
+}
+
+/// Get the slice corresponding to the given start and end range
+pub fn get_emit_slice(data: &[u8], start: Option<u64>, end: Option<u64>) -> Option<&[u8]> {
+    let start = start.unwrap_or(0) as usize;
+    let end = end.map(|x| x as usize).unwrap_or(data.len());
+    data.get(start..end)
+}
+
+/// Data struct for a `Collection`
+#[derive(
+    Clone, Debug, Default, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema, SplDiscriminate,
+)]
+#[discriminator_hash_input("spl_token_collections_interface:collection")]
+pub struct Collection {
+    /// The authority that can sign to update the collection
+    pub update_authority: OptionalNonZeroPubkey,
+    /// The current number of collection members
+    pub size: u64,
+    /// The maximum number of collection members
+    pub max_size: Option<u64>,
+}
+impl Collection {
+    /// Gives the total size of this struct as a TLV entry in an account
+    pub fn tlv_size_of(&self) -> Result<usize, ProgramError> {
+        TlvStateBorrowed::get_base_len()
+            .checked_add(get_instance_packed_len(self)?)
+            .ok_or(ProgramError::InvalidAccountData)
+    }
+
+    /// Creates a new `Collection` state
+    pub fn new(update_authority: OptionalNonZeroPubkey, max_size: Option<u64>) -> Self {
+        Self {
+            update_authority,
+            size: 0,
+            max_size,
+        }
+    }
+
+    /// Updates the max size for a collection
+    pub fn update_max_size(&mut self, max_size: Option<u64>) -> Result<(), ProgramError> {
+        // The new max size cannot be less than the current size
+        if let Some(new_max_size) = max_size {
+            if new_max_size < self.size {
+                return Err(TokenCollectionsError::SizeExceedsNewMaxSize.into());
+            }
+        }
+        self.max_size = max_size;
+        Ok(())
+    }
+
+    /// Updates the size for a collection
+    pub fn update_size(&mut self, new_size: u64) -> Result<(), ProgramError> {
+        // The new size cannot be greater than the max size
+        if let Some(max_size) = self.max_size {
+            if new_size > max_size {
+                return Err(TokenCollectionsError::SizeExceedsMaxSize.into());
+            }
+        }
+        self.size = new_size;
+        Ok(())
+    }
+}
+impl VariableLenPack for Collection {
+    fn pack_into_slice(&self, dst: &mut [u8]) -> Result<(), ProgramError> {
+        borsh::to_writer(&mut dst[..], self).map_err(Into::into)
+    }
+    fn unpack_from_slice(src: &[u8]) -> Result<Self, ProgramError> {
+        try_from_slice_unchecked(src).map_err(Into::into)
+    }
+    fn get_packed_len(&self) -> Result<usize, ProgramError> {
+        get_instance_packed_len(self).map_err(Into::into)
+    }
+}
+
+/// Data struct for a `Member` of a `Collection`
+#[derive(
+    Clone, Debug, Default, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema, SplDiscriminate,
+)]
+#[discriminator_hash_input("spl_token_collections_interface:member")]
+pub struct Member {
+    /// The pubkey of the `Collection`
+    pub collection: Pubkey,
+}
+impl Member {
+    /// Gives the total size of this struct as a TLV entry in an account
+    pub fn tlv_size_of(&self) -> Result<usize, ProgramError> {
+        TlvStateBorrowed::get_base_len()
+            .checked_add(get_instance_packed_len(self)?)
+            .ok_or(ProgramError::InvalidAccountData)
+    }
+}
+impl VariableLenPack for Member {
+    fn pack_into_slice(&self, dst: &mut [u8]) -> Result<(), ProgramError> {
+        borsh::to_writer(&mut dst[..], self).map_err(Into::into)
+    }
+    fn unpack_from_slice(src: &[u8]) -> Result<Self, ProgramError> {
+        try_from_slice_unchecked(src).map_err(Into::into)
+    }
+    fn get_packed_len(&self) -> Result<usize, ProgramError> {
+        get_instance_packed_len(self).map_err(Into::into)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, crate::NAMESPACE, solana_program::hash, spl_discriminator::ArrayDiscriminator};
+
+    #[test]
+    fn discriminators() {
+        let preimage = hash::hashv(&[format!("{NAMESPACE}:collection").as_bytes()]);
+        let discriminator =
+            ArrayDiscriminator::try_from(&preimage.as_ref()[..ArrayDiscriminator::LENGTH]).unwrap();
+        assert_eq!(Collection::SPL_DISCRIMINATOR, discriminator);
+
+        let preimage = hash::hashv(&[format!("{NAMESPACE}:member").as_bytes()]);
+        let discriminator =
+            ArrayDiscriminator::try_from(&preimage.as_ref()[..ArrayDiscriminator::LENGTH]).unwrap();
+        assert_eq!(Member::SPL_DISCRIMINATOR, discriminator);
+    }
+
+    #[test]
+    fn update_max_size() {
+        // Test with a `Some` max size
+        let max_size = Some(10);
+        let mut collection = Collection {
+            max_size,
+            ..Default::default()
+        };
+
+        let new_max_size = Some(30);
+        collection.update_max_size(new_max_size).unwrap();
+        assert_eq!(collection.max_size, new_max_size);
+
+        // Change the current size to 30
+        collection.size = 30;
+
+        // Try to set the max size to 20, which is less than the current size
+        let new_max_size = Some(20);
+        assert_eq!(
+            collection.update_max_size(new_max_size),
+            Err(ProgramError::from(
+                TokenCollectionsError::SizeExceedsNewMaxSize
+            ))
+        );
+
+        // Test with a `None` max size
+        let max_size = None;
+        let mut collection = Collection {
+            max_size,
+            ..Default::default()
+        };
+
+        let new_max_size = Some(30);
+        collection.update_max_size(new_max_size).unwrap();
+        assert_eq!(collection.max_size, new_max_size);
+    }
+
+    #[test]
+    fn update_current_size() {
+        let mut collection = Collection {
+            max_size: Some(1),
+            ..Default::default()
+        };
+
+        collection.update_size(1).unwrap();
+        assert_eq!(collection.size, 1);
+
+        // Try to set the current size to 2, which is greater than the max size
+        assert_eq!(
+            collection.update_size(2),
+            Err(ProgramError::from(
+                TokenCollectionsError::SizeExceedsMaxSize
+            ))
+        );
+
+        // Test with a `None` max size
+        let mut collection = Collection {
+            max_size: None,
+            ..Default::default()
+        };
+
+        collection.update_size(1).unwrap();
+        assert_eq!(collection.size, 1);
+    }
+}


### PR DESCRIPTION
This PR introduces an interface for Token Collections. With this interface, on-chain programs can create groups of tokens - dubbed "Collections" - that identify members of such a group through parent-child relationships.

Note: This interface is almost identical to the SPL Token Editions interface #4821 , but with some slight differences that are described in the `README.md`