### PR TITLE
token-2022: Bump to v4 for Solana v2 compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4998,7 +4998,7 @@ dependencies = [
  "solana-config-program",
  "solana-sdk",
  "spl-token 4.0.1",
- "spl-token-2022 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-2022 3.0.2",
  "spl-token-group-interface 0.2.3",
  "spl-token-metadata-interface 0.3.3",
  "thiserror",
@@ -5643,7 +5643,7 @@ dependencies = [
  "solana-vote",
  "solana-vote-program",
  "spl-token 4.0.1",
- "spl-token-2022 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-2022 3.0.2",
  "static_assertions",
  "strum 0.24.1",
  "strum_macros 0.24.3",
@@ -6040,7 +6040,7 @@ dependencies = [
  "solana-vote",
  "solana-vote-program",
  "spl-token 4.0.1",
- "spl-token-2022 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-2022 3.0.2",
  "stream-cancel",
  "thiserror",
  "tokio",
@@ -6525,7 +6525,7 @@ dependencies = [
  "spl-associated-token-account 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-memo 4.0.1",
  "spl-token 4.0.1",
- "spl-token-2022 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-2022 3.0.2",
  "spl-token-group-interface 0.2.3",
  "spl-token-metadata-interface 0.3.3",
  "thiserror",
@@ -6827,7 +6827,7 @@ dependencies = [
  "num-traits",
  "solana-program",
  "spl-token 6.0.0",
- "spl-token-2022 3.0.2",
+ "spl-token-2022 4.0.0",
  "thiserror",
 ]
 
@@ -6843,7 +6843,7 @@ dependencies = [
  "num-traits",
  "solana-program",
  "spl-token 4.0.1",
- "spl-token-2022 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-2022 3.0.2",
  "thiserror",
 ]
 
@@ -6856,7 +6856,7 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account 3.0.2",
  "spl-token 6.0.0",
- "spl-token-2022 3.0.2",
+ "spl-token-2022 4.0.0",
 ]
 
 [[package]]
@@ -7408,7 +7408,7 @@ dependencies = [
  "spl-math",
  "spl-pod 0.3.0",
  "spl-token 6.0.0",
- "spl-token-2022 3.0.2",
+ "spl-token-2022 4.0.0",
  "test-case",
  "thiserror",
 ]
@@ -7506,6 +7506,30 @@ dependencies = [
 [[package]]
 name = "spl-token-2022"
 version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5412f99ae7ee6e0afde00defaa354e6228e47e30c0e3adf553e2e01e6abb584"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-program",
+ "solana-security-txt",
+ "solana-zk-token-sdk",
+ "spl-memo 4.0.1",
+ "spl-pod 0.2.2",
+ "spl-token 4.0.1",
+ "spl-token-group-interface 0.2.3",
+ "spl-token-metadata-interface 0.3.3",
+ "spl-transfer-hook-interface 0.6.3",
+ "spl-type-length-value 0.4.3",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-token-2022"
+version = "4.0.0"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -7536,30 +7560,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-token-2022"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5412f99ae7ee6e0afde00defaa354e6228e47e30c0e3adf553e2e01e6abb584"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "num_enum",
- "solana-program",
- "solana-security-txt",
- "solana-zk-token-sdk",
- "spl-memo 4.0.1",
- "spl-pod 0.2.2",
- "spl-token 4.0.1",
- "spl-token-group-interface 0.2.3",
- "spl-token-metadata-interface 0.3.3",
- "spl-transfer-hook-interface 0.6.3",
- "spl-type-length-value 0.4.3",
- "thiserror",
-]
-
-[[package]]
 name = "spl-token-2022-test"
 version = "0.0.1"
 dependencies = [
@@ -7574,7 +7574,7 @@ dependencies = [
  "spl-memo 5.0.0",
  "spl-pod 0.3.0",
  "spl-tlv-account-resolution 0.7.0",
- "spl-token-2022 3.0.2",
+ "spl-token-2022 4.0.0",
  "spl-token-client",
  "spl-token-group-interface 0.3.0",
  "spl-token-metadata-interface 0.4.0",
@@ -7611,7 +7611,7 @@ dependencies = [
  "spl-associated-token-account 3.0.2",
  "spl-memo 5.0.0",
  "spl-token 6.0.0",
- "spl-token-2022 3.0.2",
+ "spl-token-2022 4.0.0",
  "spl-token-client",
  "spl-token-group-interface 0.3.0",
  "spl-token-metadata-interface 0.4.0",
@@ -7639,7 +7639,7 @@ dependencies = [
  "spl-associated-token-account 3.0.2",
  "spl-memo 5.0.0",
  "spl-token 6.0.0",
- "spl-token-2022 3.0.2",
+ "spl-token-2022 4.0.0",
  "spl-token-group-interface 0.3.0",
  "spl-token-metadata-interface 0.4.0",
  "spl-transfer-hook-interface 0.7.0",
@@ -7656,7 +7656,7 @@ dependencies = [
  "spl-discriminator 0.3.0",
  "spl-pod 0.3.0",
  "spl-program-error 0.5.0",
- "spl-token-2022 3.0.2",
+ "spl-token-2022 4.0.0",
  "spl-token-client",
  "spl-token-group-example",
  "spl-token-group-interface 0.3.0",
@@ -7673,7 +7673,7 @@ dependencies = [
  "solana-sdk",
  "spl-discriminator 0.3.0",
  "spl-pod 0.3.0",
- "spl-token-2022 3.0.2",
+ "spl-token-2022 4.0.0",
  "spl-token-client",
  "spl-token-group-interface 0.3.0",
  "spl-token-metadata-interface 0.4.0",
@@ -7746,7 +7746,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-pod 0.3.0",
- "spl-token-2022 3.0.2",
+ "spl-token-2022 4.0.0",
  "spl-token-client",
  "spl-token-metadata-interface 0.4.0",
  "spl-type-length-value 0.5.0",
@@ -7796,7 +7796,7 @@ dependencies = [
  "solana-sdk",
  "spl-math",
  "spl-token 6.0.0",
- "spl-token-2022 3.0.2",
+ "spl-token-2022 4.0.0",
  "test-case",
  "thiserror",
 ]
@@ -7824,7 +7824,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-token 6.0.0",
- "spl-token-2022 3.0.2",
+ "spl-token-2022 4.0.0",
  "spl-token-client",
  "test-case",
  "thiserror",
@@ -7845,7 +7845,7 @@ dependencies = [
  "solana-test-validator",
  "spl-associated-token-account 3.0.2",
  "spl-token 6.0.0",
- "spl-token-2022 3.0.2",
+ "spl-token-2022 4.0.0",
  "spl-token-client",
  "spl-token-upgrade",
  "tokio",
@@ -7861,7 +7861,7 @@ dependencies = [
  "solana-program",
  "spl-associated-token-account 3.0.2",
  "spl-token 6.0.0",
- "spl-token-2022 3.0.2",
+ "spl-token-2022 4.0.0",
  "thiserror",
 ]
 
@@ -7882,7 +7882,7 @@ dependencies = [
  "solana-sdk",
  "solana-test-validator",
  "spl-tlv-account-resolution 0.7.0",
- "spl-token-2022 3.0.2",
+ "spl-token-2022 4.0.0",
  "spl-token-client",
  "spl-transfer-hook-example",
  "spl-transfer-hook-interface 0.7.0",
@@ -7900,7 +7900,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-tlv-account-resolution 0.7.0",
- "spl-token-2022 3.0.2",
+ "spl-token-2022 4.0.0",
  "spl-transfer-hook-interface 0.7.0",
  "spl-type-length-value 0.5.0",
 ]

--- a/associated-token-account/program-test/Cargo.toml
+++ b/associated-token-account/program-test/Cargo.toml
@@ -16,4 +16,4 @@ solana-program-test = "2.0.0"
 solana-sdk = "2.0.0"
 spl-associated-token-account = { version = "3.0.2", path = "../program", features = ["no-entrypoint"] }
 spl-token = { version = "6.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "4.0.0", path = "../../token/program-2022", features = ["no-entrypoint"] }

--- a/associated-token-account/program/Cargo.toml
+++ b/associated-token-account/program/Cargo.toml
@@ -20,7 +20,7 @@ solana-program = "2.0.0"
 spl-token = { version = "6.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
-spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = [
+spl-token-2022 = { version = "4.0.0", path = "../../token/program-2022", features = [
   "no-entrypoint",
 ] }
 thiserror = "1.0"

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -28,7 +28,7 @@ spl-math = { version = "0.2", path = "../../libraries/math", features = [
 spl-pod = { version = "0.3.0", path = "../../libraries/pod", features = [
   "borsh",
 ] }
-spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = [
+spl-token-2022 = { version = "4.0.0", path = "../../token/program-2022", features = [
   "no-entrypoint",
 ] }
 thiserror = "1.0"

--- a/token-collection/program/Cargo.toml
+++ b/token-collection/program/Cargo.toml
@@ -15,7 +15,7 @@ test-sbf = []
 solana-program = "2.0.0"
 spl-pod = { version = "0.3.0", path = "../../libraries/pod" }
 spl-program-error = { version = "0.5.0" , path = "../../libraries/program-error" }
-spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "4.0.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-group-example = { version = "0.2", path = "../../token-group/example", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.3.0", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.4.0", path = "../../token-metadata/interface" }

--- a/token-group/example/Cargo.toml
+++ b/token-group/example/Cargo.toml
@@ -14,7 +14,7 @@ test-sbf = []
 [dependencies]
 solana-program = "2.0.0"
 spl-pod = { version = "0.3.0", path = "../../libraries/pod" }
-spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "4.0.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.3.0", path = "../interface" }
 spl-type-length-value = { version = "0.5.0", path = "../../libraries/type-length-value" }
 

--- a/token-metadata/example/Cargo.toml
+++ b/token-metadata/example/Cargo.toml
@@ -13,7 +13,7 @@ test-sbf = []
 
 [dependencies]
 solana-program = "2.0.0"
-spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "4.0.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-metadata-interface = { version = "0.4.0", path = "../interface" }
 spl-type-length-value = { version = "0.5.0" , path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.3.0", path = "../../libraries/pod" }

--- a/token-swap/program/Cargo.toml
+++ b/token-swap/program/Cargo.toml
@@ -20,7 +20,7 @@ num-traits = "0.2"
 solana-program = "2.0.0"
 spl-math = { version = "0.2", path = "../../libraries/math", features = [ "no-entrypoint" ] }
 spl-token = { version = "6.0", path = "../../token/program", features = [ "no-entrypoint" ] }
-spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
+spl-token-2022 = { version = "4.0.0", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 arbitrary = { version = "1.3", features = ["derive"], optional = true }
 roots = { version = "0.0.8", optional = true }

--- a/token-upgrade/cli/Cargo.toml
+++ b/token-upgrade/cli/Cargo.toml
@@ -21,7 +21,7 @@ solana-remote-wallet = "2.0.0"
 solana-sdk = "2.0.0"
 spl-associated-token-account = { version = "3.0.2", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token = { version = "6.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "4.0.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.10.0", path = "../../token/client" }
 spl-token-upgrade = { version = "0.1", path = "../program", features = ["no-entrypoint"] }
 tokio = { version = "1", features = ["full"] }

--- a/token-upgrade/program/Cargo.toml
+++ b/token-upgrade/program/Cargo.toml
@@ -16,7 +16,7 @@ num-derive = "0.4"
 num-traits = "0.2"
 num_enum = "0.7.2"
 solana-program = "2.0.0"
-spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "4.0.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/token-wrap/program/Cargo.toml
+++ b/token-wrap/program/Cargo.toml
@@ -17,7 +17,7 @@ num_enum = "0.7"
 solana-program = "2.0.0"
 spl-associated-token-account = { version = "3.0.2", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token = { version = "6.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "3.0.2", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "4.0.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [lib]

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -31,7 +31,7 @@ solana-transaction-status = "2.0.0"
 spl-token = { version = "6.0", path = "../program", features = [
   "no-entrypoint",
 ] }
-spl-token-2022 = { version = "3.0.2", path = "../program-2022", features = [
+spl-token-2022 = { version = "4.0.0", path = "../program-2022", features = [
   "no-entrypoint",
 ] }
 spl-token-client = { version = "0.10.0", path = "../client" }

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -29,7 +29,7 @@ spl-memo = { version = "5.0", path = "../../memo/program", features = [
 spl-token = { version = "6.0", path = "../program", features = [
   "no-entrypoint",
 ] }
-spl-token-2022 = { version = "3.0.2", path = "../program-2022" }
+spl-token-2022 = { version = "4.0.0", path = "../program-2022" }
 spl-token-group-interface = { version = "0.3.0", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.4.0", path = "../../token-metadata/interface" }
 spl-transfer-hook-interface = { version = "0.7.0", path = "../transfer-hook/interface" }

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -27,7 +27,7 @@ spl-memo = { version = "5.0.0", path = "../../memo/program", features = [
   "no-entrypoint",
 ] }
 spl-pod = { version = "0.3.0", path = "../../libraries/pod" }
-spl-token-2022 = { version = "3.0.2", path = "../program-2022", features = [
+spl-token-2022 = { version = "4.0.0", path = "../program-2022", features = [
   "no-entrypoint",
 ] }
 spl-instruction-padding = { version = "0.2.0", path = "../../instruction-padding/program", features = [

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-2022"
-version = "3.0.2"
+version = "4.0.0"
 description = "Solana Program Library Token 2022"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token/transfer-hook/cli/Cargo.toml
+++ b/token/transfer-hook/cli/Cargo.toml
@@ -28,7 +28,7 @@ serde_yaml = "0.9.34"
 
 [dev-dependencies]
 solana-test-validator = "2.0.0"
-spl-token-2022 = { version = "3.0.2", path = "../../program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "4.0.0", path = "../../program-2022", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.10.0", path = "../../client" }
 spl-transfer-hook-example = { version = "0.6.0", path = "../example" }
 

--- a/token/transfer-hook/example/Cargo.toml
+++ b/token/transfer-hook/example/Cargo.toml
@@ -17,7 +17,7 @@ forbid-additional-mints = []
 arrayref = "0.3.7"
 solana-program = "2.0.0"
 spl-tlv-account-resolution = { version = "0.7.0" , path = "../../../libraries/tlv-account-resolution" }
-spl-token-2022 = { version = "3.0.2",  path = "../../program-2022", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "4.0.0",  path = "../../program-2022", features = ["no-entrypoint"] }
 spl-transfer-hook-interface = { version = "0.7.0" , path = "../interface" }
 spl-type-length-value = { version = "0.5.0" , path = "../../../libraries/type-length-value" }
 


### PR DESCRIPTION
#### Problem

As part of #6897, we need to release new major versions of many crates.

#### Solution

Bump spl-token-2022 for the next release