### PR TITLE
token-2022: [L-05] Use Pubkey's `==` instead of `sol_memcmp`

### DIFF
--- a/token/program-2022/src/lib.rs
+++ b/token/program-2022/src/lib.rs
@@ -25,11 +25,7 @@ mod entrypoint;
 // Export current sdk types for downstream users building with a different sdk
 // version
 use solana_program::{
-    entrypoint::ProgramResult,
-    program_error::ProgramError,
-    program_memory::sol_memcmp,
-    pubkey::{Pubkey, PUBKEY_BYTES},
-    system_program,
+    entrypoint::ProgramResult, program_error::ProgramError, pubkey::Pubkey, system_program,
 };
 pub use {solana_program, solana_zk_token_sdk};
 
@@ -131,10 +127,4 @@ pub fn check_system_program_account(system_program_id: &Pubkey) -> ProgramResult
         return Err(ProgramError::IncorrectProgramId);
     }
     Ok(())
-}
-
-/// Checks two pubkeys for equality in a computationally cheap way using
-/// `sol_memcmp`
-pub fn cmp_pubkeys(a: &Pubkey, b: &Pubkey) -> bool {
-    sol_memcmp(a.as_ref(), b.as_ref(), PUBKEY_BYTES) == 0
 }

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -2,7 +2,7 @@
 
 use {
     crate::{
-        check_program_account, cmp_pubkeys,
+        check_program_account,
         error::TokenError,
         extension::{
             confidential_transfer::{self, ConfidentialTransferAccount, ConfidentialTransferMint},
@@ -192,7 +192,7 @@ impl Processor {
         account.base.delegate = PodCOption::none();
         account.base.delegated_amount = 0.into();
         account.base.state = starting_state.into();
-        if cmp_pubkeys(mint_info.key, &native_mint::id()) {
+        if mint_info.key == &native_mint::id() {
             let rent_exempt_reserve = rent.minimum_balance(new_account_info_data_len);
             account.base.is_native = PodCOption::some(rent_exempt_reserve.into());
             account.base.amount = new_account_info
@@ -321,7 +321,7 @@ impl Processor {
         }
         let (fee, maybe_permanent_delegate, maybe_transfer_hook_program_id) =
             if let Some((mint_info, expected_decimals)) = expected_mint_info {
-                if !cmp_pubkeys(&source_account.base.mint, mint_info.key) {
+                if &source_account.base.mint != mint_info.key {
                     return Err(TokenError::MintMismatch.into());
                 }
 
@@ -377,24 +377,22 @@ impl Processor {
             }
         }
 
-        let self_transfer = cmp_pubkeys(source_account_info.key, destination_account_info.key);
+        let self_transfer = source_account_info.key == destination_account_info.key;
         match (source_account.base.delegate, maybe_permanent_delegate) {
-            (_, Some(ref delegate)) if cmp_pubkeys(authority_info.key, delegate) => {
-                Self::validate_owner(
-                    program_id,
-                    delegate,
-                    authority_info,
-                    authority_info_data_len,
-                    account_info_iter.as_slice(),
-                )?
-            }
+            (_, Some(ref delegate)) if authority_info.key == delegate => Self::validate_owner(
+                program_id,
+                delegate,
+                authority_info,
+                authority_info_data_len,
+                account_info_iter.as_slice(),
+            )?,
             (
                 PodCOption {
                     option: PodCOption::<Pubkey>::SOME,
                     value: delegate,
                 },
                 _,
-            ) if cmp_pubkeys(authority_info.key, &delegate) => {
+            ) if authority_info.key == &delegate => {
                 Self::validate_owner(
                     program_id,
                     &delegate,
@@ -462,7 +460,7 @@ impl Processor {
         if destination_account.base.is_frozen() {
             return Err(TokenError::AccountFrozen.into());
         }
-        if !cmp_pubkeys(&source_account.base.mint, &destination_account.base.mint) {
+        if source_account.base.mint != destination_account.base.mint {
             return Err(TokenError::MintMismatch.into());
         }
 
@@ -570,7 +568,7 @@ impl Processor {
         }
 
         if let Some((mint_info, expected_decimals)) = expected_mint_info {
-            if !cmp_pubkeys(&source_account.base.mint, mint_info.key) {
+            if &source_account.base.mint != mint_info.key {
                 return Err(TokenError::MintMismatch.into());
             }
 
@@ -621,7 +619,7 @@ impl Processor {
                 PodCOption {
                     option: PodCOption::<Pubkey>::SOME,
                     value: delegate,
-                } if cmp_pubkeys(authority_info.key, delegate) => delegate,
+                } if authority_info.key == delegate => delegate,
                 _ => &source_account.base.owner,
             },
             authority_info,
@@ -936,7 +934,7 @@ impl Processor {
         if destination_account.base.is_native() {
             return Err(TokenError::NativeNotSupported.into());
         }
-        if !cmp_pubkeys(mint_info.key, &destination_account.base.mint) {
+        if mint_info.key != &destination_account.base.mint {
             return Err(TokenError::MintMismatch.into());
         }
 
@@ -1037,22 +1035,20 @@ impl Processor {
             .is_owned_by_system_program_or_incinerator()
         {
             match (&source_account.base.delegate, maybe_permanent_delegate) {
-                (_, Some(ref delegate)) if cmp_pubkeys(authority_info.key, delegate) => {
-                    Self::validate_owner(
-                        program_id,
-                        delegate,
-                        authority_info,
-                        authority_info_data_len,
-                        account_info_iter.as_slice(),
-                    )?
-                }
+                (_, Some(ref delegate)) if authority_info.key == delegate => Self::validate_owner(
+                    program_id,
+                    delegate,
+                    authority_info,
+                    authority_info_data_len,
+                    account_info_iter.as_slice(),
+                )?,
                 (
                     PodCOption {
                         option: PodCOption::<Pubkey>::SOME,
                         value: delegate,
                     },
                     _,
-                ) if cmp_pubkeys(authority_info.key, delegate) => {
+                ) if authority_info.key == delegate => {
                     Self::validate_owner(
                         program_id,
                         delegate,
@@ -1117,7 +1113,7 @@ impl Processor {
         let authority_info = next_account_info(account_info_iter)?;
         let authority_info_data_len = authority_info.data_len();
 
-        if cmp_pubkeys(source_account_info.key, destination_account_info.key) {
+        if source_account_info.key == destination_account_info.key {
             return Err(ProgramError::InvalidAccountData);
         }
 
@@ -1141,7 +1137,7 @@ impl Processor {
                 if let Ok(cpi_guard) = source_account.get_extension::<CpiGuard>() {
                     if cpi_guard.lock_cpi.into()
                         && in_cpi()
-                        && !cmp_pubkeys(destination_account_info.key, &source_account.base.owner)
+                        && destination_account_info.key != &source_account.base.owner
                     {
                         return Err(TokenError::CpiGuardCloseAccountBlocked.into());
                     }
@@ -1227,7 +1223,7 @@ impl Processor {
         if source_account.base.is_native() {
             return Err(TokenError::NativeNotSupported.into());
         }
-        if !cmp_pubkeys(mint_info.key, &source_account.base.mint) {
+        if mint_info.key != &source_account.base.mint {
             return Err(TokenError::MintMismatch.into());
         }
 
@@ -1805,12 +1801,11 @@ impl Processor {
         owner_account_data_len: usize,
         signers: &[AccountInfo],
     ) -> ProgramResult {
-        if !cmp_pubkeys(expected_owner, owner_account_info.key) {
+        if expected_owner != owner_account_info.key {
             return Err(TokenError::OwnerMismatch.into());
         }
 
-        if cmp_pubkeys(program_id, owner_account_info.owner)
-            && owner_account_data_len == PodMultisig::SIZE_OF
+        if program_id == owner_account_info.owner && owner_account_data_len == PodMultisig::SIZE_OF
         {
             let multisig_data = &owner_account_info.data.borrow();
             let multisig = pod_from_bytes::<PodMultisig>(multisig_data)?;
@@ -1818,7 +1813,7 @@ impl Processor {
             let mut matched = [false; MAX_SIGNERS];
             for signer in signers.iter() {
                 for (position, key) in multisig.signers[0..multisig.n as usize].iter().enumerate() {
-                    if cmp_pubkeys(key, signer.key) && !matched[position] {
+                    if key == signer.key && !matched[position] {
                         if !signer.is_signer {
                             return Err(ProgramError::MissingRequiredSignature);
                         }

--- a/token/program-2022/tests/assert_instruction_count.rs
+++ b/token/program-2022/tests/assert_instruction_count.rs
@@ -22,7 +22,7 @@ const TRANSFER_AMOUNT: u64 = 1_000_000_000_000_000;
 #[tokio::test]
 async fn initialize_mint() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
-    pt.set_compute_max_units(5_000); // last known 1378
+    pt.set_compute_max_units(5_000); // last known 1401
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner_key = Pubkey::new_unique();
@@ -60,7 +60,7 @@ async fn initialize_mint() {
 #[tokio::test]
 async fn initialize_account() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
-    pt.set_compute_max_units(8_000); // last known 1783
+    pt.set_compute_max_units(8_000); // last known 1643
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();
@@ -112,7 +112,7 @@ async fn initialize_account() {
 #[tokio::test]
 async fn mint_to() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
-    pt.set_compute_max_units(8_000); // last known 1115
+    pt.set_compute_max_units(8_000); // last known 996
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();
@@ -161,7 +161,7 @@ async fn mint_to() {
 #[tokio::test]
 async fn transfer() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
-    pt.set_compute_max_units(8_000); // last known 1502
+    pt.set_compute_max_units(8_000); // last known 1263
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();
@@ -229,7 +229,7 @@ async fn transfer() {
 #[tokio::test]
 async fn transfer_checked() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
-    pt.set_compute_max_units(8_000); // last known 1849
+    pt.set_compute_max_units(8_000); // last known 1557
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();
@@ -299,7 +299,7 @@ async fn transfer_checked() {
 #[tokio::test]
 async fn burn() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
-    pt.set_compute_max_units(8_000); // last known 1226
+    pt.set_compute_max_units(8_000); // last known 1097
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();
@@ -356,7 +356,7 @@ async fn burn() {
 #[tokio::test]
 async fn close_account() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
-    pt.set_compute_max_units(8_000); // last known 1315
+    pt.set_compute_max_units(8_000); // last known 1149
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();

--- a/token/program-2022/tests/assert_instruction_count.rs
+++ b/token/program-2022/tests/assert_instruction_count.rs
@@ -60,7 +60,7 @@ async fn initialize_mint() {
 #[tokio::test]
 async fn initialize_account() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
-    pt.set_compute_max_units(8_000); // last known 1643
+    pt.set_compute_max_units(8_000); // last known 1620
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();
@@ -112,7 +112,7 @@ async fn initialize_account() {
 #[tokio::test]
 async fn mint_to() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
-    pt.set_compute_max_units(8_000); // last known 996
+    pt.set_compute_max_units(8_000); // last known 967
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();
@@ -161,7 +161,7 @@ async fn mint_to() {
 #[tokio::test]
 async fn transfer() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
-    pt.set_compute_max_units(8_000); // last known 1263
+    pt.set_compute_max_units(8_000); // last known 1222
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();
@@ -229,7 +229,7 @@ async fn transfer() {
 #[tokio::test]
 async fn transfer_checked() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
-    pt.set_compute_max_units(8_000); // last known 1557
+    pt.set_compute_max_units(8_000); // last known 1516
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();
@@ -299,7 +299,7 @@ async fn transfer_checked() {
 #[tokio::test]
 async fn burn() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
-    pt.set_compute_max_units(8_000); // last known 1097
+    pt.set_compute_max_units(8_000); // last known 1070
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();
@@ -356,7 +356,7 @@ async fn burn() {
 #[tokio::test]
 async fn close_account() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
-    pt.set_compute_max_units(8_000); // last known 1149
+    pt.set_compute_max_units(8_000); // last known 1111
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();


### PR DESCRIPTION
#### Problem

From the Certora audit report, there's mixed use of `==` and `sol_memcmp` for public keys. This was done because the syscall was cheaper for a time, but is no longer the case.

#### Solution

The first commit updates the instruction counts for current master, and then the second commit makes the change and updates with the new instruction counts -- everything is reduced!