### PR TITLE
token-2022: Deserialize transfer fee instruction in its processor

### DIFF
--- a/token/program-2022/src/extension/transfer_fee/instruction.rs
+++ b/token/program-2022/src/extension/transfer_fee/instruction.rs
@@ -251,6 +251,12 @@ impl TransferFeeInstruction {
     }
 }
 
+fn encode_instruction_data(transfer_fee_instruction: TransferFeeInstruction) -> Vec<u8> {
+    let mut data = TokenInstruction::TransferFeeExtension.pack();
+    transfer_fee_instruction.pack(&mut data);
+    data
+}
+
 /// Create a `InitializeTransferFeeConfig` instruction
 pub fn initialize_transfer_fee_config(
     token_program_id: &Pubkey,
@@ -263,15 +269,12 @@ pub fn initialize_transfer_fee_config(
     check_program_account(token_program_id)?;
     let transfer_fee_config_authority = transfer_fee_config_authority.cloned().into();
     let withdraw_withheld_authority = withdraw_withheld_authority.cloned().into();
-    let data = TokenInstruction::TransferFeeExtension(
-        TransferFeeInstruction::InitializeTransferFeeConfig {
-            transfer_fee_config_authority,
-            withdraw_withheld_authority,
-            transfer_fee_basis_points,
-            maximum_fee,
-        },
-    )
-    .pack();
+    let data = encode_instruction_data(TransferFeeInstruction::InitializeTransferFeeConfig {
+        transfer_fee_config_authority,
+        withdraw_withheld_authority,
+        transfer_fee_basis_points,
+        maximum_fee,
+    });
 
     Ok(Instruction {
         program_id: *token_program_id,
@@ -294,13 +297,11 @@ pub fn transfer_checked_with_fee(
     fee: u64,
 ) -> Result<Instruction, ProgramError> {
     check_program_account(token_program_id)?;
-    let data =
-        TokenInstruction::TransferFeeExtension(TransferFeeInstruction::TransferCheckedWithFee {
-            amount,
-            decimals,
-            fee,
-        })
-        .pack();
+    let data = encode_instruction_data(TransferFeeInstruction::TransferCheckedWithFee {
+        amount,
+        decimals,
+        fee,
+    });
 
     let mut accounts = Vec::with_capacity(4 + signers.len());
     accounts.push(AccountMeta::new(*source, false));
@@ -338,10 +339,7 @@ pub fn withdraw_withheld_tokens_from_mint(
     Ok(Instruction {
         program_id: *token_program_id,
         accounts,
-        data: TokenInstruction::TransferFeeExtension(
-            TransferFeeInstruction::WithdrawWithheldTokensFromMint,
-        )
-        .pack(),
+        data: encode_instruction_data(TransferFeeInstruction::WithdrawWithheldTokensFromMint),
     })
 }
 
@@ -371,10 +369,9 @@ pub fn withdraw_withheld_tokens_from_accounts(
     Ok(Instruction {
         program_id: *token_program_id,
         accounts,
-        data: TokenInstruction::TransferFeeExtension(
-            TransferFeeInstruction::WithdrawWithheldTokensFromAccounts { num_token_accounts },
-        )
-        .pack(),
+        data: encode_instruction_data(TransferFeeInstruction::WithdrawWithheldTokensFromAccounts {
+            num_token_accounts,
+        }),
     })
 }
 
@@ -393,10 +390,7 @@ pub fn harvest_withheld_tokens_to_mint(
     Ok(Instruction {
         program_id: *token_program_id,
         accounts,
-        data: TokenInstruction::TransferFeeExtension(
-            TransferFeeInstruction::HarvestWithheldTokensToMint,
-        )
-        .pack(),
+        data: encode_instruction_data(TransferFeeInstruction::HarvestWithheldTokensToMint),
     })
 }
 
@@ -420,11 +414,10 @@ pub fn set_transfer_fee(
     Ok(Instruction {
         program_id: *token_program_id,
         accounts,
-        data: TokenInstruction::TransferFeeExtension(TransferFeeInstruction::SetTransferFee {
+        data: encode_instruction_data(TransferFeeInstruction::SetTransferFee {
             transfer_fee_basis_points,
             maximum_fee,
-        })
-        .pack(),
+        }),
     })
 }
 
@@ -432,83 +425,77 @@ pub fn set_transfer_fee(
 mod test {
     use super::*;
 
-    const TRANSFER_FEE_PREFIX: u8 = 26;
-
     #[test]
     fn test_instruction_packing() {
-        let check = TokenInstruction::TransferFeeExtension(
-            TransferFeeInstruction::InitializeTransferFeeConfig {
-                transfer_fee_config_authority: COption::Some(Pubkey::new_from_array([11u8; 32])),
-                withdraw_withheld_authority: COption::None,
-                transfer_fee_basis_points: 111,
-                maximum_fee: u64::MAX,
-            },
-        );
-        let packed = check.pack();
-        let mut expect = vec![TRANSFER_FEE_PREFIX, 0, 1];
+        let check = TransferFeeInstruction::InitializeTransferFeeConfig {
+            transfer_fee_config_authority: COption::Some(Pubkey::new_from_array([11u8; 32])),
+            withdraw_withheld_authority: COption::None,
+            transfer_fee_basis_points: 111,
+            maximum_fee: u64::MAX,
+        };
+        let mut packed = vec![];
+        check.pack(&mut packed);
+        let mut expect = vec![0, 1];
         expect.extend_from_slice(&[11u8; 32]);
         expect.extend_from_slice(&[0]);
         expect.extend_from_slice(&111u16.to_le_bytes());
         expect.extend_from_slice(&u64::MAX.to_le_bytes());
         assert_eq!(packed, expect);
-        let unpacked = TokenInstruction::unpack(&expect).unwrap();
+        let (unpacked, _) = TransferFeeInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
 
-        let check = TokenInstruction::TransferFeeExtension(
-            TransferFeeInstruction::TransferCheckedWithFee {
-                amount: 24,
-                decimals: 24,
-                fee: 23,
-            },
-        );
-        let packed = check.pack();
-        let mut expect = vec![TRANSFER_FEE_PREFIX, 1];
+        let check = TransferFeeInstruction::TransferCheckedWithFee {
+            amount: 24,
+            decimals: 24,
+            fee: 23,
+        };
+        let mut packed = vec![];
+        check.pack(&mut packed);
+        let mut expect = vec![1];
         expect.extend_from_slice(&24u64.to_le_bytes());
         expect.extend_from_slice(&[24u8]);
         expect.extend_from_slice(&23u64.to_le_bytes());
         assert_eq!(packed, expect);
-        let unpacked = TokenInstruction::unpack(&expect).unwrap();
+        let (unpacked, _) = TransferFeeInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
 
-        let check = TokenInstruction::TransferFeeExtension(
-            TransferFeeInstruction::WithdrawWithheldTokensFromMint,
-        );
-        let packed = check.pack();
-        let expect = [TRANSFER_FEE_PREFIX, 2];
+        let check = TransferFeeInstruction::WithdrawWithheldTokensFromMint;
+        let mut packed = vec![];
+        check.pack(&mut packed);
+        let expect = [2];
         assert_eq!(packed, expect);
-        let unpacked = TokenInstruction::unpack(&expect).unwrap();
+        let (unpacked, _) = TransferFeeInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
 
         let num_token_accounts = 255;
-        let check = TokenInstruction::TransferFeeExtension(
-            TransferFeeInstruction::WithdrawWithheldTokensFromAccounts { num_token_accounts },
-        );
-        let packed = check.pack();
-        let expect = [TRANSFER_FEE_PREFIX, 3, num_token_accounts];
-        assert_eq!(packed, expect);
-        let unpacked = TokenInstruction::unpack(&expect).unwrap();
-        assert_eq!(unpacked, check);
-
-        let check = TokenInstruction::TransferFeeExtension(
-            TransferFeeInstruction::HarvestWithheldTokensToMint,
-        );
-        let packed = check.pack();
-        let expect = [TRANSFER_FEE_PREFIX, 4];
-        assert_eq!(packed, expect);
-        let unpacked = TokenInstruction::unpack(&expect).unwrap();
-        assert_eq!(unpacked, check);
-
         let check =
-            TokenInstruction::TransferFeeExtension(TransferFeeInstruction::SetTransferFee {
-                transfer_fee_basis_points: u16::MAX,
-                maximum_fee: u64::MAX,
-            });
-        let packed = check.pack();
-        let mut expect = vec![TRANSFER_FEE_PREFIX, 5];
+            TransferFeeInstruction::WithdrawWithheldTokensFromAccounts { num_token_accounts };
+        let mut packed = vec![];
+        check.pack(&mut packed);
+        let expect = [3, num_token_accounts];
+        assert_eq!(packed, expect);
+        let (unpacked, _) = TransferFeeInstruction::unpack(&expect).unwrap();
+        assert_eq!(unpacked, check);
+
+        let check = TransferFeeInstruction::HarvestWithheldTokensToMint;
+        let mut packed = vec![];
+        check.pack(&mut packed);
+        let expect = [4];
+        assert_eq!(packed, expect);
+        let (unpacked, _) = TransferFeeInstruction::unpack(&expect).unwrap();
+        assert_eq!(unpacked, check);
+
+        let check = TransferFeeInstruction::SetTransferFee {
+            transfer_fee_basis_points: u16::MAX,
+            maximum_fee: u64::MAX,
+        };
+        let mut packed = vec![];
+        check.pack(&mut packed);
+        let mut expect = vec![5];
         expect.extend_from_slice(&u16::MAX.to_le_bytes());
         expect.extend_from_slice(&u64::MAX.to_le_bytes());
         assert_eq!(packed, expect);
-        let unpacked = TokenInstruction::unpack(&expect).unwrap();
+        let (unpacked, _) = TransferFeeInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
     }
 }

--- a/token/program-2022/src/extension/transfer_fee/processor.rs
+++ b/token/program-2022/src/extension/transfer_fee/processor.rs
@@ -277,8 +277,9 @@ fn process_withdraw_withheld_tokens_from_accounts(
 pub(crate) fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
-    instruction: TransferFeeInstruction,
+    input: &[u8],
 ) -> ProgramResult {
+    let (instruction, _rest) = TransferFeeInstruction::unpack(input)?;
     check_program_account(program_id)?;
 
     match instruction {

--- a/token/program-2022/src/extension/transfer_fee/processor.rs
+++ b/token/program-2022/src/extension/transfer_fee/processor.rs
@@ -279,7 +279,7 @@ pub(crate) fn process_instruction(
     accounts: &[AccountInfo],
     input: &[u8],
 ) -> ProgramResult {
-    let (instruction, _rest) = TransferFeeInstruction::unpack(input)?;
+    let instruction = TransferFeeInstruction::unpack(input)?;
     check_program_account(program_id)?;
 
     match instruction {

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -12,9 +12,8 @@ use {
 };
 use {
     crate::{
-        check_program_account, check_spl_token_program_account,
-        error::TokenError,
-        extension::{transfer_fee::instruction::TransferFeeInstruction, ExtensionType},
+        check_program_account, check_spl_token_program_account, error::TokenError,
+        extension::ExtensionType,
     },
     bytemuck::Pod,
     solana_program::{
@@ -556,7 +555,7 @@ pub enum TokenInstruction<'a> {
     /// See `extension::transfer_fee::instruction::TransferFeeInstruction` for
     /// further details about the extended instructions that share this
     /// instruction prefix
-    TransferFeeExtension(TransferFeeInstruction),
+    TransferFeeExtension,
     /// The common instruction prefix for Confidential Transfer extension
     /// instructions.
     ///
@@ -814,10 +813,7 @@ impl<'a> TokenInstruction<'a> {
                 let (close_authority, _rest) = Self::unpack_pubkey_option(rest)?;
                 Self::InitializeMintCloseAuthority { close_authority }
             }
-            26 => {
-                let (instruction, _rest) = TransferFeeInstruction::unpack(rest)?;
-                Self::TransferFeeExtension(instruction)
-            }
+            26 => Self::TransferFeeExtension,
             27 => Self::ConfidentialTransferExtension,
             28 => Self::DefaultAccountStateExtension,
             29 => {
@@ -961,9 +957,8 @@ impl<'a> TokenInstruction<'a> {
                 buf.push(25);
                 Self::pack_pubkey_option(close_authority, &mut buf);
             }
-            Self::TransferFeeExtension(instruction) => {
+            Self::TransferFeeExtension => {
                 buf.push(26);
-                TransferFeeInstruction::pack(instruction, &mut buf);
             }
             &Self::ConfidentialTransferExtension => {
                 buf.push(27);

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -1641,8 +1641,8 @@ impl Processor {
                     msg!("Instruction: InitializeMintCloseAuthority");
                     Self::process_initialize_mint_close_authority(accounts, close_authority)
                 }
-                TokenInstruction::TransferFeeExtension(instruction) => {
-                    transfer_fee::processor::process_instruction(program_id, accounts, instruction)
+                TokenInstruction::TransferFeeExtension => {
+                    transfer_fee::processor::process_instruction(program_id, accounts, &input[1..])
                 }
                 TokenInstruction::ConfidentialTransferExtension => {
                     confidential_transfer::processor::process_instruction(


### PR DESCRIPTION
#### Problem

As part of moving token-2022 to deserializing instructions as Pod-style types, we can't have enums with data, ie as:

```
enum Instruction {
    Variant(Data),
}
```

Thankfully, most of the token-2022 instructions have pretty simple data, as a pubkey or a u64. The transfer fee extension is a bit special, however, in that we include the whole type in the base `TokenInstruction` enum as `TransferFeeExtension(TransferFeeInstruction)`. This is inconsistent with how other extensions deserialize their instructions, where we only provide the first byte in `TokenInstruction`, and then deserialize the extension-specific instruction in its processor.

#### Solution

No matter what, we'll need to change the transfer fee extension to deserialize as the other extensions do, because we can't include data in the Pod instruction enum.

This PR aims to make the future PR of moving to Pod instructions simpler, by refactoring `transfer_fee::process_instruction` to take a byte slice instead of a `TransferFeeInstruction`.

This change, however, requires removing `TransferFeeInstruction` from the data type in `TokenInstruction`, which constitutes a breaking change.

You can feel free to take this or leave it, since it introduces a lot of churn just to change a couple of lines, so let me know what you prefer.