### PR TITLE
ci: Run docs publish when CI job is updated too

### DIFF
--- a/.github/workflows/spl_action.yml
+++ b/.github/workflows/spl_action.yml
@@ -5,6 +5,7 @@ on:
     branches:  [master]
     paths:
     - 'docs/**'
+    - '.github/workflows/spl_action.yml'
 
 jobs:
   build:


### PR DESCRIPTION
#### Problem

Even though the CI docs workflow was just updated, the publish step didn't run because it needs a change to `docs/**`.

#### Solution

Also have the job run when the workflow file is changed.