### PR TITLE
instruction-padding: Bump to 0.2.0 for Solana v2 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7151,7 +7151,7 @@ dependencies = [
 
 [[package]]
 name = "spl-instruction-padding"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "num_enum",
  "solana-program",

--- a/instruction-padding/program/Cargo.toml
+++ b/instruction-padding/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-instruction-padding"
-version = "0.1.1"
+version = "0.2.0"
 description = "Solana Program Library Instruction Padding Program"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -30,7 +30,7 @@ spl-pod = { version = "0.2.2", path = "../../libraries/pod" }
 spl-token-2022 = { version = "3.0.2", path = "../program-2022", features = [
   "no-entrypoint",
 ] }
-spl-instruction-padding = { version = "0.1.1", path = "../../instruction-padding/program", features = [
+spl-instruction-padding = { version = "0.2.0", path = "../../instruction-padding/program", features = [
   "no-entrypoint",
 ] }
 spl-tlv-account-resolution = { version = "0.6.3", path = "../../libraries/tlv-account-resolution" }


### PR DESCRIPTION
#### Problem

As part of #6897, we need to release new major versions of many crates.

#### Solution

Bump spl-instruction-padding for the next release