### PR TITLE
token-2022: Add `Pod`-compatible versions of `StateWithExtensions`

### DIFF
--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -792,7 +792,7 @@ impl<'data, S: BaseState + Pack> StateWithExtensionsMut<'data, S> {
         check_min_len_and_not_multisig(input, S::SIZE_OF)?;
         let (base_data, rest) = input.split_at_mut(S::SIZE_OF);
         let base = S::unpack(base_data)?;
-        let (account_type, tlv_data) = unpack_type_and_tlv_data::<S>(rest)?;
+        let (account_type, tlv_data) = unpack_type_and_tlv_data_mut::<S>(rest)?;
         Ok(Self {
             base,
             base_data,
@@ -812,7 +812,7 @@ impl<'data, S: BaseState + Pack> StateWithExtensionsMut<'data, S> {
         if base.is_initialized() {
             return Err(TokenError::AlreadyInUse.into());
         }
-        let (account_type, tlv_data) = unpack_uninitialized_type_and_tlv_data::<S>(rest)?;
+        let (account_type, tlv_data) = unpack_uninitialized_type_and_tlv_data_mut::<S>(rest)?;
         let state = Self {
             base,
             base_data,
@@ -847,7 +847,7 @@ impl<'a, S: BaseState> BaseStateWithExtensionsMut<S> for StateWithExtensionsMut<
     }
 }
 
-fn unpack_type_and_tlv_data_with_check<
+fn unpack_type_and_tlv_data_with_check_mut<
     S: BaseState,
     F: Fn(AccountType) -> Result<(), ProgramError>,
 >(
@@ -869,16 +869,16 @@ fn unpack_type_and_tlv_data_with_check<
     }
 }
 
-fn unpack_type_and_tlv_data<S: BaseState>(
+fn unpack_type_and_tlv_data_mut<S: BaseState>(
     rest: &mut [u8],
 ) -> Result<(&mut [u8], &mut [u8]), ProgramError> {
-    unpack_type_and_tlv_data_with_check::<S, _>(rest, check_account_type::<S>)
+    unpack_type_and_tlv_data_with_check_mut::<S, _>(rest, check_account_type::<S>)
 }
 
-fn unpack_uninitialized_type_and_tlv_data<S: BaseState>(
+fn unpack_uninitialized_type_and_tlv_data_mut<S: BaseState>(
     rest: &mut [u8],
 ) -> Result<(&mut [u8], &mut [u8]), ProgramError> {
-    unpack_type_and_tlv_data_with_check::<S, _>(rest, |account_type| {
+    unpack_type_and_tlv_data_with_check_mut::<S, _>(rest, |account_type| {
         if account_type != AccountType::Uninitialized {
             Err(ProgramError::InvalidAccountData)
         } else {

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -941,6 +941,7 @@ impl<'a, S: BaseState> BaseStateWithExtensionsMut<S> for PodStateWithExtensionsM
 
 fn unpack_tlv_data<S: BaseState>(rest: &[u8]) -> Result<&[u8], ProgramError> {
     if let Some((account_type_index, tlv_start_index)) = type_and_tlv_indices::<S>(rest)? {
+        // type_and_tlv_indices() checks that returned indexes are within range
         let account_type = AccountType::try_from(rest[account_type_index])
             .map_err(|_| ProgramError::InvalidAccountData)?;
         check_account_type::<S>(account_type)?;


### PR DESCRIPTION
#### Problem

Towards zero-copy deserialization in token-2022 in #6316, we need a `Pod`-compatible version of `StateWithExtensions`, where the underlying `BaseState` implements `Pod`. That way, we can `unpack` something in zero-copy.

#### Solution

Add the new types. I tried to do as much dedupe as possible by introducing `unpack_tlv_data`, but it's tough to reduce too much more than that.

Also, the `unpack` functions on the new types are extremely similar to their non-`Pod` versions, and the only difference is calling `pod_from_bytes` instead of `unpack`.

We could do this with a macro, but macros always feel a little more brittle / hacky. I don't feel too strongly though, so I'm happy to do whatever you think is best!

Also, `unpack_tlv_data` is just an immutable version of the previous `unpack_type_and_tlv_data`, not sure how to reduce the copy-pasta there.