### PR TITLE
token-js: refactor metadata pointer tests

### DIFF
--- a/token/js/test/unit/metadataPointer.test.ts
+++ b/token/js/test/unit/metadataPointer.test.ts
@@ -8,39 +8,41 @@ import {
     getMetadataPointerState,
 } from '../../src';
 
-describe('SPL Token 2022 Metadata Extension', () => {
-    it('can create createInitializeMetadataPointerInstruction', () => {
-        const mint = PublicKey.unique();
-        const authority = new PublicKey('1111111QLbz7JHiBTspS962RLKV8GndWFwiEaqKM');
-        const metadataAddress = new PublicKey('1111111ogCyDbaRMvkdsHB3qfdyFYaG1WtRUAfdh');
+const AUTHORITY_ADDRESS_BYTES = Buffer.alloc(32).fill(8);
+const METADATA_ADDRESS_BYTES = Buffer.alloc(32).fill(5);
+const NULL_OPTIONAL_NONZERO_PUBKEY_BYTES = Buffer.alloc(32).fill(0);
 
+describe('SPL Token 2022 MetadataPointer Extension', () => {
+    it('can create InitializeMetadataPointerInstruction', () => {
+        const mint = PublicKey.unique();
+        const authority = new PublicKey(AUTHORITY_ADDRESS_BYTES);
+        const metadataAddress = new PublicKey(METADATA_ADDRESS_BYTES);
         const instruction = createInitializeMetadataPointerInstruction(
             mint,
             authority,
             metadataAddress,
             TOKEN_2022_PROGRAM_ID
         );
-
         expect(instruction).to.deep.equal(
             new TransactionInstruction({
                 programId: TOKEN_2022_PROGRAM_ID,
                 keys: [{ isSigner: false, isWritable: true, pubkey: mint }],
-                data: Buffer.from([
-                    // Output of rust implementation
-                    39, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                data: Buffer.concat([
+                    Buffer.from([
+                        39, // Token instruction discriminator
+                        0, // MetadataPointer instruction discriminator
+                    ]),
+                    AUTHORITY_ADDRESS_BYTES,
+                    METADATA_ADDRESS_BYTES,
                 ]),
             })
         );
     });
-
-    it('can create createUpdateMetadataPointerInstruction', () => {
+    it('can create UpdateMetadataPointerInstruction', () => {
         const mint = PublicKey.unique();
         const authority = PublicKey.unique();
-        const metadataAddress = new PublicKey('11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP');
-
+        const metadataAddress = new PublicKey(METADATA_ADDRESS_BYTES);
         const instruction = createUpdateMetadataPointerInstruction(mint, authority, metadataAddress);
-
         expect(instruction).to.deep.equal(
             new TransactionInstruction({
                 programId: TOKEN_2022_PROGRAM_ID,
@@ -48,22 +50,21 @@ describe('SPL Token 2022 Metadata Extension', () => {
                     { isSigner: false, isWritable: true, pubkey: mint },
                     { isSigner: true, isWritable: false, pubkey: authority },
                 ],
-                data: Buffer.from([
-                    // Output of rust implementation
-                    39, 1, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0,
+                data: Buffer.concat([
+                    Buffer.from([
+                        39, // Token instruction discriminator
+                        1, // MetadataPointer instruction discriminator
+                    ]),
+                    METADATA_ADDRESS_BYTES,
                 ]),
             })
         );
     });
-
-    it('can create createUpdateMetadataPointerInstruction to none', () => {
+    it('can create UpdateMetadataPointerInstruction to none', () => {
         const mint = PublicKey.unique();
         const authority = PublicKey.unique();
         const metadataAddress = null;
-
         const instruction = createUpdateMetadataPointerInstruction(mint, authority, metadataAddress);
-
         expect(instruction).to.deep.equal(
             new TransactionInstruction({
                 programId: TOKEN_2022_PROGRAM_ID,
@@ -71,70 +72,70 @@ describe('SPL Token 2022 Metadata Extension', () => {
                     { isSigner: false, isWritable: true, pubkey: mint },
                     { isSigner: true, isWritable: false, pubkey: authority },
                 ],
-                data: Buffer.from([
-                    // Output of rust implementation
-                    39, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0,
+                data: Buffer.concat([
+                    Buffer.from([
+                        39, // Token instruction discriminator
+                        1, // MetadataPointer instruction discriminator
+                    ]),
+                    NULL_OPTIONAL_NONZERO_PUBKEY_BYTES,
                 ]),
             })
         );
     });
-
     it('can get state with authority and metadata address', async () => {
         const mintInfo = {
-            tlvData: Buffer.from([
-                18, 0, 64, 0, 134, 125, 9, 16, 205, 223, 26, 224, 220, 174, 52, 213, 193, 216, 9, 80, 82, 181, 8, 228,
-                75, 112, 233, 116, 2, 183, 51, 228, 88, 64, 179, 158, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+            tlvData: Buffer.concat([
+                Buffer.from([
+                    // Extension discriminator
+                    18, 0,
+                    // Extension length
+                    64, 0,
+                ]),
+                AUTHORITY_ADDRESS_BYTES,
+                METADATA_ADDRESS_BYTES,
             ]),
         } as Mint;
-
         const metadataPointer = getMetadataPointerState(mintInfo);
-
         expect(metadataPointer).to.deep.equal({
-            authority: new PublicKey([
-                134, 125, 9, 16, 205, 223, 26, 224, 220, 174, 52, 213, 193, 216, 9, 80, 82, 181, 8, 228, 75, 112, 233,
-                116, 2, 183, 51, 228, 88, 64, 179, 158,
-            ]),
-            metadataAddress: new PublicKey([
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
-            ]),
+            authority: new PublicKey(AUTHORITY_ADDRESS_BYTES),
+            metadataAddress: new PublicKey(METADATA_ADDRESS_BYTES),
         });
     });
     it('can get state with only metadata address', async () => {
         const mintInfo = {
-            tlvData: Buffer.from([
-                18, 0, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+            tlvData: Buffer.concat([
+                Buffer.from([
+                    // Extension discriminator
+                    18, 0,
+                    // Extension length
+                    64, 0,
+                ]),
+                NULL_OPTIONAL_NONZERO_PUBKEY_BYTES,
+                METADATA_ADDRESS_BYTES,
             ]),
         } as Mint;
-
         const metadataPointer = getMetadataPointerState(mintInfo);
-
         expect(metadataPointer).to.deep.equal({
             authority: null,
-            metadataAddress: new PublicKey([
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
-            ]),
+            metadataAddress: new PublicKey(METADATA_ADDRESS_BYTES),
         });
     });
-
     it('can get state with only authority address', async () => {
         const mintInfo = {
-            tlvData: Buffer.from([
-                18, 0, 64, 0, 16, 218, 238, 42, 17, 19, 152, 173, 216, 24, 229, 204, 215, 108, 49, 98, 233, 115, 53,
-                252, 9, 156, 216, 23, 14, 157, 139, 132, 28, 182, 4, 191, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            tlvData: Buffer.concat([
+                Buffer.from([
+                    // Extension discriminator
+                    18, 0,
+                    // Extension length
+                    64, 0,
+                ]),
+                AUTHORITY_ADDRESS_BYTES,
+                NULL_OPTIONAL_NONZERO_PUBKEY_BYTES,
             ]),
         } as Mint;
-
         const metadataPointer = getMetadataPointerState(mintInfo);
-
         expect(metadataPointer).to.deep.equal({
-            authority: new PublicKey([
-                16, 218, 238, 42, 17, 19, 152, 173, 216, 24, 229, 204, 215, 108, 49, 98, 233, 115, 53, 252, 9, 156, 216,
-                23, 14, 157, 139, 132, 28, 182, 4, 191,
-            ]),
+            authority: new PublicKey(AUTHORITY_ADDRESS_BYTES),
             metadataAddress: null,
         });
     });


### PR DESCRIPTION
The `MetadataPointer` tests are a little bit difficult to follow, so this change
refactors them to be a bit more legible, so onlookers can see what's going on
and learn how to use the `MetadataPointer` instructions & state from observing
the tests.
