### PR TITLE
token-js: bump to 0.3.11

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:
@@ -407,7 +411,7 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1
       '@solana/spl-token':
-        specifier: 0.3.10
+        specifier: 0.3.11
         version: link:../../token/js
       '@solana/web3.js':
         specifier: ^1.88.0
@@ -596,7 +600,7 @@ importers:
         specifier: ^11.1.1
         version: 11.1.5(rollup@4.9.4)(tslib@2.6.2)(typescript@5.3.3)
       '@solana/spl-token':
-        specifier: 0.3.10
+        specifier: 0.3.11
         version: link:../../token/js
       '@solana/web3.js':
         specifier: ^1.88.0
@@ -736,7 +740,7 @@ importers:
         version: 0.2.0
     devDependencies:
       '@solana/spl-token':
-        specifier: 0.3.10
+        specifier: 0.3.11
         version: link:../../token/js
       '@solana/web3.js':
         specifier: ^1.88.0
@@ -8128,7 +8132,3 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false

--- a/stake-pool/js/package.json
+++ b/stake-pool/js/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@coral-xyz/borsh": "^0.29.0",
     "@solana/buffer-layout": "^4.0.1",
-    "@solana/spl-token": "0.3.10",
+    "@solana/spl-token": "0.3.11",
     "@solana/web3.js": "^1.88.0",
     "bn.js": "^5.2.0",
     "buffer": "^6.0.3",

--- a/token-lending/js/package.json
+++ b/token-lending/js/package.json
@@ -37,14 +37,14 @@
         "bignumber.js": "^9.0.1"
     },
     "peerDependencies": {
-        "@solana/spl-token": "0.3.10",
+        "@solana/spl-token": "0.3.11",
         "@solana/web3.js": "^1.20.0"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.0",
         "@rollup/plugin-node-resolve": "^15.0.2",
         "@rollup/plugin-typescript": "^11.1.1",
-        "@solana/spl-token": "0.3.10",
+        "@solana/spl-token": "0.3.11",
         "@solana/web3.js": "^1.88.0",
         "@types/eslint": "^8.56.1",
         "@types/eslint-plugin-prettier": "^3.1.0",

--- a/token-swap/js/package.json
+++ b/token-swap/js/package.json
@@ -52,7 +52,7 @@
     "@solana/web3.js": "^1.88.0"
   },
   "devDependencies": {
-    "@solana/spl-token": "0.3.10",
+    "@solana/spl-token": "0.3.11",
     "@solana/web3.js": "^1.88.0",
     "@types/bn.js": "^5.1.0",
     "@types/chai-as-promised": "^7.1.4",

--- a/token/js/package.json
+++ b/token/js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@solana/spl-token",
     "description": "SPL Token Program JS API",
-    "version": "0.3.10",
+    "version": "0.3.11",
     "author": "Solana Labs Maintainers <maintainers@solanalabs.com>",
     "repository": "https://github.com/solana-labs/solana-program-library",
     "license": "Apache-2.0",


### PR DESCRIPTION
Bumps Token JS to `0.3.11` for release.