### PR TITLE
docs: Specify that token-2022 is ready and eligible for bounties

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,13 +51,10 @@ the Solana Mainnet Beta. Currently, this includes:
 * [name-service](https://github.com/solana-labs/solana-program-library/tree/master/name-service/program)
 * [stake-pool](https://github.com/solana-labs/solana-program-library/tree/master/stake-pool/program)
 * [token](https://github.com/solana-labs/solana-program-library/tree/master/token/program)
+* [token-2022](https://github.com/solana-labs/solana-program-library/tree/master/token/program-2022)
 
 If you discover a critical security issue in an out-of-scope program, your finding
 may still be valuable.
-
-[token-2022](https://github.com/solana-labs/solana-program-library/tree/master/token/program-2022)
-is still under audit and not meant for full production use. In the meantime, all
-clusters have the latest program deployed **for testing and development purposes ONLY**.
 
 Many programs, including
 [token-swap](https://github.com/solana-labs/solana-program-library/tree/master/token-swap/program)

--- a/docs/src/token-2022.md
+++ b/docs/src/token-2022.md
@@ -8,13 +8,6 @@ fungible and non-fungible tokens.
 The Token-2022 Program is a superset of the functionality provided by the
 [Token Program](token.mdx).
 
-The program is ready for full production use. All clusters have the latest
-program deployed **without confidential transfer functionality**.
-
-The program with confidential transfer functionality will be deployed once
-Solana v1.17 reaches mainnet-beta with the appropriate syscalls enabled. See the
-[Project Status](token-2022/status.md) for more information.
-
 | Information | Account Address |
 | --- | --- |
 | Token-2022 Program | `TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb` |
@@ -141,8 +134,8 @@ For information about the types and instructions, the Rust docs are available at
 
 ## Security Audits
 
-The Token-2022 Program has been audited multiple times to ensure safety of
-funds. All audits are published here as they are completed.
+The Token-2022 Program has been audited multiple times. All audits are published
+here as they are completed.
 
 Here are the completed audits as of 13 December 2023:
 

--- a/docs/src/token-2022.md
+++ b/docs/src/token-2022.md
@@ -8,9 +8,12 @@ fungible and non-fungible tokens.
 The Token-2022 Program is a superset of the functionality provided by the
 [Token Program](token.mdx).
 
-The program is still under audit and not meant for full production use. In the
-meantime, all clusters have the latest program deployed **for testing and development
-purposes ONLY**.
+The program is ready for full production use. All clusters have the latest
+program deployed **without confidential transfer functionality**.
+
+The program with confidential transfer functionality will be deployed once
+Solana v1.17 reaches mainnet-beta with the appropriate syscalls enabled. See the
+[Project Status](token-2022/status.md) for more information.
 
 | Information | Account Address |
 | --- | --- |
@@ -138,8 +141,8 @@ For information about the types and instructions, the Rust docs are available at
 
 ## Security Audits
 
-The Token-2022 Program is currently under multiple audits to ensure safety of
-funds. All audits will be published here as they are completed.
+The Token-2022 Program has been audited multiple times to ensure safety of
+funds. All audits are published here as they are completed.
 
 Here are the completed audits as of 13 December 2023:
 

--- a/docs/src/token-2022/status.md
+++ b/docs/src/token-2022/status.md
@@ -2,9 +2,11 @@
 title: Project Status
 ---
 
-The Token-2022 program is still under audit and not meant for full production use.
-In the meantime, all clusters have the latest program deployed **for testing and
-development purposes ONLY**.
+The Token-2022 program is ready for full production use. All clusters have the
+latest program deployed **without confidential transfer functionality**.
+
+The program with confidential transfer functionality will be deployed once
+Solana v1.17 reaches mainnet-beta with the appropriate syscalls enabled.
 
 ## Timeline
 
@@ -12,7 +14,6 @@ Here is the general program timeline and rough ETAs:
 
 | Issue                       | ETA                            |
 | --------------------------- | ------------------------------ |
-| Code-complete & final audit | Fall 2023                      |
 | Mainnet recommendation      | Winter 2024 (depends on v1.17) |
 | More ZK features            | Spring 2024 (depends on v1.18) |
 | Freeze program              | 2024                           |
@@ -34,13 +35,6 @@ In order to use confidential tokens, the cluster must run at least version 1.17
 with the ZK Token proof program enabled.
 
 More information: https://github.com/solana-labs/solana/pull/32613
-
-The ZK Token proof program was recently updated to support the splitting of
-the longer zero-knowledge proofs into smaller components. The
-token-2022 program is in the process of active development to properly process
-the new proof format.
-
-More information: https://github.com/solana-labs/solana-program-library/issues/4817
 
 ## Future work
 

--- a/docs/src/token-2022/status.md
+++ b/docs/src/token-2022/status.md
@@ -2,8 +2,8 @@
 title: Project Status
 ---
 
-The Token-2022 program is ready for full production use. All clusters have the
-latest program deployed **without confidential transfer functionality**.
+All clusters have the latest program deployed **without confidential transfer
+functionality**.
 
 The program with confidential transfer functionality will be deployed once
 Solana v1.17 reaches mainnet-beta with the appropriate syscalls enabled.


### PR DESCRIPTION
#### Problem

Token-2022 has finished its audits for version 1.0.0, making it eligible for bug bounties, but the documentation is out of date.

#### Solution

Say that token-2022 is ready!