### PR TITLE
token-cli: update member `GROUP_TOKEN_ADDRESS` arg

### DIFF
--- a/token/cli/src/clap_app.rs
+++ b/token/cli/src/clap_app.rs
@@ -1092,7 +1092,7 @@ pub fn app<'a, 'b>(
                 .arg(
                     Arg::with_name("group_token")
                         .validator(is_valid_pubkey)
-                        .value_name("TOKEN_MINT_ADDRESS")
+                        .value_name("GROUP_TOKEN_ADDRESS")
                         .takes_value(true)
                         .required(true)
                         .index(2)


### PR DESCRIPTION
#### Problem
The two arguments for `initialize-member` on the Token CLI are `token` and `group_token`.
However, when you print the help you'll see `<TOKEN_MINT_ADDRESS> <TOKEN_MINT_ADDRESS>`.
These should be a bit more clear.

#### Summary of Changes
Change the group token address help print-out to `<GROUP_TOKEN_ADDRESS>`.