### PR TITLE
token-js: opt for `PublicKey.equals`

### DIFF
--- a/token/js/src/constants.ts
+++ b/token/js/src/constants.ts
@@ -17,7 +17,7 @@ export const NATIVE_MINT_2022 = new PublicKey('9pan9bMn5HatX4EJdBwg9VgCa7Uz5HL8N
 
 /** Check that the token program provided is not `Tokenkeg...`, useful when using extensions */
 export function programSupportsExtensions(programId: PublicKey): boolean {
-    if (programId === TOKEN_PROGRAM_ID) {
+    if (programId.equals(TOKEN_PROGRAM_ID)) {
         return false;
     } else {
         return true;

--- a/token/js/src/extensions/transferHook/instructions.ts
+++ b/token/js/src/extensions/transferHook/instructions.ts
@@ -119,7 +119,7 @@ export function createUpdateTransferHookInstruction(
 
 function deEscalateAccountMeta(accountMeta: AccountMeta, accountMetas: AccountMeta[]): AccountMeta {
     const maybeHighestPrivileges = accountMetas
-        .filter((x) => x.pubkey === accountMeta.pubkey)
+        .filter((x) => x.pubkey.equals(accountMeta.pubkey))
         .reduce<{ isSigner: boolean; isWritable: boolean } | undefined>((acc, x) => {
             if (!acc) return { isSigner: x.isSigner, isWritable: x.isWritable };
             return { isSigner: acc.isSigner || x.isSigner, isWritable: acc.isWritable || x.isWritable };
@@ -205,7 +205,7 @@ export async function addExtraAccountMetasForExecute(
     const validateStateData = getExtraAccountMetas(validateStateAccount);
 
     // Check to make sure the provided keys are in the instruction
-    if (![source, mint, destination, owner].every((key) => instruction.keys.some((meta) => meta.pubkey === key))) {
+    if (![source, mint, destination, owner].every((key) => instruction.keys.some((meta) => meta.pubkey.equals(key)))) {
         throw new Error('Missing required account in instruction');
     }
 


### PR DESCRIPTION
#### Problem

Although strict equality checking _usually_ works for comparing two `PublicKey` instances, it can cause problems across different bundle types - for example when a CJS `PublicKey` meets an ESM `PublicKey`.

#### Solution

Opt for the provided byte-wise `PublicKey.equals` comparator over strict equality (`===`).

Closes #6536 