### PR TITLE
Account Compression SDK: Add back linting

### DIFF
--- a/account-compression/sdk/src/constants/index.ts
+++ b/account-compression/sdk/src/constants/index.ts
@@ -9,8 +9,8 @@ export const SPL_NOOP_PROGRAM_ID = new PublicKey(SPL_NOOP_ADDRESS);
  * creating a new {@link ConcurrentMerkleTreeAccount}.
  */
 export type DepthSizePair = {
-    maxDepth: number;
     maxBufferSize: number;
+    maxDepth: number;
 };
 
 const allPairs: number[][] = [
@@ -61,37 +61,4 @@ export const ALL_DEPTH_SIZE_PAIRS: ValidDepthSizePair[] = allPairs.map(pair => {
 });
 
 export type ValidDepthSizePair =
-    | { maxDepth: 3; maxBufferSize: 8 }
-    | { maxDepth: 5; maxBufferSize: 8 }
-    | { maxDepth: 6; maxBufferSize: 16 }
-    | { maxDepth: 7; maxBufferSize: 16 }
-    | { maxDepth: 8; maxBufferSize: 16 }
-    | { maxDepth: 9; maxBufferSize: 16 }
-    | { maxDepth: 10; maxBufferSize: 32 }
-    | { maxDepth: 11; maxBufferSize: 32 }
-    | { maxDepth: 12; maxBufferSize: 32 }
-    | { maxDepth: 13; maxBufferSize: 32 }
-    | { maxDepth: 14; maxBufferSize: 64 }
-    | { maxDepth: 14; maxBufferSize: 256 }
-    | { maxDepth: 14; maxBufferSize: 1024 }
-    | { maxDepth: 14; maxBufferSize: 2048 }
-    | { maxDepth: 15; maxBufferSize: 64 }
-    | { maxDepth: 16; maxBufferSize: 64 }
-    | { maxDepth: 17; maxBufferSize: 64 }
-    | { maxDepth: 18; maxBufferSize: 64 }
-    | { maxDepth: 19; maxBufferSize: 64 }
-    | { maxDepth: 20; maxBufferSize: 64 }
-    | { maxDepth: 20; maxBufferSize: 256 }
-    | { maxDepth: 20; maxBufferSize: 1024 }
-    | { maxDepth: 20; maxBufferSize: 2048 }
-    | { maxDepth: 24; maxBufferSize: 64 }
-    | { maxDepth: 24; maxBufferSize: 256 }
-    | { maxDepth: 24; maxBufferSize: 512 }
-    | { maxDepth: 24; maxBufferSize: 1024 }
-    | { maxDepth: 24; maxBufferSize: 2048 }
-    | { maxDepth: 26; maxBufferSize: 512 }
-    | { maxDepth: 26; maxBufferSize: 1024 }
-    | { maxDepth: 26; maxBufferSize: 2048 }
-    | { maxDepth: 30; maxBufferSize: 512 }
-    | { maxDepth: 30; maxBufferSize: 1024 }
-    | { maxDepth: 30; maxBufferSize: 2048 };
+    { maxBufferSize: 8, maxDepth: 3; } | { maxBufferSize: 8, maxDepth: 5; } | { maxBufferSize: 16, maxDepth: 6; } | { maxBufferSize: 16, maxDepth: 7; } | { maxBufferSize: 16, maxDepth: 8; } | { maxBufferSize: 16, maxDepth: 9; } | { maxBufferSize: 32, maxDepth: 10; } | { maxBufferSize: 32, maxDepth: 11; } | { maxBufferSize: 32, maxDepth: 12; } | { maxBufferSize: 32, maxDepth: 13; } | { maxBufferSize: 64, maxDepth: 14; } | { maxBufferSize: 64, maxDepth: 15; } | { maxBufferSize: 64, maxDepth: 16; } | { maxBufferSize: 64, maxDepth: 17; } | { maxBufferSize: 64, maxDepth: 18; } | { maxBufferSize: 64, maxDepth: 19; } | { maxBufferSize: 64, maxDepth: 20; } | { maxBufferSize: 64, maxDepth: 24; } | { maxBufferSize: 256, maxDepth: 14; } | { maxBufferSize: 256, maxDepth: 20; } | { maxBufferSize: 256, maxDepth: 24; } | { maxBufferSize: 512, maxDepth: 24; } | { maxBufferSize: 512, maxDepth: 26; } | { maxBufferSize: 512, maxDepth: 30; } | { maxBufferSize: 1024, maxDepth: 14; } | { maxBufferSize: 1024, maxDepth: 20; } | { maxBufferSize: 1024, maxDepth: 24; } | { maxBufferSize: 1024, maxDepth: 26; } | { maxBufferSize: 1024, maxDepth: 30; } | { maxBufferSize: 2048, maxDepth: 14; } | { maxBufferSize: 2048, maxDepth: 20; } | { maxBufferSize: 2048, maxDepth: 24; } | { maxBufferSize: 2048, maxDepth: 26; } | { maxBufferSize: 2048, maxDepth: 30; };

--- a/account-compression/sdk/src/constants/index.ts
+++ b/account-compression/sdk/src/constants/index.ts
@@ -61,4 +61,37 @@ export const ALL_DEPTH_SIZE_PAIRS: ValidDepthSizePair[] = allPairs.map(pair => {
 });
 
 export type ValidDepthSizePair =
-    { maxBufferSize: 8, maxDepth: 3; } | { maxBufferSize: 8, maxDepth: 5; } | { maxBufferSize: 16, maxDepth: 6; } | { maxBufferSize: 16, maxDepth: 7; } | { maxBufferSize: 16, maxDepth: 8; } | { maxBufferSize: 16, maxDepth: 9; } | { maxBufferSize: 32, maxDepth: 10; } | { maxBufferSize: 32, maxDepth: 11; } | { maxBufferSize: 32, maxDepth: 12; } | { maxBufferSize: 32, maxDepth: 13; } | { maxBufferSize: 64, maxDepth: 14; } | { maxBufferSize: 64, maxDepth: 15; } | { maxBufferSize: 64, maxDepth: 16; } | { maxBufferSize: 64, maxDepth: 17; } | { maxBufferSize: 64, maxDepth: 18; } | { maxBufferSize: 64, maxDepth: 19; } | { maxBufferSize: 64, maxDepth: 20; } | { maxBufferSize: 64, maxDepth: 24; } | { maxBufferSize: 256, maxDepth: 14; } | { maxBufferSize: 256, maxDepth: 20; } | { maxBufferSize: 256, maxDepth: 24; } | { maxBufferSize: 512, maxDepth: 24; } | { maxBufferSize: 512, maxDepth: 26; } | { maxBufferSize: 512, maxDepth: 30; } | { maxBufferSize: 1024, maxDepth: 14; } | { maxBufferSize: 1024, maxDepth: 20; } | { maxBufferSize: 1024, maxDepth: 24; } | { maxBufferSize: 1024, maxDepth: 26; } | { maxBufferSize: 1024, maxDepth: 30; } | { maxBufferSize: 2048, maxDepth: 14; } | { maxBufferSize: 2048, maxDepth: 20; } | { maxBufferSize: 2048, maxDepth: 24; } | { maxBufferSize: 2048, maxDepth: 26; } | { maxBufferSize: 2048, maxDepth: 30; };
+    | { maxBufferSize: 8; maxDepth: 3 }
+    | { maxBufferSize: 8; maxDepth: 5 }
+    | { maxBufferSize: 16; maxDepth: 6 }
+    | { maxBufferSize: 16; maxDepth: 7 }
+    | { maxBufferSize: 16; maxDepth: 8 }
+    | { maxBufferSize: 16; maxDepth: 9 }
+    | { maxBufferSize: 32; maxDepth: 10 }
+    | { maxBufferSize: 32; maxDepth: 11 }
+    | { maxBufferSize: 32; maxDepth: 12 }
+    | { maxBufferSize: 32; maxDepth: 13 }
+    | { maxBufferSize: 64; maxDepth: 14 }
+    | { maxBufferSize: 64; maxDepth: 15 }
+    | { maxBufferSize: 64; maxDepth: 16 }
+    | { maxBufferSize: 64; maxDepth: 17 }
+    | { maxBufferSize: 64; maxDepth: 18 }
+    | { maxBufferSize: 64; maxDepth: 19 }
+    | { maxBufferSize: 64; maxDepth: 20 }
+    | { maxBufferSize: 64; maxDepth: 24 }
+    | { maxBufferSize: 256; maxDepth: 14 }
+    | { maxBufferSize: 256; maxDepth: 20 }
+    | { maxBufferSize: 256; maxDepth: 24 }
+    | { maxBufferSize: 512; maxDepth: 24 }
+    | { maxBufferSize: 512; maxDepth: 26 }
+    | { maxBufferSize: 512; maxDepth: 30 }
+    | { maxBufferSize: 1024; maxDepth: 14 }
+    | { maxBufferSize: 1024; maxDepth: 20 }
+    | { maxBufferSize: 1024; maxDepth: 24 }
+    | { maxBufferSize: 1024; maxDepth: 26 }
+    | { maxBufferSize: 1024; maxDepth: 30 }
+    | { maxBufferSize: 2048; maxDepth: 14 }
+    | { maxBufferSize: 2048; maxDepth: 20 }
+    | { maxBufferSize: 2048; maxDepth: 24 }
+    | { maxBufferSize: 2048; maxDepth: 26 }
+    | { maxBufferSize: 2048; maxDepth: 30 };

--- a/account-compression/sdk/src/generated/instructions/append.ts
+++ b/account-compression/sdk/src/generated/instructions/append.ts
@@ -43,10 +43,10 @@ export const appendStruct = new beet.BeetArgsStruct<
  * @category generated
  */
 export type AppendInstructionAccounts = {
-    merkleTree: web3.PublicKey;
-    authority: web3.PublicKey;
-    noop: web3.PublicKey;
     anchorRemainingAccounts?: web3.AccountMeta[];
+    authority: web3.PublicKey;
+    merkleTree: web3.PublicKey;
+    noop: web3.PublicKey;
 };
 
 export const appendInstructionDiscriminator = [149, 120, 18, 222, 236, 225, 88, 203];

--- a/account-compression/sdk/src/generated/instructions/closeEmptyTree.ts
+++ b/account-compression/sdk/src/generated/instructions/closeEmptyTree.ts
@@ -27,10 +27,10 @@ export const closeEmptyTreeStruct = new beet.BeetArgsStruct<{
  * @category generated
  */
 export type CloseEmptyTreeInstructionAccounts = {
-    merkleTree: web3.PublicKey;
-    authority: web3.PublicKey;
-    recipient: web3.PublicKey;
     anchorRemainingAccounts?: web3.AccountMeta[];
+    authority: web3.PublicKey;
+    merkleTree: web3.PublicKey;
+    recipient: web3.PublicKey;
 };
 
 export const closeEmptyTreeInstructionDiscriminator = [50, 14, 219, 107, 78, 103, 16, 103];

--- a/account-compression/sdk/src/generated/instructions/initEmptyMerkleTree.ts
+++ b/account-compression/sdk/src/generated/instructions/initEmptyMerkleTree.ts
@@ -14,8 +14,8 @@ import * as web3 from '@solana/web3.js';
  * @category generated
  */
 export type InitEmptyMerkleTreeInstructionArgs = {
-    maxDepth: number;
     maxBufferSize: number;
+    maxDepth: number;
 };
 /**
  * @category Instructions
@@ -45,10 +45,10 @@ export const initEmptyMerkleTreeStruct = new beet.BeetArgsStruct<
  * @category generated
  */
 export type InitEmptyMerkleTreeInstructionAccounts = {
-    merkleTree: web3.PublicKey;
-    authority: web3.PublicKey;
-    noop: web3.PublicKey;
     anchorRemainingAccounts?: web3.AccountMeta[];
+    authority: web3.PublicKey;
+    merkleTree: web3.PublicKey;
+    noop: web3.PublicKey;
 };
 
 export const initEmptyMerkleTreeInstructionDiscriminator = [191, 11, 119, 7, 180, 107, 220, 110];

--- a/account-compression/sdk/src/generated/instructions/insertOrAppend.ts
+++ b/account-compression/sdk/src/generated/instructions/insertOrAppend.ts
@@ -14,9 +14,9 @@ import * as web3 from '@solana/web3.js';
  * @category generated
  */
 export type InsertOrAppendInstructionArgs = {
-    root: number[] /* size: 32 */;
-    leaf: number[] /* size: 32 */;
     index: number;
+    leaf: number[] /* size: 32 */;
+    root: number[] /* size: 32 */;
 };
 /**
  * @category Instructions
@@ -47,10 +47,10 @@ export const insertOrAppendStruct = new beet.BeetArgsStruct<
  * @category generated
  */
 export type InsertOrAppendInstructionAccounts = {
-    merkleTree: web3.PublicKey;
-    authority: web3.PublicKey;
-    noop: web3.PublicKey;
     anchorRemainingAccounts?: web3.AccountMeta[];
+    authority: web3.PublicKey;
+    merkleTree: web3.PublicKey;
+    noop: web3.PublicKey;
 };
 
 export const insertOrAppendInstructionDiscriminator = [6, 42, 50, 190, 51, 109, 178, 168];

--- a/account-compression/sdk/src/generated/instructions/replaceLeaf.ts
+++ b/account-compression/sdk/src/generated/instructions/replaceLeaf.ts
@@ -14,10 +14,10 @@ import * as web3 from '@solana/web3.js';
  * @category generated
  */
 export type ReplaceLeafInstructionArgs = {
-    root: number[] /* size: 32 */;
-    previousLeaf: number[] /* size: 32 */;
-    newLeaf: number[] /* size: 32 */;
     index: number;
+    newLeaf: number[] /* size: 32 */;
+    previousLeaf: number[] /* size: 32 */;
+    root: number[] /* size: 32 */;
 };
 /**
  * @category Instructions
@@ -49,10 +49,10 @@ export const replaceLeafStruct = new beet.BeetArgsStruct<
  * @category generated
  */
 export type ReplaceLeafInstructionAccounts = {
-    merkleTree: web3.PublicKey;
-    authority: web3.PublicKey;
-    noop: web3.PublicKey;
     anchorRemainingAccounts?: web3.AccountMeta[];
+    authority: web3.PublicKey;
+    merkleTree: web3.PublicKey;
+    noop: web3.PublicKey;
 };
 
 export const replaceLeafInstructionDiscriminator = [204, 165, 76, 100, 73, 147, 0, 128];

--- a/account-compression/sdk/src/generated/instructions/transferAuthority.ts
+++ b/account-compression/sdk/src/generated/instructions/transferAuthority.ts
@@ -43,9 +43,9 @@ export const transferAuthorityStruct = new beet.BeetArgsStruct<
  * @category generated
  */
 export type TransferAuthorityInstructionAccounts = {
-    merkleTree: web3.PublicKey;
-    authority: web3.PublicKey;
     anchorRemainingAccounts?: web3.AccountMeta[];
+    authority: web3.PublicKey;
+    merkleTree: web3.PublicKey;
 };
 
 export const transferAuthorityInstructionDiscriminator = [48, 169, 76, 72, 229, 180, 55, 161];

--- a/account-compression/sdk/src/generated/instructions/verifyLeaf.ts
+++ b/account-compression/sdk/src/generated/instructions/verifyLeaf.ts
@@ -14,9 +14,9 @@ import * as web3 from '@solana/web3.js';
  * @category generated
  */
 export type VerifyLeafInstructionArgs = {
-    root: number[] /* size: 32 */;
-    leaf: number[] /* size: 32 */;
     index: number;
+    leaf: number[] /* size: 32 */;
+    root: number[] /* size: 32 */;
 };
 /**
  * @category Instructions
@@ -45,8 +45,8 @@ export const verifyLeafStruct = new beet.BeetArgsStruct<
  * @category generated
  */
 export type VerifyLeafInstructionAccounts = {
-    merkleTree: web3.PublicKey;
     anchorRemainingAccounts?: web3.AccountMeta[];
+    merkleTree: web3.PublicKey;
 };
 
 export const verifyLeafInstructionDiscriminator = [124, 220, 22, 223, 104, 10, 250, 224];

--- a/account-compression/sdk/src/generated/types/AccountCompressionEvent.ts
+++ b/account-compression/sdk/src/generated/types/AccountCompressionEvent.ts
@@ -19,8 +19,8 @@ import { ChangeLogEvent, changeLogEventBeet } from './ChangeLogEvent';
  * @private
  */
 export type AccountCompressionEventRecord = {
-    ChangeLog: { fields: [ChangeLogEvent] };
     ApplicationData: { fields: [ApplicationDataEvent] };
+    ChangeLog: { fields: [ChangeLogEvent] };
 };
 
 /**

--- a/account-compression/sdk/src/generated/types/ChangeLogEventV1.ts
+++ b/account-compression/sdk/src/generated/types/ChangeLogEventV1.ts
@@ -12,9 +12,9 @@ import * as web3 from '@solana/web3.js';
 import { PathNode, pathNodeBeet } from './PathNode';
 export type ChangeLogEventV1 = {
     id: web3.PublicKey;
+    index: number;
     path: PathNode[];
     seq: beet.bignum;
-    index: number;
 };
 
 /**

--- a/account-compression/sdk/src/generated/types/ConcurrentMerkleTreeHeaderDataV1.ts
+++ b/account-compression/sdk/src/generated/types/ConcurrentMerkleTreeHeaderDataV1.ts
@@ -9,10 +9,10 @@ import * as beet from '@metaplex-foundation/beet';
 import * as beetSolana from '@metaplex-foundation/beet-solana';
 import * as web3 from '@solana/web3.js';
 export type ConcurrentMerkleTreeHeaderDataV1 = {
-    maxBufferSize: number;
-    maxDepth: number;
     authority: web3.PublicKey;
     creationSlot: beet.bignum;
+    maxBufferSize: number;
+    maxDepth: number;
     padding: number[] /* size: 6 */;
 };
 

--- a/account-compression/sdk/src/generated/types/PathNode.ts
+++ b/account-compression/sdk/src/generated/types/PathNode.ts
@@ -7,8 +7,8 @@
 
 import * as beet from '@metaplex-foundation/beet';
 export type PathNode = {
-    node: number[] /* size: 32 */;
     index: number;
+    node: number[] /* size: 32 */;
 };
 
 /**

--- a/account-compression/sdk/src/instructions/index.ts
+++ b/account-compression/sdk/src/instructions/index.ts
@@ -95,7 +95,7 @@ export function createReplaceIx(
 export function createAppendIx(
     merkleTree: PublicKey,
     authority: PublicKey,
-    newLeaf: Buffer | ArrayLike<number>,
+    newLeaf: ArrayLike<number> | Buffer,
 ): TransactionInstruction {
     return createAppendInstruction(
         {

--- a/account-compression/sdk/src/merkle-tree/index.ts
+++ b/account-compression/sdk/src/merkle-tree/index.ts
@@ -7,8 +7,8 @@ const CACHE_EMPTY_NODE = new Map<number, Buffer>();
 export const LEAF_BUFFER_LENGTH = 32;
 
 export type MerkleTreeProof = {
-    leafIndex: number;
     leaf: Buffer;
+    leafIndex: number;
     proof: Buffer[];
     root: Buffer;
 };
@@ -185,12 +185,12 @@ export class MerkleTree {
 }
 
 export type TreeNode = {
-    node: Buffer;
-    left: TreeNode | undefined;
-    right: TreeNode | undefined;
-    parent: TreeNode | undefined;
-    level: number;
     id: number;
+    left: TreeNode | undefined;
+    level: number;
+    node: Buffer;
+    parent: TreeNode | undefined;
+    right: TreeNode | undefined;
 };
 
 /**

--- a/account-compression/sdk/src/types/ConcurrentMerkleTree.ts
+++ b/account-compression/sdk/src/types/ConcurrentMerkleTree.ts
@@ -9,10 +9,11 @@ import { Path, pathBeetFactory } from './Path';
  * @private
  */
 export type ChangeLogInternal = {
-    root: PublicKey;
-    pathNodes: PublicKey[];
-    index: number; // u32
-    _padding: number; // u32
+    // u32
+    _padding: number;
+    index: number;
+    pathNodes: PublicKey[]; 
+    root: PublicKey; // u32
 };
 
 const changeLogBeetFactory = (maxDepth: number) => {
@@ -31,11 +32,14 @@ const changeLogBeetFactory = (maxDepth: number) => {
  * ConcurrentMerkleTree fields necessary for deserializing an on-chain ConcurrentMerkleTree
  */
 export type ConcurrentMerkleTree = {
-    sequenceNumber: beet.bignum; // u64
-    activeIndex: beet.bignum; // u64
-    bufferSize: beet.bignum; // u64
-    changeLogs: ChangeLogInternal[];
+    // u64
+    activeIndex: beet.bignum; 
+    // u64
+    bufferSize: beet.bignum; 
+    // u64
+    changeLogs: ChangeLogInternal[]; 
     rightMostPath: Path;
+    sequenceNumber: beet.bignum;
 };
 
 /**

--- a/account-compression/sdk/src/types/ConcurrentMerkleTree.ts
+++ b/account-compression/sdk/src/types/ConcurrentMerkleTree.ts
@@ -12,7 +12,7 @@ export type ChangeLogInternal = {
     // u32
     _padding: number;
     index: number;
-    pathNodes: PublicKey[]; 
+    pathNodes: PublicKey[];
     root: PublicKey; // u32
 };
 
@@ -33,11 +33,11 @@ const changeLogBeetFactory = (maxDepth: number) => {
  */
 export type ConcurrentMerkleTree = {
     // u64
-    activeIndex: beet.bignum; 
+    activeIndex: beet.bignum;
     // u64
-    bufferSize: beet.bignum; 
+    bufferSize: beet.bignum;
     // u64
-    changeLogs: ChangeLogInternal[]; 
+    changeLogs: ChangeLogInternal[];
     rightMostPath: Path;
     sequenceNumber: beet.bignum;
 };

--- a/account-compression/sdk/src/types/Path.ts
+++ b/account-compression/sdk/src/types/Path.ts
@@ -7,10 +7,11 @@ import { PublicKey } from '@solana/web3.js';
  * used in an {@link ConcurrentMerkleTree}
  */
 export type Path = {
-    proof: PublicKey[];
-    leaf: PublicKey;
-    index: number; // u32
-    _padding: number; // u32
+    // u32
+    _padding: number;
+    index: number;
+    leaf: PublicKey; 
+    proof: PublicKey[]; // u32
 };
 
 /**

--- a/account-compression/sdk/src/types/Path.ts
+++ b/account-compression/sdk/src/types/Path.ts
@@ -10,7 +10,7 @@ export type Path = {
     // u32
     _padding: number;
     index: number;
-    leaf: PublicKey; 
+    leaf: PublicKey;
     proof: PublicKey[]; // u32
 };
 

--- a/account-compression/sdk/src/types/index.ts
+++ b/account-compression/sdk/src/types/index.ts
@@ -7,8 +7,8 @@ export * from './Canopy';
 export * from './ConcurrentMerkleTree';
 
 export type ChangeLogEventV1 = {
-    treeId: PublicKey;
+    index: number;
     path: PathNode[];
     seq: BN;
-    index: number;
+    treeId: PublicKey;
 };

--- a/account-compression/sdk/tests/accounts/concurrentMerkleTreeAccount.test.ts
+++ b/account-compression/sdk/tests/accounts/concurrentMerkleTreeAccount.test.ts
@@ -8,7 +8,7 @@ import { ALL_DEPTH_SIZE_PAIRS, ConcurrentMerkleTreeAccount, getConcurrentMerkleT
 import { emptyNode, MerkleTree } from '../../src/merkle-tree';
 import { createEmptyTreeOnChain, createTreeOnChain } from '../utils';
 
-async function assertCMTProperties(
+function assertCMTProperties(
     onChainCMT: ConcurrentMerkleTreeAccount,
     expectedMaxDepth: number,
     expectedMaxBufferSize: number,

--- a/account-compression/sdk/tests/events/applicationData.test.ts
+++ b/account-compression/sdk/tests/events/applicationData.test.ts
@@ -6,7 +6,7 @@ import { deserializeApplicationDataEvent } from "../../src";
 
 describe("Serde tests", () => {
   describe("ApplicationDataEvent tests", () => {
-    it("Can serialize and deserialize ApplicationDataEvent", async () => {
+    it("Can serialize and deserialize ApplicationDataEvent", () => {
       const data = Buffer.from("Hello world");
       const applicationDataEvent = Buffer.concat([
         Buffer.from([0x1]), // ApplicationData Event tag

--- a/account-compression/sdk/tsconfig.json
+++ b/account-compression/sdk/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.base.json",
-  "include": ["src"],
+  "include": ["src", "tests"],
   "compilerOptions": {
     "outDir": "dist/cjs/",
     "declarationDir": "dist/types",

--- a/ci/js-test-account-compression.sh
+++ b/ci/js-test-account-compression.sh
@@ -9,5 +9,5 @@ cd account-compression/sdk
 pnpm install
 pnpm build
 pnpm build:program
-# pnpm lint # re-enable when lints are fixed
+pnpm lint
 pnpm test


### PR DESCRIPTION
#### Problem
The SPL Account Compression SDK has long been unchecked by `prettier` or
`eslint` rules. This means changes to the SDK are never checked by CI for
formatting or linting violations.

Additionally, as we migrate the workspace to use ESLint 9.0, it makes things 
difficult to test.

#### Summary of Changes
Lint `--fix` everything in the Account Compression SDK, and enable linting in 
CI!