### PR TITLE
token-cli: Bump to 4.0.1 for new release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7608,7 +7608,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-cli"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "assert_cmd",
  "base64 0.22.1",

--- a/token/cli/Cargo.toml
+++ b/token/cli/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://spl.solana.com/token"
 license = "Apache-2.0"
 name = "spl-token-cli"
 repository = "https://github.com/solana-labs/solana-program-library"
-version = "4.0.0"
+version = "4.0.1"
 
 [build-dependencies]
 walkdir = "2"


### PR DESCRIPTION
#### Problem

The current spl-token-cli fails to build, and it looks like it's because some of the SPL crates lost their ability to support 2.0 during the re-publish.

#### Solution

The 2.0.3 Solana crates use only 2.0 crates, and SPL already supports this version, so we just need to bump the token cli version and publish.

Fixes #7043