### PR TITLE
token-client: Use transaction simulation results for the compute unit limit

### DIFF
--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -1110,7 +1110,6 @@ async fn confidential_transfer_transfer_with_fee() {
     let bob_meta = ConfidentialTokenAccountMeta::new(&token, &bob, None, false, true).await;
 
     // Self-transfer of 0 tokens
-    let token = token.with_compute_unit_limit(500_000);
     token
         .confidential_transfer_transfer_with_fee(
             &alice_meta.token_account,
@@ -2524,6 +2523,9 @@ async fn confidential_transfer_transfer_with_split_proof_contexts_in_parallel() 
         &range_proof_context_state_account,
         &context_state_authority,
     ];
+    // With split proofs in parallel, one of the transactions does more work
+    // than the other, which isn't caught during the simulation to discover the
+    // compute unit limit.
     let token = token.with_compute_unit_limit(500_000);
     token
         .confidential_transfer_transfer_with_split_proofs_in_parallel(
@@ -2943,6 +2945,9 @@ async fn confidential_transfer_transfer_with_fee_and_split_proof_context_in_para
         &range_proof_context_state_account,
         &context_state_authority,
     ];
+    // With split proofs in parallel, one of the transactions does more work
+    // than the other, which isn't caught during the simulation to discover the
+    // compute unit limit.
     let token = token.with_compute_unit_limit(500_000);
     token
         .confidential_transfer_transfer_with_fee_and_split_proofs_in_parallel(

--- a/token/program-2022-test/tests/confidential_transfer_fee.rs
+++ b/token/program-2022-test/tests/confidential_transfer_fee.rs
@@ -513,7 +513,6 @@ async fn confidential_transfer_withdraw_withheld_tokens_from_mint() {
     };
 
     // Test fee is 2.5% so the withheld fees should be 3
-    let token = token.with_compute_unit_limit(500_000);
     token
         .confidential_transfer_transfer_with_fee(
             &alice_meta.token_account,
@@ -672,7 +671,6 @@ async fn confidential_transfer_withdraw_withheld_tokens_from_accounts() {
     };
 
     // Test fee is 2.5% so the withheld fees should be 3
-    let token = token.with_compute_unit_limit(500_000);
     token
         .confidential_transfer_transfer_with_fee(
             &alice_meta.token_account,
@@ -803,7 +801,6 @@ async fn confidential_transfer_withdraw_withheld_tokens_from_mint_with_proof_con
     };
 
     // Test fee is 2.5% so the withheld fees should be 3
-    let token = token.with_compute_unit_limit(500_000);
     token
         .confidential_transfer_transfer_with_fee(
             &alice_meta.token_account,
@@ -972,7 +969,6 @@ async fn confidential_transfer_withdraw_withheld_tokens_from_accounts_with_proof
     };
 
     // Test fee is 2.5% so the withheld fees should be 3
-    let token = token.with_compute_unit_limit(500_000);
     token
         .confidential_transfer_transfer_with_fee(
             &alice_meta.token_account,
@@ -1163,7 +1159,6 @@ async fn confidential_transfer_harvest_withheld_tokens_to_mint() {
         .unwrap();
 
     // Test fee is 2.5% so the withheld fees should be 3
-    let token = token.with_compute_unit_limit(500_000);
     token
         .confidential_transfer_transfer_with_fee(
             &alice_meta.token_account,


### PR DESCRIPTION
#### Problem

As part of #6492, the token-cli doesn't support priority fees. Currently, the token-client allows for setting a compute unit price and limit, but that requires users to know the compute units used by their transaction.

#### Solution

Transaction simulation gives the compute units used by a transaction, so instead of asking users to provide a number, we can be a bit smarter and use simulation results to set the compute unit limit used by a transaction.

We also need to support offline signing, which cannot simulate transactions. In this PR, the token client fails to extract the compute units used by the transaction after the offline "simulation", and thus uses the default limit of 200k * num_top_level_instructions.

A user-provided value for `compute_unit_limit` always takes precedence, so offline signing can use a hardcoded number if a compute unit limit is desired.

Note: the range proofs for confidential transfers are so close to the transaction size limit that we can't add any other instructions to the transaction, so those are created and sent without the helpers