### PR TITLE
transfer hook: bump interface to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7361,7 +7361,7 @@ dependencies = [
  "spl-token 4.0.0",
  "spl-token-group-interface",
  "spl-token-metadata-interface 0.2.0",
- "spl-transfer-hook-interface 0.4.0",
+ "spl-transfer-hook-interface 0.4.1",
  "spl-type-length-value 0.3.0",
  "thiserror",
 ]
@@ -7385,7 +7385,7 @@ dependencies = [
  "spl-token-group-interface",
  "spl-token-metadata-interface 0.2.0",
  "spl-transfer-hook-example",
- "spl-transfer-hook-interface 0.4.0",
+ "spl-transfer-hook-interface 0.4.1",
  "test-case",
  "walkdir",
 ]
@@ -7447,7 +7447,7 @@ dependencies = [
  "spl-token-2022 1.0.0",
  "spl-token-group-interface",
  "spl-token-metadata-interface 0.2.0",
- "spl-transfer-hook-interface 0.4.0",
+ "spl-transfer-hook-interface 0.4.1",
  "thiserror",
 ]
 
@@ -7673,7 +7673,7 @@ dependencies = [
  "spl-tlv-account-resolution 0.5.0",
  "spl-token-2022 1.0.0",
  "spl-token-client",
- "spl-transfer-hook-interface 0.4.0",
+ "spl-transfer-hook-interface 0.4.1",
  "strum 0.25.0",
  "strum_macros 0.25.3",
  "tokio",
@@ -7689,7 +7689,7 @@ dependencies = [
  "solana-sdk",
  "spl-tlv-account-resolution 0.5.0",
  "spl-token-2022 1.0.0",
- "spl-transfer-hook-interface 0.4.0",
+ "spl-transfer-hook-interface 0.4.1",
  "spl-type-length-value 0.3.0",
 ]
 
@@ -7711,7 +7711,7 @@ dependencies = [
 
 [[package]]
 name = "spl-transfer-hook-interface"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "arrayref",
  "bytemuck",

--- a/token/transfer-hook/interface/Cargo.toml
+++ b/token/transfer-hook/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-transfer-hook-interface"
-version = "0.4.0"
+version = "0.4.1"
 description = "Solana Program Library Transfer Hook Interface"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"


### PR DESCRIPTION
This bump to `spl-transfer-hook-interface` adds the newer version of `spl-tlv-account-resolution` (`0.5`).