### PR TITLE
token-2022: Update initialize_mint to use Pod types

### DIFF
--- a/token/program-2022/src/pod.rs
+++ b/token/program-2022/src/pod.rs
@@ -1,14 +1,11 @@
 //! Rewrites of the base state types represented as Pods
 
 #[cfg(test)]
-use {
-    crate::state::{Account, Mint, Multisig},
-    solana_program::program_option::COption,
-};
+use crate::state::{Account, Mint, Multisig};
 use {
     crate::{instruction::MAX_SIGNERS, state::PackedSizeOf},
     bytemuck::{Pod, Zeroable},
-    solana_program::{program_pack::IsInitialized, pubkey::Pubkey},
+    solana_program::{program_option::COption, program_pack::IsInitialized, pubkey::Pubkey},
     spl_pod::{
         bytemuck::pod_get_packed_len,
         primitives::{PodBool, PodU64},
@@ -169,7 +166,6 @@ impl<T: Pod + Default> PodCOption<T> {
         }
     }
 }
-#[cfg(test)]
 impl<T: Pod + Default> From<COption<T>> for PodCOption<T> {
     fn from(opt: COption<T>) -> Self {
         match opt {

--- a/token/program-2022/tests/assert_instruction_count.rs
+++ b/token/program-2022/tests/assert_instruction_count.rs
@@ -22,7 +22,7 @@ const TRANSFER_AMOUNT: u64 = 1_000_000_000_000_000;
 #[tokio::test]
 async fn initialize_mint() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
-    pt.set_compute_max_units(5_000); // last known 2196
+    pt.set_compute_max_units(5_000); // last known 1742
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner_key = Pubkey::new_unique();


### PR DESCRIPTION
#### Problem

All of the pod types are ready to be used in the instruction processors, but they're not being used anywhere.

#### Solution

Use them in `initialize_mint`, which brings CUs down from 2196 to 1742