### PR TITLE
stake-pool-js: Bump to 1.1.0 for release

### DIFF
--- a/stake-pool/js/package.json
+++ b/stake-pool/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana/spl-stake-pool",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "SPL Stake Pool Program JS API",
   "scripts": {
     "build": "tsc && cross-env NODE_ENV=production rollup -c",


### PR DESCRIPTION
#### Problem

There have been some additions to the stake pool JS library, but we haven't released them.

#### Solution

Bump the JS package to release it!