### PR TITLE
[token-2022] Update confidential transfer fee extension for solana 1.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7021,6 +7021,7 @@ name = "spl-token-client"
 version = "0.5.1"
 dependencies = [
  "async-trait",
+ "futures 0.3.28",
  "futures-util",
  "solana-banks-interface",
  "solana-cli-output",

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -9,6 +9,7 @@ version = "0.5.1"
 
 [dependencies]
 async-trait = "0.1"
+futures = "0.3.28"
 futures-util = "0.3"
 solana-banks-interface = "1.16.3"
 solana-cli-output = { version = "1.16.3", optional = true }

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -2572,6 +2572,54 @@ where
         .await
     }
 
+    /// Enable harvest of confidential fees to mint
+    pub async fn confidential_transfer_enable_harvest_to_mint<S: Signers>(
+        &self,
+        withdraw_withheld_authority: &Pubkey,
+        signing_keypairs: &S,
+    ) -> TokenResult<T::Output> {
+        let signing_pubkeys = signing_keypairs.pubkeys();
+        let multisig_signers =
+            self.get_multisig_signers(withdraw_withheld_authority, &signing_pubkeys);
+
+        self.process_ixs(
+            &[
+                confidential_transfer_fee::instruction::enable_harvest_to_mint(
+                    &self.program_id,
+                    &self.pubkey,
+                    withdraw_withheld_authority,
+                    &multisig_signers,
+                )?,
+            ],
+            signing_keypairs,
+        )
+        .await
+    }
+
+    /// Disable harvest of confidential fees to mint
+    pub async fn confidential_transfer_disable_harvest_to_mint<S: Signers>(
+        &self,
+        withdraw_withheld_authority: &Pubkey,
+        signing_keypairs: &S,
+    ) -> TokenResult<T::Output> {
+        let signing_pubkeys = signing_keypairs.pubkeys();
+        let multisig_signers =
+            self.get_multisig_signers(withdraw_withheld_authority, &signing_pubkeys);
+
+        self.process_ixs(
+            &[
+                confidential_transfer_fee::instruction::disable_harvest_to_mint(
+                    &self.program_id,
+                    &self.pubkey,
+                    withdraw_withheld_authority,
+                    &multisig_signers,
+                )?,
+            ],
+            signing_keypairs,
+        )
+        .await
+    }
+
     pub async fn withdraw_excess_lamports<S: Signers>(
         &self,
         source: &Pubkey,

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -2440,10 +2440,10 @@ where
         let account_info = if let Some(account_info) = withheld_tokens_info {
             account_info
         } else {
-            self.get_mint_info()
-                .await?
-                .get_extension::<ConfidentialTransferFeeConfig>()?
-                .withheld_tokens_info()
+            let mint_info = self.get_mint_info().await?;
+            let confidential_transfer_fee_config =
+                mint_info.get_extension::<ConfidentialTransferFeeConfig>()?;
+            WithheldTokensInfo::new(&confidential_transfer_fee_config.withheld_amount)
         };
 
         let proof_data = if context_state_account.is_some() {
@@ -2515,7 +2515,7 @@ where
                 aggregate_withheld_amount = aggregate_withheld_amount + withheld_amount;
             }
 
-            WithheldTokensInfo::new(aggregate_withheld_amount.into())
+            WithheldTokensInfo::new(&aggregate_withheld_amount.into())
         };
 
         let proof_data = if context_state_account.is_some() {

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -2555,14 +2555,13 @@ where
     }
 
     /// Harvest withheld confidential tokens to mint
