### PR TITLE
Governance: Rename governed_account to governance_seed

### DIFF
--- a/governance/chat/program/tests/program_test/mod.rs
+++ b/governance/chat/program/tests/program_test/mod.rs
@@ -183,7 +183,7 @@ impl GovernanceChatProgramTest {
         }
 
         // Create Governance
-        let governed_account_address = Pubkey::new_unique();
+        let governance_seed = Pubkey::new_unique();
 
         let governance_config = GovernanceConfig {
             community_vote_threshold: VoteThreshold::YesVotePercentage(60),
@@ -235,7 +235,7 @@ impl GovernanceChatProgramTest {
         let create_governance_ix = create_governance(
             &self.governance_program_id,
             &realm_address,
-            Some(&governed_account_address),
+            &governance_seed,
             &token_owner_record_address,
             &self.bench.payer.pubkey(),
             &token_owner.pubkey(),
@@ -253,7 +253,7 @@ impl GovernanceChatProgramTest {
         let governance_address = get_governance_address(
             &self.governance_program_id,
             &realm_address,
-            &governed_account_address,
+            &governance_seed,
         );
 
         let proposal_name = "Proposal #1".to_string();

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -829,7 +829,7 @@ pub fn create_governance(
     program_id: &Pubkey,
     // Accounts
     realm: &Pubkey,
-    governance_seed: Option<&Pubkey>,
+    governance_seed: &Pubkey,
     token_owner_record: &Pubkey,
     payer: &Pubkey,
     create_authority: &Pubkey,
@@ -837,20 +837,12 @@ pub fn create_governance(
     // Args
     config: GovernanceConfig,
 ) -> Instruction {
-    let governed_account_address = if let Some(governance_seed) = governance_seed {
-        *governance_seed
-    } else {
-        // If the governed account is not provided then generate a unique identifier for
-        // the Governance account
-        Pubkey::new_unique()
-    };
-
-    let governance_address = get_governance_address(program_id, realm, &governed_account_address);
+    let governance_address = get_governance_address(program_id, realm, governance_seed);
 
     let mut accounts = vec![
         AccountMeta::new_readonly(*realm, false),
         AccountMeta::new(governance_address, false),
-        AccountMeta::new_readonly(governed_account_address, false),
+        AccountMeta::new_readonly(*governance_seed, false),
         AccountMeta::new_readonly(*token_owner_record, false),
         AccountMeta::new(*payer, true),
         AccountMeta::new_readonly(system_program::id(), false),

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -140,10 +140,8 @@ pub enum GovernanceInstruction {
     ///
     ///   0. `[]` Realm account the created Governance belongs to
     ///   1. `[writable]` Governance account
-    ///     * PDA seeds: ['account-governance', realm, governed_account]
-    ///   2. `[]` Account governed by this Governance Note: The account doesn't
-    ///      have to exist and can be only used as a unique identifier for the
-    ///      Governance account
+    ///     * PDA seeds: ['account-governance', realm, governance_seed]
+    ///   2. `[]` Governance account PDA seed
     ///   3. `[]` Governing TokenOwnerRecord account (Used only if not signed by
     ///      RealmAuthority)
     ///   4. `[signer]` Payer
@@ -831,7 +829,7 @@ pub fn create_governance(
     program_id: &Pubkey,
     // Accounts
     realm: &Pubkey,
-    governed_account: Option<&Pubkey>,
+    governance_seed: Option<&Pubkey>,
     token_owner_record: &Pubkey,
     payer: &Pubkey,
     create_authority: &Pubkey,
@@ -839,8 +837,8 @@ pub fn create_governance(
     // Args
     config: GovernanceConfig,
 ) -> Instruction {
-    let governed_account_address = if let Some(governed_account) = governed_account {
-        *governed_account
+    let governed_account_address = if let Some(governance_seed) = governance_seed {
+        *governance_seed
     } else {
         // If the governed account is not provided then generate a unique identifier for
         // the Governance account

--- a/governance/program/src/processor/process_create_governance.rs
+++ b/governance/program/src/processor/process_create_governance.rs
@@ -32,7 +32,7 @@ pub fn process_create_governance(
 
     let realm_info = next_account_info(account_info_iter)?; // 0
     let governance_info = next_account_info(account_info_iter)?; // 1
-    let governed_account_info = next_account_info(account_info_iter)?; // 2
+    let governance_seed_info = next_account_info(account_info_iter)?; // 2
 
     let token_owner_record_info = next_account_info(account_info_iter)?; // 3
 
@@ -58,7 +58,7 @@ pub fn process_create_governance(
     let governance_data = GovernanceV2 {
         account_type: GovernanceAccountType::GovernanceV2,
         realm: *realm_info.key,
-        governed_account: *governed_account_info.key,
+        governance_seed: *governance_seed_info.key,
         config,
         reserved1: 0,
         reserved_v2: Reserved119::default(),
@@ -70,7 +70,7 @@ pub fn process_create_governance(
         payer_info,
         governance_info,
         &governance_data,
-        &get_governance_address_seeds(realm_info.key, governed_account_info.key),
+        &get_governance_address_seeds(realm_info.key, governance_seed_info.key),
         program_id,
         system_info,
         &rent,

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -272,7 +272,7 @@ impl GovernanceV2 {
             let governance_data_v1 = GovernanceV1 {
                 account_type: self.account_type,
                 realm: self.realm,
-                governed_account: self.governance_seed,
+                governance_seed: self.governance_seed,
                 proposals_count: 0,
                 config: self.config,
             };
@@ -414,7 +414,7 @@ pub fn get_governance_data(
         GovernanceV2 {
             account_type,
             realm: governance_data_v1.realm,
-            governance_seed: governance_data_v1.governed_account,
+            governance_seed: governance_data_v1.governance_seed,
             reserved1: 0,
             config: governance_data_v1.config,
             reserved_v2: Reserved119::default(),
@@ -709,7 +709,7 @@ mod test {
         GovernanceV1 {
             account_type: GovernanceAccountType::GovernanceV1,
             realm: Pubkey::new_unique(),
-            governed_account: Pubkey::new_unique(),
+            governance_seed: Pubkey::new_unique(),
             proposals_count: 10,
             config: create_test_governance_config(),
         }

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -91,19 +91,14 @@ pub struct GovernanceV2 {
     /// Governance Realm
     pub realm: Pubkey,
 
-    /// Account governed by this Governance and/or PDA identity seed
-    /// It can be Program account, Mint account, Token account or any other
-    /// account
+    /// The seed used to create Governance account PDA
     ///
-    /// Note: The account doesn't have to exist. In that case the field is only
-    /// a PDA seed
-    ///
-    /// Note: Setting governed_account doesn't give any authority over the
-    /// governed account The relevant authorities for specific account types
-    /// must still be transferred to the Governance PDA Ex: mint_authority/
-    /// freeze_authority for a Mint account or upgrade_authority for a
-    /// Program account should be transferred to the Governance PDA
-    pub governed_account: Pubkey,
+    /// Note: For the legacy asset specific Governance accounts
+    /// the seed by convention is:
+    /// MintGovernance -> mint address
+    /// TokenAccountGovernance -> token account address
+    /// ProgramGovernance -> program address
+    pub governance_seed: Pubkey,
 
     /// Reserved space for future versions
     pub reserved1: u32,
@@ -221,17 +216,17 @@ impl GovernanceV2 {
     pub fn get_governance_address_seeds(&self) -> Result<[&[u8]; 3], ProgramError> {
         let seeds = match self.account_type {
             GovernanceAccountType::GovernanceV1 | GovernanceAccountType::GovernanceV2 => {
-                get_governance_address_seeds(&self.realm, &self.governed_account)
+                get_governance_address_seeds(&self.realm, &self.governance_seed)
             }
             GovernanceAccountType::ProgramGovernanceV1
             | GovernanceAccountType::ProgramGovernanceV2 => {
-                get_program_governance_address_seeds(&self.realm, &self.governed_account)
+                get_program_governance_address_seeds(&self.realm, &self.governance_seed)
             }
             GovernanceAccountType::MintGovernanceV1 | GovernanceAccountType::MintGovernanceV2 => {
-                get_mint_governance_address_seeds(&self.realm, &self.governed_account)
+                get_mint_governance_address_seeds(&self.realm, &self.governance_seed)
             }
             GovernanceAccountType::TokenGovernanceV1 | GovernanceAccountType::TokenGovernanceV2 => {
-                get_token_governance_address_seeds(&self.realm, &self.governed_account)
+                get_token_governance_address_seeds(&self.realm, &self.governance_seed)
             }
             GovernanceAccountType::Uninitialized
             | GovernanceAccountType::RealmV1
@@ -277,7 +272,7 @@ impl GovernanceV2 {
             let governance_data_v1 = GovernanceV1 {
                 account_type: self.account_type,
                 realm: self.realm,
-                governed_account: self.governed_account,
+                governed_account: self.governance_seed,
                 proposals_count: 0,
                 config: self.config,
             };
@@ -419,7 +414,7 @@ pub fn get_governance_data(
         GovernanceV2 {
             account_type,
             realm: governance_data_v1.realm,
-            governed_account: governance_data_v1.governed_account,
+            governance_seed: governance_data_v1.governed_account,
             reserved1: 0,
             config: governance_data_v1.config,
             reserved_v2: Reserved119::default(),
@@ -560,22 +555,26 @@ pub fn get_mint_governance_address<'a>(
 /// Returns legacy TokenGovernance PDA seeds
 pub fn get_token_governance_address_seeds<'a>(
     realm: &'a Pubkey,
-    governed_token: &'a Pubkey,
+    governed_token_account: &'a Pubkey,
 ) -> [&'a [u8]; 3] {
     // 'token-governance' prefix ensures uniqueness of the PDA
     // Note: Only the current token account owner can create an account with this
     // PDA using CreateTokenGovernance instruction
-    [b"token-governance", realm.as_ref(), governed_token.as_ref()]
+    [
+        b"token-governance",
+        realm.as_ref(),
+        governed_token_account.as_ref(),
+    ]
 }
 
 /// Returns legacy TokenGovernance PDA address
 pub fn get_token_governance_address<'a>(
     program_id: &Pubkey,
     realm: &'a Pubkey,
-    governed_token: &'a Pubkey,
+    governed_token_account: &'a Pubkey,
 ) -> Pubkey {
     Pubkey::find_program_address(
-        &get_token_governance_address_seeds(realm, governed_token),
+        &get_token_governance_address_seeds(realm, governed_token_account),
         program_id,
     )
     .0
@@ -584,12 +583,12 @@ pub fn get_token_governance_address<'a>(
 /// Returns Governance PDA seeds
 pub fn get_governance_address_seeds<'a>(
     realm: &'a Pubkey,
-    governed_account: &'a Pubkey,
+    governance_seed: &'a Pubkey,
 ) -> [&'a [u8]; 3] {
     [
         b"account-governance",
         realm.as_ref(),
-        governed_account.as_ref(),
+        governance_seed.as_ref(),
     ]
 }
 
@@ -597,10 +596,10 @@ pub fn get_governance_address_seeds<'a>(
 pub fn get_governance_address<'a>(
     program_id: &Pubkey,
     realm: &'a Pubkey,
-    governed_account: &'a Pubkey,
+    governance_seed: &'a Pubkey,
 ) -> Pubkey {
     Pubkey::find_program_address(
-        &get_governance_address_seeds(realm, governed_account),
+        &get_governance_address_seeds(realm, governance_seed),
         program_id,
     )
     .0
@@ -697,7 +696,7 @@ mod test {
         GovernanceV2 {
             account_type: GovernanceAccountType::GovernanceV2,
             realm: Pubkey::new_unique(),
-            governed_account: Pubkey::new_unique(),
+            governance_seed: Pubkey::new_unique(),
             reserved1: 0,
             config: create_test_governance_config(),
             reserved_v2: Reserved119::default(),

--- a/governance/program/src/state/legacy.rs
+++ b/governance/program/src/state/legacy.rs
@@ -115,19 +115,14 @@ pub struct GovernanceV1 {
     /// Governance Realm
     pub realm: Pubkey,
 
-    /// Account governed by this Governance and/or PDA identity seed
-    /// It can be Program account, Mint account, Token account or any other
-    /// account
+    /// The seed used to create Governance account PDA
     ///
-    /// Note: The account doesn't have to exist. In that case the field is only
-    /// a PDA seed
-    ///
-    /// Note: Setting governed_account doesn't give any authority over the
-    /// governed account The relevant authorities for specific account types
-    /// must still be transferred to the Governance PDA Ex: mint_authority/
-    /// freeze_authority for a Mint account or upgrade_authority for a
-    /// Program account should be transferred to the Governance PDA
-    pub governed_account: Pubkey,
+    /// Note: For the legacy asset specific Governance accounts
+    /// the seed by convention is:
+    /// MintGovernance -> mint address
+    /// TokenAccountGovernance -> token account address
+    /// ProgramGovernance -> program address
+    pub governance_seed: Pubkey,
 
     /// Running count of proposals
     pub proposals_count: u32,

--- a/governance/program/tests/program_test/legacy.rs
+++ b/governance/program/tests/program_test/legacy.rs
@@ -13,8 +13,8 @@ pub struct LegacyGovernanceV1 {
     /// Governance Realm
     pub realm: Pubkey,
 
-    /// Account governed by this Governance.
-    pub governed_account: Pubkey,
+    /// Governance seed
+    pub governance_seed: Pubkey,
 
     /// Running count of proposals
     pub proposals_count: u32,
@@ -113,7 +113,7 @@ impl From<GovernanceV2> for LegacyGovernanceV1 {
         LegacyGovernanceV1 {
             account_type,
             realm: governance_v2.realm,
-            governed_account: governance_v2.governance_seed,
+            governance_seed: governance_v2.governance_seed,
             proposals_count: 0,
             config: LegacyGovernanceConfigV1 {
                 vote_threshold_percentage: VoteThresholdPercentage::YesVote(yes_vote_threshold),

--- a/governance/program/tests/program_test/legacy.rs
+++ b/governance/program/tests/program_test/legacy.rs
@@ -113,7 +113,7 @@ impl From<GovernanceV2> for LegacyGovernanceV1 {
         LegacyGovernanceV1 {
             account_type,
             realm: governance_v2.realm,
-            governed_account: governance_v2.governed_account,
+            governed_account: governance_v2.governance_seed,
             proposals_count: 0,
             config: LegacyGovernanceConfigV1 {
                 vote_threshold_percentage: VoteThresholdPercentage::YesVote(yes_vote_threshold),

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1473,7 +1473,7 @@ impl GovernanceProgramTest {
         let mut create_governance_ix = create_governance(
             &self.program_id,
             &realm_cookie.address,
-            Some(&governance_seed),
+            &governance_seed,
             token_owner_record.unwrap_or(&Pubkey::new_unique()),
             &self.bench.payer.pubkey(),
             &create_authority.pubkey(),

--- a/governance/program/tests/program_test/mod.rs
+++ b/governance/program/tests/program_test/mod.rs
@@ -1468,12 +1468,12 @@ impl GovernanceProgramTest {
         governance_config: &GovernanceConfig,
         signers_override: Option<&[&Keypair]>,
     ) -> Result<GovernanceCookie, ProgramError> {
-        let governed_account = Pubkey::new_unique();
+        let governance_seed = Pubkey::new_unique();
 
         let mut create_governance_ix = create_governance(
             &self.program_id,
             &realm_cookie.address,
-            Some(&governed_account),
+            Some(&governance_seed),
             token_owner_record.unwrap_or(&Pubkey::new_unique()),
             &self.bench.payer.pubkey(),
             &create_authority.pubkey(),
@@ -1484,7 +1484,7 @@ impl GovernanceProgramTest {
         let account = GovernanceV2 {
             account_type: GovernanceAccountType::GovernanceV2,
             realm: realm_cookie.address,
-            governed_account,
+            governance_seed,
             config: governance_config.clone(),
             reserved1: 0,
             reserved_v2: Reserved119::default(),
@@ -1504,7 +1504,7 @@ impl GovernanceProgramTest {
             .await?;
 
         let governance_address =
-            get_governance_address(&self.program_id, &realm_cookie.address, &governed_account);
+            get_governance_address(&self.program_id, &realm_cookie.address, &governance_seed);
 
         Ok(GovernanceCookie {
             address: governance_address,
@@ -2384,7 +2384,7 @@ impl GovernanceProgramTest {
             .unwrap();
 
         let mut upgrade_ix = bpf_loader_upgradeable::upgrade(
-            &governance_cookie.account.governed_account,
+            &governance_cookie.account.governance_seed,
             &program_buffer_keypair.pubkey(),
             &governance_cookie.address,
             &governance_cookie.address,


### PR DESCRIPTION
### Summary 

Rename `governed_account` to `governance_seed` for `Governance` account to reflect its actual meaning. The asset specific `Governance` accounts were removed in https://github.com/solana-labs/solana-program-library/pull/6335 and the concept of `governed_account` doesn't exist any longer. 

`governance_seed` was made mandatory for `create_governance` instruction creator 