### PR TITLE
pod: Add in-place stake history deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7036,6 +7036,7 @@ name = "spl-pod"
 version = "0.1.0"
 dependencies = [
  "base64 0.21.6",
+ "bincode",
  "borsh 0.10.3",
  "bytemuck",
  "serde",

--- a/libraries/pod/Cargo.toml
+++ b/libraries/pod/Cargo.toml
@@ -21,6 +21,7 @@ solana-zk-token-sdk = "1.17.6"
 spl-program-error = { version = "0.3", path = "../program-error" }
 
 [dev-dependencies]
+bincode = "1"
 serde_json = "1.0.111"
 
 [lib]

--- a/libraries/pod/src/primitives.rs
+++ b/libraries/pod/src/primitives.rs
@@ -54,6 +54,11 @@ macro_rules! impl_int_conversion {
                 Self::from_le_bytes(pod.0)
             }
         }
+        impl Into<usize> for $P {
+            fn into(self) -> usize {
+                usize::try_from(<$I>::from_le_bytes(self.0)).unwrap()
+            }
+        }
     };
 }
 


### PR DESCRIPTION
#### Problem

The stake history sysvar is too large to deserialize on-chain.

#### Solution

Using pod types, create an in-place deserializer for `StakeHistory`. It's a bit goofy, but it should give an overall look at how it can be done. A few quirks about this, which is why it's only a draft:

* bincode serializes vector sizes as a u64, whereas most other tools do a u32, which is why there's a new type parameter on `PodSlice` and a new (goofy) conversion function into `usize` for the pod number types
* the stake program types might need to start taking in the `Pod` types for things like inflation calculation, I haven't looked that far into it

Let me know how this looks!