### PR TITLE
SPL errors from hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6799,6 +6799,7 @@ version = "0.2.0"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.29",
+ "solana-program",
  "syn 2.0.28",
 ]
 
@@ -7268,15 +7269,12 @@ version = "0.1.0"
 dependencies = [
  "arrayref",
  "bytemuck",
- "num-derive 0.4.0",
- "num-traits",
- "num_enum 0.7.0",
  "solana-program",
  "spl-discriminator",
  "spl-pod",
+ "spl-program-error",
  "spl-tlv-account-resolution",
  "spl-type-length-value",
- "thiserror",
 ]
 
 [[package]]

--- a/libraries/program-error/derive/Cargo.toml
+++ b/libraries/program-error/derive/Cargo.toml
@@ -13,4 +13,5 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
+solana-program = "1.16.3"
 syn = { version = "2.0", features = ["full"] }

--- a/libraries/program-error/derive/src/lib.rs
+++ b/libraries/program-error/derive/src/lib.rs
@@ -64,12 +64,17 @@ pub fn print_program_error(input: TokenStream) -> TokenStream {
 /// - `solana_program::decode_error::DecodeError`
 /// - `solana_program::program_error::PrintProgramError`
 ///
-/// Optionally, you can add `hash_error_codes: bool` argument to create unique
-/// `u32` error codes from the names of the enum variants.
+/// Optionally, you can add `hash_error_code_start: u32` argument to create
+/// a unique `u32` _starting_ error codes from the names of the enum variants.
+/// Notes:
+/// - The _error_ variant will start at this value, and the rest will be
+/// incremented by one
+/// - The value provided is only for code readability, the actual error code
+/// will be a hash of the input string and is checked against your input
 ///
-/// Syntax: `#[spl_program_error(hash_error_codes = true)]`
+/// Syntax: `#[spl_program_error(hash_error_code_start = 1275525928)]`
 /// Hash Input: `spl_program_error:<enum name>:<variant name>`
-/// Value: `u32::from_le_bytes(<hash of input>[8..12])`
+/// Value: `u32::from_le_bytes(<hash of input>[13..17])`
 #[proc_macro_attribute]
 pub fn spl_program_error(attr: TokenStream, input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(attr as SplProgramErrorArgs);

--- a/libraries/program-error/derive/src/macro_impl.rs
+++ b/libraries/program-error/derive/src/macro_impl.rs
@@ -11,7 +11,7 @@ use {
 };
 
 const SPL_ERROR_HASH_NAMESPACE: &str = "spl_program_error";
-const SPL_ERROR_HASH_MIN_VALUE: u32 = 7_0000;
+const SPL_ERROR_HASH_MIN_VALUE: u32 = 7_000;
 
 /// The type of macro being called, thus directing which tokens to generate
 #[allow(clippy::enum_variant_names)]

--- a/libraries/program-error/derive/src/parser.rs
+++ b/libraries/program-error/derive/src/parser.rs
@@ -1,9 +1,11 @@
+//! Token parsing
+
 use {
     proc_macro2::Ident,
     syn::{
         parse::{Parse, ParseStream},
         token::Comma,
-        LitBool, Token,
+        LitInt, Token,
     },
 };
 
@@ -11,40 +13,46 @@ use {
 pub struct SplProgramErrorArgs {
     /// Whether to hash the error codes using `solana_program::hash`
     /// or to use the default error code assigned by `num_traits`.
-    pub hash_error_codes: bool,
+    pub hash_error_code_start: Option<u32>,
 }
 
 impl Parse for SplProgramErrorArgs {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         if input.is_empty() {
             return Ok(Self {
-                hash_error_codes: false,
+                hash_error_code_start: None,
             });
         }
         match SplProgramErrorArgParser::parse(input)? {
             SplProgramErrorArgParser::HashErrorCodes { value, .. } => Ok(Self {
-                hash_error_codes: value.value,
+                hash_error_code_start: Some(value.base10_parse::<u32>()?),
             }),
         }
     }
 }
 
 /// Parser for args to the `#[spl_program_error]` attribute
-/// ie. `#[spl_program_error(hash_error_codes = true)]`
+/// ie. `#[spl_program_error(hash_error_code_start = 1275525928)]`
 enum SplProgramErrorArgParser {
     HashErrorCodes {
         _ident: Ident,
         _equals_sign: Token![=],
-        value: LitBool,
+        value: LitInt,
         _comma: Option<Comma>,
     },
 }
 
 impl Parse for SplProgramErrorArgParser {
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        let _ident = input.parse::<Ident>()?;
+        let _ident = {
+            let ident = input.parse::<Ident>()?;
+            if ident != "hash_error_code_start" {
+                return Err(input.error("Expected argument 'hash_error_code_start'"));
+            }
+            ident
+        };
         let _equals_sign = input.parse::<Token![=]>()?;
-        let value = input.parse::<LitBool>()?;
+        let value = input.parse::<LitInt>()?;
         let _comma: Option<Comma> = input.parse().unwrap_or(None);
         Ok(Self::HashErrorCodes {
             _ident,

--- a/libraries/program-error/derive/src/parser.rs
+++ b/libraries/program-error/derive/src/parser.rs
@@ -1,0 +1,56 @@
+use {
+    proc_macro2::Ident,
+    syn::{
+        parse::{Parse, ParseStream},
+        token::Comma,
+        LitBool, Token,
+    },
+};
+
+/// Possible arguments to the `#[spl_program_error]` attribute
+pub struct SplProgramErrorArgs {
+    /// Whether to hash the error codes using `solana_program::hash`
+    /// or to use the default error code assigned by `num_traits`.
+    pub hash_error_codes: bool,
+}
+
+impl Parse for SplProgramErrorArgs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        if input.is_empty() {
+            return Ok(Self {
+                hash_error_codes: false,
+            });
+        }
+        match SplProgramErrorArgParser::parse(input)? {
+            SplProgramErrorArgParser::HashErrorCodes { value, .. } => Ok(Self {
+                hash_error_codes: value.value,
+            }),
+        }
+    }
+}
+
+/// Parser for args to the `#[spl_program_error]` attribute
+/// ie. `#[spl_program_error(hash_error_codes = true)]`
+enum SplProgramErrorArgParser {
+    HashErrorCodes {
+        _ident: Ident,
+        _equals_sign: Token![=],
+        value: LitBool,
+        _comma: Option<Comma>,
+    },
+}
+
+impl Parse for SplProgramErrorArgParser {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let _ident = input.parse::<Ident>()?;
+        let _equals_sign = input.parse::<Token![=]>()?;
+        let value = input.parse::<LitBool>()?;
+        let _comma: Option<Comma> = input.parse().unwrap_or(None);
+        Ok(Self::HashErrorCodes {
+            _ident,
+            _equals_sign,
+            value,
+            _comma,
+        })
+    }
+}

--- a/libraries/program-error/src/lib.rs
+++ b/libraries/program-error/src/lib.rs
@@ -8,10 +8,10 @@ extern crate self as spl_program_error;
 
 // Make these available downstream for the macro to work without
 // additional imports
-pub use num_derive;
-pub use num_traits;
-pub use solana_program;
-pub use spl_program_error_derive::{
-    spl_program_error, DecodeError, IntoProgramError, PrintProgramError,
+pub use {
+    num_derive, num_traits, solana_program,
+    spl_program_error_derive::{
+        spl_program_error, DecodeError, IntoProgramError, PrintProgramError,
+    },
+    thiserror,
 };
-pub use thiserror;

--- a/libraries/program-error/tests/decode.rs
+++ b/libraries/program-error/tests/decode.rs
@@ -1,5 +1,5 @@
 //! Tests `#[derive(DecodeError)]`
-//!
+
 use spl_program_error::*;
 
 /// Example error

--- a/libraries/program-error/tests/into.rs
+++ b/libraries/program-error/tests/into.rs
@@ -1,5 +1,5 @@
 //! Tests `#[derive(IntoProgramError)]`
-//!
+
 use spl_program_error::*;
 
 /// Example error

--- a/libraries/program-error/tests/mod.rs
+++ b/libraries/program-error/tests/mod.rs
@@ -6,13 +6,15 @@ pub mod spl;
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use serial_test::serial;
-    use solana_program::{
-        decode_error::DecodeError,
-        program_error::{PrintProgramError, ProgramError},
+    use {
+        super::*,
+        serial_test::serial,
+        solana_program::{
+            decode_error::DecodeError,
+            program_error::{PrintProgramError, ProgramError},
+        },
+        std::sync::{Arc, RwLock},
     };
-    use std::sync::{Arc, RwLock};
 
     // Used to capture output for `PrintProgramError` for testing
     lazy_static::lazy_static! {

--- a/libraries/program-error/tests/print.rs
+++ b/libraries/program-error/tests/print.rs
@@ -1,5 +1,5 @@
 //! Tests `#[derive(PrintProgramError)]`
-//!
+
 use spl_program_error::*;
 
 /// Example error

--- a/libraries/program-error/tests/spl.rs
+++ b/libraries/program-error/tests/spl.rs
@@ -20,7 +20,7 @@ fn test_macros_compile() {
 }
 
 /// Example library error with namespace
-#[spl_program_error(hash_error_code_start = 1_275_525_928)]
+#[spl_program_error(hash_error_code_start = 3_234_444_947)]
 enum ExampleLibraryError {
     /// This is a very informative error
     #[error("This is a very informative error")]
@@ -40,10 +40,17 @@ enum ExampleLibraryError {
 #[test]
 fn test_library_error_codes() {
     fn get_error_code_check(hash_input: &str) -> u32 {
-        let preimage = solana_program::hash::hashv(&[hash_input.as_bytes()]);
-        let mut bytes = [0u8; 4];
-        bytes.copy_from_slice(&preimage.to_bytes()[13..17]);
-        u32::from_le_bytes(bytes)
+        let mut nonce: u32 = 0;
+        loop {
+            let hash = solana_program::hash::hashv(&[hash_input.as_bytes(), &nonce.to_le_bytes()]);
+            let mut bytes = [0u8; 4];
+            bytes.copy_from_slice(&hash.to_bytes()[13..17]);
+            let error_code = u32::from_le_bytes(bytes);
+            if error_code >= 10_000 {
+                return error_code;
+            }
+            nonce += 1;
+        }
     }
 
     let first_error_as_u32 = ExampleLibraryError::VeryInformativeError as u32;

--- a/libraries/program-error/tests/spl.rs
+++ b/libraries/program-error/tests/spl.rs
@@ -20,7 +20,7 @@ fn test_macros_compile() {
 }
 
 /// Example library error with namespace
-#[spl_program_error(hash_error_code_start = 3_234_444_947)]
+#[spl_program_error(hash_error_code_start = 2_056_342_880)]
 enum ExampleLibraryError {
     /// This is a very informative error
     #[error("This is a very informative error")]
@@ -57,7 +57,7 @@ fn test_library_error_codes() {
 
     assert_eq!(
         ExampleLibraryError::VeryInformativeError as u32,
-        get_error_code_check("spl_program_error:ExampleLibraryError:VeryInformativeError"),
+        get_error_code_check("spl_program_error:ExampleLibraryError"),
     );
     assert_eq!(
         ExampleLibraryError::SuperImportantError as u32,

--- a/libraries/program-error/tests/spl.rs
+++ b/libraries/program-error/tests/spl.rs
@@ -1,5 +1,5 @@
 //! Tests `#[spl_program_error]`
-//!
+
 use spl_program_error::*;
 
 /// Example error
@@ -17,4 +17,48 @@ pub enum ExampleError {
 #[test]
 fn test_macros_compile() {
     let _ = ExampleError::MintHasNoMintAuthority;
+}
+
+/// Example library error with namespace
+#[spl_program_error(hash_error_codes = true)]
+enum ExampleLibraryError {
+    /// This is a very informative error
+    #[error("This is a very informative error")]
+    VeryInformativeError,
+    /// This is a super important error
+    #[error("This is a super important error")]
+    SuperImportantError,
+    /// This is a mega serious error
+    #[error("This is a mega serious error")]
+    MegaSeriousError,
+    /// You are toast
+    #[error("You are toast")]
+    YouAreToast,
+}
+
+/// Tests hashing of error codes into unique `u32` values
+#[test]
+fn test_library_error_codes() {
+    fn get_error_code_check(hash_input: &str) -> u32 {
+        let preimage = solana_program::hash::hashv(&[hash_input.as_bytes()]);
+        let mut bytes = [0u8; 4];
+        bytes.copy_from_slice(&preimage.to_bytes()[13..17]);
+        u32::from_le_bytes(bytes)
+    }
+    assert_eq!(
+        ExampleLibraryError::VeryInformativeError as u32,
+        get_error_code_check("spl_program_error:ExampleLibraryError:VeryInformativeError"),
+    );
+    assert_eq!(
+        ExampleLibraryError::SuperImportantError as u32,
+        get_error_code_check("spl_program_error:ExampleLibraryError:SuperImportantError"),
+    );
+    assert_eq!(
+        ExampleLibraryError::MegaSeriousError as u32,
+        get_error_code_check("spl_program_error:ExampleLibraryError:MegaSeriousError"),
+    );
+    assert_eq!(
+        ExampleLibraryError::YouAreToast as u32,
+        get_error_code_check("spl_program_error:ExampleLibraryError:YouAreToast"),
+    );
 }

--- a/libraries/program-error/tests/spl.rs
+++ b/libraries/program-error/tests/spl.rs
@@ -20,7 +20,7 @@ fn test_macros_compile() {
 }
 
 /// Example library error with namespace
-#[spl_program_error(hash_error_codes = true)]
+#[spl_program_error(hash_error_code_start = 1_275_525_928)]
 enum ExampleLibraryError {
     /// This is a very informative error
     #[error("This is a very informative error")]
@@ -45,20 +45,23 @@ fn test_library_error_codes() {
         bytes.copy_from_slice(&preimage.to_bytes()[13..17]);
         u32::from_le_bytes(bytes)
     }
+
+    let first_error_as_u32 = ExampleLibraryError::VeryInformativeError as u32;
+
     assert_eq!(
         ExampleLibraryError::VeryInformativeError as u32,
         get_error_code_check("spl_program_error:ExampleLibraryError:VeryInformativeError"),
     );
     assert_eq!(
         ExampleLibraryError::SuperImportantError as u32,
-        get_error_code_check("spl_program_error:ExampleLibraryError:SuperImportantError"),
+        first_error_as_u32 + 1,
     );
     assert_eq!(
         ExampleLibraryError::MegaSeriousError as u32,
-        get_error_code_check("spl_program_error:ExampleLibraryError:MegaSeriousError"),
+        first_error_as_u32 + 2,
     );
     assert_eq!(
         ExampleLibraryError::YouAreToast as u32,
-        get_error_code_check("spl_program_error:ExampleLibraryError:YouAreToast"),
+        first_error_as_u32 + 3,
     );
 }

--- a/libraries/tlv-account-resolution/src/error.rs
+++ b/libraries/tlv-account-resolution/src/error.rs
@@ -3,7 +3,7 @@
 use spl_program_error::*;
 
 /// Errors that may be returned by the Account Resolution library.
-#[spl_program_error]
+#[spl_program_error(hash_error_codes = true)]
 pub enum AccountResolutionError {
     /// Incorrect account provided
     #[error("Incorrect account provided")]

--- a/libraries/tlv-account-resolution/src/error.rs
+++ b/libraries/tlv-account-resolution/src/error.rs
@@ -3,7 +3,7 @@
 use spl_program_error::*;
 
 /// Errors that may be returned by the Account Resolution library.
-#[spl_program_error(hash_error_code_start = 2_127_734_810)]
+#[spl_program_error(hash_error_code_start = 2_724_315_840)]
 pub enum AccountResolutionError {
     /// Incorrect account provided
     #[error("Incorrect account provided")]

--- a/libraries/tlv-account-resolution/src/error.rs
+++ b/libraries/tlv-account-resolution/src/error.rs
@@ -3,7 +3,7 @@
 use spl_program_error::*;
 
 /// Errors that may be returned by the Account Resolution library.
-#[spl_program_error(hash_error_codes = true)]
+#[spl_program_error(hash_error_code_start = 3_300_368_793)]
 pub enum AccountResolutionError {
     /// Incorrect account provided
     #[error("Incorrect account provided")]

--- a/libraries/tlv-account-resolution/src/error.rs
+++ b/libraries/tlv-account-resolution/src/error.rs
@@ -3,7 +3,7 @@
 use spl_program_error::*;
 
 /// Errors that may be returned by the Account Resolution library.
-#[spl_program_error(hash_error_code_start = 3_300_368_793)]
+#[spl_program_error(hash_error_code_start = 2_127_734_810)]
 pub enum AccountResolutionError {
     /// Incorrect account provided
     #[error("Incorrect account provided")]

--- a/libraries/type-length-value/src/error.rs
+++ b/libraries/type-length-value/src/error.rs
@@ -3,7 +3,7 @@
 use spl_program_error::*;
 
 /// Errors that may be returned by the Token program.
-#[spl_program_error(hash_error_code_start = 3_979_750_883)]
+#[spl_program_error(hash_error_code_start = 3_787_709_112)]
 pub enum TlvError {
     /// Type not found in TLV data
     #[error("Type not found in TLV data")]

--- a/libraries/type-length-value/src/error.rs
+++ b/libraries/type-length-value/src/error.rs
@@ -3,7 +3,7 @@
 use spl_program_error::*;
 
 /// Errors that may be returned by the Token program.
-#[spl_program_error]
+#[spl_program_error(hash_error_codes = true)]
 pub enum TlvError {
     /// Type not found in TLV data
     #[error("Type not found in TLV data")]

--- a/libraries/type-length-value/src/error.rs
+++ b/libraries/type-length-value/src/error.rs
@@ -3,7 +3,7 @@
 use spl_program_error::*;
 
 /// Errors that may be returned by the Token program.
-#[spl_program_error(hash_error_codes = true)]
+#[spl_program_error(hash_error_code_start = 3_979_750_883)]
 pub enum TlvError {
     /// Type not found in TLV data
     #[error("Type not found in TLV data")]

--- a/libraries/type-length-value/src/error.rs
+++ b/libraries/type-length-value/src/error.rs
@@ -3,7 +3,7 @@
 use spl_program_error::*;
 
 /// Errors that may be returned by the Token program.
-#[spl_program_error(hash_error_code_start = 3_787_709_112)]
+#[spl_program_error(hash_error_code_start = 1_202_666_432)]
 pub enum TlvError {
     /// Type not found in TLV data
     #[error("Type not found in TLV data")]

--- a/token-metadata/interface/src/error.rs
+++ b/token-metadata/interface/src/error.rs
@@ -3,7 +3,7 @@
 use spl_program_error::*;
 
 /// Errors that may be returned by the interface.
-#[spl_program_error]
+#[spl_program_error(hash_error_codes = true)]
 pub enum TokenMetadataError {
     /// Incorrect account provided
     #[error("Incorrect account provided")]

--- a/token-metadata/interface/src/error.rs
+++ b/token-metadata/interface/src/error.rs
@@ -3,7 +3,7 @@
 use spl_program_error::*;
 
 /// Errors that may be returned by the interface.
-#[spl_program_error(hash_error_codes = true)]
+#[spl_program_error(hash_error_code_start = 1_907_429_725)]
 pub enum TokenMetadataError {
     /// Incorrect account provided
     #[error("Incorrect account provided")]

--- a/token-metadata/interface/src/error.rs
+++ b/token-metadata/interface/src/error.rs
@@ -3,7 +3,7 @@
 use spl_program_error::*;
 
 /// Errors that may be returned by the interface.
-#[spl_program_error(hash_error_code_start = 1_907_429_725)]
+#[spl_program_error(hash_error_code_start = 933_549_204)]
 pub enum TokenMetadataError {
     /// Incorrect account provided
     #[error("Incorrect account provided")]

--- a/token-metadata/interface/src/error.rs
+++ b/token-metadata/interface/src/error.rs
@@ -3,7 +3,7 @@
 use spl_program_error::*;
 
 /// Errors that may be returned by the interface.
-#[spl_program_error(hash_error_code_start = 933_549_204)]
+#[spl_program_error(hash_error_code_start = 901_952_957)]
 pub enum TokenMetadataError {
     /// Incorrect account provided
     #[error("Incorrect account provided")]

--- a/token/transfer-hook-example/tests/functional.rs
+++ b/token/transfer-hook-example/tests/functional.rs
@@ -18,7 +18,8 @@ use {
         transaction::{Transaction, TransactionError},
     },
     spl_tlv_account_resolution::{
-        account::ExtraAccountMeta, seeds::Seed, state::ExtraAccountMetaList,
+        account::ExtraAccountMeta, error::AccountResolutionError, seeds::Seed,
+        state::ExtraAccountMetaList,
     },
     spl_token_2022::{
         extension::{transfer_hook::TransferHookAccount, ExtensionType, StateWithExtensionsMut},
@@ -270,7 +271,7 @@ async fn success_execute() {
             error,
             TransactionError::InstructionError(
                 0,
-                InstructionError::Custom(TransferHookError::IncorrectAccount as u32),
+                InstructionError::Custom(AccountResolutionError::IncorrectAccount as u32),
             )
         );
     }
@@ -309,7 +310,7 @@ async fn success_execute() {
             error,
             TransactionError::InstructionError(
                 0,
-                InstructionError::Custom(TransferHookError::IncorrectAccount as u32),
+                InstructionError::Custom(AccountResolutionError::IncorrectAccount as u32),
             )
         );
     }
@@ -356,7 +357,7 @@ async fn success_execute() {
             error,
             TransactionError::InstructionError(
                 0,
-                InstructionError::Custom(TransferHookError::IncorrectAccount as u32),
+                InstructionError::Custom(AccountResolutionError::IncorrectAccount as u32),
             )
         );
     }
@@ -395,7 +396,7 @@ async fn success_execute() {
             error,
             TransactionError::InstructionError(
                 0,
-                InstructionError::Custom(TransferHookError::IncorrectAccount as u32),
+                InstructionError::Custom(AccountResolutionError::IncorrectAccount as u32),
             )
         );
     }

--- a/token/transfer-hook-interface/Cargo.toml
+++ b/token/transfer-hook-interface/Cargo.toml
@@ -10,15 +10,12 @@ edition = "2021"
 [dependencies]
 arrayref = "0.3.7"
 bytemuck = { version = "1.13.1", features = ["derive"] }
-num-derive = "0.4"
-num-traits = "0.2"
-num_enum = "0.7.0"
 solana-program = "1.16.3"
 spl-discriminator = { version = "0.1.0" , path = "../../libraries/discriminator" }
+spl-program-error = { version = "0.2.0" , path = "../../libraries/program-error" }
 spl-tlv-account-resolution = { version = "0.2.0" , path = "../../libraries/tlv-account-resolution" }
 spl-type-length-value = { version = "0.2.0" , path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.1.0", path = "../../libraries/pod" }
-thiserror = "1.0"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/token/transfer-hook-interface/src/error.rs
+++ b/token/transfer-hook-interface/src/error.rs
@@ -3,7 +3,7 @@
 use spl_program_error::*;
 
 /// Errors that may be returned by the interface.
-#[spl_program_error(hash_error_code_start = 3_496_640_673)]
+#[spl_program_error(hash_error_code_start = 528_258_895)]
 pub enum TransferHookError {
     /// Incorrect account provided
     #[error("Incorrect account provided")]

--- a/token/transfer-hook-interface/src/error.rs
+++ b/token/transfer-hook-interface/src/error.rs
@@ -3,7 +3,7 @@
 use spl_program_error::*;
 
 /// Errors that may be returned by the interface.
-#[spl_program_error(hash_error_code_start = 528_258_895)]
+#[spl_program_error(hash_error_code_start = 2_110_272_652)]
 pub enum TransferHookError {
     /// Incorrect account provided
     #[error("Incorrect account provided")]

--- a/token/transfer-hook-interface/src/error.rs
+++ b/token/transfer-hook-interface/src/error.rs
@@ -3,7 +3,7 @@
 use spl_program_error::*;
 
 /// Errors that may be returned by the interface.
-#[spl_program_error(hash_error_codes = true)]
+#[spl_program_error(hash_error_code_start = 3_496_640_673)]
 pub enum TransferHookError {
     /// Incorrect account provided
     #[error("Incorrect account provided")]

--- a/token/transfer-hook-interface/src/error.rs
+++ b/token/transfer-hook-interface/src/error.rs
@@ -1,17 +1,9 @@
 //! Error types
 
-use {
-    num_derive::FromPrimitive,
-    solana_program::{
-        decode_error::DecodeError,
-        msg,
-        program_error::{PrintProgramError, ProgramError},
-    },
-    thiserror::Error,
-};
+use spl_program_error::*;
 
 /// Errors that may be returned by the interface.
-#[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]
+#[spl_program_error(hash_error_codes = true)]
 pub enum TransferHookError {
     /// Incorrect account provided
     #[error("Incorrect account provided")]
@@ -25,36 +17,4 @@ pub enum TransferHookError {
     /// Program called outside of a token transfer
     #[error("Program called outside of a token transfer")]
     ProgramCalledOutsideOfTransfer,
-}
-impl From<TransferHookError> for ProgramError {
-    fn from(e: TransferHookError) -> Self {
-        ProgramError::Custom(e as u32)
-    }
-}
-impl<T> DecodeError<T> for TransferHookError {
-    fn type_of() -> &'static str {
-        "TransferHookError"
-    }
-}
-
-impl PrintProgramError for TransferHookError {
-    fn print<E>(&self)
-    where
-        E: 'static
-            + std::error::Error
-            + DecodeError<E>
-            + PrintProgramError
-            + num_traits::FromPrimitive,
-    {
-        match self {
-            Self::IncorrectAccount => msg!("Incorrect account provided"),
-            Self::MintHasNoMintAuthority => msg!("Mint has no mint authority"),
-            Self::IncorrectMintAuthority => {
-                msg!("Incorrect mint authority has signed the instruction")
-            }
-            Self::ProgramCalledOutsideOfTransfer => {
-                msg!("Program called outside of a token transfer")
-            }
-        }
-    }
 }


### PR DESCRIPTION
This PR adds unique, custom error codes to every error in SPL libraries - including the two interfaces `transfer-hook` and `token-metadata`.

The ability to derive unique `u32` error codes from hash inputs is powered by these changes to the `spl-program-error` crate, which simply hashes the following combination of inputs and takes bytes 13 through 16 as the little-endian `u32`:

```text
"spl_program_error:" + <enum name> + ":" + <variant name>
```

This creates unique error codes for each error, as requested in [this comment](https://github.com/solana-labs/solana-program-library/pull/5168#issuecomment-1697853488)

Closes #5042 
Solves discussions in #5168