### PR TITLE
token-2022: [L-03] Require memo on self-transfer with memo-transfer

### DIFF
--- a/token/program-2022-test/tests/memo_transfer.rs
+++ b/token/program-2022-test/tests/memo_transfer.rs
@@ -75,6 +75,23 @@ async fn test_memo_transfers(
     let bob_state = token.get_account_info(&bob_account).await.unwrap();
     assert_eq!(bob_state.base.amount, 0);
 
+    // attempt to transfer from bob to bob without memo
+    let err = token
+        .transfer(&bob_account, &bob_account, &bob.pubkey(), 0, &[&bob])
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::NoMemo as u32)
+            )
+        )))
+    );
+    let bob_state = token.get_account_info(&bob_account).await.unwrap();
+    assert_eq!(bob_state.base.amount, 0);
+
     // attempt to transfer from alice to bob with misplaced memo, v1 and current
     let mut memo_ix = spl_memo::build_memo(&[240, 159, 166, 150], &[]);
     for program_id in [spl_memo::id(), spl_memo::v1::id()] {

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -451,6 +451,9 @@ impl Processor {
         // This check MUST occur just before the amounts are manipulated
         // to ensure self-transfers are fully validated
         if self_transfer {
+            if memo_required(&source_account) {
+                check_previous_sibling_instruction_is_memo()?;
+            }
             return Ok(());
         }
 


### PR DESCRIPTION
#### Problem

According to the Certora audit report:

> Description: In regular instructions (Transfer, TransferChecked, and TransferCheckedWithFee)  a self-transfer does not require a memo even if the destination is extended with MemoTransfer while in ConfidentialTransferInstruction::Transfer, self-transfer always does. 

> Recommendation: Make regular and confidential instructions behave uniformly with respect to MemoTransfer.

#### Solution

The opposite of #6861: require a memo for non-confidential self-transfers