### PR TITLE
token-2022: Execute transfer hook during confidential transfer

### DIFF
--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -2159,14 +2159,18 @@ where
             &multisig_signers,
             proof_location,
         )?;
-        offchain::resolve_extra_transfer_account_metas(
+        offchain::add_extra_account_metas(
             &mut instructions[0],
+            source_account,
+            self.get_address(),
+            destination_account,
+            source_authority,
+            u64::MAX,
             |address| {
                 self.client
                     .get_account(address)
                     .map_ok(|opt| opt.map(|acc| acc.data))
             },
-            self.get_address(),
         )
         .await
         .map_err(|_| TokenError::AccountNotFound)?;
@@ -2213,14 +2217,18 @@ where
             context_state_accounts,
             source_decrypt_handles,
         )?;
-        offchain::resolve_extra_transfer_account_metas(
+        offchain::add_extra_account_metas(
             &mut instruction,
+            source_account,
+            self.get_address(),
+            destination_account,
+            source_authority,
+            u64::MAX,
             |address| {
                 self.client
                     .get_account(address)
                     .map_ok(|opt| opt.map(|acc| acc.data))
             },
-            self.get_address(),
         )
         .await
         .map_err(|_| TokenError::AccountNotFound)?;
@@ -2286,14 +2294,18 @@ where
                 context_state_accounts,
                 &source_decrypt_handles,
             )?;
-        offchain::resolve_extra_transfer_account_metas(
+        offchain::add_extra_account_metas(
             &mut transfer_instruction,
+            source_account,
+            self.get_address(),
+            destination_account,
+            source_authority,
+            u64::MAX,
             |address| {
                 self.client
                     .get_account(address)
                     .map_ok(|opt| opt.map(|acc| acc.data))
             },
-            self.get_address(),
         )
         .await
         .map_err(|_| TokenError::AccountNotFound)?;
@@ -2721,18 +2733,27 @@ where
             &multisig_signers,
             proof_location,
         )?;
-        offchain::resolve_extra_transfer_account_metas(
+        offchain::add_extra_account_metas(
             &mut instructions[0],
+            source_account,
+            self.get_address(),
+            destination_account,
+            source_authority,
+            u64::MAX,
             |address| {
                 self.client
                     .get_account(address)
                     .map_ok(|opt| opt.map(|acc| acc.data))
             },
-            self.get_address(),
         )
         .await
         .map_err(|_| TokenError::AccountNotFound)?;
-        self.process_ixs_with_additional_compute_budget(&instructions, TRANSFER_WITH_FEE_COMPUTE_BUDGET, signing_keypairs).await
+        self.process_ixs_with_additional_compute_budget(
+            &instructions,
+            TRANSFER_WITH_FEE_COMPUTE_BUDGET,
+            signing_keypairs,
+        )
+        .await
     }
 
     /// Transfer tokens confidentially with fee using split proofs.
@@ -2776,14 +2797,18 @@ where
                 context_state_accounts,
                 source_decrypt_handles,
             )?;
-        offchain::resolve_extra_transfer_account_metas(
+        offchain::add_extra_account_metas(
             &mut instruction,
+            source_account,
+            self.get_address(),
+            destination_account,
+            source_authority,
+            u64::MAX,
             |address| {
                 self.client
                     .get_account(address)
                     .map_ok(|opt| opt.map(|acc| acc.data))
             },
-            self.get_address(),
         )
         .await
         .map_err(|_| TokenError::AccountNotFound)?;
@@ -2874,14 +2899,18 @@ where
                 context_state_accounts,
                 &source_decrypt_handles,
             )?;
