### PR TITLE
token js: add variable length extension support to `getMintLen`

### DIFF
--- a/token/js/src/extensions/extensionType.ts
+++ b/token/js/src/extensions/extensionType.ts
@@ -188,29 +188,26 @@ export function getAccountTypeOfMintType(e: ExtensionType): ExtensionType {
 function getLen(
     extensionTypes: ExtensionType[],
     baseSize: number,
-    variableLengthExtensions?: [ExtensionType, number][]
+    variableLengthExtensions: { [E in ExtensionType]?: number } = {}
 ): number {
-    if (extensionTypes.length === 0) {
+    if (extensionTypes.length === 0 && Object.keys(variableLengthExtensions).length === 0) {
         return baseSize;
     } else {
-        let accountLength =
+        const accountLength =
             ACCOUNT_SIZE +
             ACCOUNT_TYPE_SIZE +
             extensionTypes
                 .filter((element, i) => i === extensionTypes.indexOf(element))
                 .map((element) => addTypeAndLengthToLen(getTypeLen(element)))
-                .reduce((a, b) => a + b);
-        if (variableLengthExtensions) {
-            accountLength += variableLengthExtensions
-                .filter((element, i) => i === variableLengthExtensions.indexOf(element))
+                .reduce((a, b) => a + b, 0) +
+            Object.entries(variableLengthExtensions)
                 .map(([extension, len]) => {
-                    if (!isVariableLengthExtension(extension)) {
+                    if (!isVariableLengthExtension(Number(extension))) {
                         throw Error(`Extension ${extension} is not variable length`);
                     }
                     return addTypeAndLengthToLen(len);
                 })
-                .reduce((a, b) => a + b);
-        }
+                .reduce((a, b) => a + b, 0);
         if (accountLength === MULTISIG_SIZE) {
             return accountLength + TYPE_SIZE;
         } else {
@@ -221,7 +218,7 @@ function getLen(
 
 export function getMintLen(
     extensionTypes: ExtensionType[],
-    variableLengthExtensions?: [ExtensionType, number][]
+    variableLengthExtensions: { [E in ExtensionType]?: number } = {}
 ): number {
     return getLen(extensionTypes, MINT_SIZE, variableLengthExtensions);
 }

--- a/token/js/test/unit/index.test.ts
+++ b/token/js/test/unit/index.test.ts
@@ -248,17 +248,20 @@ describe('extensionType', () => {
         expect(getMintLen([ExtensionType.TransferHook])).to.eql(234);
         expect(getMintLen([ExtensionType.MetadataPointer])).to.eql(234);
         expect(
-            getMintLen(
-                [ExtensionType.TransferFeeConfig, ExtensionType.NonTransferable],
-                [[ExtensionType.TokenMetadata, 200]]
-            )
+            getMintLen([ExtensionType.TransferFeeConfig, ExtensionType.NonTransferable], {
+                [ExtensionType.TokenMetadata]: 200,
+            })
         ).to.eql(486);
+        expect(
+            getMintLen([], {
+                [ExtensionType.TokenMetadata]: 200,
+            })
+        ).to.eql(370);
         // Should error on an extension that isn't variable-length
         expect(() =>
-            getMintLen(
-                [ExtensionType.TransferFeeConfig, ExtensionType.NonTransferable],
-                [[ExtensionType.TransferHook, 200]]
-            )
+            getMintLen([ExtensionType.TransferFeeConfig, ExtensionType.NonTransferable], {
+                [ExtensionType.TransferHook]: 200,
+            })
         ).to.throw('Extension 14 is not variable length');
     });
 


### PR DESCRIPTION
Some people have mentioned that calculating the expected mint size for a mint with a variable-length `TokenMetadata` extension is cumbersome. This is because if you provide `ExtensionType.TokenMetadata` to `getMintLen(..)`, it will throw an error, since it does not have a fixed size.

Currently, developers must calculate the packed length of their token metadata, get the mint length for the remaining extensions using `getMintLen(..)`, and then add 2 bytes for type, 2 bytes for length, and their token metadata packed length to the mint length, manually.

This PR proposes adding variable length extensions as an additional optional parameter to `getMintLen(..)`, which will allow developers to provide variable-length, extensions such as `TokenMetadata`, alongside their calculated extension size to get the full mint size, taking advantage of the helper!

An example of this modified helper in action can be found in the unit tests. Here's a snippet:

(Note, edited with PR feedback)

```ts
const tokenMetadataPackedLength = pack(tokenMetadata).length;
const mintLength = getMintLen([ExtensionType.TransferFeeConfig, ExtensionType.NonTransferable], {
    [ExtensionType.TokenMetadata]: tokenMetadataPackedLength,
})
```