### PR TITLE
transfer-hook-example: Only allow one mint to initialize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7914,6 +7914,7 @@ dependencies = [
  "spl-tlv-account-resolution 0.6.3",
  "spl-token-2022 3.0.2",
  "spl-token-client",
+ "spl-transfer-hook-example",
  "spl-transfer-hook-interface 0.6.3",
  "strum 0.26.2",
  "strum_macros 0.26.4",

--- a/token/js/package.json
+++ b/token/js/package.json
@@ -33,7 +33,7 @@
         "clean": "shx rm -rf lib **/*.tsbuildinfo || true",
         "build": "tsc --build --verbose tsconfig.all.json",
         "postbuild": "shx echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json",
-        "build:program": "cargo build-sbf --manifest-path=../program/Cargo.toml && cargo build-sbf --manifest-path=../program-2022/Cargo.toml && cargo build-sbf --manifest-path=../../associated-token-account/program/Cargo.toml && cargo build-sbf --manifest-path=../transfer-hook/example/Cargo.toml",
+        "build:program": "cargo build-sbf --manifest-path=../program/Cargo.toml && cargo build-sbf --manifest-path=../program-2022/Cargo.toml && cargo build-sbf --manifest-path=../../associated-token-account/program/Cargo.toml && cargo build-sbf --no-default-features --manifest-path=../transfer-hook/example/Cargo.toml",
         "watch": "tsc --build --verbose --watch tsconfig.all.json",
         "release": "npm run clean && npm run build",
         "fmt": "prettier --write '{*,**/*}.{ts,tsx,js,jsx,json}'",

--- a/token/transfer-hook/cli/Cargo.toml
+++ b/token/transfer-hook/cli/Cargo.toml
@@ -30,6 +30,7 @@ serde_yaml = "0.9.34"
 solana-test-validator = ">=1.18.11,<=2"
 spl-token-2022 = { version = "3.0.2", path = "../../program-2022", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.10.0", path = "../../client" }
+spl-transfer-hook-example = { version = "0.6.0", path = "../example" }
 
 [[bin]]
 name = "spl-transfer-hook"

--- a/token/transfer-hook/example/Cargo.toml
+++ b/token/transfer-hook/example/Cargo.toml
@@ -8,8 +8,10 @@ license = "Apache-2.0"
 edition = "2021"
 
 [features]
+default = ["forbid-additional-mints"]
 no-entrypoint = []
 test-sbf = []
+forbid-additional-mints = []
 
 [dependencies]
 arrayref = "0.3.7"

--- a/token/transfer-hook/example/src/lib.rs
+++ b/token/transfer-hook/example/src/lib.rs
@@ -16,3 +16,10 @@ mod entrypoint;
 // Export current sdk types for downstream users building with a different sdk
 // version
 pub use solana_program;
+
+/// Place the mint id that you want to target with your transfer hook program.
+/// Any other mint will fail to initialize, protecting the transfer hook program
+/// from rogue mints trying to get access to accounts.
+pub mod mint {
+    solana_program::declare_id!("Mint111111111111111111111111111111111111111");
+}

--- a/token/transfer-hook/example/src/lib.rs
+++ b/token/transfer-hook/example/src/lib.rs
@@ -20,6 +20,11 @@ pub use solana_program;
 /// Place the mint id that you want to target with your transfer hook program.
 /// Any other mint will fail to initialize, protecting the transfer hook program
 /// from rogue mints trying to get access to accounts.
+///
+/// There are many situations where it's reasonable to support multiple mints
+/// with one transfer-hook program, but because it's easy to make something
+/// unsafe, this simple example implementation only allows for one mint.
+#[cfg(feature = "forbid-additional-mints")]
 pub mod mint {
     solana_program::declare_id!("Mint111111111111111111111111111111111111111");
 }

--- a/token/transfer-hook/example/src/processor.rs
+++ b/token/transfer-hook/example/src/processor.rs
@@ -90,6 +90,7 @@ pub fn process_initialize_extra_account_meta_list(
 
     // check that the one mint we want to target is trying to create extra
     // account metas
+    #[cfg(feature = "forbid-additional-mints")]
     if *mint_info.key != crate::mint::id() {
         return Err(ProgramError::InvalidArgument);
     }

--- a/token/transfer-hook/example/src/processor.rs
+++ b/token/transfer-hook/example/src/processor.rs
@@ -88,6 +88,12 @@ pub fn process_initialize_extra_account_meta_list(
     let authority_info = next_account_info(account_info_iter)?;
     let _system_program_info = next_account_info(account_info_iter)?;
 
+    // check that the one mint we want to target is trying to create extra
+    // account metas
+    if *mint_info.key != crate::mint::id() {
+        return Err(ProgramError::InvalidArgument);
+    }
+
     // check that the mint authority is valid without fully deserializing
     let mint_data = mint_info.try_borrow_data()?;
     let mint = StateWithExtensions::<Mint>::unpack(&mint_data)?;


### PR DESCRIPTION
#### Problem

The transfer hook example program allows any mint to initialize extra account metas. If there are other accounts managed by the transfer hook program, it might be possible for an attacker to create their own extra account metas account using accounts from another mint.

For example, mint A uses the extra accounts metas account B, which declares usage of an account C, owned by the transfer hook program. An attacker creates a mint D with extra account metas E, and also declares usage of account C. Now two mints might be modifying the same account.

#### Solution

While this attack is hypothetical and not possible given the simple transfer hook program here, let's model good default behavior and limit the transfer hook example to only allow account metas for one mint.