### PR TITLE
Make spl-program-ids crate and move declare_id usage in there

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7322,6 +7322,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-program-id"
+version = "1.0.0"
+dependencies = [
+ "solana-program",
+]
+
+[[package]]
 name = "spl-record"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,6 +646,7 @@ dependencies = [
  "arrayref",
  "borsh 1.5.1",
  "solana-program",
+ "spl-program-ids",
  "spl-token 6.0.0",
  "thiserror",
  "uint",
@@ -6858,6 +6859,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "solana-program",
+ "spl-program-ids",
  "spl-token 6.0.0",
  "spl-token-2022 4.0.0",
  "thiserror",
@@ -6885,6 +6887,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
+ "spl-program-ids",
  "spl-token 6.0.0",
  "thiserror",
  "uint",
@@ -7031,6 +7034,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
+ "spl-program-ids",
  "spl-token 6.0.0",
 ]
 
@@ -7173,6 +7177,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
+ "spl-program-ids",
 ]
 
 [[package]]
@@ -7185,6 +7190,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-associated-token-account 4.0.0",
+ "spl-program-ids",
  "spl-token 6.0.0",
  "thiserror",
 ]
@@ -7201,6 +7207,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
+ "spl-program-ids",
  "thiserror",
  "uint",
 ]
@@ -7221,6 +7228,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
+ "spl-program-ids",
 ]
 
 [[package]]
@@ -7241,6 +7249,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
+ "spl-program-ids",
  "thiserror",
 ]
 
@@ -7322,7 +7331,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-program-id"
+name = "spl-program-ids"
 version = "1.0.0"
 dependencies = [
  "solana-program",
@@ -7339,6 +7348,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-pod 0.3.0",
+ "spl-program-ids",
  "thiserror",
 ]
 
@@ -7350,6 +7360,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
+ "spl-program-ids",
 ]
 
 [[package]]
