### PR TITLE
[spl-record] Add `Reallocate` instruction

### DIFF
--- a/record/program/src/instruction.rs
+++ b/record/program/src/instruction.rs
@@ -56,8 +56,8 @@ pub enum RecordInstruction<'a> {
 
     /// Reallocate additional space in a record account
     ///
-    /// If the record account already has enough space to hold the specified data length, then the
-    /// instruction does nothing.
+    /// If the record account already has enough space to hold the specified
+    /// data length, then the instruction does nothing.
     ///
     /// Accounts expected by this instruction:
     ///
@@ -66,7 +66,8 @@ pub enum RecordInstruction<'a> {
     /// 2. `[]` System program for reallocation funding
     /// 3. `[signer]` The account's owner
     Reallocate {
-        /// The length of the data to hold in the record account excluding meta data
+        /// The length of the data to hold in the record account excluding meta
+        /// data
         data_length: u64,
     },
 }

--- a/record/program/src/instruction.rs
+++ b/record/program/src/instruction.rs
@@ -6,7 +6,6 @@ use {
         instruction::{AccountMeta, Instruction},
         program_error::ProgramError,
         pubkey::Pubkey,
-        system_program,
     },
     std::mem::size_of,
 };
@@ -62,9 +61,7 @@ pub enum RecordInstruction<'a> {
     /// Accounts expected by this instruction:
     ///
     /// 0. `[writable]` The record account to reallocate
