### PR TITLE
stake-pool: Add security.txt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6198,6 +6198,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-security-txt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
+
+[[package]]
 name = "solana-send-transaction-service"
 version = "1.17.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7208,6 +7214,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
+ "solana-security-txt",
  "solana-vote-program",
  "spl-math",
  "spl-pod 0.1.0",

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -21,6 +21,7 @@ num_enum = "0.7.1"
 serde = "1.0.193"
 serde_derive = "1.0.103"
 solana-program = "1.17.6"
+solana-security-txt = "1.1.1"
 spl-math = { version = "0.2", path = "../../libraries/math", features = [ "no-entrypoint" ] }
 spl-pod = { version = "0.1", path = "../../libraries/pod", features = ["borsh"] }
 spl-token-2022 = { version = "0.9", path = "../../token/program-2022", features = [ "no-entrypoint" ] }

--- a/stake-pool/program/src/entrypoint.rs
+++ b/stake-pool/program/src/entrypoint.rs
@@ -30,7 +30,7 @@ security_txt! {
     // Required fields
     name: "SPL Stake Pool",
     project_url: "https://spl.solana.com/stake-pool",
-    contacts: "link:https://github.com/solana-labs/solana-program-library/security/advisories/new,mailto:security@solana.com,discord:https://discord.gg/solana",
+    contacts: "link:https://github.com/solana-labs/solana-program-library/security/advisories/new,mailto:security@solana.com,discord:https://solana.com/discord",
     policy: "https://github.com/solana-labs/solana-program-library/blob/master/SECURITY.md",
 
     // Optional Fields

--- a/stake-pool/program/src/entrypoint.rs
+++ b/stake-pool/program/src/entrypoint.rs
@@ -8,6 +8,7 @@ use {
         account_info::AccountInfo, entrypoint::ProgramResult, program_error::PrintProgramError,
         pubkey::Pubkey,
     },
+    solana_security_txt::security_txt,
 };
 
 solana_program::entrypoint!(process_instruction);
@@ -23,4 +24,19 @@ fn process_instruction(
     } else {
         Ok(())
     }
+}
+
+security_txt! {
+    // Required fields
+    name: "SPL Stake Pool",
+    project_url: "https://spl.solana.com/stake-pool",
+    contacts: "link:https://github.com/solana-labs/solana-program-library/security/advisories/new,mailto:security@solana.com,discord:https://discord.gg/solana",
+    policy: "https://github.com/solana-labs/solana-program-library/blob/master/SECURITY.md",
+
+    // Optional Fields
+    preferred_languages: "en",
+    source_code: "https://github.com/solana-labs/solana-program-library/tree/master/stake-pool/program",
+    source_revision: "58c1226a513d3d8bb2de8ec67586a679be7fd2d4",
+    source_release: "stake-pool-v0.6.4",
+    auditors: "https://github.com/solana-labs/security-audits#stake-pool"
 }


### PR DESCRIPTION
#### Problem

There is support for showing the Neodyme security.txt in the explorer, but none of our programs support it.

#### Solution

Following the directions at https://github.com/neodyme-labs/solana-security-txt, add it to stake pool. Note that this will need to get updated on every release along with versions.