### PR TITLE
[transfer-hook-cli] Replace `pubkey_of_signer` with `pubkey_from_source`

### DIFF
--- a/token/transfer-hook/cli/src/main.rs
+++ b/token/transfer-hook/cli/src/main.rs
@@ -5,10 +5,11 @@ use {
     clap::{crate_description, crate_name, crate_version, Arg, Command},
     solana_clap_v3_utils::{
         input_parsers::{
-            parse_url_or_moniker, pubkey_of_signer, signer::SignerSourceParserBuilder,
+            parse_url_or_moniker,
+            signer::{SignerSource, SignerSourceParserBuilder},
         },
         input_validators::normalize_to_url_if_moniker,
-        keypair::DefaultSigner,
+        keypair::{pubkey_from_source, DefaultSigner},
     },
     solana_client::nonblocking::rpc_client::RpcClient,
     solana_remote_wallet::remote_wallet::RemoteWalletManager,
@@ -443,12 +444,23 @@ extraMetas:
 
     match (command, matches) {
         ("create-extra-metas", arg_matches) => {
-            let program_id = pubkey_of_signer(arg_matches, "program_id", &mut wallet_manager)
-                .unwrap()
+            let program_id_source = arg_matches
+                .try_get_one::<SignerSource>("program_id")?
                 .unwrap();
-            let token = pubkey_of_signer(arg_matches, "token", &mut wallet_manager)
-                .unwrap()
+            let program_id = pubkey_from_source(
+                arg_matches,
+                program_id_source,
+                "program_id",
+                &mut wallet_manager,
+            )
+            .unwrap();
+
+            let token_source = arg_matches
+                .try_get_one::<SignerSource>("program_id")?
                 .unwrap();
+            let token = pubkey_from_source(arg_matches, token_source, "token", &mut wallet_manager)
+                .unwrap();
+
             let transfer_hook_accounts = arg_matches
                 .get_many::<Vec<ExtraAccountMeta>>("transfer_hook_accounts")
                 .unwrap_or_default()
@@ -483,12 +495,23 @@ extraMetas:
             println!("Signature: {signature}");
         }
         ("update-extra-metas", arg_matches) => {
-            let program_id = pubkey_of_signer(arg_matches, "program_id", &mut wallet_manager)
-                .unwrap()
+            let program_id_source = arg_matches
+                .try_get_one::<SignerSource>("program_id")?
                 .unwrap();
-            let token = pubkey_of_signer(arg_matches, "token", &mut wallet_manager)
-                .unwrap()
+            let program_id = pubkey_from_source(
+                arg_matches,
+                program_id_source,
+                "program_id",
+                &mut wallet_manager,
+            )
+            .unwrap();
+
+            let token_source = arg_matches
+                .try_get_one::<SignerSource>("program_id")?
                 .unwrap();
+            let token = pubkey_from_source(arg_matches, token_source, "token", &mut wallet_manager)
+                .unwrap();
+
             let transfer_hook_accounts = arg_matches
                 .get_many::<Vec<ExtraAccountMeta>>("transfer_hook_accounts")
                 .unwrap_or_default()


### PR DESCRIPTION
#### Problem
The `pubkey_of_signer` function from `solana-clap-v3-utils` expects arguments to be parsed as `String`. However, if when using the more up-to-date way of declaring arguments using `SignerSourceParserBuilder`, clap expects arguments to be parsed directly as `SignerSource` rather than `String` and hence returns a downcast error when `pubkey_of_signer` is invoked.

#### Summary of changes
Replace `pubkey_of_signer` with `pubkey_from_source`.

Unfortunately, this way of parsing is a bit more verbose than the original code, but it should do the job. Perhaps an analogous function to `pubkey_of_signer`, which parses arguments directly as `SignerSource` can be added to `solana-clap-v3-utils` later on to make the code less verbose.

Closes https://github.com/solana-labs/solana-program-library/issues/6623.