### PR TITLE
stake-pool: Add error logging during test failures

### DIFF
--- a/stake-pool/program/tests/decrease.rs
+++ b/stake-pool/program/tests/decrease.rs
@@ -108,7 +108,7 @@ async fn success(use_additional_instruction: bool) {
             use_additional_instruction,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // Check validator stake account balance
     let validator_stake_account =
@@ -291,7 +291,7 @@ async fn fail_twice_diff_seed(use_additional_instruction: bool) {
             use_additional_instruction,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let transient_stake_seed = validator_stake.transient_stake_seed * 100;
     let transient_stake_address = find_transient_stake_program_address(
@@ -358,7 +358,7 @@ async fn twice(success: bool, use_additional_first_time: bool, use_additional_se
             use_additional_first_time,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let error = stake_pool_accounts
         .decrease_validator_stake_either(
@@ -374,7 +374,7 @@ async fn twice(success: bool, use_additional_first_time: bool, use_additional_se
         .await;
 
     if success {
-        assert!(error.is_none());
+        assert!(error.is_none(), "{:?}", error);
         // no ephemeral account
         let ephemeral_stake = find_ephemeral_stake_program_address(
             &id(),
@@ -565,7 +565,7 @@ async fn fail_additional_with_increasing() {
             validator_stake.transient_stake_seed,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let error = stake_pool_accounts
         .decrease_validator_stake_either(

--- a/stake-pool/program/tests/deposit.rs
+++ b/stake-pool/program/tests/deposit.rs
@@ -182,7 +182,7 @@ async fn success(token_program_id: Pubkey) {
             &user,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // Original stake account should be drained
     assert!(context
@@ -355,7 +355,7 @@ async fn success_with_extra_stake_lamports() {
             &referrer_token_account.pubkey(),
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // Original stake account should be drained
     assert!(context
@@ -875,7 +875,7 @@ async fn success_with_slippage(token_program_id: Pubkey) {
             tokens_issued_user,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // Original stake account should be drained
     assert!(context

--- a/stake-pool/program/tests/deposit_authority.rs
+++ b/stake-pool/program/tests/deposit_authority.rs
@@ -120,7 +120,7 @@ async fn success_deposit() {
             &user,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 }
 
 #[tokio::test]

--- a/stake-pool/program/tests/deposit_edge_cases.rs
+++ b/stake-pool/program/tests/deposit_edge_cases.rs
@@ -151,7 +151,7 @@ async fn success_with_preferred_deposit() {
             &user,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 }
 
 #[tokio::test]

--- a/stake-pool/program/tests/deposit_sol.rs
+++ b/stake-pool/program/tests/deposit_sol.rs
@@ -98,7 +98,7 @@ async fn success(token_program_id: Pubkey) {
             None,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let tokens_issued = TEST_STAKE_AMOUNT; // For now tokens are 1:1 to stake
 
@@ -309,7 +309,7 @@ async fn success_with_sol_deposit_authority() {
             None,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let sol_deposit_authority = Keypair::new();
 
@@ -336,7 +336,7 @@ async fn success_with_sol_deposit_authority() {
             Some(&sol_deposit_authority),
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 }
 
 #[tokio::test]
@@ -569,7 +569,7 @@ async fn success_with_slippage(token_program_id: Pubkey) {
             tokens_issued,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // Stake pool should add its balance to the pool balance
     let post_stake_pool = get_account(

--- a/stake-pool/program/tests/force_destake.rs
+++ b/stake-pool/program/tests/force_destake.rs
@@ -146,7 +146,7 @@ async fn success_update() {
             false,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
     let post_reserve_lamports = context
         .banks_client
         .get_account(stake_pool_accounts.reserve_stake.pubkey())

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -2085,7 +2085,7 @@ pub async fn simple_add_validator_to_pool(
             sol_deposit_authority,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     create_vote(
         banks_client,
@@ -2106,7 +2106,7 @@ pub async fn simple_add_validator_to_pool(
             validator_stake.validator_stake_seed,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     validator_stake
 }
@@ -2207,7 +2207,7 @@ impl DepositStakeAccount {
             )
             .await;
         self.pool_tokens = get_token_balance(banks_client, &self.pool_account.pubkey()).await;
-        assert!(error.is_none());
+        assert!(error.is_none(), "{:?}", error);
     }
 }
 

--- a/stake-pool/program/tests/huge_pool.rs
+++ b/stake-pool/program/tests/huge_pool.rs
@@ -184,7 +184,7 @@ async fn update(max_validators: u32) {
             false, /* no_merge */
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let error = stake_pool_accounts
         .update_stake_pool_balance(
@@ -193,7 +193,7 @@ async fn update(max_validators: u32) {
             &context.last_blockhash,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let error = stake_pool_accounts
         .cleanup_removed_validator_entries(
@@ -202,7 +202,7 @@ async fn update(max_validators: u32) {
             &context.last_blockhash,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 }
 
 //#[test_case(MAX_POOL_SIZE_WITH_REQUESTED_COMPUTE_UNITS; "compute-budget")]
@@ -236,7 +236,7 @@ async fn remove_validator_from_pool(max_validators: u32) {
             &transient_stake_address,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let middle_index = max_validators as usize / 2;
     let middle_vote = vote_account_pubkeys[middle_index];
@@ -262,7 +262,7 @@ async fn remove_validator_from_pool(max_validators: u32) {
             &transient_stake_address,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let last_index = max_validators as usize - 1;
     let last_vote = vote_account_pubkeys[last_index];
@@ -288,7 +288,7 @@ async fn remove_validator_from_pool(max_validators: u32) {
             &transient_stake_address,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let validator_list = get_account(
         &mut context.banks_client,
@@ -330,7 +330,7 @@ async fn remove_validator_from_pool(max_validators: u32) {
             false, /* no_merge */
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let mut instructions = vec![instruction::update_validator_list_balance(
         &id(),
@@ -355,7 +355,7 @@ async fn remove_validator_from_pool(max_validators: u32) {
         .process_transaction(transaction)
         .await
         .err();
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let mut instructions = vec![instruction::update_validator_list_balance(
         &id(),
@@ -380,7 +380,7 @@ async fn remove_validator_from_pool(max_validators: u32) {
         .process_transaction(transaction)
         .await
         .err();
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let error = stake_pool_accounts
         .cleanup_removed_validator_entries(
@@ -389,7 +389,7 @@ async fn remove_validator_from_pool(max_validators: u32) {
             &context.last_blockhash,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let validator_list = get_account(
         &mut context.banks_client,
@@ -454,7 +454,7 @@ async fn add_validator_to_pool(max_validators: u32) {
             None,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let validator_list = get_account(
         &mut context.banks_client,
@@ -531,7 +531,7 @@ async fn set_preferred(max_validators: u32) {
             Some(vote_account_address),
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
     let error = stake_pool_accounts
         .set_preferred_validator(
             &mut context.banks_client,
@@ -541,7 +541,7 @@ async fn set_preferred(max_validators: u32) {
             Some(vote_account_address),
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let stake_pool = get_account(
         &mut context.banks_client,
@@ -585,7 +585,7 @@ async fn deposit_stake(max_validators: u32) {
             &user,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 }
 
 #[test_case(MAX_POOL_SIZE_WITH_REQUESTED_COMPUTE_UNITS; "compute-budget")]
@@ -613,7 +613,7 @@ async fn withdraw(max_validators: u32) {
             &user,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // Create stake account to withdraw to
     let user_stake_recipient = Keypair::new();
@@ -695,5 +695,5 @@ async fn cleanup_all(max_validators: u32) {
             &context.last_blockhash,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 }

--- a/stake-pool/program/tests/increase.rs
+++ b/stake-pool/program/tests/increase.rs
@@ -113,7 +113,7 @@ async fn success(use_additional_instruction: bool) {
             use_additional_instruction,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // Check reserve stake account balance
     let reserve_stake_account = get_account(
@@ -298,7 +298,7 @@ async fn fail_twice_diff_seed(use_additional_instruction: bool) {
             use_additional_instruction,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let transient_stake_seed = validator_stake.transient_stake_seed * 100;
     let transient_stake_address = find_transient_stake_program_address(
@@ -370,7 +370,7 @@ async fn twice(success: bool, use_additional_first_time: bool, use_additional_se
             use_additional_first_time,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let error = stake_pool_accounts
         .increase_validator_stake_either(
@@ -387,7 +387,7 @@ async fn twice(success: bool, use_additional_first_time: bool, use_additional_se
         .await;
 
     if success {
-        assert!(error.is_none());
+        assert!(error.is_none(), "{:?}", error);
         let rent = context.banks_client.get_rent().await.unwrap();
         let stake_rent = rent.minimum_balance(std::mem::size_of::<stake::state::StakeState>());
         // no ephemeral account
@@ -563,7 +563,7 @@ async fn fail_additional_with_decreasing() {
             validator_stake.transient_stake_seed,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let error = stake_pool_accounts
         .increase_validator_stake_either(

--- a/stake-pool/program/tests/redelegate.rs
+++ b/stake-pool/program/tests/redelegate.rs
@@ -176,7 +176,7 @@ async fn success() {
             destination_validator_stake.transient_stake_seed,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // Check validator stake account balance
     let validator_stake_account = get_account(
@@ -377,7 +377,7 @@ async fn success_with_increasing_stake() {
             destination_validator_stake.transient_stake_seed,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let validator_list = stake_pool_accounts
         .get_validator_list(&mut context.banks_client)
@@ -467,7 +467,7 @@ async fn success_with_increasing_stake() {
             destination_validator_stake.transient_stake_seed,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // Check destination transient stake account
     let destination_transient_stake_account = get_account(
@@ -624,7 +624,7 @@ async fn fail_with_decreasing_stake() {
             destination_validator_stake.transient_stake_seed,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let ephemeral_stake_seed = 20;
     let ephemeral_stake = find_ephemeral_stake_program_address(
@@ -993,7 +993,7 @@ async fn fail_redelegate_twice() {
             destination_validator_stake.transient_stake_seed,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let last_blockhash = context
         .banks_client

--- a/stake-pool/program/tests/set_preferred.rs
+++ b/stake-pool/program/tests/set_preferred.rs
@@ -74,7 +74,7 @@ async fn success_deposit() {
             Some(vote_account_address),
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let stake_pool = get_account(&mut banks_client, &stake_pool_accounts.stake_pool.pubkey()).await;
     let stake_pool = try_from_slice_unchecked::<StakePool>(stake_pool.data.as_slice()).unwrap();
@@ -102,7 +102,7 @@ async fn success_withdraw() {
             Some(vote_account_address),
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let stake_pool = get_account(&mut banks_client, &stake_pool_accounts.stake_pool.pubkey()).await;
     let stake_pool = try_from_slice_unchecked::<StakePool>(stake_pool.data.as_slice()).unwrap();
@@ -129,7 +129,7 @@ async fn success_unset() {
             Some(vote_account_address),
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let stake_pool = get_account(&mut banks_client, &stake_pool_accounts.stake_pool.pubkey()).await;
     let stake_pool = try_from_slice_unchecked::<StakePool>(stake_pool.data.as_slice()).unwrap();
@@ -148,7 +148,7 @@ async fn success_unset() {
             None,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let stake_pool = get_account(&mut banks_client, &stake_pool_accounts.stake_pool.pubkey()).await;
     let stake_pool = try_from_slice_unchecked::<StakePool>(stake_pool.data.as_slice()).unwrap();
@@ -230,7 +230,7 @@ async fn fail_ready_for_removal() {
         &stake_pool_accounts.stake_pool.pubkey(),
         transient_stake_seed,
     );
-    let remove_err = stake_pool_accounts
+    let error = stake_pool_accounts
         .remove_validator_from_pool(
             &mut banks_client,
             &payer,
@@ -239,7 +239,7 @@ async fn fail_ready_for_removal() {
             &transient_stake_address,
         )
         .await;
-    assert!(remove_err.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let error = stake_pool_accounts
         .set_preferred_validator(

--- a/stake-pool/program/tests/set_withdrawal_fee.rs
+++ b/stake-pool/program/tests/set_withdrawal_fee.rs
@@ -350,7 +350,7 @@ async fn success_fee_cannot_increase_more_than_once() {
             &context.last_blockhash,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // Check that nothing has changed after updating the stake pool
     let stake_pool = get_account(

--- a/stake-pool/program/tests/update_stake_pool_balance.rs
+++ b/stake-pool/program/tests/update_stake_pool_balance.rs
@@ -60,7 +60,7 @@ async fn setup(
             None,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let mut last_blockhash = context
         .banks_client
@@ -95,7 +95,7 @@ async fn setup(
                 stake_account.validator_stake_seed,
             )
             .await;
-        assert!(error.is_none());
+        assert!(error.is_none(), "{:?}", error);
 
         let mut deposit_account = DepositStakeAccount::new_with_vote(
             stake_account.vote.pubkey(),
@@ -188,7 +188,7 @@ async fn success() {
             false,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // Check fee
     let post_balance = get_validator_list_sum(
@@ -301,7 +301,7 @@ async fn success_absorbing_extra_lamports() {
             false,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // Check extra lamports are absorbed and fee'd as rewards
     let post_balance = get_validator_list_sum(

--- a/stake-pool/program/tests/update_validator_list_balance.rs
+++ b/stake-pool/program/tests/update_validator_list_balance.rs
@@ -74,7 +74,7 @@ async fn setup(
                 stake_account.validator_stake_seed,
             )
             .await;
-        assert!(error.is_none());
+        assert!(error.is_none(), "{:?}", error);
 
         let deposit_account = DepositStakeAccount::new_with_vote(
             stake_account.vote.pubkey(),
@@ -289,7 +289,7 @@ async fn merge_into_reserve() {
                 stake_account.transient_stake_seed,
             )
             .await;
-        assert!(error.is_none());
+        assert!(error.is_none(), "{:?}", error);
     }
 
     println!("Update, should not change, no merges yet");
@@ -417,7 +417,7 @@ async fn merge_into_validator_stake() {
                 stake_account.transient_stake_seed,
             )
             .await;
-        assert!(error.is_none());
+        assert!(error.is_none(), "{:?}", error);
     }
 
     // Warp just a little bit to get a new blockhash and update again
@@ -442,7 +442,7 @@ async fn merge_into_validator_stake() {
             false,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let expected_lamports = get_validator_list_sum(
         &mut context.banks_client,
@@ -482,7 +482,7 @@ async fn merge_into_validator_stake() {
             false,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
     let current_lamports = get_validator_list_sum(
         &mut context.banks_client,
         &stake_pool_accounts.reserve_stake.pubkey(),
@@ -564,7 +564,7 @@ async fn merge_transient_stake_after_remove() {
                 stake_account.transient_stake_seed,
             )
             .await;
-        assert!(error.is_none());
+        assert!(error.is_none(), "{:?}", error);
         let error = stake_pool_accounts
             .remove_validator_from_pool(
                 &mut context.banks_client,
@@ -574,7 +574,7 @@ async fn merge_transient_stake_after_remove() {
                 &stake_account.transient_stake_account,
             )
             .await;
-        assert!(error.is_none());
+        assert!(error.is_none(), "{:?}", error);
     }
 
     // Warp forward to merge time
@@ -596,7 +596,7 @@ async fn merge_transient_stake_after_remove() {
             true,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let validator_list = get_account(
         &mut context.banks_client,
@@ -633,7 +633,7 @@ async fn merge_transient_stake_after_remove() {
             false,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // stake accounts were merged in, none exist anymore
     for stake_account in &stake_accounts {
@@ -679,7 +679,7 @@ async fn merge_transient_stake_after_remove() {
     let error = stake_pool_accounts
         .update_stake_pool_balance(&mut context.banks_client, &context.payer, &last_blockhash)
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let error = stake_pool_accounts
         .cleanup_removed_validator_entries(
@@ -688,7 +688,7 @@ async fn merge_transient_stake_after_remove() {
             &last_blockhash,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let validator_list = get_account(
         &mut context.banks_client,

--- a/stake-pool/program/tests/update_validator_list_balance_hijack.rs
+++ b/stake-pool/program/tests/update_validator_list_balance_hijack.rs
@@ -81,7 +81,7 @@ async fn setup(
                 stake_account.validator_stake_seed,
             )
             .await;
-        assert!(error.is_none());
+        assert!(error.is_none(), "{:?}", error);
 
         let deposit_account = DepositStakeAccount::new_with_vote(
             stake_account.vote.pubkey(),
@@ -230,7 +230,7 @@ async fn check_ignored_hijacked_transient_stake(
             stake_account.transient_stake_seed,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     println!("Warp one epoch so the stakes deactivate and merge");
     let slots_per_epoch = context.genesis_config().epoch_schedule.slots_per_epoch;
@@ -296,7 +296,7 @@ async fn check_ignored_hijacked_transient_stake(
         .process_transaction(transaction)
         .await
         .err();
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     println!("Update again normally, should be no change in the lamports");
     let last_blockhash = context
@@ -394,7 +394,7 @@ async fn check_ignored_hijacked_validator_stake(
             stake_account.transient_stake_seed,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let error = stake_pool_accounts
         .remove_validator_from_pool(
@@ -405,7 +405,7 @@ async fn check_ignored_hijacked_validator_stake(
             &stake_account.transient_stake_account,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     println!("Warp one epoch so the stakes deactivate and merge");
     let slots_per_epoch = context.genesis_config().epoch_schedule.slots_per_epoch;
@@ -464,7 +464,7 @@ async fn check_ignored_hijacked_validator_stake(
         .process_transaction(transaction)
         .await
         .err();
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     println!("Update again normally, should be no change in the lamports");
     let last_blockhash = context
@@ -542,7 +542,7 @@ async fn check_ignored_hijacked_validator_stake(
             seed,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let stake_pool_info = get_account(
         &mut context.banks_client,

--- a/stake-pool/program/tests/vsa_add.rs
+++ b/stake-pool/program/tests/vsa_add.rs
@@ -88,7 +88,7 @@ async fn success() {
             validator_stake.validator_stake_seed,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // Check if validator account was added to the list
     let validator_list = get_account(
@@ -471,7 +471,7 @@ async fn fail_add_too_many_validator_stake_accounts() {
             validator_stake.validator_stake_seed,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let validator_stake =
         ValidatorStakeAccount::new(&stake_pool_accounts.stake_pool.pubkey(), None, 0);
@@ -590,7 +590,7 @@ async fn success_with_lamports_in_account() {
             validator_stake.validator_stake_seed,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // Check stake account existence and authority
     let stake = get_account(&mut banks_client, &validator_stake.stake_account).await;

--- a/stake-pool/program/tests/vsa_remove.rs
+++ b/stake-pool/program/tests/vsa_remove.rs
@@ -62,7 +62,7 @@ async fn setup() -> (ProgramTestContext, StakePoolAccounts, ValidatorStakeAccoun
             validator_stake.validator_stake_seed,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
     (context, stake_pool_accounts, validator_stake)
 }
 
@@ -79,7 +79,7 @@ async fn success() {
             &validator_stake.transient_stake_account,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let error = stake_pool_accounts
         .update_all(
@@ -90,7 +90,7 @@ async fn success() {
             false,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // Check if account was removed from the list of stake accounts
     let validator_list = get_account(
@@ -243,7 +243,7 @@ async fn success_at_large_value() {
             &validator_stake.transient_stake_account,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 }
 
 #[tokio::test]
@@ -259,7 +259,7 @@ async fn fail_double_remove() {
             &validator_stake.transient_stake_account,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let error = stake_pool_accounts
         .update_all(
@@ -270,7 +270,7 @@ async fn fail_double_remove() {
             false,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let last_blockhash = context
         .banks_client
@@ -405,7 +405,7 @@ async fn fail_with_activating_transient_stake() {
             validator_stake.transient_stake_seed,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let error = stake_pool_accounts
         .remove_validator_from_pool(
@@ -465,7 +465,7 @@ async fn success_with_deactivating_transient_stake() {
             validator_stake.transient_stake_seed,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let error = stake_pool_accounts
         .remove_validator_from_pool(
@@ -476,7 +476,7 @@ async fn success_with_deactivating_transient_stake() {
             &validator_stake.transient_stake_account,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // fail deposit
     let maybe_deposit = simple_deposit_stake(
@@ -568,7 +568,7 @@ async fn success_with_deactivating_transient_stake() {
             false,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let validator_list = get_account(
         &mut context.banks_client,
@@ -619,7 +619,7 @@ async fn success_resets_preferred_validator() {
             &validator_stake.transient_stake_account,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let error = stake_pool_accounts
         .update_all(
@@ -630,7 +630,7 @@ async fn success_resets_preferred_validator() {
             false,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // Check if account was removed from the list of stake accounts
     let validator_list = get_account(
@@ -686,7 +686,7 @@ async fn success_with_hijacked_transient_account() {
             validator_stake.transient_stake_seed,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // warp forward to merge
     let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
@@ -715,7 +715,7 @@ async fn success_with_hijacked_transient_account() {
             validator_stake.transient_stake_seed,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // warp forward to merge
     slot += slots_per_epoch;
@@ -784,7 +784,7 @@ async fn success_with_hijacked_transient_account() {
         .process_transaction(transaction)
         .await
         .err();
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // activate transient stake account
     delegate_stake_account(
@@ -807,7 +807,7 @@ async fn success_with_hijacked_transient_account() {
             &validator_stake.transient_stake_account,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // warp forward to merge
     slot += slots_per_epoch;
@@ -822,7 +822,7 @@ async fn success_with_hijacked_transient_account() {
             false,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // Check if account was removed from the list of stake accounts
     let validator_list = get_account(

--- a/stake-pool/program/tests/withdraw.rs
+++ b/stake-pool/program/tests/withdraw.rs
@@ -167,7 +167,7 @@ async fn _success(token_program_id: Pubkey, test_type: SuccessTestType) {
             tokens_to_withdraw,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // Check pool stats
     let stake_pool = get_account(
@@ -528,7 +528,7 @@ async fn fail_double_withdraw_to_the_same_account() {
             tokens_to_burn / 2,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let latest_blockhash = context.banks_client.get_latest_blockhash().await.unwrap();
 
@@ -825,7 +825,7 @@ async fn success_with_slippage(token_program_id: Pubkey) {
             received_lamports,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // Check tokens used
     let user_token_balance = get_token_balance(

--- a/stake-pool/program/tests/withdraw_edge_cases.rs
+++ b/stake-pool/program/tests/withdraw_edge_cases.rs
@@ -39,7 +39,7 @@ async fn fail_remove_validator() {
             validator_stake.transient_stake_seed,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // warp forward to deactivation
     let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
@@ -139,7 +139,7 @@ async fn success_remove_validator(multiple: u64) {
             validator_stake.transient_stake_seed,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // warp forward to deactivation
     let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
@@ -190,7 +190,7 @@ async fn success_remove_validator(multiple: u64) {
             pool_tokens,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // Check validator stake account gone
     let validator_stake_account = context
@@ -252,7 +252,7 @@ async fn fail_with_reserve() {
             validator_stake.transient_stake_seed,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // warp forward to deactivation
     let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
@@ -322,7 +322,7 @@ async fn success_with_reserve() {
             validator_stake.transient_stake_seed,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // warp forward to deactivation
     let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
@@ -354,7 +354,7 @@ async fn success_with_reserve() {
             deposit_info.pool_tokens,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // first and only deposit, lamports:pool 1:1
     let stake_pool = get_account(
@@ -457,7 +457,7 @@ async fn success_with_empty_preferred_withdraw() {
             tokens_to_burn / 2,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 }
 
 #[tokio::test]
@@ -553,7 +553,7 @@ async fn success_and_fail_with_preferred_withdraw() {
             tokens_to_burn / 2,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 }
 
 #[tokio::test]
@@ -615,7 +615,7 @@ async fn fail_withdraw_from_transient() {
             validator_stake_account.transient_stake_seed,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // fail withdrawing from transient, still a lamport in the validator stake account
     let new_user_authority = Pubkey::new_unique();
@@ -702,7 +702,7 @@ async fn success_withdraw_from_transient() {
             validator_stake_account.transient_stake_seed,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // nothing left in the validator stake account (or any others), so withdrawing
     // from the transient account is ok!
@@ -720,7 +720,7 @@ async fn success_withdraw_from_transient() {
             tokens_to_withdraw / 2,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 }
 
 #[tokio::test]
@@ -816,7 +816,7 @@ async fn success_with_small_preferred_withdraw() {
             preferred_validator.transient_stake_seed,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // warp forward to deactivation
     let first_normal_slot = context.genesis_config().epoch_schedule.first_normal_slot;
@@ -868,5 +868,5 @@ async fn success_with_small_preferred_withdraw() {
             tokens_to_burn / 6,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 }

--- a/stake-pool/program/tests/withdraw_sol.rs
+++ b/stake-pool/program/tests/withdraw_sol.rs
@@ -65,7 +65,7 @@ async fn setup(
             None,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     let tokens_issued =
         get_token_balance(&mut context.banks_client, &pool_token_account.pubkey()).await;
@@ -114,7 +114,7 @@ async fn success(token_program_id: Pubkey) {
             None,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // Stake pool should add its balance to the pool balance
     let post_stake_pool = get_account(
@@ -212,7 +212,7 @@ async fn fail_overdraw_reserve() {
             validator_stake.transient_stake_seed,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // try to withdraw one lamport, will overdraw
     let error = stake_pool_accounts
@@ -273,7 +273,7 @@ async fn success_with_sol_withdraw_authority() {
             Some(&sol_withdraw_authority),
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 }
 
 #[tokio::test]
@@ -373,7 +373,7 @@ async fn success_with_slippage(token_program_id: Pubkey) {
             amount_received,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // Check burned tokens
     let user_token_balance =

--- a/stake-pool/program/tests/withdraw_with_fee.rs
+++ b/stake-pool/program/tests/withdraw_with_fee.rs
@@ -78,7 +78,7 @@ async fn success_withdraw_all_fee_tokens() {
             fee_tokens,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // Check balance is 0
     let fee_tokens = get_token_balance(
@@ -217,7 +217,7 @@ async fn success_empty_out_stake_with_fee() {
             pool_tokens_to_withdraw,
         )
         .await;
-    assert!(error.is_none());
+    assert!(error.is_none(), "{:?}", error);
 
     // Check balance of validator stake account is MINIMUM + rent-exemption
     let validator_stake_account = get_account(


### PR DESCRIPTION
#### Problem

There are still some flaky tests in the stake pool program, but there's no indication about what's going on since we're just doing `assert!(error.is_none())`.

#### Solution

This doesn't fix the flaky tests, but will log the error during failures for future investigation.