### PR TITLE
Update old spl-tlv-account-resolution in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7450,20 +7450,6 @@ dependencies = [
 
 [[package]]
 name = "spl-tlv-account-resolution"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "615d381f48ddd2bb3c57c7f7fb207591a2a05054639b18a62e785117dd7a8683"
-dependencies = [
- "bytemuck",
- "solana-program",
- "spl-discriminator 0.1.0",
- "spl-pod 0.1.0",
- "spl-program-error 0.3.0",
- "spl-type-length-value 0.3.0",
-]
-
-[[package]]
-name = "spl-tlv-account-resolution"
 version = "0.5.2"
 dependencies = [
  "bytemuck",
@@ -7478,6 +7464,20 @@ dependencies = [
  "spl-pod 0.1.1",
  "spl-program-error 0.3.1",
  "spl-type-length-value 0.3.1",
+]
+
+[[package]]
+name = "spl-tlv-account-resolution"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f335787add7fa711819f9e7c573f8145a5358a709446fe2d24bf2a88117c90"
+dependencies = [
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator 0.1.0",
+ "spl-pod 0.1.0",
+ "spl-program-error 0.3.0",
+ "spl-type-length-value 0.3.0",
 ]
 
 [[package]]
@@ -7926,7 +7926,7 @@ dependencies = [
  "spl-discriminator 0.1.0",
  "spl-pod 0.1.0",
  "spl-program-error 0.3.0",
- "spl-tlv-account-resolution 0.5.1",
+ "spl-tlv-account-resolution 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-type-length-value 0.3.0",
 ]
 


### PR DESCRIPTION
Duplicate version of `spl-tlv-account-resolution` (which doesn't accept the range of solana-program versions) is breaking agave downstream CI builds when we attempt to bump to v2: https://github.com/anza-xyz/agave/pull/121

I am guessing this fix should have been part of #6221, but I am not sure why cargo did not resolve it automatically. I hope we're not going to have to make manual lock fixes all the time.