### PR TITLE
stake-pool-js: Add deserializer for `FutureEpoch`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,6 +409,9 @@ importers:
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
+      buffer-layout:
+        specifier: ^1.2.2
+        version: 1.2.2
       superstruct:
         specifier: ^1.0.4
         version: 1.0.4

--- a/stake-pool/js/package.json
+++ b/stake-pool/js/package.json
@@ -49,6 +49,7 @@
     "@solana/web3.js": "^1.91.8",
     "bn.js": "^5.2.0",
     "buffer": "^6.0.3",
+    "buffer-layout": "^1.2.2",
     "superstruct": "^1.0.4"
   },
   "devDependencies": {

--- a/stake-pool/js/src/types/buffer-layout.d.ts
+++ b/stake-pool/js/src/types/buffer-layout.d.ts
@@ -1,12 +1,22 @@
 declare module 'buffer-layout' {
-  export class Layout {}
-  export class UInt {}
-  /* eslint-disable  @typescript-eslint/no-unused-vars */
-  export function struct<T>(fields: any, property?: string, decodePrefixes?: boolean): any;
-  export function s32(property?: string): UInt;
-  export function u32(property?: string): UInt;
-  export function s16(property?: string): UInt;
-  export function u16(property?: string): UInt;
-  export function s8(property?: string): UInt;
-  export function u8(property?: string): UInt;
+  export class Layout<T = any> {
+    span: number;
+    property?: string;
+    constructor(span: number, property?: string);
+    decode(b: Buffer | string, offset?: number): T;
+    encode(src: T, b: Buffer, offset?: number): number;
+    getSpan(b: Buffer, offset?: number): number;
+    replicate(name: string): this;
+  }
+  export function struct<T>(
+    fields: Layout<any>[],
+    property?: string,
+    decodePrefixes?: boolean,
+  ): Layout<T>;
+  export function s32(property?: string): Layout<number>;
+  export function u32(property?: string): Layout<number>;
+  export function s16(property?: string): Layout<number>;
+  export function u16(property?: string): Layout<number>;
+  export function s8(property?: string): Layout<number>;
+  export function u8(property?: string): Layout<number>;
 }

--- a/stake-pool/js/src/types/buffer-layout.d.ts
+++ b/stake-pool/js/src/types/buffer-layout.d.ts
@@ -3,7 +3,7 @@ declare module 'buffer-layout' {
     span: number;
     property?: string;
     constructor(span: number, property?: string);
-    decode(b: Buffer | string, offset?: number): T;
+    decode(b: Buffer | undefined, offset?: number): T;
     encode(src: T, b: Buffer, offset?: number): number;
     getSpan(b: Buffer, offset?: number): number;
     replicate(name: string): this;


### PR DESCRIPTION
#### Problem

As outlined in #6677, the JS deserializer for the stake pool doesn't work because it doesn't handle the `FutureEpoch` type, which was introduced on the Rust side to force at least one epoch of notice for a change in withdrawal or epoch fees.

#### Solution

It's a bit gross, but this mainly copies the code from https://github.com/coral-xyz/anchor/blob/4540c8253acc2708ffd1085918e5f82f0e6c71e2/ts/packages/borsh/src/index.ts#L132, but also allows the discriminator to be 2.

This will at least allow people to deserialize pools properly until we get a real code-gen client library.

Fixes #6677