### PR TITLE
token-2022: Add instruction count test for `transfer_checked`

### DIFF
--- a/token/program-2022/tests/action.rs
+++ b/token/program-2022/tests/action.rs
@@ -121,6 +121,38 @@ pub async fn transfer(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
+pub async fn transfer_checked(
+    banks_client: &mut BanksClient,
+    payer: &Keypair,
+    recent_blockhash: Hash,
+    source: &Pubkey,
+    mint: &Pubkey,
+    destination: &Pubkey,
+    authority: &Keypair,
+    amount: u64,
+    decimals: u8,
+) -> Result<(), TransportError> {
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction::transfer_checked(
+            &id(),
+            source,
+            mint,
+            destination,
+            &authority.pubkey(),
+            &[],
+            amount,
+            decimals,
+        )
+        .unwrap()],
+        Some(&payer.pubkey()),
+        &[payer, authority],
+        recent_blockhash,
+    );
+    banks_client.process_transaction(transaction).await?;
+    Ok(())
+}
+
 pub async fn burn(
     banks_client: &mut BanksClient,
     payer: &Keypair,


### PR DESCRIPTION
#### Problem

As part of moving token-2022 to Pod-style deserializers in https://github.com/solana-labs/solana-program-library/pull/6316, we need good baseline CU usage numbers to see the impact of the Pod work, but we don't have any tests that exercise `transfer_checked`.

#### Solution

Add an instruction count test that uses `transfer_checked` as a baseline.