### PR TITLE
[token-js] Fix confidential transfer extensions account length

### DIFF
--- a/token/js/src/extensions/extensionType.ts
+++ b/token/js/src/extensions/extensionType.ts
@@ -77,9 +77,9 @@ export function getTypeLen(e: ExtensionType): number {
         case ExtensionType.MintCloseAuthority:
             return MINT_CLOSE_AUTHORITY_SIZE;
         case ExtensionType.ConfidentialTransferMint:
-            return 97;
+            return 65;
         case ExtensionType.ConfidentialTransferAccount:
-            return 286;
+            return 295;
         case ExtensionType.CpiGuard:
             return CPI_GUARD_SIZE;
         case ExtensionType.DefaultAccountState:


### PR DESCRIPTION
#### Problem
The confidential transfer extension in token-js has not been updated for a while. Currently, the wrong lengths for the confidential transfer mint and accounts are hard-coded in. Although confidential transfers are not yet supported in token-js, this could be quite confusing (e.g. https://github.com/solana-labs/solana-program-library/issues/6338).

#### Summary of changes
Hard-code the mint and account lengths with the correct number. These should be replaced with the `confidentialTransferMint.span` and `confidentialTransferAccount.span` as soon as wasm support for zk-token-sdk lands.