### PR TITLE
[confidential-transfer] Add withdraw proof generation and extraction

### DIFF
--- a/token/confidential-transfer/proof-extraction/src/lib.rs
+++ b/token/confidential-transfer/proof-extraction/src/lib.rs
@@ -2,3 +2,4 @@ pub mod encryption;
 pub mod errors;
 pub mod transfer;
 pub mod transfer_with_fee;
+pub mod withdraw;

--- a/token/confidential-transfer/proof-extraction/src/withdraw.rs
+++ b/token/confidential-transfer/proof-extraction/src/withdraw.rs
@@ -1,0 +1,53 @@
+use {
+    crate::errors::TokenProofExtractionError,
+    solana_zk_sdk::{
+        encryption::pod::elgamal::{PodElGamalCiphertext, PodElGamalPubkey},
+        zk_elgamal_proof_program::proof_data::{
+            BatchedRangeProofContext, CiphertextCommitmentEqualityProofContext,
+        },
+    },
+};
+
+const REMAINING_BALANCE_BIT_LENGTH: u8 = 64;
+
+pub struct WithdrawProofContext {
+    pub source_pubkey: PodElGamalPubkey,
+    pub remaining_balance_ciphertext: PodElGamalCiphertext,
+}
+
+impl WithdrawProofContext {
+    pub fn verify_and_extract(
+        equality_proof_context: &CiphertextCommitmentEqualityProofContext,
+        range_proof_context: &BatchedRangeProofContext,
+    ) -> Result<Self, TokenProofExtractionError> {
+        let CiphertextCommitmentEqualityProofContext {
+            pubkey: source_pubkey,
+            ciphertext: remaining_balance_ciphertext,
+            commitment: remaining_balance_commitment,
+        } = equality_proof_context;
+
+        let BatchedRangeProofContext {
+            commitments: range_proof_commitments,
+            bit_lengths: range_proof_bit_lengths,
+        } = range_proof_context;
+
+        if range_proof_commitments.is_empty()
+            || range_proof_commitments[0] != *remaining_balance_commitment
+        {
+            return Err(TokenProofExtractionError::PedersenCommitmentMismatch);
+        }
+
+        if range_proof_bit_lengths.is_empty()
+            || range_proof_bit_lengths[0] != REMAINING_BALANCE_BIT_LENGTH
+        {
+            return Err(TokenProofExtractionError::RangeProofLengthMismatch);
+        }
+
+        let context_info = WithdrawProofContext {
+            source_pubkey: *source_pubkey,
+            remaining_balance_ciphertext: *remaining_balance_ciphertext,
+        };
+
+        Ok(context_info)
+    }
+}

--- a/token/confidential-transfer/proof-generation/src/lib.rs
+++ b/token/confidential-transfer/proof-generation/src/lib.rs
@@ -10,6 +10,7 @@ pub mod encryption;
 pub mod errors;
 pub mod transfer;
 pub mod transfer_with_fee;
+pub mod withdraw;
 
 /// The low bit length of the encrypted transfer amount
 pub const TRANSFER_AMOUNT_LO_BITS: usize = 16;

--- a/token/confidential-transfer/proof-generation/src/withdraw.rs
+++ b/token/confidential-transfer/proof-generation/src/withdraw.rs
@@ -1,0 +1,60 @@
+use {
+    crate::errors::TokenProofGenerationError,
+    solana_zk_sdk::{
+        encryption::{
+            elgamal::{ElGamal, ElGamalCiphertext, ElGamalKeypair},
+            pedersen::Pedersen,
+        },
+        zk_elgamal_proof_program::proof_data::{
+            BatchedRangeProofU64Data, CiphertextCommitmentEqualityProofData,
+        },
+    },
+};
+
+const REMAINING_BALANCE_BIT_LENGTH: usize = 64;
+
+pub fn withdraw_proof_data(
+    current_available_balance: &ElGamalCiphertext,
+    current_balance: u64,
+    withdraw_amount: u64,
+    elgamal_keypair: &ElGamalKeypair,
+) -> Result<
+    (
+        CiphertextCommitmentEqualityProofData,
+        BatchedRangeProofU64Data,
+    ),
+    TokenProofGenerationError,
+> {
+    // Calculate the remaining balance after withdraw
+    let remaining_balance = current_balance
+        .checked_sub(withdraw_amount)
+        .ok_or(TokenProofGenerationError::NotEnoughFunds)?;
+
+    // Generate a Pedersen commitment for the remaining balance
+    let (remaining_balance_commitment, remaining_balance_opening) =
+        Pedersen::new(remaining_balance);
+
+    // Compute the remaining balance ciphertext
+    #[allow(clippy::arithmetic_side_effects)]
+    let remaining_balance_ciphertext = current_available_balance - ElGamal::encode(withdraw_amount);
+
+    // Generate proof data
+    let equality_proof_data = CiphertextCommitmentEqualityProofData::new(
+        elgamal_keypair,
+        &remaining_balance_ciphertext,
+        &remaining_balance_commitment,
+        &remaining_balance_opening,
+        remaining_balance,
+    )
+    .map_err(TokenProofGenerationError::from)?;
+
+    let range_proof_data = BatchedRangeProofU64Data::new(
+        vec![&remaining_balance_commitment],
+        vec![remaining_balance],
+        vec![REMAINING_BALANCE_BIT_LENGTH],
+        vec![&remaining_balance_opening],
+    )
+    .map_err(TokenProofGenerationError::from)?;
+
+    Ok((equality_proof_data, range_proof_data))
+}

--- a/token/confidential-transfer/proof-generation/src/withdraw.rs
+++ b/token/confidential-transfer/proof-generation/src/withdraw.rs
@@ -13,18 +13,18 @@ use {
 
 const REMAINING_BALANCE_BIT_LENGTH: usize = 64;
 
+/// Proof data required for a withdraw instruction
+pub struct WithdrawProofData {
+    pub equality_proof_data: CiphertextCommitmentEqualityProofData,
+    pub range_proof_data: BatchedRangeProofU64Data,
+}
+
 pub fn withdraw_proof_data(
     current_available_balance: &ElGamalCiphertext,
     current_balance: u64,
     withdraw_amount: u64,
     elgamal_keypair: &ElGamalKeypair,
-) -> Result<
-    (
-        CiphertextCommitmentEqualityProofData,
-        BatchedRangeProofU64Data,
-    ),
-    TokenProofGenerationError,
-> {
+) -> Result<WithdrawProofData, TokenProofGenerationError> {
     // Calculate the remaining balance after withdraw
     let remaining_balance = current_balance
         .checked_sub(withdraw_amount)
@@ -56,5 +56,8 @@ pub fn withdraw_proof_data(
     )
     .map_err(TokenProofGenerationError::from)?;
 
-    Ok((equality_proof_data, range_proof_data))
+    Ok(WithdrawProofData {
+        equality_proof_data,
+        range_proof_data,
+    })
 }


### PR DESCRIPTION
#### Problem
The withdraw proof logic has not yet been added to the `proof-generation` and `proof-extraction` modules.

#### Summary of changes
Add the withdraw proof logic. The logic should essentially be the same as the one in `split_proof_generation` module in `program-2022`.