### PR TITLE
token-2022: Bump to v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6647,7 +6647,7 @@ dependencies = [
  "num-traits",
  "solana-program",
  "spl-token 4.0.0",
- "spl-token-2022 1.0.0",
+ "spl-token-2022 2.0.0",
  "thiserror",
 ]
 
@@ -6660,7 +6660,7 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account 2.3.0",
  "spl-token 4.0.0",
- "spl-token-2022 1.0.0",
+ "spl-token-2022 2.0.0",
 ]
 
 [[package]]
@@ -7222,7 +7222,7 @@ dependencies = [
  "spl-math",
  "spl-pod 0.1.0",
  "spl-token 4.0.0",
- "spl-token-2022 1.0.0",
+ "spl-token-2022 2.0.0",
  "test-case",
  "thiserror",
 ]
@@ -7341,7 +7341,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-2022"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "arrayref",
  "base64 0.21.7",
@@ -7386,7 +7386,7 @@ dependencies = [
  "spl-memo 4.0.0",
  "spl-pod 0.1.0",
  "spl-tlv-account-resolution 0.5.1",
- "spl-token-2022 1.0.0",
+ "spl-token-2022 2.0.0",
  "spl-token-client",
  "spl-token-group-interface",
  "spl-token-metadata-interface 0.2.0",
@@ -7423,7 +7423,7 @@ dependencies = [
  "spl-associated-token-account 2.3.0",
  "spl-memo 4.0.0",
  "spl-token 4.0.0",
- "spl-token-2022 1.0.0",
+ "spl-token-2022 2.0.0",
  "spl-token-client",
  "spl-token-group-interface",
  "spl-token-metadata-interface 0.2.0",
@@ -7451,7 +7451,7 @@ dependencies = [
  "spl-associated-token-account 2.3.0",
  "spl-memo 4.0.0",
  "spl-token 4.0.0",
- "spl-token-2022 1.0.0",
+ "spl-token-2022 2.0.0",
  "spl-token-group-interface",
  "spl-token-metadata-interface 0.2.0",
  "spl-transfer-hook-interface 0.5.0",
@@ -7468,7 +7468,7 @@ dependencies = [
  "spl-discriminator 0.1.0",
  "spl-pod 0.1.0",
  "spl-program-error 0.3.0",
- "spl-token-2022 1.0.0",
+ "spl-token-2022 2.0.0",
  "spl-token-client",
  "spl-token-group-example",
  "spl-token-group-interface",
@@ -7485,7 +7485,7 @@ dependencies = [
  "solana-sdk",
  "spl-discriminator 0.1.0",
  "spl-pod 0.1.0",
- "spl-token-2022 1.0.0",
+ "spl-token-2022 2.0.0",
  "spl-token-client",
  "spl-token-group-interface",
  "spl-token-metadata-interface 0.2.0",
@@ -7545,7 +7545,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-pod 0.1.0",
- "spl-token-2022 1.0.0",
+ "spl-token-2022 2.0.0",
  "spl-token-client",
  "spl-token-metadata-interface 0.2.0",
  "spl-type-length-value 0.3.0",
@@ -7595,7 +7595,7 @@ dependencies = [
  "solana-sdk",
  "spl-math",
  "spl-token 4.0.0",
- "spl-token-2022 1.0.0",
+ "spl-token-2022 2.0.0",
  "test-case",
  "thiserror",
 ]
@@ -7623,7 +7623,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-token 4.0.0",
- "spl-token-2022 1.0.0",
+ "spl-token-2022 2.0.0",
  "spl-token-client",
  "test-case",
  "thiserror",
@@ -7644,7 +7644,7 @@ dependencies = [
  "solana-test-validator",
  "spl-associated-token-account 2.3.0",
  "spl-token 4.0.0",
- "spl-token-2022 1.0.0",
+ "spl-token-2022 2.0.0",
  "spl-token-client",
  "spl-token-upgrade",
  "tokio",
@@ -7660,7 +7660,7 @@ dependencies = [
  "solana-program",
  "spl-associated-token-account 2.3.0",
  "spl-token 4.0.0",
- "spl-token-2022 1.0.0",
+ "spl-token-2022 2.0.0",
  "thiserror",
 ]
 
@@ -7681,7 +7681,7 @@ dependencies = [
  "solana-sdk",
  "solana-test-validator",
  "spl-tlv-account-resolution 0.5.1",
- "spl-token-2022 1.0.0",
+ "spl-token-2022 2.0.0",
  "spl-token-client",
  "spl-transfer-hook-interface 0.5.0",
  "strum 0.25.0",
@@ -7698,7 +7698,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-tlv-account-resolution 0.5.1",
- "spl-token-2022 1.0.0",
+ "spl-token-2022 2.0.0",
  "spl-transfer-hook-interface 0.5.0",
  "spl-type-length-value 0.3.0",
 ]

--- a/associated-token-account/program-test/Cargo.toml
+++ b/associated-token-account/program-test/Cargo.toml
@@ -16,4 +16,4 @@ solana-program-test = ">=1.17.13,<=2"
 solana-sdk = ">=1.17.13,<=2"
 spl-associated-token-account = { version = "2", path = "../program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "1.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "2.0", path = "../../token/program-2022", features = ["no-entrypoint"] }

--- a/associated-token-account/program/Cargo.toml
+++ b/associated-token-account/program/Cargo.toml
@@ -18,7 +18,7 @@ num-derive = "0.4"
 num-traits = "0.2"
 solana-program = ">=1.17.13,<=2"
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "1.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "2.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [lib]

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -24,7 +24,7 @@ solana-program = ">=1.17.13,<=2"
 solana-security-txt = "1.1.1"
 spl-math = { version = "0.2", path = "../../libraries/math", features = [ "no-entrypoint" ] }
 spl-pod = { version = "0.1", path = "../../libraries/pod", features = ["borsh"] }
-spl-token-2022 = { version = "1.0", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
+spl-token-2022 = { version = "2.0", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 bincode = "1.3.1"
 

--- a/token-collection/program/Cargo.toml
+++ b/token-collection/program/Cargo.toml
@@ -15,7 +15,7 @@ test-sbf = []
 solana-program = ">=1.17.13,<=2"
 spl-pod = { version = "0.1.0", path = "../../libraries/pod" }
 spl-program-error = { version = "0.3.0" , path = "../../libraries/program-error" }
-spl-token-2022 = { version = "1.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "2.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-group-example = { version = "0.1.0", path = "../../token-group/example", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.1.0", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }

--- a/token-group/example/Cargo.toml
+++ b/token-group/example/Cargo.toml
@@ -14,7 +14,7 @@ test-sbf = []
 [dependencies]
 solana-program = ">=1.17.13,<=2"
 spl-pod = { version = "0.1.0", path = "../../libraries/pod" }
-spl-token-2022 = { version = "1.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "2.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.1.0", path = "../interface" }
 spl-type-length-value = { version = "0.3.0", path = "../../libraries/type-length-value" }
 

--- a/token-metadata/example/Cargo.toml
+++ b/token-metadata/example/Cargo.toml
@@ -13,7 +13,7 @@ test-sbf = []
 
 [dependencies]
 solana-program = ">=1.17.13,<=2"
-spl-token-2022 = { version = "1.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "2.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-metadata-interface = { version = "0.2.0", path = "../interface" }
 spl-type-length-value = { version = "0.3.0" , path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.1.0", path = "../../libraries/pod" }

--- a/token-swap/program/Cargo.toml
+++ b/token-swap/program/Cargo.toml
@@ -20,7 +20,7 @@ num-traits = "0.2"
 solana-program = ">=1.17.13,<=2"
 spl-math = { version = "0.2", path = "../../libraries/math", features = [ "no-entrypoint" ] }
 spl-token = { version = "4.0", path = "../../token/program", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "1.0", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
+spl-token-2022 = { version = "2.0", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 arbitrary = { version = "1.3", features = ["derive"], optional = true }
 roots = { version = "0.0.8", optional = true }

--- a/token-upgrade/cli/Cargo.toml
+++ b/token-upgrade/cli/Cargo.toml
@@ -21,7 +21,7 @@ solana-remote-wallet = ">=1.17.13,<=2"
 solana-sdk = ">=1.17.13,<=2"
 spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "1.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "2.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.8", path = "../../token/client" }
 spl-token-upgrade = { version = "0.1", path = "../program", features = ["no-entrypoint"] }
 tokio = { version = "1", features = ["full"] }

--- a/token-upgrade/program/Cargo.toml
+++ b/token-upgrade/program/Cargo.toml
@@ -16,7 +16,7 @@ num-derive = "0.4"
 num-traits = "0.2"
 num_enum = "0.7.2"
 solana-program = ">=1.17.13,<=2"
-spl-token-2022 = { version = "1.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "2.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/token-wrap/program/Cargo.toml
+++ b/token-wrap/program/Cargo.toml
@@ -17,7 +17,7 @@ num_enum = "0.7"
 solana-program = ">=1.17.13,<=2"
 spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "1.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "2.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [lib]

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -31,7 +31,7 @@ solana-transaction-status = ">=1.17.13,<=2"
 spl-token = { version = "4.0", path = "../program", features = [
   "no-entrypoint",
 ] }
-spl-token-2022 = { version = "1.0", path = "../program-2022", features = [
+spl-token-2022 = { version = "2.0", path = "../program-2022", features = [
   "no-entrypoint",
 ] }
 spl-token-client = { version = "0.8", path = "../client" }

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -23,7 +23,7 @@ solana-sdk = ">=1.17.13,<=2"
 spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-memo = { version = "4.0.0", path = "../../memo/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path="../program", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "1.0", path="../program-2022" }
+spl-token-2022 = { version = "2.0", path="../program-2022" }
 spl-token-group-interface = { version = "0.1", path="../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.2", path="../../token-metadata/interface" }
 spl-transfer-hook-interface = { version = "0.5", path="../transfer-hook/interface" }

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -25,7 +25,7 @@ solana-sdk = ">=1.17.13,<=2"
 spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program" }
 spl-memo = { version = "4.0.0", path = "../../memo/program", features = ["no-entrypoint"] }
 spl-pod = { version = "0.1.0", path = "../../libraries/pod" }
-spl-token-2022 = { version = "1.0", path="../program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "2.0", path="../program-2022", features = ["no-entrypoint"] }
 spl-instruction-padding = { version = "0.1.0", path="../../instruction-padding/program", features = ["no-entrypoint"] }
 spl-tlv-account-resolution = { version = "0.5.0", path = "../../libraries/tlv-account-resolution" }
 spl-token-client = { version = "0.8", path = "../client" }

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-2022"
-version = "1.0.0"
+version = "2.0.0"
 description = "Solana Program Library Token 2022"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token/transfer-hook/cli/Cargo.toml
+++ b/token/transfer-hook/cli/Cargo.toml
@@ -28,7 +28,7 @@ serde_yaml = "0.9.30"
 
 [dev-dependencies]
 solana-test-validator = ">=1.17.13,<=2"
-spl-token-2022 = { version = "1.0", path = "../../program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "2.0", path = "../../program-2022", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.8", path = "../../client" }
 
 [[bin]]

--- a/token/transfer-hook/example/Cargo.toml
+++ b/token/transfer-hook/example/Cargo.toml
@@ -15,7 +15,7 @@ test-sbf = []
 arrayref = "0.3.7"
 solana-program = ">=1.17.13,<=2"
 spl-tlv-account-resolution = { version = "0.5" , path = "../../../libraries/tlv-account-resolution" }
-spl-token-2022 = { version = "1.0",  path = "../../program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "2.0",  path = "../../program-2022", features = ["no-entrypoint"] }
 spl-transfer-hook-interface = { version = "0.5" , path = "../interface" }
 spl-type-length-value = { version = "0.3" , path = "../../../libraries/type-length-value" }
 


### PR DESCRIPTION
#### Problem

There's a breaking change in the master version of token-2022, but we need to publish new crates for the solana v2 bump in #6182

#### Solution

Bump token-2022 to a new major version so that the new crates can be used.

cc @willhickey 