### PR TITLE
ci: Ignore tungstenite security advisory

### DIFF
--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -25,5 +25,10 @@ cargo_audit_ignores=(
   #
   # No fixed upgrade is available! Only fix is switching to rustls-webpki
   --ignore RUSTSEC-2023-0052
+
+  # tungstenite
+  #
+  # Remove once SPL upgrades to Solana v1.17 or greater
+  --ignore RUSTSEC-2023-0065
 )
 cargo +"$rust_stable" audit "${cargo_audit_ignores[@]}"


### PR DESCRIPTION
#### Problem

There's a RUSTSEC advisory on tungstenite https://rustsec.org/advisories/RUSTSEC-2023-0065 causing CI failures

#### Solution

Same as 1.16, ignore the advisory: https://github.com/solana-labs/solana/pull/33457