### PR TITLE
token-2022: [L-04] Comment that TransferCheckedWithFee works for all mints

### DIFF
--- a/token/program-2022/src/extension/transfer_fee/instruction.rs
+++ b/token/program-2022/src/extension/transfer_fee/instruction.rs
@@ -50,14 +50,18 @@ pub enum TransferFeeInstruction {
     },
     /// Transfer, providing expected mint information and fees
     ///
+    /// This instruction succeeds if the mint has no configured transfer fee
+    /// and the provided fee is 0. This allows applications to use
+    /// `TransferCheckedWithFee` with any mint.
+    ///
     /// Accounts expected by this instruction:
     ///
     ///   * Single owner/delegate
-    ///   0. `[writable]` The source account. Must include the
+    ///   0. `[writable]` The source account. May include the
     ///      `TransferFeeAmount` extension.
-    ///   1. `[]` The token mint. Must include the `TransferFeeConfig`
+    ///   1. `[]` The token mint. May include the `TransferFeeConfig`
     ///      extension.
-    ///   2. `[writable]` The destination account. Must include the
+    ///   2. `[writable]` The destination account. May include the
     ///      `TransferFeeAmount` extension.
     ///   3. `[signer]` The source account's owner/delegate.
     ///
@@ -73,8 +77,8 @@ pub enum TransferFeeInstruction {
         /// Expected number of base 10 digits to the right of the decimal place.
         decimals: u8,
         /// Expected fee assessed on this transfer, calculated off-chain based
-        /// on the transfer_fee_basis_points and maximum_fee of the
-        /// mint.
+        /// on the transfer_fee_basis_points and maximum_fee of the mint. May
+        /// be 0 for a mint without a configured transfer fee.
         fee: u64,
     },
     /// Transfer all withheld tokens in the mint to an account. Signed by the

--- a/token/program-2022/src/extension/transfer_fee/instruction.rs
+++ b/token/program-2022/src/extension/transfer_fee/instruction.rs
@@ -59,8 +59,7 @@ pub enum TransferFeeInstruction {
     ///   * Single owner/delegate
     ///   0. `[writable]` The source account. May include the
     ///      `TransferFeeAmount` extension.
-    ///   1. `[]` The token mint. May include the `TransferFeeConfig`
-    ///      extension.
+    ///   1. `[]` The token mint. May include the `TransferFeeConfig` extension.
     ///   2. `[writable]` The destination account. May include the
     ///      `TransferFeeAmount` extension.
     ///   3. `[signer]` The source account's owner/delegate.


### PR DESCRIPTION
#### Problem

According to the Certora audit:

> A TransferCheckedWithFee succeeds even if the mint account is not extended with TransferFeeConfig if the instruction argument expected_fees is zero. This makes TransferChecked redundant since it can always be replaced by TransferCheckedWithFee.

> Recommendation: 
> Either not allow TransferCheckedWithFee to succeed when fees are not enabled, or document that this is an expected and allowed behavior. 

#### Solution

Comment that it is intended for TransferCheckedWithFee to work with any mint.