### PR TITLE
rename PodAccountMeta to ExtraAccountMeta

### DIFF
--- a/docs/src/token-2022/extensions.mdx
+++ b/docs/src/token-2022/extensions.mdx
@@ -1350,10 +1350,10 @@ the transfer hook interface.
 #### How to use
 
 Developers must implement the `Execute` instruction, and optionally the
-`InitializeExtraAccountMetas` instruction to write the required additional account
+`InitializeExtraAccountMetaState` instruction to write the required additional account
 pubkeys into the program-derived address defined by the mint and program id.
 
-Note: it's technically not required to implement `InitializeExtraAccountMetas`
+Note: it's technically not required to implement `InitializeExtraAccountMetaState`
 at that instruction descriminator. Your program may implement multiple interfaces,
 so any other instruction in your program can create the account at the program-derived
 address!

--- a/docs/src/token-2022/extensions.mdx
+++ b/docs/src/token-2022/extensions.mdx
@@ -1350,10 +1350,10 @@ the transfer hook interface.
 #### How to use
 
 Developers must implement the `Execute` instruction, and optionally the
-`InitializeExtraAccountMetaState` instruction to write the required additional account
+`InitializeExtraAccountMetaList` instruction to write the required additional account
 pubkeys into the program-derived address defined by the mint and program id.
 
-Note: it's technically not required to implement `InitializeExtraAccountMetaState`
+Note: it's technically not required to implement `InitializeExtraAccountMetaList`
 at that instruction descriminator. Your program may implement multiple interfaces,
 so any other instruction in your program can create the account at the program-derived
 address!

--- a/libraries/tlv-account-resolution/README.md
+++ b/libraries/tlv-account-resolution/README.md
@@ -12,7 +12,7 @@ into a TLV entry in an account, you can do the following:
 use {
     solana_program::{account_info::AccountInfo, instruction::{AccountMeta, Instruction}, pubkey::Pubkey},
     spl_discriminator::{ArrayDiscriminator, SplDiscriminate},
-    spl_tlv_account_resolution::state::ExtraAccountMetas,
+    spl_tlv_account_resolution::state::ExtraAccountMetaState,
 };
 
 struct MyInstruction;
@@ -30,16 +30,16 @@ let extra_metas = [
 ];
 
 // Assume that this buffer is actually account data, already allocated to `account_size`
-let account_size = ExtraAccountMetas::size_of(extra_metas.len()).unwrap();
+let account_size = ExtraAccountMetaState::size_of(extra_metas.len()).unwrap();
 let mut buffer = vec![0; account_size];
 
 // Initialize the structure for your instruction
-ExtraAccountMetas::init_with_account_metas::<MyInstruction>(&mut buffer, &extra_metas).unwrap();
+ExtraAccountMetaState::init_with_account_metas::<MyInstruction>(&mut buffer, &extra_metas).unwrap();
 
 // Off-chain, you can add the additional accounts directly from the account data
 let program_id = Pubkey::new_unique();
 let mut instruction = Instruction::new_with_bytes(program_id, &[], vec![]);
-ExtraAccountMetas::add_to_instruction::<MyInstruction>(&mut instruction, &buffer).unwrap();
+ExtraAccountMetaState::add_to_instruction::<MyInstruction>(&mut instruction, &buffer).unwrap();
 
 // On-chain, you can add the additional accounts *and* account infos
 let mut cpi_instruction = Instruction::new_with_bytes(program_id, &[], vec![]);
@@ -49,7 +49,7 @@ let mut cpi_account_infos = vec![];
 
 // Provide all "remaining_account_infos" that are *not* part of any other known interface
 let remaining_account_infos = &[]; 
