### PR TITLE
token-2022: Update transfer to use Pod types (uses half the CUs!)

### DIFF
--- a/token/program-2022/src/extension/memo_transfer/mod.rs
+++ b/token/program-2022/src/extension/memo_transfer/mod.rs
@@ -3,8 +3,7 @@ use serde::{Deserialize, Serialize};
 use {
     crate::{
         error::TokenError,
-        extension::{BaseStateWithExtensions, Extension, ExtensionType, StateWithExtensionsMut},
-        state::Account,
+        extension::{BaseState, BaseStateWithExtensions, Extension, ExtensionType},
     },
     bytemuck::{Pod, Zeroable},
     solana_program::{
@@ -33,7 +32,7 @@ impl Extension for MemoTransfer {
 }
 
 /// Determine if a memo is required for transfers into this account
-pub fn memo_required(account_state: &StateWithExtensionsMut<Account>) -> bool {
+pub fn memo_required<BSE: BaseStateWithExtensions<S>, S: BaseState>(account_state: &BSE) -> bool {
     if let Ok(extension) = account_state.get_extension::<MemoTransfer>() {
         return extension.require_incoming_transfer_memos.into();
     }

--- a/token/program-2022/src/extension/transfer_hook/mod.rs
+++ b/token/program-2022/src/extension/transfer_hook/mod.rs
@@ -4,9 +4,9 @@ use {
     crate::{
         extension::{
             BaseState, BaseStateWithExtensions, BaseStateWithExtensionsMut, Extension,
-            ExtensionType, StateWithExtensionsMut,
+            ExtensionType, PodStateWithExtensionsMut,
         },
-        state::Account,
+        pod::PodAccount,
     },
     bytemuck::{Pod, Zeroable},
     solana_program::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey},
@@ -62,7 +62,9 @@ pub fn get_program_id<S: BaseState, BSE: BaseStateWithExtensions<S>>(
 
 /// Helper function to set the transferring flag before calling into transfer
 /// hook
-pub fn set_transferring(account: &mut StateWithExtensionsMut<Account>) -> Result<(), ProgramError> {
+pub fn set_transferring<BSE: BaseStateWithExtensionsMut<S>, S: BaseState>(
+    account: &mut BSE,
+) -> Result<(), ProgramError> {
     let account_extension = account.get_extension_mut::<TransferHookAccount>()?;
     account_extension.transferring = true.into();
     Ok(())
@@ -71,7 +73,7 @@ pub fn set_transferring(account: &mut StateWithExtensionsMut<Account>) -> Result
 /// Helper function to unset the transferring flag after a transfer
 pub fn unset_transferring(account_info: &AccountInfo) -> Result<(), ProgramError> {
     let mut account_data = account_info.data.borrow_mut();
-    let mut account = StateWithExtensionsMut::<Account>::unpack(&mut account_data)?;
+    let mut account = PodStateWithExtensionsMut::<PodAccount>::unpack(&mut account_data)?;
     let account_extension = account.get_extension_mut::<TransferHookAccount>()?;
     account_extension.transferring = false.into();
     Ok(())

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -384,13 +384,13 @@ impl Processor {
             (
                 PodCOption {
                     option: PodCOption::<Pubkey>::SOME,
-                    value,
+                    value: delegate,
                 },
                 _,
-            ) if cmp_pubkeys(authority_info.key, &value) => {
+            ) if cmp_pubkeys(authority_info.key, &delegate) => {
                 Self::validate_owner(
                     program_id,
-                    &value,
+                    &delegate,
                     authority_info,
                     authority_info_data_len,
                     account_info_iter.as_slice(),

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -24,11 +24,12 @@ use {
             transfer_fee::{self, TransferFeeAmount, TransferFeeConfig},
             transfer_hook::{self, TransferHook, TransferHookAccount},
             AccountType, BaseStateWithExtensions, BaseStateWithExtensionsMut, ExtensionType,
-            PodStateWithExtensionsMut, StateWithExtensions, StateWithExtensionsMut,
+            PodStateWithExtensions, PodStateWithExtensionsMut, StateWithExtensions,
+            StateWithExtensionsMut,
         },
         instruction::{is_valid_signer_index, AuthorityType, TokenInstruction, MAX_SIGNERS},
         native_mint,
-        pod::{PodCOption, PodMint},
+        pod::{PodAccount, PodCOption, PodMint},
         state::{Account, AccountState, Mint, Multisig},
     },
     solana_program::{
@@ -297,11 +298,12 @@ impl Processor {
 
         let mut source_account_data = source_account_info.data.borrow_mut();
         let mut source_account =
-            StateWithExtensionsMut::<Account>::unpack(&mut source_account_data)?;
+            PodStateWithExtensionsMut::<PodAccount>::unpack(&mut source_account_data)?;
         if source_account.base.is_frozen() {
             return Err(TokenError::AccountFrozen.into());
         }
-        if source_account.base.amount < amount {
+        let source_amount = u64::from(source_account.base.amount);
+        if source_amount < amount {
             return Err(TokenError::InsufficientFunds.into());
         }
         if source_account
@@ -317,7 +319,7 @@ impl Processor {
                 }
 
                 let mint_data = mint_info.try_borrow_data()?;
-                let mint = StateWithExtensions::<Mint>::unpack(&mint_data)?;
+                let mint = PodStateWithExtensions::<PodMint>::unpack(&mint_data)?;
 
                 if expected_decimals != mint.base.decimals {
                     return Err(TokenError::MintDecimalsMismatch.into());
@@ -379,25 +381,31 @@ impl Processor {
                     account_info_iter.as_slice(),
                 )?
             }
-            (COption::Some(ref delegate), _) if cmp_pubkeys(authority_info.key, delegate) => {
+            (
+                PodCOption {
+                    option: PodCOption::<Pubkey>::SOME,
+                    value,
+                },
+                _,
+            ) if cmp_pubkeys(authority_info.key, &value) => {
                 Self::validate_owner(
                     program_id,
-                    delegate,
+                    &value,
                     authority_info,
                     authority_info_data_len,
                     account_info_iter.as_slice(),
                 )?;
-                if source_account.base.delegated_amount < amount {
+                let delegated_amount = u64::from(source_account.base.delegated_amount);
+                if delegated_amount < amount {
                     return Err(TokenError::InsufficientFunds.into());
                 }
                 if !self_transfer {
-                    source_account.base.delegated_amount = source_account
-                        .base
-                        .delegated_amount
+                    source_account.base.delegated_amount = delegated_amount
                         .checked_sub(amount)
-                        .ok_or(TokenError::Overflow)?;
-                    if source_account.base.delegated_amount == 0 {
-                        source_account.base.delegate = COption::None;
+                        .ok_or(TokenError::Overflow)?
+                        .into();
+                    if u64::from(source_account.base.delegated_amount) == 0 {
+                        source_account.base.delegate = PodCOption::none();
                     }
                 }
             }
@@ -433,7 +441,7 @@ impl Processor {
         // self-transfer was dealt with earlier, so this *should* be safe
         let mut destination_account_data = destination_account_info.data.borrow_mut();
         let mut destination_account =
-            StateWithExtensionsMut::<Account>::unpack(&mut destination_account_data)?;
+            PodStateWithExtensionsMut::<PodAccount>::unpack(&mut destination_account_data)?;
 
         if destination_account.base.is_frozen() {
             return Err(TokenError::AccountFrozen.into());
@@ -452,17 +460,15 @@ impl Processor {
             confidential_transfer_state.non_confidential_transfer_allowed()?
         }
 
-        source_account.base.amount = source_account
-            .base
-            .amount
+        source_account.base.amount = source_amount
             .checked_sub(amount)
-            .ok_or(TokenError::Overflow)?;
+            .ok_or(TokenError::Overflow)?
+            .into();
         let credited_amount = amount.checked_sub(fee).ok_or(TokenError::Overflow)?;
-        destination_account.base.amount = destination_account
-            .base
-            .amount
+        destination_account.base.amount = u64::from(destination_account.base.amount)
             .checked_add(credited_amount)
-            .ok_or(TokenError::Overflow)?;
+            .ok_or(TokenError::Overflow)?
+            .into();
         if fee > 0 {
             if let Ok(extension) = destination_account.get_extension_mut::<TransferFeeAmount>() {
                 let new_withheld_amount = u64::from(extension.withheld_amount)
@@ -488,9 +494,6 @@ impl Processor {
                 .checked_add(amount)
                 .ok_or(TokenError::Overflow)?;
         }
-
-        source_account.pack_base();
-        destination_account.pack_base();
 
         if let Some(program_id) = maybe_transfer_hook_program_id {
             if let Some((mint_info, _)) = expected_mint_info {

--- a/token/program-2022/tests/assert_instruction_count.rs
+++ b/token/program-2022/tests/assert_instruction_count.rs
@@ -161,7 +161,7 @@ async fn mint_to() {
 #[tokio::test]
 async fn transfer() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
-    pt.set_compute_max_units(8_000); // last known 2988
+    pt.set_compute_max_units(8_000); // last known 1642
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();
@@ -229,7 +229,7 @@ async fn transfer() {
 #[tokio::test]
 async fn transfer_checked() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
-    pt.set_compute_max_units(8_000); // last known 3839
+    pt.set_compute_max_units(8_000); // last known 1960
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();


### PR DESCRIPTION
#### Problem

All of the pod types are ready to be used in the instruction processors, but they're not being used anywhere.

#### Solution

Use pod types in `transfer`, which brings CUs down from 2988 to 1642 for unchecked transfers, and from 3839 to 1960 for checked transfers! This is probably the biggest win from our efforts.