### PR TITLE
Token Group Interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7105,6 +7105,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-token-group-interface"
+version = "0.1.0"
+dependencies = [
+ "borsh 0.10.3",
+ "solana-program",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
+ "spl-tlv-account-resolution",
+ "spl-transfer-hook-interface",
+ "spl-type-length-value",
+]
+
+[[package]]
 name = "spl-token-lending"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7105,6 +7105,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-token-group-example"
+version = "0.1.0"
+dependencies = [
+ "borsh 0.10.3",
+ "solana-program",
+ "solana-program-test",
+ "solana-sdk",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-tlv-account-resolution",
+ "spl-token-2022 0.7.0",
+ "spl-token-client",
+ "spl-token-group-interface",
+ "spl-token-metadata-interface",
+ "spl-type-length-value",
+ "test-case",
+]
+
+[[package]]
 name = "spl-token-group-interface"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7115,7 +7115,7 @@ dependencies = [
  "spl-discriminator",
  "spl-pod",
  "spl-tlv-account-resolution",
- "spl-token-2022 0.7.0",
+ "spl-token-2022 0.8.0",
  "spl-token-client",
  "spl-token-group-interface",
  "spl-token-metadata-interface",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ members = [
   "stake-pool/cli",
   "stake-pool/program",
   "stateless-asks/program",
+  "token-group/example",
   "token-group/interface",
   "token-lending/cli",
   "token-lending/program",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ members = [
   "stake-pool/cli",
   "stake-pool/program",
   "stateless-asks/program",
+  "token-group/interface",
   "token-lending/cli",
   "token-lending/program",
   "token-metadata/example",

--- a/token-group/example/Cargo.toml
+++ b/token-group/example/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "spl-token-group-example"
+version = "0.1.0"
+description = "Solana Program Library Token Group Example Program"
+authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
+repository = "https://github.com/solana-labs/solana-program-library"
+license = "Apache-2.0"
+edition = "2021"
+
+[features]
+no-entrypoint = []
+test-sbf = []
+
+[dependencies]
+borsh = "0.10"
+solana-program = "1.16.3"
+spl-discriminator = { version = "0.1.0" , path = "../../libraries/discriminator" }
+spl-pod = { version = "0.1.0" , path = "../../libraries/pod" }
+spl-token-2022 = { version = "0.7.0", path = "../../token/program-2022" }
+spl-token-group-interface = { version = "0.1.0", path = "../interface" }
+spl-token-metadata-interface = { version = "0.1.0", path = "../../token-metadata/interface" }
+spl-tlv-account-resolution = { version = "0.2.0" , path = "../../libraries/tlv-account-resolution" }
+spl-type-length-value = { version = "0.2.0" , path = "../../libraries/type-length-value" }
+
+[dev-dependencies]
+solana-program-test = "1.16.3"
+solana-sdk = "1.16.3"
+spl-token-client = { version = "0.5", path = "../../token/client" }
+test-case = "3.1"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/token-group/example/Cargo.toml
+++ b/token-group/example/Cargo.toml
@@ -16,16 +16,16 @@ borsh = "0.10"
 solana-program = "1.16.3"
 spl-discriminator = { version = "0.1.0" , path = "../../libraries/discriminator" }
 spl-pod = { version = "0.1.0" , path = "../../libraries/pod" }
-spl-token-2022 = { version = "0.7.0", path = "../../token/program-2022" }
+spl-token-2022 = { version = "0.8.0", path = "../../token/program-2022" }
 spl-token-group-interface = { version = "0.1.0", path = "../interface" }
-spl-token-metadata-interface = { version = "0.1.0", path = "../../token-metadata/interface" }
-spl-tlv-account-resolution = { version = "0.2.0" , path = "../../libraries/tlv-account-resolution" }
-spl-type-length-value = { version = "0.2.0" , path = "../../libraries/type-length-value" }
+spl-token-metadata-interface = { version = "0.2.0", path = "../../token-metadata/interface" }
+spl-tlv-account-resolution = { version = "0.3.0" , path = "../../libraries/tlv-account-resolution" }
+spl-type-length-value = { version = "0.3.0" , path = "../../libraries/type-length-value" }
 
 [dev-dependencies]
 solana-program-test = "1.16.3"
 solana-sdk = "1.16.3"
-spl-token-client = { version = "0.5", path = "../../token/client" }
+spl-token-client = { version = "0.6", path = "../../token/client" }
 test-case = "3.1"
 
 [lib]

--- a/token-group/example/src/entrypoint.rs
+++ b/token-group/example/src/entrypoint.rs
@@ -1,0 +1,23 @@
+//! Program entrypoint
+
+use {
+    crate::processor,
+    solana_program::{
+        account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,
+        program_error::PrintProgramError, pubkey::Pubkey,
+    },
+    spl_token_group_interface::error::TokenGroupError,
+};
+
+entrypoint!(process_instruction);
+fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    if let Err(error) = processor::process(program_id, accounts, instruction_data) {
+        error.print::<TokenGroupError>();
+        return Err(error);
+    }
+    Ok(())
+}

--- a/token-group/example/src/lib.rs
+++ b/token-group/example/src/lib.rs
@@ -1,0 +1,11 @@
+//! Crate defining an example program for creating SPL token collections and
+//! editions
+
+#![deny(missing_docs)]
+#![cfg_attr(not(test), forbid(unsafe_code))]
+
+pub mod processor;
+pub mod state;
+
+#[cfg(not(feature = "no-entrypoint"))]
+mod entrypoint;

--- a/token-group/example/src/processor.rs
+++ b/token-group/example/src/processor.rs
@@ -1,0 +1,640 @@
+//! Program state processor
+
+use {
+    crate::state::{Collection, Edition},
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        borsh::get_instance_packed_len,
+        entrypoint::ProgramResult,
+        msg,
+        program::{invoke, set_return_data},
+        program_error::ProgramError,
+        program_option::COption,
+        pubkey::Pubkey,
+    },
+    spl_pod::optional_keys::OptionalNonZeroPubkey,
+    spl_token_2022::{
+        extension::{
+            metadata_pointer::MetadataPointer, BaseStateWithExtensions, StateWithExtensions,
+        },
+        state::Mint,
+    },
+    spl_token_group_interface::{
+        error::TokenGroupError,
+        instruction::{
+            get_emit_slice, Emit, InitializeGroup, InitializeMember, ItemType,
+            TokenGroupInterfaceInstruction, UpdateGroupAuthority, UpdateGroupMaxSize,
+        },
+        state::{Group, Member, SplTokenGroup},
+    },
+    spl_token_metadata_interface::{instruction::initialize, state::TokenMetadata},
+    spl_type_length_value::state::{
+        realloc_and_pack_first_variable_len, TlvState, TlvStateBorrowed, TlvStateMut,
+    },
+};
+
+fn check_update_authority(
+    update_authority_info: &AccountInfo,
+    expected_update_authority: &OptionalNonZeroPubkey,
+) -> Result<(), ProgramError> {
+    if !update_authority_info.is_signer {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+    let update_authority = Option::<Pubkey>::from(*expected_update_authority)
+        .ok_or(TokenGroupError::ImmutableGroup)?;
+    if update_authority != *update_authority_info.key {
+        return Err(TokenGroupError::IncorrectAuthority.into());
+    }
+    Ok(())
+}
+
+/// Processes a [InitializeGroup](enum.GroupInterfaceInstruction.html)
+/// instruction for a `Collection`
+pub fn process_initialize_collection(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    data: InitializeGroup<Collection>,
+) -> ProgramResult {
+    // Assumes one has already created a mint for the collection.
+    let account_info_iter = &mut accounts.iter();
+
+    // Accounts expected by this instruction:
+    //
+    //   0. `[w]`  Collection (Group)
+    //   1. `[]`   Mint
+    //   2. `[s]`  Mint authority
+    let collection_info = next_account_info(account_info_iter)?;
+    let mint_info = next_account_info(account_info_iter)?;
+    let mint_authority_info = next_account_info(account_info_iter)?;
+
+    {
+        // IMPORTANT: this example program is designed to work with any
+        // program that implements the SPL token interface, so there is no
+        // ownership check on the mint account.
+        let mint_data = mint_info.try_borrow_data()?;
+        let mint = StateWithExtensions::<Mint>::unpack(&mint_data)?;
+
+        if !mint_authority_info.is_signer {
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+        if mint.base.mint_authority.as_ref() != COption::Some(mint_authority_info.key) {
+            return Err(TokenGroupError::IncorrectAuthority.into());
+        }
+    }
+
+    let collection = Group::new(data.update_authority, data.max_size, data.meta);
+    let instance_size = get_instance_packed_len(&collection)?;
+
+    // Allocate a TLV entry for the space and write it in
+    let mut buffer = collection_info.try_borrow_mut_data()?;
+    let mut state = TlvStateMut::unpack(&mut buffer)?;
+    state.alloc::<Group<Collection>>(instance_size, false)?;
+    state.pack_first_variable_len_value(&collection)?;
+
+    Ok(())
+}
+
+/// Processes an
+/// [UpdateGroupMaxSize](enum.GroupInterfaceInstruction.html)
+/// instruction for a `Collection`
+pub fn process_update_collection_max_size(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    data: UpdateGroupMaxSize,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    // Accounts expected by this instruction:
+    //
+    //   0. `[w]`  Collection (Group)
+    //   1. `[s]`  Update authority
+    let collection_info = next_account_info(account_info_iter)?;
+    let update_authority_info = next_account_info(account_info_iter)?;
+
+    let mut collection = {
+        let buffer = collection_info.try_borrow_data()?;
+        let state = TlvStateBorrowed::unpack(&buffer)?;
+        state.get_first_variable_len_value::<Group<Collection>>()?
+    };
+
+    check_update_authority(update_authority_info, &collection.update_authority)?;
+
+    // Update the max size
+    collection.update_max_size(data.max_size)?;
+
+    // Update the account, no realloc needed!
+    realloc_and_pack_first_variable_len(collection_info, &collection)?;
+
+    Ok(())
+}
+
+/// Processes a
+/// [UpdateGroupAuthority](enum.GroupInterfaceInstruction.html)
+/// instruction for a `Collection`
+pub fn process_update_collection_authority(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    data: UpdateGroupAuthority,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    // Accounts expected by this instruction:
+    //
+    //   0. `[w]`  Collection (Group)
+    //   1. `[s]`  Current update authority
+    let collection_info = next_account_info(account_info_iter)?;
+    let update_authority_info = next_account_info(account_info_iter)?;
+
+    let mut collection = {
+        let buffer = collection_info.try_borrow_data()?;
+        let state = TlvStateBorrowed::unpack(&buffer)?;
+        state.get_first_variable_len_value::<Group<Collection>>()?
+    };
+
+    check_update_authority(update_authority_info, &collection.update_authority)?;
+
+    // Update the authority
+    collection.update_authority = data.new_authority;
+
+    // Update the account, no realloc needed!
+    realloc_and_pack_first_variable_len(collection_info, &collection)?;
+
+    Ok(())
+}
+
+/// Processes a [InitializeMember](enum.GroupInterfaceInstruction.html)
+/// instruction for a `Collection`
+pub fn process_initialize_collection_member(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    data: InitializeMember,
+) -> ProgramResult {
+    // For this group, we are going to assume the collection has been
+    // initialized, and we're also assuming a mint _and_ metadata have been
+    // created for the member.
+    // Collection memebers in this example can have their own separate
+    // metadata that differs from the metadata of the collection.
+    let account_info_iter = &mut accounts.iter();
+
+    // Accounts expected by this instruction:
+    //
+    //   0. `[w]`  Collection Member (Member)
+    //   1. `[]`   Collection Member (Member) Mint
+    //   2. `[s]`  Collection Member (Member) Mint authority
+    //   3. `[w]`  Collection (Group)
+    //   4. `[]`   Collection (Group) Mint
+    //   5. `[s]`  Collection (Group) Mint authority
+    let member_info = next_account_info(account_info_iter)?;
+    let member_mint_info = next_account_info(account_info_iter)?;
+    let member_mint_authority_info = next_account_info(account_info_iter)?;
+    let collection_info = next_account_info(account_info_iter)?;
+    let collection_mint_info = next_account_info(account_info_iter)?;
+    let collection_mint_authority_info = next_account_info(account_info_iter)?;
+
+    // Mint checks on the member
+    {
+        // IMPORTANT: this example program is designed to work with any
+        // program that implements the SPL token interface, so there is no
+        // ownership check on the mint account.
+        let member_mint_data = member_mint_info.try_borrow_data()?;
+        let member_mint = StateWithExtensions::<Mint>::unpack(&member_mint_data)?;
+
+        if !member_mint_authority_info.is_signer {
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+        if member_mint.base.mint_authority.as_ref() != COption::Some(member_mint_authority_info.key)
+        {
+            return Err(TokenGroupError::IncorrectAuthority.into());
+        }
+    }
+
+    // Mint checks on the collection
+    {
+        // IMPORTANT: this example program is designed to work with any
+        // program that implements the SPL token interface, so there is no
+        // ownership check on the mint account.
+        let collection_mint_data = collection_mint_info.try_borrow_data()?;
+        let collection_mint = StateWithExtensions::<Mint>::unpack(&collection_mint_data)?;
+
+        if !collection_mint_authority_info.is_signer {
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+        if collection_mint.base.mint_authority.as_ref()
+            != COption::Some(collection_mint_authority_info.key)
+        {
+            return Err(TokenGroupError::IncorrectAuthority.into());
+        }
+    }
+
+    if data.group != *collection_info.key {
+        return Err(TokenGroupError::IncorrectGroup.into());
+    }
+
+    // Increment the size of the collection
+    let mut collection = {
+        let buffer = collection_info.try_borrow_data()?;
+        let state = TlvStateBorrowed::unpack(&buffer)?;
+        state.get_first_variable_len_value::<Group<Collection>>()?
+    };
+    let member_number = collection.increment_size()?;
+    realloc_and_pack_first_variable_len(collection_info, &collection)?;
+
+    // Initialize the new collection member
+    let member = Member {
+        group: data.group,
+        member_number,
+    };
+    let instance_size = get_instance_packed_len(&member)?;
+
+    // allocate a TLV entry for the space and write it in
+    let mut buffer = member_info.try_borrow_mut_data()?;
+    let mut state = TlvStateMut::unpack(&mut buffer)?;
+    state.alloc::<Member>(instance_size, false)?;
+    state.pack_first_variable_len_value(&member)?;
+
+    Ok(())
+}
+
+/// Processes a [InitializeGroup](enum.GroupInterfaceInstruction.html)
+/// instruction for an `Edition`
+pub fn process_initialize_original(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    data: InitializeGroup<Edition>,
+) -> ProgramResult {
+    // Assumes one has already created a mint and a metadata account for the
+    // original print
+    let account_info_iter = &mut accounts.iter();
+
+    // Accounts expected by this instruction:
+    //
+    //   0. `[w]`  Original (Group)
+    //   1. `[]`   Mint
+    //   2. `[s]`  Mint authority
+    let original_info = next_account_info(account_info_iter)?;
+    let mint_info = next_account_info(account_info_iter)?;
+    let mint_authority_info = next_account_info(account_info_iter)?;
+
+    // Extra accounts expected by this instruction:
+    //
+    //   0. `[]`   Metadata
+    let metadata_info = next_account_info(account_info_iter)?;
+
+    // Mint & metadata checks
+    {
+        // IMPORTANT: this example program is designed to work with any
+        // program that implements the SPL token interface, so there is no
+        // ownership check on the mint account.
+        let mint_data = mint_info.try_borrow_data()?;
+        let mint = StateWithExtensions::<Mint>::unpack(&mint_data)?;
+
+        if !mint_authority_info.is_signer {
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+        if mint.base.mint_authority.as_ref() != COption::Some(mint_authority_info.key) {
+            return Err(TokenGroupError::IncorrectAuthority.into());
+        }
+
+        // IMPORTANT: metadata is passed as a separate account because it may be owned
+        // by another program - separate from the program implementing the SPL token
+        // interface _or_ the program implementing the SPL token editions interface.
+        let metadata_pointer = mint.get_extension::<MetadataPointer>()?;
+        let metadata_pointer_address = Option::<Pubkey>::from(metadata_pointer.metadata_address);
+        if metadata_pointer_address != Some(*metadata_info.key) {
+            return Err(TokenGroupError::IncorrectAccount.into());
+        }
+    }
+
+    let original = Group::new(data.update_authority, data.max_size, data.meta);
+    let instance_size = get_instance_packed_len(&original)?;
+
+    // Allocate a TLV entry for the space and write it in
+    let mut buffer = original_info.try_borrow_mut_data()?;
+    let mut state = TlvStateMut::unpack(&mut buffer)?;
+    state.alloc::<Group<Edition>>(instance_size, false)?;
+    state.pack_first_variable_len_value(&original)?;
+
+    Ok(())
+}
+
+/// Processes an
+/// [UpdateGroupMaxSize](enum.GroupInterfaceInstruction.html)
+/// instruction for an `Edition`
+pub fn process_update_edition_max_size(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    data: UpdateGroupMaxSize,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    // Accounts expected by this instruction:
+    //
+    //   0. `[w]`  Original (Group)
+    //   1. `[s]`  Update authority
+    let original_info = next_account_info(account_info_iter)?;
+    let update_authority_info = next_account_info(account_info_iter)?;
+
+    let mut original = {
+        let buffer = original_info.try_borrow_data()?;
+        let state = TlvStateBorrowed::unpack(&buffer)?;
+        state.get_first_variable_len_value::<Group<Edition>>()?
+    };
+
+    check_update_authority(update_authority_info, &original.update_authority)?;
+
+    // Update the max size
+    original.update_max_size(data.max_size)?;
+
+    // Update the account, no realloc needed!
+    realloc_and_pack_first_variable_len(original_info, &original)?;
+
+    Ok(())
+}
+
+/// Processes a
+/// [UpdateGroupAuthority](enum.GroupInterfaceInstruction.html)
+/// instruction for an `Edition`
+pub fn process_update_edition_authority(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    data: UpdateGroupAuthority,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    // Accounts expected by this instruction:
+    //
+    //   0. `[w]`  Original (Group)
+    //   1. `[s]`  Current update authority
+    let original_info = next_account_info(account_info_iter)?;
+    let update_authority_info = next_account_info(account_info_iter)?;
+
+    let mut original = {
+        let buffer = original_info.try_borrow_data()?;
+        let state = TlvStateBorrowed::unpack(&buffer)?;
+        state.get_first_variable_len_value::<Group<Edition>>()?
+    };
+
+    check_update_authority(update_authority_info, &original.update_authority)?;
+
+    // Update the authority
+    original.update_authority = data.new_authority;
+
+    // Update the account, no realloc needed!
+    realloc_and_pack_first_variable_len(original_info, &original)?;
+
+    Ok(())
+}
+
+/// Processes a [InitializeMember](enum.GroupInterfaceInstruction.html)
+/// instruction for an `Edition`
+pub fn process_initialize_reprint(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    data: InitializeMember,
+) -> ProgramResult {
+    // For this group, we are going to assume the original print has been
+    // initialized, but _only_ a mint has been created for the reprint.
+    // We will then copy the original print's metadata to the reprint's
+    // metadata, creating a copy!
+    let account_info_iter = &mut accounts.iter();
+
+    // Accounts expected by this instruction:
+    //
+    //   0. `[w]`  Reprint (Member)
+    //   1. `[]`   Reprint (Member) Mint
+    //   2. `[s]`  Reprint (Member) Mint authority
+    //   3. `[w]`  Original (Group)
+    //   4. `[]`   Original (Group) Mint
+    //   5. `[s]`  Original (Group) Mint authority
+    let reprint_info = next_account_info(account_info_iter)?;
+    let reprint_mint_info = next_account_info(account_info_iter)?;
+    let reprint_mint_authority_info = next_account_info(account_info_iter)?;
+    let original_info = next_account_info(account_info_iter)?;
+    let original_mint_info = next_account_info(account_info_iter)?;
+    let original_mint_authority_info = next_account_info(account_info_iter)?;
+
+    // Extra accounts expected by this instruction:
+    //
+    //   0. `[w]`  Reprint Metadata
+    //   1. `[]`   Reprint Metadata Update Authoriy
+    //   2. `[]`   Original Metadata
+    //   3. `[]`   Token Metadata Program
+    let reprint_metadata_info = next_account_info(account_info_iter)?;
+    let reprint_metadata_update_authority_info = next_account_info(account_info_iter)?;
+    let original_metadata_info = next_account_info(account_info_iter)?;
+    let metadata_program_info = next_account_info(account_info_iter)?;
+
+    // Mint & metadata checks on the original
+    let token_metadata = {
+        // IMPORTANT: this example program is designed to work with any
+        // program that implements the SPL token interface, so there is no
+        // ownership check on the mint account.
+        let original_mint_data = original_mint_info.try_borrow_data()?;
+        let original_mint = StateWithExtensions::<Mint>::unpack(&original_mint_data)?;
+
+        if !original_mint_authority_info.is_signer {
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+        if original_mint.base.mint_authority.as_ref()
+            != COption::Some(original_mint_authority_info.key)
+        {
+            return Err(TokenGroupError::IncorrectAuthority.into());
+        }
+
+        // IMPORTANT: metadata is passed as a separate account because it may be owned
+        // by another program - separate from the program implementing the SPL token
+        // interface _or_ the program implementing the SPL token editions interface.
+        let metadata_pointer = original_mint.get_extension::<MetadataPointer>()?;
+        let metadata_pointer_address = Option::<Pubkey>::from(metadata_pointer.metadata_address);
+        if metadata_pointer_address != Some(*original_metadata_info.key) {
+            return Err(TokenGroupError::IncorrectAccount.into());
+        }
+
+        original_mint.get_variable_len_extension::<TokenMetadata>()?
+    };
+
+    // Mint & metadata checks on the reprint
+    {
+        // IMPORTANT: this example program is designed to work with any
+        // program that implements the SPL token interface, so there is no
+        // ownership check on the mint account.
+        let reprint_mint_data = reprint_mint_info.try_borrow_data()?;
+        let reprint_mint = StateWithExtensions::<Mint>::unpack(&reprint_mint_data)?;
+
+        if !reprint_mint_authority_info.is_signer {
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+        if reprint_mint.base.mint_authority.as_ref()
+            != COption::Some(reprint_mint_authority_info.key)
+        {
+            return Err(TokenGroupError::IncorrectAuthority.into());
+        }
+
+        // IMPORTANT: metadata is passed as a separate account because it may be owned
+        // by another program - separate from the program implementing the SPL token
+        // interface _or_ the program implementing the SPL token editions interface.
+        let metadata_pointer = reprint_mint.get_extension::<MetadataPointer>()?;
+        let metadata_pointer_address = Option::<Pubkey>::from(metadata_pointer.metadata_address);
+        if metadata_pointer_address != Some(*reprint_metadata_info.key) {
+            return Err(TokenGroupError::IncorrectAccount.into());
+        }
+    }
+
+    let mut original_print = {
+        let buffer = original_info.try_borrow_data()?;
+        let state = TlvStateBorrowed::unpack(&buffer)?;
+        state.get_first_variable_len_value::<Group<Edition>>()?
+    };
+
+    if data.group != *original_info.key {
+        return Err(TokenGroupError::IncorrectAccount.into());
+    }
+
+    // Update the current supply
+    let member_number = original_print.increment_size()?;
+    realloc_and_pack_first_variable_len(original_info, &original_print)?;
+
+    // Initialize the reprint metadata from the original metadata
+    let cpi_instruction = initialize(
+        metadata_program_info.key,
+        reprint_mint_info.key,
+        reprint_metadata_update_authority_info.key,
+        reprint_mint_info.key,
+        reprint_mint_authority_info.key,
+        token_metadata.name,
+        token_metadata.symbol,
+        token_metadata.uri,
+    );
+    let cpi_account_infos = &[
+        reprint_mint_info.clone(),
+        reprint_metadata_update_authority_info.clone(),
+        reprint_mint_info.clone(),
+        reprint_mint_authority_info.clone(),
+    ];
+    invoke(&cpi_instruction, cpi_account_infos)?;
+
+    // Initialize the reprint
+    let reprint = Member {
+        group: *original_info.key,
+        member_number,
+    };
+    let instance_size = get_instance_packed_len(&reprint)?;
+
+    // allocate a TLV entry for the space and write it in
+    let mut buffer = reprint_info.try_borrow_mut_data()?;
+    let mut state = TlvStateMut::unpack(&mut buffer)?;
+    state.alloc::<Member>(instance_size, false)?;
+    state.pack_first_variable_len_value(&reprint)?;
+
+    Ok(())
+}
+
+/// Processes an [Emit](enum.InterfaceBaseInstruction.html) instruction.
+pub fn process_emit<G>(program_id: &Pubkey, accounts: &[AccountInfo], data: Emit) -> ProgramResult
+where
+    G: SplTokenGroup,
+{
+    let account_info_iter = &mut accounts.iter();
+
+    // Accounts expected by this instruction:
+    //
+    //   0. `[]` Group or Member account
+    let asset_info = next_account_info(account_info_iter)?;
+
+    if asset_info.owner != program_id {
+        return Err(ProgramError::IllegalOwner);
+    }
+
+    let buffer = asset_info.try_borrow_data()?;
+    let state = TlvStateBorrowed::unpack(&buffer)?;
+
+    let item_bytes = match data.item_type {
+        ItemType::Group => state.get_first_bytes::<Group<G>>()?,
+        ItemType::Member => state.get_first_bytes::<Member>()?,
+    };
+
+    if let Some(range) = get_emit_slice(item_bytes, data.start, data.end) {
+        set_return_data(range);
+    }
+
+    Ok(())
+}
+
+/// Processor for a `Collection`
+fn process_collection_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction: TokenGroupInterfaceInstruction<Collection>,
+) -> ProgramResult {
+    match instruction {
+        TokenGroupInterfaceInstruction::InitializeGroup(data) => {
+            msg!("Instruction: InitializeCollection");
+            process_initialize_collection(program_id, accounts, data)
+        }
+        TokenGroupInterfaceInstruction::UpdateGroupMaxSize(data) => {
+            msg!("Instruction: UpdateCollectionMaxSize");
+            process_update_collection_max_size(program_id, accounts, data)
+        }
+        TokenGroupInterfaceInstruction::UpdateGroupAuthority(data) => {
+            msg!("Instruction: UpdateCollectionAuthority");
+            process_update_collection_authority(program_id, accounts, data)
+        }
+        TokenGroupInterfaceInstruction::InitializeMember(data) => {
+            msg!("Instruction: InitializeCollectionMember");
+            process_initialize_collection_member(program_id, accounts, data)
+        }
+        TokenGroupInterfaceInstruction::Emit(data) => {
+            msg!("Instruction: Emit");
+            process_emit::<Collection>(program_id, accounts, data)
+        }
+    }
+}
+
+/// Processor for an `Edition`
+fn process_edition_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction: TokenGroupInterfaceInstruction<Edition>,
+) -> ProgramResult {
+    match instruction {
+        TokenGroupInterfaceInstruction::InitializeGroup(data) => {
+            msg!("Instruction: InitializeOriginal");
+            process_initialize_original(program_id, accounts, data)
+        }
+        TokenGroupInterfaceInstruction::UpdateGroupMaxSize(data) => {
+            msg!("Instruction: UpdateEditionMaxSize");
+            process_update_edition_max_size(program_id, accounts, data)
+        }
+        TokenGroupInterfaceInstruction::UpdateGroupAuthority(data) => {
+            msg!("Instruction: UpdateEditionAuthority");
+            process_update_edition_authority(program_id, accounts, data)
+        }
+        TokenGroupInterfaceInstruction::InitializeMember(data) => {
+            msg!("Instruction: InitializeReprint");
+            process_initialize_reprint(program_id, accounts, data)
+        }
+        TokenGroupInterfaceInstruction::Emit(data) => {
+            msg!("Instruction: Emit");
+            process_emit::<Edition>(program_id, accounts, data)
+        }
+    }
+}
+
+/// Processes an `SplTokenGroupInstruction`
+pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> ProgramResult {
+    if TokenGroupInterfaceInstruction::<Collection>::peek(input) {
+        process_collection_instruction(
+            program_id,
+            accounts,
+            TokenGroupInterfaceInstruction::<Collection>::unpack(input)?,
+        )
+    } else if TokenGroupInterfaceInstruction::<Edition>::peek(input) {
+        process_edition_instruction(
+            program_id,
+            accounts,
+            TokenGroupInterfaceInstruction::<Edition>::unpack(input)?,
+        )
+    } else {
+        Err(ProgramError::InvalidInstructionData)
+    }
+}

--- a/token-group/example/src/state.rs
+++ b/token-group/example/src/state.rs
@@ -1,0 +1,83 @@
+//! Instruction types
+
+use {
+    borsh::{BorshDeserialize, BorshSerialize},
+    spl_discriminator::SplDiscriminate,
+    spl_token_group_interface::state::SplTokenGroup,
+    spl_type_length_value::SplBorshVariableLenPack,
+};
+
+/// A token `Collection`.
+///
+/// For this group, the relationship is simple:
+/// - The `Collection` is the group
+/// - The `Member` is a member
+#[derive(
+    BorshDeserialize,
+    BorshSerialize,
+    Clone,
+    Debug,
+    PartialEq,
+    SplBorshVariableLenPack,
+    SplDiscriminate,
+)]
+#[discriminator_hash_input("spl_token_group_example:collection")]
+pub struct Collection {
+    /// The `Collection`'s creation slot
+    pub creation_date: String,
+}
+
+impl SplTokenGroup for Collection {}
+
+/// Token `Edition`s.
+///
+/// For this group, the relationship is more complex:
+/// - The `Edition` is the group, but the group itself also serves as the
+///  "original" `Edition`
+/// - The `Reprint` is a member
+#[derive(
+    BorshDeserialize,
+    BorshSerialize,
+    Clone,
+    Debug,
+    PartialEq,
+    SplBorshVariableLenPack,
+    SplDiscriminate,
+)]
+#[discriminator_hash_input("spl_token_group_example:edition")]
+pub struct Edition {
+    /// The `Edition`'s line
+    pub line: EditionLine,
+    /// The `Edition`'s membership level
+    pub membership_level: MembershipLevel,
+}
+
+impl SplTokenGroup for Edition {}
+
+/// The `Edition`'s line.
+///
+/// Note: This data is simply for demonstration purposes.
+#[derive(BorshDeserialize, BorshSerialize, Clone, Debug, PartialEq)]
+pub enum EditionLine {
+    /// The `Edition` is an original
+    Original,
+    /// The `Edition` is a "gold" reprint
+    Gold,
+    /// The `Edition` is a "silver" reprint
+    Silver,
+    /// The `Edition` is a "bronze" reprint
+    Bronze,
+}
+
+/// The `Edition`'s membership level.
+///
+/// Note: This data is simply for demonstration purposes.
+#[derive(BorshDeserialize, BorshSerialize, Clone, Debug, PartialEq)]
+pub enum MembershipLevel {
+    /// The `Edition` is for "ultimate" members
+    Ultimate,
+    /// The `Edition` is for "premium" members
+    Premium,
+    /// The `Edition` is for "standard" members
+    Standard,
+}

--- a/token-group/example/tests/collection_initialize.rs
+++ b/token-group/example/tests/collection_initialize.rs
@@ -1,0 +1,226 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+use {
+    program_test::{setup_group, setup_program_test, TokenGroupTestContext},
+    solana_program_test::tokio,
+    solana_sdk::{
+        borsh::get_instance_packed_len,
+        instruction::InstructionError,
+        pubkey::Pubkey,
+        signer::Signer,
+        system_instruction,
+        transaction::{Transaction, TransactionError},
+    },
+    spl_token_group_example::state::Collection,
+    spl_token_group_interface::{
+        error::TokenGroupError, instruction::initialize_group, state::Group,
+    },
+    spl_type_length_value::{
+        error::TlvError,
+        state::{TlvState, TlvStateBorrowed},
+    },
+};
+
+#[tokio::test]
+async fn success_initialize_collection() {
+    let meta = Some(Collection {
+        creation_date: "August 15".to_string(),
+    });
+
+    // Setup a test for creating a token `Collection`:
+    // - Mint:         An NFT representing the `Collection` mint
+    // - Metadata:     A `TokenMetadata` representing the `Collection` metadata
+    // - Collection:   A `Collection` representing the `Collection` group
+    let TokenGroupTestContext {
+        context,
+        payer,
+        program_id,
+        mint_keypair,
+        mint_authority_keypair,
+        group_keypair: collection_keypair,
+        group: collection,
+        ..
+    } = setup_program_test::<Collection>("My Cool Collection", meta.clone()).await;
+
+    let mut context = context.lock().await;
+
+    // Hit our program to initialize the collection
+    setup_group::<Collection>(
+        &mut context,
+        &program_id,
+        &collection_keypair,
+        &mint_keypair.pubkey(),
+        &mint_authority_keypair,
+        &collection,
+        &[], // No extra account metas
+    )
+    .await;
+
+    // Fetch the collection account and ensure it matches our state
+    let fetched_collection_account = context
+        .banks_client
+        .get_account(collection_keypair.pubkey())
+        .await
+        .unwrap()
+        .unwrap();
+    let fetched_meta = TlvStateBorrowed::unpack(&fetched_collection_account.data).unwrap();
+    let fetched_collection = fetched_meta
+        .get_first_variable_len_value::<Group<Collection>>()
+        .unwrap();
+    assert_eq!(fetched_collection, collection);
+
+    // Fail doing it again, and change some params to ensure a new tx
+    {
+        let transaction = Transaction::new_signed_with_payer(
+            &[initialize_group::<Collection>(
+                &program_id,
+                &collection_keypair.pubkey(),
+                &mint_keypair.pubkey(),
+                &mint_authority_keypair.pubkey(),
+                None, // Intentionally changed params
+                Some(500),
+                &meta,
+                &[], // No extra account metas
+            )],
+            Some(&payer.pubkey()),
+            &[&payer, &mint_authority_keypair],
+            context.last_blockhash,
+        );
+        let error = context
+            .banks_client
+            .process_transaction(transaction)
+            .await
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(
+            error,
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TlvError::TypeAlreadyExists as u32)
+            )
+        );
+    }
+}
+
+#[tokio::test]
+async fn fail_without_authority_signature() {
+    let meta = Some(Collection {
+        creation_date: "August 15".to_string(),
+    });
+
+    let TokenGroupTestContext {
+        context,
+        program_id,
+        mint_keypair,
+        mint_authority_keypair,
+        group_keypair: collection_keypair,
+        group: collection,
+        ..
+    } = setup_program_test::<Collection>("My Cool Collection", meta.clone()).await;
+
+    let mut context = context.lock().await;
+
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let space = TlvStateBorrowed::get_base_len() + get_instance_packed_len(&collection).unwrap();
+    let rent_lamports = rent.minimum_balance(space);
+    let mut initialize_group_ix = initialize_group::<Collection>(
+        &program_id,
+        &collection_keypair.pubkey(),
+        &mint_keypair.pubkey(),
+        &mint_authority_keypair.pubkey(),
+        Option::<Pubkey>::from(collection.update_authority),
+        collection.max_size,
+        &meta,
+        &[], // No extra account metas
+    );
+    initialize_group_ix.accounts[2].is_signer = false;
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &collection_keypair.pubkey(),
+                rent_lamports,
+                space.try_into().unwrap(),
+                &program_id,
+            ),
+            initialize_group_ix,
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &collection_keypair], // Missing mint authority
+        context.last_blockhash,
+    );
+
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(1, InstructionError::MissingRequiredSignature,)
+    );
+}
+
+#[tokio::test]
+async fn fail_incorrect_authority() {
+    let meta = Some(Collection {
+        creation_date: "August 15".to_string(),
+    });
+
+    let TokenGroupTestContext {
+        context,
+        program_id,
+        mint_keypair,
+        group_keypair: collection_keypair,
+        group: collection,
+        ..
+    } = setup_program_test::<Collection>("My Cool Collection", meta.clone()).await;
+
+    let mut context = context.lock().await;
+
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let space = TlvStateBorrowed::get_base_len() + get_instance_packed_len(&collection).unwrap();
+    let rent_lamports = rent.minimum_balance(space);
+    let mut initialize_group_ix = initialize_group::<Collection>(
+        &program_id,
+        &collection_keypair.pubkey(),
+        &mint_keypair.pubkey(),
+        &collection_keypair.pubkey(), // NOT the mint authority
+        Option::<Pubkey>::from(collection.update_authority),
+        collection.max_size,
+        &meta,
+        &[], // No extra account metas
+    );
+    initialize_group_ix.accounts[2].is_signer = false;
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &collection_keypair.pubkey(),
+                rent_lamports,
+                space.try_into().unwrap(),
+                &program_id,
+            ),
+            initialize_group_ix,
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &collection_keypair],
+        context.last_blockhash,
+    );
+
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(
+            1,
+            InstructionError::Custom(TokenGroupError::IncorrectAuthority as u32)
+        )
+    );
+}