-ExtraAccountMetas::add_to_cpi_instruction::<MyInstruction>(
+ExtraAccountMetaState::add_to_cpi_instruction::<MyInstruction>(
     &mut cpi_instruction,
     &mut cpi_account_infos,
     &buffer,
@@ -57,7 +57,7 @@ ExtraAccountMetas::add_to_cpi_instruction::<MyInstruction>(
 ).unwrap();
 ```
 
-For ease of use on-chain, `ExtraAccountMetas::init_with_account_infos` is also
+For ease of use on-chain, `ExtraAccountMetaState::init_with_account_infos` is also
 provided to initialize directly from a set of given accounts.
 
 ## Motivation
@@ -105,12 +105,12 @@ This library uses `spl-type-length-value` to read and write required instruction
 accounts from account data.
 
 Interface instructions must have an 8-byte discriminator, so that the exposed
-`ExtraAccountMetas` type can use the instruction discriminator as a `ArrayDiscriminator`.
+`ExtraAccountMetaState` type can use the instruction discriminator as a `ArrayDiscriminator`.
 
 This can be confusing. Typically, a type implements `SplDiscriminate`, so that
-the type can be written into TLV data. In this case, `ExtraAccountMetas` is
+the type can be written into TLV data. In this case, `ExtraAccountMetaState` is
 generic over `SplDiscriminate`, meaning that a program can write many different instances of
-`ExtraAccountMetas` into one account, using different `ArrayDiscriminator`s.
+`ExtraAccountMetaState` into one account, using different `ArrayDiscriminator`s.
 
 Also, it's reusing an instruction discriminator as a TLV discriminator. For example,
 if the `transfer` instruction has a discriminator of `[1, 2, 3, 4, 5, 6, 7, 8]`,

--- a/libraries/tlv-account-resolution/README.md
+++ b/libraries/tlv-account-resolution/README.md
@@ -12,7 +12,7 @@ into a TLV entry in an account, you can do the following:
 use {
     solana_program::{account_info::AccountInfo, instruction::{AccountMeta, Instruction}, pubkey::Pubkey},
     spl_discriminator::{ArrayDiscriminator, SplDiscriminate},
-    spl_tlv_account_resolution::state::ExtraAccountMetaState,
+    spl_tlv_account_resolution::state::ExtraAccountMetaList,
 };
 
 struct MyInstruction;
@@ -30,16 +30,16 @@ let extra_metas = [
 ];
 
 // Assume that this buffer is actually account data, already allocated to `account_size`
-let account_size = ExtraAccountMetaState::size_of(extra_metas.len()).unwrap();
+let account_size = ExtraAccountMetaList::size_of(extra_metas.len()).unwrap();
 let mut buffer = vec![0; account_size];
 
 // Initialize the structure for your instruction
-ExtraAccountMetaState::init_with_account_metas::<MyInstruction>(&mut buffer, &extra_metas).unwrap();
+ExtraAccountMetaList::init_with_account_metas::<MyInstruction>(&mut buffer, &extra_metas).unwrap();
 
 // Off-chain, you can add the additional accounts directly from the account data
 let program_id = Pubkey::new_unique();
 let mut instruction = Instruction::new_with_bytes(program_id, &[], vec![]);
-ExtraAccountMetaState::add_to_instruction::<MyInstruction>(&mut instruction, &buffer).unwrap();
+ExtraAccountMetaList::add_to_instruction::<MyInstruction>(&mut instruction, &buffer).unwrap();
 
 // On-chain, you can add the additional accounts *and* account infos
 let mut cpi_instruction = Instruction::new_with_bytes(program_id, &[], vec![]);
@@ -49,7 +49,7 @@ let mut cpi_account_infos = vec![];
 
 // Provide all "remaining_account_infos" that are *not* part of any other known interface
 let remaining_account_infos = &[]; 
-ExtraAccountMetaState::add_to_cpi_instruction::<MyInstruction>(
+ExtraAccountMetaList::add_to_cpi_instruction::<MyInstruction>(
     &mut cpi_instruction,
     &mut cpi_account_infos,
     &buffer,
@@ -57,7 +57,7 @@ ExtraAccountMetaState::add_to_cpi_instruction::<MyInstruction>(
 ).unwrap();
 ```
 
-For ease of use on-chain, `ExtraAccountMetaState::init_with_account_infos` is also
+For ease of use on-chain, `ExtraAccountMetaList::init_with_account_infos` is also
 provided to initialize directly from a set of given accounts.
 
 ## Motivation
@@ -105,12 +105,12 @@ This library uses `spl-type-length-value` to read and write required instruction
 accounts from account data.
 
 Interface instructions must have an 8-byte discriminator, so that the exposed
-`ExtraAccountMetaState` type can use the instruction discriminator as a `ArrayDiscriminator`.
+`ExtraAccountMetaList` type can use the instruction discriminator as a `ArrayDiscriminator`.
 
 This can be confusing. Typically, a type implements `SplDiscriminate`, so that
-the type can be written into TLV data. In this case, `ExtraAccountMetaState` is
+the type can be written into TLV data. In this case, `ExtraAccountMetaList` is
 generic over `SplDiscriminate`, meaning that a program can write many different instances of
-`ExtraAccountMetaState` into one account, using different `ArrayDiscriminator`s.
+`ExtraAccountMetaList` into one account, using different `ArrayDiscriminator`s.
 
 Also, it's reusing an instruction discriminator as a TLV discriminator. For example,
 if the `transfer` instruction has a discriminator of `[1, 2, 3, 4, 5, 6, 7, 8]`,

--- a/libraries/tlv-account-resolution/src/account.rs
+++ b/libraries/tlv-account-resolution/src/account.rs
@@ -1,4 +1,4 @@
-//! Structs/enums for managing "required account state", ie. defining accounts
+//! Struct for managing extra required account configs, ie. defining accounts
 //! required for your interface program, which can be  `AccountMeta`s - which
 //! have fixed addresses - or PDAs - which have addresses derived from a
 //! collection of seeds
@@ -19,7 +19,7 @@ use {
 /// Can be used in TLV-encoded data.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
-pub struct PodAccountMeta {
+pub struct ExtraAccountMeta {
     /// Discriminator to tell whether this represents a standard
     /// `AccountMeta` or a PDA
     pub discriminator: u8,
@@ -31,8 +31,8 @@ pub struct PodAccountMeta {
     /// Whether the account should be writable
     pub is_writable: PodBool,
 }
-impl PodAccountMeta {
-    /// Create a `PodAccountMeta` from a public key,
+impl ExtraAccountMeta {
+    /// Create a `ExtraAccountMeta` from a public key,
     /// thus representing a standard `AccountMeta`
     pub fn new_with_pubkey(
         pubkey: &Pubkey,
@@ -47,7 +47,7 @@ impl PodAccountMeta {
         })
     }
 
-    /// Create a `PodAccountMeta` from a list of seed configurations,
+    /// Create a `ExtraAccountMeta` from a list of seed configurations,
     /// thus representing a PDA
     pub fn new_with_seeds(
         seeds: &[Seed],
@@ -63,8 +63,8 @@ impl PodAccountMeta {
     }
 }
 
-// Conversions to `PodAccountMeta`
-impl From<&AccountMeta> for PodAccountMeta {
+// Conversions to `ExtraAccountMeta`
+impl From<&AccountMeta> for ExtraAccountMeta {
     fn from(meta: &AccountMeta) -> Self {
         Self {
             discriminator: 0,
@@ -74,7 +74,7 @@ impl From<&AccountMeta> for PodAccountMeta {
         }
     }
 }
-impl From<&AccountInfo<'_>> for PodAccountMeta {
+impl From<&AccountInfo<'_>> for ExtraAccountMeta {
     fn from(account_info: &AccountInfo) -> Self {
         Self {
             discriminator: 0,
@@ -85,11 +85,11 @@ impl From<&AccountInfo<'_>> for PodAccountMeta {
     }
 }
 
-// Conversions from `PodAccountMeta`
-impl TryFrom<&PodAccountMeta> for AccountMeta {
+// Conversions from `ExtraAccountMeta`
+impl TryFrom<&ExtraAccountMeta> for AccountMeta {
     type Error = ProgramError;
 
-    fn try_from(pod: &PodAccountMeta) -> Result<Self, Self::Error> {
+    fn try_from(pod: &ExtraAccountMeta) -> Result<Self, Self::Error> {
         if pod.discriminator == 0 {
             Ok(AccountMeta {
                 pubkey: Pubkey::try_from(pod.address_config)

--- a/libraries/tlv-account-resolution/src/lib.rs
+++ b/libraries/tlv-account-resolution/src/lib.rs
@@ -7,8 +7,8 @@
 #![deny(missing_docs)]
 #![cfg_attr(not(test), forbid(unsafe_code))]
 
+pub mod account;
 pub mod error;
-pub mod pod;
 pub mod seeds;
 pub mod state;
 

--- a/libraries/tlv-account-resolution/src/seeds.rs
+++ b/libraries/tlv-account-resolution/src/seeds.rs
@@ -1,9 +1,9 @@
 //! Types for managing seed configurations in TLV Account Resolution
 //!
-//! As determined by the `address_config` field of `PodAccountMeta`,
+//! As determined by the `address_config` field of `ExtraAccountMeta`,
 //! seed configurations are limited to a maximum of 32 bytes.
 //! This means that the maximum number of seed configurations that can be
-//! packed into a single `PodAccountMeta` will depend directly on the size
+//! packed into a single `ExtraAccountMeta` will depend directly on the size
 //! of the seed configurations themselves.
 //!
 //! Sizes are as follows:

--- a/libraries/tlv-account-resolution/src/state.rs
+++ b/libraries/tlv-account-resolution/src/state.rs
@@ -1,7 +1,7 @@
 //! State transition types
 
 use {
-    crate::{error::AccountResolutionError, pod::PodAccountMeta, seeds::Seed},
+    crate::{account::ExtraAccountMeta, error::AccountResolutionError, seeds::Seed},
     solana_program::{
         account_info::AccountInfo,
         instruction::{AccountMeta, Instruction},
@@ -32,7 +32,7 @@ use {
 ///         pubkey::Pubkey
 ///     },
 ///     spl_discriminator::{ArrayDiscriminator, SplDiscriminate},
-///     spl_tlv_account_resolution::state::ExtraAccountMetas,
+///     spl_tlv_account_resolution::state::ExtraAccountMetaState,
 /// };
 ///
 /// struct MyInstruction;
@@ -50,30 +50,30 @@ use {
 /// ];
 ///
 /// // assume that this buffer is actually account data, already allocated to `account_size`
-/// let account_size = ExtraAccountMetas::size_of(extra_metas.len()).unwrap();
+/// let account_size = ExtraAccountMetaState::size_of(extra_metas.len()).unwrap();
 /// let mut buffer = vec![0; account_size];
 ///
 /// // Initialize the structure for your instruction
-/// ExtraAccountMetas::init_with_account_metas::<MyInstruction>(&mut buffer, &extra_metas).unwrap();
+/// ExtraAccountMetaState::init_with_account_metas::<MyInstruction>(&mut buffer, &extra_metas).unwrap();
 ///
 /// // Off-chain, you can add the additional accounts directly from the account data
 /// let program_id = Pubkey::new_unique();
 /// let mut instruction = Instruction::new_with_bytes(program_id, &[], vec![]);
-/// ExtraAccountMetas::add_to_instruction::<MyInstruction>(&mut instruction, &buffer).unwrap();
+/// ExtraAccountMetaState::add_to_instruction::<MyInstruction>(&mut instruction, &buffer).unwrap();
 ///
 /// // On-chain, you can add the additional accounts *and* account infos
 /// let mut cpi_instruction = Instruction::new_with_bytes(program_id, &[], vec![]);
 /// let mut cpi_account_infos = vec![]; // assume the other required account infos are already included
 /// let remaining_account_infos: &[AccountInfo<'_>] = &[]; // these are the account infos provided to the instruction that are *not* part of any other known interface
-/// ExtraAccountMetas::add_to_cpi_instruction::<MyInstruction>(
+/// ExtraAccountMetaState::add_to_cpi_instruction::<MyInstruction>(
 ///     &mut cpi_instruction,
 ///     &mut cpi_account_infos,
 ///     &buffer,
 ///     &remaining_account_infos,
 /// );
 /// ```
-pub struct ExtraAccountMetas;
-impl ExtraAccountMetas {
+pub struct ExtraAccountMetaState;
+impl ExtraAccountMetaState {
     /// Initialize pod slice data for the given instruction and any type
     /// convertible to account metas
     fn init<'a, T: SplDiscriminate, F, M>(
@@ -82,10 +82,10 @@ impl ExtraAccountMetas {
         conversion_fn: F,
     ) -> Result<(), ProgramError>
     where
-        F: Fn(&'a M) -> PodAccountMeta,
+        F: Fn(&'a M) -> ExtraAccountMeta,
     {
         let mut state = TlvStateMut::unpack(data).unwrap();
-        let tlv_size = PodSlice::<PodAccountMeta>::size_of(convertible_account_metas.len())?;
+        let tlv_size = PodSlice::<ExtraAccountMeta>::size_of(convertible_account_metas.len())?;
         let (bytes, _) = state.alloc::<T>(tlv_size, false)?;
         let mut extra_account_metas = PodSliceMut::init(bytes)?;
         for account_meta in convertible_account_metas {
@@ -101,7 +101,7 @@ impl ExtraAccountMetas {
         account_infos: &[AccountInfo<'_>],
     ) -> Result<(), ProgramError> {
         Self::init::<T, _, AccountInfo>(data, account_infos, |account_info| {
-            PodAccountMeta::from(account_info)
+            ExtraAccountMeta::from(account_info)
         })
     }
 
@@ -112,7 +112,7 @@ impl ExtraAccountMetas {
         account_metas: &[AccountMeta],
     ) -> Result<(), ProgramError> {
         Self::init::<T, _, AccountMeta>(data, account_metas, |account_meta| {
-            PodAccountMeta::from(account_meta)
+            ExtraAccountMeta::from(account_meta)
         })
     }
 
@@ -121,29 +121,29 @@ impl ExtraAccountMetas {
     /// or PDAs
     pub fn init_with_pod_account_metas<T: SplDiscriminate>(
         data: &mut [u8],
-        pod_account_metas: &[PodAccountMeta],
+        pod_account_metas: &[ExtraAccountMeta],
     ) -> Result<(), ProgramError> {
-        Self::init::<T, _, PodAccountMeta>(data, pod_account_metas, |pod_account_meta| {
+        Self::init::<T, _, ExtraAccountMeta>(data, pod_account_metas, |pod_account_meta| {
             *pod_account_meta
         })
     }
 
-    /// Get the underlying `PodSlice<PodAccountMeta>` from an unpacked TLV
+    /// Get the underlying `PodSlice<ExtraAccountMeta>` from an unpacked TLV
     ///
     /// Due to lifetime annoyances, this function can't just take in the bytes,
     /// since then we would be returning a reference to a locally created
     /// `TlvStateBorrowed`. I hope there's a better way to do this!
     pub fn unpack_with_tlv_state<'a, T: SplDiscriminate>(
         tlv_state: &'a TlvStateBorrowed,
-    ) -> Result<PodSlice<'a, PodAccountMeta>, ProgramError> {
+    ) -> Result<PodSlice<'a, ExtraAccountMeta>, ProgramError> {
         let bytes = tlv_state.get_first_bytes::<T>()?;
-        PodSlice::<PodAccountMeta>::unpack(bytes)
+        PodSlice::<ExtraAccountMeta>::unpack(bytes)
     }
 
     /// Get the byte size required to hold `num_items` items
     pub fn size_of(num_items: usize) -> Result<usize, ProgramError> {
         Ok(TlvStateBorrowed::get_base_len()
-            .saturating_add(PodSlice::<PodAccountMeta>::size_of(num_items)?))
+            .saturating_add(PodSlice::<ExtraAccountMeta>::size_of(num_items)?))
     }
 
     /// De-escalate an account meta if necessary
@@ -209,7 +209,7 @@ impl ExtraAccountMetas {
     ) -> Result<(), ProgramError> {
         let state = TlvStateBorrowed::unpack(data)?;
         let bytes = state.get_first_bytes::<T>()?;
-        let extra_account_metas = PodSlice::<PodAccountMeta>::unpack(bytes)?;
+        let extra_account_metas = PodSlice::<ExtraAccountMeta>::unpack(bytes)?;
 
         for extra_meta in extra_account_metas.data().iter() {
             let mut account_meta = match extra_meta.discriminator {
@@ -292,22 +292,23 @@ mod tests {
             AccountMeta::new_readonly(Pubkey::new_unique(), true),
             AccountMeta::new_readonly(Pubkey::new_unique(), false),
         ];
-        let account_size = ExtraAccountMetas::size_of(metas.len()).unwrap();
+        let account_size = ExtraAccountMetaState::size_of(metas.len()).unwrap();
         let mut buffer = vec![0; account_size];
 
-        ExtraAccountMetas::init_with_account_metas::<TestInstruction>(&mut buffer, &metas).unwrap();
+        ExtraAccountMetaState::init_with_account_metas::<TestInstruction>(&mut buffer, &metas)
+            .unwrap();
 
         let mut instruction = Instruction::new_with_bytes(Pubkey::new_unique(), &[], vec![]);
-        ExtraAccountMetas::add_to_instruction::<TestInstruction>(&mut instruction, &buffer)
+        ExtraAccountMetaState::add_to_instruction::<TestInstruction>(&mut instruction, &buffer)
             .unwrap();
 
         assert_eq!(
             instruction
                 .accounts
                 .iter()
-                .map(PodAccountMeta::from)
+                .map(ExtraAccountMeta::from)
                 .collect::<Vec<_>>(),
-            metas.iter().map(PodAccountMeta::from).collect::<Vec<_>>()
+            metas.iter().map(ExtraAccountMeta::from).collect::<Vec<_>>()
         );
     }
 
@@ -355,25 +356,28 @@ mod tests {
                 Epoch::default(),
             ),
         ];
-        let account_size = ExtraAccountMetas::size_of(account_infos.len()).unwrap();
+        let account_size = ExtraAccountMetaState::size_of(account_infos.len()).unwrap();
         let mut buffer = vec![0; account_size];
 
-        ExtraAccountMetas::init_with_account_infos::<TestInstruction>(&mut buffer, &account_infos)
-            .unwrap();
+        ExtraAccountMetaState::init_with_account_infos::<TestInstruction>(
+            &mut buffer,
+            &account_infos,
+        )
+        .unwrap();
 
         let mut instruction = Instruction::new_with_bytes(Pubkey::new_unique(), &[], vec![]);
-        ExtraAccountMetas::add_to_instruction::<TestInstruction>(&mut instruction, &buffer)
+        ExtraAccountMetaState::add_to_instruction::<TestInstruction>(&mut instruction, &buffer)
             .unwrap();
 
         assert_eq!(
             instruction
                 .accounts
                 .iter()
-                .map(PodAccountMeta::from)
+                .map(ExtraAccountMeta::from)
                 .collect::<Vec<_>>(),
             account_infos
                 .iter()
-                .map(PodAccountMeta::from)
+                .map(ExtraAccountMeta::from)
                 .collect::<Vec<_>>()
         );
     }
@@ -389,7 +393,7 @@ mod tests {
 
         let extra_meta1 = AccountMeta::new(Pubkey::new_unique(), false);
         let extra_meta2 = AccountMeta::new(Pubkey::new_unique(), true);
-        let extra_meta3 = PodAccountMeta::new_with_seeds(
+        let extra_meta3 = ExtraAccountMeta::new_with_seeds(
             &[
                 Seed::Literal {
                     bytes: extra_meta3_literal_str.as_bytes().to_vec(),
@@ -407,8 +411,8 @@ mod tests {
         .unwrap();
 
         let metas = [
-            PodAccountMeta::from(&extra_meta1),
-            PodAccountMeta::from(&extra_meta2),
+            ExtraAccountMeta::from(&extra_meta1),
+            ExtraAccountMeta::from(&extra_meta2),
             extra_meta3,
         ];
 
@@ -416,15 +420,15 @@ mod tests {
         let ix_accounts = vec![ix_account1.clone(), ix_account2.clone()];
         let mut instruction = Instruction::new_with_bytes(program_id, &ix_data, ix_accounts);
 
-        let account_size = ExtraAccountMetas::size_of(metas.len()).unwrap();
+        let account_size = ExtraAccountMetaState::size_of(metas.len()).unwrap();
         let mut buffer = vec![0; account_size];
 
         // Notice we use `init_with_required_accounts` instead of
         // `init_with_account_metas`
-        ExtraAccountMetas::init_with_pod_account_metas::<TestInstruction>(&mut buffer, &metas)
+        ExtraAccountMetaState::init_with_pod_account_metas::<TestInstruction>(&mut buffer, &metas)
             .unwrap();
 
-        ExtraAccountMetas::add_to_instruction::<TestInstruction>(&mut instruction, &buffer)
+        ExtraAccountMetaState::add_to_instruction::<TestInstruction>(&mut instruction, &buffer)
             .unwrap();
 
         let check_extra_meta3_u8_arg = ix_data[1];
@@ -454,11 +458,11 @@ mod tests {
             instruction
                 .accounts
                 .iter()
-                .map(PodAccountMeta::from)
+                .map(ExtraAccountMeta::from)
                 .collect::<Vec<_>>(),
             check_metas
                 .iter()
-                .map(PodAccountMeta::from)
+                .map(ExtraAccountMeta::from)
                 .collect::<Vec<_>>()
         );
     }
@@ -473,7 +477,7 @@ mod tests {
         let extra_meta2 = AccountMeta::new(Pubkey::new_unique(), true);
         let extra_meta3 = AccountMeta::new_readonly(Pubkey::new_unique(), true);
         let extra_meta4 = AccountMeta::new_readonly(Pubkey::new_unique(), false);
-        let extra_meta5 = PodAccountMeta::new_with_seeds(
+        let extra_meta5 = ExtraAccountMeta::new_with_seeds(
             &[
                 Seed::Literal {
                     bytes: extra_meta5_literal_str.as_bytes().to_vec(),
@@ -493,7 +497,7 @@ mod tests {
         .unwrap();
 
         let other_meta1 = AccountMeta::new(Pubkey::new_unique(), false);
-        let other_meta2 = PodAccountMeta::new_with_seeds(
+        let other_meta2 = ExtraAccountMeta::new_with_seeds(
             &[
                 Seed::Literal {
                     bytes: other_meta2_literal_str.as_bytes().to_vec(),
@@ -510,21 +514,21 @@ mod tests {
         .unwrap();
 
         let metas = [
-            PodAccountMeta::from(&extra_meta1),
-            PodAccountMeta::from(&extra_meta2),
-            PodAccountMeta::from(&extra_meta3),
-            PodAccountMeta::from(&extra_meta4),
+            ExtraAccountMeta::from(&extra_meta1),
+            ExtraAccountMeta::from(&extra_meta2),
+            ExtraAccountMeta::from(&extra_meta3),
+            ExtraAccountMeta::from(&extra_meta4),
             extra_meta5,
         ];
-        let other_metas = [PodAccountMeta::from(&other_meta1), other_meta2];
+        let other_metas = [ExtraAccountMeta::from(&other_meta1), other_meta2];
 
-        let account_size = ExtraAccountMetas::size_of(metas.len()).unwrap()
-            + ExtraAccountMetas::size_of(other_metas.len()).unwrap();
+        let account_size = ExtraAccountMetaState::size_of(metas.len()).unwrap()
+            + ExtraAccountMetaState::size_of(other_metas.len()).unwrap();
         let mut buffer = vec![0; account_size];
 
-        ExtraAccountMetas::init_with_pod_account_metas::<TestInstruction>(&mut buffer, &metas)
+        ExtraAccountMetaState::init_with_pod_account_metas::<TestInstruction>(&mut buffer, &metas)
             .unwrap();
-        ExtraAccountMetas::init_with_pod_account_metas::<TestOtherInstruction>(
+        ExtraAccountMetaState::init_with_pod_account_metas::<TestOtherInstruction>(
             &mut buffer,
             &other_metas,
         )
@@ -534,7 +538,7 @@ mod tests {
         let ix_data = vec![0, 0, 0, 0, 0, 7, 0, 0];
         let ix_accounts = vec![];
         let mut instruction = Instruction::new_with_bytes(program_id, &ix_data, ix_accounts);
-        ExtraAccountMetas::add_to_instruction::<TestInstruction>(&mut instruction, &buffer)
+        ExtraAccountMetaState::add_to_instruction::<TestInstruction>(&mut instruction, &buffer)
             .unwrap();
 
         let check_extra_meta5_u8_arg = ix_data[5];
@@ -564,11 +568,11 @@ mod tests {
             instruction
                 .accounts
                 .iter()
-                .map(PodAccountMeta::from)
+                .map(ExtraAccountMeta::from)
                 .collect::<Vec<_>>(),
             check_metas
                 .iter()
-                .map(PodAccountMeta::from)
+                .map(ExtraAccountMeta::from)
                 .collect::<Vec<_>>()
         );
 
@@ -578,8 +582,11 @@ mod tests {
         let ix_accounts = vec![ix_account1.clone(), ix_account2.clone()];
         let ix_data = vec![0, 26, 0, 0, 0, 0, 0];
         let mut instruction = Instruction::new_with_bytes(program_id, &ix_data, ix_accounts);
-        ExtraAccountMetas::add_to_instruction::<TestOtherInstruction>(&mut instruction, &buffer)
-            .unwrap();
+        ExtraAccountMetaState::add_to_instruction::<TestOtherInstruction>(
+            &mut instruction,
+            &buffer,
+        )
+        .unwrap();
 
         let check_other_meta2_u32_arg = u32::from_le_bytes(ix_data[1..5].try_into().unwrap());
         let check_other_meta2_pubkey = Pubkey::find_program_address(
@@ -606,11 +613,11 @@ mod tests {
             instruction
                 .accounts
                 .iter()
-                .map(PodAccountMeta::from)
+                .map(ExtraAccountMeta::from)
                 .collect::<Vec<_>>(),
             check_other_metas
                 .iter()
-                .map(PodAccountMeta::from)
+                .map(ExtraAccountMeta::from)
                 .collect::<Vec<_>>()
         );
     }
@@ -667,7 +674,7 @@ mod tests {
         let extra_meta2 = AccountMeta::new(Pubkey::new_unique(), true);
         let extra_meta3 = AccountMeta::new_readonly(Pubkey::new_unique(), true);
         let extra_meta4 = AccountMeta::new_readonly(Pubkey::new_unique(), false);
-        let extra_meta5 = PodAccountMeta::new_with_seeds(
+        let extra_meta5 = ExtraAccountMeta::new_with_seeds(
             &[
                 Seed::Literal {
                     bytes: extra_meta5_literal_str.as_bytes().to_vec(),
@@ -686,7 +693,7 @@ mod tests {
             true,
         )
         .unwrap();
-        let extra_meta6 = PodAccountMeta::new_with_seeds(
+        let extra_meta6 = ExtraAccountMeta::new_with_seeds(
             &[
                 Seed::Literal {
                     bytes: extra_meta6_literal_u64.to_le_bytes().to_vec(),
@@ -700,36 +707,42 @@ mod tests {
         .unwrap();
 
         let metas = [
-            PodAccountMeta::from(&extra_meta1),
-            PodAccountMeta::from(&extra_meta2),
-            PodAccountMeta::from(&extra_meta3),
-            PodAccountMeta::from(&extra_meta4),
+            ExtraAccountMeta::from(&extra_meta1),
+            ExtraAccountMeta::from(&extra_meta2),
+            ExtraAccountMeta::from(&extra_meta3),
+            ExtraAccountMeta::from(&extra_meta4),
             extra_meta5,
             extra_meta6,
         ];
 
-        let account_size = ExtraAccountMetas::size_of(account_infos.len()).unwrap()
-            + ExtraAccountMetas::size_of(metas.len()).unwrap();
+        let account_size = ExtraAccountMetaState::size_of(account_infos.len()).unwrap()
+            + ExtraAccountMetaState::size_of(metas.len()).unwrap();
         let mut buffer = vec![0; account_size];
 
-        ExtraAccountMetas::init_with_account_infos::<TestInstruction>(&mut buffer, &account_infos)
-            .unwrap();
-        ExtraAccountMetas::init_with_pod_account_metas::<TestOtherInstruction>(&mut buffer, &metas)
-            .unwrap();
+        ExtraAccountMetaState::init_with_account_infos::<TestInstruction>(
+            &mut buffer,
+            &account_infos,
+        )
+        .unwrap();
+        ExtraAccountMetaState::init_with_pod_account_metas::<TestOtherInstruction>(
+            &mut buffer,
+            &metas,
+        )
+        .unwrap();
 
         let program_id = Pubkey::new_unique();
         let mut instruction = Instruction::new_with_bytes(program_id, &[], vec![]);
-        ExtraAccountMetas::add_to_instruction::<TestInstruction>(&mut instruction, &buffer)
+        ExtraAccountMetaState::add_to_instruction::<TestInstruction>(&mut instruction, &buffer)
             .unwrap();
         assert_eq!(
             instruction
                 .accounts
                 .iter()
-                .map(PodAccountMeta::from)
+                .map(ExtraAccountMeta::from)
                 .collect::<Vec<_>>(),
             account_infos
                 .iter()
-                .map(PodAccountMeta::from)
+                .map(ExtraAccountMeta::from)
                 .collect::<Vec<_>>()
         );
 
@@ -740,8 +753,11 @@ mod tests {
         instruction_data.extend_from_slice(&instruction_u8array_arg);
         instruction_data.extend_from_slice(instruction_pubkey_arg.as_ref());
         let mut instruction = Instruction::new_with_bytes(program_id, &instruction_data, vec![]);
-        ExtraAccountMetas::add_to_instruction::<TestOtherInstruction>(&mut instruction, &buffer)
-            .unwrap();
+        ExtraAccountMetaState::add_to_instruction::<TestOtherInstruction>(
+            &mut instruction,
+            &buffer,
+        )
+        .unwrap();
 
         let check_extra_meta5_pubkey = Pubkey::find_program_address(
             &[
@@ -785,11 +801,11 @@ mod tests {
             instruction
                 .accounts
                 .iter()
-                .map(PodAccountMeta::from)
+                .map(ExtraAccountMeta::from)
                 .collect::<Vec<_>>(),
             check_metas
                 .iter()
-                .map(PodAccountMeta::from)
+                .map(ExtraAccountMeta::from)
                 .collect::<Vec<_>>()
         );
     }
@@ -892,7 +908,7 @@ mod tests {
         let required_pda1_literal_string = "required_pda1";
         let required_pda2_literal_u32 = 4u32;
 
-        let required_pda1 = PodAccountMeta::new_with_seeds(
+        let required_pda1 = ExtraAccountMeta::new_with_seeds(
             &[
                 Seed::Literal {
                     bytes: required_pda1_literal_string.as_bytes().to_vec(),
@@ -907,7 +923,7 @@ mod tests {
             true,
         )
         .unwrap();
-        let required_pda2 = PodAccountMeta::new_with_seeds(
+        let required_pda2 = ExtraAccountMeta::new_with_seeds(
             &[
                 Seed::Literal {
                     bytes: required_pda2_literal_u32.to_le_bytes().to_vec(),
@@ -930,15 +946,15 @@ mod tests {
 
         let mut required_accounts = extra_account_infos
             .iter()
-            .map(PodAccountMeta::from)
+            .map(ExtraAccountMeta::from)
             .collect::<Vec<_>>();
         required_accounts.push(required_pda1);
         required_accounts.push(required_pda2);
 
-        let account_size = ExtraAccountMetas::size_of(required_accounts.len()).unwrap();
+        let account_size = ExtraAccountMetaState::size_of(required_accounts.len()).unwrap();
         let mut buffer = vec![0; account_size];
 
-        ExtraAccountMetas::init_with_pod_account_metas::<TestInstruction>(
+        ExtraAccountMetaState::init_with_pod_account_metas::<TestInstruction>(
             &mut buffer,
             &required_accounts,
         )
@@ -954,7 +970,7 @@ mod tests {
 
         let mut instruction =
             Instruction::new_with_bytes(program_id, &instruction_data, ix_accounts.clone());
-        ExtraAccountMetas::add_to_instruction::<TestInstruction>(&mut instruction, &buffer)
+        ExtraAccountMetaState::add_to_instruction::<TestInstruction>(&mut instruction, &buffer)
             .unwrap();
 
         // Now our program is going to use its own set of account infos.
@@ -1056,7 +1072,7 @@ mod tests {
         let mut cpi_instruction =
             Instruction::new_with_bytes(program_id, &instruction_data, ix_accounts);
         let mut cpi_account_infos = ix_account_infos.to_vec();
-        ExtraAccountMetas::add_to_cpi_instruction::<TestInstruction>(
+        ExtraAccountMetaState::add_to_cpi_instruction::<TestInstruction>(
             &mut cpi_instruction,
             &mut cpi_account_infos,
             &buffer,

--- a/token/transfer-hook-example/src/processor.rs
+++ b/token/transfer-hook-example/src/processor.rs
@@ -11,7 +11,7 @@ use {
         pubkey::Pubkey,
         system_instruction,
     },
-    spl_tlv_account_resolution::state::ExtraAccountMetaState,
+    spl_tlv_account_resolution::state::ExtraAccountMetaList,
     spl_token_2022::{
         extension::{
             transfer_hook::TransferHookAccount, BaseStateWithExtensions, StateWithExtensions,
@@ -66,7 +66,7 @@ pub fn process_execute(
     let data = extra_account_metas_info.try_borrow_data()?;
     let state = TlvStateBorrowed::unpack(&data).unwrap();
     let extra_account_metas =
-        ExtraAccountMetaState::unpack_with_tlv_state::<ExecuteInstruction>(&state)?;
+        ExtraAccountMetaList::unpack_with_tlv_state::<ExecuteInstruction>(&state)?;
 
     // if incorrect number of are provided, error
     let extra_account_infos = account_info_iter.as_slice();
@@ -89,7 +89,7 @@ pub fn process_execute(
     Ok(())
 }
 
-/// Processes a [InitializeExtraAccountMetaState](enum.TransferHookInstruction.html) instruction.
+/// Processes a [InitializeExtraAccountMetaList](enum.TransferHookInstruction.html) instruction.
 pub fn process_initialize_extra_account_metas(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
@@ -129,7 +129,7 @@ pub fn process_initialize_extra_account_metas(
     let signer_seeds = collect_extra_account_metas_signer_seeds(mint_info.key, &bump_seed);
     let extra_account_infos = account_info_iter.as_slice();
     let length = extra_account_infos.len();
-    let account_size = ExtraAccountMetaState::size_of(length)?;
+    let account_size = ExtraAccountMetaList::size_of(length)?;
     invoke_signed(
         &system_instruction::allocate(extra_account_metas_info.key, account_size as u64),
         &[extra_account_metas_info.clone()],
@@ -143,7 +143,7 @@ pub fn process_initialize_extra_account_metas(
 
     // Write the data
     let mut data = extra_account_metas_info.try_borrow_mut_data()?;
-    ExtraAccountMetaState::init_with_account_infos::<ExecuteInstruction>(
+    ExtraAccountMetaList::init_with_account_infos::<ExecuteInstruction>(
         &mut data,
         extra_account_infos,
     )?;
@@ -160,8 +160,8 @@ pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> P
             msg!("Instruction: Execute");
             process_execute(program_id, accounts, amount)
         }
-        TransferHookInstruction::InitializeExtraAccountMetaState => {
-            msg!("Instruction: InitializeExtraAccountMetaState");
+        TransferHookInstruction::InitializeExtraAccountMetaList => {
+            msg!("Instruction: InitializeExtraAccountMetaList");
             process_initialize_extra_account_metas(program_id, accounts)
         }
     }

--- a/token/transfer-hook-example/src/processor.rs
+++ b/token/transfer-hook-example/src/processor.rs
@@ -11,7 +11,7 @@ use {
         pubkey::Pubkey,
         system_instruction,
     },
-    spl_tlv_account_resolution::state::ExtraAccountMetas,
+    spl_tlv_account_resolution::state::ExtraAccountMetaState,
     spl_token_2022::{
         extension::{
             transfer_hook::TransferHookAccount, BaseStateWithExtensions, StateWithExtensions,
@@ -66,7 +66,7 @@ pub fn process_execute(
     let data = extra_account_metas_info.try_borrow_data()?;
     let state = TlvStateBorrowed::unpack(&data).unwrap();
     let extra_account_metas =
-        ExtraAccountMetas::unpack_with_tlv_state::<ExecuteInstruction>(&state)?;
+        ExtraAccountMetaState::unpack_with_tlv_state::<ExecuteInstruction>(&state)?;
 
     // if incorrect number of are provided, error
     let extra_account_infos = account_info_iter.as_slice();
@@ -89,7 +89,7 @@ pub fn process_execute(
     Ok(())
 }
 
-/// Processes a [InitializeExtraAccountMetas](enum.TransferHookInstruction.html) instruction.
+/// Processes a [InitializeExtraAccountMetaState](enum.TransferHookInstruction.html) instruction.
 pub fn process_initialize_extra_account_metas(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
@@ -129,7 +129,7 @@ pub fn process_initialize_extra_account_metas(
     let signer_seeds = collect_extra_account_metas_signer_seeds(mint_info.key, &bump_seed);
     let extra_account_infos = account_info_iter.as_slice();
     let length = extra_account_infos.len();
-    let account_size = ExtraAccountMetas::size_of(length)?;
+    let account_size = ExtraAccountMetaState::size_of(length)?;
     invoke_signed(
         &system_instruction::allocate(extra_account_metas_info.key, account_size as u64),
         &[extra_account_metas_info.clone()],
@@ -143,7 +143,7 @@ pub fn process_initialize_extra_account_metas(
 
     // Write the data
     let mut data = extra_account_metas_info.try_borrow_mut_data()?;
-    ExtraAccountMetas::init_with_account_infos::<ExecuteInstruction>(
+    ExtraAccountMetaState::init_with_account_infos::<ExecuteInstruction>(
         &mut data,
         extra_account_infos,
     )?;
@@ -160,8 +160,8 @@ pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> P
             msg!("Instruction: Execute");
             process_execute(program_id, accounts, amount)
         }
-        TransferHookInstruction::InitializeExtraAccountMetas => {
-            msg!("Instruction: InitializeExtraAccountMetas");
+        TransferHookInstruction::InitializeExtraAccountMetaState => {
+            msg!("Instruction: InitializeExtraAccountMetaState");
             process_initialize_extra_account_metas(program_id, accounts)
         }
     }

--- a/token/transfer-hook-example/src/state.rs
+++ b/token/transfer-hook-example/src/state.rs
@@ -2,14 +2,14 @@
 
 use {
     solana_program::{instruction::AccountMeta, program_error::ProgramError},
-    spl_tlv_account_resolution::state::ExtraAccountMetas,
+    spl_tlv_account_resolution::state::ExtraAccountMetaState,
     spl_transfer_hook_interface::instruction::ExecuteInstruction,
 };
 
 /// Generate example data to be used directly in an account for testing
 pub fn example_data(account_metas: &[AccountMeta]) -> Result<Vec<u8>, ProgramError> {
-    let account_size = ExtraAccountMetas::size_of(account_metas.len())?;
+    let account_size = ExtraAccountMetaState::size_of(account_metas.len())?;
     let mut data = vec![0; account_size];
-    ExtraAccountMetas::init_with_account_metas::<ExecuteInstruction>(&mut data, account_metas)?;
+    ExtraAccountMetaState::init_with_account_metas::<ExecuteInstruction>(&mut data, account_metas)?;
     Ok(data)
 }

--- a/token/transfer-hook-example/src/state.rs
+++ b/token/transfer-hook-example/src/state.rs
@@ -2,14 +2,14 @@
 
 use {
     solana_program::{instruction::AccountMeta, program_error::ProgramError},
-    spl_tlv_account_resolution::state::ExtraAccountMetaState,
+    spl_tlv_account_resolution::state::ExtraAccountMetaList,
     spl_transfer_hook_interface::instruction::ExecuteInstruction,
 };
 
 /// Generate example data to be used directly in an account for testing
 pub fn example_data(account_metas: &[AccountMeta]) -> Result<Vec<u8>, ProgramError> {
-    let account_size = ExtraAccountMetaState::size_of(account_metas.len())?;
+    let account_size = ExtraAccountMetaList::size_of(account_metas.len())?;
     let mut data = vec![0; account_size];
-    ExtraAccountMetaState::init_with_account_metas::<ExecuteInstruction>(&mut data, account_metas)?;
+    ExtraAccountMetaList::init_with_account_metas::<ExecuteInstruction>(&mut data, account_metas)?;
     Ok(data)
 }

--- a/token/transfer-hook-example/tests/functional.rs
+++ b/token/transfer-hook-example/tests/functional.rs
@@ -16,7 +16,7 @@ use {
         system_instruction, sysvar,
         transaction::{Transaction, TransactionError},
     },
-    spl_tlv_account_resolution::state::ExtraAccountMetas,
+    spl_tlv_account_resolution::state::ExtraAccountMetaState,
     spl_token_2022::{
         extension::{transfer_hook::TransferHookAccount, ExtensionType, StateWithExtensionsMut},
         state::{Account, AccountState, Mint},
@@ -161,7 +161,7 @@ async fn success_execute() {
     let mut context = program_test.start_with_context().await;
     let rent = context.banks_client.get_rent().await.unwrap();
     let rent_lamports =
-        rent.minimum_balance(ExtraAccountMetas::size_of(extra_account_pubkeys.len()).unwrap());
+        rent.minimum_balance(ExtraAccountMetaState::size_of(extra_account_pubkeys.len()).unwrap());
     let transaction = Transaction::new_signed_with_payer(
         &[
             system_instruction::transfer(
@@ -349,7 +349,7 @@ async fn fail_incorrect_derivation() {
 
     let mut context = program_test.start_with_context().await;
     let rent = context.banks_client.get_rent().await.unwrap();
-    let rent_lamports = rent.minimum_balance(ExtraAccountMetas::size_of(0).unwrap());
+    let rent_lamports = rent.minimum_balance(ExtraAccountMetaState::size_of(0).unwrap());
 
     let transaction = Transaction::new_signed_with_payer(
         &[
@@ -442,7 +442,7 @@ async fn success_on_chain_invoke() {
     let mut context = program_test.start_with_context().await;
     let rent = context.banks_client.get_rent().await.unwrap();
     let rent_lamports =
-        rent.minimum_balance(ExtraAccountMetas::size_of(extra_account_pubkeys.len()).unwrap());
+        rent.minimum_balance(ExtraAccountMetaState::size_of(extra_account_pubkeys.len()).unwrap());
     let transaction = Transaction::new_signed_with_payer(
         &[
             system_instruction::transfer(
@@ -527,7 +527,7 @@ async fn fail_without_transferring_flag() {
     let mut context = program_test.start_with_context().await;
     let rent = context.banks_client.get_rent().await.unwrap();
     let rent_lamports =
-        rent.minimum_balance(ExtraAccountMetas::size_of(extra_account_pubkeys.len()).unwrap());
+        rent.minimum_balance(ExtraAccountMetaState::size_of(extra_account_pubkeys.len()).unwrap());
     let transaction = Transaction::new_signed_with_payer(
         &[
             system_instruction::transfer(

--- a/token/transfer-hook-example/tests/functional.rs
+++ b/token/transfer-hook-example/tests/functional.rs
@@ -16,7 +16,7 @@ use {
         system_instruction, sysvar,
         transaction::{Transaction, TransactionError},
     },
-    spl_tlv_account_resolution::state::ExtraAccountMetaState,
+    spl_tlv_account_resolution::state::ExtraAccountMetaList,
     spl_token_2022::{
         extension::{transfer_hook::TransferHookAccount, ExtensionType, StateWithExtensionsMut},
         state::{Account, AccountState, Mint},
@@ -161,7 +161,7 @@ async fn success_execute() {
     let mut context = program_test.start_with_context().await;
     let rent = context.banks_client.get_rent().await.unwrap();
     let rent_lamports =
-        rent.minimum_balance(ExtraAccountMetaState::size_of(extra_account_pubkeys.len()).unwrap());
+        rent.minimum_balance(ExtraAccountMetaList::size_of(extra_account_pubkeys.len()).unwrap());
     let transaction = Transaction::new_signed_with_payer(
         &[
             system_instruction::transfer(
@@ -349,7 +349,7 @@ async fn fail_incorrect_derivation() {
 
     let mut context = program_test.start_with_context().await;
     let rent = context.banks_client.get_rent().await.unwrap();
-    let rent_lamports = rent.minimum_balance(ExtraAccountMetaState::size_of(0).unwrap());
+    let rent_lamports = rent.minimum_balance(ExtraAccountMetaList::size_of(0).unwrap());
 
     let transaction = Transaction::new_signed_with_payer(
         &[
@@ -442,7 +442,7 @@ async fn success_on_chain_invoke() {
     let mut context = program_test.start_with_context().await;
     let rent = context.banks_client.get_rent().await.unwrap();
     let rent_lamports =
-        rent.minimum_balance(ExtraAccountMetaState::size_of(extra_account_pubkeys.len()).unwrap());
+        rent.minimum_balance(ExtraAccountMetaList::size_of(extra_account_pubkeys.len()).unwrap());
     let transaction = Transaction::new_signed_with_payer(
         &[
             system_instruction::transfer(
@@ -527,7 +527,7 @@ async fn fail_without_transferring_flag() {
     let mut context = program_test.start_with_context().await;
     let rent = context.banks_client.get_rent().await.unwrap();
     let rent_lamports =
-        rent.minimum_balance(ExtraAccountMetaState::size_of(extra_account_pubkeys.len()).unwrap());
+        rent.minimum_balance(ExtraAccountMetaList::size_of(extra_account_pubkeys.len()).unwrap());
     let transaction = Transaction::new_signed_with_payer(
         &[
             system_instruction::transfer(

--- a/token/transfer-hook-interface/README.md
+++ b/token/transfer-hook-interface/README.md
@@ -9,7 +9,7 @@ program-derived address defined by the interface.
 ```rust
 use {
     solana_program::{entrypoint::ProgramResult, program_error::ProgramError},
-    spl_tlv_account_resolution::state::ExtraAccountMetaState,
+    spl_tlv_account_resolution::state::ExtraAccountMetaList,
     spl_transfer_hook_interface::instruction::{ExecuteInstruction, TransferHookInstruction},
     spl_type_length_value::state::TlvStateBorrowed,
 };
@@ -42,7 +42,7 @@ pub fn process_instruction(
     let data = extra_account_metas_info.try_borrow_data()?;
     let state = TlvStateBorrowed::unpack(&data).unwrap();
     let extra_account_metas = 
-        ExtraAccountMetaState::unpack_with_tlv_state::<ExecuteInstruction>(&state)?;
+        ExtraAccountMetaList::unpack_with_tlv_state::<ExecuteInstruction>(&state)?;
 
     // If incorrect number of accounts is provided, error
     let extra_account_infos = account_info_iter.as_slice();
@@ -90,10 +90,10 @@ call happens after all other transfer logic, so the accounts reflect the *end*
 state of the transfer.
 
 A developer must implement the `Execute` instruction, and the
-`InitializeExtraAccountMetaState` instruction to write the required additional account
+`InitializeExtraAccountMetaList` instruction to write the required additional account
 pubkeys into the program-derived address defined by the mint and program id.
 
-Side note: it's technically not required to implement `InitializeExtraAccountMetaState`
+Side note: it's technically not required to implement `InitializeExtraAccountMetaList`
 at that instruction descriminator. Your program may implement multiple interfaces,
 so any other instruction in your program can create the account at the program-derived
 address!

--- a/token/transfer-hook-interface/README.md
+++ b/token/transfer-hook-interface/README.md
@@ -9,7 +9,7 @@ program-derived address defined by the interface.
 ```rust
 use {
     solana_program::{entrypoint::ProgramResult, program_error::ProgramError},
-    spl_tlv_account_resolution::state::ExtraAccountMetas,
+    spl_tlv_account_resolution::state::ExtraAccountMetaState,
     spl_transfer_hook_interface::instruction::{ExecuteInstruction, TransferHookInstruction},
     spl_type_length_value::state::TlvStateBorrowed,
 };
@@ -42,7 +42,7 @@ pub fn process_instruction(
     let data = extra_account_metas_info.try_borrow_data()?;
     let state = TlvStateBorrowed::unpack(&data).unwrap();
     let extra_account_metas = 
-        ExtraAccountMetas::unpack_with_tlv_state::<ExecuteInstruction>(&state)?;
+        ExtraAccountMetaState::unpack_with_tlv_state::<ExecuteInstruction>(&state)?;
 
     // If incorrect number of accounts is provided, error
     let extra_account_infos = account_info_iter.as_slice();
@@ -90,10 +90,10 @@ call happens after all other transfer logic, so the accounts reflect the *end*
 state of the transfer.
 
 A developer must implement the `Execute` instruction, and the
-`InitializeExtraAccountMetas` instruction to write the required additional account
+`InitializeExtraAccountMetaState` instruction to write the required additional account
 pubkeys into the program-derived address defined by the mint and program id.
 
-Side note: it's technically not required to implement `InitializeExtraAccountMetas`
+Side note: it's technically not required to implement `InitializeExtraAccountMetaState`
 at that instruction descriminator. Your program may implement multiple interfaces,
 so any other instruction in your program can create the account at the program-derived
 address!

--- a/token/transfer-hook-interface/src/instruction.rs
+++ b/token/transfer-hook-interface/src/instruction.rs
@@ -41,10 +41,10 @@ pub enum TransferHookInstruction {
     ///   3. `[]` System program
     ///   4..4+M `[]` `M` additional accounts, to be written to validation data
     ///
-    InitializeExtraAccountMetas,
+    InitializeExtraAccountMetaState,
 }
 /// TLV instruction type only used to define the discriminator. The actual data
-/// is entirely managed by `ExtraAccountMetas`, and it is the only data contained
+/// is entirely managed by `ExtraAccountMetaState`, and it is the only data contained
 /// by this type.
 #[derive(SplDiscriminate)]
 #[discriminator_hash_input("spl-transfer-hook-interface:execute")]
@@ -54,7 +54,7 @@ pub struct ExecuteInstruction;
 /// for the transfer hook
 #[derive(SplDiscriminate)]
 #[discriminator_hash_input("spl-transfer-hook-interface:initialize-extra-account-metas")]
-pub struct InitializeExtraAccountMetasInstruction;
+pub struct InitializeExtraAccountMetaStateInstruction;
 
 impl TransferHookInstruction {
     /// Unpacks a byte buffer into a [TransferHookInstruction](enum.TransferHookInstruction.html).
@@ -72,8 +72,8 @@ impl TransferHookInstruction {
                     .ok_or(ProgramError::InvalidInstructionData)?;
                 Self::Execute { amount }
             }
-            InitializeExtraAccountMetasInstruction::SPL_DISCRIMINATOR_SLICE => {
-                Self::InitializeExtraAccountMetas
+            InitializeExtraAccountMetaStateInstruction::SPL_DISCRIMINATOR_SLICE => {
+                Self::InitializeExtraAccountMetaState
             }
             _ => return Err(ProgramError::InvalidInstructionData),
         })
@@ -87,9 +87,9 @@ impl TransferHookInstruction {
                 buf.extend_from_slice(ExecuteInstruction::SPL_DISCRIMINATOR_SLICE);
                 buf.extend_from_slice(&amount.to_le_bytes());
             }
-            Self::InitializeExtraAccountMetas => {
+            Self::InitializeExtraAccountMetaState => {
                 buf.extend_from_slice(
-                    InitializeExtraAccountMetasInstruction::SPL_DISCRIMINATOR_SLICE,
+                    InitializeExtraAccountMetaStateInstruction::SPL_DISCRIMINATOR_SLICE,
                 );
             }
         };
@@ -149,7 +149,7 @@ pub fn execute(
     }
 }
 
-/// Creates a `InitializeExtraAccountMetas` instruction.
+/// Creates a `InitializeExtraAccountMetaState` instruction.
 pub fn initialize_extra_account_metas(
     program_id: &Pubkey,
     extra_account_metas_pubkey: &Pubkey,
@@ -157,7 +157,7 @@ pub fn initialize_extra_account_metas(
     authority_pubkey: &Pubkey,
     additional_accounts: &[AccountMeta],
 ) -> Instruction {
-    let data = TransferHookInstruction::InitializeExtraAccountMetas.pack();
+    let data = TransferHookInstruction::InitializeExtraAccountMetaState.pack();
 
     let mut accounts = vec![
         AccountMeta::new(*extra_account_metas_pubkey, false),
@@ -197,7 +197,7 @@ mod test {
 
     #[test]
     fn initialize_validation_pubkeys_packing() {
-        let check = TransferHookInstruction::InitializeExtraAccountMetas;
+        let check = TransferHookInstruction::InitializeExtraAccountMetaState;
         let packed = check.pack();
         // Please use INITIALIZE_EXTRA_ACCOUNT_METAS_DISCRIMINATOR in your program,
         // the following is just for test purposes

--- a/token/transfer-hook-interface/src/instruction.rs
+++ b/token/transfer-hook-interface/src/instruction.rs
@@ -41,10 +41,10 @@ pub enum TransferHookInstruction {
     ///   3. `[]` System program
     ///   4..4+M `[]` `M` additional accounts, to be written to validation data
     ///
-    InitializeExtraAccountMetaState,
+    InitializeExtraAccountMetaList,
 }
 /// TLV instruction type only used to define the discriminator. The actual data
-/// is entirely managed by `ExtraAccountMetaState`, and it is the only data contained
+/// is entirely managed by `ExtraAccountMetaList`, and it is the only data contained
 /// by this type.
 #[derive(SplDiscriminate)]
 #[discriminator_hash_input("spl-transfer-hook-interface:execute")]
@@ -54,7 +54,7 @@ pub struct ExecuteInstruction;
 /// for the transfer hook
 #[derive(SplDiscriminate)]
 #[discriminator_hash_input("spl-transfer-hook-interface:initialize-extra-account-metas")]
-pub struct InitializeExtraAccountMetaStateInstruction;
+pub struct InitializeExtraAccountMetaListInstruction;
 
 impl TransferHookInstruction {
     /// Unpacks a byte buffer into a [TransferHookInstruction](enum.TransferHookInstruction.html).
@@ -72,8 +72,8 @@ impl TransferHookInstruction {
                     .ok_or(ProgramError::InvalidInstructionData)?;
                 Self::Execute { amount }
             }
-            InitializeExtraAccountMetaStateInstruction::SPL_DISCRIMINATOR_SLICE => {
-                Self::InitializeExtraAccountMetaState
+            InitializeExtraAccountMetaListInstruction::SPL_DISCRIMINATOR_SLICE => {
+                Self::InitializeExtraAccountMetaList
             }
             _ => return Err(ProgramError::InvalidInstructionData),
         })
@@ -87,9 +87,9 @@ impl TransferHookInstruction {
                 buf.extend_from_slice(ExecuteInstruction::SPL_DISCRIMINATOR_SLICE);
                 buf.extend_from_slice(&amount.to_le_bytes());
             }
-            Self::InitializeExtraAccountMetaState => {
+            Self::InitializeExtraAccountMetaList => {
                 buf.extend_from_slice(
-                    InitializeExtraAccountMetaStateInstruction::SPL_DISCRIMINATOR_SLICE,
+                    InitializeExtraAccountMetaListInstruction::SPL_DISCRIMINATOR_SLICE,
                 );
             }
         };
@@ -149,7 +149,7 @@ pub fn execute(
     }
 }
 
-/// Creates a `InitializeExtraAccountMetaState` instruction.
+/// Creates a `InitializeExtraAccountMetaList` instruction.
 pub fn initialize_extra_account_metas(
     program_id: &Pubkey,
     extra_account_metas_pubkey: &Pubkey,
@@ -157,7 +157,7 @@ pub fn initialize_extra_account_metas(
     authority_pubkey: &Pubkey,
     additional_accounts: &[AccountMeta],
 ) -> Instruction {
-    let data = TransferHookInstruction::InitializeExtraAccountMetaState.pack();
+    let data = TransferHookInstruction::InitializeExtraAccountMetaList.pack();
 
     let mut accounts = vec![
         AccountMeta::new(*extra_account_metas_pubkey, false),
@@ -197,7 +197,7 @@ mod test {
 
     #[test]
     fn initialize_validation_pubkeys_packing() {
-        let check = TransferHookInstruction::InitializeExtraAccountMetaState;
+        let check = TransferHookInstruction::InitializeExtraAccountMetaList;
         let packed = check.pack();
         // Please use INITIALIZE_EXTRA_ACCOUNT_METAS_DISCRIMINATOR in your program,
         // the following is just for test purposes

--- a/token/transfer-hook-interface/src/offchain.rs
+++ b/token/transfer-hook-interface/src/offchain.rs
@@ -7,7 +7,7 @@ use {
         program_error::ProgramError,
         pubkey::Pubkey,
     },
-    spl_tlv_account_resolution::state::ExtraAccountMetaState,
+    spl_tlv_account_resolution::state::ExtraAccountMetaList,
     std::future::Future,
 };
 
@@ -55,7 +55,7 @@ where
     let validation_account_data = get_account_data_fn(validation_address)
         .await?
         .ok_or(ProgramError::InvalidAccountData)?;
-    ExtraAccountMetaState::add_to_instruction::<ExecuteInstruction>(
+    ExtraAccountMetaList::add_to_instruction::<ExecuteInstruction>(
         instruction,
         &validation_account_data,
     )?;

--- a/token/transfer-hook-interface/src/offchain.rs
+++ b/token/transfer-hook-interface/src/offchain.rs
@@ -7,7 +7,7 @@ use {
         program_error::ProgramError,
         pubkey::Pubkey,
     },
-    spl_tlv_account_resolution::state::ExtraAccountMetas,
+    spl_tlv_account_resolution::state::ExtraAccountMetaState,
     std::future::Future,
 };
 
@@ -55,7 +55,7 @@ where
     let validation_account_data = get_account_data_fn(validation_address)
         .await?
         .ok_or(ProgramError::InvalidAccountData)?;
-    ExtraAccountMetas::add_to_instruction::<ExecuteInstruction>(
+    ExtraAccountMetaState::add_to_instruction::<ExecuteInstruction>(
         instruction,
         &validation_account_data,
     )?;

--- a/token/transfer-hook-interface/src/onchain.rs
+++ b/token/transfer-hook-interface/src/onchain.rs
@@ -9,7 +9,7 @@ use {
         program::invoke,
         pubkey::Pubkey,
     },
-    spl_tlv_account_resolution::state::ExtraAccountMetas,
+    spl_tlv_account_resolution::state::ExtraAccountMetaState,
 };
 /// Helper to CPI into a transfer-hook program on-chain, looking through the
 /// additional account infos to create the proper instruction
@@ -44,7 +44,7 @@ pub fn invoke_execute<'a>(
         authority_info,
         validation_info.clone(),
     ];
-    ExtraAccountMetas::add_to_cpi_instruction::<instruction::ExecuteInstruction>(
+    ExtraAccountMetaState::add_to_cpi_instruction::<instruction::ExecuteInstruction>(
         &mut cpi_instruction,
         &mut cpi_account_infos,
         &validation_info.try_borrow_data()?,
@@ -73,7 +73,7 @@ pub fn add_cpi_accounts_for_execute<'a>(
         .find(|&x| x.key == program_id)
         .ok_or(TransferHookError::IncorrectAccount)?;
 
-    ExtraAccountMetas::add_to_cpi_instruction::<instruction::ExecuteInstruction>(
+    ExtraAccountMetaState::add_to_cpi_instruction::<instruction::ExecuteInstruction>(
         cpi_instruction,
         cpi_account_infos,
         &validation_info.try_borrow_data()?,

--- a/token/transfer-hook-interface/src/onchain.rs
+++ b/token/transfer-hook-interface/src/onchain.rs
@@ -9,7 +9,7 @@ use {
         program::invoke,
         pubkey::Pubkey,
     },
-    spl_tlv_account_resolution::state::ExtraAccountMetaState,
+    spl_tlv_account_resolution::state::ExtraAccountMetaList,
 };
 /// Helper to CPI into a transfer-hook program on-chain, looking through the
 /// additional account infos to create the proper instruction
@@ -44,7 +44,7 @@ pub fn invoke_execute<'a>(
         authority_info,
         validation_info.clone(),
     ];
-    ExtraAccountMetaState::add_to_cpi_instruction::<instruction::ExecuteInstruction>(
+    ExtraAccountMetaList::add_to_cpi_instruction::<instruction::ExecuteInstruction>(
         &mut cpi_instruction,
         &mut cpi_account_infos,
         &validation_info.try_borrow_data()?,
@@ -73,7 +73,7 @@ pub fn add_cpi_accounts_for_execute<'a>(
         .find(|&x| x.key == program_id)
         .ok_or(TransferHookError::IncorrectAccount)?;
 
-    ExtraAccountMetaState::add_to_cpi_instruction::<instruction::ExecuteInstruction>(
+    ExtraAccountMetaList::add_to_cpi_instruction::<instruction::ExecuteInstruction>(
         cpi_instruction,
         cpi_account_infos,
         &validation_info.try_borrow_data()?,


### PR DESCRIPTION
This PR renames a few things!
- `PodAccountMeta` to `ExtraAccountMeta`
- `ExtraAccountMetas` to `ExtraAccountMetaState`
- `pod.rs` to `account.rs`