### PR TITLE
token-js: add `GroupPointer` and `GroupMemberPointer` to `setAuthority`

### DIFF
--- a/token/js/src/instructions/setAuthority.ts
+++ b/token/js/src/instructions/setAuthority.ts
@@ -28,6 +28,8 @@ export enum AuthorityType {
     TransferHookProgramId = 10,
     ConfidentialTransferFeeConfig = 11,
     MetadataPointer = 12,
+    GroupPointer = 13,
+    GroupMemberPointer = 14,
 }
 
 /** TODO: docs */


### PR DESCRIPTION
Add the newly added `GroupPointer` and `GroupMemberPointer` to the
`setAuthority` instruction.
