### PR TITLE
various: Bump crates required to get a semver-compatible token-cli release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7634,7 +7634,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-client"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "curve25519-dalek",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7676,7 +7676,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-group-example"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "solana-program",
  "solana-program-test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7463,7 +7463,7 @@ dependencies = [
  "spl-discriminator 0.1.1",
  "spl-pod 0.2.0",
  "spl-program-error 0.3.1",
- "spl-type-length-value 0.3.1",
+ "spl-type-length-value 0.4.0",
 ]
 
 [[package]]
@@ -7565,7 +7565,7 @@ dependencies = [
  "spl-token-group-interface 0.1.1",
  "spl-token-metadata-interface 0.2.1",
  "spl-transfer-hook-interface 0.5.1",
- "spl-type-length-value 0.3.1",
+ "spl-type-length-value 0.4.0",
  "thiserror",
 ]
 
@@ -7671,7 +7671,7 @@ dependencies = [
  "spl-token-group-example",
  "spl-token-group-interface 0.1.1",
  "spl-token-metadata-interface 0.2.1",
- "spl-type-length-value 0.3.1",
+ "spl-type-length-value 0.4.0",
 ]
 
 [[package]]
@@ -7687,7 +7687,7 @@ dependencies = [
  "spl-token-client",
  "spl-token-group-interface 0.1.1",
  "spl-token-metadata-interface 0.2.1",
- "spl-type-length-value 0.3.1",
+ "spl-type-length-value 0.4.0",
 ]
 
 [[package]]
@@ -7712,7 +7712,7 @@ dependencies = [
  "spl-discriminator 0.1.1",
  "spl-pod 0.2.0",
  "spl-program-error 0.3.1",
- "spl-type-length-value 0.3.1",
+ "spl-type-length-value 0.4.0",
 ]
 
 [[package]]
@@ -7759,7 +7759,7 @@ dependencies = [
  "spl-token-2022 3.0.0",
  "spl-token-client",
  "spl-token-metadata-interface 0.2.1",
- "spl-type-length-value 0.3.1",
+ "spl-type-length-value 0.4.0",
  "test-case",
 ]
 
@@ -7788,7 +7788,7 @@ dependencies = [
  "spl-discriminator 0.1.1",
  "spl-pod 0.2.0",
  "spl-program-error 0.3.1",
- "spl-type-length-value 0.3.1",
+ "spl-type-length-value 0.4.0",
 ]
 
 [[package]]
@@ -7911,7 +7911,7 @@ dependencies = [
  "spl-tlv-account-resolution 0.5.2",
  "spl-token-2022 3.0.0",
  "spl-transfer-hook-interface 0.5.1",
- "spl-type-length-value 0.3.1",
+ "spl-type-length-value 0.4.0",
 ]
 
 [[package]]
@@ -7941,7 +7941,7 @@ dependencies = [
  "spl-pod 0.2.0",
  "spl-program-error 0.3.1",
  "spl-tlv-account-resolution 0.5.2",
- "spl-type-length-value 0.3.1",
+ "spl-type-length-value 0.4.0",
  "tokio",
 ]
 
