### PR TITLE
audit: Update shlex to 1.3 due to advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4801,9 +4801,9 @@ checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "shlex"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"


### PR DESCRIPTION
#### Problem

Audit jobs are failing due to https://rustsec.org/advisories/RUSTSEC-2024-0006

#### Solution

Bump the dependency to 1.3 as suggested