### PR TITLE
Adding Token Metadata Support to @solana/spl-token 

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -722,6 +722,9 @@ importers:
       '@solana/buffer-layout-utils':
         specifier: ^0.2.0
         version: 0.2.0
+      '@solana/spl-token-metadata':
+        specifier: ^0.1.1
+        version: link:../../token-metadata/js
       buffer:
         specifier: ^6.0.3
         version: 6.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:
@@ -723,12 +727,15 @@ importers:
         specifier: ^0.2.0
         version: 0.2.0
       '@solana/spl-token-metadata':
-        specifier: ^0.1.1
+        specifier: ^0.1.2
         version: link:../../token-metadata/js
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
     devDependencies:
+      '@solana/codecs-strings':
+        specifier: 2.0.0-experimental.9741939
+        version: 2.0.0-experimental.9741939(fastestsmallesttextencoderdecoder@1.0.22)
       '@solana/spl-memo':
         specifier: 0.2.3
         version: link:../../memo/js
@@ -2274,7 +2281,6 @@ packages:
 
   /@solana/codecs-core@2.0.0-experimental.9741939:
     resolution: {integrity: sha512-7E51aEwLW+1ta6VWbEq0CbvwSUOcIwmaQCLpkOKsF6cwSNqE5GDv/jw9zKuiYOynlBFQO1Ws59a/hlb2wwwWKg==}
-    dev: false
 
   /@solana/codecs-data-structures@2.0.0-experimental.9741939:
     resolution: {integrity: sha512-Ghjx0pFEA22T/cpqg3zXHYlnxqKytjTr1QjgfhWvBrlVFkqr3ZQL4av9/V6sHKvpoi+JNkEwM1wE+tlpt/54CA==}
@@ -2287,7 +2293,6 @@ packages:
     resolution: {integrity: sha512-VXBvw8LZdGUJGuC33EFzvaUxCvgNtr9y9Td8zjK9wJDqKSzR0+G53CJv5K4AF25LUu8du8XHBK3VEz3YHl44nQ==}
     dependencies:
       '@solana/codecs-core': 2.0.0-experimental.9741939
-    dev: false
 
   /@solana/codecs-strings@2.0.0-experimental.9741939(fastestsmallesttextencoderdecoder@1.0.22):
     resolution: {integrity: sha512-J1DCTJsAMhFcIIvys/yNWM2Vr4HEWi+LzFB9xxdH+FHTynApjTMd4vI7frgnckuWH7ynp8EZFPnBTje1BphQrw==}
@@ -2297,7 +2302,6 @@ packages:
       '@solana/codecs-core': 2.0.0-experimental.9741939
       '@solana/codecs-numbers': 2.0.0-experimental.9741939
       fastestsmallesttextencoderdecoder: 1.0.22
-    dev: false
 
   /@solana/eslint-config-solana@1.0.2(@typescript-eslint/eslint-plugin@6.14.0)(@typescript-eslint/parser@6.14.0)(eslint-plugin-jest@27.6.0)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-simple-import-sort@10.0.0)(eslint-plugin-sort-keys-fix@1.1.2)(eslint@8.55.0)(typescript@5.3.3):
     resolution: {integrity: sha512-/mBi2xFsX0fq3ukZ3ugA+Zh2+Ct+bh713ZSdOJAv1G7ARzyOEDxmiUz8TLzHu4joOC/3Ok4Yl7cjupOcIRzMHw==}
@@ -4585,7 +4589,6 @@ packages:
 
   /fastestsmallesttextencoderdecoder@1.0.22:
     resolution: {integrity: sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==}
-    dev: false
 
   /fastq@1.15.0:
     resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
@@ -8014,7 +8017,3 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false

--- a/token/js/package.json
+++ b/token/js/package.json
@@ -56,6 +56,7 @@
     "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
         "@solana/buffer-layout-utils": "^0.2.0",
