### PR TITLE
account-compression: Fixup sdk doc deployment

### DIFF
--- a/account-compression/sdk/package.json
+++ b/account-compression/sdk/package.json
@@ -40,7 +40,7 @@
     "lint": "set -ex; npm run pretty; eslint . --ext .js,.ts",
     "lint:fix": "npm run pretty:fix && eslint . --fix --ext .js,.ts",
     "docs": "rm -rf docs/ && typedoc --out docs",
-    "deploy:docs": "yarn docs && gh-pages -d docs",
+    "deploy:docs": "yarn docs && gh-pages --dest account-compression/sdk --dist docs --dotfiles",
     "start-validator": "solana-test-validator --reset --quiet --bpf-program cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK ../target/deploy/spl_account_compression.so --bpf-program noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV ../target/deploy/spl_noop.so",
     "run-tests": "jest tests --detectOpenHandles",
     "run-tests:events": "jest tests/events --detectOpenHandles",


### PR DESCRIPTION
#### Problem

As found out through an extensive game of telephone, the account compression JS docs have not been properly deployed.

#### Solution

Following the same changes made to the memo and token JS packages, update the deployment script to specify the destination. Now you'll see all of the docs pages:

* account-compression https://solana-labs.github.io/solana-program-library/account-compression/sdk/
* memo https://solana-labs.github.io/solana-program-library/memo/js/
* token https://solana-labs.github.io/solana-program-library/token/js/