### PR TITLE
docs: Update token-2022 extensions

### DIFF
--- a/docs/src/token-2022/extensions.mdx
+++ b/docs/src/token-2022/extensions.mdx
@@ -1370,13 +1370,13 @@ The example program and the interface are powered by the
 library, which is explained in detail in the repository's 
 [README](https://github.com/solana-labs/solana-program-library/tree/master/libraries/tlv-account-resolution/README.md)
 
-#### Example: Create a permissioned-transfer mint
+#### Example: Create a mint with a transfer hook
 
 <Tabs className="unique-tabs" groupId="language-selection">
   <TabItem value="cli" label="CLI" default>
 
 ```console
-$ spl-token --program-id TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb create-token --transfer-hook-program-id 7N4HggYEJAtCLJdnHGCtFqfxcB5rhQCsQTze3ftYstVj
+$ spl-token --program-id TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb create-token --transfer-hook 7N4HggYEJAtCLJdnHGCtFqfxcB5rhQCsQTze3ftYstVj
 Creating token HFg1FFaj4PqFHmkYrqbZsarNJEZT436aXAXgQFMJihwc under program TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb
 
 Address:  HFg1FFaj4PqFHmkYrqbZsarNJEZT436aXAXgQFMJihwc
@@ -1446,13 +1446,13 @@ import {
   </TabItem>
 </Tabs>
 
-#### Example: Update permissioned-transfer program in mint
+#### Example: Update transfer-hook program in mint
 
 <Tabs className="unique-tabs" groupId="language-selection">
   <TabItem value="cli" label="CLI" default>
 
 ```console
-$ spl-token set-transfer-hook-program-id HFg1FFaj4PqFHmkYrqbZsarNJEZT436aXAXgQFMJihwc EbPBt3XkCb9trcV4c8fidhrvoeURbDbW87Acustzyi8N
+$ spl-token set-transfer-hook HFg1FFaj4PqFHmkYrqbZsarNJEZT436aXAXgQFMJihwc EbPBt3XkCb9trcV4c8fidhrvoeURbDbW87Acustzyi8N
 
 Signature: 3Ffw6yjseDsL3Az5n2LjdwXXwVPYxDF3JUU1JC1KGAEb1LE68S9VN4ebtAyvKeYMHvhjdz1LJVyugGNdWHyotzay
 ```
@@ -1474,6 +1474,28 @@ await updateTransferHook(
 
   </TabItem>
 </Tabs>
+
+#### Example: Manage a transfer-hook programa
+
+A sample CLI for managing a transfer-hook program exists at
+[spl-transfer-hook-cli](https://github.com/solana-labs/solana-program-library/tree/master/token/transfer-hook/cli).
+A mint manager can fork the tool for their own program.
+
+It only contains a command to create the required transfer-hook account for the
+mint.
+
+First, you must build the transfer-hook program and deploy it:
+
+```console
+$ cargo build-sbf
+$ solana program deploy target/deploy/spl-transfer-hook-example.so
+```
+
+After that, you can initialize the transfer-hook account:
+
+```console
+$ spl-transfer-hook create-extra-metas <PROGRAM_ID> <MINT_ID> [<ACCOUNT_PUBKEY>:<ROLE> ...]
+```
 
 ### Metadata Pointer
 

--- a/docs/src/token-2022/presentation.md
+++ b/docs/src/token-2022/presentation.md
@@ -54,9 +54,9 @@ The base is mostly there.
 
 - RPC indexes Token-2022
 - Anchor
-- Wallets: Backpack, others coming
-- DeFi Protocols: limited to spl-token-swap
-- Metadata: Metaplex can't, so we're making our own
+- Wallets
+- DeFi Protocols
+- Token Metadata
 
 ---
 
@@ -65,7 +65,8 @@ The base is mostly there.
 - 4 audits
 - 1 more after WIP features
 - Currently upgradeable
-- Officially recommended after 1.16 on mainnet
+- Officially recommended after 1.17 on mainnet (~January 2024)
+- More ZK features in 1.18 (~May 2024)
 - May be frozen ~6 months after that
 
 ---
@@ -89,7 +90,8 @@ The base is mostly there.
 - Default account state
 - Permanent delegate
 - Transfer-hook
-- Metadata pointer + metadata (WIP)
+- Metadata pointer + metadata
+- Group pointer + group
 
 ---
 
@@ -320,11 +322,59 @@ Docs and examples at https://spl.solana.com/token-2022/wallet
 
 ---
 
+### Question 14
+
+Why did you add metadata?
+
+---
+
+### Answer 14
+
+- On-chain programming should become more open
+- People kept bothering us about it
+
+---
+
+### Question 15
+
+What if I don't want to use your metadata?
+
+---
+
+### Answer 15
+
+- No problem, bring your own!
+- The "metadata pointer" extension lets you point to *any* account
+- You can also implement the "SPL Token Metadata Interface" in your program
+
+Security bonus: check that the mint and metadata point to each other!
+
+---
+
+### Question 16
+
+Can I just use my own token program?
+
+---
+
+#### Answer 16
+
+- That's the future! In the meantime, we have Transfer Hooks
+- With a Transfer Hook, Token-2022 calls a program of your choice during all
+transfers for your mint
+- The program must implement `spl-transfer-hook-interface`
+- Feel free to fork `spl-transfer-hook-example`
+
+---
+
 ### I'm a bit overwhelmed
 
 No problem, we're done, here are your links:
 
 - Token-2022: https://spl.solana.com/token-2022
 - Token-upgrade: https://spl.solana.com/token-upgrade
+- Metadata interface: https://docs.rs/crate/spl-token-metadata-interface/latest
+- Transfer hook interface: https://docs.rs/crate/spl-transfer-hook-interface/latest
+- Confidential transfers: https://github.com/solana-labs/solana-program-library/blob/master/token/zk-token-protocol-paper/part1.pdf
 
 Thanks for listening!

--- a/docs/src/token-2022/status.md
+++ b/docs/src/token-2022/status.md
@@ -10,26 +10,27 @@ development purposes ONLY**.
 
 Here is the general program timeline and rough ETAs:
 
-| Issue                       | ETA                          |
-| --------------------------- | ---------------------------- |
-| Code-complete & final audit | Summer 2023                  |
-| Mainnet recommendation      | Fall 2023 (depends on v1.16) |
-| Freeze program              | 2024                         |
+| Issue                       | ETA                            |
+| --------------------------- | ------------------------------ |
+| Code-complete & final audit | Fall 2023                      |
+| Mainnet recommendation      | Winter 2024 (depends on v1.17) |
+| More ZK features            | Spring 2024 (depends on v1.18) |
+| Freeze program              | 2024                           |
 
 More information: https://github.com/orgs/solana-labs/projects/34
 
 ## Remaining items
 
-### v1.16 with curve syscalls
+### v1.17 with curve syscalls
 
-In order to use confidential tokens, the cluster must run at least version 1.16
+In order to use confidential tokens, the cluster must run at least version 1.17
 with the elliptic curve operations syscalls enabled.
 
 More information: https://github.com/solana-labs/solana/issues/29612
 
 ### Zero-knowledge proof split
 
-In order to use confidential tokens, the cluster must run at least version 1.16
+In order to use confidential tokens, the cluster must run at least version 1.17
 with the ZK Token proof program enabled.
 
 More information: https://github.com/solana-labs/solana/pull/32613
@@ -42,6 +43,11 @@ the new proof format.
 More information: https://github.com/solana-labs/solana-program-library/issues/4817
 
 ## Future work
+
+### Confidential transfers with fee
+
+Due to the transaction size limit, it is not possible to do confidential transfers
+with a fee. We plan to include that capability with Solana 1.18.
 
 ### Wallets
 

--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -184,7 +184,7 @@ pub enum CommandName {
     WithdrawWithheldTokens,
     SetTransferFee,
     WithdrawExcessLamports,
-    SetTransferHookProgram,
+    SetTransferHook,
     InitializeMetadata,
     UpdateMetadata,
     UpdateConfidentialTransferSettings,
@@ -3852,7 +3852,7 @@ fn app<'a, 'b>(
                 )
         )
         .subcommand(
-            SubCommand::with_name(CommandName::SetTransferHookProgram.into())
+            SubCommand::with_name(CommandName::SetTransferHook.into())
                 .about("Set the transfer hook program id for a token")
                 .arg(
                     Arg::with_name("token")
@@ -5535,7 +5535,7 @@ async fn process_command<'a>(
             )
             .await
         }
-        (CommandName::SetTransferHookProgram, arg_matches) => {
+        (CommandName::SetTransferHook, arg_matches) => {
             let token_pubkey = pubkey_of_signer(arg_matches, "token", &mut wallet_manager)
                 .unwrap()
                 .unwrap();
@@ -9819,7 +9819,7 @@ mod tests {
             &payer,
             &[
                 "spl-token",
-                CommandName::SetTransferHookProgram.into(),
+                CommandName::SetTransferHook.into(),
                 &mint.to_string(),
                 &new_transfer_hook_program_id.to_string(),
             ],
@@ -9883,7 +9883,7 @@ mod tests {
             &payer,
             &[
                 "spl-token",
-                CommandName::SetTransferHookProgram.into(),
+                CommandName::SetTransferHook.into(),
                 &mint.to_string(),
                 "--disable",
             ],


### PR DESCRIPTION
#### Problem

We've added a lot of functionality for using extensions in the CLI, but it isn't exposed in the docs.

#### Solution

This is a bit of a kitchen sink of changes, but it should update everything roughly to where we are.

Someone also pointed out that the command were incorrect for transfer-hooks, so I decided to make those consistent