--- a/token-group/example/tests/collection_initialize_member.rs
+++ b/token-group/example/tests/collection_initialize_member.rs
@@ -1,0 +1,505 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+use {
+    program_test::{
+        setup_group, setup_member, setup_mint_and_metadata, setup_program_test,
+        TokenGroupTestContext,
+    },
+    solana_program_test::tokio,
+    solana_sdk::{
+        borsh::get_instance_packed_len,
+        instruction::InstructionError,
+        signature::Signer,
+        signer::keypair::Keypair,
+        system_instruction,
+        transaction::{Transaction, TransactionError},
+    },
+    spl_token_client::token::Token,
+    spl_token_group_example::state::Collection,
+    spl_token_group_interface::{
+        error::TokenGroupError, instruction::initialize_member, state::Member,
+    },
+    spl_token_metadata_interface::state::TokenMetadata,
+    spl_type_length_value::state::{TlvState, TlvStateBorrowed},
+};
+
+#[tokio::test]
+async fn success_initialize_member() {
+    let meta = Some(Collection {
+        creation_date: "August 15".to_string(),
+    });
+
+    let TokenGroupTestContext {
+        context,
+        client,
+        payer,
+        token_program_id,
+        program_id,
+        mint_keypair,
+        mint_authority_keypair,
+        group_keypair: collection_keypair,
+        group: collection,
+        ..
+    } = setup_program_test::<Collection>("My Cool Collection", meta).await;
+
+    // In this test (similar to `setup_group_test`):
+    // - The metadata is stored in the mint (Token-2022)
+    // - The member is in a separate account
+    // - The member's _metadata_ update authority is the mint authority
+    // - The mint is an NFT (0 decimals)
+    let member_keypair = Keypair::new();
+    let member_mint_keypair = Keypair::new();
+    let member_mint_authority_keypair = Keypair::new();
+    let member_metadata_keypair = member_mint_keypair.insecure_clone();
+    let member_metadata_update_authority_keypair = member_metadata_keypair.insecure_clone();
+    let decimals = 0;
+    let member = Member {
+        group: collection_keypair.pubkey(),
+        member_number: 1,
+    };
+
+    // Set up a mint and metadata for the member
+    setup_mint_and_metadata(
+        &Token::new(
+            client.clone(),
+            &token_program_id,
+            &member_mint_keypair.pubkey(),
+            Some(decimals),
+            payer.clone(),
+        ),
+        &member_mint_keypair,
+        &member_mint_authority_keypair,
+        &member_metadata_keypair.pubkey(),
+        &member_metadata_update_authority_keypair.pubkey(),
+        &TokenMetadata {
+            name: "I'm a Member!".to_string(),
+            symbol: "MEM".to_string(),
+            uri: "member.com".to_string(),
+            update_authority: Some(member_metadata_update_authority_keypair.pubkey())
+                .try_into()
+                .unwrap(),
+            mint: member_mint_keypair.pubkey(),
+            ..Default::default()
+        },
+        payer,
+    )
+    .await;
+
+    let mut context = context.lock().await;
+
+    setup_group::<Collection>(
+        &mut context,
+        &program_id,
+        &collection_keypair,
+        &mint_keypair.pubkey(),
+        &mint_authority_keypair,
+        &collection,
+        &[], // No extra account metas
+    )
+    .await;
+
+    setup_member::<Collection>(
+        &mut context,
+        &program_id,
+        &collection_keypair.pubkey(),
+        &mint_keypair.pubkey(),
+        &mint_authority_keypair,
+        &member_keypair,
+        &member_mint_keypair.pubkey(),
+        &member_mint_authority_keypair,
+        &member,
+        &[], // No extra account metas
+    )
+    .await;
+
+    let fetched_member_account = context
+        .banks_client
+        .get_account(member_keypair.pubkey())
+        .await
+        .unwrap()
+        .unwrap();
+    let fetched_member_state = TlvStateBorrowed::unpack(&fetched_member_account.data).unwrap();
+    let fetched_member = fetched_member_state
+        .get_first_variable_len_value::<Member>()
+        .unwrap();
+    assert_eq!(fetched_member, member);
+}
+
+#[tokio::test]
+async fn fail_without_authority_signature() {
+    let meta = Some(Collection {
+        creation_date: "August 15".to_string(),
+    });
+
+    let TokenGroupTestContext {
+        context,
+        client,
+        payer,
+        token_program_id,
+        program_id,
+        mint_keypair,
+        mint_authority_keypair,
+        group_keypair: collection_keypair,
+        group: collection,
+        ..
+    } = setup_program_test::<Collection>("My Cool Collection", meta).await;
+
+    // In this test (similar to `setup_group_test`):
+    // - The metadata is stored in the mint (Token-2022)
+    // - The member is in a separate account
+    // - The member's _metadata_ update authority is the mint authority
+    // - The mint is an NFT (0 decimals)
+    let member_keypair = Keypair::new();
+    let member_mint_keypair = Keypair::new();
+    let member_mint_authority_keypair = Keypair::new();
+    let member_metadata_keypair = member_mint_keypair.insecure_clone();
+    let member_metadata_update_authority_keypair = member_metadata_keypair.insecure_clone();
+    let decimals = 0;
+    let member = Member {
+        group: collection_keypair.pubkey(),
+        member_number: 1,
+    };
+
+    // Set up a mint and metadata for the member
+    setup_mint_and_metadata(
+        &Token::new(
+            client.clone(),
+            &token_program_id,
+            &member_mint_keypair.pubkey(),
+            Some(decimals),
+            payer.clone(),
+        ),
+        &member_mint_keypair,
+        &member_mint_authority_keypair,
+        &member_metadata_keypair.pubkey(),
+        &member_metadata_update_authority_keypair.pubkey(),
+        &TokenMetadata {
+            name: "I'm a Member!".to_string(),
+            symbol: "MEM".to_string(),
+            uri: "member.com".to_string(),
+            update_authority: Some(member_metadata_update_authority_keypair.pubkey())
+                .try_into()
+                .unwrap(),
+            mint: member_mint_keypair.pubkey(),
+            ..Default::default()
+        },
+        payer,
+    )
+    .await;
+
+    let mut context = context.lock().await;
+
+    setup_group::<Collection>(
+        &mut context,
+        &program_id,
+        &collection_keypair,
+        &mint_keypair.pubkey(),
+        &mint_authority_keypair,
+        &collection,
+        &[], // No extra account metas
+    )
+    .await;
+
+    let rent = context.banks_client.get_rent().await.unwrap();
+
+    let token_metadata_space = TokenMetadata::default().tlv_size_of().unwrap();
+    let token_metadata_rent_lamports = rent.minimum_balance(token_metadata_space);
+
+    let space = TlvStateBorrowed::get_base_len() + get_instance_packed_len(&member).unwrap();
+    let rent_lamports = rent.minimum_balance(space);
+
+    // Fail missing member mint authority
+
+    let mut initialize_member_ix = initialize_member::<Collection>(
+        &program_id,
+        &collection_keypair.pubkey(),
+        &mint_keypair.pubkey(),
+        &mint_authority_keypair.pubkey(),
+        &member_keypair.pubkey(),
+        &member_mint_keypair.pubkey(),
+        &member_mint_authority_keypair.pubkey(),
+        member.member_number,
+        &[], // No extra account metas
+    );
+    initialize_member_ix.accounts[2].is_signer = false;
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &member_keypair.pubkey(),
+                rent_lamports,
+                space.try_into().unwrap(),
+                &program_id,
+            ),
+            // Fund the mint with extra rent for metadata
+            system_instruction::transfer(
+                &context.payer.pubkey(),
+                &member_mint_keypair.pubkey(),
+                token_metadata_rent_lamports,
+            ),
+            initialize_member_ix,
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &member_keypair, &mint_authority_keypair], /* Missing member mint
+                                                                      * authority */
+        context.last_blockhash,
+    );
+
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(2, InstructionError::MissingRequiredSignature,)
+    );
+
+    // Fail missing collection mint authority
+
+    let mut initialize_member_ix = initialize_member::<Collection>(
+        &program_id,
+        &collection_keypair.pubkey(),
+        &mint_keypair.pubkey(),
+        &mint_authority_keypair.pubkey(),
+        &member_keypair.pubkey(),
+        &member_mint_keypair.pubkey(),
+        &member_mint_authority_keypair.pubkey(),
+        member.member_number,
+        &[], // No extra account metas
+    );
+    initialize_member_ix.accounts[5].is_signer = false;
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &member_keypair.pubkey(),
+                rent_lamports,
+                space.try_into().unwrap(),
+                &program_id,
+            ),
+            // Fund the mint with extra rent for metadata
+            system_instruction::transfer(
+                &context.payer.pubkey(),
+                &member_mint_keypair.pubkey(),
+                token_metadata_rent_lamports,
+            ),
+            initialize_member_ix,
+        ],
+        Some(&context.payer.pubkey()),
+        &[
+            &context.payer,
+            &member_keypair,
+            &member_mint_authority_keypair,
+        ], /* Missing collection mint
+            * authority */
+        context.last_blockhash,
+    );
+
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(2, InstructionError::MissingRequiredSignature,)
+    );
+}
+
+#[tokio::test]
+async fn fail_incorrect_authority() {
+    let meta = Some(Collection {
+        creation_date: "August 15".to_string(),
+    });
+
+    let TokenGroupTestContext {
+        context,
+        client,
+        payer,
+        token_program_id,
+        program_id,
+        mint_keypair,
+        mint_authority_keypair,
+        group_keypair: collection_keypair,
+        group: collection,
+        ..
+    } = setup_program_test::<Collection>("My Cool Collection", meta).await;
+
+    // In this test (similar to `setup_group_test`):
+    // - The metadata is stored in the mint (Token-2022)
+    // - The member is in a separate account
+    // - The member's _metadata_ update authority is the mint authority
+    // - The _member_ update authority is also the mint authority
+    // - The mint is an NFT (0 decimals)
+    let member_keypair = Keypair::new();
+    let member_mint_keypair = Keypair::new();
+    let member_mint_authority_keypair = Keypair::new();
+    let member_metadata_keypair = member_mint_keypair.insecure_clone();
+    let member_metadata_update_authority_keypair = member_metadata_keypair.insecure_clone();
+    let member_update_authority_keypair = member_metadata_keypair.insecure_clone();
+    let decimals = 0;
+    let member = Member {
+        group: collection_keypair.pubkey(),
+        member_number: 1,
+    };
+
+    // Set up a mint and metadata for the member
+    setup_mint_and_metadata(
+        &Token::new(
+            client.clone(),
+            &token_program_id,
+            &member_mint_keypair.pubkey(),
+            Some(decimals),
+            payer.clone(),
+        ),
+        &member_mint_keypair,
+        &member_mint_authority_keypair,
+        &member_metadata_keypair.pubkey(),
+        &member_metadata_update_authority_keypair.pubkey(),
+        &TokenMetadata {
+            name: "I'm a Member!".to_string(),
+            symbol: "MEM".to_string(),
+            uri: "member.com".to_string(),
+            update_authority: Some(member_update_authority_keypair.pubkey())
+                .try_into()
+                .unwrap(),
+            mint: member_mint_keypair.pubkey(),
+            ..Default::default()
+        },
+        payer,
+    )
+    .await;
+
+    let mut context = context.lock().await;
+
+    setup_group::<Collection>(
+        &mut context,
+        &program_id,
+        &collection_keypair,
+        &mint_keypair.pubkey(),
+        &mint_authority_keypair,
+        &collection,
+        &[], // No extra account metas
+    )
+    .await;
+
+    let rent = context.banks_client.get_rent().await.unwrap();
+
+    let token_metadata_space = TokenMetadata::default().tlv_size_of().unwrap();
+    let token_metadata_rent_lamports = rent.minimum_balance(token_metadata_space);
+
+    let space = TlvStateBorrowed::get_base_len() + get_instance_packed_len(&member).unwrap();
+    let rent_lamports = rent.minimum_balance(space);
+
+    // Fail incorrect member mint authority
+
+    let mut initialize_member_ix = initialize_member::<Collection>(
+        &program_id,
+        &collection_keypair.pubkey(),
+        &mint_keypair.pubkey(),
+        &mint_authority_keypair.pubkey(),
+        &member_keypair.pubkey(),
+        &member_mint_keypair.pubkey(),
+        &mint_authority_keypair.pubkey(), // NOT the member mint authority
+        member.member_number,
+        &[], // No extra account metas
+    );
+    initialize_member_ix.accounts[5].is_signer = false;
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &member_keypair.pubkey(),
+                rent_lamports,
+                space.try_into().unwrap(),
+                &program_id,
+            ),
+            // Fund the mint with extra rent for metadata
+            system_instruction::transfer(
+                &context.payer.pubkey(),
+                &member_mint_keypair.pubkey(),
+                token_metadata_rent_lamports,
+            ),
+            initialize_member_ix,
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &member_keypair, &mint_authority_keypair],
+        context.last_blockhash,
+    );
+
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(
+            2,
+            InstructionError::Custom(TokenGroupError::IncorrectAuthority as u32)
+        )
+    );
+
+    // Fail missing collection mint authority
+
+    let mut initialize_member_ix = initialize_member::<Collection>(
+        &program_id,
+        &collection_keypair.pubkey(),
+        &mint_keypair.pubkey(),
+        &member_mint_authority_keypair.pubkey(), // NOT the collection mint authority
+        &member_keypair.pubkey(),
+        &member_mint_keypair.pubkey(),
+        &member_mint_authority_keypair.pubkey(),
+        member.member_number,
+        &[], // No extra account metas
+    );
+    initialize_member_ix.accounts[2].is_signer = false;
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &member_keypair.pubkey(),
+                rent_lamports,
+                space.try_into().unwrap(),
+                &program_id,
+            ),
+            // Fund the mint with extra rent for metadata
+            system_instruction::transfer(
+                &context.payer.pubkey(),
+                &member_mint_keypair.pubkey(),
+                token_metadata_rent_lamports,
+            ),
+            initialize_member_ix,
+        ],
+        Some(&context.payer.pubkey()),
+        &[
+            &context.payer,
+            &member_keypair,
+            &member_mint_authority_keypair,
+        ],
+        context.last_blockhash,
+    );
+
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(
+            2,
+            InstructionError::Custom(TokenGroupError::IncorrectAuthority as u32)
+        )
+    );
+}

