### PR TITLE
stake-pool: Allow mints with confidential transfer fee

### DIFF
--- a/stake-pool/program/src/state.rs
+++ b/stake-pool/program/src/state.rs
@@ -494,10 +494,11 @@ impl StakePool {
 
 /// Checks if the given extension is supported for the stake pool mint
 pub fn is_extension_supported_for_mint(extension_type: &ExtensionType) -> bool {
-    const SUPPORTED_EXTENSIONS: [ExtensionType; 7] = [
+    const SUPPORTED_EXTENSIONS: [ExtensionType; 8] = [
         ExtensionType::Uninitialized,
         ExtensionType::TransferFeeConfig,
         ExtensionType::ConfidentialTransferMint,
+        ExtensionType::ConfidentialTransferFeeConfig,
         ExtensionType::DefaultAccountState, // ok, but a freeze authority is not
         ExtensionType::InterestBearingConfig,
         ExtensionType::MetadataPointer,


### PR DESCRIPTION
#### Problem

Token-2022 version 0.9.0 split out the confidential transfer fee extension from the confidential transfer extension, but stake pools are not aware of that.

#### Solution

Also allow `ConfidentialTransferFeeConfig` as an extension for stake pool mints.