### PR TITLE
[libraries/pod]: improve `PodOption` type

### DIFF
--- a/libraries/pod/src/option.rs
+++ b/libraries/pod/src/option.rs
@@ -8,21 +8,26 @@
 
 use {
     bytemuck::{Pod, Zeroable},
-    solana_program::{program_option::COption, pubkey::Pubkey},
+    solana_program::{program_error::ProgramError, program_option::COption, pubkey::Pubkey},
 };
 
 /// Trait for types that can be `None`.
 ///
 /// This trait is used to indicate that a type can be `None` according to a
 /// specific value.
-pub trait Nullable: Default + Pod {
+pub trait Nullable: PartialEq + Pod + Sized {
     /// Indicates whether the value is `None` or not.
-    fn is_none(&self) -> bool;
+    fn is_none(&self) -> bool {
+        self == &Self::none()
+    }
 
     /// Indicates whether the value is `Some`` value of type `T`` or not.
     fn is_some(&self) -> bool {
         !self.is_none()
     }
+
+    /// Returns the value that represents `None` for the type.
+    fn none() -> Self;
 }
 
 /// A "pod-enabled" type that can be used as an `Option<T>` without
@@ -66,8 +71,16 @@ impl<T: Nullable> PodOption<T> {
     }
 }
 
+/// ## Safety
+///
+/// `PodOption` is a transparent wrapper around a `Pod` type `T` with identical
+/// data representation.
 unsafe impl<T: Nullable> Pod for PodOption<T> {}
 
+/// ## Safety
+///
+/// `PodOption` is a transparent wrapper around a `Pod` type `T` with identical
+/// data representation.
 unsafe impl<T: Nullable> Zeroable for PodOption<T> {}
 
 impl<T: Nullable> From<T> for PodOption<T> {
@@ -76,20 +89,26 @@ impl<T: Nullable> From<T> for PodOption<T> {
     }
 }
 
-impl<T: Nullable> From<Option<T>> for PodOption<T> {
-    fn from(from: Option<T>) -> Self {
-        match from {
-            Some(value) => PodOption(value),
-            None => PodOption(T::default()),
+impl<T: Nullable> TryFrom<Option<T>> for PodOption<T> {
+    type Error = ProgramError;
+
+    fn try_from(value: Option<T>) -> Result<Self, Self::Error> {
+        match value {
+            Some(value) if value.is_some() => Ok(PodOption(value)),
+            None => Ok(PodOption(T::none())),
+            _ => Err(ProgramError::InvalidArgument),
         }
     }
 }
 
-impl<T: Nullable> From<COption<T>> for PodOption<T> {
-    fn from(from: COption<T>) -> Self {
-        match from {
-            COption::Some(value) => PodOption(value),
-            COption::None => PodOption(T::default()),
+impl<T: Nullable> TryFrom<COption<T>> for PodOption<T> {
+    type Error = ProgramError;
+
+    fn try_from(value: COption<T>) -> Result<Self, Self::Error> {
+        match value {
+            COption::Some(value) if value.is_some() => Ok(PodOption(value)),
+            COption::None => Ok(PodOption(T::none())),
+            _ => Err(ProgramError::InvalidArgument),
         }
     }
 }
@@ -99,8 +118,8 @@ impl<T: Nullable> From<COption<T>> for PodOption<T> {
 /// The implementation assumes that the default value of `Pubkey` represents
 /// the `None` value.
 impl Nullable for Pubkey {
-    fn is_none(&self) -> bool {
-        self == &Pubkey::default()
+    fn none() -> Self {
+        Pubkey::default()
     }
 }
 
@@ -126,13 +145,38 @@ mod tests {
         assert_eq!(values[1], PodOption::from(Pubkey::default()));
 
         let option_pubkey = Some(sysvar::ID);
-        let pod_option_pubkey: PodOption<Pubkey> = option_pubkey.into();
+        let pod_option_pubkey: PodOption<Pubkey> = option_pubkey.try_into().unwrap();
         assert_eq!(pod_option_pubkey, PodOption::from(sysvar::ID));
-        assert_eq!(pod_option_pubkey, PodOption::from(option_pubkey));
+        assert_eq!(
+            pod_option_pubkey,
+            PodOption::try_from(option_pubkey).unwrap()
+        );
 
         let coption_pubkey = COption::Some(sysvar::ID);
-        let pod_option_pubkey: PodOption<Pubkey> = coption_pubkey.into();
+        let pod_option_pubkey: PodOption<Pubkey> = coption_pubkey.try_into().unwrap();
         assert_eq!(pod_option_pubkey, PodOption::from(sysvar::ID));
-        assert_eq!(pod_option_pubkey, PodOption::from(coption_pubkey));
+        assert_eq!(
+            pod_option_pubkey,
+            PodOption::try_from(coption_pubkey).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_try_from_option() {
+        let some_pubkey = Some(sysvar::ID);
+        assert_eq!(
+            PodOption::try_from(some_pubkey).unwrap(),
+            PodOption(sysvar::ID)
+        );
+
+        let none_pubkey = None;
+        assert_eq!(
+            PodOption::try_from(none_pubkey).unwrap(),
+            PodOption::from(Pubkey::none())
+        );
+
+        let invalid_option = Some(Pubkey::none());
+        let err = PodOption::try_from(invalid_option).unwrap_err();
+        assert_eq!(err, ProgramError::InvalidArgument);
     }
 }

--- a/libraries/pod/src/option.rs
+++ b/libraries/pod/src/option.rs
@@ -98,9 +98,9 @@ impl<T: Nullable> TryFrom<Option<T>> for PodOption<T> {
 
     fn try_from(value: Option<T>) -> Result<Self, Self::Error> {
         match value {
-            Some(value) if value.is_some() => Ok(PodOption(value)),
+            Some(value) if value.is_none() => Err(ProgramError::InvalidArgument),
+            Some(value) => Ok(PodOption(value)),
             None => Ok(PodOption(T::NONE)),
-            _ => Err(ProgramError::InvalidArgument),
         }
     }
 }
@@ -110,9 +110,9 @@ impl<T: Nullable> TryFrom<COption<T>> for PodOption<T> {
 
     fn try_from(value: COption<T>) -> Result<Self, Self::Error> {
         match value {
-            COption::Some(value) if value.is_some() => Ok(PodOption(value)),
+            COption::Some(value) if value.is_none() => Err(ProgramError::InvalidArgument),
+            COption::Some(value) => Ok(PodOption(value)),
             COption::None => Ok(PodOption(T::NONE)),
-            _ => Err(ProgramError::InvalidArgument),
         }
     }
 }


### PR DESCRIPTION
### Problem

The `PodOption` type currently has 2 limitations:
1. It does not handle correctly the conversion of `Option::Some(T::default())` to `PodOption` since `T::default()` corresponds to the `None` value. As a result, it will convert a `Some` to a `None` value.
2. It always assume that `T:default()` is the `None` value, which might not be true in all cases and could be a limitation.

### Solution

To address (1), replace the `From` implementation for a `TryFrom`, where the conversion will fail when trying to convert a `Option::Some(T::default())` value to `PodOption`.

To address (2), add a new associated constant `NONE` to the `Nullable` trait instead of relying on the `default` value. Types implementing the trait can then specify the value that represents `None`.