--- a/token-group/example/tests/collection_update_authority.rs
+++ b/token-group/example/tests/collection_update_authority.rs
@@ -1,0 +1,209 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+use {
+    program_test::{setup_group, setup_program_test, TokenGroupTestContext},
+    solana_program_test::tokio,
+    solana_sdk::{
+        instruction::InstructionError,
+        pubkey::Pubkey,
+        signature::Signer,
+        signer::keypair::Keypair,
+        transaction::{Transaction, TransactionError},
+    },
+    spl_token_group_example::state::Collection,
+    spl_token_group_interface::{
+        error::TokenGroupError, instruction::update_group_authority, state::Group,
+    },
+    spl_type_length_value::state::{TlvState, TlvStateBorrowed},
+};
+
+#[tokio::test]
+async fn success_update_collection_authority() {
+    let meta = Some(Collection {
+        creation_date: "August 15".to_string(),
+    });
+
+    let TokenGroupTestContext {
+        context,
+        payer,
+        program_id,
+        mint_keypair,
+        mint_authority_keypair,
+        group_keypair: collection_keypair,
+        group_update_authority_keypair: collection_update_authority_keypair,
+        group: collection,
+        ..
+    } = setup_program_test::<Collection>("My Cool Collection", meta).await;
+
+    let mut context = context.lock().await;
+
+    // Hit our program to initialize the collection
+    setup_group::<Collection>(
+        &mut context,
+        &program_id,
+        &collection_keypair,
+        &mint_keypair.pubkey(),
+        &mint_authority_keypair,
+        &collection,
+        &[], // No extra account metas
+    )
+    .await;
+
+    let new_authority_keypair = Keypair::new();
+    let new_authority_pubkey = new_authority_keypair.pubkey();
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[update_group_authority::<Collection>(
+            &program_id,
+            &collection_keypair.pubkey(),
+            &collection_update_authority_keypair.pubkey(),
+            Some(new_authority_pubkey),
+        )],
+        Some(&payer.pubkey()),
+        &[&payer, &collection_update_authority_keypair],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+
+    let fetched_collection_account = context
+        .banks_client
+        .get_account(collection_keypair.pubkey())
+        .await
+        .unwrap()
+        .unwrap();
+    let fetched_meta = TlvStateBorrowed::unpack(&fetched_collection_account.data).unwrap();
+    let fetched_collection = fetched_meta
+        .get_first_variable_len_value::<Group<Collection>>()
+        .unwrap();
+    assert_eq!(
+        Option::<Pubkey>::from(fetched_collection.update_authority),
+        Some(new_authority_pubkey),
+    );
+
+    // Can change to `None`
+
+    let second_new_authority = None;
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[update_group_authority::<Collection>(
+            &program_id,
+            &collection_keypair.pubkey(),
+            &new_authority_pubkey,
+            second_new_authority,
+        )],
+        Some(&payer.pubkey()),
+        &[&payer, &new_authority_keypair],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+
+    let fetched_collection_account = context
+        .banks_client
+        .get_account(collection_keypair.pubkey())
+        .await
+        .unwrap()
+        .unwrap();
+    let fetched_meta = TlvStateBorrowed::unpack(&fetched_collection_account.data).unwrap();
+    let fetched_collection = fetched_meta
+        .get_first_variable_len_value::<Group<Collection>>()
+        .unwrap();
+    assert_eq!(
+        Option::<Pubkey>::from(fetched_collection.update_authority),
+        second_new_authority
+    );
+}
+
+#[tokio::test]
+async fn fail_authority_checks() {
+    let meta = Some(Collection {
+        creation_date: "August 15".to_string(),
+    });
+
+    let TokenGroupTestContext {
+        context,
+        program_id,
+        mint_keypair,
+        mint_authority_keypair,
+        group_keypair: collection_keypair,
+        group_update_authority_keypair: collection_update_authority_keypair,
+        group: collection,
+        ..
+    } = setup_program_test::<Collection>("My Cool Collection", meta).await;
+
+    let mut context = context.lock().await;
+
+    // Hit our program to initialize the collection
+    setup_group::<Collection>(
+        &mut context,
+        &program_id,
+        &collection_keypair,
+        &mint_keypair.pubkey(),
+        &mint_authority_keypair,
+        &collection,
+        &[], // No extra account metas
+    )
+    .await;
+
+    let new_authority_keypair = Keypair::new();
+    let new_authority_pubkey = new_authority_keypair.pubkey();
+
+    // No signature
+    let mut update_authority_ix = update_group_authority::<Collection>(
+        &program_id,
+        &collection_keypair.pubkey(),
+        &collection_update_authority_keypair.pubkey(),
+        Some(new_authority_pubkey),
+    );
+    update_authority_ix.accounts[1].is_signer = false;
+    let transaction = Transaction::new_signed_with_payer(
+        &[update_authority_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature,)
+    );
+
+    // Wrong authority
+    let transaction = Transaction::new_signed_with_payer(
+        &[update_group_authority::<Collection>(
+            &program_id,
+            &collection_keypair.pubkey(),
+            &collection_keypair.pubkey(),
+            Some(new_authority_pubkey),
+        )],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &collection_keypair],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(TokenGroupError::IncorrectAuthority as u32),
+        )
+    );
+}

