### PR TITLE
stake-pool: Remove unsafe pointer casts via `Pod` types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6887,6 +6887,7 @@ dependencies = [
  "arrayref",
  "bincode",
  "borsh 0.10.3",
+ "bytemuck",
  "num-derive 0.4.0",
  "num-traits",
  "num_enum 0.7.0",

--- a/stake-pool/cli/src/output.rs
+++ b/stake-pool/cli/src/output.rs
@@ -3,7 +3,9 @@ use {
     solana_cli_output::{QuietDisplay, VerboseDisplay},
     solana_sdk::native_token::Sol,
     solana_sdk::{pubkey::Pubkey, stake::state::Lockup},
-    spl_stake_pool::state::{Fee, StakePool, StakeStatus, ValidatorList, ValidatorStakeInfo},
+    spl_stake_pool::state::{
+        Fee, PodStakeStatus, StakePool, StakeStatus, ValidatorList, ValidatorStakeInfo,
+    },
     std::fmt::{Display, Formatter, Result, Write},
 };
 
@@ -384,8 +386,9 @@ impl From<ValidatorStakeInfo> for CliStakePoolValidator {
     }
 }
 
-impl From<StakeStatus> for CliStakePoolValidatorStakeStatus {
-    fn from(s: StakeStatus) -> CliStakePoolValidatorStakeStatus {
+impl From<PodStakeStatus> for CliStakePoolValidatorStakeStatus {
+    fn from(s: PodStakeStatus) -> CliStakePoolValidatorStakeStatus {
+        let s = StakeStatus::try_from(s).unwrap();
         match s {
             StakeStatus::Active => CliStakePoolValidatorStakeStatus::Active,
             StakeStatus::DeactivatingTransient => {

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -14,6 +14,7 @@ test-sbf = []
 [dependencies]
 arrayref = "0.3.7"
 borsh = "0.10"
+bytemuck = "1.13"
 num-derive = "0.4"
 num-traits = "0.2"
 num_enum = "0.7.0"

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -1076,7 +1076,7 @@ impl Processor {
         )?;
 
         validator_list.push(ValidatorStakeInfo {
-            status: StakeStatus::Active,
+            status: StakeStatus::Active.into(),
             vote_account_address: *validator_vote_info.key,
             active_stake_lamports: required_lamports.into(),
             transient_stake_lamports: 0.into(),
@@ -1161,7 +1161,7 @@ impl Processor {
             NonZeroU32::new(validator_stake_info.validator_seed_suffix.into()),
         )?;
 
-        if validator_stake_info.status != StakeStatus::Active {
+        if validator_stake_info.status != StakeStatus::Active.into() {
             msg!("Validator is already marked for removal");
             return Err(StakePoolError::ValidatorNotFound.into());
         }
@@ -1211,7 +1211,7 @@ impl Processor {
             stake_pool.stake_withdraw_bump_seed,
         )?;
 
-        validator_stake_info.status = new_status;
+        validator_stake_info.status = new_status.into();
 
         if stake_pool.preferred_deposit_validator_vote_address == Some(vote_account_address) {
             stake_pool.preferred_deposit_validator_vote_address = None;
@@ -1593,7 +1593,7 @@ impl Processor {
             &stake_pool.lockup,
         )?;
 
-        if validator_stake_info.status != StakeStatus::Active {
+        if validator_stake_info.status != StakeStatus::Active.into() {
             msg!("Validator is marked for removal and no longer allows increases");
             return Err(StakePoolError::ValidatorNotFound.into());
         }
@@ -1899,7 +1899,7 @@ impl Processor {
             if u64::from(validator_stake_info.transient_stake_lamports) > 0 {
                 return Err(StakePoolError::TransientAccountInUse.into());
             }
-            if validator_stake_info.status != StakeStatus::Active {
+            if validator_stake_info.status != StakeStatus::Active.into() {
                 msg!("Validator is marked for removal and no longer allows redelegation");
                 return Err(StakePoolError::ValidatorNotFound.into());
             }
@@ -2002,7 +2002,7 @@ impl Processor {
                 validator_stake_info.validator_seed_suffix.into(),
                 &stake_pool.lockup,
             )?;
-            if validator_stake_info.status != StakeStatus::Active {
+            if validator_stake_info.status != StakeStatus::Active.into() {
                 msg!(
                     "Destination validator is marked for removal and no longer allows redelegation"
                 );
@@ -2128,7 +2128,7 @@ impl Processor {
             });
             match maybe_validator_stake_info {
                 Some(vsi) => {
-                    if vsi.status != StakeStatus::Active {
+                    if vsi.status != StakeStatus::Active.into() {
                         msg!("Validator for {:?} about to be removed, cannot set as preferred deposit account", validator_type);
                         return Err(StakePoolError::InvalidPreferredValidator.into());
                     }
@@ -2281,7 +2281,7 @@ impl Processor {
                                 clock_info.clone(),
                                 stake_history_info.clone(),
                             )?;
-                            validator_stake_record.status.remove_transient_stake();
+                            validator_stake_record.status.remove_transient_stake()?;
                         }
                     }
                 }
@@ -2305,7 +2305,7 @@ impl Processor {
                                 clock_info.clone(),
                                 stake_history_info.clone(),
                             )?;
-                            validator_stake_record.status.remove_transient_stake();
+                            validator_stake_record.status.remove_transient_stake()?;
                         } else if stake.delegation.activation_epoch < clock.epoch {
                             if let Some(stake::state::StakeState::Stake(_, validator_stake)) =
                                 validator_stake_state
@@ -2373,7 +2373,7 @@ impl Processor {
                             additional_lamports,
                         )?;
                     }
-                    match validator_stake_record.status {
+                    match validator_stake_record.status.try_into()? {
                         StakeStatus::Active => {
                             active_stake_lamports = validator_stake_info.lamports();
                         }
@@ -2398,7 +2398,7 @@ impl Processor {
                                     clock_info.clone(),
                                     stake_history_info.clone(),
                                 )?;
-                                validator_stake_record.status.remove_validator_stake();
+                                validator_stake_record.status.remove_validator_stake()?;
                             }
                         }
                         StakeStatus::DeactivatingTransient | StakeStatus::ReadyForRemoval => {
@@ -2427,7 +2427,7 @@ impl Processor {
                         clock_info.clone(),
                         stake_history_info.clone(),
                     )?;
-                    validator_stake_record.status.remove_validator_stake();
+                    validator_stake_record.status.remove_validator_stake()?;
                 }
                 Some(stake::state::StakeState::Initialized(_))
                 | Some(stake::state::StakeState::Uninitialized)
@@ -2692,7 +2692,7 @@ impl Processor {
             NonZeroU32::new(validator_stake_info.validator_seed_suffix.into()),
         )?;
 
-        if validator_stake_info.status != StakeStatus::Active {
+        if validator_stake_info.status != StakeStatus::Active.into() {
             msg!("Validator is marked for removal and no longer accepting deposits");
             return Err(StakePoolError::ValidatorNotFound.into());
         }
@@ -3202,7 +3202,7 @@ impl Processor {
                 StakeWithdrawSource::ValidatorRemoval
             };
 
-            if validator_stake_info.status != StakeStatus::Active {
+            if validator_stake_info.status != StakeStatus::Active.into() {
                 msg!("Validator is marked for removal and no longer allowing withdrawals");
                 return Err(StakePoolError::ValidatorNotFound.into());
             }
@@ -3317,7 +3317,7 @@ impl Processor {
                     }
                     // since we already checked that there's no transient stake,
                     // we can immediately set this as ready for removal
-                    validator_list_item.status = StakeStatus::ReadyForRemoval;
+                    validator_list_item.status = StakeStatus::ReadyForRemoval.into();
                 }
             }
         }

--- a/stake-pool/program/tests/force_destake.rs
+++ b/stake-pool/program/tests/force_destake.rs
@@ -63,7 +63,7 @@ async fn setup() -> (
     let active_stake_lamports = TEST_STAKE_AMOUNT - MINIMUM_ACTIVE_STAKE;
     // add to validator list
     validator_list.validators.push(ValidatorStakeInfo {
-        status: StakeStatus::Active,
+        status: StakeStatus::Active.into(),
         vote_account_address: voter_pubkey,
         active_stake_lamports: active_stake_lamports.into(),
         transient_stake_lamports: 0.into(),

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -2403,7 +2403,7 @@ pub fn add_validator_stake_account(
     let active_stake_lamports = stake_amount + STAKE_ACCOUNT_RENT_EXEMPTION;
 
     validator_list.validators.push(state::ValidatorStakeInfo {
-        status,
+        status: status.into(),
         vote_account_address: *voter_pubkey,
         active_stake_lamports: active_stake_lamports.into(),
         transient_stake_lamports: 0.into(),

--- a/stake-pool/program/tests/huge_pool.rs
+++ b/stake-pool/program/tests/huge_pool.rs
@@ -298,7 +298,10 @@ async fn remove_validator_from_pool(max_validators: u32) {
     let validator_list =
         try_from_slice_unchecked::<ValidatorList>(validator_list.data.as_slice()).unwrap();
     let first_element = &validator_list.validators[0];
-    assert_eq!(first_element.status, StakeStatus::DeactivatingValidator);
+    assert_eq!(
+        first_element.status,
+        StakeStatus::DeactivatingValidator.into()
+    );
     assert_eq!(
         u64::from(first_element.active_stake_lamports),
         LAMPORTS_PER_SOL + STAKE_ACCOUNT_RENT_EXEMPTION
@@ -306,7 +309,10 @@ async fn remove_validator_from_pool(max_validators: u32) {
     assert_eq!(u64::from(first_element.transient_stake_lamports), 0);
 
     let middle_element = &validator_list.validators[middle_index];
-    assert_eq!(middle_element.status, StakeStatus::DeactivatingValidator);
+    assert_eq!(
+        middle_element.status,
+        StakeStatus::DeactivatingValidator.into()
+    );
     assert_eq!(
         u64::from(middle_element.active_stake_lamports),
         LAMPORTS_PER_SOL + STAKE_ACCOUNT_RENT_EXEMPTION
@@ -314,7 +320,10 @@ async fn remove_validator_from_pool(max_validators: u32) {
     assert_eq!(u64::from(middle_element.transient_stake_lamports), 0);
 
     let last_element = &validator_list.validators[last_index];
-    assert_eq!(last_element.status, StakeStatus::DeactivatingValidator);
+    assert_eq!(
+        last_element.status,
+        StakeStatus::DeactivatingValidator.into()
+    );
     assert_eq!(
         u64::from(last_element.active_stake_lamports),
         LAMPORTS_PER_SOL + STAKE_ACCOUNT_RENT_EXEMPTION
@@ -465,7 +474,7 @@ async fn add_validator_to_pool(max_validators: u32) {
         try_from_slice_unchecked::<ValidatorList>(validator_list.data.as_slice()).unwrap();
     assert_eq!(validator_list.validators.len(), last_index + 1);
     let last_element = validator_list.validators[last_index];
-    assert_eq!(last_element.status, StakeStatus::Active);
+    assert_eq!(last_element.status, StakeStatus::Active.into());
     assert_eq!(
         u64::from(last_element.active_stake_lamports),
         LAMPORTS_PER_SOL + STAKE_ACCOUNT_RENT_EXEMPTION
@@ -503,7 +512,7 @@ async fn add_validator_to_pool(max_validators: u32) {
     let validator_list =
         try_from_slice_unchecked::<ValidatorList>(validator_list.data.as_slice()).unwrap();
     let last_element = validator_list.validators[last_index];
-    assert_eq!(last_element.status, StakeStatus::Active);
+    assert_eq!(last_element.status, StakeStatus::Active.into());
     assert_eq!(
         u64::from(last_element.active_stake_lamports),
         LAMPORTS_PER_SOL + STAKE_ACCOUNT_RENT_EXEMPTION

--- a/stake-pool/program/tests/huge_pool.rs
+++ b/stake-pool/program/tests/huge_pool.rs
@@ -25,7 +25,7 @@ use {
 // the test require so many helper accounts.
 // 20k is also a very safe number for the current upper bound of the network.
 const MAX_POOL_SIZE_WITH_REQUESTED_COMPUTE_UNITS: u32 = 20_000;
-const MAX_POOL_SIZE: u32 = 2_650;
+const MAX_POOL_SIZE: u32 = 3_000;
 const STAKE_AMOUNT: u64 = 200_000_000_000;
 
 async fn setup(

--- a/stake-pool/program/tests/update_validator_list_balance.rs
+++ b/stake-pool/program/tests/update_validator_list_balance.rs
@@ -608,7 +608,7 @@ async fn merge_transient_stake_after_remove() {
     assert_eq!(validator_list.validators.len(), 1);
     assert_eq!(
         validator_list.validators[0].status,
-        StakeStatus::DeactivatingAll
+        StakeStatus::DeactivatingAll.into()
     );
     assert_eq!(
         u64::from(validator_list.validators[0].active_stake_lamports),
@@ -660,7 +660,7 @@ async fn merge_transient_stake_after_remove() {
     assert_eq!(validator_list.validators.len(), 1);
     assert_eq!(
         validator_list.validators[0].status,
-        StakeStatus::ReadyForRemoval
+        StakeStatus::ReadyForRemoval.into()
     );
     assert_eq!(validator_list.validators[0].stake_lamports().unwrap(), 0);
 

--- a/stake-pool/program/tests/vsa_add.rs
+++ b/stake-pool/program/tests/vsa_add.rs
@@ -110,7 +110,7 @@ async fn success() {
                 max_validators: stake_pool_accounts.max_validators,
             },
             validators: vec![state::ValidatorStakeInfo {
-                status: state::StakeStatus::Active,
+                status: state::StakeStatus::Active.into(),
                 vote_account_address: validator_stake.vote.pubkey(),
                 last_update_epoch: 0.into(),
                 active_stake_lamports: (stake_rent + current_minimum_delegation).into(),

--- a/stake-pool/program/tests/vsa_remove.rs
+++ b/stake-pool/program/tests/vsa_remove.rs
@@ -542,7 +542,7 @@ async fn success_with_deactivating_transient_stake() {
             max_validators: stake_pool_accounts.max_validators,
         },
         validators: vec![state::ValidatorStakeInfo {
-            status: state::StakeStatus::DeactivatingAll,
+            status: state::StakeStatus::DeactivatingAll.into(),
             vote_account_address: validator_stake.vote.pubkey(),
             last_update_epoch: 0.into(),
             active_stake_lamports: (stake_rent + current_minimum_delegation).into(),


### PR DESCRIPTION
#### Problem

https://github.com/solana-labs/solana-program-library/pull/5179 was a quick fix to properly deserialize the stake pool types in-place, updating all contained types to align to 1. This works, but any other type aligned to an address greater than 1 can still expose undefined behavior.

#### Solution

Rather than parametrizing everything in `BigVec` to the `Pack` trait, change `BigVec` to use the bytemuck `Pod` trait, which is designed for this exact situation.

While going through this, I noticed that the custom iterator over `BigVec` was not very performant, and that it was much better to just deserialize the whole slice in-place. With this PR, we can once again support the big pool size from #5179.