### PR TITLE
token-cli: Make update confidential accept multiple args

### DIFF
--- a/token/cli/src/main.rs
+++ b/token/cli/src/main.rs
@@ -5125,6 +5125,7 @@ fn app<'a, 'b>(
                 .group(
                     ArgGroup::with_name("update_fields").args(&["approve_policy", "auditor_pubkey"])
                         .required(true)
+                        .multiple(true)
                 )
                 .arg(
                     Arg::with_name("confidential_transfer_authority")


### PR DESCRIPTION
#### Problem

As noted in #5804, it's currently not possible to update the approve policy and the auditor pubkey during `update-confidential-transfer-mint` because only one `update_field` is allowed at once.

#### Solution

Allow both to be set by setting `multiple(true)` on the `"update_field"` parameter.

cc @samkim-crypto 