### PR TITLE
Bump SPL crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7082,7 +7082,7 @@ dependencies = [
  "num-derive 0.4.1",
  "num-traits",
  "solana-program",
- "spl-program-error-derive 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-program-error-derive 0.3.1",
  "thiserror",
 ]
 
@@ -7096,13 +7096,15 @@ dependencies = [
  "serial_test",
  "solana-program",
  "solana-sdk",
- "spl-program-error-derive 0.3.1",
+ "spl-program-error-derive 0.3.2",
  "thiserror",
 ]
 
 [[package]]
 name = "spl-program-error-derive"
 version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5269c8e868da17b6552ef35a51355a017bd8e0eae269c201fef830d35fa52c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7112,9 +7114,7 @@ dependencies = [
 
 [[package]]
 name = "spl-program-error-derive"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5269c8e868da17b6552ef35a51355a017bd8e0eae269c201fef830d35fa52c"
+version = "0.3.2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4929,7 +4929,7 @@ dependencies = [
  "solana-sdk",
  "spl-token 4.0.0",
  "spl-token-2022 1.0.0",
- "spl-token-group-interface 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-group-interface 0.1.0",
  "spl-token-metadata-interface 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "zstd",
@@ -7337,7 +7337,7 @@ dependencies = [
  "spl-memo 4.0.0",
  "spl-pod 0.1.0",
  "spl-token 4.0.0",
- "spl-token-group-interface 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-group-interface 0.1.0",
  "spl-token-metadata-interface 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-transfer-hook-interface 0.4.1",
  "spl-type-length-value 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7369,7 +7369,7 @@ dependencies = [
  "spl-pod 0.1.1",
  "spl-tlv-account-resolution 0.5.2",
  "spl-token 4.0.1",
- "spl-token-group-interface 0.1.0",
+ "spl-token-group-interface 0.1.1",
  "spl-token-metadata-interface 0.2.0",
  "spl-transfer-hook-interface 0.5.0",
  "spl-type-length-value 0.3.0",
@@ -7393,7 +7393,7 @@ dependencies = [
  "spl-tlv-account-resolution 0.5.2",
  "spl-token-2022 2.0.0",
  "spl-token-client",
- "spl-token-group-interface 0.1.0",
+ "spl-token-group-interface 0.1.1",
  "spl-token-metadata-interface 0.2.0",
  "spl-transfer-hook-example",
  "spl-transfer-hook-interface 0.5.0",
@@ -7430,7 +7430,7 @@ dependencies = [
  "spl-token 4.0.1",
  "spl-token-2022 2.0.0",
  "spl-token-client",
- "spl-token-group-interface 0.1.0",
+ "spl-token-group-interface 0.1.1",
  "spl-token-metadata-interface 0.2.0",
  "strum 0.26.1",
  "strum_macros 0.26.1",
@@ -7457,7 +7457,7 @@ dependencies = [
  "spl-memo 4.0.1",
  "spl-token 4.0.1",
  "spl-token-2022 2.0.0",
- "spl-token-group-interface 0.1.0",
+ "spl-token-group-interface 0.1.1",
  "spl-token-metadata-interface 0.2.0",
  "spl-transfer-hook-interface 0.5.0",
  "thiserror",
@@ -7476,7 +7476,7 @@ dependencies = [
  "spl-token-2022 2.0.0",
  "spl-token-client",
  "spl-token-group-example",
- "spl-token-group-interface 0.1.0",
+ "spl-token-group-interface 0.1.1",
  "spl-token-metadata-interface 0.2.0",
  "spl-type-length-value 0.3.0",
 ]
@@ -7492,20 +7492,8 @@ dependencies = [
  "spl-pod 0.1.1",
  "spl-token-2022 2.0.0",
  "spl-token-client",
- "spl-token-group-interface 0.1.0",
+ "spl-token-group-interface 0.1.1",
  "spl-token-metadata-interface 0.2.0",
- "spl-type-length-value 0.3.0",
-]
-
-[[package]]
-name = "spl-token-group-interface"
-version = "0.1.0"
-dependencies = [
- "bytemuck",
- "solana-program",
- "spl-discriminator 0.1.1",
- "spl-pod 0.1.1",
- "spl-program-error 0.3.1",
  "spl-type-length-value 0.3.0",
 ]
 
@@ -7520,6 +7508,18 @@ dependencies = [
  "spl-discriminator 0.1.0",
  "spl-pod 0.1.0",
  "spl-program-error 0.3.0",
+]
+
+[[package]]
+name = "spl-token-group-interface"
+version = "0.1.1"
+dependencies = [
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator 0.1.1",
+ "spl-pod 0.1.1",
+ "spl-program-error 0.3.1",
+ "spl-type-length-value 0.3.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6969,7 +6969,7 @@ dependencies = [
 
 [[package]]
 name = "spl-instruction-padding"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "num_enum 0.7.2",
  "solana-program",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7049,6 +7049,19 @@ dependencies = [
 [[package]]
 name = "spl-pod"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2881dddfca792737c0706fa0175345ab282b1b0879c7d877bad129645737c079"
+dependencies = [
+ "borsh 0.10.3",
+ "bytemuck",
+ "solana-program",
+ "solana-zk-token-sdk",
+ "spl-program-error 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "spl-pod"
+version = "0.1.1"
 dependencies = [
  "base64 0.21.7",
  "borsh 0.10.3",
@@ -7058,19 +7071,6 @@ dependencies = [
  "solana-program",
  "solana-zk-token-sdk",
  "spl-program-error 0.3.0",
-]
-
-[[package]]
-name = "spl-pod"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2881dddfca792737c0706fa0175345ab282b1b0879c7d877bad129645737c079"
-dependencies = [
- "borsh 0.10.3",
- "bytemuck",
- "solana-program",
- "solana-zk-token-sdk",
- "spl-program-error 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -7132,7 +7132,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-pod 0.1.0",
+ "spl-pod 0.1.1",
  "thiserror",
 ]
 
@@ -7223,7 +7223,7 @@ dependencies = [
  "solana-security-txt",
  "solana-vote-program",
  "spl-math",
- "spl-pod 0.1.0",
+ "spl-pod 0.1.1",
  "spl-token 4.0.0",
  "spl-token-2022 2.0.0",
  "test-case",
@@ -7268,7 +7268,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-discriminator 0.1.1",
- "spl-pod 0.1.0",
+ "spl-pod 0.1.1",
  "spl-program-error 0.3.0",
  "spl-type-length-value 0.3.0",
 ]
@@ -7282,7 +7282,7 @@ dependencies = [
  "bytemuck",
  "solana-program",
  "spl-discriminator 0.1.0",
- "spl-pod 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-pod 0.1.0",
  "spl-program-error 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-type-length-value 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -7335,7 +7335,7 @@ dependencies = [
  "solana-security-txt",
  "solana-zk-token-sdk",
  "spl-memo 4.0.0",
- "spl-pod 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-pod 0.1.0",
  "spl-token 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token-group-interface 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token-metadata-interface 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7366,7 +7366,7 @@ dependencies = [
  "solana-security-txt",
  "solana-zk-token-sdk",
  "spl-memo 4.0.1",
- "spl-pod 0.1.0",
+ "spl-pod 0.1.1",
  "spl-tlv-account-resolution 0.5.1",
  "spl-token 4.0.0",
  "spl-token-group-interface 0.1.0",
@@ -7389,7 +7389,7 @@ dependencies = [
  "spl-associated-token-account 2.3.1",
  "spl-instruction-padding",
  "spl-memo 4.0.1",
- "spl-pod 0.1.0",
+ "spl-pod 0.1.1",
  "spl-tlv-account-resolution 0.5.1",
  "spl-token-2022 2.0.0",
  "spl-token-client",
@@ -7471,7 +7471,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-discriminator 0.1.1",
- "spl-pod 0.1.0",
+ "spl-pod 0.1.1",
  "spl-program-error 0.3.0",
  "spl-token-2022 2.0.0",
  "spl-token-client",
@@ -7489,7 +7489,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-discriminator 0.1.1",
- "spl-pod 0.1.0",
+ "spl-pod 0.1.1",
  "spl-token-2022 2.0.0",
  "spl-token-client",
  "spl-token-group-interface 0.1.0",
@@ -7504,7 +7504,7 @@ dependencies = [
  "bytemuck",
  "solana-program",
  "spl-discriminator 0.1.1",
- "spl-pod 0.1.0",
+ "spl-pod 0.1.1",
  "spl-program-error 0.3.0",
  "spl-type-length-value 0.3.0",
 ]
@@ -7518,7 +7518,7 @@ dependencies = [
  "bytemuck",
  "solana-program",
  "spl-discriminator 0.1.0",
- "spl-pod 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-pod 0.1.0",
  "spl-program-error 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -7562,7 +7562,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-pod 0.1.0",
+ "spl-pod 0.1.1",
  "spl-token-2022 2.0.0",
  "spl-token-client",
  "spl-token-metadata-interface 0.2.0",
@@ -7579,7 +7579,7 @@ dependencies = [
  "serde_json",
  "solana-program",
  "spl-discriminator 0.1.1",
- "spl-pod 0.1.0",
+ "spl-pod 0.1.1",
  "spl-program-error 0.3.0",
  "spl-type-length-value 0.3.0",
 ]
@@ -7593,7 +7593,7 @@ dependencies = [
  "borsh 0.10.3",
  "solana-program",
  "spl-discriminator 0.1.0",
- "spl-pod 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-pod 0.1.0",
  "spl-program-error 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-type-length-value 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -7731,7 +7731,7 @@ dependencies = [
  "bytemuck",
  "solana-program",
  "spl-discriminator 0.1.0",
- "spl-pod 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-pod 0.1.0",
  "spl-program-error 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-tlv-account-resolution 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-type-length-value 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7745,7 +7745,7 @@ dependencies = [
  "bytemuck",
  "solana-program",
  "spl-discriminator 0.1.1",
- "spl-pod 0.1.0",
+ "spl-pod 0.1.1",
  "spl-program-error 0.3.0",
  "spl-tlv-account-resolution 0.5.1",
  "spl-type-length-value 0.3.0",
@@ -7759,7 +7759,7 @@ dependencies = [
  "bytemuck",
  "solana-program",
  "spl-discriminator 0.1.1",
- "spl-pod 0.1.0",
+ "spl-pod 0.1.1",
  "spl-program-error 0.3.0",
  "spl-type-length-value-derive",
 ]
@@ -7773,7 +7773,7 @@ dependencies = [
  "bytemuck",
  "solana-program",
  "spl-discriminator 0.1.0",
- "spl-pod 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-pod 0.1.0",
  "spl-program-error 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6424,7 +6424,7 @@ dependencies = [
  "serde_json",
  "solana-account-decoder",
  "solana-sdk",
- "spl-associated-token-account 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-associated-token-account 2.3.0",
  "spl-memo 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token-2022 1.0.0",
@@ -6627,20 +6627,6 @@ dependencies = [
 [[package]]
 name = "spl-associated-token-account"
 version = "2.3.0"
-dependencies = [
- "assert_matches",
- "borsh 0.10.3",
- "num-derive 0.4.1",
- "num-traits",
- "solana-program",
- "spl-token 4.0.0",
- "spl-token-2022 2.0.0",
- "thiserror",
-]
-
-[[package]]
-name = "spl-associated-token-account"
-version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "992d9c64c2564cc8f63a4b508bf3ebcdf2254b0429b13cd1d31adb6162432a5f"
 dependencies = [
@@ -6655,13 +6641,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-associated-token-account"
+version = "2.3.1"
+dependencies = [
+ "assert_matches",
+ "borsh 0.10.3",
+ "num-derive 0.4.1",
+ "num-traits",
+ "solana-program",
+ "spl-token 4.0.0",
+ "spl-token-2022 2.0.0",
+ "thiserror",
+]
+
+[[package]]
 name = "spl-associated-token-account-test"
 version = "0.0.1"
 dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 2.3.0",
+ "spl-associated-token-account 2.3.1",
  "spl-token 4.0.0",
  "spl-token-2022 2.0.0",
 ]
@@ -6697,22 +6697,22 @@ dependencies = [
 [[package]]
 name = "spl-discriminator"
 version = "0.1.0"
-dependencies = [
- "borsh 0.10.3",
- "bytemuck",
- "solana-program",
- "spl-discriminator-derive 0.1.1",
-]
-
-[[package]]
-name = "spl-discriminator"
-version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cce5d563b58ef1bb2cdbbfe0dfb9ffdc24903b10ae6a4df2d8f425ece375033f"
 dependencies = [
  "bytemuck",
  "solana-program",
  "spl-discriminator-derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "spl-discriminator"
+version = "0.1.1"
+dependencies = [
+ "borsh 0.10.3",
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator-derive 0.1.1",
 ]
 
 [[package]]
@@ -6986,7 +6986,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 2.3.0",
+ "spl-associated-token-account 2.3.1",
  "spl-token 4.0.0",
  "thiserror",
 ]
@@ -7163,7 +7163,7 @@ dependencies = [
  "solana-sdk",
  "solana-security-txt",
  "solana-vote-program",
- "spl-associated-token-account 2.3.0",
+ "spl-associated-token-account 2.3.1",
  "spl-token 4.0.0",
  "test-case",
  "thiserror",
@@ -7193,7 +7193,7 @@ dependencies = [
  "solana-test-validator",
  "solana-transaction-status",
  "solana-vote-program",
- "spl-associated-token-account 2.3.0",
+ "spl-associated-token-account 2.3.1",
  "spl-single-pool",
  "spl-token 4.0.0",
  "spl-token-client",
@@ -7250,7 +7250,7 @@ dependencies = [
  "solana-program",
  "solana-remote-wallet",
  "solana-sdk",
- "spl-associated-token-account 2.3.0",
+ "spl-associated-token-account 2.3.1",
  "spl-stake-pool",
  "spl-token 4.0.0",
 ]
@@ -7267,7 +7267,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-discriminator 0.1.0",
+ "spl-discriminator 0.1.1",
  "spl-pod 0.1.0",
  "spl-program-error 0.3.0",
  "spl-type-length-value 0.3.0",
@@ -7281,7 +7281,7 @@ checksum = "615d381f48ddd2bb3c57c7f7fb207591a2a05054639b18a62e785117dd7a8683"
 dependencies = [
  "bytemuck",
  "solana-program",
- "spl-discriminator 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-discriminator 0.1.0",
  "spl-pod 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-program-error 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-type-length-value 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7386,7 +7386,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 2.3.0",
+ "spl-associated-token-account 2.3.1",
  "spl-instruction-padding",
  "spl-memo 4.0.0",
  "spl-pod 0.1.0",
@@ -7425,7 +7425,7 @@ dependencies = [
  "solana-sdk",
  "solana-test-validator",
  "solana-transaction-status",
- "spl-associated-token-account 2.3.0",
+ "spl-associated-token-account 2.3.1",
  "spl-memo 4.0.0",
  "spl-token 4.0.0",
  "spl-token-2022 2.0.0",
@@ -7453,7 +7453,7 @@ dependencies = [
  "solana-rpc-client",
  "solana-rpc-client-api",
  "solana-sdk",
- "spl-associated-token-account 2.3.0",
+ "spl-associated-token-account 2.3.1",
  "spl-memo 4.0.0",
  "spl-token 4.0.0",
  "spl-token-2022 2.0.0",
@@ -7470,7 +7470,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-discriminator 0.1.0",
+ "spl-discriminator 0.1.1",
  "spl-pod 0.1.0",
  "spl-program-error 0.3.0",
  "spl-token-2022 2.0.0",
@@ -7488,7 +7488,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-discriminator 0.1.0",
+ "spl-discriminator 0.1.1",
  "spl-pod 0.1.0",
  "spl-token-2022 2.0.0",
  "spl-token-client",
@@ -7503,7 +7503,7 @@ version = "0.1.0"
 dependencies = [
  "bytemuck",
  "solana-program",
- "spl-discriminator 0.1.0",
+ "spl-discriminator 0.1.1",
  "spl-pod 0.1.0",
  "spl-program-error 0.3.0",
  "spl-type-length-value 0.3.0",
@@ -7517,7 +7517,7 @@ checksum = "b889509d49fa74a4a033ca5dae6c2307e9e918122d97e58562f5c4ffa795c75d"
 dependencies = [
  "bytemuck",
  "solana-program",
- "spl-discriminator 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-discriminator 0.1.0",
  "spl-pod 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-program-error 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -7578,7 +7578,7 @@ dependencies = [
  "serde",
  "serde_json",
  "solana-program",
- "spl-discriminator 0.1.0",
+ "spl-discriminator 0.1.1",
  "spl-pod 0.1.0",
  "spl-program-error 0.3.0",
  "spl-type-length-value 0.3.0",
@@ -7592,7 +7592,7 @@ checksum = "4c16ce3ba6979645fb7627aa1e435576172dd63088dc7848cb09aa331fa1fe4f"
 dependencies = [
  "borsh 0.10.3",
  "solana-program",
- "spl-discriminator 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-discriminator 0.1.0",
  "spl-pod 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-program-error 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-type-length-value 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7660,7 +7660,7 @@ dependencies = [
  "solana-remote-wallet",
  "solana-sdk",
  "solana-test-validator",
- "spl-associated-token-account 2.3.0",
+ "spl-associated-token-account 2.3.1",
  "spl-token 4.0.0",
  "spl-token-2022 2.0.0",
  "spl-token-client",
@@ -7676,7 +7676,7 @@ dependencies = [
  "bytemuck",
  "num_enum 0.7.2",
  "solana-program",
- "spl-associated-token-account 2.3.0",
+ "spl-associated-token-account 2.3.1",
  "spl-token 4.0.0",
  "spl-token-2022 2.0.0",
  "thiserror",
@@ -7730,7 +7730,7 @@ dependencies = [
  "arrayref",
  "bytemuck",
  "solana-program",
- "spl-discriminator 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-discriminator 0.1.0",
  "spl-pod 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-program-error 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-tlv-account-resolution 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7744,7 +7744,7 @@ dependencies = [
  "arrayref",
  "bytemuck",
  "solana-program",
- "spl-discriminator 0.1.0",
+ "spl-discriminator 0.1.1",
  "spl-pod 0.1.0",
  "spl-program-error 0.3.0",
  "spl-tlv-account-resolution 0.5.1",
@@ -7758,7 +7758,7 @@ version = "0.3.0"
 dependencies = [
  "bytemuck",
  "solana-program",
- "spl-discriminator 0.1.0",
+ "spl-discriminator 0.1.1",
  "spl-pod 0.1.0",
  "spl-program-error 0.3.0",
  "spl-type-length-value-derive",
@@ -7772,7 +7772,7 @@ checksum = "a468e6f6371f9c69aae760186ea9f1a01c2908351b06a5e0026d21cfc4d7ecac"
 dependencies = [
  "bytemuck",
  "solana-program",
- "spl-discriminator 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-discriminator 0.1.0",
  "spl-pod 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-program-error 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -7792,7 +7792,7 @@ version = "0.1.0"
 dependencies = [
  "borsh 0.10.3",
  "solana-program",
- "spl-discriminator 0.1.0",
+ "spl-discriminator 0.1.1",
  "spl-type-length-value 0.3.0",
 ]
 
@@ -7804,7 +7804,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 2.3.0",
+ "spl-associated-token-account 2.3.1",
  "spl-token 4.0.0",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,7 +620,7 @@ dependencies = [
  "arrayref",
  "borsh 0.10.3",
  "solana-program",
- "spl-token 4.0.0",
+ "spl-token 4.0.1",
  "thiserror",
  "uint",
 ]
@@ -1914,7 +1914,7 @@ version = "1.0.0"
 dependencies = [
  "arrayref",
  "solana-program",
- "spl-token 4.0.0",
+ "spl-token 4.0.1",
 ]
 
 [[package]]
@@ -4927,7 +4927,7 @@ dependencies = [
  "serde_json",
  "solana-config-program",
  "solana-sdk",
- "spl-token 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token 4.0.0",
  "spl-token-2022 1.0.0",
  "spl-token-group-interface 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token-metadata-interface 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5605,7 +5605,7 @@ dependencies = [
  "solana-transaction-status",
  "solana-vote",
  "solana-vote-program",
- "spl-token 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token 4.0.0",
  "spl-token-2022 1.0.0",
  "static_assertions",
  "strum 0.24.1",
@@ -5988,7 +5988,7 @@ dependencies = [
  "solana-version",
  "solana-vote",
  "solana-vote-program",
- "spl-token 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token 4.0.0",
  "spl-token-2022 1.0.0",
  "stream-cancel",
  "thiserror",
@@ -6426,7 +6426,7 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account 2.3.0",
  "spl-memo 4.0.0",
- "spl-token 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token 4.0.0",
  "spl-token-2022 1.0.0",
  "thiserror",
 ]
@@ -6635,7 +6635,7 @@ dependencies = [
  "num-derive 0.4.1",
  "num-traits",
  "solana-program",
- "spl-token 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token 4.0.0",
  "spl-token-2022 1.0.0",
  "thiserror",
 ]
@@ -6649,7 +6649,7 @@ dependencies = [
  "num-derive 0.4.1",
  "num-traits",
  "solana-program",
- "spl-token 4.0.0",
+ "spl-token 4.0.1",
  "spl-token-2022 2.0.0",
  "thiserror",
 ]
@@ -6662,7 +6662,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-associated-token-account 2.3.1",
- "spl-token 4.0.0",
+ "spl-token 4.0.1",
  "spl-token-2022 2.0.0",
 ]
 
@@ -6676,7 +6676,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-token 4.0.0",
+ "spl-token 4.0.1",
  "thiserror",
  "uint",
 ]
@@ -6811,7 +6811,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-token 4.0.0",
+ "spl-token 4.0.1",
 ]
 
 [[package]]
@@ -6833,7 +6833,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-token 4.0.0",
+ "spl-token 4.0.1",
 ]
 
 [[package]]
@@ -6871,7 +6871,7 @@ dependencies = [
  "spl-governance-addin-mock",
  "spl-governance-test-sdk",
  "spl-governance-tools",
- "spl-token 4.0.0",
+ "spl-token 4.0.1",
  "thiserror",
 ]
 
@@ -6903,7 +6903,7 @@ dependencies = [
  "spl-governance-addin-api",
  "spl-governance-test-sdk",
  "spl-governance-tools",
- "spl-token 4.0.0",
+ "spl-token 4.0.1",
  "thiserror",
 ]
 
@@ -6928,7 +6928,7 @@ dependencies = [
  "spl-governance-addin-mock",
  "spl-governance-test-sdk",
  "spl-governance-tools",
- "spl-token 4.0.0",
+ "spl-token 4.0.1",
  "thiserror",
 ]
 
@@ -6947,7 +6947,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-token 4.0.0",
+ "spl-token 4.0.1",
  "thiserror",
 ]
 
@@ -6963,7 +6963,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-program",
- "spl-token 4.0.0",
+ "spl-token 4.0.1",
  "thiserror",
 ]
 
@@ -6987,7 +6987,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-associated-token-account 2.3.1",
- "spl-token 4.0.0",
+ "spl-token 4.0.1",
  "thiserror",
 ]
 
@@ -7164,7 +7164,7 @@ dependencies = [
  "solana-security-txt",
  "solana-vote-program",
  "spl-associated-token-account 2.3.1",
- "spl-token 4.0.0",
+ "spl-token 4.0.1",
  "test-case",
  "thiserror",
 ]
@@ -7195,7 +7195,7 @@ dependencies = [
  "solana-vote-program",
  "spl-associated-token-account 2.3.1",
  "spl-single-pool",
- "spl-token 4.0.0",
+ "spl-token 4.0.1",
  "spl-token-client",
  "tempfile",
  "test-case",
@@ -7224,7 +7224,7 @@ dependencies = [
  "solana-vote-program",
  "spl-math",
  "spl-pod 0.1.1",
- "spl-token 4.0.0",
+ "spl-token 4.0.1",
  "spl-token-2022 2.0.0",
  "test-case",
  "thiserror",
@@ -7252,7 +7252,7 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account 2.3.1",
  "spl-stake-pool",
- "spl-token 4.0.0",
+ "spl-token 4.0.1",
 ]
 
 [[package]]
@@ -7290,6 +7290,21 @@ dependencies = [
 [[package]]
 name = "spl-token"
 version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08459ba1b8f7c1020b4582c4edf0f5c7511a5e099a7a97570c9698d4f2337060"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive 0.3.3",
+ "num-traits",
+ "num_enum 0.6.1",
+ "solana-program",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-token"
+version = "4.0.1"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -7302,21 +7317,6 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "thiserror",
-]
-
-[[package]]
-name = "spl-token"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08459ba1b8f7c1020b4582c4edf0f5c7511a5e099a7a97570c9698d4f2337060"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive 0.3.3",
- "num-traits",
- "num_enum 0.6.1",
- "solana-program",
  "thiserror",
 ]
 
@@ -7336,7 +7336,7 @@ dependencies = [
  "solana-zk-token-sdk",
  "spl-memo 4.0.0",
  "spl-pod 0.1.0",
- "spl-token 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token 4.0.0",
  "spl-token-group-interface 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token-metadata-interface 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-transfer-hook-interface 0.4.1",
@@ -7368,7 +7368,7 @@ dependencies = [
  "spl-memo 4.0.1",
  "spl-pod 0.1.1",
  "spl-tlv-account-resolution 0.5.2",
- "spl-token 4.0.0",
+ "spl-token 4.0.1",
  "spl-token-group-interface 0.1.0",
  "spl-token-metadata-interface 0.2.0",
  "spl-transfer-hook-interface 0.5.0",
@@ -7427,7 +7427,7 @@ dependencies = [
  "solana-transaction-status",
  "spl-associated-token-account 2.3.1",
  "spl-memo 4.0.1",
- "spl-token 4.0.0",
+ "spl-token 4.0.1",
  "spl-token-2022 2.0.0",
  "spl-token-client",
  "spl-token-group-interface 0.1.0",
@@ -7455,7 +7455,7 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account 2.3.1",
  "spl-memo 4.0.1",
- "spl-token 4.0.0",
+ "spl-token 4.0.1",
  "spl-token-2022 2.0.0",
  "spl-token-group-interface 0.1.0",
  "spl-token-metadata-interface 0.2.0",
@@ -7535,7 +7535,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-token 4.0.0",
+ "spl-token 4.0.1",
  "thiserror",
  "uint",
 ]
@@ -7551,7 +7551,7 @@ dependencies = [
  "solana-logger",
  "solana-program",
  "solana-sdk",
- "spl-token 4.0.0",
+ "spl-token 4.0.1",
  "spl-token-lending",
 ]
 
@@ -7612,7 +7612,7 @@ dependencies = [
  "solana-program",
  "solana-sdk",
  "spl-math",
- "spl-token 4.0.0",
+ "spl-token 4.0.1",
  "spl-token-2022 2.0.0",
  "test-case",
  "thiserror",
@@ -7626,7 +7626,7 @@ dependencies = [
  "honggfuzz",
  "solana-program",
  "spl-math",
- "spl-token 4.0.0",
+ "spl-token 4.0.1",
  "spl-token-swap",
 ]
 
@@ -7640,7 +7640,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-token 4.0.0",
+ "spl-token 4.0.1",
  "spl-token-2022 2.0.0",
  "spl-token-client",
  "test-case",
@@ -7661,7 +7661,7 @@ dependencies = [
  "solana-sdk",
  "solana-test-validator",
  "spl-associated-token-account 2.3.1",
- "spl-token 4.0.0",
+ "spl-token 4.0.1",
  "spl-token-2022 2.0.0",
  "spl-token-client",
  "spl-token-upgrade",
@@ -7677,7 +7677,7 @@ dependencies = [
  "num_enum 0.7.2",
  "solana-program",
  "spl-associated-token-account 2.3.1",
- "spl-token 4.0.0",
+ "spl-token 4.0.1",
  "spl-token-2022 2.0.0",
  "thiserror",
 ]
@@ -7805,7 +7805,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-associated-token-account 2.3.1",
- "spl-token 4.0.0",
+ "spl-token 4.0.1",
  "thiserror",
 ]
 
@@ -8090,7 +8090,7 @@ version = "0.1.0"
 dependencies = [
  "solana-sdk",
  "spl-memo 4.0.1",
- "spl-token 4.0.0",
+ "spl-token 4.0.1",
  "spl-token-swap",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6722,7 +6722,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fadbefec4f3c678215ca72bd71862697bb06b41fd77c0088902dd3203354387b"
 dependencies = [
  "quote",
- "spl-discriminator-syn 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-discriminator-syn 0.1.1",
  "syn 2.0.46",
 ]
 
@@ -6731,13 +6731,15 @@ name = "spl-discriminator-derive"
 version = "0.1.2"
 dependencies = [
  "quote",
- "spl-discriminator-syn 0.1.1",
+ "spl-discriminator-syn 0.1.2",
  "syn 2.0.46",
 ]
 
 [[package]]
 name = "spl-discriminator-syn"
 version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e5f2044ca42c8938d54d1255ce599c79a1ffd86b677dfab695caa20f9ffc3f2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6748,9 +6750,7 @@ dependencies = [
 
 [[package]]
 name = "spl-discriminator-syn"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e5f2044ca42c8938d54d1255ce599c79a1ffd86b677dfab695caa20f9ffc3f2"
+version = "0.1.2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6822,7 +6822,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-program-error 0.3.0",
+ "spl-program-error 0.3.1",
 ]
 
 [[package]]
@@ -7056,7 +7056,7 @@ dependencies = [
  "bytemuck",
  "solana-program",
  "solana-zk-token-sdk",
- "spl-program-error 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-program-error 0.3.0",
 ]
 
 [[package]]
@@ -7070,21 +7070,7 @@ dependencies = [
  "serde_json",
  "solana-program",
  "solana-zk-token-sdk",
- "spl-program-error 0.3.0",
-]
-
-[[package]]
-name = "spl-program-error"
-version = "0.3.0"
-dependencies = [
- "lazy_static",
- "num-derive 0.4.1",
- "num-traits",
- "serial_test",
- "solana-program",
- "solana-sdk",
- "spl-program-error-derive 0.3.1",
- "thiserror",
+ "spl-program-error 0.3.1",
 ]
 
 [[package]]
@@ -7097,6 +7083,20 @@ dependencies = [
  "num-traits",
  "solana-program",
  "spl-program-error-derive 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-program-error"
+version = "0.3.1"
+dependencies = [
+ "lazy_static",
+ "num-derive 0.4.1",
+ "num-traits",
+ "serial_test",
+ "solana-program",
+ "solana-sdk",
+ "spl-program-error-derive 0.3.1",
  "thiserror",
 ]
 
@@ -7269,7 +7269,7 @@ dependencies = [
  "solana-sdk",
  "spl-discriminator 0.1.1",
  "spl-pod 0.1.1",
- "spl-program-error 0.3.0",
+ "spl-program-error 0.3.1",
  "spl-type-length-value 0.3.0",
 ]
 
@@ -7283,7 +7283,7 @@ dependencies = [
  "solana-program",
  "spl-discriminator 0.1.0",
  "spl-pod 0.1.0",
- "spl-program-error 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-program-error 0.3.0",
  "spl-type-length-value 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -7472,7 +7472,7 @@ dependencies = [
  "solana-sdk",
  "spl-discriminator 0.1.1",
  "spl-pod 0.1.1",
- "spl-program-error 0.3.0",
+ "spl-program-error 0.3.1",
  "spl-token-2022 2.0.0",
  "spl-token-client",
  "spl-token-group-example",
@@ -7505,7 +7505,7 @@ dependencies = [
  "solana-program",
  "spl-discriminator 0.1.1",
  "spl-pod 0.1.1",
- "spl-program-error 0.3.0",
+ "spl-program-error 0.3.1",
  "spl-type-length-value 0.3.0",
 ]
 
@@ -7519,7 +7519,7 @@ dependencies = [
  "solana-program",
  "spl-discriminator 0.1.0",
  "spl-pod 0.1.0",
- "spl-program-error 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-program-error 0.3.0",
 ]
 
 [[package]]
@@ -7580,7 +7580,7 @@ dependencies = [
  "solana-program",
  "spl-discriminator 0.1.1",
  "spl-pod 0.1.1",
- "spl-program-error 0.3.0",
+ "spl-program-error 0.3.1",
  "spl-type-length-value 0.3.0",
 ]
 
@@ -7594,7 +7594,7 @@ dependencies = [
  "solana-program",
  "spl-discriminator 0.1.0",
  "spl-pod 0.1.0",
- "spl-program-error 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-program-error 0.3.0",
  "spl-type-length-value 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -7732,7 +7732,7 @@ dependencies = [
  "solana-program",
  "spl-discriminator 0.1.0",
  "spl-pod 0.1.0",
- "spl-program-error 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-program-error 0.3.0",
  "spl-tlv-account-resolution 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-type-length-value 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -7746,7 +7746,7 @@ dependencies = [
  "solana-program",
  "spl-discriminator 0.1.1",
  "spl-pod 0.1.1",
- "spl-program-error 0.3.0",
+ "spl-program-error 0.3.1",
  "spl-tlv-account-resolution 0.5.1",
  "spl-type-length-value 0.3.0",
  "tokio",
@@ -7760,7 +7760,7 @@ dependencies = [
  "solana-program",
  "spl-discriminator 0.1.1",
  "spl-pod 0.1.1",
- "spl-program-error 0.3.0",
+ "spl-program-error 0.3.1",
  "spl-type-length-value-derive",
 ]
 
@@ -7774,7 +7774,7 @@ dependencies = [
  "solana-program",
  "spl-discriminator 0.1.0",
  "spl-pod 0.1.0",
- "spl-program-error 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-program-error 0.3.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4930,7 +4930,7 @@ dependencies = [
  "spl-token 4.0.0",
  "spl-token-2022 1.0.0",
  "spl-token-group-interface 0.1.0",
- "spl-token-metadata-interface 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-metadata-interface 0.2.0",
  "thiserror",
  "zstd",
 ]
@@ -7338,7 +7338,7 @@ dependencies = [
  "spl-pod 0.1.0",
  "spl-token 4.0.0",
  "spl-token-group-interface 0.1.0",
- "spl-token-metadata-interface 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-metadata-interface 0.2.0",
  "spl-transfer-hook-interface 0.4.1",
  "spl-type-length-value 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
@@ -7370,7 +7370,7 @@ dependencies = [
  "spl-tlv-account-resolution 0.5.2",
  "spl-token 4.0.1",
  "spl-token-group-interface 0.1.1",
- "spl-token-metadata-interface 0.2.0",
+ "spl-token-metadata-interface 0.2.1",
  "spl-transfer-hook-interface 0.5.0",
  "spl-type-length-value 0.3.0",
  "thiserror",
@@ -7394,7 +7394,7 @@ dependencies = [
  "spl-token-2022 2.0.0",
  "spl-token-client",
  "spl-token-group-interface 0.1.1",
- "spl-token-metadata-interface 0.2.0",
+ "spl-token-metadata-interface 0.2.1",
  "spl-transfer-hook-example",
  "spl-transfer-hook-interface 0.5.0",
  "test-case",
@@ -7431,7 +7431,7 @@ dependencies = [
  "spl-token-2022 2.0.0",
  "spl-token-client",
  "spl-token-group-interface 0.1.1",
- "spl-token-metadata-interface 0.2.0",
+ "spl-token-metadata-interface 0.2.1",
  "strum 0.26.1",
  "strum_macros 0.26.1",
  "tempfile",
@@ -7458,7 +7458,7 @@ dependencies = [
  "spl-token 4.0.1",
  "spl-token-2022 2.0.0",
  "spl-token-group-interface 0.1.1",
- "spl-token-metadata-interface 0.2.0",
+ "spl-token-metadata-interface 0.2.1",
  "spl-transfer-hook-interface 0.5.0",
  "thiserror",
 ]
@@ -7477,7 +7477,7 @@ dependencies = [
  "spl-token-client",
  "spl-token-group-example",
  "spl-token-group-interface 0.1.1",
- "spl-token-metadata-interface 0.2.0",
+ "spl-token-metadata-interface 0.2.1",
  "spl-type-length-value 0.3.0",
 ]
 
@@ -7493,7 +7493,7 @@ dependencies = [
  "spl-token-2022 2.0.0",
  "spl-token-client",
  "spl-token-group-interface 0.1.1",
- "spl-token-metadata-interface 0.2.0",
+ "spl-token-metadata-interface 0.2.1",
  "spl-type-length-value 0.3.0",
 ]
 
@@ -7565,23 +7565,9 @@ dependencies = [
  "spl-pod 0.1.1",
  "spl-token-2022 2.0.0",
  "spl-token-client",
- "spl-token-metadata-interface 0.2.0",
+ "spl-token-metadata-interface 0.2.1",
  "spl-type-length-value 0.3.0",
  "test-case",
-]
-
-[[package]]
-name = "spl-token-metadata-interface"
-version = "0.2.0"
-dependencies = [
- "borsh 0.10.3",
- "serde",
- "serde_json",
- "solana-program",
- "spl-discriminator 0.1.1",
- "spl-pod 0.1.1",
- "spl-program-error 0.3.1",
- "spl-type-length-value 0.3.0",
 ]
 
 [[package]]
@@ -7596,6 +7582,20 @@ dependencies = [
  "spl-pod 0.1.0",
  "spl-program-error 0.3.0",
  "spl-type-length-value 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "spl-token-metadata-interface"
+version = "0.2.1"
+dependencies = [
+ "borsh 0.10.3",
+ "serde",
+ "serde_json",
+ "solana-program",
+ "spl-discriminator 0.1.1",
+ "spl-pod 0.1.1",
+ "spl-program-error 0.3.1",
+ "spl-type-length-value 0.3.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7258,6 +7258,20 @@ dependencies = [
 [[package]]
 name = "spl-tlv-account-resolution"
 version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "615d381f48ddd2bb3c57c7f7fb207591a2a05054639b18a62e785117dd7a8683"
+dependencies = [
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator 0.1.0",
+ "spl-pod 0.1.0",
+ "spl-program-error 0.3.0",
+ "spl-type-length-value 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "spl-tlv-account-resolution"
+version = "0.5.2"
 dependencies = [
  "bytemuck",
  "futures 0.3.30",
@@ -7271,20 +7285,6 @@ dependencies = [
  "spl-pod 0.1.1",
  "spl-program-error 0.3.1",
  "spl-type-length-value 0.3.0",
-]
-
-[[package]]
-name = "spl-tlv-account-resolution"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "615d381f48ddd2bb3c57c7f7fb207591a2a05054639b18a62e785117dd7a8683"
-dependencies = [
- "bytemuck",
- "solana-program",
- "spl-discriminator 0.1.0",
- "spl-pod 0.1.0",
- "spl-program-error 0.3.0",
- "spl-type-length-value 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -7367,7 +7367,7 @@ dependencies = [
  "solana-zk-token-sdk",
  "spl-memo 4.0.1",
  "spl-pod 0.1.1",
- "spl-tlv-account-resolution 0.5.1",
+ "spl-tlv-account-resolution 0.5.2",
  "spl-token 4.0.0",
  "spl-token-group-interface 0.1.0",
  "spl-token-metadata-interface 0.2.0",
@@ -7390,7 +7390,7 @@ dependencies = [
  "spl-instruction-padding",
  "spl-memo 4.0.1",
  "spl-pod 0.1.1",
- "spl-tlv-account-resolution 0.5.1",
+ "spl-tlv-account-resolution 0.5.2",
  "spl-token-2022 2.0.0",
  "spl-token-client",
  "spl-token-group-interface 0.1.0",
@@ -7698,7 +7698,7 @@ dependencies = [
  "solana-remote-wallet",
  "solana-sdk",
  "solana-test-validator",
- "spl-tlv-account-resolution 0.5.1",
+ "spl-tlv-account-resolution 0.5.2",
  "spl-token-2022 2.0.0",
  "spl-token-client",
  "spl-transfer-hook-interface 0.5.0",
@@ -7715,7 +7715,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-tlv-account-resolution 0.5.1",
+ "spl-tlv-account-resolution 0.5.2",
  "spl-token-2022 2.0.0",
  "spl-transfer-hook-interface 0.5.0",
  "spl-type-length-value 0.3.0",
@@ -7733,7 +7733,7 @@ dependencies = [
  "spl-discriminator 0.1.0",
  "spl-pod 0.1.0",
  "spl-program-error 0.3.0",
- "spl-tlv-account-resolution 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-tlv-account-resolution 0.5.1",
  "spl-type-length-value 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -7747,7 +7747,7 @@ dependencies = [
  "spl-discriminator 0.1.1",
  "spl-pod 0.1.1",
  "spl-program-error 0.3.1",
- "spl-tlv-account-resolution 0.5.1",
+ "spl-tlv-account-resolution 0.5.2",
  "spl-type-length-value 0.3.0",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7266,7 +7266,7 @@ dependencies = [
  "spl-discriminator 0.1.0",
  "spl-pod 0.1.0",
  "spl-program-error 0.3.0",
- "spl-type-length-value 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-type-length-value 0.3.0",
 ]
 
 [[package]]
@@ -7284,7 +7284,7 @@ dependencies = [
  "spl-discriminator 0.1.1",
  "spl-pod 0.1.1",
  "spl-program-error 0.3.1",
- "spl-type-length-value 0.3.0",
+ "spl-type-length-value 0.3.1",
 ]
 
 [[package]]
@@ -7340,7 +7340,7 @@ dependencies = [
  "spl-token-group-interface 0.1.0",
  "spl-token-metadata-interface 0.2.0",
  "spl-transfer-hook-interface 0.4.1",
- "spl-type-length-value 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-type-length-value 0.3.0",
  "thiserror",
 ]
 
@@ -7371,8 +7371,8 @@ dependencies = [
  "spl-token 4.0.1",
  "spl-token-group-interface 0.1.1",
  "spl-token-metadata-interface 0.2.1",
- "spl-transfer-hook-interface 0.5.0",
- "spl-type-length-value 0.3.0",
+ "spl-transfer-hook-interface 0.5.1",
+ "spl-type-length-value 0.3.1",
  "thiserror",
 ]
 
@@ -7396,7 +7396,7 @@ dependencies = [
  "spl-token-group-interface 0.1.1",
  "spl-token-metadata-interface 0.2.1",
  "spl-transfer-hook-example",
- "spl-transfer-hook-interface 0.5.0",
+ "spl-transfer-hook-interface 0.5.1",
  "test-case",
  "walkdir",
 ]
@@ -7459,7 +7459,7 @@ dependencies = [
  "spl-token-2022 2.0.0",
  "spl-token-group-interface 0.1.1",
  "spl-token-metadata-interface 0.2.1",
- "spl-transfer-hook-interface 0.5.0",
+ "spl-transfer-hook-interface 0.5.1",
  "thiserror",
 ]
 
@@ -7478,7 +7478,7 @@ dependencies = [
  "spl-token-group-example",
  "spl-token-group-interface 0.1.1",
  "spl-token-metadata-interface 0.2.1",
- "spl-type-length-value 0.3.0",
+ "spl-type-length-value 0.3.1",
 ]
 
 [[package]]
@@ -7494,7 +7494,7 @@ dependencies = [
  "spl-token-client",
  "spl-token-group-interface 0.1.1",
  "spl-token-metadata-interface 0.2.1",
- "spl-type-length-value 0.3.0",
+ "spl-type-length-value 0.3.1",
 ]
 
 [[package]]
@@ -7519,7 +7519,7 @@ dependencies = [
  "spl-discriminator 0.1.1",
  "spl-pod 0.1.1",
  "spl-program-error 0.3.1",
- "spl-type-length-value 0.3.0",
+ "spl-type-length-value 0.3.1",
 ]
 
 [[package]]
@@ -7566,7 +7566,7 @@ dependencies = [
  "spl-token-2022 2.0.0",
  "spl-token-client",
  "spl-token-metadata-interface 0.2.1",
- "spl-type-length-value 0.3.0",
+ "spl-type-length-value 0.3.1",
  "test-case",
 ]
 
@@ -7581,7 +7581,7 @@ dependencies = [
  "spl-discriminator 0.1.0",
  "spl-pod 0.1.0",
  "spl-program-error 0.3.0",
- "spl-type-length-value 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-type-length-value 0.3.0",
 ]
 
 [[package]]
@@ -7595,7 +7595,7 @@ dependencies = [
  "spl-discriminator 0.1.1",
  "spl-pod 0.1.1",
  "spl-program-error 0.3.1",
- "spl-type-length-value 0.3.0",
+ "spl-type-length-value 0.3.1",
 ]
 
 [[package]]
@@ -7701,7 +7701,7 @@ dependencies = [
  "spl-tlv-account-resolution 0.5.2",
  "spl-token-2022 2.0.0",
  "spl-token-client",
- "spl-transfer-hook-interface 0.5.0",
+ "spl-transfer-hook-interface 0.5.1",
  "strum 0.26.1",
  "strum_macros 0.26.1",
  "tokio",
@@ -7717,8 +7717,8 @@ dependencies = [
  "solana-sdk",
  "spl-tlv-account-resolution 0.5.2",
  "spl-token-2022 2.0.0",
- "spl-transfer-hook-interface 0.5.0",
- "spl-type-length-value 0.3.0",
+ "spl-transfer-hook-interface 0.5.1",
+ "spl-type-length-value 0.3.1",
 ]
 
 [[package]]
@@ -7734,12 +7734,12 @@ dependencies = [
  "spl-pod 0.1.0",
  "spl-program-error 0.3.0",
  "spl-tlv-account-resolution 0.5.1",
- "spl-type-length-value 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-type-length-value 0.3.0",
 ]
 
 [[package]]
 name = "spl-transfer-hook-interface"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -7748,20 +7748,8 @@ dependencies = [
  "spl-pod 0.1.1",
  "spl-program-error 0.3.1",
  "spl-tlv-account-resolution 0.5.2",
- "spl-type-length-value 0.3.0",
+ "spl-type-length-value 0.3.1",
  "tokio",
-]
-
-[[package]]
-name = "spl-type-length-value"
-version = "0.3.0"
-dependencies = [
- "bytemuck",
- "solana-program",
- "spl-discriminator 0.1.1",
- "spl-pod 0.1.1",
- "spl-program-error 0.3.1",
- "spl-type-length-value-derive",
 ]
 
 [[package]]
@@ -7775,6 +7763,18 @@ dependencies = [
  "spl-discriminator 0.1.0",
  "spl-pod 0.1.0",
  "spl-program-error 0.3.0",
+]
+
+[[package]]
+name = "spl-type-length-value"
+version = "0.3.1"
+dependencies = [
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator 0.1.1",
+ "spl-pod 0.1.1",
+ "spl-program-error 0.3.1",
+ "spl-type-length-value-derive",
 ]
 
 [[package]]
@@ -7793,7 +7793,7 @@ dependencies = [
  "borsh 0.10.3",
  "solana-program",
  "spl-discriminator 0.1.1",
- "spl-type-length-value 0.3.0",
+ "spl-type-length-value 0.3.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5194,7 +5194,7 @@ dependencies = [
  "solana-sdk",
  "solana-transaction-status",
  "solana-vote-program",
- "spl-memo 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-memo 4.0.0",
 ]
 
 [[package]]
@@ -5415,7 +5415,7 @@ dependencies = [
  "solana-metrics",
  "solana-sdk",
  "solana-version",
- "spl-memo 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-memo 4.0.0",
  "thiserror",
  "tokio",
 ]
@@ -6425,7 +6425,7 @@ dependencies = [
  "solana-account-decoder",
  "solana-sdk",
  "spl-associated-token-account 2.3.0",
- "spl-memo 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-memo 4.0.0",
  "spl-token 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token-2022 1.0.0",
  "thiserror",
@@ -7010,19 +7010,19 @@ dependencies = [
 [[package]]
 name = "spl-memo"
 version = "4.0.0"
-dependencies = [
- "solana-program",
- "solana-program-test",
- "solana-sdk",
-]
-
-[[package]]
-name = "spl-memo"
-version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f180b03318c3dbab3ef4e1e4d46d5211ae3c780940dd0a28695aba4b59a75a"
 dependencies = [
  "solana-program",
+]
+
+[[package]]
+name = "spl-memo"
+version = "4.0.1"
+dependencies = [
+ "solana-program",
+ "solana-program-test",
+ "solana-sdk",
 ]
 
 [[package]]
@@ -7334,7 +7334,7 @@ dependencies = [
  "solana-program",
  "solana-security-txt",
  "solana-zk-token-sdk",
- "spl-memo 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-memo 4.0.0",
  "spl-pod 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token-group-interface 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7365,7 +7365,7 @@ dependencies = [
  "solana-sdk",
  "solana-security-txt",
  "solana-zk-token-sdk",
- "spl-memo 4.0.0",
+ "spl-memo 4.0.1",
  "spl-pod 0.1.0",
  "spl-tlv-account-resolution 0.5.1",
  "spl-token 4.0.0",
@@ -7388,7 +7388,7 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account 2.3.1",
  "spl-instruction-padding",
- "spl-memo 4.0.0",
+ "spl-memo 4.0.1",
  "spl-pod 0.1.0",
  "spl-tlv-account-resolution 0.5.1",
  "spl-token-2022 2.0.0",
@@ -7426,7 +7426,7 @@ dependencies = [
  "solana-test-validator",
  "solana-transaction-status",
  "spl-associated-token-account 2.3.1",
- "spl-memo 4.0.0",
+ "spl-memo 4.0.1",
  "spl-token 4.0.0",
  "spl-token-2022 2.0.0",
  "spl-token-client",
@@ -7454,7 +7454,7 @@ dependencies = [
  "solana-rpc-client-api",
  "solana-sdk",
  "spl-associated-token-account 2.3.1",
- "spl-memo 4.0.0",
+ "spl-memo 4.0.1",
  "spl-token 4.0.0",
  "spl-token-2022 2.0.0",
  "spl-token-group-interface 0.1.0",
@@ -8089,7 +8089,7 @@ name = "test-client"
 version = "0.1.0"
 dependencies = [
  "solana-sdk",
- "spl-memo 4.0.0",
+ "spl-memo 4.0.1",
  "spl-token 4.0.0",
  "spl-token-swap",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6702,7 +6702,7 @@ checksum = "cce5d563b58ef1bb2cdbbfe0dfb9ffdc24903b10ae6a4df2d8f425ece375033f"
 dependencies = [
  "bytemuck",
  "solana-program",
- "spl-discriminator-derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-discriminator-derive 0.1.1",
 ]
 
 [[package]]
@@ -6712,16 +6712,7 @@ dependencies = [
  "borsh 0.10.3",
  "bytemuck",
  "solana-program",
- "spl-discriminator-derive 0.1.1",
-]
-
-[[package]]
-name = "spl-discriminator-derive"
-version = "0.1.1"
-dependencies = [
- "quote",
- "spl-discriminator-syn 0.1.1",
- "syn 2.0.46",
+ "spl-discriminator-derive 0.1.2",
 ]
 
 [[package]]
@@ -6732,6 +6723,15 @@ checksum = "fadbefec4f3c678215ca72bd71862697bb06b41fd77c0088902dd3203354387b"
 dependencies = [
  "quote",
  "spl-discriminator-syn 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 2.0.46",
+]
+
+[[package]]
+name = "spl-discriminator-derive"
+version = "0.1.2"
+dependencies = [
+ "quote",
+ "spl-discriminator-syn 0.1.1",
  "syn 2.0.46",
 ]
 

--- a/associated-token-account/program/Cargo.toml
+++ b/associated-token-account/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-associated-token-account"
-version = "2.3.0"
+version = "2.3.1"
 description = "Solana Program Library Associated Token Account"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/feature-gate/program/Cargo.toml
+++ b/feature-gate/program/Cargo.toml
@@ -14,7 +14,7 @@ test-sbf = []
 [dependencies]
 num_enum = "0.7.2"
 solana-program = ">=1.17.17,<=2"
-spl-program-error = { version = "0.3.0", path = "../../libraries/program-error" }
+spl-program-error = { version = "0.3.1", path = "../../libraries/program-error" }
 
 [dev-dependencies]
 solana-program-test = ">=1.17.17,<=2"

--- a/instruction-padding/program/Cargo.toml
+++ b/instruction-padding/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-instruction-padding"
-version = "0.1.0"
+version = "0.1.1"
 description = "Solana Program Library Instruction Padding Program"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/libraries/discriminator/Cargo.toml
+++ b/libraries/discriminator/Cargo.toml
@@ -1,5 +1,3 @@
-
-
 [package]
 name = "spl-discriminator"
 version = "0.1.1"

--- a/libraries/discriminator/Cargo.toml
+++ b/libraries/discriminator/Cargo.toml
@@ -1,6 +1,8 @@
+
+
 [package]
 name = "spl-discriminator"
-version = "0.1.0"
+version = "0.1.1"
 description = "Solana Program Library 8-Byte Discriminator Management"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/libraries/discriminator/Cargo.toml
+++ b/libraries/discriminator/Cargo.toml
@@ -16,7 +16,7 @@ borsh = ["dep:borsh"]
 borsh = { version = "0.10", optional = true }
 bytemuck = { version = "1.14.1", features = ["derive"] }
 solana-program = ">=1.17.17,<=2"
-spl-discriminator-derive = { version = "0.1.0", path = "./derive" }
+spl-discriminator-derive = { version = "0.1.2", path = "./derive" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/libraries/discriminator/derive/Cargo.toml
+++ b/libraries/discriminator/derive/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 
 [dependencies]
 quote = "1.0"
-spl-discriminator-syn = { version = "0.1.0", path = "../syn" }
+spl-discriminator-syn = { version = "0.1.2", path = "../syn" }
 syn = { version = "2.0", features = ["full"] }
 
 [lib]

--- a/libraries/discriminator/derive/Cargo.toml
+++ b/libraries/discriminator/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-discriminator-derive"
-version = "0.1.1"
+version = "0.1.2"
 description = "Derive macro library for the `spl-discriminator` library"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/libraries/discriminator/syn/Cargo.toml
+++ b/libraries/discriminator/syn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-discriminator-syn"
-version = "0.1.1"
+version = "0.1.2"
 description = "Token parsing and generating library for the `spl-discriminator` library"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/libraries/pod/Cargo.toml
+++ b/libraries/pod/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-pod"
-version = "0.1.0"
+version = "0.1.1"
 description = "Solana Program Library Plain Old Data (Pod)"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/libraries/program-error/Cargo.toml
+++ b/libraries/program-error/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 num-derive = "0.4"
 num-traits = "0.2"
 solana-program = ">=1.17.17,<=2"
-spl-program-error-derive = { version = "0.3.1", path = "./derive" }
+spl-program-error-derive = { version = "0.3.2", path = "./derive" }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/libraries/program-error/Cargo.toml
+++ b/libraries/program-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-program-error"
-version = "0.3.0"
+version = "0.3.1"
 description = "Library for Solana Program error attributes and derive macro for creating them"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/libraries/program-error/derive/Cargo.toml
+++ b/libraries/program-error/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-program-error-derive"
-version = "0.3.1"
+version = "0.3.2"
 description = "Proc-Macro Library for Solana Program error attributes and derive macro"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/libraries/tlv-account-resolution/Cargo.toml
+++ b/libraries/tlv-account-resolution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-tlv-account-resolution"
-version = "0.5.1"
+version = "0.5.2"
 description = "Solana Program Library TLV Account Resolution Interface"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/libraries/type-length-value-derive-test/Cargo.toml
+++ b/libraries/type-length-value-derive-test/Cargo.toml
@@ -11,4 +11,4 @@ edition = "2021"
 borsh = "0.10"
 solana-program = "1.16"
 spl-discriminator = { version = "0.1.1", path = "../discriminator" }
-spl-type-length-value = { version = "0.3.0", path = "../type-length-value", features = ["derive"] }
+spl-type-length-value = { version = "0.3.1", path = "../type-length-value", features = ["derive"] }

--- a/libraries/type-length-value-derive-test/Cargo.toml
+++ b/libraries/type-length-value-derive-test/Cargo.toml
@@ -10,5 +10,5 @@ edition = "2021"
 [dev-dependencies]
 borsh = "0.10"
 solana-program = "1.16"
-spl-discriminator = { version = "0.1.0", path = "../discriminator" }
+spl-discriminator = { version = "0.1.1", path = "../discriminator" }
 spl-type-length-value = { version = "0.3.0", path = "../type-length-value", features = ["derive"] }

--- a/libraries/type-length-value/Cargo.toml
+++ b/libraries/type-length-value/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-type-length-value"
-version = "0.3.0"
+version = "0.3.1"
 description = "Solana Program Library Type-Length-Value Management"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/memo/program/Cargo.toml
+++ b/memo/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-memo"
-version = "4.0.0"
+version = "4.0.1"
 description = "Solana Program Library Memo"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token-collection/program/Cargo.toml
+++ b/token-collection/program/Cargo.toml
@@ -17,7 +17,7 @@ spl-pod = { version = "0.1.1", path = "../../libraries/pod" }
 spl-program-error = { version = "0.3.1" , path = "../../libraries/program-error" }
 spl-token-2022 = { version = "2.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-group-example = { version = "0.1.0", path = "../../token-group/example", features = ["no-entrypoint"] }
-spl-token-group-interface = { version = "0.1.0", path = "../../token-group/interface" }
+spl-token-group-interface = { version = "0.1.1", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }
 spl-type-length-value = { version = "0.3.0", path = "../../libraries/type-length-value" }
 

--- a/token-collection/program/Cargo.toml
+++ b/token-collection/program/Cargo.toml
@@ -24,7 +24,7 @@ spl-type-length-value = { version = "0.3.0", path = "../../libraries/type-length
 [dev-dependencies]
 solana-program-test = ">=1.17.17,<=2"
 solana-sdk = ">=1.17.17,<=2"
-spl-discriminator = { version = "0.1.0", path = "../../libraries/discriminator" }
+spl-discriminator = { version = "0.1.1", path = "../../libraries/discriminator" }
 spl-token-client = { version = "0.8", path = "../../token/client" }
 
 [lib]

--- a/token-collection/program/Cargo.toml
+++ b/token-collection/program/Cargo.toml
@@ -19,7 +19,7 @@ spl-token-2022 = { version = "2.0", path = "../../token/program-2022", features 
 spl-token-group-example = { version = "0.1.0", path = "../../token-group/example", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.1.1", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }
-spl-type-length-value = { version = "0.3.0", path = "../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.3.1", path = "../../libraries/type-length-value" }
 
 [dev-dependencies]
 solana-program-test = ">=1.17.17,<=2"

--- a/token-collection/program/Cargo.toml
+++ b/token-collection/program/Cargo.toml
@@ -14,7 +14,7 @@ test-sbf = []
 [dependencies]
 solana-program = ">=1.17.17,<=2"
 spl-pod = { version = "0.1.1", path = "../../libraries/pod" }
-spl-program-error = { version = "0.3.0" , path = "../../libraries/program-error" }
+spl-program-error = { version = "0.3.1" , path = "../../libraries/program-error" }
 spl-token-2022 = { version = "2.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-group-example = { version = "0.1.0", path = "../../token-group/example", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.1.0", path = "../../token-group/interface" }

--- a/token-collection/program/Cargo.toml
+++ b/token-collection/program/Cargo.toml
@@ -13,7 +13,7 @@ test-sbf = []
 
 [dependencies]
 solana-program = ">=1.17.17,<=2"
-spl-pod = { version = "0.1.0", path = "../../libraries/pod" }
+spl-pod = { version = "0.1.1", path = "../../libraries/pod" }
 spl-program-error = { version = "0.3.0" , path = "../../libraries/program-error" }
 spl-token-2022 = { version = "2.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-group-example = { version = "0.1.0", path = "../../token-group/example", features = ["no-entrypoint"] }

--- a/token-group/example/Cargo.toml
+++ b/token-group/example/Cargo.toml
@@ -13,7 +13,7 @@ test-sbf = []
 
 [dependencies]
 solana-program = ">=1.17.17,<=2"
-spl-pod = { version = "0.1.0", path = "../../libraries/pod" }
+spl-pod = { version = "0.1.1", path = "../../libraries/pod" }
 spl-token-2022 = { version = "2.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.1.0", path = "../interface" }
 spl-type-length-value = { version = "0.3.0", path = "../../libraries/type-length-value" }

--- a/token-group/example/Cargo.toml
+++ b/token-group/example/Cargo.toml
@@ -16,7 +16,7 @@ solana-program = ">=1.17.17,<=2"
 spl-pod = { version = "0.1.1", path = "../../libraries/pod" }
 spl-token-2022 = { version = "2.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.1.1", path = "../interface" }
-spl-type-length-value = { version = "0.3.0", path = "../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.3.1", path = "../../libraries/type-length-value" }
 
 [dev-dependencies]
 solana-program-test = ">=1.17.17,<=2"

--- a/token-group/example/Cargo.toml
+++ b/token-group/example/Cargo.toml
@@ -21,7 +21,7 @@ spl-type-length-value = { version = "0.3.0", path = "../../libraries/type-length
 [dev-dependencies]
 solana-program-test = ">=1.17.17,<=2"
 solana-sdk = ">=1.17.17,<=2"
-spl-discriminator = { version = "0.1.0", path = "../../libraries/discriminator" }
+spl-discriminator = { version = "0.1.1", path = "../../libraries/discriminator" }
 spl-token-client = { version = "0.8", path = "../../token/client" }
 spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }
 

--- a/token-group/example/Cargo.toml
+++ b/token-group/example/Cargo.toml
@@ -15,7 +15,7 @@ test-sbf = []
 solana-program = ">=1.17.17,<=2"
 spl-pod = { version = "0.1.1", path = "../../libraries/pod" }
 spl-token-2022 = { version = "2.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
-spl-token-group-interface = { version = "0.1.0", path = "../interface" }
+spl-token-group-interface = { version = "0.1.1", path = "../interface" }
 spl-type-length-value = { version = "0.3.0", path = "../../libraries/type-length-value" }
 
 [dev-dependencies]

--- a/token-group/interface/Cargo.toml
+++ b/token-group/interface/Cargo.toml
@@ -15,7 +15,7 @@ spl-pod = { version = "0.1.1" , path = "../../libraries/pod", features = ["borsh
 spl-program-error = { version = "0.3.1" , path = "../../libraries/program-error" }
 
 [dev-dependencies]
-spl-type-length-value = { version = "0.3.0", path = "../../libraries/type-length-value", features = ["derive"] }
+spl-type-length-value = { version = "0.3.1", path = "../../libraries/type-length-value", features = ["derive"] }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/token-group/interface/Cargo.toml
+++ b/token-group/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-group-interface"
-version = "0.1.0"
+version = "0.1.1"
 description = "Solana Program Library Token Group Interface"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token-group/interface/Cargo.toml
+++ b/token-group/interface/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 bytemuck = "1.14.1"
 solana-program = ">=1.17.17,<=2"
-spl-discriminator = { version = "0.1.0" , path = "../../libraries/discriminator" }
+spl-discriminator = { version = "0.1.1" , path = "../../libraries/discriminator" }
 spl-pod = { version = "0.1.0" , path = "../../libraries/pod", features = ["borsh"] }
 spl-program-error = { version = "0.3.0" , path = "../../libraries/program-error" }
 

--- a/token-group/interface/Cargo.toml
+++ b/token-group/interface/Cargo.toml
@@ -12,7 +12,7 @@ bytemuck = "1.14.1"
 solana-program = ">=1.17.17,<=2"
 spl-discriminator = { version = "0.1.1" , path = "../../libraries/discriminator" }
 spl-pod = { version = "0.1.1" , path = "../../libraries/pod", features = ["borsh"] }
-spl-program-error = { version = "0.3.0" , path = "../../libraries/program-error" }
+spl-program-error = { version = "0.3.1" , path = "../../libraries/program-error" }
 
 [dev-dependencies]
 spl-type-length-value = { version = "0.3.0", path = "../../libraries/type-length-value", features = ["derive"] }

--- a/token-group/interface/Cargo.toml
+++ b/token-group/interface/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 bytemuck = "1.14.1"
 solana-program = ">=1.17.17,<=2"
 spl-discriminator = { version = "0.1.1" , path = "../../libraries/discriminator" }
-spl-pod = { version = "0.1.0" , path = "../../libraries/pod", features = ["borsh"] }
+spl-pod = { version = "0.1.1" , path = "../../libraries/pod", features = ["borsh"] }
 spl-program-error = { version = "0.3.0" , path = "../../libraries/program-error" }
 
 [dev-dependencies]

--- a/token-metadata/example/Cargo.toml
+++ b/token-metadata/example/Cargo.toml
@@ -14,7 +14,7 @@ test-sbf = []
 [dependencies]
 solana-program = ">=1.17.17,<=2"
 spl-token-2022 = { version = "2.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
-spl-token-metadata-interface = { version = "0.2.0", path = "../interface" }
+spl-token-metadata-interface = { version = "0.2.1", path = "../interface" }
 spl-type-length-value = { version = "0.3.0" , path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.1.1", path = "../../libraries/pod" }
 

--- a/token-metadata/example/Cargo.toml
+++ b/token-metadata/example/Cargo.toml
@@ -15,7 +15,7 @@ test-sbf = []
 solana-program = ">=1.17.17,<=2"
 spl-token-2022 = { version = "2.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-metadata-interface = { version = "0.2.1", path = "../interface" }
-spl-type-length-value = { version = "0.3.0" , path = "../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.3.1" , path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.1.1", path = "../../libraries/pod" }
 
 [dev-dependencies]

--- a/token-metadata/example/Cargo.toml
+++ b/token-metadata/example/Cargo.toml
@@ -16,7 +16,7 @@ solana-program = ">=1.17.17,<=2"
 spl-token-2022 = { version = "2.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-metadata-interface = { version = "0.2.0", path = "../interface" }
 spl-type-length-value = { version = "0.3.0" , path = "../../libraries/type-length-value" }
-spl-pod = { version = "0.1.0", path = "../../libraries/pod" }
+spl-pod = { version = "0.1.1", path = "../../libraries/pod" }
 
 [dev-dependencies]
 solana-program-test = ">=1.17.17,<=2"

--- a/token-metadata/interface/Cargo.toml
+++ b/token-metadata/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-metadata-interface"
-version = "0.2.0"
+version = "0.2.1"
 description = "Solana Program Library Token Metadata Interface"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -40,7 +40,7 @@ spl-token-group-interface = { version = "0.1", path = "../../token-group/interfa
 spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }
-spl-memo = { version = "4.0.0", path = "../../memo/program", features = [
+spl-memo = { version = "4.0.1", path = "../../memo/program", features = [
   "no-entrypoint",
 ] }
 strum = "0.26"

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -23,7 +23,7 @@ solana-sdk = ">=1.17.17,<=2"
 spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }
-spl-memo = { version = "4.0.0", path = "../../memo/program", features = [
+spl-memo = { version = "4.0.1", path = "../../memo/program", features = [
   "no-entrypoint",
 ] }
 spl-token = { version = "4.0", path = "../program", features = [

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -27,7 +27,7 @@ spl-memo = { version = "4.0.1", path = "../../memo/program", features = ["no-ent
 spl-pod = { version = "0.1.1", path = "../../libraries/pod" }
 spl-token-2022 = { version = "2.0", path="../program-2022", features = ["no-entrypoint"] }
 spl-instruction-padding = { version = "0.1.1", path="../../instruction-padding/program", features = ["no-entrypoint"] }
-spl-tlv-account-resolution = { version = "0.5.0", path = "../../libraries/tlv-account-resolution" }
+spl-tlv-account-resolution = { version = "0.5.2", path = "../../libraries/tlv-account-resolution" }
 spl-token-client = { version = "0.8", path = "../client" }
 spl-token-group-interface = { version = "0.1", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -24,7 +24,7 @@ solana-program-test = ">=1.17.17,<=2"
 solana-sdk = ">=1.17.17,<=2"
 spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program" }
 spl-memo = { version = "4.0.1", path = "../../memo/program", features = ["no-entrypoint"] }
-spl-pod = { version = "0.1.0", path = "../../libraries/pod" }
+spl-pod = { version = "0.1.1", path = "../../libraries/pod" }
 spl-token-2022 = { version = "2.0", path="../program-2022", features = ["no-entrypoint"] }
 spl-instruction-padding = { version = "0.1.1", path="../../instruction-padding/program", features = ["no-entrypoint"] }
 spl-tlv-account-resolution = { version = "0.5.0", path = "../../libraries/tlv-account-resolution" }

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -23,7 +23,7 @@ solana-program = ">=1.17.17,<=2"
 solana-program-test = ">=1.17.17,<=2"
 solana-sdk = ">=1.17.17,<=2"
 spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program" }
-spl-memo = { version = "4.0.0", path = "../../memo/program", features = ["no-entrypoint"] }
+spl-memo = { version = "4.0.1", path = "../../memo/program", features = ["no-entrypoint"] }
 spl-pod = { version = "0.1.0", path = "../../libraries/pod" }
 spl-token-2022 = { version = "2.0", path="../program-2022", features = ["no-entrypoint"] }
 spl-instruction-padding = { version = "0.1.1", path="../../instruction-padding/program", features = ["no-entrypoint"] }

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -26,7 +26,7 @@ spl-associated-token-account = { version = "2.0", path = "../../associated-token
 spl-memo = { version = "4.0.0", path = "../../memo/program", features = ["no-entrypoint"] }
 spl-pod = { version = "0.1.0", path = "../../libraries/pod" }
 spl-token-2022 = { version = "2.0", path="../program-2022", features = ["no-entrypoint"] }
-spl-instruction-padding = { version = "0.1.0", path="../../instruction-padding/program", features = ["no-entrypoint"] }
+spl-instruction-padding = { version = "0.1.1", path="../../instruction-padding/program", features = ["no-entrypoint"] }
 spl-tlv-account-resolution = { version = "0.5.0", path = "../../libraries/tlv-account-resolution" }
 spl-token-client = { version = "0.8", path = "../client" }
 spl-token-group-interface = { version = "0.1", path = "../../token-group/interface" }

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -29,7 +29,7 @@ num_enum = "0.7.2"
 solana-program = ">=1.17.17,<=2"
 solana-security-txt = "1.1.1"
 solana-zk-token-sdk = ">=1.17.17,<=2"
-spl-memo = { version = "4.0.0", path = "../../memo/program", features = [ "no-entrypoint" ] }
+spl-memo = { version = "4.0.1", path = "../../memo/program", features = [ "no-entrypoint" ] }
 spl-token = { version = "4.0",  path = "../program", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.1.0", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.2.0", path = "../../token-metadata/interface" }

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -47,7 +47,7 @@ proptest = "1.4"
 serial_test = "3.0.0"
 solana-program-test = ">=1.17.17,<=2"
 solana-sdk = ">=1.17.17,<=2"
-spl-tlv-account-resolution = { version = "0.5.0", path = "../../libraries/tlv-account-resolution" }
+spl-tlv-account-resolution = { version = "0.5.2", path = "../../libraries/tlv-account-resolution" }
 serde_json = "1.0.113"
 
 [lib]

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -34,7 +34,7 @@ spl-token = { version = "4.0",  path = "../program", features = ["no-entrypoint"
 spl-token-group-interface = { version = "0.1.1", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.2.1", path = "../../token-metadata/interface" }
 spl-transfer-hook-interface = { version = "0.5.1", path = "../transfer-hook/interface" }
-spl-type-length-value = { version = "0.3.0", path = "../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.3.1", path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.1.1", path = "../../libraries/pod" }
 thiserror = "1.0"
 serde = { version = "1.0.196", optional = true }

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -35,7 +35,7 @@ spl-token-group-interface = { version = "0.1.0", path = "../../token-group/inter
 spl-token-metadata-interface = { version = "0.2.0", path = "../../token-metadata/interface" }
 spl-transfer-hook-interface = { version = "0.5.0", path = "../transfer-hook/interface" }
 spl-type-length-value = { version = "0.3.0", path = "../../libraries/type-length-value" }
-spl-pod = { version = "0.1.0", path = "../../libraries/pod" }
+spl-pod = { version = "0.1.1", path = "../../libraries/pod" }
 thiserror = "1.0"
 serde = { version = "1.0.196", optional = true }
 serde_with = { version = "3.6.0", optional = true }

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -33,7 +33,7 @@ spl-memo = { version = "4.0.1", path = "../../memo/program", features = [ "no-en
 spl-token = { version = "4.0",  path = "../program", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.1.1", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.2.1", path = "../../token-metadata/interface" }
-spl-transfer-hook-interface = { version = "0.5.0", path = "../transfer-hook/interface" }
+spl-transfer-hook-interface = { version = "0.5.1", path = "../transfer-hook/interface" }
 spl-type-length-value = { version = "0.3.0", path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.1.1", path = "../../libraries/pod" }
 thiserror = "1.0"

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -32,7 +32,7 @@ solana-zk-token-sdk = ">=1.17.17,<=2"
 spl-memo = { version = "4.0.1", path = "../../memo/program", features = [ "no-entrypoint" ] }
 spl-token = { version = "4.0",  path = "../program", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.1.1", path = "../../token-group/interface" }
-spl-token-metadata-interface = { version = "0.2.0", path = "../../token-metadata/interface" }
+spl-token-metadata-interface = { version = "0.2.1", path = "../../token-metadata/interface" }
 spl-transfer-hook-interface = { version = "0.5.0", path = "../transfer-hook/interface" }
 spl-type-length-value = { version = "0.3.0", path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.1.1", path = "../../libraries/pod" }

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -31,7 +31,7 @@ solana-security-txt = "1.1.1"
 solana-zk-token-sdk = ">=1.17.17,<=2"
 spl-memo = { version = "4.0.1", path = "../../memo/program", features = [ "no-entrypoint" ] }
 spl-token = { version = "4.0",  path = "../program", features = ["no-entrypoint"] }
-spl-token-group-interface = { version = "0.1.0", path = "../../token-group/interface" }
+spl-token-group-interface = { version = "0.1.1", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.2.0", path = "../../token-metadata/interface" }
 spl-transfer-hook-interface = { version = "0.5.0", path = "../transfer-hook/interface" }
 spl-type-length-value = { version = "0.3.0", path = "../../libraries/type-length-value" }

--- a/token/program/Cargo.toml
+++ b/token/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token"
-version = "4.0.0"
+version = "4.0.1"
 description = "Solana Program Library Token"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token/transfer-hook/cli/Cargo.toml
+++ b/token/transfer-hook/cli/Cargo.toml
@@ -18,7 +18,7 @@ solana-logger = ">=1.17.17,<=2"
 solana-remote-wallet = ">=1.17.17,<=2"
 solana-sdk = ">=1.17.17,<=2"
 spl-transfer-hook-interface = { version = "0.5", path = "../interface" }
-spl-tlv-account-resolution = { version = "0.5.1" , path = "../../../libraries/tlv-account-resolution", features = ["serde-traits"] }
+spl-tlv-account-resolution = { version = "0.5.2" , path = "../../../libraries/tlv-account-resolution", features = ["serde-traits"] }
 strum = "0.26"
 strum_macros = "0.26"
 tokio = { version = "1", features = ["full"] }

--- a/token/transfer-hook/interface/Cargo.toml
+++ b/token/transfer-hook/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-transfer-hook-interface"
-version = "0.5.0"
+version = "0.5.1"
 description = "Solana Program Library Transfer Hook Interface"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"


### PR DESCRIPTION
Bump crate versions in preparation for tagging new releases so the monorepo dependencies can be updated to SPL versions that will use 2.0.0 for transitive dependencies.  [Discord discussion](https://discord.com/channels/428295358100013066/910937142182682656/1200210293112979626)