### PR TITLE
Transfer hook: bump versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7666,7 +7666,7 @@ dependencies = [
 
 [[package]]
 name = "spl-transfer-hook-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap 3.2.25",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7366,7 +7366,7 @@ dependencies = [
  "spl-token 4.0.0",
  "spl-token-group-interface",
  "spl-token-metadata-interface 0.2.0",
- "spl-transfer-hook-interface 0.4.1",
+ "spl-transfer-hook-interface 0.5.0",
  "spl-type-length-value 0.3.0",
  "thiserror",
 ]
@@ -7391,7 +7391,7 @@ dependencies = [
  "spl-token-group-interface",
  "spl-token-metadata-interface 0.2.0",
  "spl-transfer-hook-example",
- "spl-transfer-hook-interface 0.4.1",
+ "spl-transfer-hook-interface 0.5.0",
  "test-case",
  "walkdir",
 ]
@@ -7454,7 +7454,7 @@ dependencies = [
  "spl-token-2022 1.0.0",
  "spl-token-group-interface",
  "spl-token-metadata-interface 0.2.0",
- "spl-transfer-hook-interface 0.4.1",
+ "spl-transfer-hook-interface 0.5.0",
  "thiserror",
 ]
 
@@ -7683,7 +7683,7 @@ dependencies = [
  "spl-tlv-account-resolution 0.5.1",
  "spl-token-2022 1.0.0",
  "spl-token-client",
- "spl-transfer-hook-interface 0.4.1",
+ "spl-transfer-hook-interface 0.5.0",
  "strum 0.25.0",
  "strum_macros 0.25.3",
  "tokio",
@@ -7699,7 +7699,7 @@ dependencies = [
  "solana-sdk",
  "spl-tlv-account-resolution 0.5.1",
  "spl-token-2022 1.0.0",
- "spl-transfer-hook-interface 0.4.1",
+ "spl-transfer-hook-interface 0.5.0",
  "spl-type-length-value 0.3.0",
 ]
 
@@ -7721,7 +7721,7 @@ dependencies = [
 
 [[package]]
 name = "spl-transfer-hook-interface"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "arrayref",
  "bytemuck",

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -26,7 +26,7 @@ spl-token = { version = "4.0", path="../program", features = [ "no-entrypoint" ]
 spl-token-2022 = { version = "1.0", path="../program-2022" }
 spl-token-group-interface = { version = "0.1", path="../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.2", path="../../token-metadata/interface" }
-spl-transfer-hook-interface = { version = "0.4", path="../transfer-hook/interface" }
+spl-transfer-hook-interface = { version = "0.5", path="../transfer-hook/interface" }
 thiserror = "1.0"
 
 [features]

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -32,5 +32,5 @@ spl-token-client = { version = "0.8", path = "../client" }
 spl-token-group-interface = { version = "0.1", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }
 spl-transfer-hook-example = { version = "0.4", path="../transfer-hook/example", features = ["no-entrypoint"] }
-spl-transfer-hook-interface = { version = "0.4", path="../transfer-hook/interface" }
+spl-transfer-hook-interface = { version = "0.5", path="../transfer-hook/interface" }
 test-case = "3.3"

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -33,7 +33,7 @@ spl-memo = { version = "4.0.0", path = "../../memo/program", features = [ "no-en
 spl-token = { version = "4.0",  path = "../program", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.1.0", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.2.0", path = "../../token-metadata/interface" }
-spl-transfer-hook-interface = { version = "0.4.0", path = "../transfer-hook/interface" }
+spl-transfer-hook-interface = { version = "0.5.0", path = "../transfer-hook/interface" }
 spl-type-length-value = { version = "0.3.0", path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.1.0", path = "../../libraries/pod" }
 thiserror = "1.0"

--- a/token/transfer-hook/cli/Cargo.toml
+++ b/token/transfer-hook/cli/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://spl.solana.com/token"
 license = "Apache-2.0"
 name = "spl-transfer-hook-cli"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "0.1.0"
+version = "0.1.1"
 
 [dependencies]
 clap = { version = "3", features = ["cargo"] }

--- a/token/transfer-hook/cli/Cargo.toml
+++ b/token/transfer-hook/cli/Cargo.toml
@@ -17,7 +17,7 @@ solana-client = "=1.17.13"
 solana-logger = "=1.17.13"
 solana-remote-wallet = "=1.17.13"
 solana-sdk = "=1.17.13"
-spl-transfer-hook-interface = { version = "0.4", path = "../interface" }
+spl-transfer-hook-interface = { version = "0.5", path = "../interface" }
 spl-tlv-account-resolution = { version = "0.5.1" , path = "../../../libraries/tlv-account-resolution", features = ["serde-traits"] }
 strum = "0.25"
 strum_macros = "0.25"

--- a/token/transfer-hook/example/Cargo.toml
+++ b/token/transfer-hook/example/Cargo.toml
@@ -16,7 +16,7 @@ arrayref = "0.3.7"
 solana-program = "1.17.13"
 spl-tlv-account-resolution = { version = "0.5" , path = "../../../libraries/tlv-account-resolution" }
 spl-token-2022 = { version = "1.0",  path = "../../program-2022", features = ["no-entrypoint"] }
-spl-transfer-hook-interface = { version = "0.4" , path = "../interface" }
+spl-transfer-hook-interface = { version = "0.5" , path = "../interface" }
 spl-type-length-value = { version = "0.3" , path = "../../../libraries/type-length-value" }
 
 [dev-dependencies]

--- a/token/transfer-hook/interface/Cargo.toml
+++ b/token/transfer-hook/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-transfer-hook-interface"
-version = "0.4.1"
+version = "0.5.0"
 description = "Solana Program Library Transfer Hook Interface"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"


### PR DESCRIPTION
This PR bumps the versions of the transfer hook interface and CLI. Commits:
1. `interface`: 0.4.1 -> 0.5.0
2. `cli`: 0.1.0 -> 0.1.1 (The CLI doesn't use the helpers)