### PR TITLE
stake-pool-py: Add and use new decrease instruction

### DIFF
--- a/stake-pool/py/stake_pool/actions.py
+++ b/stake-pool/py/stake_pool/actions.py
@@ -569,17 +569,18 @@ async def decrease_validator_stake(
 
     txn = Transaction()
     txn.add(
-        sp.decrease_validator_stake(
-            sp.DecreaseValidatorStakeParams(
+        sp.decrease_validator_stake_with_reserve(
+            sp.DecreaseValidatorStakeWithReserveParams(
                 program_id=STAKE_POOL_PROGRAM_ID,
                 stake_pool=stake_pool_address,
                 staker=staker.public_key,
                 withdraw_authority=withdraw_authority,
                 validator_list=stake_pool.validator_list,
+                reserve_stake=stake_pool.reserve_stake,
                 validator_stake=validator_stake,
                 transient_stake=transient_stake,
                 clock_sysvar=SYSVAR_CLOCK_PUBKEY,
-                rent_sysvar=SYSVAR_RENT_PUBKEY,
+                stake_history_sysvar=SYSVAR_STAKE_HISTORY_PUBKEY,
                 system_program_id=sys.SYS_PROGRAM_ID,
                 stake_program_id=STAKE_PROGRAM_ID,
                 lamports=lamports,

--- a/stake-pool/py/tests/test_a_time_sensitive.py
+++ b/stake-pool/py/tests/test_a_time_sensitive.py
@@ -64,7 +64,7 @@ async def test_increase_decrease_this_is_very_slow(async_client, validators, pay
     data = resp['result']['value']['data']
     validator_list = ValidatorList.decode(data[0], data[1])
     for validator in validator_list.validators:
-        assert validator.transient_stake_lamports == decrease_amount
+        assert validator.transient_stake_lamports == decrease_amount + stake_rent_exemption
         assert validator.active_stake_lamports == increase_amount - decrease_amount + minimum_amount
 
     print("Waiting for epoch to roll over")

--- a/stake-pool/py/tests/test_bot_rebalance.py
+++ b/stake-pool/py/tests/test_bot_rebalance.py
@@ -54,10 +54,10 @@ async def test_rebalance_this_is_very_slow(async_client, validators, payer, stak
     max_in_reserve = total_lamports - minimum_amount * len(validators)
     await rebalance(ENDPOINT, stake_pool_address, payer, max_in_reserve / LAMPORTS_PER_SOL)
 
-    # should still only have minimum left + rent exemptions from increase
+    # should still only have minimum left
     resp = await async_client.get_account_info(stake_pool.reserve_stake, commitment=Confirmed)
     reserve_lamports = resp['result']['value']['lamports']
-    assert reserve_lamports == stake_rent_exemption * (1 + len(validator_list.validators)) + MINIMUM_RESERVE_LAMPORTS
+    assert reserve_lamports == stake_rent_exemption + MINIMUM_RESERVE_LAMPORTS
 
     # should all be decreasing now
     resp = await async_client.get_account_info(validator_list_address, commitment=Confirmed)
@@ -65,7 +65,7 @@ async def test_rebalance_this_is_very_slow(async_client, validators, payer, stak
     validator_list = ValidatorList.decode(data[0], data[1])
     for validator in validator_list.validators:
         assert validator.active_stake_lamports == minimum_amount
-        assert validator.transient_stake_lamports == max_in_reserve / len(validators) - stake_rent_exemption
+        assert validator.transient_stake_lamports == max_in_reserve / len(validators)
 
     # Test case 3: Do nothing
     print('Waiting for next epoch')


### PR DESCRIPTION
This builds on https://github.com/solana-labs/solana-program-library/pull/5322, so only the last commit matters.

#### Problem

https://github.com/solana-labs/solana-program-library/pull/5322 introduces a new version of `DecreaseValidatorStake`, but it doesn't add it to the python bindings.

#### Solution

Add the instruction and use it properly in tests