### PR TITLE
stake-pool: Fix test for monorepo downstream job

### DIFF
--- a/stake-pool/program/tests/force_destake.rs
+++ b/stake-pool/program/tests/force_destake.rs
@@ -41,10 +41,12 @@ async fn setup(
     let (mut stake_pool, mut validator_list) = stake_pool_accounts.state();
 
     let _ = add_vote_account_with_pubkey(voter_pubkey, &mut program_test);
+    let mut data = vec![0; std::mem::size_of::<StakeState>()];
+    bincode::serialize_into(&mut data[..], forced_stake).unwrap();
 
     let stake_account = Account::create(
         TEST_STAKE_AMOUNT + STAKE_ACCOUNT_RENT_EXEMPTION,
-        bincode::serialize::<StakeState>(forced_stake).unwrap(),
+        data,
         stake::program::id(),
         false,
         Epoch::default(),
@@ -233,7 +235,6 @@ async fn fail_increase() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn success_remove_validator() {
     let stake_pool_accounts = StakePoolAccounts::default();
     let meta = Meta {


### PR DESCRIPTION
#### Problem

As noted in https://github.com/solana-labs/solana-program-library/pull/5439#issuecomment-1758777522, the new force-destake test was failing in the downstream job from the monorepo.

This is happening because the test is serializing 196 bytes for the stake account, rather than the expected 200 bytes. This works fine in 1.16, where we don't use the extra 4 bytes. In 1.17 and 1.18, however, those extra 4 bytes matter for the stake flags.

#### Solution

Overallocate the vector used when serializing a `StakeState`.