### PR TITLE
Transfer hook offchain and onchain helpers bugfix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7350,6 +7350,7 @@ dependencies = [
  "solana-zk-token-sdk",
  "spl-memo 4.0.0",
  "spl-pod 0.1.0",
+ "spl-tlv-account-resolution 0.5.0",
  "spl-token 4.0.0",
  "spl-token-group-interface",
  "spl-token-metadata-interface 0.2.0",

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -946,6 +946,7 @@ where
                         .map_ok(|opt| opt.map(|acc| acc.data))
                 },
                 self.get_address(),
+                amount,
             )
             .await
             .map_err(|_| TokenError::AccountNotFound)?;

--- a/token/js/src/extensions/transferHook/state.ts
+++ b/token/js/src/extensions/transferHook/state.ts
@@ -100,7 +100,7 @@ export const ExtraAccountMetaAccountDataLayout = struct<ExtraAccountMetaAccountD
 ]);
 
 /** Unpack an extra account metas account and parse the data into a list of ExtraAccountMetas */
-export function getExtraAccountMetas(account: AccountInfo<Buffer>): ExtraAccountMeta[] {
+export function getExtraAccountMetaList(account: AccountInfo<Buffer>): ExtraAccountMeta[] {
     const extraAccountsList = ExtraAccountMetaAccountDataLayout.decode(account.data).extraAccountsList;
     return extraAccountsList.extraAccounts.slice(0, extraAccountsList.count);
 }

--- a/token/js/test/unit/transferHook.test.ts
+++ b/token/js/test/unit/transferHook.test.ts
@@ -1,173 +1,383 @@
-import { getExtraAccountMetaList, resolveExtraAccountMeta } from '../../src';
+import {
+    addExtraAccountsToTransferInstruction,
+    createTransferCheckedInstruction,
+    getExtraAccountMetaAddress,
+    getExtraAccountMetaList,
+    resolveExtraAccountMeta,
+    TOKEN_2022_PROGRAM_ID,
+} from '../../src';
 import { expect } from 'chai';
 import type { Connection } from '@solana/web3.js';
-import { PublicKey } from '@solana/web3.js';
+import { Keypair, PublicKey } from '@solana/web3.js';
 import { getConnection } from '../common';
 
-describe('transferHookExtraAccounts', () => {
-    let connection: Connection;
-    const testProgramId = new PublicKey('7N4HggYEJAtCLJdnHGCtFqfxcB5rhQCsQTze3ftYstVj');
-    const instructionData = Buffer.from(Array.from(Array(32).keys()));
-    const plainAccount = new PublicKey('6c5q79ccBTWvZTEx3JkdHThtMa2eALba5bfvHGf8kA2c');
-    const seeds = [Buffer.from('seed'), Buffer.from([4, 5, 6, 7]), plainAccount.toBuffer(), Buffer.from([2, 2, 2, 2])];
-    const pdaPublicKey = PublicKey.findProgramAddressSync(seeds, testProgramId)[0];
-    const pdaPublicKeyWithProgramId = PublicKey.findProgramAddressSync(seeds, plainAccount)[0];
+describe('transferHook', () => {
+    describe('validation data', () => {
+        let connection: Connection;
+        const testProgramId = new PublicKey('7N4HggYEJAtCLJdnHGCtFqfxcB5rhQCsQTze3ftYstVj');
+        const instructionData = Buffer.from(Array.from(Array(32).keys()));
+        const plainAccount = new PublicKey('6c5q79ccBTWvZTEx3JkdHThtMa2eALba5bfvHGf8kA2c');
+        const seeds = [
+            Buffer.from('seed'),
+            Buffer.from([4, 5, 6, 7]),
+            plainAccount.toBuffer(),
+            Buffer.from([2, 2, 2, 2]),
+        ];
+        const pdaPublicKey = PublicKey.findProgramAddressSync(seeds, testProgramId)[0];
+        const pdaPublicKeyWithProgramId = PublicKey.findProgramAddressSync(seeds, plainAccount)[0];
 
-    const plainSeed = Buffer.concat([
-        Buffer.from([1]), // u8 discriminator
-        Buffer.from([4]), // u8 length
-        Buffer.from('seed'), // 4 bytes seed
-    ]);
+        const plainSeed = Buffer.concat([
+            Buffer.from([1]), // u8 discriminator
+            Buffer.from([4]), // u8 length
+            Buffer.from('seed'), // 4 bytes seed
+        ]);
 
-    const instructionDataSeed = Buffer.concat([
-        Buffer.from([2]), // u8 discriminator
-        Buffer.from([4]), // u8 offset
-        Buffer.from([4]), // u8 length
-    ]);
+        const instructionDataSeed = Buffer.concat([
+            Buffer.from([2]), // u8 discriminator
+            Buffer.from([4]), // u8 offset
+            Buffer.from([4]), // u8 length
+        ]);
 
-    const accountKeySeed = Buffer.concat([
-        Buffer.from([3]), // u8 discriminator
-        Buffer.from([0]), // u8 index
-    ]);
+        const accountKeySeed = Buffer.concat([
+            Buffer.from([3]), // u8 discriminator
+            Buffer.from([0]), // u8 index
+        ]);
 
-    const accountDataSeed = Buffer.concat([
-        Buffer.from([4]), // u8 discriminator
-        Buffer.from([0]), // u8 account index
-        Buffer.from([2]), // u8 account data offset
-        Buffer.from([4]), // u8 account data length
-    ]);
+        const accountDataSeed = Buffer.concat([
+            Buffer.from([4]), // u8 discriminator
+            Buffer.from([0]), // u8 account index
+            Buffer.from([2]), // u8 account data offset
+            Buffer.from([4]), // u8 account data length
+        ]);
 
-    const addressConfig = Buffer.concat([plainSeed, instructionDataSeed, accountKeySeed, accountDataSeed], 32);
+        const addressConfig = Buffer.concat([plainSeed, instructionDataSeed, accountKeySeed, accountDataSeed], 32);
 
-    const plainExtraAccountMeta = {
-        discriminator: 0,
-        addressConfig: plainAccount.toBuffer(),
-        isSigner: false,
-        isWritable: false,
-    };
-    const plainExtraAccount = Buffer.concat([
-        Buffer.from([0]), // u8 discriminator
-        plainAccount.toBuffer(), // 32 bytes address
-        Buffer.from([0]), // bool isSigner
-        Buffer.from([0]), // bool isWritable
-    ]);
+        const plainExtraAccountMeta = {
+            discriminator: 0,
+            addressConfig: plainAccount.toBuffer(),
+            isSigner: false,
+            isWritable: false,
+        };
+        const plainExtraAccount = Buffer.concat([
+            Buffer.from([0]), // u8 discriminator
+            plainAccount.toBuffer(), // 32 bytes address
+            Buffer.from([0]), // bool isSigner
+            Buffer.from([0]), // bool isWritable
+        ]);
 
-    const pdaExtraAccountMeta = {
-        discriminator: 1,
-        addressConfig,
-        isSigner: true,
-        isWritable: false,
-    };
-    const pdaExtraAccount = Buffer.concat([
-        Buffer.from([1]), // u8 discriminator
-        addressConfig, // 32 bytes address config
-        Buffer.from([1]), // bool isSigner
-        Buffer.from([0]), // bool isWritable
-    ]);
+        const pdaExtraAccountMeta = {
+            discriminator: 1,
+            addressConfig,
+            isSigner: true,
+            isWritable: false,
+        };
+        const pdaExtraAccount = Buffer.concat([
+            Buffer.from([1]), // u8 discriminator
+            addressConfig, // 32 bytes address config
+            Buffer.from([1]), // bool isSigner
+            Buffer.from([0]), // bool isWritable
+        ]);
 
-    const pdaExtraAccountMetaWithProgramId = {
-        discriminator: 128,
-        addressConfig,
-        isSigner: false,
-        isWritable: true,
-    };
-    const pdaExtraAccountWithProgramId = Buffer.concat([
-        Buffer.from([128]), // u8 discriminator
-        addressConfig, // 32 bytes address config
-        Buffer.from([0]), // bool isSigner
-        Buffer.from([1]), // bool isWritable
-    ]);
+        const pdaExtraAccountMetaWithProgramId = {
+            discriminator: 128,
+            addressConfig,
+            isSigner: false,
+            isWritable: true,
+        };
+        const pdaExtraAccountWithProgramId = Buffer.concat([
+            Buffer.from([128]), // u8 discriminator
+            addressConfig, // 32 bytes address config
+            Buffer.from([0]), // bool isSigner
+            Buffer.from([1]), // bool isWritable
+        ]);
 
-    const extraAccountList = Buffer.concat([
-        Buffer.from([0, 0, 0, 0, 0, 0, 0, 0]), // u64 accountDiscriminator
-        Buffer.from([0, 0, 0, 0]), // u32 length
-        Buffer.from([3, 0, 0, 0]), // u32 count
-        plainExtraAccount,
-        pdaExtraAccount,
-        pdaExtraAccountWithProgramId,
-    ]);
+        const extraAccountList = Buffer.concat([
+            Buffer.from([0, 0, 0, 0, 0, 0, 0, 0]), // u64 accountDiscriminator
+            Buffer.from([109, 0, 0, 0]), // u32 length (35 * 3 + 4)
+            Buffer.from([3, 0, 0, 0]), // u32 count
+            plainExtraAccount,
+            pdaExtraAccount,
+            pdaExtraAccountWithProgramId,
+        ]);
 
-    before(async () => {
-        connection = await getConnection();
-        connection.getAccountInfo = async (
-            _publicKey: PublicKey,
-            _commitmentOrConfig?: Parameters<(typeof connection)['getAccountInfo']>[1]
-        ): ReturnType<(typeof connection)['getAccountInfo']> => ({
-            data: Buffer.from([0, 0, 2, 2, 2, 2]),
-            owner: PublicKey.default,
-            executable: false,
-            lamports: 0,
+        before(async () => {
+            connection = await getConnection();
+            connection.getAccountInfo = async (
+                _publicKey: PublicKey,
+                _commitmentOrConfig?: Parameters<(typeof connection)['getAccountInfo']>[1]
+            ): ReturnType<(typeof connection)['getAccountInfo']> => ({
+                data: Buffer.from([0, 0, 2, 2, 2, 2]),
+                owner: PublicKey.default,
+                executable: false,
+                lamports: 0,
+            });
+        });
+
+        it('can parse extra metas', () => {
+            const accountInfo = {
+                data: extraAccountList,
+                owner: PublicKey.default,
+                executable: false,
+                lamports: 0,
+            };
+            const parsedExtraAccounts = getExtraAccountMetaList(accountInfo);
+            expect(parsedExtraAccounts).to.not.be.null;
+            if (parsedExtraAccounts == null) {
+                return;
+            }
+
+            expect(parsedExtraAccounts).to.have.length(3);
+            if (parsedExtraAccounts.length !== 3) {
+                return;
+            }
+
+            expect(parsedExtraAccounts[0].discriminator).to.eql(0);
+            expect(parsedExtraAccounts[0].addressConfig).to.eql(plainAccount.toBuffer());
+            expect(parsedExtraAccounts[0].isSigner).to.be.false;
+            expect(parsedExtraAccounts[0].isWritable).to.be.false;
+
+            expect(parsedExtraAccounts[1].discriminator).to.eql(1);
+            expect(parsedExtraAccounts[1].addressConfig).to.eql(addressConfig);
+            expect(parsedExtraAccounts[1].isSigner).to.be.true;
+            expect(parsedExtraAccounts[1].isWritable).to.be.false;
+
+            expect(parsedExtraAccounts[2].discriminator).to.eql(128);
+            expect(parsedExtraAccounts[2].addressConfig).to.eql(addressConfig);
+            expect(parsedExtraAccounts[2].isSigner).to.be.false;
+            expect(parsedExtraAccounts[2].isWritable).to.be.true;
+        });
+
+        it('can resolve extra metas', async () => {
+            const resolvedPlainAccount = await resolveExtraAccountMeta(
+                connection,
+                plainExtraAccountMeta,
+                [],
+                instructionData,
+                testProgramId
+            );
+
+            expect(resolvedPlainAccount.pubkey).to.eql(plainAccount);
+            expect(resolvedPlainAccount.isSigner).to.be.false;
+            expect(resolvedPlainAccount.isWritable).to.be.false;
+
+            const resolvedPdaAccount = await resolveExtraAccountMeta(
+                connection,
+                pdaExtraAccountMeta,
+                [resolvedPlainAccount],
+                instructionData,
+                testProgramId
+            );
+
+            expect(resolvedPdaAccount.pubkey).to.eql(pdaPublicKey);
+            expect(resolvedPdaAccount.isSigner).to.be.true;
+            expect(resolvedPdaAccount.isWritable).to.be.false;
+
+            const resolvedPdaAccountWithProgramId = await resolveExtraAccountMeta(
+                connection,
+                pdaExtraAccountMetaWithProgramId,
+                [resolvedPlainAccount],
+                instructionData,
+                testProgramId
+            );
+
+            expect(resolvedPdaAccountWithProgramId.pubkey).to.eql(pdaPublicKeyWithProgramId);
+            expect(resolvedPdaAccountWithProgramId.isSigner).to.be.false;
+            expect(resolvedPdaAccountWithProgramId.isWritable).to.be.true;
         });
     });
 
-    it('getExtraAccountMetaList', () => {
-        const accountInfo = {
-            data: extraAccountList,
-            owner: PublicKey.default,
-            executable: false,
-            lamports: 0,
-        };
-        const parsedExtraAccounts = getExtraAccountMetaList(accountInfo);
-        expect(parsedExtraAccounts).to.not.be.null;
-        if (parsedExtraAccounts == null) {
-            return;
+    // prettier-ignore
+    describe('adding to transfer instructions', () => {
+        const TRANSFER_HOOK_PROGRAM_ID = new PublicKey(Buffer.from([
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        ]))
+
+        const MINT_PUBKEY = new PublicKey(Buffer.from([
+            2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        ]))
+
+        const MOCK_MINT_STATE = [
+            0, 0, 0, 0, // COption (4): None = 0
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, // Mint authority (32)
+            0, 0, 0, 0, 0, 0, 0, 0, // Supply (8)
+            0, // Decimals (1)
+            1, // Is initialized (1)
+            0, 0, 0, 0, // COption (4): None = 0
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, // Freeze authority (32)
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // Padding (83)
+            1, // Account type (1): Mint = 1
+            14, 0, // Extension type (2): Transfer hook = 14
+            64, 0, // Extension length (2): 64
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, // Authority (32)
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, // Transfer hook program ID (32)
+        ];
+
+        const MOCK_EXTRA_METAS_STATE = [
+            105, 37, 101, 197, 75, 251, 102, 26, // Discriminator for `ExecuteInstruction` (8)
+            214, 0, 0, 0, // Length of pod slice (4): 214
+            6, 0, 0, 0, // Count of account metas (4): 6
+            1, // First account meta discriminator (1): PDA = 1
+            3, 0, // First seed: Account key at index 0 (2)
+            3, 1, // Second seed: Account key at index 1 (2)
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // No more seeds (28)
+            0, // First account meta is signer (1): false = 0
+            0, // First account meta is writable (1): false = 0
+            1, // Second account meta discriminator (1): PDA = 1
+            3, 4, // First seed: Account key at index 4 (2)
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // No more seeds (30)
+            0, // Second account meta is signer (1): false = 0
+            0, // Second account meta is writable (1): false = 0
+            1, // Third account meta discriminator (1): PDA = 1
+            1, 6, 112, 114, 101, 102, 105, 120, // First seed: Literal "prefix" (8)
+            2, 8, 8, // Second seed: Instruction data 8..16 (3)
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // No more seeds (21)
+            0, // Third account meta is signer (1): false = 0
+            0, // Third account meta is writable (1): false = 0
+            0, // Fourth account meta discriminator (1): Pubkey = 0
+            7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+            7, 7,   // Pubkey (32)
+            0,   // Fourth account meta is signer (1): false = 0
+            0,   // Fourth account meta is writable (1): false = 0
+            136, // Fifth account meta discriminator (1): External PDA = 128 + index 8 = 136
+            1, 6, 112, 114, 101, 102, 105, 120, // First seed: Literal "prefix" (8)
+            2, 8, 8, // Second seed: Instruction data 8..16 (3)
+            3, 6, // Third seed: Account key at index 6 (2)
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   // No more seeds (19)
+            0,   // Fifth account meta is signer (1): false = 0
+            0,   // Fifth account meta is writable (1): false = 0
+            136, // Sixth account meta discriminator (1): External PDA = 128 + index 8 = 136
+            1, 14, 97, 110, 111, 116, 104, 101, 114, 95, 112, 114, 101, 102, 105,
+            120, // First seed: Literal "another_prefix" (16)
+            2, 8, 8, // Second seed: Instruction data 8..16 (3)
+            3, 6, // Third seed: Account key at index 6 (2)
+            3, 9, // Fourth seed: Account key at index 9 (2)
+            0, 0, 0, 0, 0, 0, 0, 0, 0, // No more seeds (9)
+            0, // Sixth account meta is signer (1): false = 0
+            0, // Sixth account meta is writable (1): false = 0
+        ];
+
+        async function mockFetchAccountDataFn(
+            publicKey: PublicKey,
+            _commitmentOrConfig?: Parameters<Connection['getAccountInfo']>[1]
+        ): ReturnType<Connection['getAccountInfo']> {
+            if (publicKey.equals(MINT_PUBKEY)) {
+                return {
+                    data: Buffer.from(MOCK_MINT_STATE),
+                    owner: TOKEN_2022_PROGRAM_ID,
+                    executable: false,
+                    lamports: 0,
+                };
+            };
+            if (publicKey.equals(getExtraAccountMetaAddress(MINT_PUBKEY, TRANSFER_HOOK_PROGRAM_ID))) {
+                return {
+                    data: Buffer.from(MOCK_EXTRA_METAS_STATE),
+                    owner: TRANSFER_HOOK_PROGRAM_ID,
+                    executable: false,
+                    lamports: 0,
+                };
+            };
+            return {
+                data: Buffer.from([]),
+                owner: PublicKey.default,
+                executable: false,
+                lamports: 0,
+            };
         }
 
-        expect(parsedExtraAccounts).to.have.length(3);
-        if (parsedExtraAccounts.length !== 3) {
-            return;
-        }
+        it('can add extra accounts to a transfer instruction', async () => {
+            const amount = 2n;
+            const sourcePubkey = Keypair.generate().publicKey;
+            const mintPubkey = MINT_PUBKEY;
+            const destinationPubkey = Keypair.generate().publicKey;
+            const authorityPubkey = Keypair.generate().publicKey;
+            const validateStatePubkey = getExtraAccountMetaAddress(MINT_PUBKEY, TRANSFER_HOOK_PROGRAM_ID);
 
-        expect(parsedExtraAccounts[0].discriminator).to.eql(0);
-        expect(parsedExtraAccounts[0].addressConfig).to.eql(plainAccount.toBuffer());
-        expect(parsedExtraAccounts[0].isSigner).to.be.false;
-        expect(parsedExtraAccounts[0].isWritable).to.be.false;
+            const amountInLeBytes = Buffer.alloc(8);
+            amountInLeBytes.writeBigUInt64LE(amount);
 
-        expect(parsedExtraAccounts[1].discriminator).to.eql(1);
-        expect(parsedExtraAccounts[1].addressConfig).to.eql(addressConfig);
-        expect(parsedExtraAccounts[1].isSigner).to.be.true;
-        expect(parsedExtraAccounts[1].isWritable).to.be.false;
+            const extraMeta1Pubkey = PublicKey.findProgramAddressSync(
+                [
+                    sourcePubkey.toBuffer(), // Account key at index 0
+                    mintPubkey.toBuffer(),   // Account key at index 1
+                ],
+                TRANSFER_HOOK_PROGRAM_ID,
+            )[0];
+            const extraMeta2Pubkey = PublicKey.findProgramAddressSync(
+                [
+                    validateStatePubkey.toBuffer(), // Account key at index 4
+                ],
+                TRANSFER_HOOK_PROGRAM_ID,
+            )[0];
+            const extraMeta3Pubkey = PublicKey.findProgramAddressSync(
+                [
+                    Buffer.from("prefix"),
+                    amountInLeBytes, // Instruction data 8..16
+                ],
+                TRANSFER_HOOK_PROGRAM_ID,
+            )[0];
+            const extraMeta4Pubkey = new PublicKey(Buffer.from([
+                7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+            ])); // Some arbitrary program ID
+            const extraMeta5Pubkey = PublicKey.findProgramAddressSync(
+                [
+                    Buffer.from("prefix"),
+                    amountInLeBytes, // Instruction data 8..16
+                    extraMeta2Pubkey.toBuffer(),
+                ],
+                extraMeta4Pubkey, // PDA off of the arbitrary program ID
+            )[0];
+            const extraMeta6Pubkey = PublicKey.findProgramAddressSync(
+                [
+                    Buffer.from("another_prefix"),
+                    amountInLeBytes, // Instruction data 8..16
+                    extraMeta2Pubkey.toBuffer(),
+                    extraMeta5Pubkey.toBuffer(),
+                ],
+                extraMeta4Pubkey, // PDA off of the arbitrary program ID
+            )[0];
 
-        expect(parsedExtraAccounts[2].discriminator).to.eql(128);
-        expect(parsedExtraAccounts[2].addressConfig).to.eql(addressConfig);
-        expect(parsedExtraAccounts[2].isSigner).to.be.false;
-        expect(parsedExtraAccounts[2].isWritable).to.be.true;
-    });
-    it('resolveExtraAccountMeta', async () => {
-        const resolvedPlainAccount = await resolveExtraAccountMeta(
-            connection,
-            plainExtraAccountMeta,
-            [],
-            instructionData,
-            testProgramId
-        );
 
-        expect(resolvedPlainAccount.pubkey).to.eql(plainAccount);
-        expect(resolvedPlainAccount.isSigner).to.be.false;
-        expect(resolvedPlainAccount.isWritable).to.be.false;
+            const connection = await getConnection();
+            connection.getAccountInfo = mockFetchAccountDataFn;
 
-        const resolvedPdaAccount = await resolveExtraAccountMeta(
-            connection,
-            pdaExtraAccountMeta,
-            [resolvedPlainAccount],
-            instructionData,
-            testProgramId
-        );
+            const rawInstruction = createTransferCheckedInstruction(
+                sourcePubkey,
+                mintPubkey,
+                destinationPubkey,
+                authorityPubkey,
+                amount,
+                9,
+                undefined,
+                TOKEN_2022_PROGRAM_ID,
+            );
 
-        expect(resolvedPdaAccount.pubkey).to.eql(pdaPublicKey);
-        expect(resolvedPdaAccount.isSigner).to.be.true;
-        expect(resolvedPdaAccount.isWritable).to.be.false;
+            const hydratedInstruction = await addExtraAccountsToTransferInstruction(
+                connection,
+                rawInstruction,
+                mintPubkey,
+                amount,
+                undefined,
+                TOKEN_2022_PROGRAM_ID,
+            );
 
-        const resolvedPdaAccountWithProgramId = await resolveExtraAccountMeta(
-            connection,
-            pdaExtraAccountMetaWithProgramId,
-            [resolvedPlainAccount],
-            instructionData,
-            testProgramId
-        );
+            // The validation account should not be at index 4
+            expect(hydratedInstruction.keys[4].pubkey).to.not.eql(validateStatePubkey);
 
-        expect(resolvedPdaAccountWithProgramId.pubkey).to.eql(pdaPublicKeyWithProgramId);
-        expect(resolvedPdaAccountWithProgramId.isSigner).to.be.false;
-        expect(resolvedPdaAccountWithProgramId.isWritable).to.be.true;
+            // Verify all PDAs are correct
+            expect(hydratedInstruction.keys[4].pubkey).to.eql(extraMeta1Pubkey);
+            expect(hydratedInstruction.keys[5].pubkey).to.eql(extraMeta2Pubkey);
+            expect(hydratedInstruction.keys[6].pubkey).to.eql(extraMeta3Pubkey);
+            expect(hydratedInstruction.keys[7].pubkey).to.eql(extraMeta4Pubkey);
+            expect(hydratedInstruction.keys[8].pubkey).to.eql(extraMeta5Pubkey);
+            expect(hydratedInstruction.keys[9].pubkey).to.eql(extraMeta6Pubkey);
+        });
     });
 });

--- a/token/js/test/unit/transferHook.test.ts
+++ b/token/js/test/unit/transferHook.test.ts
@@ -1,4 +1,4 @@
-import { getExtraAccountMetas, resolveExtraAccountMeta } from '../../src';
+import { getExtraAccountMetaList, resolveExtraAccountMeta } from '../../src';
 import { expect } from 'chai';
 import type { Connection } from '@solana/web3.js';
 import { PublicKey } from '@solana/web3.js';
@@ -100,14 +100,14 @@ describe('transferHookExtraAccounts', () => {
         });
     });
 
-    it('getExtraAccountMetas', () => {
+    it('getExtraAccountMetaList', () => {
         const accountInfo = {
             data: extraAccountList,
             owner: PublicKey.default,
             executable: false,
             lamports: 0,
         };
-        const parsedExtraAccounts = getExtraAccountMetas(accountInfo);
+        const parsedExtraAccounts = getExtraAccountMetaList(accountInfo);
         expect(parsedExtraAccounts).to.not.be.null;
         if (parsedExtraAccounts == null) {
             return;

--- a/token/program-2022-test/tests/transfer_hook.rs
+++ b/token/program-2022-test/tests/transfer_hook.rs
@@ -715,6 +715,7 @@ async fn success_transfers_using_onchain_helper() {
             )
         },
         &mint_a,
+        amount,
     )
     .await
     .unwrap();
@@ -730,6 +731,7 @@ async fn success_transfers_using_onchain_helper() {
             )
         },
         &mint_b,
+        amount,
     )
     .await
     .unwrap();

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -45,6 +45,7 @@ proptest = "1.4"
 serial_test = "2.0.0"
 solana-program-test = "1.17.6"
 solana-sdk = "1.17.6"
+spl-tlv-account-resolution = { version = "0.5.0", path = "../../libraries/tlv-account-resolution" }
 serde_json = "1.0.111"
 
 [lib]

--- a/token/program-2022/src/offchain.rs
+++ b/token/program-2022/src/offchain.rs
@@ -92,3 +92,490 @@ where
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        solana_program::{account_info::AccountInfo, system_program},
+        solana_program_test::tokio,
+        spl_tlv_account_resolution::state::ExtraAccountMetaList,
+        spl_transfer_hook_interface::instruction::ExecuteInstruction,
+    };
+
+    const TRANSFER_HOOK_PROGRAM_ID: Pubkey = Pubkey::new_from_array([1; 32]);
+
+    const MINT_PUBKEY: Pubkey = Pubkey::new_from_array([2; 32]);
+
+    const MOCK_MINT_STATE: [u8; 234] = [
+        0, 0, 0, 0, // COption (4): None = 0
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, // Mint authority (32)
+        0, 0, 0, 0, 0, 0, 0, 0, // Supply (8)
+        0, // Decimals (1)
+        1, // Is initialized (1)
+        0, 0, 0, 0, // COption (4): None = 0
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, // Freeze authority (32)
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // Padding (83)
+        1, // Account type (1): Mint = 1
+        14, 0, // Extension type (2): Transfer hook = 14
+        64, 0, // Extension length (2): 64
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, // Authority (32)
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, // Transfer hook program ID (32)
+    ];
+
+    const MOCK_EXTRA_METAS_STATE: [u8; 226] = [
+        105, 37, 101, 197, 75, 251, 102, 26, // Discriminator for `ExecuteInstruction` (8)
+        214, 0, 0, 0, // Length of pod slice (4): 214
+        6, 0, 0, 0, // Count of account metas (4): 6
+        1, // First account meta discriminator (1): PDA = 1
+        3, 0, // First seed: Account key at index 0 (2)
+        3, 1, // Second seed: Account key at index 1 (2)
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, // No more seeds (28)
+        0, // First account meta is signer (1): false = 0
+        0, // First account meta is writable (1): false = 0
+        1, // Second account meta discriminator (1): PDA = 1
+        3, 4, // First seed: Account key at index 4 (2)
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, // No more seeds (30)
+        0, // Second account meta is signer (1): false = 0
+        0, // Second account meta is writable (1): false = 0
+        1, // Third account meta discriminator (1): PDA = 1
+        1, 6, 112, 114, 101, 102, 105, 120, // First seed: Literal "prefix" (8)
+        2, 8, 8, // Second seed: Instruction data 8..16 (3)
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // No more seeds (21)
+        0, // Third account meta is signer (1): false = 0
+        0, // Third account meta is writable (1): false = 0
+        0, // Fourth account meta discriminator (1): Pubkey = 0
+        7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+        7, 7,   // Pubkey (32)
+        0,   // Fourth account meta is signer (1): false = 0
+        0,   // Fourth account meta is writable (1): false = 0
+        136, // Fifth account meta discriminator (1): External PDA = 128 + index 8 = 136
+        1, 6, 112, 114, 101, 102, 105, 120, // First seed: Literal "prefix" (8)
+        2, 8, 8, // Second seed: Instruction data 8..16 (3)
+        3, 6, // Third seed: Account key at index 6 (2)
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   // No more seeds (19)
+        0,   // Fifth account meta is signer (1): false = 0
+        0,   // Fifth account meta is writable (1): false = 0
+        136, // Sixth account meta discriminator (1): External PDA = 128 + index 8 = 136
+        1, 14, 97, 110, 111, 116, 104, 101, 114, 95, 112, 114, 101, 102, 105,
+        120, // First seed: Literal "another_prefix" (16)
+        2, 8, 8, // Second seed: Instruction data 8..16 (3)
+        3, 6, // Third seed: Account key at index 6 (2)
+        3, 9, // Fourth seed: Account key at index 9 (2)
+        0, 0, 0, 0, 0, 0, 0, 0, 0, // No more seeds (9)
+        0, // Sixth account meta is signer (1): false = 0
+        0, // Sixth account meta is writable (1): false = 0
+    ];
+
+    async fn mock_fetch_account_data_fn(address: Pubkey) -> AccountDataResult {
+        if address == MINT_PUBKEY {
+            Ok(Some(MOCK_MINT_STATE.to_vec()))
+        } else if address
+            == get_extra_account_metas_address(&MINT_PUBKEY, &TRANSFER_HOOK_PROGRAM_ID)
+        {
+            Ok(Some(MOCK_EXTRA_METAS_STATE.to_vec()))
+        } else {
+            Ok(None)
+        }
+    }
+
+    #[tokio::test]
+    async fn test_resolve_extra_transfer_account_metas() {
+        let spl_token_2022_program_id = crate::id();
+        let transfer_hook_program_id = TRANSFER_HOOK_PROGRAM_ID;
+        let amount = 2u64;
+
+        let source_pubkey = Pubkey::new_unique();
+        let mut source_data = vec![0; 165]; // Mock
+        let mut source_lamports = 0; // Mock
+        let source_account_info = AccountInfo::new(
+            &source_pubkey,
+            false,
+            true,
+            &mut source_lamports,
+            &mut source_data,
+            &spl_token_2022_program_id,
+            false,
+            0,
+        );
+
+        let mint_pubkey = MINT_PUBKEY;
+        let mut mint_data = MOCK_MINT_STATE.to_vec();
+        let mut mint_lamports = 0; // Mock
+        let mint_account_info = AccountInfo::new(
+            &mint_pubkey,
+            false,
+            true,
+            &mut mint_lamports,
+            &mut mint_data,
+            &spl_token_2022_program_id,
+            false,
+            0,
+        );
+
+        let destination_pubkey = Pubkey::new_unique();
+        let mut destination_data = vec![0; 165]; // Mock
+        let mut destination_lamports = 0; // Mock
+        let destination_account_info = AccountInfo::new(
+            &destination_pubkey,
+            false,
+            true,
+            &mut destination_lamports,
+            &mut destination_data,
+            &spl_token_2022_program_id,
+            false,
+            0,
+        );
+
+        let authority_pubkey = Pubkey::new_unique();
+        let mut authority_data = vec![]; // Mock
+        let mut authority_lamports = 0; // Mock
+        let authority_account_info = AccountInfo::new(
+            &authority_pubkey,
+            false,
+            true,
+            &mut authority_lamports,
+            &mut authority_data,
+            &system_program::ID,
+            false,
+            0,
+        );
+
+        let validate_state_pubkey =
+            get_extra_account_metas_address(&mint_pubkey, &transfer_hook_program_id);
+
+        let extra_meta_1_pubkey = Pubkey::find_program_address(
+            &[
+                &source_pubkey.to_bytes(), // Account key at index 0
+                &mint_pubkey.to_bytes(),   // Account key at index 1
+            ],
+            &transfer_hook_program_id,
+        )
+        .0;
+        let mut extra_meta_1_data = vec![]; // Mock
+        let mut extra_meta_1_lamports = 0; // Mock
+        let extra_meta_1_account_info = AccountInfo::new(
+            &extra_meta_1_pubkey,
+            false,
+            true,
+            &mut extra_meta_1_lamports,
+            &mut extra_meta_1_data,
+            &transfer_hook_program_id,
+            false,
+            0,
+        );
+
+        let extra_meta_2_pubkey = Pubkey::find_program_address(
+            &[
+                &validate_state_pubkey.to_bytes(), // Account key at index 4
+            ],
+            &transfer_hook_program_id,
+        )
+        .0;
+        let mut extra_meta_2_data = vec![]; // Mock
+        let mut extra_meta_2_lamports = 0; // Mock
+        let extra_meta_2_account_info = AccountInfo::new(
+            &extra_meta_2_pubkey,
+            false,
+            true,
+            &mut extra_meta_2_lamports,
+            &mut extra_meta_2_data,
+            &transfer_hook_program_id,
+            false,
+            0,
+        );
+
+        let extra_meta_3_pubkey = Pubkey::find_program_address(
+            &[
+                b"prefix",
+                amount.to_le_bytes().as_ref(), // Instruction data 8..16
+            ],
+            &transfer_hook_program_id,
+        )
+        .0;
+        let mut extra_meta_3_data = vec![]; // Mock
+        let mut extra_meta_3_lamports = 0; // Mock
+        let extra_meta_3_account_info = AccountInfo::new(
+            &extra_meta_3_pubkey,
+            false,
+            true,
+            &mut extra_meta_3_lamports,
+            &mut extra_meta_3_data,
+            &transfer_hook_program_id,
+            false,
+            0,
+        );
+
+        let extra_meta_4_pubkey = Pubkey::new_from_array([7; 32]); // Some arbitrary program ID
+        let mut extra_meta_4_data = vec![]; // Mock
+        let mut extra_meta_4_lamports = 0; // Mock
+        let extra_meta_4_account_info = AccountInfo::new(
+            &extra_meta_4_pubkey,
+            false,
+            true,
+            &mut extra_meta_4_lamports,
+            &mut extra_meta_4_data,
+            &transfer_hook_program_id,
+            true, // Executable program
+            0,
+        );
+
+        let extra_meta_5_pubkey = Pubkey::find_program_address(
+            &[
+                b"prefix",
+                amount.to_le_bytes().as_ref(), // Instruction data 8..16
+                extra_meta_2_pubkey.as_ref(),
+            ],
+            &extra_meta_4_pubkey, // PDA off of the arbitrary program ID
+        )
+        .0;
+        let mut extra_meta_5_data = vec![]; // Mock
+        let mut extra_meta_5_lamports = 0; // Mock
+        let extra_meta_5_account_info = AccountInfo::new(
+            &extra_meta_5_pubkey,
+            false,
+            true,
+            &mut extra_meta_5_lamports,
+            &mut extra_meta_5_data,
+            &extra_meta_4_pubkey,
+            false,
+            0,
+        );
+
+        let extra_meta_6_pubkey = Pubkey::find_program_address(
+            &[
+                b"another_prefix",
+                amount.to_le_bytes().as_ref(), // Instruction data 8..16
+                extra_meta_2_pubkey.as_ref(),
+                extra_meta_5_pubkey.as_ref(),
+            ],
+            &extra_meta_4_pubkey, // PDA off of the arbitrary program ID
+        )
+        .0;
+        let mut extra_meta_6_data = vec![]; // Mock
+        let mut extra_meta_6_lamports = 0; // Mock
+        let extra_meta_6_account_info = AccountInfo::new(
+            &extra_meta_6_pubkey,
+            false,
+            true,
+            &mut extra_meta_6_lamports,
+            &mut extra_meta_6_data,
+            &extra_meta_4_pubkey,
+            false,
+            0,
+        );
+
+        let mut validate_state_data = MOCK_EXTRA_METAS_STATE.to_vec();
+        let mut validate_state_lamports = 0; // Mock
+        let validate_state_account_info = AccountInfo::new(
+            &validate_state_pubkey,
+            false,
+            true,
+            &mut validate_state_lamports,
+            &mut validate_state_data,
+            &transfer_hook_program_id,
+            false,
+            0,
+        );
+
+        // First use the resolve function to add the extra account metas to the
+        // transfer instruction from offchain
+        let mut offchain_transfer_instruction = crate::instruction::transfer_checked(
+            &spl_token_2022_program_id,
+            &source_pubkey,
+            &mint_pubkey,
+            &destination_pubkey,
+            &authority_pubkey,
+            &[],
+            amount,
+            9,
+        )
+        .unwrap();
+
+        resolve_extra_transfer_account_metas(
+            &mut offchain_transfer_instruction,
+            mock_fetch_account_data_fn,
+            &mint_pubkey,
+            amount,
+        )
+        .await
+        .unwrap();
+
+        // Then use the offchain function to add the extra account metas to the
+        // _execute_ instruction from offchain
+        let mut offchain_execute_instruction = spl_transfer_hook_interface::instruction::execute(
+            &transfer_hook_program_id,
+            &source_pubkey,
+            &mint_pubkey,
+            &destination_pubkey,
+            &authority_pubkey,
+            &validate_state_pubkey,
+            amount,
+        );
+
+        ExtraAccountMetaList::add_to_instruction::<ExecuteInstruction, _, _>(
+            &mut offchain_execute_instruction,
+            mock_fetch_account_data_fn,
+            &MOCK_EXTRA_METAS_STATE,
+        )
+        .await
+        .unwrap();
+
+        // Finally, use the onchain function to add the extra account metas to
+        // the _execute_ CPI instruction from onchain
+        let mut onchain_execute_cpi_instruction = spl_transfer_hook_interface::instruction::execute(
+            &transfer_hook_program_id,
+            &source_pubkey,
+            &mint_pubkey,
+            &destination_pubkey,
+            &authority_pubkey,
+            &validate_state_pubkey,
+            amount,
+        );
+        let mut onchain_execute_cpi_account_infos = vec![
+            source_account_info.clone(),
+            mint_account_info.clone(),
+            destination_account_info.clone(),
+            authority_account_info.clone(),
+            validate_state_account_info.clone(),
+        ];
+        let all_account_infos = &[
+            source_account_info.clone(),
+            mint_account_info.clone(),
+            destination_account_info.clone(),
+            authority_account_info.clone(),
+            validate_state_account_info.clone(),
+            extra_meta_1_account_info.clone(),
+            extra_meta_2_account_info.clone(),
+            extra_meta_3_account_info.clone(),
+            extra_meta_4_account_info.clone(),
+            extra_meta_5_account_info.clone(),
+            extra_meta_6_account_info.clone(),
+        ];
+
+        ExtraAccountMetaList::add_to_cpi_instruction::<ExecuteInstruction>(
+            &mut onchain_execute_cpi_instruction,
+            &mut onchain_execute_cpi_account_infos,
+            &MOCK_EXTRA_METAS_STATE,
+            all_account_infos,
+        )
+        .unwrap();
+
+        // The two `Execute` instructions should have the same accounts
+        assert_eq!(
+            offchain_execute_instruction.accounts,
+            onchain_execute_cpi_instruction.accounts,
+        );
+
+        // Still, the transfer instruction is going to be missing the
+        // the validation account at index 4
+        assert_ne!(
+            offchain_transfer_instruction.accounts,
+            offchain_execute_instruction.accounts,
+        );
+        assert_ne!(
+            offchain_transfer_instruction.accounts[4].pubkey,
+            validate_state_pubkey,
+        );
+
+        // Even though both execute instructions have the validation account
+        // at index 4
+        assert_eq!(
+            offchain_execute_instruction.accounts[4].pubkey,
+            validate_state_pubkey,
+        );
+        assert_eq!(
+            onchain_execute_cpi_instruction.accounts[4].pubkey,
+            validate_state_pubkey,
+        );
+
+        // The most important thing is verifying all PDAs are correct across
+        // all lists
+        // PDA 1
+        assert_eq!(
+            offchain_transfer_instruction.accounts[4].pubkey,
+            extra_meta_1_pubkey,
+        );
+        assert_eq!(
+            offchain_execute_instruction.accounts[5].pubkey,
+            extra_meta_1_pubkey,
+        );
+        assert_eq!(
+            onchain_execute_cpi_instruction.accounts[5].pubkey,
+            extra_meta_1_pubkey,
+        );
+        // PDA 2
+        assert_eq!(
+            offchain_transfer_instruction.accounts[5].pubkey,
+            extra_meta_2_pubkey,
+        );
+        assert_eq!(
+            offchain_execute_instruction.accounts[6].pubkey,
+            extra_meta_2_pubkey,
+        );
+        assert_eq!(
+            onchain_execute_cpi_instruction.accounts[6].pubkey,
+            extra_meta_2_pubkey,
+        );
+        // PDA 3
+        assert_eq!(
+            offchain_transfer_instruction.accounts[6].pubkey,
+            extra_meta_3_pubkey,
+        );
+        assert_eq!(
+            offchain_execute_instruction.accounts[7].pubkey,
+            extra_meta_3_pubkey,
+        );
+        assert_eq!(
+            onchain_execute_cpi_instruction.accounts[7].pubkey,
+            extra_meta_3_pubkey,
+        );
+        // PDA 4
+        assert_eq!(
+            offchain_transfer_instruction.accounts[7].pubkey,
+            extra_meta_4_pubkey,
+        );
+        assert_eq!(
+            offchain_execute_instruction.accounts[8].pubkey,
+            extra_meta_4_pubkey,
+        );
+        assert_eq!(
+            onchain_execute_cpi_instruction.accounts[8].pubkey,
+            extra_meta_4_pubkey,
+        );
+        // PDA 5
+        assert_eq!(
+            offchain_transfer_instruction.accounts[8].pubkey,
+            extra_meta_5_pubkey,
+        );
+        assert_eq!(
+            offchain_execute_instruction.accounts[9].pubkey,
+            extra_meta_5_pubkey,
+        );
+        assert_eq!(
+            onchain_execute_cpi_instruction.accounts[9].pubkey,
+            extra_meta_5_pubkey,
+        );
+        // PDA 6
+        assert_eq!(
+            offchain_transfer_instruction.accounts[9].pubkey,
+            extra_meta_6_pubkey,
+        );
+        assert_eq!(
+            offchain_execute_instruction.accounts[10].pubkey,
+            extra_meta_6_pubkey,
+        );
+        assert_eq!(
+            onchain_execute_cpi_instruction.accounts[10].pubkey,
+            extra_meta_6_pubkey,
+        );
+    }
+}

--- a/token/program-2022/src/onchain.rs
+++ b/token/program-2022/src/onchain.rs
@@ -139,3 +139,519 @@ pub fn invoke_transfer_checked<'a>(
 
     invoke_signed(&cpi_instruction, &cpi_account_infos, seeds)
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        solana_program::system_program,
+        solana_program_test::tokio,
+        spl_tlv_account_resolution::state::{AccountDataResult, ExtraAccountMetaList},
+        spl_transfer_hook_interface::instruction::ExecuteInstruction,
+    };
+
+    const TRANSFER_HOOK_PROGRAM_ID: Pubkey = Pubkey::new_from_array([1; 32]);
+
+    const MINT_PUBKEY: Pubkey = Pubkey::new_from_array([2; 32]);
+
+    const MOCK_MINT_STATE: [u8; 234] = [
+        0, 0, 0, 0, // COption (4): None = 0
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, // Mint authority (32)
+        0, 0, 0, 0, 0, 0, 0, 0, // Supply (8)
+        0, // Decimals (1)
+        1, // Is initialized (1)
+        0, 0, 0, 0, // COption (4): None = 0
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, // Freeze authority (32)
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // Padding (83)
+        1, // Account type (1): Mint = 1
+        14, 0, // Extension type (2): Transfer hook = 14
+        64, 0, // Extension length (2): 64
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, // Authority (32)
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, // Transfer hook program ID (32)
+    ];
+
+    const MOCK_EXTRA_METAS_STATE: [u8; 226] = [
+        105, 37, 101, 197, 75, 251, 102, 26, // Discriminator for `ExecuteInstruction` (8)
+        214, 0, 0, 0, // Length of pod slice (4): 214
+        6, 0, 0, 0, // Count of account metas (4): 6
+        1, // First account meta discriminator (1): PDA = 1
+        3, 0, // First seed: Account key at index 0 (2)
+        3, 1, // Second seed: Account key at index 1 (2)
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, // No more seeds (28)
+        0, // First account meta is signer (1): false = 0
+        0, // First account meta is writable (1): false = 0
+        1, // Second account meta discriminator (1): PDA = 1
+        3, 4, // First seed: Account key at index 4 (2)
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, // No more seeds (30)
+        0, // Second account meta is signer (1): false = 0
+        0, // Second account meta is writable (1): false = 0
+        1, // Third account meta discriminator (1): PDA = 1
+        1, 6, 112, 114, 101, 102, 105, 120, // First seed: Literal "prefix" (8)
+        2, 8, 8, // Second seed: Instruction data 8..16 (3)
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // No more seeds (21)
+        0, // Third account meta is signer (1): false = 0
+        0, // Third account meta is writable (1): false = 0
+        0, // Fourth account meta discriminator (1): Pubkey = 0
+        7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+        7, 7,   // Pubkey (32)
+        0,   // Fourth account meta is signer (1): false = 0
+        0,   // Fourth account meta is writable (1): false = 0
+        136, // Fifth account meta discriminator (1): External PDA = 128 + index 8 = 136
+        1, 6, 112, 114, 101, 102, 105, 120, // First seed: Literal "prefix" (8)
+        2, 8, 8, // Second seed: Instruction data 8..16 (3)
+        3, 6, // Third seed: Account key at index 6 (2)
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   // No more seeds (19)
+        0,   // Fifth account meta is signer (1): false = 0
+        0,   // Fifth account meta is writable (1): false = 0
+        136, // Sixth account meta discriminator (1): External PDA = 128 + index 8 = 136
+        1, 14, 97, 110, 111, 116, 104, 101, 114, 95, 112, 114, 101, 102, 105,
+        120, // First seed: Literal "another_prefix" (16)
+        2, 8, 8, // Second seed: Instruction data 8..16 (3)
+        3, 6, // Third seed: Account key at index 6 (2)
+        3, 9, // Fourth seed: Account key at index 9 (2)
+        0, 0, 0, 0, 0, 0, 0, 0, 0, // No more seeds (9)
+        0, // Sixth account meta is signer (1): false = 0
+        0, // Sixth account meta is writable (1): false = 0
+    ];
+
+    async fn mock_fetch_account_data_fn(address: Pubkey) -> AccountDataResult {
+        if address == MINT_PUBKEY {
+            Ok(Some(MOCK_MINT_STATE.to_vec()))
+        } else if address
+            == get_extra_account_metas_address(&MINT_PUBKEY, &TRANSFER_HOOK_PROGRAM_ID)
+        {
+            Ok(Some(MOCK_EXTRA_METAS_STATE.to_vec()))
+        } else {
+            Ok(None)
+        }
+    }
+
+    #[tokio::test]
+    async fn test_resolve_extra_transfer_account_metas_for_cpi() {
+        let spl_token_2022_program_id = crate::id();
+        let transfer_hook_program_id = TRANSFER_HOOK_PROGRAM_ID;
+        let amount = 2u64;
+
+        let source_pubkey = Pubkey::new_unique();
+        let mut source_data = vec![0; 165]; // Mock
+        let mut source_lamports = 0; // Mock
+        let source_account_info = AccountInfo::new(
+            &source_pubkey,
+            false,
+            true,
+            &mut source_lamports,
+            &mut source_data,
+            &spl_token_2022_program_id,
+            false,
+            0,
+        );
+
+        let mint_pubkey = MINT_PUBKEY;
+        let mut mint_data = MOCK_MINT_STATE.to_vec();
+        let mut mint_lamports = 0; // Mock
+        let mint_account_info = AccountInfo::new(
+            &mint_pubkey,
+            false,
+            true,
+            &mut mint_lamports,
+            &mut mint_data,
+            &spl_token_2022_program_id,
+            false,
+            0,
+        );
+
+        let destination_pubkey = Pubkey::new_unique();
+        let mut destination_data = vec![0; 165]; // Mock
+        let mut destination_lamports = 0; // Mock
+        let destination_account_info = AccountInfo::new(
+            &destination_pubkey,
+            false,
+            true,
+            &mut destination_lamports,
+            &mut destination_data,
+            &spl_token_2022_program_id,
+            false,
+            0,
+        );
+
+        let authority_pubkey = Pubkey::new_unique();
+        let mut authority_data = vec![]; // Mock
+        let mut authority_lamports = 0; // Mock
+        let authority_account_info = AccountInfo::new(
+            &authority_pubkey,
+            false,
+            true,
+            &mut authority_lamports,
+            &mut authority_data,
+            &system_program::ID,
+            false,
+            0,
+        );
+
+        let validate_state_pubkey =
+            get_extra_account_metas_address(&mint_pubkey, &transfer_hook_program_id);
+
+        let extra_meta_1_pubkey = Pubkey::find_program_address(
+            &[
+                &source_pubkey.to_bytes(), // Account key at index 0
+                &mint_pubkey.to_bytes(),   // Account key at index 1
+            ],
+            &transfer_hook_program_id,
+        )
+        .0;
+        let mut extra_meta_1_data = vec![]; // Mock
+        let mut extra_meta_1_lamports = 0; // Mock
+        let extra_meta_1_account_info = AccountInfo::new(
+            &extra_meta_1_pubkey,
+            false,
+            true,
+            &mut extra_meta_1_lamports,
+            &mut extra_meta_1_data,
+            &transfer_hook_program_id,
+            false,
+            0,
+        );
+
+        let extra_meta_2_pubkey = Pubkey::find_program_address(
+            &[
+                &validate_state_pubkey.to_bytes(), // Account key at index 4
+            ],
+            &transfer_hook_program_id,
+        )
+        .0;
+        let mut extra_meta_2_data = vec![]; // Mock
+        let mut extra_meta_2_lamports = 0; // Mock
+        let extra_meta_2_account_info = AccountInfo::new(
+            &extra_meta_2_pubkey,
+            false,
+            true,
+            &mut extra_meta_2_lamports,
+            &mut extra_meta_2_data,
+            &transfer_hook_program_id,
+            false,
+            0,
+        );
+
+        let extra_meta_3_pubkey = Pubkey::find_program_address(
+            &[
+                b"prefix",
+                amount.to_le_bytes().as_ref(), // Instruction data 8..16
+            ],
+            &transfer_hook_program_id,
+        )
+        .0;
+        let mut extra_meta_3_data = vec![]; // Mock
+        let mut extra_meta_3_lamports = 0; // Mock
+        let extra_meta_3_account_info = AccountInfo::new(
+            &extra_meta_3_pubkey,
+            false,
+            true,
+            &mut extra_meta_3_lamports,
+            &mut extra_meta_3_data,
+            &transfer_hook_program_id,
+            false,
+            0,
+        );
+
+        let extra_meta_4_pubkey = Pubkey::new_from_array([7; 32]); // Some arbitrary program ID
+        let mut extra_meta_4_data = vec![]; // Mock
+        let mut extra_meta_4_lamports = 0; // Mock
+        let extra_meta_4_account_info = AccountInfo::new(
+            &extra_meta_4_pubkey,
+            false,
+            true,
+            &mut extra_meta_4_lamports,
+            &mut extra_meta_4_data,
+            &transfer_hook_program_id,
+            true, // Executable program
+            0,
+        );
+
+        let extra_meta_5_pubkey = Pubkey::find_program_address(
+            &[
+                b"prefix",
+                amount.to_le_bytes().as_ref(), // Instruction data 8..16
+                extra_meta_2_pubkey.as_ref(),
+            ],
+            &extra_meta_4_pubkey, // PDA off of the arbitrary program ID
+        )
+        .0;
+        let mut extra_meta_5_data = vec![]; // Mock
+        let mut extra_meta_5_lamports = 0; // Mock
+        let extra_meta_5_account_info = AccountInfo::new(
+            &extra_meta_5_pubkey,
+            false,
+            true,
+            &mut extra_meta_5_lamports,
+            &mut extra_meta_5_data,
+            &extra_meta_4_pubkey,
+            false,
+            0,
+        );
+
+        let extra_meta_6_pubkey = Pubkey::find_program_address(
+            &[
+                b"another_prefix",
+                amount.to_le_bytes().as_ref(), // Instruction data 8..16
+                extra_meta_2_pubkey.as_ref(),
+                extra_meta_5_pubkey.as_ref(),
+            ],
+            &extra_meta_4_pubkey, // PDA off of the arbitrary program ID
+        )
+        .0;
+        let mut extra_meta_6_data = vec![]; // Mock
+        let mut extra_meta_6_lamports = 0; // Mock
+        let extra_meta_6_account_info = AccountInfo::new(
+            &extra_meta_6_pubkey,
+            false,
+            true,
+            &mut extra_meta_6_lamports,
+            &mut extra_meta_6_data,
+            &extra_meta_4_pubkey,
+            false,
+            0,
+        );
+
+        let mut validate_state_data = MOCK_EXTRA_METAS_STATE.to_vec();
+        let mut validate_state_lamports = 0; // Mock
+        let validate_state_account_info = AccountInfo::new(
+            &validate_state_pubkey,
+            false,
+            true,
+            &mut validate_state_lamports,
+            &mut validate_state_data,
+            &transfer_hook_program_id,
+            false,
+            0,
+        );
+
+        let mut transfer_hook_program_data = vec![]; // Mock
+        let mut transfer_hook_program_lamports = 0; // Mock
+        let transfer_hook_program_info = AccountInfo::new(
+            &transfer_hook_program_id,
+            false,
+            true,
+            &mut transfer_hook_program_lamports,
+            &mut transfer_hook_program_data,
+            &system_program::ID,
+            true, // Executable program
+            0,
+        );
+
+        // First use the resolve function to add the extra account metas to the
+        // transfer instruction from onchain
+        let mut onchain_transfer_cpi_instruction = crate::instruction::transfer_checked(
+            &spl_token_2022_program_id,
+            &source_pubkey,
+            &mint_pubkey,
+            &destination_pubkey,
+            &authority_pubkey,
+            &[],
+            amount,
+            9,
+        )
+        .unwrap();
+        let mut onchain_transfer_cpi_account_infos = vec![
+            source_account_info.clone(),
+            mint_account_info.clone(),
+            destination_account_info.clone(),
+            authority_account_info.clone(),
+        ];
+        let onchain_transfer_additional_account_infos = vec![
+            extra_meta_1_account_info.clone(),
+            extra_meta_2_account_info.clone(),
+            extra_meta_3_account_info.clone(),
+            extra_meta_4_account_info.clone(),
+            extra_meta_5_account_info.clone(),
+            extra_meta_6_account_info.clone(),
+            validate_state_account_info.clone(),
+            transfer_hook_program_info.clone(),
+        ];
+
+        resolve_extra_transfer_account_metas_for_cpi(
+            &mut onchain_transfer_cpi_instruction,
+            &mut onchain_transfer_cpi_account_infos,
+            &mint_account_info,
+            &onchain_transfer_additional_account_infos,
+            amount,
+        )
+        .unwrap();
+
+        // Then use the offchain function to add the extra account metas to the
+        // _execute_ instruction from offchain
+        let mut offchain_execute_instruction = spl_transfer_hook_interface::instruction::execute(
+            &transfer_hook_program_id,
+            &source_pubkey,
+            &mint_pubkey,
+            &destination_pubkey,
+            &authority_pubkey,
+            &validate_state_pubkey,
+            amount,
+        );
+
+        ExtraAccountMetaList::add_to_instruction::<ExecuteInstruction, _, _>(
+            &mut offchain_execute_instruction,
+            mock_fetch_account_data_fn,
+            &MOCK_EXTRA_METAS_STATE,
+        )
+        .await
+        .unwrap();
+
+        // Finally, use the onchain function to add the extra account metas to
+        // the _execute_ CPI instruction from onchain
+        let mut onchain_execute_cpi_instruction = spl_transfer_hook_interface::instruction::execute(
+            &transfer_hook_program_id,
+            &source_pubkey,
+            &mint_pubkey,
+            &destination_pubkey,
+            &authority_pubkey,
+            &validate_state_pubkey,
+            amount,
+        );
+        let mut onchain_execute_cpi_account_infos = vec![
+            source_account_info.clone(),
+            mint_account_info.clone(),
+            destination_account_info.clone(),
+            authority_account_info.clone(),
+            validate_state_account_info.clone(),
+        ];
+        let all_account_infos = &[
+            source_account_info.clone(),
+            mint_account_info.clone(),
+            destination_account_info.clone(),
+            authority_account_info.clone(),
+            validate_state_account_info.clone(),
+            extra_meta_1_account_info.clone(),
+            extra_meta_2_account_info.clone(),
+            extra_meta_3_account_info.clone(),
+            extra_meta_4_account_info.clone(),
+            extra_meta_5_account_info.clone(),
+            extra_meta_6_account_info.clone(),
+        ];
+
+        ExtraAccountMetaList::add_to_cpi_instruction::<ExecuteInstruction>(
+            &mut onchain_execute_cpi_instruction,
+            &mut onchain_execute_cpi_account_infos,
+            &MOCK_EXTRA_METAS_STATE,
+            all_account_infos,
+        )
+        .unwrap();
+
+        // The two `Execute` instructions should have the same accounts
+        assert_eq!(
+            offchain_execute_instruction.accounts,
+            onchain_execute_cpi_instruction.accounts,
+        );
+
+        // Still, the transfer instruction is going to be missing the
+        // the validation account at index 4
+        assert_ne!(
+            onchain_transfer_cpi_instruction.accounts,
+            offchain_execute_instruction.accounts,
+        );
+        assert_ne!(
+            onchain_transfer_cpi_instruction.accounts[4].pubkey,
+            validate_state_pubkey,
+        );
+
+        // Even though both execute instructions have the validation account
+        // at index 4
+        assert_eq!(
+            offchain_execute_instruction.accounts[4].pubkey,
+            validate_state_pubkey,
+        );
+        assert_eq!(
+            onchain_execute_cpi_instruction.accounts[4].pubkey,
+            validate_state_pubkey,
+        );
+
+        // The most important thing is verifying all PDAs are correct across
+        // all lists
+        // PDA 1
+        assert_eq!(
+            onchain_transfer_cpi_instruction.accounts[4].pubkey,
+            extra_meta_1_pubkey,
+        );
+        assert_eq!(
+            offchain_execute_instruction.accounts[5].pubkey,
+            extra_meta_1_pubkey,
+        );
+        assert_eq!(
+            onchain_execute_cpi_instruction.accounts[5].pubkey,
+            extra_meta_1_pubkey,
+        );
+        // PDA 2
+        assert_eq!(
+            onchain_transfer_cpi_instruction.accounts[5].pubkey,
+            extra_meta_2_pubkey,
+        );
+        assert_eq!(
+            offchain_execute_instruction.accounts[6].pubkey,
+            extra_meta_2_pubkey,
+        );
+        assert_eq!(
+            onchain_execute_cpi_instruction.accounts[6].pubkey,
+            extra_meta_2_pubkey,
+        );
+        // PDA 3
+        assert_eq!(
+            onchain_transfer_cpi_instruction.accounts[6].pubkey,
+            extra_meta_3_pubkey,
+        );
+        assert_eq!(
+            offchain_execute_instruction.accounts[7].pubkey,
+            extra_meta_3_pubkey,
+        );
+        assert_eq!(
+            onchain_execute_cpi_instruction.accounts[7].pubkey,
+            extra_meta_3_pubkey,
+        );
+        // PDA 4
+        assert_eq!(
+            onchain_transfer_cpi_instruction.accounts[7].pubkey,
+            extra_meta_4_pubkey,
+        );
+        assert_eq!(
+            offchain_execute_instruction.accounts[8].pubkey,
+            extra_meta_4_pubkey,
+        );
+        assert_eq!(
+            onchain_execute_cpi_instruction.accounts[8].pubkey,
+            extra_meta_4_pubkey,
+        );
+        // PDA 5
+        assert_eq!(
+            onchain_transfer_cpi_instruction.accounts[8].pubkey,
+            extra_meta_5_pubkey,
+        );
+        assert_eq!(
+            offchain_execute_instruction.accounts[9].pubkey,
+            extra_meta_5_pubkey,
+        );
+        assert_eq!(
+            onchain_execute_cpi_instruction.accounts[9].pubkey,
+            extra_meta_5_pubkey,
+        );
+        // PDA 6
+        assert_eq!(
+            onchain_transfer_cpi_instruction.accounts[9].pubkey,
+            extra_meta_6_pubkey,
+        );
+        assert_eq!(
+            offchain_execute_instruction.accounts[10].pubkey,
+            extra_meta_6_pubkey,
+        );
+        assert_eq!(
+            onchain_execute_cpi_instruction.accounts[10].pubkey,
+            extra_meta_6_pubkey,
+        );
+    }
+}

--- a/token/program-2022/src/onchain.rs
+++ b/token/program-2022/src/onchain.rs
@@ -3,19 +3,91 @@
 
 use {
     crate::{
+        error::TokenError,
         extension::{transfer_hook, StateWithExtensions},
         instruction,
         state::Mint,
     },
     solana_program::{
-        account_info::AccountInfo, entrypoint::ProgramResult, instruction::AccountMeta,
-        program::invoke_signed, pubkey::Pubkey,
+        account_info::AccountInfo,
+        entrypoint::ProgramResult,
+        instruction::{AccountMeta, Instruction},
+        msg,
+        program::invoke_signed,
+        program_error::ProgramError,
+        pubkey::Pubkey,
     },
-    spl_transfer_hook_interface::onchain::add_cpi_accounts_for_execute,
+    spl_transfer_hook_interface::{
+        error::TransferHookError, get_extra_account_metas_address,
+        onchain::add_cpi_accounts_for_execute,
+    },
 };
 
+/// Onchain helper to get all additional required account metas for a checked
+/// transfer
+///
+/// Note that this onchain helper will build a new `Execute` instruction,
+/// resolve the extra account metas, and then add them to the transfer
+/// instruction. This is because the extra account metas are configured
+/// specifically for the `Execute` instruction, which requires five accounts
+/// (source, mint, destination, authority, and validation state), wheras the
+/// transfer instruction only requires four (source, mint, destination, and
+/// authority) in addition to `n` number of multisig authorities.
+pub fn resolve_extra_transfer_account_metas_for_cpi<'a>(
+    cpi_instruction: &mut Instruction,
+    cpi_account_infos: &mut Vec<AccountInfo<'a>>,
+    mint_info: &AccountInfo<'a>,
+    additional_accounts: &[AccountInfo<'a>],
+    amount: u64,
+) -> Result<(), ProgramError> {
+    let mint_data = mint_info.try_borrow_data()?;
+    let mint = StateWithExtensions::<Mint>::unpack(&mint_data)?;
+    if let Some(program_id) = transfer_hook::get_program_id(&mint) {
+        // Convert the transfer instruction into an `Execute` instruction,
+        // then resolve the extra account metas as configured in the validation
+        // account data, then finally add the extra account metas to the original
+        // transfer instruction.
+        if cpi_instruction.accounts.len() < 4 {
+            msg!("Not a valid transfer instruction");
+            Err(TokenError::InvalidInstruction)?;
+        }
+
+        let validation_pubkey = get_extra_account_metas_address(mint_info.key, &program_id);
+        let validation_info = additional_accounts
+            .iter()
+            .find(|&x| *x.key == validation_pubkey)
+            .ok_or(TransferHookError::IncorrectAccount)?;
+
+        let mut execute_ix = spl_transfer_hook_interface::instruction::execute(
+            &program_id,
+            &cpi_instruction.accounts[0].pubkey,
+            &cpi_instruction.accounts[1].pubkey,
+            &cpi_instruction.accounts[2].pubkey,
+            &cpi_instruction.accounts[3].pubkey,
+            &validation_pubkey,
+            amount,
+        );
+
+        cpi_account_infos.push(validation_info.clone());
+
+        add_cpi_accounts_for_execute(
+            &mut execute_ix,
+            cpi_account_infos,
+            mint_info.key,
+            &program_id,
+            additional_accounts,
+        )?;
+
+        cpi_instruction
+            .accounts
+            .extend_from_slice(&execute_ix.accounts[5..]);
+    }
+    Ok(())
+}
+
 /// Helper to CPI into token-2022 on-chain, looking through the additional
-/// account infos to create the proper instruction with the proper account infos
+/// account infos to create the proper instruction with the proper account
+/// infos.
 #[allow(clippy::too_many_arguments)]
 pub fn invoke_transfer_checked<'a>(
     token_program_id: &Pubkey,
@@ -57,20 +129,13 @@ pub fn invoke_transfer_checked<'a>(
                 .push(AccountMeta::new_readonly(*ai.key, ai.is_signer));
         });
 
-    // scope the borrowing to avoid a double-borrow during CPI
-    {
-        let mint_data = mint_info.try_borrow_data()?;
-        let mint = StateWithExtensions::<Mint>::unpack(&mint_data)?;
-        if let Some(program_id) = transfer_hook::get_program_id(&mint) {
-            add_cpi_accounts_for_execute(
-                &mut cpi_instruction,
-                &mut cpi_account_infos,
-                mint_info.key,
-                &program_id,
-                additional_accounts,
-            )?;
-        }
-    }
+    resolve_extra_transfer_account_metas_for_cpi(
+        &mut cpi_instruction,
+        &mut cpi_account_infos,
+        &mint_info,
+        additional_accounts,
+        amount,
+    )?;
 
     invoke_signed(&cpi_instruction, &cpi_account_infos, seeds)
 }


### PR DESCRIPTION
This PR introduces some modifications to Token2022's off-chain and on-chain helpers that simply convert a transfer instruction into an `Execute` instruction before resolving the extra account metas.

Since anyone storing extra account meta configs should be considering the list of accounts as it will arrive in their Transfer Hook program's `Execute` instruction, it makes sense to resolve for `Execute`.

After all, the main problem we have here is that we're asking TLV Account Resolution to resolve the extra account metas for an `Execute` instruction, but we're not actually feeding it a valid `Execute` instruction. Instead, we're feeding it a transfer instruction, typically `TransferChecked`.

I've also added some tests!

Closes #6064 

---
#### A Note on Token2022 Release
A release is necessary to publish this bugfix. However, since this change is specific to Token2022's off-chain and on-chain helpers, the on-chain program does not need to be modified. Developers will simply need to use the newer version of the crate, as well as the newer versions of the Token Client and CLI if they'd like to use the repaired helpers.

We can communicate the bug in question by describing the exact use cases one may encounter issues:
- Defining extra account metas that have seed configurations pointing to instruction data by index
- Defining extra account metas that have seed configurations pointing to other extra account metas by index (_not_ instruction accounts; these will work just fine)

This means the following extra account meta configurations will still work as expected:
- Defining extra account metas that have fixed addresses
- Defining extra account metas that have seed configurations with literal bytes

Also, while we're at it, I think we need to publish some extremely detailed documentation on how to use Transfer Hook extra metas.