### PR TITLE
docs: Add "Token Extensions" in the top-level doc

### DIFF
--- a/docs/src/token-2022.md
+++ b/docs/src/token-2022.md
@@ -5,8 +5,8 @@ title: Token-2022 Program
 A token program on the Solana blockchain, defining a common implementation for
 fungible and non-fungible tokens.
 
-The Token-2022 Program is a superset of the functionality provided by the
-[Token Program](token.mdx).
+The Token-2022 Program, also known as Token Extensions,  is a superset of the
+functionality provided by the [Token Program](token.mdx).
 
 | Information | Account Address |
 | --- | --- |

--- a/docs/src/token-2022.md
+++ b/docs/src/token-2022.md
@@ -5,7 +5,7 @@ title: Token-2022 Program
 A token program on the Solana blockchain, defining a common implementation for
 fungible and non-fungible tokens.
 
-The Token-2022 Program, also known as Token Extensions,  is a superset of the
+The Token-2022 Program, also known as Token Extensions, is a superset of the
 functionality provided by the [Token Program](token.mdx).
 
 | Information | Account Address |


### PR DESCRIPTION
#### Problem

There's a disconnect between the "Token Extensions" and "Token-2022" names in the docs.

#### Solution

Call out that it's also called "Token Extensions"