### PR TITLE
associated-token-account: Increase compute budget number

### DIFF
--- a/associated-token-account/program-test/tests/program_test.rs
+++ b/associated-token-account/program-test/tests/program_test.rs
@@ -36,7 +36,7 @@ pub fn program_test(token_mint_address: Pubkey, use_latest_spl_token: bool) -> P
     );
 
     // Dial down the BPF compute budget to detect if the program gets bloated in the future
-    pc.set_compute_max_units(50_000);
+    pc.set_compute_max_units(60_000);
 
     pc
 }


### PR DESCRIPTION
#### Problem

The recover_nested tests in ATA have been flakey for sometimes using too much compute budget.

#### Solution

Increase the compute budget limit.