### PR TITLE
docs: Add status of the token program

### DIFF
--- a/docs/src/token.mdx
+++ b/docs/src/token.mdx
@@ -39,6 +39,11 @@ instructions.
 See the [SPL Associated Token Account](associated-token-account.md) program for
 convention around wallet address to token account mapping and funding.
 
+## Status
+
+The SPL Token program is considered complete, and there are no plans to add new
+functionality. There may be changes to fix important or breaking bugs.
+
 ## Reference Guide
 
 ### Setup


### PR DESCRIPTION
#### Problem

As evidenced by the comment at https://github.com/solana-labs/solana-program-library/issues/2742#issuecomment-1822038083, people don't know the status of the token program.

#### Solution

Add a couple of lines in the docs to essentially say that the token program isn't changing.