### PR TITLE
release: Bump token-2022 and all dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6407,7 +6407,7 @@ dependencies = [
 
 [[package]]
 name = "spl-associated-token-account"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "assert_matches",
  "borsh 0.10.3",
@@ -6426,7 +6426,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 2.0.0",
+ "spl-associated-token-account 2.1.0",
  "spl-token 4.0.0",
  "spl-token-2022 0.8.0",
 ]
@@ -6705,7 +6705,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 2.0.0",
+ "spl-associated-token-account 2.1.0",
  "spl-token 4.0.0",
  "thiserror",
 ]
@@ -6850,7 +6850,7 @@ dependencies = [
  "solana-test-validator",
  "solana-transaction-status",
  "solana-vote-program",
- "spl-associated-token-account 2.0.0",
+ "spl-associated-token-account 2.1.0",
  "spl-single-validator-pool",
  "spl-token 4.0.0",
  "spl-token-client",
@@ -6875,7 +6875,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "solana-vote-program",
- "spl-associated-token-account 2.0.0",
+ "spl-associated-token-account 2.1.0",
  "spl-token 4.0.0",
  "test-case",
  "thiserror",
@@ -6926,7 +6926,7 @@ dependencies = [
  "solana-program",
  "solana-remote-wallet",
  "solana-sdk",
- "spl-associated-token-account 2.0.0",
+ "spl-associated-token-account 2.1.0",
  "spl-stake-pool",
  "spl-token 4.0.0",
 ]
@@ -7035,7 +7035,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 2.0.0",
+ "spl-associated-token-account 2.1.0",
  "spl-instruction-padding",
  "spl-memo 4.0.0",
  "spl-pod",
@@ -7069,7 +7069,7 @@ dependencies = [
  "solana-sdk",
  "solana-test-validator",
  "solana-transaction-status",
- "spl-associated-token-account 2.0.0",
+ "spl-associated-token-account 2.1.0",
  "spl-memo 4.0.0",
  "spl-token 4.0.0",
  "spl-token-2022 0.8.0",
@@ -7095,7 +7095,7 @@ dependencies = [
  "solana-rpc-client",
  "solana-rpc-client-api",
  "solana-sdk",
- "spl-associated-token-account 2.0.0",
+ "spl-associated-token-account 2.1.0",
  "spl-memo 4.0.0",
  "spl-token 4.0.0",
  "spl-token-2022 0.8.0",
@@ -7228,7 +7228,7 @@ dependencies = [
  "solana-remote-wallet",
  "solana-sdk",
  "solana-test-validator",
- "spl-associated-token-account 2.0.0",
+ "spl-associated-token-account 2.1.0",
  "spl-token 4.0.0",
  "spl-token-2022 0.8.0",
  "spl-token-client",
@@ -7244,7 +7244,7 @@ dependencies = [
  "bytemuck",
  "num_enum 0.7.0",
  "solana-program",
- "spl-associated-token-account 2.0.0",
+ "spl-associated-token-account 2.1.0",
  "spl-token 4.0.0",
  "spl-token-2022 0.8.0",
  "thiserror",
@@ -7317,7 +7317,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 2.0.0",
+ "spl-associated-token-account 2.1.0",
  "spl-token 4.0.0",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6415,7 +6415,7 @@ dependencies = [
  "num-traits",
  "solana-program",
  "spl-token 4.0.0",
- "spl-token-2022 0.7.0",
+ "spl-token-2022 0.8.0",
  "thiserror",
 ]
 
@@ -6428,7 +6428,7 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account 2.0.0",
  "spl-token 4.0.0",
- "spl-token-2022 0.7.0",
+ "spl-token-2022 0.8.0",
 ]
 
 [[package]]
@@ -6781,7 +6781,7 @@ dependencies = [
 
 [[package]]
 name = "spl-program-error"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "lazy_static",
  "num-derive 0.4.0",
@@ -6795,7 +6795,7 @@ dependencies = [
 
 [[package]]
 name = "spl-program-error-derive"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.29",
@@ -6901,7 +6901,7 @@ dependencies = [
  "spl-math",
  "spl-pod",
  "spl-token 4.0.0",
- "spl-token-2022 0.7.0",
+ "spl-token-2022 0.8.0",
  "test-case",
  "thiserror",
 ]
@@ -6933,7 +6933,7 @@ dependencies = [
 
 [[package]]
 name = "spl-tlv-account-resolution"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bytemuck",
  "solana-program",
@@ -6998,7 +6998,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-2022"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "arrayref",
  "base64 0.21.3",
@@ -7039,7 +7039,7 @@ dependencies = [
  "spl-instruction-padding",
  "spl-memo 4.0.0",
  "spl-pod",
- "spl-token-2022 0.7.0",
+ "spl-token-2022 0.8.0",
  "spl-token-client",
  "spl-token-metadata-interface",
  "spl-transfer-hook-example",
@@ -7072,7 +7072,7 @@ dependencies = [
  "spl-associated-token-account 2.0.0",
  "spl-memo 4.0.0",
  "spl-token 4.0.0",
- "spl-token-2022 0.7.0",
+ "spl-token-2022 0.8.0",
  "spl-token-client",
  "spl-token-metadata-interface",
  "strum 0.25.0",
@@ -7084,7 +7084,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-client"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "futures 0.3.28",
@@ -7098,7 +7098,7 @@ dependencies = [
  "spl-associated-token-account 2.0.0",
  "spl-memo 4.0.0",
  "spl-token 4.0.0",
- "spl-token-2022 0.7.0",
+ "spl-token-2022 0.8.0",
  "spl-token-metadata-interface",
  "spl-transfer-hook-interface",
  "thiserror",
@@ -7139,13 +7139,13 @@ dependencies = [
 
 [[package]]
 name = "spl-token-metadata-example"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
  "spl-pod",
- "spl-token-2022 0.7.0",
+ "spl-token-2022 0.8.0",
  "spl-token-client",
  "spl-token-metadata-interface",
  "spl-type-length-value",
@@ -7154,7 +7154,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-metadata-interface"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "borsh 0.10.3",
  "serde",
@@ -7181,7 +7181,7 @@ dependencies = [
  "solana-sdk",
  "spl-math",
  "spl-token 4.0.0",
- "spl-token-2022 0.7.0",
+ "spl-token-2022 0.8.0",
  "test-case",
  "thiserror",
 ]
@@ -7209,7 +7209,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-token 4.0.0",
- "spl-token-2022 0.7.0",
+ "spl-token-2022 0.8.0",
  "spl-token-client",
  "test-case",
  "thiserror",
@@ -7230,7 +7230,7 @@ dependencies = [
  "solana-test-validator",
  "spl-associated-token-account 2.0.0",
  "spl-token 4.0.0",
- "spl-token-2022 0.7.0",
+ "spl-token-2022 0.8.0",
  "spl-token-client",
  "spl-token-upgrade",
  "tokio",
@@ -7246,27 +7246,27 @@ dependencies = [
  "solana-program",
  "spl-associated-token-account 2.0.0",
  "spl-token 4.0.0",
- "spl-token-2022 0.7.0",
+ "spl-token-2022 0.8.0",
  "thiserror",
 ]
 
 [[package]]
 name = "spl-transfer-hook-example"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arrayref",
  "solana-program",
  "solana-program-test",
  "solana-sdk",
  "spl-tlv-account-resolution",
- "spl-token-2022 0.7.0",
+ "spl-token-2022 0.8.0",
  "spl-transfer-hook-interface",
  "spl-type-length-value",
 ]
 
 [[package]]
 name = "spl-transfer-hook-interface"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -7280,7 +7280,7 @@ dependencies = [
 
 [[package]]
 name = "spl-type-length-value"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bytemuck",
  "solana-program",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7050,7 +7050,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-cli"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "assert_cmd",
  "clap 2.34.0",

--- a/associated-token-account/program-test/Cargo.toml
+++ b/associated-token-account/program-test/Cargo.toml
@@ -14,6 +14,6 @@ test-sbf = []
 solana-program = "1.16.3"
 solana-program-test = "1.16.3"
 solana-sdk = "1.16.3"
-spl-associated-token-account = { version = "2.0", path = "../program", features = ["no-entrypoint"] }
+spl-associated-token-account = { version = "2", path = "../program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "0.8", path = "../../token/program-2022", features = ["no-entrypoint"] }

--- a/associated-token-account/program-test/Cargo.toml
+++ b/associated-token-account/program-test/Cargo.toml
@@ -16,4 +16,4 @@ solana-program-test = "1.16.3"
 solana-sdk = "1.16.3"
 spl-associated-token-account = { version = "2.0", path = "../program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "0.7", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.8", path = "../../token/program-2022", features = ["no-entrypoint"] }

--- a/associated-token-account/program/Cargo.toml
+++ b/associated-token-account/program/Cargo.toml
@@ -18,7 +18,7 @@ num-derive = "0.4"
 num-traits = "0.2"
 solana-program = "1.16.3"
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "0.7", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.8", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [lib]

--- a/associated-token-account/program/Cargo.toml
+++ b/associated-token-account/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-associated-token-account"
-version = "2.0.0"
+version = "2.1.0"
 description = "Solana Program Library Associated Token Account"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/libraries/pod/Cargo.toml
+++ b/libraries/pod/Cargo.toml
@@ -18,7 +18,7 @@ bytemuck = { version = "1.13.1" }
 serde = { version = "1.0.183", optional = true }
 solana-program = "1.16.3"
 solana-zk-token-sdk = "1.16.3"
-spl-program-error = { version = "0.2.0", path = "../program-error" }
+spl-program-error = { version = "0.3", path = "../program-error" }
 
 [dev-dependencies]
 serde_json = "1.0.105"

--- a/libraries/program-error/Cargo.toml
+++ b/libraries/program-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-program-error"
-version = "0.2.0"
+version = "0.3.0"
 description = "Library for Solana Program error attributes and derive macro for creating them"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -11,7 +11,7 @@ edition = "2021"
 num-derive = "0.4"
 num-traits = "0.2"
 solana-program = "1.16.3"
-spl-program-error-derive = { version = "0.2.0", path = "./derive" }
+spl-program-error-derive = { version = "0.3.0", path = "./derive" }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/libraries/program-error/derive/Cargo.toml
+++ b/libraries/program-error/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-program-error-derive"
-version = "0.2.0"
+version = "0.3.0"
 description = "Proc-Macro Library for Solana Program error attributes and derive macro"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/libraries/tlv-account-resolution/Cargo.toml
+++ b/libraries/tlv-account-resolution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-tlv-account-resolution"
-version = "0.2.0"
+version = "0.3.0"
 description = "Solana Program Library TLV Account Resolution Interface"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -14,9 +14,9 @@ test-sbf = []
 bytemuck = { version = "1.13.1", features = ["derive"] }
 solana-program = "1.16.3"
 spl-discriminator = { version = "0.1", path = "../discriminator" }
-spl-program-error = { version = "0.2.0", path = "../program-error" }
-spl-type-length-value = { version = "0.2", path = "../type-length-value" }
-spl-pod = { version = "0.1.0", path = "../pod" }
+spl-program-error = { version = "0.3", path = "../program-error" }
+spl-type-length-value = { version = "0.3", path = "../type-length-value" }
+spl-pod = { version = "0.1", path = "../pod" }
 
 [dev-dependencies]
 solana-program-test = "1.16.3"

--- a/libraries/type-length-value-derive-test/Cargo.toml
+++ b/libraries/type-length-value-derive-test/Cargo.toml
@@ -11,4 +11,4 @@ edition = "2021"
 borsh = "0.10"
 solana-program = "1.16"
 spl-discriminator = { version = "0.1.0", path = "../discriminator" }
-spl-type-length-value = { version = "0.2.0", path = "../type-length-value", features = ["derive"] }
+spl-type-length-value = { version = "0.3.0", path = "../type-length-value", features = ["derive"] }

--- a/libraries/type-length-value/Cargo.toml
+++ b/libraries/type-length-value/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-type-length-value"
-version = "0.2.0"
+version = "0.3.0"
 description = "Solana Program Library Type-Length-Value Management"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -14,10 +14,10 @@ derive = ["dep:spl-type-length-value-derive"]
 [dependencies]
 bytemuck = { version = "1.13.1", features = ["derive"] }
 solana-program = "1.16.3"
-spl-discriminator = { version = "0.1.0", path = "../discriminator" }
-spl-program-error = { version = "0.2.0", path = "../program-error" }
-spl-type-length-value-derive = { version = "0.1.0", path = "./derive", optional = true }
-spl-pod = { version = "0.1.0", path = "../pod" }
+spl-discriminator = { version = "0.1", path = "../discriminator" }
+spl-program-error = { version = "0.3", path = "../program-error" }
+spl-type-length-value-derive = { version = "0.1", path = "./derive", optional = true }
+spl-pod = { version = "0.1", path = "../pod" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/single-pool/cli/Cargo.toml
+++ b/single-pool/cli/Cargo.toml
@@ -28,7 +28,7 @@ solana-sdk = "=1.16.3"
 solana-transaction-status = "=1.16.3"
 solana-vote-program = "=1.16.3"
 spl-token = { version = "4.0", path="../../token/program", features = [ "no-entrypoint" ] }
-spl-token-client = { version = "0.5", path="../../token/client" }
+spl-token-client = { version = "0.6", path="../../token/client" }
 spl-associated-token-account = { version = "2.0", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
 spl-single-validator-pool = { version = "1.0.0", path="../program", features = [ "no-entrypoint" ] }
 

--- a/stake-pool/cli/Cargo.toml
+++ b/stake-pool/cli/Cargo.toml
@@ -23,7 +23,7 @@ solana-logger = "=1.16.3"
 solana-program = "=1.16.3"
 solana-remote-wallet = "=1.16.3"
 solana-sdk = "=1.16.3"
-spl-associated-token-account = { version = "=2.0", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
+spl-associated-token-account = { version = "=2.1", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
 spl-stake-pool = { version = "=0.7.0", path="../program", features = [ "no-entrypoint" ] }
 spl-token = { version = "=4.0", path="../../token/program", features = [ "no-entrypoint" ]  }
 bs58 = "0.4.0"

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -22,7 +22,7 @@ serde_derive = "1.0.103"
 solana-program = "1.16.3"
 spl-math = { version = "0.2", path = "../../libraries/math", features = [ "no-entrypoint" ] }
 spl-pod = { version = "0.1", path = "../../libraries/pod", features = ["borsh"] }
-spl-token-2022 = { version = "0.7", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
+spl-token-2022 = { version = "0.8", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 bincode = "1.3.1"
 

--- a/token-metadata/example/Cargo.toml
+++ b/token-metadata/example/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-metadata-example"
-version = "0.1.0"
+version = "0.2.0"
 description = "Solana Program Library Token Metadata Example Program"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -13,15 +13,15 @@ test-sbf = []
 
 [dependencies]
 solana-program = "1.16.3"
-spl-token-2022 = { version = "0.7", path = "../../token/program-2022" }
-spl-token-metadata-interface = { version = "0.1.0", path = "../interface" }
-spl-type-length-value = { version = "0.2.0" , path = "../../libraries/type-length-value" }
+spl-token-2022 = { version = "0.8", path = "../../token/program-2022" }
+spl-token-metadata-interface = { version = "0.2.0", path = "../interface" }
+spl-type-length-value = { version = "0.3.0" , path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.1.0", path = "../../libraries/pod" }
 
 [dev-dependencies]
 solana-program-test = "1.16.3"
 solana-sdk = "1.16.3"
-spl-token-client = { version = "0.5", path = "../../token/client" }
+spl-token-client = { version = "0.6", path = "../../token/client" }
 test-case = "3.1"
 
 [lib]

--- a/token-metadata/interface/Cargo.toml
+++ b/token-metadata/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-metadata-interface"
-version = "0.1.0"
+version = "0.2.0"
 description = "Solana Program Library Token Metadata Interface"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -14,10 +14,10 @@ serde-traits = ["dep:serde", "spl-pod/serde-traits"]
 borsh = "0.10"
 serde = { version = "1.0.188", optional = true }
 solana-program = "1.16.3"
-spl-discriminator = { version = "0.1.0" , path = "../../libraries/discriminator" }
-spl-program-error = { version = "0.2.0" , path = "../../libraries/program-error" }
-spl-type-length-value = { version = "0.2.0", path = "../../libraries/type-length-value" }
-spl-pod = { version = "0.1.0", path = "../../libraries/pod", features = ["borsh"] }
+spl-discriminator = { version = "0.1" , path = "../../libraries/discriminator" }
+spl-program-error = { version = "0.3" , path = "../../libraries/program-error" }
+spl-type-length-value = { version = "0.3", path = "../../libraries/type-length-value" }
+spl-pod = { version = "0.1", path = "../../libraries/pod", features = ["borsh"] }
 
 [dev-dependencies]
 serde_json = "1.0.105"

--- a/token-swap/program/Cargo.toml
+++ b/token-swap/program/Cargo.toml
@@ -20,7 +20,7 @@ num-traits = "0.2"
 solana-program = "1.16.3"
 spl-math = { version = "0.2", path = "../../libraries/math", features = [ "no-entrypoint" ] }
 spl-token = { version = "4.0", path = "../../token/program", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "0.7", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
+spl-token-2022 = { version = "0.8", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
 roots = { version = "0.0.8", optional = true }

--- a/token-upgrade/cli/Cargo.toml
+++ b/token-upgrade/cli/Cargo.toml
@@ -21,8 +21,8 @@ solana-remote-wallet = "1.16.3"
 solana-sdk = "1.16.3"
 spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "0.7", path = "../../token/program-2022", features = ["no-entrypoint"] }
-spl-token-client = { version = "0.5", path = "../../token/client" }
+spl-token-2022 = { version = "0.8", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-client = { version = "0.6", path = "../../token/client" }
 spl-token-upgrade = { version = "0.1", path = "../program", features = ["no-entrypoint"] }
 tokio = { version = "1", features = ["full"] }
 

--- a/token-upgrade/program/Cargo.toml
+++ b/token-upgrade/program/Cargo.toml
@@ -16,14 +16,14 @@ num-derive = "0.4"
 num-traits = "0.2"
 num_enum = "0.7.0"
 solana-program = "1.16.3"
-spl-token-2022 = { version = "0.7", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.8", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [dev-dependencies]
 solana-program-test = "1.16.3"
 solana-sdk = "1.16.3"
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-client = { version = "0.5", path = "../../token/client" }
+spl-token-client = { version = "0.6", path = "../../token/client" }
 test-case = "3.1"
 
 [lib]

--- a/token-wrap/program/Cargo.toml
+++ b/token-wrap/program/Cargo.toml
@@ -17,7 +17,7 @@ num_enum = "0.7"
 solana-program = "1.16.3"
 spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "0.7", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.8", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [lib]

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://spl.solana.com/token"
 license = "Apache-2.0"
 name = "spl-token-cli"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "3.0.0"
+version = "3.1.0"
 
 [build-dependencies]
 walkdir = "2"

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -27,9 +27,9 @@ solana-remote-wallet = "=1.16.3"
 solana-sdk = "=1.16.3"
 solana-transaction-status = "=1.16.3"
 spl-token = { version = "4.0", path="../program", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "0.7", path="../program-2022", features = [ "no-entrypoint" ] }
-spl-token-client = { version = "0.5", path="../client" }
-spl-token-metadata-interface = { version = "0.1", path="../../token-metadata/interface" }
+spl-token-2022 = { version = "0.8", path="../program-2022", features = [ "no-entrypoint" ] }
+spl-token-client = { version = "0.6", path="../client" }
+spl-token-metadata-interface = { version = "0.2", path="../../token-metadata/interface" }
 spl-associated-token-account = { version = "2.0", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
 spl-memo = { version = "4.0.0", path="../../memo/program", features = ["no-entrypoint"] }
 strum = "0.25"

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "spl-token-client"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "0.5.1"
+version = "0.6.0"
 
 [dependencies]
 async-trait = "0.1"
@@ -22,9 +22,9 @@ solana-sdk = "1.16.3"
 spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-memo = { version = "4.0.0", path = "../../memo/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path="../program", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "0.7", path="../program-2022" }
-spl-token-metadata-interface = { version = "0.1", path="../../token-metadata/interface" }
-spl-transfer-hook-interface = { version = "0.1", path="../transfer-hook-interface" }
+spl-token-2022 = { version = "0.8", path="../program-2022" }
+spl-token-metadata-interface = { version = "0.2", path="../../token-metadata/interface" }
+spl-transfer-hook-interface = { version = "0.2", path="../transfer-hook-interface" }
 thiserror = "1.0"
 
 [features]

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -26,10 +26,10 @@ solana-sdk = "=1.16.3"
 spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program" }
 spl-memo = { version = "4.0.0", path = "../../memo/program", features = ["no-entrypoint"] }
 spl-pod = { version = "0.1.0", path = "../../libraries/pod" }
-spl-token-2022 = { version = "0.7", path="../program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.8", path="../program-2022", features = ["no-entrypoint"] }
 spl-instruction-padding = { version = "0.1.0", path="../../instruction-padding/program", features = ["no-entrypoint"] }
-spl-token-client = { version = "0.5", path = "../client" }
-spl-token-metadata-interface = { version = "0.1", path = "../../token-metadata/interface" }
-spl-transfer-hook-example = { version = "0.1", path="../transfer-hook-example", features = ["no-entrypoint"] }
-spl-transfer-hook-interface = { version = "0.1", path="../transfer-hook-interface" }
+spl-token-client = { version = "0.6", path = "../client" }
+spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }
+spl-transfer-hook-example = { version = "0.2", path="../transfer-hook-example", features = ["no-entrypoint"] }
+spl-transfer-hook-interface = { version = "0.2", path="../transfer-hook-interface" }
 test-case = "3.1"

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-2022"
-version = "0.7.0"
+version = "0.8.0"
 description = "Solana Program Library Token 2022"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -27,9 +27,9 @@ solana-program = "1.16.3"
 solana-zk-token-sdk = "1.16.3"
 spl-memo = { version = "4.0.0", path = "../../memo/program", features = [ "no-entrypoint" ] }
 spl-token = { version = "4.0",  path = "../program", features = ["no-entrypoint"] }
-spl-token-metadata-interface = { version = "0.1.0", path = "../../token-metadata/interface" }
-spl-transfer-hook-interface = { version = "0.1.0", path = "../transfer-hook-interface" }
-spl-type-length-value = { version = "0.2.0", path = "../../libraries/type-length-value" }
+spl-token-metadata-interface = { version = "0.2.0", path = "../../token-metadata/interface" }
+spl-transfer-hook-interface = { version = "0.2.0", path = "../transfer-hook-interface" }
+spl-type-length-value = { version = "0.3.0", path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.1.0", path = "../../libraries/pod" }
 thiserror = "1.0"
 serde = { version = "1.0.188", optional = true }

--- a/token/transfer-hook-example/Cargo.toml
+++ b/token/transfer-hook-example/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-transfer-hook-example"
-version = "0.1.0"
+version = "0.2.0"
 description = "Solana Program Library Transfer Hook Example Program"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -14,10 +14,10 @@ test-sbf = []
 [dependencies]
 arrayref = "0.3.7"
 solana-program = "1.16.3"
-spl-tlv-account-resolution = { version = "0.2.0" , path = "../../libraries/tlv-account-resolution" }
-spl-token-2022 = { version = "0.7",  path = "../program-2022", features = ["no-entrypoint"] }
-spl-transfer-hook-interface = { version = "0.1.0" , path = "../transfer-hook-interface" }
-spl-type-length-value = { version = "0.2.0" , path = "../../libraries/type-length-value" }
+spl-tlv-account-resolution = { version = "0.3" , path = "../../libraries/tlv-account-resolution" }
+spl-token-2022 = { version = "0.8",  path = "../program-2022", features = ["no-entrypoint"] }
+spl-transfer-hook-interface = { version = "0.2" , path = "../transfer-hook-interface" }
+spl-type-length-value = { version = "0.3" , path = "../../libraries/type-length-value" }
 
 [dev-dependencies]
 solana-program-test = "1.16.3"

--- a/token/transfer-hook-interface/Cargo.toml
+++ b/token/transfer-hook-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-transfer-hook-interface"
-version = "0.1.0"
+version = "0.2.0"
 description = "Solana Program Library Transfer Hook Interface"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -11,11 +11,11 @@ edition = "2021"
 arrayref = "0.3.7"
 bytemuck = { version = "1.13.1", features = ["derive"] }
 solana-program = "1.16.3"
-spl-discriminator = { version = "0.1.0" , path = "../../libraries/discriminator" }
-spl-program-error = { version = "0.2.0" , path = "../../libraries/program-error" }
-spl-tlv-account-resolution = { version = "0.2.0" , path = "../../libraries/tlv-account-resolution" }
-spl-type-length-value = { version = "0.2.0" , path = "../../libraries/type-length-value" }
-spl-pod = { version = "0.1.0", path = "../../libraries/pod" }
+spl-discriminator = { version = "0.1" , path = "../../libraries/discriminator" }
+spl-program-error = { version = "0.3" , path = "../../libraries/program-error" }
+spl-tlv-account-resolution = { version = "0.3" , path = "../../libraries/tlv-account-resolution" }
+spl-type-length-value = { version = "0.3" , path = "../../libraries/type-length-value" }
+spl-pod = { version = "0.1", path = "../../libraries/pod" }
 
 [lib]
 crate-type = ["cdylib", "lib"]


### PR DESCRIPTION
In order to release a new token-2022, we need to bump its version and every local crate that it depends on. That means the following:

* spl-token-2022
* spl-program-error
* spl-tlv-account-resolution
* spl-type-length-value
* spl-token-metadata-interface
* spl-token-metadata-example
* spl-transfer-hook-interface
* spl-transfer-hook-example
* spl-token-client (this one's not needed, but it's cleaner)