### PR TITLE
token-client: Bump to v0.11 for Solana v2 compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7624,7 +7624,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-client"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "curve25519-dalek",

--- a/single-pool/cli/Cargo.toml
+++ b/single-pool/cli/Cargo.toml
@@ -30,7 +30,7 @@ solana-vote-program = "2.0.0"
 spl-token = { version = "6.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
-spl-token-client = { version = "0.10.0", path = "../../token/client" }
+spl-token-client = { version = "0.11.0", path = "../../token/client" }
 spl-associated-token-account = { version = "4.0.0", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }

--- a/token-collection/program/Cargo.toml
+++ b/token-collection/program/Cargo.toml
@@ -25,7 +25,7 @@ spl-type-length-value = { version = "0.5.0", path = "../../libraries/type-length
 solana-program-test = "2.0.0"
 solana-sdk = "2.0.0"
 spl-discriminator = { version = "0.3.0", path = "../../libraries/discriminator" }
-spl-token-client = { version = "0.10.0", path = "../../token/client" }
+spl-token-client = { version = "0.11.0", path = "../../token/client" }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/token-group/example/Cargo.toml
+++ b/token-group/example/Cargo.toml
@@ -22,7 +22,7 @@ spl-type-length-value = { version = "0.5.0", path = "../../libraries/type-length
 solana-program-test = "2.0.0"
 solana-sdk = "2.0.0"
 spl-discriminator = { version = "0.3.0", path = "../../libraries/discriminator" }
-spl-token-client = { version = "0.10.0", path = "../../token/client" }
+spl-token-client = { version = "0.11.0", path = "../../token/client" }
 spl-token-metadata-interface = { version = "0.4.0", path = "../../token-metadata/interface" }
 
 [lib]

--- a/token-metadata/example/Cargo.toml
+++ b/token-metadata/example/Cargo.toml
@@ -21,7 +21,7 @@ spl-pod = { version = "0.3.0", path = "../../libraries/pod" }
 [dev-dependencies]
 solana-program-test = "2.0.0"
 solana-sdk = "2.0.0"
-spl-token-client = { version = "0.10.0", path = "../../token/client" }
+spl-token-client = { version = "0.11.0", path = "../../token/client" }
 test-case = "3.3"
 
 [lib]

--- a/token-upgrade/cli/Cargo.toml
+++ b/token-upgrade/cli/Cargo.toml
@@ -22,7 +22,7 @@ solana-sdk = "2.0.0"
 spl-associated-token-account = { version = "4.0.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token = { version = "6.0", path = "../../token/program", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "4.0.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
-spl-token-client = { version = "0.10.0", path = "../../token/client" }
+spl-token-client = { version = "0.11.0", path = "../../token/client" }
 spl-token-upgrade = { version = "0.1", path = "../program", features = ["no-entrypoint"] }
 tokio = { version = "1", features = ["full"] }
 

--- a/token-upgrade/program/Cargo.toml
+++ b/token-upgrade/program/Cargo.toml
@@ -23,7 +23,7 @@ thiserror = "1.0"
 solana-program-test = "2.0.0"
 solana-sdk = "2.0.0"
 spl-token = { version = "6.0", path = "../../token/program", features = ["no-entrypoint"] }
-spl-token-client = { version = "0.10.0", path = "../../token/client" }
+spl-token-client = { version = "0.11.0", path = "../../token/client" }
 test-case = "3.3"
 
 [lib]

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -34,7 +34,7 @@ spl-token = { version = "6.0", path = "../program", features = [
 spl-token-2022 = { version = "4.0.0", path = "../program-2022", features = [
   "no-entrypoint",
 ] }
-spl-token-client = { version = "0.10.0", path = "../client" }
+spl-token-client = { version = "0.11.0", path = "../client" }
 spl-token-metadata-interface = { version = "0.4.0", path = "../../token-metadata/interface" }
 spl-token-group-interface = { version = "0.3.0", path = "../../token-group/interface" }
 spl-associated-token-account = { version = "4.0.0", path = "../../associated-token-account/program", features = [

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "spl-token-client"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "0.10.0"
+version = "0.11.0"
 
 [dependencies]
 async-trait = "0.1"

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -34,7 +34,7 @@ spl-instruction-padding = { version = "0.2.0", path = "../../instruction-padding
   "no-entrypoint",
 ] }
 spl-tlv-account-resolution = { version = "0.7.0", path = "../../libraries/tlv-account-resolution" }
-spl-token-client = { version = "0.10.0", path = "../client" }
+spl-token-client = { version = "0.11.0", path = "../client" }
 spl-token-group-interface = { version = "0.3.0", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.4.0", path = "../../token-metadata/interface" }
 spl-transfer-hook-example = { version = "0.6", path = "../transfer-hook/example", features = [

--- a/token/transfer-hook/cli/Cargo.toml
+++ b/token/transfer-hook/cli/Cargo.toml
@@ -29,7 +29,7 @@ serde_yaml = "0.9.34"
 [dev-dependencies]
 solana-test-validator = "2.0.0"
 spl-token-2022 = { version = "4.0.0", path = "../../program-2022", features = ["no-entrypoint"] }
-spl-token-client = { version = "0.10.0", path = "../../client" }
+spl-token-client = { version = "0.11.0", path = "../../client" }
 spl-transfer-hook-example = { version = "0.6.0", path = "../example" }
 
 [[bin]]


### PR DESCRIPTION
#### Problem

As part of #6897, we need to release new major versions of many crates.

#### Solution

Bump spl-token-client for the next release