### PR TITLE
stake-pool-cli: Add metaplex program to setup script

### DIFF
--- a/stake-pool/cli/scripts/setup-stake-pool.sh
+++ b/stake-pool/cli/scripts/setup-stake-pool.sh
@@ -71,7 +71,16 @@ $spl_stake_pool \
   --reserve-keypair "$reserve_keyfile"
 
 set +ex
-echo "Depositing SOL into stake pool"
 stake_pool_pubkey=$(solana-keygen pubkey "$stake_pool_keyfile")
 set -ex
+
+echo "Creating token metadata"
+$spl_stake_pool \
+  create-token-metadata \
+  "$stake_pool_pubkey" \
+  NAME \
+  SYMBOL \
+  URI
+
+echo "Depositing SOL into stake pool"
 $spl_stake_pool deposit-sol "$stake_pool_pubkey" "$sol_amount"

--- a/stake-pool/cli/scripts/setup-test-validator.sh
+++ b/stake-pool/cli/scripts/setup-test-validator.sh
@@ -16,14 +16,23 @@ create_keypair () {
 }
 
 setup_test_validator() {
-  solana-test-validator -c SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy -c EmiU8AQkB2sswTxVB6aCmsAJftoowZGGDXuytm6X65R3 --url devnet --slots-per-epoch 32 --quiet --reset &
+  solana-test-validator \
+    --clone-upgradeable-program SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy \
+    --clone-upgradeable-program metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s \
+    --url mainnet-beta \
+    --slots-per-epoch 32 \
+    --quiet --reset &
   # Uncomment to use a locally built stake program
-  #solana-test-validator --bpf-program SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy ../../../target/deploy/spl_stake_pool.so --slots-per-epoch 32 --quiet --reset &
+  #solana-test-validator \
+  #  --bpf-program SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy ../../../target/deploy/spl_stake_pool.so \
+  #  --bpf-program metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s ../../program/tests/fixtures/mpl_token_metadata.so \
+  #  --slots-per-epoch 32 \
+  #  --quiet --reset &
   pid=$!
   solana config set --url http://127.0.0.1:8899
   solana config set --commitment confirmed
   echo "waiting for solana-test-validator, pid: $pid"
-  sleep 5
+  sleep 15
 }
 
 create_vote_accounts () {


### PR DESCRIPTION
#### Problem

Some of the stake pool setup scripts are out of date -- they don't use token-metadata, and they don't clone programs properly.

#### Solution

Update the script to add token metadata and to clone the MPL token metadata program.