### PR TITLE
token-js: Bump to 0.4.7 for release

### DIFF
--- a/token/js/package.json
+++ b/token/js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@solana/spl-token",
     "description": "SPL Token Program JS API",
-    "version": "0.4.4",
+    "version": "0.4.7",
     "author": "Solana Labs Maintainers <maintainers@solanalabs.com>",
     "repository": "https://github.com/solana-labs/solana-program-library",
     "license": "Apache-2.0",


### PR DESCRIPTION
#### Problem

We haven't released token-js since `setTransferFee` was added, among other things.

#### Solution

Bump and release