### PR TITLE
fix dependency update for new version

### DIFF
--- a/update-solana-dependencies.sh
+++ b/update-solana-dependencies.sh
@@ -84,6 +84,6 @@ crates=(
 
 set -x
 for crate in "${crates[@]}"; do
-  sed -E -i'' -e "s:(${crate} = \")(=?)${old_solana_ver}\".*:\1\2${solana_ver}\":" "${tomls[@]}"
-  sed -E -i'' -e "s:(${crate} = \{ version = \")(=?)${old_solana_ver}(\".*):\1\2${solana_ver}\3:" "${tomls[@]}"
+  sed -E -i'' -e "s:(${crate} = \")[=<>]*${old_solana_ver}[^\"]*\".*:\1=${solana_ver}\":" "${tomls[@]}"
+  sed -E -i'' -e "s:(${crate} = \{ version = \")[=<>]*${old_solana_ver}[^\"]*(\".*):\1=${solana_ver}\2:" "${tomls[@]}"
 done

--- a/update-solana-dependencies.sh
+++ b/update-solana-dependencies.sh
@@ -84,6 +84,6 @@ crates=(
 
 set -x
 for crate in "${crates[@]}"; do
-  sed -E -i'' -e "s:(${crate} = \")[=<>]*${old_solana_ver}[^\"]*\".*:\1=${solana_ver}\":" "${tomls[@]}"
-  sed -E -i'' -e "s:(${crate} = \{ version = \")[=<>]*${old_solana_ver}[^\"]*(\".*):\1=${solana_ver}\2:" "${tomls[@]}"
+  sed -E -i'' -e "s:(${crate} = \")([=<>]*)${old_solana_ver}([^\"]*)\".*:\1\2${solana_ver}\3\":" "${tomls[@]}"
+  sed -E -i'' -e "s:(${crate} = \{ version = \")([=<>]*)${old_solana_ver}([^\"]*)(\".*):\1\2${solana_ver}\3\4:" "${tomls[@]}"
 done


### PR DESCRIPTION
the regex in `update-solana-dependencies.sh` doesnt match the range dependency we current have, so running the `patch-crates.io` appears to succeed but when you build a project it doesnt use the local dependency

this changes it from "match maybe an equals sign then a single old version number, replace with the new version number preceded by whatever preceded the old one" to "match maybe eq/gt/lt/gte/lte then an old version number then whatever other nonsense comes until the end quote, replace with equals the new version number"

this still assumes if `Cargo.toml` has a version `>=1.2.3,<4.5.6` then `solana-version.sh` contains `1.2.3`