### PR TITLE
token-client: Bump to 0.7.1 for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7155,7 +7155,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-client"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "curve25519-dalek",

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "spl-token-client"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "0.7.0"
+version = "0.7.1"
 
 [dependencies]
 async-trait = "0.1"


### PR DESCRIPTION
#### Problem

We bumped token-cli in #5531, but we also need the token-client on a new version because of a changed function.

#### Solution

Bump the version!