### PR TITLE
token 2022: add `alloc_and_serialize_allow_repeating`

### DIFF
--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -3722,4 +3722,25 @@ where
         ));
         self.process_ixs(&instructions, signing_keypairs).await
     }
+
+    /// Update a token-group max size on a mint
+    pub async fn token_group_update_max_size<S: Signers>(
+        &self,
+        update_authority: &Pubkey,
+        new_max_size: u32,
+        signing_keypairs: &S,
+    ) -> TokenResult<T::Output> {
+        self.process_ixs(
+            &[
+                spl_token_group_interface::instruction::update_group_max_size(
+                    &self.program_id,
+                    &self.pubkey,
+                    update_authority,
+                    new_max_size,
+                ),
+            ],
+            signing_keypairs,
+        )
+        .await
+    }
 }

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -3743,4 +3743,25 @@ where
         )
         .await
     }
+
+    /// Update the token-group authority in a mint
+    pub async fn token_group_update_authority<S: Signers>(
+        &self,
+        current_authority: &Pubkey,
+        new_authority: Option<Pubkey>,
+        signing_keypairs: &S,
+    ) -> TokenResult<T::Output> {
+        self.process_ixs(
+            &[
+                spl_token_group_interface::instruction::update_group_authority(
+                    &self.program_id,
+                    &self.pubkey,
+                    current_authority,
+                    new_authority,
+                ),
+            ],
+            signing_keypairs,
+        )
+        .await
+    }
 }

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -42,9 +42,9 @@ use {
                 self, account_info::WithheldTokensInfo, ConfidentialTransferFeeAmount,
                 ConfidentialTransferFeeConfig,
             },
-            cpi_guard, default_account_state, group_pointer, interest_bearing_mint, memo_transfer,
-            metadata_pointer, transfer_fee, transfer_hook, BaseStateWithExtensions, Extension,
-            ExtensionType, StateWithExtensionsOwned,
+            cpi_guard, default_account_state, group_member_pointer, group_pointer,
+            interest_bearing_mint, memo_transfer, metadata_pointer, transfer_fee, transfer_hook,
+            BaseStateWithExtensions, Extension, ExtensionType, StateWithExtensionsOwned,
         },
         instruction, offchain,
         proof::ProofLocation,
@@ -176,6 +176,12 @@ pub enum ExtensionInitializationParams {
         authority: Option<Pubkey>,
         group_address: Option<Pubkey>,
     },
+    GroupMemberPointer {
+        authority: Option<Pubkey>,
+        group_update_authority: Pubkey,
+        group_address: Pubkey,
+        member_address: Option<Pubkey>,
+    },
 }
 impl ExtensionInitializationParams {
     /// Get the extension type associated with the init params
@@ -194,6 +200,7 @@ impl ExtensionInitializationParams {
                 ExtensionType::ConfidentialTransferFeeConfig
             }
             Self::GroupPointer { .. } => ExtensionType::GroupPointer,
+            Self::GroupMemberPointer { .. } => ExtensionType::GroupMemberPointer,
         }
     }
     /// Generate an appropriate initialization instruction for the given mint
@@ -293,6 +300,19 @@ impl ExtensionInitializationParams {
                 mint,
                 authority,
                 group_address,
+            ),
+            Self::GroupMemberPointer {
+                authority,
+                group_update_authority,
+                group_address,
+                member_address,
+            } => group_member_pointer::instruction::initialize(
+                token_program_id,
+                mint,
+                authority,
+                &group_update_authority,
+                &group_address,
+                member_address,
             ),
         }
     }
@@ -1694,6 +1714,33 @@ where
                 authority,
                 &multisig_signers,
                 new_group_address,
+            )?],
+            signing_keypairs,
+        )
+        .await
+    }
+
+    /// Update group member pointer address
+    pub async fn update_group_member_address<S: Signers>(
+        &self,
+        authority: &Pubkey,
+        group_update_authority: &Pubkey,
+        group_address: &Pubkey,
+        new_member_address: Option<Pubkey>,
+        signing_keypairs: &S,
+    ) -> TokenResult<T::Output> {
+        let signing_pubkeys = signing_keypairs.pubkeys();
+        let multisig_signers = self.get_multisig_signers(authority, &signing_pubkeys);
+
+        self.process_ixs(
+            &[group_member_pointer::instruction::update(
+                &self.program_id,
+                self.get_address(),
+                authority,
+                group_update_authority,
+                &multisig_signers,
+                group_address,
+                new_member_address,
             )?],
             signing_keypairs,
         )

--- a/token/program-2022-test/tests/burn.rs
+++ b/token/program-2022-test/tests/burn.rs
@@ -87,7 +87,7 @@ async fn run_basic(context: TestContext) {
 #[tokio::test]
 async fn basic() {
     let mut context = TestContext::new().await;
-    context.init_token_with_mint(vec![]).await.unwrap();
+    context.init_token_with_mint(vec![], &[]).await.unwrap();
     run_basic(context).await;
 }
 
@@ -95,12 +95,15 @@ async fn basic() {
 async fn basic_with_extension() {
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![ExtensionInitializationParams::TransferFeeConfig {
-            transfer_fee_config_authority: Some(Pubkey::new_unique()),
-            withdraw_withheld_authority: Some(Pubkey::new_unique()),
-            transfer_fee_basis_points: 100u16,
-            maximum_fee: 1_000u64,
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::TransferFeeConfig {
+                transfer_fee_config_authority: Some(Pubkey::new_unique()),
+                withdraw_withheld_authority: Some(Pubkey::new_unique()),
+                transfer_fee_basis_points: 100u16,
+                maximum_fee: 1_000u64,
+            }],
+            &[],
+        )
         .await
         .unwrap();
     run_basic(context).await;
@@ -149,7 +152,7 @@ async fn run_self_owned(context: TestContext) {
 #[tokio::test]
 async fn self_owned() {
     let mut context = TestContext::new().await;
-    context.init_token_with_mint(vec![]).await.unwrap();
+    context.init_token_with_mint(vec![], &[]).await.unwrap();
     run_self_owned(context).await;
 }
 
@@ -157,12 +160,15 @@ async fn self_owned() {
 async fn self_owned_with_extension() {
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![ExtensionInitializationParams::TransferFeeConfig {
-            transfer_fee_config_authority: Some(Pubkey::new_unique()),
-            withdraw_withheld_authority: Some(Pubkey::new_unique()),
-            transfer_fee_basis_points: 100u16,
-            maximum_fee: 1_000u64,
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::TransferFeeConfig {
+                transfer_fee_config_authority: Some(Pubkey::new_unique()),
+                withdraw_withheld_authority: Some(Pubkey::new_unique()),
+                transfer_fee_basis_points: 100u16,
+                maximum_fee: 1_000u64,
+            }],
+            &[],
+        )
         .await
         .unwrap();
     run_self_owned(context).await;
@@ -288,13 +294,13 @@ async fn run_burn_and_close_system_or_incinerator(context: TestContext, non_owne
 #[tokio::test]
 async fn burn_and_close_incinerator_tokens() {
     let mut context = TestContext::new().await;
-    context.init_token_with_mint(vec![]).await.unwrap();
+    context.init_token_with_mint(vec![], &[]).await.unwrap();
     run_burn_and_close_system_or_incinerator(context, &solana_program::incinerator::id()).await;
 }
 
 #[tokio::test]
 async fn burn_and_close_system_tokens() {
     let mut context = TestContext::new().await;
-    context.init_token_with_mint(vec![]).await.unwrap();
+    context.init_token_with_mint(vec![], &[]).await.unwrap();
     run_burn_and_close_system_or_incinerator(context, &solana_program::system_program::id()).await;
 }

--- a/token/program-2022-test/tests/close_account.rs
+++ b/token/program-2022-test/tests/close_account.rs
@@ -17,7 +17,7 @@ use {
 async fn success_init_after_close_account() {
     let mut context = TestContext::new().await;
     let payer = Keypair::from_bytes(&context.context.lock().await.payer.to_bytes()).unwrap();
-    context.init_token_with_mint(vec![]).await.unwrap();
+    context.init_token_with_mint(vec![], &[]).await.unwrap();
     let token = context.token_context.take().unwrap().token;
     let token_program_id = spl_token_2022::id();
     let owner = Keypair::new();
@@ -67,7 +67,7 @@ async fn success_init_after_close_account() {
 async fn fail_init_after_close_account() {
     let mut context = TestContext::new().await;
     let payer = Keypair::from_bytes(&context.context.lock().await.payer.to_bytes()).unwrap();
-    context.init_token_with_mint(vec![]).await.unwrap();
+    context.init_token_with_mint(vec![], &[]).await.unwrap();
     let token = context.token_context.take().unwrap().token;
     let token_program_id = spl_token_2022::id();
     let owner = Keypair::new();
@@ -119,9 +119,12 @@ async fn fail_init_after_close_mint() {
     let mut context = TestContext::new().await;
     let payer = Keypair::from_bytes(&context.context.lock().await.payer.to_bytes()).unwrap();
     context
-        .init_token_with_mint(vec![ExtensionInitializationParams::MintCloseAuthority {
-            close_authority: Some(close_authority.pubkey()),
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::MintCloseAuthority {
+                close_authority: Some(close_authority.pubkey()),
+            }],
+            &[],
+        )
         .await
         .unwrap();
     let token = context.token_context.take().unwrap().token;

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -231,13 +231,14 @@ async fn confidential_transfer_configure_token_account() {
 
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![
-            ExtensionInitializationParams::ConfidentialTransferMint {
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::ConfidentialTransferMint {
                 authority: Some(authority.pubkey()),
                 auto_approve_new_accounts,
                 auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
-            },
-        ])
+            }],
+            &[],
+        )
         .await
         .unwrap();
 
@@ -315,13 +316,14 @@ async fn confidential_transfer_enable_disable_confidential_credits() {
 
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![
-            ExtensionInitializationParams::ConfidentialTransferMint {
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::ConfidentialTransferMint {
                 authority: Some(authority.pubkey()),
                 auto_approve_new_accounts,
                 auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
-            },
-        ])
+            }],
+            &[],
+        )
         .await
         .unwrap();
 
@@ -424,13 +426,14 @@ async fn confidential_transfer_enable_disable_non_confidential_credits() {
 
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![
-            ExtensionInitializationParams::ConfidentialTransferMint {
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::ConfidentialTransferMint {
                 authority: Some(authority.pubkey()),
                 auto_approve_new_accounts,
                 auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
-            },
-        ])
+            }],
+            &[],
+        )
         .await
         .unwrap();
 
@@ -533,13 +536,14 @@ async fn confidential_transfer_empty_account() {
     // newly created confidential transfer account should hold no balance and
     // therefore, immediately closable
     context
-        .init_token_with_mint(vec![
-            ExtensionInitializationParams::ConfidentialTransferMint {
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::ConfidentialTransferMint {
                 authority: Some(authority.pubkey()),
                 auto_approve_new_accounts,
                 auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
-            },
-        ])
+            }],
+            &[],
+        )
         .await
         .unwrap();
 
@@ -569,13 +573,14 @@ async fn confidential_transfer_deposit() {
 
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![
-            ExtensionInitializationParams::ConfidentialTransferMint {
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::ConfidentialTransferMint {
                 authority: Some(authority.pubkey()),
                 auto_approve_new_accounts,
                 auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
-            },
-        ])
+            }],
+            &[],
+        )
         .await
         .unwrap();
 
@@ -785,13 +790,14 @@ async fn confidential_transfer_withdraw() {
 
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![
-            ExtensionInitializationParams::ConfidentialTransferMint {
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::ConfidentialTransferMint {
                 authority: Some(authority.pubkey()),
                 auto_approve_new_accounts,
                 auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
-            },
-        ])
+            }],
+            &[],
+        )
         .await
         .unwrap();
 
@@ -933,13 +939,14 @@ async fn confidential_transfer_transfer() {
 
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![
-            ExtensionInitializationParams::ConfidentialTransferMint {
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::ConfidentialTransferMint {
                 authority: Some(authority.pubkey()),
                 auto_approve_new_accounts,
                 auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
-            },
-        ])
+            }],
+            &[],
+        )
         .await
         .unwrap();
 
@@ -1180,23 +1187,26 @@ async fn confidential_transfer_transfer_with_fee() {
 
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![
-            ExtensionInitializationParams::TransferFeeConfig {
-                transfer_fee_config_authority: Some(transfer_fee_authority.pubkey()),
-                withdraw_withheld_authority: Some(withdraw_withheld_authority.pubkey()),
-                transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
-                maximum_fee: TEST_MAXIMUM_FEE,
-            },
-            ExtensionInitializationParams::ConfidentialTransferMint {
-                authority: Some(confidential_transfer_authority.pubkey()),
-                auto_approve_new_accounts,
-                auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
-            },
-            ExtensionInitializationParams::ConfidentialTransferFeeConfig {
-                authority: Some(confidential_transfer_fee_authority.pubkey()),
-                withdraw_withheld_authority_elgamal_pubkey,
-            },
-        ])
+        .init_token_with_mint(
+            vec![
+                ExtensionInitializationParams::TransferFeeConfig {
+                    transfer_fee_config_authority: Some(transfer_fee_authority.pubkey()),
+                    withdraw_withheld_authority: Some(withdraw_withheld_authority.pubkey()),
+                    transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
+                    maximum_fee: TEST_MAXIMUM_FEE,
+                },
+                ExtensionInitializationParams::ConfidentialTransferMint {
+                    authority: Some(confidential_transfer_authority.pubkey()),
+                    auto_approve_new_accounts,
+                    auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
+                },
+                ExtensionInitializationParams::ConfidentialTransferFeeConfig {
+                    authority: Some(confidential_transfer_fee_authority.pubkey()),
+                    withdraw_withheld_authority_elgamal_pubkey,
+                },
+            ],
+            &[],
+        )
         .await
         .unwrap();
 
@@ -1426,13 +1436,14 @@ async fn confidential_transfer_transfer_memo() {
 
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![
-            ExtensionInitializationParams::ConfidentialTransferMint {
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::ConfidentialTransferMint {
                 authority: Some(authority.pubkey()),
                 auto_approve_new_accounts,
                 auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
-            },
-        ])
+            }],
+            &[],
+        )
         .await
         .unwrap();
 
@@ -1549,23 +1560,26 @@ async fn confidential_transfer_transfer_with_fee_and_memo() {
 
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![
-            ExtensionInitializationParams::TransferFeeConfig {
-                transfer_fee_config_authority: Some(transfer_fee_authority.pubkey()),
-                withdraw_withheld_authority: Some(withdraw_withheld_authority.pubkey()),
-                transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
-                maximum_fee: TEST_MAXIMUM_FEE,
-            },
-            ExtensionInitializationParams::ConfidentialTransferMint {
-                authority: Some(confidential_transfer_authority.pubkey()),
-                auto_approve_new_accounts,
-                auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
-            },
-            ExtensionInitializationParams::ConfidentialTransferFeeConfig {
-                authority: Some(confidential_transfer_fee_authority.pubkey()),
-                withdraw_withheld_authority_elgamal_pubkey,
-            },
-        ])
+        .init_token_with_mint(
+            vec![
+                ExtensionInitializationParams::TransferFeeConfig {
+                    transfer_fee_config_authority: Some(transfer_fee_authority.pubkey()),
+                    withdraw_withheld_authority: Some(withdraw_withheld_authority.pubkey()),
+                    transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
+                    maximum_fee: TEST_MAXIMUM_FEE,
+                },
+                ExtensionInitializationParams::ConfidentialTransferMint {
+                    authority: Some(confidential_transfer_authority.pubkey()),
+                    auto_approve_new_accounts,
+                    auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
+                },
+                ExtensionInitializationParams::ConfidentialTransferFeeConfig {
+                    authority: Some(confidential_transfer_fee_authority.pubkey()),
+                    withdraw_withheld_authority_elgamal_pubkey,
+                },
+            ],
+            &[],
+        )
         .await
         .unwrap();
 
