### PR TITLE
[name-service]: cut new release for name-service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6753,7 +6753,7 @@ dependencies = [
 
 [[package]]
 name = "spl-name-service"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "borsh 0.10.3",
  "num-derive 0.4.0",

--- a/name-service/js/package.json
+++ b/name-service/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana/spl-name-service",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "SPL Name Service JavaScript API",
   "license": "MIT",
   "author": "Solana Labs Maintainers <maintainers@solanalabs.com>",

--- a/name-service/program/Cargo.toml
+++ b/name-service/program/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spl-name-service"
 description = "Solana Program Library Name Service"
-version = "0.2.0"
+version = "0.3.0"
 repository = "https://github.com/solana-labs/solana-program-library"
 authors = [
   "lcchy <lucas@bonfida.com>",


### PR DESCRIPTION
closes #5211 

Will need to publish new versions after this goes in, as well as cut tags.

For context, the `realloc` instruction was added to the program and SDK after the most recent release for both.