### PR TITLE
token-2022: Remove `token-group` and `confidential-hook` features

### DIFF
--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -12,11 +12,9 @@ exclude = ["js/**"]
 no-entrypoint = []
 test-sbf = []
 serde-traits = ["dep:serde", "dep:serde_with", "dep:base64", "spl-pod/serde-traits"]
-default = ["confidential-hook", "token-group", "zk-ops"]
+default = ["confidential-hook", "zk-ops"]
 # Remove this feature once the underlying syscalls are released on all networks
 zk-ops = []
-# Remove this feature once the token group implementation has been audited
-token-group = []
 # Remove this feature once the confidential transfer hook has been audited
 confidential-hook = []
 

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -12,11 +12,9 @@ exclude = ["js/**"]
 no-entrypoint = []
 test-sbf = []
 serde-traits = ["dep:serde", "dep:serde_with", "dep:base64", "spl-pod/serde-traits"]
-default = ["confidential-hook", "zk-ops"]
+default = ["zk-ops"]
 # Remove this feature once the underlying syscalls are released on all networks
 zk-ops = []
-# Remove this feature once the confidential transfer hook has been audited
-confidential-hook = []
 
 [dependencies]
 arrayref = "0.3.7"

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -1,6 +1,4 @@
 // Remove feature once zk ops syscalls are enabled on all networks
-#[cfg(feature = "confidential-hook")]
-use crate::extension::transfer_hook;
 #[cfg(feature = "zk-ops")]
 use {
     crate::extension::non_transferable::NonTransferableAccount,
@@ -18,8 +16,8 @@ use {
             },
             memo_transfer::{check_previous_sibling_instruction_is_memo, memo_required},
             transfer_fee::TransferFeeConfig,
-            BaseStateWithExtensions, BaseStateWithExtensionsMut, PodStateWithExtensions,
-            PodStateWithExtensionsMut,
+            transfer_hook, BaseStateWithExtensions, BaseStateWithExtensionsMut,
+            PodStateWithExtensions, PodStateWithExtensionsMut,
         },
         instruction::{decode_instruction_data, decode_instruction_type},
         pod::{PodAccount, PodMint},
@@ -625,7 +623,6 @@ fn process_transfer(
         authority_info
     };
 
-    #[cfg(feature = "confidential-hook")]
     if let Some(program_id) = transfer_hook::get_program_id(&mint) {
         // set transferring flags, scope the borrow to avoid double-borrow during CPI
         {

--- a/token/program-2022/src/extension/token_group/processor.rs
+++ b/token/program-2022/src/extension/token_group/processor.rs
@@ -205,7 +205,6 @@ pub fn process_initialize_member(_program_id: &Pubkey, accounts: &[AccountInfo])
 }
 
 /// Processes an [Instruction](enum.Instruction.html).
-#[cfg(feature = "token-group")]
 pub fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
@@ -229,14 +228,4 @@ pub fn process_instruction(
             process_initialize_member(program_id, accounts)
         }
     }
-}
-
-/// Processes an [Instruction](enum.Instruction.html).
-#[cfg(not(feature = "token-group"))]
-pub fn process_instruction(
-    _program_id: &Pubkey,
-    _accounts: &[AccountInfo],
-    _instruction: TokenGroupInstruction,
-) -> ProgramResult {
-    Err(TokenError::InvalidInstruction.into())
 }


### PR DESCRIPTION
#### Problem

The `token-group` and `confidential-hook` crate features were added to deploy a version of token-2022 without the token-group extension and without calling the transfer hook in confidential transfers.

Since then, token-2022 has been audited multiple times with these features, but they're still in the code.

#### Solution

In preparation of the next deployment, remove the features since they aren't needed anymore