### PR TITLE
token-2022: Refresh blockhash in flaky test

### DIFF
--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -402,6 +402,8 @@ async fn confidential_transfer_enable_disable_confidential_credits() {
         .unwrap();
     assert!(bool::from(&extension.allow_confidential_credits));
 
+    // Refresh the blockhash since we're doing the same thing twice in a row
+    token.get_new_latest_blockhash().await.unwrap();
     token
         .confidential_transfer_deposit(
             &alice_meta.token_account,


### PR DESCRIPTION
#### Problem

There was a spurious failure during CI in a confidential transfer test: https://github.com/solana-labs/solana-program-library/actions/runs/6383061276/job/17322950719

Essentially, we're doing the same thing twice in a row without refreshing the blockhash, so there's a chance that the program-test will return the same old response.

#### Solution

Refresh the blockhash