### PR TITLE
token metadata: replace `IncorrectMintAuthority` with `TokenError::OwnerMismatch`

### DIFF
--- a/token-metadata/example/src/processor.rs
+++ b/token-metadata/example/src/processor.rs
@@ -13,6 +13,7 @@ use {
     },
     spl_pod::optional_keys::OptionalNonZeroPubkey,
     spl_token_2022::{
+        error::TokenError,
         extension::{update_authority::check_update_authority, StateWithExtensions},
         state::Mint,
     },
@@ -53,7 +54,7 @@ pub fn process_initialize(
             return Err(ProgramError::MissingRequiredSignature);
         }
         if mint.base.mint_authority.as_ref() != COption::Some(mint_authority_info.key) {
-            return Err(TokenMetadataError::IncorrectMintAuthority.into());
+            return Err(TokenError::OwnerMismatch.into());
         }
     }
 

--- a/token-metadata/example/tests/initialize.rs
+++ b/token-metadata/example/tests/initialize.rs
@@ -12,9 +12,8 @@ use {
         system_instruction,
         transaction::{Transaction, TransactionError},
     },
-    spl_token_metadata_interface::{
-        error::TokenMetadataError, instruction::initialize, state::TokenMetadata,
-    },
+    spl_token_2022::error::TokenError,
+    spl_token_metadata_interface::{instruction::initialize, state::TokenMetadata},
     spl_type_length_value::{
         error::TlvError,
         state::{TlvState, TlvStateBorrowed},
@@ -265,7 +264,7 @@ async fn fail_incorrect_authority() {
         error,
         TransactionError::InstructionError(
             1,
-            InstructionError::Custom(TokenMetadataError::IncorrectMintAuthority as u32)
+            InstructionError::Custom(TokenError::OwnerMismatch as u32)
         )
     );
 }

--- a/token-metadata/interface/src/error.rs
+++ b/token-metadata/interface/src/error.rs
@@ -11,9 +11,6 @@ pub enum TokenMetadataError {
     /// Mint has no mint authority
     #[error("Mint has no mint authority")]
     MintHasNoMintAuthority,
-    /// Incorrect mint authority has signed the instruction
-    #[error("Incorrect mint authority has signed the instruction")]
-    IncorrectMintAuthority,
     /// Incorrect metadata update authority has signed the instruction
     #[error("Incorrect metadata update authority has signed the instruction")]
     IncorrectUpdateAuthority,

--- a/token/program-2022-test/tests/token_metadata_initialize.rs
+++ b/token/program-2022-test/tests/token_metadata_initialize.rs
@@ -11,7 +11,7 @@ use {
     },
     spl_token_2022::{error::TokenError, extension::BaseStateWithExtensions, processor::Processor},
     spl_token_client::token::{ExtensionInitializationParams, TokenError as TokenClientError},
-    spl_token_metadata_interface::{error::TokenMetadataError, state::TokenMetadata},
+    spl_token_metadata_interface::state::TokenMetadata,
     std::{convert::TryInto, sync::Arc},
 };
 
@@ -110,7 +110,7 @@ async fn success_initialize() {
         TokenClientError::Client(Box::new(TransportError::TransactionError(
             TransactionError::InstructionError(
                 1,
-                InstructionError::Custom(TokenMetadataError::IncorrectMintAuthority as u32)
+                InstructionError::Custom(TokenError::OwnerMismatch as u32)
             )
         )))
     );

--- a/token/program-2022/src/extension/token_metadata/processor.rs
+++ b/token/program-2022/src/extension/token_metadata/processor.rs
@@ -61,7 +61,7 @@ pub fn process_initialize(
             return Err(ProgramError::MissingRequiredSignature);
         }
         if mint.base.mint_authority.as_ref() != COption::Some(mint_authority_info.key) {
-            return Err(TokenMetadataError::IncorrectMintAuthority.into());
+            return Err(TokenError::OwnerMismatch.into());
         }
 
         if mint.get_extension::<MetadataPointer>().is_err() {


### PR DESCRIPTION
As per discussions on #5596, this PR removes the `IncorrectMintAuthority` error variant from `TokenMetadataError` and replaces it with `TokenError::OwnerMismatch` to follow already pre-established patterns, and allow this error handling to be shared across interfaces/extensions such as SPL Token Group.
