### PR TITLE
[token-cli] Add confidential transfer mint commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7058,6 +7058,7 @@ name = "spl-token-cli"
 version = "3.1.1"
 dependencies = [
  "assert_cmd",
+ "base64 0.21.4",
  "clap 2.34.0",
  "console",
  "serde",

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -12,6 +12,7 @@ version = "3.1.1"
 walkdir = "2"
 
 [dependencies]
+base64 = "0.21.4"
 clap = "2.33.3"
 console = "0.15.7"
 serde = "1.0.188"
@@ -26,12 +27,20 @@ solana-logger = "=1.16.13"
 solana-remote-wallet = "=1.16.13"
 solana-sdk = "=1.16.13"
 solana-transaction-status = "=1.16.13"
-spl-token = { version = "4.0", path="../program", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "0.9", path="../program-2022", features = [ "no-entrypoint" ] }
-spl-token-client = { version = "0.7", path="../client" }
-spl-token-metadata-interface = { version = "0.2", path="../../token-metadata/interface" }
-spl-associated-token-account = { version = "2.0", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
-spl-memo = { version = "4.0.0", path="../../memo/program", features = ["no-entrypoint"] }
+spl-token = { version = "4.0", path = "../program", features = [
+  "no-entrypoint",
+] }
+spl-token-2022 = { version = "0.9", path = "../program-2022", features = [
+  "no-entrypoint",
+] }
+spl-token-client = { version = "0.7", path = "../client" }
+spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }
+spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = [
+  "no-entrypoint",
+] }
+spl-memo = { version = "4.0.0", path = "../../memo/program", features = [
+  "no-entrypoint",
+] }
 strum = "0.25"
 strum_macros = "0.25"
 tokio = "1.14"

--- a/token/cli/src/encryption_keypair.rs
+++ b/token/cli/src/encryption_keypair.rs
@@ -1,0 +1,55 @@
+use {
+    base64::{prelude::BASE64_STANDARD, Engine},
+    clap::ArgMatches,
+    spl_token_2022::solana_zk_token_sdk::{
+        encryption::elgamal::{ElGamalKeypair, ElGamalPubkey},
+        zk_token_elgamal::pod::ElGamalPubkey as PodElGamalPubkey,
+    },
+};
+
+const ELGAMAL_PUBKEY_MAX_BASE64_LEN: usize = 44;
+
+pub(crate) fn elgamal_pubkey_or_none(
+    matches: &ArgMatches,
+    name: &str,
+) -> Result<Option<PodElGamalPubkey>, String> {
+    let arg_str = matches.value_of(name).unwrap();
+    if arg_str == "none" {
+        return Ok(None);
+    }
+    elgamal_pubkey_of(matches, name).map(|pubkey| Some(pubkey))
+}
+
+pub(crate) fn elgamal_pubkey_of(
+    matches: &ArgMatches,
+    name: &str,
+) -> Result<PodElGamalPubkey, String> {
+    if let Ok(keypair) = elgamal_keypair_of(matches, name) {
+        let elgamal_pubkey = (*keypair.pubkey()).into();
+        Ok(elgamal_pubkey)
+    } else {
+        let arg_str = matches.value_of(name).unwrap();
+        if let Some(pubkey) = elgamal_pubkey_from_str(arg_str) {
+            Ok(pubkey)
+        } else {
+            Err("failed to read ElGamal pubkey".to_string())
+        }
+    }
+}
+
+pub(crate) fn elgamal_keypair_of(
+    matches: &ArgMatches,
+    name: &str,
+) -> Result<ElGamalKeypair, String> {
+    let path = matches.value_of(name).unwrap();
+    ElGamalKeypair::read_json_file(path).map_err(|e| e.to_string())
+}
+
+fn elgamal_pubkey_from_str(s: &str) -> Option<PodElGamalPubkey> {
+    if s.len() > ELGAMAL_PUBKEY_MAX_BASE64_LEN {
+        return None;
+    }
+    let pubkey_vec = BASE64_STANDARD.decode(s).ok()?;
+    let elgamal_pubkey = ElGamalPubkey::from_bytes(&pubkey_vec)?;
+    Some(elgamal_pubkey.into())
+}

