### PR TITLE
[token-2022] Update confidential transfer instruction to support split proof contexts

### DIFF
--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -113,6 +113,7 @@ impl ConfidentialTokenAccountMeta {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     #[cfg(feature = "zk-ops")]
     async fn new_with_tokens<T>(
         token: &Token<T>,
@@ -2439,7 +2440,7 @@ async fn confidential_transfer_transfer_with_split_proof_context() {
     let extension = state
         .get_extension::<ConfidentialTransferAccount>()
         .unwrap();
-    let transfer_account_info = TransferAccountInfo::new(&extension);
+    let transfer_account_info = TransferAccountInfo::new(extension);
 
     let (
         equality_proof_data,

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -18,7 +18,8 @@ use {
         error::TokenError,
         extension::{
             confidential_transfer::{
-                self, ConfidentialTransferAccount, MAXIMUM_DEPOSIT_TRANSFER_AMOUNT,
+                self, instruction::TransferContextStateAccounts, ConfidentialTransferAccount,
+                MAXIMUM_DEPOSIT_TRANSFER_AMOUNT,
             },
             BaseStateWithExtensions, ExtensionType,
         },
@@ -972,6 +973,7 @@ async fn confidential_transfer_transfer() {
             alice_meta.elgamal_keypair.pubkey(),
             Some(auditor_elgamal_keypair.pubkey()),
             &[&alice],
+            None,
         )
         .await
         .unwrap();
@@ -1002,6 +1004,7 @@ async fn confidential_transfer_transfer() {
             alice_meta.elgamal_keypair.pubkey(),
             Some(auditor_elgamal_keypair.pubkey()),
             &[&alice],
+            None,
         )
         .await
         .unwrap();
@@ -1055,6 +1058,7 @@ async fn confidential_transfer_transfer() {
             bob_meta.elgamal_keypair.pubkey(),
             Some(auditor_elgamal_keypair.pubkey()),
             &[&alice],
+            None,
         )
         .await
         .unwrap();
@@ -1096,6 +1100,7 @@ async fn confidential_transfer_transfer() {
             bob_meta.elgamal_keypair.pubkey(),
             Some(auditor_elgamal_keypair.pubkey()),
             &[&bob],
+            None,
         )
         .await
         .unwrap();
@@ -1113,6 +1118,7 @@ async fn confidential_transfer_transfer() {
             bob_meta.elgamal_keypair.pubkey(),
             Some(auditor_elgamal_keypair.pubkey()),
             &[&bob],
+            None,
         )
         .await
         .unwrap_err();
@@ -1232,6 +1238,7 @@ async fn confidential_transfer_transfer_with_fee() {
             TEST_FEE_BASIS_POINTS,
             TEST_MAXIMUM_FEE,
             &[&alice],
+            None,
         )
         .await
         .unwrap();
@@ -1265,6 +1272,7 @@ async fn confidential_transfer_transfer_with_fee() {
             TEST_FEE_BASIS_POINTS,
             TEST_MAXIMUM_FEE,
             &[&alice],
+            None,
         )
         .await
         .unwrap();
@@ -1321,6 +1329,7 @@ async fn confidential_transfer_transfer_with_fee() {
             TEST_FEE_BASIS_POINTS,
             TEST_MAXIMUM_FEE,
             &[&alice],
+            None,
         )
         .await
         .unwrap();
@@ -1465,6 +1474,7 @@ async fn confidential_transfer_transfer_memo() {
             bob_meta.elgamal_keypair.pubkey(),
             Some(auditor_elgamal_keypair.pubkey()),
             &[&alice],
+            None,
         )
         .await
         .unwrap_err();
@@ -1494,6 +1504,7 @@ async fn confidential_transfer_transfer_memo() {
             bob_meta.elgamal_keypair.pubkey(),
             Some(auditor_elgamal_keypair.pubkey()),
             &[&alice],
+            None,
         )
         .await
         .unwrap();
@@ -1600,6 +1611,7 @@ async fn confidential_transfer_transfer_with_fee_and_memo() {
             TEST_FEE_BASIS_POINTS,
             TEST_MAXIMUM_FEE,
             &[&alice],
+            None,
         )
         .await
         .unwrap_err();
@@ -1631,6 +1643,7 @@ async fn confidential_transfer_transfer_with_fee_and_memo() {
             TEST_FEE_BASIS_POINTS,
             TEST_MAXIMUM_FEE,
             &[&alice],
+            None,
         )
         .await
         .unwrap();
@@ -2268,7 +2281,9 @@ async fn confidential_transfer_transfer_with_proof_context() {
             &alice_meta.token_account,
             &bob_meta.token_account,
             &alice.pubkey(),
-            Some(&context_state_account.pubkey()),
+            Some(TransferContextStateAccounts::SingleAccount(
+                &context_state_account.pubkey(),
+            )),
             42,
             None,
             &alice_meta.elgamal_keypair,
@@ -2276,6 +2291,7 @@ async fn confidential_transfer_transfer_with_proof_context() {
             bob_meta.elgamal_keypair.pubkey(),
             Some(auditor_elgamal_keypair.pubkey()),
             &[&alice],
+            None,
         )
         .await
         .unwrap();
@@ -2339,7 +2355,9 @@ async fn confidential_transfer_transfer_with_proof_context() {
             &alice_meta.token_account,
             &bob_meta.token_account,
             &alice.pubkey(),
-            Some(&context_state_account.pubkey()),
+            Some(TransferContextStateAccounts::SingleAccount(
+                &context_state_account.pubkey(),
+            )),
             0,
             None,
             &alice_meta.elgamal_keypair,
@@ -2347,6 +2365,7 @@ async fn confidential_transfer_transfer_with_proof_context() {
             bob_meta.elgamal_keypair.pubkey(),
             Some(auditor_elgamal_keypair.pubkey()),
             &[&alice],
+            None,
         )
         .await
         .unwrap_err();

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -1,5 +1,5 @@
 #![cfg(all(feature = "test-sbf"))]
-#![cfg(twoxtx)]
+// #![cfg(twoxtx)]
 
 mod program_test;
 use {
@@ -18,8 +18,10 @@ use {
         error::TokenError,
         extension::{
             confidential_transfer::{
-                self, instruction::TransferContextStateAccounts, ConfidentialTransferAccount,
-                MAXIMUM_DEPOSIT_TRANSFER_AMOUNT,
+                self,
+                account_info::TransferAccountInfo,
+                instruction::{TransferContextStateAccounts, TransferSplitContextStateAccounts},
+                ConfidentialTransferAccount, MAXIMUM_DEPOSIT_TRANSFER_AMOUNT,
             },
             BaseStateWithExtensions, ExtensionType,
         },
@@ -2376,4 +2378,244 @@ async fn confidential_transfer_transfer_with_proof_context() {
             TransactionError::InstructionError(0, InstructionError::InvalidArgument,)
         )))
     )
+}
+
+#[tokio::test]
+async fn confidential_transfer_transfer_with_split_proof_context() {
+    let authority = Keypair::new();
+    let auto_approve_new_accounts = true;
+    let auditor_elgamal_keypair = ElGamalKeypair::new_rand();
+    let auditor_elgamal_pubkey = (*auditor_elgamal_keypair.pubkey()).into();
+
+    let mut context = TestContext::new().await;
+    context
+        .init_token_with_mint(vec![
+            ExtensionInitializationParams::ConfidentialTransferMint {
+                authority: Some(authority.pubkey()),
+                auto_approve_new_accounts,
+                auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
+            },
+        ])
+        .await
+        .unwrap();
+
+    let TokenContext {
+        token,
+        alice,
+        bob,
+        mint_authority,
+        decimals,
+        ..
+    } = context.token_context.unwrap();
+
+    let alice_meta = ConfidentialTokenAccountMeta::new_with_tokens(
+        &token,
+        &alice,
+        None,
+        false,
+        false,
+        &mint_authority,
+        42,
+        decimals,
+    )
+    .await;
+
+    let bob_meta = ConfidentialTokenAccountMeta::new_with_tokens(
+        &token,
+        &bob,
+        None,
+        false,
+        false,
+        &mint_authority,
+        0,
+        decimals,
+    )
+    .await;
+
+    let state = token
+        .get_account_info(&alice_meta.token_account)
+        .await
+        .unwrap();
+    let extension = state
+        .get_extension::<ConfidentialTransferAccount>()
+        .unwrap();
+    let transfer_account_info = TransferAccountInfo::new(&extension);
+
+    let (
+        equality_proof_data,
+        ciphertext_validity_proof_data,
+        range_proof_data,
+        source_decrypt_handles,
+    ) = transfer_account_info
+        .generate_split_transfer_proof_data(
+            42,
+            &alice_meta.elgamal_keypair,
+            &alice_meta.aes_key,
+            bob_meta.elgamal_keypair.pubkey(),
+            Some(auditor_elgamal_keypair.pubkey()),
+        )
+        .unwrap();
+
+    let context_state_authority = Keypair::new();
+
+    let equality_proof_context_state_account = {
+        let context_state_account = Keypair::new();
+        let instruction_type = ProofInstruction::VerifyCiphertextCommitmentEquality;
+        let space = size_of::<ProofContextState<CiphertextCommitmentEqualityProofContext>>();
+
+        let context_state_info = ContextStateInfo {
+            context_state_account: &context_state_account.pubkey(),
+            context_state_authority: &context_state_authority.pubkey(),
+        };
+
+        let mut ctx = context.context.lock().await;
+        let rent = ctx.banks_client.get_rent().await.unwrap();
+
+        let instructions = vec![
+            system_instruction::create_account(
+                &ctx.payer.pubkey(),
+                &context_state_account.pubkey(),
+                rent.minimum_balance(space),
+                space as u64,
+                &zk_token_proof_program::id(),
+            ),
+            instruction_type.encode_verify_proof(Some(context_state_info), &equality_proof_data),
+        ];
+
+        let tx = Transaction::new_signed_with_payer(
+            &instructions,
+            Some(&ctx.payer.pubkey()),
+            &[&ctx.payer, &context_state_account],
+            ctx.last_blockhash,
+        );
+        ctx.banks_client.process_transaction(tx).await.unwrap();
+
+        context_state_account
+    };
+
+    let ciphertext_validity_proof_context_state_account = {
+        let context_state_account = Keypair::new();
+        let instruction_type = ProofInstruction::VerifyBatchedGroupedCiphertext2HandlesValidity;
+        let space =
+            size_of::<ProofContextState<BatchedGroupedCiphertext2HandlesValidityProofContext>>();
+
+        let context_state_info = ContextStateInfo {
+            context_state_account: &context_state_account.pubkey(),
+            context_state_authority: &context_state_authority.pubkey(),
+        };
+
+        let mut ctx = context.context.lock().await;
+        let rent = ctx.banks_client.get_rent().await.unwrap();
+
+        let instructions = vec![
+            system_instruction::create_account(
+                &ctx.payer.pubkey(),
+                &context_state_account.pubkey(),
+                rent.minimum_balance(space),
+                space as u64,
+                &zk_token_proof_program::id(),
+            ),
+            instruction_type
+                .encode_verify_proof(Some(context_state_info), &ciphertext_validity_proof_data),
+        ];
+
+        let tx = Transaction::new_signed_with_payer(
+            &instructions,
+            Some(&ctx.payer.pubkey()),
+            &[&ctx.payer, &context_state_account],
+            ctx.last_blockhash,
+        );
+        ctx.banks_client.process_transaction(tx).await.unwrap();
+
+        context_state_account
+    };
+
+    let range_proof_context_state_account = {
+        let context_state_account = Keypair::new();
+        let instruction_type = ProofInstruction::VerifyBatchedRangeProofU128;
+        let space = size_of::<ProofContextState<BatchedRangeProofContext>>();
+
+        let context_state_info = ContextStateInfo {
+            context_state_account: &context_state_account.pubkey(),
+            context_state_authority: &context_state_authority.pubkey(),
+        };
+
+        let mut ctx = context.context.lock().await;
+        let rent = ctx.banks_client.get_rent().await.unwrap();
+
+        let instructions = vec![
+            system_instruction::create_account(
+                &ctx.payer.pubkey(),
+                &context_state_account.pubkey(),
+                rent.minimum_balance(space),
+                space as u64,
+                &zk_token_proof_program::id(),
+            ),
+            instruction_type.encode_verify_proof(Some(context_state_info), &range_proof_data),
+        ];
+
+        let tx = Transaction::new_signed_with_payer(
+            &instructions,
+            Some(&ctx.payer.pubkey()),
+            &[&ctx.payer, &context_state_account],
+            ctx.last_blockhash,
+        );
+        ctx.banks_client.process_transaction(tx).await.unwrap();
+
+        context_state_account
+    };
+
+    let equality_proof_account_address = equality_proof_context_state_account.pubkey();
+    let ciphertext_validity_proof_account_address =
+        ciphertext_validity_proof_context_state_account.pubkey();
+    let range_proof_account_address = range_proof_context_state_account.pubkey();
+
+    let transfer_context_state_accounts =
+        TransferContextStateAccounts::SplitAccounts(TransferSplitContextStateAccounts {
+            equality_proof: &equality_proof_account_address,
+            ciphertext_validity_proof: &ciphertext_validity_proof_account_address,
+            range_proof: &range_proof_account_address,
+        });
+
+    token
+        .confidential_transfer_transfer(
+            &alice_meta.token_account,
+            &bob_meta.token_account,
+            &alice.pubkey(),
+            Some(transfer_context_state_accounts),
+            42,
+            None,
+            &alice_meta.elgamal_keypair,
+            &alice_meta.aes_key,
+            bob_meta.elgamal_keypair.pubkey(),
+            Some(auditor_elgamal_keypair.pubkey()),
+            &[&alice],
+            Some(&source_decrypt_handles),
+        )
+        .await
+        .unwrap();
+
+    alice_meta
+        .check_balances(
+            &token,
+            ConfidentialTokenAccountBalances {
+                pending_balance_lo: 0,
+                pending_balance_hi: 0,
+                available_balance: 0,
+                decryptable_available_balance: 0,
+            },
+        )
+        .await;
+
+    bob_meta
+        .check_balances(
+            &token,
+            ConfidentialTokenAccountBalances {
+                pending_balance_lo: 42,
+                pending_balance_hi: 0,
+                available_balance: 0,
+                decryptable_available_balance: 0,
+            },
+        )
+        .await;
 }

--- a/token/program-2022-test/tests/confidential_transfer_fee.rs
+++ b/token/program-2022-test/tests/confidential_transfer_fee.rs
@@ -1,5 +1,5 @@
 #![cfg(all(feature = "test-sbf"))]
-#![cfg(twoxtx)]
+// #![cfg(twoxtx)]
 
 mod program_test;
 use {
@@ -530,6 +530,7 @@ async fn confidential_transfer_withdraw_withheld_tokens_from_mint() {
             transfer_fee_parameters.transfer_fee_basis_points.into(),
             transfer_fee_parameters.maximum_fee.into(),
             &[&alice],
+            None,
         )
         .await
         .unwrap();
@@ -687,6 +688,7 @@ async fn confidential_transfer_withdraw_withheld_tokens_from_accounts() {
             transfer_fee_parameters.transfer_fee_basis_points.into(),
             transfer_fee_parameters.maximum_fee.into(),
             &[&alice],
+            None,
         )
         .await
         .unwrap();
@@ -817,6 +819,7 @@ async fn confidential_transfer_withdraw_withheld_tokens_from_mint_with_proof_con
             transfer_fee_parameters.transfer_fee_basis_points.into(),
             transfer_fee_parameters.maximum_fee.into(),
             &[&alice],
+            None,
         )
         .await
         .unwrap();
@@ -984,6 +987,7 @@ async fn confidential_transfer_withdraw_withheld_tokens_from_accounts_with_proof
             transfer_fee_parameters.transfer_fee_basis_points.into(),
             transfer_fee_parameters.maximum_fee.into(),
             &[&alice],
+            None,
         )
         .await
         .unwrap();
@@ -1174,6 +1178,7 @@ async fn confidential_transfer_harvest_withheld_tokens_to_mint() {
             transfer_fee_parameters.transfer_fee_basis_points.into(),
             transfer_fee_parameters.maximum_fee.into(),
             &[&alice],
+            None,
         )
         .await
         .unwrap();

--- a/token/program-2022/src/error.rs
+++ b/token/program-2022/src/error.rs
@@ -218,6 +218,12 @@ pub enum TokenError {
     /// Harvest of withheld tokens to mint is disabled
     #[error("Harvest of withheld tokens to mint is disabled")]
     HarvestToMintDisabled,
+    /// Split proof context state accounts not supported for instruction
+    #[error("Split proof context state accounts not supported for instruction")]
+    SplitProofContextStateAccountsNotSupported,
+    /// Not enough proof context state accounts provided
+    #[error("Not enough proof context state accounts provided")]
+    NotEnoughProofContextStateAccounts,
 }
 impl From<TokenError> for ProgramError {
     fn from(e: TokenError) -> Self {
@@ -380,6 +386,12 @@ impl PrintProgramError for TokenError {
             }
             TokenError::HarvestToMintDisabled => {
                 msg!("Harvest of withheld tokens to mint is disabled")
+            }
+            TokenError::SplitProofContextStateAccountsNotSupported => {
+                msg!("Split proof context state accounts not supported for instruction")
+            }
+            TokenError::NotEnoughProofContextStateAccounts => {
+                msg!("Not enough proof context state accounts provided")
             }
         }
     }

--- a/token/program-2022/src/error.rs
+++ b/token/program-2022/src/error.rs
@@ -224,6 +224,14 @@ pub enum TokenError {
     /// Not enough proof context state accounts provided
     #[error("Not enough proof context state accounts provided")]
     NotEnoughProofContextStateAccounts,
+    /// Ciphertext is malformed
+    #[error("Ciphertext is malformed")]
+    MalformedCiphertext,
+
+    // 60
+    /// Ciphertext arithmetic failed
+    #[error("Ciphertext arithmetic failed")]
+    CiphertextArithmeticFailed,
 }
 impl From<TokenError> for ProgramError {
     fn from(e: TokenError) -> Self {
@@ -392,6 +400,12 @@ impl PrintProgramError for TokenError {
             }
             TokenError::NotEnoughProofContextStateAccounts => {
                 msg!("Not enough proof context state accounts provided")
+            }
+            TokenError::MalformedCiphertext => {
+                msg!("Ciphertext is malformed")
+            }
+            TokenError::CiphertextArithmeticFailed => {
+                msg!("Ciphertext arithmetic failed")
             }
         }
     }

--- a/token/program-2022/src/extension/confidential_transfer/account_info.rs
+++ b/token/program-2022/src/extension/confidential_transfer/account_info.rs
@@ -47,7 +47,7 @@ impl EmptyAccountAccountInfo {
         let available_balance = self
             .available_balance
             .try_into()
-            .map_err(|_| TokenError::AccountDecryption)?;
+            .map_err(|_| TokenError::MalformedCiphertext)?;
 
         ZeroBalanceProofData::new(elgamal_keypair, &available_balance)
             .map_err(|_| TokenError::ProofGeneration)
@@ -93,7 +93,7 @@ impl ApplyPendingBalanceAccountInfo {
         let pending_balance_lo = self
             .pending_balance_lo
             .try_into()
-            .map_err(|_| TokenError::AccountDecryption)?;
+            .map_err(|_| TokenError::MalformedCiphertext)?;
         elgamal_secret_key
             .decrypt_u32(&pending_balance_lo)
             .ok_or(TokenError::AccountDecryption)
@@ -106,7 +106,7 @@ impl ApplyPendingBalanceAccountInfo {
         let pending_balance_hi = self
             .pending_balance_hi
             .try_into()
-            .map_err(|_| TokenError::AccountDecryption)?;
+            .map_err(|_| TokenError::MalformedCiphertext)?;
         elgamal_secret_key
             .decrypt_u32(&pending_balance_hi)
             .ok_or(TokenError::AccountDecryption)
@@ -116,7 +116,7 @@ impl ApplyPendingBalanceAccountInfo {
         let decryptable_available_balance = self
             .decryptable_available_balance
             .try_into()
-            .map_err(|_| TokenError::AccountDecryption)?;
+            .map_err(|_| TokenError::MalformedCiphertext)?;
         aes_key
             .decrypt(&decryptable_available_balance)
             .ok_or(TokenError::AccountDecryption)
@@ -165,7 +165,7 @@ impl WithdrawAccountInfo {
         let decryptable_available_balance = self
             .decryptable_available_balance
             .try_into()
-            .map_err(|_| TokenError::AccountDecryption)?;
+            .map_err(|_| TokenError::MalformedCiphertext)?;
         aes_key
             .decrypt(&decryptable_available_balance)
             .ok_or(TokenError::AccountDecryption)
@@ -181,7 +181,7 @@ impl WithdrawAccountInfo {
         let current_available_balance = self
             .available_balance
             .try_into()
-            .map_err(|_| TokenError::AccountDecryption)?;
+            .map_err(|_| TokenError::MalformedCiphertext)?;
         let current_decrypted_available_balance = self.decrypted_available_balance(aes_key)?;
 
         WithdrawData::new(
@@ -230,7 +230,7 @@ impl TransferAccountInfo {
         let decryptable_available_balance = self
             .decryptable_available_balance
             .try_into()
-            .map_err(|_| TokenError::AccountDecryption)?;
+            .map_err(|_| TokenError::MalformedCiphertext)?;
         aes_key
             .decrypt(&decryptable_available_balance)
             .ok_or(TokenError::AccountDecryption)
@@ -248,7 +248,7 @@ impl TransferAccountInfo {
         let current_source_available_balance = self
             .available_balance
             .try_into()
-            .map_err(|_| TokenError::AccountDecryption)?;
+            .map_err(|_| TokenError::MalformedCiphertext)?;
         let current_source_decrypted_available_balance =
             self.decrypted_available_balance(aes_key)?;
 
@@ -285,10 +285,15 @@ impl TransferAccountInfo {
         ),
         TokenError,
     > {
-        let current_available_balance = self.available_balance.try_into().unwrap(); // TODO:
-        let current_decryptable_available_balance =
-            self.decryptable_available_balance.try_into().unwrap(); // TODO: replace with a
-                                                                    // suitable error type
+        let current_available_balance = self
+            .available_balance
+            .try_into()
+            .map_err(|_| TokenError::MalformedCiphertext)?;
+        let current_decryptable_available_balance = self
+            .decryptable_available_balance
+            .try_into()
+            .map_err(|_| TokenError::MalformedCiphertext)?;
+
         transfer_split_proof_data(
             &current_available_balance,
             &current_decryptable_available_balance,
@@ -316,7 +321,7 @@ impl TransferAccountInfo {
         let current_source_available_balance = self
             .available_balance
             .try_into()
-            .map_err(|_| TokenError::AccountDecryption)?;
+            .map_err(|_| TokenError::MalformedCiphertext)?;
         let current_source_decrypted_available_balance =
             self.decrypted_available_balance(aes_key)?;
 

--- a/token/program-2022/src/extension/confidential_transfer/ciphertext_extraction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/ciphertext_extraction.rs
@@ -234,7 +234,7 @@ impl TransferProofContextInfo {
             // the fourth dummy commitment can be any commitment
         ];
 
-        if range_proof_commitments
+        if !range_proof_commitments
             .iter()
             .zip(expected_commitments.iter())
             .all(|(proof_commitment, expected_commitment)| proof_commitment == expected_commitment)
@@ -255,7 +255,7 @@ impl TransferProofContextInfo {
         ]
         .iter();
 
-        if range_proof_bit_lengths
+        if !range_proof_bit_lengths
             .iter()
             .zip(expected_bit_lengths)
             .all(|(proof_len, expected_len)| proof_len == expected_len)

--- a/token/program-2022/src/extension/confidential_transfer/ciphertext_extraction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/ciphertext_extraction.rs
@@ -132,7 +132,7 @@ pub(crate) fn transfer_amount_encryption_from_decrypt_handle(
 
     let mut transfer_amount_ciphertext_bytes = [0u8; 128];
     transfer_amount_ciphertext_bytes[..32].copy_from_slice(&grouped_ciphertext_bytes[..32]);
-    transfer_amount_ciphertext_bytes[32..64].copy_from_slice(&source_decrypt_handle_bytes);
+    transfer_amount_ciphertext_bytes[32..64].copy_from_slice(source_decrypt_handle_bytes);
     transfer_amount_ciphertext_bytes[64..128].copy_from_slice(&grouped_ciphertext_bytes[32..96]);
 
     TransferAmountCiphertext(GroupedElGamalCiphertext3Handles(

--- a/token/program-2022/src/extension/confidential_transfer/ciphertext_extraction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/ciphertext_extraction.rs
@@ -6,17 +6,13 @@ use crate::{
     extension::{confidential_transfer::*, confidential_transfer_fee::EncryptedFee},
     solana_program::program_error::ProgramError,
     solana_zk_token_sdk::{
-        encryption::pedersen::Pedersen,
         instruction::{
             transfer::TransferProofContext, BatchedGroupedCiphertext2HandlesValidityProofContext,
             BatchedRangeProofContext, CiphertextCommitmentEqualityProofContext,
         },
-        zk_token_elgamal::{
-            ops::subtract,
-            pod::{
-                DecryptHandle, GroupedElGamalCiphertext2Handles, GroupedElGamalCiphertext3Handles,
-                PedersenCommitment, TransferAmountCiphertext,
-            },
+        zk_token_elgamal::pod::{
+            DecryptHandle, GroupedElGamalCiphertext2Handles, GroupedElGamalCiphertext3Handles,
+            PedersenCommitment, TransferAmountCiphertext,
         },
     },
 };

--- a/token/program-2022/src/extension/confidential_transfer/ciphertext_extraction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/ciphertext_extraction.rs
@@ -17,6 +17,12 @@ use crate::{
     },
 };
 
+#[cfg(feature = "serde-traits")]
+use {
+    crate::serialization::decrypthandle_fromstr,
+    serde::{Deserialize, Serialize},
+};
+
 pub(crate) fn transfer_amount_commitment(
     transfer_amount_ciphertext: &GroupedElGamalCiphertext2Handles,
 ) -> PedersenCommitment {
@@ -296,11 +302,14 @@ impl TransferProofContextInfo {
 /// proof contexts as a form of optimization. These components should be added back into these
 /// split proofs in `zk-token-sdk`. Until this modifications is made, include `SourceDecryptHandle`
 /// in the transfer instruction data.
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct SourceDecryptHandles {
     /// The ElGamal decryption handle pertaining to the low 16 bits of the transfer amount.
+    #[cfg_attr(feature = "serde-traits", serde(with = "decrypthandle_fromstr"))]
     pub lo: DecryptHandle,
     /// The ElGamal decryption handle pertaining to the low 32 bits of the transfer amount.
+    #[cfg_attr(feature = "serde-traits", serde(with = "decrypthandle_fromstr"))]
     pub hi: DecryptHandle,
 }

--- a/token/program-2022/src/extension/confidential_transfer/ciphertext_extraction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/ciphertext_extraction.rs
@@ -1,0 +1,137 @@
+//! Ciphertext extraction and proof related helper logic
+//!
+//! This submodule should be removed with the next upgrade to the Solana program
+
+use crate::{
+    extension::{confidential_transfer::*, confidential_transfer_fee::EncryptedFee},
+    solana_zk_token_sdk::{
+        instruction::transfer::TransferProofContext,
+        zk_token_elgamal::pod::{
+            DecryptHandle, GroupedElGamalCiphertext2Handles, GroupedElGamalCiphertext3Handles,
+            PedersenCommitment, TransferAmountCiphertext,
+        },
+    },
+};
+
+pub(crate) fn transfer_amount_commitment(
+    transfer_amount_ciphertext: &GroupedElGamalCiphertext2Handles,
+) -> PedersenCommitment {
+    let transfer_amount_ciphertext_bytes = bytemuck::bytes_of(transfer_amount_ciphertext);
+    let transfer_amount_commitment_bytes =
+        transfer_amount_ciphertext_bytes[..32].try_into().unwrap();
+    PedersenCommitment(transfer_amount_commitment_bytes)
+}
+
+/// Extract the transfer amount ciphertext encrypted under the source ElGamal public key.
+///
+/// A transfer amount ciphertext consists of the following 32-byte components that are serialized
+/// in order:
+///   1. The `commitment` component that encodes the transfer amount.
+///   2. The `decryption handle` component with respect to the source public key.
+///   3. The `decryption handle` component with respect to the destination public key.
+///   4. The `decryption handle` component with respect to the auditor public key.
+///
+/// An ElGamal ciphertext for the source consists of the `commitment` component and the `decryption
+/// handle` component with respect to the source.
+pub(crate) fn transfer_amount_source_ciphertext(
+    transfer_amount_ciphertext: &TransferAmountCiphertext,
+) -> ElGamalCiphertext {
+    let transfer_amount_ciphertext_bytes = bytemuck::bytes_of(transfer_amount_ciphertext);
+
+    let mut source_ciphertext_bytes = [0u8; 64];
+    source_ciphertext_bytes[..32].copy_from_slice(&transfer_amount_ciphertext_bytes[..32]);
+    source_ciphertext_bytes[32..].copy_from_slice(&transfer_amount_ciphertext_bytes[32..64]);
+
+    ElGamalCiphertext(source_ciphertext_bytes)
+}
+
+/// Extract the transfer amount ciphertext encrypted under the destination ElGamal public key.
+///
+/// A transfer amount ciphertext consists of the following 32-byte components that are serialized
+/// in order:
+///   1. The `commitment` component that encodes the transfer amount.
+///   2. The `decryption handle` component with respect to the source public key.
+///   3. The `decryption handle` component with respect to the destination public key.
+///   4. The `decryption handle` component with respect to the auditor public key.
+///
+/// An ElGamal ciphertext for the destination consists of the `commitment` component and the
+/// `decryption handle` component with respect to the destination public key.
+#[cfg(feature = "zk-ops")]
+pub(crate) fn transfer_amount_destination_ciphertext(
+    transfer_amount_ciphertext: &TransferAmountCiphertext,
+) -> ElGamalCiphertext {
+    let transfer_amount_ciphertext_bytes = bytemuck::bytes_of(transfer_amount_ciphertext);
+
+    let mut destination_ciphertext_bytes = [0u8; 64];
+    destination_ciphertext_bytes[..32].copy_from_slice(&transfer_amount_ciphertext_bytes[..32]);
+    destination_ciphertext_bytes[32..].copy_from_slice(&transfer_amount_ciphertext_bytes[64..96]);
+
+    ElGamalCiphertext(destination_ciphertext_bytes)
+}
+
+/// Extract the fee amount ciphertext encrypted under the destination ElGamal public key.
+///
+/// A fee encryption amount consists of the following 32-byte components that are serialized in
+/// order:
+///   1. The `commitment` component that encodes the fee amount.
+///   2. The `decryption handle` component with respect to the destination public key.
+///   3. The `decryption handle` component with respect to the withdraw withheld authority public
+///      key.
+///
+/// An ElGamal ciphertext for the destination consists of the `commitment` component and the
+/// `decryption handle` component with respect to the destination public key.
+#[cfg(feature = "zk-ops")]
+pub(crate) fn fee_amount_destination_ciphertext(
+    transfer_amount_ciphertext: &EncryptedFee,
+) -> ElGamalCiphertext {
+    let transfer_amount_ciphertext_bytes = bytemuck::bytes_of(transfer_amount_ciphertext);
+
+    let mut source_ciphertext_bytes = [0u8; 64];
+    source_ciphertext_bytes[..32].copy_from_slice(&transfer_amount_ciphertext_bytes[..32]);
+    source_ciphertext_bytes[32..].copy_from_slice(&transfer_amount_ciphertext_bytes[32..64]);
+
+    ElGamalCiphertext(source_ciphertext_bytes)
+}
+
+/// Extract the transfer amount ciphertext encrypted under the withdraw withheld authority ElGamal
+/// public key.
+///
+/// A fee encryption amount consists of the following 32-byte components that are serialized in
+/// order:
+///   1. The `commitment` component that encodes the fee amount.
+///   2. The `decryption handle` component with respect to the destination public key.
+///   3. The `decryption handle` component with respect to the withdraw withheld authority public
+///      key.
+///
+/// An ElGamal ciphertext for the destination consists of the `commitment` component and the
+/// `decryption handle` component with respect to the withdraw withheld authority public key.
+#[cfg(feature = "zk-ops")]
+pub(crate) fn fee_amount_withdraw_withheld_authority_ciphertext(
+    transfer_amount_ciphertext: &EncryptedFee,
+) -> ElGamalCiphertext {
+    let transfer_amount_ciphertext_bytes = bytemuck::bytes_of(transfer_amount_ciphertext);
+
+    let mut destination_ciphertext_bytes = [0u8; 64];
+    destination_ciphertext_bytes[..32].copy_from_slice(&transfer_amount_ciphertext_bytes[..32]);
+    destination_ciphertext_bytes[32..].copy_from_slice(&transfer_amount_ciphertext_bytes[64..96]);
+
+    ElGamalCiphertext(destination_ciphertext_bytes)
+}
+
+#[cfg(feature = "zk-ops")]
+pub(crate) fn transfer_amount_encryption_from_decrypt_handle(
+    source_decrypt_handle: &DecryptHandle,
+    grouped_ciphertext: &GroupedElGamalCiphertext2Handles,
+) -> TransferAmountCiphertext {
+    let source_decrypt_handle_bytes = bytemuck::bytes_of(source_decrypt_handle);
+    let grouped_ciphertext_bytes = bytemuck::bytes_of(grouped_ciphertext);
+
+    let mut transfer_amount_ciphertext_bytes = [0u8; 128];
+    transfer_amount_ciphertext_bytes[..32].copy_from_slice(&grouped_ciphertext_bytes[..32]);
+    transfer_amount_ciphertext_bytes[32..64].copy_from_slice(&source_decrypt_handle_bytes);
+    transfer_amount_ciphertext_bytes[64..128].copy_from_slice(&grouped_ciphertext_bytes[32..96]);
+
+    TransferAmountCiphertext(GroupedElGamalCiphertext3Handles(
+        transfer_amount_ciphertext_bytes,
+    ))
+}

--- a/token/program-2022/src/extension/confidential_transfer/ciphertext_extraction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/ciphertext_extraction.rs
@@ -4,11 +4,19 @@
 
 use crate::{
     extension::{confidential_transfer::*, confidential_transfer_fee::EncryptedFee},
+    solana_program::program_error::ProgramError,
     solana_zk_token_sdk::{
-        instruction::transfer::TransferProofContext,
-        zk_token_elgamal::pod::{
-            DecryptHandle, GroupedElGamalCiphertext2Handles, GroupedElGamalCiphertext3Handles,
-            PedersenCommitment, TransferAmountCiphertext,
+        encryption::pedersen::Pedersen,
+        instruction::{
+            transfer::TransferProofContext, BatchedGroupedCiphertext2HandlesValidityProofContext,
+            BatchedRangeProofContext, CiphertextCommitmentEqualityProofContext,
+        },
+        zk_token_elgamal::{
+            ops::subtract,
+            pod::{
+                DecryptHandle, GroupedElGamalCiphertext2Handles, GroupedElGamalCiphertext3Handles,
+                PedersenCommitment, TransferAmountCiphertext,
+            },
         },
     },
 };
@@ -134,4 +142,141 @@ pub(crate) fn transfer_amount_encryption_from_decrypt_handle(
     TransferAmountCiphertext(GroupedElGamalCiphertext3Handles(
         transfer_amount_ciphertext_bytes,
     ))
+}
+
+/// The transfer public keys associated with a transfer.
+#[cfg(feature = "zk-ops")]
+pub struct TransferPubkeysInfo {
+    /// Source ElGamal public key
+    pub source: ElGamalPubkey,
+    /// Destination ElGamal public key
+    pub destination: ElGamalPubkey,
+    /// Auditor ElGamal public key
+    pub auditor: ElGamalPubkey,
+}
+
+/// The proof context information needed to process a [Transfer] instruction.
+#[cfg(feature = "zk-ops")]
+pub struct TransferProofContextInfo {
+    /// Ciphertext containing the low 16 bits of the transafer amount
+    pub ciphertext_lo: TransferAmountCiphertext,
+    /// Ciphertext containing the high 32 bits of the transafer amount
+    pub ciphertext_hi: TransferAmountCiphertext,
+    /// The transfer public keys associated with a transfer
+    pub transfer_pubkeys: TransferPubkeysInfo,
+    /// The new source available balance ciphertext
+    pub new_source_ciphertext: ElGamalCiphertext,
+}
+
+impl From<TransferProofContext> for TransferProofContextInfo {
+    fn from(context: TransferProofContext) -> Self {
+        let transfer_pubkeys = TransferPubkeysInfo {
+            source: context.transfer_pubkeys.source,
+            destination: context.transfer_pubkeys.destination,
+            auditor: context.transfer_pubkeys.auditor,
+        };
+
+        TransferProofContextInfo {
+            ciphertext_lo: context.ciphertext_lo,
+            ciphertext_hi: context.ciphertext_hi,
+            transfer_pubkeys,
+            new_source_ciphertext: context.new_source_ciphertext,
+        }
+    }
+}
+
+impl TransferProofContextInfo {
+    /// Create a transfer proof context information needed to process a [Transfer] instruction from
+    /// split proof contexts after verifying their consistency.
+    pub fn new(
+        equality_proof_context: &CiphertextCommitmentEqualityProofContext,
+        ciphertext_validity_proof_context: &BatchedGroupedCiphertext2HandlesValidityProofContext,
+        range_proof_context: &BatchedRangeProofContext,
+    ) -> Result<Self, ProgramError> {
+        // The equality proof context consists of the source ElGamal public key, the new source
+        // available balance ciphertext, and the new source available commitment. The public key
+        // and ciphertext should be returned as parts of `TransferProofContextInfo` and the
+        // commitment should be checked with range proof for consistency.
+        let CiphertextCommitmentEqualityProofContext {
+            pubkey: source_pubkey,
+            ciphertext: new_source_ciphertext,
+            commitment: new_source_commitment,
+        } = equality_proof_context;
+
+        // The ciphertext validity proof context consists of the destination ElGamal public key,
+        // auditor ElGamal public key, and the transfer amount ciphertexts. All of these fields
+        // should be returned as part of `TransferProofContextInfo`. In addition, the commitments
+        // pertaining to the transfer amount ciphertexts should be checked with range proof for
+        // consistency.
+        let BatchedGroupedCiphertext2HandlesValidityProofContext {
+            destination_pubkey,
+            auditor_pubkey,
+            grouped_ciphertext_lo: transfer_amount_ciphertext_lo,
+            grouped_ciphertext_hi: transfer_amount_ciphertext_hi,
+        } = ciphertext_validity_proof_context;
+
+        // The range proof context consists of the Pedersen commitments and bit-lengths for which
+        // the range proof is proved. The commitments must consist of three commitments pertaining
+        // to the low bits of the transfer amount, high bits of the transfer amount, and the new
+        // source available balance. These commitments must be checked for `16`, `32`, `80`.
+        let BatchedRangeProofContext {
+            commitments: range_proof_commitments,
+            bit_lengths: range_proof_bit_lengths,
+        } = range_proof_context;
+
+        // check that the range proof was created for the correct set of Pedersen commitments
+        let transfer_amount_commitment_lo =
+            transfer_amount_commitment(transfer_amount_ciphertext_lo);
+        let transfer_amount_commitment_hi =
+            transfer_amount_commitment(transfer_amount_ciphertext_hi);
+
+        let expected_commitments = [
+            *new_source_commitment,
+            transfer_amount_commitment_lo,
+            transfer_amount_commitment_hi,
+            // the fourth dummy commitment can be any commitment
+        ];
+
+        if range_proof_commitments
+            .iter()
+            .zip(expected_commitments.iter())
+            .all(|(proof_commitment, expected_commitment)| proof_commitment == expected_commitment)
+        {
+            return Err(ProgramError::InvalidInstructionData);
+        }
+
+        // check that the range proof was created for the correct number of bits
+        const REMAINING_BALANCE_BIT_LENGTH: u8 = 64;
+        const TRANSFER_AMOUNT_LO_BIT_LENGTH: u8 = 16;
+        const TRANSFER_AMOUNT_HI_BIT_LENGTH: u8 = 32;
+        const PADDING_BIT_LENGTH: u8 = 16;
+        let expected_bit_lengths = [
+            REMAINING_BALANCE_BIT_LENGTH,
+            TRANSFER_AMOUNT_LO_BIT_LENGTH,
+            TRANSFER_AMOUNT_HI_BIT_LENGTH,
+            PADDING_BIT_LENGTH,
+        ]
+        .iter();
+
+        if range_proof_bit_lengths
+            .iter()
+            .zip(expected_bit_lengths)
+            .all(|(proof_len, expected_len)| proof_len == expected_len)
+        {
+            return Err(ProgramError::InvalidInstructionData);
+        }
+
+        let transfer_pubkeys = TransferPubkeysInfo {
+            source: *source_pubkey,
+            destination: *destination_pubkey,
+            auditor: *auditor_pubkey,
+        };
+
+        Ok(Self {
+            ciphertext_lo: *transfer_amount_ciphertext_lo,
+            ciphertext_hi: *transfer_amount_ciphertext_hi,
+            transfer_pubkeys,
+            new_source_ciphertext: *new_source_ciphertext,
+        })
+    }
 }

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -485,6 +485,26 @@ pub struct ApplyPendingBalanceData {
     pub new_decryptable_available_balance: DecryptableBalance,
 }
 
+/// Type for transfer instruction proof context state account addresses intended to be used as
+/// parameters to functions.
+pub enum TransferContextStateAccounts<'a> {
+    /// The context state account address for a single transfer proof context.
+    SingleAccount(&'a Pubkey),
+    /// The context state account addresses for the context states of a split transfer proof.
+    SplitAccounts(TransferSplitContextStateAccounts<'a>),
+}
+
+/// Type for split transfer instruction proof context state account addresses intended to be used
+/// as parameters to functions.
+pub struct TransferSplitContextStateAccounts<'a> {
+    /// The context state account address for an equality proof needed for a transfer.
+    pub equality_proof: &'a Pubkey,
+    /// The context state account address for a ciphertext validity proof needed for a transfer.
+    pub ciphertext_validity_proof: &'a Pubkey,
+    /// The context state account address for a range proof needed for a transfer.
+    pub range_proof: &'a Pubkey,
+}
+
 /// Create a `InitializeMint` instruction
 #[cfg(not(target_os = "solana"))]
 pub fn initialize_mint(

--- a/token/program-2022/src/extension/confidential_transfer/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer/mod.rs
@@ -30,6 +30,11 @@ pub mod verify_proof;
 #[cfg(not(target_os = "solana"))]
 pub mod account_info;
 
+/// Ciphertext extraction and proof related helper logic
+///
+/// This submodule should be removed with the next upgrade to the Solana program
+pub mod ciphertext_extraction;
+
 /// ElGamal ciphertext containing an account balance
 pub type EncryptedBalance = ElGamalCiphertext;
 /// Authenticated encryption containing an account balance

--- a/token/program-2022/src/extension/confidential_transfer/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer/mod.rs
@@ -31,6 +31,7 @@ pub mod verify_proof;
 ///
 /// The logic in this submodule should belong to the `solana-zk-token-sdk` and will be removed with
 /// the next upgrade to the Solana program.
+#[cfg(not(target_os = "solana"))]
 pub mod split_proof_generation;
 
 /// Confidential Transfer Extension account information needed for instructions

--- a/token/program-2022/src/extension/confidential_transfer/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer/mod.rs
@@ -23,6 +23,9 @@ pub mod instruction;
 /// Confidential Transfer Extension processor
 pub mod processor;
 
+/// Helper functions to verify zero-knowledge proofs in the Confidential Transfer Extension
+pub mod verify_proof;
+
 /// Confidential Transfer Extension account information needed for instructions
 #[cfg(not(target_os = "solana"))]
 pub mod account_info;

--- a/token/program-2022/src/extension/confidential_transfer/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer/mod.rs
@@ -26,6 +26,13 @@ pub mod processor;
 /// Helper functions to verify zero-knowledge proofs in the Confidential Transfer Extension
 pub mod verify_proof;
 
+/// Helper functions to generate split zero-knowledge proofs for confidential transfers in the
+/// Confidential Transfer Extension.
+///
+/// The logic in this submodule should belong to the `solana-zk-token-sdk` and will be removed with
+/// the next upgrade to the Solana program.
+pub mod split_proof_generation;
+
 /// Confidential Transfer Extension account information needed for instructions
 #[cfg(not(target_os = "solana"))]
 pub mod account_info;

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -425,6 +425,7 @@ fn process_transfer(
     new_source_decryptable_available_balance: DecryptableBalance,
     proof_instruction_offset: i64,
     split_proof_context_state_accounts: bool,
+    source_decrypt_handles: &SourceDecryptHandles,
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
     let source_account_info = next_account_info(account_info_iter)?;
@@ -457,6 +458,7 @@ fn process_transfer(
             account_info_iter,
             proof_instruction_offset,
             split_proof_context_state_accounts,
+            source_decrypt_handles,
         )?;
 
         let authority_info = next_account_info(account_info_iter)?;
@@ -943,6 +945,7 @@ pub(crate) fn process_instruction(
                 data.new_source_decryptable_available_balance,
                 data.proof_instruction_offset as i64,
                 data.split_proof_context_state_accounts.into(),
+                &data.source_decrypt_handles,
             )
         }
         ConfidentialTransferInstruction::ApplyPendingBalance => {

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -303,12 +303,12 @@ fn process_deposit(
     if amount_lo > 0 {
         confidential_transfer_account.pending_balance_lo =
             syscall::add_to(&confidential_transfer_account.pending_balance_lo, amount_lo)
-                .ok_or(ProgramError::InvalidInstructionData)?;
+                .ok_or(TokenError::CiphertextArithmeticFailed)?;
     }
     if amount_hi > 0 {
         confidential_transfer_account.pending_balance_hi =
             syscall::add_to(&confidential_transfer_account.pending_balance_hi, amount_hi)
-                .ok_or(ProgramError::InvalidInstructionData)?;
+                .ok_or(TokenError::CiphertextArithmeticFailed)?;
     }
 
     confidential_transfer_account.increment_pending_balance_credit_counter()?;
@@ -398,7 +398,7 @@ fn process_withdraw(
     if amount > 0 {
         confidential_transfer_account.available_balance =
             syscall::subtract_from(&confidential_transfer_account.available_balance, amount)
-                .ok_or(ProgramError::InvalidInstructionData)?;
+                .ok_or(TokenError::CiphertextArithmeticFailed)?;
     }
     // Check that the final available balance ciphertext is consistent with the actual ciphertext
     // for which the zero-knowledge proof was generated for.
@@ -648,7 +648,7 @@ fn process_source_for_transfer(
         source_transfer_amount_lo,
         source_transfer_amount_hi,
     )
-    .ok_or(ProgramError::InvalidInstructionData)?;
+    .ok_or(TokenError::CiphertextArithmeticFailed)?;
 
     // Check that the computed available balance is consistent with what was actually used to
     // generate the zkp on the client side.
@@ -701,13 +701,13 @@ fn process_destination_for_transfer(
         &destination_confidential_transfer_account.pending_balance_lo,
         destination_transfer_amount_lo,
     )
-    .ok_or(ProgramError::InvalidInstructionData)?;
+    .ok_or(TokenError::CiphertextArithmeticFailed)?;
 
     destination_confidential_transfer_account.pending_balance_hi = syscall::add(
         &destination_confidential_transfer_account.pending_balance_hi,
         destination_transfer_amount_hi,
     )
-    .ok_or(ProgramError::InvalidInstructionData)?;
+    .ok_or(TokenError::CiphertextArithmeticFailed)?;
 
     destination_confidential_transfer_account.increment_pending_balance_credit_counter()?;
 
@@ -722,12 +722,12 @@ fn process_destination_for_transfer(
             &destination_confidential_transfer_account.pending_balance_lo,
             &destination_fee_lo,
         )
-        .ok_or(ProgramError::InvalidInstructionData)?;
+        .ok_or(TokenError::CiphertextArithmeticFailed)?;
         destination_confidential_transfer_account.pending_balance_hi = syscall::subtract(
             &destination_confidential_transfer_account.pending_balance_hi,
             &destination_fee_hi,
         )
-        .ok_or(ProgramError::InvalidInstructionData)?;
+        .ok_or(TokenError::CiphertextArithmeticFailed)?;
 
         // Decode lo and hi fee amounts encrypted under the withdraw authority encryption public
         // key
@@ -745,7 +745,7 @@ fn process_destination_for_transfer(
             &withdraw_withheld_authority_fee_lo,
             &withdraw_withheld_authority_fee_hi,
         )
-        .ok_or(ProgramError::InvalidInstructionData)?;
+        .ok_or(TokenError::CiphertextArithmeticFailed)?;
     }
 
     Ok(())
@@ -786,7 +786,7 @@ fn process_apply_pending_balance(
         &confidential_transfer_account.pending_balance_lo,
         &confidential_transfer_account.pending_balance_hi,
     )
-    .ok_or(ProgramError::InvalidInstructionData)?;
+    .ok_or(TokenError::CiphertextArithmeticFailed)?;
 
     confidential_transfer_account.actual_pending_balance_credit_counter =
         confidential_transfer_account.pending_balance_credit_counter;

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -319,7 +319,7 @@ fn process_deposit(
 /// Verifies that a deposit amount is a 48-bit number and returns the least significant 16 bits and
 /// most significant 32 bits of the amount.
 #[cfg(feature = "zk-ops")]
-fn verify_and_split_deposit_amount(amount: u64) -> Result<(u64, u64), TokenError> {
+pub(crate) fn verify_and_split_deposit_amount(amount: u64) -> Result<(u64, u64), TokenError> {
     if amount > MAXIMUM_DEPOSIT_TRANSFER_AMOUNT {
         return Err(TokenError::MaximumDepositAmountExceeded);
     }

--- a/token/program-2022/src/extension/confidential_transfer/split_proof_generation.rs
+++ b/token/program-2022/src/extension/confidential_transfer/split_proof_generation.rs
@@ -93,9 +93,10 @@ pub fn transfer_split_proof_data(
         &transfer_amount_source_ciphertext_lo,
         &transfer_amount_source_ciphertext_hi,
     )
-    .unwrap(); // TODO: replace with a suitable error type
-    let new_available_balance_ciphertext: ElGamalCiphertext =
-        new_available_balance_ciphertext.try_into().unwrap(); // TODO: replace with a suitable error type
+    .ok_or(TokenError::CiphertextArithmeticFailed)?;
+    let new_available_balance_ciphertext: ElGamalCiphertext = new_available_balance_ciphertext
+        .try_into()
+        .map_err(|_| TokenError::MalformedCiphertext)?;
 
     // generate equality proof data
     let equality_proof_data = CiphertextCommitmentEqualityProofData::new(

--- a/token/program-2022/src/extension/confidential_transfer/split_proof_generation.rs
+++ b/token/program-2022/src/extension/confidential_transfer/split_proof_generation.rs
@@ -1,0 +1,188 @@
+//! Helper functions to generate split zero-knowledge proofs for confidential transfers in the
+//! Confidential Transfer Extension.
+//!
+//! The logic in this submodule should belong to the `solana-zk-token-sdk` and will be removed with
+//! the next upgrade to the Solana program.
+
+use crate::{
+    extension::confidential_transfer::{
+        ciphertext_extraction::{transfer_amount_source_ciphertext, SourceDecryptHandles},
+        processor::verify_and_split_deposit_amount,
+        *,
+    },
+    solana_zk_token_sdk::{
+        encryption::{
+            auth_encryption::{AeCiphertext, AeKey},
+            elgamal::{DecryptHandle, ElGamalCiphertext, ElGamalKeypair, ElGamalPubkey},
+            grouped_elgamal::GroupedElGamal,
+            pedersen::Pedersen,
+        },
+        instruction::{
+            transfer::TransferAmountCiphertext, BatchedGroupedCiphertext2HandlesValidityProofData,
+            BatchedRangeProofU128Data, CiphertextCommitmentEqualityProofData,
+        },
+        zk_token_elgamal::ops::subtract_with_lo_hi,
+    },
+};
+
+/// The main logic to create the three split proof data for a transfer.
+pub fn transfer_split_proof_data(
+    current_available_balance: &ElGamalCiphertext,
+    current_decryptable_available_balance: &AeCiphertext,
+    transfer_amount: u64,
+    source_elgamal_keypair: &ElGamalKeypair,
+    aes_key: &AeKey,
+    destination_elgamal_pubkey: &ElGamalPubkey,
+    auditor_elgamal_pubkey: Option<&ElGamalPubkey>,
+) -> Result<
+    (
+        CiphertextCommitmentEqualityProofData,
+        BatchedGroupedCiphertext2HandlesValidityProofData,
+        BatchedRangeProofU128Data,
+        SourceDecryptHandles,
+    ),
+    TokenError,
+> {
+    let default_auditor_pubkey = ElGamalPubkey::default();
+    let auditor_elgamal_pubkey = auditor_elgamal_pubkey.unwrap_or(&default_auditor_pubkey);
+
+    // Split the transfer amount into the low and high bit components.
+    let (transfer_amount_lo, transfer_amount_hi) =
+        verify_and_split_deposit_amount(transfer_amount)?;
+
+    // Encrypt the `lo` and `hi` transfer amounts.
+    let (transfer_amount_grouped_ciphertext_lo, transfer_amount_opening_lo) =
+        TransferAmountCiphertext::new(
+            transfer_amount_lo,
+            source_elgamal_keypair.pubkey(),
+            destination_elgamal_pubkey,
+            auditor_elgamal_pubkey,
+        );
+
+    let (transfer_amount_grouped_ciphertext_hi, transfer_amount_opening_hi) =
+        TransferAmountCiphertext::new(
+            transfer_amount_hi,
+            source_elgamal_keypair.pubkey(),
+            destination_elgamal_pubkey,
+            auditor_elgamal_pubkey,
+        );
+
+    // Decrypt the current available balance at the source
+    let current_decrypted_available_balance = current_decryptable_available_balance
+        .decrypt(aes_key)
+        .ok_or(TokenError::AccountDecryption)?;
+
+    // Compute the remaining balance at the source
+    let new_decrypted_available_balance = current_decrypted_available_balance
+        .checked_sub(transfer_amount)
+        .ok_or(TokenError::InsufficientFunds)?;
+
+    // Create a new Pedersen commitment for the remaining balance at the source
+    let (new_available_balance_commitment, new_source_opening) =
+        Pedersen::new(new_decrypted_available_balance);
+
+    // Compute the remaining balance at the source as ElGamal ciphertexts
+    let transfer_amount_source_ciphertext_lo =
+        transfer_amount_source_ciphertext(&transfer_amount_grouped_ciphertext_lo.into());
+    let transfer_amount_source_ciphertext_hi =
+        transfer_amount_source_ciphertext(&transfer_amount_grouped_ciphertext_hi.into());
+
+    let current_available_balance = (*current_available_balance).into();
+    let new_available_balance_ciphertext = subtract_with_lo_hi(
+        &current_available_balance,
+        &transfer_amount_source_ciphertext_lo,
+        &transfer_amount_source_ciphertext_hi,
+    )
+    .unwrap(); // TODO: replace with a suitable error type
+    let new_available_balance_ciphertext: ElGamalCiphertext =
+        new_available_balance_ciphertext.try_into().unwrap(); // TODO: replace with a suitable error type
+
+    // generate equality proof data
+    let equality_proof_data = CiphertextCommitmentEqualityProofData::new(
+        source_elgamal_keypair,
+        &new_available_balance_ciphertext,
+        &new_available_balance_commitment,
+        &new_source_opening,
+        new_decrypted_available_balance,
+    )
+    .map_err(|_| TokenError::ProofGeneration)?;
+
+    // create source decrypt handle
+    let source_decrypt_handle_lo =
+        DecryptHandle::new(source_elgamal_keypair.pubkey(), &transfer_amount_opening_lo);
+    let source_decrypt_handle_hi =
+        DecryptHandle::new(source_elgamal_keypair.pubkey(), &transfer_amount_opening_hi);
+
+    let source_decrypt_handles = SourceDecryptHandles {
+        lo: source_decrypt_handle_lo.into(),
+        hi: source_decrypt_handle_hi.into(),
+    };
+
+    // encrypt the transfer amount under the destination and auditor ElGamal public key
+    let transfer_amount_destination_auditor_ciphertext_lo = GroupedElGamal::<2>::encrypt_with(
+        [destination_elgamal_pubkey, auditor_elgamal_pubkey],
+        transfer_amount_lo,
+        &transfer_amount_opening_lo,
+    );
+    let transfer_amount_destination_auditor_ciphertext_hi = GroupedElGamal::<2>::encrypt_with(
+        [destination_elgamal_pubkey, auditor_elgamal_pubkey],
+        transfer_amount_hi,
+        &transfer_amount_opening_hi,
+    );
+
+    // generate ciphertext validity data
+    let ciphertext_validity_proof_data = BatchedGroupedCiphertext2HandlesValidityProofData::new(
+        destination_elgamal_pubkey,
+        auditor_elgamal_pubkey,
+        &transfer_amount_destination_auditor_ciphertext_lo,
+        &transfer_amount_destination_auditor_ciphertext_hi,
+        transfer_amount_lo,
+        transfer_amount_hi,
+        &transfer_amount_opening_lo,
+        &transfer_amount_opening_hi,
+    )
+    .map_err(|_| TokenError::ProofGeneration)?;
+
+    // generate range proof data
+    const REMAINING_BALANCE_BIT_LENGTH: usize = 64;
+    const TRANSFER_AMOUNT_LO_BIT_LENGTH: usize = 16;
+    const TRANSFER_AMOUNT_HI_BIT_LENGTH: usize = 32;
+    const PADDING_BIT_LENGTH: usize = 16;
+
+    let (padding_commitment, padding_opening) = Pedersen::new(0_u64);
+
+    let range_proof_data = BatchedRangeProofU128Data::new(
+        vec![
+            &new_available_balance_commitment,
+            transfer_amount_grouped_ciphertext_lo.get_commitment(),
+            transfer_amount_grouped_ciphertext_hi.get_commitment(),
+            &padding_commitment,
+        ],
+        vec![
+            new_decrypted_available_balance,
+            transfer_amount_lo,
+            transfer_amount_hi,
+            0,
+        ],
+        vec![
+            REMAINING_BALANCE_BIT_LENGTH,
+            TRANSFER_AMOUNT_LO_BIT_LENGTH,
+            TRANSFER_AMOUNT_HI_BIT_LENGTH,
+            PADDING_BIT_LENGTH,
+        ],
+        vec![
+            &new_source_opening,
+            &transfer_amount_opening_lo,
+            &transfer_amount_opening_hi,
+            &padding_opening,
+        ],
+    )
+    .map_err(|_| TokenError::ProofGeneration)?;
+
+    Ok((
+        equality_proof_data,
+        ciphertext_validity_proof_data,
+        range_proof_data,
+        source_decrypt_handles,
+    ))
+}

--- a/token/program-2022/src/extension/confidential_transfer/verify_proof.rs
+++ b/token/program-2022/src/extension/confidential_transfer/verify_proof.rs
@@ -1,0 +1,165 @@
+use {
+    crate::{
+        check_zk_token_proof_program_account,
+        extension::confidential_transfer::{instruction::*, *},
+        proof::decode_proof_instruction_context,
+    },
+    solana_program::{
+        account_info::AccountInfo, program_error::ProgramError,
+        sysvar::instructions::get_instruction_relative,
+    },
+};
+
+/// Verify zero-knowledge proof needed for a [ConfigureAccount] instruction and return the
+/// corresponding proof context.
+pub fn verify_configure_account_proof(
+    account_info: &AccountInfo<'_>,
+    proof_instruction_offset: i64,
+) -> Result<PubkeyValidityProofContext, ProgramError> {
+    if proof_instruction_offset == 0 {
+        // interpret `account_info` as a context state account
+        check_zk_token_proof_program_account(account_info.owner)?;
+        let context_state_account_data = account_info.data.borrow();
+        let context_state = pod_from_bytes::<ProofContextState<PubkeyValidityProofContext>>(
+            &context_state_account_data,
+        )?;
+
+        if context_state.proof_type != ProofType::PubkeyValidity.into() {
+            return Err(ProgramError::InvalidInstructionData);
+        }
+
+        Ok(context_state.proof_context)
+    } else {
+        // interpret `account_info` as a sysvar
+        let zkp_instruction = get_instruction_relative(proof_instruction_offset, account_info)?;
+        Ok(*decode_proof_instruction_context::<
+            PubkeyValidityData,
+            PubkeyValidityProofContext,
+        >(
+            ProofInstruction::VerifyPubkeyValidity, &zkp_instruction
+        )?)
+    }
+}
+
+/// Verify zero-knowledge proof needed for a [EmptyAccount] instruction and return the
+/// corresponding proof context.
+pub fn verify_empty_account_proof(
+    account_info: &AccountInfo<'_>,
+    proof_instruction_offset: i64,
+) -> Result<ZeroBalanceProofContext, ProgramError> {
+    if proof_instruction_offset == 0 {
+        // interpret `account_info` as a context state account
+        check_zk_token_proof_program_account(account_info.owner)?;
+        let context_state_account_data = account_info.data.borrow();
+        let context_state = pod_from_bytes::<ProofContextState<ZeroBalanceProofContext>>(
+            &context_state_account_data,
+        )?;
+
+        if context_state.proof_type != ProofType::ZeroBalance.into() {
+            return Err(ProgramError::InvalidInstructionData);
+        }
+
+        Ok(context_state.proof_context)
+    } else {
+        // interpret `account_info` as a sysvar
+        let zkp_instruction = get_instruction_relative(proof_instruction_offset, account_info)?;
+        Ok(*decode_proof_instruction_context::<
+            ZeroBalanceProofData,
+            ZeroBalanceProofContext,
+        >(
+            ProofInstruction::VerifyZeroBalance, &zkp_instruction
+        )?)
+    }
+}
+
+/// Verify zero-knowledge proof needed for a [Withdraw] instruction and return the
+/// corresponding proof context.
+pub fn verify_withdraw_proof(
+    account_info: &AccountInfo<'_>,
+    proof_instruction_offset: i64,
+) -> Result<WithdrawProofContext, ProgramError> {
+    if proof_instruction_offset == 0 {
+        // interpret `account_info` as a context state account
+        check_zk_token_proof_program_account(account_info.owner)?;
+        let context_state_account_data = account_info.data.borrow();
+        let context_state =
+            pod_from_bytes::<ProofContextState<WithdrawProofContext>>(&context_state_account_data)?;
+
+        if context_state.proof_type != ProofType::Withdraw.into() {
+            return Err(ProgramError::InvalidInstructionData);
+        }
+
+        Ok(context_state.proof_context)
+    } else {
+        // interpret `account_info` as a sysvar
+        let zkp_instruction = get_instruction_relative(proof_instruction_offset, account_info)?;
+        Ok(*decode_proof_instruction_context::<
+            WithdrawData,
+            WithdrawProofContext,
+        >(
+            ProofInstruction::VerifyWithdraw, &zkp_instruction
+        )?)
+    }
+}
+
+/// Verify zero-knowledge proof needed for a [Transfer] instruction without fee and return the
+/// corresponding proof context.
+pub fn verify_transfer_proof(
+    account_info: &AccountInfo<'_>,
+    proof_instruction_offset: i64,
+) -> Result<TransferProofContext, ProgramError> {
+    if proof_instruction_offset == 0 {
+        // interpret `account_info` as a context state account
+        check_zk_token_proof_program_account(account_info.owner)?;
+        let context_state_account_data = account_info.data.borrow();
+        let context_state =
+            pod_from_bytes::<ProofContextState<TransferProofContext>>(&context_state_account_data)?;
+
+        if context_state.proof_type != ProofType::Transfer.into() {
+            return Err(ProgramError::InvalidInstructionData);
+        }
+
+        Ok(context_state.proof_context)
+    } else {
+        // interpret `account_info` as a sysvar
+        let zkp_instruction = get_instruction_relative(proof_instruction_offset, account_info)?;
+        Ok(*decode_proof_instruction_context::<
+            TransferData,
+            TransferProofContext,
+        >(
+            ProofInstruction::VerifyTransfer, &zkp_instruction
+        )?)
+    }
+}
+
+/// Verify zero-knowledge proof needed for a [Transfer] instruction with fee and return the
+/// corresponding proof context.
+pub fn verify_transfer_with_fee_proof(
+    account_info: &AccountInfo<'_>,
+    proof_instruction_offset: i64,
+) -> Result<TransferWithFeeProofContext, ProgramError> {
+    if proof_instruction_offset == 0 {
+        // interpret `account_info` as a context state account
+        check_zk_token_proof_program_account(account_info.owner)?;
+        let context_state_account_data = account_info.data.borrow();
+        let context_state = pod_from_bytes::<ProofContextState<TransferWithFeeProofContext>>(
+            &context_state_account_data,
+        )?;
+
+        if context_state.proof_type != ProofType::TransferWithFee.into() {
+            return Err(ProgramError::InvalidInstructionData);
+        }
+
+        Ok(context_state.proof_context)
+    } else {
+        // interpret `account_info` as a sysvar
+        let zkp_instruction = get_instruction_relative(proof_instruction_offset, account_info)?;
+        Ok(*decode_proof_instruction_context::<
+            TransferWithFeeData,
+            TransferWithFeeProofContext,
+        >(
+            ProofInstruction::VerifyTransferWithFee,
+            &zkp_instruction,
+        )?)
+    }
+}

--- a/token/program-2022/src/extension/confidential_transfer/verify_proof.rs
+++ b/token/program-2022/src/extension/confidential_transfer/verify_proof.rs
@@ -5,21 +5,24 @@ use {
         proof::decode_proof_instruction_context,
     },
     solana_program::{
-        account_info::AccountInfo, program_error::ProgramError,
+        account_info::{next_account_info, AccountInfo},
+        program_error::ProgramError,
         sysvar::instructions::get_instruction_relative,
     },
+    std::slice::Iter,
 };
 
 /// Verify zero-knowledge proof needed for a [ConfigureAccount] instruction and return the
 /// corresponding proof context.
 pub fn verify_configure_account_proof(
-    account_info: &AccountInfo<'_>,
+    account_info_iter: &mut Iter<'_, AccountInfo<'_>>,
     proof_instruction_offset: i64,
 ) -> Result<PubkeyValidityProofContext, ProgramError> {
     if proof_instruction_offset == 0 {
         // interpret `account_info` as a context state account
-        check_zk_token_proof_program_account(account_info.owner)?;
-        let context_state_account_data = account_info.data.borrow();
+        let context_state_account_info = next_account_info(account_info_iter)?;
+        check_zk_token_proof_program_account(context_state_account_info.owner)?;
+        let context_state_account_data = context_state_account_info.data.borrow();
         let context_state = pod_from_bytes::<ProofContextState<PubkeyValidityProofContext>>(
             &context_state_account_data,
         )?;
@@ -31,7 +34,9 @@ pub fn verify_configure_account_proof(
         Ok(context_state.proof_context)
     } else {
         // interpret `account_info` as a sysvar
-        let zkp_instruction = get_instruction_relative(proof_instruction_offset, account_info)?;
+        let sysvar_account_info = next_account_info(account_info_iter)?;
+        let zkp_instruction =
+            get_instruction_relative(proof_instruction_offset, sysvar_account_info)?;
         Ok(*decode_proof_instruction_context::<
             PubkeyValidityData,
             PubkeyValidityProofContext,
@@ -44,13 +49,14 @@ pub fn verify_configure_account_proof(
 /// Verify zero-knowledge proof needed for a [EmptyAccount] instruction and return the
 /// corresponding proof context.
 pub fn verify_empty_account_proof(
-    account_info: &AccountInfo<'_>,
+    account_info_iter: &mut Iter<'_, AccountInfo<'_>>,
     proof_instruction_offset: i64,
 ) -> Result<ZeroBalanceProofContext, ProgramError> {
     if proof_instruction_offset == 0 {
         // interpret `account_info` as a context state account
-        check_zk_token_proof_program_account(account_info.owner)?;
-        let context_state_account_data = account_info.data.borrow();
+        let context_state_account_info = next_account_info(account_info_iter)?;
+        check_zk_token_proof_program_account(context_state_account_info.owner)?;
+        let context_state_account_data = context_state_account_info.data.borrow();
         let context_state = pod_from_bytes::<ProofContextState<ZeroBalanceProofContext>>(
             &context_state_account_data,
         )?;
@@ -62,7 +68,9 @@ pub fn verify_empty_account_proof(
         Ok(context_state.proof_context)
     } else {
         // interpret `account_info` as a sysvar
-        let zkp_instruction = get_instruction_relative(proof_instruction_offset, account_info)?;
+        let sysvar_account_info = next_account_info(account_info_iter)?;
+        let zkp_instruction =
+            get_instruction_relative(proof_instruction_offset, sysvar_account_info)?;
         Ok(*decode_proof_instruction_context::<
             ZeroBalanceProofData,
             ZeroBalanceProofContext,
@@ -75,13 +83,14 @@ pub fn verify_empty_account_proof(
 /// Verify zero-knowledge proof needed for a [Withdraw] instruction and return the
 /// corresponding proof context.
 pub fn verify_withdraw_proof(
-    account_info: &AccountInfo<'_>,
+    account_info_iter: &mut Iter<'_, AccountInfo<'_>>,
     proof_instruction_offset: i64,
 ) -> Result<WithdrawProofContext, ProgramError> {
     if proof_instruction_offset == 0 {
         // interpret `account_info` as a context state account
-        check_zk_token_proof_program_account(account_info.owner)?;
-        let context_state_account_data = account_info.data.borrow();
+        let context_state_account_info = next_account_info(account_info_iter)?;
+        check_zk_token_proof_program_account(context_state_account_info.owner)?;
+        let context_state_account_data = context_state_account_info.data.borrow();
         let context_state =
             pod_from_bytes::<ProofContextState<WithdrawProofContext>>(&context_state_account_data)?;
 
@@ -92,7 +101,9 @@ pub fn verify_withdraw_proof(
         Ok(context_state.proof_context)
     } else {
         // interpret `account_info` as a sysvar
-        let zkp_instruction = get_instruction_relative(proof_instruction_offset, account_info)?;
+        let sysvar_account_info = next_account_info(account_info_iter)?;
+        let zkp_instruction =
+            get_instruction_relative(proof_instruction_offset, sysvar_account_info)?;
         Ok(*decode_proof_instruction_context::<
             WithdrawData,
             WithdrawProofContext,
@@ -105,13 +116,18 @@ pub fn verify_withdraw_proof(
 /// Verify zero-knowledge proof needed for a [Transfer] instruction without fee and return the
 /// corresponding proof context.
 pub fn verify_transfer_proof(
-    account_info: &AccountInfo<'_>,
+    account_info_iter: &mut Iter<'_, AccountInfo<'_>>,
     proof_instruction_offset: i64,
+    split_proof_context_state_accounts: bool,
 ) -> Result<TransferProofContext, ProgramError> {
-    if proof_instruction_offset == 0 {
+    if proof_instruction_offset == 0 && split_proof_context_state_accounts {
+        // TODO: decode each context state accounts and check consistency between them
+        unimplemented!()
+    } else if proof_instruction_offset == 0 && !split_proof_context_state_accounts {
         // interpret `account_info` as a context state account
-        check_zk_token_proof_program_account(account_info.owner)?;
-        let context_state_account_data = account_info.data.borrow();
+        let context_state_account_info = next_account_info(account_info_iter)?;
+        check_zk_token_proof_program_account(context_state_account_info.owner)?;
+        let context_state_account_data = context_state_account_info.data.borrow();
         let context_state =
             pod_from_bytes::<ProofContextState<TransferProofContext>>(&context_state_account_data)?;
 
@@ -121,8 +137,10 @@ pub fn verify_transfer_proof(
 
         Ok(context_state.proof_context)
     } else {
-        // interpret `account_info` as a sysvar
-        let zkp_instruction = get_instruction_relative(proof_instruction_offset, account_info)?;
+        // interpret `account_info` as sysvar
+        let sysvar_account_info = next_account_info(account_info_iter)?;
+        let zkp_instruction =
+            get_instruction_relative(proof_instruction_offset, sysvar_account_info)?;
         Ok(*decode_proof_instruction_context::<
             TransferData,
             TransferProofContext,
@@ -135,13 +153,18 @@ pub fn verify_transfer_proof(
 /// Verify zero-knowledge proof needed for a [Transfer] instruction with fee and return the
 /// corresponding proof context.
 pub fn verify_transfer_with_fee_proof(
-    account_info: &AccountInfo<'_>,
+    account_info_iter: &mut Iter<'_, AccountInfo<'_>>,
     proof_instruction_offset: i64,
+    split_proof_context_state_accounts: bool,
 ) -> Result<TransferWithFeeProofContext, ProgramError> {
-    if proof_instruction_offset == 0 {
+    if proof_instruction_offset == 0 && split_proof_context_state_accounts {
+        // TODO: decode each context state accounts and check consistency between them
+        unimplemented!()
+    } else if proof_instruction_offset == 0 && !split_proof_context_state_accounts {
         // interpret `account_info` as a context state account
-        check_zk_token_proof_program_account(account_info.owner)?;
-        let context_state_account_data = account_info.data.borrow();
+        let context_state_account_info = next_account_info(account_info_iter)?;
+        check_zk_token_proof_program_account(context_state_account_info.owner)?;
+        let context_state_account_data = context_state_account_info.data.borrow();
         let context_state = pod_from_bytes::<ProofContextState<TransferWithFeeProofContext>>(
             &context_state_account_data,
         )?;
@@ -152,8 +175,10 @@ pub fn verify_transfer_with_fee_proof(
 
         Ok(context_state.proof_context)
     } else {
-        // interpret `account_info` as a sysvar
-        let zkp_instruction = get_instruction_relative(proof_instruction_offset, account_info)?;
+        // interpret `account_info` as sysvar
+        let sysvar_account_info = next_account_info(account_info_iter)?;
+        let zkp_instruction =
+            get_instruction_relative(proof_instruction_offset, sysvar_account_info)?;
         Ok(*decode_proof_instruction_context::<
             TransferWithFeeData,
             TransferWithFeeProofContext,

--- a/token/program-2022/src/extension/confidential_transfer/verify_proof.rs
+++ b/token/program-2022/src/extension/confidential_transfer/verify_proof.rs
@@ -119,6 +119,7 @@ pub fn verify_transfer_proof(
     account_info_iter: &mut Iter<'_, AccountInfo<'_>>,
     proof_instruction_offset: i64,
     split_proof_context_state_accounts: bool,
+    source_decrypt_handles: &SourceDecryptHandles,
 ) -> Result<TransferProofContextInfo, ProgramError> {
     if proof_instruction_offset == 0 && split_proof_context_state_accounts {
         let equality_proof_context_state_account_info = next_account_info(account_info_iter)?;
@@ -137,6 +138,7 @@ pub fn verify_transfer_proof(
             &equality_proof_context,
             &ciphertext_validity_proof_context,
             &range_proof_context,
+            source_decrypt_handles,
         )?)
     } else if proof_instruction_offset == 0 && !split_proof_context_state_accounts {
         // interpret `account_info` as a context state account

--- a/token/program-2022/src/extension/confidential_transfer_fee/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer_fee/instruction.rs
@@ -288,6 +288,9 @@ pub fn inner_withdraw_withheld_tokens_from_mint(
             accounts.push(AccountMeta::new_readonly(*context_state_account, false));
             0
         }
+        ProofLocation::SplitContextStateAccounts(_) => {
+            return Err(TokenError::SplitProofContextStateAccountsNotSupported.into())
+        }
     };
 
     accounts.push(AccountMeta::new_readonly(
@@ -378,6 +381,9 @@ pub fn inner_withdraw_withheld_tokens_from_accounts(
         ProofLocation::ContextStateAccount(context_state_account) => {
             accounts.push(AccountMeta::new_readonly(*context_state_account, false));
             0
+        }
+        ProofLocation::SplitContextStateAccounts(_) => {
+            return Err(TokenError::SplitProofContextStateAccountsNotSupported.into())
         }
     };
 

--- a/token/program-2022/src/proof.rs
+++ b/token/program-2022/src/proof.rs
@@ -34,4 +34,7 @@ pub enum ProofLocation<'a, T> {
     InstructionOffset(NonZeroI8, &'a T),
     /// The proof is pre-verified into a context state account.
     ContextStateAccount(&'a Pubkey),
+    /// The proof is split into multiple smaller components and are pre-verified into context state
+    /// accounts.
+    SplitContextStateAccounts(&'a [&'a Pubkey]),
 }

--- a/token/program-2022/src/serialization.rs
+++ b/token/program-2022/src/serialization.rs
@@ -194,6 +194,55 @@ pub mod elgamalpubkey_fromstr {
     }
 }
 
+/// helper to ser/deser pod::DecryptHandle values
+pub mod decrypthandle_fromstr {
+    use {
+        base64::{prelude::BASE64_STANDARD, Engine},
+        serde::{
+            de::{Error, Visitor},
+            Deserializer, Serializer,
+        },
+        solana_zk_token_sdk::zk_token_elgamal::pod::DecryptHandle,
+        std::fmt,
+    };
+
+    const DECRYPT_HANDLE_LEN: usize = 32;
+
+    /// Serialize a decrypt handle as a base64 string
+    pub fn serialize<S>(x: &DecryptHandle, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        s.serialize_str(&BASE64_STANDARD.encode(x.0))
+    }
+
+    struct DecryptHandleVisitor;
+
+    impl<'de> Visitor<'de> for DecryptHandleVisitor {
+        type Value = DecryptHandle;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a FromStr type")
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: Error,
+        {
+            let array = super::base64_to_bytes::<DECRYPT_HANDLE_LEN, E>(v)?;
+            Ok(DecryptHandle(array))
+        }
+    }
+
+    /// Deserialize a DecryptHandle from a base64 string
+    pub fn deserialize<'de, D>(d: D) -> Result<DecryptHandle, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        d.deserialize_str(DecryptHandleVisitor)
+    }
+}
+
 /// deserialization Visitors for local types
 pub mod visitors {
     use {


### PR DESCRIPTION
#### Summary of changes
- [779eaba](https://github.com/solana-labs/solana-program-library/pull/5001/commits/779eaba30d3cecb91ba2b890eca389555f8667f1): The verify proof helper function for `Transfer` is going to be a bit more involved, so I created a `verify_proof` submodule and refactored the existing `verify_..._proof`()` helper functions into this submodule.
- [7ee73cb](https://github.com/solana-labs/solana-program-library/pull/5001/commits/7ee73cb34e210440541ff63c04f82cc9e0059fea): Modified `instruction.rs` modules to support split proof context states. The most notable change here is the addition of `SplitContextStateAccounts` variant of `ProofLocation` argument type.
- [c26ec15](https://github.com/solana-labs/solana-program-library/pull/5001/commits/c26ec15c93e4c6288e934c427e2c9caf42f1ad75): I updated the `verify_..._proof()` helper functions to take in the iterator of `account_info`'s since functions like `verify_transfer_proof` need to take in variable number of context state accounts.
- [fee378f](https://github.com/solana-labs/solana-program-library/pull/5001/commits/fee378f28427a78b7321447f60e377eafaee7f3f): I refactored ciphertext extraction related helper functions into a separate submodule. The code in the `ciphertext_extraction` module should really belong to the `solana-zk-token-sdk`, so they can be removed on a future Solana upgrade.
- [4de36f4](https://github.com/solana-labs/solana-program-library/pull/5001/commits/4de36f4ed665ccd2b30bb16952c7b523423c9329): This is commit adds the main logic that checks consistency between the split context state proofs. This is unfortunately a bit technical and lower-level in terms of zkp that should really belong to the `solana-zk-token-sdk` (and hence added to `ciphertext_extraction` submodule, which could be removed in the future).
- [f0049ce](https://github.com/solana-labs/solana-program-library/pull/5001/commits/f0049cec0c16723cf2c7b0cfb2b173d82bcd89fc): So this commit relates to a really annoying mistake that I made. The split proof context accounts for equality, ciphertext validity, and range proofs do not contain all the information that is needed to reconstruct a full transfer proof context state due to some optimizations that I mistakenly made. So the "decryption handle" components under the source public key is missing from the three split proof instructions... I added these components directly as part of the transfer instruction data for now, but they should really be removed once this is fixed on the zk token sdk side.
- [78ce6eb](https://github.com/solana-labs/solana-program-library/pull/5001/commits/78ce6eb19d84979e7162a406fc271a12718d6395): Updated the token client to account for the above changes.
- [684ca38](https://github.com/solana-labs/solana-program-library/pull/5001/commits/684ca3859da5fda79a8b1ebf1c97050427de36ca): This is another unfortunately quite technical commit that should really belong to the zk token sdk. This adds logic that generates the individual split proof data from the token account info.
- [c3be8fa](https://github.com/solana-labs/solana-program-library/pull/5001/commits/c3be8faff5cc6f9ff117aee68ccaee49acdd6dd4): Added tests for the split proof
- [655bac5](https://github.com/solana-labs/solana-program-library/pull/5001/commits/655bac546574e6b3be4b26d0d83ba87d5427d678): Took me a while to figure out why the test was keep failing, but I realized that I had the conditional state flipped backwards...
- [11c9c1f](https://github.com/solana-labs/solana-program-library/pull/5001/commits/11c9c1fafb3de967b11e1ce0333ed10d6ef5fb02): Added two additional error variants to suitably describe common error when working with ciphertexts