### PR TITLE
single-pool: Add security.txt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7145,6 +7145,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
+ "solana-security-txt",
  "solana-vote-program",
  "spl-associated-token-account 2.3.0",
  "spl-token 4.0.0",

--- a/single-pool/program/Cargo.toml
+++ b/single-pool/program/Cargo.toml
@@ -18,6 +18,7 @@ num-derive = "0.4"
 num-traits = "0.2"
 num_enum = "0.7.1"
 solana-program = "1.17.6"
+solana-security-txt = "1.1.1"
 spl-token = { version = "4.0", path = "../../token/program", features = [ "no-entrypoint" ] }
 spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = [ "no-entrypoint" ] }
 thiserror = "1.0"

--- a/single-pool/program/src/entrypoint.rs
+++ b/single-pool/program/src/entrypoint.rs
@@ -8,6 +8,7 @@ use {
         account_info::AccountInfo, entrypoint::ProgramResult, program_error::PrintProgramError,
         pubkey::Pubkey,
     },
+    solana_security_txt::security_txt,
 };
 
 solana_program::entrypoint!(process_instruction);
@@ -23,4 +24,19 @@ fn process_instruction(
     } else {
         Ok(())
     }
+}
+
+security_txt! {
+    // Required fields
+    name: "SPL Single-Validator Stake Pool",
+    project_url: "https://spl.solana.com/single-pool",
+    contacts: "link:https://github.com/solana-labs/solana-program-library/security/advisories/new,mailto:security@solana.com,discord:https://discord.gg/solana",
+    policy: "https://github.com/solana-labs/solana-program-library/blob/master/SECURITY.md",
+
+    // Optional Fields
+    preferred_languages: "en",
+    source_code: "https://github.com/solana-labs/solana-program-library/tree/master/single-pool/program",
+    source_revision: "",
+    source_release: "",
+    auditors: "https://github.com/solana-labs/security-audits#single-stake-pool"
 }

--- a/single-pool/program/src/entrypoint.rs
+++ b/single-pool/program/src/entrypoint.rs
@@ -36,7 +36,7 @@ security_txt! {
     // Optional Fields
     preferred_languages: "en",
     source_code: "https://github.com/solana-labs/solana-program-library/tree/master/single-pool/program",
-    source_revision: "",
-    source_release: "",
+    source_revision: "ef44df985e76a697ee9a8aabb3a223610e4cf1dc",
+    source_release: "single-pool-v1.0.0",
     auditors: "https://github.com/solana-labs/security-audits#single-stake-pool"
 }


### PR DESCRIPTION
#### Problem

The other new SPL programs that we deploy to the chain have a security.txt, ie #5929 and #5928, but the single pool program doesn't.

#### Solution

Add it in! Since the final audit just completed, you can fill in the information for the hash and release name.