### PR TITLE
stake-pool: Update tests for 1.17

### DIFF
--- a/stake-pool/program/src/big_vec.rs
+++ b/stake-pool/program/src/big_vec.rs
@@ -32,7 +32,10 @@ impl<'data> BigVec<'data> {
     }
 
     /// Retain all elements that match the provided function, discard all others
-    pub fn retain<T: Pack>(&mut self, predicate: fn(&[u8]) -> bool) -> Result<(), ProgramError> {
+    pub fn retain<T: Pack, F: Fn(&[u8]) -> bool>(
+        &mut self,
+        predicate: F,
+    ) -> Result<(), ProgramError> {
         let mut vec_len = self.len();
         let mut removals_found = 0;
         let mut dst_start_index = 0;
@@ -307,7 +310,7 @@ mod tests {
 
         let mut data = [0u8; 4 + 8 * 4];
         let mut v = from_slice(&mut data, &[1, 2, 3, 4]);
-        v.retain::<TestStruct>(mod_2_predicate).unwrap();
+        v.retain::<TestStruct, _>(mod_2_predicate).unwrap();
         check_big_vec_eq(&v, &[2, 4]);
     }
 

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -2582,7 +2582,7 @@ impl Processor {
             return Err(StakePoolError::InvalidState.into());
         }
 
-        validator_list.retain::<ValidatorStakeInfo>(ValidatorStakeInfo::is_not_removed)?;
+        validator_list.retain::<ValidatorStakeInfo, _>(ValidatorStakeInfo::is_not_removed)?;
 
         Ok(())
     }

--- a/stake-pool/program/tests/decrease.rs
+++ b/stake-pool/program/tests/decrease.rs
@@ -537,7 +537,7 @@ async fn fail_additional_with_increasing() {
 
     // warp forward to activation
     let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
-    context.warp_to_slot(first_normal_slot).unwrap();
+    context.warp_to_slot(first_normal_slot + 1).unwrap();
     let last_blockhash = context
         .banks_client
         .get_new_latest_blockhash(&context.last_blockhash)

--- a/stake-pool/program/tests/deposit.rs
+++ b/stake-pool/program/tests/deposit.rs
@@ -88,7 +88,7 @@ async fn setup(
     .await;
 
     let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
-    context.warp_to_slot(first_normal_slot).unwrap();
+    context.warp_to_slot(first_normal_slot + 1).unwrap();
     stake_pool_accounts
         .update_all(
             &mut context.banks_client,

--- a/stake-pool/program/tests/deposit_edge_cases.rs
+++ b/stake-pool/program/tests/deposit_edge_cases.rs
@@ -81,7 +81,7 @@ async fn setup(
     .await;
 
     let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
-    context.warp_to_slot(first_normal_slot).unwrap();
+    context.warp_to_slot(first_normal_slot + 1).unwrap();
     stake_pool_accounts
         .update_all(
             &mut context.banks_client,

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -2379,12 +2379,14 @@ pub fn add_validator_stake_account(
         credits_observed: 0,
     };
 
+    let mut data = bincode::serialize::<stake::state::StakeState>(
+        &stake::state::StakeState::Stake(meta, stake),
+    )
+    .unwrap();
+    data.extend_from_slice(&[0, 0, 0, 0]);
     let stake_account = SolanaAccount::create(
         stake_amount + STAKE_ACCOUNT_RENT_EXEMPTION,
-        bincode::serialize::<stake::state::StakeState>(&stake::state::StakeState::Stake(
-            meta, stake,
-        ))
-        .unwrap(),
+        data,
         stake::program::id(),
         false,
         Epoch::default(),

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -2379,11 +2379,9 @@ pub fn add_validator_stake_account(
         credits_observed: 0,
     };
 
-    let mut data = bincode::serialize::<stake::state::StakeState>(
-        &stake::state::StakeState::Stake(meta, stake),
-    )
-    .unwrap();
-    data.extend_from_slice(&[0, 0, 0, 0]);
+    let mut data = vec![0u8; std::mem::size_of::<stake::state::StakeState>()];
+    let stake_data = bincode::serialize(&stake::state::StakeState::Stake(meta, stake)).unwrap();
+    data[..stake_data.len()].copy_from_slice(&stake_data);
     let stake_account = SolanaAccount::create(
         stake_amount + STAKE_ACCOUNT_RENT_EXEMPTION,
         data,

--- a/stake-pool/program/tests/huge_pool.rs
+++ b/stake-pool/program/tests/huge_pool.rs
@@ -107,7 +107,7 @@ async fn setup(
 
     let mut context = program_test.start_with_context().await;
     let epoch_schedule = context.genesis_config().epoch_schedule;
-    let slot = epoch_schedule.first_normal_slot + epoch_schedule.slots_per_epoch;
+    let slot = epoch_schedule.first_normal_slot + epoch_schedule.slots_per_epoch + 1;
     context.warp_to_slot(slot).unwrap();
 
     let vote_pubkey = vote_account_pubkeys[max_validators as usize - 1];
@@ -635,7 +635,7 @@ async fn withdraw(max_validators: u32) {
             &pool_account_pubkey,
             &stake_address,
             &user.pubkey(),
-            STAKE_AMOUNT,
+            TEST_STAKE_AMOUNT,
         )
         .await;
     assert!(error.is_none(), "{:?}", error);

--- a/stake-pool/program/tests/increase.rs
+++ b/stake-pool/program/tests/increase.rs
@@ -536,7 +536,7 @@ async fn fail_additional_with_decreasing() {
 
     // warp forward to activation
     let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
-    context.warp_to_slot(first_normal_slot).unwrap();
+    context.warp_to_slot(first_normal_slot + 1).unwrap();
     let last_blockhash = context
         .banks_client
         .get_new_latest_blockhash(&context.last_blockhash)

--- a/stake-pool/program/tests/redelegate.rs
+++ b/stake-pool/program/tests/redelegate.rs
@@ -83,9 +83,9 @@ async fn setup(
     .await
     .unwrap();
 
-    let mut slot = 0;
+    let mut slot = 1;
     if do_warp {
-        slot = context.genesis_config().epoch_schedule.first_normal_slot;
+        slot += context.genesis_config().epoch_schedule.first_normal_slot;
         context.warp_to_slot(slot).unwrap();
         stake_pool_accounts
             .update_all(

--- a/stake-pool/program/tests/set_epoch_fee.rs
+++ b/stake-pool/program/tests/set_epoch_fee.rs
@@ -80,10 +80,8 @@ async fn success() {
 
     let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
     let slots_per_epoch = context.genesis_config().epoch_schedule.slots_per_epoch;
-
-    context
-        .warp_to_slot(first_normal_slot + slots_per_epoch)
-        .unwrap();
+    let slot = first_normal_slot + 1;
+    context.warp_to_slot(slot).unwrap();
     stake_pool_accounts
         .update_all(
             &mut context.banks_client,
@@ -108,9 +106,7 @@ async fn success() {
         .get_new_latest_blockhash(&context.last_blockhash)
         .await
         .unwrap();
-    context
-        .warp_to_slot(first_normal_slot + 2 * slots_per_epoch)
-        .unwrap();
+    context.warp_to_slot(slot + slots_per_epoch).unwrap();
     stake_pool_accounts
         .update_all(
             &mut context.banks_client,
@@ -220,10 +216,7 @@ async fn fail_not_updated() {
 
     // move forward so an update is required
     let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
-    let slots_per_epoch = context.genesis_config().epoch_schedule.slots_per_epoch;
-    context
-        .warp_to_slot(first_normal_slot + slots_per_epoch)
-        .unwrap();
+    context.warp_to_slot(first_normal_slot + 1).unwrap();
 
     let transaction = Transaction::new_signed_with_payer(
         &[instruction::set_fee(

--- a/stake-pool/program/tests/set_withdrawal_fee.rs
+++ b/stake-pool/program/tests/set_withdrawal_fee.rs
@@ -109,10 +109,9 @@ async fn success() {
 
     let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
     let slots_per_epoch = context.genesis_config().epoch_schedule.slots_per_epoch;
+    let slot = first_normal_slot + 1;
 
-    context
-        .warp_to_slot(first_normal_slot + slots_per_epoch)
-        .unwrap();
+    context.warp_to_slot(slot).unwrap();
     stake_pool_accounts
         .update_all(
             &mut context.banks_client,
@@ -145,9 +144,7 @@ async fn success() {
         .get_new_latest_blockhash(&context.last_blockhash)
         .await
         .unwrap();
-    context
-        .warp_to_slot(first_normal_slot + 2 * slots_per_epoch)
-        .unwrap();
+    context.warp_to_slot(slot + slots_per_epoch).unwrap();
     stake_pool_accounts
         .update_all(
             &mut context.banks_client,
@@ -237,10 +234,9 @@ async fn success_fee_cannot_increase_more_than_once() {
 
     let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
     let slots_per_epoch = context.genesis_config().epoch_schedule.slots_per_epoch;
+    let slot = first_normal_slot + 1;
 
-    context
-        .warp_to_slot(first_normal_slot + slots_per_epoch)
-        .unwrap();
+    context.warp_to_slot(slot).unwrap();
     stake_pool_accounts
         .update_all(
             &mut context.banks_client,
@@ -273,9 +269,7 @@ async fn success_fee_cannot_increase_more_than_once() {
         .get_new_latest_blockhash(&context.last_blockhash)
         .await
         .unwrap();
-    context
-        .warp_to_slot(first_normal_slot + 2 * slots_per_epoch)
-        .unwrap();
+    context.warp_to_slot(slot + slots_per_epoch).unwrap();
     stake_pool_accounts
         .update_all(
             &mut context.banks_client,
@@ -443,11 +437,7 @@ async fn success_reset_fee_after_one_epoch() {
     );
 
     let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
-    let slots_per_epoch = context.genesis_config().epoch_schedule.slots_per_epoch;
-
-    context
-        .warp_to_slot(first_normal_slot + slots_per_epoch)
-        .unwrap();
+    context.warp_to_slot(first_normal_slot + 1).unwrap();
     stake_pool_accounts
         .update_all(
             &mut context.banks_client,
@@ -603,10 +593,8 @@ async fn success_increase_fee_from_0() {
 
     let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
     let slots_per_epoch = context.genesis_config().epoch_schedule.slots_per_epoch;
-
-    context
-        .warp_to_slot(first_normal_slot + slots_per_epoch)
-        .unwrap();
+    let slot = first_normal_slot + 1;
+    context.warp_to_slot(slot).unwrap();
     stake_pool_accounts
         .update_all(
             &mut context.banks_client,
@@ -639,9 +627,7 @@ async fn success_increase_fee_from_0() {
         .get_new_latest_blockhash(&context.last_blockhash)
         .await
         .unwrap();
-    context
-        .warp_to_slot(first_normal_slot + 2 * slots_per_epoch)
-        .unwrap();
+    context.warp_to_slot(slot + slots_per_epoch).unwrap();
     stake_pool_accounts
         .update_all(
             &mut context.banks_client,
@@ -902,10 +888,8 @@ async fn fail_not_updated() {
 
     // move forward so an update is required
     let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
-    let slots_per_epoch = context.genesis_config().epoch_schedule.slots_per_epoch;
-    context
-        .warp_to_slot(first_normal_slot + slots_per_epoch)
-        .unwrap();
+    let slot = first_normal_slot + 1;
+    context.warp_to_slot(slot).unwrap();
 
     let transaction = Transaction::new_signed_with_payer(
         &[instruction::set_fee(

--- a/stake-pool/program/tests/update_stake_pool_balance.rs
+++ b/stake-pool/program/tests/update_stake_pool_balance.rs
@@ -165,7 +165,7 @@ async fn success() {
     }
 
     // Update epoch
-    let slot = context.genesis_config().epoch_schedule.first_normal_slot;
+    let slot = context.genesis_config().epoch_schedule.first_normal_slot + 1;
     context.warp_to_slot(slot).unwrap();
 
     let last_blockhash = context
@@ -279,7 +279,7 @@ async fn success_absorbing_extra_lamports() {
     let expected_fee = stake_pool.calc_epoch_fee_amount(extra_lamports).unwrap();
 
     // Update epoch
-    let slot = context.genesis_config().epoch_schedule.first_normal_slot;
+    let slot = context.genesis_config().epoch_schedule.first_normal_slot + 1;
     context.warp_to_slot(slot).unwrap();
     let last_blockhash = context
         .banks_client

--- a/stake-pool/program/tests/update_validator_list_balance.rs
+++ b/stake-pool/program/tests/update_validator_list_balance.rs
@@ -31,7 +31,7 @@ async fn setup(
     let mut context = program_test().start_with_context().await;
     let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
     let slots_per_epoch = context.genesis_config().epoch_schedule.slots_per_epoch;
-    let mut slot = first_normal_slot;
+    let mut slot = first_normal_slot + 1;
     context.warp_to_slot(slot).unwrap();
 
     let reserve_stake_amount = TEST_STAKE_AMOUNT * 2 * num_validators as u64;

--- a/stake-pool/program/tests/update_validator_list_balance_hijack.rs
+++ b/stake-pool/program/tests/update_validator_list_balance_hijack.rs
@@ -38,7 +38,7 @@ async fn setup(
     let mut context = program_test().start_with_context().await;
     let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
     let slots_per_epoch = context.genesis_config().epoch_schedule.slots_per_epoch;
-    let mut slot = first_normal_slot;
+    let mut slot = first_normal_slot + 1;
     context.warp_to_slot(slot).unwrap();
 
     let reserve_stake_amount = TEST_STAKE_AMOUNT * 2 * num_validators as u64;

--- a/stake-pool/program/tests/vsa_remove.rs
+++ b/stake-pool/program/tests/vsa_remove.rs
@@ -690,7 +690,7 @@ async fn success_with_hijacked_transient_account() {
     // warp forward to merge
     let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
     let slots_per_epoch = context.genesis_config().epoch_schedule.slots_per_epoch;
-    let mut slot = first_normal_slot + slots_per_epoch;
+    let mut slot = first_normal_slot + slots_per_epoch + 1;
     context.warp_to_slot(slot).unwrap();
     stake_pool_accounts
         .update_all(

--- a/stake-pool/program/tests/withdraw_edge_cases.rs
+++ b/stake-pool/program/tests/withdraw_edge_cases.rs
@@ -43,10 +43,7 @@ async fn fail_remove_validator() {
 
     // warp forward to deactivation
     let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
-    let slots_per_epoch = context.genesis_config().epoch_schedule.slots_per_epoch;
-    context
-        .warp_to_slot(first_normal_slot + slots_per_epoch)
-        .unwrap();
+    context.warp_to_slot(first_normal_slot + 1).unwrap();
 
     // update to merge deactivated stake into reserve
     stake_pool_accounts
@@ -146,10 +143,7 @@ async fn success_remove_validator(multiple: u64) {
 
     // warp forward to deactivation
     let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
-    let slots_per_epoch = context.genesis_config().epoch_schedule.slots_per_epoch;
-    context
-        .warp_to_slot(first_normal_slot + slots_per_epoch)
-        .unwrap();
+    context.warp_to_slot(first_normal_slot + 1).unwrap();
 
     let last_blockhash = context
         .banks_client
@@ -262,10 +256,7 @@ async fn fail_with_reserve() {
 
     // warp forward to deactivation
     let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
-    let slots_per_epoch = context.genesis_config().epoch_schedule.slots_per_epoch;
-    context
-        .warp_to_slot(first_normal_slot + slots_per_epoch)
-        .unwrap();
+    context.warp_to_slot(first_normal_slot + 1).unwrap();
 
     // update to merge deactivated stake into reserve
     stake_pool_accounts
@@ -335,10 +326,7 @@ async fn success_with_reserve() {
 
     // warp forward to deactivation
     let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
-    let slots_per_epoch = context.genesis_config().epoch_schedule.slots_per_epoch;
-    context
-        .warp_to_slot(first_normal_slot + slots_per_epoch)
-        .unwrap();
+    context.warp_to_slot(first_normal_slot + 1).unwrap();
 
     // update to merge deactivated stake into reserve
     stake_pool_accounts
@@ -834,10 +822,7 @@ async fn success_with_small_preferred_withdraw() {
 
     // warp forward to deactivation
     let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
-    let slots_per_epoch = context.genesis_config().epoch_schedule.slots_per_epoch;
-    context
-        .warp_to_slot(first_normal_slot + slots_per_epoch)
-        .unwrap();
+    context.warp_to_slot(first_normal_slot + 1).unwrap();
 
     // update to merge deactivated stake into reserve
     stake_pool_accounts

--- a/stake-pool/single-pool/tests/accounts.rs
+++ b/stake-pool/single-pool/tests/accounts.rs
@@ -33,8 +33,8 @@ async fn build_instructions(
     test_mode: TestMode,
 ) -> (Vec<Instruction>, usize) {
     let initialize_instructions = if test_mode == TestMode::Initialize {
-        let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
-        context.warp_to_slot(first_normal_slot).unwrap();
+        let slot = context.genesis_config().epoch_schedule.first_normal_slot + 1;
+        context.warp_to_slot(slot).unwrap();
 
         create_vote(
             &mut context.banks_client,

--- a/stake-pool/single-pool/tests/deposit.rs
+++ b/stake-pool/single-pool/tests/deposit.rs
@@ -268,8 +268,8 @@ async fn fail_uninitialized(activate: bool) {
     let accounts = SinglePoolAccounts::default();
     let stake_account = Keypair::new();
 
-    let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
-    context.warp_to_slot(first_normal_slot).unwrap();
+    let slot = context.genesis_config().epoch_schedule.first_normal_slot + 1;
+    context.warp_to_slot(slot).unwrap();
 
     create_vote(
         &mut context.banks_client,

--- a/stake-pool/single-pool/tests/helpers/mod.rs
+++ b/stake-pool/single-pool/tests/helpers/mod.rs
@@ -213,8 +213,8 @@ impl SinglePoolAccounts {
     // creates a vote account and stake pool for it. also sets up two users with sol and token accounts
     // note this leaves the pool in an activating state. caller can advance to next epoch if they please
     pub async fn initialize(&self, context: &mut ProgramTestContext) -> u64 {
-        let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
-        context.warp_to_slot(first_normal_slot).unwrap();
+        let slot = context.genesis_config().epoch_schedule.first_normal_slot + 1;
+        context.warp_to_slot(slot).unwrap();
 
         create_vote(
             &mut context.banks_client,


### PR DESCRIPTION
#### Problem

The SPL downstream tests were disabled in https://github.com/solana-labs/solana/pull/32524, but we need to re-enable the downstream tests to avoid breaking people in the future, per https://github.com/solana-labs/solana/pull/32655.

After doing the work to reinstate the old `StakeState` and re-enabling the downstream tests, there were errors in the stake pools tests.

#### Solution

The biggest change relates to the async rewards payout being implemented for https://github.com/solana-foundation/solana-improvement-documents/pull/15 -- we have to warp to `slot + 1` in order to get out of the rewards payout time.

After that, there was one issue where we weren't serializing 200 bytes for stake accounts in a test.

And a little extra thing, I noticed that `retain` in the stake pool program was using a function pointer instead of a closure, so I changed to be a closure, same as all the other `big_vec` functions. This should improve compute-unit performance because the Rust compiler can inline closures, but not calling into function pointers.