-    /// 1. `[signer, writable]` The payer account to fund reallocation
-    /// 2. `[]` System program for reallocation funding
-    /// 3. `[signer]` The account's owner
+    /// 1. `[signer]` The account's owner
     Reallocate {
         /// The length of the data to hold in the record account excluding meta
         /// data
@@ -193,18 +190,11 @@ pub fn close_account(record_account: &Pubkey, signer: &Pubkey, receiver: &Pubkey
 }
 
 /// Create a `RecordInstruction::Reallocate` instruction
-pub fn reallocate(
-    record_account: &Pubkey,
-    payer: &Pubkey,
-    signer: &Pubkey,
-    data_length: u64,
-) -> Instruction {
+pub fn reallocate(record_account: &Pubkey, signer: &Pubkey, data_length: u64) -> Instruction {
     Instruction {
         program_id: id(),
         accounts: vec![
             AccountMeta::new(*record_account, false),
-            AccountMeta::new(*payer, true),
-            AccountMeta::new_readonly(system_program::id(), false),
             AccountMeta::new_readonly(*signer, true),
         ],
         data: RecordInstruction::Reallocate { data_length }.pack(),

--- a/record/program/src/instruction.rs
+++ b/record/program/src/instruction.rs
@@ -6,6 +6,7 @@ use {
         instruction::{AccountMeta, Instruction},
         program_error::ProgramError,
         pubkey::Pubkey,
+        system_program,
     },
     std::mem::size_of,
 };
@@ -52,19 +53,36 @@ pub enum RecordInstruction<'a> {
     /// 1. `[signer]` Record authority
     /// 2. `[]` Receiver of account lamports
     CloseAccount,
+
+    /// Reallocate additional space in a record account
+    ///
+    /// If the record account already has enough space to hold the specified data length, then the
+    /// instruction does nothing.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    /// 0. `[writable]` The record account to reallocate
+    /// 1. `[signer, writable]` The payer account to fund reallocation
+    /// 2. `[]` System program for reallocation funding
+    /// 3. `[signer]` The account's owner
+    Reallocate {
+        /// The length of the data to hold in the record account excluding meta data
+        data_length: u64,
+    },
 }
 
 impl<'a> RecordInstruction<'a> {
     /// Unpacks a byte buffer into a [RecordInstruction].
     pub fn unpack(input: &'a [u8]) -> Result<Self, ProgramError> {
+        const U32_BYTES: usize = 4;
+        const U64_BYTES: usize = 8;
+
         let (&tag, rest) = input
             .split_first()
             .ok_or(ProgramError::InvalidInstructionData)?;
         Ok(match tag {
             0 => Self::Initialize,
             1 => {
-                const U32_BYTES: usize = 4;
-                const U64_BYTES: usize = 8;
                 let offset = rest
                     .get(..U64_BYTES)
                     .and_then(|slice| slice.try_into().ok())
@@ -84,6 +102,15 @@ impl<'a> RecordInstruction<'a> {
             }
             2 => Self::SetAuthority,
             3 => Self::CloseAccount,
+            4 => {
+                let data_length = rest
+                    .get(..U64_BYTES)
+                    .and_then(|slice| slice.try_into().ok())
+                    .map(u64::from_le_bytes)
+                    .ok_or(ProgramError::InvalidInstructionData)?;
+
+                Self::Reallocate { data_length }
+            }
             _ => return Err(ProgramError::InvalidInstructionData),
         })
     }
@@ -101,6 +128,10 @@ impl<'a> RecordInstruction<'a> {
             }
             Self::SetAuthority => buf.push(2),
             Self::CloseAccount => buf.push(3),
+            Self::Reallocate { data_length } => {
+                buf.push(4);
+                buf.extend_from_slice(&data_length.to_le_bytes());
+            }
         };
         buf
     }
@@ -160,6 +191,25 @@ pub fn close_account(record_account: &Pubkey, signer: &Pubkey, receiver: &Pubkey
     }
 }
 
+/// Create a `RecordInstruction::Reallocate` instruction
+pub fn reallocate(
+    record_account: &Pubkey,
+    payer: &Pubkey,
+    signer: &Pubkey,
+    data_length: u64,
+) -> Instruction {
+    Instruction {
+        program_id: id(),
+        accounts: vec![
+            AccountMeta::new(*record_account, false),
+            AccountMeta::new(*payer, true),
+            AccountMeta::new_readonly(system_program::id(), false),
+            AccountMeta::new_readonly(*signer, true),
+        ],
+        data: RecordInstruction::Reallocate { data_length }.pack(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use {super::*, crate::state::tests::TEST_BYTES, solana_program::program_error::ProgramError};
@@ -197,6 +247,16 @@ mod tests {
     fn serialize_close_account() {
         let instruction = RecordInstruction::CloseAccount;
         let expected = vec![3];
+        assert_eq!(instruction.pack(), expected);
+        assert_eq!(RecordInstruction::unpack(&expected).unwrap(), instruction);
+    }
+
+    #[test]
+    fn serialize_reallocate() {
+        let data_length = 16u64;
+        let instruction = RecordInstruction::Reallocate { data_length };
+        let mut expected = vec![4];
+        expected.extend_from_slice(&data_length.to_le_bytes());
         assert_eq!(instruction.pack(), expected);
         assert_eq!(RecordInstruction::unpack(&expected).unwrap(), instruction);
     }

--- a/record/program/src/processor.rs
+++ b/record/program/src/processor.rs
@@ -173,7 +173,9 @@ pub fn process_instruction(
             }
             msg!(
                 "reallocating +{:?} bytes",
-                needed_account_length - data_info.data_len()
+                needed_account_length
+                    .checked_sub(data_info.data_len())
+                    .unwrap(),
             );
             data_info.realloc(needed_account_length, false)?;
 

--- a/record/program/src/processor.rs
+++ b/record/program/src/processor.rs
@@ -158,8 +158,8 @@ pub fn process_instruction(
                 check_authority(authority_info, &account_data.authority)?;
             }
 
-            // needed account length is the sum of the meta data length and the specified data
-            // length
+            // needed account length is the sum of the meta data length and the specified
+            // data length
             let needed_account_length = pod_get_packed_len::<RecordData>()
                 .checked_add(
                     usize::try_from(data_length).map_err(|_| ProgramError::InvalidArgument)?,

--- a/record/program/tests/functional.rs
+++ b/record/program/tests/functional.rs
@@ -5,7 +5,7 @@ use {
         instruction::{AccountMeta, Instruction, InstructionError},
         pubkey::Pubkey,
         rent::Rent,
-        system_instruction,
+        system_instruction, system_program,
     },
     solana_program_test::*,
     solana_sdk::{
@@ -508,6 +508,161 @@ async fn set_authority_fail_unsigned() {
         &[&context.payer],
         context.last_blockhash,
     );
+    assert_eq!(
+        context
+            .banks_client
+            .process_transaction(transaction)
+            .await
+            .unwrap_err()
+            .unwrap(),
+        TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature)
+    );
+}
+
+#[tokio::test]
+async fn reallocate_success() {
+    let mut context = program_test().start_with_context().await;
+
+    let authority = Keypair::new();
+    let account = Keypair::new();
+    let data = &[222u8; 8];
+    initialize_storage_account(&mut context, &authority, &account, data).await;
+
+    let new_data_length = 16u64;
+    let expected_account_data_length = RecordData::WRITABLE_START_INDEX
+        .checked_add(new_data_length as usize)
+        .unwrap();
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction::reallocate(
+            &account.pubkey(),
+            &context.payer.pubkey(),
+            &authority.pubkey(),
+            new_data_length,
+        )],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &authority],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+
+    let account_handle = context
+        .banks_client
+        .get_account(account.pubkey())
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(account_handle.data.len(), expected_account_data_length);
+
+    // reallocate to a smaller length
+    let old_data_length = 8u64;
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction::reallocate(
+            &account.pubkey(),
+            &context.payer.pubkey(),
+            &authority.pubkey(),
+            old_data_length,
+        )],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &authority],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+
+    let account = context
+        .banks_client
+        .get_account(account.pubkey())
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(account.data.len(), expected_account_data_length);
+}
+
+#[tokio::test]
+async fn reallocate_fail_wrong_authority() {
+    let mut context = program_test().start_with_context().await;
+
+    let authority = Keypair::new();
+    let account = Keypair::new();
+    let data = &[222u8; 8];
+    initialize_storage_account(&mut context, &authority, &account, data).await;
+
+    let new_data_length = 16u64;
+
+    let wrong_authority = Keypair::new();
+    let transaction = Transaction::new_signed_with_payer(
+        &[Instruction {
+            program_id: id(),
+            accounts: vec![
+                AccountMeta::new(account.pubkey(), false),
+                AccountMeta::new(context.payer.pubkey(), true),
+                AccountMeta::new_readonly(system_program::id(), false),
+                AccountMeta::new(wrong_authority.pubkey(), true),
+            ],
+            data: instruction::RecordInstruction::Reallocate {
+                data_length: new_data_length,
+            }
+            .pack(),
+        }],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &wrong_authority],
+        context.last_blockhash,
+    );
+
+    assert_eq!(
+        context
+            .banks_client
+            .process_transaction(transaction)
+            .await
+            .unwrap_err()
+            .unwrap(),
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(RecordError::IncorrectAuthority as u32)
+        )
+    );
+}
+
+#[tokio::test]
+async fn reallocate_fail_unsigned() {
+    let mut context = program_test().start_with_context().await;
+
+    let authority = Keypair::new();
+    let account = Keypair::new();
+    let data = &[222u8; 8];
+    initialize_storage_account(&mut context, &authority, &account, data).await;
+
+    let new_data_length = 16u64;
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[Instruction {
+            program_id: id(),
+            accounts: vec![
+                AccountMeta::new(account.pubkey(), false),
+                AccountMeta::new(context.payer.pubkey(), true),
+                AccountMeta::new_readonly(system_program::id(), false),
+                AccountMeta::new(authority.pubkey(), false),
+            ],
+            data: instruction::RecordInstruction::Reallocate {
+                data_length: new_data_length,
+            }
+            .pack(),
+        }],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
     assert_eq!(
         context
             .banks_client


### PR DESCRIPTION
#### Problem
The record program is useful when storing arbitrary length data on accounts. However, if the data is too long to fit inside an account, it is not possible to record the data without creating a new account with enough space. It would be nice to be able to reallocate more space to the existing account to store longer record data.

#### Summary of changes
Add a reallocate instruction. I followed the main logic of the reallocate instruction in the token-2022 program.

This PR builds on top of https://github.com/solana-labs/solana-program-library/pull/6062. Once https://github.com/solana-labs/solana-program-library/pull/6062 is merged, I will rebase to master to remove the first few commits.