### PR TITLE
TLV Account Resolution: Add instruction data length check

### DIFF
--- a/libraries/tlv-account-resolution/src/account.rs
+++ b/libraries/tlv-account-resolution/src/account.rs
@@ -29,6 +29,9 @@ fn resolve_pda(
             Seed::InstructionData { index, length } => {
                 let arg_start = *index as usize;
                 let arg_end = arg_start + *length as usize;
+                if arg_end > instruction_data.len() {
+                    return Err(AccountResolutionError::InstructionDataTooSmall.into());
+                }
                 pda_seeds.push(&instruction_data[arg_start..arg_end]);
             }
             Seed::AccountKey { index } => {

--- a/libraries/tlv-account-resolution/src/error.rs
+++ b/libraries/tlv-account-resolution/src/error.rs
@@ -42,6 +42,9 @@ pub enum AccountResolutionError {
     /// Tried to pack an invalid seed configuration
     #[error("Tried to pack an invalid seed configuration")]
     InvalidSeedConfig,
+    /// Instruction data too small for seed configuration
+    #[error("Instruction data too small for seed configuration")]
+    InstructionDataTooSmall,
     /// Could not find account at specified index
     #[error("Could not find account at specified index")]
     AccountNotFound,


### PR DESCRIPTION
This PR adds a check to the seed resolution step for the provided instruction data, to ensure the instruction data buffer is at least long enough for the end index of the proposed slice.