@@ -1675,13 +1689,14 @@ async fn confidential_transfer_configure_token_account_with_proof_context() {
 
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![
-            ExtensionInitializationParams::ConfidentialTransferMint {
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::ConfidentialTransferMint {
                 authority: Some(authority.pubkey()),
                 auto_approve_new_accounts,
                 auditor_elgamal_pubkey: None,
-            },
-        ])
+            }],
+            &[],
+        )
         .await
         .unwrap();
 
@@ -1858,13 +1873,14 @@ async fn confidential_transfer_empty_account_with_proof_context() {
 
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![
-            ExtensionInitializationParams::ConfidentialTransferMint {
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::ConfidentialTransferMint {
                 authority: Some(authority.pubkey()),
                 auto_approve_new_accounts,
                 auditor_elgamal_pubkey: None,
-            },
-        ])
+            }],
+            &[],
+        )
         .await
         .unwrap();
 
@@ -1997,13 +2013,14 @@ async fn confidential_transfer_withdraw_with_proof_context() {
 
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![
-            ExtensionInitializationParams::ConfidentialTransferMint {
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::ConfidentialTransferMint {
                 authority: Some(authority.pubkey()),
                 auto_approve_new_accounts,
                 auditor_elgamal_pubkey: None,
-            },
-        ])
+            }],
+            &[],
+        )
         .await
         .unwrap();
 
@@ -2171,13 +2188,14 @@ async fn confidential_transfer_transfer_with_proof_context() {
 
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![
-            ExtensionInitializationParams::ConfidentialTransferMint {
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::ConfidentialTransferMint {
                 authority: Some(authority.pubkey()),
                 auto_approve_new_accounts,
                 auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
-            },
-        ])
+            }],
+            &[],
+        )
         .await
         .unwrap();
 
@@ -2376,13 +2394,14 @@ async fn confidential_transfer_transfer_with_split_proof_context() {
 
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![
-            ExtensionInitializationParams::ConfidentialTransferMint {
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::ConfidentialTransferMint {
                 authority: Some(authority.pubkey()),
                 auto_approve_new_accounts,
                 auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
-            },
-        ])
+            }],
+            &[],
+        )
         .await
         .unwrap();
 
@@ -2562,13 +2581,14 @@ async fn confidential_transfer_transfer_with_split_proof_contexts_in_parallel() 
 
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![
-            ExtensionInitializationParams::ConfidentialTransferMint {
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::ConfidentialTransferMint {
                 authority: Some(authority.pubkey()),
                 auto_approve_new_accounts,
                 auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
-            },
-        ])
+            }],
+            &[],
+        )
         .await
         .unwrap();
 
@@ -2685,23 +2705,26 @@ async fn confidential_transfer_transfer_with_fee_and_split_proof_context() {
 
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![
-            ExtensionInitializationParams::TransferFeeConfig {
-                transfer_fee_config_authority: Some(transfer_fee_authority.pubkey()),
-                withdraw_withheld_authority: Some(withdraw_withheld_authority.pubkey()),
-                transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
-                maximum_fee: TEST_MAXIMUM_FEE,
-            },
-            ExtensionInitializationParams::ConfidentialTransferMint {
-                authority: Some(confidential_transfer_authority.pubkey()),
-                auto_approve_new_accounts,
-                auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
-            },
-            ExtensionInitializationParams::ConfidentialTransferFeeConfig {
-                authority: Some(confidential_transfer_fee_authority.pubkey()),
-                withdraw_withheld_authority_elgamal_pubkey,
-            },
-        ])
+        .init_token_with_mint(
+            vec![
+                ExtensionInitializationParams::TransferFeeConfig {
+                    transfer_fee_config_authority: Some(transfer_fee_authority.pubkey()),
+                    withdraw_withheld_authority: Some(withdraw_withheld_authority.pubkey()),
+                    transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
+                    maximum_fee: TEST_MAXIMUM_FEE,
+                },
+                ExtensionInitializationParams::ConfidentialTransferMint {
+                    authority: Some(confidential_transfer_authority.pubkey()),
+                    auto_approve_new_accounts,
+                    auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
+                },
+                ExtensionInitializationParams::ConfidentialTransferFeeConfig {
+                    authority: Some(confidential_transfer_fee_authority.pubkey()),
+                    withdraw_withheld_authority_elgamal_pubkey,
+                },
+            ],
+            &[],
+        )
         .await
         .unwrap();
 
@@ -2935,23 +2958,26 @@ async fn confidential_transfer_transfer_with_fee_and_split_proof_context_in_para
 
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![
-            ExtensionInitializationParams::TransferFeeConfig {
-                transfer_fee_config_authority: Some(transfer_fee_authority.pubkey()),
-                withdraw_withheld_authority: Some(withdraw_withheld_authority.pubkey()),
-                transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
-                maximum_fee: TEST_MAXIMUM_FEE,
-            },
-            ExtensionInitializationParams::ConfidentialTransferMint {
-                authority: Some(confidential_transfer_authority.pubkey()),
-                auto_approve_new_accounts,
-                auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
-            },
-            ExtensionInitializationParams::ConfidentialTransferFeeConfig {
-                authority: Some(confidential_transfer_fee_authority.pubkey()),
-                withdraw_withheld_authority_elgamal_pubkey,
-            },
-        ])
+        .init_token_with_mint(
+            vec![
+                ExtensionInitializationParams::TransferFeeConfig {
+                    transfer_fee_config_authority: Some(transfer_fee_authority.pubkey()),
+                    withdraw_withheld_authority: Some(withdraw_withheld_authority.pubkey()),
+                    transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
+                    maximum_fee: TEST_MAXIMUM_FEE,
+                },
+                ExtensionInitializationParams::ConfidentialTransferMint {
+                    authority: Some(confidential_transfer_authority.pubkey()),
+                    auto_approve_new_accounts,
+                    auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
+                },
+                ExtensionInitializationParams::ConfidentialTransferFeeConfig {
+                    authority: Some(confidential_transfer_fee_authority.pubkey()),
+                    withdraw_withheld_authority_elgamal_pubkey,
+                },
+            ],
+            &[],
+        )
         .await
         .unwrap();
 

--- a/token/program-2022-test/tests/confidential_transfer_fee.rs
+++ b/token/program-2022-test/tests/confidential_transfer_fee.rs
@@ -222,19 +222,22 @@ async fn confidential_transfer_fee_config() {
 
     // Try invalid combinations of extensions
     let err = context
-        .init_token_with_mint(vec![
-            ExtensionInitializationParams::TransferFeeConfig {
-                transfer_fee_config_authority: Some(transfer_fee_authority.pubkey()),
-                withdraw_withheld_authority: Some(withdraw_withheld_authority.pubkey()),
-                transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
-                maximum_fee: TEST_MAXIMUM_FEE,
-            },
-            ExtensionInitializationParams::ConfidentialTransferMint {
-                authority: Some(confidential_transfer_authority.pubkey()),
-                auto_approve_new_accounts,
-                auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
-            },
-        ])
+        .init_token_with_mint(
+            vec![
+                ExtensionInitializationParams::TransferFeeConfig {
+                    transfer_fee_config_authority: Some(transfer_fee_authority.pubkey()),
+                    withdraw_withheld_authority: Some(withdraw_withheld_authority.pubkey()),
+                    transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
+                    maximum_fee: TEST_MAXIMUM_FEE,
+                },
+                ExtensionInitializationParams::ConfidentialTransferMint {
+                    authority: Some(confidential_transfer_authority.pubkey()),
+                    auto_approve_new_accounts,
+                    auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
+                },
+            ],
+            &[],
+        )
         .await
         .unwrap_err();
 
@@ -249,17 +252,20 @@ async fn confidential_transfer_fee_config() {
     );
 
     let err = context
-        .init_token_with_mint(vec![
-            ExtensionInitializationParams::ConfidentialTransferMint {
-                authority: Some(confidential_transfer_authority.pubkey()),
-                auto_approve_new_accounts,
-                auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
-            },
-            ExtensionInitializationParams::ConfidentialTransferFeeConfig {
-                authority: Some(confidential_transfer_fee_authority.pubkey()),
-                withdraw_withheld_authority_elgamal_pubkey,
-            },
-        ])
+        .init_token_with_mint(
+            vec![
+                ExtensionInitializationParams::ConfidentialTransferMint {
+                    authority: Some(confidential_transfer_authority.pubkey()),
+                    auto_approve_new_accounts,
+                    auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
+                },
+                ExtensionInitializationParams::ConfidentialTransferFeeConfig {
+                    authority: Some(confidential_transfer_fee_authority.pubkey()),
+                    withdraw_withheld_authority_elgamal_pubkey,
+                },
+            ],
+            &[],
+        )
         .await
         .unwrap_err();
 
@@ -274,12 +280,15 @@ async fn confidential_transfer_fee_config() {
     );
 
     let err = context
-        .init_token_with_mint(vec![
-            ExtensionInitializationParams::ConfidentialTransferFeeConfig {
-                authority: Some(confidential_transfer_fee_authority.pubkey()),
-                withdraw_withheld_authority_elgamal_pubkey,
-            },
-        ])
+        .init_token_with_mint(
+            vec![
+                ExtensionInitializationParams::ConfidentialTransferFeeConfig {
+                    authority: Some(confidential_transfer_fee_authority.pubkey()),
+                    withdraw_withheld_authority_elgamal_pubkey,
+                },
+            ],
+            &[],
+        )
         .await
         .unwrap_err();
 
@@ -294,23 +303,26 @@ async fn confidential_transfer_fee_config() {
     );
 
     context
-        .init_token_with_mint(vec![
-            ExtensionInitializationParams::TransferFeeConfig {
-                transfer_fee_config_authority: Some(transfer_fee_authority.pubkey()),
-                withdraw_withheld_authority: Some(withdraw_withheld_authority.pubkey()),
-                transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
-                maximum_fee: TEST_MAXIMUM_FEE,
-            },
-            ExtensionInitializationParams::ConfidentialTransferMint {
-                authority: Some(confidential_transfer_authority.pubkey()),
-                auto_approve_new_accounts,
-                auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
-            },
-            ExtensionInitializationParams::ConfidentialTransferFeeConfig {
-                authority: Some(confidential_transfer_fee_authority.pubkey()),
-                withdraw_withheld_authority_elgamal_pubkey,
-            },
-        ])
+        .init_token_with_mint(
+            vec![
+                ExtensionInitializationParams::TransferFeeConfig {
+                    transfer_fee_config_authority: Some(transfer_fee_authority.pubkey()),
+                    withdraw_withheld_authority: Some(withdraw_withheld_authority.pubkey()),
+                    transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
+                    maximum_fee: TEST_MAXIMUM_FEE,
+                },
+                ExtensionInitializationParams::ConfidentialTransferMint {
+                    authority: Some(confidential_transfer_authority.pubkey()),
+                    auto_approve_new_accounts,
+                    auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
+                },
+                ExtensionInitializationParams::ConfidentialTransferFeeConfig {
+                    authority: Some(confidential_transfer_fee_authority.pubkey()),
+                    withdraw_withheld_authority_elgamal_pubkey,
+                },
+            ],
+            &[],
+        )
         .await
         .unwrap();
 }
@@ -324,13 +336,14 @@ async fn confidential_transfer_initialize_and_update_mint() {
 
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![
-            ExtensionInitializationParams::ConfidentialTransferMint {
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::ConfidentialTransferMint {
                 authority: Some(authority.pubkey()),
                 auto_approve_new_accounts,
                 auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
-            },
-        ])
+            }],
+            &[],
+        )
         .await
         .unwrap();
 
@@ -472,23 +485,26 @@ async fn confidential_transfer_withdraw_withheld_tokens_from_mint() {
 
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![
-            ExtensionInitializationParams::TransferFeeConfig {
-                transfer_fee_config_authority: Some(transfer_fee_authority.pubkey()),
-                withdraw_withheld_authority: Some(withdraw_withheld_authority.pubkey()),
-                transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
-                maximum_fee: TEST_MAXIMUM_FEE,
-            },
-            ExtensionInitializationParams::ConfidentialTransferMint {
-                authority: Some(confidential_transfer_authority.pubkey()),
-                auto_approve_new_accounts,
-                auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
-            },
-            ExtensionInitializationParams::ConfidentialTransferFeeConfig {
-                authority: Some(confidential_transfer_fee_authority.pubkey()),
-                withdraw_withheld_authority_elgamal_pubkey,
-            },
-        ])
+        .init_token_with_mint(
+            vec![
+                ExtensionInitializationParams::TransferFeeConfig {
+                    transfer_fee_config_authority: Some(transfer_fee_authority.pubkey()),
+                    withdraw_withheld_authority: Some(withdraw_withheld_authority.pubkey()),
+                    transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
+                    maximum_fee: TEST_MAXIMUM_FEE,
+                },
+                ExtensionInitializationParams::ConfidentialTransferMint {
+                    authority: Some(confidential_transfer_authority.pubkey()),
+                    auto_approve_new_accounts,
+                    auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
+                },
+                ExtensionInitializationParams::ConfidentialTransferFeeConfig {
+                    authority: Some(confidential_transfer_fee_authority.pubkey()),
+                    withdraw_withheld_authority_elgamal_pubkey,
+                },
+            ],
+            &[],
+        )
         .await
         .unwrap();
 
@@ -630,23 +646,26 @@ async fn confidential_transfer_withdraw_withheld_tokens_from_accounts() {
 
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![
-            ExtensionInitializationParams::TransferFeeConfig {
-                transfer_fee_config_authority: Some(transfer_fee_authority.pubkey()),
-                withdraw_withheld_authority: Some(withdraw_withheld_authority.pubkey()),
-                transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
-                maximum_fee: TEST_MAXIMUM_FEE,
-            },
-            ExtensionInitializationParams::ConfidentialTransferMint {
-                authority: Some(confidential_transfer_authority.pubkey()),
-                auto_approve_new_accounts,
-                auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
-            },
-            ExtensionInitializationParams::ConfidentialTransferFeeConfig {
-                authority: Some(confidential_transfer_fee_authority.pubkey()),
-                withdraw_withheld_authority_elgamal_pubkey,
-            },
-        ])
+        .init_token_with_mint(
+            vec![
+                ExtensionInitializationParams::TransferFeeConfig {
+                    transfer_fee_config_authority: Some(transfer_fee_authority.pubkey()),
+                    withdraw_withheld_authority: Some(withdraw_withheld_authority.pubkey()),
+                    transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
+                    maximum_fee: TEST_MAXIMUM_FEE,
+                },
+                ExtensionInitializationParams::ConfidentialTransferMint {
+                    authority: Some(confidential_transfer_authority.pubkey()),
+                    auto_approve_new_accounts,
+                    auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
+                },
+                ExtensionInitializationParams::ConfidentialTransferFeeConfig {
+                    authority: Some(confidential_transfer_fee_authority.pubkey()),
+                    withdraw_withheld_authority_elgamal_pubkey,
+                },
+            ],
+            &[],
+        )
         .await
         .unwrap();
 
