### PR TITLE
js: Remove direct usage of `@solana/options`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -491,9 +491,6 @@ importers:
       '@solana/codecs':
         specifier: 2.0.0-preview.1
         version: 2.0.0-preview.1(fastestsmallesttextencoderdecoder@1.0.22)
-      '@solana/options':
-        specifier: 2.0.0-preview.1
-        version: 2.0.0-preview.1
       '@solana/spl-type-length-value':
         specifier: 0.1.0
         version: link:../../libraries/type-length-value/js
@@ -637,9 +634,6 @@ importers:
       '@solana/codecs':
         specifier: 2.0.0-preview.1
         version: 2.0.0-preview.1(fastestsmallesttextencoderdecoder@1.0.22)
-      '@solana/options':
-        specifier: 2.0.0-preview.1
-        version: 2.0.0-preview.1
       '@solana/spl-type-length-value':
         specifier: 0.1.0
         version: link:../../libraries/type-length-value/js

--- a/token-group/js/package.json
+++ b/token-group/js/package.json
@@ -48,7 +48,6 @@
     },
     "dependencies": {
         "@solana/codecs": "2.0.0-preview.1",
-        "@solana/options": "2.0.0-preview.1",
         "@solana/spl-type-length-value": "0.1.0"
     },
     "devDependencies": {

--- a/token-metadata/js/package.json
+++ b/token-metadata/js/package.json
@@ -48,7 +48,6 @@
     },
     "dependencies": {
         "@solana/codecs": "2.0.0-preview.1",
-        "@solana/options": "2.0.0-preview.1",
         "@solana/spl-type-length-value": "0.1.0"
     },
     "devDependencies": {

--- a/token-metadata/js/src/instruction.ts
+++ b/token-metadata/js/src/instruction.ts
@@ -3,13 +3,13 @@ import {
     getBooleanEncoder,
     getBytesEncoder,
     getDataEnumCodec,
+    getOptionEncoder,
     getStringEncoder,
     getStructEncoder,
     getTupleEncoder,
     getU64Encoder,
     mapEncoder,
 } from '@solana/codecs';
-import { getOptionEncoder } from '@solana/options';
 import { splDiscriminate } from '@solana/spl-type-length-value';
 import type { PublicKey } from '@solana/web3.js';
 import { SystemProgram, TransactionInstruction } from '@solana/web3.js';

--- a/token-metadata/js/test/instruction.test.ts
+++ b/token-metadata/js/test/instruction.test.ts
@@ -13,14 +13,14 @@ import {
     getBooleanDecoder,
     getBytesDecoder,
     getDataEnumCodec,
+    getOptionDecoder,
     getStringDecoder,
     getU64Decoder,
     getStructDecoder,
+    some,
 } from '@solana/codecs';
 import { splDiscriminate } from '@solana/spl-type-length-value';
-import type { Decoder } from '@solana/codecs';
-import type { Option } from '@solana/options';
-import { getOptionDecoder, some } from '@solana/options';
+import type { Decoder, Option } from '@solana/codecs';
 import { PublicKey, type TransactionInstruction } from '@solana/web3.js';
 
 function checkPackUnpack<T extends object>(


### PR DESCRIPTION
#### Problem

Per https://github.com/solana-labs/solana-program-library/pull/6388#discussion_r1519883981, we're using `@solana/options` by name, which is also included in `@solana/codecs`

#### Solution

Use everything from `@solana/codecs` directly, and remove the dependency on `@solana/options`