### PR TITLE
token-2022: Deserialize instructions as `Pod` types

### DIFF
--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -1993,14 +1993,17 @@ pub fn withdraw_excess_lamports(
 
 #[cfg(test)]
 mod test {
-    use {super::*, proptest::prelude::*};
+    use {super::*, crate::pod_instruction::*, proptest::prelude::*};
 
     #[test]
     fn test_initialize_mint_packing() {
+        let decimals = 2;
+        let mint_authority = Pubkey::new_from_array([1u8; 32]);
+        let freeze_authority = COption::None;
         let check = TokenInstruction::InitializeMint {
-            decimals: 2,
-            mint_authority: Pubkey::new_from_array([1u8; 32]),
-            freeze_authority: COption::None,
+            decimals,
+            mint_authority,
+            freeze_authority,
         };
         let packed = check.pack();
         let mut expect = Vec::from([0u8, 2]);
@@ -2009,11 +2012,20 @@ mod test {
         assert_eq!(packed, expect);
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
+        let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
+        assert_eq!(instruction_type, PodTokenInstruction::InitializeMint);
+        let (pod, pod_freeze_authority) =
+            decode_instruction_data_with_coption_pubkey::<InitializeMintData>(&packed).unwrap();
+        assert_eq!(pod.decimals, decimals);
+        assert_eq!(pod.mint_authority, mint_authority);
+        assert_eq!(pod_freeze_authority, freeze_authority.into());
 
+        let mint_authority = Pubkey::new_from_array([2u8; 32]);
+        let freeze_authority = COption::Some(Pubkey::new_from_array([3u8; 32]));
         let check = TokenInstruction::InitializeMint {
-            decimals: 2,
-            mint_authority: Pubkey::new_from_array([2u8; 32]),
-            freeze_authority: COption::Some(Pubkey::new_from_array([3u8; 32])),
+            decimals,
+            mint_authority,
+            freeze_authority,
         };
         let packed = check.pack();
         let mut expect = vec![0u8, 2];
@@ -2023,6 +2035,14 @@ mod test {
         assert_eq!(packed, expect);
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
+
+        let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
+        assert_eq!(instruction_type, PodTokenInstruction::InitializeMint);
+        let (pod, pod_freeze_authority) =
+            decode_instruction_data_with_coption_pubkey::<InitializeMintData>(&packed).unwrap();
+        assert_eq!(pod.decimals, decimals);
+        assert_eq!(pod.mint_authority, mint_authority);
+        assert_eq!(pod_freeze_authority, freeze_authority.into());
     }
 
     #[test]
@@ -2033,37 +2053,57 @@ mod test {
         assert_eq!(packed, expect);
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
+        let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
+        assert_eq!(instruction_type, PodTokenInstruction::InitializeAccount);
     }
 
     #[test]
     fn test_initialize_multisig_packing() {
-        let check = TokenInstruction::InitializeMultisig { m: 1 };
+        let m = 1;
+        let check = TokenInstruction::InitializeMultisig { m };
         let packed = check.pack();
         let expect = Vec::from([2u8, 1]);
         assert_eq!(packed, expect);
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
+
+        let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
+        assert_eq!(instruction_type, PodTokenInstruction::InitializeMultisig);
+        let pod = decode_instruction_data::<InitializeMultisigData>(&packed).unwrap();
+        assert_eq!(pod.m, m);
     }
 
     #[test]
     fn test_transfer_packing() {
+        let amount = 1;
         #[allow(deprecated)]
-        let check = TokenInstruction::Transfer { amount: 1 };
+        let check = TokenInstruction::Transfer { amount };
         let packed = check.pack();
         let expect = Vec::from([3u8, 1, 0, 0, 0, 0, 0, 0, 0]);
         assert_eq!(packed, expect);
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
+
+        let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
+        assert_eq!(instruction_type, PodTokenInstruction::Transfer);
+        let pod = decode_instruction_data::<AmountData>(&packed).unwrap();
+        assert_eq!(pod.amount, amount.into());
     }
 
     #[test]
     fn test_approve_packing() {
-        let check = TokenInstruction::Approve { amount: 1 };
+        let amount = 1;
+        let check = TokenInstruction::Approve { amount };
         let packed = check.pack();
         let expect = Vec::from([4u8, 1, 0, 0, 0, 0, 0, 0, 0]);
         assert_eq!(packed, expect);
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
+
+        let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
+        assert_eq!(instruction_type, PodTokenInstruction::Approve);
+        let pod = decode_instruction_data::<AmountData>(&packed).unwrap();
+        assert_eq!(pod.amount, amount.into());
     }
 
     #[test]
@@ -2074,13 +2114,17 @@ mod test {
         assert_eq!(packed, expect);
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
+        let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
+        assert_eq!(instruction_type, PodTokenInstruction::Revoke);
     }
 
     #[test]
     fn test_set_authority_packing() {
+        let authority_type = AuthorityType::FreezeAccount;
+        let new_authority = COption::Some(Pubkey::new_from_array([4u8; 32]));
         let check = TokenInstruction::SetAuthority {
-            authority_type: AuthorityType::FreezeAccount,
-            new_authority: COption::Some(Pubkey::new_from_array([4u8; 32])),
+            authority_type: authority_type.clone(),
+            new_authority,
         };
         let packed = check.pack();
         let mut expect = Vec::from([6u8, 1]);
@@ -2089,26 +2133,48 @@ mod test {
         assert_eq!(packed, expect);
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
+
+        let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
+        assert_eq!(instruction_type, PodTokenInstruction::SetAuthority);
+        let (pod, pod_new_authority) =
+            decode_instruction_data_with_coption_pubkey::<SetAuthorityData>(&packed).unwrap();
+        assert_eq!(
+            AuthorityType::from(pod.authority_type).unwrap(),
+            authority_type
+        );
+        assert_eq!(pod_new_authority, new_authority.into());
     }
 
     #[test]
     fn test_mint_to_packing() {
-        let check = TokenInstruction::MintTo { amount: 1 };
+        let amount = 1;
+        let check = TokenInstruction::MintTo { amount };
         let packed = check.pack();
         let expect = Vec::from([7u8, 1, 0, 0, 0, 0, 0, 0, 0]);
         assert_eq!(packed, expect);
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
+
+        let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
+        assert_eq!(instruction_type, PodTokenInstruction::MintTo);
+        let pod = decode_instruction_data::<AmountData>(&packed).unwrap();
+        assert_eq!(pod.amount, amount.into());
     }
 
     #[test]
     fn test_burn_packing() {
-        let check = TokenInstruction::Burn { amount: 1 };
+        let amount = 1;
+        let check = TokenInstruction::Burn { amount };
         let packed = check.pack();
         let expect = Vec::from([8u8, 1, 0, 0, 0, 0, 0, 0, 0]);
         assert_eq!(packed, expect);
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
+
+        let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
+        assert_eq!(instruction_type, PodTokenInstruction::Burn);
+        let pod = decode_instruction_data::<AmountData>(&packed).unwrap();
+        assert_eq!(pod.amount, amount.into());
     }
 
     #[test]
@@ -2119,6 +2185,8 @@ mod test {
         assert_eq!(packed, expect);
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
+        let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
+        assert_eq!(instruction_type, PodTokenInstruction::CloseAccount);
     }
 
     #[test]
@@ -2129,6 +2197,8 @@ mod test {
         assert_eq!(packed, expect);
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
+        let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
+        assert_eq!(instruction_type, PodTokenInstruction::FreezeAccount);
     }
 
     #[test]
@@ -2139,71 +2209,97 @@ mod test {
         assert_eq!(packed, expect);
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
+        let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
+        assert_eq!(instruction_type, PodTokenInstruction::ThawAccount);
     }
 
     #[test]
     fn test_transfer_checked_packing() {
-        let check = TokenInstruction::TransferChecked {
-            amount: 1,
-            decimals: 2,
-        };
+        let amount = 1;
+        let decimals = 2;
+        let check = TokenInstruction::TransferChecked { amount, decimals };
         let packed = check.pack();
         let expect = Vec::from([12u8, 1, 0, 0, 0, 0, 0, 0, 0, 2]);
         assert_eq!(packed, expect);
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
+
+        let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
+        assert_eq!(instruction_type, PodTokenInstruction::TransferChecked);
+        let pod = decode_instruction_data::<AmountCheckedData>(&packed).unwrap();
+        assert_eq!(pod.amount, amount.into());
+        assert_eq!(pod.decimals, decimals);
     }
 
     #[test]
     fn test_approve_checked_packing() {
-        let check = TokenInstruction::ApproveChecked {
-            amount: 1,
-            decimals: 2,
-        };
+        let amount = 1;
+        let decimals = 2;
+
+        let check = TokenInstruction::ApproveChecked { amount, decimals };
         let packed = check.pack();
         let expect = Vec::from([13u8, 1, 0, 0, 0, 0, 0, 0, 0, 2]);
         assert_eq!(packed, expect);
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
+
+        let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
+        assert_eq!(instruction_type, PodTokenInstruction::ApproveChecked);
+        let pod = decode_instruction_data::<AmountCheckedData>(&packed).unwrap();
+        assert_eq!(pod.amount, amount.into());
+        assert_eq!(pod.decimals, decimals);
     }
 
     #[test]
     fn test_mint_to_checked_packing() {
-        let check = TokenInstruction::MintToChecked {
-            amount: 1,
-            decimals: 2,
-        };
+        let amount = 1;
+        let decimals = 2;
+        let check = TokenInstruction::MintToChecked { amount, decimals };
         let packed = check.pack();
         let expect = Vec::from([14u8, 1, 0, 0, 0, 0, 0, 0, 0, 2]);
         assert_eq!(packed, expect);
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
+        let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
+        assert_eq!(instruction_type, PodTokenInstruction::MintToChecked);
+        let pod = decode_instruction_data::<AmountCheckedData>(&packed).unwrap();
+        assert_eq!(pod.amount, amount.into());
+        assert_eq!(pod.decimals, decimals);
     }
 
     #[test]
     fn test_burn_checked_packing() {
-        let check = TokenInstruction::BurnChecked {
-            amount: 1,
-            decimals: 2,
-        };
+        let amount = 1;
+        let decimals = 2;
+        let check = TokenInstruction::BurnChecked { amount, decimals };
         let packed = check.pack();
         let expect = Vec::from([15u8, 1, 0, 0, 0, 0, 0, 0, 0, 2]);
         assert_eq!(packed, expect);
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
+
+        let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
+        assert_eq!(instruction_type, PodTokenInstruction::BurnChecked);
+        let pod = decode_instruction_data::<AmountCheckedData>(&packed).unwrap();
+        assert_eq!(pod.amount, amount.into());
+        assert_eq!(pod.decimals, decimals);
     }
 
     #[test]
     fn test_initialize_account2_packing() {
-        let check = TokenInstruction::InitializeAccount2 {
-            owner: Pubkey::new_from_array([2u8; 32]),
-        };
+        let owner = Pubkey::new_from_array([2u8; 32]);
+        let check = TokenInstruction::InitializeAccount2 { owner };
         let packed = check.pack();
         let mut expect = vec![16u8];
         expect.extend_from_slice(&[2u8; 32]);
         assert_eq!(packed, expect);
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
+
+        let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
+        assert_eq!(instruction_type, PodTokenInstruction::InitializeAccount2);
+        let pod_owner = decode_instruction_data::<Pubkey>(&packed).unwrap();
+        assert_eq!(*pod_owner, owner);
     }
 
     #[test]
@@ -2214,37 +2310,53 @@ mod test {
         assert_eq!(packed, expect);
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
+
+        let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
+        assert_eq!(instruction_type, PodTokenInstruction::SyncNative);
     }
 
     #[test]
     fn test_initialize_account3_packing() {
-        let check = TokenInstruction::InitializeAccount3 {
-            owner: Pubkey::new_from_array([2u8; 32]),
-        };
+        let owner = Pubkey::new_from_array([2u8; 32]);
+        let check = TokenInstruction::InitializeAccount3 { owner };
         let packed = check.pack();
         let mut expect = vec![18u8];
         expect.extend_from_slice(&[2u8; 32]);
         assert_eq!(packed, expect);
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
+
+        let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
+        assert_eq!(instruction_type, PodTokenInstruction::InitializeAccount3);
+        let pod_owner = decode_instruction_data::<Pubkey>(&packed).unwrap();
+        assert_eq!(*pod_owner, owner);
     }
 
     #[test]
     fn test_initialize_multisig2_packing() {
-        let check = TokenInstruction::InitializeMultisig2 { m: 1 };
+        let m = 1;
+        let check = TokenInstruction::InitializeMultisig2 { m };
         let packed = check.pack();
         let expect = Vec::from([19u8, 1]);
         assert_eq!(packed, expect);
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
+
+        let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
+        assert_eq!(instruction_type, PodTokenInstruction::InitializeMultisig2);
+        let pod = decode_instruction_data::<InitializeMultisigData>(&packed).unwrap();
+        assert_eq!(pod.m, m);
     }
 
     #[test]
     fn test_initialize_mint2_packing() {
+        let decimals = 2;
+        let mint_authority = Pubkey::new_from_array([1u8; 32]);
+        let freeze_authority = COption::None;
         let check = TokenInstruction::InitializeMint2 {
-            decimals: 2,
-            mint_authority: Pubkey::new_from_array([1u8; 32]),
-            freeze_authority: COption::None,
+            decimals,
+            mint_authority,
+            freeze_authority,
         };
         let packed = check.pack();
         let mut expect = Vec::from([20u8, 2]);
@@ -2254,10 +2366,21 @@ mod test {
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
 
+        let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
+        assert_eq!(instruction_type, PodTokenInstruction::InitializeMint2);
+        let (pod, pod_freeze_authority) =
+            decode_instruction_data_with_coption_pubkey::<InitializeMintData>(&packed).unwrap();
+        assert_eq!(pod.decimals, decimals);
+        assert_eq!(pod.mint_authority, mint_authority);
+        assert_eq!(pod_freeze_authority, freeze_authority.into());
+
+        let decimals = 2;
+        let mint_authority = Pubkey::new_from_array([2u8; 32]);
+        let freeze_authority = COption::Some(Pubkey::new_from_array([3u8; 32]));
         let check = TokenInstruction::InitializeMint2 {
-            decimals: 2,
-            mint_authority: Pubkey::new_from_array([2u8; 32]),
-            freeze_authority: COption::Some(Pubkey::new_from_array([3u8; 32])),
+            decimals,
+            mint_authority,
+            freeze_authority,
         };
         let packed = check.pack();
         let mut expect = vec![20u8, 2];
@@ -2267,12 +2390,21 @@ mod test {
         assert_eq!(packed, expect);
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
+
+        let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
+        assert_eq!(instruction_type, PodTokenInstruction::InitializeMint2);
+        let (pod, pod_freeze_authority) =
+            decode_instruction_data_with_coption_pubkey::<InitializeMintData>(&packed).unwrap();
+        assert_eq!(pod.decimals, decimals);
+        assert_eq!(pod.mint_authority, mint_authority);
+        assert_eq!(pod_freeze_authority, freeze_authority.into());
     }
 
     #[test]
     fn test_get_account_data_size_packing() {
+        let extension_types = vec![];
         let check = TokenInstruction::GetAccountDataSize {
-            extension_types: vec![],
+            extension_types: extension_types.clone(),
         };
         let packed = check.pack();
         let expect = [21u8];
@@ -2280,50 +2412,89 @@ mod test {
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
 
+        let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
+        assert_eq!(instruction_type, PodTokenInstruction::GetAccountDataSize);
+        let pod_extension_types = packed[1..]
+            .chunks(std::mem::size_of::<ExtensionType>())
+            .map(ExtensionType::try_from)
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(pod_extension_types, extension_types);
+
+        let extension_types = vec![
+            ExtensionType::TransferFeeConfig,
+            ExtensionType::TransferFeeAmount,
+        ];
         let check = TokenInstruction::GetAccountDataSize {
-            extension_types: vec![
-                ExtensionType::TransferFeeConfig,
-                ExtensionType::TransferFeeAmount,
-            ],
+            extension_types: extension_types.clone(),
         };
         let packed = check.pack();
         let expect = [21u8, 1, 0, 2, 0];
         assert_eq!(packed, &[21u8, 1, 0, 2, 0]);
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
+
+        let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
+        assert_eq!(instruction_type, PodTokenInstruction::GetAccountDataSize);
+        let pod_extension_types = packed[1..]
+            .chunks(std::mem::size_of::<ExtensionType>())
+            .map(ExtensionType::try_from)
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(pod_extension_types, extension_types);
     }
 
     #[test]
     fn test_amount_to_ui_amount_packing() {
-        let check = TokenInstruction::AmountToUiAmount { amount: 42 };
+        let amount = 42;
+        let check = TokenInstruction::AmountToUiAmount { amount };
         let packed = check.pack();
         let expect = vec![23u8, 42, 0, 0, 0, 0, 0, 0, 0];
         assert_eq!(packed, expect);
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
+
+        let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
+        assert_eq!(instruction_type, PodTokenInstruction::AmountToUiAmount);
+        let data = decode_instruction_data::<AmountData>(&packed).unwrap();
+        assert_eq!(data.amount, amount.into());
     }
 
     #[test]
     fn test_ui_amount_to_amount_packing() {
-        let check = TokenInstruction::UiAmountToAmount { ui_amount: "0.42" };
+        let ui_amount = "0.42";
+        let check = TokenInstruction::UiAmountToAmount { ui_amount };
         let packed = check.pack();
         let expect = vec![24u8, 48, 46, 52, 50];
         assert_eq!(packed, expect);
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
+
+        let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
+        assert_eq!(instruction_type, PodTokenInstruction::UiAmountToAmount);
+        let pod_ui_amount = std::str::from_utf8(&packed[1..]).unwrap();
+        assert_eq!(pod_ui_amount, ui_amount);
     }
 
     #[test]
     fn test_initialize_mint_close_authority_packing() {
-        let check = TokenInstruction::InitializeMintCloseAuthority {
-            close_authority: COption::Some(Pubkey::new_from_array([10u8; 32])),
-        };
+        let close_authority = COption::Some(Pubkey::new_from_array([10u8; 32]));
+        let check = TokenInstruction::InitializeMintCloseAuthority { close_authority };
         let packed = check.pack();
         let mut expect = vec![25u8, 1];
         expect.extend_from_slice(&[10u8; 32]);
         assert_eq!(packed, expect);
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
+
+        let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
+        assert_eq!(
+            instruction_type,
+            PodTokenInstruction::InitializeMintCloseAuthority
+        );
+        let (_, pod_close_authority) =
+            decode_instruction_data_with_coption_pubkey::<()>(&packed).unwrap();
+        assert_eq!(pod_close_authority, close_authority.into());
     }
 
     #[test]
@@ -2334,19 +2505,29 @@ mod test {
         assert_eq!(packed, expect);
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
+
+        let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
+        assert_eq!(instruction_type, PodTokenInstruction::CreateNativeMint);
     }
 
     #[test]
     fn test_initialize_permanent_delegate_packing() {
-        let check = TokenInstruction::InitializePermanentDelegate {
-            delegate: Pubkey::new_from_array([11u8; 32]),
-        };
+        let delegate = Pubkey::new_from_array([11u8; 32]);
+        let check = TokenInstruction::InitializePermanentDelegate { delegate };
         let packed = check.pack();
         let mut expect = vec![35u8];
         expect.extend_from_slice(&[11u8; 32]);
         assert_eq!(packed, expect);
         let unpacked = TokenInstruction::unpack(&expect).unwrap();
         assert_eq!(unpacked, check);
+
+        let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
+        assert_eq!(
+            instruction_type,
+            PodTokenInstruction::InitializePermanentDelegate
+        );
+        let pod_delegate = decode_instruction_data::<Pubkey>(&packed).unwrap();
+        assert_eq!(*pod_delegate, delegate);
     }
 
     macro_rules! test_instruction {

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -48,6 +48,7 @@ const U64_BYTES: usize = 8;
 )]
 #[derive(Clone, Debug, PartialEq)]
 pub enum TokenInstruction<'a> {
+    // 0
     /// Initializes a new mint and optionally deposits all the newly minted
     /// tokens in an account.
     ///
@@ -167,6 +168,7 @@ pub enum TokenInstruction<'a> {
         /// The amount of tokens the delegate is approved for.
         amount: u64,
     },
+    // 5
     /// Revokes the delegate's authority.
     ///
     /// Accounts expected by this instruction:
@@ -272,6 +274,7 @@ pub enum TokenInstruction<'a> {
     ///   2. `[]` The account's multisignature owner.
     ///   3. ..3+M `[signer]` M signer accounts.
     CloseAccount,
+    // 10
     /// Freeze an Initialized account using the Mint's freeze_authority (if
     /// set).
     ///
@@ -388,6 +391,7 @@ pub enum TokenInstruction<'a> {
         /// Expected number of base 10 digits to the right of the decimal place.
         decimals: u8,
     },
+    // 15
     /// Burns tokens by removing them from an account.  `BurnChecked` does not
     /// support accounts associated with the native mint, use `CloseAccount`
     /// instead.
@@ -465,6 +469,7 @@ pub enum TokenInstruction<'a> {
         /// account.
         m: u8,
     },
+    // 20
     /// Like InitializeMint, but does not require the Rent sysvar to be provided
     ///
     /// Accounts expected by this instruction:
@@ -533,6 +538,7 @@ pub enum TokenInstruction<'a> {
         /// The ui_amount of tokens to convert.
         ui_amount: &'a str,
     },
+    // 25
     /// Initialize the close account authority on a new mint.
     ///
     /// Fails if the mint has already been initialized, so must be called before
@@ -592,6 +598,7 @@ pub enum TokenInstruction<'a> {
         /// New extension types to include in the reallocated account
         extension_types: Vec<ExtensionType>,
     },
+    // 30
     /// The common instruction prefix for Memo Transfer account extension
     /// instructions.
     ///
@@ -637,6 +644,7 @@ pub enum TokenInstruction<'a> {
     /// further details about the extended instructions that share this
     /// instruction prefix
     CpiGuardExtension,
+    // 35
     /// Initialize the permanent delegate on a new mint.
     ///
     /// Fails if the mint has already been initialized, so must be called before
@@ -686,6 +694,7 @@ pub enum TokenInstruction<'a> {
     /// for further details about the extended instructions that share this
     /// instruction prefix
     MetadataPointerExtension,
+    // 40
     /// The common instruction prefix for group pointer extension instructions.
     ///
     /// See `extension::group_pointer::instruction::GroupPointerInstruction`

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -1129,7 +1129,7 @@ impl AuthorityType {
         }
     }
 
-    fn from(index: u8) -> Result<Self, ProgramError> {
+    pub(crate) fn from(index: u8) -> Result<Self, ProgramError> {
         match index {
             0 => Ok(AuthorityType::MintTokens),
             1 => Ok(AuthorityType::FreezeAccount),

--- a/token/program-2022/src/lib.rs
+++ b/token/program-2022/src/lib.rs
@@ -12,6 +12,7 @@ pub mod native_mint;
 pub mod offchain;
 pub mod onchain;
 pub mod pod;
+pub mod pod_instruction;
 pub mod processor;
 pub mod proof;
 #[cfg(feature = "serde-traits")]

--- a/token/program-2022/src/pod_instruction.rs
+++ b/token/program-2022/src/pod_instruction.rs
@@ -1,0 +1,215 @@
+//! Rewrites of the instruction data types represented as Pods
+
+use {
+    crate::pod::PodCOption,
+    bytemuck::{Pod, Zeroable},
+    num_enum::{IntoPrimitive, TryFromPrimitive},
+    solana_program::{
+        program_error::ProgramError,
+        pubkey::{Pubkey, PUBKEY_BYTES},
+    },
+    spl_pod::{
+        bytemuck::{pod_from_bytes, pod_get_packed_len},
+        primitives::PodU64,
+    },
+};
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+pub(crate) struct InitializeMintData {
+    /// Number of base 10 digits to the right of the decimal place.
+    pub(crate) decimals: u8,
+    /// The authority/multisignature to mint tokens.
+    pub(crate) mint_authority: Pubkey,
+    // The freeze authority option comes later, but cannot be included as
+    // plain old data in this struct
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+pub(crate) struct InitializeMultisigData {
+    /// The number of signers (M) required to validate this multisignature
+    /// account.
+    pub(crate) m: u8,
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+pub(crate) struct AmountData {
+    /// The amount of tokens to transfer.
+    pub(crate) amount: PodU64,
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+pub(crate) struct AmountCheckedData {
+    /// The amount of tokens to transfer.
+    pub(crate) amount: PodU64,
+    /// Decimals of the mint
+    pub(crate) decimals: u8,
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+pub(crate) struct SetAuthorityData {
+    /// The type of authority to update.
+    pub(crate) authority_type: u8,
+    // The new authority option comes later, but cannot be included as
+    // plain old data in this struct
+}
+
+/// All of the base instructions in Token-2022, reduced down to their one-byte
+/// discriminant.
+///
+/// All instructions that expect data afterwards include a comment with the data
+/// type expected. For example, `PodTokenInstruction::InitializeMint` expects
+/// `InitializeMintData`.
+#[derive(Clone, Copy, Debug, TryFromPrimitive, IntoPrimitive)]
+#[repr(u8)]
+pub(crate) enum PodTokenInstruction {
+    InitializeMint, // InitializeMintData
+    InitializeAccount,
+    InitializeMultisig, // InitializeMultisigData
+    Transfer,           // AmountData
+    Approve,            // AmountData
+    Revoke,
+    SetAuthority, // SetAuthorityData
+    MintTo,       // AmountData
+    Burn,         // AmountData
+    CloseAccount,
+    FreezeAccount,
+    ThawAccount,
+    TransferChecked,    // AmountCheckedData
+    ApproveChecked,     // AmountCheckedData
+    MintToChecked,      // AmountCheckedData
+    BurnChecked,        // AmountCheckedData
+    InitializeAccount2, // Pubkey
+    SyncNative,
+    InitializeAccount3,  // Pubkey
+    InitializeMultisig2, // InitializeMultisigData
+    InitializeMint2,     // InitializeMintData
+    GetAccountDataSize,  // &[ExtensionType]
+    InitializeImmutableOwner,
+    AmountToUiAmount,             // AmountData
+    UiAmountToAmount,             // &str
+    InitializeMintCloseAuthority, // COption<Pubkey>
+    TransferFeeExtension,
+    ConfidentialTransferExtension,
+    DefaultAccountStateExtension,
+    Reallocate, // &[ExtensionType]
+    MemoTransferExtension,
+    CreateNativeMint,
+    InitializeNonTransferableMint,
+    InterestBearingMintExtension,
+    CpiGuardExtension,
+    InitializePermanentDelegate, // Pubkey
+    TransferHookExtension,
+    ConfidentialTransferFeeExtension,
+    WithdrawExcessLamports,
+    MetadataPointerExtension,
+    GroupPointerExtension,
+    GroupMemberPointerExtension,
+}
+
+fn unpack_pubkey_option(input: &[u8]) -> Result<PodCOption<Pubkey>, ProgramError> {
+    match input.split_first() {
+        Option::Some((&0, _)) => Ok(PodCOption::none()),
+        Option::Some((&1, rest)) => {
+            let pk = rest
+                .get(..PUBKEY_BYTES)
+                .and_then(|x| Pubkey::try_from(x).ok())
+                .ok_or(ProgramError::InvalidInstructionData)?;
+            Ok(PodCOption::some(pk))
+        }
+        _ => Err(ProgramError::InvalidInstructionData),
+    }
+}
+
+/// Specialty function for deserializing `Pod` data and a `COption<Pubkey>`
+///
+/// `COption<T>` is not `Pod` compatible when serialized in an instruction, but
+/// since it is always at the end of an instruction, so we can do this safely
+pub(crate) fn decode_instruction_data_with_coption_pubkey<T: Pod>(
+    input_with_type: &[u8],
+) -> Result<(&T, PodCOption<Pubkey>), ProgramError> {
+    let end_of_t = pod_get_packed_len::<T>().saturating_add(1);
+    let value = input_with_type
+        .get(1..end_of_t)
+        .ok_or(ProgramError::InvalidInstructionData)
+        .and_then(pod_from_bytes)?;
+    let pubkey = unpack_pubkey_option(&input_with_type[end_of_t..])?;
+    Ok((value, pubkey))
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::{
+            extension::ExtensionType,
+            instruction::{decode_instruction_data, decode_instruction_type},
+        },
+        proptest::prelude::*,
+    };
+
+    // Test function that mimics the "unpacking" in `Processor::process` by
+    // trying to deserialize the relevant type data after the instruction type
+    fn check_pod_instruction(input: &[u8]) -> Result<(), ProgramError> {
+        if let Ok(instruction_type) = decode_instruction_type(input) {
+            match instruction_type {
+                PodTokenInstruction::InitializeMint | PodTokenInstruction::InitializeMint2 => {
+                    let _ =
+                        decode_instruction_data_with_coption_pubkey::<InitializeMintData>(input)?;
+                }
+                PodTokenInstruction::InitializeAccount2
+                | PodTokenInstruction::InitializeAccount3
+                | PodTokenInstruction::InitializePermanentDelegate => {
+                    let _ = decode_instruction_data::<Pubkey>(input)?;
+                }
+                PodTokenInstruction::InitializeMultisig
+                | PodTokenInstruction::InitializeMultisig2 => {
+                    let _ = decode_instruction_data::<InitializeMultisigData>(input)?;
+                }
+                PodTokenInstruction::SetAuthority => {
+                    let _ = decode_instruction_data_with_coption_pubkey::<SetAuthorityData>(input)?;
+                }
+                PodTokenInstruction::Transfer
+                | PodTokenInstruction::Approve
+                | PodTokenInstruction::MintTo
+                | PodTokenInstruction::Burn
+                | PodTokenInstruction::AmountToUiAmount => {
+                    let _ = decode_instruction_data::<AmountData>(input)?;
+                }
+                PodTokenInstruction::TransferChecked
+                | PodTokenInstruction::ApproveChecked
+                | PodTokenInstruction::MintToChecked
+                | PodTokenInstruction::BurnChecked => {
+                    let _ = decode_instruction_data::<AmountCheckedData>(input)?;
+                }
+                PodTokenInstruction::InitializeMintCloseAuthority => {
+                    let _ = decode_instruction_data_with_coption_pubkey::<()>(input)?;
+                }
+                PodTokenInstruction::UiAmountToAmount => {
+                    let _ = std::str::from_utf8(&input[1..])
+                        .map_err(|_| ProgramError::InvalidInstructionData)?;
+                }
+                PodTokenInstruction::GetAccountDataSize | PodTokenInstruction::Reallocate => {
+                    let _ = input[1..]
+                        .chunks(std::mem::size_of::<ExtensionType>())
+                        .map(ExtensionType::try_from)
+                        .collect::<Result<Vec<_>, _>>()?;
+                }
+                _ => {
+                    // no extra data to deserialize
+                }
+            }
+        }
+        Ok(())
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(1024))]
+        #[test]
+        fn test_instruction_unpack_proptest(
+            data in prop::collection::vec(any::<u8>(), 0..255)
+        ) {
+            let _no_panic = check_pod_instruction(&data);
+        }
+    }
+}

--- a/token/program-2022/src/pod_instruction.rs
+++ b/token/program-2022/src/pod_instruction.rs
@@ -60,7 +60,7 @@ pub(crate) struct SetAuthorityData {
 /// All instructions that expect data afterwards include a comment with the data
 /// type expected. For example, `PodTokenInstruction::InitializeMint` expects
 /// `InitializeMintData`.
-#[derive(Clone, Copy, Debug, TryFromPrimitive, IntoPrimitive)]
+#[derive(Clone, Copy, Debug, PartialEq, TryFromPrimitive, IntoPrimitive)]
 #[repr(u8)]
 pub(crate) enum PodTokenInstruction {
     InitializeMint, // InitializeMintData

--- a/token/program-2022/src/pod_instruction.rs
+++ b/token/program-2022/src/pod_instruction.rs
@@ -63,46 +63,55 @@ pub(crate) struct SetAuthorityData {
 #[derive(Clone, Copy, Debug, PartialEq, TryFromPrimitive, IntoPrimitive)]
 #[repr(u8)]
 pub(crate) enum PodTokenInstruction {
+    // 0
     InitializeMint, // InitializeMintData
     InitializeAccount,
     InitializeMultisig, // InitializeMultisigData
     Transfer,           // AmountData
     Approve,            // AmountData
+    // 5
     Revoke,
     SetAuthority, // SetAuthorityData
     MintTo,       // AmountData
     Burn,         // AmountData
     CloseAccount,
+    // 10
     FreezeAccount,
     ThawAccount,
-    TransferChecked,    // AmountCheckedData
-    ApproveChecked,     // AmountCheckedData
-    MintToChecked,      // AmountCheckedData
+    TransferChecked, // AmountCheckedData
+    ApproveChecked,  // AmountCheckedData
+    MintToChecked,   // AmountCheckedData
+    // 15
     BurnChecked,        // AmountCheckedData
     InitializeAccount2, // Pubkey
     SyncNative,
     InitializeAccount3,  // Pubkey
     InitializeMultisig2, // InitializeMultisigData
-    InitializeMint2,     // InitializeMintData
-    GetAccountDataSize,  // &[ExtensionType]
+    // 20
+    InitializeMint2,    // InitializeMintData
+    GetAccountDataSize, // &[ExtensionType]
     InitializeImmutableOwner,
-    AmountToUiAmount,             // AmountData
-    UiAmountToAmount,             // &str
+    AmountToUiAmount, // AmountData
+    UiAmountToAmount, // &str
+    // 25
     InitializeMintCloseAuthority, // COption<Pubkey>
     TransferFeeExtension,
     ConfidentialTransferExtension,
     DefaultAccountStateExtension,
     Reallocate, // &[ExtensionType]
+    // 30
     MemoTransferExtension,
     CreateNativeMint,
     InitializeNonTransferableMint,
     InterestBearingMintExtension,
     CpiGuardExtension,
+    // 35
     InitializePermanentDelegate, // Pubkey
     TransferHookExtension,
     ConfidentialTransferFeeExtension,
     WithdrawExcessLamports,
     MetadataPointerExtension,
+    // 40
     GroupPointerExtension,
     GroupMemberPointerExtension,
 }

--- a/token/program-2022/tests/assert_instruction_count.rs
+++ b/token/program-2022/tests/assert_instruction_count.rs
@@ -22,7 +22,7 @@ const TRANSFER_AMOUNT: u64 = 1_000_000_000_000_000;
 #[tokio::test]
 async fn initialize_mint() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
-    pt.set_compute_max_units(5_000); // last known 1742
+    pt.set_compute_max_units(5_000); // last known 1378
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner_key = Pubkey::new_unique();
@@ -60,7 +60,7 @@ async fn initialize_mint() {
 #[tokio::test]
 async fn initialize_account() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
-    pt.set_compute_max_units(8_000); // last known 2016
+    pt.set_compute_max_units(8_000); // last known 1783
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();
@@ -112,7 +112,7 @@ async fn initialize_account() {
 #[tokio::test]
 async fn mint_to() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
-    pt.set_compute_max_units(8_000); // last known 1285
+    pt.set_compute_max_units(8_000); // last known 1115
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();
@@ -161,7 +161,7 @@ async fn mint_to() {
 #[tokio::test]
 async fn transfer() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
-    pt.set_compute_max_units(8_000); // last known 1642
+    pt.set_compute_max_units(8_000); // last known 1502
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();
@@ -229,7 +229,7 @@ async fn transfer() {
 #[tokio::test]
 async fn transfer_checked() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
-    pt.set_compute_max_units(8_000); // last known 1960
+    pt.set_compute_max_units(8_000); // last known 1849
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();
@@ -299,7 +299,7 @@ async fn transfer_checked() {
 #[tokio::test]
 async fn burn() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
-    pt.set_compute_max_units(8_000); // last known 1395
+    pt.set_compute_max_units(8_000); // last known 1226
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();
@@ -356,7 +356,7 @@ async fn burn() {
 #[tokio::test]
 async fn close_account() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
-    pt.set_compute_max_units(8_000); // last known 1500
+    pt.set_compute_max_units(8_000); // last known 1315
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();


### PR DESCRIPTION
#### Problem

Token-2022 is still deserializing instructions on the stack, which uses up more CUs than in-place deserialization.

#### Solution

Define a new enum `PodTokenInstruction`, which is just the discriminant from `TokenInstructions`, along with `Pod` types for the instruction data. And then use these types to deserialize instruction data in the processor.

`COption` is an outlier here because it can't be represented as a `Pod` type, so there's a helper to deserialize it when included with a `Pod` type.

The final savings are about another 150 CUs per instruction, which is pretty good! And this should be the last PR for awhile on token-2022.

Most of the changes are tests, so I hope this won't be too tough to review.