### PR TITLE
token-cli: Pass empty transfer-hook-accounts for sign-only transfer

### DIFF
--- a/token/cli/src/command.rs
+++ b/token/cli/src/command.rs
@@ -1210,6 +1210,11 @@ async fn command_transfer(
     let token = if let Some(transfer_hook_accounts) = transfer_hook_accounts {
         token_client_from_config(config, &token_pubkey, decimals)?
             .with_transfer_hook_accounts(transfer_hook_accounts)
+    } else if config.sign_only {
+        // we need to pass in empty transfer hook accounts on sign-only,
+        // otherwise the token client will try to fetch the mint account and fail
+        token_client_from_config(config, &token_pubkey, decimals)?
+            .with_transfer_hook_accounts(vec![])
     } else {
         token_client_from_config(config, &token_pubkey, decimals)?
     };


### PR DESCRIPTION
#### Problem

While looking at this SSE question https://solana.stackexchange.com/questions/11725/correct-usage-of-spl-token-transfer-with-offline-signing, I noticed there's a bug in the `transfer-hook-account`s passed in to the token CLI. During `--sign-only`, we create an offline client that will fail if trying to fetch an account, but during token-client's `transfer`, we fetch the mint account if there are no transfer-hook accounts specified. Because of that, we fail during `--sign-only`, which is incorrect.

The current workaround is to just specify an empty `--transfer-hook-account` arg on the command line, but that's annoying.

#### Solution

If we're in `--sign-only` mode and no transfer accounts have been specified, default them to an empty vector.