### PR TITLE
Doc(extensions.mdx): correct import statment

### DIFF
--- a/docs/src/token-2022/extensions.mdx
+++ b/docs/src/token-2022/extensions.mdx
@@ -1270,7 +1270,7 @@ import {
     createAccount,
     getMintLen,
     TOKEN_2022_PROGRAM_ID,
-} from '../src';
+} from '@solana/spl-token';
 
 (async () => {
     const payer = Keypair.generate();
@@ -1382,7 +1382,7 @@ import {
     getAccountLen,
     ExtensionType,
     TOKEN_2022_PROGRAM_ID,
-} from '../src';
+} from '@solana/spl-token';
 
 (async () => {
     const connection = new Connection(clusterApiUrl('devnet'), 'confirmed');
@@ -1549,7 +1549,7 @@ import {
     createAccount,
     getMintLen,
     TOKEN_2022_PROGRAM_ID,
-} from '../src';
+} from '@solana/spl-token';
 
 (async () => {
     const payer = Keypair.generate();


### PR DESCRIPTION
change the import from `../src` to `@solana/spl-token` because users will try to use these scripts in their own projects and these imports needs to come from the library itself


Related to issue:  https://github.com/solana-labs/solana-program-library/issues/6300