### PR TITLE
ci: Update script name for libraries JS run

### DIFF
--- a/.github/workflows/pull-request-libraries.yml
+++ b/.github/workflows/pull-request-libraries.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Build and test
         run: ./ci/cargo-test-sbf.sh libraries
 
-  js-test-tlv:
+  js-test:
     runs-on: ubuntu-latest
     env:
       NODE_VERSION: 16.x
@@ -76,4 +76,4 @@ jobs:
           key: node-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
             node-
-      - run: ./ci/js-test-tlv.sh
+      - run: ./ci/js-test-libraries.sh

--- a/.github/workflows/pull-request-libraries.yml
+++ b/.github/workflows/pull-request-libraries.yml
@@ -5,12 +5,14 @@ on:
     paths:
     - 'libraries/**'
     - 'ci/*-version.sh'
+    - '.github/workflows/pull-request-libraries.yml'
     - '!libraries/**/js/**'
   push:
     branches: [master]
     paths:
     - 'libraries/**'
     - 'ci/*-version.sh'
+    - '.github/workflows/pull-request-libraries.yml'
     - '!libraries/**/js/**'
 
 jobs:


### PR DESCRIPTION
#### Problem

The js-test-tlv step in the libraries CI run is failing because it's still trying to use the old script of `js-test-tlv.sh`, which was renamed to `js-test-libraries.sh`: https://github.com/solana-labs/solana-program-library/actions/runs/6934539549/job/18862851015

#### Solution

Update the script name in the CI job