### PR TITLE
Feature Gate Program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6536,7 +6536,7 @@ dependencies = [
 
 [[package]]
 name = "spl-feature-gate-cli"
-version = "1.2.0"
+version = "1.0.0"
 dependencies = [
  "clap 2.34.0",
  "solana-clap-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6527,7 +6527,6 @@ dependencies = [
 name = "spl-feature-gate"
 version = "0.1.0"
 dependencies = [
- "borsh 0.10.3",
  "solana-program",
  "solana-program-test",
  "solana-sdk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6524,6 +6524,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-feature-gate"
+version = "0.0.1"
+dependencies = [
+ "borsh 0.10.3",
+ "solana-program",
+ "solana-program-test",
+ "solana-sdk",
+ "spl-program-error",
+]
+
+[[package]]
+name = "spl-feature-gate-cli"
+version = "1.2.0"
+dependencies = [
+ "clap 2.34.0",
+ "solana-clap-utils",
+ "solana-cli-config",
+ "solana-client",
+ "solana-logger",
+ "solana-sdk",
+ "spl-feature-gate",
+]
+
+[[package]]
 name = "spl-feature-proposal"
 version = "1.0.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6525,7 +6525,7 @@ dependencies = [
 
 [[package]]
 name = "spl-feature-gate"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "borsh 0.10.3",
  "solana-program",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ members = [
   "examples/rust/sysvar",
   "examples/rust/transfer-lamports",
   "examples/rust/transfer-tokens",
+  "feature-gate/cli",
+  "feature-gate/program",
   "feature-proposal/program",
   "feature-proposal/cli",
   "governance/addin-mock/program",

--- a/feature-gate/README.md
+++ b/feature-gate/README.md
@@ -1,0 +1,10 @@
+# Feature Gate Program
+
+This program serves to manage new features on Solana.
+
+It serves two main purposes: activating new features and revoking features that
+are pending activation.
+
+More information & documentation will follow as this program matures, but you
+can follow the discussions
+[here](https://github.com/solana-labs/solana/issues/32780)!

--- a/feature-gate/cli/Cargo.toml
+++ b/feature-gate/cli/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "spl-feature-gate-cli"
+version = "1.2.0"
+description = "SPL Feature Gate Command-line Utility"
+authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
+repository = "https://github.com/solana-labs/solana-program-library"
+license = "Apache-2.0"
+edition = "2021"
+
+[dependencies]
+clap = "2.33.3"
+solana-clap-utils = "1.16.3"
+solana-cli-config = "1.16.3"
+solana-client = "1.16.3"
+solana-logger = "1.16.3"
+solana-sdk = "1.16.3"
+spl-feature-gate = { version = "0.0.1", path = "../program", features = ["no-entrypoint"] }
+
+[[bin]]
+name = "spl-feature-gate"
+path = "src/main.rs"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/feature-gate/cli/Cargo.toml
+++ b/feature-gate/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-feature-gate-cli"
-version = "1.2.0"
+version = "1.0.0"
 description = "SPL Feature Gate Command-line Utility"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -9,11 +9,11 @@ edition = "2021"
 
 [dependencies]
 clap = "2.33.3"
-solana-clap-utils = "1.16.3"
-solana-cli-config = "1.16.3"
-solana-client = "1.16.3"
-solana-logger = "1.16.3"
-solana-sdk = "1.16.3"
+solana-clap-utils = "=1.16.3"
+solana-cli-config = "=1.16.3"
+solana-client = "=1.16.3"
+solana-logger = "=1.16.3"
+solana-sdk = "=1.16.3"
 spl-feature-gate = { version = "0.0.1", path = "../program", features = ["no-entrypoint"] }
 
 [[bin]]

--- a/feature-gate/cli/Cargo.toml
+++ b/feature-gate/cli/Cargo.toml
@@ -14,7 +14,7 @@ solana-cli-config = "=1.16.3"
 solana-client = "=1.16.3"
 solana-logger = "=1.16.3"
 solana-sdk = "=1.16.3"
-spl-feature-gate = { version = "0.0.1", path = "../program", features = ["no-entrypoint"] }
+spl-feature-gate = { version = "0.1.0", path = "../program", features = ["no-entrypoint"] }
 
 [[bin]]
 name = "spl-feature-gate"

--- a/feature-gate/cli/src/main.rs
+++ b/feature-gate/cli/src/main.rs
@@ -1,0 +1,268 @@
+#![allow(clippy::integer_arithmetic)]
+
+use {
+    clap::{crate_description, crate_name, crate_version, App, AppSettings, Arg, SubCommand},
+    solana_clap_utils::{
+        input_parsers::{keypair_of, pubkey_of},
+        input_validators::{is_keypair, is_url, is_valid_pubkey},
+    },
+    solana_client::rpc_client::RpcClient,
+    solana_sdk::{
+        commitment_config::CommitmentConfig,
+        feature::Feature,
+        pubkey::Pubkey,
+        rent::Rent,
+        signature::{read_keypair_file, Keypair, Signer},
+        system_instruction,
+        transaction::Transaction,
+    },
+    spl_feature_gate::instruction::{activate, revoke},
+};
+
+fn keypair_clone(kp: &Keypair) -> Keypair {
+    Keypair::from_bytes(&kp.to_bytes()).expect("failed to copy keypair")
+}
+
+#[allow(dead_code)]
+struct Config {
+    keypair: Keypair,
+    json_rpc_url: String,
+    verbose: bool,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let app_matches = App::new(crate_name!())
+        .about(crate_description!())
+        .version(crate_version!())
+        .setting(AppSettings::SubcommandRequiredElseHelp)
+        .arg({
+            let arg = Arg::with_name("config_file")
+                .short("C")
+                .long("config")
+                .value_name("PATH")
+                .takes_value(true)
+                .global(true)
+                .help("Configuration file to use");
+            if let Some(ref config_file) = *solana_cli_config::CONFIG_FILE {
+                arg.default_value(config_file)
+            } else {
+                arg
+            }
+        })
+        .arg(
+            Arg::with_name("keypair")
+                .long("keypair")
+                .value_name("KEYPAIR")
+                .validator(is_keypair)
+                .takes_value(true)
+                .global(true)
+                .help("Filepath or URL to a keypair [default: client keypair]"),
+        )
+        .arg(
+            Arg::with_name("verbose")
+                .long("verbose")
+                .short("v")
+                .takes_value(false)
+                .global(true)
+                .help("Show additional information"),
+        )
+        .arg(
+            Arg::with_name("json_rpc_url")
+                .long("url")
+                .value_name("URL")
+                .takes_value(true)
+                .global(true)
+                .validator(is_url)
+                .help("JSON RPC URL for the cluster [default: value from configuration file]"),
+        )
+        .subcommand(
+            SubCommand::with_name("activate")
+                .about("Activate a feature")
+                .arg(
+                    Arg::with_name("feature_keypair")
+                        .value_name("FEATURE_KEYPAIR")
+                        .validator(is_keypair)
+                        .index(1)
+                        .required(true)
+                        .help("Path to keypair of the feature"),
+                )
+                .arg(
+                    Arg::with_name("authority_keypair")
+                        .value_name("AUTHORITY_KEYPAIR")
+                        .validator(is_keypair)
+                        .required(true)
+                        .help("Path to keypair of the authority"),
+                )
+                .arg(
+                    Arg::with_name("payer_keypair")
+                        .value_name("PAYER_KEYPAIR")
+                        .validator(is_keypair)
+                        .help(
+                            "Path to keypair of the payer to fund the feature account (defaults \
+                             to authority)",
+                        ),
+                ),
+        )
+        .subcommand(
+            SubCommand::with_name("revoke")
+                .about("Revoke a pending feature activation")
+                .arg(
+                    Arg::with_name("feature_id")
+                        .value_name("FEATURE_ID")
+                        .validator(is_valid_pubkey)
+                        .index(1)
+                        .required(true)
+                        .help("The address of the feature (feature ID)"),
+                )
+                .arg(
+                    Arg::with_name("destination")
+                        .value_name("DESTINATION")
+                        .validator(is_valid_pubkey)
+                        .index(2)
+                        .required(true)
+                        .help("The address of the destination for the refunded lamports"),
+                )
+                .arg(
+                    Arg::with_name("authority_keypair")
+                        .value_name("AUTHORITY_KEYPAIR")
+                        .validator(is_keypair)
+                        .required(true)
+                        .help("Path to keypair of the authority"),
+                ),
+        )
+        .get_matches();
+
+    let (sub_command, sub_matches) = app_matches.subcommand();
+    let matches = sub_matches.unwrap();
+
+    let config = {
+        let cli_config = if let Some(config_file) = matches.value_of("config_file") {
+            solana_cli_config::Config::load(config_file).unwrap_or_default()
+        } else {
+            solana_cli_config::Config::default()
+        };
+
+        Config {
+            json_rpc_url: matches
+                .value_of("json_rpc_url")
+                .unwrap_or(&cli_config.json_rpc_url)
+                .to_string(),
+            keypair: read_keypair_file(
+                matches
+                    .value_of("keypair")
+                    .unwrap_or(&cli_config.keypair_path),
+            )?,
+            verbose: matches.is_present("verbose"),
+        }
+    };
+    solana_logger::setup_with_default("solana=info");
+    let rpc_client =
+        RpcClient::new_with_commitment(config.json_rpc_url.clone(), CommitmentConfig::confirmed());
+
+    match (sub_command, sub_matches) {
+        ("activate", Some(arg_matches)) => {
+            let feature_keypair = keypair_of(arg_matches, "feature_keypair").unwrap();
+            let authority_keypair = keypair_of(arg_matches, "authority_keypair").unwrap();
+            let payer_keypair = keypair_of(arg_matches, "payer_keypair")
+                .unwrap_or(keypair_clone(&authority_keypair));
+
+            process_activate(
+                &rpc_client,
+                &config,
+                &feature_keypair,
+                &payer_keypair,
+                &authority_keypair,
+            )
+        }
+        ("revoke", Some(arg_matches)) => {
+            let feature_id = pubkey_of(arg_matches, "feature_id").unwrap();
+            let destination = pubkey_of(arg_matches, "destination").unwrap();
+            let authority_keypair = keypair_of(arg_matches, "authority_keypair").unwrap();
+
+            process_revoke(
+                &rpc_client,
+                &config,
+                &feature_id,
+                &destination,
+                &authority_keypair,
+            )
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn process_activate(
+    rpc_client: &RpcClient,
+    config: &Config,
+    feature_keypair: &Keypair,
+    payer_keypair: &Keypair,
+    authority_keypair: &Keypair,
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!();
+    println!("Activating feature...");
+    println!("Feature ID: {}", feature_keypair.pubkey());
+    println!("Payer: {}", payer_keypair.pubkey());
+    println!("Authority: {}", authority_keypair.pubkey());
+    println!();
+    println!("JSON RPC URL: {}", config.json_rpc_url);
+    println!();
+
+    let rent_lamports = Rent::default().minimum_balance(Feature::size_of());
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::transfer(
+                &payer_keypair.pubkey(),
+                &feature_keypair.pubkey(),
+                rent_lamports,
+            ),
+            activate(
+                &spl_feature_gate::id(),
+                &feature_keypair.pubkey(),
+                &authority_keypair.pubkey(),
+            ),
+        ],
+        Some(&payer_keypair.pubkey()),
+        &[payer_keypair, feature_keypair, authority_keypair],
+        rpc_client.get_latest_blockhash()?,
+    );
+    rpc_client.send_and_confirm_transaction_with_spinner(&transaction)?;
+
+    println!();
+    println!("Feature is marked for activation!");
+    Ok(())
+}
+
+fn process_revoke(
+    rpc_client: &RpcClient,
+    config: &Config,
+    feature_id: &Pubkey,
+    destination: &Pubkey,
+    authority_keypair: &Keypair,
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!();
+    println!("Revoking feature...");
+    println!("Feature ID: {}", feature_id);
+    println!("Destination: {}", destination);
+    println!("Authority: {}", authority_keypair.pubkey());
+    println!();
+    println!("JSON RPC URL: {}", config.json_rpc_url);
+    println!();
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[revoke(
+            &spl_feature_gate::id(),
+            feature_id,
+            destination,
+            &authority_keypair.pubkey(),
+        )],
+        Some(&authority_keypair.pubkey()),
+        &[authority_keypair],
+        rpc_client.get_latest_blockhash()?,
+    );
+    rpc_client.send_and_confirm_transaction_with_spinner(&transaction)?;
+
+    println!();
+    println!("Feature successfully revoked!");
+    Ok(())
+}

--- a/feature-gate/program/Cargo.toml
+++ b/feature-gate/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-feature-gate"
-version = "0.0.1"
+version = "0.1.0"
 description = "Solana Program Library Feature Gate Program"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/feature-gate/program/Cargo.toml
+++ b/feature-gate/program/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "spl-feature-gate"
+version = "0.0.1"
+description = "Solana Program Library Feature Gate Program"
+authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
+repository = "https://github.com/solana-labs/solana-program-library"
+license = "Apache-2.0"
+edition = "2021"
+
+[features]
+no-entrypoint = []
+test-sbf = []
+
+[dependencies]
+borsh = "0.10.3"
+solana-program = "1.16.3"
+spl-program-error = { version = "0.2.0", path = "../../libraries/program-error" }
+
+[dev-dependencies]
+solana-program-test = "1.16.3"
+solana-sdk = "1.16.3"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/feature-gate/program/Cargo.toml
+++ b/feature-gate/program/Cargo.toml
@@ -12,7 +12,6 @@ no-entrypoint = []
 test-sbf = []
 
 [dependencies]
-borsh = "0.10.3"
 solana-program = "1.16.3"
 spl-program-error = { version = "0.2.0", path = "../../libraries/program-error" }
 

--- a/feature-gate/program/src/entrypoint.rs
+++ b/feature-gate/program/src/entrypoint.rs
@@ -1,0 +1,17 @@
+//! Program entrypoint
+
+use {
+    crate::processor,
+    solana_program::{
+        account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
+    },
+};
+
+entrypoint!(process_instruction);
+fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    input: &[u8],
+) -> ProgramResult {
+    processor::process(program_id, accounts, input)
+}

--- a/feature-gate/program/src/error.rs
+++ b/feature-gate/program/src/error.rs
@@ -11,4 +11,7 @@ pub enum FeatureGateError {
     /// Feature account must be a system account
     #[error("Feature account must be a system account")]
     FeatureNotSystemAccount,
+    /// Feature not inactive
+    #[error("Feature not inactive")]
+    FeatureNotInactive,
 }

--- a/feature-gate/program/src/error.rs
+++ b/feature-gate/program/src/error.rs
@@ -1,0 +1,14 @@
+//! Program error types
+
+use spl_program_error::*;
+
+/// Program specific errors
+#[spl_program_error]
+pub enum FeatureGateError {
+    /// Operation overflowed
+    #[error("Operation overflowed")]
+    Overflow,
+    /// Feature account must be a system account
+    #[error("Feature account must be a system account")]
+    FeatureNotSystemAccount,
+}

--- a/feature-gate/program/src/instruction.rs
+++ b/feature-gate/program/src/instruction.rs
@@ -1,0 +1,87 @@
+//! Program instructions
+
+use {
+    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
+    solana_program::{
+        instruction::{AccountMeta, Instruction},
+        pubkey::Pubkey,
+        system_program,
+    },
+};
+
+/// Feature Gate program instructions
+#[derive(Clone, Debug, BorshSerialize, BorshDeserialize, BorshSchema, PartialEq)]
+pub enum FeatureGateInstruction {
+    /// Submit a feature for activation.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[ws]` Feature account (must be a system account)
+    ///   1. `[s]` Authority
+    ///   3. `[]` System program
+    Activate,
+    /// Revoke a pending feature activation.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[w]` Feature account
+    ///   1. `[w]` Destination (for rent lamports)
+    ///   2. `[s]` Authority
+    Revoke,
+}
+
+/// Creates an 'Activate' instruction.
+pub fn activate(program_id: &Pubkey, feature: &Pubkey, authority: &Pubkey) -> Instruction {
+    let accounts = vec![
+        AccountMeta::new(*feature, true),
+        AccountMeta::new_readonly(*authority, true),
+        AccountMeta::new_readonly(system_program::id(), false),
+    ];
+
+    Instruction {
+        program_id: *program_id,
+        accounts,
+        data: FeatureGateInstruction::Activate.try_to_vec().unwrap(),
+    }
+}
+
+/// Creates a 'Revoke' instruction.
+pub fn revoke(
+    program_id: &Pubkey,
+    feature: &Pubkey,
+    destination: &Pubkey,
+    authority: &Pubkey,
+) -> Instruction {
+    let accounts = vec![
+        AccountMeta::new(*feature, false),
+        AccountMeta::new(*destination, false),
+        AccountMeta::new_readonly(*authority, false),
+    ];
+
+    Instruction {
+        program_id: *program_id,
+        accounts,
+        data: FeatureGateInstruction::Revoke.try_to_vec().unwrap(),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn test_pack_unpack(instruction: &FeatureGateInstruction) {
+        let packed = instruction.try_to_vec().unwrap();
+        let unpacked = FeatureGateInstruction::try_from_slice(&packed).unwrap();
+        assert_eq!(instruction, &unpacked);
+    }
+
+    #[test]
+    fn test_pack_unpack_activate() {
+        test_pack_unpack(&FeatureGateInstruction::Activate);
+    }
+
+    #[test]
+    fn test_pack_unpack_revoke() {
+        test_pack_unpack(&FeatureGateInstruction::Revoke);
+    }
+}

--- a/feature-gate/program/src/instruction.rs
+++ b/feature-gate/program/src/instruction.rs
@@ -14,11 +14,17 @@ use {
 pub enum FeatureGateInstruction {
     /// Submit a feature for activation.
     ///
+    /// Note: This instruction expects the account to exist and be owned by the
+    /// system program. The account should also have enough rent-exempt lamports
+    /// to cover the cost of the account creation for a
+    /// `solana_program::feature::Feature` state prior to invoking this
+    /// instruction.
+    ///
     /// Accounts expected by this instruction:
     ///
     ///   0. `[ws]` Feature account (must be a system account)
     ///   1. `[s]` Authority
-    ///   3. `[]` System program
+    ///   2. `[]` System program
     Activate,
     /// Revoke a pending feature activation.
     ///
@@ -27,7 +33,7 @@ pub enum FeatureGateInstruction {
     ///   0. `[w]` Feature account
     ///   1. `[w]` Destination (for rent lamports)
     ///   2. `[s]` Authority
-    Revoke,
+    RevokePendingActivation,
 }
 
 /// Creates an 'Activate' instruction.
@@ -45,7 +51,7 @@ pub fn activate(program_id: &Pubkey, feature: &Pubkey, authority: &Pubkey) -> In
     }
 }
 
-/// Creates a 'Revoke' instruction.
+/// Creates a 'RevokePendingActivation' instruction.
 pub fn revoke(
     program_id: &Pubkey,
     feature: &Pubkey,
@@ -61,7 +67,9 @@ pub fn revoke(
     Instruction {
         program_id: *program_id,
         accounts,
-        data: FeatureGateInstruction::Revoke.try_to_vec().unwrap(),
+        data: FeatureGateInstruction::RevokePendingActivation
+            .try_to_vec()
+            .unwrap(),
     }
 }
 
@@ -82,6 +90,6 @@ mod test {
 
     #[test]
     fn test_pack_unpack_revoke() {
-        test_pack_unpack(&FeatureGateInstruction::Revoke);
+        test_pack_unpack(&FeatureGateInstruction::RevokePendingActivation);
     }
 }

--- a/feature-gate/program/src/lib.rs
+++ b/feature-gate/program/src/lib.rs
@@ -1,0 +1,16 @@
+//! Feature Gate program
+
+#![allow(clippy::integer_arithmetic)]
+#![deny(missing_docs)]
+#![cfg_attr(not(test), forbid(unsafe_code))]
+
+mod entrypoint;
+pub mod error;
+pub mod instruction;
+pub mod processor;
+
+// Export current SDK types for downstream users building with a different SDK
+// version
+pub use solana_program;
+
+solana_program::declare_id!("Feature111111111111111111111111111111111111");

--- a/feature-gate/program/src/lib.rs
+++ b/feature-gate/program/src/lib.rs
@@ -1,6 +1,5 @@
 //! Feature Gate program
 
-#![allow(clippy::integer_arithmetic)]
 #![deny(missing_docs)]
 #![cfg_attr(not(test), forbid(unsafe_code))]
 

--- a/feature-gate/program/src/processor.rs
+++ b/feature-gate/program/src/processor.rs
@@ -81,8 +81,8 @@ pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> P
             msg!("Instruction: Activate");
             process_activate(program_id, accounts)
         }
-        FeatureGateInstruction::Revoke => {
-            msg!("Instruction: Revoke");
+        FeatureGateInstruction::RevokePendingActivation => {
+            msg!("Instruction: RevokePendingActivation");
             process_revoke(program_id, accounts)
         }
     }

--- a/feature-gate/program/src/processor.rs
+++ b/feature-gate/program/src/processor.rs
@@ -2,7 +2,6 @@
 
 use {
     crate::{error::FeatureGateError, instruction::FeatureGateInstruction},
-    borsh::BorshDeserialize,
     solana_program::{
         account_info::{next_account_info, AccountInfo},
         entrypoint::ProgramResult,
@@ -82,7 +81,7 @@ pub fn process_revoke(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramR
 
 /// Processes an [Instruction](enum.Instruction.html).
 pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> ProgramResult {
-    let instruction = FeatureGateInstruction::try_from_slice(input)?;
+    let instruction = FeatureGateInstruction::unpack(input)?;
     match instruction {
         FeatureGateInstruction::Activate => {
             msg!("Instruction: Activate");

--- a/feature-gate/program/src/processor.rs
+++ b/feature-gate/program/src/processor.rs
@@ -19,10 +19,9 @@ pub fn process_activate(program_id: &Pubkey, accounts: &[AccountInfo]) -> Progra
     let account_info_iter = &mut accounts.iter();
 
     let feature_info = next_account_info(account_info_iter)?;
-    let authority_info = next_account_info(account_info_iter)?;
     let _system_program_info = next_account_info(account_info_iter)?;
 
-    if !feature_info.is_signer || !authority_info.is_signer {
+    if !feature_info.is_signer {
         return Err(ProgramError::MissingRequiredSignature);
     }
 
@@ -48,9 +47,8 @@ pub fn process_revoke(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramR
 
     let feature_info = next_account_info(account_info_iter)?;
     let destination_info = next_account_info(account_info_iter)?;
-    let authority_info = next_account_info(account_info_iter)?;
 
-    if !authority_info.is_signer {
+    if !feature_info.is_signer {
         return Err(ProgramError::MissingRequiredSignature);
     }
 

--- a/feature-gate/program/src/processor.rs
+++ b/feature-gate/program/src/processor.rs
@@ -59,6 +59,13 @@ pub fn process_revoke(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramR
         return Err(ProgramError::IllegalOwner);
     }
 
+    if Feature::from_account_info(feature_info)?
+        .activated_at
+        .is_some()
+    {
+        return Err(FeatureGateError::FeatureNotInactive.into());
+    }
+
     let new_destination_lamports = feature_info
         .lamports()
         .checked_add(destination_info.lamports())

--- a/feature-gate/program/src/processor.rs
+++ b/feature-gate/program/src/processor.rs
@@ -1,0 +1,89 @@
+//! Program state processor
+
+use {
+    crate::{error::FeatureGateError, instruction::FeatureGateInstruction},
+    borsh::BorshDeserialize,
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        feature::Feature,
+        msg,
+        program::invoke,
+        program_error::ProgramError,
+        pubkey::Pubkey,
+        system_instruction, system_program,
+    },
+};
+
+/// Processes an [Activate](enum.FeatureGateInstruction.html) instruction.
+pub fn process_activate(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    let feature_info = next_account_info(account_info_iter)?;
+    let authority_info = next_account_info(account_info_iter)?;
+    let _system_program_info = next_account_info(account_info_iter)?;
+
+    if !feature_info.is_signer || !authority_info.is_signer {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    if feature_info.owner != &system_program::id() {
+        return Err(FeatureGateError::FeatureNotSystemAccount.into());
+    }
+
+    invoke(
+        &system_instruction::allocate(feature_info.key, Feature::size_of() as u64),
+        &[feature_info.clone()],
+    )?;
+    invoke(
+        &system_instruction::assign(feature_info.key, program_id),
+        &[feature_info.clone()],
+    )?;
+
+    Ok(())
+}
+
+/// Processes an [revoke](enum.FeatureGateInstruction.html) instruction.
+pub fn process_revoke(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    let feature_info = next_account_info(account_info_iter)?;
+    let destination_info = next_account_info(account_info_iter)?;
+    let authority_info = next_account_info(account_info_iter)?;
+
+    if !authority_info.is_signer {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    if feature_info.owner != program_id {
+        return Err(ProgramError::IllegalOwner);
+    }
+
+    let new_destination_lamports = feature_info
+        .lamports()
+        .checked_add(destination_info.lamports())
+        .ok_or::<ProgramError>(FeatureGateError::Overflow.into())?;
+
+    **feature_info.try_borrow_mut_lamports()? = 0;
+    **destination_info.try_borrow_mut_lamports()? = new_destination_lamports;
+
+    feature_info.realloc(0, true)?;
+    feature_info.assign(&system_program::id());
+
+    Ok(())
+}
+
+/// Processes an [Instruction](enum.Instruction.html).
+pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> ProgramResult {
+    let instruction = FeatureGateInstruction::try_from_slice(input)?;
+    match instruction {
+        FeatureGateInstruction::Activate => {
+            msg!("Instruction: Activate");
+            process_activate(program_id, accounts)
+        }
+        FeatureGateInstruction::Revoke => {
+            msg!("Instruction: Revoke");
+            process_revoke(program_id, accounts)
+        }
+    }
+}

--- a/feature-gate/program/tests/functional.rs
+++ b/feature-gate/program/tests/functional.rs
@@ -1,0 +1,235 @@
+#![cfg(feature = "test-sbf")]
+
+use {
+    solana_program::instruction::InstructionError,
+    solana_program_test::{processor, tokio, ProgramTest},
+    solana_sdk::{
+        account::Account as SolanaAccount,
+        feature::Feature,
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        system_instruction,
+        transaction::{Transaction, TransactionError},
+    },
+    spl_feature_gate::{
+        error::FeatureGateError,
+        instruction::{activate, revoke},
+    },
+};
+
+#[tokio::test]
+async fn test_functional() {
+    let mock_feature_keypair = Keypair::new();
+    let feature_keypair = Keypair::new();
+    let authority_keypair = Keypair::new();
+    let destination = Pubkey::new_unique();
+
+    let mut program_test = ProgramTest::new(
+        "spl_feature_gate",
+        spl_feature_gate::id(),
+        processor!(spl_feature_gate::processor::process),
+    );
+
+    // Create the authority account with some lamports for transaction fees
+    program_test.add_account(
+        authority_keypair.pubkey(),
+        SolanaAccount {
+            lamports: 500_000_000,
+            ..SolanaAccount::default()
+        },
+    );
+
+    // Add a mock feature for testing later
+    program_test.add_account(
+        mock_feature_keypair.pubkey(),
+        SolanaAccount {
+            lamports: 500_000_000,
+            owner: spl_feature_gate::id(),
+            ..SolanaAccount::default()
+        },
+    );
+
+    let mut context = program_test.start_with_context().await;
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let rent_lamports = rent.minimum_balance(Feature::size_of());
+
+    // Activate: Fail feature not signer
+    let mut activate_ix = activate(
+        &spl_feature_gate::id(),
+        &feature_keypair.pubkey(),
+        &authority_keypair.pubkey(),
+    );
+    activate_ix.accounts[0].is_signer = false;
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::transfer(
+                &context.payer.pubkey(),
+                &feature_keypair.pubkey(),
+                rent_lamports,
+            ),
+            activate_ix,
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &authority_keypair],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(1, InstructionError::MissingRequiredSignature)
+    );
+
+    // Activate: Fail authority not signer
+    let mut activate_ix = activate(
+        &spl_feature_gate::id(),
+        &feature_keypair.pubkey(),
+        &authority_keypair.pubkey(),
+    );
+    activate_ix.accounts[1].is_signer = false;
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::transfer(
+                &context.payer.pubkey(),
+                &feature_keypair.pubkey(),
+                rent_lamports,
+            ),
+            activate_ix,
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &feature_keypair],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(1, InstructionError::MissingRequiredSignature)
+    );
+
+    // Activate: Fail feature not owned by system program
+    let transaction = Transaction::new_signed_with_payer(
+        &[activate(
+            &spl_feature_gate::id(),
+            &mock_feature_keypair.pubkey(),
+            &authority_keypair.pubkey(),
+        )],
+        Some(&authority_keypair.pubkey()),
+        &[&mock_feature_keypair, &authority_keypair],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(FeatureGateError::FeatureNotSystemAccount as u32),
+        )
+    );
+
+    // Submit a feature for activation
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::transfer(
+                &context.payer.pubkey(),
+                &feature_keypair.pubkey(),
+                rent_lamports,
+            ),
+            activate(
+                &spl_feature_gate::id(),
+                &feature_keypair.pubkey(),
+                &authority_keypair.pubkey(),
+            ),
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &feature_keypair, &authority_keypair],
+        context.last_blockhash,
+    );
+
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+
+    // Confirm feature account exists with proper configurations
+    let feature_account = context
+        .banks_client
+        .get_account(feature_keypair.pubkey())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(feature_account.owner, spl_feature_gate::id());
+
+    // Revoke: Fail authority not signer
+    let mut revoke_ix = revoke(
+        &spl_feature_gate::id(),
+        &feature_keypair.pubkey(),
+        &destination,
+        &authority_keypair.pubkey(),
+    );
+    revoke_ix.accounts[2].is_signer = false;
+    let transaction = Transaction::new_signed_with_payer(
+        &[revoke_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature)
+    );
+
+    // Revoke a feature activation
+    let transaction = Transaction::new_signed_with_payer(
+        &[revoke(
+            &spl_feature_gate::id(),
+            &feature_keypair.pubkey(),
+            &destination,
+            &authority_keypair.pubkey(),
+        )],
+        Some(&authority_keypair.pubkey()),
+        &[&authority_keypair],
+        context.last_blockhash,
+    );
+
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+
+    // Confirm feature account was closed and destination account received lamports
+    let feature_account = context
+        .banks_client
+        .get_account(feature_keypair.pubkey())
+        .await
+        .unwrap();
+    assert!(feature_account.is_none());
+    let destination_account = context
+        .banks_client
+        .get_account(destination)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(destination_account.lamports, rent_lamports);
+}


### PR DESCRIPTION
This PR adds a new program to SPL: The Feature Gate Program.

This is the exact program proposed in [this issue on the Solana monorepo](https://github.com/solana-labs/solana/issues/32780).

In summary, this program takes the place of the otherwise empty and currently utilized account address at `Feature111111111111111111111111111111111111 `. Once we've replaced that account with this program, it will be able to control (and most importantly **revoke**) pending feature activations, as described in [the linked issue](https://github.com/solana-labs/solana/issues/32780).