### PR TITLE
token-2022: add token 2022 argument to token cli for easy use

### DIFF
--- a/token/cli/README.md
+++ b/token/cli/README.md
@@ -33,3 +33,10 @@ After that, you can run the tests as any other Rust project:
 ```sh
 cargo test
 ```
+
+To run it locally you can do it like this:
+
+```sh
+cargo build --manifest-path token/cli/Cargo.toml
+target/debug/spl-token <command>
+```

--- a/token/cli/src/clap_app.rs
+++ b/token/cli/src/clap_app.rs
@@ -657,12 +657,6 @@ pub fn app<'a, 'b>(
                         ),
                 )
                 .arg(
-                    Arg::with_name("program_2022")
-                        .value_name("TOKEN_22_PROGRAM_ID")
-                        .short("token22")
-                        .long("TokenProgram22")
-                        .help("Use token extension program token 2022 program id: TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"))
-                .arg(
                     Arg::with_name("mint_authority")
                         .long("mint-authority")
                         .alias("owner")
@@ -699,6 +693,13 @@ pub fn app<'a, 'b>(
                             "Enable the mint authority to close this mint"
                         ),
                 )
+                .arg(
+                    Arg::with_name("token_program_2022")
+                        .value_name("token-program-2022")
+                        .short("2")
+                        .long("token-program-2022")
+                        .takes_value(false)
+                        .help("Use token extension program token 2022 with program id: TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"))
                 .arg(
                     Arg::with_name("interest_rate")
                         .long("interest-rate")

--- a/token/cli/src/clap_app.rs
+++ b/token/cli/src/clap_app.rs
@@ -657,6 +657,12 @@ pub fn app<'a, 'b>(
                         ),
                 )
                 .arg(
+                    Arg::with_name("program_2022")
+                        .value_name("TOKEN_22_PROGRAM_ID")
+                        .short("token22")
+                        .long("TokenProgram22")
+                        .help("Use token extension program token 2022 program id: TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"))
+                .arg(
                     Arg::with_name("mint_authority")
                         .long("mint-authority")
                         .alias("owner")

--- a/token/cli/src/clap_app.rs
+++ b/token/cli/src/clap_app.rs
@@ -593,7 +593,6 @@ pub fn app<'a, 'b>(
         )
         .arg(
             Arg::with_name("program_2022")
-                .short("2")
                 .long("program-2022")
                 .takes_value(false)
                 .global(true)

--- a/token/cli/src/clap_app.rs
+++ b/token/cli/src/clap_app.rs
@@ -592,6 +592,15 @@ pub fn app<'a, 'b>(
                 .help("Return information in specified output format"),
         )
         .arg(
+            Arg::with_name("program_2022")
+                .short("2")
+                .long("program-2022")
+                .takes_value(false)
+                .global(true)
+                .conflicts_with("program_id")
+                .help("Use token extension program token 2022 with program id: TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"),
+        )
+        .arg(
             Arg::with_name("program_id")
                 .short("p")
                 .long("program-id")
@@ -599,6 +608,7 @@ pub fn app<'a, 'b>(
                 .takes_value(true)
                 .global(true)
                 .validator(is_valid_token_program_id)
+                .conflicts_with("program_2022")
                 .help("SPL Token program id"),
         )
         .arg(
@@ -693,13 +703,6 @@ pub fn app<'a, 'b>(
                             "Enable the mint authority to close this mint"
                         ),
                 )
-                .arg(
-                    Arg::with_name("token_program_2022")
-                        .value_name("token-program-2022")
-                        .short("2")
-                        .long("token-program-2022")
-                        .takes_value(false)
-                        .help("Use token extension program token 2022 with program id: TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"))
                 .arg(
                     Arg::with_name("interest_rate")
                         .long("interest-rate")

--- a/token/cli/src/config.rs
+++ b/token/cli/src/config.rs
@@ -261,7 +261,9 @@ impl<'a> Config<'a> {
 
         let default_program_id = spl_token::id();
         let (program_id, restrict_to_program_id) =
-            if let Some(program_id) = value_of(matches, "program_id") {
+            if matches.is_present("program_2022") {
+                (spl_token_2022::id(), true)
+            } else if let Some(program_id) = value_of(matches, "program_id") {
                 (program_id, true)
             } else if !sign_only {
                 if let Some(address) = value_of(matches, "token")

--- a/token/cli/src/config.rs
+++ b/token/cli/src/config.rs
@@ -260,30 +260,29 @@ impl<'a> Config<'a> {
         let dump_transaction_message = matches.is_present(DUMP_TRANSACTION_MESSAGE.name);
 
         let default_program_id = spl_token::id();
-        let (program_id, restrict_to_program_id) =
-            if matches.is_present("program_2022") {
-                (spl_token_2022::id(), true)
-            } else if let Some(program_id) = value_of(matches, "program_id") {
-                (program_id, true)
-            } else if !sign_only {
-                if let Some(address) = value_of(matches, "token")
-                    .or_else(|| value_of(matches, "account"))
-                    .or_else(|| value_of(matches, "address"))
-                {
-                    (
-                        rpc_client
-                            .get_account(&address)
-                            .await
-                            .map(|account| account.owner)
-                            .unwrap_or(default_program_id),
-                        false,
-                    )
-                } else {
-                    (default_program_id, false)
-                }
+        let (program_id, restrict_to_program_id) = if matches.is_present("program_2022") {
+            (spl_token_2022::id(), true)
+        } else if let Some(program_id) = value_of(matches, "program_id") {
+            (program_id, true)
+        } else if !sign_only {
+            if let Some(address) = value_of(matches, "token")
+                .or_else(|| value_of(matches, "account"))
+                .or_else(|| value_of(matches, "address"))
+            {
+                (
+                    rpc_client
+                        .get_account(&address)
+                        .await
+                        .map(|account| account.owner)
+                        .unwrap_or(default_program_id),
+                    false,
+                )
             } else {
                 (default_program_id, false)
-            };
+            }
+        } else {
+            (default_program_id, false)
+        };
 
         // need to specify a compute limit if compute price and blockhash are specified
         if matches.is_present(BLOCKHASH_ARG.name)

--- a/token/cli/src/config.rs
+++ b/token/cli/src/config.rs
@@ -261,7 +261,7 @@ impl<'a> Config<'a> {
 
         let default_program_id = spl_token::id();
         let (program_id, restrict_to_program_id) =
-            if matches.is_present("token_program_2022") {
+            if matches.is_present("program_2022") {
                 (spl_token_2022::id(), true)
             } else if let Some(program_id) = value_of(matches, "program_id") {
                 (program_id, true)

--- a/token/cli/src/config.rs
+++ b/token/cli/src/config.rs
@@ -261,7 +261,7 @@ impl<'a> Config<'a> {
 
         let default_program_id = spl_token::id();
         let (program_id, restrict_to_program_id) =
-            if matches.is_present("program_2022") {
+            if matches.is_present("token_program_2022") {
                 (spl_token_2022::id(), true)
             } else if let Some(program_id) = value_of(matches, "program_id") {
                 (program_id, true)

--- a/token/cli/tests/command.rs
+++ b/token/cli/tests/command.rs
@@ -496,7 +496,6 @@ async fn create_token_default(test_validator: &TestValidator, payer: &Keypair) {
     }
 }
 
-
 async fn create_token_2022(test_validator: &TestValidator, payer: &Keypair) {
     let config = test_config_with_default_signer(test_validator, payer, &spl_token_2022::id());
     let mut wallet_manager = None;
@@ -506,7 +505,7 @@ async fn create_token_2022(test_validator: &TestValidator, payer: &Keypair) {
     let args = &[
         "spl-token",
         CommandName::CreateToken.into(),
-        "--token-program-2022"
+        "--program-2022"
     ];
     
     let default_decimals = format!("{}", spl_token_2022::native_mint::DECIMALS);
@@ -520,11 +519,8 @@ async fn create_token_2022(test_validator: &TestValidator, payer: &Keypair) {
     )
     .get_matches_from(args);
 
-    let (_sub_command, sub_matches) = app_matches.subcommand();
-    let matches = sub_matches.unwrap();
-
     let config = Config::new_with_clients_and_ws_url(
-        matches,
+        &app_matches,
         &mut wallet_manager,
         &mut bulk_signers,
         &mut multisigner_ids,

--- a/token/cli/tests/command.rs
+++ b/token/cli/tests/command.rs
@@ -505,9 +505,9 @@ async fn create_token_2022(test_validator: &TestValidator, payer: &Keypair) {
     let args = &[
         "spl-token",
         CommandName::CreateToken.into(),
-        "--program-2022"
+        "--program-2022",
     ];
-    
+
     let default_decimals = format!("{}", spl_token_2022::native_mint::DECIMALS);
     let minimum_signers_help = minimum_signers_help_string();
     let multisig_member_help = multisig_member_help_string();
@@ -527,7 +527,8 @@ async fn create_token_2022(test_validator: &TestValidator, payer: &Keypair) {
         config.rpc_client.clone(),
         config.program_client.clone(),
         config.websocket_url.clone(),
-    ).await; 
+    )
+    .await;
 
     assert_eq!(config.program_id, spl_token_2022::ID);
 }

--- a/token/cli/tests/command.rs
+++ b/token/cli/tests/command.rs
@@ -92,6 +92,7 @@ async fn main() {
     // maybe come up with a way to do this through a some macro tag on the function?
     let tests = vec![
         async_trial!(create_token_default, test_validator, payer),
+        async_trial!(create_token_2022, test_validator, payer),
         async_trial!(create_token_interest_bearing, test_validator, payer),
         async_trial!(set_interest_rate, test_validator, payer),
         async_trial!(supply, test_validator, payer),
@@ -493,6 +494,46 @@ async fn create_token_default(test_validator: &TestValidator, payer: &Keypair) {
         let account = config.rpc_client.get_account(&mint).await.unwrap();
         assert_eq!(account.owner, *program_id);
     }
+}
+
+
+async fn create_token_2022(test_validator: &TestValidator, payer: &Keypair) {
+    let config = test_config_with_default_signer(test_validator, payer, &spl_token_2022::id());
+    let mut wallet_manager = None;
+    let mut bulk_signers: Vec<Arc<dyn Signer>> = Vec::new();
+    let mut multisigner_ids = Vec::new();
+
+    let args = &[
+        "spl-token",
+        CommandName::CreateToken.into(),
+        "--token-program-2022"
+    ];
+    
+    let default_decimals = format!("{}", spl_token_2022::native_mint::DECIMALS);
+    let minimum_signers_help = minimum_signers_help_string();
+    let multisig_member_help = multisig_member_help_string();
+
+    let app_matches = app(
+        &default_decimals,
+        &minimum_signers_help,
+        &multisig_member_help,
+    )
+    .get_matches_from(args);
+
+    let (_sub_command, sub_matches) = app_matches.subcommand();
+    let matches = sub_matches.unwrap();
+
+    let config = Config::new_with_clients_and_ws_url(
+        matches,
+        &mut wallet_manager,
+        &mut bulk_signers,
+        &mut multisigner_ids,
+        config.rpc_client.clone(),
+        config.program_client.clone(),
+        config.websocket_url.clone(),
+    ).await; 
+
+    assert_eq!(config.program_id, spl_token_2022::ID);
 }
 
 async fn create_token_interest_bearing(test_validator: &TestValidator, payer: &Keypair) {


### PR DESCRIPTION
Instead of copying the token program id of the token22 program one can now just write: 
```
create-token --token-program-2022
or
create-token -2
```