+        "@solana/spl-token-metadata": "^0.1.1",
         "buffer": "^6.0.3"
     },
     "devDependencies": {

--- a/token/js/package.json
+++ b/token/js/package.json
@@ -56,10 +56,11 @@
     "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
         "@solana/buffer-layout-utils": "^0.2.0",
-        "@solana/spl-token-metadata": "^0.1.1",
+        "@solana/spl-token-metadata": "^0.1.2",
         "buffer": "^6.0.3"
     },
     "devDependencies": {
+        "@solana/codecs-strings": "2.0.0-experimental.9741939",
         "@solana/spl-memo": "0.2.3",
         "@solana/web3.js": "^1.87.6",
         "@types/chai-as-promised": "^7.1.4",

--- a/token/js/src/extensions/extensionType.ts
+++ b/token/js/src/extensions/extensionType.ts
@@ -36,6 +36,7 @@ export enum ExtensionType {
     // ConfidentialTransferFee, // Not implemented yet
     // ConfidentialTransferFeeAmount, // Not implemented yet
     MetadataPointer = 18, // Remove number once above extensions implemented
+    TokenMetadata = 19, // Remove number once above extensions implemented
 }
 
 export const TYPE_SIZE = 2;
@@ -46,6 +47,7 @@ export const LENGTH_SIZE = 2;
 export function getTypeLen(e: ExtensionType): number {
     switch (e) {
         case ExtensionType.Uninitialized:
+        case ExtensionType.TokenMetadata:
             return 0;
         case ExtensionType.TransferFeeConfig:
             return TRANSFER_FEE_CONFIG_SIZE;
@@ -95,6 +97,7 @@ export function isMintExtension(e: ExtensionType): boolean {
         case ExtensionType.PermanentDelegate:
         case ExtensionType.TransferHook:
         case ExtensionType.MetadataPointer:
+        case ExtensionType.TokenMetadata:
             return true;
         case ExtensionType.Uninitialized:
         case ExtensionType.TransferFeeAmount:
@@ -130,6 +133,7 @@ export function isAccountExtension(e: ExtensionType): boolean {
         case ExtensionType.PermanentDelegate:
         case ExtensionType.TransferHook:
         case ExtensionType.MetadataPointer:
+        case ExtensionType.TokenMetadata:
             return false;
         default:
             throw Error(`Unknown extension type: ${e}`);
@@ -154,6 +158,7 @@ export function getAccountTypeOfMintType(e: ExtensionType): ExtensionType {
         case ExtensionType.MemoTransfer:
         case ExtensionType.MintCloseAuthority:
         case ExtensionType.MetadataPointer:
+        case ExtensionType.TokenMetadata:
         case ExtensionType.Uninitialized:
         case ExtensionType.InterestBearingConfig:
         case ExtensionType.PermanentDelegate:

--- a/token/js/src/extensions/extensionType.ts
+++ b/token/js/src/extensions/extensionType.ts
@@ -238,12 +238,12 @@ export function getAccountLenForMint(mint: Mint): number {
 export function getNewAccountLenForExtensionLen(
     info: AccountInfo<Buffer>,
     address: PublicKey,
-    e: ExtensionType,
+    extensionType: ExtensionType,
     extensionLen: number,
     programId = TOKEN_2022_PROGRAM_ID
 ): number {
     const mint = unpackMint(address, info, programId);
-    const extensionData = getExtensionData(e, mint.tlvData);
+    const extensionData = getExtensionData(extensionType, mint.tlvData);
 
     const currentExtensionLen = extensionData ? addTypeAndLengthToLen(extensionData.length) : 0;
     const newExtensionLen = addTypeAndLengthToLen(extensionLen);

--- a/token/js/src/extensions/extensionType.ts
+++ b/token/js/src/extensions/extensionType.ts
@@ -47,7 +47,6 @@ export const LENGTH_SIZE = 2;
 export function getTypeLen(e: ExtensionType): number {
     switch (e) {
         case ExtensionType.Uninitialized:
-        case ExtensionType.TokenMetadata:
             return 0;
         case ExtensionType.TransferFeeConfig:
             return TRANSFER_FEE_CONFIG_SIZE;
@@ -81,6 +80,8 @@ export function getTypeLen(e: ExtensionType): number {
             return TRANSFER_HOOK_SIZE;
         case ExtensionType.TransferHookAccount:
             return TRANSFER_HOOK_ACCOUNT_SIZE;
+        case ExtensionType.TokenMetadata:
+            throw Error(`Variable length extension type: ${e}`);
         default:
             throw Error(`Unknown extension type: ${e}`);
     }

--- a/token/js/src/extensions/extensionType.ts
+++ b/token/js/src/extensions/extensionType.ts
@@ -12,7 +12,7 @@ import { INTEREST_BEARING_MINT_CONFIG_STATE_SIZE } from './interestBearingMint/s
 import { MEMO_TRANSFER_SIZE } from './memoTransfer/index.js';
 import { METADATA_POINTER_SIZE } from './metadataPointer/state.js';
 import { MINT_CLOSE_AUTHORITY_SIZE } from './mintCloseAuthority.js';
-import { NON_TRANSFERABLE_ACCOUNT_SIZE, NON_TRANSFERABLE_SIZE } from './nonTransferable.js';
+import { NON_TRANSFERABLE_SIZE, NON_TRANSFERABLE_ACCOUNT_SIZE } from './nonTransferable.js';
 import { PERMANENT_DELEGATE_SIZE } from './permanentDelegate.js';
 import { TRANSFER_FEE_AMOUNT_SIZE, TRANSFER_FEE_CONFIG_SIZE } from './transferFee/index.js';
 import { TRANSFER_HOOK_ACCOUNT_SIZE, TRANSFER_HOOK_SIZE } from './transferHook/index.js';

--- a/token/js/src/extensions/extensionType.ts
+++ b/token/js/src/extensions/extensionType.ts
@@ -81,7 +81,7 @@ export function getTypeLen(e: ExtensionType): number {
         case ExtensionType.TransferHookAccount:
             return TRANSFER_HOOK_ACCOUNT_SIZE;
         case ExtensionType.TokenMetadata:
-            throw Error(`Variable length extension type: ${e}`);
+            throw Error(`Cannot get type length for variable extension type: ${e}`);
         default:
             throw Error(`Unknown extension type: ${e}`);
     }

--- a/token/js/src/extensions/extensionType.ts
+++ b/token/js/src/extensions/extensionType.ts
@@ -252,8 +252,8 @@ export function getNewAccountLenForExtensionLen(
 ): number {
     const data = getExtensionDataFromAccountInfo(address, info, e, programId);
 
-    // 2 bytes discriminator, 2 bytes length, extensionLen
-    const newExtensionLen = 2 + 2 + extensionLen;
+    // 2 bytes type, 2 bytes length, extensionLen
+    const newExtensionLen = TYPE_SIZE + LENGTH_SIZE + extensionLen;
 
     return info.data.length + newExtensionLen - (data?.length || 0);
 }

--- a/token/js/src/extensions/index.ts
+++ b/token/js/src/extensions/index.ts
@@ -6,6 +6,7 @@ export * from './immutableOwner.js';
 export * from './interestBearingMint/index.js';
 export * from './memoTransfer/index.js';
 export * from './metadataPointer/index.js';
+export * from './tokenMetadata/index.js';
 export * from './mintCloseAuthority.js';
 export * from './nonTransferable.js';
 export * from './transferFee/index.js';

--- a/token/js/src/extensions/tokenMetadata/actions.ts
+++ b/token/js/src/extensions/tokenMetadata/actions.ts
@@ -20,16 +20,6 @@ import {
 } from '../extensionType.js';
 import { updateTokenMetadata } from './state.js';
 
-/**
- * Calculates additional lamports need for variable length extension
- *
- * @param connection       Connection to use
- * @param address          Mint Account
- * @param tokenMetadata    Token Metadata
- * @param programId        SPL Token program account
- *
- * @return lamports to send
- */
 async function getAdditionalRentForNewMetadata(
     connection: Connection,
     address: PublicKey,
@@ -45,17 +35,6 @@ async function getAdditionalRentForNewMetadata(
     );
 }
 
-/**
- * Calculates additional lamports to update field
- *
- * @param connection       Connection to use
- * @param address          Mint Account
- * @param field            Field to update in the metadata
- * @param value            Value to write for the field
- * @param programId        SPL Token program account
- *
- * @return lamports to send
- */
 async function getAdditionalRentForUpdatedMetadata(
     connection: Connection,
     address: PublicKey,
@@ -168,14 +147,19 @@ export async function tokenMetadataInitializeWithRentTransfer(
 
     const transaction = new Transaction();
 
-    const lamports = await getAdditionalRentForNewMetadata(connection, mint, {
-        updateAuthority,
+    const lamports = await getAdditionalRentForNewMetadata(
+        connection,
         mint,
-        name,
-        symbol,
-        uri,
-        additionalMetadata: [],
-    });
+        {
+            updateAuthority,
+            mint,
+            name,
+            symbol,
+            uri,
+            additionalMetadata: [],
+        },
+        programId
+    );
 
     if (lamports > 0) {
         transaction.add(SystemProgram.transfer({ fromPubkey: payer.publicKey, toPubkey: mint, lamports: lamports }));
@@ -277,7 +261,7 @@ export async function tokenMetadataUpdateFieldWithRentTransfer(
 
     const transaction = new Transaction();
 
-    const lamports = await getAdditionalRentForUpdatedMetadata(connection, mint, field, value);
+    const lamports = await getAdditionalRentForUpdatedMetadata(connection, mint, field, value, programId);
 
     if (lamports > 0) {
         transaction.add(SystemProgram.transfer({ fromPubkey: payer.publicKey, toPubkey: mint, lamports: lamports }));

--- a/token/js/src/extensions/tokenMetadata/actions.ts
+++ b/token/js/src/extensions/tokenMetadata/actions.ts
@@ -1,0 +1,133 @@
+import type { ConfirmOptions, Connection, PublicKey, Signer, TransactionSignature } from '@solana/web3.js';
+import type { Field } from '@solana/spl-token-metadata';
+import {
+    createInitializeInstruction,
+    createEmitInstruction,
+    createUpdateFieldInstruction,
+} from '@solana/spl-token-metadata';
+import { sendAndConfirmTransaction, Transaction } from '@solana/web3.js';
+
+import { TOKEN_2022_PROGRAM_ID } from '../../constants.js';
+import { getSigners } from '../../actions/internal.js';
+
+/**
+ * Initializes a TLV entry with the basic token-metadata fields.
+ *
+ * @param connection       Connection to use
+ * @param payer            Payer of the transaction fees
+ * @param updateAuthority  Update Authority
+ * @param mint             Mint Account
+ * @param mintAuthority    Mint Authority
+ * @param name             Longer name of token
+ * @param symbol           Shortened symbol of token
+ * @param uri              URI pointing to more metadata (image, video, etc)
+ * @param multiSigners     Signing accounts if `authority` is a multisig
+ * @param confirmOptions   Options for confirming the transaction
+ * @param programId        SPL Token program account
+ *
+ * @return Signature of the confirmed transaction
+ */
+export async function tokenMetadataInitialize(
+    connection: Connection,
+    payer: Signer,
+    updateAuthority: PublicKey,
+    mint: PublicKey,
+    mintAuthority: PublicKey | Signer,
+    name: string,
+    symbol: string,
+    uri: string,
+    multiSigners: Signer[] = [],
+    confirmOptions?: ConfirmOptions,
+    programId = TOKEN_2022_PROGRAM_ID
+): Promise<TransactionSignature> {
+    const [mintAuthorityPublicKey, signers] = getSigners(mintAuthority, multiSigners);
+
+    const transaction = new Transaction().add(
+        createInitializeInstruction({
+            programId,
+            metadata: mint,
+            updateAuthority,
+            mint,
+            mintAuthority: mintAuthorityPublicKey,
+            name,
+            symbol,
+            uri,
+        })
+    );
+
+    return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);
+}
+
+/**
+ * Updates a field in a token-metadata account.
+ * If the field does not exist on the account, it will be created.
+ * If the field does exist, it will be overwritten.
+ *
+ * The field can be one of the required fields (name, symbol, URI), or a
+ * totally new field denoted by a "key" string.
+ * @param connection       Connection to use
+ * @param payer            Payer of the transaction fees
+ * @param updateAuthority  Update Authority
+ * @param mint             Mint Account
+ * @param field            Longer name of token
+ * @param value            Shortened symbol of token
+ * @param multiSigners     Signing accounts if `authority` is a multisig
+ * @param confirmOptions   Options for confirming the transaction
+ * @param programId        SPL Token program account
+ *
+ * @return Signature of the confirmed transaction
+ */
+export async function tokenMetadataUpdateField(
+    connection: Connection,
+    payer: Signer,
+    updateAuthority: PublicKey | Signer,
+    mint: PublicKey,
+    field: string | Field,
+    value: string,
+    multiSigners: Signer[] = [],
+    confirmOptions?: ConfirmOptions,
+    programId = TOKEN_2022_PROGRAM_ID
+): Promise<TransactionSignature> {
+    const [updateAuthorityPublicKey, signers] = getSigners(updateAuthority, multiSigners);
+
+    const transaction = new Transaction().add(
+        createUpdateFieldInstruction({
+            programId,
+            metadata: mint,
+            updateAuthority: updateAuthorityPublicKey,
+            field,
+            value,
+        })
+    );
+
+    return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);
+}
+
+/**
+ * Emits the token-metadata as return data
+ *
+ * @param connection       Connection to use
+ * @param payer            Payer of the transaction fees
+ * @param mint             Mint Account
+ * @param multiSigners     Signing accounts if `authority` is a multisig
+ * @param confirmOptions   Options for confirming the transaction
+ * @param programId        SPL Token program account
+ *
+ * @return Signature of the confirmed transaction
+ */
+export async function tokenMetadataEmit(
+    connection: Connection,
+    payer: Signer,
+    mint: PublicKey,
+    confirmOptions?: ConfirmOptions,
+    programId = TOKEN_2022_PROGRAM_ID
+): Promise<TransactionSignature> {
+    const transaction = new Transaction().add(
+        createEmitInstruction({
+            programId,
+            metadata: mint,
+        })
+    );
+
+    return await sendAndConfirmTransaction(connection, transaction, [payer], confirmOptions);
+}

--- a/token/js/src/extensions/tokenMetadata/actions.ts
+++ b/token/js/src/extensions/tokenMetadata/actions.ts
@@ -1,14 +1,63 @@
 import type { ConfirmOptions, Connection, PublicKey, Signer, TransactionSignature } from '@solana/web3.js';
-import type { Field } from '@solana/spl-token-metadata';
+import type { Field, TokenMetadata } from '@solana/spl-token-metadata';
 import {
-    createInitializeInstruction,
     createEmitInstruction,
+    createInitializeInstruction,
+    createRemoveKeyInstruction,
+    createUpdateAuthorityInstruction,
     createUpdateFieldInstruction,
+    pack,
 } from '@solana/spl-token-metadata';
-import { sendAndConfirmTransaction, Transaction } from '@solana/web3.js';
+import { sendAndConfirmTransaction, SystemProgram, Transaction } from '@solana/web3.js';
+import { TokenAccountNotFoundError } from '../../errors.js';
 
 import { TOKEN_2022_PROGRAM_ID } from '../../constants.js';
 import { getSigners } from '../../actions/internal.js';
+import { unpackMint } from '../../state/mint.js';
+import { getExtensionData, ExtensionType } from '../extensionType.js';
+
+/**
+ * Calculates additional lamports need to variable length extension
+ *
+ * @param connection       Connection to use
+ * @param address          Mint Account
+ * @param tokenMetadata    Token Metadata
+ * @param programId        SPL Token program account
+ *
+ * @return lamports to send
+ */
+async function getAdditionalRentForNewMetadata(
+    connection: Connection,
+    address: PublicKey,
+    tokenMetadata: TokenMetadata,
+    programId = TOKEN_2022_PROGRAM_ID
+): Promise<number> {
+    const info = await connection.getAccountInfo(address);
+    const mint = unpackMint(address, info, programId);
+
+    if (!info) {
+        // unpack mint does error checking on info internally
+        // but just for typescript and just incase
+        throw new TokenAccountNotFoundError();
+    }
+
+    const data = getExtensionData(ExtensionType.TokenMetadata, mint.tlvData);
+
+    const currentDataLen = data ? data.length : 0;
+    const newDataLen = pack(tokenMetadata).length;
+
+    let newAccountLen = info.data.length + (newDataLen - currentDataLen);
+
+    if (currentDataLen === 0) {
+        // Extension not initialized
+        // Need 2 bytes extension discriminator, 2 bytes length
+        newAccountLen += 4;
+    }
+
+    const newRentExemptMinimum = await connection.getMinimumBalanceForRentExemption(newAccountLen);
+
+    return newRentExemptMinimum - info.lamports;
+}
 
 /**
  * Initializes a TLV entry with the basic token-metadata fields.
@@ -43,6 +92,70 @@ export async function tokenMetadataInitialize(
     const [mintAuthorityPublicKey, signers] = getSigners(mintAuthority, multiSigners);
 
     const transaction = new Transaction().add(
+        createInitializeInstruction({
+            programId,
+            metadata: mint,
+            updateAuthority,
+            mint,
+            mintAuthority: mintAuthorityPublicKey,
+            name,
+            symbol,
+            uri,
+        })
+    );
+
+    return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);
+}
+
+/**
+ * Initializes a TLV entry with the basic token-metadata fields,
+ * Includes a transfer for any additional rent-exempt SOL if required.
+ *
+ * @param connection       Connection to use
+ * @param payer            Payer of the transaction fees
+ * @param updateAuthority  Update Authority
+ * @param mint             Mint Account
+ * @param mintAuthority    Mint Authority
+ * @param name             Longer name of token
+ * @param symbol           Shortened symbol of token
+ * @param uri              URI pointing to more metadata (image, video, etc)
+ * @param multiSigners     Signing accounts if `authority` is a multisig
+ * @param confirmOptions   Options for confirming the transaction
+ * @param programId        SPL Token program account
+ *
+ * @return Signature of the confirmed transaction
+ */
+export async function tokenMetadataInitializeWithRentTransfer(
+    connection: Connection,
+    payer: Signer,
+    updateAuthority: PublicKey,
+    mint: PublicKey,
+    mintAuthority: PublicKey | Signer,
+    name: string,
+    symbol: string,
+    uri: string,
+    multiSigners: Signer[] = [],
+    confirmOptions?: ConfirmOptions,
+    programId = TOKEN_2022_PROGRAM_ID
+): Promise<TransactionSignature> {
+    const [mintAuthorityPublicKey, signers] = getSigners(mintAuthority, multiSigners);
+
+    const transaction = new Transaction();
+
+    const lamports = await getAdditionalRentForNewMetadata(connection, mint, {
+        updateAuthority,
+        mint,
+        name,
+        symbol,
+        uri,
+        additionalMetadata: [],
+    });
+
+    if (lamports > 0) {
+        transaction.add(SystemProgram.transfer({ fromPubkey: payer.publicKey, toPubkey: mint, lamports: lamports }));
+    }
+
+    transaction.add(
         createInitializeInstruction({
             programId,
             metadata: mint,
@@ -104,6 +217,69 @@ export async function tokenMetadataUpdateField(
 }
 
 /**
+ * Updates a field in a token-metadata account.
+ * If the field does not exist on the account, it will be created.
+ * If the field does exist, it will be overwritten.
+ * Includes a transfer for any additional rent-exempt SOL if required.
+ *
+ * The field can be one of the required fields (name, symbol, URI), or a
+ * totally new field denoted by a "key" string.
+ * @param connection       Connection to use
+ * @param payer            Payer of the transaction fees
+ * @param updateAuthority  Update Authority
+ * @param mint             Mint Account
+ * @param field            Longer name of token
+ * @param value            Shortened symbol of token
+ * @param multiSigners     Signing accounts if `authority` is a multisig
+ * @param confirmOptions   Options for confirming the transaction
+ * @param programId        SPL Token program account
+ *
+ * @return Signature of the confirmed transaction
+ */
+export async function tokenMetadataUpdateFieldWithRentTransfer(
+    connection: Connection,
+    payer: Signer,
+    updateAuthority: PublicKey | Signer,
+    mint: PublicKey,
+    field: string | Field,
+    value: string,
+    multiSigners: Signer[] = [],
+    confirmOptions?: ConfirmOptions,
+    programId = TOKEN_2022_PROGRAM_ID
+): Promise<TransactionSignature> {
+    const [updateAuthorityPublicKey, signers] = getSigners(updateAuthority, multiSigners);
+
+    const transaction = new Transaction();
+
+    // TODO:- Figure this out
+    // const lamports = await getAdditionalRentForNewMetadata(connection, mint, {
+    //     updateAuthority,
+    //     mint,
+    //     name,
+    //     symbol,
+    //     uri,
+    //     additionalMetadata: [],
+    // });
+    const lamports = 0; // TODO
+
+    if (lamports > 0) {
+        transaction.add(SystemProgram.transfer({ fromPubkey: payer.publicKey, toPubkey: mint, lamports: lamports }));
+    }
+
+    transaction.add(
+        createUpdateFieldInstruction({
+            programId,
+            metadata: mint,
+            updateAuthority: updateAuthorityPublicKey,
+            field,
+            value,
+        })
+    );
+
+    return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);
+}
+
+/**
  * Emits the token-metadata as return data
  *
  * @param connection       Connection to use
@@ -130,4 +306,85 @@ export async function tokenMetadataEmit(
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer], confirmOptions);
+}
+
+/**
+ * Remove a field in a token-metadata account.
+ *
+ * The field can be one of the required fields (name, symbol, URI), or a
+ * totally new field denoted by a "key" string.
+ * @param connection       Connection to use
+ * @param payer            Payer of the transaction fees
+ * @param updateAuthority  Update Authority
+ * @param mint             Mint Account
+ * @param key              Key to remove in the additional metadata portion
+ * @param idempotent       When true, instruction will not error if the key does not exist
+ * @param multiSigners     Signing accounts if `authority` is a multisig
+ * @param confirmOptions   Options for confirming the transaction
+ * @param programId        SPL Token program account
+ *
+ * @return Signature of the confirmed transaction
+ */
+export async function tokenMetadataRemoveKey(
+    connection: Connection,
+    payer: Signer,
+    updateAuthority: PublicKey | Signer,
+    mint: PublicKey,
+    key: string,
+    idempotent: boolean,
+    multiSigners: Signer[] = [],
+    confirmOptions?: ConfirmOptions,
+    programId = TOKEN_2022_PROGRAM_ID
+): Promise<TransactionSignature> {
+    const [updateAuthorityPublicKey, signers] = getSigners(updateAuthority, multiSigners);
+
+    const transaction = new Transaction().add(
+        createRemoveKeyInstruction({
+            programId,
+            metadata: mint,
+            updateAuthority: updateAuthorityPublicKey,
+            key,
+            idempotent,
+        })
+    );
+
+    return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);
+}
+
+/**
+ *  Update authority
+ *
+ * @param connection       Connection to use
+ * @param payer            Payer of the transaction fees
+ * @param updateAuthority  Update Authority
+ * @param mint             Mint Account
+ * @param newAuthority     New authority for the token metadata, or unset
+ * @param multiSigners     Signing accounts if `authority` is a multisig
+ * @param confirmOptions   Options for confirming the transaction
+ * @param programId        SPL Token program account
+ *
+ * @return Signature of the confirmed transaction
+ */
+export async function tokenMetadataUpdateAuthority(
+    connection: Connection,
+    payer: Signer,
+    updateAuthority: PublicKey | Signer,
+    mint: PublicKey,
+    newAuthority: PublicKey | null,
+    multiSigners: Signer[] = [],
+    confirmOptions?: ConfirmOptions,
+    programId = TOKEN_2022_PROGRAM_ID
+): Promise<TransactionSignature> {
+    const [updateAuthorityPublicKey, signers] = getSigners(updateAuthority, multiSigners);
+
+    const transaction = new Transaction().add(
+        createUpdateAuthorityInstruction({
+            programId,
+            metadata: mint,
+            oldAuthority: updateAuthorityPublicKey,
+            newAuthority,
+        })
+    );
+
+    return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);
 }

--- a/token/js/src/extensions/tokenMetadata/actions.ts
+++ b/token/js/src/extensions/tokenMetadata/actions.ts
@@ -2,7 +2,6 @@ import type { ConfirmOptions, Connection, PublicKey, Signer, TransactionSignatur
 import { sendAndConfirmTransaction, SystemProgram, Transaction } from '@solana/web3.js';
 import type { Field, TokenMetadata } from '@solana/spl-token-metadata';
 import {
-    createEmitInstruction,
     createInitializeInstruction,
     createRemoveKeyInstruction,
     createUpdateAuthorityInstruction,
@@ -62,7 +61,7 @@ async function getAdditionalRentForUpdatedMetadata(
     const mint = unpackMint(address, info, programId);
     const extensionData = getExtensionData(ExtensionType.TokenMetadata, mint.tlvData);
     if (extensionData === null) {
-        throw new Error('TokenMetadata extension not initialised');
+        throw new Error('TokenMetadata extension not initialized');
     }
 
     const updatedTokenMetadata = updateTokenMetadata(unpack(extensionData), field, value);
@@ -90,8 +89,8 @@ async function getAdditionalRentForUpdatedMetadata(
  *
  * @param connection       Connection to use
  * @param payer            Payer of the transaction fees
- * @param updateAuthority  Update Authority
  * @param mint             Mint Account
+ * @param updateAuthority  Update Authority
  * @param mintAuthority    Mint Authority
  * @param name             Longer name of token
  * @param symbol           Shortened symbol of token
@@ -105,8 +104,8 @@ async function getAdditionalRentForUpdatedMetadata(
 export async function tokenMetadataInitialize(
     connection: Connection,
     payer: Signer,
-    updateAuthority: PublicKey,
     mint: PublicKey,
+    updateAuthority: PublicKey,
     mintAuthority: PublicKey | Signer,
     name: string,
     symbol: string,
@@ -139,8 +138,8 @@ export async function tokenMetadataInitialize(
  *
  * @param connection       Connection to use
  * @param payer            Payer of the transaction fees
- * @param updateAuthority  Update Authority
  * @param mint             Mint Account
+ * @param updateAuthority  Update Authority
  * @param mintAuthority    Mint Authority
  * @param name             Longer name of token
  * @param symbol           Shortened symbol of token
@@ -154,8 +153,8 @@ export async function tokenMetadataInitialize(
 export async function tokenMetadataInitializeWithRentTransfer(
     connection: Connection,
     payer: Signer,
-    updateAuthority: PublicKey,
     mint: PublicKey,
+    updateAuthority: PublicKey,
     mintAuthority: PublicKey | Signer,
     name: string,
     symbol: string,
@@ -211,8 +210,8 @@ export async function tokenMetadataInitializeWithRentTransfer(
  * totally new field denoted by a "key" string.
  * @param connection       Connection to use
  * @param payer            Payer of the transaction fees
- * @param updateAuthority  Update Authority
  * @param mint             Mint Account
+ * @param updateAuthority  Update Authority
  * @param field            Field to update in the metadata
  * @param value            Value to write for the field
  * @param multiSigners     Signing accounts if `authority` is a multisig
@@ -224,8 +223,8 @@ export async function tokenMetadataInitializeWithRentTransfer(
 export async function tokenMetadataUpdateField(
     connection: Connection,
     payer: Signer,
-    updateAuthority: PublicKey | Signer,
     mint: PublicKey,
+    updateAuthority: PublicKey | Signer,
     field: string | Field,
     value: string,
     multiSigners: Signer[] = [],
@@ -257,8 +256,8 @@ export async function tokenMetadataUpdateField(
  * totally new field denoted by a "key" string.
  * @param connection       Connection to use
  * @param payer            Payer of the transaction fees
- * @param updateAuthority  Update Authority
  * @param mint             Mint Account
+ * @param updateAuthority  Update Authority
  * @param field            Field to update in the metadata
  * @param value            Value to write for the field
  * @param multiSigners     Signing accounts if `authority` is a multisig
@@ -270,8 +269,8 @@ export async function tokenMetadataUpdateField(
 export async function tokenMetadataUpdateFieldWithRentTransfer(
     connection: Connection,
     payer: Signer,
-    updateAuthority: PublicKey | Signer,
     mint: PublicKey,
+    updateAuthority: PublicKey | Signer,
     field: string | Field,
     value: string,
     multiSigners: Signer[] = [],
@@ -302,42 +301,14 @@ export async function tokenMetadataUpdateFieldWithRentTransfer(
 }
 
 /**
- * Emits the token-metadata as return data
- *
- * @param connection       Connection to use
- * @param payer            Payer of the transaction fees
- * @param mint             Mint Account
- * @param confirmOptions   Options for confirming the transaction
- * @param programId        SPL Token program account
- *
- * @return Signature of the confirmed transaction
- */
-export async function tokenMetadataEmit(
-    connection: Connection,
-    payer: Signer,
-    mint: PublicKey,
-    confirmOptions?: ConfirmOptions,
-    programId = TOKEN_2022_PROGRAM_ID
-): Promise<TransactionSignature> {
-    const transaction = new Transaction().add(
-        createEmitInstruction({
-            programId,
-            metadata: mint,
-        })
-    );
-
-    return await sendAndConfirmTransaction(connection, transaction, [payer], confirmOptions);
-}
-
-/**
  * Remove a field in a token-metadata account.
  *
  * The field can be one of the required fields (name, symbol, URI), or a
  * totally new field denoted by a "key" string.
  * @param connection       Connection to use
  * @param payer            Payer of the transaction fees
- * @param updateAuthority  Update Authority
  * @param mint             Mint Account
+ * @param updateAuthority  Update Authority
  * @param key              Key to remove in the additional metadata portion
  * @param idempotent       When true, instruction will not error if the key does not exist
  * @param multiSigners     Signing accounts if `authority` is a multisig
@@ -349,8 +320,8 @@ export async function tokenMetadataEmit(
 export async function tokenMetadataRemoveKey(
     connection: Connection,
     payer: Signer,
-    updateAuthority: PublicKey | Signer,
     mint: PublicKey,
+    updateAuthority: PublicKey | Signer,
     key: string,
     idempotent: boolean,
     multiSigners: Signer[] = [],
@@ -377,8 +348,8 @@ export async function tokenMetadataRemoveKey(
  *
  * @param connection       Connection to use
  * @param payer            Payer of the transaction fees
- * @param updateAuthority  Update Authority
  * @param mint             Mint Account
+ * @param updateAuthority  Update Authority
  * @param newAuthority     New authority for the token metadata, or unset
  * @param multiSigners     Signing accounts if `authority` is a multisig
  * @param confirmOptions   Options for confirming the transaction
@@ -389,8 +360,8 @@ export async function tokenMetadataRemoveKey(
 export async function tokenMetadataUpdateAuthority(
     connection: Connection,
     payer: Signer,
-    updateAuthority: PublicKey | Signer,
     mint: PublicKey,
+    updateAuthority: PublicKey | Signer,
     newAuthority: PublicKey | null,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,

--- a/token/js/src/extensions/tokenMetadata/index.ts
+++ b/token/js/src/extensions/tokenMetadata/index.ts
@@ -1,0 +1,2 @@
+export * from './actions.js';
+export * from './state.js';

--- a/token/js/src/extensions/tokenMetadata/state.ts
+++ b/token/js/src/extensions/tokenMetadata/state.ts
@@ -1,10 +1,82 @@
-import type { Commitment, Connection, Finality, PublicKey } from '@solana/web3.js';
+import type { Commitment, Connection, Finality } from '@solana/web3.js';
+import { PublicKey } from '@solana/web3.js';
 import type { TokenMetadata } from '@solana/spl-token-metadata';
-import { unpack } from '@solana/spl-token-metadata';
+import { Field, unpack } from '@solana/spl-token-metadata';
 
 import { TOKEN_2022_PROGRAM_ID } from '../../constants.js';
 import { ExtensionType, getExtensionData } from '../extensionType.js';
 import { getMint } from '../../state/mint.js';
+
+export const getNormalizedTokenMetadataField = (field: Field | string): string => {
+    if (field === Field.Name || field === 'Name' || field === 'name') {
+        return 'name';
+    }
+
+    if (field === Field.Symbol || field === 'Symbol' || field === 'symbol') {
+        return 'symbol';
+    }
+
+    if (field === Field.Uri || field === 'Uri' || field === 'uri') {
+        return 'uri';
+    }
+
+    return field;
+};
+
+export const updateTokenMetadata = (
+    current: TokenMetadata,
+    key: Field | string,
+    value: string | PublicKey | null
+): TokenMetadata => {
+    const field = getNormalizedTokenMetadataField(key);
+
+    if (field === 'mint' && !(value instanceof PublicKey)) {
+        throw new Error('TokenMetadata field mint must be a PublicKey');
+    }
+
+    if (field === 'updateAuthority' && !(value === null || value instanceof PublicKey)) {
+        throw new Error('TokenMetadata field updateAuthority must be a PublicKey or null');
+    }
+
+    if (typeof value !== 'string' && field !== 'updateAuthority' && field !== 'mint') {
+        throw new Error('TokenMetadata value must be a string');
+    }
+
+    // Handle case where updateAuthority is being removed
+    if (field === 'updateAuthority' && value === null) {
+        const { updateAuthority, ...state } = current;
+        return state;
+    }
+
+    // Handle updates to default keys
+    if (['mint', 'name', 'symbol', 'updateAuthority', 'uri'].includes(field)) {
+        return {
+            ...current,
+            [field]: value,
+        };
+    }
+
+    // If we are here, we are updating the additional metadata
+    value = value as string; // Should already be enforced by above checks
+
+    // Avoid mutating input, make a shallow copy
+    const additionalMetadata = [...current.additionalMetadata];
+
+    const i = current.additionalMetadata.findIndex((x) => x[0] === field);
+
+    if (i === -1) {
+        // Key was not found, add it
+        additionalMetadata.push([field, value]);
+    } else {
+        // Key was found, change value
+        additionalMetadata[i] = [field, value];
+    }
+
+    return {
+        ...current,
+        additionalMetadata,
+    };
+};
 
 /**
  * Retrieve Token Metadata Information

--- a/token/js/src/extensions/tokenMetadata/state.ts
+++ b/token/js/src/extensions/tokenMetadata/state.ts
@@ -1,4 +1,4 @@
-import type { Commitment, Connection, Finality } from '@solana/web3.js';
+import type { Commitment, Connection } from '@solana/web3.js';
 import { PublicKey } from '@solana/web3.js';
 import type { TokenMetadata } from '@solana/spl-token-metadata';
 import { Field, unpack } from '@solana/spl-token-metadata';
@@ -96,39 +96,6 @@ export async function getTokenMetadata(
 ): Promise<TokenMetadata | null> {
     const mintInfo = await getMint(connection, address, commitment, programId);
     const data = getExtensionData(ExtensionType.TokenMetadata, mintInfo.tlvData);
-
-    if (data === null) {
-        return null;
-    }
-
-    return unpack(data);
-}
-
-/**
- * Retrieve Token Metadata Information emitted in transaction
- *
- * @param connection Connection to use
- * @param signature  Transaction signature
- * @param commitment Desired level of commitment for querying the state
- *
- * @return Token Metadata information
- */
-export async function getEmittedTokenMetadata(
-    connection: Connection,
-    signature: string,
-    commitment?: Finality,
-    programId = TOKEN_2022_PROGRAM_ID
-): Promise<TokenMetadata | null> {
-    const tx: any = await connection.getTransaction(signature, {
-        commitment: commitment,
-        maxSupportedTransactionVersion: 2,
-    });
-
-    if (tx === null) {
-        return null;
-    }
-
-    const data = Buffer.from(tx?.meta?.returnData?.data?.[0], 'base64');
 
     if (data === null) {
         return null;

--- a/token/js/src/extensions/tokenMetadata/state.ts
+++ b/token/js/src/extensions/tokenMetadata/state.ts
@@ -52,6 +52,10 @@ export async function getEmittedTokenMetadata(
         maxSupportedTransactionVersion: 2,
     });
 
+    if (tx === null) {
+        return null;
+    }
+
     const data = Buffer.from(tx?.meta?.returnData?.data?.[0], 'base64');
 
     if (data === null) {

--- a/token/js/src/extensions/tokenMetadata/state.ts
+++ b/token/js/src/extensions/tokenMetadata/state.ts
@@ -7,7 +7,7 @@ import { TOKEN_2022_PROGRAM_ID } from '../../constants.js';
 import { ExtensionType, getExtensionData } from '../extensionType.js';
 import { getMint } from '../../state/mint.js';
 
-export const getNormalizedTokenMetadataField = (field: Field | string): string => {
+const getNormalizedTokenMetadataField = (field: Field | string): string => {
     if (field === Field.Name || field === 'Name' || field === 'name') {
         return 'name';
     }

--- a/token/js/src/extensions/tokenMetadata/state.ts
+++ b/token/js/src/extensions/tokenMetadata/state.ts
@@ -23,7 +23,7 @@ const getNormalizedTokenMetadataField = (field: Field | string): string => {
     return field;
 };
 
-export const updateTokenMetadata = (current: TokenMetadata, key: Field | string, value: string): TokenMetadata => {
+export function updateTokenMetadata(current: TokenMetadata, key: Field | string, value: string): TokenMetadata {
     const field = getNormalizedTokenMetadataField(key);
 
     if (field === 'mint' || field === 'updateAuthority') {
@@ -37,8 +37,6 @@ export const updateTokenMetadata = (current: TokenMetadata, key: Field | string,
             [field]: value,
         };
     }
-
-    // If we are here, we are updating the additional metadata
 
     // Avoid mutating input, make a shallow copy
     const additionalMetadata = [...current.additionalMetadata];
@@ -57,7 +55,7 @@ export const updateTokenMetadata = (current: TokenMetadata, key: Field | string,
         ...current,
         additionalMetadata,
     };
-};
+}
 
 /**
  * Retrieve Token Metadata Information

--- a/token/js/src/extensions/tokenMetadata/state.ts
+++ b/token/js/src/extensions/tokenMetadata/state.ts
@@ -1,0 +1,62 @@
+import type { Commitment, Connection, Finality, PublicKey } from '@solana/web3.js';
+import type { TokenMetadata } from '@solana/spl-token-metadata';
+import { unpack } from '@solana/spl-token-metadata';
+
+import { TOKEN_2022_PROGRAM_ID } from '../../constants.js';
+import { ExtensionType, getExtensionData } from '../extensionType.js';
+import { getMint } from '../../state/mint.js';
+
+/**
+ * Retrieve Token Metadata Information
+ *
+ * @param connection Connection to use
+ * @param address    Mint account
+ * @param commitment Desired level of commitment for querying the state
+ * @param programId  SPL Token program account
+ *
+ * @return Token Metadata information
+ */
+export async function getTokenMetadata(
+    connection: Connection,
+    address: PublicKey,
+    commitment?: Commitment,
+    programId = TOKEN_2022_PROGRAM_ID
+): Promise<TokenMetadata | null> {
+    const mintInfo = await getMint(connection, address, commitment, programId);
+    const data = getExtensionData(ExtensionType.TokenMetadata, mintInfo.tlvData);
+
+    if (data === null) {
+        return null;
+    }
+
+    return unpack(data);
+}
+
+/**
+ * Retrieve Token Metadata Information emitted in transaction
+ *
+ * @param connection Connection to use
+ * @param signature  Transaction signature
+ * @param commitment Desired level of commitment for querying the state
+ *
+ * @return Token Metadata information
+ */
+export async function getEmittedTokenMetadata(
+    connection: Connection,
+    signature: string,
+    commitment?: Finality,
+    programId = TOKEN_2022_PROGRAM_ID
+): Promise<TokenMetadata | null> {
+    const tx: any = await connection.getTransaction(signature, {
+        commitment: commitment,
+        maxSupportedTransactionVersion: 2,
+    });
+
+    const data = Buffer.from(tx?.meta?.returnData?.data?.[0], 'base64');
+
+    if (data === null) {
+        return null;
+    }
+
+    return unpack(data);
+}

--- a/token/js/src/instructions/index.ts
+++ b/token/js/src/instructions/index.ts
@@ -1,3 +1,11 @@
+export {
+    createInitializeInstruction,
+    createUpdateFieldInstruction,
+    createRemoveKeyInstruction,
+    createUpdateAuthorityInstruction,
+    createEmitInstruction,
+} from '@solana/spl-token-metadata';
+
 export * from './associatedTokenAccount.js';
 export * from './decode.js';
 export * from './types.js';

--- a/token/js/test/e2e-2022/tokenMetadata.test.ts
+++ b/token/js/test/e2e-2022/tokenMetadata.test.ts
@@ -17,6 +17,7 @@ import {
     tokenMetadataRemoveKey,
     tokenMetadataUpdateAuthority,
     tokenMetadataUpdateField,
+    tokenMetadataUpdateFieldWithRentTransfer,
 } from '../../src';
 import { TEST_PROGRAM_ID, newAccountWithLamports, getConnection } from '../common';
 
@@ -165,7 +166,7 @@ describe('Token Metadata initialization', async () => {
     });
 });
 
-describe.only('Token Metadata operations', () => {
+describe('Token Metadata operations', () => {
     const EXTENSIONS = [ExtensionType.MetadataPointer];
     const mintLen = getMintLen(EXTENSIONS);
 
@@ -283,19 +284,8 @@ describe.only('Token Metadata operations', () => {
     });
 
     it('can successfully update with rent transfer', async () => {
-        // TODO Remove this and change to tokenMetadataUpdateFieldWithRentTransfer when working
-        const transaction = new Transaction().add(
-            SystemProgram.transfer({
-                fromPubkey: payer.publicKey,
-                toPubkey: mint.publicKey,
-                lamports: 1_000_000,
-            })
-        );
-
-        await sendAndConfirmTransaction(connection, transaction, [payer], undefined);
-
         await Promise.all([
-            tokenMetadataUpdateField(
+            tokenMetadataUpdateFieldWithRentTransfer(
                 connection,
                 payer,
                 authority,
@@ -306,7 +296,7 @@ describe.only('Token Metadata operations', () => {
                 undefined,
                 TEST_PROGRAM_ID
             ),
-            tokenMetadataUpdateField(
+            tokenMetadataUpdateFieldWithRentTransfer(
                 connection,
                 payer,
                 authority,
@@ -348,18 +338,7 @@ describe.only('Token Metadata operations', () => {
     });
 
     it('can handle removal of additional metadata ', async () => {
-        // TODO Remove this and change to tokenMetadataUpdateFieldWithRentTransfer when working
-        const transaction = new Transaction().add(
-            SystemProgram.transfer({
-                fromPubkey: payer.publicKey,
-                toPubkey: mint.publicKey,
-                lamports: 1_000_000,
-            })
-        );
-
-        await sendAndConfirmTransaction(connection, transaction, [payer], undefined);
-
-        await tokenMetadataUpdateField(
+        await tokenMetadataUpdateFieldWithRentTransfer(
             connection,
             payer,
             authority,

--- a/token/js/test/e2e-2022/tokenMetadata.test.ts
+++ b/token/js/test/e2e-2022/tokenMetadata.test.ts
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import type { Connection, Signer } from '@solana/web3.js';
 import { sendAndConfirmTransaction, PublicKey, Keypair, SystemProgram, Transaction } from '@solana/web3.js';
@@ -7,18 +8,26 @@ import {
     ExtensionType,
     createInitializeMetadataPointerInstruction,
     createInitializeMintInstruction,
-    tokenMetadataEmit,
-    tokenMetadataInitialize,
-    tokenMetadataUpdateField,
+    getEmittedTokenMetadata,
     getMintLen,
     getTokenMetadata,
-    getEmittedTokenMetadata,
+    tokenMetadataEmit,
+    tokenMetadataInitialize,
+    tokenMetadataInitializeWithRentTransfer,
+    tokenMetadataRemoveKey,
+    tokenMetadataUpdateAuthority,
+    tokenMetadataUpdateField,
 } from '../../src';
 import { TEST_PROGRAM_ID, newAccountWithLamports, getConnection } from '../common';
 
+chai.use(chaiAsPromised);
+
 const TEST_TOKEN_DECIMALS = 2;
 
-describe('Token Metadata', () => {
+describe('Token Metadata initialization', async () => {
+    const EXTENSIONS = [ExtensionType.MetadataPointer];
+    const mintLen = getMintLen(EXTENSIONS);
+
     let connection: Connection;
     let payer: Signer;
     let mint: Keypair;
@@ -38,8 +47,146 @@ describe('Token Metadata', () => {
     beforeEach(async () => {
         mint = Keypair.generate();
 
-        const EXTENSIONS = [ExtensionType.MetadataPointer];
-        const mintLen = getMintLen(EXTENSIONS);
+        const lamports = await connection.getMinimumBalanceForRentExemption(mintLen);
+
+        const transaction = new Transaction().add(
+            SystemProgram.createAccount({
+                fromPubkey: payer.publicKey,
+                newAccountPubkey: mint.publicKey,
+                space: mintLen,
+                lamports: lamports,
+                programId: TEST_PROGRAM_ID,
+            }),
+            createInitializeMetadataPointerInstruction(
+                mint.publicKey,
+                authority.publicKey,
+                mint.publicKey,
+                TEST_PROGRAM_ID
+            ),
+            createInitializeMintInstruction(
+                mint.publicKey,
+                TEST_TOKEN_DECIMALS,
+                authority.publicKey,
+                null,
+                TEST_PROGRAM_ID
+            )
+        );
+
+        await sendAndConfirmTransaction(connection, transaction, [payer, mint], undefined);
+    });
+
+    it('can successfully initialize', async () => {
+        // await expect(
+        //     tokenMetadataInitialize(
+        //         connection,
+        //         payer,
+        //         authority.publicKey,
+        //         mint.publicKey,
+        //         authority,
+        //         'name',
+        //         'symbol',
+        //         'uri',
+        //         [],
+        //         { skipPreflight: false },
+        //         TEST_PROGRAM_ID
+        //     )
+        // ).to.be.rejectedWith(/insufficient funds for rent/);
+
+        // Transfer the required amount for rent exemption
+        const lamports = await connection.getMinimumBalanceForRentExemption(mintLen + 2 + 2 + 93); // discriminator + length + data
+        const transaction = new Transaction().add(
+            SystemProgram.transfer({
+                fromPubkey: payer.publicKey,
+                toPubkey: mint.publicKey,
+                lamports,
+            })
+        );
+        await sendAndConfirmTransaction(connection, transaction, [payer], undefined);
+
+        await tokenMetadataInitialize(
+            connection,
+            payer,
+            authority.publicKey,
+            mint.publicKey,
+            authority,
+            'name',
+            'symbol',
+            'uri',
+            undefined,
+            undefined,
+            TEST_PROGRAM_ID
+        );
+
+        const meta = await getTokenMetadata(connection, mint.publicKey, undefined, TEST_PROGRAM_ID);
+        expect(meta).to.deep.equal({
+            updateAuthority: new PublicKey('ExgT3gCWXJzY4a9SHqTqsTk6dPAj37WNq2uWNbmMG1JR'),
+            mint: mint.publicKey,
+            name: 'name',
+            symbol: 'symbol',
+            uri: 'uri',
+            additionalMetadata: [],
+        });
+    });
+
+    it('can successfully initialize with rent transfer', async () => {
+        await tokenMetadataInitializeWithRentTransfer(
+            connection,
+            payer,
+            authority.publicKey,
+            mint.publicKey,
+            authority,
+            'name',
+            'symbol',
+            'uri',
+            undefined,
+            undefined,
+            TEST_PROGRAM_ID
+        );
+        const meta = await getTokenMetadata(connection, mint.publicKey, undefined, TEST_PROGRAM_ID);
+        expect(meta).to.deep.equal({
+            updateAuthority: new PublicKey('ExgT3gCWXJzY4a9SHqTqsTk6dPAj37WNq2uWNbmMG1JR'),
+            mint: mint.publicKey,
+            name: 'name',
+            symbol: 'symbol',
+            uri: 'uri',
+            additionalMetadata: [],
+        });
+    });
+
+    it('can handle get on un-initialize token metadata', async () => {
+        expect(await getTokenMetadata(connection, mint.publicKey, undefined, TEST_PROGRAM_ID)).to.deep.equal(null);
+
+        expect(
+            await getEmittedTokenMetadata(
+                connection,
+                '4rPdnCjZkwt4CR2mih8HiepAxTmh4UFpks9vUjNLFJbrLrX3aJWss29NBzCwgxZrxVB1chYLC2YxqPfT44aRFVaG' // Random Transaction
+            )
+        ).to.deep.equal(null);
+    });
+});
+
+describe.only('Token Metadata operations', () => {
+    const EXTENSIONS = [ExtensionType.MetadataPointer];
+    const mintLen = getMintLen(EXTENSIONS);
+
+    let connection: Connection;
+    let payer: Signer;
+    let mint: Keypair;
+    const authority = Keypair.fromSecretKey(
+        new Uint8Array([
+            118, 177, 37, 231, 15, 88, 210, 92, 79, 231, 202, 22, 11, 15, 121, 54, 95, 229, 149, 119, 48, 177, 187, 198,
+            223, 51, 225, 74, 12, 54, 172, 36, 207, 107, 122, 208, 209, 168, 61, 177, 190, 137, 23, 156, 84, 32, 34, 82,
+            158, 176, 55, 51, 236, 66, 130, 167, 118, 31, 120, 107, 100, 192, 147, 10,
+        ])
+    );
+
+    before(async () => {
+        connection = await getConnection();
+        payer = await newAccountWithLamports(connection, 1000000000);
+    });
+
+    beforeEach(async () => {
+        mint = Keypair.generate();
 
         const lamports = await connection.getMinimumBalanceForRentExemption(mintLen);
 
@@ -48,7 +195,7 @@ describe('Token Metadata', () => {
                 fromPubkey: payer.publicKey,
                 newAccountPubkey: mint.publicKey,
                 space: mintLen,
-                lamports: lamports * 10, //TODO:- Handle rent
+                lamports: lamports,
                 programId: TEST_PROGRAM_ID,
             }),
             createInitializeMetadataPointerInstruction(
@@ -68,7 +215,7 @@ describe('Token Metadata', () => {
 
         await sendAndConfirmTransaction(connection, transaction, [payer, mint], undefined);
 
-        await tokenMetadataInitialize(
+        await tokenMetadataInitializeWithRentTransfer(
             connection,
             payer,
             authority.publicKey,
@@ -110,7 +257,43 @@ describe('Token Metadata', () => {
         });
     });
 
-    it('can successfully update', async () => {
+    it('can successfully update when reducing', async () => {
+        await tokenMetadataUpdateField(
+            connection,
+            payer,
+            authority,
+            mint.publicKey,
+            'symbol',
+            'TEST',
+            undefined,
+            undefined,
+            TEST_PROGRAM_ID
+        );
+
+        const meta = await getTokenMetadata(connection, mint.publicKey, undefined, TEST_PROGRAM_ID);
+
+        expect(meta).to.deep.equal({
+            updateAuthority: new PublicKey('ExgT3gCWXJzY4a9SHqTqsTk6dPAj37WNq2uWNbmMG1JR'),
+            mint: mint.publicKey,
+            name: 'name',
+            symbol: 'TEST',
+            uri: 'uri',
+            additionalMetadata: [],
+        });
+    });
+
+    it('can successfully update with rent transfer', async () => {
+        // TODO Remove this and change to tokenMetadataUpdateFieldWithRentTransfer when working
+        const transaction = new Transaction().add(
+            SystemProgram.transfer({
+                fromPubkey: payer.publicKey,
+                toPubkey: mint.publicKey,
+                lamports: 1_000_000,
+            })
+        );
+
+        await sendAndConfirmTransaction(connection, transaction, [payer], undefined);
+
         await Promise.all([
             tokenMetadataUpdateField(
                 connection,
@@ -145,6 +328,117 @@ describe('Token Metadata', () => {
             symbol: 'symbol',
             uri: 'uri',
             additionalMetadata: [['TVL', '1,000,000']],
+        });
+    });
+
+    it('can handle removal of default key', async () => {
+        await expect(
+            tokenMetadataRemoveKey(
+                connection,
+                payer,
+                authority,
+                mint.publicKey,
+                'name',
+                false,
+                undefined,
+                undefined,
+                TEST_PROGRAM_ID
+            )
+        ).to.be.rejectedWith(/Transaction simulation failed/);
+    });
+
+    it('can handle removal of additional metadata ', async () => {
+        // TODO Remove this and change to tokenMetadataUpdateFieldWithRentTransfer when working
+        const transaction = new Transaction().add(
+            SystemProgram.transfer({
+                fromPubkey: payer.publicKey,
+                toPubkey: mint.publicKey,
+                lamports: 1_000_000,
+            })
+        );
+
+        await sendAndConfirmTransaction(connection, transaction, [payer], undefined);
+
+        await tokenMetadataUpdateField(
+            connection,
+            payer,
+            authority,
+            mint.publicKey,
+            'TVL',
+            '1,000,000',
+            undefined,
+            undefined,
+            TEST_PROGRAM_ID
+        );
+
+        await tokenMetadataRemoveKey(
+            connection,
+            payer,
+            authority,
+            mint.publicKey,
+            'TVL',
+            true,
+            undefined,
+            undefined,
+            TEST_PROGRAM_ID
+        );
+        const meta = await getTokenMetadata(connection, mint.publicKey, undefined, TEST_PROGRAM_ID);
+
+        expect(meta).to.deep.equal({
+            updateAuthority: new PublicKey('ExgT3gCWXJzY4a9SHqTqsTk6dPAj37WNq2uWNbmMG1JR'),
+            mint: mint.publicKey,
+            name: 'name',
+            symbol: 'symbol',
+            uri: 'uri',
+            additionalMetadata: [],
+        });
+    });
+
+    it('can successfully update authority', async () => {
+        const newAuthority = PublicKey.unique();
+        await tokenMetadataUpdateAuthority(
+            connection,
+            payer,
+            authority,
+            mint.publicKey,
+            newAuthority,
+            undefined,
+            undefined,
+            TEST_PROGRAM_ID
+        );
+
+        const meta = await getTokenMetadata(connection, mint.publicKey, undefined, TEST_PROGRAM_ID);
+
+        expect(meta).to.deep.equal({
+            updateAuthority: newAuthority,
+            mint: mint.publicKey,
+            name: 'name',
+            symbol: 'symbol',
+            uri: 'uri',
+            additionalMetadata: [],
+        });
+    });
+
+    it('can successfully remote update authority', async () => {
+        await tokenMetadataUpdateAuthority(
+            connection,
+            payer,
+            authority,
+            mint.publicKey,
+            null,
+            undefined,
+            undefined,
+            TEST_PROGRAM_ID
+        );
+
+        const meta = await getTokenMetadata(connection, mint.publicKey, undefined, TEST_PROGRAM_ID);
+
+        expect(meta).to.deep.equal({
+            mint: mint.publicKey,
+            name: 'name',
+            symbol: 'symbol',
+            uri: 'uri',
+            additionalMetadata: [],
         });
     });
 });

--- a/token/js/test/e2e-2022/tokenMetadata.test.ts
+++ b/token/js/test/e2e-2022/tokenMetadata.test.ts
@@ -282,32 +282,42 @@ describe('Token Metadata operations', () => {
     });
 
     it('can successfully update with rent transfer', async () => {
-        await Promise.all([
-            tokenMetadataUpdateFieldWithRentTransfer(
-                connection,
-                payer,
-                authority,
-                mint.publicKey,
-                'TVL',
-                '1,000,000',
-                undefined,
-                undefined,
-                TEST_PROGRAM_ID
-            ),
-            tokenMetadataUpdateFieldWithRentTransfer(
-                connection,
-                payer,
-                authority,
-                mint.publicKey,
-                'name',
-                'TEST',
-                undefined,
-                undefined,
-                TEST_PROGRAM_ID
-            ),
-        ]);
+        await tokenMetadataUpdateFieldWithRentTransfer(
+            connection,
+            payer,
+            authority,
+            mint.publicKey,
+            'TVL',
+            '1,000,000',
+            undefined,
+            undefined,
+            TEST_PROGRAM_ID
+        );
 
-        const meta = await getTokenMetadata(connection, mint.publicKey, undefined, TEST_PROGRAM_ID);
+        let meta = await getTokenMetadata(connection, mint.publicKey, undefined, TEST_PROGRAM_ID);
+
+        expect(meta).to.deep.equal({
+            updateAuthority: new PublicKey('ExgT3gCWXJzY4a9SHqTqsTk6dPAj37WNq2uWNbmMG1JR'),
+            mint: mint.publicKey,
+            name: 'name',
+            symbol: 'symbol',
+            uri: 'uri',
+            additionalMetadata: [['TVL', '1,000,000']],
+        });
+
+        await tokenMetadataUpdateFieldWithRentTransfer(
+            connection,
+            payer,
+            authority,
+            mint.publicKey,
+            'name',
+            'TEST',
+            undefined,
+            undefined,
+            TEST_PROGRAM_ID
+        );
+
+        meta = await getTokenMetadata(connection, mint.publicKey, undefined, TEST_PROGRAM_ID);
 
         expect(meta).to.deep.equal({
             updateAuthority: new PublicKey('ExgT3gCWXJzY4a9SHqTqsTk6dPAj37WNq2uWNbmMG1JR'),

--- a/token/js/test/e2e-2022/tokenMetadata.test.ts
+++ b/token/js/test/e2e-2022/tokenMetadata.test.ts
@@ -1,0 +1,150 @@
+import { expect } from 'chai';
+
+import type { Connection, Signer } from '@solana/web3.js';
+import { sendAndConfirmTransaction, PublicKey, Keypair, SystemProgram, Transaction } from '@solana/web3.js';
+
+import {
+    ExtensionType,
+    createInitializeMetadataPointerInstruction,
+    createInitializeMintInstruction,
+    tokenMetadataEmit,
+    tokenMetadataInitialize,
+    tokenMetadataUpdateField,
+    getMintLen,
+    getTokenMetadata,
+    getEmittedTokenMetadata,
+} from '../../src';
+import { TEST_PROGRAM_ID, newAccountWithLamports, getConnection } from '../common';
+
+const TEST_TOKEN_DECIMALS = 2;
+
+describe('Token Metadata', () => {
+    let connection: Connection;
+    let payer: Signer;
+    let mint: Keypair;
+    const authority = Keypair.fromSecretKey(
+        new Uint8Array([
+            118, 177, 37, 231, 15, 88, 210, 92, 79, 231, 202, 22, 11, 15, 121, 54, 95, 229, 149, 119, 48, 177, 187, 198,
+            223, 51, 225, 74, 12, 54, 172, 36, 207, 107, 122, 208, 209, 168, 61, 177, 190, 137, 23, 156, 84, 32, 34, 82,
+            158, 176, 55, 51, 236, 66, 130, 167, 118, 31, 120, 107, 100, 192, 147, 10,
+        ])
+    );
+
+    before(async () => {
+        connection = await getConnection();
+        payer = await newAccountWithLamports(connection, 1000000000);
+    });
+
+    beforeEach(async () => {
+        mint = Keypair.generate();
+
+        const EXTENSIONS = [ExtensionType.MetadataPointer];
+        const mintLen = getMintLen(EXTENSIONS);
+
+        const lamports = await connection.getMinimumBalanceForRentExemption(mintLen);
+
+        const transaction = new Transaction().add(
+            SystemProgram.createAccount({
+                fromPubkey: payer.publicKey,
+                newAccountPubkey: mint.publicKey,
+                space: mintLen,
+                lamports: lamports * 10, //TODO:- Handle rent
+                programId: TEST_PROGRAM_ID,
+            }),
+            createInitializeMetadataPointerInstruction(
+                mint.publicKey,
+                authority.publicKey,
+                mint.publicKey,
+                TEST_PROGRAM_ID
+            ),
+            createInitializeMintInstruction(
+                mint.publicKey,
+                TEST_TOKEN_DECIMALS,
+                authority.publicKey,
+                null,
+                TEST_PROGRAM_ID
+            )
+        );
+
+        await sendAndConfirmTransaction(connection, transaction, [payer, mint], undefined);
+
+        await tokenMetadataInitialize(
+            connection,
+            payer,
+            authority.publicKey,
+            mint.publicKey,
+            authority,
+            'name',
+            'symbol',
+            'uri',
+            undefined,
+            undefined,
+            TEST_PROGRAM_ID
+        );
+    });
+
+    it('can successfully initialize', async () => {
+        const meta = await getTokenMetadata(connection, mint.publicKey, undefined, TEST_PROGRAM_ID);
+        expect(meta).to.deep.equal({
+            updateAuthority: new PublicKey('ExgT3gCWXJzY4a9SHqTqsTk6dPAj37WNq2uWNbmMG1JR'),
+            mint: mint.publicKey,
+            name: 'name',
+            symbol: 'symbol',
+            uri: 'uri',
+            additionalMetadata: [],
+        });
+    });
+
+    it('can successfully emit', async () => {
+        const signature = await tokenMetadataEmit(connection, payer, mint.publicKey);
+
+        const meta = await getEmittedTokenMetadata(connection, signature);
+
+        expect(meta).to.deep.equal({
+            updateAuthority: new PublicKey('ExgT3gCWXJzY4a9SHqTqsTk6dPAj37WNq2uWNbmMG1JR'),
+            mint: mint.publicKey,
+            name: 'name',
+            symbol: 'symbol',
+            uri: 'uri',
+            additionalMetadata: [],
+        });
+    });
+
+    it('can successfully update', async () => {
+        await Promise.all([
+            tokenMetadataUpdateField(
+                connection,
+                payer,
+                authority,
+                mint.publicKey,
+                'TVL',
+                '1,000,000',
+                undefined,
+                undefined,
+                TEST_PROGRAM_ID
+            ),
+            tokenMetadataUpdateField(
+                connection,
+                payer,
+                authority,
+                mint.publicKey,
+                'name',
+                'TEST',
+                undefined,
+                undefined,
+                TEST_PROGRAM_ID
+            ),
+        ]);
+
+        const meta = await getTokenMetadata(connection, mint.publicKey, undefined, TEST_PROGRAM_ID);
+
+        expect(meta).to.deep.equal({
+            updateAuthority: new PublicKey('ExgT3gCWXJzY4a9SHqTqsTk6dPAj37WNq2uWNbmMG1JR'),
+            mint: mint.publicKey,
+            name: 'TEST',
+            symbol: 'symbol',
+            uri: 'uri',
+            additionalMetadata: [['TVL', '1,000,000']],
+        });
+    });
+});

--- a/token/js/test/unit/tokenMetadata.test.ts
+++ b/token/js/test/unit/tokenMetadata.test.ts
@@ -3,28 +3,9 @@ import { expect } from 'chai';
 
 import type { TokenMetadata } from '@solana/spl-token-metadata';
 import { Field } from '@solana/spl-token-metadata';
-import { getNormalizedTokenMetadataField, updateTokenMetadata } from '../../src';
+import { updateTokenMetadata } from '../../src';
 
 describe('SPL Token 2022 Metadata Extension', () => {
-    it('can get normalized token metadata field', async () => {
-        expect(getNormalizedTokenMetadataField('name')).to.equal('name');
-        expect(getNormalizedTokenMetadataField('Name')).to.equal('name');
-        expect(getNormalizedTokenMetadataField(Field.Name)).to.equal('name');
-
-        expect(getNormalizedTokenMetadataField('symbol')).to.equal('symbol');
-        expect(getNormalizedTokenMetadataField('Symbol')).to.equal('symbol');
-        expect(getNormalizedTokenMetadataField(Field.Symbol)).to.equal('symbol');
-
-        expect(getNormalizedTokenMetadataField('uri')).to.equal('uri');
-        expect(getNormalizedTokenMetadataField('Uri')).to.equal('uri');
-        expect(getNormalizedTokenMetadataField(Field.Uri)).to.equal('uri');
-
-        expect(getNormalizedTokenMetadataField('mint')).to.equal('mint');
-        expect(getNormalizedTokenMetadataField('updateAuthority')).to.equal('updateAuthority');
-        expect(getNormalizedTokenMetadataField('Key1')).to.equal('Key1');
-        expect(getNormalizedTokenMetadataField('KEY_1')).to.equal('KEY_1');
-    });
-
     describe('Update token metadata', () => {
         it('guards against updates on mint or updateAuthority', async () => {
             const input = Object.freeze({

--- a/token/js/test/unit/tokenMetadata.test.ts
+++ b/token/js/test/unit/tokenMetadata.test.ts
@@ -26,38 +26,25 @@ describe('SPL Token 2022 Metadata Extension', () => {
     });
 
     describe('Update token metadata', () => {
-        it('can guard against invalid values', () => {
+        it('guards against updates on mint or updateAuthority', async () => {
             const input = Object.freeze({
                 mint: PublicKey.default,
-                updateAuthority: PublicKey.unique(),
                 name: 'new_name',
                 symbol: 'new_symbol',
                 uri: 'new_uri',
-                additionalMetadata: [],
+                additionalMetadata: [
+                    ['key1', 'value1'],
+                    ['key2', 'value2'],
+                ],
             } as TokenMetadata);
 
-            expect(() => updateTokenMetadata(input, 'mint', null)).to.throw(
-                'TokenMetadata field mint must be a PublicKey'
+            expect(() => updateTokenMetadata(input, 'mint', 'string')).to.throw(
+                'Cannot update mint via this instruction'
             );
-            expect(() => updateTokenMetadata(input, 'mint', 'asd')).to.throw(
-                'TokenMetadata field mint must be a PublicKey'
-            );
-
             expect(() => updateTokenMetadata(input, 'updateAuthority', 'string')).to.throw(
-                'TokenMetadata field updateAuthority must be a PublicKey or null'
-            );
-
-            expect(() => updateTokenMetadata(input, 'name', null)).to.throw('TokenMetadata value must be a string');
-            expect(() => updateTokenMetadata(input, 'name', PublicKey.unique())).to.throw(
-                'TokenMetadata value must be a string'
-            );
-
-            expect(() => updateTokenMetadata(input, 'key1', null)).to.throw('TokenMetadata value must be a string');
-            expect(() => updateTokenMetadata(input, 'key1', PublicKey.unique())).to.throw(
-                'TokenMetadata value must be a string'
+                'Cannot update updateAuthority via this instruction'
             );
         });
-
         it('can update name', async () => {
             const input = Object.freeze({
                 mint: PublicKey.default,
@@ -140,61 +127,6 @@ describe('SPL Token 2022 Metadata Extension', () => {
             expect(updateTokenMetadata(input, 'uri', 'updated_uri')).to.deep.equal(expected);
             expect(updateTokenMetadata(input, 'Uri', 'updated_uri')).to.deep.equal(expected);
             expect(updateTokenMetadata(input, Field.Uri, 'updated_uri')).to.deep.equal(expected);
-        });
-
-        it('can update mint', async () => {
-            const input = Object.freeze({
-                mint: PublicKey.default,
-                name: 'new_name',
-                symbol: 'new_symbol',
-                uri: 'new_uri',
-                additionalMetadata: [
-                    ['key1', 'value1'],
-                    ['key2', 'value2'],
-                ],
-            } as TokenMetadata);
-
-            const newMint = PublicKey.unique();
-
-            const expected: TokenMetadata = {
-                mint: newMint,
-                name: 'new_name',
-                symbol: 'new_symbol',
-                uri: 'new_uri',
-                additionalMetadata: [
-                    ['key1', 'value1'],
-                    ['key2', 'value2'],
-                ],
-            };
-
-            expect(updateTokenMetadata(input, 'mint', newMint)).to.deep.equal(expected);
-        });
-
-        it('can remove updateAuthority', async () => {
-            const input = Object.freeze({
-                mint: PublicKey.default,
-                name: 'new_name',
-                symbol: 'new_symbol',
-                updateAuthority: PublicKey.unique(),
-                uri: 'new_uri',
-                additionalMetadata: [
-                    ['key1', 'value1'],
-                    ['key2', 'value2'],
-                ],
-            } as TokenMetadata);
-
-            const expected: TokenMetadata = {
-                mint: PublicKey.default,
-                name: 'new_name',
-                symbol: 'new_symbol',
-                uri: 'new_uri',
-                additionalMetadata: [
-                    ['key1', 'value1'],
-                    ['key2', 'value2'],
-                ],
-            };
-
-            expect(updateTokenMetadata(input, 'updateAuthority', null)).to.deep.equal(expected);
         });
 
         it('can update additional Metadata', async () => {

--- a/token/js/test/unit/tokenMetadata.test.ts
+++ b/token/js/test/unit/tokenMetadata.test.ts
@@ -1,0 +1,308 @@
+import { PublicKey } from '@solana/web3.js';
+import { expect } from 'chai';
+
+import type { TokenMetadata } from '@solana/spl-token-metadata';
+import { Field } from '@solana/spl-token-metadata';
+import { getNormalizedTokenMetadataField, updateTokenMetadata } from '../../src';
+
+describe('SPL Token 2022 Metadata Extension', () => {
+    it('can get normalized token metadata field', async () => {
+        expect(getNormalizedTokenMetadataField('name')).to.equal('name');
+        expect(getNormalizedTokenMetadataField('Name')).to.equal('name');
+        expect(getNormalizedTokenMetadataField(Field.Name)).to.equal('name');
+
+        expect(getNormalizedTokenMetadataField('symbol')).to.equal('symbol');
+        expect(getNormalizedTokenMetadataField('Symbol')).to.equal('symbol');
+        expect(getNormalizedTokenMetadataField(Field.Symbol)).to.equal('symbol');
+
+        expect(getNormalizedTokenMetadataField('uri')).to.equal('uri');
+        expect(getNormalizedTokenMetadataField('Uri')).to.equal('uri');
+        expect(getNormalizedTokenMetadataField(Field.Uri)).to.equal('uri');
+
+        expect(getNormalizedTokenMetadataField('mint')).to.equal('mint');
+        expect(getNormalizedTokenMetadataField('updateAuthority')).to.equal('updateAuthority');
+        expect(getNormalizedTokenMetadataField('Key1')).to.equal('Key1');
+        expect(getNormalizedTokenMetadataField('KEY_1')).to.equal('KEY_1');
+    });
+
+    describe('Update token metadata', () => {
+        it('can guard against invalid values', () => {
+            const input = Object.freeze({
+                mint: PublicKey.default,
+                updateAuthority: PublicKey.unique(),
+                name: 'new_name',
+                symbol: 'new_symbol',
+                uri: 'new_uri',
+                additionalMetadata: [],
+            } as TokenMetadata);
+
+            expect(() => updateTokenMetadata(input, 'mint', null)).to.throw(
+                'TokenMetadata field mint must be a PublicKey'
+            );
+            expect(() => updateTokenMetadata(input, 'mint', 'asd')).to.throw(
+                'TokenMetadata field mint must be a PublicKey'
+            );
+
+            expect(() => updateTokenMetadata(input, 'updateAuthority', 'string')).to.throw(
+                'TokenMetadata field updateAuthority must be a PublicKey or null'
+            );
+
+            expect(() => updateTokenMetadata(input, 'name', null)).to.throw('TokenMetadata value must be a string');
+            expect(() => updateTokenMetadata(input, 'name', PublicKey.unique())).to.throw(
+                'TokenMetadata value must be a string'
+            );
+
+            expect(() => updateTokenMetadata(input, 'key1', null)).to.throw('TokenMetadata value must be a string');
+            expect(() => updateTokenMetadata(input, 'key1', PublicKey.unique())).to.throw(
+                'TokenMetadata value must be a string'
+            );
+        });
+
+        it('can update name', async () => {
+            const input = Object.freeze({
+                mint: PublicKey.default,
+                name: 'new_name',
+                symbol: 'new_symbol',
+                uri: 'new_uri',
+                additionalMetadata: [
+                    ['key1', 'value1'],
+                    ['key2', 'value2'],
+                ],
+            } as TokenMetadata);
+
+            const expected: TokenMetadata = {
+                mint: PublicKey.default,
+                name: 'updated_name',
+                symbol: 'new_symbol',
+                uri: 'new_uri',
+                additionalMetadata: [
+                    ['key1', 'value1'],
+                    ['key2', 'value2'],
+                ],
+            };
+
+            expect(updateTokenMetadata(input, 'name', 'updated_name')).to.deep.equal(expected);
+            expect(updateTokenMetadata(input, 'Name', 'updated_name')).to.deep.equal(expected);
+            expect(updateTokenMetadata(input, Field.Name, 'updated_name')).to.deep.equal(expected);
+        });
+
+        it('can update symbol', async () => {
+            const input = Object.freeze({
+                mint: PublicKey.default,
+                name: 'new_name',
+                symbol: 'new_symbol',
+                uri: 'new_uri',
+                additionalMetadata: [
+                    ['key1', 'value1'],
+                    ['key2', 'value2'],
+                ],
+            } as TokenMetadata);
+
+            const expected: TokenMetadata = {
+                mint: PublicKey.default,
+                name: 'new_name',
+                symbol: 'updated_symbol',
+                uri: 'new_uri',
+                additionalMetadata: [
+                    ['key1', 'value1'],
+                    ['key2', 'value2'],
+                ],
+            };
+
+            expect(updateTokenMetadata(input, 'symbol', 'updated_symbol')).to.deep.equal(expected);
+            expect(updateTokenMetadata(input, 'Symbol', 'updated_symbol')).to.deep.equal(expected);
+            expect(updateTokenMetadata(input, Field.Symbol, 'updated_symbol')).to.deep.equal(expected);
+        });
+
+        it('can update uri', async () => {
+            const input = Object.freeze({
+                mint: PublicKey.default,
+                name: 'new_name',
+                symbol: 'new_symbol',
+                uri: 'new_uri',
+                additionalMetadata: [
+                    ['key1', 'value1'],
+                    ['key2', 'value2'],
+                ],
+            } as TokenMetadata);
+
+            const expected: TokenMetadata = {
+                mint: PublicKey.default,
+                name: 'new_name',
+                symbol: 'new_symbol',
+                uri: 'updated_uri',
+                additionalMetadata: [
+                    ['key1', 'value1'],
+                    ['key2', 'value2'],
+                ],
+            };
+
+            expect(updateTokenMetadata(input, 'uri', 'updated_uri')).to.deep.equal(expected);
+            expect(updateTokenMetadata(input, 'Uri', 'updated_uri')).to.deep.equal(expected);
+            expect(updateTokenMetadata(input, Field.Uri, 'updated_uri')).to.deep.equal(expected);
+        });
+
+        it('can update mint', async () => {
+            const input = Object.freeze({
+                mint: PublicKey.default,
+                name: 'new_name',
+                symbol: 'new_symbol',
+                uri: 'new_uri',
+                additionalMetadata: [
+                    ['key1', 'value1'],
+                    ['key2', 'value2'],
+                ],
+            } as TokenMetadata);
+
+            const newMint = PublicKey.unique();
+
+            const expected: TokenMetadata = {
+                mint: newMint,
+                name: 'new_name',
+                symbol: 'new_symbol',
+                uri: 'new_uri',
+                additionalMetadata: [
+                    ['key1', 'value1'],
+                    ['key2', 'value2'],
+                ],
+            };
+
+            expect(updateTokenMetadata(input, 'mint', newMint)).to.deep.equal(expected);
+        });
+
+        it('can remove updateAuthority', async () => {
+            const input = Object.freeze({
+                mint: PublicKey.default,
+                name: 'new_name',
+                symbol: 'new_symbol',
+                updateAuthority: PublicKey.unique(),
+                uri: 'new_uri',
+                additionalMetadata: [
+                    ['key1', 'value1'],
+                    ['key2', 'value2'],
+                ],
+            } as TokenMetadata);
+
+            const expected: TokenMetadata = {
+                mint: PublicKey.default,
+                name: 'new_name',
+                symbol: 'new_symbol',
+                uri: 'new_uri',
+                additionalMetadata: [
+                    ['key1', 'value1'],
+                    ['key2', 'value2'],
+                ],
+            };
+
+            expect(updateTokenMetadata(input, 'updateAuthority', null)).to.deep.equal(expected);
+        });
+
+        it('can update additional Metadata', async () => {
+            const input = Object.freeze({
+                mint: PublicKey.default,
+                name: 'new_name',
+                symbol: 'new_symbol',
+                uri: 'new_uri',
+                additionalMetadata: [
+                    ['key1', 'value1'],
+                    ['key2', 'value2'],
+                ],
+            } as TokenMetadata);
+
+            const expected: TokenMetadata = {
+                mint: PublicKey.default,
+                name: 'new_name',
+                symbol: 'new_symbol',
+                uri: 'new_uri',
+                additionalMetadata: [
+                    ['key1', 'update1'],
+                    ['key2', 'value2'],
+                ],
+            };
+
+            expect(updateTokenMetadata(input, 'key1', 'update1')).to.deep.equal(expected);
+        });
+
+        it('can add additional Metadata', async () => {
+            const input = Object.freeze({
+                mint: PublicKey.default,
+                name: 'new_name',
+                symbol: 'new_symbol',
+                uri: 'new_uri',
+                additionalMetadata: [
+                    ['key1', 'value1'],
+                    ['key2', 'value2'],
+                ],
+            } as TokenMetadata);
+
+            const expected: TokenMetadata = {
+                mint: PublicKey.default,
+                name: 'new_name',
+                symbol: 'new_symbol',
+                uri: 'new_uri',
+                additionalMetadata: [
+                    ['key1', 'value1'],
+                    ['key2', 'value2'],
+                    ['key3', 'value3'],
+                ],
+            };
+
+            expect(updateTokenMetadata(input, 'key3', 'value3')).to.deep.equal(expected);
+        });
+
+        it('can update `additionalMetadata` key to additional metadata', async () => {
+            const input = Object.freeze({
+                mint: PublicKey.default,
+                name: 'new_name',
+                symbol: 'new_symbol',
+                uri: 'new_uri',
+                additionalMetadata: [
+                    ['key1', 'value1'],
+                    ['key2', 'value2'],
+                    ['additionalMetadata', 'value3'],
+                ],
+            } as TokenMetadata);
+
+            const expected: TokenMetadata = {
+                mint: PublicKey.default,
+                name: 'new_name',
+                symbol: 'new_symbol',
+                uri: 'new_uri',
+                additionalMetadata: [
+                    ['key1', 'value1'],
+                    ['key2', 'value2'],
+                    ['additionalMetadata', 'update3'],
+                ],
+            };
+
+            expect(updateTokenMetadata(input, 'additionalMetadata', 'update3')).to.deep.equal(expected);
+        });
+
+        it('can add `additionalMetadata` key to additional metadata', async () => {
+            const input = Object.freeze({
+                mint: PublicKey.default,
+                name: 'new_name',
+                symbol: 'new_symbol',
+                uri: 'new_uri',
+                additionalMetadata: [
+                    ['key1', 'value1'],
+                    ['key2', 'value2'],
+                ],
+            } as TokenMetadata);
+
+            const expected: TokenMetadata = {
+                mint: PublicKey.default,
+                name: 'new_name',
+                symbol: 'new_symbol',
+                uri: 'new_uri',
+                additionalMetadata: [
+                    ['key1', 'value1'],
+                    ['key2', 'value2'],
+                    ['additionalMetadata', 'value3'],
+                ],
+            };
+
+            expect(updateTokenMetadata(input, 'additionalMetadata', 'value3')).to.deep.equal(expected);
+        });
+    });
+});


### PR DESCRIPTION
Addresses #5229 

> With the addition of token metadata to Token2022 and the SPL Token Metadata interface itself to the SPL library, we need to support this cool feature & interface in JavaScript!
> 
> The goal here is to lay down a JavaScript library for SPL Token Metadata and then import it into @solana/spl-token for Token2022 metadata support.
> 
> This issue is importing and implementing @solana/spl-token-metadata.
