### PR TITLE
Upgrades lock_api to v0.4.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2790,10 +2790,11 @@ checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
 name = "lock_api"
-version = "0.4.6"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 


### PR DESCRIPTION
Just like https://github.com/solana-labs/solana/pull/33736, the `lock_api` dependency is old. I'd like to use [`SeqLock`](https://github.com/Amanieu/seqlock) in https://github.com/solana-labs/solana/pull/33696, but a CI check is failing because SPL's lock-api is old.

See https://github.com/solana-labs/solana/pull/33696 for more information/usage.