### PR TITLE
stake-pool-js: Bump to 1.0.1 for release

### DIFF
--- a/stake-pool/js/package.json
+++ b/stake-pool/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana/spl-stake-pool",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "SPL Stake Pool Program JS API",
   "scripts": {
     "build": "tsc && cross-env NODE_ENV=production rollup -c",


### PR DESCRIPTION
#### Problem

#6226 fixed using BNs as seeds in browser, but it hasn't been released yet.

#### Solution

Release 1.0.1 with the fix

Fixes #6269