### PR TITLE
stake-pool: make `update_validator_list_balance()` more ergonomic

### DIFF
--- a/stake-pool/program/src/instruction.rs
+++ b/stake-pool/program/src/instruction.rs
@@ -2,15 +2,13 @@
 
 #![allow(clippy::too_many_arguments)]
 
-use crate::state::ValidatorStakeInfo;
-
 use {
     crate::{
         find_deposit_authority_program_address, find_ephemeral_stake_program_address,
         find_stake_program_address, find_transient_stake_program_address,
         find_withdraw_authority_program_address,
         inline_mpl_token_metadata::{self, pda::find_metadata_account},
-        state::{Fee, FeeType, StakePool, ValidatorList},
+        state::{Fee, FeeType, StakePool, ValidatorList, ValidatorStakeInfo},
         MAX_VALIDATORS_TO_UPDATE,
     },
     borsh::{BorshDeserialize, BorshSchema, BorshSerialize},

--- a/stake-pool/program/src/instruction.rs
+++ b/stake-pool/program/src/instruction.rs
@@ -1398,7 +1398,7 @@ pub fn update_validator_list_balance(
     }
     let validator_list_subslice = match validator_list
         .validators
-        .get(start_index..start_index + len)
+        .get(start_index..start_index.saturating_add(len))
     {
         Some(s) => s,
         None => {
@@ -1517,7 +1517,7 @@ pub fn update_stake_pool(
             &stake_pool.reserve_stake,
             validator_list,
             chunk.len(),
-            i * MAX_VALIDATORS_TO_UPDATE,
+            i.saturating_mul(MAX_VALIDATORS_TO_UPDATE),
             no_merge,
         ));
     }

--- a/stake-pool/program/src/instruction.rs
+++ b/stake-pool/program/src/instruction.rs
@@ -2,8 +2,6 @@
 
 #![allow(clippy::too_many_arguments)]
 
-use solana_program::program_error::ProgramError;
-
 use {
     crate::{
         find_deposit_authority_program_address, find_ephemeral_stake_program_address,
@@ -16,6 +14,7 @@ use {
     borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
     solana_program::{
         instruction::{AccountMeta, Instruction},
+        program_error::ProgramError,
         pubkey::Pubkey,
         stake, system_program, sysvar,
     },
@@ -1575,7 +1574,8 @@ pub fn update_stake_pool(
                 chunk.len(),
                 i.saturating_mul(MAX_VALIDATORS_TO_UPDATE),
                 no_merge,
-            ).unwrap()
+            )
+            .unwrap()
         })
         .collect();
 

--- a/stake-pool/program/src/instruction.rs
+++ b/stake-pool/program/src/instruction.rs
@@ -1389,13 +1389,6 @@ pub fn update_validator_list_balance(
     }
     .try_to_vec()
     .unwrap();
-    if start_index >= validator_list.validators.len() {
-        return Instruction {
-            program_id: *program_id,
-            accounts,
-            data,
-        };
-    }
     let validator_list_subslice = match validator_list
         .validators
         .get(start_index..start_index.saturating_add(len))

--- a/stake-pool/program/tests/decrease.rs
+++ b/stake-pool/program/tests/decrease.rs
@@ -624,7 +624,6 @@ async fn fail_additional_with_increasing() {
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
-            &[validator_stake.vote.pubkey()],
             false,
         )
         .await;

--- a/stake-pool/program/tests/deposit.rs
+++ b/stake-pool/program/tests/deposit.rs
@@ -94,7 +94,6 @@ async fn setup(
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            &[validator_stake_account.vote.pubkey()],
             false,
         )
         .await;

--- a/stake-pool/program/tests/deposit_edge_cases.rs
+++ b/stake-pool/program/tests/deposit_edge_cases.rs
@@ -87,7 +87,6 @@ async fn setup(
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            &[validator_stake_account.vote.pubkey()],
             false,
         )
         .await;

--- a/stake-pool/program/tests/force_destake.rs
+++ b/stake-pool/program/tests/force_destake.rs
@@ -155,7 +155,6 @@ async fn success_update() {
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            &[voter_pubkey],
             false,
         )
         .await;
@@ -272,7 +271,6 @@ async fn success_remove_validator() {
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            &[voter_pubkey],
             false,
         )
         .await;
@@ -311,7 +309,6 @@ async fn success_remove_validator() {
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            &[voter_pubkey],
             false,
         )
         .await;

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -1,7 +1,5 @@
 #![allow(dead_code)]
 
-use spl_stake_pool::MAX_VALIDATORS_TO_UPDATE;
-
 use {
     borsh::{BorshDeserialize, BorshSerialize},
     solana_program::{
@@ -34,7 +32,7 @@ use {
         instruction, minimum_delegation,
         processor::Processor,
         state::{self, FeeType, FutureEpoch, StakePool, ValidatorList},
-        MINIMUM_RESERVE_LAMPORTS,
+        MAX_VALIDATORS_TO_UPDATE, MINIMUM_RESERVE_LAMPORTS,
     },
     spl_token_2022::{
         extension::{ExtensionType, StateWithExtensionsOwned},

--- a/stake-pool/program/tests/huge_pool.rs
+++ b/stake-pool/program/tests/huge_pool.rs
@@ -172,7 +172,7 @@ async fn setup(
 #[test_case(MAX_POOL_SIZE; "no-compute-budget")]
 #[tokio::test]
 async fn update(max_validators: u32) {
-    let (mut context, stake_pool_accounts, vote_account_pubkeys, _, _, _, _) =
+    let (mut context, stake_pool_accounts, _, _, _, _, _) =
         setup(max_validators, max_validators, STAKE_AMOUNT).await;
 
     let error = stake_pool_accounts
@@ -180,7 +180,7 @@ async fn update(max_validators: u32) {
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            &vote_account_pubkeys[0..MAX_VALIDATORS_TO_UPDATE],
+            MAX_VALIDATORS_TO_UPDATE,
             false, /* no_merge */
         )
         .await;
@@ -335,7 +335,7 @@ async fn remove_validator_from_pool(max_validators: u32) {
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            &[first_vote],
+            1,
             false, /* no_merge */
         )
         .await;
@@ -348,8 +348,8 @@ async fn remove_validator_from_pool(max_validators: u32) {
         &stake_pool_accounts.validator_list.pubkey(),
         &stake_pool_accounts.reserve_stake.pubkey(),
         &validator_list,
-        &[middle_vote],
-        middle_index as u32,
+        1,
+        middle_index,
         /* no_merge = */ false,
     )];
     stake_pool_accounts.maybe_add_compute_budget_instruction(&mut instructions);
@@ -373,8 +373,8 @@ async fn remove_validator_from_pool(max_validators: u32) {
         &stake_pool_accounts.validator_list.pubkey(),
         &stake_pool_accounts.reserve_stake.pubkey(),
         &validator_list,
-        &[last_vote],
-        last_index as u32,
+        1,
+        last_index,
         /* no_merge = */ false,
     )];
     stake_pool_accounts.maybe_add_compute_budget_instruction(&mut instructions);

--- a/stake-pool/program/tests/huge_pool.rs
+++ b/stake-pool/program/tests/huge_pool.rs
@@ -341,7 +341,7 @@ async fn remove_validator_from_pool(max_validators: u32) {
         .await;
     assert!(error.is_none(), "{:?}", error);
 
-    let mut instructions = vec![instruction::update_validator_list_balance(
+    let mut instructions = vec![instruction::update_validator_list_balance_chunk(
         &id(),
         &stake_pool_accounts.stake_pool.pubkey(),
         &stake_pool_accounts.withdraw_authority,
@@ -351,7 +351,8 @@ async fn remove_validator_from_pool(max_validators: u32) {
         1,
         middle_index,
         /* no_merge = */ false,
-    )];
+    )
+    .unwrap()];
     stake_pool_accounts.maybe_add_compute_budget_instruction(&mut instructions);
     let transaction = Transaction::new_signed_with_payer(
         &instructions,
@@ -366,7 +367,7 @@ async fn remove_validator_from_pool(max_validators: u32) {
         .err();
     assert!(error.is_none(), "{:?}", error);
 
-    let mut instructions = vec![instruction::update_validator_list_balance(
+    let mut instructions = vec![instruction::update_validator_list_balance_chunk(
         &id(),
         &stake_pool_accounts.stake_pool.pubkey(),
         &stake_pool_accounts.withdraw_authority,
@@ -376,7 +377,8 @@ async fn remove_validator_from_pool(max_validators: u32) {
         1,
         last_index,
         /* no_merge = */ false,
-    )];
+    )
+    .unwrap()];
     stake_pool_accounts.maybe_add_compute_budget_instruction(&mut instructions);
     let transaction = Transaction::new_signed_with_payer(
         &instructions,

--- a/stake-pool/program/tests/increase.rs
+++ b/stake-pool/program/tests/increase.rs
@@ -548,7 +548,6 @@ async fn fail_additional_with_decreasing() {
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
-            &[validator_stake.vote.pubkey()],
             false,
         )
         .await;

--- a/stake-pool/program/tests/redelegate.rs
+++ b/stake-pool/program/tests/redelegate.rs
@@ -92,10 +92,6 @@ async fn setup(
                 &mut context.banks_client,
                 &context.payer,
                 &context.last_blockhash,
-                &[
-                    source_validator_stake.vote.pubkey(),
-                    destination_validator_stake.vote.pubkey(),
-                ],
                 false,
             )
             .await;
@@ -296,10 +292,6 @@ async fn success() {
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
-            &[
-                source_validator_stake.vote.pubkey(),
-                destination_validator_stake.vote.pubkey(),
-            ],
             false,
         )
         .await;
@@ -548,10 +540,6 @@ async fn success_with_increasing_stake() {
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
-            &[
-                source_validator_stake.vote.pubkey(),
-                destination_validator_stake.vote.pubkey(),
-            ],
             false,
         )
         .await;
@@ -638,10 +626,6 @@ async fn fail_with_decreasing_stake() {
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
-            &[
-                source_validator_stake.vote.pubkey(),
-                destination_validator_stake.vote.pubkey(),
-            ],
             false,
         )
         .await;
@@ -1059,10 +1043,6 @@ async fn fail_redelegate_twice() {
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
-            &[
-                source_validator_stake.vote.pubkey(),
-                destination_validator_stake.vote.pubkey(),
-            ],
             false,
         )
         .await;

--- a/stake-pool/program/tests/set_epoch_fee.rs
+++ b/stake-pool/program/tests/set_epoch_fee.rs
@@ -87,7 +87,6 @@ async fn success() {
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            &[],
             false,
         )
         .await;
@@ -112,7 +111,6 @@ async fn success() {
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
-            &[],
             false,
         )
         .await;

--- a/stake-pool/program/tests/set_withdrawal_fee.rs
+++ b/stake-pool/program/tests/set_withdrawal_fee.rs
@@ -117,7 +117,6 @@ async fn success() {
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            &[],
             false,
         )
         .await;
@@ -150,7 +149,6 @@ async fn success() {
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
-            &[],
             false,
         )
         .await;
@@ -242,7 +240,6 @@ async fn success_fee_cannot_increase_more_than_once() {
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            &[],
             false,
         )
         .await;
@@ -275,7 +272,6 @@ async fn success_fee_cannot_increase_more_than_once() {
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
-            &[],
             false,
         )
         .await;
@@ -443,7 +439,6 @@ async fn success_reset_fee_after_one_epoch() {
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            &[],
             false,
         )
         .await;
@@ -600,7 +595,6 @@ async fn success_increase_fee_from_0() {
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            &[],
             false,
         )
         .await;
@@ -633,7 +627,6 @@ async fn success_increase_fee_from_0() {
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
-            &[],
             false,
         )
         .await;

--- a/stake-pool/program/tests/update_stake_pool_balance.rs
+++ b/stake-pool/program/tests/update_stake_pool_balance.rs
@@ -5,9 +5,7 @@ mod helpers;
 
 use {
     helpers::*,
-    solana_program::{
-        borsh0_10::try_from_slice_unchecked, instruction::InstructionError, pubkey::Pubkey,
-    },
+    solana_program::{borsh0_10::try_from_slice_unchecked, instruction::InstructionError},
     solana_program_test::*,
     solana_sdk::{
         hash::Hash,
@@ -180,11 +178,6 @@ async fn success() {
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
-            stake_accounts
-                .iter()
-                .map(|v| v.vote.pubkey())
-                .collect::<Vec<Pubkey>>()
-                .as_slice(),
             false,
         )
         .await;
@@ -293,11 +286,6 @@ async fn success_absorbing_extra_lamports() {
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
-            stake_accounts
-                .iter()
-                .map(|v| v.vote.pubkey())
-                .collect::<Vec<Pubkey>>()
-                .as_slice(),
             false,
         )
         .await;

--- a/stake-pool/program/tests/update_validator_list_balance.rs
+++ b/stake-pool/program/tests/update_validator_list_balance.rs
@@ -5,7 +5,7 @@ mod helpers;
 
 use {
     helpers::*,
-    solana_program::{borsh0_10::try_from_slice_unchecked, program_pack::Pack, pubkey::Pubkey},
+    solana_program::{borsh0_10::try_from_slice_unchecked, program_pack::Pack},
     solana_program_test::*,
     solana_sdk::{hash::Hash, signature::Signer, stake::state::StakeStateV2},
     spl_stake_pool::{
@@ -107,11 +107,6 @@ async fn setup(
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            stake_accounts
-                .iter()
-                .map(|v| v.vote.pubkey())
-                .collect::<Vec<Pubkey>>()
-                .as_slice(),
             false,
         )
         .await;
@@ -140,11 +135,6 @@ async fn setup(
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
-            stake_accounts
-                .iter()
-                .map(|v| v.vote.pubkey())
-                .collect::<Vec<Pubkey>>()
-                .as_slice(),
             false,
         )
         .await;
@@ -223,11 +213,6 @@ async fn success_with_normal() {
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
-            stake_accounts
-                .iter()
-                .map(|v| v.vote.pubkey())
-                .collect::<Vec<Pubkey>>()
-                .as_slice(),
             false,
         )
         .await;
@@ -299,11 +284,6 @@ async fn merge_into_reserve() {
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
-            stake_accounts
-                .iter()
-                .map(|v| v.vote.pubkey())
-                .collect::<Vec<Pubkey>>()
-                .as_slice(),
             false,
         )
         .await;
@@ -339,11 +319,6 @@ async fn merge_into_reserve() {
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
-            stake_accounts
-                .iter()
-                .map(|v| v.vote.pubkey())
-                .collect::<Vec<Pubkey>>()
-                .as_slice(),
             false,
         )
         .await;
@@ -435,11 +410,6 @@ async fn merge_into_validator_stake() {
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
-            stake_accounts
-                .iter()
-                .map(|v| v.vote.pubkey())
-                .collect::<Vec<Pubkey>>()
-                .as_slice(),
             false,
         )
         .await;
@@ -475,11 +445,6 @@ async fn merge_into_validator_stake() {
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
-            stake_accounts
-                .iter()
-                .map(|v| v.vote.pubkey())
-                .collect::<Vec<Pubkey>>()
-                .as_slice(),
             false,
         )
         .await;
@@ -591,11 +556,6 @@ async fn merge_transient_stake_after_remove() {
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
-            stake_accounts
-                .iter()
-                .map(|v| v.vote.pubkey())
-                .collect::<Vec<Pubkey>>()
-                .as_slice(),
             true,
         )
         .await;
@@ -628,11 +588,7 @@ async fn merge_transient_stake_after_remove() {
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
-            stake_accounts
-                .iter()
-                .map(|v| v.vote.pubkey())
-                .collect::<Vec<Pubkey>>()
-                .as_slice(),
+            validator_list.validators.len(),
             false,
         )
         .await;
@@ -706,16 +662,8 @@ async fn merge_transient_stake_after_remove() {
 #[tokio::test]
 async fn success_with_burned_tokens() {
     let num_validators = 5;
-    let (
-        mut context,
-        last_blockhash,
-        stake_pool_accounts,
-        stake_accounts,
-        deposit_accounts,
-        _,
-        _,
-        mut slot,
-    ) = setup(num_validators).await;
+    let (mut context, last_blockhash, stake_pool_accounts, _, deposit_accounts, _, _, mut slot) =
+        setup(num_validators).await;
 
     let mint_info = get_account(
         &mut context.banks_client,
@@ -762,11 +710,6 @@ async fn success_with_burned_tokens() {
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
-            stake_accounts
-                .iter()
-                .map(|v| v.vote.pubkey())
-                .collect::<Vec<Pubkey>>()
-                .as_slice(),
             false,
         )
         .await;

--- a/stake-pool/program/tests/update_validator_list_balance_hijack.rs
+++ b/stake-pool/program/tests/update_validator_list_balance_hijack.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::arithmetic_side_effects)]
 #![cfg(feature = "test-sbf")]
 
+use spl_stake_pool::instruction;
+
 mod helpers;
 
 use {
@@ -17,8 +19,7 @@ use {
     },
     spl_stake_pool::{
         error::StakePoolError, find_stake_program_address, find_transient_stake_program_address,
-        find_withdraw_authority_program_address, id, instruction, state::StakePool,
-        MINIMUM_RESERVE_LAMPORTS,
+        find_withdraw_authority_program_address, id, state::StakePool, MINIMUM_RESERVE_LAMPORTS,
     },
     std::num::NonZeroU32,
 };
@@ -241,7 +242,7 @@ async fn check_ignored_hijacked_transient_stake(
     .0;
     let transaction = Transaction::new_signed_with_payer(
         &[
-            instruction::update_validator_list_balance(
+            instruction::update_validator_list_balance_chunk(
                 &id(),
                 &stake_pool_accounts.stake_pool.pubkey(),
                 &stake_pool_accounts.withdraw_authority,
@@ -251,7 +252,8 @@ async fn check_ignored_hijacked_transient_stake(
                 1,
                 0,
                 /* no_merge = */ false,
-            ),
+            )
+            .unwrap(),
             system_instruction::transfer(
                 &context.payer.pubkey(),
                 &transient_stake_address,
@@ -405,7 +407,7 @@ async fn check_ignored_hijacked_validator_stake(
         .await;
     let transaction = Transaction::new_signed_with_payer(
         &[
-            instruction::update_validator_list_balance(
+            instruction::update_validator_list_balance_chunk(
                 &id(),
                 &stake_pool_accounts.stake_pool.pubkey(),
                 &stake_pool_accounts.withdraw_authority,
@@ -415,7 +417,8 @@ async fn check_ignored_hijacked_validator_stake(
                 1,
                 0,
                 /* no_merge = */ false,
-            ),
+            )
+            .unwrap(),
             system_instruction::transfer(
                 &context.payer.pubkey(),
                 &stake_account.stake_account,

--- a/stake-pool/program/tests/update_validator_list_balance_hijack.rs
+++ b/stake-pool/program/tests/update_validator_list_balance_hijack.rs
@@ -109,11 +109,6 @@ async fn setup(
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            stake_accounts
-                .iter()
-                .map(|v| v.vote.pubkey())
-                .collect::<Vec<Pubkey>>()
-                .as_slice(),
             false,
         )
         .await;
@@ -143,11 +138,6 @@ async fn setup(
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
-            stake_accounts
-                .iter()
-                .map(|v| v.vote.pubkey())
-                .collect::<Vec<Pubkey>>()
-                .as_slice(),
             false,
         )
         .await;
@@ -258,7 +248,7 @@ async fn check_ignored_hijacked_transient_stake(
                 &stake_pool_accounts.validator_list.pubkey(),
                 &stake_pool_accounts.reserve_stake.pubkey(),
                 &validator_list,
-                &[stake_account.vote.pubkey()],
+                1,
                 0,
                 /* no_merge = */ false,
             ),
@@ -310,11 +300,6 @@ async fn check_ignored_hijacked_transient_stake(
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
-            stake_accounts
-                .iter()
-                .map(|v| v.vote.pubkey())
-                .collect::<Vec<Pubkey>>()
-                .as_slice(),
             false,
         )
         .await;
@@ -427,7 +412,7 @@ async fn check_ignored_hijacked_validator_stake(
                 &stake_pool_accounts.validator_list.pubkey(),
                 &stake_pool_accounts.reserve_stake.pubkey(),
                 &validator_list,
-                &[stake_account.vote.pubkey()],
+                1,
                 0,
                 /* no_merge = */ false,
             ),
@@ -479,11 +464,6 @@ async fn check_ignored_hijacked_validator_stake(
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
-            stake_accounts
-                .iter()
-                .map(|v| v.vote.pubkey())
-                .collect::<Vec<Pubkey>>()
-                .as_slice(),
             false,
         )
         .await;

--- a/stake-pool/program/tests/vsa_remove.rs
+++ b/stake-pool/program/tests/vsa_remove.rs
@@ -734,7 +734,7 @@ async fn success_with_hijacked_transient_account() {
     .0;
     let transaction = Transaction::new_signed_with_payer(
         &[
-            instruction::update_validator_list_balance(
+            instruction::update_validator_list_balance_chunk(
                 &id(),
                 &stake_pool_accounts.stake_pool.pubkey(),
                 &stake_pool_accounts.withdraw_authority,
@@ -744,7 +744,8 @@ async fn success_with_hijacked_transient_account() {
                 1,
                 0,
                 /* no_merge = */ false,
-            ),
+            )
+            .unwrap(),
             system_instruction::transfer(
                 &context.payer.pubkey(),
                 &transient_stake_address,

--- a/stake-pool/program/tests/vsa_remove.rs
+++ b/stake-pool/program/tests/vsa_remove.rs
@@ -87,7 +87,6 @@ async fn success() {
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            &[validator_stake.vote.pubkey()],
             false,
         )
         .await;
@@ -267,7 +266,6 @@ async fn fail_double_remove() {
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            &[validator_stake.vote.pubkey()],
             false,
         )
         .await;
@@ -567,7 +565,6 @@ async fn success_with_deactivating_transient_stake() {
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            &[validator_stake.vote.pubkey()],
             false,
         )
         .await;
@@ -629,7 +626,6 @@ async fn success_resets_preferred_validator() {
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            &[validator_stake.vote.pubkey()],
             false,
         )
         .await;
@@ -701,7 +697,6 @@ async fn success_with_hijacked_transient_account() {
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            &[validator_stake.vote.pubkey()],
             false,
         )
         .await;
@@ -746,7 +741,7 @@ async fn success_with_hijacked_transient_account() {
                 &stake_pool_accounts.validator_list.pubkey(),
                 &stake_pool_accounts.reserve_stake.pubkey(),
                 &validator_list,
-                &[validator_stake.vote.pubkey()],
+                1,
                 0,
                 /* no_merge = */ false,
             ),
@@ -822,7 +817,6 @@ async fn success_with_hijacked_transient_account() {
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            &[validator_stake.vote.pubkey()],
             false,
         )
         .await;

--- a/stake-pool/program/tests/withdraw_edge_cases.rs
+++ b/stake-pool/program/tests/withdraw_edge_cases.rs
@@ -53,7 +53,6 @@ async fn fail_remove_validator() {
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            &[validator_stake.vote.pubkey()],
             false,
         )
         .await;
@@ -119,7 +118,6 @@ async fn success_remove_validator(multiple: u64) {
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            &[validator_stake.vote.pubkey()],
             false,
         )
         .await;
@@ -163,7 +161,6 @@ async fn success_remove_validator(multiple: u64) {
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
-            &[validator_stake.vote.pubkey()],
             false,
         )
         .await;
@@ -271,7 +268,6 @@ async fn fail_with_reserve() {
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            &[validator_stake.vote.pubkey()],
             false,
         )
         .await;
@@ -342,7 +338,6 @@ async fn success_with_reserve() {
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
-            &[validator_stake.vote.pubkey()],
             false,
         )
         .await;
@@ -768,7 +763,6 @@ async fn success_with_small_preferred_withdraw() {
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
-            &[validator_stake.vote.pubkey()],
             false,
         )
         .await;
@@ -843,10 +837,6 @@ async fn success_with_small_preferred_withdraw() {
             &mut context.banks_client,
             &context.payer,
             &last_blockhash,
-            &[
-                validator_stake.vote.pubkey(),
-                preferred_validator.vote.pubkey(),
-            ],
             false,
         )
         .await;


### PR DESCRIPTION
# Problem

`spl_stake_pool::instruction::update_validator_list_balance()`'s API has a redundant param in `validator_vote_accounts` since this data is already present in the `validator_list: &ValidatorList` param. This also makes usage of the function more prone to error because the actual instruction processor only works on contiguous chunks of the list but this API allows users to pass in any slice of vote accounts.

The function also does several unnecessary `Vec` allocations that can be omitted if an iterator is used instead.

# Solution

Update `update_validator_list_balance()` to just take a `len` parameter that specifies the number of validators on the `ValidatorList` starting from `start_index` to include into the instruction.

Update `update_validator_list_balance()` to remove the unnecessary `Vec` allocations.

I've also changed the `start_index` param from `u32` to `usize` to reduce the number of `u32 <-> usize` conversions required. 

The test files have been updated accordingly, with `update_all()`'s API being simplified as well.

I've kept the fail-silently-and-just-return-an-instruction-that-does-nothing behaviour in order to keep the return type consistent. 