### PR TITLE
cli: Remove dependencies on unrequired programs in tests

### DIFF
--- a/single-pool/cli/tests/test.rs
+++ b/single-pool/cli/tests/test.rs
@@ -113,18 +113,6 @@ async fn start_validator() -> (TestValidator, Keypair) {
 
     test_validator_genesis.add_upgradeable_programs_with_path(&[
         UpgradeableProgramInfo {
-            program_id: spl_token::id(),
-            loader: bpf_loader_upgradeable::id(),
-            program_path: PathBuf::from("../../target/deploy/spl_token.so"),
-            upgrade_authority: Pubkey::default(),
-        },
-        UpgradeableProgramInfo {
-            program_id: spl_associated_token_account::id(),
-            loader: bpf_loader_upgradeable::id(),
-            program_path: PathBuf::from("../../target/deploy/spl_associated_token_account.so"),
-            upgrade_authority: Pubkey::default(),
-        },
-        UpgradeableProgramInfo {
             program_id: Pubkey::from_str("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s").unwrap(),
             loader: bpf_loader_upgradeable::id(),
             program_path: PathBuf::from("../program/tests/fixtures/mpl_token_metadata.so"),

--- a/token-upgrade/cli/src/main.rs
+++ b/token-upgrade/cli/src/main.rs
@@ -504,32 +504,12 @@ mod test {
     async fn new_validator_for_test() -> (TestValidator, Keypair) {
         solana_logger::setup();
         let mut test_validator_genesis = TestValidatorGenesis::default();
-        test_validator_genesis.add_upgradeable_programs_with_path(&[
-            UpgradeableProgramInfo {
-                program_id: spl_token::id(),
-                loader: bpf_loader_upgradeable::id(),
-                program_path: PathBuf::from("../../target/deploy/spl_token.so"),
-                upgrade_authority: Pubkey::new_unique(),
-            },
-            UpgradeableProgramInfo {
-                program_id: spl_associated_token_account::id(),
-                loader: bpf_loader_upgradeable::id(),
-                program_path: PathBuf::from("../../target/deploy/spl_associated_token_account.so"),
-                upgrade_authority: Pubkey::new_unique(),
-            },
-            UpgradeableProgramInfo {
-                program_id: spl_token_2022::id(),
-                loader: bpf_loader_upgradeable::id(),
-                program_path: PathBuf::from("../../target/deploy/spl_token_2022.so"),
-                upgrade_authority: Pubkey::new_unique(),
-            },
-            UpgradeableProgramInfo {
-                program_id: spl_token_upgrade::id(),
-                loader: bpf_loader_upgradeable::id(),
-                program_path: PathBuf::from("../../target/deploy/spl_token_upgrade.so"),
-                upgrade_authority: Pubkey::new_unique(),
-            },
-        ]);
+        test_validator_genesis.add_upgradeable_programs_with_path(&[UpgradeableProgramInfo {
+            program_id: spl_token_upgrade::id(),
+            loader: bpf_loader_upgradeable::id(),
+            program_path: PathBuf::from("../../target/deploy/spl_token_upgrade.so"),
+            upgrade_authority: Pubkey::new_unique(),
+        }]);
         test_validator_genesis.start_async().await
     }
 


### PR DESCRIPTION
#### Problem

In https://github.com/solana-labs/solana/pull/32677, we need to also build programs to test the CLIs, but the token-upgrade and single-pool CLIs don't actually need the built versions of the token / token-2022 / ATA programs, and can use the default ones provided by `SolanaTestValidator`.

#### Solution

Remove those dependencies in the tests.