### PR TITLE
spl-token-cli: support compute price + limit with native tokens

### DIFF
--- a/token/cli/src/command.rs
+++ b/token/cli/src/command.rs
@@ -195,6 +195,14 @@ fn native_token_client_from_config(
         config.fee_payer()?.clone(),
     );
 
+    let token = token.with_compute_unit_limit(config.compute_unit_limit.clone());
+
+    let token = if let Some(compute_unit_price) = config.compute_unit_price {
+        token.with_compute_unit_price(compute_unit_price)
+    } else {
+        token
+    };
+
     if let (Some(nonce_account), Some(nonce_authority), Some(nonce_blockhash)) = (
         config.nonce_account,
         &config.nonce_authority,


### PR DESCRIPTION
**Problem**

Currently the `spl-token wrap` and `spl-token unwrap` commands ignore the `--compute-budget-limit` and price arguments. With the current congestion on Solana, this makes it difficult to land transactions.

**Solution**

Do not ignore these values with native mints and instead replicate the `config_token_client` within `native_token_client_from_config` to properly check for priority fees and limits.