@@ -7960,7 +7960,7 @@ dependencies = [
 
 [[package]]
 name = "spl-type-length-value"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "bytemuck",
  "solana-program",
@@ -7986,7 +7986,7 @@ dependencies = [
  "borsh 1.2.1",
  "solana-program",
  "spl-discriminator 0.1.1",
- "spl-type-length-value 0.3.1",
+ "spl-type-length-value 0.4.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7564,7 +7564,7 @@ dependencies = [
  "spl-token 4.0.1",
  "spl-token-group-interface 0.2.0",
  "spl-token-metadata-interface 0.3.0",
- "spl-transfer-hook-interface 0.5.1",
+ "spl-transfer-hook-interface 0.6.0",
  "spl-type-length-value 0.4.0",
  "thiserror",
 ]
@@ -7589,7 +7589,7 @@ dependencies = [
  "spl-token-group-interface 0.2.0",
  "spl-token-metadata-interface 0.3.0",
  "spl-transfer-hook-example",
- "spl-transfer-hook-interface 0.5.1",
+ "spl-transfer-hook-interface 0.6.0",
  "test-case",
  "walkdir",
 ]
@@ -7652,7 +7652,7 @@ dependencies = [
  "spl-token-2022 3.0.0",
  "spl-token-group-interface 0.2.0",
  "spl-token-metadata-interface 0.3.0",
- "spl-transfer-hook-interface 0.5.1",
+ "spl-transfer-hook-interface 0.6.0",
  "thiserror",
 ]
 
@@ -7894,7 +7894,7 @@ dependencies = [
  "spl-tlv-account-resolution 0.6.0",
  "spl-token-2022 3.0.0",
  "spl-token-client",
- "spl-transfer-hook-interface 0.5.1",
+ "spl-transfer-hook-interface 0.6.0",
  "strum 0.26.2",
  "strum_macros 0.26.2",
  "tokio",
@@ -7910,7 +7910,7 @@ dependencies = [
  "solana-sdk",
  "spl-tlv-account-resolution 0.6.0",
  "spl-token-2022 3.0.0",
- "spl-transfer-hook-interface 0.5.1",
+ "spl-transfer-hook-interface 0.6.0",
  "spl-type-length-value 0.4.0",
 ]
 
@@ -7932,7 +7932,7 @@ dependencies = [
 
 [[package]]
 name = "spl-transfer-hook-interface"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "arrayref",
  "bytemuck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7877,7 +7877,7 @@ dependencies = [
 
 [[package]]
 name = "spl-transfer-hook-cli"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "clap 3.2.25",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7563,7 +7563,7 @@ dependencies = [
  "spl-tlv-account-resolution 0.6.0",
  "spl-token 4.0.1",
  "spl-token-group-interface 0.2.0",
- "spl-token-metadata-interface 0.2.1",
+ "spl-token-metadata-interface 0.3.0",
  "spl-transfer-hook-interface 0.5.1",
  "spl-type-length-value 0.4.0",
  "thiserror",
@@ -7587,7 +7587,7 @@ dependencies = [
  "spl-token-2022 3.0.0",
  "spl-token-client",
  "spl-token-group-interface 0.2.0",
- "spl-token-metadata-interface 0.2.1",
+ "spl-token-metadata-interface 0.3.0",
  "spl-transfer-hook-example",
  "spl-transfer-hook-interface 0.5.1",
  "test-case",
@@ -7624,7 +7624,7 @@ dependencies = [
  "spl-token-2022 3.0.0",
  "spl-token-client",
  "spl-token-group-interface 0.2.0",
- "spl-token-metadata-interface 0.2.1",
+ "spl-token-metadata-interface 0.3.0",
  "strum 0.26.2",
  "strum_macros 0.26.2",
  "tempfile",
@@ -7651,7 +7651,7 @@ dependencies = [
  "spl-token 4.0.1",
  "spl-token-2022 3.0.0",
  "spl-token-group-interface 0.2.0",
- "spl-token-metadata-interface 0.2.1",
+ "spl-token-metadata-interface 0.3.0",
  "spl-transfer-hook-interface 0.5.1",
  "thiserror",
 ]
@@ -7670,7 +7670,7 @@ dependencies = [
  "spl-token-client",
  "spl-token-group-example",
  "spl-token-group-interface 0.2.0",
- "spl-token-metadata-interface 0.2.1",
+ "spl-token-metadata-interface 0.3.0",
  "spl-type-length-value 0.4.0",
 ]
 
@@ -7686,7 +7686,7 @@ dependencies = [
  "spl-token-2022 3.0.0",
  "spl-token-client",
  "spl-token-group-interface 0.2.0",
- "spl-token-metadata-interface 0.2.1",
+ "spl-token-metadata-interface 0.3.0",
  "spl-type-length-value 0.4.0",
 ]
 
@@ -7758,7 +7758,7 @@ dependencies = [
  "spl-pod 0.2.0",
  "spl-token-2022 3.0.0",
  "spl-token-client",
- "spl-token-metadata-interface 0.2.1",
+ "spl-token-metadata-interface 0.3.0",
  "spl-type-length-value 0.4.0",
  "test-case",
 ]
@@ -7779,7 +7779,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-metadata-interface"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "borsh 1.2.1",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7254,7 +7254,7 @@ dependencies = [
 
 [[package]]
 name = "spl-pod"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "base64 0.22.0",
  "borsh 1.2.1",
@@ -7325,7 +7325,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-pod 0.1.2",
+ "spl-pod 0.2.0",
  "thiserror",
 ]
 
@@ -7416,7 +7416,7 @@ dependencies = [
  "solana-security-txt",
  "solana-vote-program",
  "spl-math",
- "spl-pod 0.1.2",
+ "spl-pod 0.2.0",
  "spl-token 4.0.1",
  "spl-token-2022 3.0.0",
  "test-case",
@@ -7461,7 +7461,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-discriminator 0.1.1",
- "spl-pod 0.1.2",
+ "spl-pod 0.2.0",
  "spl-program-error 0.3.1",
  "spl-type-length-value 0.3.1",
 ]
@@ -7559,7 +7559,7 @@ dependencies = [
  "solana-security-txt",
  "solana-zk-token-sdk",
  "spl-memo 4.0.1",
- "spl-pod 0.1.2",
+ "spl-pod 0.2.0",
  "spl-tlv-account-resolution 0.5.2",
  "spl-token 4.0.1",
  "spl-token-group-interface 0.1.1",
@@ -7582,7 +7582,7 @@ dependencies = [
  "spl-associated-token-account 3.0.0",
  "spl-instruction-padding",
  "spl-memo 4.0.1",
- "spl-pod 0.1.2",
+ "spl-pod 0.2.0",
  "spl-tlv-account-resolution 0.5.2",
  "spl-token-2022 3.0.0",
  "spl-token-client",
@@ -7664,7 +7664,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-discriminator 0.1.1",
- "spl-pod 0.1.2",
+ "spl-pod 0.2.0",
  "spl-program-error 0.3.1",
  "spl-token-2022 3.0.0",
  "spl-token-client",
@@ -7682,7 +7682,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-discriminator 0.1.1",
- "spl-pod 0.1.2",
+ "spl-pod 0.2.0",
  "spl-token-2022 3.0.0",
  "spl-token-client",
  "spl-token-group-interface 0.1.1",
@@ -7710,7 +7710,7 @@ dependencies = [
  "bytemuck",
  "solana-program",
  "spl-discriminator 0.1.1",
- "spl-pod 0.1.2",
+ "spl-pod 0.2.0",
  "spl-program-error 0.3.1",
  "spl-type-length-value 0.3.1",
 ]
@@ -7755,7 +7755,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-pod 0.1.2",
+ "spl-pod 0.2.0",
  "spl-token-2022 3.0.0",
  "spl-token-client",
  "spl-token-metadata-interface 0.2.1",
@@ -7786,7 +7786,7 @@ dependencies = [
  "serde_json",
  "solana-program",
  "spl-discriminator 0.1.1",
- "spl-pod 0.1.2",
+ "spl-pod 0.2.0",
  "spl-program-error 0.3.1",
  "spl-type-length-value 0.3.1",
 ]
@@ -7938,7 +7938,7 @@ dependencies = [
  "bytemuck",
  "solana-program",
  "spl-discriminator 0.1.1",
- "spl-pod 0.1.2",
+ "spl-pod 0.2.0",
  "spl-program-error 0.3.1",
  "spl-tlv-account-resolution 0.5.2",
  "spl-type-length-value 0.3.1",
@@ -7965,7 +7965,7 @@ dependencies = [
  "bytemuck",
  "solana-program",
  "spl-discriminator 0.1.1",
- "spl-pod 0.1.2",
+ "spl-pod 0.2.0",
  "spl-program-error 0.3.1",
  "spl-type-length-value-derive",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7451,6 +7451,20 @@ dependencies = [
 [[package]]
 name = "spl-tlv-account-resolution"
 version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f335787add7fa711819f9e7c573f8145a5358a709446fe2d24bf2a88117c90"
+dependencies = [
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator 0.1.0",
+ "spl-pod 0.1.0",
+ "spl-program-error 0.3.0",
+ "spl-type-length-value 0.3.0",
+]
+
+[[package]]
+name = "spl-tlv-account-resolution"
+version = "0.6.0"
 dependencies = [
  "bytemuck",
  "futures 0.3.30",
@@ -7464,20 +7478,6 @@ dependencies = [
  "spl-pod 0.2.0",
  "spl-program-error 0.3.1",
  "spl-type-length-value 0.4.0",
-]
-
-[[package]]
-name = "spl-tlv-account-resolution"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f335787add7fa711819f9e7c573f8145a5358a709446fe2d24bf2a88117c90"
-dependencies = [
- "bytemuck",
- "solana-program",
- "spl-discriminator 0.1.0",
- "spl-pod 0.1.0",
- "spl-program-error 0.3.0",
- "spl-type-length-value 0.3.0",
 ]
 
 [[package]]
@@ -7560,7 +7560,7 @@ dependencies = [
  "solana-zk-token-sdk",
  "spl-memo 4.0.1",
  "spl-pod 0.2.0",
- "spl-tlv-account-resolution 0.5.2",
+ "spl-tlv-account-resolution 0.6.0",
  "spl-token 4.0.1",
  "spl-token-group-interface 0.1.1",
  "spl-token-metadata-interface 0.2.1",
@@ -7583,7 +7583,7 @@ dependencies = [
  "spl-instruction-padding",
  "spl-memo 4.0.1",
  "spl-pod 0.2.0",
- "spl-tlv-account-resolution 0.5.2",
+ "spl-tlv-account-resolution 0.6.0",
  "spl-token-2022 3.0.0",
  "spl-token-client",
  "spl-token-group-interface 0.1.1",
@@ -7891,7 +7891,7 @@ dependencies = [
  "solana-remote-wallet",
  "solana-sdk",
  "solana-test-validator",
- "spl-tlv-account-resolution 0.5.2",
+ "spl-tlv-account-resolution 0.6.0",
  "spl-token-2022 3.0.0",
  "spl-token-client",
  "spl-transfer-hook-interface 0.5.1",
@@ -7908,7 +7908,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-tlv-account-resolution 0.5.2",
+ "spl-tlv-account-resolution 0.6.0",
  "spl-token-2022 3.0.0",
  "spl-transfer-hook-interface 0.5.1",
  "spl-type-length-value 0.4.0",
@@ -7926,7 +7926,7 @@ dependencies = [
  "spl-discriminator 0.1.0",
  "spl-pod 0.1.0",
  "spl-program-error 0.3.0",
- "spl-tlv-account-resolution 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-tlv-account-resolution 0.5.2",
  "spl-type-length-value 0.3.0",
 ]
 
@@ -7940,7 +7940,7 @@ dependencies = [
  "spl-discriminator 0.1.1",
  "spl-pod 0.2.0",
  "spl-program-error 0.3.1",
- "spl-tlv-account-resolution 0.5.2",
+ "spl-tlv-account-resolution 0.6.0",
  "spl-type-length-value 0.4.0",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7902,7 +7902,7 @@ dependencies = [
 
 [[package]]
 name = "spl-transfer-hook-example"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arrayref",
  "solana-program",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7750,7 +7750,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-metadata-example"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "solana-program",
  "solana-program-test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7562,7 +7562,7 @@ dependencies = [
  "spl-pod 0.2.0",
  "spl-tlv-account-resolution 0.6.0",
  "spl-token 4.0.1",
- "spl-token-group-interface 0.1.1",
+ "spl-token-group-interface 0.2.0",
  "spl-token-metadata-interface 0.2.1",
  "spl-transfer-hook-interface 0.5.1",
  "spl-type-length-value 0.4.0",
@@ -7586,7 +7586,7 @@ dependencies = [
  "spl-tlv-account-resolution 0.6.0",
  "spl-token-2022 3.0.0",
  "spl-token-client",
- "spl-token-group-interface 0.1.1",
+ "spl-token-group-interface 0.2.0",
  "spl-token-metadata-interface 0.2.1",
  "spl-transfer-hook-example",
  "spl-transfer-hook-interface 0.5.1",
@@ -7623,7 +7623,7 @@ dependencies = [
  "spl-token 4.0.1",
  "spl-token-2022 3.0.0",
  "spl-token-client",
- "spl-token-group-interface 0.1.1",
+ "spl-token-group-interface 0.2.0",
  "spl-token-metadata-interface 0.2.1",
  "strum 0.26.2",
  "strum_macros 0.26.2",
@@ -7650,7 +7650,7 @@ dependencies = [
  "spl-memo 4.0.1",
  "spl-token 4.0.1",
  "spl-token-2022 3.0.0",
- "spl-token-group-interface 0.1.1",
+ "spl-token-group-interface 0.2.0",
  "spl-token-metadata-interface 0.2.1",
  "spl-transfer-hook-interface 0.5.1",
  "thiserror",
@@ -7669,7 +7669,7 @@ dependencies = [
  "spl-token-2022 3.0.0",
  "spl-token-client",
  "spl-token-group-example",
- "spl-token-group-interface 0.1.1",
+ "spl-token-group-interface 0.2.0",
  "spl-token-metadata-interface 0.2.1",
  "spl-type-length-value 0.4.0",
 ]
@@ -7685,7 +7685,7 @@ dependencies = [
  "spl-pod 0.2.0",
  "spl-token-2022 3.0.0",
  "spl-token-client",
- "spl-token-group-interface 0.1.1",
+ "spl-token-group-interface 0.2.0",
  "spl-token-metadata-interface 0.2.1",
  "spl-type-length-value 0.4.0",
 ]
@@ -7705,7 +7705,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-group-interface"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "bytemuck",
  "solana-program",

--- a/libraries/pod/Cargo.toml
+++ b/libraries/pod/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-pod"
-version = "0.1.2"
+version = "0.2.0"
 description = "Solana Program Library Plain Old Data (Pod)"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/libraries/tlv-account-resolution/Cargo.toml
+++ b/libraries/tlv-account-resolution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-tlv-account-resolution"
-version = "0.5.2"
+version = "0.6.0"
 description = "Solana Program Library TLV Account Resolution Interface"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/libraries/tlv-account-resolution/Cargo.toml
+++ b/libraries/tlv-account-resolution/Cargo.toml
@@ -18,7 +18,7 @@ solana-program = ">=1.18.2,<=2"
 spl-discriminator = { version = "0.1", path = "../discriminator" }
 spl-program-error = { version = "0.3", path = "../program-error" }
 spl-type-length-value = { version = "0.3", path = "../type-length-value" }
-spl-pod = { version = "0.1", path = "../pod" }
+spl-pod = { version = "0.2", path = "../pod" }
 
 [dev-dependencies]
 futures = "0.3.30"

--- a/libraries/tlv-account-resolution/Cargo.toml
+++ b/libraries/tlv-account-resolution/Cargo.toml
@@ -17,7 +17,7 @@ serde = { version = "1.0.197", optional = true }
 solana-program = ">=1.18.2,<=2"
 spl-discriminator = { version = "0.1", path = "../discriminator" }
 spl-program-error = { version = "0.3", path = "../program-error" }
-spl-type-length-value = { version = "0.3", path = "../type-length-value" }
+spl-type-length-value = { version = "0.4", path = "../type-length-value" }
 spl-pod = { version = "0.2", path = "../pod" }
 
 [dev-dependencies]

--- a/libraries/type-length-value-derive-test/Cargo.toml
+++ b/libraries/type-length-value-derive-test/Cargo.toml
@@ -11,6 +11,6 @@ edition = "2021"
 borsh = "1.2.1"
 solana-program = "1.16"
 spl-discriminator = { version = "0.1.1", path = "../discriminator" }
-spl-type-length-value = { version = "0.3.1", path = "../type-length-value", features = [
+spl-type-length-value = { version = "0.4", path = "../type-length-value", features = [
   "derive",
 ] }

--- a/libraries/type-length-value/Cargo.toml
+++ b/libraries/type-length-value/Cargo.toml
@@ -17,7 +17,7 @@ solana-program = ">=1.18.2,<=2"
 spl-discriminator = { version = "0.1", path = "../discriminator" }
 spl-program-error = { version = "0.3", path = "../program-error" }
 spl-type-length-value-derive = { version = "0.1", path = "./derive", optional = true }
-spl-pod = { version = "0.1", path = "../pod" }
+spl-pod = { version = "0.2", path = "../pod" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/libraries/type-length-value/Cargo.toml
+++ b/libraries/type-length-value/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-type-length-value"
-version = "0.3.1"
+version = "0.4.0"
 description = "Solana Program Library Type-Length-Value Management"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/record/program/Cargo.toml
+++ b/record/program/Cargo.toml
@@ -17,7 +17,7 @@ num-derive = "0.4"
 num-traits = "0.2"
 solana-program = ">=1.18.2,<=2"
 thiserror = "1.0"
-spl-pod = { version = "0.1", path = "../../libraries/pod" }
+spl-pod = { version = "0.2", path = "../../libraries/pod" }
 
 [dev-dependencies]
 solana-program-test = ">=1.18.2,<=2"

--- a/single-pool/cli/Cargo.toml
+++ b/single-pool/cli/Cargo.toml
@@ -30,7 +30,7 @@ solana-vote-program = ">=1.18.2,<=2"
 spl-token = { version = "4.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
-spl-token-client = { version = "0.8", path = "../../token/client" }
+spl-token-client = { version = "0.9", path = "../../token/client" }
 spl-associated-token-account = { version = "3.0", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -25,7 +25,7 @@ solana-security-txt = "1.1.1"
 spl-math = { version = "0.2", path = "../../libraries/math", features = [
   "no-entrypoint",
 ] }
-spl-pod = { version = "0.1", path = "../../libraries/pod", features = [
+spl-pod = { version = "0.2", path = "../../libraries/pod", features = [
   "borsh",
 ] }
 spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = [

--- a/token-collection/program/Cargo.toml
+++ b/token-collection/program/Cargo.toml
@@ -18,7 +18,7 @@ spl-program-error = { version = "0.3.1" , path = "../../libraries/program-error"
 spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-group-example = { version = "0.2", path = "../../token-group/example", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.2", path = "../../token-group/interface" }
-spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }
+spl-token-metadata-interface = { version = "0.3", path = "../../token-metadata/interface" }
 spl-type-length-value = { version = "0.4", path = "../../libraries/type-length-value" }
 
 [dev-dependencies]

--- a/token-collection/program/Cargo.toml
+++ b/token-collection/program/Cargo.toml
@@ -25,7 +25,7 @@ spl-type-length-value = { version = "0.4", path = "../../libraries/type-length-v
 solana-program-test = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
 spl-discriminator = { version = "0.1.1", path = "../../libraries/discriminator" }
-spl-token-client = { version = "0.8", path = "../../token/client" }
+spl-token-client = { version = "0.9", path = "../../token/client" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/token-collection/program/Cargo.toml
+++ b/token-collection/program/Cargo.toml
@@ -16,7 +16,7 @@ solana-program = ">=1.18.2,<=2"
 spl-pod = { version = "0.2", path = "../../libraries/pod" }
 spl-program-error = { version = "0.3.1" , path = "../../libraries/program-error" }
 spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
-spl-token-group-example = { version = "0.1.0", path = "../../token-group/example", features = ["no-entrypoint"] }
+spl-token-group-example = { version = "0.2", path = "../../token-group/example", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.2", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }
 spl-type-length-value = { version = "0.4", path = "../../libraries/type-length-value" }

--- a/token-collection/program/Cargo.toml
+++ b/token-collection/program/Cargo.toml
@@ -19,7 +19,7 @@ spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features 
 spl-token-group-example = { version = "0.1.0", path = "../../token-group/example", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.1.1", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }
-spl-type-length-value = { version = "0.3.1", path = "../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.4", path = "../../libraries/type-length-value" }
 
 [dev-dependencies]
 solana-program-test = ">=1.18.2,<=2"

--- a/token-collection/program/Cargo.toml
+++ b/token-collection/program/Cargo.toml
@@ -17,7 +17,7 @@ spl-pod = { version = "0.2", path = "../../libraries/pod" }
 spl-program-error = { version = "0.3.1" , path = "../../libraries/program-error" }
 spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-group-example = { version = "0.1.0", path = "../../token-group/example", features = ["no-entrypoint"] }
-spl-token-group-interface = { version = "0.1.1", path = "../../token-group/interface" }
+spl-token-group-interface = { version = "0.2", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }
 spl-type-length-value = { version = "0.4", path = "../../libraries/type-length-value" }
 

--- a/token-collection/program/Cargo.toml
+++ b/token-collection/program/Cargo.toml
@@ -13,7 +13,7 @@ test-sbf = []
 
 [dependencies]
 solana-program = ">=1.18.2,<=2"
-spl-pod = { version = "0.1.1", path = "../../libraries/pod" }
+spl-pod = { version = "0.2", path = "../../libraries/pod" }
 spl-program-error = { version = "0.3.1" , path = "../../libraries/program-error" }
 spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-group-example = { version = "0.1.0", path = "../../token-group/example", features = ["no-entrypoint"] }

--- a/token-group/example/Cargo.toml
+++ b/token-group/example/Cargo.toml
@@ -13,7 +13,7 @@ test-sbf = []
 
 [dependencies]
 solana-program = ">=1.18.2,<=2"
-spl-pod = { version = "0.1.1", path = "../../libraries/pod" }
+spl-pod = { version = "0.2", path = "../../libraries/pod" }
 spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.1.1", path = "../interface" }
 spl-type-length-value = { version = "0.3.1", path = "../../libraries/type-length-value" }

--- a/token-group/example/Cargo.toml
+++ b/token-group/example/Cargo.toml
@@ -23,7 +23,7 @@ solana-program-test = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
 spl-discriminator = { version = "0.1.1", path = "../../libraries/discriminator" }
 spl-token-client = { version = "0.8", path = "../../token/client" }
-spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }
+spl-token-metadata-interface = { version = "0.3", path = "../../token-metadata/interface" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/token-group/example/Cargo.toml
+++ b/token-group/example/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-group-example"
-version = "0.1.0"
+version = "0.2.0"
 description = "Solana Program Library Token Group Example"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token-group/example/Cargo.toml
+++ b/token-group/example/Cargo.toml
@@ -22,7 +22,7 @@ spl-type-length-value = { version = "0.4", path = "../../libraries/type-length-v
 solana-program-test = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
 spl-discriminator = { version = "0.1.1", path = "../../libraries/discriminator" }
-spl-token-client = { version = "0.8", path = "../../token/client" }
+spl-token-client = { version = "0.9", path = "../../token/client" }
 spl-token-metadata-interface = { version = "0.3", path = "../../token-metadata/interface" }
 
 [lib]

--- a/token-group/example/Cargo.toml
+++ b/token-group/example/Cargo.toml
@@ -15,7 +15,7 @@ test-sbf = []
 solana-program = ">=1.18.2,<=2"
 spl-pod = { version = "0.2", path = "../../libraries/pod" }
 spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
-spl-token-group-interface = { version = "0.1.1", path = "../interface" }
+spl-token-group-interface = { version = "0.2", path = "../interface" }
 spl-type-length-value = { version = "0.4", path = "../../libraries/type-length-value" }
 
 [dev-dependencies]

--- a/token-group/example/Cargo.toml
+++ b/token-group/example/Cargo.toml
@@ -16,7 +16,7 @@ solana-program = ">=1.18.2,<=2"
 spl-pod = { version = "0.2", path = "../../libraries/pod" }
 spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.1.1", path = "../interface" }
-spl-type-length-value = { version = "0.3.1", path = "../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.4", path = "../../libraries/type-length-value" }
 
 [dev-dependencies]
 solana-program-test = ">=1.18.2,<=2"

--- a/token-group/interface/Cargo.toml
+++ b/token-group/interface/Cargo.toml
@@ -15,7 +15,7 @@ spl-pod = { version = "0.2" , path = "../../libraries/pod", features = ["borsh"]
 spl-program-error = { version = "0.3.1" , path = "../../libraries/program-error" }
 
 [dev-dependencies]
-spl-type-length-value = { version = "0.3.1", path = "../../libraries/type-length-value", features = ["derive"] }
+spl-type-length-value = { version = "0.4", path = "../../libraries/type-length-value", features = ["derive"] }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/token-group/interface/Cargo.toml
+++ b/token-group/interface/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 bytemuck = "1.15.0"
 solana-program = ">=1.18.2,<=2"
 spl-discriminator = { version = "0.1.1" , path = "../../libraries/discriminator" }
-spl-pod = { version = "0.1.1" , path = "../../libraries/pod", features = ["borsh"] }
+spl-pod = { version = "0.2" , path = "../../libraries/pod", features = ["borsh"] }
 spl-program-error = { version = "0.3.1" , path = "../../libraries/program-error" }
 
 [dev-dependencies]

--- a/token-group/interface/Cargo.toml
+++ b/token-group/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-group-interface"
-version = "0.1.1"
+version = "0.2.0"
 description = "Solana Program Library Token Group Interface"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token-metadata/example/Cargo.toml
+++ b/token-metadata/example/Cargo.toml
@@ -16,7 +16,7 @@ solana-program = ">=1.18.2,<=2"
 spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-metadata-interface = { version = "0.2.1", path = "../interface" }
 spl-type-length-value = { version = "0.3.1" , path = "../../libraries/type-length-value" }
-spl-pod = { version = "0.1.1", path = "../../libraries/pod" }
+spl-pod = { version = "0.2", path = "../../libraries/pod" }
 
 [dev-dependencies]
 solana-program-test = ">=1.18.2,<=2"

--- a/token-metadata/example/Cargo.toml
+++ b/token-metadata/example/Cargo.toml
@@ -21,7 +21,7 @@ spl-pod = { version = "0.2", path = "../../libraries/pod" }
 [dev-dependencies]
 solana-program-test = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
-spl-token-client = { version = "0.8", path = "../../token/client" }
+spl-token-client = { version = "0.9", path = "../../token/client" }
 test-case = "3.3"
 
 [lib]

--- a/token-metadata/example/Cargo.toml
+++ b/token-metadata/example/Cargo.toml
@@ -14,7 +14,7 @@ test-sbf = []
 [dependencies]
 solana-program = ">=1.18.2,<=2"
 spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
-spl-token-metadata-interface = { version = "0.2.1", path = "../interface" }
+spl-token-metadata-interface = { version = "0.3", path = "../interface" }
 spl-type-length-value = { version = "0.4" , path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.2", path = "../../libraries/pod" }
 

--- a/token-metadata/example/Cargo.toml
+++ b/token-metadata/example/Cargo.toml
@@ -15,7 +15,7 @@ test-sbf = []
 solana-program = ">=1.18.2,<=2"
 spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-metadata-interface = { version = "0.2.1", path = "../interface" }
-spl-type-length-value = { version = "0.3.1" , path = "../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.4" , path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.2", path = "../../libraries/pod" }
 
 [dev-dependencies]

--- a/token-metadata/example/Cargo.toml
+++ b/token-metadata/example/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-metadata-example"
-version = "0.2.0"
+version = "0.3.0"
 description = "Solana Program Library Token Metadata Example Program"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token-metadata/interface/Cargo.toml
+++ b/token-metadata/interface/Cargo.toml
@@ -17,7 +17,7 @@ solana-program = ">=1.18.2,<=2"
 spl-discriminator = { version = "0.1", path = "../../libraries/discriminator" }
 spl-program-error = { version = "0.3", path = "../../libraries/program-error" }
 spl-type-length-value = { version = "0.3", path = "../../libraries/type-length-value" }
-spl-pod = { version = "0.1", path = "../../libraries/pod", features = [
+spl-pod = { version = "0.2", path = "../../libraries/pod", features = [
   "borsh",
 ] }
 

--- a/token-metadata/interface/Cargo.toml
+++ b/token-metadata/interface/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0.197", optional = true }
 solana-program = ">=1.18.2,<=2"
 spl-discriminator = { version = "0.1", path = "../../libraries/discriminator" }
 spl-program-error = { version = "0.3", path = "../../libraries/program-error" }
-spl-type-length-value = { version = "0.3", path = "../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.4", path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.2", path = "../../libraries/pod", features = [
   "borsh",
 ] }

--- a/token-metadata/interface/Cargo.toml
+++ b/token-metadata/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-metadata-interface"
-version = "0.2.1"
+version = "0.3.0"
 description = "Solana Program Library Token Metadata Interface"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token-upgrade/cli/Cargo.toml
+++ b/token-upgrade/cli/Cargo.toml
@@ -22,7 +22,7 @@ solana-sdk = ">=1.18.2,<=2"
 spl-associated-token-account = { version = "3.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
-spl-token-client = { version = "0.8", path = "../../token/client" }
+spl-token-client = { version = "0.9", path = "../../token/client" }
 spl-token-upgrade = { version = "0.1", path = "../program", features = ["no-entrypoint"] }
 tokio = { version = "1", features = ["full"] }
 

--- a/token-upgrade/program/Cargo.toml
+++ b/token-upgrade/program/Cargo.toml
@@ -23,7 +23,7 @@ thiserror = "1.0"
 solana-program-test = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-client = { version = "0.8", path = "../../token/client" }
+spl-token-client = { version = "0.9", path = "../../token/client" }
 test-case = "3.3"
 
 [lib]

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -35,7 +35,7 @@ spl-token-2022 = { version = "3.0", path = "../program-2022", features = [
   "no-entrypoint",
 ] }
 spl-token-client = { version = "0.8", path = "../client" }
-spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }
+spl-token-metadata-interface = { version = "0.3", path = "../../token-metadata/interface" }
 spl-token-group-interface = { version = "0.2", path = "../../token-group/interface" }
 spl-associated-token-account = { version = "3.0", path = "../../associated-token-account/program", features = [
   "no-entrypoint",

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -34,7 +34,7 @@ spl-token = { version = "4.0", path = "../program", features = [
 spl-token-2022 = { version = "3.0", path = "../program-2022", features = [
   "no-entrypoint",
 ] }
-spl-token-client = { version = "0.8", path = "../client" }
+spl-token-client = { version = "0.9", path = "../client" }
 spl-token-metadata-interface = { version = "0.3", path = "../../token-metadata/interface" }
 spl-token-group-interface = { version = "0.2", path = "../../token-group/interface" }
 spl-associated-token-account = { version = "3.0", path = "../../associated-token-account/program", features = [

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -36,7 +36,7 @@ spl-token-2022 = { version = "3.0", path = "../program-2022", features = [
 ] }
 spl-token-client = { version = "0.8", path = "../client" }
 spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }
-spl-token-group-interface = { version = "0.1", path = "../../token-group/interface" }
+spl-token-group-interface = { version = "0.2", path = "../../token-group/interface" }
 spl-associated-token-account = { version = "3.0", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -32,7 +32,7 @@ spl-token = { version = "4.0", path = "../program", features = [
 spl-token-2022 = { version = "3.0", path = "../program-2022" }
 spl-token-group-interface = { version = "0.2", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.3", path = "../../token-metadata/interface" }
-spl-transfer-hook-interface = { version = "0.5", path = "../transfer-hook/interface" }
+spl-transfer-hook-interface = { version = "0.6", path = "../transfer-hook/interface" }
 thiserror = "1.0"
 
 [features]

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -31,7 +31,7 @@ spl-token = { version = "4.0", path = "../program", features = [
 ] }
 spl-token-2022 = { version = "3.0", path = "../program-2022" }
 spl-token-group-interface = { version = "0.2", path = "../../token-group/interface" }
-spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }
+spl-token-metadata-interface = { version = "0.3", path = "../../token-metadata/interface" }
 spl-transfer-hook-interface = { version = "0.5", path = "../transfer-hook/interface" }
 thiserror = "1.0"
 

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -30,7 +30,7 @@ spl-token = { version = "4.0", path = "../program", features = [
   "no-entrypoint",
 ] }
 spl-token-2022 = { version = "3.0", path = "../program-2022" }
-spl-token-group-interface = { version = "0.1", path = "../../token-group/interface" }
+spl-token-group-interface = { version = "0.2", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }
 spl-transfer-hook-interface = { version = "0.5", path = "../transfer-hook/interface" }
 thiserror = "1.0"

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "spl-token-client"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "0.8.1"
+version = "0.9.0"
 
 [dependencies]
 async-trait = "0.1"

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -37,7 +37,7 @@ spl-tlv-account-resolution = { version = "0.6", path = "../../libraries/tlv-acco
 spl-token-client = { version = "0.8", path = "../client" }
 spl-token-group-interface = { version = "0.2", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.3", path = "../../token-metadata/interface" }
-spl-transfer-hook-example = { version = "0.5", path = "../transfer-hook/example", features = [
+spl-transfer-hook-example = { version = "0.6", path = "../transfer-hook/example", features = [
   "no-entrypoint",
 ] }
 spl-transfer-hook-interface = { version = "0.6", path = "../transfer-hook/interface" }

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -34,7 +34,7 @@ spl-instruction-padding = { version = "0.1.1", path = "../../instruction-padding
   "no-entrypoint",
 ] }
 spl-tlv-account-resolution = { version = "0.6", path = "../../libraries/tlv-account-resolution" }
-spl-token-client = { version = "0.8", path = "../client" }
+spl-token-client = { version = "0.9", path = "../client" }
 spl-token-group-interface = { version = "0.2", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.3", path = "../../token-metadata/interface" }
 spl-transfer-hook-example = { version = "0.6", path = "../transfer-hook/example", features = [

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -40,5 +40,5 @@ spl-token-metadata-interface = { version = "0.3", path = "../../token-metadata/i
 spl-transfer-hook-example = { version = "0.5", path = "../transfer-hook/example", features = [
   "no-entrypoint",
 ] }
-spl-transfer-hook-interface = { version = "0.5", path = "../transfer-hook/interface" }
+spl-transfer-hook-interface = { version = "0.6", path = "../transfer-hook/interface" }
 test-case = "3.3"

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -33,7 +33,7 @@ spl-token-2022 = { version = "3.0", path = "../program-2022", features = [
 spl-instruction-padding = { version = "0.1.1", path = "../../instruction-padding/program", features = [
   "no-entrypoint",
 ] }
-spl-tlv-account-resolution = { version = "0.5.2", path = "../../libraries/tlv-account-resolution" }
+spl-tlv-account-resolution = { version = "0.6", path = "../../libraries/tlv-account-resolution" }
 spl-token-client = { version = "0.8", path = "../client" }
 spl-token-group-interface = { version = "0.1", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -26,7 +26,7 @@ spl-associated-token-account = { version = "3.0", path = "../../associated-token
 spl-memo = { version = "4.0.1", path = "../../memo/program", features = [
   "no-entrypoint",
 ] }
-spl-pod = { version = "0.1.1", path = "../../libraries/pod" }
+spl-pod = { version = "0.2", path = "../../libraries/pod" }
 spl-token-2022 = { version = "3.0", path = "../program-2022", features = [
   "no-entrypoint",
 ] }

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -36,7 +36,7 @@ spl-instruction-padding = { version = "0.1.1", path = "../../instruction-padding
 spl-tlv-account-resolution = { version = "0.6", path = "../../libraries/tlv-account-resolution" }
 spl-token-client = { version = "0.8", path = "../client" }
 spl-token-group-interface = { version = "0.2", path = "../../token-group/interface" }
-spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }
+spl-token-metadata-interface = { version = "0.3", path = "../../token-metadata/interface" }
 spl-transfer-hook-example = { version = "0.5", path = "../transfer-hook/example", features = [
   "no-entrypoint",
 ] }

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -35,7 +35,7 @@ spl-instruction-padding = { version = "0.1.1", path = "../../instruction-padding
 ] }
 spl-tlv-account-resolution = { version = "0.6", path = "../../libraries/tlv-account-resolution" }
 spl-token-client = { version = "0.8", path = "../client" }
-spl-token-group-interface = { version = "0.1", path = "../../token-group/interface" }
+spl-token-group-interface = { version = "0.2", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }
 spl-transfer-hook-example = { version = "0.5", path = "../transfer-hook/example", features = [
   "no-entrypoint",

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -31,7 +31,7 @@ solana-security-txt = "1.1.1"
 solana-zk-token-sdk = ">=1.18.2,<=2"
 spl-memo = { version = "4.0", path = "../../memo/program", features = [ "no-entrypoint" ] }
 spl-token = { version = "4.0",  path = "../program", features = ["no-entrypoint"] }
-spl-token-group-interface = { version = "0.1", path = "../../token-group/interface" }
+spl-token-group-interface = { version = "0.2", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }
 spl-transfer-hook-interface = { version = "0.5.1", path = "../transfer-hook/interface" }
 spl-type-length-value = { version = "0.4", path = "../../libraries/type-length-value" }

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -47,7 +47,7 @@ proptest = "1.4"
 serial_test = "3.0.0"
 solana-program-test = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
-spl-tlv-account-resolution = { version = "0.5.2", path = "../../libraries/tlv-account-resolution" }
+spl-tlv-account-resolution = { version = "0.6", path = "../../libraries/tlv-account-resolution" }
 serde_json = "1.0.115"
 
 [lib]

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -35,7 +35,7 @@ spl-token-group-interface = { version = "0.1", path = "../../token-group/interfa
 spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }
 spl-transfer-hook-interface = { version = "0.5.1", path = "../transfer-hook/interface" }
 spl-type-length-value = { version = "0.3.1", path = "../../libraries/type-length-value" }
-spl-pod = { version = "0.1", path = "../../libraries/pod" }
+spl-pod = { version = "0.2", path = "../../libraries/pod" }
 thiserror = "1.0"
 serde = { version = "1.0.197", optional = true }
 serde_with = { version = "3.7.0", optional = true }

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -32,7 +32,7 @@ solana-zk-token-sdk = ">=1.18.2,<=2"
 spl-memo = { version = "4.0", path = "../../memo/program", features = [ "no-entrypoint" ] }
 spl-token = { version = "4.0",  path = "../program", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.2", path = "../../token-group/interface" }
-spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }
+spl-token-metadata-interface = { version = "0.3", path = "../../token-metadata/interface" }
 spl-transfer-hook-interface = { version = "0.5.1", path = "../transfer-hook/interface" }
 spl-type-length-value = { version = "0.4", path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.2", path = "../../libraries/pod" }

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -33,7 +33,7 @@ spl-memo = { version = "4.0", path = "../../memo/program", features = [ "no-entr
 spl-token = { version = "4.0",  path = "../program", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.2", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.3", path = "../../token-metadata/interface" }
-spl-transfer-hook-interface = { version = "0.5.1", path = "../transfer-hook/interface" }
+spl-transfer-hook-interface = { version = "0.6", path = "../transfer-hook/interface" }
 spl-type-length-value = { version = "0.4", path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.2", path = "../../libraries/pod" }
 thiserror = "1.0"

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -34,7 +34,7 @@ spl-token = { version = "4.0",  path = "../program", features = ["no-entrypoint"
 spl-token-group-interface = { version = "0.1", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.2", path = "../../token-metadata/interface" }
 spl-transfer-hook-interface = { version = "0.5.1", path = "../transfer-hook/interface" }
-spl-type-length-value = { version = "0.3.1", path = "../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.4", path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.2", path = "../../libraries/pod" }
 thiserror = "1.0"
 serde = { version = "1.0.197", optional = true }

--- a/token/transfer-hook/cli/Cargo.toml
+++ b/token/transfer-hook/cli/Cargo.toml
@@ -29,7 +29,7 @@ serde_yaml = "0.9.34"
 [dev-dependencies]
 solana-test-validator = ">=1.18.2,<=2"
 spl-token-2022 = { version = "3.0", path = "../../program-2022", features = ["no-entrypoint"] }
-spl-token-client = { version = "0.8", path = "../../client" }
+spl-token-client = { version = "0.9", path = "../../client" }
 
 [[bin]]
 name = "spl-transfer-hook"

--- a/token/transfer-hook/cli/Cargo.toml
+++ b/token/transfer-hook/cli/Cargo.toml
@@ -18,7 +18,7 @@ solana-logger = ">=1.18.2,<=2"
 solana-remote-wallet = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
 spl-transfer-hook-interface = { version = "0.5", path = "../interface" }
-spl-tlv-account-resolution = { version = "0.5.2" , path = "../../../libraries/tlv-account-resolution", features = ["serde-traits"] }
+spl-tlv-account-resolution = { version = "0.6" , path = "../../../libraries/tlv-account-resolution", features = ["serde-traits"] }
 strum = "0.26"
 strum_macros = "0.26"
 tokio = { version = "1", features = ["full"] }

--- a/token/transfer-hook/cli/Cargo.toml
+++ b/token/transfer-hook/cli/Cargo.toml
@@ -17,7 +17,7 @@ solana-client = ">=1.18.2,<=2"
 solana-logger = ">=1.18.2,<=2"
 solana-remote-wallet = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
-spl-transfer-hook-interface = { version = "0.5", path = "../interface" }
+spl-transfer-hook-interface = { version = "0.6", path = "../interface" }
 spl-tlv-account-resolution = { version = "0.6" , path = "../../../libraries/tlv-account-resolution", features = ["serde-traits"] }
 strum = "0.26"
 strum_macros = "0.26"

--- a/token/transfer-hook/cli/Cargo.toml
+++ b/token/transfer-hook/cli/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://spl.solana.com/token"
 license = "Apache-2.0"
 name = "spl-transfer-hook-cli"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "0.1.1"
+version = "0.2.0"
 
 [dependencies]
 clap = { version = "3", features = ["cargo"] }

--- a/token/transfer-hook/example/Cargo.toml
+++ b/token/transfer-hook/example/Cargo.toml
@@ -16,7 +16,7 @@ arrayref = "0.3.7"
 solana-program = ">=1.18.2,<=2"
 spl-tlv-account-resolution = { version = "0.6" , path = "../../../libraries/tlv-account-resolution" }
 spl-token-2022 = { version = "3.0",  path = "../../program-2022", features = ["no-entrypoint"] }
-spl-transfer-hook-interface = { version = "0.5" , path = "../interface" }
+spl-transfer-hook-interface = { version = "0.6" , path = "../interface" }
 spl-type-length-value = { version = "0.4" , path = "../../../libraries/type-length-value" }
 
 [dev-dependencies]

--- a/token/transfer-hook/example/Cargo.toml
+++ b/token/transfer-hook/example/Cargo.toml
@@ -17,7 +17,7 @@ solana-program = ">=1.18.2,<=2"
 spl-tlv-account-resolution = { version = "0.5" , path = "../../../libraries/tlv-account-resolution" }
 spl-token-2022 = { version = "3.0",  path = "../../program-2022", features = ["no-entrypoint"] }
 spl-transfer-hook-interface = { version = "0.5" , path = "../interface" }
-spl-type-length-value = { version = "0.3" , path = "../../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.4" , path = "../../../libraries/type-length-value" }
 
 [dev-dependencies]
 solana-program-test = ">=1.18.2,<=2"

--- a/token/transfer-hook/example/Cargo.toml
+++ b/token/transfer-hook/example/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-transfer-hook-example"
-version = "0.5.0"
+version = "0.6.0"
 description = "Solana Program Library Transfer Hook Example Program"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token/transfer-hook/example/Cargo.toml
+++ b/token/transfer-hook/example/Cargo.toml
@@ -14,7 +14,7 @@ test-sbf = []
 [dependencies]
 arrayref = "0.3.7"
 solana-program = ">=1.18.2,<=2"
-spl-tlv-account-resolution = { version = "0.5" , path = "../../../libraries/tlv-account-resolution" }
+spl-tlv-account-resolution = { version = "0.6" , path = "../../../libraries/tlv-account-resolution" }
 spl-token-2022 = { version = "3.0",  path = "../../program-2022", features = ["no-entrypoint"] }
 spl-transfer-hook-interface = { version = "0.5" , path = "../interface" }
 spl-type-length-value = { version = "0.4" , path = "../../../libraries/type-length-value" }

--- a/token/transfer-hook/interface/Cargo.toml
+++ b/token/transfer-hook/interface/Cargo.toml
@@ -13,7 +13,7 @@ bytemuck = { version = "1.15.0", features = ["derive"] }
 solana-program = ">=1.18.2,<=2"
 spl-discriminator = { version = "0.1" , path = "../../../libraries/discriminator" }
 spl-program-error = { version = "0.3" , path = "../../../libraries/program-error" }
-spl-tlv-account-resolution = { version = "0.5" , path = "../../../libraries/tlv-account-resolution" }
+spl-tlv-account-resolution = { version = "0.6" , path = "../../../libraries/tlv-account-resolution" }
 spl-type-length-value = { version = "0.4" , path = "../../../libraries/type-length-value" }
 spl-pod = { version = "0.2", path = "../../../libraries/pod" }
 

--- a/token/transfer-hook/interface/Cargo.toml
+++ b/token/transfer-hook/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-transfer-hook-interface"
-version = "0.5.1"
+version = "0.6.0"
 description = "Solana Program Library Transfer Hook Interface"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token/transfer-hook/interface/Cargo.toml
+++ b/token/transfer-hook/interface/Cargo.toml
@@ -14,7 +14,7 @@ solana-program = ">=1.18.2,<=2"
 spl-discriminator = { version = "0.1" , path = "../../../libraries/discriminator" }
 spl-program-error = { version = "0.3" , path = "../../../libraries/program-error" }
 spl-tlv-account-resolution = { version = "0.5" , path = "../../../libraries/tlv-account-resolution" }
-spl-type-length-value = { version = "0.3" , path = "../../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.4" , path = "../../../libraries/type-length-value" }
 spl-pod = { version = "0.2", path = "../../../libraries/pod" }
 
 [lib]

--- a/token/transfer-hook/interface/Cargo.toml
+++ b/token/transfer-hook/interface/Cargo.toml
@@ -15,7 +15,7 @@ spl-discriminator = { version = "0.1" , path = "../../../libraries/discriminator
 spl-program-error = { version = "0.3" , path = "../../../libraries/program-error" }
 spl-tlv-account-resolution = { version = "0.5" , path = "../../../libraries/tlv-account-resolution" }
 spl-type-length-value = { version = "0.3" , path = "../../../libraries/type-length-value" }
-spl-pod = { version = "0.1", path = "../../../libraries/pod" }
+spl-pod = { version = "0.2", path = "../../../libraries/pod" }
 
 [lib]
 crate-type = ["cdylib", "lib"]


### PR DESCRIPTION
#### Problem

We need to release a new token-cli crate to get the priority fees out to people, but the crates aren't at the proper version to be released.

#### Solution

Bump all the required crates to do this in a semver-compatible way, since we've bumped to borsh v1 in SPL:

* pod
* tlv
* tlv-account-resolution
* token-group (interface and example)
* token-metadata (interface and example)
* token-2022 (already done)
* token-cli (already done)
* token-client
* transfer-hook (interface, example, and CLI)
* associated-token-account (already done)

To make tagging releases simpler, this PR won't be squashed