### PR TITLE
stake-pool-js: Add new decrease instruction 

### DIFF
--- a/stake-pool/js/src/index.ts
+++ b/stake-pool/js/src/index.ts
@@ -807,10 +807,11 @@ export async function decreaseValidatorStake(
     );
   } else {
     instructions.push(
-      StakePoolInstruction.decreaseValidatorStake({
+      StakePoolInstruction.decreaseValidatorStakeWithReserve({
         stakePool: stakePoolAddress,
         staker: stakePool.account.data.staker,
         validatorList: stakePool.account.data.validatorList,
+        reserveStake: stakePool.account.data.reserveStake,
         transientStakeSeed: transientStakeSeed.toNumber(),
         withdrawAuthority,
         validatorStake,

--- a/stake-pool/js/test/instructions.test.ts
+++ b/stake-pool/js/test/instructions.test.ts
@@ -347,7 +347,7 @@ describe('StakePoolProgram', () => {
         res.instructions[0].data,
       );
 
-      expect(decodedData.instruction).toBe(21);
+      expect(decodedData.instruction).toBe(22);
       expect(decodedData.lamports).toBe(data.lamports);
       expect(decodedData.sourceTransientStakeSeed).toBe(data.sourceTransientStakeSeed);
       expect(decodedData.destinationTransientStakeSeed).toBe(data.destinationTransientStakeSeed);


### PR DESCRIPTION
This builds on  #5322, so only the last commit matters.

#### Problem

#5322 introduces a new version of `DecreaseValidatorStake`, but it doesn't add it to the JS bindings.

#### Solution

Add the instruction