### PR TITLE
repo: Add `[toolchain]` to `Anchor.toml`

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -1,3 +1,4 @@
+[toolchain]
 anchor_version = "0.29.0"
 solana_version = "1.17.6"
 


### PR DESCRIPTION
### Problem

`anchor_version` and `solana_version` in [`Anchor.toml`](https://github.com/solana-labs/solana-program-library/blob/5da184aed56cda46b0006ebf3ea5d617ef0501a8/Anchor.toml#L1-L2) is obsolete after `anchor-cli 0.29.0`.

### Solution

Define the versions under `[toolchain]`.

**Note:** This change also makes Anchor use the versions specified in `Anchor.toml` in all commands, not just verifiable builds. See the [release notes](https://github.com/coral-xyz/anchor/blob/dfee9589fd56f9aa1a52aa949507b70035482857/docs/src/pages/docs/release-notes.md#override-toolchain-for-the-workspace) for more info.