### PR TITLE
token-cli{,ent}: Relax spl-memo dependency

### DIFF
--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -40,7 +40,7 @@ spl-token-group-interface = { version = "0.2", path = "../../token-group/interfa
 spl-associated-token-account = { version = "3.0", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }
-spl-memo = { version = "4.0.1", path = "../../memo/program", features = [
+spl-memo = { version = "4.0", path = "../../memo/program", features = [
   "no-entrypoint",
 ] }
 strum = "0.26"

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -23,7 +23,7 @@ solana-sdk = ">=1.18.2,<=2"
 spl-associated-token-account = { version = "3.0", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }
-spl-memo = { version = "4.0.1", path = "../../memo/program", features = [
+spl-memo = { version = "4.0", path = "../../memo/program", features = [
   "no-entrypoint",
 ] }
 spl-token = { version = "4.0", path = "../program", features = [


### PR DESCRIPTION
#### Problem

The token client and CLI declare a requirement of spl-memo 4.0.1, which restricts it from being used with some older crates.

#### Solution

Relax the dependency to 4.0, same as with token.