### PR TITLE
[token cli]: add validation to metadata address

### DIFF
--- a/token/cli/src/clap_app.rs
+++ b/token/cli/src/clap_app.rs
@@ -663,6 +663,7 @@ pub fn app<'a, 'b>(
                     Arg::with_name("metadata_address")
                         .long("metadata-address")
                         .value_name("ADDRESS")
+                        .validator(is_valid_pubkey)
                         .takes_value(true)
                         .conflicts_with("enable_metadata")
                         .help(


### PR DESCRIPTION
This PR adds the validation for a valid pubkey on the `--metadata-address <ADDRESS>` arg for `spl-token create-token`.