### PR TITLE
transfer hook cli: add support for PDAs as extra metas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7270,6 +7270,7 @@ dependencies = [
  "bytemuck",
  "futures 0.3.29",
  "futures-util",
+ "serde",
  "solana-client",
  "solana-program",
  "solana-program-test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4608,9 +4608,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.25"
+version = "0.9.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
+checksum = "3cc7a1570e38322cfe4154732e5110f887ea57e22b76f4bfd32b5bdd3368666c"
 dependencies = [
  "indexmap 2.0.2",
  "itoa",
@@ -7664,6 +7664,9 @@ version = "0.2.0"
 dependencies = [
  "clap 3.2.25",
  "futures-util",
+ "serde",
+ "serde_json",
+ "serde_yaml",
  "solana-clap-v3-utils",
  "solana-cli-config",
  "solana-client",

--- a/libraries/tlv-account-resolution/Cargo.toml
+++ b/libraries/tlv-account-resolution/Cargo.toml
@@ -8,10 +8,12 @@ license = "Apache-2.0"
 edition = "2021"
 
 [features]
+serde-traits = ["dep:serde"]
 test-sbf = []
 
 [dependencies]
 bytemuck = { version = "1.14.0", features = ["derive"] }
+serde = { version = "1.0.193", optional = true }
 solana-program = "1.17.6"
 spl-discriminator = { version = "0.1", path = "../discriminator" }
 spl-program-error = { version = "0.3", path = "../program-error" }

--- a/libraries/tlv-account-resolution/src/seeds.rs
+++ b/libraries/tlv-account-resolution/src/seeds.rs
@@ -34,7 +34,7 @@ use {crate::error::AccountResolutionError, solana_program::program_error::Progra
 /// Enum to describe a required seed for a Program-Derived Address
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde-traits", serde(rename_all = "snake_case"))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
 pub enum Seed {
     /// Uninitialized configuration byte space
     Uninitialized,
@@ -57,7 +57,7 @@ pub enum Seed {
     ///     * 1 - Discriminator
     ///     * 1 - Start index of instruction data
     ///     * 1 - Length of instruction data starting at index
-    #[cfg_attr(feature = "serde-traits", serde(alias = "instructionData"))]
+    #[cfg_attr(feature = "serde-traits", serde(alias = "instruction_data"))]
     InstructionData {
         /// The index where the bytes of an instruction argument begin
         index: u8,
@@ -72,7 +72,7 @@ pub enum Seed {
     /// Packed as:
     ///     * 1 - Discriminator
     ///     * 1 - Index of account in accounts list
-    #[cfg_attr(feature = "serde-traits", serde(alias = "accountKey"))]
+    #[cfg_attr(feature = "serde-traits", serde(alias = "account_key"))]
     AccountKey {
         /// The index of the account in the entire accounts list
         index: u8,
@@ -83,13 +83,16 @@ pub enum Seed {
     ///     * 1 - Index of account in accounts list
     ///     * 1 - Start index of account data
     ///     * 1 - Length of account data starting at index
-    #[cfg_attr(feature = "serde-traits", serde(alias = "accountData"))]
+    #[cfg_attr(
+        feature = "serde-traits",
+        serde(rename_all = "camelCase", alias = "account_data")
+    )]
     AccountData {
         /// The index of the account in the entire accounts list
-        #[cfg_attr(feature = "serde-traits", serde(alias = "accountIndex"))]
+        #[cfg_attr(feature = "serde-traits", serde(alias = "account_index"))]
         account_index: u8,
         /// The index where the bytes of an account data argument begin
-        #[cfg_attr(feature = "serde-traits", serde(alias = "dataIndex"))]
+        #[cfg_attr(feature = "serde-traits", serde(alias = "data_index"))]
         data_index: u8,
         /// The length of the argument (number of bytes)
         ///

--- a/libraries/tlv-account-resolution/src/seeds.rs
+++ b/libraries/tlv-account-resolution/src/seeds.rs
@@ -57,7 +57,6 @@ pub enum Seed {
     ///     * 1 - Discriminator
     ///     * 1 - Start index of instruction data
     ///     * 1 - Length of instruction data starting at index
-    #[cfg_attr(feature = "serde-traits", serde(alias = "instruction_data"))]
     InstructionData {
         /// The index where the bytes of an instruction argument begin
         index: u8,
@@ -72,7 +71,6 @@ pub enum Seed {
     /// Packed as:
     ///     * 1 - Discriminator
     ///     * 1 - Index of account in accounts list
-    #[cfg_attr(feature = "serde-traits", serde(alias = "account_key"))]
     AccountKey {
         /// The index of the account in the entire accounts list
         index: u8,
@@ -89,10 +87,8 @@ pub enum Seed {
     )]
     AccountData {
         /// The index of the account in the entire accounts list
-        #[cfg_attr(feature = "serde-traits", serde(alias = "account_index"))]
         account_index: u8,
         /// The index where the bytes of an account data argument begin
-        #[cfg_attr(feature = "serde-traits", serde(alias = "data_index"))]
         data_index: u8,
         /// The length of the argument (number of bytes)
         ///

--- a/libraries/tlv-account-resolution/src/seeds.rs
+++ b/libraries/tlv-account-resolution/src/seeds.rs
@@ -27,10 +27,14 @@
 //! No matter which types of seeds you choose, the total size of all seed
 //! configurations must be less than or equal to 32 bytes.
 
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
 use {crate::error::AccountResolutionError, solana_program::program_error::ProgramError};
 
 /// Enum to describe a required seed for a Program-Derived Address
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "snake_case"))]
 pub enum Seed {
     /// Uninitialized configuration byte space
     Uninitialized,
@@ -53,6 +57,7 @@ pub enum Seed {
     ///     * 1 - Discriminator
     ///     * 1 - Start index of instruction data
     ///     * 1 - Length of instruction data starting at index
+    #[cfg_attr(feature = "serde-traits", serde(alias = "instructionData"))]
     InstructionData {
         /// The index where the bytes of an instruction argument begin
         index: u8,
@@ -67,6 +72,7 @@ pub enum Seed {
     /// Packed as:
     ///     * 1 - Discriminator
     ///     * 1 - Index of account in accounts list
+    #[cfg_attr(feature = "serde-traits", serde(alias = "accountKey"))]
     AccountKey {
         /// The index of the account in the entire accounts list
         index: u8,
@@ -77,10 +83,13 @@ pub enum Seed {
     ///     * 1 - Index of account in accounts list
     ///     * 1 - Start index of account data
     ///     * 1 - Length of account data starting at index
+    #[cfg_attr(feature = "serde-traits", serde(alias = "accountData"))]
     AccountData {
         /// The index of the account in the entire accounts list
+        #[cfg_attr(feature = "serde-traits", serde(alias = "accountIndex"))]
         account_index: u8,
         /// The index where the bytes of an account data argument begin
+        #[cfg_attr(feature = "serde-traits", serde(alias = "dataIndex"))]
         data_index: u8,
         /// The length of the argument (number of bytes)
         ///

--- a/token/transfer-hook/cli/Cargo.toml
+++ b/token/transfer-hook/cli/Cargo.toml
@@ -18,10 +18,13 @@ solana-logger = "=1.17.6"
 solana-remote-wallet = "=1.17.6"
 solana-sdk = "=1.17.6"
 spl-transfer-hook-interface = { version = "0.4", path = "../interface" }
-spl-tlv-account-resolution = { version = "0.5" , path = "../../../libraries/tlv-account-resolution" }
+spl-tlv-account-resolution = { version = "0.5" , path = "../../../libraries/tlv-account-resolution", features = ["serde-traits"] }
 strum = "0.25"
 strum_macros = "0.25"
 tokio = { version = "1", features = ["full"] }
+serde = { version = "1.0.193", features = ["derive"] }
+serde_json = "1.0.108"
+serde_yaml = "0.9.27"
 
 [dev-dependencies]
 solana-test-validator = "=1.17.6"

--- a/token/transfer-hook/cli/src/main.rs
+++ b/token/transfer-hook/cli/src/main.rs
@@ -252,16 +252,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         .help("The token mint address for the transfer hook"),
                 )
                 .arg(
-                    Arg::with_name("transfer_hook_account")
+                    Arg::with_name("transfer_hook_accounts")
                         .value_parser(parse_transfer_hook_account_arg)
-                        .value_name("PUBKEY:ROLE")
+                        .value_name("TRANSFER_HOOK_ACCOUNTS")
                         .takes_value(true)
                         .multiple(true)
                         .min_values(0)
                         .index(3)
-                        .help("Additional pubkey(s) required for a transfer hook and their \
-                            role, in the format \"<PUBKEY>:<ROLE>\". The role must be \
-                            \"readonly\", \"writable\". \"readonly-signer\", or \"writable-signer\".")
+                        .help("Additional account(s) required for a transfer hook and their \
+                            respective configurations, whether they are a fixed address or PDA. \
+                            \nAdditional accounts with known fixed addresses can be passed at the \
+                            command line in the format \"<PUBKEY>:<ROLE>\". The role must be \
+                            \"readonly\", \"writable\". \"readonly-signer\", or \"writable-signer\". \
+                            \n Additional acounts requiring seed configurations can be defined in a \
+                            configuration file using either JSON or YAML.")
                 )
                 .arg(
                     Arg::new("mint_authority")
@@ -295,16 +299,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         .help("The token mint address for the transfer hook"),
                 )
                 .arg(
-                    Arg::with_name("transfer_hook_account")
+                    Arg::with_name("transfer_hook_accounts")
                         .value_parser(parse_transfer_hook_account_arg)
-                        .value_name("PUBKEY:ROLE")
+                        .value_name("TRANSFER_HOOK_ACCOUNTS")
                         .takes_value(true)
                         .multiple(true)
                         .min_values(0)
                         .index(3)
-                        .help("Additional pubkey(s) required for a transfer hook and their \
-                            role, in the format \"<PUBKEY>:<ROLE>\". The role must be \
-                            \"readonly\", \"writable\". \"readonly-signer\", or \"writable-signer\".")
+                        .help("Additional account(s) required for a transfer hook and their \
+                            respective configurations, whether they are a fixed address or PDA. \
+                            \nAdditional accounts with known fixed addresses can be passed at the \
+                            command line in the format \"<PUBKEY>:<ROLE>\". The role must be \
+                            \"readonly\", \"writable\". \"readonly-signer\", or \"writable-signer\". \
+                            \n Additional acounts requiring seed configurations can be defined in a \
+                            configuration file using either JSON or YAML.")
                 )
                 .arg(
                     Arg::new("mint_authority")

--- a/token/transfer-hook/cli/src/main.rs
+++ b/token/transfer-hook/cli/src/main.rs
@@ -370,8 +370,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .unwrap()
                 .unwrap();
             let transfer_hook_accounts = arg_matches
-                .get_many::<ExtraAccountMeta>("transfer_hook_account")
+                .get_many::<Vec<ExtraAccountMeta>>("transfer_hook_account")
                 .unwrap_or_default()
+                .flatten()
                 .cloned()
                 .collect();
             let mint_authority = DefaultSigner::new(
@@ -409,8 +410,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .unwrap()
                 .unwrap();
             let transfer_hook_accounts = arg_matches
-                .get_many::<ExtraAccountMeta>("transfer_hook_account")
+                .get_many::<Vec<ExtraAccountMeta>>("transfer_hook_account")
                 .unwrap_or_default()
+                .flatten()
                 .cloned()
                 .collect();
             let mint_authority = DefaultSigner::new(

--- a/token/transfer-hook/cli/src/main.rs
+++ b/token/transfer-hook/cli/src/main.rs
@@ -259,13 +259,50 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         .multiple(true)
                         .min_values(0)
                         .index(3)
-                        .help("Additional account(s) required for a transfer hook and their \
-                            respective configurations, whether they are a fixed address or PDA. \
-                            \nAdditional accounts with known fixed addresses can be passed at the \
-                            command line in the format \"<PUBKEY>:<ROLE>\". The role must be \
-                            \"readonly\", \"writable\". \"readonly-signer\", or \"writable-signer\". \
-                            \n Additional acounts requiring seed configurations can be defined in a \
-                            configuration file using either JSON or YAML.")
+                        .help(r#"Additional account(s) required for a transfer hook and their respective configurations, whether they are a fixed address or PDA.
+
+Additional accounts with known fixed addresses can be passed at the command line in the format "<PUBKEY>:<ROLE>". The role must be "readonly", "writable". "readonly-signer", or "writable-signer".
+
+Additional acounts requiring seed configurations can be defined in a configuration file using either JSON or YAML. The format is as follows:
+                            
+```json
+{
+    "extraMetas": [
+        {
+            "pubkey": "39UhV...",
+            "role": "readonly-signer"
+        },
+        {
+            "seeds": [
+                {
+                    "literal": {
+                        "bytes": [1, 2, 3, 4, 5, 6]
+                    }
+                },
+                {
+                    "accountKey": {
+                        "index": 0
+                    }
+                }
+            ],
+            "role": "writable"
+        }
+    ]
+}
+```
+
+```yaml
+extraMetas:
+  - pubkey: "39UhV..."
+      role: "readonly-signer"
+  - seeds:
+      - literal:
+          bytes: [1, 2, 3, 4, 5, 6]
+      - accountKey:
+          index: 0
+      role: "writable"
+```
+"#)
                 )
                 .arg(
                     Arg::new("mint_authority")
@@ -306,13 +343,50 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         .multiple(true)
                         .min_values(0)
                         .index(3)
-                        .help("Additional account(s) required for a transfer hook and their \
-                            respective configurations, whether they are a fixed address or PDA. \
-                            \nAdditional accounts with known fixed addresses can be passed at the \
-                            command line in the format \"<PUBKEY>:<ROLE>\". The role must be \
-                            \"readonly\", \"writable\". \"readonly-signer\", or \"writable-signer\". \
-                            \n Additional acounts requiring seed configurations can be defined in a \
-                            configuration file using either JSON or YAML.")
+                        .help(r#"Additional account(s) required for a transfer hook and their respective configurations, whether they are a fixed address or PDA.
+
+Additional accounts with known fixed addresses can be passed at the command line in the format "<PUBKEY>:<ROLE>". The role must be "readonly", "writable". "readonly-signer", or "writable-signer".
+
+Additional acounts requiring seed configurations can be defined in a configuration file using either JSON or YAML. The format is as follows:
+                            
+```json
+{
+    "extraMetas": [
+        {
+            "pubkey": "39UhV...",
+            "role": "readonly-signer"
+        },
+        {
+            "seeds": [
+                {
+                    "literal": {
+                        "bytes": [1, 2, 3, 4, 5, 6]
+                    }
+                },
+                {
+                    "accountKey": {
+                        "index": 0
+                    }
+                }
+            ],
+            "role": "writable"
+        }
+    ]
+}
+```
+
+```yaml
+extraMetas:
+  - pubkey: "39UhV..."
+      role: "readonly-signer"
+  - seeds:
+      - literal:
+          bytes: [1, 2, 3, 4, 5, 6]
+      - accountKey:
+          index: 0
+      role: "writable"
+```
+"#)
                 )
                 .arg(
                     Arg::new("mint_authority")

--- a/token/transfer-hook/cli/src/main.rs
+++ b/token/transfer-hook/cli/src/main.rs
@@ -1,4 +1,7 @@
+pub mod meta;
+
 use {
+    crate::meta::parse_transfer_hook_account,
     clap::{crate_description, crate_name, crate_version, Arg, Command},
     solana_clap_v3_utils::{
         input_parsers::{parse_url_or_moniker, pubkey_of_signer},
@@ -20,38 +23,8 @@ use {
         get_extra_account_metas_address,
         instruction::{initialize_extra_account_meta_list, update_extra_account_meta_list},
     },
-    std::{fmt, process::exit, rc::Rc, str::FromStr},
-    strum_macros::{EnumString, IntoStaticStr},
+    std::{process::exit, rc::Rc},
 };
-
-#[derive(Debug, Clone, Copy, PartialEq, EnumString, IntoStaticStr)]
-#[strum(serialize_all = "kebab-case")]
-pub enum AccountMetaRole {
-    Readonly,
-    Writable,
-    ReadonlySigner,
-    WritableSigner,
-}
-impl fmt::Display for AccountMetaRole {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
-    }
-}
-fn parse_transfer_hook_account(arg: &str) -> Result<AccountMeta, String> {
-    match arg.split(':').collect::<Vec<_>>().as_slice() {
-        [address, role] => {
-            let address = Pubkey::from_str(address).map_err(|e| format!("{e}"))?;
-            let meta = match AccountMetaRole::from_str(role).map_err(|e| format!("{e}"))? {
-                AccountMetaRole::Readonly => AccountMeta::new_readonly(address, false),
-                AccountMetaRole::Writable => AccountMeta::new(address, false),
-                AccountMetaRole::ReadonlySigner => AccountMeta::new_readonly(address, true),
-                AccountMetaRole::WritableSigner => AccountMeta::new(address, true),
-            };
-            Ok(meta)
-        }
-        _ => Err("Transfer hook account must be present as <ADDRESS>:<ROLE>".to_string()),
-    }
-}
 
 fn clap_is_valid_pubkey(arg: &str) -> Result<(), String> {
     is_valid_pubkey(arg)

--- a/token/transfer-hook/cli/src/main.rs
+++ b/token/transfer-hook/cli/src/main.rs
@@ -261,7 +261,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         .index(3)
                         .help(r#"Additional account(s) required for a transfer hook and their respective configurations, whether they are a fixed address or PDA.
 
-Additional accounts with known fixed addresses can be passed at the command line in the format "<PUBKEY>:<ROLE>". The role must be "readonly", "writable". "readonly-signer", or "writable-signer".
+Additional accounts with known fixed addresses can be passed at the command line in the format "<PUBKEY>:<ROLE>". The role must be "readonly", "writable". "readonlySigner", or "writableSigner".
 
 Additional acounts requiring seed configurations can be defined in a configuration file using either JSON or YAML. The format is as follows:
                             
@@ -270,7 +270,7 @@ Additional acounts requiring seed configurations can be defined in a configurati
     "extraMetas": [
         {
             "pubkey": "39UhV...",
-            "role": "readonly-signer"
+            "role": "readonlySigner"
         },
         {
             "seeds": [
@@ -294,7 +294,7 @@ Additional acounts requiring seed configurations can be defined in a configurati
 ```yaml
 extraMetas:
   - pubkey: "39UhV..."
-      role: "readonly-signer"
+      role: "readonlySigner"
   - seeds:
       - literal:
           bytes: [1, 2, 3, 4, 5, 6]
@@ -345,7 +345,7 @@ extraMetas:
                         .index(3)
                         .help(r#"Additional account(s) required for a transfer hook and their respective configurations, whether they are a fixed address or PDA.
 
-Additional accounts with known fixed addresses can be passed at the command line in the format "<PUBKEY>:<ROLE>". The role must be "readonly", "writable". "readonly-signer", or "writable-signer".
+Additional accounts with known fixed addresses can be passed at the command line in the format "<PUBKEY>:<ROLE>". The role must be "readonly", "writable". "readonlySigner", or "writableSigner".
 
 Additional acounts requiring seed configurations can be defined in a configuration file using either JSON or YAML. The format is as follows:
                             
@@ -354,7 +354,7 @@ Additional acounts requiring seed configurations can be defined in a configurati
     "extraMetas": [
         {
             "pubkey": "39UhV...",
-            "role": "readonly-signer"
+            "role": "readonlySigner"
         },
         {
             "seeds": [
@@ -378,7 +378,7 @@ Additional acounts requiring seed configurations can be defined in a configurati
 ```yaml
 extraMetas:
   - pubkey: "39UhV..."
-      role: "readonly-signer"
+      role: "readonlySigner"
   - seeds:
       - literal:
           bytes: [1, 2, 3, 4, 5, 6]

--- a/token/transfer-hook/cli/src/main.rs
+++ b/token/transfer-hook/cli/src/main.rs
@@ -378,7 +378,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .unwrap()
                 .unwrap();
             let transfer_hook_accounts = arg_matches
-                .get_many::<Vec<ExtraAccountMeta>>("transfer_hook_account")
+                .get_many::<Vec<ExtraAccountMeta>>("transfer_hook_accounts")
                 .unwrap_or_default()
                 .flatten()
                 .cloned()
@@ -418,7 +418,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .unwrap()
                 .unwrap();
             let transfer_hook_accounts = arg_matches
-                .get_many::<Vec<ExtraAccountMeta>>("transfer_hook_account")
+                .get_many::<Vec<ExtraAccountMeta>>("transfer_hook_accounts")
                 .unwrap_or_default()
                 .flatten()
                 .cloned()

--- a/token/transfer-hook/cli/src/meta.rs
+++ b/token/transfer-hook/cli/src/meta.rs
@@ -2,121 +2,148 @@ use {
     serde::{Deserialize, Serialize},
     solana_sdk::pubkey::Pubkey,
     spl_tlv_account_resolution::{account::ExtraAccountMeta, seeds::Seed},
-    std::{fmt, path::Path, str::FromStr},
+    std::{path::Path, str::FromStr},
     strum_macros::{EnumString, IntoStaticStr},
 };
+
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Access {
+    #[serde(alias = "is_signer")]
+    is_signer: bool,
+    #[serde(alias = "is_writable")]
+    is_writable: bool,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, EnumString, IntoStaticStr, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[strum(serialize_all = "kebab-case")]
-enum AccountMetaRole {
+enum Role {
     Readonly,
     Writable,
     ReadonlySigner,
     WritableSigner,
 }
-impl AccountMetaRole {
-    fn bools(&self) -> (/* is_signer */ bool, /* is_writable */ bool) {
-        match self {
-            AccountMetaRole::Readonly => (false, false),
-            AccountMetaRole::Writable => (false, true),
-            AccountMetaRole::ReadonlySigner => (true, false),
-            AccountMetaRole::WritableSigner => (true, true),
-        }
-    }
-}
-impl fmt::Display for AccountMetaRole {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
-    }
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", untagged)]
+enum AccessLevel {
+    Access(Access),
+    Role { role: Role },
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
-struct ExtraAccountMetaConfigFile {
-    #[serde(alias = "extraMetas")]
-    extra_metas: Vec<ExtraAccountMetaConfig>,
+#[serde(rename_all = "camelCase")]
+enum AddressConfig {
+    Pubkey(String),
+    Seeds(Vec<Seed>),
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
-struct ExtraAccountMetaConfig {
-    pubkey: Option<String>,
-    seeds: Option<Vec<Seed>>,
-    role: Option<AccountMetaRole>,
-    #[serde(alias = "isSigner")]
-    is_signer: Option<bool>,
-    #[serde(alias = "isWritable")]
-    is_writable: Option<bool>,
+#[serde(rename_all = "camelCase")]
+struct Config {
+    #[serde(flatten)]
+    address_config: AddressConfig,
+    #[serde(flatten)]
+    access_level: AccessLevel,
 }
-impl From<&ExtraAccountMetaConfig> for ExtraAccountMeta {
-    fn from(config: &ExtraAccountMetaConfig) -> Self {
-        if config.pubkey.is_some() && config.seeds.is_some() {
-            panic!("Only one of `pubkey` or `seeds` must be present");
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ConfigFile {
+    #[serde(alias = "extra_metas")]
+    extra_metas: Vec<Config>,
+}
+
+impl From<&Role> for Access {
+    fn from(role: &Role) -> Self {
+        match role {
+            Role::Readonly => Access {
+                is_signer: false,
+                is_writable: false,
+            },
+            Role::Writable => Access {
+                is_signer: false,
+                is_writable: true,
+            },
+            Role::ReadonlySigner => Access {
+                is_signer: true,
+                is_writable: false,
+            },
+            Role::WritableSigner => Access {
+                is_signer: true,
+                is_writable: true,
+            },
         }
-        let (is_signer, is_writable) = {
-            if config.role.is_none() && config.is_signer.is_none() && config.is_writable.is_none() {
-                panic!("Either `role` or `is_signer`/`is_writable` must be present");
-            }
-            if let Some(role) = config.role {
-                if config.is_signer.is_some() || config.is_writable.is_some() {
-                    panic!("`role` and `is_signer`/`is_writable` are mutually exclusive");
-                }
-                role.bools()
-            } else {
-                if config.is_signer.is_none() || config.is_writable.is_none() {
-                    panic!(
-                        "`is_signer` and `is_writable` must be present when `role` is not present"
-                    );
-                }
-                (config.is_signer.unwrap(), config.is_writable.unwrap())
-            }
+    }
+}
+
+impl From<&Config> for ExtraAccountMeta {
+    fn from(config: &Config) -> Self {
+        let Access {
+            is_signer,
+            is_writable,
+        } = match &config.access_level {
+            AccessLevel::Role { role } => role.into(),
+            AccessLevel::Access(access) => *access,
         };
-        if let Some(pubkey_string) = &config.pubkey {
-            ExtraAccountMeta::new_with_pubkey(
+        match &config.address_config {
+            AddressConfig::Pubkey(pubkey_string) => ExtraAccountMeta::new_with_pubkey(
                 &Pubkey::from_str(pubkey_string).unwrap(),
                 is_signer,
                 is_writable,
             )
-            .unwrap()
-        } else if let Some(seeds) = &config.seeds {
-            ExtraAccountMeta::new_with_seeds(seeds, is_signer, is_writable).unwrap()
-        } else {
-            panic!("Either `pubkey` or `seeds` must be present");
+            .unwrap(),
+            AddressConfig::Seeds(seeds) => {
+                ExtraAccountMeta::new_with_seeds(seeds, is_signer, is_writable).unwrap()
+            }
         }
     }
 }
 
+type ParseFn = fn(&str) -> Result<ConfigFile, String>;
+
+fn get_parse_function(path: &Path) -> Result<ParseFn, String> {
+    match path.extension().and_then(|s| s.to_str()) {
+        Some("json") => Ok(|v: &str| {
+            serde_json::from_str::<ConfigFile>(v).map_err(|e| format!("Unable to parse file: {e}"))
+        }),
+        Some("yaml") | Some("yml") => Ok(|v: &str| {
+            serde_yaml::from_str::<ConfigFile>(v).map_err(|e| format!("Unable to parse file: {e}"))
+        }),
+        _ => Err(format!("Unsupported file extension: {}", path.display())),
+    }
+}
+
+fn parse_config_file_arg(path_str: &str) -> Result<Vec<ExtraAccountMeta>, String> {
+    let path = Path::new(path_str);
+    let parse_fn = get_parse_function(path)?;
+    let file =
+        std::fs::read_to_string(path).map_err(|err| format!("Unable to read file: {err}"))?;
+    let parsed_config_file = parse_fn(&file)?;
+    Ok(parsed_config_file
+        .extra_metas
+        .iter()
+        .map(ExtraAccountMeta::from)
+        .collect())
+}
+
+fn parse_pubkey_role_arg(pubkey_string: &str, role: &str) -> Result<Vec<ExtraAccountMeta>, String> {
+    let pubkey = Pubkey::from_str(pubkey_string).map_err(|e| format!("{e}"))?;
+    let role = &Role::from_str(role).map_err(|e| format!("{e}"))?;
+    let Access {
+        is_signer,
+        is_writable,
+    } = role.into();
+    ExtraAccountMeta::new_with_pubkey(&pubkey, is_signer, is_writable)
+        .map(|meta| vec![meta])
+        .map_err(|e| format!("{e}"))
+}
+
 pub fn parse_transfer_hook_account_arg(arg: &str) -> Result<Vec<ExtraAccountMeta>, String> {
     match arg.split(':').collect::<Vec<_>>().as_slice() {
-        [address, role] => {
-            let pubkey = Pubkey::from_str(address).map_err(|e| format!("{e}"))?;
-            let role = AccountMetaRole::from_str(role).map_err(|e| format!("{e}"))?;
-            let (is_signer, is_writable) = role.bools();
-            let meta = ExtraAccountMeta::new_with_pubkey(&pubkey, is_signer, is_writable)
-                .map_err(|e| format!("{e}"))?;
-            Ok(vec![meta])
-        }
-        _ => {
-            let path = Path::new(arg);
-            let parse_fn = match path.extension().and_then(|s| s.to_str()) {
-                Some("json") => |v: &str| {
-                    serde_json::from_str::<ExtraAccountMetaConfigFile>(v)
-                        .map_err(|e| format!("Unable to parse file: {e}"))
-                },
-                Some("yaml") | Some("yml") => |v: &str| {
-                    serde_yaml::from_str::<ExtraAccountMetaConfigFile>(v)
-                        .map_err(|e| format!("Unable to parse file: {e}"))
-                },
-                _ => panic!("Unsupported file extension: {}", path.display()),
-            };
-            let file = std::fs::read_to_string(path)
-                .map_err(|err| format!("Unable to read file: {err}"))?;
-            let parsed_config_file = parse_fn(&file)?;
-            Ok(parsed_config_file
-                .extra_metas
-                .iter()
-                .map(ExtraAccountMeta::from)
-                .collect())
-        }
+        [pubkey_str, role] => parse_pubkey_role_arg(pubkey_str, role),
+        _ => parse_config_file_arg(arg),
     }
 }
 
@@ -178,8 +205,7 @@ mod tests {
                 }
             ]
         }"#;
-        let parsed_config_file =
-            serde_json::from_str::<ExtraAccountMetaConfigFile>(config).unwrap();
+        let parsed_config_file = serde_json::from_str::<ConfigFile>(config).unwrap();
         let parsed_extra_metas: Vec<ExtraAccountMeta> = parsed_config_file
             .extra_metas
             .iter()
@@ -240,26 +266,25 @@ mod tests {
                   is_signer: false
                   is_writable: false
                 - seeds:
-                    - !literal
-                      bytes: [1, 2, 3, 4, 5, 6]
-                    - !instruction_data
-                      index: 0
-                      length: 8
-                    - !account_key
-                      index: 0
+                    - literal:
+                        bytes: [1, 2, 3, 4, 5, 6]
+                    - instruction_data:
+                        index: 0
+                        length: 8
+                    - account_key:
+                        index: 0
                   role: "writable"
                 - seeds:
-                    - !account_data
-                      account_index: 1
-                      data_index: 4
-                      length: 4
-                    - !account_key
-                      index: 1
+                    - account_data:
+                        account_index: 1
+                        data_index: 4
+                        length: 4
+                    - account_key:
+                        index: 1
                   is_signer: false
                   is_writable: false
         "#;
-        let parsed_config_file =
-            serde_yaml::from_str::<ExtraAccountMetaConfigFile>(config).unwrap();
+        let parsed_config_file = serde_yaml::from_str::<ConfigFile>(config).unwrap();
         let parsed_extra_metas: Vec<ExtraAccountMeta> = parsed_config_file
             .extra_metas
             .iter()

--- a/token/transfer-hook/cli/src/meta.rs
+++ b/token/transfer-hook/cli/src/meta.rs
@@ -14,8 +14,8 @@ struct Access {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, EnumString, IntoStaticStr, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-#[strum(serialize_all = "kebab-case")]
+#[serde(rename_all = "camelCase")]
+#[strum(serialize_all = "camelCase")]
 enum Role {
     Readonly,
     Writable,
@@ -146,7 +146,7 @@ mod tests {
             "extraMetas": [
                 {
                     "pubkey": "39UhVsxAmJwzPnoWhBSHsZ6nBDtdzt9D8rfDa8zGHrP6",
-                    "role": "readonly-signer"
+                    "role": "readonlySigner"
                 },
                 {
                     "pubkey": "6WEvW9B9jTKc3EhP1ewGEJPrxw5d8vD9eMYCf2snNYsV",
@@ -248,7 +248,7 @@ mod tests {
         let config = r#"
             extraMetas:
                 - pubkey: "39UhVsxAmJwzPnoWhBSHsZ6nBDtdzt9D8rfDa8zGHrP6"
-                  role: "readonly-signer"
+                  role: "readonlySigner"
                 - pubkey: "6WEvW9B9jTKc3EhP1ewGEJPrxw5d8vD9eMYCf2snNYsV"
                   role: "readonly"
                 - seeds:

--- a/token/transfer-hook/cli/src/meta.rs
+++ b/token/transfer-hook/cli/src/meta.rs
@@ -108,7 +108,7 @@ pub fn parse_transfer_hook_account_arg(arg: &str) -> Result<Vec<ExtraAccountMeta
                     serde_json::from_str::<ExtraAccountMetaConfigFile>(v)
                         .map_err(|e| format!("Unable to parse file: {e}"))
                 },
-                Some("yaml") => |v: &str| {
+                Some("yaml") | Some("yml") => |v: &str| {
                     serde_yaml::from_str::<ExtraAccountMetaConfigFile>(v)
                         .map_err(|e| format!("Unable to parse file: {e}"))
                 },

--- a/token/transfer-hook/cli/src/meta.rs
+++ b/token/transfer-hook/cli/src/meta.rs
@@ -1,11 +1,13 @@
 use {
+    serde::{Deserialize, Serialize},
     solana_sdk::pubkey::Pubkey,
-    spl_tlv_account_resolution::account::ExtraAccountMeta,
-    std::{fmt, str::FromStr},
+    spl_tlv_account_resolution::{account::ExtraAccountMeta, seeds::Seed},
+    std::{fmt, path::Path, str::FromStr},
     strum_macros::{EnumString, IntoStaticStr},
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, EnumString, IntoStaticStr)]
+#[derive(Debug, Clone, Copy, PartialEq, EnumString, IntoStaticStr, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 #[strum(serialize_all = "kebab-case")]
 enum AccountMetaRole {
     Readonly,
@@ -14,7 +16,7 @@ enum AccountMetaRole {
     WritableSigner,
 }
 impl AccountMetaRole {
-    fn bools(&self) -> (bool, bool) {
+    fn bools(&self) -> (/* is_signer */ bool, /* is_writable */ bool) {
         match self {
             AccountMetaRole::Readonly => (false, false),
             AccountMetaRole::Writable => (false, true),
@@ -29,15 +31,288 @@ impl fmt::Display for AccountMetaRole {
     }
 }
 
-pub fn parse_transfer_hook_account_arg(arg: &str) -> Result<ExtraAccountMeta, String> {
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct ExtraAccountMetaConfigFile {
+    #[serde(alias = "extraMetas")]
+    extra_metas: Vec<ExtraAccountMetaConfig>,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct ExtraAccountMetaConfig {
+    pubkey: Option<String>,
+    seeds: Option<Vec<Seed>>,
+    role: Option<AccountMetaRole>,
+    #[serde(alias = "isSigner")]
+    is_signer: Option<bool>,
+    #[serde(alias = "isWritable")]
+    is_writable: Option<bool>,
+}
+impl ExtraAccountMetaConfig {
+    fn discriminator_and_address(&self) -> (u8, [u8; 32]) {
+        if self.pubkey.is_some() && self.seeds.is_some() {
+            panic!("Only one of `pubkey` or `seeds` must be present");
+        }
+        if let Some(pubkey_string) = &self.pubkey {
+            (0, Pubkey::from_str(pubkey_string).unwrap().to_bytes())
+        } else if let Some(seeds) = &self.seeds {
+            (1, Seed::pack_into_address_config(seeds).unwrap())
+        } else {
+            panic!("Either `pubkey` or `seeds` must be present");
+        }
+    }
+
+    fn bools(&self) -> (/* is_signer */ bool, /* is_writable */ bool) {
+        if self.role.is_none() && self.is_signer.is_none() && self.is_writable.is_none() {
+            panic!("Either `role` or `is_signer`/`is_writable` must be present");
+        }
+        if let Some(role) = self.role {
+            if self.is_signer.is_some() || self.is_writable.is_some() {
+                panic!("`role` and `is_signer`/`is_writable` are mutually exclusive");
+            }
+            role.bools()
+        } else {
+            if self.is_signer.is_none() || self.is_writable.is_none() {
+                panic!("`is_signer` and `is_writable` must be present when `role` is not present");
+            }
+            (self.is_signer.unwrap(), self.is_writable.unwrap())
+        }
+    }
+}
+impl From<&ExtraAccountMetaConfig> for ExtraAccountMeta {
+    fn from(config: &ExtraAccountMetaConfig) -> Self {
+        let (discriminator, address_config) = config.discriminator_and_address();
+        let (is_signer, is_writable) = config.bools();
+        ExtraAccountMeta {
+            discriminator,
+            address_config,
+            is_signer: is_signer.into(),
+            is_writable: is_writable.into(),
+        }
+    }
+}
+
+pub fn parse_transfer_hook_account_arg(arg: &str) -> Result<Vec<ExtraAccountMeta>, String> {
     match arg.split(':').collect::<Vec<_>>().as_slice() {
         [address, role] => {
             let pubkey = Pubkey::from_str(address).map_err(|e| format!("{e}"))?;
             let role = AccountMetaRole::from_str(role).map_err(|e| format!("{e}"))?;
             let (is_signer, is_writable) = role.bools();
-            ExtraAccountMeta::new_with_pubkey(&pubkey, is_signer, is_writable)
-                .map_err(|e| format!("{e}"))
+            let meta = ExtraAccountMeta::new_with_pubkey(&pubkey, is_signer, is_writable)
+                .map_err(|e| format!("{e}"))?;
+            Ok(vec![meta])
         }
-        _ => Err("Transfer hook account must be present as <ADDRESS>:<ROLE>".to_string()),
+        _ => {
+            let path = Path::new(arg);
+            let parse_fn = match path.extension().and_then(|s| s.to_str()) {
+                Some("json") => |v: &str| {
+                    serde_json::from_str::<ExtraAccountMetaConfigFile>(v)
+                        .map_err(|e| format!("Unable to parse file: {e}"))
+                },
+                Some("yaml") => |v: &str| {
+                    serde_yaml::from_str::<ExtraAccountMetaConfigFile>(v)
+                        .map_err(|e| format!("Unable to parse file: {e}"))
+                },
+                _ => panic!("Unsupported file extension: {}", path.display()),
+            };
+            let file = std::fs::read_to_string(path)
+                .map_err(|err| format!("Unable to read file: {err}"))?;
+            let parsed_config_file = parse_fn(&file)?;
+            Ok(parsed_config_file
+                .extra_metas
+                .iter()
+                .map(ExtraAccountMeta::from)
+                .collect())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_json() {
+        let config = r#"{
+            "extraMetas": [
+                {
+                    "pubkey": "39UhVsxAmJwzPnoWhBSHsZ6nBDtdzt9D8rfDa8zGHrP6",
+                    "role": "readonly-signer"
+                },
+                {
+                    "pubkey": "6WEvW9B9jTKc3EhP1ewGEJPrxw5d8vD9eMYCf2snNYsV",
+                    "isSigner": false,
+                    "isWritable": false
+                },
+                {
+                    "seeds": [
+                        {
+                            "literal": {
+                                "bytes": [1, 2, 3, 4, 5, 6]
+                            }
+                        },
+                        {
+                            "instructionData": {
+                                "index": 0,
+                                "length": 8
+                            }
+                        },
+                        {
+                            "accountKey": {
+                                "index": 0
+                            }
+                        }
+                    ],
+                    "role": "writable"
+                },
+                {
+                    "seeds": [
+                        {
+                            "accountData": {
+                                "accountIndex": 1,
+                                "dataIndex": 4,
+                                "length": 4
+                            }
+                        },
+                        {
+                            "accountKey": {
+                                "index": 1
+                            }
+                        }
+                    ],
+                    "isSigner": false,
+                    "isWritable": false
+                }
+            ]
+        }"#;
+        let parsed_config_file =
+            serde_json::from_str::<ExtraAccountMetaConfigFile>(config).unwrap();
+        let parsed_extra_metas: Vec<ExtraAccountMeta> = parsed_config_file
+            .extra_metas
+            .iter()
+            .map(|config| config.into())
+            .collect::<Vec<_>>();
+        let expected = vec![
+            ExtraAccountMeta::new_with_pubkey(
+                &Pubkey::from_str("39UhVsxAmJwzPnoWhBSHsZ6nBDtdzt9D8rfDa8zGHrP6").unwrap(),
+                true,
+                false,
+            )
+            .unwrap(),
+            ExtraAccountMeta::new_with_pubkey(
+                &Pubkey::from_str("6WEvW9B9jTKc3EhP1ewGEJPrxw5d8vD9eMYCf2snNYsV").unwrap(),
+                false,
+                false,
+            )
+            .unwrap(),
+            ExtraAccountMeta::new_with_seeds(
+                &[
+                    Seed::Literal {
+                        bytes: vec![1, 2, 3, 4, 5, 6],
+                    },
+                    Seed::InstructionData {
+                        index: 0,
+                        length: 8,
+                    },
+                    Seed::AccountKey { index: 0 },
+                ],
+                false,
+                true,
+            )
+            .unwrap(),
+            ExtraAccountMeta::new_with_seeds(
+                &[
+                    Seed::AccountData {
+                        account_index: 1,
+                        data_index: 4,
+                        length: 4,
+                    },
+                    Seed::AccountKey { index: 1 },
+                ],
+                false,
+                false,
+            )
+            .unwrap(),
+        ];
+        assert_eq!(parsed_extra_metas, expected);
+    }
+
+    #[test]
+    fn test_parse_yaml() {
+        let config = r#"
+            extra_metas:
+                - pubkey: "39UhVsxAmJwzPnoWhBSHsZ6nBDtdzt9D8rfDa8zGHrP6"
+                  role: "readonly-signer"
+                - pubkey: "6WEvW9B9jTKc3EhP1ewGEJPrxw5d8vD9eMYCf2snNYsV"
+                  is_signer: false
+                  is_writable: false
+                - seeds:
+                    - !literal
+                      bytes: [1, 2, 3, 4, 5, 6]
+                    - !instruction_data
+                      index: 0
+                      length: 8
+                    - !account_key
+                      index: 0
+                  role: "writable"
+                - seeds:
+                    - !account_data
+                      account_index: 1
+                      data_index: 4
+                      length: 4
+                    - !account_key
+                      index: 1
+                  is_signer: false
+                  is_writable: false
+        "#;
+        let parsed_config_file =
+            serde_yaml::from_str::<ExtraAccountMetaConfigFile>(config).unwrap();
+        let parsed_extra_metas: Vec<ExtraAccountMeta> = parsed_config_file
+            .extra_metas
+            .iter()
+            .map(|config| config.into())
+            .collect::<Vec<_>>();
+        let expected = vec![
+            ExtraAccountMeta::new_with_pubkey(
+                &Pubkey::from_str("39UhVsxAmJwzPnoWhBSHsZ6nBDtdzt9D8rfDa8zGHrP6").unwrap(),
+                true,
+                false,
+            )
+            .unwrap(),
+            ExtraAccountMeta::new_with_pubkey(
+                &Pubkey::from_str("6WEvW9B9jTKc3EhP1ewGEJPrxw5d8vD9eMYCf2snNYsV").unwrap(),
+                false,
+                false,
+            )
+            .unwrap(),
+            ExtraAccountMeta::new_with_seeds(
+                &[
+                    Seed::Literal {
+                        bytes: vec![1, 2, 3, 4, 5, 6],
+                    },
+                    Seed::InstructionData {
+                        index: 0,
+                        length: 8,
+                    },
+                    Seed::AccountKey { index: 0 },
+                ],
+                false,
+                true,
+            )
+            .unwrap(),
+            ExtraAccountMeta::new_with_seeds(
+                &[
+                    Seed::AccountData {
+                        account_index: 1,
+                        data_index: 4,
+                        length: 4,
+                    },
+                    Seed::AccountKey { index: 1 },
+                ],
+                false,
+                false,
+            )
+            .unwrap(),
+        ];
+        assert_eq!(parsed_extra_metas, expected);
     }
 }

--- a/token/transfer-hook/cli/src/meta.rs
+++ b/token/transfer-hook/cli/src/meta.rs
@@ -1,16 +1,27 @@
 use {
-    solana_sdk::{instruction::AccountMeta, pubkey::Pubkey},
+    solana_sdk::pubkey::Pubkey,
+    spl_tlv_account_resolution::account::ExtraAccountMeta,
     std::{fmt, str::FromStr},
     strum_macros::{EnumString, IntoStaticStr},
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, EnumString, IntoStaticStr)]
 #[strum(serialize_all = "kebab-case")]
-pub enum AccountMetaRole {
+enum AccountMetaRole {
     Readonly,
     Writable,
     ReadonlySigner,
     WritableSigner,
+}
+impl AccountMetaRole {
+    fn bools(&self) -> (bool, bool) {
+        match self {
+            AccountMetaRole::Readonly => (false, false),
+            AccountMetaRole::Writable => (false, true),
+            AccountMetaRole::ReadonlySigner => (true, false),
+            AccountMetaRole::WritableSigner => (true, true),
+        }
+    }
 }
 impl fmt::Display for AccountMetaRole {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -18,17 +29,14 @@ impl fmt::Display for AccountMetaRole {
     }
 }
 
-pub fn parse_transfer_hook_account(arg: &str) -> Result<AccountMeta, String> {
+pub fn parse_transfer_hook_account_arg(arg: &str) -> Result<ExtraAccountMeta, String> {
     match arg.split(':').collect::<Vec<_>>().as_slice() {
         [address, role] => {
-            let address = Pubkey::from_str(address).map_err(|e| format!("{e}"))?;
-            let meta = match AccountMetaRole::from_str(role).map_err(|e| format!("{e}"))? {
-                AccountMetaRole::Readonly => AccountMeta::new_readonly(address, false),
-                AccountMetaRole::Writable => AccountMeta::new(address, false),
-                AccountMetaRole::ReadonlySigner => AccountMeta::new_readonly(address, true),
-                AccountMetaRole::WritableSigner => AccountMeta::new(address, true),
-            };
-            Ok(meta)
+            let pubkey = Pubkey::from_str(address).map_err(|e| format!("{e}"))?;
+            let role = AccountMetaRole::from_str(role).map_err(|e| format!("{e}"))?;
+            let (is_signer, is_writable) = role.bools();
+            ExtraAccountMeta::new_with_pubkey(&pubkey, is_signer, is_writable)
+                .map_err(|e| format!("{e}"))
         }
         _ => Err("Transfer hook account must be present as <ADDRESS>:<ROLE>".to_string()),
     }

--- a/token/transfer-hook/cli/src/meta.rs
+++ b/token/transfer-hook/cli/src/meta.rs
@@ -97,7 +97,10 @@ fn get_parse_function(path: &Path) -> Result<ParseFn, String> {
         Some("yaml") | Some("yml") => Ok(|v: &str| {
             serde_yaml::from_str::<ConfigFile>(v).map_err(|e| format!("Unable to parse file: {e}"))
         }),
-        _ => Err(format!("Unsupported file extension: {}", path.display())),
+        _ => Err(format!(
+            "Unsupported file extension: {}. Only JSON and YAML files are supported",
+            path.display()
+        )),
     }
 }
 

--- a/token/transfer-hook/cli/src/meta.rs
+++ b/token/transfer-hook/cli/src/meta.rs
@@ -1,0 +1,35 @@
+use {
+    solana_sdk::{instruction::AccountMeta, pubkey::Pubkey},
+    std::{fmt, str::FromStr},
+    strum_macros::{EnumString, IntoStaticStr},
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, EnumString, IntoStaticStr)]
+#[strum(serialize_all = "kebab-case")]
+pub enum AccountMetaRole {
+    Readonly,
+    Writable,
+    ReadonlySigner,
+    WritableSigner,
+}
+impl fmt::Display for AccountMetaRole {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+pub fn parse_transfer_hook_account(arg: &str) -> Result<AccountMeta, String> {
+    match arg.split(':').collect::<Vec<_>>().as_slice() {
+        [address, role] => {
+            let address = Pubkey::from_str(address).map_err(|e| format!("{e}"))?;
+            let meta = match AccountMetaRole::from_str(role).map_err(|e| format!("{e}"))? {
+                AccountMetaRole::Readonly => AccountMeta::new_readonly(address, false),
+                AccountMetaRole::Writable => AccountMeta::new(address, false),
+                AccountMetaRole::ReadonlySigner => AccountMeta::new_readonly(address, true),
+                AccountMetaRole::WritableSigner => AccountMeta::new(address, true),
+            };
+            Ok(meta)
+        }
+        _ => Err("Transfer hook account must be present as <ADDRESS>:<ROLE>".to_string()),
+    }
+}

--- a/token/transfer-hook/cli/src/meta.rs
+++ b/token/transfer-hook/cli/src/meta.rs
@@ -9,9 +9,7 @@ use {
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct Access {
-    #[serde(alias = "is_signer")]
     is_signer: bool,
-    #[serde(alias = "is_writable")]
     is_writable: bool,
 }
 
@@ -51,7 +49,6 @@ struct Config {
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ConfigFile {
-    #[serde(alias = "extra_metas")]
     extra_metas: Vec<Config>,
 }
 
@@ -259,30 +256,30 @@ mod tests {
     #[test]
     fn test_parse_yaml() {
         let config = r#"
-            extra_metas:
+            extraMetas:
                 - pubkey: "39UhVsxAmJwzPnoWhBSHsZ6nBDtdzt9D8rfDa8zGHrP6"
                   role: "readonly-signer"
                 - pubkey: "6WEvW9B9jTKc3EhP1ewGEJPrxw5d8vD9eMYCf2snNYsV"
-                  is_signer: false
-                  is_writable: false
+                  isSigner: false
+                  isWritable: false
                 - seeds:
                     - literal:
                         bytes: [1, 2, 3, 4, 5, 6]
-                    - instruction_data:
+                    - instructionData:
                         index: 0
                         length: 8
-                    - account_key:
+                    - accountKey:
                         index: 0
                   role: "writable"
                 - seeds:
-                    - account_data:
-                        account_index: 1
-                        data_index: 4
+                    - accountData:
+                        accountIndex: 1
+                        dataIndex: 4
                         length: 4
-                    - account_key:
+                    - accountKey:
                         index: 1
-                  is_signer: false
-                  is_writable: false
+                  isSigner: false
+                  isWritable: false
         "#;
         let parsed_config_file = serde_yaml::from_str::<ConfigFile>(config).unwrap();
         let parsed_extra_metas: Vec<ExtraAccountMeta> = parsed_config_file


### PR DESCRIPTION
This PR adds support to the Transfer Hook CLI to add extra account meta configurations that involve seed configs!

This feature supports JSON or YAML file types, with a flexible layout to represent the extra metas.

Closes #5661.