### PR TITLE
token-2022: Bump to 0.8.1 for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6415,7 +6415,7 @@ dependencies = [
  "num-traits",
  "solana-program",
  "spl-token 4.0.0",
- "spl-token-2022 0.8.0",
+ "spl-token-2022 0.8.1",
  "thiserror",
 ]
 
@@ -6428,7 +6428,7 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account 2.1.0",
  "spl-token 4.0.0",
- "spl-token-2022 0.8.0",
+ "spl-token-2022 0.8.1",
 ]
 
 [[package]]
@@ -6903,7 +6903,7 @@ dependencies = [
  "spl-math",
  "spl-pod",
  "spl-token 4.0.0",
- "spl-token-2022 0.8.0",
+ "spl-token-2022 0.8.1",
  "test-case",
  "thiserror",
 ]
@@ -7003,7 +7003,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-2022"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "arrayref",
  "base64 0.21.4",
@@ -7044,7 +7044,7 @@ dependencies = [
  "spl-instruction-padding",
  "spl-memo 4.0.0",
  "spl-pod",
- "spl-token-2022 0.8.0",
+ "spl-token-2022 0.8.1",
  "spl-token-client",
  "spl-token-metadata-interface",
  "spl-transfer-hook-example",
@@ -7077,7 +7077,7 @@ dependencies = [
  "spl-associated-token-account 2.1.0",
  "spl-memo 4.0.0",
  "spl-token 4.0.0",
- "spl-token-2022 0.8.0",
+ "spl-token-2022 0.8.1",
  "spl-token-client",
  "spl-token-metadata-interface",
  "strum 0.25.0",
@@ -7104,7 +7104,7 @@ dependencies = [
  "spl-associated-token-account 2.1.0",
  "spl-memo 4.0.0",
  "spl-token 4.0.0",
- "spl-token-2022 0.8.0",
+ "spl-token-2022 0.8.1",
  "spl-token-metadata-interface",
  "spl-transfer-hook-interface",
  "thiserror",
@@ -7151,7 +7151,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-pod",
- "spl-token-2022 0.8.0",
+ "spl-token-2022 0.8.1",
  "spl-token-client",
  "spl-token-metadata-interface",
  "spl-type-length-value",
@@ -7187,7 +7187,7 @@ dependencies = [
  "solana-sdk",
  "spl-math",
  "spl-token 4.0.0",
- "spl-token-2022 0.8.0",
+ "spl-token-2022 0.8.1",
  "test-case",
  "thiserror",
 ]
@@ -7215,7 +7215,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-token 4.0.0",
- "spl-token-2022 0.8.0",
+ "spl-token-2022 0.8.1",
  "spl-token-client",
  "test-case",
  "thiserror",
@@ -7236,7 +7236,7 @@ dependencies = [
  "solana-test-validator",
  "spl-associated-token-account 2.1.0",
  "spl-token 4.0.0",
- "spl-token-2022 0.8.0",
+ "spl-token-2022 0.8.1",
  "spl-token-client",
  "spl-token-upgrade",
  "tokio",
@@ -7252,7 +7252,7 @@ dependencies = [
  "solana-program",
  "spl-associated-token-account 2.1.0",
  "spl-token 4.0.0",
- "spl-token-2022 0.8.0",
+ "spl-token-2022 0.8.1",
  "thiserror",
 ]
 
@@ -7265,7 +7265,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-tlv-account-resolution",
- "spl-token-2022 0.8.0",
+ "spl-token-2022 0.8.1",
  "spl-transfer-hook-interface",
  "spl-type-length-value",
 ]

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-2022"
-version = "0.8.0"
+version = "0.8.1"
 description = "Solana Program Library Token 2022"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"


### PR DESCRIPTION
#### Problem

We need to update the monorepo to a newer version of token-2022, but the 0.8.0 release is missing some required features from the monorepo, as it's still on 1.16.3.

#### Solution

Cut a release for 0.8.1

cc @samkim-crypto 