### PR TITLE
single-pool-js: Update to web3.js v2 rc

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,8 +307,8 @@ importers:
   single-pool/js/packages/classic:
     dependencies:
       '@solana/addresses':
-        specifier: '=2.0.0-experimental.21e994f'
-        version: 2.0.0-experimental.21e994f
+        specifier: 2.0.0-rc.0
+        version: 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
       '@solana/spl-single-pool':
         specifier: 1.0.0
         version: link:../modern
@@ -343,9 +343,15 @@ importers:
 
   single-pool/js/packages/modern:
     dependencies:
-      '@solana/web3.js':
-        specifier: '=2.0.0-experimental.21e994f'
-        version: 2.0.0-experimental.21e994f(node-fetch@2.7.0)(ws@8.14.2)
+      '@solana/addresses':
+        specifier: 2.0.0-rc.0
+        version: 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
+      '@solana/instructions':
+        specifier: 2.0.0-rc.0
+        version: 2.0.0-rc.0(typescript@5.5.4)
+      '@solana/transaction-messages':
+        specifier: 2.0.0-rc.0
+        version: 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
     devDependencies:
       '@types/node':
         specifier: ^22.2.0
@@ -1827,42 +1833,6 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@metaplex-foundation/umi-options@0.8.9:
-    resolution: {integrity: sha512-jSQ61sZMPSAk/TXn8v8fPqtz3x8d0/blVZXLLbpVbo2/T5XobiI6/MfmlUosAjAUaQl6bHRF8aIIqZEFkJiy4A==}
-    dev: false
-
-  /@metaplex-foundation/umi-public-keys@0.8.9:
-    resolution: {integrity: sha512-CxMzN7dgVGOq9OcNCJe2casKUpJ3RmTVoOvDFyeoTQuK+vkZ1YSSahbqC1iGuHEtKTLSjtWjKvUU6O7zWFTw3Q==}
-    dependencies:
-      '@metaplex-foundation/umi-serializers-encodings': 0.8.9
-    dev: false
-
-  /@metaplex-foundation/umi-serializers-core@0.8.9:
-    resolution: {integrity: sha512-WT82tkiYJ0Qmscp7uTj1Hz6aWQPETwaKLAENAUN5DeWghkuBKtuxyBKVvEOuoXerJSdhiAk0e8DWA4cxcTTQ/w==}
-    dev: false
-
-  /@metaplex-foundation/umi-serializers-encodings@0.8.9:
-    resolution: {integrity: sha512-N3VWLDTJ0bzzMKcJDL08U3FaqRmwlN79FyE4BHj6bbAaJ9LEHjDQ9RJijZyWqTm0jE7I750fU7Ow5EZL38Xi6Q==}
-    dependencies:
-      '@metaplex-foundation/umi-serializers-core': 0.8.9
-    dev: false
-
-  /@metaplex-foundation/umi-serializers-numbers@0.8.9:
-    resolution: {integrity: sha512-NtBf1fnVNQJHFQjLFzRu2i9GGnigb9hOm/Gfrk628d0q0tRJB7BOM3bs5C61VAs7kJs4yd+pDNVAERJkknQ7Lg==}
-    dependencies:
-      '@metaplex-foundation/umi-serializers-core': 0.8.9
-    dev: false
-
-  /@metaplex-foundation/umi-serializers@0.8.9:
-    resolution: {integrity: sha512-Sve8Etm3zqvLSUfza+MYRkjTnCpiaAFT7VWdqeHzA3n58P0AfT3p74RrZwVt/UFkxI+ln8BslwBDJmwzcPkuHw==}
-    dependencies:
-      '@metaplex-foundation/umi-options': 0.8.9
-      '@metaplex-foundation/umi-public-keys': 0.8.9
-      '@metaplex-foundation/umi-serializers-core': 0.8.9
-      '@metaplex-foundation/umi-serializers-encodings': 0.8.9
-      '@metaplex-foundation/umi-serializers-numbers': 0.8.9
-    dev: false
-
   /@noble/curves@1.4.2:
     resolution: {integrity: sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==}
     dependencies:
@@ -2233,15 +2203,27 @@ packages:
       '@sinonjs/commons': 3.0.0
     dev: true
 
-  /@solana/addresses@2.0.0-experimental.21e994f:
-    resolution: {integrity: sha512-zmg+ALhjxZApKJKSjeGK7EgMT9NywdvGKlAjyNL2fieiFWp0lRTBmWyjPBCQQGdJjBkayCscq3GQkDF2MhC6fg==}
+  /@solana/addresses@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4):
+    resolution: {integrity: sha512-cx/Vdwqn7Ns3ud+tyvD5ua4q2UtTleaAWuqyv7opAZLJOZWq2sL9esG3MIEZR5P9wW6sai8Mk9ule1DoWC+pqQ==}
+    peerDependencies:
+      typescript: '>=5'
     dependencies:
-      '@metaplex-foundation/umi-serializers': 0.8.9
-      '@solana/assertions': 2.0.0-experimental.21e994f
+      '@solana/assertions': 2.0.0-rc.0(typescript@5.5.4)
+      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.5.4)
+      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
+      '@solana/errors': 2.0.0-rc.0(typescript@5.5.4)
+      typescript: 5.5.4
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
     dev: false
 
-  /@solana/assertions@2.0.0-experimental.21e994f:
-    resolution: {integrity: sha512-iGOUpOqkqxzQ/xi4Q3YLiBQPASiQ43NYTalmQm99hmOhySRA4+yyQTmMW1PJ8FAm7Zf86cCiYTf19Exa7+DxoQ==}
+  /@solana/assertions@2.0.0-rc.0(typescript@5.5.4):
+    resolution: {integrity: sha512-O9g764n0CC3y8OTe7o02syj/S6ecqHvOcquf0z1qwQKZkwCJ8eyb6Xj9l82RKuMEvMtgaIiMrg8jMDo2ML5aCw==}
+    peerDependencies:
+      typescript: '>=5'
+    dependencies:
+      '@solana/errors': 2.0.0-rc.0(typescript@5.5.4)
+      typescript: 5.5.4
     dev: false
 
   /@solana/buffer-layout-utils@0.2.0:
@@ -2422,18 +2404,21 @@ packages:
       typescript: 5.5.4
     dev: true
 
