### PR TITLE
name-service-js: add `.prettierignore` and `.eslintignore`

### DIFF
--- a/name-service/js/.eslintignore
+++ b/name-service/js/.eslintignore
@@ -1,0 +1,5 @@
+docs
+lib
+test-ledger
+
+package-lock.json

--- a/name-service/js/.prettierignore
+++ b/name-service/js/.prettierignore
@@ -1,0 +1,5 @@
+docs
+lib
+test-ledger
+
+package-lock.json


### PR DESCRIPTION
#### Problem
When linting against `name-service-js`, the build target directory, `lib`, can get
included in linting, since there's no ignore rules set for prettier.

#### Summary of Changes
Add some ignore rules!