### PR TITLE
stake-pool: supporting AddValidatorToPool in js library

### DIFF
--- a/stake-pool/js/src/utils/program-address.ts
+++ b/stake-pool/js/src/utils/program-address.ts
@@ -28,9 +28,14 @@ export async function findStakeProgramAddress(
   programId: PublicKey,
   voteAccountAddress: PublicKey,
   stakePoolAddress: PublicKey,
+  seed?: number,
 ) {
   const [publicKey] = await PublicKey.findProgramAddress(
-    [voteAccountAddress.toBuffer(), stakePoolAddress.toBuffer()],
+    [
+      voteAccountAddress.toBuffer(),
+      stakePoolAddress.toBuffer(),
+      seed ? new BN(seed).toArrayLike(Buffer, 'le', 4) : Buffer.alloc(0),
+    ],
     programId,
   );
   return publicKey;

--- a/stake-pool/js/src/utils/stake.ts
+++ b/stake-pool/js/src/utils/stake.ts
@@ -25,6 +25,7 @@ export async function getValidatorListAccount(connection: Connection, pubkey: Pu
   if (!account) {
     throw new Error('Invalid validator list account');
   }
+
   return {
     pubkey,
     account: {


### PR DESCRIPTION
This PR adds support for the `AddValidatorToPool` instruction for the stake pool program in the javascript library. Removing a validator has not been implemented in the spirit of keeping the PR as small as possible. If accepted, I can also implement support for that instruction as well.

My guess is that this instruction was never prioritized in the javascript library due to the `spl-stake-pool` package mostly being used in frontend applications. This instruction is helpful to have though for users who are using nodejs, hence why I added support for it.

The code was successfully run on mainnet with tx hash `4QnuyTWTYYTPX1pr8sw5haFUp96PnNXCe4VWbWZVzN9PcRvhDkTaGpxKvpRC2wETC23VrgoSBdDC1UhZ7s3vfoM6` targetting Edgevana's stake pool.