@@ -7370,6 +7381,7 @@ dependencies = [
  "solana-security-txt",
  "solana-vote-program",
  "spl-associated-token-account 4.0.0",
+ "spl-program-ids",
  "spl-token 6.0.0",
  "test-case",
  "thiserror",
@@ -7430,6 +7442,7 @@ dependencies = [
  "solana-vote-program",
  "spl-math",
  "spl-pod 0.3.0",
+ "spl-program-ids",
  "spl-token 6.0.0",
  "spl-token-2022 4.0.0",
  "test-case",
@@ -7523,6 +7536,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
+ "spl-program-ids",
  "thiserror",
 ]
 
@@ -7573,6 +7587,7 @@ dependencies = [
  "solana-zk-token-sdk",
  "spl-memo 5.0.0",
  "spl-pod 0.3.0",
+ "spl-program-ids",
  "spl-tlv-account-resolution 0.7.0",
  "spl-token 6.0.0",
  "spl-token-group-interface 0.3.0",
@@ -7771,6 +7786,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
+ "spl-program-ids",
  "spl-token 6.0.0",
  "thiserror",
  "uint",
@@ -7848,6 +7864,7 @@ dependencies = [
  "solana-program",
  "solana-sdk",
  "spl-math",
+ "spl-program-ids",
  "spl-token 6.0.0",
  "spl-token-2022 4.0.0",
  "test-case",
@@ -7876,6 +7893,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
+ "spl-program-ids",
  "spl-token 6.0.0",
  "spl-token-2022 4.0.0",
  "spl-token-client",
@@ -7913,6 +7931,7 @@ dependencies = [
  "num_enum",
  "solana-program",
  "spl-associated-token-account 4.0.0",
+ "spl-program-ids",
  "spl-token 6.0.0",
  "spl-token-2022 4.0.0",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
   "memo/program",
   "name-service/program",
   "managed-token/program",
+  "program-ids",
   "record/program",
   "shared-memory/program",
   "single-pool/cli",

--- a/account-compression/programs/account-compression/Cargo.toml
+++ b/account-compression/programs/account-compression/Cargo.toml
@@ -25,6 +25,7 @@ spl-concurrent-merkle-tree = { version = "0.3.0", path = "../../../libraries/con
     "sol-log",
 ] }
 spl-noop = { version = "0.2.0", path = "../noop", features = ["no-entrypoint"] }
+spl-program-ids = { version = "1.0.0", path = "../../../program-ids" }
 
 [profile.release]
 overflow-checks = true

--- a/account-compression/programs/account-compression/src/lib.rs
+++ b/account-compression/programs/account-compression/src/lib.rs
@@ -57,7 +57,7 @@ pub use spl_concurrent_merkle_tree::{
     node::Node,
 };
 
-declare_id!("cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK");
+pub use spl_program_ids::spl_account_compression::*;
 
 /// Context for initializing a new SPL ConcurrentMerkleTree
 #[derive(Accounts)]

--- a/account-compression/programs/noop/Cargo.toml
+++ b/account-compression/programs/noop/Cargo.toml
@@ -17,3 +17,4 @@ default = []
 
 [dependencies]
 solana-program = ">=1.18.11,<=2"
+spl-program-ids = { version = "1.0.0", path = "../../../program-ids" }

--- a/account-compression/programs/noop/src/lib.rs
+++ b/account-compression/programs/noop/src/lib.rs
@@ -3,7 +3,7 @@ use solana_program::{
     pubkey::Pubkey,
 };
 
-declare_id!("noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV");
+pub use spl_program_ids::spl_noop::*;
 
 #[cfg(not(feature = "no-entrypoint"))]
 solana_program::entrypoint!(noop);

--- a/associated-token-account/program/Cargo.toml
+++ b/associated-token-account/program/Cargo.toml
@@ -17,6 +17,7 @@ borsh = "1.5.1"
 num-derive = "0.4"
 num-traits = "0.2"
 solana-program = "2.0.0"
+spl-program-ids = { version = "1.0.0", path = "../../program-ids" }
 spl-token = { version = "6.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }

--- a/associated-token-account/program/src/lib.rs
+++ b/associated-token-account/program/src/lib.rs
@@ -8,16 +8,14 @@ pub mod instruction;
 pub mod processor;
 pub mod tools;
 
-// Export current SDK types for downstream users building with a different SDK
-// version
-pub use solana_program;
 use solana_program::{
     instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
     sysvar,
 };
-
-pub use spl_program_ids::spl_associated_token_account::*;
+// Export current SDK types for downstream users building with a different SDK
+// version
+pub use {solana_program, spl_program_ids::spl_associated_token_account::*};
 
 pub(crate) fn get_associated_token_address_and_bump_seed(
     wallet_address: &Pubkey,

--- a/associated-token-account/program/src/lib.rs
+++ b/associated-token-account/program/src/lib.rs
@@ -17,7 +17,7 @@ use solana_program::{
     sysvar,
 };
 
-solana_program::declare_id!("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
+pub use spl_program_ids::spl_associated_token_account::*;
 
 pub(crate) fn get_associated_token_address_and_bump_seed(
     wallet_address: &Pubkey,

--- a/binary-option/program/Cargo.toml
+++ b/binary-option/program/Cargo.toml
@@ -10,6 +10,7 @@ test-sbf = []
 
 [dependencies]
 solana-program = "2.0.0"
+spl-program-ids = { version = "1.0.0", path = "../../program-ids" }
 thiserror = "1.0"
 spl-token = { version = "6.0", path = "../../token/program", features = [
   "no-entrypoint",

--- a/binary-option/program/src/lib.rs
+++ b/binary-option/program/src/lib.rs
@@ -11,4 +11,4 @@ pub mod validation_utils;
 // version
 pub use solana_program;
 
-solana_program::declare_id!("betw959P4WToez4DkuXwNsJszqbpe3HuY56AcG5yevx");
+pub use spl_program_ids::spl_binary_option::*;

--- a/binary-option/program/src/lib.rs
+++ b/binary-option/program/src/lib.rs
@@ -9,6 +9,4 @@ pub mod system_utils;
 pub mod validation_utils;
 // Export current sdk types for downstream users building with a different sdk
 // version
-pub use solana_program;
-
-pub use spl_program_ids::spl_binary_option::*;
+pub use {solana_program, spl_program_ids::spl_binary_option::*};

--- a/binary-oracle-pair/program/Cargo.toml
+++ b/binary-oracle-pair/program/Cargo.toml
@@ -14,6 +14,7 @@ test-sbf = []
 num-derive = "0.4"
 num-traits = "0.2"
 solana-program = "2.0.0"
+spl-program-ids = { version = "1.0.0", path = "../../program-ids" }
 spl-token = { version = "6.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }

--- a/binary-oracle-pair/program/src/lib.rs
+++ b/binary-oracle-pair/program/src/lib.rs
@@ -14,4 +14,4 @@ mod entrypoint;
 pub use solana_program;
 
 // Binary Oracle Pair id
-solana_program::declare_id!("Fd7btgySsrjuo25CJCj7oE7VPMyezDhnx7pZkj2v69Nk");
+pub use spl_program_ids::spl_bianry_oracle_pair::*;

--- a/binary-oracle-pair/program/src/lib.rs
+++ b/binary-oracle-pair/program/src/lib.rs
@@ -12,6 +12,5 @@ mod entrypoint;
 // Export current sdk types for downstream users building with a different sdk
 // version
 pub use solana_program;
-
 // Binary Oracle Pair id
 pub use spl_program_ids::spl_bianry_oracle_pair::*;

--- a/feature-proposal/program/Cargo.toml
+++ b/feature-proposal/program/Cargo.toml
@@ -14,6 +14,7 @@ test-sbf = []
 [dependencies]
 borsh = "1.5.1"
 solana-program = "2.0.0"
+spl-program-ids = { version = "1.0.0", path = "../../program-ids" }
 spl-token = { version = "6.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }

--- a/feature-proposal/program/src/lib.rs
+++ b/feature-proposal/program/src/lib.rs
@@ -7,12 +7,10 @@ pub mod instruction;
 pub mod processor;
 pub mod state;
 
+use solana_program::{program_pack::Pack, pubkey::Pubkey};
 // Export current SDK types for downstream users building with a different SDK
 // version
-pub use solana_program;
-use solana_program::{program_pack::Pack, pubkey::Pubkey};
-
-pub use spl_program_ids::spl_feature_proposal::*;
+pub use {solana_program, spl_program_ids::spl_feature_proposal::*};
 
 pub(crate) fn get_mint_address_with_seed(feature_proposal_address: &Pubkey) -> (Pubkey, u8) {
     Pubkey::find_program_address(&[&feature_proposal_address.to_bytes(), br"mint"], &id())

--- a/feature-proposal/program/src/lib.rs
+++ b/feature-proposal/program/src/lib.rs
@@ -12,7 +12,7 @@ pub mod state;
 pub use solana_program;
 use solana_program::{program_pack::Pack, pubkey::Pubkey};
 
-solana_program::declare_id!("Feat1YXHhH6t1juaWF74WLcfv4XoNocjXA6sPWHNgAse");
+pub use spl_program_ids::spl_feature_proposal::*;
 
 pub(crate) fn get_mint_address_with_seed(feature_proposal_address: &Pubkey) -> (Pubkey, u8) {
     Pubkey::find_program_address(&[&feature_proposal_address.to_bytes(), br"mint"], &id())

--- a/instruction-padding/program/Cargo.toml
+++ b/instruction-padding/program/Cargo.toml
@@ -15,6 +15,7 @@ test-sbf = []
 [dependencies]
 num_enum = "0.7.2"
 solana-program = "2.0.0"
+spl-program-ids = { version = "1.0.0", path = "../../program-ids" }
 
 [dev-dependencies]
 solana-program-test = "2.0.0"

--- a/instruction-padding/program/src/lib.rs
+++ b/instruction-padding/program/src/lib.rs
@@ -3,4 +3,4 @@ pub mod instruction;
 pub mod processor;
 
 pub use solana_program;
-solana_program::declare_id!("iXpADd6AW1k5FaaXum5qHbSqyd7TtoN6AD7suVa83MF");
+pub use spl_program_ids::spl_instruction_padding::*;

--- a/instruction-padding/program/src/lib.rs
+++ b/instruction-padding/program/src/lib.rs
@@ -2,5 +2,4 @@ mod entrypoint;
 pub mod instruction;
 pub mod processor;
 
-pub use solana_program;
-pub use spl_program_ids::spl_instruction_padding::*;
+pub use {solana_program, spl_program_ids::spl_instruction_padding::*};

--- a/libraries/math/Cargo.toml
+++ b/libraries/math/Cargo.toml
@@ -16,6 +16,7 @@ borsh = "1.5.1"
 num-derive = "0.4"
 num-traits = "0.2"
 solana-program = "2.0.0"
+spl-program-ids = { version = "1.0.0", path = "../../program-ids" }
 thiserror = "1.0"
 uint = "0.9"
 

--- a/libraries/math/src/lib.rs
+++ b/libraries/math/src/lib.rs
@@ -12,4 +12,4 @@ pub mod precise_number;
 pub mod processor;
 pub mod uint;
 
-solana_program::declare_id!("Math111111111111111111111111111111111111111");
+pub use spl_program_ids::spl_math::*;

--- a/managed-token/program/Cargo.toml
+++ b/managed-token/program/Cargo.toml
@@ -28,6 +28,7 @@ solana-program = "2.0.0"
 spl-associated-token-account = { version = "4.0.0", path = "../../associated-token-account/program", features = [
   "no-entrypoint",
 ] }
+spl-program-ids = { version = "1.0.0", path = "../../program-ids" }
 spl-token = { version = "6.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }

--- a/managed-token/program/src/lib.rs
+++ b/managed-token/program/src/lib.rs
@@ -1,5 +1,4 @@
 pub use spl_program_ids::spl_managed_token::*;
-
 use {
     borsh::BorshDeserialize,
     solana_program::{

--- a/managed-token/program/src/lib.rs
+++ b/managed-token/program/src/lib.rs
@@ -1,4 +1,4 @@
-solana_program::declare_id!("mTok58Lg4YfcmwqyrDHpf7ogp599WRhzb6PxjaBqAxS");
+pub use spl_program_ids::spl_managed_token::*;
 
 use {
     borsh::BorshDeserialize,

--- a/memo/program/Cargo.toml
+++ b/memo/program/Cargo.toml
@@ -13,6 +13,7 @@ test-sbf = []
 
 [dependencies]
 solana-program = "2.0.0"
+spl-program-ids = { version = "1.0.0", path = "../../program-ids" }
 
 [dev-dependencies]
 solana-program-test = "2.0.0"

--- a/memo/program/src/lib.rs
+++ b/memo/program/src/lib.rs
@@ -15,12 +15,7 @@ use solana_program::{
     pubkey::Pubkey,
 };
 
-/// Legacy symbols from Memo v1
-pub mod v1 {
-    solana_program::declare_id!("Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo");
-}
-
-solana_program::declare_id!("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr");
+pub use spl_program_ids::spl_memo::*;
 
 /// Build a memo instruction, possibly signed
 ///

--- a/memo/program/src/lib.rs
+++ b/memo/program/src/lib.rs
@@ -7,15 +7,13 @@
 mod entrypoint;
 pub mod processor;
 
-// Export current sdk types for downstream users building with a different sdk
-// version
-pub use solana_program;
 use solana_program::{
     instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
 };
-
-pub use spl_program_ids::spl_memo::*;
+// Export current sdk types for downstream users building with a different sdk
+// version
+pub use {solana_program, spl_program_ids::spl_memo::*};
 
 /// Build a memo instruction, possibly signed
 ///

--- a/name-service/program/Cargo.toml
+++ b/name-service/program/Cargo.toml
@@ -18,6 +18,7 @@ test-sbf = []
 
 [dependencies]
 solana-program = "2.0.0"
+spl-program-ids = { version = "1.0.0", path = "../../program-ids" }
 num-traits = "0.2"
 borsh = "1.5.1"
 num-derive = "0.4.2"

--- a/name-service/program/src/lib.rs
+++ b/name-service/program/src/lib.rs
@@ -9,4 +9,4 @@ pub mod state;
 // version
 pub use solana_program;
 
-solana_program::declare_id!("namesLPneVptA9Z5rqUDD9tMTWEJwofgaYwp8cawRkX");
+pub use spl_program_ids::spl_name_service::*;

--- a/name-service/program/src/lib.rs
+++ b/name-service/program/src/lib.rs
@@ -7,6 +7,4 @@ pub mod state;
 
 // Export current sdk types for downstream users building with a different sdk
 // version
-pub use solana_program;
-
-pub use spl_program_ids::spl_name_service::*;
+pub use {solana_program, spl_program_ids::spl_name_service::*};

--- a/program-ids/Cargo.toml
+++ b/program-ids/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "spl-program-id"
+version = "1.0.0"
+description = "Solana Program Library Program IDs"
+authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
+repository = "https://github.com/solana-labs/solana-program-library"
+license = "Apache-2.0"
+edition = "2021"
+
+
+[dependencies]
+solana-program = "2.0.0"

--- a/program-ids/Cargo.toml
+++ b/program-ids/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "spl-program-id"
+name = "spl-program-ids"
 version = "1.0.0"
 description = "Solana Program Library Program IDs"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]

--- a/program-ids/README.md
+++ b/program-ids/README.md
@@ -1,0 +1,10 @@
+# SPL Program IDs
+
+This crate defines program IDs for all SPL programs,
+so you if you can import a program ID without importing
+entire programs.
+
+## Example
+```rust
+use spl_program_ids::token::ID;
+```

--- a/program-ids/src/lib.rs
+++ b/program-ids/src/lib.rs
@@ -8,14 +8,53 @@ macro_rules! delcare_id_mod {
     }
 }
 
-delcare_id_mod!(account_compression, "cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK");
+delcare_id_mod!(spl_account_compression, "cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK");
+delcare_id_mod!(spl_noop, "noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV");
+delcare_id_mod!(spl_associated_token_account, "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
+declare_id_mod!(spl_binary_option, "betw959P4WToez4DkuXwNsJszqbpe3HuY56AcG5yevx");
+declare_id_mod!(spl_bianry_oracle_pair, "Fd7btgySsrjuo25CJCj7oE7VPMyezDhnx7pZkj2v69Nk");
+declare_id_mod!(spl_feature_proposal, "Feat1YXHhH6t1juaWF74WLcfv4XoNocjXA6sPWHNgAse");
+declare_id_mod!(spl_instruction_padding, "iXpADd6AW1k5FaaXum5qHbSqyd7TtoN6AD7suVa83MF");
+declare_id_mod!(spl_math, "Math111111111111111111111111111111111111111");
+declare_id_mod!(spl_managed_token, "mTok58Lg4YfcmwqyrDHpf7ogp599WRhzb6PxjaBqAxS");
+declare_id_mod!(spl_name_service, "namesLPneVptA9Z5rqUDD9tMTWEJwofgaYwp8cawRkX");
+declare_id_mod!(spl_record, "recr1L3PCGKLbckBqMNcJhuuyU1zgo8nBhfLVsJNwr5");
+declare_id_mod!(spl_shared_memory, "shmem4EWT2sPdVGvTZCzXXRAURL9G5vpPxNwSeKhHUL");
+declare_id_mod!(spl_single_pool, "SVSPxpvHdN29nkVg9rPapPNDddN5DipNLRUFhyjFThE");
+declare_id_mod!(spl_stake_pool, "SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy");
+declare_id_mod!(spl_token_lending, "6TvznH3B2e3p2mbhufNBpgSrLx6UkgvxtVQvopEZ2kuH");
+declare_id_mod!(spl_token_swap, "SwapsVeCiPHMUAtzQWZw7RjsKjgCjhwU55QGu4U1Szw");
+declare_id_mod!(spl_token_upgrade, "TkupDoNseygccBCjSsrSpMccjwHfTYwcrjpnDSrFDhC");
+declare_id_mod!(spl_token_wrap, "TwRapQCDhWkZRrDaHfZGuHxkZ91gHDRkyuzNqeU5MgR");
+
+pub mod spl_memo {
+    /// Legacy symbols from Memo v1
+    pub mod v1 {
+        solana_program::declare_id!("Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo");
+    }
+    solana_program::declare_id!("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr");
+}
+
+pub mod spl_token {
+    pub mod native_mint {
+        solana_program::declare_id!("So11111111111111111111111111111111111111112");
+    }
+    solana_program::declare_id!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+}
+
+pub mod spl_token_2022 {
+    pub mod native_mint {
+        solana_program::declare_id!("9pan9bMn5HatX4EJdBwg9VgCa7Uz5HL8N1m5D3NdXejP");
+    }
+    solana_program::declare_id!("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
+}
 
 #[cfg(test)]
 mod tests {
-    use super::account_compression;
+    use super::spl_account_compression;
 
     #[test]
     fn test_declare_id_mod() {
-        assert_eq!(account_compression::ID.to_string(), "cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK");
+        assert_eq!(spl_account_compression::ID.to_string(), "cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK");
     }
 }

--- a/program-ids/src/lib.rs
+++ b/program-ids/src/lib.rs
@@ -8,9 +8,9 @@ macro_rules! declare_id_mod {
     }
 }
 
-delcare_id_mod!(spl_account_compression, "cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK");
-delcare_id_mod!(spl_noop, "noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV");
-delcare_id_mod!(spl_associated_token_account, "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
+declare_id_mod!(spl_account_compression, "cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK");
+declare_id_mod!(spl_noop, "noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV");
+declare_id_mod!(spl_associated_token_account, "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
 declare_id_mod!(spl_binary_option, "betw959P4WToez4DkuXwNsJszqbpe3HuY56AcG5yevx");
 declare_id_mod!(spl_bianry_oracle_pair, "Fd7btgySsrjuo25CJCj7oE7VPMyezDhnx7pZkj2v69Nk");
 declare_id_mod!(spl_feature_proposal, "Feat1YXHhH6t1juaWF74WLcfv4XoNocjXA6sPWHNgAse");

--- a/program-ids/src/lib.rs
+++ b/program-ids/src/lib.rs
@@ -1,0 +1,21 @@
+//! SPL Program IDs
+
+macro_rules! delcare_id_mod {
+    ($mod_name:ident, $id_bs58:literal) => {
+        pub mod $mod_name {
+            ::solana_program::declare_id!($id_bs58);
+        }
+    }
+}
+
+delcare_id_mod!(account_compression, "cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK");
+
+#[cfg(test)]
+mod tests {
+    use super::account_compression;
+
+    #[test]
+    fn test_declare_id_mod() {
+        assert_eq!(account_compression::ID.to_string(), "cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK");
+    }
+}

--- a/program-ids/src/lib.rs
+++ b/program-ids/src/lib.rs
@@ -1,6 +1,6 @@
 //! SPL Program IDs
 
-macro_rules! delcare_id_mod {
+macro_rules! declare_id_mod {
     ($mod_name:ident, $id_bs58:literal) => {
         pub mod $mod_name {
             ::solana_program::declare_id!($id_bs58);

--- a/program-ids/src/lib.rs
+++ b/program-ids/src/lib.rs
@@ -5,27 +5,72 @@ macro_rules! declare_id_mod {
         pub mod $mod_name {
             ::solana_program::declare_id!($id_bs58);
         }
-    }
+    };
 }
 
-declare_id_mod!(spl_account_compression, "cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK");
+declare_id_mod!(
+    spl_account_compression,
+    "cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK"
+);
 declare_id_mod!(spl_noop, "noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV");
-declare_id_mod!(spl_associated_token_account, "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
-declare_id_mod!(spl_binary_option, "betw959P4WToez4DkuXwNsJszqbpe3HuY56AcG5yevx");
-declare_id_mod!(spl_bianry_oracle_pair, "Fd7btgySsrjuo25CJCj7oE7VPMyezDhnx7pZkj2v69Nk");
-declare_id_mod!(spl_feature_proposal, "Feat1YXHhH6t1juaWF74WLcfv4XoNocjXA6sPWHNgAse");
-declare_id_mod!(spl_instruction_padding, "iXpADd6AW1k5FaaXum5qHbSqyd7TtoN6AD7suVa83MF");
+declare_id_mod!(
+    spl_associated_token_account,
+    "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+);
+declare_id_mod!(
+    spl_binary_option,
+    "betw959P4WToez4DkuXwNsJszqbpe3HuY56AcG5yevx"
+);
+declare_id_mod!(
+    spl_bianry_oracle_pair,
+    "Fd7btgySsrjuo25CJCj7oE7VPMyezDhnx7pZkj2v69Nk"
+);
+declare_id_mod!(
+    spl_feature_proposal,
+    "Feat1YXHhH6t1juaWF74WLcfv4XoNocjXA6sPWHNgAse"
+);
+declare_id_mod!(
+    spl_instruction_padding,
+    "iXpADd6AW1k5FaaXum5qHbSqyd7TtoN6AD7suVa83MF"
+);
 declare_id_mod!(spl_math, "Math111111111111111111111111111111111111111");
-declare_id_mod!(spl_managed_token, "mTok58Lg4YfcmwqyrDHpf7ogp599WRhzb6PxjaBqAxS");
-declare_id_mod!(spl_name_service, "namesLPneVptA9Z5rqUDD9tMTWEJwofgaYwp8cawRkX");
+declare_id_mod!(
+    spl_managed_token,
+    "mTok58Lg4YfcmwqyrDHpf7ogp599WRhzb6PxjaBqAxS"
+);
+declare_id_mod!(
+    spl_name_service,
+    "namesLPneVptA9Z5rqUDD9tMTWEJwofgaYwp8cawRkX"
+);
 declare_id_mod!(spl_record, "recr1L3PCGKLbckBqMNcJhuuyU1zgo8nBhfLVsJNwr5");
-declare_id_mod!(spl_shared_memory, "shmem4EWT2sPdVGvTZCzXXRAURL9G5vpPxNwSeKhHUL");
-declare_id_mod!(spl_single_pool, "SVSPxpvHdN29nkVg9rPapPNDddN5DipNLRUFhyjFThE");
-declare_id_mod!(spl_stake_pool, "SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy");
-declare_id_mod!(spl_token_lending, "6TvznH3B2e3p2mbhufNBpgSrLx6UkgvxtVQvopEZ2kuH");
-declare_id_mod!(spl_token_swap, "SwapsVeCiPHMUAtzQWZw7RjsKjgCjhwU55QGu4U1Szw");
-declare_id_mod!(spl_token_upgrade, "TkupDoNseygccBCjSsrSpMccjwHfTYwcrjpnDSrFDhC");
-declare_id_mod!(spl_token_wrap, "TwRapQCDhWkZRrDaHfZGuHxkZ91gHDRkyuzNqeU5MgR");
+declare_id_mod!(
+    spl_shared_memory,
+    "shmem4EWT2sPdVGvTZCzXXRAURL9G5vpPxNwSeKhHUL"
+);
+declare_id_mod!(
+    spl_single_pool,
+    "SVSPxpvHdN29nkVg9rPapPNDddN5DipNLRUFhyjFThE"
+);
+declare_id_mod!(
+    spl_stake_pool,
+    "SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy"
+);
+declare_id_mod!(
+    spl_token_lending,
+    "6TvznH3B2e3p2mbhufNBpgSrLx6UkgvxtVQvopEZ2kuH"
+);
+declare_id_mod!(
+    spl_token_swap,
+    "SwapsVeCiPHMUAtzQWZw7RjsKjgCjhwU55QGu4U1Szw"
+);
+declare_id_mod!(
+    spl_token_upgrade,
+    "TkupDoNseygccBCjSsrSpMccjwHfTYwcrjpnDSrFDhC"
+);
+declare_id_mod!(
+    spl_token_wrap,
+    "TwRapQCDhWkZRrDaHfZGuHxkZ91gHDRkyuzNqeU5MgR"
+);
 
 pub mod spl_memo {
     /// Legacy symbols from Memo v1
@@ -55,6 +100,9 @@ mod tests {
 
     #[test]
     fn test_declare_id_mod() {
-        assert_eq!(spl_account_compression::ID.to_string(), "cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK");
+        assert_eq!(
+            spl_account_compression::ID.to_string(),
+            "cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK"
+        );
     }
 }

--- a/record/program/Cargo.toml
+++ b/record/program/Cargo.toml
@@ -18,6 +18,7 @@ num-traits = "0.2"
 solana-program = "2.0.0"
 thiserror = "1.0"
 spl-pod = { version = "0.3.0", path = "../../libraries/pod" }
+spl-program-ids = { version = "1.0.0", path = "../../program-ids" }
 
 [dev-dependencies]
 solana-program-test = "2.0.0"

--- a/record/program/src/lib.rs
+++ b/record/program/src/lib.rs
@@ -9,6 +9,4 @@ pub mod state;
 
 // Export current SDK types for downstream users building with a different SDK
 // version
-pub use solana_program;
-
-pub use spl_program_ids::spl_record::*;
+pub use {solana_program, spl_program_ids::spl_record::*};

--- a/record/program/src/lib.rs
+++ b/record/program/src/lib.rs
@@ -11,4 +11,4 @@ pub mod state;
 // version
 pub use solana_program;
 
-solana_program::declare_id!("recr1L3PCGKLbckBqMNcJhuuyU1zgo8nBhfLVsJNwr5");
+pub use spl_program_ids::spl_record::*;

--- a/shared-memory/program/Cargo.toml
+++ b/shared-memory/program/Cargo.toml
@@ -13,6 +13,7 @@ test-sbf = []
 [dependencies]
 arrayref = "0.3.7"
 solana-program = "2.0.0"
+spl-program-ids = { version = "1.0.0", path = "../../program-ids" }
 
 [dev-dependencies]
 solana-program-test = "2.0.0"

--- a/shared-memory/program/src/lib.rs
+++ b/shared-memory/program/src/lib.rs
@@ -11,7 +11,6 @@ extern crate solana_program;
 use {
     arrayref::{array_refs, mut_array_refs},
     solana_program::{
-        declare_id,
         entrypoint::{MAX_PERMITTED_DATA_INCREASE, SUCCESS},
         program_error::ProgramError,
         pubkey::Pubkey,
@@ -23,7 +22,7 @@ use {
     },
 };
 
-declare_id!("shmem4EWT2sPdVGvTZCzXXRAURL9G5vpPxNwSeKhHUL");
+pub use spl_program_ids::spl_shared_memory::*;
 
 /// A more efficient `copy_from_slice` implementation.
 fn fast_copy(mut src: &[u8], mut dst: &mut [u8]) {

--- a/shared-memory/program/src/lib.rs
+++ b/shared-memory/program/src/lib.rs
@@ -8,6 +8,7 @@
 // implement the typical `process_instruction` entrypoint.
 
 extern crate solana_program;
+pub use spl_program_ids::spl_shared_memory::*;
 use {
     arrayref::{array_refs, mut_array_refs},
     solana_program::{
@@ -21,8 +22,6 @@ use {
         slice::{from_raw_parts, from_raw_parts_mut},
     },
 };
-
-pub use spl_program_ids::spl_shared_memory::*;
 
 /// A more efficient `copy_from_slice` implementation.
 fn fast_copy(mut src: &[u8], mut dst: &mut [u8]) {

--- a/single-pool/program/Cargo.toml
+++ b/single-pool/program/Cargo.toml
@@ -19,6 +19,7 @@ num-traits = "0.2"
 num_enum = "0.7.2"
 solana-program = "2.0.0"
 solana-security-txt = "1.1.1"
+spl-program-ids = { version = "1.0.0", path = "../../program-ids" }
 spl-token = { version = "6.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }

--- a/single-pool/program/src/lib.rs
+++ b/single-pool/program/src/lib.rs
@@ -16,7 +16,7 @@ pub mod entrypoint;
 pub use solana_program;
 use solana_program::{pubkey::Pubkey, stake};
 
-solana_program::declare_id!("SVSPxpvHdN29nkVg9rPapPNDddN5DipNLRUFhyjFThE");
+pub use spl_program_ids::spl_single_pool::*;
 
 const POOL_PREFIX: &[u8] = b"pool";
 const POOL_STAKE_PREFIX: &[u8] = b"stake";

--- a/single-pool/program/src/lib.rs
+++ b/single-pool/program/src/lib.rs
@@ -11,12 +11,10 @@ pub mod state;
 #[cfg(not(feature = "no-entrypoint"))]
 pub mod entrypoint;
 
+use solana_program::{pubkey::Pubkey, stake};
 // export current sdk types for downstream users building with a different sdk
 // version
-pub use solana_program;
-use solana_program::{pubkey::Pubkey, stake};
-
-pub use spl_program_ids::spl_single_pool::*;
+pub use {solana_program, spl_program_ids::spl_single_pool::*};
 
 const POOL_PREFIX: &[u8] = b"pool";
 const POOL_STAKE_PREFIX: &[u8] = b"stake";

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -28,6 +28,7 @@ spl-math = { version = "0.2", path = "../../libraries/math", features = [
 spl-pod = { version = "0.3.0", path = "../../libraries/pod", features = [
   "borsh",
 ] }
+spl-program-ids = { version = "1.0.0", path = "../../program-ids" }
 spl-token-2022 = { version = "4.0.0", path = "../../token/program-2022", features = [
   "no-entrypoint",
 ] }

--- a/stake-pool/program/src/lib.rs
+++ b/stake-pool/program/src/lib.rs
@@ -157,7 +157,7 @@ pub fn find_ephemeral_stake_program_address(
     )
 }
 
-solana_program::declare_id!("SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy");
+pub use spl_program_ids::spl_stake_pool::*;
 
 #[cfg(test)]
 mod test {

--- a/token-lending/program/Cargo.toml
+++ b/token-lending/program/Cargo.toml
@@ -17,6 +17,7 @@ bytemuck = "1.16.1"
 num-derive = "0.4"
 num-traits = "0.2"
 solana-program = "2.0.0"
+spl-program-ids = { version = "1.0.0", path = "../../program-ids" }
 spl-token = { version = "6.0", path = "../../token/program", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 uint = "0.9"

--- a/token-lending/program/src/lib.rs
+++ b/token-lending/program/src/lib.rs
@@ -13,6 +13,4 @@ pub mod state;
 
 // Export current sdk types for downstream users building with a different sdk
 // version
-pub use solana_program;
-
-pub use spl_program_ids::spl_token_lending::*;
+pub use {solana_program, spl_program_ids::spl_token_lending::*};

--- a/token-lending/program/src/lib.rs
+++ b/token-lending/program/src/lib.rs
@@ -15,4 +15,4 @@ pub mod state;
 // version
 pub use solana_program;
 
-solana_program::declare_id!("6TvznH3B2e3p2mbhufNBpgSrLx6UkgvxtVQvopEZ2kuH");
+pub use spl_program_ids::spl_token_lending::*;

--- a/token-swap/program/Cargo.toml
+++ b/token-swap/program/Cargo.toml
@@ -19,6 +19,7 @@ num-derive = "0.4"
 num-traits = "0.2"
 solana-program = "2.0.0"
 spl-math = { version = "0.2", path = "../../libraries/math", features = [ "no-entrypoint" ] }
+spl-program-ids = { version = "1.0.0", path = "../../program-ids" }
 spl-token = { version = "6.0", path = "../../token/program", features = [ "no-entrypoint" ] }
 spl-token-2022 = { version = "4.0.0", path = "../../token/program-2022", features = [ "no-entrypoint" ] }
 thiserror = "1.0"

--- a/token-swap/program/src/lib.rs
+++ b/token-swap/program/src/lib.rs
@@ -15,6 +15,4 @@ mod entrypoint;
 
 // Export current sdk types for downstream users building with a different sdk
 // version
-pub use solana_program;
-
-pub use spl_program_ids::spl_token_swap::*;
+pub use {solana_program, spl_program_ids::spl_token_swap::*};

--- a/token-swap/program/src/lib.rs
+++ b/token-swap/program/src/lib.rs
@@ -17,4 +17,4 @@ mod entrypoint;
 // version
 pub use solana_program;
 
-solana_program::declare_id!("SwapsVeCiPHMUAtzQWZw7RjsKjgCjhwU55QGu4U1Szw");
+pub use spl_program_ids::spl_token_swap::*;

--- a/token-upgrade/program/Cargo.toml
+++ b/token-upgrade/program/Cargo.toml
@@ -17,6 +17,7 @@ num-traits = "0.2"
 num_enum = "0.7.2"
 solana-program = "2.0.0"
 spl-token-2022 = { version = "4.0.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
+spl-program-ids = { version = "1.0.0", path = "../../program-ids" }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/token-upgrade/program/src/lib.rs
+++ b/token-upgrade/program/src/lib.rs
@@ -7,12 +7,10 @@ pub mod error;
 pub mod instruction;
 pub mod processor;
 
+use solana_program::pubkey::Pubkey;
 // Export current SDK types for downstream users building with a different SDK
 // version
-pub use solana_program;
-use solana_program::pubkey::Pubkey;
-
-pub use spl_program_ids::spl_token_upgrade::*;
+pub use {solana_program, spl_program_ids::spl_token_upgrade::*};
 
 const TOKEN_ESCROW_AUTHORITY_SEED: &[u8] = b"token-escrow-authority";
 

--- a/token-upgrade/program/src/lib.rs
+++ b/token-upgrade/program/src/lib.rs
@@ -12,7 +12,7 @@ pub mod processor;
 pub use solana_program;
 use solana_program::pubkey::Pubkey;
 
-solana_program::declare_id!("TkupDoNseygccBCjSsrSpMccjwHfTYwcrjpnDSrFDhC");
+pub use spl_program_ids::spl_token_upgrade::*;
 
 const TOKEN_ESCROW_AUTHORITY_SEED: &[u8] = b"token-escrow-authority";
 

--- a/token-wrap/program/Cargo.toml
+++ b/token-wrap/program/Cargo.toml
@@ -16,6 +16,7 @@ bytemuck = { version = "1.16.1", features = ["derive"] }
 num_enum = "0.7"
 solana-program = "2.0.0"
 spl-associated-token-account = { version = "4.0.0", path = "../../associated-token-account/program", features = ["no-entrypoint"] }
+spl-program-ids = { version = "1.0.0", path = "../../program-ids" }
 spl-token = { version = "6.0", path = "../../token/program", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "4.0.0", path = "../../token/program-2022", features = ["no-entrypoint"] }
 thiserror = "1.0"

--- a/token-wrap/program/src/lib.rs
+++ b/token-wrap/program/src/lib.rs
@@ -12,7 +12,7 @@ pub mod state;
 pub use solana_program;
 use solana_program::pubkey::Pubkey;
 
-solana_program::declare_id!("TwRapQCDhWkZRrDaHfZGuHxkZ91gHDRkyuzNqeU5MgR");
+pub use spl_program_ids::spl_token_wrap::*;
 
 const WRAPPED_MINT_SEED: &[u8] = br"mint";
 

--- a/token-wrap/program/src/lib.rs
+++ b/token-wrap/program/src/lib.rs
@@ -7,12 +7,10 @@ pub mod instruction;
 pub mod processor;
 pub mod state;
 
+use solana_program::pubkey::Pubkey;
 // Export current SDK types for downstream users building with a different SDK
 // version
-pub use solana_program;
-use solana_program::pubkey::Pubkey;
-
-pub use spl_program_ids::spl_token_wrap::*;
+pub use {solana_program, spl_program_ids::spl_token_wrap::*};
 
 const WRAPPED_MINT_SEED: &[u8] = br"mint";
 

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -26,6 +26,7 @@ solana-program = "2.0.0"
 solana-security-txt = "1.1.1"
 solana-zk-token-sdk = "2.0.0"
 spl-memo = { version = "5.0", path = "../../memo/program", features = [ "no-entrypoint" ] }
+spl-program-ids = { version = "1.0.0", path = "../../program-ids" }
 spl-token = { version = "6.0",  path = "../program", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.3.0", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.4.0", path = "../../token-metadata/interface" }

--- a/token/program-2022/src/lib.rs
+++ b/token/program-2022/src/lib.rs
@@ -93,7 +93,7 @@ pub fn try_ui_amount_into_amount(ui_amount: String, decimals: u8) -> Result<u64,
         .map_err(|_| ProgramError::InvalidArgument)
 }
 
-solana_program::declare_id!("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
+pub use spl_program_ids::spl_token_2022::{check_id, id, ID};
 
 /// Checks that the supplied program ID is correct for spl-token-2022
 pub fn check_program_account(spl_token_program_id: &Pubkey) -> ProgramResult {

--- a/token/program-2022/src/native_mint.rs
+++ b/token/program-2022/src/native_mint.rs
@@ -4,7 +4,7 @@
 pub const DECIMALS: u8 = 9;
 
 // The Mint for native SOL Token accounts
-solana_program::declare_id!("9pan9bMn5HatX4EJdBwg9VgCa7Uz5HL8N1m5D3NdXejP");
+pub use spl_program_ids::spl_token_2022::native_mint::*;
 
 /// Seed for the native_mint's program-derived address
 pub const PROGRAM_ADDRESS_SEEDS: &[&[u8]] = &["native-mint".as_bytes(), &[255]];

--- a/token/program/Cargo.toml
+++ b/token/program/Cargo.toml
@@ -19,6 +19,7 @@ num-derive = "0.4"
 num-traits = "0.2"
 num_enum = "0.7.2"
 solana-program = "2.0.0"
+spl-program-ids = { version = "1.0.0", path = "../../program-ids" }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/token/program/src/lib.rs
+++ b/token/program/src/lib.rs
@@ -82,7 +82,7 @@ pub fn try_ui_amount_into_amount(ui_amount: String, decimals: u8) -> Result<u64,
         .map_err(|_| ProgramError::InvalidArgument)
 }
 
-solana_program::declare_id!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+pub use spl_program_ids::spl_token::{check_id, id, ID};
 
 /// Checks that the supplied program ID is the correct one for SPL-token
 pub fn check_program_account(spl_token_program_id: &Pubkey) -> ProgramResult {

--- a/token/program/src/native_mint.rs
+++ b/token/program/src/native_mint.rs
@@ -4,7 +4,7 @@
 pub const DECIMALS: u8 = 9;
 
 // The Mint for native SOL Token accounts
-solana_program::declare_id!("So11111111111111111111111111111111111111112");
+pub use spl_program_ids::spl_token::native_mint::*;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
There are many cases of people adding, for example, spl_token_2022 as a dependency just so they can import the program ID. This is terrible for dependency bloat and conflicts.

This PR puts SPL program IDs in one crate and re-exports them in their original crates for backwards compatibility.

On my machine a release build of the new spl_program_ids crate takes 0.05s after compiling its dependencies, so I definitely think it's fine to dump every SPL program ID in here. Semver also shouldn't get messy since it's not like we expect breaking changes to the IDs