### PR TITLE
[token-cli] Add confidential transfer deposit, withdraw, apply pending balance, and confidential transfer

### DIFF
--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -39,8 +39,8 @@ use spl_associated_token_account::get_associated_token_address_with_program_id;
 use spl_token_2022::{
     extension::{
         confidential_transfer::{
-            account_info::WithdrawAccountInfo, ConfidentialTransferAccount,
-            ConfidentialTransferMint,
+            account_info::{ApplyPendingBalanceAccountInfo, WithdrawAccountInfo},
+            ConfidentialTransferAccount, ConfidentialTransferMint,
         },
         confidential_transfer_fee::ConfidentialTransferFeeConfig,
         cpi_guard::CpiGuard,
@@ -3367,11 +3367,14 @@ async fn command_apply_pending_balance(
     let state_with_extension = StateWithExtensionsOwned::<Account>::unpack(account.data)?;
     let token = token_client_from_config(config, &state_with_extension.base.mint, None)?;
 
+    let extension_state = state_with_extension.get_extension::<ConfidentialTransferAccount>()?;
+    let account_info = ApplyPendingBalanceAccountInfo::new(extension_state);
+
     let res = token
         .confidential_transfer_apply_pending_balance(
             &token_account_address,
             &owner,
-            None,
+            Some(account_info),
             elgamal_keypair.secret(),
             aes_key,
             &bulk_signers,

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -1606,11 +1606,11 @@ async fn command_transfer(
                     && expected_auditor_elgamal_pubkey != args.auditor_elgamal_pubkey
                 {
                     return Err(format!(
-                        "Mint {} has confidential transfer authority {}, but {} was provided",
+                        "Mint {} has confidential transfer auditor {}, but {} was provided",
                         token_pubkey,
                         expected_auditor_elgamal_pubkey
                             .map(|pubkey| pubkey.to_string())
-                            .unwrap_or_else(|| "auditor disabled".to_string()),
+                            .unwrap_or_else(|| "disabled".to_string()),
                         args.auditor_elgamal_pubkey.unwrap(),
                     )
                     .into());


### PR DESCRIPTION
#### Problem
The token-cli does not yet support confidential transfer instructions to deposit and withdraw confidential transfer tokens, apply pending balance to available balance, and make a confidential transfer.

#### Summary of changes
Add the four commands for the four instructions listed above. For confidential transfers, the functionality is added into the existing `transfer` command instead of creating a dedicated command for confidential transfers.