### PR TITLE
token-cli: Allow a token to be a group and a member

### DIFF
--- a/token/cli/src/clap_app.rs
+++ b/token/cli/src/clap_app.rs
@@ -777,8 +777,6 @@ pub fn app<'a, 'b>(
                 .arg(
                     Arg::with_name("enable_member")
                         .long("enable-member")
-                        .conflicts_with("group_address")
-                        .conflicts_with("enable_group")
                         .conflicts_with("member_address")
                         .takes_value(false)
                         .help("Enables group member configurations in the mint. The mint authority must initialize the member."),


### PR DESCRIPTION
#### Problem

While trying to create a "megatoken", AKA a token with every extension enabled, I noticed that a mint wasn't allowed to be both a group and a member.

From our earlier discussions, I'm pretty sure we wanted to allow this exact case, but the CLI prevents it.

#### Solution

Remove those extra conflicts! If this is the wrong approach and I've missed something, please let me know