### PR TITLE
token-2022: Bump to 1.0.0 for prod release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4925,7 +4925,7 @@ dependencies = [
  "solana-config-program",
  "solana-sdk",
  "spl-token 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token-2022 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-2022 0.9.0",
  "spl-token-metadata-interface 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "zstd",
@@ -5602,7 +5602,7 @@ dependencies = [
  "solana-vote",
  "solana-vote-program",
  "spl-token 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token-2022 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-2022 0.9.0",
  "static_assertions",
  "strum 0.24.1",
  "strum_macros 0.24.3",
@@ -5985,7 +5985,7 @@ dependencies = [
  "solana-vote",
  "solana-vote-program",
  "spl-token 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token-2022 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-2022 0.9.0",
  "stream-cancel",
  "thiserror",
  "tokio",
@@ -6036,7 +6036,7 @@ dependencies = [
  "solana-sdk",
  "solana-transaction-status",
  "solana-version",
- "spl-token-2022 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-2022 0.9.0",
  "thiserror",
 ]
 
@@ -6423,7 +6423,7 @@ dependencies = [
  "spl-associated-token-account 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-memo 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token-2022 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-2022 0.9.0",
  "thiserror",
 ]
 
@@ -6630,7 +6630,7 @@ dependencies = [
  "num-traits",
  "solana-program",
  "spl-token 4.0.0",
- "spl-token-2022 0.9.0",
+ "spl-token-2022 1.0.0",
  "thiserror",
 ]
 
@@ -6646,7 +6646,7 @@ dependencies = [
  "num-traits",
  "solana-program",
  "spl-token 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token-2022 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-2022 0.9.0",
  "thiserror",
 ]
 
@@ -6659,7 +6659,7 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account 2.2.0",
  "spl-token 4.0.0",
- "spl-token-2022 0.9.0",
+ "spl-token-2022 1.0.0",
 ]
 
 [[package]]
@@ -7219,7 +7219,7 @@ dependencies = [
  "spl-math",
  "spl-pod 0.1.0",
  "spl-token 4.0.0",
- "spl-token-2022 0.9.0",
+ "spl-token-2022 1.0.0",
  "test-case",
  "thiserror",
 ]
@@ -7316,6 +7316,28 @@ dependencies = [
 [[package]]
 name = "spl-token-2022"
 version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4abf34a65ba420584a0c35f3903f8d727d1f13ababbdc3f714c6b065a686e86"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive 0.4.1",
+ "num-traits",
+ "num_enum 0.7.1",
+ "solana-program",
+ "solana-zk-token-sdk",
+ "spl-memo 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-pod 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-metadata-interface 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-transfer-hook-interface 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-type-length-value 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-token-2022"
+version = "1.0.0"
 dependencies = [
  "arrayref",
  "base64 0.21.5",
@@ -7345,28 +7367,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-token-2022"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4abf34a65ba420584a0c35f3903f8d727d1f13ababbdc3f714c6b065a686e86"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive 0.4.1",
- "num-traits",
- "num_enum 0.7.1",
- "solana-program",
- "solana-zk-token-sdk",
- "spl-memo 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-pod 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token-metadata-interface 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-transfer-hook-interface 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-type-length-value 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
-]
-
-[[package]]
 name = "spl-token-2022-test"
 version = "0.0.1"
 dependencies = [
@@ -7380,7 +7380,7 @@ dependencies = [
  "spl-instruction-padding",
  "spl-memo 4.0.0",
  "spl-pod 0.1.0",
- "spl-token-2022 0.9.0",
+ "spl-token-2022 1.0.0",
  "spl-token-client",
  "spl-token-group-interface",
  "spl-token-metadata-interface 0.2.0",
@@ -7417,7 +7417,7 @@ dependencies = [
  "spl-associated-token-account 2.2.0",
  "spl-memo 4.0.0",
  "spl-token 4.0.0",
- "spl-token-2022 0.9.0",
+ "spl-token-2022 1.0.0",
  "spl-token-client",
  "spl-token-metadata-interface 0.2.0",
  "strum 0.25.0",
@@ -7444,7 +7444,7 @@ dependencies = [
  "spl-associated-token-account 2.2.0",
  "spl-memo 4.0.0",
  "spl-token 4.0.0",
- "spl-token-2022 0.9.0",
+ "spl-token-2022 1.0.0",
  "spl-token-group-interface",
  "spl-token-metadata-interface 0.2.0",
  "spl-transfer-hook-interface 0.3.0",
@@ -7461,7 +7461,7 @@ dependencies = [
  "spl-discriminator 0.1.0",
  "spl-pod 0.1.0",
  "spl-program-error 0.3.0",
- "spl-token-2022 0.9.0",
+ "spl-token-2022 1.0.0",
  "spl-token-client",
  "spl-token-group-example",
  "spl-token-group-interface",
@@ -7478,7 +7478,7 @@ dependencies = [
  "solana-sdk",
  "spl-discriminator 0.1.0",
  "spl-pod 0.1.0",
- "spl-token-2022 0.9.0",
+ "spl-token-2022 1.0.0",
  "spl-token-client",
  "spl-token-group-interface",
  "spl-token-metadata-interface 0.2.0",
@@ -7538,7 +7538,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-pod 0.1.0",
- "spl-token-2022 0.9.0",
+ "spl-token-2022 1.0.0",
  "spl-token-client",
  "spl-token-metadata-interface 0.2.0",
  "spl-type-length-value 0.3.0",
@@ -7588,7 +7588,7 @@ dependencies = [
  "solana-sdk",
  "spl-math",
  "spl-token 4.0.0",
- "spl-token-2022 0.9.0",
+ "spl-token-2022 1.0.0",
  "test-case",
  "thiserror",
 ]
@@ -7616,7 +7616,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-token 4.0.0",
- "spl-token-2022 0.9.0",
+ "spl-token-2022 1.0.0",
  "spl-token-client",
  "test-case",
  "thiserror",
@@ -7637,7 +7637,7 @@ dependencies = [
  "solana-test-validator",
  "spl-associated-token-account 2.2.0",
  "spl-token 4.0.0",
- "spl-token-2022 0.9.0",
+ "spl-token-2022 1.0.0",
  "spl-token-client",
  "spl-token-upgrade",
  "tokio",
@@ -7653,7 +7653,7 @@ dependencies = [
  "solana-program",
  "spl-associated-token-account 2.2.0",
  "spl-token 4.0.0",
- "spl-token-2022 0.9.0",
+ "spl-token-2022 1.0.0",
  "thiserror",
 ]
 
@@ -7671,7 +7671,7 @@ dependencies = [
  "solana-sdk",
  "solana-test-validator",
  "spl-tlv-account-resolution 0.4.0",
- "spl-token-2022 0.9.0",
+ "spl-token-2022 1.0.0",
  "spl-token-client",
  "spl-transfer-hook-interface 0.3.0",
  "strum 0.25.0",
@@ -7688,7 +7688,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-tlv-account-resolution 0.4.0",
- "spl-token-2022 0.9.0",
+ "spl-token-2022 1.0.0",
  "spl-transfer-hook-interface 0.3.0",
  "spl-type-length-value 0.3.0",
 ]

--- a/associated-token-account/program-test/Cargo.toml
+++ b/associated-token-account/program-test/Cargo.toml
@@ -16,4 +16,4 @@ solana-program-test = "1.17.6"
 solana-sdk = "1.17.6"
 spl-associated-token-account = { version = "2", path = "../program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "0.9", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "1.0", path = "../../token/program-2022", features = ["no-entrypoint"] }

--- a/associated-token-account/program/Cargo.toml
+++ b/associated-token-account/program/Cargo.toml
@@ -18,7 +18,7 @@ num-derive = "0.4"
 num-traits = "0.2"
 solana-program = "1.17.6"
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "0.9", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "1.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [lib]

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -24,7 +24,7 @@ solana-program = "1.17.6"
 solana-security-txt = "1.1.1"
 spl-math = { version = "0.2", path = "../../libraries/math", features = [ "no-entrypoint" ] }
 spl-pod = { version = "0.1", path = "../../libraries/pod", features = ["borsh"] }
-spl-token-2022 = { version = "0.9", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
+spl-token-2022 = { version = "1.0", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 bincode = "1.3.1"
 

--- a/token-collection/program/Cargo.toml
+++ b/token-collection/program/Cargo.toml
@@ -15,7 +15,7 @@ test-sbf = []
 solana-program = "1.17.6"
 spl-pod = { version = "0.1.0", path = "../../libraries/pod" }
 spl-program-error = { version = "0.3.0" , path = "../../libraries/program-error" }
-spl-token-2022 = { version = "0.9.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "1.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-group-example = { version = "0.1.0", path = "../../token-group/example", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.1.0", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }

--- a/token-group/example/Cargo.toml
+++ b/token-group/example/Cargo.toml
@@ -14,7 +14,7 @@ test-sbf = []
 [dependencies]
 solana-program = "1.17.6"
 spl-pod = { version = "0.1.0", path = "../../libraries/pod" }
-spl-token-2022 = { version = "0.9.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "1.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.1.0", path = "../interface" }
 spl-type-length-value = { version = "0.3.0", path = "../../libraries/type-length-value" }
 

--- a/token-metadata/example/Cargo.toml
+++ b/token-metadata/example/Cargo.toml
@@ -13,7 +13,7 @@ test-sbf = []
 
 [dependencies]
 solana-program = "1.17.6"
-spl-token-2022 = { version = "0.9", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "1.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-metadata-interface = { version = "0.2.0", path = "../interface" }
 spl-type-length-value = { version = "0.3.0" , path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.1.0", path = "../../libraries/pod" }

--- a/token-swap/program/Cargo.toml
+++ b/token-swap/program/Cargo.toml
@@ -20,7 +20,7 @@ num-traits = "0.2"
 solana-program = "1.17.6"
 spl-math = { version = "0.2", path = "../../libraries/math", features = [ "no-entrypoint" ] }
 spl-token = { version = "4.0", path = "../../token/program", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "0.9", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
+spl-token-2022 = { version = "1.0", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 arbitrary = { version = "1.3", features = ["derive"], optional = true }
 roots = { version = "0.0.8", optional = true }

--- a/token-upgrade/cli/Cargo.toml
+++ b/token-upgrade/cli/Cargo.toml
@@ -21,7 +21,7 @@ solana-remote-wallet = "1.17.6"
 solana-sdk = "1.17.6"
 spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "0.9", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "1.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.8", path = "../../token/client" }
 spl-token-upgrade = { version = "0.1", path = "../program", features = ["no-entrypoint"] }
 tokio = { version = "1", features = ["full"] }

--- a/token-upgrade/program/Cargo.toml
+++ b/token-upgrade/program/Cargo.toml
@@ -16,7 +16,7 @@ num-derive = "0.4"
 num-traits = "0.2"
 num_enum = "0.7.1"
 solana-program = "1.17.6"
-spl-token-2022 = { version = "0.9", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "1.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/token-wrap/program/Cargo.toml
+++ b/token-wrap/program/Cargo.toml
@@ -17,7 +17,7 @@ num_enum = "0.7"
 solana-program = "1.17.6"
 spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "0.9", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "1.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [lib]

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -31,7 +31,7 @@ solana-transaction-status = "=1.17.6"
 spl-token = { version = "4.0", path = "../program", features = [
   "no-entrypoint",
 ] }
-spl-token-2022 = { version = "0.9", path = "../program-2022", features = [
+spl-token-2022 = { version = "1.0", path = "../program-2022", features = [
   "no-entrypoint",
 ] }
 spl-token-client = { version = "0.8", path = "../client" }

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -23,7 +23,7 @@ solana-sdk = "1.17.6"
 spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-memo = { version = "4.0.0", path = "../../memo/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path="../program", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "0.9", path="../program-2022" }
+spl-token-2022 = { version = "1.0", path="../program-2022" }
 spl-token-group-interface = { version = "0.1", path="../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.2", path="../../token-metadata/interface" }
 spl-transfer-hook-interface = { version = "0.3", path="../transfer-hook/interface" }

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -25,7 +25,7 @@ solana-sdk = "=1.17.6"
 spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program" }
 spl-memo = { version = "4.0.0", path = "../../memo/program", features = ["no-entrypoint"] }
 spl-pod = { version = "0.1.0", path = "../../libraries/pod" }
-spl-token-2022 = { version = "0.9", path="../program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "1.0", path="../program-2022", features = ["no-entrypoint"] }
 spl-instruction-padding = { version = "0.1.0", path="../../instruction-padding/program", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.8", path = "../client" }
 spl-token-group-interface = { version = "0.1", path = "../../token-group/interface" }

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-2022"
-version = "0.9.0"
+version = "1.0.0"
 description = "Solana Program Library Token 2022"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token/program-2022/src/entrypoint.rs
+++ b/token/program-2022/src/entrypoint.rs
@@ -33,7 +33,7 @@ security_txt! {
     // Optional Fields
     preferred_languages: "en",
     source_code: "https://github.com/solana-labs/solana-program-library/tree/master/token/program-2022",
-    source_revision: "79a575fb7af56d26deeda94fef8f55bde7a90df3",
-    source_release: "token-2022-v0.9.0",
+    source_revision: "", // Add after PR is merged
+    source_release: "token-2022-v1.0.0",
     auditors: "https://github.com/solana-labs/security-audits#token-2022"
 }

--- a/token/transfer-hook/cli/Cargo.toml
+++ b/token/transfer-hook/cli/Cargo.toml
@@ -25,7 +25,7 @@ tokio = { version = "1", features = ["full"] }
 
 [dev-dependencies]
 solana-test-validator = "=1.17.6"
-spl-token-2022 = { version = "0.9", path = "../../program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "1.0", path = "../../program-2022", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.8", path = "../../client" }
 
 [[bin]]

--- a/token/transfer-hook/example/Cargo.toml
+++ b/token/transfer-hook/example/Cargo.toml
@@ -15,7 +15,7 @@ test-sbf = []
 arrayref = "0.3.7"
 solana-program = "1.17.6"
 spl-tlv-account-resolution = { version = "0.4" , path = "../../../libraries/tlv-account-resolution" }
-spl-token-2022 = { version = "0.9",  path = "../../program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "1.0",  path = "../../program-2022", features = ["no-entrypoint"] }
 spl-transfer-hook-interface = { version = "0.3" , path = "../interface" }
 spl-type-length-value = { version = "0.3" , path = "../../../libraries/type-length-value" }
 


### PR DESCRIPTION
#### Problem

Token-2022 is ready for 1.0, but it's still on version 0.9.

#### Solution

Bump it! We'll also need to bump all of its downstream users in SPL, but I wanted to keep this PR separate so we can tag a release from it more cleanly.