### PR TITLE
token-cli: Support offline signing for update-metadata

### DIFF
--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -3174,6 +3174,8 @@ fn app<'a, 'b>(
                     .takes_value(true)
                     .help("Specify the metadata update authority keypair. Defaults to the client keypair.")
                 )
+                .nonce_args(true)
+                .offline_args(),
         )
         .subcommand(
             SubCommand::with_name(CommandName::CreateAccount.into())


### PR DESCRIPTION
#### Problem

Update-metadata doesn't support offline signing in the token CLI.

#### Solution

Thankfully it's pretty simple -- just add the offline args!

Fixes #5291