### PR TITLE
reduce cluttering by removing debug print command

### DIFF
--- a/stake-pool/py/stake_pool/state.py
+++ b/stake-pool/py/stake_pool/state.py
@@ -179,7 +179,6 @@ class ValidatorList(NamedTuple):
     def decode(cls, data: str, encoding: str):
         data_bytes = decode_byte_string(data, encoding)
         parsed = DECODE_VALIDATOR_LIST_LAYOUT.parse(data_bytes)
-        print(parsed)
         return ValidatorList(
             max_validators=parsed['max_validators'],
             validators=[ValidatorStakeInfo.decode_container(container) for container in parsed['validators']],


### PR DESCRIPTION
The ValidatorList.decode method has a debug print command in it that clutters the output whenever I use that function. Assume it is there for debugging purposes so should be safe to remove.