### PR TITLE
stake-pool: Enforce that pool mint uses 9 decimal places (HAL-03)

### DIFF
--- a/stake-pool/program/src/error.rs
+++ b/stake-pool/program/src/error.rs
@@ -144,6 +144,11 @@ pub enum StakePoolError {
     /// Instruction exceeds desired slippage limit
     #[error("Instruction exceeds desired slippage limit")]
     ExceededSlippage,
+
+    // 40.
+    /// Provided mint does not have 9 decimals to match SOL
+    #[error("IncorrectMintDecimals")]
+    IncorrectMintDecimals,
 }
 impl From<StakePoolError> for ProgramError {
     fn from(e: StakePoolError) -> Self {

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -39,6 +39,7 @@ use {
     spl_token_2022::{
         check_spl_token_program_account,
         extension::{BaseStateWithExtensions, StateWithExtensions},
+        native_mint,
         state::Mint,
     },
     std::num::NonZeroU32,
@@ -826,6 +827,10 @@ impl Processor {
 
             if pool_mint.base.supply != 0 {
                 return Err(StakePoolError::NonZeroPoolTokenSupply.into());
+            }
+
+            if pool_mint.base.decimals != native_mint::DECIMALS {
+                return Err(StakePoolError::IncorrectMintDecimals.into());
             }
 
             if !pool_mint
@@ -3995,6 +4000,7 @@ impl PrintProgramError for StakePoolError {
             StakePoolError::UnsupportedMintExtension => msg!("Error: mint has an unsupported extension"),
             StakePoolError::UnsupportedFeeAccountExtension => msg!("Error: fee account has an unsupported extension"),
             StakePoolError::ExceededSlippage => msg!("Error: instruction exceeds desired slippage limit"),
+            StakePoolError::IncorrectMintDecimals => msg!("Error: Provided mint does not have 9 decimals to match SOL"),
         }
     }
 }

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -36,6 +36,7 @@ use {
     },
     spl_token_2022::{
         extension::{ExtensionType, StateWithExtensionsOwned},
+        native_mint,
         state::{Account, Mint},
     },
     std::{convert::TryInto, num::NonZeroU32},
@@ -2013,7 +2014,7 @@ impl Default for StakePoolAccounts {
             token_program_id: spl_token::id(),
             pool_mint,
             pool_fee_account,
-            pool_decimals: 0,
+            pool_decimals: native_mint::DECIMALS,
             manager,
             staker,
             withdraw_authority,


### PR DESCRIPTION
#### Problem

It's possible to create a stake pool with some number of decimals that isn't equal to 9. This has absolutely no impact on the functioning of the program, but if a stake pool mint has 2 decimals, when you deposit 1 SOL, you would get ~10,000,000.00 tokens. It's the same number underneath, but it would look wildly different.

#### Solution

Although the tooling already uses 9 in most places to avoid this exact issue, let's just enforce it on-chain to avoid any confusion.