### PR TITLE
ProgramClient : add Send and Sync maker  trait

### DIFF
--- a/token/client/src/client.rs
+++ b/token/client/src/client.rs
@@ -192,7 +192,7 @@ pub type ProgramClientResult<T> = Result<T, ProgramClientError>;
 
 /// Generic client interface for programs.
 #[async_trait]
-pub trait ProgramClient<ST>
+pub trait ProgramClient<ST>: Send + Sync
 where
     ST: SendTransaction + SimulateTransaction,
 {


### PR DESCRIPTION
I plan to use ProgramClient to build a service, which is a multi-threaded service. However, the current design prevents ProgramClient from being sent or shared directly between multiple threads. Therefore, I have added these two markers to the trait.