### PR TITLE
[token js]: bump version

### DIFF
--- a/token/js/package.json
+++ b/token/js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@solana/spl-token",
     "description": "SPL Token Program JS API",
-    "version": "0.3.8",
+    "version": "0.3.9",
     "author": "Solana Labs Maintainers <maintainers@solanalabs.com>",
     "repository": "https://github.com/solana-labs/solana-program-library",
     "license": "Apache-2.0",


### PR DESCRIPTION
After adding the `MetadataPointer` extension to `@solana/spl-token` (#4550), we need to release a new version!

Here's the bump.