### PR TITLE
token-2022: Use serde with `rename_all = "camelCase"`

### DIFF
--- a/token/program-2022/src/extension/cpi_guard/mod.rs
+++ b/token/program-2022/src/extension/cpi_guard/mod.rs
@@ -20,6 +20,7 @@ pub mod processor;
 /// CPI Guard extension for Accounts
 #[repr(C)]
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct CpiGuard {
     /// Lock privileged token operations from happening via CPI

--- a/token/program-2022/src/extension/default_account_state/mod.rs
+++ b/token/program-2022/src/extension/default_account_state/mod.rs
@@ -15,6 +15,7 @@ pub mod processor;
 /// Default Account::state extension data for mints.
 #[repr(C)]
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct DefaultAccountState {
     /// Default Account::state in which new Accounts should be initialized

--- a/token/program-2022/src/extension/immutable_owner.rs
+++ b/token/program-2022/src/extension/immutable_owner.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 
 /// Indicates that the Account owner authority cannot be changed
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 #[repr(transparent)]
 pub struct ImmutableOwner;

--- a/token/program-2022/src/extension/interest_bearing_mint/mod.rs
+++ b/token/program-2022/src/extension/interest_bearing_mint/mod.rs
@@ -36,6 +36,7 @@ pub type UnixTimestamp = PodI64;
 /// rate.
 #[repr(C)]
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct InterestBearingConfig {
     /// Authority that can set the interest rate and authority

--- a/token/program-2022/src/extension/memo_transfer/mod.rs
+++ b/token/program-2022/src/extension/memo_transfer/mod.rs
@@ -23,6 +23,7 @@ pub mod processor;
 /// Memo Transfer extension for Accounts
 #[repr(C)]
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct MemoTransfer {
     /// Require transfers into this account to be accompanied by a memo

--- a/token/program-2022/src/extension/metadata_pointer/mod.rs
+++ b/token/program-2022/src/extension/metadata_pointer/mod.rs
@@ -15,6 +15,7 @@ pub mod processor;
 /// Metadata pointer extension data for mints.
 #[repr(C)]
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct MetadataPointer {
     /// Authority that can set the metadata address

--- a/token/program-2022/src/extension/mint_close_authority.rs
+++ b/token/program-2022/src/extension/mint_close_authority.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 /// Close authority extension data for mints.
 #[repr(C)]
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct MintCloseAuthority {
     /// Optional authority to close the mint

--- a/token/program-2022/src/extension/non_transferable.rs
+++ b/token/program-2022/src/extension/non_transferable.rs
@@ -8,12 +8,14 @@ use serde::{Deserialize, Serialize};
 
 /// Indicates that the tokens from this mint can't be transfered
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 #[repr(transparent)]
 pub struct NonTransferable;
 
 /// Indicates that the tokens from this account belong to a non-transferable mint
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 #[repr(transparent)]
 pub struct NonTransferableAccount;

--- a/token/program-2022/src/extension/permanent_delegate.rs
+++ b/token/program-2022/src/extension/permanent_delegate.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 /// Permanent delegate extension data for mints.
 #[repr(C)]
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct PermanentDelegate {
     /// Optional permanent delegate for transferring or burning tokens

--- a/token/program-2022/src/extension/transfer_fee/mod.rs
+++ b/token/program-2022/src/extension/transfer_fee/mod.rs
@@ -31,6 +31,7 @@ const ONE_IN_BASIS_POINTS: u128 = MAX_FEE_BASIS_POINTS as u128;
 /// Transfer fee information
 #[repr(C)]
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct TransferFee {
     /// First epoch where the transfer fee takes effect
@@ -114,6 +115,8 @@ impl TransferFee {
 
 /// Transfer fee extension data for mints.
 #[repr(C)]
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct TransferFeeConfig {
     /// Optional authority to set the fee
@@ -152,6 +155,8 @@ impl Extension for TransferFeeConfig {
 
 /// Transfer fee extension data for accounts.
 #[repr(C)]
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct TransferFeeAmount {
     /// Amount withheld during transfers, to be harvested to the mint

--- a/token/program-2022/src/extension/transfer_hook/mod.rs
+++ b/token/program-2022/src/extension/transfer_hook/mod.rs
@@ -21,6 +21,7 @@ pub mod processor;
 /// Transfer hook extension data for mints.
 #[repr(C)]
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct TransferHook {
     /// Authority that can set the transfer hook program id
@@ -31,6 +32,7 @@ pub struct TransferHook {
 
 /// Indicates that the tokens from this account belong to a mint with a transfer hook
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 #[repr(transparent)]
 pub struct TransferHookAccount {


### PR DESCRIPTION
#### Problem

#5437 did some great work with deriving the serde traits, but we forgot to specify `rename_all = "camelCase"` as a separate attribute, which means that we'd get some inconsistency in the serialization.

#### Solution

Just add the attribute config. There were also a couple of transfer-fee structs that didn't have it, so I added those.