### PR TITLE
token-cli: Add initialize-member command

### DIFF
--- a/token/cli/src/clap_app.rs
+++ b/token/cli/src/clap_app.rs
@@ -1077,8 +1077,8 @@ pub fn app<'a, 'b>(
                         ),
                 )
                 .arg(
-                    Arg::with_name("update_authority")
-                        .long("update-authority")
+                    Arg::with_name("group_update_authority")
+                        .long("group-update-authority")
                         .value_name("KEYPAIR")
                         .validator(is_valid_signer)
                         .takes_value(true)

--- a/token/cli/src/clap_app.rs
+++ b/token/cli/src/clap_app.rs
@@ -109,6 +109,7 @@ pub enum CommandName {
     UpdateMetadata,
     InitializeGroup,
     UpdateGroupMaxSize,
+    InitializeMember,
     UpdateConfidentialTransferSettings,
     ConfigureConfidentialTransferAccount,
     EnableConfidentialCredits,
@@ -1037,6 +1038,53 @@ pub fn app<'a, 'b>(
                         .takes_value(true)
                         .help(
                             "Specify the update authority address. \
+                             Defaults to the client keypair address."
+                        ),
+                )
+        )
+        .subcommand(
+            SubCommand::with_name(CommandName::InitializeMember.into())
+                .about("Initialize group member extension on a token mint")
+                .arg(
+                    Arg::with_name("token")
+                        .validator(is_valid_pubkey)
+                        .value_name("TOKEN_MINT_ADDRESS")
+                        .takes_value(true)
+                        .required(true)
+                        .index(1)
+                        .help("The token address of the member account."),
+                )
+                .arg(
+                    Arg::with_name("group_token")
+                        .validator(is_valid_pubkey)
+                        .value_name("TOKEN_MINT_ADDRESS")
+                        .takes_value(true)
+                        .required(true)
+                        .index(2)
+                        .help("The token address of the group account that the token will join."),
+                )
+                .arg(
+                    Arg::with_name("mint_authority")
+                        .long("mint-authority")
+                        .alias("owner")
+                        .value_name("KEYPAIR")
+                        .validator(is_valid_signer)
+                        .takes_value(true)
+                        .help(
+                            "Specify the mint authority keypair. \
+                             This may be a keypair file or the ASK keyword. \
+                             Defaults to the client keypair."
+                        ),
+                )
+                .arg(
+                    Arg::with_name("update_authority")
+                        .long("update-authority")
+                        .value_name("KEYPAIR")
+                        .validator(is_valid_signer)
+                        .takes_value(true)
+                        .help(
+                            "Specify the update authority keypair. \
+                             This may be a keypair file or the ASK keyword. \
                              Defaults to the client keypair address."
                         ),
                 )

--- a/token/cli/src/command.rs
+++ b/token/cli/src/command.rs
@@ -658,7 +658,7 @@ async fn command_initialize_member(
     member_token_pubkey: Pubkey,
     mint_authority: Pubkey,
     group_token_pubkey: Pubkey,
-    update_authority: Pubkey,
+    group_update_authority: Pubkey,
     bulk_signers: Vec<Arc<dyn Signer>>,
 ) -> CommandResult {
     let token = token_client_from_config(config, &member_token_pubkey, None)?;
@@ -668,7 +668,7 @@ async fn command_initialize_member(
             &config.fee_payer()?.pubkey(),
             &mint_authority,
             &group_token_pubkey,
-            &update_authority,
+            &group_update_authority,
             &bulk_signers,
         )
         .await?;
@@ -3592,17 +3592,20 @@ pub async fn process_command<'a>(
                     .unwrap();
             let (mint_authority_signer, mint_authority) =
                 config.signer_or_default(arg_matches, "mint_authority", &mut wallet_manager);
-            let (update_authority_signer, update_authority) =
-                config.signer_or_default(arg_matches, "update_authority", &mut wallet_manager);
+            let (group_update_authority_signer, group_update_authority) = config.signer_or_default(
+                arg_matches,
+                "group_update_authority",
+                &mut wallet_manager,
+            );
             let mut bulk_signers = vec![mint_authority_signer];
-            push_signer_with_dedup(update_authority_signer, &mut bulk_signers);
+            push_signer_with_dedup(group_update_authority_signer, &mut bulk_signers);
 
             command_initialize_member(
                 config,
                 member_token_pubkey,
                 mint_authority,
                 group_token_pubkey,
-                update_authority,
+                group_update_authority,
                 bulk_signers,
             )
             .await

--- a/token/cli/src/command.rs
+++ b/token/cli/src/command.rs
@@ -653,6 +653,37 @@ async fn command_update_group_max_size(
     })
 }
 
+async fn command_initialize_member(
+    config: &Config<'_>,
+    member_token_pubkey: Pubkey,
+    mint_authority: Pubkey,
+    group_token_pubkey: Pubkey,
+    update_authority: Pubkey,
+    bulk_signers: Vec<Arc<dyn Signer>>,
+) -> CommandResult {
+    let token = token_client_from_config(config, &member_token_pubkey, None)?;
+
+    let res = token
+        .token_group_initialize_member_with_rent_transfer(
+            &config.fee_payer()?.pubkey(),
+            &mint_authority,
+            &group_token_pubkey,
+            &update_authority,
+            &bulk_signers,
+        )
+        .await?;
+
+    let tx_return = finish_tx(config, &res, false).await?;
+    Ok(match tx_return {
+        TransactionReturnData::CliSignature(signature) => {
+            config.output_format.formatted_string(&signature)
+        }
+        TransactionReturnData::CliSignOnlyData(sign_only_data) => {
+            config.output_format.formatted_string(&sign_only_data)
+        }
+    })
+}
+
 async fn command_set_transfer_fee(
     config: &Config<'_>,
     token_pubkey: Pubkey,
@@ -3547,6 +3578,31 @@ pub async fn process_command<'a>(
                 token_pubkey,
                 update_authority,
                 new_max_size,
+                bulk_signers,
+            )
+            .await
+        }
+        (CommandName::InitializeMember, arg_matches) => {
+            let member_token_pubkey = pubkey_of_signer(arg_matches, "token", &mut wallet_manager)
+                .unwrap()
+                .unwrap();
+            let group_token_pubkey =
+                pubkey_of_signer(arg_matches, "group_token", &mut wallet_manager)
+                    .unwrap()
+                    .unwrap();
+            let (mint_authority_signer, mint_authority) =
+                config.signer_or_default(arg_matches, "mint_authority", &mut wallet_manager);
+            let (update_authority_signer, update_authority) =
+                config.signer_or_default(arg_matches, "update_authority", &mut wallet_manager);
+            let mut bulk_signers = vec![mint_authority_signer];
+            push_signer_with_dedup(update_authority_signer, &mut bulk_signers);
+
+            command_initialize_member(
+                config,
+                member_token_pubkey,
+                mint_authority,
+                group_token_pubkey,
+                update_authority,
                 bulk_signers,
             )
             .await


### PR DESCRIPTION
#### Problem

Token-2022 and token-client support initializing token group members, but we can't do it in the CLI.

#### Solution

Following the excellent work in #6135, pretty much do the same thing, but for initializing members