### PR TITLE
token-2022: Featurize `zk-ops` to build without it

### DIFF
--- a/token/program-2022/src/extension/confidential_transfer/ciphertext_extraction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/ciphertext_extraction.rs
@@ -170,6 +170,7 @@ pub struct TransferProofContextInfo {
     pub new_source_ciphertext: ElGamalCiphertext,
 }
 
+#[cfg(feature = "zk-ops")]
 impl From<TransferProofContext> for TransferProofContextInfo {
     fn from(context: TransferProofContext) -> Self {
         let transfer_pubkeys = TransferPubkeysInfo {
@@ -187,6 +188,7 @@ impl From<TransferProofContext> for TransferProofContextInfo {
     }
 }
 
+#[cfg(feature = "zk-ops")]
 impl TransferProofContextInfo {
     /// Create a transfer proof context information needed to process a [Transfer] instruction from
     /// split proof contexts after verifying their consistency.

--- a/token/program-2022/src/extension/confidential_transfer/verify_proof.rs
+++ b/token/program-2022/src/extension/confidential_transfer/verify_proof.rs
@@ -124,6 +124,7 @@ pub fn verify_withdraw_proof(
 /// to verify, then the function returns a `TransferProofContextInfo` that is wrapped inside
 /// `Ok(Some(TransferProofContextInfo))`. If `no_op_on_split_proof_context_state` is `true` and
 /// some a split context state account is not initialized, then it returns `Ok(None)`.
+#[cfg(feature = "zk-ops")]
 pub fn verify_transfer_proof(
     account_info_iter: &mut Iter<'_, AccountInfo<'_>>,
     proof_instruction_offset: i64,


### PR DESCRIPTION
#### Problem

It isn't possible to build token-2022 with `--no-default-features`, since some parts depend on the `zk-ops` feature being enabled.

#### Solution

Add the feature check wherever needed to get `cargo build-sbf --no-default-features` to work.