### PR TITLE
stake-pool: Add comments about unnecessary ownership checks (HAL-01)

### DIFF
--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -738,6 +738,8 @@ impl Processor {
             return Err(StakePoolError::AlreadyInUse.into());
         }
 
+        // This check is unnecessary since the runtime will check the ownership,
+        // but provides clarity that the parameter is in fact checked.
         check_account_owner(stake_pool_info, program_id)?;
         let mut stake_pool = try_from_slice_unchecked::<StakePool>(&stake_pool_info.data.borrow())?;
         if !stake_pool.is_uninitialized() {
@@ -745,6 +747,8 @@ impl Processor {
             return Err(StakePoolError::AlreadyInUse.into());
         }
 
+        // This check is unnecessary since the runtime will check the ownership,
+        // but provides clarity that the parameter is in fact checked.
         check_account_owner(validator_list_info, program_id)?;
         let mut validator_list =
             try_from_slice_unchecked::<ValidatorList>(&validator_list_info.data.borrow())?;


### PR DESCRIPTION
#### Problem

There are unnecessary ownership checks in `Initialize` in the stake pool program since the runtime will do the check.

#### Solution

Since security folks typically want to see every parameter checked, even if it's redundant, keep the checks, but add a comment about them