### PR TITLE
Added a TLVData parsing helper class

### DIFF
--- a/token/js/src/extensions/tlvData.ts
+++ b/token/js/src/extensions/tlvData.ts
@@ -1,0 +1,95 @@
+export type TLVNumberSize = 1 | 2 | 4 | 8;
+
+function readTLVNumberSize<T>(
+    buffer: Buffer,
+    size: TLVNumberSize,
+    offset: number,
+    constructor: (x: number | bigint) => T
+): T {
+    switch (size) {
+        case 1:
+            return constructor(buffer.readUInt8(offset));
+        case 2:
+            return constructor(buffer.readUInt16LE(offset));
+        case 4:
+            return constructor(buffer.readUInt32LE(offset));
+        case 8:
+            return constructor(buffer.readBigUInt64LE(offset));
+    }
+}
+
+export class TLVData {
+    private readonly tlvData: Buffer;
+    private readonly typeSize: TLVNumberSize;
+    private readonly lengthSize: TLVNumberSize;
+
+    public constructor(buffer: Buffer, typeSize: TLVNumberSize = 2, lengthSize: TLVNumberSize = 2, offset: number = 0) {
+        this.tlvData = buffer.subarray(offset);
+        this.typeSize = typeSize;
+        this.lengthSize = lengthSize;
+    }
+
+    /**
+     * Get the raw tlv data
+     *
+     * @return the raw tlv data
+     */
+    public get data(): Buffer {
+        return this.tlvData;
+    }
+
+    /**
+     * Get a single entry from the tlv data. This function performs a greedy search returning the first entry with the given type.
+     *
+     * @param type the type of the entry to get
+     *
+     * @return the entry from the tlv data or null
+     */
+    public entry(type: Buffer | Uint8Array | number | bigint): Buffer | null {
+        let offset = 0;
+        while (offset + this.typeSize + this.lengthSize <= this.tlvData.length) {
+            let typeMatches = false;
+            switch (typeof type) {
+                case 'number':
+                    typeMatches = readTLVNumberSize(this.tlvData, this.typeSize, offset, Number) === type;
+                    break;
+                case 'bigint':
+                    typeMatches = readTLVNumberSize(this.tlvData, this.typeSize, offset, BigInt) === type;
+                    break;
+                default:
+                    typeMatches = this.tlvData.subarray(offset, offset + this.typeSize).equals(type);
+                    break;
+            }
+            offset += this.typeSize;
+            const entryLength = readTLVNumberSize(this.tlvData, this.lengthSize, offset, Number);
+            offset += this.lengthSize;
+            if (typeMatches && offset + entryLength <= this.tlvData.length) {
+                return this.tlvData.subarray(offset, offset + entryLength);
+            }
+            offset += entryLength;
+        }
+        return null;
+    }
+
+    /**
+     * Get all entries from the tlv data. If you need to get a single entry, use the entry function instead.
+     *
+     * @return a map of all entries in the tlv data
+     */
+    public entries(): Map<bigint, Buffer> {
+        let offset = 0;
+        const entries = new Map<bigint, Buffer>();
+        while (offset + this.typeSize + this.lengthSize <= this.tlvData.length) {
+            const entryType = readTLVNumberSize(this.tlvData, this.typeSize, offset, BigInt);
+            offset += this.typeSize;
+            const entryLength = readTLVNumberSize(this.tlvData, this.lengthSize, offset, Number);
+            offset += this.lengthSize;
+            if (offset + entryLength <= this.tlvData.length) {
+                const entryData = this.tlvData.subarray(offset, offset + entryLength);
+                entries.set(entryType, entryData);
+            }
+            offset += entryLength;
+        }
+        return entries;
+    }
+}

