### PR TITLE
token-2022: Update interest_bearing_mint to Pod types

### DIFF
--- a/token/program-2022/src/extension/interest_bearing_mint/processor.rs
+++ b/token/program-2022/src/extension/interest_bearing_mint/processor.rs
@@ -7,11 +7,11 @@ use {
                 instruction::{InitializeInstructionData, InterestBearingMintInstruction},
                 BasisPoints, InterestBearingConfig,
             },
-            BaseStateWithExtensionsMut, StateWithExtensionsMut,
+            BaseStateWithExtensionsMut, PodStateWithExtensionsMut,
         },
         instruction::{decode_instruction_data, decode_instruction_type},
+        pod::PodMint,
         processor::Processor,
-        state::Mint,
     },
     solana_program::{
         account_info::{next_account_info, AccountInfo},
@@ -33,7 +33,7 @@ fn process_initialize(
     let account_info_iter = &mut accounts.iter();
     let mint_account_info = next_account_info(account_info_iter)?;
     let mut mint_data = mint_account_info.data.borrow_mut();
-    let mut mint = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut mint_data)?;
+    let mut mint = PodStateWithExtensionsMut::<PodMint>::unpack_uninitialized(&mut mint_data)?;
 
     let clock = Clock::get()?;
     let extension = mint.init_extension::<InterestBearingConfig>(true)?;
@@ -58,7 +58,7 @@ fn process_update_rate(
     let owner_info_data_len = owner_info.data_len();
 
     let mut mint_data = mint_account_info.data.borrow_mut();
-    let mut mint = StateWithExtensionsMut::<Mint>::unpack(&mut mint_data)?;
+    let mut mint = PodStateWithExtensionsMut::<PodMint>::unpack(&mut mint_data)?;
     let extension = mint.get_extension_mut::<InterestBearingConfig>()?;
     let rate_authority =
         Option::<Pubkey>::from(extension.rate_authority).ok_or(TokenError::NoAuthorityExists)?;


### PR DESCRIPTION
#### Problem

As part of #6418, the interest-bearing mint extension does not use Pod types.

#### Solution

Use them