### PR TITLE
Fix incorrect code doc

### DIFF
--- a/libraries/pod/src/bytemuck.rs
+++ b/libraries/pod/src/bytemuck.rs
@@ -36,7 +36,7 @@ pub fn pod_from_bytes_mut<T: Pod>(bytes: &mut [u8]) -> Result<&mut T, ProgramErr
     bytemuck::try_from_bytes_mut(bytes).map_err(|_| ProgramError::InvalidArgument)
 }
 
-/// Convert a slice into a mutable `Pod` slice (zero copy)
+/// Convert a slice into a `Pod` slice (zero copy)
 pub fn pod_slice_from_bytes<T: Pod>(bytes: &[u8]) -> Result<&[T], ProgramError> {
     bytemuck::try_cast_slice(bytes).map_err(|_| ProgramError::InvalidArgument)
 }


### PR DESCRIPTION
`pod_slice_from_bytes()` return type isn't mutable, so let's fix the doc that suggests it will be.

Also, I find the docs in this file a little hard to read, because the word `slice` is used so many times. Do you think it is worth saying `slice of bytes` or `byte slice` or something to distinguish those slices from the slices of `Pod`?