### PR TITLE
Transfer Hook & TLV Account Resolution docs update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6394,7 +6394,7 @@ dependencies = [
  "num-traits",
  "solana-program",
  "spl-token 4.0.0",
- "spl-token-2022 0.7.0",
+ "spl-token-2022 0.8.0",
  "thiserror",
 ]
 
@@ -6407,7 +6407,7 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account 2.0.0",
  "spl-token 4.0.0",
- "spl-token-2022 0.7.0",
+ "spl-token-2022 0.8.0",
 ]
 
 [[package]]
@@ -6864,7 +6864,7 @@ dependencies = [
  "solana-vote-program",
  "spl-math",
  "spl-token 4.0.0",
- "spl-token-2022 0.7.0",
+ "spl-token-2022 0.8.0",
  "test-case",
  "thiserror",
 ]
@@ -6896,7 +6896,7 @@ dependencies = [
 
 [[package]]
 name = "spl-tlv-account-resolution"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bytemuck",
  "solana-program",
@@ -6960,7 +6960,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-2022"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -6998,7 +6998,7 @@ dependencies = [
  "spl-associated-token-account 2.0.0",
  "spl-instruction-padding",
  "spl-memo 4.0.0",
- "spl-token-2022 0.7.0",
+ "spl-token-2022 0.8.0",
  "spl-token-client",
  "spl-token-metadata-interface",
  "spl-transfer-hook-example",
@@ -7031,7 +7031,7 @@ dependencies = [
  "spl-associated-token-account 2.0.0",
  "spl-memo 4.0.0",
  "spl-token 4.0.0",
- "spl-token-2022 0.7.0",
+ "spl-token-2022 0.8.0",
  "spl-token-client",
  "strum 0.25.0",
  "strum_macros 0.25.2",
@@ -7055,7 +7055,7 @@ dependencies = [
  "spl-associated-token-account 2.0.0",
  "spl-memo 4.0.0",
  "spl-token 4.0.0",
- "spl-token-2022 0.7.0",
+ "spl-token-2022 0.8.0",
  "spl-token-metadata-interface",
  "spl-transfer-hook-interface",
  "thiserror",
@@ -7101,7 +7101,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-token-2022 0.7.0",
+ "spl-token-2022 0.8.0",
  "spl-token-client",
  "spl-token-metadata-interface",
  "spl-type-length-value",
@@ -7134,7 +7134,7 @@ dependencies = [
  "solana-sdk",
  "spl-math",
  "spl-token 4.0.0",
- "spl-token-2022 0.7.0",
+ "spl-token-2022 0.8.0",
  "test-case",
  "thiserror",
 ]
@@ -7162,7 +7162,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-token 4.0.0",
- "spl-token-2022 0.7.0",
+ "spl-token-2022 0.8.0",
  "spl-token-client",
  "test-case",
  "thiserror",
@@ -7183,7 +7183,7 @@ dependencies = [
  "solana-test-validator",
  "spl-associated-token-account 2.0.0",
  "spl-token 4.0.0",
- "spl-token-2022 0.7.0",
+ "spl-token-2022 0.8.0",
  "spl-token-client",
  "spl-token-upgrade",
  "tokio",
@@ -7199,27 +7199,27 @@ dependencies = [
  "solana-program",
  "spl-associated-token-account 2.0.0",
  "spl-token 4.0.0",
- "spl-token-2022 0.7.0",
+ "spl-token-2022 0.8.0",
  "thiserror",
 ]
 
 [[package]]
 name = "spl-transfer-hook-example"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arrayref",
  "solana-program",
  "solana-program-test",
  "solana-sdk",
  "spl-tlv-account-resolution",
- "spl-token-2022 0.7.0",
+ "spl-token-2022 0.8.0",
  "spl-transfer-hook-interface",
  "spl-type-length-value",
 ]
 
 [[package]]
 name = "spl-transfer-hook-interface"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arrayref",
  "bytemuck",

--- a/associated-token-account/program-test/Cargo.toml
+++ b/associated-token-account/program-test/Cargo.toml
@@ -16,4 +16,4 @@ solana-program-test = "1.16.3"
 solana-sdk = "1.16.3"
 spl-associated-token-account = { version = "2.0", path = "../program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "0.7", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.8", path = "../../token/program-2022", features = ["no-entrypoint"] }

--- a/associated-token-account/program/Cargo.toml
+++ b/associated-token-account/program/Cargo.toml
@@ -18,7 +18,7 @@ num-derive = "0.4"
 num-traits = "0.2"
 solana-program = "1.16.3"
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "0.7", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.8", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [lib]

--- a/libraries/tlv-account-resolution/Cargo.toml
+++ b/libraries/tlv-account-resolution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-tlv-account-resolution"
-version = "0.2.0"
+version = "0.3.0"
 description = "Solana Program Library TLV Account Resolution Interface"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/libraries/tlv-account-resolution/src/pod.rs
+++ b/libraries/tlv-account-resolution/src/pod.rs
@@ -61,6 +61,17 @@ impl PodAccountMeta {
             is_writable: is_writable.into(),
         })
     }
+
+    /// Returns `true` if this `PodAccountMeta` represents a standard
+    /// `AccountMeta`
+    pub fn is_account_meta(&self) -> bool {
+        self.discriminator == 0
+    }
+
+    /// Returns `true` if this `PodAccountMeta` represents a PDA
+    pub fn is_pda(&self) -> bool {
+        self.discriminator == 1
+    }
 }
 
 // Conversions to `PodAccountMeta`

