### PR TITLE
token-client: Use `Signers` instead of `Signer` for confidential transfer functions

### DIFF
--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -2743,7 +2743,7 @@ where
         fee_rate_basis_points: u16,
         maximum_fee: u64,
         equality_and_ciphertext_validity_proof_signers: &S,
-        fee_sigma_signers: &S,
+        fee_sigma_proof_signers: &S,
         range_proof_signers: &S,
     ) -> TokenResult<(T::Output, T::Output, T::Output)> {
         let account_info = if let Some(account_info) = account_info {
@@ -2820,7 +2820,7 @@ where
                 &fee_sigma_proof_data,
                 &fee_ciphertext_validity_proof_data,
                 &transfer_instruction,
-                fee_sigma_signers,
+                fee_sigma_proof_signers,
             );
 
         let transfer_with_range_proof = self

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -1989,7 +1989,7 @@ where
 
     /// Fetch the ElGamal public key associated with a confidential token account
     #[cfg(feature = "proof-program")]
-    pub async fn confidential_transfer_get_elgamal_pubkey<S: Signer>(
+    pub async fn confidential_transfer_get_elgamal_pubkey(
         &self,
         token_account: &Pubkey,
     ) -> TokenResult<ElGamalPubkey> {
@@ -2006,7 +2006,7 @@ where
 
     /// Fetch the ElGamal pubkey key of the auditor associated with a confidential token mint
     #[cfg(feature = "proof-program")]
-    pub async fn confidential_transfer_get_auditor_elgamal_pubkey<S: Signer>(
+    pub async fn confidential_transfer_get_auditor_elgamal_pubkey(
         &self,
     ) -> TokenResult<Option<ElGamalPubkey>> {
         let mint_state = self.get_mint_info().await.unwrap();
@@ -2026,7 +2026,7 @@ where
     /// Fetch the ElGamal pubkey key of the withdraw withheld authority associated with a
     /// confidential token mint
     #[cfg(feature = "proof-program")]
-    pub async fn confidential_transfer_get_withdraw_withheld_authority_elgamal_pubkey<S: Signer>(
+    pub async fn confidential_transfer_get_withdraw_withheld_authority_elgamal_pubkey(
         &self,
     ) -> TokenResult<Option<ElGamalPubkey>> {
         let mint_state = self.get_mint_info().await.unwrap();
@@ -2139,16 +2139,17 @@ where
     /// keys
     #[allow(clippy::too_many_arguments)]
     #[cfg(feature = "proof-program")]
-    pub async fn confidential_transfer_withdraw_with_key<S: Signer>(
+    pub async fn confidential_transfer_withdraw_with_key<S: Signers>(
         &self,
         token_account: &Pubkey,
-        token_authority: &S,
+        token_authority: &Pubkey,
         amount: u64,
         decimals: u8,
         available_balance: u64,
         available_balance_ciphertext: &ElGamalCiphertext,
         elgamal_keypair: &ElGamalKeypair,
         authenticated_encryption_key: &AeKey,
+        signing_keypairs: &S,
     ) -> TokenResult<T::Output> {
         let proof_data = confidential_transfer::instruction::WithdrawData::new(
             amount,
@@ -2172,11 +2173,11 @@ where
                 amount,
                 decimals,
                 new_decryptable_available_balance,
-                &token_authority.pubkey(),
+                token_authority,
                 &[],
                 &proof_data,
             )?,
-            &[token_authority],
+            signing_keypairs,
         )
         .await
     }
@@ -2256,7 +2257,7 @@ where
     ///
     /// This function assumes that proof context states have already been created.
     #[allow(clippy::too_many_arguments)]
-    pub async fn confidential_transfer_transfer_with_split_proofs<S: Signer>(
+    pub async fn confidential_transfer_transfer_with_split_proofs<S: Signers>(
         &self,
         source_account: &Pubkey,
         destination_account: &Pubkey,
@@ -2265,8 +2266,8 @@ where
         transfer_amount: u64,
         account_info: Option<TransferAccountInfo>,
         source_aes_key: &AeKey,
-        source_authority_keypair: &S,
         source_decrypt_handles: &SourceDecryptHandles,
+        signing_keypairs: &S,
     ) -> TokenResult<T::Output> {
         let account_info = if let Some(account_info) = account_info {
             account_info
@@ -2294,7 +2295,7 @@ where
                     source_decrypt_handles,
                 )?,
             ],
-            &[source_authority_keypair],
+            signing_keypairs,
         )
         .await
     }
@@ -2728,7 +2729,7 @@ where
     ///
     /// This function assumes that proof context states have already been created.
     #[allow(clippy::too_many_arguments)]
-    pub async fn confidential_transfer_transfer_with_fee_and_split_proofs<S: Signer>(
+    pub async fn confidential_transfer_transfer_with_fee_and_split_proofs<S: Signers>(
         &self,
         source_account: &Pubkey,
         destination_account: &Pubkey,
@@ -2737,8 +2738,8 @@ where
         transfer_amount: u64,
         account_info: Option<TransferAccountInfo>,
         source_aes_key: &AeKey,
-        source_authority_keypair: &S,
         source_decrypt_handles: &SourceDecryptHandles,
+        signing_keypairs: &S,
     ) -> TokenResult<T::Output> {
         let account_info = if let Some(account_info) = account_info {
             account_info
@@ -2766,7 +2767,7 @@ where
                     source_decrypt_handles,
                 )?,
             ],
-            &[source_authority_keypair],
+            signing_keypairs,
         )
         .await
     }

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -2791,10 +2791,10 @@ async fn confidential_transfer_transfer_with_fee_and_split_proof_context() {
             transfer_context_state_accounts,
             &equality_proof_data,
             &transfer_amount_ciphertext_validity_proof_data,
-            None,
-            &equality_proof_context_state_account,
-            &transfer_amount_ciphertext_validity_proof_context_state_account,
-            None,
+            &[
+                &equality_proof_context_state_account,
+                &transfer_amount_ciphertext_validity_proof_context_state_account,
+            ],
         )
         .await
         .unwrap();

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -2475,9 +2475,7 @@ async fn confidential_transfer_transfer_with_split_proof_context() {
         .create_range_proof_context_state_for_transfer(
             transfer_context_state_accounts,
             &range_proof_data,
-            None,
-            &range_proof_context_state_account,
-            None,
+            &[&range_proof_context_state_account],
         )
         .await
         .unwrap();

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -2492,8 +2492,8 @@ async fn confidential_transfer_transfer_with_split_proof_context() {
             42,
             None,
             &alice_meta.aes_key,
-            &alice,
             &source_decrypt_handles,
+            &[&alice],
         )
         .await
         .unwrap();
@@ -2833,8 +2833,8 @@ async fn confidential_transfer_transfer_with_fee_and_split_proof_context() {
             100,
             None,
             &alice_meta.aes_key,
-            &alice,
             &source_decrypt_handles,
+            &[&alice],
         )
         .await
         .unwrap();

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -2804,10 +2804,10 @@ async fn confidential_transfer_transfer_with_fee_and_split_proof_context() {
             transfer_context_state_accounts,
             &fee_sigma_proof_data,
             &fee_ciphertext_validity_proof_data,
-            None,
-            &fee_sigma_proof_context_state_account,
-            &fee_ciphertext_validity_proof_context_state_account,
-            None,
+            &[
+                &fee_sigma_proof_context_state_account,
+                &fee_ciphertext_validity_proof_context_state_account,
+            ],
         )
         .await
         .unwrap();

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -2817,9 +2817,7 @@ async fn confidential_transfer_transfer_with_fee_and_split_proof_context() {
         .create_range_proof_context_state_for_transfer_with_fee(
             transfer_context_state_accounts,
             &range_proof_data,
-            None,
-            &range_proof_context_state_account,
-            None,
+            &[&range_proof_context_state_account],
         )
         .await
         .unwrap();
@@ -2992,6 +2990,17 @@ async fn confidential_transfer_transfer_with_fee_and_split_proof_context_in_para
         close_split_context_state_accounts: None,
     };
 
+    let equality_and_ciphertext_signers = vec![
+        &alice,
+        &equality_proof_context_state_account,
+        &transfer_amount_ciphertext_validity_proof_context_state_account,
+    ];
+    let fee_sigma_signers = vec![
+        &alice,
+        &fee_sigma_proof_context_state_account,
+        &fee_ciphertext_validity_proof_context_state_account,
+    ];
+    let range_proof_signers = vec![&alice, &range_proof_context_state_account];
     token
         .confidential_transfer_transfer_with_fee_and_split_proofs_in_parallel(
             &alice_meta.token_account,
@@ -3007,13 +3016,9 @@ async fn confidential_transfer_transfer_with_fee_and_split_proof_context_in_para
             withdraw_withheld_authority_elgamal_keypair.pubkey(),
             TEST_FEE_BASIS_POINTS,
             TEST_MAXIMUM_FEE,
-            &alice,
-            &equality_proof_context_state_account,
-            &transfer_amount_ciphertext_validity_proof_context_state_account,
-            &fee_sigma_proof_context_state_account,
-            &fee_ciphertext_validity_proof_context_state_account,
-            &range_proof_context_state_account,
-            None,
+            &equality_and_ciphertext_signers,
+            &fee_sigma_signers,
+            &range_proof_signers,
         )
         .await
         .unwrap();

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -2463,10 +2463,10 @@ async fn confidential_transfer_transfer_with_split_proof_context() {
             transfer_context_state_accounts,
             &equality_proof_data,
             &ciphertext_validity_proof_data,
-            None,
-            &equality_proof_context_state_account,
-            &ciphertext_validity_proof_context_state_account,
-            None,
+            &[
+                &equality_proof_context_state_account,
+                &ciphertext_validity_proof_context_state_account,
+            ],
         )
         .await
         .unwrap();

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -2616,6 +2616,12 @@ async fn confidential_transfer_transfer_with_split_proof_contexts_in_parallel() 
         close_split_context_state_accounts: None,
     };
 
+    let equality_signers = vec![
+        &alice,
+        &equality_proof_context_state_account,
+        &ciphertext_validity_proof_context_state_account,
+    ];
+    let range_proof_signers = vec![&alice, &range_proof_context_state_account];
     token
         .confidential_transfer_transfer_with_split_proofs_in_parallel(
             &alice_meta.token_account,
@@ -2628,11 +2634,8 @@ async fn confidential_transfer_transfer_with_split_proof_contexts_in_parallel() 
             &alice_meta.aes_key,
             bob_meta.elgamal_keypair.pubkey(),
             Some(auditor_elgamal_keypair.pubkey()),
-            &alice,
-            &equality_proof_context_state_account,
-            &ciphertext_validity_proof_context_state_account,
-            &range_proof_context_state_account,
-            None,
+            &equality_signers,
+            &range_proof_signers,
         )
         .await
         .unwrap();

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -2616,7 +2616,7 @@ async fn confidential_transfer_transfer_with_split_proof_contexts_in_parallel() 
         close_split_context_state_accounts: None,
     };
 
-    let equality_signers = vec![
+    let equality_and_ciphertext_proof_signers = vec![
         &alice,
         &equality_proof_context_state_account,
         &ciphertext_validity_proof_context_state_account,
@@ -2634,7 +2634,7 @@ async fn confidential_transfer_transfer_with_split_proof_contexts_in_parallel() 
             &alice_meta.aes_key,
             bob_meta.elgamal_keypair.pubkey(),
             Some(auditor_elgamal_keypair.pubkey()),
-            &equality_signers,
+            &equality_and_ciphertext_proof_signers,
             &range_proof_signers,
         )
         .await
@@ -2990,12 +2990,12 @@ async fn confidential_transfer_transfer_with_fee_and_split_proof_context_in_para
         close_split_context_state_accounts: None,
     };
 
-    let equality_and_ciphertext_signers = vec![
+    let equality_and_ciphertext_proof_signers = vec![
         &alice,
         &equality_proof_context_state_account,
         &transfer_amount_ciphertext_validity_proof_context_state_account,
     ];
-    let fee_sigma_signers = vec![
+    let fee_sigma_proof_signers = vec![
         &alice,
         &fee_sigma_proof_context_state_account,
         &fee_ciphertext_validity_proof_context_state_account,
@@ -3016,8 +3016,8 @@ async fn confidential_transfer_transfer_with_fee_and_split_proof_context_in_para
             withdraw_withheld_authority_elgamal_keypair.pubkey(),
             TEST_FEE_BASIS_POINTS,
             TEST_MAXIMUM_FEE,
-            &equality_and_ciphertext_signers,
-            &fee_sigma_signers,
+            &equality_and_ciphertext_proof_signers,
+            &fee_sigma_proof_signers,
             &range_proof_signers,
         )
         .await


### PR DESCRIPTION
#### Problem

A lot of the confidential transfer functions in the token client parametrize on `Signer` and accept multiple keypairs for the required signatures (account authority, context state accounts, etc). This does not work with the token CLI, which uses a huge `bulk_signers` everywhere.

#### Solution

Change all of the functions to take in `Signers` instead! This works very nicely for the most part, but the split-proofs-in-parallel functions get a little tricky since you need to craft the correct `Signers` arrays for each transaction.

Let me know how it looks! You should be able to track each commit pretty easily, since each one actually works on its own.