### PR TITLE
ci: Don't run token-collection for js changes

### DIFF
--- a/.github/workflows/pull-request-token-collection.yml
+++ b/.github/workflows/pull-request-token-collection.yml
@@ -10,6 +10,7 @@ on:
     - 'ci/*-version.sh'
     - '.github/workflows/pull-request-token-collection.yml'
     - '!token/js/**'
+    - '!token-group/js/**'
     - '!token-metadata/js/**'
   push:
     branches: [master]
@@ -21,6 +22,7 @@ on:
     - 'ci/*-version.sh'
     - '.github/workflows/pull-request-token-collection.yml'
     - '!token/js/**'
+    - '!token-group/js/**'
     - '!token-metadata/js/**'
 
 concurrency:


### PR DESCRIPTION
#### Problem

During PR #6233, the token-collection CI job was run because there was a change in `token-group/js`, but that's unnecessary.

#### Solution

Don't run token-collection CI if `token-group/js` was changed.