### PR TITLE
token 2022: Expose token-metadata state decoder in @solana/token-metata

### DIFF
--- a/token-metadata/js/package.json
+++ b/token-metadata/js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@solana/spl-token-metadata",
     "description": "SPL Token Metadata Interface JS API",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "author": "Solana Labs Maintainers <maintainers@solanalabs.com>",
     "repository": "https://github.com/solana-labs/solana-program-library",
     "license": "Apache-2.0",

--- a/token-metadata/js/package.json
+++ b/token-metadata/js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@solana/spl-token-metadata",
     "description": "SPL Token Metadata Interface JS API",
-    "version": "0.2.0",
+    "version": "0.1.0",
     "author": "Solana Labs Maintainers <maintainers@solanalabs.com>",
     "repository": "https://github.com/solana-labs/solana-program-library",
     "license": "Apache-2.0",

--- a/token-metadata/js/src/state.ts
+++ b/token-metadata/js/src/state.ts
@@ -1,17 +1,17 @@
 import { PublicKey } from '@solana/web3.js';
-import {
-    getArrayDecoder,
-    getArrayEncoder,
-    getBytesDecoder,
-    getBytesEncoder,
-    getStructDecoder,
-    getStructEncoder,
-    getTupleDecoder,
-    getTupleEncoder,
-} from '@solana/codecs-data-structures';
-import { getStringDecoder, getStringEncoder } from '@solana/codecs-strings';
+import { getArrayCodec, getBytesCodec, getStructCodec, getTupleCodec } from '@solana/codecs-data-structures';
+import { getStringCodec } from '@solana/codecs-strings';
 
 export const TOKEN_METADATA_DISCRIMINATOR = Buffer.from([112, 132, 90, 90, 11, 88, 157, 87]);
