### PR TITLE
stake-pool: Upgrade to version 1.0.0 to tag release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7198,7 +7198,7 @@ dependencies = [
 
 [[package]]
 name = "spl-stake-pool"
-version = "0.7.0"
+version = "1.0.0"
 dependencies = [
  "arrayref",
  "assert_matches",
@@ -7226,7 +7226,7 @@ dependencies = [
 
 [[package]]
 name = "spl-stake-pool-cli"
-version = "0.7.0"
+version = "1.0.0"
 dependencies = [
  "bincode",
  "borsh 0.10.3",

--- a/stake-pool/cli/Cargo.toml
+++ b/stake-pool/cli/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://spl.solana.com/stake-pool"
 license = "Apache-2.0"
 name = "spl-stake-pool-cli"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "0.7.0"
+version = "1.0.0"
 
 [dependencies]
 borsh = "0.10"
@@ -24,7 +24,7 @@ solana-program = "=1.17.6"
 solana-remote-wallet = "=1.17.6"
 solana-sdk = "=1.17.6"
 spl-associated-token-account = { version = "=2.2", path="../../associated-token-account/program", features = [ "no-entrypoint" ] }
-spl-stake-pool = { version = "=0.7.0", path="../program", features = [ "no-entrypoint" ] }
+spl-stake-pool = { version = "=1.0.0", path="../program", features = [ "no-entrypoint" ] }
 spl-token = { version = "=4.0", path="../../token/program", features = [ "no-entrypoint" ]  }
 bs58 = "0.4.0"
 bincode = "1.3.1"

--- a/stake-pool/js/package.json
+++ b/stake-pool/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana/spl-stake-pool",
-  "version": "0.7.0",
+  "version": "1.0.0",
   "description": "SPL Stake Pool Program JS API",
   "scripts": {
     "build": "tsc && cross-env NODE_ENV=production rollup -c",

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-stake-pool"
-version = "0.7.0"
+version = "1.0.0"
 description = "Solana Program Library Stake Pool"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/stake-pool/program/src/entrypoint.rs
+++ b/stake-pool/program/src/entrypoint.rs
@@ -36,7 +36,7 @@ security_txt! {
     // Optional Fields
     preferred_languages: "en",
     source_code: "https://github.com/solana-labs/solana-program-library/tree/master/stake-pool/program",
-    source_revision: "58c1226a513d3d8bb2de8ec67586a679be7fd2d4",
-    source_release: "stake-pool-v0.6.4",
+    source_revision: "", // fill in after v1.0.0 bump lands
+    source_release: "stake-pool-v1.0.0",
     auditors: "https://github.com/solana-labs/security-audits#stake-pool"
 }


### PR DESCRIPTION
#### Problem

All the security audits are in, so stake pool is ready for version 1.0.0, but we're still on an unreleased version 0.7.0.

#### Solution

Bump the version everywhere