### PR TITLE
discriminator: Bump to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6900,7 +6900,7 @@ dependencies = [
 
 [[package]]
 name = "spl-discriminator"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "borsh 1.2.1",
  "bytemuck",
@@ -7464,7 +7464,7 @@ dependencies = [
 
 [[package]]
 name = "spl-tlv-account-resolution"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bytemuck",
  "futures 0.3.30",
@@ -7474,10 +7474,10 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-discriminator 0.1.1",
+ "spl-discriminator 0.2.0",
  "spl-pod 0.2.0",
  "spl-program-error 0.3.1",
- "spl-type-length-value 0.4.0",
+ "spl-type-length-value 0.4.1",
 ]
 
 [[package]]
@@ -7560,12 +7560,12 @@ dependencies = [
  "solana-zk-token-sdk",
  "spl-memo 4.0.1",
  "spl-pod 0.2.0",
- "spl-tlv-account-resolution 0.6.0",
+ "spl-tlv-account-resolution 0.6.1",
  "spl-token 4.0.1",
- "spl-token-group-interface 0.2.0",
- "spl-token-metadata-interface 0.3.0",
- "spl-transfer-hook-interface 0.6.0",
- "spl-type-length-value 0.4.0",
+ "spl-token-group-interface 0.2.1",
+ "spl-token-metadata-interface 0.3.1",
+ "spl-transfer-hook-interface 0.6.1",
+ "spl-type-length-value 0.4.1",
  "thiserror",
 ]
 
@@ -7583,13 +7583,13 @@ dependencies = [
  "spl-instruction-padding",
  "spl-memo 4.0.1",
  "spl-pod 0.2.0",
- "spl-tlv-account-resolution 0.6.0",
+ "spl-tlv-account-resolution 0.6.1",
  "spl-token-2022 3.0.0",
  "spl-token-client",
- "spl-token-group-interface 0.2.0",
- "spl-token-metadata-interface 0.3.0",
+ "spl-token-group-interface 0.2.1",
+ "spl-token-metadata-interface 0.3.1",
  "spl-transfer-hook-example",
- "spl-transfer-hook-interface 0.6.0",
+ "spl-transfer-hook-interface 0.6.1",
  "test-case",
  "walkdir",
 ]
@@ -7623,8 +7623,8 @@ dependencies = [
  "spl-token 4.0.1",
  "spl-token-2022 3.0.0",
  "spl-token-client",
- "spl-token-group-interface 0.2.0",
- "spl-token-metadata-interface 0.3.0",
+ "spl-token-group-interface 0.2.1",
+ "spl-token-metadata-interface 0.3.1",
  "strum 0.26.2",
  "strum_macros 0.26.2",
  "tempfile",
@@ -7650,9 +7650,9 @@ dependencies = [
  "spl-memo 4.0.1",
  "spl-token 4.0.1",
  "spl-token-2022 3.0.0",
- "spl-token-group-interface 0.2.0",
- "spl-token-metadata-interface 0.3.0",
- "spl-transfer-hook-interface 0.6.0",
+ "spl-token-group-interface 0.2.1",
+ "spl-token-metadata-interface 0.3.1",
+ "spl-transfer-hook-interface 0.6.1",
  "thiserror",
 ]
 
@@ -7663,31 +7663,31 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-discriminator 0.1.1",
+ "spl-discriminator 0.2.0",
  "spl-pod 0.2.0",
  "spl-program-error 0.3.1",
  "spl-token-2022 3.0.0",
  "spl-token-client",
  "spl-token-group-example",
- "spl-token-group-interface 0.2.0",
- "spl-token-metadata-interface 0.3.0",
- "spl-type-length-value 0.4.0",
+ "spl-token-group-interface 0.2.1",
+ "spl-token-metadata-interface 0.3.1",
+ "spl-type-length-value 0.4.1",
 ]
 
 [[package]]
 name = "spl-token-group-example"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-discriminator 0.1.1",
+ "spl-discriminator 0.2.0",
  "spl-pod 0.2.0",
  "spl-token-2022 3.0.0",
  "spl-token-client",
- "spl-token-group-interface 0.2.0",
- "spl-token-metadata-interface 0.3.0",
- "spl-type-length-value 0.4.0",
+ "spl-token-group-interface 0.2.1",
+ "spl-token-metadata-interface 0.3.1",
+ "spl-type-length-value 0.4.1",
 ]
 
 [[package]]
@@ -7705,14 +7705,14 @@ dependencies = [
 
 [[package]]
 name = "spl-token-group-interface"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bytemuck",
  "solana-program",
- "spl-discriminator 0.1.1",
+ "spl-discriminator 0.2.0",
  "spl-pod 0.2.0",
  "spl-program-error 0.3.1",
- "spl-type-length-value 0.4.0",
+ "spl-type-length-value 0.4.1",
 ]
 
 [[package]]