-  /@solana/functional@2.0.0-experimental.21e994f:
-    resolution: {integrity: sha512-FMXFiTA+hsc9FCv0r47oF7njq/K9x7zh0H+To7tpeqwN65LtJPu5BMG7xZY3rn5TrudgKw6XPuIr3ARbI8+IWA==}
-    dev: false
-
-  /@solana/instructions@2.0.0-experimental.21e994f:
-    resolution: {integrity: sha512-PuJJzvT7wtwE5UcGavUppnfVWnoxL8CPhZBb96HpOaQhQ2JuyhN445bfav5KkaUMCE6ubrVzOEqzrbtygD3aBg==}
-    dev: false
-
-  /@solana/keys@2.0.0-experimental.21e994f:
-    resolution: {integrity: sha512-Qsm7ARy69PdIuis7TZy8ELyhq0pcRFPXtaZ8vLFUvsukrcWRowiJ8JJs6Q3tA+gQK5vUn9ABp7a7Qs0FHzgbyw==}
+  /@solana/functional@2.0.0-rc.0(typescript@5.5.4):
+    resolution: {integrity: sha512-Z+nkjtWyjp3yktU8ip2MxbKb7+I2YUiY8kbpvxAWnWKGcUoKhgcW3EhxhSxFWKbaiEcBmyoPCEdM2MJgJPZJug==}
+    peerDependencies:
+      typescript: '>=5'
     dependencies:
-      '@solana/assertions': 2.0.0-experimental.21e994f
+      typescript: 5.5.4
+    dev: false
+
+  /@solana/instructions@2.0.0-rc.0(typescript@5.5.4):
+    resolution: {integrity: sha512-0/MQ80BXZfELZuCc7GudopuCpQC4VnN9WJDHtR8Tur0j8shiSyHWOOZlWfx66eQuSiQsnbOLT1CRTdhEt/vZhA==}
+    peerDependencies:
+      typescript: '>=5'
+    dependencies:
+      '@solana/errors': 2.0.0-rc.0(typescript@5.5.4)
+      typescript: 5.5.4
     dev: false
 
   /@solana/options@2.0.0-preview.2:
@@ -2465,20 +2450,19 @@ packages:
       prettier: 3.3.3
     dev: true
 
-  /@solana/rpc-core@2.0.0-experimental.21e994f:
-    resolution: {integrity: sha512-T7VcTLRi4dsqmpFYdnvcHZFS8Vcgdi6funMUrXcM7ofQqb8vWGJnlX6AX0eIZiVsmoYk5Ki8wW4D6Ul6bXZyZg==}
-    dependencies:
-      '@metaplex-foundation/umi-serializers': 0.8.9
-    dev: false
-
-  /@solana/rpc-transport@2.0.0-experimental.21e994f(node-fetch@2.7.0)(ws@8.14.2):
-    resolution: {integrity: sha512-PfGPzRuEodhfLyOD8ZneYQ389SWYgmj1Q/HWQZo8yZMsiAaW/lqCygoW88lecxXKlZF5gJYrBX154kgvGqEM7g==}
+  /@solana/rpc-types@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4):
+    resolution: {integrity: sha512-KFuPmkVlZitZnncDGbwu5FSFXljHQsWb4u6fJbmq0yNGwjAlUspOnl7ufL0bS7e+hh0NKfyNOXWuC4vmYEMThw==}
     peerDependencies:
-      node-fetch: ^2.6.7
-      ws: ^8.14.0
+      typescript: '>=5'
     dependencies:
-      node-fetch: 2.7.0
-      ws: 8.14.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
+      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.5.4)
+      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.5.4)
+      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
+      '@solana/errors': 2.0.0-rc.0(typescript@5.5.4)
+      typescript: 5.5.4
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
     dev: false
 
   /@solana/spl-token-group@0.0.4(@solana/web3.js@1.95.2)(fastestsmallesttextencoderdecoder@1.0.22):
@@ -2529,12 +2513,22 @@ packages:
     dependencies:
       buffer: 6.0.3
 
-  /@solana/transactions@2.0.0-experimental.21e994f:
-    resolution: {integrity: sha512-DunbTMBzlC7jmTzkFsRm5DhGe+MjaZ8m+SJ7V520mQq+kxrbPrRmI3ikfUVdejg0WaEV4Dy+RwQ5xllsrJ47kA==}
+  /@solana/transaction-messages@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4):
+    resolution: {integrity: sha512-WY3eQ6z1gsRffwSzRWy8MjJzLlNs47Wd99Up1vQggn9vJtwoGPF1uIYkjkTxsCEBXQOC1Z1RTy87dgcM7US/Jg==}
+    peerDependencies:
+      typescript: '>=5'
     dependencies:
-      '@metaplex-foundation/umi-serializers': 0.8.9
-      '@solana/addresses': 2.0.0-experimental.21e994f
-      '@solana/keys': 2.0.0-experimental.21e994f
+      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
+      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.5.4)
+      '@solana/codecs-data-structures': 2.0.0-rc.0(typescript@5.5.4)
+      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.5.4)
+      '@solana/errors': 2.0.0-rc.0(typescript@5.5.4)
+      '@solana/functional': 2.0.0-rc.0(typescript@5.5.4)
+      '@solana/instructions': 2.0.0-rc.0(typescript@5.5.4)
+      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
+      typescript: 5.5.4
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
     dev: false
 
   /@solana/web3.js@1.95.2:
@@ -2559,23 +2553,6 @@ packages:
       - bufferutil
       - encoding
       - utf-8-validate