+
+export const tokenMetadataCodec = getStructCodec([
+    ['updateAuthority', getBytesCodec({ size: 32 })],
+    ['mint', getBytesCodec({ size: 32 })],
+    ['name', getStringCodec()],
+    ['symbol', getStringCodec()],
+    ['uri', getStringCodec()],
+    ['additionalMetadata', getArrayCodec(getTupleCodec([getStringCodec(), getStringCodec()]))],
+]);
 
 export interface TokenMetadata {
     // The authority that can sign to update the metadata
@@ -40,18 +40,9 @@ function isNonePubkey(buffer: Uint8Array): boolean {
 
 // Pack TokenMetadata into byte slab
 export const pack = (meta: TokenMetadata): Uint8Array => {
-    const encoder = getStructEncoder([
-        ['updateAuthority', getBytesEncoder({ size: 32 })],
-        ['mint', getBytesEncoder({ size: 32 })],
-        ['name', getStringEncoder()],
-        ['symbol', getStringEncoder()],
-        ['uri', getStringEncoder()],
-        ['additionalMetadata', getArrayEncoder(getTupleEncoder([getStringEncoder(), getStringEncoder()]))],
-    ]);
-
     // If no updateAuthority given, set it to the None/Zero PublicKey for encoding
     const updateAuthority = meta.updateAuthority ?? PublicKey.default;
-    return encoder.encode({
+    return tokenMetadataCodec.encode({
         ...meta,
         updateAuthority: updateAuthority.toBuffer(),
         mint: meta.mint.toBuffer(),
@@ -60,16 +51,7 @@ export const pack = (meta: TokenMetadata): Uint8Array => {
 
 // unpack byte slab into TokenMetadata
 export function unpack(buffer: Buffer | Uint8Array): TokenMetadata {
-    const decoder = getStructDecoder([
-        ['updateAuthority', getBytesDecoder({ size: 32 })],
-        ['mint', getBytesDecoder({ size: 32 })],
-        ['name', getStringDecoder()],
-        ['symbol', getStringDecoder()],
-        ['uri', getStringDecoder()],
-        ['additionalMetadata', getArrayDecoder(getTupleDecoder([getStringDecoder(), getStringDecoder()]))],
-    ]);
-
-    const data = decoder.decode(buffer);
+    const data = tokenMetadataCodec.decode(buffer);
 
     return isNonePubkey(data[0].updateAuthority)
         ? {

--- a/token-metadata/js/src/state.ts
+++ b/token-metadata/js/src/state.ts
@@ -4,7 +4,6 @@ import { getStringCodec } from '@solana/codecs-strings';
 
 export const TOKEN_METADATA_DISCRIMINATOR = Buffer.from([112, 132, 90, 90, 11, 88, 157, 87]);
 
-// Don't export as you still need custom logic for all-zero update authorities
 const tokenMetadataCodec = getStructCodec([
     ['updateAuthority', getBytesCodec({ size: 32 })],
     ['mint', getBytesCodec({ size: 32 })],

--- a/token-metadata/js/src/state.ts
+++ b/token-metadata/js/src/state.ts
@@ -4,7 +4,8 @@ import { getStringCodec } from '@solana/codecs-strings';
 
 export const TOKEN_METADATA_DISCRIMINATOR = Buffer.from([112, 132, 90, 90, 11, 88, 157, 87]);
 
-export const tokenMetadataCodec = getStructCodec([
+// Don't export as you still need custom logic for all-zero update authorities
+const tokenMetadataCodec = getStructCodec([
     ['updateAuthority', getBytesCodec({ size: 32 })],
     ['mint', getBytesCodec({ size: 32 })],
     ['name', getStringCodec()],

--- a/token-metadata/js/test/state.test.ts
+++ b/token-metadata/js/test/state.test.ts
@@ -2,68 +2,31 @@ import { PublicKey } from '@solana/web3.js';
 import { expect } from 'chai';
 
 import type { TokenMetadata } from '../src/state';
-import { TOKEN_METADATA_DISCRIMINATOR, unpack } from '../src/state';
-import { getArrayEncoder, getBytesEncoder, getStructEncoder, getTupleEncoder } from '@solana/codecs-data-structures';
-import { getStringEncoder } from '@solana/codecs-strings';
+import { unpack, pack } from '../src';
 
 describe('Token Metadata State', () => {
-    const lengthBuffer = (buffer: Buffer | Uint8Array): Buffer => {
-        const length = Buffer.alloc(4);
-        length.writeUIntLE(buffer.length, 0, 4);
-        return length;
-    };
-
-    // Helper function to pack meta into tlv bytes slab
-    const pack = (meta: TokenMetadata) => {
-        const encoder = getStructEncoder([
-            ['updateAuthority', getBytesEncoder({ size: 32 })],
-            ['mint', getBytesEncoder({ size: 32 })],
-            ['name', getStringEncoder()],
-            ['symbol', getStringEncoder()],
-            ['uri', getStringEncoder()],
-            ['additionalMetadata', getArrayEncoder(getTupleEncoder([getStringEncoder(), getStringEncoder()]))],
-        ]);
-        const data = encoder.encode({
-            ...meta,
-            updateAuthority: meta.updateAuthority?.toBuffer(),
-            mint: meta.mint.toBuffer(),
-        });
-        return Buffer.concat([TOKEN_METADATA_DISCRIMINATOR, lengthBuffer(data), data]);
-    };
-
-    it('Can unpack', () => {
-        const data = Buffer.from([
-            // From rust implementation
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 110, 97,
-            109, 101, 6, 0, 0, 0, 115, 121, 109, 98, 111, 108, 3, 0, 0, 0, 117, 114, 105, 0, 0, 0, 0,
-        ]);
-
-        const input = Buffer.concat([TOKEN_METADATA_DISCRIMINATOR, lengthBuffer(data), data]);
-
-        const meta = unpack(input);
-        expect(meta).to.deep.equal({
+    it('Can pack and unpack as rust implementation', () => {
+        const meta = {
             mint: PublicKey.default,
             name: 'name',
             symbol: 'symbol',
             uri: 'uri',
             additionalMetadata: [],
-        });
+        };
+
+        // From rust implementation
+        const bytes = Buffer.from([
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 110, 97,
+            109, 101, 6, 0, 0, 0, 115, 121, 109, 98, 111, 108, 3, 0, 0, 0, 117, 114, 105, 0, 0, 0, 0,
+        ]);
+
+        expect(pack(meta)).to.deep.equal(bytes);
+        expect(unpack(bytes)).to.deep.equal(meta);
     });
 
     it('Can unpack with additionalMetadata', () => {
-        const data = Buffer.from([
-            // From rust implementation
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 110, 101,
-            119, 95, 110, 97, 109, 101, 10, 0, 0, 0, 110, 101, 119, 95, 115, 121, 109, 98, 111, 108, 7, 0, 0, 0, 110,
-            101, 119, 95, 117, 114, 105, 2, 0, 0, 0, 4, 0, 0, 0, 107, 101, 121, 49, 6, 0, 0, 0, 118, 97, 108, 117, 101,
-            49, 4, 0, 0, 0, 107, 101, 121, 50, 6, 0, 0, 0, 118, 97, 108, 117, 101, 50,
-        ]);
-
-        const input = Buffer.concat([TOKEN_METADATA_DISCRIMINATOR, lengthBuffer(data), data]);
-        const meta = unpack(input);
-        expect(meta).to.deep.equal({
+        const meta: TokenMetadata = {
             mint: PublicKey.default,
             name: 'new_name',
             symbol: 'new_symbol',
@@ -72,7 +35,18 @@ describe('Token Metadata State', () => {
                 ['key1', 'value1'],
                 ['key2', 'value2'],
             ],
-        });
+        };
+        // From rust implementation
+        const bytes = Buffer.from([
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 110, 101,
+            119, 95, 110, 97, 109, 101, 10, 0, 0, 0, 110, 101, 119, 95, 115, 121, 109, 98, 111, 108, 7, 0, 0, 0, 110,
+            101, 119, 95, 117, 114, 105, 2, 0, 0, 0, 4, 0, 0, 0, 107, 101, 121, 49, 6, 0, 0, 0, 118, 97, 108, 117, 101,
+            49, 4, 0, 0, 0, 107, 101, 121, 50, 6, 0, 0, 0, 118, 97, 108, 117, 101, 50,
+        ]);
+
+        expect(pack(meta)).to.deep.equal(bytes);
+        expect(unpack(bytes)).to.deep.equal(meta);
     });
 
     it('Can pack and unpack with mint and updateAuthority', () => {

--- a/token-metadata/js/test/state.test.ts
+++ b/token-metadata/js/test/state.test.ts
@@ -69,4 +69,30 @@ describe('Token Metadata State', () => {
         expect(pack(meta)).to.deep.equal(bytes);
         expect(unpack(bytes)).to.deep.equal(meta);
     });
+
+    it('Can pack and unpack with mint, updateAuthority and additional metadata', () => {
+        const meta: TokenMetadata = {
+            updateAuthority: new PublicKey('44444444444444444444444444444444444444444444'),
+            mint: new PublicKey('55555555555555555555555555555555555555555555'),
+            name: 'name',
+            symbol: 'symbol',
+            uri: 'uri',
+            additionalMetadata: [
+                ['key1', 'value1'],
+                ['key2', 'value2'],
+            ],
+        };
+
+        const bytes = Buffer.from([
+            45, 91, 65, 60, 101, 64, 222, 21, 12, 147, 115, 20, 77, 81, 51, 202, 76, 184, 48, 186, 15, 117, 103, 22,
+            172, 234, 14, 80, 215, 148, 53, 229, 60, 121, 172, 80, 135, 1, 40, 28, 16, 196, 153, 112, 103, 22, 239, 184,
+            102, 74, 235, 162, 191, 71, 52, 30, 59, 226, 189, 193, 31, 112, 71, 220, 4, 0, 0, 0, 110, 97, 109, 101, 6,
+            0, 0, 0, 115, 121, 109, 98, 111, 108, 3, 0, 0, 0, 117, 114, 105, 2, 0, 0, 0, 4, 0, 0, 0, 107, 101, 121, 49,
+            6, 0, 0, 0, 118, 97, 108, 117, 101, 49, 4, 0, 0, 0, 107, 101, 121, 50, 6, 0, 0, 0, 118, 97, 108, 117, 101,
+            50,
+        ]);
+
+        expect(pack(meta)).to.deep.equal(bytes);
+        expect(unpack(bytes)).to.deep.equal(meta);
+    });
 });

--- a/token-metadata/js/test/state.test.ts
+++ b/token-metadata/js/test/state.test.ts
@@ -25,7 +25,7 @@ describe('Token Metadata State', () => {
         expect(unpack(bytes)).to.deep.equal(meta);
     });
 
-    it('Can unpack with additionalMetadata', () => {
+    it('Can pack and unpack as rust implementation with additionalMetadata', () => {
         const meta: TokenMetadata = {
             mint: PublicKey.default,
             name: 'new_name',

--- a/token-metadata/js/test/state.test.ts
+++ b/token-metadata/js/test/state.test.ts
@@ -50,23 +50,23 @@ describe('Token Metadata State', () => {
     });
 
     it('Can pack and unpack with mint and updateAuthority', () => {
-        const input = pack({
+        const meta = {
             updateAuthority: new PublicKey('44444444444444444444444444444444444444444444'),
             mint: new PublicKey('55555555555555555555555555555555555555555555'),
             name: 'name',
             symbol: 'symbol',
             uri: 'uri',
             additionalMetadata: [],
-        });
+        };
 
-        const meta = unpack(input);
-        expect(meta).to.deep.equal({
-            updateAuthority: new PublicKey('44444444444444444444444444444444444444444444'),
-            mint: new PublicKey('55555555555555555555555555555555555555555555'),
-            name: 'name',
-            symbol: 'symbol',
-            uri: 'uri',
-            additionalMetadata: [],
-        });
+        const bytes = Buffer.from([
+            45, 91, 65, 60, 101, 64, 222, 21, 12, 147, 115, 20, 77, 81, 51, 202, 76, 184, 48, 186, 15, 117, 103, 22,
+            172, 234, 14, 80, 215, 148, 53, 229, 60, 121, 172, 80, 135, 1, 40, 28, 16, 196, 153, 112, 103, 22, 239, 184,
+            102, 74, 235, 162, 191, 71, 52, 30, 59, 226, 189, 193, 31, 112, 71, 220, 4, 0, 0, 0, 110, 97, 109, 101, 6,
+            0, 0, 0, 115, 121, 109, 98, 111, 108, 3, 0, 0, 0, 117, 114, 105, 0, 0, 0, 0,
+        ]);
+
+        expect(pack(meta)).to.deep.equal(bytes);
+        expect(unpack(bytes)).to.deep.equal(meta);
     });
 });


### PR DESCRIPTION
Token2022 doesn't using 8-byte discriminators, and can't use the unpack function current in @solana/spl-token-metadata which assumes 8-byte discriminators.

This PR exposes a function that just decodes to the data, so it can be used in Token2022.

Discussion where the need arose:
https://github.com/solana-labs/solana-program-library/pull/5667#discussion_r1390234922