### PR TITLE
tlv account resolution: bump to include serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7256,7 +7256,7 @@ dependencies = [
 
 [[package]]
 name = "spl-tlv-account-resolution"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bytemuck",
  "futures 0.3.30",
@@ -7665,7 +7665,7 @@ dependencies = [
  "solana-remote-wallet",
  "solana-sdk",
  "solana-test-validator",
- "spl-tlv-account-resolution 0.5.0",
+ "spl-tlv-account-resolution 0.5.1",
  "spl-token-2022 1.0.0",
  "spl-token-client",
  "spl-transfer-hook-interface 0.4.1",
@@ -7682,7 +7682,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-tlv-account-resolution 0.5.0",
+ "spl-tlv-account-resolution 0.5.1",
  "spl-token-2022 1.0.0",
  "spl-transfer-hook-interface 0.4.1",
  "spl-type-length-value 0.3.0",
@@ -7714,7 +7714,7 @@ dependencies = [
  "spl-discriminator 0.1.0",
  "spl-pod 0.1.0",
  "spl-program-error 0.3.0",
- "spl-tlv-account-resolution 0.5.0",
+ "spl-tlv-account-resolution 0.5.1",
  "spl-type-length-value 0.3.0",
 ]
 

--- a/libraries/tlv-account-resolution/Cargo.toml
+++ b/libraries/tlv-account-resolution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-tlv-account-resolution"
-version = "0.5.0"
+version = "0.5.1"
 description = "Solana Program Library TLV Account Resolution Interface"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token/transfer-hook/cli/Cargo.toml
+++ b/token/transfer-hook/cli/Cargo.toml
@@ -18,7 +18,7 @@ solana-logger = "=1.17.6"
 solana-remote-wallet = "=1.17.6"
 solana-sdk = "=1.17.6"
 spl-transfer-hook-interface = { version = "0.4", path = "../interface" }
-spl-tlv-account-resolution = { version = "0.5" , path = "../../../libraries/tlv-account-resolution", features = ["serde-traits"] }
+spl-tlv-account-resolution = { version = "0.5.1" , path = "../../../libraries/tlv-account-resolution", features = ["serde-traits"] }
 strum = "0.25"
 strum_macros = "0.25"
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
Bumps TLC Account Resolution's patch version to include the new `serde-traits` feature. Backwards compatible without the feature, so we shouldn't need a minor release (?).