### PR TITLE
token-2022: Prohibit self-delegated transfers with CPI Guard

### DIFF
--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -402,6 +402,15 @@ impl Processor {
                     authority_info_data_len,
                     account_info_iter.as_slice(),
                 )?;
+                if let Ok(cpi_guard) = source_account.get_extension::<CpiGuard>() {
+                    // If delegated to self, don't allow a transfer with CPI Guard
+                    if delegate == source_account.base.owner
+                        && cpi_guard.lock_cpi.into()
+                        && in_cpi()
+                    {
+                        return Err(TokenError::CpiGuardTransferBlocked.into());
+                    }
+                }
                 let delegated_amount = u64::from(source_account.base.delegated_amount);
                 if delegated_amount < amount {
                     return Err(TokenError::InsufficientFunds.into());


### PR DESCRIPTION
#### Problem

If someone has CPI guard enabled, and their token account is delegated to the owner, then it's still possible to sign with the owner's key to transfer. This goes against the spirit of the CPI guard, which does not allow transfers in CPI if they were signed by the owner.

#### Solution

Prohibit a transfer if:

* CPI guard is enabled
* the call is in a CPI
* the delegate is the owner