### PR TITLE
add single pool to spl.solana.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ the Solana Mainnet Beta. Currently, this includes:
 | [name-service](https://github.com/solana-labs/solana-program-library/tree/master/name-service/program) | Not audited | [0.3.0](https://github.com/solana-labs/solana-program-library/releases/tag/name-service-v0.3.0) |
 | [memo](https://github.com/solana-labs/solana-program-library/tree/master/memo/program) | Not audited | [3.0.0](https://github.com/solana-labs/solana-program-library/releases/tag/memo-v3.0.0) |
 
+In addition, one program is planned for deployment to Solana Mainnet Beta:
+| Program | Last Audit Date | Version |
+| --- | --- | --- |
+| [single-pool](https://github.com/solana-labs/solana-program-library/tree/master/single-pool/program) | 2023-08-08 | n/a |
+
 All other programs may be updated from time to time. These programs are not
 audited, so fork and deploy them at your own risk. Here is the full list of
 unaudited programs:

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -34,6 +34,7 @@ module.exports = {
         "stake-pool/cli",
       ],
     },
+    "single-pool",
     "feature-proposal",
     {
       type: "category",

--- a/docs/src/single-pool.md
+++ b/docs/src/single-pool.md
@@ -1,0 +1,29 @@
+---
+title: Single-Validator Stake Pool
+---
+
+Trustless liquid staking for all Solana validators.
+
+## Overview
+
+The single-validator stake pool program is an upcoming SPL program that enables liquid staking with zero fees, no counterparty, and 100% capital efficiency.
+
+The program defines a canonical pool for every vote account, which can be initialized permissionlessly, and mints tokens in exchange for stake delegated to its designated validator.
+
+The program is a stripped-down adaptation of the existing multi-validator stake pool program, with approximately 80% less code, to minimize execution risk.
+
+## Source
+
+The Single Pool Program's source is available on
+[GitHub](https://github.com/solana-labs/solana-program-library/tree/master/single-pool/program).
+
+## Security Audits
+
+The Single Pool Program has received two audits to ensure total safety of funds:
+
+* Neodyme (2023-08-08)
+    - Review commit hash [`735d729`](https://github.com/solana-labs/solana-program-library/commit/735d7292e35d35101750a4452d2647bdbf848e8b)
+    - Final report https://github.com/solana-labs/security-audits/blob/master/spl/NeodymeSinglePoolAudit-2023-08-08.pdf
+* Zellic (2023-06-21)
+    - Review commit hash [`9dbdc3b`](https://github.com/solana-labs/solana-program-library/commit/9dbdc3bdae31dda1dcb35346aab2d879deecf194)
+    - Final report https://github.com/solana-labs/security-audits/blob/master/spl/ZellicSinglePoolAudit-2023-06-21.pdf


### PR DESCRIPTION
urls are correct after #5010 and https://github.com/solana-labs/security-audits/pull/13 land. also opening an issue for todos which can only be done after crates.io/npm releases

incidentally i dont know how to ensure this deploys after the pr is merged