### PR TITLE
feature gate: add multisig/authority support to activate instruction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6558,7 +6558,6 @@ dependencies = [
 name = "spl-feature-gate"
 version = "0.1.0"
 dependencies = [
- "num_enum 0.7.0",
  "solana-program",
  "solana-program-test",
  "solana-sdk",

--- a/feature-gate/program/Cargo.toml
+++ b/feature-gate/program/Cargo.toml
@@ -12,7 +12,6 @@ no-entrypoint = []
 test-sbf = []
 
 [dependencies]
-num_enum = "0.7.0"
 solana-program = "1.16.16"
 spl-program-error = { version = "0.3.0", path = "../../libraries/program-error" }
 

--- a/feature-gate/program/src/error.rs
+++ b/feature-gate/program/src/error.rs
@@ -17,4 +17,7 @@ pub enum FeatureGateError {
     /// Invalid feature account
     #[error("Invalid feature account")]
     InvalidFeatureAccount,
+    /// Missing nonce for authority
+    #[error("Missing nonce for authority")]
+    MissingNonce,
 }

--- a/feature-gate/program/src/feature_id.rs
+++ b/feature-gate/program/src/feature_id.rs
@@ -1,0 +1,11 @@
+//! Module for managing feature IDs
+
+use solana_program::{program_error::ProgramError, pubkey::Pubkey};
+
+/// Derives the feature ID from an authority's address and a nonce.
+pub fn derive_feature_id(authority: &Pubkey, nonce: u16) -> Result<(Pubkey, u8), ProgramError> {
+    Ok(Pubkey::find_program_address(
+        &[b"feature", &nonce.to_le_bytes(), authority.as_ref()],
+        &crate::id(),
+    ))
+}

--- a/feature-gate/program/src/lib.rs
+++ b/feature-gate/program/src/lib.rs
@@ -6,6 +6,7 @@
 #[cfg(not(feature = "no-entrypoint"))]
 mod entrypoint;
 pub mod error;
+pub mod feature_id;
 pub mod instruction;
 pub mod processor;
 

--- a/feature-gate/program/tests/with_authority.rs
+++ b/feature-gate/program/tests/with_authority.rs
@@ -1,0 +1,190 @@
+#![cfg(feature = "test-sbf")]
+
+use {
+    solana_program::instruction::InstructionError,
+    solana_program_test::{processor, tokio, ProgramTest},
+    solana_sdk::{
+        account::Account as SolanaAccount,
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        system_program,
+        transaction::{Transaction, TransactionError},
+    },
+    spl_feature_gate::{
+        error::FeatureGateError, feature_id::derive_feature_id, instruction::activate_feature,
+    },
+};
+
+#[tokio::test]
+async fn test_activate_feature_with_authority() {
+    let authority = Keypair::new();
+    let mock_invalid_signer = Keypair::new();
+    let mock_invalid_feature = Pubkey::new_unique();
+
+    let mut program_test = ProgramTest::new(
+        "spl_feature_gate",
+        spl_feature_gate::id(),
+        processor!(spl_feature_gate::processor::process),
+    );
+
+    // Create the authority
+    program_test.add_account(
+        authority.pubkey(),
+        SolanaAccount {
+            lamports: 500_000_000,
+            owner: system_program::id(),
+            ..SolanaAccount::default()
+        },
+    );
+    // Need to fund this account for a test transfer later
+    program_test.add_account(
+        mock_invalid_signer.pubkey(),
+        SolanaAccount {
+            lamports: 500_000_000,
+            owner: system_program::id(),
+            ..SolanaAccount::default()
+        },
+    );
+    // Add a mock account that's NOT a valid feature account for testing later
+    program_test.add_account(
+        mock_invalid_feature,
+        SolanaAccount {
+            lamports: 500_000_000,
+            owner: spl_feature_gate::id(),
+            ..SolanaAccount::default()
+        },
+    );
+
+    let mut context = program_test.start_with_context().await;
+
+    let nonce = 0u16;
+    let (feature_id, _) = derive_feature_id(&authority.pubkey(), nonce).unwrap();
+
+    // Fail: incorrect feature ID
+    let incorrect_id = Pubkey::new_unique();
+    let transaction = Transaction::new_signed_with_payer(
+        &[activate_feature(
+            &incorrect_id,
+            &context.payer.pubkey(),
+            Some((&authority.pubkey(), nonce)),
+        )],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &authority],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(FeatureGateError::IncorrectFeatureId as u32)
+        )
+    );
+
+    // Fail: authority not signer
+    let mut activate_ix = activate_feature(
+        &feature_id,
+        &context.payer.pubkey(),
+        Some((&authority.pubkey(), nonce)),
+    );
+    activate_ix.accounts[3].is_signer = false;
+    let transaction = Transaction::new_signed_with_payer(
+        &[activate_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature)
+    );
+
+    // Fail: feature not owned by system program
+    let transaction = Transaction::new_signed_with_payer(
+        &[activate_feature(
+            &mock_invalid_feature,
+            &context.payer.pubkey(),
+            Some((&authority.pubkey(), nonce)),
+        )],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &authority],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(FeatureGateError::InvalidFeatureAccount as u32),
+        )
+    );
+
+    // Success: Submit a feature for activation
+    let transaction = Transaction::new_signed_with_payer(
+        &[activate_feature(
+            &feature_id,
+            &context.payer.pubkey(),
+            Some((&authority.pubkey(), nonce)),
+        )],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &authority],
+        context.last_blockhash,
+    );
+
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+
+    // Confirm feature account exists with proper configurations
+    let feature_account = context
+        .banks_client
+        .get_account(feature_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(feature_account.owner, spl_feature_gate::id());
+
+    // Cannot activate the same feature again
+    let new_latest_blockhash = context.get_new_latest_blockhash().await.unwrap();
+    let transaction = Transaction::new_signed_with_payer(
+        &[activate_feature(
+            &feature_id,
+            &context.payer.pubkey(),
+            Some((&authority.pubkey(), nonce)),
+        )],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &authority],
+        new_latest_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(FeatureGateError::InvalidFeatureAccount as u32)
+        )
+    );
+}

