### PR TITLE
bump twoxtx ci rust version to 1.72.0

### DIFF
--- a/.github/workflows/pull-request-token.yml
+++ b/.github/workflows/pull-request-token.yml
@@ -214,7 +214,7 @@ jobs:
 
       - name: Set env vars
         run: |
-          echo "RUST_STABLE_VERSION=1.69.0" >> $GITHUB_ENV
+          echo "RUST_STABLE_VERSION=1.72.0" >> $GITHUB_ENV
           source ci/rust-version.sh
           echo "RUST_STABLE=$rust_stable" >> $GITHUB_ENV
           source ci/solana-version.sh


### PR DESCRIPTION
The monorepo is running 1.72 and the setup steps involved in the `twoxtx` CI job are pulling in the latest Solana version, which causes some non-compatibility between crates.

This repairs failing CI job for `twoxtx`

https://github.com/solana-labs/solana-program-library/actions/runs/6111174177/job/16592442873#step:8:756