--- a/token-group/example/tests/collection_update_max_size.rs
+++ b/token-group/example/tests/collection_update_max_size.rs
@@ -1,0 +1,166 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+use {
+    program_test::{setup_group, setup_program_test, TokenGroupTestContext},
+    solana_program_test::tokio,
+    solana_sdk::{
+        instruction::InstructionError,
+        signer::Signer,
+        transaction::{Transaction, TransactionError},
+    },
+    spl_token_group_example::state::Collection,
+    spl_token_group_interface::{
+        error::TokenGroupError, instruction::update_group_max_size, state::Group,
+    },
+    spl_type_length_value::state::{TlvState, TlvStateBorrowed},
+};
+
+#[tokio::test]
+async fn success_update_collection_max_size() {
+    let meta = Some(Collection {
+        creation_date: "August 15".to_string(),
+    });
+
+    let TokenGroupTestContext {
+        context,
+        payer,
+        program_id,
+        mint_keypair,
+        mint_authority_keypair,
+        group_keypair: collection_keypair,
+        group_update_authority_keypair: collection_update_authority_keypair,
+        group: collection,
+        ..
+    } = setup_program_test::<Collection>("My Cool Collection", meta).await;
+
+    let mut context = context.lock().await;
+
+    // Hit our program to initialize the collection
+    setup_group::<Collection>(
+        &mut context,
+        &program_id,
+        &collection_keypair,
+        &mint_keypair.pubkey(),
+        &mint_authority_keypair,
+        &collection,
+        &[], // No extra account metas
+    )
+    .await;
+
+    let new_max_size = Some(200);
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[update_group_max_size::<Collection>(
+            &program_id,
+            &collection_keypair.pubkey(),
+            &collection_update_authority_keypair.pubkey(),
+            new_max_size,
+        )],
+        Some(&payer.pubkey()),
+        &[&payer, &collection_update_authority_keypair],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+
+    let fetched_collection_account = context
+        .banks_client
+        .get_account(collection_keypair.pubkey())
+        .await
+        .unwrap()
+        .unwrap();
+    let fetched_meta = TlvStateBorrowed::unpack(&fetched_collection_account.data).unwrap();
+    let fetched_collection_data = fetched_meta
+        .get_first_variable_len_value::<Group<Collection>>()
+        .unwrap();
+    assert_eq!(fetched_collection_data.max_size, new_max_size);
+}
+
+#[tokio::test]
+async fn fail_authority_checks() {
+    let meta = Some(Collection {
+        creation_date: "August 15".to_string(),
+    });
+
+    let TokenGroupTestContext {
+        context,
+        program_id,
+        mint_keypair,
+        mint_authority_keypair,
+        group_keypair: collection_keypair,
+        group_update_authority_keypair: collection_update_authority_keypair,
+        group: collection,
+        ..
+    } = setup_program_test::<Collection>("My Cool Collection", meta).await;
+
+    let mut context = context.lock().await;
+
+    // Hit our program to initialize the collection
+    setup_group::<Collection>(
+        &mut context,
+        &program_id,
+        &collection_keypair,
+        &mint_keypair.pubkey(),
+        &mint_authority_keypair,
+        &collection,
+        &[], // No extra account metas
+    )
+    .await;
+
+    let new_max_size = Some(200);
+
+    // No signature
+    let mut update_size_ix = update_group_max_size::<Collection>(
+        &program_id,
+        &collection_keypair.pubkey(),
+        &collection_update_authority_keypair.pubkey(),
+        new_max_size,
+    );
+    update_size_ix.accounts[1].is_signer = false;
+    let transaction = Transaction::new_signed_with_payer(
+        &[update_size_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature,)
+    );
+
+    // Wrong authority
+    let transaction = Transaction::new_signed_with_payer(
+        &[update_group_max_size::<Collection>(
+            &program_id,
+            &collection_keypair.pubkey(),
+            &collection_keypair.pubkey(),
+            new_max_size,
+        )],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &collection_keypair],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(TokenGroupError::IncorrectAuthority as u32),
+        )
+    );
+}

--- a/token-group/example/tests/edition_initialize.rs
+++ b/token-group/example/tests/edition_initialize.rs
@@ -1,0 +1,307 @@
+#![cfg(feature = "test-sbf")]
+
+use solana_program::instruction::AccountMeta;
+
+mod program_test;
+use {
+    program_test::{setup_group, setup_program_test, TokenGroupTestContext},
+    solana_program_test::tokio,
+    solana_sdk::{
+        borsh::get_instance_packed_len,
+        instruction::InstructionError,
+        pubkey::Pubkey,
+        signer::Signer,
+        system_instruction,
+        transaction::{Transaction, TransactionError},
+    },
+    spl_token_group_example::state::{Edition, EditionLine, MembershipLevel},
+    spl_token_group_interface::{
+        error::TokenGroupError, instruction::initialize_group, state::Group,
+    },
+    spl_type_length_value::{
+        error::TlvError,
+        state::{TlvState, TlvStateBorrowed},
+    },
+};
+
+#[tokio::test]
+async fn success_initialize_original_print() {
+    let meta = Some(Edition {
+        line: EditionLine::Original,
+        membership_level: MembershipLevel::Ultimate,
+    });
+
+    // Setup a test for creating a token `Edition`:
+    // - Mint:         An NFT representing the `Edition` mint (original print)
+    // - Metadata:     A `TokenMetadata` representing the original print's metadata
+    // - Edition:      An `Edition` representing the `Edition` group
+    let TokenGroupTestContext {
+        context,
+        payer,
+        program_id,
+        mint_keypair,
+        mint_authority_keypair,
+        metadata_keypair,
+        group_keypair: original_print_keypair,
+        group: original_print,
+        ..
+    } = setup_program_test::<Edition>("My Cool Edition", meta.clone()).await;
+
+    let mut context = context.lock().await;
+
+    let extra_metas = [AccountMeta::new_readonly(metadata_keypair.pubkey(), false)];
+
+    // Hit our program to initialize the original print
+    setup_group::<Edition>(
+        &mut context,
+        &program_id,
+        &original_print_keypair,
+        &mint_keypair.pubkey(),
+        &mint_authority_keypair,
+        &original_print,
+        &extra_metas,
+    )
+    .await;
+
+    // Fetch the original print account and ensure it matches our state
+    let fetched_original_print_account = context
+        .banks_client
+        .get_account(original_print_keypair.pubkey())
+        .await
+        .unwrap()
+        .unwrap();
+    let fetched_meta = TlvStateBorrowed::unpack(&fetched_original_print_account.data).unwrap();
+    let fetched_original_print = fetched_meta
+        .get_first_variable_len_value::<Group<Edition>>()
+        .unwrap();
+    assert_eq!(fetched_original_print, original_print);
+
+    // Fail doing it again, and change some params to ensure a new tx
+    {
+        let transaction = Transaction::new_signed_with_payer(
+            &[initialize_group::<Edition>(
+                &program_id,
+                &original_print_keypair.pubkey(),
+                &mint_keypair.pubkey(),
+                &mint_authority_keypair.pubkey(),
+                None, // Intentionally changed params
+                Some(500),
+                &meta,
+                &extra_metas,
+            )],
+            Some(&payer.pubkey()),
+            &[&payer, &mint_authority_keypair],
+            context.last_blockhash,
+        );
+        let error = context
+            .banks_client
+            .process_transaction(transaction)
+            .await
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(
+            error,
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TlvError::TypeAlreadyExists as u32)
+            )
+        );
+    }
+}
+
+#[tokio::test]
+async fn fail_without_authority_signature() {
+    let meta = Some(Edition {
+        line: EditionLine::Original,
+        membership_level: MembershipLevel::Ultimate,
+    });
+
+    let TokenGroupTestContext {
+        context,
+        program_id,
+        mint_keypair,
+        mint_authority_keypair,
+        metadata_keypair,
+        group_keypair: original_print_keypair,
+        group: original_print,
+        ..
+    } = setup_program_test::<Edition>("My Cool Edition", meta.clone()).await;
+
+    let mut context = context.lock().await;
+
+    let extra_metas = [AccountMeta::new_readonly(metadata_keypair.pubkey(), false)];
+
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let space =
+        TlvStateBorrowed::get_base_len() + get_instance_packed_len(&original_print).unwrap();
+    let rent_lamports = rent.minimum_balance(space);
+    let mut initialize_group_ix = initialize_group::<Edition>(
+        &program_id,
+        &original_print_keypair.pubkey(),
+        &mint_keypair.pubkey(),
+        &mint_authority_keypair.pubkey(),
+        Option::<Pubkey>::from(original_print.update_authority),
+        original_print.max_size,
+        &meta,
+        &extra_metas,
+    );
+    initialize_group_ix.accounts[2].is_signer = false;
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &original_print_keypair.pubkey(),
+                rent_lamports,
+                space.try_into().unwrap(),
+                &program_id,
+            ),
+            initialize_group_ix,
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &original_print_keypair], // Missing mint authority
+        context.last_blockhash,
+    );
+
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(1, InstructionError::MissingRequiredSignature,)
+    );
+}
+
+#[tokio::test]
+async fn fail_incorrect_authority() {
+    let meta = Some(Edition {
+        line: EditionLine::Original,
+        membership_level: MembershipLevel::Ultimate,
+    });
+
+    let TokenGroupTestContext {
+        context,
+        program_id,
+        mint_keypair,
+        metadata_keypair,
+        group_keypair: original_print_keypair,
+        group: original_print,
+        ..
+    } = setup_program_test::<Edition>("My Cool Edition", meta.clone()).await;
+
+    let mut context = context.lock().await;
+
+    let extra_metas = [AccountMeta::new_readonly(metadata_keypair.pubkey(), false)];
+
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let space =
+        TlvStateBorrowed::get_base_len() + get_instance_packed_len(&original_print).unwrap();
+    let rent_lamports = rent.minimum_balance(space);
+    let mut initialize_group_ix = initialize_group::<Edition>(
+        &program_id,
+        &original_print_keypair.pubkey(),
+        &mint_keypair.pubkey(),
+        &original_print_keypair.pubkey(), // NOT the mint authority
+        Option::<Pubkey>::from(original_print.update_authority),
+        original_print.max_size,
+        &meta,
+        &extra_metas,
+    );
+    initialize_group_ix.accounts[2].is_signer = false;
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &original_print_keypair.pubkey(),
+                rent_lamports,
+                space.try_into().unwrap(),
+                &program_id,
+            ),
+            initialize_group_ix,
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &original_print_keypair],
+        context.last_blockhash,
+    );
+
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(
+            1,
+            InstructionError::Custom(TokenGroupError::IncorrectAuthority as u32)
+        )
+    );
+}
+
+#[tokio::test]
+async fn fail_missing_extra_metas() {
+    let meta = Some(Edition {
+        line: EditionLine::Original,
+        membership_level: MembershipLevel::Ultimate,
+    });
+
+    let TokenGroupTestContext {
+        context,
+        program_id,
+        mint_keypair,
+        mint_authority_keypair,
+        group_keypair: original_print_keypair,
+        group: original_print,
+        ..
+    } = setup_program_test::<Edition>("My Cool Edition", meta.clone()).await;
+
+    let mut context = context.lock().await;
+
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let space =
+        TlvStateBorrowed::get_base_len() + get_instance_packed_len(&original_print).unwrap();
+    let rent_lamports = rent.minimum_balance(space);
+    let initialize_group_ix = initialize_group::<Edition>(
+        &program_id,
+        &original_print_keypair.pubkey(),
+        &mint_keypair.pubkey(),
+        &mint_authority_keypair.pubkey(),
+        Option::<Pubkey>::from(original_print.update_authority),
+        original_print.max_size,
+        &meta,
+        &[], // Missing extra metas
+    );
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &original_print_keypair.pubkey(),
+                rent_lamports,
+                space.try_into().unwrap(),
+                &program_id,
+            ),
+            initialize_group_ix,
+        ],
+        Some(&context.payer.pubkey()),
+        &[
+            &context.payer,
+            &original_print_keypair,
+            &mint_authority_keypair,
+        ],
+        context.last_blockhash,
+    );
+
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(1, InstructionError::NotEnoughAccountKeys)
+    );
+}

