### PR TITLE
 token-cli: reverse logic for --recipient-is-ata-owner

### DIFF
--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -1145,7 +1145,6 @@ async fn command_transfer(
     fund_recipient: bool,
     mint_decimals: Option<u8>,
     no_recipient_is_ata_owner: bool,
-    recipient_is_ata_owner: bool,
     use_unchecked_instruction: bool,
     ui_fee: Option<f64>,
     memo: Option<String>,
@@ -1232,9 +1231,6 @@ async fn command_transfer(
     let maybe_fee =
         ui_fee.map(|ui_amount| spl_token::ui_amount_to_amount(ui_amount, mint_info.decimals));
 
-    if recipient_is_ata_owner {
-        println_display(config, format!("recipient-is-ata-owner is now the default behavior. The option has been deprecated and will be removed in a future release."));
-    };
 
     // determine whether recipient is a token account or an expected owner of one
     let recipient_is_token_account = if !config.sign_only {
@@ -3150,6 +3146,7 @@ fn app<'a, 'b>(
                         .long("recipient-is-ata-owner")
                         .takes_value(false)
                         .hidden(true)
+                        .conflicts_with("no_recipient_is_ata_owner")
                         .requires("sign_only")
                         .help("recipient-is-ata-owner is now the default behavior. The option has been deprecated and will be removed in a future release."),
                 )
@@ -4256,8 +4253,11 @@ async fn process_command<'a>(
             let allow_unfunded_recipient = arg_matches.is_present("allow_empty_recipient")
                 || arg_matches.is_present("allow_unfunded_recipient");
 
-            let no_recipient_is_ata_owner = arg_matches.is_present("no_recipient_is_ata_owner");
             let recipient_is_ata_owner = arg_matches.is_present("recipient_is_ata_owner");
+            let no_recipient_is_ata_owner = arg_matches.is_present("no_recipient_is_ata_owner") || !arg_matches.is_present("recipient_is_ata_owner");
+            if arg_matches.is_present("recipient_is_ata_owner") {
+                println_display(config, format!("recipient-is-ata-owner is now the default behavior. The option has been deprecated and will be removed in a future release."));
+            }
             let use_unchecked_instruction = arg_matches.is_present("use_unchecked_instruction");
             let expected_fee = value_of::<f64>(arg_matches, "expected_fee");
             let memo = value_t!(arg_matches, "memo", String).ok();
@@ -4278,7 +4278,6 @@ async fn process_command<'a>(
                 fund_recipient,
                 mint_decimals,
                 no_recipient_is_ata_owner,
-                recipient_is_ata_owner,
                 use_unchecked_instruction,
                 expected_fee,
                 memo,

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -1145,6 +1145,7 @@ async fn command_transfer(
     fund_recipient: bool,
     mint_decimals: Option<u8>,
     no_recipient_is_ata_owner: bool,
+    recipient_is_ata_owner: bool,
     use_unchecked_instruction: bool,
     ui_fee: Option<f64>,
     memo: Option<String>,
@@ -1230,6 +1231,10 @@ async fn command_transfer(
 
     let maybe_fee =
         ui_fee.map(|ui_amount| spl_token::ui_amount_to_amount(ui_amount, mint_info.decimals));
+
+    if recipient_is_ata_owner {
+        println_display(config, format!("recipient-is-ata-owner is now the default behavior. The option has been deprecated and will be removed in a future release."));
+    }
 
     // determine whether recipient is a token account or an expected owner of one
     let recipient_is_token_account = if !config.sign_only {
@@ -3141,6 +3146,14 @@ fn app<'a, 'b>(
                         .help("In sign-only mode, specifies that the recipient is the owner of the associated token account rather than an actual token account"),
                 )
                 .arg(
+                    Arg::with_name("recipient_is_ata_owner")
+                        .long("recipient-is-ata-owner")
+                        .takes_value(false)
+                        .hidden(true)
+                        .requires("sign_only")
+                        .help("recipient-is-ata-owner is now the default behavior. The option has been deprecated and will be removed in a future release."),
+                )
+                .arg(
                     Arg::with_name("expected_fee")
                         .long("expected-fee")
                         .validator(is_amount)
@@ -4244,6 +4257,7 @@ async fn process_command<'a>(
                 || arg_matches.is_present("allow_unfunded_recipient");
 
             let no_recipient_is_ata_owner = arg_matches.is_present("no_recipient_is_ata_owner");
+            let recipient_is_ata_owner = arg_matches.is_present("recipient_is_ata_owner");
             let use_unchecked_instruction = arg_matches.is_present("use_unchecked_instruction");
             let expected_fee = value_of::<f64>(arg_matches, "expected_fee");
             let memo = value_t!(arg_matches, "memo", String).ok();
@@ -4264,6 +4278,7 @@ async fn process_command<'a>(
                 fund_recipient,
                 mint_decimals,
                 no_recipient_is_ata_owner,
+                recipient_is_ata_owner,
                 use_unchecked_instruction,
                 expected_fee,
                 memo,

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -1234,7 +1234,7 @@ async fn command_transfer(
 
     if recipient_is_ata_owner {
         println_display(config, format!("recipient-is-ata-owner is now the default behavior. The option has been deprecated and will be removed in a future release."));
-    }
+    };
 
     // determine whether recipient is a token account or an expected owner of one
     let recipient_is_token_account = if !config.sign_only {

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -1231,7 +1231,6 @@ async fn command_transfer(
     let maybe_fee =
         ui_fee.map(|ui_amount| spl_token::ui_amount_to_amount(ui_amount, mint_info.decimals));
 
-
     // determine whether recipient is a token account or an expected owner of one
     let recipient_is_token_account = if !config.sign_only {
         // in online mode we can fetch it and see
@@ -4254,8 +4253,9 @@ async fn process_command<'a>(
                 || arg_matches.is_present("allow_unfunded_recipient");
 
             let recipient_is_ata_owner = arg_matches.is_present("recipient_is_ata_owner");
-            let no_recipient_is_ata_owner = arg_matches.is_present("no_recipient_is_ata_owner") || !arg_matches.is_present("recipient_is_ata_owner");
-            if arg_matches.is_present("recipient_is_ata_owner") {
+            let no_recipient_is_ata_owner =
+                arg_matches.is_present("no_recipient_is_ata_owner") || !recipient_is_ata_owner;
+            if recipient_is_ata_owner {
                 println_display(config, format!("recipient-is-ata-owner is now the default behavior. The option has been deprecated and will be removed in a future release."));
             }
             let use_unchecked_instruction = arg_matches.is_present("use_unchecked_instruction");

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -1144,7 +1144,7 @@ async fn command_transfer(
     allow_unfunded_recipient: bool,
     fund_recipient: bool,
     mint_decimals: Option<u8>,
-    recipient_is_ata_owner: bool,
+    no_recipient_is_ata_owner: bool,
     use_unchecked_instruction: bool,
     ui_fee: Option<f64>,
     memo: Option<String>,
@@ -1290,7 +1290,7 @@ async fn command_transfer(
         }
     } else {
         // in offline mode we gotta trust them
-        !recipient_is_ata_owner
+        no_recipient_is_ata_owner
     };
 
     // now if its a token account, life is ez
@@ -3134,8 +3134,8 @@ fn app<'a, 'b>(
                         .help("Send tokens to the recipient even if the recipient is not a wallet owned by System Program."),
                 )
                 .arg(
-                    Arg::with_name("recipient_is_ata_owner")
-                        .long("recipient-is-ata-owner")
+                    Arg::with_name("no_recipient_is_ata_owner")
+                        .long("no-recipient-is-ata-owner")
                         .takes_value(false)
                         .requires("sign_only")
                         .help("In sign-only mode, specifies that the recipient is the owner of the associated token account rather than an actual token account"),
@@ -4243,7 +4243,7 @@ async fn process_command<'a>(
             let allow_unfunded_recipient = arg_matches.is_present("allow_empty_recipient")
                 || arg_matches.is_present("allow_unfunded_recipient");
 
-            let recipient_is_ata_owner = arg_matches.is_present("recipient_is_ata_owner");
+            let no_recipient_is_ata_owner = arg_matches.is_present("no_recipient_is_ata_owner");
             let use_unchecked_instruction = arg_matches.is_present("use_unchecked_instruction");
             let expected_fee = value_of::<f64>(arg_matches, "expected_fee");
             let memo = value_t!(arg_matches, "memo", String).ok();
@@ -4263,7 +4263,7 @@ async fn process_command<'a>(
                 allow_unfunded_recipient,
                 fund_recipient,
                 mint_decimals,
-                recipient_is_ata_owner,
+                no_recipient_is_ata_owner,
                 use_unchecked_instruction,
                 expected_fee,
                 memo,


### PR DESCRIPTION
This is finishing up #3356 -- thanks to @SUMEETRM !

Copying that pull request text:

Pull request for issue https://github.com/solana-labs/solana-program-library/issues/1805

Retained --recipient-is-ata-owner as a hidden flag and, if passed, warn the user that the behavior is now default, the flag is deprecated and can be removed.

New flag called --no-recipient-is-ata-owner to match convention of other CLI tools. Reverse the logic for the flag.

