### PR TITLE
bump spl lib errors

### DIFF
--- a/libraries/tlv-account-resolution/src/error.rs
+++ b/libraries/tlv-account-resolution/src/error.rs
@@ -3,11 +3,13 @@
 use spl_program_error::*;
 
 /// Errors that may be returned by the Account Resolution library.
+/// 
+/// Note: Error codes range from 20_000 - (20_000 + n)
 #[spl_program_error]
 pub enum AccountResolutionError {
     /// Incorrect account provided
     #[error("Incorrect account provided")]
-    IncorrectAccount,
+    IncorrectAccount = 20_000, // Error code offset
     /// Not enough accounts provided
     #[error("Not enough accounts provided")]
     NotEnoughAccounts,

--- a/libraries/tlv-account-resolution/src/error.rs
+++ b/libraries/tlv-account-resolution/src/error.rs
@@ -3,7 +3,6 @@
 use spl_program_error::*;
 
 /// Errors that may be returned by the Account Resolution library.
-/// 
 /// Note: Error codes range from 20_000 - (20_000 + n)
 #[spl_program_error]
 pub enum AccountResolutionError {

--- a/libraries/type-length-value/src/error.rs
+++ b/libraries/type-length-value/src/error.rs
@@ -3,11 +3,13 @@
 use spl_program_error::*;
 
 /// Errors that may be returned by the Token program.
+/// 
+/// Note: Error codes range from 10_000 - (10_000 + n)
 #[spl_program_error]
 pub enum TlvError {
     /// Type not found in TLV data
     #[error("Type not found in TLV data")]
-    TypeNotFound,
+    TypeNotFound = 10_000, // Error code offset
     /// Type already exists in TLV data
     #[error("Type already exists in TLV data")]
     TypeAlreadyExists,

--- a/libraries/type-length-value/src/error.rs
+++ b/libraries/type-length-value/src/error.rs
@@ -3,7 +3,6 @@
 use spl_program_error::*;
 
 /// Errors that may be returned by the Token program.
-/// 
 /// Note: Error codes range from 10_000 - (10_000 + n)
 #[spl_program_error]
 pub enum TlvError {

--- a/token-metadata/interface/src/error.rs
+++ b/token-metadata/interface/src/error.rs
@@ -3,11 +3,13 @@
 use spl_program_error::*;
 
 /// Errors that may be returned by the interface.
+/// 
+/// Note: Error codes range from 40_000 - (40_000 + n)
 #[spl_program_error]
 pub enum TokenMetadataError {
     /// Incorrect account provided
     #[error("Incorrect account provided")]
-    IncorrectAccount,
+    IncorrectAccount = 40_000, // Error code offset
     /// Mint has no mint authority
     #[error("Mint has no mint authority")]
     MintHasNoMintAuthority,

--- a/token-metadata/interface/src/error.rs
+++ b/token-metadata/interface/src/error.rs
@@ -3,7 +3,6 @@
 use spl_program_error::*;
 
 /// Errors that may be returned by the interface.
-/// 
 /// Note: Error codes range from 40_000 - (40_000 + n)
 #[spl_program_error]
 pub enum TokenMetadataError {

--- a/token/transfer-hook-example/tests/functional.rs
+++ b/token/transfer-hook-example/tests/functional.rs
@@ -18,7 +18,8 @@ use {
         transaction::{Transaction, TransactionError},
     },
     spl_tlv_account_resolution::{
-        account::ExtraAccountMeta, seeds::Seed, state::ExtraAccountMetaList,
+        account::ExtraAccountMeta, error::AccountResolutionError, seeds::Seed,
+        state::ExtraAccountMetaList,
     },
     spl_token_2022::{
         extension::{transfer_hook::TransferHookAccount, ExtensionType, StateWithExtensionsMut},
@@ -270,7 +271,7 @@ async fn success_execute() {
             error,
             TransactionError::InstructionError(
                 0,
-                InstructionError::Custom(TransferHookError::IncorrectAccount as u32),
+                InstructionError::Custom(AccountResolutionError::IncorrectAccount as u32),
             )
         );
     }
@@ -309,7 +310,7 @@ async fn success_execute() {
             error,
             TransactionError::InstructionError(
                 0,
-                InstructionError::Custom(TransferHookError::IncorrectAccount as u32),
+                InstructionError::Custom(AccountResolutionError::IncorrectAccount as u32),
             )
         );
     }
@@ -356,7 +357,7 @@ async fn success_execute() {
             error,
             TransactionError::InstructionError(
                 0,
-                InstructionError::Custom(TransferHookError::IncorrectAccount as u32),
+                InstructionError::Custom(AccountResolutionError::IncorrectAccount as u32),
             )
         );
     }
@@ -395,7 +396,7 @@ async fn success_execute() {
             error,
             TransactionError::InstructionError(
                 0,
-                InstructionError::Custom(TransferHookError::IncorrectAccount as u32),
+                InstructionError::Custom(AccountResolutionError::IncorrectAccount as u32),
             )
         );
     }

--- a/token/transfer-hook-interface/src/error.rs
+++ b/token/transfer-hook-interface/src/error.rs
@@ -11,7 +11,6 @@ use {
 };
 
 /// Errors that may be returned by the interface.
-/// 
 /// Note: Error codes range from 30_000 - (30_000 + n)
 #[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]
 pub enum TransferHookError {

--- a/token/transfer-hook-interface/src/error.rs
+++ b/token/transfer-hook-interface/src/error.rs
@@ -11,11 +11,13 @@ use {
 };
 
 /// Errors that may be returned by the interface.
+/// 
+/// Note: Error codes range from 30_000 - (30_000 + n)
 #[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]
 pub enum TransferHookError {
     /// Incorrect account provided
     #[error("Incorrect account provided")]
-    IncorrectAccount,
+    IncorrectAccount = 30_000, // Error code offset
     /// Mint has no mint authority
     #[error("Mint has no mint authority")]
     MintHasNoMintAuthority,


### PR DESCRIPTION
This PR addresses the problems presented by #5042 , however I would like
to discuss a deeper issue that may cause a wider range of problems for
downstream consumers of our SPL libraries.

## Problem

Our libraries have various methods that are designed to return `ProgramError`
in order to make using them within on-chain programs seamless and concise.
However, the concept of mapping a library's error directly to a program error
is actually a flawed design.

The `ProgramError::Custom(u32)` variant is specifically designed for an
on-chain program to implement any number of errors that can be mapped to a
`u32` error code from `0` to `u32::MAX`. These custom codes are intended for
errors that are **specific to that program** and have no relevance outside the
scope of that program's crate.

Thus, we cannot force errors from shared libraries to map to
`ProgramError::Custom(u32)` using pre-defined `u32` values. This will only
cause more issues related to #5042  and things will get further
complicated with libraries that are built on _other_ libraries, and so on.

## Solution

Decouple library errors from `ProgramError`, and instead provide tooling to
easily map library errors to `ProgramError` within on-chain programs.

## Temporary Solution

Simply bump the library errors to be very large `u32` values with
deterministic offsets.

Also create an issue describing the above problem.
