### PR TITLE
Remove usage of VoteStateVersions::vote_state_size_of

### DIFF
--- a/single-pool/cli/tests/test.rs
+++ b/single-pool/cli/tests/test.rs
@@ -21,7 +21,7 @@ use {
     solana_test_validator::{TestValidator, TestValidatorGenesis, UpgradeableProgramInfo},
     solana_vote_program::{
         vote_instruction::{self, CreateVoteAccountConfig},
-        vote_state::{VoteInit, VoteState, VoteStateVersions},
+        vote_state::{VoteInit, VoteState},
     },
     spl_token_client::client::{ProgramClient, ProgramRpcClient, ProgramRpcClientSendTransaction},
     std::{path::PathBuf, process::Command, str::FromStr, sync::Arc, time::Duration},
@@ -182,7 +182,7 @@ async fn create_vote_account(
         },
         vote_rent,
         CreateVoteAccountConfig {
-            space: VoteStateVersions::vote_state_size_of(true) as u64,
+            space: VoteState::size_of() as u64,
             ..Default::default()
         },
     ));

--- a/single-pool/program/tests/helpers/mod.rs
+++ b/single-pool/program/tests/helpers/mod.rs
@@ -15,7 +15,7 @@ use {
     },
     solana_vote_program::{
         self, vote_instruction,
-        vote_state::{VoteInit, VoteState, VoteStateVersions},
+        vote_state::{VoteInit, VoteState},
     },
     spl_associated_token_account as atoken,
     spl_single_pool::{
@@ -380,7 +380,7 @@ pub async fn create_vote(
         },
         rent_voter,
         vote_instruction::CreateVoteAccountConfig {
-            space: VoteStateVersions::vote_state_size_of(true) as u64,
+            space: VoteState::size_of() as u64,
             ..Default::default()
         },
     ));

--- a/stake-pool/program/tests/helpers/mod.rs
+++ b/stake-pool/program/tests/helpers/mod.rs
@@ -626,7 +626,7 @@ pub async fn create_vote(
         },
         rent_voter,
         vote_instruction::CreateVoteAccountConfig {
-            space: VoteStateVersions::vote_state_size_of(true) as u64,
+            space: VoteState::size_of() as u64,
             ..Default::default()
         },
     ));


### PR DESCRIPTION
The feature flag `vote_state_add_vote_latency` has been activated on all clusters, so the old vote state version is no longer supported. 
As such, consumers should use `VoteState::size_of()` instead of `VoteStateVersions::vote_state_size_of(true)`.

Unblocks the cleanup of this feature flag https://github.com/anza-xyz/agave/pull/468