### PR TITLE
associated-token-account: Bump to v4 for Solana v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6522,7 +6522,7 @@ dependencies = [
  "serde_json",
  "solana-account-decoder",
  "solana-sdk",
- "spl-associated-token-account 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-associated-token-account 3.0.2",
  "spl-memo 4.0.1",
  "spl-token 4.0.1",
  "spl-token-2022 3.0.2",
@@ -6820,20 +6820,6 @@ checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
 [[package]]
 name = "spl-associated-token-account"
 version = "3.0.2"
-dependencies = [
- "assert_matches",
- "borsh 1.5.1",
- "num-derive",
- "num-traits",
- "solana-program",
- "spl-token 6.0.0",
- "spl-token-2022 4.0.0",
- "thiserror",
-]
-
-[[package]]
-name = "spl-associated-token-account"
-version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2e688554bac5838217ffd1fab7845c573ff106b6336bf7d290db7c98d5a8efd"
 dependencies = [
@@ -6848,13 +6834,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-associated-token-account"
+version = "4.0.0"
+dependencies = [
+ "assert_matches",
+ "borsh 1.5.1",
+ "num-derive",
+ "num-traits",
+ "solana-program",
+ "spl-token 6.0.0",
+ "spl-token-2022 4.0.0",
+ "thiserror",
+]
+
+[[package]]
 name = "spl-associated-token-account-test"
 version = "0.0.1"
 dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 3.0.2",
+ "spl-associated-token-account 4.0.0",
  "spl-token 6.0.0",
  "spl-token-2022 4.0.0",
 ]
@@ -7168,7 +7168,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 3.0.2",
+ "spl-associated-token-account 4.0.0",
  "spl-token 6.0.0",
  "thiserror",
 ]
