### PR TITLE
token-cli: Support creating mint with fee and conf transfer

### DIFF
--- a/token/cli/src/command.rs
+++ b/token/cli/src/command.rs
@@ -255,6 +255,21 @@ async fn command_create_token(
             auto_approve_new_accounts: auto_approve,
             auditor_elgamal_pubkey: None,
         });
+        if transfer_fee.is_some() {
+            // Deriving ElGamal key from default signer. Custom ElGamal keys
+            // will be supported in the future once upgrading to clap-v3.
+            //
+            // NOTE: Seed bytes are hardcoded to be empty bytes for now. They
+            // will be updated once custom ElGamal keys are supported.
+            let elgamal_keypair =
+                ElGamalKeypair::new_from_signer(config.default_signer()?.as_ref(), b"").unwrap();
+            extensions.push(
+                ExtensionInitializationParams::ConfidentialTransferFeeConfig {
+                    authority: Some(authority),
+                    withdraw_withheld_authority_elgamal_pubkey: (*elgamal_keypair.pubkey()).into(),
+                },
+            );
+        }
     }
 
     if let Some(program_id) = transfer_hook_program_id {

--- a/token/cli/tests/command.rs
+++ b/token/cli/tests/command.rs
@@ -18,6 +18,7 @@ use {
     spl_token_2022::{
         extension::{
             confidential_transfer::{ConfidentialTransferAccount, ConfidentialTransferMint},
+            confidential_transfer_fee::ConfidentialTransferFeeConfig,
             cpi_guard::CpiGuard,
             default_account_state::DefaultAccountState,
             interest_bearing_mint::InterestBearingConfig,
@@ -126,6 +127,7 @@ async fn main() {
         async_trial!(metadata_pointer, test_validator, payer),
         async_trial!(transfer_hook, test_validator, payer),
         async_trial!(metadata, test_validator, payer),
+        async_trial!(confidential_transfer_with_fee, test_validator, payer),
         // GC messes with every other test, so have it on its own test validator
         async_trial!(gc, gc_test_validator, gc_payer),
     ];
@@ -2717,6 +2719,62 @@ async fn confidential_transfer(test_validator: &TestValidator, payer: &Keypair) 
     )
     .await
     .unwrap();
+}
+
+async fn confidential_transfer_with_fee(test_validator: &TestValidator, payer: &Keypair) {
+    let config = test_config_with_default_signer(test_validator, payer, &spl_token_2022::id());
+
+    // create token with confidential transfers enabled
+    let auto_approve = true;
+    let confidential_transfer_mint_authority = payer.pubkey();
+
+    let token = Keypair::new();
+    let token_keypair_file = NamedTempFile::new().unwrap();
+    write_keypair_file(&token, &token_keypair_file).unwrap();
+    let token_pubkey = token.pubkey();
+    process_test_command(
+        &config,
+        payer,
+        &[
+            "spl-token",
+            CommandName::CreateToken.into(),
+            token_keypair_file.path().to_str().unwrap(),
+            "--enable-confidential-transfers",
+            "auto",
+            "--transfer-fee",
+            "100",
+            "1000000000",
+        ],
+    )
+    .await
+    .unwrap();
+
+    let account = config.rpc_client.get_account(&token_pubkey).await.unwrap();
+    let test_mint = StateWithExtensionsOwned::<Mint>::unpack(account.data).unwrap();
+    let extension = test_mint
+        .get_extension::<ConfidentialTransferMint>()
+        .unwrap();
+
+    assert_eq!(
+        Option::<Pubkey>::from(extension.authority),
+        Some(confidential_transfer_mint_authority),
+    );
+    assert_eq!(
+        bool::from(extension.auto_approve_new_accounts),
+        auto_approve,
+    );
+    assert_eq!(
+        Option::<ElGamalPubkey>::from(extension.auditor_elgamal_pubkey),
+        None,
+    );
+
+    let extension = test_mint
+        .get_extension::<ConfidentialTransferFeeConfig>()
+        .unwrap();
+    assert_eq!(
+        Option::<Pubkey>::from(extension.authority),
+        Some(confidential_transfer_mint_authority),
+    );
 }
 
 async fn multisig_transfer(test_validator: &TestValidator, payer: &Keypair) {


### PR DESCRIPTION
#### Problem

As reported at https://solana.stackexchange.com/questions/8106/is-it-possible-yet-to-use-mint-tokens-supporting-both-transfer-fees-and-confiden, the token-cli currently fails when creating a mint with a transfer fee and confidential transfers, even though we have tests that work for creating the mint.

#### Solution

It's a bit tricky since we're not receiving the ElGamal keypair, but this little bandaid solution uses the default signer's derived ElGamal keypair. This will unblock people who want to create a mint with both.

If you think this is a bad idea, however, I'll relent and we can just say it's unsupported until 1.18.