### PR TITLE
[token-upgrade] Remove clap deprecated functions

### DIFF
--- a/token-upgrade/cli/Cargo.toml
+++ b/token-upgrade/cli/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 walkdir = "2"
 
 [dependencies]
-clap = { version = "3", features = ["cargo", "deprecated"] }
+clap = { version = "3", features = ["cargo"] }
 futures-util = "0.3.30"
 solana-clap-v3-utils = "2.0.0"
 solana-cli-config = "2.0.0"

--- a/token-upgrade/cli/Cargo.toml
+++ b/token-upgrade/cli/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 walkdir = "2"
 
 [dependencies]
-clap = { version = "3", features = ["cargo"] }
+clap = { version = "3", features = ["cargo", "deprecated"] }
 futures-util = "0.3.30"
 solana-clap-v3-utils = "2.0.0"
 solana-cli-config = "2.0.0"

--- a/token-upgrade/cli/src/main.rs
+++ b/token-upgrade/cli/src/main.rs
@@ -3,7 +3,7 @@ use {
     solana_clap_v3_utils::{
         input_parsers::{
             parse_url_or_moniker,
-            signer::{try_pubkey_of, SignerSource, SignerSourceParserBuilder},
+            signer::{SignerSource, SignerSourceParserBuilder},
         },
         input_validators::normalize_to_url_if_moniker,
         keypair::{signer_from_path, signer_from_source, SignerFromPathConfig},
@@ -390,10 +390,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     match (command, matches) {
         ("create-escrow", arg_matches) => {
-            let original_mint = try_pubkey_of(arg_matches, "original_mint")
-                .unwrap()
-                .unwrap();
-            let new_mint = try_pubkey_of(arg_matches, "new_mint").unwrap().unwrap();
+            let original_mint =
+                SignerSource::try_get_pubkey(arg_matches, "original_mint", &mut wallet_manager)
+                    .unwrap()
+                    .unwrap();
+            let new_mint =
+                SignerSource::try_get_pubkey(arg_matches, "new_mint", &mut wallet_manager)
+                    .unwrap()
+                    .unwrap();
             let account_keypair =
                 SignerSource::try_get_signer(matches, "account_keypair", &mut wallet_manager)?
                     .map(|(signer, _)| signer);
@@ -435,10 +439,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 }
             }
 
-            let original_mint = try_pubkey_of(arg_matches, "original_mint")
-                .unwrap()
-                .unwrap();
-            let new_mint = try_pubkey_of(arg_matches, "new_mint").unwrap().unwrap();
+            let original_mint =
+                SignerSource::try_get_pubkey(arg_matches, "original_mint", &mut wallet_manager)
+                    .unwrap()
+                    .unwrap();
+            let new_mint =
+                SignerSource::try_get_pubkey(arg_matches, "new_mint", &mut wallet_manager)
+                    .unwrap()
+                    .unwrap();
             let signer_config = SignerFromPathConfig {
                 allow_null_signer: !multisig_pubkeys.is_empty(),
             };
@@ -452,9 +460,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
             if !signer_config.allow_null_signer && !bulk_signers.contains(&owner) {
                 bulk_signers.push(owner.clone());
             }
-            let burn_from = try_pubkey_of(arg_matches, "burn_from").unwrap();
-            let escrow = try_pubkey_of(arg_matches, "escrow").unwrap();
-            let destination = try_pubkey_of(arg_matches, "destination").unwrap();
+            let burn_from =
+                SignerSource::try_get_pubkey(arg_matches, "burn_from", &mut wallet_manager)
+                    .unwrap();
+            let escrow =
+                SignerSource::try_get_pubkey(arg_matches, "escrow", &mut wallet_manager).unwrap();
+            let destination =
+                SignerSource::try_get_pubkey(arg_matches, "destination", &mut wallet_manager)
+                    .unwrap();
 
             let signature = process_exchange(
                 &rpc_client,

--- a/token-upgrade/cli/src/main.rs
+++ b/token-upgrade/cli/src/main.rs
@@ -1,5 +1,5 @@
 use {
-    clap::{crate_description, crate_name, crate_version, Arg, Command},
+    clap::{crate_description, crate_name, crate_version, Arg, ArgAction, Command},
     solana_clap_v3_utils::{
         input_parsers::{
             parse_url_or_moniker,
@@ -336,7 +336,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     .value_parser(SignerSourceParserBuilder::default().allow_all().build())
                     .value_name("MULTISIG_SIGNER")
                     .takes_value(true)
-                    .multiple(true)
+                    .action(ArgAction::Append)
                     .min_values(0)
                     .max_values(spl_token_2022::instruction::MAX_SIGNERS)
                     .help("Member signer of a multisig account")

--- a/token-upgrade/cli/src/main.rs
+++ b/token-upgrade/cli/src/main.rs
@@ -3,12 +3,10 @@ use {
     solana_clap_v3_utils::{
         input_parsers::{
             parse_url_or_moniker,
-            signer::{try_pubkey_of, SignerSourceParserBuilder},
+            signer::{try_pubkey_of, SignerSource, SignerSourceParserBuilder},
         },
         input_validators::normalize_to_url_if_moniker,
-        keypair::{
-            signer_from_path, signer_from_path_with_config, DefaultSigner, SignerFromPathConfig,
-        },
+        keypair::{signer_from_path, signer_from_source, SignerFromPathConfig},
     },
     solana_client::nonblocking::rpc_client::RpcClient,
     solana_remote_wallet::remote_wallet::RemoteWalletManager,
@@ -348,19 +346,24 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let mut wallet_manager: Option<Rc<RemoteWalletManager>> = None;
 
     let config = {
-        let cli_config = if let Some(config_file) = matches.value_of("config_file") {
+        let cli_config = if let Some(config_file) = matches.try_get_one::<String>("config_file")? {
             solana_cli_config::Config::load(config_file).unwrap_or_default()
         } else {
             solana_cli_config::Config::default()
         };
 
-        let payer = DefaultSigner::new(
-            "payer",
-            matches
-                .value_of("payer")
-                .map(|s| s.to_string())
-                .unwrap_or_else(|| cli_config.keypair_path.clone()),
-        );
+        let payer = if let Ok(Some((signer, _))) =
+            SignerSource::try_get_signer(matches, "payer", &mut wallet_manager)
+        {
+            Box::new(signer)
+        } else {
+            signer_from_path(
+                matches,
+                &cli_config.keypair_path,
+                "payer",
+                &mut wallet_manager,
+            )?
+        };
 
         let json_rpc_url = normalize_to_url_if_moniker(
             matches
@@ -370,14 +373,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
         Config {
             commitment_config: CommitmentConfig::confirmed(),
-            payer: Arc::from(
-                payer
-                    .signer_from_path(matches, &mut wallet_manager)
-                    .unwrap_or_else(|err| {
-                        eprintln!("error: {}", err);
-                        exit(1);
-                    }),
-            ),
+            payer: Arc::from(payer),
             json_rpc_url,
             verbose: matches.try_contains_id("verbose")?,
         }
@@ -398,13 +394,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 .unwrap()
                 .unwrap();
             let new_mint = try_pubkey_of(arg_matches, "new_mint").unwrap().unwrap();
-            let account_keypair = matches.value_of("account_keypair").map(|path| {
-                signer_from_path(arg_matches, path, "account_keypair", &mut wallet_manager)
-                    .unwrap_or_else(|err| {
-                        eprintln!("error: account keypair: {}", err);
-                        exit(1);
-                    })
-            });
+            let account_keypair =
+                SignerSource::try_get_signer(matches, "account_keypair", &mut wallet_manager)?
+                    .map(|(signer, _)| signer);
             let response = process_create_escrow_account(
                 &rpc_client,
                 &config.payer,
@@ -422,14 +414,16 @@ async fn main() -> Result<(), Box<dyn Error>> {
         ("exchange", arg_matches) => {
             let mut bulk_signers = vec![config.payer.clone()];
             let mut multisig_pubkeys = vec![];
-            if let Some(values) = arg_matches.values_of("multisig_signer") {
-                for (i, value) in values.enumerate() {
+
+            if let Some(sources) = arg_matches.try_get_many::<SignerSource>("multisig_signer")? {
+                for (i, source) in sources.enumerate() {
                     let name = format!("{}-{}", "multisig_signer", i.saturating_add(1));
-                    let signer = signer_from_path(arg_matches, value, &name, &mut wallet_manager)
-                        .unwrap_or_else(|e| {
-                            eprintln!("error parsing multisig signer: {}", e);
-                            exit(1);
-                        });
+                    let signer =
+                        signer_from_source(arg_matches, source, &name, &mut wallet_manager)
+                            .unwrap_or_else(|e| {
+                                eprint!("error parsing multisig signer: {}", e);
+                                exit(1);
+                            });
                     let signer_pubkey = signer.pubkey();
                     let signer = Arc::from(signer);
                     if !bulk_signers.contains(&signer) {
@@ -448,22 +442,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
             let signer_config = SignerFromPathConfig {
                 allow_null_signer: !multisig_pubkeys.is_empty(),
             };
-            let owner = matches
-                .value_of("owner")
-                .map_or(Ok(config.payer.clone()), |path| {
-                    signer_from_path_with_config(
-                        arg_matches,
-                        path,
-                        "owner",
-                        &mut wallet_manager,
-                        &signer_config,
-                    )
-                    .map(Arc::from)
-                })
-                .unwrap_or_else(|err| {
-                    eprintln!("error: owner signer: {}", err);
-                    exit(1);
-                });
+            let owner = if let Ok(Some((signer, _))) =
+                SignerSource::try_get_signer(matches, "owner", &mut wallet_manager)
+            {
+                Arc::from(signer)
+            } else {
+                config.payer.clone()
+            };
             if !signer_config.allow_null_signer && !bulk_signers.contains(&owner) {
                 bulk_signers.push(owner.clone());
             }

--- a/token-upgrade/cli/src/main.rs
+++ b/token-upgrade/cli/src/main.rs
@@ -379,7 +379,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     }),
             ),
             json_rpc_url,
-            verbose: matches.is_present("verbose"),
+            verbose: matches.try_contains_id("verbose")?,
         }
     };
     solana_logger::setup_with_default("solana=info");


### PR DESCRIPTION
#### Problem
The token-upgrade cli tool still uses some deprecated functions from clap-v2.

#### Summary
Updated the deprecated functions from clap-v2. Most of the changes should be straightforward:
- Replaced `Arg::multiple` with `ArgAction::Append`, which should be functionally identical
- Replaced `is_present` with `try_contains_id`. The old `is_present` panics if the arg is not previously known/defined while `try_contains_id` gives an error. Otherwise, the two functions are identical.
- Replaced `try_pubkey_of` with `SignerSource::try_get_pubkey`. The `try_pubkey_of` internally tries to parse `Pubkey` from `SignerSource`, which unfortunately, solana-clap-v3-utils does not yet support. The `SignerSource::try_get_pubkey` parses `SignerSource` correctly and then extracts `Pubkey` from it.

The only non-trivial change would be replacing `value_of`. This should technically be updated to `try_get_one::<T>(...)` or `get_one::<T>(...)`, but I replaced it with a convenience function `try_get_signer`, which was added with `solana-clap-v3-utils 2.0`. I ended up removing the use of `DefaultSigner` and just added the logic to parse signers directly.

The feature `deprecated` in clap v3 allows us to toggle warnings from the use of deprecated functions. The deprecated functions are all removed from this crate, but other crates in the repo still uses some deprecated functions, so I removed this feature from clap for now.

This is an analogous PR to https://github.com/solana-labs/solana-program-library/pull/6952.