### PR TITLE
token-cli: Allow burn command to accept ALL keyword for amount

### DIFF
--- a/token/cli/src/clap_app.rs
+++ b/token/cli/src/clap_app.rs
@@ -1371,12 +1371,12 @@ pub fn app<'a, 'b>(
                 )
                 .arg(
                     Arg::with_name("amount")
-                        .validator(is_amount)
+                        .validator(is_amount_or_all)
                         .value_name("TOKEN_AMOUNT")
                         .takes_value(true)
                         .index(2)
                         .required(true)
-                        .help("Amount to burn, in tokens"),
+                        .help("Amount to burn, in tokens; accepts keyword ALL"),
                 )
                 .arg(owner_keypair_arg_with_value_name("TOKEN_OWNER_KEYPAIR")
                         .help(

--- a/token/cli/src/command.rs
+++ b/token/cli/src/command.rs
@@ -1679,10 +1679,16 @@ async fn command_burn(
 
     let token = token_client_from_config(config, &mint_info.address, decimals)?;
 
-    let balance = token.get_account_info(&account).await?.base.amount;
-    let amount = ui_amount
-        .map(|ui_amount| spl_token::ui_amount_to_amount(ui_amount, mint_info.decimals))
-        .unwrap_or(balance);
+    let amount = if let Some(ui_amount) = ui_amount {
+        spl_token::ui_amount_to_amount(ui_amount, mint_info.decimals)
+    } else {
+        if config.sign_only {
+            return Err("Use of ALL keyword to burn tokens requires online signing"
+                .to_string()
+                .into());
+        }
+        token.get_account_info(&account).await?.base.amount
+    };
 
     println_display(
         config,

--- a/token/cli/src/command.rs
+++ b/token/cli/src/command.rs
@@ -107,6 +107,14 @@ fn get_signer(
         (Arc::from(signer), signer_pubkey)
     })
 }
+
+fn parse_amount_or_all(matches: &ArgMatches<'_>) -> Option<f64> {
+    match matches.value_of("amount").unwrap() {
+        "ALL" => None,
+        amount => Some(amount.parse::<f64>().unwrap()),
+    }
+}
+
 async fn check_wallet_balance(
     config: &Config<'_>,
     wallet: &Pubkey,
@@ -3701,10 +3709,7 @@ pub async fn process_command<'a>(
             let token = pubkey_of_signer(arg_matches, "token", &mut wallet_manager)
                 .unwrap()
                 .unwrap();
-            let amount = match arg_matches.value_of("amount").unwrap() {
-                "ALL" => None,
-                amount => Some(amount.parse::<f64>().unwrap()),
-            };
+            let amount = parse_amount_or_all(arg_matches);
             let recipient = pubkey_of_signer(arg_matches, "recipient", &mut wallet_manager)
                 .unwrap()
                 .unwrap();
@@ -4424,10 +4429,7 @@ pub async fn process_command<'a>(
             let token = pubkey_of_signer(arg_matches, "token", &mut wallet_manager)
                 .unwrap()
                 .unwrap();
-            let amount = match arg_matches.value_of("amount").unwrap() {
-                "ALL" => None,
-                amount => Some(amount.parse::<f64>().unwrap()),
-            };
+            let amount = parse_amount_or_all(arg_matches);
             let account = pubkey_of_signer(arg_matches, "address", &mut wallet_manager).unwrap();
 
             let (owner_signer, owner) =


### PR DESCRIPTION
Several of the token commands, such as `transfer`, support using the `ALL` keyword for the `amount` argument in order to automatically choose all of the tokens in the account.

This PR adds support for the `ALL` keyword to the `burn` command as well.

~~TODO: haven't tested this, should probably do so before this PR is considered for submission~~
UPDATE: I have since tested this, and confirmed that running with the keyword `ALL` worked as expected and selected all available tokens in an account. Please let me know if any other level of testing is desired; it doesn't look like the CLI has unit testing but I'll also admit that I haven't spent much time looking in / contributing in this repo