### PR TITLE
macro: Remove dependency on solana-program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6471,7 +6471,7 @@ dependencies = [
 
 [[package]]
 name = "spl-discriminator-derive"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "quote 1.0.29",
  "spl-discriminator-syn",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "spl-discriminator-syn"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.29",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6484,7 +6484,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.29",
- "solana-program",
+ "sha2 0.10.7",
  "syn 2.0.28",
  "thiserror",
 ]
@@ -6799,7 +6799,7 @@ version = "0.3.0"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.29",
- "solana-program",
+ "sha2 0.10.7",
  "syn 2.0.28",
 ]
 

--- a/libraries/discriminator/derive/Cargo.toml
+++ b/libraries/discriminator/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-discriminator-derive"
-version = "0.1.0"
+version = "0.1.1"
 description = "Derive macro library for the `spl-discriminator` library"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/libraries/discriminator/syn/Cargo.toml
+++ b/libraries/discriminator/syn/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-solana-program = "1.16.13"
+sha2 = "0.10"
 syn = { version = "2.0", features = ["full"] }
 thiserror = "1.0"
 

--- a/libraries/discriminator/syn/Cargo.toml
+++ b/libraries/discriminator/syn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-discriminator-syn"
-version = "0.1.0"
+version = "0.1.1"
 description = "Token parsing and generating library for the `spl-discriminator` library"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/libraries/discriminator/syn/src/lib.rs
+++ b/libraries/discriminator/syn/src/lib.rs
@@ -10,7 +10,7 @@ use {
     crate::{error::SplDiscriminateError, parser::parse_hash_input},
     proc_macro2::{Span, TokenStream},
     quote::{quote, ToTokens},
-    solana_program::hash,
+    sha2::{Digest, Sha256},
     syn::{parse::Parse, Generics, Ident, Item, ItemEnum, ItemStruct, LitByteStr, WhereClause},
 };
 
@@ -102,7 +102,7 @@ impl From<&SplDiscriminateBuilder> for TokenStream {
 /// Returns the bytes for the TLV hash_input discriminator
 fn get_discriminator_bytes(hash_input: &str) -> LitByteStr {
     LitByteStr::new(
-        &hash::hashv(&[hash_input.as_bytes()]).to_bytes()[..8],
+        &Sha256::digest(hash_input.as_bytes())[..8],
         Span::call_site(),
     )
 }

--- a/libraries/program-error/derive/Cargo.toml
+++ b/libraries/program-error/derive/Cargo.toml
@@ -13,5 +13,5 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-solana-program = "1.16.13"
+sha2 = "0.10"
 syn = { version = "2.0", features = ["full"] }

--- a/libraries/program-error/derive/src/macro_impl.rs
+++ b/libraries/program-error/derive/src/macro_impl.rs
@@ -186,7 +186,7 @@ fn u32_from_hash(enum_ident: &Ident) -> u32 {
     let mut nonce: u32 = 0;
     loop {
         let mut hasher = Sha256::new_with_prefix(hash_input.as_bytes());
-        hasher.update(&nonce.to_le_bytes());
+        hasher.update(nonce.to_le_bytes());
         let d = u32::from_le_bytes(
             hasher.finalize()[13..17]
                 .try_into()

--- a/libraries/program-error/derive/src/macro_impl.rs
+++ b/libraries/program-error/derive/src/macro_impl.rs
@@ -4,6 +4,7 @@ use {
     crate::parser::SplProgramErrorArgs,
     proc_macro2::Span,
     quote::quote,
+    sha2::{Digest, Sha256},
     syn::{
         punctuated::Punctuated, token::Comma, Expr, ExprLit, Ident, ItemEnum, Lit, LitInt, LitStr,
         Token, Variant,
@@ -184,9 +185,10 @@ fn u32_from_hash(enum_ident: &Ident) -> u32 {
     // `SPL_ERROR_HASH_MIN_VALUE`!
     let mut nonce: u32 = 0;
     loop {
-        let hash = solana_program::hash::hashv(&[hash_input.as_bytes(), &nonce.to_le_bytes()]);
+        let mut hasher = Sha256::new_with_prefix(hash_input.as_bytes());
+        hasher.update(&nonce.to_le_bytes());
         let d = u32::from_le_bytes(
-            hash.to_bytes()[13..17]
+            hasher.finalize()[13..17]
                 .try_into()
                 .expect("Unable to convert hash to u32"),
         );


### PR DESCRIPTION
#### Problem

While updating the monorepo to use the new spl crates, like token-2022, I got a really strange build error:

```
warning: output filename collision.
The lib target `solana-program` in package `solana-program v1.17.0 (/home/jon/src/solana/solana/sdk/program)` has the same output filename as the lib target `solana-program` in package `solana-program v1.17.0 (/home/jon/src/solana/solana/sdk/program)`.
Colliding filename is: /home/jon/src/solana/solana/target/debug/deps/libsolana_program.so
The targets should have unique names.
Consider changing their names to be unique or compiling them separately.
This may become a hard error in the future; see <https://github.com/rust-lang/cargo/issues/6313>.
```

After the warning, it complained that `solana_sdk` didn't exist.

I dug around for a bit, and narrowed it down to the usage of `solana_program` in the new derive crates. Since the derive crates are `proc-macro = true`, cargo treats it and its dependencies as completely different libraries, which meant that we were building `solana-program` twice: once in the proc-macro context, and another time in the normal build context.

#### Solution

Thankfully, both crates were only using the hasher from `solana-program`, so this change just uses `Sha256` directly. Some tests might fail here, so I'll fix those up as needed.

I've also bumped the versions so we can publish new versions and use those immediately.