### PR TITLE
token-2022: initialize an account on a non-transferable mint without immutable ownership

### DIFF
--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -812,6 +812,9 @@ impl<'data, S: BaseState> StateWithExtensionsMut<'data, S> {
             ExtensionType::TransferFeeAmount => {
                 self.init_extension::<TransferFeeAmount>(true).map(|_| ())
             }
+            ExtensionType::ImmutableOwner => {
+                self.init_extension::<ImmutableOwner>(true).map(|_| ())
+            }
             ExtensionType::NonTransferableAccount => self
                 .init_extension::<NonTransferableAccount>(true)
                 .map(|_| ()),
@@ -1133,6 +1136,7 @@ impl ExtensionType {
                 }
                 ExtensionType::NonTransferable => {
                     account_extension_types.push(ExtensionType::NonTransferableAccount);
+                    account_extension_types.push(ExtensionType::ImmutableOwner);
                 }
                 ExtensionType::TransferHook => {
                     account_extension_types.push(ExtensionType::TransferHookAccount);


### PR DESCRIPTION
This PR improves the token-2022 account initialisation addressed by issue (#5884).
when trying to initialize an account on a non-transferable mint,  Now It will check whether the account has immutable ownership:
1. if yes, pass the check.
2. if no, return NonTransferableNeedsImmutableOwnership error.