--- a/token-group/example/tests/edition_initialize_member.rs
+++ b/token-group/example/tests/edition_initialize_member.rs
@@ -1,0 +1,557 @@
+#![cfg(feature = "test-sbf")]
+
+use solana_program::instruction::AccountMeta;
+
+mod program_test;
+use {
+    program_test::{
+        setup_group, setup_member_with_metadata_rent, setup_mint_with_metadata_pointer,
+        setup_program_test, TokenGroupTestContext,
+    },
+    solana_program_test::tokio,
+    solana_sdk::{
+        borsh::get_instance_packed_len,
+        instruction::InstructionError,
+        signature::Signer,
+        signer::keypair::Keypair,
+        system_instruction,
+        transaction::{Transaction, TransactionError},
+    },
+    spl_token_client::token::Token,
+    spl_token_group_example::state::{Edition, EditionLine, MembershipLevel},
+    spl_token_group_interface::{
+        error::TokenGroupError, instruction::initialize_member, state::Member,
+    },
+    spl_type_length_value::state::{TlvState, TlvStateBorrowed},
+};
+
+#[tokio::test]
+async fn success_initialize_reprint() {
+    let meta = Some(Edition {
+        line: EditionLine::Original,
+        membership_level: MembershipLevel::Ultimate,
+    });
+
+    let TokenGroupTestContext {
+        context,
+        client,
+        payer,
+        token_program_id,
+        program_id,
+        mint_keypair,
+        mint_authority_keypair,
+        metadata_keypair,
+        group_keypair: original_print_keypair,
+        group: original_print,
+        group_token_metadata: original_print_token_metadata,
+        ..
+    } = setup_program_test::<Edition>("My Cool Edition", meta).await;
+
+    // In this test (similar to `setup_group_test`):
+    // - The metadata is stored in the mint (Token-2022)
+    // - The reprint is in a separate account
+    // - The reprint's _metadata_ update authority is the mint authority
+    // - The mint is an NFT (0 decimals)
+    let reprint_keypair = Keypair::new();
+    let reprint_mint_keypair = Keypair::new();
+    let reprint_mint_authority_keypair = Keypair::new();
+    let reprint_metadata_keypair = reprint_mint_keypair.insecure_clone();
+    let reprint_metadata_update_authority_keypair = reprint_metadata_keypair.insecure_clone();
+    let decimals = 0;
+    let reprint = Member {
+        group: original_print_keypair.pubkey(),
+        member_number: 1,
+    };
+
+    // Set up a mint for the reprint
+    setup_mint_with_metadata_pointer(
+        &Token::new(
+            client.clone(),
+            &token_program_id,
+            &reprint_mint_keypair.pubkey(),
+            Some(decimals),
+            payer.clone(),
+        ),
+        &reprint_mint_keypair,
+        &reprint_mint_authority_keypair,
+        &reprint_metadata_keypair.pubkey(),
+        &reprint_metadata_update_authority_keypair.pubkey(),
+    )
+    .await;
+
+    let mut context = context.lock().await;
+
+    let group_extra_metas = [AccountMeta::new_readonly(metadata_keypair.pubkey(), false)];
+    let member_extra_metas = [
+        AccountMeta::new(reprint_metadata_keypair.pubkey(), false),
+        AccountMeta::new_readonly(reprint_metadata_update_authority_keypair.pubkey(), false),
+        AccountMeta::new_readonly(metadata_keypair.pubkey(), false), // Group metadata
+        AccountMeta::new_readonly(token_program_id, false),          // Token metadata program
+    ];
+
+    setup_group::<Edition>(
+        &mut context,
+        &program_id,
+        &original_print_keypair,
+        &mint_keypair.pubkey(),
+        &mint_authority_keypair,
+        &original_print,
+        &group_extra_metas,
+    )
+    .await;
+
+    setup_member_with_metadata_rent::<Edition>(
+        &mut context,
+        &program_id,
+        &original_print_keypair.pubkey(),
+        &mint_keypair.pubkey(),
+        &mint_authority_keypair,
+        &original_print_token_metadata,
+        &reprint_keypair,
+        &reprint_mint_keypair.pubkey(),
+        &reprint_mint_authority_keypair,
+        &reprint,
+        &member_extra_metas,
+    )
+    .await;
+
+    let fetched_reprint_account = context
+        .banks_client
+        .get_account(reprint_keypair.pubkey())
+        .await
+        .unwrap()
+        .unwrap();
+    let fetched_reprint_state = TlvStateBorrowed::unpack(&fetched_reprint_account.data).unwrap();
+    let fetched_reprint = fetched_reprint_state
+        .get_first_variable_len_value::<Member>()
+        .unwrap();
+    assert_eq!(fetched_reprint, reprint);
+}
+
+#[tokio::test]
+async fn fail_without_authority_signature() {
+    let meta = Some(Edition {
+        line: EditionLine::Original,
+        membership_level: MembershipLevel::Ultimate,
+    });
+
+    let TokenGroupTestContext {
+        context,
+        client,
+        payer,
+        token_program_id,
+        program_id,
+        mint_keypair,
+        mint_authority_keypair,
+        metadata_keypair,
+        group_keypair: original_print_keypair,
+        group: original_print,
+        group_token_metadata: original_print_token_metadata,
+        ..
+    } = setup_program_test::<Edition>("My Cool Edition", meta).await;
+
+    // In this test (similar to `setup_group_test`):
+    // - The metadata is stored in the mint (Token-2022)
+    // - The reprint is in a separate account
+    // - The reprint's _metadata_ update authority is the mint authority
+    // - The mint is an NFT (0 decimals)
+    let reprint_keypair = Keypair::new();
+    let reprint_mint_keypair = Keypair::new();
+    let reprint_mint_authority_keypair = Keypair::new();
+    let reprint_metadata_keypair = reprint_mint_keypair.insecure_clone();
+    let reprint_metadata_update_authority_keypair = reprint_metadata_keypair.insecure_clone();
+    let decimals = 0;
+    let reprint = Member {
+        group: original_print_keypair.pubkey(),
+        member_number: 1,
+    };
+
+    // Set up a mint for the reprint
+    setup_mint_with_metadata_pointer(
+        &Token::new(
+            client.clone(),
+            &token_program_id,
+            &reprint_mint_keypair.pubkey(),
+            Some(decimals),
+            payer.clone(),
+        ),
+        &reprint_mint_keypair,
+        &reprint_mint_authority_keypair,
+        &reprint_metadata_keypair.pubkey(),
+        &reprint_metadata_update_authority_keypair.pubkey(),
+    )
+    .await;
+
+    let mut context = context.lock().await;
+
+    let group_extra_metas = [AccountMeta::new_readonly(metadata_keypair.pubkey(), false)];
+    let member_extra_metas = [
+        AccountMeta::new(reprint_metadata_keypair.pubkey(), false),
+        AccountMeta::new_readonly(reprint_metadata_update_authority_keypair.pubkey(), false),
+        AccountMeta::new_readonly(metadata_keypair.pubkey(), false), // Group metadata
+        AccountMeta::new_readonly(token_program_id, false),          // Token metadata program
+    ];
+
+    setup_group::<Edition>(
+        &mut context,
+        &program_id,
+        &original_print_keypair,
+        &mint_keypair.pubkey(),
+        &mint_authority_keypair,
+        &original_print,
+        &group_extra_metas,
+    )
+    .await;
+
+    let rent = context.banks_client.get_rent().await.unwrap();
+
+    let token_metadata_space = original_print_token_metadata.tlv_size_of().unwrap();
+    let token_metadata_rent_lamports = rent.minimum_balance(token_metadata_space);
+
+    let space = TlvStateBorrowed::get_base_len() + get_instance_packed_len(&reprint).unwrap();
+    let rent_lamports = rent.minimum_balance(space);
+
+    // Fail missing reprint mint authority
+
+    let mut initialize_reprint_ix = initialize_member::<Edition>(
+        &program_id,
+        &original_print_keypair.pubkey(),
+        &mint_keypair.pubkey(),
+        &mint_authority_keypair.pubkey(),
+        &reprint_keypair.pubkey(),
+        &reprint_mint_keypair.pubkey(),
+        &reprint_mint_authority_keypair.pubkey(),
+        reprint.member_number,
+        &member_extra_metas,
+    );
+    initialize_reprint_ix.accounts[2].is_signer = false;
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &reprint_keypair.pubkey(),
+                rent_lamports,
+                space.try_into().unwrap(),
+                &program_id,
+            ),
+            // Fund the mint with extra rent for metadata
+            system_instruction::transfer(
+                &context.payer.pubkey(),
+                &reprint_mint_keypair.pubkey(),
+                token_metadata_rent_lamports,
+            ),
+            initialize_reprint_ix,
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &reprint_keypair, &mint_authority_keypair], /* Missing reprint mint
+                                                                       * authority */
+        context.last_blockhash,
+    );
+
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(2, InstructionError::MissingRequiredSignature,)
+    );
+
+    // Fail missing original print mint authority
+
+    let mut initialize_reprint_ix = initialize_member::<Edition>(
+        &program_id,
+        &original_print_keypair.pubkey(),
+        &mint_keypair.pubkey(),
+        &mint_authority_keypair.pubkey(),
+        &reprint_keypair.pubkey(),
+        &reprint_mint_keypair.pubkey(),
+        &reprint_mint_authority_keypair.pubkey(),
+        reprint.member_number,
+        &member_extra_metas,
+    );
+    initialize_reprint_ix.accounts[5].is_signer = false;
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &reprint_keypair.pubkey(),
+                rent_lamports,
+                space.try_into().unwrap(),
+                &program_id,
+            ),
+            // Fund the mint with extra rent for metadata
+            system_instruction::transfer(
+                &context.payer.pubkey(),
+                &reprint_mint_keypair.pubkey(),
+                token_metadata_rent_lamports,
+            ),
+            initialize_reprint_ix,
+        ],
+        Some(&context.payer.pubkey()),
+        &[
+            &context.payer,
+            &reprint_keypair,
+            &reprint_mint_authority_keypair,
+        ], /* Missing original print mint
+            * authority */
+        context.last_blockhash,
+    );
+
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(2, InstructionError::MissingRequiredSignature,)
+    );
+}
+
+#[tokio::test]
+async fn fail_incorrect_authority() {
+    let meta = Some(Edition {
+        line: EditionLine::Original,
+        membership_level: MembershipLevel::Ultimate,
+    });
+
+    let TokenGroupTestContext {
+        context,
+        client,
+        payer,
+        token_program_id,
+        program_id,
+        mint_keypair,
+        mint_authority_keypair,
+        metadata_keypair,
+        group_keypair: original_print_keypair,
+        group: original_print,
+        group_token_metadata: original_print_token_metadata,
+        ..
+    } = setup_program_test::<Edition>("My Cool Edition", meta).await;
+
+    // In this test (similar to `setup_group_test`):
+    // - The metadata is stored in the mint (Token-2022)
+    // - The reprint is in a separate account
+    // - The reprint's _metadata_ update authority is the mint authority
+    // - The mint is an NFT (0 decimals)
+    let reprint_keypair = Keypair::new();
+    let reprint_mint_keypair = Keypair::new();
+    let reprint_mint_authority_keypair = Keypair::new();
+    let reprint_metadata_keypair = reprint_mint_keypair.insecure_clone();
+    let reprint_metadata_update_authority_keypair = reprint_metadata_keypair.insecure_clone();
+    let decimals = 0;
+    let reprint = Member {
+        group: original_print_keypair.pubkey(),
+        member_number: 1,
+    };
+
+    // Set up a mint for the reprint
+    setup_mint_with_metadata_pointer(
+        &Token::new(
+            client.clone(),
+            &token_program_id,
+            &reprint_mint_keypair.pubkey(),
+            Some(decimals),
+            payer.clone(),
+        ),
+        &reprint_mint_keypair,
+        &reprint_mint_authority_keypair,
+        &reprint_metadata_keypair.pubkey(),
+        &reprint_metadata_update_authority_keypair.pubkey(),
+    )
+    .await;
+
+    let mut context = context.lock().await;
+
+    let group_extra_metas = [AccountMeta::new_readonly(metadata_keypair.pubkey(), false)];
+    let member_extra_metas = [
+        AccountMeta::new(reprint_metadata_keypair.pubkey(), false),
+        AccountMeta::new_readonly(reprint_metadata_update_authority_keypair.pubkey(), false),
+        AccountMeta::new_readonly(metadata_keypair.pubkey(), false), // Group metadata
+        AccountMeta::new_readonly(token_program_id, false),          // Token metadata program
+    ];
+
+    setup_group::<Edition>(
+        &mut context,
+        &program_id,
+        &original_print_keypair,
+        &mint_keypair.pubkey(),
+        &mint_authority_keypair,
+        &original_print,
+        &group_extra_metas,
+    )
+    .await;
+
+    let rent = context.banks_client.get_rent().await.unwrap();
+
+    let token_metadata_space = original_print_token_metadata.tlv_size_of().unwrap();
+    let token_metadata_rent_lamports = rent.minimum_balance(token_metadata_space);
+
+    let space = TlvStateBorrowed::get_base_len() + get_instance_packed_len(&reprint).unwrap();
+    let rent_lamports = rent.minimum_balance(space);
+
+    // Fail incorrect reprint mint authority
+
+    let mut initialize_reprint_ix = initialize_member::<Edition>(
+        &program_id,
+        &original_print_keypair.pubkey(),
+        &mint_keypair.pubkey(),
+        &mint_authority_keypair.pubkey(),
+        &reprint_keypair.pubkey(),
+        &reprint_mint_keypair.pubkey(),
+        &mint_authority_keypair.pubkey(), // NOT the reprint mint authority
+        reprint.member_number,
+        &member_extra_metas,
+    );
+    initialize_reprint_ix.accounts[5].is_signer = false;
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &reprint_keypair.pubkey(),
+                rent_lamports,
+                space.try_into().unwrap(),
+                &program_id,
+            ),
+            // Fund the mint with extra rent for metadata
+            system_instruction::transfer(
+                &context.payer.pubkey(),
+                &reprint_mint_keypair.pubkey(),
+                token_metadata_rent_lamports,
+            ),
+            initialize_reprint_ix,
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &reprint_keypair, &mint_authority_keypair],
+        context.last_blockhash,
+    );
+
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(
+            2,
+            InstructionError::Custom(TokenGroupError::IncorrectAuthority as u32)
+        )
+    );
+
+    // Fail missing original print mint authority
+
+    let mut initialize_reprint_ix = initialize_member::<Edition>(
+        &program_id,
+        &original_print_keypair.pubkey(),
+        &mint_keypair.pubkey(),
+        &reprint_mint_authority_keypair.pubkey(), // NOT the original print mint authority
+        &reprint_keypair.pubkey(),
+        &reprint_mint_keypair.pubkey(),
+        &reprint_mint_authority_keypair.pubkey(),
+        reprint.member_number,
+        &member_extra_metas,
+    );
+    initialize_reprint_ix.accounts[2].is_signer = false;
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &reprint_keypair.pubkey(),
+                rent_lamports,
+                space.try_into().unwrap(),
+                &program_id,
+            ),
+            // Fund the mint with extra rent for metadata
+            system_instruction::transfer(
+                &context.payer.pubkey(),
+                &reprint_mint_keypair.pubkey(),
+                token_metadata_rent_lamports,
+            ),
+            initialize_reprint_ix,
+        ],
+        Some(&context.payer.pubkey()),
+        &[
+            &context.payer,
+            &reprint_keypair,
+            &reprint_mint_authority_keypair,
+        ],
+        context.last_blockhash,
+    );
+
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(
+            2,
+            InstructionError::Custom(TokenGroupError::IncorrectAuthority as u32)
+        )
+    );
+
+    // Fail missing extra metas
+
+    let initialize_reprint_ix = initialize_member::<Edition>(
+        &program_id,
+        &original_print_keypair.pubkey(),
+        &mint_keypair.pubkey(),
+        &mint_authority_keypair.pubkey(),
+        &reprint_keypair.pubkey(),
+        &reprint_mint_keypair.pubkey(),
+        &reprint_mint_authority_keypair.pubkey(),
+        reprint.member_number,
+        &[], // Missing extra metas
+    );
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &reprint_keypair.pubkey(),
+                rent_lamports,
+                space.try_into().unwrap(),
+                &program_id,
+            ),
+            // Fund the mint with extra rent for metadata
+            system_instruction::transfer(
+                &context.payer.pubkey(),
+                &reprint_mint_keypair.pubkey(),
+                token_metadata_rent_lamports,
+            ),
+            initialize_reprint_ix,
+        ],
+        Some(&context.payer.pubkey()),
+        &[
+            &context.payer,
+            &reprint_keypair,
+            &mint_authority_keypair,
+            &reprint_mint_authority_keypair,
+        ],
+        context.last_blockhash,
+    );
+
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(2, InstructionError::NotEnoughAccountKeys)
+    );
+}

--- a/token-group/example/tests/edition_update_authority.rs
+++ b/token-group/example/tests/edition_update_authority.rs
@@ -1,0 +1,219 @@
+#![cfg(feature = "test-sbf")]
+
+use solana_program::instruction::AccountMeta;
+
+mod program_test;
+use {
+    program_test::{setup_group, setup_program_test, TokenGroupTestContext},
+    solana_program_test::tokio,
+    solana_sdk::{
+        instruction::InstructionError,
+        pubkey::Pubkey,
+        signature::Signer,
+        signer::keypair::Keypair,
+        transaction::{Transaction, TransactionError},
+    },
+    spl_token_group_example::state::{Edition, EditionLine, MembershipLevel},
+    spl_token_group_interface::{
+        error::TokenGroupError, instruction::update_group_authority, state::Group,
+    },
+    spl_type_length_value::state::{TlvState, TlvStateBorrowed},
+};
+
+#[tokio::test]
+async fn success_update_edition_authority() {
+    let meta = Some(Edition {
+        line: EditionLine::Original,
+        membership_level: MembershipLevel::Ultimate,
+    });
+
+    let TokenGroupTestContext {
+        context,
+        payer,
+        program_id,
+        mint_keypair,
+        mint_authority_keypair,
+        metadata_keypair,
+        group_keypair: original_print_keypair,
+        group_update_authority_keypair: original_print_update_authority_keypair,
+        group: original_print,
+        ..
+    } = setup_program_test::<Edition>("My Cool Edition", meta).await;
+
+    let mut context = context.lock().await;
+
+    let extra_metas = [AccountMeta::new_readonly(metadata_keypair.pubkey(), false)];
+
+    // Hit our program to initialize the original print
+    setup_group::<Edition>(
+        &mut context,
+        &program_id,
+        &original_print_keypair,
+        &mint_keypair.pubkey(),
+        &mint_authority_keypair,
+        &original_print,
+        &extra_metas,
+    )
+    .await;
+
+    let new_authority_keypair = Keypair::new();
+    let new_authority_pubkey = new_authority_keypair.pubkey();
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[update_group_authority::<Edition>(
+            &program_id,
+            &original_print_keypair.pubkey(),
+            &original_print_update_authority_keypair.pubkey(),
+            Some(new_authority_pubkey),
+        )],
+        Some(&payer.pubkey()),
+        &[&payer, &original_print_update_authority_keypair],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+
+    let fetched_original_print_account = context
+        .banks_client
+        .get_account(original_print_keypair.pubkey())
+        .await
+        .unwrap()
+        .unwrap();
+    let fetched_meta = TlvStateBorrowed::unpack(&fetched_original_print_account.data).unwrap();
+    let fetched_original_print = fetched_meta
+        .get_first_variable_len_value::<Group<Edition>>()
+        .unwrap();
+    assert_eq!(
+        Option::<Pubkey>::from(fetched_original_print.update_authority),
+        Some(new_authority_pubkey),
+    );
+
+    // Can change to `None`
+
+    let second_new_authority = None;
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[update_group_authority::<Edition>(
+            &program_id,
+            &original_print_keypair.pubkey(),
+            &new_authority_pubkey,
+            second_new_authority,
+        )],
+        Some(&payer.pubkey()),
+        &[&payer, &new_authority_keypair],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+
+    let fetched_original_print_account = context
+        .banks_client
+        .get_account(original_print_keypair.pubkey())
+        .await
+        .unwrap()
+        .unwrap();
+    let fetched_meta = TlvStateBorrowed::unpack(&fetched_original_print_account.data).unwrap();
+    let fetched_original_print = fetched_meta
+        .get_first_variable_len_value::<Group<Edition>>()
+        .unwrap();
+    assert_eq!(
+        Option::<Pubkey>::from(fetched_original_print.update_authority),
+        second_new_authority
+    );
+}
+
+#[tokio::test]
+async fn fail_authority_checks() {
+    let meta = Some(Edition {
+        line: EditionLine::Original,
+        membership_level: MembershipLevel::Ultimate,
+    });
+
+    let TokenGroupTestContext {
+        context,
+        program_id,
+        mint_keypair,
+        mint_authority_keypair,
+        metadata_keypair,
+        group_keypair: original_print_keypair,
+        group_update_authority_keypair: original_print_update_authority_keypair,
+        group: original_print,
+        ..
+    } = setup_program_test::<Edition>("My Cool Edition", meta).await;
+
+    let mut context = context.lock().await;
+
+    let extra_metas = [AccountMeta::new_readonly(metadata_keypair.pubkey(), false)];
+
+    // Hit our program to initialize the original print
+    setup_group::<Edition>(
+        &mut context,
+        &program_id,
+        &original_print_keypair,
+        &mint_keypair.pubkey(),
+        &mint_authority_keypair,
+        &original_print,
+        &extra_metas,
+    )
+    .await;
+
+    let new_authority_keypair = Keypair::new();
+    let new_authority_pubkey = new_authority_keypair.pubkey();
+
+    // No signature
+    let mut update_authority_ix = update_group_authority::<Edition>(
+        &program_id,
+        &original_print_keypair.pubkey(),
+        &original_print_update_authority_keypair.pubkey(),
+        Some(new_authority_pubkey),
+    );
+    update_authority_ix.accounts[1].is_signer = false;
+    let transaction = Transaction::new_signed_with_payer(
+        &[update_authority_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature,)
+    );
+
+    // Wrong authority
+    let transaction = Transaction::new_signed_with_payer(
+        &[update_group_authority::<Edition>(
+            &program_id,
+            &original_print_keypair.pubkey(),
+            &original_print_keypair.pubkey(),
+            Some(new_authority_pubkey),
+        )],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &original_print_keypair],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(TokenGroupError::IncorrectAuthority as u32),
+        )
+    );
+}

--- a/token-group/example/tests/edition_update_max_size.rs
+++ b/token-group/example/tests/edition_update_max_size.rs
@@ -1,0 +1,176 @@
+#![cfg(feature = "test-sbf")]
+
+use solana_program::instruction::AccountMeta;
+
+mod program_test;
+use {
+    program_test::{setup_group, setup_program_test, TokenGroupTestContext},
+    solana_program_test::tokio,
+    solana_sdk::{
+        instruction::InstructionError,
+        signer::Signer,
+        transaction::{Transaction, TransactionError},
+    },
+    spl_token_group_example::state::{Edition, EditionLine, MembershipLevel},
+    spl_token_group_interface::{
+        error::TokenGroupError, instruction::update_group_max_size, state::Group,
+    },
+    spl_type_length_value::state::{TlvState, TlvStateBorrowed},
+};
+
+#[tokio::test]
+async fn success_update_edition_max_size() {
+    let meta = Some(Edition {
+        line: EditionLine::Original,
+        membership_level: MembershipLevel::Ultimate,
+    });
+
+    let TokenGroupTestContext {
+        context,
+        payer,
+        program_id,
+        mint_keypair,
+        mint_authority_keypair,
+        metadata_keypair,
+        group_keypair: original_print_keypair,
+        group_update_authority_keypair: original_print_update_authority_keypair,
+        group: original_print,
+        ..
+    } = setup_program_test::<Edition>("My Cool Edition", meta).await;
+
+    let mut context = context.lock().await;
+
+    let extra_metas = [AccountMeta::new_readonly(metadata_keypair.pubkey(), false)];
+
+    // Hit our program to initialize the original print
+    setup_group::<Edition>(
+        &mut context,
+        &program_id,
+        &original_print_keypair,
+        &mint_keypair.pubkey(),
+        &mint_authority_keypair,
+        &original_print,
+        &extra_metas,
+    )
+    .await;
+
+    let new_max_size = Some(200);
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[update_group_max_size::<Edition>(
+            &program_id,
+            &original_print_keypair.pubkey(),
+            &original_print_update_authority_keypair.pubkey(),
+            new_max_size,
+        )],
+        Some(&payer.pubkey()),
+        &[&payer, &original_print_update_authority_keypair],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+
+    let fetched_original_print_account = context
+        .banks_client
+        .get_account(original_print_keypair.pubkey())
+        .await
+        .unwrap()
+        .unwrap();
+    let fetched_meta = TlvStateBorrowed::unpack(&fetched_original_print_account.data).unwrap();
+    let fetched_original_print_data = fetched_meta
+        .get_first_variable_len_value::<Group<Edition>>()
+        .unwrap();
+    assert_eq!(fetched_original_print_data.max_size, new_max_size);
+}
+
+#[tokio::test]
+async fn fail_authority_checks() {
+    let meta = Some(Edition {
+        line: EditionLine::Original,
+        membership_level: MembershipLevel::Ultimate,
+    });
+
+    let TokenGroupTestContext {
+        context,
+        program_id,
+        mint_keypair,
+        mint_authority_keypair,
+        metadata_keypair,
+        group_keypair: original_print_keypair,
+        group_update_authority_keypair: original_print_update_authority_keypair,
+        group: original_print,
+        ..
+    } = setup_program_test::<Edition>("My Cool Edition", meta).await;
+
+    let mut context = context.lock().await;
+
+    let extra_metas = [AccountMeta::new_readonly(metadata_keypair.pubkey(), false)];
+
+    // Hit our program to initialize the original print
+    setup_group::<Edition>(
+        &mut context,
+        &program_id,
+        &original_print_keypair,
+        &mint_keypair.pubkey(),
+        &mint_authority_keypair,
+        &original_print,
+        &extra_metas,
+    )
+    .await;
+
+    let new_max_size = Some(200);
+
+    // No signature
+    let mut update_size_ix = update_group_max_size::<Edition>(
+        &program_id,
+        &original_print_keypair.pubkey(),
+        &original_print_update_authority_keypair.pubkey(),
+        new_max_size,
+    );
+    update_size_ix.accounts[1].is_signer = false;
+    let transaction = Transaction::new_signed_with_payer(
+        &[update_size_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature,)
+    );
+
+    // Wrong authority
+    let transaction = Transaction::new_signed_with_payer(
+        &[update_group_max_size::<Edition>(
+            &program_id,
+            &original_print_keypair.pubkey(),
+            &original_print_keypair.pubkey(),
+            new_max_size,
+        )],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &original_print_keypair],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(TokenGroupError::IncorrectAuthority as u32),
+        )
+    );
+}

