### PR TITLE
single-pool-js: Fix ci

### DIFF
--- a/single-pool/js/packages/classic/package.json
+++ b/single-pool/js/packages/classic/package.json
@@ -5,7 +5,7 @@
     "build": "pnpm tsc",
     "lint": "eslint --max-warnings 0 .",
     "lint:fix": "eslint . --fix",
-    "test": "NODE_OPTIONS='--loader=tsx' ava"
+    "test": "NODE_OPTIONS='--import=tsx' ava"
   },
   "type": "module",
   "main": "./dist/index.js",
@@ -32,10 +32,10 @@
   },
   "ava": {
     "extensions": {
-      "ts": "module"
+      "ts": "commonjs"
     },
     "nodeArguments": [
-      "--loader=tsx"
+      "--import=tsx"
     ]
   }
 }


### PR DESCRIPTION
#### Problem

The single-pool js tests are failing in CI, e..g https://github.com/solana-labs/solana-program-library/actions/runs/6560481835/job/17818975411

#### Solution

It was fiddly, but I needed to make two changes -- one to use the `import` flag instead of `loader`, and then to use the common js loader instead of esm. Who knows why this works? Not me! :upside_down_face: 