### PR TITLE
token: Update to v5 for solana-program 2.0 compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,7 +652,7 @@ dependencies = [
  "arrayref",
  "borsh 1.5.1",
  "solana-program",
- "spl-token 4.0.1",
+ "spl-token 5.0.0",
  "thiserror",
  "uint",
 ]
@@ -1972,7 +1972,7 @@ version = "1.0.0"
 dependencies = [
  "arrayref",
  "solana-program",
- "spl-token 4.0.1",
+ "spl-token 5.0.0",
 ]
 
 [[package]]
@@ -6873,7 +6873,7 @@ dependencies = [
  "num-derive 0.4.2",
  "num-traits",
  "solana-program",
- "spl-token 4.0.1",
+ "spl-token 5.0.0",
  "spl-token-2022 3.0.2",
  "thiserror",
 ]
@@ -6886,7 +6886,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-associated-token-account 3.0.2",
- "spl-token 4.0.1",
+ "spl-token 5.0.0",
  "spl-token-2022 3.0.2",
 ]
 
@@ -6900,7 +6900,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-token 4.0.1",
+ "spl-token 5.0.0",
  "thiserror",
  "uint",
 ]
@@ -7035,7 +7035,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-token 4.0.1",
+ "spl-token 5.0.0",
 ]
 
 [[package]]
@@ -7046,7 +7046,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-token 4.0.1",
+ "spl-token 5.0.0",
 ]
 
 [[package]]
@@ -7084,7 +7084,7 @@ dependencies = [
  "spl-governance-addin-mock",
  "spl-governance-test-sdk",
  "spl-governance-tools",
- "spl-token 4.0.1",
+ "spl-token 5.0.0",
  "thiserror",
 ]
 
@@ -7116,7 +7116,7 @@ dependencies = [
  "spl-governance-addin-api",
  "spl-governance-test-sdk",
  "spl-governance-tools",
- "spl-token 4.0.1",
+ "spl-token 5.0.0",
  "thiserror",
 ]
 
@@ -7141,7 +7141,7 @@ dependencies = [
  "spl-governance-addin-mock",
  "spl-governance-test-sdk",
  "spl-governance-tools",
- "spl-token 4.0.1",
+ "spl-token 5.0.0",
  "thiserror",
 ]
 
@@ -7160,7 +7160,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-token 4.0.1",
+ "spl-token 5.0.0",
  "thiserror",
 ]
 
@@ -7176,7 +7176,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-program",
- "spl-token 4.0.1",
+ "spl-token 5.0.0",
  "thiserror",
 ]
 
@@ -7200,7 +7200,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-associated-token-account 3.0.2",
- "spl-token 4.0.1",
+ "spl-token 5.0.0",
  "thiserror",
 ]
 
@@ -7377,7 +7377,7 @@ dependencies = [
  "solana-security-txt",
  "solana-vote-program",
  "spl-associated-token-account 3.0.2",
- "spl-token 4.0.1",
+ "spl-token 5.0.0",
  "test-case",
  "thiserror",
 ]
