### PR TITLE
ci: Update actions/setup-python to v4

### DIFF
--- a/.github/workflows/pull-request-stake-pool.yml
+++ b/.github/workflows/pull-request-stake-pool.yml
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Python version
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 


### PR DESCRIPTION
#### Problem

As a final follow-up to #5844, actions/setup-python is also outdated.

#### Solution

To keep this PR slim, just update the stake pool job to use actions/setup-python v4