### PR TITLE
Revert "Revert "Update Stake with the additional deactivation flag (#4504)""

### DIFF
--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -683,7 +683,7 @@ fn command_deposit_stake(
         println!("Depositing stake account {:?}", stake_state);
     }
     let vote_account = match stake_state {
-        stake::state::StakeState::Stake(_, stake) => Ok(stake.delegation.voter_pubkey),
+        stake::state::StakeState::Stake(_, stake, _) => Ok(stake.delegation.voter_pubkey),
         _ => Err("Wrong stake account state, must be delegated to validator"),
     }?;
 
@@ -865,7 +865,7 @@ fn command_deposit_all_stake(
         let stake_state = get_stake_state(&config.rpc_client, &stake_address)?;
 
         let vote_account = match stake_state {
-            stake::state::StakeState::Stake(_, stake) => Ok(stake.delegation.voter_pubkey),
+            stake::state::StakeState::Stake(_, stake, _) => Ok(stake.delegation.voter_pubkey),
             _ => Err("Wrong stake account state, must be delegated to validator"),
         }?;
 

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -51,7 +51,7 @@ fn get_stake_state(
     let stake_state =
         try_from_slice_unchecked::<stake::state::StakeState>(&stake_account_info.data.borrow())?;
     match stake_state {
-        stake::state::StakeState::Stake(meta, stake) => Ok((meta, stake)),
+        stake::state::StakeState::Stake(meta, stake, _) => Ok((meta, stake)),
         _ => Err(StakePoolError::WrongStakeState.into()),
     }
 }
@@ -1738,7 +1738,7 @@ impl Processor {
             )?;
             match stake_state {
                 // if it was delegated on or before this epoch, we're good
-                stake::state::StakeState::Stake(_, stake)
+                stake::state::StakeState::Stake(_, stake, _)
                     if stake.delegation.activation_epoch <= clock.epoch => {}
                 // all other situations, delegate!
                 _ => {
@@ -2275,7 +2275,7 @@ impl Processor {
                         }
                     }
                 }
-                Some(stake::state::StakeState::Stake(meta, stake)) => {
+                Some(stake::state::StakeState::Stake(meta, stake, _)) => {
                     if stake_is_usable_by_pool(
                         &meta,
                         withdraw_authority_info.key,
@@ -2297,7 +2297,7 @@ impl Processor {
                             )?;
                             validator_stake_record.status.remove_transient_stake();
                         } else if stake.delegation.activation_epoch < clock.epoch {
-                            if let Some(stake::state::StakeState::Stake(_, validator_stake)) =
+                            if let Some(stake::state::StakeState::Stake(_, validator_stake, _)) =
                                 validator_stake_state
                             {
                                 if validator_stake.delegation.activation_epoch < clock.epoch {
@@ -2338,7 +2338,7 @@ impl Processor {
             )
             .ok();
             match validator_stake_state {
-                Some(stake::state::StakeState::Stake(meta, stake)) => {
+                Some(stake::state::StakeState::Stake(meta, stake, _)) => {
                     let additional_lamports = validator_stake_info
                         .lamports()
                         .saturating_sub(stake.delegation.stake)

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -2382,7 +2382,9 @@ pub fn add_validator_stake_account(
     let stake_account = SolanaAccount::create(
         stake_amount + STAKE_ACCOUNT_RENT_EXEMPTION,
         bincode::serialize::<stake::state::StakeState>(&stake::state::StakeState::Stake(
-            meta, stake,
+            meta,
+            stake,
+            stake::stake_flags::StakeFlags::empty(),
         ))
         .unwrap(),
         stake::program::id(),

--- a/stake-pool/program/tests/vsa_add.rs
+++ b/stake-pool/program/tests/vsa_add.rs
@@ -129,7 +129,7 @@ async fn success() {
     let stake = get_account(&mut banks_client, &validator_stake.stake_account).await;
     let stake_state = deserialize::<stake::state::StakeState>(&stake.data).unwrap();
     match stake_state {
-        stake::state::StakeState::Stake(meta, _) => {
+        stake::state::StakeState::Stake(meta, _, _) => {
             assert_eq!(
                 &meta.authorized.staker,
                 &stake_pool_accounts.withdraw_authority
@@ -595,7 +595,7 @@ async fn success_with_lamports_in_account() {
     let stake = get_account(&mut banks_client, &validator_stake.stake_account).await;
     let stake_state = deserialize::<stake::state::StakeState>(&stake.data).unwrap();
     match stake_state {
-        stake::state::StakeState::Stake(meta, _) => {
+        stake::state::StakeState::Stake(meta, _, _) => {
             assert_eq!(
                 &meta.authorized.staker,
                 &stake_pool_accounts.withdraw_authority

--- a/stake-pool/single-pool-cli/src/quarantine.rs
+++ b/stake-pool/single-pool-cli/src/quarantine.rs
@@ -42,7 +42,7 @@ pub async fn get_stake_info(
         .await?
     {
         match bincode::deserialize::<StakeState>(&stake_account.data)? {
-            StakeState::Stake(meta, stake) => Ok(Some((meta, stake))),
+            StakeState::Stake(meta, stake, _) => Ok(Some((meta, stake))),
             StakeState::Initialized(_) => {
                 Err(format!("Stake account {} is undelegated", stake_account_address).into())
             }

--- a/stake-pool/single-pool/src/processor.rs
+++ b/stake-pool/single-pool/src/processor.rs
@@ -78,7 +78,7 @@ fn get_stake_state(stake_account_info: &AccountInfo) -> Result<(Meta, Stake), Pr
     let stake_state = try_from_slice_unchecked::<StakeState>(&stake_account_info.data.borrow())?;
 
     match stake_state {
-        StakeState::Stake(meta, stake) => Ok((meta, stake)),
+        StakeState::Stake(meta, stake, _) => Ok((meta, stake)),
         _ => Err(SinglePoolError::WrongStakeState.into()),
     }
 }

--- a/stake-pool/single-pool/tests/helpers/stake.rs
+++ b/stake-pool/single-pool/tests/helpers/stake.rs
@@ -28,7 +28,7 @@ pub async fn get_stake_account(
     let lamports = stake_account.lamports;
     match deserialize::<StakeState>(&stake_account.data).unwrap() {
         StakeState::Initialized(meta) => (meta, None, lamports),
-        StakeState::Stake(meta, stake) => (meta, Some(stake), lamports),
+        StakeState::Stake(meta, stake, _) => (meta, Some(stake), lamports),
         _ => unimplemented!(),
     }
 }


### PR DESCRIPTION
Reverts solana-labs/solana-program-library#4841

actually I found we have included required changes in monorepo here
https://github.com/solana-labs/solana/blob/de4ff348b404be5bba2ee62463d785fb070a0a57/sdk/program/src/stake/state.rs#L26

so I think maybe we can try to restore this one. if someone encounter a similar error, they can try to rebase their monorepo first.