### PR TITLE
token 2022 & transfer hook: drop deprecated helpers

### DIFF
--- a/token/program-2022/src/offchain.rs
+++ b/token/program-2022/src/offchain.rs
@@ -11,58 +11,6 @@ use {
     std::future::Future,
 };
 
-/// Offchain helper to get all additional required account metas for a checked
-/// transfer
-///
-/// To be client-agnostic and to avoid pulling in the full solana-sdk, this
-/// simply takes a function that will return its data as `Future<Vec<u8>>` for
-/// the given address. Can be called in the following way:
-///
-/// ```rust,ignore
-/// use futures_util::TryFutureExt;
-/// use solana_client::nonblocking::rpc_client::RpcClient;
-/// use solana_program::pubkey::Pubkey;
-///
-/// let mint = Pubkey::new_unique();
-/// let client = RpcClient::new_mock("succeeds".to_string());
-/// let mut account_metas = vec![];
-///
-/// get_extra_transfer_account_metas(
-///     &mut account_metas,
-///     |address| self.client.get_account(&address).map_ok(|opt| opt.map(|acc| acc.data)),
-///     &mint,
-/// ).await?;
-/// ```
-#[deprecated(
-    since = "1.1.0",
-    note = "Please use `create_transfer_checked_instruction_with_extra_metas` instead"
-)]
-pub async fn resolve_extra_transfer_account_metas<F, Fut>(
-    instruction: &mut Instruction,
-    fetch_account_data_fn: F,
-    mint_address: &Pubkey,
-) -> Result<(), AccountFetchError>
-where
-    F: Fn(Pubkey) -> Fut,
-    Fut: Future<Output = AccountDataResult>,
-{
-    let mint_data = fetch_account_data_fn(*mint_address)
-        .await?
-        .ok_or(ProgramError::InvalidAccountData)?;
-    let mint = StateWithExtensions::<Mint>::unpack(&mint_data)?;
-    if let Some(program_id) = transfer_hook::get_program_id(&mint) {
-        #[allow(deprecated)]
-        spl_transfer_hook_interface::offchain::resolve_extra_account_metas(
-            instruction,
-            fetch_account_data_fn,
-            mint_address,
-            &program_id,
-        )
-        .await?;
-    }
-    Ok(())
-}
-
 /// Offchain helper to create a `TransferChecked` instruction with all
 /// additional required account metas for a transfer, including the ones
 /// required by the transfer hook.

--- a/token/transfer-hook/interface/src/offchain.rs
+++ b/token/transfer-hook/interface/src/offchain.rs
@@ -16,67 +16,6 @@ use {
     std::future::Future,
 };
 
-/// Offchain helper to get all additional required account metas for a mint
-///
-/// To be client-agnostic and to avoid pulling in the full solana-sdk, this
-/// simply takes a function that will return its data as `Future<Vec<u8>>` for
-/// the given address. Can be called in the following way:
-///
-/// ```rust,ignore
-/// use futures_util::TryFutureExt;
-/// use solana_client::nonblocking::rpc_client::RpcClient;
-/// use solana_program::pubkey::Pubkey;
-///
-/// let program_id = Pubkey::new_unique();
-/// let mint = Pubkey::new_unique();
-/// let client = RpcClient::new_mock("succeeds".to_string());
-/// let mut account_metas = vec![];
-///
-/// get_extra_account_metas(
-///     &mut account_metas,
-///     |address| self.client.get_account(&address).map_ok(|opt| opt.map(|acc| acc.data)),
-///     &mint,
-///     &program_id,
-/// ).await?;
-/// ```
-#[deprecated(
-    since = "0.5.0",
-    note = "Please use `add_extra_account_metas_for_execute` instead"
-)]
-pub async fn resolve_extra_account_metas<F, Fut>(
-    instruction: &mut Instruction,
-    fetch_account_data_fn: F,
-    mint: &Pubkey,
-    permissioned_transfer_program_id: &Pubkey,
-) -> Result<(), AccountFetchError>
-where
-    F: Fn(Pubkey) -> Fut,
-    Fut: Future<Output = AccountDataResult>,
-{
-    let validation_address =
-        get_extra_account_metas_address(mint, permissioned_transfer_program_id);
-    let validation_account_data = fetch_account_data_fn(validation_address)
-        .await?
-        .ok_or(ProgramError::InvalidAccountData)?;
-    ExtraAccountMetaList::add_to_instruction::<ExecuteInstruction, _, _>(
-        instruction,
-        fetch_account_data_fn,
-        &validation_account_data,
-    )
-    .await?;
-    // The onchain helpers pull out the required accounts from an opaque
-    // slice by pubkey, so the order doesn't matter here!
-    instruction.accounts.push(AccountMeta::new_readonly(
-        *permissioned_transfer_program_id,
-        false,
-    ));
-    instruction
-        .accounts
-        .push(AccountMeta::new_readonly(validation_address, false));
-
-    Ok(())
-}
-
 /// Offchain helper to get all additional required account metas for an execute
 /// instruction, based on a validation state account.
 ///


### PR DESCRIPTION
Ahead of #6119, if we're going to do releases, we can drop the deprecated helpers altogether.

This PR removes the deprecated `offchain` and `onchain` helpers from SPL Transfer Hook interface, as well as the deprecated `offchain` helper from Token2022.