--- a/feature-gate/program/tests/without_authority.rs
+++ b/feature-gate/program/tests/without_authority.rs
@@ -22,6 +22,7 @@ async fn setup_pending_feature(context: &mut ProgramTestContext, feature_keypair
         &[activate_feature(
             &feature_keypair.pubkey(),
             &context.payer.pubkey(),
+            None,
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, feature_keypair],
@@ -69,7 +70,8 @@ async fn test_activate_feature() {
     let mut context = program_test.start_with_context().await;
 
     // Fail: feature not signer
-    let mut activate_ix = activate_feature(&feature_keypair.pubkey(), &context.payer.pubkey());
+    let mut activate_ix =
+        activate_feature(&feature_keypair.pubkey(), &context.payer.pubkey(), None);
     activate_ix.accounts[0].is_signer = false;
     let transaction = Transaction::new_signed_with_payer(
         &[activate_ix],
@@ -89,7 +91,8 @@ async fn test_activate_feature() {
     );
 
     // Fail: payer not signer
-    let mut activate_ix = activate_feature(&feature_keypair.pubkey(), &context.payer.pubkey());
+    let mut activate_ix =
+        activate_feature(&feature_keypair.pubkey(), &context.payer.pubkey(), None);
     activate_ix.accounts[1].is_signer = false;
     let transaction = Transaction::new_signed_with_payer(
         &[activate_ix],
@@ -113,6 +116,7 @@ async fn test_activate_feature() {
         &[activate_feature(
             &mock_invalid_feature.pubkey(),
             &context.payer.pubkey(),
+            None,
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, &mock_invalid_feature],
@@ -137,6 +141,7 @@ async fn test_activate_feature() {
         &[activate_feature(
             &feature_keypair.pubkey(),
             &context.payer.pubkey(),
+            None,
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, &feature_keypair],
@@ -164,6 +169,7 @@ async fn test_activate_feature() {
         &[activate_feature(
             &feature_keypair.pubkey(),
             &context.payer.pubkey(),
+            None,
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, &feature_keypair],


### PR DESCRIPTION
This PR adds multisig/authority support to the Feature Gate program's `ActivateFeature` instruction.

This activation process will support multi-sig authorities for activations, as discussed in [this comment](https://github.com/solana-labs/solana-program-library/pull/5510#discussion_r1357539741) on #5510.
