### PR TITLE
token-2022: Update compute unit numbers to get baseline CU usage

### DIFF
--- a/token/program-2022/tests/assert_instruction_count.rs
+++ b/token/program-2022/tests/assert_instruction_count.rs
@@ -22,7 +22,7 @@ const TRANSFER_AMOUNT: u64 = 1_000_000_000_000_000;
 #[tokio::test]
 async fn initialize_mint() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
-    pt.set_compute_max_units(5_000); // last known 2252
+    pt.set_compute_max_units(5_000); // last known 2196
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner_key = Pubkey::new_unique();
@@ -60,7 +60,7 @@ async fn initialize_mint() {
 #[tokio::test]
 async fn initialize_account() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
-    pt.set_compute_max_units(8_000); // last known 7064
+    pt.set_compute_max_units(8_000); // last known 3229
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();
@@ -112,7 +112,7 @@ async fn initialize_account() {
 #[tokio::test]
 async fn mint_to() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
-    pt.set_compute_max_units(8_000); // last known 7033
+    pt.set_compute_max_units(8_000); // last known 2694
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();
@@ -161,7 +161,7 @@ async fn mint_to() {
 #[tokio::test]
 async fn transfer() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
-    pt.set_compute_max_units(8_000); // last known 7033
+    pt.set_compute_max_units(8_000); // last known 2988
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();
@@ -229,7 +229,7 @@ async fn transfer() {
 #[tokio::test]
 async fn burn() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
-    pt.set_compute_max_units(8_000); // last known 7042
+    pt.set_compute_max_units(8_000); // last known 2860
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();
@@ -286,7 +286,7 @@ async fn burn() {
 #[tokio::test]
 async fn close_account() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
-    pt.set_compute_max_units(8_000); // last known 1783
+    pt.set_compute_max_units(8_000); // last known 1990
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();


### PR DESCRIPTION
#### Problem

As part of moving token-2022 to `Pod`-style deserializers in #6316, we need good baseline CU usage numbers to see the impact of the Pod work.

#### Solution

Update the numbers based on the compiler that comes with 1.18.2.