### PR TITLE
stake-pool-js: implement bindings for token metadata instructions

### DIFF
--- a/stake-pool/js/src/constants.ts
+++ b/stake-pool/js/src/constants.ts
@@ -1,6 +1,12 @@
 import { Buffer } from 'buffer';
 import { LAMPORTS_PER_SOL, PublicKey } from '@solana/web3.js';
 
+// Public key that identifies the metadata program.
+export const METADATA_PROGRAM_ID = new PublicKey('metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s');
+export const METADATA_MAX_NAME_LENGTH = 32;
+export const METADATA_MAX_SYMBOL_LENGTH = 10;
+export const METADATA_MAX_URI_LENGTH = 200;
+
 // Public key that identifies the SPL Stake Pool program.
 export const STAKE_POOL_PROGRAM_ID = new PublicKey('SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy');
 

--- a/stake-pool/js/src/index.ts
+++ b/stake-pool/js/src/index.ts
@@ -28,6 +28,7 @@ import {
   lamportsToSol,
   solToLamports,
   findEphemeralStakeProgramAddress,
+  findMetadataAddress,
 } from './utils';
 import { StakePoolInstruction } from './instructions';
 import {
@@ -1127,11 +1128,10 @@ export async function redelegate(props: RedelegateProps) {
 export async function createPoolTokenMetadata(
   connection: Connection,
   stakePoolAddress: PublicKey,
-  tokenMetadata: PublicKey,
   name: string,
   symbol: string,
   uri: string,
-  payer?: PublicKey,
+  payer: PublicKey,
 ) {
   const stakePool = await getStakePoolAccount(connection, stakePoolAddress);
 
@@ -1139,7 +1139,7 @@ export async function createPoolTokenMetadata(
     STAKE_POOL_PROGRAM_ID,
     stakePoolAddress,
   );
-
+  const tokenMetadata = findMetadataAddress(stakePool.account.data.poolMint);
   const manager = stakePool.account.data.manager;
 
   const instructions: TransactionInstruction[] = [];
@@ -1147,7 +1147,7 @@ export async function createPoolTokenMetadata(
     StakePoolInstruction.createTokenMetadata({
       stakePool: stakePoolAddress,
       poolMint: stakePool.account.data.poolMint,
-      payer: payer ?? manager,
+      payer,
       manager,
       tokenMetadata,
       withdrawAuthority,
@@ -1168,7 +1168,6 @@ export async function createPoolTokenMetadata(
 export async function updatePoolTokenMetadata(
   connection: Connection,
   stakePoolAddress: PublicKey,
-  tokenMetadata: PublicKey,
   name: string,
   symbol: string,
   uri: string,
@@ -1179,6 +1178,8 @@ export async function updatePoolTokenMetadata(
     STAKE_POOL_PROGRAM_ID,
     stakePoolAddress,
   );
+
+  const tokenMetadata = findMetadataAddress(stakePool.account.data.poolMint);
 
   const instructions: TransactionInstruction[] = [];
   instructions.push(

--- a/stake-pool/js/src/instructions.ts
+++ b/stake-pool/js/src/instructions.ts
@@ -10,9 +10,15 @@ import {
 } from '@solana/web3.js';
 import * as BufferLayout from '@solana/buffer-layout';
 import { TOKEN_PROGRAM_ID } from '@solana/spl-token';
-import { STAKE_POOL_PROGRAM_ID } from './constants';
 import { InstructionType, encodeData, decodeData } from './utils';
 import BN from 'bn.js';
+import {
+  METADATA_MAX_NAME_LENGTH,
+  METADATA_MAX_SYMBOL_LENGTH,
+  METADATA_MAX_URI_LENGTH,
+  METADATA_PROGRAM_ID,
+  STAKE_POOL_PROGRAM_ID,
+} from './constants';
 
 /**
  * An enumeration of valid StakePoolInstructionType's
@@ -29,7 +35,9 @@ export type StakePoolInstructionType =
   | 'WithdrawSol'
   | 'IncreaseAdditionalValidatorStake'
   | 'DecreaseAdditionalValidatorStake'
-  | 'Redelegate';
+  | 'Redelegate'
+  | 'UpdateTokenMetadata'
+  | 'CreateTokenMetadata';
 
 const MOVE_STAKE_LAYOUT = BufferLayout.struct<any>([
   BufferLayout.u8('instruction'),
@@ -43,6 +51,12 @@ const UPDATE_VALIDATOR_LIST_BALANCE_LAYOUT = BufferLayout.struct<any>([
   BufferLayout.u8('noMerge'),
 ]);
 
+const TOKEN_METADATA_LAYOUT = BufferLayout.struct<any>([
+  BufferLayout.u8('instruction'),
+  BufferLayout.blob(METADATA_MAX_NAME_LENGTH, 'name'),
+  BufferLayout.blob(METADATA_MAX_SYMBOL_LENGTH, 'symbol'),
+  BufferLayout.blob(METADATA_MAX_URI_LENGTH, 'uri'),
+]);
 /**
  * An enumeration of valid stake InstructionType's
  * @internal
@@ -133,6 +147,18 @@ export const STAKE_POOL_INSTRUCTION_LAYOUTS: {
       /// it can be anything
       BufferLayout.ns64('destinationTransientStakeSeed'),
     ]),
+  },
+  /// Create token metadata for the stake-pool token in the
+  /// metaplex-token program
+  CreateTokenMetadata: {
+    index: 17,
+    layout: TOKEN_METADATA_LAYOUT,
+  },
+  /// Update token metadata for the stake-pool token in the
+  /// metaplex-token program
+  UpdateTokenMetadata: {
+    index: 18,
+    layout: TOKEN_METADATA_LAYOUT,
   },
 });
 
@@ -301,6 +327,28 @@ export type RedelegateParams = {
   // already transient stake, this must match the current seed, otherwise
   // it can be anything
   destinationTransientStakeSeed: number | BN;
+};
+
+export type CreateTokenMetadataParams = {
+  stakePool: PublicKey;
+  manager: PublicKey;
+  tokenMetadata: PublicKey;
+  withdrawAuthority: PublicKey;
+  poolMint: PublicKey;
+  payer: PublicKey;
+  name: string;
+  symbol: string;
+  uri: string;
+};
+
+export type UpdateTokenMetadataParams = {
+  stakePool: PublicKey;
+  manager: PublicKey;
+  tokenMetadata: PublicKey;
+  withdrawAuthority: PublicKey;
+  name: string;
+  symbol: string;
+  uri: string;
 };
 
 /**
@@ -814,6 +862,76 @@ export class StakePoolInstruction {
       sourceTransientStakeSeed,
       ephemeralStakeSeed,
       destinationTransientStakeSeed,
+    });
+
+    return new TransactionInstruction({
+      programId: STAKE_POOL_PROGRAM_ID,
+      keys,
+      data,
+    });
+  }
+
+  /**
+   * Creates an instruction to create metadata
+   * using the mpl token metadata program for the pool token
+   */
+  static createTokenMetadata(params: CreateTokenMetadataParams): TransactionInstruction {
+    const {
+      stakePool,
+      withdrawAuthority,
+      tokenMetadata,
+      manager,
+      payer,
+      poolMint,
+      name,
+      symbol,
+      uri,
+    } = params;
+
+    const keys = [
+      { pubkey: stakePool, isSigner: false, isWritable: false },
+      { pubkey: manager, isSigner: true, isWritable: false },
+      { pubkey: withdrawAuthority, isSigner: false, isWritable: false },
+      { pubkey: poolMint, isSigner: false, isWritable: false },
+      { pubkey: payer, isSigner: true, isWritable: true },
+      { pubkey: tokenMetadata, isSigner: false, isWritable: true },
+      { pubkey: METADATA_PROGRAM_ID, isSigner: false, isWritable: false },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+      { pubkey: SYSVAR_RENT_PUBKEY, isSigner: false, isWritable: false },
+    ];
+
+    const data = encodeData(STAKE_POOL_INSTRUCTION_LAYOUTS.CreateTokenMetadata, {
+      name: new TextEncoder().encode(name.padEnd(METADATA_MAX_NAME_LENGTH, '\0')),
+      symbol: new TextEncoder().encode(symbol.padEnd(METADATA_MAX_SYMBOL_LENGTH, '\0')),
+      uri: new TextEncoder().encode(uri.padEnd(METADATA_MAX_URI_LENGTH, '\0')),
+    });
+
+    return new TransactionInstruction({
+      programId: STAKE_POOL_PROGRAM_ID,
+      keys,
+      data,
+    });
+  }
+
+  /**
+   * Creates an instruction to update metadata
+   * in the mpl token metadata program account for the pool token
+   */
+  static updateTokenMetadata(params: UpdateTokenMetadataParams): TransactionInstruction {
+    const { stakePool, withdrawAuthority, tokenMetadata, manager, name, symbol, uri } = params;
+
+    const keys = [
+      { pubkey: stakePool, isSigner: false, isWritable: false },
+      { pubkey: manager, isSigner: true, isWritable: false },
+      { pubkey: withdrawAuthority, isSigner: false, isWritable: false },
+      { pubkey: tokenMetadata, isSigner: false, isWritable: true },
+      { pubkey: METADATA_PROGRAM_ID, isSigner: false, isWritable: false },
+    ];
+
+    const data = encodeData(STAKE_POOL_INSTRUCTION_LAYOUTS.UpdateTokenMetadata, {
+      name: new TextEncoder().encode(name.padEnd(METADATA_MAX_NAME_LENGTH, '\0')),
+      symbol: new TextEncoder().encode(symbol.padEnd(METADATA_MAX_SYMBOL_LENGTH, '\0')),
+      uri: new TextEncoder().encode(uri.padEnd(METADATA_MAX_URI_LENGTH, '\0')),
     });
 
     return new TransactionInstruction({

--- a/stake-pool/js/src/utils/program-address.ts
+++ b/stake-pool/js/src/utils/program-address.ts
@@ -1,7 +1,11 @@
 import { PublicKey } from '@solana/web3.js';
 import BN from 'bn.js';
 import { Buffer } from 'buffer';
-import { EPHEMERAL_STAKE_SEED_PREFIX, TRANSIENT_STAKE_SEED_PREFIX } from '../constants';
+import {
+  METADATA_PROGRAM_ID,
+  EPHEMERAL_STAKE_SEED_PREFIX,
+  TRANSIENT_STAKE_SEED_PREFIX,
+} from '../constants';
 
 /**
  * Generates the withdraw authority program address for the stake pool
@@ -64,6 +68,17 @@ export async function findEphemeralStakeProgramAddress(
   const [publicKey] = await PublicKey.findProgramAddress(
     [EPHEMERAL_STAKE_SEED_PREFIX, stakePoolAddress.toBuffer(), seed.toBuffer('le', 8)],
     programId,
+  );
+  return publicKey;
+}
+
+/**
+ * Generates the metadata program address for the stake pool
+ */
+export function findMetadataAddress(stakePoolMintAddress: PublicKey) {
+  const [publicKey] = PublicKey.findProgramAddressSync(
+    [Buffer.from('metadata'), METADATA_PROGRAM_ID.toBuffer(), stakePoolMintAddress.toBuffer()],
+    METADATA_PROGRAM_ID,
   );
   return publicKey;
 }

--- a/stake-pool/js/test/instructions.test.ts
+++ b/stake-pool/js/test/instructions.test.ts
@@ -26,6 +26,8 @@ import {
   withdrawStake,
   redelegate,
   getStakeAccount,
+  createPoolTokenMetadata,
+  updatePoolTokenMetadata,
 } from '../src';
 
 import { decodeData } from '../src/utils';
@@ -349,6 +351,54 @@ describe('StakePoolProgram', () => {
       expect(decodedData.sourceTransientStakeSeed).toBe(data.sourceTransientStakeSeed);
       expect(decodedData.destinationTransientStakeSeed).toBe(data.destinationTransientStakeSeed);
       expect(decodedData.ephemeralStakeSeed).toBe(data.ephemeralStakeSeed);
+    });
+  });
+  describe('createPoolTokenMetadata', () => {
+    it.only('should create pool token metadata', async () => {
+      connection.getAccountInfo = jest.fn(async (pubKey: PublicKey) => {
+        if (pubKey == stakePoolAddress) {
+          return stakePoolAccount;
+        }
+        return null;
+      });
+
+      const tokenMetadata = new PublicKey(0);
+
+      const res = await createPoolTokenMetadata(
+        connection,
+        stakePoolAddress,
+        tokenMetadata,
+        'test',
+        'TEST',
+        'https://example.com',
+      );
+
+      const data = STAKE_POOL_INSTRUCTION_LAYOUTS.CreateTokenMetadata.layout.decode(
+        res.instructions[0].data,
+      );
+      expect(Buffer.from(data.name).toString().replace(/\0/g, '')).toBe('test');
+      expect(Buffer.from(data.symbol).toString().replace(/\0/g, '')).toBe('TEST');
+      expect(Buffer.from(data.uri).toString().replace(/\0/g, '')).toBe('https://example.com');
+    });
+
+    it.only('should update pool token metadata', async () => {
+      const tokenMetadata = new PublicKey(0);
+
+      const res = await updatePoolTokenMetadata(
+        connection,
+        stakePoolAddress,
+        tokenMetadata,
+        'test',
+        'TEST',
+        'https://example.com',
+      );
+
+      const data = STAKE_POOL_INSTRUCTION_LAYOUTS.UpdateTokenMetadata.layout.decode(
+        res.instructions[0].data,
+      );
+      expect(Buffer.from(data.name).toString().replace(/\0/g, '')).toBe('test');
+      expect(Buffer.from(data.symbol).toString().replace(/\0/g, '')).toBe('TEST');
+      expect(Buffer.from(data.uri).toString().replace(/\0/g, '')).toBe('https://example.com');
     });
   });
 });

--- a/stake-pool/js/test/instructions.test.ts
+++ b/stake-pool/js/test/instructions.test.ts
@@ -354,7 +354,7 @@ describe('StakePoolProgram', () => {
     });
   });
   describe('createPoolTokenMetadata', () => {
-    it.only('should create pool token metadata', async () => {
+    it('should create pool token metadata', async () => {
       connection.getAccountInfo = jest.fn(async (pubKey: PublicKey) => {
         if (pubKey == stakePoolAddress) {
           return stakePoolAccount;
@@ -362,15 +362,14 @@ describe('StakePoolProgram', () => {
         return null;
       });
 
-      const tokenMetadata = new PublicKey(0);
-
+      const payer = new PublicKey(0);
       const res = await createPoolTokenMetadata(
         connection,
         stakePoolAddress,
-        tokenMetadata,
         'test',
         'TEST',
         'https://example.com',
+        payer,
       );
 
       const data = STAKE_POOL_INSTRUCTION_LAYOUTS.CreateTokenMetadata.layout.decode(
@@ -381,13 +380,10 @@ describe('StakePoolProgram', () => {
       expect(Buffer.from(data.uri).toString().replace(/\0/g, '')).toBe('https://example.com');
     });
 
-    it.only('should update pool token metadata', async () => {
-      const tokenMetadata = new PublicKey(0);
-
+    it('should update pool token metadata', async () => {
       const res = await updatePoolTokenMetadata(
         connection,
         stakePoolAddress,
-        tokenMetadata,
         'test',
         'TEST',
         'https://example.com',


### PR DESCRIPTION
#### Problem

The stake pool program supports metaplex token metadata, but the JS bindings don't allow this currently.

#### Solution

Rebased and addressed the comments from #3441 -- thanks to @AlexanderRay for his work!

Fixes https://github.com/solana-labs/solana-program-library/issues/3369