### PR TITLE
stake-pool: Bump to v2 for Solana v2 compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7381,7 +7381,7 @@ dependencies = [
 
 [[package]]
 name = "spl-stake-pool"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "arrayref",
  "assert_matches",

--- a/stake-pool/cli/Cargo.toml
+++ b/stake-pool/cli/Cargo.toml
@@ -26,7 +26,7 @@ solana-sdk = "2.0.0"
 spl-associated-token-account = { version = "=4.0.0", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }
-spl-stake-pool = { version = "=1.0.0", path = "../program", features = [
+spl-stake-pool = { version = "=2.0.0", path = "../program", features = [
   "no-entrypoint",
 ] }
 spl-token = { version = "=6.0", path = "../../token/program", features = [

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-stake-pool"
-version = "1.0.0"
+version = "2.0.0"
 description = "Solana Program Library Stake Pool"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"


### PR DESCRIPTION
#### Problem

The stake-pool-cli v1 is failing to build due to multiple solana-program versions, same issue that we've been seeing in #6897.

#### Solution

Bump and release the v2 compatible crate