### PR TITLE
token-2022: Prepare processors for Pod instructions by taking references and pod types

### DIFF
--- a/libraries/pod/src/optional_keys.rs
+++ b/libraries/pod/src/optional_keys.rs
@@ -23,6 +23,11 @@ use {
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 #[repr(transparent)]
 pub struct OptionalNonZeroPubkey(Pubkey);
+impl From<Pubkey> for OptionalNonZeroPubkey {
+    fn from(p: Pubkey) -> Self {
+        Self(p)
+    }
+}
 impl TryFrom<Option<Pubkey>> for OptionalNonZeroPubkey {
     type Error = ProgramError;
     fn try_from(p: Option<Pubkey>) -> Result<Self, Self::Error> {

--- a/libraries/pod/src/optional_keys.rs
+++ b/libraries/pod/src/optional_keys.rs
@@ -22,12 +22,7 @@ use {
 )]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 #[repr(transparent)]
-pub struct OptionalNonZeroPubkey(Pubkey);
-impl From<Pubkey> for OptionalNonZeroPubkey {
-    fn from(p: Pubkey) -> Self {
-        Self(p)
-    }
-}
+pub struct OptionalNonZeroPubkey(pub Pubkey);
 impl TryFrom<Option<Pubkey>> for OptionalNonZeroPubkey {
     type Error = ProgramError;
     fn try_from(p: Option<Pubkey>) -> Result<Self, Self::Error> {

--- a/token/program-2022/src/pod.rs
+++ b/token/program-2022/src/pod.rs
@@ -8,9 +8,13 @@ use {
         state::{AccountState, PackedSizeOf},
     },
     bytemuck::{Pod, Zeroable},
-    solana_program::{program_option::COption, program_pack::IsInitialized, pubkey::Pubkey},
+    solana_program::{
+        program_error::ProgramError, program_option::COption, program_pack::IsInitialized,
+        pubkey::Pubkey,
+    },
     spl_pod::{
         bytemuck::pod_get_packed_len,
+        optional_keys::OptionalNonZeroPubkey,
         primitives::{PodBool, PodU64},
     },
 };
@@ -200,6 +204,11 @@ impl<T: Pod + Default> PodCOption<T> {
         self.option == Self::SOME
     }
 
+    /// Checks to see if no value is set, equivalent of `Option::is_none`
+    pub fn is_none(&self) -> bool {
+        self.option == Self::NONE
+    }
+
     /// Converts the option into a Result, similar to `Option::ok_or`
     pub fn ok_or<E>(self, error: E) -> Result<T, E> {
         match self {
@@ -222,6 +231,22 @@ impl<T: Pod + Default> From<COption<T>> for PodCOption<T> {
                 option: Self::SOME,
                 value: v,
             },
+        }
+    }
+}
+impl TryFrom<PodCOption<Pubkey>> for OptionalNonZeroPubkey {
+    type Error = ProgramError;
+    fn try_from(p: PodCOption<Pubkey>) -> Result<Self, Self::Error> {
+        match p {
+            PodCOption {
+                option: PodCOption::<Pubkey>::SOME,
+                value,
+            } if value == Pubkey::default() => Err(ProgramError::InvalidArgument),
+            PodCOption {
+                option: PodCOption::<Pubkey>::SOME,
+                value,
+            } => Ok(Self::from(value)),
+            _ => Ok(Self::from(Pubkey::default())),
         }
     }
 }

--- a/token/program-2022/src/pod.rs
+++ b/token/program-2022/src/pod.rs
@@ -245,8 +245,12 @@ impl TryFrom<PodCOption<Pubkey>> for OptionalNonZeroPubkey {
             PodCOption {
                 option: PodCOption::<Pubkey>::SOME,
                 value,
-            } => Ok(Self::from(value)),
-            _ => Ok(Self::from(Pubkey::default())),
+            } => Ok(Self(value)),
+            PodCOption {
+                option: PodCOption::<Pubkey>::NONE,
+                value: _,
+            } => Ok(Self(Pubkey::default())),
+            _ => unreachable!(),
         }
     }
 }


### PR DESCRIPTION
#### Problem

There's still one more way to reduce CU usage in token-2022, and that's through Pod-style deserialization of the instruction, similar to how all of the extensions deserialize their instructions. 

#### Solution

To prepare the switch over to Pod instructions, start with some refactoring. This PR moves all of the `process_*` functions to accept `Pod` types and references, which will come out of the instruction deserialization.

Note: Once this is all done, Pod instructions reduce usage by around 150 CUs, and since it isn't too complicated, it seems like a good option.