### PR TITLE
Serde optional dependencies clean-up

### DIFF
--- a/libraries/pod/Cargo.toml
+++ b/libraries/pod/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [features]
-serde-traits = ["serde", "base64"]
+serde-traits = ["dep:serde", "dep:base64"]
 borsh = ["dep:borsh"]
 
 [dependencies]

--- a/token-metadata/interface/Cargo.toml
+++ b/token-metadata/interface/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [features]
-serde-traits = ["serde", "spl-pod/serde-traits"]
+serde-traits = ["dep:serde", "spl-pod/serde-traits"]
 
 [dependencies]
 borsh = "0.10"

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["js/**"]
 [features]
 no-entrypoint = []
 test-sbf = []
-serde-traits = ["serde", "serde_with", "base64", "spl-pod/serde-traits"]
+serde-traits = ["dep:serde", "dep:serde_with", "dep:base64", "spl-pod/serde-traits"]
 # Remove these features once the underlying syscalls are released on all networks
 default = ["zk-ops"]
 zk-ops = []


### PR DESCRIPTION
When declaring an optional dependency in `Cargo.toml` like so: `serde_with = { version = "3.3.0", optional = true }`, it will automatically define a new feature, in this case `serde_with`.  Adding the `dep:` prefix prevents this.

This is why some spl crates have extra feature flags, for example `spl-token-2022` has `serde` and `serde_with` features, https://docs.rs/crate/spl-token-2022/0.7.0/features

This PR should fix it.

@buffalojoec @joncinque 