-
-  /@solana/web3.js@2.0.0-experimental.21e994f(node-fetch@2.7.0)(ws@8.14.2):
-    resolution: {integrity: sha512-Yy0D57nlNTDm0BhBRIM85Sn52T6vjxpBRRdwE/FOJJmN92n0Qpc4mTAwOPfEqoVpiTcluUBZ4l8FAWxjGCFMgQ==}
-    dependencies:
-      '@metaplex-foundation/umi-serializers': 0.8.9
-      '@solana/addresses': 2.0.0-experimental.21e994f
-      '@solana/functional': 2.0.0-experimental.21e994f
-      '@solana/instructions': 2.0.0-experimental.21e994f
-      '@solana/keys': 2.0.0-experimental.21e994f
-      '@solana/rpc-core': 2.0.0-experimental.21e994f
-      '@solana/rpc-transport': 2.0.0-experimental.21e994f(node-fetch@2.7.0)(ws@8.14.2)
-      '@solana/transactions': 2.0.0-experimental.21e994f
-      fast-stable-stringify: 1.0.0
-    transitivePeerDependencies:
-      - node-fetch
-      - ws
-    dev: false
 
   /@swc/helpers@0.5.11:
     resolution: {integrity: sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,8 +307,8 @@ importers:
   single-pool/js/packages/classic:
     dependencies:
       '@solana/addresses':
-        specifier: 2.0.0-rc.0
-        version: 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
+        specifier: 2.0.0-rc.1
+        version: 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
       '@solana/spl-single-pool':
         specifier: 1.0.0
         version: link:../modern
@@ -344,14 +344,14 @@ importers:
   single-pool/js/packages/modern:
     dependencies:
       '@solana/addresses':
-        specifier: 2.0.0-rc.0
-        version: 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
+        specifier: 2.0.0-rc.1
+        version: 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
       '@solana/instructions':
-        specifier: 2.0.0-rc.0
-        version: 2.0.0-rc.0(typescript@5.5.4)
+        specifier: 2.0.0-rc.1
+        version: 2.0.0-rc.1(typescript@5.5.4)
       '@solana/transaction-messages':
-        specifier: 2.0.0-rc.0
-        version: 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
+        specifier: 2.0.0-rc.1
+        version: 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
     devDependencies:
       '@types/node':
         specifier: ^22.2.0
@@ -2203,26 +2203,26 @@ packages:
       '@sinonjs/commons': 3.0.0
     dev: true
 
-  /@solana/addresses@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4):
-    resolution: {integrity: sha512-cx/Vdwqn7Ns3ud+tyvD5ua4q2UtTleaAWuqyv7opAZLJOZWq2sL9esG3MIEZR5P9wW6sai8Mk9ule1DoWC+pqQ==}
+  /@solana/addresses@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4):
+    resolution: {integrity: sha512-g31KrLZdECjAKceShlGoYxnWDmEVklpjPs8xOtnj/HWupEk+Mds4vtmTACTAeJkWZW/3x+z0aexMtO86MKA47g==}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/assertions': 2.0.0-rc.0(typescript@5.5.4)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.5.4)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.5.4)
+      '@solana/assertions': 2.0.0-rc.1(typescript@5.5.4)
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.5.4)
+      '@solana/codecs-strings': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
+      '@solana/errors': 2.0.0-rc.1(typescript@5.5.4)
       typescript: 5.5.4
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
     dev: false
 
-  /@solana/assertions@2.0.0-rc.0(typescript@5.5.4):
-    resolution: {integrity: sha512-O9g764n0CC3y8OTe7o02syj/S6ecqHvOcquf0z1qwQKZkwCJ8eyb6Xj9l82RKuMEvMtgaIiMrg8jMDo2ML5aCw==}
+  /@solana/assertions@2.0.0-rc.1(typescript@5.5.4):
+    resolution: {integrity: sha512-dvxYCUB7ftZa5lWcsyMYLsGm204H6yVN8Q3ngluMG0rhTtScMBRklVg7Vs39ISwJOkJWJPGToaZ7DjNJ83bm1Q==}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.5.4)
+      '@solana/errors': 2.0.0-rc.1(typescript@5.5.4)
       typescript: 5.5.4
     dev: false
 
@@ -2404,20 +2404,20 @@ packages:
       typescript: 5.5.4
     dev: true
 
-  /@solana/functional@2.0.0-rc.0(typescript@5.5.4):
-    resolution: {integrity: sha512-Z+nkjtWyjp3yktU8ip2MxbKb7+I2YUiY8kbpvxAWnWKGcUoKhgcW3EhxhSxFWKbaiEcBmyoPCEdM2MJgJPZJug==}
+  /@solana/functional@2.0.0-rc.1(typescript@5.5.4):
+    resolution: {integrity: sha512-BmedS5o8HTlU8/NA22I6urJqat9QYIw0oH6rKdMMBisDwX7MtgJhe38W8iLP7QCcxoJeS4526qaD8uD62+Pheg==}
     peerDependencies:
       typescript: '>=5'
     dependencies:
       typescript: 5.5.4
     dev: false
 
-  /@solana/instructions@2.0.0-rc.0(typescript@5.5.4):
-    resolution: {integrity: sha512-0/MQ80BXZfELZuCc7GudopuCpQC4VnN9WJDHtR8Tur0j8shiSyHWOOZlWfx66eQuSiQsnbOLT1CRTdhEt/vZhA==}
+  /@solana/instructions@2.0.0-rc.1(typescript@5.5.4):
+    resolution: {integrity: sha512-zkfL4WBHPbkMrYsuGZc/sekPa/oALIVvVGUw/gwAervMeLZ34cWCUE6WC2uUUh+bq3OFq0/FSFhAg2YbHHDyUw==}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.5.4)
+      '@solana/errors': 2.0.0-rc.1(typescript@5.5.4)
       typescript: 5.5.4
     dev: false
 
@@ -2450,16 +2450,16 @@ packages:
       prettier: 3.3.3
     dev: true
 
-  /@solana/rpc-types@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4):
-    resolution: {integrity: sha512-KFuPmkVlZitZnncDGbwu5FSFXljHQsWb4u6fJbmq0yNGwjAlUspOnl7ufL0bS7e+hh0NKfyNOXWuC4vmYEMThw==}
+  /@solana/rpc-types@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4):
+    resolution: {integrity: sha512-EcGx9VXqA0+uYEdaa1lKTaGBVxLyNL8nkecE4GkqQ+ntRyYlNBPecd4b8siQGSleUQa+Tk/VSPUawSkHqNTLug==}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.5.4)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.5.4)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.5.4)
+      '@solana/addresses': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.5.4)
+      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.5.4)
+      '@solana/codecs-strings': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
+      '@solana/errors': 2.0.0-rc.1(typescript@5.5.4)
       typescript: 5.5.4
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -2513,19 +2513,19 @@ packages:
     dependencies:
       buffer: 6.0.3
 
