### PR TITLE
stake-pool: Fund rent-exemption from reserve in `decrease_additional`

### DIFF
--- a/stake-pool/js/src/index.ts
+++ b/stake-pool/js/src/index.ts
@@ -795,6 +795,7 @@ export async function decreaseValidatorStake(
         stakePool: stakePoolAddress,
         staker: stakePool.account.data.staker,
         validatorList: stakePool.account.data.validatorList,
+        reserveStake: stakePool.account.data.reserveStake,
         transientStakeSeed: transientStakeSeed.toNumber(),
         withdrawAuthority,
         validatorStake,

--- a/stake-pool/js/src/instructions.ts
+++ b/stake-pool/js/src/instructions.ts
@@ -226,6 +226,7 @@ export type DecreaseValidatorStakeParams = {
 };
 
 export interface DecreaseAdditionalValidatorStakeParams extends DecreaseValidatorStakeParams {
+  reserveStake: PublicKey;
   ephemeralStake: PublicKey;
   ephemeralStakeSeed: number;
 }
@@ -612,6 +613,7 @@ export class StakePoolInstruction {
       staker,
       withdrawAuthority,
       validatorList,
+      reserveStake,
       validatorStake,
       transientStake,
       lamports,
@@ -628,6 +630,7 @@ export class StakePoolInstruction {
       { pubkey: staker, isSigner: true, isWritable: false },
       { pubkey: withdrawAuthority, isSigner: false, isWritable: false },
       { pubkey: validatorList, isSigner: false, isWritable: true },
+      { pubkey: reserveStake, isSigner: false, isWritable: true },
       { pubkey: validatorStake, isSigner: false, isWritable: true },
       { pubkey: ephemeralStake, isSigner: false, isWritable: true },
       { pubkey: transientStake, isSigner: false, isWritable: true },

--- a/stake-pool/program/src/error.rs
+++ b/stake-pool/program/src/error.rs
@@ -154,6 +154,9 @@ pub enum StakePoolError {
     /// the rent-exempt reserve for a stake account.
     #[error("ReserveDepleted")]
     ReserveDepleted,
+    /// Missing required sysvar account
+    #[error("Missing required sysvar account")]
+    MissingRequiredSysvar,
 }
 impl From<StakePoolError> for ProgramError {
     fn from(e: StakePoolError) -> Self {

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -1442,9 +1442,7 @@ impl Processor {
 
                 (
                     ephemeral_stake_account_info,
-                    lamports
-                        .checked_add(stake_rent)
-                        .ok_or(StakePoolError::CalculationFailure)?,
+                    ephemeral_stake_account_info.lamports()
                 )
             } else {
                 // if no ephemeral account is provided, split everything from the

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -1442,7 +1442,7 @@ impl Processor {
 
                 (
                     ephemeral_stake_account_info,
-                    ephemeral_stake_account_info.lamports()
+                    ephemeral_stake_account_info.lamports(),
                 )
             } else {
                 // if no ephemeral account is provided, split everything from the

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -1398,14 +1398,14 @@ impl Processor {
 
                 // if needed, withdraw rent-exempt reserve for ephemeral account
                 if let Some(reserve_stake_info) = maybe_reserve_stake_info {
-                    let stake_history_info =
-                        maybe_stake_history_info.ok_or(StakePoolError::MissingRequiredSysvar)?;
                     let required_lamports_for_rent_exemption =
                         stake_rent.saturating_sub(ephemeral_stake_account_info.lamports());
-                    if required_lamports_for_rent_exemption >= reserve_stake_info.lamports() {
-                        return Err(StakePoolError::ReserveDepleted.into());
-                    }
                     if required_lamports_for_rent_exemption > 0 {
+                        if required_lamports_for_rent_exemption >= reserve_stake_info.lamports() {
+                            return Err(StakePoolError::ReserveDepleted.into());
+                        }
+                        let stake_history_info = maybe_stake_history_info
+                            .ok_or(StakePoolError::MissingRequiredSysvar)?;
                         Self::stake_withdraw(
                             stake_pool_info.key,
                             reserve_stake_info.clone(),

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -1241,12 +1241,16 @@ impl Processor {
         lamports: u64,
         transient_stake_seed: u64,
         maybe_ephemeral_stake_seed: Option<u64>,
+        fund_rent_exempt_reserve: bool,
     ) -> ProgramResult {
         let account_info_iter = &mut accounts.iter();
         let stake_pool_info = next_account_info(account_info_iter)?;
         let staker_info = next_account_info(account_info_iter)?;
         let withdraw_authority_info = next_account_info(account_info_iter)?;
         let validator_list_info = next_account_info(account_info_iter)?;
+        let maybe_reserve_stake_info = fund_rent_exempt_reserve
+            .then(|| next_account_info(account_info_iter))
+            .transpose()?;
         let validator_stake_account_info = next_account_info(account_info_iter)?;
         let maybe_ephemeral_stake_account_info = maybe_ephemeral_stake_seed
             .map(|_| next_account_info(account_info_iter))
@@ -1298,6 +1302,10 @@ impl Processor {
             return Err(StakePoolError::InvalidState.into());
         }
 
+        if let Some(reserve_stake_info) = maybe_reserve_stake_info {
+            stake_pool.check_reserve_stake(reserve_stake_info)?;
+        }
+
         let (meta, stake) = get_stake_state(validator_stake_account_info)?;
         let vote_account_address = stake.delegation.voter_pubkey;
 
@@ -1339,10 +1347,10 @@ impl Processor {
         }
 
         let stake_space = std::mem::size_of::<stake::state::StakeState>();
-        let stake_minimum_delegation = stake::tools::get_minimum_delegation()?;
         let stake_rent = rent.minimum_balance(stake_space);
-        let current_minimum_lamports =
-            stake_rent.saturating_add(minimum_delegation(stake_minimum_delegation));
+
+        let stake_minimum_delegation = stake::tools::get_minimum_delegation()?;
+        let current_minimum_lamports = minimum_delegation(stake_minimum_delegation);
         if lamports < current_minimum_lamports {
             msg!(
                 "Need at least {} lamports for transient stake to meet minimum delegation and rent-exempt requirements, {} provided",
@@ -1366,7 +1374,7 @@ impl Processor {
             return Err(ProgramError::InsufficientFunds);
         }
 
-        let source_stake_account_info =
+        let (source_stake_account_info, split_lamports) =
             if let Some((ephemeral_stake_seed, ephemeral_stake_account_info)) =
                 maybe_ephemeral_stake_seed.zip(maybe_ephemeral_stake_account_info)
             {
@@ -1388,6 +1396,23 @@ impl Processor {
                     stake_space,
                 )?;
 
+                // withdraw rent-exempt reserve for ephemeral account
+                if let Some(reserve_stake_info) = maybe_reserve_stake_info {
+                    let stake_history_info =
+                        maybe_stake_history_info.ok_or(StakePoolError::MissingRequiredSysvar)?;
+                    Self::stake_withdraw(
+                        stake_pool_info.key,
+                        reserve_stake_info.clone(),
+                        withdraw_authority_info.clone(),
+                        AUTHORITY_WITHDRAW,
+                        stake_pool.stake_withdraw_bump_seed,
+                        ephemeral_stake_account_info.clone(),
+                        clock_info.clone(),
+                        stake_history_info.clone(),
+                        stake_rent,
+                    )?;
+                }
+
                 // split into ephemeral stake account
                 Self::stake_split(
                     stake_pool_info.key,
@@ -1408,11 +1433,16 @@ impl Processor {
                     stake_pool.stake_withdraw_bump_seed,
                 )?;
 
-                ephemeral_stake_account_info
+                (
+                    ephemeral_stake_account_info,
+                    lamports
+                        .checked_add(stake_rent)
+                        .ok_or(StakePoolError::CalculationFailure)?,
+                )
             } else {
                 // if no ephemeral account is provided, split everything from the
                 // validator stake account, into the transient stake account
-                validator_stake_account_info
+                (validator_stake_account_info, lamports)
             };
 
         let transient_stake_bump_seed = check_transient_stake_address(
@@ -1459,7 +1489,7 @@ impl Processor {
                 withdraw_authority_info.clone(),
                 AUTHORITY_WITHDRAW,
                 stake_pool.stake_withdraw_bump_seed,
-                lamports,
+                split_lamports,
                 transient_stake_account_info.clone(),
             )?;
 
@@ -1482,9 +1512,11 @@ impl Processor {
                 .checked_sub(lamports)
                 .ok_or(StakePoolError::CalculationFailure)?
                 .into();
+        // `split_lamports` may be greater than `lamports` if the reserve stake
+        // funded the rent-exempt reserve
         validator_stake_info.transient_stake_lamports =
             u64::from(validator_stake_info.transient_stake_lamports)
-                .checked_add(lamports)
+                .checked_add(split_lamports)
                 .ok_or(StakePoolError::CalculationFailure)?
                 .into();
         validator_stake_info.transient_seed_suffix = transient_stake_seed.into();
@@ -3811,6 +3843,7 @@ impl Processor {
                     lamports,
                     transient_stake_seed,
                     None,
+                    false,
                 )
             }
             StakePoolInstruction::DecreaseAdditionalValidatorStake {
@@ -3825,6 +3858,7 @@ impl Processor {
                     lamports,
                     transient_stake_seed,
                     Some(ephemeral_stake_seed),
+                    true,
                 )
             }
             StakePoolInstruction::IncreaseValidatorStake {
@@ -4038,6 +4072,7 @@ impl PrintProgramError for StakePoolError {
             StakePoolError::ExceededSlippage => msg!("Error: instruction exceeds desired slippage limit"),
             StakePoolError::IncorrectMintDecimals => msg!("Error: Provided mint does not have 9 decimals to match SOL"),
             StakePoolError::ReserveDepleted => msg!("Error: Pool reserve does not have enough lamports to fund rent-exempt reserve in split destination. Deposit more SOL in reserve, or pre-fund split destination with the rent-exempt reserve for a stake account."),
+            StakePoolError::MissingRequiredSysvar => msg!("Missing required sysvar account"),
         }
     }
 }

--- a/stake-pool/program/src/processor.rs
+++ b/stake-pool/program/src/processor.rs
@@ -1402,6 +1402,9 @@ impl Processor {
                         maybe_stake_history_info.ok_or(StakePoolError::MissingRequiredSysvar)?;
                     let required_lamports_for_rent_exemption =
                         stake_rent.saturating_sub(ephemeral_stake_account_info.lamports());
+                    if required_lamports_for_rent_exemption >= reserve_stake_info.lamports() {
+                        return Err(StakePoolError::ReserveDepleted.into());
+                    }
                     if required_lamports_for_rent_exemption > 0 {
                         Self::stake_withdraw(
                             stake_pool_info.key,

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -1668,6 +1668,7 @@ impl StakePoolAccounts {
             &self.staker.pubkey(),
             &self.withdraw_authority,
             &self.validator_list.pubkey(),
+            &self.reserve_stake.pubkey(),
             validator_stake,
             ephemeral_stake,
             transient_stake,


### PR DESCRIPTION
#### Problem

We should fund the rent-exempt reserve for the transient stake account from the stake pool reserve during decrease.

#### Solution

To start with, require the reserve during `decrease_additional_validator_stake`, and then withdraw the rent-exemption from the reserve during processing.

The next step after this is to create a new instruction for a normal decrease without an ephemeral stake account. Or we could deprecate the old one and force people to always use this one.