### PR TITLE
token 2022: move update authority check to shared file

### DIFF
--- a/token-metadata/example/src/processor.rs
+++ b/token-metadata/example/src/processor.rs
@@ -12,7 +12,10 @@ use {
         pubkey::Pubkey,
     },
     spl_pod::optional_keys::OptionalNonZeroPubkey,
-    spl_token_2022::{extension::StateWithExtensions, state::Mint},
+    spl_token_2022::{
+        extension::{update_authority::check_update_authority, StateWithExtensions},
+        state::Mint,
+    },
     spl_token_metadata_interface::{
         error::TokenMetadataError,
         instruction::{
@@ -24,21 +27,6 @@ use {
         realloc_and_pack_first_variable_len, TlvState, TlvStateBorrowed, TlvStateMut,
     },
 };
-
-fn check_update_authority(
-    update_authority_info: &AccountInfo,
-    expected_update_authority: &OptionalNonZeroPubkey,
-) -> Result<(), ProgramError> {
-    if !update_authority_info.is_signer {
-        return Err(ProgramError::MissingRequiredSignature);
-    }
-    let update_authority = Option::<Pubkey>::from(*expected_update_authority)
-        .ok_or(TokenMetadataError::ImmutableMetadata)?;
-    if update_authority != *update_authority_info.key {
-        return Err(TokenMetadataError::IncorrectUpdateAuthority.into());
-    }
-    Ok(())
-}
 
 /// Processes a [Initialize](enum.TokenMetadataInstruction.html) instruction.
 pub fn process_initialize(

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -74,6 +74,8 @@ pub mod token_metadata;
 pub mod transfer_fee;
 /// Transfer Hook extension
 pub mod transfer_hook;
+/// Update authority util
+pub mod update_authority;
 
 /// Length in TLV structure
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]

--- a/token/program-2022/src/extension/token_metadata/processor.rs
+++ b/token/program-2022/src/extension/token_metadata/processor.rs
@@ -5,8 +5,8 @@ use {
         check_program_account,
         error::TokenError,
         extension::{
-            alloc_and_serialize, metadata_pointer::MetadataPointer, BaseStateWithExtensions,
-            StateWithExtensions,
+            alloc_and_serialize, metadata_pointer::MetadataPointer,
+            update_authority::check_update_authority, BaseStateWithExtensions, StateWithExtensions,
         },
         state::Mint,
     },
@@ -28,21 +28,6 @@ use {
         state::TokenMetadata,
     },
 };
-
-fn check_update_authority(
-    update_authority_info: &AccountInfo,
-    expected_update_authority: &OptionalNonZeroPubkey,
-) -> Result<(), ProgramError> {
-    if !update_authority_info.is_signer {
-        return Err(ProgramError::MissingRequiredSignature);
-    }
-    let update_authority = Option::<Pubkey>::from(*expected_update_authority)
-        .ok_or(TokenMetadataError::ImmutableMetadata)?;
-    if update_authority != *update_authority_info.key {
-        return Err(TokenMetadataError::IncorrectUpdateAuthority.into());
-    }
-    Ok(())
-}
 
 /// Processes a [Initialize](enum.TokenMetadataInstruction.html) instruction.
 pub fn process_initialize(

--- a/token/program-2022/src/extension/update_authority.rs
+++ b/token/program-2022/src/extension/update_authority.rs
@@ -1,0 +1,23 @@
+//! Utility function for checking an update authority
+
+use {
+    solana_program::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey},
+    spl_pod::optional_keys::OptionalNonZeroPubkey,
+    spl_token_metadata_interface::error::TokenMetadataError,
+};
+
+/// Checks that the update authority is correct
+pub fn check_update_authority(
+    update_authority_info: &AccountInfo,
+    expected_update_authority: &OptionalNonZeroPubkey,
+) -> Result<(), ProgramError> {
+    if !update_authority_info.is_signer {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+    let update_authority = Option::<Pubkey>::from(*expected_update_authority)
+        .ok_or(TokenMetadataError::ImmutableMetadata)?;
+    if update_authority != *update_authority_info.key {
+        return Err(TokenMetadataError::IncorrectUpdateAuthority.into());
+    }
+    Ok(())
+}


### PR DESCRIPTION
This PR moves the `check_update_authority` function into its own module, for use across multiple extention processors.
