### PR TITLE
token metadata js: bump version to 0.1.0

### DIFF
--- a/token-metadata/js/package-lock.json
+++ b/token-metadata/js/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@solana/spl-token-metadata",
-    "version": "0.0.1",
+    "version": "0.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@solana/spl-token-metadata",
-            "version": "0.0.1",
+            "version": "0.1.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@solana/codecs-core": "2.0.0-experimental.398c396",

--- a/token-metadata/js/package.json
+++ b/token-metadata/js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@solana/spl-token-metadata",
     "description": "SPL Token Metadata Interface JS API",
-    "version": "0.0.1",
+    "version": "0.1.0",
     "author": "Solana Labs Maintainers <maintainers@solanalabs.com>",
     "repository": "https://github.com/solana-labs/solana-program-library",
     "license": "Apache-2.0",


### PR DESCRIPTION
Bumps the version of the new SPL Token Metadata JS library to `0.1.0` for release.