### PR TITLE
[account compression] bump sdk versions

### DIFF
--- a/account-compression/Cargo.lock
+++ b/account-compression/Cargo.lock
@@ -1382,9 +1382,9 @@ checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.16.15"
+version = "1.16.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "361cc834e5fbbe1a73f1d904fcb8ab052a665e5be6061bd1ba7ab478d7d17c9c"
+checksum = "02eb4f0ed3eade20f4abdcc0031167344237cd6e16808bd0f33945f9db7861fe"
 dependencies = [
  "ahash 0.8.3",
  "blake3",
@@ -1415,9 +1415,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.16.15"
+version = "1.16.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "575d875dc050689f9f88c542e292e295e2f081d4e96e0df297981e45cbad8824"
+checksum = "f28514761a285944cbad5b3d7930546369b80a713ba37d84bcf6ed2753611765"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1427,9 +1427,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.16.15"
+version = "1.16.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9863ff5c6e828015bec331c26fb53e48352a264a9be682e7e078d2c3b3e93b46"
+checksum = "cff2aa5434a77413e9d43e971ceb47bdb003f2e8bbc0365a25b684aca2605c25"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1482,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.16.15"
+version = "1.16.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd177a74fb3a0a362f1292c027d668eff609ac189f08b78158324587a0a4f8d1"
+checksum = "4b41b63b2da4a37ce323aba108db21f4c7bfa638dd1bf58fdc870f83bdce48ba"
 dependencies = [
  "bs58 0.4.0",
  "proc-macro2",
@@ -1495,7 +1495,7 @@ dependencies = [
 
 [[package]]
 name = "spl-account-compression"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anchor-lang",
  "bytemuck",

--- a/account-compression/programs/account-compression/Cargo.toml
+++ b/account-compression/programs/account-compression/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-account-compression"
-version = "0.2.0"
+version = "0.3.0"
 description = "Solana Program Library Account Compression Program"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/account-compression/sdk/package.json
+++ b/account-compression/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@solana/spl-account-compression",
   "description": "SPL Account Compression Program JS API",
-  "version": "0.1.11",
+  "version": "0.2.0",
   "author": "Solana Labs Maintainers <maintainers@solanalabs.com>",
   "repository": {
     "url": "https://github.com/solana-labs/solana-program-library",

--- a/account-compression/sdk/package.json
+++ b/account-compression/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@solana/spl-account-compression",
   "description": "SPL Account Compression Program JS API",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "author": "Solana Labs Maintainers <maintainers@solanalabs.com>",
   "repository": {
     "url": "https://github.com/solana-labs/solana-program-library",


### PR DESCRIPTION
- rust sdk 0.2.0 -> 0.3.0 
- ts sdk 0.1.10 -> 0.2.0

Minor versioning because new buffer/depth options have tiny potential to break systems that hard-coded the previous list.