### PR TITLE
Implement unpacking the rest of base token account's fields for `GenericTokenAccount`

### DIFF
--- a/token/program/src/state.rs
+++ b/token/program/src/state.rs
@@ -316,9 +316,9 @@ pub trait GenericTokenAccount {
         bytemuck::from_bytes(&account_data[offset..offset + PUBKEY_BYTES])
     }
 
-    /// Call after account length has already been verified to unpack a COption<&Pubkey>
-    /// at the specified offset. Panics if `account_data.len()` is less than
-    /// 36 or COption tag is invalid
+    /// Call after account length has already been verified to unpack a
+    /// COption<&Pubkey> at the specified offset. Panics if
+    /// `account_data.len()` is less than 36 or COption tag is invalid
     fn unpack_coption_pubkey_unchecked(account_data: &[u8], offset: usize) -> COption<&Pubkey> {
         let subslice = &account_data[offset..offset + 36];
         match subslice[..4] {


### PR DESCRIPTION
**Problem**

Original problem described in #2970.

`GenericTokenAccount` was created for fast reading of single fields on token account without unpacking the entire struct for both `token` and `token-2022`. However, it was only implemented for `owner` and `mint` in #2970 

**Solution**

Implement the rest of the fields
