### PR TITLE
[spl-record] Remove `Data` type from `RecordData` type

### DIFF
--- a/record/program/src/instruction.rs
+++ b/record/program/src/instruction.rs
@@ -162,10 +162,7 @@ pub fn close_account(record_account: &Pubkey, signer: &Pubkey, receiver: &Pubkey
 
 #[cfg(test)]
 mod tests {
-    use {
-        super::*, crate::state::tests::TEST_DATA, solana_program::program_error::ProgramError,
-        spl_pod::bytemuck::pod_bytes_of,
-    };
+    use {super::*, crate::state::tests::TEST_BYTES, solana_program::program_error::ProgramError};
 
     #[test]
     fn serialize_initialize() {
@@ -177,7 +174,7 @@ mod tests {
 
     #[test]
     fn serialize_write() {
-        let data = pod_bytes_of(&TEST_DATA);
+        let data = &TEST_BYTES;
         let offset = 0u64;
         let instruction = RecordInstruction::Write { offset: 0, data };
         let mut expected = vec![1];
@@ -207,7 +204,7 @@ mod tests {
     #[test]
     fn deserialize_invalid_instruction() {
         let mut expected = vec![12];
-        expected.append(&mut pod_bytes_of(&TEST_DATA).to_vec());
+        expected.extend_from_slice(&TEST_BYTES);
         let err: ProgramError = RecordInstruction::unpack(&expected).unwrap_err();
         assert_eq!(err, ProgramError::InvalidInstructionData);
     }

--- a/record/program/src/processor.rs
+++ b/record/program/src/processor.rs
@@ -1,11 +1,7 @@
 //! Program state processor
 
 use {
-    crate::{
-        error::RecordError,
-        instruction::RecordInstruction,
-        state::{Data, RecordData},
-    },
+    crate::{error::RecordError, instruction::RecordInstruction, state::RecordData},
     solana_program::{
         account_info::{next_account_info, AccountInfo},
         entrypoint::ProgramResult,
@@ -46,7 +42,13 @@ pub fn process_instruction(
             let authority_info = next_account_info(account_info_iter)?;
 
             let raw_data = &mut data_info.data.borrow_mut();
-            let account_data = pod_from_bytes_mut::<RecordData>(raw_data)?;
+            if raw_data.len() < RecordData::WRITABLE_START_INDEX {
+                return Err(ProgramError::InvalidAccountData);
+            }
+
+            let account_data = pod_from_bytes_mut::<RecordData>(
+                &mut raw_data[..RecordData::WRITABLE_START_INDEX],
+            )?;
             if account_data.is_initialized() {
                 msg!("Record account already initialized");
                 return Err(ProgramError::AccountAlreadyInitialized);
@@ -63,7 +65,11 @@ pub fn process_instruction(
             let authority_info = next_account_info(account_info_iter)?;
             {
                 let raw_data = &data_info.data.borrow();
-                let account_data = pod_from_bytes::<RecordData>(raw_data)?;
+                if raw_data.len() < RecordData::WRITABLE_START_INDEX {
+                    return Err(ProgramError::InvalidAccountData);
+                }
+                let account_data =
+                    pod_from_bytes::<RecordData>(&raw_data[..RecordData::WRITABLE_START_INDEX])?;
                 if !account_data.is_initialized() {
                     msg!("Record account not initialized");
                     return Err(ProgramError::UninitializedAccount);
@@ -86,7 +92,12 @@ pub fn process_instruction(
             let authority_info = next_account_info(account_info_iter)?;
             let new_authority_info = next_account_info(account_info_iter)?;
             let raw_data = &mut data_info.data.borrow_mut();
-            let account_data = pod_from_bytes_mut::<RecordData>(raw_data)?;
+            if raw_data.len() < RecordData::WRITABLE_START_INDEX {
+                return Err(ProgramError::InvalidAccountData);
+            }
+            let account_data = pod_from_bytes_mut::<RecordData>(
+                &mut raw_data[..RecordData::WRITABLE_START_INDEX],
+            )?;
             if !account_data.is_initialized() {
                 msg!("Record account not initialized");
                 return Err(ProgramError::UninitializedAccount);
@@ -102,7 +113,12 @@ pub fn process_instruction(
             let authority_info = next_account_info(account_info_iter)?;
             let destination_info = next_account_info(account_info_iter)?;
             let raw_data = &mut data_info.data.borrow_mut();
-            let account_data = pod_from_bytes_mut::<RecordData>(raw_data)?;
+            if raw_data.len() < RecordData::WRITABLE_START_INDEX {
+                return Err(ProgramError::InvalidAccountData);
+            }
+            let account_data = pod_from_bytes_mut::<RecordData>(
+                &mut raw_data[..RecordData::WRITABLE_START_INDEX],
+            )?;
             if !account_data.is_initialized() {
                 msg!("Record not initialized");
                 return Err(ProgramError::UninitializedAccount);
@@ -114,7 +130,6 @@ pub fn process_instruction(
             **destination_info.lamports.borrow_mut() = destination_starting_lamports
                 .checked_add(data_lamports)
                 .ok_or(RecordError::Overflow)?;
-            account_data.data = Data::default();
             Ok(())
         }
     }

--- a/record/program/src/state.rs
+++ b/record/program/src/state.rs
@@ -13,25 +13,6 @@ pub struct RecordData {
 
     /// The account allowed to update the data
     pub authority: Pubkey,
-
-    /// The data contained by the account, could be anything serializable
-    pub data: Data,
-}
-
-/// The length of the data contained in the account for testing.
-const DATA_SIZE: usize = 8;
-
-/// Struct just for data
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
-pub struct Data {
-    /// The data contained by the account, could be anything or serializable
-    pub bytes: [u8; DATA_SIZE],
-}
-
-impl Data {
-    /// very small data for easy testing
-    pub const DATA_SIZE: usize = 8;
 }
 
 impl RecordData {
@@ -62,21 +43,17 @@ pub mod tests {
     /// Pubkey for tests
     pub const TEST_PUBKEY: Pubkey = Pubkey::new_from_array([100; 32]);
     /// Bytes for tests
-    pub const TEST_BYTES: [u8; Data::DATA_SIZE] = [42; Data::DATA_SIZE];
-    /// Data for tests
-    pub const TEST_DATA: Data = Data { bytes: TEST_BYTES };
+    pub const TEST_BYTES: [u8; 8] = [42; 8];
     /// RecordData for tests
     pub const TEST_RECORD_DATA: RecordData = RecordData {
         version: TEST_VERSION,
         authority: TEST_PUBKEY,
-        data: TEST_DATA,
     };
 
     #[test]
     fn serialize_data() {
         let mut expected = vec![TEST_VERSION];
         expected.extend_from_slice(&TEST_PUBKEY.to_bytes());
-        expected.extend_from_slice(&TEST_DATA.bytes);
         assert_eq!(pod_bytes_of(&TEST_RECORD_DATA), expected);
         assert_eq!(
             *pod_from_bytes::<RecordData>(&expected).unwrap(),
@@ -86,10 +63,9 @@ pub mod tests {
 
     #[test]
     fn deserialize_invalid_slice() {
-        let data = [200; Data::DATA_SIZE - 1];
         let mut expected = vec![TEST_VERSION];
         expected.extend_from_slice(&TEST_PUBKEY.to_bytes());
-        expected.extend_from_slice(&data);
+        expected.extend_from_slice(&TEST_BYTES);
         let err: ProgramError = pod_from_bytes::<RecordData>(&expected).unwrap_err();
         assert_eq!(err, ProgramError::InvalidArgument);
     }

--- a/record/program/src/state.rs
+++ b/record/program/src/state.rs
@@ -4,7 +4,7 @@ use {
     solana_program::{program_pack::IsInitialized, pubkey::Pubkey},
 };
 
-/// Struct wrapping data and providing metadata
+/// Header type for recorded account data
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
 pub struct RecordData {


### PR DESCRIPTION
#### Problem
The record program uses the struct `RecordData` to represent record data in accounts.
```
pub struct RecordData {
    pub version: u8,
    pub authority: Pubkey,
    pub data: Data,
}
```
The `Data` type is an array of fixed size 8. It seems like this struct was added just for initial testing. The logic to support arbitrary length record data already exists in the processor logic.

By removing `Data` from the `RecordData` type and using it just as a header for data, we should be able to support arbitrary length record data.

#### Summary of changes
Removed the `Data` struct from state and updated the record program to support arbitrary length data.

This is a follow-up to https://github.com/solana-labs/solana-program-library/pull/6054#discussion_r1441021286.