### PR TITLE
ci: Update quinn-proto to 0.9.5 for rustsec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3889,9 +3889,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31999cfc7927c4e212e60fd50934ab40e8e8bfd2d493d6095d2d306bc0764d9"
+checksum = "c956be1b23f4261676aed05a0046e204e8a6836e50203902683a718af0797989"
 dependencies = [
  "bytes",
  "rand 0.8.5",


### PR DESCRIPTION
#### Problem

Per the failed CI run at https://github.com/solana-labs/solana-program-library/actions/runs/6262299761/job/17004155266?pr=5326, quinn-proto 0.9.4 has a security advisory out.

#### Solution

Bump to quinn-proto 0.9.5