--- a/token-group/example/tests/emit.rs
+++ b/token-group/example/tests/emit.rs
@@ -1,0 +1,341 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+use {
+    borsh::{BorshDeserialize, BorshSerialize},
+    program_test::{
+        setup_group, setup_member, setup_member_with_metadata_rent, setup_mint_and_metadata,
+        setup_mint_with_metadata_pointer, setup_program_test, TokenGroupTestContext,
+    },
+    solana_program_test::{tokio, ProgramTestContext},
+    solana_sdk::{
+        borsh::try_from_slice_unchecked, instruction::AccountMeta, program::MAX_RETURN_DATA,
+        pubkey::Pubkey, signature::Signer, signer::keypair::Keypair, transaction::Transaction,
+    },
+    spl_token_client::token::Token,
+    spl_token_group_example::state::{Collection, Edition, EditionLine, MembershipLevel},
+    spl_token_group_interface::{
+        instruction::{emit, get_emit_slice, ItemType},
+        state::{Group, Member},
+    },
+    spl_token_metadata_interface::state::TokenMetadata,
+    test_case::test_case,
+};
+
+#[allow(clippy::too_many_arguments)]
+async fn check_emit<V: BorshDeserialize + BorshSerialize + std::fmt::Debug + PartialEq>(
+    context: &mut ProgramTestContext,
+    print_buffer: Vec<u8>,
+    print_pubkey: &Pubkey,
+    start: Option<u64>,
+    end: Option<u64>,
+    item_type: ItemType,
+    program_id: &Pubkey,
+    payer: &Keypair,
+    check_print_data: V,
+) {
+    let transaction = Transaction::new_signed_with_payer(
+        &[emit::<Collection>(
+            program_id,
+            print_pubkey,
+            start,
+            end,
+            item_type,
+        )],
+        Some(&payer.pubkey()),
+        &[payer],
+        context.last_blockhash,
+    );
+    let simulation = context
+        .banks_client
+        .simulate_transaction(transaction)
+        .await
+        .unwrap();
+
+    if let Some(check_buffer) = get_emit_slice(&print_buffer, start, end) {
+        if !check_buffer.is_empty() {
+            // pad the data if necessary
+            let mut return_data = vec![0; MAX_RETURN_DATA];
+            let simulation_return_data =
+                simulation.simulation_details.unwrap().return_data.unwrap();
+            assert_eq!(simulation_return_data.program_id, *program_id);
+            return_data[..simulation_return_data.data.len()]
+                .copy_from_slice(&simulation_return_data.data);
+
+            assert_eq!(*check_buffer, return_data[..check_buffer.len()]);
+            // we're sure that we're getting the full data, so also compare the deserialized
+            // type
+            if start.is_none() && end.is_none() {
+                let emitted_token_collection = try_from_slice_unchecked::<V>(&return_data).unwrap();
+                assert_eq!(check_print_data, emitted_token_collection);
+            }
+        } else {
+            assert!(simulation.simulation_details.unwrap().return_data.is_none());
+        }
+    } else {
+        assert!(simulation.simulation_details.unwrap().return_data.is_none());
+    }
+}
+
+#[test_case(Some(40), Some(40) ; "zero bytes")]
+#[test_case(Some(40), Some(41) ; "one byte")]
+#[test_case(Some(1_000_000), Some(1_000_001) ; "too far")]
+#[test_case(Some(50), Some(49) ; "wrong way")]
+#[test_case(Some(50), None ; "truncate start")]
+#[test_case(None, Some(50) ; "truncate end")]
+#[test_case(None, None ; "full data")]
+#[tokio::test]
+async fn success_emit_collection(start: Option<u64>, end: Option<u64>) {
+    let collection_state = Collection {
+        creation_date: "August 15".to_string(),
+    };
+
+    let TokenGroupTestContext {
+        context,
+        client,
+        payer,
+        token_program_id,
+        program_id,
+        mint_keypair,
+        mint_authority_keypair,
+        group_keypair: collection_keypair,
+        group: mut collection,
+        ..
+    } = setup_program_test::<Collection>("My Cool Collection", Some(collection_state)).await;
+
+    // In this test (similar to `setup_collection_test`):
+    // - The metadata is stored in the mint (Token-2022)
+    // - The member is in a separate account
+    // - The member's _metadata_ update authority is the mint authority
+    // - The _member_ update authority is also the mint authority
+    // - The mint is an NFT (0 decimals)
+    let member_keypair = Keypair::new();
+    let member_mint_keypair = Keypair::new();
+    let member_mint_authority_keypair = Keypair::new();
+    let member_metadata_keypair = member_mint_keypair.insecure_clone();
+    let member_metadata_update_authority_keypair = member_metadata_keypair.insecure_clone();
+    let member_update_authority_keypair = member_metadata_keypair.insecure_clone();
+    let decimals = 0;
+    let member = Member {
+        group: collection_keypair.pubkey(),
+        member_number: 1,
+    };
+
+    // Size will be 1 after creation of a member
+    collection.size = 1;
+
+    // Set up a mint and metadata for the member
+    setup_mint_and_metadata(
+        &Token::new(
+            client.clone(),
+            &token_program_id,
+            &member_mint_keypair.pubkey(),
+            Some(decimals),
+            payer.clone(),
+        ),
+        &member_mint_keypair,
+        &member_mint_authority_keypair,
+        &member_metadata_keypair.pubkey(),
+        &member_metadata_update_authority_keypair.pubkey(),
+        &TokenMetadata {
+            name: "I'm a Member!".to_string(),
+            symbol: "MEM".to_string(),
+            uri: "member.com".to_string(),
+            update_authority: Some(member_update_authority_keypair.pubkey())
+                .try_into()
+                .unwrap(),
+            mint: member_mint_keypair.pubkey(),
+            ..Default::default()
+        },
+        payer.clone(),
+    )
+    .await;
+
+    let mut context = context.lock().await;
+
+    setup_group::<Collection>(
+        &mut context,
+        &program_id,
+        &collection_keypair,
+        &mint_keypair.pubkey(),
+        &mint_authority_keypair,
+        &collection,
+        &[], // No extra account metas
+    )
+    .await;
+
+    setup_member::<Collection>(
+        &mut context,
+        &program_id,
+        &collection_keypair.pubkey(),
+        &mint_keypair.pubkey(),
+        &mint_authority_keypair,
+        &member_keypair,
+        &member_mint_keypair.pubkey(),
+        &member_mint_authority_keypair,
+        &member,
+        &[], // No extra account metas
+    )
+    .await;
+
+    // Group
+    let collection_buffer = collection.try_to_vec().unwrap();
+    check_emit::<Group<Collection>>(
+        &mut context,
+        collection_buffer,
+        &collection_keypair.pubkey(),
+        start,
+        end,
+        ItemType::Group,
+        &program_id,
+        &payer,
+        collection,
+    )
+    .await;
+
+    // Member
+    let member_buffer = member.try_to_vec().unwrap();
+    check_emit::<Member>(
+        &mut context,
+        member_buffer,
+        &member_keypair.pubkey(),
+        start,
+        end,
+        ItemType::Member,
+        &program_id,
+        &payer,
+        member,
+    )
+    .await;
+}
+
+#[test_case(Some(20), Some(20) ; "zero bytes")]
+#[test_case(Some(20), Some(21) ; "one byte")]
+#[test_case(Some(1_000_000), Some(1_000_001) ; "too far")]
+#[test_case(Some(30), Some(29) ; "wrong way")]
+#[test_case(Some(30), None ; "truncate start")]
+#[test_case(None, Some(30) ; "truncate end")]
+#[test_case(None, None ; "full data")]
+#[tokio::test]
+async fn success_emit_edition(start: Option<u64>, end: Option<u64>) {
+    let meta = Some(Edition {
+        line: EditionLine::Original,
+        membership_level: MembershipLevel::Ultimate,
+    });
+
+    let TokenGroupTestContext {
+        context,
+        client,
+        payer,
+        token_program_id,
+        program_id,
+        mint_keypair,
+        mint_authority_keypair,
+        metadata_keypair,
+        group_keypair: original_print_keypair,
+        group: mut original_print,
+        group_token_metadata: original_print_token_metadata,
+        ..
+    } = setup_program_test::<Edition>("My Cool Edition", meta).await;
+
+    // In this test (similar to `setup_group_test`):
+    // - The metadata is stored in the mint (Token-2022)
+    // - The reprint is in a separate account
+    // - The reprint's _metadata_ update authority is the mint authority
+    // - The mint is an NFT (0 decimals)
+    let reprint_keypair = Keypair::new();
+    let reprint_mint_keypair = Keypair::new();
+    let reprint_mint_authority_keypair = Keypair::new();
+    let reprint_metadata_keypair = reprint_mint_keypair.insecure_clone();
+    let reprint_metadata_update_authority_keypair = reprint_metadata_keypair.insecure_clone();
+    let decimals = 0;
+    let reprint = Member {
+        group: original_print_keypair.pubkey(),
+        member_number: 1,
+    };
+
+    // Size will be 1 after creation of a reprint
+    original_print.size = 1;
+
+    // Set up a mint for the reprint
+    setup_mint_with_metadata_pointer(
+        &Token::new(
+            client.clone(),
+            &token_program_id,
+            &reprint_mint_keypair.pubkey(),
+            Some(decimals),
+            payer.clone(),
+        ),
+        &reprint_mint_keypair,
+        &reprint_mint_authority_keypair,
+        &reprint_metadata_keypair.pubkey(),
+        &reprint_metadata_update_authority_keypair.pubkey(),
+    )
+    .await;
+
+    let mut context = context.lock().await;
+
+    let group_extra_metas = [AccountMeta::new_readonly(metadata_keypair.pubkey(), false)];
+    let member_extra_metas = [
+        AccountMeta::new_readonly(reprint_metadata_keypair.pubkey(), false),
+        AccountMeta::new_readonly(reprint_metadata_update_authority_keypair.pubkey(), false),
+        AccountMeta::new_readonly(metadata_keypair.pubkey(), false), // Group metadata
+        AccountMeta::new_readonly(token_program_id, false),          // Token metadata program
+    ];
+
+    setup_group::<Edition>(
+        &mut context,
+        &program_id,
+        &original_print_keypair,
+        &mint_keypair.pubkey(),
+        &mint_authority_keypair,
+        &original_print,
+        &group_extra_metas,
+    )
+    .await;
+
+    setup_member_with_metadata_rent::<Edition>(
+        &mut context,
+        &program_id,
+        &original_print_keypair.pubkey(),
+        &mint_keypair.pubkey(),
+        &mint_authority_keypair,
+        &original_print_token_metadata,
+        &reprint_keypair,
+        &reprint_mint_keypair.pubkey(),
+        &reprint_mint_authority_keypair,
+        &reprint,
+        &member_extra_metas,
+    )
+    .await;
+
+    // Group
+    let original_print_buffer = original_print.try_to_vec().unwrap();
+    check_emit::<Group<Edition>>(
+        &mut context,
+        original_print_buffer,
+        &original_print_keypair.pubkey(),
+        start,
+        end,
+        ItemType::Group,
+        &program_id,
+        &payer,
+        original_print,
+    )
+    .await;
+
+    // Member
+    let reprint_buffer = reprint.try_to_vec().unwrap();
+    check_emit::<Member>(
+        &mut context,
+        reprint_buffer,
+        &reprint_keypair.pubkey(),
+        start,
+        end,
+        ItemType::Member,
+        &program_id,
+        &payer,
+        reprint,
+    )
+    .await;
+}

--- a/token-group/example/tests/program_test.rs
+++ b/token-group/example/tests/program_test.rs
@@ -1,0 +1,386 @@
+#![cfg(feature = "test-sbf")]
+#![allow(clippy::integer_arithmetic)]
+
+use {
+    solana_program_test::{processor, tokio::sync::Mutex, ProgramTest, ProgramTestContext},
+    solana_sdk::{
+        borsh::get_instance_packed_len, instruction::AccountMeta, pubkey::Pubkey,
+        signature::Signer, signer::keypair::Keypair, system_instruction, transaction::Transaction,
+    },
+    spl_token_client::{
+        client::{
+            ProgramBanksClient, ProgramBanksClientProcessTransaction, ProgramClient,
+            SendTransaction, SimulateTransaction,
+        },
+        token::{ExtensionInitializationParams, Token},
+    },
+    spl_token_group_interface::{
+        instruction::{initialize_group, initialize_member},
+        state::{Group, Member, SplTokenGroup},
+    },
+    spl_token_metadata_interface::state::TokenMetadata,
+    spl_type_length_value::state::{TlvState, TlvStateBorrowed},
+    std::sync::Arc,
+};
+
+pub struct TokenGroupTestContext<G>
+where
+    G: SplTokenGroup,
+{
+    pub context: Arc<Mutex<ProgramTestContext>>,
+    pub client: Arc<dyn ProgramClient<ProgramBanksClientProcessTransaction>>,
+    pub payer: Arc<Keypair>,
+    pub token_program_id: Pubkey,
+    pub program_id: Pubkey,
+    pub mint_keypair: Keypair,
+    pub mint_authority_keypair: Keypair,
+    pub metadata_keypair: Keypair,
+    pub metadata_update_authority_keypair: Keypair,
+    pub group_keypair: Keypair,
+    pub group_update_authority_keypair: Keypair,
+    pub group: Group<G>,
+    pub group_token_metadata: TokenMetadata,
+}
+
+/// Set up a program test
+pub async fn setup(
+    program_id: &Pubkey,
+) -> (
+    Arc<Mutex<ProgramTestContext>>,
+    Arc<dyn ProgramClient<ProgramBanksClientProcessTransaction>>,
+    Arc<Keypair>,
+) {
+    let mut program_test = ProgramTest::new(
+        "spl_token_group_example",
+        *program_id,
+        processor!(spl_token_group_example::processor::process),
+    );
+    program_test.prefer_bpf(false);
+    program_test.add_program(
+        "spl_token_2022",
+        spl_token_2022::id(),
+        processor!(spl_token_2022::processor::Processor::process),
+    );
+    let context = program_test.start_with_context().await;
+    let payer = Arc::new(context.payer.insecure_clone());
+    let context = Arc::new(Mutex::new(context));
+    let client: Arc<dyn ProgramClient<ProgramBanksClientProcessTransaction>> =
+        Arc::new(ProgramBanksClient::new_from_context(
+            Arc::clone(&context),
+            ProgramBanksClientProcessTransaction,
+        ));
+    (context, client, payer)
+}
+
+/// Set up a Token-2022 mint and metadata
+pub async fn setup_mint_with_metadata_pointer<T: SendTransaction + SimulateTransaction>(
+    token_client: &Token<T>,
+    mint_keypair: &Keypair,
+    mint_authority_keypair: &Keypair,
+    metadata_pubkey: &Pubkey,
+    metadata_update_authority_pubkey: &Pubkey,
+) {
+    token_client
+        .create_mint(
+            &mint_authority_keypair.pubkey(),
+            None,
+            vec![ExtensionInitializationParams::MetadataPointer {
+                authority: Some(*metadata_update_authority_pubkey),
+                metadata_address: Some(*metadata_pubkey),
+            }],
+            &[mint_keypair],
+        )
+        .await
+        .unwrap();
+}
+
+/// Set up a Token-2022 mint and metadata
+pub async fn setup_mint_and_metadata<T: SendTransaction + SimulateTransaction>(
+    token_client: &Token<T>,
+    mint_keypair: &Keypair,
+    mint_authority_keypair: &Keypair,
+    metadata_pubkey: &Pubkey,
+    metadata_update_authority_pubkey: &Pubkey,
+    token_metadata: &TokenMetadata,
+    payer: Arc<Keypair>,
+) {
+    setup_mint_with_metadata_pointer(
+        token_client,
+        mint_keypair,
+        mint_authority_keypair,
+        metadata_pubkey,
+        metadata_update_authority_pubkey,
+    )
+    .await;
+    token_client
+        .token_metadata_initialize_with_rent_transfer(
+            &payer.pubkey(),
+            metadata_update_authority_pubkey,
+            &mint_authority_keypair.pubkey(),
+            token_metadata.name.clone(),
+            token_metadata.symbol.clone(),
+            token_metadata.uri.clone(),
+            &[&payer, mint_authority_keypair],
+        )
+        .await
+        .unwrap();
+}
+
+pub async fn setup_group<G: SplTokenGroup>(
+    context: &mut ProgramTestContext,
+    program_id: &Pubkey,
+    group_keypair: &Keypair,
+    mint: &Pubkey,
+    mint_authority_keypair: &Keypair,
+    group: &Group<G>,
+    extra_account_metas: &[AccountMeta],
+) {
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let space = TlvStateBorrowed::get_base_len() + get_instance_packed_len(group).unwrap();
+    let rent_lamports = rent.minimum_balance(space);
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &group_keypair.pubkey(),
+                rent_lamports,
+                space.try_into().unwrap(),
+                program_id,
+            ),
+            initialize_group::<G>(
+                program_id,
+                &group_keypair.pubkey(),
+                mint,
+                &mint_authority_keypair.pubkey(),
+                Option::<Pubkey>::from(group.update_authority),
+                group.max_size,
+                &group.meta,
+                extra_account_metas,
+            ),
+        ],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, group_keypair, mint_authority_keypair],
+        context.last_blockhash,
+    );
+
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+}
+
+#[allow(clippy::too_many_arguments)]
+#[allow(dead_code)]
+pub async fn setup_member<G: SplTokenGroup>(
+    context: &mut ProgramTestContext,
+    group_program_id: &Pubkey,
+    group_pubkey: &Pubkey,
+    group_mint_pubkey: &Pubkey,
+    group_mint_authority_keypair: &Keypair,
+    member_keypair: &Keypair,
+    member_mint_pubkey: &Pubkey,
+    member_mint_authority_keypair: &Keypair,
+    member_data: &Member,
+    extra_account_metas: &[AccountMeta],
+) {
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let space = TlvStateBorrowed::get_base_len() + get_instance_packed_len(member_data).unwrap();
+    let rent_lamports = rent.minimum_balance(space);
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &member_keypair.pubkey(),
+                rent_lamports,
+                space.try_into().unwrap(),
+                group_program_id,
+            ),
+            initialize_member::<G>(
+                group_program_id,
+                group_pubkey,
+                group_mint_pubkey,
+                &group_mint_authority_keypair.pubkey(),
+                &member_keypair.pubkey(),
+                member_mint_pubkey,
+                &member_mint_authority_keypair.pubkey(),
+                member_data.member_number,
+                extra_account_metas,
+            ),
+        ],
+        Some(&context.payer.pubkey()),
+        &[
+            &context.payer,
+            member_keypair,
+            member_mint_authority_keypair,
+            group_mint_authority_keypair,
+        ],
+        context.last_blockhash,
+    );
+
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+}
+
+#[allow(clippy::too_many_arguments)]
+#[allow(dead_code)]
+pub async fn setup_member_with_metadata_rent<G: SplTokenGroup>(
+    context: &mut ProgramTestContext,
+    group_program_id: &Pubkey,
+    group_pubkey: &Pubkey,
+    group_mint_pubkey: &Pubkey,
+    group_mint_authority_keypair: &Keypair,
+    group_token_metadata: &TokenMetadata,
+    member_keypair: &Keypair,
+    member_mint_pubkey: &Pubkey,
+    member_mint_authority_keypair: &Keypair,
+    member_data: &Member,
+    extra_account_metas: &[AccountMeta],
+) {
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let member_space =
+        TlvStateBorrowed::get_base_len() + get_instance_packed_len(member_data).unwrap();
+    let member_rent_lamports = rent.minimum_balance(member_space);
+
+    let metadata_space = group_token_metadata.tlv_size_of().unwrap();
+    let metadata_rent_lamports = rent.minimum_balance(metadata_space);
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &context.payer.pubkey(),
+                &member_keypair.pubkey(),
+                member_rent_lamports,
+                member_space.try_into().unwrap(),
+                group_program_id,
+            ),
+            // Fund the mint for the metadata
+            system_instruction::transfer(
+                &context.payer.pubkey(),
+                member_mint_pubkey,
+                metadata_rent_lamports,
+            ),
+            initialize_member::<G>(
+                group_program_id,
+                group_pubkey,
+                group_mint_pubkey,
+                &group_mint_authority_keypair.pubkey(),
+                &member_keypair.pubkey(),
+                member_mint_pubkey,
+                &member_mint_authority_keypair.pubkey(),
+                member_data.member_number,
+                extra_account_metas,
+            ),
+        ],
+        Some(&context.payer.pubkey()),
+        &[
+            &context.payer,
+            member_keypair,
+            member_mint_authority_keypair,
+            group_mint_authority_keypair,
+        ],
+        context.last_blockhash,
+    );
+
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+}
+
+// pub async fn setup_extra_account_metas<I:
+// SplDiscriminate>(extra_account_metas: &[ExtraAccountMeta]) { todo!()
+// TODO: We want to use the instruction for creating extra metas, but in
+// our program we actually need to create this account once (if it doesn't)
+// exist, and write the validation data in. The key here is that the
+// validation data is going to be for more than one instruction.
+// }
+
+/// Setup a test for creating a token `Collection`:
+/// - Mint:         An NFT representing the `Collection` mint
+/// - Metadata:     A `TokenMetadata` representing the `Collection` metadata
+/// - Collection:   A `Collection` representing the `Collection` group
+pub async fn setup_program_test<G>(group_name: &str, meta: Option<G>) -> TokenGroupTestContext<G>
+where
+    G: SplTokenGroup,
+{
+    let program_id = Pubkey::new_unique();
+    let (context, client, payer) = setup(&program_id).await;
+
+    // We'll use Token-2022 for the mint and the metadata
+    let token_program_id = spl_token_2022::id();
+    let mint_authority_keypair = Keypair::new();
+    let mint_keypair = Keypair::new();
+
+    // In this test:
+    // - The metadata is stored in the mint (Token-2022)
+    // - The group is in a separate account
+    // - The _metadata_ update authority is the mint authority
+    // - The _group_ update authority is also the mint authority
+    // - The mint is an NFT (0 decimals)
+    let metadata_keypair = mint_keypair.insecure_clone();
+    let group_keypair = Keypair::new();
+    let metadata_update_authority_keypair = mint_authority_keypair.insecure_clone();
+    let group_update_authority_keypair = mint_authority_keypair.insecure_clone();
+    let decimals = 0;
+
+    let token_client = Token::new(
+        client.clone(),
+        &token_program_id,
+        &mint_keypair.pubkey(),
+        Some(decimals),
+        payer.clone(),
+    );
+
+    let group_token_metadata = TokenMetadata {
+        name: group_name.to_string(),
+        symbol: "GRP".to_string(),
+        uri: "cool.token.group.com".to_string(),
+        update_authority: Some(metadata_update_authority_keypair.pubkey())
+            .try_into()
+            .unwrap(),
+        mint: mint_keypair.pubkey(),
+        ..Default::default()
+    };
+
+    setup_mint_and_metadata(
+        &token_client,
+        &mint_keypair,
+        &mint_authority_keypair,
+        &metadata_keypair.pubkey(),
+        &metadata_update_authority_keypair.pubkey(),
+        &group_token_metadata,
+        payer.clone(),
+    )
+    .await;
+
+    let group = Group {
+        update_authority: Some(group_update_authority_keypair.pubkey())
+            .try_into()
+            .unwrap(),
+        max_size: Some(100),
+        size: 0,
+        meta,
+    };
+
+    TokenGroupTestContext {
+        context,
+        client,
+        payer,
+        token_program_id,
+        program_id,
+        mint_keypair,
+        mint_authority_keypair,
+        metadata_keypair,
+        metadata_update_authority_keypair,
+        group_keypair,
+        group_update_authority_keypair,
+        group,
+        group_token_metadata,
+    }
+}

