### PR TITLE
rustfmt: format imports

### DIFF
--- a/associated-token-account/program-test/tests/spl_token_create.rs
+++ b/associated-token-account/program-test/tests/spl_token_create.rs
@@ -3,6 +3,8 @@
 
 mod program_test;
 
+#[allow(deprecated)]
+use spl_associated_token_account::create_associated_token_account as deprecated_create_associated_token_account;
 use {
     program_test::program_test,
     solana_program::pubkey::Pubkey,
@@ -13,9 +15,6 @@ use {
     },
     spl_token::state::Account,
 };
-
-#[allow(deprecated)]
-use spl_associated_token_account::create_associated_token_account as deprecated_create_associated_token_account;
 
 #[tokio::test]
 async fn success_create() {

--- a/binary-option/program/src/entrypoint.rs
+++ b/binary-option/program/src/entrypoint.rs
@@ -1,8 +1,9 @@
 #![cfg(all(target_os = "solana", not(feature = "no-entrypoint")))]
 
-use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
-
-use crate::processor::Processor;
+use {
+    crate::processor::Processor,
+    solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey},
+};
 
 solana_program::entrypoint!(process_instruction);
 fn process_instruction(

--- a/binary-option/program/src/error.rs
+++ b/binary-option/program/src/error.rs
@@ -1,6 +1,4 @@
-use thiserror::Error;
-
-use solana_program::program_error::ProgramError;
+use {solana_program::program_error::ProgramError, thiserror::Error};
 
 #[derive(Error, Debug, Copy, Clone)]
 pub enum BinaryOptionError {

--- a/binary-option/program/src/instruction.rs
+++ b/binary-option/program/src/instruction.rs
@@ -1,10 +1,11 @@
-use solana_program::{
-    instruction::{AccountMeta, Instruction},
-    pubkey::Pubkey,
-    sysvar,
+use {
+    borsh::{BorshDeserialize, BorshSerialize},
+    solana_program::{
+        instruction::{AccountMeta, Instruction},
+        pubkey::Pubkey,
+        sysvar,
+    },
 };
-
-use borsh::{BorshDeserialize, BorshSerialize};
 
 #[repr(C)]
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug, Clone)]

--- a/binary-option/program/src/processor.rs
+++ b/binary-option/program/src/processor.rs
@@ -1,28 +1,30 @@
-use crate::{
-    error::BinaryOptionError,
-    instruction::BinaryOptionInstruction,
-    spl_utils::{
-        spl_approve, spl_burn, spl_burn_signed, spl_initialize, spl_mint_initialize, spl_mint_to,
-        spl_set_authority, spl_token_transfer, spl_token_transfer_signed,
+use {
+    crate::{
+        error::BinaryOptionError,
+        instruction::BinaryOptionInstruction,
+        spl_utils::{
+            spl_approve, spl_burn, spl_burn_signed, spl_initialize, spl_mint_initialize,
+            spl_mint_to, spl_set_authority, spl_token_transfer, spl_token_transfer_signed,
+        },
+        state::BinaryOption,
+        system_utils::{create_new_account, create_or_allocate_account_raw},
+        validation_utils::{
+            assert_initialized, assert_keys_equal, assert_keys_unequal, assert_owned_by,
+        },
     },
-    state::BinaryOption,
-    system_utils::{create_new_account, create_or_allocate_account_raw},
-    validation_utils::{
-        assert_initialized, assert_keys_equal, assert_keys_unequal, assert_owned_by,
+    borsh::BorshDeserialize,
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        msg,
+        program_error::ProgramError,
+        program_pack::Pack,
+        pubkey::Pubkey,
     },
-};
-use borsh::BorshDeserialize;
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    entrypoint::ProgramResult,
-    msg,
-    program_error::ProgramError,
-    program_pack::Pack,
-    pubkey::Pubkey,
-};
-use spl_token::{
-    instruction::AuthorityType,
-    state::{Account, Mint},
+    spl_token::{
+        instruction::AuthorityType,
+        state::{Account, Mint},
+    },
 };
 
 pub struct Processor;

--- a/binary-option/program/src/state.rs
+++ b/binary-option/program/src/state.rs
@@ -1,10 +1,11 @@
-use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, program_error::ProgramError,
-    pubkey::Pubkey,
+use {
+    crate::error::BinaryOptionError,
+    borsh::{BorshDeserialize, BorshSerialize},
+    solana_program::{
+        account_info::AccountInfo, entrypoint::ProgramResult, program_error::ProgramError,
+        pubkey::Pubkey,
+    },
 };
-
-use crate::error::BinaryOptionError;
-use borsh::{BorshDeserialize, BorshSerialize};
 
 #[repr(C)]
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone)]

--- a/binary-oracle-pair/program/src/entrypoint.rs
+++ b/binary-oracle-pair/program/src/entrypoint.rs
@@ -2,10 +2,12 @@
 
 #![cfg(all(target_os = "solana", not(feature = "no-entrypoint")))]
 
-use crate::{error::PoolError, processor};
-use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, program_error::PrintProgramError,
-    pubkey::Pubkey,
+use {
+    crate::{error::PoolError, processor},
+    solana_program::{
+        account_info::AccountInfo, entrypoint::ProgramResult, program_error::PrintProgramError,
+        pubkey::Pubkey,
+    },
 };
 
 solana_program::entrypoint!(process_instruction);

--- a/binary-oracle-pair/program/src/error.rs
+++ b/binary-oracle-pair/program/src/error.rs
@@ -1,11 +1,15 @@
 //! Error types
 
