### PR TITLE
single-pool: Allow stake config to be anything in tests

### DIFF
--- a/single-pool/program/tests/accounts.rs
+++ b/single-pool/program/tests/accounts.rs
@@ -157,6 +157,12 @@ async fn fail_account_checks(test_mode: TestMode) {
         if instruction_account.pubkey == accounts.alice.pubkey() {
             continue;
         }
+        // stake config address can also be arbitrary. Remove all usage of
+        // `stake::config` with the upgrade to 2.0
+        #[allow(deprecated)]
+        if instruction_account.pubkey == stake::config::id() {
+            continue;
+        }
 
         let prev_pubkey = instruction_account.pubkey;
         instruction_account.pubkey = Pubkey::new_unique();


### PR DESCRIPTION
#### Problem

The stake config is getting removed with https://github.com/anza-xyz/agave/pull/470, but this causes the single pool tests to fail, since it's expecting that the program will *fail* if any account (including stake config), is arbitrarily changed.

#### Solution

The full fix will come with https://github.com/solana-labs/solana-program-library/issues/6542, but to unblock the PR on Agave, just allow that account to be anything.