### PR TITLE
dependabot: Update npm to root to properly update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,91 +4,19 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "01:00"
-    timezone: America/Los_Angeles
+    time: "9:00"
+    timezone: UTC
   labels:
     - "automerge"
   open-pull-requests-limit: 6
   ignore:
     - dependency-name: "cbindgen"
 - package-ecosystem: npm
-  directory: "/libraries/type-length-value/js"
+  directory: "/"
   schedule:
     interval: daily
-    time: "02:00"
-    timezone: America/Los_Angeles
-  open-pull-requests-limit: 3
-  labels:
-    - "automerge"
-- package-ecosystem: npm
-  directory: "/token/js"
-  schedule:
-    interval: daily
-    time: "02:00"
-    timezone: America/Los_Angeles
-  open-pull-requests-limit: 3
-  labels:
-    - "automerge"
-- package-ecosystem: npm
-  directory: "/token-lending/js"
-  schedule:
-    interval: daily
-    time: "03:00"
-    timezone: America/Los_Angeles
-  open-pull-requests-limit: 3
-  labels:
-    - "automerge"
-- package-ecosystem: npm
-  directory: "/token-swap/js"
-  schedule:
-    interval: daily
-    time: "04:00"
-    timezone: America/Los_Angeles
-  open-pull-requests-limit: 3
-  labels:
-    - "automerge"
-- package-ecosystem: npm
-  directory: "/stake-pool/js"
-  schedule:
-    interval: daily
-    time: "05:00"
-    timezone: America/Los_Angeles
-  open-pull-requests-limit: 3
-  labels:
-    - "automerge"
-- package-ecosystem: npm
-  directory: "/name-service/js"
-  schedule:
-    interval: daily
-    time: "06:00"
-    timezone: America/Los_Angeles
-  open-pull-requests-limit: 3
-  labels:
-    - "automerge"
-- package-ecosystem: npm
-  directory: "/memo/js"
-  schedule:
-    interval: daily
-    time: "07:00"
-    timezone: America/Los_Angeles
-  open-pull-requests-limit: 3
-  labels:
-    - "automerge"
-- package-ecosystem: npm
-  directory: "/single-pool/js/packages/classic"
-  schedule:
-    interval: daily
-    time: "05:00"
-    timezone: America/Los_Angeles
-  open-pull-requests-limit: 3
-  labels:
-    - "automerge"
-- package-ecosystem: npm
-  directory: "/single-pool/js/packages/modern"
-  schedule:
-    interval: daily
-    time: "05:00"
-    timezone: America/Los_Angeles
-  open-pull-requests-limit: 3
+    time: "10:00"
+    timezone: UTC
+  open-pull-requests-limit: 12
   labels:
     - "automerge"


### PR DESCRIPTION
#### Problem

The dependabot PRs don't properly update the lockfile, probably because we have a job for each JS library, where it doesn't look for the pnpm lockfile.

#### Solution

Update the npm directory to the root of the repo and remove all of the copied jobs. While I was at it, I updated to UTC to make it clearer when it runs.