### PR TITLE
psuedo-bump transfer hook CLI to 0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7651,7 +7651,7 @@ dependencies = [
 
 [[package]]
 name = "spl-transfer-hook-cli"
-version = "0.2.0"
+version = "0.1.0"
 dependencies = [
  "clap 3.2.25",
  "futures-util",

--- a/token/transfer-hook/cli/Cargo.toml
+++ b/token/transfer-hook/cli/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://spl.solana.com/token"
 license = "Apache-2.0"
 name = "spl-transfer-hook-cli"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "0.2.0"
+version = "0.1.0"
 
 [dependencies]
 clap = { version = "3", features = ["cargo"] }


### PR DESCRIPTION
So, we've made some minor enhancements to the Transfer Hook CLI over the last few months, and we've never actually published a crate beyond the `0.0.1` placeholder.

This PR reverts the crate version for Transfer Hook CLI back to `0.1.0` in preparation for it's first release.

After this PR goes in, I'll cut a tag and release for `0.1.0` with the significant enhancements mentioned.