### PR TITLE
stake-pool: CLI QOL improvements

### DIFF
--- a/stake-pool/cli/src/main.rs
+++ b/stake-pool/cli/src/main.rs
@@ -471,8 +471,6 @@ fn setup_and_initialize_validator_list_with_stake_pool(
     let mut instructions = vec![];
     let mut signers = vec![
         config.fee_payer.as_ref(),
-        // stake_pool_keypair,
-        // validator_list_keypair,
         config.manager.as_ref(),
     ];
 


### PR DESCRIPTION
When creating a stake-pool using the CLI, if at any point an instruction fails subsequent commands will also fail. This behavior creates a problem when initializing a stake pool in the CLI with vanity keypairs. This solution aims to break up the `command_create_pool` into iterative steps with checks along the way.

I had changed the deprecated ` use spl_associated_token_account::create_associated_token_account` but am happy to change it back.