### PR TITLE
token-cli: Bump to v4 for Solana v2 compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7586,7 +7586,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-cli"
-version = "3.4.1"
+version = "4.0.0"
 dependencies = [
  "assert_cmd",
  "base64 0.22.1",

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://spl.solana.com/token"
 license = "Apache-2.0"
 name = "spl-token-cli"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "3.4.1"
+version = "4.0.0"
 
 [build-dependencies]
 walkdir = "2"


### PR DESCRIPTION
#### Problem

As part of #6897, we need to release new major versions of many crates.

#### Solution

Bump spl-token-cli for the next release