### PR TITLE
token-2022: Introduce `PackedSizeOf` and relax `BaseState` trait

### DIFF
--- a/token/program-2022/src/state.rs
+++ b/token/program-2022/src/state.rs
@@ -16,6 +16,14 @@ use {
     },
 };
 
+/// Simplified version of the `Pack` trait which only gives the size of the
+/// packed struct. Useful when a function doesn't need a type to implement all
+/// of `Pack`, but a size is still needed.
+pub trait PackedSizeOf {
+    /// The packed size of the struct
+    const SIZE_OF: usize;
+}
+
 /// Mint data.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
@@ -85,6 +93,9 @@ impl Pack for Mint {
         is_initialized_dst[0] = is_initialized as u8;
         pack_coption_key(freeze_authority, freeze_authority_dst);
     }
+}
+impl PackedSizeOf for Mint {
+    const SIZE_OF: usize = Self::LEN;
 }
 
 /// Account data.
@@ -184,6 +195,9 @@ impl Pack for Account {
         pack_coption_key(close_authority, close_authority_dst);
     }
 }
+impl PackedSizeOf for Account {
+    const SIZE_OF: usize = Self::LEN;
+}
 
 /// Account state.
 #[repr(u8)]
@@ -253,6 +267,9 @@ impl Pack for Multisig {
             dst_array.copy_from_slice(src.as_ref());
         }
     }
+}
+impl PackedSizeOf for Multisig {
+    const SIZE_OF: usize = Self::LEN;
 }
 
 // Helpers


### PR DESCRIPTION
#### Problem

As part of #6316, in order to create a `Pod`-compatible version of `StateWithExtensions`, we need to relax the requirement for `BaseState` to implement `Pack`, since it will implement `Pod` instead for the pod version of `StateWithExtensions`.

On the flip-side, we do need to know the size of the underlying type to move through the underlying buffer.

#### Solution

Introduce a new trait, `PackedSizeOf`, which only gives the packed length of a type. This is just a more limited version of the `LEN` on the `Pack` trait.

Relax the trait bound on `BaseState` so that it requires `PackedSizeOf` instead of `Pack`.