### PR TITLE
token-2022: Update ui_amount_to_amount to use Pod types

### DIFF
--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -1345,7 +1345,7 @@ impl Processor {
         check_program_account(mint_info.owner)?;
 
         let mint_data = mint_info.data.borrow();
-        let mint = StateWithExtensions::<Mint>::unpack(&mint_data)
+        let mint = PodStateWithExtensions::<PodMint>::unpack(&mint_data)
             .map_err(|_| Into::<ProgramError>::into(TokenError::InvalidMint))?;
         let amount = if let Ok(extension) = mint.get_extension::<InterestBearingConfig>() {
             let unix_timestamp = Clock::get()?.unix_timestamp;


### PR DESCRIPTION
#### Problem

The Pod types exist in token-2022, but ui_amount_to_amount doesn't use them

#### Solution

Use Pod types in ui_amount_to_amount in token-2022

Side note: even more one-liners!