### PR TITLE
token 2022: repair onchain helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7373,6 +7373,7 @@ dependencies = [
  "spl-instruction-padding",
  "spl-memo 4.0.0",
  "spl-pod 0.1.0",
+ "spl-tlv-account-resolution 0.5.1",
  "spl-token-2022 1.0.0",
  "spl-token-client",
  "spl-token-group-interface",

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -27,6 +27,7 @@ spl-memo = { version = "4.0.0", path = "../../memo/program", features = ["no-ent
 spl-pod = { version = "0.1.0", path = "../../libraries/pod" }
 spl-token-2022 = { version = "1.0", path="../program-2022", features = ["no-entrypoint"] }
 spl-instruction-padding = { version = "0.1.0", path="../../instruction-padding/program", features = ["no-entrypoint"] }
+spl-tlv-account-resolution = { version = "0.5.0", path = "../../libraries/tlv-account-resolution" }
 spl-token-client = { version = "0.8", path = "../client" }
 spl-token-group-interface = { version = "0.1", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }

--- a/token/program-2022-test/tests/transfer_hook.rs
+++ b/token/program-2022-test/tests/transfer_hook.rs
@@ -17,6 +17,7 @@ use {
         transaction::TransactionError,
         transport::TransportError,
     },
+    spl_tlv_account_resolution::{account::ExtraAccountMeta, seeds::Seed},
     spl_token_2022::{
         error::TokenError,
         extension::{
@@ -191,6 +192,28 @@ fn add_validation_account(program_test: &mut ProgramTest, mint: &Pubkey, program
             is_writable: false,
         }
         .into(),
+        ExtraAccountMeta::new_with_seeds(
+            &[
+                Seed::AccountKey { index: 0 }, // source
+                Seed::AccountKey { index: 2 }, // destination
+                Seed::AccountKey { index: 4 }, // validation state
+            ],
+            false,
+            true,
+        )
+        .unwrap(),
+        ExtraAccountMeta::new_with_seeds(
+            &[
+                Seed::Literal {
+                    bytes: vec![1, 2, 3, 4, 5, 6],
+                },
+                Seed::AccountKey { index: 2 }, // destination
+                Seed::AccountKey { index: 5 }, // extra meta 1
+            ],
+            false,
+            true,
+        )
+        .unwrap(),
     ];
     program_test.add_account(
         validation_address,


### PR DESCRIPTION
Continuing on from the new helper introduced in #6111.

Here the onchain helper in Token2022 is updated to use the non-deprecated new
onchain helper from SPL Transfer Hook interface.

PDAs as extra meta configs are also added to the transfer hook test in
`program-2022-test` for additional assurance.
