### PR TITLE
token-2022: Fix build with zk-ops disabled

### DIFF
--- a/token/program-2022/src/extension/confidential_transfer/verify_proof.rs
+++ b/token/program-2022/src/extension/confidential_transfer/verify_proof.rs
@@ -268,6 +268,7 @@ pub fn verify_transfer_proof(
 
 /// Verify zero-knowledge proof needed for a [Transfer] instruction with fee and return the
 /// corresponding proof context.
+#[cfg(feature = "zk-ops")]
 pub fn verify_transfer_with_fee_proof(
     account_info_iter: &mut Iter<'_, AccountInfo<'_>>,
     proof_instruction_offset: i64,


### PR DESCRIPTION
#### Problem

Token-2022 currently doesn't build with the zk-ops feature disabled.

#### Solution

Mark a function as requiring `zk-ops` to get it to work.