### PR TITLE
token-cli: Bump to 3.1.1 for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7050,7 +7050,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-cli"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "assert_cmd",
  "clap 2.34.0",

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://spl.solana.com/token"
 license = "Apache-2.0"
 name = "spl-token-cli"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "3.1.0"
+version = "3.1.1"
 
 [build-dependencies]
 walkdir = "2"


### PR DESCRIPTION
#### Problem

There have been a couple of fixes since 3.1.0, but they're not accessible to people using `cargo install` or the solana releases.

#### Solution

Bump the version to publish a new release!