### PR TITLE
token-2022: [I-01] Assert that a transfer fee always includes mint decimals

### DIFF
--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -296,6 +296,9 @@ impl Processor {
         let expected_mint_info = if let Some(expected_decimals) = expected_decimals {
             Some((next_account_info(account_info_iter)?, expected_decimals))
         } else {
+            // Transfer must not be called with an expected fee but no mint,
+            // otherwise it's a programmer error.
+            assert!(expected_fee.is_none());
             None
         };
 


### PR DESCRIPTION
#### Problem

According to the Certora audit findings:

> Description: The function process_transfer in token-2022/src/processor.rs is used to implement Transfer, TransferChecked, and TransferCheckedWithFee. However, it also succeeds when called with a fee and no mint. 

> Recommendation: Return an error if the function is called with the last two arguments being None and Some.

#### Solution

It's really a programmer error if we call `process_transfer` with an expected fee, but no mint decimals, so be more bold and assert that there's never an expected fee if there's no mint decimals.