### PR TITLE
token-cli: Integrate token-metadata in the mint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7055,6 +7055,7 @@ dependencies = [
  "spl-token 4.0.0",
  "spl-token-2022 0.7.0",
  "spl-token-client",
+ "spl-token-metadata-interface",
  "strum 0.25.0",
  "strum_macros 0.25.2",
  "tempfile",

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -29,6 +29,7 @@ solana-transaction-status = "=1.16.3"
 spl-token = { version = "4.0", path="../program", features = [ "no-entrypoint" ] }
 spl-token-2022 = { version = "0.7", path="../program-2022", features = [ "no-entrypoint" ] }
 spl-token-client = { version = "0.5", path="../client" }
+spl-token-metadata-interface = { version = "0.1", path="../../token-metadata/interface" }
 spl-associated-token-account = { version = "2.0", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
 spl-memo = { version = "4.0.0", path="../../memo/program", features = ["no-entrypoint"] }
 strum = "0.25"

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -5419,7 +5419,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn create_token_default() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5440,7 +5439,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn create_token_interest_bearing() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5474,7 +5472,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn set_interest_rate() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5512,7 +5509,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn supply() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5532,7 +5528,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn create_account_default() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5554,7 +5549,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn account_info() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5589,7 +5583,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn balance() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5611,7 +5604,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn mint() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5693,7 +5685,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn balance_after_mint() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5715,7 +5706,6 @@ mod tests {
         }
     }
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn balance_after_mint_with_owner() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5745,7 +5735,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn accounts() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5772,7 +5761,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn accounts_with_owner() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5805,7 +5793,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn wrap() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5839,7 +5826,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn unwrap() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5874,7 +5860,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn transfer() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5909,7 +5894,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn transfer_fund_recipient() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5943,7 +5927,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn transfer_non_standard_recipient() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -6104,7 +6087,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn allow_non_system_account_recipient() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -6142,7 +6124,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn close_account() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -6210,7 +6191,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn close_wrapped_sol_account() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -6270,7 +6250,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn disable_mint_authority() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -6298,7 +6277,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn gc() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -6453,7 +6431,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn set_owner() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -6483,7 +6460,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn transfer_with_account_delegate() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -6589,7 +6565,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn burn_with_account_delegate() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -6677,7 +6652,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn close_mint() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -6732,7 +6706,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn burn_with_permanent_delegate() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -6811,7 +6784,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn transfer_with_permanent_delegate() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -6912,7 +6884,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn required_transfer_memos() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -7014,7 +6985,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn cpi_guard() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -7076,7 +7046,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn immutable_accounts() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -7174,7 +7143,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn non_transferable() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -7236,7 +7204,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn default_account_state() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -7307,7 +7274,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn transfer_fee() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -7578,7 +7544,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn confidential_transfer() {
         use spl_token_2022::solana_zk_token_sdk::zk_token_elgamal::pod::ElGamalPubkey;
@@ -7651,7 +7616,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn multisig_transfer() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -7736,7 +7700,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn offline_multisig_transfer_with_nonce() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -7829,7 +7792,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn withdraw_excess_lamports_from_multisig() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -7934,7 +7896,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn withdraw_excess_lamports_from_mint() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -8007,7 +7968,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn withdraw_excess_lamports_from_account() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -8083,7 +8043,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn metadata_pointer() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -8168,7 +8127,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[serial]
     async fn transfer_hook() {
         let (test_validator, payer) = new_validator_for_test().await;

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -720,6 +720,7 @@ async fn command_set_transfer_hook_program(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn command_initialize_metadata(
     config: &Config<'_>,
     token_pubkey: Pubkey,

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -58,6 +58,7 @@ use spl_token_client::{
     client::{ProgramRpcClientSendTransaction, RpcClientResponse},
     token::{ExtensionInitializationParams, Token},
 };
+use spl_token_metadata_interface::state::Field;
 use std::{collections::HashMap, fmt, fmt::Display, process::exit, str::FromStr, sync::Arc};
 use strum_macros::{EnumString, IntoStaticStr};
 
@@ -150,6 +151,8 @@ pub enum CommandName {
     SetTransferFee,
     WithdrawExcessLamports,
     SetTransferHookProgram,
+    InitializeMetadata,
+    UpdateMetadata,
 }
 impl fmt::Display for CommandName {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -470,6 +473,7 @@ async fn command_create_token(
     transfer_fee: Option<(u16, u64)>,
     confidential_transfer_auto_approve: Option<bool>,
     transfer_hook_program_id: Option<Pubkey>,
+    enable_metadata: bool,
     bulk_signers: Vec<Arc<dyn Signer>>,
 ) -> CommandResult {
     println_display(
@@ -545,7 +549,13 @@ async fn command_create_token(
         token.with_memo(text, vec![config.default_signer()?.pubkey()]);
     }
 
-    if metadata_address.is_some() {
+    // CLI checks that only one is set
+    if metadata_address.is_some() || enable_metadata {
+        let metadata_address = if enable_metadata {
+            Some(token_pubkey)
+        } else {
+            metadata_address
+        };
         extensions.push(ExtensionInitializationParams::MetadataPointer {
             authority: Some(authority),
             metadata_address,
@@ -562,6 +572,18 @@ async fn command_create_token(
         .await?;
 
     let tx_return = finish_tx(config, &res, false).await?;
+
+    if enable_metadata {
+        println_display(
+            config,
+            format!(
+                "To initialize metadata inside the mint, please run \
+                `spl-token initialize-metadata {token_pubkey} <YOUR_TOKEN_NAME> <YOUR_TOKEN_SYMBOL> <YOUR_TOKEN_URI>`, \
+                and sign with the mint authority.",
+            ),
+        );
+    }
+
     Ok(match tx_return {
         TransactionReturnData::CliSignature(cli_signature) => format_output(
             CliCreateToken {
@@ -686,6 +708,88 @@ async fn command_set_transfer_hook_program(
     let res = token
         .update_transfer_hook_program_id(&authority, new_program_id, &bulk_signers)
         .await?;
+
+    let tx_return = finish_tx(config, &res, false).await?;
+    Ok(match tx_return {
+        TransactionReturnData::CliSignature(signature) => {
+            config.output_format.formatted_string(&signature)
+        }
+        TransactionReturnData::CliSignOnlyData(sign_only_data) => {
+            config.output_format.formatted_string(&sign_only_data)
+        }
+    })
+}
+
+async fn command_initialize_metadata(
+    config: &Config<'_>,
+    token_pubkey: Pubkey,
+    mint_authority: Pubkey,
+    name: String,
+    symbol: String,
+    uri: String,
+    bulk_signers: Vec<Arc<dyn Signer>>,
+) -> CommandResult {
+    let token = token_client_from_config(config, &token_pubkey, None)?;
+
+    let res = token
+        .token_metadata_initialize_with_rent_transfer(
+            &config.fee_payer()?.pubkey(),
+            &mint_authority,
+            &mint_authority,
+            name,
+            symbol,
+            uri,
+            &bulk_signers,
+        )
+        .await?;
+
+    let tx_return = finish_tx(config, &res, false).await?;
+    Ok(match tx_return {
+        TransactionReturnData::CliSignature(signature) => {
+            config.output_format.formatted_string(&signature)
+        }
+        TransactionReturnData::CliSignOnlyData(sign_only_data) => {
+            config.output_format.formatted_string(&sign_only_data)
+        }
+    })
+}
+
+async fn command_update_metadata(
+    config: &Config<'_>,
+    token_pubkey: Pubkey,
+    authority: Pubkey,
+    field: Field,
+    value: Option<String>,
+    bulk_signers: Vec<Arc<dyn Signer>>,
+) -> CommandResult {
+    let token = token_client_from_config(config, &token_pubkey, None)?;
+
+    let res = if let Some(value) = value {
+        token
+            .token_metadata_update_field_with_rent_transfer(
+                &config.fee_payer()?.pubkey(),
+                &authority,
+                field,
+                value,
+                &bulk_signers,
+            )
+            .await?
+    } else if let Field::Key(key) = field {
+        token
+            .token_metadata_remove_key(
+                &authority,
+                key,
+                true, // idempotent
+                &bulk_signers,
+            )
+            .await?
+    } else {
+        return Err(format!(
+            "Attempting to remove field {field:?}, which cannot be removed. \
+            Please re-run the command with a value of \"\" rather than the `--remove` flag."
+        )
+        .into());
+    };
 
     let tx_return = finish_tx(config, &res, false).await?;
     Ok(match tx_return {
@@ -2780,6 +2884,7 @@ fn app<'a, 'b>(
                         .long("metadata-address")
                         .value_name("ADDRESS")
                         .takes_value(true)
+                        .conflicts_with("enable_metadata")
                         .help(
                             "Specify address that stores token metadata."
                         ),
@@ -2845,6 +2950,13 @@ fn app<'a, 'b>(
                         .validator(is_valid_pubkey)
                         .takes_value(true)
                         .help("Enable the mint authority to set the transfer hook program for this mint"),
+                )
+                .arg(
+                    Arg::with_name("enable_metadata")
+                        .long("enable-metadata")
+                        .conflicts_with("metadata_address")
+                        .takes_value(false)
+                        .help("Enables metadata in the mint. The mint authority must initialize the metadata."),
                 )
                 .nonce_args(true)
                 .arg(memo_arg())
@@ -2914,6 +3026,97 @@ fn app<'a, 'b>(
                     .value_name("SIGNER")
                     .takes_value(true)
                     .help("Specify the authority keypair. Defaults to the client keypair address.")
+                )
+        )
+        .subcommand(
+            SubCommand::with_name(CommandName::InitializeMetadata.into())
+                .about("Initialize metadata extension on a token mint")
+                .arg(
+                    Arg::with_name("token")
+                        .validator(is_valid_pubkey)
+                        .value_name("TOKEN_MINT_ADDRESS")
+                        .takes_value(true)
+                        .required(true)
+                        .index(1)
+                        .help("The token address with no metadata present"),
+                )
+                .arg(
+                    Arg::with_name("name")
+                        .value_name("TOKEN_NAME")
+                        .takes_value(true)
+                        .index(2)
+                        .help("The name of the token to set in metadata"),
+                )
+                .arg(
+                    Arg::with_name("symbol")
+                        .value_name("TOKEN_SYMBOL")
+                        .takes_value(true)
+                        .index(3)
+                        .help("The symbol of the token to set in metadata"),
+                )
+                .arg(
+                    Arg::with_name("uri")
+                        .value_name("TOKEN_URI")
+                        .takes_value(true)
+                        .index(4)
+                        .help("The URI of the token to set in metadata"),
+                )
+                .arg(
+                    Arg::with_name("mint_authority")
+                        .long("mint-authority")
+                        .alias("owner")
+                        .value_name("KEYPAIR")
+                        .validator(is_valid_signer)
+                        .takes_value(true)
+                        .help(
+                            "Specify the mint authority keypair. \
+                             This may be a keypair file or the ASK keyword. \
+                             Defaults to the client keypair."
+                        ),
+                )
+        )
+        .subcommand(
+            SubCommand::with_name(CommandName::UpdateMetadata.into())
+                .about("Update metadata on a token mint that has the extension")
+                .arg(
+                    Arg::with_name("token")
+                        .validator(is_valid_pubkey)
+                        .value_name("TOKEN_MINT_ADDRESS")
+                        .takes_value(true)
+                        .required(true)
+                        .index(1)
+                        .help("The token address with no metadata present"),
+                )
+                .arg(
+                    Arg::with_name("field")
+                        .value_name("FIELD_NAME")
+                        .takes_value(true)
+                        .required(true)
+                        .index(2)
+                        .help("The name of the field to update. Can be a base field (\"name\", \"symbol\", or \"uri\") or any new field to add."),
+                )
+                .arg(
+                    Arg::with_name("value")
+                        .value_name("VALUE_STRING")
+                        .takes_value(true)
+                        .index(3)
+                        .required_unless("remove")
+                        .help("The value for the field"),
+                )
+                .arg(
+                    Arg::with_name("remove")
+                        .long("remove")
+                        .takes_value(false)
+                        .conflicts_with("value")
+                        .help("Remove the key and value for the given field. Does not work with base fields: \"name\", \"symbol\", or \"uri\".")
+                )
+                .arg(
+                    Arg::with_name("authority")
+                    .long("authority")
+                    .validator(is_valid_signer)
+                    .value_name("SIGNER")
+                    .takes_value(true)
+                    .help("Specify the metadata update authority keypair. Defaults to the client keypair.")
                 )
         )
         .subcommand(
@@ -4102,6 +4305,7 @@ async fn process_command<'a>(
                 transfer_fee,
                 confidential_transfer_auto_approve,
                 transfer_hook_program_id,
+                arg_matches.is_present("enable_metadata"),
                 bulk_signers,
             )
             .await
@@ -4142,6 +4346,47 @@ async fn process_command<'a>(
                 bulk_signers,
             )
             .await
+        }
+        (CommandName::InitializeMetadata, arg_matches) => {
+            let token_pubkey = pubkey_of_signer(arg_matches, "token", &mut wallet_manager)
+                .unwrap()
+                .unwrap();
+            let name = arg_matches.value_of("name").unwrap().to_string();
+            let symbol = arg_matches.value_of("symbol").unwrap().to_string();
+            let uri = arg_matches.value_of("uri").unwrap().to_string();
+            let (mint_authority_signer, mint_authority) =
+                config.signer_or_default(arg_matches, "mint_authority", &mut wallet_manager);
+            let bulk_signers = vec![mint_authority_signer];
+
+            command_initialize_metadata(
+                config,
+                token_pubkey,
+                mint_authority,
+                name,
+                symbol,
+                uri,
+                bulk_signers,
+            )
+            .await
+        }
+        (CommandName::UpdateMetadata, arg_matches) => {
+            let token_pubkey = pubkey_of_signer(arg_matches, "token", &mut wallet_manager)
+                .unwrap()
+                .unwrap();
+            let (authority_signer, authority) =
+                config.signer_or_default(arg_matches, "authority", &mut wallet_manager);
+            let field = arg_matches.value_of("field").unwrap();
+            let field = match field.to_lowercase().as_str() {
+                "name" => Field::Name,
+                "symbol" => Field::Symbol,
+                "uri" => Field::Uri,
+                _ => Field::Key(field.to_string()),
+            };
+            let value = arg_matches.value_of("value").map(|v| v.to_string());
+            let bulk_signers = vec![authority_signer];
+
+            command_update_metadata(config, token_pubkey, authority, field, value, bulk_signers)
+                .await
         }
         (CommandName::CreateAccount, arg_matches) => {
             let token = pubkey_of_signer(arg_matches, "token", &mut wallet_manager)
@@ -4848,6 +5093,7 @@ mod tests {
         spl_token_client::client::{
             ProgramClient, ProgramOfflineClient, ProgramRpcClient, ProgramRpcClientSendTransaction,
         },
+        spl_token_metadata_interface::{borsh::BorshDeserialize, state::TokenMetadata},
         std::path::PathBuf,
         tempfile::NamedTempFile,
     };
@@ -5011,6 +5257,7 @@ mod tests {
             None,
             None,
             None,
+            false,
             bulk_signers,
         )
         .await
@@ -5044,6 +5291,7 @@ mod tests {
             None,
             None,
             None,
+            false,
             bulk_signers,
         )
         .await
@@ -5171,6 +5419,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn create_token_default() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5191,6 +5440,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn create_token_interest_bearing() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5224,6 +5474,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn set_interest_rate() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5261,6 +5512,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn supply() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5280,6 +5532,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn create_account_default() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5301,6 +5554,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn account_info() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5335,6 +5589,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn balance() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5356,6 +5611,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn mint() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5437,6 +5693,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn balance_after_mint() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5458,6 +5715,7 @@ mod tests {
         }
     }
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn balance_after_mint_with_owner() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5487,6 +5745,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn accounts() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5513,6 +5772,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn accounts_with_owner() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5545,6 +5805,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn wrap() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5578,6 +5839,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn unwrap() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5612,6 +5874,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn transfer() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5646,6 +5909,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn transfer_fund_recipient() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5679,6 +5943,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn transfer_non_standard_recipient() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5839,6 +6104,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn allow_non_system_account_recipient() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5876,6 +6142,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn close_account() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -5943,6 +6210,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn close_wrapped_sol_account() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -6002,6 +6270,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn disable_mint_authority() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -6029,6 +6298,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn gc() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -6183,6 +6453,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn set_owner() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -6212,6 +6483,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn transfer_with_account_delegate() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -6317,6 +6589,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn burn_with_account_delegate() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -6404,6 +6677,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn close_mint() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -6431,6 +6705,7 @@ mod tests {
             None,
             None,
             None,
+            false,
             bulk_signers,
         )
         .await
@@ -6457,6 +6732,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn burn_with_permanent_delegate() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -6484,6 +6760,7 @@ mod tests {
             None,
             None,
             None,
+            false,
             bulk_signers,
         )
         .await
@@ -6534,6 +6811,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn transfer_with_permanent_delegate() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -6561,6 +6839,7 @@ mod tests {
             None,
             None,
             None,
+            false,
             bulk_signers,
         )
         .await
@@ -6633,6 +6912,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn required_transfer_memos() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -6734,6 +7014,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn cpi_guard() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -6795,6 +7076,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn immutable_accounts() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -6892,6 +7174,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn non_transferable() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -6919,6 +7202,7 @@ mod tests {
             None,
             None,
             None,
+            false,
             bulk_signers,
         )
         .await
@@ -6952,6 +7236,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn default_account_state() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -6978,6 +7263,7 @@ mod tests {
             None,
             None,
             None,
+            false,
             bulk_signers,
         )
         .await
@@ -7021,6 +7307,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn transfer_fee() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -7050,6 +7337,7 @@ mod tests {
             Some((transfer_fee_basis_points, maximum_fee)),
             None,
             None,
+            false,
             bulk_signers,
         )
         .await
@@ -7290,6 +7578,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn confidential_transfer() {
         use spl_token_2022::solana_zk_token_sdk::zk_token_elgamal::pod::ElGamalPubkey;
@@ -7321,6 +7610,7 @@ mod tests {
             None,
             Some(auto_approve),
             None,
+            false,
             bulk_signers,
         )
         .await
@@ -7361,6 +7651,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn multisig_transfer() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -7445,6 +7736,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn offline_multisig_transfer_with_nonce() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -7537,6 +7829,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn withdraw_excess_lamports_from_multisig() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -7641,6 +7934,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn withdraw_excess_lamports_from_mint() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -7713,6 +8007,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn withdraw_excess_lamports_from_account() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -7788,6 +8083,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn metadata_pointer() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -7872,6 +8168,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     #[serial]
     async fn transfer_hook() {
         let (test_validator, payer) = new_validator_for_test().await;
@@ -7988,5 +8285,147 @@ mod tests {
         let extension = mint_state.get_extension::<TransferHook>().unwrap();
 
         assert_eq!(extension.program_id, None.try_into().unwrap());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn metadata() {
+        let (test_validator, payer) = new_validator_for_test().await;
+        let program_id = spl_token_2022::id();
+        let config = test_config_with_default_signer(&test_validator, &payer, &program_id);
+        let name = "this";
+        let symbol = "is";
+        let uri = "METADATA!";
+
+        let result = process_test_command(
+            &config,
+            &payer,
+            &[
+                "spl-token",
+                CommandName::CreateToken.into(),
+                "--program-id",
+                &program_id.to_string(),
+                "--enable-metadata",
+            ],
+        )
+        .await;
+
+        let value: serde_json::Value = serde_json::from_str(&result.unwrap()).unwrap();
+        let mint = Pubkey::from_str(value["commandOutput"]["address"].as_str().unwrap()).unwrap();
+        let account = config.rpc_client.get_account(&mint).await.unwrap();
+        let mint_state = StateWithExtensionsOwned::<Mint>::unpack(account.data).unwrap();
+
+        let extension = mint_state.get_extension::<MetadataPointer>().unwrap();
+        assert_eq!(extension.metadata_address, Some(mint).try_into().unwrap());
+
+        process_test_command(
+            &config,
+            &payer,
+            &[
+                "spl-token",
+                CommandName::InitializeMetadata.into(),
+                &mint.to_string(),
+                name,
+                symbol,
+                uri,
+            ],
+        )
+        .await
+        .unwrap();
+
+        let account = config.rpc_client.get_account(&mint).await.unwrap();
+        let mint_state = StateWithExtensionsOwned::<Mint>::unpack(account.data).unwrap();
+        let metadata_bytes = mint_state.get_extension_bytes::<TokenMetadata>().unwrap();
+        let fetched_metadata = TokenMetadata::try_from_slice(metadata_bytes).unwrap();
+        assert_eq!(fetched_metadata.name, name);
+        assert_eq!(fetched_metadata.symbol, symbol);
+        assert_eq!(fetched_metadata.uri, uri);
+        assert_eq!(fetched_metadata.mint, mint);
+        assert_eq!(
+            fetched_metadata.update_authority,
+            Some(payer.pubkey()).try_into().unwrap()
+        );
+        assert_eq!(fetched_metadata.additional_metadata, []);
+
+        // update canonical field
+        let new_value = "THIS!";
+        process_test_command(
+            &config,
+            &payer,
+            &[
+                "spl-token",
+                CommandName::UpdateMetadata.into(),
+                &mint.to_string(),
+                "NAME",
+                new_value,
+            ],
+        )
+        .await
+        .unwrap();
+        let account = config.rpc_client.get_account(&mint).await.unwrap();
+        let mint_state = StateWithExtensionsOwned::<Mint>::unpack(account.data).unwrap();
+        let metadata_bytes = mint_state.get_extension_bytes::<TokenMetadata>().unwrap();
+        let fetched_metadata = TokenMetadata::try_from_slice(metadata_bytes).unwrap();
+        assert_eq!(fetched_metadata.name, new_value);
+
+        // add new field
+        let field = "My field!";
+        let value = "Try and stop me";
+        process_test_command(
+            &config,
+            &payer,
+            &[
+                "spl-token",
+                CommandName::UpdateMetadata.into(),
+                &mint.to_string(),
+                field,
+                value,
+            ],
+        )
+        .await
+        .unwrap();
+        let account = config.rpc_client.get_account(&mint).await.unwrap();
+        let mint_state = StateWithExtensionsOwned::<Mint>::unpack(account.data).unwrap();
+        let metadata_bytes = mint_state.get_extension_bytes::<TokenMetadata>().unwrap();
+        let fetched_metadata = TokenMetadata::try_from_slice(metadata_bytes).unwrap();
+        assert_eq!(
+            fetched_metadata.additional_metadata,
+            [(field.to_string(), value.to_string())]
+        );
+
+        // remove it
+        process_test_command(
+            &config,
+            &payer,
+            &[
+                "spl-token",
+                CommandName::UpdateMetadata.into(),
+                &mint.to_string(),
+                field,
+                "--remove",
+            ],
+        )
+        .await
+        .unwrap();
+        let account = config.rpc_client.get_account(&mint).await.unwrap();
+        let mint_state = StateWithExtensionsOwned::<Mint>::unpack(account.data).unwrap();
+        let metadata_bytes = mint_state.get_extension_bytes::<TokenMetadata>().unwrap();
+        let fetched_metadata = TokenMetadata::try_from_slice(metadata_bytes).unwrap();
+        assert_eq!(fetched_metadata.additional_metadata, []);
+
+        // fail to remove name
+        process_test_command(
+            &config,
+            &payer,
+            &[
+                "spl-token",
+                CommandName::UpdateMetadata.into(),
+                &mint.to_string(),
+                "name",
+                "--remove",
+            ],
+        )
+        .await
+        .unwrap_err();
     }
 }


### PR DESCRIPTION
#### Problem

The metadata extension in token-2022 is great, but currently unusable except in the token client.

#### Solution

Support initializing and updating metadata!

Unfortunately, we can't also initialize the metadata during that first call to `create-token` because the mint authority doesn't sign that command, and it's more confusing than anything else to have it take a maybe-keypair and then maybe-do-it. The solution there was to explain the next steps.

Otherwise, the rest should be straightforward!