### PR TITLE
token-cli: Fix offline signing by making simulated compute unit limit explicit

### DIFF
--- a/token/cli/src/clap_app.rs
+++ b/token/cli/src/clap_app.rs
@@ -17,7 +17,7 @@ use {
     spl_token_2022::instruction::{AuthorityType, MAX_SIGNERS, MIN_SIGNERS},
     std::{fmt, str::FromStr},
     strum::IntoEnumIterator,
-    strum_macros::{EnumIter, EnumString, IntoStaticStr},
+    strum_macros::{AsRefStr, EnumIter, EnumString, IntoStaticStr},
 };
 
 pub type Error = Box<dyn std::error::Error + Send + Sync>;
@@ -78,7 +78,7 @@ pub const COMPUTE_UNIT_LIMIT_ARG: ArgConstant<'static> = ArgConstant {
 
 pub static VALID_TOKEN_PROGRAM_IDS: [Pubkey; 2] = [spl_token_2022::ID, spl_token::ID];
 
-#[derive(Debug, Clone, Copy, PartialEq, EnumString, IntoStaticStr)]
+#[derive(AsRefStr, Debug, Clone, Copy, PartialEq, EnumString, IntoStaticStr)]
 #[strum(serialize_all = "kebab-case")]
 pub enum CommandName {
     CreateToken,

--- a/token/cli/src/clap_app.rs
+++ b/token/cli/src/clap_app.rs
@@ -15,6 +15,7 @@ use {
     },
     solana_sdk::{instruction::AccountMeta, pubkey::Pubkey},
     spl_token_2022::instruction::{AuthorityType, MAX_SIGNERS, MIN_SIGNERS},
+    spl_token_client::token::ComputeUnitLimit,
     std::{fmt, str::FromStr},
     strum::IntoEnumIterator,
     strum_macros::{EnumIter, EnumString, IntoStaticStr},
@@ -73,7 +74,10 @@ pub const COMPUTE_UNIT_PRICE_ARG: ArgConstant<'static> = ArgConstant {
 pub const COMPUTE_UNIT_LIMIT_ARG: ArgConstant<'static> = ArgConstant {
     name: "compute_unit_limit",
     long: "--with-compute-unit-limit",
-    help: "Set compute unit limit for transaction, in compute units.",
+    help: "Set compute unit limit for transaction, in compute units; also accepts \
+        keyword SIMULATED to use compute units from transaction simulation prior \
+        to sending. Note that SIMULATED may fail if accounts are modified by another \
+        transaction between simulation and execution.",
 };
 
 pub static VALID_TOKEN_PROGRAM_IDS: [Pubkey; 2] = [spl_token_2022::ID, spl_token::ID];
@@ -350,6 +354,32 @@ where
         Err(e) => Err(e),
     }
 }
