### PR TITLE
stake-pool-cli: Bump to v2 for Solana v2 compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7409,7 +7409,7 @@ dependencies = [
 
 [[package]]
 name = "spl-stake-pool-cli"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "bincode",
  "borsh 1.5.1",

--- a/stake-pool/cli/Cargo.toml
+++ b/stake-pool/cli/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://spl.solana.com/stake-pool"
 license = "Apache-2.0"
 name = "spl-stake-pool-cli"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "1.0.0"
+version = "2.0.0"
 
 [dependencies]
 borsh = "1.5.1"


### PR DESCRIPTION
#### Problem

All of the SPL crates have been bumped up to using the Solana v2 crates, but there hasn't been a new release of the stake pool CLI.

#### Solution

Bump to v2 for the next release