### PR TITLE
token-2022: Add security.txt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6198,6 +6198,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-security-txt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
+
+[[package]]
 name = "solana-send-transaction-service"
 version = "1.17.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7325,6 +7331,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
+ "solana-security-txt",
  "solana-zk-token-sdk",
  "spl-memo 4.0.0",
  "spl-pod 0.1.0",

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -24,6 +24,7 @@ num-derive = "0.4"
 num-traits = "0.2"
 num_enum = "0.7.1"
 solana-program = "1.17.6"
+solana-security-txt = "1.1.1"
 solana-zk-token-sdk = "1.17.6"
 spl-memo = { version = "4.0.0", path = "../../memo/program", features = [ "no-entrypoint" ] }
 spl-token = { version = "4.0",  path = "../program", features = ["no-entrypoint"] }

--- a/token/program-2022/src/entrypoint.rs
+++ b/token/program-2022/src/entrypoint.rs
@@ -6,6 +6,7 @@ use {
         account_info::AccountInfo, entrypoint::ProgramResult, program_error::PrintProgramError,
         pubkey::Pubkey,
     },
+    solana_security_txt::security_txt,
 };
 
 solana_program::entrypoint!(process_instruction);
@@ -20,4 +21,19 @@ fn process_instruction(
         return Err(error);
     }
     Ok(())
+}
+
+security_txt! {
+    // Required fields
+    name: "SPL Token-2022",
+    project_url: "https://spl.solana.com/token-2022",
+    contacts: "link:https://github.com/solana-labs/solana-program-library/security/advisories/new,mailto:security@solana.com,discord:https://discord.gg/solana",
+    policy: "https://github.com/solana-labs/solana-program-library/blob/master/SECURITY.md",
+
+    // Optional Fields
+    preferred_languages: "en",
+    source_code: "https://github.com/solana-labs/solana-program-library/tree/master/token/program-2022",
+    source_revision: "79a575fb7af56d26deeda94fef8f55bde7a90df3",
+    source_release: "token-2022-v0.9.0",
+    auditors: "https://github.com/solana-labs/security-audits#token-2022"
 }


### PR DESCRIPTION
#### Problem

There is support for showing the Neodyme security.txt in the explorer, but none of our programs support it.

#### Solution

Following the directions at https://github.com/neodyme-labs/solana-security-txt, add it to token-2022. Note that this will need to get updated on every release along with versions.