### PR TITLE
spl-pod: make code docs more explicit

### DIFF
--- a/libraries/pod/src/bytemuck.rs
+++ b/libraries/pod/src/bytemuck.rs
@@ -7,19 +7,20 @@ pub const fn pod_get_packed_len<T: Pod>() -> usize {
     std::mem::size_of::<T>()
 }
 
-/// Convert a `Pod` into a slice (zero copy)
+/// Convert a `Pod` into a slice of bytes (zero copy)
 pub fn pod_bytes_of<T: Pod>(t: &T) -> &[u8] {
     bytemuck::bytes_of(t)
 }
 
-/// Convert a slice into a `Pod` (zero copy)
+/// Convert a slice of bytes into a `Pod` (zero copy)
 pub fn pod_from_bytes<T: Pod>(bytes: &[u8]) -> Result<&T, ProgramError> {
     bytemuck::try_from_bytes(bytes).map_err(|_| ProgramError::InvalidArgument)
 }
 
-/// Maybe convert a slice into a `Pod` (zero copy)
+/// Maybe convert a slice of bytes into a `Pod` (zero copy)
 ///
-/// Returns `None` if the slice is empty, but `Err` if all other lengths but `get_packed_len()`
+/// Returns `None` if the slice is empty, or else `Err` if input length is not equal to
+/// `pod_get_packed_len::<T>()`.
 /// This function exists primarily because `Option<T>` is not a `Pod`.
 pub fn pod_maybe_from_bytes<T: Pod>(bytes: &[u8]) -> Result<Option<&T>, ProgramError> {
     if bytes.is_empty() {
@@ -31,22 +32,22 @@ pub fn pod_maybe_from_bytes<T: Pod>(bytes: &[u8]) -> Result<Option<&T>, ProgramE
     }
 }
 
-/// Convert a slice into a mutable `Pod` (zero copy)
+/// Convert a slice of bytes into a mutable `Pod` (zero copy)
 pub fn pod_from_bytes_mut<T: Pod>(bytes: &mut [u8]) -> Result<&mut T, ProgramError> {
     bytemuck::try_from_bytes_mut(bytes).map_err(|_| ProgramError::InvalidArgument)
 }
 
-/// Convert a slice into a `Pod` slice (zero copy)
+/// Convert a slice of bytes into a `Pod` slice (zero copy)
 pub fn pod_slice_from_bytes<T: Pod>(bytes: &[u8]) -> Result<&[T], ProgramError> {
     bytemuck::try_cast_slice(bytes).map_err(|_| ProgramError::InvalidArgument)
 }
 
-/// Convert a slice into a mutable `Pod` slice (zero copy)
+/// Convert a slice of bytes into a mutable `Pod` slice (zero copy)
 pub fn pod_slice_from_bytes_mut<T: Pod>(bytes: &mut [u8]) -> Result<&mut [T], ProgramError> {
     bytemuck::try_cast_slice_mut(bytes).map_err(|_| ProgramError::InvalidArgument)
 }
 
-/// Convert a pod slice into its raw bytes
+/// Convert a `Pod` slice into a single slice of bytes
 pub fn pod_slice_to_bytes<T: Pod>(slice: &[T]) -> &[u8] {
     bytemuck::cast_slice(slice)
 }


### PR DESCRIPTION
This PR updates code docs in bytemuck.rs to specify what each slice is a slice of, as discussed [here](https://github.com/solana-labs/solana-program-library/pull/5177#pullrequestreview-1603204939)
I also threw in a couple other changes that I thought made the docs more clear, and for consistency.