### PR TITLE
token js: bump to 0.3.10

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:
@@ -408,7 +412,7 @@ importers:
         version: 4.0.1
       '@solana/spl-token':
         specifier: 0.3.9
-        version: link:../../token/js
+        version: 0.3.9(@solana/web3.js@1.87.6)
       '@solana/web3.js':
         specifier: ^1.87.6
         version: 1.87.6
@@ -521,7 +525,7 @@ importers:
         version: 11.1.5(rollup@4.9.0)(tslib@2.6.2)(typescript@5.3.3)
       '@solana/spl-token':
         specifier: 0.3.9
-        version: link:../../token/js
+        version: 0.3.9(@solana/web3.js@1.87.6)
       '@solana/web3.js':
         specifier: ^1.87.6
         version: 1.87.6
@@ -661,7 +665,7 @@ importers:
     devDependencies:
       '@solana/spl-token':
         specifier: 0.3.9
-        version: link:../../token/js
+        version: 0.3.9(@solana/web3.js@1.87.6)
       '@solana/web3.js':
         specifier: ^1.87.6
         version: 1.87.6
@@ -2261,7 +2265,6 @@ packages:
       - bufferutil
       - encoding
       - utf-8-validate
-    dev: false
 
   /@solana/buffer-layout@4.0.1:
     resolution: {integrity: sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==}
@@ -2362,6 +2365,21 @@ packages:
       node-fetch: 2.7.0
       ws: 8.14.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     dev: false
+
+  /@solana/spl-token@0.3.9(@solana/web3.js@1.87.6):
+    resolution: {integrity: sha512-1EXHxKICMnab35MvvY/5DBc/K/uQAOJCYnDZXw83McCAYUAfi+rwq6qfd6MmITmSTEhcfBcl/zYxmW/OSN0RmA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.47.4
+    dependencies:
+      '@solana/buffer-layout': 4.0.1
+      '@solana/buffer-layout-utils': 0.2.0
+      '@solana/web3.js': 1.87.6
+      buffer: 6.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
 
   /@solana/transactions@2.0.0-experimental.21e994f:
     resolution: {integrity: sha512-DunbTMBzlC7jmTzkFsRm5DhGe+MjaZ8m+SJ7V520mQq+kxrbPrRmI3ikfUVdejg0WaEV4Dy+RwQ5xllsrJ47kA==}
@@ -3302,7 +3320,6 @@ packages:
 
   /bignumber.js@9.1.2:
     resolution: {integrity: sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==}
-    dev: false
 
   /binary-extensions@2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
@@ -8011,7 +8028,3 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -411,8 +411,8 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1
       '@solana/spl-token':
-        specifier: 0.3.9
-        version: 0.3.9(@solana/web3.js@1.87.6)
+        specifier: 0.3.10
+        version: link:../../token/js
       '@solana/web3.js':
         specifier: ^1.87.6
         version: 1.87.6
@@ -524,8 +524,8 @@ importers:
         specifier: ^11.1.1
         version: 11.1.5(rollup@4.9.0)(tslib@2.6.2)(typescript@5.3.3)
       '@solana/spl-token':
-        specifier: 0.3.9
-        version: 0.3.9(@solana/web3.js@1.87.6)
+        specifier: 0.3.10
+        version: link:../../token/js
       '@solana/web3.js':
         specifier: ^1.87.6
         version: 1.87.6
@@ -664,8 +664,8 @@ importers:
         version: 0.2.0
     devDependencies:
       '@solana/spl-token':
-        specifier: 0.3.9
-        version: 0.3.9(@solana/web3.js@1.87.6)
+        specifier: 0.3.10
+        version: link:../../token/js
       '@solana/web3.js':
         specifier: ^1.87.6
         version: 1.87.6
@@ -2265,6 +2265,7 @@ packages:
       - bufferutil
       - encoding
       - utf-8-validate
+    dev: false
 
   /@solana/buffer-layout@4.0.1:
     resolution: {integrity: sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==}
@@ -2365,21 +2366,6 @@ packages:
       node-fetch: 2.7.0
       ws: 8.14.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     dev: false
-
-  /@solana/spl-token@0.3.9(@solana/web3.js@1.87.6):
-    resolution: {integrity: sha512-1EXHxKICMnab35MvvY/5DBc/K/uQAOJCYnDZXw83McCAYUAfi+rwq6qfd6MmITmSTEhcfBcl/zYxmW/OSN0RmA==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      '@solana/web3.js': ^1.47.4
-    dependencies:
-      '@solana/buffer-layout': 4.0.1
-      '@solana/buffer-layout-utils': 0.2.0
-      '@solana/web3.js': 1.87.6
-      buffer: 6.0.3
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - utf-8-validate
 
   /@solana/transactions@2.0.0-experimental.21e994f:
     resolution: {integrity: sha512-DunbTMBzlC7jmTzkFsRm5DhGe+MjaZ8m+SJ7V520mQq+kxrbPrRmI3ikfUVdejg0WaEV4Dy+RwQ5xllsrJ47kA==}
@@ -3320,6 +3306,7 @@ packages:
 
   /bignumber.js@9.1.2:
     resolution: {integrity: sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==}
+    dev: false
 
   /binary-extensions@2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}

--- a/stake-pool/js/package.json
+++ b/stake-pool/js/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@coral-xyz/borsh": "^0.29.0",
     "@solana/buffer-layout": "^4.0.1",
-    "@solana/spl-token": "0.3.9",
+    "@solana/spl-token": "0.3.10",
     "@solana/web3.js": "^1.87.6",
     "bn.js": "^5.2.0",
     "buffer": "^6.0.3",

--- a/token-lending/js/package.json
+++ b/token-lending/js/package.json
@@ -37,14 +37,14 @@
         "bignumber.js": "^9.0.1"
     },
     "peerDependencies": {
-        "@solana/spl-token": "0.3.9",
+        "@solana/spl-token": "0.3.10",
         "@solana/web3.js": "^1.20.0"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.0",
         "@rollup/plugin-node-resolve": "^15.0.2",
         "@rollup/plugin-typescript": "^11.1.1",
-        "@solana/spl-token": "0.3.9",
+        "@solana/spl-token": "0.3.10",
         "@solana/web3.js": "^1.87.6",
         "@types/eslint": "^8.44.9",
         "@types/eslint-plugin-prettier": "^3.1.0",

--- a/token-swap/js/package.json
+++ b/token-swap/js/package.json
@@ -52,7 +52,7 @@
     "@solana/web3.js": "^1.87.6"
   },
   "devDependencies": {
-    "@solana/spl-token": "0.3.9",
+    "@solana/spl-token": "0.3.10",
     "@solana/web3.js": "^1.87.6",
     "@types/bn.js": "^5.1.0",
     "@types/chai-as-promised": "^7.1.4",

--- a/token/js/package.json
+++ b/token/js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@solana/spl-token",
     "description": "SPL Token Program JS API",
-    "version": "0.3.9",
+    "version": "0.3.10",
     "author": "Solana Labs Maintainers <maintainers@solanalabs.com>",
     "repository": "https://github.com/solana-labs/solana-program-library",
     "license": "Apache-2.0",


### PR DESCRIPTION
After #5667 we need to bump Token JS so we can cut a new release and folks can start using the Token Metadata tooling!