### PR TITLE
Fix init empty stack frame violation

### DIFF
--- a/account-compression/programs/account-compression/src/concurrent_tree_wrapper.rs
+++ b/account-compression/programs/account-compression/src/concurrent_tree_wrapper.rs
@@ -28,6 +28,16 @@ use {
     anchor_lang::prelude::*,
 };
 
+#[inline(never)]
+pub fn merkle_tree_initialize_empty(
+    header: &ConcurrentMerkleTreeHeader,
+    tree_id: Pubkey,
+    tree_bytes: &mut [u8],
+) -> Result<Box<ChangeLogEvent>> {
+    merkle_tree_apply_fn_mut!(header, tree_id, tree_bytes, initialize,)
+}
+
+#[inline(never)]
 pub fn merkle_tree_initialize_with_root(
     header: &ConcurrentMerkleTreeHeader,
     tree_id: Pubkey,
@@ -37,6 +47,7 @@ pub fn merkle_tree_initialize_with_root(
     merkle_tree_apply_fn_mut!(header, tree_id, tree_bytes, initialize_with_root, args)
 }
 
+#[inline(never)]
 pub fn merkle_tree_set_leaf(
     header: &ConcurrentMerkleTreeHeader,
     tree_id: Pubkey,
@@ -46,6 +57,7 @@ pub fn merkle_tree_set_leaf(
     merkle_tree_apply_fn_mut!(header, tree_id, tree_bytes, set_leaf, args)
 }
 
+#[inline(never)]
 pub fn merkle_tree_fill_empty_or_append(
     header: &ConcurrentMerkleTreeHeader,
     tree_id: Pubkey,
@@ -55,6 +67,7 @@ pub fn merkle_tree_fill_empty_or_append(
     merkle_tree_apply_fn_mut!(header, tree_id, tree_bytes, fill_empty_or_append, args)
 }
 
+#[inline(never)]
 pub fn merkle_tree_prove_leaf(
     header: &ConcurrentMerkleTreeHeader,
     tree_id: Pubkey,

--- a/account-compression/programs/account-compression/src/lib.rs
+++ b/account-compression/programs/account-compression/src/lib.rs
@@ -166,10 +166,13 @@ pub mod spl_account_compression {
             Clock::get()?.slot,
         );
         header.serialize(&mut header_bytes)?;
+
         let merkle_tree_size = merkle_tree_get_size(&header)?;
         let (tree_bytes, canopy_bytes) = rest.split_at_mut(merkle_tree_size);
         let id = ctx.accounts.merkle_tree.key();
-        let change_log_event = merkle_tree_apply_fn_mut!(header, id, tree_bytes, initialize,)?;
+
+        let change_log_event = merkle_tree_initialize_empty(&header, id, tree_bytes)?;
+
         wrap_event(
             &AccountCompressionEvent::ChangeLog(*change_log_event),
             &ctx.accounts.noop,


### PR DESCRIPTION
Fixes stack frame violation found when deployed on devnet ([here](https://explorer.solana.com/tx/vqdom3dquBA3zzkbkBc7XNaF9oC3h5HFmKHu7V4vASXMfX1EiwU7KyN58bWXFFYjq4WaBVW2wXsmcSdxwTmVeGA)).