### PR TITLE
[token-2022] Add constructors for confidential transfer account info types

### DIFF
--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -1774,10 +1774,10 @@ where
         let account_info = if let Some(account_info) = account_info {
             account_info
         } else {
-            self.get_account_info(account)
-                .await?
-                .get_extension::<ConfidentialTransferAccount>()?
-                .empty_account_account_info()
+            let account = self.get_account_info(account).await?;
+            let confidential_transfer_account =
+                account.get_extension::<ConfidentialTransferAccount>()?;
+            EmptyAccountAccountInfo::new(confidential_transfer_account)
         };
 
         let proof_data = if context_state_account.is_some() {
@@ -2042,10 +2042,10 @@ where
         let account_info = if let Some(account_info) = account_info {
             account_info
         } else {
-            self.get_account_info(account)
-                .await?
-                .get_extension::<ConfidentialTransferAccount>()?
-                .withdraw_account_info()
+            let account = self.get_account_info(account).await?;
+            let confidential_transfer_account =
+                account.get_extension::<ConfidentialTransferAccount>()?;
+            WithdrawAccountInfo::new(confidential_transfer_account)
         };
 
         let proof_data = if context_state_account.is_some() {
@@ -2154,10 +2154,10 @@ where
         let account_info = if let Some(account_info) = account_info {
             account_info
         } else {
-            self.get_account_info(source_account)
-                .await?
-                .get_extension::<ConfidentialTransferAccount>()?
-                .transfer_account_info()
+            let account = self.get_account_info(source_account).await?;
+            let confidential_transfer_account =
+                account.get_extension::<ConfidentialTransferAccount>()?;
+            TransferAccountInfo::new(confidential_transfer_account)
         };
 
         let proof_data = if context_state_account.is_some() {
@@ -2228,10 +2228,10 @@ where
         let account_info = if let Some(account_info) = account_info {
             account_info
         } else {
-            self.get_account_info(source_account)
-                .await?
-                .get_extension::<ConfidentialTransferAccount>()?
-                .transfer_account_info()
+            let account = self.get_account_info(source_account).await?;
+            let confidential_transfer_account =
+                account.get_extension::<ConfidentialTransferAccount>()?;
+            TransferAccountInfo::new(confidential_transfer_account)
         };
 
         let proof_data = if context_state_account.is_some() {
@@ -2296,10 +2296,10 @@ where
         let account_info = if let Some(account_info) = account_info {
             account_info
         } else {
-            self.get_account_info(account)
-                .await?
-                .get_extension::<ConfidentialTransferAccount>()?
-                .apply_pending_balance_account_info()
+            let account = self.get_account_info(account).await?;
+            let confidential_transfer_account =
+                account.get_extension::<ConfidentialTransferAccount>()?;
+            ApplyPendingBalanceAccountInfo::new(confidential_transfer_account)
         };
 
         let expected_pending_balance_credit_counter = account_info.pending_balance_credit_counter();

--- a/token/program-2022/src/extension/confidential_transfer/account_info.rs
+++ b/token/program-2022/src/extension/confidential_transfer/account_info.rs
@@ -2,7 +2,8 @@ use {
     crate::{
         error::TokenError,
         extension::confidential_transfer::{
-            DecryptableBalance, EncryptedBalance, PENDING_BALANCE_LO_BIT_LENGTH,
+            ConfidentialTransferAccount, DecryptableBalance, EncryptedBalance,
+            PENDING_BALANCE_LO_BIT_LENGTH,
         },
         pod::*,
     },
@@ -28,6 +29,13 @@ pub struct EmptyAccountAccountInfo {
     pub(crate) available_balance: EncryptedBalance,
 }
 impl EmptyAccountAccountInfo {
+    /// Create the `EmptyAccount` instruction account information from `ConfidentialTransferAccount`.
+    pub fn new(account: &ConfidentialTransferAccount) -> Self {
+        Self {
+            available_balance: account.available_balance,
+        }
+    }
+
     /// Create an empty account proof data.
     pub fn generate_proof_data(
         &self,
@@ -59,6 +67,17 @@ pub struct ApplyPendingBalanceAccountInfo {
     pub(crate) decryptable_available_balance: DecryptableBalance,
 }
 impl ApplyPendingBalanceAccountInfo {
+    /// Create the `ApplyPendingBalance` instruction account information from
+    /// `ConfidentialTransferAccount`.
+    pub fn new(account: &ConfidentialTransferAccount) -> Self {
+        Self {
+            pending_balance_credit_counter: account.pending_balance_credit_counter,
+            pending_balance_lo: account.pending_balance_lo,
+            pending_balance_hi: account.pending_balance_hi,
+            decryptable_available_balance: account.decryptable_available_balance,
+        }
+    }
+
     /// Return the pending balance credit counter of the account.
     pub fn pending_balance_credit_counter(&self) -> u64 {
         self.pending_balance_credit_counter.into()
@@ -130,6 +149,15 @@ pub struct WithdrawAccountInfo {
     pub decryptable_available_balance: DecryptableBalance,
 }
 impl WithdrawAccountInfo {
+    /// Create the `ApplyPendingBalance` instruction account information from
+    /// `ConfidentialTransferAccount`.
+    pub fn new(account: &ConfidentialTransferAccount) -> Self {
+        Self {
+            available_balance: account.available_balance,
+            decryptable_available_balance: account.decryptable_available_balance,
+        }
+    }
+
     fn decrypted_available_balance(&self, aes_key: &AeKey) -> Result<u64, TokenError> {
         let decryptable_available_balance = self
             .decryptable_available_balance
@@ -187,6 +215,14 @@ pub struct TransferAccountInfo {
     pub decryptable_available_balance: DecryptableBalance,
 }
 impl TransferAccountInfo {
+    /// Create the `Transfer` instruction account information from `ConfidentialTransferAccount`.
+    pub fn new(account: &ConfidentialTransferAccount) -> Self {
+        Self {
+            available_balance: account.available_balance,
+            decryptable_available_balance: account.decryptable_available_balance,
+        }
+    }
+
     fn decrypted_available_balance(&self, aes_key: &AeKey) -> Result<u64, TokenError> {
         let decryptable_available_balance = self
             .decryptable_available_balance

--- a/token/program-2022/src/extension/confidential_transfer/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer/mod.rs
@@ -1,5 +1,3 @@
-#[cfg(not(target_os = "solana"))]
-use crate::extension::confidential_transfer::account_info::*;
 use {
     crate::{
         error::TokenError,
@@ -180,53 +178,5 @@ impl ConfidentialTransferAccount {
             .ok_or(TokenError::Overflow)?)
         .into();
         Ok(())
-    }
-
-    /// Return the account information needed to construct an `EmptyAccount` instruction.
-    #[cfg(not(target_os = "solana"))]
-    pub fn empty_account_account_info(&self) -> EmptyAccountAccountInfo {
-        let available_balance = self.available_balance;
-
-        EmptyAccountAccountInfo { available_balance }
-    }
-
-    /// Return the account information needed to construct an `ApplyPendingBalance` instruction.
-    #[cfg(not(target_os = "solana"))]
-    pub fn apply_pending_balance_account_info(&self) -> ApplyPendingBalanceAccountInfo {
-        let pending_balance_credit_counter = self.pending_balance_credit_counter;
-        let pending_balance_lo = self.pending_balance_lo;
-        let pending_balance_hi = self.pending_balance_hi;
-        let decryptable_available_balance = self.decryptable_available_balance;
-
-        ApplyPendingBalanceAccountInfo {
-            pending_balance_credit_counter,
-            pending_balance_lo,
-            pending_balance_hi,
-            decryptable_available_balance,
-        }
-    }
-
-    /// Return the account information needed to construct a `Withdraw` instruction.
-    #[cfg(not(target_os = "solana"))]
-    pub fn withdraw_account_info(&self) -> WithdrawAccountInfo {
-        let available_balance = self.available_balance;
-        let decryptable_available_balance = self.decryptable_available_balance;
-
-        WithdrawAccountInfo {
-            available_balance,
-            decryptable_available_balance,
-        }
-    }
-
-    /// Return the account information needed to construct a `Transfer` instruction.
-    #[cfg(not(target_os = "solana"))]
-    pub fn transfer_account_info(&self) -> TransferAccountInfo {
-        let available_balance = self.available_balance;
-        let decryptable_available_balance = self.decryptable_available_balance;
-
-        TransferAccountInfo {
-            available_balance,
-            decryptable_available_balance,
-        }
     }
 }


### PR DESCRIPTION
#### Problem
This is a follow-up to https://github.com/solana-labs/solana-program-library/pull/4896#discussion_r1289197648.

#### Summary of changes
Added the constructors for the account info types in the confidential transfer instructions. Previously, the account information types had to be constructed using the associated function of `ConfidentialTransferAccount` type, which was quite unnatural.