### PR TITLE
ci: Fix flakiness on token js tests

### DIFF
--- a/.github/workflows/pull-request-token.yml
+++ b/.github/workflows/pull-request-token.yml
@@ -253,7 +253,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NODE_VERSION: 16.x
-    needs: [cargo-test-sbf, cargo-test-sbf-associated-token-account]
+    needs: [cargo-test-sbf, cargo-test-sbf-associated-token-account, cargo-test-sbf-transfer-hook]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ env.NODE_VERSION }}


### PR DESCRIPTION
#### Problem

The token JS tests have been flaky in CI, sometimes failing to download the transfer hook example program. This is because the JS step incorrectly doesn't require the transfer hook example to be built.

#### Solution

Require that the transfer hook example program be built too!