### PR TITLE
bump token-group and token-js

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+enable-pre-post-scripts=true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -779,7 +779,7 @@ importers:
         specifier: ^0.2.0
         version: 0.2.0
       '@solana/spl-token-group':
-        specifier: ^0.0.3
+        specifier: ^0.0.5
         version: link:../../token-group/js
       '@solana/spl-token-metadata':
         specifier: ^0.1.3

--- a/token-group/js/package.json
+++ b/token-group/js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@solana/spl-token-group",
     "description": "SPL Token Group Interface JS API",
-    "version": "0.0.3",
+    "version": "0.0.5",
     "author": "Solana Labs Maintainers <maintainers@solanalabs.com>",
     "repository": "https://github.com/solana-labs/solana-program-library",
     "license": "Apache-2.0",

--- a/token/js/package.json
+++ b/token/js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@solana/spl-token",
     "description": "SPL Token Program JS API",
-    "version": "0.4.7",
+    "version": "0.4.8",
     "author": "Solana Labs Maintainers <maintainers@solanalabs.com>",
     "repository": "https://github.com/solana-labs/solana-program-library",
     "license": "Apache-2.0",
@@ -56,7 +56,7 @@
     "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
         "@solana/buffer-layout-utils": "^0.2.0",
-        "@solana/spl-token-group": "^0.0.3",
+        "@solana/spl-token-group": "^0.0.5",
         "@solana/spl-token-metadata": "^0.1.3",
         "buffer": "^6.0.3"
     },


### PR DESCRIPTION
Bump & publish `@solana/spl-token-group` version `0.0.5` to include any recent changes to dependencies.

Then bump & publish `@solana/spl-token` version `0.4.8` to include the newer Token Group JS, eliminating the dependency on the deprecated version.

Closes #6958 

### SPL JS Postbuild Step

In our repository, we build and publish packages using `pnpm` version `8.14.3` (see workspace package.json). There are a few ways you can configure a matching `pnpm` version locally, but I use the following command, since my global version is 9.5.0.

```shell
npx pnpm@8.14.3 <command>
```

When using the proper version of `pnpm` and - after installing all packages - running the build step from the **workspace root** (ie., `npx pnpm@8.14.3 run build`), the postbuild step that configures the CJS output is successfully run by Turbo.

However, if you run this command within any package's local directory, for example `token/js`, Turbo won't be used, and instead `pnpm` is used directly to call the script in that package's package.json. In this situation, the **post-build step is not run**.

`pnpm` version 9 includes pre- and post-build scripts by default, so whenever SPL's version of `pnpm` is upgraded we will no longer need to worry about this crucial pre-publish step being missed. However, as a precaution, and to solve the issue for `pnpm` version 8, I've added the following configuration in a `.npmrc` file:

```
enable-pre-post-scripts=true
```

See [the discussion on the `pnpm` repository](https://github.com/pnpm/pnpm/issues/2891#issuecomment-1716861266) or [this blog](https://thedaviddias.com/notes/how-to-fix-post-pre-build-pnpm) for more information.