### PR TITLE
rustfmt: use entrypoint full path

### DIFF
--- a/account-compression/programs/noop/src/lib.rs
+++ b/account-compression/programs/noop/src/lib.rs
@@ -6,10 +6,7 @@ use solana_program::{
 declare_id!("noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV");
 
 #[cfg(not(feature = "no-entrypoint"))]
-use solana_program::entrypoint;
-
-#[cfg(not(feature = "no-entrypoint"))]
-entrypoint!(noop);
+solana_program::entrypoint!(noop);
 
 pub fn noop(
     _program_id: &Pubkey,

--- a/associated-token-account/program/src/entrypoint.rs
+++ b/associated-token-account/program/src/entrypoint.rs
@@ -2,11 +2,9 @@
 
 #![cfg(not(feature = "no-entrypoint"))]
 
-use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
-};
+use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/binary-option/program/src/entrypoint.rs
+++ b/binary-option/program/src/entrypoint.rs
@@ -1,12 +1,10 @@
 #![cfg(all(target_os = "solana", not(feature = "no-entrypoint")))]
 
-use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
-};
+use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
 
 use crate::processor::Processor;
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/binary-oracle-pair/program/src/entrypoint.rs
+++ b/binary-oracle-pair/program/src/entrypoint.rs
@@ -4,11 +4,11 @@
 
 use crate::{error::PoolError, processor};
 use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,
-    program_error::PrintProgramError, pubkey::Pubkey,
+    account_info::AccountInfo, entrypoint::ProgramResult, program_error::PrintProgramError,
+    pubkey::Pubkey,
 };
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/examples/rust/cross-program-invocation/src/entrypoint.rs
+++ b/examples/rust/cross-program-invocation/src/entrypoint.rs
@@ -2,11 +2,9 @@
 
 #![cfg(not(feature = "no-entrypoint"))]
 
-use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
-};
+use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/examples/rust/custom-heap/src/entrypoint.rs
+++ b/examples/rust/custom-heap/src/entrypoint.rs
@@ -4,7 +4,6 @@
 
 use solana_program::{
     account_info::AccountInfo,
-    entrypoint,
     entrypoint::{ProgramResult, HEAP_LENGTH, HEAP_START_ADDRESS},
     pubkey::Pubkey,
 };
@@ -44,7 +43,7 @@ unsafe impl std::alloc::GlobalAlloc for BumpAllocator {
 #[global_allocator]
 static A: BumpAllocator = BumpAllocator;
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/examples/rust/logging/src/entrypoint.rs
+++ b/examples/rust/logging/src/entrypoint.rs
@@ -2,11 +2,9 @@
 
 #![cfg(not(feature = "no-entrypoint"))]
 
-use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
-};
+use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/examples/rust/sysvar/src/entrypoint.rs
+++ b/examples/rust/sysvar/src/entrypoint.rs
@@ -2,11 +2,9 @@
 
 #![cfg(not(feature = "no-entrypoint"))]
 
-use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
-};
+use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/examples/rust/transfer-lamports/src/entrypoint.rs
+++ b/examples/rust/transfer-lamports/src/entrypoint.rs
@@ -2,11 +2,9 @@
 
 #![cfg(not(feature = "no-entrypoint"))]
 
-use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
-};
+use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/examples/rust/transfer-tokens/src/entrypoint.rs
+++ b/examples/rust/transfer-tokens/src/entrypoint.rs
@@ -2,11 +2,9 @@
 
 #![cfg(not(feature = "no-entrypoint"))]
 
-use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
-};
+use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/feature-gate/program/src/entrypoint.rs
+++ b/feature-gate/program/src/entrypoint.rs
@@ -2,12 +2,10 @@
 
 use {
     crate::processor,
-    solana_program::{
-        account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
-    },
+    solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey},
 };
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/feature-proposal/program/src/entrypoint.rs
+++ b/feature-proposal/program/src/entrypoint.rs
@@ -2,11 +2,9 @@
 
 #![cfg(all(target_os = "solana", not(feature = "no-entrypoint")))]
 
-use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
-};
+use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/governance/addin-mock/program/src/entrypoint.rs
+++ b/governance/addin-mock/program/src/entrypoint.rs
@@ -3,11 +3,11 @@
 
 use crate::{error::VoterWeightAddinError, processor};
 use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,
