### PR TITLE
Transfer Hook: Update Docs & Examples

### DIFF
--- a/docs/src/token-2022/extensions.mdx
+++ b/docs/src/token-2022/extensions.mdx
@@ -1361,6 +1361,35 @@ address!
 More information in the
 [spl-transfer-hook-interface README](https://github.com/solana-labs/solana-program-library/tree/master/token/transfer-hook-interface/README.md).
 
+#### Types of Required Accounts
+
+Implementers of this interface are encouraged to make use of the SPL library
+[spl-tlv-account-resolution](https://github.com/solana-labs/solana-program-library/tree/master/libraries/tlv-account-resolution/README.md)
+to manage the additional required accounts for their transfer hook program.
+
+This library is capable of storing configurations for two types of additional
+required accounts: accounts with fixed addresses known at the time the
+configuration is written to state, and accounts with a **Program-Derived Address**,
+which can be comprised of seeds that may come from any combination of the
+following:
+
+- Hard-coded values, such as string literals or integers
+- A slice of the instruction data provided to the program
+- The address of another account in the total list of accounts
+
+When you store configurations for a Program-Derived Address within the
+additional required accounts, the PDA itself is evaluated (or resolved) at the
+time of instruction invocation using data from the instruction itself. This
+occurs in the offchain and onchain helpers mentioned below, which leverage
+the SPL TLV Account Resolution library to perform this resolution
+automatically.
+
+For more information on storing seed configurations for additional required
+accounts for a program, you can check out the
+[Transfer Hook Example Program](https://github.com/solana-labs/solana-program-library/tree/master/token/transfer-hook-example)
+or the
+[TLV Account Resolution library itself](https://github.com/solana-labs/solana-program-library/tree/master/libraries/tlv-account-resolution/README.md).
+
 #### Utilities
 
 The `spl-transfer-hook-interface` library provides offchain and onchain helpers

--- a/libraries/tlv-account-resolution/src/pod.rs
+++ b/libraries/tlv-account-resolution/src/pod.rs
@@ -61,6 +61,17 @@ impl PodAccountMeta {
             is_writable: is_writable.into(),
         })
     }
+
+    /// Returns `true` if this `PodAccountMeta` represents a standard
+    /// `AccountMeta`
+    pub fn is_account_meta(&self) -> bool {
+        self.discriminator == 0
+    }
+
+    /// Returns `true` if this `PodAccountMeta` represents a PDA
+    pub fn is_pda(&self) -> bool {
+        self.discriminator == 1
+    }
 }
 
 // Conversions to `PodAccountMeta`

--- a/token/transfer-hook-example/src/processor.rs
+++ b/token/transfer-hook-example/src/processor.rs
@@ -1,10 +1,10 @@
 //! Program state processor
 
 use {
+    crate::state::{create_validation_data, validate_extra_provided_accounts},
     solana_program::{
         account_info::{next_account_info, AccountInfo},
         entrypoint::ProgramResult,
-        instruction::AccountMeta,
         msg,
         program::invoke_signed,
         program_error::ProgramError,
@@ -69,27 +69,21 @@ pub fn process_execute(
         ExtraAccountMetas::unpack_with_tlv_state::<ExecuteInstruction>(&state)?;
 
     // if incorrect number of are provided, error
-    let extra_account_infos = account_info_iter.as_slice();
-    let account_metas = extra_account_metas.data();
-    if extra_account_infos.len() != account_metas.len() {
+    let provided_extra_account_infos = account_info_iter.as_slice();
+    let required_extra_account_metas = extra_account_metas.data();
+    if provided_extra_account_infos.len() != required_extra_account_metas.len() {
         return Err(TransferHookError::IncorrectAccount.into());
     }
 
-    // Let's assume that they're provided in the correct order
-    for (i, account_info) in extra_account_infos.iter().enumerate() {
-        let meta = AccountMeta::try_from(&account_metas[i])?;
-        if !(&meta.pubkey == account_info.key
-            && meta.is_signer == account_info.is_signer
-            && meta.is_writable == account_info.is_writable)
-        {
-            return Err(TransferHookError::IncorrectAccount.into());
-        }
-    }
+    // Validate all required accounts were provided.
+    // One could instead place custom logic here
+    validate_extra_provided_accounts(accounts, required_extra_account_metas, program_id)?;
 
     Ok(())
 }
 
-/// Processes a [InitializeExtraAccountMetas](enum.TransferHookInstruction.html) instruction.
+/// Processes a [InitializeExtraAccountMetas](enum.TransferHookInstruction.html)
+/// instruction.
 pub fn process_initialize_extra_account_metas(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
@@ -127,8 +121,9 @@ pub fn process_initialize_extra_account_metas(
     // Create the account
     let bump_seed = [bump_seed];
     let signer_seeds = collect_extra_account_metas_signer_seeds(mint_info.key, &bump_seed);
-    let extra_account_infos = account_info_iter.as_slice();
-    let length = extra_account_infos.len();
+    let extra_required_accounts =
+        create_validation_data(account_info_iter.as_slice(), &mint_authority)?;
+    let length = extra_required_accounts.len();
     let account_size = ExtraAccountMetas::size_of(length)?;
     invoke_signed(
         &system_instruction::allocate(extra_account_metas_info.key, account_size as u64),
@@ -143,9 +138,9 @@ pub fn process_initialize_extra_account_metas(
 
     // Write the data
     let mut data = extra_account_metas_info.try_borrow_mut_data()?;
-    ExtraAccountMetas::init_with_account_infos::<ExecuteInstruction>(
+    ExtraAccountMetas::init_with_pod_account_metas::<ExecuteInstruction>(
         &mut data,
-        extra_account_infos,
+        &extra_required_accounts,
     )?;
 
     Ok(())

--- a/token/transfer-hook-example/src/state.rs
+++ b/token/transfer-hook-example/src/state.rs
@@ -1,9 +1,12 @@
 //! State helpers for working with the example program
 
 use {
-    solana_program::{instruction::AccountMeta, program_error::ProgramError},
-    spl_tlv_account_resolution::state::ExtraAccountMetas,
-    spl_transfer_hook_interface::instruction::ExecuteInstruction,
+    solana_program::{
+        account_info::AccountInfo, instruction::AccountMeta, program_error::ProgramError,
+        pubkey::Pubkey, sysvar,
+    },
+    spl_tlv_account_resolution::{pod::PodAccountMeta, seeds::Seed, state::ExtraAccountMetas},
+    spl_transfer_hook_interface::{error::TransferHookError, instruction::ExecuteInstruction},
 };
 
 /// Generate example data to be used directly in an account for testing
@@ -12,4 +15,64 @@ pub fn example_data(account_metas: &[AccountMeta]) -> Result<Vec<u8>, ProgramErr
     let mut data = vec![0; account_size];
     ExtraAccountMetas::init_with_account_metas::<ExecuteInstruction>(&mut data, account_metas)?;
     Ok(data)
+}
+
+/// Create the validation data (the extra required accounts configs)
+///
+/// Note: since the PDA is not known at the time of intialization
+/// of the extra required accounts config, we only need to make sure
+/// the account metas were provided in the instruction.
+pub fn create_validation_data(
+    remaining_account_infos: &[AccountInfo],
+    mint_authority: &Pubkey,
+) -> Result<[PodAccountMeta; 4], ProgramError> {
+    if !(remaining_account_infos.len() == 3 // 3 metas and one PDA
+        && remaining_account_infos[0].key == &sysvar::instructions::id()
+        && remaining_account_infos[1].key == mint_authority)
+    {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    }
+    Ok([
+        PodAccountMeta::from(&remaining_account_infos[0]),
+        PodAccountMeta::from(&remaining_account_infos[1]),
+        // Third required account: PDA
+        PodAccountMeta::new_with_seeds(
+            &[
+                Seed::Literal {
+                    bytes: b"transfer-hook-example".to_vec(),
+                },
+                Seed::AccountKey { index: 0 }, // Source account's key
+            ],
+            false,
+            false,
+        )?,
+        PodAccountMeta::from(&remaining_account_infos[2]),
+    ])
+}
+
+/// As an example, just checks that all the required additional accounts
+/// were provided
+pub fn validate_extra_provided_accounts(
+    all_account_infos: &[AccountInfo],
+    required_extra_account_metas: &[PodAccountMeta],
+    program_id: &Pubkey,
+) -> Result<(), ProgramError> {
+    for pod_meta in required_extra_account_metas {
+        let meta = ExtraAccountMetas::resolve_account_meta::<AccountInfo>(
+            pod_meta,
+            all_account_infos,
+            &[], // No instruction data used in this example
+            program_id,
+        )?;
+        if !all_account_infos.iter().any(|info| {
+            if info.key == &meta.pubkey {
+                info.is_signer == meta.is_signer && info.is_writable == meta.is_writable
+            } else {
+                false
+            }
+        }) {
+            return Err(TransferHookError::IncorrectAccount.into());
+        }
+    }
+    Ok(())
 }


### PR DESCRIPTION
This PR updates the docs for Transfer Hook and TLV Account Resolution - both within their respective crates and in the Token2022 docs on the main SPL docs site.

I've re-worked some of the Transfer Hook Example program to reflect these recent changes/capabilities as well.

In doing so, I decided to add a few minor tweaks to TLV Account Resolution that made on-chain usage of the library a bit smoother:
- `is_account_meta()` and `is_pda()` methods for `PodAccountMeta` discriminator evaluation
- `resolve_account_meta` function for resolving one account meta - in case it's needed
- A shared `ToPubkey` trait to allow functions like `resolve_account_meta` and `resolve_pda` to work with `AccountMeta` or `AccountInfo` interchangeably

Closes #4942 

---

Note: Marking as draft until versioning discussions are had!

After the addition of #4785, it's prudent to cut a release for TLV Account Resolution and bump many of the crate versions that depend on it. I'm curious what we should bump to.

  We could cut a release for TLV Account Resolution: `0.2.0` -> `0.3.0` and then bump everyone else, including Program 2022 (ie. `0.7.0` -> `0.8.0`)