### PR TITLE
token-cli: Add command authorize support for TokenGroup 

### DIFF
--- a/token/cli/src/clap_app.rs
+++ b/token/cli/src/clap_app.rs
@@ -191,6 +191,7 @@ pub enum CliAuthorityType {
     Metadata,
     GroupPointer,
     GroupMemberPointer,
+    TokenGroup,
 }
 impl TryFrom<CliAuthorityType> for AuthorityType {
     type Error = Error;
@@ -218,6 +219,9 @@ impl TryFrom<CliAuthorityType> for AuthorityType {
             }
             CliAuthorityType::GroupPointer => Ok(AuthorityType::GroupPointer),
             CliAuthorityType::GroupMemberPointer => Ok(AuthorityType::GroupMemberPointer),
+            CliAuthorityType::TokenGroup => {
+                Err("Token Group update authority does not map to a token authority type".into())
+            }
         }
     }
 }

--- a/token/cli/src/command.rs
+++ b/token/cli/src/command.rs
@@ -70,6 +70,7 @@ use {
         client::{ProgramRpcClientSendTransaction, RpcClientResponse},
         token::{ExtensionInitializationParams, Token},
     },
+    spl_token_group_interface::state::TokenGroup,
     spl_token_metadata_interface::state::{Field, TokenMetadata},
     std::{collections::HashMap, fmt::Display, process::exit, rc::Rc, str::FromStr, sync::Arc},
 };
@@ -1016,6 +1017,16 @@ async fn command_authorize(
                         ))
                     }
                 }
+                CliAuthorityType::TokenGroup => {
+                    if let Ok(extension) = mint.get_extension::<TokenGroup>() {
+                        Ok(Option::<Pubkey>::from(extension.update_authority))
+                    } else {
+                        Err(format!(
+                            "Mint `{}` does not support a group member pointer",
+                            account
+                        ))
+                    }
+                }
             }?;
 
             Ok((account, previous_authority))
@@ -1056,6 +1067,7 @@ async fn command_authorize(
                 | CliAuthorityType::MetadataPointer
                 | CliAuthorityType::Metadata
                 | CliAuthorityType::GroupPointer
+                | CliAuthorityType::TokenGroup
                 | CliAuthorityType::GroupMemberPointer => Err(format!(
                     "Authority type `{auth_str}` not supported for SPL Token accounts",
                 )),
@@ -1107,20 +1119,28 @@ async fn command_authorize(
         ),
     );
 
-    let res = if let CliAuthorityType::Metadata = authority_type {
-        token
-            .token_metadata_update_authority(&authority, new_authority, &bulk_signers)
-            .await?
-    } else {
-        token
-            .set_authority(
-                &account,
-                &authority,
-                new_authority.as_ref(),
-                authority_type.try_into()?,
-                &bulk_signers,
-            )
-            .await?
+    let res = match authority_type {
+        CliAuthorityType::Metadata => {
+            token
+                .token_metadata_update_authority(&authority, new_authority, &bulk_signers)
+                .await?
+        }
+        CliAuthorityType::TokenGroup => {
+            token
+                .token_group_update_authority(&authority, new_authority, &bulk_signers)
+                .await?
+        }
+        _ => {
+            token
+                .set_authority(
+                    &account,
+                    &authority,
+                    new_authority.as_ref(),
+                    authority_type.try_into()?,
+                    &bulk_signers,
+                )
+                .await?
+        }
     };
 
     let tx_return = finish_tx(config, &res, false).await?;

--- a/token/cli/tests/command.rs
+++ b/token/cli/tests/command.rs
@@ -3912,4 +3912,27 @@ async fn group(test_validator: &TestValidator, payer: &Keypair) {
     assert_eq!(extension.group, mint);
     assert_eq!(extension.mint, member_mint);
     assert_eq!(u32::from(extension.member_number), 1);
+
+    // update authority
+    process_test_command(
+        &config,
+        payer,
+        &[
+            "spl-token",
+            CommandName::Authorize.into(),
+            &mint.to_string(),
+            "token-group",
+            &mint.to_string(),
+        ],
+    )
+    .await
+    .unwrap();
+
+    let account = config.rpc_client.get_account(&mint).await.unwrap();
+    let mint_state = StateWithExtensionsOwned::<Mint>::unpack(account.data).unwrap();
+    let fetched_metadata = mint_state.get_extension::<TokenGroup>().unwrap();
+    assert_eq!(
+        fetched_metadata.update_authority,
+        Some(mint).try_into().unwrap()
+    );
 }


### PR DESCRIPTION
Added support for changing the update authority for a Token group. Added a similar test used for updating the metadata authority. 

#5937