### PR TITLE
bump: Bump everything up for new token cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6835,7 +6835,7 @@ dependencies = [
 
 [[package]]
 name = "spl-associated-token-account"
-version = "2.3.1"
+version = "3.0.0"
 dependencies = [
  "assert_matches",
  "borsh 1.2.1",
@@ -6843,7 +6843,7 @@ dependencies = [
  "num-traits",
  "solana-program",
  "spl-token 4.0.1",
- "spl-token-2022 2.0.2",
+ "spl-token-2022 3.0.0",
  "thiserror",
 ]
 
@@ -6854,9 +6854,9 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 2.3.1",
+ "spl-associated-token-account 3.0.0",
  "spl-token 4.0.1",
- "spl-token-2022 2.0.2",
+ "spl-token-2022 3.0.0",
 ]
 
 [[package]]
@@ -7179,7 +7179,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 2.3.1",
+ "spl-associated-token-account 3.0.0",
  "spl-token 4.0.1",
  "thiserror",
 ]
@@ -7254,7 +7254,7 @@ dependencies = [
 
 [[package]]
 name = "spl-pod"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "base64 0.22.0",
  "borsh 1.2.1",
@@ -7325,7 +7325,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-pod 0.1.1",
+ "spl-pod 0.1.2",
  "thiserror",
 ]
 