-        offchain::resolve_extra_transfer_account_metas(
+        offchain::add_extra_account_metas(
             &mut transfer_instruction,
+            source_account,
+            self.get_address(),
+            destination_account,
+            source_authority,
+            u64::MAX,
             |address| {
                 self.client
                     .get_account(address)
                     .map_ok(|opt| opt.map(|acc| acc.data))
             },
-            self.get_address(),
         )
         .await
         .map_err(|_| TokenError::AccountNotFound)?;

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -2152,7 +2152,7 @@ where
         let mut instructions = confidential_transfer::instruction::transfer(
             &self.program_id,
             source_account,
-            &self.pubkey,
+            self.get_address(),
             destination_account,
             new_decryptable_available_balance,
             source_authority,
@@ -2210,7 +2210,7 @@ where
         let mut instruction = confidential_transfer::instruction::transfer_with_split_proofs(
             &self.program_id,
             source_account,
-            &self.pubkey,
+            self.get_address(),
             destination_account,
             new_decryptable_available_balance.into(),
             source_authority,
@@ -2287,7 +2287,7 @@ where
             confidential_transfer::instruction::transfer_with_split_proofs(
                 &self.program_id,
                 source_account,
-                &self.pubkey,
+                self.get_address(),
                 destination_account,
                 new_decryptable_available_balance.into(),
                 source_authority,
@@ -2727,7 +2727,7 @@ where
             &self.program_id,
             source_account,
             destination_account,
-            &self.pubkey,
+            self.get_address(),
             new_decryptable_available_balance,
             source_authority,
             &multisig_signers,
@@ -2790,7 +2790,7 @@ where
             confidential_transfer::instruction::transfer_with_fee_and_split_proofs(
                 &self.program_id,
                 source_account,
-                &self.pubkey,
+                self.get_address(),
                 destination_account,
                 new_decryptable_available_balance.into(),
                 source_authority,
@@ -2892,7 +2892,7 @@ where
             confidential_transfer::instruction::transfer_with_fee_and_split_proofs(
                 &self.program_id,
                 source_account,
-                &self.pubkey,
+                self.get_address(),
                 destination_account,
                 new_decryptable_available_balance.into(),
                 source_authority,

--- a/token/program-2022-test/tests/program_test.rs
+++ b/token/program-2022-test/tests/program_test.rs
@@ -2,10 +2,24 @@
 
 use {
     solana_program_test::{processor, tokio::sync::Mutex, ProgramTest, ProgramTestContext},
-    solana_sdk::signer::{keypair::Keypair, Signer},
-    spl_token_2022::{id, native_mint, processor::Processor},
+    solana_sdk::{
+        pubkey::Pubkey,
+        signer::{keypair::Keypair, Signer},
+    },
+    spl_token_2022::{
+        extension::{
+            confidential_transfer::ConfidentialTransferAccount, BaseStateWithExtensions,
+            ExtensionType,
+        },
+        id, native_mint,
+        processor::Processor,
+        solana_zk_token_sdk::encryption::{auth_encryption::*, elgamal::*},
+    },
     spl_token_client::{
-        client::{ProgramBanksClient, ProgramBanksClientProcessTransaction, ProgramClient},
+        client::{
+            ProgramBanksClient, ProgramBanksClientProcessTransaction, ProgramClient,
+            SendTransaction, SimulateTransaction,
+        },
         token::{ExtensionInitializationParams, Token, TokenResult},
     },
     std::sync::Arc,
@@ -159,4 +173,182 @@ impl TestContext {
 
 pub(crate) fn keypair_clone(kp: &Keypair) -> Keypair {
     Keypair::from_bytes(&kp.to_bytes()).expect("failed to copy keypair")
+}
+
+pub(crate) struct ConfidentialTokenAccountMeta {
+    pub(crate) token_account: Pubkey,
+    pub(crate) elgamal_keypair: ElGamalKeypair,
+    pub(crate) aes_key: AeKey,
+}
+
+impl ConfidentialTokenAccountMeta {
+    pub(crate) async fn new<T>(
+        token: &Token<T>,
+        owner: &Keypair,
+        maximum_pending_balance_credit_counter: Option<u64>,
+        require_memo: bool,
+        require_fee: bool,
+    ) -> Self
+    where
+        T: SendTransaction + SimulateTransaction,
+    {
+        let token_account_keypair = Keypair::new();
+
+        let mut extensions = vec![ExtensionType::ConfidentialTransferAccount];
+        if require_memo {
+            extensions.push(ExtensionType::MemoTransfer);
+        }
+        if require_fee {
+            extensions.push(ExtensionType::ConfidentialTransferFeeAmount);
+        }
+
+        token
+            .create_auxiliary_token_account_with_extension_space(
+                &token_account_keypair,
+                &owner.pubkey(),
+                extensions,
+            )
+            .await
+            .unwrap();
+        let token_account = token_account_keypair.pubkey();
+
+        let elgamal_keypair =
+            ElGamalKeypair::new_from_signer(owner, &token_account.to_bytes()).unwrap();
+        let aes_key = AeKey::new_from_signer(owner, &token_account.to_bytes()).unwrap();
+
+        token
+            .confidential_transfer_configure_token_account(
+                &token_account,
+                &owner.pubkey(),
+                None,
+                maximum_pending_balance_credit_counter,
+                &elgamal_keypair,
+                &aes_key,
+                &[owner],
+            )
+            .await
+            .unwrap();
+
+        if require_memo {
+            token
+                .enable_required_transfer_memos(&token_account, &owner.pubkey(), &[owner])
+                .await
+                .unwrap();
+        }
+
+        Self {
+            token_account,
+            elgamal_keypair,
+            aes_key,
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    #[cfg(feature = "zk-ops")]
+    pub(crate) async fn new_with_tokens<T>(
+        token: &Token<T>,
+        owner: &Keypair,
+        maximum_pending_balance_credit_counter: Option<u64>,
+        require_memo: bool,
+        require_fee: bool,
+        mint_authority: &Keypair,
+        amount: u64,
+        decimals: u8,
+    ) -> Self
+    where
+        T: SendTransaction + SimulateTransaction,
+    {
+        let meta = Self::new(
+            token,
+            owner,
+            maximum_pending_balance_credit_counter,
+            require_memo,
+            require_fee,
+        )
+        .await;
+
+        token
+            .mint_to(
+                &meta.token_account,
+                &mint_authority.pubkey(),
+                amount,
+                &[mint_authority],
+            )
+            .await
+            .unwrap();
+
+        token
+            .confidential_transfer_deposit(
+                &meta.token_account,
+                &owner.pubkey(),
+                amount,
+                decimals,
+                &[owner],
+            )
+            .await
+            .unwrap();
+
+        token
+            .confidential_transfer_apply_pending_balance(
+                &meta.token_account,
+                &owner.pubkey(),
+                None,
+                meta.elgamal_keypair.secret(),
+                &meta.aes_key,
+                &[owner],
+            )
+            .await
+            .unwrap();
+        meta
+    }
+
+    #[cfg(feature = "zk-ops")]
+    pub(crate) async fn check_balances<T>(
+        &self,
+        token: &Token<T>,
+        expected: ConfidentialTokenAccountBalances,
+    ) where
+        T: SendTransaction + SimulateTransaction,
+    {
+        let state = token.get_account_info(&self.token_account).await.unwrap();
+        let extension = state
+            .get_extension::<ConfidentialTransferAccount>()
+            .unwrap();
+
+        assert_eq!(
+            extension
+                .pending_balance_lo
+                .decrypt(self.elgamal_keypair.secret())
+                .unwrap(),
+            expected.pending_balance_lo,
+        );
+        assert_eq!(
+            extension
+                .pending_balance_hi
+                .decrypt(self.elgamal_keypair.secret())
+                .unwrap(),
+            expected.pending_balance_hi,
+        );
+        assert_eq!(
+            extension
+                .available_balance
+                .decrypt(self.elgamal_keypair.secret())
+                .unwrap(),
+            expected.available_balance,
+        );
+        assert_eq!(
+            self.aes_key
+                .decrypt(&extension.decryptable_available_balance.try_into().unwrap())
+                .unwrap(),
+            expected.decryptable_available_balance,
+        );
+    }
+}
+
+#[cfg(feature = "zk-ops")]
+pub(crate) struct ConfidentialTokenAccountBalances {
+    pub(crate) pending_balance_lo: u64,
+    pub(crate) pending_balance_hi: u64,
+    pub(crate) available_balance: u64,
+    pub(crate) decryptable_available_balance: u64,
 }

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -12,11 +12,13 @@ exclude = ["js/**"]
 no-entrypoint = []
 test-sbf = []
 serde-traits = ["dep:serde", "dep:serde_with", "dep:base64", "spl-pod/serde-traits"]
-default = ["token-group", "zk-ops"]
+default = ["confidential-hook", "token-group", "zk-ops"]
 # Remove this feature once the underlying syscalls are released on all networks
 zk-ops = []
 # Remove this feature once the token group implementation has been audited
 token-group = []
+# Remove this feature once the confidential transfer hook has been audited
+confidential-hook = []
 
 [dependencies]
 arrayref = "0.3.7"

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -1,4 +1,6 @@
 // Remove feature once zk ops syscalls are enabled on all networks
+#[cfg(feature = "confidential-hook")]
+use crate::extension::transfer_hook;
 #[cfg(feature = "zk-ops")]
 use {
     crate::extension::non_transferable::NonTransferable,
@@ -16,7 +18,7 @@ use {
             },
             memo_transfer::{check_previous_sibling_instruction_is_memo, memo_required},
             transfer_fee::TransferFeeConfig,
-            transfer_hook, BaseStateWithExtensions, StateWithExtensions, StateWithExtensionsMut,
+            BaseStateWithExtensions, StateWithExtensions, StateWithExtensionsMut,
         },
         instruction::{decode_instruction_data, decode_instruction_type},
         processor::Processor,
@@ -625,6 +627,7 @@ fn process_transfer(
         authority_info
     };
 
+    #[cfg(feature = "confidential-hook")]
     if let Some(program_id) = transfer_hook::get_program_id(&mint) {
         // set transferring flags, scope the borrow to avoid double-borrow during CPI
         {

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -16,7 +16,7 @@ use {
             },
             memo_transfer::{check_previous_sibling_instruction_is_memo, memo_required},
             transfer_fee::TransferFeeConfig,
-            BaseStateWithExtensions, StateWithExtensions, StateWithExtensionsMut,
+            transfer_hook, BaseStateWithExtensions, StateWithExtensions, StateWithExtensionsMut,
         },
         instruction::{decode_instruction_data, decode_instruction_type},
         processor::Processor,
@@ -445,11 +445,11 @@ fn process_transfer(
     let account_info_iter = &mut accounts.iter();
     let source_account_info = next_account_info(account_info_iter)?;
     let mint_info = next_account_info(account_info_iter)?;
-    let destination_token_account_info = next_account_info(account_info_iter)?;
+    let destination_account_info = next_account_info(account_info_iter)?;
 
     check_program_account(mint_info.owner)?;
-    let mint_data = &mint_info.data.borrow_mut();
-    let mint = StateWithExtensions::<Mint>::unpack(mint_data)?;
+    let mint_data = mint_info.data.borrow_mut();
+    let mint = StateWithExtensions::<Mint>::unpack(&mint_data)?;
 
     if mint.get_extension::<NonTransferable>().is_ok() {
         return Err(TokenError::NonTransferable.into());
@@ -466,7 +466,7 @@ fn process_transfer(
     //   - If the mint is extended for fees and the instruction is not a
     //     self-transfer, then
     //   transfer fee is required.
-    if mint.get_extension::<TransferFeeConfig>().is_err() {
+    let authority_info = if mint.get_extension::<TransferFeeConfig>().is_err() {
         // Transfer fee is not required. Decode the zero-knowledge proof as
         // `TransferData`.
         //
@@ -521,7 +521,7 @@ fn process_transfer(
         )?;
 
         process_destination_for_transfer(
-            destination_token_account_info,
+            destination_account_info,
             mint_info,
             maybe_proof_context.as_ref(),
         )?;
@@ -532,6 +532,7 @@ fn process_transfer(
             executed"
             );
         }
+        authority_info
     } else {
         // Transfer fee is required.
         let transfer_fee_config = mint.get_extension::<TransferFeeConfig>()?;
@@ -608,9 +609,9 @@ fn process_transfer(
             new_source_decryptable_available_balance,
         )?;
 
-        let is_self_transfer = source_account_info.key == destination_token_account_info.key;
+        let is_self_transfer = source_account_info.key == destination_account_info.key;
         process_destination_for_transfer_with_fee(
-            destination_token_account_info,
+            destination_account_info,
             mint_info,
             maybe_proof_context.as_ref(),
             is_self_transfer,
@@ -621,6 +622,42 @@ fn process_transfer(
                 "Context state not fully initialized: returning with no op; transfer is NOT yet executed"
             );
         }
+        authority_info
+    };
+
+    if let Some(program_id) = transfer_hook::get_program_id(&mint) {
+        // set transferring flags, scope the borrow to avoid double-borrow during CPI
+        {
+            let mut source_account_data = source_account_info.data.borrow_mut();
+            let mut source_account =
+                StateWithExtensionsMut::<Account>::unpack(&mut source_account_data)?;
+            transfer_hook::set_transferring(&mut source_account)?;
+        }
+        {
+            let mut destination_account_data = destination_account_info.data.borrow_mut();
+            let mut destination_account =
+                StateWithExtensionsMut::<Account>::unpack(&mut destination_account_data)?;
+            transfer_hook::set_transferring(&mut destination_account)?;
+        }
+
+        // can't doubly-borrow the mint data either
+        drop(mint_data);
+
+        // Since the amount is unknown during a confidential transfer, pass in
+        // u64::MAX as a convention.
+        spl_transfer_hook_interface::onchain::invoke_execute(
+            &program_id,
+            source_account_info.clone(),
+            mint_info.clone(),
+            destination_account_info.clone(),
+            authority_info.clone(),
+            account_info_iter.as_slice(),
+            u64::MAX,
+        )?;
+
+        // unset transferring flag
+        transfer_hook::unset_transferring(source_account_info)?;
+        transfer_hook::unset_transferring(destination_account_info)?;
     }
 
     Ok(())
@@ -696,12 +733,12 @@ fn process_source_for_transfer(
 
 #[cfg(feature = "zk-ops")]
 fn process_destination_for_transfer(
-    destination_token_account_info: &AccountInfo,
+    destination_account_info: &AccountInfo,
     mint_info: &AccountInfo,
     maybe_transfer_proof_context_info: Option<&TransferProofContextInfo>,
 ) -> ProgramResult {
-    check_program_account(destination_token_account_info.owner)?;
-    let destination_token_account_data = &mut destination_token_account_info.data.borrow_mut();
+    check_program_account(destination_account_info.owner)?;
+    let destination_token_account_data = &mut destination_account_info.data.borrow_mut();
     let mut destination_token_account =
         StateWithExtensionsMut::<Account>::unpack(destination_token_account_data)?;
 
@@ -824,13 +861,13 @@ fn process_source_for_transfer_with_fee(
 
 #[cfg(feature = "zk-ops")]
 fn process_destination_for_transfer_with_fee(
-    destination_token_account_info: &AccountInfo,
+    destination_account_info: &AccountInfo,
     mint_info: &AccountInfo,
     maybe_proof_context: Option<&TransferWithFeeProofContextInfo>,
     is_self_transfer: bool,
 ) -> ProgramResult {
-    check_program_account(destination_token_account_info.owner)?;
-    let destination_token_account_data = &mut destination_token_account_info.data.borrow_mut();
+    check_program_account(destination_account_info.owner)?;
+    let destination_token_account_data = &mut destination_account_info.data.borrow_mut();
     let mut destination_token_account =
         StateWithExtensionsMut::<Account>::unpack(destination_token_account_data)?;
 


### PR DESCRIPTION
#### Problem

If a mint is configured with a transfer hook, the program is meant to be called during all transfers. This doesn't happen during confidential transfers though.

#### Summary of changes

The program changes are pretty simple: just execute the transfer hook, as in a normal transfer. This comes with a few other changes:

* b834e962f4919acd0c5c892166bb444289324b60 refactor some confidential transfer test helpers to be used in the transfer hook test
* 55f51c84e7cc44fc3eba8389a94fd8f37500181a call the incorrect #6064 account resolver in token-client for all confidential transfer functions
* dc28301b featurize the processor changes, to avoid deploying them accidentally
* rename `destination_token_account_info` -> `destination_account_info` for consistency

The biggest issue is that we don't know the amount transferred when calling the hook. I decided to go with `u64::MAX` as a convention, rather than adding another instruction to the interface. Transfer hooks are complicated enough as is, so forcing programs to implement another instruction seems like a bad idea. Let me know if you have better ideas!