@@ -760,23 +779,26 @@ async fn confidential_transfer_withdraw_withheld_tokens_from_mint_with_proof_con
 
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![
-            ExtensionInitializationParams::TransferFeeConfig {
-                transfer_fee_config_authority: Some(transfer_fee_authority.pubkey()),
-                withdraw_withheld_authority: Some(withdraw_withheld_authority.pubkey()),
-                transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
-                maximum_fee: TEST_MAXIMUM_FEE,
-            },
-            ExtensionInitializationParams::ConfidentialTransferMint {
-                authority: Some(confidential_transfer_authority.pubkey()),
-                auto_approve_new_accounts,
-                auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
-            },
-            ExtensionInitializationParams::ConfidentialTransferFeeConfig {
-                authority: Some(confidential_transfer_fee_authority.pubkey()),
-                withdraw_withheld_authority_elgamal_pubkey,
-            },
-        ])
+        .init_token_with_mint(
+            vec![
+                ExtensionInitializationParams::TransferFeeConfig {
+                    transfer_fee_config_authority: Some(transfer_fee_authority.pubkey()),
+                    withdraw_withheld_authority: Some(withdraw_withheld_authority.pubkey()),
+                    transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
+                    maximum_fee: TEST_MAXIMUM_FEE,
+                },
+                ExtensionInitializationParams::ConfidentialTransferMint {
+                    authority: Some(confidential_transfer_authority.pubkey()),
+                    auto_approve_new_accounts,
+                    auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
+                },
+                ExtensionInitializationParams::ConfidentialTransferFeeConfig {
+                    authority: Some(confidential_transfer_fee_authority.pubkey()),
+                    withdraw_withheld_authority_elgamal_pubkey,
+                },
+            ],
+            &[],
+        )
         .await
         .unwrap();
 
@@ -928,23 +950,26 @@ async fn confidential_transfer_withdraw_withheld_tokens_from_accounts_with_proof
 
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![
-            ExtensionInitializationParams::TransferFeeConfig {
-                transfer_fee_config_authority: Some(transfer_fee_authority.pubkey()),
-                withdraw_withheld_authority: Some(withdraw_withheld_authority.pubkey()),
-                transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
-                maximum_fee: TEST_MAXIMUM_FEE,
-            },
-            ExtensionInitializationParams::ConfidentialTransferMint {
-                authority: Some(confidential_transfer_authority.pubkey()),
-                auto_approve_new_accounts,
-                auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
-            },
-            ExtensionInitializationParams::ConfidentialTransferFeeConfig {
-                authority: Some(confidential_transfer_fee_authority.pubkey()),
-                withdraw_withheld_authority_elgamal_pubkey,
-            },
-        ])
+        .init_token_with_mint(
+            vec![
+                ExtensionInitializationParams::TransferFeeConfig {
+                    transfer_fee_config_authority: Some(transfer_fee_authority.pubkey()),
+                    withdraw_withheld_authority: Some(withdraw_withheld_authority.pubkey()),
+                    transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
+                    maximum_fee: TEST_MAXIMUM_FEE,
+                },
+                ExtensionInitializationParams::ConfidentialTransferMint {
+                    authority: Some(confidential_transfer_authority.pubkey()),
+                    auto_approve_new_accounts,
+                    auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
+                },
+                ExtensionInitializationParams::ConfidentialTransferFeeConfig {
+                    authority: Some(confidential_transfer_fee_authority.pubkey()),
+                    withdraw_withheld_authority_elgamal_pubkey,
+                },
+            ],
+            &[],
+        )
         .await
         .unwrap();
 
@@ -1112,23 +1137,26 @@ async fn confidential_transfer_harvest_withheld_tokens_to_mint() {
 
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![
-            ExtensionInitializationParams::TransferFeeConfig {
-                transfer_fee_config_authority: Some(transfer_fee_authority.pubkey()),
-                withdraw_withheld_authority: Some(withdraw_withheld_authority.pubkey()),
-                transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
-                maximum_fee: TEST_MAXIMUM_FEE,
-            },
-            ExtensionInitializationParams::ConfidentialTransferMint {
-                authority: Some(confidential_transfer_authority.pubkey()),
-                auto_approve_new_accounts,
-                auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
-            },
-            ExtensionInitializationParams::ConfidentialTransferFeeConfig {
-                authority: Some(confidential_transfer_fee_authority.pubkey()),
-                withdraw_withheld_authority_elgamal_pubkey,
-            },
-        ])
+        .init_token_with_mint(
+            vec![
+                ExtensionInitializationParams::TransferFeeConfig {
+                    transfer_fee_config_authority: Some(transfer_fee_authority.pubkey()),
+                    withdraw_withheld_authority: Some(withdraw_withheld_authority.pubkey()),
+                    transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
+                    maximum_fee: TEST_MAXIMUM_FEE,
+                },
+                ExtensionInitializationParams::ConfidentialTransferMint {
+                    authority: Some(confidential_transfer_authority.pubkey()),
+                    auto_approve_new_accounts,
+                    auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
+                },
+                ExtensionInitializationParams::ConfidentialTransferFeeConfig {
+                    authority: Some(confidential_transfer_fee_authority.pubkey()),
+                    withdraw_withheld_authority_elgamal_pubkey,
+                },
+            ],
+            &[],
+        )
         .await
         .unwrap();
 

--- a/token/program-2022-test/tests/cpi_guard.rs
+++ b/token/program-2022-test/tests/cpi_guard.rs
@@ -59,7 +59,10 @@ async fn make_context() -> TestContext {
         token_context: None,
     };
 
-    test_context.init_token_with_mint(vec![]).await.unwrap();
+    test_context
+        .init_token_with_mint(vec![], &[])
+        .await
+        .unwrap();
     let token_context = test_context.token_context.as_ref().unwrap();
 
     token_context

