### PR TITLE
audit: Add curve25519-dalek RUSTSEC to ignore list

### DIFF
--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -30,5 +30,10 @@ cargo_audit_ignores=(
   #
   # Remove once SPL upgrades to Solana v1.17 or greater
   --ignore RUSTSEC-2023-0065
+
+  # curve25519-dalek
+  #
+  # Remove once SPL upgrades to curve25519-dalek v4
+  --ignore RUSTSEC-2024-0344
 )
 cargo +"$rust_stable" audit "${cargo_audit_ignores[@]}"


### PR DESCRIPTION
#### Problem

Just like https://github.com/anza-xyz/agave/pull/1786, SPL is failing the audit check in CI.

#### Solution

Until we can upgrade to curve25519-dalek v4, ignore it