### PR TITLE
token-2022: [L-02] Check for non-transferable extension consistently

### DIFF
--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -3,7 +3,7 @@
 use crate::extension::transfer_hook;
 #[cfg(feature = "zk-ops")]
 use {
-    crate::extension::non_transferable::NonTransferable,
+    crate::extension::non_transferable::NonTransferableAccount,
     solana_zk_token_sdk::zk_token_elgamal::ops as syscall,
 };
 use {
@@ -269,13 +269,15 @@ fn process_deposit(
         return Err(TokenError::MintDecimalsMismatch.into());
     }
 
-    if mint.get_extension::<NonTransferable>().is_ok() {
-        return Err(TokenError::NonTransferable.into());
-    }
-
     check_program_account(token_account_info.owner)?;
     let token_account_data = &mut token_account_info.data.borrow_mut();
     let mut token_account = PodStateWithExtensionsMut::<PodAccount>::unpack(token_account_data)?;
+    if token_account
+        .get_extension::<NonTransferableAccount>()
+        .is_ok()
+    {
+        return Err(TokenError::NonTransferable.into());
+    }
 
     Processor::validate_owner(
         program_id,
@@ -367,13 +369,15 @@ fn process_withdraw(
         return Err(TokenError::MintDecimalsMismatch.into());
     }
 
-    if mint.get_extension::<NonTransferable>().is_ok() {
-        return Err(TokenError::NonTransferable.into());
-    }
-
     check_program_account(token_account_info.owner)?;
     let token_account_data = &mut token_account_info.data.borrow_mut();
     let mut token_account = PodStateWithExtensionsMut::<PodAccount>::unpack(token_account_data)?;
+    if token_account
+        .get_extension::<NonTransferableAccount>()
+        .is_ok()
+    {
+        return Err(TokenError::NonTransferable.into());
+    }
 
     Processor::validate_owner(
         program_id,
@@ -450,9 +454,6 @@ fn process_transfer(
     let mint_data = mint_info.data.borrow_mut();
     let mint = PodStateWithExtensions::<PodMint>::unpack(&mint_data)?;
 
-    if mint.get_extension::<NonTransferable>().is_ok() {
-        return Err(TokenError::NonTransferable.into());
-    }
     let confidential_transfer_mint = mint.get_extension::<ConfidentialTransferMint>()?;
 
     // A `Transfer` instruction must be accompanied by a zero-knowledge proof
@@ -677,6 +678,12 @@ fn process_source_for_transfer(
     let authority_info_data_len = authority_info.data_len();
     let token_account_data = &mut source_account_info.data.borrow_mut();
     let mut token_account = PodStateWithExtensionsMut::<PodAccount>::unpack(token_account_data)?;
+    if token_account
+        .get_extension::<NonTransferableAccount>()
+        .is_ok()
+    {
+        return Err(TokenError::NonTransferable.into());
+    }
 
     Processor::validate_owner(
         program_id,
@@ -803,6 +810,12 @@ fn process_source_for_transfer_with_fee(
     let authority_info_data_len = authority_info.data_len();
     let token_account_data = &mut source_account_info.data.borrow_mut();
     let mut token_account = PodStateWithExtensionsMut::<PodAccount>::unpack(token_account_data)?;
+    if token_account
+        .get_extension::<NonTransferableAccount>()
+        .is_ok()
+    {
+        return Err(TokenError::NonTransferable.into());
+    }
 
     Processor::validate_owner(
         program_id,


### PR DESCRIPTION
#### Problem

According to the Certora audit findings:

> Description: Regular instructions (Transfer, TransferChecked, and TransferCheckedWithFee) determine that an account is non-transferable by checking for presence of NonTransferableAccount extension in the source account. ConfidentialTransferInstruction::Transfer, instead, checks that the mint has the NonTransferable mint extension.

> Recommendation: This is not an issue at the moment because every account of NonTransferable mint has a NonTransferableAccount extension. We recommend that all instructions use NonTransferableAccount to make the code more uniform and to prevent any deviation in the future should the invariant no longer be maintained.

#### Solution

We have to use the account check for the extension in non-confidential transfers, since the mint might not always be present, so switch to checking the extension on the account in confidential transfers too.