### PR TITLE
pod: Use `bytemuck_derive` explicitly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7248,6 +7248,7 @@ dependencies = [
  "base64 0.22.1",
  "borsh 1.5.1",
  "bytemuck",
+ "bytemuck_derive",
  "serde",
  "serde_json",
  "solana-program",

--- a/libraries/pod/Cargo.toml
+++ b/libraries/pod/Cargo.toml
@@ -15,6 +15,7 @@ borsh = ["dep:borsh"]
 base64 = { version = "0.22.1", optional = true }
 borsh = { version = "1.5.1", optional = true }
 bytemuck = { version = "1.16.1" }
+bytemuck_derive = { version = "1.7.0" }
 serde = { version = "1.0.203", optional = true }
 solana-program = "2.0.0"
 solana-zk-token-sdk = "2.0.0"

--- a/libraries/pod/src/optional_keys.rs
+++ b/libraries/pod/src/optional_keys.rs
@@ -9,7 +9,7 @@ use {
     std::{convert::TryFrom, fmt, str::FromStr},
 };
 use {
-    bytemuck::{Pod, Zeroable},
+    bytemuck_derive::{Pod, Zeroable},
     solana_program::{program_error::ProgramError, program_option::COption, pubkey::Pubkey},
     solana_zk_token_sdk::zk_token_elgamal::pod::ElGamalPubkey,
 };

--- a/libraries/pod/src/primitives.rs
+++ b/libraries/pod/src/primitives.rs
@@ -1,7 +1,7 @@
 //! primitive types that can be used in `Pod`s
 #[cfg(feature = "borsh")]
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-use bytemuck::{Pod, Zeroable};
+use bytemuck_derive::{Pod, Zeroable};
 #[cfg(feature = "serde-traits")]
 use serde::{Deserialize, Serialize};
 

--- a/libraries/pod/src/slice.rs
+++ b/libraries/pod/src/slice.rs
@@ -129,7 +129,11 @@ fn max_len_for_type<T>(data_len: usize) -> Result<usize, ProgramError> {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, crate::bytemuck::pod_slice_to_bytes, bytemuck::Zeroable};
+    use {
+        super::*,
+        crate::bytemuck::pod_slice_to_bytes,
+        bytemuck_derive::{Pod, Zeroable},
+    };
 
     #[repr(C)]
     #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]


### PR DESCRIPTION
#### Problem

We can't publish spl-pod because it runs into issues with trying to derive `Pod` and `Zeroable`, likely because all of our tests activate the `derive` feature on bytemuck, but the solo crate does not.

#### Solution

Use `bytemuck_derive` explicitly