### PR TITLE
stake-pool: Add RemoveValidatorFromPool instruction in JS bindings

### DIFF
--- a/stake-pool/js/src/instructions.ts
+++ b/stake-pool/js/src/instructions.ts
@@ -37,7 +37,8 @@ export type StakePoolInstructionType =
   | 'DecreaseAdditionalValidatorStake'
   | 'DecreaseValidatorStakeWithReserve'
   | 'Redelegate'
-  | 'AddValidatorToPool';
+  | 'AddValidatorToPool'
+  | 'RemoveValidatorFromPool';
 
 // 'UpdateTokenMetadata' and 'CreateTokenMetadata' have dynamic layouts
 
@@ -95,6 +96,10 @@ export const STAKE_POOL_INSTRUCTION_LAYOUTS: {
   AddValidatorToPool: {
     index: 1,
     layout: BufferLayout.struct<any>([BufferLayout.u8('instruction'), BufferLayout.u32('seed')]),
+  },
+  RemoveValidatorFromPool: {
+    index: 1,
+    layout: BufferLayout.struct<any>([BufferLayout.u8('instruction')]),
   },
   DecreaseValidatorStake: {
     index: 3,
@@ -392,6 +397,15 @@ export type AddValidatorToPoolParams = {
   seed?: number;
 };
 
+export type RemoveValidatorFromPoolParams = {
+  stakePool: PublicKey;
+  staker: PublicKey;
+  withdrawAuthority: PublicKey;
+  validatorList: PublicKey;
+  validatorStake: PublicKey;
+  transientStake: PublicKey;
+};
+
 /**
  * Stake Pool Instruction class
  */
@@ -426,6 +440,39 @@ export class StakePoolInstruction {
       { pubkey: SYSVAR_STAKE_HISTORY_PUBKEY, isSigner: false, isWritable: false },
       { pubkey: STAKE_CONFIG_ID, isSigner: false, isWritable: false },
       { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+      { pubkey: StakeProgram.programId, isSigner: false, isWritable: false },
+    ];
+
+    return new TransactionInstruction({
+      programId: STAKE_POOL_PROGRAM_ID,
+      keys,
+      data,
+    });
+  }
+
+  /**
+   * Creates instruction to remove a validator from the stake pool.
+   */
+  static removeValidatorFromPool(params: RemoveValidatorFromPoolParams): TransactionInstruction {
+    const {
+      stakePool,
+      staker,
+      withdrawAuthority,
+      validatorList,
+      validatorStake,
+      transientStake,
+    } = params;
+    const type = STAKE_POOL_INSTRUCTION_LAYOUTS.RemoveValidatorFromPool;
+    const data = encodeData(type);
+
+    const keys = [
+      { pubkey: stakePool, isSigner: false, isWritable: true },
+      { pubkey: staker, isSigner: true, isWritable: false },
+      { pubkey: withdrawAuthority, isSigner: false, isWritable: false },
+      { pubkey: validatorList, isSigner: false, isWritable: true },
+      { pubkey: validatorStake, isSigner: false, isWritable: true },
+      { pubkey: transientStake, isSigner: false, isWritable: true },
+      { pubkey: SYSVAR_CLOCK_PUBKEY, isSigner: false, isWritable: false },
       { pubkey: StakeProgram.programId, isSigner: false, isWritable: false },
     ];
 

--- a/stake-pool/js/src/instructions.ts
+++ b/stake-pool/js/src/instructions.ts
@@ -454,14 +454,8 @@ export class StakePoolInstruction {
    * Creates instruction to remove a validator from the stake pool.
    */
   static removeValidatorFromPool(params: RemoveValidatorFromPoolParams): TransactionInstruction {
-    const {
-      stakePool,
-      staker,
-      withdrawAuthority,
-      validatorList,
-      validatorStake,
-      transientStake,
-    } = params;
+    const { stakePool, staker, withdrawAuthority, validatorList, validatorStake, transientStake } =
+      params;
     const type = STAKE_POOL_INSTRUCTION_LAYOUTS.RemoveValidatorFromPool;
     const data = encodeData(type);
 

--- a/stake-pool/js/src/instructions.ts
+++ b/stake-pool/js/src/instructions.ts
@@ -98,7 +98,7 @@ export const STAKE_POOL_INSTRUCTION_LAYOUTS: {
     layout: BufferLayout.struct<any>([BufferLayout.u8('instruction'), BufferLayout.u32('seed')]),
   },
   RemoveValidatorFromPool: {
-    index: 1,
+    index: 2,
     layout: BufferLayout.struct<any>([BufferLayout.u8('instruction')]),
   },
   DecreaseValidatorStake: {

--- a/stake-pool/js/test/instructions.test.ts
+++ b/stake-pool/js/test/instructions.test.ts
@@ -230,18 +230,12 @@ describe('StakePoolProgram', () => {
     });
 
     it('should successfully remove a validator', async () => {
-      const validatorStake = await findStakeProgramAddress(
-        STAKE_POOL_PROGRAM_ID,
-        validatorListMock.validators[0].voteAccountAddress,
-        stakePoolAddress,
-        0,
-      );
       connection.getAccountInfo = jest.fn(async (pubKey) => {
         if (pubKey === stakePoolAddress) {
           return stakePoolAccount;
         }
-        if (pubKey.equals(validatorStake)) {
-          return mockValidatorsStakeAccount();
+        if (pubKey.equals(stakePoolMock.validatorList)) {
+          return mockValidatorList();
         }
         return <AccountInfo<any>>{
           executable: true,
@@ -258,6 +252,12 @@ describe('StakePoolProgram', () => {
       expect((connection.getAccountInfo as jest.Mock).mock.calls.length).toBe(2);
       expect(res.instructions).toHaveLength(1);
       // Make sure that the validator stake account being added is the one we passed
+      const validatorStake = await findStakeProgramAddress(
+        STAKE_POOL_PROGRAM_ID,
+        validatorListMock.validators[0].voteAccountAddress,
+        stakePoolAddress,
+        0,
+      );
       expect(res.instructions[0].keys[4].pubkey).toEqual(validatorStake);
     });
   });

--- a/stake-pool/js/test/instructions.test.ts
+++ b/stake-pool/js/test/instructions.test.ts
@@ -33,6 +33,7 @@ import {
   tokenMetadataLayout,
   addValidatorToPool,
 } from '../src';
+import { STAKE_POOL_PROGRAM_ID } from '../constants';
 
 import { decodeData } from '../src/utils';
 
@@ -97,6 +98,35 @@ describe('StakePoolProgram', () => {
       STAKE_POOL_INSTRUCTION_LAYOUTS.AddValidatorToPool.index,
     );
     expect(decodedData.seed).toEqual(payload.seed);
+  });
+
+  it('StakePoolInstruction.removeValidatorFromPool', () => {
+    const payload: RemoveValidatorFromPoolParams = {
+      stakePool: stakePoolAddress,
+      staker: Keypair.generate().publicKey,
+      withdrawAuthority: Keypair.generate().publicKey,
+      validatorList: Keypair.generate().publicKey,
+      validatorStake: Keypair.generate().publicKey,
+      transientStake: Keypair.generate().publicKey,
+    };
+
+    const instruction = StakePoolInstruction.removeValidatorFromPool(payload);
+    expect(instruction.keys).toHaveLength(8);
+    expect(instruction.keys[0].pubkey).toEqual(payload.stakePool);
+    expect(instruction.keys[1].pubkey).toEqual(payload.staker);
+    expect(instruction.keys[2].pubkey).toEqual(payload.withdrawAuthority);
+    expect(instruction.keys[3].pubkey).toEqual(payload.validatorList);
+    expect(instruction.keys[4].pubkey).toEqual(payload.validatorStake);
+    expect(instruction.keys[5].pubkey).toEqual(payload.transientStake);
+    expect(instruction.keys[7].pubkey).toEqual(StakeProgram.programId);
+
+    const decodedData = decodeData(
+      STAKE_POOL_INSTRUCTION_LAYOUTS.RemoveValidatorFromPool,
+      instruction.data,
+    );
+    expect(decodedData.instruction).toEqual(
+      STAKE_POOL_INSTRUCTION_LAYOUTS.RemoveValidatorFromPool.index,
+    );
   });
 
   it('StakePoolInstruction.depositSol', () => {
@@ -177,6 +207,53 @@ describe('StakePoolProgram', () => {
       expect(res.instructions[0].keys[6].pubkey).toEqual(
         validatorListMock.validators[0].voteAccountAddress,
       );
+    });
+  });
+
+  describe('removeValidatorFromPool', () => {
+    const validatorList = mockValidatorList();
+    const decodedValidatorList = ValidatorListLayout.decode(validatorList.data);
+    const voteAccount = Keypair.generate().publicKey;
+
+    it('should throw an error when trying to remove a non-existing validator', async () => {
+      connection.getAccountInfo = jest.fn(async (pubKey) => {
+        if (pubKey === stakePoolAddress) {
+          return stakePoolAccount;
+        }
+        return mockValidatorList();
+      });
+      await expect(removeValidatorFromPool(connection, stakePoolAddress, voteAccount)).rejects.toThrow(
+        Error('Vote account is not already in validator list'),
+      );
+    });
+
+    it('should successfully remove a validator', async () => {
+      connection.getAccountInfo = jest.fn(async (pubKey) => {
+        if (pubKey === stakePoolAddress) {
+          return stakePoolAccount;
+        }
+        return <AccountInfo<any>>{
+          executable: true,
+          owner: new PublicKey(0),
+          lamports: 0,
+          data,
+        };
+      });
+      const res = await removeValidatorFromPool(
+        connection,
+        stakePoolAddress,
+        validatorListMock.validators[0].voteAccountAddress,
+      );
+      expect((connection.getAccountInfo as jest.Mock).mock.calls.length).toBe(2);
+      expect(res.instructions).toHaveLength(1);
+      // Make sure that the validator stake account being added is the one we passed
+      const validatorStake = await findStakeProgramAddress(
+        STAKE_POOL_PROGRAM_ID,
+        validatorListMock.validators[0].voteAccountAddress,
+        stakePoolAddress,
+        0,
+      );
+      expect(res.instructions[0].keys[4].pubkey).toEqual(validatorStake);
     });
   });
 

--- a/stake-pool/js/test/instructions.test.ts
+++ b/stake-pool/js/test/instructions.test.ts
@@ -213,8 +213,6 @@ describe('StakePoolProgram', () => {
   });
 
   describe('removeValidatorFromPool', () => {
-    const validatorList = mockValidatorList();
-    const decodedValidatorList = ValidatorListLayout.decode(validatorList.data);
     const voteAccount = Keypair.generate().publicKey;
 
     it('should throw an error when trying to remove a non-existing validator', async () => {
@@ -222,11 +220,19 @@ describe('StakePoolProgram', () => {
         if (pubKey === stakePoolAddress) {
           return stakePoolAccount;
         }
-        return mockValidatorList();
+        if (pubKey.equals(stakePoolMock.validatorList)) {
+          return mockValidatorList();
+        }
+        return <AccountInfo<any>>{
+          executable: true,
+          owner: new PublicKey(0),
+          lamports: 0,
+          data,
+        };
       });
-      await expect(removeValidatorFromPool(connection, stakePoolAddress, voteAccount)).rejects.toThrow(
-        Error('Vote account is not already in validator list'),
-      );
+      await expect(
+        removeValidatorFromPool(connection, stakePoolAddress, voteAccount),
+      ).rejects.toThrow(Error('Vote account is not already in validator list'));
     });
 
     it('should successfully remove a validator', async () => {

--- a/stake-pool/js/test/instructions.test.ts
+++ b/stake-pool/js/test/instructions.test.ts
@@ -22,6 +22,7 @@ import {
   STAKE_POOL_INSTRUCTION_LAYOUTS,
   DepositSolParams,
   AddValidatorToPoolParams,
+  RemoveValidatorFromPoolParams,
   StakePoolInstruction,
   depositSol,
   withdrawSol,
@@ -32,10 +33,11 @@ import {
   updatePoolTokenMetadata,
   tokenMetadataLayout,
   addValidatorToPool,
+  removeValidatorFromPool,
 } from '../src';
-import { STAKE_POOL_PROGRAM_ID } from '../constants';
+import { STAKE_POOL_PROGRAM_ID } from '../src/constants';
 
-import { decodeData } from '../src/utils';
+import { decodeData, findStakeProgramAddress } from '../src/utils';
 
 import {
   mockRpc,

--- a/stake-pool/js/test/instructions.test.ts
+++ b/stake-pool/js/test/instructions.test.ts
@@ -251,7 +251,7 @@ describe('StakePoolProgram', () => {
       );
       expect((connection.getAccountInfo as jest.Mock).mock.calls.length).toBe(2);
       expect(res.instructions).toHaveLength(1);
-      // Make sure that the validator stake account being added is the one we passed
+      // Make sure that the validator stake account being removed is the one we passed
       const validatorStake = await findStakeProgramAddress(
         STAKE_POOL_PROGRAM_ID,
         validatorListMock.validators[0].voteAccountAddress,

--- a/stake-pool/js/test/instructions.test.ts
+++ b/stake-pool/js/test/instructions.test.ts
@@ -230,9 +230,18 @@ describe('StakePoolProgram', () => {
     });
 
     it('should successfully remove a validator', async () => {
+      const validatorStake = await findStakeProgramAddress(
+        STAKE_POOL_PROGRAM_ID,
+        validatorListMock.validators[0].voteAccountAddress,
+        stakePoolAddress,
+        0,
+      );
       connection.getAccountInfo = jest.fn(async (pubKey) => {
         if (pubKey === stakePoolAddress) {
           return stakePoolAccount;
+        }
+        if (pubKey.equals(validatorStake)) {
+          return mockValidatorsStakeAccount();
         }
         return <AccountInfo<any>>{
           executable: true,
@@ -249,12 +258,6 @@ describe('StakePoolProgram', () => {
       expect((connection.getAccountInfo as jest.Mock).mock.calls.length).toBe(2);
       expect(res.instructions).toHaveLength(1);
       // Make sure that the validator stake account being added is the one we passed
-      const validatorStake = await findStakeProgramAddress(
-        STAKE_POOL_PROGRAM_ID,
-        validatorListMock.validators[0].voteAccountAddress,
-        stakePoolAddress,
-        0,
-      );
       expect(res.instructions[0].keys[4].pubkey).toEqual(validatorStake);
     });
   });


### PR DESCRIPTION
This PR adds the `RemoveValidatorFromPool` instruction to the stake-pool JS bindings. Like the recent addition of `AddValidatorToPool`, this instruction is useful for pool operators using Node.js bots to maintain their pools.

The code was successfully run against the mainnet-beta instance of the BlazeStake pool at transaction hash `RjEP2XBmA6nyVM2Ej23Xct67JZJEAQdb777DkUPJvatkqGWRdzphtGyDKpWMDGmmuHxMjZvBsYBCZiLtWNVpdTR`