### PR TITLE
token-js: bump to 0.4.2 for release

### DIFF
--- a/token/js/package.json
+++ b/token/js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@solana/spl-token",
     "description": "SPL Token Program JS API",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "author": "Solana Labs Maintainers <maintainers@solanalabs.com>",
     "repository": "https://github.com/solana-labs/solana-program-library",
     "license": "Apache-2.0",


### PR DESCRIPTION
#### Problem

Thanks to @qiweiii, the `TokenGroup` and `TokenGroupMember` extensions are now available in `@solana/spl-token`, but we need to publish a release with the new features!

#### Solution
Ship it!