### PR TITLE
[token-client] Add interface to add additional compute budget for transactions

### DIFF
--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -2641,7 +2641,10 @@ where
             .new_decryptable_available_balance(transfer_amount, source_aes_key)
             .map_err(|_| TokenError::AccountDecryption)?;
 
-        self.process_ixs(
+        // additional compute budget required for `VerifyTransferWithFee`
+        const TRANSFER_WITH_FEE_COMPUTE_BUDGET: u32 = 500_000;
+
+        self.process_ixs_with_additional_compute_budget(
             &confidential_transfer::instruction::transfer_with_fee(
                 &self.program_id,
                 source_account,
@@ -2652,6 +2655,7 @@ where
                 &multisig_signers,
                 proof_location,
             )?,
+            Some(TRANSFER_WITH_FEE_COMPUTE_BUDGET),
             signing_keypairs,
         )
         .await


### PR DESCRIPTION
#### Problem
With the new activation of the feature `8pgXCMNXC8qyEFypuwpXyRxLXZdpM4Qo72gJ6k87A6wL - Native program should consume compute units` activated, the token-2022 tests seem to break downstream ci in the monorepo due to the token-2022 confidential transfer with fee instruction taking too many compute units.

#### Summary of Changes
- Update the token-client by adding `process_ixs_with_additional_compute_budget`, which adds an extra compute budget instruction to the transaction
- Use the new function to allocate additional compute budget for transfer with fee