### PR TITLE
ci: Make space in token test-sbf run

### DIFF
--- a/.github/workflows/pull-request-token.yml
+++ b/.github/workflows/pull-request-token.yml
@@ -21,15 +21,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Clear disk space
-        run: |
-          # if we need more: `sudo apt-get install -y wajig && wajig large`
-          for p in ant mono-complete lldb-14 google-cloud-sdk azure-cli microsoft-edge-stable \
-              google-chrome-stable firefox powershell mono-devel dotnet-sdk-6.0 dotnet-sdk-7.0 \
-              temurin-8-jdk temurin-11-jdk temurin-17-jdk llvm-12-dev llvm-13-dev llvm-14-dev \
-              fake-canary-package; do sudo apt-get remove -y $p || true; done
-          sudo apt-get autoremove -y
-          sudo rm -rf /imagegeneration
+      - name: Remove unneeded packages for more space
+        run: bash ./ci/warning/purge-ubuntu-runner.sh
 
       - name: Set env vars
         run: |

--- a/ci/warning/purge-ubuntu-runner.sh
+++ b/ci/warning/purge-ubuntu-runner.sh
@@ -23,4 +23,5 @@ if [[ -n "$CI" ]]; then
 
   sudo rm -rf /usr/local/lib/android
   sudo rm -rf /usr/local/lib/heroku
+  sudo rm -rf /imagegeneration
 fi


### PR DESCRIPTION
#### Problem

As noted in #5231, CI keeps breaking because of a lack of disk space.

#### Solution

Use the `purge-ubuntu-runner.sh` script in token's `cargo-test-sbf` step.

I added `/imagegeneration` to the script, which I wasn't aware of.