### PR TITLE
tlv account resolution: bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7252,6 +7252,20 @@ dependencies = [
 [[package]]
 name = "spl-tlv-account-resolution"
 version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "062e148d3eab7b165582757453632ffeef490c02c86a48bfdb4988f63eefb3b9"
+dependencies = [
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-pod 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-program-error 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-type-length-value 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "spl-tlv-account-resolution"
+version = "0.5.0"
 dependencies = [
  "bytemuck",
  "futures 0.3.29",
@@ -7264,20 +7278,6 @@ dependencies = [
  "spl-pod 0.1.0",
  "spl-program-error 0.3.0",
  "spl-type-length-value 0.3.0",
-]
-
-[[package]]
-name = "spl-tlv-account-resolution"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062e148d3eab7b165582757453632ffeef490c02c86a48bfdb4988f63eefb3b9"
-dependencies = [
- "bytemuck",
- "solana-program",
- "spl-discriminator 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-pod 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-program-error 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-type-length-value 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -7670,7 +7670,7 @@ dependencies = [
  "solana-remote-wallet",
  "solana-sdk",
  "solana-test-validator",
- "spl-tlv-account-resolution 0.4.0",
+ "spl-tlv-account-resolution 0.5.0",
  "spl-token-2022 1.0.0",
  "spl-token-client",
  "spl-transfer-hook-interface 0.4.0",
@@ -7687,7 +7687,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-tlv-account-resolution 0.4.0",
+ "spl-tlv-account-resolution 0.5.0",
  "spl-token-2022 1.0.0",
  "spl-transfer-hook-interface 0.4.0",
  "spl-type-length-value 0.3.0",
@@ -7705,7 +7705,7 @@ dependencies = [
  "spl-discriminator 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-pod 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-program-error 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-tlv-account-resolution 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-tlv-account-resolution 0.4.0",
  "spl-type-length-value 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -7719,7 +7719,7 @@ dependencies = [
  "spl-discriminator 0.1.0",
  "spl-pod 0.1.0",
  "spl-program-error 0.3.0",
- "spl-tlv-account-resolution 0.4.0",
+ "spl-tlv-account-resolution 0.5.0",
  "spl-type-length-value 0.3.0",
 ]
 

--- a/libraries/tlv-account-resolution/Cargo.toml
+++ b/libraries/tlv-account-resolution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-tlv-account-resolution"
-version = "0.4.0"
+version = "0.5.0"
 description = "Solana Program Library TLV Account Resolution Interface"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token/transfer-hook/cli/Cargo.toml
+++ b/token/transfer-hook/cli/Cargo.toml
@@ -18,7 +18,7 @@ solana-logger = "=1.17.6"
 solana-remote-wallet = "=1.17.6"
 solana-sdk = "=1.17.6"
 spl-transfer-hook-interface = { version = "0.4", path = "../interface" }
-spl-tlv-account-resolution = { version = "0.4" , path = "../../../libraries/tlv-account-resolution" }
+spl-tlv-account-resolution = { version = "0.5" , path = "../../../libraries/tlv-account-resolution" }
 strum = "0.25"
 strum_macros = "0.25"
 tokio = { version = "1", features = ["full"] }

--- a/token/transfer-hook/example/Cargo.toml
+++ b/token/transfer-hook/example/Cargo.toml
@@ -14,7 +14,7 @@ test-sbf = []
 [dependencies]
 arrayref = "0.3.7"
 solana-program = "1.17.6"
-spl-tlv-account-resolution = { version = "0.4" , path = "../../../libraries/tlv-account-resolution" }
+spl-tlv-account-resolution = { version = "0.5" , path = "../../../libraries/tlv-account-resolution" }
 spl-token-2022 = { version = "1.0",  path = "../../program-2022", features = ["no-entrypoint"] }
 spl-transfer-hook-interface = { version = "0.4" , path = "../interface" }
 spl-type-length-value = { version = "0.3" , path = "../../../libraries/type-length-value" }

--- a/token/transfer-hook/interface/Cargo.toml
+++ b/token/transfer-hook/interface/Cargo.toml
@@ -13,7 +13,7 @@ bytemuck = { version = "1.14.0", features = ["derive"] }
 solana-program = "1.17.6"
 spl-discriminator = { version = "0.1" , path = "../../../libraries/discriminator" }
 spl-program-error = { version = "0.3" , path = "../../../libraries/program-error" }
-spl-tlv-account-resolution = { version = "0.4" , path = "../../../libraries/tlv-account-resolution" }
+spl-tlv-account-resolution = { version = "0.5" , path = "../../../libraries/tlv-account-resolution" }
 spl-type-length-value = { version = "0.3" , path = "../../../libraries/type-length-value" }
 spl-pod = { version = "0.1", path = "../../../libraries/pod" }
 


### PR DESCRIPTION
In step with #5970 we need to bump the TLV Account Resolution library.

Note: I think I semi-bungled this a bit. I published `spl-transfer-hook-interface`, which was using the previous version of TLV Account Resolution, however it does not use any of the new version `0.5.0` code.

The example, however, does use the new code, so it requires version `0.5.0`.

If both are used together, Cargo should resolve to `0.5.0` all the time, right?