--- a/token-group/interface/Cargo.toml
+++ b/token-group/interface/Cargo.toml
@@ -12,10 +12,10 @@ borsh = "0.10"
 solana-program = "1.16.3"
 spl-discriminator = { version = "0.1.0" , path = "../../libraries/discriminator" }
 spl-pod = { version = "0.1.0" , path = "../../libraries/pod", features = ["borsh"] }
-spl-program-error = { version = "0.2.0" , path = "../../libraries/program-error" }
-spl-tlv-account-resolution = { version = "0.2.0", path = "../../libraries/tlv-account-resolution" }
-spl-transfer-hook-interface = { version = "0.1.0", path = "../../token/transfer-hook-interface" }
-spl-type-length-value = { version = "0.2.0", path = "../../libraries/type-length-value", features = ["derive"] }
+spl-program-error = { version = "0.3.0" , path = "../../libraries/program-error" }
+spl-tlv-account-resolution = { version = "0.3.0", path = "../../libraries/tlv-account-resolution" }
+spl-transfer-hook-interface = { version = "0.2.0", path = "../../token/transfer-hook-interface" }
+spl-type-length-value = { version = "0.3.0", path = "../../libraries/type-length-value", features = ["derive"] }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/token-group/interface/Cargo.toml
+++ b/token-group/interface/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "spl-token-group-interface"
+version = "0.1.0"
+description = "Solana Program Library Token Group Interface"
+authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
+repository = "https://github.com/solana-labs/solana-program-library"
+license = "Apache-2.0"
+edition = "2021"
+
+[dependencies]
+borsh = "0.10"
+solana-program = "1.16.3"
+spl-discriminator = { version = "0.1.0" , path = "../../libraries/discriminator" }
+spl-pod = { version = "0.1.0" , path = "../../libraries/pod", features = ["borsh"] }
+spl-program-error = { version = "0.2.0" , path = "../../libraries/program-error" }
+spl-tlv-account-resolution = { version = "0.2.0", path = "../../libraries/tlv-account-resolution" }
+spl-transfer-hook-interface = { version = "0.1.0", path = "../../token/transfer-hook-interface" }
+spl-type-length-value = { version = "0.2.0", path = "../../libraries/type-length-value", features = ["derive"] }
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/token-group/interface/src/error.rs
+++ b/token-group/interface/src/error.rs
@@ -1,0 +1,26 @@
+//! Interface error types
+
+use spl_program_error::*;
+
+/// Errors that may be returned by the interface.
+#[spl_program_error]
+pub enum TokenGroupError {
+    /// Incorrect account provided
+    #[error("Incorrect account provided")]
+    IncorrectAccount,
+    /// Incorrect authority has signed the instruction
+    #[error("Incorrect authority has signed the instruction")]
+    IncorrectAuthority,
+    /// Size is greater than proposed max size
+    #[error("Size is greater than proposed max size")]
+    SizeExceedsNewMaxSize,
+    /// Size is greater than max size
+    #[error("Size is greater than max size")]
+    SizeExceedsMaxSize,
+    /// Group has no update authority
+    #[error("Group has no update authority")]
+    ImmutableGroup,
+    /// Incorrect group provided
+    #[error("Incorrect group provided")]
+    IncorrectGroup,
+}

--- a/token-group/interface/src/instruction.rs
+++ b/token-group/interface/src/instruction.rs
@@ -1,0 +1,495 @@
+//! Instruction types
+
+use {
+    crate::state::SplTokenGroup,
+    borsh::{BorshDeserialize, BorshSerialize},
+    solana_program::{
+        instruction::{AccountMeta, Instruction},
+        program_error::ProgramError,
+        pubkey::Pubkey,
+    },
+    spl_discriminator::{ArrayDiscriminator, SplDiscriminate},
+    spl_pod::optional_keys::OptionalNonZeroPubkey,
+};
+
+/// Get the slice corresponding to the given start and end range
+pub fn get_emit_slice(data: &[u8], start: Option<u64>, end: Option<u64>) -> Option<&[u8]> {
+    let start: usize = start.unwrap_or(0) as usize;
+    let end = end.map(|x| x as usize).unwrap_or(data.len());
+    data.get(start..end)
+}
+
+/// Instruction data for initializing a new `Group`
+#[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize, SplDiscriminate)]
+#[discriminator_hash_input("spl_token_group_interface:initialize_group")]
+pub struct InitializeGroup<G>
+where
+    G: SplTokenGroup,
+{
+    /// Update authority for the group
+    pub update_authority: OptionalNonZeroPubkey,
+    /// The maximum number of group members
+    pub max_size: Option<u64>,
+    /// Additional state
+    pub meta: Option<G>,
+}
+
+/// Instruction data for updating the max size of a `Group`
+#[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize, SplDiscriminate)]
+#[discriminator_hash_input("spl_token_group_interface:update_group_max_size")]
+pub struct UpdateGroupMaxSize {
+    /// New max size for the group
+    pub max_size: Option<u64>,
+}
+
+/// Instruction data for updating the authority of a `Group`
+#[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize, SplDiscriminate)]
+#[discriminator_hash_input("spl_token_group_interface:update_group_authority")]
+pub struct UpdateGroupAuthority {
+    /// New authority for the group, or unset if `None`
+    pub new_authority: OptionalNonZeroPubkey,
+}
+
+/// Instruction data for initializing a new `Member` of a `Group`
+#[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize, SplDiscriminate)]
+#[discriminator_hash_input("spl_token_group_interface:initialize_member")]
+pub struct InitializeMember {
+    /// The pubkey of the `Group`
+    pub group: Pubkey,
+    /// The member number
+    pub member_number: u64,
+}
+
+/// The type of item to emit
+#[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize)]
+pub enum ItemType {
+    /// Emit the `Group`
+    Group,
+    /// Emit the `Member`
+    Member,
+}
+
+/// Instruction data for `Emit`
+#[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize, SplDiscriminate)]
+#[discriminator_hash_input("spl_token_group_interface:emitter")]
+pub struct Emit {
+    /// Start of range of data to emit
+    pub start: Option<u64>,
+    /// End of range of data to emit
+    pub end: Option<u64>,
+    /// The type of item to emit
+    pub item_type: ItemType,
+}
+
+/// All instructions that must be implemented in the SPL Token Group Interface
+///
+/// Note: Any instruction can be extended using additional required accounts by
+/// using the `InitializeExtraAccountMetaList` instruction to write
+/// configurations for extra required accounts into validation data
+/// corresponding to an instruction's unique discriminator.
+#[derive(Clone, Debug, PartialEq)]
+pub enum TokenGroupInterfaceInstruction<G>
+where
+    G: SplTokenGroup,
+{
+    /// Initialize a new `Group`
+    ///
+    /// Assumes one has already initialized a mint for the
+    /// group.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[w]`  Group
+    ///   1. `[]`   Mint
+    ///   2. `[s]`  Mint authority
+    ///   3..3+M `[]` `M` additional accounts, written in validation account
+    /// data
+    InitializeGroup(InitializeGroup<G>),
+
+    /// Update the max size of a `Group`
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[w]`  Group
+    ///   1. `[s]`  Update authority
+    UpdateGroupMaxSize(UpdateGroupMaxSize),
+
+    /// Update the authority of a `Group`
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[w]`  Group
+    ///   1. `[s]`  Current update authority
+    UpdateGroupAuthority(UpdateGroupAuthority),
+
+    /// Initialize a new `Member` of a `Group`
+    ///
+    /// Assumes the `Group` has already been initialized,
+    /// as well as the mint for the member.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[w]`  Member
+    ///   1. `[]`   Member Mint
+    ///   2. `[s]`  Member Mint authority
+    ///   3. `[w]`  Group
+    ///   4. `[]`   Group Mint
+    ///   5. `[s]`  Group Mint authority
+    ///   6..6+M `[]` `M` additional accounts, written in validation account
+    /// data
+    InitializeMember(InitializeMember),
+
+    /// Emits the group or member as return data
+    ///
+    /// The format of the data emitted follows either the `Group` or
+    /// `Member` struct,  but it's possible that the account data is stored in
+    /// another format by the program.
+    ///
+    /// With this instruction, a program that implements the token-groups
+    /// interface can return `Group` or `Member` without adhering to the
+    /// specific byte layout of the structs in any accounts.
+    ///
+    /// The dictation of which data to emit is determined by the `ItemType`
+    /// enum argument to the instruction data.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[]`   Group _or_ Member account
+    Emit(Emit),
+}
+impl<G> TokenGroupInterfaceInstruction<G>
+where
+    G: SplTokenGroup,
+{
+    /// Unpacks a byte buffer into a `TokenGroupInterfaceInstruction`
+    pub fn unpack(input: &[u8]) -> Result<Self, ProgramError> {
+        // Should have at least _two_ leading discriminators
+        if input.len() < ArrayDiscriminator::LENGTH * 2 {
+            return Err(ProgramError::InvalidInstructionData);
+        }
+        let (discriminator, rest) = {
+            let (discriminators, rest) = input.split_at(ArrayDiscriminator::LENGTH * 2);
+            let (generic_discriminator, instruction_discriminator) =
+                discriminators.split_at(ArrayDiscriminator::LENGTH);
+            if !generic_discriminator.eq(G::SPL_DISCRIMINATOR_SLICE) {
+                return Err(ProgramError::InvalidInstructionData);
+            }
+            (instruction_discriminator, rest)
+        };
+        Ok(match discriminator {
+            InitializeGroup::<G>::SPL_DISCRIMINATOR_SLICE => {
+                let data = InitializeGroup::try_from_slice(rest)?;
+                Self::InitializeGroup(data)
+            }
+            UpdateGroupMaxSize::SPL_DISCRIMINATOR_SLICE => {
+                let data = UpdateGroupMaxSize::try_from_slice(rest)?;
+                Self::UpdateGroupMaxSize(data)
+            }
+            UpdateGroupAuthority::SPL_DISCRIMINATOR_SLICE => {
+                let data = UpdateGroupAuthority::try_from_slice(rest)?;
+                Self::UpdateGroupAuthority(data)
+            }
+            InitializeMember::SPL_DISCRIMINATOR_SLICE => {
+                let data = InitializeMember::try_from_slice(rest)?;
+                Self::InitializeMember(data)
+            }
+            Emit::SPL_DISCRIMINATOR_SLICE => {
+                let data = Emit::try_from_slice(rest)?;
+                Self::Emit(data)
+            }
+            _ => return Err(ProgramError::InvalidInstructionData),
+        })
+    }
+
+    /// Packs a `TokenGroupInterfaceInstruction` into a byte buffer.
+    pub fn pack(&self) -> Vec<u8> {
+        let mut buf = vec![];
+        // The first discriminator is the generic discriminator
+        buf.extend_from_slice(G::SPL_DISCRIMINATOR_SLICE);
+        // The second discriminator is the instruction-specific discriminator
+        match self {
+            Self::InitializeGroup(data) => {
+                buf.extend_from_slice(InitializeGroup::<G>::SPL_DISCRIMINATOR_SLICE);
+                buf.append(&mut data.try_to_vec().unwrap());
+            }
+            Self::UpdateGroupMaxSize(data) => {
+                buf.extend_from_slice(UpdateGroupMaxSize::SPL_DISCRIMINATOR_SLICE);
+                buf.append(&mut data.try_to_vec().unwrap());
+            }
+            Self::UpdateGroupAuthority(data) => {
+                buf.extend_from_slice(UpdateGroupAuthority::SPL_DISCRIMINATOR_SLICE);
+                buf.append(&mut data.try_to_vec().unwrap());
+            }
+            Self::InitializeMember(data) => {
+                buf.extend_from_slice(InitializeMember::SPL_DISCRIMINATOR_SLICE);
+                buf.append(&mut data.try_to_vec().unwrap());
+            }
+            Self::Emit(data) => {
+                buf.extend_from_slice(Emit::SPL_DISCRIMINATOR_SLICE);
+                buf.append(&mut data.try_to_vec().unwrap());
+            }
+        };
+        buf
+    }
+
+    /// Peeks the instruction data to determine its generic implementation
+    pub fn peek(input: &[u8]) -> bool {
+        input[..8].eq(G::SPL_DISCRIMINATOR_SLICE)
+    }
+}
+
+/// Creates a `InitializeGroup` instruction
+#[allow(clippy::too_many_arguments)]
+pub fn initialize_group<G>(
+    program_id: &Pubkey,
+    group: &Pubkey,
+    mint: &Pubkey,
+    mint_authority: &Pubkey,
+    update_authority: Option<Pubkey>,
+    max_size: Option<u64>,
+    meta: &Option<G>,
+    extra_account_metas: &[AccountMeta],
+) -> Instruction
+where
+    G: SplTokenGroup,
+{
+    let update_authority = OptionalNonZeroPubkey::try_from(update_authority)
+        .expect("Failed to deserialize `Option<Pubkey>`");
+    let data = TokenGroupInterfaceInstruction::<G>::InitializeGroup(InitializeGroup {
+        update_authority,
+        max_size,
+        meta: meta.clone(),
+    })
+    .pack();
+    let mut accounts = vec![
+        AccountMeta::new(*group, false),
+        AccountMeta::new_readonly(*mint, false),
+        AccountMeta::new_readonly(*mint_authority, true),
+    ];
+    accounts.extend_from_slice(extra_account_metas);
+
+    Instruction {
+        program_id: *program_id,
+        accounts,
+        data,
+    }
+}
+
+/// Creates a `UpdateGroupMaxSize` instruction
+pub fn update_group_max_size<G>(
+    program_id: &Pubkey,
+    group: &Pubkey,
+    update_authority: &Pubkey,
+    max_size: Option<u64>,
+) -> Instruction
+where
+    G: SplTokenGroup,
+{
+    let data =
+        TokenGroupInterfaceInstruction::<G>::UpdateGroupMaxSize(UpdateGroupMaxSize { max_size })
+            .pack();
+    Instruction {
+        program_id: *program_id,
+        accounts: vec![
+            AccountMeta::new(*group, false),
+            AccountMeta::new_readonly(*update_authority, true),
+        ],
+        data,
+    }
+}
+
+/// Creates a `UpdateGroupAuthority` instruction
+pub fn update_group_authority<G>(
+    program_id: &Pubkey,
+    group: &Pubkey,
+    current_authority: &Pubkey,
+    new_authority: Option<Pubkey>,
+) -> Instruction
+where
+    G: SplTokenGroup,
+{
+    let new_authority = OptionalNonZeroPubkey::try_from(new_authority)
+        .expect("Failed to deserialize `Option<Pubkey>`");
+    let data = TokenGroupInterfaceInstruction::<G>::UpdateGroupAuthority(UpdateGroupAuthority {
+        new_authority,
+    })
+    .pack();
+    Instruction {
+        program_id: *program_id,
+        accounts: vec![
+            AccountMeta::new(*group, false),
+            AccountMeta::new_readonly(*current_authority, true),
+        ],
+        data,
+    }
+}
+
+/// Creates a `InitializeMember` instruction
+#[allow(clippy::too_many_arguments)]
+pub fn initialize_member<G>(
+    program_id: &Pubkey,
+    group: &Pubkey,
+    group_mint: &Pubkey,
+    group_mint_authority: &Pubkey,
+    member: &Pubkey,
+    member_mint: &Pubkey,
+    member_mint_authority: &Pubkey,
+    member_number: u64,
+    extra_account_metas: &[AccountMeta],
+) -> Instruction
+where
+    G: SplTokenGroup,
+{
+    let data = TokenGroupInterfaceInstruction::<G>::InitializeMember(InitializeMember {
+        group: *group,
+        member_number,
+    })
+    .pack();
+    let mut accounts = vec![
+        AccountMeta::new(*member, false),
+        AccountMeta::new_readonly(*member_mint, false),
+        AccountMeta::new_readonly(*member_mint_authority, true),
+        AccountMeta::new(*group, false),
+        AccountMeta::new_readonly(*group_mint, false),
+        AccountMeta::new_readonly(*group_mint_authority, true),
+    ];
+    accounts.extend_from_slice(extra_account_metas);
+
+    Instruction {
+        program_id: *program_id,
+        accounts,
+        data,
+    }
+}
+
+/// Creates an `Emit` instruction
+pub fn emit<G>(
+    program_id: &Pubkey,
+    item: &Pubkey,
+    start: Option<u64>,
+    end: Option<u64>,
+    item_type: ItemType,
+) -> Instruction
+where
+    G: SplTokenGroup,
+{
+    let data = TokenGroupInterfaceInstruction::<G>::Emit(Emit {
+        start,
+        end,
+        item_type,
+    })
+    .pack();
+    Instruction {
+        program_id: *program_id,
+        accounts: vec![AccountMeta::new_readonly(*item, false)],
+        data,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use {
+        super::*, crate::NAMESPACE, solana_program::hash,
+        spl_type_length_value::SplBorshVariableLenPack,
+    };
+
+    #[derive(
+        Clone,
+        Debug,
+        Default,
+        PartialEq,
+        BorshSerialize,
+        BorshDeserialize,
+        SplDiscriminate,
+        SplBorshVariableLenPack,
+    )]
+    #[discriminator_hash_input("mock_group")]
+    struct MockGroup;
+    impl SplTokenGroup for MockGroup {}
+
+    fn instruction_pack_unpack<I, G>(
+        instruction: TokenGroupInterfaceInstruction<G>,
+        discriminator: &[u8],
+        data: I,
+    ) where
+        I: core::fmt::Debug + PartialEq + BorshDeserialize + BorshSerialize + SplDiscriminate,
+        G: core::fmt::Debug + PartialEq + SplTokenGroup,
+    {
+        let mut expect = vec![];
+        expect.extend_from_slice(G::SPL_DISCRIMINATOR_SLICE);
+        expect.extend_from_slice(discriminator.as_ref());
+        expect.append(&mut data.try_to_vec().unwrap());
+        let packed = instruction.pack();
+        assert_eq!(packed, expect);
+        let unpacked = TokenGroupInterfaceInstruction::<G>::unpack(&expect).unwrap();
+        assert_eq!(unpacked, instruction);
+    }
+
+    #[test]
+    fn initialize_group_pack() {
+        let data = InitializeGroup {
+            update_authority: OptionalNonZeroPubkey::default(),
+            max_size: Some(100),
+            meta: None,
+        };
+        let instruction = TokenGroupInterfaceInstruction::InitializeGroup(data.clone());
+        let preimage = hash::hashv(&[format!("{NAMESPACE}:initialize_group").as_bytes()]);
+        let discriminator = &preimage.as_ref()[..ArrayDiscriminator::LENGTH];
+        instruction_pack_unpack::<InitializeGroup<MockGroup>, MockGroup>(
+            instruction,
+            discriminator,
+            data,
+        );
+    }
+
+    #[test]
+    fn update_group_max_size_pack() {
+        let data = UpdateGroupMaxSize {
+            max_size: Some(200),
+        };
+        let instruction = TokenGroupInterfaceInstruction::UpdateGroupMaxSize(data.clone());
+        let preimage = hash::hashv(&[format!("{NAMESPACE}:update_group_max_size").as_bytes()]);
+        let discriminator = &preimage.as_ref()[..ArrayDiscriminator::LENGTH];
+        instruction_pack_unpack::<UpdateGroupMaxSize, MockGroup>(instruction, discriminator, data);
+    }
+
+    #[test]
+    fn update_authority_pack() {
+        let data = UpdateGroupAuthority {
+            new_authority: OptionalNonZeroPubkey::default(),
+        };
+        let instruction = TokenGroupInterfaceInstruction::UpdateGroupAuthority(data.clone());
+        let preimage = hash::hashv(&[format!("{NAMESPACE}:update_group_authority").as_bytes()]);
+        let discriminator = &preimage.as_ref()[..ArrayDiscriminator::LENGTH];
+        instruction_pack_unpack::<UpdateGroupAuthority, MockGroup>(
+            instruction,
+            discriminator,
+            data,
+        );
+    }
+
+    #[test]
+    fn initialize_member_pack() {
+        let data = InitializeMember {
+            group: Pubkey::new_unique(),
+            member_number: 100,
+        };
+        let instruction = TokenGroupInterfaceInstruction::InitializeMember(data.clone());
+        let preimage = hash::hashv(&[format!("{NAMESPACE}:initialize_member").as_bytes()]);
+        let discriminator = &preimage.as_ref()[..ArrayDiscriminator::LENGTH];
+        instruction_pack_unpack::<InitializeMember, MockGroup>(instruction, discriminator, data);
+    }
+
+    #[test]
+    fn emit_pack() {
+        let data = Emit {
+            start: Some(100),
+            end: Some(200),
+            item_type: ItemType::Group,
+        };
+        let instruction = TokenGroupInterfaceInstruction::Emit(data.clone());
+        let preimage = hash::hashv(&[format!("{NAMESPACE}:emitter").as_bytes()]);
+        let discriminator = &preimage.as_ref()[..ArrayDiscriminator::LENGTH];
+        instruction_pack_unpack::<Emit, MockGroup>(instruction, discriminator, data);
+    }
+}

