### PR TITLE
token-js: renamed `getExtraAccountMetaAccount` to `getExtraAccountMetaAddress`

### DIFF
--- a/token/js/src/extensions/transferHook/instructions.ts
+++ b/token/js/src/extensions/transferHook/instructions.ts
@@ -9,7 +9,7 @@ import { publicKey } from '@solana/buffer-layout-utils';
 import { createTransferCheckedInstruction } from '../../instructions/transferChecked.js';
 import { createTransferCheckedWithFeeInstruction } from '../transferFee/instructions.js';
 import { getMint } from '../../state/mint.js';
-import { getExtraAccountMetaAccount, getExtraAccountMetas, getTransferHook, resolveExtraAccountMeta } from './state.js';
+import { getExtraAccountMetaAddress, getExtraAccountMetas, getTransferHook, resolveExtraAccountMeta } from './state.js';
 
 export enum TransferHookInstruction {
     Initialize = 0,
@@ -144,7 +144,7 @@ export async function addExtraAccountsToInstruction(
         return instruction;
     }
 
-    const extraAccountsAccount = getExtraAccountMetaAccount(transferHook.programId, mint);
+    const extraAccountsAccount = getExtraAccountMetaAddress(mint, transferHook.programId);
     const extraAccountsInfo = await connection.getAccountInfo(extraAccountsAccount, commitment);
     if (extraAccountsInfo == null) {
         return instruction;

--- a/token/js/src/extensions/transferHook/state.ts
+++ b/token/js/src/extensions/transferHook/state.ts
@@ -53,7 +53,7 @@ export function getTransferHookAccount(account: Account): TransferHookAccount | 
     }
 }
 
-export function getExtraAccountMetaAccount(programId: PublicKey, mint: PublicKey): PublicKey {
+export function getExtraAccountMetaAddress(mint: PublicKey, programId: PublicKey): PublicKey {
     const seeds = [Buffer.from('extra-account-metas'), mint.toBuffer()];
     return PublicKey.findProgramAddressSync(seeds, programId)[0];
 }

--- a/token/js/test/e2e-2022/transferHook.test.ts
+++ b/token/js/test/e2e-2022/transferHook.test.ts
@@ -19,7 +19,7 @@ import {
     getAssociatedTokenAddressSync,
     ASSOCIATED_TOKEN_PROGRAM_ID,
     createMintToCheckedInstruction,
-    getExtraAccountMetaAccount,
+    getExtraAccountMetaAddress,
     ExtraAccountMetaListLayout,
     ExtraAccountMetaLayout,
     transferCheckedWithTransferHook,
@@ -48,7 +48,7 @@ describe('transferHook', () => {
     beforeEach(async () => {
         const mintKeypair = Keypair.generate();
         mint = mintKeypair.publicKey;
-        pdaExtraAccountMeta = getExtraAccountMetaAccount(TRANSFER_HOOK_TEST_PROGRAM_ID, mint);
+        pdaExtraAccountMeta = getExtraAccountMetaAddress(mint, TRANSFER_HOOK_TEST_PROGRAM_ID);
         payerAta = getAssociatedTokenAddressSync(
             mint,
             payer.publicKey,


### PR DESCRIPTION
The method is not actually getting any account. Rather it is computing the address for the account. Alongside that I have flipped the parameters around to be consistent with other address getter functions.