### PR TITLE
Governance: Remove assert_can_flag_transaction_error

### DIFF
--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -269,9 +269,9 @@ pub enum GovernanceError {
     #[error("Governance PDA must sign")]
     GovernancePdaMustSign, // 561
 
-    /// Transaction already flagged with error
-    #[error("Transaction already flagged with error")]
-    TransactionAlreadyFlaggedWithError, // 562
+    /// Previously TransactionAlreadyFlaggedWithError
+    #[error("Legacy2")]
+    Legacy2, // 562
 
     /// Invalid Realm for Governance
     #[error("Invalid Realm for Governance")]

--- a/governance/program/src/state/enums.rs
+++ b/governance/program/src/state/enums.rs
@@ -214,6 +214,7 @@ pub enum TransactionExecutionStatus {
     Success,
 
     /// Transaction execution failed
+    /// Note: The field is not used any longer
     Error,
 }
 

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -10,7 +10,7 @@ use {
         state::{
             enums::{
                 GovernanceAccountType, InstructionExecutionFlags, MintMaxVoterWeightSource,
-                ProposalState, TransactionExecutionStatus, VoteThreshold, VoteTipping,
+                ProposalState, VoteThreshold, VoteTipping,
             },
             governance::GovernanceConfig,
             legacy::ProposalV1,
@@ -875,23 +875,6 @@ impl ProposalV2 {
 
         if proposal_transaction_data.executed_at.is_some() {
             return Err(GovernanceError::TransactionAlreadyExecuted.into());
-        }
-
-        Ok(())
-    }
-
-    /// Checks if the instruction can be flagged with error for the Proposal in
-    /// the given state
-    pub fn assert_can_flag_transaction_error(
-        &self,
-        proposal_transaction_data: &ProposalTransactionV2,
-        current_unix_timestamp: UnixTimestamp,
-    ) -> Result<(), ProgramError> {
-        // Instruction can be flagged for error only when it's eligible for execution
-        self.assert_can_execute_transaction(proposal_transaction_data, current_unix_timestamp)?;
-
-        if proposal_transaction_data.execution_status == TransactionExecutionStatus::Error {
-            return Err(GovernanceError::TransactionAlreadyFlaggedWithError.into());
         }
 
         Ok(())


### PR DESCRIPTION
### Summary 

The function `assert_can_flag_transaction_error` is not used any longer and cna be removed