### PR TITLE
single-pool: add `ReactivatePool` instruction

### DIFF
--- a/single-pool/cli/src/cli.rs
+++ b/single-pool/cli/src/cli.rs
@@ -110,7 +110,7 @@ pub enum ManageCommand {
     /// Permissionlessly re-stake the pool stake account in the case when it has been deactivated.
     /// This may happen if the validator is force-deactivated, and then later reactivated using
     /// the same address for its vote account.
-    Reactivate(ReactivateCli),
+    ReactivatePoolStake(ReactivateCli),
 
     /// Permissionlessly create default MPL token metadata for the pool mint. Normally this is done
     /// automatically upon initialization, so this does not need to be called.
@@ -145,7 +145,7 @@ pub struct ReactivateCli {
 
     // backdoor for testing, theres no reason to ever use this
     #[clap(long, hide = true)]
-    pub yolo: bool,
+    pub skip_deactivation_check: bool,
 }
 
 #[derive(Clone, Debug, Args)]

--- a/single-pool/cli/src/cli.rs
+++ b/single-pool/cli/src/cli.rs
@@ -76,6 +76,11 @@ pub enum Command {
     /// along with the cluster-configured minimum stake delegation
     Initialize(InitializeCli),
 
+    /// Permissionlessly re-stake the pool stake account in the case when it has been deactivated.
+    /// This may happen if the validator is force-deactivated, and then later reactivated using
+    /// the same address for its vote account.
+    Reactivate(ReactivateCli),
+
     /// Deposit delegated stake into a pool in exchange for pool tokens, closing out
     /// the original stake account. Provide either a stake account address, or a
     /// pool or vote account address along with the --default-stake-account flag to
@@ -112,6 +117,22 @@ pub struct InitializeCli {
     /// Do not create MPL metadata for the pool mint
     #[clap(long)]
     pub skip_metadata: bool,
+}
+
+#[derive(Clone, Debug, Args)]
+#[clap(group(pool_source_group()))]
+pub struct ReactivateCli {
+    /// The pool to reactivate
+    #[clap(short, long = "pool", value_parser = |p: &str| parse_address(p, "pool_address"))]
+    pub pool_address: Option<Pubkey>,
+
+    /// The vote account corresponding to the pool to reactivate
+    #[clap(long = "vote-account", value_parser = |p: &str| parse_address(p, "vote_account_address"))]
+    pub vote_account_address: Option<Pubkey>,
+
+    // backdoor for testing, theres no reason to ever use this
+    #[clap(long, hide = true)]
+    pub yolo: bool,
 }
 
 #[derive(Clone, Debug, Args)]

--- a/single-pool/cli/src/main.rs
+++ b/single-pool/cli/src/main.rs
@@ -60,16 +60,22 @@ pub type CommandResult = Result<String, Error>;
 impl Command {
     pub async fn execute(self, config: &Config) -> CommandResult {
         match self {
-            Command::Initialize(command_config) => command_initialize(config, command_config).await,
-            Command::Reactivate(command_config) => command_reactivate(config, command_config).await,
+            Command::Manage(command) => match command.manage {
+                ManageCommand::Initialize(command_config) => {
+                    command_initialize(config, command_config).await
+                }
+                ManageCommand::Reactivate(command_config) => {
+                    command_reactivate(config, command_config).await
+                }
+                ManageCommand::CreateTokenMetadata(command_config) => {
+                    command_create_metadata(config, command_config).await
+                }
+                ManageCommand::UpdateTokenMetadata(command_config) => {
+                    command_update_metadata(config, command_config).await
+                }
+            },
             Command::Deposit(command_config) => command_deposit(config, command_config).await,
             Command::Withdraw(command_config) => command_withdraw(config, command_config).await,
-            Command::CreateTokenMetadata(command_config) => {
-                command_create_metadata(config, command_config).await
-            }
-            Command::UpdateTokenMetadata(command_config) => {
-                command_update_metadata(config, command_config).await
-            }
             Command::CreateDefaultStake(command_config) => {
                 command_create_stake(config, command_config).await
             }

--- a/single-pool/cli/tests/test.rs
+++ b/single-pool/cli/tests/test.rs
@@ -248,6 +248,29 @@ async fn create_and_delegate_stake_account(
     stake_account.pubkey()
 }
 
+#[tokio::test]
+#[serial]
+async fn reactivate() {
+    let env = setup(true).await;
+
+    // setting up a test validator for this to succeed is hell, and success is tested in program tests
+    // so we just make sure the cli can send a well-formed instruction
+    let output = Command::new(SVSP_CLI)
+        .args([
+            "reactivate",
+            "-C",
+            &env.config_file_path,
+            "--vote-account",
+            &env.vote_account.to_string(),
+            "--yolo",
+        ])
+        .output()
+        .unwrap();
+    assert!(String::from_utf8(output.stderr)
+        .unwrap()
+        .contains("custom program error: 0xc"));
+}
+
 #[test_case(true; "default_stake")]
 #[test_case(false; "normal_stake")]
 #[tokio::test]

--- a/single-pool/cli/tests/test.rs
+++ b/single-pool/cli/tests/test.rs
@@ -253,7 +253,7 @@ async fn create_and_delegate_stake_account(
 
 #[tokio::test]
 #[serial]
-async fn reactivate() {
+async fn reactivate_pool_stake() {
     let env = setup(true).await;
 
     // setting up a test validator for this to succeed is hell, and success is tested in program tests
@@ -261,12 +261,12 @@ async fn reactivate() {
     let output = Command::new(SVSP_CLI)
         .args([
             "manage",
-            "reactivate",
+            "reactivate-pool-stake",
             "-C",
             &env.config_file_path,
             "--vote-account",
             &env.vote_account.to_string(),
-            "--yolo",
+            "--skip-deactivation-check",
         ])
         .output()
         .unwrap();

--- a/single-pool/cli/tests/test.rs
+++ b/single-pool/cli/tests/test.rs
@@ -39,6 +39,7 @@ pub struct Env {
     pub rpc_client: Arc<RpcClient>,
     pub program_client: PClient,
     pub payer: Keypair,
+    pub keypair_file_path: String,
     pub config_file_path: String,
     pub vote_account: Pubkey,
 
@@ -79,6 +80,7 @@ async fn setup(initialize: bool) -> Env {
     if initialize {
         let status = Command::new(SVSP_CLI)
             .args([
+                "manage",
                 "initialize",
                 "-C",
                 config_file_path,
@@ -93,6 +95,7 @@ async fn setup(initialize: bool) -> Env {
         rpc_client,
         program_client,
         payer,
+        keypair_file_path: keypair_file.path().to_str().unwrap().to_string(),
         config_file_path: config_file_path.to_string(),
         vote_account,
         validator,
@@ -257,6 +260,7 @@ async fn reactivate() {
     // so we just make sure the cli can send a well-formed instruction
     let output = Command::new(SVSP_CLI)
         .args([
+            "manage",
             "reactivate",
             "-C",
             &env.config_file_path,
@@ -360,6 +364,7 @@ async fn create_metadata() {
 
     let status = Command::new(SVSP_CLI)
         .args([
+            "manage",
             "initialize",
             "-C",
             &env.config_file_path,
@@ -372,6 +377,7 @@ async fn create_metadata() {
 
     let status = Command::new(SVSP_CLI)
         .args([
+            "manage",
             "create-token-metadata",
             "-C",
             &env.config_file_path,
@@ -390,6 +396,7 @@ async fn update_metadata() {
 
     let status = Command::new(SVSP_CLI)
         .args([
+            "manage",
             "update-token-metadata",
             "-C",
             &env.config_file_path,
@@ -397,6 +404,24 @@ async fn update_metadata() {
             &env.vote_account.to_string(),
             "whatever",
             "idk",
+        ])
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    // testing this flag because the match is rather torturous
+    let status = Command::new(SVSP_CLI)
+        .args([
+            "manage",
+            "update-token-metadata",
+            "-C",
+            &env.config_file_path,
+            "--vote-account",
+            &env.vote_account.to_string(),
+            "--authorized-withdrawer",
+            &env.keypair_file_path,
+            "something",
+            "new",
         ])
         .status()
         .unwrap();

--- a/single-pool/js/src/internal.ts
+++ b/single-pool/js/src/internal.ts
@@ -57,11 +57,11 @@ export const SINGLE_POOL_INSTRUCTION_LAYOUTS: {
     layout: BufferLayout.struct<any>([BufferLayout.u8('instruction')]),
   },
   DepositStake: {
-    index: 1,
+    index: 2,
     layout: BufferLayout.struct<any>([BufferLayout.u8('instruction')]),
   },
   WithdrawStake: {
-    index: 2,
+    index: 3,
     layout: BufferLayout.struct<any>([
       BufferLayout.u8('instruction'),
       BufferLayout.seq(BufferLayout.u8(), 32, 'userStakeAuthority'),
@@ -69,7 +69,7 @@ export const SINGLE_POOL_INSTRUCTION_LAYOUTS: {
     ]),
   },
   CreateTokenMetadata: {
-    index: 3,
+    index: 4,
     layout: BufferLayout.struct<any>([BufferLayout.u8('instruction')]),
   },
 });
@@ -92,7 +92,7 @@ export function updateTokenMetadataLayout(
   }
 
   return {
-    index: 4,
+    index: 5,
     layout: BufferLayout.struct<any>([
       BufferLayout.u8('instruction'),
       BufferLayout.u32('tokenNameLen'),

--- a/single-pool/program/src/instruction.rs
+++ b/single-pool/program/src/instruction.rs
@@ -43,8 +43,8 @@ pub enum SinglePoolInstruction {
     ///  12. `[]` Stake program
     InitializePool,
 
-    ///   Restake the pool stake account if its validator is force-deactivated and later
-    ///   recreated with the same vote account.
+    ///   Restake the pool stake account if it was deactivated. This can happen through the
+    ///   stake program's `DeactivateDelinquent` instruction, or during a cluster restart.
     ///
     ///   0. `[]` Validator vote account
     ///   1. `[]` Pool account
@@ -54,7 +54,7 @@ pub enum SinglePoolInstruction {
     ///   5. `[]` Stake history sysvar
     ///   6. `[]` Stake config sysvar
     ///   7. `[]` Stake program
-    ReactivatePool,
+    ReactivatePoolStake,
 
     ///   Deposit stake into the pool.  The output is a "pool" token representing fractional
     ///   ownership of the pool stake. Inputs are converted to the current ratio.
@@ -190,11 +190,13 @@ pub fn initialize_pool(program_id: &Pubkey, vote_account_address: &Pubkey) -> In
     }
 }
 
-/// Creates a `ReactivatePool` instruction.
-pub fn reactivate_pool(program_id: &Pubkey, vote_account_address: &Pubkey) -> Instruction {
+/// Creates a `ReactivatePoolStake` instruction.
+pub fn reactivate_pool_stake(program_id: &Pubkey, vote_account_address: &Pubkey) -> Instruction {
     let pool_address = find_pool_address(program_id, vote_account_address);
 
-    let data = SinglePoolInstruction::ReactivatePool.try_to_vec().unwrap();
+    let data = SinglePoolInstruction::ReactivatePoolStake
+        .try_to_vec()
+        .unwrap();
     let accounts = vec![
         AccountMeta::new_readonly(*vote_account_address, false),
         AccountMeta::new_readonly(pool_address, false),

--- a/single-pool/program/src/processor.rs
+++ b/single-pool/program/src/processor.rs
@@ -707,7 +707,10 @@ impl Processor {
         Ok(())
     }
 
-    fn process_reactivate_pool(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
+    fn process_reactivate_pool_stake(
+        program_id: &Pubkey,
+        accounts: &[AccountInfo],
+    ) -> ProgramResult {
         let account_info_iter = &mut accounts.iter();
         let vote_account_info = next_account_info(account_info_iter)?;
         let pool_info = next_account_info(account_info_iter)?;
@@ -733,7 +736,7 @@ impl Processor {
         check_stake_program(stake_program_info.key)?;
 
         let (_, pool_stake_state) = get_stake_state(pool_stake_info)?;
-        if pool_stake_state.delegation.deactivation_epoch >= clock.epoch {
+        if pool_stake_state.delegation.deactivation_epoch > clock.epoch {
             return Err(SinglePoolError::WrongStakeState.into());
         }
 
@@ -1178,9 +1181,9 @@ impl Processor {
                 msg!("Instruction: InitializePool");
                 Self::process_initialize_pool(program_id, accounts)
             }
-            SinglePoolInstruction::ReactivatePool => {
-                msg!("Instruction: ReactivatePool");
-                Self::process_reactivate_pool(program_id, accounts)
+            SinglePoolInstruction::ReactivatePoolStake => {
+                msg!("Instruction: ReactivatePoolStake");
+                Self::process_reactivate_pool_stake(program_id, accounts)
             }
             SinglePoolInstruction::DepositStake => {
                 msg!("Instruction: DepositStake");

--- a/single-pool/program/tests/accounts.rs
+++ b/single-pool/program/tests/accounts.rs
@@ -196,6 +196,7 @@ async fn fail_account_checks(test_mode: TestMode) {
 
 // make an individual instruction for all program instructions
 // the match is just so this will error if new instructions are added
+// if you are reading this because of that error, add the case to the `consistent_account_order` test!!!
 fn make_basic_instruction(
     accounts: &SinglePoolAccounts,
     instruction_type: SinglePoolInstruction,
@@ -203,6 +204,9 @@ fn make_basic_instruction(
     match instruction_type {
         SinglePoolInstruction::InitializePool => {
             instruction::initialize_pool(&id(), &accounts.vote_account.pubkey())
+        }
+        SinglePoolInstruction::ReactivatePool => {
+            instruction::reactivate_pool(&id(), &accounts.vote_account.pubkey())
         }
         SinglePoolInstruction::DepositStake => instruction::deposit_stake(
             &id(),
@@ -258,6 +262,7 @@ fn consistent_account_order() {
 
     let instructions = vec![
         make_basic_instruction(&accounts, SinglePoolInstruction::InitializePool),
+        make_basic_instruction(&accounts, SinglePoolInstruction::ReactivatePool),
         make_basic_instruction(&accounts, SinglePoolInstruction::DepositStake),
         make_basic_instruction(
             &accounts,

--- a/single-pool/program/tests/accounts.rs
+++ b/single-pool/program/tests/accounts.rs
@@ -205,8 +205,8 @@ fn make_basic_instruction(
         SinglePoolInstruction::InitializePool => {
             instruction::initialize_pool(&id(), &accounts.vote_account.pubkey())
         }
-        SinglePoolInstruction::ReactivatePool => {
-            instruction::reactivate_pool(&id(), &accounts.vote_account.pubkey())
+        SinglePoolInstruction::ReactivatePoolStake => {
+            instruction::reactivate_pool_stake(&id(), &accounts.vote_account.pubkey())
         }
         SinglePoolInstruction::DepositStake => instruction::deposit_stake(
             &id(),
@@ -262,7 +262,7 @@ fn consistent_account_order() {
 
     let instructions = vec![
         make_basic_instruction(&accounts, SinglePoolInstruction::InitializePool),
-        make_basic_instruction(&accounts, SinglePoolInstruction::ReactivatePool),
+        make_basic_instruction(&accounts, SinglePoolInstruction::ReactivatePoolStake),
         make_basic_instruction(&accounts, SinglePoolInstruction::DepositStake),
         make_basic_instruction(
             &accounts,

--- a/single-pool/program/tests/reactivate.rs
+++ b/single-pool/program/tests/reactivate.rs
@@ -1,0 +1,149 @@
+#![allow(clippy::integer_arithmetic)]
+#![cfg(feature = "test-sbf")]
+
+mod helpers;
+
+use {
+    bincode::serialize,
+    helpers::*,
+    solana_program_test::*,
+    solana_sdk::{
+        account::AccountSharedData,
+        signature::Signer,
+        stake::state::{Delegation, Stake, StakeState},
+        transaction::Transaction,
+    },
+    spl_single_validator_pool::{error::SinglePoolError, id, instruction},
+    test_case::test_case,
+};
+
+#[tokio::test]
+async fn success() {
+    let mut context = program_test().start_with_context().await;
+    let accounts = SinglePoolAccounts::default();
+    accounts
+        .initialize_for_deposit(&mut context, TEST_STAKE_AMOUNT, None)
+        .await;
+    advance_epoch(&mut context).await;
+
+    // deactivate the pool stake account
+    let (meta, stake, _) =
+        get_stake_account(&mut context.banks_client, &accounts.stake_account).await;
+    let delegation = Delegation {
+        activation_epoch: 0,
+        deactivation_epoch: 0,
+        ..stake.unwrap().delegation
+    };
+    let account_data = serialize(&StakeState::Stake(
+        meta,
+        Stake {
+            delegation,
+            ..stake.unwrap()
+        },
+    ))
+    .unwrap();
+
+    let mut stake_account = get_account(&mut context.banks_client, &accounts.stake_account).await;
+    stake_account.data = account_data;
+    context.set_account(
+        &accounts.stake_account,
+        &AccountSharedData::from(stake_account),
+    );
+
+    // make sure deposit fails
+    let instructions = instruction::deposit(
+        &id(),
+        &accounts.pool,
+        &accounts.alice_stake.pubkey(),
+        &accounts.alice_token,
+        &accounts.alice.pubkey(),
+        &accounts.alice.pubkey(),
+    );
+    let transaction = Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &accounts.alice],
+        context.last_blockhash,
+    );
+
+    let e = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err();
+    check_error(e, SinglePoolError::WrongStakeState);
+
+    // reactivate
+    let instruction = instruction::reactivate_pool(&id(), &accounts.vote_account.pubkey());
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+
+    advance_epoch(&mut context).await;
+
+    // deposit works again
+    let instructions = instruction::deposit(
+        &id(),
+        &accounts.pool,
+        &accounts.alice_stake.pubkey(),
+        &accounts.alice_token,
+        &accounts.alice.pubkey(),
+        &accounts.alice.pubkey(),
+    );
+    let transaction = Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &accounts.alice],
+        context.last_blockhash,
+    );
+
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+
+    assert!(context
+        .banks_client
+        .get_account(accounts.alice_stake.pubkey())
+        .await
+        .expect("get_account")
+        .is_none());
+}
+
+#[test_case(true; "activated")]
+#[test_case(false; "activating")]
+#[tokio::test]
+async fn fail_not_deactivated(activate: bool) {
+    let mut context = program_test().start_with_context().await;
+    let accounts = SinglePoolAccounts::default();
+    accounts.initialize(&mut context).await;
+
+    if activate {
+        advance_epoch(&mut context).await;
+    }
+
+    let instruction = instruction::reactivate_pool(&id(), &accounts.vote_account.pubkey());
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    let e = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err();
+    check_error(e, SinglePoolError::WrongStakeState);
+}


### PR DESCRIPTION
handles the issue described in #5439. the first commit is the important one (changes the program itself), the others just add to the cli. also i moved half the commands into a subcommand, 99% of users are only ever going to need `deposit` and `withdraw` so im trying to minimize visual clutter