### PR TITLE
token-2022(feat): add serialisation option for the extensions

### DIFF
--- a/token/program-2022/src/extension/cpi_guard/mod.rs
+++ b/token/program-2022/src/extension/cpi_guard/mod.rs
@@ -8,6 +8,9 @@ use {
     spl_pod::primitives::PodBool,
 };
 
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
+
 /// CPI Guard extension instructions
 pub mod instruction;
 
@@ -16,6 +19,7 @@ pub mod processor;
 
 /// CPI Guard extension for Accounts
 #[repr(C)]
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct CpiGuard {
     /// Lock privileged token operations from happening via CPI

--- a/token/program-2022/src/extension/default_account_state/mod.rs
+++ b/token/program-2022/src/extension/default_account_state/mod.rs
@@ -3,6 +3,9 @@ use {
     bytemuck::{Pod, Zeroable},
 };
 
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
+
 /// Default Account state extension instructions
 pub mod instruction;
 
@@ -11,6 +14,7 @@ pub mod processor;
 
 /// Default Account::state extension data for mints.
 #[repr(C)]
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct DefaultAccountState {
     /// Default Account::state in which new Accounts should be initialized

--- a/token/program-2022/src/extension/immutable_owner.rs
+++ b/token/program-2022/src/extension/immutable_owner.rs
@@ -3,7 +3,11 @@ use {
     bytemuck::{Pod, Zeroable},
 };
 
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
+
 /// Indicates that the Account owner authority cannot be changed
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 #[repr(transparent)]
 pub struct ImmutableOwner;

--- a/token/program-2022/src/extension/interest_bearing_mint/mod.rs
+++ b/token/program-2022/src/extension/interest_bearing_mint/mod.rs
@@ -9,6 +9,9 @@ use {
     std::convert::TryInto,
 };
 
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
+
 /// Interest-bearing mint extension instructions
 pub mod instruction;
 
@@ -32,6 +35,7 @@ pub type UnixTimestamp = PodI64;
 /// To support changing the rate, the config also maintains state for the previous
 /// rate.
 #[repr(C)]
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct InterestBearingConfig {
     /// Authority that can set the interest rate and authority

--- a/token/program-2022/src/extension/memo_transfer/mod.rs
+++ b/token/program-2022/src/extension/memo_transfer/mod.rs
@@ -11,6 +11,9 @@ use {
     spl_pod::primitives::PodBool,
 };
 
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
+
 /// Memo Transfer extension instructions
 pub mod instruction;
 
@@ -19,6 +22,7 @@ pub mod processor;
 
 /// Memo Transfer extension for Accounts
 #[repr(C)]
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct MemoTransfer {
     /// Require transfers into this account to be accompanied by a memo

--- a/token/program-2022/src/extension/metadata_pointer/mod.rs
+++ b/token/program-2022/src/extension/metadata_pointer/mod.rs
@@ -4,6 +4,9 @@ use {
     spl_pod::optional_keys::OptionalNonZeroPubkey,
 };
 
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
+
 /// Instructions for the MetadataPointer extension
 pub mod instruction;
 /// Instruction processor for the MetadataPointer extension
@@ -11,6 +14,7 @@ pub mod processor;
 
 /// Metadata pointer extension data for mints.
 #[repr(C)]
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct MetadataPointer {
     /// Authority that can set the metadata address

--- a/token/program-2022/src/extension/mint_close_authority.rs
+++ b/token/program-2022/src/extension/mint_close_authority.rs
@@ -4,8 +4,12 @@ use {
     spl_pod::optional_keys::OptionalNonZeroPubkey,
 };
 
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
+
 /// Close authority extension data for mints.
 #[repr(C)]
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct MintCloseAuthority {
     /// Optional authority to close the mint

--- a/token/program-2022/src/extension/non_transferable.rs
+++ b/token/program-2022/src/extension/non_transferable.rs
@@ -3,12 +3,17 @@ use {
     bytemuck::{Pod, Zeroable},
 };
 
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
+
 /// Indicates that the tokens from this mint can't be transfered
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 #[repr(transparent)]
 pub struct NonTransferable;
 
 /// Indicates that the tokens from this account belong to a non-transferable mint
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 #[repr(transparent)]
 pub struct NonTransferableAccount;

--- a/token/program-2022/src/extension/permanent_delegate.rs
+++ b/token/program-2022/src/extension/permanent_delegate.rs
@@ -5,8 +5,12 @@ use {
     spl_pod::optional_keys::OptionalNonZeroPubkey,
 };
 
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
+
 /// Permanent delegate extension data for mints.
 #[repr(C)]
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct PermanentDelegate {
     /// Optional permanent delegate for transferring or burning tokens

--- a/token/program-2022/src/extension/transfer_fee/mod.rs
+++ b/token/program-2022/src/extension/transfer_fee/mod.rs
@@ -15,6 +15,9 @@ use {
     },
 };
 
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
+
 /// Transfer fee extension instructions
 pub mod instruction;
 
@@ -27,6 +30,7 @@ const ONE_IN_BASIS_POINTS: u128 = MAX_FEE_BASIS_POINTS as u128;
 
 /// Transfer fee information
 #[repr(C)]
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct TransferFee {
     /// First epoch where the transfer fee takes effect

--- a/token/program-2022/src/extension/transfer_hook/mod.rs
+++ b/token/program-2022/src/extension/transfer_hook/mod.rs
@@ -10,6 +10,9 @@ use {
     spl_pod::{optional_keys::OptionalNonZeroPubkey, primitives::PodBool},
 };
 
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
+
 /// Instructions for the TransferHook extension
 pub mod instruction;
 /// Instruction processor for the TransferHook extension
@@ -17,6 +20,7 @@ pub mod processor;
 
 /// Transfer hook extension data for mints.
 #[repr(C)]
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct TransferHook {
     /// Authority that can set the transfer hook program id
@@ -26,6 +30,7 @@ pub struct TransferHook {
 }
 
 /// Indicates that the tokens from this account belong to a mint with a transfer hook
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 #[repr(transparent)]
 pub struct TransferHookAccount {


### PR DESCRIPTION
Fixes #5431 

Note that for extension `confidentional_transfer` and `confidential_transfer_fee`,  some the fields are in a separate sdk which doesn't  have the serialisation enabled. We would have to change there first before setting it here 

Tested by turning on the compile time flags `serde-trait` by default and using it in our codebase. 