### PR TITLE
governance: Ignore test for changes in monorepo

### DIFF
--- a/governance/program/tests/process_execute_transaction.rs
+++ b/governance/program/tests/process_execute_transaction.rs
@@ -224,7 +224,11 @@ async fn test_execute_transfer_transaction() {
     assert_eq!(15, instruction_token_account.amount);
 }
 
+// Ignored until program-test manages fork graphs correctly, see
+// https://github.com/solana-labs/solana/pull/34407 for the failing downstream
+// test
 #[tokio::test]
+#[ignore]
 async fn test_execute_upgrade_program_transaction() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;


### PR DESCRIPTION
#### Problem

According to https://github.com/solana-labs/solana/pull/34407, a governance test currently fails because of how solana-program-test manages forks.

#### Solution

To unblock that PR, ignore the test for now. Once solana-program-test does things correctly, we can re-enable it.