### PR TITLE
token-{metadata,group,transfer-hook}-interface: Bump for Solana v2 compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4999,7 +4999,7 @@ dependencies = [
  "solana-sdk",
  "spl-token 4.0.1",
  "spl-token-2022 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token-group-interface 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-group-interface 0.2.3",
  "spl-token-metadata-interface 0.3.3",
  "thiserror",
  "zstd",
@@ -6526,7 +6526,7 @@ dependencies = [
  "spl-memo 4.0.1",
  "spl-token 4.0.1",
  "spl-token-2022 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token-group-interface 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-group-interface 0.2.3",
  "spl-token-metadata-interface 0.3.3",
  "thiserror",
 ]
@@ -7528,7 +7528,7 @@ dependencies = [
  "spl-pod 0.3.0",
  "spl-tlv-account-resolution 0.7.0",
  "spl-token 6.0.0",
- "spl-token-group-interface 0.2.3",
+ "spl-token-group-interface 0.3.0",
  "spl-token-metadata-interface 0.4.0",
  "spl-transfer-hook-interface 0.6.3",
  "spl-type-length-value 0.5.0",
@@ -7552,7 +7552,7 @@ dependencies = [
  "spl-memo 4.0.1",
  "spl-pod 0.2.2",
  "spl-token 4.0.1",
- "spl-token-group-interface 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-group-interface 0.2.3",
  "spl-token-metadata-interface 0.3.3",
  "spl-transfer-hook-interface 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-type-length-value 0.4.3",
@@ -7576,7 +7576,7 @@ dependencies = [
  "spl-tlv-account-resolution 0.7.0",
  "spl-token-2022 3.0.2",
  "spl-token-client",
- "spl-token-group-interface 0.2.3",
+ "spl-token-group-interface 0.3.0",
  "spl-token-metadata-interface 0.4.0",
  "spl-transfer-hook-example",
  "spl-transfer-hook-interface 0.6.3",
@@ -7613,7 +7613,7 @@ dependencies = [
  "spl-token 6.0.0",
  "spl-token-2022 3.0.2",
  "spl-token-client",
- "spl-token-group-interface 0.2.3",
+ "spl-token-group-interface 0.3.0",
  "spl-token-metadata-interface 0.4.0",
  "strum 0.26.3",
  "strum_macros 0.26.4",
@@ -7640,7 +7640,7 @@ dependencies = [
  "spl-memo 5.0.0",
  "spl-token 6.0.0",
  "spl-token-2022 3.0.2",
- "spl-token-group-interface 0.2.3",
+ "spl-token-group-interface 0.3.0",
  "spl-token-metadata-interface 0.4.0",
  "spl-transfer-hook-interface 0.6.3",
  "thiserror",
@@ -7659,7 +7659,7 @@ dependencies = [
  "spl-token-2022 3.0.2",
  "spl-token-client",
  "spl-token-group-example",
- "spl-token-group-interface 0.2.3",
+ "spl-token-group-interface 0.3.0",
  "spl-token-metadata-interface 0.4.0",
  "spl-type-length-value 0.5.0",
 ]
@@ -7675,20 +7675,8 @@ dependencies = [
  "spl-pod 0.3.0",
  "spl-token-2022 3.0.2",
  "spl-token-client",
- "spl-token-group-interface 0.2.3",
+ "spl-token-group-interface 0.3.0",
  "spl-token-metadata-interface 0.4.0",
- "spl-type-length-value 0.5.0",
-]
-
-[[package]]
-name = "spl-token-group-interface"
-version = "0.2.3"
-dependencies = [
- "bytemuck",
- "solana-program",
- "spl-discriminator 0.3.0",
- "spl-pod 0.3.0",
- "spl-program-error 0.5.0",
  "spl-type-length-value 0.5.0",
 ]
 
@@ -7703,6 +7691,18 @@ dependencies = [
  "spl-discriminator 0.2.2",
  "spl-pod 0.2.2",
  "spl-program-error 0.4.1",
+]
+
+[[package]]
+name = "spl-token-group-interface"
+version = "0.3.0"
+dependencies = [
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator 0.3.0",
+ "spl-pod 0.3.0",
+ "spl-program-error 0.5.0",
+ "spl-type-length-value 0.5.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5000,7 +5000,7 @@ dependencies = [
  "spl-token 4.0.1",
  "spl-token-2022 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token-group-interface 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token-metadata-interface 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-metadata-interface 0.3.3",
  "thiserror",
  "zstd",
 ]
@@ -6527,7 +6527,7 @@ dependencies = [
  "spl-token 4.0.1",
  "spl-token-2022 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token-group-interface 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token-metadata-interface 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-metadata-interface 0.3.3",
  "thiserror",
 ]
 
@@ -7529,7 +7529,7 @@ dependencies = [
  "spl-tlv-account-resolution 0.7.0",
  "spl-token 6.0.0",
  "spl-token-group-interface 0.2.3",
- "spl-token-metadata-interface 0.3.3",
+ "spl-token-metadata-interface 0.4.0",
  "spl-transfer-hook-interface 0.6.3",
  "spl-type-length-value 0.5.0",
  "thiserror",
@@ -7553,7 +7553,7 @@ dependencies = [
  "spl-pod 0.2.2",
  "spl-token 4.0.1",
  "spl-token-group-interface 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token-metadata-interface 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-metadata-interface 0.3.3",
  "spl-transfer-hook-interface 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-type-length-value 0.4.3",
  "thiserror",
@@ -7577,7 +7577,7 @@ dependencies = [
  "spl-token-2022 3.0.2",
  "spl-token-client",
  "spl-token-group-interface 0.2.3",
- "spl-token-metadata-interface 0.3.3",
+ "spl-token-metadata-interface 0.4.0",
  "spl-transfer-hook-example",
  "spl-transfer-hook-interface 0.6.3",
  "test-case",
@@ -7614,7 +7614,7 @@ dependencies = [
  "spl-token-2022 3.0.2",
  "spl-token-client",
  "spl-token-group-interface 0.2.3",
- "spl-token-metadata-interface 0.3.3",
+ "spl-token-metadata-interface 0.4.0",
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "tempfile",
@@ -7641,7 +7641,7 @@ dependencies = [
  "spl-token 6.0.0",
  "spl-token-2022 3.0.2",
  "spl-token-group-interface 0.2.3",
- "spl-token-metadata-interface 0.3.3",
+ "spl-token-metadata-interface 0.4.0",
  "spl-transfer-hook-interface 0.6.3",
  "thiserror",
 ]
@@ -7660,7 +7660,7 @@ dependencies = [
  "spl-token-client",
  "spl-token-group-example",
  "spl-token-group-interface 0.2.3",
- "spl-token-metadata-interface 0.3.3",
+ "spl-token-metadata-interface 0.4.0",
  "spl-type-length-value 0.5.0",
 ]
 
@@ -7676,7 +7676,7 @@ dependencies = [
  "spl-token-2022 3.0.2",
  "spl-token-client",
  "spl-token-group-interface 0.2.3",
- "spl-token-metadata-interface 0.3.3",
+ "spl-token-metadata-interface 0.4.0",
  "spl-type-length-value 0.5.0",
 ]
 
@@ -7748,23 +7748,9 @@ dependencies = [
  "spl-pod 0.3.0",
  "spl-token-2022 3.0.2",
  "spl-token-client",
- "spl-token-metadata-interface 0.3.3",
+ "spl-token-metadata-interface 0.4.0",
  "spl-type-length-value 0.5.0",
  "test-case",
-]
-
-[[package]]
-name = "spl-token-metadata-interface"
-version = "0.3.3"
-dependencies = [
- "borsh 1.5.1",
- "serde",
- "serde_json",
- "solana-program",
- "spl-discriminator 0.3.0",
- "spl-pod 0.3.0",
- "spl-program-error 0.5.0",
- "spl-type-length-value 0.5.0",
 ]
 
 [[package]]
@@ -7779,6 +7765,20 @@ dependencies = [
  "spl-pod 0.2.2",
  "spl-program-error 0.4.1",
  "spl-type-length-value 0.4.3",
+]
+
+[[package]]
+name = "spl-token-metadata-interface"
+version = "0.4.0"
+dependencies = [
+ "borsh 1.5.1",
+ "serde",
+ "serde_json",
+ "solana-program",
+ "spl-discriminator 0.3.0",
+ "spl-pod 0.3.0",
+ "spl-program-error 0.5.0",
+ "spl-type-length-value 0.5.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7530,7 +7530,7 @@ dependencies = [
  "spl-token 6.0.0",
  "spl-token-group-interface 0.3.0",
  "spl-token-metadata-interface 0.4.0",
- "spl-transfer-hook-interface 0.6.3",
+ "spl-transfer-hook-interface 0.7.0",
  "spl-type-length-value 0.5.0",
  "thiserror",
 ]
@@ -7554,7 +7554,7 @@ dependencies = [
  "spl-token 4.0.1",
  "spl-token-group-interface 0.2.3",
  "spl-token-metadata-interface 0.3.3",
- "spl-transfer-hook-interface 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-transfer-hook-interface 0.6.3",
  "spl-type-length-value 0.4.3",
  "thiserror",
 ]
@@ -7579,7 +7579,7 @@ dependencies = [
  "spl-token-group-interface 0.3.0",
  "spl-token-metadata-interface 0.4.0",
  "spl-transfer-hook-example",
- "spl-transfer-hook-interface 0.6.3",
+ "spl-transfer-hook-interface 0.7.0",
  "test-case",
  "walkdir",
 ]
@@ -7642,7 +7642,7 @@ dependencies = [
  "spl-token-2022 3.0.2",
  "spl-token-group-interface 0.3.0",
  "spl-token-metadata-interface 0.4.0",
- "spl-transfer-hook-interface 0.6.3",
+ "spl-transfer-hook-interface 0.7.0",
  "thiserror",
 ]
 
@@ -7885,7 +7885,7 @@ dependencies = [
  "spl-token-2022 3.0.2",
  "spl-token-client",
  "spl-transfer-hook-example",
- "spl-transfer-hook-interface 0.6.3",
+ "spl-transfer-hook-interface 0.7.0",
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "tokio",
@@ -7901,23 +7901,8 @@ dependencies = [
  "solana-sdk",
  "spl-tlv-account-resolution 0.7.0",
  "spl-token-2022 3.0.2",
- "spl-transfer-hook-interface 0.6.3",
+ "spl-transfer-hook-interface 0.7.0",
  "spl-type-length-value 0.5.0",
-]
-
-[[package]]
-name = "spl-transfer-hook-interface"
-version = "0.6.3"
-dependencies = [
- "arrayref",
- "bytemuck",
- "solana-program",
- "spl-discriminator 0.3.0",
- "spl-pod 0.3.0",
- "spl-program-error 0.5.0",
- "spl-tlv-account-resolution 0.7.0",
- "spl-type-length-value 0.5.0",
- "tokio",
 ]
 
 [[package]]
@@ -7934,6 +7919,21 @@ dependencies = [
  "spl-program-error 0.4.1",
  "spl-tlv-account-resolution 0.6.3",
  "spl-type-length-value 0.4.3",
+]
+
+[[package]]
+name = "spl-transfer-hook-interface"
+version = "0.7.0"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator 0.3.0",
+ "spl-pod 0.3.0",
+ "spl-program-error 0.5.0",
+ "spl-tlv-account-resolution 0.7.0",
+ "spl-type-length-value 0.5.0",
+ "tokio",
 ]
 
 [[package]]

--- a/token-collection/program/Cargo.toml
+++ b/token-collection/program/Cargo.toml
@@ -18,7 +18,7 @@ spl-program-error = { version = "0.5.0" , path = "../../libraries/program-error"
 spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-group-example = { version = "0.2", path = "../../token-group/example", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.2.3", path = "../../token-group/interface" }
-spl-token-metadata-interface = { version = "0.3.3", path = "../../token-metadata/interface" }
+spl-token-metadata-interface = { version = "0.4.0", path = "../../token-metadata/interface" }
 spl-type-length-value = { version = "0.5.0", path = "../../libraries/type-length-value" }
 
 [dev-dependencies]

--- a/token-collection/program/Cargo.toml
+++ b/token-collection/program/Cargo.toml
@@ -17,7 +17,7 @@ spl-pod = { version = "0.3.0", path = "../../libraries/pod" }
 spl-program-error = { version = "0.5.0" , path = "../../libraries/program-error" }
 spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-group-example = { version = "0.2", path = "../../token-group/example", features = ["no-entrypoint"] }
-spl-token-group-interface = { version = "0.2.3", path = "../../token-group/interface" }
+spl-token-group-interface = { version = "0.3.0", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.4.0", path = "../../token-metadata/interface" }
 spl-type-length-value = { version = "0.5.0", path = "../../libraries/type-length-value" }
 

--- a/token-group/example/Cargo.toml
+++ b/token-group/example/Cargo.toml
@@ -23,7 +23,7 @@ solana-program-test = "2.0.0"
 solana-sdk = "2.0.0"
 spl-discriminator = { version = "0.3.0", path = "../../libraries/discriminator" }
 spl-token-client = { version = "0.10.0", path = "../../token/client" }
-spl-token-metadata-interface = { version = "0.3.3", path = "../../token-metadata/interface" }
+spl-token-metadata-interface = { version = "0.4.0", path = "../../token-metadata/interface" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/token-group/example/Cargo.toml
+++ b/token-group/example/Cargo.toml
@@ -15,7 +15,7 @@ test-sbf = []
 solana-program = "2.0.0"
 spl-pod = { version = "0.3.0", path = "../../libraries/pod" }
 spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = ["no-entrypoint"] }
-spl-token-group-interface = { version = "0.2.3", path = "../interface" }
+spl-token-group-interface = { version = "0.3.0", path = "../interface" }
 spl-type-length-value = { version = "0.5.0", path = "../../libraries/type-length-value" }
 
 [dev-dependencies]

--- a/token-group/interface/Cargo.toml
+++ b/token-group/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-group-interface"
-version = "0.2.3"
+version = "0.3.0"
 description = "Solana Program Library Token Group Interface"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token-metadata/example/Cargo.toml
+++ b/token-metadata/example/Cargo.toml
@@ -14,7 +14,7 @@ test-sbf = []
 [dependencies]
 solana-program = "2.0.0"
 spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = ["no-entrypoint"] }
-spl-token-metadata-interface = { version = "0.3.3", path = "../interface" }
+spl-token-metadata-interface = { version = "0.4.0", path = "../interface" }
 spl-type-length-value = { version = "0.5.0" , path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.3.0", path = "../../libraries/pod" }
 

--- a/token-metadata/interface/Cargo.toml
+++ b/token-metadata/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-metadata-interface"
-version = "0.3.3"
+version = "0.4.0"
 description = "Solana Program Library Token Metadata Interface"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -36,7 +36,7 @@ spl-token-2022 = { version = "3.0.2", path = "../program-2022", features = [
 ] }
 spl-token-client = { version = "0.10.0", path = "../client" }
 spl-token-metadata-interface = { version = "0.4.0", path = "../../token-metadata/interface" }
-spl-token-group-interface = { version = "0.2.3", path = "../../token-group/interface" }
+spl-token-group-interface = { version = "0.3.0", path = "../../token-group/interface" }
 spl-associated-token-account = { version = "3.0.2", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -35,7 +35,7 @@ spl-token-2022 = { version = "3.0.2", path = "../program-2022", features = [
   "no-entrypoint",
 ] }
 spl-token-client = { version = "0.10.0", path = "../client" }
-spl-token-metadata-interface = { version = "0.3.3", path = "../../token-metadata/interface" }
+spl-token-metadata-interface = { version = "0.4.0", path = "../../token-metadata/interface" }
 spl-token-group-interface = { version = "0.2.3", path = "../../token-group/interface" }
 spl-associated-token-account = { version = "3.0.2", path = "../../associated-token-account/program", features = [
   "no-entrypoint",

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -31,7 +31,7 @@ spl-token = { version = "6.0", path = "../program", features = [
 ] }
 spl-token-2022 = { version = "3.0.2", path = "../program-2022" }
 spl-token-group-interface = { version = "0.2.3", path = "../../token-group/interface" }
-spl-token-metadata-interface = { version = "0.3.3", path = "../../token-metadata/interface" }
+spl-token-metadata-interface = { version = "0.4.0", path = "../../token-metadata/interface" }
 spl-transfer-hook-interface = { version = "0.6.3", path = "../transfer-hook/interface" }
 thiserror = "1.0"
 

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -32,7 +32,7 @@ spl-token = { version = "6.0", path = "../program", features = [
 spl-token-2022 = { version = "3.0.2", path = "../program-2022" }
 spl-token-group-interface = { version = "0.3.0", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.4.0", path = "../../token-metadata/interface" }
-spl-transfer-hook-interface = { version = "0.6.3", path = "../transfer-hook/interface" }
+spl-transfer-hook-interface = { version = "0.7.0", path = "../transfer-hook/interface" }
 thiserror = "1.0"
 
 [features]

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -30,7 +30,7 @@ spl-token = { version = "6.0", path = "../program", features = [
   "no-entrypoint",
 ] }
 spl-token-2022 = { version = "3.0.2", path = "../program-2022" }
-spl-token-group-interface = { version = "0.2.3", path = "../../token-group/interface" }
+spl-token-group-interface = { version = "0.3.0", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.4.0", path = "../../token-metadata/interface" }
 spl-transfer-hook-interface = { version = "0.6.3", path = "../transfer-hook/interface" }
 thiserror = "1.0"

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -40,5 +40,5 @@ spl-token-metadata-interface = { version = "0.4.0", path = "../../token-metadata
 spl-transfer-hook-example = { version = "0.6", path = "../transfer-hook/example", features = [
   "no-entrypoint",
 ] }
-spl-transfer-hook-interface = { version = "0.6.3", path = "../transfer-hook/interface" }
+spl-transfer-hook-interface = { version = "0.7.0", path = "../transfer-hook/interface" }
 test-case = "3.3"

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -36,7 +36,7 @@ spl-instruction-padding = { version = "0.2.0", path = "../../instruction-padding
 spl-tlv-account-resolution = { version = "0.7.0", path = "../../libraries/tlv-account-resolution" }
 spl-token-client = { version = "0.10.0", path = "../client" }
 spl-token-group-interface = { version = "0.2.3", path = "../../token-group/interface" }
-spl-token-metadata-interface = { version = "0.3.3", path = "../../token-metadata/interface" }
+spl-token-metadata-interface = { version = "0.4.0", path = "../../token-metadata/interface" }
 spl-transfer-hook-example = { version = "0.6", path = "../transfer-hook/example", features = [
   "no-entrypoint",
 ] }

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -35,7 +35,7 @@ spl-instruction-padding = { version = "0.2.0", path = "../../instruction-padding
 ] }
 spl-tlv-account-resolution = { version = "0.7.0", path = "../../libraries/tlv-account-resolution" }
 spl-token-client = { version = "0.10.0", path = "../client" }
-spl-token-group-interface = { version = "0.2.3", path = "../../token-group/interface" }
+spl-token-group-interface = { version = "0.3.0", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.4.0", path = "../../token-metadata/interface" }
 spl-transfer-hook-example = { version = "0.6", path = "../transfer-hook/example", features = [
   "no-entrypoint",

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -31,7 +31,7 @@ solana-security-txt = "1.1.1"
 solana-zk-token-sdk = "2.0.0"
 spl-memo = { version = "5.0", path = "../../memo/program", features = [ "no-entrypoint" ] }
 spl-token = { version = "6.0",  path = "../program", features = ["no-entrypoint"] }
-spl-token-group-interface = { version = "0.2.3", path = "../../token-group/interface" }
+spl-token-group-interface = { version = "0.3.0", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.4.0", path = "../../token-metadata/interface" }
 spl-transfer-hook-interface = { version = "0.6.3", path = "../transfer-hook/interface" }
 spl-type-length-value = { version = "0.5.0", path = "../../libraries/type-length-value" }

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -32,7 +32,7 @@ solana-zk-token-sdk = "2.0.0"
 spl-memo = { version = "5.0", path = "../../memo/program", features = [ "no-entrypoint" ] }
 spl-token = { version = "6.0",  path = "../program", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.2.3", path = "../../token-group/interface" }
-spl-token-metadata-interface = { version = "0.3.3", path = "../../token-metadata/interface" }
+spl-token-metadata-interface = { version = "0.4.0", path = "../../token-metadata/interface" }
 spl-transfer-hook-interface = { version = "0.6.3", path = "../transfer-hook/interface" }
 spl-type-length-value = { version = "0.5.0", path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.3.0", path = "../../libraries/pod" }

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -33,7 +33,7 @@ spl-memo = { version = "5.0", path = "../../memo/program", features = [ "no-entr
 spl-token = { version = "6.0",  path = "../program", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.3.0", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.4.0", path = "../../token-metadata/interface" }
-spl-transfer-hook-interface = { version = "0.6.3", path = "../transfer-hook/interface" }
+spl-transfer-hook-interface = { version = "0.7.0", path = "../transfer-hook/interface" }
 spl-type-length-value = { version = "0.5.0", path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.3.0", path = "../../libraries/pod" }
 thiserror = "1.0"

--- a/token/transfer-hook/cli/Cargo.toml
+++ b/token/transfer-hook/cli/Cargo.toml
@@ -17,8 +17,8 @@ solana-client = "2.0.0"
 solana-logger = "2.0.0"
 solana-remote-wallet = "2.0.0"
 solana-sdk = "2.0.0"
-spl-transfer-hook-interface = { version = "0.6.3", path = "../interface" }
 spl-tlv-account-resolution = { version = "0.7.0" , path = "../../../libraries/tlv-account-resolution", features = ["serde-traits"] }
+spl-transfer-hook-interface = { version = "0.7.0", path = "../interface" }
 strum = "0.26"
 strum_macros = "0.26"
 tokio = { version = "1", features = ["full"] }

--- a/token/transfer-hook/example/Cargo.toml
+++ b/token/transfer-hook/example/Cargo.toml
@@ -18,7 +18,7 @@ arrayref = "0.3.7"
 solana-program = "2.0.0"
 spl-tlv-account-resolution = { version = "0.7.0" , path = "../../../libraries/tlv-account-resolution" }
 spl-token-2022 = { version = "3.0.2",  path = "../../program-2022", features = ["no-entrypoint"] }
-spl-transfer-hook-interface = { version = "0.6.3" , path = "../interface" }
+spl-transfer-hook-interface = { version = "0.7.0" , path = "../interface" }
 spl-type-length-value = { version = "0.5.0" , path = "../../../libraries/type-length-value" }
 
 [dev-dependencies]

--- a/token/transfer-hook/interface/Cargo.toml
+++ b/token/transfer-hook/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-transfer-hook-interface"
-version = "0.6.3"
+version = "0.7.0"
 description = "Solana Program Library Transfer Hook Interface"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"


### PR DESCRIPTION
#### Problem

As part of #6897, we need to release new major versions of many crates.

#### Solution

Bump spl-token-metadata-interface, spl-token-group-interface, and spl-transfer-hook-interface for the next release