### PR TITLE
token-group: hash error codes

### DIFF
--- a/token-group/interface/src/error.rs
+++ b/token-group/interface/src/error.rs
@@ -3,7 +3,7 @@
 use spl_program_error::*;
 
 /// Errors that may be returned by the interface.
-#[spl_program_error]
+#[spl_program_error(hash_error_code_start = 3_406_457_176)]
 pub enum TokenGroupError {
     /// Size is greater than proposed max size
     #[error("Size is greater than proposed max size")]


### PR DESCRIPTION
#### Problem
We decided a while back to use an error code discriminator, derived from the
name of the error enum, to offset error codes that may arise in Token-2022.

We applied this concept to a few libraries and the Token Metadata interface, but
not to Token Group.

#### Summary of Changes
Apply hashed error code discriminators to SPL Token Group error codes.