### PR TITLE
feat: Add compatibility for publicKeys

### DIFF
--- a/token/js/src/instructions/internal.ts
+++ b/token/js/src/instructions/internal.ts
@@ -13,7 +13,7 @@ export function addSigners(
         for (const signer of multiSigners) {
             if (signer instanceof PublicKey || signer instanceof Keypair) {
                 keys.push({
-                    pubkey: signer instanceof PublicKey ? signer : signer.publicKey,
+                    pubkey: 'publicKey' in signer ? signer.publicKey : signer,
                     isSigner: true,
                     isWritable: false,
                 });

--- a/token/js/src/instructions/internal.ts
+++ b/token/js/src/instructions/internal.ts
@@ -1,5 +1,5 @@
 import type { AccountMeta, Signer } from '@solana/web3.js';
-import { PublicKey } from '@solana/web3.js';
+import { PublicKey, Keypair } from '@solana/web3.js';
 
 /** @internal */
 export function addSigners(
@@ -9,12 +9,28 @@ export function addSigners(
 ): AccountMeta[] {
     if (multiSigners.length) {
         keys.push({ pubkey: ownerOrAuthority, isSigner: false, isWritable: false });
+        
         for (const signer of multiSigners) {
-            keys.push({
-                pubkey: signer instanceof PublicKey ? signer : signer.publicKey,
-                isSigner: true,
-                isWritable: false,
-            });
+            if (signer instanceof PublicKey || signer instanceof Keypair) {
+                keys.push({
+                    pubkey: signer instanceof PublicKey ? signer : signer.publicKey,
+                    isSigner: true,
+                    isWritable: false,
+                });
+            }
+            else if (signer.toString()) {
+                try {
+                    const compatiblePubkey = new PublicKey(signer.toString())
+                    keys.push({
+                        pubkey: compatiblePubkey,
+                        isSigner: true,
+                        isWritable: false,
+                    });
+                }
+                catch (e) {
+                     // not a pubkey 
+                }
+            }
         }
     } else {
         keys.push({ pubkey: ownerOrAuthority, isSigner: true, isWritable: false });


### PR DESCRIPTION
Ran into an issue where I was passing web3.publicKeys to createMintToInstruction with 3 multiSigners but received an anonymous.toString() is undefined error while trying to use serializeMessage() for offline signing. 

The error was that the docs allowed a (signer | publicKey) [ ] but the function only works with a signer[ ], my fix was to move my web3.publicKeys into an object. {publicKey: myKey} which allowed me to serialize the instruction. 

What I assume happened was that the logic 
`pubkey: signer instanceof PublicKey ? signer : signer.publicKey`
did not work as intended and saw my publicKeys as signers and thus tried publicKey.publicKey.toString() 

I believe the changes to the logic in this file will resolve the issue for anyone encountering it in the future.

I'm not entirely familiar with the SPL library yet so I'd be glad for suggestions for how to improve my PR or just have a discussion if anything else might have caused it 