### PR TITLE
dependabot: Fix time format to add leading 0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "9:00"
+    time: "09:00"
     timezone: UTC
   labels:
     - "automerge"


### PR DESCRIPTION
#### Problem

The dependabot tab in the dependency graph is giving an error:

```
The property '#/updates/0/schedule/time' value "9:00" did not match the regex '^\d\d:\d\d$'
```

Because the time is specified "9:00".

#### Solution

Update it to "09:00"