### PR TITLE
Revert "single-pool: Allow stake config to be anything in tests (#6543)"

### DIFF
--- a/single-pool/program/tests/accounts.rs
+++ b/single-pool/program/tests/accounts.rs
@@ -157,12 +157,6 @@ async fn fail_account_checks(test_mode: TestMode) {
         if instruction_account.pubkey == accounts.alice.pubkey() {
             continue;
         }
-        // stake config address can also be arbitrary. Remove all usage of
-        // `stake::config` with the upgrade to 2.0
-        #[allow(deprecated)]
-        if instruction_account.pubkey == stake::config::id() {
-            continue;
-        }
 
         let prev_pubkey = instruction_account.pubkey;
         instruction_account.pubkey = Pubkey::new_unique();


### PR DESCRIPTION
This reverts commit b32ab740bf536e3867186ec11700c1be355f16f9.

#### Problem

The fix in #6543 doesn't actually work for the future changes, as https://github.com/anza-xyz/agave/pull/470#issuecomment-2035749009 explains.

#### Solution

Revert the test change.