### PR TITLE
js: remove workspace paths

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:
@@ -336,7 +340,7 @@ importers:
   single-pool/js/packages/classic:
     dependencies:
       '@solana/spl-single-pool':
-        specifier: workspace:*
+        specifier: 1.0.0
         version: link:../modern
       '@solana/web3.js':
         specifier: ^1.87.6
@@ -407,7 +411,7 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1
       '@solana/spl-token':
-        specifier: workspace:*
+        specifier: 0.3.9
         version: link:../../token/js
       '@solana/web3.js':
         specifier: ^1.87.6
@@ -520,7 +524,7 @@ importers:
         specifier: ^11.1.1
         version: 11.1.5(rollup@4.7.0)(tslib@2.6.2)(typescript@5.3.3)
       '@solana/spl-token':
-        specifier: workspace:*
+        specifier: 0.3.9
         version: link:../../token/js
       '@solana/web3.js':
         specifier: ^1.87.6
@@ -589,7 +593,7 @@ importers:
         specifier: 2.0.0-experimental.8618508
         version: 2.0.0-experimental.8618508
       '@solana/spl-type-length-value':
-        specifier: workspace:*
+        specifier: 0.1.0
         version: link:../../libraries/type-length-value/js
     devDependencies:
       '@solana/web3.js':
@@ -660,7 +664,7 @@ importers:
         version: 0.2.0
     devDependencies:
       '@solana/spl-token':
-        specifier: workspace:*
+        specifier: 0.3.9
         version: link:../../token/js
       '@solana/web3.js':
         specifier: ^1.87.6
@@ -727,7 +731,7 @@ importers:
         version: 6.0.3
     devDependencies:
       '@solana/spl-memo':
-        specifier: workspace:*
+        specifier: 0.2.3
         version: link:../../memo/js
       '@solana/web3.js':
         specifier: ^1.87.6
@@ -7996,7 +8000,3 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false

--- a/single-pool/js/packages/classic/package.json
+++ b/single-pool/js/packages/classic/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@solana/web3.js": "^1.87.6",
-    "@solana/spl-single-pool": "workspace:*"
+    "@solana/spl-single-pool": "1.0.0"
   },
   "ava": {
     "extensions": {

--- a/stake-pool/js/package.json
+++ b/stake-pool/js/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@coral-xyz/borsh": "^0.29.0",
     "@solana/buffer-layout": "^4.0.1",
-    "@solana/spl-token": "workspace:*",
+    "@solana/spl-token": "0.3.9",
     "@solana/web3.js": "^1.87.6",
     "bn.js": "^5.2.0",
     "buffer": "^6.0.3",

--- a/token-lending/js/package.json
+++ b/token-lending/js/package.json
@@ -37,14 +37,14 @@
         "bignumber.js": "^9.0.1"
     },
     "peerDependencies": {
-        "@solana/spl-token": "workspace:*",
+        "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.20.0"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.0",
         "@rollup/plugin-node-resolve": "^15.0.2",
         "@rollup/plugin-typescript": "^11.1.1",
-        "@solana/spl-token": "workspace:*",
+        "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.87.6",
         "@types/eslint": "^8.44.8",
         "@types/eslint-plugin-prettier": "^3.1.0",

--- a/token-metadata/js/package.json
+++ b/token-metadata/js/package.json
@@ -52,7 +52,7 @@
         "@solana/codecs-numbers": "2.0.0-experimental.8618508",
         "@solana/codecs-strings": "2.0.0-experimental.8618508",
         "@solana/options": "2.0.0-experimental.8618508",
-        "@solana/spl-type-length-value": "workspace:*"
+        "@solana/spl-type-length-value": "0.1.0"
     },
     "devDependencies": {
         "@solana/web3.js": "^1.87.6",

--- a/token-swap/js/package.json
+++ b/token-swap/js/package.json
@@ -52,7 +52,7 @@
     "@solana/web3.js": "^1.87.6"
   },
   "devDependencies": {
-    "@solana/spl-token": "workspace:*",
+    "@solana/spl-token": "0.3.9",
     "@solana/web3.js": "^1.87.6",
     "@types/bn.js": "^5.1.0",
     "@types/chai-as-promised": "^7.1.4",

--- a/token/js/package.json
+++ b/token/js/package.json
@@ -59,7 +59,7 @@
         "buffer": "^6.0.3"
     },
     "devDependencies": {
-        "@solana/spl-memo": "workspace:*",
+        "@solana/spl-memo": "0.2.3",
         "@solana/web3.js": "^1.87.6",
         "@types/chai-as-promised": "^7.1.4",
         "@types/chai": "^4.3.11",


### PR DESCRIPTION
This PR removes the `workspace:*` path from all JS libraries, while we wait for `npm` to incorporate workspace resolution.

In the meantime, this will ensure any downstream developers can install these packages with any package manager.