### PR TITLE
stake-pool-js: Bump version to 1.1.4 for release

### DIFF
--- a/stake-pool/js/package.json
+++ b/stake-pool/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana/spl-stake-pool",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "SPL Stake Pool Program JS API",
   "scripts": {
     "build": "tsc && cross-env NODE_ENV=production rollup -c",


### PR DESCRIPTION
#### Problem

There have been some fixes to the stake pool JS lib, but it's not available.

#### Solution

Bump the package to release.