### PR TITLE
token-2022: adjust `PodAccount` initialized check

### DIFF
--- a/token/program-2022/src/pod.rs
+++ b/token/program-2022/src/pod.rs
@@ -101,7 +101,7 @@ impl PodAccount {
 }
 impl IsInitialized for PodAccount {
     fn is_initialized(&self) -> bool {
-        self.state != 0
+        self.state == AccountState::Initialized as u8 || self.state == AccountState::Frozen as u8
     }
 }
 impl PackedSizeOf for PodAccount {


### PR DESCRIPTION
#### Problem
The method to determine if a particular `PodAccount` is initialized simply checks
whether or not the `state` field (`AccountState`) is _not_ equal to zero.

However, this means that any number besides `0` is considered to be an initialized
`PodAccount`. This allows arbitrary data with size 165 to be considered a valid token
account. For example, `&[5; 165]` registers as an initialized token account.

#### Summary of Changes
Adjust the `is_initialized` method to explicitly check the two initialized `AccountState`
variants, rather than `!= 0 `.