### PR TITLE
token-2022: [OS-SPL-ADV-02] Fix instruction creator

### DIFF
--- a/token/program-2022/src/extension/confidential_transfer_fee/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer_fee/instruction.rs
@@ -319,7 +319,7 @@ pub fn inner_withdraw_withheld_tokens_from_mint(
     ));
 
     for multisig_signer in multisig_signers.iter() {
-        accounts.push(AccountMeta::new(**multisig_signer, false));
+        accounts.push(AccountMeta::new(**multisig_signer, true));
     }
 
     Ok(encode_instruction(
@@ -411,7 +411,7 @@ pub fn inner_withdraw_withheld_tokens_from_accounts(
     ));
 
     for multisig_signer in multisig_signers.iter() {
-        accounts.push(AccountMeta::new(**multisig_signer, false));
+        accounts.push(AccountMeta::new(**multisig_signer, true));
     }
 
     for source in sources.iter() {

--- a/token/program-2022/src/extension/confidential_transfer_fee/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer_fee/instruction.rs
@@ -319,7 +319,7 @@ pub fn inner_withdraw_withheld_tokens_from_mint(
     ));
 
     for multisig_signer in multisig_signers.iter() {
-        accounts.push(AccountMeta::new(**multisig_signer, true));
+        accounts.push(AccountMeta::new_readonly(**multisig_signer, true));
     }
 
     Ok(encode_instruction(
@@ -411,7 +411,7 @@ pub fn inner_withdraw_withheld_tokens_from_accounts(
     ));
 
     for multisig_signer in multisig_signers.iter() {
-        accounts.push(AccountMeta::new(**multisig_signer, true));
+        accounts.push(AccountMeta::new_readonly(**multisig_signer, true));
     }
 
     for source in sources.iter() {


### PR DESCRIPTION
#### Problem

The instruction creators for some of the confidential-transfer-with-fee instructions add the multisig signers as non-signers. An instruction created in this way will not work, since all of the multisig signers must sign the transaction.

#### Solution

Have the multisig signers declared as signing.