--- a/libraries/tlv-account-resolution/src/state.rs
+++ b/libraries/tlv-account-resolution/src/state.rs
@@ -72,6 +72,76 @@ use {
 ///     &remaining_account_infos,
 /// );
 /// ```
+///
+/// Sample usage with PDAs:
+///
+/// ```
+/// use {
+///     solana_program::{
+///         account_info::AccountInfo, instruction::{AccountMeta, Instruction},
+///         pubkey::Pubkey
+///     },
+///     spl_discriminator::{ArrayDiscriminator, SplDiscriminate},
+///     spl_tlv_account_resolution::{
+///         pod::PodAccountMeta,
+///         seeds::Seed,
+///         state::ExtraAccountMetas,
+///    },
+/// };
+///
+/// struct MyInstruction;
+/// impl SplDiscriminate for MyInstruction {
+///     // Give it a unique discriminator, can also be generated using a hash function
+///     const SPL_DISCRIMINATOR: ArrayDiscriminator = ArrayDiscriminator::new([1; ArrayDiscriminator::LENGTH]);
+/// }
+///
+/// // Create a list of `PodAccountMeta` types if you want to store
+/// // _both_ account metas _and_ PDAs in your extra required accounts
+/// let extra_accounts = [
+///     PodAccountMeta::new_with_pubkey(&Pubkey::new_unique(), false, false).unwrap(),
+///     PodAccountMeta::new_with_pubkey(&Pubkey::new_unique(), true, false).unwrap(),
+///     PodAccountMeta::new_with_seeds(
+///         &[
+///             Seed::Literal {
+///                 bytes: b"my_prefix".to_vec(),
+///             },
+///             Seed::InstructionData {
+///                 index: 0,
+///                 length: 8,
+///             },
+///             Seed::AccountKey { index: 0 },
+///         ],
+///         false,
+///         true,
+///     ).unwrap(),
+/// ];
+///
+/// // This time you'll use `init_with_pod_account_metas(..)`
+/// let account_size = ExtraAccountMetas::size_of(extra_accounts.len()).unwrap();
+/// let mut buffer = vec![0; account_size];
+/// ExtraAccountMetas::init_with_pod_account_metas::<MyInstruction>(&mut buffer, &extra_accounts).unwrap();
+///
+/// // We'll want to include instruction data this time
+/// let instruction_data = vec![1; 12];
+/// let program_id = Pubkey::new_unique();
+///
+/// // The rest is the same as the other example!
+///
+/// // Off-chain
+/// let mut instruction = Instruction::new_with_bytes(program_id, &instruction_data, vec![]);
+/// ExtraAccountMetas::add_to_instruction::<MyInstruction>(&mut instruction, &buffer).unwrap();
+///
+/// // On-chain
+/// let mut cpi_instruction = Instruction::new_with_bytes(program_id, &instruction_data, vec![]);
+/// let mut cpi_account_infos = vec![]; // assume the other required account infos are already included
+/// let remaining_account_infos: &[AccountInfo<'_>] = &[]; // these are the account infos provided to the instruction that are *not* part of any other known interface
+/// ExtraAccountMetas::add_to_cpi_instruction::<MyInstruction>(
+///     &mut cpi_instruction,
+///     &mut cpi_account_infos,
+///     &buffer,
+///     &remaining_account_infos,
+/// );
+/// ```
 pub struct ExtraAccountMetas;
 impl ExtraAccountMetas {
     /// Initialize pod slice data for the given instruction and any type
@@ -174,12 +244,15 @@ impl ExtraAccountMetas {
 
     /// Resolve a program-derived address (PDA) from the instruction data
     /// and the accounts that have already been resolved
-    fn resolve_pda(
-        resolved_metas: &[AccountMeta],
+    pub fn resolve_pda<M>(
+        seeds: &[Seed],
+        resolved_metas: &[M],
         instruction_data: &[u8],
         program_id: &Pubkey,
-        seeds: &[Seed],
-    ) -> Result<Pubkey, ProgramError> {
+    ) -> Result<Pubkey, ProgramError>
+    where
+        M: HasPubkey,
+    {
         let mut pda_seeds: Vec<&[u8]> = vec![];
         for config in seeds {
             match config {
@@ -195,11 +268,35 @@ impl ExtraAccountMetas {
                     let account_meta = resolved_metas
                         .get(account_index)
                         .ok_or::<ProgramError>(AccountResolutionError::AccountNotFound.into())?;
-                    pda_seeds.push(account_meta.pubkey.as_ref());
+                    pda_seeds.push(account_meta.pubkey().as_ref());
                 }
             }
         }
         Ok(Pubkey::find_program_address(&pda_seeds, program_id).0)
+    }
+
+    /// Resolve a `PodAccountMeta` into an `AccountMeta`, potentially
+    /// resolving a program-derived address (PDA) if necessary
+    pub fn resolve_account_meta<M>(
+        pod_account_meta: &PodAccountMeta,
+        resolved_metas: &[M],
+        instruction_data: &[u8],
+        program_id: &Pubkey,
+    ) -> Result<AccountMeta, ProgramError>
+    where
+        M: HasPubkey,
+    {
+        let account_meta = if pod_account_meta.is_pda() {
+            let seeds = Seed::unpack_address_config(&pod_account_meta.address_config)?;
+            AccountMeta {
+                pubkey: Self::resolve_pda(&seeds, resolved_metas, instruction_data, program_id)?,
+                is_signer: pod_account_meta.is_signer.into(),
+                is_writable: pod_account_meta.is_writable.into(),
+            }
+        } else {
+            AccountMeta::try_from(pod_account_meta)?
+        };
+        Ok(account_meta)
     }
 
     /// Add the additional account metas to an existing instruction
@@ -212,23 +309,12 @@ impl ExtraAccountMetas {
         let extra_account_metas = PodSlice::<PodAccountMeta>::unpack(bytes)?;
 
         for extra_meta in extra_account_metas.data().iter() {
-            let mut account_meta = match extra_meta.discriminator {
-                0 => AccountMeta::try_from(extra_meta)?,
-                1 => {
-                    let seeds = Seed::unpack_address_config(&extra_meta.address_config)?;
-                    AccountMeta {
-                        pubkey: Self::resolve_pda(
-                            &instruction.accounts,
-                            &instruction.data,
-                            &instruction.program_id,
-                            &seeds,
-                        )?,
-                        is_signer: extra_meta.is_signer.into(),
-                        is_writable: extra_meta.is_writable.into(),
-                    }
-                }
-                _ => return Err(ProgramError::InvalidAccountData),
-            };
+            let mut account_meta = Self::resolve_account_meta::<AccountMeta>(
+                extra_meta,
+                &instruction.accounts,
+                &instruction.data,
+                &instruction.program_id,
+            )?;
             Self::de_escalate_account_meta(&mut account_meta, &instruction.accounts);
             instruction.accounts.push(account_meta);
         }
@@ -260,6 +346,23 @@ impl ExtraAccountMetas {
             cpi_account_infos.push(account_info);
         }
         Ok(())
+    }
+}
+
+/// Trait for getting the pubkey of an account regardless of whether it's an
+/// `AccountMeta` or `AccountInfo`
+pub trait HasPubkey {
+    /// Returns the pubkey of the account
+    fn pubkey(&self) -> &Pubkey;
+}
+impl HasPubkey for AccountMeta {
+    fn pubkey(&self) -> &Pubkey {
+        &self.pubkey
+    }
+}
+impl HasPubkey for AccountInfo<'_> {
+    fn pubkey(&self) -> &Pubkey {
+        self.key
     }
 }
 

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -21,7 +21,7 @@ serde = "1.0.183"
 serde_derive = "1.0.103"
 solana-program = "1.16.3"
 spl-math = { version = "0.2", path = "../../libraries/math", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "0.7", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
+spl-token-2022 = { version = "0.8", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 bincode = "1.3.1"
 

--- a/token-metadata/example/Cargo.toml
+++ b/token-metadata/example/Cargo.toml
@@ -13,7 +13,7 @@ test-sbf = []
 
 [dependencies]
 solana-program = "1.16.3"
-spl-token-2022 = { version = "0.7", path = "../../token/program-2022" }
+spl-token-2022 = { version = "0.8", path = "../../token/program-2022" }
 spl-token-metadata-interface = { version = "0.1.0", path = "../interface" }
 spl-type-length-value = { version = "0.2.0" , path = "../../libraries/type-length-value" }
 

--- a/token-swap/program/Cargo.toml
+++ b/token-swap/program/Cargo.toml
@@ -20,7 +20,7 @@ num-traits = "0.2"
 solana-program = "1.16.3"
 spl-math = { version = "0.2", path = "../../libraries/math", features = [ "no-entrypoint" ] }
 spl-token = { version = "4.0", path = "../../token/program", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "0.7", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
+spl-token-2022 = { version = "0.8", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
 roots = { version = "0.0.8", optional = true }

--- a/token-upgrade/cli/Cargo.toml
+++ b/token-upgrade/cli/Cargo.toml
@@ -21,7 +21,7 @@ solana-remote-wallet = "1.16.3"
 solana-sdk = "1.16.3"
 spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "0.7", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.8", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.5", path = "../../token/client" }
 spl-token-upgrade = { version = "0.1", path = "../program", features = ["no-entrypoint"] }
 tokio = { version = "1", features = ["full"] }

--- a/token-upgrade/program/Cargo.toml
+++ b/token-upgrade/program/Cargo.toml
@@ -16,7 +16,7 @@ num-derive = "0.4"
 num-traits = "0.2"
 num_enum = "0.6.1"
 solana-program = "1.16.3"
-spl-token-2022 = { version = "0.7", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.8", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/token-wrap/program/Cargo.toml
+++ b/token-wrap/program/Cargo.toml
@@ -17,7 +17,7 @@ num_enum = "0.6"
 solana-program = "1.16.3"
 spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "0.7", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.8", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [lib]

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -27,7 +27,7 @@ solana-remote-wallet = "=1.16.3"
 solana-sdk = "=1.16.3"
 solana-transaction-status = "=1.16.3"
 spl-token = { version = "4.0", path="../program", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "0.7", path="../program-2022", features = [ "no-entrypoint" ] }
+spl-token-2022 = { version = "0.8", path="../program-2022", features = [ "no-entrypoint" ] }
 spl-token-client = { version = "0.5", path="../client" }
 spl-associated-token-account = { version = "2.0", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
 spl-memo = { version = "4.0.0", path="../../memo/program", features = ["no-entrypoint"] }

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -21,9 +21,9 @@ solana-sdk = "1.16.3"
 spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-memo = { version = "4.0.0", path = "../../memo/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path="../program", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "0.7", path="../program-2022" }
+spl-token-2022 = { version = "0.8", path="../program-2022" }
 spl-token-metadata-interface = { version = "0.1", path="../../token-metadata/interface" }
-spl-transfer-hook-interface = { version = "0.1", path="../transfer-hook-interface" }
+spl-transfer-hook-interface = { version = "0.2", path="../transfer-hook-interface" }
 thiserror = "1.0"
 
 [features]

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -25,10 +25,10 @@ solana-program-test = "=1.16.3"
 solana-sdk = "=1.16.3"
 spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program" }
 spl-memo = { version = "4.0.0", path = "../../memo/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "0.7", path="../program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.8", path="../program-2022", features = ["no-entrypoint"] }
 spl-instruction-padding = { version = "0.1.0", path="../../instruction-padding/program", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.5", path = "../client" }
 spl-token-metadata-interface = { version = "0.1", path = "../../token-metadata/interface" }
-spl-transfer-hook-example = { version = "0.1", path="../transfer-hook-example", features = ["no-entrypoint"] }
-spl-transfer-hook-interface = { version = "0.1", path="../transfer-hook-interface" }
+spl-transfer-hook-example = { version = "0.2", path="../transfer-hook-example", features = ["no-entrypoint"] }
+spl-transfer-hook-interface = { version = "0.2", path="../transfer-hook-interface" }
 test-case = "3.1"

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-2022"
-version = "0.7.0"
+version = "0.8.0"
 description = "Solana Program Library Token 2022"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -28,7 +28,7 @@ solana-zk-token-sdk = "1.16.3"
 spl-memo = { version = "4.0.0", path = "../../memo/program", features = [ "no-entrypoint" ] }
 spl-token = { version = "4.0",  path = "../program", features = ["no-entrypoint"] }
 spl-token-metadata-interface = { version = "0.1.0", path = "../../token-metadata/interface" }
-spl-transfer-hook-interface = { version = "0.1.0", path = "../transfer-hook-interface" }
+spl-transfer-hook-interface = { version = "0.2.0", path = "../transfer-hook-interface" }
 spl-type-length-value = { version = "0.2.0", path = "../../libraries/type-length-value" }
 thiserror = "1.0"
 serde = { version = "1.0.183", optional = true }

--- a/token/transfer-hook-example/Cargo.toml
+++ b/token/transfer-hook-example/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-transfer-hook-example"
-version = "0.1.0"
+version = "0.2.0"
 description = "Solana Program Library Transfer Hook Example Program"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -14,9 +14,9 @@ test-sbf = []
 [dependencies]
 arrayref = "0.3.7"
 solana-program = "1.16.3"
-spl-tlv-account-resolution = { version = "0.2.0" , path = "../../libraries/tlv-account-resolution" }
-spl-token-2022 = { version = "0.7",  path = "../program-2022", features = ["no-entrypoint"] }
-spl-transfer-hook-interface = { version = "0.1.0" , path = "../transfer-hook-interface" }
+spl-tlv-account-resolution = { version = "0.3.0" , path = "../../libraries/tlv-account-resolution" }
+spl-token-2022 = { version = "0.8",  path = "../program-2022", features = ["no-entrypoint"] }
+spl-transfer-hook-interface = { version = "0.2.0" , path = "../transfer-hook-interface" }
 spl-type-length-value = { version = "0.2.0" , path = "../../libraries/type-length-value" }
 
 [dev-dependencies]

--- a/token/transfer-hook-example/src/entrypoint.rs
+++ b/token/transfer-hook-example/src/entrypoint.rs
@@ -3,8 +3,11 @@
 use {
     crate::processor,
     solana_program::{
-        account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,
-        program_error::PrintProgramError, pubkey::Pubkey,
+        account_info::AccountInfo,
+        entrypoint,
+        entrypoint::ProgramResult,
+        program_error::PrintProgramError,
+        pubkey::Pubkey,
     },
     spl_transfer_hook_interface::error::TransferHookError,
 };

--- a/token/transfer-hook-example/src/state.rs
+++ b/token/transfer-hook-example/src/state.rs
@@ -1,9 +1,12 @@
 //! State helpers for working with the example program
 
 use {
-    solana_program::{instruction::AccountMeta, program_error::ProgramError},
-    spl_tlv_account_resolution::state::ExtraAccountMetas,
-    spl_transfer_hook_interface::instruction::ExecuteInstruction,
+    solana_program::{
+        account_info::AccountInfo, instruction::AccountMeta, program_error::ProgramError,
+        pubkey::Pubkey, sysvar,
+    },
+    spl_tlv_account_resolution::{pod::PodAccountMeta, seeds::Seed, state::ExtraAccountMetas},
+    spl_transfer_hook_interface::{error::TransferHookError, instruction::ExecuteInstruction},
 };
 
 /// Generate example data to be used directly in an account for testing
@@ -12,4 +15,71 @@ pub fn example_data(account_metas: &[AccountMeta]) -> Result<Vec<u8>, ProgramErr
     let mut data = vec![0; account_size];
     ExtraAccountMetas::init_with_account_metas::<ExecuteInstruction>(&mut data, account_metas)?;
     Ok(data)
+}
+
+/// Utility struct for managing extra required accounts for the example program
+pub struct TransferHookExampleExtraAccounts;
+impl TransferHookExampleExtraAccounts {
+    /// Create the validation data (the extra required accounts configs)
+    ///
+    /// Note: since the PDA is not known at the time of intialization
+    /// of the extra required accounts config, we only need to make sure
+    /// the account metas were provided in the instruction.
+    pub fn create_validation_data(
+        remaining_account_infos: &[AccountInfo],
+        mint_authority: &Pubkey,
+    ) -> Result<[PodAccountMeta; 4], ProgramError> {
+        if !(remaining_account_infos.len() == 3 // 3 metas and one PDA
+            && remaining_account_infos[0].key == &sysvar::instructions::id()
+            && remaining_account_infos[1].key == mint_authority)
+        {
+            return Err(ProgramError::NotEnoughAccountKeys);
+        }
+        Ok([
+            // First required account: Program ID
+            PodAccountMeta::from(&remaining_account_infos[0]),
+            // Second required account: Mint authority
+            PodAccountMeta::from(&remaining_account_infos[1]),
+            // Third required account: PDA
+            PodAccountMeta::new_with_seeds(
+                &[
+                    Seed::Literal {
+                        bytes: b"transfer-hook-example".to_vec(),
+                    },
+                    Seed::AccountKey { index: 0 }, // Source account's key
+                ],
+                false,
+                false,
+            )?,
+            // Fourth required account: the validation account
+            PodAccountMeta::from(&remaining_account_infos[2]),
+        ])
+    }
+
+    /// As an example, just checks that all the required additional accounts
+    /// were provided
+    pub fn validate_extra_provided_accounts(
+        all_account_infos: &[AccountInfo],
+        required_extra_account_metas: &[PodAccountMeta],
+        program_id: &Pubkey,
+    ) -> Result<(), ProgramError> {
+        for pod_meta in required_extra_account_metas {
+            let meta = ExtraAccountMetas::resolve_account_meta::<AccountInfo>(
+                pod_meta,
+                all_account_infos,
+                &[], // No instruction data used in this example
+                program_id,
+            )?;
+            if !all_account_infos.iter().any(|info| {
+                if info.key == &meta.pubkey {
+                    info.is_signer == meta.is_signer && info.is_writable == meta.is_writable
+                } else {
+                    false
+                }
+            }) {
+                return Err(TransferHookError::IncorrectAccount.into());
+            }
+        }
+        Ok(())
+    }
 }

--- a/token/transfer-hook-interface/Cargo.toml
+++ b/token/transfer-hook-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-transfer-hook-interface"
-version = "0.1.0"
+version = "0.2.0"
 description = "Solana Program Library Transfer Hook Interface"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -15,7 +15,7 @@ num-traits = "0.2"
 num_enum = "0.6.1"
 solana-program = "1.16.3"
 spl-discriminator = { version = "0.1.0" , path = "../../libraries/discriminator" }
-spl-tlv-account-resolution = { version = "0.2.0" , path = "../../libraries/tlv-account-resolution" }
+spl-tlv-account-resolution = { version = "0.3.0" , path = "../../libraries/tlv-account-resolution" }
 spl-type-length-value = { version = "0.2.0" , path = "../../libraries/type-length-value" }
 thiserror = "1.0"
 

--- a/token/transfer-hook-interface/src/instruction.rs
+++ b/token/transfer-hook-interface/src/instruction.rs
@@ -24,8 +24,8 @@ pub enum TransferHookInstruction {
     ///   2. `[]` Destination account
     ///   3. `[]` Source account's owner/delegate
     ///   4. `[]` Validation account
-    ///   5..5+M `[]` `M` additional accounts, written in validation account data
-    ///
+    ///   5..5+M `[]` `M` additional accounts, written in validation account
+    /// data
     Execute {
         /// Amount of tokens to transfer
         amount: u64,
@@ -40,12 +40,11 @@ pub enum TransferHookInstruction {
     ///   2. `[s]` Mint authority
     ///   3. `[]` System program
     ///   4..4+M `[]` `M` additional accounts, to be written to validation data
-    ///
     InitializeExtraAccountMetas,
 }
 /// TLV instruction type only used to define the discriminator. The actual data
-/// is entirely managed by `ExtraAccountMetas`, and it is the only data contained
-/// by this type.
+/// is entirely managed by `ExtraAccountMetas`, and it is the only data
+/// contained by this type.
 #[derive(SplDiscriminate)]
 #[discriminator_hash_input("spl-transfer-hook-interface:execute")]
 pub struct ExecuteInstruction;
@@ -57,7 +56,8 @@ pub struct ExecuteInstruction;
 pub struct InitializeExtraAccountMetasInstruction;
 
 impl TransferHookInstruction {
-    /// Unpacks a byte buffer into a [TransferHookInstruction](enum.TransferHookInstruction.html).
+    /// Unpacks a byte buffer into a
+    /// [TransferHookInstruction](enum.TransferHookInstruction.html).
     pub fn unpack(input: &[u8]) -> Result<Self, ProgramError> {
         if input.len() < ArrayDiscriminator::LENGTH {
             return Err(ProgramError::InvalidInstructionData);
@@ -79,7 +79,8 @@ impl TransferHookInstruction {
         })
     }
 
-    /// Packs a [TokenInstruction](enum.TokenInstruction.html) into a byte buffer.
+    /// Packs a [TokenInstruction](enum.TokenInstruction.html) into a byte
+    /// buffer.
     pub fn pack(&self) -> Vec<u8> {
         let mut buf = vec![];
         match self {

--- a/token/transfer-hook-interface/src/lib.rs
+++ b/token/transfer-hook-interface/src/lib.rs
@@ -12,7 +12,8 @@ pub mod instruction;
 pub mod offchain;
 pub mod onchain;
 
-// Export current sdk types for downstream users building with a different sdk version
+// Export current sdk types for downstream users building with a different sdk
+// version
 pub use solana_program;
 use solana_program::pubkey::Pubkey;
 

--- a/token/transfer-hook-interface/src/offchain.rs
+++ b/token/transfer-hook-interface/src/offchain.rs
@@ -14,7 +14,8 @@ use {
 /// Type representing the output of an account fetching function, for easy
 /// chaining between APIs
 pub type AccountDataResult = Result<Option<Vec<u8>>, AccountFetchError>;
-/// Generic error type that can come out of any client while fetching account data
+/// Generic error type that can come out of any client while fetching account
+/// data
 pub type AccountFetchError = Box<dyn std::error::Error + Send + Sync>;
 
 /// Offchain helper to get all additional required account metas for a mint

--- a/token/transfer-hook-interface/src/onchain.rs
+++ b/token/transfer-hook-interface/src/onchain.rs
@@ -1,4 +1,5 @@
-//! On-chain program invoke helper to perform on-chain `execute` with correct accounts
+//! On-chain program invoke helper to perform on-chain `execute` with correct
+//! accounts
 
 use {
     crate::{error::TransferHookError, get_extra_account_metas_address, instruction},
@@ -53,8 +54,8 @@ pub fn invoke_execute<'a>(
     invoke(&cpi_instruction, &cpi_account_infos)
 }
 
-/// Helper to add accounts required for the transfer-hook program on-chain, looking
-/// through the additional account infos to add the proper accounts
+/// Helper to add accounts required for the transfer-hook program on-chain,
+/// looking through the additional account infos to add the proper accounts
 pub fn add_cpi_accounts_for_execute<'a>(
     cpi_instruction: &mut Instruction,
     cpi_account_infos: &mut Vec<AccountInfo<'a>>,


### PR DESCRIPTION
This PR updates the docs for Transfer Hook and TLV Account Resolution - both within their respective crates and in the Token2022 docs on the main SPL docs site.

Note: I have included proposed changes for bumping the versions of each affected crate as a result of #4785.