### PR TITLE
cargo: Update lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7425,6 +7425,7 @@ dependencies = [
  "spl-token 4.0.0",
  "spl-token-2022 1.0.0",
  "spl-token-client",
+ "spl-token-group-interface",
  "spl-token-metadata-interface 0.2.0",
  "strum 0.25.0",
  "strum_macros 0.25.3",


### PR DESCRIPTION
#### Problem

The Cargo.lock file wasn't updated when the token-group was added to the token-cli, causing a lockfile change to happen on master if you just run `cargo check`.

#### Solution

Update the lockfile to be consistent