### PR TITLE
Governance: Remove ProposalTransaction hold_up_time

### DIFF
--- a/governance/chat/program/tests/program_test/mod.rs
+++ b/governance/chat/program/tests/program_test/mod.rs
@@ -188,7 +188,7 @@ impl GovernanceChatProgramTest {
         let governance_config = GovernanceConfig {
             community_vote_threshold: VoteThreshold::YesVotePercentage(60),
             min_community_weight_to_create_proposal: 5,
-            min_transaction_hold_up_time: 10,
+            transactions_hold_up_time: 10,
             voting_base_time: 10,
             community_vote_tipping: spl_governance::state::enums::VoteTipping::Strict,
             council_vote_threshold: VoteThreshold::YesVotePercentage(10),

--- a/governance/program/src/error.rs
+++ b/governance/program/src/error.rs
@@ -128,9 +128,9 @@ pub enum GovernanceError {
     #[error("Invalid Transaction index")]
     InvalidTransactionIndex, // 527
 
-    /// Transaction hold up time is below the min specified by Governance
-    #[error("Transaction hold up time is below the min specified by Governance")]
-    TransactionHoldUpTimeBelowRequiredMin, // 528
+    /// Legacy TransactionHoldUpTimeBelowRequiredMin
+    #[error("Legacy3")]
+    Legacy3, // 528
 
     /// Transaction at the given index for the Proposal already exists
     #[error("Transaction at the given index for the Proposal already exists")]

--- a/governance/program/src/instruction.rs
+++ b/governance/program/src/instruction.rs
@@ -260,9 +260,8 @@ pub enum GovernanceInstruction {
         /// Transaction index to be inserted at.
         index: u16,
         #[allow(dead_code)]
-        /// Waiting time (in seconds) between vote period ending and this being
-        /// eligible for execution
-        hold_up_time: u32,
+        /// Legacy hold_up_time
+        legacy: u32,
 
         #[allow(dead_code)]
         /// Instructions Data
@@ -1172,7 +1171,6 @@ pub fn insert_transaction(
     // Args
     option_index: u8,
     index: u16,
-    hold_up_time: u32,
     instructions: Vec<InstructionData>,
 ) -> Instruction {
     let proposal_transaction_address = get_proposal_transaction_address(
@@ -1196,7 +1194,7 @@ pub fn insert_transaction(
     let instruction = GovernanceInstruction::InsertTransaction {
         option_index,
         index,
-        hold_up_time,
+        legacy: 0,
         instructions,
     };
 

--- a/governance/program/src/processor/mod.rs
+++ b/governance/program/src/processor/mod.rs
@@ -85,16 +85,15 @@ pub fn process_instruction(
     if let GovernanceInstruction::InsertTransaction {
         option_index,
         index,
-        hold_up_time,
+        legacy: _,
         instructions: _,
     } = instruction
     {
         // Do not dump instruction data into logs
         msg!(
-            "GOVERNANCE-INSTRUCTION: InsertInstruction {{option_index: {:?}, index: {:?}, hold_up_time: {:?} }}",
+            "GOVERNANCE-INSTRUCTION: InsertInstruction {{option_index: {:?}, index: {:?}}}",
             option_index,
             index,
-            hold_up_time
         );
     } else {
         msg!("GOVERNANCE-INSTRUCTION: {:?}", instruction);
@@ -162,16 +161,9 @@ pub fn process_instruction(
         GovernanceInstruction::InsertTransaction {
             option_index,
             index,
-            hold_up_time,
+            legacy: _,
             instructions,
-        } => process_insert_transaction(
-            program_id,
-            accounts,
-            option_index,
-            index,
-            hold_up_time,
-            instructions,
-        ),
+        } => process_insert_transaction(program_id, accounts, option_index, index, instructions),
 
         GovernanceInstruction::RemoveTransaction {} => {
             process_remove_transaction(program_id, accounts)

--- a/governance/program/src/processor/process_execute_transaction.rs
+++ b/governance/program/src/processor/process_execute_transaction.rs
@@ -40,8 +40,11 @@ pub fn process_execute_transaction(program_id: &Pubkey, accounts: &[AccountInfo]
         proposal_info.key,
     )?;
 
-    proposal_data
-        .assert_can_execute_transaction(&proposal_transaction_data, clock.unix_timestamp)?;
+    proposal_data.assert_can_execute_transaction(
+        &proposal_transaction_data,
+        &governance_data.config,
+        clock.unix_timestamp,
+    )?;
 
     // Execute instruction with Governance PDA as signer
     let instructions = proposal_transaction_data

--- a/governance/program/src/processor/process_insert_transaction.rs
+++ b/governance/program/src/processor/process_insert_transaction.rs
@@ -51,7 +51,8 @@ pub fn process_insert_transaction(
         return Err(GovernanceError::TransactionAlreadyExists.into());
     }
 
-    // Governance account is no longer used and it's deserialized only to validate the provided account
+    // Governance account is no longer used and it's deserialized only to validate
+    // the provided account
     let _governance_data = get_governance_data(program_id, governance_info)?;
 
     let mut proposal_data =

--- a/governance/program/src/processor/process_insert_transaction.rs
+++ b/governance/program/src/processor/process_insert_transaction.rs
@@ -30,7 +30,6 @@ pub fn process_insert_transaction(
     accounts: &[AccountInfo],
     option_index: u8,
     instruction_index: u16,
-    hold_up_time: u32,
     instructions: Vec<InstructionData>,
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
@@ -52,11 +51,8 @@ pub fn process_insert_transaction(
         return Err(GovernanceError::TransactionAlreadyExists.into());
     }
 
-    let governance_data = get_governance_data(program_id, governance_info)?;
-
-    if hold_up_time < governance_data.config.min_transaction_hold_up_time {
-        return Err(GovernanceError::TransactionHoldUpTimeBelowRequiredMin.into());
-    }
+    // Governance account is no longer used and it's deserialized only to validate the provided account
+    let _governance_data = get_governance_data(program_id, governance_info)?;
 
     let mut proposal_data =
         get_proposal_data_for_governance(program_id, proposal_info, governance_info.key)?;
@@ -90,7 +86,7 @@ pub fn process_insert_transaction(
         account_type: GovernanceAccountType::ProposalTransactionV2,
         option_index,
         transaction_index: instruction_index,
-        hold_up_time,
+        legacy: 0,
         instructions,
         executed_at: None,
         execution_status: TransactionExecutionStatus::None,

--- a/governance/program/src/state/governance.rs
+++ b/governance/program/src/state/governance.rs
@@ -36,9 +36,9 @@ pub struct GovernanceConfig {
     /// able to create a proposal
     pub min_community_weight_to_create_proposal: u64,
 
-    /// Minimum waiting time in seconds for a transaction to be executed after
-    /// proposal is voted on
-    pub min_transaction_hold_up_time: u32,
+    /// The wait time in seconds before transactions can be executed after
+    /// proposal is successfully voted on
+    pub transactions_hold_up_time: u32,
 
     /// The base voting time in seconds for proposal to be open for voting
     /// Voting is unrestricted during the base voting time and any vote types
@@ -679,7 +679,7 @@ mod test {
         GovernanceConfig {
             community_vote_threshold: VoteThreshold::YesVotePercentage(60),
             min_community_weight_to_create_proposal: 5,
-            min_transaction_hold_up_time: 10,
+            transactions_hold_up_time: 10,
             voting_base_time: 5,
             community_vote_tipping: VoteTipping::Strict,
             council_vote_threshold: VoteThreshold::YesVotePercentage(60),

--- a/governance/program/src/state/legacy.rs
+++ b/governance/program/src/state/legacy.rs
@@ -297,9 +297,8 @@ pub struct ProposalInstructionV1 {
     /// Unique instruction index within it's parent Proposal
     pub instruction_index: u16,
 
-    /// Minimum waiting time in seconds for the instruction to be executed once
-    /// proposal is voted on
-    pub hold_up_time: u32,
+    /// Previously hold_up_time in versions < V4
+    pub legacy: u32,
 
     /// Instruction to execute
     /// The instruction will be signed by Governance PDA the Proposal belongs to

--- a/governance/program/src/state/proposal.rs
+++ b/governance/program/src/state/proposal.rs
@@ -840,6 +840,7 @@ impl ProposalV2 {
     pub fn assert_can_execute_transaction(
         &self,
         proposal_transaction_data: &ProposalTransactionV2,
+        governance_config: &GovernanceConfig,
         current_unix_timestamp: UnixTimestamp,
     ) -> Result<(), ProgramError> {
         match self.state {
@@ -866,7 +867,7 @@ impl ProposalV2 {
         if self
             .voting_completed_at
             .unwrap()
-            .checked_add(proposal_transaction_data.hold_up_time as i64)
+            .checked_add(governance_config.transactions_hold_up_time as i64)
             .unwrap()
             >= current_unix_timestamp
         {
@@ -1355,7 +1356,7 @@ mod test {
         GovernanceConfig {
             community_vote_threshold: VoteThreshold::YesVotePercentage(60),
             min_community_weight_to_create_proposal: 5,
-            min_transaction_hold_up_time: 10,
+            transactions_hold_up_time: 10,
             voting_base_time: 5,
             community_vote_tipping: VoteTipping::Strict,
             council_vote_threshold: VoteThreshold::YesVotePercentage(60),

--- a/governance/program/src/state/proposal_transaction.rs
+++ b/governance/program/src/state/proposal_transaction.rs
@@ -97,9 +97,8 @@ pub struct ProposalTransactionV2 {
     /// Unique transaction index within it's parent Proposal
     pub transaction_index: u16,
 
-    /// Minimum waiting time in seconds for the  instruction to be executed once
-    /// proposal is voted on
-    pub hold_up_time: u32,
+    /// Previously hold_up_time in versions < V4
+    pub legacy: u32,
 
     /// Instructions to execute
     /// The instructions will be signed by Governance PDA the Proposal belongs
@@ -160,7 +159,7 @@ impl ProposalTransactionV2 {
                 account_type: self.account_type,
                 proposal: self.proposal,
                 instruction_index: self.transaction_index,
-                hold_up_time: self.hold_up_time,
+                legacy: self.legacy,
                 instruction: self.instructions[0].clone(),
                 executed_at: self.executed_at,
                 execution_status: self.execution_status,
@@ -223,7 +222,7 @@ pub fn get_proposal_transaction_data(
             proposal: proposal_transaction_data_v1.proposal,
             option_index: 0, // V1 has a single implied option at index 0
             transaction_index: proposal_transaction_data_v1.instruction_index,
-            hold_up_time: proposal_transaction_data_v1.hold_up_time,
+            legacy: proposal_transaction_data_v1.legacy,
             instructions: vec![proposal_transaction_data_v1.instruction],
             executed_at: proposal_transaction_data_v1.executed_at,
             execution_status: proposal_transaction_data_v1.execution_status,
@@ -287,7 +286,7 @@ mod test {
             proposal: Pubkey::new_unique(),
             option_index: 0,
             transaction_index: 1,
-            hold_up_time: 10,
+            legacy: 0,
             instructions: create_test_instruction_data(),
             executed_at: Some(100),
             execution_status: TransactionExecutionStatus::Success,
@@ -367,7 +366,7 @@ mod test {
             account_type: GovernanceAccountType::ProposalInstructionV1,
             proposal: Pubkey::new_unique(),
             instruction_index: 1,
-            hold_up_time: 120,
+            legacy: 0,
             instruction: create_test_instruction_data()[0].clone(),
             executed_at: Some(155),
             execution_status: TransactionExecutionStatus::Success,

--- a/governance/program/tests/process_add_required_signatory.rs
+++ b/governance/program/tests/process_add_required_signatory.rs
@@ -59,7 +59,9 @@ async fn test_add_required_signatory() {
 
     // Advance timestamp past hold_up_time
     governance_test
-        .advance_clock_by_min_timespan(proposal_transaction_cookie.account.hold_up_time as u64)
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
         .await;
 
     // Act
@@ -126,7 +128,9 @@ pub async fn add_same_required_signatory_to_governance_twice_err() {
         .unwrap();
 
     governance_test
-        .advance_clock_by_min_timespan(proposal_transaction_cookie.account.hold_up_time as u64)
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
         .await;
 
     // Act

--- a/governance/program/tests/process_add_signatory.rs
+++ b/governance/program/tests/process_add_signatory.rs
@@ -205,7 +205,9 @@ async fn test_add_signatory_for_required_signatory() {
 
     // Advance timestamp past hold_up_time
     governance_test
-        .advance_clock_by_min_timespan(proposal_transaction_cookie.account.hold_up_time as u64)
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
         .await;
 
     governance_test
@@ -299,7 +301,9 @@ async fn test_add_signatory_for_required_signatory_multiple_times_err() {
 
     // Advance timestamp past hold_up_time
     governance_test
-        .advance_clock_by_min_timespan(proposal_transaction_cookie.account.hold_up_time as u64)
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
         .await;
 
     governance_test

--- a/governance/program/tests/process_create_native_treasury.rs
+++ b/governance/program/tests/process_create_native_treasury.rs
@@ -98,7 +98,9 @@ async fn test_execute_transfer_from_native_treasury() {
 
     // Advance timestamp past hold_up_time
     governance_test
-        .advance_clock_by_min_timespan(proposal_transaction_cookie.account.hold_up_time as u64)
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
         .await;
 
     // Act

--- a/governance/program/tests/process_execute_transaction.rs
+++ b/governance/program/tests/process_execute_transaction.rs
@@ -56,7 +56,6 @@ async fn test_execute_mint_transaction() {
             &token_owner_record_cookie,
             0,
             None,
-            None,
         )
         .await
         .unwrap();
@@ -73,7 +72,9 @@ async fn test_execute_mint_transaction() {
 
     // Advance timestamp past hold_up_time
     governance_test
-        .advance_clock_by_min_timespan(proposal_transaction_cookie.account.hold_up_time as u64)
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
         .await;
 
     let clock = governance_test.bench.get_clock().await;
@@ -175,7 +176,9 @@ async fn test_execute_transfer_transaction() {
 
     // Advance timestamp past hold_up_time
     governance_test
-        .advance_clock_by_min_timespan(proposal_transaction_cookie.account.hold_up_time as u64)
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
         .await;
 
     let clock = governance_test.bench.get_clock().await;
@@ -280,7 +283,9 @@ async fn test_execute_upgrade_program_transaction() {
 
     // Advance timestamp past hold_up_time
     governance_test
-        .advance_clock_by_min_timespan(proposal_transaction_cookie.account.hold_up_time as u64)
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
         .await;
 
     // Ensure we can invoke the governed program before upgrade
@@ -402,7 +407,6 @@ async fn test_execute_proposal_transaction_with_invalid_state_errors() {
             &token_owner_record_cookie,
             0,
             None,
-            None,
         )
         .await
         .unwrap();
@@ -488,7 +492,9 @@ async fn test_execute_proposal_transaction_with_invalid_state_errors() {
     // Arrange
     // Advance timestamp past hold_up_time
     governance_test
-        .advance_clock_by_min_timespan(proposal_transaction_cookie.account.hold_up_time as u64)
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
         .await;
 
     // Act
@@ -563,7 +569,6 @@ async fn test_execute_proposal_transaction_for_other_proposal_error() {
             &token_owner_record_cookie,
             0,
             None,
-            None,
         )
         .await
         .unwrap();
@@ -581,7 +586,9 @@ async fn test_execute_proposal_transaction_for_other_proposal_error() {
     // Advance clock past hold_up_time
 
     governance_test
-        .advance_clock_by_min_timespan(proposal_transaction_cookie.account.hold_up_time as u64)
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
         .await;
 
     let token_owner_record_cookie2 = governance_test
@@ -650,7 +657,6 @@ async fn test_execute_mint_transaction_twice_error() {
             &token_owner_record_cookie,
             0,
             None,
-            None,
         )
         .await
         .unwrap();
@@ -673,7 +679,9 @@ async fn test_execute_mint_transaction_twice_error() {
     // Advance clock past hold_up_time
 
     governance_test
-        .advance_clock_by_min_timespan(proposal_transaction_cookie.account.hold_up_time as u64)
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
         .await;
 
     governance_test
@@ -708,7 +716,7 @@ async fn test_execute_transaction_with_create_proposal_and_execute_in_single_slo
         .unwrap();
 
     let mut governance_config = governance_test.get_default_governance_config();
-    governance_config.min_transaction_hold_up_time = 0;
+    governance_config.transactions_hold_up_time = 0;
 
     let mut governance_cookie = governance_test
         .with_governance_using_config(
@@ -742,7 +750,6 @@ async fn test_execute_transaction_with_create_proposal_and_execute_in_single_slo
             &token_owner_record_cookie,
             0,
             None,
-            Some(0),
         )
         .await
         .unwrap();

--- a/governance/program/tests/process_insert_transaction.rs
+++ b/governance/program/tests/process_insert_transaction.rs
@@ -174,45 +174,6 @@ async fn test_insert_transaction_with_proposal_transaction_already_exists_error(
 }
 
 #[tokio::test]
-async fn test_insert_transaction_with_invalid_hold_up_time_error() {
-    // Arrange
-    let mut governance_test = GovernanceProgramTest::start_new().await;
-
-    let realm_cookie = governance_test.with_realm().await;
-
-    let mut config = governance_test.get_default_governance_config();
-
-    config.min_transaction_hold_up_time = 100;
-
-    let token_owner_record_cookie = governance_test
-        .with_community_token_deposit(&realm_cookie)
-        .await
-        .unwrap();
-
-    let mut governance_cookie = governance_test
-        .with_governance_using_config(&realm_cookie, &token_owner_record_cookie, &config)
-        .await
-        .unwrap();
-
-    let mut proposal_cookie = governance_test
-        .with_proposal(&token_owner_record_cookie, &mut governance_cookie)
-        .await
-        .unwrap();
-
-    // Act
-    let err = governance_test
-        .with_nop_transaction(&mut proposal_cookie, &token_owner_record_cookie, 0, None)
-        .await
-        .err()
-        .unwrap();
-
-    // Assert
-    assert_eq!(
-        err,
-        GovernanceError::TransactionHoldUpTimeBelowRequiredMin.into()
-    );
-}
-#[tokio::test]
 async fn test_insert_transaction_with_not_editable_proposal_error() {
     // Arrange
     let mut governance_test = GovernanceProgramTest::start_new().await;

--- a/governance/program/tests/process_remove_required_signatory.rs
+++ b/governance/program/tests/process_remove_required_signatory.rs
@@ -65,7 +65,9 @@ async fn test_remove_required_signatory() {
 
     // Advance timestamp past hold_up_time
     governance_test
-        .advance_clock_by_min_timespan(proposal_transaction_cookie.account.hold_up_time as u64)
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
         .await;
 
     // Act
@@ -146,7 +148,9 @@ async fn test_remove_non_existing_required_signatory_err() {
 
     // Advance timestamp past hold_up_time
     governance_test
-        .advance_clock_by_min_timespan(proposal_transaction_cookie.account.hold_up_time as u64)
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
         .await;
 
     // Act

--- a/governance/program/tests/process_set_governance_config.rs
+++ b/governance/program/tests/process_set_governance_config.rs
@@ -70,7 +70,9 @@ async fn test_set_governance_config() {
 
     // Advance timestamp past hold_up_time
     governance_test
-        .advance_clock_by_min_timespan(proposal_transaction_cookie.account.hold_up_time as u64)
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
         .await;
 
     // Act
@@ -203,7 +205,6 @@ async fn test_set_governance_config_with_invalid_governance_authority_error() {
             0,
             None,
             &mut set_governance_config_ix,
-            None,
         )
         .await
         .unwrap();
@@ -220,7 +221,9 @@ async fn test_set_governance_config_with_invalid_governance_authority_error() {
 
     // Advance timestamp past hold_up_time
     governance_test
-        .advance_clock_by_min_timespan(proposal_transaction_cookie.account.hold_up_time as u64)
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
         .await;
 
     // Act

--- a/governance/program/tests/process_sign_off_proposal.rs
+++ b/governance/program/tests/process_sign_off_proposal.rs
@@ -430,7 +430,9 @@ async fn test_sign_off_proposal_with_required_signatory() {
         .unwrap();
 
     governance_test
-        .advance_clock_by_min_timespan(proposal_transaction_cookie.account.hold_up_time as u64)
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
         .await;
 
     governance_test
@@ -537,7 +539,9 @@ async fn test_partial_sign_off_proposal_with_two_governance_signatories() {
         .unwrap();
 
     governance_test
-        .advance_clock_by_min_timespan(proposal_transaction_cookie_2.account.hold_up_time as u64)
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
         .await;
 
     governance_test
@@ -651,7 +655,9 @@ async fn test_repeat_sign_off_proposal_err() {
         .unwrap();
 
     governance_test
-        .advance_clock_by_min_timespan(proposal_transaction_cookie.account.hold_up_time as u64)
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
         .await;
 
     governance_test
@@ -700,7 +706,9 @@ async fn test_repeat_sign_off_proposal_err() {
         .unwrap();
 
     governance_test
-        .advance_clock_by_min_timespan(proposal_transaction_cookie.account.hold_up_time as u64)
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
         .await;
 
     governance_test
@@ -817,7 +825,9 @@ async fn test_sign_off_without_all_required_signatories_err() {
         .unwrap();
 
     governance_test
-        .advance_clock_by_min_timespan(proposal_transaction_cookie.account.hold_up_time as u64)
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
         .await;
 
     governance_test
@@ -866,7 +876,9 @@ async fn test_sign_off_without_all_required_signatories_err() {
         .unwrap();
 
     governance_test
-        .advance_clock_by_min_timespan(proposal_transaction_cookie.account.hold_up_time as u64)
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
         .await;
 
     governance_test

--- a/governance/program/tests/program_test/legacy.rs
+++ b/governance/program/tests/program_test/legacy.rs
@@ -36,9 +36,9 @@ pub struct LegacyGovernanceConfigV1 {
     /// to be able to create a proposal
     pub min_community_tokens_to_create_proposal: u64,
 
-    /// Minimum waiting time in seconds for an instruction to be executed after
-    /// proposal is voted on
-    pub min_instruction_hold_up_time: u32,
+    /// The wait time in seconds before transactions can be executed after
+    /// proposal is successfully voted on
+    pub transactions_hold_up_time: u32,
 
     /// Time limit in seconds for proposal to be open for voting
     pub max_voting_time: u32,
@@ -120,7 +120,7 @@ impl From<GovernanceV2> for LegacyGovernanceV1 {
                 min_community_tokens_to_create_proposal: governance_v2
                     .config
                     .min_community_weight_to_create_proposal,
-                min_instruction_hold_up_time: governance_v2.config.min_transaction_hold_up_time,
+                transactions_hold_up_time: governance_v2.config.transactions_hold_up_time,
                 max_voting_time: governance_v2.config.voting_base_time,
                 vote_weight_source: VoteWeightSource::Deposit,
                 proposal_cool_off_time: 0,

--- a/governance/program/tests/use_proposals_with_multiple_options.rs
+++ b/governance/program/tests/use_proposals_with_multiple_options.rs
@@ -655,7 +655,6 @@ async fn test_execute_proposal_with_multiple_options_and_partial_success() {
             &token_owner_record_cookie1,
             0,
             Some(0),
-            None,
         )
         .await
         .unwrap();
@@ -667,7 +666,6 @@ async fn test_execute_proposal_with_multiple_options_and_partial_success() {
             &token_owner_record_cookie1,
             1,
             Some(0),
-            None,
         )
         .await
         .unwrap();
@@ -679,7 +677,6 @@ async fn test_execute_proposal_with_multiple_options_and_partial_success() {
             &token_owner_record_cookie1,
             2,
             Some(0),
-            None,
         )
         .await
         .unwrap();
@@ -761,7 +758,9 @@ async fn test_execute_proposal_with_multiple_options_and_partial_success() {
 
     // Advance timestamp past hold_up_time
     governance_test
-        .advance_clock_by_min_timespan(proposal_transaction_cookie1.account.hold_up_time as u64)
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
         .await;
 
     let mut proposal_account = governance_test
@@ -868,7 +867,6 @@ async fn test_try_execute_proposal_with_multiple_options_and_full_deny() {
             &token_owner_record_cookie1,
             0,
             Some(0),
-            None,
         )
         .await
         .unwrap();
@@ -880,7 +878,6 @@ async fn test_try_execute_proposal_with_multiple_options_and_full_deny() {
             &token_owner_record_cookie1,
             1,
             Some(0),
-            None,
         )
         .await
         .unwrap();
@@ -892,7 +889,6 @@ async fn test_try_execute_proposal_with_multiple_options_and_full_deny() {
             &token_owner_record_cookie1,
             2,
             Some(0),
-            None,
         )
         .await
         .unwrap();
@@ -933,7 +929,9 @@ async fn test_try_execute_proposal_with_multiple_options_and_full_deny() {
 
     // Advance timestamp past hold_up_time
     governance_test
-        .advance_clock_by_min_timespan(proposal_transaction_cookie1.account.hold_up_time as u64)
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
         .await;
 
     let proposal_account = governance_test
@@ -1270,7 +1268,6 @@ async fn test_vote_multi_weighted_choice_proposal_with_partial_success() {
             &token_owner_record_cookie1,
             0,
             Some(0),
-            None,
         )
         .await
         .unwrap();
@@ -1281,7 +1278,6 @@ async fn test_vote_multi_weighted_choice_proposal_with_partial_success() {
             &token_owner_record_cookie1,
             1,
             Some(0),
-            None,
         )
         .await
         .unwrap();
@@ -1292,7 +1288,6 @@ async fn test_vote_multi_weighted_choice_proposal_with_partial_success() {
             &token_owner_record_cookie1,
             2,
             Some(0),
-            None,
         )
         .await
         .unwrap();
@@ -1303,7 +1298,6 @@ async fn test_vote_multi_weighted_choice_proposal_with_partial_success() {
             &token_owner_record_cookie1,
             3,
             Some(0),
-            None,
         )
         .await
         .unwrap();
@@ -1384,7 +1378,9 @@ async fn test_vote_multi_weighted_choice_proposal_with_partial_success() {
         .unwrap();
     // Advance timestamp past hold_up_time
     governance_test
-        .advance_clock_by_min_timespan(proposal_transaction_cookie1.account.hold_up_time as u64)
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
         .await;
 
     let mut proposal_account = governance_test
@@ -1491,7 +1487,6 @@ async fn test_vote_multi_weighted_choice_proposal_with_multi_success() {
             &token_owner_record_cookie1,
             0,
             Some(0),
-            None,
         )
         .await
         .unwrap();
@@ -1502,7 +1497,6 @@ async fn test_vote_multi_weighted_choice_proposal_with_multi_success() {
             &token_owner_record_cookie1,
             1,
             Some(0),
-            None,
         )
         .await
         .unwrap();
@@ -1513,7 +1507,6 @@ async fn test_vote_multi_weighted_choice_proposal_with_multi_success() {
             &token_owner_record_cookie1,
             2,
             Some(0),
-            None,
         )
         .await
         .unwrap();
@@ -1579,7 +1572,9 @@ async fn test_vote_multi_weighted_choice_proposal_with_multi_success() {
         .unwrap();
     // Advance timestamp past hold_up_time
     governance_test
-        .advance_clock_by_min_timespan(proposal_transaction_cookie1.account.hold_up_time as u64)
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
         .await;
 
     let mut proposal_account = governance_test
@@ -1671,7 +1666,6 @@ async fn test_vote_multi_weighted_choice_proposal_executable_with_full_deny() {
             &token_owner_record_cookie1,
             0,
             Some(0),
-            None,
         )
         .await
         .unwrap();
@@ -1683,7 +1677,6 @@ async fn test_vote_multi_weighted_choice_proposal_executable_with_full_deny() {
             &token_owner_record_cookie1,
             1,
             Some(0),
-            None,
         )
         .await
         .unwrap();
@@ -1717,7 +1710,9 @@ async fn test_vote_multi_weighted_choice_proposal_executable_with_full_deny() {
 
     // Advance timestamp past hold_up_time
     governance_test
-        .advance_clock_by_min_timespan(proposal_transaction_cookie1.account.hold_up_time as u64)
+        .advance_clock_by_min_timespan(
+            governance_cookie.account.config.transactions_hold_up_time as u64,
+        )
         .await;
 
     let proposal_account = governance_test


### PR DESCRIPTION
### Summary 

Remove `hold_up_time` for individual `ProposalTransactions` and use a single `Governance` level `hold_up_time` for all transactions within a `Proposal` instead.

The individual hold up times for transactions haven't been used and if the delay logic, in addition to the `Governance` defined time lock,  is required then it can be implemented by other means like inserting instructions with a delay guard  or a wrapping instructions with a configured delay.
