### PR TITLE
fix: 'owner' should be 'authority' in associated-token-account.md

### DIFF
--- a/docs/src/associated-token-account.md
+++ b/docs/src/associated-token-account.md
@@ -86,5 +86,4 @@ If the associated token account for a given wallet address does not yet exist,
 it may be created by *anybody* by issuing a transaction containing the
 instruction returned by [create_associated_token_account](https://docs.rs/spl-associated-token-account/latest/spl_associated_token_account/instruction/fn.create_associated_token_account.html).
 
-Regardless of creator the new associated token account will be fully owned by
-the wallet, as if the wallet itself had created it.
+Regardless of the creator, the new associated token account's authority will be the wallet, as if the wallet itself had created the associated token account.


### PR DESCRIPTION
The old wording seemed incorrect. Solana uses the term 'owner' to mean program owner. I believe this sentence is saying the authority on the new ATA will be the associated wallet, can someone confirm that's correct?