### PR TITLE
token-2022: Fix some flaky tests

### DIFF
--- a/token/program-2022-test/tests/confidential_transfer_fee.rs
+++ b/token/program-2022-test/tests/confidential_transfer_fee.rs
@@ -1211,6 +1211,8 @@ async fn confidential_transfer_harvest_withheld_tokens_to_mint() {
         .await
         .unwrap();
 
+    // Refresh the blockhash since we're doing the same thing twice in a row
+    token.get_new_latest_blockhash().await.unwrap();
     token
         .confidential_transfer_harvest_withheld_tokens_to_mint(&[&bob_meta.token_account])
         .await

--- a/token/program-2022-test/tests/cpi_guard.rs
+++ b/token/program-2022-test/tests/cpi_guard.rs
@@ -516,6 +516,8 @@ async fn test_cpi_guard_approve() {
             .await
             .unwrap();
 
+        // refresh the blockhash
+        token_obj.get_new_latest_blockhash().await.unwrap();
         token_obj
             .process_ixs(&[mk_approve(do_checked)], &[&alice])
             .await

--- a/token/program-2022-test/tests/token_metadata_emit.rs
+++ b/token/program-2022-test/tests/token_metadata_emit.rs
@@ -118,11 +118,13 @@ async fn success(start: Option<u64>, end: Option<u64>) {
         if !check_buffer.is_empty() {
             // pad the data if necessary
             let mut return_data = vec![0; MAX_RETURN_DATA];
-            let simulation_return_data =
-                simulation.simulation_details.unwrap().return_data.unwrap();
-            assert_eq!(simulation_return_data.program_id, program_id);
-            return_data[..simulation_return_data.data.len()]
-                .copy_from_slice(&simulation_return_data.data);
+            if let Some(simulation_details) = simulation.simulation_details {
+                if let Some(simulation_return_data) = simulation_details.return_data {
+                    assert_eq!(simulation_return_data.program_id, program_id);
+                    return_data[..simulation_return_data.data.len()]
+                        .copy_from_slice(&simulation_return_data.data);
+                }
+            }
 
             assert_eq!(*check_buffer, return_data[..check_buffer.len()]);
             // we're sure that we're getting the full data, so also compare the deserialized type


### PR DESCRIPTION
#### Problem

Some of the token-2022 tests are flaky, typically failing because we're doing the same transaction twice in a row.

#### Solution

Refresh the blockhash where needed, and check conditions appropriately. There will probably be some other situations like this, but we'll fix them as they come up.