-    program_error::PrintProgramError, pubkey::Pubkey,
+    account_info::AccountInfo, entrypoint::ProgramResult, program_error::PrintProgramError,
+    pubkey::Pubkey,
 };
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/governance/chat/program/src/entrypoint.rs
+++ b/governance/chat/program/src/entrypoint.rs
@@ -3,11 +3,11 @@
 
 use crate::{error::GovernanceChatError, processor};
 use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,
-    program_error::PrintProgramError, pubkey::Pubkey,
+    account_info::AccountInfo, entrypoint::ProgramResult, program_error::PrintProgramError,
+    pubkey::Pubkey,
 };
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/governance/program/src/entrypoint.rs
+++ b/governance/program/src/entrypoint.rs
@@ -3,11 +3,11 @@
 
 use crate::{error::GovernanceError, processor};
 use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,
-    program_error::PrintProgramError, pubkey::Pubkey,
+    account_info::AccountInfo, entrypoint::ProgramResult, program_error::PrintProgramError,
+    pubkey::Pubkey,
 };
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/instruction-padding/program/src/entrypoint.rs
+++ b/instruction-padding/program/src/entrypoint.rs
@@ -2,11 +2,9 @@
 
 #![cfg(not(feature = "no-entrypoint"))]
 
-use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
-};
+use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/libraries/math/src/entrypoint.rs
+++ b/libraries/math/src/entrypoint.rs
@@ -2,11 +2,9 @@
 
 #![cfg(not(feature = "no-entrypoint"))]
 
-use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
-};
+use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/memo/program/src/entrypoint.rs
+++ b/memo/program/src/entrypoint.rs
@@ -2,11 +2,9 @@
 
 #![cfg(not(feature = "no-entrypoint"))]
 
-use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
-};
+use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/name-service/program/src/entrypoint.rs
+++ b/name-service/program/src/entrypoint.rs
@@ -3,12 +3,12 @@ use {
     crate::processor::Processor,
     num_traits::FromPrimitive,
     solana_program::{
-        account_info::AccountInfo, decode_error::DecodeError, entrypoint,
-        entrypoint::ProgramResult, msg, program_error::PrintProgramError, pubkey::Pubkey,
+        account_info::AccountInfo, decode_error::DecodeError, entrypoint::ProgramResult, msg,
+        program_error::PrintProgramError, pubkey::Pubkey,
     },
 };
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 
 pub fn process_instruction(
     program_id: &Pubkey,

--- a/record/program/src/entrypoint.rs
+++ b/record/program/src/entrypoint.rs
@@ -2,11 +2,9 @@
 
 #![cfg(all(target_os = "solana", not(feature = "no-entrypoint")))]
 
-use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
-};
+use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/single-pool/program/src/entrypoint.rs
+++ b/single-pool/program/src/entrypoint.rs
@@ -5,12 +5,12 @@
 use {
     crate::{error::SinglePoolError, processor::Processor},
     solana_program::{
-        account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,
-        program_error::PrintProgramError, pubkey::Pubkey,
+        account_info::AccountInfo, entrypoint::ProgramResult, program_error::PrintProgramError,
+        pubkey::Pubkey,
     },
 };
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/stake-pool/program/src/entrypoint.rs
+++ b/stake-pool/program/src/entrypoint.rs
@@ -5,12 +5,12 @@
 use {
     crate::{error::StakePoolError, processor::Processor},
     solana_program::{
-        account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,
-        program_error::PrintProgramError, pubkey::Pubkey,
+        account_info::AccountInfo, entrypoint::ProgramResult, program_error::PrintProgramError,
+        pubkey::Pubkey,
     },
 };
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/stateless-asks/program/src/entrypoint.rs
+++ b/stateless-asks/program/src/entrypoint.rs
@@ -1,12 +1,10 @@
 #![cfg(all(target_os = "solana", not(feature = "no-entrypoint")))]
 
-use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
-};
+use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
 
 use crate::processor::Processor;
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/token-collection/program/src/entrypoint.rs
+++ b/token-collection/program/src/entrypoint.rs
@@ -3,13 +3,13 @@
 use {
     crate::processor,
     solana_program::{
-        account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,
-        program_error::PrintProgramError, pubkey::Pubkey,
+        account_info::AccountInfo, entrypoint::ProgramResult, program_error::PrintProgramError,
+        pubkey::Pubkey,
     },
     spl_token_group_interface::error::TokenGroupError,
 };
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/token-group/example/src/entrypoint.rs
+++ b/token-group/example/src/entrypoint.rs
@@ -3,13 +3,13 @@
 use {
     crate::processor,
     solana_program::{
-        account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,
-        program_error::PrintProgramError, pubkey::Pubkey,
+        account_info::AccountInfo, entrypoint::ProgramResult, program_error::PrintProgramError,
+        pubkey::Pubkey,
     },
     spl_token_group_interface::error::TokenGroupError,
 };
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/token-lending/flash_loan_receiver/src/entrypoint.rs
+++ b/token-lending/flash_loan_receiver/src/entrypoint.rs
@@ -1,8 +1,6 @@
-use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
-};
+use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/token-lending/program/src/entrypoint.rs
+++ b/token-lending/program/src/entrypoint.rs
@@ -4,11 +4,11 @@
 
 use crate::{error::LendingError, processor};
 use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,
