### PR TITLE
token-2022: bump patch version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6843,7 +6843,7 @@ dependencies = [
  "num-traits",
  "solana-program",
  "spl-token 4.0.1",
- "spl-token-2022 2.0.1",
+ "spl-token-2022 2.0.2",
  "thiserror",
 ]
 
@@ -6856,7 +6856,7 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account 2.3.1",
  "spl-token 4.0.1",
- "spl-token-2022 2.0.1",
+ "spl-token-2022 2.0.2",
 ]
 
 [[package]]
@@ -7418,7 +7418,7 @@ dependencies = [
  "spl-math",
  "spl-pod 0.1.1",
  "spl-token 4.0.1",
- "spl-token-2022 2.0.1",
+ "spl-token-2022 2.0.2",
  "test-case",
  "thiserror",
 ]
@@ -7539,7 +7539,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-2022"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "arrayref",
  "base64 0.22.0",
@@ -7584,7 +7584,7 @@ dependencies = [
  "spl-memo 4.0.1",
  "spl-pod 0.1.1",
  "spl-tlv-account-resolution 0.5.2",
- "spl-token-2022 2.0.1",
+ "spl-token-2022 2.0.2",
  "spl-token-client",
  "spl-token-group-interface 0.1.1",
  "spl-token-metadata-interface 0.2.1",
@@ -7621,7 +7621,7 @@ dependencies = [
  "spl-associated-token-account 2.3.1",
  "spl-memo 4.0.1",
  "spl-token 4.0.1",
- "spl-token-2022 2.0.1",
+ "spl-token-2022 2.0.2",
  "spl-token-client",
  "spl-token-group-interface 0.1.1",
  "spl-token-metadata-interface 0.2.1",
@@ -7649,7 +7649,7 @@ dependencies = [
  "spl-associated-token-account 2.3.1",
  "spl-memo 4.0.1",
  "spl-token 4.0.1",
- "spl-token-2022 2.0.1",
+ "spl-token-2022 2.0.2",
  "spl-token-group-interface 0.1.1",
  "spl-token-metadata-interface 0.2.1",
  "spl-transfer-hook-interface 0.5.1",
@@ -7666,7 +7666,7 @@ dependencies = [
  "spl-discriminator 0.1.1",
  "spl-pod 0.1.1",
  "spl-program-error 0.3.1",
- "spl-token-2022 2.0.1",
+ "spl-token-2022 2.0.2",
  "spl-token-client",
  "spl-token-group-example",
  "spl-token-group-interface 0.1.1",
@@ -7683,7 +7683,7 @@ dependencies = [
  "solana-sdk",
  "spl-discriminator 0.1.1",
  "spl-pod 0.1.1",
- "spl-token-2022 2.0.1",
+ "spl-token-2022 2.0.2",
  "spl-token-client",
  "spl-token-group-interface 0.1.1",
  "spl-token-metadata-interface 0.2.1",
@@ -7756,7 +7756,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-pod 0.1.1",
- "spl-token-2022 2.0.1",
+ "spl-token-2022 2.0.2",
  "spl-token-client",
  "spl-token-metadata-interface 0.2.1",
  "spl-type-length-value 0.3.1",
@@ -7806,7 +7806,7 @@ dependencies = [
  "solana-sdk",
  "spl-math",
  "spl-token 4.0.1",
- "spl-token-2022 2.0.1",
+ "spl-token-2022 2.0.2",
  "test-case",
  "thiserror",
 ]
@@ -7834,7 +7834,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-token 4.0.1",
- "spl-token-2022 2.0.1",
+ "spl-token-2022 2.0.2",
  "spl-token-client",
  "test-case",
  "thiserror",
@@ -7855,7 +7855,7 @@ dependencies = [
  "solana-test-validator",
  "spl-associated-token-account 2.3.1",
  "spl-token 4.0.1",
- "spl-token-2022 2.0.1",
+ "spl-token-2022 2.0.2",
  "spl-token-client",
  "spl-token-upgrade",
  "tokio",
@@ -7871,7 +7871,7 @@ dependencies = [
  "solana-program",
  "spl-associated-token-account 2.3.1",
  "spl-token 4.0.1",
- "spl-token-2022 2.0.1",
+ "spl-token-2022 2.0.2",
  "thiserror",
 ]
 
@@ -7892,7 +7892,7 @@ dependencies = [
  "solana-sdk",
  "solana-test-validator",
  "spl-tlv-account-resolution 0.5.2",
- "spl-token-2022 2.0.1",
+ "spl-token-2022 2.0.2",
  "spl-token-client",
  "spl-transfer-hook-interface 0.5.1",
  "strum 0.26.1",
@@ -7909,7 +7909,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-tlv-account-resolution 0.5.2",
- "spl-token-2022 2.0.1",
+ "spl-token-2022 2.0.2",
  "spl-transfer-hook-interface 0.5.1",
  "spl-type-length-value 0.3.1",
 ]

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-2022"
-version = "2.0.1"
+version = "2.0.2"
 description = "Solana Program Library Token 2022"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"


### PR DESCRIPTION
Bumps the patch version of Token-2022 to include the new lockfile changes from #6325 and #6324.