### PR TITLE
token-2022: Featurize the token-group processor

### DIFF
--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -11,7 +11,6 @@ version = "0.0.1"
 test-sbf = ["zk-ops"]
 default = ["zk-ops"]
 zk-ops = []
-proof-program = ["spl-token-2022/proof-program"]
 
 [build-dependencies]
 walkdir = "2"

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -12,10 +12,11 @@ exclude = ["js/**"]
 no-entrypoint = []
 test-sbf = []
 serde-traits = ["dep:serde", "dep:serde_with", "dep:base64", "spl-pod/serde-traits"]
-# Remove these features once the underlying syscalls are released on all networks
-default = ["zk-ops"]
+default = ["token-group", "zk-ops"]
+# Remove this feature once the underlying syscalls are released on all networks
 zk-ops = []
-proof-program = []
+# Remove this feature once the token group implementation has been audited
+token-group = []
 
 [dependencies]
 arrayref = "0.3.7"

--- a/token/program-2022/src/extension/token_group/processor.rs
+++ b/token/program-2022/src/extension/token_group/processor.rs
@@ -207,6 +207,7 @@ pub fn process_initialize_member(_program_id: &Pubkey, accounts: &[AccountInfo])
 }
 
 /// Processes an [Instruction](enum.Instruction.html).
+#[cfg(feature = "token-group")]
 pub fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
@@ -230,4 +231,14 @@ pub fn process_instruction(
             process_initialize_member(program_id, accounts)
         }
     }
+}
+
+/// Processes an [Instruction](enum.Instruction.html).
+#[cfg(not(feature = "token-group"))]
+pub fn process_instruction(
+    _program_id: &Pubkey,
+    _accounts: &[AccountInfo],
+    _instruction: TokenGroupInstruction,
+) -> ProgramResult {
+    Err(TokenError::InvalidInstruction.into())
 }


### PR DESCRIPTION
#### Problem

Token-2022 has undergone the final audit for 1.17, but the audit did not include the implementation of the token-group interface.

#### Solution

For safety, featurize the token-group instruction processor. This way, we can still build a version of the program for mainnet, while still keeping and testing its code. Also, this will let us implement the type decoders in the monorepo without going through another round of releases.

While I was at it, I noticed that the `proof-program` feature wasn't used anywhere, so I removed it