### PR TITLE
stake-pool: Use unaligned types for safe pointer cast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6898,6 +6898,7 @@ dependencies = [
  "solana-sdk",
  "solana-vote-program",
  "spl-math",
+ "spl-pod",
  "spl-token 4.0.0",
  "spl-token-2022 0.7.0",
  "test-case",

--- a/libraries/pod/src/primitives.rs
+++ b/libraries/pod/src/primitives.rs
@@ -4,6 +4,9 @@ use bytemuck::{Pod, Zeroable};
 #[cfg(feature = "serde-traits")]
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "borsh")]
+use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+
 /// The standard `bool` is not a `Pod`, define a replacement that is
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde-traits", serde(from = "bool", into = "bool"))]
@@ -72,6 +75,10 @@ pub struct PodI16([u8; 2]);
 impl_int_conversion!(PodI16, i16);
 
 /// `u32` type that can be used in `Pod`s
+#[cfg_attr(
+    feature = "borsh",
+    derive(BorshDeserialize, BorshSerialize, BorshSchema)
+)]
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde-traits", serde(from = "u32", into = "u32"))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
@@ -80,6 +87,10 @@ pub struct PodU32([u8; 4]);
 impl_int_conversion!(PodU32, u32);
 
 /// `u64` type that can be used in Pods
+#[cfg_attr(
+    feature = "borsh",
+    derive(BorshDeserialize, BorshSerialize, BorshSchema)
+)]
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde-traits", serde(from = "u64", into = "u64"))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]

