### PR TITLE
release: Bump tlv-account-resolution and dependents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6407,7 +6407,7 @@ dependencies = [
 
 [[package]]
 name = "spl-associated-token-account"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "assert_matches",
  "borsh 0.10.3",
@@ -6415,7 +6415,7 @@ dependencies = [
  "num-traits",
  "solana-program",
  "spl-token 4.0.0",
- "spl-token-2022 0.8.1",
+ "spl-token-2022 0.9.0",
  "thiserror",
 ]
 
@@ -6426,9 +6426,9 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 2.1.0",
+ "spl-associated-token-account 2.2.0",
  "spl-token 4.0.0",
- "spl-token-2022 0.8.1",
+ "spl-token-2022 0.9.0",
 ]
 
 [[package]]
@@ -6705,7 +6705,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 2.1.0",
+ "spl-associated-token-account 2.2.0",
  "spl-token 4.0.0",
  "thiserror",
 ]
@@ -6850,7 +6850,7 @@ dependencies = [
  "solana-test-validator",
  "solana-transaction-status",
  "solana-vote-program",
- "spl-associated-token-account 2.1.0",
+ "spl-associated-token-account 2.2.0",
  "spl-single-validator-pool",
  "spl-token 4.0.0",
  "spl-token-client",
@@ -6875,7 +6875,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "solana-vote-program",
- "spl-associated-token-account 2.1.0",
+ "spl-associated-token-account 2.2.0",
  "spl-token 4.0.0",
  "test-case",
  "thiserror",
@@ -6903,7 +6903,7 @@ dependencies = [
  "spl-math",
  "spl-pod",
  "spl-token 4.0.0",
- "spl-token-2022 0.8.1",
+ "spl-token-2022 0.9.0",
  "test-case",
  "thiserror",
 ]
@@ -6928,14 +6928,14 @@ dependencies = [
  "solana-program",
  "solana-remote-wallet",
  "solana-sdk",
- "spl-associated-token-account 2.1.0",
+ "spl-associated-token-account 2.2.0",
  "spl-stake-pool",
  "spl-token 4.0.0",
 ]
 
 [[package]]
 name = "spl-tlv-account-resolution"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bytemuck",
  "futures 0.3.28",
@@ -7003,7 +7003,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-2022"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "arrayref",
  "base64 0.21.4",
@@ -7040,11 +7040,11 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 2.1.0",
+ "spl-associated-token-account 2.2.0",
  "spl-instruction-padding",
  "spl-memo 4.0.0",
  "spl-pod",
- "spl-token-2022 0.8.1",
+ "spl-token-2022 0.9.0",
  "spl-token-client",
  "spl-token-metadata-interface",
  "spl-transfer-hook-example",
@@ -7074,10 +7074,10 @@ dependencies = [
  "solana-sdk",
  "solana-test-validator",
  "solana-transaction-status",
- "spl-associated-token-account 2.1.0",
+ "spl-associated-token-account 2.2.0",
  "spl-memo 4.0.0",
  "spl-token 4.0.0",
- "spl-token-2022 0.8.1",
+ "spl-token-2022 0.9.0",
  "spl-token-client",
  "spl-token-metadata-interface",
  "strum 0.25.0",
@@ -7089,7 +7089,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-client"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "curve25519-dalek",
@@ -7101,10 +7101,10 @@ dependencies = [
  "solana-rpc-client",
  "solana-rpc-client-api",
  "solana-sdk",
- "spl-associated-token-account 2.1.0",
+ "spl-associated-token-account 2.2.0",
  "spl-memo 4.0.0",
  "spl-token 4.0.0",
- "spl-token-2022 0.8.1",
+ "spl-token-2022 0.9.0",
  "spl-token-metadata-interface",
  "spl-transfer-hook-interface",
  "thiserror",
@@ -7151,7 +7151,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-pod",
- "spl-token-2022 0.8.1",
+ "spl-token-2022 0.9.0",
  "spl-token-client",
  "spl-token-metadata-interface",
  "spl-type-length-value",
@@ -7187,7 +7187,7 @@ dependencies = [
  "solana-sdk",
  "spl-math",
  "spl-token 4.0.0",
- "spl-token-2022 0.8.1",
+ "spl-token-2022 0.9.0",
  "test-case",
  "thiserror",
 ]
@@ -7215,7 +7215,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-token 4.0.0",
- "spl-token-2022 0.8.1",
+ "spl-token-2022 0.9.0",
  "spl-token-client",
  "test-case",
  "thiserror",
@@ -7234,9 +7234,9 @@ dependencies = [
  "solana-remote-wallet",
  "solana-sdk",
  "solana-test-validator",
- "spl-associated-token-account 2.1.0",
+ "spl-associated-token-account 2.2.0",
  "spl-token 4.0.0",
- "spl-token-2022 0.8.1",
+ "spl-token-2022 0.9.0",
  "spl-token-client",
  "spl-token-upgrade",
  "tokio",
@@ -7250,29 +7250,29 @@ dependencies = [
  "bytemuck",
  "num_enum 0.7.0",
  "solana-program",
- "spl-associated-token-account 2.1.0",
+ "spl-associated-token-account 2.2.0",
  "spl-token 4.0.0",
- "spl-token-2022 0.8.1",
+ "spl-token-2022 0.9.0",
  "thiserror",
 ]
 
 [[package]]
 name = "spl-transfer-hook-example"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "arrayref",
  "solana-program",
  "solana-program-test",
  "solana-sdk",
  "spl-tlv-account-resolution",
- "spl-token-2022 0.8.1",
+ "spl-token-2022 0.9.0",
  "spl-transfer-hook-interface",
  "spl-type-length-value",
 ]
 
 [[package]]
 name = "spl-transfer-hook-interface"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -7323,7 +7323,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 2.1.0",
+ "spl-associated-token-account 2.2.0",
  "spl-token 4.0.0",
  "thiserror",
 ]

--- a/associated-token-account/program-test/Cargo.toml
+++ b/associated-token-account/program-test/Cargo.toml
@@ -16,4 +16,4 @@ solana-program-test = "1.16.13"
 solana-sdk = "1.16.13"
 spl-associated-token-account = { version = "2", path = "../program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "0.8", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.9", path = "../../token/program-2022", features = ["no-entrypoint"] }

--- a/associated-token-account/program/Cargo.toml
+++ b/associated-token-account/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-associated-token-account"
-version = "2.1.0"
+version = "2.2.0"
 description = "Solana Program Library Associated Token Account"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -18,7 +18,7 @@ num-derive = "0.4"
 num-traits = "0.2"
 solana-program = "1.16.13"
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "0.8", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.9", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [lib]

--- a/libraries/tlv-account-resolution/Cargo.toml
+++ b/libraries/tlv-account-resolution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-tlv-account-resolution"
-version = "0.3.0"
+version = "0.4.0"
 description = "Solana Program Library TLV Account Resolution Interface"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/single-pool/cli/Cargo.toml
+++ b/single-pool/cli/Cargo.toml
@@ -28,7 +28,7 @@ solana-sdk = "=1.16.13"
 solana-transaction-status = "=1.16.13"
 solana-vote-program = "=1.16.13"
 spl-token = { version = "4.0", path="../../token/program", features = [ "no-entrypoint" ] }
-spl-token-client = { version = "0.6", path="../../token/client" }
+spl-token-client = { version = "0.7", path="../../token/client" }
 spl-associated-token-account = { version = "2.0", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
 spl-single-validator-pool = { version = "1.0.0", path="../program", features = [ "no-entrypoint" ] }
 

--- a/stake-pool/cli/Cargo.toml
+++ b/stake-pool/cli/Cargo.toml
@@ -23,7 +23,7 @@ solana-logger = "=1.16.13"
 solana-program = "=1.16.13"
 solana-remote-wallet = "=1.16.13"
 solana-sdk = "=1.16.13"
-spl-associated-token-account = { version = "=2.1", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
+spl-associated-token-account = { version = "=2.2", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
 spl-stake-pool = { version = "=0.7.0", path="../program", features = [ "no-entrypoint" ] }
 spl-token = { version = "=4.0", path="../../token/program", features = [ "no-entrypoint" ]  }
 bs58 = "0.4.0"

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -23,7 +23,7 @@ serde_derive = "1.0.103"
 solana-program = "1.16.13"
 spl-math = { version = "0.2", path = "../../libraries/math", features = [ "no-entrypoint" ] }
 spl-pod = { version = "0.1", path = "../../libraries/pod", features = ["borsh"] }
-spl-token-2022 = { version = "0.8", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
+spl-token-2022 = { version = "0.9", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 bincode = "1.3.1"
 

--- a/token-metadata/example/Cargo.toml
+++ b/token-metadata/example/Cargo.toml
@@ -13,7 +13,7 @@ test-sbf = []
 
 [dependencies]
 solana-program = "1.16.13"
-spl-token-2022 = { version = "0.8", path = "../../token/program-2022" }
+spl-token-2022 = { version = "0.9", path = "../../token/program-2022" }
 spl-token-metadata-interface = { version = "0.2.0", path = "../interface" }
 spl-type-length-value = { version = "0.3.0" , path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.1.0", path = "../../libraries/pod" }
@@ -21,7 +21,7 @@ spl-pod = { version = "0.1.0", path = "../../libraries/pod" }
 [dev-dependencies]
 solana-program-test = "1.16.13"
 solana-sdk = "1.16.13"
-spl-token-client = { version = "0.6", path = "../../token/client" }
+spl-token-client = { version = "0.7", path = "../../token/client" }
 test-case = "3.2"
 
 [lib]

--- a/token-swap/program/Cargo.toml
+++ b/token-swap/program/Cargo.toml
@@ -20,7 +20,7 @@ num-traits = "0.2"
 solana-program = "1.16.13"
 spl-math = { version = "0.2", path = "../../libraries/math", features = [ "no-entrypoint" ] }
 spl-token = { version = "4.0", path = "../../token/program", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "0.8", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
+spl-token-2022 = { version = "0.9", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
 roots = { version = "0.0.8", optional = true }

--- a/token-upgrade/cli/Cargo.toml
+++ b/token-upgrade/cli/Cargo.toml
@@ -21,8 +21,8 @@ solana-remote-wallet = "1.16.13"
 solana-sdk = "1.16.13"
 spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "0.8", path = "../../token/program-2022", features = ["no-entrypoint"] }
-spl-token-client = { version = "0.6", path = "../../token/client" }
+spl-token-2022 = { version = "0.9", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-client = { version = "0.7", path = "../../token/client" }
 spl-token-upgrade = { version = "0.1", path = "../program", features = ["no-entrypoint"] }
 tokio = { version = "1", features = ["full"] }
 

--- a/token-upgrade/program/Cargo.toml
+++ b/token-upgrade/program/Cargo.toml
@@ -16,14 +16,14 @@ num-derive = "0.4"
 num-traits = "0.2"
 num_enum = "0.7.0"
 solana-program = "1.16.13"
-spl-token-2022 = { version = "0.8", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.9", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [dev-dependencies]
 solana-program-test = "1.16.13"
 solana-sdk = "1.16.13"
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-client = { version = "0.6", path = "../../token/client" }
+spl-token-client = { version = "0.7", path = "../../token/client" }
 test-case = "3.2"
 
 [lib]

--- a/token-wrap/program/Cargo.toml
+++ b/token-wrap/program/Cargo.toml
@@ -17,7 +17,7 @@ num_enum = "0.7"
 solana-program = "1.16.13"
 spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "0.8", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.9", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [lib]

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -27,8 +27,8 @@ solana-remote-wallet = "=1.16.13"
 solana-sdk = "=1.16.13"
 solana-transaction-status = "=1.16.13"
 spl-token = { version = "4.0", path="../program", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "0.8", path="../program-2022", features = [ "no-entrypoint" ] }
-spl-token-client = { version = "0.6", path="../client" }
+spl-token-2022 = { version = "0.9", path="../program-2022", features = [ "no-entrypoint" ] }
+spl-token-client = { version = "0.7", path="../client" }
 spl-token-metadata-interface = { version = "0.2", path="../../token-metadata/interface" }
 spl-associated-token-account = { version = "2.0", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
 spl-memo = { version = "4.0.0", path="../../memo/program", features = ["no-entrypoint"] }

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "spl-token-client"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "0.6.0"
+version = "0.7.0"
 
 [dependencies]
 async-trait = "0.1"
@@ -23,9 +23,9 @@ solana-sdk = "1.16.13"
 spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-memo = { version = "4.0.0", path = "../../memo/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path="../program", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "0.8", path="../program-2022" }
+spl-token-2022 = { version = "0.9", path="../program-2022" }
 spl-token-metadata-interface = { version = "0.2", path="../../token-metadata/interface" }
-spl-transfer-hook-interface = { version = "0.2", path="../transfer-hook-interface" }
+spl-transfer-hook-interface = { version = "0.3", path="../transfer-hook-interface" }
 thiserror = "1.0"
 
 [features]

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -26,10 +26,10 @@ solana-sdk = "=1.16.13"
 spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program" }
 spl-memo = { version = "4.0.0", path = "../../memo/program", features = ["no-entrypoint"] }
 spl-pod = { version = "0.1.0", path = "../../libraries/pod" }
-spl-token-2022 = { version = "0.8", path="../program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.9", path="../program-2022", features = ["no-entrypoint"] }
 spl-instruction-padding = { version = "0.1.0", path="../../instruction-padding/program", features = ["no-entrypoint"] }
-spl-token-client = { version = "0.6", path = "../client" }
+spl-token-client = { version = "0.7", path = "../client" }
 spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }
-spl-transfer-hook-example = { version = "0.2", path="../transfer-hook-example", features = ["no-entrypoint"] }
-spl-transfer-hook-interface = { version = "0.2", path="../transfer-hook-interface" }
+spl-transfer-hook-example = { version = "0.3", path="../transfer-hook-example", features = ["no-entrypoint"] }
+spl-transfer-hook-interface = { version = "0.3", path="../transfer-hook-interface" }
 test-case = "3.2"

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-2022"
-version = "0.8.1"
+version = "0.9.0"
 description = "Solana Program Library Token 2022"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -28,7 +28,7 @@ solana-zk-token-sdk = "1.16.13"
 spl-memo = { version = "4.0.0", path = "../../memo/program", features = [ "no-entrypoint" ] }
 spl-token = { version = "4.0",  path = "../program", features = ["no-entrypoint"] }
 spl-token-metadata-interface = { version = "0.2.0", path = "../../token-metadata/interface" }
-spl-transfer-hook-interface = { version = "0.2.0", path = "../transfer-hook-interface" }
+spl-transfer-hook-interface = { version = "0.3.0", path = "../transfer-hook-interface" }
 spl-type-length-value = { version = "0.3.0", path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.1.0", path = "../../libraries/pod" }
 thiserror = "1.0"

--- a/token/transfer-hook-example/Cargo.toml
+++ b/token/transfer-hook-example/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-transfer-hook-example"
-version = "0.2.0"
+version = "0.3.0"
 description = "Solana Program Library Transfer Hook Example Program"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -14,9 +14,9 @@ test-sbf = []
 [dependencies]
 arrayref = "0.3.7"
 solana-program = "1.16.13"
-spl-tlv-account-resolution = { version = "0.3" , path = "../../libraries/tlv-account-resolution" }
-spl-token-2022 = { version = "0.8",  path = "../program-2022", features = ["no-entrypoint"] }
-spl-transfer-hook-interface = { version = "0.2" , path = "../transfer-hook-interface" }
+spl-tlv-account-resolution = { version = "0.4" , path = "../../libraries/tlv-account-resolution" }
+spl-token-2022 = { version = "0.9",  path = "../program-2022", features = ["no-entrypoint"] }
+spl-transfer-hook-interface = { version = "0.3" , path = "../transfer-hook-interface" }
 spl-type-length-value = { version = "0.3" , path = "../../libraries/type-length-value" }
 
 [dev-dependencies]

--- a/token/transfer-hook-interface/Cargo.toml
+++ b/token/transfer-hook-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-transfer-hook-interface"
-version = "0.2.0"
+version = "0.3.0"
 description = "Solana Program Library Transfer Hook Interface"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -13,7 +13,7 @@ bytemuck = { version = "1.14.0", features = ["derive"] }
 solana-program = "1.16.13"
 spl-discriminator = { version = "0.1" , path = "../../libraries/discriminator" }
 spl-program-error = { version = "0.3" , path = "../../libraries/program-error" }
-spl-tlv-account-resolution = { version = "0.3" , path = "../../libraries/tlv-account-resolution" }
+spl-tlv-account-resolution = { version = "0.4" , path = "../../libraries/tlv-account-resolution" }
 spl-type-length-value = { version = "0.3" , path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.1", path = "../../libraries/pod" }
 


### PR DESCRIPTION
#### Problem

We want to use a new version of spl-token-2022, but its version on master depends on spl-tlv-account-resolution, which made a breaking change to support deriving PDAs from account data.

#### Solution

Bump tlv-account-resolution and everything that depends on it to a new minor version. The idea was to do a minor version bump on things that we want to release, and things that would break because of the change.