--- a/token/program-2022-test/tests/default_account_state.rs
+++ b/token/program-2022-test/tests/default_account_state.rs
@@ -23,9 +23,12 @@ async fn success_init_default_acct_state_frozen() {
     let default_account_state = AccountState::Frozen;
     let mut context = TestContext::new().await;
     context
-        .init_token_with_freezing_mint(vec![ExtensionInitializationParams::DefaultAccountState {
-            state: default_account_state,
-        }])
+        .init_token_with_freezing_mint(
+            vec![ExtensionInitializationParams::DefaultAccountState {
+                state: default_account_state,
+            }],
+            &[],
+        )
         .await
         .unwrap();
     let TokenContext {
@@ -60,9 +63,12 @@ async fn fail_init_no_authority_default_acct_state_frozen() {
     let default_account_state = AccountState::Frozen;
     let mut context = TestContext::new().await;
     let err = context
-        .init_token_with_mint(vec![ExtensionInitializationParams::DefaultAccountState {
-            state: default_account_state,
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::DefaultAccountState {
+                state: default_account_state,
+            }],
+            &[],
+        )
         .await
         .unwrap_err();
 
@@ -82,9 +88,12 @@ async fn success_init_default_acct_state_initialized() {
     let default_account_state = AccountState::Initialized;
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![ExtensionInitializationParams::DefaultAccountState {
-            state: default_account_state,
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::DefaultAccountState {
+                state: default_account_state,
+            }],
+            &[],
+        )
         .await
         .unwrap();
     let TokenContext {
@@ -115,9 +124,12 @@ async fn success_no_authority_init_default_acct_state_initialized() {
     let default_account_state = AccountState::Initialized;
     let mut context = TestContext::new().await;
     context
-        .init_token_with_freezing_mint(vec![ExtensionInitializationParams::DefaultAccountState {
-            state: default_account_state,
-        }])
+        .init_token_with_freezing_mint(
+            vec![ExtensionInitializationParams::DefaultAccountState {
+                state: default_account_state,
+            }],
+            &[],
+        )
         .await
         .unwrap();
     let TokenContext {
@@ -152,9 +164,12 @@ async fn fail_invalid_default_acct_state() {
     let default_account_state = AccountState::Uninitialized;
     let mut context = TestContext::new().await;
     let err = context
-        .init_token_with_freezing_mint(vec![ExtensionInitializationParams::DefaultAccountState {
-            state: default_account_state,
-        }])
+        .init_token_with_freezing_mint(
+            vec![ExtensionInitializationParams::DefaultAccountState {
+                state: default_account_state,
+            }],
+            &[],
+        )
         .await
         .unwrap_err();
     assert_eq!(
@@ -173,9 +188,12 @@ async fn end_to_end_default_account_state() {
     let default_account_state = AccountState::Frozen;
     let mut context = TestContext::new().await;
     context
-        .init_token_with_freezing_mint(vec![ExtensionInitializationParams::DefaultAccountState {
-            state: default_account_state,
-        }])
+        .init_token_with_freezing_mint(
+            vec![ExtensionInitializationParams::DefaultAccountState {
+                state: default_account_state,
+            }],
+            &[],
+        )
         .await
         .unwrap();
     let TokenContext {

--- a/token/program-2022-test/tests/delegate.rs
+++ b/token/program-2022-test/tests/delegate.rs
@@ -197,7 +197,7 @@ async fn run_basic(
 #[tokio::test]
 async fn basic() {
     let mut context = TestContext::new().await;
-    context.init_token_with_mint(vec![]).await.unwrap();
+    context.init_token_with_mint(vec![], &[]).await.unwrap();
     run_basic(
         context,
         OwnerMode::External,
@@ -210,7 +210,7 @@ async fn basic() {
 #[tokio::test]
 async fn basic_checked() {
     let mut context = TestContext::new().await;
-    context.init_token_with_mint(vec![]).await.unwrap();
+    context.init_token_with_mint(vec![], &[]).await.unwrap();
     run_basic(
         context,
         OwnerMode::External,
@@ -223,7 +223,7 @@ async fn basic_checked() {
 #[tokio::test]
 async fn basic_self_owned() {
     let mut context = TestContext::new().await;
-    context.init_token_with_mint(vec![]).await.unwrap();
+    context.init_token_with_mint(vec![], &[]).await.unwrap();
     run_basic(
         context,
         OwnerMode::SelfOwned,
@@ -237,12 +237,15 @@ async fn basic_self_owned() {
 async fn basic_with_extension() {
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![ExtensionInitializationParams::TransferFeeConfig {
-            transfer_fee_config_authority: Some(Pubkey::new_unique()),
-            withdraw_withheld_authority: Some(Pubkey::new_unique()),
-            transfer_fee_basis_points: 100u16,
-            maximum_fee: 1_000u64,
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::TransferFeeConfig {
+                transfer_fee_config_authority: Some(Pubkey::new_unique()),
+                withdraw_withheld_authority: Some(Pubkey::new_unique()),
+                transfer_fee_basis_points: 100u16,
+                maximum_fee: 1_000u64,
+            }],
+            &[],
+        )
         .await
         .unwrap();
     run_basic(
@@ -258,12 +261,15 @@ async fn basic_with_extension() {
 async fn basic_with_extension_checked() {
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![ExtensionInitializationParams::TransferFeeConfig {
-            transfer_fee_config_authority: Some(Pubkey::new_unique()),
-            withdraw_withheld_authority: Some(Pubkey::new_unique()),
-            transfer_fee_basis_points: 100u16,
-            maximum_fee: 1_000u64,
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::TransferFeeConfig {
+                transfer_fee_config_authority: Some(Pubkey::new_unique()),
+                withdraw_withheld_authority: Some(Pubkey::new_unique()),
+                transfer_fee_basis_points: 100u16,
+                maximum_fee: 1_000u64,
+            }],
+            &[],
+        )
         .await
         .unwrap();
     run_basic(
@@ -279,12 +285,15 @@ async fn basic_with_extension_checked() {
 async fn basic_self_owned_with_extension() {
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![ExtensionInitializationParams::TransferFeeConfig {
-            transfer_fee_config_authority: Some(Pubkey::new_unique()),
-            withdraw_withheld_authority: Some(Pubkey::new_unique()),
-            transfer_fee_basis_points: 100u16,
-            maximum_fee: 1_000u64,
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::TransferFeeConfig {
+                transfer_fee_config_authority: Some(Pubkey::new_unique()),
+                withdraw_withheld_authority: Some(Pubkey::new_unique()),
+                transfer_fee_basis_points: 100u16,
+                maximum_fee: 1_000u64,
+            }],
+            &[],
+        )
         .await
         .unwrap();
     run_basic(

--- a/token/program-2022-test/tests/freeze.rs
+++ b/token/program-2022-test/tests/freeze.rs
@@ -11,7 +11,10 @@ use {
 #[tokio::test]
 async fn basic() {
     let mut context = TestContext::new().await;
-    context.init_token_with_freezing_mint(vec![]).await.unwrap();
+    context
+        .init_token_with_freezing_mint(vec![], &[])
+        .await
+        .unwrap();
     let TokenContext {
         freeze_authority,
         token,

--- a/token/program-2022-test/tests/group_member_pointer.rs
+++ b/token/program-2022-test/tests/group_member_pointer.rs
@@ -1,0 +1,520 @@
+#![cfg(feature = "test-sbf")]
+
+use {
+    solana_program::system_instruction, solana_program_test::tokio::sync::Mutex,
+    spl_token_2022::extension::ExtensionType,
+};
+
+mod program_test;
+use {
+    program_test::{TestContext, TokenContext},
+    solana_program_test::{processor, tokio, ProgramTest, ProgramTestContext},
+    solana_sdk::{
+        account::{Account as SolanaAccount, AccountSharedData},
+        instruction::InstructionError,
+        pubkey::Pubkey,
+        signature::Signer,
+        signer::keypair::Keypair,
+        transaction::{Transaction, TransactionError},
+        transport::TransportError,
+    },
+    spl_token_2022::{
+        error::TokenError,
+        extension::{
+            group_member_pointer::{
+                instruction::{initialize, update},
+                GroupMemberPointer,
+            },
+            BaseStateWithExtensions,
+        },
+        instruction,
+        processor::Processor,
+        state::Mint,
+    },
+    spl_token_client::token::{ExtensionInitializationParams, TokenError as TokenClientError},
+    std::{convert::TryInto, sync::Arc},
+};
+
+fn setup_program_test() -> ProgramTest {
+    let mut program_test = ProgramTest::default();
+    program_test.prefer_bpf(false);
+    program_test.add_program(
+        "spl_token_2022",
+        spl_token_2022::id(),
+        processor!(Processor::process),
+    );
+    program_test
+}
+
+async fn setup_group_mint(
+    context: Arc<Mutex<ProgramTestContext>>,
+    mint: Keypair,
+    authority: &Pubkey,
+) -> TestContext {
+    let mut context = TestContext {
+        context,
+        token_context: None,
+    };
+    let group_address = Some(mint.pubkey());
+    context
+        .init_token_with_mint_keypair_and_freeze_authority(
+            mint,
+            vec![ExtensionInitializationParams::GroupPointer {
+                authority: Some(*authority),
+                group_address,
+            }],
+            None,
+            &[],
+        )
+        .await
+        .unwrap();
+    context
+}
+
+async fn setup_token_group(
+    token_context: &TokenContext,
+    mint_authority: &Keypair,
+    update_authority: &Pubkey,
+    payer: &Keypair,
+) {
+    token_context
+        .token
+        .token_group_initialize_with_rent_transfer(
+            &payer.pubkey(),
+            &mint_authority.pubkey(),
+            update_authority,
+            3,
+            &[&payer, &mint_authority],
+        )
+        .await
+        .unwrap();
+}
+
+async fn setup_member_mint(
+    context: Arc<Mutex<ProgramTestContext>>,
+    mint: Keypair,
+    group_address: &Pubkey,
+    authority: &Pubkey,
+    group_update_authority: &Keypair,
+) -> TestContext {
+    let mut context = TestContext {
+        context,
+        token_context: None,
+    };
+    let member_address = Some(mint.pubkey());
+    context
+        .init_token_with_mint_keypair_and_freeze_authority(
+            mint,
+            vec![ExtensionInitializationParams::GroupMemberPointer {
+                authority: Some(*authority),
+                group_address: *group_address,
+                group_update_authority: group_update_authority.pubkey(),
+                member_address,
+            }],
+            None,
+            &[&group_update_authority],
+        )
+        .await
+        .unwrap();
+    context
+}
+
+#[tokio::test]
+async fn success_init() {
+    let payer = Keypair::new();
+    let group_mint = Keypair::new();
+    let group_update_authority = Keypair::new();
+    let member_mint = Keypair::new();
+    let member_authority = Keypair::new();
+
+    let program_test = setup_program_test();
+    let mut context = program_test.start_with_context().await;
+    context.set_account(
+        &payer.pubkey(),
+        &SolanaAccount {
+            lamports: 500_000_000,
+            ..SolanaAccount::default()
+        }
+        .into(),
+    );
+    let context = Arc::new(tokio::sync::Mutex::new(context));
+
+    let group_token = setup_group_mint(
+        context.clone(),
+        group_mint.insecure_clone(),
+        &group_update_authority.pubkey(),
+    )
+    .await
+    .token_context
+    .take()
+    .unwrap();
+
+    setup_token_group(
+        &group_token,
+        &group_token.mint_authority,
+        &group_update_authority.pubkey(),
+        &payer,
+    )
+    .await;
+
+    let member_token = setup_member_mint(
+        context,
+        member_mint.insecure_clone(),
+        &group_mint.pubkey(),
+        &member_authority.pubkey(),
+        &group_update_authority,
+    )
+    .await
+    .token_context
+    .take()
+    .unwrap()
+    .token;
+
+    let state = member_token.get_mint_info().await.unwrap();
+    assert!(state.base.is_initialized);
+    let extension = state.get_extension::<GroupMemberPointer>().unwrap();
+    assert_eq!(
+        extension.authority,
+        Some(member_authority.pubkey()).try_into().unwrap()
+    );
+    assert_eq!(extension.group_address, group_mint.pubkey());
+    assert_eq!(
+        extension.member_address,
+        Some(member_mint.pubkey()).try_into().unwrap()
+    );
+}
+
+#[tokio::test]
+async fn fail_init() {
+    let payer = Keypair::new();
+    let group_mint = Keypair::new();
+    let group_update_authority = Keypair::new();
+    let member_mint = Keypair::new();
+    let member_authority = Keypair::new();
+
+    let program_test = setup_program_test();
+    let mut context = program_test.start_with_context().await;
+    context.set_account(
+        &payer.pubkey(),
+        &SolanaAccount {
+            lamports: 500_000_000,
+            ..SolanaAccount::default()
+        }
+        .into(),
+    );
+    let context = Arc::new(tokio::sync::Mutex::new(context));
+
+    let group_token = setup_group_mint(
+        context.clone(),
+        group_mint.insecure_clone(),
+        &group_update_authority.pubkey(),
+    )
+    .await
+    .token_context
+    .take()
+    .unwrap();
+
+    setup_token_group(
+        &group_token,
+        &group_token.mint_authority,
+        &group_update_authority.pubkey(),
+        &payer,
+    )
+    .await;
+
+    // fail with all none
+    let mut context = TestContext {
+        context,
+        token_context: None,
+    };
+    let err = context
+        .init_token_with_mint_keypair_and_freeze_authority(
+            Keypair::new(),
+            vec![ExtensionInitializationParams::GroupMemberPointer {
+                authority: None,
+                group_address: group_mint.pubkey(),
+                group_update_authority: group_update_authority.pubkey(),
+                member_address: None,
+            }],
+            None,
+            &[&group_update_authority],
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                1,
+                InstructionError::Custom(TokenError::InvalidInstruction as u32)
+            )
+        )))
+    );
+
+    // fail missing group update authority signature
+    let mut context = context.context.lock().await;
+    let space =
+        ExtensionType::try_calculate_account_len::<Mint>(&[ExtensionType::GroupMemberPointer])
+            .unwrap();
+    let lamports = context
+        .banks_client
+        .get_rent()
+        .await
+        .unwrap()
+        .minimum_balance(space);
+    let mut instruction = initialize(
+        &spl_token_2022::id(),
+        &member_mint.pubkey(),
+        Some(member_authority.pubkey()),
+        &group_update_authority.pubkey(),
+        &group_mint.pubkey(),
+        Some(member_mint.pubkey()),
+    )
+    .unwrap();
+    instruction.accounts[2].is_signer = false;
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &payer.pubkey(),
+                &member_mint.pubkey(),
+                lamports,
+                space as u64,
+                &spl_token_2022::id(),
+            ),
+            instruction,
+        ],
+        Some(&payer.pubkey()),
+        &[&payer, &member_mint],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(1, InstructionError::MissingRequiredSignature,)
+    );
+}
+
+#[tokio::test]
+async fn success_update() {
+    let payer = Keypair::new();
+    let group_mint = Keypair::new();
+    let group_update_authority = Keypair::new();
+    let member_mint = Keypair::new();
+    let member_authority = Keypair::new();
+
+    let program_test = setup_program_test();
+    let mut context = program_test.start_with_context().await;
+    context.set_account(
+        &payer.pubkey(),
+        &SolanaAccount {
+            lamports: 500_000_000,
+            ..SolanaAccount::default()
+        }
+        .into(),
+    );
+    let context = Arc::new(tokio::sync::Mutex::new(context));
+
+    let group_token = setup_group_mint(
+        context.clone(),
+        group_mint.insecure_clone(),
+        &group_update_authority.pubkey(),
+    )
+    .await
+    .token_context
+    .take()
+    .unwrap();
+
+    setup_token_group(
+        &group_token,
+        &group_token.mint_authority,
+        &group_update_authority.pubkey(),
+        &payer,
+    )
+    .await;
+
+    let member_token = setup_member_mint(
+        context,
+        member_mint.insecure_clone(),
+        &group_mint.pubkey(),
+        &member_authority.pubkey(),
+        &group_update_authority,
+    )
+    .await
+    .token_context
+    .take()
+    .unwrap()
+    .token;
+
+    let wrong = Keypair::new();
+    let new_member_address = Pubkey::default();
+
+    // fail, wrong signature for group update authority
+    let err = member_token
+        .update_group_member_address(
+            &member_authority.pubkey(),
+            &wrong.pubkey(),
+            &group_mint.pubkey(),
+            Some(new_member_address),
+            &[&wrong, &member_authority],
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::OwnerMismatch as u32)
+            )
+        )))
+    );
+
+    // fail, wrong signature for member pointer authority
+    let err = member_token
+        .update_group_member_address(
+            &wrong.pubkey(),
+            &group_update_authority.pubkey(),
+            &group_mint.pubkey(),
+            Some(new_member_address),
+            &[&group_update_authority, &wrong],
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::OwnerMismatch as u32)
+            )
+        )))
+    );
+
+    let mut context = context.context.lock().await;
+
+    // fail, missing group update authority signature
+    let mut instruction = update(
+        &spl_token_2022::id(),
+        &member_mint.pubkey(),
+        &member_authority.pubkey(),
+        &group_update_authority.pubkey(),
+        &[],
+        &group_mint.pubkey(),
+        Some(member_mint.pubkey()),
+    )
+    .unwrap();
+    instruction.accounts[3].is_signer = false;
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &payer.pubkey(),
+                &member_mint.pubkey(),
+                lamports,
+                space as u64,
+                &spl_token_2022::id(),
+            ),
+            instruction,
+        ],
+        Some(&payer.pubkey()),
+        &[&payer, &member_authority],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(1, InstructionError::MissingRequiredSignature,)
+    );
+
+    // fail, missing member pointer authority signature
+    let mut instruction = update(
+        &spl_token_2022::id(),
+        &member_mint.pubkey(),
+        &member_authority.pubkey(),
+        &group_update_authority.pubkey(),
+        &[],
+        &group_mint.pubkey(),
+        Some(member_mint.pubkey()),
+    )
+    .unwrap();
+    instruction.accounts[2].is_signer = false;
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::create_account(
+                &payer.pubkey(),
+                &member_mint.pubkey(),
+                lamports,
+                space as u64,
+                &spl_token_2022::id(),
+            ),
+            instruction,
+        ],
+        Some(&payer.pubkey()),
+        &[&payer, &group_update_authority],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(1, InstructionError::MissingRequiredSignature,)
+    );
+
+    // success
+    member_token
+        .update_group_member_address(
+            &member_authority.pubkey(),
+            &group_update_authority.pubkey(),
+            &group_mint.pubkey(),
+            Some(new_member_address),
+            &[&group_update_authority, &member_authority],
+        )
+        .await
+        .unwrap();
+    let state = member_token.get_mint_info().await.unwrap();
+    assert!(state.base.is_initialized);
+    let extension = state.get_extension::<GroupMemberPointer>().unwrap();
+    assert_eq!(
+        extension.authority,
+        Some(member_authority.pubkey()).try_into().unwrap()
+    );
+    assert_eq!(extension.group_address, group_mint.pubkey());
+    assert_eq!(
+        extension.member_address,
+        Some(new_member_address).try_into().unwrap()
+    );
+
+    // set to none
+    member_token
+        .update_group_member_address(
+            &member_authority.pubkey(),
+            &group_update_authority.pubkey(),
+            &group_mint.pubkey(),
+            None,
+            &[&group_update_authority, &member_authority],
+        )
+        .await
+        .unwrap();
+    let state = member_token.get_mint_info().await.unwrap();
+    assert!(state.base.is_initialized);
+    let extension = state.get_extension::<GroupMemberPointer>().unwrap();
+    assert_eq!(
+        extension.authority,
+        Some(member_authority.pubkey()).try_into().unwrap()
+    );
+    assert_eq!(extension.group_address, group_mint.pubkey());
+    assert_eq!(extension.member_address, None.try_into().unwrap());
+}

--- a/token/program-2022-test/tests/group_pointer.rs
+++ b/token/program-2022-test/tests/group_pointer.rs
@@ -46,6 +46,7 @@ async fn setup(mint: Keypair, group_address: &Pubkey, authority: &Pubkey) -> Tes
                 group_address: Some(*group_address),
             }],
             None,
+            &[],
         )
         .await
         .unwrap();
@@ -97,6 +98,7 @@ async fn fail_init_all_none() {
                 group_address: None,
             }],
             None,
+            &[],
         )
         .await
         .unwrap_err();

--- a/token/program-2022-test/tests/initialize_mint.rs
+++ b/token/program-2022-test/tests/initialize_mint.rs
@@ -32,7 +32,7 @@ use {
 #[tokio::test]
 async fn success_base() {
     let mut context = TestContext::new().await;
-    context.init_token_with_mint(vec![]).await.unwrap();
+    context.init_token_with_mint(vec![], &[]).await.unwrap();
     let TokenContext {
         decimals,
         mint_authority,
@@ -160,9 +160,10 @@ async fn success_extension_and_base() {
     let close_authority = Some(Pubkey::new_unique());
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![ExtensionInitializationParams::MintCloseAuthority {
-            close_authority,
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::MintCloseAuthority { close_authority }],
+            &[],
+        )
         .await
         .unwrap();
     let TokenContext {

--- a/token/program-2022-test/tests/interest_bearing_mint.rs
+++ b/token/program-2022-test/tests/interest_bearing_mint.rs
@@ -36,10 +36,13 @@ async fn success_initialize() {
     for (rate, rate_authority) in [(i16::MIN, None), (i16::MAX, Some(Pubkey::new_unique()))] {
         let mut context = TestContext::new().await;
         context
-            .init_token_with_mint(vec![ExtensionInitializationParams::InterestBearingConfig {
-                rate_authority,
-                rate,
-            }])
+            .init_token_with_mint(
+                vec![ExtensionInitializationParams::InterestBearingConfig {
+                    rate_authority,
+                    rate,
+                }],
+                &[],
+            )
             .await
             .unwrap();
         let TokenContext { token, .. } = context.token_context.unwrap();
@@ -61,10 +64,13 @@ async fn update_rate() {
     let initial_rate = 500;
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![ExtensionInitializationParams::InterestBearingConfig {
-            rate_authority: Some(rate_authority.pubkey()),
-            rate: initial_rate,
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::InterestBearingConfig {
+                rate_authority: Some(rate_authority.pubkey()),
+                rate: initial_rate,
+            }],
+            &[],
+        )
         .await
         .unwrap();
     let TokenContext { token, .. } = context.token_context.take().unwrap();
@@ -153,10 +159,13 @@ async fn set_authority() {
     let initial_rate = 500;
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![ExtensionInitializationParams::InterestBearingConfig {
-            rate_authority: Some(rate_authority.pubkey()),
-            rate: initial_rate,
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::InterestBearingConfig {
+                rate_authority: Some(rate_authority.pubkey()),
+                rate: initial_rate,
+            }],
+            &[],
+        )
         .await
         .unwrap();
     let TokenContext { token, .. } = context.token_context.take().unwrap();
@@ -306,10 +315,13 @@ async fn amount_conversions() {
     };
     let initial_rate = i16::MAX;
     context
-        .init_token_with_mint(vec![ExtensionInitializationParams::InterestBearingConfig {
-            rate_authority: Some(rate_authority.pubkey()),
-            rate: initial_rate,
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::InterestBearingConfig {
+                rate_authority: Some(rate_authority.pubkey()),
+                rate: initial_rate,
+            }],
+            &[],
+        )
         .await
         .unwrap();
     let TokenContext { token, .. } = context.token_context.take().unwrap();

--- a/token/program-2022-test/tests/memo_transfer.rs
+++ b/token/program-2022-test/tests/memo_transfer.rs
@@ -172,7 +172,7 @@ async fn test_memo_transfers(
 #[tokio::test]
 async fn require_memo_transfers_without_realloc() {
     let mut context = TestContext::new().await;
-    context.init_token_with_mint(vec![]).await.unwrap();
+    context.init_token_with_mint(vec![], &[]).await.unwrap();
     let token_context = context.token_context.unwrap();
 
     // create token accounts
@@ -199,7 +199,7 @@ async fn require_memo_transfers_without_realloc() {
 #[tokio::test]
 async fn require_memo_transfers_with_realloc() {
     let mut context = TestContext::new().await;
-    context.init_token_with_mint(vec![]).await.unwrap();
+    context.init_token_with_mint(vec![], &[]).await.unwrap();
     let token_context = context.token_context.unwrap();
 
     // create token accounts

--- a/token/program-2022-test/tests/metadata_pointer.rs
+++ b/token/program-2022-test/tests/metadata_pointer.rs
@@ -46,6 +46,7 @@ async fn setup(mint: Keypair, metadata_address: &Pubkey, authority: &Pubkey) -> 
                 metadata_address: Some(*metadata_address),
             }],
             None,
+            &[],
         )
         .await
         .unwrap();
@@ -97,6 +98,7 @@ async fn fail_init_all_none() {
                 metadata_address: None,
             }],
             None,
+            &[],
         )
         .await
         .unwrap_err();

--- a/token/program-2022-test/tests/mint_close_authority.rs
+++ b/token/program-2022-test/tests/mint_close_authority.rs
@@ -22,9 +22,10 @@ async fn success_init() {
     let close_authority = Some(Pubkey::new_unique());
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![ExtensionInitializationParams::MintCloseAuthority {
-            close_authority,
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::MintCloseAuthority { close_authority }],
+            &[],
+        )
         .await
         .unwrap();
     let TokenContext {
@@ -55,9 +56,12 @@ async fn set_authority() {
     let close_authority = Keypair::new();
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![ExtensionInitializationParams::MintCloseAuthority {
-            close_authority: Some(close_authority.pubkey()),
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::MintCloseAuthority {
+                close_authority: Some(close_authority.pubkey()),
+            }],
+            &[],
+        )
         .await
         .unwrap();
     let token = context.token_context.unwrap().token;
@@ -166,9 +170,12 @@ async fn success_close() {
     let close_authority = Keypair::new();
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![ExtensionInitializationParams::MintCloseAuthority {
-            close_authority: Some(close_authority.pubkey()),
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::MintCloseAuthority {
+                close_authority: Some(close_authority.pubkey()),
+            }],
+            &[],
+        )
         .await
         .unwrap();
     let token = context.token_context.unwrap().token;
@@ -191,7 +198,7 @@ async fn success_close() {
 async fn fail_without_extension() {
     let close_authority = Pubkey::new_unique();
     let mut context = TestContext::new().await;
-    context.init_token_with_mint(vec![]).await.unwrap();
+    context.init_token_with_mint(vec![], &[]).await.unwrap();
     let TokenContext {
         mint_authority,
         token,
@@ -240,9 +247,12 @@ async fn fail_close_with_supply() {
     let close_authority = Keypair::new();
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![ExtensionInitializationParams::MintCloseAuthority {
-            close_authority: Some(close_authority.pubkey()),
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::MintCloseAuthority {
+                close_authority: Some(close_authority.pubkey()),
+            }],
+            &[],
+        )
         .await
         .unwrap();
     let TokenContext {

--- a/token/program-2022-test/tests/non_transferable.rs
+++ b/token/program-2022-test/tests/non_transferable.rs
@@ -20,7 +20,7 @@ async fn transfer() {
     let test_transfer_amount = 100;
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![ExtensionInitializationParams::NonTransferable])
+        .init_token_with_mint(vec![ExtensionInitializationParams::NonTransferable], &[])
         .await
         .unwrap();
 
@@ -166,15 +166,18 @@ async fn transfer_checked_with_fee() {
 
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![
-            ExtensionInitializationParams::TransferFeeConfig {
-                transfer_fee_config_authority: transfer_fee_config_authority.pubkey().into(),
-                withdraw_withheld_authority: withdraw_withheld_authority.pubkey().into(),
-                transfer_fee_basis_points,
-                maximum_fee,
-            },
-            ExtensionInitializationParams::NonTransferable,
-        ])
+        .init_token_with_mint(
+            vec![
+                ExtensionInitializationParams::TransferFeeConfig {
+                    transfer_fee_config_authority: transfer_fee_config_authority.pubkey().into(),
+                    withdraw_withheld_authority: withdraw_withheld_authority.pubkey().into(),
+                    transfer_fee_basis_points,
+                    maximum_fee,
+                },
+                ExtensionInitializationParams::NonTransferable,
+            ],
+            &[],
+        )
         .await
         .unwrap();
 

--- a/token/program-2022-test/tests/permanent_delegate.rs
+++ b/token/program-2022-test/tests/permanent_delegate.rs
@@ -52,9 +52,10 @@ async fn success_init() {
     let delegate = Pubkey::new_unique();
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![ExtensionInitializationParams::PermanentDelegate {
-            delegate,
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::PermanentDelegate { delegate }],
+            &[],
+        )
         .await
         .unwrap();
     let TokenContext { token, .. } = context.token_context.unwrap();
@@ -70,9 +71,12 @@ async fn set_authority() {
     let delegate = Keypair::new();
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![ExtensionInitializationParams::PermanentDelegate {
-            delegate: delegate.pubkey(),
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::PermanentDelegate {
+                delegate: delegate.pubkey(),
+            }],
+            &[],
+        )
         .await
         .unwrap();
     let token_context = context.token_context.unwrap();
@@ -191,9 +195,12 @@ async fn success_transfer() {
     let delegate = Keypair::new();
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![ExtensionInitializationParams::PermanentDelegate {
-            delegate: delegate.pubkey(),
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::PermanentDelegate {
+                delegate: delegate.pubkey(),
+            }],
+            &[],
+        )
         .await
         .unwrap();
     let token_context = context.token_context.unwrap();
@@ -225,9 +232,12 @@ async fn success_burn() {
     let delegate = Keypair::new();
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![ExtensionInitializationParams::PermanentDelegate {
-            delegate: delegate.pubkey(),
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::PermanentDelegate {
+                delegate: delegate.pubkey(),
+            }],
+            &[],
+        )
         .await
         .unwrap();
     let token_context = context.token_context.unwrap();
@@ -252,7 +262,7 @@ async fn success_burn() {
 async fn fail_without_extension() {
     let delegate = Pubkey::new_unique();
     let mut context = TestContext::new().await;
-    context.init_token_with_mint(vec![]).await.unwrap();
+    context.init_token_with_mint(vec![], &[]).await.unwrap();
     let token_context = context.token_context.unwrap();
 
     // fail set

--- a/token/program-2022-test/tests/reallocate.rs
+++ b/token/program-2022-test/tests/reallocate.rs
@@ -23,7 +23,7 @@ use {
 #[tokio::test]
 async fn reallocate() {
     let mut context = TestContext::new().await;
-    context.init_token_with_mint(vec![]).await.unwrap();
+    context.init_token_with_mint(vec![], &[]).await.unwrap();
     let TokenContext {
         token,
         alice,
@@ -161,12 +161,19 @@ async fn reallocate() {
 async fn reallocate_without_current_extension_knowledge() {
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![ExtensionInitializationParams::TransferFeeConfig {
-            transfer_fee_config_authority: COption::Some(Pubkey::new_unique()).try_into().unwrap(),
-            withdraw_withheld_authority: COption::Some(Pubkey::new_unique()).try_into().unwrap(),
-            transfer_fee_basis_points: 250,
-            maximum_fee: 10_000_000,
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::TransferFeeConfig {
+                transfer_fee_config_authority: COption::Some(Pubkey::new_unique())
+                    .try_into()
+                    .unwrap(),
+                withdraw_withheld_authority: COption::Some(Pubkey::new_unique())
+                    .try_into()
+                    .unwrap(),
+                transfer_fee_basis_points: 250,
+                maximum_fee: 10_000_000,
+            }],
+            &[],
+        )
         .await
         .unwrap();
     let TokenContext { token, alice, .. } = context.token_context.unwrap();

--- a/token/program-2022-test/tests/token_group_initialize.rs
+++ b/token/program-2022-test/tests/token_group_initialize.rs
@@ -43,6 +43,7 @@ async fn setup(mint: Keypair, authority: &Pubkey) -> TestContext {
                 group_address,
             }],
             None,
+            &[],
         )
         .await
         .unwrap();
@@ -159,7 +160,7 @@ async fn fail_without_group_pointer() {
             token_context: None,
         };
         context
-            .init_token_with_mint_keypair_and_freeze_authority(mint_keypair, vec![], None)
+            .init_token_with_mint_keypair_and_freeze_authority(mint_keypair, vec![], None, &[])
             .await
             .unwrap();
         context
@@ -206,6 +207,7 @@ async fn fail_init_in_another_mint() {
                 group_address: Some(second_mint),
             }],
             None,
+            &[],
         )
         .await
         .unwrap();

--- a/token/program-2022-test/tests/token_group_update_authority.rs
+++ b/token/program-2022-test/tests/token_group_update_authority.rs
@@ -1,0 +1,202 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+use {
+    program_test::TestContext,
+    solana_program_test::{processor, tokio, ProgramTest},
+    solana_sdk::{
+        instruction::InstructionError,
+        pubkey::Pubkey,
+        signature::Signer,
+        signer::keypair::Keypair,
+        transaction::{Transaction, TransactionError},
+        transport::TransportError,
+    },
+    spl_pod::optional_keys::OptionalNonZeroPubkey,
+    spl_token_2022::{extension::BaseStateWithExtensions, processor::Processor},
+    spl_token_client::token::{ExtensionInitializationParams, TokenError as TokenClientError},
+    spl_token_group_interface::{
+        error::TokenGroupError, instruction::update_group_authority, state::TokenGroup,
+    },
+    std::{convert::TryInto, sync::Arc},
+};
+
+fn setup_program_test() -> ProgramTest {
+    let mut program_test = ProgramTest::default();
+    program_test.add_program(
+        "spl_token_2022",
+        spl_token_2022::id(),
+        processor!(Processor::process),
+    );
+    program_test
+}
+
+async fn setup(mint: Keypair, authority: &Pubkey) -> TestContext {
+    let program_test = setup_program_test();
+
+    let context = program_test.start_with_context().await;
+    let context = Arc::new(tokio::sync::Mutex::new(context));
+    let mut context = TestContext {
+        context,
+        token_context: None,
+    };
+    let group_address = Some(mint.pubkey());
+    context
+        .init_token_with_mint_keypair_and_freeze_authority(
+            mint,
+            vec![ExtensionInitializationParams::GroupPointer {
+                authority: Some(*authority),
+                group_address,
+            }],
+            None,
+        )
+        .await
+        .unwrap();
+    context
+}
+
+#[tokio::test]
+async fn success_update() {
+    let authority = Keypair::new();
+    let mint_keypair = Keypair::new();
+    let mut test_context = setup(mint_keypair.insecure_clone(), &authority.pubkey()).await;
+    let payer_pubkey = test_context.context.lock().await.payer.pubkey();
+    let token_context = test_context.token_context.take().unwrap();
+
+    let update_authority = Keypair::new();
+    let mut token_group = TokenGroup::new(
+        &mint_keypair.pubkey(),
+        Some(update_authority.pubkey()).try_into().unwrap(),
+        10,
+    );
+
+    token_context
+        .token
+        .token_group_initialize_with_rent_transfer(
+            &payer_pubkey,
+            &token_context.mint_authority.pubkey(),
+            &update_authority.pubkey(),
+            10,
+            &[&token_context.mint_authority],
+        )
+        .await
+        .unwrap();
+
+    let new_update_authority = Keypair::new();
+    let new_update_authority_pubkey =
+        OptionalNonZeroPubkey::try_from(Some(new_update_authority.pubkey())).unwrap();
+    token_group.update_authority = new_update_authority_pubkey;
+
+    token_context
+        .token
+        .token_group_update_authority(
+            &update_authority.pubkey(),
+            Some(new_update_authority.pubkey()),
+            &[&update_authority],
+        )
+        .await
+        .unwrap();
+
+    // check that the data is correct
+    let mint = token_context.token.get_mint_info().await.unwrap();
+    let fetched_group = mint.get_extension::<TokenGroup>().unwrap();
+    assert_eq!(fetched_group, &token_group);
+
+    // unset
+    token_group.update_authority = None.try_into().unwrap();
+    token_context
+        .token
+        .token_group_update_authority(
+            &new_update_authority.pubkey(),
+            None,
+            &[&new_update_authority],
+        )
+        .await
+        .unwrap();
+
+    let mint = token_context.token.get_mint_info().await.unwrap();
+    let fetched_group = mint.get_extension::<TokenGroup>().unwrap();
+    assert_eq!(fetched_group, &token_group);
+
+    // fail to update
+    let error = token_context
+        .token
+        .token_group_update_authority(
+            &new_update_authority.pubkey(),
+            Some(new_update_authority.pubkey()),
+            &[&new_update_authority],
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenGroupError::ImmutableGroup as u32)
+            )
+        )))
+    );
+}
+
+#[tokio::test]
+async fn fail_authority_checks() {
+    let program_id = spl_token_2022::id();
+    let authority = Keypair::new();
+    let mint_keypair = Keypair::new();
+    let mint_pubkey = mint_keypair.pubkey();
+    let mut test_context = setup(mint_keypair, &authority.pubkey()).await;
+    let payer_pubkey = test_context.context.lock().await.payer.pubkey();
+    let token_context = test_context.token_context.take().unwrap();
+
+    let update_authority = Keypair::new();
+    token_context
+        .token
+        .token_group_initialize_with_rent_transfer(
+            &payer_pubkey,
+            &token_context.mint_authority.pubkey(),
+            &update_authority.pubkey(),
+            10,
+            &[&token_context.mint_authority],
+        )
+        .await
+        .unwrap();
+
+    // wrong authority
+    let error = token_context
+        .token
+        .token_group_update_authority(&payer_pubkey, None, &[] as &[&dyn Signer; 0])
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenGroupError::IncorrectUpdateAuthority as u32),
+            )
+        )))
+    );
+
+    // no signature
+    let mut context = test_context.context.lock().await;
+    let mut instruction =
+        update_group_authority(&program_id, &mint_pubkey, &authority.pubkey(), None);
+    instruction.accounts[1].is_signer = false;
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+    let error = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(
+        error,
+        TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature,)
+    );
+}

--- a/token/program-2022-test/tests/token_group_update_authority.rs
+++ b/token/program-2022-test/tests/token_group_update_authority.rs
@@ -49,6 +49,7 @@ async fn setup(mint: Keypair, authority: &Pubkey) -> TestContext {
                 group_address,
             }],
             None,
+            &[],
         )
         .await
         .unwrap();

--- a/token/program-2022-test/tests/token_group_update_max_size.rs
+++ b/token/program-2022-test/tests/token_group_update_max_size.rs
@@ -1,0 +1,249 @@
+#![cfg(feature = "test-sbf")]
+#![allow(clippy::items_after_test_module)]
+
+mod program_test;
+use {
+    program_test::TestContext,
+    solana_program_test::{processor, tokio, ProgramTest},
+    solana_sdk::{
+        account::Account as SolanaAccount, instruction::InstructionError, pubkey::Pubkey,
+        signature::Signer, signer::keypair::Keypair, transaction::TransactionError,
+        transport::TransportError,
+    },
+    spl_token_2022::{extension::BaseStateWithExtensions, processor::Processor},
+    spl_token_client::token::{ExtensionInitializationParams, TokenError as TokenClientError},
+    spl_token_group_interface::{
+        error::TokenGroupError, instruction::update_group_max_size, state::TokenGroup,
+    },
+    std::{convert::TryInto, sync::Arc},
+    test_case::test_case,
+};
+
+fn setup_program_test() -> ProgramTest {
+    let mut program_test = ProgramTest::default();
+    program_test.add_program(
+        "spl_token_2022",
+        spl_token_2022::id(),
+        processor!(Processor::process),
+    );
+    program_test
+}
+
+async fn setup(mint: Keypair, authority: &Pubkey) -> TestContext {
+    let program_test = setup_program_test();
+
+    let context = program_test.start_with_context().await;
+    let context = Arc::new(tokio::sync::Mutex::new(context));
+    let mut context = TestContext {
+        context,
+        token_context: None,
+    };
+    let group_address = Some(mint.pubkey());
+    context
+        .init_token_with_mint_keypair_and_freeze_authority(
+            mint,
+            vec![ExtensionInitializationParams::GroupPointer {
+                authority: Some(*authority),
+                group_address,
+            }],
+            None,
+        )
+        .await
+        .unwrap();
+    context
+}
+
+// Successful attempts to set higher than size
+#[test_case(0, 0, 10)]
+#[test_case(5, 0, 10)]
+#[test_case(50, 0, 200_000)]
+#[test_case(100_000, 100_000, 200_000)]
+#[test_case(50, 0, 300_000_000)]
+#[test_case(100_000, 100_000, 300_000_000)]
+#[test_case(100_000_000, 100_000_000, 300_000_000)]
+#[test_case(0, 0, u32::MAX)]
+#[test_case(200_000, 200_000, u32::MAX)]
+#[test_case(300_000_000, 300_000_000, u32::MAX)]
+// Attempts to set lower than size
+#[test_case(5, 5, 4)]
+#[test_case(200_000, 200_000, 50)]
+#[test_case(200_000, 200_000, 100_000)]
+#[test_case(300_000_000, 300_000_000, 50)]
+#[test_case(u32::MAX, u32::MAX, 0)]
+#[tokio::test]
+async fn test_update_group_max_size(max_size: u32, size: u32, new_max_size: u32) {
+    let authority = Keypair::new();
+    let mint_keypair = Keypair::new();
+    let mut test_context = setup(mint_keypair.insecure_clone(), &authority.pubkey()).await;
+    let payer_pubkey = test_context.context.lock().await.payer.pubkey();
+    let token_context = test_context.token_context.take().unwrap();
+
+    let update_authority = Keypair::new();
+    let mut token_group = TokenGroup::new(
+        &mint_keypair.pubkey(),
+        Some(update_authority.pubkey()).try_into().unwrap(),
+        max_size,
+    );
+
+    token_context
+        .token
+        .token_group_initialize_with_rent_transfer(
+            &payer_pubkey,
+            &token_context.mint_authority.pubkey(),
+            &update_authority.pubkey(),
+            max_size,
+            &[&token_context.mint_authority],
+        )
+        .await
+        .unwrap();
+
+    {
+        // Update the group's size manually
+        let mut context = test_context.context.lock().await;
+
+        let group_mint_account = context
+            .banks_client
+            .get_account(mint_keypair.pubkey())
+            .await
+            .unwrap()
+            .unwrap();
+
+        let old_data = context
+            .banks_client
+            .get_account(mint_keypair.pubkey())
+            .await
+            .unwrap()
+            .unwrap()
+            .data;
+
+        let data = {
+            // 0....81:     mint
+            // 82...164:    padding
+            // 165..166:    account type
+            // 167..170:    extension discriminator (GroupPointer)
+            // 171..202:    authority
+            // 203..234:    group pointer
+            // 235..238:    extension discriminator (TokenGroup)
+            // 239..270:    mint
+            // 271..302:    update_authority
+            // 303..306:    size
+            // 307..310:    max_size
+            let (front, back) = old_data.split_at(302);
+            let (_, back) = back.split_at(3);
+            let size_bytes = size.to_le_bytes();
+            let mut bytes = vec![];
+            bytes.extend_from_slice(front);
+            bytes.extend_from_slice(&size_bytes);
+            bytes.extend_from_slice(back);
+            bytes
+        };
+
+        context.set_account(
+            &mint_keypair.pubkey(),
+            &SolanaAccount {
+                data,
+                ..group_mint_account
+            }
+            .into(),
+        );
+
+        token_group.size = size.into();
+    }
+
+    token_group.max_size = new_max_size.into();
+
+    if new_max_size < size {
+        let error = token_context
+            .token
+            .token_group_update_max_size(
+                &update_authority.pubkey(),
+                new_max_size,
+                &[&update_authority],
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(
+            error,
+            TokenClientError::Client(Box::new(TransportError::TransactionError(
+                TransactionError::InstructionError(
+                    0,
+                    InstructionError::Custom(TokenGroupError::SizeExceedsNewMaxSize as u32)
+                )
+            ))),
+        );
+    } else {
+        token_context
+            .token
+            .token_group_update_max_size(
+                &update_authority.pubkey(),
+                new_max_size,
+                &[&update_authority],
+            )
+            .await
+            .unwrap();
+
+        let mint_info = token_context.token.get_mint_info().await.unwrap();
+        let fetched_group = mint_info.get_extension::<TokenGroup>().unwrap();
+        assert_eq!(fetched_group, &token_group);
+    }
+}
+
+#[tokio::test]
+async fn fail_authority_checks() {
+    let authority = Keypair::new();
+    let mint_keypair = Keypair::new();
+    let mut test_context = setup(mint_keypair, &authority.pubkey()).await;
+    let payer_pubkey = test_context.context.lock().await.payer.pubkey();
+    let token_context = test_context.token_context.take().unwrap();
+
+    let update_authority = Keypair::new();
+    token_context
+        .token
+        .token_group_initialize_with_rent_transfer(
+            &payer_pubkey,
+            &token_context.mint_authority.pubkey(),
+            &update_authority.pubkey(),
+            10,
+            &[&token_context.mint_authority],
+        )
+        .await
+        .unwrap();
+
+    // no signature
+    let mut instruction = update_group_max_size(
+        &spl_token_2022::id(),
+        token_context.token.get_address(),
+        &update_authority.pubkey(),
+        20,
+    );
+    instruction.accounts[1].is_signer = false;
+
+    let error = token_context
+        .token
+        .process_ixs(&[instruction], &[] as &[&dyn Signer; 0]) // yuck, but the compiler needs it
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature)
+        )))
+    );
+
+    // wrong authority
+    let wrong_authority = Keypair::new();
+    let error = token_context
+        .token
+        .token_group_update_max_size(&wrong_authority.pubkey(), 20, &[&wrong_authority])
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenGroupError::IncorrectUpdateAuthority as u32)
+            )
+        )))
+    );
+}

--- a/token/program-2022-test/tests/token_group_update_max_size.rs
+++ b/token/program-2022-test/tests/token_group_update_max_size.rs
@@ -47,6 +47,7 @@ async fn setup(mint: Keypair, authority: &Pubkey) -> TestContext {
                 group_address,
             }],
             None,
+            &[],
         )
         .await
         .unwrap();

--- a/token/program-2022-test/tests/token_metadata_emit.rs
+++ b/token/program-2022-test/tests/token_metadata_emit.rs
@@ -45,6 +45,7 @@ async fn setup(mint: Keypair, authority: &Pubkey) -> TestContext {
                 metadata_address,
             }],
             None,
+            &[],
         )
         .await
         .unwrap();

--- a/token/program-2022-test/tests/token_metadata_initialize.rs
+++ b/token/program-2022-test/tests/token_metadata_initialize.rs
@@ -43,6 +43,7 @@ async fn setup(mint: Keypair, authority: &Pubkey) -> TestContext {
                 metadata_address,
             }],
             None,
+            &[],
         )
         .await
         .unwrap();
@@ -172,7 +173,7 @@ async fn fail_without_metadata_pointer() {
             token_context: None,
         };
         context
-            .init_token_with_mint_keypair_and_freeze_authority(mint_keypair, vec![], None)
+            .init_token_with_mint_keypair_and_freeze_authority(mint_keypair, vec![], None, &[])
             .await
             .unwrap();
         context
@@ -221,6 +222,7 @@ async fn fail_init_in_another_mint() {
                 metadata_address: Some(second_mint),
             }],
             None,