@@ -7356,7 +7356,7 @@ dependencies = [
  "solana-sdk",
  "solana-security-txt",
  "solana-vote-program",
- "spl-associated-token-account 2.3.1",
+ "spl-associated-token-account 3.0.0",
  "spl-token 4.0.1",
  "test-case",
  "thiserror",
@@ -7386,7 +7386,7 @@ dependencies = [
  "solana-test-validator",
  "solana-transaction-status",
  "solana-vote-program",
- "spl-associated-token-account 2.3.1",
+ "spl-associated-token-account 3.0.0",
  "spl-single-pool",
  "spl-token 4.0.1",
  "spl-token-client",
@@ -7416,9 +7416,9 @@ dependencies = [
  "solana-security-txt",
  "solana-vote-program",
  "spl-math",
- "spl-pod 0.1.1",
+ "spl-pod 0.1.2",
  "spl-token 4.0.1",
- "spl-token-2022 2.0.2",
+ "spl-token-2022 3.0.0",
  "test-case",
  "thiserror",
 ]
@@ -7443,7 +7443,7 @@ dependencies = [
  "solana-program",
  "solana-remote-wallet",
  "solana-sdk",
- "spl-associated-token-account 2.3.1",
+ "spl-associated-token-account 3.0.0",
  "spl-stake-pool",
  "spl-token 4.0.1",
 ]
@@ -7461,7 +7461,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-discriminator 0.1.1",
- "spl-pod 0.1.1",
+ "spl-pod 0.1.2",
  "spl-program-error 0.3.1",
  "spl-type-length-value 0.3.1",
 ]
@@ -7539,7 +7539,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-2022"
-version = "2.0.2"
+version = "3.0.0"
 dependencies = [
  "arrayref",
  "base64 0.22.0",
@@ -7559,7 +7559,7 @@ dependencies = [
  "solana-security-txt",
  "solana-zk-token-sdk",
  "spl-memo 4.0.1",
- "spl-pod 0.1.1",
+ "spl-pod 0.1.2",
  "spl-tlv-account-resolution 0.5.2",
  "spl-token 4.0.1",
  "spl-token-group-interface 0.1.1",
@@ -7579,12 +7579,12 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 2.3.1",
+ "spl-associated-token-account 3.0.0",
  "spl-instruction-padding",
  "spl-memo 4.0.1",
- "spl-pod 0.1.1",
+ "spl-pod 0.1.2",
  "spl-tlv-account-resolution 0.5.2",
- "spl-token-2022 2.0.2",
+ "spl-token-2022 3.0.0",
  "spl-token-client",
  "spl-token-group-interface 0.1.1",
  "spl-token-metadata-interface 0.2.1",
@@ -7596,7 +7596,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-cli"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "assert_cmd",
  "base64 0.22.0",
@@ -7618,10 +7618,10 @@ dependencies = [
  "solana-sdk",
  "solana-test-validator",
  "solana-transaction-status",
- "spl-associated-token-account 2.3.1",
+ "spl-associated-token-account 3.0.0",
  "spl-memo 4.0.1",
  "spl-token 4.0.1",
- "spl-token-2022 2.0.2",
+ "spl-token-2022 3.0.0",
  "spl-token-client",
  "spl-token-group-interface 0.1.1",
  "spl-token-metadata-interface 0.2.1",
@@ -7634,7 +7634,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-client"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "curve25519-dalek",
@@ -7646,10 +7646,10 @@ dependencies = [
  "solana-rpc-client",
  "solana-rpc-client-api",
  "solana-sdk",
- "spl-associated-token-account 2.3.1",
+ "spl-associated-token-account 3.0.0",
  "spl-memo 4.0.1",
  "spl-token 4.0.1",
- "spl-token-2022 2.0.2",
+ "spl-token-2022 3.0.0",
  "spl-token-group-interface 0.1.1",
  "spl-token-metadata-interface 0.2.1",
  "spl-transfer-hook-interface 0.5.1",
@@ -7664,9 +7664,9 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-discriminator 0.1.1",
- "spl-pod 0.1.1",
+ "spl-pod 0.1.2",
  "spl-program-error 0.3.1",
- "spl-token-2022 2.0.2",
+ "spl-token-2022 3.0.0",
  "spl-token-client",
  "spl-token-group-example",
  "spl-token-group-interface 0.1.1",
@@ -7682,8 +7682,8 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-discriminator 0.1.1",
- "spl-pod 0.1.1",
- "spl-token-2022 2.0.2",
+ "spl-pod 0.1.2",
+ "spl-token-2022 3.0.0",
  "spl-token-client",
  "spl-token-group-interface 0.1.1",
  "spl-token-metadata-interface 0.2.1",
@@ -7710,7 +7710,7 @@ dependencies = [
  "bytemuck",
  "solana-program",
  "spl-discriminator 0.1.1",
- "spl-pod 0.1.1",
+ "spl-pod 0.1.2",
  "spl-program-error 0.3.1",
  "spl-type-length-value 0.3.1",
 ]
@@ -7755,8 +7755,8 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-pod 0.1.1",
- "spl-token-2022 2.0.2",
+ "spl-pod 0.1.2",
+ "spl-token-2022 3.0.0",
  "spl-token-client",
  "spl-token-metadata-interface 0.2.1",
  "spl-type-length-value 0.3.1",
@@ -7786,7 +7786,7 @@ dependencies = [
  "serde_json",
  "solana-program",
  "spl-discriminator 0.1.1",
- "spl-pod 0.1.1",
+ "spl-pod 0.1.2",
  "spl-program-error 0.3.1",
  "spl-type-length-value 0.3.1",
 ]
@@ -7806,7 +7806,7 @@ dependencies = [
  "solana-sdk",
  "spl-math",
  "spl-token 4.0.1",
- "spl-token-2022 2.0.2",
+ "spl-token-2022 3.0.0",
  "test-case",
  "thiserror",
 ]
@@ -7834,7 +7834,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-token 4.0.1",
- "spl-token-2022 2.0.2",
+ "spl-token-2022 3.0.0",
  "spl-token-client",
  "test-case",
  "thiserror",
@@ -7853,9 +7853,9 @@ dependencies = [
  "solana-remote-wallet",
  "solana-sdk",
  "solana-test-validator",
- "spl-associated-token-account 2.3.1",
+ "spl-associated-token-account 3.0.0",
  "spl-token 4.0.1",
- "spl-token-2022 2.0.2",
+ "spl-token-2022 3.0.0",
  "spl-token-client",
  "spl-token-upgrade",
  "tokio",
@@ -7869,9 +7869,9 @@ dependencies = [
  "bytemuck",
  "num_enum 0.7.2",
  "solana-program",
- "spl-associated-token-account 2.3.1",
+ "spl-associated-token-account 3.0.0",
  "spl-token 4.0.1",
- "spl-token-2022 2.0.2",
+ "spl-token-2022 3.0.0",
  "thiserror",
 ]
 
@@ -7892,7 +7892,7 @@ dependencies = [
  "solana-sdk",
  "solana-test-validator",
  "spl-tlv-account-resolution 0.5.2",
- "spl-token-2022 2.0.2",
+ "spl-token-2022 3.0.0",
  "spl-token-client",
  "spl-transfer-hook-interface 0.5.1",
  "strum 0.26.2",
@@ -7909,7 +7909,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-tlv-account-resolution 0.5.2",
- "spl-token-2022 2.0.2",
+ "spl-token-2022 3.0.0",
  "spl-transfer-hook-interface 0.5.1",
  "spl-type-length-value 0.3.1",
 ]
@@ -7938,7 +7938,7 @@ dependencies = [
  "bytemuck",
  "solana-program",
  "spl-discriminator 0.1.1",
- "spl-pod 0.1.1",
+ "spl-pod 0.1.2",
  "spl-program-error 0.3.1",
  "spl-tlv-account-resolution 0.5.2",
  "spl-type-length-value 0.3.1",
@@ -7965,7 +7965,7 @@ dependencies = [
  "bytemuck",
  "solana-program",
  "spl-discriminator 0.1.1",
- "spl-pod 0.1.1",
+ "spl-pod 0.1.2",
  "spl-program-error 0.3.1",
  "spl-type-length-value-derive",
 ]
@@ -7997,7 +7997,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 2.3.1",
+ "spl-associated-token-account 3.0.0",
  "spl-token 4.0.1",
  "thiserror",
 ]

--- a/associated-token-account/program-test/Cargo.toml
+++ b/associated-token-account/program-test/Cargo.toml
@@ -14,6 +14,6 @@ test-sbf = []
 solana-program = ">=1.18.2,<=2"
 solana-program-test = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
-spl-associated-token-account = { version = "2", path = "../program", features = ["no-entrypoint"] }
+spl-associated-token-account = { version = "3.0", path = "../program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "2.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }

--- a/associated-token-account/program/Cargo.toml
+++ b/associated-token-account/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-associated-token-account"
-version = "2.3.1"
+version = "3.0.0"
 description = "Solana Program Library Associated Token Account"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -20,7 +20,7 @@ solana-program = ">=1.18.2,<=2"
 spl-token = { version = "4.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
-spl-token-2022 = { version = "2.0", path = "../../token/program-2022", features = [
+spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = [
   "no-entrypoint",
 ] }
 thiserror = "1.0"

--- a/libraries/pod/Cargo.toml
+++ b/libraries/pod/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-pod"
-version = "0.1.1"
+version = "0.1.2"
 description = "Solana Program Library Plain Old Data (Pod)"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/managed-token/program/Cargo.toml
+++ b/managed-token/program/Cargo.toml
@@ -25,7 +25,7 @@ test = []
 borsh = "1.2.1"
 shank = "^0.4.2"
 solana-program = ">=1.18.2,<=2"
-spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = [
+spl-associated-token-account = { version = "3.0", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }
 spl-token = { version = "4.0", path = "../../token/program", features = [

--- a/single-pool/cli/Cargo.toml
+++ b/single-pool/cli/Cargo.toml
@@ -31,7 +31,7 @@ spl-token = { version = "4.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
 spl-token-client = { version = "0.8", path = "../../token/client" }
-spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = [
+spl-associated-token-account = { version = "3.0", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }
 spl-single-pool = { version = "1.0.0", path = "../program", features = [

--- a/single-pool/program/Cargo.toml
+++ b/single-pool/program/Cargo.toml
@@ -22,7 +22,7 @@ solana-security-txt = "1.1.1"
 spl-token = { version = "4.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
-spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = [
+spl-associated-token-account = { version = "3.0", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }
 thiserror = "1.0"

--- a/stake-pool/cli/Cargo.toml
+++ b/stake-pool/cli/Cargo.toml
@@ -23,7 +23,7 @@ solana-logger = ">=1.18.2,<=2"
 solana-program = ">=1.18.2,<=2"
 solana-remote-wallet = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
-spl-associated-token-account = { version = "=2.3", path = "../../associated-token-account/program", features = [
+spl-associated-token-account = { version = "=3.0", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }
 spl-stake-pool = { version = "=1.0.0", path = "../program", features = [

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -28,7 +28,7 @@ spl-math = { version = "0.2", path = "../../libraries/math", features = [
 spl-pod = { version = "0.1", path = "../../libraries/pod", features = [
   "borsh",
 ] }
-spl-token-2022 = { version = "2.0", path = "../../token/program-2022", features = [
+spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = [
   "no-entrypoint",
 ] }
 thiserror = "1.0"

--- a/stateless-asks/program/Cargo.toml
+++ b/stateless-asks/program/Cargo.toml
@@ -16,7 +16,7 @@ solana-program = ">=1.18.2,<=2"
 spl-token = { version = "4.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
-spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = [
+spl-associated-token-account = { version = "3.0", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }
 thiserror = "1.0"

--- a/token-collection/program/Cargo.toml
+++ b/token-collection/program/Cargo.toml
@@ -15,7 +15,7 @@ test-sbf = []
 solana-program = ">=1.18.2,<=2"
 spl-pod = { version = "0.1.1", path = "../../libraries/pod" }
 spl-program-error = { version = "0.3.1" , path = "../../libraries/program-error" }
-spl-token-2022 = { version = "2.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-group-example = { version = "0.1.0", path = "../../token-group/example", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.1.1", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }

--- a/token-group/example/Cargo.toml
+++ b/token-group/example/Cargo.toml
@@ -14,7 +14,7 @@ test-sbf = []
 [dependencies]
 solana-program = ">=1.18.2,<=2"
 spl-pod = { version = "0.1.1", path = "../../libraries/pod" }
-spl-token-2022 = { version = "2.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.1.1", path = "../interface" }
 spl-type-length-value = { version = "0.3.1", path = "../../libraries/type-length-value" }
 

--- a/token-metadata/example/Cargo.toml
+++ b/token-metadata/example/Cargo.toml
@@ -13,7 +13,7 @@ test-sbf = []
 
 [dependencies]
 solana-program = ">=1.18.2,<=2"
-spl-token-2022 = { version = "2.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-metadata-interface = { version = "0.2.1", path = "../interface" }
 spl-type-length-value = { version = "0.3.1" , path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.1.1", path = "../../libraries/pod" }

--- a/token-swap/program/Cargo.toml
+++ b/token-swap/program/Cargo.toml
@@ -20,7 +20,7 @@ num-traits = "0.2"
 solana-program = ">=1.18.2,<=2"
 spl-math = { version = "0.2", path = "../../libraries/math", features = [ "no-entrypoint" ] }
 spl-token = { version = "4.0", path = "../../token/program", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "2.0", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
+spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 arbitrary = { version = "1.3", features = ["derive"], optional = true }
 roots = { version = "0.0.8", optional = true }

--- a/token-upgrade/cli/Cargo.toml
+++ b/token-upgrade/cli/Cargo.toml
@@ -19,9 +19,9 @@ solana-client = ">=1.18.2,<=2"
 solana-logger = ">=1.18.2,<=2"
 solana-remote-wallet = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
-spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
+spl-associated-token-account = { version = "3.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "2.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.8", path = "../../token/client" }
 spl-token-upgrade = { version = "0.1", path = "../program", features = ["no-entrypoint"] }
 tokio = { version = "1", features = ["full"] }

--- a/token-upgrade/program/Cargo.toml
+++ b/token-upgrade/program/Cargo.toml
@@ -16,7 +16,7 @@ num-derive = "0.4"
 num-traits = "0.2"
 num_enum = "0.7.2"
 solana-program = ">=1.18.2,<=2"
-spl-token-2022 = { version = "2.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/token-wrap/program/Cargo.toml
+++ b/token-wrap/program/Cargo.toml
@@ -15,9 +15,9 @@ test-sbf = []
 bytemuck = { version = "1.15.0", features = ["derive"] }
 num_enum = "0.7"
 solana-program = ">=1.18.2,<=2"
-spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
+spl-associated-token-account = { version = "3.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "2.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [lib]

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://spl.solana.com/token"
 license = "Apache-2.0"
 name = "spl-token-cli"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "3.3.0"
+version = "3.4.0"
 
 [build-dependencies]
 walkdir = "2"
@@ -31,13 +31,13 @@ solana-transaction-status = ">=1.18.2,<=2"
 spl-token = { version = "4.0", path = "../program", features = [
   "no-entrypoint",
 ] }
-spl-token-2022 = { version = "2.0", path = "../program-2022", features = [
+spl-token-2022 = { version = "3.0", path = "../program-2022", features = [
   "no-entrypoint",
 ] }
 spl-token-client = { version = "0.8", path = "../client" }
 spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }
 spl-token-group-interface = { version = "0.1", path = "../../token-group/interface" }
-spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = [
+spl-associated-token-account = { version = "3.0", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }
 spl-memo = { version = "4.0.1", path = "../../memo/program", features = [

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "spl-token-client"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "0.8.0"
+version = "0.8.1"
 
 [dependencies]
 async-trait = "0.1"
@@ -20,7 +20,7 @@ solana-rpc-client-api = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
 # We never want the entrypoint for ATA, but we want the entrypoint for token when
 # testing token
-spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program", features = [
+spl-associated-token-account = { version = "3.0", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }
 spl-memo = { version = "4.0.1", path = "../../memo/program", features = [
@@ -29,7 +29,7 @@ spl-memo = { version = "4.0.1", path = "../../memo/program", features = [
 spl-token = { version = "4.0", path = "../program", features = [
   "no-entrypoint",
 ] }
-spl-token-2022 = { version = "2.0", path = "../program-2022" }
+spl-token-2022 = { version = "3.0", path = "../program-2022" }
 spl-token-group-interface = { version = "0.1", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }
 spl-transfer-hook-interface = { version = "0.5", path = "../transfer-hook/interface" }

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -22,12 +22,12 @@ futures-util = "0.3"
 solana-program = ">=1.18.2,<=2"
 solana-program-test = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
-spl-associated-token-account = { version = "2.0", path = "../../associated-token-account/program" }
+spl-associated-token-account = { version = "3.0", path = "../../associated-token-account/program" }
 spl-memo = { version = "4.0.1", path = "../../memo/program", features = [
   "no-entrypoint",
 ] }
 spl-pod = { version = "0.1.1", path = "../../libraries/pod" }
-spl-token-2022 = { version = "2.0", path = "../program-2022", features = [
+spl-token-2022 = { version = "3.0", path = "../program-2022", features = [
   "no-entrypoint",
 ] }
 spl-instruction-padding = { version = "0.1.1", path = "../../instruction-padding/program", features = [

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-2022"
-version = "2.0.2"
+version = "3.0.0"
 description = "Solana Program Library Token 2022"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -35,7 +35,7 @@ spl-token-group-interface = { version = "0.1", path = "../../token-group/interfa
 spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }
 spl-transfer-hook-interface = { version = "0.5.1", path = "../transfer-hook/interface" }
 spl-type-length-value = { version = "0.3.1", path = "../../libraries/type-length-value" }
-spl-pod = { version = "0.1.1", path = "../../libraries/pod" }
+spl-pod = { version = "0.1", path = "../../libraries/pod" }
 thiserror = "1.0"
 serde = { version = "1.0.197", optional = true }
 serde_with = { version = "3.7.0", optional = true }

--- a/token/transfer-hook/cli/Cargo.toml
+++ b/token/transfer-hook/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
-description = "SPL-Token Command-line Utility"
+description = "SPL Transfer Hook Command-line Utility"
 edition = "2021"
 homepage = "https://spl.solana.com/token"
 license = "Apache-2.0"
@@ -28,7 +28,7 @@ serde_yaml = "0.9.34"
 
 [dev-dependencies]
 solana-test-validator = ">=1.18.2,<=2"
-spl-token-2022 = { version = "2.0", path = "../../program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "3.0", path = "../../program-2022", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.8", path = "../../client" }
 
 [[bin]]

--- a/token/transfer-hook/example/Cargo.toml
+++ b/token/transfer-hook/example/Cargo.toml
@@ -15,7 +15,7 @@ test-sbf = []
 arrayref = "0.3.7"
 solana-program = ">=1.18.2,<=2"
 spl-tlv-account-resolution = { version = "0.5" , path = "../../../libraries/tlv-account-resolution" }
-spl-token-2022 = { version = "2.0",  path = "../../program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "3.0",  path = "../../program-2022", features = ["no-entrypoint"] }
 spl-transfer-hook-interface = { version = "0.5" , path = "../interface" }
 spl-type-length-value = { version = "0.3" , path = "../../../libraries/type-length-value" }
 


### PR DESCRIPTION
#### Problem

We need to get a new token cli release out to go with the next 1.18 release, since it includes priority fees.

#### Solution

Bump everything needed for token-cli:

* token-cli
* token-client
* token-2022 (major because of breaking changes)
* associated-token-account (major because of new borsh version)
* pod (needed for new constructors)

I was worried that the major version bump on token-2022 would be an absolute horror, but it was pretty ok!