### PR TITLE
token-2022: Fix test because of blockhash not updating

### DIFF
--- a/token/program-2022-test/tests/token_metadata_remove_key.rs
+++ b/token/program-2022-test/tests/token_metadata_remove_key.rs
@@ -145,7 +145,7 @@ async fn success_remove() {
     let mut context = test_context.context.lock().await;
 
     // refresh blockhash before trying again
-    context.get_new_latest_blockhash().await.unwrap();
+    let blockhash = context.get_new_latest_blockhash().await.unwrap();
     let transaction = Transaction::new_signed_with_payer(
         &[remove_key(
             &spl_token_2022::id(),
@@ -156,7 +156,7 @@ async fn success_remove() {
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, &update_authority],
-        context.last_blockhash,
+        blockhash,
     );
     let error = context
         .banks_client


### PR DESCRIPTION
#### Problem

The token-2022 token metadata tests are still flaky, likely because it's doing the same transaction twice, ie https://github.com/joncinque/solana-program-library/actions/runs/6944082461/job/18890479294

#### Solution

I thought the last solution did it, but we might need to explicitly use the new blockhash