### PR TITLE
token-2022: enable camelCase for serde

### DIFF
--- a/token/program-2022/src/extension/confidential_transfer/ciphertext_extraction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/ciphertext_extraction.rs
@@ -303,6 +303,7 @@ impl TransferProofContextInfo {
 /// split proofs in `zk-token-sdk`. Until this modifications is made, include `SourceDecryptHandle`
 /// in the transfer instruction data.
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct SourceDecryptHandles {

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -28,6 +28,7 @@ use {
 
 /// Confidential Transfer extension instructions
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, TryFromPrimitive, IntoPrimitive)]
 #[repr(u8)]
 pub enum ConfidentialTransferInstruction {
@@ -368,6 +369,7 @@ pub enum ConfidentialTransferInstruction {
 
 /// Data expected by `ConfidentialTransferInstruction::InitializeMint`
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
 #[repr(C)]
 pub struct InitializeMintData {
@@ -383,6 +385,7 @@ pub struct InitializeMintData {
 
 /// Data expected by `ConfidentialTransferInstruction::UpdateMint`
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
 #[repr(C)]
 pub struct UpdateMintData {
@@ -395,6 +398,7 @@ pub struct UpdateMintData {
 
 /// Data expected by `ConfidentialTransferInstruction::ConfigureAccount`
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
 #[repr(C)]
 pub struct ConfigureAccountInstructionData {
@@ -412,6 +416,7 @@ pub struct ConfigureAccountInstructionData {
 
 /// Data expected by `ConfidentialTransferInstruction::EmptyAccount`
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
 #[repr(C)]
 pub struct EmptyAccountInstructionData {
@@ -423,6 +428,7 @@ pub struct EmptyAccountInstructionData {
 
 /// Data expected by `ConfidentialTransferInstruction::Deposit`
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
 #[repr(C)]
 pub struct DepositInstructionData {
@@ -434,6 +440,7 @@ pub struct DepositInstructionData {
 
 /// Data expected by `ConfidentialTransferInstruction::Withdraw`
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
 #[repr(C)]
 pub struct WithdrawInstructionData {
@@ -452,6 +459,7 @@ pub struct WithdrawInstructionData {
 
 /// Data expected by `ConfidentialTransferInstruction::Transfer`
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
 #[repr(C)]
 pub struct TransferInstructionData {
@@ -474,6 +482,7 @@ pub struct TransferInstructionData {
 
 /// Data expected by `ConfidentialTransferInstruction::ApplyPendingBalance`
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
 #[repr(C)]
 pub struct ApplyPendingBalanceData {

--- a/token/program-2022/src/extension/confidential_transfer_fee/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer_fee/instruction.rs
@@ -32,6 +32,7 @@ use {
 
 /// Confidential Transfer extension instructions
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, TryFromPrimitive, IntoPrimitive)]
 #[repr(u8)]
 pub enum ConfidentialTransferFeeInstruction {
@@ -198,6 +199,7 @@ pub enum ConfidentialTransferFeeInstruction {
 
 /// Data expected by `InitializeConfidentialTransferFeeConfig`
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
 #[repr(C)]
 pub struct InitializeConfidentialTransferFeeConfigData {
@@ -211,6 +213,7 @@ pub struct InitializeConfidentialTransferFeeConfigData {
 
 /// Data expected by `ConfidentialTransferFeeInstruction::WithdrawWithheldTokensFromMint`
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
 #[repr(C)]
 pub struct WithdrawWithheldTokensFromMintData {
@@ -225,6 +228,7 @@ pub struct WithdrawWithheldTokensFromMintData {
 
 /// Data expected by `ConfidentialTransferFeeInstruction::WithdrawWithheldTokensFromAccounts`
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
 #[repr(C)]
 pub struct WithdrawWithheldTokensFromAccountsData {

--- a/token/program-2022/src/extension/cpi_guard/instruction.rs
+++ b/token/program-2022/src/extension/cpi_guard/instruction.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 
 /// CPI Guard extension instructions
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, PartialEq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u8)]
 pub enum CpiGuardInstruction {

--- a/token/program-2022/src/extension/default_account_state/instruction.rs
+++ b/token/program-2022/src/extension/default_account_state/instruction.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 
 /// Default Account State extension instructions
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, PartialEq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u8)]
 pub enum DefaultAccountStateInstruction {

--- a/token/program-2022/src/extension/interest_bearing_mint/instruction.rs
+++ b/token/program-2022/src/extension/interest_bearing_mint/instruction.rs
@@ -20,6 +20,7 @@ use serde::{Deserialize, Serialize};
 
 /// Interesting-bearing mint extension instructions
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, PartialEq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u8)]
 pub enum InterestBearingMintInstruction {
@@ -62,6 +63,7 @@ pub enum InterestBearingMintInstruction {
 
 /// Data expected by `InterestBearing::Initialize`
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
 pub struct InitializeInstructionData {

--- a/token/program-2022/src/extension/memo_transfer/instruction.rs
+++ b/token/program-2022/src/extension/memo_transfer/instruction.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 
 /// Required Memo Transfers extension instructions
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, PartialEq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u8)]
 pub enum RequiredMemoTransfersInstruction {

--- a/token/program-2022/src/extension/metadata_pointer/instruction.rs
+++ b/token/program-2022/src/extension/metadata_pointer/instruction.rs
@@ -19,6 +19,7 @@ use serde::{Deserialize, Serialize};
 
 /// Metadata pointer extension instructions
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, PartialEq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u8)]
 pub enum MetadataPointerInstruction {
@@ -61,6 +62,7 @@ pub enum MetadataPointerInstruction {
 
 /// Data expected by `Initialize`
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
 pub struct InitializeInstructionData {
@@ -72,6 +74,7 @@ pub struct InitializeInstructionData {
 
 /// Data expected by `Update`
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
 pub struct UpdateInstructionData {

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -858,6 +858,7 @@ impl Default for AccountType {
 /// accounts.
 #[repr(u16)]
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, PartialEq, TryFromPrimitive, IntoPrimitive)]
 pub enum ExtensionType {
     /// Used as padding if the account size would otherwise be 355, same as a multisig

--- a/token/program-2022/src/extension/transfer_fee/instruction.rs
+++ b/token/program-2022/src/extension/transfer_fee/instruction.rs
@@ -17,6 +17,7 @@ use {
 
 /// Transfer Fee extension instructions
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase", rename_all_fields = "camelCase"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(u8)]
 pub enum TransferFeeInstruction {

--- a/token/program-2022/src/extension/transfer_fee/instruction.rs
+++ b/token/program-2022/src/extension/transfer_fee/instruction.rs
@@ -17,7 +17,10 @@ use {
 
 /// Transfer Fee extension instructions
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase", rename_all_fields = "camelCase"))]
+#[cfg_attr(
+    feature = "serde-traits",
+    serde(rename_all = "camelCase", rename_all_fields = "camelCase")
+)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(u8)]
 pub enum TransferFeeInstruction {

--- a/token/program-2022/src/extension/transfer_hook/instruction.rs
+++ b/token/program-2022/src/extension/transfer_hook/instruction.rs
@@ -19,6 +19,7 @@ use serde::{Deserialize, Serialize};
 
 /// Transfer hook extension instructions
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, PartialEq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u8)]
 pub enum TransferHookInstruction {
@@ -61,6 +62,7 @@ pub enum TransferHookInstruction {
 
 /// Data expected by `Initialize`
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
 pub struct InitializeInstructionData {
@@ -72,6 +74,7 @@ pub struct InitializeInstructionData {
 
 /// Data expected by `Update`
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
 pub struct UpdateInstructionData {

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -42,6 +42,7 @@ const U64_BYTES: usize = 8;
 /// Instructions supported by the token program.
 #[repr(C)]
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all_fields = "camelCase", rename_all = "camelCase"))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum TokenInstruction<'a> {
     /// Initializes a new mint and optionally deposits all the newly minted
@@ -1033,6 +1034,7 @@ impl<'a> TokenInstruction<'a> {
 /// Specifies the authority type for SetAuthority instructions
 #[repr(u8)]
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum AuthorityType {
     /// Authority to mint new tokens

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -42,7 +42,10 @@ const U64_BYTES: usize = 8;
 /// Instructions supported by the token program.
 #[repr(C)]
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde-traits", serde(rename_all_fields = "camelCase", rename_all = "camelCase"))]
+#[cfg_attr(
+    feature = "serde-traits",
+    serde(rename_all_fields = "camelCase", rename_all = "camelCase")
+)]
 #[derive(Clone, Debug, PartialEq)]
 pub enum TokenInstruction<'a> {
     /// Initializes a new mint and optionally deposits all the newly minted

--- a/token/program-2022/tests/serialization.rs
+++ b/token/program-2022/tests/serialization.rs
@@ -23,7 +23,7 @@ fn serde_instruction_coption_pubkey() {
     };
 
     let serialized = serde_json::to_string(&inst).unwrap();
-    assert_eq!(&serialized, "{\"InitializeMint2\":{\"decimals\":0,\"mint_authority\":\"4uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJziofM\",\"freeze_authority\":\"8opHzTAnfzRpPEx21XtnrVTX28YQuCpAjcn1PczScKh\"}}");
+    assert_eq!(&serialized, "{\"initializeMint2\":{\"decimals\":0,\"mintAuthority\":\"4uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJziofM\",\"freezeAuthority\":\"8opHzTAnfzRpPEx21XtnrVTX28YQuCpAjcn1PczScKh\"}}");
 
     serde_json::from_str::<instruction::TokenInstruction>(&serialized).unwrap();
 }
@@ -37,7 +37,7 @@ fn serde_instruction_coption_pubkey_with_none() {
     let serialized = serde_json::to_string(&inst).unwrap();
     assert_eq!(
         &serialized,
-        "{\"InitializeMintCloseAuthority\":{\"close_authority\":null}}"
+        "{\"initializeMintCloseAuthority\":{\"closeAuthority\":null}}"
     );
 
     serde_json::from_str::<instruction::TokenInstruction>(&serialized).unwrap();
@@ -64,7 +64,7 @@ fn serde_instruction_optional_nonzero_pubkeys_podbool() {
     };
 
     let serialized = serde_json::to_string(&inst).unwrap();
-    let serialized_expected = &format!("{{\"authority\":\"4uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJziofM\",\"auto_approve_new_accounts\":false,\"auditor_elgamal_pubkey\":\"ohdsJIKPEtvEhvKRszHlwUpAA55E63xY95Ck/uQMrVU=\"}}");
+    let serialized_expected = &format!("{{\"authority\":\"4uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJziofM\",\"autoApproveNewAccounts\":false,\"auditorElgamalPubkey\":\"ohdsJIKPEtvEhvKRszHlwUpAA55E63xY95Ck/uQMrVU=\"}}");
     assert_eq!(&serialized, serialized_expected);
 
     let deserialized =
@@ -89,7 +89,7 @@ fn serde_instruction_optional_nonzero_pubkeys_podbool_with_none() {
     };
 
     let serialized = serde_json::to_string(&inst).unwrap();
-    let serialized_expected = &format!("{{\"authority\":null,\"auto_approve_new_accounts\":false,\"auditor_elgamal_pubkey\":null}}");
+    let serialized_expected = &format!("{{\"authority\":null,\"autoApproveNewAccounts\":false,\"auditorElgamalPubkey\":null}}");
     assert_eq!(&serialized, serialized_expected);
 
     let deserialized =
@@ -114,7 +114,7 @@ fn serde_instruction_decryptable_balance_podu64() {
     };
 
     let serialized = serde_json::to_string(&inst).unwrap();
-    let serialized_expected = &format!("{{\"decryptable_zero_balance\":\"OBZmMHBqOhkZ9MLZSYlJJhgaJBnr6kS1C1Kqo1nNcaA3ECOX\",\"maximum_pending_balance_credit_counter\":1099,\"proof_instruction_offset\":100}}");
+    let serialized_expected = &format!("{{\"decryptableZeroBalance\":\"OBZmMHBqOhkZ9MLZSYlJJhgaJBnr6kS1C1Kqo1nNcaA3ECOX\",\"maximumPendingBalanceCreditCounter\":1099,\"proofInstructionOffset\":100}}");
     assert_eq!(&serialized, serialized_expected);
 
     let deserialized = serde_json::from_str::<
@@ -139,7 +139,7 @@ fn serde_instruction_elgamal_pubkey() {
     };
 
     let serialized = serde_json::to_string(&inst).unwrap();
-    let serialized_expected = "{\"authority\":null,\"withdraw_withheld_authority_elgamal_pubkey\":\"ohdsJIKPEtvEhvKRszHlwUpAA55E63xY95Ck/uQMrVU=\"}";
+    let serialized_expected = "{\"authority\":null,\"withdrawWithheldAuthorityElgamalPubkey\":\"ohdsJIKPEtvEhvKRszHlwUpAA55E63xY95Ck/uQMrVU=\"}";
     assert_eq!(&serialized, serialized_expected);
 
     let deserialized =
@@ -158,7 +158,7 @@ fn serde_instruction_basis_points() {
     };
 
     let serialized = serde_json::to_string(&inst).unwrap();
-    let serialized_expected = "{\"rate_authority\":null,\"rate\":127}";
+    let serialized_expected = "{\"rateAuthority\":null,\"rate\":127}";
     assert_eq!(&serialized, serialized_expected);
 
     serde_json::from_str::<InitializeInstructionData>(&serialized_expected).unwrap();

--- a/token/program-2022/tests/serialization.rs
+++ b/token/program-2022/tests/serialization.rs
@@ -89,7 +89,9 @@ fn serde_instruction_optional_nonzero_pubkeys_podbool_with_none() {
     };
 
     let serialized = serde_json::to_string(&inst).unwrap();
-    let serialized_expected = &format!("{{\"authority\":null,\"autoApproveNewAccounts\":false,\"auditorElgamalPubkey\":null}}");
+    let serialized_expected = &format!(
+        "{{\"authority\":null,\"autoApproveNewAccounts\":false,\"auditorElgamalPubkey\":null}}"
+    );
     assert_eq!(&serialized, serialized_expected);
 
     let deserialized =


### PR DESCRIPTION
Issue #3325

Addresses this comment: https://github.com/solana-labs/solana-program-library/pull/5050#discussion_r1300031644

I still plan on implementing a macro to replace a lot of these serde attributes, but until that is done it feels like the camelCase should not be postponed too much so I added it in this PR.

@joncinque @buffalojoec 