### PR TITLE
token-2022: Update initialize_mint_close_authority to use Pod type

### DIFF
--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -1270,7 +1270,7 @@ impl Processor {
         let mint_account_info = next_account_info(account_info_iter)?;
 
         let mut mint_data = mint_account_info.data.borrow_mut();
-        let mut mint = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut mint_data)?;
+        let mut mint = PodStateWithExtensionsMut::<PodMint>::unpack_uninitialized(&mut mint_data)?;
         let extension = mint.init_extension::<MintCloseAuthority>(true)?;
         extension.close_authority = close_authority.try_into()?;
 


### PR DESCRIPTION
#### Problem

The Pod types exist in token-2022, but initialize_mint_close_authority doesn't use them

#### Solution

Use Pod types in initialize_mint_close_authority in token-2022

Side note: another one-liner!