### PR TITLE
ci: Add dalek advisory to ignore list

### DIFF
--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -16,9 +16,9 @@ cargo_audit_ignores=(
   # https://github.com/solana-labs/solana/issues/29586
   --ignore RUSTSEC-2023-0001
 
-  # openssl: `openssl` `X509VerifyParamRef::set_host` buffer over-read
+  # ed25519-dalek: Double Public Key Signing Function Oracle Attack
   #
-  # Remove once SPL upgrades to Solana v1.16.2 or greater
-  --ignore RUSTSEC-2023-0044
+  # Remove once SPL upgrades to Solana v1.17 or greater
+  --ignore RUSTSEC-2022-0093
 )
 cargo +"$rust_stable" audit "${cargo_audit_ignores[@]}"


### PR DESCRIPTION
#### Problem

CI is failing because of the Rust security advisory on ed25519-dalek.

#### Solution

Since the fix requires a major version bump on ed25519-dalek, and SPL picks up these crates from the Solana SDK, we can't just fix it.

Instead, ignore the vulnerability until SPL updates to 1.17.

While I was at it, I noticed the openssl vulernability no longer applied, so I removed it from the list