### PR TITLE
token-2022: Bump to 4.0.1 for next release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6859,7 +6859,7 @@ dependencies = [
  "num-traits",
  "solana-program",
  "spl-token 6.0.0",
- "spl-token-2022 4.0.0",
+ "spl-token-2022 4.0.1",
  "thiserror",
 ]
 
@@ -6872,7 +6872,7 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account 4.0.0",
  "spl-token 6.0.0",
- "spl-token-2022 4.0.0",
+ "spl-token-2022 4.0.1",
 ]
 
 [[package]]
@@ -7424,7 +7424,7 @@ dependencies = [
  "spl-math",
  "spl-pod 0.3.0",
  "spl-token 6.0.0",
- "spl-token-2022 4.0.0",
+ "spl-token-2022 4.0.1",
  "test-case",
  "thiserror",
 ]
@@ -7545,7 +7545,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-2022"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -7590,7 +7590,7 @@ dependencies = [
  "spl-memo 5.0.0",
  "spl-pod 0.3.0",
  "spl-tlv-account-resolution 0.7.0",
- "spl-token-2022 4.0.0",
+ "spl-token-2022 4.0.1",
  "spl-token-client",
  "spl-token-group-interface 0.3.0",
  "spl-token-metadata-interface 0.4.0",
@@ -7627,7 +7627,7 @@ dependencies = [
  "spl-associated-token-account 4.0.0",
  "spl-memo 5.0.0",
  "spl-token 6.0.0",
- "spl-token-2022 4.0.0",
+ "spl-token-2022 4.0.1",
  "spl-token-client",
  "spl-token-group-interface 0.3.0",
  "spl-token-metadata-interface 0.4.0",
@@ -7655,7 +7655,7 @@ dependencies = [
  "spl-associated-token-account 4.0.0",
  "spl-memo 5.0.0",
  "spl-token 6.0.0",
- "spl-token-2022 4.0.0",
+ "spl-token-2022 4.0.1",
  "spl-token-group-interface 0.3.0",
  "spl-token-metadata-interface 0.4.0",
  "spl-transfer-hook-interface 0.7.0",
@@ -7672,7 +7672,7 @@ dependencies = [
  "spl-discriminator 0.3.0",
  "spl-pod 0.3.0",
  "spl-program-error 0.5.0",
- "spl-token-2022 4.0.0",
+ "spl-token-2022 4.0.1",
  "spl-token-client",
  "spl-token-group-example",
  "spl-token-group-interface 0.3.0",
@@ -7731,7 +7731,7 @@ dependencies = [
  "solana-sdk",
  "spl-discriminator 0.3.0",
  "spl-pod 0.3.0",
- "spl-token-2022 4.0.0",
+ "spl-token-2022 4.0.1",
  "spl-token-client",
  "spl-token-group-interface 0.3.0",
  "spl-token-metadata-interface 0.4.0",
@@ -7804,7 +7804,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-pod 0.3.0",
- "spl-token-2022 4.0.0",
+ "spl-token-2022 4.0.1",
  "spl-token-client",
  "spl-token-metadata-interface 0.4.0",
  "spl-type-length-value 0.5.0",
@@ -7854,7 +7854,7 @@ dependencies = [
  "solana-sdk",
  "spl-math",
  "spl-token 6.0.0",
- "spl-token-2022 4.0.0",
+ "spl-token-2022 4.0.1",
  "test-case",
  "thiserror",
 ]
@@ -7882,7 +7882,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-token 6.0.0",
- "spl-token-2022 4.0.0",
+ "spl-token-2022 4.0.1",
  "spl-token-client",
  "test-case",
  "thiserror",
@@ -7903,7 +7903,7 @@ dependencies = [
  "solana-test-validator",
  "spl-associated-token-account 4.0.0",
  "spl-token 6.0.0",
- "spl-token-2022 4.0.0",
+ "spl-token-2022 4.0.1",
  "spl-token-client",
  "spl-token-upgrade",
  "tokio",
@@ -7919,7 +7919,7 @@ dependencies = [
  "solana-program",
  "spl-associated-token-account 4.0.0",
  "spl-token 6.0.0",
- "spl-token-2022 4.0.0",
+ "spl-token-2022 4.0.1",
  "thiserror",
 ]
 
@@ -7940,7 +7940,7 @@ dependencies = [
  "solana-sdk",
  "solana-test-validator",
  "spl-tlv-account-resolution 0.7.0",
- "spl-token-2022 4.0.0",
+ "spl-token-2022 4.0.1",
  "spl-token-client",
  "spl-transfer-hook-example",
  "spl-transfer-hook-interface 0.7.0",
@@ -7958,7 +7958,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-tlv-account-resolution 0.7.0",
- "spl-token-2022 4.0.0",
+ "spl-token-2022 4.0.1",
  "spl-transfer-hook-interface 0.7.0",
  "spl-type-length-value 0.5.0",
 ]

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-2022"
-version = "4.0.0"
+version = "4.0.1"
 description = "Solana Program Library Token 2022"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"


### PR DESCRIPTION
#### Problem

1.18 is out on mainnet, and token-2022 has had a few more audits since the last deployment, so it's time to deploy!

#### Solution

Bump the crate to 4.0.1 to include recent fixes