### PR TITLE
token-cli: Add priority fee args

### DIFF
--- a/token/cli/src/clap_app.rs
+++ b/token/cli/src/clap_app.rs
@@ -64,6 +64,18 @@ pub const MULTISIG_SIGNER_ARG: ArgConstant<'static> = ArgConstant {
     help: "Member signer of a multisig account",
 };
 
+pub const COMPUTE_UNIT_PRICE_ARG: ArgConstant<'static> = ArgConstant {
+    name: "compute_unit_price",
+    long: "--with-compute-unit-price",
+    help: "Set compute unit price for transaction, in increments of 0.000001 lamports per compute unit.",
+};
+
+pub const COMPUTE_UNIT_LIMIT_ARG: ArgConstant<'static> = ArgConstant {
+    name: "compute_unit_limit",
+    long: "--with-compute-unit-limit",
+    help: "Set compute unit limit for transaction, in compute units.",
+};
+
 pub static VALID_TOKEN_PROGRAM_IDS: [Pubkey; 2] = [spl_token_2022::ID, spl_token::ID];
 
 #[derive(Debug, Clone, Copy, PartialEq, EnumString, IntoStaticStr)]
@@ -610,6 +622,22 @@ pub fn app<'a, 'b>(
                 .global(true)
                 .hidden(true)
                 .help("Use unchecked instruction if appropriate. Supports transfer, burn, mint, and approve."),
+        )
+        .arg(
+            Arg::with_name(COMPUTE_UNIT_LIMIT_ARG.name)
+                .long(COMPUTE_UNIT_LIMIT_ARG.long)
+                .takes_value(true)
+                .value_name("COMPUTE-UNIT-LIMIT")
+                .validator(is_parsable::<u32>)
+                .help(COMPUTE_UNIT_LIMIT_ARG.help)
+        )
+        .arg(
+            Arg::with_name(COMPUTE_UNIT_PRICE_ARG.name)
+                .long(COMPUTE_UNIT_PRICE_ARG.long)
+                .takes_value(true)
+                .value_name("COMPUTE-UNIT-PRICE")
+                .validator(is_parsable::<u64>)
+                .help(COMPUTE_UNIT_PRICE_ARG.help)
         )
         .bench_subcommand()
         .subcommand(SubCommand::with_name(CommandName::CreateToken.into()).about("Create a new token")

--- a/token/cli/src/command.rs
+++ b/token/cli/src/command.rs
@@ -147,6 +147,18 @@ fn token_client_from_config(
         config.fee_payer()?.clone(),
     );
 
+    let token = if let Some(compute_unit_limit) = config.compute_unit_limit {
+        token.with_compute_unit_limit(compute_unit_limit)
+    } else {
+        token
+    };
+
+    let token = if let Some(compute_unit_price) = config.compute_unit_price {
+        token.with_compute_unit_price(compute_unit_price)
+    } else {
+        token
+    };
+
     if let (Some(nonce_account), Some(nonce_authority), Some(nonce_blockhash)) = (
         config.nonce_account,
         &config.nonce_authority,

--- a/token/cli/src/config.rs
+++ b/token/cli/src/config.rs
@@ -1,5 +1,5 @@
 use {
-    crate::clap_app::{Error, MULTISIG_SIGNER_ARG},
+    crate::clap_app::{Error, COMPUTE_UNIT_LIMIT_ARG, COMPUTE_UNIT_PRICE_ARG, MULTISIG_SIGNER_ARG},
     clap::ArgMatches,
     solana_clap_utils::{
         input_parsers::{pubkey_of_signer, value_of},
@@ -67,6 +67,8 @@ pub struct Config<'a> {
     pub multisigner_pubkeys: Vec<&'a Pubkey>,
     pub program_id: Pubkey,
     pub restrict_to_program_id: bool,
+    pub compute_unit_price: Option<u64>,
+    pub compute_unit_limit: Option<u32>,
 }
 
 impl<'a> Config<'a> {
@@ -279,6 +281,8 @@ impl<'a> Config<'a> {
             };
 
         let nonce_blockhash = value_of(matches, BLOCKHASH_ARG.name);
+        let compute_unit_price = value_of(matches, COMPUTE_UNIT_PRICE_ARG.name);
+        let compute_unit_limit = value_of(matches, COMPUTE_UNIT_LIMIT_ARG.name);
         Self {
             default_signer,
             rpc_client,
@@ -294,6 +298,8 @@ impl<'a> Config<'a> {
             multisigner_pubkeys,
             program_id,
             restrict_to_program_id,
+            compute_unit_price,
+            compute_unit_limit,
         }
     }
 


### PR DESCRIPTION
#### Problem

As the last part of #6492, the token-cli isn't using the new fields for setting the compute unit price and limit.

#### Solution

Pipe them down into the token client, and that's pretty much it!

There's also a refactor for the `transfer` test so that the `compute_budget` test can use it directly, without any change in behavior.

Note that this copies `COMPUTE_UNIT_PRICE_ARG` from clap-utils rather than importing. I made this choice because #6376 updates to clap-v3, which doesn't have any compute budget helpers. I've put in a PR to add them to clap-v3 at https://github.com/anza-xyz/agave/pull/440