### PR TITLE
token-cli{,ent}: Bump version for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7285,7 +7285,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-cli"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "assert_cmd",
  "base64 0.21.5",
@@ -7320,7 +7320,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-client"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "curve25519-dalek",

--- a/single-pool/cli/Cargo.toml
+++ b/single-pool/cli/Cargo.toml
@@ -28,7 +28,7 @@ solana-sdk = "=1.17.2"
 solana-transaction-status = "=1.17.2"
 solana-vote-program = "=1.17.2"
 spl-token = { version = "4.0", path="../../token/program", features = [ "no-entrypoint" ] }
-spl-token-client = { version = "0.7", path="../../token/client" }
+spl-token-client = { version = "0.8", path="../../token/client" }
 spl-associated-token-account = { version = "2.0", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
 spl-single-pool = { version = "1.0.0", path="../program", features = [ "no-entrypoint" ] }
 

--- a/token-collection/program/Cargo.toml
+++ b/token-collection/program/Cargo.toml
@@ -25,7 +25,7 @@ spl-type-length-value = { version = "0.3.0", path = "../../libraries/type-length
 solana-program-test = "1.17.2"
 solana-sdk = "1.17.2"
 spl-discriminator = { version = "0.1.0", path = "../../libraries/discriminator" }
-spl-token-client = { version = "0.7", path = "../../token/client" }
+spl-token-client = { version = "0.8", path = "../../token/client" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/token-group/example/Cargo.toml
+++ b/token-group/example/Cargo.toml
@@ -22,7 +22,7 @@ spl-type-length-value = { version = "0.3.0", path = "../../libraries/type-length
 solana-program-test = "1.17.2"
 solana-sdk = "1.17.2"
 spl-discriminator = { version = "0.1.0", path = "../../libraries/discriminator" }
-spl-token-client = { version = "0.7", path = "../../token/client" }
+spl-token-client = { version = "0.8", path = "../../token/client" }
 spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }
 
 [lib]

--- a/token-metadata/example/Cargo.toml
+++ b/token-metadata/example/Cargo.toml
@@ -21,7 +21,7 @@ spl-pod = { version = "0.1.0", path = "../../libraries/pod" }
 [dev-dependencies]
 solana-program-test = "1.17.2"
 solana-sdk = "1.17.2"
-spl-token-client = { version = "0.7", path = "../../token/client" }
+spl-token-client = { version = "0.8", path = "../../token/client" }
 test-case = "3.2"
 
 [lib]

--- a/token-upgrade/cli/Cargo.toml
+++ b/token-upgrade/cli/Cargo.toml
@@ -22,7 +22,7 @@ solana-sdk = "1.17.2"
 spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "0.9", path = "../../token/program-2022", features = ["no-entrypoint"] }
-spl-token-client = { version = "0.7", path = "../../token/client" }
+spl-token-client = { version = "0.8", path = "../../token/client" }
 spl-token-upgrade = { version = "0.1", path = "../program", features = ["no-entrypoint"] }
 tokio = { version = "1", features = ["full"] }
 

--- a/token-upgrade/program/Cargo.toml
+++ b/token-upgrade/program/Cargo.toml
@@ -23,7 +23,7 @@ thiserror = "1.0"
 solana-program-test = "1.17.2"
 solana-sdk = "1.17.2"
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-client = { version = "0.7", path = "../../token/client" }
+spl-token-client = { version = "0.8", path = "../../token/client" }
 test-case = "3.2"
 
 [lib]

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://spl.solana.com/token"
 license = "Apache-2.0"
 name = "spl-token-cli"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "3.2.0"
+version = "3.3.0"
 
 [build-dependencies]
 walkdir = "2"
@@ -33,7 +33,7 @@ spl-token = { version = "4.0", path = "../program", features = [
 spl-token-2022 = { version = "0.9", path = "../program-2022", features = [
   "no-entrypoint",
 ] }
-spl-token-client = { version = "0.7", path = "../client" }
+spl-token-client = { version = "0.8", path = "../client" }
 spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }
 spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = [
   "no-entrypoint",

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "spl-token-client"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "0.7.1"
+version = "0.8.0"
 
 [dependencies]
 async-trait = "0.1"

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -28,7 +28,7 @@ spl-memo = { version = "4.0.0", path = "../../memo/program", features = ["no-ent
 spl-pod = { version = "0.1.0", path = "../../libraries/pod" }
 spl-token-2022 = { version = "0.9", path="../program-2022", features = ["no-entrypoint"] }
 spl-instruction-padding = { version = "0.1.0", path="../../instruction-padding/program", features = ["no-entrypoint"] }
-spl-token-client = { version = "0.7", path = "../client" }
+spl-token-client = { version = "0.8", path = "../client" }
 spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }
 spl-transfer-hook-example = { version = "0.3", path="../transfer-hook/example", features = ["no-entrypoint"] }
 spl-transfer-hook-interface = { version = "0.3", path="../transfer-hook/interface" }

--- a/token/transfer-hook/cli/Cargo.toml
+++ b/token/transfer-hook/cli/Cargo.toml
@@ -26,7 +26,7 @@ tokio = { version = "1", features = ["full"] }
 [dev-dependencies]
 solana-test-validator = "=1.17.2"
 spl-token-2022 = { version = "0.9", path = "../../program-2022", features = ["no-entrypoint"] }
-spl-token-client = { version = "0.7", path = "../../client" }
+spl-token-client = { version = "0.8", path = "../../client" }
 
 [[bin]]
 name = "spl-transfer-hook"


### PR DESCRIPTION
#### Problem

The token-cli supports confidential operations, but it hasn't been released yet!

#### Solution

Bump it (and spl-token-client` to new minor versions for the next release.

Note: this should land after #5688