### PR TITLE
transfer-hook-cli: patch token arg

### DIFF
--- a/token/transfer-hook/cli/src/main.rs
+++ b/token/transfer-hook/cli/src/main.rs
@@ -455,9 +455,7 @@ extraMetas:
             )
             .unwrap();
 
-            let token_source = arg_matches
-                .try_get_one::<SignerSource>("program_id")?
-                .unwrap();
+            let token_source = arg_matches.try_get_one::<SignerSource>("token")?.unwrap();
             let token = pubkey_from_source(arg_matches, token_source, "token", &mut wallet_manager)
                 .unwrap();
 
@@ -506,9 +504,7 @@ extraMetas:
             )
             .unwrap();
 
-            let token_source = arg_matches
-                .try_get_one::<SignerSource>("program_id")?
-                .unwrap();
+            let token_source = arg_matches.try_get_one::<SignerSource>("token")?.unwrap();
             let token = pubkey_from_source(arg_matches, token_source, "token", &mut wallet_manager)
                 .unwrap();
 


### PR DESCRIPTION
#### Problem
The arg for the token mint address in the Transfer Hook CLI's `create-extra-metas`
and `update-extra-metas` commands was searching for `program_id`. This causes
the program ID to be passed to the transfer hook program, when instead it should
be the mint address!

#### Summary of Changes
Fix the parameter parsers!