### PR TITLE
token-2022: Remove the "development and testing purposes"

### DIFF
--- a/token/program-2022/README.md
+++ b/token/program-2022/README.md
@@ -7,10 +7,6 @@ utilize to create and use their tokens.
 
 Full documentation is available at https://spl.solana.com/token-2022
 
-The Token-2022 program is still under audit and not meant for full production use.
-In the meantime, all clusters have the latest program deployed **for testing and
-development purposes ONLY**.
-
 ## Audit
 
 The repository [README](https://github.com/solana-labs/solana-program-library#audits)


### PR DESCRIPTION
#### Problem

Everywhere else in the docs, we say that token-2022 is ready for production use, but not in the README.

#### Solution

Remove the bit about "development and testing purposes" from the README