### PR TITLE
token-client: Add compute unit price and limit fields

### DIFF
--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -1110,6 +1110,7 @@ async fn confidential_transfer_transfer_with_fee() {
     let bob_meta = ConfidentialTokenAccountMeta::new(&token, &bob, None, false, true).await;
 
     // Self-transfer of 0 tokens
+    let token = token.with_compute_unit_limit(500_000);
     token
         .confidential_transfer_transfer_with_fee(
             &alice_meta.token_account,
@@ -2523,6 +2524,7 @@ async fn confidential_transfer_transfer_with_split_proof_contexts_in_parallel() 
         &range_proof_context_state_account,
         &context_state_authority,
     ];
+    let token = token.with_compute_unit_limit(500_000);
     token
         .confidential_transfer_transfer_with_split_proofs_in_parallel(
             &alice_meta.token_account,
@@ -2941,6 +2943,7 @@ async fn confidential_transfer_transfer_with_fee_and_split_proof_context_in_para
         &range_proof_context_state_account,
         &context_state_authority,
     ];
+    let token = token.with_compute_unit_limit(500_000);
     token
         .confidential_transfer_transfer_with_fee_and_split_proofs_in_parallel(
             &alice_meta.token_account,

--- a/token/program-2022-test/tests/confidential_transfer_fee.rs
+++ b/token/program-2022-test/tests/confidential_transfer_fee.rs
@@ -513,6 +513,7 @@ async fn confidential_transfer_withdraw_withheld_tokens_from_mint() {
     };
 
     // Test fee is 2.5% so the withheld fees should be 3
+    let token = token.with_compute_unit_limit(500_000);
     token
         .confidential_transfer_transfer_with_fee(
             &alice_meta.token_account,
@@ -671,6 +672,7 @@ async fn confidential_transfer_withdraw_withheld_tokens_from_accounts() {
     };
 
     // Test fee is 2.5% so the withheld fees should be 3
+    let token = token.with_compute_unit_limit(500_000);
     token
         .confidential_transfer_transfer_with_fee(
             &alice_meta.token_account,
@@ -801,6 +803,7 @@ async fn confidential_transfer_withdraw_withheld_tokens_from_mint_with_proof_con
     };
 
     // Test fee is 2.5% so the withheld fees should be 3
+    let token = token.with_compute_unit_limit(500_000);
     token
         .confidential_transfer_transfer_with_fee(
             &alice_meta.token_account,
@@ -969,6 +972,7 @@ async fn confidential_transfer_withdraw_withheld_tokens_from_accounts_with_proof
     };
 
     // Test fee is 2.5% so the withheld fees should be 3
+    let token = token.with_compute_unit_limit(500_000);
     token
         .confidential_transfer_transfer_with_fee(
             &alice_meta.token_account,
@@ -1159,6 +1163,7 @@ async fn confidential_transfer_harvest_withheld_tokens_to_mint() {
         .unwrap();
 
     // Test fee is 2.5% so the withheld fees should be 3
+    let token = token.with_compute_unit_limit(500_000);
     token
         .confidential_transfer_transfer_with_fee(
             &alice_meta.token_account,


### PR DESCRIPTION
#### Problem

The token-cli doesn't support priority fees.

#### Solution

As the first part of #6492, add the ability to specify a compute unit limit on the token-client directly.

Note: Some of the parts of setting the compute unit limit by hand in the tests can be removed once we dynamically calculate the compute unit limit based on simulation, for part 2 of #6492