### PR TITLE
tlv-account-resolution: Bump to 0.7.0 for Solana v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7440,6 +7440,20 @@ dependencies = [
 [[package]]
 name = "spl-tlv-account-resolution"
 version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cace91ba08984a41556efe49cbf2edca4db2f577b649da7827d3621161784bf8"
+dependencies = [
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator 0.2.2",
+ "spl-pod 0.2.2",
+ "spl-program-error 0.4.1",
+ "spl-type-length-value 0.4.3",
+]
+
+[[package]]
+name = "spl-tlv-account-resolution"
+version = "0.7.0"
 dependencies = [
  "bytemuck",
  "futures 0.3.30",
@@ -7453,20 +7467,6 @@ dependencies = [
  "spl-pod 0.3.0",
  "spl-program-error 0.5.0",
  "spl-type-length-value 0.5.0",
-]
-
-[[package]]
-name = "spl-tlv-account-resolution"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cace91ba08984a41556efe49cbf2edca4db2f577b649da7827d3621161784bf8"
-dependencies = [
- "bytemuck",
- "solana-program",
- "spl-discriminator 0.2.2",
- "spl-pod 0.2.2",
- "spl-program-error 0.4.1",
- "spl-type-length-value 0.4.3",
 ]
 
 [[package]]
@@ -7525,7 +7525,7 @@ dependencies = [
  "solana-zk-token-sdk",
  "spl-memo 5.0.0",
  "spl-pod 0.3.0",
- "spl-tlv-account-resolution 0.6.3",
+ "spl-tlv-account-resolution 0.7.0",
  "spl-token 6.0.0",
  "spl-token-group-interface 0.2.3",
  "spl-token-metadata-interface 0.3.3",
@@ -7572,7 +7572,7 @@ dependencies = [
  "spl-instruction-padding",
  "spl-memo 5.0.0",
  "spl-pod 0.3.0",
- "spl-tlv-account-resolution 0.6.3",
+ "spl-tlv-account-resolution 0.7.0",
  "spl-token-2022 3.0.2",
  "spl-token-client",
  "spl-token-group-interface 0.2.3",
@@ -7880,7 +7880,7 @@ dependencies = [
  "solana-remote-wallet",
  "solana-sdk",
  "solana-test-validator",
- "spl-tlv-account-resolution 0.6.3",
+ "spl-tlv-account-resolution 0.7.0",
  "spl-token-2022 3.0.2",
  "spl-token-client",
  "spl-transfer-hook-example",
@@ -7898,7 +7898,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-tlv-account-resolution 0.6.3",
+ "spl-tlv-account-resolution 0.7.0",
  "spl-token-2022 3.0.2",
  "spl-transfer-hook-interface 0.6.3",
  "spl-type-length-value 0.5.0",
@@ -7914,7 +7914,7 @@ dependencies = [
  "spl-discriminator 0.3.0",
  "spl-pod 0.3.0",
  "spl-program-error 0.5.0",
- "spl-tlv-account-resolution 0.6.3",
+ "spl-tlv-account-resolution 0.7.0",
  "spl-type-length-value 0.5.0",
  "tokio",
 ]
@@ -7931,7 +7931,7 @@ dependencies = [
  "spl-discriminator 0.2.2",
  "spl-pod 0.2.2",
  "spl-program-error 0.4.1",
- "spl-tlv-account-resolution 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-tlv-account-resolution 0.6.3",
  "spl-type-length-value 0.4.3",
 ]
 

--- a/libraries/tlv-account-resolution/Cargo.toml
+++ b/libraries/tlv-account-resolution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-tlv-account-resolution"
-version = "0.6.3"
+version = "0.7.0"
 description = "Solana Program Library TLV Account Resolution Interface"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -33,7 +33,7 @@ spl-token-2022 = { version = "3.0.2", path = "../program-2022", features = [
 spl-instruction-padding = { version = "0.2.0", path = "../../instruction-padding/program", features = [
   "no-entrypoint",
 ] }
-spl-tlv-account-resolution = { version = "0.6.3", path = "../../libraries/tlv-account-resolution" }
+spl-tlv-account-resolution = { version = "0.7.0", path = "../../libraries/tlv-account-resolution" }
 spl-token-client = { version = "0.10.0", path = "../client" }
 spl-token-group-interface = { version = "0.2.3", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.3.3", path = "../../token-metadata/interface" }

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -47,7 +47,7 @@ proptest = "1.5"
 serial_test = "3.1.1"
 solana-program-test = "2.0.0"
 solana-sdk = "2.0.0"
-spl-tlv-account-resolution = { version = "0.6.3", path = "../../libraries/tlv-account-resolution" }
+spl-tlv-account-resolution = { version = "0.7.0", path = "../../libraries/tlv-account-resolution" }
 serde_json = "1.0.117"
 
 [lib]

--- a/token/transfer-hook/cli/Cargo.toml
+++ b/token/transfer-hook/cli/Cargo.toml
@@ -18,7 +18,7 @@ solana-logger = "2.0.0"
 solana-remote-wallet = "2.0.0"
 solana-sdk = "2.0.0"
 spl-transfer-hook-interface = { version = "0.6.3", path = "../interface" }
-spl-tlv-account-resolution = { version = "0.6.3" , path = "../../../libraries/tlv-account-resolution", features = ["serde-traits"] }
+spl-tlv-account-resolution = { version = "0.7.0" , path = "../../../libraries/tlv-account-resolution", features = ["serde-traits"] }
 strum = "0.26"
 strum_macros = "0.26"
 tokio = { version = "1", features = ["full"] }

--- a/token/transfer-hook/example/Cargo.toml
+++ b/token/transfer-hook/example/Cargo.toml
@@ -16,7 +16,7 @@ forbid-additional-mints = []
 [dependencies]
 arrayref = "0.3.7"
 solana-program = "2.0.0"
-spl-tlv-account-resolution = { version = "0.6.3" , path = "../../../libraries/tlv-account-resolution" }
+spl-tlv-account-resolution = { version = "0.7.0" , path = "../../../libraries/tlv-account-resolution" }
 spl-token-2022 = { version = "3.0.2",  path = "../../program-2022", features = ["no-entrypoint"] }
 spl-transfer-hook-interface = { version = "0.6.3" , path = "../interface" }
 spl-type-length-value = { version = "0.5.0" , path = "../../../libraries/type-length-value" }

--- a/token/transfer-hook/interface/Cargo.toml
+++ b/token/transfer-hook/interface/Cargo.toml
@@ -13,7 +13,7 @@ bytemuck = { version = "1.16.1", features = ["derive"] }
 solana-program = "2.0.0"
 spl-discriminator = { version = "0.3.0" , path = "../../../libraries/discriminator" }
 spl-program-error = { version = "0.5.0" , path = "../../../libraries/program-error" }
-spl-tlv-account-resolution = { version = "0.6.3" , path = "../../../libraries/tlv-account-resolution" }
+spl-tlv-account-resolution = { version = "0.7.0" , path = "../../../libraries/tlv-account-resolution" }
 spl-type-length-value = { version = "0.5.0" , path = "../../../libraries/type-length-value" }
 spl-pod = { version = "0.3.0", path = "../../../libraries/pod" }
 


### PR DESCRIPTION
#### Problem

As part of #6897, we need to release new major versions of many crates.

#### Solution

Bump spl-tlv-account-resolution for the next release