-use num_derive::FromPrimitive;
-use num_traits::FromPrimitive;
-use solana_program::{
-    decode_error::DecodeError, msg, program_error::PrintProgramError, program_error::ProgramError,
+use {
+    num_derive::FromPrimitive,
+    num_traits::FromPrimitive,
+    solana_program::{
+        decode_error::DecodeError,
+        msg,
+        program_error::{PrintProgramError, ProgramError},
+    },
+    thiserror::Error,
 };
-use thiserror::Error;
 
 /// Errors that may be returned by the Binary Oracle Pair program.
 #[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]

--- a/binary-oracle-pair/program/src/instruction.rs
+++ b/binary-oracle-pair/program/src/instruction.rs
@@ -1,12 +1,14 @@
 //! Instruction types
 
-use borsh::{BorshDeserialize, BorshSerialize};
-use solana_program::{
-    clock::Slot,
-    instruction::{AccountMeta, Instruction},
-    program_error::ProgramError,
-    pubkey::Pubkey,
-    sysvar,
+use {
+    borsh::{BorshDeserialize, BorshSerialize},
+    solana_program::{
+        clock::Slot,
+        instruction::{AccountMeta, Instruction},
+        program_error::ProgramError,
+        pubkey::Pubkey,
+        sysvar,
+    },
 };
 
 /// Initialize arguments for pool

--- a/binary-oracle-pair/program/src/processor.rs
+++ b/binary-oracle-pair/program/src/processor.rs
@@ -1,25 +1,26 @@
 //! Program state processor
 
-use crate::{
-    error::PoolError,
-    instruction::PoolInstruction,
-    state::{Decision, Pool, POOL_VERSION},
+use {
+    crate::{
+        error::PoolError,
+        instruction::PoolInstruction,
+        state::{Decision, Pool, POOL_VERSION},
+    },
+    borsh::BorshDeserialize,
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        clock::{Clock, Slot},
+        entrypoint::ProgramResult,
+        msg,
+        program::{invoke, invoke_signed},
+        program_error::ProgramError,
+        program_pack::{IsInitialized, Pack},
+        pubkey::Pubkey,
+        rent::Rent,
+        sysvar::Sysvar,
+    },
+    spl_token::state::{Account, Mint},
 };
-use borsh::BorshDeserialize;
-use solana_program::{
-    account_info::next_account_info,
-    account_info::AccountInfo,
-    clock::{Clock, Slot},
-    entrypoint::ProgramResult,
-    msg,
-    program::{invoke, invoke_signed},
-    program_error::ProgramError,
-    program_pack::{IsInitialized, Pack},
-    pubkey::Pubkey,
-    rent::Rent,
-    sysvar::Sysvar,
-};
-use spl_token::state::{Account, Mint};
 
 /// Program state handler.
 pub struct Processor {}

--- a/binary-oracle-pair/program/src/state.rs
+++ b/binary-oracle-pair/program/src/state.rs
@@ -1,7 +1,9 @@
 //! State transition types
 
-use borsh::{BorshDeserialize, BorshSerialize};
-use solana_program::pubkey::Pubkey;
+use {
+    borsh::{BorshDeserialize, BorshSerialize},
+    solana_program::pubkey::Pubkey,
+};
 
 /// Uninitialized version value, all instances are at least version 1
 pub const UNINITIALIZED_VERSION: u8 = 0;

--- a/binary-oracle-pair/program/tests/tests.rs
+++ b/binary-oracle-pair/program/tests/tests.rs
@@ -1,15 +1,17 @@
 #![cfg(feature = "test-sbf")]
 
-use borsh::de::BorshDeserialize;
-use solana_program::{hash::Hash, program_pack::Pack, pubkey::Pubkey, system_instruction};
-use solana_program_test::*;
-use solana_sdk::{
-    account::Account,
-    signature::{Keypair, Signer},
-    transaction::Transaction,
-    transport::TransportError,
+use {
+    borsh::de::BorshDeserialize,
+    solana_program::{hash::Hash, program_pack::Pack, pubkey::Pubkey, system_instruction},
+    solana_program_test::*,
+    solana_sdk::{
+        account::Account,
+        signature::{Keypair, Signer},
+        transaction::Transaction,
+        transport::TransportError,
+    },
+    spl_binary_oracle_pair::*,
 };
-use spl_binary_oracle_pair::*;
 
 pub fn program_test() -> ProgramTest {
     ProgramTest::new(

--- a/examples/rust/custom-heap/src/entrypoint.rs
+++ b/examples/rust/custom-heap/src/entrypoint.rs
@@ -2,12 +2,14 @@
 
 #![cfg(not(feature = "no-entrypoint"))]
 
-use solana_program::{
-    account_info::AccountInfo,
-    entrypoint::{ProgramResult, HEAP_LENGTH, HEAP_START_ADDRESS},
-    pubkey::Pubkey,
+use {
+    solana_program::{
+        account_info::AccountInfo,
+        entrypoint::{ProgramResult, HEAP_LENGTH, HEAP_START_ADDRESS},
+        pubkey::Pubkey,
+    },
+    std::{alloc::Layout, mem::size_of, ptr::null_mut, usize},
 };
-use std::{alloc::Layout, mem::size_of, ptr::null_mut, usize};
 
 /// Developers can implement their own heap by defining their own
 /// `#[global_allocator]`.  The following implements a dummy for test purposes

--- a/feature-proposal/program/src/instruction.rs
+++ b/feature-proposal/program/src/instruction.rs
@@ -1,14 +1,16 @@
 //! Program instructions
 
-use crate::{state::AcceptanceCriteria, *};
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-use solana_program::{
-    instruction::{AccountMeta, Instruction},
-    msg,
-    program_error::ProgramError,
-    program_pack::{Pack, Sealed},
-    pubkey::Pubkey,
-    sysvar,
+use {
+    crate::{state::AcceptanceCriteria, *},
+    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
+    solana_program::{
+        instruction::{AccountMeta, Instruction},
+        msg,
+        program_error::ProgramError,
+        program_pack::{Pack, Sealed},
+        pubkey::Pubkey,
+        sysvar,
+    },
 };
 
 /// Instructions supported by the Feature Proposal program

--- a/feature-proposal/program/src/processor.rs
+++ b/feature-proposal/program/src/processor.rs
@@ -1,18 +1,20 @@
 //! Program state processor
 
-use crate::{instruction::*, state::*, *};
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    clock::Clock,
-    entrypoint::ProgramResult,
-    feature::{self, Feature},
-    msg,
-    program::{invoke, invoke_signed},
-    program_error::ProgramError,
-    pubkey::Pubkey,
-    rent::Rent,
-    system_instruction,
-    sysvar::Sysvar,
+use {
+    crate::{instruction::*, state::*, *},
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        clock::Clock,
+        entrypoint::ProgramResult,
+        feature::{self, Feature},
+        msg,
+        program::{invoke, invoke_signed},
+        program_error::ProgramError,
+        pubkey::Pubkey,
+        rent::Rent,
+        system_instruction,
+        sysvar::Sysvar,
+    },
 };
 
 /// Instruction processor

--- a/feature-proposal/program/src/state.rs
+++ b/feature-proposal/program/src/state.rs
@@ -1,10 +1,12 @@
 //! Program state
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-use solana_program::{
-    clock::UnixTimestamp,
-    msg,
-    program_error::ProgramError,
-    program_pack::{Pack, Sealed},
+use {
+    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
+    solana_program::{
+        clock::UnixTimestamp,
+        msg,
+        program_error::ProgramError,
+        program_pack::{Pack, Sealed},
+    },
 };
 
 /// Criteria for accepting a feature proposal

--- a/governance/addin-api/src/max_voter_weight.rs
+++ b/governance/addin-api/src/max_voter_weight.rs
@@ -1,8 +1,10 @@
 //! MaxVoterWeight Addin interface
 
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-use solana_program::{clock::Slot, program_pack::IsInitialized, pubkey::Pubkey};
-use spl_governance_tools::account::AccountMaxSize;
+use {
+    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
+    solana_program::{clock::Slot, program_pack::IsInitialized, pubkey::Pubkey},
+    spl_governance_tools::account::AccountMaxSize,
+};
 
 /// MaxVoterWeightRecord account
 /// The account is used as an api interface to provide max voting power to the governance program from external addin contracts

--- a/governance/addin-api/src/voter_weight.rs
+++ b/governance/addin-api/src/voter_weight.rs
@@ -1,8 +1,10 @@
 //! VoterWeight Addin interface
 
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-use solana_program::{clock::Slot, program_pack::IsInitialized, pubkey::Pubkey};
-use spl_governance_tools::account::AccountMaxSize;
+use {
+    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
+    solana_program::{clock::Slot, program_pack::IsInitialized, pubkey::Pubkey},
+    spl_governance_tools::account::AccountMaxSize,
+};
 
 /// The governance action VoterWeight is evaluated for
 #[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]

--- a/governance/addin-mock/program/src/entrypoint.rs
+++ b/governance/addin-mock/program/src/entrypoint.rs
@@ -1,10 +1,12 @@
 //! Program entrypoint
 #![cfg(all(target_os = "solana", not(feature = "no-entrypoint")))]
 
-use crate::{error::VoterWeightAddinError, processor};
-use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, program_error::PrintProgramError,
-    pubkey::Pubkey,
+use {
+    crate::{error::VoterWeightAddinError, processor},
+    solana_program::{
+        account_info::AccountInfo, entrypoint::ProgramResult, program_error::PrintProgramError,
+        pubkey::Pubkey,
+    },
 };
 
 solana_program::entrypoint!(process_instruction);

--- a/governance/addin-mock/program/src/error.rs
+++ b/governance/addin-mock/program/src/error.rs
@@ -1,12 +1,14 @@
 //! Error types
 
-use num_derive::FromPrimitive;
-use solana_program::{
-    decode_error::DecodeError,
-    msg,
-    program_error::{PrintProgramError, ProgramError},
+use {
+    num_derive::FromPrimitive,
+    solana_program::{
+        decode_error::DecodeError,
+        msg,
+        program_error::{PrintProgramError, ProgramError},
+    },
+    thiserror::Error,
 };
-use thiserror::Error;
 
 /// Errors that may be returned by the VoterWeightAddin program
 #[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]

--- a/governance/addin-mock/program/src/instruction.rs
+++ b/governance/addin-mock/program/src/instruction.rs
@@ -1,13 +1,15 @@
 //! Program instructions
 
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-use solana_program::{
-    clock::Slot,
-    instruction::{AccountMeta, Instruction},
-    pubkey::Pubkey,
-    system_program,
+use {
+    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
+    solana_program::{
+        clock::Slot,
+        instruction::{AccountMeta, Instruction},
+        pubkey::Pubkey,
+        system_program,
+    },
+    spl_governance_addin_api::voter_weight::VoterWeightAction,
 };
-use spl_governance_addin_api::voter_weight::VoterWeightAction;
 
 /// Instructions supported by the VoterWeight addin program
 /// This program is a mock program used by spl-governance for testing and not real addin

--- a/governance/addin-mock/program/src/processor.rs
+++ b/governance/addin-mock/program/src/processor.rs
@@ -1,22 +1,22 @@
 //! Program processor
 
-use borsh::BorshDeserialize;
-
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    clock::Slot,
-    entrypoint::ProgramResult,
-    msg,
-    program_error::ProgramError,
-    pubkey::Pubkey,
+use {
+    crate::instruction::VoterWeightAddinInstruction,
+    borsh::BorshDeserialize,
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        clock::Slot,
+        entrypoint::ProgramResult,
+        msg,
+        program_error::ProgramError,
+        pubkey::Pubkey,
+    },
+    spl_governance_addin_api::{
+        max_voter_weight::MaxVoterWeightRecord,
+        voter_weight::{VoterWeightAction, VoterWeightRecord},
+    },
+    spl_governance_tools::account::create_and_serialize_account,
 };
-use spl_governance_addin_api::{
-    max_voter_weight::MaxVoterWeightRecord,
-    voter_weight::{VoterWeightAction, VoterWeightRecord},
-};
-use spl_governance_tools::account::create_and_serialize_account;
-
-use crate::instruction::VoterWeightAddinInstruction;
 
 /// Processes an instruction
 pub fn process_instruction(

--- a/governance/chat/program/src/entrypoint.rs
+++ b/governance/chat/program/src/entrypoint.rs
@@ -1,10 +1,12 @@
 //! Program entrypoint
 #![cfg(all(target_os = "solana", not(feature = "no-entrypoint")))]
 
-use crate::{error::GovernanceChatError, processor};
-use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, program_error::PrintProgramError,
-    pubkey::Pubkey,
+use {
+    crate::{error::GovernanceChatError, processor},
+    solana_program::{
+        account_info::AccountInfo, entrypoint::ProgramResult, program_error::PrintProgramError,
+        pubkey::Pubkey,
+    },
 };
 
 solana_program::entrypoint!(process_instruction);

--- a/governance/chat/program/src/error.rs
+++ b/governance/chat/program/src/error.rs
@@ -1,12 +1,14 @@
 //! Error types
 
-use num_derive::FromPrimitive;
-use solana_program::{
-    decode_error::DecodeError,
-    msg,
-    program_error::{PrintProgramError, ProgramError},
+use {
+    num_derive::FromPrimitive,
+    solana_program::{
+        decode_error::DecodeError,
+        msg,
+        program_error::{PrintProgramError, ProgramError},
+    },
+    thiserror::Error,
 };
-use thiserror::Error;
 
 /// Errors that may be returned by the GovernanceChat program
 #[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]

--- a/governance/chat/program/src/instruction.rs
+++ b/governance/chat/program/src/instruction.rs
@@ -1,14 +1,15 @@
 //! Program instructions
 
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-use solana_program::{
-    instruction::{AccountMeta, Instruction},
-    pubkey::Pubkey,
-    system_program,
+use {
+    crate::state::MessageBody,
+    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
+    solana_program::{
+        instruction::{AccountMeta, Instruction},
+        pubkey::Pubkey,
+        system_program,
+    },
+    spl_governance::instruction::with_realm_config_accounts,
 };
-use spl_governance::instruction::with_realm_config_accounts;
-
-use crate::state::MessageBody;
 
 /// Instructions supported by the GovernanceChat program
 #[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]

--- a/governance/chat/program/src/processor.rs
+++ b/governance/chat/program/src/processor.rs
@@ -1,28 +1,31 @@
 //! Program processor
 
-use crate::{
-    error::GovernanceChatError,
-    instruction::GovernanceChatInstruction,
-    state::{assert_is_valid_chat_message, ChatMessage, GovernanceChatAccountType, MessageBody},
+use {
+    crate::{
+        error::GovernanceChatError,
+        instruction::GovernanceChatInstruction,
+        state::{
+            assert_is_valid_chat_message, ChatMessage, GovernanceChatAccountType, MessageBody,
+        },
+    },
+    borsh::BorshDeserialize,
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        clock::Clock,
+        entrypoint::ProgramResult,
+        msg,
+        program_error::ProgramError,
+        pubkey::Pubkey,
+        sysvar::Sysvar,
+    },
+    spl_governance::state::{
+        governance::get_governance_data_for_realm, proposal::get_proposal_data_for_governance,
+        realm::get_realm_data, realm_config::get_realm_config_data_for_realm,
+        token_owner_record::get_token_owner_record_data_for_realm,
+    },
+    spl_governance_addin_api::voter_weight::VoterWeightAction,
+    spl_governance_tools::account::create_and_serialize_account,
 };
-use borsh::BorshDeserialize;
-
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    clock::Clock,
-    entrypoint::ProgramResult,
-    msg,
-    program_error::ProgramError,
-    pubkey::Pubkey,
-    sysvar::Sysvar,
-};
-use spl_governance::state::{
-    governance::get_governance_data_for_realm, proposal::get_proposal_data_for_governance,
-    realm::get_realm_data, realm_config::get_realm_config_data_for_realm,
-    token_owner_record::get_token_owner_record_data_for_realm,
-};
-use spl_governance_addin_api::voter_weight::VoterWeightAction;
-use spl_governance_tools::account::create_and_serialize_account;
 
 /// Processes an instruction
 pub fn process_instruction(

--- a/governance/chat/program/src/state.rs
+++ b/governance/chat/program/src/state.rs
@@ -1,11 +1,13 @@
 //! Program state
 
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-use solana_program::{
-    account_info::AccountInfo, clock::UnixTimestamp, program_error::ProgramError, pubkey::Pubkey,
+use {
+    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
+    solana_program::{
+        account_info::AccountInfo, clock::UnixTimestamp, program_error::ProgramError,
+        pubkey::Pubkey,
+    },
+    spl_governance_tools::account::{assert_is_valid_account_of_type, AccountMaxSize},
 };
-
-use spl_governance_tools::account::{assert_is_valid_account_of_type, AccountMaxSize};
 
 /// Defines all GovernanceChat accounts types
 #[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]

--- a/governance/chat/program/tests/process_post_message.rs
+++ b/governance/chat/program/tests/process_post_message.rs
@@ -1,10 +1,10 @@
 #![cfg(feature = "test-sbf")]
 
-use program_test::GovernanceChatProgramTest;
-use solana_program_test::tokio;
-use solana_sdk::signature::Keypair;
-use spl_governance::error::GovernanceError;
-use spl_governance_chat::error::GovernanceChatError;
+use {
+    program_test::GovernanceChatProgramTest, solana_program_test::tokio,
+    solana_sdk::signature::Keypair, spl_governance::error::GovernanceError,
+    spl_governance_chat::error::GovernanceChatError,
+};
 
 mod program_test;
 

--- a/governance/chat/program/tests/program_test/cookies.rs
+++ b/governance/chat/program/tests/program_test/cookies.rs
@@ -1,6 +1,7 @@
-use solana_program::pubkey::Pubkey;
-use solana_sdk::signature::Keypair;
-use spl_governance_chat::state::ChatMessage;
+use {
+    solana_program::pubkey::Pubkey, solana_sdk::signature::Keypair,
+    spl_governance_chat::state::ChatMessage,
+};
 
 #[derive(Debug)]
 pub struct ChatMessageCookie {

--- a/governance/chat/program/tests/program_test/mod.rs
+++ b/governance/chat/program/tests/program_test/mod.rs
@@ -1,36 +1,34 @@
-use std::str::FromStr;
-
-use solana_program::{program_error::ProgramError, pubkey::Pubkey};
-use solana_program_test::{processor, ProgramTest};
-
-use solana_sdk::{signature::Keypair, signer::Signer};
-use spl_governance::{
-    instruction::{
-        create_governance, create_proposal, create_realm, create_token_owner_record,
-        deposit_governing_tokens,
-    },
-    state::{
-        enums::{MintMaxVoterWeightSource, VoteThreshold},
-        governance::{
-            get_governance_address, GovernanceConfig, DEFAULT_DEPOSIT_EXEMPT_PROPOSAL_COUNT,
+use {
+    self::cookies::TokenOwnerRecordCookie,
+    crate::program_test::cookies::{ChatMessageCookie, ProposalCookie},
+    solana_program::{program_error::ProgramError, pubkey::Pubkey},
+    solana_program_test::{processor, ProgramTest},
+    solana_sdk::{signature::Keypair, signer::Signer},
+    spl_governance::{
+        instruction::{
+            create_governance, create_proposal, create_realm, create_token_owner_record,
+            deposit_governing_tokens,
         },
-        proposal::{get_proposal_address, VoteType},
-        realm::{get_realm_address, GoverningTokenConfigAccountArgs},
-        realm_config::GoverningTokenType,
-        token_owner_record::get_token_owner_record_address,
+        state::{
+            enums::{MintMaxVoterWeightSource, VoteThreshold},
+            governance::{
+                get_governance_address, GovernanceConfig, DEFAULT_DEPOSIT_EXEMPT_PROPOSAL_COUNT,
+            },
+            proposal::{get_proposal_address, VoteType},
+            realm::{get_realm_address, GoverningTokenConfigAccountArgs},
+            realm_config::GoverningTokenType,
+            token_owner_record::get_token_owner_record_address,
+        },
     },
+    spl_governance_addin_mock::instruction::setup_voter_weight_record,
+    spl_governance_chat::{
+        instruction::post_message,
+        processor::process_instruction,
+        state::{ChatMessage, GovernanceChatAccountType, MessageBody},
+    },
+    spl_governance_test_sdk::{addins::ensure_addin_mock_is_built, ProgramTestBench},
+    std::str::FromStr,
 };
-use spl_governance_addin_mock::instruction::setup_voter_weight_record;
-use spl_governance_chat::{
-    instruction::post_message,
-    processor::process_instruction,
-    state::{ChatMessage, GovernanceChatAccountType, MessageBody},
-};
-use spl_governance_test_sdk::{addins::ensure_addin_mock_is_built, ProgramTestBench};
-
-use crate::program_test::cookies::{ChatMessageCookie, ProposalCookie};
-
-use self::cookies::TokenOwnerRecordCookie;
 
 pub mod cookies;
 

--- a/governance/program/src/addins/max_voter_weight.rs
+++ b/governance/program/src/addins/max_voter_weight.rs
@@ -1,13 +1,14 @@
 //! MaxVoterWeight Addin interface
 
-use solana_program::{
-    account_info::AccountInfo, clock::Clock, program_error::ProgramError, pubkey::Pubkey,
-    sysvar::Sysvar,
+use {
+    crate::error::GovernanceError,
+    solana_program::{
+        account_info::AccountInfo, clock::Clock, program_error::ProgramError, pubkey::Pubkey,
+        sysvar::Sysvar,
+    },
+    spl_governance_addin_api::max_voter_weight::MaxVoterWeightRecord,
+    spl_governance_tools::account::get_account_data,
 };
-use spl_governance_addin_api::max_voter_weight::MaxVoterWeightRecord;
-use spl_governance_tools::account::get_account_data;
-
-use crate::error::GovernanceError;
 
 /// Asserts MaxVoterWeightRecord hasn't expired
 pub fn assert_is_valid_max_voter_weight(

--- a/governance/program/src/addins/voter_weight.rs
+++ b/governance/program/src/addins/voter_weight.rs
@@ -1,13 +1,14 @@
 //! VoterWeight Addin interface
 
-use solana_program::{
-    account_info::AccountInfo, clock::Clock, program_error::ProgramError, pubkey::Pubkey,
-    sysvar::Sysvar,
+use {
+    crate::{error::GovernanceError, state::token_owner_record::TokenOwnerRecordV2},
+    solana_program::{
+        account_info::AccountInfo, clock::Clock, program_error::ProgramError, pubkey::Pubkey,
+        sysvar::Sysvar,
+    },
+    spl_governance_addin_api::voter_weight::{VoterWeightAction, VoterWeightRecord},
+    spl_governance_tools::account::get_account_data,
 };
-use spl_governance_addin_api::voter_weight::{VoterWeightAction, VoterWeightRecord};
-use spl_governance_tools::account::get_account_data;
-
-use crate::{error::GovernanceError, state::token_owner_record::TokenOwnerRecordV2};
 
 /// Asserts the VoterWeightRecord hasn't expired and matches the given action and target if specified
 pub fn assert_is_valid_voter_weight(

--- a/governance/program/src/entrypoint.rs
+++ b/governance/program/src/entrypoint.rs
@@ -1,10 +1,12 @@
 //! Program entrypoint definitions
 #![cfg(all(target_os = "solana", not(feature = "no-entrypoint")))]
 
-use crate::{error::GovernanceError, processor};
-use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, program_error::PrintProgramError,
-    pubkey::Pubkey,
+use {
+    crate::{error::GovernanceError, processor},
+    solana_program::{
+        account_info::AccountInfo, entrypoint::ProgramResult, program_error::PrintProgramError,
+        pubkey::Pubkey,
+    },
 };
 
 solana_program::entrypoint!(process_instruction);

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -1,12 +1,14 @@
 //! Error types
 
-use num_derive::FromPrimitive;
-use solana_program::{
-    decode_error::DecodeError,
-    msg,
-    program_error::{PrintProgramError, ProgramError},
+use {
+    num_derive::FromPrimitive,
+    solana_program::{
+        decode_error::DecodeError,
+        msg,
+        program_error::{PrintProgramError, ProgramError},
+    },
+    thiserror::Error,
 };
-use thiserror::Error;
 
 /// Errors that may be returned by the Governance program
 #[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -1,36 +1,38 @@
 //! Program instructions
 
-use crate::{
-    state::{
-        enums::MintMaxVoterWeightSource,
-        governance::{
-            get_governance_address, get_mint_governance_address, get_program_governance_address,
-            get_token_governance_address, GovernanceConfig,
+use {
+    crate::{
+        state::{
+            enums::MintMaxVoterWeightSource,
+            governance::{
+                get_governance_address, get_mint_governance_address,
+                get_program_governance_address, get_token_governance_address, GovernanceConfig,
+            },
+            native_treasury::get_native_treasury_address,
+            program_metadata::get_program_metadata_address,
+            proposal::{get_proposal_address, VoteType},
+            proposal_deposit::get_proposal_deposit_address,
+            proposal_transaction::{get_proposal_transaction_address, InstructionData},
+            realm::{
+                get_governing_token_holding_address, get_realm_address,
+                GoverningTokenConfigAccountArgs, GoverningTokenConfigArgs, RealmConfigArgs,
+                SetRealmAuthorityAction,
+            },
+            realm_config::get_realm_config_address,
+            required_signatory::get_required_signatory_address,
+            signatory_record::get_signatory_record_address,
+            token_owner_record::get_token_owner_record_address,
+            vote_record::{get_vote_record_address, Vote},
         },
-        native_treasury::get_native_treasury_address,
-        program_metadata::get_program_metadata_address,
-        proposal::{get_proposal_address, VoteType},
-        proposal_deposit::get_proposal_deposit_address,
-        proposal_transaction::{get_proposal_transaction_address, InstructionData},
-        realm::{
-            get_governing_token_holding_address, get_realm_address,
-            GoverningTokenConfigAccountArgs, RealmConfigArgs,
-        },
-        realm::{GoverningTokenConfigArgs, SetRealmAuthorityAction},
-        realm_config::get_realm_config_address,
-        required_signatory::get_required_signatory_address,
-        signatory_record::get_signatory_record_address,
-        token_owner_record::get_token_owner_record_address,
-        vote_record::{get_vote_record_address, Vote},
+        tools::bpf_loader_upgradeable::get_program_data_address,
     },
-    tools::bpf_loader_upgradeable::get_program_data_address,
-};
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-use solana_program::{
-    bpf_loader_upgradeable,
-    instruction::{AccountMeta, Instruction},
-    pubkey::Pubkey,
-    system_program, sysvar,
+    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
+    solana_program::{
+        bpf_loader_upgradeable,
+        instruction::{AccountMeta, Instruction},
+        pubkey::Pubkey,
+        system_program, sysvar,
+    },
 };
 
 /// Instructions supported by the Governance program

--- a/governance/program/src/processor/mod.rs
+++ b/governance/program/src/processor/mod.rs
@@ -31,42 +31,42 @@ mod process_sign_off_proposal;
 mod process_update_program_metadata;
 mod process_withdraw_governing_tokens;
 
-use crate::{error::GovernanceError, instruction::GovernanceInstruction};
-
-use process_add_required_signatory::*;
-use process_add_signatory::*;
-use process_cancel_proposal::*;
-use process_cast_vote::*;
-use process_complete_proposal::*;
-use process_create_governance::*;
-use process_create_mint_governance::*;
-use process_create_native_treasury::*;
-use process_create_program_governance::*;
-use process_create_proposal::*;
-use process_create_realm::*;
-use process_create_token_governance::*;
-use process_create_token_owner_record::*;
-use process_deposit_governing_tokens::*;
-use process_execute_transaction::*;
-use process_finalize_vote::*;
-use process_flag_transaction_error::*;
-use process_insert_transaction::*;
-use process_refund_proposal_deposit::*;
-use process_relinquish_vote::*;
-use process_remove_required_signatory::*;
-use process_remove_transaction::*;
-use process_revoke_governing_tokens::*;
-use process_set_governance_config::*;
-use process_set_governance_delegate::*;
-use process_set_realm_authority::*;
-use process_set_realm_config::*;
-use process_sign_off_proposal::*;
-use process_update_program_metadata::*;
-use process_withdraw_governing_tokens::*;
-
-use solana_program::{
-    account_info::AccountInfo, borsh0_10::try_from_slice_unchecked, entrypoint::ProgramResult, msg,
-    program_error::ProgramError, pubkey::Pubkey,
+use {
+    crate::{error::GovernanceError, instruction::GovernanceInstruction},
+    process_add_required_signatory::*,
+    process_add_signatory::*,
+    process_cancel_proposal::*,
+    process_cast_vote::*,
+    process_complete_proposal::*,
+    process_create_governance::*,
+    process_create_mint_governance::*,
+    process_create_native_treasury::*,
+    process_create_program_governance::*,
+    process_create_proposal::*,
+    process_create_realm::*,
+    process_create_token_governance::*,
+    process_create_token_owner_record::*,
+    process_deposit_governing_tokens::*,
+    process_execute_transaction::*,
+    process_finalize_vote::*,
+    process_flag_transaction_error::*,
+    process_insert_transaction::*,
+    process_refund_proposal_deposit::*,
+    process_relinquish_vote::*,
+    process_remove_required_signatory::*,
+    process_remove_transaction::*,
+    process_revoke_governing_tokens::*,
+    process_set_governance_config::*,
+    process_set_governance_delegate::*,
+    process_set_realm_authority::*,
+    process_set_realm_config::*,
+    process_sign_off_proposal::*,
+    process_update_program_metadata::*,
+    process_withdraw_governing_tokens::*,
+    solana_program::{
+        account_info::AccountInfo, borsh0_10::try_from_slice_unchecked, entrypoint::ProgramResult,
+        msg, program_error::ProgramError, pubkey::Pubkey,
+    },
 };
 
 /// Processes an instruction

--- a/governance/program/src/processor/process_add_required_signatory.rs
+++ b/governance/program/src/processor/process_add_required_signatory.rs
@@ -1,21 +1,22 @@
 //! Program state processor
 
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    entrypoint::ProgramResult,
-    pubkey::Pubkey,
-    rent::Rent,
-    sysvar::Sysvar,
-};
-use spl_governance_tools::account::create_and_serialize_account_signed;
-
-use crate::{
-    error::GovernanceError,
-    state::{
-        enums::GovernanceAccountType,
-        governance::get_governance_data,
-        required_signatory::{get_required_signatory_address_seeds, RequiredSignatory},
+use {
+    crate::{
+        error::GovernanceError,
+        state::{
+            enums::GovernanceAccountType,
+            governance::get_governance_data,
+            required_signatory::{get_required_signatory_address_seeds, RequiredSignatory},
+        },
     },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        pubkey::Pubkey,
+        rent::Rent,
+        sysvar::Sysvar,
+    },
+    spl_governance_tools::account::create_and_serialize_account_signed,
 };
 
 /// Processes AddRequiredSignatory instruction

--- a/governance/program/src/processor/process_add_signatory.rs
+++ b/governance/program/src/processor/process_add_signatory.rs
@@ -1,24 +1,25 @@
 //! Program state processor
 
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    entrypoint::ProgramResult,
-    pubkey::Pubkey,
-    rent::Rent,
-    sysvar::Sysvar,
-};
-use spl_governance_tools::account::create_and_serialize_account_signed;
-
-use crate::{
-    error::GovernanceError,
-    state::{
-        enums::GovernanceAccountType,
-        governance::get_governance_data,
-        proposal::get_proposal_data_for_governance,
-        required_signatory::get_required_signatory_data_for_governance,
-        signatory_record::{get_signatory_record_address_seeds, SignatoryRecordV2},
-        token_owner_record::get_token_owner_record_data_for_proposal_owner,
+use {
+    crate::{
+        error::GovernanceError,
+        state::{
+            enums::GovernanceAccountType,
+            governance::get_governance_data,
+            proposal::get_proposal_data_for_governance,
+            required_signatory::get_required_signatory_data_for_governance,
+            signatory_record::{get_signatory_record_address_seeds, SignatoryRecordV2},
+            token_owner_record::get_token_owner_record_data_for_proposal_owner,
+        },
     },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        pubkey::Pubkey,
+        rent::Rent,
+        sysvar::Sysvar,
+    },
+    spl_governance_tools::account::create_and_serialize_account_signed,
 };
 
 /// Processes AddSignatory instruction

--- a/governance/program/src/processor/process_cancel_proposal.rs
+++ b/governance/program/src/processor/process_cancel_proposal.rs
@@ -1,17 +1,18 @@
 //! Program state processor
 
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    clock::Clock,
-    entrypoint::ProgramResult,
-    pubkey::Pubkey,
-    sysvar::Sysvar,
-};
-
-use crate::state::{
-    enums::ProposalState, governance::get_governance_data_for_realm,
-    proposal::get_proposal_data_for_governance, realm::assert_is_valid_realm,
-    token_owner_record::get_token_owner_record_data_for_proposal_owner,
+use {
+    crate::state::{
+        enums::ProposalState, governance::get_governance_data_for_realm,
+        proposal::get_proposal_data_for_governance, realm::assert_is_valid_realm,
+        token_owner_record::get_token_owner_record_data_for_proposal_owner,
+    },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        clock::Clock,
+        entrypoint::ProgramResult,
+        pubkey::Pubkey,
+        sysvar::Sysvar,
+    },
 };
 
 /// Processes CancelProposal instruction

--- a/governance/program/src/processor/process_cast_vote.rs
+++ b/governance/program/src/processor/process_cast_vote.rs
@@ -1,30 +1,31 @@
 //! Program state processor
 
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    clock::Clock,
-    entrypoint::ProgramResult,
-    pubkey::Pubkey,
-    rent::Rent,
-    sysvar::Sysvar,
-};
-use spl_governance_addin_api::voter_weight::VoterWeightAction;
-use spl_governance_tools::account::create_and_serialize_account_signed;
-
-use crate::{
-    error::GovernanceError,
-    state::{
-        enums::GovernanceAccountType,
-        governance::get_governance_data_for_realm,
-        proposal::get_proposal_data_for_governance_and_governing_mint,
-        realm::get_realm_data_for_governing_token_mint,
-        realm_config::get_realm_config_data_for_realm,
-        token_owner_record::{
-            get_token_owner_record_data_for_proposal_owner,
-            get_token_owner_record_data_for_realm_and_governing_mint,
+use {
+    crate::{
+        error::GovernanceError,
+        state::{
+            enums::GovernanceAccountType,
+            governance::get_governance_data_for_realm,
+            proposal::get_proposal_data_for_governance_and_governing_mint,
+            realm::get_realm_data_for_governing_token_mint,
+            realm_config::get_realm_config_data_for_realm,
+            token_owner_record::{
+                get_token_owner_record_data_for_proposal_owner,
+                get_token_owner_record_data_for_realm_and_governing_mint,
+            },
+            vote_record::{get_vote_kind, get_vote_record_address_seeds, Vote, VoteRecordV2},
         },
-        vote_record::{get_vote_kind, get_vote_record_address_seeds, Vote, VoteRecordV2},
     },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        clock::Clock,
+        entrypoint::ProgramResult,
+        pubkey::Pubkey,
+        rent::Rent,
+        sysvar::Sysvar,
+    },
+    spl_governance_addin_api::voter_weight::VoterWeightAction,
+    spl_governance_tools::account::create_and_serialize_account_signed,
 };
 
 /// Processes CastVote instruction

--- a/governance/program/src/processor/process_complete_proposal.rs
+++ b/governance/program/src/processor/process_complete_proposal.rs
@@ -1,16 +1,17 @@
 //! Program state processor
 
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    clock::Clock,
-    entrypoint::ProgramResult,
-    pubkey::Pubkey,
-    sysvar::Sysvar,
-};
-
-use crate::state::{
-    enums::ProposalState, proposal::get_proposal_data,
-    token_owner_record::get_token_owner_record_data_for_proposal_owner,
+use {
+    crate::state::{
+        enums::ProposalState, proposal::get_proposal_data,
+        token_owner_record::get_token_owner_record_data_for_proposal_owner,
+    },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        clock::Clock,
+        entrypoint::ProgramResult,
+        pubkey::Pubkey,
+        sysvar::Sysvar,
+    },
 };
 
 /// Processes CompleteProposal instruction

--- a/governance/program/src/processor/process_create_governance.rs
+++ b/governance/program/src/processor/process_create_governance.rs
@@ -1,25 +1,26 @@
 //! Program state processor
 
-use crate::{
-    state::{
-        enums::GovernanceAccountType,
-        governance::{
-            assert_valid_create_governance_args, get_governance_address_seeds, GovernanceConfig,
-            GovernanceV2,
+use {
+    crate::{
+        state::{
+            enums::GovernanceAccountType,
+            governance::{
+                assert_valid_create_governance_args, get_governance_address_seeds,
+                GovernanceConfig, GovernanceV2,
+            },
+            realm::get_realm_data,
         },
-        realm::get_realm_data,
+        tools::structs::Reserved119,
     },
-    tools::structs::Reserved119,
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        pubkey::Pubkey,
+        rent::Rent,
+        sysvar::Sysvar,
+    },
+    spl_governance_tools::account::create_and_serialize_account_signed,
 };
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    entrypoint::ProgramResult,
-    pubkey::Pubkey,
-    rent::Rent,
-    sysvar::Sysvar,
-};
-
-use spl_governance_tools::account::create_and_serialize_account_signed;
 
 /// Processes CreateGovernance instruction
 pub fn process_create_governance(

--- a/governance/program/src/processor/process_create_mint_governance.rs
+++ b/governance/program/src/processor/process_create_mint_governance.rs
@@ -1,30 +1,33 @@
 //! Program state processor
 
-use crate::{
-    state::{
-        enums::GovernanceAccountType,
-        governance::{
-            assert_valid_create_governance_args, get_mint_governance_address_seeds,
-            GovernanceConfig, GovernanceV2,
+use {
+    crate::{
+        state::{
+            enums::GovernanceAccountType,
+            governance::{
+                assert_valid_create_governance_args, get_mint_governance_address_seeds,
+                GovernanceConfig, GovernanceV2,
+            },
+            realm::get_realm_data,
         },
-        realm::get_realm_data,
+        tools::{
+            spl_token::{
+                assert_spl_token_mint_authority_is_signer, set_spl_token_account_authority,
+            },
+            structs::Reserved119,
+        },
     },
-    tools::{
-        spl_token::{assert_spl_token_mint_authority_is_signer, set_spl_token_account_authority},
-        structs::Reserved119,
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        program_pack::Pack,
+        pubkey::Pubkey,
+        rent::Rent,
+        sysvar::Sysvar,
     },
+    spl_governance_tools::account::create_and_serialize_account_signed,
+    spl_token::{instruction::AuthorityType, state::Mint},
 };
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    entrypoint::ProgramResult,
-    program_pack::Pack,
-    pubkey::Pubkey,
-    rent::Rent,
-    sysvar::Sysvar,
-};
-
-use spl_governance_tools::account::create_and_serialize_account_signed;
-use spl_token::{instruction::AuthorityType, state::Mint};
 
 /// Processes CreateMintGovernance instruction
 pub fn process_create_mint_governance(

--- a/governance/program/src/processor/process_create_native_treasury.rs
+++ b/governance/program/src/processor/process_create_native_treasury.rs
@@ -1,18 +1,19 @@
 //! Program state processor
 
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    entrypoint::ProgramResult,
-    pubkey::Pubkey,
-    rent::Rent,
-    system_program,
-    sysvar::Sysvar,
-};
-use spl_governance_tools::account::create_and_serialize_account_with_owner_signed;
-
-use crate::state::{
-    governance::assert_is_valid_governance,
-    native_treasury::{get_native_treasury_address_seeds, NativeTreasury},
+use {
+    crate::state::{
+        governance::assert_is_valid_governance,
+        native_treasury::{get_native_treasury_address_seeds, NativeTreasury},
+    },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        pubkey::Pubkey,
+        rent::Rent,
+        system_program,
+        sysvar::Sysvar,
+    },
+    spl_governance_tools::account::create_and_serialize_account_with_owner_signed,
 };
 
 /// Processes CreateNativeTreasury instruction

--- a/governance/program/src/processor/process_create_program_governance.rs
+++ b/governance/program/src/processor/process_create_program_governance.rs
@@ -1,31 +1,31 @@
 //! Program state processor
 
-use crate::{
-    state::governance::GovernanceV2,
-    state::{
-        enums::GovernanceAccountType,
-        governance::{
-            assert_valid_create_governance_args, get_program_governance_address_seeds,
-            GovernanceConfig,
+use {
+    crate::{
+        state::{
+            enums::GovernanceAccountType,
+            governance::{
+                assert_valid_create_governance_args, get_program_governance_address_seeds,
+                GovernanceConfig, GovernanceV2,
+            },
+            realm::get_realm_data,
         },
-        realm::get_realm_data,
-    },
-    tools::{
-        bpf_loader_upgradeable::{
-            assert_program_upgrade_authority_is_signer, set_program_upgrade_authority,
+        tools::{
+            bpf_loader_upgradeable::{
+                assert_program_upgrade_authority_is_signer, set_program_upgrade_authority,
+            },
+            structs::Reserved119,
         },
-        structs::Reserved119,
     },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        pubkey::Pubkey,
+        rent::Rent,
+        sysvar::Sysvar,
+    },
+    spl_governance_tools::account::create_and_serialize_account_signed,
 };
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    entrypoint::ProgramResult,
-    pubkey::Pubkey,
-    rent::Rent,
-    sysvar::Sysvar,
-};
-
-use spl_governance_tools::account::create_and_serialize_account_signed;
 
 /// Processes CreateProgramGovernance instruction
 pub fn process_create_program_governance(

--- a/governance/program/src/processor/process_create_proposal.rs
+++ b/governance/program/src/processor/process_create_proposal.rs
@@ -1,31 +1,32 @@
 //! Program state processor
 
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    clock::Clock,
-    entrypoint::ProgramResult,
-    pubkey::Pubkey,
-    rent::Rent,
-    sysvar::Sysvar,
-};
-use spl_governance_addin_api::voter_weight::VoterWeightAction;
-use spl_governance_tools::account::create_and_serialize_account_signed;
-
-use crate::{
-    error::GovernanceError,
-    state::{
-        enums::{GovernanceAccountType, InstructionExecutionFlags, ProposalState},
-        governance::get_governance_data_for_realm,
-        proposal::{
-            assert_valid_proposal_options, get_proposal_address_seeds, OptionVoteResult,
-            ProposalOption, ProposalV2, VoteType,
+use {
+    crate::{
+        error::GovernanceError,
+        state::{
+            enums::{GovernanceAccountType, InstructionExecutionFlags, ProposalState},
+            governance::get_governance_data_for_realm,
+            proposal::{
+                assert_valid_proposal_options, get_proposal_address_seeds, OptionVoteResult,
+                ProposalOption, ProposalV2, VoteType,
+            },
+            proposal_deposit::{get_proposal_deposit_address_seeds, ProposalDeposit},
+            realm::get_realm_data_for_governing_token_mint,
+            realm_config::get_realm_config_data_for_realm,
+            token_owner_record::get_token_owner_record_data_for_realm,
+            vote_record::VoteKind,
         },
-        proposal_deposit::{get_proposal_deposit_address_seeds, ProposalDeposit},
-        realm::get_realm_data_for_governing_token_mint,
-        realm_config::get_realm_config_data_for_realm,
-        token_owner_record::get_token_owner_record_data_for_realm,
-        vote_record::VoteKind,
     },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        clock::Clock,
+        entrypoint::ProgramResult,
+        pubkey::Pubkey,
+        rent::Rent,
+        sysvar::Sysvar,
+    },
+    spl_governance_addin_api::voter_weight::VoterWeightAction,
+    spl_governance_tools::account::create_and_serialize_account_signed,
 };
 
 /// Processes CreateProposal instruction

--- a/governance/program/src/processor/process_create_realm.rs
+++ b/governance/program/src/processor/process_create_realm.rs
@@ -1,27 +1,28 @@
 //! Program state processor
 
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    entrypoint::ProgramResult,
-    pubkey::Pubkey,
-    rent::Rent,
-    sysvar::Sysvar,
-};
-use spl_governance_tools::account::create_and_serialize_account_signed;
-
-use crate::{
-    error::GovernanceError,
-    state::{
-        enums::GovernanceAccountType,
-        realm::{
-            assert_valid_realm_config_args, get_governing_token_holding_address_seeds,
-            get_realm_address_seeds, RealmConfig, RealmConfigArgs, RealmV2,
+use {
+    crate::{
+        error::GovernanceError,
+        state::{
+            enums::GovernanceAccountType,
+            realm::{
+                assert_valid_realm_config_args, get_governing_token_holding_address_seeds,
+                get_realm_address_seeds, RealmConfig, RealmConfigArgs, RealmV2,
+            },
+            realm_config::{
+                get_realm_config_address_seeds, resolve_governing_token_config, RealmConfigAccount,
+            },
         },
-        realm_config::{
-            get_realm_config_address_seeds, resolve_governing_token_config, RealmConfigAccount,
-        },
+        tools::{spl_token::create_spl_token_account_signed, structs::Reserved110},
     },
-    tools::{spl_token::create_spl_token_account_signed, structs::Reserved110},
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        pubkey::Pubkey,
+        rent::Rent,
+        sysvar::Sysvar,
+    },
+    spl_governance_tools::account::create_and_serialize_account_signed,
 };
 
 /// Processes CreateRealm instruction

--- a/governance/program/src/processor/process_create_token_governance.rs
+++ b/governance/program/src/processor/process_create_token_governance.rs
@@ -1,30 +1,31 @@
 //! Program state processor
 
-use crate::{
-    state::{
-        enums::GovernanceAccountType,
-        governance::{
-            assert_valid_create_governance_args, get_token_governance_address_seeds,
-            GovernanceConfig, GovernanceV2,
+use {
+    crate::{
+        state::{
+            enums::GovernanceAccountType,
+            governance::{
+                assert_valid_create_governance_args, get_token_governance_address_seeds,
+                GovernanceConfig, GovernanceV2,
+            },
+            realm::get_realm_data,
         },
-        realm::get_realm_data,
+        tools::{
+            spl_token::{assert_spl_token_owner_is_signer, set_spl_token_account_authority},
+            structs::Reserved119,
+        },
     },
-    tools::{
-        spl_token::{assert_spl_token_owner_is_signer, set_spl_token_account_authority},
-        structs::Reserved119,
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        program_pack::Pack,
+        pubkey::Pubkey,
+        rent::Rent,
+        sysvar::Sysvar,
     },
+    spl_governance_tools::account::create_and_serialize_account_signed,
+    spl_token::{instruction::AuthorityType, state::Account},
 };
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    entrypoint::ProgramResult,
-    program_pack::Pack,
-    pubkey::Pubkey,
-    rent::Rent,
-    sysvar::Sysvar,
-};
-
-use spl_governance_tools::account::create_and_serialize_account_signed;
-use spl_token::{instruction::AuthorityType, state::Account};
 
 /// Processes CreateTokenGovernance instruction
 pub fn process_create_token_governance(

--- a/governance/program/src/processor/process_create_token_owner_record.rs
+++ b/governance/program/src/processor/process_create_token_owner_record.rs
@@ -1,24 +1,25 @@
 //! Program state processor
 
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    entrypoint::ProgramResult,
-    pubkey::Pubkey,
-    rent::Rent,
-    sysvar::Sysvar,
-};
-use spl_governance_tools::account::create_and_serialize_account_signed;
-
-use crate::{
-    error::GovernanceError,
-    state::{
-        enums::GovernanceAccountType,
-        realm::get_realm_data,
-        token_owner_record::{
-            get_token_owner_record_address_seeds, TokenOwnerRecordV2,
-            TOKEN_OWNER_RECORD_LAYOUT_VERSION,
+use {
+    crate::{
+        error::GovernanceError,
+        state::{
+            enums::GovernanceAccountType,
+            realm::get_realm_data,
+            token_owner_record::{
+                get_token_owner_record_address_seeds, TokenOwnerRecordV2,
+                TOKEN_OWNER_RECORD_LAYOUT_VERSION,
+            },
         },
     },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        pubkey::Pubkey,
+        rent::Rent,
+        sysvar::Sysvar,
+    },
+    spl_governance_tools::account::create_and_serialize_account_signed,
 };
 
 /// Processes CreateTokenOwnerRecord instruction

--- a/governance/program/src/processor/process_deposit_governing_tokens.rs
+++ b/governance/program/src/processor/process_deposit_governing_tokens.rs
@@ -1,29 +1,30 @@
 //! Program state processor
 
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    entrypoint::ProgramResult,
-    pubkey::Pubkey,
-    rent::Rent,
-    sysvar::Sysvar,
-};
-use spl_governance_tools::account::create_and_serialize_account_signed;
-
-use crate::{
-    error::GovernanceError,
-    state::{
-        enums::GovernanceAccountType,
-        realm::get_realm_data,
-        realm_config::get_realm_config_data_for_realm,
-        token_owner_record::{
-            get_token_owner_record_address_seeds, get_token_owner_record_data_for_seeds,
-            TokenOwnerRecordV2, TOKEN_OWNER_RECORD_LAYOUT_VERSION,
+use {
+    crate::{
+        error::GovernanceError,
+        state::{
+            enums::GovernanceAccountType,
+            realm::get_realm_data,
+            realm_config::get_realm_config_data_for_realm,
+            token_owner_record::{
+                get_token_owner_record_address_seeds, get_token_owner_record_data_for_seeds,
+                TokenOwnerRecordV2, TOKEN_OWNER_RECORD_LAYOUT_VERSION,
+            },
+        },
+        tools::spl_token::{
+            get_spl_token_mint, is_spl_token_account, is_spl_token_mint, mint_spl_tokens_to,
+            transfer_spl_tokens,
         },
     },
-    tools::spl_token::{
-        get_spl_token_mint, is_spl_token_account, is_spl_token_mint, mint_spl_tokens_to,
-        transfer_spl_tokens,
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        pubkey::Pubkey,
+        rent::Rent,
+        sysvar::Sysvar,
     },
+    spl_governance_tools::account::create_and_serialize_account_signed,
 };
 
 /// Processes DepositGoverningTokens instruction

--- a/governance/program/src/processor/process_execute_transaction.rs
+++ b/governance/program/src/processor/process_execute_transaction.rs
@@ -1,21 +1,22 @@
 //! Program state processor
 
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    clock::Clock,
-    entrypoint::ProgramResult,
-    instruction::Instruction,
-    program::invoke_signed,
-    pubkey::Pubkey,
-    sysvar::Sysvar,
-};
-
-use crate::state::{
-    enums::{ProposalState, TransactionExecutionStatus},
-    governance::get_governance_data,
-    native_treasury::get_native_treasury_address_seeds,
-    proposal::{get_proposal_data_for_governance, OptionVoteResult},
-    proposal_transaction::get_proposal_transaction_data_for_proposal,
+use {
+    crate::state::{
+        enums::{ProposalState, TransactionExecutionStatus},
+        governance::get_governance_data,
+        native_treasury::get_native_treasury_address_seeds,
+        proposal::{get_proposal_data_for_governance, OptionVoteResult},
+        proposal_transaction::get_proposal_transaction_data_for_proposal,
+    },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        clock::Clock,
+        entrypoint::ProgramResult,
+        instruction::Instruction,
+        program::invoke_signed,
+        pubkey::Pubkey,
+        sysvar::Sysvar,
+    },
 };
 
 /// Processes ExecuteTransaction instruction

--- a/governance/program/src/processor/process_finalize_vote.rs
+++ b/governance/program/src/processor/process_finalize_vote.rs
@@ -1,18 +1,20 @@
 //! Program state processor
 
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    clock::Clock,
-    entrypoint::ProgramResult,
-    pubkey::Pubkey,
-    sysvar::Sysvar,
-};
-
-use crate::state::{
-    governance::get_governance_data_for_realm,
-    proposal::get_proposal_data_for_governance_and_governing_mint,
-    realm::get_realm_data_for_governing_token_mint, realm_config::get_realm_config_data_for_realm,
-    token_owner_record::get_token_owner_record_data_for_proposal_owner, vote_record::VoteKind,
+use {
+    crate::state::{
+        governance::get_governance_data_for_realm,
+        proposal::get_proposal_data_for_governance_and_governing_mint,
+        realm::get_realm_data_for_governing_token_mint,
+        realm_config::get_realm_config_data_for_realm,
+        token_owner_record::get_token_owner_record_data_for_proposal_owner, vote_record::VoteKind,
+    },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        clock::Clock,
+        entrypoint::ProgramResult,
+        pubkey::Pubkey,
+        sysvar::Sysvar,
+    },
 };
 
 /// Processes FinalizeVote instruction

--- a/governance/program/src/processor/process_flag_transaction_error.rs
+++ b/governance/program/src/processor/process_flag_transaction_error.rs
@@ -1,18 +1,19 @@
 //! Program state processor
 
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    clock::Clock,
-    entrypoint::ProgramResult,
-    pubkey::Pubkey,
-    sysvar::Sysvar,
-};
-
-use crate::state::{
-    enums::{ProposalState, TransactionExecutionStatus},
-    proposal::get_proposal_data,
-    proposal_transaction::get_proposal_transaction_data_for_proposal,
-    token_owner_record::get_token_owner_record_data_for_proposal_owner,
+use {
+    crate::state::{
+        enums::{ProposalState, TransactionExecutionStatus},
+        proposal::get_proposal_data,
+        proposal_transaction::get_proposal_transaction_data_for_proposal,
+        token_owner_record::get_token_owner_record_data_for_proposal_owner,
+    },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        clock::Clock,
+        entrypoint::ProgramResult,
+        pubkey::Pubkey,
+        sysvar::Sysvar,
+    },
 };
 
 /// Processes FlagTransactionError instruction

--- a/governance/program/src/processor/process_insert_transaction.rs
+++ b/governance/program/src/processor/process_insert_transaction.rs
@@ -1,27 +1,27 @@
 //! Program state processor
 
-use std::cmp::Ordering;
-
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    entrypoint::ProgramResult,
-    pubkey::Pubkey,
-    rent::Rent,
-    sysvar::Sysvar,
-};
-use spl_governance_tools::account::create_and_serialize_account_signed;
-
-use crate::{
-    error::GovernanceError,
-    state::{
-        enums::{GovernanceAccountType, TransactionExecutionStatus},
-        governance::get_governance_data,
-        proposal::get_proposal_data_for_governance,
-        proposal_transaction::{
-            get_proposal_transaction_address_seeds, InstructionData, ProposalTransactionV2,
+use {
+    crate::{
+        error::GovernanceError,
+        state::{
+            enums::{GovernanceAccountType, TransactionExecutionStatus},
+            governance::get_governance_data,
+            proposal::get_proposal_data_for_governance,
+            proposal_transaction::{
+                get_proposal_transaction_address_seeds, InstructionData, ProposalTransactionV2,
+            },
+            token_owner_record::get_token_owner_record_data_for_proposal_owner,
         },
-        token_owner_record::get_token_owner_record_data_for_proposal_owner,
     },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        pubkey::Pubkey,
+        rent::Rent,
+        sysvar::Sysvar,
+    },
+    spl_governance_tools::account::create_and_serialize_account_signed,
+    std::cmp::Ordering,
 };
 
 /// Processes InsertTransaction instruction

--- a/governance/program/src/processor/process_refund_proposal_deposit.rs
+++ b/governance/program/src/processor/process_refund_proposal_deposit.rs
@@ -1,15 +1,16 @@
 //! Program state processor
 
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    entrypoint::ProgramResult,
-    pubkey::Pubkey,
-};
-use spl_governance_tools::account::dispose_account;
-
-use crate::state::{
-    proposal::get_proposal_data,
-    proposal_deposit::get_proposal_deposit_data_for_proposal_and_deposit_payer,
+use {
+    crate::state::{
+        proposal::get_proposal_data,
+        proposal_deposit::get_proposal_deposit_data_for_proposal_and_deposit_payer,
+    },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        pubkey::Pubkey,
+    },
+    spl_governance_tools::account::dispose_account,
 };
 
 /// Processes RefundProposalDeposit instruction

--- a/governance/program/src/processor/process_relinquish_vote.rs
+++ b/governance/program/src/processor/process_relinquish_vote.rs
@@ -1,24 +1,25 @@
 //! Program state processor
 
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    clock::Clock,
-    entrypoint::ProgramResult,
-    pubkey::Pubkey,
-    sysvar::Sysvar,
-};
-use spl_governance_tools::account::dispose_account;
-
-use crate::{
-    error::GovernanceError,
-    state::{
-        enums::ProposalState,
-        governance::get_governance_data_for_realm,
-        proposal::get_proposal_data_for_governance,
-        realm::get_realm_data_for_governing_token_mint,
-        token_owner_record::get_token_owner_record_data_for_realm_and_governing_mint,
-        vote_record::{get_vote_record_data_for_proposal_and_token_owner_record, Vote},
+use {
+    crate::{
+        error::GovernanceError,
+        state::{
+            enums::ProposalState,
+            governance::get_governance_data_for_realm,
+            proposal::get_proposal_data_for_governance,
+            realm::get_realm_data_for_governing_token_mint,
+            token_owner_record::get_token_owner_record_data_for_realm_and_governing_mint,
+            vote_record::{get_vote_record_data_for_proposal_and_token_owner_record, Vote},
+        },
     },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        clock::Clock,
+        entrypoint::ProgramResult,
+        pubkey::Pubkey,
+        sysvar::Sysvar,
+    },
+    spl_governance_tools::account::dispose_account,
 };
 
 /// Processes RelinquishVote instruction

--- a/governance/program/src/processor/process_remove_required_signatory.rs
+++ b/governance/program/src/processor/process_remove_required_signatory.rs
@@ -1,13 +1,17 @@
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    entrypoint::ProgramResult,
-    pubkey::Pubkey,
-};
-use spl_governance_tools::account::dispose_account;
-
-use crate::{
-    error::GovernanceError, state::governance::get_governance_data,
-    state::required_signatory::get_required_signatory_data_for_governance,
+use {
+    crate::{
+        error::GovernanceError,
+        state::{
+            governance::get_governance_data,
+            required_signatory::get_required_signatory_data_for_governance,
+        },
+    },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        pubkey::Pubkey,
+    },
+    spl_governance_tools::account::dispose_account,
 };
 
 pub fn process_remove_required_signatory(

--- a/governance/program/src/processor/process_remove_transaction.rs
+++ b/governance/program/src/processor/process_remove_transaction.rs
@@ -1,15 +1,17 @@
 //! Program state processor
 
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    entrypoint::ProgramResult,
-    pubkey::Pubkey,
-};
-use spl_governance_tools::account::dispose_account;
-
-use crate::state::{
-    proposal::get_proposal_data, proposal_transaction::get_proposal_transaction_data_for_proposal,
-    token_owner_record::get_token_owner_record_data_for_proposal_owner,
+use {
+    crate::state::{
+        proposal::get_proposal_data,
+        proposal_transaction::get_proposal_transaction_data_for_proposal,
+        token_owner_record::get_token_owner_record_data_for_proposal_owner,
+    },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        pubkey::Pubkey,
+    },
+    spl_governance_tools::account::dispose_account,
 };
 
 /// Processes RemoveTransaction instruction

--- a/governance/program/src/processor/process_revoke_governing_tokens.rs
+++ b/governance/program/src/processor/process_revoke_governing_tokens.rs
@@ -1,19 +1,20 @@
 //! Program state processor
 
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    entrypoint::ProgramResult,
-    pubkey::Pubkey,
-};
-
-use crate::{
-    error::GovernanceError,
-    state::{
-        realm::{get_realm_address_seeds, get_realm_data},
-        realm_config::get_realm_config_data_for_realm,
-        token_owner_record::get_token_owner_record_data_for_realm_and_governing_mint,
+use {
+    crate::{
+        error::GovernanceError,
+        state::{
+            realm::{get_realm_address_seeds, get_realm_data},
+            realm_config::get_realm_config_data_for_realm,
+            token_owner_record::get_token_owner_record_data_for_realm_and_governing_mint,
+        },
+        tools::spl_token::{assert_spl_token_mint_authority_is_signer, burn_spl_tokens_signed},
     },
-    tools::spl_token::{assert_spl_token_mint_authority_is_signer, burn_spl_tokens_signed},
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        pubkey::Pubkey,
+    },
 };
 
 /// Processes RevokeGoverningTokens instruction

--- a/governance/program/src/processor/process_set_governance_config.rs
+++ b/governance/program/src/processor/process_set_governance_config.rs
@@ -1,14 +1,17 @@
 //! Program state processor
 
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    entrypoint::ProgramResult,
-    pubkey::Pubkey,
-};
-
-use crate::{
-    error::GovernanceError,
-    state::governance::{assert_is_valid_governance_config, get_governance_data, GovernanceConfig},
+use {
+    crate::{
+        error::GovernanceError,
+        state::governance::{
+            assert_is_valid_governance_config, get_governance_data, GovernanceConfig,
+        },
+    },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        pubkey::Pubkey,
+    },
 };
 
 /// Processes SetGovernanceConfig instruction

--- a/governance/program/src/processor/process_set_governance_delegate.rs
+++ b/governance/program/src/processor/process_set_governance_delegate.rs
@@ -1,12 +1,13 @@
 //! Program state processor
 
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    entrypoint::ProgramResult,
-    pubkey::Pubkey,
+use {
+    crate::state::token_owner_record::get_token_owner_record_data,
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        pubkey::Pubkey,
+    },
 };
-
-use crate::state::token_owner_record::get_token_owner_record_data;
 
 /// Processes SetGovernanceDelegate instruction
 pub fn process_set_governance_delegate(

--- a/governance/program/src/processor/process_set_realm_authority.rs
+++ b/governance/program/src/processor/process_set_realm_authority.rs
@@ -1,16 +1,17 @@
 //! Program state processor
 
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    entrypoint::ProgramResult,
-    pubkey::Pubkey,
-};
-
-use crate::{
-    error::GovernanceError,
-    state::{
-        governance::assert_governance_for_realm,
-        realm::{get_realm_data_for_authority, SetRealmAuthorityAction},
+use {
+    crate::{
+        error::GovernanceError,
+        state::{
+            governance::assert_governance_for_realm,
+            realm::{get_realm_data_for_authority, SetRealmAuthorityAction},
+        },
+    },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        pubkey::Pubkey,
     },
 };
 

--- a/governance/program/src/processor/process_set_realm_config.rs
+++ b/governance/program/src/processor/process_set_realm_config.rs
@@ -1,23 +1,26 @@
 //! Program state processor
 
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    entrypoint::ProgramResult,
-    pubkey::Pubkey,
-    rent::Rent,
-    sysvar::Sysvar,
-};
-use spl_governance_tools::account::create_and_serialize_account_signed;
-
-use crate::{
-    error::GovernanceError,
-    state::{
-        realm::{assert_valid_realm_config_args, get_realm_data_for_authority, RealmConfigArgs},
-        realm_config::{
-            get_realm_config_address_seeds, get_realm_config_data_for_realm,
-            resolve_governing_token_config, RealmConfigAccount,
+use {
+    crate::{
+        error::GovernanceError,
+        state::{
+            realm::{
+                assert_valid_realm_config_args, get_realm_data_for_authority, RealmConfigArgs,
+            },
+            realm_config::{
+                get_realm_config_address_seeds, get_realm_config_data_for_realm,
+                resolve_governing_token_config, RealmConfigAccount,
+            },
         },
     },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        pubkey::Pubkey,
+        rent::Rent,
+        sysvar::Sysvar,
+    },
+    spl_governance_tools::account::create_and_serialize_account_signed,
 };
 
 /// Processes SetRealmConfig instruction

--- a/governance/program/src/processor/process_sign_off_proposal.rs
+++ b/governance/program/src/processor/process_sign_off_proposal.rs
@@ -1,21 +1,23 @@
 //! Program state processor
 
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    clock::Clock,
-    entrypoint::ProgramResult,
-    pubkey::Pubkey,
-    sysvar::Sysvar,
+use {
+    crate::{
+        error::GovernanceError,
+        state::{
+            enums::ProposalState, governance::get_governance_data_for_realm,
+            proposal::get_proposal_data_for_governance, realm::assert_is_valid_realm,
+            signatory_record::get_signatory_record_data_for_seeds,
+            token_owner_record::get_token_owner_record_data_for_proposal_owner,
+        },
+    },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        clock::Clock,
+        entrypoint::ProgramResult,
+        pubkey::Pubkey,
+        sysvar::Sysvar,
+    },
 };
-
-use crate::state::{
-    enums::ProposalState, governance::get_governance_data_for_realm,
-    proposal::get_proposal_data_for_governance, realm::assert_is_valid_realm,
-    signatory_record::get_signatory_record_data_for_seeds,
-    token_owner_record::get_token_owner_record_data_for_proposal_owner,
-};
-
-use crate::error::GovernanceError;
 
 /// Processes SignOffProposal instruction
 pub fn process_sign_off_proposal(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {

--- a/governance/program/src/processor/process_update_program_metadata.rs
+++ b/governance/program/src/processor/process_update_program_metadata.rs
@@ -1,19 +1,22 @@
 //! Program state processor
 
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    clock::Clock,
-    entrypoint::ProgramResult,
-    msg,
-    pubkey::Pubkey,
-    rent::Rent,
-    sysvar::Sysvar,
-};
-use spl_governance_tools::account::create_and_serialize_account_signed;
-
-use crate::state::{
-    enums::GovernanceAccountType,
-    program_metadata::{get_program_metadata_data, get_program_metadata_seeds, ProgramMetadata},
+use {
+    crate::state::{
+        enums::GovernanceAccountType,
+        program_metadata::{
+            get_program_metadata_data, get_program_metadata_seeds, ProgramMetadata,
+        },
+    },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        clock::Clock,
+        entrypoint::ProgramResult,
+        msg,
+        pubkey::Pubkey,
+        rent::Rent,
+        sysvar::Sysvar,
+    },
+    spl_governance_tools::account::create_and_serialize_account_signed,
 };
 
 /// Processes UpdateProgramMetadata instruction

--- a/governance/program/src/processor/process_withdraw_governing_tokens.rs
+++ b/governance/program/src/processor/process_withdraw_governing_tokens.rs
@@ -1,21 +1,22 @@
 //! Program state processor
 
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    entrypoint::ProgramResult,
-    pubkey::Pubkey,
-};
-
-use crate::{
-    error::GovernanceError,
-    state::{
-        realm::{get_realm_address_seeds, get_realm_data},
-        realm_config::get_realm_config_data_for_realm,
-        token_owner_record::{
-            get_token_owner_record_address_seeds, get_token_owner_record_data_for_seeds,
+use {
+    crate::{
+        error::GovernanceError,
+        state::{
+            realm::{get_realm_address_seeds, get_realm_data},
+            realm_config::get_realm_config_data_for_realm,
+            token_owner_record::{
+                get_token_owner_record_address_seeds, get_token_owner_record_data_for_seeds,
+            },
         },
+        tools::spl_token::{get_spl_token_mint, transfer_spl_tokens_signed},
     },
-    tools::spl_token::{get_spl_token_mint, transfer_spl_tokens_signed},
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        pubkey::Pubkey,
+    },
 };
 
 /// Processes WithdrawGoverningTokens instruction

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -1,27 +1,27 @@
 //! Governance Account
-use borsh::maybestd::io::Write;
-
-use crate::{
-    error::GovernanceError,
-    state::{
-        enums::{GovernanceAccountType, VoteThreshold, VoteTipping},
-        legacy::{is_governance_v1_account_type, GovernanceV1},
-        realm::{assert_is_valid_realm, RealmV2},
-        vote_record::VoteKind,
+use {
+    crate::{
+        error::GovernanceError,
+        state::{
+            enums::{GovernanceAccountType, VoteThreshold, VoteTipping},
+            legacy::{is_governance_v1_account_type, GovernanceV1},
+            realm::{assert_is_valid_realm, RealmV2},
+            vote_record::VoteKind,
+        },
+        tools::structs::Reserved119,
     },
-    tools::structs::Reserved119,
-};
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-use solana_program::{
-    account_info::AccountInfo, program_error::ProgramError, program_pack::IsInitialized,
-    pubkey::Pubkey, rent::Rent,
-};
-use spl_governance_tools::{
-    account::{
-        assert_is_valid_account_of_types, extend_account_size, get_account_data, get_account_type,
-        AccountMaxSize,
+    borsh::{maybestd::io::Write, BorshDeserialize, BorshSchema, BorshSerialize},
+    solana_program::{
+        account_info::AccountInfo, program_error::ProgramError, program_pack::IsInitialized,
+        pubkey::Pubkey, rent::Rent,
     },
-    error::GovernanceToolsError,
+    spl_governance_tools::{
+        account::{
+            assert_is_valid_account_of_types, extend_account_size, get_account_data,
+            get_account_type, AccountMaxSize,
+        },
+        error::GovernanceToolsError,
+    },
 };
 
 /// Governance config
@@ -629,9 +629,7 @@ pub fn assert_is_valid_vote_threshold(vote_threshold: &VoteThreshold) -> Result<
 
 #[cfg(test)]
 mod test {
-    use solana_program::clock::Epoch;
-
-    use super::*;
+    use {super::*, solana_program::clock::Epoch};
 
     fn create_test_governance_config() -> GovernanceConfig {
         GovernanceConfig {

--- a/governance/program/src/state/legacy.rs
+++ b/governance/program/src/state/legacy.rs
@@ -1,19 +1,21 @@
 //! Legacy Accounts
 
-use crate::state::{
-    enums::{
-        GovernanceAccountType, InstructionExecutionFlags, ProposalState,
-        TransactionExecutionStatus, VoteThreshold,
+use {
+    crate::state::{
+        enums::{
+            GovernanceAccountType, InstructionExecutionFlags, ProposalState,
+            TransactionExecutionStatus, VoteThreshold,
+        },
+        governance::GovernanceConfig,
+        proposal_transaction::InstructionData,
+        realm::RealmConfig,
     },
-    governance::GovernanceConfig,
-    proposal_transaction::InstructionData,
-    realm::RealmConfig,
-};
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-use solana_program::{
-    clock::{Slot, UnixTimestamp},
-    program_pack::IsInitialized,
-    pubkey::Pubkey,
+    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
+    solana_program::{
+        clock::{Slot, UnixTimestamp},
+        program_pack::IsInitialized,
+        pubkey::Pubkey,
+    },
 };
 
 /// Governance Realm Account

--- a/governance/program/src/state/native_treasury.rs
+++ b/governance/program/src/state/native_treasury.rs
@@ -1,8 +1,10 @@
 //! Native treasury account
 
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-use solana_program::pubkey::Pubkey;
-use spl_governance_tools::account::AccountMaxSize;
+use {
+    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
+    solana_program::pubkey::Pubkey,
+    spl_governance_tools::account::AccountMaxSize,
+};
 
 /// Treasury account
 /// The account has no data and can be used as a payer for instruction signed by Governance PDAs or as a native SOL treasury

--- a/governance/program/src/state/program_metadata.rs
+++ b/governance/program/src/state/program_metadata.rs
@@ -1,13 +1,14 @@
 //! ProgramMetadata Account
 
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-use solana_program::{
-    account_info::AccountInfo, clock::Slot, program_error::ProgramError,
-    program_pack::IsInitialized, pubkey::Pubkey,
+use {
+    crate::state::enums::GovernanceAccountType,
+    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
+    solana_program::{
+        account_info::AccountInfo, clock::Slot, program_error::ProgramError,
+        program_pack::IsInitialized, pubkey::Pubkey,
+    },
+    spl_governance_tools::account::{get_account_data, AccountMaxSize},
 };
-use spl_governance_tools::account::{get_account_data, AccountMaxSize};
-
-use crate::state::enums::GovernanceAccountType;
 
 /// Program metadata account. It stores information about the particular SPL-Governance program instance
 #[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -1,42 +1,38 @@
 //! Proposal  Account
 
-use borsh::maybestd::io::Write;
-use solana_program::account_info::next_account_info;
-use std::cmp::Ordering;
-use std::slice::Iter;
-
-use solana_program::clock::{Slot, UnixTimestamp};
-
-use solana_program::{
-    account_info::AccountInfo, program_error::ProgramError, program_pack::IsInitialized,
-    pubkey::Pubkey,
-};
-use spl_governance_tools::account::{get_account_data, get_account_type, AccountMaxSize};
-
-use crate::addins::max_voter_weight::{
-    assert_is_valid_max_voter_weight,
-    get_max_voter_weight_record_data_for_realm_and_governing_token_mint,
-};
-use crate::state::legacy::ProposalV1;
-use crate::tools::spl_token::get_spl_token_mint_supply;
-use crate::{
-    error::GovernanceError,
-    state::{
-        enums::{
-            GovernanceAccountType, InstructionExecutionFlags, MintMaxVoterWeightSource,
-            ProposalState, TransactionExecutionStatus, VoteThreshold, VoteTipping,
+use {
+    crate::{
+        addins::max_voter_weight::{
+            assert_is_valid_max_voter_weight,
+            get_max_voter_weight_record_data_for_realm_and_governing_token_mint,
         },
-        governance::GovernanceConfig,
-        proposal_transaction::ProposalTransactionV2,
-        realm::RealmV2,
-        vote_record::Vote,
-        vote_record::VoteKind,
+        error::GovernanceError,
+        state::{
+            enums::{
+                GovernanceAccountType, InstructionExecutionFlags, MintMaxVoterWeightSource,
+                ProposalState, TransactionExecutionStatus, VoteThreshold, VoteTipping,
+            },
+            governance::GovernanceConfig,
+            legacy::ProposalV1,
+            proposal_transaction::ProposalTransactionV2,
+            realm::RealmV2,
+            realm_config::RealmConfigAccount,
+            vote_record::{Vote, VoteKind},
+        },
+        tools::spl_token::get_spl_token_mint_supply,
+        PROGRAM_AUTHORITY_SEED,
     },
-    PROGRAM_AUTHORITY_SEED,
+    borsh::{maybestd::io::Write, BorshDeserialize, BorshSchema, BorshSerialize},
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        clock::{Slot, UnixTimestamp},
+        program_error::ProgramError,
+        program_pack::IsInitialized,
+        pubkey::Pubkey,
+    },
+    spl_governance_tools::account::{get_account_data, get_account_type, AccountMaxSize},
+    std::{cmp::Ordering, slice::Iter},
 };
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-
-use crate::state::realm_config::RealmConfigAccount;
 
 /// Proposal option vote result
 #[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
@@ -1199,17 +1195,17 @@ pub fn assert_valid_proposal_options(
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use solana_program::clock::Epoch;
-
-    use crate::state::{
-        enums::{MintMaxVoterWeightSource, VoteThreshold},
-        legacy::ProposalV1,
-        realm::RealmConfig,
-        vote_record::VoteChoice,
+    use {
+        super::*,
+        crate::state::{
+            enums::{MintMaxVoterWeightSource, VoteThreshold},
+            legacy::ProposalV1,
+            realm::RealmConfig,
+            vote_record::VoteChoice,
+        },
+        proptest::prelude::*,
+        solana_program::clock::Epoch,
     };
-
-    use proptest::prelude::*;
 
     fn create_test_proposal() -> ProposalV2 {
         ProposalV2 {

--- a/governance/program/src/state/proposal_deposit.rs
+++ b/governance/program/src/state/proposal_deposit.rs
@@ -1,13 +1,14 @@
 //! Proposal deposit account
 
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-use solana_program::{
-    account_info::AccountInfo, program_error::ProgramError, program_pack::IsInitialized,
-    pubkey::Pubkey,
+use {
+    crate::{error::GovernanceError, state::enums::GovernanceAccountType},
+    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
+    solana_program::{
+        account_info::AccountInfo, program_error::ProgramError, program_pack::IsInitialized,
+        pubkey::Pubkey,
+    },
+    spl_governance_tools::account::{get_account_data, AccountMaxSize},
 };
-use spl_governance_tools::account::{get_account_data, AccountMaxSize};
-
-use crate::{error::GovernanceError, state::enums::GovernanceAccountType};
 
 /// Proposal deposit account
 /// The account is used to limit spam of proposals

--- a/governance/program/src/state/proposal_transaction.rs
+++ b/governance/program/src/state/proposal_transaction.rs
@@ -1,27 +1,26 @@
 //! ProposalTransaction Account
 
-use core::panic;
-
-use borsh::maybestd::io::Write;
-
-use crate::{
-    error::GovernanceError,
-    state::{
-        enums::{GovernanceAccountType, TransactionExecutionStatus},
-        legacy::ProposalInstructionV1,
+use {
+    crate::{
+        error::GovernanceError,
+        state::{
+            enums::{GovernanceAccountType, TransactionExecutionStatus},
+            legacy::ProposalInstructionV1,
+        },
+        PROGRAM_AUTHORITY_SEED,
     },
-    PROGRAM_AUTHORITY_SEED,
+    borsh::{maybestd::io::Write, BorshDeserialize, BorshSchema, BorshSerialize},
+    core::panic,
+    solana_program::{
+        account_info::AccountInfo,
+        clock::UnixTimestamp,
+        instruction::{AccountMeta, Instruction},
+        program_error::ProgramError,
+        program_pack::IsInitialized,
+        pubkey::Pubkey,
+    },
+    spl_governance_tools::account::{get_account_data, get_account_type, AccountMaxSize},
 };
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-use solana_program::{
-    account_info::AccountInfo,
-    clock::UnixTimestamp,
-    instruction::{AccountMeta, Instruction},
-    program_error::ProgramError,
-    program_pack::IsInitialized,
-    pubkey::Pubkey,
-};
-use spl_governance_tools::account::{get_account_data, get_account_type, AccountMaxSize};
 
 /// InstructionData wrapper. It can be removed once Borsh serialization for Instruction is supported in the SDK
 #[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]

--- a/governance/program/src/state/realm.rs
+++ b/governance/program/src/state/realm.rs
@@ -1,33 +1,30 @@
 //! Realm Account
 
-use borsh::maybestd::io::Write;
-use std::slice::Iter;
-
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    program_error::ProgramError,
-    program_pack::IsInitialized,
-    pubkey::Pubkey,
-};
-use spl_governance_addin_api::voter_weight::VoterWeightAction;
-use spl_governance_tools::account::{
-    assert_is_valid_account_of_types, get_account_data, get_account_type, AccountMaxSize,
-};
-
-use crate::{
-    error::GovernanceError,
-    state::{
-        enums::{GovernanceAccountType, MintMaxVoterWeightSource},
-        legacy::RealmV1,
-        realm_config::GoverningTokenType,
-        token_owner_record::get_token_owner_record_data_for_realm,
-        vote_record::VoteKind,
+use {
+    crate::{
+        error::GovernanceError,
+        state::{
+            enums::{GovernanceAccountType, MintMaxVoterWeightSource},
+            legacy::RealmV1,
+            realm_config::{get_realm_config_data_for_realm, GoverningTokenType},
+            token_owner_record::get_token_owner_record_data_for_realm,
+            vote_record::VoteKind,
+        },
+        PROGRAM_AUTHORITY_SEED,
     },
-    PROGRAM_AUTHORITY_SEED,
+    borsh::{maybestd::io::Write, BorshDeserialize, BorshSchema, BorshSerialize},
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        program_error::ProgramError,
+        program_pack::IsInitialized,
+        pubkey::Pubkey,
+    },
+    spl_governance_addin_api::voter_weight::VoterWeightAction,
+    spl_governance_tools::account::{
+        assert_is_valid_account_of_types, get_account_data, get_account_type, AccountMaxSize,
+    },
+    std::slice::Iter,
 };
-
-use crate::state::realm_config::get_realm_config_data_for_realm;
 
 /// Realm Config instruction args
 #[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]
@@ -457,10 +454,10 @@ pub fn assert_valid_realm_config_args(
 #[cfg(test)]
 mod test {
 
-    use crate::instruction::GovernanceInstruction;
-    use solana_program::borsh0_10::try_from_slice_unchecked;
-
-    use super::*;
+    use {
+        super::*, crate::instruction::GovernanceInstruction,
+        solana_program::borsh0_10::try_from_slice_unchecked,
+    };
 
     #[test]
     fn test_max_size() {

--- a/governance/program/src/state/realm_config.rs
+++ b/governance/program/src/state/realm_config.rs
@@ -1,22 +1,23 @@
 //! RealmConfig account
-use std::slice::Iter;
-
-use solana_program::account_info::next_account_info;
-
-use solana_program::{
-    account_info::AccountInfo, program_error::ProgramError, program_pack::IsInitialized,
-    pubkey::Pubkey,
+use {
+    crate::{
+        error::GovernanceError,
+        state::{
+            enums::GovernanceAccountType,
+            realm::{GoverningTokenConfigArgs, RealmConfigArgs, RealmV2},
+        },
+        tools::structs::Reserved110,
+    },
+    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        program_error::ProgramError,
+        program_pack::IsInitialized,
+        pubkey::Pubkey,
+    },
+    spl_governance_tools::account::{get_account_data, AccountMaxSize},
+    std::slice::Iter,
 };
-
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-use spl_governance_tools::account::{get_account_data, AccountMaxSize};
-
-use crate::tools::structs::Reserved110;
-use crate::{error::GovernanceError, state::enums::GovernanceAccountType};
-
-use crate::state::realm::GoverningTokenConfigArgs;
-
-use crate::state::realm::{RealmConfigArgs, RealmV2};
 
 /// The type of the governing token defines:
 /// 1) Who retains the authority over deposited tokens
@@ -281,8 +282,10 @@ pub fn resolve_governing_token_config(
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::state::{enums::GovernanceAccountType, realm_config::RealmConfigAccount};
+    use {
+        super::*,
+        crate::state::{enums::GovernanceAccountType, realm_config::RealmConfigAccount},
+    };
 
     #[test]
     fn test_max_size() {

--- a/governance/program/src/state/required_signatory.rs
+++ b/governance/program/src/state/required_signatory.rs
@@ -1,11 +1,13 @@
 //! RequiredSignatory account
-use crate::{error::GovernanceError, state::enums::GovernanceAccountType};
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-use solana_program::{
-    account_info::AccountInfo, program_error::ProgramError, program_pack::IsInitialized,
-    pubkey::Pubkey,
+use {
+    crate::{error::GovernanceError, state::enums::GovernanceAccountType},
+    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
+    solana_program::{
+        account_info::AccountInfo, program_error::ProgramError, program_pack::IsInitialized,
+        pubkey::Pubkey,
+    },
+    spl_governance_tools::account::{get_account_data, AccountMaxSize},
 };
-use spl_governance_tools::account::{get_account_data, AccountMaxSize};
 
 /// Required signatory
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]

--- a/governance/program/src/state/signatory_record.rs
+++ b/governance/program/src/state/signatory_record.rs
@@ -1,18 +1,18 @@
 //! Signatory Record
 
-use borsh::maybestd::io::Write;
-
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-
-use solana_program::{
-    account_info::AccountInfo, program_error::ProgramError, program_pack::IsInitialized,
-    pubkey::Pubkey,
+use {
+    crate::{
+        error::GovernanceError,
+        state::{enums::GovernanceAccountType, legacy::SignatoryRecordV1},
+        PROGRAM_AUTHORITY_SEED,
+    },
+    borsh::{maybestd::io::Write, BorshDeserialize, BorshSchema, BorshSerialize},
+    solana_program::{
+        account_info::AccountInfo, program_error::ProgramError, program_pack::IsInitialized,
+        pubkey::Pubkey,
+    },
+    spl_governance_tools::account::{get_account_data, get_account_type, AccountMaxSize},
 };
-use spl_governance_tools::account::{get_account_data, get_account_type, AccountMaxSize};
-
-use crate::{error::GovernanceError, PROGRAM_AUTHORITY_SEED};
-
-use crate::state::{enums::GovernanceAccountType, legacy::SignatoryRecordV1};
 
 /// Account PDA seeds: ['governance', proposal, signatory]
 #[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, BorshSchema)]

--- a/governance/program/src/state/token_owner_record.rs
+++ b/governance/program/src/state/token_owner_record.rs
@@ -1,31 +1,28 @@
 //! Token Owner Record Account
 
-use borsh::maybestd::io::Write;
-use std::slice::Iter;
-
-use crate::{
-    addins::voter_weight::{
-        assert_is_valid_voter_weight, get_voter_weight_record_data_for_token_owner_record,
+use {
+    crate::{
+        addins::voter_weight::{
+            assert_is_valid_voter_weight, get_voter_weight_record_data_for_token_owner_record,
+        },
+        error::GovernanceError,
+        state::{
+            enums::GovernanceAccountType, governance::GovernanceConfig, legacy::TokenOwnerRecordV1,
+            realm::RealmV2, realm_config::RealmConfigAccount,
+        },
+        PROGRAM_AUTHORITY_SEED,
     },
-    error::GovernanceError,
-    state::{
-        enums::GovernanceAccountType, governance::GovernanceConfig, legacy::TokenOwnerRecordV1,
-        realm::RealmV2,
+    borsh::{maybestd::io::Write, BorshDeserialize, BorshSchema, BorshSerialize},
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        program_error::ProgramError,
+        program_pack::IsInitialized,
+        pubkey::Pubkey,
     },
-    PROGRAM_AUTHORITY_SEED,
+    spl_governance_addin_api::voter_weight::VoterWeightAction,
+    spl_governance_tools::account::{get_account_data, get_account_type, AccountMaxSize},
+    std::slice::Iter,
 };
-
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    program_error::ProgramError,
-    program_pack::IsInitialized,
-    pubkey::Pubkey,
-};
-use spl_governance_addin_api::voter_weight::VoterWeightAction;
-use spl_governance_tools::account::{get_account_data, get_account_type, AccountMaxSize};
-
-use crate::state::realm_config::RealmConfigAccount;
 
 /// Governance Token Owner Record
 /// Account PDA seeds: ['governance', realm, token_mint, token_owner ]
@@ -422,9 +419,10 @@ pub fn get_token_owner_record_data_for_proposal_owner(
 
 #[cfg(test)]
 mod test {
-    use solana_program::{borsh0_10::get_packed_len, stake_history::Epoch};
-
-    use super::*;
+    use {
+        super::*,
+        solana_program::{borsh0_10::get_packed_len, stake_history::Epoch},
+    };
 
     fn create_test_token_owner_record() -> TokenOwnerRecordV2 {
         TokenOwnerRecordV2 {

--- a/governance/program/src/state/vote_record.rs
+++ b/governance/program/src/state/vote_record.rs
@@ -1,24 +1,23 @@
 //! Proposal Vote Record Account
 
-use borsh::maybestd::io::Write;
-
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-use solana_program::account_info::AccountInfo;
-
-use solana_program::program_error::ProgramError;
-use solana_program::{program_pack::IsInitialized, pubkey::Pubkey};
-use spl_governance_tools::account::{get_account_data, get_account_type, AccountMaxSize};
-
-use crate::error::GovernanceError;
-
-use crate::PROGRAM_AUTHORITY_SEED;
-
-use crate::state::{
-    enums::GovernanceAccountType,
-    legacy::{VoteRecordV1, VoteWeightV1},
-    proposal::ProposalV2,
-    realm::RealmV2,
-    token_owner_record::TokenOwnerRecordV2,
+use {
+    crate::{
+        error::GovernanceError,
+        state::{
+            enums::GovernanceAccountType,
+            legacy::{VoteRecordV1, VoteWeightV1},
+            proposal::ProposalV2,
+            realm::RealmV2,
+            token_owner_record::TokenOwnerRecordV2,
+        },
+        PROGRAM_AUTHORITY_SEED,
+    },
+    borsh::{maybestd::io::Write, BorshDeserialize, BorshSchema, BorshSerialize},
+    solana_program::{
+        account_info::AccountInfo, program_error::ProgramError, program_pack::IsInitialized,
+        pubkey::Pubkey,
+    },
+    spl_governance_tools::account::{get_account_data, get_account_type, AccountMaxSize},
 };
 
 /// Voter choice for a proposal option
@@ -264,9 +263,7 @@ pub fn get_vote_record_address<'a>(
 #[cfg(test)]
 mod test {
 
-    use solana_program::clock::Epoch;
-
-    use super::*;
+    use {super::*, solana_program::clock::Epoch};
 
     #[test]
     fn test_vote_record_v1_to_v2_serialisation_roundtrip() {

--- a/governance/program/src/tools/bpf_loader_upgradeable.rs
+++ b/governance/program/src/tools/bpf_loader_upgradeable.rs
@@ -1,16 +1,16 @@
 //! General purpose bpf_loader_upgradeable utility functions
 
-use solana_program::{
-    account_info::AccountInfo,
-    bpf_loader_upgradeable::{self, UpgradeableLoaderState},
-    program::invoke,
-    program_error::ProgramError,
-    pubkey::Pubkey,
+use {
+    crate::error::GovernanceError,
+    bincode::deserialize,
+    solana_program::{
+        account_info::AccountInfo,
+        bpf_loader_upgradeable::{self, UpgradeableLoaderState},
+        program::invoke,
+        program_error::ProgramError,
+        pubkey::Pubkey,
+    },
 };
-
-use bincode::deserialize;
-
-use crate::error::GovernanceError;
 
 /// Returns ProgramData account address for the given Program
 pub fn get_program_data_address(program: &Pubkey) -> Pubkey {

--- a/governance/program/src/tools/pack.rs
+++ b/governance/program/src/tools/pack.rs
@@ -1,7 +1,9 @@
 //! General purpose packing utility functions
 
-use arrayref::array_refs;
-use solana_program::{program_error::ProgramError, program_option::COption, pubkey::Pubkey};
+use {
+    arrayref::array_refs,
+    solana_program::{program_error::ProgramError, program_option::COption, pubkey::Pubkey},
+};
 
 /// Unpacks COption from a slice
 pub fn unpack_coption_pubkey(src: &[u8; 36]) -> Result<COption<Pubkey>, ProgramError> {

--- a/governance/program/src/tools/spl_token.rs
+++ b/governance/program/src/tools/spl_token.rs
@@ -1,24 +1,25 @@
 //! General purpose SPL token utility functions
 
-use arrayref::array_ref;
-use solana_program::{
-    account_info::AccountInfo,
-    entrypoint::ProgramResult,
-    msg,
-    program::{invoke, invoke_signed},
-    program_error::ProgramError,
-    program_option::COption,
-    program_pack::Pack,
-    pubkey::Pubkey,
-    rent::Rent,
-    system_instruction,
+use {
+    crate::{error::GovernanceError, tools::pack::unpack_coption_pubkey},
+    arrayref::array_ref,
+    solana_program::{
+        account_info::AccountInfo,
+        entrypoint::ProgramResult,
+        msg,
+        program::{invoke, invoke_signed},
+        program_error::ProgramError,
+        program_option::COption,
+        program_pack::Pack,
+        pubkey::Pubkey,
+        rent::Rent,
+        system_instruction,
+    },
+    spl_token::{
+        instruction::{set_authority, AuthorityType},
+        state::{Account, Mint},
+    },
 };
-use spl_token::{
-    instruction::{set_authority, AuthorityType},
-    state::{Account, Mint},
-};
-
-use crate::{error::GovernanceError, tools::pack::unpack_coption_pubkey};
 
 /// Creates and initializes SPL token account with PDA using the provided PDA seeds
 #[allow(clippy::too_many_arguments)]

--- a/governance/program/tests/migrate_legacy_accounts.rs
+++ b/governance/program/tests/migrate_legacy_accounts.rs
@@ -4,12 +4,12 @@ use solana_program_test::*;
 
 mod program_test;
 
-use program_test::legacy::*;
-use program_test::*;
-
-use spl_governance::state::{
-    enums::{VoteThreshold, VoteTipping},
-    governance::DEFAULT_DEPOSIT_EXEMPT_PROPOSAL_COUNT,
+use {
+    program_test::{legacy::*, *},
+    spl_governance::state::{
+        enums::{VoteThreshold, VoteTipping},
+        governance::DEFAULT_DEPOSIT_EXEMPT_PROPOSAL_COUNT,
+    },
 };
 
 #[tokio::test]

--- a/governance/program/tests/process_add_required_signatory.rs
+++ b/governance/program/tests/process_add_required_signatory.rs
@@ -2,16 +2,16 @@
 
 mod program_test;
 
-use solana_program_test::tokio;
-
-use num_traits::cast::ToPrimitive;
-use program_test::*;
-use solana_program::{
-    program_error::ProgramError, pubkey::Pubkey, system_instruction::SystemError,
+use {
+    num_traits::cast::ToPrimitive,
+    program_test::*,
+    solana_program::{
+        program_error::ProgramError, pubkey::Pubkey, system_instruction::SystemError,
+    },
+    solana_program_test::tokio,
+    solana_sdk::signature::Signer,
+    spl_governance::{error::GovernanceError, instruction::add_required_signatory},
 };
-use solana_sdk::signature::Signer;
-use spl_governance::error::GovernanceError;
-use spl_governance::instruction::add_required_signatory;
 
 #[tokio::test]
 async fn test_add_required_signatory() {

--- a/governance/program/tests/process_add_signatory.rs
+++ b/governance/program/tests/process_add_signatory.rs
@@ -2,16 +2,16 @@
 
 mod program_test;
 
-use solana_program::program_error::ProgramError;
-use solana_program_test::tokio;
-
-use borsh::BorshSerialize;
-use program_test::*;
-use solana_sdk::{pubkey::Pubkey, signature::Signer};
-
-use spl_governance::{
-    error::GovernanceError,
-    instruction::{add_signatory, AddSignatoryAuthority, GovernanceInstruction},
+use {
+    borsh::BorshSerialize,
+    program_test::*,
+    solana_program::program_error::ProgramError,
+    solana_program_test::tokio,
+    solana_sdk::{pubkey::Pubkey, signature::Signer},
+    spl_governance::{
+        error::GovernanceError,
+        instruction::{add_signatory, AddSignatoryAuthority, GovernanceInstruction},
+    },
 };
 
 #[tokio::test]

--- a/governance/program/tests/process_cancel_proposal.rs
+++ b/governance/program/tests/process_cancel_proposal.rs
@@ -2,10 +2,11 @@
 
 mod program_test;
 
-use solana_program_test::tokio;
-
-use program_test::*;
-use spl_governance::{error::GovernanceError, state::enums::ProposalState};
+use {
+    program_test::*,
+    solana_program_test::tokio,
+    spl_governance::{error::GovernanceError, state::enums::ProposalState},
+};
 
 #[tokio::test]
 async fn test_cancel_proposal() {

--- a/governance/program/tests/process_cast_vote.rs
+++ b/governance/program/tests/process_cast_vote.rs
@@ -2,19 +2,19 @@
 
 mod program_test;
 
-use solana_program::pubkey::Pubkey;
-use solana_program_test::tokio;
-
-use program_test::*;
-use spl_governance::{
-    error::GovernanceError,
-    state::{
-        enums::{MintMaxVoterWeightSource, ProposalState, VoteThreshold, VoteTipping},
-        vote_record::Vote,
+use {
+    crate::program_test::args::RealmSetupArgs,
+    program_test::*,
+    solana_program::pubkey::Pubkey,
+    solana_program_test::tokio,
+    spl_governance::{
+        error::GovernanceError,
+        state::{
+            enums::{MintMaxVoterWeightSource, ProposalState, VoteThreshold, VoteTipping},
+            vote_record::Vote,
+        },
     },
 };
-
-use crate::program_test::args::RealmSetupArgs;
 
 #[tokio::test]
 async fn test_cast_vote() {

--- a/governance/program/tests/process_complete_proposal.rs
+++ b/governance/program/tests/process_complete_proposal.rs
@@ -2,11 +2,11 @@
 
 mod program_test;
 
-use solana_program_test::tokio;
-
-use program_test::*;
-use spl_governance::error::GovernanceError;
-use spl_governance::state::enums::ProposalState;
+use {
+    program_test::*,
+    solana_program_test::tokio,
+    spl_governance::{error::GovernanceError, state::enums::ProposalState},
+};
 
 #[tokio::test]
 async fn test_complete_proposal() {

--- a/governance/program/tests/process_create_governance.rs
+++ b/governance/program/tests/process_create_governance.rs
@@ -1,13 +1,14 @@
 #![cfg(feature = "test-sbf")]
 mod program_test;
 
-use solana_program_test::*;
-
-use crate::program_test::args::RealmSetupArgs;
-use program_test::*;
-use solana_sdk::signature::Keypair;
-use spl_governance::{error::GovernanceError, state::enums::VoteThreshold};
-use spl_governance_tools::error::GovernanceToolsError;
+use {
+    crate::program_test::args::RealmSetupArgs,
+    program_test::*,
+    solana_program_test::*,
+    solana_sdk::signature::Keypair,
+    spl_governance::{error::GovernanceError, state::enums::VoteThreshold},
+    spl_governance_tools::error::GovernanceToolsError,
+};
 
 #[tokio::test]
 async fn test_create_governance() {

--- a/governance/program/tests/process_create_mint_governance.rs
+++ b/governance/program/tests/process_create_mint_governance.rs
@@ -1,13 +1,14 @@
 #![cfg(feature = "test-sbf")]
 mod program_test;
 
-use solana_program_test::*;
-
-use program_test::*;
-use solana_sdk::{signature::Keypair, signer::Signer};
-use spl_governance::error::GovernanceError;
-use spl_governance_tools::error::GovernanceToolsError;
-use spl_token::error::TokenError;
+use {
+    program_test::*,
+    solana_program_test::*,
+    solana_sdk::{signature::Keypair, signer::Signer},
+    spl_governance::error::GovernanceError,
+    spl_governance_tools::error::GovernanceToolsError,
+    spl_token::error::TokenError,
+};
 
 #[tokio::test]
 async fn test_create_mint_governance() {

--- a/governance/program/tests/process_create_program_governance.rs
+++ b/governance/program/tests/process_create_program_governance.rs
@@ -1,15 +1,16 @@
 #![cfg(feature = "test-sbf")]
 mod program_test;
 
-use solana_program_test::*;
-
-use program_test::*;
-use solana_sdk::signature::{Keypair, Signer};
-use spl_governance::{
-    error::GovernanceError, tools::bpf_loader_upgradeable::get_program_upgrade_authority,
+use {
+    program_test::*,
+    solana_program_test::*,
+    solana_sdk::signature::{Keypair, Signer},
+    spl_governance::{
+        error::GovernanceError, tools::bpf_loader_upgradeable::get_program_upgrade_authority,
+    },
+    spl_governance_test_sdk::tools::ProgramInstructionError,
+    spl_governance_tools::error::GovernanceToolsError,
 };
-use spl_governance_test_sdk::tools::ProgramInstructionError;
-use spl_governance_tools::error::GovernanceToolsError;
 
 #[tokio::test]
 async fn test_create_program_governance() {

--- a/governance/program/tests/process_create_proposal.rs
+++ b/governance/program/tests/process_create_proposal.rs
@@ -1,17 +1,21 @@
 #![cfg(feature = "test-sbf")]
 
-use solana_program::{instruction::AccountMeta, pubkey::Pubkey};
-use solana_program_test::*;
+use {
+    solana_program::{instruction::AccountMeta, pubkey::Pubkey},
+    solana_program_test::*,
+};
 
 mod program_test;
 
-use program_test::*;
-use solana_sdk::signature::Keypair;
-use spl_governance::{
-    error::GovernanceError,
-    state::{enums::VoteThreshold, governance::SECURITY_DEPOSIT_BASE_LAMPORTS},
+use {
+    program_test::*,
+    solana_sdk::signature::Keypair,
+    spl_governance::{
+        error::GovernanceError,
+        state::{enums::VoteThreshold, governance::SECURITY_DEPOSIT_BASE_LAMPORTS},
+    },
+    spl_governance_tools::account::AccountMaxSize,
 };
-use spl_governance_tools::account::AccountMaxSize;
 
 #[tokio::test]
 async fn test_create_community_proposal() {

--- a/governance/program/tests/process_create_realm.rs
+++ b/governance/program/tests/process_create_realm.rs
@@ -4,10 +4,11 @@ use solana_program_test::*;
 
 mod program_test;
 
-use program_test::*;
-use spl_governance::state::{enums::MintMaxVoterWeightSource, realm::get_realm_address};
-
-use crate::program_test::args::RealmSetupArgs;
+use {
+    crate::program_test::args::RealmSetupArgs,
+    program_test::*,
+    spl_governance::state::{enums::MintMaxVoterWeightSource, realm::get_realm_address},
+};
 
 #[tokio::test]
 async fn test_create_realm() {

--- a/governance/program/tests/process_create_token_governance.rs
+++ b/governance/program/tests/process_create_token_governance.rs
@@ -1,14 +1,14 @@
 #![cfg(feature = "test-sbf")]
 mod program_test;
 
-use solana_program_test::*;
-
-use program_test::*;
-use solana_sdk::{signature::Keypair, signer::Signer};
-use spl_governance::error::GovernanceError;
-use spl_governance_tools::error::GovernanceToolsError;
-
-use spl_token::{error::TokenError, instruction::AuthorityType};
+use {
+    program_test::*,
+    solana_program_test::*,
+    solana_sdk::{signature::Keypair, signer::Signer},
+    spl_governance::error::GovernanceError,
+    spl_governance_tools::error::GovernanceToolsError,
+    spl_token::{error::TokenError, instruction::AuthorityType},
+};
 
 #[tokio::test]
 async fn test_create_token_governance() {

--- a/governance/program/tests/process_create_token_owner_record.rs
+++ b/governance/program/tests/process_create_token_owner_record.rs
@@ -4,8 +4,9 @@ use solana_program_test::*;
 
 mod program_test;
 
-use program_test::*;
-use spl_governance::state::token_owner_record::TOKEN_OWNER_RECORD_LAYOUT_VERSION;
+use {
+    program_test::*, spl_governance::state::token_owner_record::TOKEN_OWNER_RECORD_LAYOUT_VERSION,
+};
 
 #[tokio::test]
 async fn test_create_token_owner_record() {

--- a/governance/program/tests/process_deposit_governing_tokens.rs
+++ b/governance/program/tests/process_deposit_governing_tokens.rs
@@ -1,21 +1,21 @@
 #![cfg(feature = "test-sbf")]
 
-use solana_program::instruction::AccountMeta;
-use solana_program_test::*;
+use {solana_program::instruction::AccountMeta, solana_program_test::*};
 
 mod program_test;
 
-use program_test::*;
-use solana_sdk::signature::{Keypair, Signer};
-use spl_governance::{
-    error::GovernanceError,
-    instruction::deposit_governing_tokens,
-    state::{
-        realm_config::GoverningTokenType, token_owner_record::TOKEN_OWNER_RECORD_LAYOUT_VERSION,
+use {
+    crate::program_test::args::*,
+    program_test::*,
+    solana_sdk::signature::{Keypair, Signer},
+    spl_governance::{
+        error::GovernanceError,
+        instruction::deposit_governing_tokens,
+        state::{
+            realm_config::GoverningTokenType, token_owner_record::TOKEN_OWNER_RECORD_LAYOUT_VERSION,
+        },
     },
 };
-
-use crate::program_test::args::*;
 
 #[tokio::test]
 async fn test_deposit_initial_community_tokens() {

--- a/governance/program/tests/process_execute_transaction.rs
+++ b/governance/program/tests/process_execute_transaction.rs
@@ -2,17 +2,18 @@
 
 mod program_test;
 
-use solana_program::{
-    instruction::{AccountMeta, Instruction},
-    program_error::ProgramError,
-    sysvar::clock,
-};
-use solana_program_test::tokio;
-
-use program_test::*;
-use spl_governance::{
-    error::GovernanceError,
-    state::enums::{ProposalState, TransactionExecutionStatus},
+use {
+    program_test::*,
+    solana_program::{
+        instruction::{AccountMeta, Instruction},
+        program_error::ProgramError,
+        sysvar::clock,
+    },
+    solana_program_test::tokio,
+    spl_governance::{
+        error::GovernanceError,
+        state::enums::{ProposalState, TransactionExecutionStatus},
+    },
 };
 
 #[tokio::test]

--- a/governance/program/tests/process_finalize_vote.rs
+++ b/governance/program/tests/process_finalize_vote.rs
@@ -2,12 +2,13 @@
 
 mod program_test;
 
-use solana_program_test::tokio;
-
-use program_test::*;
-use spl_governance::{
-    error::GovernanceError,
-    state::enums::{ProposalState, VoteThreshold},
+use {
+    program_test::*,
+    solana_program_test::tokio,
+    spl_governance::{
+        error::GovernanceError,
+        state::enums::{ProposalState, VoteThreshold},
+    },
 };
 
 #[tokio::test]

--- a/governance/program/tests/process_flag_transaction_error.rs
+++ b/governance/program/tests/process_flag_transaction_error.rs
@@ -2,12 +2,13 @@
 
 mod program_test;
 
-use solana_program_test::tokio;
-
-use program_test::*;
-use spl_governance::{
-    error::GovernanceError,
-    state::enums::{ProposalState, TransactionExecutionStatus},
+use {
+    program_test::*,
+    solana_program_test::tokio,
+    spl_governance::{
+        error::GovernanceError,
+        state::enums::{ProposalState, TransactionExecutionStatus},
+    },
 };
 
 #[tokio::test]

--- a/governance/program/tests/process_insert_transaction.rs
+++ b/governance/program/tests/process_insert_transaction.rs
@@ -2,10 +2,7 @@
 
 mod program_test;
 
-use solana_program_test::tokio;
-
-use program_test::*;
-use spl_governance::error::GovernanceError;
+use {program_test::*, solana_program_test::tokio, spl_governance::error::GovernanceError};
 
 #[tokio::test]
 async fn test_insert_transaction() {

--- a/governance/program/tests/process_refund_proposal_deposit.rs
+++ b/governance/program/tests/process_refund_proposal_deposit.rs
@@ -1,12 +1,10 @@
 #![cfg(feature = "test-sbf")]
 
-use solana_program::program_error::ProgramError;
-use solana_program_test::*;
+use {solana_program::program_error::ProgramError, solana_program_test::*};
 
 mod program_test;
 
-use program_test::*;
-use spl_governance::error::GovernanceError;
+use {program_test::*, spl_governance::error::GovernanceError};
 
 #[tokio::test]
 async fn test_refund_proposal_deposit() {

--- a/governance/program/tests/process_relinquish_vote.rs
+++ b/governance/program/tests/process_relinquish_vote.rs
@@ -2,17 +2,18 @@
 
 mod program_test;
 
-use solana_program::{instruction::AccountMeta, pubkey::Pubkey};
-use solana_program_test::tokio;
-
-use program_test::*;
-use solana_sdk::signer::Signer;
-use spl_governance::{
-    error::GovernanceError,
-    instruction::{cast_vote, relinquish_vote},
-    state::{
-        enums::{ProposalState, VoteTipping},
-        vote_record::{Vote, VoteChoice},
+use {
+    program_test::*,
+    solana_program::{instruction::AccountMeta, pubkey::Pubkey},
+    solana_program_test::tokio,
+    solana_sdk::signer::Signer,
+    spl_governance::{
+        error::GovernanceError,
+        instruction::{cast_vote, relinquish_vote},
+        state::{
+            enums::{ProposalState, VoteTipping},
+            vote_record::{Vote, VoteChoice},
+        },
     },
 };
 

--- a/governance/program/tests/process_remove_required_signatory.rs
+++ b/governance/program/tests/process_remove_required_signatory.rs
@@ -2,15 +2,14 @@
 
 mod program_test;
 
-use solana_program_test::tokio;
-
-use program_test::*;
-use solana_program::pubkey::Pubkey;
-use spl_governance::instruction::remove_required_signatory;
-
-use solana_sdk::signature::Signer;
-use spl_governance::error::GovernanceError;
-use spl_governance_tools::error::GovernanceToolsError;
+use {
+    program_test::*,
+    solana_program::pubkey::Pubkey,
+    solana_program_test::tokio,
+    solana_sdk::signature::Signer,
+    spl_governance::{error::GovernanceError, instruction::remove_required_signatory},
+    spl_governance_tools::error::GovernanceToolsError,
+};
 
 #[tokio::test]
 async fn test_remove_required_signatory() {

--- a/governance/program/tests/process_remove_transaction.rs
+++ b/governance/program/tests/process_remove_transaction.rs
@@ -2,10 +2,7 @@
 
 mod program_test;
 
-use solana_program_test::tokio;
-
-use program_test::*;
-use spl_governance::error::GovernanceError;
+use {program_test::*, solana_program_test::tokio, spl_governance::error::GovernanceError};
 
 #[tokio::test]
 async fn test_remove_transaction() {

--- a/governance/program/tests/process_revoke_governing_tokens.rs
+++ b/governance/program/tests/process_revoke_governing_tokens.rs
@@ -1,20 +1,19 @@
 #![cfg(feature = "test-sbf")]
 
-use solana_program::pubkey::Pubkey;
-use solana_program_test::*;
+use {solana_program::pubkey::Pubkey, solana_program_test::*};
 
 mod program_test;
 
-use program_test::*;
-
-use spl_governance::{
-    error::GovernanceError,
-    state::{realm::get_governing_token_holding_address, realm_config::GoverningTokenType},
+use {
+    crate::program_test::args::RealmSetupArgs,
+    program_test::*,
+    solana_sdk::signature::{Keypair, Signer},
+    spl_governance::{
+        error::GovernanceError,
+        state::{realm::get_governing_token_holding_address, realm_config::GoverningTokenType},
+    },
+    spl_governance_test_sdk::tools::{clone_keypair, NopOverride},
 };
-use spl_governance_test_sdk::tools::{clone_keypair, NopOverride};
-
-use crate::program_test::args::RealmSetupArgs;
-use solana_sdk::signature::{Keypair, Signer};
 
 #[tokio::test]
 async fn test_revoke_community_tokens() {

--- a/governance/program/tests/process_set_governance_config.rs
+++ b/governance/program/tests/process_set_governance_config.rs
@@ -2,15 +2,16 @@
 
 mod program_test;
 
-use program_test::*;
-use solana_program_test::tokio;
-use solana_sdk::{signature::Keypair, signer::Signer};
-use spl_governance::{
-    error::GovernanceError, instruction::set_governance_config, state::enums::VoteThreshold,
+use {
+    program_test::*,
+    solana_program_test::tokio,
+    solana_sdk::{signature::Keypair, signer::Signer},
+    spl_governance::{
+        error::GovernanceError, instruction::set_governance_config, state::enums::VoteThreshold,
+    },
+    spl_governance_test_sdk::tools::ProgramInstructionError,
+    spl_governance_tools::error::GovernanceToolsError,
 };
-use spl_governance_test_sdk::tools::ProgramInstructionError;
-
-use spl_governance_tools::error::GovernanceToolsError;
 
 #[tokio::test]
 async fn test_set_governance_config() {

--- a/governance/program/tests/process_set_governance_delegate.rs
+++ b/governance/program/tests/process_set_governance_delegate.rs
@@ -1,13 +1,14 @@
 #![cfg(feature = "test-sbf")]
 
-use solana_program::instruction::AccountMeta;
-use solana_program_test::*;
+use {solana_program::instruction::AccountMeta, solana_program_test::*};
 
 mod program_test;
 
-use program_test::*;
-use solana_sdk::signature::{Keypair, Signer};
-use spl_governance::{error::GovernanceError, instruction::set_governance_delegate};
+use {
+    program_test::*,
+    solana_sdk::signature::{Keypair, Signer},
+    spl_governance::{error::GovernanceError, instruction::set_governance_delegate},
+};
 
 #[tokio::test]
 async fn test_set_community_governance_delegate() {

--- a/governance/program/tests/process_set_realm_authority.rs
+++ b/governance/program/tests/process_set_realm_authority.rs
@@ -1,13 +1,13 @@
 #![cfg(feature = "test-sbf")]
 
-use solana_program::pubkey::Pubkey;
-use solana_program_test::*;
+use {solana_program::pubkey::Pubkey, solana_program_test::*};
 
 mod program_test;
 
-use program_test::*;
-use spl_governance::error::GovernanceError;
-use spl_governance_tools::error::GovernanceToolsError;
+use {
+    program_test::*, spl_governance::error::GovernanceError,
+    spl_governance_tools::error::GovernanceToolsError,
+};
 
 #[tokio::test]
 async fn test_set_realm_authority() {

--- a/governance/program/tests/process_set_realm_config.rs
+++ b/governance/program/tests/process_set_realm_config.rs
@@ -1,17 +1,17 @@
 #![cfg(feature = "test-sbf")]
 
-use solana_program::pubkey::Pubkey;
-use solana_program_test::*;
+use {solana_program::pubkey::Pubkey, solana_program_test::*};
 
 mod program_test;
 
-use program_test::*;
-use spl_governance::{
-    error::GovernanceError,
-    state::{realm::GoverningTokenConfigAccountArgs, realm_config::GoverningTokenType},
+use {
+    crate::program_test::args::RealmSetupArgs,
+    program_test::*,
+    spl_governance::{
+        error::GovernanceError,
+        state::{realm::GoverningTokenConfigAccountArgs, realm_config::GoverningTokenType},
+    },
 };
-
-use crate::program_test::args::RealmSetupArgs;
 
 #[tokio::test]
 async fn test_set_realm_config() {

--- a/governance/program/tests/process_sign_off_proposal.rs
+++ b/governance/program/tests/process_sign_off_proposal.rs
@@ -2,13 +2,14 @@
 
 mod program_test;
 
-use solana_program::pubkey::Pubkey;
-use solana_program_test::tokio;
-
-use program_test::*;
-use solana_sdk::signature::{Keypair, Signer};
-use spl_governance::{error::GovernanceError, state::enums::ProposalState};
-use spl_governance_tools::error::GovernanceToolsError;
+use {
+    program_test::*,
+    solana_program::pubkey::Pubkey,
+    solana_program_test::tokio,
+    solana_sdk::signature::{Keypair, Signer},
+    spl_governance::{error::GovernanceError, state::enums::ProposalState},
+    spl_governance_tools::error::GovernanceToolsError,
+};
 
 #[tokio::test]
 async fn test_sign_off_proposal() {

--- a/governance/program/tests/process_withdraw_governing_tokens.rs
+++ b/governance/program/tests/process_withdraw_governing_tokens.rs
@@ -1,20 +1,24 @@
 #![cfg(feature = "test-sbf")]
 
-use solana_program::{instruction::AccountMeta, pubkey::Pubkey};
-use solana_program_test::*;
+use {
+    solana_program::{instruction::AccountMeta, pubkey::Pubkey},
+    solana_program_test::*,
+};
 
 mod program_test;
 
-use program_test::*;
-use solana_sdk::signature::Signer;
-
-use spl_governance::{
-    error::GovernanceError,
-    instruction::withdraw_governing_tokens,
-    state::{realm_config::GoverningTokenType, token_owner_record::get_token_owner_record_address},
+use {
+    crate::program_test::args::RealmSetupArgs,
+    program_test::*,
+    solana_sdk::signature::Signer,
+    spl_governance::{
+        error::GovernanceError,
+        instruction::withdraw_governing_tokens,
+        state::{
+            realm_config::GoverningTokenType, token_owner_record::get_token_owner_record_address,
+        },
+    },
 };
-
-use crate::program_test::args::RealmSetupArgs;
 
 #[tokio::test]
 async fn test_withdraw_community_tokens() {

--- a/governance/program/tests/program_test/cookies.rs
+++ b/governance/program/tests/program_test/cookies.rs
@@ -1,17 +1,18 @@
-use solana_program::{instruction::Instruction, pubkey::Pubkey};
-use solana_sdk::signature::Keypair;
-use spl_governance::state::{
-    governance::GovernanceV2, native_treasury::NativeTreasury, program_metadata::ProgramMetadata,
-    proposal::ProposalV2, proposal_deposit::ProposalDeposit,
-    proposal_transaction::ProposalTransactionV2, realm::RealmV2, realm_config::RealmConfigAccount,
-    signatory_record::SignatoryRecordV2, token_owner_record::TokenOwnerRecordV2,
-    vote_record::VoteRecordV2,
+use {
+    solana_program::{instruction::Instruction, pubkey::Pubkey},
+    solana_sdk::signature::Keypair,
+    spl_governance::state::{
+        governance::GovernanceV2, native_treasury::NativeTreasury,
+        program_metadata::ProgramMetadata, proposal::ProposalV2, proposal_deposit::ProposalDeposit,
+        proposal_transaction::ProposalTransactionV2, realm::RealmV2,
+        realm_config::RealmConfigAccount, signatory_record::SignatoryRecordV2,
+        token_owner_record::TokenOwnerRecordV2, vote_record::VoteRecordV2,
+    },
+    spl_governance_addin_api::{
+        max_voter_weight::MaxVoterWeightRecord, voter_weight::VoterWeightRecord,
+    },
+    spl_governance_test_sdk::tools::clone_keypair,
 };
-
-use spl_governance_addin_api::{
-    max_voter_weight::MaxVoterWeightRecord, voter_weight::VoterWeightRecord,
-};
-use spl_governance_test_sdk::tools::clone_keypair;
 
 pub trait AccountCookie {
     fn get_address(&self) -> Pubkey;

--- a/governance/program/tests/program_test/legacy.rs
+++ b/governance/program/tests/program_test/legacy.rs
@@ -1,6 +1,8 @@
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-use solana_program::pubkey::Pubkey;
-use spl_governance::state::{enums::GovernanceAccountType, governance::GovernanceV2};
+use {
+    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
+    solana_program::pubkey::Pubkey,
+    spl_governance::state::{enums::GovernanceAccountType, governance::GovernanceV2},
+};
 
 /// Legacy Governance account as of spl-gov V1
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]

--- a/governance/program/tests/setup_realm_with_all_addins.rs
+++ b/governance/program/tests/setup_realm_with_all_addins.rs
@@ -1,13 +1,10 @@
 #![cfg(feature = "test-sbf")]
 
-use solana_program::pubkey::Pubkey;
-use solana_program_test::*;
+use {solana_program::pubkey::Pubkey, solana_program_test::*};
 
 mod program_test;
 
-use program_test::*;
-
-use crate::program_test::args::RealmSetupArgs;
+use {crate::program_test::args::RealmSetupArgs, program_test::*};
 
 #[tokio::test]
 async fn test_create_realm_with_all_addins() {

--- a/governance/program/tests/setup_realm_with_max_voter_weight_addin.rs
+++ b/governance/program/tests/setup_realm_with_max_voter_weight_addin.rs
@@ -1,13 +1,10 @@
 #![cfg(feature = "test-sbf")]
 
-use solana_program::pubkey::Pubkey;
-use solana_program_test::*;
+use {solana_program::pubkey::Pubkey, solana_program_test::*};
 
 mod program_test;
 
-use program_test::*;
-
-use crate::program_test::args::RealmSetupArgs;
+use {crate::program_test::args::RealmSetupArgs, program_test::*};
 
 #[tokio::test]
 async fn test_create_realm_with_max_voter_weight_addin() {

--- a/governance/program/tests/setup_realm_with_voter_weight_addin.rs
+++ b/governance/program/tests/setup_realm_with_voter_weight_addin.rs
@@ -1,12 +1,10 @@
 #![cfg(feature = "test-sbf")]
 
-use solana_program::pubkey::Pubkey;
-use solana_program_test::*;
+use {solana_program::pubkey::Pubkey, solana_program_test::*};
 
 mod program_test;
 
-use crate::program_test::args::RealmSetupArgs;
-use program_test::*;
+use {crate::program_test::args::RealmSetupArgs, program_test::*};
 
 #[tokio::test]
 async fn test_create_realm_with_voter_weight_addin() {

--- a/governance/program/tests/use_proposals_with_multiple_options.rs
+++ b/governance/program/tests/use_proposals_with_multiple_options.rs
@@ -4,14 +4,15 @@ use solana_program_test::*;
 
 mod program_test;
 
-use program_test::*;
-use spl_governance::state::proposal::MultiChoiceType;
-use spl_governance::{
-    error::GovernanceError,
-    state::{
-        enums::{ProposalState, VoteThreshold},
-        proposal::{OptionVoteResult, VoteType},
-        vote_record::{Vote, VoteChoice},
+use {
+    program_test::*,
+    spl_governance::{
+        error::GovernanceError,
+        state::{
+            enums::{ProposalState, VoteThreshold},
+            proposal::{MultiChoiceType, OptionVoteResult, VoteType},
+            vote_record::{Vote, VoteChoice},
+        },
     },
 };
 

--- a/governance/program/tests/use_realm_with_all_addins.rs
+++ b/governance/program/tests/use_realm_with_all_addins.rs
@@ -4,9 +4,10 @@ use solana_program_test::*;
 
 mod program_test;
 
-use program_test::args::*;
-use program_test::*;
-use spl_governance::state::enums::ProposalState;
+use {
+    program_test::{args::*, *},
+    spl_governance::state::enums::ProposalState,
+};
 
 #[tokio::test]
 async fn test_cast_community_vote_with_all_addin() {

--- a/governance/program/tests/use_realm_with_max_voter_weight_addin.rs
+++ b/governance/program/tests/use_realm_with_max_voter_weight_addin.rs
@@ -4,9 +4,10 @@ use solana_program_test::*;
 
 mod program_test;
 
-use program_test::args::*;
-use program_test::*;
-use spl_governance::{error::GovernanceError, state::enums::ProposalState};
+use {
+    program_test::{args::*, *},
+    spl_governance::{error::GovernanceError, state::enums::ProposalState},
+};
 
 #[tokio::test]
 async fn test_cast_vote_with_community_max_voter_weight_addin() {

--- a/governance/program/tests/use_realm_with_voter_weight_addin.rs
+++ b/governance/program/tests/use_realm_with_voter_weight_addin.rs
@@ -1,18 +1,17 @@
 #![cfg(feature = "test-sbf")]
 
-use solana_program::pubkey::Pubkey;
-use solana_program_test::*;
+use {solana_program::pubkey::Pubkey, solana_program_test::*};
 
 mod program_test;
 
-use program_test::args::*;
-use program_test::*;
-
-use spl_governance::{
-    error::GovernanceError,
-    state::vote_record::{Vote, VoteChoice},
+use {
+    program_test::{args::*, *},
+    spl_governance::{
+        error::GovernanceError,
+        state::vote_record::{Vote, VoteChoice},
+    },
+    spl_governance_addin_api::voter_weight::VoterWeightAction,
 };
-use spl_governance_addin_api::voter_weight::VoterWeightAction;
 
 #[tokio::test]
 async fn test_create_governance_with_community_voter_weight_addin() {

--- a/governance/program/tests/use_veto_vote.rs
+++ b/governance/program/tests/use_veto_vote.rs
@@ -1,21 +1,20 @@
 #![cfg(feature = "test-sbf")]
 
 mod program_test;
-use program_test::*;
-
-use solana_program::instruction::AccountMeta;
-use solana_program_test::tokio;
-
-use spl_governance::{
-    error::GovernanceError,
-    state::{
-        enums::{ProposalState, VoteThreshold},
-        vote_record::Vote,
+use {
+    crate::program_test::args::{PluginSetupArgs, RealmSetupArgs},
+    program_test::*,
+    solana_program::instruction::AccountMeta,
+    solana_program_test::tokio,
+    spl_governance::{
+        error::GovernanceError,
+        state::{
+            enums::{ProposalState, VoteThreshold},
+            vote_record::Vote,
+        },
     },
+    spl_governance_test_sdk::tools::clone_keypair,
 };
-use spl_governance_test_sdk::tools::clone_keypair;
-
-use crate::program_test::args::{PluginSetupArgs, RealmSetupArgs};
 
 #[tokio::test]
 async fn test_cast_council_veto_vote() {

--- a/governance/test-sdk/src/addins.rs
+++ b/governance/test-sdk/src/addins.rs
@@ -1,7 +1,8 @@
-use lazy_static::lazy_static;
-
-use solana_program_test::find_file;
-use std::{process::Command, sync::Mutex};
+use {
+    lazy_static::lazy_static,
+    solana_program_test::find_file,
+    std::{process::Command, sync::Mutex},
+};
 
 lazy_static! {
     pub static ref VOTER_WEIGHT_ADDIN_BUILD_GUARD: Mutex::<u8> = Mutex::new(0);

--- a/governance/test-sdk/src/cookies.rs
+++ b/governance/test-sdk/src/cookies.rs
@@ -1,5 +1,4 @@
-use solana_program::pubkey::Pubkey;
-use solana_sdk::account::Account;
+use {solana_program::pubkey::Pubkey, solana_sdk::account::Account};
 
 #[derive(Debug)]
 pub struct TokenAccountCookie {

--- a/governance/test-sdk/src/lib.rs
+++ b/governance/test-sdk/src/lib.rs
@@ -1,27 +1,25 @@
 #![allow(clippy::arithmetic_side_effects)]
-use std::borrow::Borrow;
-
-use borsh::{BorshDeserialize, BorshSerialize};
-use cookies::{TokenAccountCookie, WalletCookie};
-use solana_program::{
-    borsh0_10::try_from_slice_unchecked, clock::Clock, instruction::Instruction,
-    program_error::ProgramError, program_pack::Pack, pubkey::Pubkey, rent::Rent,
-    stake_history::Epoch, system_instruction, system_program, sysvar,
+use {
+    crate::tools::map_transaction_error,
+    bincode::deserialize,
+    borsh::{BorshDeserialize, BorshSerialize},
+    cookies::{TokenAccountCookie, WalletCookie},
+    solana_program::{
+        borsh0_10::try_from_slice_unchecked, clock::Clock, instruction::Instruction,
+        program_error::ProgramError, program_pack::Pack, pubkey::Pubkey, rent::Rent,
+        stake_history::Epoch, system_instruction, system_program, sysvar,
+    },
+    solana_program_test::{ProgramTest, ProgramTestContext},
+    solana_sdk::{
+        account::{Account, AccountSharedData, WritableAccount},
+        signature::Keypair,
+        signer::Signer,
+        transaction::Transaction,
+    },
+    spl_token::instruction::{set_authority, AuthorityType},
+    std::borrow::Borrow,
+    tools::clone_keypair,
 };
-use solana_program_test::{ProgramTest, ProgramTestContext};
-use solana_sdk::{
-    account::{Account, AccountSharedData, WritableAccount},
-    signature::Keypair,
-    signer::Signer,
-    transaction::Transaction,
-};
-
-use bincode::deserialize;
-
-use spl_token::instruction::{set_authority, AuthorityType};
-use tools::clone_keypair;
-
-use crate::tools::map_transaction_error;
 
 pub mod addins;
 pub mod cookies;

--- a/governance/test-sdk/src/tools.rs
+++ b/governance/test-sdk/src/tools.rs
@@ -1,7 +1,8 @@
-use std::convert::TryFrom;
-
-use solana_program::{instruction::InstructionError, program_error::ProgramError};
-use solana_sdk::{signature::Keypair, transaction::TransactionError, transport::TransportError};
+use {
+    solana_program::{instruction::InstructionError, program_error::ProgramError},
+    solana_sdk::{signature::Keypair, transaction::TransactionError, transport::TransportError},
+    std::convert::TryFrom,
+};
 
 /// TODO: Add to Solana SDK
 /// Instruction errors not mapped in the sdk

--- a/governance/tools/src/account.rs
+++ b/governance/tools/src/account.rs
@@ -1,22 +1,22 @@
 //! General purpose account utility functions
 
-use borsh::{BorshDeserialize, BorshSerialize};
-use solana_program::{
-    account_info::AccountInfo,
-    borsh0_10::try_from_slice_unchecked,
-    msg,
-    program::invoke,
-    program::invoke_signed,
-    program_error::ProgramError,
-    program_pack::IsInitialized,
-    pubkey::Pubkey,
-    rent::Rent,
-    system_instruction::{self, create_account},
-    system_program,
-    sysvar::Sysvar,
+use {
+    crate::error::GovernanceToolsError,
+    borsh::{BorshDeserialize, BorshSerialize},
+    solana_program::{
+        account_info::AccountInfo,
+        borsh0_10::try_from_slice_unchecked,
+        msg,
+        program::{invoke, invoke_signed},
+        program_error::ProgramError,
+        program_pack::IsInitialized,
+        pubkey::Pubkey,
+        rent::Rent,
+        system_instruction::{self, create_account},
+        system_program,
+        sysvar::Sysvar,
+    },
 };
-
-use crate::error::GovernanceToolsError;
 
 /// Trait for accounts to return their max size
 pub trait AccountMaxSize {

--- a/governance/tools/src/error.rs
+++ b/governance/tools/src/error.rs
@@ -1,12 +1,14 @@
 //! Error types
 
-use num_derive::FromPrimitive;
-use solana_program::{
-    decode_error::DecodeError,
-    msg,
-    program_error::{PrintProgramError, ProgramError},
+use {
+    num_derive::FromPrimitive,
+    solana_program::{
+        decode_error::DecodeError,
+        msg,
+        program_error::{PrintProgramError, ProgramError},
+    },
+    thiserror::Error,
 };
-use thiserror::Error;
 
 /// Errors that may be returned by the GovernanceTools
 #[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]

--- a/libraries/concurrent-merkle-tree/src/concurrent_merkle_tree.rs
+++ b/libraries/concurrent-merkle-tree/src/concurrent_merkle_tree.rs
@@ -1,13 +1,14 @@
-use crate::{
-    changelog::ChangeLog,
-    error::ConcurrentMerkleTreeError,
-    hash::{fill_in_proof, hash_to_parent, recompute},
-    node::{empty_node, empty_node_cached, Node, EMPTY},
-    path::Path,
+use {
+    crate::{
+        changelog::ChangeLog,
+        error::ConcurrentMerkleTreeError,
+        hash::{fill_in_proof, hash_to_parent, recompute},
+        node::{empty_node, empty_node_cached, Node, EMPTY},
+        path::Path,
+    },
+    bytemuck::{Pod, Zeroable},
+    log_compute, solana_logging,
 };
-use bytemuck::{Pod, Zeroable};
-use log_compute;
-use solana_logging;
 
 /// Enforce constraints on max depth and buffer size
 #[inline(always)]

--- a/libraries/concurrent-merkle-tree/src/hash.rs
+++ b/libraries/concurrent-merkle-tree/src/hash.rs
@@ -1,5 +1,7 @@
-use crate::node::{empty_node, Node};
-use solana_program::keccak::hashv;
+use {
+    crate::node::{empty_node, Node},
+    solana_program::keccak::hashv,
+};
 
 /// Recomputes root of the Merkle tree from Node & proof
 pub fn recompute(leaf: Node, proof: &[Node], index: u32) -> Node {

--- a/libraries/concurrent-merkle-tree/tests/tests.rs
+++ b/libraries/concurrent-merkle-tree/tests/tests.rs
@@ -1,10 +1,13 @@
 #![allow(clippy::arithmetic_side_effects)]
-use rand::thread_rng;
-use rand::{self, Rng};
-use spl_concurrent_merkle_tree::concurrent_merkle_tree::ConcurrentMerkleTree;
-use spl_concurrent_merkle_tree::error::ConcurrentMerkleTreeError;
-use spl_concurrent_merkle_tree::node::{Node, EMPTY};
-use spl_merkle_tree_reference::MerkleTree;
+use {
+    rand::{self, thread_rng, Rng},
+    spl_concurrent_merkle_tree::{
+        concurrent_merkle_tree::ConcurrentMerkleTree,
+        error::ConcurrentMerkleTreeError,
+        node::{Node, EMPTY},
+    },
+    spl_merkle_tree_reference::MerkleTree,
+};
 
 const DEPTH: usize = 10;
 const BUFFER_SIZE: usize = 64;

--- a/libraries/discriminator/derive/src/lib.rs
+++ b/libraries/discriminator/derive/src/lib.rs
@@ -5,10 +5,10 @@
 
 extern crate proc_macro;
 
-use proc_macro::TokenStream;
-use quote::ToTokens;
-use spl_discriminator_syn::SplDiscriminateBuilder;
-use syn::parse_macro_input;
+use {
+    proc_macro::TokenStream, quote::ToTokens, spl_discriminator_syn::SplDiscriminateBuilder,
+    syn::parse_macro_input,
+};
 
 /// Derive macro library to implement the `SplDiscriminate` trait
 /// on an enum or struct

--- a/libraries/math/src/error.rs
+++ b/libraries/math/src/error.rs
@@ -29,8 +29,7 @@ impl<T> DecodeError<T> for MathError {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use solana_program::program_error::ProgramError;
+    use {super::*, solana_program::program_error::ProgramError};
 
     #[test]
     fn test_math_error_from() {

--- a/libraries/math/src/precise_number.rs
+++ b/libraries/math/src/precise_number.rs
@@ -366,8 +366,7 @@ impl PreciseNumber {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use proptest::prelude::*;
+    use {super::*, proptest::prelude::*};
 
     fn check_pow_approximation(base: InnerUint, exponent: InnerUint, expected: InnerUint) {
         let precision = InnerUint::from(5_000_000); // correct to at least 3 decimal places

--- a/libraries/math/src/processor.rs
+++ b/libraries/math/src/processor.rs
@@ -167,9 +167,7 @@ pub fn process_instruction(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::instruction::MathInstruction;
-    use borsh::BorshSerialize;
+    use {super::*, crate::instruction::MathInstruction, borsh::BorshSerialize};
 
     #[test]
     fn test_u64_multiply() {

--- a/libraries/merkle-tree-reference/src/lib.rs
+++ b/libraries/merkle-tree-reference/src/lib.rs
@@ -1,9 +1,8 @@
 #![allow(clippy::arithmetic_side_effects)]
-use solana_program::keccak::hashv;
-use std::cell::RefCell;
-use std::collections::VecDeque;
-use std::iter::FromIterator;
-use std::rc::Rc;
+use {
+    solana_program::keccak::hashv,
+    std::{cell::RefCell, collections::VecDeque, iter::FromIterator, rc::Rc},
+};
 
 pub type Node = [u8; 32];
 pub const EMPTY: Node = [0; 32];

--- a/libraries/pod/src/optional_keys.rs
+++ b/libraries/pod/src/optional_keys.rs
@@ -1,10 +1,6 @@
 //! Optional pubkeys that can be used a `Pod`s
-use {
-    bytemuck::{Pod, Zeroable},
-    solana_program::{program_error::ProgramError, program_option::COption, pubkey::Pubkey},
-    solana_zk_token_sdk::zk_token_elgamal::pod::ElGamalPubkey,
-};
-
+#[cfg(feature = "borsh")]
+use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 #[cfg(feature = "serde-traits")]
 use {
     base64::{prelude::BASE64_STANDARD, Engine},
@@ -12,9 +8,11 @@ use {
     serde::{Deserialize, Deserializer, Serialize, Serializer},
     std::{convert::TryFrom, fmt, str::FromStr},
 };
-
-#[cfg(feature = "borsh")]
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use {
+    bytemuck::{Pod, Zeroable},
+    solana_program::{program_error::ProgramError, program_option::COption, pubkey::Pubkey},
+    solana_zk_token_sdk::zk_token_elgamal::pod::ElGamalPubkey,
+};
 
 /// A Pubkey that encodes `None` as all `0`, meant to be usable as a Pod type, similar to all
 /// NonZero* number types from the bytemuck library.

--- a/libraries/pod/src/primitives.rs
+++ b/libraries/pod/src/primitives.rs
@@ -1,11 +1,9 @@
 //! primitive types that can be used in `Pod`s
-use bytemuck::{Pod, Zeroable};
-
-#[cfg(feature = "serde-traits")]
-use serde::{Deserialize, Serialize};
-
 #[cfg(feature = "borsh")]
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use bytemuck::{Pod, Zeroable};
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
 
 /// The standard `bool` is not a `Pod`, define a replacement that is
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]

--- a/managed-token/program/src/accounts.rs
+++ b/managed-token/program/src/accounts.rs
@@ -1,8 +1,10 @@
-use crate::assert_with_msg;
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    program_error::ProgramError,
-    system_program,
+use {
+    crate::assert_with_msg,
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        program_error::ProgramError,
+        system_program,
+    },
 };
 
 pub struct InitializeMint<'a, 'info> {

--- a/managed-token/program/src/instruction.rs
+++ b/managed-token/program/src/instruction.rs
@@ -1,14 +1,15 @@
-use borsh::{BorshDeserialize, BorshSerialize};
-use shank::ShankInstruction;
-use solana_program::{
-    instruction::{AccountMeta, Instruction},
-    program_error::ProgramError,
-    pubkey::Pubkey,
-    system_program,
+use {
+    crate::get_authority,
+    borsh::{BorshDeserialize, BorshSerialize},
+    shank::ShankInstruction,
+    solana_program::{
+        instruction::{AccountMeta, Instruction},
+        program_error::ProgramError,
+        pubkey::Pubkey,
+        system_program,
+    },
+    spl_associated_token_account::get_associated_token_address,
 };
-use spl_associated_token_account::get_associated_token_address;
-
-use crate::get_authority;
 
 #[derive(Debug, Clone, ShankInstruction, BorshSerialize, BorshDeserialize)]
 #[rustfmt::skip]

--- a/managed-token/program/src/lib.rs
+++ b/managed-token/program/src/lib.rs
@@ -1,12 +1,14 @@
 solana_program::declare_id!("mTok58Lg4YfcmwqyrDHpf7ogp599WRhzb6PxjaBqAxS");
 
-use borsh::BorshDeserialize;
-use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, msg, program::invoke,
-    program_error::ProgramError, program_pack::Pack, pubkey::Pubkey, rent::Rent,
-    system_instruction, sysvar::Sysvar,
+use {
+    borsh::BorshDeserialize,
+    solana_program::{
+        account_info::AccountInfo, entrypoint::ProgramResult, msg, program::invoke,
+        program_error::ProgramError, program_pack::Pack, pubkey::Pubkey, rent::Rent,
+        system_instruction, sysvar::Sysvar,
+    },
+    spl_associated_token_account::instruction::create_associated_token_account,
 };
-use spl_associated_token_account::instruction::create_associated_token_account;
 
 #[track_caller]
 #[inline(always)]
@@ -23,9 +25,11 @@ pub fn assert_with_msg(v: bool, err: impl Into<ProgramError>, msg: &str) -> Prog
 pub mod accounts;
 pub mod instruction;
 pub mod token;
-use accounts::{Approve, Burn, Close, InitializeAccount, InitializeMint, Mint, Revoke, Transfer};
-use instruction::ManagedTokenInstruction;
-use token::{approve, burn, close, freeze, initialize_mint, mint_to, revoke, thaw, transfer};
+use {
+    accounts::{Approve, Burn, Close, InitializeAccount, InitializeMint, Mint, Revoke, Transfer},
+    instruction::ManagedTokenInstruction,
+    token::{approve, burn, close, freeze, initialize_mint, mint_to, revoke, thaw, transfer},
+};
 
 #[cfg(not(feature = "no-entrypoint"))]
 solana_program::entrypoint!(process_instruction);

--- a/managed-token/program/tests/test.rs
+++ b/managed-token/program/tests/test.rs
@@ -1,21 +1,21 @@
-use solana_program::program_option::COption;
-use solana_program_test::*;
-use solana_sdk::{
-    commitment_config::CommitmentLevel,
-    instruction::Instruction,
-    native_token::LAMPORTS_PER_SOL,
-    pubkey::Pubkey,
-    signature::Signature,
-    signature::{Keypair, Signer},
-    system_instruction,
-    transaction::Transaction,
+use {
+    solana_program::program_option::COption,
+    solana_program_test::*,
+    solana_sdk::{
+        commitment_config::CommitmentLevel,
+        instruction::Instruction,
+        native_token::LAMPORTS_PER_SOL,
+        pubkey::Pubkey,
+        signature::{Keypair, Signature, Signer},
+        system_instruction,
+        transaction::Transaction,
+    },
+    spl_associated_token_account::{
+        get_associated_token_address, instruction::create_associated_token_account,
+    },
+    spl_managed_token::instruction::*,
+    spl_token::state::Account as TokenAccount,
 };
-
-use spl_associated_token_account::{
-    get_associated_token_address, instruction::create_associated_token_account,
-};
-use spl_managed_token::instruction::*;
-use spl_token::state::Account as TokenAccount;
 
 pub fn sol(amount: f64) -> u64 {
     (amount * LAMPORTS_PER_SOL as f64) as u64

--- a/memo/program/src/processor.rs
+++ b/memo/program/src/processor.rs
@@ -1,10 +1,12 @@
 //! Program state processor
 
-use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, msg, program_error::ProgramError,
-    pubkey::Pubkey,
+use {
+    solana_program::{
+        account_info::AccountInfo, entrypoint::ProgramResult, msg, program_error::ProgramError,
+        pubkey::Pubkey,
+    },
+    std::str::from_utf8,
 };
-use std::str::from_utf8;
 
 /// Instruction processor
 pub fn process_instruction(
@@ -36,11 +38,13 @@ pub fn process_instruction(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use solana_program::{
-        account_info::IntoAccountInfo, program_error::ProgramError, pubkey::Pubkey,
+    use {
+        super::*,
+        solana_program::{
+            account_info::IntoAccountInfo, program_error::ProgramError, pubkey::Pubkey,
+        },
+        solana_sdk::account::Account,
     };
-    use solana_sdk::account::Account;
 
     #[test]
     fn test_utf8_memo() {

--- a/memo/program/tests/functional.rs
+++ b/memo/program/tests/functional.rs
@@ -1,15 +1,17 @@
 #![cfg(feature = "test-sbf")]
 
-use solana_program::{
-    instruction::{AccountMeta, Instruction, InstructionError},
-    pubkey::Pubkey,
+use {
+    solana_program::{
+        instruction::{AccountMeta, Instruction, InstructionError},
+        pubkey::Pubkey,
+    },
+    solana_program_test::*,
+    solana_sdk::{
+        signature::{Keypair, Signer},
+        transaction::{Transaction, TransactionError},
+    },
+    spl_memo::*,
 };
-use solana_program_test::*;
-use solana_sdk::{
-    signature::{Keypair, Signer},
-    transaction::{Transaction, TransactionError},
-};
-use spl_memo::*;
 
 fn program_test() -> ProgramTest {
     ProgramTest::new("spl_memo", id(), processor!(processor::process_instruction))

--- a/name-service/program/src/entrypoint.rs
+++ b/name-service/program/src/entrypoint.rs
@@ -1,6 +1,5 @@
 use {
-    crate::error::NameServiceError,
-    crate::processor::Processor,
+    crate::{error::NameServiceError, processor::Processor},
     num_traits::FromPrimitive,
     solana_program::{
         account_info::AccountInfo, decode_error::DecodeError, entrypoint::ProgramResult, msg,

--- a/name-service/program/src/processor.rs
+++ b/name-service/program/src/processor.rs
@@ -1,8 +1,7 @@
 use {
     crate::{
         instruction::NameRegistryInstruction,
-        state::get_seeds_and_key,
-        state::{write_data, NameRecordHeader},
+        state::{get_seeds_and_key, write_data, NameRecordHeader},
     },
     borsh::BorshDeserialize,
     solana_program::{

--- a/name-service/program/tests/functional.rs
+++ b/name-service/program/tests/functional.rs
@@ -1,21 +1,20 @@
 #![cfg(feature = "test-sbf")]
-use std::str::FromStr;
-
-use solana_program::{instruction::Instruction, program_pack::Pack, pubkey::Pubkey};
-use solana_program_test::{
-    processor, tokio, ProgramTest, ProgramTestBanksClientExt, ProgramTestContext,
-};
-
-use solana_program::hash::hashv;
-use solana_sdk::{
-    signature::{Keypair, Signer},
-    transaction::Transaction,
-    transport::TransportError,
-};
-use spl_name_service::{
-    instruction::{create, delete, realloc, transfer, update, NameRegistryInstruction},
-    processor::Processor,
-    state::{get_seeds_and_key, NameRecordHeader, HASH_PREFIX},
+use {
+    solana_program::{hash::hashv, instruction::Instruction, program_pack::Pack, pubkey::Pubkey},
+    solana_program_test::{
+        processor, tokio, ProgramTest, ProgramTestBanksClientExt, ProgramTestContext,
+    },
+    solana_sdk::{
+        signature::{Keypair, Signer},
+        transaction::Transaction,
+        transport::TransportError,
+    },
+    spl_name_service::{
+        instruction::{create, delete, realloc, transfer, update, NameRegistryInstruction},
+        processor::Processor,
+        state::{get_seeds_and_key, NameRecordHeader, HASH_PREFIX},
+    },
+    std::str::FromStr,
 };
 
 #[tokio::test]

--- a/record/program/src/error.rs
+++ b/record/program/src/error.rs
@@ -1,8 +1,10 @@
 //! Error types
 
-use num_derive::FromPrimitive;
-use solana_program::{decode_error::DecodeError, program_error::ProgramError};
-use thiserror::Error;
+use {
+    num_derive::FromPrimitive,
+    solana_program::{decode_error::DecodeError, program_error::ProgramError},
+    thiserror::Error,
+};
 
 /// Errors that may be returned by the program.
 #[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]

--- a/record/program/src/instruction.rs
+++ b/record/program/src/instruction.rs
@@ -1,10 +1,12 @@
 //! Program instructions
 
-use crate::id;
-use borsh::{BorshDeserialize, BorshSerialize};
-use solana_program::{
-    instruction::{AccountMeta, Instruction},
-    pubkey::Pubkey,
+use {
+    crate::id,
+    borsh::{BorshDeserialize, BorshSerialize},
+    solana_program::{
+        instruction::{AccountMeta, Instruction},
+        pubkey::Pubkey,
+    },
 };
 
 /// Instructions supported by the program
@@ -106,9 +108,7 @@ pub fn close_account(record_account: &Pubkey, signer: &Pubkey, receiver: &Pubkey
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::state::tests::TEST_DATA;
-    use solana_program::program_error::ProgramError;
+    use {super::*, crate::state::tests::TEST_DATA, solana_program::program_error::ProgramError};
 
     #[test]
     fn serialize_initialize() {

--- a/record/program/src/state.rs
+++ b/record/program/src/state.rs
@@ -46,8 +46,7 @@ impl IsInitialized for RecordData {
 
 #[cfg(test)]
 pub mod tests {
-    use super::*;
-    use solana_program::program_error::ProgramError;
+    use {super::*, solana_program::program_error::ProgramError};
 
     /// Version for tests
     pub const TEST_VERSION: u8 = 1;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,3 @@
 edition = "2021"
+group_imports = "One"
+imports_granularity = "One"

--- a/shared-memory/program/src/lib.rs
+++ b/shared-memory/program/src/lib.rs
@@ -8,15 +8,19 @@
 // implement the typical `process_instruction` entrypoint.
 
 extern crate solana_program;
-use arrayref::{array_refs, mut_array_refs};
-use solana_program::{
-    declare_id, entrypoint::MAX_PERMITTED_DATA_INCREASE, entrypoint::SUCCESS,
-    program_error::ProgramError, pubkey::Pubkey,
-};
-use std::{
-    mem::{align_of, size_of},
-    ptr::read,
-    slice::{from_raw_parts, from_raw_parts_mut},
+use {
+    arrayref::{array_refs, mut_array_refs},
+    solana_program::{
+        declare_id,
+        entrypoint::{MAX_PERMITTED_DATA_INCREASE, SUCCESS},
+        program_error::ProgramError,
+        pubkey::Pubkey,
+    },
+    std::{
+        mem::{align_of, size_of},
+        ptr::read,
+        slice::{from_raw_parts, from_raw_parts_mut},
+    },
 };
 
 declare_id!("shmem4EWT2sPdVGvTZCzXXRAURL9G5vpPxNwSeKhHUL");

--- a/shared-memory/program/tests/shared-memory.rs
+++ b/shared-memory/program/tests/shared-memory.rs
@@ -1,14 +1,15 @@
 // Program test does not support calling a raw program entrypoint, only `process_instruction`
 #![cfg(feature = "test-sbf")]
 
-use solana_program_test::*;
-use solana_sdk::{
-    account::Account,
-    instruction::InstructionError,
-    instruction::{AccountMeta, Instruction},
-    pubkey::Pubkey,
-    signature::Signer,
-    transaction::{Transaction, TransactionError},
+use {
+    solana_program_test::*,
+    solana_sdk::{
+        account::Account,
+        instruction::{AccountMeta, Instruction, InstructionError},
+        pubkey::Pubkey,
+        signature::Signer,
+        transaction::{Transaction, TransactionError},
+    },
 };
 
 #[tokio::test]

--- a/single-pool/cli/src/config.rs
+++ b/single-pool/cli/src/config.rs
@@ -1,4 +1,5 @@
 use {
+    crate::cli::*,
     clap::ArgMatches,
     solana_clap_v3_utils::keypair::signer_from_path,
     solana_cli_output::OutputFormat,
@@ -8,8 +9,6 @@ use {
     spl_token_client::client::{ProgramClient, ProgramRpcClient, ProgramRpcClientSendTransaction},
     std::{process::exit, rc::Rc, sync::Arc},
 };
-
-use crate::cli::*;
 
 pub type Error = Box<dyn std::error::Error + Send + Sync>;
 

--- a/single-pool/cli/src/main.rs
+++ b/single-pool/cli/src/main.rs
@@ -11,8 +11,7 @@ use {
     solana_sdk::{
         borsh0_10::try_from_slice_unchecked,
         pubkey::Pubkey,
-        signature::Signature,
-        signature::{Keypair, Signer},
+        signature::{Keypair, Signature, Signer},
         stake,
         transaction::Transaction,
     },

--- a/single-pool/cli/src/quarantine.rs
+++ b/single-pool/cli/src/quarantine.rs
@@ -1,18 +1,19 @@
 // XXX this file will be deleted and replaced with a stake program client once i write one
 
-use solana_sdk::{
-    instruction::Instruction,
-    native_token::LAMPORTS_PER_SOL,
-    pubkey::Pubkey,
-    stake::{
-        self,
-        state::{Meta, Stake, StakeStateV2},
+use {
+    crate::config::*,
+    solana_sdk::{
+        instruction::Instruction,
+        native_token::LAMPORTS_PER_SOL,
+        pubkey::Pubkey,
+        stake::{
+            self,
+            state::{Meta, Stake, StakeStateV2},
+        },
+        system_instruction,
+        sysvar::{self, rent::Rent},
     },
-    system_instruction,
-    sysvar::{self, rent::Rent},
 };
-
-use crate::config::*;
 
 pub async fn get_rent(config: &Config) -> Result<Rent, Error> {
     let rent_data = config

--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -2,6 +2,9 @@
 mod client;
 mod output;
 
+// use instruction::create_associated_token_account once ATA 1.0.5 is released
+#[allow(deprecated)]
+use spl_associated_token_account::create_associated_token_account;
 use {
     crate::{
         client::*,
@@ -41,21 +44,16 @@ use {
         transaction::Transaction,
     },
     spl_associated_token_account::get_associated_token_address,
-    spl_stake_pool::state::ValidatorStakeInfo,
     spl_stake_pool::{
         self, find_stake_program_address, find_transient_stake_program_address,
         find_withdraw_authority_program_address,
         instruction::{FundingType, PreferredValidatorType},
         minimum_delegation,
-        state::{Fee, FeeType, StakePool, ValidatorList},
+        state::{Fee, FeeType, StakePool, ValidatorList, ValidatorStakeInfo},
         MINIMUM_RESERVE_LAMPORTS,
     },
-    std::cmp::Ordering,
-    std::{num::NonZeroU32, process::exit, rc::Rc},
+    std::{cmp::Ordering, num::NonZeroU32, process::exit, rc::Rc},
 };
-// use instruction::create_associated_token_account once ATA 1.0.5 is released
-#[allow(deprecated)]
-use spl_associated_token_account::create_associated_token_account;
 
 pub(crate) struct Config {
     rpc_client: RpcClient,

--- a/stake-pool/cli/src/output.rs
+++ b/stake-pool/cli/src/output.rs
@@ -1,8 +1,7 @@
 use {
     serde::{Deserialize, Serialize},
     solana_cli_output::{QuietDisplay, VerboseDisplay},
-    solana_sdk::native_token::Sol,
-    solana_sdk::{pubkey::Pubkey, stake::state::Lockup},
+    solana_sdk::{native_token::Sol, pubkey::Pubkey, stake::state::Lockup},
     spl_stake_pool::state::{
         Fee, PodStakeStatus, StakePool, StakeStatus, ValidatorList, ValidatorStakeInfo,
     },

--- a/stateless-asks/program/src/entrypoint.rs
+++ b/stateless-asks/program/src/entrypoint.rs
@@ -1,8 +1,9 @@
 #![cfg(all(target_os = "solana", not(feature = "no-entrypoint")))]
 
-use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
-
-use crate::processor::Processor;
+use {
+    crate::processor::Processor,
+    solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey},
+};
 
 solana_program::entrypoint!(process_instruction);
 fn process_instruction(

--- a/stateless-asks/program/src/error.rs
+++ b/stateless-asks/program/src/error.rs
@@ -1,6 +1,4 @@
-use thiserror::Error;
-
-use solana_program::program_error::ProgramError;
+use {solana_program::program_error::ProgramError, thiserror::Error};
 
 #[derive(Error, Debug, Copy, Clone)]
 pub enum UtilError {

--- a/stateless-asks/program/src/processor.rs
+++ b/stateless-asks/program/src/processor.rs
@@ -8,8 +8,7 @@ use {
     },
     borsh::BorshDeserialize,
     solana_program::{
-        account_info::next_account_info,
-        account_info::AccountInfo,
+        account_info::{next_account_info, AccountInfo},
         borsh0_10::try_from_slice_unchecked,
         entrypoint::ProgramResult,
         msg,

--- a/stateless-asks/program/src/validation_utils.rs
+++ b/stateless-asks/program/src/validation_utils.rs
@@ -1,14 +1,15 @@
-use super::error::UtilError;
-use solana_program::{
-    account_info::AccountInfo,
-    entrypoint::ProgramResult,
-    program_error::ProgramError,
-    program_pack::{IsInitialized, Pack},
-    pubkey::Pubkey,
+use {
+    super::error::UtilError,
+    solana_program::{
+        account_info::AccountInfo,
+        entrypoint::ProgramResult,
+        program_error::ProgramError,
+        program_pack::{IsInitialized, Pack},
+        pubkey::Pubkey,
+    },
+    spl_associated_token_account::get_associated_token_address,
+    spl_token::{self, state::Account},
 };
-use spl_associated_token_account::get_associated_token_address;
-use spl_token;
-use spl_token::state::Account;
 
 pub fn assert_is_ata(ata: &AccountInfo, wallet: &Pubkey, mint: &Pubkey) -> ProgramResult {
     assert_owned_by(ata, &spl_token::id())?;

--- a/token-lending/flash_loan_receiver/src/processor.rs
+++ b/token-lending/flash_loan_receiver/src/processor.rs
@@ -1,12 +1,13 @@
-use std::convert::TryInto;
-
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    entrypoint::ProgramResult,
-    msg,
-    program::invoke,
-    program_error::ProgramError,
-    pubkey::Pubkey,
+use {
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        msg,
+        program::invoke,
+        program_error::ProgramError,
+        pubkey::Pubkey,
+    },
+    std::convert::TryInto,
 };
 
 pub fn process_instruction(

--- a/token-lending/program/src/entrypoint.rs
+++ b/token-lending/program/src/entrypoint.rs
@@ -2,10 +2,12 @@
 
 #![cfg(all(target_os = "solana", not(feature = "no-entrypoint")))]
 
-use crate::{error::LendingError, processor};
-use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, program_error::PrintProgramError,
-    pubkey::Pubkey,
+use {
+    crate::{error::LendingError, processor},
+    solana_program::{
+        account_info::AccountInfo, entrypoint::ProgramResult, program_error::PrintProgramError,
+        pubkey::Pubkey,
+    },
 };
 
 solana_program::entrypoint!(process_instruction);

--- a/token-lending/program/src/error.rs
+++ b/token-lending/program/src/error.rs
@@ -1,8 +1,10 @@
 //! Error types
 
-use num_derive::FromPrimitive;
-use solana_program::{decode_error::DecodeError, program_error::ProgramError};
-use thiserror::Error;
+use {
+    num_derive::FromPrimitive,
+    solana_program::{decode_error::DecodeError, program_error::ProgramError},
+    thiserror::Error,
+};
 
 /// Errors that may be returned by the TokenLending program.
 #[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]

--- a/token-lending/program/src/instruction.rs
+++ b/token-lending/program/src/instruction.rs
@@ -1,17 +1,19 @@
 //! Instruction types
 
-use crate::{
-    error::LendingError,
-    state::{ReserveConfig, ReserveFees},
+use {
+    crate::{
+        error::LendingError,
+        state::{ReserveConfig, ReserveFees},
+    },
+    solana_program::{
+        instruction::{AccountMeta, Instruction},
+        msg,
+        program_error::ProgramError,
+        pubkey::{Pubkey, PUBKEY_BYTES},
+        sysvar,
+    },
+    std::{convert::TryInto, mem::size_of},
 };
-use solana_program::{
-    instruction::{AccountMeta, Instruction},
-    msg,
-    program_error::ProgramError,
-    pubkey::{Pubkey, PUBKEY_BYTES},
-    sysvar,
-};
-use std::{convert::TryInto, mem::size_of};
 
 /// Instructions supported by the lending program.
 #[derive(Clone, Debug, PartialEq)]

--- a/token-lending/program/src/math/decimal.rs
+++ b/token-lending/program/src/math/decimal.rs
@@ -12,13 +12,15 @@
 #![allow(clippy::ptr_offset_with_cast)]
 #![allow(clippy::manual_range_contains)]
 
-use crate::{
-    error::LendingError,
-    math::{common::*, Rate},
+use {
+    crate::{
+        error::LendingError,
+        math::{common::*, Rate},
+    },
+    solana_program::program_error::ProgramError,
+    std::{convert::TryFrom, fmt},
+    uint::construct_uint,
 };
-use solana_program::program_error::ProgramError;
-use std::{convert::TryFrom, fmt};
-use uint::construct_uint;
 
 // U192 with 192 bits consisting of 3 x 64-bit words
 construct_uint! {

--- a/token-lending/program/src/math/mod.rs
+++ b/token-lending/program/src/math/mod.rs
@@ -4,6 +4,4 @@ mod common;
 mod decimal;
 mod rate;
 
-pub use common::*;
-pub use decimal::*;
-pub use rate::*;
+pub use {common::*, decimal::*, rate::*};

--- a/token-lending/program/src/math/rate.rs
+++ b/token-lending/program/src/math/rate.rs
@@ -18,13 +18,15 @@
 #![allow(clippy::reversed_empty_ranges)]
 #![allow(clippy::manual_range_contains)]
 
-use crate::{
-    error::LendingError,
-    math::{common::*, decimal::Decimal},
+use {
+    crate::{
+        error::LendingError,
+        math::{common::*, decimal::Decimal},
+    },
+    solana_program::program_error::ProgramError,
+    std::{convert::TryFrom, fmt},
+    uint::construct_uint,
 };
-use solana_program::program_error::ProgramError;
-use std::{convert::TryFrom, fmt};
-use uint::construct_uint;
 
 // U128 with 128 bits consisting of 2 x 64-bit words
 construct_uint! {

--- a/token-lending/program/src/processor.rs
+++ b/token-lending/program/src/processor.rs
@@ -1,33 +1,37 @@
 //! Program state processor
 
-use crate::{
-    error::LendingError,
-    instruction::LendingInstruction,
-    math::{Decimal, Rate, TryAdd, TryDiv, TryMul},
-    pyth,
-    state::{
-        CalculateBorrowResult, CalculateLiquidationResult, CalculateRepayResult,
-        InitLendingMarketParams, InitObligationParams, InitReserveParams, LendingMarket,
-        NewReserveCollateralParams, NewReserveLiquidityParams, Obligation, Reserve,
-        ReserveCollateral, ReserveConfig, ReserveLiquidity,
+use {
+    crate::{
+        error::LendingError,
+        instruction::LendingInstruction,
+        math::{Decimal, Rate, TryAdd, TryDiv, TryMul},
+        pyth,
+        state::{
+            CalculateBorrowResult, CalculateLiquidationResult, CalculateRepayResult,
+            InitLendingMarketParams, InitObligationParams, InitReserveParams, LendingMarket,
+            NewReserveCollateralParams, NewReserveLiquidityParams, Obligation, Reserve,
+            ReserveCollateral, ReserveConfig, ReserveLiquidity,
+        },
     },
+    num_traits::FromPrimitive,
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        decode_error::DecodeError,
+        entrypoint::ProgramResult,
+        instruction::Instruction,
+        msg,
+        program::{invoke, invoke_signed},
+        program_error::{PrintProgramError, ProgramError},
+        program_pack::{IsInitialized, Pack},
+        pubkey::Pubkey,
+        sysvar::{clock::Clock, rent::Rent, Sysvar},
+    },
+    spl_token::{
+        solana_program::instruction::AccountMeta,
+        state::{Account, Mint},
+    },
+    std::convert::TryInto,
 };
-use num_traits::FromPrimitive;
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    decode_error::DecodeError,
-    entrypoint::ProgramResult,
-    instruction::Instruction,
-    msg,
-    program::{invoke, invoke_signed},
-    program_error::{PrintProgramError, ProgramError},
-    program_pack::{IsInitialized, Pack},
-    pubkey::Pubkey,
-    sysvar::{clock::Clock, rent::Rent, Sysvar},
-};
-use spl_token::solana_program::instruction::AccountMeta;
-use spl_token::state::{Account, Mint};
-use std::convert::TryInto;
 
 /// Processes an instruction
 pub fn process_instruction(

--- a/token-lending/program/src/state/last_update.rs
+++ b/token-lending/program/src/state/last_update.rs
@@ -1,6 +1,8 @@
-use crate::error::LendingError;
-use solana_program::{clock::Slot, program_error::ProgramError};
-use std::cmp::Ordering;
+use {
+    crate::error::LendingError,
+    solana_program::{clock::Slot, program_error::ProgramError},
+    std::cmp::Ordering,
+};
 
 /// Number of slots to consider stale after
 pub const STALE_AFTER_SLOTS_ELAPSED: u64 = 1;

--- a/token-lending/program/src/state/lending_market.rs
+++ b/token-lending/program/src/state/lending_market.rs
@@ -1,10 +1,12 @@
-use super::*;
-use arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs};
-use solana_program::{
-    msg,
-    program_error::ProgramError,
-    program_pack::{IsInitialized, Pack, Sealed},
-    pubkey::{Pubkey, PUBKEY_BYTES},
+use {
+    super::*,
+    arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs},
+    solana_program::{
+        msg,
+        program_error::ProgramError,
+        program_pack::{IsInitialized, Pack, Sealed},
+        pubkey::{Pubkey, PUBKEY_BYTES},
+    },
 };
 
 /// Lending market state

--- a/token-lending/program/src/state/mod.rs
+++ b/token-lending/program/src/state/mod.rs
@@ -5,17 +5,15 @@ mod lending_market;
 mod obligation;
 mod reserve;
 
-pub use last_update::*;
-pub use lending_market::*;
-pub use obligation::*;
-pub use reserve::*;
-
-use crate::math::{Decimal, WAD};
-use solana_program::{
-    clock::{DEFAULT_TICKS_PER_SECOND, DEFAULT_TICKS_PER_SLOT, SECONDS_PER_DAY},
-    msg,
-    program_error::ProgramError,
+use {
+    crate::math::{Decimal, WAD},
+    solana_program::{
+        clock::{DEFAULT_TICKS_PER_SECOND, DEFAULT_TICKS_PER_SLOT, SECONDS_PER_DAY},
+        msg,
+        program_error::ProgramError,
+    },
 };
+pub use {last_update::*, lending_market::*, obligation::*, reserve::*};
 
 /// Collateral tokens are initially valued at a ratio of 5:1 (collateral:liquidity)
 // @FIXME: restore to 5

--- a/token-lending/program/src/state/obligation.rs
+++ b/token-lending/program/src/state/obligation.rs
@@ -1,20 +1,22 @@
-use super::*;
-use crate::{
-    error::LendingError,
-    math::{Decimal, Rate, TryAdd, TryDiv, TryMul, TrySub},
-};
-use arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs};
-use solana_program::{
-    clock::Slot,
-    entrypoint::ProgramResult,
-    msg,
-    program_error::ProgramError,
-    program_pack::{IsInitialized, Pack, Sealed},
-    pubkey::{Pubkey, PUBKEY_BYTES},
-};
-use std::{
-    cmp::Ordering,
-    convert::{TryFrom, TryInto},
+use {
+    super::*,
+    crate::{
+        error::LendingError,
+        math::{Decimal, Rate, TryAdd, TryDiv, TryMul, TrySub},
+    },
+    arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs},
+    solana_program::{
+        clock::Slot,
+        entrypoint::ProgramResult,
+        msg,
+        program_error::ProgramError,
+        program_pack::{IsInitialized, Pack, Sealed},
+        pubkey::{Pubkey, PUBKEY_BYTES},
+    },
+    std::{
+        cmp::Ordering,
+        convert::{TryFrom, TryInto},
+    },
 };
 
 /// Max number of collateral and liquidity reserve accounts combined for an obligation
@@ -502,9 +504,7 @@ impl Pack for Obligation {
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::math::TryAdd;
-    use proptest::prelude::*;
+    use {super::*, crate::math::TryAdd, proptest::prelude::*};
 
     const MAX_COMPOUNDED_INTEREST: u64 = 100; // 10,000%
 

--- a/token-lending/program/src/state/reserve.rs
+++ b/token-lending/program/src/state/reserve.rs
@@ -1,20 +1,22 @@
-use super::*;
-use crate::{
-    error::LendingError,
-    math::{Decimal, Rate, TryAdd, TryDiv, TryMul, TrySub},
-};
-use arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs};
-use solana_program::{
-    clock::Slot,
-    entrypoint::ProgramResult,
-    msg,
-    program_error::ProgramError,
-    program_pack::{IsInitialized, Pack, Sealed},
-    pubkey::{Pubkey, PUBKEY_BYTES},
-};
-use std::{
-    cmp::Ordering,
-    convert::{TryFrom, TryInto},
+use {
+    super::*,
+    crate::{
+        error::LendingError,
+        math::{Decimal, Rate, TryAdd, TryDiv, TryMul, TrySub},
+    },
+    arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs},
+    solana_program::{
+        clock::Slot,
+        entrypoint::ProgramResult,
+        msg,
+        program_error::ProgramError,
+        program_pack::{IsInitialized, Pack, Sealed},
+        pubkey::{Pubkey, PUBKEY_BYTES},
+    },
+    std::{
+        cmp::Ordering,
+        convert::{TryFrom, TryInto},
+    },
 };
 
 /// Percentage of an obligation that can be repaid during each liquidation call
@@ -982,10 +984,12 @@ impl Pack for Reserve {
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::math::{PERCENT_SCALER, WAD};
-    use proptest::prelude::*;
-    use std::cmp::Ordering;
+    use {
+        super::*,
+        crate::math::{PERCENT_SCALER, WAD},
+        proptest::prelude::*,
+        std::cmp::Ordering,
+    };
 
     const MAX_LIQUIDITY: u64 = u64::MAX / 5;
 

--- a/token-lending/program/tests/borrow_obligation_liquidity.rs
+++ b/token-lending/program/tests/borrow_obligation_liquidity.rs
@@ -3,21 +3,23 @@
 
 mod helpers;
 
-use helpers::*;
-use solana_program_test::*;
-use solana_sdk::{
-    instruction::InstructionError,
-    signature::{Keypair, Signer},
-    transaction::{Transaction, TransactionError},
+use {
+    helpers::*,
+    solana_program_test::*,
+    solana_sdk::{
+        instruction::InstructionError,
+        signature::{Keypair, Signer},
+        transaction::{Transaction, TransactionError},
+    },
+    spl_token_lending::{
+        error::LendingError,
+        instruction::{borrow_obligation_liquidity, refresh_obligation},
+        math::Decimal,
+        processor::process_instruction,
+        state::{FeeCalculation, INITIAL_COLLATERAL_RATIO},
+    },
+    std::u64,
 };
-use spl_token_lending::{
-    error::LendingError,
-    instruction::{borrow_obligation_liquidity, refresh_obligation},
-    math::Decimal,
-    processor::process_instruction,
-    state::{FeeCalculation, INITIAL_COLLATERAL_RATIO},
-};
-use std::u64;
 
 #[tokio::test]
 async fn test_borrow_usdc_fixed_amount() {

--- a/token-lending/program/tests/deposit_obligation_collateral.rs
+++ b/token-lending/program/tests/deposit_obligation_collateral.rs
@@ -3,16 +3,18 @@
 
 mod helpers;
 
-use helpers::*;
-use solana_program_test::*;
-use solana_sdk::{
-    signature::{Keypair, Signer},
-    transaction::Transaction,
-};
-use spl_token::instruction::approve;
-use spl_token_lending::{
-    instruction::deposit_obligation_collateral, processor::process_instruction,
-    state::INITIAL_COLLATERAL_RATIO,
+use {
+    helpers::*,
+    solana_program_test::*,
+    solana_sdk::{
+        signature::{Keypair, Signer},
+        transaction::Transaction,
+    },
+    spl_token::instruction::approve,
+    spl_token_lending::{
+        instruction::deposit_obligation_collateral, processor::process_instruction,
+        state::INITIAL_COLLATERAL_RATIO,
+    },
 };
 
 #[tokio::test]

--- a/token-lending/program/tests/deposit_reserve_liquidity.rs
+++ b/token-lending/program/tests/deposit_reserve_liquidity.rs
@@ -3,10 +3,10 @@
 
 mod helpers;
 
-use helpers::*;
-use solana_program_test::*;
-use solana_sdk::signature::Keypair;
-use spl_token_lending::processor::process_instruction;
+use {
+    helpers::*, solana_program_test::*, solana_sdk::signature::Keypair,
+    spl_token_lending::processor::process_instruction,
+};
 
 #[tokio::test]
 async fn test_success() {

--- a/token-lending/program/tests/flash_loan.rs
+++ b/token-lending/program/tests/flash_loan.rs
@@ -3,17 +3,19 @@
 
 mod helpers;
 
-use helpers::*;
-use solana_program::instruction::AccountMeta;
-use solana_program_test::*;
-use solana_sdk::{
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-    transaction::{Transaction, TransactionError},
-};
-use spl_token::solana_program::instruction::InstructionError;
-use spl_token_lending::{
-    error::LendingError, instruction::flash_loan, processor::process_instruction,
+use {
+    helpers::*,
+    solana_program::instruction::AccountMeta,
+    solana_program_test::*,
+    solana_sdk::{
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        transaction::{Transaction, TransactionError},
+    },
+    spl_token::solana_program::instruction::InstructionError,
+    spl_token_lending::{
+        error::LendingError, instruction::flash_loan, processor::process_instruction,
+    },
 };
 
 #[tokio::test]

--- a/token-lending/program/tests/helpers/flash_loan_receiver.rs
+++ b/token-lending/program/tests/helpers/flash_loan_receiver.rs
@@ -1,16 +1,16 @@
-use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, msg, pubkey::Pubkey};
-
-use crate::helpers::flash_loan_receiver::FlashLoanReceiverError::InvalidInstruction;
-use spl_token::{
-    solana_program::{
-        account_info::next_account_info, program::invoke_signed, program_error::ProgramError,
-        program_pack::Pack,
+use {
+    crate::helpers::flash_loan_receiver::FlashLoanReceiverError::InvalidInstruction,
+    solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, msg, pubkey::Pubkey},
+    spl_token::{
+        solana_program::{
+            account_info::next_account_info, program::invoke_signed, program_error::ProgramError,
+            program_pack::Pack,
+        },
+        state::Account,
     },
-    state::Account,
+    std::{cmp::min, convert::TryInto},
+    thiserror::Error,
 };
-use std::cmp::min;
-use std::convert::TryInto;
-use thiserror::Error;
 
 pub enum FlashLoanReceiverInstruction {
     /// Receive a flash loan and perform user-defined operation and finally return the fund back.

--- a/token-lending/program/tests/helpers/mod.rs
+++ b/token-lending/program/tests/helpers/mod.rs
@@ -2,34 +2,36 @@
 
 pub mod flash_loan_receiver;
 
-use assert_matches::*;
-use solana_program::{program_option::COption, program_pack::Pack, pubkey::Pubkey};
-use solana_program_test::*;
-use solana_sdk::{
-    account::Account,
-    signature::{read_keypair_file, Keypair, Signer},
-    system_instruction::create_account,
-    transaction::{Transaction, TransactionError},
-};
-use spl_token::{
-    instruction::approve,
-    state::{Account as Token, AccountState, Mint},
-};
-use spl_token_lending::{
-    instruction::{
-        borrow_obligation_liquidity, deposit_reserve_liquidity, init_lending_market,
-        init_obligation, init_reserve, liquidate_obligation, refresh_reserve,
+use {
+    assert_matches::*,
+    solana_program::{program_option::COption, program_pack::Pack, pubkey::Pubkey},
+    solana_program_test::*,
+    solana_sdk::{
+        account::Account,
+        signature::{read_keypair_file, Keypair, Signer},
+        system_instruction::create_account,
+        transaction::{Transaction, TransactionError},
     },
-    math::{Decimal, Rate, TryAdd, TryMul},
-    pyth,
-    state::{
-        InitLendingMarketParams, InitObligationParams, InitReserveParams, LendingMarket,
-        NewReserveCollateralParams, NewReserveLiquidityParams, Obligation, ObligationCollateral,
-        ObligationLiquidity, Reserve, ReserveCollateral, ReserveConfig, ReserveFees,
-        ReserveLiquidity, INITIAL_COLLATERAL_RATIO, PROGRAM_VERSION,
+    spl_token::{
+        instruction::approve,
+        state::{Account as Token, AccountState, Mint},
     },
+    spl_token_lending::{
+        instruction::{
+            borrow_obligation_liquidity, deposit_reserve_liquidity, init_lending_market,
+            init_obligation, init_reserve, liquidate_obligation, refresh_reserve,
+        },
+        math::{Decimal, Rate, TryAdd, TryMul},
+        pyth,
+        state::{
+            InitLendingMarketParams, InitObligationParams, InitReserveParams, LendingMarket,
+            NewReserveCollateralParams, NewReserveLiquidityParams, Obligation,
+            ObligationCollateral, ObligationLiquidity, Reserve, ReserveCollateral, ReserveConfig,
+            ReserveFees, ReserveLiquidity, INITIAL_COLLATERAL_RATIO, PROGRAM_VERSION,
+        },
+    },
+    std::{convert::TryInto, str::FromStr},
 };
-use std::{convert::TryInto, str::FromStr};
 
 pub const QUOTE_CURRENCY: [u8; 32] =
     *b"USD\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";

--- a/token-lending/program/tests/init_lending_market.rs
+++ b/token-lending/program/tests/init_lending_market.rs
@@ -3,15 +3,17 @@
 
 mod helpers;
 
-use helpers::*;
-use solana_program_test::*;
-use solana_sdk::{
-    instruction::InstructionError,
-    signature::Signer,
-    transaction::{Transaction, TransactionError},
-};
-use spl_token_lending::{
-    error::LendingError, instruction::init_lending_market, processor::process_instruction,
+use {
+    helpers::*,
+    solana_program_test::*,
+    solana_sdk::{
+        instruction::InstructionError,
+        signature::Signer,
+        transaction::{Transaction, TransactionError},
+    },
+    spl_token_lending::{
+        error::LendingError, instruction::init_lending_market, processor::process_instruction,
+    },
 };
 
 #[tokio::test]

--- a/token-lending/program/tests/init_obligation.rs
+++ b/token-lending/program/tests/init_obligation.rs
@@ -3,15 +3,17 @@
 
 mod helpers;
 
-use helpers::*;
-use solana_program_test::*;
-use solana_sdk::{
-    instruction::InstructionError,
-    signature::{Keypair, Signer},
-    transaction::{Transaction, TransactionError},
-};
-use spl_token_lending::{
-    error::LendingError, instruction::init_obligation, processor::process_instruction,
+use {
+    helpers::*,
+    solana_program_test::*,
+    solana_sdk::{
+        instruction::InstructionError,
+        signature::{Keypair, Signer},
+        transaction::{Transaction, TransactionError},
+    },
+    spl_token_lending::{
+        error::LendingError, instruction::init_obligation, processor::process_instruction,
+    },
 };
 
 #[tokio::test]

--- a/token-lending/program/tests/init_reserve.rs
+++ b/token-lending/program/tests/init_reserve.rs
@@ -3,18 +3,20 @@
 
 mod helpers;
 
-use helpers::*;
-use solana_program_test::*;
-use solana_sdk::{
-    instruction::InstructionError,
-    signature::{Keypair, Signer},
-    transaction::{Transaction, TransactionError},
-};
-use spl_token_lending::{
-    error::LendingError,
-    instruction::init_reserve,
-    processor::process_instruction,
-    state::{ReserveFees, INITIAL_COLLATERAL_RATIO},
+use {
+    helpers::*,
+    solana_program_test::*,
+    solana_sdk::{
+        instruction::InstructionError,
+        signature::{Keypair, Signer},
+        transaction::{Transaction, TransactionError},
+    },
+    spl_token_lending::{
+        error::LendingError,
+        instruction::init_reserve,
+        processor::process_instruction,
+        state::{ReserveFees, INITIAL_COLLATERAL_RATIO},
+    },
 };
 
 #[tokio::test]

--- a/token-lending/program/tests/liquidate_obligation.rs
+++ b/token-lending/program/tests/liquidate_obligation.rs
@@ -3,17 +3,19 @@
 
 mod helpers;
 
-use helpers::*;
-use solana_program_test::*;
-use solana_sdk::{
-    signature::{Keypair, Signer},
-    transaction::Transaction,
-};
-use spl_token::instruction::approve;
-use spl_token_lending::{
-    instruction::{liquidate_obligation, refresh_obligation},
-    processor::process_instruction,
-    state::INITIAL_COLLATERAL_RATIO,
+use {
+    helpers::*,
+    solana_program_test::*,
+    solana_sdk::{
+        signature::{Keypair, Signer},
+        transaction::Transaction,
+    },
+    spl_token::instruction::approve,
+    spl_token_lending::{
+        instruction::{liquidate_obligation, refresh_obligation},
+        processor::process_instruction,
+        state::INITIAL_COLLATERAL_RATIO,
+    },
 };
 
 #[tokio::test]

--- a/token-lending/program/tests/modify_reserve_config.rs
+++ b/token-lending/program/tests/modify_reserve_config.rs
@@ -3,21 +3,23 @@
 
 mod helpers;
 
-use helpers::*;
-use solana_program::pubkey::Pubkey;
-use solana_program_test::*;
-use solana_sdk::{
-    instruction::InstructionError,
-    signature::{read_keypair_file, Keypair, Signer},
-    transaction::{Transaction, TransactionError},
-};
-use spl_token_lending::{
-    error::LendingError,
-    instruction::modify_reserve_config,
-    processor::process_instruction,
-    state::{
-        InitLendingMarketParams, LendingMarket, ReserveConfig, ReserveFees,
-        INITIAL_COLLATERAL_RATIO,
+use {
+    helpers::*,
+    solana_program::pubkey::Pubkey,
+    solana_program_test::*,
+    solana_sdk::{
+        instruction::InstructionError,
+        signature::{read_keypair_file, Keypair, Signer},
+        transaction::{Transaction, TransactionError},
+    },
+    spl_token_lending::{
+        error::LendingError,
+        instruction::modify_reserve_config,
+        processor::process_instruction,
+        state::{
+            InitLendingMarketParams, LendingMarket, ReserveConfig, ReserveFees,
+            INITIAL_COLLATERAL_RATIO,
+        },
     },
 };
 

--- a/token-lending/program/tests/obligation_end_to_end.rs
+++ b/token-lending/program/tests/obligation_end_to_end.rs
@@ -3,24 +3,26 @@
 
 mod helpers;
 
-use helpers::*;
-use solana_program_test::*;
-use solana_sdk::{
-    account::Account,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_token::{instruction::approve, solana_program::program_pack::Pack};
-use spl_token_lending::{
-    instruction::{
-        borrow_obligation_liquidity, deposit_obligation_collateral, init_obligation,
-        refresh_obligation, refresh_reserve, repay_obligation_liquidity,
-        withdraw_obligation_collateral,
+use {
+    helpers::*,
+    solana_program_test::*,
+    solana_sdk::{
+        account::Account,
+        signature::{Keypair, Signer},
+        system_instruction::create_account,
+        transaction::Transaction,
     },
-    math::Decimal,
-    processor::process_instruction,
-    state::{Obligation, INITIAL_COLLATERAL_RATIO},
+    spl_token::{instruction::approve, solana_program::program_pack::Pack},
+    spl_token_lending::{
+        instruction::{
+            borrow_obligation_liquidity, deposit_obligation_collateral, init_obligation,
+            refresh_obligation, refresh_reserve, repay_obligation_liquidity,
+            withdraw_obligation_collateral,
+        },
+        math::Decimal,
+        processor::process_instruction,
+        state::{Obligation, INITIAL_COLLATERAL_RATIO},
+    },
 };
 
 #[tokio::test]

--- a/token-lending/program/tests/redeem_reserve_collateral.rs
+++ b/token-lending/program/tests/redeem_reserve_collateral.rs
@@ -3,16 +3,18 @@
 
 mod helpers;
 
-use helpers::*;
-use solana_program_test::*;
-use solana_sdk::{
-    signature::{Keypair, Signer},
-    transaction::Transaction,
-};
-use spl_token::instruction::approve;
-use spl_token_lending::{
-    instruction::redeem_reserve_collateral, processor::process_instruction,
-    state::INITIAL_COLLATERAL_RATIO,
+use {
+    helpers::*,
+    solana_program_test::*,
+    solana_sdk::{
+        signature::{Keypair, Signer},
+        transaction::Transaction,
+    },
+    spl_token::instruction::approve,
+    spl_token_lending::{
+        instruction::redeem_reserve_collateral, processor::process_instruction,
+        state::INITIAL_COLLATERAL_RATIO,
+    },
 };
 
 #[tokio::test]

--- a/token-lending/program/tests/refresh_obligation.rs
+++ b/token-lending/program/tests/refresh_obligation.rs
@@ -3,19 +3,19 @@
 
 mod helpers;
 
-use helpers::*;
-use solana_program_test::*;
-use solana_sdk::{
-    signature::{Keypair, Signer},
-    transaction::Transaction,
-};
-use spl_token_lending::math::{Rate, TryAdd, TryMul};
-use spl_token_lending::state::SLOTS_PER_YEAR;
-use spl_token_lending::{
-    instruction::{refresh_obligation, refresh_reserve},
-    math::{Decimal, TryDiv},
-    processor::process_instruction,
-    state::INITIAL_COLLATERAL_RATIO,
+use {
+    helpers::*,
+    solana_program_test::*,
+    solana_sdk::{
+        signature::{Keypair, Signer},
+        transaction::Transaction,
+    },
+    spl_token_lending::{
+        instruction::{refresh_obligation, refresh_reserve},
+        math::{Decimal, Rate, TryAdd, TryDiv, TryMul},
+        processor::process_instruction,
+        state::{INITIAL_COLLATERAL_RATIO, SLOTS_PER_YEAR},
+    },
 };
 
 #[tokio::test]

--- a/token-lending/program/tests/refresh_reserve.rs
+++ b/token-lending/program/tests/refresh_reserve.rs
@@ -3,17 +3,19 @@
 
 mod helpers;
 
-use helpers::*;
-use solana_program_test::*;
-use solana_sdk::{
-    signature::{Keypair, Signer},
-    transaction::Transaction,
-};
-use spl_token_lending::{
-    instruction::refresh_reserve,
-    math::{Decimal, Rate, TryAdd, TryDiv, TryMul},
-    processor::process_instruction,
-    state::SLOTS_PER_YEAR,
+use {
+    helpers::*,
+    solana_program_test::*,
+    solana_sdk::{
+        signature::{Keypair, Signer},
+        transaction::Transaction,
+    },
+    spl_token_lending::{
+        instruction::refresh_reserve,
+        math::{Decimal, Rate, TryAdd, TryDiv, TryMul},
+        processor::process_instruction,
+        state::SLOTS_PER_YEAR,
+    },
 };
 
 #[tokio::test]

--- a/token-lending/program/tests/repay_obligation_liquidity.rs
+++ b/token-lending/program/tests/repay_obligation_liquidity.rs
@@ -3,17 +3,19 @@
 
 mod helpers;
 
-use helpers::*;
-use solana_program_test::*;
-use solana_sdk::{
-    signature::{Keypair, Signer},
-    transaction::Transaction,
-};
-use spl_token::instruction::approve;
-use spl_token_lending::instruction::refresh_obligation;
-use spl_token_lending::{
-    instruction::repay_obligation_liquidity, processor::process_instruction,
-    state::INITIAL_COLLATERAL_RATIO,
+use {
+    helpers::*,
+    solana_program_test::*,
+    solana_sdk::{
+        signature::{Keypair, Signer},
+        transaction::Transaction,
+    },
+    spl_token::instruction::approve,
+    spl_token_lending::{
+        instruction::{refresh_obligation, repay_obligation_liquidity},
+        processor::process_instruction,
+        state::INITIAL_COLLATERAL_RATIO,
+    },
 };
 
 #[tokio::test]

--- a/token-lending/program/tests/set_lending_market_owner.rs
+++ b/token-lending/program/tests/set_lending_market_owner.rs
@@ -3,19 +3,21 @@
 
 mod helpers;
 
-use helpers::*;
-use solana_program::instruction::{AccountMeta, Instruction};
-use solana_program_test::*;
-use solana_sdk::{
-    instruction::InstructionError,
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-    transaction::{Transaction, TransactionError},
-};
-use spl_token_lending::{
-    error::LendingError,
-    instruction::{set_lending_market_owner, LendingInstruction},
-    processor::process_instruction,
+use {
+    helpers::*,
+    solana_program::instruction::{AccountMeta, Instruction},
+    solana_program_test::*,
+    solana_sdk::{
+        instruction::InstructionError,
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        transaction::{Transaction, TransactionError},
+    },
+    spl_token_lending::{
+        error::LendingError,
+        instruction::{set_lending_market_owner, LendingInstruction},
+        processor::process_instruction,
+    },
 };
 
 #[tokio::test]

--- a/token-lending/program/tests/withdraw_obligation_collateral.rs
+++ b/token-lending/program/tests/withdraw_obligation_collateral.rs
@@ -3,20 +3,22 @@
 
 mod helpers;
 
-use helpers::*;
-use solana_program_test::*;
-use solana_sdk::{
-    instruction::InstructionError,
-    signature::{Keypair, Signer},
-    transaction::{Transaction, TransactionError},
+use {
+    helpers::*,
+    solana_program_test::*,
+    solana_sdk::{
+        instruction::InstructionError,
+        signature::{Keypair, Signer},
+        transaction::{Transaction, TransactionError},
+    },
+    spl_token_lending::{
+        error::LendingError,
+        instruction::{refresh_obligation, withdraw_obligation_collateral},
+        processor::process_instruction,
+        state::INITIAL_COLLATERAL_RATIO,
+    },
+    std::u64,
 };
-use spl_token_lending::{
-    error::LendingError,
-    instruction::{refresh_obligation, withdraw_obligation_collateral},
-    processor::process_instruction,
-    state::INITIAL_COLLATERAL_RATIO,
-};
-use std::u64;
 
 #[tokio::test]
 async fn test_withdraw_fixed_amount() {

--- a/token-metadata/interface/src/instruction.rs
+++ b/token-metadata/interface/src/instruction.rs
@@ -1,5 +1,7 @@
 //! Instruction types
 
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
 use {
     crate::state::Field,
     borsh::{BorshDeserialize, BorshSerialize},
@@ -11,9 +13,6 @@ use {
     spl_discriminator::{discriminator::ArrayDiscriminator, SplDiscriminate},
     spl_pod::optional_keys::OptionalNonZeroPubkey,
 };
-
-#[cfg(feature = "serde-traits")]
-use serde::{Deserialize, Serialize};
 
 /// Initialization instruction data
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
@@ -320,10 +319,9 @@ pub fn emit(
 
 #[cfg(test)]
 mod test {
-    use {super::*, crate::NAMESPACE, solana_program::hash};
-
     #[cfg(feature = "serde-traits")]
     use std::str::FromStr;
+    use {super::*, crate::NAMESPACE, solana_program::hash};
 
     fn check_pack_unpack<T: BorshSerialize>(
         instruction: TokenMetadataInstruction,

--- a/token-metadata/interface/src/lib.rs
+++ b/token-metadata/interface/src/lib.rs
@@ -9,9 +9,8 @@ pub mod instruction;
 pub mod state;
 
 // Export current sdk types for downstream users building with a different sdk version
-pub use solana_program;
 // Export borsh for downstream users
-pub use borsh;
+pub use {borsh, solana_program};
 
 /// Namespace for all programs implementing token-metadata
 pub const NAMESPACE: &str = "spl_token_metadata_interface";

--- a/token-metadata/interface/src/state.rs
+++ b/token-metadata/interface/src/state.rs
@@ -1,5 +1,7 @@
 //! Token-metadata interface state types
 
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
 use {
     borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
     solana_program::{
@@ -14,9 +16,6 @@ use {
         variable_len_pack::VariableLenPack,
     },
 };
-
-#[cfg(feature = "serde-traits")]
-use serde::{Deserialize, Serialize};
 
 /// Data struct for all token-metadata, stored in a TLV entry
 ///

--- a/token-swap/program/fuzz/src/native_processor.rs
+++ b/token-swap/program/fuzz/src/native_processor.rs
@@ -1,8 +1,9 @@
-use crate::native_account_data::NativeAccountData;
-
-use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, instruction::Instruction,
-    program_error::ProgramError, program_stubs, pubkey::Pubkey,
+use {
+    crate::native_account_data::NativeAccountData,
+    solana_program::{
+        account_info::AccountInfo, entrypoint::ProgramResult, instruction::Instruction,
+        program_error::ProgramError, program_stubs, pubkey::Pubkey,
+    },
 };
 
 struct TestSyscallStubs {}

--- a/token-swap/program/fuzz/src/native_token.rs
+++ b/token-swap/program/fuzz/src/native_token.rs
@@ -1,8 +1,8 @@
-use crate::native_account_data::NativeAccountData;
-
-use spl_token::state::{Account as TokenAccount, AccountState as TokenAccountState, Mint};
-
-use solana_program::{program_option::COption, program_pack::Pack, pubkey::Pubkey};
+use {
+    crate::native_account_data::NativeAccountData,
+    solana_program::{program_option::COption, program_pack::Pack, pubkey::Pubkey},
+    spl_token::state::{Account as TokenAccount, AccountState as TokenAccountState, Mint},
+};
 
 pub fn create_mint(owner: &Pubkey) -> NativeAccountData {
     let mut account_data = NativeAccountData::new(Mint::LEN, spl_token::id());

--- a/token-swap/program/fuzz/src/native_token_swap.rs
+++ b/token-swap/program/fuzz/src/native_token_swap.rs
@@ -1,21 +1,21 @@
 //! Helpers for working with swaps in a fuzzing environment
 
-use crate::native_account_data::NativeAccountData;
-use crate::native_processor::do_process_instruction;
-use crate::native_token;
-
-use spl_token_swap::{
-    curve::{base::SwapCurve, calculator::TradeDirection, fees::Fees},
-    instruction::{
-        self, DepositAllTokenTypes, DepositSingleTokenTypeExactAmountIn, Swap,
-        WithdrawAllTokenTypes, WithdrawSingleTokenTypeExactAmountOut,
+use {
+    crate::{
+        native_account_data::NativeAccountData, native_processor::do_process_instruction,
+        native_token,
     },
-    state::SwapVersion,
+    solana_program::{bpf_loader, entrypoint::ProgramResult, pubkey::Pubkey, system_program},
+    spl_token::instruction::approve,
+    spl_token_swap::{
+        curve::{base::SwapCurve, calculator::TradeDirection, fees::Fees},
+        instruction::{
+            self, DepositAllTokenTypes, DepositSingleTokenTypeExactAmountIn, Swap,
+            WithdrawAllTokenTypes, WithdrawSingleTokenTypeExactAmountOut,
+        },
+        state::SwapVersion,
+    },
 };
-
-use spl_token::instruction::approve;
-
-use solana_program::{bpf_loader, entrypoint::ProgramResult, pubkey::Pubkey, system_program};
 
 pub struct NativeTokenSwap {
     pub user_account: NativeAccountData,

--- a/token-swap/program/src/constraints.rs
+++ b/token-swap/program/src/constraints.rs
@@ -1,16 +1,17 @@
 //! Various constraints as required for production environments
 
-use crate::{
-    curve::{
-        base::{CurveType, SwapCurve},
-        fees::Fees,
-    },
-    error::SwapError,
-};
-use solana_program::program_error::ProgramError;
-
 #[cfg(feature = "production")]
 use std::env;
+use {
+    crate::{
+        curve::{
+            base::{CurveType, SwapCurve},
+            fees::Fees,
+        },
+        error::SwapError,
+    },
+    solana_program::program_error::ProgramError,
+};
 
 /// Encodes fee constraints, used in multihost environments where the program
 /// may be used by multiple frontends, to ensure that proper fees are being
@@ -98,9 +99,11 @@ pub const SWAP_CONSTRAINTS: Option<SwapConstraints> = {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::curve::{base::CurveType, constant_product::ConstantProductCurve};
-    use std::sync::Arc;
+    use {
+        super::*,
+        crate::curve::{base::CurveType, constant_product::ConstantProductCurve},
+        std::sync::Arc,
+    };
 
     #[test]
     fn validate_fees() {

--- a/token-swap/program/src/curve/base.rs
+++ b/token-swap/program/src/curve/base.rs
@@ -1,24 +1,26 @@
 //! Base curve implementation
 
-use solana_program::{
-    program_error::ProgramError,
-    program_pack::{Pack, Sealed},
-};
-
-use crate::curve::{
-    calculator::{CurveCalculator, RoundDirection, SwapWithoutFeesResult, TradeDirection},
-    constant_price::ConstantPriceCurve,
-    constant_product::ConstantProductCurve,
-    fees::Fees,
-    offset::OffsetCurve,
-};
-use arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs};
-use std::convert::{TryFrom, TryInto};
-use std::fmt::Debug;
-use std::sync::Arc;
-
 #[cfg(feature = "fuzz")]
 use arbitrary::Arbitrary;
+use {
+    crate::curve::{
+        calculator::{CurveCalculator, RoundDirection, SwapWithoutFeesResult, TradeDirection},
+        constant_price::ConstantPriceCurve,
+        constant_product::ConstantProductCurve,
+        fees::Fees,
+        offset::OffsetCurve,
+    },
+    arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs},
+    solana_program::{
+        program_error::ProgramError,
+        program_pack::{Pack, Sealed},
+    },
+    std::{
+        convert::{TryFrom, TryInto},
+        fmt::Debug,
+        sync::Arc,
+    },
+};
 
 /// Curve types supported by the token-swap program.
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
@@ -262,9 +264,7 @@ impl TryFrom<u8> for CurveType {
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::curve::calculator::test::total_and_intermediate;
-    use proptest::prelude::*;
+    use {super::*, crate::curve::calculator::test::total_and_intermediate, proptest::prelude::*};
 
     #[test]
     fn pack_swap_curve() {

--- a/token-swap/program/src/curve/calculator.rs
+++ b/token-swap/program/src/curve/calculator.rs
@@ -1,9 +1,8 @@
 //! Swap calculations
 
-use {crate::error::SwapError, spl_math::precise_number::PreciseNumber, std::fmt::Debug};
-
 #[cfg(feature = "fuzz")]
 use arbitrary::Arbitrary;
+use {crate::error::SwapError, spl_math::precise_number::PreciseNumber, std::fmt::Debug};
 
 /// Initial amount of pool tokens for swap contract, hard-coded to something
 /// "sensible" given a maximum of u128.
@@ -195,9 +194,7 @@ pub trait CurveCalculator: Debug + DynPack {
 /// Test helpers for curves
 #[cfg(test)]
 pub mod test {
-    use super::*;
-    use proptest::prelude::*;
-    use spl_math::uint::U256;
+    use {super::*, proptest::prelude::*, spl_math::uint::U256};
 
     /// The epsilon for most curves when performing the conversion test,
     /// comparing a one-sided deposit to a swap + deposit.

--- a/token-swap/program/src/curve/constant_price.rs
+++ b/token-swap/program/src/curve/constant_price.rs
@@ -262,16 +262,18 @@ impl DynPack for ConstantPriceCurve {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::curve::calculator::{
-        test::{
-            check_curve_value_from_swap, check_deposit_token_conversion,
-            check_withdraw_token_conversion, total_and_intermediate,
-            CONVERSION_BASIS_POINTS_GUARANTEE,
+    use {
+        super::*,
+        crate::curve::calculator::{
+            test::{
+                check_curve_value_from_swap, check_deposit_token_conversion,
+                check_withdraw_token_conversion, total_and_intermediate,
+                CONVERSION_BASIS_POINTS_GUARANTEE,
+            },
+            INITIAL_SWAP_POOL_AMOUNT,
         },
-        INITIAL_SWAP_POOL_AMOUNT,
+        proptest::prelude::*,
     };
-    use proptest::prelude::*;
 
     #[test]
     fn swap_calculation_no_price() {

--- a/token-swap/program/src/curve/constant_product.rs
+++ b/token-swap/program/src/curve/constant_product.rs
@@ -278,17 +278,19 @@ impl DynPack for ConstantProductCurve {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::curve::calculator::{
-        test::{
-            check_curve_value_from_swap, check_deposit_token_conversion,
-            check_pool_value_from_deposit, check_pool_value_from_withdraw,
-            check_withdraw_token_conversion, total_and_intermediate,
-            CONVERSION_BASIS_POINTS_GUARANTEE,
+    use {
+        super::*,
+        crate::curve::calculator::{
+            test::{
+                check_curve_value_from_swap, check_deposit_token_conversion,
+                check_pool_value_from_deposit, check_pool_value_from_withdraw,
+                check_withdraw_token_conversion, total_and_intermediate,
+                CONVERSION_BASIS_POINTS_GUARANTEE,
+            },
+            RoundDirection, INITIAL_SWAP_POOL_AMOUNT,
         },
-        RoundDirection, INITIAL_SWAP_POOL_AMOUNT,
+        proptest::prelude::*,
     };
-    use proptest::prelude::*;
 
     #[test]
     fn initial_pool_amount() {

--- a/token-swap/program/src/curve/fees.rs
+++ b/token-swap/program/src/curve/fees.rs
@@ -1,12 +1,14 @@
 //! All fee information, to be used for validation currently
 
-use crate::error::SwapError;
-use arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs};
-use solana_program::{
-    program_error::ProgramError,
-    program_pack::{IsInitialized, Pack, Sealed},
+use {
+    crate::error::SwapError,
+    arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs},
+    solana_program::{
+        program_error::ProgramError,
+        program_pack::{IsInitialized, Pack, Sealed},
+    },
+    std::convert::TryFrom,
 };
-use std::convert::TryFrom;
 
 /// Encapsulates all fee information and calculations for swap operations
 #[derive(Clone, Debug, Default, PartialEq)]

--- a/token-swap/program/src/curve/offset.rs
+++ b/token-swap/program/src/curve/offset.rs
@@ -186,17 +186,19 @@ impl DynPack for OffsetCurve {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::curve::calculator::{
-        test::{
-            check_curve_value_from_swap, check_deposit_token_conversion,
-            check_pool_value_from_deposit, check_pool_value_from_withdraw,
-            check_withdraw_token_conversion, total_and_intermediate,
-            CONVERSION_BASIS_POINTS_GUARANTEE,
+    use {
+        super::*,
+        crate::curve::calculator::{
+            test::{
+                check_curve_value_from_swap, check_deposit_token_conversion,
+                check_pool_value_from_deposit, check_pool_value_from_withdraw,
+                check_withdraw_token_conversion, total_and_intermediate,
+                CONVERSION_BASIS_POINTS_GUARANTEE,
+            },
+            INITIAL_SWAP_POOL_AMOUNT,
         },
-        INITIAL_SWAP_POOL_AMOUNT,
+        proptest::prelude::*,
     };
-    use proptest::prelude::*;
 
     #[test]
     fn pack_curve() {

--- a/token-swap/program/src/entrypoint.rs
+++ b/token-swap/program/src/entrypoint.rs
@@ -1,9 +1,11 @@
 //! Program entrypoint definitions
 
-use crate::{error::SwapError, processor::Processor};
-use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, program_error::PrintProgramError,
-    pubkey::Pubkey,
+use {
+    crate::{error::SwapError, processor::Processor},
+    solana_program::{
+        account_info::AccountInfo, entrypoint::ProgramResult, program_error::PrintProgramError,
+        pubkey::Pubkey,
+    },
 };
 
 solana_program::entrypoint!(process_instruction);

--- a/token-swap/program/src/error.rs
+++ b/token-swap/program/src/error.rs
@@ -1,12 +1,14 @@
 //! Error types
 
-use num_derive::FromPrimitive;
-use solana_program::{
-    decode_error::DecodeError,
-    msg,
-    program_error::{PrintProgramError, ProgramError},
+use {
+    num_derive::FromPrimitive,
+    solana_program::{
+        decode_error::DecodeError,
+        msg,
+        program_error::{PrintProgramError, ProgramError},
+    },
+    thiserror::Error,
 };
-use thiserror::Error;
 
 /// Errors that may be returned by the TokenSwap program.
 #[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]

--- a/token-swap/program/src/instruction.rs
+++ b/token-swap/program/src/instruction.rs
@@ -2,19 +2,21 @@
 
 #![allow(clippy::too_many_arguments)]
 
-use crate::curve::{base::SwapCurve, fees::Fees};
-use crate::error::SwapError;
-use solana_program::{
-    instruction::{AccountMeta, Instruction},
-    program_error::ProgramError,
-    program_pack::Pack,
-    pubkey::Pubkey,
-};
-use std::convert::TryInto;
-use std::mem::size_of;
-
 #[cfg(feature = "fuzz")]
 use arbitrary::Arbitrary;
+use {
+    crate::{
+        curve::{base::SwapCurve, fees::Fees},
+        error::SwapError,
+    },
+    solana_program::{
+        instruction::{AccountMeta, Instruction},
+        program_error::ProgramError,
+        program_pack::Pack,
+        pubkey::Pubkey,
+    },
+    std::{convert::TryInto, mem::size_of},
+};
 
 /// Initialize instruction data
 #[repr(C)]
@@ -613,9 +615,11 @@ pub fn unpack<T>(input: &[u8]) -> Result<&T, ProgramError> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::curve::{base::CurveType, offset::OffsetCurve};
-    use std::sync::Arc;
+    use {
+        super::*,
+        crate::curve::{base::CurveType, offset::OffsetCurve},
+        std::sync::Arc,
+    };
 
     #[test]
     fn pack_intialize() {

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -1,43 +1,45 @@
 //! Program state processor
 
-use crate::constraints::{SwapConstraints, SWAP_CONSTRAINTS};
-use crate::{
-    curve::{
-        base::SwapCurve,
-        calculator::{RoundDirection, TradeDirection},
-        fees::Fees,
+use {
+    crate::{
+        constraints::{SwapConstraints, SWAP_CONSTRAINTS},
+        curve::{
+            base::SwapCurve,
+            calculator::{RoundDirection, TradeDirection},
+            fees::Fees,
+        },
+        error::SwapError,
+        instruction::{
+            DepositAllTokenTypes, DepositSingleTokenTypeExactAmountIn, Initialize, Swap,
+            SwapInstruction, WithdrawAllTokenTypes, WithdrawSingleTokenTypeExactAmountOut,
+        },
+        state::{SwapState, SwapV1, SwapVersion},
     },
-    error::SwapError,
-    instruction::{
-        DepositAllTokenTypes, DepositSingleTokenTypeExactAmountIn, Initialize, Swap,
-        SwapInstruction, WithdrawAllTokenTypes, WithdrawSingleTokenTypeExactAmountOut,
+    num_traits::FromPrimitive,
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        clock::Clock,
+        decode_error::DecodeError,
+        entrypoint::ProgramResult,
+        instruction::Instruction,
+        msg,
+        program::invoke_signed,
+        program_error::{PrintProgramError, ProgramError},
+        program_option::COption,
+        pubkey::Pubkey,
+        sysvar::Sysvar,
     },
-    state::{SwapState, SwapV1, SwapVersion},
-};
-use num_traits::FromPrimitive;
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    clock::Clock,
-    decode_error::DecodeError,
-    entrypoint::ProgramResult,
-    instruction::Instruction,
-    msg,
-    program::invoke_signed,
-    program_error::{PrintProgramError, ProgramError},
-    program_option::COption,
-    pubkey::Pubkey,
-    sysvar::Sysvar,
-};
-use spl_token_2022::{
-    check_spl_token_program_account,
-    error::TokenError,
-    extension::{
-        mint_close_authority::MintCloseAuthority, transfer_fee::TransferFeeConfig,
-        BaseStateWithExtensions, StateWithExtensions,
+    spl_token_2022::{
+        check_spl_token_program_account,
+        error::TokenError,
+        extension::{
+            mint_close_authority::MintCloseAuthority, transfer_fee::TransferFeeConfig,
+            BaseStateWithExtensions, StateWithExtensions,
+        },
+        state::{Account, Mint},
     },
-    state::{Account, Mint},
+    std::{convert::TryInto, error::Error},
 };
-use std::{convert::TryInto, error::Error};
 
 /// Program state handler.
 pub struct Processor {}
@@ -1271,39 +1273,43 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::{
-        curve::calculator::{CurveCalculator, INITIAL_SWAP_POOL_AMOUNT},
-        curve::{
-            base::CurveType, constant_price::ConstantPriceCurve,
-            constant_product::ConstantProductCurve, offset::OffsetCurve,
+    use {
+        super::*,
+        crate::{
+            curve::{
+                base::CurveType,
+                calculator::{CurveCalculator, INITIAL_SWAP_POOL_AMOUNT},
+                constant_price::ConstantPriceCurve,
+                constant_product::ConstantProductCurve,
+                offset::OffsetCurve,
+            },
+            instruction::{
+                deposit_all_token_types, deposit_single_token_type_exact_amount_in, initialize,
+                swap, withdraw_all_token_types, withdraw_single_token_type_exact_amount_out,
+            },
         },
-        instruction::{
-            deposit_all_token_types, deposit_single_token_type_exact_amount_in, initialize, swap,
-            withdraw_all_token_types, withdraw_single_token_type_exact_amount_out,
+        solana_program::{
+            clock::Clock, entrypoint::SUCCESS, instruction::Instruction, program_pack::Pack,
+            program_stubs, rent::Rent,
         },
-    };
-    use solana_program::{
-        clock::Clock, entrypoint::SUCCESS, instruction::Instruction, program_pack::Pack,
-        program_stubs, rent::Rent,
-    };
-    use solana_sdk::account::{
-        create_account_for_test, create_is_signer_account_infos, Account as SolanaAccount,
-    };
-    use spl_token_2022::{
-        error::TokenError,
-        extension::{
-            transfer_fee::{instruction::initialize_transfer_fee_config, TransferFee},
-            ExtensionType,
+        solana_sdk::account::{
+            create_account_for_test, create_is_signer_account_infos, Account as SolanaAccount,
         },
-        instruction::{
-            approve, close_account, freeze_account, initialize_account, initialize_immutable_owner,
-            initialize_mint, initialize_mint_close_authority, mint_to, revoke, set_authority,
-            AuthorityType,
+        spl_token_2022::{
+            error::TokenError,
+            extension::{
+                transfer_fee::{instruction::initialize_transfer_fee_config, TransferFee},
+                ExtensionType,
+            },
+            instruction::{
+                approve, close_account, freeze_account, initialize_account,
+                initialize_immutable_owner, initialize_mint, initialize_mint_close_authority,
+                mint_to, revoke, set_authority, AuthorityType,
+            },
         },
+        std::sync::Arc,
+        test_case::test_case,
     };
-    use std::sync::Arc;
-    use test_case::test_case;
 
     // Test program id for the swap program.
     const SWAP_PROGRAM_ID: Pubkey = Pubkey::new_from_array([2u8; 32]);

--- a/token-swap/program/src/state.rs
+++ b/token-swap/program/src/state.rs
@@ -1,23 +1,25 @@
 //! State transition types
 
-use crate::{
-    curve::{base::SwapCurve, fees::Fees},
-    error::SwapError,
+use {
+    crate::{
+        curve::{base::SwapCurve, fees::Fees},
+        error::SwapError,
+    },
+    arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs},
+    enum_dispatch::enum_dispatch,
+    solana_program::{
+        account_info::AccountInfo,
+        msg,
+        program_error::ProgramError,
+        program_pack::{IsInitialized, Pack, Sealed},
+        pubkey::Pubkey,
+    },
+    spl_token_2022::{
+        extension::StateWithExtensions,
+        state::{Account, AccountState},
+    },
+    std::sync::Arc,
 };
-use arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs};
-use enum_dispatch::enum_dispatch;
-use solana_program::{
-    account_info::AccountInfo,
-    msg,
-    program_error::ProgramError,
-    program_pack::{IsInitialized, Pack, Sealed},
-    pubkey::Pubkey,
-};
-use spl_token_2022::{
-    extension::StateWithExtensions,
-    state::{Account, AccountState},
-};
-use std::sync::Arc;
 
 /// Trait representing access to program state across all versions
 #[enum_dispatch]
@@ -281,10 +283,7 @@ impl Pack for SwapV1 {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::curve::offset::OffsetCurve;
-
-    use std::convert::TryInto;
+    use {super::*, crate::curve::offset::OffsetCurve, std::convert::TryInto};
 
     const TEST_FEES: Fees = Fees {
         trade_fee_numerator: 1,

--- a/token/cli/src/config.rs
+++ b/token/cli/src/config.rs
@@ -1,28 +1,30 @@
-use crate::{signers_of, Error, MULTISIG_SIGNER_ARG};
-use clap::ArgMatches;
-use solana_clap_utils::{
-    input_parsers::{pubkey_of_signer, value_of},
-    input_validators::normalize_to_url_if_moniker,
-    keypair::{signer_from_path, signer_from_path_with_config, SignerFromPathConfig},
-    nonce::{NONCE_ARG, NONCE_AUTHORITY_ARG},
-    offline::{BLOCKHASH_ARG, DUMP_TRANSACTION_MESSAGE, SIGN_ONLY_ARG},
+use {
+    crate::{signers_of, Error, MULTISIG_SIGNER_ARG},
+    clap::ArgMatches,
+    solana_clap_utils::{
+        input_parsers::{pubkey_of_signer, value_of},
+        input_validators::normalize_to_url_if_moniker,
+        keypair::{signer_from_path, signer_from_path_with_config, SignerFromPathConfig},
+        nonce::{NONCE_ARG, NONCE_AUTHORITY_ARG},
+        offline::{BLOCKHASH_ARG, DUMP_TRANSACTION_MESSAGE, SIGN_ONLY_ARG},
+    },
+    solana_cli_output::OutputFormat,
+    solana_client::nonblocking::rpc_client::RpcClient,
+    solana_remote_wallet::remote_wallet::RemoteWalletManager,
+    solana_sdk::{
+        account::Account as RawAccount, commitment_config::CommitmentConfig, hash::Hash,
+        pubkey::Pubkey, signature::Signer,
+    },
+    spl_associated_token_account::*,
+    spl_token_2022::{
+        extension::StateWithExtensionsOwned,
+        state::{Account, Mint},
+    },
+    spl_token_client::client::{
+        ProgramClient, ProgramOfflineClient, ProgramRpcClient, ProgramRpcClientSendTransaction,
+    },
+    std::{process::exit, rc::Rc, sync::Arc},
 };
-use solana_cli_output::OutputFormat;
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_remote_wallet::remote_wallet::RemoteWalletManager;
-use solana_sdk::{
-    account::Account as RawAccount, commitment_config::CommitmentConfig, hash::Hash,
-    pubkey::Pubkey, signature::Signer,
-};
-use spl_associated_token_account::*;
-use spl_token_2022::{
-    extension::StateWithExtensionsOwned,
-    state::{Account, Mint},
-};
-use spl_token_client::client::{
-    ProgramClient, ProgramOfflineClient, ProgramRpcClient, ProgramRpcClientSendTransaction,
-};
-use std::{process::exit, rc::Rc, sync::Arc};
 
 pub(crate) struct MintInfo {
     pub program_id: Pubkey,

--- a/token/cli/src/output.rs
+++ b/token/cli/src/output.rs
@@ -1,18 +1,20 @@
-use crate::{config::Config, sort::UnsupportedAccount};
-use console::{style, Emoji};
-use serde::{Deserialize, Serialize, Serializer};
-use solana_account_decoder::{
-    parse_token::{UiAccountState, UiMint, UiMultisig, UiTokenAccount, UiTokenAmount},
-    parse_token_extension::{
-        UiConfidentialTransferAccount, UiConfidentialTransferFeeAmount,
-        UiConfidentialTransferFeeConfig, UiConfidentialTransferMint, UiCpiGuard,
-        UiDefaultAccountState, UiExtension, UiInterestBearingConfig, UiMemoTransfer,
-        UiMetadataPointer, UiMintCloseAuthority, UiPermanentDelegate, UiTokenMetadata,
-        UiTransferFeeAmount, UiTransferFeeConfig, UiTransferHook, UiTransferHookAccount,
+use {
+    crate::{config::Config, sort::UnsupportedAccount},
+    console::{style, Emoji},
+    serde::{Deserialize, Serialize, Serializer},
+    solana_account_decoder::{
+        parse_token::{UiAccountState, UiMint, UiMultisig, UiTokenAccount, UiTokenAmount},
+        parse_token_extension::{
+            UiConfidentialTransferAccount, UiConfidentialTransferFeeAmount,
+            UiConfidentialTransferFeeConfig, UiConfidentialTransferMint, UiCpiGuard,
+            UiDefaultAccountState, UiExtension, UiInterestBearingConfig, UiMemoTransfer,
+            UiMetadataPointer, UiMintCloseAuthority, UiPermanentDelegate, UiTokenMetadata,
+            UiTransferFeeAmount, UiTransferFeeConfig, UiTransferHook, UiTransferHookAccount,
+        },
     },
+    solana_cli_output::{display::writeln_name_value, OutputFormat, QuietDisplay, VerboseDisplay},
+    std::fmt::{self, Display},
 };
-use solana_cli_output::{display::writeln_name_value, OutputFormat, QuietDisplay, VerboseDisplay};
-use std::fmt::{self, Display};
 
 pub(crate) trait Output: Serialize + fmt::Display + QuietDisplay + VerboseDisplay {}
 

--- a/token/cli/src/sort.rs
+++ b/token/cli/src/sort.rs
@@ -1,15 +1,17 @@
-use crate::{
-    output::{CliTokenAccount, CliTokenAccounts},
-    Error,
-};
-use serde::{Deserialize, Serialize};
-use solana_account_decoder::{parse_token::TokenAccountType, UiAccountData};
-use solana_client::rpc_response::RpcKeyedAccount;
-use solana_sdk::pubkey::Pubkey;
-use spl_associated_token_account::get_associated_token_address_with_program_id;
-use std::{
-    collections::{btree_map::Entry, BTreeMap},
-    str::FromStr,
+use {
+    crate::{
+        output::{CliTokenAccount, CliTokenAccounts},
+        Error,
+    },
+    serde::{Deserialize, Serialize},
+    solana_account_decoder::{parse_token::TokenAccountType, UiAccountData},
+    solana_client::rpc_response::RpcKeyedAccount,
+    solana_sdk::pubkey::Pubkey,
+    spl_associated_token_account::get_associated_token_address_with_program_id,
+    std::{
+        collections::{btree_map::Entry, BTreeMap},
+        str::FromStr,
+    },
 };
 
 #[derive(Serialize, Deserialize)]

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -19,8 +19,10 @@ use {
         transaction::Transaction,
     },
     spl_associated_token_account::{
-        get_associated_token_address_with_program_id, instruction::create_associated_token_account,
-        instruction::create_associated_token_account_idempotent,
+        get_associated_token_address_with_program_id,
+        instruction::{
+            create_associated_token_account, create_associated_token_account_idempotent,
+        },
     },
     spl_token_2022::{
         extension::{

--- a/token/program-2022/src/extension/confidential_transfer/ciphertext_extraction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/ciphertext_extraction.rs
@@ -24,7 +24,6 @@ use crate::{
         },
     },
 };
-
 #[cfg(feature = "serde-traits")]
 use {
     crate::serialization::decrypthandle_fromstr,

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -3,6 +3,11 @@ use solana_zk_token_sdk::encryption::auth_encryption::AeCiphertext;
 pub use solana_zk_token_sdk::{
     zk_token_proof_instruction::*, zk_token_proof_state::ProofContextState,
 };
+#[cfg(feature = "serde-traits")]
+use {
+    crate::serialization::aeciphertext_fromstr,
+    serde::{Deserialize, Serialize},
+};
 use {
     crate::{
         check_program_account,
@@ -18,12 +23,6 @@ use {
         pubkey::Pubkey,
         sysvar,
     },
-};
-
-#[cfg(feature = "serde-traits")]
-use {
-    crate::serialization::aeciphertext_fromstr,
-    serde::{Deserialize, Serialize},
 };
 
 /// Confidential Transfer extension instructions

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -1,3 +1,9 @@
+// Remove feature once zk ops syscalls are enabled on all networks
+#[cfg(feature = "zk-ops")]
+use {
+    crate::extension::non_transferable::NonTransferable,
+    solana_zk_token_sdk::zk_token_elgamal::ops as syscall,
+};
 use {
     crate::{
         check_program_account,
@@ -25,12 +31,6 @@ use {
         pubkey::Pubkey,
         sysvar::Sysvar,
     },
-};
-// Remove feature once zk ops syscalls are enabled on all networks
-#[cfg(feature = "zk-ops")]
-use {
-    crate::extension::non_transferable::NonTransferable,
-    solana_zk_token_sdk::zk_token_elgamal::ops as syscall,
 };
 
 /// Processes an [InitializeMint] instruction.

--- a/token/program-2022/src/extension/confidential_transfer_fee/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer_fee/instruction.rs
@@ -1,3 +1,8 @@
+#[cfg(feature = "serde-traits")]
+use {
+    crate::serialization::{aeciphertext_fromstr, elgamalpubkey_fromstr},
+    serde::{Deserialize, Serialize},
+};
 use {
     crate::{
         check_program_account,
@@ -22,12 +27,6 @@ use {
     },
     spl_pod::optional_keys::OptionalNonZeroPubkey,
     std::convert::TryFrom,
-};
-
-#[cfg(feature = "serde-traits")]
-use {
-    crate::serialization::{aeciphertext_fromstr, elgamalpubkey_fromstr},
-    serde::{Deserialize, Serialize},
 };
 
 /// Confidential Transfer extension instructions

--- a/token/program-2022/src/extension/confidential_transfer_fee/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer_fee/processor.rs
@@ -1,3 +1,6 @@
+// Remove feature once zk ops syscalls are enabled on all networks
+#[cfg(feature = "zk-ops")]
+use solana_zk_token_sdk::zk_token_elgamal::ops as syscall;
 use {
     crate::{
         check_program_account, check_zk_token_proof_program_account,
@@ -40,10 +43,6 @@ use {
     },
     spl_pod::{bytemuck::pod_from_bytes, optional_keys::OptionalNonZeroPubkey},
 };
-
-// Remove feature once zk ops syscalls are enabled on all networks
-#[cfg(feature = "zk-ops")]
-use solana_zk_token_sdk::zk_token_elgamal::ops as syscall;
 
 /// Processes an [InitializeConfidentialTransferFeeConfig] instruction.
 fn process_initialize_confidential_transfer_fee_config(

--- a/token/program-2022/src/extension/cpi_guard/instruction.rs
+++ b/token/program-2022/src/extension/cpi_guard/instruction.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
 use {
     crate::{
         check_program_account,
@@ -10,9 +12,6 @@ use {
         pubkey::Pubkey,
     },
 };
-
-#[cfg(feature = "serde-traits")]
-use serde::{Deserialize, Serialize};
 
 /// CPI Guard extension instructions
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]

--- a/token/program-2022/src/extension/cpi_guard/mod.rs
+++ b/token/program-2022/src/extension/cpi_guard/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
 use {
     crate::{
         extension::{BaseStateWithExtensions, Extension, ExtensionType, StateWithExtensionsMut},
@@ -7,9 +9,6 @@ use {
     solana_program::instruction::{get_stack_height, TRANSACTION_LEVEL_STACK_HEIGHT},
     spl_pod::primitives::PodBool,
 };
-
-#[cfg(feature = "serde-traits")]
-use serde::{Deserialize, Serialize};
 
 /// CPI Guard extension instructions
 pub mod instruction;

--- a/token/program-2022/src/extension/default_account_state/instruction.rs
+++ b/token/program-2022/src/extension/default_account_state/instruction.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
 use {
     crate::{
         check_program_account, error::TokenError, instruction::TokenInstruction,
@@ -11,9 +13,6 @@ use {
     },
     std::convert::TryFrom,
 };
-
-#[cfg(feature = "serde-traits")]
-use serde::{Deserialize, Serialize};
 
 /// Default Account State extension instructions
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]

--- a/token/program-2022/src/extension/default_account_state/mod.rs
+++ b/token/program-2022/src/extension/default_account_state/mod.rs
@@ -1,10 +1,9 @@
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
 use {
     crate::extension::{Extension, ExtensionType},
     bytemuck::{Pod, Zeroable},
 };
-
-#[cfg(feature = "serde-traits")]
-use serde::{Deserialize, Serialize};
 
 /// Default Account state extension instructions
 pub mod instruction;

--- a/token/program-2022/src/extension/group_pointer/instruction.rs
+++ b/token/program-2022/src/extension/group_pointer/instruction.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
 use {
     crate::{
         check_program_account,
@@ -13,9 +15,6 @@ use {
     spl_pod::optional_keys::OptionalNonZeroPubkey,
     std::convert::TryInto,
 };
-
-#[cfg(feature = "serde-traits")]
-use serde::{Deserialize, Serialize};
 
 /// Group pointer extension instructions
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]

--- a/token/program-2022/src/extension/group_pointer/mod.rs
+++ b/token/program-2022/src/extension/group_pointer/mod.rs
@@ -1,11 +1,10 @@
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
 use {
     crate::extension::{Extension, ExtensionType},
     bytemuck::{Pod, Zeroable},
     spl_pod::optional_keys::OptionalNonZeroPubkey,
 };
-
-#[cfg(feature = "serde-traits")]
-use serde::{Deserialize, Serialize};
 
 /// Instructions for the GroupPointer extension
 pub mod instruction;

--- a/token/program-2022/src/extension/immutable_owner.rs
+++ b/token/program-2022/src/extension/immutable_owner.rs
@@ -1,10 +1,9 @@
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
 use {
     crate::extension::{Extension, ExtensionType},
     bytemuck::{Pod, Zeroable},
 };
-
-#[cfg(feature = "serde-traits")]
-use serde::{Deserialize, Serialize};
 
 /// Indicates that the Account owner authority cannot be changed
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]

--- a/token/program-2022/src/extension/interest_bearing_mint/instruction.rs
+++ b/token/program-2022/src/extension/interest_bearing_mint/instruction.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
 use {
     crate::{
         check_program_account,
@@ -14,9 +16,6 @@ use {
     spl_pod::optional_keys::OptionalNonZeroPubkey,
     std::convert::TryInto,
 };
-
-#[cfg(feature = "serde-traits")]
-use serde::{Deserialize, Serialize};
 
 /// Interesting-bearing mint extension instructions
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]

--- a/token/program-2022/src/extension/interest_bearing_mint/mod.rs
+++ b/token/program-2022/src/extension/interest_bearing_mint/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
 use {
     crate::extension::{Extension, ExtensionType},
     bytemuck::{Pod, Zeroable},
@@ -8,9 +10,6 @@ use {
     },
     std::convert::TryInto,
 };
-
-#[cfg(feature = "serde-traits")]
-use serde::{Deserialize, Serialize};
 
 /// Interest-bearing mint extension instructions
 pub mod instruction;

--- a/token/program-2022/src/extension/memo_transfer/instruction.rs
+++ b/token/program-2022/src/extension/memo_transfer/instruction.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
 use {
     crate::{
         check_program_account,
@@ -10,9 +12,6 @@ use {
         pubkey::Pubkey,
     },
 };
-
-#[cfg(feature = "serde-traits")]
-use serde::{Deserialize, Serialize};
 
 /// Required Memo Transfers extension instructions
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]

--- a/token/program-2022/src/extension/memo_transfer/mod.rs
+++ b/token/program-2022/src/extension/memo_transfer/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
 use {
     crate::{
         error::TokenError,
@@ -10,9 +12,6 @@ use {
     },
     spl_pod::primitives::PodBool,
 };
-
-#[cfg(feature = "serde-traits")]
-use serde::{Deserialize, Serialize};
 
 /// Memo Transfer extension instructions
 pub mod instruction;

--- a/token/program-2022/src/extension/metadata_pointer/instruction.rs
+++ b/token/program-2022/src/extension/metadata_pointer/instruction.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
 use {
     crate::{
         check_program_account,
@@ -13,9 +15,6 @@ use {
     spl_pod::optional_keys::OptionalNonZeroPubkey,
     std::convert::TryInto,
 };
-
-#[cfg(feature = "serde-traits")]
-use serde::{Deserialize, Serialize};
 
 /// Metadata pointer extension instructions
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]

--- a/token/program-2022/src/extension/metadata_pointer/mod.rs
+++ b/token/program-2022/src/extension/metadata_pointer/mod.rs
@@ -1,11 +1,10 @@
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
 use {
     crate::extension::{Extension, ExtensionType},
     bytemuck::{Pod, Zeroable},
     spl_pod::optional_keys::OptionalNonZeroPubkey,
 };
-
-#[cfg(feature = "serde-traits")]
-use serde::{Deserialize, Serialize};
 
 /// Instructions for the MetadataPointer extension
 pub mod instruction;

--- a/token/program-2022/src/extension/mint_close_authority.rs
+++ b/token/program-2022/src/extension/mint_close_authority.rs
@@ -1,11 +1,10 @@
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
 use {
     crate::extension::{Extension, ExtensionType},
     bytemuck::{Pod, Zeroable},
     spl_pod::optional_keys::OptionalNonZeroPubkey,
 };
-
-#[cfg(feature = "serde-traits")]
-use serde::{Deserialize, Serialize};
 
 /// Close authority extension data for mints.
 #[repr(C)]

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -1,5 +1,7 @@
 //! Extensions available to token mints and accounts
 
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
 use {
     crate::{
         error::TokenError,
@@ -41,9 +43,6 @@ use {
         mem::size_of,
     },
 };
-
-#[cfg(feature = "serde-traits")]
-use serde::{Deserialize, Serialize};
 
 /// Confidential Transfer extension
 pub mod confidential_transfer;

--- a/token/program-2022/src/extension/non_transferable.rs
+++ b/token/program-2022/src/extension/non_transferable.rs
@@ -1,10 +1,9 @@
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
 use {
     crate::extension::{Extension, ExtensionType},
     bytemuck::{Pod, Zeroable},
 };
-
-#[cfg(feature = "serde-traits")]
-use serde::{Deserialize, Serialize};
 
 /// Indicates that the tokens from this mint can't be transfered
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]

--- a/token/program-2022/src/extension/permanent_delegate.rs
+++ b/token/program-2022/src/extension/permanent_delegate.rs
@@ -1,12 +1,11 @@
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
 use {
     crate::extension::{BaseState, BaseStateWithExtensions, Extension, ExtensionType},
     bytemuck::{Pod, Zeroable},
     solana_program::pubkey::Pubkey,
     spl_pod::optional_keys::OptionalNonZeroPubkey,
 };
-
-#[cfg(feature = "serde-traits")]
-use serde::{Deserialize, Serialize};
 
 /// Permanent delegate extension data for mints.
 #[repr(C)]

--- a/token/program-2022/src/extension/transfer_fee/instruction.rs
+++ b/token/program-2022/src/extension/transfer_fee/instruction.rs
@@ -1,3 +1,8 @@
+#[cfg(feature = "serde-traits")]
+use {
+    crate::serialization::coption_fromstr,
+    serde::{Deserialize, Serialize},
+};
 use {
     crate::{check_program_account, error::TokenError, instruction::TokenInstruction},
     solana_program::{
@@ -7,12 +12,6 @@ use {
         pubkey::Pubkey,
     },
     std::convert::TryFrom,
-};
-
-#[cfg(feature = "serde-traits")]
-use {
-    crate::serialization::coption_fromstr,
-    serde::{Deserialize, Serialize},
 };
 
 /// Transfer Fee extension instructions

--- a/token/program-2022/src/extension/transfer_fee/mod.rs
+++ b/token/program-2022/src/extension/transfer_fee/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
 use {
     crate::{
         error::TokenError,
@@ -14,9 +16,6 @@ use {
         convert::{TryFrom, TryInto},
     },
 };
-
-#[cfg(feature = "serde-traits")]
-use serde::{Deserialize, Serialize};
 
 /// Transfer fee extension instructions
 pub mod instruction;

--- a/token/program-2022/src/extension/transfer_hook/instruction.rs
+++ b/token/program-2022/src/extension/transfer_hook/instruction.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
 use {
     crate::{
         check_program_account,
@@ -13,9 +15,6 @@ use {
     spl_pod::optional_keys::OptionalNonZeroPubkey,
     std::convert::TryInto,
 };
-
-#[cfg(feature = "serde-traits")]
-use serde::{Deserialize, Serialize};
 
 /// Transfer hook extension instructions
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]

--- a/token/program-2022/src/extension/transfer_hook/mod.rs
+++ b/token/program-2022/src/extension/transfer_hook/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
 use {
     crate::{
         extension::{
@@ -9,9 +11,6 @@ use {
     solana_program::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey},
     spl_pod::{optional_keys::OptionalNonZeroPubkey, primitives::PodBool},
 };
-
-#[cfg(feature = "serde-traits")]
-use serde::{Deserialize, Serialize};
 
 /// Instructions for the TransferHook extension
 pub mod instruction;

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -2,6 +2,12 @@
 
 #![allow(deprecated)] // needed to avoid deprecation warning when generating serde implementation for TokenInstruction
 
+#[cfg(feature = "serde-traits")]
+use {
+    crate::serialization::coption_fromstr,
+    serde::{Deserialize, Serialize},
+    serde_with::{As, DisplayFromStr},
+};
 use {
     crate::{
         check_program_account, check_spl_token_program_account,
@@ -21,13 +27,6 @@ use {
         convert::{TryFrom, TryInto},
         mem::size_of,
     },
-};
-
-#[cfg(feature = "serde-traits")]
-use {
-    crate::serialization::coption_fromstr,
-    serde::{Deserialize, Serialize},
-    serde_with::{As, DisplayFromStr},
 };
 
 /// Minimum number of multisignature signers (min N)

--- a/token/program-2022/src/lib.rs
+++ b/token/program-2022/src/lib.rs
@@ -21,7 +21,6 @@ pub mod state;
 mod entrypoint;
 
 // Export current sdk types for downstream users building with a different sdk version
-pub use solana_program;
 use solana_program::{
     entrypoint::ProgramResult,
     program_error::ProgramError,
@@ -29,7 +28,7 @@ use solana_program::{
     pubkey::{Pubkey, PUBKEY_BYTES},
     system_program,
 };
-pub use solana_zk_token_sdk;
+pub use {solana_program, solana_zk_token_sdk};
 
 /// Convert the UI representation of a token amount (using the decimals field defined in its mint)
 /// to the raw amount

--- a/token/program-2022/src/state.rs
+++ b/token/program-2022/src/state.rs
@@ -311,8 +311,7 @@ impl GenericTokenAccount for Account {
 
 #[cfg(test)]
 pub(crate) mod test {
-    use super::*;
-    use crate::generic_token_account::ACCOUNT_INITIALIZED_INDEX;
+    use {super::*, crate::generic_token_account::ACCOUNT_INITIALIZED_INDEX};
 
     pub const TEST_MINT: Mint = Mint {
         mint_authority: COption::Some(Pubkey::new_from_array([1; 32])),

--- a/token/program/src/entrypoint.rs
+++ b/token/program/src/entrypoint.rs
@@ -1,9 +1,11 @@
 //! Program entrypoint
 
-use crate::{error::TokenError, processor::Processor};
-use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, program_error::PrintProgramError,
-    pubkey::Pubkey,
+use {
+    crate::{error::TokenError, processor::Processor},
+    solana_program::{
+        account_info::AccountInfo, entrypoint::ProgramResult, program_error::PrintProgramError,
+        pubkey::Pubkey,
+    },
 };
 
 solana_program::entrypoint!(process_instruction);

--- a/token/program/src/error.rs
+++ b/token/program/src/error.rs
@@ -1,12 +1,14 @@
 //! Error types
 
-use num_derive::FromPrimitive;
-use solana_program::{
-    decode_error::DecodeError,
-    msg,
-    program_error::{PrintProgramError, ProgramError},
+use {
+    num_derive::FromPrimitive,
+    solana_program::{
+        decode_error::DecodeError,
+        msg,
+        program_error::{PrintProgramError, ProgramError},
+    },
+    thiserror::Error,
 };
-use thiserror::Error;
 
 /// Errors that may be returned by the Token program.
 #[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]

--- a/token/program/src/instruction.rs
+++ b/token/program/src/instruction.rs
@@ -1,15 +1,16 @@
 //! Instruction types
 
-use crate::{check_program_account, error::TokenError};
-use solana_program::{
-    instruction::{AccountMeta, Instruction},
-    program_error::ProgramError,
-    program_option::COption,
-    pubkey::Pubkey,
-    sysvar,
+use {
+    crate::{check_program_account, error::TokenError},
+    solana_program::{
+        instruction::{AccountMeta, Instruction},
+        program_error::ProgramError,
+        program_option::COption,
+        pubkey::Pubkey,
+        sysvar,
+    },
+    std::{convert::TryInto, mem::size_of},
 };
-use std::convert::TryInto;
-use std::mem::size_of;
 
 /// Minimum number of multisignature signers (min N)
 pub const MIN_SIGNERS: usize = 1;

--- a/token/program/src/native_mint.rs
+++ b/token/program/src/native_mint.rs
@@ -8,8 +8,7 @@ solana_program::declare_id!("So11111111111111111111111111111111111111112");
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use solana_program::native_token::*;
+    use {super::*, solana_program::native_token::*};
 
     #[test]
     fn test_decimals() {

--- a/token/program/src/processor.rs
+++ b/token/program/src/processor.rs
@@ -1,24 +1,26 @@
 //! Program state processor
 
-use crate::{
-    amount_to_ui_amount_string_trimmed,
-    error::TokenError,
-    instruction::{is_valid_signer_index, AuthorityType, TokenInstruction, MAX_SIGNERS},
-    state::{Account, AccountState, Mint, Multisig},
-    try_ui_amount_into_amount,
-};
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    entrypoint::ProgramResult,
-    msg,
-    program::set_return_data,
-    program_error::ProgramError,
-    program_memory::sol_memcmp,
-    program_option::COption,
-    program_pack::{IsInitialized, Pack},
-    pubkey::{Pubkey, PUBKEY_BYTES},
-    system_program,
-    sysvar::{rent::Rent, Sysvar},
+use {
+    crate::{
+        amount_to_ui_amount_string_trimmed,
+        error::TokenError,
+        instruction::{is_valid_signer_index, AuthorityType, TokenInstruction, MAX_SIGNERS},
+        state::{Account, AccountState, Mint, Multisig},
+        try_ui_amount_into_amount,
+    },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        msg,
+        program::set_return_data,
+        program_error::ProgramError,
+        program_memory::sol_memcmp,
+        program_option::COption,
+        program_pack::{IsInitialized, Pack},
+        pubkey::{Pubkey, PUBKEY_BYTES},
+        system_program,
+        sysvar::{rent::Rent, Sysvar},
+    },
 };
 
 /// Program state handler.
@@ -1028,20 +1030,22 @@ fn delete_account(account_info: &AccountInfo) -> Result<(), ProgramError> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::instruction::*;
-    use serial_test::serial;
-    use solana_program::{
-        account_info::IntoAccountInfo,
-        clock::Epoch,
-        instruction::Instruction,
-        program_error::{self, PrintProgramError},
-        sysvar::rent,
+    use {
+        super::*,
+        crate::instruction::*,
+        serial_test::serial,
+        solana_program::{
+            account_info::IntoAccountInfo,
+            clock::Epoch,
+            instruction::Instruction,
+            program_error::{self, PrintProgramError},
+            sysvar::rent,
+        },
+        solana_sdk::account::{
+            create_account_for_test, create_is_signer_account_infos, Account as SolanaAccount,
+        },
+        std::sync::{Arc, RwLock},
     };
-    use solana_sdk::account::{
-        create_account_for_test, create_is_signer_account_infos, Account as SolanaAccount,
-    };
-    use std::sync::{Arc, RwLock};
 
     lazy_static::lazy_static! {
         static ref EXPECTED_DATA: Arc<RwLock<Vec<u8>>> = Arc::new(RwLock::new(Vec::new()));

--- a/token/program/src/state.rs
+++ b/token/program/src/state.rs
@@ -1,13 +1,15 @@
 //! State transition types
 
-use crate::instruction::MAX_SIGNERS;
-use arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs};
-use num_enum::TryFromPrimitive;
-use solana_program::{
-    program_error::ProgramError,
-    program_option::COption,
-    program_pack::{IsInitialized, Pack, Sealed},
-    pubkey::{Pubkey, PUBKEY_BYTES},
+use {
+    crate::instruction::MAX_SIGNERS,
+    arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs},
+    num_enum::TryFromPrimitive,
+    solana_program::{
+        program_error::ProgramError,
+        program_option::COption,
+        program_pack::{IsInitialized, Pack, Sealed},
+        pubkey::{Pubkey, PUBKEY_BYTES},
+    },
 };
 
 /// Mint data.

--- a/utils/cgen/src/main.rs
+++ b/utils/cgen/src/main.rs
@@ -1,7 +1,6 @@
 extern crate cbindgen;
 
-use std::env;
-use std::path::Path;
+use std::{env, path::Path};
 
 fn token<P: AsRef<Path>>(crate_dir: P) {
     let output_file = crate_dir.as_ref().join("inc/token.h");


### PR DESCRIPTION
This PR adds import formatting configurations to the repository's `rustfmt.toml` file, and the associated changes from `cargo +nightly fmt --all`.