--- a/token/cli/src/encryption_keypair.rs
+++ b/token/cli/src/encryption_keypair.rs
@@ -13,15 +13,31 @@ use {
 
 const ELGAMAL_PUBKEY_MAX_BASE64_LEN: usize = 44;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ElGamalPubkeyOrNone {
+    ElGamalPubkey(PodElGamalPubkey),
+    None,
+}
+
+impl Into<Option<PodElGamalPubkey>> for ElGamalPubkeyOrNone {
+    fn into(self) -> Option<PodElGamalPubkey> {
+        match self {
+            ElGamalPubkeyOrNone::ElGamalPubkey(pubkey) => Some(pubkey),
+            ElGamalPubkeyOrNone::None => None,
+        }
+    }
+}
+
 pub(crate) fn elgamal_pubkey_or_none(
     matches: &ArgMatches,
     name: &str,
-) -> Result<Option<PodElGamalPubkey>, String> {
+) -> Result<ElGamalPubkeyOrNone, String> {
     let arg_str = matches.value_of(name).unwrap();
     if arg_str == "none" {
-        return Ok(None);
+        return Ok(ElGamalPubkeyOrNone::None);
     }
-    elgamal_pubkey_of(matches, name).map(Some)
+    let elgamal_pubkey = elgamal_pubkey_of(matches, name)?;
+    Ok(ElGamalPubkeyOrNone::ElGamalPubkey(elgamal_pubkey))
 }
 
 pub(crate) fn elgamal_pubkey_of(

--- a/token/cli/src/encryption_keypair.rs
+++ b/token/cli/src/encryption_keypair.rs
@@ -17,7 +17,7 @@ pub(crate) fn elgamal_pubkey_or_none(
     if arg_str == "none" {
         return Ok(None);
     }
-    elgamal_pubkey_of(matches, name).map(|pubkey| Some(pubkey))
+    elgamal_pubkey_of(matches, name).map(Some)
 }
 
 pub(crate) fn elgamal_pubkey_of(

--- a/token/cli/src/encryption_keypair.rs
+++ b/token/cli/src/encryption_keypair.rs
@@ -1,3 +1,7 @@
+//! Temporary ElGamal keypair argument parser.
+//!
+//! NOTE: this module should be remoeved in the next Solana upgrade.
+
 use {
     base64::{prelude::BASE64_STANDARD, Engine},
     clap::ArgMatches,

--- a/token/cli/src/encryption_keypair.rs
+++ b/token/cli/src/encryption_keypair.rs
@@ -19,9 +19,9 @@ pub(crate) enum ElGamalPubkeyOrNone {
     None,
 }
 
-impl Into<Option<PodElGamalPubkey>> for ElGamalPubkeyOrNone {
-    fn into(self) -> Option<PodElGamalPubkey> {
-        match self {
+impl From<ElGamalPubkeyOrNone> for Option<PodElGamalPubkey> {
+    fn from(val: ElGamalPubkeyOrNone) -> Self {
+        match val {
             ElGamalPubkeyOrNone::ElGamalPubkey(pubkey) => Some(pubkey),
             ElGamalPubkeyOrNone::None => None,
         }

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -2780,19 +2780,19 @@ async fn command_update_confidential_transfer_settings(
                 .into());
             }
 
-            let current_auto_approve = if let Some(auto_approve) = auto_approve {
+            let new_auto_approve = if let Some(auto_approve) = auto_approve {
                 auto_approve
             } else {
                 bool::from(confidential_transfer_mint.auto_approve_new_accounts)
             };
 
-            let current_auditor_pubkey = if let Some(auditor_pubkey) = auditor_pubkey {
+            let new_auditor_pubkey = if let Some(auditor_pubkey) = auditor_pubkey {
                 auditor_pubkey.into()
             } else {
                 Option::<ElGamalPubkey>::from(confidential_transfer_mint.auditor_elgamal_pubkey)
             };
 
-            (current_auto_approve, current_auditor_pubkey)
+            (new_auto_approve, new_auditor_pubkey)
         } else {
             return Err(format!(
                 "Mint {} does not support confidential transfers",

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -2813,7 +2813,7 @@ async fn command_update_confidential_transfer_settings(
             ),
         );
     } else {
-        println_display(config, format!("  auditability set to disabled",))
+        println_display(config, format!("  auditability disabled",))
     }
 
     let token = token_client_from_config(config, &token_pubkey, None)?;
@@ -4366,7 +4366,7 @@ fn app<'a, 'b>(
                         .index(2)
                         .possible_values(&["auto", "manual"])
                         .help(
-                            "Enable accounts to make confidential transfers. If \"auto\" \
+                            "Policy for enabling accounts to make confidential transfers. If \"auto\" \
                             is selected, then accounts are automatically approved to make \
                             confidential transfers. If \"manual\" is selected, then the \
                             confidential transfer mint authority must approve each account \
@@ -7834,7 +7834,7 @@ mod tests {
             &config,
             token_pubkey,
             confidential_transfer_mint_authority,
-            false,                // auto approve
+            new_auto_approve,
             Some(auditor_pubkey), // auditor pubkey
             bulk_signers.clone(),
         )

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -76,6 +76,7 @@ use sort::{sort_and_parse_token_accounts, AccountFilter};
 mod bench;
 use bench::*;
 
+// NOTE: this submodule should be removed in the next Solana upgrade
 mod encryption_keypair;
 use encryption_keypair::*;
 
@@ -7826,6 +7827,8 @@ mod tests {
         let auditor_keypair = ElGamalKeypair::new_rand();
         let auditor_pubkey: ElGamalPubkey = (*auditor_keypair.pubkey()).into();
         let new_auto_approve = false;
+
+        println!("{}", auditor_keypair.pubkey());
 
         command_update_confidential_transfer_settings(
             &config,

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -4400,6 +4400,8 @@ fn app<'a, 'b>(
                             Defaults to the client keypair address."
                         )
                 )
+                .nonce_args(true)
+                .offline_args(),
         )
 }
 

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -2162,6 +2162,9 @@ async fn command_display(config: &Config<'_>, address: Pubkey) -> CommandResult 
 
     let token_data = parse_token(&account_data.data, decimals);
 
+    // remove on next `solana-account-decoder` upgrade
+    let ui_confidential_transfer_extension = has_confidential_transfer(&account_data.data);
+
     match token_data {
         Ok(TokenAccountType::Account(account)) => {
             let mint_address = Pubkey::from_str(&account.mint)?;
@@ -2189,6 +2192,7 @@ async fn command_display(config: &Config<'_>, address: Pubkey) -> CommandResult 
                 epoch: epoch_info.epoch,
                 program_id: config.program_id.to_string(),
                 mint,
+                ui_confidential_transfer_extension,
             };
 
             Ok(config.output_format.formatted_string(&cli_output))

--- a/token/cli/src/output.rs
+++ b/token/cli/src/output.rs
@@ -766,9 +766,7 @@ pub(crate) struct UiConfidentialTransferMint {
 
 pub(crate) fn has_confidential_transfer(data: &[u8]) -> Option<UiConfidentialTransferExtension> {
     if let Ok(mint) = StateWithExtensions::<Mint>::unpack(data) {
-        if let Some(confidential_transfer_mint) =
-            mint.get_extension::<ConfidentialTransferMint>().ok()
-        {
+        if let Ok(confidential_transfer_mint) = mint.get_extension::<ConfidentialTransferMint>() {
             let authority: Option<Pubkey> = confidential_transfer_mint.authority.into();
             let auditor_encryption_pubkey: Option<ElGamalPubkey> =
                 confidential_transfer_mint.auditor_elgamal_pubkey.into();

--- a/token/cli/src/output.rs
+++ b/token/cli/src/output.rs
@@ -9,6 +9,15 @@ use solana_account_decoder::{
     },
 };
 use solana_cli_output::{display::writeln_name_value, OutputFormat, QuietDisplay, VerboseDisplay};
+use spl_token_2022::{
+    extension::{
+        confidential_transfer::ConfidentialTransferMint, BaseStateWithExtensions,
+        StateWithExtensions,
+    },
+    solana_program::pubkey::Pubkey,
+    solana_zk_token_sdk::zk_token_elgamal::pod::ElGamalPubkey,
+    state::Mint,
+};
 use std::fmt::{self, Display};
 
 pub(crate) trait Output: Serialize + fmt::Display + QuietDisplay + VerboseDisplay {}
@@ -250,7 +259,7 @@ impl fmt::Display for CliTokenAccount {
         if !self.account.extensions.is_empty() {
             writeln!(f, "{}", style("Extensions:").bold())?;
             for extension in &self.account.extensions {
-                display_ui_extension(f, 0, extension)?;
+                display_ui_extension(f, 0, extension, None)?;
             }
         }
 
@@ -288,6 +297,7 @@ pub(crate) struct CliMint {
     pub(crate) epoch: u64,
     #[serde(flatten)]
     pub(crate) mint: UiMint,
+    pub(crate) ui_confidential_transfer_extension: Option<UiConfidentialTransferExtension>,
 }
 
 impl QuietDisplay for CliMint {}
@@ -319,7 +329,12 @@ impl fmt::Display for CliMint {
         if !self.mint.extensions.is_empty() {
             writeln!(f, "{}", style("Extensions").bold())?;
             for extension in &self.mint.extensions {
-                display_ui_extension(f, self.epoch, extension)?;
+                display_ui_extension(
+                    f,
+                    self.epoch,
+                    extension,
+                    self.ui_confidential_transfer_extension.as_ref(),
+                )?;
             }
         }
 
@@ -547,6 +562,7 @@ fn display_ui_extension(
     f: &mut fmt::Formatter,
     epoch: u64,
     ui_extension: &UiExtension,
+    ui_confidential_transfer_extension: Option<&UiConfidentialTransferExtension>,
 ) -> fmt::Result {
     match ui_extension {
         UiExtension::TransferFeeConfig(UiTransferFeeConfig {
@@ -683,21 +699,47 @@ fn display_ui_extension(
         }
         // ExtensionType::Uninitialized is a hack to ensure a mint/account is never the same length as a multisig
         UiExtension::Uninitialized => Ok(()),
-        UiExtension::ConfidentialTransferMint(_) => writeln_name_value(
-            f,
-            "    Unparseable extension:",
-            "ConfidentialTransferMint is not presently supported",
-        ),
         UiExtension::ConfidentialTransferAccount(_) => writeln_name_value(
             f,
-            "    Unparseable extension:",
+            "  Confidential transfer:",
             "ConfidentialTransferAccount is not presently supported",
         ),
-        _ => writeln_name_value(
-            f,
-            "    Unparseable extension:",
-            "Consider upgrading to a newer version of spl-token",
-        ),
+        _ => {
+            if let Some(ui_confidential_transfer_extension) = ui_confidential_transfer_extension {
+                match ui_confidential_transfer_extension {
+                    UiConfidentialTransferExtension::ConfidentialTransferMint(ui_mint) => {
+                        writeln!(f, "  {}", style("Confidential transfer:").bold())?;
+                        writeln!(
+                            f,
+                            "    {}: {}",
+                            style("Account approve policy").bold(),
+                            if ui_mint.auto_approve_new_accounts {
+                                "auto"
+                            } else {
+                                "manual"
+                            },
+                        )?;
+                        writeln!(
+                            f,
+                            "    {}: {}",
+                            style("Audit key:").bold(),
+                            if let Some(auditor_pubkey) = ui_mint.auditor_encryption_pubkey.as_ref()
+                            {
+                                auditor_pubkey
+                            } else {
+                                "audits are not enabled"
+                            }
+                        )
+                    }
+                }
+            } else {
+                writeln_name_value(
+                    f,
+                    "  Unparseable extension:",
+                    "Consider upgrading to a newer version of spl-token",
+                )
+            }
+        }
     }
 }
 
@@ -707,4 +749,40 @@ fn flattened<S: Serializer>(
 ) -> Result<S::Ok, S::Error> {
     let flattened: Vec<_> = vec.iter().flatten().collect();
     flattened.serialize(serializer)
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) enum UiConfidentialTransferExtension {
+    ConfidentialTransferMint(UiConfidentialTransferMint),
+    // TODO: add `ConfidentialTransferAccount`
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct UiConfidentialTransferMint {
+    pub authority: Option<String>,
+    pub auto_approve_new_accounts: bool,
+    pub auditor_encryption_pubkey: Option<String>,
+}
+
+pub(crate) fn has_confidential_transfer(data: &[u8]) -> Option<UiConfidentialTransferExtension> {
+    if let Ok(mint) = StateWithExtensions::<Mint>::unpack(data) {
+        if let Some(confidential_transfer_mint) =
+            mint.get_extension::<ConfidentialTransferMint>().ok()
+        {
+            let authority: Option<Pubkey> = confidential_transfer_mint.authority.into();
+            let auditor_encryption_pubkey: Option<ElGamalPubkey> =
+                confidential_transfer_mint.auditor_elgamal_pubkey.into();
+            return Some(UiConfidentialTransferExtension::ConfidentialTransferMint(
+                UiConfidentialTransferMint {
+                    authority: authority.map(|pubkey| pubkey.to_string()),
+                    auto_approve_new_accounts: confidential_transfer_mint
+                        .auto_approve_new_accounts
+                        .into(),
+                    auditor_encryption_pubkey: auditor_encryption_pubkey
+                        .map(|pubkey| pubkey.to_string()),
+                },
+            ));
+        }
+    }
+    None
 }

--- a/token/cli/src/output.rs
+++ b/token/cli/src/output.rs
@@ -728,7 +728,7 @@ fn display_ui_extension(
                             {
                                 auditor_pubkey
                             } else {
-                                "audits are not enabled"
+                                "audits are disabled"
                             }
                         )
                     }

--- a/token/cli/src/output.rs
+++ b/token/cli/src/output.rs
@@ -297,6 +297,7 @@ pub(crate) struct CliMint {
     pub(crate) epoch: u64,
     #[serde(flatten)]
     pub(crate) mint: UiMint,
+    // NOTE: this should be removed in the next solana upgrade
     pub(crate) ui_confidential_transfer_extension: Option<UiConfidentialTransferExtension>,
 }
 
@@ -751,12 +752,18 @@ fn flattened<S: Serializer>(
     flattened.serialize(serializer)
 }
 
+// Ui struct for confidential transfer extensions
+//
+// NOTE: this should be removed in the next Solana upgrade
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) enum UiConfidentialTransferExtension {
     ConfidentialTransferMint(UiConfidentialTransferMint),
     // TODO: add `ConfidentialTransferAccount`
 }
 
+// Ui struct for confidential transfer mint
+//
+// NOTE: this should be removed in the next Solana upgrade
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct UiConfidentialTransferMint {
     pub authority: Option<String>,
@@ -764,6 +771,9 @@ pub(crate) struct UiConfidentialTransferMint {
     pub auditor_encryption_pubkey: Option<String>,
 }
 
+// Checks whether a token 2022 state with extension contains the confidential transfer extension
+//
+// NOTE: this should be removed in the next Solana upgrade
 pub(crate) fn has_confidential_transfer(data: &[u8]) -> Option<UiConfidentialTransferExtension> {
     if let Ok(mint) = StateWithExtensions::<Mint>::unpack(data) {
         if let Ok(confidential_transfer_mint) = mint.get_extension::<ConfidentialTransferMint>() {


### PR DESCRIPTION
#### Problem
There are no cli support for confidential transfers yet.

#### Summary of changes
Updated/added cli commands regarding the mint. The `create-token` with `--enable-confidential-transfers` flag should already be supported.

[f616231](https://github.com/solana-labs/solana-program-library/pull/5335/commits/f616231da8b821759220b30072a01de9ba7605fc): Updated the `display` command to support the confidential transfer mint extension. Unfortunately, the `solana-account-decoder` is still using the older version of token-2022 before the confidential transfer and confidential transfer fee extensions were split, which means we can't use the `UiConfidentialTransferMint` type from `solana-account-decoder`. I hard-coded a temporary `UiConfidentialTransferMint` type in `output.rs` to account for this. This part can be removed in the next monorepo upgrade.

[09ad0d9](https://github.com/solana-labs/solana-program-library/pull/5335/commits/09ad0d9075ce04a0a23eeb6420b3701426cc5c55): ElGamal keys are [supported](https://github.com/solana-labs/solana/blob/master/clap-v3-utils/src/keypair.rs#L1049) in `solana-clap-v3-utils`, but an upgrade to clap-v3 for token-cli is blocked until 1.17 due to a new panicking behavior that was introduced with clap-v3 (https://github.com/solana-labs/solana/pull/33184). So I added temporary functions to read ElGamal keypairs and pubkeys to unblock work on the token-cli. These functions only support either reading from ElGamal keypair files or reading form base64-encoded pubkey string. Once we upgrade to `solana-clap-v3-utils`, we can support a more variety of ways to take ElGamal arguments.

I didn't write tests for these hard-coded functions since they will eventually be replaced anyway, but I can add them in if suggested.

[7e52fc5](https://github.com/solana-labs/solana-program-library/pull/5335/commits/7e52fc5ca4b7fa7801509f3bd7f4c083d06395ff): Added `update-confidential-transfer-settings`, which allows updating the confidential transfer mint configuration. 

To try out the new commands:
```
> cargo run -- create-token --enable-confidential-transfers auto -p TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb

Address:  [MINT-ADDRESS]
Decimals:  9

... the auditing feature is set to none by default
```

```
> cargo run -- display [MINT-ADDRESS]
... will display the confidential transfer mint settings

> cargo run -- update-confidential-transfer-settings [MINT-ADDRESS] manual 5DcMEnLGCFYe2qChv9uexI8tuM6sDJlrbe+tMeIf+UA=
... will update the confidential transfer mint settings to manual approve and auditor key

> cargo run --display [MINT-ADDRESS]
... verify that the update was done correctly
```

To generate an arbitrary ElGamal public key, I just did
```rust
let elgamal_keypair = ElGamalKeypair::new_rand();
println!("{}", elgamal_keypair.pubkey());
// this prints base64 encoding of ElGamal public key like `5DcMEnLGCFYe2qChv9uexI8tuM6sDJlrbe+tMeIf+UA=`
```

Once the issues in `solana-clap-v3-utils` are resolved and we publish `solana-zk-keygen`, then we can use that instead to generate ElGamal keypairs/pubkeys.