### PR TITLE
release: Bump spl-program-error-derive for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6795,7 +6795,7 @@ dependencies = [
 
 [[package]]
 name = "spl-program-error-derive"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.29",

--- a/libraries/program-error/Cargo.toml
+++ b/libraries/program-error/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 num-derive = "0.4"
 num-traits = "0.2"
 solana-program = "1.16.13"
-spl-program-error-derive = { version = "0.3.0", path = "./derive" }
+spl-program-error-derive = { version = "0.3.1", path = "./derive" }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/libraries/program-error/derive/Cargo.toml
+++ b/libraries/program-error/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-program-error-derive"
-version = "0.3.0"
+version = "0.3.1"
 description = "Proc-Macro Library for Solana Program error attributes and derive macro"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"


### PR DESCRIPTION
#### Problem

While making the change in #5375 to remove the solana-program dependency, I forgot to bump the version on spl-program-error-derive

#### Solution

Bump the version!