### PR TITLE
tlv: Bump to 0.5.0 for Solana v2 compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7452,7 +7452,7 @@ dependencies = [
  "spl-discriminator 0.3.0",
  "spl-pod 0.3.0",
  "spl-program-error 0.5.0",
- "spl-type-length-value 0.4.3",
+ "spl-type-length-value 0.5.0",
 ]
 
 [[package]]
@@ -7466,7 +7466,7 @@ dependencies = [
  "spl-discriminator 0.2.2",
  "spl-pod 0.2.2",
  "spl-program-error 0.4.1",
- "spl-type-length-value 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-type-length-value 0.4.3",
 ]
 
 [[package]]
@@ -7530,7 +7530,7 @@ dependencies = [
  "spl-token-group-interface 0.2.3",
  "spl-token-metadata-interface 0.3.3",
  "spl-transfer-hook-interface 0.6.3",
- "spl-type-length-value 0.4.3",
+ "spl-type-length-value 0.5.0",
  "thiserror",
 ]
 
@@ -7554,7 +7554,7 @@ dependencies = [
  "spl-token-group-interface 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token-metadata-interface 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-transfer-hook-interface 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-type-length-value 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-type-length-value 0.4.3",
  "thiserror",
 ]
 
@@ -7660,7 +7660,7 @@ dependencies = [
  "spl-token-group-example",
  "spl-token-group-interface 0.2.3",
  "spl-token-metadata-interface 0.3.3",
- "spl-type-length-value 0.4.3",
+ "spl-type-length-value 0.5.0",
 ]
 
 [[package]]
@@ -7676,7 +7676,7 @@ dependencies = [
  "spl-token-client",
  "spl-token-group-interface 0.2.3",
  "spl-token-metadata-interface 0.3.3",
- "spl-type-length-value 0.4.3",
+ "spl-type-length-value 0.5.0",
 ]
 
 [[package]]
@@ -7688,7 +7688,7 @@ dependencies = [
  "spl-discriminator 0.3.0",
  "spl-pod 0.3.0",
  "spl-program-error 0.5.0",
- "spl-type-length-value 0.4.3",
+ "spl-type-length-value 0.5.0",
 ]
 
 [[package]]
@@ -7748,7 +7748,7 @@ dependencies = [
  "spl-token-2022 3.0.2",
  "spl-token-client",
  "spl-token-metadata-interface 0.3.3",
- "spl-type-length-value 0.4.3",
+ "spl-type-length-value 0.5.0",
  "test-case",
 ]
 
@@ -7763,7 +7763,7 @@ dependencies = [
  "spl-discriminator 0.3.0",
  "spl-pod 0.3.0",
  "spl-program-error 0.5.0",
- "spl-type-length-value 0.4.3",
+ "spl-type-length-value 0.5.0",
 ]
 
 [[package]]
@@ -7777,7 +7777,7 @@ dependencies = [
  "spl-discriminator 0.2.2",
  "spl-pod 0.2.2",
  "spl-program-error 0.4.1",
- "spl-type-length-value 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-type-length-value 0.4.3",
 ]
 
 [[package]]
@@ -7901,7 +7901,7 @@ dependencies = [
  "spl-tlv-account-resolution 0.6.3",
  "spl-token-2022 3.0.2",
  "spl-transfer-hook-interface 0.6.3",
- "spl-type-length-value 0.4.3",
+ "spl-type-length-value 0.5.0",
 ]
 
 [[package]]
@@ -7915,7 +7915,7 @@ dependencies = [
  "spl-pod 0.3.0",
  "spl-program-error 0.5.0",
  "spl-tlv-account-resolution 0.6.3",
- "spl-type-length-value 0.4.3",
+ "spl-type-length-value 0.5.0",
  "tokio",
 ]
 
