### PR TITLE
Remove sollet reference from token docs

### DIFF
--- a/docs/src/token.mdx
+++ b/docs/src/token.mdx
@@ -1815,9 +1815,7 @@ then:
    creation the transfer will require more SOL than normal.
    However a wallet that chooses to not support creating the recipient's
    associated token account at this time should present a message to the user with enough
-   information to permit them to find a workaround (such as transferring the
-   token through a fully compliant intermediary wallet such as https://sollet.io)
-   to allow the users to accomplish their goal
+   information to find a workaround to accomplish their goal
 1. Use `TokenInstruction::Transfer` to complete the transfer
 
 The sender's wallet must not require that the recipient's main wallet address


### PR DESCRIPTION
Token docs reference obsolete wallet `sollet`. Remove the parenthetical entirely. Also tighten language, removing meaningless clauses.

Fixes #6031 