### PR TITLE
ci: Only run one of each workflow at once for a branch / PR

### DIFF
--- a/.github/workflows/pull-request-account-compression.yml
+++ b/.github/workflows/pull-request-account-compression.yml
@@ -19,6 +19,10 @@ on:
       - ".github/workflows/pull-request-account-compression.yml"
       - "!account-compression/sdk/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   anchor-build-account-compression:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-binary-oracle-pair.yml
+++ b/.github/workflows/pull-request-binary-oracle-pair.yml
@@ -15,6 +15,10 @@ on:
     - 'ci/*-version.sh'
     - '!token/js/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-docs.yml
+++ b/.github/workflows/pull-request-docs.yml
@@ -11,6 +11,10 @@ on:
     - 'docs/**'
     - '.github/workflows/pull-request-docs.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   all_github_action_checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-examples.yml
+++ b/.github/workflows/pull-request-examples.yml
@@ -11,6 +11,10 @@ on:
     - 'examples/rust/**'
     - 'ci/*-version.sh'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-feature-gate.yml
+++ b/.github/workflows/pull-request-feature-gate.yml
@@ -13,6 +13,10 @@ on:
     - 'ci/*-version.sh'
     - '.github/workflows/pull-request-feature-gate.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-feature-proposal.yml
+++ b/.github/workflows/pull-request-feature-proposal.yml
@@ -15,6 +15,10 @@ on:
     - 'ci/*-version.sh'
     - '!token/js/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-governance.yml
+++ b/.github/workflows/pull-request-governance.yml
@@ -15,6 +15,10 @@ on:
       - "ci/*-version.sh"
       - '!token/js/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-instruction-padding.yml
+++ b/.github/workflows/pull-request-instruction-padding.yml
@@ -13,6 +13,10 @@ on:
     - 'ci/*-version.sh'
     - '.github/workflows/pull-request-instruction-padding.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-js.yml
+++ b/.github/workflows/pull-request-js.yml
@@ -32,6 +32,10 @@ on:
       - 'pnpm-lock.yaml'
       - '.github/workflows/pull-request-js.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   js-test:
     strategy:

--- a/.github/workflows/pull-request-libraries.yml
+++ b/.github/workflows/pull-request-libraries.yml
@@ -15,6 +15,10 @@ on:
     - '.github/workflows/pull-request-libraries.yml'
     - '!libraries/**/js/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-memo.yml
+++ b/.github/workflows/pull-request-memo.yml
@@ -13,6 +13,10 @@ on:
     - 'ci/*-version.sh'
     - '!memo/js/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-name-service.yml
+++ b/.github/workflows/pull-request-name-service.yml
@@ -13,6 +13,10 @@ on:
     - 'ci/*-version.sh'
     - '!name-service/js/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-record.yml
+++ b/.github/workflows/pull-request-record.yml
@@ -11,6 +11,10 @@ on:
     - 'record/**'
     - 'ci/*-version.sh'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-shared-memory.yml
+++ b/.github/workflows/pull-request-shared-memory.yml
@@ -11,6 +11,10 @@ on:
     - 'shared-memory/**'
     - 'ci/*-version.sh'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-single-pool.yml
+++ b/.github/workflows/pull-request-single-pool.yml
@@ -21,6 +21,10 @@ on:
     - '!single-pool/js/**'
     - '!token/js/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-stake-pool.yml
+++ b/.github/workflows/pull-request-stake-pool.yml
@@ -21,6 +21,10 @@ on:
     - '!stake-pool/js/**'
     - '!token/js/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-token-collection.yml
+++ b/.github/workflows/pull-request-token-collection.yml
@@ -23,6 +23,10 @@ on:
     - '!token/js/**'
     - '!token-metadata/js/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-token-group.yml
+++ b/.github/workflows/pull-request-token-group.yml
@@ -17,6 +17,10 @@ on:
       - '.github/workflows/pull-request-token-group.yml'
       - '!token-group/js/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-token-lending.yml
+++ b/.github/workflows/pull-request-token-lending.yml
@@ -17,6 +17,10 @@ on:
     - '!token-lending/js/**'
     - '!token/js/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-token-metadata.yml
+++ b/.github/workflows/pull-request-token-metadata.yml
@@ -17,6 +17,10 @@ on:
     - '.github/workflows/pull-request-token-metadata.yml'
     - '!token-metadata/js/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-token-swap.yml
+++ b/.github/workflows/pull-request-token-swap.yml
@@ -19,6 +19,10 @@ on:
     - '!token-swap/js/**'
     - '!token/js/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-token-upgrade.yml
+++ b/.github/workflows/pull-request-token-upgrade.yml
@@ -17,6 +17,10 @@ on:
     - '.github/workflows/pull-request-token-upgrade.yml'
     - '!token/js/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-token.yml
+++ b/.github/workflows/pull-request-token.yml
@@ -17,6 +17,10 @@ on:
     - '.github/workflows/pull-request-token.yml'
     - '!token/js/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,6 +9,10 @@ on:
     paths-ignore:
     - 'docs/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   all_github_action_checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/spl_action.yml
+++ b/.github/workflows/spl_action.yml
@@ -7,6 +7,10 @@ on:
     - 'docs/**'
     - '.github/workflows/spl_action.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### Problem

It's easy for our CI machines to get bogged down if many PRs go in quickly, which often happens when we have multiple dependabot PRs in at once. This happens because CI is run at the same time for every single commit.

#### Solution

Following https://github.com/solana-labs/solana/pull/34733, limit the concurrency on PRs and branches to one per workflow type.