### PR TITLE
token-2022: Update SetAuthority to use Pod types

### DIFF
--- a/token/program-2022/src/pod.rs
+++ b/token/program-2022/src/pod.rs
@@ -199,6 +199,17 @@ impl<T: Pod + Default> PodCOption<T> {
     pub fn is_some(&self) -> bool {
         self.option == Self::SOME
     }
+
+    /// Converts the option into a Result, similar to `Option::ok_or`
+    pub fn ok_or<E>(self, error: E) -> Result<T, E> {
+        match self {
+            Self {
+                option: Self::SOME,
+                value,
+            } => Ok(value),
+            _ => Err(error),
+        }
+    }
 }
 impl<T: Pod + Default> From<COption<T>> for PodCOption<T> {
     fn from(opt: COption<T>) -> Self {


### PR DESCRIPTION
#### Problem

While porting all of the instruction processors over to use Pod types, I missed porting `set-authority`.

#### Solution

Port it over to the pod types!

Note: it's not clear where the new `ok_or` function is used. It's at lines 708 and 724 in `processor.rs`