### PR TITLE
[token-cli] Enable configuring confidential transfer account

### DIFF
--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -2966,24 +2966,6 @@ async fn command_enable_disable_confidential_transfers(
         );
     }
 
-    // Reallocation (if needed)
-    let mut existing_extensions: Vec<ExtensionType> = state_with_extension.get_extension_types()?;
-    if !existing_extensions.contains(&ExtensionType::ConfidentialTransferAccount) {
-        existing_extensions.push(ExtensionType::ConfidentialTransferAccount);
-        let needed_account_len =
-            ExtensionType::try_calculate_account_len::<Account>(&existing_extensions)?;
-        if needed_account_len > current_account_len {
-            token
-                .reallocate(
-                    &token_account_address,
-                    &owner,
-                    &[ExtensionType::ConfidentialTransferAccount],
-                    &bulk_signers,
-                )
-                .await?;
-        }
-    }
-
     let res = if let Some(allow_confidential_credits) = allow_confidential_credits {
         let extension_state = state_with_extension
             .get_extension::<ConfidentialTransferAccount>()?

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -4715,7 +4715,7 @@ fn app<'a, 'b>(
                         .value_name("TOKEN_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .conflicts_with("token")
-                        .help("The address of the token account to configure confidential transfers for \
+                        .help("The address of the token account to enable confidential transfers for \
                             [default: owner's associated token account]")
                 )
                 .arg(
@@ -4744,7 +4744,7 @@ fn app<'a, 'b>(
                         .value_name("TOKEN_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .conflicts_with("token")
-                        .help("The address of the token account to configure confidential transfers for \
+                        .help("The address of the token account to disable confidential transfers for \
                             [default: owner's associated token account]")
                 )
                 .arg(
@@ -4773,7 +4773,7 @@ fn app<'a, 'b>(
                         .value_name("TOKEN_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .conflicts_with("token")
-                        .help("The address of the token account to configure confidential transfers for \
+                        .help("The address of the token account to enable non-confidential transfers for \
                             [default: owner's associated token account]")
                 )
                 .arg(
@@ -4802,7 +4802,7 @@ fn app<'a, 'b>(
                         .value_name("TOKEN_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .conflicts_with("token")
-                        .help("The address of the token account to configure confidential transfers for \
+                        .help("The address of the token account to disable non-confidential transfers for \
                             [default: owner's associated token account]")
                 )
                 .arg(

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -170,10 +170,10 @@ pub enum CommandName {
     UpdateMetadata,
     UpdateConfidentialTransferSettings,
     ConfigureConfidentialTransferAccount,
-    EnableConfidentialTransfers,
-    DisableConfidentialTransfers,
-    EnableNonConfidentialTransfers,
-    DisableNonConfidentialTransfers,
+    EnableConfidentialCredits,
+    DisableConfidentialCredits,
+    EnableNonConfidentialCredits,
+    DisableNonConfidentialCredits,
 }
 impl fmt::Display for CommandName {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -4685,7 +4685,7 @@ fn app<'a, 'b>(
                 .nonce_args(true)
         )
         .subcommand(
-            SubCommand::with_name(CommandName::EnableConfidentialTransfers.into())
+            SubCommand::with_name(CommandName::EnableConfidentialCredits.into())
                 .about("Enable confidential transfers for token account. To enable confidential transfers \
                 for the first time, use `configure-confidential-transfer-account` instead.")
                 .arg(
@@ -4704,7 +4704,7 @@ fn app<'a, 'b>(
                 .nonce_args(true)
         )
         .subcommand(
-            SubCommand::with_name(CommandName::DisableConfidentialTransfers.into())
+            SubCommand::with_name(CommandName::DisableConfidentialCredits.into())
                 .about("Disable confidential transfers for token account")
                 .arg(
                     Arg::with_name("account")
@@ -4722,7 +4722,7 @@ fn app<'a, 'b>(
                 .nonce_args(true)
         )
         .subcommand(
-            SubCommand::with_name(CommandName::EnableNonConfidentialTransfers.into())
+            SubCommand::with_name(CommandName::EnableNonConfidentialCredits.into())
                 .about("Enable non-confidential transfers for token account.")
                 .arg(
                     Arg::with_name("account")
@@ -4740,7 +4740,7 @@ fn app<'a, 'b>(
                 .nonce_args(true)
         )
         .subcommand(
-            SubCommand::with_name(CommandName::DisableNonConfidentialTransfers.into())
+            SubCommand::with_name(CommandName::DisableNonConfidentialCredits.into())
                 .about("Disable non-confidential transfers for token account")
                 .arg(
                     Arg::with_name("account")
@@ -5641,7 +5641,7 @@ async fn process_command<'a>(
             )
             .await
         }
-        (CommandName::EnableConfidentialTransfers, arg_matches) => {
+        (CommandName::EnableConfidentialCredits, arg_matches) => {
             let (owner_signer, owner) =
                 config.signer_or_default(arg_matches, "owner", &mut wallet_manager);
 
@@ -5662,7 +5662,7 @@ async fn process_command<'a>(
             )
             .await
         }
-        (CommandName::DisableConfidentialTransfers, arg_matches) => {
+        (CommandName::DisableConfidentialCredits, arg_matches) => {
             let (owner_signer, owner) =
                 config.signer_or_default(arg_matches, "owner", &mut wallet_manager);
 
@@ -5683,7 +5683,7 @@ async fn process_command<'a>(
             )
             .await
         }
-        (CommandName::EnableNonConfidentialTransfers, arg_matches) => {
+        (CommandName::EnableNonConfidentialCredits, arg_matches) => {
             let (owner_signer, owner) =
                 config.signer_or_default(arg_matches, "owner", &mut wallet_manager);
 
@@ -5704,7 +5704,7 @@ async fn process_command<'a>(
             )
             .await
         }
-        (CommandName::DisableNonConfidentialTransfers, arg_matches) => {
+        (CommandName::DisableNonConfidentialCredits, arg_matches) => {
             let (owner_signer, owner) =
                 config.signer_or_default(arg_matches, "owner", &mut wallet_manager);
 
@@ -8370,7 +8370,7 @@ mod tests {
             &payer,
             &[
                 "spl-token",
-                CommandName::DisableConfidentialTransfers.into(),
+                CommandName::DisableConfidentialCredits.into(),
                 &token_account.to_string(),
             ],
         )
@@ -8389,7 +8389,7 @@ mod tests {
             &payer,
             &[
                 "spl-token",
-                CommandName::EnableConfidentialTransfers.into(),
+                CommandName::EnableConfidentialCredits.into(),
                 &token_account.to_string(),
             ],
         )
@@ -8409,7 +8409,7 @@ mod tests {
             &payer,
             &[
                 "spl-token",
-                CommandName::DisableNonConfidentialTransfers.into(),
+                CommandName::DisableNonConfidentialCredits.into(),
                 &token_account.to_string(),
             ],
         )
@@ -8428,7 +8428,7 @@ mod tests {
             &payer,
             &[
                 "spl-token",
-                CommandName::EnableNonConfidentialTransfers.into(),
+                CommandName::EnableNonConfidentialCredits.into(),
                 &token_account.to_string(),
             ],
         )

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -5602,11 +5602,16 @@ async fn process_command<'a>(
                 push_signer_with_dedup(owner_signer, &mut bulk_signers);
             }
 
-            let maximum_credit_counter = value_t!(
-                arg_matches.value_of("maximum_pending_balance_credit_counter"),
-                u64
-            )
-            .ok();
+            let maximum_credit_counter =
+                if arg_matches.is_present("maximum_pending_balance_credit_counter") {
+                    let maximum_credit_counter = value_t_or_exit!(
+                        arg_matches.value_of("maximum_pending_balance_credit_counter"),
+                        u64
+                    );
+                    Some(maximum_credit_counter)
+                } else {
+                    None
+                };
 
             command_configure_confidential_transfer_account(
                 config,

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -4657,6 +4657,16 @@ fn app<'a, 'b>(
             SubCommand::with_name(CommandName::ConfigureConfidentialTransferAccount.into())
                 .about("Configure confidential transfers for token account")
                 .arg(
+                    Arg::with_name("token")
+                        .long("token")
+                        .validator(is_valid_pubkey)
+                        .value_name("TOKEN_MINT_ADDRESS")
+                        .takes_value(true)
+                        .index(1)
+                        .required_unless("address")
+                        .help("The token address with confidential transfers enabled"),
+                )
+                .arg(
                     Arg::with_name("address")
                         .long("address")
                         .validator(is_valid_pubkey)
@@ -4668,16 +4678,6 @@ fn app<'a, 'b>(
                 )
                 .arg(
                     owner_address_arg()
-                )
-                .arg(
-                    Arg::with_name("token")
-                        .long("token")
-                        .validator(is_valid_pubkey)
-                        .value_name("TOKEN_MINT_ADDRESS")
-                        .takes_value(true)
-                        .index(1)
-                        .required_unless("address")
-                        .help("The token address with confidential transfers enabled"),
                 )
                 .arg(
                     Arg::with_name("maximum_pending_balance_credit_counter")
@@ -4699,20 +4699,24 @@ fn app<'a, 'b>(
                 .about("Enable confidential transfers for token account. To enable confidential transfers \
                 for the first time, use `configure-confidential-transfer-account` instead.")
                 .arg(
-                    Arg::with_name("account")
-                        .validator(is_valid_pubkey)
-                        .value_name("TOKEN_ACCOUNT_ADDRESS")
-                        .takes_value(true)
-                        .index(1)
-                        .help("The address of the token account to enable confidential transfers for")
-                )
-                .arg(
                     Arg::with_name("token")
                         .long("token")
                         .validator(is_valid_pubkey)
                         .value_name("TOKEN_MINT_ADDRESS")
                         .takes_value(true)
+                        .index(1)
+                        .required_unless("address")
                         .help("The token address with confidential transfers enabled"),
+                )
+                .arg(
+                    Arg::with_name("address")
+                        .long("address")
+                        .validator(is_valid_pubkey)
+                        .value_name("TOKEN_ACCOUNT_ADDRESS")
+                        .takes_value(true)
+                        .conflicts_with("token")
+                        .help("The address of the token account to configure confidential transfers for \
+                            [default: owner's associated token account]")
                 )
                 .arg(
                     owner_address_arg()
@@ -4724,20 +4728,24 @@ fn app<'a, 'b>(
             SubCommand::with_name(CommandName::DisableConfidentialCredits.into())
                 .about("Disable confidential transfers for token account")
                 .arg(
-                    Arg::with_name("account")
-                        .validator(is_valid_pubkey)
-                        .value_name("TOKEN_ACCOUNT_ADDRESS")
-                        .takes_value(true)
-                        .index(1)
-                        .help("The address of the token account to disable confidential transfers for")
-                )
-                .arg(
                     Arg::with_name("token")
                         .long("token")
                         .validator(is_valid_pubkey)
                         .value_name("TOKEN_MINT_ADDRESS")
                         .takes_value(true)
+                        .index(1)
+                        .required_unless("address")
                         .help("The token address with confidential transfers enabled"),
+                )
+                .arg(
+                    Arg::with_name("address")
+                        .long("address")
+                        .validator(is_valid_pubkey)
+                        .value_name("TOKEN_ACCOUNT_ADDRESS")
+                        .takes_value(true)
+                        .conflicts_with("token")
+                        .help("The address of the token account to configure confidential transfers for \
+                            [default: owner's associated token account]")
                 )
                 .arg(
                     owner_address_arg()
@@ -4749,20 +4757,24 @@ fn app<'a, 'b>(
             SubCommand::with_name(CommandName::EnableNonConfidentialCredits.into())
                 .about("Enable non-confidential transfers for token account.")
                 .arg(
-                    Arg::with_name("account")
-                        .validator(is_valid_pubkey)
-                        .value_name("TOKEN_ACCOUNT_ADDRESS")
-                        .takes_value(true)
-                        .index(1)
-                        .help("The address of the token account to enable non-confidential transfers for")
-                )
-                .arg(
                     Arg::with_name("token")
                         .long("token")
                         .validator(is_valid_pubkey)
                         .value_name("TOKEN_MINT_ADDRESS")
                         .takes_value(true)
+                        .index(1)
+                        .required_unless("address")
                         .help("The token address with confidential transfers enabled"),
+                )
+                .arg(
+                    Arg::with_name("address")
+                        .long("address")
+                        .validator(is_valid_pubkey)
+                        .value_name("TOKEN_ACCOUNT_ADDRESS")
+                        .takes_value(true)
+                        .conflicts_with("token")
+                        .help("The address of the token account to configure confidential transfers for \
+                            [default: owner's associated token account]")
                 )
                 .arg(
                     owner_address_arg()
@@ -4774,20 +4786,24 @@ fn app<'a, 'b>(
             SubCommand::with_name(CommandName::DisableNonConfidentialCredits.into())
                 .about("Disable non-confidential transfers for token account")
                 .arg(
-                    Arg::with_name("account")
-                        .validator(is_valid_pubkey)
-                        .value_name("TOKEN_ACCOUNT_ADDRESS")
-                        .takes_value(true)
-                        .index(1)
-                        .help("The address of the token account to disable non-confidential transfers for")
-                )
-                .arg(
                     Arg::with_name("token")
                         .long("token")
                         .validator(is_valid_pubkey)
                         .value_name("TOKEN_MINT_ADDRESS")
                         .takes_value(true)
+                        .index(1)
+                        .required_unless("address")
                         .help("The token address with confidential transfers enabled"),
+                )
+                .arg(
+                    Arg::with_name("address")
+                        .long("address")
+                        .validator(is_valid_pubkey)
+                        .value_name("TOKEN_ACCOUNT_ADDRESS")
+                        .takes_value(true)
+                        .conflicts_with("token")
+                        .help("The address of the token account to configure confidential transfers for \
+                            [default: owner's associated token account]")
                 )
                 .arg(
                     owner_address_arg()
@@ -5650,7 +5666,7 @@ async fn process_command<'a>(
             let (owner_signer, owner) =
                 config.signer_or_default(arg_matches, "owner", &mut wallet_manager);
 
-            let account = pubkey_of_signer(arg_matches, "account", &mut wallet_manager).unwrap();
+            let account = pubkey_of_signer(arg_matches, "address", &mut wallet_manager).unwrap();
 
             // Deriving ElGamal and AES key from signer. Custom ElGamal and AES keys will be
             // supported in the future once upgrading to clap-v3.
@@ -5696,7 +5712,7 @@ async fn process_command<'a>(
             let (owner_signer, owner) =
                 config.signer_or_default(arg_matches, "owner", &mut wallet_manager);
 
-            let account = pubkey_of_signer(arg_matches, "account", &mut wallet_manager).unwrap();
+            let account = pubkey_of_signer(arg_matches, "address", &mut wallet_manager).unwrap();
 
             if config.multisigner_pubkeys.is_empty() {
                 push_signer_with_dedup(owner_signer, &mut bulk_signers);
@@ -8345,7 +8361,7 @@ mod tests {
             &[
                 "spl-token",
                 CommandName::ConfigureConfidentialTransferAccount.into(),
-                &token_account.to_string(),
+                &token_pubkey.to_string(),
             ],
         )
         .await
@@ -8367,7 +8383,7 @@ mod tests {
             &[
                 "spl-token",
                 CommandName::DisableConfidentialCredits.into(),
-                &token_account.to_string(),
+                &token_pubkey.to_string(),
             ],
         )
         .await
@@ -8386,7 +8402,7 @@ mod tests {
             &[
                 "spl-token",
                 CommandName::EnableConfidentialCredits.into(),
-                &token_account.to_string(),
+                &token_pubkey.to_string(),
             ],
         )
         .await
@@ -8406,7 +8422,7 @@ mod tests {
             &[
                 "spl-token",
                 CommandName::DisableNonConfidentialCredits.into(),
-                &token_account.to_string(),
+                &token_pubkey.to_string(),
             ],
         )
         .await
@@ -8425,7 +8441,7 @@ mod tests {
             &[
                 "spl-token",
                 CommandName::EnableNonConfidentialCredits.into(),
-                &token_account.to_string(),
+                &token_pubkey.to_string(),
             ],
         )
         .await

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -4657,12 +4657,14 @@ fn app<'a, 'b>(
             SubCommand::with_name(CommandName::ConfigureConfidentialTransferAccount.into())
                 .about("Configure confidential transfers for token account")
                 .arg(
-                    Arg::with_name("account")
+                    Arg::with_name("address")
+                        .long("address")
                         .validator(is_valid_pubkey)
                         .value_name("TOKEN_ACCOUNT_ADDRESS")
                         .takes_value(true)
-                        .index(1)
-                        .help("The address of the token account to configure confidential transfers for")
+                        .conflicts_with("token")
+                        .help("The address of the token account to configure confidential transfers for \
+                            [default: owner's associated token account]")
                 )
                 .arg(
                     owner_address_arg()
@@ -4673,6 +4675,8 @@ fn app<'a, 'b>(
                         .validator(is_valid_pubkey)
                         .value_name("TOKEN_MINT_ADDRESS")
                         .takes_value(true)
+                        .index(1)
+                        .required_unless("address")
                         .help("The token address with confidential transfers enabled"),
                 )
                 .arg(

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -2852,13 +2852,10 @@ async fn command_update_confidential_transfer_settings(
         if let Some(new_auditor_pubkey) = new_auditor_pubkey {
             println_display(
                 config,
-                format!(
-                    "  auditor encryption pubkey set to {}",
-                    new_auditor_pubkey.to_string(),
-                ),
+                format!("  auditor encryption pubkey set to {}", new_auditor_pubkey,),
             );
         } else {
-            println_display(config, format!("  auditability disabled",))
+            println_display(config, "  auditability disabled".to_string())
         }
     }
 
@@ -5060,7 +5057,7 @@ async fn process_command<'a>(
             let no_recipient_is_ata_owner =
                 arg_matches.is_present("no_recipient_is_ata_owner") || !recipient_is_ata_owner;
             if recipient_is_ata_owner {
-                println_display(config, format!("recipient-is-ata-owner is now the default behavior. The option has been deprecated and will be removed in a future release."));
+                println_display(config, "recipient-is-ata-owner is now the default behavior. The option has been deprecated and will be removed in a future release.".to_string());
             }
             let use_unchecked_instruction = arg_matches.is_present("use_unchecked_instruction");
             let expected_fee = value_of::<f64>(arg_matches, "expected_fee");
@@ -8360,9 +8357,9 @@ mod tests {
         let extension = account_state
             .get_extension::<ConfidentialTransferAccount>()
             .unwrap();
-        assert_eq!(bool::from(extension.approved), false);
-        assert_eq!(bool::from(extension.allow_confidential_credits), true);
-        assert_eq!(bool::from(extension.allow_non_confidential_credits), true);
+        assert!(!bool::from(extension.approved));
+        assert!(bool::from(extension.allow_confidential_credits));
+        assert!(bool::from(extension.allow_non_confidential_credits));
 
         // disable and enable confidential transfers for an account
         process_test_command(
@@ -8382,7 +8379,7 @@ mod tests {
         let extension = account_state
             .get_extension::<ConfidentialTransferAccount>()
             .unwrap();
-        assert_eq!(bool::from(extension.allow_confidential_credits), false);
+        assert!(!bool::from(extension.allow_confidential_credits));
 
         process_test_command(
             &config,
@@ -8401,7 +8398,7 @@ mod tests {
         let extension = account_state
             .get_extension::<ConfidentialTransferAccount>()
             .unwrap();
-        assert_eq!(bool::from(extension.allow_confidential_credits), true);
+        assert!(bool::from(extension.allow_confidential_credits));
 
         // disable and eanble non-confidential transfers for an account
         process_test_command(
@@ -8421,7 +8418,7 @@ mod tests {
         let extension = account_state
             .get_extension::<ConfidentialTransferAccount>()
             .unwrap();
-        assert_eq!(bool::from(extension.allow_non_confidential_credits), false);
+        assert!(!bool::from(extension.allow_non_confidential_credits));
 
         process_test_command(
             &config,
@@ -8440,7 +8437,7 @@ mod tests {
         let extension = account_state
             .get_extension::<ConfidentialTransferAccount>()
             .unwrap();
-        assert_eq!(bool::from(extension.allow_non_confidential_credits), true);
+        assert!(bool::from(extension.allow_non_confidential_credits));
 
         // disable confidential transfers for mint
         process_test_command(


### PR DESCRIPTION
#### Problem
The token-cli does not yet support initializing confidential transfer account

#### Summary of changes
Added configuring cli commands for confidential transfer accounts. I think each commits should be pretty straightforward and independent with the following note:
- For `configure-confidential-transfer-account`, I made it so that the elgamal and aes keys are derived from the signer by default. This can be updated so that users have the option to initialize the account with custom keys once we upgrade to clap-v3-utils.