### PR TITLE
Tighten Up Account Resolution Methods

### DIFF
--- a/libraries/tlv-account-resolution/src/seeds.rs
+++ b/libraries/tlv-account-resolution/src/seeds.rs
@@ -143,11 +143,11 @@ impl Seed {
 
     /// Unpacks all seed configurations from a 32-byte array.
     /// Stops when it hits uninitialized data (0s).
-    pub fn unpack_address_config(bytes: &[u8; 32]) -> Result<Vec<Self>, ProgramError> {
+    pub fn unpack_address_config(address_config: &[u8; 32]) -> Result<Vec<Self>, ProgramError> {
         let mut seeds = vec![];
         let mut i = 0;
         while i < 32 {
-            let seed = Self::unpack(&bytes[i..])?;
+            let seed = Self::unpack(&address_config[i..])?;
             let seed_size = seed.tlv_size() as usize;
             i += seed_size;
             if seed == Self::Uninitialized {


### PR DESCRIPTION
This PR swaps methods from `ExtraAccountMetaList` to `ExtraAccountMeta` and tightens up implementation.

This sets the stage for:
- Removal of `AccountInfo` helpers
- Updated integration with `spl-transfer-hook-example`

Summary:
- Moved `de_escalate_account_meta` and `resolve_pda` into `account.rs` as private helpers
- Added `resolve` to `ExtraAccountMeta`
- Trimmed implementation of `add_to_instruction` for `ExtraAccountMetaList`

Note: As it relates to #4963:
- An `is_pda()` or enum is no longer required
- An `AccountKeyable` trait is no longer required