### PR TITLE
ci: Don't run downstream workflows if token/js is changed

### DIFF
--- a/.github/workflows/pull-request-binary-oracle-pair.yml
+++ b/.github/workflows/pull-request-binary-oracle-pair.yml
@@ -6,12 +6,14 @@ on:
     - 'binary-oracle-pair/**'
     - 'token/**'
     - 'ci/*-version.sh'
+    - '!token/js/**'
   push:
     branches: [master]
     paths:
     - 'binary-oracle-pair/**'
     - 'token/**'
     - 'ci/*-version.sh'
+    - '!token/js/**'
 
 jobs:
   cargo-test-sbf:

--- a/.github/workflows/pull-request-feature-proposal.yml
+++ b/.github/workflows/pull-request-feature-proposal.yml
@@ -6,12 +6,14 @@ on:
     - 'feature-proposal/**'
     - 'token/**'
     - 'ci/*-version.sh'
+    - '!token/js/**'
   push:
     branches: [master]
     paths:
     - 'feature-proposal/**'
     - 'token/**'
     - 'ci/*-version.sh'
+    - '!token/js/**'
 
 jobs:
   cargo-test-sbf:

--- a/.github/workflows/pull-request-governance.yml
+++ b/.github/workflows/pull-request-governance.yml
@@ -6,12 +6,14 @@ on:
       - "governance/**"
       - "token/**"
       - "ci/*-version.sh"
+      - '!token/js/**'
   push:
     branches: [master]
     paths:
       - "governance/**"
       - "token/**"
       - "ci/*-version.sh"
+      - '!token/js/**'
 
 jobs:
   cargo-test-sbf:

--- a/.github/workflows/pull-request-single-pool.yml
+++ b/.github/workflows/pull-request-single-pool.yml
@@ -9,6 +9,7 @@ on:
     - 'ci/*-version.sh'
     - '.github/workflows/pull-request-single-pool.yml'
     - '!single-pool/js/**'
+    - '!token/js/**'
   push:
     branches: [master]
     paths:
@@ -18,6 +19,7 @@ on:
     - 'ci/*-version.sh'
     - '.github/workflows/pull-request-single-pool.yml'
     - '!single-pool/js/**'
+    - '!token/js/**'
 
 jobs:
   cargo-test-sbf:

--- a/.github/workflows/pull-request-stake-pool.yml
+++ b/.github/workflows/pull-request-stake-pool.yml
@@ -9,6 +9,7 @@ on:
     - 'ci/warning/purge-ubuntu-runner.sh'
     - '.github/workflows/pull-request-stake-pool.yml'
     - '!stake-pool/js/**'
+    - '!token/js/**'
   push:
     branches: [master]
     paths:
@@ -18,6 +19,7 @@ on:
     - 'ci/warning/purge-ubuntu-runner.sh'
     - '.github/workflows/pull-request-stake-pool.yml'
     - '!stake-pool/js/**'
+    - '!token/js/**'
 
 jobs:
   cargo-test-sbf:

--- a/.github/workflows/pull-request-token-collection.yml
+++ b/.github/workflows/pull-request-token-collection.yml
@@ -9,6 +9,8 @@ on:
     - 'token-metadata/**'
     - 'ci/*-version.sh'
     - '.github/workflows/pull-request-token-collection.yml'
+    - '!token/js/**'
+    - '!token-metadata/js/**'
   push:
     branches: [master]
     paths:
@@ -18,6 +20,8 @@ on:
     - 'token-metadata/**'
     - 'ci/*-version.sh'
     - '.github/workflows/pull-request-token-collection.yml'
+    - '!token/js/**'
+    - '!token-metadata/js/**'
 
 jobs:
   cargo-test-sbf:

--- a/.github/workflows/pull-request-token-lending.yml
+++ b/.github/workflows/pull-request-token-lending.yml
@@ -7,6 +7,7 @@ on:
     - 'token/**'
     - 'ci/*-version.sh'
     - '!token-lending/js/**'
+    - '!token/js/**'
   push:
     branches: [master]
     paths:
@@ -14,6 +15,7 @@ on:
     - 'token/**'
     - 'ci/*-version.sh'
     - '!token-lending/js/**'
+    - '!token/js/**'
 
 jobs:
   cargo-test-sbf:

--- a/.github/workflows/pull-request-token-swap.yml
+++ b/.github/workflows/pull-request-token-swap.yml
@@ -8,6 +8,7 @@ on:
     - 'libraries/math/**'
     - 'ci/*-version.sh'
     - '!token-swap/js/**'
+    - '!token/js/**'
   push:
     branches: [master]
     paths:
@@ -16,6 +17,7 @@ on:
     - 'libraries/math/**'
     - 'ci/*-version.sh'
     - '!token-swap/js/**'
+    - '!token/js/**'
 
 jobs:
   cargo-test-sbf:

--- a/.github/workflows/pull-request-token-upgrade.yml
+++ b/.github/workflows/pull-request-token-upgrade.yml
@@ -7,6 +7,7 @@ on:
     - 'token/**'
     - 'ci/*-version.sh'
     - '.github/workflows/pull-request-token-upgrade.yml'
+    - '!token/js/**'
   push:
     branches: [master]
     paths:
@@ -14,6 +15,7 @@ on:
     - 'token/**'
     - 'ci/*-version.sh'
     - '.github/workflows/pull-request-token-upgrade.yml'
+    - '!token/js/**'
 
 jobs:
   cargo-test-sbf:


### PR DESCRIPTION
#### Problem

CI is still running too many jobs when `token/js` changes because many downstream workflows run if `token/**` is changed.

#### Solution

Update the downstream workflows to also exclude `token/js/**`