### PR TITLE
token-2022: Update alloc_and_serialize to use Pod types

### DIFF
--- a/token/program-2022/src/extension/token_group/processor.rs
+++ b/token/program-2022/src/extension/token_group/processor.rs
@@ -9,6 +9,7 @@ use {
             group_pointer::GroupPointer, BaseStateWithExtensions, BaseStateWithExtensionsMut,
             StateWithExtensions, StateWithExtensionsMut,
         },
+        pod::PodMint,
         state::Mint,
     },
     solana_program::{
@@ -90,7 +91,7 @@ pub fn process_initialize_group(
     // Allocate a TLV entry for the space and write it in
     // Assumes that there's enough SOL for the new rent-exemption
     let group = TokenGroup::new(mint_info.key, data.update_authority, data.max_size.into());
-    alloc_and_serialize::<Mint, TokenGroup>(group_info, &group, false)?;
+    alloc_and_serialize::<PodMint, TokenGroup>(group_info, &group, false)?;
 
     Ok(())
 }
@@ -201,7 +202,7 @@ pub fn process_initialize_member(_program_id: &Pubkey, accounts: &[AccountInfo])
 
     // Allocate a TLV entry for the space and write it in
     let member = TokenGroupMember::new(member_mint_info.key, group_info.key, member_number);
-    alloc_and_serialize::<Mint, TokenGroupMember>(member_info, &member, false)?;
+    alloc_and_serialize::<PodMint, TokenGroupMember>(member_info, &member, false)?;
 
     Ok(())
 }

--- a/token/program-2022/src/extension/token_metadata/processor.rs
+++ b/token/program-2022/src/extension/token_metadata/processor.rs
@@ -8,6 +8,7 @@ use {
             alloc_and_serialize_variable_len_extension, metadata_pointer::MetadataPointer,
             BaseStateWithExtensions, StateWithExtensions,
         },
+        pod::PodMint,
         state::Mint,
     },
     solana_program::{
@@ -98,7 +99,11 @@ pub fn process_initialize(
 
     // allocate a TLV entry for the space and write it in, assumes that there's
     // enough SOL for the new rent-exemption
-    alloc_and_serialize_variable_len_extension::<Mint, _>(metadata_info, &token_metadata, false)?;
+    alloc_and_serialize_variable_len_extension::<PodMint, _>(
+        metadata_info,
+        &token_metadata,
+        false,
+    )?;
 
     Ok(())
 }
@@ -127,7 +132,7 @@ pub fn process_update_field(
     token_metadata.update(data.field, data.value);
 
     // Update / realloc the account
-    alloc_and_serialize_variable_len_extension::<Mint, _>(metadata_info, &token_metadata, true)?;
+    alloc_and_serialize_variable_len_extension::<PodMint, _>(metadata_info, &token_metadata, true)?;
 
     Ok(())
 }
@@ -154,7 +159,7 @@ pub fn process_remove_key(
     if !token_metadata.remove_key(&data.key) && !data.idempotent {
         return Err(TokenMetadataError::KeyNotFound.into());
     }
-    alloc_and_serialize_variable_len_extension::<Mint, _>(metadata_info, &token_metadata, true)?;
+    alloc_and_serialize_variable_len_extension::<PodMint, _>(metadata_info, &token_metadata, true)?;
     Ok(())
 }
 
@@ -180,7 +185,7 @@ pub fn process_update_authority(
     check_update_authority(update_authority_info, &token_metadata.update_authority)?;
     token_metadata.update_authority = data.new_authority;
     // Update the account, no realloc needed!
-    alloc_and_serialize_variable_len_extension::<Mint, _>(metadata_info, &token_metadata, true)?;
+    alloc_and_serialize_variable_len_extension::<PodMint, _>(metadata_info, &token_metadata, true)?;
 
     Ok(())
 }


### PR DESCRIPTION
#### Problem

As part of the transition to using `Pod` types with #6316, the `alloc_and_serialize` extension helpers need to use `Pod` types to avoid more expensive deserialization.

#### Solution

Use `PodStateWithExtensions*` in the `alloc_and_serialize*` functions.

I spent a long time trying to do this by adding an `unpack` function to the `BaseStateWithExtensions` traits, but because `unpack` takes in a `&[u8]`, and `StateWithExtensions` holds onto a reference, the lifetimes were an absolute nightmare. Because of that, I decided to just transition the whole function to use only `Pod` types.

I don't know why the alloc functions were `pub` to begin with, so I've also made them `pub(crate)`. This will require a major version bump.