### PR TITLE
[docs]: add edit page button to GitHub PRs

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -75,6 +75,9 @@ module.exports = {
           path: "src",
           routeBasePath: "/",
           sidebarPath: require.resolve("./sidebars.js"),
+          editUrl: ({ docPath }) => {
+            return `https://github.com/solana-labs/solana-program-library/edit/master/docs/src/${docPath}`;
+          }
         },
         theme: {
           customCss: require.resolve("./src/css/custom.css"),


### PR DESCRIPTION
This will open the editor on `master` and then prompt the user to commit directly to `master` or create a PR, and they _shouldn't_ have perms to do the former.