### PR TITLE
token-2022: Update discord link in security.txt

### DIFF
--- a/token/program-2022/src/entrypoint.rs
+++ b/token/program-2022/src/entrypoint.rs
@@ -27,7 +27,7 @@ security_txt! {
     // Required fields
     name: "SPL Token-2022",
     project_url: "https://spl.solana.com/token-2022",
-    contacts: "link:https://github.com/solana-labs/solana-program-library/security/advisories/new,mailto:security@solana.com,discord:https://discord.gg/solana",
+    contacts: "link:https://github.com/solana-labs/solana-program-library/security/advisories/new,mailto:security@solana.com,discord:https://solana.com/discord",
     policy: "https://github.com/solana-labs/solana-program-library/blob/master/SECURITY.md",
 
     // Optional Fields


### PR DESCRIPTION
#### Problem

As pointed out at https://github.com/solana-labs/solana-program-library/pull/5929#discussion_r1409700660, the current discord link might expire.

#### Solution

Use the solana.com version