### PR TITLE
Access epoch_schedule by reference

### DIFF
--- a/stake-pool/program/tests/huge_pool.rs
+++ b/stake-pool/program/tests/huge_pool.rs
@@ -106,7 +106,7 @@ async fn setup(
     );
 
     let mut context = program_test.start_with_context().await;
-    let epoch_schedule = context.genesis_config().epoch_schedule;
+    let epoch_schedule = &context.genesis_config().epoch_schedule;
     let slot = epoch_schedule.first_normal_slot + epoch_schedule.slots_per_epoch + 1;
     context.warp_to_slot(slot).unwrap();
 


### PR DESCRIPTION
- https://github.com/solana-labs/solana/pull/32767 removes `Copy` from `EpochSchedule` and `Rent` because they are inconsistent with `CloneZeroed`
- A test in `huge_pool.rs` was `Copy`ing an `EpochSchedule`. Changed to just reference it.