### PR TITLE
discriminator: Bump to 0.3.0 for Solana v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6890,22 +6890,22 @@ dependencies = [
 [[package]]
 name = "spl-discriminator"
 version = "0.2.2"
-dependencies = [
- "borsh 1.5.1",
- "bytemuck",
- "solana-program",
- "spl-discriminator-derive 0.2.0",
-]
-
-[[package]]
-name = "spl-discriminator"
-version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34d1814406e98b08c5cd02c1126f83fd407ad084adce0b05fda5730677822eac"
 dependencies = [
  "bytemuck",
  "solana-program",
  "spl-discriminator-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "spl-discriminator"
+version = "0.3.0"
+dependencies = [
+ "borsh 1.5.1",
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator-derive 0.2.0",
 ]
 
 [[package]]
@@ -7449,7 +7449,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-discriminator 0.2.2",
+ "spl-discriminator 0.3.0",
  "spl-pod 0.2.2",
  "spl-program-error 0.4.1",
  "spl-type-length-value 0.4.3",
@@ -7463,7 +7463,7 @@ checksum = "cace91ba08984a41556efe49cbf2edca4db2f577b649da7827d3621161784bf8"
 dependencies = [
  "bytemuck",
  "solana-program",
- "spl-discriminator 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-discriminator 0.2.2",
  "spl-pod 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-program-error 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-type-length-value 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7652,7 +7652,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-discriminator 0.2.2",
+ "spl-discriminator 0.3.0",
  "spl-pod 0.2.2",
  "spl-program-error 0.4.1",
  "spl-token-2022 3.0.2",
@@ -7670,7 +7670,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-discriminator 0.2.2",
+ "spl-discriminator 0.3.0",
  "spl-pod 0.2.2",
  "spl-token-2022 3.0.2",
  "spl-token-client",
@@ -7685,7 +7685,7 @@ version = "0.2.3"
 dependencies = [
  "bytemuck",
  "solana-program",
- "spl-discriminator 0.2.2",
+ "spl-discriminator 0.3.0",
  "spl-pod 0.2.2",
  "spl-program-error 0.4.1",
  "spl-type-length-value 0.4.3",
@@ -7699,7 +7699,7 @@ checksum = "d419b5cfa3ee8e0f2386fd7e02a33b3ec8a7db4a9c7064a2ea24849dc4a273b6"
 dependencies = [
  "bytemuck",
  "solana-program",
- "spl-discriminator 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-discriminator 0.2.2",
  "spl-pod 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-program-error 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -7760,7 +7760,7 @@ dependencies = [
  "serde",
  "serde_json",
  "solana-program",
- "spl-discriminator 0.2.2",
+ "spl-discriminator 0.3.0",
  "spl-pod 0.2.2",
  "spl-program-error 0.4.1",
  "spl-type-length-value 0.4.3",
@@ -7774,7 +7774,7 @@ checksum = "30179c47e93625680dabb620c6e7931bd12d62af390f447bc7beb4a3a9b5feee"
 dependencies = [
  "borsh 1.5.1",
  "solana-program",
- "spl-discriminator 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-discriminator 0.2.2",
  "spl-pod 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-program-error 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-type-length-value 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7911,7 +7911,7 @@ dependencies = [
  "arrayref",
  "bytemuck",
  "solana-program",
- "spl-discriminator 0.2.2",
+ "spl-discriminator 0.3.0",
  "spl-pod 0.2.2",
  "spl-program-error 0.4.1",
  "spl-tlv-account-resolution 0.6.3",
@@ -7928,7 +7928,7 @@ dependencies = [
  "arrayref",
  "bytemuck",
  "solana-program",
- "spl-discriminator 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-discriminator 0.2.2",
  "spl-pod 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-program-error 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-tlv-account-resolution 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7941,7 +7941,7 @@ version = "0.4.3"
 dependencies = [
  "bytemuck",
  "solana-program",
- "spl-discriminator 0.2.2",
+ "spl-discriminator 0.3.0",
  "spl-pod 0.2.2",
  "spl-program-error 0.4.1",
  "spl-type-length-value-derive",
@@ -7955,7 +7955,7 @@ checksum = "422ce13429dbd41d2cee8a73931c05fda0b0c8ca156a8b0c19445642550bb61a"
 dependencies = [
  "bytemuck",
  "solana-program",
- "spl-discriminator 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-discriminator 0.2.2",
  "spl-pod 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-program-error 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -7975,7 +7975,7 @@ version = "0.1.0"
 dependencies = [
  "borsh 1.5.1",
  "solana-program",
- "spl-discriminator 0.2.2",
+ "spl-discriminator 0.3.0",
  "spl-type-length-value 0.4.3",
 ]
 

--- a/libraries/discriminator/Cargo.toml
+++ b/libraries/discriminator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-discriminator"
-version = "0.2.2"
+version = "0.3.0"
 description = "Solana Program Library 8-Byte Discriminator Management"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/libraries/tlv-account-resolution/Cargo.toml
+++ b/libraries/tlv-account-resolution/Cargo.toml
@@ -15,7 +15,7 @@ test-sbf = []
 bytemuck = { version = "1.16.1", features = ["derive"] }
 serde = { version = "1.0.203", optional = true }
 solana-program = "2.0.0"
-spl-discriminator = { version = "0.2.2", path = "../discriminator" }
+spl-discriminator = { version = "0.3.0", path = "../discriminator" }
 spl-program-error = { version = "0.4.0", path = "../program-error" }
 spl-type-length-value = { version = "0.4.3", path = "../type-length-value" }
 spl-pod = { version = "0.2.2", path = "../pod" }

--- a/libraries/type-length-value-derive-test/Cargo.toml
+++ b/libraries/type-length-value-derive-test/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dev-dependencies]
 borsh = "1.5.1"
 solana-program = "2.0.0"
-spl-discriminator = { version = "0.2.2", path = "../discriminator" }
+spl-discriminator = { version = "0.3.0", path = "../discriminator" }
 spl-type-length-value = { version = "0.4.3", path = "../type-length-value", features = [
   "derive",
 ] }

--- a/libraries/type-length-value/Cargo.toml
+++ b/libraries/type-length-value/Cargo.toml
@@ -14,7 +14,7 @@ derive = ["dep:spl-type-length-value-derive"]
 [dependencies]
 bytemuck = { version = "1.16.1", features = ["derive"] }
 solana-program = "2.0.0"
-spl-discriminator = { version = "0.2.2", path = "../discriminator" }
+spl-discriminator = { version = "0.3.0", path = "../discriminator" }
 spl-program-error = { version = "0.4.0", path = "../program-error" }
 spl-type-length-value-derive = { version = "0.1", path = "./derive", optional = true }
 spl-pod = { version = "0.2.2", path = "../pod" }

--- a/token-collection/program/Cargo.toml
+++ b/token-collection/program/Cargo.toml
@@ -24,7 +24,7 @@ spl-type-length-value = { version = "0.4.3", path = "../../libraries/type-length
 [dev-dependencies]
 solana-program-test = "2.0.0"
 solana-sdk = "2.0.0"
-spl-discriminator = { version = "0.2.2", path = "../../libraries/discriminator" }
+spl-discriminator = { version = "0.3.0", path = "../../libraries/discriminator" }
 spl-token-client = { version = "0.10.0", path = "../../token/client" }
 
 [lib]

--- a/token-group/example/Cargo.toml
+++ b/token-group/example/Cargo.toml
@@ -21,7 +21,7 @@ spl-type-length-value = { version = "0.4.3", path = "../../libraries/type-length
 [dev-dependencies]
 solana-program-test = "2.0.0"
 solana-sdk = "2.0.0"
-spl-discriminator = { version = "0.2.2", path = "../../libraries/discriminator" }
+spl-discriminator = { version = "0.3.0", path = "../../libraries/discriminator" }
 spl-token-client = { version = "0.10.0", path = "../../token/client" }
 spl-token-metadata-interface = { version = "0.3.3", path = "../../token-metadata/interface" }
 

--- a/token-group/interface/Cargo.toml
+++ b/token-group/interface/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 bytemuck = "1.16.1"
 solana-program = "2.0.0"
-spl-discriminator = { version = "0.2.2" , path = "../../libraries/discriminator" }
+spl-discriminator = { version = "0.3.0" , path = "../../libraries/discriminator" }
 spl-pod = { version = "0.2.2" , path = "../../libraries/pod", features = ["borsh"] }
 spl-program-error = { version = "0.4.0" , path = "../../libraries/program-error" }
 

--- a/token-metadata/interface/Cargo.toml
+++ b/token-metadata/interface/Cargo.toml
@@ -14,7 +14,7 @@ serde-traits = ["dep:serde", "spl-pod/serde-traits"]
 borsh = "1.5.1"
 serde = { version = "1.0.203", optional = true }
 solana-program = "2.0.0"
-spl-discriminator = { version = "0.2.2", path = "../../libraries/discriminator" }
+spl-discriminator = { version = "0.3.0", path = "../../libraries/discriminator" }
 spl-program-error = { version = "0.4.0", path = "../../libraries/program-error" }
 spl-type-length-value = { version = "0.4.3", path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.2.2", path = "../../libraries/pod", features = [

--- a/token/transfer-hook/interface/Cargo.toml
+++ b/token/transfer-hook/interface/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 arrayref = "0.3.7"
 bytemuck = { version = "1.16.1", features = ["derive"] }
 solana-program = "2.0.0"
-spl-discriminator = { version = "0.2.2" , path = "../../../libraries/discriminator" }
+spl-discriminator = { version = "0.3.0" , path = "../../../libraries/discriminator" }
 spl-program-error = { version = "0.4.0" , path = "../../../libraries/program-error" }
 spl-tlv-account-resolution = { version = "0.6.3" , path = "../../../libraries/tlv-account-resolution" }
 spl-type-length-value = { version = "0.4.3" , path = "../../../libraries/type-length-value" }


### PR DESCRIPTION
#### Problem

As part of #6897, we need to release new major versions of many crates.

#### Solution

Bump spl-discriminator for the next release