### PR TITLE
token-js: added extra account resolution for transfer hook extension

### DIFF
--- a/token/js/examples/transferHook.ts
+++ b/token/js/examples/transferHook.ts
@@ -16,6 +16,9 @@ import {
     getMintLen,
     TOKEN_2022_PROGRAM_ID,
     updateTransferHook,
+    transferCheckedWithHook,
+    getAssociatedTokenAddressSync,
+    ASSOCIATED_TOKEN_PROGRAM_ID,
 } from '../src';
 
 (async () => {
@@ -24,6 +27,9 @@ import {
     const mintAuthority = Keypair.generate();
     const mintKeypair = Keypair.generate();
     const mint = mintKeypair.publicKey;
+
+    const sender = Keypair.generate();
+    const recipient = Keypair.generate();
 
     const extensions = [ExtensionType.TransferHook];
     const mintLen = getMintLen(extensions);
@@ -56,6 +62,35 @@ import {
         mint,
         newTransferHookProgramId,
         payer.publicKey,
+        [],
+        undefined,
+        TOKEN_2022_PROGRAM_ID
+    );
+
+    const senderAta = getAssociatedTokenAddressSync(
+        mint,
+        sender.publicKey,
+        false,
+        TOKEN_2022_PROGRAM_ID,
+        ASSOCIATED_TOKEN_PROGRAM_ID
+    );
+    const recipientAta = getAssociatedTokenAddressSync(
+        mint,
+        recipient.publicKey,
+        false,
+        TOKEN_2022_PROGRAM_ID,
+        ASSOCIATED_TOKEN_PROGRAM_ID
+    );
+
+    await transferCheckedWithHook(
+        connection,
+        payer,
+        senderAta,
+        mint,
+        recipientAta,
+        sender,
+        BigInt(1000000000),
+        9,
         [],
         undefined,
         TOKEN_2022_PROGRAM_ID

--- a/token/js/src/errors.ts
+++ b/token/js/src/errors.ts
@@ -70,9 +70,9 @@ export class TokenUnsupportedInstructionError extends TokenError {
     name = 'TokenUnsupportedInstructionError';
 }
 
-/** Thrown if the transfer hook extra accounts contains an invalid discriminator */
-export class TokenTransferHookInvalidDiscriminator extends TokenError {
-    name = 'TokenTransferHookInvalidDiscriminator';
+/** Thrown if the transfer hook extra accounts contains an invalid account index */
+export class TokenTransferHookAccountNotFound extends TokenError {
+    name = 'TokenTransferHookAccountNotFound';
 }
 
 /** Thrown if the transfer hook extra accounts contains an invalid seed */

--- a/token/js/src/errors.ts
+++ b/token/js/src/errors.ts
@@ -15,6 +15,11 @@ export class TokenInvalidAccountError extends TokenError {
     name = 'TokenInvalidAccountError';
 }
 
+/** Thrown if a program state account does not contain valid data */
+export class TokenInvalidAccountDataError extends TokenError {
+    name = 'TokenInvalidAccountDataError';
+}
+
 /** Thrown if a program state account is not owned by the expected token program */
 export class TokenInvalidAccountOwnerError extends TokenError {
     name = 'TokenInvalidAccountOwnerError';
@@ -63,4 +68,14 @@ export class TokenInvalidInstructionTypeError extends TokenError {
 /** Thrown if the program does not support the desired instruction */
 export class TokenUnsupportedInstructionError extends TokenError {
     name = 'TokenUnsupportedInstructionError';
+}
+
+/** Thrown if the transfer hook extra accounts contains an invalid discriminator */
+export class TokenTransferHookInvalidDiscriminator extends TokenError {
+    name = 'TokenTransferHookInvalidDiscriminator';
+}
+
+/** Thrown if the transfer hook extra accounts contains an invalid seed */
+export class TokenTransferHookInvalidSeed extends TokenError {
+    name = 'TokenTransferHookInvalidSeed';
 }

--- a/token/js/src/extensions/transferHook/actions.ts
+++ b/token/js/src/extensions/transferHook/actions.ts
@@ -1,22 +1,18 @@
 import type { Commitment, ConfirmOptions, Connection, Signer, TransactionSignature } from '@solana/web3.js';
 import { TransactionInstruction } from '@solana/web3.js';
-import { PublicKey } from '@solana/web3.js';
+import type { PublicKey } from '@solana/web3.js';
 import { sendAndConfirmTransaction, Transaction } from '@solana/web3.js';
 import { getSigners } from '../../actions/internal.js';
 import { TOKEN_2022_PROGRAM_ID, programSupportsExtensions } from '../../constants.js';
-import { createInitializeTransferHookInstruction, createUpdateTransferHookInstruction } from './instructions.js';
+import {
+    createInitializeTransferHookInstruction,
+    createTransferCheckedWithFeeAndTransferHookInstruction,
+    createTransferCheckedWithTransferHookInstruction,
+    createUpdateTransferHookInstruction,
+} from './instructions.js';
 import { getExtraAccountMetaAccount, getExtraAccountMetas, getTransferHook, resolveExtraAccountMeta } from './state.js';
 import { getMint } from '../../state/index.js';
-import {
-    TokenInvalidAccountDataError,
-    TokenInvalidAccountError,
-    TokenInvalidMintError,
-    TokenUnsupportedInstructionError,
-} from '../../errors.js';
-import {
-    createTransferCheckedInstruction,
-    decodeTransferCheckedInstruction,
-} from '../../instructions/transferChecked.js';
+import { TokenUnsupportedInstructionError } from '../../errors.js';
 
 /**
  * Initialize a transfer hook on a mint
@@ -131,7 +127,7 @@ export async function addExtraAccountsToInstruction(
 }
 
 /**
- * Transfer tokens from one account to another, asserting the transfer fee, token mint, and decimals
+ * Transfer tokens from one account to another, asserting the token mint, and decimals
  *
  * @param connection     Connection to use
  * @param payer          Payer of the transaction fees
@@ -162,26 +158,73 @@ export async function transferCheckedWithTransferHook(
 ): Promise<TransactionSignature> {
     const [authorityPublicKey, signers] = getSigners(authority, multiSigners);
 
-    const rawInstruction = createTransferCheckedInstruction(
-        source,
-        mint,
-        destination,
-        authorityPublicKey,
-        amount,
-        decimals,
-        signers,
-        programId
+    const transaction = new Transaction().add(
+        await createTransferCheckedWithTransferHookInstruction(
+            connection,
+            source,
+            mint,
+            destination,
+            authorityPublicKey,
+            amount,
+            decimals,
+            signers,
+            confirmOptions?.commitment,
+            programId
+        )
     );
 
-    const hydratedInstruction = await addExtraAccountsToInstruction(
-        connection,
-        rawInstruction,
-        mint,
-        confirmOptions?.commitment,
-        programId
-    );
+    return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);
+}
 
-    const transaction = new Transaction().add(hydratedInstruction);
+/**
+ * Transfer tokens from one account to another, asserting the transfer fee, token mint, and decimals
+ *
+ * @param connection     Connection to use
+ * @param payer          Payer of the transaction fees
+ * @param source         Source account
+ * @param mint           Mint for the account
+ * @param destination    Destination account
+ * @param authority      Authority of the source account
+ * @param amount         Number of tokens to transfer
+ * @param decimals       Number of decimals in transfer amount
+ * @param fee            The calculated fee for the transfer fee extension
+ * @param multiSigners   Signing accounts if `owner` is a multisig
+ * @param confirmOptions Options for confirming the transaction
+ * @param programId      SPL Token program account
+ *
+ * @return Signature of the confirmed transaction
+ */
+export async function transferCheckedWithFeeAndTransferHook(
+    connection: Connection,
+    payer: Signer,
+    source: PublicKey,
+    mint: PublicKey,
+    destination: PublicKey,
+    authority: Signer | PublicKey,
+    amount: bigint,
+    decimals: number,
+    fee: bigint,
+    multiSigners: Signer[] = [],
+    confirmOptions?: ConfirmOptions,
+    programId = TOKEN_2022_PROGRAM_ID
+): Promise<TransactionSignature> {
+    const [authorityPublicKey, signers] = getSigners(authority, multiSigners);
+
+    const transaction = new Transaction().add(
+        await createTransferCheckedWithFeeAndTransferHookInstruction(
+            connection,
+            source,
+            mint,
+            destination,
+            authorityPublicKey,
+            amount,
+            decimals,
+            fee,
+            signers,
+            confirmOptions?.commitment,
+            programId
+        )
+    );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);
 }

--- a/token/js/src/extensions/transferHook/actions.ts
+++ b/token/js/src/extensions/transferHook/actions.ts
@@ -1,8 +1,22 @@
-import type { ConfirmOptions, Connection, PublicKey, Signer, TransactionSignature } from '@solana/web3.js';
+import type { Commitment, ConfirmOptions, Connection, Signer, TransactionSignature } from '@solana/web3.js';
+import { TransactionInstruction } from '@solana/web3.js';
+import { PublicKey } from '@solana/web3.js';
 import { sendAndConfirmTransaction, Transaction } from '@solana/web3.js';
 import { getSigners } from '../../actions/internal.js';
-import { TOKEN_2022_PROGRAM_ID } from '../../constants.js';
+import { TOKEN_2022_PROGRAM_ID, programSupportsExtensions } from '../../constants.js';
 import { createInitializeTransferHookInstruction, createUpdateTransferHookInstruction } from './instructions.js';
+import { getExtraAccountMetas, getTransferHook, resolveExtraAccountMeta } from './state.js';
+import { getMint } from '../../state/index.js';
+import {
+    TokenInvalidAccountDataError,
+    TokenInvalidAccountError,
+    TokenInvalidMintError,
+    TokenUnsupportedInstructionError,
+} from '../../errors.js';
+import {
+    createTransferCheckedInstruction,
+    decodeTransferCheckedInstruction,
+} from '../../instructions/transferChecked.js';
 
 /**
  * Initialize a transfer hook on a mint
@@ -62,6 +76,119 @@ export async function updateTransferHook(
     const transaction = new Transaction().add(
         createUpdateTransferHookInstruction(mint, authorityPublicKey, transferHookProgramId, signers, programId)
     );
+
+    return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);
+}
+
+/**
+ * Add extra accounts needed for transfer hook to an instruction
+ *
+ * @param connection      Connection to use
+ * @param instruction     The transferChecked instruction to add accounts to
+ * @param commitment      Commitment to use
+ * @param programId       SPL Token program account
+ *
+ * @return Instruction to add to a transaction
+ */
+export async function addExtraAccountsToInstruction(
+    connection: Connection,
+    instruction: TransactionInstruction,
+    commitment?: Commitment,
+    programId = TOKEN_2022_PROGRAM_ID
+): Promise<TransactionInstruction> {
+    if (!programSupportsExtensions(programId)) {
+        throw new TokenUnsupportedInstructionError();
+    }
+
+    const decodedInstruction = decodeTransferCheckedInstruction(instruction, programId);
+
+    const mint = decodedInstruction.keys.mint.pubkey;
+    const mintInfo = await getMint(connection, mint, commitment, programId);
+    const transferHook = getTransferHook(mintInfo);
+    if (transferHook == null) {
+        throw new TokenInvalidMintError();
+    }
+
+    const extraAccountsAccount = PublicKey.findProgramAddressSync(
+        [Buffer.from('extra-account-metas'), mint.toBuffer()],
+        transferHook.programId
+    )[0];
+    const extraAccountsInfo = await connection.getAccountInfo(extraAccountsAccount, commitment);
+    if (extraAccountsInfo == null) {
+        throw new TokenInvalidAccountError();
+    }
+
+    const extraAccountMetas = getExtraAccountMetas(extraAccountsInfo);
+    if (extraAccountMetas == null) {
+        throw new TokenInvalidAccountDataError();
+    }
+
+    const accountMetas = instruction.keys;
+
+    for (const extraAccountMeta of extraAccountMetas) {
+        const accountMeta = resolveExtraAccountMeta(
+            extraAccountMeta,
+            accountMetas,
+            instruction.data,
+            transferHook.programId
+        );
+        accountMetas.push(accountMeta);
+    }
+
+    return new TransactionInstruction({ keys: accountMetas, programId, data: instruction.data });
+}
+
+/**
+ * Transfer tokens from one account to another, asserting the transfer fee, token mint, and decimals
+ *
+ * @param connection     Connection to use
+ * @param payer          Payer of the transaction fees
+ * @param source         Source account
+ * @param mint           Mint for the account
+ * @param destination    Destination account
+ * @param authority      Authority of the source account
+ * @param amount         Number of tokens to transfer
+ * @param decimals       Number of decimals in transfer amount
+ * @param multiSigners   Signing accounts if `owner` is a multisig
+ * @param confirmOptions Options for confirming the transaction
+ * @param programId      SPL Token program account
+ *
+ * @return Signature of the confirmed transaction
+ */
+export async function transferCheckedWithHook(
+    connection: Connection,
+    payer: Signer,
+    source: PublicKey,
+    mint: PublicKey,
+    destination: PublicKey,
+    authority: Signer | PublicKey,
+    amount: bigint,
+    decimals: number,
+    multiSigners: Signer[] = [],
+    confirmOptions?: ConfirmOptions,
+    programId = TOKEN_2022_PROGRAM_ID
+): Promise<TransactionSignature> {
+    const [authorityPublicKey, signers] = getSigners(authority, multiSigners);
+
+    const rawInstruction = createTransferCheckedInstruction(
+        source,
+        mint,
+        destination,
+        authorityPublicKey,
+        amount,
+        decimals,
+        signers,
+        programId
+    );
+
+    const hydratedInstruction = await addExtraAccountsToInstruction(
+        connection,
+        rawInstruction,
+        confirmOptions?.commitment,
+        programId
+    );
+
+    const transaction = new Transaction().add(hydratedInstruction);
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);
 }

--- a/token/js/src/extensions/transferHook/index.ts
+++ b/token/js/src/extensions/transferHook/index.ts
@@ -1,3 +1,4 @@
 export * from './actions.js';
 export * from './instructions.js';
+export * from './seeds.js';
 export * from './state.js';

--- a/token/js/src/extensions/transferHook/seeds.ts
+++ b/token/js/src/extensions/transferHook/seeds.ts
@@ -1,0 +1,80 @@
+import type { AccountMeta } from '@solana/web3.js';
+import { TokenTransferHookInvalidSeed } from '../../errors.js';
+
+interface Seed {
+    length: number;
+    data: Buffer;
+}
+
+function unpackSeedLiteral(seeds: Uint8Array): Seed {
+    if (seeds.length < 1) {
+        throw new TokenTransferHookInvalidSeed();
+    }
+    const [length, ...rest] = seeds;
+    if (rest.length < length) {
+        throw new TokenTransferHookInvalidSeed();
+    }
+    return {
+        data: Buffer.from(rest.slice(0, length)),
+        length: length + 2,
+    };
+}
+
+function unpackSeedInstructionArg(seeds: Uint8Array, instructionData: Buffer): Seed {
+    if (seeds.length < 2) {
+        throw new TokenTransferHookInvalidSeed();
+    }
+    const [index, length] = seeds;
+    if (instructionData.length < length) {
+        throw new TokenTransferHookInvalidSeed();
+    }
+    return {
+        data: instructionData.subarray(index, index + length),
+        length: 3,
+    };
+}
+
+function unpackSeedAccountKey(seeds: Uint8Array, previousMetas: AccountMeta[]): Seed {
+    if (seeds.length < 1) {
+        throw new TokenTransferHookInvalidSeed();
+    }
+    const [index] = seeds;
+    if (previousMetas.length <= index) {
+        throw new TokenTransferHookInvalidSeed();
+    }
+    return {
+        data: previousMetas[index].pubkey.toBuffer(),
+        length: 2,
+    };
+}
+
+function unpackFirstSeed(seeds: Uint8Array, previousMetas: AccountMeta[], instructionData: Buffer): Seed | null {
+    const [discriminator, ...rest] = seeds;
+    const remaining = new Uint8Array(rest);
+    switch (discriminator) {
+        case 0:
+            return null;
+        case 1:
+            return unpackSeedLiteral(remaining);
+        case 2:
+            return unpackSeedInstructionArg(remaining, instructionData);
+        case 3:
+            return unpackSeedAccountKey(remaining, previousMetas);
+        default:
+            throw new TokenTransferHookInvalidSeed();
+    }
+}
+
+export function unpackSeeds(seeds: Uint8Array, previousMetas: AccountMeta[], instructionData: Buffer): Buffer[] {
+    const unpackedSeeds: Buffer[] = [];
+    let i = 0;
+    while (i < 32) {
+        const seed = unpackFirstSeed(seeds.slice(i), previousMetas, instructionData);
+        if (seed == null) {
+            break;
+        }
+        unpackedSeeds.push(seed.data);
+        i += seed.length;
+    }
+    return unpackedSeeds;
+}

--- a/token/js/src/extensions/transferHook/state.ts
+++ b/token/js/src/extensions/transferHook/state.ts
@@ -88,20 +88,21 @@ export const ExtraAccountMetaListLayout = struct<ExtraAccountMetaList>([
 /** Buffer layout for de/serializing a list of ExtraAccountMetaAccountData prefixed by a u32 length */
 export interface ExtraAccountMetaAccountData {
     instructionDiscriminator: bigint;
-    arrayDiscriminator: number;
+    length: number;
     extraAccountsList: ExtraAccountMetaList;
 }
 
 /** Buffer layout for de/serializing an ExtraAccountMetaAccountData */
 export const ExtraAccountMetaAccountDataLayout = struct<ExtraAccountMetaAccountData>([
     u64('instructionDiscriminator'),
-    u32('arrayDiscriminator'),
+    u32('length'),
     ExtraAccountMetaListLayout.replicate('extraAccountsList'),
 ]);
 
 /** Unpack an extra account metas account and parse the data into a list of ExtraAccountMetas */
 export function getExtraAccountMetas(account: AccountInfo<Buffer>): ExtraAccountMeta[] {
-    return ExtraAccountMetaAccountDataLayout.decode(account.data).extraAccountsList.extraAccounts;
+    const extraAccountsList = ExtraAccountMetaAccountDataLayout.decode(account.data).extraAccountsList;
+    return extraAccountsList.extraAccounts.slice(0, extraAccountsList.count);
 }
 
 /** Take an ExtraAccountMeta and construct that into an acutal AccountMeta */

--- a/token/js/src/extensions/transferHook/state.ts
+++ b/token/js/src/extensions/transferHook/state.ts
@@ -53,6 +53,11 @@ export function getTransferHookAccount(account: Account): TransferHookAccount | 
     }
 }
 
+export function getExtraAccountMetaAccount(programId: PublicKey, mint: PublicKey): PublicKey {
+    const seeds = [Buffer.from('extra-account-metas'), mint.toBuffer()];
+    return PublicKey.findProgramAddressSync(seeds, programId)[0];
+}
+
 /** ExtraAccountMeta as stored by the transfer hook program */
 export interface ExtraAccountMeta {
     discriminator: number;
@@ -81,7 +86,7 @@ export const ExtraAccountMetaListLayout = struct<ExtraAccountMetaList>([
 ]);
 
 /** Unpack an extra account metas account and parse the data into a list of ExtraAccountMetas */
-export function getExtraAccountMetas(account: AccountInfo<Buffer>): ExtraAccountMeta[] | null {
+export function getExtraAccountMetas(account: AccountInfo<Buffer>): ExtraAccountMeta[] {
     return ExtraAccountMetaListLayout.decode(account.data).extraAccounts;
 }
 

--- a/token/js/test/unit/transferHook.test.ts
+++ b/token/js/test/unit/transferHook.test.ts
@@ -1,0 +1,139 @@
+import { getExtraAccountMetas, resolveExtraAccountMeta } from '../../src';
+import { expect } from 'chai';
+import { AccountMeta, Keypair, PublicKey } from '@solana/web3.js';
+
+describe('transferHookExtraAccounts', () => {
+    const testProgramId = new PublicKey('7N4HggYEJAtCLJdnHGCtFqfxcB5rhQCsQTze3ftYstVj');
+    const instructionData = Buffer.from(Array.from(Array(32).keys()));
+    const plainAccount = new PublicKey('6c5q79ccBTWvZTEx3JkdHThtMa2eALba5bfvHGf8kA2c');
+    const pdaPublicKey = new PublicKey('8Zibh9ywkKCZc3h23vwxvdMPG9yhg4LYYzky2yRkLHBJ');
+    const pdaPublicKeyWithProgramId = new PublicKey('9Apejge9XvJ3toZ8PX2sKKgMoyN7sSegzdq8n1kMzRae');
+
+    const plainSeed = Buffer.concat([
+        Buffer.from([1]), // u8 discriminator
+        Buffer.from([4]), // u8 length
+        Buffer.from('seed'), // 4 bytes seed
+    ]);
+
+    const instructionDataSeed = Buffer.concat([
+        Buffer.from([2]), // u8 discriminator
+        Buffer.from([4]), // u8 offset
+        Buffer.from([4]), // u8 length
+    ]);
+
+    const accountKeySeed = Buffer.concat([
+        Buffer.from([3]), // u8 discriminator
+        Buffer.from([0]), // u8 index
+    ]);
+
+    const addressConfig = Buffer.concat([plainSeed, instructionDataSeed, accountKeySeed], 32);
+
+    const plainExtraAccountMeta = {
+        discriminator: 0,
+        addressConfig: plainAccount.toBuffer(),
+        isSigner: false,
+        isWritable: false,
+    };
+    const plainExtraAccount = Buffer.concat([
+        Buffer.from([0]), // u8 discriminator
+        plainAccount.toBuffer(), // 32 bytes address
+        Buffer.from([0]), // bool isSigner
+        Buffer.from([0]), // bool isWritable
+    ]);
+
+    const pdaExtraAccountMeta = {
+        discriminator: 1,
+        addressConfig,
+        isSigner: true,
+        isWritable: false,
+    };
+    const pdaExtraAccount = Buffer.concat([
+        Buffer.from([1]), // u8 discriminator
+        addressConfig, // 32 bytes address config
+        Buffer.from([1]), // bool isSigner
+        Buffer.from([0]), // bool isWritable
+    ]);
+
+    const pdaExtraAccountMetaWithProgramId = {
+        discriminator: 128,
+        addressConfig,
+        isSigner: false,
+        isWritable: true,
+    };
+    const pdaExtraAccountWithProgramId = Buffer.concat([
+        Buffer.from([128]), // u8 discriminator
+        addressConfig, // 32 bytes address config
+        Buffer.from([0]), // bool isSigner
+        Buffer.from([1]), // bool isWritable
+    ]);
+
+    const extraAccountList = Buffer.concat([
+        Buffer.from([3, 0, 0, 0]), // u32 count
+        plainExtraAccount,
+        pdaExtraAccount,
+        pdaExtraAccountWithProgramId,
+    ]);
+
+    it('getExtraAccountMetas', () => {
+        const accountInfo = {
+            data: extraAccountList,
+            owner: PublicKey.default,
+            executable: false,
+            lamports: 0,
+        };
+        const parsedExtraAccounts = getExtraAccountMetas(accountInfo);
+        expect(parsedExtraAccounts).to.not.be.null;
+        if (parsedExtraAccounts == null) {
+            return;
+        }
+
+        expect(parsedExtraAccounts).to.have.length(3);
+        if (parsedExtraAccounts.length !== 3) {
+            return;
+        }
+
+        expect(parsedExtraAccounts[0].discriminator).to.eql(0);
+        expect(parsedExtraAccounts[0].addressConfig).to.eql(plainAccount.toBuffer());
+        expect(parsedExtraAccounts[0].isSigner).to.be.false;
+        expect(parsedExtraAccounts[0].isWritable).to.be.false;
+
+        expect(parsedExtraAccounts[1].discriminator).to.eql(1);
+        expect(parsedExtraAccounts[1].addressConfig).to.eql(addressConfig);
+        expect(parsedExtraAccounts[1].isSigner).to.be.true;
+        expect(parsedExtraAccounts[1].isWritable).to.be.false;
+
+        expect(parsedExtraAccounts[2].discriminator).to.eql(128);
+        expect(parsedExtraAccounts[2].addressConfig).to.eql(addressConfig);
+        expect(parsedExtraAccounts[2].isSigner).to.be.false;
+        expect(parsedExtraAccounts[2].isWritable).to.be.true;
+    });
+    it('resolveExtraAccountMeta', () => {
+        const resolvedPlainAccount = resolveExtraAccountMeta(plainExtraAccountMeta, [], instructionData, testProgramId);
+
+        expect(resolvedPlainAccount.pubkey).to.eql(plainAccount);
+        expect(resolvedPlainAccount.isSigner).to.be.false;
+        expect(resolvedPlainAccount.isWritable).to.be.false;
+
+        const resolvedPdaAccount = resolveExtraAccountMeta(
+            pdaExtraAccountMeta,
+            [resolvedPlainAccount],
+            instructionData,
+            testProgramId
+        );
+
+        expect(resolvedPdaAccount.pubkey).to.eql(pdaPublicKey);
+        expect(resolvedPdaAccount.isSigner).to.be.true;
+        expect(resolvedPdaAccount.isWritable).to.be.false;
+
+        const resolvedPdaAccountWithProgramId = resolveExtraAccountMeta(
+            pdaExtraAccountMetaWithProgramId,
+            [resolvedPlainAccount],
+            instructionData,
+            testProgramId
+        );
+
+        expect(resolvedPdaAccountWithProgramId.pubkey).to.eql(pdaPublicKeyWithProgramId);
+        expect(resolvedPdaAccountWithProgramId.isSigner).to.be.false;
+        expect(resolvedPdaAccountWithProgramId.isWritable).to.be.true;
+    });
+});

--- a/token/js/test/unit/transferHook.test.ts
+++ b/token/js/test/unit/transferHook.test.ts
@@ -6,8 +6,9 @@ describe('transferHookExtraAccounts', () => {
     const testProgramId = new PublicKey('7N4HggYEJAtCLJdnHGCtFqfxcB5rhQCsQTze3ftYstVj');
     const instructionData = Buffer.from(Array.from(Array(32).keys()));
     const plainAccount = new PublicKey('6c5q79ccBTWvZTEx3JkdHThtMa2eALba5bfvHGf8kA2c');
-    const pdaPublicKey = new PublicKey('8Zibh9ywkKCZc3h23vwxvdMPG9yhg4LYYzky2yRkLHBJ');
-    const pdaPublicKeyWithProgramId = new PublicKey('9Apejge9XvJ3toZ8PX2sKKgMoyN7sSegzdq8n1kMzRae');
+    const seeds = [Buffer.from('seed'), Buffer.from([4, 5, 6, 7]), plainAccount.toBuffer()];
+    const pdaPublicKey = PublicKey.findProgramAddressSync(seeds, testProgramId)[0];
+    const pdaPublicKeyWithProgramId = PublicKey.findProgramAddressSync(seeds, plainAccount)[0];
 
     const plainSeed = Buffer.concat([
         Buffer.from([1]), // u8 discriminator

--- a/token/js/test/unit/transferHook.test.ts
+++ b/token/js/test/unit/transferHook.test.ts
@@ -69,6 +69,8 @@ describe('transferHookExtraAccounts', () => {
     ]);
 
     const extraAccountList = Buffer.concat([
+        Buffer.from([0, 0, 0, 0, 0, 0, 0, 0]), // u64 accountDiscriminator
+        Buffer.from([0, 0, 0, 0]), // u32 arrayDiscriminator
         Buffer.from([3, 0, 0, 0]), // u32 count
         plainExtraAccount,
         pdaExtraAccount,


### PR DESCRIPTION
resolves #5108

Couple notes:
* Not sure exactly how multisigners is implemented for extra account resolution in the program since it changes the ordering of the account keys. Does it mean that if a user wants multisigners to work they explicitly need to code this into their transfer hook program?
* What is done by `tlv-account-resolution` in rust is now baked into `@solana/spl-token` for js. Might be a nice improvement to separate that into its own package?
* I have written a few tests to the best of my understanding of what exactly the data structure of the extra accounts data account is. Might be worth for @joncinque or @buffalojoec to check if my implementation actually matches that of the rust client.
* The way `transferCheckedWithHook` and `addExtraAccountsToInstruction` are structured is a little bit made up by me. Let me know if it matches your expectations @joncinque 