--- a/token/js/test/unit/tlvData.test.ts
+++ b/token/js/test/unit/tlvData.test.ts
@@ -1,0 +1,117 @@
+import type { TLVNumberSize } from '../../src/extensions/tlvData';
+import { TLVData } from '../../src/extensions/tlvData';
+import { expect } from 'chai';
+
+describe('tlvData', () => {
+    // typeLength 1, lengthSize 2
+    const tlvData1 = Buffer.concat([
+        Buffer.from([0]),
+        Buffer.from([0, 0]),
+        Buffer.from([]),
+        Buffer.from([1]),
+        Buffer.from([1, 0]),
+        Buffer.from([1]),
+        Buffer.from([2]),
+        Buffer.from([2, 0]),
+        Buffer.from([1, 2]),
+    ]);
+
+    // typeLength 2, lengthSize 1
+    const tlvData2 = Buffer.concat([
+        Buffer.from([0, 0]),
+        Buffer.from([0]),
+        Buffer.from([]),
+        Buffer.from([1, 0]),
+        Buffer.from([1]),
+        Buffer.from([1]),
+        Buffer.from([2, 0]),
+        Buffer.from([2]),
+        Buffer.from([1, 2]),
+    ]);
+
+    // typeLength 4, lengthSize 8
+    const tlvData3 = Buffer.concat([
+        Buffer.from([0, 0, 0, 0]),
+        Buffer.from([0, 0, 0, 0, 0, 0, 0, 0]),
+        Buffer.from([]),
+        Buffer.from([1, 0, 0, 0]),
+        Buffer.from([1, 0, 0, 0, 0, 0, 0, 0]),
+        Buffer.from([1]),
+        Buffer.from([2, 0, 0, 0]),
+        Buffer.from([2, 0, 0, 0, 0, 0, 0, 0]),
+        Buffer.from([1, 2]),
+    ]);
+
+    // typeLength 8, lengthSize 4
+    const tlvData4 = Buffer.concat([
+        Buffer.from([0, 0, 0, 0, 0, 0, 0, 0]),
+        Buffer.from([0, 0, 0, 0]),
+        Buffer.from([]),
+        Buffer.from([1, 0, 0, 0, 0, 0, 0, 0]),
+        Buffer.from([1, 0, 0, 0]),
+        Buffer.from([1]),
+        Buffer.from([2, 0, 0, 0, 0, 0, 0, 0]),
+        Buffer.from([2, 0, 0, 0]),
+        Buffer.from([1, 2]),
+    ]);
+
+    const testRawData = (tlvData: Buffer, typeSize: TLVNumberSize, lengthSize: TLVNumberSize) => {
+        const tlv = new TLVData(tlvData, typeSize, lengthSize);
+        expect(tlv.data).to.be.deep.equal(tlvData);
+        const tlvWithOffset = new TLVData(tlvData, typeSize, lengthSize, typeSize + lengthSize);
+        expect(tlvWithOffset.data).to.be.deep.equal(tlvData.subarray(typeSize + lengthSize));
+    };
+
+    it('should get the raw tlv data', () => {
+        testRawData(tlvData1, 1, 2);
+        testRawData(tlvData2, 2, 1);
+        testRawData(tlvData3, 4, 8);
+        testRawData(tlvData4, 8, 4);
+    });
+
+    const testIndividualEntries = (tlvData: Buffer, typeSize: TLVNumberSize, lengthSize: TLVNumberSize) => {
+        const tlv = new TLVData(tlvData, typeSize, lengthSize);
+        expect(tlv.entry(Number(0))).to.be.deep.equal(Buffer.alloc(0));
+        expect(tlv.entry(Number(1))).to.be.deep.equal(Buffer.from([1]));
+        expect(tlv.entry(Number(2))).to.be.deep.equal(Buffer.from([1, 2]));
+        expect(tlv.entry(Number(3))).to.be.null;
+        expect(tlv.entry(BigInt(0))).to.be.deep.equal(Buffer.alloc(0));
+        expect(tlv.entry(BigInt(1))).to.be.deep.equal(Buffer.from([1]));
+        expect(tlv.entry(BigInt(2))).to.be.deep.equal(Buffer.from([1, 2]));
+        expect(tlv.entry(BigInt(3))).to.be.null;
+
+        const type = Buffer.alloc(typeSize);
+        type[0] = 0;
+        expect(tlv.entry(type)).to.be.deep.equal(Buffer.alloc(0));
+        type[0] = 1;
+        expect(tlv.entry(type)).to.be.deep.equal(Buffer.from([1]));
+        type[0] = 2;
+        expect(tlv.entry(type)).to.be.deep.equal(Buffer.from([1, 2]));
+        type[0] = 3;
+        expect(tlv.entry(type)).to.be.null;
+    };
+
+    it('should get the entries individually', () => {
+        testIndividualEntries(tlvData1, 1, 2);
+        testIndividualEntries(tlvData2, 2, 1);
+        testIndividualEntries(tlvData3, 4, 8);
+        testIndividualEntries(tlvData4, 8, 4);
+    });
+
+    const testEntries = (tlvData: Buffer, typeSize: TLVNumberSize, lengthSize: TLVNumberSize) => {
+        const tlv = new TLVData(tlvData, typeSize, lengthSize);
+        const entries = tlv.entries();
+        expect(entries).to.have.length(3);
+        expect(entries.get(BigInt(0))).to.be.deep.equal(Buffer.alloc(0));
+        expect(entries.get(BigInt(1))).to.be.deep.equal(Buffer.from([1]));
+        expect(entries.get(BigInt(2))).to.be.deep.equal(Buffer.from([1, 2]));
+        expect(entries.get(BigInt(3))).to.be.undefined;
+    };
+
+    it('should get the entries', () => {
+        testEntries(tlvData1, 1, 2);
+        testEntries(tlvData2, 2, 1);
+        testEntries(tlvData3, 4, 8);
+        testEntries(tlvData4, 8, 4);
+    });
+});


### PR DESCRIPTION
resolves #5127

In this PR I have isolated parsing of TLVData into its own file. For ticket #5127, I think this is fine for now as this allows us to very quickly extract TLVData parsing into its own library if we ever need it.

The `TLVData` class adds two helper functions for reading TLVData.
* `entry(type)` returns the first entry where the type matches the supplied type (preferred)
* `entries()` returns a map of all entries in the TLVData.

The TLVData class allows you to specify the length/span of both the type and length part of the tlv which should make parsing tlv data much easier in the future.

I added a couple simple tests for parsing and reading TLVData. 

This new class is not actually being used yet anywhere in the code. I plan to create (at least) two follow up PRs that switch out the old implementation for this new one once this PR is merged:
* `getExtensionData` in `./token/js/extension/extensionType.ts`
* `getExtraAccountMetaAccount` in `./token/js/exension/transferHook/state.ts`
* Anything else?