### PR TITLE
[spl-record] Remove borsh dependency from spl-record program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7111,7 +7111,6 @@ dependencies = [
 name = "spl-record"
 version = "0.1.0"
 dependencies = [
- "borsh 0.10.3",
  "bytemuck",
  "num-derive 0.4.1",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7112,11 +7112,13 @@ name = "spl-record"
 version = "0.1.0"
 dependencies = [
  "borsh 0.10.3",
+ "bytemuck",
  "num-derive 0.4.1",
  "num-traits",
  "solana-program",
  "solana-program-test",
  "solana-sdk",
+ "spl-pod 0.1.0",
  "thiserror",
 ]
 

--- a/record/program/Cargo.toml
+++ b/record/program/Cargo.toml
@@ -13,10 +13,12 @@ test-sbf = []
 
 [dependencies]
 borsh = "0.10"
+bytemuck = { version = "1.14.0", features = ["derive"] }
 num-derive = "0.4"
 num-traits = "0.2"
 solana-program = "1.17.6"
 thiserror = "1.0"
+spl-pod = { version = "0.1", path = "../../libraries/pod" }
 
 [dev-dependencies]
 solana-program-test = "1.17.6"

--- a/record/program/Cargo.toml
+++ b/record/program/Cargo.toml
@@ -12,7 +12,6 @@ no-entrypoint = []
 test-sbf = []
 
 [dependencies]
-borsh = "0.10"
 bytemuck = { version = "1.14.0", features = ["derive"] }
 num-derive = "0.4"
 num-traits = "0.2"

--- a/record/program/src/instruction.rs
+++ b/record/program/src/instruction.rs
@@ -2,7 +2,6 @@
 
 use {
     crate::id,
-    borsh::{BorshDeserialize, BorshSerialize},
     solana_program::{
         instruction::{AccountMeta, Instruction},
         program_error::ProgramError,
@@ -12,7 +11,7 @@ use {
 };
 
 /// Instructions supported by the program
-#[derive(Clone, Debug, BorshSerialize, BorshDeserialize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum RecordInstruction {
     /// Create a new record
     ///

--- a/record/program/src/processor.rs
+++ b/record/program/src/processor.rs
@@ -6,7 +6,6 @@ use {
         instruction::RecordInstruction,
         state::{Data, RecordData},
     },
-    borsh::BorshDeserialize,
     solana_program::{
         account_info::{next_account_info, AccountInfo},
         entrypoint::ProgramResult,
@@ -15,6 +14,7 @@ use {
         program_pack::IsInitialized,
         pubkey::Pubkey,
     },
+    spl_pod::bytemuck::{pod_from_bytes, pod_from_bytes_mut},
 };
 
 fn check_authority(authority_info: &AccountInfo, expected_authority: &Pubkey) -> ProgramResult {
@@ -35,7 +35,7 @@ pub fn process_instruction(
     accounts: &[AccountInfo],
     input: &[u8],
 ) -> ProgramResult {
-    let instruction = RecordInstruction::try_from_slice(input)?;
+    let instruction = RecordInstruction::unpack(input)?;
     let account_info_iter = &mut accounts.iter();
 
     match instruction {
@@ -45,7 +45,8 @@ pub fn process_instruction(
             let data_info = next_account_info(account_info_iter)?;
             let authority_info = next_account_info(account_info_iter)?;
 
-            let mut account_data = RecordData::try_from_slice(*data_info.data.borrow())?;
+            let raw_data = &mut data_info.data.borrow_mut();
+            let account_data = pod_from_bytes_mut::<RecordData>(raw_data)?;
             if account_data.is_initialized() {
                 msg!("Record account already initialized");
                 return Err(ProgramError::AccountAlreadyInitialized);
@@ -53,20 +54,22 @@ pub fn process_instruction(
 
             account_data.authority = *authority_info.key;
             account_data.version = RecordData::CURRENT_VERSION;
-            borsh::to_writer(&mut data_info.data.borrow_mut()[..], &account_data)
-                .map_err(|e| e.into())
+            Ok(())
         }
 
         RecordInstruction::Write { offset, data } => {
             msg!("RecordInstruction::Write");
             let data_info = next_account_info(account_info_iter)?;
             let authority_info = next_account_info(account_info_iter)?;
-            let account_data = RecordData::try_from_slice(&data_info.data.borrow())?;
-            if !account_data.is_initialized() {
-                msg!("Record account not initialized");
-                return Err(ProgramError::UninitializedAccount);
+            {
+                let raw_data = &data_info.data.borrow();
+                let account_data = pod_from_bytes::<RecordData>(raw_data)?;
+                if !account_data.is_initialized() {
+                    msg!("Record account not initialized");
+                    return Err(ProgramError::UninitializedAccount);
+                }
+                check_authority(authority_info, &account_data.authority)?;
             }
-            check_authority(authority_info, &account_data.authority)?;
             let start = RecordData::WRITABLE_START_INDEX.saturating_add(offset as usize);
             let end = start.saturating_add(data.len());
             if end > data_info.data.borrow().len() {
@@ -82,15 +85,15 @@ pub fn process_instruction(
             let data_info = next_account_info(account_info_iter)?;
             let authority_info = next_account_info(account_info_iter)?;
             let new_authority_info = next_account_info(account_info_iter)?;
-            let mut account_data = RecordData::try_from_slice(&data_info.data.borrow())?;
+            let raw_data = &mut data_info.data.borrow_mut();
+            let account_data = pod_from_bytes_mut::<RecordData>(raw_data)?;
             if !account_data.is_initialized() {
                 msg!("Record account not initialized");
                 return Err(ProgramError::UninitializedAccount);
             }
             check_authority(authority_info, &account_data.authority)?;
             account_data.authority = *new_authority_info.key;
-            borsh::to_writer(&mut data_info.data.borrow_mut()[..], &account_data)
-                .map_err(|e| e.into())
+            Ok(())
         }
 
         RecordInstruction::CloseAccount => {
@@ -98,7 +101,8 @@ pub fn process_instruction(
             let data_info = next_account_info(account_info_iter)?;
             let authority_info = next_account_info(account_info_iter)?;
             let destination_info = next_account_info(account_info_iter)?;
-            let mut account_data = RecordData::try_from_slice(&data_info.data.borrow())?;
+            let raw_data = &mut data_info.data.borrow_mut();
+            let account_data = pod_from_bytes_mut::<RecordData>(raw_data)?;
             if !account_data.is_initialized() {
                 msg!("Record not initialized");
                 return Err(ProgramError::UninitializedAccount);
@@ -111,8 +115,7 @@ pub fn process_instruction(
                 .checked_add(data_lamports)
                 .ok_or(RecordError::Overflow)?;
             account_data.data = Data::default();
-            borsh::to_writer(&mut data_info.data.borrow_mut()[..], &account_data)
-                .map_err(|e| e.into())
+            Ok(())
         }
     }
 }

--- a/record/program/src/processor.rs
+++ b/record/program/src/processor.rs
@@ -75,7 +75,7 @@ pub fn process_instruction(
             if end > data_info.data.borrow().len() {
                 Err(ProgramError::AccountDataTooSmall)
             } else {
-                data_info.data.borrow_mut()[start..end].copy_from_slice(&data);
+                data_info.data.borrow_mut()[start..end].copy_from_slice(data);
                 Ok(())
             }
         }

--- a/record/program/src/state.rs
+++ b/record/program/src/state.rs
@@ -1,15 +1,12 @@
 //! Program state
 use {
-    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
     bytemuck::{Pod, Zeroable},
     solana_program::{program_pack::IsInitialized, pubkey::Pubkey},
 };
 
 /// Struct wrapping data and providing metadata
 #[repr(C)]
-#[derive(
-    Clone, Copy, Debug, BorshSerialize, BorshDeserialize, BorshSchema, PartialEq, Pod, Zeroable,
-)]
+#[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
 pub struct RecordData {
     /// Struct version, allows for upgrades to the program
     pub version: u8,
@@ -26,18 +23,7 @@ const DATA_SIZE: usize = 8;
 
 /// Struct just for data
 #[repr(C)]
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    Default,
-    BorshSerialize,
-    BorshDeserialize,
-    BorshSchema,
-    PartialEq,
-    Pod,
-    Zeroable,
-)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct Data {
     /// The data contained by the account, could be anything or serializable
     pub bytes: [u8; DATA_SIZE],

--- a/record/program/tests/functional.rs
+++ b/record/program/tests/functional.rs
@@ -45,7 +45,7 @@ async fn initialize_storage_account(
                 &account.pubkey(),
                 &authority.pubkey(),
                 0,
-                pod_bytes_of(&data).to_vec(),
+                pod_bytes_of(&data),
             ),
         ],
         Some(&context.payer.pubkey()),
@@ -104,12 +104,7 @@ async fn initialize_with_seed_success() {
                 &id(),
             ),
             instruction::initialize(&account, &authority.pubkey()),
-            instruction::write(
-                &account,
-                &authority.pubkey(),
-                0,
-                pod_bytes_of(&data).to_vec(),
-            ),
+            instruction::write(&account, &authority.pubkey(), 0, pod_bytes_of(&data)),
         ],
         Some(&context.payer.pubkey()),
         &[&context.payer, &authority],
@@ -181,7 +176,7 @@ async fn write_success() {
             &account.pubkey(),
             &authority.pubkey(),
             0,
-            pod_bytes_of(&new_data).to_vec(),
+            pod_bytes_of(&new_data),
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, &authority],
@@ -225,7 +220,7 @@ async fn write_fail_wrong_authority() {
             &account.pubkey(),
             &wrong_authority.pubkey(),
             0,
-            pod_bytes_of(&new_data).to_vec(),
+            pod_bytes_of(&new_data),
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, &wrong_authority],
@@ -258,8 +253,7 @@ async fn write_fail_unsigned() {
 
     let data = pod_bytes_of(&Data {
         bytes: [200u8; Data::DATA_SIZE],
-    })
-    .to_vec();
+    });
 
     let transaction = Transaction::new_signed_with_payer(
         &[Instruction {
@@ -446,7 +440,7 @@ async fn set_authority_success() {
             &account.pubkey(),
             &new_authority.pubkey(),
             0,
-            pod_bytes_of(&new_data).to_vec(),
+            pod_bytes_of(&new_data),
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer, &new_authority],


### PR DESCRIPTION
#### Problem
Currently, the zero-knowledge proofs that are required for the token-2022 program barely fits in a single transaction. The spl-record program provides a convenient way to break up the proofs into byte chunks to be submitted on chain. However, the record program depends on borsh serialization, which creates issues when combined with the zk-token-proof program.

#### Summary of changes
Remove the borsh dependency from the record program and use bytemuck for the serialization of data.