### PR TITLE
token-cli: Update CU number on tests

### DIFF
--- a/token/cli/tests/command.rs
+++ b/token/cli/tests/command.rs
@@ -4100,7 +4100,7 @@ async fn compute_budget(test_validator: &TestValidator, payer: &Keypair) {
     for program_id in VALID_TOKEN_PROGRAM_IDS.iter() {
         let mut config = test_config_with_default_signer(test_validator, payer, program_id);
         config.compute_unit_price = Some(42);
-        config.compute_unit_limit = ComputeUnitLimit::Static(30_000);
+        config.compute_unit_limit = ComputeUnitLimit::Static(40_000);
         run_transfer_test(&config, payer).await;
     }
 }


### PR DESCRIPTION
#### Problem

The compute budget test is failing CI: https://github.com/solana-labs/solana-program-library/actions/runs/9408429916/job/25916391900

The static compute unit budget is too low.

#### Solution

Since this test isn't checking that compute units are below a certain amount, just bump it from 30k to 40k