### PR TITLE
condense TLV AR state to one init

### DIFF
--- a/libraries/tlv-account-resolution/README.md
+++ b/libraries/tlv-account-resolution/README.md
@@ -23,10 +23,10 @@ impl SplDiscriminate for MyInstruction {
 
 // Actually put it in the additional required account keys and signer / writable
 let extra_metas = [
-    AccountMeta::new(Pubkey::new_unique(), false),
-    AccountMeta::new(Pubkey::new_unique(), true),
-    AccountMeta::new_readonly(Pubkey::new_unique(), true),
-    AccountMeta::new_readonly(Pubkey::new_unique(), false),
+    AccountMeta::new(Pubkey::new_unique(), false).into(),
+    AccountMeta::new(Pubkey::new_unique(), true).into(),
+    AccountMeta::new_readonly(Pubkey::new_unique(), true).into(),
+    AccountMeta::new_readonly(Pubkey::new_unique(), false).into(),
 ];
 
 // Assume that this buffer is actually account data, already allocated to `account_size`
@@ -34,7 +34,7 @@ let account_size = ExtraAccountMetaList::size_of(extra_metas.len()).unwrap();
 let mut buffer = vec![0; account_size];
 
 // Initialize the structure for your instruction
-ExtraAccountMetaList::init_with_account_metas::<MyInstruction>(&mut buffer, &extra_metas).unwrap();
+ExtraAccountMetaList::init::<MyInstruction>(&mut buffer, &extra_metas).unwrap();
 
 // Off-chain, you can add the additional accounts directly from the account data
 let program_id = Pubkey::new_unique();

--- a/libraries/tlv-account-resolution/src/account.rs
+++ b/libraries/tlv-account-resolution/src/account.rs
@@ -136,7 +136,6 @@ impl ExtraAccountMeta {
     }
 }
 
-// Conversions to `ExtraAccountMeta`
 impl From<&AccountMeta> for ExtraAccountMeta {
     fn from(meta: &AccountMeta) -> Self {
         Self {
@@ -145,6 +144,11 @@ impl From<&AccountMeta> for ExtraAccountMeta {
             is_signer: meta.is_signer.into(),
             is_writable: meta.is_writable.into(),
         }
+    }
+}
+impl From<AccountMeta> for ExtraAccountMeta {
+    fn from(meta: AccountMeta) -> Self {
+        ExtraAccountMeta::from(&meta)
     }
 }
 impl From<&AccountInfo<'_>> for ExtraAccountMeta {
@@ -157,8 +161,12 @@ impl From<&AccountInfo<'_>> for ExtraAccountMeta {
         }
     }
 }
+impl From<AccountInfo<'_>> for ExtraAccountMeta {
+    fn from(account_info: AccountInfo) -> Self {
+        ExtraAccountMeta::from(&account_info)
+    }
+}
 
-// Conversions from `ExtraAccountMeta`
 impl TryFrom<&ExtraAccountMeta> for AccountMeta {
     type Error = ProgramError;
 

--- a/libraries/tlv-account-resolution/src/error.rs
+++ b/libraries/tlv-account-resolution/src/error.rs
@@ -26,7 +26,8 @@ pub enum AccountResolutionError {
     /// Attempted to deserialize an `AccountMeta` but the underlying type has
     /// PDA configs rather than a fixed address
     #[error(
-        "Attempted to deserialize an `AccountMeta` but the underlying type has PDA configs rather than a fixed address"
+        "Attempted to deserialize an `AccountMeta` but the underlying type has PDA configs rather \
+         than a fixed address"
     )]
     AccountTypeNotAccountMeta,
     /// Provided list of seed configurations too large for a validation account

--- a/libraries/tlv-account-resolution/src/state.rs
+++ b/libraries/tlv-account-resolution/src/state.rs
@@ -191,7 +191,7 @@ mod tests {
                 .iter()
                 .map(ExtraAccountMeta::from)
                 .collect::<Vec<_>>(),
-            metas.to_vec()
+            metas
         );
     }
 
@@ -257,12 +257,12 @@ mod tests {
                 .iter()
                 .map(ExtraAccountMeta::from)
                 .collect::<Vec<_>>(),
-            account_infos.to_vec()
+            account_infos
         );
     }
 
     #[test]