@@ -7932,19 +7932,7 @@ dependencies = [
  "spl-pod 0.2.2",
  "spl-program-error 0.4.1",
  "spl-tlv-account-resolution 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-type-length-value 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "spl-type-length-value"
-version = "0.4.3"
-dependencies = [
- "bytemuck",
- "solana-program",
- "spl-discriminator 0.3.0",
- "spl-pod 0.3.0",
- "spl-program-error 0.5.0",
- "spl-type-length-value-derive",
+ "spl-type-length-value 0.4.3",
 ]
 
 [[package]]
@@ -7958,6 +7946,18 @@ dependencies = [
  "spl-discriminator 0.2.2",
  "spl-pod 0.2.2",
  "spl-program-error 0.4.1",
+]
+
+[[package]]
+name = "spl-type-length-value"
+version = "0.5.0"
+dependencies = [
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator 0.3.0",
+ "spl-pod 0.3.0",
+ "spl-program-error 0.5.0",
+ "spl-type-length-value-derive",
 ]
 
 [[package]]
@@ -7976,7 +7976,7 @@ dependencies = [
  "borsh 1.5.1",
  "solana-program",
  "spl-discriminator 0.3.0",
- "spl-type-length-value 0.4.3",
+ "spl-type-length-value 0.5.0",
 ]
 
 [[package]]

--- a/libraries/tlv-account-resolution/Cargo.toml
+++ b/libraries/tlv-account-resolution/Cargo.toml
@@ -17,8 +17,8 @@ serde = { version = "1.0.203", optional = true }
 solana-program = "2.0.0"
 spl-discriminator = { version = "0.3.0", path = "../discriminator" }
 spl-program-error = { version = "0.5.0", path = "../program-error" }
-spl-type-length-value = { version = "0.4.3", path = "../type-length-value" }
 spl-pod = { version = "0.3.0", path = "../pod" }
+spl-type-length-value = { version = "0.5.0", path = "../type-length-value" }
 
 [dev-dependencies]
 futures = "0.3.30"

--- a/libraries/type-length-value-derive-test/Cargo.toml
+++ b/libraries/type-length-value-derive-test/Cargo.toml
@@ -11,6 +11,6 @@ edition = "2021"
 borsh = "1.5.1"
 solana-program = "2.0.0"
 spl-discriminator = { version = "0.3.0", path = "../discriminator" }
-spl-type-length-value = { version = "0.4.3", path = "../type-length-value", features = [
+spl-type-length-value = { version = "0.5.0", path = "../type-length-value", features = [
   "derive",
 ] }

--- a/libraries/type-length-value/Cargo.toml
+++ b/libraries/type-length-value/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-type-length-value"
-version = "0.4.3"
+version = "0.5.0"
 description = "Solana Program Library Type-Length-Value Management"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token-collection/program/Cargo.toml
+++ b/token-collection/program/Cargo.toml
@@ -19,7 +19,7 @@ spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", feature
 spl-token-group-example = { version = "0.2", path = "../../token-group/example", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.2.3", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.3.3", path = "../../token-metadata/interface" }
-spl-type-length-value = { version = "0.4.3", path = "../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.5.0", path = "../../libraries/type-length-value" }
 
 [dev-dependencies]
 solana-program-test = "2.0.0"

--- a/token-group/example/Cargo.toml
+++ b/token-group/example/Cargo.toml
@@ -16,7 +16,7 @@ solana-program = "2.0.0"
 spl-pod = { version = "0.3.0", path = "../../libraries/pod" }
 spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.2.3", path = "../interface" }
-spl-type-length-value = { version = "0.4.3", path = "../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.5.0", path = "../../libraries/type-length-value" }
 
 [dev-dependencies]
 solana-program-test = "2.0.0"

--- a/token-group/interface/Cargo.toml
+++ b/token-group/interface/Cargo.toml
@@ -15,7 +15,7 @@ spl-pod = { version = "0.3.0" , path = "../../libraries/pod", features = ["borsh
 spl-program-error = { version = "0.5.0" , path = "../../libraries/program-error" }
 
 [dev-dependencies]
-spl-type-length-value = { version = "0.4.3", path = "../../libraries/type-length-value", features = ["derive"] }
+spl-type-length-value = { version = "0.5.0", path = "../../libraries/type-length-value", features = ["derive"] }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/token-metadata/example/Cargo.toml
+++ b/token-metadata/example/Cargo.toml
@@ -15,7 +15,7 @@ test-sbf = []
 solana-program = "2.0.0"
 spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-metadata-interface = { version = "0.3.3", path = "../interface" }
-spl-type-length-value = { version = "0.4.3" , path = "../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.5.0" , path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.3.0", path = "../../libraries/pod" }
 
 [dev-dependencies]

--- a/token-metadata/interface/Cargo.toml
+++ b/token-metadata/interface/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0.203", optional = true }
 solana-program = "2.0.0"
 spl-discriminator = { version = "0.3.0", path = "../../libraries/discriminator" }
 spl-program-error = { version = "0.5.0", path = "../../libraries/program-error" }
-spl-type-length-value = { version = "0.4.3", path = "../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.5.0", path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.3.0", path = "../../libraries/pod", features = [
   "borsh",
 ] }

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -34,7 +34,7 @@ spl-token = { version = "6.0",  path = "../program", features = ["no-entrypoint"
 spl-token-group-interface = { version = "0.2.3", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.3.3", path = "../../token-metadata/interface" }
 spl-transfer-hook-interface = { version = "0.6.3", path = "../transfer-hook/interface" }
-spl-type-length-value = { version = "0.4.3", path = "../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.5.0", path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.3.0", path = "../../libraries/pod" }
 thiserror = "1.0"
 serde = { version = "1.0.203", optional = true }

--- a/token/transfer-hook/example/Cargo.toml
+++ b/token/transfer-hook/example/Cargo.toml
@@ -19,7 +19,7 @@ solana-program = "2.0.0"
 spl-tlv-account-resolution = { version = "0.6.3" , path = "../../../libraries/tlv-account-resolution" }
 spl-token-2022 = { version = "3.0.2",  path = "../../program-2022", features = ["no-entrypoint"] }
 spl-transfer-hook-interface = { version = "0.6.3" , path = "../interface" }
-spl-type-length-value = { version = "0.4.3" , path = "../../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.5.0" , path = "../../../libraries/type-length-value" }
 
 [dev-dependencies]
 solana-program-test = "2.0.0"

--- a/token/transfer-hook/interface/Cargo.toml
+++ b/token/transfer-hook/interface/Cargo.toml
@@ -14,7 +14,7 @@ solana-program = "2.0.0"
 spl-discriminator = { version = "0.3.0" , path = "../../../libraries/discriminator" }
 spl-program-error = { version = "0.5.0" , path = "../../../libraries/program-error" }
 spl-tlv-account-resolution = { version = "0.6.3" , path = "../../../libraries/tlv-account-resolution" }
-spl-type-length-value = { version = "0.4.3" , path = "../../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.5.0" , path = "../../../libraries/type-length-value" }
 spl-pod = { version = "0.3.0", path = "../../../libraries/pod" }
 
 [lib]


### PR DESCRIPTION
#### Problem

As part of #6897, we need to release new major versions of many crates.

#### Solution

Bump spl-type-length-value for the next release