### PR TITLE
token-cli: Bump to 3.4.1 for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7601,7 +7601,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-cli"
-version = "3.4.0"
+version = "3.4.1"
 dependencies = [
  "assert_cmd",
  "base64 0.22.0",

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://spl.solana.com/token"
 license = "Apache-2.0"
 name = "spl-token-cli"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "3.4.0"
+version = "3.4.1"
 
 [build-dependencies]
 walkdir = "2"


### PR DESCRIPTION
#### Problem

There have been a couple of bug fixes on the token CLI, but they haven't been released yet.

#### Solution

Bump the crate for a new release.