@@ -7408,7 +7408,7 @@ dependencies = [
  "solana-vote-program",
  "spl-associated-token-account 3.0.2",
  "spl-single-pool",
- "spl-token 4.0.1",
+ "spl-token 5.0.0",
  "spl-token-client",
  "tempfile",
  "test-case",
@@ -7437,7 +7437,7 @@ dependencies = [
  "solana-vote-program",
  "spl-math",
  "spl-pod 0.2.2",
- "spl-token 4.0.1",
+ "spl-token 5.0.0",
  "spl-token-2022 3.0.2",
  "test-case",
  "thiserror",
@@ -7465,7 +7465,7 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account 3.0.2",
  "spl-stake-pool",
- "spl-token 4.0.1",
+ "spl-token 5.0.0",
 ]
 
 [[package]]
@@ -7517,7 +7517,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token"
-version = "4.0.1"
+version = "5.0.0"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -7581,7 +7581,7 @@ dependencies = [
  "spl-memo 4.0.1",
  "spl-pod 0.2.2",
  "spl-tlv-account-resolution 0.6.3",
- "spl-token 4.0.1",
+ "spl-token 5.0.0",
  "spl-token-group-interface 0.2.3",
  "spl-token-metadata-interface 0.3.3",
  "spl-transfer-hook-interface 0.6.3",
@@ -7640,7 +7640,7 @@ dependencies = [
  "solana-transaction-status",
  "spl-associated-token-account 3.0.2",
  "spl-memo 4.0.1",
- "spl-token 4.0.1",
+ "spl-token 5.0.0",
  "spl-token-2022 3.0.2",
  "spl-token-client",
  "spl-token-group-interface 0.2.3",
@@ -7668,7 +7668,7 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account 3.0.2",
  "spl-memo 4.0.1",
- "spl-token 4.0.1",
+ "spl-token 5.0.0",
  "spl-token-2022 3.0.2",
  "spl-token-group-interface 0.2.3",
  "spl-token-metadata-interface 0.3.3",
@@ -7748,7 +7748,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-token 4.0.1",
+ "spl-token 5.0.0",
  "thiserror",
  "uint",
 ]
@@ -7764,7 +7764,7 @@ dependencies = [
  "solana-logger",
  "solana-program",
  "solana-sdk",
- "spl-token 4.0.1",
+ "spl-token 5.0.0",
  "spl-token-lending",
 ]
 
@@ -7825,7 +7825,7 @@ dependencies = [
  "solana-program",
  "solana-sdk",
  "spl-math",
- "spl-token 4.0.1",
+ "spl-token 5.0.0",
  "spl-token-2022 3.0.2",
  "test-case",
  "thiserror",
@@ -7839,7 +7839,7 @@ dependencies = [
  "honggfuzz",
  "solana-program",
  "spl-math",
- "spl-token 4.0.1",
+ "spl-token 5.0.0",
  "spl-token-swap",
 ]
 
@@ -7853,7 +7853,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-token 4.0.1",
+ "spl-token 5.0.0",
  "spl-token-2022 3.0.2",
  "spl-token-client",
  "test-case",
@@ -7874,7 +7874,7 @@ dependencies = [
  "solana-sdk",
  "solana-test-validator",
  "spl-associated-token-account 3.0.2",
- "spl-token 4.0.1",
+ "spl-token 5.0.0",
  "spl-token-2022 3.0.2",
  "spl-token-client",
  "spl-token-upgrade",
@@ -7890,7 +7890,7 @@ dependencies = [
  "num_enum 0.7.2",
  "solana-program",
  "spl-associated-token-account 3.0.2",
- "spl-token 4.0.1",
+ "spl-token 5.0.0",
  "spl-token-2022 3.0.2",
  "thiserror",
 ]
@@ -8019,7 +8019,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-associated-token-account 3.0.2",
- "spl-token 4.0.1",
+ "spl-token 5.0.0",
  "thiserror",
 ]
 
@@ -8315,7 +8315,7 @@ version = "0.1.0"
 dependencies = [
  "solana-sdk",
  "spl-memo 4.0.1",
- "spl-token 4.0.1",
+ "spl-token 5.0.0",
  "spl-token-swap",
 ]
 

--- a/associated-token-account/program-test/Cargo.toml
+++ b/associated-token-account/program-test/Cargo.toml
@@ -15,5 +15,5 @@ solana-program = ">=1.18.11,<=2"
 solana-program-test = ">=1.18.11,<=2"
 solana-sdk = ">=1.18.11,<=2"
 spl-associated-token-account = { version = "3.0.2", path = "../program", features = ["no-entrypoint"] }
-spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
+spl-token = { version = "5.0", path = "../../token/program", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = ["no-entrypoint"] }

--- a/associated-token-account/program/Cargo.toml
+++ b/associated-token-account/program/Cargo.toml
@@ -17,7 +17,7 @@ borsh = "1.5.1"
 num-derive = "0.4"
 num-traits = "0.2"
 solana-program = ">=1.18.11,<=2"
-spl-token = { version = "4.0", path = "../../token/program", features = [
+spl-token = { version = "5.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
 spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = [

--- a/binary-option/program/Cargo.toml
+++ b/binary-option/program/Cargo.toml
@@ -11,7 +11,7 @@ test-sbf = []
 [dependencies]
 solana-program = ">=1.18.11,<=2"
 thiserror = "1.0"
-spl-token = { version = "4.0", path = "../../token/program", features = [
+spl-token = { version = "5.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
 arrayref = "0.3.7"

--- a/binary-oracle-pair/program/Cargo.toml
+++ b/binary-oracle-pair/program/Cargo.toml
@@ -14,7 +14,7 @@ test-sbf = []
 num-derive = "0.4"
 num-traits = "0.2"
 solana-program = ">=1.18.11,<=2"
-spl-token = { version = "4.0", path = "../../token/program", features = [
+spl-token = { version = "5.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
 thiserror = "1.0"

--- a/examples/rust/transfer-tokens/Cargo.toml
+++ b/examples/rust/transfer-tokens/Cargo.toml
@@ -13,7 +13,7 @@ test-sbf = []
 
 [dependencies]
 solana-program = ">=1.18.11,<=2"
-spl-token = { version = "4.0", path = "../../../token/program", features = [ "no-entrypoint" ] }
+spl-token = { version = "5.0", path = "../../../token/program", features = [ "no-entrypoint" ] }
 
 [dev-dependencies]
 solana-program-test = ">=1.18.11,<=2"

--- a/feature-proposal/program/Cargo.toml
+++ b/feature-proposal/program/Cargo.toml
@@ -14,7 +14,7 @@ test-sbf = []
 [dependencies]
 borsh = "1.5.1"
 solana-program = ">=1.18.11,<=2"
-spl-token = { version = "4.0", path = "../../token/program", features = [
+spl-token = { version = "5.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
 

--- a/governance/addin-mock/program/Cargo.toml
+++ b/governance/addin-mock/program/Cargo.toml
@@ -20,7 +20,7 @@ num-traits = "0.2"
 serde = "1.0.203"
 serde_derive = "1.0.103"
 solana-program = ">=1.18.11,<=2"
-spl-token = { version = "4.0", path = "../../../token/program", features = [
+spl-token = { version = "5.0", path = "../../../token/program", features = [
   "no-entrypoint",
 ] }
 spl-governance-addin-api = { version = "0.1.4", path = "../../addin-api" }

--- a/governance/chat/program/Cargo.toml
+++ b/governance/chat/program/Cargo.toml
@@ -20,7 +20,7 @@ num-traits = "0.2"
 serde = "1.0.203"
 serde_derive = "1.0.103"
 solana-program = ">=1.18.11,<=2"
-spl-token = { version = "4.0", path = "../../../token/program", features = [
+spl-token = { version = "5.0", path = "../../../token/program", features = [
   "no-entrypoint",
 ] }
 spl-governance = { version = "4.0.0", path = "../../program", features = [

--- a/governance/program/Cargo.toml
+++ b/governance/program/Cargo.toml
@@ -20,7 +20,7 @@ num-traits = "0.2"
 serde = "1.0.203"
 serde_derive = "1.0.103"
 solana-program = ">=1.18.11,<=2"
-spl-token = { version = "4.0", path = "../../token/program", features = [
+spl-token = { version = "5.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
 spl-governance-tools = { version = "0.1.4", path = "../tools" }

--- a/governance/test-sdk/Cargo.toml
+++ b/governance/test-sdk/Cargo.toml
@@ -19,7 +19,7 @@ serde_derive = "1.0.103"
 solana-program = ">=1.18.11,<=2"
 solana-program-test = ">=1.18.11,<=2"
 solana-sdk = ">=1.18.11,<=2"
-spl-token = { version = "4.0", path = "../../token/program", features = [
+spl-token = { version = "5.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
 thiserror = "1.0"

--- a/governance/tools/Cargo.toml
+++ b/governance/tools/Cargo.toml
@@ -16,7 +16,7 @@ num-traits = "0.2"
 serde = "1.0.203"
 serde_derive = "1.0.103"
 solana-program = ">=1.18.11,<=2"
-spl-token = { version = "4.0", path = "../../token/program", features = [
+spl-token = { version = "5.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
 thiserror = "1.0"

--- a/managed-token/program/Cargo.toml
+++ b/managed-token/program/Cargo.toml
@@ -28,7 +28,7 @@ solana-program = ">=1.18.11,<=2"
 spl-associated-token-account = { version = "3.0.2", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }
-spl-token = { version = "4.0", path = "../../token/program", features = [
+spl-token = { version = "5.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
 thiserror = "^1.0.61"

--- a/single-pool/cli/Cargo.toml
+++ b/single-pool/cli/Cargo.toml
@@ -27,7 +27,7 @@ solana-remote-wallet = ">=1.18.11,<=2"
 solana-sdk = ">=1.18.11,<=2"
 solana-transaction-status = ">=1.18.11,<=2"
 solana-vote-program = ">=1.18.11,<=2"
-spl-token = { version = "4.0", path = "../../token/program", features = [
+spl-token = { version = "5.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
 spl-token-client = { version = "0.10.0", path = "../../token/client" }

--- a/single-pool/program/Cargo.toml
+++ b/single-pool/program/Cargo.toml
@@ -19,7 +19,7 @@ num-traits = "0.2"
 num_enum = "0.7.2"
 solana-program = ">=1.18.11,<=2"
 solana-security-txt = "1.1.1"
-spl-token = { version = "4.0", path = "../../token/program", features = [
+spl-token = { version = "5.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
 spl-associated-token-account = { version = "3.0.2", path = "../../associated-token-account/program", features = [

--- a/stake-pool/cli/Cargo.toml
+++ b/stake-pool/cli/Cargo.toml
@@ -29,7 +29,7 @@ spl-associated-token-account = { version = "=3.0.2", path = "../../associated-to
 spl-stake-pool = { version = "=1.0.0", path = "../program", features = [
   "no-entrypoint",
 ] }
-spl-token = { version = "=4.0", path = "../../token/program", features = [
+spl-token = { version = "=5.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
 bs58 = "0.4.0"

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -40,7 +40,7 @@ proptest = "1.5"
 solana-program-test = ">=1.18.11,<=2"
 solana-sdk = ">=1.18.11,<=2"
 solana-vote-program = ">=1.18.11,<=2"
-spl-token = { version = "4.0", path = "../../token/program", features = [
+spl-token = { version = "5.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
 test-case = "3.3"

--- a/stateless-asks/program/Cargo.toml
+++ b/stateless-asks/program/Cargo.toml
@@ -13,7 +13,7 @@ test-sbf = []
 [dependencies]
 borsh = "1.5.1"
 solana-program = ">=1.18.11,<=2"
-spl-token = { version = "4.0", path = "../../token/program", features = [
+spl-token = { version = "5.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
 spl-associated-token-account = { version = "3.0.2", path = "../../associated-token-account/program", features = [

--- a/token-lending/cli/Cargo.toml
+++ b/token-lending/cli/Cargo.toml
@@ -17,7 +17,7 @@ solana-logger = ">=1.18.11,<=2"
 solana-sdk = ">=1.18.11,<=2"
 solana-program = ">=1.18.11,<=2"
 spl-token-lending = { version = "0.2", path="../program", features = [ "no-entrypoint" ] }
-spl-token = { version = "4.0", path="../../token/program", features = [ "no-entrypoint" ]  }
+spl-token = { version = "5.0", path="../../token/program", features = [ "no-entrypoint" ]  }
 
 [[bin]]
 name = "spl-token-lending"

--- a/token-lending/flash_loan_receiver/Cargo.toml
+++ b/token-lending/flash_loan_receiver/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 arrayref = "0.3.7"
 solana-program = ">=1.18.11,<=2"
-spl-token = { version = "4.0", path = "../../token/program", features=["no-entrypoint"] }
+spl-token = { version = "5.0", path = "../../token/program", features=["no-entrypoint"] }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/token-lending/program/Cargo.toml
+++ b/token-lending/program/Cargo.toml
@@ -17,7 +17,7 @@ bytemuck = "1.16.1"
 num-derive = "0.4"
 num-traits = "0.2"
 solana-program = ">=1.18.11,<=2"
-spl-token = { version = "4.0", path = "../../token/program", features = [ "no-entrypoint" ] }
+spl-token = { version = "5.0", path = "../../token/program", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 uint = "0.9"
 

--- a/token-swap/program/Cargo.toml
+++ b/token-swap/program/Cargo.toml
@@ -19,7 +19,7 @@ num-derive = "0.4"
 num-traits = "0.2"
 solana-program = ">=1.18.11,<=2"
 spl-math = { version = "0.2", path = "../../libraries/math", features = [ "no-entrypoint" ] }
-spl-token = { version = "4.0", path = "../../token/program", features = [ "no-entrypoint" ] }
+spl-token = { version = "5.0", path = "../../token/program", features = [ "no-entrypoint" ] }
 spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 arbitrary = { version = "1.3", features = ["derive"], optional = true }

--- a/token-swap/program/fuzz/Cargo.toml
+++ b/token-swap/program/fuzz/Cargo.toml
@@ -13,7 +13,7 @@ honggfuzz = { version = "0.5.56" }
 arbitrary = { version = "1.3", features = ["derive"] }
 solana-program = ">=1.18.11,<=2"
 spl-math = { version = "0.2", path = "../../../libraries/math", features = [ "no-entrypoint" ] }
-spl-token = { version = "4.0", path = "../../../token/program", features = [ "no-entrypoint" ] }
+spl-token = { version = "5.0", path = "../../../token/program", features = [ "no-entrypoint" ] }
 spl-token-swap = { path = "..", features = ["fuzz", "no-entrypoint"] }
 
 [[bin]]

--- a/token-upgrade/cli/Cargo.toml
+++ b/token-upgrade/cli/Cargo.toml
@@ -20,7 +20,7 @@ solana-logger = ">=1.18.11,<=2"
 solana-remote-wallet = ">=1.18.11,<=2"
 solana-sdk = ">=1.18.11,<=2"
 spl-associated-token-account = { version = "3.0.2", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
-spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
+spl-token = { version = "5.0", path = "../../token/program", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.10.0", path = "../../token/client" }
 spl-token-upgrade = { version = "0.1", path = "../program", features = ["no-entrypoint"] }

--- a/token-upgrade/program/Cargo.toml
+++ b/token-upgrade/program/Cargo.toml
@@ -22,7 +22,7 @@ thiserror = "1.0"
 [dev-dependencies]
 solana-program-test = ">=1.18.11,<=2"
 solana-sdk = ">=1.18.11,<=2"
-spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
+spl-token = { version = "5.0", path = "../../token/program", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.10.0", path = "../../token/client" }
 test-case = "3.3"
 

--- a/token-wrap/program/Cargo.toml
+++ b/token-wrap/program/Cargo.toml
@@ -16,7 +16,7 @@ bytemuck = { version = "1.16.1", features = ["derive"] }
 num_enum = "0.7"
 solana-program = ">=1.18.11,<=2"
 spl-associated-token-account = { version = "3.0.2", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
-spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
+spl-token = { version = "5.0", path = "../../token/program", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"
 

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -28,7 +28,7 @@ solana-logger = ">=1.18.11,<=2"
 solana-remote-wallet = ">=1.18.11,<=2"
 solana-sdk = ">=1.18.11,<=2"
 solana-transaction-status = ">=1.18.11,<=2"
-spl-token = { version = "4.0", path = "../program", features = [
+spl-token = { version = "5.0", path = "../program", features = [
   "no-entrypoint",
 ] }
 spl-token-2022 = { version = "3.0.2", path = "../program-2022", features = [

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -26,7 +26,7 @@ spl-associated-token-account = { version = "3.0.2", path = "../../associated-tok
 spl-memo = { version = "4.0", path = "../../memo/program", features = [
   "no-entrypoint",
 ] }
-spl-token = { version = "4.0", path = "../program", features = [
+spl-token = { version = "5.0", path = "../program", features = [
   "no-entrypoint",
 ] }
 spl-token-2022 = { version = "3.0.2", path = "../program-2022" }

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -30,7 +30,7 @@ solana-program = ">=1.18.11,<=2"
 solana-security-txt = "1.1.1"
 solana-zk-token-sdk = ">=1.18.11,<=2"
 spl-memo = { version = "4.0", path = "../../memo/program", features = [ "no-entrypoint" ] }
-spl-token = { version = "4.0",  path = "../program", features = ["no-entrypoint"] }
+spl-token = { version = "5.0",  path = "../program", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.2.3", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.3.3", path = "../../token-metadata/interface" }
 spl-transfer-hook-interface = { version = "0.6.3", path = "../transfer-hook/interface" }

--- a/token/program/Cargo.toml
+++ b/token/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token"
-version = "4.0.1"
+version = "5.0.0"
 description = "Solana Program Library Token"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"


### PR DESCRIPTION
#### Problem

As mentioned in #6897, updating to allow for version <= 2.0 of the solana crates can appear as a breaking change for new projects, since cargo pulls in the latest version of all dependencies, and once there's an attempt to mix v1 and v2, downstream users will see errors.

This is made worse that the patch versions will quietly pick up the v2 dependency, so if someone doesn't know how to manipulate a cargo lockfile, they will get build errors and won't know how to resolve them.

All other SPL crates contain a new breaking version (new major for crates on v1 or more, new minor for crates on v0.X), except for spl-token.

#### Solution

Bump spl-token to v5.