+
+fn is_compute_unit_limit_or_simulated<T>(string: T) -> Result<(), String>
+where
+    T: AsRef<str> + fmt::Display,
+{
+    if string.as_ref().parse::<u32>().is_ok() || string.as_ref() == "SIMULATED" {
+        Ok(())
+    } else {
+        Err(format!(
+            "Unable to parse input compute unit limit as integer or SIMULATED, provided: {string}"
+        ))
+    }
+}
+pub(crate) fn parse_compute_unit_limit<T>(string: T) -> Result<ComputeUnitLimit, String>
+where
+    T: AsRef<str> + fmt::Display,
+{
+    match string.as_ref().parse::<u32>() {
+        Ok(compute_unit_limit) => Ok(ComputeUnitLimit::Static(compute_unit_limit)),
+        Err(_) if string.as_ref() == "SIMULATED" => Ok(ComputeUnitLimit::Simulated),
+        _ => Err(format!(
+            "Unable to parse compute unit limit, provided: {string}"
+        )),
+    }
+}
+
 struct SignOnlyNeedsFullMintSpec {}
 impl offline::ArgsConfig for SignOnlyNeedsFullMintSpec {
     fn sign_only_arg<'a, 'b>(&self, arg: Arg<'a, 'b>) -> Arg<'a, 'b> {
@@ -629,7 +659,7 @@ pub fn app<'a, 'b>(
                 .takes_value(true)
                 .global(true)
                 .value_name("COMPUTE-UNIT-LIMIT")
-                .validator(is_parsable::<u32>)
+                .validator(is_compute_unit_limit_or_simulated)
                 .help(COMPUTE_UNIT_LIMIT_ARG.help)
         )
         .arg(

--- a/token/cli/src/clap_app.rs
+++ b/token/cli/src/clap_app.rs
@@ -670,6 +670,7 @@ pub fn app<'a, 'b>(
                 .value_name("COMPUTE-UNIT-PRICE")
                 .validator(is_parsable::<u64>)
                 .help(COMPUTE_UNIT_PRICE_ARG.help)
+                .requires(COMPUTE_UNIT_LIMIT_ARG.name)
         )
         .bench_subcommand()
         .subcommand(SubCommand::with_name(CommandName::CreateToken.into()).about("Create a new token")

--- a/token/cli/src/command.rs
+++ b/token/cli/src/command.rs
@@ -68,7 +68,7 @@ use {
     },
     spl_token_client::{
         client::{ProgramRpcClientSendTransaction, RpcClientResponse},
-        token::{ExtensionInitializationParams, Token},
+        token::{ComputeUnitLimit, ExtensionInitializationParams, Token},
     },
     spl_token_group_interface::state::TokenGroup,
     spl_token_metadata_interface::state::{Field, TokenMetadata},
@@ -152,11 +152,7 @@ fn config_token_client(
     token: Token<ProgramRpcClientSendTransaction>,
     config: &Config<'_>,
 ) -> Result<Token<ProgramRpcClientSendTransaction>, Error> {
-    let token = if let Some(compute_unit_limit) = config.compute_unit_limit {
-        token.with_compute_unit_limit(compute_unit_limit)
-    } else {
-        token
-    };
+    let token = token.with_compute_unit_limit(config.compute_unit_limit.clone());
 
     let token = if let Some(compute_unit_price) = config.compute_unit_price {
         token.with_compute_unit_price(compute_unit_price)
@@ -434,7 +430,8 @@ async fn command_set_interest_rate(
 ) -> CommandResult {
     // Because set_interest_rate depends on the time, it can cost more between
     // simulation and execution. To help that, just set a static compute limit
-    let token = base_token_client(config, &token_pubkey, None)?.with_compute_unit_limit(2_500);
+    let token = base_token_client(config, &token_pubkey, None)?
+        .with_compute_unit_limit(ComputeUnitLimit::Static(2_500));
     let token = config_token_client(token, config)?;
 
     if !config.sign_only {

--- a/token/cli/src/command.rs
+++ b/token/cli/src/command.rs
@@ -428,11 +428,13 @@ async fn command_set_interest_rate(
     rate_bps: i16,
     bulk_signers: Vec<Arc<dyn Signer>>,
 ) -> CommandResult {
+    let mut token = token_client_from_config(config, &token_pubkey, None)?;
     // Because set_interest_rate depends on the time, it can cost more between
     // simulation and execution. To help that, just set a static compute limit
-    let token = base_token_client(config, &token_pubkey, None)?
-        .with_compute_unit_limit(ComputeUnitLimit::Static(5_000));
-    let token = config_token_client(token, config)?;
+    // if none has been set
+    if !matches!(config.compute_unit_limit, ComputeUnitLimit::Static(_)) {
+        token = token.with_compute_unit_limit(ComputeUnitLimit::Static(2_500));
+    }
 
     if !config.sign_only {
         let mint_account = config.get_account_checked(&token_pubkey).await?;

--- a/token/cli/src/command.rs
+++ b/token/cli/src/command.rs
@@ -431,7 +431,7 @@ async fn command_set_interest_rate(
     // Because set_interest_rate depends on the time, it can cost more between
     // simulation and execution. To help that, just set a static compute limit
     let token = base_token_client(config, &token_pubkey, None)?
-        .with_compute_unit_limit(ComputeUnitLimit::Static(2_500));
+        .with_compute_unit_limit(ComputeUnitLimit::Static(5_000));
     let token = config_token_client(token, config)?;
 
     if !config.sign_only {

--- a/token/cli/src/config.rs
+++ b/token/cli/src/config.rs
@@ -288,11 +288,14 @@ impl<'a> Config<'a> {
             && matches.is_present(COMPUTE_UNIT_PRICE_ARG.name)
             && !matches.is_present(COMPUTE_UNIT_LIMIT_ARG.name)
         {
-            eprintln!(
-                "error: need to set {} if {} and {} are set",
-                COMPUTE_UNIT_LIMIT_ARG.name, COMPUTE_UNIT_PRICE_ARG.name, BLOCKHASH_ARG.name,
-            );
-            exit(1);
+            clap::Error::with_description(
+                &format!(
+                    "Need to set `{}` if `{}` and `--{}` are set",
+                    COMPUTE_UNIT_LIMIT_ARG.long, COMPUTE_UNIT_PRICE_ARG.long, BLOCKHASH_ARG.long,
+                ),
+                clap::ErrorKind::MissingRequiredArgument,
+            )
+            .exit();
         }
 
         let nonce_blockhash = value_of(matches, BLOCKHASH_ARG.name);

--- a/token/cli/src/config.rs
+++ b/token/cli/src/config.rs
@@ -1,5 +1,8 @@
 use {
-    crate::clap_app::{Error, COMPUTE_UNIT_LIMIT_ARG, COMPUTE_UNIT_PRICE_ARG, MULTISIG_SIGNER_ARG},
+    crate::clap_app::{
+        parse_compute_unit_limit, Error, COMPUTE_UNIT_LIMIT_ARG, COMPUTE_UNIT_PRICE_ARG,
+        MULTISIG_SIGNER_ARG,
+    },
     clap::ArgMatches,
     solana_clap_utils::{
         input_parsers::{pubkey_of_signer, value_of},
@@ -20,8 +23,11 @@ use {
         extension::StateWithExtensionsOwned,
         state::{Account, Mint},
     },
-    spl_token_client::client::{
-        ProgramClient, ProgramOfflineClient, ProgramRpcClient, ProgramRpcClientSendTransaction,
+    spl_token_client::{
+        client::{
+            ProgramClient, ProgramOfflineClient, ProgramRpcClient, ProgramRpcClientSendTransaction,
+        },
+        token::ComputeUnitLimit,
     },
     std::{process::exit, rc::Rc, sync::Arc},
 };
@@ -68,7 +74,7 @@ pub struct Config<'a> {
     pub program_id: Pubkey,
     pub restrict_to_program_id: bool,
     pub compute_unit_price: Option<u64>,
-    pub compute_unit_limit: Option<u32>,
+    pub compute_unit_limit: ComputeUnitLimit,
 }
 
 impl<'a> Config<'a> {
@@ -282,7 +288,10 @@ impl<'a> Config<'a> {
 
         let nonce_blockhash = value_of(matches, BLOCKHASH_ARG.name);
         let compute_unit_price = value_of(matches, COMPUTE_UNIT_PRICE_ARG.name);
-        let compute_unit_limit = value_of(matches, COMPUTE_UNIT_LIMIT_ARG.name);
+        let compute_unit_limit = matches
+            .value_of(COMPUTE_UNIT_LIMIT_ARG.name)
+            .map(|x| parse_compute_unit_limit(x).unwrap())
+            .unwrap_or(ComputeUnitLimit::Default);
         Self {
             default_signer,
             rpc_client,

--- a/token/cli/tests/command.rs
+++ b/token/cli/tests/command.rs
@@ -44,7 +44,7 @@ use {
         client::{
             ProgramClient, ProgramOfflineClient, ProgramRpcClient, ProgramRpcClientSendTransaction,
         },
-        token::Token,
+        token::{ComputeUnitLimit, Token},
     },
     spl_token_group_interface::state::{TokenGroup, TokenGroupMember},
     spl_token_metadata_interface::state::TokenMetadata,
@@ -201,7 +201,7 @@ fn test_config_with_default_signer<'a>(
         program_id: *program_id,
         restrict_to_program_id: true,
         compute_unit_price: None,
-        compute_unit_limit: None,
+        compute_unit_limit: ComputeUnitLimit::Simulated,
     }
 }
 
@@ -230,7 +230,7 @@ fn test_config_without_default_signer<'a>(
         program_id: *program_id,
         restrict_to_program_id: true,
         compute_unit_price: None,
-        compute_unit_limit: None,
+        compute_unit_limit: ComputeUnitLimit::Simulated,
     }
 }
 
@@ -2991,6 +2991,7 @@ async fn offline_multisig_transfer_with_nonce(test_validator: &TestValidator, pa
         .unzip();
     for program_id in VALID_TOKEN_PROGRAM_IDS.iter() {
         let mut config = test_config_with_default_signer(test_validator, payer, program_id);
+        config.compute_unit_limit = ComputeUnitLimit::Default;
         let token = create_token(&config, payer).await;
         let nonce = create_nonce(&config, payer).await;
 
@@ -4081,7 +4082,7 @@ async fn compute_budget(test_validator: &TestValidator, payer: &Keypair) {
     for program_id in VALID_TOKEN_PROGRAM_IDS.iter() {
         let mut config = test_config_with_default_signer(test_validator, payer, program_id);
         config.compute_unit_price = Some(42);
-        config.compute_unit_limit = Some(30_000);
+        config.compute_unit_limit = ComputeUnitLimit::Static(30_000);
         run_transfer_test(&config, payer).await;
     }
 }

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -39,7 +39,7 @@ use {
     },
     spl_token_client::{
         proof_generation::transfer_with_fee_split_proof_data,
-        token::{ExtensionInitializationParams, TokenError as TokenClientError},
+        token::{ComputeUnitLimit, ExtensionInitializationParams, TokenError as TokenClientError},
     },
     std::{convert::TryInto, mem::size_of},
 };
@@ -2526,7 +2526,7 @@ async fn confidential_transfer_transfer_with_split_proof_contexts_in_parallel() 
     // With split proofs in parallel, one of the transactions does more work
     // than the other, which isn't caught during the simulation to discover the
     // compute unit limit.
-    let token = token.with_compute_unit_limit(500_000);
+    let token = token.with_compute_unit_limit(ComputeUnitLimit::Static(500_000));
     token
         .confidential_transfer_transfer_with_split_proofs_in_parallel(
             &alice_meta.token_account,
@@ -2948,7 +2948,7 @@ async fn confidential_transfer_transfer_with_fee_and_split_proof_context_in_para
     // With split proofs in parallel, one of the transactions does more work
     // than the other, which isn't caught during the simulation to discover the
     // compute unit limit.
-    let token = token.with_compute_unit_limit(500_000);
+    let token = token.with_compute_unit_limit(ComputeUnitLimit::Static(500_000));
     token
         .confidential_transfer_transfer_with_fee_and_split_proofs_in_parallel(
             &alice_meta.token_account,

--- a/token/program-2022-test/tests/program_test.rs
+++ b/token/program-2022-test/tests/program_test.rs
@@ -20,7 +20,7 @@ use {
             ProgramBanksClient, ProgramBanksClientProcessTransaction, ProgramClient,
             SendTransaction, SimulateTransaction,
         },
-        token::{ExtensionInitializationParams, Token, TokenResult},
+        token::{ComputeUnitLimit, ExtensionInitializationParams, Token, TokenResult},
     },
     std::sync::Arc,
 };
@@ -113,7 +113,8 @@ impl TestContext {
             &mint_account.pubkey(),
             Some(decimals),
             Arc::new(keypair_clone(&payer)),
-        );
+        )
+        .with_compute_unit_limit(ComputeUnitLimit::Simulated);
 
         let token_unchecked = Token::new(
             Arc::clone(&client),
@@ -121,7 +122,8 @@ impl TestContext {
             &mint_account.pubkey(),
             None,
             Arc::new(payer),
-        );
+        )
+        .with_compute_unit_limit(ComputeUnitLimit::Simulated);
 
         token
             .create_mint(
@@ -157,7 +159,8 @@ impl TestContext {
             Token::create_native_mint(Arc::clone(&client), &id(), Arc::new(keypair_clone(&payer)))
                 .await?;
         // unchecked native is never needed because decimals is known statically
-        let token_unchecked = Token::new_native(Arc::clone(&client), &id(), Arc::new(payer));
+        let token_unchecked = Token::new_native(Arc::clone(&client), &id(), Arc::new(payer))
+            .with_compute_unit_limit(ComputeUnitLimit::Simulated);
         self.token_context = Some(TokenContext {
             decimals: native_mint::DECIMALS,
             mint_authority: Keypair::new(), /* bogus */


### PR DESCRIPTION
#### Problem

https://github.com/solana-labs/solana-program-library/pull/6501 broke offline signing -- by default, the token client sets the compute unit limit based on simulation. If it's using offline signing, it'll silently swallow the error and pop the compute unit limit instruction.

So when we offline-sign a transaction, it won't have the compute unit limit instruction, and when we broadcast it, we'll simulate and add the compute unit limit instruction, causing a pre-signer error.

This was the classic overly-clever-but-brittle solution. I discovered it while applying the token-cli changes to the Solana CLI.

#### Solution

Be more explicit:

* don't simulate by default
* allow users to specify `--with-compute-unit-limit SIMULATED` if they want that
* error if someone sets `--with-compute-unit-price` *without* `--with-compute-unit-limit`. This one might be contentious, and I could be talked down to making it a warning. But since we've only just introduced the flag, I think it's better to do the right thing and force people to be explicit
* improve the offline signing test by actually sending the transaction so we catch this in the future

Let me know how you like the `ComputeUnitLimit`, because I'll likely do the same exact thing for the Solana CLI. Except there, `--with-compute-unit-price` has been around for some time, so I would show a warning if someone specifies price without a limit.