### PR TITLE
stake-pool: Update minimum reserve balance to 0

### DIFF
--- a/stake-pool/js/src/index.ts
+++ b/stake-pool/js/src/index.ts
@@ -934,8 +934,9 @@ export async function stakePoolInfo(connection: Connection, stakePoolAddress: Pu
     stakePoolAddress,
   );
 
-  const minimumReserveStakeBalance =
-    (await connection.getMinimumBalanceForRentExemption(StakeProgram.space)) + 1;
+  const minimumReserveStakeBalance = await connection.getMinimumBalanceForRentExemption(
+    StakeProgram.space,
+  );
 
   const stakeAccounts = await Promise.all(
     validatorList.account.data.validators.map(async (validator) => {

--- a/stake-pool/js/src/utils/stake.ts
+++ b/stake-pool/js/src/utils/stake.ts
@@ -115,7 +115,7 @@ export async function prepareWithdrawAccounts(
   accounts = accounts.sort(compareFn ? compareFn : (a, b) => b.lamports - a.lamports);
 
   const reserveStake = await connection.getAccountInfo(stakePool.reserveStake);
-  const reserveStakeBalance = (reserveStake?.lamports ?? 0) - minBalanceForRentExemption - 1;
+  const reserveStakeBalance = (reserveStake?.lamports ?? 0) - minBalanceForRentExemption;
   if (reserveStakeBalance > 0) {
     accounts.push({
       type: 'reserve',

--- a/stake-pool/program/src/lib.rs
+++ b/stake-pool/program/src/lib.rs
@@ -37,9 +37,7 @@ const EPHEMERAL_STAKE_SEED_PREFIX: &[u8] = b"ephemeral";
 pub const MINIMUM_ACTIVE_STAKE: u64 = 1_000_000;
 
 /// Minimum amount of lamports in the reserve
-/// NOTE: This can be changed to 0 once the `stake_allow_zero_undelegated_amount`
-/// feature is enabled on all clusters
-pub const MINIMUM_RESERVE_LAMPORTS: u64 = 1;
+pub const MINIMUM_RESERVE_LAMPORTS: u64 = 0;
 
 /// Maximum amount of validator stake accounts to update per
 /// `UpdateValidatorListBalance` instruction, based on compute limits

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -1619,13 +1619,13 @@ impl Processor {
         if reserve_stake_account_info
             .lamports()
             .saturating_sub(total_lamports)
-            <= stake_rent
+            < stake_rent
         {
             let max_split_amount = reserve_stake_account_info
                 .lamports()
                 .saturating_sub(stake_rent.saturating_mul(2));
             msg!(
-                "Reserve stake does not have enough lamports for increase, must be less than {}, {} requested",
+                "Reserve stake does not have enough lamports for increase, maximum amount {}, {} requested",
                 max_split_amount,
                 lamports
             );

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -676,7 +676,7 @@ pub async fn create_blank_stake_account(
     stake: &Keypair,
 ) -> u64 {
     let rent = banks_client.get_rent().await.unwrap();
-    let lamports = rent.minimum_balance(std::mem::size_of::<stake::state::StakeState>()) + 1;
+    let lamports = rent.minimum_balance(std::mem::size_of::<stake::state::StakeState>());
 
     let transaction = Transaction::new_signed_with_payer(
         &[system_instruction::create_account(

--- a/stake-pool/program/tests/withdraw_edge_cases.rs
+++ b/stake-pool/program/tests/withdraw_edge_cases.rs
@@ -11,7 +11,7 @@ use {
     },
     solana_program_test::*,
     solana_sdk::{signature::Signer, transaction::TransactionError},
-    spl_stake_pool::{error::StakePoolError, instruction, state, MINIMUM_RESERVE_LAMPORTS},
+    spl_stake_pool::{error::StakePoolError, instruction, state},
     test_case::test_case,
 };
 
@@ -205,7 +205,7 @@ async fn success_remove_validator(multiple: u64) {
         get_account(&mut context.banks_client, &user_stake_recipient.pubkey()).await;
     assert_eq!(
         user_stake_recipient_account.lamports,
-        remaining_lamports + stake_rent + 1
+        remaining_lamports + stake_rent
     );
 
     // Check that cleanup happens correctly
@@ -398,7 +398,7 @@ async fn success_with_reserve() {
     let stake_state = deserialize::<stake::state::StakeState>(&reserve_stake_account.data).unwrap();
     let meta = stake_state.meta().unwrap();
     assert_eq!(
-        MINIMUM_RESERVE_LAMPORTS + meta.rent_exempt_reserve + withdrawal_fee + deposit_fee,
+        meta.rent_exempt_reserve + withdrawal_fee + deposit_fee,
         reserve_stake_account.lamports
     );
 
@@ -407,9 +407,7 @@ async fn success_with_reserve() {
         get_account(&mut context.banks_client, &user_stake_recipient.pubkey()).await;
     assert_eq!(
         user_stake_recipient_account.lamports,
-        MINIMUM_RESERVE_LAMPORTS + deposit_info.stake_lamports + stake_rent * 2
-            - withdrawal_fee
-            - deposit_fee
+        deposit_info.stake_lamports + stake_rent * 2 - withdrawal_fee - deposit_fee
     );
 }
 

--- a/stake-pool/py/stake_pool/constants.py
+++ b/stake-pool/py/stake_pool/constants.py
@@ -11,7 +11,7 @@ STAKE_POOL_PROGRAM_ID: PublicKey = PublicKey("SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41
 MAX_VALIDATORS_TO_UPDATE: int = 5
 """Maximum number of validators to update during UpdateValidatorListBalance."""
 
-MINIMUM_RESERVE_LAMPORTS: int = 1
+MINIMUM_RESERVE_LAMPORTS: int = 0
 """Minimum balance required in the stake pool reserve"""
 
 MINIMUM_ACTIVE_STAKE: int = MINIMUM_DELEGATION


### PR DESCRIPTION
#### Problem

The `MINIMUM_RESERVE_BALANCE` in the stake pool program is `1`, which is no longer the case after https://github.com/solana-labs/solana/issues/24669 was enabled on mainnet.

#### Solution

Update `MINIMUM_RESERVE_BALANCE` to `0`. There was one check during increase that needed to be changed too from `<=` to `<`, and then a few places in the testing where we added an additional lamport to make stake accounts "valid".