### PR TITLE
token-2022: Update mint_to to use Pod types

### DIFF
--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -909,8 +909,8 @@ impl Processor {
         let owner_info_data_len = owner_info.data_len();
 
         let mut destination_account_data = destination_account_info.data.borrow_mut();
-        let mut destination_account =
-            StateWithExtensionsMut::<Account>::unpack(&mut destination_account_data)?;
+        let destination_account =
+            PodStateWithExtensionsMut::<PodAccount>::unpack(&mut destination_account_data)?;
         if destination_account.base.is_frozen() {
             return Err(TokenError::AccountFrozen.into());
         }
@@ -923,7 +923,7 @@ impl Processor {
         }
 
         let mut mint_data = mint_info.data.borrow_mut();
-        let mut mint = StateWithExtensionsMut::<Mint>::unpack(&mut mint_data)?;
+        let mint = PodStateWithExtensionsMut::<PodMint>::unpack(&mut mint_data)?;
 
         // If the mint if non-transferable, only allow minting to accounts
         // with immutable ownership.
@@ -941,15 +941,18 @@ impl Processor {
             }
         }
 
-        match mint.base.mint_authority {
-            COption::Some(mint_authority) => Self::validate_owner(
+        match &mint.base.mint_authority {
+            PodCOption {
+                option: PodCOption::<Pubkey>::SOME,
+                value: mint_authority,
+            } => Self::validate_owner(
                 program_id,
-                &mint_authority,
+                mint_authority,
                 owner_info,
                 owner_info_data_len,
                 account_info_iter.as_slice(),
             )?,
-            COption::None => return Err(TokenError::FixedSupply.into()),
+            _ => return Err(TokenError::FixedSupply.into()),
         }
 
         // Revisit this later to see if it's worth adding a check to reduce
@@ -958,20 +961,15 @@ impl Processor {
         check_program_account(mint_info.owner)?;
         check_program_account(destination_account_info.owner)?;
 
-        destination_account.base.amount = destination_account
-            .base
-            .amount
+        destination_account.base.amount = u64::from(destination_account.base.amount)
             .checked_add(amount)
-            .ok_or(TokenError::Overflow)?;
+            .ok_or(TokenError::Overflow)?
+            .into();
 
-        mint.base.supply = mint
-            .base
-            .supply
+        mint.base.supply = u64::from(mint.base.supply)
             .checked_add(amount)
-            .ok_or(TokenError::Overflow)?;
-
-        mint.pack_base();
-        destination_account.pack_base();
+            .ok_or(TokenError::Overflow)?
+            .into();
 
         Ok(())
     }

--- a/token/program-2022/tests/assert_instruction_count.rs
+++ b/token/program-2022/tests/assert_instruction_count.rs
@@ -112,7 +112,7 @@ async fn initialize_account() {
 #[tokio::test]
 async fn mint_to() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
-    pt.set_compute_max_units(8_000); // last known 2694
+    pt.set_compute_max_units(8_000); // last known 1285
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();


### PR DESCRIPTION
#### Problem

The Pod types exist in token-2022, but mint_to doesn't use them

#### Solution

Use Pod types in mint_to in token-2022