### PR TITLE
[transfer-hook] Remove clap deprecated functions

### DIFF
--- a/token/transfer-hook/cli/Cargo.toml
+++ b/token/transfer-hook/cli/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/solana-labs/solana-program-library"
 version = "0.2.0"
 
 [dependencies]
-clap = { version = "3", features = ["cargo"] }
+clap = { version = "3", features = ["cargo", "deprecated"] }
 futures-util = "0.3.30"
 solana-clap-v3-utils = "2.0.0"
 solana-cli-config = "2.0.0"

--- a/token/transfer-hook/cli/Cargo.toml
+++ b/token/transfer-hook/cli/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/solana-labs/solana-program-library"
 version = "0.2.0"
 
 [dependencies]
-clap = { version = "3", features = ["cargo", "deprecated"] }
+clap = { version = "3", features = ["cargo"] }
 futures-util = "0.3.30"
 solana-clap-v3-utils = "2.0.0"
 solana-cli-config = "2.0.0"

--- a/token/transfer-hook/cli/src/main.rs
+++ b/token/transfer-hook/cli/src/main.rs
@@ -2,7 +2,7 @@ pub mod meta;
 
 use {
     crate::meta::parse_transfer_hook_account_arg,
-    clap::{crate_description, crate_name, crate_version, Arg, Command},
+    clap::{crate_description, crate_name, crate_version, Arg, ArgAction, Command},
     solana_clap_v3_utils::{
         input_parsers::{
             parse_url_or_moniker,
@@ -255,7 +255,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         .value_parser(parse_transfer_hook_account_arg)
                         .value_name("TRANSFER_HOOK_ACCOUNTS")
                         .takes_value(true)
-                        .multiple(true)
+                        .action(ArgAction::Append)
                         .min_values(0)
                         .index(3)
                         .help(r#"Additional account(s) required for a transfer hook and their respective configurations, whether they are a fixed address or PDA.
@@ -339,7 +339,7 @@ extraMetas:
                         .value_parser(parse_transfer_hook_account_arg)
                         .value_name("TRANSFER_HOOK_ACCOUNTS")
                         .takes_value(true)
-                        .multiple(true)
+                        .action(ArgAction::Append)
                         .min_values(0)
                         .index(3)
                         .help(r#"Additional account(s) required for a transfer hook and their respective configurations, whether they are a fixed address or PDA.

--- a/token/transfer-hook/cli/src/main.rs
+++ b/token/transfer-hook/cli/src/main.rs
@@ -233,7 +233,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Command::new("create-extra-metas")
                 .about("Create the extra account metas account for a transfer hook program")
                 .arg(
-                    Arg::with_name("program_id")
+                    Arg::new("program_id")
                         .value_parser(SignerSourceParserBuilder::default().allow_pubkey().allow_file_path().build())
                         .value_name("TRANSFER_HOOK_PROGRAM")
                         .takes_value(true)
@@ -242,7 +242,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         .help("The transfer hook program id"),
                 )
                 .arg(
-                    Arg::with_name("token")
+                    Arg::new("token")
                         .value_parser(SignerSourceParserBuilder::default().allow_pubkey().allow_file_path().build())
                         .value_name("TOKEN_MINT_ADDRESS")
                         .takes_value(true)
@@ -251,7 +251,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         .help("The token mint address for the transfer hook"),
                 )
                 .arg(
-                    Arg::with_name("transfer_hook_accounts")
+                    Arg::new("transfer_hook_accounts")
                         .value_parser(parse_transfer_hook_account_arg)
                         .value_name("TRANSFER_HOOK_ACCOUNTS")
                         .takes_value(true)
@@ -317,7 +317,7 @@ extraMetas:
             Command::new("update-extra-metas")
                 .about("Update the extra account metas account for a transfer hook program")
                 .arg(
-                    Arg::with_name("program_id")
+                    Arg::new("program_id")
                         .value_parser(SignerSourceParserBuilder::default().allow_pubkey().allow_file_path().build())
                         .value_name("TRANSFER_HOOK_PROGRAM")
                         .takes_value(true)
@@ -326,7 +326,7 @@ extraMetas:
                         .help("The transfer hook program id"),
                 )
                 .arg(
-                    Arg::with_name("token")
+                    Arg::new("token")
                         .value_parser(SignerSourceParserBuilder::default().allow_pubkey().allow_file_path().build())
                         .value_name("TOKEN_MINT_ADDRESS")
                         .takes_value(true)
@@ -335,7 +335,7 @@ extraMetas:
                         .help("The token mint address for the transfer hook"),
                 )
                 .arg(
-                    Arg::with_name("transfer_hook_accounts")
+                    Arg::new("transfer_hook_accounts")
                         .value_parser(parse_transfer_hook_account_arg)
                         .value_name("TRANSFER_HOOK_ACCOUNTS")
                         .takes_value(true)

--- a/token/transfer-hook/cli/src/main.rs
+++ b/token/transfer-hook/cli/src/main.rs
@@ -9,7 +9,7 @@ use {
             signer::{SignerSource, SignerSourceParserBuilder},
         },
         input_validators::normalize_to_url_if_moniker,
-        keypair::{pubkey_from_source, signer_from_path},
+        keypair::signer_from_path,
     },
     solana_client::nonblocking::rpc_client::RpcClient,
     solana_remote_wallet::remote_wallet::RemoteWalletManager,
@@ -444,20 +444,11 @@ extraMetas:
 
     match (command, matches) {
         ("create-extra-metas", arg_matches) => {
-            let program_id_source = arg_matches
-                .try_get_one::<SignerSource>("program_id")?
-                .unwrap();
-            let program_id = pubkey_from_source(
-                arg_matches,
-                program_id_source,
-                "program_id",
-                &mut wallet_manager,
-            )
-            .unwrap();
-
-            let token_source = arg_matches.try_get_one::<SignerSource>("token")?.unwrap();
-            let token = pubkey_from_source(arg_matches, token_source, "token", &mut wallet_manager)
-                .unwrap();
+            let program_id =
+                SignerSource::try_get_pubkey(arg_matches, "program_id", &mut wallet_manager)?
+                    .unwrap();
+            let token =
+                SignerSource::try_get_pubkey(arg_matches, "token", &mut wallet_manager)?.unwrap();
 
             let transfer_hook_accounts = arg_matches
                 .get_many::<Vec<ExtraAccountMeta>>("transfer_hook_accounts")
@@ -493,20 +484,11 @@ extraMetas:
             println!("Signature: {signature}");
         }
         ("update-extra-metas", arg_matches) => {
-            let program_id_source = arg_matches
-                .try_get_one::<SignerSource>("program_id")?
-                .unwrap();
-            let program_id = pubkey_from_source(
-                arg_matches,
-                program_id_source,
-                "program_id",
-                &mut wallet_manager,
-            )
-            .unwrap();
-
-            let token_source = arg_matches.try_get_one::<SignerSource>("token")?.unwrap();
-            let token = pubkey_from_source(arg_matches, token_source, "token", &mut wallet_manager)
-                .unwrap();
+            let program_id =
+                SignerSource::try_get_pubkey(arg_matches, "program_id", &mut wallet_manager)?
+                    .unwrap();
+            let token =
+                SignerSource::try_get_pubkey(arg_matches, "token", &mut wallet_manager)?.unwrap();
 
             let transfer_hook_accounts = arg_matches
                 .get_many::<Vec<ExtraAccountMeta>>("transfer_hook_accounts")

--- a/token/transfer-hook/cli/src/main.rs
+++ b/token/transfer-hook/cli/src/main.rs
@@ -431,7 +431,7 @@ extraMetas:
                     exit(1);
                 }),
             json_rpc_url,
-            verbose: matches.is_present("verbose"),
+            verbose: matches.try_contains_id("verbose")?,
         }
     };
     solana_logger::setup_with_default("solana=info");


### PR DESCRIPTION
#### Problem
The transfer hook cli tool still uses some deprecated functions from clap-v2.

#### Summary
Updated the deprecated functions from clap-v2. Most of the changes should be straightforward:
- Replaced `Arg::with_name` to `Arg::new`, which is functionally identical
- Replaced `Arg::multiple` with `ArgAction::Append`, which should be functionally identical
- Replaced `is_present` with `try_contains_id`. The old `is_present` panics if the arg is not previously known/defined while `try_contains_id` gives an error. Otherwise, the two functions are identical.

The only non-trivial change would be replacing `value_of`. This should technically be updated to `try_get_one::<T>(...)` or `get_one::<T>(...)`, but I replaced it with a convenience function `try_get_signer`, which was added with `solana-clap-v3-utils 2.0`. I ended up removing the use of `DefaultSigner` and just added logic to parse signers directly.

I also used `SignerSource::try_get_pubkey` to remove some verbose parsing code (from https://github.com/solana-labs/solana-program-library/pull/6625).

The feature `deprecated` in clap v3 allows us to toggle warnings from the use of deprecated functions. The deprecated functions are all removed from this crate, but the other crates in the repo still uses some deprecated functions, so I removed this feature from clap for now.