### PR TITLE
stake-pool-test: Fix updating blockhash, force a new one

### DIFF
--- a/stake-pool/program/tests/update_validator_list_balance.rs
+++ b/stake-pool/program/tests/update_validator_list_balance.rs
@@ -141,7 +141,7 @@ async fn setup(
 
     let last_blockhash = context
         .banks_client
-        .get_new_latest_blockhash(&context.last_blockhash)
+        .get_new_latest_blockhash(&last_blockhash)
         .await
         .unwrap();
 
@@ -696,6 +696,12 @@ async fn success_with_burned_tokens() {
     let slots_per_epoch = context.genesis_config().epoch_schedule.slots_per_epoch;
     slot += slots_per_epoch;
     context.warp_to_slot(slot).unwrap();
+
+    let last_blockhash = context
+        .banks_client
+        .get_new_latest_blockhash(&last_blockhash)
+        .await
+        .unwrap();
 
     let mint_info = get_account(
         &mut context.banks_client,


### PR DESCRIPTION
#### Problem

The `success_with_burned_tokens` stake pool test is still flaky: https://github.com/solana-labs/solana-program-library/actions/runs/7625706514/job/20770570815?pr=6165

#### Solution

Force refresh the blockhash to be sure that the pool update happens, and fix the blockhash provided by the test setup.