-  /@solana/transaction-messages@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4):
-    resolution: {integrity: sha512-WY3eQ6z1gsRffwSzRWy8MjJzLlNs47Wd99Up1vQggn9vJtwoGPF1uIYkjkTxsCEBXQOC1Z1RTy87dgcM7US/Jg==}
+  /@solana/transaction-messages@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4):
+    resolution: {integrity: sha512-pZTetOtRDwfuK/fyE8FKbtRsLQOTgEIQld3tskB85npUHaEgrnCYzp3nJtMhKOLel3w3f/27VtWLNSrRyyAiew==}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.5.4)
-      '@solana/codecs-data-structures': 2.0.0-rc.0(typescript@5.5.4)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.5.4)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.5.4)
-      '@solana/functional': 2.0.0-rc.0(typescript@5.5.4)
-      '@solana/instructions': 2.0.0-rc.0(typescript@5.5.4)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
+      '@solana/addresses': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.5.4)
+      '@solana/codecs-data-structures': 2.0.0-rc.1(typescript@5.5.4)
+      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.5.4)
+      '@solana/errors': 2.0.0-rc.1(typescript@5.5.4)
+      '@solana/functional': 2.0.0-rc.1(typescript@5.5.4)
+      '@solana/instructions': 2.0.0-rc.1(typescript@5.5.4)
+      '@solana/rpc-types': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
       typescript: 5.5.4
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder

