### PR TITLE
token-cli: Bump to 3.2.0 for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7120,7 +7120,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-cli"
-version = "3.1.1"
+version = "3.2.0"
 dependencies = [
  "assert_cmd",
  "base64 0.21.4",

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://spl.solana.com/token"
 license = "Apache-2.0"
 name = "spl-token-cli"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "3.1.1"
+version = "3.2.0"
 
 [build-dependencies]
 walkdir = "2"


### PR DESCRIPTION
#### Problem

There have been some fixes and updates to the token-cli, to display new extensions, and to correctly update metadata with offline signers, but it's not released yet.

#### Solution

Bump the version to release!