### PR TITLE
token-cli: Add command_update_group_max_size to token CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7425,6 +7425,7 @@ dependencies = [
  "spl-token 4.0.0",
  "spl-token-2022 1.0.0",
  "spl-token-client",
+ "spl-token-group-interface",
  "spl-token-metadata-interface 0.2.0",
  "strum 0.25.0",
  "strum_macros 0.25.3",

--- a/token/cli/src/clap_app.rs
+++ b/token/cli/src/clap_app.rs
@@ -1033,7 +1033,7 @@ pub fn app<'a, 'b>(
                     Arg::with_name("update_authority")
                         .long("update-authority")
                         .value_name("ADDRESS")
-                        .validator(is_valid_pubkey)
+                        .validator(is_valid_signer)
                         .takes_value(true)
                         .help(
                             "Specify the update authority address. \

--- a/token/cli/src/clap_app.rs
+++ b/token/cli/src/clap_app.rs
@@ -1032,7 +1032,7 @@ pub fn app<'a, 'b>(
                 .arg(
                     Arg::with_name("update_authority")
                         .long("update-authority")
-                        .value_name("ADDRESS")
+                        .value_name("SIGNER")
                         .validator(is_valid_signer)
                         .takes_value(true)
                         .help(

--- a/token/cli/src/clap_app.rs
+++ b/token/cli/src/clap_app.rs
@@ -1010,7 +1010,7 @@ pub fn app<'a, 'b>(
         )
         .subcommand(
             SubCommand::with_name(CommandName::UpdateGroupMaxSize.into())
-                .about("Updates the number of member in the group.")
+                .about("Updates the maximum number of members for a group.")
                 .arg(
                     Arg::with_name("token")
                         .validator(is_valid_pubkey)

--- a/token/cli/src/clap_app.rs
+++ b/token/cli/src/clap_app.rs
@@ -1010,7 +1010,7 @@ pub fn app<'a, 'b>(
         )
         .subcommand(
             SubCommand::with_name(CommandName::UpdateGroupMaxSize.into())
-                .about("Initialize group extension on a token mint")
+                .about("Updates the number of member in the group.")
                 .arg(
                     Arg::with_name("token")
                         .validator(is_valid_pubkey)

--- a/token/cli/src/clap_app.rs
+++ b/token/cli/src/clap_app.rs
@@ -108,6 +108,7 @@ pub enum CommandName {
     InitializeMetadata,
     UpdateMetadata,
     InitializeGroup,
+    UpdateGroupMaxSize,
     UpdateConfidentialTransferSettings,
     ConfigureConfidentialTransferAccount,
     EnableConfidentialCredits,
@@ -995,6 +996,39 @@ pub fn app<'a, 'b>(
                              Defaults to the client keypair."
                         ),
                 )
+                .arg(
+                    Arg::with_name("update_authority")
+                        .long("update-authority")
+                        .value_name("ADDRESS")
+                        .validator(is_valid_pubkey)
+                        .takes_value(true)
+                        .help(
+                            "Specify the update authority address. \
+                             Defaults to the client keypair address."
+                        ),
+                )
+        )
+        .subcommand(
+            SubCommand::with_name(CommandName::UpdateGroupMaxSize.into())
+                .about("Initialize group extension on a token mint")
+                .arg(
+                    Arg::with_name("token")
+                        .validator(is_valid_pubkey)
+                        .value_name("TOKEN_MINT_ADDRESS")
+                        .takes_value(true)
+                        .required(true)
+                        .index(1)
+                        .help("The token address of the group account."),
+                )
+                .arg(
+                        Arg::with_name("new_max_size")
+                        .validator(is_amount)
+                        .value_name("NEW_MAX_SIZE")
+                        .takes_value(true)
+                        .required(true)
+                        .index(2)
+                        .help("The number of members in the group."),
+                    )
                 .arg(
                     Arg::with_name("update_authority")
                         .long("update-authority")

--- a/token/cli/tests/command.rs
+++ b/token/cli/tests/command.rs
@@ -3865,12 +3865,4 @@ async fn group(test_validator: &TestValidator, payer: &Keypair) {
 
     let updated_extension = updated_mint_state.get_extension::<TokenGroup>().unwrap();
     assert_eq!(updated_extension.max_size, new_max_size.into());
-
-    // let mint_state =
-    // StateWithExtensionsOwned::<Mint>::unpack(account.data).unwrap(); // let
-    // fetched_metadata = mint_state //
-    // .get_variable_len_extension::<TokenGroup>() //     .unwrap();
-    // let fetched_token_group =
-    // mint_state.get_extension::<TokenGroup>().unwrap();
-    // assert_eq!(fetched_token_group.max_size, 10.into());
 }

--- a/token/cli/tests/command.rs
+++ b/token/cli/tests/command.rs
@@ -3842,4 +3842,35 @@ async fn group(test_validator: &TestValidator, payer: &Keypair) {
         extension_pointer.group_address,
         Some(mint).try_into().unwrap()
     );
+
+    let new_max_size = 12;
+
+    // Update token-group max-size
+    process_test_command(
+        &config,
+        payer,
+        &[
+            "spl-token",
+            CommandName::UpdateGroupMaxSize.into(),
+            &mint.to_string(),
+            &new_max_size.to_string(),
+        ],
+    )
+    .await
+    .unwrap();
+
+    let account = config.rpc_client.get_account(&mint).await.unwrap();
+
+    let updated_mint_state = StateWithExtensionsOwned::<Mint>::unpack(account.data).unwrap();
+
+    let updated_extension = updated_mint_state.get_extension::<TokenGroup>().unwrap();
+    assert_eq!(updated_extension.max_size, new_max_size.into());
+
+    // let mint_state =
+    // StateWithExtensionsOwned::<Mint>::unpack(account.data).unwrap(); // let
+    // fetched_metadata = mint_state //
+    // .get_variable_len_extension::<TokenGroup>() //     .unwrap();
+    // let fetched_token_group =
+    // mint_state.get_extension::<TokenGroup>().unwrap();
+    // assert_eq!(fetched_token_group.max_size, 10.into());
 }


### PR DESCRIPTION
As per #5937, added command_update_group_max_size to the token CLI. This allows one to update the max_size of a token group given the update_authority. 