### PR TITLE
[token-cli] Make owner address argument in `account-info` command to be non-positional

### DIFF
--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -3874,7 +3874,11 @@ fn app<'a, 'b>(
                                To query a specific account, use the `--address` parameter instead"),
                 )
                 .arg(
-                    owner_address_arg()
+                    Arg::with_name(OWNER_ADDRESS_ARG.name)
+                        .takes_value(true)
+                        .value_name("OWNER_ADDRESS")
+                        .validator(is_valid_signer)
+                        .help(OWNER_ADDRESS_ARG.help)
                         .index(2)
                         .conflicts_with("address")
                         .help("Owner of the associated account for the specified token. \


### PR DESCRIPTION
#### Problem
I am in the process of upgrading the token-cli to use clap-v3 (https://github.com/solana-labs/solana-program-library/pull/4506). Since this upgrade necessarily needs a big change, I am trying to divide some smaller parts into individual PRs.

The deprecated `account-info` command uses the helper function `owner_address_arg()` to specify a positional argument.
```
pub fn owner_address_arg<'a, 'b>() -> Arg<'a, 'b> {
    Arg::with_name(OWNER_ADDRESS_ARG.name)
        .long(OWNER_ADDRESS_ARG.long)
        .takes_value(true)
        .value_name("OWNER_ADDRESS")
        .validator(is_valid_pubkey)
        .help(OWNER_ADDRESS_ARG.help)
}
```
The long name does not really make sense for positional arguments, but this is ignored in clap-v2. However, in clap-v3, this becomes an error.

#### Summary of changes
I just hardcoded `owner_address_arg()` into the argument specification where the `account-info` command is defined, but with the `long(OWNER_ADDRESS_ARG.long)` removed. Since this command is deprecated, I think this is fine to do since the command will not really be updated.
