### PR TITLE
stake-pool-cli: Add support for priority fees

### DIFF
--- a/stake-pool/cli/src/client.rs
+++ b/stake-pool/cli/src/client.rs
@@ -153,9 +153,6 @@ pub(crate) fn get_all_stake(
 
 /// Helper function to add a compute unit limit instruction to a given set
 /// of instructions
-///
-/// Returns true if the instruction was added, false if it wasn't. The false
-/// case is used for offline signing, where we cannot access the network.
 pub(crate) fn add_compute_unit_limit_from_simulation(
     rpc_client: &RpcClient,
     instructions: &mut Vec<Instruction>,

--- a/stake-pool/cli/src/client.rs
+++ b/stake-pool/cli/src/client.rs
@@ -7,7 +7,11 @@ use {
         rpc_config::{RpcAccountInfoConfig, RpcProgramAccountsConfig},
         rpc_filter::{Memcmp, RpcFilterType},
     },
-    solana_program::{borsh1::try_from_slice_unchecked, program_pack::Pack, pubkey::Pubkey, stake},
+    solana_program::{
+        borsh1::try_from_slice_unchecked, hash::Hash, instruction::Instruction, message::Message,
+        program_pack::Pack, pubkey::Pubkey, stake,
+    },
+    solana_sdk::{compute_budget::ComputeBudgetInstruction, transaction::Transaction},
     spl_stake_pool::{
         find_withdraw_authority_program_address,
         state::{StakePool, ValidatorList},
@@ -15,7 +19,7 @@ use {
     std::collections::HashSet,
 };
 
-type Error = Box<dyn std::error::Error>;
+pub(crate) type Error = Box<dyn std::error::Error>;
 
 pub fn get_stake_pool(
     rpc_client: &RpcClient,
@@ -145,4 +149,39 @@ pub(crate) fn get_all_stake(
         .into_iter()
         .map(|(address, _)| address)
         .collect())
+}
+
+/// Helper function to add a compute unit limit instruction to a given set
+/// of instructions
+///
+/// Returns true if the instruction was added, false if it wasn't. The false
+/// case is used for offline signing, where we cannot access the network.
+pub(crate) fn add_compute_unit_limit_from_simulation(
+    rpc_client: &RpcClient,
+    instructions: &mut Vec<Instruction>,
+    payer: &Pubkey,
+    blockhash: &Hash,
+) -> Result<(), Error> {
+    // add a max compute unit limit instruction for the simulation
+    const MAX_COMPUTE_UNIT_LIMIT: u32 = 1_400_000;
+    instructions.push(ComputeBudgetInstruction::set_compute_unit_limit(
+        MAX_COMPUTE_UNIT_LIMIT,
+    ));
+
+    let transaction = Transaction::new_unsigned(Message::new_with_blockhash(
+        instructions,
+        Some(payer),
+        blockhash,
+    ));
+    let simulation_result = rpc_client.simulate_transaction(&transaction)?.value;
+    let units_consumed = simulation_result
+        .units_consumed
+        .ok_or("No units consumed on simulation")?;
+    // Overwrite the compute unit limit instruction with the actual units consumed
+    let compute_unit_limit = u32::try_from(units_consumed)?;
+    instructions
+        .last_mut()
+        .expect("Compute budget instruction was added earlier")
+        .data = ComputeBudgetInstruction::set_compute_unit_limit(compute_unit_limit).data;
+    Ok(())
 }

--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -68,7 +68,6 @@ pub(crate) struct Config {
     no_update: bool,
 }
 
-type Error = Box<dyn std::error::Error>;
 type CommandResult = Result<(), Error>;
 
 const STAKE_STATE_LEN: usize = 200;

--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -2004,7 +2004,7 @@ fn main() {
                 .global(true)
                 .help("Transaction fee payer account [default: cli config keypair]"),
         )
-        .arg(compute_unit_price_arg().validator(is_parsable::<u64>))
+        .arg(compute_unit_price_arg().validator(is_parsable::<u64>).global(true))
         .arg(
             Arg::with_name(COMPUTE_UNIT_LIMIT_ARG.name)
                 .long(COMPUTE_UNIT_LIMIT_ARG.long)
@@ -2012,6 +2012,7 @@ fn main() {
                 .value_name("COMPUTE-UNIT-LIMIT")
                 .help(COMPUTE_UNIT_LIMIT_ARG.help)
                 .validator(is_parsable::<u32>)
+                .global(true)
         )
         .subcommand(SubCommand::with_name("create-pool")
             .about("Create a new stake pool")


### PR DESCRIPTION
#### Problem

Due to network congestion mainnet and the lack of priority fee support, stake pool users can't interact with their pool on mainnet.

#### Solution

A few things to provide a full solution:

* Add `--with-compute-unit-price` flag to set micro-lamports per CU for all transactions in a command
* Add `--with-compute-unit-limit` flag to set the number of CUs for all transactions in a command
* If `--with-compute-unit-limit` is not set, simulate the transaction and use the number of compute units reported

As part of this, the idea is to funnel all transaction creation through `checked_transaction_with_signer` or `checked_transaction_with_signers_and_additional_fee`, which will do the simulation work and add the compute budget instructions.

Since there is some refactor, it might be easier to go through this commit by commit.