@@ -7758,8 +7758,8 @@ dependencies = [
  "spl-pod 0.2.0",
  "spl-token-2022 3.0.0",
  "spl-token-client",
- "spl-token-metadata-interface 0.3.0",
- "spl-type-length-value 0.4.0",
+ "spl-token-metadata-interface 0.3.1",
+ "spl-type-length-value 0.4.1",
  "test-case",
 ]
 
@@ -7779,16 +7779,16 @@ dependencies = [
 
 [[package]]
 name = "spl-token-metadata-interface"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "borsh 1.2.1",
  "serde",
  "serde_json",
  "solana-program",
- "spl-discriminator 0.1.1",
+ "spl-discriminator 0.2.0",
  "spl-pod 0.2.0",
  "spl-program-error 0.3.1",
- "spl-type-length-value 0.4.0",
+ "spl-type-length-value 0.4.1",
 ]
 
 [[package]]
@@ -7891,10 +7891,10 @@ dependencies = [
  "solana-remote-wallet",
  "solana-sdk",
  "solana-test-validator",
- "spl-tlv-account-resolution 0.6.0",
+ "spl-tlv-account-resolution 0.6.1",
  "spl-token-2022 3.0.0",
  "spl-token-client",
- "spl-transfer-hook-interface 0.6.0",
+ "spl-transfer-hook-interface 0.6.1",
  "strum 0.26.2",
  "strum_macros 0.26.2",
  "tokio",
@@ -7908,10 +7908,10 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-tlv-account-resolution 0.6.0",
+ "spl-tlv-account-resolution 0.6.1",
  "spl-token-2022 3.0.0",
- "spl-transfer-hook-interface 0.6.0",
- "spl-type-length-value 0.4.0",
+ "spl-transfer-hook-interface 0.6.1",
+ "spl-type-length-value 0.4.1",
 ]
 
 [[package]]
@@ -7932,16 +7932,16 @@ dependencies = [
 
 [[package]]
 name = "spl-transfer-hook-interface"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "arrayref",
  "bytemuck",
  "solana-program",
- "spl-discriminator 0.1.1",
+ "spl-discriminator 0.2.0",
  "spl-pod 0.2.0",
  "spl-program-error 0.3.1",
- "spl-tlv-account-resolution 0.6.0",
- "spl-type-length-value 0.4.0",
+ "spl-tlv-account-resolution 0.6.1",
+ "spl-type-length-value 0.4.1",
  "tokio",
 ]
 
