### PR TITLE
stake-pool-js: Bump to 0.7.0 to release

### DIFF
--- a/stake-pool/js/package-lock.json
+++ b/stake-pool/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@solana/spl-stake-pool",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@solana/spl-stake-pool",
-      "version": "0.6.5",
+      "version": "0.7.0",
       "license": "ISC",
       "dependencies": {
         "@coral-xyz/borsh": "^0.28.0",

--- a/stake-pool/js/package.json
+++ b/stake-pool/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana/spl-stake-pool",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "description": "SPL Stake Pool Program JS API",
   "scripts": {
     "build": "npm run clean && tsc && cross-env NODE_ENV=production rollup -c",


### PR DESCRIPTION
#### Problem

The stake-pool JS bindings support a newer spl-token package and add support for metadata, but they haven't been released in awhile.

#### Solution

Bump the package to eventually release.