### PR TITLE
program-error: Add option to specify solana_program crate

### DIFF
--- a/libraries/program-error/derive/src/parser.rs
+++ b/libraries/program-error/derive/src/parser.rs
@@ -101,7 +101,7 @@ impl Parse for SplProgramErrorArgParser {
                     _comma,
                 })
             }
-            "solana_program_crate" => {
+            "solana_program" => {
                 let _equals_sign = input.parse::<Token![=]>()?;
                 let value = input.parse::<LitStr>()?;
                 let _comma: Option<Comma> = input.parse().unwrap_or(None);
@@ -111,10 +111,7 @@ impl Parse for SplProgramErrorArgParser {
                     _comma,
                 })
             }
-            _ => {
-                Err(input
-                    .error("Expected argument 'hash_error_code_start' or 'solana_program_crate'"))
-            }
+            _ => Err(input.error("Expected argument 'hash_error_code_start' or 'solana_program'")),
         }
     }
 }

--- a/libraries/program-error/derive/src/parser.rs
+++ b/libraries/program-error/derive/src/parser.rs
@@ -1,11 +1,11 @@
 //! Token parsing
 
 use {
-    proc_macro2::Ident,
+    proc_macro2::{Ident, Span},
     syn::{
         parse::{Parse, ParseStream},
         token::Comma,
-        LitInt, Token,
+        LitInt, LitStr, Path, Token,
     },
 };
 
@@ -14,20 +14,31 @@ pub struct SplProgramErrorArgs {
     /// Whether to hash the error codes using `solana_program::hash`
     /// or to use the default error code assigned by `num_traits`.
     pub hash_error_code_start: Option<u32>,
+    /// Crate to use for solana_program
+    pub solana_program_crate: Path,
 }
 
 impl Parse for SplProgramErrorArgs {
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        if input.is_empty() {
-            return Ok(Self {
-                hash_error_code_start: None,
-            });
+        let default_solana_program_crate = Ident::new("solana_program", Span::call_site());
+        let mut hash_error_code_start = None;
+        let mut solana_program_crate = None;
+        while !input.is_empty() {
+            match SplProgramErrorArgParser::parse(input)? {
+                SplProgramErrorArgParser::HashErrorCodes { value, .. } => {
+                    hash_error_code_start = Some(value.base10_parse::<u32>()?);
+                }
+                SplProgramErrorArgParser::SolanaProgramCrate { value, .. } => {
+                    solana_program_crate = value.parse()?;
+                }
+            }
         }
-        match SplProgramErrorArgParser::parse(input)? {
-            SplProgramErrorArgParser::HashErrorCodes { value, .. } => Ok(Self {
-                hash_error_code_start: Some(value.base10_parse::<u32>()?),
-            }),
-        }
+        Ok(Self {
+            hash_error_code_start,
+            solana_program_crate: solana_program_crate
+                .unwrap_or(default_solana_program_crate)
+                .into(),
+        })
     }
 }
 