@@ -7960,11 +7960,11 @@ dependencies = [
 
 [[package]]
 name = "spl-type-length-value"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bytemuck",
  "solana-program",
- "spl-discriminator 0.1.1",
+ "spl-discriminator 0.2.0",
  "spl-pod 0.2.0",
  "spl-program-error 0.3.1",
  "spl-type-length-value-derive",
@@ -7985,8 +7985,8 @@ version = "0.1.0"
 dependencies = [
  "borsh 1.2.1",
  "solana-program",
- "spl-discriminator 0.1.1",
- "spl-type-length-value 0.4.0",
+ "spl-discriminator 0.2.0",
+ "spl-type-length-value 0.4.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6902,7 +6902,7 @@ dependencies = [
 name = "spl-discriminator"
 version = "0.1.1"
 dependencies = [
- "borsh 0.10.3",
+ "borsh 1.2.1",
  "bytemuck",
  "solana-program",
  "spl-discriminator-derive 0.1.2",

--- a/libraries/discriminator/Cargo.toml
+++ b/libraries/discriminator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-discriminator"
-version = "0.1.1"
+version = "0.2.0"
 description = "Solana Program Library 8-Byte Discriminator Management"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/libraries/discriminator/Cargo.toml
+++ b/libraries/discriminator/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 borsh = ["dep:borsh"]
 
 [dependencies]
-borsh = { version = "0.10", optional = true }
+borsh = { version = "1", optional = true }
 bytemuck = { version = "1.15.0", features = ["derive"] }
 solana-program = ">=1.18.2,<=2"
 spl-discriminator-derive = { version = "0.1.2", path = "./derive" }

--- a/libraries/tlv-account-resolution/Cargo.toml
+++ b/libraries/tlv-account-resolution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-tlv-account-resolution"
-version = "0.6.0"
+version = "0.6.1"
 description = "Solana Program Library TLV Account Resolution Interface"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -15,7 +15,7 @@ test-sbf = []
 bytemuck = { version = "1.15.0", features = ["derive"] }
 serde = { version = "1.0.197", optional = true }
 solana-program = ">=1.18.2,<=2"
-spl-discriminator = { version = "0.1", path = "../discriminator" }
+spl-discriminator = { version = "0.2", path = "../discriminator" }
 spl-program-error = { version = "0.3", path = "../program-error" }
 spl-type-length-value = { version = "0.4", path = "../type-length-value" }
 spl-pod = { version = "0.2", path = "../pod" }
@@ -26,7 +26,6 @@ futures-util = "0.3"
 solana-client = ">=1.18.2,<=2"
 solana-program-test = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
-spl-discriminator = { version = "0.1", path = "../discriminator" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/libraries/type-length-value-derive-test/Cargo.toml
+++ b/libraries/type-length-value-derive-test/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dev-dependencies]
 borsh = "1.2.1"
 solana-program = "1.16"
-spl-discriminator = { version = "0.1.1", path = "../discriminator" }
+spl-discriminator = { version = "0.2", path = "../discriminator" }
 spl-type-length-value = { version = "0.4", path = "../type-length-value", features = [
   "derive",
 ] }

--- a/libraries/type-length-value/Cargo.toml
+++ b/libraries/type-length-value/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-type-length-value"
-version = "0.4.0"
+version = "0.4.1"
 description = "Solana Program Library Type-Length-Value Management"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -14,7 +14,7 @@ derive = ["dep:spl-type-length-value-derive"]
 [dependencies]
 bytemuck = { version = "1.15.0", features = ["derive"] }
 solana-program = ">=1.18.2,<=2"
-spl-discriminator = { version = "0.1", path = "../discriminator" }
+spl-discriminator = { version = "0.2", path = "../discriminator" }
 spl-program-error = { version = "0.3", path = "../program-error" }
 spl-type-length-value-derive = { version = "0.1", path = "./derive", optional = true }
 spl-pod = { version = "0.2", path = "../pod" }

--- a/token-collection/program/Cargo.toml
+++ b/token-collection/program/Cargo.toml
@@ -24,7 +24,7 @@ spl-type-length-value = { version = "0.4", path = "../../libraries/type-length-v
 [dev-dependencies]
 solana-program-test = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
-spl-discriminator = { version = "0.1.1", path = "../../libraries/discriminator" }
+spl-discriminator = { version = "0.2", path = "../../libraries/discriminator" }
 spl-token-client = { version = "0.9", path = "../../token/client" }
 
 [lib]

--- a/token-group/example/Cargo.toml
+++ b/token-group/example/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-group-example"
-version = "0.2.0"
+version = "0.2.1"
 description = "Solana Program Library Token Group Example"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -21,7 +21,7 @@ spl-type-length-value = { version = "0.4", path = "../../libraries/type-length-v
 [dev-dependencies]
 solana-program-test = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
-spl-discriminator = { version = "0.1.1", path = "../../libraries/discriminator" }
+spl-discriminator = { version = "0.2", path = "../../libraries/discriminator" }
 spl-token-client = { version = "0.9", path = "../../token/client" }
 spl-token-metadata-interface = { version = "0.3", path = "../../token-metadata/interface" }
 

--- a/token-group/interface/Cargo.toml
+++ b/token-group/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-group-interface"
-version = "0.2.0"
+version = "0.2.1"
 description = "Solana Program Library Token Group Interface"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 bytemuck = "1.15.0"
 solana-program = ">=1.18.2,<=2"
-spl-discriminator = { version = "0.1.1" , path = "../../libraries/discriminator" }
+spl-discriminator = { version = "0.2" , path = "../../libraries/discriminator" }
 spl-pod = { version = "0.2" , path = "../../libraries/pod", features = ["borsh"] }
 spl-program-error = { version = "0.3.1" , path = "../../libraries/program-error" }
 

--- a/token-metadata/interface/Cargo.toml
+++ b/token-metadata/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-metadata-interface"
-version = "0.3.0"
+version = "0.3.1"
 description = "Solana Program Library Token Metadata Interface"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -14,7 +14,7 @@ serde-traits = ["dep:serde", "spl-pod/serde-traits"]
 borsh = "1.2.1"
 serde = { version = "1.0.197", optional = true }
 solana-program = ">=1.18.2,<=2"
-spl-discriminator = { version = "0.1", path = "../../libraries/discriminator" }
+spl-discriminator = { version = "0.2", path = "../../libraries/discriminator" }
 spl-program-error = { version = "0.3", path = "../../libraries/program-error" }
 spl-type-length-value = { version = "0.4", path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.2", path = "../../libraries/pod", features = [

--- a/token/transfer-hook/interface/Cargo.toml
+++ b/token/transfer-hook/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-transfer-hook-interface"
-version = "0.6.0"
+version = "0.6.1"
 description = "Solana Program Library Transfer Hook Interface"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -11,7 +11,7 @@ edition = "2021"
 arrayref = "0.3.7"
 bytemuck = { version = "1.15.0", features = ["derive"] }
 solana-program = ">=1.18.2,<=2"
-spl-discriminator = { version = "0.1" , path = "../../../libraries/discriminator" }
+spl-discriminator = { version = "0.2" , path = "../../../libraries/discriminator" }
 spl-program-error = { version = "0.3" , path = "../../../libraries/program-error" }
 spl-tlv-account-resolution = { version = "0.6" , path = "../../../libraries/tlv-account-resolution" }
 spl-type-length-value = { version = "0.4" , path = "../../../libraries/type-length-value" }


### PR DESCRIPTION
#### Problem

The discriminator library is still using borsh 0.10, which is causing very strange failures when trying to publish.

#### Solution

Bump to borsh 1 and its version to 0.2.0