--- a/token-group/interface/src/lib.rs
+++ b/token-group/interface/src/lib.rs
@@ -1,0 +1,12 @@
+//! Crate defining the SPL Token Group Interface
+
+#![allow(clippy::integer_arithmetic)]
+#![deny(missing_docs)]
+#![cfg_attr(not(test), forbid(unsafe_code))]
+
+pub mod error;
+pub mod instruction;
+pub mod state;
+
+/// Namespace for all programs implementing spl-group
+pub const NAMESPACE: &str = "spl_token_group_interface";

--- a/token-group/interface/src/state.rs
+++ b/token-group/interface/src/state.rs
@@ -1,0 +1,303 @@
+//! Interface state types
+
+use {
+    crate::error::TokenGroupError,
+    borsh::{BorshDeserialize, BorshSerialize},
+    solana_program::{program_error::ProgramError, pubkey::Pubkey},
+    spl_discriminator::SplDiscriminate,
+    spl_pod::{error::PodSliceError, optional_keys::OptionalNonZeroPubkey},
+    spl_type_length_value::{variable_len_pack::VariableLenPack, SplBorshVariableLenPack},
+};
+
+/// Trait defining a `Group` context
+pub trait SplTokenGroup:
+    BorshDeserialize + BorshSerialize + Clone + SplDiscriminate + VariableLenPack
+{
+}
+
+/// Data struct for a `Group`
+#[derive(
+    BorshDeserialize,
+    BorshSerialize,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    SplBorshVariableLenPack,
+    SplDiscriminate,
+)]
+#[discriminator_hash_input("spl_token_group_interface:group")]
+pub struct Group<G>
+where
+    G: SplTokenGroup,
+{
+    /// The authority that can sign to update the group
+    pub update_authority: OptionalNonZeroPubkey,
+    /// The current number of group members
+    pub size: u64,
+    /// The maximum number of group members
+    pub max_size: Option<u64>,
+    /// Additional state
+    pub meta: Option<G>,
+}
+
+impl<G> Group<G>
+where
+    G: SplTokenGroup,
+{
+    /// Creates a new `Group` state
+    pub fn new(
+        update_authority: OptionalNonZeroPubkey,
+        max_size: Option<u64>,
+        meta: Option<G>,
+    ) -> Self {
+        Self {
+            update_authority,
+            size: 0,
+            max_size,
+            meta,
+        }
+    }
+
+    /// Updates the max size for a group
+    pub fn update_max_size(&mut self, max_size: Option<u64>) -> Result<(), ProgramError> {
+        // The new max size cannot be less than the current size
+        if let Some(new_max_size) = max_size {
+            if new_max_size < self.size {
+                return Err(TokenGroupError::SizeExceedsNewMaxSize.into());
+            }
+        }
+        self.max_size = max_size;
+        Ok(())
+    }
+
+    /// Increment the size for a group, returning the new size
+    pub fn increment_size(&mut self) -> Result<u64, ProgramError> {
+        // The new size cannot be greater than the max size
+        let new_size = self
+            .size
+            .checked_add(1)
+            .ok_or::<ProgramError>(PodSliceError::CalculationFailure.into())?;
+        if let Some(max_size) = self.max_size {
+            if new_size > max_size {
+                return Err(TokenGroupError::SizeExceedsMaxSize.into());
+            }
+        }
+        self.size = new_size;
+        Ok(self.size)
+    }
+}
+
+/// Data struct for a `Member` of a `Group`
+#[derive(
+    BorshDeserialize,
+    BorshSerialize,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    SplBorshVariableLenPack,
+    SplDiscriminate,
+)]
+#[discriminator_hash_input("spl_token_group_interface:member")]
+pub struct Member {
+    /// The pubkey of the `Group`
+    pub group: Pubkey,
+    /// The member number
+    pub member_number: u64,
+}
+impl Member {
+    /// Creates a new `Member` state
+    pub fn new(group: Pubkey, member_number: u64) -> Self {
+        Self {
+            group,
+            member_number,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::NAMESPACE,
+        solana_program::{borsh::get_instance_packed_len, hash},
+        spl_discriminator::ArrayDiscriminator,
+        spl_type_length_value::{
+            error::TlvError,
+            state::{TlvState, TlvStateBorrowed, TlvStateMut},
+        },
+    };
+
+    #[derive(
+        Clone,
+        Debug,
+        Default,
+        PartialEq,
+        BorshSerialize,
+        BorshDeserialize,
+        SplDiscriminate,
+        SplBorshVariableLenPack,
+    )]
+    #[discriminator_hash_input("mock_group")]
+    struct MockGroup {
+        pub data: u64,
+    }
+    impl SplTokenGroup for MockGroup {}
+
+    #[test]
+    fn discriminators() {
+        let preimage = hash::hashv(&[format!("{NAMESPACE}:group").as_bytes()]);
+        let discriminator =
+            ArrayDiscriminator::try_from(&preimage.as_ref()[..ArrayDiscriminator::LENGTH]).unwrap();
+        assert_eq!(Group::<MockGroup>::SPL_DISCRIMINATOR, discriminator);
+
+        let preimage = hash::hashv(&[format!("{NAMESPACE}:member").as_bytes()]);
+        let discriminator =
+            ArrayDiscriminator::try_from(&preimage.as_ref()[..ArrayDiscriminator::LENGTH]).unwrap();
+        assert_eq!(Member::SPL_DISCRIMINATOR, discriminator);
+    }
+
+    #[test]
+    fn tlv_state_pack() {
+        // Make sure we can pack more than one instance of each type
+        let group = Group {
+            update_authority: OptionalNonZeroPubkey::try_from(Some(Pubkey::new_unique())).unwrap(),
+            size: 10,
+            max_size: Some(20),
+            meta: Some(MockGroup { data: 30 }),
+        };
+        let group_instance_size = get_instance_packed_len(&group).unwrap();
+
+        let member_data = Member {
+            group: Pubkey::new_unique(),
+            member_number: 0,
+        };
+        let member_instance_size = get_instance_packed_len(&member_data).unwrap();
+
+        let account_size = TlvStateBorrowed::get_base_len()
+            + get_instance_packed_len(&group).unwrap()
+            + TlvStateBorrowed::get_base_len()
+            + get_instance_packed_len(&member_data).unwrap();
+        let mut buffer = vec![0; account_size];
+        let mut state = TlvStateMut::unpack(&mut buffer).unwrap();
+
+        state
+            .alloc::<Group<MockGroup>>(group_instance_size, false)
+            .unwrap();
+        state.pack_first_variable_len_value(&group).unwrap();
+
+        state.alloc::<Member>(member_instance_size, false).unwrap();
+        state.pack_first_variable_len_value(&member_data).unwrap();
+
+        assert_eq!(
+            state
+                .get_first_variable_len_value::<Group<MockGroup>>()
+                .unwrap(),
+            group
+        );
+        assert_eq!(
+            state.get_first_variable_len_value::<Member>().unwrap(),
+            member_data
+        );
+
+        // But we don't want to be able to pack two of the same
+
+        let mut buffer = vec![0; account_size];
+        let mut state = TlvStateMut::unpack(&mut buffer).unwrap();
+
+        state
+            .alloc::<Group<MockGroup>>(group_instance_size, false)
+            .unwrap();
+        state.pack_first_variable_len_value(&group).unwrap();
+
+        assert_eq!(
+            state
+                .alloc::<Group<MockGroup>>(group_instance_size, false)
+                .unwrap_err(),
+            TlvError::TypeAlreadyExists.into(),
+        );
+
+        let mut buffer = vec![0; account_size];
+        let mut state = TlvStateMut::unpack(&mut buffer).unwrap();
+
+        state.alloc::<Member>(member_instance_size, false).unwrap();
+        state.pack_first_variable_len_value(&member_data).unwrap();
+
+        assert_eq!(
+            state
+                .alloc::<Member>(member_instance_size, false)
+                .unwrap_err(),
+            TlvError::TypeAlreadyExists.into(),
+        );
+    }
+
+    #[test]
+    fn update_max_size() {
+        // Test with a `Some` max size
+        let max_size = Some(10);
+        let mut group = Group {
+            update_authority: OptionalNonZeroPubkey::try_from(Some(Pubkey::new_unique())).unwrap(),
+            size: 0,
+            max_size,
+            meta: Some(MockGroup { data: 30 }),
+        };
+
+        let new_max_size = Some(30);
+        group.update_max_size(new_max_size).unwrap();
+        assert_eq!(group.max_size, new_max_size);
+
+        // Change the current size to 30
+        group.size = 30;
+
+        // Try to set the max size to 20, which is less than the current size
+        let new_max_size = Some(20);
+        assert_eq!(
+            group.update_max_size(new_max_size),
+            Err(ProgramError::from(TokenGroupError::SizeExceedsNewMaxSize))
+        );
+
+        // Test with a `None` max size
+        let max_size = None;
+        let mut group = Group {
+            update_authority: OptionalNonZeroPubkey::try_from(Some(Pubkey::new_unique())).unwrap(),
+            size: 0,
+            max_size,
+            meta: Some(MockGroup { data: 30 }),
+        };
+
+        let new_max_size = Some(30);
+        group.update_max_size(new_max_size).unwrap();
+        assert_eq!(group.max_size, new_max_size);
+    }
+
+    #[test]
+    fn increment_current_size() {
+        let mut group = Group {
+            update_authority: OptionalNonZeroPubkey::try_from(Some(Pubkey::new_unique())).unwrap(),
+            size: 0,
+            max_size: Some(1),
+            meta: Some(MockGroup { data: 30 }),
+        };
+
+        group.increment_size().unwrap();
+        assert_eq!(group.size, 1);
+
+        // Try to increase the current size to 2, which is greater than the max size
+        assert_eq!(
+            group.increment_size(),
+            Err(ProgramError::from(TokenGroupError::SizeExceedsMaxSize))
+        );
+
+        // Test with a `None` max size
+        let mut group = Group {
+            update_authority: OptionalNonZeroPubkey::try_from(Some(Pubkey::new_unique())).unwrap(),
+            size: 0,
+            max_size: None,
+            meta: Some(MockGroup { data: 30 }),
+        };
+
+        group.increment_size().unwrap();
+        assert_eq!(group.size, 1);
+    }
+}


### PR DESCRIPTION
The following is a spec for a "Token Group Interface" - which serves to outline
an interface for grouping tokens together.

This interface is designed to be generic over whatever type of asset
(represented by tokens) you might be implementing the interface for.

Two common examples are demonstrated in this PR/spec:

- Token Collections: Collections of tokens where one token identifies the
collection (or group), and all other tokens are simply "members" of the
collection.
- Token Editions: Token "editions" where one token serves as the original,
and all others are "reprints"

> Note: These are implementations of the interface specific only to this
> example, and interfaces that follow the guise of "collections" or "editions"
> can be implemented in a variety of ways.

## Reviewing this Spec

- Commit 1: Token Group Interface
- Commit 2: Token Group Example
- Commit 3: Token Group Example Tests

### Token Group Interface

The interface itself is structured similar to the
[Token Metadata Interface](https://github.com/solana-labs/solana-program-library/tree/master/token-metadata)
or the
[Transfer Hook Interface](https://github.com/solana-labs/solana-program-library/tree/master/token/transfer-hook-interface),
however this particular interface introduced the idea of a _generic interface_.

This basically means that specified values can be injected into things like
instructions and state, all while still preserving a compliant implementation.

Key points:

- The instructions require a generic argument describing the asset to which
the group is tied to. This generic argument is keyed to the **group**, even
when working with a **member**.
- Some instruction data structs can be extended with an optional `meta` field
that can take metadata about the group or member.
- Some instructions can be expanded with extra required accounts.
- The interface supports a slightly more robust version of managing extra
required accounts (`ExtraAccountMetaList`) via TLV data and a validation
account - adapted from Transfer Hook.
- The data for a `Group` or a `Member` is stored in TLV data, so it can live
within its own account, or be stored alongside other TLV data in an account
such as a Token2022 mint!

### Token Group Example

This example demonstrates how an on-chain program might serve as _both_ a
token **collection** and **edition** standard.

Key points:

- When working with a `Collection`, the example provides a `Collection` as the
generic argument for the interface.
  - It leverages the optional additional group and member metadata for
  collections and collection members.
  - Creation of both collections and collection members is straightforward and,
  in this example, done in individual separate accounts.
- When working with an `Edition`, the example provides an `Edition` as the
generic argument for the interface.
  - It leverages the optional additional group and member metadata for
  collections and collection members.
  - It _also_ leverages extra required accounts to perform some additional
  operations when working with a "reprint" (member).
  - Creation of a "reprint" (member) demonstrates how this example program can
  leverage extra account metas _and_ some other arbitrary program which
  implements the SPL Token Metadata interface.
- The example program itself shows how an on-chain program might implement this
interface multiple times over, demonstrating through a modularized processor
and separated state.

### A Note on Extra Account Metas

In this example, I'm not actually storing the extra required account
configurations in a validation account.

Should this specification gain traction as something we want to pursue, I
propose we actually pop the extra account configuration instructions, state,
and helpers out of the transfer hook interface and into a more generalized
library for other interfaces to use.

In this example - in the tests - I'm just providing the extra accounts
manually.
