### PR TITLE
[token js]: transfer-hook: add support for account data seeds

### DIFF
--- a/token/js/src/errors.ts
+++ b/token/js/src/errors.ts
@@ -79,3 +79,8 @@ export class TokenTransferHookAccountNotFound extends TokenError {
 export class TokenTransferHookInvalidSeed extends TokenError {
     name = 'TokenTransferHookInvalidSeed';
 }
+
+/** Thrown if account data required by an extra account meta seed config could not be fetched */
+export class TokenTransferHookAccountDataNotFound extends TokenError {
+    name = 'TokenTransferHookAccountDataNotFound';
+}

--- a/token/js/src/extensions/transferHook/instructions.ts
+++ b/token/js/src/extensions/transferHook/instructions.ts
@@ -156,7 +156,8 @@ export async function addExtraAccountsToInstruction(
     accountMetas.push({ pubkey: extraAccountsAccount, isSigner: false, isWritable: false });
 
     for (const extraAccountMeta of extraAccountMetas) {
-        const accountMeta = resolveExtraAccountMeta(
+        const accountMeta = await resolveExtraAccountMeta(
+            connection,
             extraAccountMeta,
             accountMetas,
             instruction.data,

--- a/token/js/test/common.ts
+++ b/token/js/test/common.ts
@@ -12,7 +12,6 @@ export async function newAccountWithLamports(connection: Connection, lamports = 
 export async function getConnection(): Promise<Connection> {
     const url = 'http://127.0.0.1:8899';
     const connection = new Connection(url, 'confirmed');
-    await connection.getVersion();
     return connection;
 }
 


### PR DESCRIPTION
This PR adds support for the `AccountData` seed from the
`spl-tlv-account-resolution` library and Token2022.

This addresses point number 2 in #5685.