+            &[],
         )
         .await
         .unwrap();

--- a/token/program-2022-test/tests/token_metadata_remove_key.rs
+++ b/token/program-2022-test/tests/token_metadata_remove_key.rs
@@ -50,6 +50,7 @@ async fn setup(mint: Keypair, authority: &Pubkey) -> TestContext {
                 metadata_address,
             }],
             None,
+            &[],
         )
         .await
         .unwrap();

--- a/token/program-2022-test/tests/token_metadata_update_authority.rs
+++ b/token/program-2022-test/tests/token_metadata_update_authority.rs
@@ -49,6 +49,7 @@ async fn setup(mint: Keypair, authority: &Pubkey) -> TestContext {
                 metadata_address,
             }],
             None,
+            &[],
         )
         .await
         .unwrap();

--- a/token/program-2022-test/tests/token_metadata_update_field.rs
+++ b/token/program-2022-test/tests/token_metadata_update_field.rs
@@ -48,6 +48,7 @@ async fn setup(mint: Keypair, authority: &Pubkey) -> TestContext {
                 metadata_address,
             }],
             None,
+            &[],
         )
         .await
         .unwrap();

--- a/token/program-2022-test/tests/transfer.rs
+++ b/token/program-2022-test/tests/transfer.rs
@@ -107,7 +107,7 @@ async fn run_basic_transfers(context: TestContext, test_mode: TestMode) {
 #[tokio::test]
 async fn basic() {
     let mut context = TestContext::new().await;
-    context.init_token_with_mint(vec![]).await.unwrap();
+    context.init_token_with_mint(vec![], &[]).await.unwrap();
     run_basic_transfers(context, TestMode::All).await;
 }
 
@@ -115,12 +115,15 @@ async fn basic() {
 async fn basic_with_extension() {
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![ExtensionInitializationParams::TransferFeeConfig {
-            transfer_fee_config_authority: Some(Pubkey::new_unique()),
-            withdraw_withheld_authority: Some(Pubkey::new_unique()),
-            transfer_fee_basis_points: 100u16,
-            maximum_fee: 1_000_000u64,
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::TransferFeeConfig {
+                transfer_fee_config_authority: Some(Pubkey::new_unique()),
+                withdraw_withheld_authority: Some(Pubkey::new_unique()),
+                transfer_fee_basis_points: 100u16,
+                maximum_fee: 1_000_000u64,
+            }],
+            &[],
+        )
         .await
         .unwrap();
     run_basic_transfers(context, TestMode::CheckedOnly).await;
@@ -203,7 +206,7 @@ async fn run_self_transfers(context: TestContext, test_mode: TestMode) {
 #[tokio::test]
 async fn self_transfer() {
     let mut context = TestContext::new().await;
-    context.init_token_with_mint(vec![]).await.unwrap();
+    context.init_token_with_mint(vec![], &[]).await.unwrap();
     run_self_transfers(context, TestMode::All).await;
 }
 
@@ -211,12 +214,15 @@ async fn self_transfer() {
 async fn self_transfer_with_extension() {
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![ExtensionInitializationParams::TransferFeeConfig {
-            transfer_fee_config_authority: Some(Pubkey::new_unique()),
-            withdraw_withheld_authority: Some(Pubkey::new_unique()),
-            transfer_fee_basis_points: 100u16,
-            maximum_fee: 1_000_000u64,
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::TransferFeeConfig {
+                transfer_fee_config_authority: Some(Pubkey::new_unique()),
+                withdraw_withheld_authority: Some(Pubkey::new_unique()),
+                transfer_fee_basis_points: 100u16,
+                maximum_fee: 1_000_000u64,
+            }],
+            &[],
+        )
         .await
         .unwrap();
     run_self_transfers(context, TestMode::CheckedOnly).await;
@@ -286,7 +292,7 @@ async fn run_self_owned(context: TestContext, test_mode: TestMode) {
 #[tokio::test]
 async fn self_owned() {
     let mut context = TestContext::new().await;
-    context.init_token_with_mint(vec![]).await.unwrap();
+    context.init_token_with_mint(vec![], &[]).await.unwrap();
     run_self_owned(context, TestMode::All).await;
 }
 
@@ -294,12 +300,15 @@ async fn self_owned() {
 async fn self_owned_with_extension() {
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![ExtensionInitializationParams::TransferFeeConfig {
-            transfer_fee_config_authority: Some(Pubkey::new_unique()),
-            withdraw_withheld_authority: Some(Pubkey::new_unique()),
-            transfer_fee_basis_points: 100u16,
-            maximum_fee: 1_000_000u64,
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::TransferFeeConfig {
+                transfer_fee_config_authority: Some(Pubkey::new_unique()),
+                withdraw_withheld_authority: Some(Pubkey::new_unique()),
+                transfer_fee_basis_points: 100u16,
+                maximum_fee: 1_000_000u64,
+            }],
+            &[],
+        )
         .await
         .unwrap();
     run_self_owned(context, TestMode::CheckedOnly).await;
@@ -308,7 +317,7 @@ async fn self_owned_with_extension() {
 #[tokio::test]
 async fn transfer_with_fee_on_mint_without_fee_configured() {
     let mut context = TestContext::new().await;
-    context.init_token_with_mint(vec![]).await.unwrap();
+    context.init_token_with_mint(vec![], &[]).await.unwrap();
     let TokenContext {
         mint_authority,
         token,

--- a/token/program-2022-test/tests/transfer_fee.rs
+++ b/token/program-2022-test/tests/transfer_fee.rs
@@ -102,12 +102,15 @@ async fn create_mint_with_accounts(alice_amount: u64) -> TokenWithAccounts {
     );
     let maximum_fee = u64::from(transfer_fee_config.newer_transfer_fee.maximum_fee);
     context
-        .init_token_with_freezing_mint(vec![ExtensionInitializationParams::TransferFeeConfig {
-            transfer_fee_config_authority: transfer_fee_config_authority.pubkey().into(),
-            withdraw_withheld_authority: withdraw_withheld_authority.pubkey().into(),
-            transfer_fee_basis_points,
-            maximum_fee,
-        }])
+        .init_token_with_freezing_mint(
+            vec![ExtensionInitializationParams::TransferFeeConfig {
+                transfer_fee_config_authority: transfer_fee_config_authority.pubkey().into(),
+                withdraw_withheld_authority: withdraw_withheld_authority.pubkey().into(),
+                transfer_fee_basis_points,
+                maximum_fee,
+            }],
+            &[],
+        )
         .await
         .unwrap();
     let TokenContext {
@@ -166,12 +169,15 @@ async fn success_init() {
     } = test_transfer_fee_config();
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![ExtensionInitializationParams::TransferFeeConfig {
-            transfer_fee_config_authority: transfer_fee_config_authority.into(),
-            withdraw_withheld_authority: withdraw_withheld_authority.into(),
-            transfer_fee_basis_points: newer_transfer_fee.transfer_fee_basis_points.into(),
-            maximum_fee: newer_transfer_fee.maximum_fee.into(),
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::TransferFeeConfig {
+                transfer_fee_config_authority: transfer_fee_config_authority.into(),
+                withdraw_withheld_authority: withdraw_withheld_authority.into(),
+                transfer_fee_basis_points: newer_transfer_fee.transfer_fee_basis_points.into(),
+                maximum_fee: newer_transfer_fee.maximum_fee.into(),
+            }],
+            &[],
+        )
         .await
         .unwrap();
     let TokenContext {
@@ -212,12 +218,15 @@ async fn fail_init_default_pubkey_as_authority() {
     } = test_transfer_fee_config();
     let mut context = TestContext::new().await;
     let err = context
-        .init_token_with_mint(vec![ExtensionInitializationParams::TransferFeeConfig {
-            transfer_fee_config_authority: transfer_fee_config_authority.into(),
-            withdraw_withheld_authority: Some(Pubkey::default()),
-            transfer_fee_basis_points: newer_transfer_fee.transfer_fee_basis_points.into(),
-            maximum_fee: newer_transfer_fee.maximum_fee.into(),
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::TransferFeeConfig {
+                transfer_fee_config_authority: transfer_fee_config_authority.into(),
+                withdraw_withheld_authority: Some(Pubkey::default()),
+                transfer_fee_basis_points: newer_transfer_fee.transfer_fee_basis_points.into(),
+                maximum_fee: newer_transfer_fee.maximum_fee.into(),
+            }],
+            &[],
+        )
         .await
         .unwrap_err();
     assert_eq!(
@@ -238,12 +247,15 @@ async fn fail_init_fee_too_high() {
     } = test_transfer_fee_config();
     let mut context = TestContext::new().await;
     let err = context
-        .init_token_with_mint(vec![ExtensionInitializationParams::TransferFeeConfig {
-            transfer_fee_config_authority: transfer_fee_config_authority.into(),
-            withdraw_withheld_authority: withdraw_withheld_authority.into(),
-            transfer_fee_basis_points: MAX_FEE_BASIS_POINTS + 1,
-            maximum_fee: newer_transfer_fee.maximum_fee.into(),
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::TransferFeeConfig {
+                transfer_fee_config_authority: transfer_fee_config_authority.into(),
+                withdraw_withheld_authority: withdraw_withheld_authority.into(),
+                transfer_fee_basis_points: MAX_FEE_BASIS_POINTS + 1,
+                maximum_fee: newer_transfer_fee.maximum_fee.into(),
+            }],
+            &[],
+        )
         .await
         .unwrap_err();
     assert_eq!(
@@ -269,12 +281,15 @@ async fn set_fee() {
     } = test_transfer_fee_config_with_keypairs();
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![ExtensionInitializationParams::TransferFeeConfig {
-            transfer_fee_config_authority: transfer_fee_config_authority.pubkey().into(),
-            withdraw_withheld_authority: withdraw_withheld_authority.pubkey().into(),
-            transfer_fee_basis_points: newer_transfer_fee.transfer_fee_basis_points.into(),
-            maximum_fee: newer_transfer_fee.maximum_fee.into(),
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::TransferFeeConfig {
+                transfer_fee_config_authority: transfer_fee_config_authority.pubkey().into(),
+                withdraw_withheld_authority: withdraw_withheld_authority.pubkey().into(),
+                transfer_fee_basis_points: newer_transfer_fee.transfer_fee_basis_points.into(),
+                maximum_fee: newer_transfer_fee.maximum_fee.into(),
+            }],
+            &[],
+        )
         .await
         .unwrap();
 
@@ -451,7 +466,7 @@ async fn set_fee() {
 #[tokio::test]
 async fn fail_unsupported_mint() {
     let mut context = TestContext::new().await;
-    context.init_token_with_mint(vec![]).await.unwrap();
+    context.init_token_with_mint(vec![], &[]).await.unwrap();
     let TokenContext {
         mint_authority,
         token,
@@ -515,12 +530,15 @@ async fn set_transfer_fee_config_authority() {
     } = test_transfer_fee_config_with_keypairs();
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![ExtensionInitializationParams::TransferFeeConfig {
-            transfer_fee_config_authority: transfer_fee_config_authority.pubkey().into(),
-            withdraw_withheld_authority: withdraw_withheld_authority.pubkey().into(),
-            transfer_fee_basis_points: newer_transfer_fee.transfer_fee_basis_points.into(),
-            maximum_fee: newer_transfer_fee.maximum_fee.into(),
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::TransferFeeConfig {
+                transfer_fee_config_authority: transfer_fee_config_authority.pubkey().into(),
+                withdraw_withheld_authority: withdraw_withheld_authority.pubkey().into(),
+                transfer_fee_basis_points: newer_transfer_fee.transfer_fee_basis_points.into(),
+                maximum_fee: newer_transfer_fee.maximum_fee.into(),
+            }],
+            &[],
+        )
         .await
         .unwrap();
     let token = context.token_context.unwrap().token;
@@ -670,12 +688,15 @@ async fn set_withdraw_withheld_authority() {
     } = test_transfer_fee_config_with_keypairs();
     let mut context = TestContext::new().await;
     context
-        .init_token_with_mint(vec![ExtensionInitializationParams::TransferFeeConfig {
-            transfer_fee_config_authority: transfer_fee_config_authority.pubkey().into(),
-            withdraw_withheld_authority: withdraw_withheld_authority.pubkey().into(),
-            transfer_fee_basis_points: newer_transfer_fee.transfer_fee_basis_points.into(),
-            maximum_fee: newer_transfer_fee.maximum_fee.into(),
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::TransferFeeConfig {
+                transfer_fee_config_authority: transfer_fee_config_authority.pubkey().into(),
+                withdraw_withheld_authority: withdraw_withheld_authority.pubkey().into(),
+                transfer_fee_basis_points: newer_transfer_fee.transfer_fee_basis_points.into(),
+                maximum_fee: newer_transfer_fee.maximum_fee.into(),
+            }],
+            &[],
+        )
         .await
         .unwrap();
     let token = context.token_context.unwrap().token;
@@ -1236,12 +1257,15 @@ async fn harvest_withheld_tokens_to_mint() {
         create_and_transfer_to_account(&token, &alice_account, &alice, &alice.pubkey(), amount)
             .await;
     context
-        .init_token_with_mint(vec![ExtensionInitializationParams::TransferFeeConfig {
-            transfer_fee_config_authority: Some(Pubkey::new_unique()),
-            withdraw_withheld_authority: Some(Pubkey::new_unique()),
-            transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
-            maximum_fee: TEST_MAXIMUM_FEE,
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::TransferFeeConfig {
+                transfer_fee_config_authority: Some(Pubkey::new_unique()),
+                withdraw_withheld_authority: Some(Pubkey::new_unique()),
+                transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
+                maximum_fee: TEST_MAXIMUM_FEE,
+            }],
+            &[],
+        )
         .await
         .unwrap();
     let TokenContext { token, .. } = context.token_context.take().unwrap();
@@ -1489,12 +1513,15 @@ async fn withdraw_withheld_tokens_from_mint() {
 
     // fail on new mint with mint mismatch
     context
-        .init_token_with_mint(vec![ExtensionInitializationParams::TransferFeeConfig {
-            transfer_fee_config_authority: Some(Pubkey::new_unique()),
-            withdraw_withheld_authority: Some(withdraw_withheld_authority.pubkey()),
-            transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
-            maximum_fee: TEST_MAXIMUM_FEE,
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::TransferFeeConfig {
+                transfer_fee_config_authority: Some(Pubkey::new_unique()),
+                withdraw_withheld_authority: Some(withdraw_withheld_authority.pubkey()),
+                transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
+                maximum_fee: TEST_MAXIMUM_FEE,
+            }],
+            &[],
+        )
         .await
         .unwrap();
     let TokenContext { token, .. } = context.token_context.take().unwrap();
@@ -1607,12 +1634,15 @@ async fn withdraw_withheld_tokens_from_accounts() {
         create_and_transfer_to_account(&token, &alice_account, &alice, &alice.pubkey(), amount)
             .await;
     context
-        .init_token_with_mint(vec![ExtensionInitializationParams::TransferFeeConfig {
-            transfer_fee_config_authority: Some(Pubkey::new_unique()),
-            withdraw_withheld_authority: Some(withdraw_withheld_authority.pubkey()),
-            transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
-            maximum_fee: TEST_MAXIMUM_FEE,
-        }])
+        .init_token_with_mint(
+            vec![ExtensionInitializationParams::TransferFeeConfig {
+                transfer_fee_config_authority: Some(Pubkey::new_unique()),
+                withdraw_withheld_authority: Some(withdraw_withheld_authority.pubkey()),
+                transfer_fee_basis_points: TEST_FEE_BASIS_POINTS,
+                maximum_fee: TEST_MAXIMUM_FEE,
+            }],
+            &[],
+        )
         .await
         .unwrap();
     let TokenContext { token, .. } = context.token_context.take().unwrap();

--- a/token/program-2022-test/tests/transfer_hook.rs
+++ b/token/program-2022-test/tests/transfer_hook.rs
@@ -219,6 +219,7 @@ async fn setup(mint: Keypair, program_id: &Pubkey, authority: &Pubkey) -> TestCo
                 program_id: Some(*program_id),
             }],
             None,
+            &[],
         )
         .await
         .unwrap();
@@ -267,6 +268,7 @@ async fn fail_init_all_none() {
                 program_id: None,
             }],
             None,
+            &[],
         )
         .await
         .unwrap_err();
@@ -519,6 +521,7 @@ async fn fail_transfer_hook_program() {
                 program_id: Some(program_id),
             }],
             None,
+            &[],
         )
         .await
         .unwrap();
@@ -604,6 +607,7 @@ async fn success_downgrade_writable_and_signer_accounts() {
                 program_id: Some(program_id),
             }],
             None,
+            &[],
         )
         .await
         .unwrap();
@@ -661,6 +665,7 @@ async fn success_transfers_using_onchain_helper() {
                 program_id: Some(program_id),
             }],
             None,
+            &[],
         )
         .await
         .unwrap();
@@ -681,6 +686,7 @@ async fn success_transfers_using_onchain_helper() {
                 program_id: Some(program_id),
             }],
             None,
+            &[],
         )
         .await
         .unwrap();

--- a/token/program-2022/src/extension/group_member_pointer/instruction.rs
+++ b/token/program-2022/src/extension/group_member_pointer/instruction.rs
@@ -1,0 +1,149 @@
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
+use {
+    crate::{
+        check_program_account,
+        instruction::{encode_instruction, TokenInstruction},
+    },
+    bytemuck::{Pod, Zeroable},
+    num_enum::{IntoPrimitive, TryFromPrimitive},
+    solana_program::{
+        instruction::{AccountMeta, Instruction},
+        program_error::ProgramError,
+        pubkey::Pubkey,
+    },
+    spl_pod::optional_keys::OptionalNonZeroPubkey,
+    std::convert::TryInto,
+};
+
+/// Group member pointer extension instructions
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
+#[derive(Clone, Copy, Debug, PartialEq, IntoPrimitive, TryFromPrimitive)]
+#[repr(u8)]
+pub enum GroupMemberPointerInstruction {
+    /// Initialize a new mint with a group member pointer
+    ///
+    /// Fails if the mint has already been initialized, so must be called before
+    /// `InitializeMint`.
+    ///
+    /// The mint must have exactly enough space allocated for the base mint (82
+    /// bytes), plus 83 bytes of padding, 1 byte reserved for the account type,
+    /// then space required for this extension, plus any others.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[writable]` The mint to initialize.
+    ///   1. `[]`         The group mint.
+    ///   2. `[signer]`   The group's update authority.
+    ///
+    /// Data expected by this instruction:
+    ///   `crate::extension::group_member_pointer::instruction::InitializeInstructionData`
+    Initialize,
+    /// Update the group member pointer address. Only supported for mints that
+    /// include the `GroupMemberPointer` extension.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   * Single authority
+    ///   0. `[writable]` The mint.
+    ///   1. `[]`         The group mint.
+    ///   2. `[signer]`   The group's update authority.
+    ///
+    ///   * Multisignature authority
+    ///   0. `[writable]` The mint.
+    ///   1. `[]`         The group mint.
+    ///   2. `[]`         The mint's group member pointer authority.
+    ///   3. `[signer]`   The group's update authority.
+    ///   4. ..4+M `[signer]` M signer accounts.
+    ///
+    /// Data expected by this instruction:
+    ///   `crate::extension::group_member_pointer::instruction::UpdateInstructionData`
+    Update,
+}
+
+/// Data expected by `Initialize`
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct InitializeInstructionData {
+    /// The public key for the account that can update the group address
+    pub authority: OptionalNonZeroPubkey,
+    /// The account address that holds the group
+    pub group_address: Pubkey,
+    /// The account address that holds the member
+    pub member_address: OptionalNonZeroPubkey,
+}
+
+/// Data expected by `Update`
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct UpdateInstructionData {
+    /// The account address that holds the group
+    pub group_address: Pubkey,
+    /// The new account address that holds the group
+    pub member_address: OptionalNonZeroPubkey,
+}
+
+/// Create an `Initialize` instruction
+pub fn initialize(
+    token_program_id: &Pubkey,
+    mint: &Pubkey,
+    authority: Option<Pubkey>,
+    group_update_authority: &Pubkey,
+    group_address: &Pubkey,
+    member_address: Option<Pubkey>,
+) -> Result<Instruction, ProgramError> {
+    check_program_account(token_program_id)?;
+    let accounts = vec![
+        AccountMeta::new(*mint, false),
+        AccountMeta::new(*group_address, false),
+        AccountMeta::new(*group_update_authority, true),
+    ];
+    Ok(encode_instruction(
+        token_program_id,
+        accounts,
+        TokenInstruction::GroupMemberPointerExtension,
+        GroupMemberPointerInstruction::Initialize,
+        &InitializeInstructionData {
+            authority: authority.try_into()?,
+            group_address: *group_address,
+            member_address: member_address.try_into()?,
+        },
+    ))
+}
+
+/// Create an `Update` instruction
+pub fn update(
+    token_program_id: &Pubkey,
+    mint: &Pubkey,
+    authority: &Pubkey,
+    group_update_authority: &Pubkey,
+    signers: &[&Pubkey],
+    group_address: &Pubkey,
+    member_address: Option<Pubkey>,
+) -> Result<Instruction, ProgramError> {
+    check_program_account(token_program_id)?;
+    let mut accounts = vec![
+        AccountMeta::new(*mint, false),
+        AccountMeta::new(*group_address, false),
+        AccountMeta::new_readonly(*authority, signers.is_empty()),
+        AccountMeta::new_readonly(*group_update_authority, true),
+    ];
+    for signer_pubkey in signers.iter() {
+        accounts.push(AccountMeta::new_readonly(**signer_pubkey, true));
+    }
+    Ok(encode_instruction(
+        token_program_id,
+        accounts,
+        TokenInstruction::GroupMemberPointerExtension,
+        GroupMemberPointerInstruction::Update,
+        &UpdateInstructionData {
+            group_address: *group_address,
+            member_address: member_address.try_into()?,
+        },
+    ))
+}

--- a/token/program-2022/src/extension/group_member_pointer/mod.rs
+++ b/token/program-2022/src/extension/group_member_pointer/mod.rs
@@ -1,0 +1,30 @@
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
+use {
+    crate::extension::{Extension, ExtensionType},
+    bytemuck::{Pod, Zeroable},
+    solana_program::pubkey::Pubkey,
+    spl_pod::optional_keys::OptionalNonZeroPubkey,
+};
+
+/// Instructions for the GroupMemberPointer extension
+pub mod instruction;
+/// Instruction processor for the GroupMemberPointer extension
+pub mod processor;
+
+/// Group member pointer extension data for mints.
+#[repr(C)]
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+pub struct GroupMemberPointer {
+    /// Authority that can set the group address
+    pub authority: OptionalNonZeroPubkey,
+    /// Account address that holds the group
+    pub group_address: Pubkey,
+    /// Account address that holds the member
+    pub member_address: OptionalNonZeroPubkey,
+}
+
+impl Extension for GroupMemberPointer {
+    const TYPE: ExtensionType = ExtensionType::GroupMemberPointer;
+}

--- a/token/program-2022/src/extension/group_member_pointer/processor.rs
+++ b/token/program-2022/src/extension/group_member_pointer/processor.rs
@@ -1,0 +1,167 @@
+use {
+    crate::{
+        check_program_account,
+        error::TokenError,
+        extension::{
+            group_member_pointer::{
+                instruction::{
+                    GroupMemberPointerInstruction, InitializeInstructionData, UpdateInstructionData,
+                },
+                GroupMemberPointer,
+            },
+            BaseStateWithExtensions, StateWithExtensions, StateWithExtensionsMut,
+        },
+        instruction::{decode_instruction_data, decode_instruction_type},
+        processor::Processor,
+        state::Mint,
+    },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        msg,
+        program_error::ProgramError,
+        pubkey::Pubkey,
+    },
+    spl_pod::optional_keys::OptionalNonZeroPubkey,
+    spl_token_group_interface::state::TokenGroup,
+};
+
+fn check_group_update_authority(
+    group_info: &AccountInfo,
+    group_update_authority_info: &AccountInfo,
+) -> Result<(), ProgramError> {
+    if !group_update_authority_info.is_signer {
+        msg!("Group update authority must be a signer");
+        return Err(ProgramError::MissingRequiredSignature)?;
+    }
+    let group_data = group_info.data.borrow();
+    let group_mint = StateWithExtensions::<Mint>::unpack(&group_data)?;
+    let group_state = group_mint.get_extension::<TokenGroup>()?;
+    if Option::<Pubkey>::from(group_state.update_authority)
+        != Some(*group_update_authority_info.key)
+    {
+        msg!("Incorrect update authority for group");
+        return Err(TokenError::OwnerMismatch)?;
+    }
+    Ok(())
+}
+
+fn process_initialize(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    authority: &OptionalNonZeroPubkey,
+    group_address: &Pubkey,
+    member_address: &OptionalNonZeroPubkey,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let mint_info = next_account_info(account_info_iter)?;
+    let group_info = next_account_info(account_info_iter)?;
+    let group_update_authority_info = next_account_info(account_info_iter)?;
+
+    // Group update authority checks
+    check_group_update_authority(group_info, group_update_authority_info)?;
+
+    let mut mint_data = mint_info.data.borrow_mut();
+    let mut mint = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut mint_data)?;
+
+    // Ensure this mint doesn't already have a group member pointer extension
+    // for this group address
+    if mint
+        .get_all_extensions::<GroupMemberPointer>()?
+        .iter()
+        .any(|extension| Option::<Pubkey>::from(extension.group_address) == Some(*group_address))
+    {
+        msg!(
+            "The group member pointer extension for this group address already exists on this \
+            mint"
+        );
+        Err(TokenError::InvalidInstruction)?;
+    }
+
+    if Option::<Pubkey>::from(*authority).is_none()
+        && Option::<Pubkey>::from(*member_address).is_none()
+    {
+        msg!(
+            "The group member pointer extension requires at least an authority or an address for \
+            initialization, neither was provided"
+        );
+        Err(TokenError::InvalidInstruction)?;
+    }
+
+    let extension = mint.init_extension_allow_repeating::<GroupMemberPointer>()?;
+    extension.authority = *authority;
+    extension.group_address = *group_address;
+    extension.member_address = *member_address;
+    Ok(())
+}
+
+fn process_update(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    group_address: &Pubkey,
+    new_member_address: &OptionalNonZeroPubkey,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let mint_info = next_account_info(account_info_iter)?;
+    let group_info = next_account_info(account_info_iter)?;
+    let owner_info = next_account_info(account_info_iter)?;
+    let group_update_authority_info = next_account_info(account_info_iter)?;
+
+    // Group update authority checks
+    check_group_update_authority(group_info, group_update_authority_info)?;
+
+    let mut mint_data = mint_info.data.borrow_mut();
+    let mut mint = StateWithExtensionsMut::<Mint>::unpack(&mut mint_data)?;
+
+    let extension =
+        mint.get_first_matched_repeating_extension_mut::<GroupMemberPointer>(|extension| {
+            extension.group_address == *group_address
+        })?;
+    let authority =
+        Option::<Pubkey>::from(extension.authority).ok_or(TokenError::NoAuthorityExists)?;
+
+    let owner_info_data_len = owner_info.data_len();
+    Processor::validate_owner(
+        program_id,
+        &authority,
+        owner_info,
+        owner_info_data_len,
+        account_info_iter.as_slice(),
+    )?;
+
+    extension.member_address = *new_member_address;
+    Ok(())
+}
+
+pub(crate) fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    input: &[u8],
+) -> ProgramResult {
+    check_program_account(program_id)?;
+    match decode_instruction_type(input)? {
+        GroupMemberPointerInstruction::Initialize => {
+            msg!("GroupMemberPointerInstruction::Initialize");
+            let InitializeInstructionData {
+                authority,
+                group_address,
+                member_address,
+            } = decode_instruction_data(input)?;
+            process_initialize(
+                program_id,
+                accounts,
+                authority,
+                group_address,
+                member_address,
+            )
+        }
+        GroupMemberPointerInstruction::Update => {
+            msg!("GroupMemberPointerInstruction::Update");
+            let UpdateInstructionData {
+                group_address,
+                member_address,
+            } = decode_instruction_data(input)?;
+            process_update(program_id, accounts, group_address, member_address)
+        }
+    }
+}

--- a/token/program-2022/src/extension/group_pointer/processor.rs
+++ b/token/program-2022/src/extension/group_pointer/processor.rs
@@ -35,9 +35,6 @@ fn process_initialize(
     let mut mint_data = mint_account_info.data.borrow_mut();
     let mut mint = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut mint_data)?;
 
-    let extension = mint.init_extension::<GroupPointer>(true)?;
-    extension.authority = *authority;
-
     if Option::<Pubkey>::from(*authority).is_none()
         && Option::<Pubkey>::from(*group_address).is_none()
     {
@@ -47,6 +44,9 @@ fn process_initialize(
         );
         Err(TokenError::InvalidInstruction)?;
     }
+
+    let extension = mint.init_extension::<GroupPointer>(true)?;
+    extension.authority = *authority;
     extension.group_address = *group_address;
     Ok(())
 }

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -12,6 +12,7 @@ use {
             },
             cpi_guard::CpiGuard,
             default_account_state::DefaultAccountState,
+            group_member_pointer::GroupMemberPointer,
             group_pointer::GroupPointer,
             immutable_owner::ImmutableOwner,
             interest_bearing_mint::InterestBearingConfig,
@@ -53,6 +54,8 @@ pub mod confidential_transfer_fee;
 pub mod cpi_guard;
 /// Default Account State extension
 pub mod default_account_state;
+/// Group Member Pointer extension
+pub mod group_member_pointer;
 /// Group Pointer extension
 pub mod group_pointer;
 /// Immutable Owner extension
@@ -1164,6 +1167,9 @@ pub enum ExtensionType {
     GroupPointer,
     /// Mint contains token group configurations
     TokenGroup,
+    /// Mint contains a pointer to another account (or the same account) that
+    /// holds group member configurations
+    GroupMemberPointer,
     /// Test variable-length mint extension
     #[cfg(test)]
     VariableLenMintTest = u16::MAX - 2,
@@ -1242,6 +1248,7 @@ impl ExtensionType {
             ExtensionType::TokenMetadata => unreachable!(),
             ExtensionType::GroupPointer => pod_get_packed_len::<GroupPointer>(),
             ExtensionType::TokenGroup => pod_get_packed_len::<TokenGroup>(),
+            ExtensionType::GroupMemberPointer => pod_get_packed_len::<GroupMemberPointer>(),
             #[cfg(test)]
             ExtensionType::AccountPaddingTest => pod_get_packed_len::<AccountPaddingTest>(),
             #[cfg(test)]
@@ -1303,7 +1310,8 @@ impl ExtensionType {
             | ExtensionType::MetadataPointer
             | ExtensionType::TokenMetadata
             | ExtensionType::GroupPointer
-            | ExtensionType::TokenGroup => AccountType::Mint,
+            | ExtensionType::TokenGroup
+            | ExtensionType::GroupMemberPointer => AccountType::Mint,
             ExtensionType::ImmutableOwner
             | ExtensionType::TransferFeeAmount
             | ExtensionType::ConfidentialTransferAccount

--- a/token/program-2022/src/extension/token_group/processor.rs
+++ b/token/program-2022/src/extension/token_group/processor.rs
@@ -6,7 +6,7 @@ use {
         error::TokenError,
         extension::{
             alloc_and_serialize, group_pointer::GroupPointer, BaseStateWithExtensions,
-            StateWithExtensions,
+            StateWithExtensions, StateWithExtensionsMut,
         },
         state::Mint,
     },
@@ -18,12 +18,28 @@ use {
         program_option::COption,
         pubkey::Pubkey,
     },
+    spl_pod::optional_keys::OptionalNonZeroPubkey,
     spl_token_group_interface::{
         error::TokenGroupError,
-        instruction::{InitializeGroup, TokenGroupInstruction},
+        instruction::{InitializeGroup, TokenGroupInstruction, UpdateGroupMaxSize},
         state::TokenGroup,
     },
 };
+
+fn check_update_authority(
+    update_authority_info: &AccountInfo,
+    expected_update_authority: &OptionalNonZeroPubkey,
+) -> Result<(), ProgramError> {
+    if !update_authority_info.is_signer {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+    let update_authority = Option::<Pubkey>::from(*expected_update_authority)
+        .ok_or(TokenGroupError::ImmutableGroup)?;
+    if update_authority != *update_authority_info.key {
+        return Err(TokenGroupError::IncorrectUpdateAuthority.into());
+    }
+    Ok(())
+}
 
 /// Processes a [InitializeGroup](enum.TokenGroupInstruction.html) instruction.
 pub fn process_initialize_group(
@@ -76,6 +92,30 @@ pub fn process_initialize_group(
     Ok(())
 }
 
+/// Processes an
+/// [UpdateGroupMaxSize](enum.GroupInterfaceInstruction.html)
+/// instruction
+pub fn process_update_group_max_size(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    data: UpdateGroupMaxSize,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    let group_info = next_account_info(account_info_iter)?;
+    let update_authority_info = next_account_info(account_info_iter)?;
+
+    let mut buffer = group_info.try_borrow_mut_data()?;
+    let mut state = StateWithExtensionsMut::<Mint>::unpack(&mut buffer)?;
+    let group = state.get_extension_mut::<TokenGroup>()?;
+
+    check_update_authority(update_authority_info, &group.update_authority)?;
+
+    group.update_max_size(data.max_size.into())?;
+
+    Ok(())
+}
+
 /// Processes an [Instruction](enum.Instruction.html).
 pub fn process_instruction(
     program_id: &Pubkey,
@@ -86,6 +126,10 @@ pub fn process_instruction(
         TokenGroupInstruction::InitializeGroup(data) => {
             msg!("TokenGroupInstruction: InitializeGroup");
             process_initialize_group(program_id, accounts, data)
+        }
+        TokenGroupInstruction::UpdateGroupMaxSize(data) => {
+            msg!("TokenGroupInstruction: UpdateGroupMaxSize");
+            process_update_group_max_size(program_id, accounts, data)
         }
         _ => Err(ProgramError::InvalidInstructionData),
     }

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -693,6 +693,13 @@ pub enum TokenInstruction<'a> {
     /// for further details about the extended instructions that share this
     /// instruction prefix
     GroupPointerExtension,
+    /// The common instruction prefix for group member pointer extension
+    /// instructions.
+    ///
+    /// See `extension::group_member_pointer::instruction::GroupMemberPointerInstruction`
+    /// for further details about the extended instructions that share this
+    /// instruction prefix
+    GroupMemberPointerExtension,
 }
 impl<'a> TokenInstruction<'a> {
     /// Unpacks a byte buffer into a
@@ -834,6 +841,7 @@ impl<'a> TokenInstruction<'a> {
             38 => Self::WithdrawExcessLamports,
             39 => Self::MetadataPointerExtension,
             40 => Self::GroupPointerExtension,
+            41 => Self::GroupMemberPointerExtension,
             _ => return Err(TokenError::InvalidInstruction.into()),
         })
     }
@@ -1003,6 +1011,9 @@ impl<'a> TokenInstruction<'a> {
             &Self::GroupPointerExtension => {
                 buf.push(40);
             }
+            &Self::GroupMemberPointerExtension => {
+                buf.push(41);
+            }
         };
         buf
     }
@@ -1098,6 +1109,8 @@ pub enum AuthorityType {
     MetadataPointer,
     /// Authority to set the group address
     GroupPointer,
+    /// Authority to set the group member address
+    GroupMemberPointer,
 }
 
 impl AuthorityType {
@@ -1117,6 +1130,7 @@ impl AuthorityType {
             AuthorityType::ConfidentialTransferFeeConfig => 11,
             AuthorityType::MetadataPointer => 12,
             AuthorityType::GroupPointer => 13,
+            AuthorityType::GroupMemberPointer => 14,
         }
     }
 
@@ -1136,6 +1150,7 @@ impl AuthorityType {
             11 => Ok(AuthorityType::ConfidentialTransferFeeConfig),
             12 => Ok(AuthorityType::MetadataPointer),
             13 => Ok(AuthorityType::GroupPointer),
+            14 => Ok(AuthorityType::GroupMemberPointer),
             _ => Err(TokenError::InvalidInstruction.into()),
         }
     }


### PR DESCRIPTION
This PR adds another "allocate" function that supports repeating entries.

Namely, this new function is almost identical to `alloc_and_serialize`, but will
_not_ fail if the extension exists.