@@ -7346,7 +7346,7 @@ dependencies = [
  "solana-sdk",
  "solana-security-txt",
  "solana-vote-program",
- "spl-associated-token-account 3.0.2",
+ "spl-associated-token-account 4.0.0",
  "spl-token 6.0.0",
  "test-case",
  "thiserror",
@@ -7376,7 +7376,7 @@ dependencies = [
  "solana-test-validator",
  "solana-transaction-status",
  "solana-vote-program",
- "spl-associated-token-account 3.0.2",
+ "spl-associated-token-account 4.0.0",
  "spl-single-pool",
  "spl-token 6.0.0",
  "spl-token-client",
@@ -7433,7 +7433,7 @@ dependencies = [
  "solana-program",
  "solana-remote-wallet",
  "solana-sdk",
- "spl-associated-token-account 3.0.2",
+ "spl-associated-token-account 4.0.0",
  "spl-stake-pool",
  "spl-token 6.0.0",
 ]
@@ -7569,7 +7569,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 3.0.2",
+ "spl-associated-token-account 4.0.0",
  "spl-instruction-padding",
  "spl-memo 5.0.0",
  "spl-pod 0.3.0",
@@ -7608,7 +7608,7 @@ dependencies = [
  "solana-sdk",
  "solana-test-validator",
  "solana-transaction-status",
- "spl-associated-token-account 3.0.2",
+ "spl-associated-token-account 4.0.0",
  "spl-memo 5.0.0",
  "spl-token 6.0.0",
  "spl-token-2022 4.0.0",
@@ -7636,7 +7636,7 @@ dependencies = [
  "solana-rpc-client",
  "solana-rpc-client-api",
  "solana-sdk",
- "spl-associated-token-account 3.0.2",
+ "spl-associated-token-account 4.0.0",
  "spl-memo 5.0.0",
  "spl-token 6.0.0",
  "spl-token-2022 4.0.0",
@@ -7843,7 +7843,7 @@ dependencies = [
  "solana-remote-wallet",
  "solana-sdk",
  "solana-test-validator",
- "spl-associated-token-account 3.0.2",
+ "spl-associated-token-account 4.0.0",
  "spl-token 6.0.0",
  "spl-token-2022 4.0.0",
  "spl-token-client",
@@ -7859,7 +7859,7 @@ dependencies = [
  "bytemuck",
  "num_enum",
  "solana-program",
- "spl-associated-token-account 3.0.2",
+ "spl-associated-token-account 4.0.0",
  "spl-token 6.0.0",
  "spl-token-2022 4.0.0",
  "thiserror",
@@ -7988,7 +7988,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 3.0.2",
+ "spl-associated-token-account 4.0.0",
  "spl-token 6.0.0",
  "thiserror",
 ]

--- a/associated-token-account/program-test/Cargo.toml
+++ b/associated-token-account/program-test/Cargo.toml
@@ -14,6 +14,6 @@ test-sbf = []
 solana-program = "2.0.0"
 solana-program-test = "2.0.0"
 solana-sdk = "2.0.0"
-spl-associated-token-account = { version = "3.0.2", path = "../program", features = ["no-entrypoint"] }
+spl-associated-token-account = { version = "4.0.0", path = "../program", features = ["no-entrypoint"] }
 spl-token = { version = "6.0", path = "../../token/program", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "4.0.0", path = "../../token/program-2022", features = ["no-entrypoint"] }

--- a/associated-token-account/program/Cargo.toml
+++ b/associated-token-account/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-associated-token-account"
-version = "3.0.2"
+version = "4.0.0"
 description = "Solana Program Library Associated Token Account"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/managed-token/program/Cargo.toml
+++ b/managed-token/program/Cargo.toml
@@ -25,7 +25,7 @@ test = []
 borsh = "1.5.1"
 shank = "^0.4.2"
 solana-program = "2.0.0"
-spl-associated-token-account = { version = "3.0.2", path = "../../associated-token-account/program", features = [
+spl-associated-token-account = { version = "4.0.0", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }
 spl-token = { version = "6.0", path = "../../token/program", features = [

--- a/single-pool/cli/Cargo.toml
+++ b/single-pool/cli/Cargo.toml
@@ -31,7 +31,7 @@ spl-token = { version = "6.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
 spl-token-client = { version = "0.10.0", path = "../../token/client" }
-spl-associated-token-account = { version = "3.0.2", path = "../../associated-token-account/program", features = [
+spl-associated-token-account = { version = "4.0.0", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }
 spl-single-pool = { version = "1.0.0", path = "../program", features = [

--- a/single-pool/program/Cargo.toml
+++ b/single-pool/program/Cargo.toml
@@ -22,7 +22,7 @@ solana-security-txt = "1.1.1"
 spl-token = { version = "6.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
-spl-associated-token-account = { version = "3.0.2", path = "../../associated-token-account/program", features = [
+spl-associated-token-account = { version = "4.0.0", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }
 thiserror = "1.0"

--- a/stake-pool/cli/Cargo.toml
+++ b/stake-pool/cli/Cargo.toml
@@ -23,7 +23,7 @@ solana-logger = "2.0.0"
 solana-program = "2.0.0"
 solana-remote-wallet = "2.0.0"
 solana-sdk = "2.0.0"
-spl-associated-token-account = { version = "=3.0.2", path = "../../associated-token-account/program", features = [
+spl-associated-token-account = { version = "=4.0.0", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }
 spl-stake-pool = { version = "=1.0.0", path = "../program", features = [

--- a/stateless-asks/program/Cargo.toml
+++ b/stateless-asks/program/Cargo.toml
@@ -16,7 +16,7 @@ solana-program = "2.0.0"
 spl-token = { version = "6.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
-spl-associated-token-account = { version = "3.0.2", path = "../../associated-token-account/program", features = [
+spl-associated-token-account = { version = "4.0.0", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }
 thiserror = "1.0"

--- a/token-upgrade/cli/Cargo.toml
+++ b/token-upgrade/cli/Cargo.toml
@@ -19,7 +19,7 @@ solana-client = "2.0.0"
 solana-logger = "2.0.0"
 solana-remote-wallet = "2.0.0"
 solana-sdk = "2.0.0"
-spl-associated-token-account = { version = "3.0.2", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
+spl-associated-token-account = { version = "4.0.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token = { version = "6.0", path = "../../token/program", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "4.0.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.10.0", path = "../../token/client" }

--- a/token-wrap/program/Cargo.toml
+++ b/token-wrap/program/Cargo.toml
@@ -15,7 +15,7 @@ test-sbf = []
 bytemuck = { version = "1.16.1", features = ["derive"] }
 num_enum = "0.7"
 solana-program = "2.0.0"
-spl-associated-token-account = { version = "3.0.2", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
+spl-associated-token-account = { version = "4.0.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
 spl-token = { version = "6.0", path = "../../token/program", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "4.0.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -37,7 +37,7 @@ spl-token-2022 = { version = "4.0.0", path = "../program-2022", features = [
 spl-token-client = { version = "0.10.0", path = "../client" }
 spl-token-metadata-interface = { version = "0.4.0", path = "../../token-metadata/interface" }
 spl-token-group-interface = { version = "0.3.0", path = "../../token-group/interface" }
-spl-associated-token-account = { version = "3.0.2", path = "../../associated-token-account/program", features = [
+spl-associated-token-account = { version = "4.0.0", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }
 spl-memo = { version = "5.0", path = "../../memo/program", features = [

--- a/token/client/Cargo.toml
+++ b/token/client/Cargo.toml
@@ -20,7 +20,7 @@ solana-rpc-client-api = "2.0.0"
 solana-sdk = "2.0.0"
 # We never want the entrypoint for ATA, but we want the entrypoint for token when
 # testing token
-spl-associated-token-account = { version = "3.0.2", path = "../../associated-token-account/program", features = [
+spl-associated-token-account = { version = "4.0.0", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }
 spl-memo = { version = "5.0", path = "../../memo/program", features = [

--- a/token/program-2022-test/Cargo.toml
+++ b/token/program-2022-test/Cargo.toml
@@ -22,7 +22,7 @@ futures-util = "0.3"
 solana-program = "2.0.0"
 solana-program-test = "2.0.0"
 solana-sdk = "2.0.0"
-spl-associated-token-account = { version = "3.0.2", path = "../../associated-token-account/program" }
+spl-associated-token-account = { version = "4.0.0", path = "../../associated-token-account/program" }
 spl-memo = { version = "5.0.0", path = "../../memo/program", features = [
   "no-entrypoint",
 ] }


### PR DESCRIPTION
#### Problem

As part of #6897, we need to release new major versions of many crates.

#### Solution

Bump spl-associated-token-account for the next release