### PR TITLE
token-cli: initialize-metadata args are required

### DIFF
--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -3046,6 +3046,7 @@ fn app<'a, 'b>(
                     Arg::with_name("name")
                         .value_name("TOKEN_NAME")
                         .takes_value(true)
+                        .required(true)
                         .index(2)
                         .help("The name of the token to set in metadata"),
                 )
@@ -3053,6 +3054,7 @@ fn app<'a, 'b>(
                     Arg::with_name("symbol")
                         .value_name("TOKEN_SYMBOL")
                         .takes_value(true)
+                        .required(true)
                         .index(3)
                         .help("The symbol of the token to set in metadata"),
                 )
@@ -3060,6 +3062,7 @@ fn app<'a, 'b>(
                     Arg::with_name("uri")
                         .value_name("TOKEN_URI")
                         .takes_value(true)
+                        .required(true)
                         .index(4)
                         .help("The URI of the token to set in metadata"),
                 )


### PR DESCRIPTION
```
cargo run -- initialize-metadata 27vKc6xe74j79vwmaUYd18mgjDNLHWXTv49BWKTBktBW lol hi
    Finished dev [unoptimized + debuginfo] target(s) in 0.21s   
     Running `/home/hana/work/solana/spl/target/debug/spl-token initialize-metadata 27vKc6xe74j79vwmaUYd18mgjDNLHWXTv49BWKTBktBW lol hi`
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', token/cli/src/main.rs:4404:51
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