@@ -35,30 +46,45 @@ impl Parse for SplProgramErrorArgs {
 /// ie. `#[spl_program_error(hash_error_code_start = 1275525928)]`
 enum SplProgramErrorArgParser {
     HashErrorCodes {
-        _ident: Ident,
         _equals_sign: Token![=],
         value: LitInt,
+        _comma: Option<Comma>,
+    },
+    SolanaProgramCrate {
+        _equals_sign: Token![=],
+        value: LitStr,
         _comma: Option<Comma>,
     },
 }
 
 impl Parse for SplProgramErrorArgParser {
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        let _ident = {
-            let ident = input.parse::<Ident>()?;
-            if ident != "hash_error_code_start" {
-                return Err(input.error("Expected argument 'hash_error_code_start'"));
+        let ident = input.parse::<Ident>()?;
+        match ident.to_string().as_str() {
+            "hash_error_code_start" => {
+                let _equals_sign = input.parse::<Token![=]>()?;
+                let value = input.parse::<LitInt>()?;
+                let _comma: Option<Comma> = input.parse().unwrap_or(None);
+                Ok(Self::HashErrorCodes {
+                    _equals_sign,
+                    value,
+                    _comma,
+                })
             }
-            ident
-        };
-        let _equals_sign = input.parse::<Token![=]>()?;
-        let value = input.parse::<LitInt>()?;
-        let _comma: Option<Comma> = input.parse().unwrap_or(None);
-        Ok(Self::HashErrorCodes {
-            _ident,
-            _equals_sign,
-            value,
-            _comma,
-        })
+            "solana_program_crate" => {
+                let _equals_sign = input.parse::<Token![=]>()?;
+                let value = input.parse::<LitStr>()?;
+                let _comma: Option<Comma> = input.parse().unwrap_or(None);
+                Ok(Self::SolanaProgramCrate {
+                    _equals_sign,
+                    value,
+                    _comma,
+                })
+            }
+            _ => {
+                Err(input
+                    .error("Expected argument 'hash_error_code_start' or 'solana_program_crate'"))
+            }
+        }
     }
 }

--- a/libraries/program-error/derive/src/parser.rs
+++ b/libraries/program-error/derive/src/parser.rs
@@ -1,11 +1,12 @@
 //! Token parsing
 
 use {
-    proc_macro2::{Ident, Span},
+    proc_macro2::{Ident, Span, TokenStream},
+    quote::quote,
     syn::{
         parse::{Parse, ParseStream},
         token::Comma,
-        LitInt, LitStr, Path, Token,
+        LitInt, LitStr, Token,
     },
 };
 
@@ -15,29 +16,58 @@ pub struct SplProgramErrorArgs {
     /// or to use the default error code assigned by `num_traits`.
     pub hash_error_code_start: Option<u32>,
     /// Crate to use for solana_program
-    pub solana_program_crate: Path,
+    pub import: SolanaProgram,
+}
+
+/// Struct representing the path to a `solana_program` crate, which may be
+/// renamed or otherwise.
+pub struct SolanaProgram {
+    import: Ident,
+    explicit: bool,
+}
+impl quote::ToTokens for SolanaProgram {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.import.to_tokens(tokens);
+    }
+}
+impl SolanaProgram {
+    pub fn wrap(&self, output: TokenStream) -> TokenStream {
+        if self.explicit {
+            output
+        } else {
+            anon_const_trick(output)
+        }
+    }
+}
+impl Default for SolanaProgram {
+    fn default() -> Self {
+        Self {
+            import: Ident::new("_solana_program", Span::call_site()),
+            explicit: false,
+        }
+    }
 }
 
 impl Parse for SplProgramErrorArgs {
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        let default_solana_program_crate = Ident::new("solana_program", Span::call_site());
         let mut hash_error_code_start = None;
-        let mut solana_program_crate = None;
+        let mut import = None;
         while !input.is_empty() {
             match SplProgramErrorArgParser::parse(input)? {
                 SplProgramErrorArgParser::HashErrorCodes { value, .. } => {
                     hash_error_code_start = Some(value.base10_parse::<u32>()?);
                 }
                 SplProgramErrorArgParser::SolanaProgramCrate { value, .. } => {
-                    solana_program_crate = value.parse()?;
+                    import = Some(SolanaProgram {
+                        import: value.parse()?,
+                        explicit: true,
+                    });
                 }
             }
         }
         Ok(Self {
             hash_error_code_start,
-            solana_program_crate: solana_program_crate
-                .unwrap_or(default_solana_program_crate)
-                .into(),
+            import: import.unwrap_or(SolanaProgram::default()),
         })
     }
 }
@@ -86,5 +116,33 @@ impl Parse for SplProgramErrorArgParser {
                     .error("Expected argument 'hash_error_code_start' or 'solana_program_crate'"))
             }
         }
