### PR TITLE
[token-metadata] Add serde support for token metadata instructions

### DIFF
--- a/.github/workflows/pull-request-token-metadata.yml
+++ b/.github/workflows/pull-request-token-metadata.yml
@@ -58,5 +58,12 @@ jobs:
           ./ci/install-program-deps.sh
           echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
 
+      - name: Test token-metadata with "serde" activated
+        run: |
+          cargo test \
+            --manifest-path=token-metadata/interface/Cargo.toml \
+            --features serde-traits \
+            -- --nocapture
+
       - name: Build and test example
         run: ./ci/cargo-test-sbf.sh token-metadata/example

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7136,6 +7136,8 @@ name = "spl-token-metadata-interface"
 version = "0.1.0"
 dependencies = [
  "borsh 0.10.3",
+ "serde",
+ "serde_json",
  "solana-program",
  "spl-discriminator",
  "spl-program-error",

--- a/token-metadata/interface/Cargo.toml
+++ b/token-metadata/interface/Cargo.toml
@@ -7,12 +7,19 @@ repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
 edition = "2021"
 
+[features]
+serde-traits = ["serde"]
+
 [dependencies]
 borsh = "0.10"
 solana-program = "1.16.3"
 spl-discriminator = { version = "0.1.0" , path = "../../libraries/discriminator" }
 spl-program-error = { version = "0.2.0" , path = "../../libraries/program-error" }
 spl-type-length-value = { version = "0.2.0", path = "../../libraries/type-length-value" }
+serde = { version = "1.0.183", optional = true }
+
+[dev-dependencies]
+serde_json = "1.0.105"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/token-metadata/interface/src/instruction.rs
+++ b/token-metadata/interface/src/instruction.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 
 /// Initialization instruction data
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize, SplDiscriminate)]
 #[discriminator_hash_input("spl_token_metadata_interface:initialize_account")]
 pub struct Initialize {
@@ -29,6 +30,7 @@ pub struct Initialize {
 
 /// Update field instruction data
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize, SplDiscriminate)]
 #[discriminator_hash_input("spl_token_metadata_interface:updating_field")]
 pub struct UpdateField {
@@ -40,6 +42,7 @@ pub struct UpdateField {
 
 /// Remove key instruction data
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize, SplDiscriminate)]
 #[discriminator_hash_input("spl_token_metadata_interface:remove_key_ix")]
 pub struct RemoveKey {
@@ -53,6 +56,7 @@ pub struct RemoveKey {
 /// Update authority instruction data
 #[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize, SplDiscriminate)]
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[discriminator_hash_input("spl_token_metadata_interface:update_the_authority")]
 pub struct UpdateAuthority {
     /// New authority for the token metadata, or unset if `None`
@@ -61,6 +65,7 @@ pub struct UpdateAuthority {
 
 /// Instruction data for Emit
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize, SplDiscriminate)]
 #[discriminator_hash_input("spl_token_metadata_interface:emitter")]
 pub struct Emit {
@@ -72,6 +77,7 @@ pub struct Emit {
 
 /// All instructions that must be implemented in the token-metadata interface
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum TokenMetadataInstruction {
     /// Initializes a TLV entry with the basic token-metadata fields.
@@ -408,7 +414,7 @@ mod test {
         let ix = TokenMetadataInstruction::Initialize(data);
         let serialized = serde_json::to_string(&ix).unwrap();
         let serialized_expected =
-            "{\"Initialize\":{\"name\":\"Token Name\",\"symbol\":\"TST\",\"uri\":\"uri.test\"}}";
+            "{\"initialize\":{\"name\":\"Token Name\",\"symbol\":\"TST\",\"uri\":\"uri.test\"}}";
         assert_eq!(&serialized, serialized_expected);
 
         let deserialized = serde_json::from_str::<TokenMetadataInstruction>(&serialized).unwrap();
@@ -425,7 +431,7 @@ mod test {
         let ix = TokenMetadataInstruction::UpdateField(data);
         let serialized = serde_json::to_string(&ix).unwrap();
         let serialized_expected =
-            "{\"UpdateField\":{\"field\":{\"Key\":\"MyField\"},\"value\":\"my field value\"}}";
+            "{\"updateField\":{\"field\":{\"key\":\"MyField\"},\"value\":\"my field value\"}}";
         assert_eq!(&serialized, serialized_expected);
 
         let deserialized = serde_json::from_str::<TokenMetadataInstruction>(&serialized).unwrap();
@@ -441,7 +447,7 @@ mod test {
         };
         let ix = TokenMetadataInstruction::RemoveKey(data);
         let serialized = serde_json::to_string(&ix).unwrap();
-        let serialized_expected = "{\"RemoveKey\":{\"idempotent\":true,\"key\":\"MyTestField\"}}";
+        let serialized_expected = "{\"removeKey\":{\"idempotent\":true,\"key\":\"MyTestField\"}}";
         assert_eq!(&serialized, serialized_expected);
 
         let deserialized = serde_json::from_str::<TokenMetadataInstruction>(&serialized).unwrap();
@@ -459,7 +465,7 @@ mod test {
         };
         let ix = TokenMetadataInstruction::UpdateAuthority(data);
         let serialized = serde_json::to_string(&ix).unwrap();
-        let serialized_expected = "{\"UpdateAuthority\":{\"new_authority\":\"4uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJziofM\"}}";
+        let serialized_expected = "{\"updateAuthority\":{\"newAuthority\":\"4uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJziofM\"}}";
         assert_eq!(&serialized, serialized_expected);
 
         let deserialized = serde_json::from_str::<TokenMetadataInstruction>(&serialized).unwrap();
@@ -474,7 +480,7 @@ mod test {
         };
         let ix = TokenMetadataInstruction::UpdateAuthority(data);
         let serialized = serde_json::to_string(&ix).unwrap();
-        let serialized_expected = "{\"UpdateAuthority\":{\"new_authority\":null}}";
+        let serialized_expected = "{\"updateAuthority\":{\"newAuthority\":null}}";
         assert_eq!(&serialized, serialized_expected);
 
         let deserialized = serde_json::from_str::<TokenMetadataInstruction>(&serialized).unwrap();
@@ -490,7 +496,7 @@ mod test {
         };
         let ix = TokenMetadataInstruction::Emit(data);
         let serialized = serde_json::to_string(&ix).unwrap();
-        let serialized_expected = "{\"Emit\":{\"start\":null,\"end\":10}}";
+        let serialized_expected = "{\"emit\":{\"start\":null,\"end\":10}}";
         assert_eq!(&serialized, serialized_expected);
 
         let deserialized = serde_json::from_str::<TokenMetadataInstruction>(&serialized).unwrap();

--- a/token-metadata/interface/src/instruction.rs
+++ b/token-metadata/interface/src/instruction.rs
@@ -11,7 +11,11 @@ use {
     spl_discriminator::{discriminator::ArrayDiscriminator, SplDiscriminate},
 };
 
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
+
 /// Initialization instruction data
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize, SplDiscriminate)]
 #[discriminator_hash_input("spl_token_metadata_interface:initialize_account")]
 pub struct Initialize {
@@ -24,6 +28,7 @@ pub struct Initialize {
 }
 
 /// Update field instruction data
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize, SplDiscriminate)]
 #[discriminator_hash_input("spl_token_metadata_interface:updating_field")]
 pub struct UpdateField {
@@ -34,6 +39,7 @@ pub struct UpdateField {
 }
 
 /// Remove key instruction data
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize, SplDiscriminate)]
 #[discriminator_hash_input("spl_token_metadata_interface:remove_key_ix")]
 pub struct RemoveKey {
@@ -46,6 +52,7 @@ pub struct RemoveKey {
 
 /// Update authority instruction data
 #[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize, SplDiscriminate)]
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
 #[discriminator_hash_input("spl_token_metadata_interface:update_the_authority")]
 pub struct UpdateAuthority {
     /// New authority for the token metadata, or unset if `None`
@@ -53,6 +60,7 @@ pub struct UpdateAuthority {
 }
 
 /// Instruction data for Emit
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize, SplDiscriminate)]
 #[discriminator_hash_input("spl_token_metadata_interface:emitter")]
 pub struct Emit {
@@ -63,6 +71,7 @@ pub struct Emit {
 }
 
 /// All instructions that must be implemented in the token-metadata interface
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum TokenMetadataInstruction {
     /// Initializes a TLV entry with the basic token-metadata fields.
@@ -306,6 +315,9 @@ pub fn emit(
 mod test {
     use {super::*, crate::NAMESPACE, solana_program::hash};
 
+    #[cfg(feature = "serde-traits")]
+    use std::str::FromStr;
+
     fn check_pack_unpack<T: BorshSerialize>(
         instruction: TokenMetadataInstruction,
         discriminator: &[u8],
@@ -383,5 +395,105 @@ mod test {
         let preimage = hash::hashv(&[format!("{NAMESPACE}:emitter").as_bytes()]);
         let discriminator = &preimage.as_ref()[..ArrayDiscriminator::LENGTH];
         check_pack_unpack(check, discriminator, data);
+    }
+
+    #[cfg(feature = "serde-traits")]
+    #[test]
+    fn initialize_serde() {
+        let data = Initialize {
+            name: "Token Name".to_string(),
+            symbol: "TST".to_string(),
+            uri: "uri.test".to_string(),
+        };
+        let ix = TokenMetadataInstruction::Initialize(data);
+        let serialized = serde_json::to_string(&ix).unwrap();
+        let serialized_expected =
+            "{\"Initialize\":{\"name\":\"Token Name\",\"symbol\":\"TST\",\"uri\":\"uri.test\"}}";
+        assert_eq!(&serialized, serialized_expected);
+
+        let deserialized = serde_json::from_str::<TokenMetadataInstruction>(&serialized).unwrap();
+        assert_eq!(ix, deserialized);
+    }
+
+    #[cfg(feature = "serde-traits")]
+    #[test]
+    fn update_field_serde() {
+        let data = UpdateField {
+            field: Field::Key("MyField".to_string()),
+            value: "my field value".to_string(),
+        };
+        let ix = TokenMetadataInstruction::UpdateField(data);
+        let serialized = serde_json::to_string(&ix).unwrap();
+        let serialized_expected =
+            "{\"UpdateField\":{\"field\":{\"Key\":\"MyField\"},\"value\":\"my field value\"}}";
+        assert_eq!(&serialized, serialized_expected);
+
+        let deserialized = serde_json::from_str::<TokenMetadataInstruction>(&serialized).unwrap();
+        assert_eq!(ix, deserialized);
+    }
+
+    #[cfg(feature = "serde-traits")]
+    #[test]
+    fn remove_key_serde() {
+        let data = RemoveKey {
+            key: "MyTestField".to_string(),
+            idempotent: true,
+        };
+        let ix = TokenMetadataInstruction::RemoveKey(data);
+        let serialized = serde_json::to_string(&ix).unwrap();
+        let serialized_expected = "{\"RemoveKey\":{\"idempotent\":true,\"key\":\"MyTestField\"}}";
+        assert_eq!(&serialized, serialized_expected);
+
+        let deserialized = serde_json::from_str::<TokenMetadataInstruction>(&serialized).unwrap();
+        assert_eq!(ix, deserialized);
+    }
+
+    #[cfg(feature = "serde-traits")]
+    #[test]
+    fn update_authority_serde() {
+        let update_authority_option: Option<Pubkey> =
+            Some(Pubkey::from_str("4uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJziofM").unwrap());
+        let update_authority: OptionalNonZeroPubkey = update_authority_option.try_into().unwrap();
+        let data = UpdateAuthority {
+            new_authority: update_authority,
+        };
+        let ix = TokenMetadataInstruction::UpdateAuthority(data);
+        let serialized = serde_json::to_string(&ix).unwrap();
+        let serialized_expected = "{\"UpdateAuthority\":{\"new_authority\":\"4uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJziofM\"}}";
+        assert_eq!(&serialized, serialized_expected);
+
+        let deserialized = serde_json::from_str::<TokenMetadataInstruction>(&serialized).unwrap();
+        assert_eq!(ix, deserialized);
+    }
+
+    #[cfg(feature = "serde-traits")]
+    #[test]
+    fn update_authority_serde_with_none() {
+        let data = UpdateAuthority {
+            new_authority: OptionalNonZeroPubkey::default(),
+        };
+        let ix = TokenMetadataInstruction::UpdateAuthority(data);
+        let serialized = serde_json::to_string(&ix).unwrap();
+        let serialized_expected = "{\"UpdateAuthority\":{\"new_authority\":null}}";
+        assert_eq!(&serialized, serialized_expected);
+
+        let deserialized = serde_json::from_str::<TokenMetadataInstruction>(&serialized).unwrap();
+        assert_eq!(ix, deserialized);
+    }
+
+    #[cfg(feature = "serde-traits")]
+    #[test]
+    fn emit_serde() {
+        let data = Emit {
+            start: None,
+            end: Some(10),
+        };
+        let ix = TokenMetadataInstruction::Emit(data);
+        let serialized = serde_json::to_string(&ix).unwrap();
+        let serialized_expected = "{\"Emit\":{\"start\":null,\"end\":10}}";
+        assert_eq!(&serialized, serialized_expected);
+
+        let deserialized = serde_json::from_str::<TokenMetadataInstruction>(&serialized).unwrap();
+        assert_eq!(ix, deserialized);
     }
 }

--- a/token-metadata/interface/src/state.rs
+++ b/token-metadata/interface/src/state.rs
@@ -201,6 +201,7 @@ impl VariableLenPack for TokenMetadata {
 
 /// Fields in the metadata account, used for updating
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize)]
 pub enum Field {
     /// The name field, corresponding to `TokenMetadata.name`


### PR DESCRIPTION
Issue #3325

Adds serde support for instructions from `token-metadata`. Continuation of #4772

Notes:
* Added `serde-traits` feature flag to `token-metadata`, all serde code is behind this flag
* Noticed `OptionalNonZeroPubkey` is virtually identical to the type with the same name from `token-2022` so I basically copy/pasted the de/serialization logic from there. Let me know if a different approach is preferred.

@joncinque @buffalojoec 