### PR TITLE
ci: Update node version to 18 on docs

### DIFF
--- a/.github/workflows/spl_action.yml
+++ b/.github/workflows/spl_action.yml
@@ -14,8 +14,8 @@ jobs:
         name: "importing all the document"
       - uses: actions/setup-node@v4
         with:
-          node-version: '16'
-        name: "installing the node.js with version 16"
+          node-version: '18'
+        name: "installing the node.js with version 18"
       - name: "Build Docs"
         if: ${{ github.event_name == ('push' || 'pull_request')}} && ${{github.ref == 'master'}}
         run: |


### PR DESCRIPTION
#### Problem

The docs publish job is still using node 16, whereas the deployment now requires 18, and the vercel build is already configured to 18.

#### Solution

Update the publish job to 18 too.