### PR TITLE
token metadata js: bump version

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:
@@ -589,7 +593,7 @@ importers:
         specifier: 2.0.0-experimental.8618508
         version: 2.0.0-experimental.8618508
       '@solana/spl-type-length-value':
-        specifier: workspace:*
+        specifier: 0.1.0
         version: link:../../libraries/type-length-value/js
     devDependencies:
       '@solana/web3.js':
@@ -7996,7 +8000,3 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false

--- a/token-metadata/js/package.json
+++ b/token-metadata/js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@solana/spl-token-metadata",
     "description": "SPL Token Metadata Interface JS API",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "author": "Solana Labs Maintainers <maintainers@solanalabs.com>",
     "repository": "https://github.com/solana-labs/solana-program-library",
     "license": "Apache-2.0",
@@ -52,7 +52,7 @@
         "@solana/codecs-numbers": "2.0.0-experimental.8618508",
         "@solana/codecs-strings": "2.0.0-experimental.8618508",
         "@solana/options": "2.0.0-experimental.8618508",
-        "@solana/spl-type-length-value": "workspace:*"
+        "@solana/spl-type-length-value": "0.1.0"
     },
     "devDependencies": {
         "@solana/web3.js": "^1.87.6",


### PR DESCRIPTION
This PR bumps the version for SPL Token Metadata JS.

Note the previous patch version was published with `npm publish`, not `pnpm publish`, so the dependency link to the TLV library does not resolve on install:

```json
"@solana/spl-type-length-value": "workspace:*",
```

In order to avoid this issue in the future, and allow installing of `@solana/spl-token-metadata` with any package manager, I've also removed the `workspace:*` path in exchange for the real version.