### PR TITLE
token js: add missing "mint" param to docs for approveChecked

### DIFF
--- a/token/js/src/actions/approveChecked.ts
+++ b/token/js/src/actions/approveChecked.ts
@@ -10,7 +10,7 @@ import { getSigners } from './internal.js';
  *
  * @param connection     Connection to use
  * @param payer          Payer of the transaction fees
- * @param mint           Mint for the account
+ * @param mint           Address of the mint
  * @param account        Address of the account
  * @param delegate       Account authorized to perform a transfer tokens from the source account
  * @param owner          Owner of the source account

--- a/token/js/src/actions/approveChecked.ts
+++ b/token/js/src/actions/approveChecked.ts
@@ -10,6 +10,7 @@ import { getSigners } from './internal.js';
  *
  * @param connection     Connection to use
  * @param payer          Payer of the transaction fees
+ * @param mint           Mint for the account
  * @param account        Address of the account
  * @param delegate       Account authorized to perform a transfer tokens from the source account
  * @param owner          Owner of the source account


### PR DESCRIPTION
The documentation on the `approveChecked` function in `token/js/src/actions/approveChecked.ts` is missing the mint param.