### PR TITLE
stake-pool: add new version of `DecreaseValidatorStake` to use reserve, add compatibility with master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6886,6 +6886,7 @@ name = "spl-stake-pool"
 version = "0.7.0"
 dependencies = [
  "arrayref",
+ "assert_matches",
  "bincode",
  "borsh 0.10.3",
  "bytemuck",

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -28,6 +28,7 @@ thiserror = "1.0"
 bincode = "1.3.1"
 
 [dev-dependencies]
+assert_matches = "1.5.0"
 proptest = "1.2"
 solana-program-test = "1.16.13"
 solana-sdk = "1.16.13"

--- a/stake-pool/program/tests/decrease.rs
+++ b/stake-pool/program/tests/decrease.rs
@@ -149,11 +149,7 @@ async fn success(instruction_type: DecreaseInstruction) {
     .await;
     let transient_stake_state =
         deserialize::<stake::state::StakeState>(&transient_stake_account.data).unwrap();
-    let transient_lamports = if instruction_type == DecreaseInstruction::Deprecated {
-        decrease_lamports
-    } else {
-        decrease_lamports + stake_rent
-    };
+    let transient_lamports = decrease_lamports + stake_rent;
     assert_eq!(transient_stake_account.lamports, transient_lamports);
     let reserve_lamports = if instruction_type == DecreaseInstruction::Deprecated {
         reserve_lamports

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -2600,6 +2600,7 @@ pub fn add_token_account(
 
 pub async fn setup_for_withdraw(
     token_program_id: Pubkey,
+    reserve_lamports: u64,
 ) -> (
     ProgramTestContext,
     StakePoolAccounts,
@@ -2616,7 +2617,7 @@ pub async fn setup_for_withdraw(
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            MINIMUM_RESERVE_LAMPORTS,
+            reserve_lamports,
         )
         .await
         .unwrap();

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -1614,7 +1614,7 @@ impl StakePoolAccounts {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub async fn decrease_validator_stake(
+    pub async fn decrease_validator_stake_deprecated(
         &self,
         banks_client: &mut BanksClient,
         payer: &Keypair,
@@ -1624,12 +1624,50 @@ impl StakePoolAccounts {
         lamports: u64,
         transient_stake_seed: u64,
     ) -> Option<TransportError> {
+        #[allow(deprecated)]
         let mut instructions = vec![instruction::decrease_validator_stake(
             &id(),
             &self.stake_pool.pubkey(),
             &self.staker.pubkey(),
             &self.withdraw_authority,
             &self.validator_list.pubkey(),
+            validator_stake,
+            transient_stake,
+            lamports,
+            transient_stake_seed,
+        )];
+        self.maybe_add_compute_budget_instruction(&mut instructions);
+        let transaction = Transaction::new_signed_with_payer(
+            &instructions,
+            Some(&payer.pubkey()),
+            &[payer, &self.staker],
+            *recent_blockhash,
+        );
+        banks_client
+            .process_transaction(transaction)
+            .await
+            .map_err(|e| e.into())
+            .err()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn decrease_validator_stake_with_reserve(
+        &self,
+        banks_client: &mut BanksClient,
+        payer: &Keypair,
+        recent_blockhash: &Hash,
+        validator_stake: &Pubkey,
+        transient_stake: &Pubkey,
+        lamports: u64,
+        transient_stake_seed: u64,
+    ) -> Option<TransportError> {
+        let mut instructions = vec![instruction::decrease_validator_stake_with_reserve(
+            &id(),
+            &self.stake_pool.pubkey(),
+            &self.staker.pubkey(),
+            &self.withdraw_authority,
+            &self.validator_list.pubkey(),
+            &self.reserve_stake.pubkey(),
             validator_stake,
             transient_stake,
             lamports,
@@ -1700,39 +1738,56 @@ impl StakePoolAccounts {
         transient_stake: &Pubkey,
         lamports: u64,
         transient_stake_seed: u64,
-        use_additional_instruction: bool,
+        instruction_type: DecreaseInstruction,
     ) -> Option<TransportError> {
-        if use_additional_instruction {
-            let ephemeral_stake_seed = 0;
-            let ephemeral_stake = find_ephemeral_stake_program_address(
-                &id(),
-                &self.stake_pool.pubkey(),
-                ephemeral_stake_seed,
-            )
-            .0;
-            self.decrease_additional_validator_stake(
-                banks_client,
-                payer,
-                recent_blockhash,
-                validator_stake,
-                &ephemeral_stake,
-                transient_stake,
-                lamports,
-                transient_stake_seed,
-                ephemeral_stake_seed,
-            )
-            .await
-        } else {
-            self.decrease_validator_stake(
-                banks_client,
-                payer,
-                recent_blockhash,
-                validator_stake,
-                transient_stake,
-                lamports,
-                transient_stake_seed,
-            )
-            .await
+        match instruction_type {
+            DecreaseInstruction::Additional => {
+                let ephemeral_stake_seed = 0;
+                let ephemeral_stake = find_ephemeral_stake_program_address(
+                    &id(),
+                    &self.stake_pool.pubkey(),
+                    ephemeral_stake_seed,
+                )
+                .0;
+                self.decrease_additional_validator_stake(
+                    banks_client,
+                    payer,
+                    recent_blockhash,
+                    validator_stake,
+                    &ephemeral_stake,
+                    transient_stake,
+                    lamports,
+                    transient_stake_seed,
+                    ephemeral_stake_seed,
+                )
+                .await
+            }
+            DecreaseInstruction::Reserve => {
+                self.decrease_validator_stake_with_reserve(
+                    banks_client,
+                    payer,
+                    recent_blockhash,
+                    validator_stake,
+                    transient_stake,
+                    lamports,
+                    transient_stake_seed,
+                )
+                .await
+            }
+            DecreaseInstruction::Deprecated =>
+            {
+                #[allow(deprecated)]
+                self.decrease_validator_stake_deprecated(
+                    banks_client,
+                    payer,
+                    recent_blockhash,
+                    validator_stake,
+                    transient_stake,
+                    lamports,
+                    transient_stake_seed,
+                )
+                .await
+            }
         }
     }
 
@@ -2628,4 +2683,11 @@ pub async fn setup_for_withdraw(
         user_stake_recipient,
         tokens_to_withdraw,
     )
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum DecreaseInstruction {
+    Additional,
+    Reserve,
+    Deprecated,
 }

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -1625,17 +1625,24 @@ impl StakePoolAccounts {
         transient_stake_seed: u64,
     ) -> Option<TransportError> {
         #[allow(deprecated)]
-        let mut instructions = vec![instruction::decrease_validator_stake(
-            &id(),
-            &self.stake_pool.pubkey(),
-            &self.staker.pubkey(),
-            &self.withdraw_authority,
-            &self.validator_list.pubkey(),
-            validator_stake,
-            transient_stake,
-            lamports,
-            transient_stake_seed,
-        )];
+        let mut instructions = vec![
+            system_instruction::transfer(
+                &payer.pubkey(),
+                transient_stake,
+                STAKE_ACCOUNT_RENT_EXEMPTION,
+            ),
+            instruction::decrease_validator_stake(
+                &id(),
+                &self.stake_pool.pubkey(),
+                &self.staker.pubkey(),
+                &self.withdraw_authority,
+                &self.validator_list.pubkey(),
+                validator_stake,
+                transient_stake,
+                lamports,
+                transient_stake_seed,
+            ),
+        ];
         self.maybe_add_compute_budget_instruction(&mut instructions);
         let transaction = Transaction::new_signed_with_payer(
             &instructions,

--- a/stake-pool/program/tests/increase.rs
+++ b/stake-pool/program/tests/increase.rs
@@ -561,7 +561,7 @@ async fn fail_additional_with_decreasing() {
             &validator_stake.transient_stake_account,
             current_minimum_delegation + stake_rent,
             validator_stake.transient_stake_seed,
-            DecreaseInstruction::Deprecated,
+            DecreaseInstruction::Reserve,
         )
         .await;
     assert!(error.is_none(), "{:?}", error);

--- a/stake-pool/program/tests/increase.rs
+++ b/stake-pool/program/tests/increase.rs
@@ -553,7 +553,7 @@ async fn fail_additional_with_decreasing() {
         .await;
 
     let error = stake_pool_accounts
-        .decrease_validator_stake(
+        .decrease_validator_stake_either(
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
@@ -561,6 +561,7 @@ async fn fail_additional_with_decreasing() {
             &validator_stake.transient_stake_account,
             current_minimum_delegation + stake_rent,
             validator_stake.transient_stake_seed,
+            DecreaseInstruction::Deprecated,
         )
         .await;
     assert!(error.is_none(), "{:?}", error);

--- a/stake-pool/program/tests/redelegate.rs
+++ b/stake-pool/program/tests/redelegate.rs
@@ -659,7 +659,7 @@ async fn fail_with_decreasing_stake() {
             &destination_validator_stake.transient_stake_account,
             minimum_decrease_lamports,
             destination_validator_stake.transient_stake_seed,
-            DecreaseInstruction::Deprecated,
+            DecreaseInstruction::Reserve,
         )
         .await;
     assert!(error.is_none(), "{:?}", error);

--- a/stake-pool/program/tests/redelegate.rs
+++ b/stake-pool/program/tests/redelegate.rs
@@ -651,7 +651,7 @@ async fn fail_with_decreasing_stake() {
         .unwrap();
 
     let error = stake_pool_accounts
-        .decrease_validator_stake(
+        .decrease_validator_stake_either(
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
@@ -659,6 +659,7 @@ async fn fail_with_decreasing_stake() {
             &destination_validator_stake.transient_stake_account,
             minimum_decrease_lamports,
             destination_validator_stake.transient_stake_seed,
+            DecreaseInstruction::Deprecated,
         )
         .await;
     assert!(error.is_none(), "{:?}", error);

--- a/stake-pool/program/tests/update_validator_list_balance.rs
+++ b/stake-pool/program/tests/update_validator_list_balance.rs
@@ -279,7 +279,7 @@ async fn merge_into_reserve() {
     println!("Decrease from all validators");
     for stake_account in &stake_accounts {
         let error = stake_pool_accounts
-            .decrease_validator_stake(
+            .decrease_validator_stake_either(
                 &mut context.banks_client,
                 &context.payer,
                 &last_blockhash,
@@ -287,6 +287,7 @@ async fn merge_into_reserve() {
                 &stake_account.transient_stake_account,
                 lamports,
                 stake_account.transient_stake_seed,
+                DecreaseInstruction::Deprecated,
             )
             .await;
         assert!(error.is_none(), "{:?}", error);
@@ -554,7 +555,7 @@ async fn merge_transient_stake_after_remove() {
     // Decrease and remove all validators
     for stake_account in &stake_accounts {
         let error = stake_pool_accounts
-            .decrease_validator_stake(
+            .decrease_validator_stake_either(
                 &mut context.banks_client,
                 &context.payer,
                 &last_blockhash,
@@ -562,6 +563,7 @@ async fn merge_transient_stake_after_remove() {
                 &stake_account.transient_stake_account,
                 deactivated_lamports,
                 stake_account.transient_stake_seed,
+                DecreaseInstruction::Deprecated,
             )
             .await;
         assert!(error.is_none(), "{:?}", error);

--- a/stake-pool/program/tests/update_validator_list_balance.rs
+++ b/stake-pool/program/tests/update_validator_list_balance.rs
@@ -287,7 +287,7 @@ async fn merge_into_reserve() {
                 &stake_account.transient_stake_account,
                 lamports,
                 stake_account.transient_stake_seed,
-                DecreaseInstruction::Deprecated,
+                DecreaseInstruction::Reserve,
             )
             .await;
         assert!(error.is_none(), "{:?}", error);
@@ -563,7 +563,7 @@ async fn merge_transient_stake_after_remove() {
                 &stake_account.transient_stake_account,
                 deactivated_lamports,
                 stake_account.transient_stake_seed,
-                DecreaseInstruction::Deprecated,
+                DecreaseInstruction::Reserve,
             )
             .await;
         assert!(error.is_none(), "{:?}", error);
@@ -618,7 +618,7 @@ async fn merge_transient_stake_after_remove() {
     );
     assert_eq!(
         u64::from(validator_list.validators[0].transient_stake_lamports),
-        deactivated_lamports
+        deactivated_lamports + stake_rent
     );
 
     // Update with merge, status should be ReadyForRemoval and no lamports

--- a/stake-pool/program/tests/update_validator_list_balance_hijack.rs
+++ b/stake-pool/program/tests/update_validator_list_balance_hijack.rs
@@ -220,7 +220,7 @@ async fn check_ignored_hijacked_transient_stake(
     println!("Decrease from all validators");
     let stake_account = &stake_accounts[0];
     let error = stake_pool_accounts
-        .decrease_validator_stake(
+        .decrease_validator_stake_either(
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
@@ -228,6 +228,7 @@ async fn check_ignored_hijacked_transient_stake(
             &stake_account.transient_stake_account,
             lamports,
             stake_account.transient_stake_seed,
+            DecreaseInstruction::Deprecated,
         )
         .await;
     assert!(error.is_none(), "{:?}", error);
@@ -384,7 +385,7 @@ async fn check_ignored_hijacked_validator_stake(
 
     let stake_account = &stake_accounts[0];
     let error = stake_pool_accounts
-        .decrease_validator_stake(
+        .decrease_validator_stake_either(
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
@@ -392,6 +393,7 @@ async fn check_ignored_hijacked_validator_stake(
             &stake_account.transient_stake_account,
             lamports,
             stake_account.transient_stake_seed,
+            DecreaseInstruction::Deprecated,
         )
         .await;
     assert!(error.is_none(), "{:?}", error);

--- a/stake-pool/program/tests/update_validator_list_balance_hijack.rs
+++ b/stake-pool/program/tests/update_validator_list_balance_hijack.rs
@@ -228,7 +228,7 @@ async fn check_ignored_hijacked_transient_stake(
             &stake_account.transient_stake_account,
             lamports,
             stake_account.transient_stake_seed,
-            DecreaseInstruction::Deprecated,
+            DecreaseInstruction::Reserve,
         )
         .await;
     assert!(error.is_none(), "{:?}", error);
@@ -393,7 +393,7 @@ async fn check_ignored_hijacked_validator_stake(
             &stake_account.transient_stake_account,
             lamports,
             stake_account.transient_stake_seed,
-            DecreaseInstruction::Deprecated,
+            DecreaseInstruction::Reserve,
         )
         .await;
     assert!(error.is_none(), "{:?}", error);

--- a/stake-pool/program/tests/vsa_remove.rs
+++ b/stake-pool/program/tests/vsa_remove.rs
@@ -455,7 +455,7 @@ async fn success_with_deactivating_transient_stake() {
 
     // increase the validator stake
     let error = stake_pool_accounts
-        .decrease_validator_stake(
+        .decrease_validator_stake_either(
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
@@ -463,6 +463,7 @@ async fn success_with_deactivating_transient_stake() {
             &validator_stake.transient_stake_account,
             TEST_STAKE_AMOUNT + stake_rent,
             validator_stake.transient_stake_seed,
+            DecreaseInstruction::Deprecated,
         )
         .await;
     assert!(error.is_none(), "{:?}", error);
@@ -705,7 +706,7 @@ async fn success_with_hijacked_transient_account() {
 
     // decrease
     let error = stake_pool_accounts
-        .decrease_validator_stake(
+        .decrease_validator_stake_either(
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
@@ -713,6 +714,7 @@ async fn success_with_hijacked_transient_account() {
             &validator_stake.transient_stake_account,
             increase_amount,
             validator_stake.transient_stake_seed,
+            DecreaseInstruction::Deprecated,
         )
         .await;
     assert!(error.is_none(), "{:?}", error);

--- a/stake-pool/program/tests/vsa_remove.rs
+++ b/stake-pool/program/tests/vsa_remove.rs
@@ -463,7 +463,7 @@ async fn success_with_deactivating_transient_stake() {
             &validator_stake.transient_stake_account,
             TEST_STAKE_AMOUNT + stake_rent,
             validator_stake.transient_stake_seed,
-            DecreaseInstruction::Deprecated,
+            DecreaseInstruction::Reserve,
         )
         .await;
     assert!(error.is_none(), "{:?}", error);
@@ -547,7 +547,7 @@ async fn success_with_deactivating_transient_stake() {
             vote_account_address: validator_stake.vote.pubkey(),
             last_update_epoch: 0.into(),
             active_stake_lamports: (stake_rent + current_minimum_delegation).into(),
-            transient_stake_lamports: (TEST_STAKE_AMOUNT + stake_rent).into(),
+            transient_stake_lamports: (TEST_STAKE_AMOUNT + stake_rent * 2).into(),
             transient_seed_suffix: validator_stake.transient_stake_seed.into(),
             unused: 0.into(),
             validator_seed_suffix: validator_stake
@@ -714,7 +714,7 @@ async fn success_with_hijacked_transient_account() {
             &validator_stake.transient_stake_account,
             increase_amount,
             validator_stake.transient_stake_seed,
-            DecreaseInstruction::Deprecated,
+            DecreaseInstruction::Reserve,
         )
         .await;
     assert!(error.is_none(), "{:?}", error);

--- a/stake-pool/program/tests/withdraw.rs
+++ b/stake-pool/program/tests/withdraw.rs
@@ -49,7 +49,7 @@ async fn _success(token_program_id: Pubkey, test_type: SuccessTestType) {
         user_transfer_authority,
         user_stake_recipient,
         tokens_to_withdraw,
-    ) = setup_for_withdraw(token_program_id).await;
+    ) = setup_for_withdraw(token_program_id, 0).await;
 
     // Save stake pool state before withdrawal
     let stake_pool_before = get_account(
@@ -268,7 +268,7 @@ async fn fail_with_wrong_stake_program() {
         user_transfer_authority,
         user_stake_recipient,
         tokens_to_burn,
-    ) = setup_for_withdraw(spl_token::id()).await;
+    ) = setup_for_withdraw(spl_token::id(), 0).await;
 
     let new_authority = Pubkey::new_unique();
     let wrong_stake_program = Pubkey::new_unique();
@@ -328,7 +328,7 @@ async fn fail_with_wrong_withdraw_authority() {
         user_transfer_authority,
         user_stake_recipient,
         tokens_to_burn,
-    ) = setup_for_withdraw(spl_token::id()).await;
+    ) = setup_for_withdraw(spl_token::id(), 0).await;
 
     let new_authority = Pubkey::new_unique();
     stake_pool_accounts.withdraw_authority = Keypair::new().pubkey();
@@ -370,7 +370,7 @@ async fn fail_with_wrong_token_program_id() {
         user_transfer_authority,
         user_stake_recipient,
         tokens_to_burn,
-    ) = setup_for_withdraw(spl_token::id()).await;
+    ) = setup_for_withdraw(spl_token::id(), 0).await;
 
     let new_authority = Pubkey::new_unique();
     let wrong_token_program = Keypair::new();
@@ -421,7 +421,7 @@ async fn fail_with_wrong_validator_list() {
         user_transfer_authority,
         user_stake_recipient,
         tokens_to_burn,
-    ) = setup_for_withdraw(spl_token::id()).await;
+    ) = setup_for_withdraw(spl_token::id(), 0).await;
 
     let new_authority = Pubkey::new_unique();
     stake_pool_accounts.validator_list = Keypair::new();
@@ -465,7 +465,7 @@ async fn fail_with_unknown_validator() {
         user_transfer_authority,
         user_stake_recipient,
         tokens_to_withdraw,
-    ) = setup_for_withdraw(spl_token::id()).await;
+    ) = setup_for_withdraw(spl_token::id(), 0).await;
 
     let unknown_stake = create_unknown_validator_stake(
         &mut context.banks_client,
@@ -512,7 +512,7 @@ async fn fail_double_withdraw_to_the_same_account() {
         user_transfer_authority,
         user_stake_recipient,
         tokens_to_burn,
-    ) = setup_for_withdraw(spl_token::id()).await;
+    ) = setup_for_withdraw(spl_token::id(), 0).await;
 
     let new_authority = Pubkey::new_unique();
     let error = stake_pool_accounts
@@ -578,7 +578,7 @@ async fn fail_without_token_approval() {
         user_transfer_authority,
         user_stake_recipient,
         tokens_to_burn,
-    ) = setup_for_withdraw(spl_token::id()).await;
+    ) = setup_for_withdraw(spl_token::id(), 0).await;
 
     revoke_tokens(
         &mut context.banks_client,
@@ -630,7 +630,7 @@ async fn fail_with_not_enough_tokens() {
         user_transfer_authority,
         user_stake_recipient,
         tokens_to_burn,
-    ) = setup_for_withdraw(spl_token::id()).await;
+    ) = setup_for_withdraw(spl_token::id(), 0).await;
 
     let last_blockhash = context
         .banks_client
@@ -773,7 +773,7 @@ async fn success_with_slippage(token_program_id: Pubkey) {
         user_transfer_authority,
         user_stake_recipient,
         tokens_to_withdraw,
-    ) = setup_for_withdraw(token_program_id).await;
+    ) = setup_for_withdraw(token_program_id, 0).await;
 
     // Save user token balance
     let user_token_balance_before = get_token_balance(

--- a/stake-pool/program/tests/withdraw_edge_cases.rs
+++ b/stake-pool/program/tests/withdraw_edge_cases.rs
@@ -25,7 +25,7 @@ async fn fail_remove_validator() {
         user_transfer_authority,
         user_stake_recipient,
         _,
-    ) = setup_for_withdraw(spl_token::id()).await;
+    ) = setup_for_withdraw(spl_token::id(), STAKE_ACCOUNT_RENT_EXEMPTION).await;
 
     // decrease a little stake, not all
     let error = stake_pool_accounts
@@ -101,7 +101,7 @@ async fn success_remove_validator(multiple: u64) {
         user_transfer_authority,
         user_stake_recipient,
         _,
-    ) = setup_for_withdraw(spl_token::id()).await;
+    ) = setup_for_withdraw(spl_token::id(), STAKE_ACCOUNT_RENT_EXEMPTION).await;
 
     // make pool tokens very valuable, so it isn't possible to exactly get down to the minimum
     transfer(
@@ -241,7 +241,7 @@ async fn fail_with_reserve() {
         user_transfer_authority,
         user_stake_recipient,
         tokens_to_burn,
-    ) = setup_for_withdraw(spl_token::id()).await;
+    ) = setup_for_withdraw(spl_token::id(), STAKE_ACCOUNT_RENT_EXEMPTION).await;
 
     // decrease a little stake, not all
     let error = stake_pool_accounts
@@ -309,7 +309,7 @@ async fn success_with_reserve() {
         user_transfer_authority,
         user_stake_recipient,
         _,
-    ) = setup_for_withdraw(spl_token::id()).await;
+    ) = setup_for_withdraw(spl_token::id(), STAKE_ACCOUNT_RENT_EXEMPTION).await;
 
     let rent = context.banks_client.get_rent().await.unwrap();
     let stake_rent = rent.minimum_balance(std::mem::size_of::<stake::state::StakeState>());
@@ -403,7 +403,7 @@ async fn success_with_reserve() {
     let stake_state = deserialize::<stake::state::StakeState>(&reserve_stake_account.data).unwrap();
     let meta = stake_state.meta().unwrap();
     assert_eq!(
-        meta.rent_exempt_reserve + withdrawal_fee + deposit_fee,
+        meta.rent_exempt_reserve + withdrawal_fee + deposit_fee + stake_rent,
         reserve_stake_account.lamports
     );
 
@@ -426,7 +426,7 @@ async fn success_with_empty_preferred_withdraw() {
         user_transfer_authority,
         user_stake_recipient,
         tokens_to_burn,
-    ) = setup_for_withdraw(spl_token::id()).await;
+    ) = setup_for_withdraw(spl_token::id(), 0).await;
 
     let preferred_validator = simple_add_validator_to_pool(
         &mut context.banks_client,
@@ -475,7 +475,7 @@ async fn success_and_fail_with_preferred_withdraw() {
         user_transfer_authority,
         user_stake_recipient,
         tokens_to_burn,
-    ) = setup_for_withdraw(spl_token::id()).await;
+    ) = setup_for_withdraw(spl_token::id(), 0).await;
 
     let last_blockhash = context
         .banks_client
@@ -571,7 +571,7 @@ async fn fail_withdraw_from_transient() {
         user_transfer_authority,
         user_stake_recipient,
         tokens_to_withdraw,
-    ) = setup_for_withdraw(spl_token::id()).await;
+    ) = setup_for_withdraw(spl_token::id(), STAKE_ACCOUNT_RENT_EXEMPTION).await;
 
     let last_blockhash = context
         .banks_client
@@ -659,7 +659,7 @@ async fn success_withdraw_from_transient() {
         user_transfer_authority,
         user_stake_recipient,
         tokens_to_withdraw,
-    ) = setup_for_withdraw(spl_token::id()).await;
+    ) = setup_for_withdraw(spl_token::id(), STAKE_ACCOUNT_RENT_EXEMPTION).await;
 
     let last_blockhash = context
         .banks_client
@@ -740,7 +740,7 @@ async fn success_with_small_preferred_withdraw() {
         user_transfer_authority,
         user_stake_recipient,
         tokens_to_burn,
-    ) = setup_for_withdraw(spl_token::id()).await;
+    ) = setup_for_withdraw(spl_token::id(), 0).await;
 
     let last_blockhash = context
         .banks_client

--- a/stake-pool/program/tests/withdraw_edge_cases.rs
+++ b/stake-pool/program/tests/withdraw_edge_cases.rs
@@ -37,7 +37,7 @@ async fn fail_remove_validator() {
             &validator_stake.transient_stake_account,
             deposit_info.stake_lamports / 2,
             validator_stake.transient_stake_seed,
-            DecreaseInstruction::Deprecated,
+            DecreaseInstruction::Reserve,
         )
         .await;
     assert!(error.is_none(), "{:?}", error);
@@ -47,7 +47,7 @@ async fn fail_remove_validator() {
     context.warp_to_slot(first_normal_slot + 1).unwrap();
 
     // update to merge deactivated stake into reserve
-    stake_pool_accounts
+    let error = stake_pool_accounts
         .update_all(
             &mut context.banks_client,
             &context.payer,
@@ -56,6 +56,7 @@ async fn fail_remove_validator() {
             false,
         )
         .await;
+    assert!(error.is_none(), "{:?}", error);
 
     // Withdraw entire account, fail because some stake left
     let validator_stake_account =
@@ -138,7 +139,7 @@ async fn success_remove_validator(multiple: u64) {
             &validator_stake.transient_stake_account,
             deposit_info.stake_lamports + stake_rent - lamports_per_pool_token,
             validator_stake.transient_stake_seed,
-            DecreaseInstruction::Deprecated,
+            DecreaseInstruction::Reserve,
         )
         .await;
     assert!(error.is_none(), "{:?}", error);
@@ -252,7 +253,7 @@ async fn fail_with_reserve() {
             &validator_stake.transient_stake_account,
             deposit_info.stake_lamports / 2,
             validator_stake.transient_stake_seed,
-            DecreaseInstruction::Deprecated,
+            DecreaseInstruction::Reserve,
         )
         .await;
     assert!(error.is_none(), "{:?}", error);
@@ -323,7 +324,7 @@ async fn success_with_reserve() {
             &validator_stake.transient_stake_account,
             deposit_info.stake_lamports + stake_rent,
             validator_stake.transient_stake_seed,
-            DecreaseInstruction::Deprecated,
+            DecreaseInstruction::Reserve,
         )
         .await;
     assert!(error.is_none(), "{:?}", error);
@@ -617,7 +618,7 @@ async fn fail_withdraw_from_transient() {
             &validator_stake_account.transient_stake_account,
             deposit_info.stake_lamports + stake_rent - 2,
             validator_stake_account.transient_stake_seed,
-            DecreaseInstruction::Deprecated,
+            DecreaseInstruction::Reserve,
         )
         .await;
     assert!(error.is_none(), "{:?}", error);
@@ -705,7 +706,7 @@ async fn success_withdraw_from_transient() {
             &validator_stake_account.transient_stake_account,
             deposit_info.stake_lamports + stake_rent,
             validator_stake_account.transient_stake_seed,
-            DecreaseInstruction::Deprecated,
+            DecreaseInstruction::Reserve,
         )
         .await;
     assert!(error.is_none(), "{:?}", error);
@@ -820,7 +821,7 @@ async fn success_with_small_preferred_withdraw() {
             &preferred_validator.transient_stake_account,
             minimum_lamports,
             preferred_validator.transient_stake_seed,
-            DecreaseInstruction::Deprecated,
+            DecreaseInstruction::Reserve,
         )
         .await;
     assert!(error.is_none(), "{:?}", error);

--- a/stake-pool/program/tests/withdraw_edge_cases.rs
+++ b/stake-pool/program/tests/withdraw_edge_cases.rs
@@ -29,7 +29,7 @@ async fn fail_remove_validator() {
 
     // decrease a little stake, not all
     let error = stake_pool_accounts
-        .decrease_validator_stake(
+        .decrease_validator_stake_either(
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
@@ -37,6 +37,7 @@ async fn fail_remove_validator() {
             &validator_stake.transient_stake_account,
             deposit_info.stake_lamports / 2,
             validator_stake.transient_stake_seed,
+            DecreaseInstruction::Deprecated,
         )
         .await;
     assert!(error.is_none(), "{:?}", error);
@@ -129,7 +130,7 @@ async fn success_remove_validator(multiple: u64) {
 
     // decrease all of stake except for lamports_per_pool_token lamports, must be withdrawable
     let error = stake_pool_accounts
-        .decrease_validator_stake(
+        .decrease_validator_stake_either(
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
@@ -137,6 +138,7 @@ async fn success_remove_validator(multiple: u64) {
             &validator_stake.transient_stake_account,
             deposit_info.stake_lamports + stake_rent - lamports_per_pool_token,
             validator_stake.transient_stake_seed,
+            DecreaseInstruction::Deprecated,
         )
         .await;
     assert!(error.is_none(), "{:?}", error);
@@ -242,7 +244,7 @@ async fn fail_with_reserve() {
 
     // decrease a little stake, not all
     let error = stake_pool_accounts
-        .decrease_validator_stake(
+        .decrease_validator_stake_either(
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
@@ -250,6 +252,7 @@ async fn fail_with_reserve() {
             &validator_stake.transient_stake_account,
             deposit_info.stake_lamports / 2,
             validator_stake.transient_stake_seed,
+            DecreaseInstruction::Deprecated,
         )
         .await;
     assert!(error.is_none(), "{:?}", error);
@@ -312,7 +315,7 @@ async fn success_with_reserve() {
 
     // decrease all of stake
     let error = stake_pool_accounts
-        .decrease_validator_stake(
+        .decrease_validator_stake_either(
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
@@ -320,6 +323,7 @@ async fn success_with_reserve() {
             &validator_stake.transient_stake_account,
             deposit_info.stake_lamports + stake_rent,
             validator_stake.transient_stake_seed,
+            DecreaseInstruction::Deprecated,
         )
         .await;
     assert!(error.is_none(), "{:?}", error);
@@ -605,7 +609,7 @@ async fn fail_withdraw_from_transient() {
 
     // decrease to minimum stake + 2 lamports
     let error = stake_pool_accounts
-        .decrease_validator_stake(
+        .decrease_validator_stake_either(
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
@@ -613,6 +617,7 @@ async fn fail_withdraw_from_transient() {
             &validator_stake_account.transient_stake_account,
             deposit_info.stake_lamports + stake_rent - 2,
             validator_stake_account.transient_stake_seed,
+            DecreaseInstruction::Deprecated,
         )
         .await;
     assert!(error.is_none(), "{:?}", error);
@@ -692,7 +697,7 @@ async fn success_withdraw_from_transient() {
 
     // decrease all of stake
     let error = stake_pool_accounts
-        .decrease_validator_stake(
+        .decrease_validator_stake_either(
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
@@ -700,6 +705,7 @@ async fn success_withdraw_from_transient() {
             &validator_stake_account.transient_stake_account,
             deposit_info.stake_lamports + stake_rent,
             validator_stake_account.transient_stake_seed,
+            DecreaseInstruction::Deprecated,
         )
         .await;
     assert!(error.is_none(), "{:?}", error);
@@ -806,7 +812,7 @@ async fn success_with_small_preferred_withdraw() {
 
     // decrease all stake except for 1 lamport
     let error = stake_pool_accounts
-        .decrease_validator_stake(
+        .decrease_validator_stake_either(
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
@@ -814,6 +820,7 @@ async fn success_with_small_preferred_withdraw() {
             &preferred_validator.transient_stake_account,
             minimum_lamports,
             preferred_validator.transient_stake_seed,
+            DecreaseInstruction::Deprecated,
         )
         .await;
     assert!(error.is_none(), "{:?}", error);

--- a/stake-pool/program/tests/withdraw_with_fee.rs
+++ b/stake-pool/program/tests/withdraw_with_fee.rs
@@ -22,7 +22,7 @@ async fn success_withdraw_all_fee_tokens() {
         user_transfer_authority,
         user_stake_recipient,
         tokens_to_withdraw,
-    ) = setup_for_withdraw(spl_token::id()).await;
+    ) = setup_for_withdraw(spl_token::id(), 0).await;
 
     let last_blockhash = context
         .banks_client
@@ -99,7 +99,7 @@ async fn success_empty_out_stake_with_fee() {
         user_transfer_authority,
         user_stake_recipient,
         tokens_to_withdraw,
-    ) = setup_for_withdraw(spl_token::id()).await;
+    ) = setup_for_withdraw(spl_token::id(), 0).await;
 
     let last_blockhash = context
         .banks_client


### PR DESCRIPTION
Note: this PR builds on #5288, starting with [b482537](https://github.com/solana-labs/solana-program-library/pull/5322/commits/b482537949e1dfcf03e2a0f17587fdb3f77a7a42)

#### Problem

To adapt stake pools to the upcoming changes in https://github.com/solana-labs/solana/pull/33295, stake pools need to pre-fund the rent-exempt reserve during splits in `DecreaseValidatorStake`.

#### Solution

The first commit [b482537](https://github.com/solana-labs/solana-program-library/pull/5322/commits/b482537949e1dfcf03e2a0f17587fdb3f77a7a42) is the meat of the change which adds a new instruction to use the reserve, deprecates the old one. And the rest of the commits fix the tests.

I tested this with #5285 against the monorepo master, and everything passes!