### PR TITLE
token-2022: Update initialize_immutable_owner to use Pod types

### DIFF
--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -1310,7 +1310,7 @@ impl Processor {
         let token_account_info = next_account_info(account_info_iter)?;
         let token_account_data = &mut token_account_info.data.borrow_mut();
         let mut token_account =
-            StateWithExtensionsMut::<Account>::unpack_uninitialized(token_account_data)?;
+            PodStateWithExtensionsMut::<PodAccount>::unpack_uninitialized(token_account_data)?;
         token_account
             .init_extension::<ImmutableOwner>(true)
             .map(|_| ())


### PR DESCRIPTION
#### Problem

The Pod types exist in token-2022, but initialize_immutable_owner doesn't use them

#### Solution

Use Pod types in initialize_immutable_owner in token-2022

Side note: I thought it was very cool that this only takes one line