### PR TITLE
single-pool: rename program to spl_single_pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6874,6 +6874,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-single-pool"
+version = "1.0.0"
+dependencies = [
+ "approx",
+ "arrayref",
+ "bincode",
+ "borsh 0.10.3",
+ "num-derive 0.4.1",
+ "num-traits",
+ "num_enum 0.7.0",
+ "rand 0.8.5",
+ "solana-program",
+ "solana-program-test",
+ "solana-sdk",
+ "solana-vote-program",
+ "spl-associated-token-account 2.2.0",
+ "spl-token 4.0.0",
+ "test-case",
+ "thiserror",
+]
+
+[[package]]
 name = "spl-single-pool-cli"
 version = "1.0.0"
 dependencies = [
@@ -6898,34 +6920,12 @@ dependencies = [
  "solana-transaction-status",
  "solana-vote-program",
  "spl-associated-token-account 2.2.0",
- "spl-single-validator-pool",
+ "spl-single-pool",
  "spl-token 4.0.0",
  "spl-token-client",
  "tempfile",
  "test-case",
  "tokio",
-]
-
-[[package]]
-name = "spl-single-validator-pool"
-version = "1.0.0"
-dependencies = [
- "approx",
- "arrayref",
- "bincode",
- "borsh 0.10.3",
- "num-derive 0.4.1",
- "num-traits",
- "num_enum 0.7.0",
- "rand 0.8.5",
- "solana-program",
- "solana-program-test",
- "solana-sdk",
- "solana-vote-program",
- "spl-associated-token-account 2.2.0",
- "spl-token 4.0.0",
- "test-case",
- "thiserror",
 ]
 
 [[package]]

--- a/single-pool/cli/Cargo.toml
+++ b/single-pool/cli/Cargo.toml
@@ -30,7 +30,7 @@ solana-vote-program = "=1.16.16"
 spl-token = { version = "4.0", path="../../token/program", features = [ "no-entrypoint" ] }
 spl-token-client = { version = "0.7", path="../../token/client" }
 spl-associated-token-account = { version = "2.0", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
-spl-single-validator-pool = { version = "1.0.0", path="../program", features = [ "no-entrypoint" ] }
+spl-single-pool = { version = "1.0.0", path="../program", features = [ "no-entrypoint" ] }
 
 [dev-dependencies]
 solana-test-validator = "=1.16.16"

--- a/single-pool/cli/src/cli.rs
+++ b/single-pool/cli/src/cli.rs
@@ -13,7 +13,7 @@ use {
     },
     solana_remote_wallet::remote_wallet::RemoteWalletManager,
     solana_sdk::{pubkey::Pubkey, signer::Signer},
-    spl_single_validator_pool::{self as single_pool, find_pool_address},
+    spl_single_pool::{self, find_pool_address},
     std::{str::FromStr, sync::Arc},
 };
 
@@ -90,7 +90,7 @@ pub enum Command {
     /// linked to the intended depository pool
     CreateDefaultStake(CreateStakeCli),
 
-    /// Display info for one or all single single-validator stake pool(s)
+    /// Display info for one or all single-validator stake pool(s)
     Display(DisplayCli),
 }
 
@@ -355,7 +355,7 @@ pub fn pool_address_from_args(maybe_pool: Option<Pubkey>, maybe_vote: Option<Pub
     if let Some(pool_address) = maybe_pool {
         pool_address
     } else if let Some(vote_account_address) = maybe_vote {
-        find_pool_address(&single_pool::id(), &vote_account_address)
+        find_pool_address(&spl_single_pool::id(), &vote_account_address)
     } else {
         unreachable!()
     }

--- a/single-pool/cli/src/main.rs
+++ b/single-pool/cli/src/main.rs
@@ -16,10 +16,9 @@ use {
         transaction::Transaction,
     },
     solana_vote_program::{self as vote_program, vote_state::VoteState},
-    spl_single_validator_pool::{
-        self as single_pool, find_default_deposit_account_address, find_pool_address,
-        find_pool_mint_address, find_pool_stake_address, instruction::SinglePoolInstruction,
-        state::SinglePool,
+    spl_single_pool::{
+        self, find_default_deposit_account_address, find_pool_address, find_pool_mint_address,
+        find_pool_stake_address, instruction::SinglePoolInstruction, state::SinglePool,
     },
     spl_token_client::token::Token,
 };
@@ -106,7 +105,7 @@ async fn command_initialize(config: &Config, command_config: InitializeCli) -> C
         return Err(format!("{} is not a valid vote account", vote_account_address,).into());
     }
 
-    let pool_address = find_pool_address(&single_pool::id(), &vote_account_address);
+    let pool_address = find_pool_address(&spl_single_pool::id(), &vote_account_address);
 
     // check if the pool has already been initialized
     if config
@@ -122,8 +121,8 @@ async fn command_initialize(config: &Config, command_config: InitializeCli) -> C
         .into());
     }
 
