### PR TITLE
Use curve25519-dalek from solana-zk-token-sdk

### DIFF
--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -9,7 +9,6 @@ version = "0.10.0"
 
 [dependencies]
 async-trait = "0.1"
-curve25519-dalek = "3.2.1"
 futures = "0.3.30"
 futures-util = "0.3"
 solana-banks-interface = ">=1.18.11,<=2"

--- a/token/client/src/proof_generation.rs
+++ b/token/client/src/proof_generation.rs
@@ -4,31 +4,29 @@
 //! The logic in this submodule should belong to the `solana-zk-token-sdk` and
 //! will be removed with an upgrade to the Solana program.
 
-use {
-    curve25519_dalek::scalar::Scalar,
-    spl_token_2022::{
-        error::TokenError,
-        extension::confidential_transfer::{
-            ciphertext_extraction::{transfer_amount_source_ciphertext, SourceDecryptHandles},
-            processor::verify_and_split_deposit_amount,
+use spl_token_2022::{
+    error::TokenError,
+    extension::confidential_transfer::{
+        ciphertext_extraction::{transfer_amount_source_ciphertext, SourceDecryptHandles},
+        processor::verify_and_split_deposit_amount,
+    },
+    solana_zk_token_sdk::{
+        curve25519_dalek::scalar::Scalar,
+        encryption::{
+            auth_encryption::{AeCiphertext, AeKey},
+            elgamal::{DecryptHandle, ElGamalCiphertext, ElGamalKeypair, ElGamalPubkey},
+            grouped_elgamal::GroupedElGamal,
+            pedersen::{Pedersen, PedersenCommitment, PedersenOpening},
         },
-        solana_zk_token_sdk::{
-            encryption::{
-                auth_encryption::{AeCiphertext, AeKey},
-                elgamal::{DecryptHandle, ElGamalCiphertext, ElGamalKeypair, ElGamalPubkey},
-                grouped_elgamal::GroupedElGamal,
-                pedersen::{Pedersen, PedersenCommitment, PedersenOpening},
+        instruction::{
+            transfer::{
+                combine_lo_hi_commitments, combine_lo_hi_openings, FeeEncryption, FeeParameters,
+                TransferAmountCiphertext,
             },
-            instruction::{
-                transfer::{
-                    combine_lo_hi_commitments, combine_lo_hi_openings, FeeEncryption,
-                    FeeParameters, TransferAmountCiphertext,
-                },
-                BatchedGroupedCiphertext2HandlesValidityProofData, BatchedRangeProofU256Data,
-                CiphertextCommitmentEqualityProofData, FeeSigmaProofData,
-            },
-            zk_token_elgamal::ops::subtract_with_lo_hi,
+            BatchedGroupedCiphertext2HandlesValidityProofData, BatchedRangeProofU256Data,
+            CiphertextCommitmentEqualityProofData, FeeSigmaProofData,
         },
+        zk_token_elgamal::ops::subtract_with_lo_hi,
     },
 };
 


### PR DESCRIPTION
Decouples `spl-token-client` crate from an explicit version for `curve25519-dalek` by using the re-exported module from `solana-zk-token-sdk`.

Related to https://github.com/anza-xyz/agave/pull/1657 and https://github.com/anza-xyz/agave/pull/513

@samkim-crypto 