+    }
+}
+
+// Within `exp`, you can bring things into scope with `extern crate`.
+//
+// We don't want to assume that `solana_program::` is in scope - the user may
+// have imported it under a different name, or may have imported it in a
+// non-toplevel module (common when putting impls behind a feature gate).
+//
+// Solution: let's just generate `extern crate solana_program as
+// _solana_program` and then refer to `_solana_program` in the derived code.
+// However, macros are not allowed to produce `extern crate` statements at the
+// toplevel.
+//
+// Solution: let's generate `mod _impl_foo` and import solana_program within
+// that.  However, now we lose access to private members of the surrounding
+// module.  This is a problem if, for example, we're deriving for a newtype,
+// where the inner type is defined in the same module, but not exported.
+//
+// Solution: use the anonymous const trick.  For some reason, `extern crate`
+// statements are allowed here, but everything from the surrounding module is in
+// scope.  This trick is taken from serde and num_traits.
+fn anon_const_trick(exp: TokenStream) -> TokenStream {
+    quote! {
+        const _: () = {
+            extern crate solana_program as _solana_program;
+            #exp
+        };
     }
 }

--- a/libraries/program-error/tests/spl.rs
+++ b/libraries/program-error/tests/spl.rs
@@ -74,7 +74,7 @@ fn test_library_error_codes() {
 }
 
 /// Example error with solana_program crate set
-#[spl_program_error(solana_program_crate = "solana_program")]
+#[spl_program_error(solana_program = "solana_program")]
 enum ExampleSolanaProgramCrateError {
     /// This is a very informative error
     #[error("This is a very informative error")]

--- a/libraries/program-error/tests/spl.rs
+++ b/libraries/program-error/tests/spl.rs
@@ -72,3 +72,20 @@ fn test_library_error_codes() {
         first_error_as_u32 + 3,
     );
 }
+
+/// Example error with solana_program crate set
+#[spl_program_error(solana_program_crate = "solana_program")]
+enum ExampleSolanaProgramCrateError {
+    /// This is a very informative error
+    #[error("This is a very informative error")]
+    VeryInformativeError,
+    /// This is a super important error
+    #[error("This is a super important error")]
+    SuperImportantError,
+}
+
+/// Tests that all macros compile
+#[test]
+fn test_macros_compile_with_solana_program_crate() {
+    let _ = ExampleSolanaProgramCrateError::VeryInformativeError;
+}

--- a/libraries/type-length-value/src/error.rs
+++ b/libraries/type-length-value/src/error.rs
@@ -5,7 +5,7 @@ use spl_program_error::*;
 /// Errors that may be returned by the Token program.
 #[spl_program_error(
     hash_error_code_start = 1_202_666_432,
-    solana_program_crate = "solana_program"
+    solana_program = "solana_program"
 )]
 pub enum TlvError {
     /// Type not found in TLV data

--- a/libraries/type-length-value/src/error.rs
+++ b/libraries/type-length-value/src/error.rs
@@ -3,7 +3,10 @@
 use spl_program_error::*;
 
 /// Errors that may be returned by the Token program.
-#[spl_program_error(hash_error_code_start = 1_202_666_432)]
+#[spl_program_error(
+    hash_error_code_start = 1_202_666_432,
+    solana_program_crate = "solana_program"
+)]
 pub enum TlvError {
     /// Type not found in TLV data
     #[error("Type not found in TLV data")]


### PR DESCRIPTION
#### Problem

There are going to be a lot of issues with people seeing errors on
spl_program_error derivation. When a build pulls in two version of
solana_program, the macro uses `::solana_program`, which now becomes
ambiguous.

#### Summary of changes

I'm not sure if this is a good idea, but this PR gives the ability
to specify which version of `solana_program` to use when deriving the
various traits on your error type.

Borsh has this same functionality, and it's saved us when pulling in
multiple versions of borsh in the SDK.

Note: this PR defaults to `solana_program` instead of
`::solana_program`, which might cause downstream issues.