-    let mut instructions = single_pool::instruction::initialize(
-        &single_pool::id(),
+    let mut instructions = spl_single_pool::instruction::initialize(
+        &spl_single_pool::id(),
         &vote_account_address,
         &payer.pubkey(),
         &quarantine::get_rent(config).await?,
@@ -190,7 +189,7 @@ async fn command_reactivate_pool_stake(
     // the only reason this check is skippable is for testing, otherwise theres no reason
     if !command_config.skip_deactivation_check {
         let current_epoch = config.rpc_client.get_epoch_info().await?.epoch;
-        let pool_stake_address = find_pool_stake_address(&single_pool::id(), &pool_address);
+        let pool_stake_address = find_pool_stake_address(&spl_single_pool::id(), &pool_address);
         let pool_stake_deactivated = quarantine::get_stake_info(config, &pool_stake_address)
             .await?
             .unwrap()
@@ -204,8 +203,10 @@ async fn command_reactivate_pool_stake(
         }
     }
 
-    let instruction =
-        single_pool::instruction::reactivate_pool_stake(&single_pool::id(), &vote_account_address);
+    let instruction = spl_single_pool::instruction::reactivate_pool_stake(
+        &spl_single_pool::id(),
+        &vote_account_address,
+    );
     let transaction = Transaction::new_signed_with_payer(
         &[instruction],
         Some(&payer.pubkey()),
@@ -240,7 +241,7 @@ async fn command_deposit(config: &Config, command_config: DepositCli) -> Command
     let provided_pool_address = command_config.pool_address.or_else(|| {
         command_config
             .vote_account_address
-            .map(|address| find_pool_address(&single_pool::id(), &address))
+            .map(|address| find_pool_address(&spl_single_pool::id(), &address))
     });
 
     // from there we can determine the stake account address
@@ -259,7 +260,7 @@ async fn command_deposit(config: &Config, command_config: DepositCli) -> Command
         quarantine::get_stake_info(config, &stake_account_address).await?
     {
         let derived_pool_address =
-            find_pool_address(&single_pool::id(), &stake.delegation.voter_pubkey);
+            find_pool_address(&spl_single_pool::id(), &stake.delegation.voter_pubkey);
 
         if let Some(provided_pool_address) = provided_pool_address {
             if provided_pool_address != derived_pool_address {
@@ -314,7 +315,7 @@ async fn command_deposit(config: &Config, command_config: DepositCli) -> Command
         return Err(format!("Pool {} has not been initialized", pool_address).into());
     }
 
-    let pool_stake_address = find_pool_stake_address(&single_pool::id(), &pool_address);
+    let pool_stake_address = find_pool_stake_address(&spl_single_pool::id(), &pool_address);
     let pool_stake_active = quarantine::get_stake_info(config, &pool_stake_address)
         .await?
         .unwrap()
@@ -327,7 +328,7 @@ async fn command_deposit(config: &Config, command_config: DepositCli) -> Command
         return Err("Activation status mismatch; try again next epoch".into());
     }
 
-    let pool_mint_address = find_pool_mint_address(&single_pool::id(), &pool_address);
+    let pool_mint_address = find_pool_mint_address(&spl_single_pool::id(), &pool_address);
     let token = Token::new(
         config.program_client.clone(),
         &spl_token::id(),
@@ -352,8 +353,8 @@ async fn command_deposit(config: &Config, command_config: DepositCli) -> Command
         .base
         .amount;
 
-    let instructions = single_pool::instruction::deposit(
-        &single_pool::id(),
+    let instructions = spl_single_pool::instruction::deposit(
+        &spl_single_pool::id(),
         &pool_address,
         &stake_account_address,
         &token_account_address,
@@ -423,7 +424,7 @@ async fn command_withdraw(config: &Config, command_config: WithdrawCli) -> Comma
     }
 
     // now all the mint and token info
-    let pool_mint_address = find_pool_mint_address(&single_pool::id(), &pool_address);
+    let pool_mint_address = find_pool_mint_address(&spl_single_pool::id(), &pool_address);
     let token = Token::new(
         config.program_client.clone(),
         &spl_token::id(),
@@ -484,8 +485,8 @@ async fn command_withdraw(config: &Config, command_config: WithdrawCli) -> Comma
     ];
 
     // perform the withdrawal
-    instructions.extend(single_pool::instruction::withdraw(
-        &single_pool::id(),
+    instructions.extend(spl_single_pool::instruction::withdraw(
+        &spl_single_pool::id(),
         &pool_address,
         &stake_account_address,
         &stake_authority_address,
@@ -570,8 +571,8 @@ async fn command_create_metadata(
 
     // and... i guess thats it?
 
-    let instruction = single_pool::instruction::create_token_metadata(
-        &single_pool::id(),
+    let instruction = spl_single_pool::instruction::create_token_metadata(
+        &spl_single_pool::id(),
         &pool_address,
         &payer.pubkey(),
     );
@@ -641,8 +642,8 @@ async fn command_update_metadata(
         unreachable!();
     }
 
-    let instruction = single_pool::instruction::update_token_metadata(
-        &single_pool::id(),
+    let instruction = spl_single_pool::instruction::update_token_metadata(
+        &spl_single_pool::id(),
         &vote_account_address,
         &authorized_withdrawer.pubkey(),
         command_config.token_name,
@@ -717,8 +718,8 @@ async fn command_create_stake(config: &Config, command_config: CreateStakeCli) -
         );
     }
 
-    let instructions = single_pool::instruction::create_and_delegate_user_stake(
-        &single_pool::id(),
+    let instructions = spl_single_pool::instruction::create_and_delegate_user_stake(
+        &spl_single_pool::id(),
         &vote_account_address,
         &stake_authority_address,
         &quarantine::get_rent(config).await?,
@@ -755,7 +756,7 @@ async fn command_display(config: &Config, command_config: DisplayCli) -> Command
         let pools = config
             .rpc_client
             .get_program_accounts_with_config(
-                &single_pool::id(),
+                &spl_single_pool::id(),
                 RpcProgramAccountsConfig {
                     filters: Some(vec![RpcFilterType::Memcmp(Memcmp::new_raw_bytes(
                         0,
@@ -813,7 +814,7 @@ async fn get_pool_display(
         return Err(format!("Pool {} does not exist", pool_address).into());
     };
 
-    let pool_stake_address = find_pool_stake_address(&single_pool::id(), &pool_address);
+    let pool_stake_address = find_pool_stake_address(&spl_single_pool::id(), &pool_address);
     let available_stake =
         if let Some((_, stake)) = quarantine::get_stake_info(config, &pool_stake_address).await? {
             stake.delegation.stake - quarantine::get_minimum_delegation(config).await?
@@ -821,7 +822,7 @@ async fn get_pool_display(
             unreachable!()
         };
 
-    let pool_mint_address = find_pool_mint_address(&single_pool::id(), &pool_address);
+    let pool_mint_address = find_pool_mint_address(&spl_single_pool::id(), &pool_address);
     let token_supply = config
         .rpc_client
         .get_token_supply(&pool_mint_address)

--- a/single-pool/cli/src/output.rs
+++ b/single-pool/cli/src/output.rs
@@ -5,8 +5,8 @@ use {
     serde_with::{serde_as, DisplayFromStr},
     solana_cli_output::{display::writeln_name_value, QuietDisplay, VerboseDisplay},
     solana_sdk::{pubkey::Pubkey, signature::Signature},
-    spl_single_validator_pool::{
-        self as single_pool, find_pool_mint_address, find_pool_mint_authority_address,
+    spl_single_pool::{
+        self, find_pool_mint_address, find_pool_mint_authority_address,
         find_pool_mpl_authority_address, find_pool_stake_address,
         find_pool_stake_authority_address,
     },
@@ -113,27 +113,30 @@ impl VerboseDisplay for StakePoolOutput {
         writeln_name_value(
             w,
             "  Pool stake address:",
-            &find_pool_stake_address(&single_pool::id(), &self.pool_address).to_string(),
+            &find_pool_stake_address(&spl_single_pool::id(), &self.pool_address).to_string(),
         )?;
         writeln_name_value(
             w,
             "  Pool mint address:",
-            &find_pool_mint_address(&single_pool::id(), &self.pool_address).to_string(),
+            &find_pool_mint_address(&spl_single_pool::id(), &self.pool_address).to_string(),
         )?;
         writeln_name_value(
             w,
             "  Pool stake authority address:",
-            &find_pool_stake_authority_address(&single_pool::id(), &self.pool_address).to_string(),
+            &find_pool_stake_authority_address(&spl_single_pool::id(), &self.pool_address)
+                .to_string(),
         )?;
         writeln_name_value(
             w,
             "  Pool mint authority address:",
-            &find_pool_mint_authority_address(&single_pool::id(), &self.pool_address).to_string(),
+            &find_pool_mint_authority_address(&spl_single_pool::id(), &self.pool_address)
+                .to_string(),
         )?;
         writeln_name_value(
             w,
             "  Pool MPL authority address:",
-            &find_pool_mpl_authority_address(&single_pool::id(), &self.pool_address).to_string(),
+            &find_pool_mpl_authority_address(&spl_single_pool::id(), &self.pool_address)
+                .to_string(),
         )?;
 
         writeln_name_value(w, "  Available stake:", &self.available_stake.to_string())?;

--- a/single-pool/cli/tests/test.rs
+++ b/single-pool/cli/tests/test.rs
@@ -23,7 +23,6 @@ use {
         vote_instruction::{self, CreateVoteAccountConfig},
         vote_state::{VoteInit, VoteState, VoteStateVersions},
     },
-    spl_single_validator_pool::{self as single_pool},
     spl_token_client::client::{ProgramClient, ProgramRpcClient, ProgramRpcClientSendTransaction},
     std::{path::PathBuf, process::Command, str::FromStr, sync::Arc, time::Duration},
     tempfile::NamedTempFile,
@@ -122,9 +121,9 @@ async fn start_validator() -> (TestValidator, Keypair) {
             upgrade_authority: Pubkey::default(),
         },
         UpgradeableProgramInfo {
-            program_id: single_pool::id(),
+            program_id: spl_single_pool::id(),
             loader: bpf_loader_upgradeable::id(),
-            program_path: PathBuf::from("../../target/deploy/spl_single_validator_pool.so"),
+            program_path: PathBuf::from("../../target/deploy/spl_single_pool.so"),
             upgrade_authority: Pubkey::default(),
         },
     ]);

--- a/single-pool/js/packages/classic/tests/fixtures/spl_single_pool.so
+++ b/single-pool/js/packages/classic/tests/fixtures/spl_single_pool.so
@@ -1,0 +1,1 @@
+../../../../../../target/deploy/spl_single_pool.so

--- a/single-pool/js/packages/classic/tests/fixtures/spl_single_validator_pool.so
+++ b/single-pool/js/packages/classic/tests/fixtures/spl_single_validator_pool.so
@@ -1,1 +1,0 @@
-../../../../../../target/deploy/spl_single_validator_pool.so

--- a/single-pool/js/packages/classic/tests/transactions.test.ts
+++ b/single-pool/js/packages/classic/tests/transactions.test.ts
@@ -76,7 +76,7 @@ async function startWithContext(authorizedWithdrawer?: PublicKey) {
 
   return await start(
     [
-      { name: 'spl_single_validator_pool', programId: SinglePoolProgram.programId },
+      { name: 'spl_single_pool', programId: SinglePoolProgram.programId },
       { name: 'mpl_token_metadata', programId: MPL_METADATA_PROGRAM_ID },
     ],
     [

--- a/single-pool/program/Cargo.toml
+++ b/single-pool/program/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "spl-single-validator-pool"
+name = "spl-single-pool"
 version = "1.0.0"
 description = "Solana Program Library Single-Validator Stake Pool"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]

--- a/single-pool/program/src/instruction.rs
+++ b/single-pool/program/src/instruction.rs
@@ -24,7 +24,7 @@ use {
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize)]
 pub enum SinglePoolInstruction {
-    ///   Initialize the mint and stake account for a new single-validator pool.
+    ///   Initialize the mint and stake account for a new single-validator stake pool.
     ///   The pool stake account must contain the rent-exempt minimum plus the minimum delegation.
     ///   No tokens will be minted: to deposit more, use `Deposit` after `InitializeStake`.
     ///

--- a/single-pool/program/tests/accounts.rs
+++ b/single-pool/program/tests/accounts.rs
@@ -10,7 +10,7 @@ use {
         instruction::Instruction, program_error::ProgramError, pubkey::Pubkey, signature::Signer,
         stake, system_program, transaction::Transaction,
     },
-    spl_single_validator_pool::{
+    spl_single_pool::{
         error::SinglePoolError,
         id,
         instruction::{self, SinglePoolInstruction},

--- a/single-pool/program/tests/create_pool_token_metadata.rs
+++ b/single-pool/program/tests/create_pool_token_metadata.rs
@@ -10,7 +10,7 @@ use {
         instruction::InstructionError, pubkey::Pubkey, signature::Signer,
         system_instruction::SystemError, transaction::Transaction,
     },
-    spl_single_validator_pool::{id, instruction},
+    spl_single_pool::{id, instruction},
 };
 
 fn assert_metadata(vote_account: &Pubkey, metadata: &Metadata) {

--- a/single-pool/program/tests/deposit.rs
+++ b/single-pool/program/tests/deposit.rs
@@ -13,7 +13,7 @@ use {
         transaction::Transaction,
     },
     spl_associated_token_account as atoken,
-    spl_single_validator_pool::{
+    spl_single_pool::{
         error::SinglePoolError, find_default_deposit_account_address, id, instruction,
     },
     test_case::test_case,

--- a/single-pool/program/tests/helpers/mod.rs
+++ b/single-pool/program/tests/helpers/mod.rs
@@ -17,7 +17,7 @@ use {
         vote_state::{VoteInit, VoteState, VoteStateVersions},
     },
     spl_associated_token_account as atoken,
-    spl_single_validator_pool::{
+    spl_single_pool::{
         find_pool_address, find_pool_mint_address, find_pool_mint_authority_address,
         find_pool_mpl_authority_address, find_pool_stake_address,
         find_pool_stake_authority_address, id, inline_mpl_token_metadata, instruction,
@@ -38,11 +38,7 @@ pub fn program_test() -> ProgramTest {
     let mut program_test = ProgramTest::default();
     program_test.add_program("mpl_token_metadata", inline_mpl_token_metadata::id(), None);
 
-    program_test.add_program(
-        "spl_single_validator_pool",
-        id(),
-        processor!(Processor::process),
-    );
+    program_test.add_program("spl_single_pool", id(), processor!(Processor::process));
 
     program_test.prefer_bpf(false);
     program_test

--- a/single-pool/program/tests/helpers/token.rs
+++ b/single-pool/program/tests/helpers/token.rs
@@ -12,7 +12,7 @@ use {
         transaction::Transaction,
     },
     spl_associated_token_account as atoken,
-    spl_single_validator_pool::inline_mpl_token_metadata::pda::find_metadata_account,
+    spl_single_pool::inline_mpl_token_metadata::pda::find_metadata_account,
     spl_token::state::{Account, Mint},
 };
 

--- a/single-pool/program/tests/initialize.rs
+++ b/single-pool/program/tests/initialize.rs
@@ -7,7 +7,7 @@ use {
     helpers::*,
     solana_program_test::*,
     solana_sdk::{program_pack::Pack, signature::Signer, stake, transaction::Transaction},
-    spl_single_validator_pool::{error::SinglePoolError, id, instruction},
+    spl_single_pool::{error::SinglePoolError, id, instruction},
     spl_token::state::Mint,
 };
 

--- a/single-pool/program/tests/reactivate.rs
+++ b/single-pool/program/tests/reactivate.rs
@@ -12,7 +12,7 @@ use {
         stake::state::{Delegation, Stake, StakeState},
         transaction::Transaction,
     },
-    spl_single_validator_pool::{error::SinglePoolError, id, instruction},
+    spl_single_pool::{error::SinglePoolError, id, instruction},
     test_case::test_case,
 };
 

--- a/single-pool/program/tests/update_pool_token_metadata.rs
+++ b/single-pool/program/tests/update_pool_token_metadata.rs
@@ -6,7 +6,7 @@ use {
     helpers::*,
     solana_program_test::*,
     solana_sdk::{signature::Signer, transaction::Transaction},
-    spl_single_validator_pool::{error::SinglePoolError, id, instruction},
+    spl_single_pool::{error::SinglePoolError, id, instruction},
     test_case::test_case,
 };
 

--- a/single-pool/program/tests/withdraw.rs
+++ b/single-pool/program/tests/withdraw.rs
@@ -7,7 +7,7 @@ use {
     helpers::*,
     solana_program_test::*,
     solana_sdk::{signature::Signer, transaction::Transaction},
-    spl_single_validator_pool::{error::SinglePoolError, id, instruction},
+    spl_single_pool::{error::SinglePoolError, id, instruction},
     test_case::test_case,
 };
 

--- a/stake-pool/program/src/inline_mpl_token_metadata.rs
+++ b/stake-pool/program/src/inline_mpl_token_metadata.rs
@@ -1,5 +1,5 @@
 //! Inlined MPL metadata types to avoid a direct dependency on `mpl-token-metadata'
-//! NOTE: this file is sym-linked in `spl-single-validator-pool`, so be careful
+//! NOTE: this file is sym-linked in `spl-single-pool`, so be careful
 //! with changes!
 
 solana_program::declare_id!("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s");


### PR DESCRIPTION
actually for real final pr before i tag my 1.0 versions and release... this is so we can be `spl-single-pool` and `spl-single-pool-cli` on crates.io. ive removed all uses of "single-validator pool," officially we are "single-pool" or "svsp" for short and "single-validator stake pool" in full

once this is in i will:
* make three tags and three releases for program, cli, js (js-classic depends on js-modern so these should advance in lockstep, hence no fourth release)
* cargo and npm publish
* update docs with npm url and reactivate example and merge #5414 
* program on devnet!!!

ill hold the devnet upgrade authority for now, we need to figure out who will ultimately be the uprgrader for mainnet before we deploy there. but the finish line is in sight