### PR TITLE
token-cli: Cleanup `conflicts_with` and output colons

### DIFF
--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -5306,7 +5306,6 @@ fn app<'a, 'b>(
                         .validator(is_valid_pubkey)
                         .value_name("TOKEN_ACCOUNT_ADDRESS")
                         .takes_value(true)
-                        .conflicts_with("token")
                         .help("The address of the token account to configure confidential transfers for \
                             [default: owner's associated token account]")
                 )
@@ -5374,7 +5373,6 @@ fn app<'a, 'b>(
                         .validator(is_valid_pubkey)
                         .value_name("TOKEN_ACCOUNT_ADDRESS")
                         .takes_value(true)
-                        .conflicts_with("token")
                         .help("The address of the token account to configure confidential transfers for \
                             [default: owner's associated token account]")
                 )

--- a/token/cli/src/output.rs
+++ b/token/cli/src/output.rs
@@ -759,7 +759,7 @@ fn display_ui_extension(
             writeln!(
                 f,
                 "    {}: {}",
-                style("Authority:").bold(),
+                style("Authority").bold(),
                 if let Some(authority) = authority.as_ref() {
                     authority
                 } else {
@@ -779,7 +779,7 @@ fn display_ui_extension(
             writeln!(
                 f,
                 "    {}: {}",
-                style("Audit key:").bold(),
+                style("Audit key").bold(),
                 if let Some(auditor_pubkey) = auditor_elgamal_pubkey.as_ref() {
                     auditor_pubkey
                 } else {


### PR DESCRIPTION
#### Problem

The `conflicts_with` on confidential token `deposit` and `withdraw` makes it unusable with `--address`.

Also, colons `:` appear twice while displaying confidential transfer mint info.

#### Solution

In separate commits:

* remove `conflicts_with("address")` for deposit and withdraw
* remove the extra colon