### PR TITLE
token-cli: Support updating metadata authority

### DIFF
--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -3224,7 +3224,7 @@ fn app<'a, 'b>(
                             "mint", "freeze", "owner", "close",
                             "close-mint", "transfer-fee-config", "withheld-withdraw",
                             "interest-rate", "permanent-delegate", "confidential-transfer-mint",
-                            "transfer-hook",
+                            "transfer-hook-program-id", "confidential-transfer-fee", "metadata-pointer",
                         ])
                         .index(2)
                         .required(true)


### PR DESCRIPTION
#### Problem

Although token-metadata operations are supported in the CLI, the metadata update-authority missed the boat because I thought it was handled by `authorize`, when it wasn't. It uses a separate instruction on the token-metadata interface.

#### Solution

Since the token metadata authority isn't a normal `AuthorityType`, and exists on a separate interface, I preferred to keep a cleaner separation of interfaces and avoid mixing the two by adding `AuthorityType::Metadata`.

To do that, add a new `CliAuthorityType`, which also contains the metadata authority, and will do a better job of supporting new authority types going forward. From there, call the token-metadata `update_authority` function properly.

We had a bunch of missing types in the "possible values" part of the authorize command, which is natural considering there's a few places that need to be updated with strings. With the new enum, we'll be able to support new authorities with just a couple of lines of code rather than a few random places that need to be updated!