### PR TITLE
token-2022: Update initialize_account to use Pod types

### DIFF
--- a/token/program-2022/tests/assert_instruction_count.rs
+++ b/token/program-2022/tests/assert_instruction_count.rs
@@ -60,7 +60,7 @@ async fn initialize_mint() {
 #[tokio::test]
 async fn initialize_account() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
-    pt.set_compute_max_units(8_000); // last known 3229
+    pt.set_compute_max_units(8_000); // last known 2016
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();


### PR DESCRIPTION
#### Problem

All of the pod types are ready to be used in the instruction processors, but they're not being used anywhere.

#### Solution

Use them in `initialize_account`, which brings CUs down from 3229 to 2016