### PR TITLE
single-pool: remove stray TODO, add explicit owner check in deposit

### DIFF
--- a/stake-pool/single-pool/src/instruction.rs
+++ b/stake-pool/single-pool/src/instruction.rs
@@ -328,7 +328,6 @@ pub fn withdraw_stake(
 /// Creates necessary instructions to create and delegate a new stake account to a given validator.
 /// Uses a fixed address for each wallet and vote account combination to make it easier to find for deposits.
 /// This is an optional helper function; deposits can come from any owned stake account without lockup.
-// TODO FIXME ugh this is wrong... i need to pass in vote account
 pub fn create_and_delegate_user_stake(
     vote_account_address: &Pubkey,
     pool_address: &Pubkey,

--- a/stake-pool/single-pool/src/processor.rs
+++ b/stake-pool/single-pool/src/processor.rs
@@ -754,9 +754,11 @@ impl Processor {
         msg!("Available stake pre merge {}", pre_pool_stake);
 
         // user can deposit active stake into an active pool or inactive stake into an activating pool
-        let (_, user_stake_state) = get_stake_state(user_stake_info)?;
-        if is_stake_active_without_history(&pool_stake_state, clock.epoch)
-            != is_stake_active_without_history(&user_stake_state, clock.epoch)
+        let (user_stake_meta, user_stake_state) = get_stake_state(user_stake_info)?;
+        if user_stake_meta.authorized
+            != stake::state::Authorized::auto(pool_stake_authority_info.key)
+            || is_stake_active_without_history(&pool_stake_state, clock.epoch)
+                != is_stake_active_without_history(&user_stake_state, clock.epoch)
         {
             return Err(SinglePoolError::WrongStakeState.into());
         }

--- a/stake-pool/single-pool/tests/deposit.rs
+++ b/stake-pool/single-pool/tests/deposit.rs
@@ -7,13 +7,9 @@ use {
     helpers::*,
     solana_program_test::*,
     solana_sdk::{
-        instruction::InstructionError,
         signature::Signer,
         signer::keypair::Keypair,
-        stake::{
-            instruction::StakeError,
-            state::{Authorized, Lockup},
-        },
+        stake::state::{Authorized, Lockup},
         transaction::Transaction,
     },
     spl_associated_token_account as atoken,
@@ -377,7 +373,7 @@ async fn fail_bad_account(activate: bool, automorph: bool) {
     if automorph {
         check_error(e, SinglePoolError::InvalidPoolStakeAccountUsage);
     } else {
-        check_error::<InstructionError>(e, StakeError::MergeMismatch.into());
+        check_error(e, SinglePoolError::WrongStakeState);
     }
 }
 


### PR DESCRIPTION
the TODO was a note to myself to add the first parameter to that function (which I did) but the comment survived a merge. the owner check was already done by the stake program but since both audits commented on it i made it explicit in the svsp program