### PR TITLE
program-error: Bump to 0.5.0 for Solana v2 compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7239,7 +7239,7 @@ dependencies = [
  "serde_json",
  "solana-program",
  "solana-zk-token-sdk",
- "spl-program-error 0.4.1",
+ "spl-program-error 0.5.0",
 ]
 
 [[package]]
@@ -7252,21 +7252,7 @@ dependencies = [
  "bytemuck",
  "solana-program",
  "solana-zk-token-sdk",
- "spl-program-error 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "spl-program-error"
-version = "0.4.1"
-dependencies = [
- "lazy_static",
- "num-derive",
- "num-traits",
- "serial_test",
- "solana-program",
- "solana-sdk",
- "spl-program-error-derive 0.4.1",
- "thiserror",
+ "spl-program-error 0.4.1",
 ]
 
 [[package]]
@@ -7279,6 +7265,20 @@ dependencies = [
  "num-traits",
  "solana-program",
  "spl-program-error-derive 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-program-error"
+version = "0.5.0"
+dependencies = [
+ "lazy_static",
+ "num-derive",
+ "num-traits",
+ "serial_test",
+ "solana-program",
+ "solana-sdk",
+ "spl-program-error-derive 0.4.1",
  "thiserror",
 ]
 
@@ -7451,7 +7451,7 @@ dependencies = [
  "solana-sdk",
  "spl-discriminator 0.3.0",
  "spl-pod 0.2.2",
- "spl-program-error 0.4.1",
+ "spl-program-error 0.5.0",
  "spl-type-length-value 0.4.3",
 ]
 
@@ -7465,7 +7465,7 @@ dependencies = [
  "solana-program",
  "spl-discriminator 0.2.2",
  "spl-pod 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-program-error 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-program-error 0.4.1",
  "spl-type-length-value 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -7654,7 +7654,7 @@ dependencies = [
  "solana-sdk",
  "spl-discriminator 0.3.0",
  "spl-pod 0.2.2",
- "spl-program-error 0.4.1",
+ "spl-program-error 0.5.0",
  "spl-token-2022 3.0.2",
  "spl-token-client",
  "spl-token-group-example",
@@ -7687,7 +7687,7 @@ dependencies = [
  "solana-program",
  "spl-discriminator 0.3.0",
  "spl-pod 0.2.2",
- "spl-program-error 0.4.1",
+ "spl-program-error 0.5.0",
  "spl-type-length-value 0.4.3",
 ]
 
@@ -7701,7 +7701,7 @@ dependencies = [
  "solana-program",
  "spl-discriminator 0.2.2",
  "spl-pod 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-program-error 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-program-error 0.4.1",
 ]
 
 [[package]]
@@ -7762,7 +7762,7 @@ dependencies = [
  "solana-program",
  "spl-discriminator 0.3.0",
  "spl-pod 0.2.2",
- "spl-program-error 0.4.1",
+ "spl-program-error 0.5.0",
  "spl-type-length-value 0.4.3",
 ]
 
@@ -7776,7 +7776,7 @@ dependencies = [
  "solana-program",
  "spl-discriminator 0.2.2",
  "spl-pod 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-program-error 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-program-error 0.4.1",
  "spl-type-length-value 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -7913,7 +7913,7 @@ dependencies = [
  "solana-program",
  "spl-discriminator 0.3.0",
  "spl-pod 0.2.2",
- "spl-program-error 0.4.1",
+ "spl-program-error 0.5.0",
  "spl-tlv-account-resolution 0.6.3",
  "spl-type-length-value 0.4.3",
  "tokio",
@@ -7930,7 +7930,7 @@ dependencies = [
  "solana-program",
  "spl-discriminator 0.2.2",
  "spl-pod 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-program-error 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-program-error 0.4.1",
  "spl-tlv-account-resolution 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-type-length-value 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -7943,7 +7943,7 @@ dependencies = [
  "solana-program",
  "spl-discriminator 0.3.0",
  "spl-pod 0.2.2",
- "spl-program-error 0.4.1",
+ "spl-program-error 0.5.0",
  "spl-type-length-value-derive",
 ]
 
@@ -7957,7 +7957,7 @@ dependencies = [
  "solana-program",
  "spl-discriminator 0.2.2",
  "spl-pod 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-program-error 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-program-error 0.4.1",
 ]
 
 [[package]]

--- a/libraries/pod/Cargo.toml
+++ b/libraries/pod/Cargo.toml
@@ -18,7 +18,7 @@ bytemuck = { version = "1.16.1" }
 serde = { version = "1.0.203", optional = true }
 solana-program = "2.0.0"
 solana-zk-token-sdk = "2.0.0"
-spl-program-error = { version = "0.4.0", path = "../program-error" }
+spl-program-error = { version = "0.5.0", path = "../program-error" }
 
 [dev-dependencies]
 serde_json = "1.0.117"

--- a/libraries/program-error/Cargo.toml
+++ b/libraries/program-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-program-error"
-version = "0.4.1"
+version = "0.5.0"
 description = "Library for Solana Program error attributes and derive macro for creating them"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/libraries/tlv-account-resolution/Cargo.toml
+++ b/libraries/tlv-account-resolution/Cargo.toml
@@ -16,7 +16,7 @@ bytemuck = { version = "1.16.1", features = ["derive"] }
 serde = { version = "1.0.203", optional = true }
 solana-program = "2.0.0"
 spl-discriminator = { version = "0.3.0", path = "../discriminator" }
-spl-program-error = { version = "0.4.0", path = "../program-error" }
+spl-program-error = { version = "0.5.0", path = "../program-error" }
 spl-type-length-value = { version = "0.4.3", path = "../type-length-value" }
 spl-pod = { version = "0.2.2", path = "../pod" }
 

--- a/libraries/type-length-value/Cargo.toml
+++ b/libraries/type-length-value/Cargo.toml
@@ -15,7 +15,7 @@ derive = ["dep:spl-type-length-value-derive"]
 bytemuck = { version = "1.16.1", features = ["derive"] }
 solana-program = "2.0.0"
 spl-discriminator = { version = "0.3.0", path = "../discriminator" }
-spl-program-error = { version = "0.4.0", path = "../program-error" }
+spl-program-error = { version = "0.5.0", path = "../program-error" }
 spl-type-length-value-derive = { version = "0.1", path = "./derive", optional = true }
 spl-pod = { version = "0.2.2", path = "../pod" }
 

--- a/token-collection/program/Cargo.toml
+++ b/token-collection/program/Cargo.toml
@@ -14,7 +14,7 @@ test-sbf = []
 [dependencies]
 solana-program = "2.0.0"
 spl-pod = { version = "0.2.2", path = "../../libraries/pod" }
-spl-program-error = { version = "0.4.0" , path = "../../libraries/program-error" }
+spl-program-error = { version = "0.5.0" , path = "../../libraries/program-error" }
 spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-group-example = { version = "0.2", path = "../../token-group/example", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.2.3", path = "../../token-group/interface" }

--- a/token-group/interface/Cargo.toml
+++ b/token-group/interface/Cargo.toml
@@ -12,7 +12,7 @@ bytemuck = "1.16.1"
 solana-program = "2.0.0"
 spl-discriminator = { version = "0.3.0" , path = "../../libraries/discriminator" }
 spl-pod = { version = "0.2.2" , path = "../../libraries/pod", features = ["borsh"] }
-spl-program-error = { version = "0.4.0" , path = "../../libraries/program-error" }
+spl-program-error = { version = "0.5.0" , path = "../../libraries/program-error" }
 
 [dev-dependencies]
 spl-type-length-value = { version = "0.4.3", path = "../../libraries/type-length-value", features = ["derive"] }

--- a/token-metadata/interface/Cargo.toml
+++ b/token-metadata/interface/Cargo.toml
@@ -15,7 +15,7 @@ borsh = "1.5.1"
 serde = { version = "1.0.203", optional = true }
 solana-program = "2.0.0"
 spl-discriminator = { version = "0.3.0", path = "../../libraries/discriminator" }
-spl-program-error = { version = "0.4.0", path = "../../libraries/program-error" }
+spl-program-error = { version = "0.5.0", path = "../../libraries/program-error" }
 spl-type-length-value = { version = "0.4.3", path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.2.2", path = "../../libraries/pod", features = [
   "borsh",

--- a/token/transfer-hook/interface/Cargo.toml
+++ b/token/transfer-hook/interface/Cargo.toml
@@ -12,7 +12,7 @@ arrayref = "0.3.7"
 bytemuck = { version = "1.16.1", features = ["derive"] }
 solana-program = "2.0.0"
 spl-discriminator = { version = "0.3.0" , path = "../../../libraries/discriminator" }
-spl-program-error = { version = "0.4.0" , path = "../../../libraries/program-error" }
+spl-program-error = { version = "0.5.0" , path = "../../../libraries/program-error" }
 spl-tlv-account-resolution = { version = "0.6.3" , path = "../../../libraries/tlv-account-resolution" }
 spl-type-length-value = { version = "0.4.3" , path = "../../../libraries/type-length-value" }
 spl-pod = { version = "0.2.2", path = "../../../libraries/pod" }


### PR DESCRIPTION
#### Problem

As part of #6897, we need to release new major versions of many crates.

#### Solution

Bump spl-program-error for the next release