### PR TITLE
 Bump all crates for token-cli release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6835,7 +6835,7 @@ dependencies = [
 
 [[package]]
 name = "spl-associated-token-account"
-version = "3.0.0"
+version = "3.0.2"
 dependencies = [
  "assert_matches",
  "borsh 1.2.1",
@@ -6854,7 +6854,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 3.0.0",
+ "spl-associated-token-account 3.0.2",
  "spl-token 4.0.1",
  "spl-token-2022 3.0.2",
 ]
@@ -7179,7 +7179,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 3.0.0",
+ "spl-associated-token-account 3.0.2",
  "spl-token 4.0.1",
  "thiserror",
 ]
@@ -7356,7 +7356,7 @@ dependencies = [
  "solana-sdk",
  "solana-security-txt",
  "solana-vote-program",
- "spl-associated-token-account 3.0.0",
+ "spl-associated-token-account 3.0.2",
  "spl-token 4.0.1",
  "test-case",
  "thiserror",
@@ -7386,7 +7386,7 @@ dependencies = [
  "solana-test-validator",
  "solana-transaction-status",
  "solana-vote-program",
- "spl-associated-token-account 3.0.0",
+ "spl-associated-token-account 3.0.2",
  "spl-single-pool",
  "spl-token 4.0.1",
  "spl-token-client",
@@ -7443,7 +7443,7 @@ dependencies = [
  "solana-program",
  "solana-remote-wallet",
  "solana-sdk",
- "spl-associated-token-account 3.0.0",
+ "spl-associated-token-account 3.0.2",
  "spl-stake-pool",
  "spl-token 4.0.1",
 ]
@@ -7579,7 +7579,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 3.0.0",
+ "spl-associated-token-account 3.0.2",
  "spl-instruction-padding",
  "spl-memo 4.0.1",
  "spl-pod 0.2.2",
@@ -7618,7 +7618,7 @@ dependencies = [
  "solana-sdk",
  "solana-test-validator",
  "solana-transaction-status",
- "spl-associated-token-account 3.0.0",
+ "spl-associated-token-account 3.0.2",
  "spl-memo 4.0.1",
  "spl-token 4.0.1",
  "spl-token-2022 3.0.2",
@@ -7646,7 +7646,7 @@ dependencies = [
  "solana-rpc-client",
  "solana-rpc-client-api",
  "solana-sdk",
- "spl-associated-token-account 3.0.0",
+ "spl-associated-token-account 3.0.2",
  "spl-memo 4.0.1",
  "spl-token 4.0.1",
  "spl-token-2022 3.0.2",
@@ -7853,7 +7853,7 @@ dependencies = [
  "solana-remote-wallet",
  "solana-sdk",
  "solana-test-validator",
- "spl-associated-token-account 3.0.0",
+ "spl-associated-token-account 3.0.2",
  "spl-token 4.0.1",
  "spl-token-2022 3.0.2",
  "spl-token-client",
@@ -7869,7 +7869,7 @@ dependencies = [
  "bytemuck",
  "num_enum 0.7.2",
  "solana-program",
- "spl-associated-token-account 3.0.0",
+ "spl-associated-token-account 3.0.2",
  "spl-token 4.0.1",
  "spl-token-2022 3.0.2",
  "thiserror",
@@ -7997,7 +7997,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 3.0.0",
+ "spl-associated-token-account 3.0.2",
  "spl-token 4.0.1",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6843,7 +6843,7 @@ dependencies = [
  "num-traits",
  "solana-program",
  "spl-token 4.0.1",
- "spl-token-2022 3.0.0",
+ "spl-token-2022 3.0.2",
  "thiserror",
 ]
 
@@ -6856,7 +6856,7 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account 3.0.0",
  "spl-token 4.0.1",
- "spl-token-2022 3.0.0",
+ "spl-token-2022 3.0.2",
 ]
 
 [[package]]
@@ -7418,7 +7418,7 @@ dependencies = [
  "spl-math",
  "spl-pod 0.2.2",
  "spl-token 4.0.1",
- "spl-token-2022 3.0.0",
+ "spl-token-2022 3.0.2",
  "test-case",
  "thiserror",
 ]
@@ -7539,7 +7539,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-2022"
-version = "3.0.0"
+version = "3.0.2"
 dependencies = [
  "arrayref",
  "base64 0.22.0",
@@ -7584,7 +7584,7 @@ dependencies = [
  "spl-memo 4.0.1",
  "spl-pod 0.2.2",
  "spl-tlv-account-resolution 0.6.3",
- "spl-token-2022 3.0.0",
+ "spl-token-2022 3.0.2",
  "spl-token-client",
  "spl-token-group-interface 0.2.3",
  "spl-token-metadata-interface 0.3.3",
@@ -7621,7 +7621,7 @@ dependencies = [
  "spl-associated-token-account 3.0.0",
  "spl-memo 4.0.1",
  "spl-token 4.0.1",
- "spl-token-2022 3.0.0",
+ "spl-token-2022 3.0.2",
  "spl-token-client",
  "spl-token-group-interface 0.2.3",
  "spl-token-metadata-interface 0.3.3",
@@ -7649,7 +7649,7 @@ dependencies = [
  "spl-associated-token-account 3.0.0",
  "spl-memo 4.0.1",
  "spl-token 4.0.1",
- "spl-token-2022 3.0.0",
+ "spl-token-2022 3.0.2",
  "spl-token-group-interface 0.2.3",
  "spl-token-metadata-interface 0.3.3",
  "spl-transfer-hook-interface 0.6.1",
@@ -7666,7 +7666,7 @@ dependencies = [
  "spl-discriminator 0.2.0",
  "spl-pod 0.2.2",
  "spl-program-error 0.4.0",
- "spl-token-2022 3.0.0",
+ "spl-token-2022 3.0.2",
  "spl-token-client",
  "spl-token-group-example",
  "spl-token-group-interface 0.2.3",
@@ -7683,7 +7683,7 @@ dependencies = [
  "solana-sdk",
  "spl-discriminator 0.2.0",
  "spl-pod 0.2.2",
- "spl-token-2022 3.0.0",
+ "spl-token-2022 3.0.2",
  "spl-token-client",
  "spl-token-group-interface 0.2.3",
  "spl-token-metadata-interface 0.3.3",
@@ -7756,7 +7756,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-pod 0.2.2",
- "spl-token-2022 3.0.0",
+ "spl-token-2022 3.0.2",
  "spl-token-client",
  "spl-token-metadata-interface 0.3.3",
  "spl-type-length-value 0.4.3",
@@ -7806,7 +7806,7 @@ dependencies = [
  "solana-sdk",
  "spl-math",
  "spl-token 4.0.1",
- "spl-token-2022 3.0.0",
+ "spl-token-2022 3.0.2",
  "test-case",
  "thiserror",
 ]
@@ -7834,7 +7834,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-token 4.0.1",
- "spl-token-2022 3.0.0",
+ "spl-token-2022 3.0.2",
  "spl-token-client",
  "test-case",
  "thiserror",
@@ -7855,7 +7855,7 @@ dependencies = [
  "solana-test-validator",
  "spl-associated-token-account 3.0.0",
  "spl-token 4.0.1",
- "spl-token-2022 3.0.0",
+ "spl-token-2022 3.0.2",
  "spl-token-client",
  "spl-token-upgrade",
  "tokio",
@@ -7871,7 +7871,7 @@ dependencies = [
  "solana-program",
  "spl-associated-token-account 3.0.0",
  "spl-token 4.0.1",
- "spl-token-2022 3.0.0",
+ "spl-token-2022 3.0.2",
  "thiserror",
 ]
 
@@ -7892,7 +7892,7 @@ dependencies = [
  "solana-sdk",
  "solana-test-validator",
  "spl-tlv-account-resolution 0.6.3",
- "spl-token-2022 3.0.0",
+ "spl-token-2022 3.0.2",
  "spl-token-client",
  "spl-transfer-hook-interface 0.6.1",
  "strum 0.26.2",
@@ -7909,7 +7909,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-tlv-account-resolution 0.6.3",
- "spl-token-2022 3.0.0",
+ "spl-token-2022 3.0.2",
  "spl-transfer-hook-interface 0.6.1",
  "spl-type-length-value 0.4.3",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7562,7 +7562,7 @@ dependencies = [
  "spl-pod 0.2.2",
  "spl-tlv-account-resolution 0.6.3",
  "spl-token 4.0.1",
- "spl-token-group-interface 0.2.1",
+ "spl-token-group-interface 0.2.3",
  "spl-token-metadata-interface 0.3.1",
  "spl-transfer-hook-interface 0.6.1",
  "spl-type-length-value 0.4.3",
@@ -7586,7 +7586,7 @@ dependencies = [
  "spl-tlv-account-resolution 0.6.3",
  "spl-token-2022 3.0.0",
  "spl-token-client",
- "spl-token-group-interface 0.2.1",
+ "spl-token-group-interface 0.2.3",
  "spl-token-metadata-interface 0.3.1",
  "spl-transfer-hook-example",
  "spl-transfer-hook-interface 0.6.1",
@@ -7623,7 +7623,7 @@ dependencies = [
  "spl-token 4.0.1",
  "spl-token-2022 3.0.0",
  "spl-token-client",
- "spl-token-group-interface 0.2.1",
+ "spl-token-group-interface 0.2.3",
  "spl-token-metadata-interface 0.3.1",
  "strum 0.26.2",
  "strum_macros 0.26.2",
@@ -7650,7 +7650,7 @@ dependencies = [
  "spl-memo 4.0.1",
  "spl-token 4.0.1",
  "spl-token-2022 3.0.0",
- "spl-token-group-interface 0.2.1",
+ "spl-token-group-interface 0.2.3",
  "spl-token-metadata-interface 0.3.1",
  "spl-transfer-hook-interface 0.6.1",
  "thiserror",
@@ -7669,7 +7669,7 @@ dependencies = [
  "spl-token-2022 3.0.0",
  "spl-token-client",
  "spl-token-group-example",
- "spl-token-group-interface 0.2.1",
+ "spl-token-group-interface 0.2.3",
  "spl-token-metadata-interface 0.3.1",
  "spl-type-length-value 0.4.3",
 ]
@@ -7685,7 +7685,7 @@ dependencies = [
  "spl-pod 0.2.2",
  "spl-token-2022 3.0.0",
  "spl-token-client",
- "spl-token-group-interface 0.2.1",
+ "spl-token-group-interface 0.2.3",
  "spl-token-metadata-interface 0.3.1",
  "spl-type-length-value 0.4.3",
 ]
@@ -7705,7 +7705,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-group-interface"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "bytemuck",
  "solana-program",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7634,7 +7634,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-client"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "curve25519-dalek",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7464,7 +7464,7 @@ dependencies = [
 
 [[package]]
 name = "spl-tlv-account-resolution"
-version = "0.6.1"
+version = "0.6.3"
 dependencies = [
  "bytemuck",
  "futures 0.3.30",
@@ -7560,7 +7560,7 @@ dependencies = [
  "solana-zk-token-sdk",
  "spl-memo 4.0.1",
  "spl-pod 0.2.2",
- "spl-tlv-account-resolution 0.6.1",
+ "spl-tlv-account-resolution 0.6.3",
  "spl-token 4.0.1",
  "spl-token-group-interface 0.2.1",
  "spl-token-metadata-interface 0.3.1",
@@ -7583,7 +7583,7 @@ dependencies = [
  "spl-instruction-padding",
  "spl-memo 4.0.1",
  "spl-pod 0.2.2",
- "spl-tlv-account-resolution 0.6.1",
+ "spl-tlv-account-resolution 0.6.3",
  "spl-token-2022 3.0.0",
  "spl-token-client",
  "spl-token-group-interface 0.2.1",
@@ -7891,7 +7891,7 @@ dependencies = [
  "solana-remote-wallet",
  "solana-sdk",
  "solana-test-validator",
- "spl-tlv-account-resolution 0.6.1",
+ "spl-tlv-account-resolution 0.6.3",
  "spl-token-2022 3.0.0",
  "spl-token-client",
  "spl-transfer-hook-interface 0.6.1",
@@ -7908,7 +7908,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-tlv-account-resolution 0.6.1",
+ "spl-tlv-account-resolution 0.6.3",
  "spl-token-2022 3.0.0",
  "spl-transfer-hook-interface 0.6.1",
  "spl-type-length-value 0.4.3",
@@ -7940,7 +7940,7 @@ dependencies = [
  "spl-discriminator 0.2.0",
  "spl-pod 0.2.2",
  "spl-program-error 0.4.0",
- "spl-tlv-account-resolution 0.6.1",
+ "spl-tlv-account-resolution 0.6.3",
  "spl-type-length-value 0.4.3",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6900,12 +6900,12 @@ dependencies = [
 
 [[package]]
 name = "spl-discriminator"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "borsh 1.2.1",
  "bytemuck",
  "solana-program",
- "spl-discriminator-derive 0.1.2",
+ "spl-discriminator-derive 0.2.0",
 ]
 
 [[package]]
@@ -6921,10 +6921,10 @@ dependencies = [
 
 [[package]]
 name = "spl-discriminator-derive"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "quote",
- "spl-discriminator-syn 0.1.2",
+ "spl-discriminator-syn 0.2.0",
  "syn 2.0.46",
 ]
 
@@ -6943,7 +6943,7 @@ dependencies = [
 
 [[package]]
 name = "spl-discriminator-syn"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7474,7 +7474,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-discriminator 0.2.0",
+ "spl-discriminator 0.2.2",
  "spl-pod 0.2.2",
  "spl-program-error 0.4.0",
  "spl-type-length-value 0.4.3",
@@ -7663,7 +7663,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-discriminator 0.2.0",
+ "spl-discriminator 0.2.2",
  "spl-pod 0.2.2",
  "spl-program-error 0.4.0",
  "spl-token-2022 3.0.2",
@@ -7681,7 +7681,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-discriminator 0.2.0",
+ "spl-discriminator 0.2.2",
  "spl-pod 0.2.2",
  "spl-token-2022 3.0.2",
  "spl-token-client",
@@ -7709,7 +7709,7 @@ version = "0.2.3"
 dependencies = [
  "bytemuck",
  "solana-program",
- "spl-discriminator 0.2.0",
+ "spl-discriminator 0.2.2",
  "spl-pod 0.2.2",
  "spl-program-error 0.4.0",
  "spl-type-length-value 0.4.3",
@@ -7785,7 +7785,7 @@ dependencies = [
  "serde",
  "serde_json",
  "solana-program",
- "spl-discriminator 0.2.0",
+ "spl-discriminator 0.2.2",
  "spl-pod 0.2.2",
  "spl-program-error 0.4.0",
  "spl-type-length-value 0.4.3",
@@ -7937,7 +7937,7 @@ dependencies = [
  "arrayref",
  "bytemuck",
  "solana-program",
- "spl-discriminator 0.2.0",
+ "spl-discriminator 0.2.2",
  "spl-pod 0.2.2",
  "spl-program-error 0.4.0",
  "spl-tlv-account-resolution 0.6.3",
@@ -7964,7 +7964,7 @@ version = "0.4.3"
 dependencies = [
  "bytemuck",
  "solana-program",
- "spl-discriminator 0.2.0",
+ "spl-discriminator 0.2.2",
  "spl-pod 0.2.2",
  "spl-program-error 0.4.0",
  "spl-type-length-value-derive",
@@ -7985,7 +7985,7 @@ version = "0.1.0"
 dependencies = [
  "borsh 1.2.1",
  "solana-program",
- "spl-discriminator 0.2.0",
+ "spl-discriminator 0.2.2",
  "spl-type-length-value 0.4.3",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7477,7 +7477,7 @@ dependencies = [
  "spl-discriminator 0.2.0",
  "spl-pod 0.2.2",
  "spl-program-error 0.4.0",
- "spl-type-length-value 0.4.1",
+ "spl-type-length-value 0.4.3",
 ]
 
 [[package]]
@@ -7565,7 +7565,7 @@ dependencies = [
  "spl-token-group-interface 0.2.1",
  "spl-token-metadata-interface 0.3.1",
  "spl-transfer-hook-interface 0.6.1",
- "spl-type-length-value 0.4.1",
+ "spl-type-length-value 0.4.3",
  "thiserror",
 ]
 
@@ -7671,7 +7671,7 @@ dependencies = [
  "spl-token-group-example",
  "spl-token-group-interface 0.2.1",
  "spl-token-metadata-interface 0.3.1",
- "spl-type-length-value 0.4.1",
+ "spl-type-length-value 0.4.3",
 ]
 
 [[package]]
@@ -7687,7 +7687,7 @@ dependencies = [
  "spl-token-client",
  "spl-token-group-interface 0.2.1",
  "spl-token-metadata-interface 0.3.1",
- "spl-type-length-value 0.4.1",
+ "spl-type-length-value 0.4.3",
 ]
 
 [[package]]
@@ -7712,7 +7712,7 @@ dependencies = [
  "spl-discriminator 0.2.0",
  "spl-pod 0.2.2",
  "spl-program-error 0.4.0",
- "spl-type-length-value 0.4.1",
+ "spl-type-length-value 0.4.3",
 ]
 
 [[package]]
@@ -7759,7 +7759,7 @@ dependencies = [
  "spl-token-2022 3.0.0",
  "spl-token-client",
  "spl-token-metadata-interface 0.3.1",
- "spl-type-length-value 0.4.1",
+ "spl-type-length-value 0.4.3",
  "test-case",
 ]
 
@@ -7788,7 +7788,7 @@ dependencies = [
  "spl-discriminator 0.2.0",
  "spl-pod 0.2.2",
  "spl-program-error 0.4.0",
- "spl-type-length-value 0.4.1",
+ "spl-type-length-value 0.4.3",
 ]
 
 [[package]]
@@ -7911,7 +7911,7 @@ dependencies = [
  "spl-tlv-account-resolution 0.6.1",
  "spl-token-2022 3.0.0",
  "spl-transfer-hook-interface 0.6.1",
- "spl-type-length-value 0.4.1",
+ "spl-type-length-value 0.4.3",
 ]
 
 [[package]]
@@ -7941,7 +7941,7 @@ dependencies = [
  "spl-pod 0.2.2",
  "spl-program-error 0.4.0",
  "spl-tlv-account-resolution 0.6.1",
- "spl-type-length-value 0.4.1",
+ "spl-type-length-value 0.4.3",
  "tokio",
 ]
 
@@ -7960,7 +7960,7 @@ dependencies = [
 
 [[package]]
 name = "spl-type-length-value"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "bytemuck",
  "solana-program",
@@ -7986,7 +7986,7 @@ dependencies = [
  "borsh 1.2.1",
  "solana-program",
  "spl-discriminator 0.2.0",
- "spl-type-length-value 0.4.1",
+ "spl-type-length-value 0.4.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7564,7 +7564,7 @@ dependencies = [
  "spl-token 4.0.1",
  "spl-token-group-interface 0.2.3",
  "spl-token-metadata-interface 0.3.3",
- "spl-transfer-hook-interface 0.6.1",
+ "spl-transfer-hook-interface 0.6.3",
  "spl-type-length-value 0.4.3",
  "thiserror",
 ]
@@ -7589,7 +7589,7 @@ dependencies = [
  "spl-token-group-interface 0.2.3",
  "spl-token-metadata-interface 0.3.3",
  "spl-transfer-hook-example",
- "spl-transfer-hook-interface 0.6.1",
+ "spl-transfer-hook-interface 0.6.3",
  "test-case",
  "walkdir",
 ]
@@ -7652,7 +7652,7 @@ dependencies = [
  "spl-token-2022 3.0.2",
  "spl-token-group-interface 0.2.3",
  "spl-token-metadata-interface 0.3.3",
- "spl-transfer-hook-interface 0.6.1",
+ "spl-transfer-hook-interface 0.6.3",
  "thiserror",
 ]
 
@@ -7894,7 +7894,7 @@ dependencies = [
  "spl-tlv-account-resolution 0.6.3",
  "spl-token-2022 3.0.2",
  "spl-token-client",
- "spl-transfer-hook-interface 0.6.1",
+ "spl-transfer-hook-interface 0.6.3",
  "strum 0.26.2",
  "strum_macros 0.26.2",
  "tokio",
@@ -7910,7 +7910,7 @@ dependencies = [
  "solana-sdk",
  "spl-tlv-account-resolution 0.6.3",
  "spl-token-2022 3.0.2",
- "spl-transfer-hook-interface 0.6.1",
+ "spl-transfer-hook-interface 0.6.3",
  "spl-type-length-value 0.4.3",
 ]
 
@@ -7932,7 +7932,7 @@ dependencies = [
 
 [[package]]
 name = "spl-transfer-hook-interface"
-version = "0.6.1"
+version = "0.6.3"
 dependencies = [
  "arrayref",
  "bytemuck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7254,7 +7254,7 @@ dependencies = [
 
 [[package]]
 name = "spl-pod"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "base64 0.22.0",
  "borsh 1.2.1",
@@ -7325,7 +7325,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-pod 0.2.0",
+ "spl-pod 0.2.2",
  "thiserror",
 ]
 
@@ -7416,7 +7416,7 @@ dependencies = [
  "solana-security-txt",
  "solana-vote-program",
  "spl-math",
- "spl-pod 0.2.0",
+ "spl-pod 0.2.2",
  "spl-token 4.0.1",
  "spl-token-2022 3.0.0",
  "test-case",
@@ -7475,7 +7475,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-discriminator 0.2.0",
- "spl-pod 0.2.0",
+ "spl-pod 0.2.2",
  "spl-program-error 0.3.1",
  "spl-type-length-value 0.4.1",
 ]
@@ -7559,7 +7559,7 @@ dependencies = [
  "solana-security-txt",
  "solana-zk-token-sdk",
  "spl-memo 4.0.1",
- "spl-pod 0.2.0",
+ "spl-pod 0.2.2",
  "spl-tlv-account-resolution 0.6.1",
  "spl-token 4.0.1",
  "spl-token-group-interface 0.2.1",
@@ -7582,7 +7582,7 @@ dependencies = [
  "spl-associated-token-account 3.0.0",
  "spl-instruction-padding",
  "spl-memo 4.0.1",
- "spl-pod 0.2.0",
+ "spl-pod 0.2.2",
  "spl-tlv-account-resolution 0.6.1",
  "spl-token-2022 3.0.0",
  "spl-token-client",
@@ -7664,7 +7664,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-discriminator 0.2.0",
- "spl-pod 0.2.0",
+ "spl-pod 0.2.2",
  "spl-program-error 0.3.1",
  "spl-token-2022 3.0.0",
  "spl-token-client",
@@ -7682,7 +7682,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-discriminator 0.2.0",
- "spl-pod 0.2.0",
+ "spl-pod 0.2.2",
  "spl-token-2022 3.0.0",
  "spl-token-client",
  "spl-token-group-interface 0.2.1",
@@ -7710,7 +7710,7 @@ dependencies = [
  "bytemuck",
  "solana-program",
  "spl-discriminator 0.2.0",
- "spl-pod 0.2.0",
+ "spl-pod 0.2.2",
  "spl-program-error 0.3.1",
  "spl-type-length-value 0.4.1",
 ]
@@ -7755,7 +7755,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-pod 0.2.0",
+ "spl-pod 0.2.2",
  "spl-token-2022 3.0.0",
  "spl-token-client",
  "spl-token-metadata-interface 0.3.1",
@@ -7786,7 +7786,7 @@ dependencies = [
  "serde_json",
  "solana-program",
  "spl-discriminator 0.2.0",
- "spl-pod 0.2.0",
+ "spl-pod 0.2.2",
  "spl-program-error 0.3.1",
  "spl-type-length-value 0.4.1",
 ]
@@ -7938,7 +7938,7 @@ dependencies = [
  "bytemuck",
  "solana-program",
  "spl-discriminator 0.2.0",
- "spl-pod 0.2.0",
+ "spl-pod 0.2.2",
  "spl-program-error 0.3.1",
  "spl-tlv-account-resolution 0.6.1",
  "spl-type-length-value 0.4.1",
@@ -7965,7 +7965,7 @@ dependencies = [
  "bytemuck",
  "solana-program",
  "spl-discriminator 0.2.0",
- "spl-pod 0.2.0",
+ "spl-pod 0.2.2",
  "spl-program-error 0.3.1",
  "spl-type-length-value-derive",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7015,7 +7015,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-program-error 0.3.1",
+ "spl-program-error 0.4.0",
 ]
 
 [[package]]
@@ -7263,7 +7263,7 @@ dependencies = [
  "serde_json",
  "solana-program",
  "solana-zk-token-sdk",
- "spl-program-error 0.3.1",
+ "spl-program-error 0.4.0",
 ]
 
 [[package]]
@@ -7281,7 +7281,7 @@ dependencies = [
 
 [[package]]
 name = "spl-program-error"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "lazy_static",
  "num-derive 0.4.2",
@@ -7289,7 +7289,7 @@ dependencies = [
  "serial_test",
  "solana-program",
  "solana-sdk",
- "spl-program-error-derive 0.3.2",
+ "spl-program-error-derive 0.4.0",
  "thiserror",
 ]
 
@@ -7307,7 +7307,7 @@ dependencies = [
 
 [[package]]
 name = "spl-program-error-derive"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7476,7 +7476,7 @@ dependencies = [
  "solana-sdk",
  "spl-discriminator 0.2.0",
  "spl-pod 0.2.2",
- "spl-program-error 0.3.1",
+ "spl-program-error 0.4.0",
  "spl-type-length-value 0.4.1",
 ]
 
@@ -7665,7 +7665,7 @@ dependencies = [
  "solana-sdk",
  "spl-discriminator 0.2.0",
  "spl-pod 0.2.2",
- "spl-program-error 0.3.1",
+ "spl-program-error 0.4.0",
  "spl-token-2022 3.0.0",
  "spl-token-client",
  "spl-token-group-example",
@@ -7711,7 +7711,7 @@ dependencies = [
  "solana-program",
  "spl-discriminator 0.2.0",
  "spl-pod 0.2.2",
- "spl-program-error 0.3.1",
+ "spl-program-error 0.4.0",
  "spl-type-length-value 0.4.1",
 ]
 
@@ -7787,7 +7787,7 @@ dependencies = [
  "solana-program",
  "spl-discriminator 0.2.0",
  "spl-pod 0.2.2",
- "spl-program-error 0.3.1",
+ "spl-program-error 0.4.0",
  "spl-type-length-value 0.4.1",
 ]
 
@@ -7939,7 +7939,7 @@ dependencies = [
  "solana-program",
  "spl-discriminator 0.2.0",
  "spl-pod 0.2.2",
- "spl-program-error 0.3.1",
+ "spl-program-error 0.4.0",
  "spl-tlv-account-resolution 0.6.1",
  "spl-type-length-value 0.4.1",
  "tokio",
@@ -7966,7 +7966,7 @@ dependencies = [
  "solana-program",
  "spl-discriminator 0.2.0",
  "spl-pod 0.2.2",
- "spl-program-error 0.3.1",
+ "spl-program-error 0.4.0",
  "spl-type-length-value-derive",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7563,7 +7563,7 @@ dependencies = [
  "spl-tlv-account-resolution 0.6.3",
  "spl-token 4.0.1",
  "spl-token-group-interface 0.2.3",
- "spl-token-metadata-interface 0.3.1",
+ "spl-token-metadata-interface 0.3.3",
  "spl-transfer-hook-interface 0.6.1",
  "spl-type-length-value 0.4.3",
  "thiserror",
@@ -7587,7 +7587,7 @@ dependencies = [
  "spl-token-2022 3.0.0",
  "spl-token-client",
  "spl-token-group-interface 0.2.3",
- "spl-token-metadata-interface 0.3.1",
+ "spl-token-metadata-interface 0.3.3",
  "spl-transfer-hook-example",
  "spl-transfer-hook-interface 0.6.1",
  "test-case",
@@ -7624,7 +7624,7 @@ dependencies = [
  "spl-token-2022 3.0.0",
  "spl-token-client",
  "spl-token-group-interface 0.2.3",
- "spl-token-metadata-interface 0.3.1",
+ "spl-token-metadata-interface 0.3.3",
  "strum 0.26.2",
  "strum_macros 0.26.2",
  "tempfile",
@@ -7651,7 +7651,7 @@ dependencies = [
  "spl-token 4.0.1",
  "spl-token-2022 3.0.0",
  "spl-token-group-interface 0.2.3",
- "spl-token-metadata-interface 0.3.1",
+ "spl-token-metadata-interface 0.3.3",
  "spl-transfer-hook-interface 0.6.1",
  "thiserror",
 ]
@@ -7670,7 +7670,7 @@ dependencies = [
  "spl-token-client",
  "spl-token-group-example",
  "spl-token-group-interface 0.2.3",
- "spl-token-metadata-interface 0.3.1",
+ "spl-token-metadata-interface 0.3.3",
  "spl-type-length-value 0.4.3",
 ]
 
@@ -7686,7 +7686,7 @@ dependencies = [
  "spl-token-2022 3.0.0",
  "spl-token-client",
  "spl-token-group-interface 0.2.3",
- "spl-token-metadata-interface 0.3.1",
+ "spl-token-metadata-interface 0.3.3",
  "spl-type-length-value 0.4.3",
 ]
 
@@ -7758,7 +7758,7 @@ dependencies = [
  "spl-pod 0.2.2",
  "spl-token-2022 3.0.0",
  "spl-token-client",
- "spl-token-metadata-interface 0.3.1",
+ "spl-token-metadata-interface 0.3.3",
  "spl-type-length-value 0.4.3",
  "test-case",
 ]
@@ -7779,7 +7779,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-metadata-interface"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "borsh 1.2.1",
  "serde",

--- a/associated-token-account/program-test/Cargo.toml
+++ b/associated-token-account/program-test/Cargo.toml
@@ -16,4 +16,4 @@ solana-program-test = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
 spl-associated-token-account = { version = "3.0", path = "../program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = ["no-entrypoint"] }

--- a/associated-token-account/program-test/Cargo.toml
+++ b/associated-token-account/program-test/Cargo.toml
@@ -14,6 +14,6 @@ test-sbf = []
 solana-program = ">=1.18.2,<=2"
 solana-program-test = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
-spl-associated-token-account = { version = "3.0", path = "../program", features = ["no-entrypoint"] }
+spl-associated-token-account = { version = "3.0.2", path = "../program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = ["no-entrypoint"] }

--- a/associated-token-account/program/Cargo.toml
+++ b/associated-token-account/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-associated-token-account"
-version = "3.0.0"
+version = "3.0.2"
 description = "Solana Program Library Associated Token Account"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/associated-token-account/program/Cargo.toml
+++ b/associated-token-account/program/Cargo.toml
@@ -20,7 +20,7 @@ solana-program = ">=1.18.2,<=2"
 spl-token = { version = "4.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
-spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = [
+spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = [
   "no-entrypoint",
 ] }
 thiserror = "1.0"

--- a/feature-gate/program/Cargo.toml
+++ b/feature-gate/program/Cargo.toml
@@ -14,7 +14,7 @@ test-sbf = []
 [dependencies]
 num_enum = "0.7.2"
 solana-program = ">=1.18.2,<=2"
-spl-program-error = { version = "0.3.1", path = "../../libraries/program-error" }
+spl-program-error = { version = "0.4.0", path = "../../libraries/program-error" }
 
 [dev-dependencies]
 solana-program-test = ">=1.18.2,<=2"

--- a/libraries/discriminator/Cargo.toml
+++ b/libraries/discriminator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-discriminator"
-version = "0.2.0"
+version = "0.2.2"
 description = "Solana Program Library 8-Byte Discriminator Management"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -14,7 +14,7 @@ borsh = ["dep:borsh"]
 borsh = { version = "1", optional = true }
 bytemuck = { version = "1.15.0", features = ["derive"] }
 solana-program = ">=1.18.2,<=2"
-spl-discriminator-derive = { version = "0.1.2", path = "./derive" }
+spl-discriminator-derive = { version = "0.2.0", path = "./derive" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/libraries/discriminator/derive/Cargo.toml
+++ b/libraries/discriminator/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-discriminator-derive"
-version = "0.1.2"
+version = "0.2.0"
 description = "Derive macro library for the `spl-discriminator` library"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -9,7 +9,7 @@ edition = "2021"
 
 [dependencies]
 quote = "1.0"
-spl-discriminator-syn = { version = "0.1.2", path = "../syn" }
+spl-discriminator-syn = { version = "0.2.0", path = "../syn" }
 syn = { version = "2.0", features = ["full"] }
 
 [lib]

--- a/libraries/discriminator/syn/Cargo.toml
+++ b/libraries/discriminator/syn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-discriminator-syn"
-version = "0.1.2"
+version = "0.2.0"
 description = "Token parsing and generating library for the `spl-discriminator` library"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/libraries/pod/Cargo.toml
+++ b/libraries/pod/Cargo.toml
@@ -18,7 +18,7 @@ bytemuck = { version = "1.15.0" }
 serde = { version = "1.0.197", optional = true }
 solana-program = ">=1.18.2,<=2"
 solana-zk-token-sdk = ">=1.18.2,<=2"
-spl-program-error = { version = "0.3", path = "../program-error" }
+spl-program-error = { version = "0.4.0", path = "../program-error" }
 
 [dev-dependencies]
 serde_json = "1.0.115"

--- a/libraries/pod/Cargo.toml
+++ b/libraries/pod/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-pod"
-version = "0.2.0"
+version = "0.2.2"
 description = "Solana Program Library Plain Old Data (Pod)"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/libraries/program-error/Cargo.toml
+++ b/libraries/program-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-program-error"
-version = "0.3.1"
+version = "0.4.0"
 description = "Library for Solana Program error attributes and derive macro for creating them"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -11,7 +11,7 @@ edition = "2021"
 num-derive = "0.4"
 num-traits = "0.2"
 solana-program = ">=1.18.2,<=2"
-spl-program-error-derive = { version = "0.3.2", path = "./derive" }
+spl-program-error-derive = { version = "0.4.0", path = "./derive" }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/libraries/program-error/derive/Cargo.toml
+++ b/libraries/program-error/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-program-error-derive"
-version = "0.3.2"
+version = "0.4.0"
 description = "Proc-Macro Library for Solana Program error attributes and derive macro"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/libraries/tlv-account-resolution/Cargo.toml
+++ b/libraries/tlv-account-resolution/Cargo.toml
@@ -15,7 +15,7 @@ test-sbf = []
 bytemuck = { version = "1.15.0", features = ["derive"] }
 serde = { version = "1.0.197", optional = true }
 solana-program = ">=1.18.2,<=2"
-spl-discriminator = { version = "0.2", path = "../discriminator" }
+spl-discriminator = { version = "0.2.2", path = "../discriminator" }
 spl-program-error = { version = "0.4.0", path = "../program-error" }
 spl-type-length-value = { version = "0.4.3", path = "../type-length-value" }
 spl-pod = { version = "0.2.2", path = "../pod" }

--- a/libraries/tlv-account-resolution/Cargo.toml
+++ b/libraries/tlv-account-resolution/Cargo.toml
@@ -16,7 +16,7 @@ bytemuck = { version = "1.15.0", features = ["derive"] }
 serde = { version = "1.0.197", optional = true }
 solana-program = ">=1.18.2,<=2"
 spl-discriminator = { version = "0.2", path = "../discriminator" }
-spl-program-error = { version = "0.3", path = "../program-error" }
+spl-program-error = { version = "0.4.0", path = "../program-error" }
 spl-type-length-value = { version = "0.4", path = "../type-length-value" }
 spl-pod = { version = "0.2.2", path = "../pod" }
 

--- a/libraries/tlv-account-resolution/Cargo.toml
+++ b/libraries/tlv-account-resolution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-tlv-account-resolution"
-version = "0.6.1"
+version = "0.6.3"
 description = "Solana Program Library TLV Account Resolution Interface"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/libraries/tlv-account-resolution/Cargo.toml
+++ b/libraries/tlv-account-resolution/Cargo.toml
@@ -18,7 +18,7 @@ solana-program = ">=1.18.2,<=2"
 spl-discriminator = { version = "0.2", path = "../discriminator" }
 spl-program-error = { version = "0.3", path = "../program-error" }
 spl-type-length-value = { version = "0.4", path = "../type-length-value" }
-spl-pod = { version = "0.2", path = "../pod" }
+spl-pod = { version = "0.2.2", path = "../pod" }
 
 [dev-dependencies]
 futures = "0.3.30"

--- a/libraries/tlv-account-resolution/Cargo.toml
+++ b/libraries/tlv-account-resolution/Cargo.toml
@@ -17,7 +17,7 @@ serde = { version = "1.0.197", optional = true }
 solana-program = ">=1.18.2,<=2"
 spl-discriminator = { version = "0.2", path = "../discriminator" }
 spl-program-error = { version = "0.4.0", path = "../program-error" }
-spl-type-length-value = { version = "0.4", path = "../type-length-value" }
+spl-type-length-value = { version = "0.4.3", path = "../type-length-value" }
 spl-pod = { version = "0.2.2", path = "../pod" }
 
 [dev-dependencies]

--- a/libraries/type-length-value-derive-test/Cargo.toml
+++ b/libraries/type-length-value-derive-test/Cargo.toml
@@ -11,6 +11,6 @@ edition = "2021"
 borsh = "1.2.1"
 solana-program = "1.16"
 spl-discriminator = { version = "0.2", path = "../discriminator" }
-spl-type-length-value = { version = "0.4", path = "../type-length-value", features = [
+spl-type-length-value = { version = "0.4.3", path = "../type-length-value", features = [
   "derive",
 ] }

--- a/libraries/type-length-value-derive-test/Cargo.toml
+++ b/libraries/type-length-value-derive-test/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dev-dependencies]
 borsh = "1.2.1"
 solana-program = "1.16"
-spl-discriminator = { version = "0.2", path = "../discriminator" }
+spl-discriminator = { version = "0.2.2", path = "../discriminator" }
 spl-type-length-value = { version = "0.4.3", path = "../type-length-value", features = [
   "derive",
 ] }

--- a/libraries/type-length-value/Cargo.toml
+++ b/libraries/type-length-value/Cargo.toml
@@ -14,7 +14,7 @@ derive = ["dep:spl-type-length-value-derive"]
 [dependencies]
 bytemuck = { version = "1.15.0", features = ["derive"] }
 solana-program = ">=1.18.2,<=2"
-spl-discriminator = { version = "0.2", path = "../discriminator" }
+spl-discriminator = { version = "0.2.2", path = "../discriminator" }
 spl-program-error = { version = "0.4.0", path = "../program-error" }
 spl-type-length-value-derive = { version = "0.1", path = "./derive", optional = true }
 spl-pod = { version = "0.2.2", path = "../pod" }

--- a/libraries/type-length-value/Cargo.toml
+++ b/libraries/type-length-value/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-type-length-value"
-version = "0.4.1"
+version = "0.4.3"
 description = "Solana Program Library Type-Length-Value Management"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/libraries/type-length-value/Cargo.toml
+++ b/libraries/type-length-value/Cargo.toml
@@ -15,7 +15,7 @@ derive = ["dep:spl-type-length-value-derive"]
 bytemuck = { version = "1.15.0", features = ["derive"] }
 solana-program = ">=1.18.2,<=2"
 spl-discriminator = { version = "0.2", path = "../discriminator" }
-spl-program-error = { version = "0.3", path = "../program-error" }
+spl-program-error = { version = "0.4.0", path = "../program-error" }
 spl-type-length-value-derive = { version = "0.1", path = "./derive", optional = true }
 spl-pod = { version = "0.2.2", path = "../pod" }
 

--- a/libraries/type-length-value/Cargo.toml
+++ b/libraries/type-length-value/Cargo.toml
@@ -17,7 +17,7 @@ solana-program = ">=1.18.2,<=2"
 spl-discriminator = { version = "0.2", path = "../discriminator" }
 spl-program-error = { version = "0.3", path = "../program-error" }
 spl-type-length-value-derive = { version = "0.1", path = "./derive", optional = true }
-spl-pod = { version = "0.2", path = "../pod" }
+spl-pod = { version = "0.2.2", path = "../pod" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/managed-token/program/Cargo.toml
+++ b/managed-token/program/Cargo.toml
@@ -25,7 +25,7 @@ test = []
 borsh = "1.2.1"
 shank = "^0.4.2"
 solana-program = ">=1.18.2,<=2"
-spl-associated-token-account = { version = "3.0", path = "../../associated-token-account/program", features = [
+spl-associated-token-account = { version = "3.0.2", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }
 spl-token = { version = "4.0", path = "../../token/program", features = [

--- a/record/program/Cargo.toml
+++ b/record/program/Cargo.toml
@@ -17,7 +17,7 @@ num-derive = "0.4"
 num-traits = "0.2"
 solana-program = ">=1.18.2,<=2"
 thiserror = "1.0"
-spl-pod = { version = "0.2", path = "../../libraries/pod" }
+spl-pod = { version = "0.2.2", path = "../../libraries/pod" }
 
 [dev-dependencies]
 solana-program-test = ">=1.18.2,<=2"

--- a/single-pool/cli/Cargo.toml
+++ b/single-pool/cli/Cargo.toml
@@ -30,7 +30,7 @@ solana-vote-program = ">=1.18.2,<=2"
 spl-token = { version = "4.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
-spl-token-client = { version = "0.9", path = "../../token/client" }
+spl-token-client = { version = "0.9.2", path = "../../token/client" }
 spl-associated-token-account = { version = "3.0", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }

--- a/single-pool/cli/Cargo.toml
+++ b/single-pool/cli/Cargo.toml
@@ -31,7 +31,7 @@ spl-token = { version = "4.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
 spl-token-client = { version = "0.9.2", path = "../../token/client" }
-spl-associated-token-account = { version = "3.0", path = "../../associated-token-account/program", features = [
+spl-associated-token-account = { version = "3.0.2", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }
 spl-single-pool = { version = "1.0.0", path = "../program", features = [

--- a/single-pool/program/Cargo.toml
+++ b/single-pool/program/Cargo.toml
@@ -22,7 +22,7 @@ solana-security-txt = "1.1.1"
 spl-token = { version = "4.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
-spl-associated-token-account = { version = "3.0", path = "../../associated-token-account/program", features = [
+spl-associated-token-account = { version = "3.0.2", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }
 thiserror = "1.0"

--- a/stake-pool/cli/Cargo.toml
+++ b/stake-pool/cli/Cargo.toml
@@ -23,7 +23,7 @@ solana-logger = ">=1.18.2,<=2"
 solana-program = ">=1.18.2,<=2"
 solana-remote-wallet = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
-spl-associated-token-account = { version = "=3.0", path = "../../associated-token-account/program", features = [
+spl-associated-token-account = { version = "=3.0.2", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }
 spl-stake-pool = { version = "=1.0.0", path = "../program", features = [

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -25,7 +25,7 @@ solana-security-txt = "1.1.1"
 spl-math = { version = "0.2", path = "../../libraries/math", features = [
   "no-entrypoint",
 ] }
-spl-pod = { version = "0.2", path = "../../libraries/pod", features = [
+spl-pod = { version = "0.2.2", path = "../../libraries/pod", features = [
   "borsh",
 ] }
 spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = [

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -28,7 +28,7 @@ spl-math = { version = "0.2", path = "../../libraries/math", features = [
 spl-pod = { version = "0.2.2", path = "../../libraries/pod", features = [
   "borsh",
 ] }
-spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = [
+spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = [
   "no-entrypoint",
 ] }
 thiserror = "1.0"

--- a/stateless-asks/program/Cargo.toml
+++ b/stateless-asks/program/Cargo.toml
@@ -16,7 +16,7 @@ solana-program = ">=1.18.2,<=2"
 spl-token = { version = "4.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
-spl-associated-token-account = { version = "3.0", path = "../../associated-token-account/program", features = [
+spl-associated-token-account = { version = "3.0.2", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }
 thiserror = "1.0"

--- a/token-collection/program/Cargo.toml
+++ b/token-collection/program/Cargo.toml
@@ -18,7 +18,7 @@ spl-program-error = { version = "0.4.0" , path = "../../libraries/program-error"
 spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-group-example = { version = "0.2", path = "../../token-group/example", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.2.3", path = "../../token-group/interface" }
-spl-token-metadata-interface = { version = "0.3", path = "../../token-metadata/interface" }
+spl-token-metadata-interface = { version = "0.3.3", path = "../../token-metadata/interface" }
 spl-type-length-value = { version = "0.4.3", path = "../../libraries/type-length-value" }
 
 [dev-dependencies]

--- a/token-collection/program/Cargo.toml
+++ b/token-collection/program/Cargo.toml
@@ -24,7 +24,7 @@ spl-type-length-value = { version = "0.4.3", path = "../../libraries/type-length
 [dev-dependencies]
 solana-program-test = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
-spl-discriminator = { version = "0.2", path = "../../libraries/discriminator" }
+spl-discriminator = { version = "0.2.2", path = "../../libraries/discriminator" }
 spl-token-client = { version = "0.9.2", path = "../../token/client" }
 
 [lib]

--- a/token-collection/program/Cargo.toml
+++ b/token-collection/program/Cargo.toml
@@ -17,7 +17,7 @@ spl-pod = { version = "0.2.2", path = "../../libraries/pod" }
 spl-program-error = { version = "0.4.0" , path = "../../libraries/program-error" }
 spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-group-example = { version = "0.2", path = "../../token-group/example", features = ["no-entrypoint"] }
-spl-token-group-interface = { version = "0.2", path = "../../token-group/interface" }
+spl-token-group-interface = { version = "0.2.3", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.3", path = "../../token-metadata/interface" }
 spl-type-length-value = { version = "0.4.3", path = "../../libraries/type-length-value" }
 

--- a/token-collection/program/Cargo.toml
+++ b/token-collection/program/Cargo.toml
@@ -19,7 +19,7 @@ spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features 
 spl-token-group-example = { version = "0.2", path = "../../token-group/example", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.2", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.3", path = "../../token-metadata/interface" }
-spl-type-length-value = { version = "0.4", path = "../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.4.3", path = "../../libraries/type-length-value" }
 
 [dev-dependencies]
 solana-program-test = ">=1.18.2,<=2"

--- a/token-collection/program/Cargo.toml
+++ b/token-collection/program/Cargo.toml
@@ -25,7 +25,7 @@ spl-type-length-value = { version = "0.4.3", path = "../../libraries/type-length
 solana-program-test = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
 spl-discriminator = { version = "0.2", path = "../../libraries/discriminator" }
-spl-token-client = { version = "0.9", path = "../../token/client" }
+spl-token-client = { version = "0.9.2", path = "../../token/client" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/token-collection/program/Cargo.toml
+++ b/token-collection/program/Cargo.toml
@@ -14,7 +14,7 @@ test-sbf = []
 [dependencies]
 solana-program = ">=1.18.2,<=2"
 spl-pod = { version = "0.2.2", path = "../../libraries/pod" }
-spl-program-error = { version = "0.3.1" , path = "../../libraries/program-error" }
+spl-program-error = { version = "0.4.0" , path = "../../libraries/program-error" }
 spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-group-example = { version = "0.2", path = "../../token-group/example", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.2", path = "../../token-group/interface" }

--- a/token-collection/program/Cargo.toml
+++ b/token-collection/program/Cargo.toml
@@ -15,7 +15,7 @@ test-sbf = []
 solana-program = ">=1.18.2,<=2"
 spl-pod = { version = "0.2.2", path = "../../libraries/pod" }
 spl-program-error = { version = "0.4.0" , path = "../../libraries/program-error" }
-spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-group-example = { version = "0.2", path = "../../token-group/example", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.2.3", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.3.3", path = "../../token-metadata/interface" }

--- a/token-collection/program/Cargo.toml
+++ b/token-collection/program/Cargo.toml
@@ -13,7 +13,7 @@ test-sbf = []
 
 [dependencies]
 solana-program = ">=1.18.2,<=2"
-spl-pod = { version = "0.2", path = "../../libraries/pod" }
+spl-pod = { version = "0.2.2", path = "../../libraries/pod" }
 spl-program-error = { version = "0.3.1" , path = "../../libraries/program-error" }
 spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-group-example = { version = "0.2", path = "../../token-group/example", features = ["no-entrypoint"] }

--- a/token-group/example/Cargo.toml
+++ b/token-group/example/Cargo.toml
@@ -22,7 +22,7 @@ spl-type-length-value = { version = "0.4.3", path = "../../libraries/type-length
 solana-program-test = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
 spl-discriminator = { version = "0.2", path = "../../libraries/discriminator" }
-spl-token-client = { version = "0.9", path = "../../token/client" }
+spl-token-client = { version = "0.9.2", path = "../../token/client" }
 spl-token-metadata-interface = { version = "0.3.3", path = "../../token-metadata/interface" }
 
 [lib]

--- a/token-group/example/Cargo.toml
+++ b/token-group/example/Cargo.toml
@@ -15,7 +15,7 @@ test-sbf = []
 solana-program = ">=1.18.2,<=2"
 spl-pod = { version = "0.2.2", path = "../../libraries/pod" }
 spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
-spl-token-group-interface = { version = "0.2", path = "../interface" }
+spl-token-group-interface = { version = "0.2.3", path = "../interface" }
 spl-type-length-value = { version = "0.4.3", path = "../../libraries/type-length-value" }
 
 [dev-dependencies]

--- a/token-group/example/Cargo.toml
+++ b/token-group/example/Cargo.toml
@@ -21,7 +21,7 @@ spl-type-length-value = { version = "0.4.3", path = "../../libraries/type-length
 [dev-dependencies]
 solana-program-test = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
-spl-discriminator = { version = "0.2", path = "../../libraries/discriminator" }
+spl-discriminator = { version = "0.2.2", path = "../../libraries/discriminator" }
 spl-token-client = { version = "0.9.2", path = "../../token/client" }
 spl-token-metadata-interface = { version = "0.3.3", path = "../../token-metadata/interface" }
 

--- a/token-group/example/Cargo.toml
+++ b/token-group/example/Cargo.toml
@@ -13,7 +13,7 @@ test-sbf = []
 
 [dependencies]
 solana-program = ">=1.18.2,<=2"
-spl-pod = { version = "0.2", path = "../../libraries/pod" }
+spl-pod = { version = "0.2.2", path = "../../libraries/pod" }
 spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.2", path = "../interface" }
 spl-type-length-value = { version = "0.4", path = "../../libraries/type-length-value" }

--- a/token-group/example/Cargo.toml
+++ b/token-group/example/Cargo.toml
@@ -14,7 +14,7 @@ test-sbf = []
 [dependencies]
 solana-program = ">=1.18.2,<=2"
 spl-pod = { version = "0.2.2", path = "../../libraries/pod" }
-spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.2.3", path = "../interface" }
 spl-type-length-value = { version = "0.4.3", path = "../../libraries/type-length-value" }
 

--- a/token-group/example/Cargo.toml
+++ b/token-group/example/Cargo.toml
@@ -16,7 +16,7 @@ solana-program = ">=1.18.2,<=2"
 spl-pod = { version = "0.2.2", path = "../../libraries/pod" }
 spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.2", path = "../interface" }
-spl-type-length-value = { version = "0.4", path = "../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.4.3", path = "../../libraries/type-length-value" }
 
 [dev-dependencies]
 solana-program-test = ">=1.18.2,<=2"

--- a/token-group/example/Cargo.toml
+++ b/token-group/example/Cargo.toml
@@ -23,7 +23,7 @@ solana-program-test = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
 spl-discriminator = { version = "0.2", path = "../../libraries/discriminator" }
 spl-token-client = { version = "0.9", path = "../../token/client" }
-spl-token-metadata-interface = { version = "0.3", path = "../../token-metadata/interface" }
+spl-token-metadata-interface = { version = "0.3.3", path = "../../token-metadata/interface" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/token-group/interface/Cargo.toml
+++ b/token-group/interface/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 bytemuck = "1.15.0"
 solana-program = ">=1.18.2,<=2"
-spl-discriminator = { version = "0.2" , path = "../../libraries/discriminator" }
+spl-discriminator = { version = "0.2.2" , path = "../../libraries/discriminator" }
 spl-pod = { version = "0.2.2" , path = "../../libraries/pod", features = ["borsh"] }
 spl-program-error = { version = "0.4.0" , path = "../../libraries/program-error" }
 

--- a/token-group/interface/Cargo.toml
+++ b/token-group/interface/Cargo.toml
@@ -15,7 +15,7 @@ spl-pod = { version = "0.2.2" , path = "../../libraries/pod", features = ["borsh
 spl-program-error = { version = "0.4.0" , path = "../../libraries/program-error" }
 
 [dev-dependencies]
-spl-type-length-value = { version = "0.4", path = "../../libraries/type-length-value", features = ["derive"] }
+spl-type-length-value = { version = "0.4.3", path = "../../libraries/type-length-value", features = ["derive"] }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/token-group/interface/Cargo.toml
+++ b/token-group/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-group-interface"
-version = "0.2.1"
+version = "0.2.3"
 description = "Solana Program Library Token Group Interface"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token-group/interface/Cargo.toml
+++ b/token-group/interface/Cargo.toml
@@ -12,7 +12,7 @@ bytemuck = "1.15.0"
 solana-program = ">=1.18.2,<=2"
 spl-discriminator = { version = "0.2" , path = "../../libraries/discriminator" }
 spl-pod = { version = "0.2.2" , path = "../../libraries/pod", features = ["borsh"] }
-spl-program-error = { version = "0.3.1" , path = "../../libraries/program-error" }
+spl-program-error = { version = "0.4.0" , path = "../../libraries/program-error" }
 
 [dev-dependencies]
 spl-type-length-value = { version = "0.4", path = "../../libraries/type-length-value", features = ["derive"] }

--- a/token-group/interface/Cargo.toml
+++ b/token-group/interface/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 bytemuck = "1.15.0"
 solana-program = ">=1.18.2,<=2"
 spl-discriminator = { version = "0.2" , path = "../../libraries/discriminator" }
-spl-pod = { version = "0.2" , path = "../../libraries/pod", features = ["borsh"] }
+spl-pod = { version = "0.2.2" , path = "../../libraries/pod", features = ["borsh"] }
 spl-program-error = { version = "0.3.1" , path = "../../libraries/program-error" }
 
 [dev-dependencies]

--- a/token-metadata/example/Cargo.toml
+++ b/token-metadata/example/Cargo.toml
@@ -16,7 +16,7 @@ solana-program = ">=1.18.2,<=2"
 spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-metadata-interface = { version = "0.3", path = "../interface" }
 spl-type-length-value = { version = "0.4" , path = "../../libraries/type-length-value" }
-spl-pod = { version = "0.2", path = "../../libraries/pod" }
+spl-pod = { version = "0.2.2", path = "../../libraries/pod" }
 
 [dev-dependencies]
 solana-program-test = ">=1.18.2,<=2"

--- a/token-metadata/example/Cargo.toml
+++ b/token-metadata/example/Cargo.toml
@@ -21,7 +21,7 @@ spl-pod = { version = "0.2.2", path = "../../libraries/pod" }
 [dev-dependencies]
 solana-program-test = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
-spl-token-client = { version = "0.9", path = "../../token/client" }
+spl-token-client = { version = "0.9.2", path = "../../token/client" }
 test-case = "3.3"
 
 [lib]

--- a/token-metadata/example/Cargo.toml
+++ b/token-metadata/example/Cargo.toml
@@ -14,7 +14,7 @@ test-sbf = []
 [dependencies]
 solana-program = ">=1.18.2,<=2"
 spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
-spl-token-metadata-interface = { version = "0.3", path = "../interface" }
+spl-token-metadata-interface = { version = "0.3.3", path = "../interface" }
 spl-type-length-value = { version = "0.4.3" , path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.2.2", path = "../../libraries/pod" }
 

--- a/token-metadata/example/Cargo.toml
+++ b/token-metadata/example/Cargo.toml
@@ -15,7 +15,7 @@ test-sbf = []
 solana-program = ">=1.18.2,<=2"
 spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-metadata-interface = { version = "0.3", path = "../interface" }
-spl-type-length-value = { version = "0.4" , path = "../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.4.3" , path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.2.2", path = "../../libraries/pod" }
 
 [dev-dependencies]

--- a/token-metadata/example/Cargo.toml
+++ b/token-metadata/example/Cargo.toml
@@ -13,7 +13,7 @@ test-sbf = []
 
 [dependencies]
 solana-program = ">=1.18.2,<=2"
-spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-metadata-interface = { version = "0.3.3", path = "../interface" }
 spl-type-length-value = { version = "0.4.3" , path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.2.2", path = "../../libraries/pod" }

--- a/token-metadata/interface/Cargo.toml
+++ b/token-metadata/interface/Cargo.toml
@@ -15,7 +15,7 @@ borsh = "1.2.1"
 serde = { version = "1.0.197", optional = true }
 solana-program = ">=1.18.2,<=2"
 spl-discriminator = { version = "0.2", path = "../../libraries/discriminator" }
-spl-program-error = { version = "0.3", path = "../../libraries/program-error" }
+spl-program-error = { version = "0.4.0", path = "../../libraries/program-error" }
 spl-type-length-value = { version = "0.4", path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.2.2", path = "../../libraries/pod", features = [
   "borsh",

--- a/token-metadata/interface/Cargo.toml
+++ b/token-metadata/interface/Cargo.toml
@@ -14,7 +14,7 @@ serde-traits = ["dep:serde", "spl-pod/serde-traits"]
 borsh = "1.2.1"
 serde = { version = "1.0.197", optional = true }
 solana-program = ">=1.18.2,<=2"
-spl-discriminator = { version = "0.2", path = "../../libraries/discriminator" }
+spl-discriminator = { version = "0.2.2", path = "../../libraries/discriminator" }
 spl-program-error = { version = "0.4.0", path = "../../libraries/program-error" }
 spl-type-length-value = { version = "0.4.3", path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.2.2", path = "../../libraries/pod", features = [

--- a/token-metadata/interface/Cargo.toml
+++ b/token-metadata/interface/Cargo.toml
@@ -17,7 +17,7 @@ solana-program = ">=1.18.2,<=2"
 spl-discriminator = { version = "0.2", path = "../../libraries/discriminator" }
 spl-program-error = { version = "0.3", path = "../../libraries/program-error" }
 spl-type-length-value = { version = "0.4", path = "../../libraries/type-length-value" }
-spl-pod = { version = "0.2", path = "../../libraries/pod", features = [
+spl-pod = { version = "0.2.2", path = "../../libraries/pod", features = [
   "borsh",
 ] }
 

--- a/token-metadata/interface/Cargo.toml
+++ b/token-metadata/interface/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0.197", optional = true }
 solana-program = ">=1.18.2,<=2"
 spl-discriminator = { version = "0.2", path = "../../libraries/discriminator" }
 spl-program-error = { version = "0.4.0", path = "../../libraries/program-error" }
-spl-type-length-value = { version = "0.4", path = "../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.4.3", path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.2.2", path = "../../libraries/pod", features = [
   "borsh",
 ] }

--- a/token-metadata/interface/Cargo.toml
+++ b/token-metadata/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-metadata-interface"
-version = "0.3.1"
+version = "0.3.3"
 description = "Solana Program Library Token Metadata Interface"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token-swap/program/Cargo.toml
+++ b/token-swap/program/Cargo.toml
@@ -20,7 +20,7 @@ num-traits = "0.2"
 solana-program = ">=1.18.2,<=2"
 spl-math = { version = "0.2", path = "../../libraries/math", features = [ "no-entrypoint" ] }
 spl-token = { version = "4.0", path = "../../token/program", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
+spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 arbitrary = { version = "1.3", features = ["derive"], optional = true }
 roots = { version = "0.0.8", optional = true }

--- a/token-upgrade/cli/Cargo.toml
+++ b/token-upgrade/cli/Cargo.toml
@@ -21,7 +21,7 @@ solana-remote-wallet = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
 spl-associated-token-account = { version = "3.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.9", path = "../../token/client" }
 spl-token-upgrade = { version = "0.1", path = "../program", features = ["no-entrypoint"] }
 tokio = { version = "1", features = ["full"] }

--- a/token-upgrade/cli/Cargo.toml
+++ b/token-upgrade/cli/Cargo.toml
@@ -22,7 +22,7 @@ solana-sdk = ">=1.18.2,<=2"
 spl-associated-token-account = { version = "3.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = ["no-entrypoint"] }
-spl-token-client = { version = "0.9", path = "../../token/client" }
+spl-token-client = { version = "0.9.2", path = "../../token/client" }
 spl-token-upgrade = { version = "0.1", path = "../program", features = ["no-entrypoint"] }
 tokio = { version = "1", features = ["full"] }
 

--- a/token-upgrade/cli/Cargo.toml
+++ b/token-upgrade/cli/Cargo.toml
@@ -19,7 +19,7 @@ solana-client = ">=1.18.2,<=2"
 solana-logger = ">=1.18.2,<=2"
 solana-remote-wallet = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
-spl-associated-token-account = { version = "3.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
+spl-associated-token-account = { version = "3.0.2", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.9.2", path = "../../token/client" }

--- a/token-upgrade/program/Cargo.toml
+++ b/token-upgrade/program/Cargo.toml
@@ -16,7 +16,7 @@ num-derive = "0.4"
 num-traits = "0.2"
 num_enum = "0.7.2"
 solana-program = ">=1.18.2,<=2"
-spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/token-upgrade/program/Cargo.toml
+++ b/token-upgrade/program/Cargo.toml
@@ -23,7 +23,7 @@ thiserror = "1.0"
 solana-program-test = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-client = { version = "0.9", path = "../../token/client" }
+spl-token-client = { version = "0.9.2", path = "../../token/client" }
 test-case = "3.3"
 
 [lib]

--- a/token-wrap/program/Cargo.toml
+++ b/token-wrap/program/Cargo.toml
@@ -15,7 +15,7 @@ test-sbf = []
 bytemuck = { version = "1.15.0", features = ["derive"] }
 num_enum = "0.7"
 solana-program = ">=1.18.2,<=2"
-spl-associated-token-account = { version = "3.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
+spl-associated-token-account = { version = "3.0.2", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"

--- a/token-wrap/program/Cargo.toml
+++ b/token-wrap/program/Cargo.toml
@@ -17,7 +17,7 @@ num_enum = "0.7"
 solana-program = ">=1.18.2,<=2"
 spl-associated-token-account = { version = "3.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "3.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [lib]

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -34,7 +34,7 @@ spl-token = { version = "4.0", path = "../program", features = [
 spl-token-2022 = { version = "3.0.2", path = "../program-2022", features = [
   "no-entrypoint",
 ] }
-spl-token-client = { version = "0.9", path = "../client" }
+spl-token-client = { version = "0.9.2", path = "../client" }
 spl-token-metadata-interface = { version = "0.3.3", path = "../../token-metadata/interface" }
 spl-token-group-interface = { version = "0.2.3", path = "../../token-group/interface" }
 spl-associated-token-account = { version = "3.0", path = "../../associated-token-account/program", features = [

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -31,7 +31,7 @@ solana-transaction-status = ">=1.18.2,<=2"
 spl-token = { version = "4.0", path = "../program", features = [
   "no-entrypoint",
 ] }
-spl-token-2022 = { version = "3.0", path = "../program-2022", features = [
+spl-token-2022 = { version = "3.0.2", path = "../program-2022", features = [
   "no-entrypoint",
 ] }
 spl-token-client = { version = "0.9", path = "../client" }

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -35,7 +35,7 @@ spl-token-2022 = { version = "3.0", path = "../program-2022", features = [
   "no-entrypoint",
 ] }
 spl-token-client = { version = "0.9", path = "../client" }
-spl-token-metadata-interface = { version = "0.3", path = "../../token-metadata/interface" }
+spl-token-metadata-interface = { version = "0.3.3", path = "../../token-metadata/interface" }
 spl-token-group-interface = { version = "0.2.3", path = "../../token-group/interface" }
 spl-associated-token-account = { version = "3.0", path = "../../associated-token-account/program", features = [
   "no-entrypoint",

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -37,7 +37,7 @@ spl-token-2022 = { version = "3.0.2", path = "../program-2022", features = [
 spl-token-client = { version = "0.9.2", path = "../client" }
 spl-token-metadata-interface = { version = "0.3.3", path = "../../token-metadata/interface" }
 spl-token-group-interface = { version = "0.2.3", path = "../../token-group/interface" }
-spl-associated-token-account = { version = "3.0", path = "../../associated-token-account/program", features = [
+spl-associated-token-account = { version = "3.0.2", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }
 spl-memo = { version = "4.0", path = "../../memo/program", features = [

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -36,7 +36,7 @@ spl-token-2022 = { version = "3.0", path = "../program-2022", features = [
 ] }
 spl-token-client = { version = "0.9", path = "../client" }
 spl-token-metadata-interface = { version = "0.3", path = "../../token-metadata/interface" }
-spl-token-group-interface = { version = "0.2", path = "../../token-group/interface" }
+spl-token-group-interface = { version = "0.2.3", path = "../../token-group/interface" }
 spl-associated-token-account = { version = "3.0", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -20,7 +20,7 @@ solana-rpc-client-api = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
 # We never want the entrypoint for ATA, but we want the entrypoint for token when
 # testing token
-spl-associated-token-account = { version = "3.0", path = "../../associated-token-account/program", features = [
+spl-associated-token-account = { version = "3.0.2", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }
 spl-memo = { version = "4.0", path = "../../memo/program", features = [

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -31,7 +31,7 @@ spl-token = { version = "4.0", path = "../program", features = [
 ] }
 spl-token-2022 = { version = "3.0", path = "../program-2022" }
 spl-token-group-interface = { version = "0.2.3", path = "../../token-group/interface" }
-spl-token-metadata-interface = { version = "0.3", path = "../../token-metadata/interface" }
+spl-token-metadata-interface = { version = "0.3.3", path = "../../token-metadata/interface" }
 spl-transfer-hook-interface = { version = "0.6", path = "../transfer-hook/interface" }
 thiserror = "1.0"
 

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -30,7 +30,7 @@ spl-token = { version = "4.0", path = "../program", features = [
   "no-entrypoint",
 ] }
 spl-token-2022 = { version = "3.0", path = "../program-2022" }
-spl-token-group-interface = { version = "0.2", path = "../../token-group/interface" }
+spl-token-group-interface = { version = "0.2.3", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.3", path = "../../token-metadata/interface" }
 spl-transfer-hook-interface = { version = "0.6", path = "../transfer-hook/interface" }
 thiserror = "1.0"

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -29,7 +29,7 @@ spl-memo = { version = "4.0", path = "../../memo/program", features = [
 spl-token = { version = "4.0", path = "../program", features = [
   "no-entrypoint",
 ] }
-spl-token-2022 = { version = "3.0", path = "../program-2022" }
+spl-token-2022 = { version = "3.0.2", path = "../program-2022" }
 spl-token-group-interface = { version = "0.2.3", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.3.3", path = "../../token-metadata/interface" }
 spl-transfer-hook-interface = { version = "0.6", path = "../transfer-hook/interface" }

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -32,7 +32,7 @@ spl-token = { version = "4.0", path = "../program", features = [
 spl-token-2022 = { version = "3.0.2", path = "../program-2022" }
 spl-token-group-interface = { version = "0.2.3", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.3.3", path = "../../token-metadata/interface" }
-spl-transfer-hook-interface = { version = "0.6", path = "../transfer-hook/interface" }
+spl-transfer-hook-interface = { version = "0.6.3", path = "../transfer-hook/interface" }
 thiserror = "1.0"
 
 [features]

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "spl-token-client"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "0.9.0"
+version = "0.9.2"
 
 [dependencies]
 async-trait = "0.1"

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -35,7 +35,7 @@ spl-instruction-padding = { version = "0.1.1", path = "../../instruction-padding
 ] }
 spl-tlv-account-resolution = { version = "0.6.3", path = "../../libraries/tlv-account-resolution" }
 spl-token-client = { version = "0.9", path = "../client" }
-spl-token-group-interface = { version = "0.2", path = "../../token-group/interface" }
+spl-token-group-interface = { version = "0.2.3", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.3", path = "../../token-metadata/interface" }
 spl-transfer-hook-example = { version = "0.6", path = "../transfer-hook/example", features = [
   "no-entrypoint",

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -33,7 +33,7 @@ spl-token-2022 = { version = "3.0", path = "../program-2022", features = [
 spl-instruction-padding = { version = "0.1.1", path = "../../instruction-padding/program", features = [
   "no-entrypoint",
 ] }
-spl-tlv-account-resolution = { version = "0.6", path = "../../libraries/tlv-account-resolution" }
+spl-tlv-account-resolution = { version = "0.6.3", path = "../../libraries/tlv-account-resolution" }
 spl-token-client = { version = "0.9", path = "../client" }
 spl-token-group-interface = { version = "0.2", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.3", path = "../../token-metadata/interface" }

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -27,7 +27,7 @@ spl-memo = { version = "4.0.1", path = "../../memo/program", features = [
   "no-entrypoint",
 ] }
 spl-pod = { version = "0.2.2", path = "../../libraries/pod" }
-spl-token-2022 = { version = "3.0", path = "../program-2022", features = [
+spl-token-2022 = { version = "3.0.2", path = "../program-2022", features = [
   "no-entrypoint",
 ] }
 spl-instruction-padding = { version = "0.1.1", path = "../../instruction-padding/program", features = [

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -40,5 +40,5 @@ spl-token-metadata-interface = { version = "0.3.3", path = "../../token-metadata
 spl-transfer-hook-example = { version = "0.6", path = "../transfer-hook/example", features = [
   "no-entrypoint",
 ] }
-spl-transfer-hook-interface = { version = "0.6", path = "../transfer-hook/interface" }
+spl-transfer-hook-interface = { version = "0.6.3", path = "../transfer-hook/interface" }
 test-case = "3.3"

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -34,7 +34,7 @@ spl-instruction-padding = { version = "0.1.1", path = "../../instruction-padding
   "no-entrypoint",
 ] }
 spl-tlv-account-resolution = { version = "0.6.3", path = "../../libraries/tlv-account-resolution" }
-spl-token-client = { version = "0.9", path = "../client" }
+spl-token-client = { version = "0.9.2", path = "../client" }
 spl-token-group-interface = { version = "0.2.3", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.3.3", path = "../../token-metadata/interface" }
 spl-transfer-hook-example = { version = "0.6", path = "../transfer-hook/example", features = [

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -36,7 +36,7 @@ spl-instruction-padding = { version = "0.1.1", path = "../../instruction-padding
 spl-tlv-account-resolution = { version = "0.6.3", path = "../../libraries/tlv-account-resolution" }
 spl-token-client = { version = "0.9", path = "../client" }
 spl-token-group-interface = { version = "0.2.3", path = "../../token-group/interface" }
-spl-token-metadata-interface = { version = "0.3", path = "../../token-metadata/interface" }
+spl-token-metadata-interface = { version = "0.3.3", path = "../../token-metadata/interface" }
 spl-transfer-hook-example = { version = "0.6", path = "../transfer-hook/example", features = [
   "no-entrypoint",
 ] }

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -22,7 +22,7 @@ futures-util = "0.3"
 solana-program = ">=1.18.2,<=2"
 solana-program-test = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
-spl-associated-token-account = { version = "3.0", path = "../../associated-token-account/program" }
+spl-associated-token-account = { version = "3.0.2", path = "../../associated-token-account/program" }
 spl-memo = { version = "4.0.1", path = "../../memo/program", features = [
   "no-entrypoint",
 ] }

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -26,7 +26,7 @@ spl-associated-token-account = { version = "3.0", path = "../../associated-token
 spl-memo = { version = "4.0.1", path = "../../memo/program", features = [
   "no-entrypoint",
 ] }
-spl-pod = { version = "0.2", path = "../../libraries/pod" }
+spl-pod = { version = "0.2.2", path = "../../libraries/pod" }
 spl-token-2022 = { version = "3.0", path = "../program-2022", features = [
   "no-entrypoint",
 ] }

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -32,7 +32,7 @@ solana-zk-token-sdk = ">=1.18.2,<=2"
 spl-memo = { version = "4.0", path = "../../memo/program", features = [ "no-entrypoint" ] }
 spl-token = { version = "4.0",  path = "../program", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.2.3", path = "../../token-group/interface" }
-spl-token-metadata-interface = { version = "0.3", path = "../../token-metadata/interface" }
+spl-token-metadata-interface = { version = "0.3.3", path = "../../token-metadata/interface" }
 spl-transfer-hook-interface = { version = "0.6", path = "../transfer-hook/interface" }
 spl-type-length-value = { version = "0.4.3", path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.2.2", path = "../../libraries/pod" }

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -31,7 +31,7 @@ solana-security-txt = "1.1.1"
 solana-zk-token-sdk = ">=1.18.2,<=2"
 spl-memo = { version = "4.0", path = "../../memo/program", features = [ "no-entrypoint" ] }
 spl-token = { version = "4.0",  path = "../program", features = ["no-entrypoint"] }
-spl-token-group-interface = { version = "0.2", path = "../../token-group/interface" }
+spl-token-group-interface = { version = "0.2.3", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.3", path = "../../token-metadata/interface" }
 spl-transfer-hook-interface = { version = "0.6", path = "../transfer-hook/interface" }
 spl-type-length-value = { version = "0.4.3", path = "../../libraries/type-length-value" }

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -34,7 +34,7 @@ spl-token = { version = "4.0",  path = "../program", features = ["no-entrypoint"
 spl-token-group-interface = { version = "0.2", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.3", path = "../../token-metadata/interface" }
 spl-transfer-hook-interface = { version = "0.6", path = "../transfer-hook/interface" }
-spl-type-length-value = { version = "0.4", path = "../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.4.3", path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.2.2", path = "../../libraries/pod" }
 thiserror = "1.0"
 serde = { version = "1.0.197", optional = true }

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -35,7 +35,7 @@ spl-token-group-interface = { version = "0.2", path = "../../token-group/interfa
 spl-token-metadata-interface = { version = "0.3", path = "../../token-metadata/interface" }
 spl-transfer-hook-interface = { version = "0.6", path = "../transfer-hook/interface" }
 spl-type-length-value = { version = "0.4", path = "../../libraries/type-length-value" }
-spl-pod = { version = "0.2", path = "../../libraries/pod" }
+spl-pod = { version = "0.2.2", path = "../../libraries/pod" }
 thiserror = "1.0"
 serde = { version = "1.0.197", optional = true }
 serde_with = { version = "3.7.0", optional = true }

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -47,7 +47,7 @@ proptest = "1.4"
 serial_test = "3.0.0"
 solana-program-test = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
-spl-tlv-account-resolution = { version = "0.6", path = "../../libraries/tlv-account-resolution" }
+spl-tlv-account-resolution = { version = "0.6.3", path = "../../libraries/tlv-account-resolution" }
 serde_json = "1.0.115"
 
 [lib]

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -33,7 +33,7 @@ spl-memo = { version = "4.0", path = "../../memo/program", features = [ "no-entr
 spl-token = { version = "4.0",  path = "../program", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.2.3", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.3.3", path = "../../token-metadata/interface" }
-spl-transfer-hook-interface = { version = "0.6", path = "../transfer-hook/interface" }
+spl-transfer-hook-interface = { version = "0.6.3", path = "../transfer-hook/interface" }
 spl-type-length-value = { version = "0.4.3", path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.2.2", path = "../../libraries/pod" }
 thiserror = "1.0"

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-2022"
-version = "3.0.0"
+version = "3.0.2"
 description = "Solana Program Library Token 2022"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token/transfer-hook/cli/Cargo.toml
+++ b/token/transfer-hook/cli/Cargo.toml
@@ -29,7 +29,7 @@ serde_yaml = "0.9.34"
 [dev-dependencies]
 solana-test-validator = ">=1.18.2,<=2"
 spl-token-2022 = { version = "3.0.2", path = "../../program-2022", features = ["no-entrypoint"] }
-spl-token-client = { version = "0.9", path = "../../client" }
+spl-token-client = { version = "0.9.2", path = "../../client" }
 
 [[bin]]
 name = "spl-transfer-hook"

--- a/token/transfer-hook/cli/Cargo.toml
+++ b/token/transfer-hook/cli/Cargo.toml
@@ -17,7 +17,7 @@ solana-client = ">=1.18.2,<=2"
 solana-logger = ">=1.18.2,<=2"
 solana-remote-wallet = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
-spl-transfer-hook-interface = { version = "0.6", path = "../interface" }
+spl-transfer-hook-interface = { version = "0.6.3", path = "../interface" }
 spl-tlv-account-resolution = { version = "0.6.3" , path = "../../../libraries/tlv-account-resolution", features = ["serde-traits"] }
 strum = "0.26"
 strum_macros = "0.26"

--- a/token/transfer-hook/cli/Cargo.toml
+++ b/token/transfer-hook/cli/Cargo.toml
@@ -18,7 +18,7 @@ solana-logger = ">=1.18.2,<=2"
 solana-remote-wallet = ">=1.18.2,<=2"
 solana-sdk = ">=1.18.2,<=2"
 spl-transfer-hook-interface = { version = "0.6", path = "../interface" }
-spl-tlv-account-resolution = { version = "0.6" , path = "../../../libraries/tlv-account-resolution", features = ["serde-traits"] }
+spl-tlv-account-resolution = { version = "0.6.3" , path = "../../../libraries/tlv-account-resolution", features = ["serde-traits"] }
 strum = "0.26"
 strum_macros = "0.26"
 tokio = { version = "1", features = ["full"] }

--- a/token/transfer-hook/cli/Cargo.toml
+++ b/token/transfer-hook/cli/Cargo.toml
@@ -28,7 +28,7 @@ serde_yaml = "0.9.34"
 
 [dev-dependencies]
 solana-test-validator = ">=1.18.2,<=2"
-spl-token-2022 = { version = "3.0", path = "../../program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "3.0.2", path = "../../program-2022", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.9", path = "../../client" }
 
 [[bin]]

--- a/token/transfer-hook/example/Cargo.toml
+++ b/token/transfer-hook/example/Cargo.toml
@@ -14,7 +14,7 @@ test-sbf = []
 [dependencies]
 arrayref = "0.3.7"
 solana-program = ">=1.18.2,<=2"
-spl-tlv-account-resolution = { version = "0.6" , path = "../../../libraries/tlv-account-resolution" }
+spl-tlv-account-resolution = { version = "0.6.3" , path = "../../../libraries/tlv-account-resolution" }
 spl-token-2022 = { version = "3.0",  path = "../../program-2022", features = ["no-entrypoint"] }
 spl-transfer-hook-interface = { version = "0.6" , path = "../interface" }
 spl-type-length-value = { version = "0.4.3" , path = "../../../libraries/type-length-value" }

--- a/token/transfer-hook/example/Cargo.toml
+++ b/token/transfer-hook/example/Cargo.toml
@@ -15,7 +15,7 @@ test-sbf = []
 arrayref = "0.3.7"
 solana-program = ">=1.18.2,<=2"
 spl-tlv-account-resolution = { version = "0.6.3" , path = "../../../libraries/tlv-account-resolution" }
-spl-token-2022 = { version = "3.0",  path = "../../program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "3.0.2",  path = "../../program-2022", features = ["no-entrypoint"] }
 spl-transfer-hook-interface = { version = "0.6" , path = "../interface" }
 spl-type-length-value = { version = "0.4.3" , path = "../../../libraries/type-length-value" }
 

--- a/token/transfer-hook/example/Cargo.toml
+++ b/token/transfer-hook/example/Cargo.toml
@@ -17,7 +17,7 @@ solana-program = ">=1.18.2,<=2"
 spl-tlv-account-resolution = { version = "0.6" , path = "../../../libraries/tlv-account-resolution" }
 spl-token-2022 = { version = "3.0",  path = "../../program-2022", features = ["no-entrypoint"] }
 spl-transfer-hook-interface = { version = "0.6" , path = "../interface" }
-spl-type-length-value = { version = "0.4" , path = "../../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.4.3" , path = "../../../libraries/type-length-value" }
 
 [dev-dependencies]
 solana-program-test = ">=1.18.2,<=2"

--- a/token/transfer-hook/example/Cargo.toml
+++ b/token/transfer-hook/example/Cargo.toml
@@ -16,7 +16,7 @@ arrayref = "0.3.7"
 solana-program = ">=1.18.2,<=2"
 spl-tlv-account-resolution = { version = "0.6.3" , path = "../../../libraries/tlv-account-resolution" }
 spl-token-2022 = { version = "3.0.2",  path = "../../program-2022", features = ["no-entrypoint"] }
-spl-transfer-hook-interface = { version = "0.6" , path = "../interface" }
+spl-transfer-hook-interface = { version = "0.6.3" , path = "../interface" }
 spl-type-length-value = { version = "0.4.3" , path = "../../../libraries/type-length-value" }
 
 [dev-dependencies]

--- a/token/transfer-hook/interface/Cargo.toml
+++ b/token/transfer-hook/interface/Cargo.toml
@@ -12,7 +12,7 @@ arrayref = "0.3.7"
 bytemuck = { version = "1.15.0", features = ["derive"] }
 solana-program = ">=1.18.2,<=2"
 spl-discriminator = { version = "0.2" , path = "../../../libraries/discriminator" }
-spl-program-error = { version = "0.3" , path = "../../../libraries/program-error" }
+spl-program-error = { version = "0.4.0" , path = "../../../libraries/program-error" }
 spl-tlv-account-resolution = { version = "0.6" , path = "../../../libraries/tlv-account-resolution" }
 spl-type-length-value = { version = "0.4" , path = "../../../libraries/type-length-value" }
 spl-pod = { version = "0.2.2", path = "../../../libraries/pod" }

--- a/token/transfer-hook/interface/Cargo.toml
+++ b/token/transfer-hook/interface/Cargo.toml
@@ -14,7 +14,7 @@ solana-program = ">=1.18.2,<=2"
 spl-discriminator = { version = "0.2" , path = "../../../libraries/discriminator" }
 spl-program-error = { version = "0.4.0" , path = "../../../libraries/program-error" }
 spl-tlv-account-resolution = { version = "0.6" , path = "../../../libraries/tlv-account-resolution" }
-spl-type-length-value = { version = "0.4" , path = "../../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.4.3" , path = "../../../libraries/type-length-value" }
 spl-pod = { version = "0.2.2", path = "../../../libraries/pod" }
 
 [lib]

--- a/token/transfer-hook/interface/Cargo.toml
+++ b/token/transfer-hook/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-transfer-hook-interface"
-version = "0.6.1"
+version = "0.6.3"
 description = "Solana Program Library Transfer Hook Interface"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token/transfer-hook/interface/Cargo.toml
+++ b/token/transfer-hook/interface/Cargo.toml
@@ -13,7 +13,7 @@ bytemuck = { version = "1.15.0", features = ["derive"] }
 solana-program = ">=1.18.2,<=2"
 spl-discriminator = { version = "0.2" , path = "../../../libraries/discriminator" }
 spl-program-error = { version = "0.4.0" , path = "../../../libraries/program-error" }
-spl-tlv-account-resolution = { version = "0.6" , path = "../../../libraries/tlv-account-resolution" }
+spl-tlv-account-resolution = { version = "0.6.3" , path = "../../../libraries/tlv-account-resolution" }
 spl-type-length-value = { version = "0.4.3" , path = "../../../libraries/type-length-value" }
 spl-pod = { version = "0.2.2", path = "../../../libraries/pod" }
 

--- a/token/transfer-hook/interface/Cargo.toml
+++ b/token/transfer-hook/interface/Cargo.toml
@@ -15,7 +15,7 @@ spl-discriminator = { version = "0.2" , path = "../../../libraries/discriminator
 spl-program-error = { version = "0.3" , path = "../../../libraries/program-error" }
 spl-tlv-account-resolution = { version = "0.6" , path = "../../../libraries/tlv-account-resolution" }
 spl-type-length-value = { version = "0.4" , path = "../../../libraries/type-length-value" }
-spl-pod = { version = "0.2", path = "../../../libraries/pod" }
+spl-pod = { version = "0.2.2", path = "../../../libraries/pod" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/token/transfer-hook/interface/Cargo.toml
+++ b/token/transfer-hook/interface/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 arrayref = "0.3.7"
 bytemuck = { version = "1.15.0", features = ["derive"] }
 solana-program = ">=1.18.2,<=2"
-spl-discriminator = { version = "0.2" , path = "../../../libraries/discriminator" }
+spl-discriminator = { version = "0.2.2" , path = "../../../libraries/discriminator" }
 spl-program-error = { version = "0.4.0" , path = "../../../libraries/program-error" }
 spl-tlv-account-resolution = { version = "0.6.3" , path = "../../../libraries/tlv-account-resolution" }
 spl-type-length-value = { version = "0.4.3" , path = "../../../libraries/type-length-value" }


### PR DESCRIPTION
#### Problem

The bumps for #6507 ended up restricting the available versions too much, making it impossible to publish spl-token-cli.

Also, we need to bump absolutely everything because of the strict versions used by the monorepo.

#### Solution

Relax all of the dependencies and bump all the required crates:

* pod
* tlv
* tlv-account-resolution
* token-group-interface
* token-metadata-interface
* token-2022
* token-client
* transfer-hook-interface
* associated-token-account
* discriminator, derive, syn
* program-error, derive