--- a/stake-pool/cli/src/output.rs
+++ b/stake-pool/cli/src/output.rs
@@ -372,12 +372,12 @@ pub(crate) struct CliStakePoolValidator {
 impl From<ValidatorStakeInfo> for CliStakePoolValidator {
     fn from(v: ValidatorStakeInfo) -> Self {
         Self {
-            active_stake_lamports: v.active_stake_lamports,
-            transient_stake_lamports: v.transient_stake_lamports,
-            last_update_epoch: v.last_update_epoch,
-            transient_seed_suffix: v.transient_seed_suffix,
-            unused: v.unused,
-            validator_seed_suffix: v.validator_seed_suffix,
+            active_stake_lamports: v.active_stake_lamports.into(),
+            transient_stake_lamports: v.transient_stake_lamports.into(),
+            last_update_epoch: v.last_update_epoch.into(),
+            transient_seed_suffix: v.transient_seed_suffix.into(),
+            unused: v.unused.into(),
+            validator_seed_suffix: v.validator_seed_suffix.into(),
             status: CliStakePoolValidatorStakeStatus::from(v.status),
             vote_account_address: v.vote_account_address.to_string(),
         }

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -21,6 +21,7 @@ serde = "1.0.188"
 serde_derive = "1.0.103"
 solana-program = "1.16.3"
 spl-math = { version = "0.2", path = "../../libraries/math", features = [ "no-entrypoint" ] }
+spl-pod = { version = "0.1", path = "../../libraries/pod", features = ["borsh"] }
 spl-token-2022 = { version = "0.7", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 bincode = "1.3.1"

--- a/stake-pool/program/src/instruction.rs
+++ b/stake-pool/program/src/instruction.rs
@@ -1247,13 +1247,13 @@ pub fn update_validator_list_balance(
                         program_id,
                         vote_account_address,
                         stake_pool,
-                        NonZeroU32::new(validator_stake_info.validator_seed_suffix),
+                        NonZeroU32::new(validator_stake_info.validator_seed_suffix.into()),
                     );
                     let (transient_stake_account, _) = find_transient_stake_program_address(
                         program_id,
                         vote_account_address,
                         stake_pool,
-                        validator_stake_info.transient_seed_suffix,
+                        validator_stake_info.transient_seed_suffix.into(),
                     );
                     vec![
                         AccountMeta::new(validator_stake_account, false),

--- a/stake-pool/program/tests/decrease.rs
+++ b/stake-pool/program/tests/decrease.rs
@@ -424,7 +424,7 @@ async fn twice(success: bool, use_additional_first_time: bool, use_additional_se
             .get_validator_list(&mut context.banks_client)
             .await;
         let entry = validator_list.find(&validator_stake.vote.pubkey()).unwrap();
-        assert_eq!(entry.transient_stake_lamports, total_decrease);
+        assert_eq!(u64::from(entry.transient_stake_lamports), total_decrease);
     } else {
         let error = error.unwrap().unwrap();
         assert_eq!(

--- a/stake-pool/program/tests/deposit.rs
+++ b/stake-pool/program/tests/deposit.rs
@@ -249,7 +249,10 @@ async fn success(token_program_id: Pubkey) {
         validator_stake_account.lamports,
         post_validator_stake_item.stake_lamports().unwrap()
     );
-    assert_eq!(post_validator_stake_item.transient_stake_lamports, 0);
+    assert_eq!(
+        u64::from(post_validator_stake_item.transient_stake_lamports),
+        0
+    );
 
     // Check reserve
     let post_reserve_lamports = get_account(
@@ -443,7 +446,10 @@ async fn success_with_extra_stake_lamports() {
         validator_stake_account.lamports,
         post_validator_stake_item.stake_lamports().unwrap()
     );
-    assert_eq!(post_validator_stake_item.transient_stake_lamports, 0);
+    assert_eq!(
+        u64::from(post_validator_stake_item.transient_stake_lamports),
+        0
+    );
 
     // Check reserve
     let post_reserve_lamports = get_account(

--- a/stake-pool/program/tests/force_destake.rs
+++ b/stake-pool/program/tests/force_destake.rs
@@ -65,12 +65,12 @@ async fn setup() -> (
     validator_list.validators.push(ValidatorStakeInfo {
         status: StakeStatus::Active,
         vote_account_address: voter_pubkey,
-        active_stake_lamports,
-        transient_stake_lamports: 0,
-        last_update_epoch: 0,
-        transient_seed_suffix: 0,
-        unused: 0,
-        validator_seed_suffix: raw_validator_seed,
+        active_stake_lamports: active_stake_lamports.into(),
+        transient_stake_lamports: 0.into(),
+        last_update_epoch: 0.into(),
+        transient_seed_suffix: 0.into(),
+        unused: 0.into(),
+        validator_seed_suffix: raw_validator_seed.into(),
     });
 
     stake_pool.total_lamports += active_stake_lamports;

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -2405,12 +2405,12 @@ pub fn add_validator_stake_account(
     validator_list.validators.push(state::ValidatorStakeInfo {
         status,
         vote_account_address: *voter_pubkey,
-        active_stake_lamports,
-        transient_stake_lamports: 0,
-        last_update_epoch: FIRST_NORMAL_EPOCH,
-        transient_seed_suffix: 0,
-        unused: 0,
-        validator_seed_suffix: raw_suffix,
+        active_stake_lamports: active_stake_lamports.into(),
+        transient_stake_lamports: 0.into(),
+        last_update_epoch: FIRST_NORMAL_EPOCH.into(),
+        transient_seed_suffix: 0.into(),
+        unused: 0.into(),
+        validator_seed_suffix: raw_suffix.into(),
     });
 
     stake_pool.total_lamports += active_stake_lamports;

--- a/stake-pool/program/tests/huge_pool.rs
+++ b/stake-pool/program/tests/huge_pool.rs
@@ -25,7 +25,7 @@ use {
 // the test require so many helper accounts.
 // 20k is also a very safe number for the current upper bound of the network.
 const MAX_POOL_SIZE_WITH_REQUESTED_COMPUTE_UNITS: u32 = 20_000;
-const MAX_POOL_SIZE: u32 = 3_000;
+const MAX_POOL_SIZE: u32 = 2_650;
 const STAKE_AMOUNT: u64 = 200_000_000_000;
 
 async fn setup(
@@ -300,26 +300,26 @@ async fn remove_validator_from_pool(max_validators: u32) {
     let first_element = &validator_list.validators[0];
     assert_eq!(first_element.status, StakeStatus::DeactivatingValidator);
     assert_eq!(
-        first_element.active_stake_lamports,
+        u64::from(first_element.active_stake_lamports),
         LAMPORTS_PER_SOL + STAKE_ACCOUNT_RENT_EXEMPTION
     );
-    assert_eq!(first_element.transient_stake_lamports, 0);
+    assert_eq!(u64::from(first_element.transient_stake_lamports), 0);
 
     let middle_element = &validator_list.validators[middle_index];
     assert_eq!(middle_element.status, StakeStatus::DeactivatingValidator);
     assert_eq!(
-        middle_element.active_stake_lamports,
+        u64::from(middle_element.active_stake_lamports),
         LAMPORTS_PER_SOL + STAKE_ACCOUNT_RENT_EXEMPTION
     );
-    assert_eq!(middle_element.transient_stake_lamports, 0);
+    assert_eq!(u64::from(middle_element.transient_stake_lamports), 0);
 
     let last_element = &validator_list.validators[last_index];
     assert_eq!(last_element.status, StakeStatus::DeactivatingValidator);
     assert_eq!(
-        last_element.active_stake_lamports,
+        u64::from(last_element.active_stake_lamports),
         LAMPORTS_PER_SOL + STAKE_ACCOUNT_RENT_EXEMPTION
     );
-    assert_eq!(last_element.transient_stake_lamports, 0);
+    assert_eq!(u64::from(last_element.transient_stake_lamports), 0);
 
     let error = stake_pool_accounts
         .update_validator_list_balance(
@@ -467,10 +467,10 @@ async fn add_validator_to_pool(max_validators: u32) {
     let last_element = validator_list.validators[last_index];
     assert_eq!(last_element.status, StakeStatus::Active);
     assert_eq!(
-        last_element.active_stake_lamports,
+        u64::from(last_element.active_stake_lamports),
         LAMPORTS_PER_SOL + STAKE_ACCOUNT_RENT_EXEMPTION
     );
-    assert_eq!(last_element.transient_stake_lamports, 0);
+    assert_eq!(u64::from(last_element.transient_stake_lamports), 0);
     assert_eq!(last_element.vote_account_address, test_vote_address);
 
     let transient_stake_seed = u64::MAX;
@@ -505,11 +505,11 @@ async fn add_validator_to_pool(max_validators: u32) {
     let last_element = validator_list.validators[last_index];
     assert_eq!(last_element.status, StakeStatus::Active);
     assert_eq!(
-        last_element.active_stake_lamports,
+        u64::from(last_element.active_stake_lamports),
         LAMPORTS_PER_SOL + STAKE_ACCOUNT_RENT_EXEMPTION
     );
     assert_eq!(
-        last_element.transient_stake_lamports,
+        u64::from(last_element.transient_stake_lamports),
         increase_amount + STAKE_ACCOUNT_RENT_EXEMPTION
     );
     assert_eq!(last_element.vote_account_address, test_vote_address);

--- a/stake-pool/program/tests/increase.rs
+++ b/stake-pool/program/tests/increase.rs
@@ -440,7 +440,7 @@ async fn twice(success: bool, use_additional_first_time: bool, use_additional_se
             .await;
         let entry = validator_list.find(&validator_stake.vote.pubkey()).unwrap();
         assert_eq!(
-            entry.transient_stake_lamports,
+            u64::from(entry.transient_stake_lamports),
             total_increase + stake_rent * 2
         );
     } else {

--- a/stake-pool/program/tests/redelegate.rs
+++ b/stake-pool/program/tests/redelegate.rs
@@ -250,15 +250,15 @@ async fn success() {
         .find(&source_validator_stake.vote.pubkey())
         .unwrap();
     assert_eq!(
-        source_item.active_stake_lamports,
+        u64::from(source_item.active_stake_lamports),
         validator_stake_account.lamports
     );
     assert_eq!(
-        source_item.transient_stake_lamports,
+        u64::from(source_item.transient_stake_lamports),
         source_transient_stake_account.lamports
     );
     assert_eq!(
-        source_item.transient_seed_suffix,
+        u64::from(source_item.transient_seed_suffix),
         source_validator_stake.transient_stake_seed
     );
 
@@ -266,11 +266,11 @@ async fn success() {
         .find(&destination_validator_stake.vote.pubkey())
         .unwrap();
     assert_eq!(
-        destination_item.transient_stake_lamports,
+        u64::from(destination_item.transient_stake_lamports),
         destination_transient_stake_account.lamports
     );
     assert_eq!(
-        destination_item.transient_seed_suffix,
+        u64::from(destination_item.transient_seed_suffix),
         destination_validator_stake.transient_stake_seed
     );
 
@@ -313,17 +313,17 @@ async fn success() {
         .find(&source_validator_stake.vote.pubkey())
         .unwrap();
     assert_eq!(
-        source_item.active_stake_lamports,
+        u64::from(source_item.active_stake_lamports),
         validator_stake_account.lamports
     );
-    assert_eq!(source_item.transient_stake_lamports, 0);
+    assert_eq!(u64::from(source_item.transient_stake_lamports), 0);
 
     let destination_item = validator_list
         .find(&destination_validator_stake.vote.pubkey())
         .unwrap();
-    assert_eq!(destination_item.transient_stake_lamports, 0);
+    assert_eq!(u64::from(destination_item.transient_stake_lamports), 0);
     assert_eq!(
-        destination_item.active_stake_lamports,
+        u64::from(destination_item.active_stake_lamports),
         pre_destination_validator_stake_account.lamports + redelegate_lamports - stake_rent * 2
     );
     let post_destination_validator_stake_account = get_account(
@@ -386,7 +386,7 @@ async fn success_with_increasing_stake() {
         .find(&destination_validator_stake.vote.pubkey())
         .unwrap();
     assert_eq!(
-        destination_item.transient_stake_lamports,
+        u64::from(destination_item.transient_stake_lamports),
         current_minimum_delegation + stake_rent
     );
     let pre_transient_stake_account = get_account(
@@ -499,11 +499,11 @@ async fn success_with_increasing_stake() {
         .find(&destination_validator_stake.vote.pubkey())
         .unwrap();
     assert_eq!(
-        destination_item.transient_stake_lamports,
+        u64::from(destination_item.transient_stake_lamports),
         destination_transient_stake_account.lamports
     );
     assert_eq!(
-        destination_item.transient_seed_suffix,
+        u64::from(destination_item.transient_seed_suffix),
         destination_validator_stake.transient_stake_seed
     );
 
@@ -539,11 +539,11 @@ async fn success_with_increasing_stake() {
     let destination_item = validator_list
         .find(&destination_validator_stake.vote.pubkey())
         .unwrap();
-    assert_eq!(destination_item.transient_stake_lamports, 0);
+    assert_eq!(u64::from(destination_item.transient_stake_lamports), 0);
     // redelegate is smart enough to activate *everything*, so there's only one rent-exemption
     // worth of inactive stake!
     assert_eq!(
-        destination_item.active_stake_lamports,
+        u64::from(destination_item.active_stake_lamports),
         pre_validator_stake_account.lamports + redelegate_lamports + current_minimum_delegation
             - stake_rent
     );

--- a/stake-pool/program/tests/update_validator_list_balance.rs
+++ b/stake-pool/program/tests/update_validator_list_balance.rs
@@ -611,11 +611,11 @@ async fn merge_transient_stake_after_remove() {
         StakeStatus::DeactivatingAll
     );
     assert_eq!(
-        validator_list.validators[0].active_stake_lamports,
+        u64::from(validator_list.validators[0].active_stake_lamports),
         stake_rent + current_minimum_delegation
     );
     assert_eq!(
-        validator_list.validators[0].transient_stake_lamports,
+        u64::from(validator_list.validators[0].transient_stake_lamports),
         deactivated_lamports
     );
 

--- a/stake-pool/program/tests/vsa_add.rs
+++ b/stake-pool/program/tests/vsa_add.rs
@@ -112,15 +112,16 @@ async fn success() {
             validators: vec![state::ValidatorStakeInfo {
                 status: state::StakeStatus::Active,
                 vote_account_address: validator_stake.vote.pubkey(),
-                last_update_epoch: 0,
-                active_stake_lamports: stake_rent + current_minimum_delegation,
-                transient_stake_lamports: 0,
-                transient_seed_suffix: 0,
-                unused: 0,
+                last_update_epoch: 0.into(),
+                active_stake_lamports: (stake_rent + current_minimum_delegation).into(),
+                transient_stake_lamports: 0.into(),
+                transient_seed_suffix: 0.into(),
+                unused: 0.into(),
                 validator_seed_suffix: validator_stake
                     .validator_stake_seed
                     .map(|s| s.get())
-                    .unwrap_or(0),
+                    .unwrap_or(0)
+                    .into(),
             }]
         }
     );

--- a/stake-pool/program/tests/vsa_remove.rs
+++ b/stake-pool/program/tests/vsa_remove.rs
@@ -544,15 +544,16 @@ async fn success_with_deactivating_transient_stake() {
         validators: vec![state::ValidatorStakeInfo {
             status: state::StakeStatus::DeactivatingAll,
             vote_account_address: validator_stake.vote.pubkey(),
-            last_update_epoch: 0,
-            active_stake_lamports: stake_rent + current_minimum_delegation,
-            transient_stake_lamports: TEST_STAKE_AMOUNT + stake_rent,
-            transient_seed_suffix: validator_stake.transient_stake_seed,
-            unused: 0,
+            last_update_epoch: 0.into(),
+            active_stake_lamports: (stake_rent + current_minimum_delegation).into(),
+            transient_stake_lamports: (TEST_STAKE_AMOUNT + stake_rent).into(),
+            transient_seed_suffix: validator_stake.transient_stake_seed.into(),
+            unused: 0.into(),
             validator_seed_suffix: validator_stake
                 .validator_stake_seed
                 .map(|s| s.get())
-                .unwrap_or(0),
+                .unwrap_or(0)
+                .into(),
         }],
     };
     assert_eq!(validator_list, expected_list);

--- a/stake-pool/program/tests/withdraw.rs
+++ b/stake-pool/program/tests/withdraw.rs
@@ -223,7 +223,7 @@ async fn _success(token_program_id: Pubkey, test_type: SuccessTestType) {
         validator_stake_item_before.stake_lamports().unwrap() - tokens_burnt
     );
     assert_eq!(
-        validator_stake_item.active_stake_lamports,
+        u64::from(validator_stake_item.active_stake_lamports),
         validator_stake_item.stake_lamports().unwrap(),
     );
 
@@ -246,7 +246,7 @@ async fn _success(token_program_id: Pubkey, test_type: SuccessTestType) {
     .await;
     assert_eq!(
         validator_stake_account.lamports,
-        validator_stake_item.active_stake_lamports
+        u64::from(validator_stake_item.active_stake_lamports)
     );
 
     // Check user recipient stake account balance


### PR DESCRIPTION
#### Problem

Under Rust 1.72, the cast done by the stake pool program from raw bytes into a `ValidatorStakeInfo` panics because the underlying pointer might not be aligned to an address with a multiple of 8. See the offending line: https://github.com/solana-labs/solana-program-library/blob/c79c727f88710e565cd47bde0049f1b449aef0eb/stake-pool/program/src/big_vec.rs#L163C1-L163C80

And see https://github.com/solana-labs/solana/actions/runs/6029425589/job/16358927677?pr=32961 for a failing run.

#### Solution

It causes loads of churn, but do the right thing: use the alignment-safe `PodU64` and `PodU32` instead of `u64` and `u32`, respectively.

Note: this is blocking the upgrade of the monorepo to 1.72 because of downstream build errors