### PR TITLE
single pool: minor cleanups

### DIFF
--- a/single-pool/cli/src/main.rs
+++ b/single-pool/cli/src/main.rs
@@ -653,8 +653,8 @@ async fn command_create_stake(config: &Config, command_config: CreateStakeCli) -
     }
 
     let instructions = single_pool::instruction::create_and_delegate_user_stake(
+        &single_pool::id(),
         &vote_account_address,
-        &pool_address,
         &stake_authority_address,
         &quarantine::get_rent(config).await?,
         command_config.lamports,

--- a/single-pool/program/src/instruction.rs
+++ b/single-pool/program/src/instruction.rs
@@ -329,18 +329,19 @@ pub fn withdraw_stake(
 /// Uses a fixed address for each wallet and vote account combination to make it easier to find for deposits.
 /// This is an optional helper function; deposits can come from any owned stake account without lockup.
 pub fn create_and_delegate_user_stake(
+    program_id: &Pubkey,
     vote_account_address: &Pubkey,
-    pool_address: &Pubkey,
     user_wallet: &Pubkey,
     rent: &Rent,
     stake_amount: u64,
 ) -> Vec<Instruction> {
+    let pool_address = find_pool_address(program_id, vote_account_address);
     let stake_space = std::mem::size_of::<stake::state::StakeState>();
     let lamports = rent
         .minimum_balance(stake_space)
         .saturating_add(stake_amount);
     let (deposit_address, deposit_seed) =
-        find_default_deposit_account_address_and_seed(pool_address, user_wallet);
+        find_default_deposit_account_address_and_seed(&pool_address, user_wallet);
 
     stake::instruction::create_account_with_seed_and_delegate_stake(
         user_wallet,

--- a/single-pool/program/src/lib.rs
+++ b/single-pool/program/src/lib.rs
@@ -32,45 +32,46 @@ const VOTE_STATE_DISCRIMINATOR_END: usize = 4;
 const VOTE_STATE_AUTHORIZED_WITHDRAWER_START: usize = 36;
 const VOTE_STATE_AUTHORIZED_WITHDRAWER_END: usize = 68;
 
-fn find_address_and_bump(
-    program_id: &Pubkey,
-    pool_address: &Pubkey,
-    prefix: &[u8],
-) -> (Pubkey, u8) {
-    Pubkey::find_program_address(&[prefix, pool_address.as_ref()], program_id)
-}
-
 fn find_pool_address_and_bump(program_id: &Pubkey, vote_account_address: &Pubkey) -> (Pubkey, u8) {
-    find_address_and_bump(program_id, vote_account_address, POOL_PREFIX)
+    Pubkey::find_program_address(&[POOL_PREFIX, vote_account_address.as_ref()], program_id)
 }
 
 fn find_pool_stake_address_and_bump(program_id: &Pubkey, pool_address: &Pubkey) -> (Pubkey, u8) {
-    find_address_and_bump(program_id, pool_address, POOL_STAKE_PREFIX)
+    Pubkey::find_program_address(&[POOL_STAKE_PREFIX, pool_address.as_ref()], program_id)
 }
 
 fn find_pool_mint_address_and_bump(program_id: &Pubkey, pool_address: &Pubkey) -> (Pubkey, u8) {
-    find_address_and_bump(program_id, pool_address, POOL_MINT_PREFIX)
+    Pubkey::find_program_address(&[POOL_MINT_PREFIX, pool_address.as_ref()], program_id)
 }
 
 fn find_pool_stake_authority_address_and_bump(
     program_id: &Pubkey,
     pool_address: &Pubkey,
 ) -> (Pubkey, u8) {
-    find_address_and_bump(program_id, pool_address, POOL_STAKE_AUTHORITY_PREFIX)
+    Pubkey::find_program_address(
+        &[POOL_STAKE_AUTHORITY_PREFIX, pool_address.as_ref()],
+        program_id,
+    )
 }
 
 fn find_pool_mint_authority_address_and_bump(
     program_id: &Pubkey,
     pool_address: &Pubkey,
 ) -> (Pubkey, u8) {
-    find_address_and_bump(program_id, pool_address, POOL_MINT_AUTHORITY_PREFIX)
+    Pubkey::find_program_address(
+        &[POOL_MINT_AUTHORITY_PREFIX, pool_address.as_ref()],
+        program_id,
+    )
 }
 
 fn find_pool_mpl_authority_address_and_bump(
     program_id: &Pubkey,
     pool_address: &Pubkey,
 ) -> (Pubkey, u8) {
-    find_address_and_bump(program_id, pool_address, POOL_MPL_AUTHORITY_PREFIX)
+    Pubkey::find_program_address(
+        &[POOL_MPL_AUTHORITY_PREFIX, pool_address.as_ref()],
+        program_id,
+    )
 }
 
 fn find_default_deposit_account_address_and_seed(

--- a/single-pool/program/tests/deposit.rs
+++ b/single-pool/program/tests/deposit.rs
@@ -169,8 +169,8 @@ async fn success_with_seed(activate: bool) {
         find_default_deposit_account_address(&accounts.pool, &accounts.alice.pubkey());
 
     let instructions = instruction::create_and_delegate_user_stake(
+        &id(),
         &accounts.vote_account.pubkey(),
-        &accounts.pool,
         &accounts.alice.pubkey(),
         &rent,
         minimum_stake,


### PR DESCRIPTION
when implementing `create_and_delegate_user_stake` in js i realized providing both vote and pool was weird (a result of hastiliy adding the vote param when i realized i needed it), so i normalized it to have the same interface as all the other functions

also neodyme pointed out `find_address_and_bump` is clever for no reason, and yea, i forget why i did this originally