-    fn init_with_pod_account_metas() {
+    fn init_with_extra_account_metas() {
         let program_id = Pubkey::new_unique();
 
         let extra_meta3_literal_str = "seed_prefix";
@@ -603,7 +603,7 @@ mod tests {
                 .iter()
                 .map(ExtraAccountMeta::from)
                 .collect::<Vec<_>>(),
-            account_infos.to_vec()
+            account_infos
         );
 
         let program_id = Pubkey::new_unique();

--- a/token/program-2022-test/tests/transfer_hook.rs
+++ b/token/program-2022-test/tests/transfer_hook.rs
@@ -176,23 +176,25 @@ fn setup_program_test(program_id: &Pubkey) -> ProgramTest {
 
 fn add_validation_account(program_test: &mut ProgramTest, mint: &Pubkey, program_id: &Pubkey) {
     let validation_address = get_extra_account_metas_address(mint, program_id);
-    let account_metas = vec![
+    let extra_account_metas = vec![
         AccountMeta {
             pubkey: Pubkey::new_unique(),
             is_signer: false,
             is_writable: false,
-        },
+        }
+        .into(),
         AccountMeta {
             pubkey: Pubkey::new_unique(),
             is_signer: false,
             is_writable: false,
-        },
+        }
+        .into(),
     ];
     program_test.add_account(
         validation_address,
         Account {
             lamports: 1_000_000_000, // a lot, just to be safe
-            data: spl_transfer_hook_example::state::example_data(&account_metas).unwrap(),
+            data: spl_transfer_hook_example::state::example_data(&extra_account_metas).unwrap(),
             owner: *program_id,
             ..Account::default()
         },
@@ -565,23 +567,25 @@ async fn success_downgrade_writable_and_signer_accounts() {
     let alice = Keypair::new();
     let alice_account = Keypair::new();
     let validation_address = get_extra_account_metas_address(&mint.pubkey(), &program_id);
-    let account_metas = vec![
+    let extra_account_metas = vec![
         AccountMeta {
             pubkey: alice_account.pubkey(),
             is_signer: false,
             is_writable: true,
-        },
+        }
+        .into(),
         AccountMeta {
             pubkey: alice.pubkey(),
             is_signer: true,
             is_writable: false,
-        },
+        }
+        .into(),
     ];
     program_test.add_account(
         validation_address,
         Account {
             lamports: 1_000_000_000, // a lot, just to be safe
-            data: spl_transfer_hook_example::state::example_data(&account_metas).unwrap(),
+            data: spl_transfer_hook_example::state::example_data(&extra_account_metas).unwrap(),
             owner: program_id,
             ..Account::default()
         },

--- a/token/transfer-hook-example/src/processor.rs
+++ b/token/transfer-hook-example/src/processor.rs
@@ -11,7 +11,7 @@ use {
         pubkey::Pubkey,
         system_instruction,
     },
-    spl_tlv_account_resolution::state::ExtraAccountMetaList,
+    spl_tlv_account_resolution::{account::ExtraAccountMeta, state::ExtraAccountMetaList},
     spl_token_2022::{
         extension::{
             transfer_hook::TransferHookAccount, BaseStateWithExtensions, StateWithExtensions,
@@ -143,9 +143,12 @@ pub fn process_initialize_extra_account_metas(
 
     // Write the data
     let mut data = extra_account_metas_info.try_borrow_mut_data()?;
-    ExtraAccountMetaList::init_with_account_infos::<ExecuteInstruction>(
+    ExtraAccountMetaList::init::<ExecuteInstruction>(
         &mut data,
-        extra_account_infos,
+        &extra_account_infos
+            .iter()
+            .map(ExtraAccountMeta::from)
+            .collect::<Vec<_>>(),
     )?;
 
     Ok(())

--- a/token/transfer-hook-example/src/state.rs
+++ b/token/transfer-hook-example/src/state.rs
@@ -1,15 +1,15 @@
 //! State helpers for working with the example program
 
 use {
-    solana_program::{instruction::AccountMeta, program_error::ProgramError},
-    spl_tlv_account_resolution::state::ExtraAccountMetaList,
+    solana_program::program_error::ProgramError,
+    spl_tlv_account_resolution::{account::ExtraAccountMeta, state::ExtraAccountMetaList},
     spl_transfer_hook_interface::instruction::ExecuteInstruction,
 };
 
 /// Generate example data to be used directly in an account for testing
-pub fn example_data(account_metas: &[AccountMeta]) -> Result<Vec<u8>, ProgramError> {
+pub fn example_data(account_metas: &[ExtraAccountMeta]) -> Result<Vec<u8>, ProgramError> {
     let account_size = ExtraAccountMetaList::size_of(account_metas.len())?;
     let mut data = vec![0; account_size];
-    ExtraAccountMetaList::init_with_account_metas::<ExecuteInstruction>(&mut data, account_metas)?;
+    ExtraAccountMetaList::init::<ExecuteInstruction>(&mut data, account_metas)?;
     Ok(data)
 }


### PR DESCRIPTION
This PR sets the stage for modifying the Transfer Hook Interface `InitializeExtraAccountMetas` instruction.

Here I'm condensing the act of initializing `ExtraAccountMetaList` state into one `init` function, rather than 3