-    #[cfg(feature = "proof-program")]
     pub async fn confidential_transfer_harvest_withheld_tokens_to_mint(
         &self,
         sources: &[&Pubkey],
     ) -> TokenResult<T::Output> {
         self.process_ixs::<[&dyn Signer; 0]>(
             &[
-                confidential_transfer::instruction::harvest_withheld_tokens_to_mint(
+                confidential_transfer_fee::instruction::harvest_withheld_tokens_to_mint(
                     &self.program_id,
                     &self.pubkey,
                     sources,

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -18,12 +18,10 @@ use {
         error::TokenError,
         extension::{
             confidential_transfer::{
-                self, ConfidentialTransferAccount, ConfidentialTransferMint,
-                MAXIMUM_DEPOSIT_TRANSFER_AMOUNT,
+                self, ConfidentialTransferAccount, MAXIMUM_DEPOSIT_TRANSFER_AMOUNT,
             },
             BaseStateWithExtensions, ExtensionType,
         },
-        instruction,
         solana_zk_token_sdk::{
             encryption::{auth_encryption::*, elgamal::*},
             zk_token_elgamal::pod::{self, Zeroable},

--- a/token/program-2022-test/tests/confidential_transfer_fee.rs
+++ b/token/program-2022-test/tests/confidential_transfer_fee.rs
@@ -844,7 +844,7 @@ async fn confidential_transfer_withdraw_withheld_tokens_from_mint_with_proof_con
         let extension = state
             .get_extension::<ConfidentialTransferFeeConfig>()
             .unwrap();
-        let withheld_tokens_info = extension.withheld_tokens_info();
+        let withheld_tokens_info = WithheldTokensInfo::new(&extension.withheld_amount);
 
         let proof_data = withheld_tokens_info
             .generate_proof_data(
@@ -1010,7 +1010,7 @@ async fn confidential_transfer_withdraw_withheld_tokens_from_accounts_with_proof
             .get_extension::<ConfidentialTransferFeeAmount>()
             .unwrap()
             .withheld_amount;
-        let withheld_tokens_info = WithheldTokensInfo::new(withheld_amount);
+        let withheld_tokens_info = WithheldTokensInfo::new(&withheld_amount);
 
         let proof_data = withheld_tokens_info
             .generate_proof_data(

--- a/token/program-2022-test/tests/confidential_transfer_fee.rs
+++ b/token/program-2022-test/tests/confidential_transfer_fee.rs
@@ -1092,3 +1092,141 @@ async fn confidential_transfer_withdraw_withheld_tokens_from_accounts_with_proof
         .unwrap();
     assert_eq!(extension.withheld_amount, pod::ElGamalCiphertext::zeroed());
 }
+
+#[cfg(feature = "zk-ops")]
+#[tokio::test]
+async fn confidential_transfer_harvest_withheld_tokens_to_mint() {
+    let transfer_fee_authority = Keypair::new();
+    let withdraw_withheld_authority = Keypair::new();
+
+    let confidential_transfer_authority = Keypair::new();
+    let auto_approve_new_accounts = true;
+    let auditor_elgamal_keypair = ElGamalKeypair::new_rand();
+    let auditor_elgamal_pubkey = (*auditor_elgamal_keypair.pubkey()).into();
+
+    let confidential_transfer_fee_authority = Keypair::new();
+    let withdraw_withheld_authority_elgamal_keypair = ElGamalKeypair::new_rand();
+    let withdraw_withheld_authority_elgamal_pubkey =
+        (*withdraw_withheld_authority_elgamal_keypair.pubkey()).into();
+
+    let mut context = TestContext::new().await;
+    context
+        .init_token_with_mint(vec![
+            ExtensionInitializationParams::TransferFeeConfig {
+                transfer_fee_config_authority: Some(transfer_fee_authority.pubkey()),
+                withdraw_withheld_authority: Some(withdraw_withheld_authority.pubkey()),
+                transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
+                maximum_fee: TEST_MAXIMUM_FEE,
+            },
+            ExtensionInitializationParams::ConfidentialTransferMint {
+                authority: Some(confidential_transfer_authority.pubkey()),
+                auto_approve_new_accounts,
+                auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
+            },
+            ExtensionInitializationParams::ConfidentialTransferFeeConfig {
+                authority: Some(confidential_transfer_fee_authority.pubkey()),
+                withdraw_withheld_authority_elgamal_pubkey,
+            },
+        ])
+        .await
+        .unwrap();
+
+    let TokenContext {
+        token,
+        alice,
+        bob,
+        mint_authority,
+        decimals,
+        ..
+    } = context.token_context.unwrap();
+
+    let alice_meta =
+        ConfidentialTokenAccountMeta::new(&token, &alice, &mint_authority, 100, decimals).await;
+    let bob_meta =
+        ConfidentialTokenAccountMeta::new(&token, &bob, &mint_authority, 0, decimals).await;
+
+    let transfer_fee_parameters = TransferFee {
+        epoch: 0.into(),
+        maximum_fee: TEST_MAXIMUM_FEE.into(),
+        transfer_fee_basis_points: TEST_FEE_BASIS_POINTS.into(),
+    };
+
+    // there are no withheld fees in bob's account yet, but try harvesting
+    token
+        .confidential_transfer_harvest_withheld_tokens_to_mint(&[&bob_meta.token_account])
+        .await
+        .unwrap();
+
+    // Test fee is 2.5% so the withheld fees should be 3
+    token
+        .confidential_transfer_transfer_with_fee(
+            &alice_meta.token_account,
+            &bob_meta.token_account,
+            &alice.pubkey(),
+            None,
+            100,
+            None,
+            &alice_meta.elgamal_keypair,
+            &alice_meta.aes_key,
+            bob_meta.elgamal_keypair.pubkey(),
+            Some(auditor_elgamal_keypair.pubkey()),
+            withdraw_withheld_authority_elgamal_keypair.pubkey(),
+            transfer_fee_parameters.transfer_fee_basis_points.into(),
+            transfer_fee_parameters.maximum_fee.into(),
+            &[&alice],
+        )
+        .await
+        .unwrap();
+
+    // disable harvest withheld tokens to mint
+    token
+        .confidential_transfer_disable_harvest_to_mint(
+            &confidential_transfer_fee_authority.pubkey(),
+            &[&confidential_transfer_fee_authority],
+        )
+        .await
+        .unwrap();
+
+    let err = token
+        .confidential_transfer_harvest_withheld_tokens_to_mint(&[&bob_meta.token_account])
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::HarvestToMintDisabled as u32),
+            )
+        )))
+    );
+
+    // enable harvest withheld tokens to mint
+    token
+        .confidential_transfer_enable_harvest_to_mint(
+            &confidential_transfer_fee_authority.pubkey(),
+            &[&confidential_transfer_fee_authority],
+        )
+        .await
+        .unwrap();
+
+    token
+        .confidential_transfer_harvest_withheld_tokens_to_mint(&[&bob_meta.token_account])
+        .await
+        .unwrap();
+
+    let state = token
+        .get_account_info(&bob_meta.token_account)
+        .await
+        .unwrap();
+    let extension = state
+        .get_extension::<ConfidentialTransferFeeAmount>()
+        .unwrap();
+    assert_eq!(extension.withheld_amount, pod::ElGamalCiphertext::zeroed());
+
+    // calculate and encrypt fee to attach to the `WithdrawWithheldTokensFromMint` instruction data
+    let fee = transfer_fee_parameters.calculate_fee(100).unwrap();
+
+    check_withheld_amount_in_mint(&token, &withdraw_withheld_authority_elgamal_keypair, fee).await;
+}

--- a/token/program-2022-test/tests/confidential_transfer_fee.rs
+++ b/token/program-2022-test/tests/confidential_transfer_fee.rs
@@ -6,37 +6,30 @@ use {
     program_test::{TestContext, TokenContext},
     solana_program_test::tokio,
     solana_sdk::{
-        instruction::InstructionError,
-        pubkey::Pubkey,
-        signature::Signer,
-        signer::keypair::Keypair,
-        system_instruction,
-        transaction::{Transaction, TransactionError},
-        transport::TransportError,
+        instruction::InstructionError, pubkey::Pubkey, signature::Signer, signer::keypair::Keypair,
+        transaction::TransactionError, transport::TransportError,
     },
     spl_token_2022::{
         error::TokenError,
         extension::{
-            confidential_transfer::{
-                self, ConfidentialTransferAccount, ConfidentialTransferMint,
-                MAXIMUM_DEPOSIT_TRANSFER_AMOUNT,
+            confidential_transfer::{ConfidentialTransferAccount, ConfidentialTransferMint},
+            confidential_transfer_fee::{
+                ConfidentialTransferFeeAmount, ConfidentialTransferFeeConfig,
             },
+            transfer_fee::TransferFee,
             BaseStateWithExtensions, ExtensionType,
         },
         instruction,
         solana_zk_token_sdk::{
             encryption::{auth_encryption::*, elgamal::*},
             zk_token_elgamal::pod::{self, Zeroable},
-            zk_token_proof_instruction::*,
-            zk_token_proof_program,
-            zk_token_proof_state::ProofContextState,
         },
     },
     spl_token_client::{
         client::{SendTransaction, SimulateTransaction},
         token::{ExtensionInitializationParams, Token, TokenError as TokenClientError},
     },
-    std::{convert::TryInto, mem::size_of},
+    std::convert::TryInto,
 };
 
 #[cfg(feature = "zk-ops")]
@@ -44,7 +37,145 @@ const TEST_MAXIMUM_FEE: u64 = 100;
 #[cfg(feature = "zk-ops")]
 const TEST_FEE_BASIS_POINTS: u16 = 250;
 
-#[cfg(all(feature = "zk-ops", feature = "proof-program"))]
+struct ConfidentialTokenAccountMeta {
+    token_account: Pubkey,
+    elgamal_keypair: ElGamalKeypair,
+    aes_key: AeKey,
+}
+
+impl ConfidentialTokenAccountMeta {
+    async fn new<T>(
+        token: &Token<T>,
+        owner: &Keypair,
+        mint_authority: &Keypair,
+        amount: u64,
+        decimals: u8,
+    ) -> Self
+    where
+        T: SendTransaction + SimulateTransaction,
+    {
+        let token_account_keypair = Keypair::new();
+        let extensions = vec![
+            ExtensionType::ConfidentialTransferAccount,
+            ExtensionType::ConfidentialTransferFeeAmount,
+        ];
+
+        token
+            .create_auxiliary_token_account_with_extension_space(
+                &token_account_keypair,
+                &owner.pubkey(),
+                extensions,
+            )
+            .await
+            .unwrap();
+        let token_account = token_account_keypair.pubkey();
+
+        let elgamal_keypair =
+            ElGamalKeypair::new_from_signer(owner, &token_account.to_bytes()).unwrap();
+        let aes_key = AeKey::new_from_signer(owner, &token_account.to_bytes()).unwrap();
+
+        token
+            .confidential_transfer_configure_token_account(
+                &token_account,
+                &owner.pubkey(),
+                None,
+                None,
+                &elgamal_keypair,
+                &aes_key,
+                &[owner],
+            )
+            .await
+            .unwrap();
+
+        token
+            .mint_to(
+                &token_account,
+                &mint_authority.pubkey(),
+                amount,
+                &[mint_authority],
+            )
+            .await
+            .unwrap();
+
+        token
+            .confidential_transfer_deposit(
+                &token_account,
+                &owner.pubkey(),
+                amount,
+                decimals,
+                &[owner],
+            )
+            .await
+            .unwrap();
+
+        token
+            .confidential_transfer_apply_pending_balance(
+                &token_account,
+                &owner.pubkey(),
+                None,
+                elgamal_keypair.secret(),
+                &aes_key,
+                &[owner],
+            )
+            .await
+            .unwrap();
+
+        Self {
+            token_account,
+            elgamal_keypair,
+            aes_key,
+        }
+    }
+
+    #[cfg(feature = "zk-ops")]
+    async fn check_balances<T>(&self, token: &Token<T>, expected: ConfidentialTokenAccountBalances)
+    where
+        T: SendTransaction + SimulateTransaction,
+    {
+        let state = token.get_account_info(&self.token_account).await.unwrap();
+        let extension = state
+            .get_extension::<ConfidentialTransferAccount>()
+            .unwrap();
+
+        assert_eq!(
+            extension
+                .pending_balance_lo
+                .decrypt(self.elgamal_keypair.secret())
+                .unwrap(),
+            expected.pending_balance_lo,
+        );
+        assert_eq!(
+            extension
+                .pending_balance_hi
+                .decrypt(self.elgamal_keypair.secret())
+                .unwrap(),
+            expected.pending_balance_hi,
+        );
+        assert_eq!(
+            extension
+                .available_balance
+                .decrypt(self.elgamal_keypair.secret())
+                .unwrap(),
+            expected.available_balance,
+        );
+        assert_eq!(
+            self.aes_key
+                .decrypt(&extension.decryptable_available_balance.try_into().unwrap())
+                .unwrap(),
+            expected.decryptable_available_balance,
+        );
+    }
+}
+
+#[cfg(feature = "zk-ops")]
+struct ConfidentialTokenAccountBalances {
+    pending_balance_lo: u64,
+    pending_balance_hi: u64,
+    available_balance: u64,
+    decryptable_available_balance: u64,
+}
+
+#[cfg(feature = "zk-ops")]
 async fn check_withheld_amount_in_mint<T>(
     token: &Token<T>,
     withdraw_withheld_authority_elgamal_keypair: &ElGamalKeypair,
@@ -53,10 +184,12 @@ async fn check_withheld_amount_in_mint<T>(
     T: SendTransaction + SimulateTransaction,
 {
     let state = token.get_mint_info().await.unwrap();
-    let extension = state.get_extension::<ConfidentialTransferMint>().unwrap();
+    let extension = state
+        .get_extension::<ConfidentialTransferFeeConfig>()
+        .unwrap();
     let decrypted_amount = extension
         .withheld_amount
-        .decrypt(&withdraw_withheld_authority_elgamal_keypair.secret)
+        .decrypt(withdraw_withheld_authority_elgamal_keypair.secret())
         .unwrap();
     assert_eq!(decrypted_amount, expected);
 }
@@ -313,34 +446,39 @@ async fn confidential_transfer_initialize_and_update_mint() {
     assert_eq!(extension.authority, None.try_into().unwrap());
 }
 
-#[cfg(all(feature = "zk-ops", feature = "proof-program"))]
+#[cfg(feature = "zk-ops")]
 #[tokio::test]
-async fn ct_withdraw_withheld_tokens_from_mint() {
-    let ConfidentialTransferMintWithKeypairs {
-        ct_mint,
-        ct_mint_transfer_auditor_elgamal_keypair,
-        ct_mint_withdraw_withheld_authority_elgamal_keypair,
-        ..
-    } = ConfidentialTransferMintWithKeypairs::new();
+async fn confidential_transfer_withdraw_withheld_tokens_from_mint() {
+    let transfer_fee_authority = Keypair::new();
+    let withdraw_withheld_authority = Keypair::new();
 
-    let ct_mint_withdraw_withheld_authority = Keypair::new();
+    let confidential_transfer_authority = Keypair::new();
+    let auto_approve_new_accounts = true;
+    let auditor_elgamal_keypair = ElGamalKeypair::new_rand();
+    let auditor_elgamal_pubkey = (*auditor_elgamal_keypair.pubkey()).into();
+
+    let confidential_transfer_fee_authority = Keypair::new();
+    let withdraw_withheld_authority_elgamal_keypair = ElGamalKeypair::new_rand();
+    let withdraw_withheld_authority_elgamal_pubkey =
+        (*withdraw_withheld_authority_elgamal_keypair.pubkey()).into();
 
     let mut context = TestContext::new().await;
     context
         .init_token_with_mint(vec![
             ExtensionInitializationParams::TransferFeeConfig {
-                transfer_fee_config_authority: Some(Pubkey::new_unique()),
-                withdraw_withheld_authority: Some(ct_mint_withdraw_withheld_authority.pubkey()),
+                transfer_fee_config_authority: Some(transfer_fee_authority.pubkey()),
+                withdraw_withheld_authority: Some(withdraw_withheld_authority.pubkey()),
                 transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
                 maximum_fee: TEST_MAXIMUM_FEE,
             },
             ExtensionInitializationParams::ConfidentialTransferMint {
-                authority: ct_mint.authority.into(),
-                auto_approve_new_accounts: ct_mint.auto_approve_new_accounts.try_into().unwrap(),
-                auditor_elgamal_pubkey: ct_mint.auditor_elgamal_pubkey.into(),
-                withdraw_withheld_authority_elgamal_pubkey: ct_mint
-                    .withdraw_withheld_authority_elgamal_pubkey
-                    .into(),
+                authority: Some(confidential_transfer_authority.pubkey()),
+                auto_approve_new_accounts,
+                auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
+            },
+            ExtensionInitializationParams::ConfidentialTransferFeeConfig {
+                authority: Some(confidential_transfer_fee_authority.pubkey()),
+                withdraw_withheld_authority_elgamal_pubkey,
             },
         ])
         .await
@@ -355,75 +493,68 @@ async fn ct_withdraw_withheld_tokens_from_mint() {
         ..
     } = context.token_context.unwrap();
 
-    let epoch_info = test_epoch_info();
+    let alice_meta =
+        ConfidentialTokenAccountMeta::new(&token, &alice, &mint_authority, 100, decimals).await;
+    let bob_meta =
+        ConfidentialTokenAccountMeta::new(&token, &bob, &mint_authority, 0, decimals).await;
 
-    let alice_meta = ConfidentialTokenAccountMeta::with_tokens(
-        &token,
-        &alice,
-        None,
-        false,
-        false,
-        &mint_authority,
-        100,
-        decimals,
-    )
-    .await;
-    let bob_meta = ConfidentialTokenAccountMeta::new(&token, &bob, None, false, false).await;
-
-    token
-        .confidential_transfer_withdraw_withheld_tokens_from_mint_with_key(
-            &ct_mint_withdraw_withheld_authority,
-            &alice_meta.token_account,
-            &alice_meta.elgamal_keypair.public,
-            0_u64,
-            &ct_mint.withheld_amount.try_into().unwrap(),
-            &ct_mint_withdraw_withheld_authority_elgamal_keypair,
-        )
-        .await
-        .unwrap();
-
-    alice_meta
-        .check_balances(
-            &token,
-            ConfidentialTokenAccountBalances {
-                pending_balance_lo: 0,
-                pending_balance_hi: 0,
-                available_balance: 100,
-                decryptable_available_balance: 100,
-            },
-        )
-        .await;
-
-    check_withheld_amount_in_mint(
-        &token,
-        &ct_mint_withdraw_withheld_authority_elgamal_keypair,
-        0,
-    )
-    .await;
-
-    let state = token
-        .get_account_info(&alice_meta.token_account)
-        .await
-        .unwrap();
-    let extension = state
-        .get_extension::<ConfidentialTransferAccount>()
-        .unwrap();
+    let transfer_fee_parameters = TransferFee {
+        epoch: 0.into(),
+        maximum_fee: TEST_MAXIMUM_FEE.into(),
+        transfer_fee_basis_points: TEST_FEE_BASIS_POINTS.into(),
+    };
 
     // Test fee is 2.5% so the withheld fees should be 3
     token
         .confidential_transfer_transfer_with_fee(
             &alice_meta.token_account,
             &bob_meta.token_account,
-            &alice,
+            &alice.pubkey(),
             None,
             100,
-            100,
-            &extension.available_balance.try_into().unwrap(),
-            &bob_meta.elgamal_keypair.public,
-            Some(ct_mint_transfer_auditor_elgamal_keypair.public),
-            &ct_mint_withdraw_withheld_authority_elgamal_keypair.public,
-            &epoch_info,
+            None,
+            &alice_meta.elgamal_keypair,
+            &alice_meta.aes_key,
+            bob_meta.elgamal_keypair.pubkey(),
+            Some(auditor_elgamal_keypair.pubkey()),
+            withdraw_withheld_authority_elgamal_keypair.pubkey(),
+            transfer_fee_parameters.transfer_fee_basis_points.into(),
+            transfer_fee_parameters.maximum_fee.into(),
+            &[&alice],
         )
+        .await
+        .unwrap();
+
+    let new_decryptable_available_balance = alice_meta.aes_key.encrypt(0);
+    token
+        .confidential_transfer_withdraw_withheld_tokens_from_mint(
+            &alice_meta.token_account,
+            &withdraw_withheld_authority.pubkey(),
+            None,
+            None,
+            &withdraw_withheld_authority_elgamal_keypair,
+            alice_meta.elgamal_keypair.pubkey(),
+            &new_decryptable_available_balance.into(),
+            &[&withdraw_withheld_authority],
+        )
+        .await
+        .unwrap();
+
+    // withheld fees are not harvested to mint yet
+    alice_meta
+        .check_balances(
+            &token,
+            ConfidentialTokenAccountBalances {
+                pending_balance_lo: 0,
+                pending_balance_hi: 0,
+                available_balance: 0,
+                decryptable_available_balance: 0,
+            },
+        )
+        .await;
+
+    token
+        .confidential_transfer_harvest_withheld_tokens_to_mint(&[&bob_meta.token_account])
         .await
         .unwrap();
 
@@ -432,54 +563,44 @@ async fn ct_withdraw_withheld_tokens_from_mint() {
         .await
         .unwrap();
     let extension = state
-        .get_extension::<ConfidentialTransferAccount>()
+        .get_extension::<ConfidentialTransferFeeAmount>()
         .unwrap();
+    assert_eq!(extension.withheld_amount, pod::ElGamalCiphertext::zeroed());
 
-    assert_eq!(
-        extension
-            .withheld_amount
-            .decrypt(&ct_mint_withdraw_withheld_authority_elgamal_keypair.secret),
-        Some(3),
-    );
+    // calculate and encrypt fee to attach to the `WithdrawWithheldTokensFromMint` instruction data
+    let fee = transfer_fee_parameters.calculate_fee(100).unwrap();
+    let new_decryptable_available_balance = alice_meta.aes_key.encrypt(fee);
+
+    check_withheld_amount_in_mint(&token, &withdraw_withheld_authority_elgamal_keypair, fee).await;
 
     token
-        .confidential_transfer_harvest_withheld_tokens_to_mint(&[&bob_meta.token_account])
-        .await
-        .unwrap();
-
-    check_withheld_amount_in_mint(
-        &token,
-        &ct_mint_withdraw_withheld_authority_elgamal_keypair,
-        3,
-    )
-    .await;
-
-    let state = token.get_mint_info().await.unwrap();
-    let ct_mint = state.get_extension::<ConfidentialTransferMint>().unwrap();
-
-    token
-        .confidential_transfer_withdraw_withheld_tokens_from_mint_with_key(
-            &ct_mint_withdraw_withheld_authority,
+        .confidential_transfer_withdraw_withheld_tokens_from_mint(
             &alice_meta.token_account,
-            &alice_meta.elgamal_keypair.public,
-            3_u64,
-            &ct_mint.withheld_amount.try_into().unwrap(),
-            &ct_mint_withdraw_withheld_authority_elgamal_keypair,
+            &withdraw_withheld_authority.pubkey(),
+            None,
+            None,
+            &withdraw_withheld_authority_elgamal_keypair,
+            alice_meta.elgamal_keypair.pubkey(),
+            &new_decryptable_available_balance.into(),
+            &[&withdraw_withheld_authority],
         )
         .await
         .unwrap();
 
+    // withheld fees are withdrawn back to alice's account
     alice_meta
         .check_balances(
             &token,
             ConfidentialTokenAccountBalances {
-                pending_balance_lo: 3,
+                pending_balance_lo: 0,
                 pending_balance_hi: 0,
-                available_balance: 0,
-                decryptable_available_balance: 0,
+                available_balance: 3,
+                decryptable_available_balance: 3,
             },
         )
         .await;
+
+    check_withheld_amount_in_mint(&token, &withdraw_withheld_authority_elgamal_keypair, 0).await;
 }
 
 #[cfg(all(feature = "zk-ops", feature = "proof-program"))]

--- a/token/program-2022/src/error.rs
+++ b/token/program-2022/src/error.rs
@@ -213,8 +213,11 @@ pub enum TokenError {
 
     // 55
     /// An invalid proof instruction offset was provided
-    #[error("An invalid proof instruction offset was provided ")]
+    #[error("An invalid proof instruction offset was provided")]
     InvalidProofInstructionOffset,
+    /// Harvest of withheld tokens to mint is disabled
+    #[error("Harvest of withheld tokens to mint is disabled")]
+    HarvestToMintDisabled,
 }
 impl From<TokenError> for ProgramError {
     fn from(e: TokenError) -> Self {
@@ -374,6 +377,9 @@ impl PrintProgramError for TokenError {
             }
             TokenError::InvalidProofInstructionOffset => {
                 msg!("An invalid proof instruction offset was provided")
+            }
+            TokenError::HarvestToMintDisabled => {
+                msg!("Harvest of withheld tokens to mint is disabled")
             }
         }
     }

--- a/token/program-2022/src/extension/confidential_transfer_fee/account_info.rs
+++ b/token/program-2022/src/extension/confidential_transfer_fee/account_info.rs
@@ -1,0 +1,57 @@
+use {
+    crate::{error::TokenError, extension::confidential_transfer_fee::EncryptedWithheldAmount},
+    bytemuck::{Pod, Zeroable},
+    solana_zk_token_sdk::{
+        encryption::{
+            elgamal::{ElGamalCiphertext, ElGamalKeypair, ElGamalPubkey},
+            pedersen::PedersenOpening,
+        },
+        instruction::ciphertext_ciphertext_equality::CiphertextCiphertextEqualityProofData,
+    },
+};
+
+/// Confidential transfer fee extension information needed to construct a
+/// `WithdrawWithheldTokensFromMint` or `WithdrawWithheldTokensFromAccounts` instruction.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+pub struct WithheldTokensInfo {
+    /// The available balance
+    pub(crate) withheld_amount: EncryptedWithheldAmount,
+}
+impl WithheldTokensInfo {
+    /// Create a `WithheldTokensInfo` from an ElGamal ciphertext.
+    pub fn new(withheld_amount: EncryptedWithheldAmount) -> Self {
+        Self { withheld_amount }
+    }
+
+    /// Create an empty account proof data.
+    pub fn generate_proof_data(
+        &self,
+        withdraw_withheld_authority_elgamal_keypair: &ElGamalKeypair,
+        destination_elgamal_pubkey: &ElGamalPubkey,
+    ) -> Result<CiphertextCiphertextEqualityProofData, TokenError> {
+        let withheld_amount_in_mint: ElGamalCiphertext = self
+            .withheld_amount
+            .try_into()
+            .map_err(|_| TokenError::AccountDecryption)?;
+
+        let decrypted_withheld_amount_in_mint = withheld_amount_in_mint
+            .decrypt_u32(withdraw_withheld_authority_elgamal_keypair.secret())
+            .ok_or(TokenError::AccountDecryption)?;
+
+        let destination_opening = PedersenOpening::new_rand();
+
+        let destination_ciphertext = destination_elgamal_pubkey
+            .encrypt_with(decrypted_withheld_amount_in_mint, &destination_opening);
+
+        CiphertextCiphertextEqualityProofData::new(
+            withdraw_withheld_authority_elgamal_keypair,
+            destination_elgamal_pubkey,
+            &withheld_amount_in_mint,
+            &destination_ciphertext,
+            &destination_opening,
+            decrypted_withheld_amount_in_mint,
+        )
+        .map_err(|_| TokenError::ProofGeneration)
+    }
+}

--- a/token/program-2022/src/extension/confidential_transfer_fee/account_info.rs
+++ b/token/program-2022/src/extension/confidential_transfer_fee/account_info.rs
@@ -24,7 +24,7 @@ impl WithheldTokensInfo {
         Self { withheld_amount }
     }
 
-    /// Create an empty account proof data.
+    /// Create withdraw withheld proof data.
     pub fn generate_proof_data(
         &self,
         withdraw_withheld_authority_elgamal_keypair: &ElGamalKeypair,

--- a/token/program-2022/src/extension/confidential_transfer_fee/account_info.rs
+++ b/token/program-2022/src/extension/confidential_transfer_fee/account_info.rs
@@ -20,8 +20,10 @@ pub struct WithheldTokensInfo {
 }
 impl WithheldTokensInfo {
     /// Create a `WithheldTokensInfo` from an ElGamal ciphertext.
-    pub fn new(withheld_amount: EncryptedWithheldAmount) -> Self {
-        Self { withheld_amount }
+    pub fn new(withheld_amount: &EncryptedWithheldAmount) -> Self {
+        Self {
+            withheld_amount: *withheld_amount,
+        }
     }
 
     /// Create withdraw withheld proof data.

--- a/token/program-2022/src/extension/confidential_transfer_fee/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer_fee/instruction.rs
@@ -153,6 +153,40 @@ pub enum ConfidentialTransferFeeInstruction {
     ///   None
     ///
     HarvestWithheldTokensToMint,
+
+    /// Configure a confidential transfer fee mint to accept harvested confidential fees.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   * Single owner/delegate
+    ///   0. `[writable]` The SPL Token account.
+    ///   1. `[signer]` The confidential transfer fee authority.
+    ///
+    ///   *Multisignature owner/delegate
+    ///   0. `[writable]` The SPL Token account.
+    ///   1. `[]` The confidential transfer fee multisig authority,
+    ///   2. `[signer]` Required M signer accounts for the SPL Token Multisig account.
+    ///
+    /// Data expected by this instruction:
+    ///   None
+    EnableHarvestToMint,
+
+    /// Configure a confidential transfer fee mint to reject any harvested confidential fees.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   * Single owner/delegate
+    ///   0. `[writable]` The SPL Token account.
+    ///   1. `[signer]` The confidential transfer fee authority.
+    ///
+    ///   *Multisignature owner/delegate
+    ///   0. `[writable]` The SPL Token account.
+    ///   1. `[]` The confidential transfer fee multisig authority,
+    ///   2. `[signer]` Required M signer accounts for the SPL Token Multisig account.
+    ///
+    /// Data expected by this instruction:
+    ///   None
+    DisableHarvestToMint,
 }
 
 /// Data expected by `InitializeConfidentialTransferFeeConfig`
@@ -418,6 +452,58 @@ pub fn harvest_withheld_tokens_to_mint(
         accounts,
         TokenInstruction::ConfidentialTransferFeeExtension,
         ConfidentialTransferFeeInstruction::HarvestWithheldTokensToMint,
+        &(),
+    ))
+}
+
+/// Create an `EnableHarvestToMint` instruction
+pub fn enable_harvest_to_mint(
+    token_program_id: &Pubkey,
+    mint: &Pubkey,
+    authority: &Pubkey,
+    multisig_signers: &[&Pubkey],
+) -> Result<Instruction, ProgramError> {
+    check_program_account(token_program_id)?;
+    let mut accounts = vec![
+        AccountMeta::new(*mint, false),
+        AccountMeta::new_readonly(*authority, multisig_signers.is_empty()),
+    ];
+
+    for multisig_signer in multisig_signers.iter() {
+        accounts.push(AccountMeta::new_readonly(**multisig_signer, true));
+    }
+
+    Ok(encode_instruction(
+        token_program_id,
+        accounts,
+        TokenInstruction::ConfidentialTransferFeeExtension,
+        ConfidentialTransferFeeInstruction::EnableHarvestToMint,
+        &(),
+    ))
+}
+
+/// Create a `DisableHarvestToMint` instruction
+pub fn disable_harvest_to_mint(
+    token_program_id: &Pubkey,
+    mint: &Pubkey,
+    authority: &Pubkey,
+    multisig_signers: &[&Pubkey],
+) -> Result<Instruction, ProgramError> {
+    check_program_account(token_program_id)?;
+    let mut accounts = vec![
+        AccountMeta::new(*mint, false),
+        AccountMeta::new_readonly(*authority, multisig_signers.is_empty()),
+    ];
+
+    for multisig_signer in multisig_signers.iter() {
+        accounts.push(AccountMeta::new_readonly(**multisig_signer, true));
+    }
+
+    Ok(encode_instruction(
+        token_program_id,
+        accounts,
+        TokenInstruction::ConfidentialTransferFeeExtension,
+        ConfidentialTransferFeeInstruction::DisableHarvestToMint,
         &(),
     ))
 }

--- a/token/program-2022/src/extension/confidential_transfer_fee/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer_fee/instruction.rs
@@ -416,7 +416,7 @@ pub fn harvest_withheld_tokens_to_mint(
     Ok(encode_instruction(
         token_program_id,
         accounts,
-        TokenInstruction::ConfidentialTransferExtension,
+        TokenInstruction::ConfidentialTransferFeeExtension,
         ConfidentialTransferFeeInstruction::HarvestWithheldTokensToMint,
         &(),
     ))

--- a/token/program-2022/src/extension/confidential_transfer_fee/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer_fee/instruction.rs
@@ -87,6 +87,9 @@ pub enum ConfidentialTransferFeeInstruction {
     /// authority. This instruction is susceptible to front-running. Use
     /// `HarvestWithheldTokensToMint` and `WithdrawWithheldTokensFromMint` as an alternative.
     ///
+    /// The withheld confidential tokens are aggregated directly into the destination available
+    /// balance.
+    ///
     /// Note on front-running: This instruction requires a zero-knowledge proof verification
     /// instruction that is checked with respect to the account state (the currently withheld
     /// fees). Suppose that a withdraw withheld authority generates the
@@ -104,7 +107,7 @@ pub enum ConfidentialTransferFeeInstruction {
     ///
     /// In order for this instruction to be successfully processed, it must be accompanied by the
     /// `VerifyWithdrawWithheldTokens` instruction of the `zk_token_proof` program in the same
-    /// transaction.
+    /// transaction or the address of a context state account for the proof must be provided.
     ///
     /// Accounts expected by this instruction:
     ///
@@ -112,7 +115,9 @@ pub enum ConfidentialTransferFeeInstruction {
     ///   0. `[]` The token mint. Must include the `TransferFeeConfig` extension.
     ///   1. `[writable]` The fee receiver account. Must include the `TransferFeeAmount` and
     ///      `ConfidentialTransferAccount` extensions.
-    ///   2. `[]` Instructions sysvar.
+    ///   2. `[]` Instructions sysvar if `VerifyCiphertextCiphertextEquality` is included in the
+    ///      same transaction or context state account if `VerifyCiphertextCiphertextEquality` is
+    ///      pre-verified into a context state account.
     ///   3. `[signer]` The mint's `withdraw_withheld_authority`.
     ///   4. ..3+N `[writable]` The source accounts to withdraw from.
     ///
@@ -120,10 +125,12 @@ pub enum ConfidentialTransferFeeInstruction {
     ///   0. `[]` The token mint. Must include the `TransferFeeConfig` extension.
     ///   1. `[writable]` The fee receiver account. Must include the `TransferFeeAmount` and
     ///      `ConfidentialTransferAccount` extensions.
-    ///   2. `[]` Instructions sysvar.
+    ///   2. `[]` Instructions sysvar if `VerifyCiphertextCiphertextEquality` is included in the
+    ///      same transaction or context state account if `VerifyCiphertextCiphertextEquality` is
+    ///      pre-verified into a context state account.
     ///   3. `[]` The mint's multisig `withdraw_withheld_authority`.
     ///   4. ..4+M `[signer]` M signer accounts.
-    ///   4+M+1. ..3+M+N `[writable]` The source accounts to withdraw from.
+    ///   4+M+1. ..4+M+N `[writable]` The source accounts to withdraw from.
     ///
     /// Data expected by this instruction:
     ///   WithdrawWithheldTokensFromAccountsData
@@ -178,8 +185,11 @@ pub struct WithdrawWithheldTokensFromAccountsData {
     /// Number of token accounts harvested
     pub num_token_accounts: u8,
     /// Relative location of the `ProofInstruction::VerifyWithdrawWithheld` instruction to the
-    /// `VerifyWithdrawWithheldTokensFromAccounts` instruction in the transaction
+    /// `VerifyWithdrawWithheldTokensFromAccounts` instruction in the transaction. If the offset is
+    /// `0`, then use a context state account for the proof.
     pub proof_instruction_offset: i8,
+    /// The new decryptable balance in the destination token account.
+    pub new_decryptable_available_balance: DecryptableBalance,
 }
 
 /// Create a `InitializeConfidentialTransferFeeConfig` instruction
@@ -280,7 +290,7 @@ pub fn withdraw_withheld_tokens_from_mint(
         // This constructor appends the proof instruction right after the
         // `WithdrawWithheldTokensFromMint` instruction. This means that the proof instruction
         // offset must be always be 1. To use an arbitrary proof instruction offset, use the
-        // `inner_configure_account` constructor.
+        // `inner_withdraw_withheld_tokens_from_mint` constructor.
         let proof_instruction_offset: i8 = proof_instruction_offset.into();
         if proof_instruction_offset != 1 {
             return Err(TokenError::InvalidProofInstructionOffset.into());
@@ -294,14 +304,16 @@ pub fn withdraw_withheld_tokens_from_mint(
 /// Create an inner `WithdrawWithheldTokensFromMint` instruction
 ///
 /// This instruction is suitable for use with a cross-program `invoke`
+#[allow(clippy::too_many_arguments)]
 pub fn inner_withdraw_withheld_tokens_from_accounts(
     token_program_id: &Pubkey,
     mint: &Pubkey,
     destination: &Pubkey,
+    new_decryptable_available_balance: &DecryptableBalance,
     authority: &Pubkey,
     multisig_signers: &[&Pubkey],
     sources: &[&Pubkey],
-    proof_instruction_offset: i8,
+    proof_data_location: ProofLocation<CiphertextCiphertextEqualityProofData>,
 ) -> Result<Instruction, ProgramError> {
     check_program_account(token_program_id)?;
     let num_token_accounts =
@@ -309,9 +321,23 @@ pub fn inner_withdraw_withheld_tokens_from_accounts(
     let mut accounts = vec![
         AccountMeta::new(*mint, false),
         AccountMeta::new(*destination, false),
-        AccountMeta::new_readonly(sysvar::instructions::id(), false),
-        AccountMeta::new_readonly(*authority, multisig_signers.is_empty()),
     ];
+
+    let proof_instruction_offset = match proof_data_location {
+        ProofLocation::InstructionOffset(proof_instruction_offset, _) => {
+            accounts.push(AccountMeta::new_readonly(sysvar::instructions::id(), false));
+            proof_instruction_offset.into()
+        }
+        ProofLocation::ContextStateAccount(context_state_account) => {
+            accounts.push(AccountMeta::new_readonly(*context_state_account, false));
+            0
+        }
+    };
+
+    accounts.push(AccountMeta::new_readonly(
+        *authority,
+        multisig_signers.is_empty(),
+    ));
 
     for multisig_signer in multisig_signers.iter() {
         accounts.push(AccountMeta::new(**multisig_signer, false));
@@ -324,39 +350,54 @@ pub fn inner_withdraw_withheld_tokens_from_accounts(
     Ok(encode_instruction(
         token_program_id,
         accounts,
-        TokenInstruction::ConfidentialTransferExtension,
+        TokenInstruction::ConfidentialTransferFeeExtension,
         ConfidentialTransferFeeInstruction::WithdrawWithheldTokensFromAccounts,
         &WithdrawWithheldTokensFromAccountsData {
             proof_instruction_offset,
             num_token_accounts,
+            new_decryptable_available_balance: *new_decryptable_available_balance,
         },
     ))
 }
 
 /// Create a `WithdrawWithheldTokensFromAccounts` instruction
-#[cfg(feature = "proof-program")]
+#[allow(clippy::too_many_arguments)]
 pub fn withdraw_withheld_tokens_from_accounts(
     token_program_id: &Pubkey,
     mint: &Pubkey,
     destination: &Pubkey,
+    new_decryptable_available_balance: &DecryptableBalance,
     authority: &Pubkey,
     multisig_signers: &[&Pubkey],
     sources: &[&Pubkey],
-    proof_data: &WithdrawWithheldTokensData,
+    proof_data_location: ProofLocation<CiphertextCiphertextEqualityProofData>,
 ) -> Result<Vec<Instruction>, ProgramError> {
-    Ok(vec![
-        inner_withdraw_withheld_tokens_from_accounts(
-            token_program_id,
-            mint,
-            destination,
-            authority,
-            multisig_signers,
-            sources,
-            1,
-        )?,
-        #[cfg(feature = "proof-program")]
-        verify_withdraw_withheld_tokens(proof_data),
-    ])
+    let mut instructions = vec![inner_withdraw_withheld_tokens_from_accounts(
+        token_program_id,
+        mint,
+        destination,
+        new_decryptable_available_balance,
+        authority,
+        multisig_signers,
+        sources,
+        proof_data_location,
+    )?];
+
+    if let ProofLocation::InstructionOffset(proof_instruction_offset, proof_data) =
+        proof_data_location
+    {
+        // This constructor appends the proof instruction right after the
+        // `WithdrawWithheldTokensFromAccounts` instruction. This means that the proof instruction
+        // offset must always be 1. To use an arbitrary proof instruction offset, use the
+        // `inner_withdraw_withheld_tokens_from_accounts` constructor.
+        let proof_instruction_offset: i8 = proof_instruction_offset.into();
+        if proof_instruction_offset != 1 {
+            return Err(TokenError::InvalidProofInstructionOffset.into());
+        }
+        instructions.push(verify_ciphertext_ciphertext_equality(None, proof_data));
+    };
+
+    Ok(instructions)
 }
 
 /// Creates a `HarvestWithheldTokensToMint` instruction

--- a/token/program-2022/src/extension/confidential_transfer_fee/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer_fee/instruction.rs
@@ -159,11 +159,11 @@ pub enum ConfidentialTransferFeeInstruction {
     /// Accounts expected by this instruction:
     ///
     ///   * Single owner/delegate
-    ///   0. `[writable]` The SPL Token account.
+    ///   0. `[writable]` The token mint.
     ///   1. `[signer]` The confidential transfer fee authority.
     ///
     ///   *Multisignature owner/delegate
-    ///   0. `[writable]` The SPL Token account.
+    ///   0. `[writable]` The token mint.
     ///   1. `[]` The confidential transfer fee multisig authority,
     ///   2. `[signer]` Required M signer accounts for the SPL Token Multisig account.
     ///
@@ -176,11 +176,11 @@ pub enum ConfidentialTransferFeeInstruction {
     /// Accounts expected by this instruction:
     ///
     ///   * Single owner/delegate
-    ///   0. `[writable]` The SPL Token account.
+    ///   0. `[writable]` The token mint.
     ///   1. `[signer]` The confidential transfer fee authority.
     ///
     ///   *Multisignature owner/delegate
-    ///   0. `[writable]` The SPL Token account.
+    ///   0. `[writable]` The token mint.
     ///   1. `[]` The confidential transfer fee multisig authority,
     ///   2. `[signer]` Required M signer accounts for the SPL Token Multisig account.
     ///

--- a/token/program-2022/src/extension/confidential_transfer_fee/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer_fee/instruction.rs
@@ -1,12 +1,16 @@
-#[cfg(feature = "proof-program")]
-use crate::extension::confidential_transfer::instruction::{
-    verify_withdraw_withheld_tokens, WithdrawWithheldTokensData,
-};
 use {
     crate::{
         check_program_account,
+        error::TokenError,
+        extension::confidential_transfer::{
+            instruction::{
+                verify_ciphertext_ciphertext_equality, CiphertextCiphertextEqualityProofData,
+            },
+            DecryptableBalance,
+        },
         instruction::{encode_instruction, TokenInstruction},
         pod::OptionalNonZeroPubkey,
+        proof::ProofLocation,
         solana_zk_token_sdk::zk_token_elgamal::pod::ElGamalPubkey,
     },
     bytemuck::{Pod, Zeroable},
@@ -46,9 +50,12 @@ pub enum ConfidentialTransferFeeInstruction {
     /// Transfer all withheld confidential tokens in the mint to an account. Signed by the mint's
     /// withdraw withheld tokens authority.
     ///
+    /// The withheld confidential tokens are aggregated directly into the destination available
+    /// balance.
+    ///
     /// In order for this instruction to be successfully processed, it must be accompanied by the
-    /// `VerifyWithdrawWithheldTokens` instruction of the `zk_token_proof` program in the same
-    /// transaction.
+    /// `VerifyCiphertextCiphertextEquality` instruction of the `zk_token_proof` program in the
+    /// same transaction or the address of a context state account for the proof must be provided.
     ///
     /// Accounts expected by this instruction:
     ///
@@ -56,14 +63,18 @@ pub enum ConfidentialTransferFeeInstruction {
     ///   0. `[writable]` The token mint. Must include the `TransferFeeConfig` extension.
     ///   1. `[writable]` The fee receiver account. Must include the `TransferFeeAmount` and
     ///      `ConfidentialTransferAccount` extensions.
-    ///   2. `[]` Instructions sysvar.
+    ///   2. `[]` Instructions sysvar if `VerifyCiphertextCiphertextEquality` is included in the same
+    ///      transaction or context state account if `VerifyCiphertextCiphertextEquality` is
+    ///      pre-verified into a context state account.
     ///   3. `[signer]` The mint's `withdraw_withheld_authority`.
     ///
     ///   * Multisignature owner/delegate
     ///   0. `[writable]` The token mint. Must include the `TransferFeeConfig` extension.
     ///   1. `[writable]` The fee receiver account. Must include the `TransferFeeAmount` and
     ///      `ConfidentialTransferAccount` extensions.
-    ///   2. `[]` Instructions sysvar.
+    ///   2. `[]` Instructions sysvar if `VerifyCiphertextCiphertextEquality` is included in the same
+    ///      transaction or context state account if `VerifyCiphertextCiphertextEquality` is
+    ///      pre-verified into a context state account.
     ///   3. `[]` The mint's multisig `withdraw_withheld_authority`.
     ///   4. ..3+M `[signer]` M signer accounts.
     ///
@@ -153,8 +164,11 @@ pub struct InitializeConfidentialTransferFeeConfigData {
 #[repr(C)]
 pub struct WithdrawWithheldTokensFromMintData {
     /// Relative location of the `ProofInstruction::VerifyWithdrawWithheld` instruction to the
-    /// `WithdrawWithheldTokensFromMint` instruction in the transaction
+    /// `WithdrawWithheldTokensFromMint` instruction in the transaction. If the offset is `0`, then
+    /// use a context state account for the proof.
     pub proof_instruction_offset: i8,
+    /// The new decryptable balance in the destination token account.
+    pub new_decryptable_available_balance: DecryptableBalance,
 }
 
 /// Data expected by `ConfidentialTransferFeeInstruction::WithdrawWithheldTokensFromAccounts`
@@ -197,17 +211,32 @@ pub fn inner_withdraw_withheld_tokens_from_mint(
     token_program_id: &Pubkey,
     mint: &Pubkey,
     destination: &Pubkey,
+    new_decryptable_available_balance: &DecryptableBalance,
     authority: &Pubkey,
     multisig_signers: &[&Pubkey],
-    proof_instruction_offset: i8,
+    proof_data_location: ProofLocation<CiphertextCiphertextEqualityProofData>,
 ) -> Result<Instruction, ProgramError> {
     check_program_account(token_program_id)?;
     let mut accounts = vec![
         AccountMeta::new(*mint, false),
         AccountMeta::new(*destination, false),
-        AccountMeta::new_readonly(sysvar::instructions::id(), false),
-        AccountMeta::new_readonly(*authority, multisig_signers.is_empty()),
     ];
+
+    let proof_instruction_offset = match proof_data_location {
+        ProofLocation::InstructionOffset(proof_instruction_offset, _) => {
+            accounts.push(AccountMeta::new_readonly(sysvar::instructions::id(), false));
+            proof_instruction_offset.into()
+        }
+        ProofLocation::ContextStateAccount(context_state_account) => {
+            accounts.push(AccountMeta::new_readonly(*context_state_account, false));
+            0
+        }
+    };
+
+    accounts.push(AccountMeta::new_readonly(
+        *authority,
+        multisig_signers.is_empty(),
+    ));
 
     for multisig_signer in multisig_signers.iter() {
         accounts.push(AccountMeta::new(**multisig_signer, false));
@@ -216,36 +245,50 @@ pub fn inner_withdraw_withheld_tokens_from_mint(
     Ok(encode_instruction(
         token_program_id,
         accounts,
-        TokenInstruction::ConfidentialTransferExtension,
+        TokenInstruction::ConfidentialTransferFeeExtension,
         ConfidentialTransferFeeInstruction::WithdrawWithheldTokensFromMint,
         &WithdrawWithheldTokensFromMintData {
             proof_instruction_offset,
+            new_decryptable_available_balance: *new_decryptable_available_balance,
         },
     ))
 }
 
 /// Create an `WithdrawWithheldTokensFromMint` instruction
-#[cfg(feature = "proof-program")]
 pub fn withdraw_withheld_tokens_from_mint(
     token_program_id: &Pubkey,
     mint: &Pubkey,
     destination: &Pubkey,
+    new_decryptable_available_balance: &DecryptableBalance,
     authority: &Pubkey,
     multisig_signers: &[&Pubkey],
-    proof_data: &WithdrawWithheldTokensData,
+    proof_data_location: ProofLocation<CiphertextCiphertextEqualityProofData>,
 ) -> Result<Vec<Instruction>, ProgramError> {
-    Ok(vec![
-        inner_withdraw_withheld_tokens_from_mint(
-            token_program_id,
-            mint,
-            destination,
-            authority,
-            multisig_signers,
-            1,
-        )?,
-        #[cfg(feature = "proof-program")]
-        verify_withdraw_withheld_tokens(proof_data),
-    ])
+    let mut instructions = vec![inner_withdraw_withheld_tokens_from_mint(
+        token_program_id,
+        mint,
+        destination,
+        new_decryptable_available_balance,
+        authority,
+        multisig_signers,
+        proof_data_location,
+    )?];
+
+    if let ProofLocation::InstructionOffset(proof_instruction_offset, proof_data) =
+        proof_data_location
+    {
+        // This constructor appends the proof instruction right after the
+        // `WithdrawWithheldTokensFromMint` instruction. This means that the proof instruction
+        // offset must be always be 1. To use an arbitrary proof instruction offset, use the
+        // `inner_configure_account` constructor.
+        let proof_instruction_offset: i8 = proof_instruction_offset.into();
+        if proof_instruction_offset != 1 {
+            return Err(TokenError::InvalidProofInstructionOffset.into());
+        }
+        instructions.push(verify_ciphertext_ciphertext_equality(None, proof_data));
+    };
+
+    Ok(instructions)
 }
 
 /// Create an inner `WithdrawWithheldTokensFromMint` instruction

--- a/token/program-2022/src/extension/confidential_transfer_fee/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer_fee/mod.rs
@@ -40,6 +40,9 @@ pub struct ConfidentialTransferFeeConfig {
     /// fee parameters, the withheld fee amounts can reveal information about transfer amounts.
     pub withdraw_withheld_authority_elgamal_pubkey: ElGamalPubkey,
 
+    /// If `false`, the harvest of withheld tokens to mint is rejected.
+    pub harvest_to_mint_disabled: PodBool,
+
     /// Withheld confidential transfer fee tokens that have been moved to the mint for withdrawal.
     pub withheld_amount: EncryptedWithheldAmount,
 }

--- a/token/program-2022/src/extension/confidential_transfer_fee/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer_fee/mod.rs
@@ -41,7 +41,7 @@ pub struct ConfidentialTransferFeeConfig {
     pub withdraw_withheld_authority_elgamal_pubkey: ElGamalPubkey,
 
     /// If `false`, the harvest of withheld tokens to mint is rejected.
-    pub harvest_to_mint_disabled: PodBool,
+    pub harvest_to_mint_enabled: PodBool,
 
     /// Withheld confidential transfer fee tokens that have been moved to the mint for withdrawal.
     pub withheld_amount: EncryptedWithheldAmount,

--- a/token/program-2022/src/extension/confidential_transfer_fee/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer_fee/mod.rs
@@ -1,5 +1,3 @@
-#[cfg(not(target_os = "solana"))]
-use crate::extension::confidential_transfer_fee::account_info::*;
 use {
     crate::{
         error::TokenError,
@@ -49,17 +47,6 @@ pub struct ConfidentialTransferFeeConfig {
 
 impl Extension for ConfidentialTransferFeeConfig {
     const TYPE: ExtensionType = ExtensionType::ConfidentialTransferFeeConfig;
-}
-
-impl ConfidentialTransferFeeConfig {
-    /// Return the account information needed to construct a `WithdrawWithheldTokensFromMint`
-    /// instruction.
-    #[cfg(not(target_os = "solana"))]
-    pub fn withheld_tokens_info(&self) -> WithheldTokensInfo {
-        WithheldTokensInfo {
-            withheld_amount: self.withheld_amount,
-        }
-    }
 }
 
 /// Confidential transfer fee

--- a/token/program-2022/src/extension/confidential_transfer_fee/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer_fee/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(not(target_os = "solana"))]
+use crate::extension::confidential_transfer_fee::account_info::*;
 use {
     crate::{
         error::TokenError,
@@ -14,6 +16,10 @@ pub mod instruction;
 
 /// Confidential transfer fee extension processor
 pub mod processor;
+
+/// Confidential Transfer Fee extension account information needed for instructions
+#[cfg(not(target_os = "solana"))]
+pub mod account_info;
 
 /// ElGamal ciphertext containing a transfer fee
 pub type EncryptedFee = FeeEncryption;
@@ -40,6 +46,17 @@ pub struct ConfidentialTransferFeeConfig {
 
 impl Extension for ConfidentialTransferFeeConfig {
     const TYPE: ExtensionType = ExtensionType::ConfidentialTransferFeeConfig;
+}
+
+impl ConfidentialTransferFeeConfig {
+    /// Return the account information needed to construct a `WithdrawWithheldTokensFromMint`
+    /// instruction.
+    #[cfg(not(target_os = "solana"))]
+    pub fn withheld_tokens_info(&self) -> WithheldTokensInfo {
+        WithheldTokensInfo {
+            withheld_amount: self.withheld_amount,
+        }
+    }
 }
 
 /// Confidential transfer fee

--- a/token/program-2022/src/extension/confidential_transfer_fee/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer_fee/processor.rs
@@ -469,24 +469,31 @@ pub(crate) fn process_instruction(
         }
         ConfidentialTransferFeeInstruction::WithdrawWithheldTokensFromMint => {
             msg!("ConfidentialTransferFeeInstruction::WithdrawWithheldTokensFromMint");
-            let data = decode_instruction_data::<WithdrawWithheldTokensFromMintData>(input)?;
-            process_withdraw_withheld_tokens_from_mint(
-                program_id,
-                accounts,
-                &data.new_decryptable_available_balance,
-                data.proof_instruction_offset as i64,
-            )
+            #[cfg(feature = "zk-ops")]
+            {
+                let data = decode_instruction_data::<WithdrawWithheldTokensFromMintData>(input)?;
+                process_withdraw_withheld_tokens_from_mint(
+                    program_id,
+                    accounts,
+                    &data.new_decryptable_available_balance,
+                    data.proof_instruction_offset as i64,
+                )
+            }
         }
         ConfidentialTransferFeeInstruction::WithdrawWithheldTokensFromAccounts => {
             msg!("ConfidentialTransferFeeInstruction::WithdrawWithheldTokensFromAccounts");
-            let data = decode_instruction_data::<WithdrawWithheldTokensFromAccountsData>(input)?;
-            process_withdraw_withheld_tokens_from_accounts(
-                program_id,
-                accounts,
-                data.num_token_accounts,
-                &data.new_decryptable_available_balance,
-                data.proof_instruction_offset as i64,
-            )
+            #[cfg(feature = "zk-ops")]
+            {
+                let data =
+                    decode_instruction_data::<WithdrawWithheldTokensFromAccountsData>(input)?;
+                process_withdraw_withheld_tokens_from_accounts(
+                    program_id,
+                    accounts,
+                    data.num_token_accounts,
+                    &data.new_decryptable_available_balance,
+                    data.proof_instruction_offset as i64,
+                )
+            }
         }
         ConfidentialTransferFeeInstruction::HarvestWithheldTokensToMint => {
             msg!("ConfidentialTransferFeeInstruction::HarvestWithheldTokensToMint");

--- a/token/program-2022/src/extension/confidential_transfer_fee/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer_fee/processor.rs
@@ -481,6 +481,10 @@ pub(crate) fn process_instruction(
                     data.proof_instruction_offset as i64,
                 )
             }
+            #[cfg(not(feature = "zk-ops"))]
+            {
+                Err(ProgramError::InvalidInstructionData)
+            }
         }
         ConfidentialTransferFeeInstruction::WithdrawWithheldTokensFromAccounts => {
             msg!("ConfidentialTransferFeeInstruction::WithdrawWithheldTokensFromAccounts");
@@ -495,6 +499,10 @@ pub(crate) fn process_instruction(
                     &data.new_decryptable_available_balance,
                     data.proof_instruction_offset as i64,
                 )
+            }
+            #[cfg(not(feature = "zk-ops"))]
+            {
+                Err(ProgramError::InvalidInstructionData)
             }
         }
         ConfidentialTransferFeeInstruction::HarvestWithheldTokensToMint => {

--- a/token/program-2022/src/extension/confidential_transfer_fee/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer_fee/processor.rs
@@ -60,7 +60,7 @@ fn process_initialize_confidential_transfer_fee_config(
     extension.authority = *authority;
     extension.withdraw_withheld_authority_elgamal_pubkey =
         *withdraw_withheld_authority_elgamal_pubkey;
-    extension.harvest_to_mint_disabled = false.into();
+    extension.harvest_to_mint_enabled = true.into();
     extension.withheld_amount = EncryptedWithheldAmount::zeroed();
 
     Ok(())

--- a/token/program-2022/src/extension/confidential_transfer_fee/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer_fee/processor.rs
@@ -414,13 +414,13 @@ pub(crate) fn process_instruction(
         ConfidentialTransferFeeInstruction::WithdrawWithheldTokensFromAccounts => {
             msg!("ConfidentialTransferInstruction::WithdrawWithheldTokensFromAccounts");
             let data = decode_instruction_data::<WithdrawWithheldTokensFromAccountsData>(input)?;
-            return process_withdraw_withheld_tokens_from_accounts(
+            process_withdraw_withheld_tokens_from_accounts(
                 program_id,
                 accounts,
                 data.num_token_accounts,
                 &data.new_decryptable_available_balance,
                 data.proof_instruction_offset as i64,
-            );
+            )
         }
         ConfidentialTransferFeeInstruction::HarvestWithheldTokensToMint => {
             msg!("ConfidentialTransferInstruction::HarvestWithheldTokensToMint");

--- a/token/program-2022/src/extension/confidential_transfer_fee/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer_fee/processor.rs
@@ -364,10 +364,10 @@ fn process_harvest_withheld_tokens_to_mint(accounts: &[AccountInfo]) -> ProgramR
     let confidential_transfer_fee_mint =
         mint.get_extension_mut::<ConfidentialTransferFeeConfig>()?;
 
-    if confidential_transfer_fee_mint
-        .harvest_to_mint_disabled
-        .into()
-    {
+    let harvest_to_mint_enabled: bool = confidential_transfer_fee_mint
+        .harvest_to_mint_enabled
+        .into();
+    if !harvest_to_mint_enabled {
         return Err(TokenError::HarvestToMintDisabled.into());
     }
 
@@ -415,7 +415,7 @@ fn process_enable_harvest_to_mint(accounts: &[AccountInfo]) -> ProgramResult {
         return Err(TokenError::OwnerMismatch.into());
     }
 
-    confidential_transfer_fee_mint.harvest_to_mint_disabled = false.into();
+    confidential_transfer_fee_mint.harvest_to_mint_enabled = true.into();
     Ok(())
 }
 
@@ -444,7 +444,7 @@ fn process_disable_harvest_to_mint(accounts: &[AccountInfo]) -> ProgramResult {
         return Err(TokenError::OwnerMismatch.into());
     }
 
-    confidential_transfer_fee_mint.harvest_to_mint_disabled = true.into();
+    confidential_transfer_fee_mint.harvest_to_mint_enabled = false.into();
     Ok(())
 }
 


### PR DESCRIPTION
#### Problem
The confidential transfer fee extension is not updated for solana 1.16

#### Summary of changes
The most importants changes in the first, second, and last commits.

[b96f57a](https://github.com/solana-labs/solana-program-library/pull/4896/commits/b96f57a632187bc21c28418bb4df8d84dbbac1fb): Updated the `WithdrawWithheldTokensFromMint` instruction for Solana 1.16 and for it to support context states. This is pretty straightforward except for the part about adding the withheld feeds directly into a destination available balance.

The original plan (https://github.com/solana-labs/solana-program-library/issues/4817) was to divide the withheld amount into low and high parts. Transfer amounts and fees in the instruction are divided into low and high bits so that they are easier to decrypt. When the transfer amount is accumulated into a destination account, the transfer amounts are added into the lo and hi pending balance fields. However, for the case of fees, they are merged and added to the single withheld fees field. Similarly, when these withheld fees are harvest into the mint, it is added to a single withheld fee field. If the withheld fees grow large then it could be inefficient for a withdraw withheld authority to decrypt the ciphertext. 

We can choose to also break up the withheld fees into lo and hi parts like the pending balance to make it easier for withdraw withheld authority to decrypt the withheld fees in an account for mint. However, I ended up deciding against it  because
- Having two ciphertexts for withheld fees in each account requires extra space
- More importantly, the instruction `WithdrawWithheldTokensFromMint` requires a `CiphertextCiphertextEqualityProof`. If there are two ciphertexts for withheld fees, then we have to either attach two instances of this zkp or batch them, which would require a new instruction in the proof program.
- In the worst case that the withdraw withheld authority cannot decrypt the withheld fees directly from the mint info, it can look up the previously list of transactions and decrypt. 

Previously, when the withheld fees in the mint are withdrawn to an account, they were added into the "lo" part of the pending balance of the destination account. This is fine, but a little unnatural. If the fees are already merged, then it should really be added into the available balance. So in this PR, I made the change. Since we are making changes to the available balance, I also added the new decryptable available balance field in the instruction.

[e64c9f0](https://github.com/solana-labs/solana-program-library/pull/4896/commits/e64c9f0b58d6b7a6b730d5f35409d31a2c026733): Updated the `WithdrawWithheldTokensFromAccount` instruction for Solana 1.16 and for it to support context states as above.

[0ed218e](https://github.com/solana-labs/solana-program-library/pull/4896/commits/0ed218e832e97802cc8968cb2d8ee77f055771e2): Small PR to unfeaturize the client function for `HarvestWithheldTokensToMint` instruction.

[dcc8574](https://github.com/solana-labs/solana-program-library/pull/4896/commits/dcc857472611006aa1346d74bd482a7e5093cf1a): Updated the tests for the `WithdrawWithheldTokensFromMint` instruction. I added the `ConfidentialTokenAccountMeta` helper struct in `tests/confidential_transfer_fee.rs`, which is a stripped down version of `ConfidentialTokensAccountMeta` in `tests/confidential_transfer.rs`. I can re-use the helper struct from `tests/confidential_transfer.rs`, but I decided to just have a separate helper struct in `test/confidential_transfer_fee.rs` that does not deal with fields like memo. The rest of the tests were straightforward.

[c582a53](https://github.com/solana-labs/solana-program-library/pull/4896/commits/c582a536fbab7a22a95ad85dcd1ce333685a2565): Updated the tests for the `WithdrawWithheldTokensFromAccounts` instruction.

[a00c50e](https://github.com/solana-labs/solana-program-library/pull/4896/commits/a00c50e23df62a1acd9f363de60cc1be6d6a1afd): Added tests that deal with context states for the `WithdrawWithheldTokensFromMint` and `WithdrawWithheldTokensFromAccounts` instructions.

[3a6b3e0](https://github.com/solana-labs/solana-program-library/pull/4896/commits/3a6b3e0dec00e10492d080f31921b6c667815635): Right now, the instruction `WithdrawWithheldTokensFromMint` could be susceptible to front-running. The zero-knowledge proof that is needed for the instruction depends on the currently withheld amount ciphertext in the mint. If the withheld amount is constantly harvested into the mint, the zkp can be nullified. 

This PR added `EnableHarvestToMint` and `DisableHarvestToMint`, which acts like `{Enable,Disable}ConfidentialTransfers` and `{Enable,Disable}NonConfidentialTransfers` for harvest. If the harvest fails due to front-running, the harvest authority can disable harvest, withdraw withheld tokens, and then enable harvest.