### PR TITLE
bump transfer hook example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7691,7 +7691,7 @@ dependencies = [
 
 [[package]]
 name = "spl-transfer-hook-example"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arrayref",
  "solana-program",

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -31,6 +31,6 @@ spl-tlv-account-resolution = { version = "0.5.0", path = "../../libraries/tlv-ac
 spl-token-client = { version = "0.8", path = "../client" }
 spl-token-group-interface = { version = "0.1", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }
-spl-transfer-hook-example = { version = "0.4", path="../transfer-hook/example", features = ["no-entrypoint"] }
+spl-transfer-hook-example = { version = "0.5", path="../transfer-hook/example", features = ["no-entrypoint"] }
 spl-transfer-hook-interface = { version = "0.5", path="../transfer-hook/interface" }
 test-case = "3.3"

--- a/token/transfer-hook/example/Cargo.toml
+++ b/token/transfer-hook/example/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-transfer-hook-example"
-version = "0.4.0"
+version = "0.5.0"
 description = "Solana Program Library Transfer Hook Example Program"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"


### PR DESCRIPTION
Marking this as a draft for now. I want to make sure this one is timed right.

Technically, since this depends on Token2022, we should really publish Token2022 first and then update this crate's version. Although I wanted to at least check out the bump since nowhere in the example or tests are we using the helpers from Token2022, only the interface.

`cargo publish --dry-run` checks out.

Lmk.