### PR TITLE
token-client: Make `Token` properly `Send + Sync`

### DIFF
--- a/token/client/src/client.rs
+++ b/token/client/src/client.rs
@@ -192,7 +192,7 @@ pub type ProgramClientResult<T> = Result<T, ProgramClientError>;
 
 /// Generic client interface for programs.
 #[async_trait]
-pub trait ProgramClient<ST>
+pub trait ProgramClient<ST>: Send + Sync
 where
     ST: SendTransaction + SimulateTransaction,
 {

--- a/token/program-2022-test/tests/cpi_guard.rs
+++ b/token/program-2022-test/tests/cpi_guard.rs
@@ -531,7 +531,7 @@ async fn test_cpi_guard_approve() {
     }
 }
 
-async fn make_close_test_account<S: Signer>(
+async fn make_close_test_account<S: Signer + Send + Sync>(
     token: &Token<ProgramBanksClientProcessTransaction>,
     owner: &S,
     authority: Option<Pubkey>,

--- a/token/program-2022-test/tests/token_group_initialize.rs
+++ b/token/program-2022-test/tests/token_group_initialize.rs
@@ -258,7 +258,7 @@ async fn fail_without_signature() {
     instruction.accounts[2].is_signer = false;
     let error = token_context
         .token
-        .process_ixs(&[instruction], &[] as &[&dyn Signer; 0]) // yuck, but the compiler needs it
+        .process_ixs(&[instruction], &[] as &[&Keypair; 0]) // yuck, but the compiler needs it
         .await
         .unwrap_err();
 

--- a/token/program-2022-test/tests/token_group_update_authority.rs
+++ b/token/program-2022-test/tests/token_group_update_authority.rs
@@ -165,7 +165,7 @@ async fn fail_authority_checks() {
     // wrong authority
     let error = token_context
         .token
-        .token_group_update_authority(&payer_pubkey, None, &[] as &[&dyn Signer; 0])
+        .token_group_update_authority(&payer_pubkey, None, &[] as &[&Keypair; 0])
         .await
         .unwrap_err();
     assert_eq!(

--- a/token/program-2022-test/tests/token_group_update_max_size.rs
+++ b/token/program-2022-test/tests/token_group_update_max_size.rs
@@ -220,7 +220,7 @@ async fn fail_authority_checks() {
 
     let error = token_context
         .token
-        .process_ixs(&[instruction], &[] as &[&dyn Signer; 0]) // yuck, but the compiler needs it
+        .process_ixs(&[instruction], &[] as &[&Keypair; 0]) // yuck, but the compiler needs it
         .await
         .unwrap_err();
     assert_eq!(

--- a/token/program-2022-test/tests/token_metadata_initialize.rs
+++ b/token/program-2022-test/tests/token_metadata_initialize.rs
@@ -277,7 +277,7 @@ async fn fail_without_signature() {
     instruction.accounts[3].is_signer = false;
     let error = token_context
         .token
-        .process_ixs(&[instruction], &[] as &[&dyn Signer; 0]) // yuck, but the compiler needs it
+        .process_ixs(&[instruction], &[] as &[&Keypair; 0]) // yuck, but the compiler needs it
         .await
         .unwrap_err();
 

--- a/token/program-2022-test/tests/token_metadata_remove_key.rs
+++ b/token/program-2022-test/tests/token_metadata_remove_key.rs
@@ -215,7 +215,7 @@ async fn fail_authority_checks() {
             &payer_pubkey,
             key,
             true, // idempotent
-            &[] as &[&dyn Signer; 0],
+            &[] as &[&Keypair; 0],
         )
         .await
         .unwrap_err();

--- a/token/program-2022-test/tests/token_metadata_update_authority.rs
+++ b/token/program-2022-test/tests/token_metadata_update_authority.rs
@@ -187,7 +187,7 @@ async fn fail_authority_checks() {
     // wrong authority
     let error = token_context
         .token
-        .token_metadata_update_authority(&payer_pubkey, None, &[] as &[&dyn Signer; 0])
+        .token_metadata_update_authority(&payer_pubkey, None, &[] as &[&Keypair; 0])
         .await
         .unwrap_err();
     assert_eq!(

--- a/token/program-2022-test/tests/token_metadata_update_field.rs
+++ b/token/program-2022-test/tests/token_metadata_update_field.rs
@@ -172,7 +172,7 @@ async fn fail_authority_checks() {
 
     let error = token_context
         .token
-        .process_ixs(&[instruction], &[] as &[&dyn Signer; 0]) // yuck, but the compiler needs it
+        .process_ixs(&[instruction], &[] as &[&Keypair; 0]) // yuck, but the compiler needs it
         .await
         .unwrap_err();
     assert_eq!(


### PR DESCRIPTION
#### Problem

It's not possible to use token-client's `Token` in a detached async context because not all the types contained are `Send + Sync`. See #6510 for more info.

#### Solution

Add `Send + Sync` to all types contained within `Token` and all type parameters. This is a pretty invasive change and breaks current CLI users, but we can consider doing this in a breaking release.

Fixes #6478

cc @1500256797