-    program_error::PrintProgramError, pubkey::Pubkey,
+    account_info::AccountInfo, entrypoint::ProgramResult, program_error::PrintProgramError,
+    pubkey::Pubkey,
 };
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/token-lending/program/tests/helpers/flash_loan_receiver.rs
+++ b/token-lending/program/tests/helpers/flash_loan_receiver.rs
@@ -1,6 +1,4 @@
-use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, msg, pubkey::Pubkey,
-};
+use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, msg, pubkey::Pubkey};
 
 use crate::helpers::flash_loan_receiver::FlashLoanReceiverError::InvalidInstruction;
 use spl_token::{
@@ -29,7 +27,7 @@ pub enum FlashLoanReceiverInstruction {
     },
 }
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 pub fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/token-metadata/example/src/entrypoint.rs
+++ b/token-metadata/example/src/entrypoint.rs
@@ -3,13 +3,13 @@
 use {
     crate::processor,
     solana_program::{
-        account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,
-        program_error::PrintProgramError, pubkey::Pubkey,
+        account_info::AccountInfo, entrypoint::ProgramResult, program_error::PrintProgramError,
+        pubkey::Pubkey,
     },
     spl_token_metadata_interface::error::TokenMetadataError,
 };
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/token-swap/program/src/entrypoint.rs
+++ b/token-swap/program/src/entrypoint.rs
@@ -2,11 +2,11 @@
 
 use crate::{error::SwapError, processor::Processor};
 use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,
-    program_error::PrintProgramError, pubkey::Pubkey,
+    account_info::AccountInfo, entrypoint::ProgramResult, program_error::PrintProgramError,
+    pubkey::Pubkey,
 };
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/token-upgrade/program/src/entrypoint.rs
+++ b/token-upgrade/program/src/entrypoint.rs
@@ -2,11 +2,9 @@
 
 #![cfg(not(feature = "no-entrypoint"))]
 
-use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
-};
+use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/token-wrap/program/src/entrypoint.rs
+++ b/token-wrap/program/src/entrypoint.rs
@@ -2,11 +2,9 @@
 
 #![cfg(all(target_os = "solana", not(feature = "no-entrypoint")))]
 
-use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
-};
+use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/token/program-2022/src/entrypoint.rs
+++ b/token/program-2022/src/entrypoint.rs
@@ -3,12 +3,12 @@
 use {
     crate::{error::TokenError, processor::Processor},
     solana_program::{
-        account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,
-        program_error::PrintProgramError, pubkey::Pubkey,
+        account_info::AccountInfo, entrypoint::ProgramResult, program_error::PrintProgramError,
+        pubkey::Pubkey,
     },
 };
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/token/program/src/entrypoint.rs
+++ b/token/program/src/entrypoint.rs
@@ -2,11 +2,11 @@
 
 use crate::{error::TokenError, processor::Processor};
 use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,
-    program_error::PrintProgramError, pubkey::Pubkey,
+    account_info::AccountInfo, entrypoint::ProgramResult, program_error::PrintProgramError,
+    pubkey::Pubkey,
 };
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/token/transfer-hook/example/src/entrypoint.rs
+++ b/token/transfer-hook/example/src/entrypoint.rs
@@ -3,13 +3,13 @@
 use {
     crate::processor,
     solana_program::{
-        account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,
-        program_error::PrintProgramError, pubkey::Pubkey,
+        account_info::AccountInfo, entrypoint::ProgramResult, program_error::PrintProgramError,
+        pubkey::Pubkey,
     },
     spl_transfer_hook_interface::error::TransferHookError,
 };
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],


### PR DESCRIPTION
This PR swaps any calls to the `entrypoint!` macro with the full path, ie: `solana_program::entrypoint!`.

This will play a role in the effort to introduce a linting standard to SPL.
