### PR TITLE
Refactor Function Declaration

### DIFF
--- a/token-metadata/js/src/state.ts
+++ b/token-metadata/js/src/state.ts
@@ -39,7 +39,7 @@ function isNonePubkey(buffer: Uint8Array): boolean {
 }
 
 // Pack TokenMetadata into byte slab
-export const pack = (meta: TokenMetadata): Uint8Array => {
+export function pack(meta: TokenMetadata): Uint8Array {
     // If no updateAuthority given, set it to the None/Zero PublicKey for encoding
     const updateAuthority = meta.updateAuthority ?? PublicKey.default;
     return tokenMetadataCodec.encode({


### PR DESCRIPTION
Refactors function declaration to use named function declaration syntax instead of arrow function declaration system to remain consistent.

Resolves: #6282