--- a/single-pool/js/packages/classic/package.json
+++ b/single-pool/js/packages/classic/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@solana/web3.js": "^1.95.2",
-    "@solana/addresses": "=2.0.0-experimental.21e994f",
+    "@solana/addresses": "2.0.0-rc.0",
     "@solana/spl-single-pool": "1.0.0"
   },
   "ava": {

--- a/single-pool/js/packages/classic/package.json
+++ b/single-pool/js/packages/classic/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@solana/web3.js": "^1.95.2",
-    "@solana/addresses": "2.0.0-rc.0",
+    "@solana/addresses": "2.0.0-rc.1",
     "@solana/spl-single-pool": "1.0.0"
   },
   "ava": {

--- a/single-pool/js/packages/classic/src/addresses.ts
+++ b/single-pool/js/packages/classic/src/addresses.ts
@@ -1,4 +1,4 @@
-import type { Base58EncodedAddress } from '@solana/addresses';
+import type { Address } from '@solana/addresses';
 import { PublicKey } from '@solana/web3.js';
 import type { PoolAddress, VoteAccountAddress } from '@solana/spl-single-pool';
 import {
@@ -14,7 +14,7 @@ import {
 export async function findPoolAddress(programId: PublicKey, voteAccountAddress: PublicKey) {
   return new PublicKey(
     await findPoolModern(
-      programId.toBase58() as Base58EncodedAddress,
+      programId.toBase58() as Address,
       voteAccountAddress.toBase58() as VoteAccountAddress,
     ),
   );
@@ -22,26 +22,20 @@ export async function findPoolAddress(programId: PublicKey, voteAccountAddress: 
 
 export async function findPoolStakeAddress(programId: PublicKey, poolAddress: PublicKey) {
   return new PublicKey(
-    await findStakeModern(
-      programId.toBase58() as Base58EncodedAddress,
-      poolAddress.toBase58() as PoolAddress,
-    ),
+    await findStakeModern(programId.toBase58() as Address, poolAddress.toBase58() as PoolAddress),
   );
 }
 
 export async function findPoolMintAddress(programId: PublicKey, poolAddress: PublicKey) {
   return new PublicKey(
-    await findMintModern(
-      programId.toBase58() as Base58EncodedAddress,
-      poolAddress.toBase58() as PoolAddress,
-    ),
+    await findMintModern(programId.toBase58() as Address, poolAddress.toBase58() as PoolAddress),
   );
 }
 
 export async function findPoolStakeAuthorityAddress(programId: PublicKey, poolAddress: PublicKey) {
   return new PublicKey(
     await findStakeAuthorityModern(
-      programId.toBase58() as Base58EncodedAddress,
+      programId.toBase58() as Address,
       poolAddress.toBase58() as PoolAddress,
     ),
   );
@@ -50,7 +44,7 @@ export async function findPoolStakeAuthorityAddress(programId: PublicKey, poolAd
 export async function findPoolMintAuthorityAddress(programId: PublicKey, poolAddress: PublicKey) {
   return new PublicKey(
     await findMintAuthorityModern(
-      programId.toBase58() as Base58EncodedAddress,
+      programId.toBase58() as Address,
       poolAddress.toBase58() as PoolAddress,
     ),
   );
@@ -59,7 +53,7 @@ export async function findPoolMintAuthorityAddress(programId: PublicKey, poolAdd
 export async function findPoolMplAuthorityAddress(programId: PublicKey, poolAddress: PublicKey) {
   return new PublicKey(
     await findMplAuthorityModern(
-      programId.toBase58() as Base58EncodedAddress,
+      programId.toBase58() as Address,
       poolAddress.toBase58() as PoolAddress,
     ),
   );
@@ -72,7 +66,7 @@ export async function findDefaultDepositAccountAddress(
   return new PublicKey(
     await findDefaultDepositModern(
       poolAddress.toBase58() as PoolAddress,
-      userWallet.toBase58() as Base58EncodedAddress,
+      userWallet.toBase58() as Address,
     ),
   );
 }

--- a/single-pool/js/packages/classic/src/instructions.ts
+++ b/single-pool/js/packages/classic/src/instructions.ts
@@ -1,4 +1,4 @@
-import type { Base58EncodedAddress } from '@solana/addresses';
+import type { Address } from '@solana/addresses';
 import { PublicKey, TransactionInstruction } from '@solana/web3.js';
 import type { PoolAddress, VoteAccountAddress } from '@solana/spl-single-pool';
 import { SinglePoolInstruction as PoolInstructionModern } from '@solana/spl-single-pool';
@@ -28,9 +28,9 @@ export class SinglePoolInstruction {
   ): Promise<TransactionInstruction> {
     const instruction = await PoolInstructionModern.depositStake(
       pool.toBase58() as PoolAddress,
-      userStakeAccount.toBase58() as Base58EncodedAddress,
-      userTokenAccount.toBase58() as Base58EncodedAddress,
-      userLamportAccount.toBase58() as Base58EncodedAddress,
+      userStakeAccount.toBase58() as Address,
+      userTokenAccount.toBase58() as Address,
+      userLamportAccount.toBase58() as Address,
     );
     return modernInstructionToLegacy(instruction);
   }
@@ -44,9 +44,9 @@ export class SinglePoolInstruction {
   ): Promise<TransactionInstruction> {
     const instruction = await PoolInstructionModern.withdrawStake(
       pool.toBase58() as PoolAddress,
-      userStakeAccount.toBase58() as Base58EncodedAddress,
-      userStakeAuthority.toBase58() as Base58EncodedAddress,
-      userTokenAccount.toBase58() as Base58EncodedAddress,
+      userStakeAccount.toBase58() as Address,
+      userStakeAuthority.toBase58() as Address,
+      userTokenAccount.toBase58() as Address,
       BigInt(tokenAmount),
     );
     return modernInstructionToLegacy(instruction);
@@ -58,7 +58,7 @@ export class SinglePoolInstruction {
   ): Promise<TransactionInstruction> {
     const instruction = await PoolInstructionModern.createTokenMetadata(
       pool.toBase58() as PoolAddress,
-      payer.toBase58() as Base58EncodedAddress,
+      payer.toBase58() as Address,
     );
     return modernInstructionToLegacy(instruction);
   }
@@ -72,7 +72,7 @@ export class SinglePoolInstruction {
   ): Promise<TransactionInstruction> {
     const instruction = await PoolInstructionModern.updateTokenMetadata(
       voteAccount.toBase58() as VoteAccountAddress,
-      authorizedWithdrawer.toBase58() as Base58EncodedAddress,
+      authorizedWithdrawer.toBase58() as Address,
       tokenName,
       tokenSymbol,
       tokenUri,

--- a/single-pool/js/packages/classic/src/transactions.ts
+++ b/single-pool/js/packages/classic/src/transactions.ts
@@ -1,4 +1,4 @@
-import type { Base58EncodedAddress } from '@solana/addresses';
+import type { Address } from '@solana/addresses';
 import { PublicKey, Connection } from '@solana/web3.js';
 import type { PoolAddress, VoteAccountAddress } from '@solana/spl-single-pool';
 import { SinglePoolProgram as PoolProgramModern } from '@solana/spl-single-pool';
@@ -41,7 +41,7 @@ export class SinglePoolProgram {
     const modernTransaction = await PoolProgramModern.initialize(
       rpc(connection),
       voteAccount.toBase58() as VoteAccountAddress,
-      payer.toBase58() as Base58EncodedAddress,
+      payer.toBase58() as Address,
       skipMetadata,
     );
 
@@ -73,7 +73,7 @@ export class SinglePoolProgram {
   static async createTokenMetadata(pool: PublicKey, payer: PublicKey) {
     const modernTransaction = await PoolProgramModern.createTokenMetadata(
       pool.toBase58() as PoolAddress,
-      payer.toBase58() as Base58EncodedAddress,
+      payer.toBase58() as Address,
     );
 
     return modernTransactionToLegacy(modernTransaction);
@@ -88,7 +88,7 @@ export class SinglePoolProgram {
   ) {
     const modernTransaction = await PoolProgramModern.updateTokenMetadata(
       voteAccount.toBase58() as VoteAccountAddress,
-      authorizedWithdrawer.toBase58() as Base58EncodedAddress,
+      authorizedWithdrawer.toBase58() as Address,
       name,
       symbol,
       uri,
@@ -106,7 +106,7 @@ export class SinglePoolProgram {
     const modernTransaction = await PoolProgramModern.createAndDelegateUserStake(
       rpc(connection),
       voteAccount.toBase58() as VoteAccountAddress,
-      userWallet.toBase58() as Base58EncodedAddress,
+      userWallet.toBase58() as Address,
       BigInt(stakeAmount),
     );
 

--- a/single-pool/js/packages/classic/tests/transactions.test.ts
+++ b/single-pool/js/packages/classic/tests/transactions.test.ts
@@ -14,7 +14,6 @@ import {
   getVoteAccountAddressForPool,
   findDefaultDepositAccountAddress,
   MPL_METADATA_PROGRAM_ID,
-  SinglePoolProgram,
   findPoolAddress,
   findPoolStakeAddress,
   findPoolMintAddress,

--- a/single-pool/js/packages/modern/package.json
+++ b/single-pool/js/packages/modern/package.json
@@ -22,6 +22,8 @@
     "typescript": "^5.5.4"
   },
   "dependencies": {
-    "@solana/web3.js": "=2.0.0-experimental.21e994f"
+    "@solana/addresses": "2.0.0-rc.0",
+    "@solana/instructions": "2.0.0-rc.0",
+    "@solana/transaction-messages": "2.0.0-rc.0"
   }
 }

--- a/single-pool/js/packages/modern/package.json
+++ b/single-pool/js/packages/modern/package.json
@@ -22,8 +22,8 @@
     "typescript": "^5.5.4"
   },
   "dependencies": {
-    "@solana/addresses": "2.0.0-rc.0",
-    "@solana/instructions": "2.0.0-rc.0",
-    "@solana/transaction-messages": "2.0.0-rc.0"
+    "@solana/addresses": "2.0.0-rc.1",
+    "@solana/instructions": "2.0.0-rc.1",
+    "@solana/transaction-messages": "2.0.0-rc.1"
   }
 }

--- a/single-pool/js/packages/modern/src/addresses.ts
+++ b/single-pool/js/packages/modern/src/addresses.ts
@@ -1,99 +1,91 @@
 import {
   address,
   getAddressCodec,
-  Base58EncodedAddress,
   getProgramDerivedAddress,
   createAddressWithSeed,
-} from '@solana/web3.js';
+  Address,
+} from '@solana/addresses';
 
 import { MPL_METADATA_PROGRAM_ID } from './internal.js';
 import { STAKE_PROGRAM_ID } from './quarantine.js';
 
 export const SINGLE_POOL_PROGRAM_ID = address('SVSPxpvHdN29nkVg9rPapPNDddN5DipNLRUFhyjFThE');
 
-export type VoteAccountAddress<TAddress extends string = string> =
-  Base58EncodedAddress<TAddress> & {
-    readonly __voteAccountAddress: unique symbol;
-  };
+export type VoteAccountAddress<TAddress extends string = string> = Address<TAddress> & {
+  readonly __voteAccountAddress: unique symbol;
+};
 
-export type PoolAddress<TAddress extends string = string> = Base58EncodedAddress<TAddress> & {
+export type PoolAddress<TAddress extends string = string> = Address<TAddress> & {
   readonly __poolAddress: unique symbol;
 };
 
-export type PoolStakeAddress<TAddress extends string = string> = Base58EncodedAddress<TAddress> & {
+export type PoolStakeAddress<TAddress extends string = string> = Address<TAddress> & {
   readonly __poolStakeAddress: unique symbol;
 };
 
-export type PoolMintAddress<TAddress extends string = string> = Base58EncodedAddress<TAddress> & {
+export type PoolMintAddress<TAddress extends string = string> = Address<TAddress> & {
   readonly __poolMintAddress: unique symbol;
 };
 
-export type PoolStakeAuthorityAddress<TAddress extends string = string> =
-  Base58EncodedAddress<TAddress> & {
-    readonly __poolStakeAuthorityAddress: unique symbol;
-  };
+export type PoolStakeAuthorityAddress<TAddress extends string = string> = Address<TAddress> & {
+  readonly __poolStakeAuthorityAddress: unique symbol;
+};
 
-export type PoolMintAuthorityAddress<TAddress extends string = string> =
-  Base58EncodedAddress<TAddress> & {
-    readonly __poolMintAuthorityAddress: unique symbol;
-  };
+export type PoolMintAuthorityAddress<TAddress extends string = string> = Address<TAddress> & {
+  readonly __poolMintAuthorityAddress: unique symbol;
+};
 
-export type PoolMplAuthorityAddress<TAddress extends string = string> =
-  Base58EncodedAddress<TAddress> & {
-    readonly __poolMplAuthorityAddress: unique symbol;
-  };
+export type PoolMplAuthorityAddress<TAddress extends string = string> = Address<TAddress> & {
+  readonly __poolMplAuthorityAddress: unique symbol;
+};
 
 export async function findPoolAddress(
-  programId: Base58EncodedAddress,
+  programId: Address,
   voteAccountAddress: VoteAccountAddress,
 ): Promise<PoolAddress> {
   return (await findPda(programId, voteAccountAddress, 'pool')) as PoolAddress;
 }
 
 export async function findPoolStakeAddress(
-  programId: Base58EncodedAddress,
+  programId: Address,
   poolAddress: PoolAddress,
 ): Promise<PoolStakeAddress> {
   return (await findPda(programId, poolAddress, 'stake')) as PoolStakeAddress;
 }
 
 export async function findPoolMintAddress(
-  programId: Base58EncodedAddress,
+  programId: Address,
   poolAddress: PoolAddress,
 ): Promise<PoolMintAddress> {
   return (await findPda(programId, poolAddress, 'mint')) as PoolMintAddress;
 }
 
 export async function findPoolStakeAuthorityAddress(
-  programId: Base58EncodedAddress,
+  programId: Address,
   poolAddress: PoolAddress,
 ): Promise<PoolStakeAuthorityAddress> {
   return (await findPda(programId, poolAddress, 'stake_authority')) as PoolStakeAuthorityAddress;
 }
 
 export async function findPoolMintAuthorityAddress(
-  programId: Base58EncodedAddress,
+  programId: Address,
   poolAddress: PoolAddress,
 ): Promise<PoolMintAuthorityAddress> {
   return (await findPda(programId, poolAddress, 'mint_authority')) as PoolMintAuthorityAddress;
 }
 
 export async function findPoolMplAuthorityAddress(
-  programId: Base58EncodedAddress,
+  programId: Address,
   poolAddress: PoolAddress,
 ): Promise<PoolMplAuthorityAddress> {
   return (await findPda(programId, poolAddress, 'mpl_authority')) as PoolMplAuthorityAddress;
 }
 
-async function findPda(
-  programId: Base58EncodedAddress,
-  baseAddress: Base58EncodedAddress,
-  prefix: string,
-) {
-  const { serialize } = getAddressCodec();
+async function findPda(programId: Address, baseAddress: Address, prefix: string) {
+  const { encode } = getAddressCodec();
   const [pda] = await getProgramDerivedAddress({
     programAddress: programId,
-    seeds: [prefix, serialize(baseAddress)],
+    seeds: [prefix, encode(baseAddress)],
   });
 
   return pda;
@@ -101,7 +93,7 @@ async function findPda(
 
 export async function findDefaultDepositAccountAddress(
   poolAddress: PoolAddress,
-  userWallet: Base58EncodedAddress,
+  userWallet: Address,
 ) {
   return createAddressWithSeed({
     baseAddress: userWallet,
@@ -115,10 +107,10 @@ export function defaultDepositAccountSeed(poolAddress: PoolAddress): string {
 }
 
 export async function findMplMetadataAddress(poolMintAddress: PoolMintAddress) {
-  const { serialize } = getAddressCodec();
+  const { encode } = getAddressCodec();
   const [pda] = await getProgramDerivedAddress({
     programAddress: MPL_METADATA_PROGRAM_ID,
-    seeds: ['metadata', serialize(MPL_METADATA_PROGRAM_ID), serialize(poolMintAddress)],
+    seeds: ['metadata', encode(MPL_METADATA_PROGRAM_ID), encode(poolMintAddress)],
   });
 
   return pda;

--- a/single-pool/js/packages/modern/src/index.ts
+++ b/single-pool/js/packages/modern/src/index.ts
@@ -1,4 +1,4 @@
-import { getAddressCodec } from '@solana/web3.js';
+import { getAddressCodec } from '@solana/addresses';
 
 import { PoolAddress, VoteAccountAddress } from './addresses.js';
 
@@ -15,5 +15,5 @@ export async function getVoteAccountAddressForPool(
   if (!(poolAccount && poolAccount.data[0] === 1)) {
     throw 'invalid pool address';
   }
-  return getAddressCodec().deserialize(poolAccount.data.slice(1))[0] as VoteAccountAddress;
+  return getAddressCodec().decode(poolAccount.data.slice(1)) as VoteAccountAddress;
 }

--- a/single-pool/js/packages/modern/src/instructions.ts
+++ b/single-pool/js/packages/modern/src/instructions.ts
@@ -1,6 +1,5 @@
+import { getAddressCodec, Address } from '@solana/addresses';
 import {
-  getAddressCodec,
-  Base58EncodedAddress,
   ReadonlySignerAccount,
   ReadonlyAccount,
   IInstructionWithAccounts,
@@ -9,7 +8,7 @@ import {
   WritableSignerAccount,
   IInstruction,
   AccountRole,
-} from '@solana/web3.js';
+} from '@solana/instructions';
 
 import {
   PoolMintAuthorityAddress,
@@ -84,9 +83,9 @@ type DepositStakeInstruction = IInstruction<typeof SINGLE_POOL_PROGRAM_ID> &
       WritableAccount<PoolMintAddress>,
       ReadonlyAccount<PoolStakeAuthorityAddress>,
       ReadonlyAccount<PoolMintAuthorityAddress>,
-      WritableAccount<Base58EncodedAddress>, // user stake
-      WritableAccount<Base58EncodedAddress>, // user token
-      WritableAccount<Base58EncodedAddress>, // user lamport
+      WritableAccount<Address>, // user stake
+      WritableAccount<Address>, // user token
+      WritableAccount<Address>, // user lamport
       ReadonlyAccount<typeof SYSVAR_CLOCK_ID>,
       ReadonlyAccount<typeof SYSVAR_STAKE_HISTORY_ID>,
       ReadonlyAccount<typeof TOKEN_PROGRAM_ID>,
@@ -103,8 +102,8 @@ type WithdrawStakeInstruction = IInstruction<typeof SINGLE_POOL_PROGRAM_ID> &
       WritableAccount<PoolMintAddress>,
       ReadonlyAccount<PoolStakeAuthorityAddress>,
       ReadonlyAccount<PoolMintAuthorityAddress>,
-      WritableAccount<Base58EncodedAddress>, // user stake
-      WritableAccount<Base58EncodedAddress>, // user token
+      WritableAccount<Address>, // user stake
+      WritableAccount<Address>, // user token
       ReadonlyAccount<typeof SYSVAR_CLOCK_ID>,
       ReadonlyAccount<typeof TOKEN_PROGRAM_ID>,
       ReadonlyAccount<typeof STAKE_PROGRAM_ID>,
@@ -119,8 +118,8 @@ type CreateTokenMetadataInstruction = IInstruction<typeof SINGLE_POOL_PROGRAM_ID
       ReadonlyAccount<PoolMintAddress>,
       ReadonlyAccount<PoolMintAuthorityAddress>,
       ReadonlyAccount<PoolMplAuthorityAddress>,
-      WritableSignerAccount<Base58EncodedAddress>, // mpl payer
-      WritableAccount<Base58EncodedAddress>, // mpl account
+      WritableSignerAccount<Address>, // mpl payer
+      WritableAccount<Address>, // mpl account
       ReadonlyAccount<typeof MPL_METADATA_PROGRAM_ID>,
       ReadonlyAccount<typeof SYSTEM_PROGRAM_ID>,
     ]
@@ -133,8 +132,8 @@ type UpdateTokenMetadataInstruction = IInstruction<typeof SINGLE_POOL_PROGRAM_ID
       ReadonlyAccount<VoteAccountAddress>,
       ReadonlyAccount<PoolAddress>,
       ReadonlyAccount<PoolMplAuthorityAddress>,
-      ReadonlySignerAccount<Base58EncodedAddress>, // authorized withdrawer
-      WritableAccount<Base58EncodedAddress>, // mpl account
+      ReadonlySignerAccount<Address>, // authorized withdrawer
+      WritableAccount<Address>, // mpl account
       ReadonlyAccount<typeof MPL_METADATA_PROGRAM_ID>,
     ]
   > &
@@ -223,9 +222,9 @@ export async function reactivatePoolStakeInstruction(
 
 export async function depositStakeInstruction(
   pool: PoolAddress,
-  userStakeAccount: Base58EncodedAddress,
-  userTokenAccount: Base58EncodedAddress,
-  userLamportAccount: Base58EncodedAddress,
+  userStakeAccount: Address,
+  userTokenAccount: Address,
+  userLamportAccount: Address,
 ): Promise<DepositStakeInstruction> {
   const programAddress = SINGLE_POOL_PROGRAM_ID;
   const [stake, mint, stakeAuthority, mintAuthority] = await Promise.all([
@@ -259,9 +258,9 @@ export async function depositStakeInstruction(
 
 export async function withdrawStakeInstruction(
   pool: PoolAddress,
-  userStakeAccount: Base58EncodedAddress,
-  userStakeAuthority: Base58EncodedAddress,
-  userTokenAccount: Base58EncodedAddress,
+  userStakeAccount: Address,
+  userStakeAuthority: Address,
+  userTokenAccount: Address,
   tokenAmount: bigint,
 ): Promise<WithdrawStakeInstruction> {
   const programAddress = SINGLE_POOL_PROGRAM_ID;
@@ -272,10 +271,10 @@ export async function withdrawStakeInstruction(
     findPoolMintAuthorityAddress(programAddress, pool),
   ]);
 
-  const { serialize } = getAddressCodec();
+  const { encode } = getAddressCodec();
   const data = new Uint8Array([
     SinglePoolInstructionType.WithdrawStake,
-    ...serialize(userStakeAuthority),
+    ...encode(userStakeAuthority),
     ...u64(tokenAmount),
   ]);
 
@@ -299,7 +298,7 @@ export async function withdrawStakeInstruction(
 
 export async function createTokenMetadataInstruction(
   pool: PoolAddress,
-  payer: Base58EncodedAddress,
+  payer: Address,
 ): Promise<CreateTokenMetadataInstruction> {
   const programAddress = SINGLE_POOL_PROGRAM_ID;
   const mint = await findPoolMintAddress(programAddress, pool);
@@ -329,7 +328,7 @@ export async function createTokenMetadataInstruction(
 
 export async function updateTokenMetadataInstruction(
   voteAccount: VoteAccountAddress,
-  authorizedWithdrawer: Base58EncodedAddress,
+  authorizedWithdrawer: Address,
   tokenName: string,
   tokenSymbol: string,
   tokenUri?: string,

--- a/single-pool/js/packages/modern/src/internal.ts
+++ b/single-pool/js/packages/modern/src/internal.ts
@@ -1,3 +1,3 @@
-import { address } from '@solana/web3.js';
+import { address } from '@solana/addresses';
 
 export const MPL_METADATA_PROGRAM_ID = address('metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s');

--- a/single-pool/js/packages/modern/src/quarantine.ts
+++ b/single-pool/js/packages/modern/src/quarantine.ts
@@ -1,10 +1,5 @@
-import {
-  address,
-  getAddressCodec,
-  Base58EncodedAddress,
-  AccountRole,
-  getProgramDerivedAddress,
-} from '@solana/web3.js';
+import { address, getAddressCodec, getProgramDerivedAddress, Address } from '@solana/addresses';
+import { AccountRole } from '@solana/instructions';
 
 // HERE BE DRAGONS
 // this is all the stuff that shouldn't be in our library once we can import from elsewhere
@@ -33,18 +28,18 @@ export function u64(n: bigint): Uint8Array {
 
 export class SystemInstruction {
   static createAccount(params: {
-    from: Base58EncodedAddress;
-    newAccount: Base58EncodedAddress;
+    from: Address;
+    newAccount: Address;
     lamports: bigint;
     space: bigint;
-    programAddress: Base58EncodedAddress;
+    programAddress: Address;
   }) {
-    const { serialize } = getAddressCodec();
+    const { encode } = getAddressCodec();
     const data = new Uint8Array([
       ...u32(0),
       ...u64(params.lamports),
       ...u64(params.space),
-      ...serialize(params.programAddress),
+      ...encode(params.programAddress),
     ]);
 
     const accounts = [
@@ -59,11 +54,7 @@ export class SystemInstruction {
     };
   }
 
-  static transfer(params: {
-    from: Base58EncodedAddress;
-    to: Base58EncodedAddress;
-    lamports: bigint;
-  }) {
+  static transfer(params: { from: Address; to: Address; lamports: bigint }) {
     const data = new Uint8Array([...u32(2), ...u64(params.lamports)]);
 
     const accounts = [
@@ -79,23 +70,23 @@ export class SystemInstruction {
   }
 
   static createAccountWithSeed(params: {
-    from: Base58EncodedAddress;
-    newAccount: Base58EncodedAddress;
-    base: Base58EncodedAddress;
+    from: Address;
+    newAccount: Address;
+    base: Address;
     seed: string;
     lamports: bigint;
     space: bigint;
-    programAddress: Base58EncodedAddress;
+    programAddress: Address;
   }) {
-    const { serialize } = getAddressCodec();
+    const { encode } = getAddressCodec();
     const data = new Uint8Array([
       ...u32(3),
-      ...serialize(params.base),
+      ...encode(params.base),
       ...u64(BigInt(params.seed.length)),
       ...new TextEncoder().encode(params.seed),
       ...u64(params.lamports),
       ...u64(params.space),
-      ...serialize(params.programAddress),
+      ...encode(params.programAddress),
     ]);
 
     const accounts = [
@@ -115,12 +106,7 @@ export class SystemInstruction {
 }
 
 export class TokenInstruction {
-  static approve(params: {
-    account: Base58EncodedAddress;
-    delegate: Base58EncodedAddress;
-    owner: Base58EncodedAddress;
-    amount: bigint;
-  }) {
+  static approve(params: { account: Address; delegate: Address; owner: Address; amount: bigint }) {
     const data = new Uint8Array([...u32(4), ...u64(params.amount)]);
 
     const accounts = [
@@ -137,10 +123,10 @@ export class TokenInstruction {
   }
 
   static createAssociatedTokenAccount(params: {
-    payer: Base58EncodedAddress;
-    associatedAccount: Base58EncodedAddress;
-    owner: Base58EncodedAddress;
-    mint: Base58EncodedAddress;
+    payer: Address;
+    associatedAccount: Address;
+    owner: Address;
+    mint: Address;
   }) {
     const data = new Uint8Array([0]);
 
@@ -168,16 +154,12 @@ export enum StakeAuthorizationType {
 
 export class StakeInstruction {
   // idc about doing it right unless this goes in a lib
-  static initialize(params: {
-    stakeAccount: Base58EncodedAddress;
-    staker: Base58EncodedAddress;
-    withdrawer: Base58EncodedAddress;
-  }) {
-    const { serialize } = getAddressCodec();
+  static initialize(params: { stakeAccount: Address; staker: Address; withdrawer: Address }) {
+    const { encode } = getAddressCodec();
     const data = new Uint8Array([
       ...u32(0),
-      ...serialize(params.staker),
-      ...serialize(params.withdrawer),
+      ...encode(params.staker),
+      ...encode(params.withdrawer),
       ...Array(48).fill(0),
     ]);
 
@@ -194,16 +176,16 @@ export class StakeInstruction {
   }
 
   static authorize(params: {
-    stakeAccount: Base58EncodedAddress;
-    authorized: Base58EncodedAddress;
-    newAuthorized: Base58EncodedAddress;
+    stakeAccount: Address;
+    authorized: Address;
+    newAuthorized: Address;
     authorizationType: StakeAuthorizationType;
-    custodian?: Base58EncodedAddress;
+    custodian?: Address;
   }) {
-    const { serialize } = getAddressCodec();
+    const { encode } = getAddressCodec();
     const data = new Uint8Array([
       ...u32(1),
-      ...serialize(params.newAuthorized),
+      ...encode(params.newAuthorized),
       ...u32(params.authorizationType),
     ]);
 
@@ -223,11 +205,7 @@ export class StakeInstruction {
     };
   }
 
-  static delegate(params: {
-    stakeAccount: Base58EncodedAddress;
-    authorized: Base58EncodedAddress;
-    voteAccount: Base58EncodedAddress;
-  }) {
+  static delegate(params: { stakeAccount: Address; authorized: Address; voteAccount: Address }) {
     const data = new Uint8Array(u32(2));
 
     const accounts = [
@@ -247,14 +225,11 @@ export class StakeInstruction {
   }
 }
 
-export async function getAssociatedTokenAddress(
-  mint: Base58EncodedAddress,
-  owner: Base58EncodedAddress,
-) {
-  const { serialize } = getAddressCodec();
+export async function getAssociatedTokenAddress(mint: Address, owner: Address) {
+  const { encode } = getAddressCodec();
   const [pda] = await getProgramDerivedAddress({
     programAddress: ATOKEN_PROGRAM_ID,
-    seeds: [serialize(owner), serialize(TOKEN_PROGRAM_ID), serialize(mint)],
+    seeds: [encode(owner), encode(TOKEN_PROGRAM_ID), encode(mint)],
   });
 
   return pda;


### PR DESCRIPTION
#### Problem

The single pool js package has been fixed to a certain version of the new web3.js library. Now that the RC has been tagged, let's update it!

#### Solution

Update to rc.0 and make all other required changes. As part of this, I updated to using the individual packages (ie. address + transaction-messages over the omnibus), which will confuse dependabot less in the future.